### PR TITLE
fix: widen portrait ID field and add portrait name in Unit Editor (#128)

### DIFF
--- a/FEBuilderGBA/InputFormRef.cs
+++ b/FEBuilderGBA/InputFormRef.cs
@@ -352,6 +352,20 @@ namespace FEBuilderGBA
 
                 return;
             }
+            if (linktype == "PORTRAITNAME")
+            {// portrait name text link
+                TextBoxEx link_object = ((TextBoxEx)link_info);
+                src_object.ValueChanged += (sender, e) =>
+                {
+                    link_object.Text = ImagePortraitForm.GetPortraitName((uint)src_object.Value);
+                };
+                link_object.DoubleClick += (sender, e) =>
+                {
+                    JumpTo(src_object, link_info, "PORTRAIT", new string[] { });
+                };
+
+                return;
+            }
             if (linktype == "GENERICENEMYPORTRAIT")
             {//一般兵の顔像とリンク.
                 PictureBox link_object = ((PictureBox)link_info);
@@ -3849,6 +3863,17 @@ namespace FEBuilderGBA
                 }
             }
             else if (linktype == "PORTRAIT")
+            {
+                if (Program.ROM.RomInfo.version == 6)
+                {
+                    InputFormRef.JumpForm<ImagePortraitFE6Form>(value, "AddressList", src_object);
+                }
+                else
+                {
+                    InputFormRef.JumpForm<ImagePortraitForm>(value, "AddressList", src_object);
+                }
+            }
+            else if (linktype == "PORTRAITNAME")
             {
                 if (Program.ROM.RomInfo.version == 6)
                 {

--- a/FEBuilderGBA/UnitFE6Form.designer.cs
+++ b/FEBuilderGBA/UnitFE6Form.designer.cs
@@ -39,6 +39,7 @@
             this.J_10 = new System.Windows.Forms.Label();
             this.B8 = new System.Windows.Forms.NumericUpDown();
             this.W6 = new System.Windows.Forms.NumericUpDown();
+            this.L_6_PORTRAITNAME = new FEBuilderGBA.TextBoxEx();
             this.J_8_GENERICENEMYPORTRAIT = new System.Windows.Forms.Label();
             this.J_6_PORTRAIT = new System.Windows.Forms.Label();
             this.B5 = new System.Windows.Forms.NumericUpDown();
@@ -2233,7 +2234,7 @@
             // L_6_PORTRAIT_AUTO
             // 
             this.L_6_PORTRAIT_AUTO.Interpolation = System.Drawing.Drawing2D.InterpolationMode.Bicubic;
-            this.L_6_PORTRAIT_AUTO.Location = new System.Drawing.Point(1016, 89);
+            this.L_6_PORTRAIT_AUTO.Location = new System.Drawing.Point(1016, 108);
             this.L_6_PORTRAIT_AUTO.Margin = new System.Windows.Forms.Padding(2);
             this.L_6_PORTRAIT_AUTO.Name = "L_6_PORTRAIT_AUTO";
             this.L_6_PORTRAIT_AUTO.Size = new System.Drawing.Size(172, 143);
@@ -2251,7 +2252,18 @@
             this.L_5_CLASS.ReadOnly = true;
             this.L_5_CLASS.Size = new System.Drawing.Size(116, 25);
             this.L_5_CLASS.TabIndex = 23;
-            // 
+            //
+            // L_6_PORTRAITNAME
+            //
+            this.L_6_PORTRAITNAME.ErrorMessage = "";
+            this.L_6_PORTRAITNAME.Location = new System.Drawing.Point(1016, 80);
+            this.L_6_PORTRAITNAME.Margin = new System.Windows.Forms.Padding(2);
+            this.L_6_PORTRAITNAME.Name = "L_6_PORTRAITNAME";
+            this.L_6_PORTRAITNAME.Placeholder = "";
+            this.L_6_PORTRAITNAME.ReadOnly = true;
+            this.L_6_PORTRAITNAME.Size = new System.Drawing.Size(116, 25);
+            this.L_6_PORTRAITNAME.TabIndex = 2854;
+            //
             // systemIconPictureBox7
             // 
             this.systemIconPictureBox7.IconNumber = ((uint)(6u));
@@ -2547,6 +2559,7 @@
             this.Controls.Add(this.J_6_PORTRAIT);
             this.Controls.Add(this.J_18);
             this.Controls.Add(this.L_5_CLASS);
+            this.Controls.Add(this.L_6_PORTRAITNAME);
             this.Controls.Add(this.systemIconPictureBox7);
             this.Controls.Add(this.B5);
             this.Controls.Add(this.J_17);
@@ -2721,6 +2734,7 @@
         private System.Windows.Forms.Label J_8_GENERICENEMYPORTRAIT;
         private System.Windows.Forms.Label J_6_PORTRAIT;
         private FEBuilderGBA.TextBoxEx L_5_CLASS;
+        private FEBuilderGBA.TextBoxEx L_6_PORTRAITNAME;
         private System.Windows.Forms.NumericUpDown B5;
         private System.Windows.Forms.NumericUpDown B9;
         private System.Windows.Forms.Label L_9_ATTRIBUTE;

--- a/FEBuilderGBA/UnitFE7Form.designer.cs
+++ b/FEBuilderGBA/UnitFE7Form.designer.cs
@@ -39,6 +39,7 @@
             this.J_10 = new System.Windows.Forms.Label();
             this.B8 = new System.Windows.Forms.NumericUpDown();
             this.W6 = new System.Windows.Forms.NumericUpDown();
+            this.L_6_PORTRAITNAME = new FEBuilderGBA.TextBoxEx();
             this.J_8_GENERICENEMYPORTRAIT = new System.Windows.Forms.Label();
             this.J_6_PORTRAIT = new System.Windows.Forms.Label();
             this.B5 = new System.Windows.Forms.NumericUpDown();
@@ -2350,7 +2351,7 @@
             // L_6_PORTRAIT_AUTO
             // 
             this.L_6_PORTRAIT_AUTO.Interpolation = System.Drawing.Drawing2D.InterpolationMode.Bicubic;
-            this.L_6_PORTRAIT_AUTO.Location = new System.Drawing.Point(1016, 89);
+            this.L_6_PORTRAIT_AUTO.Location = new System.Drawing.Point(1016, 108);
             this.L_6_PORTRAIT_AUTO.Margin = new System.Windows.Forms.Padding(2);
             this.L_6_PORTRAIT_AUTO.Name = "L_6_PORTRAIT_AUTO";
             this.L_6_PORTRAIT_AUTO.Size = new System.Drawing.Size(172, 143);
@@ -2368,9 +2369,20 @@
             this.L_5_CLASS.ReadOnly = true;
             this.L_5_CLASS.Size = new System.Drawing.Size(116, 25);
             this.L_5_CLASS.TabIndex = 23;
-            // 
+            //
+            // L_6_PORTRAITNAME
+            //
+            this.L_6_PORTRAITNAME.ErrorMessage = "";
+            this.L_6_PORTRAITNAME.Location = new System.Drawing.Point(1016, 80);
+            this.L_6_PORTRAITNAME.Margin = new System.Windows.Forms.Padding(2);
+            this.L_6_PORTRAITNAME.Name = "L_6_PORTRAITNAME";
+            this.L_6_PORTRAITNAME.Placeholder = "";
+            this.L_6_PORTRAITNAME.ReadOnly = true;
+            this.L_6_PORTRAITNAME.Size = new System.Drawing.Size(116, 25);
+            this.L_6_PORTRAITNAME.TabIndex = 2991;
+            //
             // systemIconPictureBox7
-            // 
+            //
             this.systemIconPictureBox7.IconNumber = ((uint)(6u));
             this.systemIconPictureBox7.Location = new System.Drawing.Point(845, 457);
             this.systemIconPictureBox7.Name = "systemIconPictureBox7";
@@ -2672,6 +2684,7 @@
             this.Controls.Add(this.J_6_PORTRAIT);
             this.Controls.Add(this.J_18);
             this.Controls.Add(this.L_5_CLASS);
+            this.Controls.Add(this.L_6_PORTRAITNAME);
             this.Controls.Add(this.systemIconPictureBox7);
             this.Controls.Add(this.B5);
             this.Controls.Add(this.J_17);
@@ -2850,6 +2863,7 @@
         private System.Windows.Forms.Label J_8_GENERICENEMYPORTRAIT;
         private System.Windows.Forms.Label J_6_PORTRAIT;
         private FEBuilderGBA.TextBoxEx L_5_CLASS;
+        private FEBuilderGBA.TextBoxEx L_6_PORTRAITNAME;
         private System.Windows.Forms.NumericUpDown B5;
         private System.Windows.Forms.NumericUpDown B9;
         private System.Windows.Forms.Label L_9_ATTRIBUTE;

--- a/FEBuilderGBA/UnitForm.designer.cs
+++ b/FEBuilderGBA/UnitForm.designer.cs
@@ -49,6 +49,7 @@
             this.J_10 = new System.Windows.Forms.Label();
             this.B8 = new System.Windows.Forms.NumericUpDown();
             this.W6 = new System.Windows.Forms.NumericUpDown();
+            this.L_6_PORTRAITNAME = new FEBuilderGBA.TextBoxEx();
             this.J_8_GENERICENEMYPORTRAIT = new System.Windows.Forms.Label();
             this.J_6_PORTRAIT = new System.Windows.Forms.Label();
             this.B5 = new System.Windows.Forms.NumericUpDown();
@@ -589,7 +590,7 @@
             0,
             0});
             this.W6.Name = "W6";
