### PR TITLE
feat: improve Welcome screen, Easy Mode filter, and misc UI (#70, #72, #56, #59, #76)

### DIFF
--- a/FEBuilderGBA.Avalonia/ViewModels/WelcomeViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/WelcomeViewModel.cs
@@ -1,13 +1,32 @@
+using System;
+
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
     public class WelcomeViewModel : ViewModelBase
     {
         bool _isLoaded;
+        string _versionInfo = "";
 
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
 
+        /// <summary>Version string displayed on the Welcome screen.</summary>
+        public string VersionInfo { get => _versionInfo; set => SetField(ref _versionInfo, value); }
+
         public void Initialize()
         {
+            try
+            {
+#if DEBUG
+                VersionInfo = "Version: Debug Build";
+#else
+                VersionInfo = $"Version: {U.getVersion()}";
+#endif
+            }
+            catch
+            {
+                VersionInfo = "";
+            }
+
             IsLoaded = true;
         }
     }

--- a/FEBuilderGBA.Avalonia/Views/EasyModePanel.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EasyModePanel.axaml
@@ -8,9 +8,12 @@
       <TextBlock Text="Common editing tasks organized by category. Click any button to open its editor."
                  FontSize="13" HorizontalAlignment="Center" Foreground="Gray" Margin="0,0,0,8"
                  TextWrapping="Wrap" TextAlignment="Center" />
+      <!-- Search/Filter -->
+      <TextBox Name="SearchBox" Watermark="Search editors..." Margin="0,0,0,4"
+               HorizontalAlignment="Center" MinWidth="300" MaxWidth="500" />
 
       <!-- Characters -->
-      <Border BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
+      <Border Name="CategoryCharacters" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
         <StackPanel Spacing="8">
           <TextBlock Text="Characters" FontSize="18" FontWeight="SemiBold" Foreground="#2B579A" />
           <TextBlock Text="Edit playable and enemy unit stats, class data, and support relationships."
@@ -25,7 +28,7 @@
       </Border>
 
       <!-- Items -->
-      <Border BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
+      <Border Name="CategoryItems" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
         <StackPanel Spacing="8">
           <TextBlock Text="Items" FontSize="18" FontWeight="SemiBold" Foreground="#2B579A" />
           <TextBlock Text="Edit weapons, items, their effects, shops, and promotions."
@@ -40,7 +43,7 @@
       </Border>
 
       <!-- Maps -->
-      <Border BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
+      <Border Name="CategoryMaps" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
         <StackPanel Spacing="8">
           <TextBlock Text="Maps" FontSize="18" FontWeight="SemiBold" Foreground="#2B579A" />
           <TextBlock Text="Configure chapter settings, map layouts, terrain, and movement costs."
@@ -55,7 +58,7 @@
       </Border>
 
       <!-- Events -->
-      <Border BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
+      <Border Name="CategoryEvents" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
         <StackPanel Spacing="8">
           <TextBlock Text="Events" FontSize="18" FontWeight="SemiBold" Foreground="#2B579A" />
           <TextBlock Text="Edit event scripts that control story scenes, cutscenes, and gameplay triggers."
@@ -69,7 +72,7 @@
       </Border>
 
       <!-- Graphics -->
-      <Border BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
+      <Border Name="CategoryGraphics" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
         <StackPanel Spacing="8">
           <TextBlock Text="Graphics" FontSize="18" FontWeight="SemiBold" Foreground="#2B579A" />
           <TextBlock Text="Edit character portraits, battle animations, CGs, and sprite graphics."
@@ -84,7 +87,7 @@
       </Border>
 
       <!-- Music -->
-      <Border BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
+      <Border Name="CategoryMusic" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
         <StackPanel Spacing="8">
           <TextBlock Text="Music" FontSize="18" FontWeight="SemiBold" Foreground="#2B579A" />
           <TextBlock Text="Manage background music, sound effects, and the in-game sound room."
@@ -98,7 +101,7 @@
       </Border>
 
       <!-- Text -->
-      <Border BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
+      <Border Name="CategoryText" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
         <StackPanel Spacing="8">
           <TextBlock Text="Text" FontSize="18" FontWeight="SemiBold" Foreground="#2B579A" />
           <TextBlock Text="Edit in-game dialogue, menus, and all text strings in the ROM."
@@ -110,7 +113,7 @@
       </Border>
 
       <!-- Tools -->
-      <Border BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
+      <Border Name="CategoryTools" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
         <StackPanel Spacing="8">
           <TextBlock Text="Tools" FontSize="18" FontWeight="SemiBold" Foreground="#2B579A" />
           <TextBlock Text="Advanced utilities: hex editing, patching, ROM diagnostics, and more."

--- a/FEBuilderGBA.Avalonia/Views/EasyModePanel.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EasyModePanel.axaml.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Services;
@@ -6,9 +8,53 @@ namespace FEBuilderGBA.Avalonia.Views
 {
     public partial class EasyModePanel : UserControl
     {
+        /// <summary>Category borders paired with their searchable keywords (category name + button labels).</summary>
+        private List<(Border border, string keywords)>? _categories;
+
         public EasyModePanel()
         {
             InitializeComponent();
+            SearchBox.TextChanged += SearchBox_TextChanged;
+        }
+
+        /// <summary>Lazily build the category list after the control is initialized.</summary>
+        private List<(Border border, string keywords)> GetCategories()
+        {
+            if (_categories != null) return _categories;
+            _categories = new List<(Border, string)>
+            {
+                (CategoryCharacters, "characters units classes support talk"),
+                (CategoryItems, "items weapons weapon effect shops promotions"),
+                (CategoryMaps, "maps map settings editor terrain names move costs"),
+                (CategoryEvents, "events event scripts conditions units"),
+                (CategoryGraphics, "graphics portraits battle animations cg viewer image"),
+                (CategoryMusic, "music song table tracks sound room"),
+                (CategoryText, "text editor dialogue"),
+                (CategoryTools, "tools hex editor patch manager lint pointer"),
+            };
+            return _categories;
+        }
+
+        private void SearchBox_TextChanged(object? sender, TextChangedEventArgs e)
+        {
+            ApplyFilter(SearchBox.Text);
+        }
+
+        /// <summary>
+        /// Show/hide category sections based on the search query.
+        /// Empty query shows all categories. Otherwise, only categories whose
+        /// keywords contain the query substring (case-insensitive) are shown.
+        /// </summary>
+        internal void ApplyFilter(string? query)
+        {
+            var categories = GetCategories();
+            bool showAll = string.IsNullOrWhiteSpace(query);
+            var q = (query ?? "").Trim();
+
+            foreach (var (border, keywords) in categories)
+            {
+                border.IsVisible = showAll || keywords.Contains(q, StringComparison.OrdinalIgnoreCase);
+            }
         }
 
         // Characters

--- a/FEBuilderGBA.Avalonia/Views/WelcomeView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/WelcomeView.axaml
@@ -14,20 +14,20 @@
                    HorizontalAlignment="Center" />
         <TextBlock Text="Avalonia Cross-Platform Edition" FontSize="16"
                    Foreground="Gray" HorizontalAlignment="Center" Margin="0,4,0,0" />
-        <TextBlock Name="VersionText" FontSize="12"
+        <TextBlock Name="VersionText" Text="{Binding VersionInfo}" FontSize="12"
                    Foreground="Gray" HorizontalAlignment="Center" Margin="0,4,0,0" />
       </StackPanel>
     </Border>
-    <!-- Buttons (WinForms 851x47/50 each, centered at X:214) -->
+    <!-- Buttons (constrained width for better layout) -->
     <StackPanel Spacing="12" HorizontalAlignment="Center">
-      <Button Name="OpenLastROMButton" Content="Open Last ROM" Width="851" Height="47"
-              HorizontalContentAlignment="Center" Click="OpenLastROM_Click" />
-      <Button Name="OpenROMButton" Content="Open ROM" Width="851" Height="50"
-              HorizontalContentAlignment="Center" Click="OpenROM_Click" />
-      <Button Name="UpdateCheckButton" Content="Check for Updates" Width="851" Height="47"
-              HorizontalContentAlignment="Center" Click="UpdateCheck_Click" />
-      <Button Name="ManButton" Content="Online Manual" Width="851" Height="47"
-              HorizontalContentAlignment="Center" Click="Manual_Click" />
+      <Button Name="OpenLastROMButton" Content="Open Last ROM" MinWidth="200" MaxWidth="400" Height="47"
+              HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Click="OpenLastROM_Click" />
+      <Button Name="OpenROMButton" Content="Open ROM" MinWidth="200" MaxWidth="400" Height="50"
+              HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Click="OpenROM_Click" />
+      <Button Name="UpdateCheckButton" Content="Check for Updates" MinWidth="200" MaxWidth="400" Height="47"
+              HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Click="UpdateCheck_Click" />
+      <Button Name="ManButton" Content="Online Manual" MinWidth="200" MaxWidth="400" Height="47"
+              HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Click="Manual_Click" />
     </StackPanel>
   </DockPanel>
   </ScrollViewer>

--- a/FEBuilderGBA.Avalonia/Views/WelcomeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WelcomeView.axaml.cs
@@ -18,17 +18,6 @@ namespace FEBuilderGBA.Avalonia.Views
             InitializeComponent();
             DataContext = _vm;
             _vm.Initialize();
-
-            // Show version info
-            try
-            {
-#if DEBUG
-                VersionText.Text = "Version: Debug Build";
-#else
-                VersionText.Text = $"Version: {U.getVersion()}";
-#endif
-            }
-            catch { VersionText.Text = ""; }
         }
 
         void OpenLastROM_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Tests/Unit/AvaloniaDialogViewTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AvaloniaDialogViewTests.cs
@@ -800,7 +800,23 @@ namespace FEBuilderGBA.Tests.Unit
             Assert.Contains("Name=\"OpenROMButton\"", src);
             Assert.Contains("Name=\"UpdateCheckButton\"", src);
             Assert.Contains("Name=\"ManButton\"", src);
-            Assert.Contains("Width=\"851\"", src);
+            Assert.Contains("MaxWidth=\"400\"", src);
+        }
+
+        [Fact]
+        public void WelcomeView_Axaml_HasVersionInfoBinding()
+        {
+            var src = ReadAxaml("WelcomeView.axaml");
+            Assert.Contains("{Binding VersionInfo}", src);
+            Assert.Contains("Name=\"VersionText\"", src);
+        }
+
+        [Fact]
+        public void WelcomeViewModel_HasVersionInfoProperty()
+        {
+            var src = ReadVM("WelcomeViewModel.cs");
+            Assert.Contains("VersionInfo", src);
+            Assert.Contains("SetField", src);
         }
 
         [Fact]
@@ -811,6 +827,39 @@ namespace FEBuilderGBA.Tests.Unit
             Assert.Contains("OpenROM_Click", src);
             Assert.Contains("UpdateCheck_Click", src);
             Assert.Contains("Manual_Click", src);
+        }
+
+        // --- EasyModePanel search/filter (#72) ---
+
+        [Fact]
+        public void EasyModePanel_Axaml_HasSearchBox()
+        {
+            var src = ReadAxaml("EasyModePanel.axaml");
+            Assert.Contains("Name=\"SearchBox\"", src);
+            Assert.Contains("Watermark=\"Search editors...\"", src);
+        }
+
+        [Fact]
+        public void EasyModePanel_Axaml_HasNamedCategories()
+        {
+            var src = ReadAxaml("EasyModePanel.axaml");
+            Assert.Contains("Name=\"CategoryCharacters\"", src);
+            Assert.Contains("Name=\"CategoryItems\"", src);
+            Assert.Contains("Name=\"CategoryMaps\"", src);
+            Assert.Contains("Name=\"CategoryEvents\"", src);
+            Assert.Contains("Name=\"CategoryGraphics\"", src);
+            Assert.Contains("Name=\"CategoryMusic\"", src);
+            Assert.Contains("Name=\"CategoryText\"", src);
+            Assert.Contains("Name=\"CategoryTools\"", src);
+        }
+
+        [Fact]
+        public void EasyModePanel_CodeBehind_HasApplyFilterMethod()
+        {
+            var src = ReadView("EasyModePanel.axaml.cs");
+            Assert.Contains("ApplyFilter", src);
+            Assert.Contains("SearchBox_TextChanged", src);
+            Assert.Contains("GetCategories", src);
         }
 
         // ===========================================================================


### PR DESCRIPTION
## Summary
- Constrain Welcome screen button widths (MaxWidth=400) for better, more proportional layout
- Add version info display via VersionInfo ViewModel property with data binding
- Add search/filter TextBox to Easy Mode panel that shows/hides category sections by keyword
- Add unit tests for version info binding, named categories, and filter method

Ref #70 (partial — welcome screen sizing and version info; recent files/logo/tagline still needed)
Ref #72 (partial — Easy Mode search/filter; text-editing tools still needed)
Closes #76 (already implemented)

## Test plan
- [x] Welcome screen buttons constrained to MaxWidth=400
- [x] Version info displayed via ViewModel binding
- [x] Easy Mode search box filters categories by keyword
- [x] Avalonia project builds successfully
- [x] Core tests pass (823)
- [x] Dialog view tests pass (202)

Generated with Claude Code (claude-opus-4-6)