### PR TITLE
feat: add WinForms auto-save with sidecar file (#126)

### DIFF
--- a/FEBuilderGBA/AutoSaveWinForms.cs
+++ b/FEBuilderGBA/AutoSaveWinForms.cs
@@ -15,8 +15,8 @@ namespace FEBuilderGBA
 
         Timer _timer;
         string _romFilename;
-        int _lastSavedUndoPosition = -1;
-        bool _writing;
+        volatile int _lastSavedUndoPosition = -1;
+        volatile bool _writing;
 
         AutoSaveWinForms() { }
 
@@ -94,6 +94,7 @@ namespace FEBuilderGBA
 
             _writing = true;
             int savedPos = currentPos;
+            var ctx = System.Threading.SynchronizationContext.Current;
             Task.Run(() =>
             {
                 try
@@ -102,11 +103,14 @@ namespace FEBuilderGBA
                     File.WriteAllBytes(tempPath, data);
                     File.Move(tempPath, sidecar, true);
                     _lastSavedUndoPosition = savedPos;
-                    Log.Notify("Auto-saved to " + Path.GetFileName(sidecar));
+                    // Marshal log notification to UI thread to avoid cross-thread ListBox access
+                    if (ctx != null)
+                        ctx.Post(_ => Log.Notify("Auto-saved to " + Path.GetFileName(sidecar)), null);
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("Auto-save failed: {0}", ex.Message);
+                    if (ctx != null)
+                        ctx.Post(_ => Log.Error("Auto-save failed: {0}", ex.Message), null);
                 }
                 finally
                 {
@@ -123,9 +127,9 @@ namespace FEBuilderGBA
             bool enabled = Program.Config?.at("autosave_enabled", "false") == "true";
             int interval = 5;
             string val = Program.Config?.at("autosave_interval_minutes", "5");
-            if (val != null) int.TryParse(val, out interval);
-            if (interval < 1) interval = 1;
-            if (interval > 60) interval = 60;
+            if (val != null && int.TryParse(val, out int parsed))
+                interval = parsed;
+            interval = Math.Clamp(interval, 1, 60);
             return (enabled, interval);
         }
     }

--- a/FEBuilderGBA/Program.cs
+++ b/FEBuilderGBA/Program.cs
@@ -413,31 +413,30 @@ namespace FEBuilderGBA
                 return InputFormRef.JumpFormLow<MainFE0Form>();
             }
 
+            // Start auto-save if enabled (before any main form)
+            TryStartAutoSave();
+
+            Form mainForm;
             if (OptionForm.first_form() == OptionForm.first_form_enum.EASY
                 && U.stringbool(U.at(ArgsDic, "--force-detail","0")) == false )
             {
-                return InputFormRef.JumpFormLow<MainSimpleMenuForm>();
+                mainForm = InputFormRef.JumpFormLow<MainSimpleMenuForm>();
             }
-
-            // Start auto-save if enabled
-            TryStartAutoSave();
-
-            DialogResult result;
-            if (Program.ROM.RomInfo.version == 6)
+            else if (Program.ROM.RomInfo.version == 6)
             {
-                result = InputFormRef.JumpFormLow<MainFE6Form>();
+                mainForm = InputFormRef.JumpFormLow<MainFE6Form>();
             }
             else if (Program.ROM.RomInfo.version == 7)
             {
-                result = InputFormRef.JumpFormLow<MainFE7Form>();
+                mainForm = InputFormRef.JumpFormLow<MainFE7Form>();
             }
             else
             {
-                result = InputFormRef.JumpFormLow<MainFE8Form>();
+                mainForm = InputFormRef.JumpFormLow<MainFE8Form>();
             }
 
             AutoSaveWinForms.Instance.Stop();
-            return result;
+            return mainForm;
         }
 
         static void TryStartAutoSave()


### PR DESCRIPTION
## Summary
- Add WinForms `AutoSaveWinForms` class mirroring Avalonia's AutoSaveService
- Timer-based auto-save writes to `.autosave.gba` sidecar file (never overwrites primary ROM)
- Same config keys as Avalonia: `autosave_enabled`, `autosave_interval_minutes`
- Atomic write via temp file + File.Move, background thread for I/O
- Wired into Program.cs main form lifecycle (start on ROM load, stop on form close)
- Disabled by default

## Plan Reference
Implements WinForms portion from [plan on issue #126](https://github.com/laqieer/FEBuilderGBA/issues/126#issuecomment-4086826788)

## Scope
Closes #126 — Avalonia auto-save already implemented + WinForms auto-save (this PR)

## Screenshots
This is a background timer feature. Configuration is via existing Avalonia Options UI or config.xml keys.

## Test plan
- [x] WinForms builds successfully with AutoSaveWinForms
- [x] 1004 Core tests pass
- [x] Auto-save uses same config keys as Avalonia (compatible)
- [ ] Manual: enable auto-save in config.xml, open ROM in WinForms, make edit, verify .autosave.gba appears

## Known limitations
- WinForms OptionForm UI for auto-save settings not added (use Avalonia Options or edit config.xml)
- Crash-restore prompt not implemented (out of scope per plan)

Generated with Claude Code (claude-opus-4-6)