### PR TITLE
docs: update stale editor count references to 325

### DIFF
--- a/FEBuilderGBA.E2ETests/Tests/AvaloniaScreenshotTests.cs
+++ b/FEBuilderGBA.E2ETests/Tests/AvaloniaScreenshotTests.cs
@@ -17,7 +17,7 @@ namespace FEBuilderGBA.E2ETests.Tests
 
         /// <summary>
         /// Captures screenshots of all editors via --screenshot-all.
-        /// Verifies at least 100 PNG files are created (of 323 total editors).
+        /// Verifies at least 100 PNG files are created (of 325 total editors).
         /// </summary>
         [SkippableTheory]
         [MemberData(nameof(RomLocator.AllRoms), MemberType = typeof(RomLocator))]


### PR DESCRIPTION
## Summary
- Update stale editor count "323" to "325" in `AvaloniaScreenshotTests.cs` XML doc comment (line 20)
- Only one stale reference found; README.md and `AvaloniaAllEditorsCoverageTests.cs` already had the correct value of 325

Closes #312

## Test plan
- [x] Grep for "323 editors", "324 editors", "323 total", "324 total" across codebase -- only one hit found
- [x] Fix the single stale reference in `FEBuilderGBA.E2ETests/Tests/AvaloniaScreenshotTests.cs`
- [x] Verify README.md already says 325 -- confirmed
- [x] Verify `AvaloniaAllEditorsCoverageTests.cs` already says 325 -- confirmed
- [x] Run `dotnet test FEBuilderGBA.Core.Tests` -- 1209 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Code v1.0.33 / claude-opus-4-6