### PR TITLE
fix: dispatch MapSetting view by ROM version in Avalonia (#188)

### DIFF
--- a/FEBuilderGBA.Avalonia/ViewModels/MapSettingViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapSettingViewModel.cs
@@ -224,6 +224,10 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             ROM rom = CoreState.ROM;
             if (rom == null) return;
 
+            // FE6 has a completely different struct layout (u8 BGM fields, 68-72 bytes).
+            // Use MapSettingFE6ViewModel instead. Guard against accidental misuse.
+            if (rom.RomInfo.version == 6) return;
+
             uint dataSize = rom.RomInfo.map_setting_datasize;
             if (dataSize == 0) dataSize = 148;
             if (addr + dataSize > (uint)rom.Data.Length) return;
@@ -379,6 +383,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         {
             ROM rom = CoreState.ROM;
             if (rom == null || CurrentAddr == 0) return;
+
+            // FE6 has a completely different struct layout — block writes here.
+            if (rom.RomInfo.version == 6) return;
 
             uint addr = CurrentAddr;
             uint dataSize = DataSize;

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
@@ -1788,7 +1788,18 @@ namespace FEBuilderGBA.Avalonia.Views
 
         private void OpenMapSettings_Click(object? sender, RoutedEventArgs e)
         {
-            WindowManager.Instance.Open<MapSettingView>();
+            var rom = CoreState.ROM;
+            int ver = rom?.RomInfo?.version ?? 0;
+            bool isMultibyte = rom?.RomInfo?.is_multibyte ?? false;
+
+            if (ver == 6)
+                WindowManager.Instance.Open<MapSettingFE6View>();
+            else if (ver == 7 && !isMultibyte)
+                WindowManager.Instance.Open<MapSettingFE7UView>();
+            else if (ver == 7)
+                WindowManager.Instance.Open<MapSettingFE7View>();
+            else
+                WindowManager.Instance.Open<MapSettingView>();
         }
 
         private void OpenTextViewer_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Core.Tests/MapSettingCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/MapSettingCoreTests.cs
@@ -66,6 +66,66 @@ namespace FEBuilderGBA.Core.Tests
             }
         }
 
+        // ---- FE6-specific version data size tests ----
+
+        [Fact]
+        public void FE6_MapSettingDataSize_Is68Or72()
+        {
+            var rom = new ROM();
+            rom.LoadLow("test.gba", new byte[0x1000000], "AFEJ01");
+            Assert.NotNull(rom.RomInfo);
+            Assert.Equal(6, rom.RomInfo.version);
+            // FE6 data size is either 68 or 72 depending on the world map event table
+            Assert.True(rom.RomInfo.map_setting_datasize == 68 || rom.RomInfo.map_setting_datasize == 72,
+                $"FE6 map_setting_datasize should be 68 or 72 but was {rom.RomInfo.map_setting_datasize}");
+        }
+
+        [Fact]
+        public void FE8U_MapSettingDataSize_Is148()
+        {
+            var rom = new ROM();
+            rom.LoadLow("test.gba", new byte[0x1000000], "BE8E01");
+            Assert.NotNull(rom.RomInfo);
+            Assert.Equal(8, rom.RomInfo.version);
+            Assert.Equal(148u, rom.RomInfo.map_setting_datasize);
+        }
+
+        [Fact]
+        public void FE7JP_MapSettingDataSize_Is148()
+        {
+            var rom = new ROM();
+            rom.LoadLow("test.gba", new byte[0x1000000], "AE7J01");
+            Assert.NotNull(rom.RomInfo);
+            Assert.Equal(7, rom.RomInfo.version);
+            Assert.Equal(148u, rom.RomInfo.map_setting_datasize);
+        }
+
+        [Fact]
+        public void FE7U_MapSettingDataSize_Is152()
+        {
+            var rom = new ROM();
+            rom.LoadLow("test.gba", new byte[0x1000000], "AE7E01");
+            Assert.NotNull(rom.RomInfo);
+            Assert.Equal(7, rom.RomInfo.version);
+            Assert.Equal(152u, rom.RomInfo.map_setting_datasize);
+        }
+
+        [Fact]
+        public void FE6_IsMultibyte_True()
+        {
+            var rom = new ROM();
+            rom.LoadLow("test.gba", new byte[0x1000000], "AFEJ01");
+            Assert.True(rom.RomInfo.is_multibyte);
+        }
+
+        [Fact]
+        public void FE7U_IsMultibyte_False()
+        {
+            var rom = new ROM();
+            rom.LoadLow("test.gba", new byte[0x1000000], "AE7E01");
+            Assert.False(rom.RomInfo.is_multibyte);
+        }
+
         static void WriteU32(byte[] data, int offset, uint value)
         {
             data[offset + 0] = (byte)(value & 0xFF);

--- a/FEBuilderGBA.Tests/Unit/AvaloniaEditorTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AvaloniaEditorTests.cs
@@ -243,6 +243,35 @@ namespace FEBuilderGBA.Tests.Unit
             Assert.Contains("public void SelectFirstItem()", src);
         }
 
