### PR TITLE
fix: improve status bar layout for responsive sizing (#80)

### DIFF
--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml
@@ -46,11 +46,14 @@
     </Menu>
 
     <!-- Status Bar -->
-    <Border DockPanel.Dock="Bottom" Background="#E8E8E8" Padding="8,4">
-      <Grid ColumnDefinitions="*,Auto">
-        <TextBlock Grid.Column="0" Name="StatusText" Text="No ROM loaded" />
-        <TextBlock Grid.Column="1" Name="VersionDetectionLabel" Text="" Foreground="Gray" Margin="8,0,0,0" />
-      </Grid>
+    <Border DockPanel.Dock="Bottom" Background="#E8E8E8" Padding="8,4" BorderBrush="#CCCCCC" BorderThickness="0,1,0,0">
+      <DockPanel>
+        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+          <TextBlock Name="RomSizeLabel" Text="" Foreground="Gray" Margin="8,0,0,0" VerticalAlignment="Center" />
+          <TextBlock Name="VersionDetectionLabel" Text="" Foreground="Gray" Margin="8,0,0,0" VerticalAlignment="Center" />
+        </StackPanel>
+        <TextBlock Name="StatusText" Text="No ROM loaded" TextTrimming="CharacterEllipsis" VerticalAlignment="Center" />
+      </DockPanel>
     </Border>
 
     <!-- Toolbar with Easy Mode toggle -->
@@ -58,7 +61,7 @@
       <DockPanel>
         <ToggleButton Name="EasyModeToggle" Content="Easy Mode" Click="ToggleEasyMode_Click"
                       DockPanel.Dock="Right" Padding="12,4" Margin="4,0" FontSize="12" />
-        <TextBlock Text="" /> <!-- spacer -->
+        <Panel /> <!-- fill remaining space -->
       </DockPanel>
     </Border>
 

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
@@ -234,13 +234,15 @@ namespace FEBuilderGBA.Avalonia.Views
             // Filter editor buttons for loaded ROM version
             UpdateEditorVisibility();
 
-            // Show detected ROM version in status bar
+            // Show detected ROM version and size in status bar
             try
             {
                 string ver = CoreState.ROM.RomInfo?.VersionToFilename ?? "Unknown";
                 VersionDetectionLabel.Text = R._("ROM:") + $" {ver}";
+                long romBytes = CoreState.ROM.Data?.Length ?? 0;
+                RomSizeLabel.Text = romBytes > 0 ? $"{romBytes / 1024.0 / 1024.0:F1} MB" : "";
             }
-            catch { VersionDetectionLabel.Text = ""; }
+            catch { VersionDetectionLabel.Text = ""; RomSizeLabel.Text = ""; }
 
             // Remember last opened ROM
             if (CoreState.Config != null)

--- a/FEBuilderGBA.Tests/Unit/AvaloniaProjectTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AvaloniaProjectTests.cs
@@ -135,5 +135,35 @@ namespace FEBuilderGBA.Tests.Unit
             var slnContent = File.ReadAllText(slnPath);
             Assert.Contains("FEBuilderGBA.Avalonia", slnContent);
         }
+
+        [Fact]
+        public void MainWindowStatusBarUsesDockPanelLayout()
+        {
+            var axaml = File.ReadAllText(Path.Combine(AvaloniaProjectDir, "Views", "MainWindow.axaml"));
+
+            // Status bar should use DockPanel for responsive layout (not fixed-width Grid columns)
+            Assert.Contains("DockPanel.Dock=\"Bottom\"", axaml);
+            // Right-aligned items should dock right
+            Assert.Contains("DockPanel.Dock=\"Right\"", axaml);
+            // StatusText should have text trimming for overflow
+            Assert.Contains("TextTrimming=\"CharacterEllipsis\"", axaml);
+            // Status bar should have top border for visual separation
+            Assert.Contains("BorderThickness=\"0,1,0,0\"", axaml);
+            // Named status elements must be present
+            Assert.Contains("Name=\"StatusText\"", axaml);
+            Assert.Contains("Name=\"VersionDetectionLabel\"", axaml);
+            Assert.Contains("Name=\"RomSizeLabel\"", axaml);
+        }
+
+        [Fact]
+        public void MainWindowToolbarUsesSemanticSpacer()
+        {
+            var axaml = File.ReadAllText(Path.Combine(AvaloniaProjectDir, "Views", "MainWindow.axaml"));
+
+            // Toolbar should not use empty TextBlock as spacer
+            Assert.DoesNotContain("Text=\"\" />", axaml);
+            // Should use Panel as a proper fill element
+            Assert.Contains("<Panel />", axaml);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Replace Grid-based status bar with DockPanel layout for proper responsive resizing
- Right-aligned items (ROM version, ROM size) dock right; status text fills remaining space with ellipsis trimming
- Add top border on status bar for visual separation
- Fix toolbar spacer: use semantic `<Panel />` instead of empty `<TextBlock Text="" />`
- Add ROM file size display in status bar when ROM is loaded

Closes #80

## Test plan
- [x] Avalonia project builds successfully
- [x] Core tests pass (823/823)
- [x] All tests pass (1525/1525)
- [x] New tests verify DockPanel layout structure and semantic spacer

Generated with Claude Code (claude-opus-4-6)