### PR TITLE
fix: remove dead Redo menu item (#64)

### DIFF
--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml
@@ -19,7 +19,6 @@
       </MenuItem>
       <MenuItem Header="_Edit">
         <MenuItem Header="_Undo" Name="UndoMenuItem" IsEnabled="False" Click="Undo_Click" />
-        <MenuItem Header="_Redo" Name="RedoMenuItem" IsEnabled="False" IsVisible="False" />
       </MenuItem>
       <MenuItem Header="_View">
         <MenuItem Header="Toggle _Easy Mode" Click="ToggleEasyMode_Click" Name="EasyModeMenuItem" />

--- a/FEBuilderGBA.Tests/Unit/AvaloniaMenuCleanupTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AvaloniaMenuCleanupTests.cs
@@ -1,0 +1,47 @@
+using System.Text.RegularExpressions;
+
+namespace FEBuilderGBA.Tests.Unit
+{
+    /// <summary>
+    /// Validates that MainWindow.axaml has no hidden (dead) menu items.
+    /// </summary>
+    public class AvaloniaMenuCleanupTests
+    {
+        private static string SolutionDir
+        {
+            get
+            {
+                var dir = AppContext.BaseDirectory;
+                while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                    dir = Path.GetDirectoryName(dir);
+                return dir ?? throw new InvalidOperationException("Cannot find solution root");
+            }
+        }
+
+        [Fact]
+        public void MainWindow_HasNoHiddenMenuItems()
+        {
+            var axamlPath = Path.Combine(SolutionDir, "FEBuilderGBA.Avalonia", "Views", "MainWindow.axaml");
+            Assert.True(File.Exists(axamlPath), $"MainWindow.axaml should exist at {axamlPath}");
+
+            var content = File.ReadAllText(axamlPath);
+
+            // Match <MenuItem ... IsVisible="False" ... /> patterns
+            var matches = Regex.Matches(content, @"<MenuItem\b[^>]*IsVisible\s*=\s*""False""[^>]*/?>");
+            Assert.True(matches.Count == 0,
+                $"MainWindow.axaml should not contain hidden MenuItems but found {matches.Count}: " +
+                string.Join(", ", matches.Cast<Match>().Select(m => m.Value)));
+        }
+
+        [Fact]
+        public void MainWindow_HasNoRedoMenuItem()
+        {
+            var axamlPath = Path.Combine(SolutionDir, "FEBuilderGBA.Avalonia", "Views", "MainWindow.axaml");
+            Assert.True(File.Exists(axamlPath), $"MainWindow.axaml should exist at {axamlPath}");
+
+            var content = File.ReadAllText(axamlPath);
+
+            Assert.DoesNotContain("Redo", content, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Remove hidden Redo MenuItem from MainWindow.axaml
- Clean up any related dead code
- Core Undo class has no redo stack

Closes #64

## Test plan
- [x] No hidden menu items remain (verified by new test)
- [x] Build succeeds
- [x] All 1525 tests pass

Generated with Claude Code (claude-opus-4-6)