### PR TITLE
feat: add IDataVerifiableView to 53 remaining editor views

### DIFF
--- a/FEBuilderGBA.Avalonia/Views/AIASMCALLTALKView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIASMCALLTALKView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class AIASMCALLTALKView : TranslatedWindow, IEditorView
+    public partial class AIASMCALLTALKView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly AIASMCALLTALKViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -91,5 +91,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/AIASMCoordinateView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIASMCoordinateView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class AIASMCoordinateView : TranslatedWindow, IEditorView
+    public partial class AIASMCoordinateView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly AIASMCoordinateViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -91,5 +91,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/AIASMRangeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIASMRangeView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class AIASMRangeView : TranslatedWindow, IEditorView
+    public partial class AIASMRangeView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly AIASMRangeViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -91,5 +91,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/AITilesView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AITilesView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class AITilesView : TranslatedWindow, IEditorView
+    public partial class AITilesView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly AITilesViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -85,5 +85,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/AIUnitsView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIUnitsView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class AIUnitsView : TranslatedWindow, IEditorView
+    public partial class AIUnitsView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly AIUnitsViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -87,5 +87,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ClassOPDemoView : TranslatedWindow, IEditorView
+    public partial class ClassOPDemoView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ClassOPDemoViewModel _vm = new();
 
@@ -53,5 +53,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ClassOPFontView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ClassOPFontView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ClassOPFontView : TranslatedWindow, IEditorView
+    public partial class ClassOPFontView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ClassOPFontViewModel _vm = new();
 
@@ -53,5 +53,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/Command85PointerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/Command85PointerView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class Command85PointerView : TranslatedWindow, IEditorView
+    public partial class Command85PointerView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly Command85PointerViewModel _vm = new();
 
@@ -53,5 +53,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/EventBattleDataFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventBattleDataFE7View.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class EventBattleDataFE7View : TranslatedWindow, IEditorView
+    public partial class EventBattleDataFE7View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventBattleDataFE7ViewModel _vm = new();
 
@@ -53,5 +53,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/EventFinalSerifFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventFinalSerifFE7View.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class EventFinalSerifFE7View : TranslatedWindow, IEditorView
+    public partial class EventFinalSerifFE7View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventFinalSerifFE7ViewModel _vm = new();
 
@@ -53,5 +53,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/EventForceSortieFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventForceSortieFE7View.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class EventForceSortieFE7View : TranslatedWindow, IEditorView
+    public partial class EventForceSortieFE7View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventForceSortieFE7ViewModel _vm = new();
 
@@ -77,5 +77,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/EventFunctionPointerFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventFunctionPointerFE7View.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class EventFunctionPointerFE7View : TranslatedWindow, IEditorView
+    public partial class EventFunctionPointerFE7View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventFunctionPointerFE7ViewModel _vm = new();
 
@@ -70,5 +70,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/EventFunctionPointerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventFunctionPointerView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class EventFunctionPointerView : TranslatedWindow, IEditorView
+    public partial class EventFunctionPointerView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventFunctionPointerViewModel _vm = new();
 
@@ -68,5 +68,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/EventMapChangeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventMapChangeView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class EventMapChangeView : TranslatedWindow, IEditorView
+    public partial class EventMapChangeView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventMapChangeViewModel _vm = new();
 
@@ -53,5 +53,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/EventMoveDataFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventMoveDataFE7View.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class EventMoveDataFE7View : TranslatedWindow, IEditorView
+    public partial class EventMoveDataFE7View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventMoveDataFE7ViewModel _vm = new();
 
@@ -68,5 +68,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/EventTalkGroupFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventTalkGroupFE7View.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class EventTalkGroupFE7View : TranslatedWindow, IEditorView
+    public partial class EventTalkGroupFE7View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventTalkGroupFE7ViewModel _vm = new();
 
@@ -68,5 +68,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/EventUnitFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventUnitFE6View.axaml.cs
@@ -8,7 +8,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class EventUnitFE6View : TranslatedWindow, IEditorView
+    public partial class EventUnitFE6View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventUnitFE6ViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -247,5 +247,6 @@ namespace FEBuilderGBA.Avalonia.Views
             if (_mapItems.Count > 0)
                 MapListBox.SelectedIndex = 0;
         }
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/EventUnitFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventUnitFE7View.axaml.cs
@@ -8,7 +8,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class EventUnitFE7View : TranslatedWindow, IEditorView
+    public partial class EventUnitFE7View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventUnitFE7ViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -247,5 +247,6 @@ namespace FEBuilderGBA.Avalonia.Views
             if (_mapItems.Count > 0)
                 MapListBox.SelectedIndex = 0;
         }
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/EventUnitView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventUnitView.axaml.cs
@@ -8,7 +8,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class EventUnitView : TranslatedWindow, IEditorView
+    public partial class EventUnitView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventUnitViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -251,5 +251,6 @@ namespace FEBuilderGBA.Avalonia.Views
             if (_mapItems.Count > 0)
                 MapListBox.SelectedIndex = 0;
         }
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ExtraUnitView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ExtraUnitView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ExtraUnitView : TranslatedWindow, IEditorView
+    public partial class ExtraUnitView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ExtraUnitViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -82,5 +82,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImageBGView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBGView.axaml.cs
@@ -8,7 +8,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ImageBGView : TranslatedWindow, IEditorView
+    public partial class ImageBGView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ImageBGViewModel _vm = new();
 
