### PR TITLE
fix: show skill names instead of hex IDs (#67)

### DIFF
--- a/FEBuilderGBA.Avalonia/Services/PatchDetectionService.cs
+++ b/FEBuilderGBA.Avalonia/Services/PatchDetectionService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 
 namespace FEBuilderGBA.Avalonia.Services
 {
@@ -321,5 +322,134 @@ namespace FEBuilderGBA.Avalonia.Services
 
         /// <summary>True if the HALFBODY portrait extension is installed.</summary>
         public bool IsHalfBody => PortraitExtends == PortraitExtendsType.HalfBody;
+
+        // ---- Skill name resolution ----
+
+        /// <summary>Cached skill text table base address for SkillSystem patch.</summary>
+        uint _skillSystemTextBase;
+
+        /// <summary>
+        /// Resolve a skill ID to a human-readable name using the detected skill system.
+        /// Returns null if resolution fails (caller should use hex fallback).
+        /// </summary>
+        public string ResolveSkillName(uint id)
+        {
+            if (id == 0) return null;
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return null;
+
+            try
+            {
+                switch (SkillSystem)
+                {
+                    case SkillSystemType.CSkillSys09x:
+                    case SkillSystemType.CSkillSys300:
+                        return ResolveCSkillSysName(rom, id);
+
+                    case SkillSystemType.SkillSystem:
+                        return ResolveSkillSystemName(rom, id);
+
+                    case SkillSystemType.FE8N_Ver2:
+                    case SkillSystemType.FE8N_Ver3:
+                    case SkillSystemType.FE8N:
+                        return ResolveFE8NSkillName(rom, id);
+
+                    default:
+                        return null;
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// CSkillSys09x/300: skill info table at fixed address 0xB2A614.
+        /// Each entry is 8 bytes; text ID at offset +4 (u16).
+        /// </summary>
+        static string ResolveCSkillSysName(ROM rom, uint id)
+        {
+            const uint gpSkillInfos = 0xB2A614;
+            if (!U.isSafetyOffset(gpSkillInfos + 4, rom)) return null;
+            uint baseAddr = rom.p32(gpSkillInfos);
+            if (!U.isSafetyOffset(baseAddr, rom)) return null;
+            uint entryAddr = baseAddr + 8 * id;
+            if (!U.isSafetyOffset(entryAddr + 6, rom)) return null;
+            uint textId = rom.u16(entryAddr + 4);
+            if (textId == 0) return null;
+            string text = NameResolver.GetTextById(textId);
+            return string.IsNullOrEmpty(text) || text == "???" ? null : text;
+        }
+
+        /// <summary>
+        /// SkillSystems (FE8U): find TEXT pointer via byte-pattern scan.
+        /// Text table stores u16 text IDs, entry = base + id * 2.
+        /// </summary>
+        string ResolveSkillSystemName(ROM rom, uint id)
+        {
+            if (_skillSystemTextBase == 0)
+                _skillSystemTextBase = FindSkillSystemTextBase(rom);
+            if (_skillSystemTextBase == 0 || _skillSystemTextBase == U.NOT_FOUND)
+                return null;
+            uint entryAddr = _skillSystemTextBase + id * 2;
+            if (!U.isSafetyOffset(entryAddr + 2, rom)) return null;
+            uint textId = rom.u16(entryAddr);
+            if (textId == 0) return null;
+            string text = NameResolver.GetTextById(textId);
+            if (string.IsNullOrEmpty(text) || text == "???") return null;
+            // SkillSystem text format is often "Name: Description" — extract just the name
+            int colon = text.IndexOf(':');
+            if (colon > 0) return text.Substring(0, colon).Trim();
+            return text;
+        }
+
+        /// <summary>
+        /// FE8N variants: skill config at 0x89268 area.
+        /// The text table pointer is at 0x89274 (ver2/ver3) or found via pattern scan.
+        /// </summary>
+        static string ResolveFE8NSkillName(ROM rom, uint id)
+        {
+            // FE8N ver2/3 have skill text pointers at known offsets
+            // Ver2: 5 pointers at 0x89274, text pointer is at index 2 (0x8927C)
+            // Ver3: similar layout with extension at 0x89280
+            // Base FE8N: simpler layout at 0x89268 area
+            uint textPtrAddr = 0x8927C; // common for ver2/3
+            if (!U.isSafetyOffset(textPtrAddr + 4, rom)) return null;
+            uint textBase = rom.p32(textPtrAddr);
+            if (!U.isSafetyOffset(textBase, rom)) return null;
+            uint entryAddr = textBase + id * 2;
+            if (!U.isSafetyOffset(entryAddr + 2, rom)) return null;
+            uint textId = rom.u16(entryAddr);
+            if (textId == 0) return null;
+            string text = NameResolver.GetTextById(textId);
+            return string.IsNullOrEmpty(text) || text == "???" ? null : text;
+        }
+
+        /// <summary>
+        /// Scan for the SkillSystems TEXT pointer by searching byte patterns in ROM.
+        /// Mirrors the WinForms SkillConfigSkillSystemForm.FindSkillPointer("TEXT", 0).
+        /// </summary>
+        static uint FindSkillSystemTextBase(ROM rom)
+        {
+            // Two known TEXT patterns from WinForms
+            var patterns = new (byte[] data, uint skip)[]
+            {
+                (new byte[] { 0x07, 0x49, 0x40, 0x00, 0x40, 0x18, 0x00, 0x88, 0x00, 0x28, 0x00, 0xD1, 0x06, 0x48, 0x21, 0x1C }, 16),
+                (new byte[] { 0x40, 0x5D, 0x08, 0x49, 0x40, 0x00, 0x40, 0x18, 0x00, 0x88, 0x00, 0x28, 0x00, 0xD1, 0x07, 0x48, 0x21, 0x1C, 0x4C, 0x31 }, 16),
+            };
+
+            foreach (var (data, skip) in patterns)
+            {
+                uint found = U.Grep(rom.Data, data, 0xB00000, 0xC00000, 4);
+                if (found == U.NOT_FOUND) continue;
+                uint a = found + (uint)data.Length + skip;
+                if (!U.isSafetyOffset(a + 4, rom)) continue;
+                uint p = rom.u32(a);
+                if (!U.isSafetyPointer(p)) continue;
+                return U.toOffset(p);
+            }
+            return 0;
+        }
     }
 }

--- a/FEBuilderGBA.Avalonia/ViewModels/ItemEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ItemEditorViewModel.cs
@@ -470,14 +470,12 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         }
 
         /// <summary>
-        /// Resolve a skill ID to a display name.
-        /// Falls back to hex representation since skill name tables
-        /// vary by skill system variant.
+        /// Resolve a skill ID to a display name via NameResolver.
         /// </summary>
         static string ResolveSkillName(uint skillId)
         {
             if (skillId == 0) return "(None)";
-            return $"Skill 0x{skillId:X02}";
+            return NameResolver.GetSkillName(skillId);
         }
     }
 }

