### PR TITLE
docs: enforce Copilot CLI version/model footer on all GitHub outputs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -109,12 +109,14 @@ Runtime data is not embedded into the binaries. The WinForms project copies `con
 
 **Every** piece of text that Copilot CLI posts to GitHub MUST end with a footer containing the current Copilot CLI version and model configuration. This applies to ALL of the following without exception:
 
+- Issue bodies (when creating new issues)
+- Issue comments and replies
+- Pull request descriptions/bodies (when creating new PRs)
 - Pull request reviews (including approval/comment reviews)
 - Pull request comments and replies
-- Issue comments and replies
+- Discussion opening posts (when creating new discussions)
 - Discussion comments and replies
 - Commit messages
-- PR descriptions/bodies
 
 **Format:** Two lines at the very end of the message:
 ```


### PR DESCRIPTION
## Summary
- Promote the Copilot CLI footer rule from a single bullet in Key Conventions to a dedicated, prominent section
- Explicitly list every type of GitHub output that requires the footer (PR reviews, comments, replies, issue comments, discussion posts, commit messages, PR bodies)
- Provide exact format template and example with live session values

## Motivation
Copilot CLI was posting reviews and comments without version/model identification, making it impossible to trace which model produced which output. This rule ensures every Copilot CLI output is attributable.

## Test plan
- [x] Docs only — no code changes, no tests needed
- [x] Format example is correct and follows existing convention

Generated with Claude Code (claude-opus-4-6)