### PR TITLE
fix: enforce relevant editor screenshots in PR workflow

### DIFF
--- a/DEVELOPMENT-WORKFLOW.md
+++ b/DEVELOPMENT-WORKFLOW.md
@@ -247,10 +247,14 @@ Ref #M (partial — <what remains>)
 
 ## Screenshots
 <!-- For feat/fix PRs: MANDATORY — replace this comment with REAL GUI screenshot(s).
-     Screenshots MUST be captured from the actual running application (e.g., via PrintWindow API
-     or MCP computer-use). Fabricated images (e.g., DrawString on Bitmap) are NOT acceptable.
-     Image URLs MUST be permanent — use blob/master/pr-screenshots/ paths or GitHub asset uploads.
-     NEVER use blob/{feature-branch}/ URLs — they 404 after branch deletion.
+     CRITICAL: Screenshots MUST show the SPECIFIC affected editor with populated data.
+     NEVER use the generic main Avalonia window as proof — it proves nothing about the fix.
+     Capture steps:
+       1. Launch: dotnet run --project FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj -c Release -- --rom roms/FE8U.gba &
+       2. Navigate: Use PowerShell UIAutomation to click the specific editor button
+       3. Capture: dotnet run --project tools/WinCapture -c Release -- "Editor Title" screenshot.png
+       4. Commit to pr-screenshots/ on master, reference via raw.githubusercontent.com
+     Fabricated images are NOT acceptable. Generic main window screenshots are NOT acceptable.
      For docs/chore PRs: This entire section may be deleted. -->
 
 ## GUI Test Report
@@ -525,6 +529,10 @@ A `feat` or `fix` PR without visual proof is incomplete. Copilot CLI reviews are
 ### Don't: Fabricate screenshots
 Drawing text on a Bitmap with `System.Drawing.DrawString` (e.g., "VALIDATION PASSED" in green on black) is NOT a screenshot — it proves nothing about the GUI working. It's cheating the review process.
 **Do:** Use `PrintWindow` API to capture real window content. It works even with a locked screen. Combine with PowerShell `UIAutomationClient` for headless navigation.
+
+### Don't: Use the generic main Avalonia window as a screenshot
+The main FEBuilderGBA hub window with category buttons proves nothing about whether a specific editor fix works. A PR fixing MapTerrain needs a MapTerrain screenshot, not the main menu.
+**Do:** Navigate to the SPECIFIC affected editor using UIAutomation (`powershell Add-Type -AssemblyName UIAutomationClient; $btn.GetCurrentPattern([InvokePattern]::Pattern).Invoke()`), then capture THAT editor window with `tools/WinCapture`. Every feat/fix screenshot must show populated data in the changed editor.
 
 ### Don't: Use feature branch blob URLs for screenshot images
 `blob/{feature-branch}/file.png?raw=1` becomes a 404 after the branch is deleted post-merge. Every screenshot in the PR breaks permanently.

--- a/scripts/validate-pr-screenshots.sh
+++ b/scripts/validate-pr-screenshots.sh
@@ -70,5 +70,45 @@ if [ -n "$VIOLATIONS" ]; then
   exit 1
 fi
 
-echo "VALIDATION PASSED: No feature-branch blob URLs found in PR description"
+echo "CHECK 1 PASSED: No feature-branch blob URLs found"
+
+# --- CHECK 2: feat/fix PRs must have at least one rendered image ---
+# Get PR title
+PR_TITLE=""
+if command -v gh &>/dev/null; then
+  PR_TITLE=$(gh pr view "$PR_NUMBER" -R "$REPO" --json title --jq .title 2>/dev/null || echo "")
+fi
+
+if echo "$PR_TITLE" | grep -qiE "^(feat|fix):"; then
+  IMAGE_COUNT=$(echo "$BODY" | grep -cE '!\[.*\]\(https://raw\.githubusercontent\.com/|!\[.*\]\(https://github\.com/.*assets/|<img.*src=' || true)
+
+  if [ "$IMAGE_COUNT" -eq 0 ]; then
+    echo ""
+    echo "ERROR: feat/fix PR #${PR_NUMBER} has NO rendered screenshots!"
+    echo ""
+    echo "Every feat/fix PR that modifies FEBuilderGBA.Avalonia/ MUST include"
+    echo "at least one screenshot of the SPECIFIC affected editor with data."
+    echo ""
+    echo "Steps:"
+    echo "  1. Launch app with ROM"
+    echo "  2. Use UIAutomation to navigate to the affected editor"
+    echo "  3. Capture via: dotnet run --project tools/WinCapture -c Release -- \"Title\" file.png"
+    echo "  4. Commit to pr-screenshots/ and reference via raw.githubusercontent.com"
+    echo ""
+    echo "VALIDATION FAILED: Missing screenshots"
+    exit 1
+  fi
+
+  # Warn about generic main window screenshots
+  if echo "$BODY" | grep -qiE 'main.window|FEBuilderGBA.*main|proof\.png'; then
+    echo "WARNING: PR may contain a generic main window screenshot."
+    echo "Ensure screenshots show the SPECIFIC affected editor, not just the main window."
+  fi
+
+  echo "CHECK 2 PASSED: Found $IMAGE_COUNT screenshot(s) in feat/fix PR"
+else
+  echo "CHECK 2 SKIPPED: Not a feat/fix PR (title: $PR_TITLE)"
+fi
+
+echo "VALIDATION PASSED"
 exit 0


### PR DESCRIPTION
## Summary
Add enforcement to prevent generic main window screenshots in feat/fix PRs:
- Enhanced `validate-pr-screenshots.sh` to check for rendered images in feat/fix PRs
- Added anti-pattern in DEVELOPMENT-WORKFLOW.md: "Don't use the generic main Avalonia window"
- Added mandatory step 9.5 in dev-flow skill: capture SPECIFIC editor before opening PR
- Updated PR template comments to require specific editor screenshots

## Scope
Closes quality issue: 7 of 10 feat/fix PRs in the #270 session had missing or irrelevant screenshots

## Test plan
- [x] validate-pr-screenshots.sh checks for rendered images in feat/fix PRs
- [x] DEVELOPMENT-WORKFLOW.md has explicit anti-pattern and capture instructions
- [x] dev-flow skill has step 9.5 with screenshot capture before PR creation

Generated with Claude Code (claude-opus-4-6)