### PR TITLE
chore: remove unused using in ClassEditorMoveCostJumpTests (#346 follow-up)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ClassEditorMoveCostJumpTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ClassEditorMoveCostJumpTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using FEBuilderGBA;


### PR DESCRIPTION
Tiny follow-up cleanup. PR #346's separate rename commit removed `using System.Collections.Generic;` from `ClassEditorMoveCostJumpTests.cs`, but the auto-merge fired before that commit reached origin's PR head, so master still carries the unused using. Copilot CLI's post-merge re-review flagged this.

Drops the line; nothing else changes.

Ref #344

## Test plan
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests/FEBuilderGBA.Avalonia.Tests.csproj --filter "FullyQualifiedName~ClassEditorMoveCostJumpTests"` still passes (8/8)
- [x] No new warnings

---
Generated with Claude Code (claude-opus-4-7)