--- a/FEBuilderGBA.Avalonia/ViewModels/SkillAssignmentClassCSkillSysViewViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SkillAssignmentClassCSkillSysViewViewModel.cs
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             return new Dictionary<string, string>
             {
                 ["addr"] = $"0x{CurrentAddr:X08}",
-                ["ClassSkill"] = $"0x{ClassSkill:X04}",
+                ["ClassSkill"] = NameResolver.GetSkillName(ClassSkill),
             };
         }
 

--- a/FEBuilderGBA.Avalonia/ViewModels/SkillAssignmentClassSkillSystemViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SkillAssignmentClassSkillSystemViewModel.cs
@@ -57,7 +57,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             return new Dictionary<string, string>
             {
                 ["addr"] = $"0x{CurrentAddr:X08}",
-                ["ClassSkill"] = $"0x{ClassSkill:X02}",
+                ["ClassSkill"] = NameResolver.GetSkillName(ClassSkill),
             };
         }
 

--- a/FEBuilderGBA.Avalonia/ViewModels/SkillAssignmentUnitCSkillSysViewViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SkillAssignmentUnitCSkillSysViewViewModel.cs
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             return new Dictionary<string, string>
             {
                 ["addr"] = $"0x{CurrentAddr:X08}",
-                ["UnitSkill"] = $"0x{UnitSkill:X04}",
+                ["UnitSkill"] = NameResolver.GetSkillName(UnitSkill),
             };
         }
 

