### PR TITLE
fix: replace silent exception swallowing with logging (#65)

### DIFF
--- a/FEBuilderGBA.Avalonia/Services/ImageImportValidator.cs
+++ b/FEBuilderGBA.Avalonia/Services/ImageImportValidator.cs
@@ -206,7 +206,7 @@ namespace FEBuilderGBA.Avalonia.Services
                     Array.Copy(romBackup, rom.Data, romBackup.Length);
 
                     // Clean up temp files
-                    try { File.Delete(tempFile1); } catch { }
+                    try { File.Delete(tempFile1); } catch (Exception ex) { Log.Error("ImageImportValidator temp file cleanup: {0}", ex.Message); }
                 }
             }
             catch (Exception ex)

--- a/FEBuilderGBA.Avalonia/Services/WindowManager.cs
+++ b/FEBuilderGBA.Avalonia/Services/WindowManager.cs
@@ -109,7 +109,7 @@ namespace FEBuilderGBA.Avalonia.Services
         {
             foreach (var w in new List<Window>(_windows.Values))
             {
-                try { w.Close(); } catch { }
+                try { w.Close(); } catch (Exception ex) { Log.Error("WindowManager.CloseAll window close: {0}", ex.Message); }
             }
             _windows.Clear();
         }

--- a/FEBuilderGBA.Avalonia/ViewModels/BattleTerrainViewerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/BattleTerrainViewerViewModel.cs
@@ -66,7 +66,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                         tname += (char)b;
                     }
                 }
-                catch { }
+                catch (Exception ex) { Log.Error("BattleTerrainViewerViewModel.LoadList terrain name read: {0}", ex.Message); }
 
                 string name = U.ToHexString(i) + " " + tname;
                 result.Add(new AddrResult(addr, name, i));
@@ -91,7 +91,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                     tname += (char)b;
                 }
             }
-            catch { }
+            catch (Exception ex) { Log.Error("BattleTerrainViewerViewModel.LoadBattleTerrain terrain name read: {0}", ex.Message); }
             TerrainName = tname;
 
             NameChar0 = rom.u8(addr + 0);

--- a/FEBuilderGBA.Avalonia/ViewModels/ImagePortraitViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImagePortraitViewModel.cs
@@ -181,7 +181,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 string name = $"0x{i:X2}";
                 // Try to get unit name if this portrait index corresponds to a unit
                 try { string uname = NameResolver.GetUnitName((uint)i); if (uname != "???" && uname != $"#{i}") name += $" {uname}"; }
-                catch { }
+                catch (Exception ex) { Log.Error("ImagePortraitViewModel.LoadList unit name resolve: {0}", ex.Message); }
                 result.Add(new AddrResult(addr, name, (uint)i));
             }
             return result;

--- a/FEBuilderGBA.Avalonia/ViewModels/OPClassAlphaNameFE6ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/OPClassAlphaNameFE6ViewModel.cs
@@ -68,7 +68,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                                 name = U.ToHexString(i + 1) + " " + resolved;
                         }
                     }
-                    catch { }
+                    catch (Exception ex) { Log.Error("OPClassAlphaNameFE6ViewModel.LoadList name resolve: {0}", ex.Message); }
                 }
                 result.Add(new AddrResult(addr, name, i));
             }
@@ -94,7 +94,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                     if (U.isSafetyOffset(strAddr))
                         AlphaName = rom.getString(strAddr, 64);
                 }
-                catch { }
+                catch (Exception ex) { Log.Error("OPClassAlphaNameFE6ViewModel.LoadEntry alpha name read: {0}", ex.Message); }
             }
             CanWrite = true;
         }

--- a/FEBuilderGBA.Avalonia/ViewModels/SoundRoomFE6ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SoundRoomFE6ViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text;
 using FEBuilderGBA.Avalonia.Services;
@@ -75,7 +76,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 if (textId > 0 && textId < 0xFFFF)
                     return NameResolver.GetTextById(textId);
             }
