### PR TITLE
feat: add dark mode support and clean up hardcoded colors (#69)

### DIFF
--- a/FEBuilderGBA.Avalonia/App.axaml
+++ b/FEBuilderGBA.Avalonia/App.axaml
@@ -4,4 +4,70 @@
     <Application.Styles>
         <FluentTheme />
     </Application.Styles>
+
+    <Application.Resources>
+        <ResourceDictionary>
+            <!-- Status bar / toolbar backgrounds (overridden per theme in code-behind) -->
+            <SolidColorBrush x:Key="StatusBarBackgroundBrush" Color="#E8E8E8" />
+            <SolidColorBrush x:Key="ToolbarBackgroundBrush" Color="#F0F0F0" />
+            <SolidColorBrush x:Key="ToolbarBorderBrush" Color="#DDDDDD" />
+
+            <!-- Section heading accent color (EasyMode panel headers, etc.) -->
+            <SolidColorBrush x:Key="SectionHeadingBrush" Color="#2B579A" />
+
+            <!-- Category card border -->
+            <SolidColorBrush x:Key="CardBorderBrush" Color="#CCCCCC" />
+
+            <!-- Info banner (light blue info boxes) -->
+            <SolidColorBrush x:Key="InfoBannerBackgroundBrush" Color="#D1ECF1" />
+            <SolidColorBrush x:Key="InfoBannerBorderBrush" Color="#17A2B8" />
+
+            <!-- Subtle panel background -->
+            <SolidColorBrush x:Key="SubtlePanelBackgroundBrush" Color="#F8F9FA" />
+            <SolidColorBrush x:Key="SubtlePanelBorderBrush" Color="#DEE2E6" />
+
+            <!-- Warning banner -->
+            <SolidColorBrush x:Key="WarningBackgroundBrush" Color="#FFF3CD" />
+            <SolidColorBrush x:Key="WarningBorderBrush" Color="#FFC107" />
+            <SolidColorBrush x:Key="WarningTextBrush" Color="#B8860B" />
+            <SolidColorBrush x:Key="WarningTextSecondaryBrush" Color="#8B6914" />
+
+            <!-- Dependency warning (PatchManager) -->
+            <SolidColorBrush x:Key="DependencyWarningBackgroundBrush" Color="#FFFDE8" />
+            <SolidColorBrush x:Key="DependencyWarningBorderBrush" Color="#F0C000" />
+
+            <!-- Highlight / accent overlay -->
+            <SolidColorBrush x:Key="AccentOverlayBrush" Color="#33FF8C00" />
+
+            <!-- Script category select button -->
+            <SolidColorBrush x:Key="ScriptCategoryButtonBrush" Color="#4060A0" />
+            <SolidColorBrush x:Key="ScriptCategoryOverlayBrush" Color="#20808080" />
+
+            <!-- Error/long message dialog -->
+            <SolidColorBrush x:Key="ErrorDialogBackgroundBrush" Color="#FFF8F8" />
+
+            <!-- Undo popup info -->
+            <SolidColorBrush x:Key="UndoInfoBackgroundBrush" Color="#E3F2FD" />
+            <SolidColorBrush x:Key="UndoInfoBorderBrush" Color="#90CAF9" />
+
+            <!-- Emulator/RAM warning -->
+            <SolidColorBrush x:Key="EmulatorWarningBackgroundBrush" Color="#FFF8E1" />
+
+            <!-- Map editor dark backgrounds -->
+            <SolidColorBrush x:Key="MapEditorToolbarBrush" Color="#FF2A2A2A" />
+            <SolidColorBrush x:Key="MapEditorCanvasBrush" Color="#FF202020" />
+
+            <!-- Text char code view -->
+            <SolidColorBrush x:Key="CharCodeHeaderBrush" Color="#FF6888A8" />
+            <SolidColorBrush x:Key="CharCodeCellBrush" Color="#FFE0E0E0" />
+
+            <!-- Welcome banner -->
+            <SolidColorBrush x:Key="WelcomeBannerBrush" Color="#E8EAF6" />
+            <SolidColorBrush x:Key="WelcomeBannerBorderBrush" Color="#C5CAE9" />
+
+            <!-- Subtitle overlay (intentionally dark for video overlay) -->
+            <SolidColorBrush x:Key="SubtitleOverlayBackgroundBrush" Color="Black" />
+            <SolidColorBrush x:Key="SubtitleOverlayForegroundBrush" Color="White" />
+        </ResourceDictionary>
+    </Application.Resources>
 </Application>

--- a/FEBuilderGBA.Avalonia/App.axaml.cs
+++ b/FEBuilderGBA.Avalonia/App.axaml.cs
@@ -4,12 +4,20 @@ using System.Text;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Styling;
 using FEBuilderGBA.SkiaSharp;
 
 namespace FEBuilderGBA.Avalonia
 {
     public partial class App : Application
     {
+        /// <summary>Config key used to persist the theme preference.</summary>
+        internal const string ThemeConfigKey = "Avalonia_Theme";
+
+        /// <summary>Returns true when the app is currently using dark mode.</summary>
+        public bool IsDarkMode => RequestedThemeVariant == ThemeVariant.Dark;
+
         /// <summary>ROM path passed via --rom command line argument.</summary>
         public static string? StartupRomPath { get; set; }
 
@@ -71,6 +79,9 @@ namespace FEBuilderGBA.Avalonia
                 CoreState.Config = config;
             }
 
+            // Apply saved theme preference
+            ApplySavedTheme();
+
             // Parse command line arguments
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
@@ -79,6 +90,105 @@ namespace FEBuilderGBA.Avalonia
             }
 
             base.OnFrameworkInitializationCompleted();
+        }
+
+        /// <summary>Toggle between light and dark mode, updating dynamic resources and persisting the choice.</summary>
+        public void ToggleTheme()
+        {
+            bool switchToDark = !IsDarkMode;
+            RequestedThemeVariant = switchToDark ? ThemeVariant.Dark : ThemeVariant.Light;
+            ApplyThemeResources(switchToDark);
+
+            // Persist
+            if (CoreState.Config != null)
+            {
+                CoreState.Config[ThemeConfigKey] = switchToDark ? "Dark" : "Light";
+                CoreState.Config.Save();
+            }
+        }
+
+        void ApplySavedTheme()
+        {
+            bool dark = false;
+            if (CoreState.Config != null)
+            {
+                string pref = CoreState.Config.at(ThemeConfigKey, "Light");
+                dark = string.Equals(pref, "Dark", StringComparison.OrdinalIgnoreCase);
+            }
+            RequestedThemeVariant = dark ? ThemeVariant.Dark : ThemeVariant.Light;
+            ApplyThemeResources(dark);
+        }
+
+        void ApplyThemeResources(bool dark)
+        {
+            if (Resources == null) return;
+
+            if (dark)
+            {
+                SetBrush("StatusBarBackgroundBrush", "#2D2D2D");
+                SetBrush("ToolbarBackgroundBrush", "#333333");
+                SetBrush("ToolbarBorderBrush", "#444444");
+                SetBrush("SectionHeadingBrush", "#6B9BD2");
+                SetBrush("CardBorderBrush", "#555555");
+                SetBrush("InfoBannerBackgroundBrush", "#1A3A4A");
+                SetBrush("InfoBannerBorderBrush", "#2A8A9A");
+                SetBrush("SubtlePanelBackgroundBrush", "#2A2A2A");
+                SetBrush("SubtlePanelBorderBrush", "#444444");
+                SetBrush("WarningBackgroundBrush", "#3D3520");
+                SetBrush("WarningBorderBrush", "#AA8800");
+                SetBrush("WarningTextBrush", "#D4A830");
+                SetBrush("WarningTextSecondaryBrush", "#C4A040");
+                SetBrush("DependencyWarningBackgroundBrush", "#3D3820");
+                SetBrush("DependencyWarningBorderBrush", "#AA8800");
+                SetBrush("AccentOverlayBrush", "#33FF8C00");
+                SetBrush("ScriptCategoryButtonBrush", "#5070B0");
+                SetBrush("ScriptCategoryOverlayBrush", "#30808080");
+                SetBrush("ErrorDialogBackgroundBrush", "#3A2020");
+                SetBrush("UndoInfoBackgroundBrush", "#1A2A3A");
+                SetBrush("UndoInfoBorderBrush", "#406090");
+                SetBrush("EmulatorWarningBackgroundBrush", "#3A3520");
+                SetBrush("CharCodeHeaderBrush", "#4A6080");
+                SetBrush("CharCodeCellBrush", "#3A3A3A");
+                SetBrush("WelcomeBannerBrush", "#2A2A3A");
+                SetBrush("WelcomeBannerBorderBrush", "#3A3A5A");
+            }
+            else
+            {
+                SetBrush("StatusBarBackgroundBrush", "#E8E8E8");
+                SetBrush("ToolbarBackgroundBrush", "#F0F0F0");
+                SetBrush("ToolbarBorderBrush", "#DDDDDD");
+                SetBrush("SectionHeadingBrush", "#2B579A");
+                SetBrush("CardBorderBrush", "#CCCCCC");
+                SetBrush("InfoBannerBackgroundBrush", "#D1ECF1");
+                SetBrush("InfoBannerBorderBrush", "#17A2B8");
+                SetBrush("SubtlePanelBackgroundBrush", "#F8F9FA");
+                SetBrush("SubtlePanelBorderBrush", "#DEE2E6");
+                SetBrush("WarningBackgroundBrush", "#FFF3CD");
+                SetBrush("WarningBorderBrush", "#FFC107");
+                SetBrush("WarningTextBrush", "#B8860B");
+                SetBrush("WarningTextSecondaryBrush", "#8B6914");
+                SetBrush("DependencyWarningBackgroundBrush", "#FFFDE8");
+                SetBrush("DependencyWarningBorderBrush", "#F0C000");
+                SetBrush("AccentOverlayBrush", "#33FF8C00");
+                SetBrush("ScriptCategoryButtonBrush", "#4060A0");
+                SetBrush("ScriptCategoryOverlayBrush", "#20808080");
+                SetBrush("ErrorDialogBackgroundBrush", "#FFF8F8");
+                SetBrush("UndoInfoBackgroundBrush", "#E3F2FD");
+                SetBrush("UndoInfoBorderBrush", "#90CAF9");
+                SetBrush("EmulatorWarningBackgroundBrush", "#FFF8E1");
+                SetBrush("CharCodeHeaderBrush", "#FF6888A8");
+                SetBrush("CharCodeCellBrush", "#FFE0E0E0");
+                SetBrush("WelcomeBannerBrush", "#E8EAF6");
+                SetBrush("WelcomeBannerBorderBrush", "#C5CAE9");
+            }
+        }
+
+        void SetBrush(string key, string color)
+        {
+            if (Resources.ContainsKey(key) && Resources[key] is SolidColorBrush brush)
+            {
+                brush.Color = Color.Parse(color);
+            }
         }
 
         static void ParseArgs(string[]? args)

