### PR TITLE
chore: add worktree cleanup, master sync, and branch discipline to workflow (#136)

### DIFF
--- a/DEVELOPMENT-WORKFLOW.md
+++ b/DEVELOPMENT-WORKFLOW.md
@@ -117,7 +117,7 @@ Repeat steps 4-5 until Copilot CLI reports **no blocking concerns**.
 ```bash
 # Run this in the main repo root — not inside a linked worktree
 git checkout master && git pull
-git checkout -b <branch-name>
+git checkout -b feat/<short-desc>-<issue>   # or fix/<short-desc>-<issue>
 ```
 For parallel worktree agents: sync master in the main repo first, then create worktrees from it.
 


### PR DESCRIPTION
## Summary
- **Step 7**: Require `git checkout master && git pull` before creating feature branches; add "never work directly on master" rule
- **Step 16**: Add worktree cleanup step with dirty-worktree warning before switching to master
- **Anti-patterns**: Add "Don't: Work directly on master"
- **Quick reference**: Include worktree cleanup in post-merge flow

## Plan Reference
Implements the revised plan from https://github.com/laqieer/FEBuilderGBA/issues/136#issuecomment-4083148656

## Scope
Closes #136

## Test plan
- [x] Docs-only change — no code tests needed
- [x] All four changes match the accepted plan

## Known limitations
None — pure documentation change.

Generated with Claude Code (claude-opus-4-6)