### PR TITLE
ci: add Avalonia data-verify tests to cross-platform CI (#263)

### DIFF
--- a/.github/workflows/crossplatform.yml
+++ b/.github/workflows/crossplatform.yml
@@ -44,6 +44,9 @@ jobs:
     - name: Run Core tests
       run: dotnet test FEBuilderGBA.Core.Tests/FEBuilderGBA.Core.Tests.csproj -c Release --logger "trx;LogFileName=core-tests.trx"
 
+    - name: Run Avalonia tests (data-verify headless validation)
+      run: dotnet test FEBuilderGBA.Avalonia.Tests/FEBuilderGBA.Avalonia.Tests.csproj -c Release --logger "trx;LogFileName=avalonia-tests.trx"
+
     - name: CLI smoke test
       run: dotnet run --project FEBuilderGBA.CLI/FEBuilderGBA.CLI.csproj -- --version
 
@@ -55,7 +58,9 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: test-results-${{ matrix.os }}
-        path: '**/core-tests.trx'
+        path: |
+          **/core-tests.trx
+          **/avalonia-tests.trx
         if-no-files-found: ignore
 
   publish:


### PR DESCRIPTION
## Summary

- Add `FEBuilderGBA.Avalonia.Tests` to the `crossplatform.yml` CI workflow so data-verify headless tests run on all three platforms (Linux, macOS, Windows)
- Upload Avalonia test results as artifacts alongside Core test results
- Closes the cross-platform CI coverage gap for `--data-verify` validation infrastructure

## Context

PRs #264 and #265 implemented `--data-verify-full` with field-level cross-checking across 31 editors. The `DataVerifiableSweepTests` in `FEBuilderGBA.Avalonia.Tests` validate:

| Test | What it validates | ROM needed? |
|------|-------------------|-------------|
| `Discovery_FindsExpectedTypeCount` | >= 100 IDataVerifiable types discovered | No |
| `FieldOffsetMap_CoverageCount` | >= 30 editors have field offset maps | No |
| `NormalizeHexValueTests` (20 cases) | Signed/unsigned byte normalization | No |
| `CanInstantiate` / `GetDataReport_ReturnsNonNull` / etc. | Per-VM smoke tests | Graceful skip without ROM |
| `FieldLevelCrossCheck_AllFieldsMatch` | Byte-level field comparison | Yes (skips without ROM) |

### CI coverage before this PR

| Workflow | Core.Tests | Avalonia.Tests | E2E (ROM) |
|----------|-----------|---------------|-----------|
| `check.yml` (Windows only) | Yes (via solution `dotnet test`) | Yes (via solution) | No |
| `crossplatform.yml` (3 platforms) | Yes | **No** | No |
| `e2e-run.yml` (Windows + ROM) | No | No | Yes |

### CI coverage after this PR

| Workflow | Core.Tests | Avalonia.Tests | E2E (ROM) |
|----------|-----------|---------------|-----------|
| `check.yml` (Windows only) | Yes | Yes | No |
| `crossplatform.yml` (3 platforms) | Yes | **Yes** | No |
| `e2e-run.yml` (Windows + ROM) | No | No | Yes |

## Test plan

- [x] `NormalizeHexValueTests` pass locally (20/20)
- [x] `Discovery_FindsExpectedTypeCount` passes locally
- [x] `FieldOffsetMap_CoverageCount` passes locally (>= 30 editors)
- [ ] Cross-platform CI passes on all 3 platforms

## Closes

Part of #263 (WU12: CI integration)

---
Claude Code version: Claude Code 1.0.34 / Opus 4.6 (1M context)