--- a/FEBuilderGBA.Avalonia/Views/AIScriptCategorySelectView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/AIScriptCategorySelectView.axaml
@@ -38,7 +38,7 @@
         <TextBlock DockPanel.Dock="Top" Text="Parameters" FontWeight="SemiBold" Margin="0,0,0,4" />
 
         <!-- Command name header -->
-        <Border DockPanel.Dock="Top" Background="#20808080" CornerRadius="4" Padding="8,4" Margin="0,0,0,8">
+        <Border DockPanel.Dock="Top" Background="{DynamicResource ScriptCategoryOverlayBrush}" CornerRadius="4" Padding="8,4" Margin="0,0,0,8">
           <TextBlock Name="CommandNameLabel" Text="(select a command)" FontFamily="Consolas" FontSize="13"
                      TextWrapping="Wrap" />
         </Border>
@@ -46,7 +46,7 @@
         <!-- Write button at bottom -->
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
           <Button Name="WriteButton" Content="Write to ROM" Click="Write_Click" IsEnabled="False"
-                  Background="#4060A0" Foreground="White" Padding="16,6" />
+                  Background="{DynamicResource ScriptCategoryButtonBrush}" Foreground="White" Padding="16,6" />
           <Button Name="RefreshButton" Content="Refresh" Click="Refresh_Click" IsEnabled="False"
                   Padding="16,6" />
         </StackPanel>

--- a/FEBuilderGBA.Avalonia/Views/ClassEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ClassEditorView.axaml
@@ -268,7 +268,7 @@
         <!-- Validation Warnings -->
         <Border Name="WarningsBorder" IsVisible="False"
                 BorderBrush="Orange" BorderThickness="1" Padding="8" CornerRadius="4"
-                Background="#33FF8C00" Margin="0,8,0,0">
+                Background="{DynamicResource AccentOverlayBrush}" Margin="0,8,0,0">
           <StackPanel Spacing="2">
             <TextBlock Text="Warnings" FontWeight="Bold" Foreground="DarkOrange" />
             <ItemsControl Name="WarningsList">

--- a/FEBuilderGBA.Avalonia/Views/EasyModePanel.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EasyModePanel.axaml
@@ -13,9 +13,9 @@
                HorizontalAlignment="Center" MinWidth="300" MaxWidth="500" />
 
       <!-- Characters -->
-      <Border Name="CategoryCharacters" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
+      <Border Name="CategoryCharacters" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
         <StackPanel Spacing="8">
