### PR TITLE
fix: add retry logic to E2E ROM download step (#334)

### DIFF
--- a/.github/workflows/e2e-run.yml
+++ b/.github/workflows/e2e-run.yml
@@ -85,12 +85,12 @@ jobs:
             if ($attempt -gt 1) {
               Write-Host "Cleaning up stale artifacts..."
               if (Test-Path $zip) {
-                Remove-Item $zip -Force
+                Remove-Item $zip -Force -ErrorAction Stop
                 Write-Host "  Removed stale $zip"
               }
               $romsCleanDir = "${{ github.workspace }}\roms"
               if (Test-Path $romsCleanDir) {
-                Remove-Item $romsCleanDir -Recurse -Force
+                Remove-Item $romsCleanDir -Recurse -Force -ErrorAction Stop
                 Write-Host "  Removed stale $romsCleanDir"
               }
             }
@@ -111,6 +111,14 @@ jobs:
             Write-Host "Downloaded $zipSize bytes."
 
             # ---- Validate zip header -------------------------------------------
+            if ($zipSize -lt 4) {
+              Write-Host "##[warning]Attempt $attempt : Downloaded file is too small ($zipSize bytes) to be a valid zip."
+              if ($attempt -lt $maxAttempts) {
+                Write-Host "Retrying in $($backoffSeconds[$attempt]) seconds..."
+                Start-Sleep -Seconds $backoffSeconds[$attempt]
+              }
+              continue
+            }
             $header = [System.IO.File]::ReadAllBytes($zip)[0..3]
             if ($header[0] -ne 0x50 -or $header[1] -ne 0x4B) {
               Write-Host "##[warning]Attempt $attempt : Downloaded file is not a valid zip archive."
@@ -127,15 +135,19 @@ jobs:
             Write-Host ""
             Write-Host "=== Zip contents ==="
             $zipCorrupt = $false
+            $za = $null
             try {
               $za = [System.IO.Compression.ZipFile]::OpenRead($zip)
               foreach ($entry in $za.Entries) {
                 Write-Host ("  {0,-20}  {1,12:N0} bytes" -f $entry.FullName, $entry.Length)
               }
-              $za.Dispose()
             } catch {
               Write-Host "##[warning]Attempt $attempt : Zip is corrupt: $($_.Exception.Message)"
               $zipCorrupt = $true
+            } finally {
+              if ($null -ne $za) {
+                $za.Dispose()
+              }
             }
             if ($zipCorrupt) {
               if ($attempt -lt $maxAttempts) {

--- a/.github/workflows/e2e-run.yml
+++ b/.github/workflows/e2e-run.yml
@@ -71,65 +71,122 @@ jobs:
         run: |
           $zip = "$env:TEMP\roms.zip"
 
-          # ---- Download -------------------------------------------------------
-          Write-Host "Downloading roms.zip..."
-          try {
-            Invoke-WebRequest -Uri $env:ROMS_URL -OutFile $zip -ErrorAction Stop
-          } catch {
-            Write-Host "##[error]ROM download failed (network/HTTP error): $($_.Exception.Message)"
-            Write-Host "Update the ROMS_URL secret and re-run to enable ROM-based tests."
-            exit 1
-          }
-          $zipSize = (Get-Item $zip).Length
-          Write-Host "Downloaded $zipSize bytes."
-
-          # ---- Validate zip ---------------------------------------------------
-          $header = [System.IO.File]::ReadAllBytes($zip)[0..3]
-          if ($header[0] -ne 0x50 -or $header[1] -ne 0x4B) {
-            Write-Host "##[warning]Downloaded file is not a valid zip archive."
-            Write-Host "  Magic bytes: $([BitConverter]::ToString($header))  (expected 50-4B-03-04)"
-            Write-Host "  File size : $zipSize bytes"
-            Write-Host "ROM-based tests will be skipped this run."
-            exit 0
-          }
+          $maxAttempts = 3
+          $backoffSeconds = @(0, 10, 30)  # no wait before attempt 1, 10s after fail 1, 30s after fail 2
+          $success = $false
 
           Add-Type -AssemblyName System.IO.Compression.FileSystem
-          Write-Host ""
-          Write-Host "=== Zip contents ==="
-          try {
-            $za = [System.IO.Compression.ZipFile]::OpenRead($zip)
-            foreach ($entry in $za.Entries) {
-              Write-Host ("  {0,-20}  {1,12:N0} bytes" -f $entry.FullName, $entry.Length)
+
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Write-Host ""
+            Write-Host "========== Attempt $attempt of $maxAttempts =========="
+
+            # ---- Clean up stale artifacts from previous attempt ----------------
+            if ($attempt -gt 1) {
+              Write-Host "Cleaning up stale artifacts..."
+              if (Test-Path $zip) {
+                Remove-Item $zip -Force
+                Write-Host "  Removed stale $zip"
+              }
+              $romsCleanDir = "${{ github.workspace }}\roms"
+              if (Test-Path $romsCleanDir) {
+                Remove-Item $romsCleanDir -Recurse -Force
+                Write-Host "  Removed stale $romsCleanDir"
+              }
             }
-            $za.Dispose()
-          } catch {
-            Write-Host "##[warning]Zip is corrupt: $($_.Exception.Message)"
-            Write-Host "ROM-based tests will be skipped this run."
-            exit 0
+
+            # ---- Download ------------------------------------------------------
+            Write-Host "Downloading roms.zip..."
+            try {
+              Invoke-WebRequest -Uri $env:ROMS_URL -OutFile $zip -ErrorAction Stop
+            } catch {
+              Write-Host "##[warning]Attempt $attempt : ROM download failed (network/HTTP error): $($_.Exception.Message)"
+              if ($attempt -lt $maxAttempts) {
+                Write-Host "Retrying in $($backoffSeconds[$attempt]) seconds..."
+                Start-Sleep -Seconds $backoffSeconds[$attempt]
+              }
+              continue
+            }
+            $zipSize = (Get-Item $zip).Length
+            Write-Host "Downloaded $zipSize bytes."
+
+            # ---- Validate zip header -------------------------------------------
+            $header = [System.IO.File]::ReadAllBytes($zip)[0..3]
+            if ($header[0] -ne 0x50 -or $header[1] -ne 0x4B) {
+              Write-Host "##[warning]Attempt $attempt : Downloaded file is not a valid zip archive."
+              Write-Host "  Magic bytes: $([BitConverter]::ToString($header))  (expected 50-4B-03-04)"
+              Write-Host "  File size : $zipSize bytes"
+              if ($attempt -lt $maxAttempts) {
+                Write-Host "Retrying in $($backoffSeconds[$attempt]) seconds..."
+                Start-Sleep -Seconds $backoffSeconds[$attempt]
+              }
+              continue
+            }
+
+            # ---- List zip contents ---------------------------------------------
+            Write-Host ""
+            Write-Host "=== Zip contents ==="
+            $zipCorrupt = $false
+            try {
+              $za = [System.IO.Compression.ZipFile]::OpenRead($zip)
+              foreach ($entry in $za.Entries) {
+                Write-Host ("  {0,-20}  {1,12:N0} bytes" -f $entry.FullName, $entry.Length)
+              }
+              $za.Dispose()
+            } catch {
+              Write-Host "##[warning]Attempt $attempt : Zip is corrupt: $($_.Exception.Message)"
+              $zipCorrupt = $true
+            }
+            if ($zipCorrupt) {
+              if ($attempt -lt $maxAttempts) {
+                Write-Host "Retrying in $($backoffSeconds[$attempt]) seconds..."
+                Start-Sleep -Seconds $backoffSeconds[$attempt]
+              }
+              continue
+            }
+
+            # ---- Extract -------------------------------------------------------
+            Write-Host ""
+            Write-Host "Extracting roms.zip..."
+            $extractFailed = $false
+            try {
+              Expand-Archive -Path $zip -DestinationPath "${{ github.workspace }}" -Force -ErrorAction Stop
+            } catch {
+              Write-Host "##[warning]Attempt $attempt : Failed to extract roms.zip: $($_.Exception.Message)"
+              $extractFailed = $true
+            }
+            if ($extractFailed) {
+              if ($attempt -lt $maxAttempts) {
+                Write-Host "Retrying in $($backoffSeconds[$attempt]) seconds..."
+                Start-Sleep -Seconds $backoffSeconds[$attempt]
+              }
+              continue
+            }
+
+            # ---- Verify target ROM ---------------------------------------------
+            $romsDir = "${{ github.workspace }}\roms"
+            $target  = "${{ inputs.rom-name }}.gba"
+            $path    = Join-Path $romsDir $target
+            if (Test-Path $path) {
+              $size = (Get-Item $path).Length
+              Write-Host "  [OK] $target  ($size bytes)"
+              $success = $true
+              break
+            } else {
+              Write-Host "##[warning]Attempt $attempt : Target ROM $target not found after extraction."
+              if ($attempt -lt $maxAttempts) {
+                Write-Host "Retrying in $($backoffSeconds[$attempt]) seconds..."
+                Start-Sleep -Seconds $backoffSeconds[$attempt]
+              }
+              continue
+            }
           }
 
-          # ---- Extract --------------------------------------------------------
-          Write-Host ""
-          Write-Host "Extracting roms.zip..."
-          try {
-            Expand-Archive -Path $zip -DestinationPath "${{ github.workspace }}" -Force -ErrorAction Stop
-          } catch {
-            Write-Host "##[warning]Failed to extract roms.zip: $($_.Exception.Message)"
-            Write-Host "ROM-based tests will be skipped this run."
-            exit 0
-          }
-
-          # ---- Verify target ROM -----------------------------------------------
-          $romsDir = "${{ github.workspace }}\roms"
-          $target  = "${{ inputs.rom-name }}.gba"
-          $path    = Join-Path $romsDir $target
-          if (Test-Path $path) {
-            $size = (Get-Item $path).Length
-            Write-Host "  [OK] $target  ($size bytes)"
-          } else {
-            Write-Host "##[warning]Target ROM $target not found after extraction."
-            Write-Host "ROM tests will be skipped."
-            exit 0
+          if (-not $success) {
+            Write-Host ""
+            Write-Host "##[error]ROM download failed after $maxAttempts attempts. All failure modes exhausted."
+            Write-Host "Update the ROMS_URL secret and re-run to enable ROM-based tests."
+            exit 1
           }
 
       # ---------------------------------------------------------------- Filter ROMs (keep only target)


### PR DESCRIPTION
## Summary
- Wraps the full ROM download pipeline (download → validate zip → list contents → extract → verify target ROM) in a retry loop with 3 attempts and exponential backoff (10s, 30s)
- Cleans up stale artifacts (`roms.zip`, `roms/` directory) between retries so each attempt starts fresh
- All failure modes (HTTP error, invalid zip, corrupt zip, extraction failure, missing ROM) now trigger retries instead of silently exiting 0
- After all retries exhausted, exits with `exit 1` to surface the failure — no more hidden skips

## Plan Reference
Implements the plan from https://github.com/laqieer/FEBuilderGBA/issues/334#issuecomment-4206492928

## Scope
Closes #334

## Test plan
- [x] Verified retry loop covers all 5 failure modes (HTTP error, invalid zip header, corrupt zip, extract failure, missing ROM)
- [x] Verified cleanup of stale artifacts between attempts (removes $zip and roms\ directory)
- [x] Verified backoff delays: 0s before attempt 1, 10s after failure 1, 30s after failure 2
- [x] Verified success path breaks out of loop immediately on target ROM verification
- [x] Verified `exit 1` after all attempts exhausted (no silent `exit 0`)
- [x] No other workflow steps modified
- [x] Workflow validates: `Invoke-WebRequest` is still the download mechanism, `Expand-Archive` for extraction

## Known limitations
- Retries all error types uniformly (no distinction between transient 500 vs permanent 404) — acceptable since the URL is a secret and most failures are transient

Generated with Claude Code (claude-opus-4-6)