@@ -139,5 +139,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleAnimeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleAnimeView.axaml.cs
@@ -7,7 +7,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ImageBattleAnimeView : TranslatedWindow, IEditorView
+    public partial class ImageBattleAnimeView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ImageBattleAnimeViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -285,5 +285,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleBGView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleBGView.axaml.cs
@@ -9,7 +9,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ImageBattleBGView : TranslatedWindow, IEditorView
+    public partial class ImageBattleBGView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ImageBattleBGViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -231,5 +231,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImageCGFE7UView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageCGFE7UView.axaml.cs
@@ -8,7 +8,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ImageCGFE7UView : TranslatedWindow, IEditorView
+    public partial class ImageCGFE7UView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ImageCGFE7UViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -164,5 +164,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImageCGView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageCGView.axaml.cs
@@ -9,7 +9,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ImageCGView : TranslatedWindow, IEditorView
+    public partial class ImageCGView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ImageCGViewModel _vm = new();
 
@@ -202,5 +202,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImageGenericEnemyPortraitView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageGenericEnemyPortraitView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ImageGenericEnemyPortraitView : TranslatedWindow, IEditorView
+    public partial class ImageGenericEnemyPortraitView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ImageGenericEnemyPortraitViewModel _vm = new();
 
@@ -58,5 +58,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImageMagicCSACreatorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageMagicCSACreatorView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ImageMagicCSACreatorView : TranslatedWindow, IEditorView
+    public partial class ImageMagicCSACreatorView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ImageMagicCSACreatorViewModel _vm = new();
 
@@ -53,5 +53,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ImageMagicFEditorView : TranslatedWindow, IEditorView
+    public partial class ImageMagicFEditorView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ImageMagicFEditorViewModel _vm = new();
 
@@ -53,5 +53,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImageMapActionAnimationView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageMapActionAnimationView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ImageMapActionAnimationView : TranslatedWindow, IEditorView
+    public partial class ImageMapActionAnimationView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ImageMapActionAnimationViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -87,5 +87,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImagePortraitFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImagePortraitFE6View.axaml.cs
@@ -8,7 +8,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ImagePortraitFE6View : TranslatedWindow, IEditorView
+    public partial class ImagePortraitFE6View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ImagePortraitFE6ViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -174,5 +174,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImagePortraitView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImagePortraitView.axaml.cs
@@ -11,7 +11,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ImagePortraitView : TranslatedWindow, IEditorView
+    public partial class ImagePortraitView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ImagePortraitViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -597,5 +597,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImageSystemAreaView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageSystemAreaView.axaml.cs
@@ -7,7 +7,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ImageSystemAreaView : TranslatedWindow, IEditorView
+    public partial class ImageSystemAreaView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ImageSystemAreaViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -86,5 +86,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImageTSAAnime2View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageTSAAnime2View.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ImageTSAAnime2View : TranslatedWindow, IEditorView
+    public partial class ImageTSAAnime2View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ImageTSAAnime2ViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -125,5 +125,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImageTSAAnimeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageTSAAnimeView.axaml.cs
@@ -8,7 +8,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ImageTSAAnimeView : TranslatedWindow, IEditorView
+    public partial class ImageTSAAnimeView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ImageTSAAnimeViewModel _vm = new();
 
@@ -139,5 +139,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitMoveIconView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitMoveIconView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ImageUnitMoveIconView : TranslatedWindow, IEditorView
+    public partial class ImageUnitMoveIconView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ImageUnitMoveIconViewModel _vm = new();
 
@@ -53,5 +53,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ImageUnitPaletteView : TranslatedWindow, IEditorView
+    public partial class ImageUnitPaletteView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ImageUnitPaletteViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -108,5 +108,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitWaitIconView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitWaitIconView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ImageUnitWaitIconView : TranslatedWindow, IEditorView
+    public partial class ImageUnitWaitIconView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ImageUnitWaitIconViewModel _vm = new();
 
@@ -53,5 +53,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/MantAnimationView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MantAnimationView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class MantAnimationView : TranslatedWindow, IEditorView
+    public partial class MantAnimationView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly MantAnimationViewModel _vm = new();
 
@@ -53,5 +53,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/MapLoadFunctionView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapLoadFunctionView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class MapLoadFunctionView : TranslatedWindow, IEditorView
+    public partial class MapLoadFunctionView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly MapLoadFunctionViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -77,5 +77,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/MapMiniMapTerrainImageView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapMiniMapTerrainImageView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class MapMiniMapTerrainImageView : TranslatedWindow, IEditorView
+    public partial class MapMiniMapTerrainImageView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly MapMiniMapTerrainImageViewModel _vm = new();
 
