### PR TITLE
chore: add post-merge checkout master step to workflow (#136)

### DIFF
--- a/DEVELOPMENT-WORKFLOW.md
+++ b/DEVELOPMENT-WORKFLOW.md
@@ -319,7 +319,10 @@ gh pr view <M> -R laqieer/FEBuilderGBA --json mergeable --jq '.mergeable'
 
 ### 16. Post-Merge
 - Verify the issue was auto-closed (if `Closes #N` was used)
-- Pull latest master: `git fetch origin master`
+- Switch back to master and sync:
+  ```bash
+  git checkout master && git pull
+  ```
 
 ---
 
@@ -374,6 +377,7 @@ Issue → Plan Comment → Copilot Review → Revise → Accept
   → PR → Copilot Review + Bot Comments → Fix All → Resolve Threads
   → Re-review → Signoff → CI Green → Merge → Confirm MERGED
   ↑___________________________________________|  (loop until MERGED)
+  → Checkout master & pull
 ```
 
 **All `gh` commands MUST use `-R laqieer/FEBuilderGBA`.**


### PR DESCRIPTION
## Summary
- Updated step 16 (Post-Merge) in `DEVELOPMENT-WORKFLOW.md`: replaced `git fetch origin master` with `git checkout master && git pull`
- Updated quick reference diagram to include `→ Checkout master & pull` as the final step after the merge loop

## Plan Reference
Implements the plan from https://github.com/laqieer/FEBuilderGBA/issues/136#issuecomment-4083148656

## Scope
Closes #136

## Test plan
- [x] Docs-only change — no code tests needed
- [x] Verified the two edits match the accepted plan exactly

## Known limitations
None — pure documentation change.

Generated with Claude Code (claude-opus-4-6)