### PR TITLE
fix: add overwrite confirmation to image export (#66)

### DIFF
--- a/FEBuilderGBA.Avalonia/Services/ImageExportService.cs
+++ b/FEBuilderGBA.Avalonia/Services/ImageExportService.cs
@@ -34,6 +34,16 @@ namespace FEBuilderGBA.Avalonia.Services
 
             if (image is Bitmap bmp)
             {
+                if (File.Exists(path))
+                {
+                    var confirm = await MessageBoxWindow.Show(
+                        owner,
+                        $"File \"{Path.GetFileName(path)}\" already exists. Overwrite?",
+                        "Export",
+                        MessageBoxMode.YesNo);
+                    if (confirm != MessageBoxResult.Yes) return;
+                }
+
                 using var stream = File.Create(path);
                 bmp.Save(stream);
                 await MessageBoxWindow.Show(owner, $"Image saved to {Path.GetFileName(path)}", "Export", MessageBoxMode.Ok);

--- a/FEBuilderGBA.Tests/Unit/AvaloniaServiceTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AvaloniaServiceTests.cs
@@ -198,6 +198,39 @@ namespace FEBuilderGBA.Tests.Unit
             Assert.Contains("editor.MaxDiffPercent", src);
         }
 
+        // ---- ImageExportService overwrite confirmation (#66) ----
+
+        [Fact]
+        public void ImageExportService_ChecksFileExists_BeforeOverwrite()
+        {
+            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "Services", "ImageExportService.cs"));
+            Assert.Contains("File.Exists(path)", src);
+        }
+
+        [Fact]
+        public void ImageExportService_ShowsYesNoDialog_ForOverwrite()
+        {
+            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "Services", "ImageExportService.cs"));
+            Assert.Contains("MessageBoxMode.YesNo", src);
+        }
+
+        [Fact]
+        public void ImageExportService_CancelsExport_WhenUserDeclinesOverwrite()
+        {
+            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "Services", "ImageExportService.cs"));
+            // Verify the method returns early when user does not confirm
+            Assert.Contains("MessageBoxResult.Yes", src);
+            Assert.Contains("if (confirm != MessageBoxResult.Yes) return", src);
+        }
+
+        [Fact]
+        public void ImageExportService_OverwritePrompt_ContainsFileName()
+        {
+            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "Services", "ImageExportService.cs"));
+            // The overwrite prompt should display the filename
+            Assert.Contains("already exists. Overwrite?", src);
+        }
+
         // ---- All Avalonia editors have their corresponding .axaml view ----
 
         [Theory]


### PR DESCRIPTION
## Summary
- Check if file exists before export in `ImageExportService.SavePng()`
- Show Yes/No confirmation dialog before overwriting existing files
- Cancel export if user declines overwrite

Closes #66

## Test plan
- [x] Overwrite check logic verified via source-level tests
- [x] Avalonia project builds successfully
- [x] All 823 Core tests pass
- [x] All 1527 Tests pass (including 4 new overwrite confirmation tests)

🤖 Generated with [Claude Code](https://claude.ai/code) (claude-opus-4-6)