### PR TITLE
fix: resolve PickFromEditor race condition (#78)

### DIFF
--- a/FEBuilderGBA.Avalonia/Services/WindowManager.cs
+++ b/FEBuilderGBA.Avalonia/Services/WindowManager.cs
@@ -89,8 +89,9 @@ namespace FEBuilderGBA.Avalonia.Services
             var parent = owner ?? MainWindow;
             if (parent != null)
             {
-                // Show as modal dialog; navigate after it's opened
-                _ = window.ShowDialog(parent).ContinueWith(_ => tcs.TrySetResult(null), TaskScheduler.Default);
+                // Show as modal dialog. The Closed event handler above already
+                // sets tcs to null when the window closes without a selection.
+                _ = window.ShowDialog(parent);
             }
             else
             {

--- a/FEBuilderGBA.Tests/Unit/AvaloniaServiceTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AvaloniaServiceTests.cs
@@ -84,6 +84,53 @@ namespace FEBuilderGBA.Tests.Unit
             Assert.Contains("CloseAll", src);
         }
 
+        [Fact]
+        public void WindowManager_PickFromEditor_WiresEventBeforeShow()
+        {
+            // Verify SelectionConfirmed is wired before ShowDialog/Show is called
+            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "Services", "WindowManager.cs"));
+            // Search within PickFromEditor method only
+            int pickMethodStart = src.IndexOf("PickFromEditor");
+            Assert.True(pickMethodStart > 0, "PickFromEditor method not found");
+            int eventWirePos = src.IndexOf("SelectionConfirmed +=", pickMethodStart);
+            int showDialogPos = src.IndexOf(".ShowDialog(", pickMethodStart);
+            int showPos = src.IndexOf("window.Show()", pickMethodStart);
+            Assert.True(eventWirePos > 0, "SelectionConfirmed event wiring not found");
+            Assert.True(showDialogPos > 0, "ShowDialog call not found");
+            Assert.True(eventWirePos < showDialogPos,
+                "SelectionConfirmed must be wired BEFORE ShowDialog to prevent race condition");
+            if (showPos > 0)
+            {
+                Assert.True(eventWirePos < showPos,
+                    "SelectionConfirmed must be wired BEFORE Show to prevent race condition");
+            }
+        }
+
+        [Fact]
+        public void WindowManager_PickFromEditor_NoShowDialogContinueWith()
+        {
+            // The race condition was caused by .ShowDialog().ContinueWith() which could
+            // set tcs to null before SelectionConfirmed had a chance to fire.
+            // The Closed event handler already covers the "no selection" case.
+            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "Services", "WindowManager.cs"));
+            // Extract just the PickFromEditor method body
+            int methodStart = src.IndexOf("PickFromEditor");
+            int returnPos = src.IndexOf("return await tcs.Task;", methodStart);
+            string methodBody = src.Substring(methodStart, returnPos - methodStart);
+            // ShowDialog should not be chained with .ContinueWith
+            Assert.DoesNotContain("ShowDialog(parent).ContinueWith", methodBody);
+        }
+
+        [Fact]
+        public void WindowManager_PickFromEditor_ClosedEventSetsTcsNull()
+        {
+            // Verify the Closed event handler provides the fallback null result
+            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "Services", "WindowManager.cs"));
+            int closedPos = src.IndexOf("window.Closed +=");
+            Assert.True(closedPos > 0, "Closed event handler not found");
+            Assert.Contains("tcs.TrySetResult(null)", src);
+        }
+
         // ---- IEditorView ----
 
         [Fact]


### PR DESCRIPTION
## Summary
- Remove redundant `.ContinueWith()` on `ShowDialog` that could override a valid `SelectionConfirmed` result with null
- The `Closed` event handler already provides the fallback null result when the user closes without selecting
- Add 3 source-verification tests ensuring correct event wiring order and no race condition

Closes #78

## Test plan
- [x] Event wiring order verified (SelectionConfirmed before ShowDialog/Show)
- [x] No ContinueWith chained on ShowDialog
- [x] Closed event provides fallback null result
- [x] Avalonia project builds successfully
- [x] All 823 Core tests pass
- [x] All 1526 WinForms tests pass

Generated with Claude Code (claude-opus-4-6)