### PR TITLE
fix: add missing addr key to EventForceSortieFE7 + fix hex formatting (#270)

### DIFF
--- a/FEBuilderGBA.Avalonia/ViewModels/EventForceSortieFE7ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EventForceSortieFE7ViewModel.cs
@@ -117,11 +117,24 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         {
             return new Dictionary<string, string>
             {
-                ["UnitListPointer"] = UnitListPointer.ToString("X08"),
-                ["UnitId"] = UnitId.ToString("X02"),
-                ["Unknown1"] = Unknown1.ToString("X02"),
-                ["Unknown2"] = Unknown2.ToString("X02"),
-                ["Unknown3"] = Unknown3.ToString("X02"),
+                ["addr"] = $"0x{CurrentAddr:X08}",
+                ["UnitListPointer"] = $"0x{UnitListPointer:X08}",
+                ["UnitId"] = $"0x{UnitId:X02}",
+                ["Unknown1"] = $"0x{Unknown1:X02}",
+                ["Unknown2"] = $"0x{Unknown2:X02}",
+                ["Unknown3"] = $"0x{Unknown3:X02}",
+            };
+        }
+
+        public Dictionary<string, string> GetFieldOffsetMap()
+        {
+            return new Dictionary<string, string>
+            {
+                ["UnitListPointer"] = "u32@0x00_UnitListPointer",
+                ["UnitId"] = "u8@0x00_UnitId",
+                ["Unknown1"] = "u8@0x01_Unknown1",
+                ["Unknown2"] = "u8@0x02_Unknown2",
+                ["Unknown3"] = "u8@0x03_Unknown3",
             };
         }
 


### PR DESCRIPTION
## Summary
Fix EventForceSortieFE7ViewModel: add missing `addr` key to GetDataReport (was causing Skip), fix hex formatting to include `0x` prefix, add GetFieldOffsetMap.

## Scope
Ref #270 (partial — batch 15: reaches 150 verified in cross-ROM union)

## Screenshots
```
Cross-ROM union: 150 verified editors ✓ (target met!)
FE8U: 137, FE8J: 143, FE7J: 119, FE7U: 116, FE6: 103
All ROMs: 0 failures, 0 fieldMismatches
```

## GUI Test Report
| Test | Expected | Actual | Status |
|------|----------|--------|--------|
| EventForceSortieFE7View VERIFIED on FE7J | VERIFIED | VERIFIED | PASS |
| Cross-ROM union >= 150 | >= 150 | 150 | PASS |
| All 5 ROMs 0 fieldMismatches | 0 | 0 | PASS |

Verdict: PASS

## Test plan
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` — 4186 pass
- [x] Cross-ROM union: 150 verified editors
- [x] All 5 ROMs: 0 failures, 0 fieldMismatches

Generated with Claude Code (claude-opus-4-6)