-            catch { }
+            catch (Exception ex) { Log.Error("SoundRoomFE6ViewModel.GetSongName text resolve: {0}", ex.Message); }
             return $"Song {rom.u32(addr):X}";
         }
 

--- a/FEBuilderGBA.Avalonia/ViewModels/StatusParamViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/StatusParamViewModel.cs
@@ -87,7 +87,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                             name = U.ToHexString(i) + " " + resolved;
                     }
                 }
-                catch { }
+                catch (Exception ex) { Log.Error("StatusParamViewModel.LoadList string resolve: {0}", ex.Message); }
 
                 result.Add(new AddrResult(addr, name, i));
             }
@@ -121,7 +121,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                         StringText = rom.getString(strAddr, 32);
                 }
             }
-            catch { }
+            catch (Exception ex) { Log.Error("StatusParamViewModel.LoadStatusParam string resolve: {0}", ex.Message); }
 
             CanWrite = true;
         }

--- a/FEBuilderGBA.Avalonia/ViewModels/TextViewerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/TextViewerViewModel.cs
@@ -210,7 +210,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 ScanTable(rom, rom.RomInfo.item_pointer, rom.RomInfo.item_datasize,
                     textId, "Item", id => NameResolver.GetItemName(id), refs);
             }
-            catch { }
+            catch (Exception ex) { Log.Error("TextViewerViewModel.FindCrossReferences: {0}", ex.Message); }
             return refs;
         }
 
@@ -459,7 +459,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                         result.Add(new AddrResult(entryAddr, $"{U.ToHexString(i)} {preview}", i));
                     }
                 }
-                catch { }
+                catch (Exception ex) { Log.Error("TextViewerViewModel.LoadTextList text decode: {0}", ex.Message); }
             }
             return result;
         }

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
@@ -357,7 +357,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     {
                         var window = factory();
                         await Task.Delay(50);  // Let it initialize
-                        try { window.Close(); } catch { }
+                        try { window.Close(); } catch (Exception ex) { Log.Error("MainWindow.SmokeTest window close: {0}", ex.Message); }
                         passed++;
                         Console.WriteLine($"SMOKE: {name} ... OK");
                     }
@@ -442,7 +442,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     }
                     finally
                     {
-                        try { window?.Close(); } catch { }
+                        try { window?.Close(); } catch (Exception ex) { Log.Error("MainWindow.ScreenshotAll window close: {0}", ex.Message); }
                     }
                 }
 
@@ -807,7 +807,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     }
                     finally
                     {
-                        try { window?.Close(); } catch { }
+                        try { window?.Close(); } catch (Exception ex) { Log.Error("MainWindow.DataVerify window close: {0}", ex.Message); }
                     }
                 }
 
@@ -2105,13 +2105,13 @@ namespace FEBuilderGBA.Avalonia.Views
         private void OnlineManual_Click(object? sender, RoutedEventArgs e)
         {
             try { System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("https://github.com/laqieer/FEBuilderGBA/wiki") { UseShellExecute = true }); }
-            catch { }
+            catch (Exception ex) { Log.Error("MainWindow.OnlineManual_Click launch browser: {0}", ex.Message); }
         }
 
         private void Discussions_Click(object? sender, RoutedEventArgs e)
         {
             try { System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("https://github.com/laqieer/FEBuilderGBA/discussions") { UseShellExecute = true }); }
-            catch { }
+            catch (Exception ex) { Log.Error("MainWindow.Discussions_Click launch browser: {0}", ex.Message); }
         }
 
         private async void RunEmulator_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/ToolASMEditView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolASMEditView.axaml.cs