-          <TextBlock Text="Characters" FontSize="18" FontWeight="SemiBold" Foreground="#2B579A" />
+          <TextBlock Text="Characters" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource SectionHeadingBrush}" />
           <TextBlock Text="Edit playable and enemy unit stats, class data, and support relationships."
                      FontSize="12" Foreground="Gray" TextWrapping="Wrap" />
           <WrapPanel Orientation="Horizontal">
@@ -28,9 +28,9 @@
       </Border>
 
       <!-- Items -->
-      <Border Name="CategoryItems" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
+      <Border Name="CategoryItems" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
         <StackPanel Spacing="8">
-          <TextBlock Text="Items" FontSize="18" FontWeight="SemiBold" Foreground="#2B579A" />
+          <TextBlock Text="Items" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource SectionHeadingBrush}" />
           <TextBlock Text="Edit weapons, items, their effects, shops, and promotions."
                      FontSize="12" Foreground="Gray" TextWrapping="Wrap" />
           <WrapPanel Orientation="Horizontal">
@@ -43,9 +43,9 @@
       </Border>
 
       <!-- Maps -->
-      <Border Name="CategoryMaps" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
+      <Border Name="CategoryMaps" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
         <StackPanel Spacing="8">
-          <TextBlock Text="Maps" FontSize="18" FontWeight="SemiBold" Foreground="#2B579A" />
+          <TextBlock Text="Maps" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource SectionHeadingBrush}" />
           <TextBlock Text="Configure chapter settings, map layouts, terrain, and movement costs."
                      FontSize="12" Foreground="Gray" TextWrapping="Wrap" />
           <WrapPanel Orientation="Horizontal">
@@ -58,9 +58,9 @@
       </Border>
 
       <!-- Events -->
-      <Border Name="CategoryEvents" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
+      <Border Name="CategoryEvents" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
         <StackPanel Spacing="8">
-          <TextBlock Text="Events" FontSize="18" FontWeight="SemiBold" Foreground="#2B579A" />
+          <TextBlock Text="Events" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource SectionHeadingBrush}" />
           <TextBlock Text="Edit event scripts that control story scenes, cutscenes, and gameplay triggers."
                      FontSize="12" Foreground="Gray" TextWrapping="Wrap" />
           <WrapPanel Orientation="Horizontal">
@@ -72,9 +72,9 @@
       </Border>
 
       <!-- Graphics -->
-      <Border Name="CategoryGraphics" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
+      <Border Name="CategoryGraphics" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
         <StackPanel Spacing="8">
-          <TextBlock Text="Graphics" FontSize="18" FontWeight="SemiBold" Foreground="#2B579A" />
+          <TextBlock Text="Graphics" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource SectionHeadingBrush}" />
           <TextBlock Text="Edit character portraits, battle animations, CGs, and sprite graphics."
                      FontSize="12" Foreground="Gray" TextWrapping="Wrap" />
           <WrapPanel Orientation="Horizontal">
@@ -88,9 +88,9 @@
       </Border>
 
       <!-- Music -->
-      <Border Name="CategoryMusic" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
+      <Border Name="CategoryMusic" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
         <StackPanel Spacing="8">
-          <TextBlock Text="Music" FontSize="18" FontWeight="SemiBold" Foreground="#2B579A" />
+          <TextBlock Text="Music" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource SectionHeadingBrush}" />
           <TextBlock Text="Manage background music, sound effects, and the in-game sound room."
                      FontSize="12" Foreground="Gray" TextWrapping="Wrap" />
           <WrapPanel Orientation="Horizontal">
@@ -102,9 +102,9 @@
       </Border>
 
       <!-- Text -->
-      <Border Name="CategoryText" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
+      <Border Name="CategoryText" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
         <StackPanel Spacing="8">
-          <TextBlock Text="Text" FontSize="18" FontWeight="SemiBold" Foreground="#2B579A" />
+          <TextBlock Text="Text" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource SectionHeadingBrush}" />
           <TextBlock Text="Edit in-game dialogue, menus, and all text strings in the ROM."
                      FontSize="12" Foreground="Gray" TextWrapping="Wrap" />
           <WrapPanel Orientation="Horizontal">
@@ -114,9 +114,9 @@
       </Border>
 
       <!-- Tools -->
-      <Border Name="CategoryTools" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
+      <Border Name="CategoryTools" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="6" Padding="12" Margin="0,4">
         <StackPanel Spacing="8">
-          <TextBlock Text="Tools" FontSize="18" FontWeight="SemiBold" Foreground="#2B579A" />
+          <TextBlock Text="Tools" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource SectionHeadingBrush}" />
           <TextBlock Text="Advanced utilities: hex editing, patching, ROM diagnostics, and more."
                      FontSize="12" Foreground="Gray" TextWrapping="Wrap" />
           <WrapPanel Orientation="Horizontal">

--- a/FEBuilderGBA.Avalonia/Views/EmulatorMemoryView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EmulatorMemoryView.axaml
@@ -10,7 +10,7 @@
     <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Spacing="8" Margin="0,12,0,0" HorizontalAlignment="Right">
       <Button Content="Close" Width="80" Click="Close_Click" />
     </StackPanel>
-    <Border BorderBrush="Orange" BorderThickness="2" Padding="16" Background="#FFF8E1">
+    <Border BorderBrush="Orange" BorderThickness="2" Padding="16" Background="{DynamicResource EmulatorWarningBackgroundBrush}">
       <StackPanel Spacing="8">
         <TextBlock Text="Platform Notice" FontWeight="Bold" FontSize="14" Foreground="DarkOrange" />
         <TextBlock TextWrapping="Wrap"

--- a/FEBuilderGBA.Avalonia/Views/ErrorLongMessageDialogView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ErrorLongMessageDialogView.axaml
@@ -8,7 +8,7 @@
   <DockPanel>
     <!-- Top panel: Red title + Close button (WinForms panel1 1104x43) -->
     <Grid DockPanel.Dock="Top" ColumnDefinitions="*,Auto" Height="43"
-          Background="#FFF8F8" Margin="0,0,0,0">
+          Background="{DynamicResource ErrorDialogBackgroundBrush}" Margin="0,0,0,0">
       <TextBlock Grid.Column="0" Text="The following error has occurred."
                  Foreground="Red" FontWeight="Bold" FontSize="14"
                  VerticalAlignment="Center" Margin="12,0,0,0" />

--- a/FEBuilderGBA.Avalonia/Views/EventScriptPopupView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventScriptPopupView.axaml
@@ -37,7 +37,7 @@
         <TextBlock DockPanel.Dock="Top" Text="Parameters" FontWeight="SemiBold" Margin="0,0,0,4" />
 
         <!-- Command name header -->
-        <Border DockPanel.Dock="Top" Background="#20808080" CornerRadius="4" Padding="8,4" Margin="0,0,0,8">
+        <Border DockPanel.Dock="Top" Background="{DynamicResource ScriptCategoryOverlayBrush}" CornerRadius="4" Padding="8,4" Margin="0,0,0,8">
           <TextBlock Name="CommandNameLabel" Text="(select a command)" FontFamily="Consolas" FontSize="13"
                      TextWrapping="Wrap" />
         </Border>
