### PR TITLE
feat: add ROM test infrastructure for Avalonia headless tests (#210)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/RomFixture.cs
+++ b/FEBuilderGBA.Avalonia.Tests/RomFixture.cs
@@ -1,0 +1,155 @@
+using System;
+using System.IO;
+using System.Text;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// xUnit fixture that loads a ROM and initializes CoreState for headless tests.
+    /// Use with IClassFixture&lt;RomFixture&gt; to share ROM state across test classes.
+    ///
+    /// ROM loading uses the same RomLoader.InitFull() pattern as the CLI:
+    ///   CoreState.ROM, headless caches, Huffman encoder, event scripts, etc.
+    ///
+    /// If no ROM is available, IsAvailable is false and tests should skip.
+    /// </summary>
+    public class RomFixture : IDisposable
+    {
+        /// <summary>Whether a ROM was successfully loaded.</summary>
+        public bool IsAvailable { get; }
+
+        /// <summary>The loaded ROM instance, or null if unavailable.</summary>
+        public ROM? ROM { get; }
+
+        /// <summary>The detected version string ("FE6", "FE7J", "FE7U", "FE8J", "FE8U"), or null.</summary>
+        public string? Version { get; }
+
+        /// <summary>Path to the ROM file, or null if unavailable.</summary>
+        public string? RomPath { get; }
+
+        // Snapshot of CoreState before we modified it, so Dispose can restore.
+        private readonly ROM? _prevRom;
+        private readonly IEtcCache? _prevCommentCache;
+        private readonly IEtcCache? _prevLintCache;
+        private readonly IEtcCache? _prevWorkSupportCache;
+        private readonly ISystemTextEncoder? _prevSystemTextEncoder;
+        private readonly string? _prevBaseDirectory;
+
+        /// <summary>
+        /// Creates the fixture. Attempts to load a ROM in priority order:
+        /// FE8U, FE7U, FE8J, FE7J, FE6 (US English ROMs preferred for broader test coverage).
+        /// </summary>
+        public RomFixture()
+        {
+            // Save previous CoreState
+            _prevRom = CoreState.ROM;
+            _prevCommentCache = CoreState.CommentCache;
+            _prevLintCache = CoreState.LintCache;
+            _prevWorkSupportCache = CoreState.WorkSupportCache;
+            _prevSystemTextEncoder = CoreState.SystemTextEncoder;
+            _prevBaseDirectory = CoreState.BaseDirectory;
+
+            // Try to find a ROM, preferring US versions
+            string[] preferred = { "FE8U", "FE7U", "FE8J", "FE7J", "FE6" };
+            foreach (string ver in preferred)
+            {
+                string? path = TestRomLocator.FindRom(ver);
+                if (path != null)
+                {
+                    RomPath = path;
+                    Version = ver;
+                    break;
+                }
+            }
+
+            if (RomPath == null)
+            {
+                IsAvailable = false;
+                return;
+            }
+
+            try
+            {
+                // Set BaseDirectory to the test assembly output dir (where config/ is copied)
+                string assemblyDir = Path.GetDirectoryName(
+                    System.Reflection.Assembly.GetExecutingAssembly().Location) ?? ".";
+                CoreState.BaseDirectory = assemblyDir;
+
+                // Register code pages for Shift-JIS, etc.
+                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+                // Load config if available
+                string configPath = Path.Combine(assemblyDir, "config", "config.xml");
+                if (File.Exists(configPath))
+                {
+                    var config = new Config();
+                    config.Load(configPath);
+                    CoreState.Config = config;
+                }
+
+                // Load the ROM
+                var rom = new ROM();
+                bool ok = rom.Load(RomPath, out string _);
+                if (!ok)
+                {
+                    IsAvailable = false;
+                    return;
+                }
+
+                CoreState.ROM = rom;
+                ROM = rom;
+
+                // Wire headless caches
+                CoreState.CommentCache = new HeadlessEtcCache();
+                CoreState.LintCache = new HeadlessEtcCache();
+                CoreState.WorkSupportCache = new HeadlessEtcCache();
+
+                // Wire text encoder
+                try
+                {
+                    CoreState.SystemTextEncoder = new SystemTextEncoder(CoreState.TextEncoding, rom);
+                }
+                catch
+                {
+                    CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+                }
+
+                // Init Huffman text encoder
+                try
+                {
+                    CoreState.FETextEncoder = new FETextEncode();
+                }
+                catch
+                {
+                    // Non-fatal: some tests don't need text encoding
+                }
+
+                // Init text escape
+                CoreState.TextEscape ??= new TextEscape();
+
+                // Init undo
+                CoreState.Undo ??= new Undo();
+
+                IsAvailable = true;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"RomFixture init failed: {ex.Message}");
+                IsAvailable = false;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Restore previous CoreState to avoid leaking between test collections
+            CoreState.ROM = _prevRom;
+            CoreState.CommentCache = _prevCommentCache;
+            CoreState.LintCache = _prevLintCache;
+            CoreState.WorkSupportCache = _prevWorkSupportCache;
+            CoreState.SystemTextEncoder = _prevSystemTextEncoder;
+            if (_prevBaseDirectory != null)
+                CoreState.BaseDirectory = _prevBaseDirectory;
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/RomInfrastructureTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/RomInfrastructureTests.cs
@@ -1,0 +1,148 @@
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// Tests verifying that the ROM test infrastructure (TestRomLocator, RomFixture) works correctly.
+    /// Tests skip gracefully when ROMs are not available.
+    /// </summary>
+    public class RomInfrastructureTests : IClassFixture<RomFixture>
+    {
+        private readonly RomFixture _fixture;
+
+        public RomInfrastructureTests(RomFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public void TestRomLocator_RomsDirIsNullOrValid()
+        {
+            // RomsDir should be null (no roms found) or a valid directory
+            if (TestRomLocator.RomsDir != null)
+            {
+                Assert.True(System.IO.Directory.Exists(TestRomLocator.RomsDir),
+                    $"RomsDir '{TestRomLocator.RomsDir}' does not exist");
+            }
+        }
+
+        [Fact]
+        public void TestRomLocator_FindRom_InvalidVersionReturnsNull()
+        {
+            Assert.Null(TestRomLocator.FindRom("INVALID"));
+        }
+
+        [Fact]
+        public void TestRomLocator_FindRom_EmptyVersionReturnsNull()
+        {
+            Assert.Null(TestRomLocator.FindRom(""));
+        }
+
+        [Fact]
+        public void TestRomLocator_DetectVersion_NonexistentFileReturnsNull()
+        {
+            Assert.Null(TestRomLocator.DetectVersion("/nonexistent/path/rom.gba"));
+        }
+
+        [Fact]
+        public void TestRomLocator_AllRoms_YieldsFiveEntries()
+        {
+            int count = 0;
+            foreach (var entry in TestRomLocator.AllRoms)
+            {
+                Assert.Equal(2, entry.Length);
+                Assert.NotNull(entry[0]); // version name is always non-null
+                count++;
+            }
+            Assert.Equal(5, count);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestRomLocator.AllRoms), MemberType = typeof(TestRomLocator))]
+        public void TestRomLocator_FindRom_DetectsCorrectVersion(string version, string? romPath)
+        {
+            if (romPath == null)
+            {
+                // ROM not available -- skip
+                return;
+            }
+
+            Assert.True(System.IO.File.Exists(romPath), $"ROM path does not exist: {romPath}");
+
+            // Verify DetectVersion returns the expected version
+            string? detected = TestRomLocator.DetectVersion(romPath);
+            Assert.Equal(version, detected);
+        }
+
+        [Fact]
+        public void RomFixture_LoadsSuccessfully_WhenRomAvailable()
+        {
+            if (!_fixture.IsAvailable)
+            {
+                // No ROMs on this machine -- skip
+                return;
+            }
+
+            Assert.NotNull(_fixture.ROM);
+            Assert.NotNull(_fixture.Version);
+            Assert.NotNull(_fixture.RomPath);
+            Assert.True(System.IO.File.Exists(_fixture.RomPath));
+        }
+
+        [Fact]
+        public void RomFixture_CoreStateIsWired_WhenRomAvailable()
+        {
+            if (!_fixture.IsAvailable)
+                return;
+
+            Assert.NotNull(CoreState.ROM);
+            Assert.Same(_fixture.ROM, CoreState.ROM);
+            Assert.NotNull(CoreState.ROM.RomInfo);
+            Assert.NotNull(CoreState.CommentCache);
+            Assert.NotNull(CoreState.LintCache);
+            Assert.NotNull(CoreState.WorkSupportCache);
+            Assert.NotNull(CoreState.SystemTextEncoder);
+        }
+
+        [Fact]
+        public void RomFixture_VersionMatchesRomInfo_WhenRomAvailable()
+        {
+            if (!_fixture.IsAvailable)
+                return;
+
+            var romInfo = _fixture.ROM!.RomInfo;
+            int ver = romInfo.version;
+
+            // Verify the numeric version matches the string version
+            switch (_fixture.Version)
+            {
+                case "FE6":
+                    Assert.Equal(6, ver);
+                    break;
+                case "FE7J":
+                case "FE7U":
+                    Assert.Equal(7, ver);
+                    break;
+                case "FE8J":
+                case "FE8U":
+                    Assert.Equal(8, ver);
+                    break;
+                default:
+                    Assert.Fail($"Unexpected version: {_fixture.Version}");
+                    break;
+            }
+        }
+
+        [Fact]
+        public void RomFixture_RomDataIsNonEmpty_WhenRomAvailable()
+        {
+            if (!_fixture.IsAvailable)
+                return;
+
+            Assert.NotNull(_fixture.ROM!.Data);
+            Assert.True(_fixture.ROM.Data.Length >= 0x800000,
+                "ROM data should be at least 8MB (minimum FE6 size)");
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/TestRomLocator.cs
+++ b/FEBuilderGBA.Avalonia.Tests/TestRomLocator.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// Locates ROM files for Avalonia headless tests.
+    ///
+    /// Priority:
+    ///   1. ROMS_DIR environment variable (set by CI when ROMs are downloaded)
+    ///   2. roms/ directory beside FEBuilderGBA.sln (local dev)
+    ///
+    /// ROM filenames expected: FE6.gba, FE7J.gba, FE7U.gba, FE8J.gba, FE8U.gba
+    /// Version is detected by reading the 6-byte header signature at offset 0xAC.
+    /// </summary>
+    public static class TestRomLocator
+    {
+        /// <summary>
+        /// Map from header signature (6 ASCII bytes at offset 0xAC) to friendly version name.
+        /// </summary>
+        private static readonly Dictionary<string, string> SignatureToVersion = new()
+        {
+            { "AFEJ01", "FE6" },
+            { "AE7J01", "FE7J" },
+            { "AE7E01", "FE7U" },
+            { "BE8J01", "FE8J" },
+            { "BE8E01", "FE8U" },
+        };
+
+        public static readonly string? RomsDir;
+
+        static TestRomLocator()
+        {
+            // Priority 1: ROMS_DIR env var (CI injects this after downloading roms.zip).
+            // If the variable is present at all (even empty / non-existent path) we treat
+            // it as an explicit override and skip the walk-up fallback entirely.
+            string? envDir = Environment.GetEnvironmentVariable("ROMS_DIR");
+            bool envExplicitlySet = envDir != null;
+
+            if (envExplicitlySet)
+            {
+                if (!string.IsNullOrEmpty(envDir) && Directory.Exists(envDir))
+                    RomsDir = envDir;
+            }
+            else
+            {
+                // Priority 2: roms/ beside FEBuilderGBA.sln -- walk up from test assembly
+                string thisAssembly = Assembly.GetExecutingAssembly().Location;
+                string? dir = Path.GetDirectoryName(thisAssembly);
+                for (int i = 0; i < 10 && dir != null; i++)
+                {
+                    if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                    {
+                        string candidate = Path.Combine(dir, "roms");
+                        if (Directory.Exists(candidate))
+                            RomsDir = candidate;
+                        break;
+                    }
+                    dir = Path.GetDirectoryName(dir);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Find a ROM file for the given version ("FE6", "FE7J", "FE7U", "FE8J", "FE8U").
+        /// Returns the full path if found and the header signature matches, null otherwise.
+        /// </summary>
+        public static string? FindRom(string version)
+        {
+            if (RomsDir == null)
+                return null;
+
+            string path = Path.Combine(RomsDir, version + ".gba");
+            if (!File.Exists(path))
+                return null;
+
+            // Verify version by reading header signature
+            string? detected = DetectVersion(path);
+            if (detected != null && detected == version)
+                return path;
+
+            // If detection failed but file exists with expected name, still return it
+            // (ROM may be modified but filename is correct)
+            if (detected == null)
+                return path;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Detect ROM version from the 6-byte header signature at offset 0xAC.
+        /// Returns "FE6", "FE7J", "FE7U", "FE8J", "FE8U", or null if unrecognized.
+        /// </summary>
+        public static string? DetectVersion(string romPath)
+        {
+            try
+            {
+                // Read just the header bytes we need (offset 0xAC, 6 bytes)
+                using var fs = new FileStream(romPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                if (fs.Length < 0xAC + 6)
+                    return null;
+
+                fs.Seek(0xAC, SeekOrigin.Begin);
+                byte[] sigBytes = new byte[6];
+                int read = fs.Read(sigBytes, 0, 6);
+                if (read < 6)
+                    return null;
+
+                string sig = Encoding.ASCII.GetString(sigBytes);
+                return SignatureToVersion.TryGetValue(sig, out string? ver) ? ver : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// MemberData source for [Theory] tests -- yields one entry per ROM version:
+        ///   object?[] { versionName, romPath? }
+        /// romPath is null when the ROM file is not available; tests should skip in that case.
+        /// </summary>
+        public static IEnumerable<object?[]> AllRoms
+        {
+            get
+            {
+                yield return new object?[] { "FE6", FindRom("FE6") };
+                yield return new object?[] { "FE7J", FindRom("FE7J") };
+                yield return new object?[] { "FE7U", FindRom("FE7U") };
+                yield return new object?[] { "FE8J", FindRom("FE8J") };
+                yield return new object?[] { "FE8U", FindRom("FE8U") };
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `TestRomLocator` for finding ROMs via ROMS_DIR env var or roms/ directory
- Add `RomFixture` xUnit fixture for shared ROM loading with CoreState wiring
- Add 14 infrastructure tests verifying locator, fixture, and ROM loading
- All tests skip gracefully when ROMs are not available

## Plan Reference
Implements WU0 from https://github.com/laqieer/FEBuilderGBA/issues/210#issuecomment-4102934843

## Scope
Ref #210 (partial — WU0 only, WU1-WU8 remain)

## Test plan
- [x] 14 new infrastructure tests pass
- [x] All 53 Avalonia tests pass
- [x] All Core tests pass

## Known limitations
- WU1-WU8 (actual control/ViewModel tests) are not included — will follow in subsequent PRs

Generated with Claude Code (claude-opus-4-6)