-            this.W6.Size = new System.Drawing.Size(48, 20);
+            this.W6.Size = new System.Drawing.Size(72, 20);
             this.W6.TabIndex = 9;
             // 
             // J_8_GENERICENEMYPORTRAIT
@@ -2806,7 +2807,7 @@
             // L_6_PORTRAIT_AUTO
             // 
             this.L_6_PORTRAIT_AUTO.Interpolation = System.Drawing.Drawing2D.InterpolationMode.Bicubic;
-            this.L_6_PORTRAIT_AUTO.Location = new System.Drawing.Point(677, 59);
+            this.L_6_PORTRAIT_AUTO.Location = new System.Drawing.Point(701, 73);
             this.L_6_PORTRAIT_AUTO.Margin = new System.Windows.Forms.Padding(1);
             this.L_6_PORTRAIT_AUTO.Name = "L_6_PORTRAIT_AUTO";
             this.L_6_PORTRAIT_AUTO.Size = new System.Drawing.Size(115, 95);
@@ -2824,7 +2825,18 @@
             this.L_5_CLASS.ReadOnly = true;
             this.L_5_CLASS.Size = new System.Drawing.Size(79, 20);
             this.L_5_CLASS.TabIndex = 23;
-            // 
+            //
+            // L_6_PORTRAITNAME
+            //
+            this.L_6_PORTRAITNAME.ErrorMessage = "";
+            this.L_6_PORTRAITNAME.Location = new System.Drawing.Point(701, 52);
+            this.L_6_PORTRAITNAME.Margin = new System.Windows.Forms.Padding(1);
+            this.L_6_PORTRAITNAME.Name = "L_6_PORTRAITNAME";
+            this.L_6_PORTRAITNAME.Placeholder = "";
+            this.L_6_PORTRAITNAME.ReadOnly = true;
+            this.L_6_PORTRAITNAME.Size = new System.Drawing.Size(115, 20);
+            this.L_6_PORTRAITNAME.TabIndex = 3371;
+            //
             // systemIconPictureBox7
             // 
             this.systemIconPictureBox7.IconNumber = ((uint)(6u));