--- a/FEBuilderGBA.Avalonia/ViewModels/SkillAssignmentUnitFE8NViewViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SkillAssignmentUnitFE8NViewViewModel.cs
@@ -57,9 +57,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             return new Dictionary<string, string>
             {
                 ["addr"] = $"0x{CurrentAddr:X08}",
-                ["PersonalSkill"] = $"0x{PersonalSkill:X02}",
-                ["SkillSet1"] = $"0x{SkillSet1:X02}",
-                ["SkillSet2"] = $"0x{SkillSet2:X02}",
+                ["PersonalSkill"] = NameResolver.GetSkillName(PersonalSkill),
+                ["SkillSet1"] = NameResolver.GetSkillName(SkillSet1),
+                ["SkillSet2"] = NameResolver.GetSkillName(SkillSet2),
             };
         }
 

--- a/FEBuilderGBA.Avalonia/ViewModels/SkillAssignmentUnitSkillSystemViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SkillAssignmentUnitSkillSystemViewModel.cs
@@ -57,7 +57,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             return new Dictionary<string, string>
             {
                 ["addr"] = $"0x{CurrentAddr:X08}",
-                ["UnitSkill"] = $"0x{UnitSkill:X02}",
+                ["UnitSkill"] = NameResolver.GetSkillName(UnitSkill),
             };
         }
 

--- a/FEBuilderGBA.Avalonia/ViewModels/SkillConfigFE8UCSkillSys09xViewViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SkillConfigFE8UCSkillSys09xViewViewModel.cs
@@ -54,7 +54,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             return new Dictionary<string, string>
             {
                 ["addr"] = $"0x{CurrentAddr:X08}",
-                ["SkillName"] = $"0x{SkillName:X04}",
+                ["SkillName"] = NameResolver.GetTextById(SkillName),
                 ["Description"] = $"0x{Description:X04}",
             };
         }

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
@@ -219,6 +219,9 @@ namespace FEBuilderGBA.Avalonia.Views
             // Detect installed patches (SkillSystem, MagicSplit, etc.)
             PatchDetectionService.Instance.Refresh();
 
+            // Wire skill name resolution callback for NameResolver
+            CoreState.SkillNameResolver = id => PatchDetectionService.Instance.ResolveSkillName(id);
+
             // Update UI
             _vm.UpdateFromRom();
             StatusText.Text = _vm.StatusText;

--- a/FEBuilderGBA.Core.Tests/NameResolverTests.cs
+++ b/FEBuilderGBA.Core.Tests/NameResolverTests.cs
@@ -109,6 +109,84 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Equal(expected, NameResolver.StripControlCodes(input!));
         }
 
+        [Fact]
+        public void GetSkillName_Zero_ReturnsNone()
+        {
+            NameResolver.ClearCache();
+            string result = NameResolver.GetSkillName(0);
+            Assert.Equal("(None)", result);
+        }
+
+        [Fact]
+        public void GetSkillName_NoResolver_ReturnsHexFallback()
+        {
+            var savedResolver = CoreState.SkillNameResolver;
+            try
+            {
+                CoreState.SkillNameResolver = null;
+                NameResolver.ClearCache();
+                string result = NameResolver.GetSkillName(0x1A);
+                Assert.Equal("Skill 0x1A", result);
+            }
+            finally
+            {
+                CoreState.SkillNameResolver = savedResolver;
+            }
+        }
+
+        [Fact]
+        public void GetSkillName_WithResolver_ReturnsResolvedName()
+        {
+            var savedResolver = CoreState.SkillNameResolver;
+            try
+            {
+                CoreState.SkillNameResolver = id => id == 5 ? "Adept" : null;
+                NameResolver.ClearCache();
+                string result = NameResolver.GetSkillName(5);
+                Assert.Equal("Adept", result);
+            }
+            finally
+            {
+                CoreState.SkillNameResolver = savedResolver;
+            }
+        }
+
+        [Fact]
+        public void GetSkillName_ResolverReturnsNull_FallsBackToHex()
+        {
+            var savedResolver = CoreState.SkillNameResolver;
+            try
+            {
+                CoreState.SkillNameResolver = id => null;
+                NameResolver.ClearCache();
+                string result = NameResolver.GetSkillName(0xFF);
+                Assert.Equal("Skill 0xFF", result);
+            }
+            finally
+            {
+                CoreState.SkillNameResolver = savedResolver;
+            }
+        }
+
+        [Fact]
+        public void GetSkillName_CacheWorksAcrossCalls()
+        {
+            var savedResolver = CoreState.SkillNameResolver;
+            try
+            {
+                int callCount = 0;
+                CoreState.SkillNameResolver = id => { callCount++; return "TestSkill"; };
+                NameResolver.ClearCache();
+                NameResolver.GetSkillName(10);
+                NameResolver.GetSkillName(10); // should use cache
+                Assert.Equal(1, callCount);
+            }
+            finally
+            {
+                CoreState.SkillNameResolver = savedResolver;
+            }
+        }
+
         [Theory]
         [InlineData(" Lord ", "Lord")]
         [InlineData("\r\nKnight\n", "Knight")]

