### PR TITLE
feat: FE-Repo Music GUI browser for WinForms + Avalonia (#125)

### DIFF
--- a/FEBuilderGBA.Avalonia/ViewModels/FERepoResourceBrowserViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/FERepoResourceBrowserViewModel.cs
@@ -16,6 +16,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         bool _canInsert;
         CategoryNode _selectedCategory;
         string _repoRoot;
+        bool _musicMode;
 
         public ObservableCollection<CategoryNode> Categories
         {
@@ -69,10 +70,15 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
         public string SelectedFilePath { get; set; }
 
-        public FERepoResourceBrowserViewModel()
+        public FERepoResourceBrowserViewModel() : this(false) { }
+
+        public FERepoResourceBrowserViewModel(bool musicMode)
         {
+            _musicMode = musicMode;
             string baseDir = CoreState.BaseDirectory ?? AppDomain.CurrentDomain.BaseDirectory;
-            _repoRoot = FERepoResourceBrowser.FindRepoRoot(baseDir);
+            _repoRoot = musicMode
+                ? FERepoResourceBrowser.FindMusicRepoRoot(baseDir)
+                : FERepoResourceBrowser.FindRepoRoot(baseDir);
             LoadCategories();
         }
 
@@ -105,7 +111,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             CanInsert = false;
             SelectedFilePath = null;
 
-            var files = FERepoResourceBrowser.GetResourceFiles(_repoRoot, node.Category, node.SubCategory, maxResults: 200);
+            var files = _musicMode
+                ? FERepoResourceBrowser.GetMusicFiles(_repoRoot, node.Category, node.SubCategory, maxResults: 500)
+                : FERepoResourceBrowser.GetResourceFiles(_repoRoot, node.Category, node.SubCategory, maxResults: 200);
             StatusText = $"{files.Length} resources found";
             if (files.Length >= 200) StatusText += " (limited to 200)";
 

--- a/FEBuilderGBA.Avalonia/Views/FERepoResourceBrowserWindow.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/FERepoResourceBrowserWindow.axaml.cs
@@ -8,10 +8,13 @@ namespace FEBuilderGBA.Avalonia.Views
     {
         public string SelectedFilePath => (DataContext as FERepoResourceBrowserViewModel)?.SelectedFilePath;
 
-        public FERepoResourceBrowserWindow()
+        public FERepoResourceBrowserWindow() : this(false) { }
+
+        public FERepoResourceBrowserWindow(bool musicMode)
         {
             InitializeComponent();
-            DataContext = new FERepoResourceBrowserViewModel();
+            DataContext = new FERepoResourceBrowserViewModel(musicMode);
+            if (musicMode) Title = "FE-Repo Music Browser";
         }
 
         void InsertButton_Click(object sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Core/FERepoResourceBrowser.cs
+++ b/FEBuilderGBA.Core/FERepoResourceBrowser.cs
@@ -29,6 +29,7 @@ namespace FEBuilderGBA
         };
 
         static readonly string[] ImageExtensions = { ".png", ".bmp", ".gif" };
+        static readonly string[] MusicExtensions = { ".s", ".mid", ".midi", ".wav" };
 
         /// <summary>
         /// Find the FE-Repo root directory by searching from the given base directory.
@@ -49,6 +50,69 @@ namespace FEBuilderGBA
                 dir = parent;
             }
             return null;
+        }
+
+        /// <summary>
+        /// Find the FE-Repo-Music root directory by searching from the given base directory.
+        /// </summary>
+        public static string FindMusicRepoRoot(string baseDir)
+        {
+            if (string.IsNullOrEmpty(baseDir)) return null;
+
+            string dir = baseDir;
+            while (!string.IsNullOrEmpty(dir))
+            {
+                string candidate = Path.Combine(dir, "resources", "FE-Repo-Music-No-Preview");
+                if (Directory.Exists(candidate))
+                    return candidate;
+                string parent = Path.GetDirectoryName(dir);
+                if (parent == dir) break;
+                dir = parent;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Get music resource files within a category and optional subcategory.
+        /// Filters for .s, .mid, .midi, .wav files.
+        /// </summary>
+        public static ResourceEntry[] GetMusicFiles(string repoRoot, string category, string subCategory = null, int maxResults = 0)
+        {
+            if (string.IsNullOrEmpty(repoRoot) || string.IsNullOrEmpty(category))
+                return Array.Empty<ResourceEntry>();
+
+            string searchDir = string.IsNullOrEmpty(subCategory)
+                ? Path.Combine(repoRoot, category)
+                : Path.Combine(repoRoot, category, subCategory);
+
+            if (!Directory.Exists(searchDir))
+                return Array.Empty<ResourceEntry>();
+
+            var entries = new List<ResourceEntry>();
+            try
+            {
+                foreach (string file in Directory.EnumerateFiles(searchDir, "*", SearchOption.AllDirectories))
+                {
+                    string ext = Path.GetExtension(file).ToLowerInvariant();
+                    if (!MusicExtensions.Contains(ext)) continue;
+
+                    var info = new FileInfo(file);
+                    entries.Add(new ResourceEntry
+                    {
+                        FullPath = file,
+                        FileName = Path.GetFileName(file),
+                        Category = category,
+                        SubCategory = subCategory ?? "",
+                        FileSize = info.Length
+                    });
+
+                    if (maxResults > 0 && entries.Count >= maxResults)
+                        break;
+                }
+            }
+            catch (Exception) { }
+
+            return entries.OrderBy(e => e.FileName).ToArray();
         }
 
         /// <summary>

--- a/FEBuilderGBA/FERepoMusicBrowserForm.cs
+++ b/FEBuilderGBA/FERepoMusicBrowserForm.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Browser form for FE-Repo-Music resources. Shows categories and .s files
+    /// for song import via the song exchange system.
+    /// </summary>
+    public class FERepoMusicBrowserForm : Form
+    {
+        TreeView categoryTree;
+        ListView fileListView;
+        Button selectButton;
+        Button cancelButton;
+        Label statusLabel;
+        TextBox previewBox;
+
+        string repoRoot;
+
+        public string SelectedFilePath { get; private set; }
+
+        public FERepoMusicBrowserForm()
+        {
+            InitializeComponent();
+            LoadCategories();
+        }
+
+        void InitializeComponent()
+        {
+            Text = R._("FE-Repo Music Browser");
+            Size = new Size(800, 500);
+            StartPosition = FormStartPosition.CenterParent;
+            MinimizeBox = false;
+            MaximizeBox = false;
+
+            var splitMain = new SplitContainer
+            {
+                Dock = DockStyle.Fill,
+                SplitterDistance = 250,
+                Orientation = Orientation.Vertical
+            };
+
+            categoryTree = new TreeView { Dock = DockStyle.Fill };
+            categoryTree.AfterSelect += CategoryTree_AfterSelect;
+            splitMain.Panel1.Controls.Add(categoryTree);
+
+            var splitRight = new SplitContainer
+            {
+                Dock = DockStyle.Fill,
+                SplitterDistance = 250,
+                Orientation = Orientation.Vertical
+            };
+
+            fileListView = new ListView
+            {
+                Dock = DockStyle.Fill,
+                View = View.Details,
+                FullRowSelect = true,
+                MultiSelect = false
+            };
+            fileListView.Columns.Add(R._("Filename"), 300);
+            fileListView.Columns.Add(R._("Size"), 80);
+            fileListView.SelectedIndexChanged += FileListView_SelectedIndexChanged;
+            fileListView.DoubleClick += (s, e) => { if (SelectedFilePath != null) { DialogResult = DialogResult.OK; Close(); } };
+            splitRight.Panel1.Controls.Add(fileListView);
+
+            previewBox = new TextBox
+            {
+                Dock = DockStyle.Fill,
+                Multiline = true,
+                ReadOnly = true,
+                ScrollBars = ScrollBars.Both,
+                Font = new Font("Consolas", 9)
+            };
+            splitRight.Panel2.Controls.Add(previewBox);
+
+            splitMain.Panel2.Controls.Add(splitRight);
+
+            var bottomPanel = new Panel { Dock = DockStyle.Bottom, Height = 40 };
+            statusLabel = new Label { Dock = DockStyle.Fill, TextAlign = ContentAlignment.MiddleLeft, Text = R._("Select a music file") };
+            selectButton = new Button { Text = R._("Select"), Dock = DockStyle.Right, Width = 80, Enabled = false };
+            selectButton.Click += (s, e) => { DialogResult = DialogResult.OK; Close(); };
+            cancelButton = new Button { Text = R._("Cancel"), Dock = DockStyle.Right, Width = 80 };
+            cancelButton.Click += (s, e) => { DialogResult = DialogResult.Cancel; Close(); };
+            bottomPanel.Controls.Add(statusLabel);
+            bottomPanel.Controls.Add(selectButton);
+            bottomPanel.Controls.Add(cancelButton);
+
+            Controls.Add(splitMain);
+            Controls.Add(bottomPanel);
+        }
+
+        void LoadCategories()
+        {
+            string baseDir = CoreState.BaseDirectory ?? AppDomain.CurrentDomain.BaseDirectory;
+            repoRoot = FERepoResourceBrowser.FindMusicRepoRoot(baseDir);
+            if (repoRoot == null)
+            {
+                categoryTree.Nodes.Add(R._("FE-Repo-Music not found. Run: git submodule update --init resources/FE-Repo-Music-No-Preview"));
+                return;
+            }
+
+            string[] categories = FERepoResourceBrowser.GetCategories(repoRoot);
+            foreach (string cat in categories)
+            {
+                var catNode = new TreeNode(cat) { Tag = cat };
+                string[] subs = FERepoResourceBrowser.GetSubCategories(repoRoot, cat);
+                foreach (string sub in subs)
+                {
+                    catNode.Nodes.Add(new TreeNode(sub) { Tag = sub });
+                }
+                categoryTree.Nodes.Add(catNode);
+            }
+        }
+
+        void CategoryTree_AfterSelect(object sender, TreeViewEventArgs e)
+        {
+            if (repoRoot == null || e.Node?.Tag == null) return;
+
+            string category, subCategory = null;
+            if (e.Node.Parent != null)
+            {
+                category = e.Node.Parent.Tag as string;
+                subCategory = e.Node.Tag as string;
+            }
+            else
+            {
+                category = e.Node.Tag as string;
+            }
+
+            fileListView.Items.Clear();
+            previewBox.Text = "";
+            selectButton.Enabled = false;
+            SelectedFilePath = null;
+
+            var files = FERepoResourceBrowser.GetMusicFiles(repoRoot, category, subCategory, maxResults: 500);
+            statusLabel.Text = string.Format(R._("{0} music files found"), files.Length);
+
+            foreach (var entry in files)
+            {
+                var item = new ListViewItem(entry.FileName) { Tag = entry.FullPath };
+                item.SubItems.Add(U.ToHexString4((uint)entry.FileSize));
+                fileListView.Items.Add(item);
+            }
+        }
+
+        void FileListView_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (fileListView.SelectedItems.Count == 0)
+            {
+                previewBox.Text = "";
+                selectButton.Enabled = false;
+                SelectedFilePath = null;
+                return;
+            }
+
+            string path = fileListView.SelectedItems[0].Tag as string;
+            SelectedFilePath = path;
+            selectButton.Enabled = true;
+
+            try
+            {
+                // Show first 50 lines of .s file as preview
+                string[] lines = File.ReadAllLines(path);
+                int previewLines = Math.Min(lines.Length, 50);
+                previewBox.Text = string.Join(Environment.NewLine, lines, 0, previewLines);
+                if (lines.Length > previewLines)
+                    previewBox.Text += Environment.NewLine + $"... ({lines.Length - previewLines} more lines)";
+
+                var info = new FileInfo(path);
+                statusLabel.Text = string.Format(R._("{0} ({1} lines, {2} bytes)"),
+                    Path.GetFileName(path), lines.Length, info.Length);
+            }
+            catch
+            {
+                previewBox.Text = R._("(Unable to preview file)");
+            }
+        }
+    }
+}

--- a/FEBuilderGBA/SongExchangeForm.cs
+++ b/FEBuilderGBA/SongExchangeForm.cs
@@ -21,6 +21,31 @@ namespace FEBuilderGBA
 
             this.SongTable.OwnerDraw(ListBoxEx.DrawTextOnly, DrawMode.OwnerDrawFixed);
             this.OtherROMSongTable.OwnerDraw(ListBoxEx.DrawTextOnly, DrawMode.OwnerDrawFixed);
+
+            // Add FE-Repo Music browse button
+            var feRepoMusicButton = new Button
+            {
+                Text = R._("FE-Repo Music"),
+                Size = new System.Drawing.Size(120, 25),
+                Location = new System.Drawing.Point(5, 5)
+            };
+            feRepoMusicButton.Click += FERepoMusicButton_Click;
+            this.Controls.Add(feRepoMusicButton);
+            feRepoMusicButton.BringToFront();
+        }
+
+        void FERepoMusicButton_Click(object sender, EventArgs e)
+        {
+            using (var browser = new FERepoMusicBrowserForm())
+            {
+                if (browser.ShowDialog(this) == DialogResult.OK && !string.IsNullOrEmpty(browser.SelectedFilePath))
+                {
+                    // Copy selected .s file path to clipboard for use in song exchange
+                    System.Windows.Forms.Clipboard.SetText(browser.SelectedFilePath);
+                    R.ShowOK(R._("Music file path copied to clipboard:\n{0}\n\nUse this path with the song exchange import."),
+                        browser.SelectedFilePath);
+                }
+            }
         }
         public class SongSt
         {


### PR DESCRIPTION
## Summary
- Extend FERepoResourceBrowser with FindMusicRepoRoot() and GetMusicFiles() for .s/.mid/.wav
- New WinForms FERepoMusicBrowserForm with TreeView, ListView, .s preview, Select button
- Add "FE-Repo Music" button to SongExchangeForm
- Extend Avalonia browser with musicMode for music file browsing

## Scope
Closes #125 — submodule (done) + CLI (done) + WinForms music browser + Avalonia music browser (this PR)

## Screenshots
Music browser shows category tree and .s file preview. Same pattern as graphics browser (#123).

## Test plan
- [x] Core builds, Avalonia builds, WinForms builds
- [x] 1004 Core tests pass
- [ ] Manual: open SongExchangeForm, click FE-Repo Music, browse categories

Generated with Claude Code (claude-opus-4-6)