@@ -2993,6 +3005,7 @@
             this.Controls.Add(this.B30);
             this.Controls.Add(this.J_ID_UNITPALETTEFE8);
             this.Controls.Add(this.b16);
+            this.Controls.Add(this.L_6_PORTRAITNAME);
             this.Controls.Add(this.L_6_PORTRAIT_AUTO);
             this.Controls.Add(this.b12);
             this.Controls.Add(this.B10);
@@ -3188,6 +3201,7 @@
         private System.Windows.Forms.Label J_8_GENERICENEMYPORTRAIT;
         private System.Windows.Forms.Label J_6_PORTRAIT;
         private FEBuilderGBA.TextBoxEx L_5_CLASS;
+        private FEBuilderGBA.TextBoxEx L_6_PORTRAITNAME;
         private System.Windows.Forms.NumericUpDown B5;
         private System.Windows.Forms.NumericUpDown B9;
         private System.Windows.Forms.Label L_9_ATTRIBUTE;


### PR DESCRIPTION
## Summary
- Widens the portrait ID field (`W6`) from 48px to 72px in `UnitForm` for better readability
- Adds a read-only `L_6_PORTRAITNAME` TextBoxEx to all three Unit Editor forms (`UnitForm`, `UnitFE6Form`, `UnitFE7Form`) that displays the portrait name next to the ID
- Adds a new `PORTRAITNAME` linktype to `InputFormRef.cs` that resolves portrait IDs to names via `ImagePortraitForm.GetPortraitName()` and supports double-click navigation to the portrait editor

Closes #128

## Test plan
- [x] Solution builds with 0 errors (`dotnet build FEBuilderGBA.sln`)
- [x] All 981 Core tests pass (`dotnet test FEBuilderGBA.Core.Tests`)
- [ ] Visual verification: open Unit Editor with a ROM, confirm portrait name appears next to ID field
- [ ] Verify double-click on portrait name opens the portrait editor

## Screenshot proof
Build and test output:
```
0 Error(s)
Passed! - Failed: 0, Passed: 981, Skipped: 0, Total: 981
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)