--- a/FEBuilderGBA.Core/CoreState.cs
+++ b/FEBuilderGBA.Core/CoreState.cs
@@ -170,5 +170,12 @@ namespace FEBuilderGBA
         /// Used by GrowSimulator.CalcMaxLevel.
         /// </summary>
         public static Func<uint, int> GetCCCount { get; set; }
+
+        /// <summary>
+        /// Resolves a skill ID to a human-readable name.
+        /// Set by the UI layer (Avalonia/WinForms) which knows the installed skill system.
+        /// Returns null if the name cannot be resolved (NameResolver will use hex fallback).
+        /// </summary>
+        public static Func<uint, string> SkillNameResolver { get; set; }
     }
 }

--- a/FEBuilderGBA.Core/NameResolver.cs
+++ b/FEBuilderGBA.Core/NameResolver.cs
@@ -131,6 +131,12 @@ namespace FEBuilderGBA
             catch { return "???"; }
         }
 
+        /// <summary>Get the name of a skill by index.</summary>
+        public static string GetSkillName(uint id)
+        {
+            return _cache.GetOrAdd(("skill", id), _ => ResolveSkillName(id));
+        }
+
         static string ResolveSongName(uint id)
         {
             try
@@ -141,6 +147,25 @@ namespace FEBuilderGBA
                 return $"Song 0x{id:X}";
             }
             catch { return "???"; }
+        }
+
+        static string ResolveSkillName(uint id)
+        {
+            if (id == 0) return "(None)";
+            try
+            {
+                // Delegate to the UI-layer resolver if available
+                var resolver = CoreState.SkillNameResolver;
+                if (resolver != null)
+                {
+                    string name = resolver(id);
+                    if (!string.IsNullOrEmpty(name))
+                        return name;
+                }
+                // Fallback: hex representation
+                return $"Skill 0x{id:X02}";
+            }
+            catch { return $"Skill 0x{id:X02}"; }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `NameResolver.GetSkillName(uint id)` to Core library with `CoreState.SkillNameResolver` callback delegate
- Wire `PatchDetectionService` in Avalonia to resolve skill names from ROM text tables for SkillSystem, CSkillSys09x/300, and FE8N skill patch variants
- Replace hex skill display (`0x{id:X02}`) in 7 Avalonia ViewModels with human-readable name lookup:
  - `ItemEditorViewModel` (skill field)
  - `SkillAssignmentClassSkillSystemViewModel`, `SkillAssignmentClassCSkillSysViewViewModel`
  - `SkillAssignmentUnitSkillSystemViewModel`, `SkillAssignmentUnitCSkillSysViewViewModel`
  - `SkillAssignmentUnitFE8NViewViewModel` (PersonalSkill, SkillSet1, SkillSet2)
  - `SkillConfigFE8UCSkillSys09xViewViewModel` (SkillName text ID resolved to text)

Closes #67

## Test plan
- [x] `GetSkillName(0)` returns `(None)`
- [x] `GetSkillName` returns hex fallback when no resolver is set
- [x] `GetSkillName` returns resolved name when callback is provided
- [x] `GetSkillName` falls back to hex when resolver returns null
- [x] Cache works correctly across calls (resolver called only once per ID)
- [x] Core tests pass (828 tests)
- [x] Main tests pass (1523 tests)
- [x] Avalonia builds successfully

Generated with [Claude Code](https://claude.ai/code) (claude-opus-4-6[1m])