### PR TITLE
fix: Enter key in search boxes triggers filter (#62)

### DIFF
--- a/FEBuilderGBA.Avalonia/Controls/AddressListControl.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Controls/AddressListControl.axaml.cs
@@ -34,6 +34,7 @@ namespace FEBuilderGBA.Avalonia.Controls
             AddressList.ItemsSource = _displayItems;
             AddressList.DoubleTapped += AddressList_DoubleTapped;
             AddressList.KeyDown += AddressList_KeyDown;
+            SearchBox.KeyDown += SearchBox_KeyDown;
         }
 
         /// <summary>Load address list from AddrResult items.</summary>
@@ -164,7 +165,21 @@ namespace FEBuilderGBA.Avalonia.Controls
                 AddressList.SelectedIndex++;
         }
 
+        void SearchBox_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                ApplySearchFilter();
+                e.Handled = true;
+            }
+        }
+
         void Search_Click(object? sender, RoutedEventArgs e)
+        {
+            ApplySearchFilter();
+        }
+
+        void ApplySearchFilter()
         {
             string? filter = SearchBox.Text;
             if (string.IsNullOrWhiteSpace(filter))

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
@@ -28,6 +28,7 @@ namespace FEBuilderGBA.Avalonia.Views
             Opened += MainWindow_Opened;
             Closing += MainWindow_Closing;
             FilterTextBox.TextChanged += FilterTextBox_TextChanged;
+            FilterTextBox.KeyDown += FilterTextBox_KeyDown;
 
             // Enable drag-and-drop for ROM files
             DragDrop.SetAllowDrop(this, true);
@@ -1461,6 +1462,15 @@ namespace FEBuilderGBA.Avalonia.Views
         private void FilterTextBox_TextChanged(object? sender, global::Avalonia.Controls.TextChangedEventArgs e)
         {
             ApplyFilter(FilterTextBox.Text ?? "");
+        }
+
+        private void FilterTextBox_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                ApplyFilter(FilterTextBox.Text ?? "");
+                e.Handled = true;
+            }
         }
 
         private void ClearFilter_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Tests/Unit/AvaloniaEditorTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AvaloniaEditorTests.cs
@@ -99,6 +99,40 @@ namespace FEBuilderGBA.Tests.Unit
                 "SelectFirst() must be called after RefreshDisplay()");
         }
 
+        [Fact]
+        public void AddressListControl_SearchBoxKeyDownHandlerExists()
+        {
+            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "Controls", "AddressListControl.axaml.cs"));
+            Assert.Contains("SearchBox.KeyDown += SearchBox_KeyDown", src);
+        }
+
+        [Fact]
+        public void AddressListControl_SearchBoxKeyDownInvokesFilter()
+        {
+            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "Controls", "AddressListControl.axaml.cs"));
+            Assert.Contains("void SearchBox_KeyDown(object? sender, KeyEventArgs e)", src);
+            Assert.Contains("ApplySearchFilter()", src);
+        }
+
+        [Fact]
+        public void MainWindow_FilterTextBoxKeyDownHandlerExists()
+        {
+            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "Views", "MainWindow.axaml.cs"));
+            Assert.Contains("FilterTextBox.KeyDown += FilterTextBox_KeyDown", src);
+        }
+
+        [Fact]
+        public void MainWindow_FilterTextBoxKeyDownInvokesApplyFilter()
+        {
+            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "Views", "MainWindow.axaml.cs"));
+            Assert.Contains("void FilterTextBox_KeyDown(object? sender, KeyEventArgs e)", src);
+            // The handler must call ApplyFilter
+            var handlerStart = src.IndexOf("void FilterTextBox_KeyDown(");
+            Assert.True(handlerStart >= 0);
+            var handlerBody = src.Substring(handlerStart, src.IndexOf('}', src.IndexOf('}', handlerStart) + 1) - handlerStart + 1);
+            Assert.Contains("ApplyFilter(", handlerBody);
+        }
+
         // ------------------------------------------------------------------ ViewModel bounds checks
 
         [Fact]


### PR DESCRIPTION
## Summary
- Add KeyDown handler on search TextBoxes in AddressListControl and MainWindow
- Pressing Enter triggers the existing search/filter logic
- AddressListControl: `SearchBox_KeyDown` calls `ApplySearchFilter()`
- MainWindow: `FilterTextBox_KeyDown` calls `ApplyFilter()`

Closes #62

## Test plan
- [ ] Enter key triggers filter in AddressListControl search box
- [ ] Enter key triggers filter in MainWindow filter text box
- [ ] Build succeeds
- [ ] All tests pass (4 new tests added)

Generated with [Claude Code](https://claude.ai/code) (claude-opus-4-6)