### PR TITLE
feat: add --export-portrait-all CLI command (#124)

### DIFF
--- a/FEBuilderGBA.CLI/Program.cs
+++ b/FEBuilderGBA.CLI/Program.cs
@@ -1672,19 +1672,41 @@ namespace FEBuilderGBA.CLI
                 return 1;
             }
 
-            Directory.CreateDirectory(outputDir);
+            try { Directory.CreateDirectory(outputDir); }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Error: Cannot create output directory: {ex.Message}");
+                return 1;
+            }
 
             uint portraitBase = rom.p32(U.toOffset(rom.RomInfo.portrait_pointer));
             uint portraitDataSize = rom.RomInfo.portrait_datasize;
 
             // Determine entry count by scanning for valid portrait entries
+            // Stop at first entry where both face and palette pointers are invalid (non-pointer, non-zero)
             int maxEntries = 0;
+            int consecutiveInvalid = 0;
             for (uint id = 0; id < 0x400; id++)
             {
                 uint addr = portraitBase + (id * portraitDataSize);
                 if (!U.isSafetyOffset(addr + portraitDataSize - 1, rom))
                     break;
-                maxEntries++;
+
+                uint faceVal = rom.u32(addr + 0);
+                uint palVal = rom.u32(addr + 8);
+                bool faceOk = faceVal == 0 || U.isPointer(faceVal);
+                bool palOk = palVal == 0 || U.isPointer(palVal);
+
+                if (!faceOk && !palOk)
+                {
+                    consecutiveInvalid++;
+                    if (consecutiveInvalid >= 3) break; // 3 consecutive invalid = end of table
+                }
+                else
+                {
+                    consecutiveInvalid = 0;
+                }
+                maxEntries = (int)id + 1;
             }
 
             int exported = 0;
@@ -1698,14 +1720,25 @@ namespace FEBuilderGBA.CLI
                 if (facePtr == 0 || palettePtr == 0)
                     continue;
 
-                // FE7/8 portrait struct: +20=mouthX, +21=mouthY, +22=eyeX, +23=eyeY, +24=state
-                byte eyeX = (portraitDataSize > 23) ? (byte)rom.u8(portraitAddr + 22) : (byte)0;
-                byte eyeY = (portraitDataSize > 23) ? (byte)rom.u8(portraitAddr + 23) : (byte)0;
-                byte state = (portraitDataSize > 24) ? (byte)rom.u8(portraitAddr + 24) : (byte)0;
-
                 try
                 {
-                    using (var image = PortraitRendererCore.DrawPortraitUnit(facePtr, palettePtr, eyeX, eyeY, state))
+                    IImage image;
+                    if (rom.RomInfo.version == 6)
+                    {
+                        // FE6: portrait struct has mouth at +12/+13
+                        byte fe6MouthX = (portraitDataSize > 13) ? (byte)rom.u8(portraitAddr + 12) : (byte)0;
+                        byte fe6MouthY = (portraitDataSize > 13) ? (byte)rom.u8(portraitAddr + 13) : (byte)0;
+                        image = PortraitRendererCoreFE6.DrawPortraitUnitFE6(facePtr, palettePtr, fe6MouthX, fe6MouthY, 0);
+                    }
+                    else
+                    {
+                        // FE7/8 portrait struct: +20=mouthX, +21=mouthY, +22=eyeX, +23=eyeY, +24=state
+                        byte eyeX = (portraitDataSize > 23) ? (byte)rom.u8(portraitAddr + 22) : (byte)0;
+                        byte eyeY = (portraitDataSize > 23) ? (byte)rom.u8(portraitAddr + 23) : (byte)0;
+                        byte state = (portraitDataSize > 24) ? (byte)rom.u8(portraitAddr + 24) : (byte)0;
+                        image = PortraitRendererCore.DrawPortraitUnit(facePtr, palettePtr, eyeX, eyeY, state);
+                    }
+                    using (image)
                     {
                         if (image == null) { Console.Error.WriteLine($"  Portrait {id}: render returned null"); errors++; continue; }
 


### PR DESCRIPTION
## Summary
- Add `--export-portrait-all` CLI command for bulk portrait export
- Loops through all portrait entries, renders each using PortraitRendererCore, saves as PNG
- Usage: `--export-portrait-all --rom=rom.gba --out=portraits/`
- Skips entries with null face/palette pointers, reports count and errors

## Plan Reference
Implements WU3 from [Revised Plan v2](https://github.com/laqieer/FEBuilderGBA/issues/124#issuecomment-4089038917)

## Scope
Ref #124 (partial — adds bulk portrait export; import-portrait deferred pending Core quantization infrastructure; patch-status already covered by --list-patches)

## Screenshots
This is a CLI command. Proof is the --help output showing the new command:
```
--export-portrait-all    Export all portraits to PNG files (requires --rom, --out)
```

## Test plan
- [x] CLI builds successfully
- [x] `--help` shows new command
- [x] 1004 Core tests pass
- [ ] Manual: `--export-portrait-all --rom=roms/FE8U.gba --out=portraits/` produces PNG files

## Known limitations
- Portrait import CLI not included (needs ImageImportService to be moved to Core/SkiaSharp)
- Hard/Very Hard items (event script compilation, map tiles, battle animation) deferred

Generated with Claude Code (claude-opus-4-6)