+        [Fact]
+        public void OpenMapSettings_Click_DispatchesByVersion()
+        {
+            // The "Map Settings" button handler must dispatch to version-specific views
+            // instead of always opening the generic MapSettingView
+            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "Views", "MainWindow.axaml.cs"));
+
+            // Extract the OpenMapSettings_Click method body
+            int methodStart = src.IndexOf("private void OpenMapSettings_Click");
+            Assert.True(methodStart >= 0, "OpenMapSettings_Click not found");
+
+            // Must check ver == 6 for FE6 dispatch
+            string afterMethod = src.Substring(methodStart, 600);
+            Assert.Contains("ver == 6", afterMethod);
+            Assert.Contains("MapSettingFE6View", afterMethod);
+
+            // Must check FE7U (version 7, !isMultibyte) before generic FE7
+            Assert.Contains("MapSettingFE7UView", afterMethod);
+            Assert.Contains("MapSettingFE7View", afterMethod);
+        }
+
+        [Fact]
+        public void MapSettingViewModel_GuardsFE6Version()
+        {
+            // The generic MapSettingViewModel must reject FE6 ROMs to prevent data corruption
+            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "ViewModels", "MapSettingViewModel.cs"));
+            Assert.Contains("rom.RomInfo.version == 6", src);
+        }
+
         // ------------------------------------------------------------------ Text Viewer (WU-9)
 
         [Fact]


### PR DESCRIPTION
## Summary

- Fix the "Map Settings" button in Avalonia MainWindow to dispatch to the correct version-specific view based on loaded ROM version (FE6/FE7JP/FE7U/FE8), matching WinForms behavior
- Add defensive guards in the generic `MapSettingViewModel` to reject FE6 ROMs and prevent data corruption
- Add 8 unit tests covering version-specific `map_setting_datasize` values and the dispatch logic

## Root Cause

`OpenMapSettings_Click` always opened `MapSettingView` (generic 148-byte FE7/FE8 layout), even for FE6 ROMs. FE6 has a completely different struct layout:
- BGM fields are `u8` (not `u16`)
- Total struct size is 68-72 bytes (not 148)
- Field offsets diverge starting at offset 15

This caused misinterpreted fields and would corrupt ROM data on write-back.

## Fix

`OpenMapSettings_Click` now dispatches:
| ROM Version | View |
|---|---|
| FE6 (ver=6) | `MapSettingFE6View` |
| FE7JP (ver=7, multibyte) | `MapSettingFE7View` |
| FE7U (ver=7, !multibyte) | `MapSettingFE7UView` |
| FE8 (default) | `MapSettingView` |

## Test plan

- [x] 6 new Core.Tests: `FE6_MapSettingDataSize_Is68Or72`, `FE8U_MapSettingDataSize_Is148`, `FE7JP_MapSettingDataSize_Is148`, `FE7U_MapSettingDataSize_Is152`, `FE6_IsMultibyte_True`, `FE7U_IsMultibyte_False`
- [x] 2 new AvaloniaEditorTests: `OpenMapSettings_Click_DispatchesByVersion`, `MapSettingViewModel_GuardsFE6Version`
- [x] All 1088 Core.Tests pass
- [x] All 1702 FEBuilderGBA.Tests pass

Fixes #188

---
Generated with Claude Code v1.0.33 (claude-opus-4-6)