### PR TITLE
docs: enforce merge completion loop in development workflow

### DIFF
--- a/DEVELOPMENT-WORKFLOW.md
+++ b/DEVELOPMENT-WORKFLOW.md
@@ -220,7 +220,8 @@ gh api graphql -f query='{
       }
     }
   }
-}' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | "\(.id) [\(.comments.nodes[0].path):\(.comments.nodes[0].line)] \(.comments.nodes[0].body | split("\n")[0])"'
+}' --jq '(.data.repository.pullRequest.reviewThreads | "hasNextPage=\(.pageInfo.hasNextPage) endCursor=\(.pageInfo.endCursor)"), (.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | "\(.id) [\(.comments.nodes[0].path):\(.comments.nodes[0].line)] \(.comments.nodes[0].body | split("\n")[0])")'
+# If hasNextPage=true, re-run with: reviewThreads(first: 100, after: "<endCursor>")
 ```
 
 These must ALL be addressed (fix the code) and then resolved:


### PR DESCRIPTION
## Summary
- Add "continue until MERGED" as top-level workflow principle
- Replace Phase 5 static checklist with a merge completion loop: checklist → attempt → diagnose blocker → fix → confirm MERGED
- Add blocker diagnosis table covering CI failures, unresolved threads, conflicts, and policy violations
- Add inline comment checking and thread resolution commands to Phase 4
- Add anti-patterns for stopping early and ignoring bot inline comments
- Update quick reference with loop visualization

## Motivation
Previous workflow stopped at "ready to merge" but didn't handle merge failures (CI red, unresolved conversations, ruleset blockers). PR #109 required 9 rounds to reach MERGED.

## Test plan
- [x] Docs only — no code changes
- [x] All `gh` and `copilot` CLI commands are verified from practice

Generated with Claude Code (claude-opus-4-6)