@@ -45,7 +45,7 @@
         <!-- Write button at bottom -->
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
           <Button Name="WriteButton" Content="Write to ROM" Click="Write_Click" IsEnabled="False"
-                  Background="#4060A0" Foreground="White" Padding="16,6" />
+                  Background="{DynamicResource ScriptCategoryButtonBrush}" Foreground="White" Padding="16,6" />
           <Button Name="RefreshButton" Content="Refresh" Click="Refresh_Click" IsEnabled="False"
                   Padding="16,6" />
         </StackPanel>

--- a/FEBuilderGBA.Avalonia/Views/GraphicsToolView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/GraphicsToolView.axaml
@@ -56,10 +56,10 @@
     </StackPanel>
 
     <!-- Image info -->
-    <TextBlock DockPanel.Dock="Top" Text="{Binding ImageInfo}" Margin="0,0,0,4" Foreground="DimGray" />
+    <TextBlock DockPanel.Dock="Top" Text="{Binding ImageInfo}" Margin="0,0,0,4" Foreground="{DynamicResource SubtleTextForegroundBrush}" />
 
     <!-- Image display -->
-    <Border Background="#F0F0F0" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="4" Padding="4"
+    <Border Background="{DynamicResource SubtlePanelBackgroundBrush}" BorderBrush="{DynamicResource SubtlePanelBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="4"
             MinHeight="128" MinWidth="128">
       <controls:GbaImageControl x:Name="ImageDisplay" />
     </Border>

--- a/FEBuilderGBA.Avalonia/Views/ImageBGSelectPopupView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageBGSelectPopupView.axaml
@@ -7,7 +7,7 @@
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
   <DockPanel Margin="16">
     <TextBlock DockPanel.Dock="Top" Text="BG Image Select" FontSize="18" FontWeight="Bold" Margin="0,0,0,12" />
-    <Border DockPanel.Dock="Top" Background="#D1ECF1" BorderBrush="#17A2B8" BorderThickness="1" CornerRadius="4" Padding="12" Margin="0,0,0,8">
+    <Border DockPanel.Dock="Top" Background="{DynamicResource InfoBannerBackgroundBrush}" BorderBrush="{DynamicResource InfoBannerBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="12" Margin="0,0,0,8">
       <TextBlock TextWrapping="Wrap"
                  Text="Background Image Selector.&#10;Choose a background image from the available BG entries in the ROM." />
     </Border>

--- a/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml
@@ -173,7 +173,7 @@
         <!-- Validation Warnings -->
         <Border Name="WarningsBorder" IsVisible="False"
                 BorderBrush="Orange" BorderThickness="1" Padding="8" CornerRadius="4"
-                Background="#33FF8C00" Margin="0,8,0,0">
+                Background="{DynamicResource AccentOverlayBrush}" Margin="0,8,0,0">
           <StackPanel Spacing="2">
             <TextBlock Text="Warnings" FontWeight="Bold" Foreground="DarkOrange" />
             <ItemsControl Name="WarningsList">

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml
@@ -27,6 +27,8 @@
         <MenuItem Header="Toggle _Easy Mode" Click="ToggleEasyMode_Click" Name="EasyModeMenuItem" />
         <MenuItem Header="_Collapse All Sections" Click="CollapseAll_Click" Name="CollapseAllMenuItem" />
         <MenuItem Header="_Expand All Sections" Click="ExpandAll_Click" Name="ExpandAllMenuItem" />
+        <Separator />
+        <MenuItem Header="Toggle _Dark Mode" Click="ToggleDarkMode_Click" Name="DarkModeMenuItem" />
       </MenuItem>
       <MenuItem Header="_Tools">
         <MenuItem Header="_Lint Check" Click="Lint_Click" Name="LintMenuItem" IsEnabled="False" />
@@ -50,7 +52,7 @@
     </Menu>
 
     <!-- Status Bar -->
-    <Border DockPanel.Dock="Bottom" Background="#E8E8E8" Padding="8,4" BorderBrush="#CCCCCC" BorderThickness="0,1,0,0">
+    <Border DockPanel.Dock="Bottom" Background="{DynamicResource StatusBarBackgroundBrush}" Padding="8,4" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="0,1,0,0">
       <DockPanel>
         <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
           <TextBlock Name="RomSizeLabel" Text="" Foreground="Gray" Margin="8,0,0,0" VerticalAlignment="Center" />
@@ -61,7 +63,7 @@
     </Border>
 
     <!-- Toolbar with Easy Mode toggle -->
-    <Border DockPanel.Dock="Top" Background="#F0F0F0" Padding="8,4" BorderBrush="#DDDDDD" BorderThickness="0,0,0,1">
+    <Border DockPanel.Dock="Top" Background="{DynamicResource ToolbarBackgroundBrush}" Padding="8,4" BorderBrush="{DynamicResource ToolbarBorderBrush}" BorderThickness="0,0,0,1">
       <DockPanel>
         <ToggleButton Name="EasyModeToggle" Content="Easy Mode" Click="ToggleEasyMode_Click"
                       DockPanel.Dock="Right" Padding="12,4" Margin="4,0" FontSize="12" />

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
@@ -137,6 +137,9 @@ namespace FEBuilderGBA.Avalonia.Views
             // Refresh Easy Mode toggle text
             if (EasyModeMenuItem != null)
                 EasyModeMenuItem.Header = _isEasyMode ? R._("Switch to _Normal Mode") : R._("Toggle _Easy Mode");
+            // Refresh Dark Mode toggle text
+            if (DarkModeMenuItem != null && Application.Current is App app)
+                DarkModeMenuItem.Header = app.IsDarkMode ? R._("Switch to _Light Mode") : R._("Toggle _Dark Mode");
         }
 
         void OnDragOver(object? sender, DragEventArgs e)
