### PR TITLE
feat: fix UnitIncreaseHeightViewModel.GetListCount (batch 4)

### DIFF
--- a/FEBuilderGBA.Avalonia/ViewModels/UnitIncreaseHeightViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/UnitIncreaseHeightViewModel.cs
@@ -9,6 +9,8 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         static readonly List<EditorFormRef.FieldDef> _fields =
             EditorFormRef.DetectFields(new[] { "D0" });
 
+        const uint EntrySize = 4;
+
         uint _currentAddr;
         bool _isLoaded;
         uint _p0;
@@ -17,12 +19,53 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
         public uint P0 { get => _p0; set => SetField(ref _p0, value); }
 
+        /// <summary>
+        /// Check if the switch2 opcode pattern is present (inline version of PatchUtil.IsSwitch2Enable).
+        /// Looks for SUB + CMP ARM opcodes at switch2_address.
+        /// </summary>
+        static bool IsSwitch2Enable(ROM rom, uint switch2Addr)
+        {
+            if (switch2Addr == 0 || !U.isSafetyOffset(switch2Addr + 4)) return false;
+
+            uint extraByte = 0;
+            if (rom.u16(switch2Addr + 2) == 0x9A00)
+                extraByte = 2;
+
+            uint op1 = rom.u8(switch2Addr + 1);
+            if (op1 < 0x38 || op1 > 0x3D) return false; // SUB check
+
+            uint op2 = rom.u8(switch2Addr + 3 + extraByte);
+            if (op2 < 0x28 || op2 > 0x2D) return false; // CMP check
+
+            return true;
+        }
+
         public List<AddrResult> LoadList()
         {
             ROM rom = CoreState.ROM;
             if (rom?.RomInfo == null) return new List<AddrResult>();
+
+            uint ptrAddr = rom.RomInfo.unit_increase_height_pointer;
+            uint switch2Addr = rom.RomInfo.unit_increase_height_switch2_address;
+            if (ptrAddr == 0 || switch2Addr == 0) return new List<AddrResult>();
+            if (!IsSwitch2Enable(rom, switch2Addr)) return new List<AddrResult>();
+
+            uint baseAddr = rom.p32(ptrAddr);
+            if (!U.isSafetyOffset(baseAddr)) return new List<AddrResult>();
+
+            uint count = rom.u8(switch2Addr + 2);
+
             var result = new List<AddrResult>();
-            result.Add(new AddrResult(0, "Unit Height Adjustment", 0));
+            for (uint i = 0; i <= count; i++)
+            {
+                uint addr = baseAddr + i * EntrySize;
+                if (addr + EntrySize > (uint)rom.Data.Length) break;
+
+                uint startId = rom.u8(switch2Addr);
+                uint id = startId + i;
+                string name = U.ToHexString(id) + " Unit Height";
+                result.Add(new AddrResult(addr, name, i));
+            }
             return result;
         }
 
@@ -37,7 +80,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             IsLoaded = true;
         }
 
-        public int GetListCount() => 0;
+        public int GetListCount() => LoadList().Count;
 
         public Dictionary<string, string> GetDataReport()
         {


### PR DESCRIPTION
## Summary
Fix `UnitIncreaseHeightViewModel.GetListCount()`: was returning 0 unconditionally. Now reads count from the Switch2 table address, matching WinForms `UnitIncreaseHeightForm.ReInit()` behavior.

UnitActionPointerViewModel deferred — needs complex `SearchActionPointer` + `ReInitPointer` logic.

## Scope
Ref #270 (partial — batch 4: 1 editor)

## Screenshots

![FEBuilderGBA main window](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/40f04622c021f02f2f6ae854414c424568b4ce17/pr-screenshots/pr273-fe6-main.png)

## GUI Test Report
| Test | Expected | Actual | Status |
|------|----------|--------|--------|
| UnitIncreaseHeightView | VERIFIED | VERIFIED on FE8U | PASS |
| Build | 0 errors | 0 errors | PASS |

### Verdict
PASS

## Test plan
- [x] Build succeeds with 0 errors
- [x] UnitIncreaseHeightView now VERIFIED on FE8U
- [x] Implementation matches WinForms Switch2 pattern

Generated with Claude Code (claude-opus-4-6)