@@ -185,9 +185,9 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             finally
             {
-                try { if (File.Exists(tempAsm)) File.Delete(tempAsm); } catch { }
-                try { if (File.Exists(tempObj)) File.Delete(tempObj); } catch { }
-                try { if (File.Exists(tempBin)) File.Delete(tempBin); } catch { }
+                try { if (File.Exists(tempAsm)) File.Delete(tempAsm); } catch (Exception ex) { Log.Error("ToolASMEditView temp asm cleanup: {0}", ex.Message); }
+                try { if (File.Exists(tempObj)) File.Delete(tempObj); } catch (Exception ex) { Log.Error("ToolASMEditView temp obj cleanup: {0}", ex.Message); }
+                try { if (File.Exists(tempBin)) File.Delete(tempBin); } catch (Exception ex) { Log.Error("ToolASMEditView temp bin cleanup: {0}", ex.Message); }
             }
         }
         void Close_Click(object? sender, RoutedEventArgs e) => Close();

--- a/FEBuilderGBA.Tests/Unit/AvaloniaNoBareThrowTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AvaloniaNoBareThrowTests.cs
@@ -1,0 +1,52 @@
+using System.Text.RegularExpressions;
+
+namespace FEBuilderGBA.Tests.Unit
+{
+    /// <summary>
+    /// Regression test: ensures no bare/empty catch blocks remain in the Avalonia project.
+    /// See GitHub issue #65: silent exception swallowing.
+    /// </summary>
+    public class AvaloniaNoBareThrowTests
+    {
+        private static string SolutionDir
+        {
+            get
+            {
+                var dir = AppContext.BaseDirectory;
+                while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                    dir = Path.GetDirectoryName(dir);
+                return dir ?? throw new InvalidOperationException("Cannot find solution root");
+            }
+        }
+
+        private string AvaloniaProjectDir => Path.Combine(SolutionDir, "FEBuilderGBA.Avalonia");
+
+        [Fact]
+        public void NoBareEmptyCatchBlocks()
+        {
+            // Pattern matches: catch { }, catch (Exception) { }, catch (Exception ex) { }
+            // where the body is empty (only whitespace)
+            var bareCatchPattern = new Regex(@"catch\s*(\([^)]*\))?\s*\{\s*\}", RegexOptions.Singleline);
+            var violations = new List<string>();
+
+            var csFiles = Directory.GetFiles(AvaloniaProjectDir, "*.cs", SearchOption.AllDirectories);
+            foreach (var file in csFiles)
+            {
+                var content = File.ReadAllText(file);
+                var matches = bareCatchPattern.Matches(content);
+                foreach (Match m in matches)
+                {
+                    // Find line number
+                    int lineNum = content[..m.Index].Count(c => c == '\n') + 1;
+                    var relPath = Path.GetRelativePath(AvaloniaProjectDir, file);
+                    violations.Add($"{relPath}:{lineNum} => {m.Value.Trim()}");
+                }
+            }
+
+            Assert.True(violations.Count == 0,
+                $"Found {violations.Count} bare/empty catch block(s) in Avalonia project. " +
+                $"All catch blocks should log via Log.Error(). Violations:\n" +
+                string.Join("\n", violations));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Replace all 20 bare `catch { }` blocks in the Avalonia project with `Log.Error()` calls
- Each error log includes a descriptive context string (method name + operation)
- Add regression test (`AvaloniaNoBareThrowTests`) that scans all `.cs` files in the Avalonia project for bare catch blocks

Closes #65

## Files changed (10 source + 1 test)
- `BattleTerrainViewerViewModel.cs` — 2 catches
- `ImagePortraitViewModel.cs` — 1 catch
- `OPClassAlphaNameFE6ViewModel.cs` — 2 catches
- `SoundRoomFE6ViewModel.cs` — 1 catch
- `StatusParamViewModel.cs` — 2 catches
- `TextViewerViewModel.cs` — 2 catches
- `MainWindow.axaml.cs` — 5 catches
- `WindowManager.cs` — 1 catch
- `ImageImportValidator.cs` — 1 catch
- `ToolASMEditView.axaml.cs` — 3 catches

## Test plan
- [x] No bare catch blocks remain (verified by grep + new test)
- [x] Avalonia project builds successfully
- [x] All 823 Core tests pass
- [x] All 1524 Tests pass (including new regression test)

Generated with Claude Code (claude-opus-4-6)