@@ -193,6 +196,9 @@ namespace FEBuilderGBA.Avalonia.Views
 
         private async void MainWindow_Opened(object? sender, EventArgs e)
         {
+            // Set dark mode menu label from persisted preference
+            RefreshMenuHeaders();
+
             // Auto-load ROM if --rom was specified
             if (!string.IsNullOrEmpty(App.StartupRomPath))
             {
@@ -1525,6 +1531,18 @@ namespace FEBuilderGBA.Avalonia.Views
         private void Exit_Click(object? sender, RoutedEventArgs e)
         {
             Close();
+        }
+
+        // ===== Dark Mode Toggle =====
+
+        private void ToggleDarkMode_Click(object? sender, RoutedEventArgs e)
+        {
+            if (Application.Current is App app)
+            {
+                app.ToggleTheme();
+                if (DarkModeMenuItem != null)
+                    DarkModeMenuItem.Header = app.IsDarkMode ? R._("Switch to _Light Mode") : R._("Toggle _Dark Mode");
+            }
         }
 
         // ===== Easy Mode Toggle =====

--- a/FEBuilderGBA.Avalonia/Views/MapEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapEditorView.axaml
@@ -22,7 +22,7 @@
 
       <!-- Tile editing panel -->
       <Border Grid.Row="1" BorderBrush="Gray" BorderThickness="1" Margin="8,4,8,4" Padding="8"
-              Background="#FF2A2A2A" CornerRadius="4">
+              Background="{DynamicResource MapEditorToolbarBrush}" CornerRadius="4">
         <StackPanel Spacing="4">
           <TextBlock Text="Tile Editor (click on map to select)" FontWeight="SemiBold" />
           <TextBlock Name="TileInfoLabel" FontFamily="Consolas,Courier New,monospace" FontSize="12"
@@ -37,7 +37,7 @@
       </Border>
 
       <!-- Map image in scrollable area -->
-      <Border Grid.Row="2" BorderBrush="Gray" BorderThickness="1" Background="#FF202020" Margin="8,0,8,8">
+      <Border Grid.Row="2" BorderBrush="Gray" BorderThickness="1" Background="{DynamicResource MapEditorCanvasBrush}" Margin="8,0,8,8">
         <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
           <controls:GbaImageControl Name="MapImageControl" />
         </ScrollViewer>

--- a/FEBuilderGBA.Avalonia/Views/PaletteChangeColorsView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/PaletteChangeColorsView.axaml
@@ -7,7 +7,7 @@
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
   <DockPanel Margin="16">
     <TextBlock DockPanel.Dock="Top" Text="Palette Change Colors" FontSize="18" FontWeight="Bold" Margin="0,0,0,12" />
-    <Border DockPanel.Dock="Top" Background="#D1ECF1" BorderBrush="#17A2B8" BorderThickness="1" CornerRadius="4" Padding="12" Margin="0,0,0,8">
+    <Border DockPanel.Dock="Top" Background="{DynamicResource InfoBannerBackgroundBrush}" BorderBrush="{DynamicResource InfoBannerBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="12" Margin="0,0,0,8">
       <TextBlock TextWrapping="Wrap"
                  Text="Palette Color Editor allows editing individual colors in a 16-color GBA palette.&#10;Select a palette slot to modify its RGB values." />
     </Border>
@@ -17,7 +17,7 @@
     </StackPanel>
     <StackPanel Spacing="8">
       <TextBlock Text="Color Grid (16 colors):" FontWeight="SemiBold" />
-      <Border Background="#F8F9FA" BorderBrush="#DEE2E6" BorderThickness="1" CornerRadius="4" Padding="12" MinHeight="80">
+      <Border Background="{DynamicResource SubtlePanelBackgroundBrush}" BorderBrush="{DynamicResource SubtlePanelBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="12" MinHeight="80">
         <TextBlock Text="[Palette color grid - 16 color slots]" Foreground="Gray" />
       </Border>
       <Grid ColumnDefinitions="Auto,*,Auto,*,Auto,*" Margin="0,4,0,0">

--- a/FEBuilderGBA.Avalonia/Views/PaletteClipboardView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/PaletteClipboardView.axaml
@@ -7,7 +7,7 @@
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
   <DockPanel Margin="16">
     <TextBlock DockPanel.Dock="Top" Text="Palette Clipboard" FontSize="18" FontWeight="Bold" Margin="0,0,0,12" />
-    <Border DockPanel.Dock="Top" Background="#D1ECF1" BorderBrush="#17A2B8" BorderThickness="1" CornerRadius="4" Padding="12" Margin="0,0,0,8">
+    <Border DockPanel.Dock="Top" Background="{DynamicResource InfoBannerBackgroundBrush}" BorderBrush="{DynamicResource InfoBannerBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="12" Margin="0,0,0,8">
       <TextBlock TextWrapping="Wrap"
                  Text="Palette Clipboard Manager stores and retrieves palette data.&#10;Copy palettes between different graphics entries or save them for later use." />
     </Border>
@@ -19,7 +19,7 @@
     </StackPanel>
     <StackPanel Spacing="8">
       <TextBlock Text="Clipboard Contents:" FontWeight="SemiBold" />
-      <Border Background="#F8F9FA" BorderBrush="#DEE2E6" BorderThickness="1" CornerRadius="4" Padding="12" MinHeight="60">
+      <Border Background="{DynamicResource SubtlePanelBackgroundBrush}" BorderBrush="{DynamicResource SubtlePanelBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="12" MinHeight="60">
         <TextBlock Name="ClipboardStatusLabel" Text="[No palette data in clipboard]" Foreground="Gray" />
       </Border>
     </StackPanel>

--- a/FEBuilderGBA.Avalonia/Views/PaletteSwapView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/PaletteSwapView.axaml
@@ -7,7 +7,7 @@
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
   <DockPanel Margin="16">
     <TextBlock DockPanel.Dock="Top" Text="Palette Swap" FontSize="18" FontWeight="Bold" Margin="0,0,0,12" />
-    <Border DockPanel.Dock="Top" Background="#D1ECF1" BorderBrush="#17A2B8" BorderThickness="1" CornerRadius="4" Padding="12" Margin="0,0,0,8">
+    <Border DockPanel.Dock="Top" Background="{DynamicResource InfoBannerBackgroundBrush}" BorderBrush="{DynamicResource InfoBannerBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="12" Margin="0,0,0,8">
       <TextBlock TextWrapping="Wrap"
                  Text="Palette Swap exchanges palette assignments between entries.&#10;Select source and destination palette slots to exchange their color data." />
     </Border>

--- a/FEBuilderGBA.Avalonia/Views/PatchManagerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/PatchManagerView.axaml
@@ -78,12 +78,12 @@
 
           <!-- Dependencies Warning -->
           <Border Name="DependencyWarningBorder" IsVisible="False"
-                  Background="#FFFDE8" BorderBrush="#F0C000" BorderThickness="1"
+                  Background="{DynamicResource DependencyWarningBackgroundBrush}" BorderBrush="{DynamicResource DependencyWarningBorderBrush}" BorderThickness="1"
                   CornerRadius="4" Padding="8" Margin="0,0,0,4">
             <StackPanel Spacing="4">
-              <TextBlock Text="Unmet Dependencies" FontWeight="SemiBold" Foreground="#B8860B" />
+              <TextBlock Text="Unmet Dependencies" FontWeight="SemiBold" Foreground="{DynamicResource WarningTextBrush}" />
               <TextBlock Name="DependencyWarningText" TextWrapping="Wrap" FontSize="12"
-                         Foreground="#8B6914" />
+                         Foreground="{DynamicResource WarningTextSecondaryBrush}" />
             </StackPanel>
           </Border>
 

--- a/FEBuilderGBA.Avalonia/Views/ProcsScriptCategorySelectView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ProcsScriptCategorySelectView.axaml
@@ -38,7 +38,7 @@
         <TextBlock DockPanel.Dock="Top" Text="Parameters" FontWeight="SemiBold" Margin="0,0,0,4" />
 
         <!-- Command name header -->
-        <Border DockPanel.Dock="Top" Background="#20808080" CornerRadius="4" Padding="8,4" Margin="0,0,0,8">
+        <Border DockPanel.Dock="Top" Background="{DynamicResource ScriptCategoryOverlayBrush}" CornerRadius="4" Padding="8,4" Margin="0,0,0,8">
           <TextBlock Name="CommandNameLabel" Text="(select a command)" FontFamily="Consolas" FontSize="13"
                      TextWrapping="Wrap" />
         </Border>
@@ -46,7 +46,7 @@
         <!-- Write button at bottom -->
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
           <Button Name="WriteButton" Content="Write to ROM" Click="Write_Click" IsEnabled="False"
-                  Background="#4060A0" Foreground="White" Padding="16,6" />
+                  Background="{DynamicResource ScriptCategoryButtonBrush}" Foreground="White" Padding="16,6" />
           <Button Name="RefreshButton" Content="Refresh" Click="Refresh_Click" IsEnabled="False"
                   Padding="16,6" />
         </StackPanel>

--- a/FEBuilderGBA.Avalonia/Views/RAMRewriteToolView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/RAMRewriteToolView.axaml
@@ -11,7 +11,7 @@
       <Button Content="Close" Width="80" Click="Close_Click" />
     </StackPanel>
     <StackPanel Spacing="12">
-      <Border BorderBrush="Orange" BorderThickness="2" Padding="16" Background="#FFF8E1">
+      <Border BorderBrush="Orange" BorderThickness="2" Padding="16" Background="{DynamicResource EmulatorWarningBackgroundBrush}">
         <StackPanel Spacing="8">
           <TextBlock Text="Platform Notice" FontWeight="Bold" FontSize="14" Foreground="DarkOrange" />
           <TextBlock TextWrapping="Wrap"

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml
@@ -6,7 +6,7 @@
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
   <StackPanel Margin="16" Spacing="12">
     <TextBlock Text="Skill Assignment - Class (CSkillSys)" FontSize="18" FontWeight="Bold" />
-    <Border Background="#FFF3CD" BorderBrush="#FFC107" BorderThickness="1" CornerRadius="4" Padding="12">
+    <Border Background="{DynamicResource WarningBackgroundBrush}" BorderBrush="{DynamicResource WarningBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="12">
       <TextBlock TextWrapping="Wrap" Name="StatusText"
                  Text="Skill system editors require a compatible skill patch to be installed.&#10;Use the Patch Manager to install a skill system patch first.&#10;&#10;Supported skill systems: CSkillSys, FE8N Skill System" />
     </Border>

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitCSkillSysView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitCSkillSysView.axaml
@@ -6,7 +6,7 @@
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
   <StackPanel Margin="16" Spacing="12">
     <TextBlock Text="Skill Assignment - Unit (CSkillSys)" FontSize="18" FontWeight="Bold" />
-    <Border Background="#FFF3CD" BorderBrush="#FFC107" BorderThickness="1" CornerRadius="4" Padding="12">
+    <Border Background="{DynamicResource WarningBackgroundBrush}" BorderBrush="{DynamicResource WarningBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="12">
       <TextBlock TextWrapping="Wrap" Name="StatusText"
                  Text="Skill system editors require a compatible skill patch to be installed.&#10;Use the Patch Manager to install a skill system patch first.&#10;&#10;Supported skill systems: CSkillSys, FE8N Skill System" />
     </Border>

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitFE8NView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitFE8NView.axaml
@@ -6,7 +6,7 @@
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
   <StackPanel Margin="16" Spacing="12">
     <TextBlock Text="Skill Assignment - Unit (FE8N)" FontSize="18" FontWeight="Bold" />
-    <Border Background="#FFF3CD" BorderBrush="#FFC107" BorderThickness="1" CornerRadius="4" Padding="12">
+    <Border Background="{DynamicResource WarningBackgroundBrush}" BorderBrush="{DynamicResource WarningBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="12">
       <TextBlock TextWrapping="Wrap" Name="StatusText"
                  Text="Skill system editors require a compatible skill patch to be installed.&#10;Use the Patch Manager to install a skill system patch first.&#10;&#10;Supported skill systems: CSkillSys, FE8N Skill System" />
     </Border>

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NSkillView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NSkillView.axaml
@@ -6,7 +6,7 @@
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
   <StackPanel Margin="16" Spacing="12">
     <TextBlock Text="Skill Configuration (FE8N)" FontSize="18" FontWeight="Bold" />
-    <Border Background="#FFF3CD" BorderBrush="#FFC107" BorderThickness="1" CornerRadius="4" Padding="12">
+    <Border Background="{DynamicResource WarningBackgroundBrush}" BorderBrush="{DynamicResource WarningBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="12">
       <TextBlock TextWrapping="Wrap" Name="StatusText"
                  Text="Skill system editors require a compatible skill patch to be installed.&#10;Use the Patch Manager to install a skill system patch first.&#10;&#10;Supported skill systems: CSkillSys, FE8N Skill System" />
     </Border>

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer2SkillView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer2SkillView.axaml
@@ -6,7 +6,7 @@
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
   <StackPanel Margin="16" Spacing="12">
     <TextBlock Text="Skill Configuration (FE8N v2)" FontSize="18" FontWeight="Bold" />
-    <Border Background="#FFF3CD" BorderBrush="#FFC107" BorderThickness="1" CornerRadius="4" Padding="12">
+    <Border Background="{DynamicResource WarningBackgroundBrush}" BorderBrush="{DynamicResource WarningBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="12">
       <TextBlock TextWrapping="Wrap" Name="StatusText"
                  Text="Skill system editors require a compatible skill patch to be installed.&#10;Use the Patch Manager to install a skill system patch first.&#10;&#10;Supported skill systems: CSkillSys, FE8N Skill System" />
     </Border>

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml
@@ -6,7 +6,7 @@
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
   <StackPanel Margin="16" Spacing="12">
     <TextBlock Text="Skill Configuration (FE8N v3)" FontSize="18" FontWeight="Bold" />
-    <Border Background="#FFF3CD" BorderBrush="#FFC107" BorderThickness="1" CornerRadius="4" Padding="12">
+    <Border Background="{DynamicResource WarningBackgroundBrush}" BorderBrush="{DynamicResource WarningBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="12">
       <TextBlock TextWrapping="Wrap" Name="StatusText"
                  Text="Skill system editors require a compatible skill patch to be installed.&#10;Use the Patch Manager to install a skill system patch first.&#10;&#10;Supported skill systems: CSkillSys, FE8N Skill System" />
     </Border>

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml
@@ -6,7 +6,7 @@
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
   <StackPanel Margin="16" Spacing="12">
     <TextBlock Text="Skill Configuration (CSkillSys 0.9.x)" FontSize="18" FontWeight="Bold" />
-    <Border Background="#FFF3CD" BorderBrush="#FFC107" BorderThickness="1" CornerRadius="4" Padding="12">
+    <Border Background="{DynamicResource WarningBackgroundBrush}" BorderBrush="{DynamicResource WarningBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="12">
       <TextBlock TextWrapping="Wrap" Name="StatusText"
                  Text="Skill system editors require a compatible skill patch to be installed.&#10;Use the Patch Manager to install a skill system patch first.&#10;&#10;Supported skill systems: CSkillSys, FE8N Skill System" />
     </Border>

--- a/FEBuilderGBA.Avalonia/Views/SkillSystemsEffectivenessReworkClassTypeView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillSystemsEffectivenessReworkClassTypeView.axaml
@@ -6,7 +6,7 @@
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
   <StackPanel Margin="16" Spacing="12">
     <TextBlock Text="Effectiveness Rework - Class Type" FontSize="18" FontWeight="Bold" />
-    <Border Background="#FFF3CD" BorderBrush="#FFC107" BorderThickness="1" CornerRadius="4" Padding="12">
+    <Border Background="{DynamicResource WarningBackgroundBrush}" BorderBrush="{DynamicResource WarningBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="12">
       <TextBlock TextWrapping="Wrap" Name="StatusText"
                  Text="Skill system editors require a compatible skill patch to be installed.&#10;Use the Patch Manager to install a skill system patch first.&#10;&#10;Supported skill systems: CSkillSys, FE8N Skill System" />
     </Border>

--- a/FEBuilderGBA.Avalonia/Views/TextCharCodeView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/TextCharCodeView.axaml
@@ -23,7 +23,7 @@
     <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Spacing="24" Margin="0,0,0,8">
       <StackPanel Spacing="4">
         <TextBlock Text="Item Font" FontWeight="SemiBold" />
-        <Border Background="#FF6888A8" Padding="4" CornerRadius="2">
+        <Border Background="{DynamicResource CharCodeHeaderBrush}" Padding="4" CornerRadius="2">
           <Image Name="ItemFontImage" Width="64" Height="64" Stretch="Uniform"
                  RenderOptions.BitmapInterpolationMode="None" />
         </Border>
@@ -31,7 +31,7 @@
       </StackPanel>
       <StackPanel Spacing="4">
         <TextBlock Text="Serif Font" FontWeight="SemiBold" />
-        <Border Background="#FFE0E0E0" Padding="4" CornerRadius="2">
+        <Border Background="{DynamicResource CharCodeCellBrush}" Padding="4" CornerRadius="2">
           <Image Name="SerifFontImage" Width="64" Height="64" Stretch="Uniform"
                  RenderOptions.BitmapInterpolationMode="None" />
         </Border>

--- a/FEBuilderGBA.Avalonia/Views/ToolSubtitleOverlayView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolSubtitleOverlayView.axaml
@@ -16,8 +16,8 @@
       <TextBox Name="SubtitleTextBox" AcceptsReturn="True" Height="100"
                Watermark="Enter subtitle text..." />
       <TextBlock Text="Preview:" FontWeight="SemiBold" Margin="0,8,0,0" />
-      <Border BorderBrush="Gray" BorderThickness="1" Background="Black" Height="200">
-        <TextBlock Name="PreviewTextBlock" Text="" Foreground="White"
+      <Border BorderBrush="Gray" BorderThickness="1" Background="{DynamicResource SubtitleOverlayBackgroundBrush}" Height="200">
+        <TextBlock Name="PreviewTextBlock" Text="" Foreground="{DynamicResource SubtitleOverlayForegroundBrush}"
                    HorizontalAlignment="Center" VerticalAlignment="Bottom"
                    Margin="0,0,0,20" FontSize="16" />
       </Border>

--- a/FEBuilderGBA.Avalonia/Views/ToolUndoPopupDialogView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolUndoPopupDialogView.axaml
@@ -9,7 +9,7 @@
   <Grid ColumnDefinitions="Auto,*" Margin="12,22,12,12">
     <!-- Icon (WinForms FormIcon 80x80 at 12,22) -->
     <Border Grid.Column="0" Width="80" Height="80" VerticalAlignment="Top"
-            Background="#E3F2FD" BorderBrush="#90CAF9" BorderThickness="1"
+            Background="{DynamicResource UndoInfoBackgroundBrush}" BorderBrush="{DynamicResource UndoInfoBorderBrush}" BorderThickness="1"
             Margin="0,0,12,0">
       <TextBlock Text="↩" FontSize="36" HorizontalAlignment="Center" VerticalAlignment="Center" />
     </Border>

--- a/FEBuilderGBA.Avalonia/Views/UnitEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/UnitEditorView.axaml
@@ -231,7 +231,7 @@
         <!-- Validation Warnings -->
         <Border Name="WarningsBorder" IsVisible="False"
                 BorderBrush="Orange" BorderThickness="1" Padding="8" CornerRadius="4"
-                Background="#33FF8C00" Margin="0,8,0,0">
+                Background="{DynamicResource AccentOverlayBrush}" Margin="0,8,0,0">
           <StackPanel Spacing="2">
             <TextBlock Text="Warnings" FontWeight="Bold" Foreground="DarkOrange" />
             <ItemsControl Name="WarningsList">

--- a/FEBuilderGBA.Avalonia/Views/WelcomeView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/WelcomeView.axaml
@@ -7,8 +7,8 @@
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
   <DockPanel Margin="14,10,14,10">
     <!-- Logo area (WinForms pictureBox1 1123x278) -->
-    <Border DockPanel.Dock="Top" Height="278" Background="#E8EAF6"
-            BorderBrush="#C5CAE9" BorderThickness="1" Margin="0,0,0,8">
+    <Border DockPanel.Dock="Top" Height="278" Background="{DynamicResource WelcomeBannerBrush}"
+            BorderBrush="{DynamicResource WelcomeBannerBorderBrush}" BorderThickness="1" Margin="0,0,0,8">
       <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
         <TextBlock Text="FEBuilderGBA" FontSize="36" FontWeight="Bold"
                    HorizontalAlignment="Center" />

--- a/FEBuilderGBA.Tests/Unit/AvaloniaDarkModeTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AvaloniaDarkModeTests.cs
@@ -1,0 +1,154 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace FEBuilderGBA.Tests.Unit
+{
+    /// <summary>
+    /// Tests for dark mode support and hardcoded color cleanup in Avalonia views.
+    /// Validates that no hardcoded hex color values remain in AXAML files and that
+    /// the theme toggle infrastructure exists.
+    /// </summary>
+    public class AvaloniaDarkModeTests
+    {
+        private static string SolutionDir
+        {
+            get
+            {
+                var dir = AppContext.BaseDirectory;
+                while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                    dir = Path.GetDirectoryName(dir);
+                return dir ?? throw new InvalidOperationException("Cannot find solution root");
+            }
+        }
+
+        private string AvaloniaDir => Path.Combine(SolutionDir, "FEBuilderGBA.Avalonia");
+
+        [Fact]
+        public void NoHardcodedHexColorsInViewAxamlFiles()
+        {
+            var viewsDir = Path.Combine(AvaloniaDir, "Views");
+            Assert.True(Directory.Exists(viewsDir), "Views directory must exist");
+
+            var axamlFiles = Directory.GetFiles(viewsDir, "*.axaml", SearchOption.AllDirectories);
+            Assert.NotEmpty(axamlFiles);
+
+            // Match Background="#XXXXXX" or Foreground="#XXXXXX" (6 or 8 hex digit colors)
+            var hexColorPattern = new Regex(@"(Background|Foreground)=""#([0-9A-Fa-f]{6,8})""");
+            // Semi-transparent overlays (8-digit ARGB with low alpha, e.g. #20000000) are intentional
+            // and work acceptably in both light and dark themes — exclude them.
+            var semiTransparentPattern = new Regex(@"^[0-3][0-9A-Fa-f][0-9A-Fa-f]{6}$");
+            var violations = new List<string>();
+
+            foreach (var file in axamlFiles)
+            {
+                var content = File.ReadAllText(file);
+                var matches = hexColorPattern.Matches(content);
+                foreach (Match m in matches)
+                {
+                    var hexValue = m.Groups[2].Value;
+                    // Allow semi-transparent 8-digit ARGB colors (alpha < 0x40)
+                    if (hexValue.Length == 8 && semiTransparentPattern.IsMatch(hexValue))
+                        continue;
+                    violations.Add($"{Path.GetFileName(file)}: {m.Value}");
+                }
+            }
+
+            Assert.True(violations.Count == 0,
+                $"Found {violations.Count} hardcoded hex color(s) in AXAML files that should use DynamicResource:\n" +
+                string.Join("\n", violations));
+        }
+
+        [Fact]
+        public void DarkModeMenuItemExistsInMainWindow()
+        {
+            var mainWindowAxaml = Path.Combine(AvaloniaDir, "Views", "MainWindow.axaml");
+            Assert.True(File.Exists(mainWindowAxaml));
+
+            var content = File.ReadAllText(mainWindowAxaml);
+            Assert.Contains("DarkModeMenuItem", content);
+            Assert.Contains("ToggleDarkMode_Click", content);
+        }
+
+        [Fact]
+        public void DarkModeToggleHandlerExistsInCodeBehind()
+        {
+            var mainWindowCs = Path.Combine(AvaloniaDir, "Views", "MainWindow.axaml.cs");
+            Assert.True(File.Exists(mainWindowCs));
+
+            var content = File.ReadAllText(mainWindowCs);
+            Assert.Contains("ToggleDarkMode_Click", content);
+            Assert.Contains("ToggleTheme", content);
+        }
+
+        [Fact]
+        public void FluentThemeExistsInAppAxaml()
+        {
+            var appAxaml = Path.Combine(AvaloniaDir, "App.axaml");
+            Assert.True(File.Exists(appAxaml));
+
+            var content = File.ReadAllText(appAxaml);
+            Assert.Contains("<FluentTheme />", content);
+        }
+
+        [Fact]
+        public void ThemeResourcesDefinedInAppAxaml()
+        {
+            var appAxaml = Path.Combine(AvaloniaDir, "App.axaml");
+            var content = File.ReadAllText(appAxaml);
+
+            // Verify key theme resources are defined
+            Assert.Contains("StatusBarBackgroundBrush", content);
+            Assert.Contains("ToolbarBackgroundBrush", content);
+            Assert.Contains("SectionHeadingBrush", content);
+            Assert.Contains("CardBorderBrush", content);
+            Assert.Contains("WarningBackgroundBrush", content);
+            Assert.Contains("InfoBannerBackgroundBrush", content);
+        }
+
+        [Fact]
+        public void ThemeToggleMethodExistsInAppCs()
+        {
+            var appCs = Path.Combine(AvaloniaDir, "App.axaml.cs");
+            Assert.True(File.Exists(appCs));
+
+            var content = File.ReadAllText(appCs);
+            Assert.Contains("public void ToggleTheme()", content);
+            Assert.Contains("IsDarkMode", content);
+            Assert.Contains("ThemeConfigKey", content);
+        }
+
+        [Fact]
+        public void ThemePreferencePersistedViaConfig()
+        {
+            var appCs = Path.Combine(AvaloniaDir, "App.axaml.cs");
+            var content = File.ReadAllText(appCs);
+
+            // Verify config persistence pattern
+            Assert.Contains("CoreState.Config", content);
+            Assert.Contains("Avalonia_Theme", content);
+            Assert.Contains(".Save()", content);
+        }
+
+        [Fact]
+        public void AxamlViewsUseDynamicResourceForColors()
+        {
+            var viewsDir = Path.Combine(AvaloniaDir, "Views");
+            var axamlFiles = Directory.GetFiles(viewsDir, "*.axaml", SearchOption.AllDirectories);
+
+            // Check that at least some views use DynamicResource for colors
+            int dynamicResourceCount = 0;
+            foreach (var file in axamlFiles)
+            {
+                var content = File.ReadAllText(file);
+                if (content.Contains("DynamicResource") &&
+                    (content.Contains("BackgroundBrush") || content.Contains("BorderBrush}")))
+                {
+                    dynamicResourceCount++;
+                }
+            }
+
+            Assert.True(dynamicResourceCount >= 5,
+                $"Expected at least 5 views using DynamicResource for theme colors, found {dynamicResourceCount}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add View > Toggle Dark Mode menu item with persistent preference
- Implement FluentTheme light/dark switching via `App.ToggleTheme()`
- Define 30+ DynamicResource theme brushes in App.axaml (light + dark variants)
- Replace all hardcoded hex color values across 30+ AXAML view files with DynamicResource references
- Persist theme preference in config via `Avalonia_Theme` key

Closes #69

## Test plan
- [x] Toggle Dark Mode menu item switches between light and dark themes
- [x] Theme preference persists across app restarts
- [x] No hardcoded hex colors remain in AXAML files (verified by unit test)
- [x] All 8 dark mode unit tests pass
- [x] Avalonia project builds successfully
- [x] Core tests (823) pass
- [x] Manual smoke test: verified Unit Editor, Class Editor, Item Editor, Map Editor, and Hex Editor render correctly in both light and dark modes

Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-4-6 1M context)