@@ -53,5 +53,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/MapSettingFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapSettingFE6View.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class MapSettingFE6View : TranslatedWindow, IEditorView
+    public partial class MapSettingFE6View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly MapSettingFE6ViewModel _vm = new();
 
@@ -57,5 +57,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassSkillSystemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassSkillSystemView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class SkillAssignmentClassSkillSystemView : TranslatedWindow, IEditorView
+    public partial class SkillAssignmentClassSkillSystemView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly SkillAssignmentClassSkillSystemViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -82,5 +82,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitSkillSystemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitSkillSystemView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class SkillAssignmentUnitSkillSystemView : TranslatedWindow, IEditorView
+    public partial class SkillAssignmentUnitSkillSystemView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly SkillAssignmentUnitSkillSystemViewModel _vm = new();
 
@@ -68,5 +68,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class SkillConfigSkillSystemView : TranslatedWindow, IEditorView
+    public partial class SkillConfigSkillSystemView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly SkillConfigSkillSystemViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -82,5 +82,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/SongInstrumentDirectSoundView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongInstrumentDirectSoundView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class SongInstrumentDirectSoundView : TranslatedWindow, IEditorView
+    public partial class SongInstrumentDirectSoundView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly SongInstrumentDirectSoundViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -93,5 +93,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/SongInstrumentView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongInstrumentView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class SongInstrumentView : TranslatedWindow, IEditorView
+    public partial class SongInstrumentView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly SongInstrumentViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -205,5 +205,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/SongTrackView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongTrackView.axaml.cs
@@ -7,7 +7,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class SongTrackView : TranslatedWindow, IEditorView
+    public partial class SongTrackView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly SongTrackViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -170,5 +170,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/SoundRoomCGView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SoundRoomCGView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class SoundRoomCGView : TranslatedWindow, IEditorView
+    public partial class SoundRoomCGView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly SoundRoomCGViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -87,5 +87,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/SoundRoomFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SoundRoomFE6View.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class SoundRoomFE6View : TranslatedWindow, IEditorView
+    public partial class SoundRoomFE6View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly SoundRoomFE6ViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -93,5 +93,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/UnitActionPointerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/UnitActionPointerView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class UnitActionPointerView : TranslatedWindow, IEditorView
+    public partial class UnitActionPointerView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly UnitActionPointerViewModel _vm = new();
 
@@ -53,5 +53,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/UnitIncreaseHeightView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/UnitIncreaseHeightView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class UnitIncreaseHeightView : TranslatedWindow, IEditorView
+    public partial class UnitIncreaseHeightView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly UnitIncreaseHeightViewModel _vm = new();
 
@@ -53,5 +53,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/WorldMapPathMoveEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapPathMoveEditorView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class WorldMapPathMoveEditorView : TranslatedWindow, IEditorView
+    public partial class WorldMapPathMoveEditorView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly WorldMapPathMoveEditorViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -87,5 +87,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/WorldMapPathView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapPathView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class WorldMapPathView : TranslatedWindow, IEditorView
+    public partial class WorldMapPathView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly WorldMapPathViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -96,5 +96,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }


### PR DESCRIPTION
## Summary
Bulk sweep to add `IDataVerifiableView` interface to 53 editor Views that had corresponding IDataVerifiable ViewModels but lacked the View-side interface. This is the gate checked by `RunDataVerify()`.

## Plan Reference
Ref https://github.com/laqieer/FEBuilderGBA/issues/270#issuecomment-4125322818

## Scope
Ref #270 (partial — 53 of remaining ~171 views without IDataVerifiableView)

## Screenshots

Avalonia app with FE8U ROM loaded, showing editor sections affected by this change (PrintWindow capture):

![FEBuilderGBA main window](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/40f04622c021f02f2f6ae854414c424568b4ce17/pr-screenshots/pr273-fe6-main.png)

Data-verify results showing +24 newly verified editors:

```
Before (batch 1): 83 verified, 0 failed, 239 skipped (FE8U)
After  (batch 2): 107 verified, 0 failed, 215 skipped (FE8U)
```

## GUI Test Report

### Environment
- ROM: FE8U.gba
- Mode: `--data-verify` CLI mode

### Test Results
| Test | Expected | Actual | Status |
|------|----------|--------|--------|
| Verified count increases | >83 verified | 107 verified (+24) | PASS |
| No failures | 0 failed | 0 failed | PASS |
| No field mismatches | 0 fieldMismatches | 0 fieldMismatches | PASS |
| No regressions | 83 previous editors still pass | All still verified | PASS |

### Verdict
PASS — 24 additional editors now verified, 0 regressions.

## Test plan
- [x] Build succeeds with 0 errors
- [x] FE8U `--data-verify`: 107 verified, 0 failed, 0 fieldMismatches
- [x] No regressions from batch 1 editors
- [x] All 53 view changes follow identical pattern (add interface + DataViewModel property)

## Known limitations
- Many of the 53 newly-wired views still SKIP due to GetListCount=0 or VM issues
- ViewModel fixes deferred to future batches

Generated with Claude Code (claude-opus-4-6)