### PR TITLE
docs: propagate 3-channel feedback check through all workflow sections

### DIFF
--- a/.claude/skills/dev-flow/SKILL.md
+++ b/.claude/skills/dev-flow/SKILL.md
@@ -59,7 +59,7 @@ Read `DEVELOPMENT-WORKFLOW.md` NOW for full details on each step.
 
 ## Phase 4 — Merge
 
-15. **Pre-merge checklist**: CI green, branch up-to-date, no unresolved threads.
+15. **Pre-merge checklist**: CI green, branch up-to-date, all feedback addressed (all three channels: issue comments, review bodies, inline threads).
 16. **Merge**: `gh pr merge <N> -R laqieer/FEBuilderGBA --merge`
 17. **Confirm**: `gh pr view <N> -R laqieer/FEBuilderGBA --json state --jq .state` — must be `MERGED`.
 18. If not MERGED, diagnose and fix (see DEVELOPMENT-WORKFLOW.md), loop back to step 15.

--- a/DEVELOPMENT-WORKFLOW.md
+++ b/DEVELOPMENT-WORKFLOW.md
@@ -375,7 +375,7 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<THRE
 - Re-run ALL THREE checks from step 10 (issue comments + review bodies + inline threads) to catch **newly posted** feedback
 - Resolve all review threads after addressing them
 - Re-trigger Copilot CLI review using the same invocation from step 10
-- Repeat until: **no unresolved comments of any kind**
+- Repeat until: **all inline review threads resolved AND no unaddressed feedback in issue comments or PR review bodies**
 
 **Exit condition:** Copilot CLI posts a review with no blocking concerns AND includes its version/model footer in this exact format:
 ```


### PR DESCRIPTION
## Summary
Propagates the 3-channel feedback check (issue comments + PR review bodies + inline threads) through all later workflow sections that previously referenced only inline threads.

### Changes (BOTH files updated in same commit)

**DEVELOPMENT-WORKFLOW.md:**
- Section 11 (Iterate): "check all 3" not just threads
- Section 12 (Pre-Merge): "all three channels" 
- Blocker table: "Unresolved feedback" → all 3 checks
- Anti-pattern renamed: "Don't ignore non-inline feedback"

**SKILL.md:**
- Step 12 heading: "all three channels"
- Step 14: "no unaddressed feedback across all three channels"

## Test plan
- [x] DEVELOPMENT-WORKFLOW.md and SKILL.md are consistent
- [x] All references to feedback channels now say "three channels"
- [x] No code changes — docs only

Generated with Claude Code (claude-opus-4-6)