### PR TITLE
feat(gap-sweep): Phase 2 field-label diff sweep (#374)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/LabelDiffScannerTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/LabelDiffScannerTests.cs
@@ -1,0 +1,573 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Phase 2 tests — LabelDiffScanner label extraction + diff + formatting. (#374)
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using FEBuilderGBA.Avalonia.GapSweep;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests.GapSweep;
+
+/// <summary>
+/// Tests for <see cref="LabelDiffScanner"/>. We mostly drive the scanner via
+/// in-memory source / XML strings so the tests are hermetic. A handful of
+/// repo-driven tests confirm the live-pair extraction picks up labels from
+/// real Designer.cs / .axaml files.
+/// </summary>
+public class LabelDiffScannerTests
+{
+    // =====================================================================
+    // Normalize — strips trailing colons, collapses whitespace, lowercases,
+    // and removes mnemonic markers (& for WF, _ for AV).
+    // =====================================================================
+
+    [Fact]
+    public void Normalize_TrimsLeadingAndTrailingWhitespace()
+    {
+        Assert.Equal("name", LabelDiffScanner.Normalize("  Name  "));
+    }
+
+    [Fact]
+    public void Normalize_StripsTrailingColon()
+    {
+        Assert.Equal("name", LabelDiffScanner.Normalize("Name:"));
+    }
+
+    [Fact]
+    public void Normalize_StripsMultipleTrailingColonsAndWhitespace()
+    {
+        // Pathological but legal: "  Name :  : " should still collapse to "name".
+        Assert.Equal("name", LabelDiffScanner.Normalize("  Name :  : "));
+    }
+
+    [Fact]
+    public void Normalize_CollapsesInternalWhitespace()
+    {
+        Assert.Equal("first name", LabelDiffScanner.Normalize("First   Name"));
+    }
+
+    [Fact]
+    public void Normalize_Lowercases()
+    {
+        Assert.Equal("save", LabelDiffScanner.Normalize("SAVE"));
+    }
+
+    [Fact]
+    public void Normalize_StripsWfMnemonicAmpersand()
+    {
+        // WinForms uses & for keyboard mnemonics; Avalonia uses _. Both must
+        // normalise to the same key so cross-platform-equivalent labels match.
+        Assert.Equal("save", LabelDiffScanner.Normalize("&Save"));
+    }
+
+    [Fact]
+    public void Normalize_StripsAvMnemonicUnderscore()
+    {
+        Assert.Equal("save", LabelDiffScanner.Normalize("_Save"));
+    }
+
+    [Fact]
+    public void Normalize_MnemonicAndColonTogether()
+    {
+        // WF designer literal: "&Save:" → "save"
+        Assert.Equal("save", LabelDiffScanner.Normalize("&Save:"));
+    }
+
+    [Fact]
+    public void Normalize_AllVariantsCollideToSameKey()
+    {
+        // The core property: every reasonable cross-platform spelling of the
+        // SAME label collides to the same set key.
+        string baseline = LabelDiffScanner.Normalize("Save");
+        Assert.Equal(baseline, LabelDiffScanner.Normalize("save"));
+        Assert.Equal(baseline, LabelDiffScanner.Normalize("Save:"));
+        Assert.Equal(baseline, LabelDiffScanner.Normalize("&Save"));
+        Assert.Equal(baseline, LabelDiffScanner.Normalize("_Save"));
+        Assert.Equal(baseline, LabelDiffScanner.Normalize("  Save  "));
+        Assert.Equal(baseline, LabelDiffScanner.Normalize("SAVE"));
+    }
+
+    [Fact]
+    public void Normalize_NullOrEmpty_ReturnsEmpty()
+    {
+        Assert.Equal(string.Empty, LabelDiffScanner.Normalize(""));
+        Assert.Equal(string.Empty, LabelDiffScanner.Normalize(null!));
+    }
+
+    // =====================================================================
+    // ExtractWfLabelsFromSource — pulls `.Text = "..."` from designer code
+    // when the LHS is a recognised label-host control.
+    // =====================================================================
+
+    [Fact]
+    public void ExtractWfLabels_CountsLabelTextAssignments()
+    {
+        string src = @"
+namespace X {
+    partial class F {
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label3;
+        void Init() {
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.label1.Text = ""Hello"";
+            this.label2.Text = ""World"";
+            this.label3.Text = ""!"";
+        }
+    }
+}";
+        var labels = LabelDiffScanner.ExtractWfLabelsFromSource(src);
+        Assert.Equal(3, labels.Count);
+        Assert.Contains("Hello", labels);
+        Assert.Contains("World", labels);
+        Assert.Contains("!", labels);
+    }
+
+    [Fact]
+    public void ExtractWfLabels_PropertyInitializerSyntax()
+    {
+        // Hand-coded forms sometimes use `new Label { Text = "X" }` instead of
+        // the assignment-statement designer style.
+        string src = @"
+namespace X {
+    class F {
+        void Init() {
+            var hello = new System.Windows.Forms.Label { Text = ""Hello"" };
+            var world = new System.Windows.Forms.Button { Text = ""World"" };
+        }
+    }
+}";
+        var labels = LabelDiffScanner.ExtractWfLabelsFromSource(src);
+        Assert.Equal(2, labels.Count);
+        Assert.Contains("Hello", labels);
+        Assert.Contains("World", labels);
+    }
+
+    [Fact]
+    public void ExtractWfLabels_SkipsNonLabelHostTypes()
+    {
+        // TextBox.Text and ComboBox.Text are DATA, not labels — must be excluded.
+        // PictureBox doesn't have a meaningful Text but a designer might still
+        // assign to it; we ignore that case too.
+        string src = @"
+namespace X {
+    partial class F {
+        private System.Windows.Forms.TextBox textBox1;
+        private System.Windows.Forms.ComboBox comboBox1;
+        private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.Label label1;
+        void Init() {
+            this.textBox1 = new System.Windows.Forms.TextBox();
+            this.comboBox1 = new System.Windows.Forms.ComboBox();
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.textBox1.Text = ""DATA-1"";
+            this.comboBox1.Text = ""DATA-2"";
+            this.pictureBox1.Text = ""DATA-3"";
+            this.label1.Text = ""REAL LABEL"";
+        }
+    }
+}";
+        var labels = LabelDiffScanner.ExtractWfLabelsFromSource(src);
+        Assert.Single(labels);
+        Assert.Equal("REAL LABEL", labels[0]);
+    }
+
+    [Fact]
+    public void ExtractWfLabels_GroupBoxAndButtonAndCheckBoxAndRadioButtonAndTabPage()
+    {
+        // All five non-Label host types that also count.
+        string src = @"
+namespace X {
+    partial class F {
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.CheckBox checkBox1;
+        private System.Windows.Forms.RadioButton radioButton1;
+        private System.Windows.Forms.TabPage tabPage1;
+        void Init() {
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.button1 = new System.Windows.Forms.Button();
+            this.checkBox1 = new System.Windows.Forms.CheckBox();
+            this.radioButton1 = new System.Windows.Forms.RadioButton();
+            this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.groupBox1.Text = ""G"";
+            this.button1.Text = ""B"";
+            this.checkBox1.Text = ""C"";
+            this.radioButton1.Text = ""R"";
+            this.tabPage1.Text = ""T"";
+        }
+    }
+}";
+        var labels = LabelDiffScanner.ExtractWfLabelsFromSource(src);
+        Assert.Equal(5, labels.Count);
+        Assert.Equal(new[] { "G", "B", "C", "R", "T" }, labels);
+    }
+
+    [Fact]
+    public void ExtractWfLabels_EmptyStringSkipped()
+    {
+        // Empty literals carry no signal — must be skipped (otherwise the
+        // diff would treat "" as a label and produce noise).
+        string src = @"
+namespace X {
+    partial class F {
+        private System.Windows.Forms.Label label1;
+        void Init() {
+            this.label1 = new System.Windows.Forms.Label();
+            this.label1.Text = """";
+        }
+    }
+}";
+        var labels = LabelDiffScanner.ExtractWfLabelsFromSource(src);
+        Assert.Empty(labels);
+    }
+
+    // =====================================================================
+    // ExtractAvLabelsFromDocument — pulls Text/Content/Header/ToolTip/
+    // Watermark literals from .axaml.
+    // =====================================================================
+
+    [Fact]
+    public void ExtractAvLabels_ButtonContentAndTextBoxWatermark()
+    {
+        string xml = @"<UserControl xmlns='https://github.com/avaloniaui'>
+  <StackPanel>
+    <Button Content='Save' />
+    <TextBox Watermark='search' />
+  </StackPanel>
+</UserControl>";
+        var labels = LabelDiffScanner.ExtractAvLabelsFromDocument(XDocument.Parse(xml));
+        Assert.Equal(2, labels.Count);
+        Assert.Contains("Save", labels);
+        Assert.Contains("search", labels);
+    }
+
+    [Fact]
+    public void ExtractAvLabels_SkipsBindings()
+    {
+        // Markup-extension values (any value starting with `{`) must be
+        // excluded — they're data references, not label text.
+        string xml = @"<UserControl xmlns='https://github.com/avaloniaui'>
+  <StackPanel>
+    <TextBlock Text='{Binding Name}' />
+    <Button Content='{StaticResource OkText}' />
+    <Button Content='Real Text' />
+  </StackPanel>
+</UserControl>";
+        var labels = LabelDiffScanner.ExtractAvLabelsFromDocument(XDocument.Parse(xml));
+        Assert.Single(labels);
+        Assert.Equal("Real Text", labels[0]);
+    }
+
+    [Fact]
+    public void ExtractAvLabels_SkipsTemplateContent()
+    {
+        // Anything inside <DataTemplate> or <Style> is template content,
+        // not realised label text. Must be excluded.
+        string xml = @"<UserControl xmlns='https://github.com/avaloniaui'>
+  <UserControl.Styles>
+    <Style>
+      <Setter Property='Content' Value='styled' />
+    </Style>
+  </UserControl.Styles>
+  <ListBox>
+    <ListBox.ItemTemplate>
+      <DataTemplate>
+        <StackPanel>
+          <Button Content='Per-item Save' />
+        </StackPanel>
+      </DataTemplate>
+    </ListBox.ItemTemplate>
+  </ListBox>
+  <Button Content='Outer Save' />
+</UserControl>";
+        var labels = LabelDiffScanner.ExtractAvLabelsFromDocument(XDocument.Parse(xml));
+        Assert.Single(labels);
+        Assert.Equal("Outer Save", labels[0]);
+    }
+
+    [Fact]
+    public void ExtractAvLabels_ToolTipLiteralCountedToolTipBindingSkipped()
+    {
+        string xml = @"<UserControl xmlns='https://github.com/avaloniaui'>
+  <StackPanel>
+    <Button ToolTip='Click to save' />
+    <Button ToolTip='{Binding TipText}' />
+  </StackPanel>
+</UserControl>";
+        var labels = LabelDiffScanner.ExtractAvLabelsFromDocument(XDocument.Parse(xml));
+        Assert.Single(labels);
+        Assert.Equal("Click to save", labels[0]);
+    }
+
+    [Fact]
+    public void ExtractAvLabels_HeaderAndExpanderHeader()
+    {
+        string xml = @"<UserControl xmlns='https://github.com/avaloniaui'>
+  <TabControl>
+    <TabItem Header='Stats' />
+    <Expander Header='Advanced'>
+      <TextBlock Text='Body text' />
+    </Expander>
+  </TabControl>
+</UserControl>";
+        var labels = LabelDiffScanner.ExtractAvLabelsFromDocument(XDocument.Parse(xml));
+        Assert.Equal(3, labels.Count);
+        Assert.Contains("Stats", labels);
+        Assert.Contains("Advanced", labels);
+        Assert.Contains("Body text", labels);
+    }
+
+    // =====================================================================
+    // ComputeDiff — the set-difference algorithm, case- and mnemonic-insensitive.
+    // =====================================================================
+
+    [Fact]
+    public void ComputeDiff_BasicWfOnlyAndAvOnly()
+    {
+        var pair = new EditorPair("TestForm", null, "TestView", null,
+            MatchMethod.ListParityHelper, Confidence.High);
+        var wfLabels = new[] { "Name:", "Class:", "HP" };
+        var avLabels = new[] { "Name", "Speed" };
+        var row = LabelDiffScanner.ComputeDiff(pair, wfLabels, avLabels);
+        // "Name:" and "Name" normalise the same → Common.
+        // "Class:" only on WF → WfOnly.
+        // "HP" only on WF → WfOnly.
+        // "Speed" only on AV → AvOnly.
+        Assert.Equal(2, row.WfOnlyLabels.Count);
+        Assert.Contains("Class:", row.WfOnlyLabels);
+        Assert.Contains("HP", row.WfOnlyLabels);
+        Assert.Single(row.AvOnlyLabels);
+        Assert.Equal("Speed", row.AvOnlyLabels[0]);
+        Assert.Single(row.CommonLabels);
+        // Common preserves the FIRST occurrence (WF side, since it's iterated first).
+        Assert.Equal("Name:", row.CommonLabels[0]);
+    }
+
+    [Fact]
+    public void ComputeDiff_MnemonicEquivalenceCrossPlatform()
+    {
+        // The regression-grade case: WF "&Save", AV "_Save" must collide.
+        // The plain "Save" variant on a third platform also collides.
+        var pair = new EditorPair("X", null, "Y", null,
+            MatchMethod.Heuristic, Confidence.High);
+        var wfLabels = new[] { "&Save", "&Cancel" };
+        var avLabels = new[] { "_Save", "Save" };
+        var row = LabelDiffScanner.ComputeDiff(pair, wfLabels, avLabels);
+        // "&Save" / "_Save" / "Save" all normalise to "save" — one Common row.
+        // "&Cancel" only on WF → one WfOnly row.
+        Assert.Single(row.CommonLabels);
+        Assert.Single(row.WfOnlyLabels);
+        Assert.Equal("&Cancel", row.WfOnlyLabels[0]);
+        Assert.Empty(row.AvOnlyLabels);
+    }
+
+    [Fact]
+    public void ComputeDiff_PreservesOriginalCasing()
+    {
+        // The diff key is lowercased but the report must show the ORIGINAL
+        // casing from the first occurrence on each side.
+        var pair = new EditorPair("X", null, "Y", null,
+            MatchMethod.Heuristic, Confidence.High);
+        var wfLabels = new[] { "ATTACK Power" };
+        var avLabels = new[] { "Defense" };
+        var row = LabelDiffScanner.ComputeDiff(pair, wfLabels, avLabels);
+        Assert.Equal("ATTACK Power", row.WfOnlyLabels[0]);
+        Assert.Equal("Defense", row.AvOnlyLabels[0]);
+    }
+
+    [Fact]
+    public void ComputeDiff_EmptyWfLabels_ProducesEmptyWfOnly()
+    {
+        // Edge case: WF designer has no label assignments → WfOnly is empty.
+        var pair = new EditorPair("Stub", null, "Stub", null,
+            MatchMethod.Heuristic, Confidence.High);
+        var row = LabelDiffScanner.ComputeDiff(pair, Array.Empty<string>(), new[] { "Hello" });
+        Assert.Empty(row.WfOnlyLabels);
+        Assert.Single(row.AvOnlyLabels);
+        Assert.Empty(row.CommonLabels);
+    }
+
+    [Fact]
+    public void ComputeDiff_DuplicateLabelsAreDeduplicatedViaNormalisation()
+    {
+        // A designer might emit the same label twice (e.g. two GroupBox
+        // headers both reading "Name:"). The Common list de-dupes via the
+        // normalised key.
+        var pair = new EditorPair("X", null, "Y", null,
+            MatchMethod.Heuristic, Confidence.High);
+        var wfLabels = new[] { "Name:", "Name:", "Class" };
+        var avLabels = new[] { "Name" };
+        var row = LabelDiffScanner.ComputeDiff(pair, wfLabels, avLabels);
+        Assert.Single(row.CommonLabels);
+        Assert.Single(row.WfOnlyLabels);
+        Assert.Equal("Class", row.WfOnlyLabels[0]);
+    }
+
+    // =====================================================================
+    // FormatReport — exercises the markdown structure end-to-end.
+    // =====================================================================
+
+    [Fact]
+    public void FormatReport_OutputsHeaderAndSummary()
+    {
+        // Empty rows still produce a well-formed report skeleton.
+        string report = LabelDiffScanner.FormatReport(Array.Empty<LabelDiffRow>());
+        Assert.Contains("# Avalonia vs WinForms — Field Label Diff Sweep", report);
+        Assert.Contains("## Summary", report);
+        Assert.Contains("## Top 20 Forms by WF-only Label Count", report);
+        Assert.Contains("## Per-pair WF-only Labels (gaps)", report);
+    }
+
+    [Fact]
+    public void FormatReport_OrdersByWfOnlyDescending()
+    {
+        // Three rows with WfOnly counts 5, 1, 3 must appear in the per-pair
+        // sections in the order 5 → 3 → 1.
+        var rows = new List<LabelDiffRow>
+        {
+            new LabelDiffRow(
+                new EditorPair("AaForm", null, "AaView", null, MatchMethod.Heuristic, Confidence.High),
+                new[] { "x" },
+                Array.Empty<string>(),
+                Array.Empty<string>()),
+            new LabelDiffRow(
+                new EditorPair("BbForm", null, "BbView", null, MatchMethod.Heuristic, Confidence.High),
+                new[] { "a", "b", "c", "d", "e" },
+                Array.Empty<string>(),
+                Array.Empty<string>()),
+            new LabelDiffRow(
+                new EditorPair("CcForm", null, "CcView", null, MatchMethod.Heuristic, Confidence.High),
+                new[] { "x", "y", "z" },
+                Array.Empty<string>(),
+                Array.Empty<string>()),
+        };
+        string report = LabelDiffScanner.FormatReport(rows);
+
+        int idxBb = report.IndexOf("### BbForm", StringComparison.Ordinal);
+        int idxCc = report.IndexOf("### CcForm", StringComparison.Ordinal);
+        int idxAa = report.IndexOf("### AaForm", StringComparison.Ordinal);
+        Assert.True(idxBb >= 0);
+        Assert.True(idxCc >= 0);
+        Assert.True(idxAa >= 0);
+        Assert.True(idxBb < idxCc, $"BbForm (5) must come before CcForm (3) — got {idxBb} vs {idxCc}");
+        Assert.True(idxCc < idxAa, $"CcForm (3) must come before AaForm (1) — got {idxCc} vs {idxAa}");
+    }
+
+    [Fact]
+    public void FormatReport_SkipsRowsWithoutGap()
+    {
+        // A row with WfOnly == 0 must NOT get a per-pair section (we only
+        // surface forms with at least one candidate missing field).
+        var rows = new[]
+        {
+            new LabelDiffRow(
+                new EditorPair("PerfectForm", null, "PerfectView", null, MatchMethod.Heuristic, Confidence.High),
+                Array.Empty<string>(),
+                Array.Empty<string>(),
+                new[] { "Name", "Class" }),
+            new LabelDiffRow(
+                new EditorPair("GapForm", null, "GapView", null, MatchMethod.Heuristic, Confidence.High),
+                new[] { "Missing1" },
+                Array.Empty<string>(),
+                Array.Empty<string>()),
+        };
+        string report = LabelDiffScanner.FormatReport(rows);
+        Assert.DoesNotContain("### PerfectForm", report);
+        Assert.Contains("### GapForm", report);
+        Assert.Contains("`Missing1`", report);
+    }
+
+    [Fact]
+    public void FormatReport_IncludesAvOnlyLabelsWhenPresent()
+    {
+        // AV-only labels should appear under an "AV-only" sub-heading when
+        // the row has any (they're informational — usually fine).
+        var row = new LabelDiffRow(
+            new EditorPair("MixedForm", null, "MixedView", null, MatchMethod.Heuristic, Confidence.High),
+            new[] { "MissingField" },
+            new[] { "ExtraField" },
+            Array.Empty<string>());
+        string report = LabelDiffScanner.FormatReport(new[] { row });
+        Assert.Contains("`MissingField`", report);
+        Assert.Contains("`ExtraField`", report);
+        Assert.Contains("AV-only labels", report);
+    }
+
+    [Fact]
+    public void FormatReport_CrossLinksDensityVerdictWhenProvided()
+    {
+        var pair = new EditorPair("UnitForm", null, "UnitEditorView", null,
+            MatchMethod.ListParityHelper, Confidence.High);
+        var row = new LabelDiffRow(pair, new[] { "X" }, Array.Empty<string>(), Array.Empty<string>());
+        var density = new DensityRow(pair, 100, 30, -70.0, Verdict.High);
+        string report = LabelDiffScanner.FormatReport(new[] { row }, new[] { density });
+        // The cross-link emits the density verdict and counts.
+        Assert.Contains("Density verdict", report);
+        Assert.Contains("High", report);
+        Assert.Contains("100", report);
+        Assert.Contains("30", report);
+    }
+
+    // =====================================================================
+    // Scan — orchestration, parallel-safety. Mostly an integration smoke test
+    // using temp files because Scan reads from disk.
+    // =====================================================================
+
+    [Fact]
+    public void Scan_SkipsPairsWithMissingFiles()
+    {
+        // Pair with null paths → no row. Confirms Scan filters orphans / half-pairs.
+        var pair = new EditorPair("Lonely", null, "Lonely", null,
+            MatchMethod.Orphan, Confidence.Low);
+        var rows = LabelDiffScanner.Scan(new[] { pair });
+        Assert.Empty(rows);
+    }
+
+    [Fact]
+    public void Scan_ReadsRealTempFilesAndProducesDiff()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), "fbgba-labelsdiff-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            string wfPath = Path.Combine(tempDir, "FakeForm.cs");
+            string designerPath = Path.Combine(tempDir, "FakeForm.Designer.cs");
+            string avPath = Path.Combine(tempDir, "FakeView.axaml");
+
+            File.WriteAllText(wfPath, "namespace X { partial class FakeForm {} }");
+            File.WriteAllText(designerPath, @"
+namespace X {
+    partial class FakeForm {
+        private System.Windows.Forms.Label label1;
+        void Init() {
+            this.label1 = new System.Windows.Forms.Label();
+            this.label1.Text = ""Missing in Avalonia"";
+        }
+    }
+}");
+            File.WriteAllText(avPath, @"<UserControl xmlns='https://github.com/avaloniaui'>
+  <TextBlock Text='Different' />
+</UserControl>");
+
+            var pair = new EditorPair("FakeForm", wfPath, "FakeView", avPath,
+                MatchMethod.Heuristic, Confidence.High);
+            var rows = LabelDiffScanner.Scan(new[] { pair });
+            Assert.Single(rows);
+            var row = rows[0];
+            Assert.Single(row.WfOnlyLabels);
+            Assert.Equal("Missing in Avalonia", row.WfOnlyLabels[0]);
+            Assert.Single(row.AvOnlyLabels);
+            Assert.Equal("Different", row.AvOnlyLabels[0]);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/LabelDiffScannerTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/LabelDiffScannerTests.cs
@@ -570,4 +570,220 @@ namespace X {
             try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
         }
     }
+
+    // =====================================================================
+    // Review-fix regression tests (PR #377 round 2)
+    // =====================================================================
+
+    [Fact]
+    public void ExtractAvLabels_HarvestsToolTipTipAttachedProperty()
+    {
+        // Avalonia's tooltip uses the attached-property syntax `ToolTip.Tip="..."`.
+        // XDocument exposes the local-name verbatim including the dot, so the
+        // scanner must include `ToolTip.Tip` in its attribute allow-list.
+        // Regression for PR #377 review comment 1.
+        string xml = @"<UserControl xmlns='https://github.com/avaloniaui'>
+  <TextBox ToolTip.Tip='Helpful hint' />
+</UserControl>";
+        var labels = LabelDiffScanner.ExtractAvLabelsFromDocument(XDocument.Parse(xml));
+        Assert.Single(labels);
+        Assert.Equal("Helpful hint", labels[0]);
+    }
+
+    [Fact]
+    public void ExtractAvLabels_ToolTipTipBindingSkipped()
+    {
+        // Same attached-property name, but the value is a `{Binding}` —
+        // markup-extension values must STILL be skipped on attached properties.
+        string xml = @"<UserControl xmlns='https://github.com/avaloniaui'>
+  <TextBox ToolTip.Tip='{Binding TipText}' />
+</UserControl>";
+        var labels = LabelDiffScanner.ExtractAvLabelsFromDocument(XDocument.Parse(xml));
+        Assert.Empty(labels);
+    }
+
+    [Fact]
+    public void ExtractWfLabelsFromSource_ResolvesResourcesGetString()
+    {
+        // PR #377 review comment 3: some Designer.cs files use
+        // `this.label1.Text = resources.GetString("label1.Text");` instead of
+        // an inline literal. The scanner must resolve those via a sibling
+        // .resx (or an injected lookup dictionary in tests).
+        string src = @"
+namespace X {
+    partial class F {
+        private System.Windows.Forms.Label label1;
+        void Init() {
+            this.label1 = new System.Windows.Forms.Label();
+            this.label1.Text = resources.GetString(""label1.Text"");
+        }
+    }
+}";
+        var resx = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["label1.Text"] = "From RESX",
+        };
+        var labels = LabelDiffScanner.ExtractWfLabelsFromSource(src, resx);
+        Assert.Single(labels);
+        Assert.Equal("From RESX", labels[0]);
+    }
+
+    [Fact]
+    public void ExtractWfLabelsFromSource_ResourcesGetStringMissingKeyProducesNoLabel()
+    {
+        // If the resx is missing or the key doesn't exist, the scanner must
+        // silently drop the assignment rather than produce a fake label.
+        string src = @"
+namespace X {
+    partial class F {
+        private System.Windows.Forms.Label label1;
+        void Init() {
+            this.label1 = new System.Windows.Forms.Label();
+            this.label1.Text = resources.GetString(""label1.Text"");
+        }
+    }
+}";
+        // No resx provided.
+        var labels = LabelDiffScanner.ExtractWfLabelsFromSource(src, resourceLookup: null);
+        Assert.Empty(labels);
+        // Empty resx provided.
+        labels = LabelDiffScanner.ExtractWfLabelsFromSource(src, new Dictionary<string, string>());
+        Assert.Empty(labels);
+    }
+
+    [Fact]
+    public void FormatReport_EscapesMultilineLabelsAndTruncatesVeryLongOnes()
+    {
+        // PR #377 review comment 4: multi-line label literals would break the
+        // markdown bullet (renderer treats the second line as a sibling).
+        // Newlines must be escaped to `\\n` so the label stays on one line.
+        // Very long labels (>200 chars) should be truncated with an ellipsis
+        // so the report stays readable.
+        string multiline = "First line\r\nSecond line";
+        string verylong = new string('x', 250) + "TAIL";
+        var rows = new[]
+        {
+            new LabelDiffRow(
+                new EditorPair("MultilineForm", null, "MultilineView", null, MatchMethod.Heuristic, Confidence.High),
+                new[] { multiline, verylong },
+                Array.Empty<string>(),
+                Array.Empty<string>()),
+        };
+        string report = LabelDiffScanner.FormatReport(rows);
+        // The original CR/LF must NOT appear inside the bullet — only the
+        // escaped form (`\\r`, `\\n`).
+        // The escape sequence we emit is the two-character literal `\\n`;
+        // we test by searching for the literal "First line\\r\\n" (which is
+        // `First line\r\n` in source).
+        Assert.Contains(@"First line\r\nSecond line", report);
+        // The very-long label is truncated with the ellipsis marker.
+        Assert.Contains("… (truncated; see designer file)", report);
+        // No raw line-break inside a bullet — that would split it into two.
+        int bulletIdx = report.IndexOf("- `First line", StringComparison.Ordinal);
+        Assert.True(bulletIdx >= 0);
+        int endOfLine = report.IndexOf('\n', bulletIdx);
+        Assert.True(endOfLine >= 0);
+        string bulletText = report.Substring(bulletIdx, endOfLine - bulletIdx);
+        Assert.DoesNotContain('\r', bulletText);
+    }
+
+    [Fact]
+    public void FormatReport_NoTrailingBlankLine()
+    {
+        // PR #377 review comment 3 also flagged `git diff --check` reporting
+        // a trailing blank line. The report body must end in exactly one
+        // newline (not two).
+        var rows = new[]
+        {
+            new LabelDiffRow(
+                new EditorPair("AForm", null, "AView", null, MatchMethod.Heuristic, Confidence.High),
+                new[] { "x" },
+                Array.Empty<string>(),
+                Array.Empty<string>()),
+        };
+        string report = LabelDiffScanner.FormatReport(rows);
+        Assert.True(report.Length > 0);
+        // Must end in exactly one '\n', not two.
+        Assert.Equal('\n', report[^1]);
+        Assert.NotEqual('\n', report[^2]);
+    }
+
+    [Fact]
+    public void FormatReport_OmitsDensityLinkWhenNoneProvided()
+    {
+        // PR #377 review comment 5: the density-link path was hardcoded
+        // (`2026-05-21-density-sweep.md`). The fix: accept null and emit
+        // a generic pointer in that case.
+        var rows = new[]
+        {
+            new LabelDiffRow(
+                new EditorPair("X", null, "Y", null, MatchMethod.Heuristic, Confidence.High),
+                new[] { "z" },
+                Array.Empty<string>(),
+                Array.Empty<string>()),
+        };
+        string report = LabelDiffScanner.FormatReport(rows, densityRows: null, densityReportLink: null);
+        Assert.DoesNotContain("2026-05-21-density-sweep.md", report);
+        Assert.Contains("latest density baseline", report);
+    }
+
+    [Fact]
+    public void FormatReport_UsesProvidedDensityLink()
+    {
+        var rows = new[]
+        {
+            new LabelDiffRow(
+                new EditorPair("X", null, "Y", null, MatchMethod.Heuristic, Confidence.High),
+                new[] { "z" },
+                Array.Empty<string>(),
+                Array.Empty<string>()),
+        };
+        string report = LabelDiffScanner.FormatReport(rows, densityRows: null, densityReportLink: "2099-12-31-density-sweep.md");
+        Assert.Contains("2099-12-31-density-sweep.md", report);
+        Assert.DoesNotContain("2026-05-21-density-sweep.md", report);
+    }
+
+    [Fact]
+    public void FindLatestDensityReport_PicksLexicographicallyMaxFilename()
+    {
+        // ISO-8601 dates sort naturally as strings, so picking the lex max
+        // gives the newest density report.
+        string tempDir = Path.Combine(Path.GetTempPath(), "fbgba-finddensity-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "2026-05-21-density-sweep.md"), "old");
+            File.WriteAllText(Path.Combine(tempDir, "2026-05-22-density-sweep.md"), "newer");
+            File.WriteAllText(Path.Combine(tempDir, "2026-06-01-density-sweep.md"), "newest");
+            File.WriteAllText(Path.Combine(tempDir, "ignore-me.md"), "decoy");
+            // Place the labels report in the same dir; FindLatestDensityReport
+            // reads from the labels report's parent directory.
+            string labelsPath = Path.Combine(tempDir, "2026-06-01-labels-sweep.md");
+            File.WriteAllText(labelsPath, "");
+
+            string? picked = LabelDiffScanner.FindLatestDensityReport(labelsPath);
+            Assert.Equal("2026-06-01-density-sweep.md", picked);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void FindLatestDensityReport_ReturnsNullWhenNoDensityReports()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), "fbgba-finddensity-empty-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            string labelsPath = Path.Combine(tempDir, "2026-06-01-labels-sweep.md");
+            File.WriteAllText(labelsPath, "");
+            Assert.Null(LabelDiffScanner.FindLatestDensityReport(labelsPath));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
 }

--- a/FEBuilderGBA.Avalonia/App.axaml.cs
+++ b/FEBuilderGBA.Avalonia/App.axaml.cs
@@ -268,7 +268,19 @@ namespace FEBuilderGBA.Avalonia
             int pairsWithGap = rows.Count(r => r.WfOnlyLabels.Count > 0);
             Console.WriteLine($"GAPSWEEP[labels]: scanned {rows.Count} pairs with both files; {pairsWithGap} have >=1 WF-only label.");
 
-            string body = LabelDiffScanner.FormatReport(rows);
+            // Also run the density scan in-memory so the labels report can
+            // cross-link each per-pair section to its density verdict. The
+            // density scan is cheap (~1-2 s with the parallel scanner) and
+            // gives reviewers the quantitative context for each qualitative
+            // gap row.
+            var densityRows = ControlDensityScanner.Scan(pairs, repoRoot);
+            // Pick the latest density baseline (file name only, no directory
+            // prefix) sitting in the same docs folder so the top-of-report
+            // cross-link works regardless of the date of THIS report.
+            string? densityLink = LabelDiffScanner.FindLatestDensityReport(outPath);
+            Console.WriteLine($"GAPSWEEP[labels]: density cross-link → {densityLink ?? "(none found)"}");
+
+            string body = LabelDiffScanner.FormatReport(rows, densityRows, densityLink);
             ReportWriter.WriteReport(outPath, "labels", new[] { body }, gitWorkingDir: repoRoot);
             Console.WriteLine($"GAPSWEEP[labels]: report written to {outPath}");
             return 0;

--- a/FEBuilderGBA.Avalonia/App.axaml.cs
+++ b/FEBuilderGBA.Avalonia/App.axaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -164,6 +165,8 @@ namespace FEBuilderGBA.Avalonia
                         return RunDensitySweep(repoRoot, GapSweepOut!, GapSweepDryRun);
 
                     case "labels":
+                        return RunLabelsSweep(repoRoot, GapSweepOut!, GapSweepDryRun);
+
                     case "jumps":
                     case "undo":
                     case "l10n":
@@ -234,6 +237,40 @@ namespace FEBuilderGBA.Avalonia
             string body = ControlDensityScanner.FormatReport(rows);
             ReportWriter.WriteReport(outPath, "density", new[] { body }, gitWorkingDir: repoRoot);
             Console.WriteLine($"GAPSWEEP[density]: report written to {outPath}");
+            return 0;
+        }
+
+        /// <summary>
+        /// Phase 2: field-label diff sweep. Returns 0 on success.
+        /// In dry-run mode we still discover pairs so we can log a count, but we
+        /// write a header-only file (no markdown body, just YAML front-matter) —
+        /// callers use this to verify file-system permissions and the CLI plumbing
+        /// without paying the Roslyn / XML scan cost. Mirrors RunDensitySweep's
+        /// shape exactly so the two flag handlers stay symmetrical.
+        /// </summary>
+        static int RunLabelsSweep(string repoRoot, string outPath, bool dryRun)
+        {
+            var pairs = PairMatcher.DiscoverAll(repoRoot);
+            Console.WriteLine($"GAPSWEEP[labels]: discovered {pairs.Count} editor pairs.");
+
+            if (dryRun)
+            {
+                // Header-only: identical pattern to RunDensitySweep's dry-run.
+                string dir = Path.GetDirectoryName(Path.GetFullPath(outPath)) ?? "";
+                if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                    Directory.CreateDirectory(dir);
+                File.WriteAllText(outPath, ReportWriter.BuildFrontMatter("labels", gitWorkingDir: repoRoot));
+                Console.WriteLine("GAPSWEEP[labels]: dry-run header written.");
+                return 0;
+            }
+
+            var rows = LabelDiffScanner.Scan(pairs);
+            int pairsWithGap = rows.Count(r => r.WfOnlyLabels.Count > 0);
+            Console.WriteLine($"GAPSWEEP[labels]: scanned {rows.Count} pairs with both files; {pairsWithGap} have >=1 WF-only label.");
+
+            string body = LabelDiffScanner.FormatReport(rows);
+            ReportWriter.WriteReport(outPath, "labels", new[] { body }, gitWorkingDir: repoRoot);
+            Console.WriteLine($"GAPSWEEP[labels]: report written to {outPath}");
             return 0;
         }
 

--- a/FEBuilderGBA.Avalonia/GapSweep/LabelDiffScanner.cs
+++ b/FEBuilderGBA.Avalonia/GapSweep/LabelDiffScanner.cs
@@ -1,0 +1,748 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// FEBuilderGBA gap-sweep tooling (#374) — Phase 2: field-label diff.
+//
+// Phase 1 (ControlDensityScanner) gives a QUANTITATIVE gap signal: "this
+// WinForms form has 183 controls and its Avalonia counterpart has 54 — that
+// is a -70 % density delta, almost certainly missing fields". The density
+// signal is necessary but not sufficient — it tells us WHERE to look, not
+// WHAT is missing.
+//
+// Phase 2 (this scanner) is the QUALITATIVE follow-up: for every paired
+// editor, extract the human-readable label literals from both sides, run a
+// normalised set-difference, and produce a per-pair list of:
+//
+//   WF-only labels  — strong candidates for missing fields in Avalonia
+//   AV-only labels  — usually fine (different layout, language polish, etc.)
+//   Common labels   — count only (signal that some coverage exists)
+//
+// The output is the backlog seed for the actual gap-fix PRs that follow.
+//
+// WinForms side: Roslyn parses *Form.Designer.cs files (the VS Designer auto-
+// generates `this.foo.Text = "..."` assignments for every Label/Button/etc.).
+// We collect string-literal assignments to `.Text` whose enclosing object-
+// creation type is in a known control allow-list, plus property-initialiser
+// syntax `new Label { Text = "..." }` for hand-coded forms.
+//
+// Avalonia side: System.Xml.Linq parses *View.axaml. We walk every element
+// and harvest literal values from `Text`, `Content`, `Header`, `ToolTip`,
+// `Watermark` attributes (and the property-element forms). Values that start
+// with `{` are markup extensions (`{Binding ...}`, `{StaticResource ...}`,
+// `{DynamicResource ...}`, `{x:Static ...}`, etc.) and are skipped. Elements
+// inside templating containers (Style/Styles/DataTemplate/ControlTemplate/
+// Design.DataContext) are also skipped — they describe templates, not the
+// realised layout.
+//
+// Normalisation strips trailing colons (UI convention "Name:" vs AXAML "Name"),
+// collapses whitespace, lowercases, and removes mnemonic markers (`&` for
+// WinForms, `_` for Avalonia) so equivalent labels match across platforms.
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace FEBuilderGBA.Avalonia.GapSweep
+{
+    /// <summary>
+    /// One paired editor's label-diff result. WfOnlyLabels are the labels we
+    /// found in the WinForms designer that have no normalised counterpart in
+    /// the Avalonia view — the qualitative gap-finding signal.
+    /// AvOnlyLabels are the reverse (usually fine, often just a re-worded UI).
+    /// CommonLabels are labels that survived normalisation on both sides.
+    /// All three lists preserve the ORIGINAL casing/punctuation of the first
+    /// occurrence — the normalisation is used only as the diff key.
+    /// </summary>
+    public record LabelDiffRow(
+        EditorPair Pair,
+        IReadOnlyList<string> WfOnlyLabels,
+        IReadOnlyList<string> AvOnlyLabels,
+        IReadOnlyList<string> CommonLabels);
+
+    /// <summary>
+    /// Phase 2: extract label literals from both sides of every paired editor
+    /// and emit a per-pair set-difference report. Methodology complements the
+    /// Phase 1 density scan — Phase 1 says "this pair has 70 % fewer controls",
+    /// Phase 2 says "and here are the specific labels Avalonia is missing".
+    /// </summary>
+    public static class LabelDiffScanner
+    {
+        /// <summary>
+        /// WinForms control type identifiers whose `.Text = "..."` assignments
+        /// we treat as labels. We deliberately limit this to controls that
+        /// actually render their `Text` property as user-facing label text:
+        ///   - Label / GroupBox: pure labels
+        ///   - Button / CheckBox / RadioButton: caption text
+        ///   - TabPage: tab caption
+        /// Excludes types whose `Text` is data, not a label (TextBox, ComboBox,
+        /// NumericUpDown, RichTextBox, MaskedTextBox, …).
+        /// </summary>
+        static readonly HashSet<string> WfLabelHostTypes = new(StringComparer.Ordinal)
+        {
+            "Label",
+            "GroupBox",
+            "Button",
+            "CheckBox",
+            "RadioButton",
+            "TabPage",
+        };
+
+        /// <summary>
+        /// AXAML attribute names we treat as literal-label sources. Property-
+        /// element forms (`&lt;Button.Content&gt;Save&lt;/Button.Content&gt;`)
+        /// are handled by inspecting every XElement's child text nodes for
+        /// these names — but the attribute form (the common case) is what
+        /// the scanner harvests.
+        /// </summary>
+        static readonly HashSet<string> AvLabelAttributes = new(StringComparer.Ordinal)
+        {
+            "Text", "Content", "Header", "ToolTip", "Watermark",
+        };
+
+        /// <summary>
+        /// Template containers — same set as ControlDensityScanner — so the
+        /// label diff stays consistent with the density count. Elements nested
+        /// under any of these are SKIPPED because they describe templates
+        /// (e.g. per-row DataTemplate) rather than the realised layout, and
+        /// would otherwise inflate the AV side with synthetic literals that
+        /// never appear in the actual UI.
+        /// </summary>
+        static readonly HashSet<string> AvTemplateContainers = new(StringComparer.Ordinal)
+        {
+            "Design.DataContext",
+            "Style",
+            "Styles",
+            "DataTemplate",
+            "ControlTemplate",
+            "ItemTemplate",
+            "ItemsPanelTemplate",
+            "HierarchicalDataTemplate",
+        };
+
+        /// <summary>
+        /// Normalise a label for set-membership comparison. The goal is that
+        /// every reasonable cross-platform encoding of the SAME label collides
+        /// to the same key:
+        ///
+        ///   "Name:"           // WF Designer
+        ///   "Name"            // AV plain
+        ///   " name "          // AV with whitespace
+        ///   "&Name"           // WF with mnemonic
+        ///   "_Name"           // AV with mnemonic
+        ///   "  Name  :  "     // pathological
+        ///
+        /// all map to "name". Mnemonic markers (`&` for WF, `_` for AV) are
+        /// stripped so cross-platform-equivalent labels don't show up as
+        /// spurious WF-only hits. The trailing colon is stripped because the
+        /// WF designer convention is `"Field Name:"` whereas the AV convention
+        /// is `"Field Name"`. Internal whitespace is collapsed to single
+        /// spaces. The result is then lowercased.
+        ///
+        /// The original casing/punctuation IS preserved in the report — the
+        /// normalised key is only the dictionary lookup. Callers see the first
+        /// occurrence's original spelling in the WfOnly/AvOnly/Common lists.
+        /// </summary>
+        public static string Normalize(string raw)
+        {
+            if (string.IsNullOrEmpty(raw))
+                return string.Empty;
+            // Strip mnemonic markers (& for WinForms, _ for Avalonia). We
+            // strip BOTH markers from BOTH sides because the goal is to match
+            // labels across the platform-specific marker convention.
+            // Note: WinForms also uses "&&" as a literal ampersand — for the
+            // normalisation pass we just strip all `&`/`_` since the report
+            // preserves the original anyway and the data we deal with is
+            // 99.9 % field labels (rarely literal ampersands).
+            var sb = new StringBuilder(raw.Length);
+            foreach (char c in raw)
+            {
+                if (c == '&' || c == '_')
+                    continue;
+                sb.Append(c);
+            }
+            string stripped = sb.ToString();
+            // Trim outer whitespace, strip trailing colon, collapse internal
+            // whitespace to single spaces, lowercase. We do the collapse via
+            // a manual walk because Regex would be overkill here.
+            stripped = stripped.Trim();
+            while (stripped.EndsWith(":", StringComparison.Ordinal))
+                stripped = stripped.Substring(0, stripped.Length - 1).TrimEnd();
+            // Collapse internal whitespace runs to single spaces.
+            var collapsed = new StringBuilder(stripped.Length);
+            bool prevSpace = false;
+            foreach (char c in stripped)
+            {
+                if (char.IsWhiteSpace(c))
+                {
+                    if (!prevSpace)
+                        collapsed.Append(' ');
+                    prevSpace = true;
+                }
+                else
+                {
+                    collapsed.Append(c);
+                    prevSpace = false;
+                }
+            }
+            return collapsed.ToString().ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// Extract label literals from a WinForms form's *Form.Designer.cs (or
+        /// the *Form.cs itself if no Designer.cs sibling exists — some forms
+        /// are hand-coded without the designer). Returns the original-cased
+        /// label strings in the order they appear. Duplicates ARE returned
+        /// because a designer can legitimately emit the same label twice
+        /// (e.g. two "Name:" group headers for distinct sections); the
+        /// caller's normalised set takes care of de-duplication.
+        /// </summary>
+        public static IReadOnlyList<string> ExtractWfLabels(string designerCsPath)
+        {
+            try
+            {
+                if (!File.Exists(designerCsPath))
+                    return Array.Empty<string>();
+                string code = File.ReadAllText(designerCsPath);
+                return ExtractWfLabelsFromSource(code);
+            }
+            catch
+            {
+                return Array.Empty<string>();
+            }
+        }
+
+        /// <summary>
+        /// In-memory variant for unit tests — same logic as
+        /// <see cref="ExtractWfLabels"/> but takes a source string.
+        /// </summary>
+        public static IReadOnlyList<string> ExtractWfLabelsFromSource(string sourceCode)
+        {
+            if (string.IsNullOrEmpty(sourceCode))
+                return Array.Empty<string>();
+            var labels = new List<string>();
+            SyntaxTree tree = CSharpSyntaxTree.ParseText(sourceCode);
+            SyntaxNode root = tree.GetRoot();
+
+            // Map: local-variable name (e.g. "this.label1") → host type name (e.g. "Label").
+            // We build it by walking ObjectCreationExpressionSyntax and matching the
+            // adjacent assignment / variable-declarator that anchored it. That way we
+            // can later filter `xxx.Text = "..."` by whether `xxx` was constructed as a
+            // recognised label-host type.
+            var variableToHostType = BuildWfVariableHostMap(root);
+
+            // ---- 1. Pattern: `this.foo.Text = "Hello";` (designer-style) ----
+            //    or  `foo.Text = "Hello";` (rare but legal)
+            // We collect string-literal assignments and resolve the LHS variable's
+            // host type via the map.
+            foreach (var assign in root.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+            {
+                if (!assign.OperatorToken.IsKind(SyntaxKind.EqualsToken))
+                    continue;
+                if (assign.Left is not MemberAccessExpressionSyntax memberAccess)
+                    continue;
+                if (memberAccess.Name.Identifier.Text != "Text")
+                    continue;
+                if (assign.Right is not LiteralExpressionSyntax literal)
+                    continue;
+                if (!literal.IsKind(SyntaxKind.StringLiteralExpression))
+                    continue;
+
+                string? owner = ExtractWfOwnerVariable(memberAccess.Expression);
+                if (owner == null)
+                    continue;
+                if (!variableToHostType.TryGetValue(owner, out string? hostType))
+                    continue;
+                if (!WfLabelHostTypes.Contains(hostType))
+                    continue;
+
+                string text = (string?)literal.Token.Value ?? "";
+                if (text.Length == 0)
+                    continue;
+                labels.Add(text);
+            }
+
+            // ---- 2. Pattern: `new Label { Text = "Hello" }` (object initialiser) ----
+            // Some hand-coded forms construct controls inline rather than
+            // through the designer. We harvest those directly.
+            foreach (var oce in root.DescendantNodes().OfType<ObjectCreationExpressionSyntax>())
+            {
+                string typeName = ExtractTypeName(oce.Type);
+                if (!WfLabelHostTypes.Contains(typeName))
+                    continue;
+                if (oce.Initializer == null)
+                    continue;
+                foreach (var expr in oce.Initializer.Expressions)
+                {
+                    if (expr is not AssignmentExpressionSyntax init)
+                        continue;
+                    if (init.Left is not IdentifierNameSyntax id)
+                        continue;
+                    if (id.Identifier.Text != "Text")
+                        continue;
+                    if (init.Right is not LiteralExpressionSyntax lit)
+                        continue;
+                    if (!lit.IsKind(SyntaxKind.StringLiteralExpression))
+                        continue;
+                    string text = (string?)lit.Token.Value ?? "";
+                    if (text.Length == 0)
+                        continue;
+                    labels.Add(text);
+                }
+            }
+
+            return labels;
+        }
+
+        /// <summary>
+        /// Walk the syntax tree once and build a map from declared variable
+        /// names ("this.foo" or "foo") to the trailing identifier of the type
+        /// they were constructed as. Used by the `.Text = "..."` filter so we
+        /// only pick up labels on actual label-host controls (and not, e.g.,
+        /// TextBox's Text-as-data).
+        /// </summary>
+        static Dictionary<string, string> BuildWfVariableHostMap(SyntaxNode root)
+        {
+            var map = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            // Pattern A: field declaration with initializer
+            //   private System.Windows.Forms.Label label1 = new System.Windows.Forms.Label();
+            foreach (var field in root.DescendantNodes().OfType<FieldDeclarationSyntax>())
+            {
+                string fieldType = ExtractTypeName(field.Declaration.Type);
+                if (!WfLabelHostTypes.Contains(fieldType))
+                {
+                    // Even if the declared type isn't a recognised host, the initializer
+                    // may still be one (rare) — fall through to expression-level scan.
+                }
+                foreach (var v in field.Declaration.Variables)
+                {
+                    string varName = v.Identifier.Text;
+                    if (WfLabelHostTypes.Contains(fieldType))
+                    {
+                        // Designer-style: the declared type IS the host. Record both
+                        // `name` and `this.name` so member-access on either spelling
+                        // matches.
+                        map[varName] = fieldType;
+                        map["this." + varName] = fieldType;
+                    }
+                }
+            }
+
+            // Pattern B: assignment of `new X(...)` to a member-access target
+            //   this.label1 = new System.Windows.Forms.Label();
+            foreach (var assign in root.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+            {
+                if (!assign.OperatorToken.IsKind(SyntaxKind.EqualsToken))
+                    continue;
+                if (assign.Right is not ObjectCreationExpressionSyntax oce)
+                    continue;
+                string ctorType = ExtractTypeName(oce.Type);
+                // Don't gate on WfLabelHostTypes here — we want a complete map so
+                // later filters can decide. (Non-label types get filtered at lookup
+                // time.)
+                string? owner = ExtractWfOwnerVariable(assign.Left);
+                if (owner == null)
+                    continue;
+                map[owner] = ctorType;
+                // Also register the bare-identifier form so `foo.Text = "..."`
+                // resolves the same as `this.foo.Text = "..."`.
+                if (owner.StartsWith("this.", StringComparison.Ordinal))
+                    map[owner.Substring("this.".Length)] = ctorType;
+                else
+                    map["this." + owner] = ctorType;
+            }
+
+            // Pattern C: local variable declaration with initializer
+            //   var label = new Label { ... };
+            foreach (var loc in root.DescendantNodes().OfType<LocalDeclarationStatementSyntax>())
+            {
+                foreach (var v in loc.Declaration.Variables)
+                {
+                    if (v.Initializer == null) continue;
+                    if (v.Initializer.Value is not ObjectCreationExpressionSyntax oce) continue;
+                    string ctorType = ExtractTypeName(oce.Type);
+                    string varName = v.Identifier.Text;
+                    map[varName] = ctorType;
+                }
+            }
+
+            return map;
+        }
+
+        /// <summary>
+        /// Render the LHS of a member-access (`this.foo`, `foo`) as its
+        /// canonical string-key form so we can look it up in the host map.
+        /// Returns null for anything more exotic (chained method-call results,
+        /// element access, …) which we deliberately decline to handle.
+        /// </summary>
+        static string? ExtractWfOwnerVariable(ExpressionSyntax expr)
+        {
+            return expr switch
+            {
+                IdentifierNameSyntax id => id.Identifier.Text,
+                MemberAccessExpressionSyntax m when m.Expression is ThisExpressionSyntax
+                    => "this." + m.Name.Identifier.Text,
+                MemberAccessExpressionSyntax m when m.Expression is IdentifierNameSyntax
+                    => ((IdentifierNameSyntax)m.Expression).Identifier.Text + "." + m.Name.Identifier.Text,
+                _ => null,
+            };
+        }
+
+        /// <summary>Pull the trailing identifier out of a TypeSyntax (e.g. <c>System.Windows.Forms.Button</c> → <c>Button</c>).</summary>
+        static string ExtractTypeName(TypeSyntax type)
+        {
+            return type switch
+            {
+                QualifiedNameSyntax q => q.Right.Identifier.Text,
+                IdentifierNameSyntax id => id.Identifier.Text,
+                AliasQualifiedNameSyntax aqn => aqn.Name.Identifier.Text,
+                GenericNameSyntax gn => gn.Identifier.Text,
+                _ => type.ToString(),
+            };
+        }
+
+        /// <summary>
+        /// Extract label literals from an Avalonia .axaml file.
+        /// Returns the original-cased labels in document order. Skips:
+        ///   - elements inside template containers (Style/DataTemplate/...)
+        ///   - attribute values starting with `{` (markup extensions — bindings, resources)
+        /// </summary>
+        public static IReadOnlyList<string> ExtractAvLabels(string axamlPath)
+        {
+            try
+            {
+                if (!File.Exists(axamlPath))
+                    return Array.Empty<string>();
+                XDocument doc = XDocument.Load(axamlPath);
+                return ExtractAvLabelsFromDocument(doc);
+            }
+            catch
+            {
+                return Array.Empty<string>();
+            }
+        }
+
+        /// <summary>
+        /// In-memory variant for unit tests — same logic as
+        /// <see cref="ExtractAvLabels"/> but takes an XDocument directly.
+        /// </summary>
+        public static IReadOnlyList<string> ExtractAvLabelsFromDocument(XDocument doc)
+        {
+            var labels = new List<string>();
+            if (doc.Root == null)
+                return labels;
+            foreach (XElement el in doc.Descendants())
+            {
+                if (IsInsideTemplate(el))
+                    continue;
+                foreach (XAttribute attr in el.Attributes())
+                {
+                    if (!AvLabelAttributes.Contains(attr.Name.LocalName))
+                        continue;
+                    string value = attr.Value;
+                    if (string.IsNullOrEmpty(value))
+                        continue;
+                    // Skip markup extensions: any value starting with `{` is a
+                    // binding, resource lookup, or static reference. Avalonia
+                    // also supports literal `{}` escape — e.g. `{}{actual text}`
+                    // — but those are vanishingly rare in this codebase; we
+                    // exclude them too rather than parse the escape, because
+                    // for the gap-finding purpose they're never the human-
+                    // readable label we're trying to harvest.
+                    if (value[0] == '{')
+                        continue;
+                    labels.Add(value);
+                }
+            }
+            return labels;
+        }
+
+        /// <summary>
+        /// Walk the ancestor chain looking for a known template container.
+        /// Returns true if the element is nested inside one (and therefore is
+        /// part of a template rather than the realised layout).
+        /// </summary>
+        static bool IsInsideTemplate(XElement el)
+        {
+            for (XElement? cur = el.Parent; cur != null; cur = cur.Parent)
+            {
+                if (AvTemplateContainers.Contains(cur.Name.LocalName))
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Run the label diff over <paramref name="pairs"/>. Only pairs whose
+        /// WfPath AND AvPath are both non-null AND exist on disk participate —
+        /// orphans and pairing artifacts contribute no signal here (they're
+        /// already surfaced in the density report's unmatched-counterparts
+        /// sections).
+        ///
+        /// Returns rows ordered by `(WfOnlyLabels.Count desc, WfFormName asc)`
+        /// so the biggest candidate-missing-field counts surface first.
+        /// </summary>
+        public static IReadOnlyList<LabelDiffRow> Scan(IReadOnlyList<EditorPair> pairs)
+        {
+            if (pairs == null) throw new ArgumentNullException(nameof(pairs));
+
+            var rows = new ConcurrentBag<LabelDiffRow>();
+            Parallel.ForEach(pairs, pair =>
+            {
+                if (pair.WfPath == null || pair.AvPath == null)
+                    return;
+                if (!File.Exists(pair.WfPath) || !File.Exists(pair.AvPath))
+                    return;
+
+                // Prefer the *Form.Designer.cs sibling — that's where the VS
+                // designer emits the bulk of `.Text = "..."` initialisers.
+                // Fall back to the *Form.cs itself when there's no designer
+                // file (some forms are hand-coded).
+                string? designerPath = TryFindDesignerSibling(pair.WfPath);
+                IReadOnlyList<string> wfLabels;
+                if (designerPath != null && File.Exists(designerPath))
+                {
+                    var fromDesigner = ExtractWfLabels(designerPath);
+                    var fromForm = ExtractWfLabels(pair.WfPath);
+                    // Concatenate — duplicates are OK; the normalisation map
+                    // de-dupes them. Include both because hand-coded controls
+                    // in the public partial complement the designer's set.
+                    var combined = new List<string>(fromDesigner.Count + fromForm.Count);
+                    combined.AddRange(fromDesigner);
+                    combined.AddRange(fromForm);
+                    wfLabels = combined;
+                }
+                else
+                {
+                    wfLabels = ExtractWfLabels(pair.WfPath);
+                }
+                IReadOnlyList<string> avLabels = ExtractAvLabels(pair.AvPath);
+
+                var row = ComputeDiff(pair, wfLabels, avLabels);
+                rows.Add(row);
+            });
+
+            return rows
+                .OrderByDescending(r => r.WfOnlyLabels.Count)
+                .ThenBy(r => r.Pair.WfFormName ?? r.Pair.AvViewName ?? "", StringComparer.Ordinal)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Compute the diff for a single pair from already-extracted label
+        /// lists. Exposed for unit-test convenience — production callers go
+        /// through <see cref="Scan"/>.
+        /// </summary>
+        public static LabelDiffRow ComputeDiff(
+            EditorPair pair,
+            IReadOnlyList<string> wfLabels,
+            IReadOnlyList<string> avLabels)
+        {
+            // Maps `normalised key -> first original-cased occurrence`. We
+            // record the first occurrence so the report preserves casing /
+            // punctuation rather than the lowercase-no-colon normalised form.
+            var wfMap = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (string lbl in wfLabels)
+            {
+                string key = Normalize(lbl);
+                if (key.Length == 0)
+                    continue;
+                if (!wfMap.ContainsKey(key))
+                    wfMap[key] = lbl;
+            }
+            var avMap = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (string lbl in avLabels)
+            {
+                string key = Normalize(lbl);
+                if (key.Length == 0)
+                    continue;
+                if (!avMap.ContainsKey(key))
+                    avMap[key] = lbl;
+            }
+
+            var wfOnly = wfMap
+                .Where(kv => !avMap.ContainsKey(kv.Key))
+                .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+                .Select(kv => kv.Value)
+                .ToList();
+            var avOnly = avMap
+                .Where(kv => !wfMap.ContainsKey(kv.Key))
+                .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+                .Select(kv => kv.Value)
+                .ToList();
+            var common = wfMap
+                .Where(kv => avMap.ContainsKey(kv.Key))
+                .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+                .Select(kv => kv.Value)
+                .ToList();
+
+            return new LabelDiffRow(pair, wfOnly, avOnly, common);
+        }
+
+        /// <summary>Locate the *.Designer.cs file that sits next to a *Form.cs (or null).</summary>
+        static string? TryFindDesignerSibling(string formCsPath)
+        {
+            string dir = Path.GetDirectoryName(formCsPath) ?? "";
+            string baseName = Path.GetFileNameWithoutExtension(formCsPath);
+            string candidate = Path.Combine(dir, baseName + ".Designer.cs");
+            return File.Exists(candidate) ? candidate : null;
+        }
+
+        /// <summary>
+        /// Format the markdown body of the labels report (sans front-matter — that
+        /// is added by <see cref="ReportWriter"/>). Layout:
+        ///
+        ///  1. Methodology header
+        ///  2. Summary table with totals + top-20 WF-only counts
+        ///  3. Per-pair `### &lt;FormName&gt;` sections (only rows with WfOnly.Count > 0,
+        ///     sorted by WfOnly count descending)
+        ///
+        /// If <paramref name="densityRows"/> is supplied, each per-pair section
+        /// cross-links to that pair's density verdict (provides quantitative
+        /// context for the qualitative label list).
+        /// </summary>
+        public static string FormatReport(
+            IReadOnlyList<LabelDiffRow> rows,
+            IReadOnlyList<DensityRow>? densityRows = null)
+        {
+            if (rows == null) throw new ArgumentNullException(nameof(rows));
+            // Density lookup keyed by (WfFormName, AvViewName) so each labels
+            // row can cite its density verdict / counts. Keyed by both to
+            // disambiguate forms that pair with multiple views (e.g.
+            // ClassForm ↔ {ClassEditorView, ClassFE6View}).
+            var densityLookup = new Dictionary<(string?, string?), DensityRow>();
+            if (densityRows != null)
+            {
+                foreach (var d in densityRows)
+                    densityLookup[(d.Pair.WfFormName, d.Pair.AvViewName)] = d;
+            }
+
+            var sb = new StringBuilder();
+            sb.Append("# Avalonia vs WinForms — Field Label Diff Sweep\n\n");
+            sb.Append("This report extracts label literals from paired WinForms ↔ Avalonia\n");
+            sb.Append("editors and lists, per pair, the labels present in the WinForms designer\n");
+            sb.Append("but missing from the Avalonia counterpart. These are strong candidates\n");
+            sb.Append("for **missing fields in the Avalonia migration** — qualitative follow-up\n");
+            sb.Append("to the Phase 1 control-density sweep.\n\n");
+            sb.Append("WinForms side: Roslyn extracts `.Text = \"...\"` assignments on\n");
+            sb.Append("`Label`, `GroupBox`, `Button`, `CheckBox`, `RadioButton`, `TabPage`\n");
+            sb.Append("controls (plus property-initialiser syntax for hand-coded forms).\n");
+            sb.Append("Avalonia side: `XDocument` parses every view, harvests literal values from\n");
+            sb.Append("`Text` / `Content` / `Header` / `ToolTip` / `Watermark` attributes,\n");
+            sb.Append("skipping markup-extension values (`{Binding ...}`, `{StaticResource ...}`)\n");
+            sb.Append("and elements nested inside template containers (`Style`, `DataTemplate`, ...).\n\n");
+            sb.Append("Normalisation collapses whitespace, strips trailing colons, removes mnemonic\n");
+            sb.Append("markers (`&` for WF, `_` for AV), and lowercases — so `Name:` / `&Name` /\n");
+            sb.Append("`_Name` / `Name` all collide to the same set key. Original casing is preserved\n");
+            sb.Append("in the report's WF-only / AV-only / Common lists.\n\n");
+            sb.Append("Methodology lives in `FEBuilderGBA.Avalonia/GapSweep/LabelDiffScanner.cs`.\n");
+            sb.Append("Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-labels --out=<path>`.\n\n");
+
+            // ---- Summary ----
+            int totalPairs = rows.Count;
+            int totalWfOnly = rows.Sum(r => r.WfOnlyLabels.Count);
+            int totalAvOnly = rows.Sum(r => r.AvOnlyLabels.Count);
+            int totalCommon = rows.Sum(r => r.CommonLabels.Count);
+            int pairsWithGap = rows.Count(r => r.WfOnlyLabels.Count > 0);
+            sb.Append("## Summary\n\n");
+            sb.Append("| Metric | Count |\n");
+            sb.Append("|---|---:|\n");
+            sb.Append("| Pairs scanned (both files exist) | ").Append(totalPairs).Append(" |\n");
+            sb.Append("| Pairs with ≥1 WF-only label | ").Append(pairsWithGap).Append(" |\n");
+            sb.Append("| Total WF-only labels | ").Append(totalWfOnly).Append(" |\n");
+            sb.Append("| Total AV-only labels | ").Append(totalAvOnly).Append(" |\n");
+            sb.Append("| Total common labels | ").Append(totalCommon).Append(" |\n");
+            sb.Append('\n');
+
+            // ---- Top-20 candidate-missing-field counts ----
+            sb.Append("## Top 20 Forms by WF-only Label Count\n\n");
+            sb.Append("Each row's WF-only count is the upper bound on missing fields in the AV view.\n");
+            sb.Append("Cross-link to the [density sweep](2026-05-21-density-sweep.md) for quantitative context.\n\n");
+            sb.Append("| Rank | WF Form | AV View | WF-only | AV-only | Common |\n");
+            sb.Append("|---:|---|---|---:|---:|---:|\n");
+            int rank = 0;
+            foreach (var r in rows
+                .Where(r => r.WfOnlyLabels.Count > 0)
+                .OrderByDescending(r => r.WfOnlyLabels.Count)
+                .ThenBy(r => r.Pair.WfFormName ?? "", StringComparer.Ordinal)
+                .Take(20))
+            {
+                rank++;
+                sb.Append("| ").Append(rank)
+                  .Append(" | `").Append(r.Pair.WfFormName ?? "—").Append('`')
+                  .Append(" | `").Append(r.Pair.AvViewName ?? "—").Append('`')
+                  .Append(" | ").Append(r.WfOnlyLabels.Count)
+                  .Append(" | ").Append(r.AvOnlyLabels.Count)
+                  .Append(" | ").Append(r.CommonLabels.Count)
+                  .Append(" |\n");
+            }
+            sb.Append('\n');
+
+            // ---- Per-pair sections (only those with WfOnly.Count > 0) ----
+            sb.Append("## Per-pair WF-only Labels (gaps)\n\n");
+            sb.Append("Sections sorted by WF-only count descending. Each label is rendered as a\n");
+            sb.Append("backticked literal preserving the original casing/punctuation. Use these as\n");
+            sb.Append("the per-form backlog for follow-up gap-fix PRs.\n\n");
+
+            foreach (var r in rows
+                .Where(r => r.WfOnlyLabels.Count > 0)
+                .OrderByDescending(r => r.WfOnlyLabels.Count)
+                .ThenBy(r => r.Pair.WfFormName ?? "", StringComparer.Ordinal))
+            {
+                string formName = r.Pair.WfFormName ?? r.Pair.AvViewName ?? "?";
+                sb.Append("### ").Append(formName).Append('\n');
+                sb.Append("WF labels: **").Append(r.WfOnlyLabels.Count + r.CommonLabels.Count)
+                  .Append("** · AV labels: **").Append(r.AvOnlyLabels.Count + r.CommonLabels.Count)
+                  .Append("** · WF-only: **").Append(r.WfOnlyLabels.Count)
+                  .Append("** · AV-only: **").Append(r.AvOnlyLabels.Count)
+                  .Append("** · Common: **").Append(r.CommonLabels.Count)
+                  .Append("**");
+                if (densityLookup.TryGetValue((r.Pair.WfFormName, r.Pair.AvViewName), out var d))
+                {
+                    sb.Append(" · Density verdict: **").Append(d.Verdict)
+                      .Append("** (WF ").Append(d.WfControlCount)
+                      .Append(" / AV ").Append(d.AvControlCount).Append(')');
+                }
+                sb.Append("\n\n");
+
+                sb.Append("WF-only labels (candidates for missing fields in AV):\n\n");
+                foreach (string lbl in r.WfOnlyLabels)
+                {
+                    sb.Append("- ").Append(RenderLabelLiteral(lbl)).Append('\n');
+                }
+                sb.Append('\n');
+
+                if (r.AvOnlyLabels.Count > 0)
+                {
+                    sb.Append("AV-only labels (usually fine — layout polish or rewording):\n\n");
+                    foreach (string lbl in r.AvOnlyLabels)
+                    {
+                        sb.Append("- ").Append(RenderLabelLiteral(lbl)).Append('\n');
+                    }
+                    sb.Append('\n');
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Render a label literal as inline-code markdown. If the literal
+        /// itself contains a backtick (rare for UI labels but possible), we
+        /// emit the double-backtick variant with surrounding spaces per the
+        /// CommonMark rule so the markdown renders correctly.
+        /// </summary>
+        static string RenderLabelLiteral(string label)
+        {
+            if (label.IndexOf('`') < 0)
+                return "`" + label + "`";
+            // Use the double-backtick fence with leading/trailing space.
+            return "`` " + label + " ``";
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/GapSweep/LabelDiffScanner.cs
+++ b/FEBuilderGBA.Avalonia/GapSweep/LabelDiffScanner.cs
@@ -21,16 +21,21 @@
 // generates `this.foo.Text = "..."` assignments for every Label/Button/etc.).
 // We collect string-literal assignments to `.Text` whose enclosing object-
 // creation type is in a known control allow-list, plus property-initialiser
-// syntax `new Label { Text = "..." }` for hand-coded forms.
+// syntax `new Label { Text = "..." }` for hand-coded forms. Designers that
+// use VS's localisation-aware emit mode (`resources.GetString("key")`) are
+// resolved by parsing the sibling *.resx file.
 //
 // Avalonia side: System.Xml.Linq parses *View.axaml. We walk every element
 // and harvest literal values from `Text`, `Content`, `Header`, `ToolTip`,
-// `Watermark` attributes (and the property-element forms). Values that start
-// with `{` are markup extensions (`{Binding ...}`, `{StaticResource ...}`,
-// `{DynamicResource ...}`, `{x:Static ...}`, etc.) and are skipped. Elements
-// inside templating containers (Style/Styles/DataTemplate/ControlTemplate/
-// Design.DataContext) are also skipped — they describe templates, not the
-// realised layout.
+// `ToolTip.Tip` (the attached-property form, which this codebase uses ~55
+// times), `Watermark` attributes. The implementation reads ATTRIBUTES only,
+// not property-element forms (`<Button.Content>Save</Button.Content>`); the
+// repo's views never use that syntax so handling it would add complexity
+// for no real signal. Values that start with `{` are markup extensions
+// (`{Binding ...}`, `{StaticResource ...}`, `{DynamicResource ...}`,
+// `{x:Static ...}`, etc.) and are skipped. Elements inside templating
+// containers (Style/Styles/DataTemplate/ControlTemplate/Design.DataContext)
+// are also skipped — they describe templates, not the realised layout.
 //
 // Normalisation strips trailing colons (UI convention "Name:" vs AXAML "Name"),
 // collapses whitespace, lowercases, and removes mnemonic markers (`&` for
@@ -93,15 +98,23 @@ namespace FEBuilderGBA.Avalonia.GapSweep
         };
 
         /// <summary>
-        /// AXAML attribute names we treat as literal-label sources. Property-
-        /// element forms (`&lt;Button.Content&gt;Save&lt;/Button.Content&gt;`)
-        /// are handled by inspecting every XElement's child text nodes for
-        /// these names — but the attribute form (the common case) is what
-        /// the scanner harvests.
+        /// AXAML attribute local-names we treat as literal-label sources. Only the
+        /// attribute form is harvested — property-element syntax
+        /// (`&lt;Button.Content&gt;Save&lt;/Button.Content&gt;`) is rare across
+        /// this codebase's views (a `grep -r '\.Content&gt;' Views/` finds zero
+        /// matches), so the implementation deliberately skips that path to keep
+        /// the scanner simple.
+        ///
+        /// `ToolTip.Tip` is included for Avalonia's attached-property form
+        /// `ToolTip.Tip="..."` — the codebase has ~55 such usages across
+        /// ClassEditorView / ItemEditorView / etc. XDocument exposes the
+        /// attribute's local-name verbatim including the dot, so we match
+        /// `ToolTip.Tip` literally (NOT just `Tip`, which would over-match any
+        /// element with a `Tip` attribute).
         /// </summary>
         static readonly HashSet<string> AvLabelAttributes = new(StringComparer.Ordinal)
         {
-            "Text", "Content", "Header", "ToolTip", "Watermark",
+            "Text", "Content", "Header", "ToolTip", "ToolTip.Tip", "Watermark",
         };
 
         /// <summary>
@@ -200,6 +213,12 @@ namespace FEBuilderGBA.Avalonia.GapSweep
         /// because a designer can legitimately emit the same label twice
         /// (e.g. two "Name:" group headers for distinct sections); the
         /// caller's normalised set takes care of de-duplication.
+        ///
+        /// Some designer files use `resources.GetString("label1.Text")`
+        /// instead of inline literals. We resolve those by parsing the sibling
+        /// .resx file when present so the WF inventory isn't silently under-
+        /// counted for forms that route through ComponentResourceManager (the
+        /// VS Designer's localisation-aware emit mode).
         /// </summary>
         public static IReadOnlyList<string> ExtractWfLabels(string designerCsPath)
         {
@@ -208,7 +227,14 @@ namespace FEBuilderGBA.Avalonia.GapSweep
                 if (!File.Exists(designerCsPath))
                     return Array.Empty<string>();
                 string code = File.ReadAllText(designerCsPath);
-                return ExtractWfLabelsFromSource(code);
+                // Look up the sibling .resx so resources.GetString(...) calls
+                // resolve to concrete strings. The .resx sits next to the
+                // *Form.Designer.cs OR next to the *Form.cs (one of the two);
+                // try both. Missing .resx is fine — the resolver just returns
+                // an empty dictionary and `resources.GetString` calls produce
+                // no labels.
+                Dictionary<string, string>? resx = TryLoadSiblingResx(designerCsPath);
+                return ExtractWfLabelsFromSource(code, resx);
             }
             catch
             {
@@ -217,10 +243,51 @@ namespace FEBuilderGBA.Avalonia.GapSweep
         }
 
         /// <summary>
-        /// In-memory variant for unit tests — same logic as
-        /// <see cref="ExtractWfLabels"/> but takes a source string.
+        /// Locate a sibling .resx file for a *.cs designer file and parse it
+        /// into a name→value dictionary. Designer convention is the .resx
+        /// shares the form's base name (e.g. `Foo.Designer.cs` ↔ `Foo.resx`).
+        /// Returns null if no .resx exists.
         /// </summary>
-        public static IReadOnlyList<string> ExtractWfLabelsFromSource(string sourceCode)
+        static Dictionary<string, string>? TryLoadSiblingResx(string csPath)
+        {
+            try
+            {
+                string dir = Path.GetDirectoryName(csPath) ?? "";
+                string baseName = Path.GetFileNameWithoutExtension(csPath);
+                // Strip ".Designer" if present so "Foo.Designer.cs" → "Foo".
+                if (baseName.EndsWith(".Designer", StringComparison.Ordinal))
+                    baseName = baseName.Substring(0, baseName.Length - ".Designer".Length);
+                string candidate = Path.Combine(dir, baseName + ".resx");
+                if (!File.Exists(candidate))
+                    return null;
+                var dict = new Dictionary<string, string>(StringComparer.Ordinal);
+                XDocument doc = XDocument.Load(candidate);
+                foreach (XElement data in doc.Descendants("data"))
+                {
+                    XAttribute? nameAttr = data.Attribute("name");
+                    XElement? valueEl = data.Element("value");
+                    if (nameAttr == null || valueEl == null)
+                        continue;
+                    dict[nameAttr.Value] = valueEl.Value;
+                }
+                return dict;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// In-memory variant for unit tests — same logic as
+        /// <see cref="ExtractWfLabels"/> but takes a source string. If
+        /// <paramref name="resourceLookup"/> is provided, `resources.GetString("k")`
+        /// callsites resolve to `resourceLookup["k"]` so .resx-backed
+        /// localisations participate in the inventory.
+        /// </summary>
+        public static IReadOnlyList<string> ExtractWfLabelsFromSource(
+            string sourceCode,
+            IReadOnlyDictionary<string, string>? resourceLookup = null)
         {
             if (string.IsNullOrEmpty(sourceCode))
                 return Array.Empty<string>();
@@ -237,6 +304,9 @@ namespace FEBuilderGBA.Avalonia.GapSweep
 
             // ---- 1. Pattern: `this.foo.Text = "Hello";` (designer-style) ----
             //    or  `foo.Text = "Hello";` (rare but legal)
+            // ---- 1b. Pattern: `this.foo.Text = resources.GetString("foo.Text");` ----
+            //    (VS Designer's localisation-aware emit mode — resolved via the
+            //     sibling .resx when one is provided.)
             // We collect string-literal assignments and resolve the LHS variable's
             // host type via the map.
             foreach (var assign in root.DescendantNodes().OfType<AssignmentExpressionSyntax>())
@@ -247,10 +317,6 @@ namespace FEBuilderGBA.Avalonia.GapSweep
                     continue;
                 if (memberAccess.Name.Identifier.Text != "Text")
                     continue;
-                if (assign.Right is not LiteralExpressionSyntax literal)
-                    continue;
-                if (!literal.IsKind(SyntaxKind.StringLiteralExpression))
-                    continue;
 
                 string? owner = ExtractWfOwnerVariable(memberAccess.Expression);
                 if (owner == null)
@@ -260,10 +326,28 @@ namespace FEBuilderGBA.Avalonia.GapSweep
                 if (!WfLabelHostTypes.Contains(hostType))
                     continue;
 
-                string text = (string?)literal.Token.Value ?? "";
-                if (text.Length == 0)
+                // Case A: RHS is a string literal.
+                if (assign.Right is LiteralExpressionSyntax literal &&
+                    literal.IsKind(SyntaxKind.StringLiteralExpression))
+                {
+                    string text = (string?)literal.Token.Value ?? "";
+                    if (text.Length > 0)
+                        labels.Add(text);
                     continue;
-                labels.Add(text);
+                }
+
+                // Case B: RHS is `resources.GetString("key")` — look up in the
+                // provided dictionary. We accept any callable whose method-name
+                // identifier is `GetString` (handles both ComponentResourceManager
+                // and ResourceManager subclasses) and a single string-literal arg.
+                if (resourceLookup != null &&
+                    assign.Right is InvocationExpressionSyntax inv &&
+                    TryGetResourceKey(inv) is { } key &&
+                    resourceLookup.TryGetValue(key, out string? resolved) &&
+                    !string.IsNullOrEmpty(resolved))
+                {
+                    labels.Add(resolved);
+                }
             }
 
             // ---- 2. Pattern: `new Label { Text = "Hello" }` (object initialiser) ----
@@ -391,6 +475,34 @@ namespace FEBuilderGBA.Avalonia.GapSweep
                     => ((IdentifierNameSyntax)m.Expression).Identifier.Text + "." + m.Name.Identifier.Text,
                 _ => null,
             };
+        }
+
+        /// <summary>
+        /// Recognise `resources.GetString("key")` (or any other
+        /// invocation whose method-name is `GetString` and which carries a
+        /// single string-literal argument) and return the literal key. The
+        /// receiver-name match (`resources`) would be too brittle — the
+        /// designer sometimes uses a different identifier — so we go by the
+        /// method-name + single-string-literal-arg signature instead. Returns
+        /// null if the invocation doesn't fit.
+        /// </summary>
+        static string? TryGetResourceKey(InvocationExpressionSyntax inv)
+        {
+            string methodName = inv.Expression switch
+            {
+                MemberAccessExpressionSyntax m => m.Name.Identifier.Text,
+                IdentifierNameSyntax id => id.Identifier.Text,
+                _ => "",
+            };
+            if (methodName != "GetString")
+                return null;
+            if (inv.ArgumentList.Arguments.Count != 1)
+                return null;
+            if (inv.ArgumentList.Arguments[0].Expression is not LiteralExpressionSyntax lit)
+                return null;
+            if (!lit.IsKind(SyntaxKind.StringLiteralExpression))
+                return null;
+            return (string?)lit.Token.Value;
         }
 
         /// <summary>Pull the trailing identifier out of a TypeSyntax (e.g. <c>System.Windows.Forms.Button</c> → <c>Button</c>).</summary>
@@ -605,10 +717,16 @@ namespace FEBuilderGBA.Avalonia.GapSweep
         /// If <paramref name="densityRows"/> is supplied, each per-pair section
         /// cross-links to that pair's density verdict (provides quantitative
         /// context for the qualitative label list).
+        ///
+        /// <paramref name="densityReportLink"/> is the path (relative to this
+        /// report's location) of the latest density baseline to cross-link from
+        /// the "Top 20" section. Pass null/empty to suppress the link entirely;
+        /// callers normally derive this from `FindLatestDensityReport(outDir)`.
         /// </summary>
         public static string FormatReport(
             IReadOnlyList<LabelDiffRow> rows,
-            IReadOnlyList<DensityRow>? densityRows = null)
+            IReadOnlyList<DensityRow>? densityRows = null,
+            string? densityReportLink = null)
         {
             if (rows == null) throw new ArgumentNullException(nameof(rows));
             // Density lookup keyed by (WfFormName, AvViewName) so each labels
@@ -631,11 +749,13 @@ namespace FEBuilderGBA.Avalonia.GapSweep
             sb.Append("to the Phase 1 control-density sweep.\n\n");
             sb.Append("WinForms side: Roslyn extracts `.Text = \"...\"` assignments on\n");
             sb.Append("`Label`, `GroupBox`, `Button`, `CheckBox`, `RadioButton`, `TabPage`\n");
-            sb.Append("controls (plus property-initialiser syntax for hand-coded forms).\n");
+            sb.Append("controls (plus property-initialiser syntax for hand-coded forms, and\n");
+            sb.Append("`resources.GetString(\"key\")` calls resolved via the sibling .resx).\n");
             sb.Append("Avalonia side: `XDocument` parses every view, harvests literal values from\n");
-            sb.Append("`Text` / `Content` / `Header` / `ToolTip` / `Watermark` attributes,\n");
-            sb.Append("skipping markup-extension values (`{Binding ...}`, `{StaticResource ...}`)\n");
-            sb.Append("and elements nested inside template containers (`Style`, `DataTemplate`, ...).\n\n");
+            sb.Append("`Text` / `Content` / `Header` / `ToolTip` / `ToolTip.Tip` / `Watermark`\n");
+            sb.Append("attributes, skipping markup-extension values (`{Binding ...}`,\n");
+            sb.Append("`{StaticResource ...}`) and elements nested inside template containers\n");
+            sb.Append("(`Style`, `DataTemplate`, ...).\n\n");
             sb.Append("Normalisation collapses whitespace, strips trailing colons, removes mnemonic\n");
             sb.Append("markers (`&` for WF, `_` for AV), and lowercases — so `Name:` / `&Name` /\n");
             sb.Append("`_Name` / `Name` all collide to the same set key. Original casing is preserved\n");
@@ -662,7 +782,16 @@ namespace FEBuilderGBA.Avalonia.GapSweep
             // ---- Top-20 candidate-missing-field counts ----
             sb.Append("## Top 20 Forms by WF-only Label Count\n\n");
             sb.Append("Each row's WF-only count is the upper bound on missing fields in the AV view.\n");
-            sb.Append("Cross-link to the [density sweep](2026-05-21-density-sweep.md) for quantitative context.\n\n");
+            if (!string.IsNullOrEmpty(densityReportLink))
+            {
+                sb.Append("Cross-link to the [density sweep](")
+                  .Append(densityReportLink)
+                  .Append(") for quantitative context.\n\n");
+            }
+            else
+            {
+                sb.Append("See the latest density baseline (under `docs/avalonia-gaps/`) for quantitative context.\n\n");
+            }
             sb.Append("| Rank | WF Form | AV View | WF-only | AV-only | Common |\n");
             sb.Append("|---:|---|---|---:|---:|---:|\n");
             int rank = 0;
@@ -728,21 +857,81 @@ namespace FEBuilderGBA.Avalonia.GapSweep
                 }
             }
 
+            // Trim any trailing blank lines so the body ends in a single `\n`.
+            // ReportWriter then adds at most one terminal newline, giving a
+            // clean EOF with no `git diff --check`-flagged extra blank lines.
+            // (Phase 1's density report had the same issue — fixed in #375's
+            // follow-up commit `e803555e6`; we apply the same discipline here.)
+            while (sb.Length >= 2 && sb[sb.Length - 1] == '\n' && sb[sb.Length - 2] == '\n')
+                sb.Length--;
             return sb.ToString();
         }
 
         /// <summary>
-        /// Render a label literal as inline-code markdown. If the literal
-        /// itself contains a backtick (rare for UI labels but possible), we
-        /// emit the double-backtick variant with surrounding spaces per the
-        /// CommonMark rule so the markdown renders correctly.
+        /// Render a label literal as inline-code markdown safely.
+        ///
+        /// Three concerns:
+        ///   1. Embedded backticks would break a single-backtick code span.
+        ///      Use double-backticks with leading/trailing space per CommonMark.
+        ///   2. Embedded CR/LF would break the markdown bullet (the renderer
+        ///      sees the second line as a sibling bullet or paragraph). We
+        ///      escape `\r` and `\n` as literal `\\r` / `\\n` sequences so the
+        ///      whole label stays on one line. The original label is still
+        ///      identifiable; readers can recover it by reversing the escape.
+        ///   3. Very long labels (≥ 200 chars) bloat the report; we truncate
+        ///      with an explicit ellipsis marker so the report stays scannable
+        ///      while still telling the reader "there's a long explanatory
+        ///      label here, dig into the designer file if you need the full
+        ///      text".
         /// </summary>
         static string RenderLabelLiteral(string label)
         {
-            if (label.IndexOf('`') < 0)
-                return "`" + label + "`";
-            // Use the double-backtick fence with leading/trailing space.
-            return "`` " + label + " ``";
+            // Step 1: escape embedded CR/LF so the bullet stays on one line.
+            string escaped = label.Replace("\r", "\\r").Replace("\n", "\\n");
+
+            // Step 2: truncate very long labels (these are typically
+            // explanatory paragraphs, not field labels).
+            const int MaxLen = 200;
+            if (escaped.Length > MaxLen)
+                escaped = escaped.Substring(0, MaxLen) + "… (truncated; see designer file)";
+
+            // Step 3: choose the safe code-fence (double-backtick with padding
+            // if the value itself contains a backtick).
+            if (escaped.IndexOf('`') < 0)
+                return "`" + escaped + "`";
+            return "`` " + escaped + " ``";
+        }
+
+        /// <summary>
+        /// Pick the latest density-sweep report (by filename date prefix) sitting
+        /// next to <paramref name="labelsReportPath"/>. Returns the file name
+        /// (no directory) so the link is portable across worktree paths. Returns
+        /// null when no density report exists.
+        ///
+        /// Convention: reports are named `YYYY-MM-DD-{type}-sweep.md`. We pick
+        /// the lexicographic max of `*-density-sweep.md` files because ISO-8601
+        /// dates sort naturally as strings.
+        /// </summary>
+        public static string? FindLatestDensityReport(string labelsReportPath)
+        {
+            try
+            {
+                string? dir = Path.GetDirectoryName(Path.GetFullPath(labelsReportPath));
+                if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir))
+                    return null;
+                string? latest = null;
+                foreach (string path in Directory.EnumerateFiles(dir, "*-density-sweep.md", SearchOption.TopDirectoryOnly))
+                {
+                    string name = Path.GetFileName(path);
+                    if (latest == null || string.CompareOrdinal(name, latest) > 0)
+                        latest = name;
+                }
+                return latest;
+            }
+            catch
+            {
+                return null;
+            }
         }
     }
 }

--- a/docs/avalonia-gaps/2026-05-22-labels-sweep.md
+++ b/docs/avalonia-gaps/2026-05-22-labels-sweep.md
@@ -1,0 +1,9912 @@
+---
+generated: "2026-05-21T16:32:05Z"
+git-sha: c7db152fd
+sweep-type: labels
+---
+
+# Avalonia vs WinForms — Field Label Diff Sweep
+
+This report extracts label literals from paired WinForms ↔ Avalonia
+editors and lists, per pair, the labels present in the WinForms designer
+but missing from the Avalonia counterpart. These are strong candidates
+for **missing fields in the Avalonia migration** — qualitative follow-up
+to the Phase 1 control-density sweep.
+
+WinForms side: Roslyn extracts `.Text = "..."` assignments on
+`Label`, `GroupBox`, `Button`, `CheckBox`, `RadioButton`, `TabPage`
+controls (plus property-initialiser syntax for hand-coded forms).
+Avalonia side: `XDocument` parses every view, harvests literal values from
+`Text` / `Content` / `Header` / `ToolTip` / `Watermark` attributes,
+skipping markup-extension values (`{Binding ...}`, `{StaticResource ...}`)
+and elements nested inside template containers (`Style`, `DataTemplate`, ...).
+
+Normalisation collapses whitespace, strips trailing colons, removes mnemonic
+markers (`&` for WF, `_` for AV), and lowercases — so `Name:` / `&Name` /
+`_Name` / `Name` all collide to the same set key. Original casing is preserved
+in the report's WF-only / AV-only / Common lists.
+
+Methodology lives in `FEBuilderGBA.Avalonia/GapSweep/LabelDiffScanner.cs`.
+Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-labels --out=<path>`.
+
+## Summary
+
+| Metric | Count |
+|---|---:|
+| Pairs scanned (both files exist) | 298 |
+| Pairs with ≥1 WF-only label | 293 |
+| Total WF-only labels | 4645 |
+| Total AV-only labels | 2463 |
+| Total common labels | 52 |
+
+## Top 20 Forms by WF-only Label Count
+
+Each row's WF-only count is the upper bound on missing fields in the AV view.
+Cross-link to the [density sweep](2026-05-21-density-sweep.md) for quantitative context.
+
+| Rank | WF Form | AV View | WF-only | AV-only | Common |
+|---:|---|---|---:|---:|---:|
+| 1 | `EmulatorMemoryForm` | `EmulatorMemoryView` | 174 | 4 | 1 |
+| 2 | `MapSettingFE7UForm` | `MapSettingFE7UView` | 90 | 78 | 0 |
+| 3 | `MapSettingFE7Form` | `MapSettingFE7View` | 87 | 78 | 0 |
+| 4 | `SkillConfigFE8NSkillForm` | `SkillConfigFE8NSkillView` | 84 | 18 | 0 |
+| 5 | `EventCondForm` | `EventCondView` | 81 | 21 | 0 |
+| 6 | `MapSettingForm` | `MapSettingView` | 78 | 116 | 0 |
+| 7 | `MapSettingFE6Form` | `MapSettingFE6View` | 65 | 2 | 0 |
+| 8 | `ClassForm` | `ClassEditorView` | 57 | 78 | 1 |
+| 9 | `EventUnitForm` | `EventUnitView` | 50 | 24 | 0 |
+| 10 | `SongInstrumentForm` | `SongInstrumentView` | 50 | 21 | 1 |
+| 11 | `TextForm` | `TextViewerView` | 48 | 11 | 0 |
+| 12 | `WorldMapImageForm` | `WorldMapImageView` | 47 | 2 | 0 |
+| 13 | `ImageUnitPaletteForm` | `ImageUnitPaletteView` | 45 | 17 | 0 |
+| 14 | `ItemForm` | `ItemEditorView` | 45 | 47 | 0 |
+| 15 | `MapStyleEditorForm` | `MapStyleEditorView` | 45 | 5 | 0 |
+| 16 | `UnitForm` | `UnitEditorView` | 45 | 50 | 4 |
+| 17 | `ItemFE6Form` | `ItemFE6View` | 44 | 27 | 0 |
+| 18 | `ToolInitWizardForm` | `ToolInitWizardView` | 44 | 8 | 0 |
+| 19 | `ClassFE6Form` | `ClassFE6View` | 43 | 5 | 0 |
+| 20 | `ImageBattleScreenForm` | `ImageBattleScreenView` | 42 | 2 | 0 |
+
+## Per-pair WF-only Labels (gaps)
+
+Sections sorted by WF-only count descending. Each label is rendered as a
+backticked literal preserving the original casing/punctuation. Use these as
+the per-form backlog for follow-up gap-fix PRs.
+
+### EmulatorMemoryForm
+WF labels: **175** · AV labels: **5** · WF-only: **174** · AV-only: **4** · Common: **1**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `0で霧なし。1が視界1マスの最大の霧です。`
+- `100(0x64)`
+- `104(0x68)`
+- `41(0x29)`
+- `44(0x2C)`
+- `48(0x30)`
+- `52(0x34)`
+- `56(0x38)`
+- `60(0x3C)`
+- `64(0x40)`
+- `68(0x44)`
+- `72(0x48)`
+- `76(0x4C)`
+- `80(0x50)`
+- `84(0x54)`
+- `88(0x58)`
+- `92(0x5C)`
+- `96(0x60)`
+- `??? 1`
+- `??? 2`
+- `??? 3`
+- `??? 8`
+- `??? 9`
+- `ActionData`
+- `AI1`
+- `AI1 Count`
+- `AI2`
+- `AI2 Count`
+- `AI3`
+- `AI4`
+- `AIData`
+- `BattleActor`
+- `BattleRound`
+- `BattleRounds`
+- `BattleSome`
+- `BattleTarget`
+- `BGM`
+- `Block Counter`
+- `BWL`
+- `ChapterData`
+- `Code cursor`
+- `Destructor Routine`
+- `Dungeon`
+- `ERROR`
+- `Etc`
+- `Exp`
+- `First Child Struct`
+- `Loop Routine`
+- `Lv`
+- `MapSprite`
+- `Mark`
+- `Name`
+- `Next Struct`
+- `Parent Procs`
+- `PartyCount`
+- `Previous Struct`
+- `Procs`
+- `ROM Class`
+- `ROM Unit`
+- `Sleep Timer`
+- `Some kind of bitfield`
+- `Start of code`
+- `Text`
+- `UserSpace`
+- `UserSpace1`
+- `UserSpace2`
+- `UserSpace3`
+- `Worldmap`
+- `Worldmap FE8`
+- `X`
+- `Y`
+- `↑最新`
+- `このユニットに以下のアイテムをもたせる`
+- `このユニットのHPを1にする。`
+- `このユニットのパラメータをカンストさせる。`
+- `このユニットの座標を変更しワープさせる。`
+- `この章へワープする`
+- `すべての味方ユニットを最強にします。(Hotkey Ctrl + G)`
+- `すべての敵ユニットAIを「移動しない」に設定にします。`
+- `すべての敵ユニットのHPを1にします。`
+- `より古い↓`
+- `アイテムID1`
+- `アイテムID2`
+- `アイテムID3`
+- `アイテムID4`
+- `アイテムID5`
+- `アイテム数1`
+- `アイテム数2`
+- `アイテム数3`
+- `アイテム数4`
+- `アイテム数5`
+- `アドレス`
+- `イベント`
+- `イベント履歴`
+- `イベント履歴(上が最新)
+時刻,イベント開始アドレス,実行中のアドレス,イベント`
+- `クリアターン数`
+- `クリアフラグ以外の、他のフラグを変更したい場合は、イベント画面から、変更したいフラグをダブルクリックしてください。`
+- `ターン数`
+- `ターン数を変更`
+- `チート`
+- `デバッグ用に便利なチート機能です`
+- `トラップデータ`
+- `パレット`
+- `パーティー`
+- `フラグ`
+- `マップID`
+- `メモリをダンプしてファイルに書き込む 0x02000000`
+- `メモリをダンプしてファイルに書き込む 0x03000000`
+- `メモリスロット`
+- `ユニットの行動で設定される項目`
+- `ワープする章`
+- `ワールドマップ拠点`
+- `体格＋`
+- `個数`
+- `光 EXP`
+- `再生されている音楽`
+- `剣 EXP`
+- `力と魔力`
+- `同行者ID`
+- `回復モード`
+- `塔と遺跡のデータ`
+- `天気`
+- `天気を変更(次のターンから適用されます。)`
+- `守備`
+- `実行しているイベント`
+- `弓 EXP`
+- `戦歴データ`
+- `戦闘に関係する諸データ`
+- `戦闘データ gBattleActor`
+- `戦闘データ gBattleTarget`
+- `所持金`
+- `所持金を以下の値に変更する`
+- `技`
+- `持たせるアイテム`
+- `操作中のユニット`
+- `支援1`
+- `支援2`
+- `支援3`
+- `支援4`
+- `支援5`
+- `支援6`
+- `支援7`
+- `支援フラグ`
+- `敵を含めて、すべてのユニットを最強にします`
+- `斧 EXP`
+- `最大HP`
+- `杖 EXP`
+- `検索`
+- `槍 EXP`
+- `汎用`
+- `状態`
+- `状態とターン`
+- `現在HP`
+- `現在、操作しているユニット`
+- `現在の章をクリアします。(Hotkey: Ctrl + U)`
+- `理 EXP`
+- `移動＋`
+- `章データ`
+- `編`
+- `聖水松明`
+- `自動的に更新する`
+- `解析者向けの機能`
+- `輸送隊`
+- `輸送隊の内容`
+- `速さ`
+- `運`
+- `選択アドレス:`
+- `部隊表ID`
+- `闇 EXP`
+- `闘技場`
+- `闘技場の相手選出に利用するデータ`
+- `霧レベル`
+- `霧レベルを変更(次のターンから適用されます。)`
+- `魔防`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Emulator Memory`
+- `Emulator memory reading requires Windows P/Invoke and is not available in the cross-platform Avalonia version.`
+- `Platform Notice`
+- `This feature uses Windows-specific APIs to read the memory of a running GBA emulator process for live debugging. Please use the Windows (WinForms) version of FEBuilderGBA for this functionality.`
+
+### MapSettingFE7UForm
+WF labels: **90** · AV labels: **78** · WF-only: **90** · AV-only: **78** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Aエリウッドノーマル`
+- `Aエリウッドハード`
+- `Aヘクトルノーマル`
+- `Aヘクトルハード`
+- `Bエリウッドノーマル`
+- `Bエリウッドハード`
+- `Bヘクトルノーマル`
+- `Bヘクトルハード`
+- `CP`
+- `Cエリウッドノーマル`
+- `Cエリウッドハード`
+- `Cヘクトルノーマル`
+- `Cヘクトルハード`
+- `Dエリウッドノーマル`
+- `Dエリウッドハード`
+- `Dヘクトルノーマル`
+- `Dヘクトルハード`
+- `PreparationScreenCh No.`
+- `Size:`
+- `X:`
+- `Y:`
+- `♪`
+- `アドレス`
+- `イベントID(Plist)`
+- `エリウッドノーマル`
+- `エリウッドハード`
+- `オブジェクトタイプ(Plist)`
+- `クリア条件(表示のみ)`
+- `タイルアニメーション1`
+- `タイルアニメーション2`
+- `ターン数表示用`
+- `チップセットクタイプ(Plist)`
+- `パレット(Plist)`
+- `ヘクトルノーマル`
+- `ヘクトルハード`
+- `マップエディタへJump`
+- `マップスタイルの変更`
+- `マップポインタ(Plist)`
+- `マップ部分変更(Plist)`
+- `リストの拡張`
+- `ワールドマップ自動イベント`
+- `先頭アドレス`
+- `再取得`
+- `初期座標`
+- `勝利BGMに変わる敵数`
+- `占い会話(エリウッド)`
+- `占い会話(ヘクトル)`
+- `占い会話(冒頭)`
+- `占い会話(終了確認)`
+- `占い師の顔`
+- `占い料`
+- `友軍BGM(エリウッド編)`
+- `友軍BGM(ヘクトル編)`
+- `名前`
+- `味方フェーズBGM(エリウッド編)`
+- `味方フェーズBGM(ヘクトル編)`
+- `味方フェーズBGMフラグ4`
+- `壊れる壁HP`
+- `天気`
+- `戦闘準備の有無`
+- `戦闘背景`
+- `攻略評価`
+- `敵フェーズBGM(エリウッド編)`
+- `敵フェーズBGM(ヘクトル編)`
+- `敵フェーズBGMフラグ4`
+- `書き込み`
+- `特殊表示`
+- `章タイトル(エリウッド)`
+- `章タイトル(ヘクトル)`
+- `章タイトル文字(エリウッド)`
+- `章タイトル文字(ヘクトル)`
+- `章タイトル画像`
+- `章タイトル画像2`
+- `章プロローグBGM(エリウッド編)`
+- `章プロローグBGM(ヘクトル編)`
+- `章プロローグBGM(共通)`
+- `経験評価`
+- `詳細クリア条件(表示のみ)`
+- `読込数`
+- `資産評価`
+- `輸送隊 エリウッド編`
+- `輸送隊 ヘクトル編`
+- `選択アドレス:`
+- `開始イベント前に暗転`
+- `防衛ユニットの◇マーク`
+- `離脱▲マーク`
+- `離脱ポイントへJump`
+- `難易度補正`
+- `霧レベル`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `B10: Tile animation 2 (PLIST)`
+- `B11: Map change (PLIST)`
+- `B120: Event ID (PLIST)`
+- `B121: World map auto event`
+- `B12: Fog level`
+- `B130: Fortune portrait`
+- `B131: Fortune fee`
+- `B132: Prep screen Ch no. 1`
+- `B133: Prep screen Ch no. 2`
+- `B134: Transporter Eliwood X`
+- `B135: Transporter Hector X`
+- `B136: Transporter Eliwood Y`
+- `B137: Transporter Hector Y`
+- `B138: Victory BGM enemy count`
+- `B139: Darken before start`
+- `B13: Battle preparation`
+- `B144: Special display`
+- `B145: Turn count display`
+- `B146: Defense unit mark`
+- `B147: Escape marker X`
+- `B148: Escape marker Y`
+- `B149: ??`
+- `B14: Chapter title image`
+- `B150: ??`
+- `B151: ??`
+- `B15: Chapter title image 2`
+- `B16: Padding`
+- `B17: Padding`
+- `B18: Weather`
+- `B19: Battle BG`
+- `B44: Breakable wall HP`
+- `B61: ??`
+- `B6: Palette (PLIST)`
+- `B7: Chipset config (PLIST)`
+- `B8: Map pointer (PLIST)`
+- `B9: Tile animation 1 (PLIST)`
+- `BGM / Music`
+- `Breakable Wall HP / Unknowns`
+- `Chapter / Transporter / Victory`
+- `Chapter Title Text IDs`
+- `Clear Conditions`
+- `CP / Pointer`
+- `D0: CP`
+- `Difficulty Pointers (D96-D108)`
+- `Display Flags (B144-B151)`
+- `Eliwood Hard (D100):`
+- `Eliwood Normal (D96):`
+- `Event / Fortune Teller`
+- `Hector Hard (D108):`
+- `Hector Normal (D104):`
+- `Map Properties`
+- `Map Settings (FE7U)`
+- `Map Style / PLIST`
+- `W112: Eliwood title text`
+- `W114: Hector title text`
+- `W116: Eliwood title text 2`
+- `W118: Hector title text 2`
+- `W122: Fortune text (opening)`
+- `W124: Fortune text (Eliwood)`
+- `W126: Fortune text (Hector)`
+- `W128: Fortune text (confirm)`
+- `W140: Clear condition text`
+- `W142: Detail clear condition`
+- `W20: Difficulty adjustment`
+- `W22: Player phase BGM`
+- `W24: Enemy phase BGM`
+- `W26: NPC phase BGM`
+- `W28: Player phase BGM 2`
+- `W30: Enemy phase BGM 2`
+- `W32: NPC phase BGM 2`
+- `W34: Player phase BGM flag 4`
+- `W36: Enemy phase BGM flag 4`
+- `W38: Prologue BGM (Common)`
+- `W40: Prologue BGM (Eliwood)`
+- `W42: Prologue BGM (Hector)`
+- `W4: Object type (PLIST)`
+- `W94: ??`
+- `Write`
+
+### MapSettingFE7Form
+WF labels: **87** · AV labels: **78** · WF-only: **87** · AV-only: **78** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Aエリウッドノーマル`
+- `Aエリウッドハード`
+- `Aヘクトルノーマル`
+- `Aヘクトルハード`
+- `Bエリウッドノーマル`
+- `Bエリウッドハード`
+- `Bヘクトルノーマル`
+- `Bヘクトルハード`
+- `CP`
+- `Cエリウッドノーマル`
+- `Cエリウッドハード`
+- `Cヘクトルノーマル`
+- `Cヘクトルハード`
+- `Dエリウッドノーマル`
+- `Dエリウッドハード`
+- `Dヘクトルノーマル`
+- `Dヘクトルハード`
+- `PreparationScreenCh No.`
+- `Size:`
+- `X:`
+- `Y:`
+- `♪`
+- `アドレス`
+- `イベントID(Plist)`
+- `エリウッドノーマル`
+- `エリウッドハード`
+- `オブジェクトタイプ(Plist)`
+- `クリア条件(表示のみ)`
+- `タイルアニメーション1`
+- `タイルアニメーション2`
+- `ターン数表示用`
+- `チップセットクタイプ(Plist)`
+- `パレット(Plist)`
+- `ヘクトルノーマル`
+- `ヘクトルハード`
+- `マップエディタへJump`
+- `マップスタイルの変更`
+- `マップポインタ(Plist)`
+- `マップ部分変更(Plist)`
+- `リストの拡張`
+- `ワールドマップ自動イベント`
+- `先頭アドレス`
+- `再取得`
+- `初期座標`
+- `勝利BGMに変わる敵数`
+- `占い会話(エリウッド)`
+- `占い会話(ヘクトル)`
+- `占い会話(冒頭)`
+- `占い会話(終了確認)`
+- `占い師の顔`
+- `占い料`
+- `友軍BGM(エリウッド編)`
+- `友軍BGM(ヘクトル編)`
+- `名前`
+- `味方フェーズBGM(エリウッド編)`
+- `味方フェーズBGM(ヘクトル編)`
+- `味方フェーズBGMフラグ4`
+- `壊れる壁HP`
+- `天気`
+- `戦闘準備の有無`
+- `戦闘背景`
+- `攻略評価`
+- `敵フェーズBGM(エリウッド編)`
+- `敵フェーズBGM(ヘクトル編)`
+- `敵フェーズBGMフラグ4`
+- `書き込み`
+- `特殊表示`
+- `章タイトル(エリウッド)`
+- `章タイトル(ヘクトル)`
+- `章タイトル画像`
+- `章タイトル画像2`
+- `章プロローグBGM(エリウッド編)`
+- `章プロローグBGM(ヘクトル編)`
+- `章プロローグBGM(共通)`
+- `経験評価`
+- `詳細クリア条件(表示のみ)`
+- `読込数`
+- `資産評価`
+- `輸送隊 エリウッド編`
+- `輸送隊 ヘクトル編`
+- `選択アドレス:`
+- `開始イベント前に暗転`
+- `離脱▲マーク`
+- `離脱ポイントへJump`
+- `難易度補正`
+- `霧レベル`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `B10: Tile animation 2 (PLIST)`
+- `B116: Event ID (PLIST)`
+- `B117: World map auto event`
+- `B11: Map change (PLIST)`
+- `B126: Fortune portrait`
+- `B127: Fortune fee`
+- `B128: Chapter number`
+- `B129: Prep screen Ch no. 1`
+- `B12: Fog level`
+- `B130: Transporter Eliwood X`
+- `B131: Transporter Hector X`
+- `B132: Transporter Eliwood Y`
+- `B133: Transporter Hector Y`
+- `B134: Victory BGM enemy count`
+- `B135: Blackout before start`
+- `B13: Battle preparation`
+- `B140: Special display`
+- `B141: Turn count display`
+- `B142: Defense unit mark`
+- `B143: Escape marker X`
+- `B144: Escape marker Y`
+- `B145: ??`
+- `B146: ??`
+- `B147: ??`
+- `B14: Chapter title image`
+- `B15: Chapter title image 2`
+- `B16: Initial X coordinate`
+- `B17: Initial Y coordinate`
+- `B18: Weather`
+- `B19: Battle BG lookup`
+- `B44: Breakable wall HP`
+- `B61: ??`
+- `B61: Unknown`
+- `B6: Palette (PLIST)`
+- `B7: Chipset config (PLIST)`
+- `B8: Map pointer (PLIST)`
+- `B9: Tile animation 1 (PLIST)`
+- `BGM / Music`
+- `Breakable Wall HP / Difficulty Ratings`
+- `Chapter / Transporter / Victory`
+- `Clear Conditions`
+- `CP / Pointer`
+- `D0: CP`
+- `Difficulty Pointers (D96-D108)`
+- `Display Flags (B140-B147)`
+- `Eliwood Hard (D100):`
+- `Eliwood Normal (D96):`
+- `Event / Fortune Teller`
+- `Hector Hard (D108):`
+- `Hector Normal (D104):`
+- `Map Name Text IDs`
+- `Map Properties`
+- `Map Settings (FE7JP)`
+- `Map Style / PLIST`
+- `W112: Map name 1`
+- `W114: Map name 2`
+- `W118: Fortune text (opening)`
+- `W120: Fortune text (Eliwood)`
+- `W122: Fortune text (Hector)`
+- `W124: Fortune text (confirm)`
+- `W136: Clear condition text`
+- `W138: Detail clear condition`
+- `W20: Difficulty adjustment`
+- `W22: Player phase BGM`
+- `W24: Enemy phase BGM`
+- `W26: NPC phase BGM`
+- `W28: Player phase BGM 2`
+- `W30: Enemy phase BGM 2`
+- `W32: NPC phase BGM 2`
+- `W34: Player phase BGM flag 4`
+- `W36: Enemy phase BGM flag 4`
+- `W38: ???`
+- `W40: ???`
+- `W42: ???`
+- `W4: Object type (PLIST)`
+- `W94: ??`
+- `W94: Unknown`
+- `Write`
+
+### SkillConfigFE8NSkillForm
+WF labels: **84** · AV labels: **18** · WF-only: **84** · AV-only: **18** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Size:`
+- `↓文字列内訳`
+- `その他`
+- `その他1`
+- `その他10`
+- `その他11`
+- `その他12`
+- `その他13`
+- `その他14`
+- `その他15`
+- `その他16`
+- `その他2`
+- `その他3`
+- `その他4`
+- `その他5`
+- `その他6`
+- `その他7`
+- `その他8`
+- `その他9`
+- `アイコン`
+- `アイコン表示条件`
+- `アイテム`
+- `アイテム1`
+- `アイテム10`
+- `アイテム11`
+- `アイテム12`
+- `アイテム13`
+- `アイテム14`
+- `アイテム15`
+- `アイテム16`
+- `アイテム2`
+- `アイテム3`
+- `アイテム4`
+- `アイテム5`
+- `アイテム6`
+- `アイテム7`
+- `アイテム8`
+- `アイテム9`
+- `アドレス`
+- `クラス`
+- `クラス1`
+- `クラス10`
+- `クラス11`
+- `クラス12`
+- `クラス13`
+- `クラス14`
+- `クラス15`
+- `クラス16`
+- `クラス2`
+- `クラス3`
+- `クラス4`
+- `クラス5`
+- `クラス6`
+- `クラス7`
+- `クラス8`
+- `クラス9`
+- `スキル名`
+- `ユニット`
+- `ユニット1`
+- `ユニット10`
+- `ユニット11`
+- `ユニット12`
+- `ユニット13`
+- `ユニット14`
+- `ユニット15`
+- `ユニット16`
+- `ユニット2`
+- `ユニット3`
+- `ユニット4`
+- `ユニット5`
+- `ユニット6`
+- `ユニット7`
+- `ユニット8`
+- `ユニット9`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `条件:`
+- `説明`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Condition Class 1:`
+- `Condition Class 2:`
+- `Condition Class 3:`
+- `Condition Class 4:`
+- `Condition Item 1:`
+- `Condition Item 2:`
+- `Condition Item 3:`
+- `Condition Item 4:`
+- `Condition Unit 1:`
+- `Condition Unit 2:`
+- `Condition Unit 3:`
+- `Condition Unit 4:`
+- `Description:`
+- `Icon:`
+- `Skill Configuration (FE8N)`
+- `Skill system editors require a compatible skill patch to be installed.
+Use the Patch Manager to install a skill system patch first.
+
+Supported skill systems: CSkillSys, FE8N Skill System`
+- `Write`
+
+### EventCondForm
+WF labels: **81** · AV labels: **21** · WF-only: **81** · AV-only: **21** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `0:`
+- `00`
+- `??`
+- `ASM会話条件`
+- `ASM条件`
+- `ASM条件FE6`
+- `LV`
+- `NOP`
+- `Size:`
+- `TextID`
+- `Vein`
+- `VeinEffectID`
+- `X:`
+- `Y:`
+- `アドレス`
+- `アーチの種類`
+- `アーチ配置`
+- `イベント`
+- `イベントポインタ`
+- `イベントポインタ書き込み`
+- `イベント種類`
+- `ガスの方向`
+- `コメント`
+- `ゴーゴンの卵`
+- `ゴールド`
+- `ターン前指定`
+- `ターン条件`
+- `ターン条件FE7`
+- `チュートリアル`
+- `トラップ`
+- `トラップ床`
+- `マップオブジェクト`
+- `マップ名`
+- `リストの拡張`
+- `リピートタイマー`
+- `会話元`
+- `会話先`
+- `会話条件`
+- `先頭アドレス`
+- `再取得`
+- `初期タイマー`
+- `判定ASM関数`
+- `判定フラグ`
+- `制圧ポイントと民家`
+- `名前`
+- `地雷`
+- `宝箱`
+- `宝箱の中身`
+- `常時条件`
+- `店`
+- `店の売り物`
+- `店の種類`
+- `座標`
+- `扉`
+- `新規イベント`
+- `新規確保`
+- `書き込み`
+- `毒ガス`
+- `炎`
+- `発生タイプ`
+- `神の矢`
+- `種類`
+- `範囲条件`
+- `範囲終了`
+- `範囲開始`
+- `終了ターン`
+- `編`
+- `羽化開始`
+- `耐久`
+- `訪問村`
+- `話す条件`
+- `話す条件FE6`
+- `読込数`
+- `追加判定`
+- `達成フラグ`
+- `選択されている配置情報を、ユニット配置画面で開く`
+- `選択されている開始/終了イベントを、イベント編集画面で開く`
+- `選択アドレス:`
+- `配置`
+- `配置座標`
+- `開始ターン`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `B10:`
+- `B11:`
+- `B12:`
+- `B13:`
+- `B14:`
+- `B15:`
+- `B8:`
+- `B9:`
+- `Condition Slot`
+- `Event Condition Editor`
+- `Event Pointer:`
+- `Flag ID:`
+- `Maps`
+- `Raw Hex:`
+- `Record Address:`
+- `Record Size:`
+- `Records`
+- `Sub-type:`
+- `Type:`
+- `Type Name:`
+- `Write`
+
+### MapSettingForm
+WF labels: **78** · AV labels: **116** · WF-only: **78** · AV-only: **116** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `???`
+- `Aエリウッドノーマル`
+- `Aエリウッドハード`
+- `Aヘクトルノーマル`
+- `Aヘクトルハード`
+- `Bエリウッドノーマル`
+- `Bエリウッドハード`
+- `Bヘクトルノーマル`
+- `Bヘクトルハード`
+- `Chapter Number`
+- `CP`
+- `Cエリウッドノーマル`
+- `Cエリウッドハード`
+- `Cヘクトルノーマル`
+- `Cヘクトルハード`
+- `Dエリウッドノーマル`
+- `Dエリウッドハード`
+- `Dヘクトルノーマル`
+- `Dヘクトルハード`
+- `Size:`
+- `X:`
+- `Y:`
+- `♪`
+- `アドレス`
+- `イベントID(Plist)`
+- `エリウッドノーマル`
+- `エリウッドハード`
+- `オブジェクトタイプ(Plist)`
+- `クリア条件(表示のみ)`
+- `タイルアニメーション1`
+- `タイルアニメーション2`
+- `ターン数表示用`
+- `チップセットクタイプ(Plist)`
+- `パレット(Plist)`
+- `ヘクトルノーマル`
+- `ヘクトルハード`
+- `マップエディタへJump`
+- `マップスタイルの変更`
+- `マップポインタ(Plist)`
+- `マップ名1`
+- `マップ名2(X)`
+- `マップ部分変更(Plist)`
+- `リストの拡張`
+- `ワールドマップ自動イベント`
+- `先頭アドレス`
+- `再取得`
+- `初期座標`
+- `勝利BGMに変わる敵数`
+- `友軍BGM`
+- `友軍BGM2(X)`
+- `名前`
+- `味方フェーズBGM`
+- `味方フェーズBGM2(X)`
+- `味方フェーズBGMフラグ4`
+- `壊れる壁HP`
+- `戦闘準備の有無(X)`
+- `戦闘背景`
+- `指南へJump`
+- `攻略評価`
+- `敵フェーズBGM`
+- `敵フェーズBGM2(X)`
+- `敵フェーズBGMフラグ4`
+- `書き込み`
+- `特殊表示`
+- `章タイトル画像`
+- `章タイトル画像2(X)`
+- `経験評価`
+- `詳細クリア条件(表示のみ)`
+- `読込数`
+- `資産評価`
+- `選択アドレス:`
+- `開始イベント前に暗転`
+- `防衛ユニットの◇マーク`
+- `離脱▲マーク`
+- `離脱ポイントへJump`
+- `難易度補正`
+- `霧レベル`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `?? (B119):`
+- `?? (B120):`
+- `?? (B121):`
+- `?? (B122):`
+- `?? (B123):`
+- `?? (B124):`
+- `?? (B125):`
+- `?? (B126):`
+- `?? (B127):`
+- `?? (B129):`
+- `?? (B130):`
+- `?? (B131):`
+- `?? (B132):`
+- `?? (B133):`
+- `Asset Rating`
+- `B10: Tile animation 2 (PLIST)`
+- `B116: Event ID (PLIST)`
+- `B117: World map auto event`
+- `B118: ??`
+- `B11: Map change (PLIST)`
+- `B12: Fog level`
+- `B134: Enemies for victory BGM`
+- `B135: Blackout before start`
+- `B13: Battle preparation (X)`
+- `B140: Special display`
+- `B141: Turn count display`
+- `B142: Defense unit mark`
+- `B143: Escape marker X`
+- `B144: Escape marker Y`
+- `B145: ??`
+- `B146: ??`
+- `B147: ??`
+- `B14: Chapter title image`
+- `B15: Chapter title image 2 (X)`
+- `B16: Initial X coordinate`
+- `B17: Initial Y coordinate`
+- `B18: Weather`
+- `B19: Battle BG lookup`
+- `B44: Breakable wall HP`
+- `B45: A Eliwood Normal`
+- `B46: A Eliwood Hard`
+- `B47: A Hector Normal`
+- `B48: A Hector Hard`
+- `B49: B Eliwood Normal`
+- `B50: B Eliwood Hard`
+- `B51: B Hector Normal`
+- `B52: B Hector Hard`
+- `B53: C Eliwood Normal`
+- `B54: C Eliwood Hard`
+- `B55: C Hector Normal`
+- `B56: C Hector Hard`
+- `B57: D Eliwood Normal`
+- `B58: D Eliwood Hard`
+- `B59: D Hector Normal`
+- `B60: D Hector Hard`
+- `B61: ??`
+- `B6: Palette (PLIST)`
+- `B7: Chipset config (PLIST)`
+- `B8: Map pointer (PLIST)`
+- `B9: Tile animation 1 (PLIST)`
+- `BGM / Music`
+- `Breakable Wall HP / Difficulty Ratings`
+- `Chapter number (B128):`
+- `Clear Condition (display only)`
+- `CP / Pointer`
+- `D Rating`
+- `D0: CP`
+- `Difficulty Ratings`
+- `Display Flags (B140-B147)`
+- `Eliwood Hard (D100):`
+- `Eliwood Normal (D96):`
+- `Event / World Map (B116-B135)`
+- `Experience Rating`
+- `Hector Hard (D108):`
+- `Hector Normal (D104):`
+- `Map Name Text IDs`
+- `Map Properties`
+- `Map Settings`
+- `Map Style / PLIST`
+- `Pointers (D96-D108)`
+- `Strategy Rating`
+- `W112: Map name 1`
+- `W114: Map name 2 (X)`
+- `W136: Clear condition (display only)`
+- `W138: Detail clear condition (display only)`
+- `W20: Difficulty adjustment`
+- `W22: Player phase BGM`
+- `W24: Enemy phase BGM`
+- `W26: NPC phase BGM`
+- `W28: Player phase BGM 2 (X)`
+- `W30: Enemy phase BGM 2 (X)`
+- `W32: NPC phase BGM 2 (X)`
+- `W34: Player phase BGM flag 4`
+- `W36: Enemy phase BGM flag 4`
+- `W38: ???`
+- `W40: ???`
+- `W42: ???`
+- `W4: Object type (PLIST)`
+- `W62: A Eliwood Normal`
+- `W64: A Eliwood Hard`
+- `W66: A Hector Normal`
+- `W68: A Hector Hard`
+- `W70: B Eliwood Normal`
+- `W72: B Eliwood Hard`
+- `W74: B Hector Normal`
+- `W76: B Hector Hard`
+- `W78: C Eliwood Normal`
+- `W80: C Eliwood Hard`
+- `W82: C Hector Normal`
+- `W84: C Hector Hard`
+- `W86: D Eliwood Normal`
+- `W88: D Eliwood Hard`
+- `W90: D Hector Normal`
+- `W92: D Hector Hard`
+- `W94: ??`
+- `Write`
+
+### MapSettingFE6Form
+WF labels: **65** · AV labels: **2** · WF-only: **65** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Chapter Number`
+- `CP`
+- `Size:`
+- `X:`
+- `Y:`
+- `♪`
+- `アドレス`
+- `イベントID(Plist)`
+- `オブジェクトタイプ(Plist)`
+- `クリア条件(表示のみ)`
+- `タイルアニメーション1`
+- `タイルアニメーション2`
+- `チップセットクタイプ(Plist)`
+- `ハードブースト`
+- `パレット(Plist)`
+- `マップエディタへJump`
+- `マップスタイルの変更`
+- `マップポインタ(Plist)`
+- `マップ部分変更(Plist)`
+- `リストの拡張`
+- `ワールドマップBGM`
+- `ワールドマップX`
+- `ワールドマップY`
+- `ワールドマップポイントX`
+- `ワールドマップポイントY`
+- `ワールドマップ地名`
+- `ワールドマップ自動イベント`
+- `上の軍`
+- `下の軍`
+- `先頭アドレス`
+- `再取得`
+- `初期座標`
+- `勝利BGMに変わる敵数`
+- `友軍BGM`
+- `名前`
+- `味方フェーズBGM`
+- `壊れる壁HP`
+- `天気`
+- `戦力評価A`
+- `戦力評価B`
+- `戦力評価C`
+- `戦力評価D`
+- `戦闘準備の有無`
+- `戦闘背景`
+- `攻略評価`
+- `攻略評価A`
+- `攻略評価B`
+- `攻略評価C`
+- `攻略評価D`
+- `敵の軍旗`
+- `敵フェーズBGM`
+- `書き込み`
+- `章オープニングBGM`
+- `章タイトル`
+- `章タイトル画像`
+- `経験評価`
+- `経験評価A`
+- `経験評価B`
+- `経験評価C`
+- `経験評価D`
+- `読込数`
+- `選択アドレス:`
+- `離脱ポイントへJump`
+- `霧レベル`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Map Settings (FE6)`
+
+### ClassForm
+WF labels: **58** · AV labels: **79** · WF-only: **57** · AV-only: **78** · Common: **1**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `???`
+- `[HardCoding]`
+- `CCボーナス`
+- `Export All`
+- `Export Selected`
+- `Growths as Decimal`
+- `HP`
+- `ID`
+- `Import All`
+- `Import Selected`
+- `Include Base Stats`
+- `Include Growths`
+- `Include Header`
+- `Include Name`
+- `Include UID`
+- `Include Wep Level`
+- `LV`
+- `Size:`
+- `Use Clipboard`
+- `アドレス`
+- `クラスチェンジクラス`
+- `クラス基礎能力`
+- `クラス能力最大値`
+- `シミュレーション`
+- `スキル`
+- `ソート順`
+- `リストの拡張`
+- `一般兵顔`
+- `体格`
+- `先頭アドレス`
+- `再取得`
+- `合計%`
+- `名前`
+- `地形回避`
+- `地形防御`
+- `地形魔防`
+- `守備`
+- `幸運`
+- `待機アイコン`
+- `戦闘時アニメ`
+- ` 技 `
+- `攻撃`
+- `敵成長率(%)`
+- `書き込み`
+- `武器LV`
+- `移動`
+- `移動コスト`
+- `移動コスト(雨)`
+- `移動コスト(雪)`
+- `移動速度`
+- `経験値補正値`
+- `詳細`
+- `読込数`
+- `速さ`
+- `選択アドレス:`
+- `魔力`
+- `魔防`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `??? (D80):`
+- `Ability 1 (B40):`
+- `Ability 2 (B41):`
+- `Ability 3 (B42):`
+- `Ability 4 (B43):`
+- `Ability Flags`
+- `Address:`
+- `Anima (B49):`
+- `Axe (B46):`
+- `Base Stats`
+- `Battle Anime (P52):`
+- `Bow (B47):`
+- `Calculate Growth`
+- `Class # (B4):`
+- `Class Editor`
+- `Con (B17):`
+- `Dark (B51):`
+- `Def (B15):`
+- `Def (B31):`
+- `Def (b38):`
+- `Desc`
+- `Desc ID (W2):`
+- `Edit Skills`
+- `Export TSV`
+- `Growth Rates`
+- `Growth Simulator`
+- `HP (B11):`
+- `HP (B27):`
+- `HP (b34):`
+- `Identity / Misc`
+- `Import TSV`
+- `Jump`
+- `Lance (B45):`
+- `Lck (B33):`
+- `Light (B50):`
+- `Max Con (B25):`
+- `Max Def (B23):`
+- `Max HP (B19):`
+- `Max Res (B24):`
+- `Max Skl (B21):`
+- `Max Spd (B22):`
+- `Max Str (B20):`
+- `Mov (B18):`
+- `Move Cost (P56):`
+- `Move Cost Rain (P60):`
+- `Move Cost Snow (P64):`
+- `Name:`
+- `Name ID (W0):`
+- `Pointers / Movement / Terrain`
+- `Portrait (W8):`
+- `Power (B26):`
+- `Promo Lv (B5):`
+- `Promotion Gains (CC Bonus)`
+- `Res (B16):`
+- `Res (B32):`
+- `Res (b39):`
+- `Sim Level:`
+- `Skl (B13):`
+- `Skl (B29):`
+- `Skl (b36):`
+- `Sort Order (B10):`
+- `Spd (B14):`
+- `Spd (B30):`
+- `Spd (b37):`
+- `Staff (B48):`
+- `Stat Caps (Max Values)`
+- `Str (B12):`
+- `Str (B28):`
+- `Str (b35):`
+- `Sword (B44):`
+- `Terrain Avoid (P68):`
+- `Terrain Def (P72):`
+- `Terrain Res (P76):`
+- `Wait Icon (B6):`
+- `Walk Spd (B7):`
+- `Warnings`
+- `Weapon Rank Levels (B44-B51)`
+- `Write`
+
+### EventUnitForm
+WF labels: **50** · AV labels: **24** · WF-only: **50** · AV-only: **24** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `/60秒`
+- `1次AI`
+- `2次AI`
+- `??`
+- `Close`
+- `FF`
+- `LV:`
+- `Size:`
+- `X:`
+- `Y:`
+- `↑`
+- `↓`
+- `アイテムドロップ`
+- `アドレス`
+- `イベント名前`
+- `クラス`
+- `コメント`
+- `マップ名前`
+- `ユニット情報`
+- `ユニット番号`
+- `リストの拡張`
+- `交戦時BGMへJump`
+- `交戦時セリフへJump`
+- `先頭アドレス`
+- `再取得`
+- `削除`
+- `名前`
+- `変更`
+- `座標`
+- `待機`
+- `成長率:`
+- `所属:`
+- `所持品1`
+- `所持品2`
+- `所持品3`
+- `所持品4`
+- `指揮官`
+- `新規挿入`
+- `新規領域の確保`
+- `書き込み`
+- `標的と回復AI`
+- `死亡時セリフへJump`
+- `特殊`
+- `移動後座標`
+- `移動速度`
+- `読込数`
+- `追従`
+- `退避AI`
+- `選択アドレス:`
+- `配置後座標格納アドレス`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `0x Address`
+- `Address:`
+- `AI1 Primary:`
+- `AI2 Secondary:`
+- `AI3 Target/Recovery:`
+- `AI4 Retreat:`
+- `Class ID:`
+- `Coord Count:`
+- `Coord Pointer:`
+- `Event Unit Placement (FE8)`
+- `Item 1:`
+- `Item 2:`
+- `Item 3:`
+- `Item 4:`
+- `Leader Unit ID:`
+- `Load`
+- `Maps`
+- `Reserved (0x06):`
+- `Unit Groups`
+- `Unit Growth:`
+- `Unit ID:`
+- `Unit Info:`
+- `Units`
+- `Write`
+
+### SongInstrumentForm
+WF labels: **51** · AV labels: **22** · WF-only: **50** · AV-only: **21** · Common: **1**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `= c_v - 64`
+- `??`
+- `atk`
+- `dec`
+- `DirectSound`
+- `DirectSound Fixed Freq`
+- `DirectSound Reverse`
+- `DrumPart`
+- `Info`
+- `Multi Sample`
+- `Noise`
+- `Noise2`
+- `noisepattern`
+- `PAN強制`
+- `Preview`
+- `rel`
+- `s`
+- `Size:`
+- `SongData FingerPrint`
+- `squarepattern`
+- `SquareWave1`
+- `SquareWave2`
+- `SquareWave3`
+- `SquareWave4`
+- `sus`
+- `sweepshift`
+- `sweeptime`
+- `Wave Memory`
+- `Wave Memory2`
+- `アドレス`
+- `キー割り当て`
+- `ドラムセット`
+- `パンポット`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `基準ノート値`
+- `書き込み`
+- `楽器セット`
+- `楽器データ 書出`
+- `楽器データ 読込`
+- `波形データ`
+- `種類`
+- `読込数`
+- `選択アドレス:`
+- `音データ`
+- `音データ 書出`
+- `音データ 読込`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Attack:`
+- `Decay:`
+- `Drum Part Pointer`
+- `Duty / Length:`
+- `Envelope Step:`
+- `Header Byte:`
+- `Instrument Editor`
+- `Key Map Pointer:`
+- `Multi Sample Pointers`
+- `Noise Parameters + ADSR`
+- `Period:`
+- `Release:`
+- `Square Wave Parameters + ADSR`
+- `Sub-Instrument Ptr:`
+- `Sustain:`
+- `Type:`
+- `Unknown instrument type. Raw 12-byte data is shown in the header byte field.`
+- `Wave Pointer:`
+- `Wave Pointer + ADSR`
+- `Write`
+
+### TextForm
+WF labels: **48** · AV labels: **11** · WF-only: **48** · AV-only: **11** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `AI用に登場人物のヒントを追加`
+- `from:`
+- `google translateに投げて、翻訳しますw
+負荷をかけすぎないように、忖度してください。`
+- `ID テキスト`
+- `Import/Export`
+- `REDO`
+- `Size:`
+- `to:`
+- `UNDO`
+- `このテキストを利用している箇所`
+- `すべてのテキストをファイルに書きだす`
+- `アドレス`
+- `エクスポート制限`
+- `キャラ消去`
+- `キャラ登場`
+- `キャラ移動`
+- `ジャンプ`
+- `ジャンプする場所:`
+- `セリフ`
+- `ソーステキスト`
+- `テキスト`
+- `リストの拡張`
+- `先頭アドレス`
+- `全てのテキストをファイルから読みこむ`
+- `再取得`
+- `削除`
+- `参照`
+- `参照情報の追加`
+- `参照箇所`
+- `名前`
+- `変更`
+- `変更したい行をダブルクリック or Enterキーを押してください。 右クリックでメニューが出ます。`
+- `新規追加`
+- `書き込み`
+- `未参照の空き領域の探索`
+- `検索`
+- `検索ワード`
+- `消去する場所:`
+- `登場する人:`
+- `登場する場所:`
+- `移動元場所:`
+- `移動先場所:`
+- `簡易`
+- `翻訳`
+- `翻訳する`
+- `話す人:`
+- `読込数`
+- `警告:
+セリフが
+3行以上に
+なっています`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Edit Text:`
+- `Export All Texts (TSV)`
+- `ID:`
+- `Import Texts (TSV)`
+- `Other reference sources (maps, events, supports, …) not yet ported. Track full parity in a follow-up issue.`
+- `References (units, classes, items):`
+- `Search Content`
+- `Search in text content...`
+- `Show All`
+- `Text Editor`
+- `Write Text`
+
+### WorldMapImageForm
+WF labels: **47** · AV labels: **2** · WF-only: **47** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00 Padding`
+- `??`
+- `AP`
+- `Center X`
+- `Center Y`
+- `Height`
+- `OAMTable entry`
+- `Size:`
+- `tcs params??`
+- `TSA`
+- `Width`
+- `X`
+- `Y`
+- `アイコン用のデータ`
+- `アドレス`
+- `イベント用`
+- `ソースファイルを開く`
+- `ソースフォルダーを開く`
+- `パレット`
+- `パレットマップ`
+- `ポインタを書き込む`
+- `ミニマップ`
+- `メインフィールドマップ`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `国境`
+- `拠点アイコン`
+- `拠点画像1`
+- `拠点画像2`
+- `描画例`
+- `書き込み`
+- `減色ツール`
+- `画像`
+- `画像シート番号`
+- `画像取出`
+- `画像取出し`
+- `画像読込`
+- `読込数`
+- `通常時パレット`
+- `道画像`
+- `選択アドレス:`
+- `闇パレット`
+- `闇マップ`
+- `闇マップ画像取出`
+- `闇マップ画像読込(パレット)`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `World Map Image`
+
+### ImageUnitPaletteForm
+WF labels: **45** · AV labels: **17** · WF-only: **45** · AV-only: **17** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `1`
+- `10`
+- `11`
+- `12`
+- `13`
+- `14`
+- `15`
+- `16`
+- `2`
+- `3`
+- `4`
+- `5`
+- `6`
+- `7`
+- `8`
+- `9`
+- `B`
+- `G`
+- `R`
+- `REDO`
+- `Size:`
+- `UNDO`
+- `↓文字列内訳`
+- `アドレス`
+- `クリップボード`
+- `コメント`
+- `パレットアドレス`
+- `パレット書き込み`
+- `パレット種類`
+- `ポインタ`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `利用クラスとアニメ`
+- `名前`
+- `戦闘アニメ`
+- `拡大`
+- `敵とNPC、グレーも同じ色に設定する`
+- `新規パレット割り当て`
+- `書き込み`
+- `画像取出`
+- `画像読込`
+- `読込数`
+- `識別子`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Id 0:`
+- `Id 1:`
+- `Id 10:`
+- `Id 11:`
+- `Id 2:`
+- `Id 3:`
+- `Id 4:`
+- `Id 5:`
+- `Id 6:`
+- `Id 7:`
+- `Id 8:`
+- `Id 9:`
+- `Identifier:`
+- `Palette Ptr (P12):`
+- `Unit Palette Editor`
+- `Write`
+
+### ItemForm
+WF labels: **45** · AV labels: **47** · WF-only: **45** · AV-only: **47** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `[HardCoding]`
+- `HP`
+- `ID`
+- `Size:`
+- `アイコン`
+- `アドレス`
+- `ダメージ追加効果`
+- `リストの拡張`
+- `レベル`
+- `体格`
+- `使った場合`
+- `使用画面`
+- `先頭アドレス`
+- `再取得`
+- `単価`
+- `名前`
+- `命中`
+- `売却価格`
+- `守備`
+- `幸運`
+- `店での買値`
+- `必殺`
+- `性能`
+- ` 技 `
+- `攻撃`
+- `書き込み`
+- `武器LV熟練度`
+- `特効`
+- `特効効果
+新規割当`
+- `移動`
+- `種別`
+- `耐久`
+- `能力補正`
+- `能力補正
+新規割当`
+- `能力補正値`
+- `説明`
+- `読込数`
+- `速さ`
+- `進撃準備店`
+- `選択アドレス:`
+- `重さ`
+- `間接エフェクト Jump`
+- `魔力`
+- `魔防`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Basic Info`
+- `Buy Price:`
+- `Crit (B24):`
+- `Desc`
+- `Desc ID (W2):`
+- `Dmg Effect (B31):`
+- `Edit Skill Config`
+- `Effective (P16):`
+- `Effective Against`
+- `Export TSV`
+- `Forge Price:`
+- `Hit (B22):`
+- `Icon (B29):`
+- `Import TSV`
+- `Item # (B6):`
+- `Item Editor`
+- `Jump`
+- `Might (B21):`
+- `Name:`
+- `Name ID (W0):`
+- `Price (W26):`
+- `Range (B25):`
+- `Rank (B28):`
+- `Sell Price:`
+- `Stat Bonus (P12):`
+- `Stat Bonuses Preview`
+- `Stats / Bonuses`
+- `Trait 1 (B8):`
+- `Trait 2 (B9):`
+- `Trait 3 (B10):`
+- `Trait 4 (B11):`
+- `Trait Flags`
+- `Type (B7):`
+- `Unk33 (B33):`
+- `Unk34 (B34):`
+- `Unk35 (B35):`
+- `Use Desc (W4):`
+- `Use Effect (B30):`
+- `Uses (B20):`
+- `Warning: Effectiveness pointer is null (P16=0). Consider allocating.`
+- `Warning: Stat Bonuses pointer is null (P12=0). Consider allocating.`
+- `Warnings`
+- `Weapon Properties`
+- `Weight (B23):`
+- `Wep Exp (B32):`
+- `Write`
+
+### MapStyleEditorForm
+WF labels: **45** · AV labels: **5** · WF-only: **45** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `1`
+- `10`
+- `11`
+- `12`
+- `13`
+- `14`
+- `15`
+- `16`
+- `2`
+- `3`
+- `4`
+- `5`
+- `6`
+- `7`
+- `8`
+- `9`
+- `B`
+- `G`
+- `No`
+- `R`
+- `REDO`
+- `UNDO`
+- `X`
+- `Y`
+- `アドレス`
+- `オブジェクト`
+- `クリップボード`
+- `タイルのコピー(Alt + T) `
+- `パレット`
+- `パレットNo`
+- `パレット取出`
+- `パレット読込`
+- `マップスタイル`
+- `マップチップ割り当ての保存`
+- `マップチップ割り当ての読込`
+- `右上`
+- `右下`
+- `左上`
+- `左下`
+- `張り付け(Alt + V)`
+- `書き込み`
+- `画像取出`
+- `画像読込`
+- `種類`
+- `種類のコピー(Alt + C)`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Config Pointer:`
+- `Map Style Editor`
+- `OBJ Tile Pointer:`
+- `Write`
+
+### UnitForm
+WF labels: **49** · AV labels: **54** · WF-only: **45** · AV-only: **50** · Common: **4**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `[HardCoding]`
+- `Export All`
+- `Export Selected`
+- `Growths as Decimal`
+- `ID`
+- `Import All`
+- `Import Selected`
+- `Include Base Stats`
+- `Include Growths`
+- `Include Header`
+- `Include Name`
+- `Include UID`
+- `Include Wep Level`
+- `Size:`
+- `Use Clipboard`
+- `アドレス`
+- `シミュレーション`
+- `スキル`
+- `マップ顔`
+- `ユニットソート順`
+- `ユニット別パレットへジャンプ`
+- `ユニット別能力`
+- `会話グループ`
+- `体格`
+- `先頭アドレス`
+- `再取得`
+- `合計%`
+- `名前`
+- `守備`
+- `属性:-`
+- `幸運`
+- `成長率(%)`
+- ` 技 `
+- `支援クラス`
+- `支援データ`
+- `攻撃`
+- `書き込み`
+- `武器LV`
+- `詳細`
+- `読込数`
+- `速さ`
+- `選択アドレス:`
+- `顔`
+- `魔力`
+- `魔防`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Ability Flags`
+- `Address:`
+- `Affinity:`
+- `Anima:`
+- `Axe:`
+- `Base Stats`
+- `Bow:`
+- `Byte 1:`
+- `Byte 2:`
+- `Byte 3:`
+- `Byte 4:`
+- `Calculate Growth`
+- `Class ID:`
+- `Con:`
+- `Dark:`
+- `Def:`
+- `Desc`
+- `Desc ID:`
+- `Edit Skills`
+- `Export TSV`
+- `Growth Rates (%)`
+- `Growth Simulator`
+- `Identity`
+- `Import TSV`
+- `Jump`
+- `Lance:`
+- `Lck:`
+- `Light:`
+- `Map Face:`
+- `Name:`
+- `Name ID:`
+- `Pick...`
+- `Portrait:`
+- `Res:`
+- `Simulate to LV:`
+- `Skl:`
+- `Sort:`
+- `Spd:`
+- `Staff:`
+- `Str:`
+- `Support & Other`
+- `Support Ptr:`
+- `Sword:`
+- `Talk:`
+- `Undo`
+- `Unit Editor`
+- `Unit ID:`
+- `Warnings`
+- `Weapon Levels`
+- `Write`
+
+### ItemFE6Form
+WF labels: **44** · AV labels: **27** · WF-only: **44** · AV-only: **27** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `[HardCoding]`
+- `HP`
+- `ID`
+- `Size:`
+- `アイコン`
+- `アドレス`
+- `ダメージ追加効果`
+- `リストの拡張`
+- `レベル`
+- `体格`
+- `使った場合`
+- `使用画面`
+- `先頭アドレス`
+- `再取得`
+- `単価`
+- `名前`
+- `命中`
+- `売却価格`
+- `守備`
+- `射程`
+- `幸運`
+- `店での買値`
+- `必殺`
+- `性能`
+- ` 技 `
+- `攻撃`
+- `書き込み`
+- `特効`
+- `特効効果
+新規割当`
+- `移動`
+- `種別`
+- `耐久`
+- `能力補正`
+- `能力補正
+新規割当`
+- `能力補正値`
+- `説明`
+- `読込数`
+- `速さ`
+- `進撃準備店`
+- `選択アドレス:`
+- `重さ`
+- `間接エフェクト Jump`
+- `魔力`
+- `魔防`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Crit (B24):`
+- `Desc`
+- `Desc ID (W2):`
+- `Dmg Effect (B31):`
+- `Effective (P16):`
+- `Hit (B22):`
+- `Icon (B29):`
+- `Item # (B6):`
+- `Item Editor (FE6)`
+- `Might (B21):`
+- `Name:`
+- `Name ID (W0):`
+- `Price (W26):`
+- `Range (B25):`
+- `Rank (B28):`
+- `Stat Bonus (P12):`
+- `Trait 1 (B8):`
+- `Trait 2 (B9):`
+- `Trait 3 (B10):`
+- `Trait 4 (B11):`
+- `Type (B7):`
+- `Use Desc (W4):`
+- `Use Effect (B30):`
+- `Uses (B20):`
+- `Weight (B23):`
+- `Write`
+
+### ToolInitWizardForm
+WF labels: **44** · AV labels: **8** · WF-only: **44** · AV-only: **8** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `BeginPage`
+- `EA:`
+- `EN`
+- `EndPage`
+- `gba mus riper`
+- `git`
+- `JP`
+- `mGBAをダウンロードする`
+- `midfix4agb`
+- `Sappy:`
+- `Sappyをダウンロードする`
+- `Sappyを設定しない`
+- `SettingNowPage`
+- `sox`
+- `Step1Page`
+- `Step2Page`
+- `Step3Page`
+- `Step4Page`
+- `Step5Page`
+- `Step6Page`
+- `VGMusicStudioをダウンロードする`
+- `ZH`
+- `しばらくお待ちください....`
+- `すべての設定が完了しました。`
+- `または、`
+- `アセンブラ:`
+- `エミュレータ:`
+- `デバッガー:`
+- `参照`
+- `始める`
+- `安定して動作するバージョンのVBA-Mをダウンロードする`
+- `完了`
+- `戻る`
+- `最新版のEAをダウンロードする`
+- `最新版のGitを自動でダウンロードしてインストールします。`
+- `最新版を自動的にダウンロードします。`
+- `白背景`
+- `色`
+- `言語`
+- `設定して完了する`
+- `設定して次へ`
+- `設定しない`
+- `黒背景`
+- `黒背景2`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Initial Configuration`
+- `Setup Steps`
+- `Setup Wizard`
+- `Step 1: Select your clean Fire Emblem GBA ROM file.`
+- `Step 2: Choose your preferred language for the editor interface.`
+- `Step 3: Configure paths for external tools (emulators, assemblers).`
+- `Step 4: Review settings and begin editing.`
+- `You can change these settings later from the Options menu.`
+
+### ClassFE6Form
+WF labels: **43** · AV labels: **5** · WF-only: **43** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `- `
+- `??`
+- `???`
+- `[HardCoding]`
+- `HP`
+- `ID`
+- `LV`
+- `Size:`
+- `アドレス`
+- `クラスチェンジクラス`
+- `クラス基礎能力`
+- `クラス能力最大値`
+- `シミュレーション`
+- `ソート順`
+- `リストの拡張`
+- `一般兵顔`
+- `体格`
+- `先頭アドレス`
+- `再取得`
+- `合計%`
+- `名前`
+- `地形回避`
+- `地形防御`
+- `地形魔防`
+- `守備`
+- `幸運`
+- `待機アイコン`
+- `戦闘時アニメ`
+- ` 技 `
+- `攻撃`
+- `敵成長率(%)`
+- `書き込み`
+- `武器LV`
+- `移動`
+- `移動コスト`
+- `移動速度`
+- `経験値補正値`
+- `詳細`
+- `読込数`
+- `速さ`
+- `選択アドレス:`
+- `魔力`
+- `魔防`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `--- Growth Simulator ---`
+- `Address:`
+- `Calculate Growth`
+- `Class Editor (FE6)`
+- `Sim Level:`
+
+### ImageBattleScreenForm
+WF labels: **42** · AV labels: **2** · WF-only: **42** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `1`
+- `10`
+- `11`
+- `12`
+- `13`
+- `14`
+- `15`
+- `16`
+- `2`
+- `3`
+- `4`
+- `5`
+- `6`
+- `7`
+- `8`
+- `9`
+- `B`
+- `G`
+- `Import/Export`
+- `R`
+- `REDO`
+- `Tile1`
+- `Tile2`
+- `Tile3`
+- `Tile4`
+- `Tile5`
+- `UNDO`
+- `アイテム`
+- `クリップボード`
+- `パレット`
+- `パレットアドレス`
+- `パレット書き込み`
+- `パレット種類`
+- `メイン画像`
+- `右側`
+- `名前`
+- `左側`
+- `戦闘画面を一括でインポートします。
+TSAがあるので、共通タイルは1つにまとめられるという制約があります。`
+- `書き込み`
+- `画像`
+- `画像取出`
+- `画像読込`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Battle Screen Layout`
+
+### UnitFE7Form
+WF labels: **39** · AV labels: **58** · WF-only: **38** · AV-only: **57** · Common: **1**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `- `
+- `??`
+- `[HardCoding]`
+- `ID`
+- `LV`
+- `Size:`
+- `アドレス`
+- `シミュレーション`
+- `マップ顔`
+- `ユニットソート順`
+- `ユニット別能力`
+- `上位クラス戦闘アニメ色`
+- `上級専用アニメ`
+- `下位クラス戦闘アニメ色`
+- `下級専用アニメ`
+- `会話グループ`
+- `体格`
+- `先頭アドレス`
+- `再取得`
+- `合計%`
+- `名前`
+- `守備`
+- `属性:-`
+- `幸運`
+- `成長率(%)`
+- ` 技 `
+- `支援クラス`
+- `支援データ`
+- `攻撃`
+- `書き込み`
+- `武器LV`
+- `詳細`
+- `読込数`
+- `速さ`
+- `選択アドレス:`
+- `顔`
+- `魔力`
+- `魔防`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Ability 1:`
+- `Ability 2:`
+- `Ability 3:`
+- `Ability 4:`
+- `Ability Flags:`
+- `Address:`
+- `Affinity:`
+- `Anima:`
+- `Axe:`
+- `Base Stats:`
+- `Bow:`
+- `CON:`
+- `Dark:`
+- `Decoded:`
+- `DEF:`
+- `DEF Growth:`
+- `Desc`
+- `Description:`
+- `Growth Rates (%):`
+- `HP Growth:`
+- `Lance:`
+- `LCK:`
+- `LCK Growth:`
+- `Level:`
+- `Light:`
+- `Lower Class Anime:`
+- `Lower Class Palette:`
+- `Map Face:`
+- `Name:`
+- `Palette / Custom Animation:`
+- `Portrait:`
+- `RES:`
+- `RES Growth:`
+- `SKL:`
+- `SKL Growth:`
+- `Sort Order:`
+- `SPD:`
+- `SPD Growth:`
+- `Staff:`
+- `STR:`
+- `STR Growth:`
+- `Support / Talk:`
+- `Support Class:`
+- `Support Data Ptr:`
+- `Sword:`
+- `Talk Group:`
+- `Unit ID:`
+- `Units (FE7) Editor`
+- `Unknown 39:`
+- `Unknown 49:`
+- `Unknown 50:`
+- `Unknown 51:`
+- `Unknown Fields:`
+- `Upper Class Anime:`
+- `Upper Class Palette:`
+- `Weapon Ranks:`
+- `Write`
+
+### MonsterItemForm
+WF labels: **37** · AV labels: **8** · WF-only: **37** · AV-only: **8** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `Size:`
+- `アイテム1`
+- `アイテム1確率`
+- `アイテム2`
+- `アイテム2確率`
+- `アイテム3`
+- `アイテム3確率`
+- `アイテム4`
+- `アイテム4確率`
+- `アイテム5`
+- `アイテム5確率`
+- `アイテム確率`
+- `アドレス`
+- `クラス`
+- `コメント`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `合計`
+- `所持品1 候補1`
+- `所持品1 候補2`
+- `所持品1 候補3`
+- `所持品1 候補4`
+- `所持品1 候補5`
+- `所持品2 候補1`
+- `所持品2 候補2`
+- `所持品2 候補3`
+- `所持品2 候補4`
+- `所持品2 候補5`
+- `書き込み`
+- `確率`
+- `読込数`
+- `選択アドレス:`
+- `魔物アイテムテーブル`
+- `魔物アイテム確率`
+- `魔物所持品テーブル`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Drop Rate:`
+- `Item ID:`
+- `Monster Item Editor`
+- `Unknown 1:`
+- `Unknown 2:`
+- `Unknown 3:`
+- `Write`
+
+### SkillConfigFE8NVer3SkillForm
+WF labels: **37** · AV labels: **11** · WF-only: **37** · AV-only: **11** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `COMBAT_ARTへ移動`
+- `Size:`
+- `このアイテムを所持しているときに、このスキルを有効にします。`
+- `このアイテムを武器として装備しているときに、このスキルを有効にします。`
+- `アイコン`
+- `アイテム`
+- `アドレス`
+- `アニメ`
+- `アニメーション取出`
+- `アニメーション読込`
+- `エディタ`
+- `クラス`
+- `クラススキル`
+- `スキル`
+- `パレット`
+- `フレーム`
+- `ユニット`
+- `ユニットクラス`
+- `ユニットスキル`
+- `リストの拡張`
+- `レベルアップで取得するスキルの先頭アドレス`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `所持アイテムスキル`
+- `拡大`
+- `書き込み`
+- `武器アイテムスキル`
+- `現在のスキルに、指定した他のスキルの効果を追加します。`
+- `画像取出`
+- `画像読込`
+- `表示例`
+- `複合スキル`
+- `詳細`
+- `読込数`
+- `選択アドレス:`
+- `領域が確保されていません。
+「リストの拡張ボタン」を押して領域を確保してください。`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Class Skill Pointer:`
+- `Composite Skill Pointer:`
+- `Held Item Skill Pointer:`
+- `Palette:`
+- `Skill Configuration (FE8N v3)`
+- `Skill system editors require a compatible skill patch to be installed.
+Use the Patch Manager to install a skill system patch first.
+
+Supported skill systems: CSkillSys, FE8N Skill System`
+- `Text Detail:`
+- `Unit/Class Pointer:`
+- `Weapon Item Skill Pointer:`
+- `Write`
+
+### EventUnitFE7Form
+WF labels: **36** · AV labels: **24** · WF-only: **36** · AV-only: **24** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `1次AI`
+- `2次AI`
+- `LV:`
+- `Size:`
+- `X:`
+- `Y:`
+- `アイテムドロップ`
+- `アドレス`
+- `イベント名前`
+- `クラス`
+- `コメント`
+- `マップ名前`
+- `ユニット情報`
+- `ユニット番号`
+- `リストの拡張`
+- `交戦時BGMへJump`
+- `交戦時セリフへJump`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `成長率:`
+- `所属:`
+- `所持品1`
+- `所持品2`
+- `所持品3`
+- `所持品4`
+- `指揮官`
+- `新規領域の確保`
+- `書き込み`
+- `標的と回復AI`
+- `死亡時セリフへJump`
+- `読込数`
+- `退避AI`
+- `選択アドレス:`
+- `配置前座標`
+- `配置後座標`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `0x Address`
+- `Address:`
+- `AI1 Primary:`
+- `AI2 Secondary:`
+- `AI3 Target/Recovery:`
+- `AI4 Retreat:`
+- `Class ID:`
+- `End X:`
+- `End Y:`
+- `Event Unit (FE7)`
+- `Item 1:`
+- `Item 2:`
+- `Item 3:`
+- `Item 4:`
+- `Leader Unit ID:`
+- `Load`
+- `Maps`
+- `Start X:`
+- `Start Y:`
+- `Unit Groups`
+- `Unit ID:`
+- `Unit Info:`
+- `Units`
+- `Write`
+
+### ImageBattleAnimeForm
+WF labels: **35** · AV labels: **29** · WF-only: **35** · AV-only: **29** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `FrameData`
+- `LeftToRightOAM`
+- `RightToLeftOAM`
+- `SectionData`
+- `Size:`
+- `↓文字列内訳`
+- `このテーブルは、複数のクラスで参照されています。`
+- `アドレス`
+- `アニメ番号`
+- `インターネットから新しいリソースを探す`
+- `エディタ`
+- `コメント`
+- `セクション`
+- `ソースファイルを開く`
+- `ソースフォルダーを開く`
+- `パレット`
+- `フレーム`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `戦闘アニメの書出し`
+- `戦闘アニメの読込`
+- `拡大`
+- `方向`
+- `書き込み`
+- `武器種類`
+- `汎用色`
+- `特殊`
+- `表示例`
+- `読込数`
+- `識別子`
+- `選択アドレス:`
+- `選択クラスの分離独立`
+- `領域が確保されていません。
+「リストの拡張ボタン」を押して領域を確保してください。`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Animation # (W2):`
+- `Animation Data Details`
+- `Animation Frame Viewer`
+- `Animation Table Summary`
+- `Battle Animation Editor`
+- `Data Address:`
+- `Export Tile Sheet PNG...`
+- `Frame:`
+- `Frame Data:`
+- `Frame Ptr:`
+- `Name:`
+- `Next`
+- `No animation data found for this ID (ID=0 or invalid pointer chain).`
+- `OAM (L→R) Ptr:`
+- `OAM (R→L) Ptr:`
+- `OAM Data:`
+- `Palette Ptr:`
+- `Play`
+- `Prev`
+- `Resolved:`
+- `Section:`
+- `Section Ptr:`
+- `Special (B1):`
+- `Speed:`
+- `Sprite Tile Sheet`
+- `Total animations: --`
+- `Weapon Type (B0):`
+- `Write`
+
+### EventUnitFE6Form
+WF labels: **34** · AV labels: **24** · WF-only: **34** · AV-only: **24** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `1次AI`
+- `2次AI`
+- `LV:`
+- `Size:`
+- `X:`
+- `Y:`
+- `アドレス`
+- `イベント名前`
+- `クラス`
+- `コメント`
+- `マップ名前`
+- `ユニット情報`
+- `ユニット番号`
+- `リストの拡張`
+- `交戦時セリフへJump`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `成長率:`
+- `所属:`
+- `所持品1`
+- `所持品2`
+- `所持品3`
+- `所持品4`
+- `指揮官`
+- `新規領域の確保`
+- `書き込み`
+- `標的と回復AI`
+- `死亡時セリフへJump`
+- `読込数`
+- `退避AI`
+- `選択アドレス:`
+- `配置前座標`
+- `配置後座標`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `0x Address`
+- `Address:`
+- `AI1 Primary:`
+- `AI2 Secondary:`
+- `AI3 Target/Recovery:`
+- `AI4 Retreat:`
+- `Class ID:`
+- `End X:`
+- `End Y:`
+- `Event Unit (FE6)`
+- `Item 1:`
+- `Item 2:`
+- `Item 3:`
+- `Item 4:`
+- `Leader Unit ID:`
+- `Load`
+- `Maps`
+- `Start X:`
+- `Start Y:`
+- `Unit Groups`
+- `Unit ID:`
+- `Unit Info:`
+- `Units`
+- `Write`
+
+### SongTrackForm
+WF labels: **37** · AV labels: **11** · WF-only: **34** · AV-only: **8** · Common: **3**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Sappyで再生`
+- `Size:`
+- `アドレス`
+- `インターネットから新しいリソースを探す`
+- `ソースファイルを開く`
+- `ソースフォルダーを開く`
+- `トラック1`
+- `トラック10`
+- `トラック11`
+- `トラック12`
+- `トラック13`
+- `トラック14`
+- `トラック15`
+- `トラック16`
+- `トラック2`
+- `トラック3`
+- `トラック4`
+- `トラック5`
+- `トラック6`
+- `トラック7`
+- `トラック8`
+- `トラック9`
+- `トラック数`
+- `先頭アドレス`
+- `再取得`
+- `別ゲームからの曲移植`
+- `名前`
+- `書き込み`
+- `楽器セット`
+- `楽譜`
+- `読込数`
+- `選択アドレス:`
+- `音楽をファイルから読み込む`
+- `音楽をファイルへ書き出す`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Export MIDI`
+- `Import MIDI`
+- `Instrument Set:`
+- `Song Track Editor`
+- `Track Count:`
+- `Tracks`
+- `Write`
+
+### UnitFE6Form
+WF labels: **36** · AV labels: **45** · WF-only: **33** · AV-only: **42** · Common: **3**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `- `
+- `[HardCoding]`
+- `ID`
+- `Size:`
+- `アドレス`
+- `シミュレーション`
+- `マップ顔`
+- `ユニットソート順`
+- `ユニット別能力`
+- `上位クラス戦闘アニメ色`
+- `下位クラス戦闘アニメ色`
+- `体格`
+- `先頭アドレス`
+- `再取得`
+- `合計%`
+- `名前`
+- `守備`
+- `属性:-`
+- `幸運`
+- `成長率(%)`
+- ` 技 `
+- `支援クラス`
+- `支援データ`
+- `攻撃`
+- `書き込み`
+- `武器LV`
+- `詳細`
+- `読込数`
+- `速さ`
+- `選択アドレス:`
+- `顔`
+- `魔力`
+- `魔防`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Ability Flags`
+- `Address:`
+- `Affinity:`
+- `Anima:`
+- `Axe:`
+- `Base Stats`
+- `Bow:`
+- `Byte1:`
+- `Byte2:`
+- `Byte3:`
+- `Byte4:`
+- `Class ID:`
+- `Con:`
+- `Dark:`
+- `Def:`
+- `Desc`
+- `Desc ID:`
+- `Growth Rates (%)`
+- `Identity`
+- `Lance:`
+- `Lck:`
+- `Light:`
+- `Lower Class Anim Color`
+- `Map Face:`
+- `Name:`
+- `Name ID:`
+- `Portrait:`
+- `Res:`
+- `Skl:`
+- `Sort:`
+- `Spd:`
+- `Staff:`
+- `Str:`
+- `Support & Other`
+- `Support Ptr:`
+- `Sword:`
+- `Undo`
+- `Unit Editor (FE6)`
+- `Unit ID:`
+- `Upper Class Anim Color`
+- `Weapon Levels`
+- `Write`
+
+### ClassOPDemoForm
+WF labels: **32** · AV labels: **2** · WF-only: **32** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `/60 (秒)`
+- `00固定`
+- `05固定`
+- `??`
+- `size:`
+- `アドレス`
+- `アニメの特殊指定`
+- `アニメ指定
+ポインタ書き込み`
+- `アニメ指定のポインタ`
+- `アニメ指定のポインタ先`
+- `アニメ指定共有`
+- `ウェイト`
+- `パレットID`
+- `リストの拡張`
+- `使用可能表示武器`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `戦闘アニメ`
+- `敵味方カラー`
+- `日本語名
+ポインタ書き込み`
+- `日本語名の長さ`
+- `日本語名ポインタ`
+- `日本語名ポインタ先`
+- `書き込み`
+- `英語ポインタ`
+- `表示地形右半分`
+- `表示地形左半分`
+- `説明文ID`
+- `読込数`
+- `選択アドレス:`
+- `魔法エフェクト`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Class OP Demo`
+
+### ImagePortraitForm
+WF labels: **32** · AV labels: **22** · WF-only: **32** · AV-only: **22** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `mug_exceed用のタイルをどこに配置するか設定してください`
+- `Size:`
+- `X:`
+- `Y:`
+- `アドレス`
+- `インターネットから新しいリソースを探す`
+- `クラス顔`
+- `コメント`
+- `ステータス画面の背丈調整へJump`
+- `ソースファイルを開く`
+- `ソースフォルダーを開く`
+- `タイル1`
+- `タイル2`
+- `パレット`
+- `フレーム`
+- `マップ顔`
+- `ユニット顔`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `口`
+- `口座標`
+- `名前`
+- `書き込み`
+- `状態`
+- `画像取出`
+- `画像読込`
+- `目座標`
+- `表示例`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Class Card:`
+- `Export PAL`
+- `Export PNG`
+- `Eye X:`
+- `Eye Y:`
+- `Image Pointer:`
+- `Import PAL`
+- `Import PNG`
+- `Main Portrait`
+- `Map Pointer:`
+- `Mini Portrait`
+- `Mouth:`
+- `Mouth X:`
+- `Mouth Y:`
+- `Padding (B25):`
+- `Padding (B26):`
+- `Padding (B27):`
+- `Palette Pointer:`
+- `Portrait Editor`
+- `State:`
+- `Write`
+
+### ImagePortraitForm
+WF labels: **32** · AV labels: **28** · WF-only: **32** · AV-only: **28** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `mug_exceed用のタイルをどこに配置するか設定してください`
+- `Size:`
+- `X:`
+- `Y:`
+- `アドレス`
+- `インターネットから新しいリソースを探す`
+- `クラス顔`
+- `コメント`
+- `ステータス画面の背丈調整へJump`
+- `ソースファイルを開く`
+- `ソースフォルダーを開く`
+- `タイル1`
+- `タイル2`
+- `パレット`
+- `フレーム`
+- `マップ顔`
+- `ユニット顔`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `口`
+- `口座標`
+- `名前`
+- `書き込み`
+- `状態`
+- `画像取出`
+- `画像読込`
+- `目座標`
+- `表示例`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Class Card`
+- `Export Face`
+- `Export Mini`
+- `Export PAL`
+- `Export Sheet`
+- `Eye Frames (32x16 x2)`
+- `Eye X:`
+- `Eye Y:`
+- `FE-Repo`
+- `Import PAL`
+- `Import PNG`
+- `Map Face:`
+- `Map Face (32x32)`
+- `Mouth Frames:`
+- `Mouth Frames (32x16 x6)`
+- `Mouth X:`
+- `Mouth Y:`
+- `Palette:`
+- `Portrait Image Editor`
+- `Show Frame:`
+- `Status:`
+- `Unit Face:`
+- `Unit Face (96x80)`
+- `Unused (B25):`
+- `Unused (B26):`
+- `Unused (B27):`
+- `Write Positions`
+
+### SkillConfigFE8NVer2SkillForm
+WF labels: **31** · AV labels: **10** · WF-only: **31** · AV-only: **10** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Size:`
+- `アイコン`
+- `アイテム`
+- `アドレス`
+- `アニメ`
+- `アニメーション取出`
+- `アニメーション読込`
+- `エディタ`
+- `クラス`
+- `クラススキル`
+- `パレット`
+- `フレーム`
+- `ユニット`
+- `ユニットスキル建設予定地`
+- `リストの拡張`
+- `レベルアップで取得するスキルの先頭アドレス`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `所持アイテムスキル`
+- `拡大`
+- `書き込み`
+- `武器アイテムスキル`
+- `画像取出`
+- `画像読込`
+- `表示例`
+- `詳細`
+- `読込数`
+- `選択アドレス:`
+- `領域が確保されていません。
+「リストの拡張ボタン」を押して領域を確保してください。`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Class Skill Pointer:`
+- `Held Item Skill Pointer:`
+- `Palette:`
+- `Skill Configuration (FE8N v2)`
+- `Skill system editors require a compatible skill patch to be installed.
+Use the Patch Manager to install a skill system patch first.
+
+Supported skill systems: CSkillSys, FE8N Skill System`
+- `Text Detail:`
+- `Unit Skill Pointer:`
+- `Weapon Item Skill Pointer:`
+- `Write`
+
+### ImageTSAEditorForm
+WF labels: **30** · AV labels: **2** · WF-only: **30** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `1`
+- `10`
+- `11`
+- `12`
+- `13`
+- `14`
+- `15`
+- `16`
+- `2`
+- `3`
+- `4`
+- `5`
+- `6`
+- `7`
+- `8`
+- `9`
+- `B`
+- `G`
+- `R`
+- `REDO`
+- `UNDO`
+- `クリップボード`
+- `パレット`
+- `パレットアドレス`
+- `パレット書き込み`
+- `メイン画像`
+- `書き込み`
+- `画像`
+- `画像取出`
+- `画像読込`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `TSA Tile Editor`
+
+### SummonsDemonKingForm
+WF labels: **30** · AV labels: **19** · WF-only: **30** · AV-only: **19** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `1次AI`
+- `2次AI`
+- `??`
+- `LV:`
+- `Size:`
+- `X:`
+- `Y:`
+- `アドレス`
+- `クラス`
+- `ユニット情報`
+- `ユニット番号`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `座標`
+- `成長率:`
+- `所属:`
+- `所持品1`
+- `所持品2`
+- `所持品3`
+- `所持品4`
+- `指揮官`
+- `書き込み`
+- `標的と回復AI`
+- `特殊:`
+- `読込数`
+- `退避AI`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `AI 1:`
+- `AI 2:`
+- `AI Pointer:`
+- `Class ID:`
+- `Commander:`
+- `Coordinates:`
+- `Demon King Summon Editor`
+- `Item 1:`
+- `Item 2:`
+- `Item 3:`
+- `Item 4:`
+- `Level/Growth:`
+- `Padding (B7):`
+- `Retreat AI:`
+- `Special:`
+- `Target/Recovery AI:`
+- `Unit ID:`
+- `Write`
+
+### ImageBattleAnimePalletForm
+WF labels: **29** · AV labels: **2** · WF-only: **29** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `1`
+- `10`
+- `11`
+- `12`
+- `13`
+- `14`
+- `15`
+- `16`
+- `2`
+- `3`
+- `32ColorMode`
+- `4`
+- `5`
+- `6`
+- `7`
+- `8`
+- `9`
+- `B`
+- `G`
+- `R`
+- `REDO`
+- `UNDO`
+- `クリップボード`
+- `パレットアドレス`
+- `パレット書き込み`
+- `パレット種類`
+- `拡大`
+- `画像取出`
+- `画像読込`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Battle Animation Palette`
+
+### ImagePalletForm
+WF labels: **28** · AV labels: **2** · WF-only: **28** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `1`
+- `10`
+- `11`
+- `12`
+- `13`
+- `14`
+- `15`
+- `16`
+- `2`
+- `3`
+- `4`
+- `5`
+- `6`
+- `7`
+- `8`
+- `9`
+- `B`
+- `G`
+- `R`
+- `REDO`
+- `UNDO`
+- `クリップボード`
+- `パレットアドレス`
+- `パレット書き込み`
+- `パレット種類`
+- `拡大`
+- `画像取出`
+- `画像読込`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Palette Editor`
+
+### OPClassDemoFE7Form
+WF labels: **28** · AV labels: **16** · WF-only: **28** · AV-only: **16** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `/60 (秒)`
+- `00`
+- `??`
+- `Commamd`
+- `Size:`
+- `アドレス`
+- `アニメ指定
+ポインタ書き込み`
+- `アニメ指定のポインタ`
+- `グラフィックツール`
+- `パレットID`
+- `リストの拡張`
+- `使用可能表示武器`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `戦闘アニメ`
+- `敵味方カラー`
+- `日本語名 開始位置`
+- `日本語名の長さ`
+- `日本語名アドレス`
+- `書き込み`
+- `英語ポインタ`
+- `表示地形右半分`
+- `表示地形左半分`
+- `説明文ID`
+- `読込数`
+- `選択アドレス:`
+- `魔法エフェクト`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Ally/Enemy Color:`
+- `Anime Pointer:`
+- `Battle Anime:`
+- `Class ID:`
+- `Description Text ID:`
+- `Display Weapon:`
+- `English Name Pointer:`
+- `Japanese Name Length:`
+- `Japanese Name Pointer:`
+- `Magic Effect:`
+- `OP Class Demo (FE7) Editor`
+- `Palette ID:`
+- `Terrain Left:`
+- `Terrain Right:`
+- `Write`
+
+### StatusOptionForm
+WF labels: **28** · AV labels: **22** · WF-only: **28** · AV-only: **22** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `ASM関数`
+- `Size:`
+- `アイコン(value*8)`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+- `選択子1テキスト`
+- `選択子1ヘルプ`
+- `選択子1不明2`
+- `選択子1表示位地`
+- `選択子2テキスト`
+- `選択子2ヘルプ`
+- `選択子2不明2`
+- `選択子2表示位地`
+- `選択子3テキスト`
+- `選択子3ヘルプ`
+- `選択子3不明2`
+- `選択子3表示位地`
+- `選択子4テキスト`
+- `選択子4ヘルプ`
+- `選択子4不明2`
+- `選択子4表示位地`
+- `項目名`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `ASM Pointer:`
+- `Columns:`
+- `Default Text ID:`
+- `Default Value:`
+- `Help Text ID:`
+- `Icon ID:`
+- `ID Text:`
+- `Max Value:`
+- `Min Value:`
+- `Name Text ID:`
+- `On/Off Text 1:`
+- `On/Off Text 2:`
+- `Option Type:`
+- `Rows:`
+- `Selection Text 1:`
+- `Selection Text 2:`
+- `Status Screen Options`
+- `Write`
+- `X Position:`
+- `Y Position:`
+- `Yes Text ID:`
+
+### ToolLZ77Form
+WF labels: **28** · AV labels: **2** · WF-only: **28** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Base64`
+- `Base64 Text to File`
+- `Base64 Text to Run Emulator`
+- `DEST`
+- `Emulator`
+- `File to Base64 Text`
+- `FROM`
+- `LENGTH`
+- `lz77再圧縮`
+- `Plain`
+- `SRC`
+- `SRC開始アドレス`
+- `TO`
+- `この領域をゼロクリア`
+- `この領域を移動する`
+- `再圧縮`
+- `再圧縮する`
+- `別ファイル選択`
+- `圧縮する`
+- `戦闘アニメOAM`
+- `戦闘アニメOAMの最適化`
+- `消去`
+- `移動`
+- `解凍する`
+- `音楽GOTO-FINE`
+- `音楽GOTO-FINE最適化`
+- `顔画像`
+- `顔画像を圧縮する`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `LZ77 Compression Tool`
+
+### OPClassDemoForm
+WF labels: **27** · AV labels: **16** · WF-only: **27** · AV-only: **16** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `/60 (秒)`
+- `00`
+- `??`
+- `Commamd`
+- `Size:`
+- `アドレス`
+- `アニメ指定
+ポインタ書き込み`
+- `アニメ指定のポインタ`
+- `パレットID`
+- `リストの拡張`
+- `使用可能表示武器`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `戦闘アニメ`
+- `敵味方カラー`
+- `日本語名
+ポインタ書き込み`
+- `日本語名の長さ`
+- `日本語名ポインタ`
+- `書き込み`
+- `英語ポインタ`
+- `表示地形右半分`
+- `表示地形左半分`
+- `説明文ID`
+- `読込数`
+- `選択アドレス:`
+- `魔法エフェクト`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Ally/Enemy Color:`
+- `Anime Pointer:`
+- `Battle Anime:`
+- `Description Text ID:`
+- `Display Weapon:`
+- `English Name Pointer:`
+- `Japanese Name Length:`
+- `Japanese Name Pointer:`
+- `Magic Effect:`
+- `OP Class Demo Editor`
+- `Palette ID:`
+- `Terrain Left:`
+- `Terrain Right:`
+- `Unknown (0x12):`
+- `Write`
+
+### ImageMagicCSACreatorForm
+WF labels: **25** · AV labels: **2** · WF-only: **25** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `dim`
+- `FrameData`
+- `OBJBGLeftToRight`
+- `OBJBGRightToLeft`
+- `OBJLeftToRight`
+- `OBJRightToLeft`
+- `Size:`
+- `アドレス`
+- `インターネットから新しいリソースを探す`
+- `エディタ`
+- `コメント`
+- `ソースファイルを開く`
+- `ソースフォルダーを開く`
+- `フレーム`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `拡大`
+- `書き込み`
+- `表示例`
+- `読込数`
+- `選択アドレス:`
+- `魔法アニメの書出し`
+- `魔法アニメの読込`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `CSA Magic Creator`
+
+### ImageMagicFEditorForm
+WF labels: **25** · AV labels: **2** · WF-only: **25** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `dim`
+- `FrameData`
+- `OBBGLeftToRight`
+- `OBJBGRightToLeft`
+- `OBJLeftToRight`
+- `OBJRightToLeft`
+- `Size:`
+- `アドレス`
+- `インターネットから新しいリソースを探す`
+- `エディタ`
+- `コメント`
+- `ソースファイルを開く`
+- `ソースフォルダーを開く`
+- `フレーム`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `拡大`
+- `書き込み`
+- `表示例`
+- `読込数`
+- `選択アドレス:`
+- `魔法アニメの書出し`
+- `魔法アニメの読込`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Magic Effect Editor (FEditor)`
+
+### AIScriptForm
+WF labels: **24** · AV labels: **2** · WF-only: **24** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Close`
+- `アドレス`
+- `コメント`
+- `バイナリコード`
+- `パラメータ1`
+- `パラメータ2`
+- `パラメータ3`
+- `パラメータ4`
+- `パラメータ5`
+- `ファイルからインポート`
+- `ファイルへエクスポート`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `切替`
+- `削除`
+- `名前`
+- `命令変更`
+- `変更`
+- `新規挿入`
+- `書き込み`
+- `説明`
+- `読込バイト数`
+- `読込数`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `AI Script Editor`
+
+### OPClassDemoFE7UForm
+WF labels: **24** · AV labels: **13** · WF-only: **24** · AV-only: **13** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `/60 (秒)`
+- `00`
+- `??`
+- `Commamd`
+- `Size:`
+- `アドレス`
+- `アニメ指定
+ポインタ書き込み`
+- `アニメ指定のポインタ`
+- `クラス`
+- `パレットID`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `戦闘アニメ`
+- `敵味方カラー`
+- `書き込み`
+- `英語ポインタ`
+- `表示地形右半分`
+- `表示地形左半分`
+- `説明文ID`
+- `読込数`
+- `選択アドレス:`
+- `魔法エフェクト`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Ally/Enemy Color:`
+- `Anime Pointer:`
+- `Battle Anime:`
+- `Class ID:`
+- `Description Text ID:`
+- `English Name Pointer:`
+- `Japanese Name Length:`
+- `Magic Effect:`
+- `OP Class Demo (FE7U) Editor`
+- `Terrain Left:`
+- `Terrain Right:`
+- `Write`
+
+### SkillAssignmentClassCSkillSysForm
+WF labels: **24** · AV labels: **5** · WF-only: **24** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `EnemyOnly(LV+64)`
+- `Hard only (LV+128)`
+- `Normal&&Hard (LV+96)`
+- `PlayerOnly(LV+32)`
+- `Size:`
+- `このテーブルは、複数のクラスで参照されています。`
+- `アドレス`
+- `クラススキル`
+- `スキル`
+- `リストの拡張`
+- `レベル`
+- `一括インポート`
+- `一括エクスポート`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `習得レベル`
+- `習得レベルとスキルの詳細は、ここをクリックしてください。`
+- `習得レベルの内訳`
+- `読込数`
+- `選択アドレス:`
+- `選択クラスの分離独立`
+- `領域が確保されていません。
+「リストの拡張ボタン」を押して領域を確保してください。`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Class Skill:`
+- `Skill Assignment - Class (CSkillSys)`
+- `Skill system editors require a compatible skill patch to be installed.
+Use the Patch Manager to install a skill system patch first.
+
+Supported skill systems: CSkillSys, FE8N Skill System`
+- `Write`
+
+### SkillAssignmentClassSkillSystemForm
+WF labels: **24** · AV labels: **5** · WF-only: **24** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `EnemyOnly(LV+64)`
+- `Hard only (LV+128)`
+- `Normal&&Hard (LV+96)`
+- `PlayerOnly(LV+32)`
+- `Size:`
+- `このテーブルは、複数のクラスで参照されています。`
+- `アドレス`
+- `クラススキル`
+- `スキル`
+- `リストの拡張`
+- `レベル`
+- `一括インポート`
+- `一括エクスポート`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `習得レベル`
+- `習得レベルとスキルの詳細は、ここをクリックしてください。`
+- `習得レベルの内訳`
+- `読込数`
+- `選択アドレス:`
+- `選択クラスの分離独立`
+- `領域が確保されていません。
+「リストの拡張ボタン」を押して領域を確保してください。`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Assigns a skill to each class via the SkillSystem patch.`
+- `Class Skill:`
+- `Skill Assignment (Class)`
+- `Write`
+
+### WorldMapPointForm
+WF labels: **24** · AV labels: **21** · WF-only: **24** · AV-only: **21** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Size:`
+- `いつでも入れるかどうか`
+- `アドレス`
+- `イベント分岐用フラグ`
+- `クリア前アイコン`
+- `クリア後アイコン`
+- `フリーマップの種類`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `次の拠点ID(エイリーク)`
+- `次の拠点ID(エイリーク2回目)`
+- `次の拠点ID(エフラム)`
+- `次の拠点ID(エフラム2回目)`
+- `武器屋`
+- `秘密の店`
+- `章ID`
+- `船の指定`
+- `読込数`
+- `道具屋`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Always Accessible:`
+- `Armory Pointer:`
+- `Chapter ID 1:`
+- `Chapter ID 2:`
+- `Coordinate X:`
+- `Coordinate Y:`
+- `Event Branch Flag:`
+- `Free Map Type:`
+- `Name Text ID:`
+- `Next Node (Eirika 2nd):`
+- `Next Node (Eirika):`
+- `Next Node (Ephraim 2nd):`
+- `Next Node (Ephraim):`
+- `Post-Clear Icon:`
+- `Pre-Clear Icon:`
+- `Secret Shop Pointer:`
+- `Ship Setting:`
+- `Vendor Pointer:`
+- `World Map Point Editor`
+- `Write`
+
+### EDFE7Form
+WF labels: **23** · AV labels: **2** · WF-only: **23** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `0000`
+- `Size:`
+- `その後`
+- `アドレス`
+- `クリア後　その後　`
+- `ユニット`
+- `リストの拡張`
+- `リン編`
+- `リン編ユニット`
+- `先頭アドレス`
+- `内容`
+- `再取得`
+- `名前`
+- `指定`
+- `撤退`
+- `撤退指定 02`
+- `撤退時　その後　`
+- `書き込み`
+- `条件:`
+- `登場ユニット`
+- `読込数`
+- `通り名`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `ED (FE7)`
+
+### OPClassDemoFE8UForm
+WF labels: **23** · AV labels: **13** · WF-only: **23** · AV-only: **13** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `/60 (秒)`
+- `00`
+- `??`
+- `Commamd`
+- `Size:`
+- `アドレス`
+- `アニメ指定
+ポインタ書き込み`
+- `アニメ指定のポインタ`
+- `クラス`
+- `パレットID`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `戦闘アニメ`
+- `敵味方カラー`
+- `書き込み`
+- `表示地形右半分`
+- `表示地形左半分`
+- `説明文ID`
+- `読込数`
+- `選択アドレス:`
+- `魔法エフェクト`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Ally/Enemy Color:`
+- `Anime Pointer:`
+- `Anime Type:`
+- `Battle Anime:`
+- `Class ID:`
+- `Description Text ID:`
+- `Display Weapon:`
+- `Magic Effect:`
+- `OP Class Demo (FE8U) Editor`
+- `Terrain Left:`
+- `Terrain Right:`
+- `Write`
+
+### SupportUnitFE6Form
+WF labels: **23** · AV labels: **38** · WF-only: **23** · AV-only: **38** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `初期値`
+- `区切り00`
+- `名前`
+- `支援人数`
+- `支援相手1`
+- `支援相手10`
+- `支援相手2`
+- `支援相手3`
+- `支援相手4`
+- `支援相手5`
+- `支援相手6`
+- `支援相手7`
+- `支援相手8`
+- `支援相手9`
+- `書き込み`
+- `読込数`
+- `進行度`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Growth Rate 1:`
+- `Growth Rate 10:`
+- `Growth Rate 2:`
+- `Growth Rate 3:`
+- `Growth Rate 4:`
+- `Growth Rate 5:`
+- `Growth Rate 6:`
+- `Growth Rate 7:`
+- `Growth Rate 8:`
+- `Growth Rate 9:`
+- `Growth Rates`
+- `Initial Value 1:`
+- `Initial Value 10:`
+- `Initial Value 2:`
+- `Initial Value 3:`
+- `Initial Value 4:`
+- `Initial Value 5:`
+- `Initial Value 6:`
+- `Initial Value 7:`
+- `Initial Value 8:`
+- `Initial Value 9:`
+- `Initial Values`
+- `Partner 1:`
+- `Partner 10:`
+- `Partner 2:`
+- `Partner 3:`
+- `Partner 4:`
+- `Partner 5:`
+- `Partner 6:`
+- `Partner 7:`
+- `Partner 8:`
+- `Partner 9:`
+- `Partner Count:`
+- `Partner Count / Separator`
+- `Separator:`
+- `Support Partners`
+- `Support Units (FE6)`
+- `Write`
+
+### MonsterProbabilityForm
+WF labels: **22** · AV labels: **15** · WF-only: **22** · AV-only: **15** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `Size:`
+- `アドレス`
+- `コメント`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `出現魔物1`
+- `出現魔物2`
+- `出現魔物3`
+- `出現魔物4`
+- `出現魔物5`
+- `名前`
+- `座標設定の2バイトの一番左が5の時のクラスが確率テーブル`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+- `魔物1出現確率`
+- `魔物2出現確率`
+- `魔物3出現確率`
+- `魔物4出現確率`
+- `魔物5出現確率`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Class ID 1:`
+- `Class ID 2:`
+- `Class ID 3:`
+- `Class ID 4:`
+- `Class ID 5:`
+- `Monster Probability Editor`
+- `Probability 1:`
+- `Probability 2:`
+- `Probability 3:`
+- `Probability 4:`
+- `Probability 5:`
+- `Unknown 1:`
+- `Unknown 2:`
+- `Write`
+
+### SkillConfigSkillSystemForm
+WF labels: **22** · AV labels: **5** · WF-only: **22** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アイコン`
+- `アドレス`
+- `アニメーション`
+- `アニメーション取出`
+- `アニメーション読込`
+- `エディタ`
+- `フレーム`
+- `リストの拡張`
+- `一括インポート`
+- `一括エクスポート`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `拡大`
+- `書き込み`
+- `画像取出`
+- `画像読込`
+- `表示例`
+- `詳細`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Configures skill text details for the SkillSystem patch.`
+- `Skill Config (SkillSystem)`
+- `Text Detail:`
+- `Write`
+
+### SupportUnitForm
+WF labels: **22** · AV labels: **30** · WF-only: **22** · AV-only: **30** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `初期値`
+- `区切り00`
+- `名前`
+- `支援元`
+- `支援相手`
+- `支援相手1`
+- `支援相手2`
+- `支援相手3`
+- `支援相手4`
+- `支援相手5`
+- `支援相手6`
+- `支援相手7`
+- `書き込み`
+- `相手の初期値も自動調整する`
+- `読込数`
+- `進行度`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Growth Rate 1:`
+- `Growth Rate 2:`
+- `Growth Rate 3:`
+- `Growth Rate 4:`
+- `Growth Rate 5:`
+- `Growth Rate 6:`
+- `Growth Rate 7:`
+- `Growth Rates`
+- `Initial Value 1:`
+- `Initial Value 2:`
+- `Initial Value 3:`
+- `Initial Value 4:`
+- `Initial Value 5:`
+- `Initial Value 6:`
+- `Initial Value 7:`
+- `Initial Values`
+- `Partner 1:`
+- `Partner 2:`
+- `Partner 3:`
+- `Partner 4:`
+- `Partner 5:`
+- `Partner 6:`
+- `Partner 7:`
+- `Partner Count:`
+- `Partner Count / Separator`
+- `Separator 1:`
+- `Separator 2:`
+- `Support Partners`
+- `Support Unit Editor`
+- `Write`
+
+### ToolTranslateROMForm
+WF labels: **22** · AV labels: **2** · WF-only: **22** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `..`
+- `from:`
+- `OneLiner`
+- `to:`
+- `すべてのテキストをテキストファイルに書きだします。`
+- `フォント取込`
+- `全テキストの書出し`
+- `全テキストの読込`
+- `利用フォント`
+- `変更`
+- `定型文ROM FROM`
+- `定型文ROM TO`
+- `定型文の翻訳(FROM ROMと TO ROMから、定型文を取得し、翻訳の参考にする)`
+- `改造されたテキストのみ取得する`
+- `日本語フォントの上書き`
+- `現行ROMに足りないフォントを、以下のROMにあるフォントからコピーする`
+- `簡易`
+- `翻訳データ`
+- `翻訳開始`
+- `詳細`
+- `足りないフォントの自動生成`
+- `追加フォント ROM`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `ROM Translation Tool`
+
+### ImagePortraitFE6Form
+WF labels: **23** · AV labels: **14** · WF-only: **21** · AV-only: **12** · Common: **2**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `Size:`
+- `アドレス`
+- `コメント`
+- `ソースファイルを開く`
+- `ソースフォルダーを開く`
+- `パレット`
+- `フレーム`
+- `マップ顔`
+- `ユニット顔`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `口座標`
+- `名前`
+- `書き込み`
+- `画像取出`
+- `画像読込`
+- `表示例`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Export PAL`
+- `Export PNG`
+- `Import PAL`
+- `Import PNG`
+- `Map Face:`
+- `Mouth Coord:`
+- `Palette:`
+- `Portrait Editor (FE6)`
+- `Unit Face:`
+- `Unused (B14):`
+- `Unused (B15):`
+
+### MapExitPointForm
+WF labels: **21** · AV labels: **4** · WF-only: **21** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `Size:`
+- `X:`
+- `Y:`
+- `これは敵のエスケープポイントです。
+NPC用は、左上のコンボボックスを切り替えてください。`
+- `アドレス`
+- `マップ名`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `新規領域の確保`
+- `書き込み`
+- `条件:`
+- `消滅方法`
+- `読込数`
+- `選択アドレス:`
+- `離脱ポインタ`
+- `離脱ポインタ書き込み`
+- `離脱ポイント再取得`
+- `離脱座標`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Exit Pointer:`
+- `Map Exit Point Editor`
+- `Write`
+
+### MenuCommandForm
+WF labels: **21** · AV labels: **13** · WF-only: **21** · AV-only: **13** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `MenuCommandID`
+- `Size:`
+- `アドレス`
+- `カーソルで選択されたときの動作ポインタ`
+- `キャンセルされたときの動作ポインタ`
+- `ヘルプID`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `可否診断ルーチンポインタ`
+- `名前`
+- `名前(日本語の場合、未使用)`
+- `描画ルーチンポインタ`
+- `日本語の名前ポインタ`
+- `書き込み`
+- `色`
+- `読込数`
+- `選択アドレス:`
+- `選択時に実行する効果ポインタ`
+- `選択時に毎ターン呼び出されるポインタ`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Cancel Action:`
+- `Color/ID (u32@8):`
+- `Cursor Select Action:`
+- `Draw Routine:`
+- `Effect Routine:`
+- `Help Text ID:`
+- `Japanese Name Pointer:`
+- `Menu Command Editor`
+- `Name Text ID:`
+- `Per-Turn Callback:`
+- `Usability Routine:`
+- `Write`
+
+### PointerToolForm
+WF labels: **21** · AV labels: **20** · WF-only: **21** · AV-only: **20** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `LoadROMNAME`
+- `この場所への最初の参照`
+- `アドレス`
+- `アドレスがポインタの場合の
+指されるデータ位置`
+- `アドレスの種類判定`
+- `アドレス値の参照先の
+データがある場所`
+- `スライドして追加検索`
+- `バッチ (一括処理)`
+- `ポインタ化`
+- `リトルエンディアン`
+- `上記データの参照場所`
+- `内容`
+- `別ROM読込`
+- `参照値から追跡
+マッチアドレス`
+- `探索にASMMapを利用する`
+- `比較サイズ`
+- `比較方法`
+- `自動追跡システム`
+- `警告:0地帯です`
+- `警告:元データと離れすぎ`
+- `警告システム`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address`
+- `Auto Tracking`
+- `Batch`
+- `Close`
+- `Compare current ROM against another version to locate
+specific data such as images or programs that are
+shared between FE7 and FE8.`
+- `Comparison Size`
+- `Content Type`
+- `Data Address
+(if pointer)`
+- `e.g. 0x08000000`
+- `First Reference`
+- `Little Endian`
+- `Match Method`
+- `Other ROM
+Data Address`
+- `Other ROM Ref`
+- `Pointer`
+- `Search Options`
+- `Slide Search`
+- `Use ASM Map for search`
+- `Warning Level`
+- `What Is`
+
+### EDForm
+WF labels: **20** · AV labels: **8** · WF-only: **20** · AV-only: **8** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `0000`
+- `Size:`
+- `その後`
+- `アドレス`
+- `ユニット`
+- `リストの拡張`
+- `先頭アドレス`
+- `内容`
+- `再取得`
+- `名前`
+- `指定`
+- `撤退`
+- `撤退指定 02`
+- `書き込み`
+- `条件:`
+- `登場ユニット`
+- `読込数`
+- `通り名`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Condition:`
+- `Condition: 00=Died, 01=Wounded/Left, 02=Wounded/Stayed`
+- `Ending Event Editor`
+- `Unit ID:`
+- `Unknown (0x02):`
+- `Unknown (0x03):`
+- `Write`
+
+### EventMapChangeForm
+WF labels: **20** · AV labels: **2** · WF-only: **20** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `H:`
+- `size:`
+- `W:`
+- `X:`
+- `Y:`
+- `アドレス`
+- `サイズ`
+- `マップ名前`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `変化データ
+ポインタ先へのインポート`
+- `変化データポインタ`
+- `座標`
+- `書き込み`
+- `番号`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Map Change Event Editor`
+
+### ImageBGForm
+WF labels: **20** · AV labels: **6** · WF-only: **20** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `グラフィックツール`
+- `コメント`
+- `ソースファイルを開く`
+- `ソースフォルダーを開く`
+- `パレット`
+- `ヘッダ付きTSA`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `参照箇所`
+- `名前`
+- `書き込み`
+- `減色ツール`
+- `画像`
+- `画像取出`
+- `画像読込`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Background Image Editor`
+- `Export PAL`
+- `Export PNG`
+- `Import PAL`
+- `Import PNG`
+
+### ImageBattleBGForm
+WF labels: **20** · AV labels: **9** · WF-only: **20** · AV-only: **9** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `TSA`
+- `アドレス`
+- `グラフィックツール`
+- `コメント`
+- `ソースファイルを開く`
+- `ソースフォルダーを開く`
+- `パレット`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `参照箇所`
+- `名前`
+- `書き込み`
+- `減色ツール`
+- `画像`
+- `画像取出し`
+- `画像読込`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Battle Background Editor`
+- `Export PAL`
+- `Image (D0):`
+- `Import PAL`
+- `Import PNG`
+- `Palette (D8):`
+- `TSA (D4):`
+- `Write`
+
+### ImageMapActionAnimationForm
+WF labels: **20** · AV labels: **7** · WF-only: **20** · AV-only: **7** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `ID=00 Emptyはnullデータとして予約されています。
+0x0以外の値を設定しないでください。`
+- `Size:`
+- `アドレス`
+- `アニメーション`
+- `アニメーション取出`
+- `アニメーション読込`
+- `コメント`
+- `ソースファイルを開く`
+- `ソースフォルダーを開く`
+- `フレーム`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `拡大`
+- `書き込み`
+- `表示例`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Animation Ptr (D0):`
+- `Map Action Animation`
+- `Padding 1 (W4):`
+- `Padding 2 (W6):`
+- `Preview (Frame 0):`
+- `Write`
+
+### MapTileAnimation2Form
+WF labels: **20** · AV labels: **8** · WF-only: **20** · AV-only: **8** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `B`
+- `G`
+- `GBAカラー`
+- `R`
+- `Size:`
+- `アドレス`
+- `アニメーション間隔`
+- `データ個数`
+- `リストの拡張`
+- `一括インポート`
+- `一括エクスポート`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き換えるパレットデータ`
+- `書き換え始めパレット番号`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Animation Interval:`
+- `Data Count:`
+- `Map Tile Animation Type 2 (Palette)`
+- `Palette Data Pointer:`
+- `Start Palette Index:`
+- `Unknown (0x07):`
+- `Write`
+
+### SkillConfigFE8UCSkillSys09xForm
+WF labels: **20** · AV labels: **6** · WF-only: **20** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アイコン`
+- `アドレス`
+- `アニメーション`
+- `アニメーション取出`
+- `アニメーション読込`
+- `エディタ`
+- `スキル名`
+- `フレーム`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `拡大`
+- `書き込み`
+- `画像取出`
+- `画像読込`
+- `表示例`
+- `詳細`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Description:`
+- `Skill Configuration (CSkillSys 0.9.x)`
+- `Skill Name:`
+- `Skill system editors require a compatible skill patch to be installed.
+Use the Patch Manager to install a skill system patch first.
+
+Supported skill systems: CSkillSys, FE8N Skill System`
+- `Write`
+
+### SongTableForm
+WF labels: **20** · AV labels: **8** · WF-only: **20** · AV-only: **8** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Priority(PlayerType)`
+- `Size:`
+- `♪`
+- `アドレス`
+- `コメント`
+- `サウンドルームに曲を登録すると、曲名をつけられます。
+FEには、曲と効果音の違いはありません。
+`
+- `サウンドルームへ`
+- `ソングヘッダー`
+- `ソングヘッダーへ`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `参照箇所`
+- `名前`
+- `曲の楽譜を表示します。
+ここからは、曲のインポート、エクスポートを行います。`
+- `曲を構成する楽器テーブルを表示します。
+通常は気にする必要はありません。開発者向けの機能です。`
+- `書き込み`
+- `楽器テーブルへ`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Header Priority:`
+- `Header Reverb:`
+- `Priority (PlayerType):`
+- `Song Header Pointer:`
+- `Song Table Editor`
+- `Track Count:`
+- `Write`
+
+### ErrorPaletteTransparentForm
+WF labels: **19** · AV labels: **2** · WF-only: **19** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Info`
+- `No.1`
+- `No.10`
+- `No.11`
+- `No.12`
+- `No.13`
+- `No.14`
+- `No.15`
+- `No.16`
+- `No.2`
+- `No.3`
+- `No.4`
+- `No.5`
+- `No.6`
+- `No.7`
+- `No.8`
+- `No.9`
+- `パレットの透過色はどれですか？`
+- `通常、1番最初のパレットを背景の透過色にするべきですが、この画像はそうなっていないように思われます。
+背景の透過色はどれですか？`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Close`
+- `Palette Transparency Error`
+
+### ImageCGFE7UForm
+WF labels: **20** · AV labels: **11** · WF-only: **19** · AV-only: **10** · Common: **1**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `10分割画像`
+- `??`
+- `Size:`
+- `アドレス`
+- `コメント`
+- `ソースファイルを開く`
+- `ソースフォルダーを開く`
+- `パレット`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `減色ツール`
+- `画像取出`
+- `画像読込`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `10-Split Image:`
+- `Address:`
+- `CG Editor (FE7U)`
+- `Export PAL`
+- `Export PNG`
+- `Image Type:`
+- `Import PAL`
+- `Import PNG`
+- `Palette:`
+- `Reserved (B1-B3):`
+
+### ImageItemIconForm
+WF labels: **19** · AV labels: **7** · WF-only: **19** · AV-only: **7** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `インターネットから新しいリソースを探す`
+- `コメント`
+- `ソースファイルを開く`
+- `ソースフォルダーを開く`
+- `パレットの変更`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `原寸大`
+- `参照アイテム`
+- `名前`
+- `拡大`
+- `書き込み`
+- `画像取出`
+- `画像読込`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Export PAL`
+- `Export PNG`
+- `Image Pointer:`
+- `Import PNG`
+- `Item/Weapon Icon Viewer`
+- `Palette Pointer:`
+
+### MapChangeForm
+WF labels: **21** · AV labels: **15** · WF-only: **19** · AV-only: **13** · Common: **2**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `H:`
+- `Size:`
+- `W:`
+- `アドレス`
+- `コメント`
+- `サイズ`
+- `マップエディタ Jump`
+- `マップ名`
+- `マップ変化の再取得`
+- `マップ変更ポインタ`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `座標`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Change ID:`
+- `Change Pointer:`
+- `Change Records`
+- `Height:`
+- `Map Change Editor`
+- `Map Pointer`
+- `Record Address:`
+- `Selected Record`
+- `Tile Data Ptr:`
+- `Width:`
+- `Write Pointer`
+- `Write Record`
+
+### MenuDefinitionForm
+WF labels: **20** · AV labels: **15** · WF-only: **19** · AV-only: **14** · Common: **1**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Height(0でいい)`
+- `idk`
+- `On B Press`
+- `On HelpBox`
+- `On R Press`
+- `OnEnd`
+- `OnInit`
+- `Size:`
+- `X`
+- `Y`
+- `アドレス`
+- `メニューコマンド`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Height:`
+- `Menu Command Ptr:`
+- `Menu Definition Editor`
+- `On B Press Routine:`
+- `On HelpBox Routine:`
+- `On R Press Routine:`
+- `OnEnd Routine:`
+- `OnInit Routine:`
+- `Style Data:`
+- `Unknown Routine:`
+- `Write`
+- `X Position:`
+- `Y Position:`
+
+### SongTrackImportMidiForm
+WF labels: **19** · AV labels: **8** · WF-only: **19** · AV-only: **8** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `BEND,BENDR命令を無視する`
+- `FEBuilderGBAでインポート`
+- `LFOS,LFODL命令を無視する`
+- `mid2agbでインポート`
+- `midfix4agbのPATHが設定されていません。`
+- `midfix4agbを利用する`
+- `midi2agbのmodscを有効にする`
+- `MOD,MODT命令を無視する`
+- `それでも改善しない場合は、次のオプションも利用できます。`
+- `インポートする`
+- `オプション`
+- `マスターボリューム`
+- `古いオプション`
+- `楽器セット`
+- `楽譜の前方の無音区間を無視する`
+- `楽譜の後方の無音区間を無視する`
+- `無音区間を除去します。`
+- `選択する`
+- `音が「みょーん」となる場合は、有効にしてみてください。`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Browse MIDI File...`
+- `Import to ROM (Experimental)`
+- `MIDI File Metadata`
+- `MIDI Import`
+- `MIDI write-back to ROM is not yet fully implemented. You can preview MIDI file metadata above, but importing MIDI data into the ROM may produce unexpected results.`
+- `No file selected`
+- `Note`
+
+### AITargetForm
+WF labels: **18** · AV labels: **23** · WF-only: **18** · AV-only: **23** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Size:`
+- `それぞれのAIが何を優先するか指定します。詳細はこちらをクリック。`
+- `アドレス`
+- `先頭アドレス`
+- `再取得`
+- `包囲警戒度`
+- `反撃ダメージ警戒度`
+- `名前`
+- `敵との距離優先度`
+- `敵のクラス優先度`
+- `敵の残りHP優先度`
+- `書き込み`
+- `現在ターン優先度`
+- `自分の残りHP警戒度`
+- `致死ダメージ＆最終ダメージ優先度`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `AI Targeting`
+- `Counter Damage Warning:`
+- `Current Turn Priority:`
+- `Enemy Class Priority:`
+- `Enemy Distance Priority:`
+- `Enemy Remaining HP Priority:`
+- `Lethal Damage Priority:`
+- `Self Remaining HP Warning:`
+- `Surround Warning:`
+- `Unknown 10:`
+- `Unknown 11:`
+- `Unknown 12:`
+- `Unknown 13:`
+- `Unknown 14:`
+- `Unknown 15:`
+- `Unknown 16:`
+- `Unknown 17:`
+- `Unknown 18:`
+- `Unknown 19:`
+- `Unknown 8:`
+- `Unknown 9:`
+- `Write`
+
+### DumpStructSelectDialogForm
+WF labels: **18** · AV labels: **2** · WF-only: **18** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `1234`
+- `C言語の構造体の表示`
+- `NightmareModule nmmファイルの作成`
+- `no$gbaの読込ブレークポイントとしてコピー`
+- `インポートする`
+- `クリップボード`
+- `クリップボードへコピー`
+- `ダンプしていたデータのインポート`
+- `データダンプ`
+- `バイナリエディタ`
+- `ポインタとしてクリップボードへコピー`
+- `リトルエンディアンポインタとしてクリップボードへコピー`
+- `値:`
+- `構造体`
+- `表示しているリストにあるすべてのデータのCSV形式を取得`
+- `表示しているリストにあるすべてのデータのEA形式を取得`
+- `表示しているリストにあるすべてのデータのTSV形式を取得`
+- `選択しているアドレスをバイナリエディタで表示`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Struct Dump Selector`
+
+### EventBattleTalkFE7Form
+WF labels: **18** · AV labels: **2** · WF-only: **18** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Size:`
+- `アドレス`
+- `イベント`
+- `テキスト`
+- `ユニット`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `反撃側ユニット`
+- `名前`
+- `攻撃側ユニット`
+- `新規イベント`
+- `書き込み`
+- `章ID`
+- `読込数`
+- `達成フラグ`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Battle Dialogue (FE7)`
+
+### ImageCGForm
+WF labels: **18** · AV labels: **6** · WF-only: **18** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `10分割画像`
+- `Size:`
+- `TSA`
+- `アドレス`
+- `コメント`
+- `ソースファイルを開く`
+- `ソースフォルダーを開く`
+- `パレット`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `減色ツール`
+- `画像取出`
+- `画像読込`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `CG Image Editor`
+- `Export PAL`
+- `Export PNG`
+- `Import PAL`
+- `Import PNG`
+
+### ImageChapterTitleForm
+WF labels: **18** · AV labels: **9** · WF-only: **18** · AV-only: **9** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `セーブ画像`
+- `セーブ画像取出し`
+- `セーブ画像読込`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `章タイトル`
+- `章タイトル取出し`
+- `章タイトル読込`
+- `章画像`
+- `章画像取出し`
+- `章画像読込`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Chapter Image Ptr:`
+- `Chapter Title Editor`
+- `Export PAL`
+- `Export PNG`
+- `Import PNG`
+- `Save Image Ptr:`
+- `Title Image Ptr:`
+- `Write`
+
+### ItemStatBonusesForm
+WF labels: **19** · AV labels: **15** · WF-only: **18** · AV-only: **14** · Common: **1**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Size:`
+- `アイテムを追加したい場合、アイテムエディタ画面にある、「能力補正」の項目から追加してください。`
+- `アドレス`
+- `体格`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `守備`
+- `幸運`
+- ` 技 `
+- `攻撃`
+- `書き込み`
+- `移動`
+- `該当アイテム`
+- `速さ`
+- `選択アドレス:`
+- `魔防`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Con:`
+- `Defense:`
+- `Item Stat Bonuses Editor`
+- `Luck:`
+- `Move:`
+- `Resistance:`
+- `Skill:`
+- `Speed:`
+- `Str/Mag:`
+- `Unknown (byte 10):`
+- `Unknown (byte 11):`
+- `Unknown (byte 9):`
+- `Write`
+
+### PaletteChangeColorsForm
+WF labels: **21** · AV labels: **9** · WF-only: **18** · AV-only: **6** · Common: **3**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `No.1`
+- `No.10`
+- `No.11`
+- `No.12`
+- `No.13`
+- `No.14`
+- `No.15`
+- `No.16`
+- `No.2`
+- `No.3`
+- `No.4`
+- `No.5`
+- `No.6`
+- `No.7`
+- `No.8`
+- `No.9`
+- `リセット`
+- `変更`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `[Palette color grid - 16 color slots]`
+- `Apply`
+- `Close`
+- `Color Grid (16 colors):`
+- `Palette Change Colors`
+- `Palette Color Editor allows editing individual colors in a 16-color GBA palette.
+Select a palette slot to modify its RGB values.`
+
+### PaletteSwapForm
+WF labels: **18** · AV labels: **6** · WF-only: **18** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Info`
+- `No.1`
+- `No.10`
+- `No.11`
+- `No.12`
+- `No.13`
+- `No.14`
+- `No.15`
+- `No.16`
+- `No.2`
+- `No.3`
+- `No.4`
+- `No.5`
+- `No.6`
+- `No.7`
+- `No.8`
+- `No.9`
+- `場所を入れ替える色を選択してください`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Cancel`
+- `Destination Palette:`
+- `Palette Swap`
+- `Palette Swap exchanges palette assignments between entries.
+Select source and destination palette slots to exchange their color data.`
+- `Source Palette:`
+- `Swap`
+
+### SupportAttributeForm
+WF labels: **18** · AV labels: **11** · WF-only: **18** · AV-only: **11** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Size:`
+- `アドレス`
+- `コメント`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `命中`
+- `回避`
+- `属性:-`
+- `必殺`
+- `必殺回避`
+- `攻撃`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+- `防御`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Affinity Type:`
+- `Attack Bonus:`
+- `Avoid Bonus:`
+- `Crit Avoid Bonus:`
+- `Crit Bonus:`
+- `Defense Bonus:`
+- `Hit Bonus:`
+- `Support Attribute Editor`
+- `Unknown 7:`
+- `Write`
+
+### EventBattleTalkForm
+WF labels: **17** · AV labels: **2** · WF-only: **17** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Size:`
+- `アドレス`
+- `イベント`
+- `テキスト`
+- `マップ`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `反撃側ユニット`
+- `名前`
+- `攻撃側ユニット`
+- `新規イベント`
+- `書き込み`
+- `読込数`
+- `達成フラグ`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Battle Dialogue Editor`
+
+### EventHaikuForm
+WF labels: **17** · AV labels: **2** · WF-only: **17** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Size:`
+- `アドレス`
+- `イベント`
+- `テキスト`
+- `ユニット`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `新規イベント`
+- `書き込み`
+- `章ID`
+- `編`
+- `読込数`
+- `達成フラグ`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Haiku Event Editor`
+
+### FE8SpellMenuExtendsForm
+WF labels: **17** · AV labels: **2** · WF-only: **17** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `このテーブルは、複数のクラスで参照されています。`
+- `アドレス`
+- `リストの拡張`
+- `レベル`
+- `レベルアップで取得する魔法の先頭アドレス`
+- `上級職のみ`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `習得レベル`
+- `読込数`
+- `選択アドレス:`
+- `選択クラスの分離独立`
+- `領域が確保されていません。
+「リストの拡張ボタン」を押して領域を確保してください。`
+- `魔法`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Spell Menu Extensions`
+
+### GraphicsToolForm
+WF labels: **17** · AV labels: **12** · WF-only: **17** · AV-only: **12** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Data Dump`
+- `No`
+- `PageDown`
+- `PageUp`
+- `PatchMaker`
+- `TSA`
+- `TSA Editor(非推奨)`
+- `パレット`
+- `パレットエディタ`
+- `パレット番号`
+- `幅/8`
+- `画像が利用している16色パレットの個数`
+- `画像アドレス`
+- `画像取出`
+- `画像読込`
+- `第2画像`
+- `高さ/8`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `0x08000000`
+- `4bpp`
+- `Close`
+- `Draw`
+- `Graphics Tool`
+- `Image Address:`
+- `LZ77 Compressed`
+- `Palette Address:`
+- `Tiles X:`
+- `Tiles Y:`
+- `View tile graphics from ROM. Enter addresses and click Draw.`
+- `Zoom:`
+
+### ImagePortraitImporterForm
+WF labels: **17** · AV labels: **2** · WF-only: **17** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `BlockX`
+- `BlockY`
+- `H`
+- `Preview`
+- `STATUS`
+- `W`
+- `X`
+- `Y`
+- `この画像は16色を超えているので、減色処理が必要です`
+- `インポートする`
+- `フレーム:`
+- `口の位置`
+- `目の位置`
+- `簡易`
+- `縁を黒どりする`
+- `自動的に減色してインポートする`
+- `詳細な減色`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Portrait Import Wizard`
+
+### ItemStatBonusesSkillSystemsForm
+WF labels: **19** · AV labels: **17** · WF-only: **17** · AV-only: **15** · Common: **2**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アイテムを追加したい場合、アイテムエディタ画面にある、「能力補正」の項目から追加してください。`
+- `アドレス`
+- `体格`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `守備`
+- `幸運`
+- `技`
+- `攻撃`
+- `書き込み`
+- `移動`
+- `該当アイテム`
+- `速さ`
+- `選択アドレス:`
+- `魔防`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Con`
+- `Defense`
+- `Growth Rate Bonuses`
+- `Luck`
+- `Magic/??`
+- `Move`
+- `Padding`
+- `Resistance`
+- `Skill`
+- `Speed`
+- `Stat Bonuses`
+- `Stat Bonuses (Skill Systems)`
+- `Str/Mag`
+- `Write`
+
+### ItemStatBonusesVennoForm
+WF labels: **18** · AV labels: **14** · WF-only: **17** · AV-only: **13** · Common: **1**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アイテムを追加したい場合、アイテムエディタ画面にある、「能力補正」の項目から追加してください。`
+- `アドレス`
+- `体格`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `守備`
+- `幸運`
+- `技`
+- `攻撃`
+- `書き込み`
+- `移動`
+- `該当アイテム`
+- `速さ`
+- `選択アドレス:`
+- `魔防`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Con`
+- `Defense`
+- `Growth Rate Bonuses`
+- `Luck`
+- `Move`
+- `Resistance`
+- `Skill`
+- `Speed`
+- `Stat Bonuses`
+- `Stat Bonuses (Venno)`
+- `Str/Mag`
+- `Write`
+
+### ItemWeaponEffectForm
+WF labels: **17** · AV labels: **14** · WF-only: **17** · AV-only: **14** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `1か2`
+- `??`
+- `Size:`
+- `アイテムID`
+- `アドレス`
+- `エフェクトID`
+- `ダメージエフェクト`
+- `マップ使用時エフェクト`
+- `モーション`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `被弾色`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Anim Type:`
+- `Damage Effect:`
+- `Effect ID:`
+- `Hit Color:`
+- `Item ID:`
+- `Item Weapon Effect Editor`
+- `Map Effect Pointer:`
+- `Motion:`
+- `Unknown (byte 1):`
+- `Unknown (byte 15):`
+- `Unknown (byte 3):`
+- `Unknown (bytes 6-7):`
+- `Write`
+
+### MapTileAnimation1Form
+WF labels: **17** · AV labels: **6** · WF-only: **17** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `アニメーション間隔`
+- `データ個数`
+- `パレット`
+- `リストの拡張`
+- `一括インポート`
+- `一括エクスポート`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き換えるマップチップ`
+- `書き込み`
+- `画像取出`
+- `画像読込`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Animation Interval:`
+- `Data Count:`
+- `Map Tile Animation Type 1`
+- `Map Tile Data Pointer:`
+- `Write`
+
+### SkillAssignmentUnitCSkillSysForm
+WF labels: **17** · AV labels: **5** · WF-only: **17** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `このテーブルは、複数のクラスで参照されています。`
+- `アドレス`
+- `スキル`
+- `リストの拡張`
+- `一括インポート`
+- `一括エクスポート`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `習得レベル`
+- `習得レベルとスキルの詳細は、ここをクリックしてください。`
+- `読込数`
+- `選択アドレス:`
+- `選択クラスの分離独立`
+- `領域が確保されていません。
+「リストの拡張ボタン」を押して領域を確保してください。`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Skill Assignment - Unit (CSkillSys)`
+- `Skill system editors require a compatible skill patch to be installed.
+Use the Patch Manager to install a skill system patch first.
+
+Supported skill systems: CSkillSys, FE8N Skill System`
+- `Unit Skill:`
+- `Write`
+
+### SkillAssignmentUnitSkillSystemForm
+WF labels: **17** · AV labels: **5** · WF-only: **17** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `このテーブルは、複数のクラスで参照されています。`
+- `アドレス`
+- `スキル`
+- `リストの拡張`
+- `一括インポート`
+- `一括エクスポート`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `習得レベル`
+- `習得レベルとスキルの詳細は、ここをクリックしてください。`
+- `読込数`
+- `選択アドレス:`
+- `選択クラスの分離独立`
+- `領域が確保されていません。
+「リストの拡張ボタン」を押して領域を確保してください。`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Assigns a skill to each unit via the SkillSystem patch.`
+- `Skill Assignment (Unit)`
+- `Unit Skill:`
+- `Write`
+
+### TextCharCodeForm
+WF labels: **17** · AV labels: **8** · WF-only: **17** · AV-only: **8** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `ASCII`
+- `FFFF`
+- `Size:`
+- `アイテムフォント`
+- `アドレス`
+- `セリフフォント`
+- `使用回数検索`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `回以下しか出現しない文字取得`
+- `文字文字`
+- `文字検索`
+- `書き込み`
+- `番号 文字 回数　登場会話ID`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Char Code (ASCII):`
+- `Character Code Table`
+- `Character Display:`
+- `Close`
+- `Item Font`
+- `Lists all character codes in the ROM's text encoding table.`
+- `Serif Font`
+- `Terminator (FFFF):`
+
+### ToolProblemReportForm
+WF labels: **17** · AV labels: **2** · WF-only: **17** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `BeginPage`
+- `DiscordコミニティURL`
+- `EndPage`
+- `Step1Page`
+- `Step2Page`
+- `この機能の説明`
+- `どの章？`
+- `ファイル選択`
+- `作成`
+- `始める`
+- `完了`
+- `完了ボタンでDiscordコミニティURLを開く`
+- `戻る`
+- `次へ`
+- `添付データ`
+- `無改造ROM`
+- `誰？`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Problem Reporter`
+
+### UnitCustomBattleAnimeForm
+WF labels: **17** · AV labels: **6** · WF-only: **17** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `このテーブルは、複数のクラスで参照されています。`
+- `アドレス`
+- `アニメ内容の先頭アドレス`
+- `アニメ番号`
+- `アニメ設定`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `専用アニメポインタの書き込み`
+- `書き込み`
+- `武器種類`
+- `特殊`
+- `読込数`
+- `選択アドレス:`
+- `選択クラスの分離独立`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Animation Number:`
+- `Custom Battle Animation`
+- `Special:`
+- `Weapon Type:`
+- `Write`
+
+### WorldMapEventPointerForm
+WF labels: **17** · AV labels: **4** · WF-only: **17** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `エイリークエンディング`
+- `エフラムエンディング`
+- `オープニングイベント`
+- `リストの拡張`
+- `ワールドマップ拠点へJump`
+- `ワールドマップ道へJump`
+- `先頭アドレス`
+- `再取得`
+- `前の拠点クリア後に発生するイベント`
+- `名前`
+- `拠点選択後に発生するイベント`
+- `新規イベント`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Event Pointer (u32@0):`
+- `World Map Event Editor`
+- `Write`
+
+### EventHaikuFE7Form
+WF labels: **16** · AV labels: **2** · WF-only: **16** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Size:`
+- `アドレス`
+- `イベント`
+- `テキスト`
+- `ユニット`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `新規イベント`
+- `書き込み`
+- `章ID`
+- `読込数`
+- `達成フラグ`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Haiku (FE7)`
+
+### ItemUsagePointerForm
+WF labels: **16** · AV labels: **5** · WF-only: **16** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `ASMポインタ`
+- `CCアイテム`
+- `IERがインストールされているため、パッチ画面から設定してください。`
+- `Size:`
+- `このバージョンのFEでは利用しません。`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `条件:`
+- `能力補正`
+- `読込数`
+- `選択アドレス:`
+- `関連項目`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Function pointers for item usability checks`
+- `Item Usage Pointer Editor`
+- `Usability Pointer:`
+- `Write`
+
+### MainSimpleMenuImageSubForm
+WF labels: **16** · AV labels: **2** · WF-only: **16** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `CG`
+- `WMAP画像`
+- `アイテムアイコン`
+- `キャラパレット`
+- `システムアイコン`
+- `フォント`
+- `待機アイコン`
+- `戦闘アニメ`
+- `戦闘地形`
+- `戦闘画面`
+- `戦闘背景`
+- `移動アイコン`
+- `章タイトル`
+- `背景`
+- `追加魔法`
+- `顔画像`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Image Sub-Menu`
+
+### MapEditorForm
+WF labels: **16** · AV labels: **10** · WF-only: **16** · AV-only: **10** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Address`
+- `Redo`
+- `UNDO`
+- `サイズ変更`
+- `スタイル編集`
+- `ソースファイルを開く`
+- `ソースフォルダーを開く`
+- `タイルの拡大`
+- `ファイルから読込`
+- `ファイルに保存`
+- `マップサイズ`
+- `マップスタイル`
+- `マップ変化追加`
+- `拡大`
+- `書き込み`
+- `編集マップ変更`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `+`
+- `-`
+- `1x`
+- `No tile selected`
+- `Refresh Map`
+- `Tile Editor (click on map to select)`
+- `Tile ID (hex):`
+- `Visual Map Editor`
+- `Write Tile`
+- `Zoom:`
+
+### StatusRMenuForm
+WF labels: **16** · AV labels: **12** · WF-only: **16** · AV-only: **12** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Getter`
+- `Loop`
+- `Size:`
+- `TID`
+- `X`
+- `Y`
+- `アドレス`
+- `上 RMenuPointer`
+- `下 RMenuPointer`
+- `先頭アドレス`
+- `再取得`
+- `右 RMenuPointer`
+- `名前`
+- `左 RMenuPointer`
+- `書き込み`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Down RMenuPointer:`
+- `Getter Routine:`
+- `Left RMenuPointer:`
+- `Loop Routine:`
+- `Right RMenuPointer:`
+- `Status R-Menu Editor`
+- `Text ID (TID):`
+- `Up RMenuPointer:`
+- `Write`
+- `X Position:`
+- `Y Position:`
+
+### SupportTalkFE7Form
+WF labels: **16** · AV labels: **13** · WF-only: **16** · AV-only: **13** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `A会話`
+- `B会話`
+- `C会話`
+- `Size:`
+- `♪`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `支援相手1`
+- `支援相手2`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `A Support Song:`
+- `A Support Text:`
+- `Address:`
+- `B Support Song:`
+- `B Support Text:`
+- `C Support Song:`
+- `C Support Text:`
+- `Jump`
+- `Padding:`
+- `Support Partner 1:`
+- `Support Partner 2:`
+- `Support Talk (FE7)`
+- `Write`
+
+### SupportTalkForm
+WF labels: **16** · AV labels: **12** · WF-only: **16** · AV-only: **12** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `A会話`
+- `B会話`
+- `C会話`
+- `Size:`
+- `♪`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `支援相手1`
+- `支援相手2`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `A Support Song:`
+- `A Support Text:`
+- `Address:`
+- `B Support Song:`
+- `B Support Text:`
+- `C Support Song:`
+- `C Support Text:`
+- `Jump`
+- `Support Partner 1:`
+- `Support Partner 2:`
+- `Support Talk`
+- `Write`
+
+### TextDicForm
+WF labels: **16** · AV labels: **14** · WF-only: **16** · AV-only: **14** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Size:`
+- `アドレス`
+- `タイトル`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `既読フラグ`
+- `書き込み`
+- `章タイトル`
+- `表示フラグ`
+- `詳細`
+- `読込数`
+- `選択アドレス:`
+- `項目名`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `12-byte records: title index, chapter index, text IDs, flags, unit/class.`
+- `Chapter Index:`
+- `Class:`
+- `Class ID:`
+- `Flag 1:`
+- `Flag 2:`
+- `Preview:`
+- `Text Dictionary`
+- `Text ID 1:`
+- `Text ID 2:`
+- `Title Index:`
+- `Unit:`
+- `Unit ID:`
+- `Write`
+
+### EventHaikuFE6Form
+WF labels: **15** · AV labels: **2** · WF-only: **15** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Size:`
+- `アドレス`
+- `ユニット`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `死亡時`
+- `章ID`
+- `終章`
+- `読込数`
+- `達成フラグ`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Haiku (FE6)`
+
+### ImageTSAAnimeForm
+WF labels: **15** · AV labels: **6** · WF-only: **15** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `グラフィックツール`
+- `パレット`
+- `ヘッダ付きTSA`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `減色ツール`
+- `画像`
+- `画像取出`
+- `画像読込`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Export PAL`
+- `Export PNG`
+- `Import PAL`
+- `Import PNG`
+- `TSA Animation Editor`
+
+### ItemEffectivenessForm
+WF labels: **15** · AV labels: **5** · WF-only: **15** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `このデータは、複数のアイテムで参照されています。`
+- `アドレス`
+- `クラス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `特効クラス`
+- `特効ポインタアドレス`
+- `特効再取得`
+- `該当アイテム`
+- `選択アイテムの分離独立`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Class ID:`
+- `Item Effectiveness Editor`
+- `Weapon effectiveness 2x/3x class list (FE8 only)`
+- `Write`
+
+### ItemEffectivenessSkillSystemsReworkForm
+WF labels: **15** · AV labels: **2** · WF-only: **15** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `ClassType`
+- `coefficient_times*2`
+- `Size:`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `特効クラス`
+- `特効ポインタアドレス`
+- `特効再取得`
+- `該当アイテム`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Effectiveness (Skill Systems Rework)`
+
+### MonsterWMapProbabilityForm
+WF labels: **15** · AV labels: **4** · WF-only: **15** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `それぞれのルートでクリアする章を指定します。
+これは、まだクリアしていない拠点には魔物を出せないためです。`
+- `アドレス`
+- `フリーマップ終了イベント`
+- `フリーマップ開始イベント`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `拠点ID`
+- `拠点ごとの魔物の発生確率を定義します。`
+- `書き込み`
+- `章ID`
+- `読込数`
+- `選択アドレス:`
+- `魔物が出現する拠点IDを指定します。`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Base Point ID:`
+- `World Map Monster Editor`
+- `Write`
+
+### SupportTalkFE6Form
+WF labels: **15** · AV labels: **11** · WF-only: **15** · AV-only: **11** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `A会話`
+- `B会話`
+- `C会話`
+- `Size:`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `支援相手1`
+- `支援相手2`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `A Support Text:`
+- `Address:`
+- `B Support Text:`
+- `C Support Text:`
+- `Jump`
+- `Padding 1:`
+- `Padding 2:`
+- `Support Partner 1:`
+- `Support Partner 2:`
+- `Support Talk (FE6)`
+- `Write`
+
+### UnitPaletteForm
+WF labels: **15** · AV labels: **10** · WF-only: **15** · AV-only: **10** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `上級クラス1`
+- `上級クラス2`
+- `上級クラス3`
+- `上級クラス4`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `基本クラス1`
+- `基本クラス2(見習いキャラのみ)`
+- `書き込み`
+- `見習いクラス(見習いキャラのみ)`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Advanced Class 1:`
+- `Advanced Class 2:`
+- `Advanced Class 3:`
+- `Advanced Class 4:`
+- `Base Class 1:`
+- `Base Class 2 (trainee only):`
+- `Trainee Class (trainee only):`
+- `Unit Palette Assignment`
+- `Write`
+
+### EventBattleTalkFE6Form
+WF labels: **14** · AV labels: **2** · WF-only: **14** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Size:`
+- `アドレス`
+- `テキスト`
+- `ユニット`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `章ID`
+- `読込数`
+- `達成フラグ`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Battle Dialogue (FE6)`
+
+### EventForceSortieFE7Form
+WF labels: **14** · AV labels: **8** · WF-only: **14** · AV-only: **8** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Size:`
+- `アドレス`
+- `マップ名`
+- `ユニット`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `強制出撃ポインタ`
+- `強制出撃ポインタ書き込み`
+- `強制出撃ポイント再取得`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Force Sortie (FE7)`
+- `Unit ID:`
+- `Unit List Pointer:`
+- `Unknown 1:`
+- `Unknown 2:`
+- `Unknown 3:`
+- `Write`
+
+### FontForm
+WF labels: **14** · AV labels: **2** · WF-only: **14** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `アドレス`
+- `サンプル`
+- `フォントの種類`
+- `フォント幅`
+- `一括インポート`
+- `一括エクスポート`
+- `利用フォント`
+- `変更`
+- `書き込み`
+- `検索`
+- `検索文字`
+- `画像取出`
+- `画像読込`
+- `自動生成`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Font Editor`
+
+### OPPrologueForm
+WF labels: **14** · AV labels: **10** · WF-only: **14** · AV-only: **10** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Size:`
+- `TSA`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `画像`
+- `画像取出`
+- `画像読込`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Export PAL`
+- `Export PNG`
+- `Image Pointer:`
+- `Import PAL`
+- `Import PNG`
+- `OP Prologue Editor`
+- `Palette Address:`
+- `TSA Pointer:`
+- `Write`
+
+### SongTrackImportWaveForm
+WF labels: **14** · AV labels: **2** · WF-only: **14** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `DPCM lookahead`
+- `DPCM圧縮`
+- `m4a_hq_mixer Patchがインストールされていないので、DPCM圧縮は利用できません。`
+- `Preview`
+- `Waveファイルは効果音に使うことを想定しています。
+それを、音楽に利用すると、大量に容量を消費しますが、インポートしてもよろしいですか？`
+- `インポートする`
+- `キャンセル`
+- `チャンネル`
+- `前後の無音除去`
+- `格納方法と最適化`
+- `楽譜`
+- `楽譜のループ`
+- `音質を下げる`
+- `音量`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Wave Track Import`
+
+### SoundRoomForm
+WF labels: **14** · AV labels: **8** · WF-only: **14** · AV-only: **8** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `BGMID`
+- `Size:`
+- `♪`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `曲の長さ`
+- `曲名`
+- `書き込み`
+- `表示条件ASM`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Display Cond ASM:`
+- `Jump`
+- `Song ID:`
+- `Song Length:`
+- `Sound Room Editor`
+- `Text ID:`
+- `Write`
+
+### StatusParamForm
+WF labels: **15** · AV labels: **11** · WF-only: **14** · AV-only: **10** · Common: **1**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `?? Bitmap`
+- `Size:`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `字下げ`
+- `文字列ポインタ`
+- `書き込み`
+- `色`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `B10:`
+- `B11:`
+- `Bitmap:`
+- `Color:`
+- `Indent:`
+- `Status Parameters Editor`
+- `String Pointer:`
+- `String Text:`
+- `Write`
+
+### WorldMapPathForm
+WF labels: **14** · AV labels: **10** · WF-only: **14** · AV-only: **10** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `0000`
+- `NULLの場合、拠点間を直線で通る`
+- `Size:`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `道の起点になる拠点ID`
+- `道を移動するパスのポインタ`
+- `道データへのポインタ`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `(NULL path move pointer = straight line between nodes)`
+- `Address:`
+- `End Base Point ID:`
+- `Padding (B6):`
+- `Padding (B7):`
+- `Path Data Pointer:`
+- `Path Move Pointer:`
+- `Start Base Point ID:`
+- `World Map Paths`
+- `Write`
+
+### WorldMapPathForm
+WF labels: **14** · AV labels: **2** · WF-only: **14** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `0000`
+- `NULLの場合、拠点間を直線で通る`
+- `Size:`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `道の起点になる拠点ID`
+- `道を移動するパスのポインタ`
+- `道データへのポインタ`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Path Editor`
+
+### AIPerformItemForm
+WF labels: **13** · AV labels: **7** · WF-only: **13** · AV-only: **7** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `AIがアイテムを使用するかどうか判定する関数を指定します。
+なお、章ごとにアイテムを使えるかどうかの設定は、「AIの章ごとの設定」にあります。`
+- `ASM`
+- `Size:`
+- `アイテム`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `AI Item Performance`
+- `ASM Pointer:`
+- `Item:`
+- `Specifies the function that determines whether AI will use an item.`
+- `Unused:`
+- `Write`
+
+### AIPerformStaffForm
+WF labels: **13** · AV labels: **7** · WF-only: **13** · AV-only: **7** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `ASM`
+- `Size:`
+- `アイテム`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `杖を利用できるAIが杖を使用するかどうか判定する関数を指定します。`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `AI Staff Performance`
+- `ASM Pointer:`
+- `Item (Staff):`
+- `Specifies the function that determines whether AI will use a staff.`
+- `Unused:`
+- `Write`
+
+### CCBranchForm
+WF labels: **13** · AV labels: **6** · WF-only: **13** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `CC3分岐パッチよって追加された値です。
+上の2つの同じであれば無視されます。
+この値は、クラスデータの「クラスチェンジ」に保存されます。`
+- `CC時に表示されるクラスの英語表記へJump`
+- `Size:`
+- `この値を0にしないでください`
+- `アドレス`
+- `クラスチェンジ前`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+- `選択中のクラス`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `CC Branch Editor`
+- `Promotion Class 1:`
+- `Promotion Class 2:`
+- `Upstream Chain (classes that promote to this one):`
+- `Write`
+
+### EDSensekiCommentForm
+WF labels: **13** · AV labels: **7** · WF-only: **13** · AV-only: **7** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `ユニット`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `戦績悪`
+- `戦績普通`
+- `戦績良`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Conversation Text 1:`
+- `Conversation Text 2:`
+- `Conversation Text 3:`
+- `ED Senseki Comment`
+- `Unit ID:`
+- `Write`
+
+### EventBattleDataFE7Form
+WF labels: **13** · AV labels: **2** · WF-only: **13** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `もし、リストを縮めたい場合は、「攻撃側」で「戦闘終了」を選択してください。`
+- `アドレス`
+- `ダメージ`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `攻撃側`
+- `攻撃方法`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Battle Data (FE7)`
+
+### FontZHForm
+WF labels: **13** · AV labels: **2** · WF-only: **13** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `アドレス`
+- `サンプル`
+- `フォントの種類`
+- `フォント幅`
+- `一括エクスポート`
+- `利用フォント`
+- `変更`
+- `書き込み`
+- `検索`
+- `検索文字`
+- `画像取出`
+- `画像読込`
+- `自動生成`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Font Editor (Chinese)`
+
+### ImageGenericEnemyPortraitForm
+WF labels: **13** · AV labels: **3** · WF-only: **13** · AV-only: **3** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `xxx`
+- `アドレス`
+- `パレット`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `画像`
+- `画像取出`
+- `画像読込`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Generic Enemy Portraits`
+- `Image Pointer:`
+
+### ImageTSAAnime2Form
+WF labels: **13** · AV labels: **9** · WF-only: **13** · AV-only: **9** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `IMG`
+- `Size:`
+- `アドレス`
+- `パレット`
+- `ヘッダー書き込み`
+- `ヘッダ付きTSA`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Import PNG`
+- `TSA Animation Editor v2`
+- `TSA w/ Header (P8):`
+- `Unknown 0 (W0):`
+- `Unknown 2 (W2):`
+- `Unknown 4 (W4):`
+- `Unknown 6 (W6):`
+- `Write`
+
+### ItemWeaponTriangleForm
+WF labels: **13** · AV labels: **8** · WF-only: **13** · AV-only: **8** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `命中補正`
+- `攻撃武器`
+- `攻撃補正`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+- `防御武器`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Bonus:`
+- `Penalty:`
+- `Weapon triangle bonus/penalty data`
+- `Weapon Triangle Editor`
+- `Weapon Type 1:`
+- `Weapon Type 2:`
+- `Write`
+
+### SoundBossBGMForm
+WF labels: **13** · AV labels: **10** · WF-only: **13** · AV-only: **10** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Size:`
+- `♪`
+- `アドレス`
+- `ユニット`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `曲番号`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Boss BGM Editor`
+- `Jump`
+- `Pick...`
+- `Song ID:`
+- `Unit ID:`
+- `Unknown 1:`
+- `Unknown 2:`
+- `Unknown 3:`
+- `Write`
+
+### SoundRoomFE6Form
+WF labels: **13** · AV labels: **6** · WF-only: **13** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `BGMID`
+- `Size:`
+- `♪`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `曲名`
+- `書き込み`
+- `説明`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `BGM ID:`
+- `Description (Text ID):`
+- `Song Name (Text ID):`
+- `Sound Room (FE6)`
+- `Write`
+
+### WorldMapBGMForm
+WF labels: **13** · AV labels: **6** · WF-only: **13** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `♪`
+- `この拠点が、次の目的地となったときに再生するBGMを選択します。`
+- `アドレス`
+- `エイリーク編`
+- `エフラム編`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Jump`
+- `Song ID 1 (u16@0):`
+- `Song ID 2 (u16@2):`
+- `World Map BGM Editor`
+- `Write`
+
+### WorldMapEventPointerFE7Form
+WF labels: **13** · AV labels: **2** · WF-only: **13** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `エリウッドエンディング`
+- `ヘクトルエンディング`
+- `リストの拡張`
+- `ワールドマップイベント`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `新規イベント`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Event Pointer (FE7)`
+
+### WorldMapImageFE7Form
+WF labels: **13** · AV labels: **2** · WF-only: **13** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `12分割TSA`
+- `12分割画像`
+- `TSA`
+- `イベント用`
+- `ソースファイルを開く`
+- `ソースフォルダーを開く`
+- `パレット`
+- `ポインタを書き込む`
+- `メインフィールドマップ`
+- `減色ツール`
+- `画像`
+- `画像取出`
+- `画像読込`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `World Map Image (FE7)`
+
+### AIStealItemForm
+WF labels: **12** · AV labels: **6** · WF-only: **12** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `Size:`
+- `アイテム`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `盗賊AIが、アイテムを盗むときに利用する、アイテムの優先度を設定します。
+リストの先頭がもっとも優先度が高いアイテムになります。`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `AI Steal Item Logic`
+- `Item:`
+- `Sets the priority of items that thief AI will try to steal. Items at the top of the list have the highest priority.`
+- `Unused 1:`
+- `Write`
+
+### ArenaClassForm
+WF labels: **12** · AV labels: **4** · WF-only: **12** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `クラス`
+- `リストの拡張`
+- `上級職、下級職は自動で調整されます。
+闘技場で敵として使用されるユニットは、0xFD 対戦相手です。
+ほかのユニットが出ることはないようです。`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `条件:`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Arena Class Editor`
+- `Class ID:`
+- `Write`
+
+### BigCGForm
+WF labels: **12** · AV labels: **10** · WF-only: **12** · AV-only: **10** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `10分割画像`
+- `size:`
+- `TSA`
+- `アドレス`
+- `パレット`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Big CG Editor`
+- `Export PAL`
+- `Export PNG`
+- `Import PAL`
+- `Import PNG`
+- `Palette Pointer:`
+- `Table Pointer:`
+- `TSA Pointer:`
+- `Write`
+
+### DecreaseColorTSAToolForm
+WF labels: **12** · AV labels: **2** · WF-only: **12** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `+余白`
+- `TSAを無視`
+- `サイズ補正方法`
+- `パレット数`
+- `ファイル選択`
+- `元ファイル`
+- `出力ファイル`
+- `幅`
+- `種類`
+- `透過色`
+- `開始`
+- `高さ`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Color Reduction Tool`
+
+### EDFE6Form
+WF labels: **12** · AV labels: **2** · WF-only: **12** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `ショート版`
+- `ロイと支援Ａ時`
+- `ロング版`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `肩書`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `ED (FE6)`
+
+### EDStaffRollForm
+WF labels: **12** · AV labels: **5** · WF-only: **12** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `TSA`
+- `アドレス`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `画像`
+- `画像取出`
+- `画像読込`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Image Pointer:`
+- `Staff Roll Editor`
+- `TSA Pointer:`
+- `Write`
+
+### EventForceSortieForm
+WF labels: **12** · AV labels: **6** · WF-only: **12** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `ユニット`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `章ID`
+- `編`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Chapter ID:`
+- `Force Sortie Editor`
+- `Squad:`
+- `Unit:`
+- `Write`
+
+### ImageChapterTitleFE7Form
+WF labels: **12** · AV labels: **7** · WF-only: **12** · AV-only: **7** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `セーブ画像`
+- `セーブ画像取出し`
+- `セーブ画像読込`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Chapter Title FE7 Editor`
+- `Export PAL`
+- `Export PNG`
+- `Import PNG`
+- `Save Image Ptr:`
+- `Write`
+
+### ImageRomAnimeForm
+WF labels: **12** · AV labels: **2** · WF-only: **12** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `アニメの書出し`
+- `アニメの読込`
+- `グラフィックツール`
+- `ソースファイルを開く`
+- `ソースフォルダーを開く`
+- `フレーム`
+- `名前`
+- `書き込み`
+- `表示例`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `ROM Animation Viewer`
+
+### ItemPromotionForm
+WF labels: **12** · AV labels: **5** · WF-only: **12** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `CCアイテムの名前`
+- `IERがインストールされているため、パッチ画面から設定してください。`
+- `Size:`
+- `アドレス`
+- `クラス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Item Promotion Editor`
+- `Promotion target class per source class`
+- `Target Class ID:`
+- `Write`
+
+### ItemShopForm
+WF labels: **12** · AV labels: **6** · WF-only: **12** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `Size:`
+- `アイテム `
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `店の名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Item ID:`
+- `Item Shop Editor`
+- `Preparation shop item list`
+- `Quantity/Uses:`
+- `Write`
+
+### MantAnimationForm
+WF labels: **12** · AV labels: **2** · WF-only: **12** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `よくわからなければ、この設定を変更しないでください。
+バグの原因になります。`
+- `アドレス`
+- `マント設定`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `戦闘アニメへ移動する`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Mant Animation`
+
+### MapStyleEditorAppendPopupForm
+WF labels: **12** · AV labels: **4** · WF-only: **12** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `(FE7のみ)`
+- `MapPointer(PLIST)を拡張`
+- `OK`
+- `PLIST拡張`
+- `オブジェクトタイプ`
+- `オブジェクトタイプ2`
+- `キャンセル`
+- `タイルアニメーション1`
+- `タイルアニメーション2`
+- `チップセットクタイプ`
+- `パレット`
+- `既に拡張済みです`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Append`
+- `Append Map Style`
+- `Cancel`
+- `Do you want to append a new map style entry? This will add a new tileset configuration at the end of the list.`
+
+### MenuExtendSplitMenuForm
+WF labels: **14** · AV labels: **15** · WF-only: **12** · AV-only: **13** · Common: **2**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `X`
+- `Y`
+- `先頭アドレス`
+- `文字列0`
+- `文字列1`
+- `文字列2`
+- `文字列3`
+- `文字列4`
+- `文字列5`
+- `文字列6`
+- `文字列7`
+- `書き込み`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Split Menu Definition`
+- `String 0:`
+- `String 1:`
+- `String 2:`
+- `String 3:`
+- `String 4:`
+- `String 5:`
+- `String 6:`
+- `String 7:`
+- `Write`
+- `X Position:`
+- `Y Position:`
+
+### OPClassFontFE8UForm
+WF labels: **12** · AV labels: **4** · WF-only: **12** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `OPフォント`
+- `Size:`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `画像取出`
+- `画像読込`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Image Pointer:`
+- `OP Class Font (FE8U) Editor`
+- `Write`
+
+### OPClassFontForm
+WF labels: **12** · AV labels: **5** · WF-only: **12** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `OPフォント`
+- `Size:`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `画像取出`
+- `画像読込`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Export PNG`
+- `Image Pointer:`
+- `OP Class Font Editor`
+- `Write`
+
+### StatusUnitsMenuForm
+WF labels: **12** · AV labels: **7** · WF-only: **12** · AV-only: **7** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `RMenu`
+- `Size:`
+- `アドレス`
+- `先頭アドレス`
+- `再取得`
+- `参照データ`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+- `項目名`
+- `順番`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Item Name Text ID:`
+- `Order:`
+- `Reference Data:`
+- `RMenu Text ID:`
+- `Status Units Menu Editor`
+- `Write`
+
+### ToolExportEAEventForm
+WF labels: **12** · AV labels: **14** · WF-only: **12** · AV-only: **14** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `EA形式でイベントをエクスポート`
+- `EA形式でイベントをエクスポートします。`
+- `EA形式でワールドマップイベント(選択時)をエクスポート`
+- `EA形式でワールドマップイベントをエクスポート`
+- `UndoBufferのエクスポート`
+- `インポートは、メニューの「実行」->「Event Assemblerで追加」で追加から実行してください。`
+- `エクスポート時にaddEndGuardsを付与する`
+- `マップ名`
+- `ユニットやクラス、アイテムなどのテーブルをダンプします。`
+- `主要テーブルのエクスポート`
+- `今回このROMに行った変更点を出力します`
+- `最新版のEAでは拡張領域のデータがダンプできないことがあるので、その場合は、古いEA ver9を利用してください。`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Add EndGuards on export`
+- `Data`
+- `Dumps unit, class, item, and other tables.`
+- `Export changes made to the ROM in this session.`
+- `Export Events in EA format`
+- `Export events in EA format.`
+- `Export Main Tables`
+- `Export Undo Buffer`
+- `Export World Map Events (selected) in EA format`
+- `Export World Map Events in EA format`
+- `For import, use Run > Event Assembler Add.`
+- `Map Name`
+- `The latest EA may not dump extended area data. In that case, use EA ver9.`
+- `Undo Buffer`
+
+### WorldMapPathMoveEditorForm
+WF labels: **12** · AV labels: **7** · WF-only: **12** · AV-only: **7** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `X`
+- `Y`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `書き込み`
+- `経過時間`
+- `読込数`
+- `道`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Coordinate X:`
+- `Coordinate Y:`
+- `Elapsed Time:`
+- `Elapsed Time controls how long the unit pauses at this node. Lower values = longer pause. Total movement uses 4096 time units. Sum of all elapsed times across nodes must be <= 4095, otherwise instant movement occurs.`
+- `Path Movement Editor`
+- `Write`
+
+### AIUnitsForm
+WF labels: **11** · AV labels: **5** · WF-only: **11** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Size:`
+- `アドレス`
+- `ユニット`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `AI Units Evaluation`
+- `Unit:`
+- `Unknown 1:`
+- `Write`
+
+### EventFinalSerifFE7Form
+WF labels: **11** · AV labels: **2** · WF-only: **11** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `セリフ`
+- `ユニット`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Final Serif (FE7)`
+
+### EventMoveDataFE7Form
+WF labels: **11** · AV labels: **5** · WF-only: **11** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `時間または速度`
+- `書き込み`
+- `移動方向`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Direction values: 00=Left, 01=Right, 02=Down, 03=Up, 04=End, 09=Highlight, 0A=Collision mark, 0C=Speed change`
+- `Move Data (FE7)`
+- `Move Direction:`
+- `Write`
+
+### EventTemplate2Form
+WF labels: **11** · AV labels: **2** · WF-only: **11** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `テンプレート1`
+- `友軍(NPC/緑)が侵入したら発動するイベントを作成`
+- `敵軍(赤)が侵入したら発動するイベントを作成`
+- `新規にイベントを割り振りますか？`
+- `新規にイベント領域を割り振り、空のイベントを定義します。`
+- `既存イベントを呼び出す`
+- `特定のユニットが侵入したらゲームオーバーイベント`
+- `特定のユニットが侵入したら発動するイベントを作成`
+- `砂漠の財宝`
+- `章終了イベントを呼び出す(章クリア)`
+- `自軍が侵入したら発動するイベントを作成`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Event Template 2`
+
+### EventTemplate3Form
+WF labels: **11** · AV labels: **2** · WF-only: **11** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `カウンターを利用して特定のイベントから数ターン増援`
+- `ゲームオーバーイベント`
+- `テンプレート`
+- `会話イベント`
+- `援軍`
+- `敵増援`
+- `敵増援(難易度:ハードのみ)`
+- `新規にイベントを割り振りますか？`
+- `新規にイベント領域を割り振り、空のイベントを定義します。`
+- `既存イベントを呼び出す`
+- `章終了イベントを呼び出す(章クリア)`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Event Template 3`
+
+### ExtraUnitFE8UForm
+WF labels: **11** · AV labels: **5** · WF-only: **11** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `フラグ`
+- `ユニット情報`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Extra Unit (FE8U)`
+- `Flag ID:`
+- `Unit Info Pointer:`
+- `Write`
+
+### ItemRandomChestForm
+WF labels: **11** · AV labels: **5** · WF-only: **11** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アイテム `
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `確率%`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Item:`
+- `Probability %:`
+- `Random Chest Items`
+- `Write`
+
+### MapLoadFunctionForm
+WF labels: **11** · AV labels: **6** · WF-only: **11** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `マップを読み込んだ時の追加処理`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `別のパッチでデータが書きかれられているため、修正することができません。`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Function Pointer:`
+- `Function pointers called when entering each map chapter.`
+- `Info:`
+- `Map Load Functions (FE8)`
+- `Write`
+
+### MapPointerForm
+WF labels: **11** · AV labels: **4** · WF-only: **11** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `PLIST分割`
+- `Size:`
+- `Text`
+- `アドレス`
+- `ポインタ`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Map Data Pointer:`
+- `Map Pointer Editor`
+- `Write`
+
+### MapTerrainBGLookupTableForm
+WF labels: **11** · AV labels: **4** · WF-only: **11** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `アドレス`
+- `値`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `戦闘アニメの床へJump`
+- `拡張された領域にデータが割り当てられていません。
+パッチ「戦闘床地形と戦闘背景のリストを拡張する」から、データを割り振ってください。`
+- `書き込み`
+- `条件:`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Battle BG:`
+- `Terrain BG Lookup Table`
+- `Write`
+
+### MapTerrainFloorLookupTableForm
+WF labels: **11** · AV labels: **4** · WF-only: **11** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `アドレス`
+- `値`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `戦闘アニメの背景へJump`
+- `拡張された領域にデータが割り当てられていません。
+パッチ「戦闘床地形と戦闘背景のリストを拡張する」から、データを割り振ってください。`
+- `書き込み`
+- `条件:`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Terrain Battle Floor:`
+- `Terrain Floor Lookup Table`
+- `Write`
+
+### OPClassAlphaNameForm
+WF labels: **11** · AV labels: **4** · WF-only: **11** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `↓文字列内訳`
+- `アドレス`
+- `先頭アドレス`
+- `再取得`
+- `分岐CC選択時のクラス名`
+- `名前`
+- `書き込み`
+- `読込数`
+- `警告:アルファベット以外の文字が入っています。`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Alpha Name:`
+- `OP Class Alpha Name Editor`
+- `Write`
+
+### SongInstrumentImportWaveForm
+WF labels: **11** · AV labels: **2** · WF-only: **11** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `DPCM lookahead`
+- `DPCM圧縮`
+- `m4a_hq_mixer Patchがインストールされていないので、DPCM圧縮は利用できません。`
+- `Preview`
+- `Waveは容量をたくさん消費するため、低音質に変換してインポートすることをお勧めします。`
+- `インポートする`
+- `キャンセル`
+- `チャンネル`
+- `前後の無音除去`
+- `音質を下げる`
+- `音量`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Wave Import`
+
+### SoundFootStepsForm
+WF labels: **11** · AV labels: **4** · WF-only: **11** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `別のパッチでデータが書きかれられているため、修正することができません。`
+- `名前`
+- `書き込み`
+- `読込数`
+- `足音`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Data Pointer:`
+- `Footstep Sounds Editor`
+- `Write`
+
+### SummonUnitForm
+WF labels: **11** · AV labels: **5** · WF-only: **11** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `召喚士ユニット`
+- `名前`
+- `呼びされるユニット`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Summon Unit Editor`
+- `Summoned Unit:`
+- `Summoner:`
+- `Write`
+
+### ToolASMInsertForm
+WF labels: **11** · AV labels: **2** · WF-only: **11** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Patch Maker`
+- `SRC`
+- `Undo`
+- `アセンブリ(コンパイル)に成功した場合は、ROMに埋め込みますか?`
+- `デバッグ用のシンボル `
+- `フックに利用するレジスタ`
+- `フリーエリアの定義`
+- `中間ファイル`
+- `別ファイル選択`
+- `実行`
+- `自動ラベルチェック`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `ASM Insertion Tool`
+
+### ToolWorkSupportForm
+WF labels: **12** · AV labels: **14** · WF-only: **11** · AV-only: **13** · Common: **1**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Open`
+- `UpdateInfo:`
+- `コミニティ`
+- `バージョン`
+- `他の作品を表示する`
+- `名前`
+- `最新バージョンに更新する`
+- `現在自動フィードバックは有効になっています。ご協力に感謝します。`
+- `自動フィードバックを無効にする`
+- `著者`
+- `開発コミニティにアクセスする`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Actions`
+- `Author:`
+- `Check Update`
+- `Close`
+- `Community:`
+- `Name:`
+- `Open Community`
+- `Open Info File`
+- `Project Information`
+- `Show All Works`
+- `Status`
+- `Version:`
+- `Work Support`
+
+### UnitIncreaseHeightForm
+WF labels: **11** · AV labels: **2** · WF-only: **11** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `ステータス画面で背丈を伸ばす補正をするか？`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `別のパッチでデータが書きかれられているため、修正することができません。`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Unit Height Adjustment`
+
+### AITilesForm
+WF labels: **10** · AV labels: **4** · WF-only: **10** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `タイル`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `AI Tiles Evaluation`
+- `Tile:`
+- `Write`
+
+### ClassOPFontForm
+WF labels: **10** · AV labels: **2** · WF-only: **10** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `OPフォント`
+- `size:`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Class OP Font`
+
+### EventFunctionPointerFE7Form
+WF labels: **10** · AV labels: **5** · WF-only: **10** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `??`
+- `Size:`
+- `アドレス`
+- `イベント命令の関数ポインタテーブル`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Event Command Function Pointer:`
+- `Event Command Function Pointer Table (FE7)`
+- `Unknown (offset 4):`
+- `Write`
+
+### EventFunctionPointerForm
+WF labels: **10** · AV labels: **4** · WF-only: **10** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `イベント命令の関数ポインタテーブル`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `条件:`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Event Command Function Pointer:`
+- `Event Command Function Pointer Table`
+- `Write`
+
+### EventTalkGroupFE7Form
+WF labels: **10** · AV labels: **4** · WF-only: **10** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `セリフ`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Talk Group (FE7)`
+- `Text ID:`
+- `Write`
+
+### EventTemplate1Form
+WF labels: **10** · AV labels: **2** · WF-only: **10** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `テンプレート`
+- `何もしないイベント1を設定`
+- `新規にイベントを割り振りますか？`
+- `新規にイベント領域を割り振り、空のイベントを定義します。`
+- `既存イベントを呼び出す`
+- `村でのアイテム取得イベントを作成`
+- `村でのゴールド取得イベントを作成`
+- `村での仲間加入イベントを作成`
+- `民家での会話イベントを作成`
+- `章終了イベントを呼び出す(章クリア)`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Event Template 1`
+
+### ExtraUnitForm
+WF labels: **10** · AV labels: **4** · WF-only: **10** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `フラグ`
+- `ユニット情報`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Extra Unit Editor`
+- `Unit Data Pointer:`
+- `Write`
+
+### ImageSystemAreaForm
+WF labels: **13** · AV labels: **8** · WF-only: **10** · AV-only: **5** · Common: **3**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `GBAカラー`
+- `Size:`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `GBA Color (W0):`
+- `Preview:`
+- `System Area Graphics`
+- `Write`
+
+### LinkArenaDenyUnitForm
+WF labels: **10** · AV labels: **4** · WF-only: **10** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `ユニット`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Link Arena Deny Unit Editor`
+- `Unit ID:`
+- `Write`
+
+### SMEPromoListForm
+WF labels: **11** · AV labels: **9** · WF-only: **10** · AV-only: **8** · Common: **1**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `BaseClass`
+- `PromoClass`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Base Class`
+- `Count:`
+- `Expand List`
+- `Name`
+- `Promo Class`
+- `Reload`
+- `Write`
+
+### SomeClassListForm
+WF labels: **10** · AV labels: **5** · WF-only: **10** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Class`
+- `Size:`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Class ID (u8):`
+- `Class List Editor`
+- `Null-terminated list of class IDs (1 byte per entry).`
+- `Write`
+
+### StatusOptionOrderForm
+WF labels: **10** · AV labels: **4** · WF-only: **10** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `ゲームオプション`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Option ID (u8@0):`
+- `Status Option Order Editor`
+- `Write`
+
+### ToolDiffDebugSelectForm
+WF labels: **10** · AV labels: **10** · WF-only: **10** · AV-only: **10** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `..`
+- `↑最新`
+- `このROMが最後に安定していたROMとして、
+相違点を取得する`
+- `より古い↓`
+- `バックアップROMがある場所を追加`
+- `バックアップ履歴(上が最新) `
+- `探索するprefix`
+- `無改造ROM`
+- `選択されているROM情報`
+- `選択しているROMをエミュレータでテストプレイする`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `...`
+- `Add backup ROM location`
+- `Backup History (newest on top)`
+- `Older ↓`
+- `Search prefix`
+- `Selected ROM Info`
+- `Test play selected ROM in emulator`
+- `Use this ROM as the last stable baseline and get differences`
+- `Vanilla ROM`
+- `↑ Newest`
+
+### ToolROMRebuildForm
+WF labels: **10** · AV labels: **2** · WF-only: **10** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `nullの連続数`
+- `ファイル選択`
+- `フリー領域の利用`
+- `フリー領域の定義`
+- `ポインタの共有`
+- `再構築アドレス`
+- `変更点をファイルに書きだす`
+- `探索開始アドレス`
+- `無改造ROM`
+- `追加設定ファイル`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `ROM Rebuild Tool`
+
+### UnitActionPointerForm
+WF labels: **10** · AV labels: **2** · WF-only: **10** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `このROMには、UnitAction Patchが適応されています。`
+- `アドレス`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+- `関数ポインタ`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Unit Action Pointers`
+
+### WelcomeForm
+WF labels: **10** · AV labels: **8** · WF-only: **10** · AV-only: **8** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `EN`
+- `FEBuilderGBAの使い方の説明書を見る`
+- `FEBuilderGBAを最新版へ更新する`
+- `JP`
+- `ROMを開く`
+- `ZH`
+- `アップデートチェック`
+- `オンラインマニュアル`
+- `他のFE ROMを開く`
+- `最後に開いたROM`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Avalonia Cross-Platform Edition`
+- `Check for Updates`
+- `FEBuilderGBA`
+- `No recent files`
+- `Online Manual`
+- `Open Last ROM`
+- `Open ROM`
+- `Recent Files`
+
+### WorldMapEventPointerFE6Form
+WF labels: **10** · AV labels: **2** · WF-only: **10** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `ワールドマップイベント`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `新規イベント`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Event Pointer (FE6)`
+
+### WorldMapImageFE6Form
+WF labels: **10** · AV labels: **2** · WF-only: **10** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `256色画像`
+- `ZOOM NE`
+- `ZOOM NW`
+- `ZOOM SE`
+- `ZOOM SW`
+- `パレット`
+- `ポインタを書き込む`
+- `メインフィールドマップ`
+- `画像取出`
+- `画像読込`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `World Map Image (FE6)`
+
+### AIMapSettingForm
+WF labels: **9** · AV labels: **7** · WF-only: **9** · AV-only: **7** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `章ごとにAIが実行できる行動を定義します。
+例えば、扉の鍵をドロップするAIがいるのに、敵AIが扉の鍵を利用可能にすると、敵は勝手に扉を開けてしまいます。`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `AI Map Settings`
+- `Trait 1 (flags):`
+- `Trait 2 (flags):`
+- `Trait 3 (flags):`
+- `Trait 4 (flags):`
+- `Write`
+
+### AOERANGEForm
+WF labels: **9** · AV labels: **8** · WF-only: **9** · AV-only: **8** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `AoE攻撃の範囲を指定します。
+中心点は、攻撃が炸裂する中心点です。
+攻撃するマスを1に、それ以外を0に指定してください。`
+- `中心点`
+- `中心点X`
+- `中心点Y`
+- `先頭アドレス`
+- `再取得`
+- `幅`
+- `書き込み`
+- `高さ`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Area of Effect Range`
+- `Center X:`
+- `Center Y:`
+- `Height:`
+- `Specifies the AoE attack range mask. Center point is where the attack detonates. Set attacked tiles to 1, others to 0.`
+- `Width:`
+- `Write`
+
+### ArenaEnemyWeaponForm
+WF labels: **9** · AV labels: **4** · WF-only: **9** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `ランクアップ武器`
+- `先頭アドレス`
+- `再取得`
+- `基本武器`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Arena Enemy Weapon Editor`
+- `Weapon ID:`
+- `Write`
+
+### Command85PointerForm
+WF labels: **9** · AV labels: **2** · WF-only: **9** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `イベント命令の関数ポインタテーブル`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Command 0x85 Pointer`
+
+### DisASMDumpAllForm
+WF labels: **9** · AV labels: **12** · WF-only: **9** · AV-only: **12** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Arg Grep`
+- `IDAにimportできる形式でMAPファイルを生成します。`
+- `MAKE IDAMapFile`
+- `MAKE no$gba sym File`
+- `no$gba debuggerで利用できるsym形式のMAPファイルを作成します。
+ROMと同じディレクトリに設置してください。`
+- `このゲームのプログラムデータをすべてファイルに出力します。
+処理には時間がかかるものがあります。`
+- `すべてのコードを逆アセンブルしてファイルに保存します。`
+- `全部逆アセンブルして保存する`
+- `特定の関数の引数だけを抽出します。`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `0x08000000`
+- `0x100`
+- `Address:`
+- `Address Range`
+- `Close`
+- `DisASM`
+- `Disassembly Dump All`
+- `IDA MAP`
+- `Length:`
+- `No$GBA SYM`
+- `Run Dump`
+- `Select an output format and run the disassembly dump.`
+
+### ErrorPaletteShowForm
+WF labels: **9** · AV labels: **2** · WF-only: **9** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `できるだけ規定値2になるように再構築をしてインポートします。`
+- `できるだけ規定値になるように再構築をしてインポートします。`
+- `インポート処理をキャンセルします.`
+- `キャンセル`
+- `パレットが規定値と違います。`
+- `無視して強行`
+- `規定値2で再構築してインポート`
+- `規定値で再構築してインポート`
+- `規定値と違いますが、このまま強引にインポートします。`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Close`
+- `Palette Error Display`
+
+### EventAssemblerForm
+WF labels: **9** · AV labels: **2** · WF-only: **9** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Event Assemblerでeventスクリプトを読み込んで現在のROMに適応します。`
+- `UNDO`
+- `スクリプト`
+- `スクリプトのアンインストール`
+- `スクリプト読込`
+- `デバッグ用のシンボル `
+- `フリーエリアの定義`
+- `別ファイル選択`
+- `更新されたプログラムを再コンパイル`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Event Assembler`
+
+### EventTemplate4Form
+WF labels: **9** · AV labels: **2** · WF-only: **9** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `アイテム取得イベントを作成`
+- `テンプレート`
+- `ユニットを説得しパーティ加入`
+- `会話イベントを作成`
+- `何もしないイベント1を設定します。`
+- `新規にイベントを割り振りますか？`
+- `新規にイベント領域を割り振り、空のイベントを定義します。`
+- `既存イベントを呼び出す`
+- `章終了イベントを呼び出す(章クリア)`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Event Template 4`
+
+### ItemEffectPointerForm
+WF labels: **9** · AV labels: **5** · WF-only: **9** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `イベント命令の関数ポインタテーブル`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Effect Pointer:`
+- `Indirect effect pointer table`
+- `Item Effect Pointer Editor`
+- `Write`
+
+### RAMRewriteToolMAPForm
+WF labels: **9** · AV labels: **10** · WF-only: **9** · AV-only: **10** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `no$gbaの読込ブレークポイントとしてコピー`
+- `X`
+- `Y`
+- `クリップボードへコピー`
+- `データの直書き換え`
+- `ポインタとしてクリップボードへコピー`
+- `リトルエンディアンポインタとしてクリップボードへコピー`
+- `値`
+- `値の書き換え`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Close`
+- `e.g. 0x01`
+- `e.g. 0x02000000`
+- `e.g. 0xFF`
+- `Map ID:`
+- `RAM Rewrite Tool (MAP)`
+- `Rewrite RAM values for map data in a running emulator.`
+- `Value:`
+- `Write`
+
+### SoundRoomCGForm
+WF labels: **10** · AV labels: **4** · WF-only: **9** · AV-only: **3** · Common: **1**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Sound Room CG`
+- `Write`
+
+### ToolFELintForm
+WF labels: **9** · AV labels: **2** · WF-only: **9** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Error`
+- `NoError`
+- `Scan`
+- `このROMには、自動的に検出できるエラーは存在しません。`
+- `以下のマップにエラーが存在します。`
+- `再取得(Ctrl+R)`
+- `名前`
+- `比較デバッグツール`
+- `非表示のエラーも表示`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `FELint GUI`
+
+### UnitsShortTextForm
+WF labels: **9** · AV labels: **7** · WF-only: **9** · AV-only: **7** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `セリフ`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Maps each unit index to a description text ID (2 bytes per entry).`
+- `Preview:`
+- `Text ID:`
+- `Unit:`
+- `Units Short Text Editor`
+- `Write`
+
+### VennouWeaponLockForm
+WF labels: **9** · AV labels: **7** · WF-only: **9** · AV-only: **7** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Description:`
+- `First byte = type (0-3), rest = unit/class IDs. Null-terminated.`
+- `Linked Name:`
+- `Lock Type / ID:`
+- `Weapon Lock (Vennou) Editor`
+- `Write`
+
+### DisASMDumpAllArgGrepForm
+WF labels: **8** · AV labels: **6** · WF-only: **8** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `blまたはb呼び出しの関数名
+または、関数のアドレスを指定ください。`
+- `事前に逆アセンブラによって、ソースコードをすべて逆アセンブルしてください。`
+- `参照`
+- `探すレジスタ`
+- `検索結果に関数呼び出しは含めない`
+- `検索開始`
+- `用途が判明していない関数呼び出しのみ表示`
+- `許容する行数`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Close`
+- `Disassembly Argument Grep`
+- `Enter search pattern...`
+- `Pattern:`
+- `Search`
+- `Search disassembly output by argument pattern.`
+
+### MapMiniMapTerrainImageForm
+WF labels: **8** · AV labels: **2** · WF-only: **8** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `ASMポインタ`
+- `Size:`
+- `アドレス`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Mini-Map Terrain`
+
+### PatchFilterExForm
+WF labels: **8** · AV labels: **5** · WF-only: **8** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `イベント命令(#EVENT)`
+- `インストール済みのパッチ(!)`
+- `エンジン(#ENGINE)`
+- `ソート`
+- `フィルタ解除`
+- `定番の修正(#ESSENTIALFIXES)`
+- `画像(#IMAGE)`
+- `音楽(#SOUND)`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Cancel`
+- `Enter filter keywords...`
+- `Filter text:`
+- `OK`
+- `Patch Filter`
+
+### ToolDiffForm
+WF labels: **8** · AV labels: **2** · WF-only: **8** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `フリースペースはまとめる`
+- `別ファイル選択`
+- `容認差異`
+- `差分をBINパッチとして作成する`
+- `比較ファイル`
+- `比較ファイルA`
+- `比較ファイルB`
+- `比較方法`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `ROM Diff Tool`
+
+### ErrorPaletteMissMatchForm
+WF labels: **7** · AV labels: **2** · WF-only: **7** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `できるだけ元の画像を再現できるように再構築をしてインポートします。`
+- `インポート処理をキャンセルします.`
+- `キャンセル`
+- `パレットの並び順が違います。`
+- `並び順が違うようですが、このまま強引にインポートします。`
+- `無視して強行`
+- `規定値で再構築してインポート`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Close`
+- `Palette Mismatch`
+
+### ErrorReportForm
+WF labels: **7** · AV labels: **2** · WF-only: **7** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `このボタンを押して開発者にエラーを報告してください。 ---->`
+- `アップデートを確認してください`
+- `エラーを開発者に報告する`
+- `エラーメッセージ`
+- `スタックトレース`
+- `何をしたらエラーが起きたのか教えてください`
+- `未知のエラーが発生しました。開発者までご連絡ください。`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Close`
+- `Error Report`
+
+### ErrorTSAErrorForm
+WF labels: **7** · AV labels: **2** · WF-only: **7** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `この画像は、必要な形式の基準を満たしていません。`
+- `インポート処理をキャンセルします.`
+- `キャンセル`
+- `減色処理や、パレットの入れ替えを行い、自動的に形式を満たせる形式に変換します`
+- `自動変換してインポート`
+- `規約を守っていないデータはパレットの最初の色としてインポートします。`
+- `違反データは0に指定`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Close`
+- `TSA Error`
+
+### EventTemplate6Form
+WF labels: **7** · AV labels: **2** · WF-only: **7** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `ゲームオーバーイベント`
+- `テンプレート`
+- `何もしないイベント1を設定`
+- `新規にイベントを割り振りますか？`
+- `新規にイベント領域を割り振り、空のイベントを定義します。`
+- `既存イベントを呼び出す`
+- `章終了イベントを呼び出す(章クリア)`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Event Template 6`
+
+### MapEditorResizeDialogForm
+WF labels: **11** · AV labels: **11** · WF-only: **7** · AV-only: **7** · Common: **4**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `B`
+- `L`
+- `R`
+- `T`
+- `サイズ`
+- `位置`
+- `変更する`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Bot`
+- `Left`
+- `Position`
+- `Resize`
+- `Right`
+- `Size`
+- `Top`
+
+### MapPointerNewPLISTPopupForm
+WF labels: **7** · AV labels: **6** · WF-only: **7** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `MapPointer(PLIST)を拡張`
+- `PLIST割り当て`
+- `PLIST割り当てがありません。`
+- `PLIST拡張`
+- `キャンセル`
+- `割り当て`
+- `既に拡張済みです`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Cancel`
+- `Enter the PLIST number for the new map pointer entry.`
+- `Extend PLIST Range`
+- `OK`
+- `PLIST (Pointer List) assigns a numeric ID to each map.
+Choose an unused PLIST number to add a new map pointer entry.
+The PLIST ID is used internally to reference map data.`
+- `PLIST ID:`
+
+### MapTerrainNameEngForm
+WF labels: **7** · AV labels: **5** · WF-only: **7** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Resolved Name:`
+- `Terrain Name (English)`
+- `Terrain Name Text ID:`
+- `Write`
+
+### MapTerrainNameForm
+WF labels: **7** · AV labels: **5** · WF-only: **7** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Name:`
+- `Terrain Name Editor`
+- `Text ID:`
+- `Write`
+
+### MapTerrainNameForm
+WF labels: **7** · AV labels: **5** · WF-only: **7** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Name:`
+- `Name Pointer:`
+- `Terrain Name Editor`
+- `Write`
+
+### OPClassAlphaNameFE6Form
+WF labels: **7** · AV labels: **5** · WF-only: **7** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き込み`
+- `読込数`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Alpha Name:`
+- `Name Pointer:`
+- `OP Class Alpha Name (FE6) Editor`
+- `Write`
+
+### RAMRewriteToolForm
+WF labels: **7** · AV labels: **9** · WF-only: **7** · AV-only: **9** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `no$gbaの読込ブレークポイントとしてコピー`
+- `クリップボードへコピー`
+- `データの直書き換え`
+- `ポインタとしてクリップボードへコピー`
+- `リトルエンディアンポインタとしてクリップボードへコピー`
+- `値`
+- `値の書き換え`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Close`
+- `e.g. 0x02000000`
+- `e.g. 0xFF`
+- `Platform Notice`
+- `Please use the Windows (WinForms) version of FEBuilderGBA for this functionality.`
+- `RAM Rewrite Tool`
+- `RAM rewriting requires Windows P/Invoke to access emulator process memory and is not available in the cross-platform Avalonia version.`
+- `Value:`
+
+### ToolFlagNameForm
+WF labels: **7** · AV labels: **2** · WF-only: **7** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `ディフォルトに戻す`
+- `フラグに名前を設定すると、より理解しやすくなります。
+フラグの名前は、ROMごとに別ファイルに保存します。`
+- `フラグの名前`
+- `リストの拡張`
+- `名前`
+- `書き込み`
+- `章内で利用しているフラグの確認`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Flag Name Editor`
+
+### DevTranslateForm
+WF labels: **6** · AV labels: **2** · WF-only: **6** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Convert`
+- `form design`
+- `Reverse`
+- `日本語ではなく、可能な限り英語から翻訳する`
+- `翻訳`
+- `言語`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Developer Translation Tool`
+
+### EventUnitColorForm
+WF labels: **6** · AV labels: **2** · WF-only: **6** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `MESSAGE`
+- `友軍`
+- `敵軍`
+- `第4軍`
+- `自軍`
+- `適応`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Unit Color Assignment`
+
+### PointerToolCopyToForm
+WF labels: **6** · AV labels: **6** · WF-only: **6** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `no$gbaの読込ブレークポイントとしてコピー`
+- `クリップボードへコピー`
+- `バイナリエディタ`
+- `ポインタとしてクリップボードへコピー`
+- `リトルエンディアンポインタとしてクリップボードへコピー`
+- `値:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Copy (No $ / GBA / Rad / BreakPoint)`
+- `Copy as Hex`
+- `Copy as Little Endian`
+- `Copy as Pointer`
+- `Copy to Clipboard`
+- `Value:`
+
+### SongTrackChangeTrackForm
+WF labels: **6** · AV labels: **2** · WF-only: **6** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `このトラックのPANに、指定された値を足します。
+マイナスは左側、プラスは右側です。`
+- `このトラックの音量に、指定された値を足しこみます。
+大きくするほど、大きな音になります。`
+- `アドレス`
+- `ベロシティも補正する`
+- `変更する`
+- `変更先`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Track Change`
+
+### TextToSpeechForm
+WF labels: **6** · AV labels: **6** · WF-only: **6** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `このサイズ以上の文字列を読み上げる`
+- `合成音声エンジンで自動的にテキストを読み上げます。
+タイプミスを見つけるには音読するのが一番です。`
+- `読み上げエンジン`
+- `読み上げ停止`
+- `読み上げ速度`
+- `読み上げ開始`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Close`
+- `Enter or paste text to have it read aloud using the system TTS engine.`
+- `Enter text here...`
+- `Ready`
+- `Speak`
+- `Text to Speech`
+
+### ToolThreeMargeForm
+WF labels: **6** · AV labels: **14** · WF-only: **6** · AV-only: **14** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Mark&List`
+- `Set&Mark`
+- `アドレス`
+- `アドレス,長さ,対処法,ヒント`
+- `変更をすべてキャンセルする`
+- `相違点を現在のROMへマージします。書き込んだらF5でエミュレータを動作して確認してください。`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Both (same): `
+- `Browse...`
+- `Close`
+- `Conflict bytes: `
+- `Conflicts (resolve each: Mine or Theirs)`
+- `Merge`
+- `Merge Statistics`
+- `My changes: `
+- `My ROM:`
+- `Original ROM:`
+- `Save Merged ROM`
+- `Their changes: `
+- `Their ROM:`
+- `Three-Way ROM Merge`
+
+### ToolUpdateDialogForm
+WF labels: **6** · AV labels: **2** · WF-only: **6** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Gitでパッチデータを更新します`
+- `アップデートしません`
+- `ブラウザでURLを開きます`
+- `プログラム本体を更新します`
+- `全自動でアップデートします`
+- `最新版({0})があるようです。
+アップデートしますか？
+
+{1}`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Update Checker`
+
+### AIASMCALLTALKForm
+WF labels: **5** · AV labels: **8** · WF-only: **5** · AV-only: **8** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `From`
+- `To`
+- `先頭アドレス`
+- `書き込み`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `AI ASM Call Talk`
+- `Configures enemy AI to trigger a talk event (like FE7 Farina).`
+- `From Unit:`
+- `To Unit:`
+- `Unused 2:`
+- `Unused 3:`
+- `Write`
+
+### EventTemplate5Form
+WF labels: **5** · AV labels: **2** · WF-only: **5** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `何もしないイベント1を設定`
+- `新規にイベントを割り振りますか？`
+- `新規にイベント領域を割り振り、空のイベントを定義します。`
+- `既存イベントを呼び出す`
+- `章終了イベントを呼び出す(章クリア)`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Event Template 5`
+
+### HexEditorForm
+WF labels: **6** · AV labels: **6** · WF-only: **5** · AV-only: **5** · Common: **1**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `DisASM`
+- `&Jump`
+- `Mark&List`
+- `Set&Mark`
+- `Write`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `0x00000000`
+- `Address:`
+- `Go`
+- `Page Down`
+- `Page Up`
+
+### ImageBGSelectPopupForm
+WF labels: **5** · AV labels: **4** · WF-only: **5** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `TSAを利用しないBG224色(会話用)`
+- `TSAを利用しないBG256色(カットシーン)`
+- `インポートするBGの形式を指定してください。`
+- `バニラの仕様であるTSAを利用した最大8パレットを指定します。
+減色ツールの「01=背景(BG,CG)」で減色した画像を指定してください。`
+- `バニラ形式。TSA方式を利用する方法でインポートする`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Background Image Selector.
+Choose a background image from the available BG entries in the ROM.`
+- `BG Image Select`
+- `Cancel`
+- `Select`
+
+### MapEditorAddMapChangeDialogForm
+WF labels: **5** · AV labels: **6** · WF-only: **5** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `キャンセル`
+- `マップ変化の設定画面を出します。`
+- `マップ変化を減らす場合は、設定画面から消去してください。
+変更したマップ変化は、マップを切り替えたときに読み込まれます。`
+- `新規にマップ変化を割り当てます。`
+- `訪問村や、宝箱、壊れる壁、古木などのために、
+マップ変化を新規に割り当てる場合は、ここから新規にマップ変化を割り当ててください。`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Assign a new map change ID. A new PLIST entry will be allocated automatically.`
+- `Assign new map change`
+- `Cancel`
+- `Do you want to create additional map changes?`
+- `Open map change settings`
+- `Open the map change configuration screen to edit existing map change entries.`
+
+### MapSettingDifficultyForm
+WF labels: **5** · AV labels: **2** · WF-only: **5** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `ノーマルモードペナルティ`
+- `ハードブースト`
+- `変更する`
+- `簡易モードペナルティ`
+- `難易度補正`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Difficulty Settings`
+
+### MapStyleEditorImportImageOptionForm
+WF labels: **5** · AV labels: **5** · WF-only: **5** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `マップチップのインポート`
+- `一枚絵としてインポートする。(この画像からmap_configを自動生成する)`
+- `一枚絵のインポート`
+- `画像だけをインポートする。(パレットはインポートしない)`
+- `画像と同時にパレットもインポートする(推奨)`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Import as one picture (auto-generate map_config from this image)`
+- `Import image only (do not import palette)`
+- `Import image with palette (recommended)`
+- `Map Chip Import`
+- `One Picture Import`
+
+### SongInstrumentDirectSoundForm
+WF labels: **7** · AV labels: **7** · WF-only: **5** · AV-only: **5** · Common: **2**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `LengthByte`
+- `LoopStartByte`
+- `これより下のアドレスには、waveデータが、LengthByteだけ格納されています。`
+- `先頭アドレス`
+- `書き込み`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Direct Sound Instruments`
+- `Length Byte:`
+- `Loop Start Byte:`
+- `Write`
+
+### SongTrackAllChangeTrackForm
+WF labels: **5** · AV labels: **2** · WF-only: **5** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `全トラックのPANに、指定された値を足します。
+マイナスは左側、プラスは右側です。`
+- `全トラックのテンポに、指定された値を足します。
+大きくするほど早くなります。`
+- `全トラックの音量に、指定された値を足しこみます。
+大きくするほど、大きな音になります。`
+- `変更する`
+- `変更先`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Bulk Track Change`
+
+### ToolCustomBuildForm
+WF labels: **5** · AV labels: **2** · WF-only: **5** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `スキル割り当ての引き継ぎ`
+- `ターゲット:ビルドするスキル拡張`
+- `ビルド開始`
+- `別ファイル選択`
+- `無改造ROM`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Custom Build Tool`
+
+### ToolUPSOpenSimpleForm
+WF labels: **5** · AV labels: **2** · WF-only: **5** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `UPSパッチを適応したROMを、UPSファイル名.gbaとして保存する`
+- `UPSパッチを開く`
+- `UPSパッチを開くために無改造のROMを選択してください`
+- `ファイル選択`
+- `無改造ROM`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `UPS Patch Applier`
+
+### ToolUndoForm
+WF labels: **5** · AV labels: **2** · WF-only: **5** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `↑最新`
+- `このバージョンに戻す`
+- `このバージョンをエミュレータでテストプレイ`
+- `より古い↓`
+- `履歴(上が最新)`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Undo History Viewer`
+
+### EventUnitItemDropForm
+WF labels: **4** · AV labels: **2** · WF-only: **4** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `この敵を倒すと、アイテムドロップするようにしますか？
+アイテムドロップする場合、一番最後に持っているアイテムが対象になります。`
+- `アイテムドロップしない`
+- `アイテムドロップする`
+- `キャンセル`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Unit Item Drop Editor`
+
+### EventUnitNewAllocForm
+WF labels: **4** · AV labels: **2** · WF-only: **4** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `増援等で、追加で登場させたいユニットのために、
+新規に領域を確保します。`
+- `確保`
+- `確保した領域を使わないで、
+ユニット配置ウィンドウを閉じてしまうと、
+利用されない無駄データとなってしまうので
+注意してください。`
+- `確保する人数`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Unit Allocation Editor`
+
+### HowDoYouLikePatch2Form
+WF labels: **4** · AV labels: **3** · WF-only: **4** · AV-only: **3** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Enable`
+- `Reason`
+- `このパッチを推奨しない`
+- `無視して続行する`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Apply`
+- `Patch Review`
+- `Skip`
+
+### HowDoYouLikePatchForm
+WF labels: **4** · AV labels: **3** · WF-only: **4** · AV-only: **3** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Enable`
+- `Reason`
+- `このパッチを推奨しない`
+- `無視して続行する`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Apply`
+- `Patch Review`
+- `Skip`
+
+### MainSimpleMenuEventErrorIgnoreErrorForm
+WF labels: **4** · AV labels: **4** · WF-only: **4** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `このエラーを非表示にしますか？`
+- `エラーを非表示にする`
+- `キャンセル`
+- `非表示にする理由`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Cancel`
+- `Do you want to hide this error?`
+- `Hide this error`
+- `Reason for hiding:`
+
+### OAMSPForm
+WF labels: **4** · AV labels: **2** · WF-only: **4** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `名前`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `OAM Sprite Editor`
+
+### OtherTextForm
+WF labels: **4** · AV labels: **2** · WF-only: **4** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Size:`
+- `アドレス`
+- `名前`
+- `書き込み`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Other Text Strings`
+
+### SkillAssignmentUnitFE8NForm
+WF labels: **4** · AV labels: **7** · WF-only: **4** · AV-only: **7** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `スキル1`
+- `スキル2`
+- `個別スキル`
+- `適応`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Personal Skill:`
+- `Skill Assignment - Unit (FE8N)`
+- `Skill Set 1:`
+- `Skill Set 2:`
+- `Skill system editors require a compatible skill patch to be installed.
+Use the Patch Manager to install a skill system patch first.
+
+Supported skill systems: CSkillSys, FE8N Skill System`
+- `Write`
+
+### TextBadCharPopupForm
+WF labels: **4** · AV labels: **5** · WF-only: **4** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Error_MessageLabel`
+- `方法1  あきらめる`
+- `方法2 Anti-Huffman`
+- `方法3 符号テーブル`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Anti-Huffman`
+- `Bad Character Detected`
+- `Characters that cannot be encoded in the ROM's text encoding table will cause display errors in-game.
+
+Common issues:
+  - Using characters outside the ROM's supported character set
+  - Pasting text from external sources with special Unicode characters
+  - Using control characters that are not valid escape sequences
+
+Please choose one of the options below to resolve the issue.`
+- `Encoding Table`
+- `Give Up`
+
+### TextRefAddDialogForm
+WF labels: **4** · AV labels: **6** · WF-only: **4** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `この文字列の参照を追加しますか？`
+- `キャンセル`
+- `参照される場所について説明してください`
+- `参照の更新`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Add Text Reference`
+- `Cancel`
+- `Enter reference text...`
+- `OK`
+- `Reference Text:`
+- `Text ID:`
+
+### ToolAutomaticRecoveryROMHeaderForm
+WF labels: **4** · AV labels: **3** · WF-only: **4** · AV-only: **3** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `ROMヘッダーを自動復旧する`
+- `ファイル選択`
+- `損傷したROMヘッダー 0x0 - 0x100を自動復帰します。`
+- `無改造ROM`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Recover ROM Header`
+- `Select File`
+- `Unmodified ROM`
+
+### ToolBGMMuteDialogForm
+WF labels: **4** · AV labels: **2** · WF-only: **4** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `label1`
+- `toggle`
+- `このトラックだけを再生する`
+- `すべてのトラックを再生する`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Play all tracks`
+- `Play only this track`
+
+### ToolUPSPatchSimpleForm
+WF labels: **4** · AV labels: **2** · WF-only: **4** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `ファイル選択`
+- `差分をUPSパッチとして作成する`
+- `無改造ROM`
+- `現在のデータをUPSパッチとして保存します。
+特別な理由がない限り、通常の保存をしたあとで利用してください。`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `UPS Patch Creator`
+
+### ToolWorkSupport_SelectUPSForm
+WF labels: **4** · AV labels: **3** · WF-only: **4** · AV-only: **3** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `UPSパッチを開く`
+- `UPSパッチを開くために無改造のROMを選択してください`
+- `ファイル選択`
+- `無改造ROM`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Open UPS Patch`
+- `Select File`
+- `Vanilla ROM`
+
+### AIASMCoordinateForm
+WF labels: **5** · AV labels: **7** · WF-only: **3** · AV-only: **5** · Common: **2**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `先頭アドレス`
+- `書き込み`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `AI Coordinate Editor`
+- `Unused 2:`
+- `Unused 3:`
+- `Write`
+
+### AIScriptCategorySelectForm
+WF labels: **3** · AV labels: **11** · WF-only: **3** · AV-only: **11** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `カテゴリ`
+- `命令を選択する`
+- `検索`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `(select a command)`
+- `0x08XXXXXX or hex offset`
+- `Address:`
+- `AI Script Editor`
+- `Close`
+- `Commands`
+- `Disassemble`
+- `Insert Command...`
+- `Parameters`
+- `Refresh`
+- `Write to ROM`
+
+### GraphicsToolPatchMakerForm
+WF labels: **3** · AV labels: **9** · WF-only: **3** · AV-only: **9** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `ファイルとして保存する`
+- `選択されている内容を変更するパッチ`
+- `閉じる`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Browse...`
+- `Changed bytes: `
+- `Close`
+- `Compare two ROMs and generate a patch of changed regions`
+- `Generate Patch`
+- `Modified ROM:`
+- `Original ROM:`
+- `Regions: `
+- `Save Patch File`
+
+### LogForm
+WF labels: **3** · AV labels: **2** · WF-only: **3** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `クリップボードへ`
+- `ファイルに保存`
+- `ログディレクトリを開く`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Log Viewer`
+
+### MainSimpleMenuEventErrorForm
+WF labels: **3** · AV labels: **2** · WF-only: **3** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `エラー`
+- `再取得(Ctrl+R)`
+- `非表示のエラーも表示`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Event Error Display`
+
+### MapEditorMarSizeDialogForm
+WF labels: **3** · AV labels: **3** · WF-only: **3** · AV-only: **3** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `データサイズが不一致。
+(データ数/2) % 幅 == 0 ではありません`
+- `幅`
+- `適応`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Apply`
+- `Data size mismatch.
+(DataCount/2) % Width != 0`
+- `Width`
+
+### MoveCostFE6Form
+WF labels: **3** · AV labels: **6** · WF-only: **3** · AV-only: **6** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `再取得`
+- `書き込み`
+- `選択クラスの分離独立`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Class Name:`
+- `Cost Type:`
+- `Move Cost (FE6) Editor`
+- `Terrain Move Costs (51 entries):`
+- `Write`
+
+### MoveCostForm
+WF labels: **3** · AV labels: **4** · WF-only: **3** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `再取得`
+- `書き込み`
+- `選択クラスの分離独立`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Cost Type:`
+- `Move Cost Editor`
+- `Terrain Move Costs (65 terrains: 0x00 - 0x40):`
+- `Write`
+
+### OpenLastSelectedFileForm
+WF labels: **3** · AV labels: **2** · WF-only: **3** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `ディレクトリの場所を開く`
+- `最後に利用したファイル`
+- `関連付けされたアプリケーションで開く`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Open Last Selected File`
+
+### PaletteClipboardForm
+WF labels: **3** · AV labels: **8** · WF-only: **3** · AV-only: **8** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `キャンセル`
+- `パレット値`
+- `変更`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `[No palette data in clipboard]`
+- `Clear`
+- `Clipboard Contents:`
+- `Close`
+- `Copy Current`
+- `Palette Clipboard`
+- `Palette Clipboard Manager stores and retrieves palette data.
+Copy palettes between different graphics entries or save them for later use.`
+- `Paste`
+
+### PatchFormUninstallDialogForm
+WF labels: **3** · AV labels: **4** · WF-only: **3** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `アンインストール`
+- `パッチを含んでいないROM`
+- `ファイル選択`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Please select the ROM from before this patch was installed for recovery.
+
+This feature does not guarantee a reliable uninstallation.
+It may fail, so please make a backup beforehand.
+Also, while the patch code can be removed, associated data may not always be removable.
+In that case, there may be a loss of a few hundred bytes. Please understand.`
+- `ROM without patch`
+- `Select file`
+- `Uninstall`
+
+### ProcsScriptCategorySelectForm
+WF labels: **3** · AV labels: **11** · WF-only: **3** · AV-only: **11** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `カテゴリ`
+- `命令を選択する`
+- `検索`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `(select a command)`
+- `0x08XXXXXX or hex offset`
+- `Address:`
+- `Close`
+- `Commands`
+- `Disassemble`
+- `Insert Command...`
+- `Parameters`
+- `Procs Script Editor`
+- `Refresh`
+- `Write to ROM`
+
+### SongExchangeForm
+WF labels: **3** · AV labels: **2** · WF-only: **3** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `<---------
+選択した曲を
+移植する
+<---------`
+- `サウンドテーブル`
+- `別ROMを開く`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Song Exchange Tool`
+
+### SongTrackImportSelectInstrumentForm
+WF labels: **3** · AV labels: **8** · WF-only: **3** · AV-only: **8** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `ディフォルト値から変更しない`
+- `楽器セット`
+- `選択する`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `About Instrument Selection`
+- `Address:`
+- `Current Instrument Set`
+- `Instrument Selection`
+- `Instrument set selection is not yet available in the Avalonia UI. To select a different instrument set for MIDI import, please use the WinForms version. This feature requires porting PatchUtil.SearchInstrumentSet to the cross-platform Core library.`
+- `No song selected`
+- `Not Yet Implemented`
+- `This view allows selecting the instrument set (voicegroup) used when importing MIDI or .s files into the ROM. The instrument set determines which GBA sound samples are mapped to MIDI program changes.`
+
+### ToolChangeProjectnameForm
+WF labels: **3** · AV labels: **4** · WF-only: **3** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `プロジェクト名の変更する`
+- `新しい名前`
+- `現在の名前`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Change Project Name`
+- `Current Name:`
+- `Enter new project name`
+- `New Name:`
+
+### ToolClickWriteFloatControlPanelButtonForm
+WF labels: **3** · AV labels: **3** · WF-only: **3** · AV-only: **3** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `どちらのボタンをクリックしますか？`
+- `変更`
+- `新規挿入`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Insert New`
+- `Update`
+- `❓`
+
+### ToolEmulatorSetupMessageForm
+WF labels: **3** · AV labels: **2** · WF-only: **3** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `InitWizardで自動設定する`
+- `Option画面から手動で設定する`
+- `エミュレータが設定されていません。
+動作テストに利用するエミュレータを設定してください。`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Automatically configure with Init Wizard`
+- `Manually configure from Options screen`
+
+### ToolRunHintMessageForm
+WF labels: **3** · AV labels: **2** · WF-only: **3** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `このメッセージを再度表示しない`
+- `これよりテスト実行を開始します。`
+- `開始`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Do not show this message again`
+- `Start`
+
+### ToolThreeMargeCloseAlertForm
+WF labels: **3** · AV labels: **3** · WF-only: **3** · AV-only: **3** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `マージをやめます。マージでの変更点をすべてキャンセルします。`
+- `現在の結果で強制終了します。`
+- `終了せずに、まだマージ作業を続けます。`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Abort merge. Cancel all merge changes.`
+- `Continue merging without closing.`
+- `Force close with current results.`
+
+### ToolUndoPopupDialogForm
+WF labels: **3** · AV labels: **4** · WF-only: **3** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `このバージョンに戻す`
+- `このバージョンをエミュレータでテストプレイ`
+- `キャンセル`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Cancel`
+- `Revert to This Version`
+- `Test Play in Emulator`
+- `↩`
+
+### AIASMRangeForm
+WF labels: **6** · AV labels: **8** · WF-only: **2** · AV-only: **4** · Common: **4**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `先頭アドレス`
+- `書き込み`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `AI Range Editor`
+- `Checks if a unit is within the range from (X1,Y1) to (X2,Y2).`
+- `Write`
+
+### CStringForm
+WF labels: **2** · AV labels: **2** · WF-only: **2** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `書き込み`
+- `直接ROMに書き込まれた文字列`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `C-String Editor`
+
+### DumpStructSelectToTextDialogForm
+WF labels: **2** · AV labels: **4** · WF-only: **2** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `ファイルに保存する`
+- `閉じる`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Close`
+- `Dump Struct to Text`
+- `File name: `
+- `Save to File...`
+
+### PackedMemorySlotForm
+WF labels: **2** · AV labels: **4** · WF-only: **2** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `MESSAGE`
+- `適応`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- ` + `
+- `=`
+- `Apply`
+- `Packed Memory Slot`
+
+### PointerToolBatchInputForm
+WF labels: **2** · AV labels: **3** · WF-only: **2** · AV-only: **3** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `一括アドレス変換`
+- `値:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `0x08000000
+0x08000004
+...`
+- `Batch Address Convert`
+- `Value:`
+
+### ResourceForm
+WF labels: **2** · AV labels: **5** · WF-only: **2** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `クリップボードへ`
+- `ファイルに保存`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Configuration`
+- `Resources`
+- `ROM and Configuration Information`
+- `ROM Data Sections`
+- `ROM Information`
+
+### ToolProblemReportSearchSavForm
+WF labels: **3** · AV labels: **2** · WF-only: **2** · AV-only: **1** · Common: **1**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `savファイルが含まれていないようです。
+問題を確実に再現するためには、savファイルが必要です。
+対応するsavがある場合は、パスを指定してください。`
+- `参照`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Browse...`
+
+### ToolUseFlagForm
+WF labels: **2** · AV labels: **2** · WF-only: **2** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `マップ名`
+- `全マップ共通のフラグも表示する`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Flag Usage Viewer`
+
+### ToolWorkSupport_UpdateQuestionDialogForm
+WF labels: **2** · AV labels: **3** · WF-only: **2** · AV-only: **3** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `強制アップデート`
+- `閉じる`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Close`
+- `Force Update`
+- `❓`
+
+### UbyteBitFlagForm
+WF labels: **2** · AV labels: **11** · WF-only: **2** · AV-only: **11** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `MESSAGE`
+- `適応`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Apply`
+- `Bit 0 (0x01)`
+- `Bit 1 (0x02)`
+- `Bit 2 (0x04)`
+- `Bit 3 (0x08)`
+- `Bit 4 (0x10)`
+- `Bit 5 (0x20)`
+- `Bit 6 (0x40)`
+- `Bit 7 (0x80)`
+- `Byte Bit Flags (8-bit)`
+- `Hex:`
+
+### UshortBitFlagForm
+WF labels: **2** · AV labels: **20** · WF-only: **2** · AV-only: **20** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `MESSAGE`
+- `適応`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Apply`
+- `Bit 0  (0x01)`
+- `Bit 1  (0x02)`
+- `Bit 10 (0x04)`
+- `Bit 11 (0x08)`
+- `Bit 12 (0x10)`
+- `Bit 13 (0x20)`
+- `Bit 14 (0x40)`
+- `Bit 15 (0x80)`
+- `Bit 2  (0x04)`
+- `Bit 3  (0x08)`
+- `Bit 4  (0x10)`
+- `Bit 5  (0x20)`
+- `Bit 6  (0x40)`
+- `Bit 7  (0x80)`
+- `Bit 8  (0x01)`
+- `Bit 9  (0x02)`
+- `High byte:`
+- `Low byte:`
+- `Short Bit Flags (16-bit)`
+
+### UwordBitFlagForm
+WF labels: **2** · AV labels: **38** · WF-only: **2** · AV-only: **38** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `MESSAGE`
+- `適応`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Apply`
+- `Bit 0  (0x01)`
+- `Bit 1  (0x02)`
+- `Bit 10 (0x04)`
+- `Bit 11 (0x08)`
+- `Bit 12 (0x10)`
+- `Bit 13 (0x20)`
+- `Bit 14 (0x40)`
+- `Bit 15 (0x80)`
+- `Bit 16 (0x01)`
+- `Bit 17 (0x02)`
+- `Bit 18 (0x04)`
+- `Bit 19 (0x08)`
+- `Bit 2  (0x04)`
+- `Bit 20 (0x10)`
+- `Bit 21 (0x20)`
+- `Bit 22 (0x40)`
+- `Bit 23 (0x80)`
+- `Bit 24 (0x01)`
+- `Bit 25 (0x02)`
+- `Bit 26 (0x04)`
+- `Bit 27 (0x08)`
+- `Bit 28 (0x10)`
+- `Bit 29 (0x20)`
+- `Bit 3  (0x08)`
+- `Bit 30 (0x40)`
+- `Bit 31 (0x80)`
+- `Bit 4  (0x10)`
+- `Bit 5  (0x20)`
+- `Bit 6  (0x40)`
+- `Bit 7  (0x80)`
+- `Bit 8  (0x01)`
+- `Bit 9  (0x02)`
+- `Byte 0:`
+- `Byte 1:`
+- `Byte 2:`
+- `Byte 3:`
+- `Word Bit Flags (32-bit)`
+
+### ErrorLongMessageDialogForm
+WF labels: **2** · AV labels: **2** · WF-only: **1** · AV-only: **1** · Common: **1**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `以下のエラーが発生しました。`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `The following error has occurred.`
+
+### EventScriptTemplateForm
+WF labels: **1** · AV labels: **2** · WF-only: **1** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `このテンプレートを選択する`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Script Template Browser`
+
+### ProcsScriptForm
+WF labels: **1** · AV labels: **2** · WF-only: **1** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `名前`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Procs Script Editor`
+
+### SkillSystemsEffectivenessReworkClassTypeForm
+WF labels: **1** · AV labels: **5** · WF-only: **1** · AV-only: **5** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `適応`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Class Type:`
+- `Effectiveness Rework - Class Type`
+- `Skill system editors require a compatible skill patch to be installed.
+Use the Patch Manager to install a skill system patch first.
+
+Supported skill systems: CSkillSys, FE8N Skill System`
+- `Write`
+
+### ToolASMEditForm
+WF labels: **1** · AV labels: **4** · WF-only: **1** · AV-only: **4** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `書き込む`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `ASM Code Editor`
+- `Close`
+- `Compile`
+- `Enter ARM/Thumb ASM code here...`
+
+### ToolAllWorkSupportForm
+WF labels: **1** · AV labels: **2** · WF-only: **1** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `更新チェック`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Work Support`
+
+### ToolProblemReportSearchBackupForm
+WF labels: **2** · AV labels: **2** · WF-only: **1** · AV-only: **1** · Common: **1**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `参照`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Browse...`
+
+### ToolUnitTalkGroupForm
+WF labels: **1** · AV labels: **2** · WF-only: **1** · AV-only: **2** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `会話グループを選択してください`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address:`
+- `Talk Group Editor`
+
+### VersionForm
+WF labels: **1** · AV labels: **0** · WF-only: **1** · AV-only: **0** · Common: **0**
+
+WF-only labels (candidates for missing fields in AV):
+
+- `開発者機能: 翻訳`
+

--- a/docs/avalonia-gaps/2026-05-22-labels-sweep.md
+++ b/docs/avalonia-gaps/2026-05-22-labels-sweep.md
@@ -1,6 +1,6 @@
 ---
-generated: "2026-05-21T16:32:05Z"
-git-sha: c7db152fd
+generated: "2026-05-21T16:53:37Z"
+git-sha: 8735d946d
 sweep-type: labels
 ---
 
@@ -14,11 +14,13 @@ to the Phase 1 control-density sweep.
 
 WinForms side: Roslyn extracts `.Text = "..."` assignments on
 `Label`, `GroupBox`, `Button`, `CheckBox`, `RadioButton`, `TabPage`
-controls (plus property-initialiser syntax for hand-coded forms).
+controls (plus property-initialiser syntax for hand-coded forms, and
+`resources.GetString("key")` calls resolved via the sibling .resx).
 Avalonia side: `XDocument` parses every view, harvests literal values from
-`Text` / `Content` / `Header` / `ToolTip` / `Watermark` attributes,
-skipping markup-extension values (`{Binding ...}`, `{StaticResource ...}`)
-and elements nested inside template containers (`Style`, `DataTemplate`, ...).
+`Text` / `Content` / `Header` / `ToolTip` / `ToolTip.Tip` / `Watermark`
+attributes, skipping markup-extension values (`{Binding ...}`,
+`{StaticResource ...}`) and elements nested inside template containers
+(`Style`, `DataTemplate`, ...).
 
 Normalisation collapses whitespace, strips trailing colons, removes mnemonic
 markers (`&` for WF, `_` for AV), and lowercases — so `Name:` / `&Name` /
@@ -34,8 +36,8 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-labels --out=<path>`.
 |---|---:|
 | Pairs scanned (both files exist) | 298 |
 | Pairs with ≥1 WF-only label | 293 |
-| Total WF-only labels | 4645 |
-| Total AV-only labels | 2463 |
+| Total WF-only labels | 4648 |
+| Total AV-only labels | 2562 |
 | Total common labels | 52 |
 
 ## Top 20 Forms by WF-only Label Count
@@ -52,16 +54,16 @@ Cross-link to the [density sweep](2026-05-21-density-sweep.md) for quantitative 
 | 5 | `EventCondForm` | `EventCondView` | 81 | 21 | 0 |
 | 6 | `MapSettingForm` | `MapSettingView` | 78 | 116 | 0 |
 | 7 | `MapSettingFE6Form` | `MapSettingFE6View` | 65 | 2 | 0 |
-| 8 | `ClassForm` | `ClassEditorView` | 57 | 78 | 1 |
+| 8 | `ClassForm` | `ClassEditorView` | 57 | 99 | 1 |
 | 9 | `EventUnitForm` | `EventUnitView` | 50 | 24 | 0 |
 | 10 | `SongInstrumentForm` | `SongInstrumentView` | 50 | 21 | 1 |
 | 11 | `TextForm` | `TextViewerView` | 48 | 11 | 0 |
 | 12 | `WorldMapImageForm` | `WorldMapImageView` | 47 | 2 | 0 |
 | 13 | `ImageUnitPaletteForm` | `ImageUnitPaletteView` | 45 | 17 | 0 |
-| 14 | `ItemForm` | `ItemEditorView` | 45 | 47 | 0 |
+| 14 | `ItemForm` | `ItemEditorView` | 45 | 71 | 0 |
 | 15 | `MapStyleEditorForm` | `MapStyleEditorView` | 45 | 5 | 0 |
-| 16 | `UnitForm` | `UnitEditorView` | 45 | 50 | 4 |
-| 17 | `ItemFE6Form` | `ItemFE6View` | 44 | 27 | 0 |
+| 16 | `UnitForm` | `UnitEditorView` | 45 | 69 | 4 |
+| 17 | `ItemFE6Form` | `ItemFE6View` | 44 | 30 | 0 |
 | 18 | `ToolInitWizardForm` | `ToolInitWizardView` | 44 | 8 | 0 |
 | 19 | `ClassFE6Form` | `ClassFE6View` | 43 | 5 | 0 |
 | 20 | `ImageBattleScreenForm` | `ImageBattleScreenView` | 42 | 2 | 0 |
@@ -73,7 +75,7 @@ backticked literal preserving the original casing/punctuation. Use these as
 the per-form backlog for follow-up gap-fix PRs.
 
 ### EmulatorMemoryForm
-WF labels: **175** · AV labels: **5** · WF-only: **174** · AV-only: **4** · Common: **1**
+WF labels: **175** · AV labels: **5** · WF-only: **174** · AV-only: **4** · Common: **1** · Density verdict: **High** (WF 353 / AV 5)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -171,8 +173,7 @@ WF-only labels (candidates for missing fields in AV):
 - `アドレス`
 - `イベント`
 - `イベント履歴`
-- `イベント履歴(上が最新)
-時刻,イベント開始アドレス,実行中のアドレス,イベント`
+- `イベント履歴(上が最新)\r\n時刻,イベント開始アドレス,実行中のアドレス,イベント`
 - `クリアターン数`
 - `クリアフラグ以外の、他のフラグを変更したい場合は、イベント画面から、変更したいフラグをダブルクリックしてください。`
 - `ターン数`
@@ -261,7 +262,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `This feature uses Windows-specific APIs to read the memory of a running GBA emulator process for live debugging. Please use the Windows (WinForms) version of FEBuilderGBA for this functionality.`
 
 ### MapSettingFE7UForm
-WF labels: **90** · AV labels: **78** · WF-only: **90** · AV-only: **78** · Common: **0**
+WF labels: **90** · AV labels: **78** · WF-only: **90** · AV-only: **78** · Common: **0** · Density verdict: **Medium** (WF 233 / AV 150)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -438,7 +439,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### MapSettingFE7Form
-WF labels: **87** · AV labels: **78** · WF-only: **87** · AV-only: **78** · Common: **0**
+WF labels: **87** · AV labels: **78** · WF-only: **87** · AV-only: **78** · Common: **0** · Density verdict: **Medium** (WF 229 / AV 146)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -612,7 +613,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### SkillConfigFE8NSkillForm
-WF labels: **84** · AV labels: **18** · WF-only: **84** · AV-only: **18** · Common: **0**
+WF labels: **84** · AV labels: **18** · WF-only: **84** · AV-only: **18** · Common: **0** · Density verdict: **High** (WF 169 / AV 33)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -719,14 +720,11 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Description:`
 - `Icon:`
 - `Skill Configuration (FE8N)`
-- `Skill system editors require a compatible skill patch to be installed.
-Use the Patch Manager to install a skill system patch first.
-
-Supported skill systems: CSkillSys, FE8N Skill System`
+- `Skill system editors require a compatible skill patch to be installed.\nUse the Patch Manager to install a skill system patch first.\n\nSupported skill systems: CSkillSys, FE8N Skill System`
 - `Write`
 
 ### EventCondForm
-WF labels: **81** · AV labels: **21** · WF-only: **81** · AV-only: **21** · Common: **0**
+WF labels: **81** · AV labels: **21** · WF-only: **81** · AV-only: **21** · Common: **0** · Density verdict: **High** (WF 414 / AV 41)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -837,7 +835,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### MapSettingForm
-WF labels: **78** · AV labels: **116** · WF-only: **78** · AV-only: **116** · Common: **0**
+WF labels: **78** · AV labels: **116** · WF-only: **78** · AV-only: **116** · Common: **0** · Density verdict: **Low** (WF 224 / AV 220)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -1040,7 +1038,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### MapSettingFE6Form
-WF labels: **65** · AV labels: **2** · WF-only: **65** · AV-only: **2** · Common: **0**
+WF labels: **65** · AV labels: **2** · WF-only: **65** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 126 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -1116,7 +1114,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Map Settings (FE6)`
 
 ### ClassForm
-WF labels: **58** · AV labels: **79** · WF-only: **57** · AV-only: **78** · Common: **1**
+WF labels: **58** · AV labels: **100** · WF-only: **57** · AV-only: **99** · Common: **1** · Density verdict: **Medium** (WF 211 / AV 145)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -1189,32 +1187,43 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Address:`
 - `Anima (B49):`
 - `Axe (B46):`
+- `Base constitution`
+- `Base HP for this class`
+- `Base movement range`
 - `Base Stats`
 - `Battle Anime (P52):`
 - `Bow (B47):`
 - `Calculate Growth`
 - `Class # (B4):`
 - `Class Editor`
+- `Class power / EXP correction value`
 - `Con (B17):`
 - `Dark (B51):`
+- `Decoded description text`
 - `Def (B15):`
 - `Def (B31):`
 - `Def (b38):`
 - `Desc`
 - `Desc ID (W2):`
 - `Edit Skills`
+- `Export all classes to a TSV file`
 - `Export TSV`
 - `Growth Rates`
 - `Growth Simulator`
 - `HP (B11):`
 - `HP (B27):`
 - `HP (b34):`
+- `HP bonus gained on class change`
 - `Identity / Misc`
+- `Import classes from a TSV file`
 - `Import TSV`
+- `Internal class number`
 - `Jump`
 - `Lance (B45):`
 - `Lck (B33):`
+- `Level required for promotion (0=unpromoted)`
 - `Light (B50):`
+- `Map sprite index when idle`
 - `Max Con (B25):`
 - `Max Def (B23):`
 - `Max HP (B19):`
@@ -1222,14 +1231,20 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Max Skl (B21):`
 - `Max Spd (B22):`
 - `Max Str (B20):`
+- `Maximum HP stat cap for this class`
 - `Mov (B18):`
 - `Move Cost (P56):`
 - `Move Cost Rain (P60):`
 - `Move Cost Snow (P64):`
 - `Name:`
 - `Name ID (W0):`
+- `Open skill assignment editor for this class`
+- `Open text viewer for this description`
+- `Pointer to battle animation data`
+- `Pointer to terrain movement cost table`
 - `Pointers / Movement / Terrain`
 - `Portrait (W8):`
+- `Portrait graphic index (click to open Portrait Viewer)`
 - `Power (B26):`
 - `Promo Lv (B5):`
 - `Promotion Gains (CC Bonus)`
@@ -1241,6 +1256,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Skl (B29):`
 - `Skl (b36):`
 - `Sort Order (B10):`
+- `Sort order for class list`
 - `Spd (B14):`
 - `Spd (B30):`
 - `Spd (b37):`
@@ -1253,14 +1269,17 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Terrain Avoid (P68):`
 - `Terrain Def (P72):`
 - `Terrain Res (P76):`
+- `Text ID for this class's description (click to open Text Viewer)`
+- `Text ID for this class's display name (click to open Text Viewer)`
 - `Wait Icon (B6):`
 - `Walk Spd (B7):`
+- `Walking speed on the map`
 - `Warnings`
 - `Weapon Rank Levels (B44-B51)`
 - `Write`
 
 ### EventUnitForm
-WF labels: **50** · AV labels: **24** · WF-only: **50** · AV-only: **24** · Common: **0**
+WF labels: **50** · AV labels: **24** · WF-only: **50** · AV-only: **24** · Common: **0** · Density verdict: **Medium** (WF 95 / AV 54)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -1343,7 +1362,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### SongInstrumentForm
-WF labels: **51** · AV labels: **22** · WF-only: **50** · AV-only: **21** · Common: **1**
+WF labels: **51** · AV labels: **22** · WF-only: **50** · AV-only: **21** · Common: **1** · Density verdict: **High** (WF 323 / AV 54)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -1423,14 +1442,13 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### TextForm
-WF labels: **48** · AV labels: **11** · WF-only: **48** · AV-only: **11** · Common: **0**
+WF labels: **48** · AV labels: **11** · WF-only: **48** · AV-only: **11** · Common: **0** · Density verdict: **High** (WF 62 / AV 15)
 
 WF-only labels (candidates for missing fields in AV):
 
 - `AI用に登場人物のヒントを追加`
 - `from:`
-- `google translateに投げて、翻訳しますw
-負荷をかけすぎないように、忖度してください。`
+- `google translateに投げて、翻訳しますw\r\n負荷をかけすぎないように、忖度してください。`
 - `ID テキスト`
 - `Import/Export`
 - `REDO`
@@ -1475,10 +1493,7 @@ WF-only labels (candidates for missing fields in AV):
 - `翻訳する`
 - `話す人:`
 - `読込数`
-- `警告:
-セリフが
-3行以上に
-なっています`
+- `警告:\r\nセリフが\r\n3行以上に\r\nなっています`
 
 AV-only labels (usually fine — layout polish or rewording):
 
@@ -1495,7 +1510,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write Text`
 
 ### WorldMapImageForm
-WF labels: **47** · AV labels: **2** · WF-only: **47** · AV-only: **2** · Common: **0**
+WF labels: **47** · AV labels: **2** · WF-only: **47** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 107 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -1553,7 +1568,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `World Map Image`
 
 ### ImageUnitPaletteForm
-WF labels: **45** · AV labels: **17** · WF-only: **45** · AV-only: **17** · Common: **0**
+WF labels: **45** · AV labels: **17** · WF-only: **45** · AV-only: **17** · Common: **0** · Density verdict: **High** (WF 133 / AV 32)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -1624,7 +1639,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ItemForm
-WF labels: **45** · AV labels: **47** · WF-only: **45** · AV-only: **47** · Common: **0**
+WF labels: **45** · AV labels: **71** · WF-only: **45** · AV-only: **71** · Common: **0** · Density verdict: **Medium** (WF 128 / AV 88)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -1657,14 +1672,12 @@ WF-only labels (candidates for missing fields in AV):
 - `書き込み`
 - `武器LV熟練度`
 - `特効`
-- `特効効果
-新規割当`
+- `特効効果\r\n新規割当`
 - `移動`
 - `種別`
 - `耐久`
 - `能力補正`
-- `能力補正
-新規割当`
+- `能力補正\r\n新規割当`
 - `能力補正値`
 - `説明`
 - `読込数`
@@ -1679,33 +1692,55 @@ WF-only labels (candidates for missing fields in AV):
 AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
+- `Attack power`
+- `Attack range (encoded as min-max)`
+- `Base item price`
 - `Basic Info`
 - `Buy Price:`
 - `Crit (B24):`
+- `Critical hit rate bonus`
+- `Decoded description text`
+- `Decoded usage description text`
 - `Desc`
 - `Desc ID (W2):`
 - `Dmg Effect (B31):`
 - `Edit Skill Config`
+- `Effect when using the item`
 - `Effective (P16):`
 - `Effective Against`
+- `Export all items to a TSV file`
 - `Export TSV`
 - `Forge Price:`
 - `Hit (B22):`
+- `Hit rate bonus`
 - `Icon (B29):`
+- `Import items from a TSV file`
 - `Import TSV`
+- `Internal item number (unique ID)`
 - `Item # (B6):`
 - `Item Editor`
+- `Item weight (reduces attack speed)`
 - `Jump`
 - `Might (B21):`
 - `Name:`
 - `Name ID (W0):`
+- `Number of uses before the item breaks`
+- `Open skill configuration editor`
+- `Open text viewer for this description`
+- `Open text viewer for this usage description`
+- `Pointer to effectiveness list (bonus vs. classes)`
+- `Pointer to stat bonuses when equipped`
 - `Price (W26):`
 - `Range (B25):`
 - `Rank (B28):`
 - `Sell Price:`
+- `Special effect applied on hit`
 - `Stat Bonus (P12):`
 - `Stat Bonuses Preview`
 - `Stats / Bonuses`
+- `Text ID for the item description (click to open Text Viewer)`
+- `Text ID for the item usage description (click to open Text Viewer)`
+- `Text ID for this item's display name (click to open Text Viewer)`
 - `Trait 1 (B8):`
 - `Trait 2 (B9):`
 - `Trait 3 (B10):`
@@ -1721,13 +1756,15 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Warning: Effectiveness pointer is null (P16=0). Consider allocating.`
 - `Warning: Stat Bonuses pointer is null (P12=0). Consider allocating.`
 - `Warnings`
+- `Weapon experience gained per use`
 - `Weapon Properties`
+- `Weapon type (Sword, Lance, Axe, etc.)`
 - `Weight (B23):`
 - `Wep Exp (B32):`
 - `Write`
 
 ### MapStyleEditorForm
-WF labels: **45** · AV labels: **5** · WF-only: **45** · AV-only: **5** · Common: **0**
+WF labels: **45** · AV labels: **5** · WF-only: **45** · AV-only: **5** · Common: **0** · Density verdict: **High** (WF 153 / AV 8)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -1786,7 +1823,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### UnitForm
-WF labels: **49** · AV labels: **54** · WF-only: **45** · AV-only: **50** · Common: **4**
+WF labels: **49** · AV labels: **73** · WF-only: **45** · AV-only: **69** · Common: **4** · Density verdict: **Medium** (WF 183 / AV 126)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -1843,7 +1880,9 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Affinity:`
 - `Anima:`
 - `Axe:`
+- `Base Hit Points (signed offset from class base)`
 - `Base Stats`
+- `Base Strength/Magic (signed offset from class base)`
 - `Bow:`
 - `Byte 1:`
 - `Byte 2:`
@@ -1853,44 +1892,61 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Class ID:`
 - `Con:`
 - `Dark:`
+- `Decoded description text`
 - `Def:`
 - `Desc`
 - `Desc ID:`
 - `Edit Skills`
+- `Elemental affinity for support bonuses`
+- `Export all units to a TSV file`
 - `Export TSV`
 - `Growth Rates (%)`
 - `Growth Simulator`
 - `Identity`
 - `Import TSV`
+- `Import units from a TSV file`
 - `Jump`
 - `Lance:`
 - `Lck:`
 - `Light:`
 - `Map Face:`
+- `Map sprite face index`
 - `Name:`
 - `Name ID:`
+- `Open skill assignment editor for this unit`
+- `Open text viewer for this description`
+- `Percent chance of HP increasing on level up`
+- `Pick class from editor`
+- `Pick portrait from editor`
 - `Pick...`
 - `Portrait:`
+- `Portrait graphic index (click to open Portrait Viewer)`
 - `Res:`
 - `Simulate to LV:`
 - `Skl:`
 - `Sort:`
 - `Spd:`
 - `Staff:`
+- `Starting level of this unit`
 - `Str:`
 - `Support & Other`
 - `Support Ptr:`
 - `Sword:`
 - `Talk:`
+- `Text ID for the unit's description (click to open Text Viewer)`
+- `Text ID for the unit's display name (click to open Text Viewer)`
+- `The unit's class (click to open Class Editor)`
 - `Undo`
+- `Unique identifier for this unit`
 - `Unit Editor`
 - `Unit ID:`
+- `Unit or class name associated with this portrait ID`
 - `Warnings`
 - `Weapon Levels`
 - `Write`
 
 ### ItemFE6Form
-WF labels: **44** · AV labels: **27** · WF-only: **44** · AV-only: **27** · Common: **0**
+WF labels: **44** · AV labels: **30** · WF-only: **44** · AV-only: **30** · Common: **0** · Density verdict: **High** (WF 121 / AV 53)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -1922,14 +1978,12 @@ WF-only labels (candidates for missing fields in AV):
 - `攻撃`
 - `書き込み`
 - `特効`
-- `特効効果
-新規割当`
+- `特効効果\r\n新規割当`
 - `移動`
 - `種別`
 - `耐久`
 - `能力補正`
-- `能力補正
-新規割当`
+- `能力補正\r\n新規割当`
 - `能力補正値`
 - `説明`
 - `読込数`
@@ -1945,6 +1999,7 @@ AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
 - `Crit (B24):`
+- `Decoded description text`
 - `Desc`
 - `Desc ID (W2):`
 - `Dmg Effect (B31):`
@@ -1956,10 +2011,12 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Might (B21):`
 - `Name:`
 - `Name ID (W0):`
+- `Open text viewer for this description`
 - `Price (W26):`
 - `Range (B25):`
 - `Rank (B28):`
 - `Stat Bonus (P12):`
+- `Text ID for the item's description`
 - `Trait 1 (B8):`
 - `Trait 2 (B9):`
 - `Trait 3 (B10):`
@@ -1972,7 +2029,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ToolInitWizardForm
-WF labels: **44** · AV labels: **8** · WF-only: **44** · AV-only: **8** · Common: **0**
+WF labels: **44** · AV labels: **8** · WF-only: **44** · AV-only: **8** · Common: **0** · Density verdict: **High** (WF 80 / AV 8)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -2033,7 +2090,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `You can change these settings later from the Options menu.`
 
 ### ClassFE6Form
-WF labels: **43** · AV labels: **5** · WF-only: **43** · AV-only: **5** · Common: **0**
+WF labels: **43** · AV labels: **5** · WF-only: **43** · AV-only: **5** · Common: **0** · Density verdict: **High** (WF 173 / AV 8)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -2090,7 +2147,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Sim Level:`
 
 ### ImageBattleScreenForm
-WF labels: **42** · AV labels: **2** · WF-only: **42** · AV-only: **2** · Common: **0**
+WF labels: **42** · AV labels: **2** · WF-only: **42** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 133 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -2131,8 +2188,7 @@ WF-only labels (candidates for missing fields in AV):
 - `右側`
 - `名前`
 - `左側`
-- `戦闘画面を一括でインポートします。
-TSAがあるので、共通タイルは1つにまとめられるという制約があります。`
+- `戦闘画面を一括でインポートします。\r\nTSAがあるので、共通タイルは1つにまとめられるという制約があります。`
 - `書き込み`
 - `画像`
 - `画像取出`
@@ -2144,7 +2200,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Battle Screen Layout`
 
 ### UnitFE7Form
-WF labels: **39** · AV labels: **58** · WF-only: **38** · AV-only: **57** · Common: **1**
+WF labels: **39** · AV labels: **63** · WF-only: **38** · AV-only: **62** · Common: **1** · Density verdict: **Medium** (WF 160 / AV 107)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -2200,9 +2256,12 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Axe:`
 - `Base Stats:`
 - `Bow:`
+- `Click to open Class Editor`
+- `Click to open Portrait Viewer`
 - `CON:`
 - `Dark:`
 - `Decoded:`
+- `Decoded description text`
 - `DEF:`
 - `DEF Growth:`
 - `Desc`
@@ -2218,6 +2277,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Lower Class Palette:`
 - `Map Face:`
 - `Name:`
+- `Open text viewer for this description`
 - `Palette / Custom Animation:`
 - `Portrait:`
 - `RES:`
@@ -2235,6 +2295,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Support Data Ptr:`
 - `Sword:`
 - `Talk Group:`
+- `Text ID for the unit's description`
 - `Unit ID:`
 - `Units (FE7) Editor`
 - `Unknown 39:`
@@ -2248,7 +2309,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### MonsterItemForm
-WF labels: **37** · AV labels: **8** · WF-only: **37** · AV-only: **8** · Common: **0**
+WF labels: **37** · AV labels: **9** · WF-only: **37** · AV-only: **9** · Common: **0** · Density verdict: **High** (WF 129 / AV 14)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -2293,6 +2354,7 @@ WF-only labels (candidates for missing fields in AV):
 AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
+- `Click to open Item Editor`
 - `Drop Rate:`
 - `Item ID:`
 - `Monster Item Editor`
@@ -2302,7 +2364,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### SkillConfigFE8NVer3SkillForm
-WF labels: **37** · AV labels: **11** · WF-only: **37** · AV-only: **11** · Common: **0**
+WF labels: **37** · AV labels: **11** · WF-only: **37** · AV-only: **11** · Common: **0** · Density verdict: **High** (WF 166 / AV 19)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -2342,8 +2404,7 @@ WF-only labels (candidates for missing fields in AV):
 - `詳細`
 - `読込数`
 - `選択アドレス:`
-- `領域が確保されていません。
-「リストの拡張ボタン」を押して領域を確保してください。`
+- `領域が確保されていません。\r\n「リストの拡張ボタン」を押して領域を確保してください。`
 
 AV-only labels (usually fine — layout polish or rewording):
 
@@ -2353,17 +2414,14 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Held Item Skill Pointer:`
 - `Palette:`
 - `Skill Configuration (FE8N v3)`
-- `Skill system editors require a compatible skill patch to be installed.
-Use the Patch Manager to install a skill system patch first.
-
-Supported skill systems: CSkillSys, FE8N Skill System`
+- `Skill system editors require a compatible skill patch to be installed.\nUse the Patch Manager to install a skill system patch first.\n\nSupported skill systems: CSkillSys, FE8N Skill System`
 - `Text Detail:`
 - `Unit/Class Pointer:`
 - `Weapon Item Skill Pointer:`
 - `Write`
 
 ### EventUnitFE7Form
-WF labels: **36** · AV labels: **24** · WF-only: **36** · AV-only: **24** · Common: **0**
+WF labels: **36** · AV labels: **24** · WF-only: **36** · AV-only: **24** · Common: **0** · Density verdict: **Low** (WF 66 / AV 54)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -2432,7 +2490,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ImageBattleAnimeForm
-WF labels: **35** · AV labels: **29** · WF-only: **35** · AV-only: **29** · Common: **0**
+WF labels: **35** · AV labels: **29** · WF-only: **35** · AV-only: **29** · Common: **0** · Density verdict: **Medium** (WF 79 / AV 47)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -2470,8 +2528,7 @@ WF-only labels (candidates for missing fields in AV):
 - `識別子`
 - `選択アドレス:`
 - `選択クラスの分離独立`
-- `領域が確保されていません。
-「リストの拡張ボタン」を押して領域を確保してください。`
+- `領域が確保されていません。\r\n「リストの拡張ボタン」を押して領域を確保してください。`
 
 AV-only labels (usually fine — layout polish or rewording):
 
@@ -2506,7 +2563,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### EventUnitFE6Form
-WF labels: **34** · AV labels: **24** · WF-only: **34** · AV-only: **24** · Common: **0**
+WF labels: **34** · AV labels: **24** · WF-only: **34** · AV-only: **24** · Common: **0** · Density verdict: **Low** (WF 64 / AV 54)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -2573,7 +2630,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### SongTrackForm
-WF labels: **37** · AV labels: **11** · WF-only: **34** · AV-only: **8** · Common: **3**
+WF labels: **37** · AV labels: **11** · WF-only: **34** · AV-only: **8** · Common: **3** · Density verdict: **High** (WF 45 / AV 19)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -2624,7 +2681,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### UnitFE6Form
-WF labels: **36** · AV labels: **45** · WF-only: **33** · AV-only: **42** · Common: **3**
+WF labels: **36** · AV labels: **50** · WF-only: **33** · AV-only: **47** · Common: **3** · Density verdict: **Medium** (WF 152 / AV 99)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -2676,8 +2733,11 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Byte3:`
 - `Byte4:`
 - `Class ID:`
+- `Click to open Class Editor`
+- `Click to open Portrait Viewer`
 - `Con:`
 - `Dark:`
+- `Decoded description text`
 - `Def:`
 - `Desc`
 - `Desc ID:`
@@ -2690,6 +2750,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Map Face:`
 - `Name:`
 - `Name ID:`
+- `Open text viewer for this description`
 - `Portrait:`
 - `Res:`
 - `Skl:`
@@ -2700,6 +2761,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Support & Other`
 - `Support Ptr:`
 - `Sword:`
+- `Text ID for the unit's description`
 - `Undo`
 - `Unit Editor (FE6)`
 - `Unit ID:`
@@ -2708,7 +2770,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ClassOPDemoForm
-WF labels: **32** · AV labels: **2** · WF-only: **32** · AV-only: **2** · Common: **0**
+WF labels: **32** · AV labels: **2** · WF-only: **32** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 71 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -2719,8 +2781,7 @@ WF-only labels (candidates for missing fields in AV):
 - `size:`
 - `アドレス`
 - `アニメの特殊指定`
-- `アニメ指定
-ポインタ書き込み`
+- `アニメ指定\r\nポインタ書き込み`
 - `アニメ指定のポインタ`
 - `アニメ指定のポインタ先`
 - `アニメ指定共有`
@@ -2733,8 +2794,7 @@ WF-only labels (candidates for missing fields in AV):
 - `名前`
 - `戦闘アニメ`
 - `敵味方カラー`
-- `日本語名
-ポインタ書き込み`
+- `日本語名\r\nポインタ書き込み`
 - `日本語名の長さ`
 - `日本語名ポインタ`
 - `日本語名ポインタ先`
@@ -2753,7 +2813,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Class OP Demo`
 
 ### ImagePortraitForm
-WF labels: **32** · AV labels: **22** · WF-only: **32** · AV-only: **22** · Common: **0**
+WF labels: **32** · AV labels: **22** · WF-only: **32** · AV-only: **22** · Common: **0** · Density verdict: **Medium** (WF 63 / AV 37)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -2816,7 +2876,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ImagePortraitForm
-WF labels: **32** · AV labels: **28** · WF-only: **32** · AV-only: **28** · Common: **0**
+WF labels: **32** · AV labels: **28** · WF-only: **32** · AV-only: **28** · Common: **0** · Density verdict: **Medium** (WF 63 / AV 45)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -2885,7 +2945,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write Positions`
 
 ### SkillConfigFE8NVer2SkillForm
-WF labels: **31** · AV labels: **10** · WF-only: **31** · AV-only: **10** · Common: **0**
+WF labels: **31** · AV labels: **10** · WF-only: **31** · AV-only: **10** · Common: **0** · Density verdict: **High** (WF 136 / AV 17)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -2919,8 +2979,7 @@ WF-only labels (candidates for missing fields in AV):
 - `詳細`
 - `読込数`
 - `選択アドレス:`
-- `領域が確保されていません。
-「リストの拡張ボタン」を押して領域を確保してください。`
+- `領域が確保されていません。\r\n「リストの拡張ボタン」を押して領域を確保してください。`
 
 AV-only labels (usually fine — layout polish or rewording):
 
@@ -2929,17 +2988,14 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Held Item Skill Pointer:`
 - `Palette:`
 - `Skill Configuration (FE8N v2)`
-- `Skill system editors require a compatible skill patch to be installed.
-Use the Patch Manager to install a skill system patch first.
-
-Supported skill systems: CSkillSys, FE8N Skill System`
+- `Skill system editors require a compatible skill patch to be installed.\nUse the Patch Manager to install a skill system patch first.\n\nSupported skill systems: CSkillSys, FE8N Skill System`
 - `Text Detail:`
 - `Unit Skill Pointer:`
 - `Weapon Item Skill Pointer:`
 - `Write`
 
 ### ImageTSAEditorForm
-WF labels: **30** · AV labels: **2** · WF-only: **30** · AV-only: **2** · Common: **0**
+WF labels: **30** · AV labels: **2** · WF-only: **30** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 100 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -2980,7 +3036,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `TSA Tile Editor`
 
 ### SummonsDemonKingForm
-WF labels: **30** · AV labels: **19** · WF-only: **30** · AV-only: **19** · Common: **0**
+WF labels: **30** · AV labels: **21** · WF-only: **30** · AV-only: **21** · Common: **0** · Density verdict: **Medium** (WF 60 / AV 36)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3022,6 +3078,8 @@ AV-only labels (usually fine — layout polish or rewording):
 - `AI 2:`
 - `AI Pointer:`
 - `Class ID:`
+- `Click to open Class Editor`
+- `Click to open Unit Editor`
 - `Commander:`
 - `Coordinates:`
 - `Demon King Summon Editor`
@@ -3038,7 +3096,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ImageBattleAnimePalletForm
-WF labels: **29** · AV labels: **2** · WF-only: **29** · AV-only: **2** · Common: **0**
+WF labels: **29** · AV labels: **2** · WF-only: **29** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 99 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3078,7 +3136,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Battle Animation Palette`
 
 ### ImagePalletForm
-WF labels: **28** · AV labels: **2** · WF-only: **28** · AV-only: **2** · Common: **0**
+WF labels: **28** · AV labels: **2** · WF-only: **28** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 98 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3117,7 +3175,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Palette Editor`
 
 ### OPClassDemoFE7Form
-WF labels: **28** · AV labels: **16** · WF-only: **28** · AV-only: **16** · Common: **0**
+WF labels: **28** · AV labels: **17** · WF-only: **28** · AV-only: **17** · Common: **0** · Density verdict: **High** (WF 64 / AV 32)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3127,8 +3185,7 @@ WF-only labels (candidates for missing fields in AV):
 - `Commamd`
 - `Size:`
 - `アドレス`
-- `アニメ指定
-ポインタ書き込み`
+- `アニメ指定\r\nポインタ書き込み`
 - `アニメ指定のポインタ`
 - `グラフィックツール`
 - `パレットID`
@@ -3158,6 +3215,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Anime Pointer:`
 - `Battle Anime:`
 - `Class ID:`
+- `Click to open Class Editor`
 - `Description Text ID:`
 - `Display Weapon:`
 - `English Name Pointer:`
@@ -3171,7 +3229,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### StatusOptionForm
-WF labels: **28** · AV labels: **22** · WF-only: **28** · AV-only: **22** · Common: **0**
+WF labels: **28** · AV labels: **22** · WF-only: **28** · AV-only: **22** · Common: **0** · Density verdict: **Low** (WF 50 / AV 47)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3230,7 +3288,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Yes Text ID:`
 
 ### ToolLZ77Form
-WF labels: **28** · AV labels: **2** · WF-only: **28** · AV-only: **2** · Common: **0**
+WF labels: **28** · AV labels: **2** · WF-only: **28** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 50 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3269,7 +3327,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `LZ77 Compression Tool`
 
 ### OPClassDemoForm
-WF labels: **27** · AV labels: **16** · WF-only: **27** · AV-only: **16** · Common: **0**
+WF labels: **27** · AV labels: **16** · WF-only: **27** · AV-only: **16** · Common: **0** · Density verdict: **High** (WF 63 / AV 31)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3279,8 +3337,7 @@ WF-only labels (candidates for missing fields in AV):
 - `Commamd`
 - `Size:`
 - `アドレス`
-- `アニメ指定
-ポインタ書き込み`
+- `アニメ指定\r\nポインタ書き込み`
 - `アニメ指定のポインタ`
 - `パレットID`
 - `リストの拡張`
@@ -3290,8 +3347,7 @@ WF-only labels (candidates for missing fields in AV):
 - `名前`
 - `戦闘アニメ`
 - `敵味方カラー`
-- `日本語名
-ポインタ書き込み`
+- `日本語名\r\nポインタ書き込み`
 - `日本語名の長さ`
 - `日本語名ポインタ`
 - `書き込み`
@@ -3323,7 +3379,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ImageMagicCSACreatorForm
-WF labels: **25** · AV labels: **2** · WF-only: **25** · AV-only: **2** · Common: **0**
+WF labels: **25** · AV labels: **2** · WF-only: **25** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 37 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3359,7 +3415,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `CSA Magic Creator`
 
 ### ImageMagicFEditorForm
-WF labels: **25** · AV labels: **2** · WF-only: **25** · AV-only: **2** · Common: **0**
+WF labels: **25** · AV labels: **2** · WF-only: **25** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 37 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3395,7 +3451,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Magic Effect Editor (FEditor)`
 
 ### AIScriptForm
-WF labels: **24** · AV labels: **2** · WF-only: **24** · AV-only: **2** · Common: **0**
+WF labels: **24** · AV labels: **2** · WF-only: **24** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 37 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3430,7 +3486,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `AI Script Editor`
 
 ### OPClassDemoFE7UForm
-WF labels: **24** · AV labels: **13** · WF-only: **24** · AV-only: **13** · Common: **0**
+WF labels: **24** · AV labels: **14** · WF-only: **24** · AV-only: **14** · Common: **0** · Density verdict: **High** (WF 56 / AV 26)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3440,8 +3496,7 @@ WF-only labels (candidates for missing fields in AV):
 - `Commamd`
 - `Size:`
 - `アドレス`
-- `アニメ指定
-ポインタ書き込み`
+- `アニメ指定\r\nポインタ書き込み`
 - `アニメ指定のポインタ`
 - `クラス`
 - `パレットID`
@@ -3467,6 +3522,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Anime Pointer:`
 - `Battle Anime:`
 - `Class ID:`
+- `Click to open Class Editor`
 - `Description Text ID:`
 - `English Name Pointer:`
 - `Japanese Name Length:`
@@ -3477,7 +3533,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### SkillAssignmentClassCSkillSysForm
-WF labels: **24** · AV labels: **5** · WF-only: **24** · AV-only: **5** · Common: **0**
+WF labels: **24** · AV labels: **5** · WF-only: **24** · AV-only: **5** · Common: **0** · Density verdict: **High** (WF 43 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3504,22 +3560,18 @@ WF-only labels (candidates for missing fields in AV):
 - `読込数`
 - `選択アドレス:`
 - `選択クラスの分離独立`
-- `領域が確保されていません。
-「リストの拡張ボタン」を押して領域を確保してください。`
+- `領域が確保されていません。\r\n「リストの拡張ボタン」を押して領域を確保してください。`
 
 AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
 - `Class Skill:`
 - `Skill Assignment - Class (CSkillSys)`
-- `Skill system editors require a compatible skill patch to be installed.
-Use the Patch Manager to install a skill system patch first.
-
-Supported skill systems: CSkillSys, FE8N Skill System`
+- `Skill system editors require a compatible skill patch to be installed.\nUse the Patch Manager to install a skill system patch first.\n\nSupported skill systems: CSkillSys, FE8N Skill System`
 - `Write`
 
 ### SkillAssignmentClassSkillSystemForm
-WF labels: **24** · AV labels: **5** · WF-only: **24** · AV-only: **5** · Common: **0**
+WF labels: **24** · AV labels: **5** · WF-only: **24** · AV-only: **5** · Common: **0** · Density verdict: **High** (WF 43 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3546,8 +3598,7 @@ WF-only labels (candidates for missing fields in AV):
 - `読込数`
 - `選択アドレス:`
 - `選択クラスの分離独立`
-- `領域が確保されていません。
-「リストの拡張ボタン」を押して領域を確保してください。`
+- `領域が確保されていません。\r\n「リストの拡張ボタン」を押して領域を確保してください。`
 
 AV-only labels (usually fine — layout polish or rewording):
 
@@ -3558,7 +3609,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### WorldMapPointForm
-WF labels: **24** · AV labels: **21** · WF-only: **24** · AV-only: **21** · Common: **0**
+WF labels: **24** · AV labels: **21** · WF-only: **24** · AV-only: **21** · Common: **0** · Density verdict: **Low** (WF 51 / AV 41)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3612,7 +3663,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### EDFE7Form
-WF labels: **23** · AV labels: **2** · WF-only: **23** · AV-only: **2** · Common: **0**
+WF labels: **23** · AV labels: **2** · WF-only: **23** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 81 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3646,7 +3697,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `ED (FE7)`
 
 ### OPClassDemoFE8UForm
-WF labels: **23** · AV labels: **13** · WF-only: **23** · AV-only: **13** · Common: **0**
+WF labels: **23** · AV labels: **14** · WF-only: **23** · AV-only: **14** · Common: **0** · Density verdict: **Medium** (WF 50 / AV 26)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3656,8 +3707,7 @@ WF-only labels (candidates for missing fields in AV):
 - `Commamd`
 - `Size:`
 - `アドレス`
-- `アニメ指定
-ポインタ書き込み`
+- `アニメ指定\r\nポインタ書き込み`
 - `アニメ指定のポインタ`
 - `クラス`
 - `パレットID`
@@ -3683,6 +3733,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Anime Type:`
 - `Battle Anime:`
 - `Class ID:`
+- `Click to open Class Editor`
 - `Description Text ID:`
 - `Display Weapon:`
 - `Magic Effect:`
@@ -3692,7 +3743,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### SupportUnitFE6Form
-WF labels: **23** · AV labels: **38** · WF-only: **23** · AV-only: **38** · Common: **0**
+WF labels: **23** · AV labels: **38** · WF-only: **23** · AV-only: **38** · Common: **0** · Density verdict: **Low** (WF 58 / AV 71)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3762,7 +3813,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### MonsterProbabilityForm
-WF labels: **22** · AV labels: **15** · WF-only: **22** · AV-only: **15** · Common: **0**
+WF labels: **22** · AV labels: **15** · WF-only: **22** · AV-only: **15** · Common: **0** · Density verdict: **Medium** (WF 38 / AV 28)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3808,7 +3859,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### SkillConfigSkillSystemForm
-WF labels: **22** · AV labels: **5** · WF-only: **22** · AV-only: **5** · Common: **0**
+WF labels: **22** · AV labels: **5** · WF-only: **22** · AV-only: **5** · Common: **0** · Density verdict: **High** (WF 30 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3844,7 +3895,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### SupportUnitForm
-WF labels: **22** · AV labels: **30** · WF-only: **22** · AV-only: **30** · Common: **0**
+WF labels: **22** · AV labels: **30** · WF-only: **22** · AV-only: **30** · Common: **0** · Density verdict: **Low** (WF 50 / AV 55)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3905,7 +3956,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ToolTranslateROMForm
-WF labels: **22** · AV labels: **2** · WF-only: **22** · AV-only: **2** · Common: **0**
+WF labels: **22** · AV labels: **2** · WF-only: **22** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 35 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3938,7 +3989,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `ROM Translation Tool`
 
 ### ImagePortraitFE6Form
-WF labels: **23** · AV labels: **14** · WF-only: **21** · AV-only: **12** · Common: **2**
+WF labels: **23** · AV labels: **14** · WF-only: **21** · AV-only: **12** · Common: **2** · Density verdict: **Medium** (WF 34 / AV 22)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3980,7 +4031,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Unused (B15):`
 
 ### MapExitPointForm
-WF labels: **21** · AV labels: **4** · WF-only: **21** · AV-only: **4** · Common: **0**
+WF labels: **21** · AV labels: **4** · WF-only: **21** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 32 / AV 6)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3988,8 +4039,7 @@ WF-only labels (candidates for missing fields in AV):
 - `Size:`
 - `X:`
 - `Y:`
-- `これは敵のエスケープポイントです。
-NPC用は、左上のコンボボックスを切り替えてください。`
+- `これは敵のエスケープポイントです。\r\nNPC用は、左上のコンボボックスを切り替えてください。`
 - `アドレス`
 - `マップ名`
 - `リストの拡張`
@@ -4015,7 +4065,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### MenuCommandForm
-WF labels: **21** · AV labels: **13** · WF-only: **21** · AV-only: **13** · Common: **0**
+WF labels: **21** · AV labels: **13** · WF-only: **21** · AV-only: **13** · Common: **0** · Density verdict: **Medium** (WF 39 / AV 26)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4058,18 +4108,16 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### PointerToolForm
-WF labels: **21** · AV labels: **20** · WF-only: **21** · AV-only: **20** · Common: **0**
+WF labels: **21** · AV labels: **20** · WF-only: **21** · AV-only: **20** · Common: **0** · Density verdict: **Low** (WF 31 / AV 33)
 
 WF-only labels (candidates for missing fields in AV):
 
 - `LoadROMNAME`
 - `この場所への最初の参照`
 - `アドレス`
-- `アドレスがポインタの場合の
-指されるデータ位置`
+- `アドレスがポインタの場合の\r\n指されるデータ位置`
 - `アドレスの種類判定`
-- `アドレス値の参照先の
-データがある場所`
+- `アドレス値の参照先の\r\nデータがある場所`
 - `スライドして追加検索`
 - `バッチ (一括処理)`
 - `ポインタ化`
@@ -4077,8 +4125,7 @@ WF-only labels (candidates for missing fields in AV):
 - `上記データの参照場所`
 - `内容`
 - `別ROM読込`
-- `参照値から追跡
-マッチアドレス`
+- `参照値から追跡\r\nマッチアドレス`
 - `探索にASMMapを利用する`
 - `比較サイズ`
 - `比較方法`
@@ -4093,19 +4140,15 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Auto Tracking`
 - `Batch`
 - `Close`
-- `Compare current ROM against another version to locate
-specific data such as images or programs that are
-shared between FE7 and FE8.`
+- `Compare current ROM against another version to locate\nspecific data such as images or programs that are\nshared between FE7 and FE8.`
 - `Comparison Size`
 - `Content Type`
-- `Data Address
-(if pointer)`
+- `Data Address\n(if pointer)`
 - `e.g. 0x08000000`
 - `First Reference`
 - `Little Endian`
 - `Match Method`
-- `Other ROM
-Data Address`
+- `Other ROM\nData Address`
 - `Other ROM Ref`
 - `Pointer`
 - `Search Options`
@@ -4115,7 +4158,7 @@ Data Address`
 - `What Is`
 
 ### EDForm
-WF labels: **20** · AV labels: **8** · WF-only: **20** · AV-only: **8** · Common: **0**
+WF labels: **20** · AV labels: **9** · WF-only: **20** · AV-only: **9** · Common: **0** · Density verdict: **High** (WF 65 / AV 13)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4143,6 +4186,7 @@ WF-only labels (candidates for missing fields in AV):
 AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
+- `Click to open Unit Editor`
 - `Condition:`
 - `Condition: 00=Died, 01=Wounded/Left, 02=Wounded/Stayed`
 - `Ending Event Editor`
@@ -4152,7 +4196,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### EventMapChangeForm
-WF labels: **20** · AV labels: **2** · WF-only: **20** · AV-only: **2** · Common: **0**
+WF labels: **20** · AV labels: **2** · WF-only: **20** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 36 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4169,8 +4213,7 @@ WF-only labels (candidates for missing fields in AV):
 - `先頭アドレス`
 - `再取得`
 - `名前`
-- `変化データ
-ポインタ先へのインポート`
+- `変化データ\r\nポインタ先へのインポート`
 - `変化データポインタ`
 - `座標`
 - `書き込み`
@@ -4184,7 +4227,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Map Change Event Editor`
 
 ### ImageBGForm
-WF labels: **20** · AV labels: **6** · WF-only: **20** · AV-only: **6** · Common: **0**
+WF labels: **20** · AV labels: **6** · WF-only: **20** · AV-only: **6** · Common: **0** · Density verdict: **High** (WF 26 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4219,7 +4262,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Import PNG`
 
 ### ImageBattleBGForm
-WF labels: **20** · AV labels: **9** · WF-only: **20** · AV-only: **9** · Common: **0**
+WF labels: **20** · AV labels: **9** · WF-only: **20** · AV-only: **9** · Common: **0** · Density verdict: **High** (WF 26 / AV 13)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4257,13 +4300,12 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ImageMapActionAnimationForm
-WF labels: **20** · AV labels: **7** · WF-only: **20** · AV-only: **7** · Common: **0**
+WF labels: **20** · AV labels: **7** · WF-only: **20** · AV-only: **7** · Common: **0** · Density verdict: **High** (WF 29 / AV 12)
 
 WF-only labels (candidates for missing fields in AV):
 
 - `00`
-- `ID=00 Emptyはnullデータとして予約されています。
-0x0以外の値を設定しないでください。`
+- `ID=00 Emptyはnullデータとして予約されています。\r\n0x0以外の値を設定しないでください。`
 - `Size:`
 - `アドレス`
 - `アニメーション`
@@ -4294,7 +4336,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### MapTileAnimation2Form
-WF labels: **20** · AV labels: **8** · WF-only: **20** · AV-only: **8** · Common: **0**
+WF labels: **20** · AV labels: **8** · WF-only: **20** · AV-only: **8** · Common: **0** · Density verdict: **High** (WF 40 / AV 14)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4331,7 +4373,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### SkillConfigFE8UCSkillSys09xForm
-WF labels: **20** · AV labels: **6** · WF-only: **20** · AV-only: **6** · Common: **0**
+WF labels: **20** · AV labels: **6** · WF-only: **20** · AV-only: **6** · Common: **0** · Density verdict: **High** (WF 29 / AV 9)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4362,14 +4404,11 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Description:`
 - `Skill Configuration (CSkillSys 0.9.x)`
 - `Skill Name:`
-- `Skill system editors require a compatible skill patch to be installed.
-Use the Patch Manager to install a skill system patch first.
-
-Supported skill systems: CSkillSys, FE8N Skill System`
+- `Skill system editors require a compatible skill patch to be installed.\nUse the Patch Manager to install a skill system patch first.\n\nSupported skill systems: CSkillSys, FE8N Skill System`
 - `Write`
 
 ### SongTableForm
-WF labels: **20** · AV labels: **8** · WF-only: **20** · AV-only: **8** · Common: **0**
+WF labels: **20** · AV labels: **8** · WF-only: **20** · AV-only: **8** · Common: **0** · Density verdict: **Medium** (WF 26 / AV 14)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4378,9 +4417,7 @@ WF-only labels (candidates for missing fields in AV):
 - `♪`
 - `アドレス`
 - `コメント`
-- `サウンドルームに曲を登録すると、曲名をつけられます。
-FEには、曲と効果音の違いはありません。
-`
+- `サウンドルームに曲を登録すると、曲名をつけられます。\r\nFEには、曲と効果音の違いはありません。\r\n`
 - `サウンドルームへ`
 - `ソングヘッダー`
 - `ソングヘッダーへ`
@@ -4389,10 +4426,8 @@ FEには、曲と効果音の違いはありません。
 - `再取得`
 - `参照箇所`
 - `名前`
-- `曲の楽譜を表示します。
-ここからは、曲のインポート、エクスポートを行います。`
-- `曲を構成する楽器テーブルを表示します。
-通常は気にする必要はありません。開発者向けの機能です。`
+- `曲の楽譜を表示します。\r\nここからは、曲のインポート、エクスポートを行います。`
+- `曲を構成する楽器テーブルを表示します。\r\n通常は気にする必要はありません。開発者向けの機能です。`
 - `書き込み`
 - `楽器テーブルへ`
 - `読込数`
@@ -4410,7 +4445,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ErrorPaletteTransparentForm
-WF labels: **19** · AV labels: **2** · WF-only: **19** · AV-only: **2** · Common: **0**
+WF labels: **19** · AV labels: **2** · WF-only: **19** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 50 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4432,8 +4467,7 @@ WF-only labels (candidates for missing fields in AV):
 - `No.8`
 - `No.9`
 - `パレットの透過色はどれですか？`
-- `通常、1番最初のパレットを背景の透過色にするべきですが、この画像はそうなっていないように思われます。
-背景の透過色はどれですか？`
+- `通常、1番最初のパレットを背景の透過色にするべきですが、この画像はそうなっていないように思われます。\r\n背景の透過色はどれですか？`
 
 AV-only labels (usually fine — layout polish or rewording):
 
@@ -4441,7 +4475,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Palette Transparency Error`
 
 ### ImageCGFE7UForm
-WF labels: **20** · AV labels: **11** · WF-only: **19** · AV-only: **10** · Common: **1**
+WF labels: **20** · AV labels: **11** · WF-only: **19** · AV-only: **10** · Common: **1** · Density verdict: **Medium** (WF 31 / AV 17)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4479,7 +4513,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Reserved (B1-B3):`
 
 ### ImageItemIconForm
-WF labels: **19** · AV labels: **7** · WF-only: **19** · AV-only: **7** · Common: **0**
+WF labels: **19** · AV labels: **7** · WF-only: **19** · AV-only: **7** · Common: **0** · Density verdict: **High** (WF 22 / AV 10)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4514,7 +4548,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Palette Pointer:`
 
 ### MapChangeForm
-WF labels: **21** · AV labels: **15** · WF-only: **19** · AV-only: **13** · Common: **2**
+WF labels: **21** · AV labels: **15** · WF-only: **19** · AV-only: **13** · Common: **2** · Density verdict: **Medium** (WF 37 / AV 25)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4555,7 +4589,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write Record`
 
 ### MenuDefinitionForm
-WF labels: **20** · AV labels: **15** · WF-only: **19** · AV-only: **14** · Common: **1**
+WF labels: **20** · AV labels: **15** · WF-only: **19** · AV-only: **14** · Common: **1** · Density verdict: **Low** (WF 35 / AV 28)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4597,7 +4631,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Y Position:`
 
 ### SongTrackImportMidiForm
-WF labels: **19** · AV labels: **8** · WF-only: **19** · AV-only: **8** · Common: **0**
+WF labels: **19** · AV labels: **8** · WF-only: **19** · AV-only: **8** · Common: **0** · Density verdict: **High** (WF 25 / AV 10)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4633,7 +4667,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Note`
 
 ### AITargetForm
-WF labels: **18** · AV labels: **23** · WF-only: **18** · AV-only: **23** · Common: **0**
+WF labels: **18** · AV labels: **23** · WF-only: **18** · AV-only: **23** · Common: **0** · Density verdict: **Low** (WF 52 / AV 44)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4683,7 +4717,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### DumpStructSelectDialogForm
-WF labels: **18** · AV labels: **2** · WF-only: **18** · AV-only: **2** · Common: **0**
+WF labels: **18** · AV labels: **2** · WF-only: **18** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 19 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4712,7 +4746,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Struct Dump Selector`
 
 ### EventBattleTalkFE7Form
-WF labels: **18** · AV labels: **2** · WF-only: **18** · AV-only: **2** · Common: **0**
+WF labels: **18** · AV labels: **2** · WF-only: **18** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 62 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4741,7 +4775,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Battle Dialogue (FE7)`
 
 ### ImageCGForm
-WF labels: **18** · AV labels: **6** · WF-only: **18** · AV-only: **6** · Common: **0**
+WF labels: **18** · AV labels: **6** · WF-only: **18** · AV-only: **6** · Common: **0** · Density verdict: **High** (WF 24 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4774,7 +4808,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Import PNG`
 
 ### ImageChapterTitleForm
-WF labels: **18** · AV labels: **9** · WF-only: **18** · AV-only: **9** · Common: **0**
+WF labels: **18** · AV labels: **9** · WF-only: **18** · AV-only: **9** · Common: **0** · Density verdict: **Medium** (WF 25 / AV 13)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4810,7 +4844,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ItemStatBonusesForm
-WF labels: **19** · AV labels: **15** · WF-only: **18** · AV-only: **14** · Common: **1**
+WF labels: **19** · AV labels: **15** · WF-only: **18** · AV-only: **14** · Common: **1** · Density verdict: **Low** (WF 35 / AV 28)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4851,7 +4885,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### PaletteChangeColorsForm
-WF labels: **21** · AV labels: **9** · WF-only: **18** · AV-only: **6** · Common: **3**
+WF labels: **21** · AV labels: **9** · WF-only: **18** · AV-only: **6** · Common: **3** · Density verdict: **High** (WF 25 / AV 12)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4881,11 +4915,10 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Close`
 - `Color Grid (16 colors):`
 - `Palette Change Colors`
-- `Palette Color Editor allows editing individual colors in a 16-color GBA palette.
-Select a palette slot to modify its RGB values.`
+- `Palette Color Editor allows editing individual colors in a 16-color GBA palette.\nSelect a palette slot to modify its RGB values.`
 
 ### PaletteSwapForm
-WF labels: **18** · AV labels: **6** · WF-only: **18** · AV-only: **6** · Common: **0**
+WF labels: **18** · AV labels: **6** · WF-only: **18** · AV-only: **6** · Common: **0** · Density verdict: **High** (WF 49 / AV 8)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4913,13 +4946,12 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Cancel`
 - `Destination Palette:`
 - `Palette Swap`
-- `Palette Swap exchanges palette assignments between entries.
-Select source and destination palette slots to exchange their color data.`
+- `Palette Swap exchanges palette assignments between entries.\nSelect source and destination palette slots to exchange their color data.`
 - `Source Palette:`
 - `Swap`
 
 ### SupportAttributeForm
-WF labels: **18** · AV labels: **11** · WF-only: **18** · AV-only: **11** · Common: **0**
+WF labels: **18** · AV labels: **11** · WF-only: **18** · AV-only: **11** · Common: **0** · Density verdict: **Medium** (WF 29 / AV 20)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4957,7 +4989,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### EventBattleTalkForm
-WF labels: **17** · AV labels: **2** · WF-only: **17** · AV-only: **2** · Common: **0**
+WF labels: **17** · AV labels: **2** · WF-only: **17** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 30 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -4985,7 +5017,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Battle Dialogue Editor`
 
 ### EventHaikuForm
-WF labels: **17** · AV labels: **2** · WF-only: **17** · AV-only: **2** · Common: **0**
+WF labels: **17** · AV labels: **2** · WF-only: **17** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 28 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5013,7 +5045,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Haiku Event Editor`
 
 ### FE8SpellMenuExtendsForm
-WF labels: **17** · AV labels: **2** · WF-only: **17** · AV-only: **2** · Common: **0**
+WF labels: **17** · AV labels: **2** · WF-only: **17** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 34 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5032,8 +5064,7 @@ WF-only labels (candidates for missing fields in AV):
 - `読込数`
 - `選択アドレス:`
 - `選択クラスの分離独立`
-- `領域が確保されていません。
-「リストの拡張ボタン」を押して領域を確保してください。`
+- `領域が確保されていません。\r\n「リストの拡張ボタン」を押して領域を確保してください。`
 - `魔法`
 
 AV-only labels (usually fine — layout polish or rewording):
@@ -5042,7 +5073,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Spell Menu Extensions`
 
 ### GraphicsToolForm
-WF labels: **17** · AV labels: **12** · WF-only: **17** · AV-only: **12** · Common: **0**
+WF labels: **17** · AV labels: **12** · WF-only: **17** · AV-only: **12** · Common: **0** · Density verdict: **Medium** (WF 33 / AV 18)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5080,7 +5111,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Zoom:`
 
 ### ImagePortraitImporterForm
-WF labels: **17** · AV labels: **2** · WF-only: **17** · AV-only: **2** · Common: **0**
+WF labels: **17** · AV labels: **2** · WF-only: **17** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 42 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5108,7 +5139,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Portrait Import Wizard`
 
 ### ItemStatBonusesSkillSystemsForm
-WF labels: **19** · AV labels: **17** · WF-only: **17** · AV-only: **15** · Common: **2**
+WF labels: **19** · AV labels: **17** · WF-only: **17** · AV-only: **15** · Common: **2** · Density verdict: **Low** (WF 51 / AV 47)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5149,7 +5180,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ItemStatBonusesVennoForm
-WF labels: **18** · AV labels: **14** · WF-only: **17** · AV-only: **13** · Common: **1**
+WF labels: **18** · AV labels: **14** · WF-only: **17** · AV-only: **13** · Common: **1** · Density verdict: **Low** (WF 41 / AV 36)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5188,7 +5219,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ItemWeaponEffectForm
-WF labels: **17** · AV labels: **14** · WF-only: **17** · AV-only: **14** · Common: **0**
+WF labels: **17** · AV labels: **15** · WF-only: **17** · AV-only: **15** · Common: **0** · Density verdict: **Medium** (WF 40 / AV 26)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5214,6 +5245,7 @@ AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
 - `Anim Type:`
+- `Click to open Item Editor`
 - `Damage Effect:`
 - `Effect ID:`
 - `Hit Color:`
@@ -5228,7 +5260,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### MapTileAnimation1Form
-WF labels: **17** · AV labels: **6** · WF-only: **17** · AV-only: **6** · Common: **0**
+WF labels: **17** · AV labels: **6** · WF-only: **17** · AV-only: **6** · Common: **0** · Density verdict: **High** (WF 25 / AV 10)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5260,7 +5292,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### SkillAssignmentUnitCSkillSysForm
-WF labels: **17** · AV labels: **5** · WF-only: **17** · AV-only: **5** · Common: **0**
+WF labels: **17** · AV labels: **5** · WF-only: **17** · AV-only: **5** · Common: **0** · Density verdict: **High** (WF 35 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5280,22 +5312,18 @@ WF-only labels (candidates for missing fields in AV):
 - `読込数`
 - `選択アドレス:`
 - `選択クラスの分離独立`
-- `領域が確保されていません。
-「リストの拡張ボタン」を押して領域を確保してください。`
+- `領域が確保されていません。\r\n「リストの拡張ボタン」を押して領域を確保してください。`
 
 AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
 - `Skill Assignment - Unit (CSkillSys)`
-- `Skill system editors require a compatible skill patch to be installed.
-Use the Patch Manager to install a skill system patch first.
-
-Supported skill systems: CSkillSys, FE8N Skill System`
+- `Skill system editors require a compatible skill patch to be installed.\nUse the Patch Manager to install a skill system patch first.\n\nSupported skill systems: CSkillSys, FE8N Skill System`
 - `Unit Skill:`
 - `Write`
 
 ### SkillAssignmentUnitSkillSystemForm
-WF labels: **17** · AV labels: **5** · WF-only: **17** · AV-only: **5** · Common: **0**
+WF labels: **17** · AV labels: **5** · WF-only: **17** · AV-only: **5** · Common: **0** · Density verdict: **High** (WF 35 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5315,8 +5343,7 @@ WF-only labels (candidates for missing fields in AV):
 - `読込数`
 - `選択アドレス:`
 - `選択クラスの分離独立`
-- `領域が確保されていません。
-「リストの拡張ボタン」を押して領域を確保してください。`
+- `領域が確保されていません。\r\n「リストの拡張ボタン」を押して領域を確保してください。`
 
 AV-only labels (usually fine — layout polish or rewording):
 
@@ -5327,7 +5354,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### TextCharCodeForm
-WF labels: **17** · AV labels: **8** · WF-only: **17** · AV-only: **8** · Common: **0**
+WF labels: **17** · AV labels: **8** · WF-only: **17** · AV-only: **8** · Common: **0** · Density verdict: **Medium** (WF 24 / AV 16)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5361,7 +5388,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Terminator (FFFF):`
 
 ### ToolProblemReportForm
-WF labels: **17** · AV labels: **2** · WF-only: **17** · AV-only: **2** · Common: **0**
+WF labels: **17** · AV labels: **2** · WF-only: **17** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 20 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5389,7 +5416,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Problem Reporter`
 
 ### UnitCustomBattleAnimeForm
-WF labels: **17** · AV labels: **6** · WF-only: **17** · AV-only: **6** · Common: **0**
+WF labels: **17** · AV labels: **6** · WF-only: **17** · AV-only: **6** · Common: **0** · Density verdict: **High** (WF 31 / AV 10)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5421,7 +5448,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### WorldMapEventPointerForm
-WF labels: **17** · AV labels: **4** · WF-only: **17** · AV-only: **4** · Common: **0**
+WF labels: **17** · AV labels: **4** · WF-only: **17** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 39 / AV 6)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5451,7 +5478,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### EventHaikuFE7Form
-WF labels: **16** · AV labels: **2** · WF-only: **16** · AV-only: **2** · Common: **0**
+WF labels: **16** · AV labels: **2** · WF-only: **16** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 60 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5478,7 +5505,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Haiku (FE7)`
 
 ### ItemUsagePointerForm
-WF labels: **16** · AV labels: **5** · WF-only: **16** · AV-only: **5** · Common: **0**
+WF labels: **16** · AV labels: **5** · WF-only: **16** · AV-only: **5** · Common: **0** · Density verdict: **High** (WF 23 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5508,7 +5535,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### MainSimpleMenuImageSubForm
-WF labels: **16** · AV labels: **2** · WF-only: **16** · AV-only: **2** · Common: **0**
+WF labels: **16** · AV labels: **2** · WF-only: **16** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 16 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5535,7 +5562,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Image Sub-Menu`
 
 ### MapEditorForm
-WF labels: **16** · AV labels: **10** · WF-only: **16** · AV-only: **10** · Common: **0**
+WF labels: **16** · AV labels: **10** · WF-only: **16** · AV-only: **10** · Common: **0** · Density verdict: **Medium** (WF 23 / AV 12)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5570,7 +5597,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Zoom:`
 
 ### StatusRMenuForm
-WF labels: **16** · AV labels: **12** · WF-only: **16** · AV-only: **12** · Common: **0**
+WF labels: **16** · AV labels: **12** · WF-only: **16** · AV-only: **12** · Common: **0** · Density verdict: **Low** (WF 28 / AV 23)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5607,7 +5634,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Y Position:`
 
 ### SupportTalkFE7Form
-WF labels: **16** · AV labels: **13** · WF-only: **16** · AV-only: **13** · Common: **0**
+WF labels: **16** · AV labels: **13** · WF-only: **16** · AV-only: **13** · Common: **0** · Density verdict: **Medium** (WF 34 / AV 25)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5645,7 +5672,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### SupportTalkForm
-WF labels: **16** · AV labels: **12** · WF-only: **16** · AV-only: **12** · Common: **0**
+WF labels: **16** · AV labels: **12** · WF-only: **16** · AV-only: **12** · Common: **0** · Density verdict: **Medium** (WF 32 / AV 23)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5682,7 +5709,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### TextDicForm
-WF labels: **16** · AV labels: **14** · WF-only: **16** · AV-only: **14** · Common: **0**
+WF labels: **16** · AV labels: **16** · WF-only: **16** · AV-only: **16** · Common: **0** · Density verdict: **High** (WF 60 / AV 27)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5709,6 +5736,8 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Chapter Index:`
 - `Class:`
 - `Class ID:`
+- `Click to open Class Editor`
+- `Click to open Unit Editor`
 - `Flag 1:`
 - `Flag 2:`
 - `Preview:`
@@ -5721,7 +5750,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### EventHaikuFE6Form
-WF labels: **15** · AV labels: **2** · WF-only: **15** · AV-only: **2** · Common: **0**
+WF labels: **15** · AV labels: **2** · WF-only: **15** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 34 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5747,7 +5776,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Haiku (FE6)`
 
 ### ImageTSAAnimeForm
-WF labels: **15** · AV labels: **6** · WF-only: **15** · AV-only: **6** · Common: **0**
+WF labels: **15** · AV labels: **6** · WF-only: **15** · AV-only: **6** · Common: **0** · Density verdict: **High** (WF 22 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5777,7 +5806,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `TSA Animation Editor`
 
 ### ItemEffectivenessForm
-WF labels: **15** · AV labels: **5** · WF-only: **15** · AV-only: **5** · Common: **0**
+WF labels: **15** · AV labels: **6** · WF-only: **15** · AV-only: **6** · Common: **0** · Density verdict: **High** (WF 19 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5801,12 +5830,13 @@ AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
 - `Class ID:`
+- `Click to open Class Editor`
 - `Item Effectiveness Editor`
 - `Weapon effectiveness 2x/3x class list (FE8 only)`
 - `Write`
 
 ### ItemEffectivenessSkillSystemsReworkForm
-WF labels: **15** · AV labels: **2** · WF-only: **15** · AV-only: **2** · Common: **0**
+WF labels: **15** · AV labels: **2** · WF-only: **15** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 21 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5832,13 +5862,12 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Effectiveness (Skill Systems Rework)`
 
 ### MonsterWMapProbabilityForm
-WF labels: **15** · AV labels: **4** · WF-only: **15** · AV-only: **4** · Common: **0**
+WF labels: **15** · AV labels: **4** · WF-only: **15** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 66 / AV 6)
 
 WF-only labels (candidates for missing fields in AV):
 
 - `Size:`
-- `それぞれのルートでクリアする章を指定します。
-これは、まだクリアしていない拠点には魔物を出せないためです。`
+- `それぞれのルートでクリアする章を指定します。\r\nこれは、まだクリアしていない拠点には魔物を出せないためです。`
 - `アドレス`
 - `フリーマップ終了イベント`
 - `フリーマップ開始イベント`
@@ -5861,7 +5890,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### SupportTalkFE6Form
-WF labels: **15** · AV labels: **11** · WF-only: **15** · AV-only: **11** · Common: **0**
+WF labels: **15** · AV labels: **11** · WF-only: **15** · AV-only: **11** · Common: **0** · Density verdict: **Low** (WF 26 / AV 21)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5896,7 +5925,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### UnitPaletteForm
-WF labels: **15** · AV labels: **10** · WF-only: **15** · AV-only: **10** · Common: **0**
+WF labels: **15** · AV labels: **10** · WF-only: **15** · AV-only: **10** · Common: **0** · Density verdict: **High** (WF 50 / AV 18)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5930,7 +5959,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### EventBattleTalkFE6Form
-WF labels: **14** · AV labels: **2** · WF-only: **14** · AV-only: **2** · Common: **0**
+WF labels: **14** · AV labels: **2** · WF-only: **14** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 61 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5955,7 +5984,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Battle Dialogue (FE6)`
 
 ### EventForceSortieFE7Form
-WF labels: **14** · AV labels: **8** · WF-only: **14** · AV-only: **8** · Common: **0**
+WF labels: **14** · AV labels: **8** · WF-only: **14** · AV-only: **8** · Common: **0** · Density verdict: **Medium** (WF 24 / AV 14)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -5986,7 +6015,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### FontForm
-WF labels: **14** · AV labels: **2** · WF-only: **14** · AV-only: **2** · Common: **0**
+WF labels: **14** · AV labels: **2** · WF-only: **14** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 21 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6011,7 +6040,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Font Editor`
 
 ### OPPrologueForm
-WF labels: **14** · AV labels: **10** · WF-only: **14** · AV-only: **10** · Common: **0**
+WF labels: **14** · AV labels: **10** · WF-only: **14** · AV-only: **10** · Common: **0** · Density verdict: **Medium** (WF 26 / AV 14)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6044,7 +6073,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### SongTrackImportWaveForm
-WF labels: **14** · AV labels: **2** · WF-only: **14** · AV-only: **2** · Common: **0**
+WF labels: **14** · AV labels: **2** · WF-only: **14** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 23 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6052,8 +6081,7 @@ WF-only labels (candidates for missing fields in AV):
 - `DPCM圧縮`
 - `m4a_hq_mixer Patchがインストールされていないので、DPCM圧縮は利用できません。`
 - `Preview`
-- `Waveファイルは効果音に使うことを想定しています。
-それを、音楽に利用すると、大量に容量を消費しますが、インポートしてもよろしいですか？`
+- `Waveファイルは効果音に使うことを想定しています。\r\nそれを、音楽に利用すると、大量に容量を消費しますが、インポートしてもよろしいですか？`
 - `インポートする`
 - `キャンセル`
 - `チャンネル`
@@ -6070,7 +6098,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Wave Track Import`
 
 ### SoundRoomForm
-WF labels: **14** · AV labels: **8** · WF-only: **14** · AV-only: **8** · Common: **0**
+WF labels: **14** · AV labels: **9** · WF-only: **14** · AV-only: **9** · Common: **0** · Density verdict: **Medium** (WF 22 / AV 14)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6092,6 +6120,7 @@ WF-only labels (candidates for missing fields in AV):
 AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
+- `Click to open Song Table`
 - `Display Cond ASM:`
 - `Jump`
 - `Song ID:`
@@ -6101,7 +6130,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### StatusParamForm
-WF labels: **15** · AV labels: **11** · WF-only: **14** · AV-only: **10** · Common: **1**
+WF labels: **15** · AV labels: **11** · WF-only: **14** · AV-only: **10** · Common: **1** · Density verdict: **Low** (WF 27 / AV 21)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6134,7 +6163,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### WorldMapPathForm
-WF labels: **14** · AV labels: **10** · WF-only: **14** · AV-only: **10** · Common: **0**
+WF labels: **14** · AV labels: **10** · WF-only: **14** · AV-only: **10** · Common: **0** · Density verdict: **Medium** (WF 24 / AV 17)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6167,7 +6196,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### WorldMapPathForm
-WF labels: **14** · AV labels: **2** · WF-only: **14** · AV-only: **2** · Common: **0**
+WF labels: **14** · AV labels: **2** · WF-only: **14** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 24 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6192,13 +6221,12 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Path Editor`
 
 ### AIPerformItemForm
-WF labels: **13** · AV labels: **7** · WF-only: **13** · AV-only: **7** · Common: **0**
+WF labels: **13** · AV labels: **7** · WF-only: **13** · AV-only: **7** · Common: **0** · Density verdict: **Medium** (WF 19 / AV 11)
 
 WF-only labels (candidates for missing fields in AV):
 
 - `00`
-- `AIがアイテムを使用するかどうか判定する関数を指定します。
-なお、章ごとにアイテムを使えるかどうかの設定は、「AIの章ごとの設定」にあります。`
+- `AIがアイテムを使用するかどうか判定する関数を指定します。\r\nなお、章ごとにアイテムを使えるかどうかの設定は、「AIの章ごとの設定」にあります。`
 - `ASM`
 - `Size:`
 - `アイテム`
@@ -6222,7 +6250,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### AIPerformStaffForm
-WF labels: **13** · AV labels: **7** · WF-only: **13** · AV-only: **7** · Common: **0**
+WF labels: **13** · AV labels: **7** · WF-only: **13** · AV-only: **7** · Common: **0** · Density verdict: **Medium** (WF 19 / AV 11)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6251,13 +6279,11 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### CCBranchForm
-WF labels: **13** · AV labels: **6** · WF-only: **13** · AV-only: **6** · Common: **0**
+WF labels: **13** · AV labels: **6** · WF-only: **13** · AV-only: **6** · Common: **0** · Density verdict: **High** (WF 25 / AV 12)
 
 WF-only labels (candidates for missing fields in AV):
 
-- `CC3分岐パッチよって追加された値です。
-上の2つの同じであれば無視されます。
-この値は、クラスデータの「クラスチェンジ」に保存されます。`
+- `CC3分岐パッチよって追加された値です。\r\n上の2つの同じであれば無視されます。\r\nこの値は、クラスデータの「クラスチェンジ」に保存されます。`
 - `CC時に表示されるクラスの英語表記へJump`
 - `Size:`
 - `この値を0にしないでください`
@@ -6281,7 +6307,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### EDSensekiCommentForm
-WF labels: **13** · AV labels: **7** · WF-only: **13** · AV-only: **7** · Common: **0**
+WF labels: **13** · AV labels: **8** · WF-only: **13** · AV-only: **8** · Common: **0** · Density verdict: **Medium** (WF 20 / AV 12)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6302,6 +6328,7 @@ WF-only labels (candidates for missing fields in AV):
 AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
+- `Click to open Unit Editor`
 - `Conversation Text 1:`
 - `Conversation Text 2:`
 - `Conversation Text 3:`
@@ -6310,7 +6337,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### EventBattleDataFE7Form
-WF labels: **13** · AV labels: **2** · WF-only: **13** · AV-only: **2** · Common: **0**
+WF labels: **13** · AV labels: **2** · WF-only: **13** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 21 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6334,7 +6361,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Battle Data (FE7)`
 
 ### FontZHForm
-WF labels: **13** · AV labels: **2** · WF-only: **13** · AV-only: **2** · Common: **0**
+WF labels: **13** · AV labels: **2** · WF-only: **13** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 17 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6358,7 +6385,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Font Editor (Chinese)`
 
 ### ImageGenericEnemyPortraitForm
-WF labels: **13** · AV labels: **3** · WF-only: **13** · AV-only: **3** · Common: **0**
+WF labels: **13** · AV labels: **3** · WF-only: **13** · AV-only: **3** · Common: **0** · Density verdict: **High** (WF 18 / AV 5)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6383,7 +6410,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Image Pointer:`
 
 ### ImageTSAAnime2Form
-WF labels: **13** · AV labels: **9** · WF-only: **13** · AV-only: **9** · Common: **0**
+WF labels: **13** · AV labels: **9** · WF-only: **13** · AV-only: **9** · Common: **0** · Density verdict: **High** (WF 38 / AV 15)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6414,7 +6441,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ItemWeaponTriangleForm
-WF labels: **13** · AV labels: **8** · WF-only: **13** · AV-only: **8** · Common: **0**
+WF labels: **13** · AV labels: **8** · WF-only: **13** · AV-only: **8** · Common: **0** · Density verdict: **Medium** (WF 22 / AV 13)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6443,8 +6470,34 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Weapon Type 2:`
 - `Write`
 
+### MapStyleEditorAppendPopupForm
+WF labels: **13** · AV labels: **4** · WF-only: **13** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 19 / AV 4)
+
+WF-only labels (candidates for missing fields in AV):
+
+- `(FE7のみ)`
+- `MapPointer(PLIST)を拡張`
+- `OK`
+- `PLIST拡張`
+- `オブジェクトタイプ`
+- `オブジェクトタイプ2`
+- `キャンセル`
+- `タイルアニメーション1`
+- `タイルアニメーション2`
+- `チップセットクタイプ`
+- `パレット`
+- `マップのデザインを新規に定義するには、PLSITでスタイルを割り当てます。\nPLISTはマップ関係のデータへのポインタが格納されているリストです。\n(注意してください。間違ったPLISTを割り当てると危険です。バックアップを取った後でやることをお勧めします。)\n\n全く新しいデザインを割り当てたいときは、PLIST拡張をしたあとで未使用のPLISTを割り当ててください。\nその後でマップスタ… (truncated; see designer file)`
+- `既に拡張済みです`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Append`
+- `Append Map Style`
+- `Cancel`
+- `Do you want to append a new map style entry? This will add a new tileset configuration at the end of the list.`
+
 ### SoundBossBGMForm
-WF labels: **13** · AV labels: **10** · WF-only: **13** · AV-only: **10** · Common: **0**
+WF labels: **13** · AV labels: **13** · WF-only: **13** · AV-only: **13** · Common: **0** · Density verdict: **Low** (WF 20 / AV 17)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6466,7 +6519,10 @@ AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
 - `Boss BGM Editor`
+- `Click to open Song Table`
+- `Click to open Unit Editor`
 - `Jump`
+- `Pick unit from editor`
 - `Pick...`
 - `Song ID:`
 - `Unit ID:`
@@ -6476,7 +6532,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### SoundRoomFE6Form
-WF labels: **13** · AV labels: **6** · WF-only: **13** · AV-only: **6** · Common: **0**
+WF labels: **13** · AV labels: **6** · WF-only: **13** · AV-only: **6** · Common: **0** · Density verdict: **Medium** (WF 20 / AV 12)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6504,7 +6560,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### WorldMapBGMForm
-WF labels: **13** · AV labels: **6** · WF-only: **13** · AV-only: **6** · Common: **0**
+WF labels: **13** · AV labels: **6** · WF-only: **13** · AV-only: **6** · Common: **0** · Density verdict: **Medium** (WF 19 / AV 10)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6532,7 +6588,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### WorldMapEventPointerFE7Form
-WF labels: **13** · AV labels: **2** · WF-only: **13** · AV-only: **2** · Common: **0**
+WF labels: **13** · AV labels: **2** · WF-only: **13** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 20 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6556,7 +6612,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Event Pointer (FE7)`
 
 ### WorldMapImageFE7Form
-WF labels: **13** · AV labels: **2** · WF-only: **13** · AV-only: **2** · Common: **0**
+WF labels: **13** · AV labels: **2** · WF-only: **13** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 23 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6580,7 +6636,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `World Map Image (FE7)`
 
 ### AIStealItemForm
-WF labels: **12** · AV labels: **6** · WF-only: **12** · AV-only: **6** · Common: **0**
+WF labels: **12** · AV labels: **6** · WF-only: **12** · AV-only: **6** · Common: **0** · Density verdict: **Medium** (WF 17 / AV 9)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6593,8 +6649,7 @@ WF-only labels (candidates for missing fields in AV):
 - `再取得`
 - `名前`
 - `書き込み`
-- `盗賊AIが、アイテムを盗むときに利用する、アイテムの優先度を設定します。
-リストの先頭がもっとも優先度が高いアイテムになります。`
+- `盗賊AIが、アイテムを盗むときに利用する、アイテムの優先度を設定します。\r\nリストの先頭がもっとも優先度が高いアイテムになります。`
 - `読込数`
 - `選択アドレス:`
 
@@ -6608,7 +6663,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ArenaClassForm
-WF labels: **12** · AV labels: **4** · WF-only: **12** · AV-only: **4** · Common: **0**
+WF labels: **12** · AV labels: **5** · WF-only: **12** · AV-only: **5** · Common: **0** · Density verdict: **High** (WF 17 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6616,9 +6671,7 @@ WF-only labels (candidates for missing fields in AV):
 - `アドレス`
 - `クラス`
 - `リストの拡張`
-- `上級職、下級職は自動で調整されます。
-闘技場で敵として使用されるユニットは、0xFD 対戦相手です。
-ほかのユニットが出ることはないようです。`
+- `上級職、下級職は自動で調整されます。\r\n闘技場で敵として使用されるユニットは、0xFD 対戦相手です。\r\nほかのユニットが出ることはないようです。`
 - `先頭アドレス`
 - `再取得`
 - `名前`
@@ -6632,10 +6685,11 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Address:`
 - `Arena Class Editor`
 - `Class ID:`
+- `Click to open Class Editor`
 - `Write`
 
 ### BigCGForm
-WF labels: **12** · AV labels: **10** · WF-only: **12** · AV-only: **10** · Common: **0**
+WF labels: **12** · AV labels: **10** · WF-only: **12** · AV-only: **10** · Common: **0** · Density verdict: **Medium** (WF 20 / AV 14)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6666,7 +6720,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### DecreaseColorTSAToolForm
-WF labels: **12** · AV labels: **2** · WF-only: **12** · AV-only: **2** · Common: **0**
+WF labels: **12** · AV labels: **2** · WF-only: **12** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 20 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6689,7 +6743,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Color Reduction Tool`
 
 ### EDFE6Form
-WF labels: **12** · AV labels: **2** · WF-only: **12** · AV-only: **2** · Common: **0**
+WF labels: **12** · AV labels: **2** · WF-only: **12** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 19 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6712,7 +6766,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `ED (FE6)`
 
 ### EDStaffRollForm
-WF labels: **12** · AV labels: **5** · WF-only: **12** · AV-only: **5** · Common: **0**
+WF labels: **12** · AV labels: **5** · WF-only: **12** · AV-only: **5** · Common: **0** · Density verdict: **High** (WF 17 / AV 8)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6738,7 +6792,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### EventForceSortieForm
-WF labels: **12** · AV labels: **6** · WF-only: **12** · AV-only: **6** · Common: **0**
+WF labels: **12** · AV labels: **6** · WF-only: **12** · AV-only: **6** · Common: **0** · Density verdict: **Medium** (WF 19 / AV 10)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6765,7 +6819,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ImageChapterTitleFE7Form
-WF labels: **12** · AV labels: **7** · WF-only: **12** · AV-only: **7** · Common: **0**
+WF labels: **12** · AV labels: **7** · WF-only: **12** · AV-only: **7** · Common: **0** · Density verdict: **Medium** (WF 16 / AV 9)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6793,7 +6847,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ImageRomAnimeForm
-WF labels: **12** · AV labels: **2** · WF-only: **12** · AV-only: **2** · Common: **0**
+WF labels: **12** · AV labels: **2** · WF-only: **12** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 14 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6816,7 +6870,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `ROM Animation Viewer`
 
 ### ItemPromotionForm
-WF labels: **12** · AV labels: **5** · WF-only: **12** · AV-only: **5** · Common: **0**
+WF labels: **12** · AV labels: **6** · WF-only: **12** · AV-only: **6** · Common: **0** · Density verdict: **High** (WF 16 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6836,13 +6890,14 @@ WF-only labels (candidates for missing fields in AV):
 AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
+- `Click to open Class Editor`
 - `Item Promotion Editor`
 - `Promotion target class per source class`
 - `Target Class ID:`
 - `Write`
 
 ### ItemShopForm
-WF labels: **12** · AV labels: **6** · WF-only: **12** · AV-only: **6** · Common: **0**
+WF labels: **12** · AV labels: **7** · WF-only: **12** · AV-only: **7** · Common: **0** · Density verdict: **Medium** (WF 17 / AV 9)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6862,6 +6917,7 @@ WF-only labels (candidates for missing fields in AV):
 AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
+- `Click to open Item Editor`
 - `Item ID:`
 - `Item Shop Editor`
 - `Preparation shop item list`
@@ -6869,13 +6925,12 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### MantAnimationForm
-WF labels: **12** · AV labels: **2** · WF-only: **12** · AV-only: **2** · Common: **0**
+WF labels: **12** · AV labels: **2** · WF-only: **12** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 17 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
 - `Size:`
-- `よくわからなければ、この設定を変更しないでください。
-バグの原因になります。`
+- `よくわからなければ、この設定を変更しないでください。\r\nバグの原因になります。`
 - `アドレス`
 - `マント設定`
 - `リストの拡張`
@@ -6892,33 +6947,8 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Address:`
 - `Mant Animation`
 
-### MapStyleEditorAppendPopupForm
-WF labels: **12** · AV labels: **4** · WF-only: **12** · AV-only: **4** · Common: **0**
-
-WF-only labels (candidates for missing fields in AV):
-
-- `(FE7のみ)`
-- `MapPointer(PLIST)を拡張`
-- `OK`
-- `PLIST拡張`
-- `オブジェクトタイプ`
-- `オブジェクトタイプ2`
-- `キャンセル`
-- `タイルアニメーション1`
-- `タイルアニメーション2`
-- `チップセットクタイプ`
-- `パレット`
-- `既に拡張済みです`
-
-AV-only labels (usually fine — layout polish or rewording):
-
-- `Append`
-- `Append Map Style`
-- `Cancel`
-- `Do you want to append a new map style entry? This will add a new tileset configuration at the end of the list.`
-
 ### MenuExtendSplitMenuForm
-WF labels: **14** · AV labels: **15** · WF-only: **12** · AV-only: **13** · Common: **2**
+WF labels: **14** · AV labels: **15** · WF-only: **12** · AV-only: **13** · Common: **2** · Density verdict: **Low** (WF 27 / AV 28)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6952,7 +6982,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Y Position:`
 
 ### OPClassFontFE8UForm
-WF labels: **12** · AV labels: **4** · WF-only: **12** · AV-only: **4** · Common: **0**
+WF labels: **12** · AV labels: **4** · WF-only: **12** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 16 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -6977,7 +7007,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### OPClassFontForm
-WF labels: **12** · AV labels: **5** · WF-only: **12** · AV-only: **5** · Common: **0**
+WF labels: **12** · AV labels: **5** · WF-only: **12** · AV-only: **5** · Common: **0** · Density verdict: **High** (WF 16 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7003,7 +7033,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### StatusUnitsMenuForm
-WF labels: **12** · AV labels: **7** · WF-only: **12** · AV-only: **7** · Common: **0**
+WF labels: **12** · AV labels: **7** · WF-only: **12** · AV-only: **7** · Common: **0** · Density verdict: **Medium** (WF 19 / AV 14)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7031,7 +7061,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ToolExportEAEventForm
-WF labels: **12** · AV labels: **14** · WF-only: **12** · AV-only: **14** · Common: **0**
+WF labels: **12** · AV labels: **14** · WF-only: **12** · AV-only: **14** · Common: **0** · Density verdict: **Medium** (WF 12 / AV 16)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7066,7 +7096,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Undo Buffer`
 
 ### WorldMapPathMoveEditorForm
-WF labels: **12** · AV labels: **7** · WF-only: **12** · AV-only: **7** · Common: **0**
+WF labels: **12** · AV labels: **7** · WF-only: **12** · AV-only: **7** · Common: **0** · Density verdict: **Medium** (WF 20 / AV 11)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7089,12 +7119,12 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Coordinate X:`
 - `Coordinate Y:`
 - `Elapsed Time:`
-- `Elapsed Time controls how long the unit pauses at this node. Lower values = longer pause. Total movement uses 4096 time units. Sum of all elapsed times across nodes must be <= 4095, otherwise instant movement occurs.`
+- `Elapsed Time controls how long the unit pauses at this node. Lower values = longer pause. Total movement uses 4096 time units. Sum of all elapsed times across nodes must be <= 4095, otherwise instant … (truncated; see designer file)`
 - `Path Movement Editor`
 - `Write`
 
 ### AIUnitsForm
-WF labels: **11** · AV labels: **5** · WF-only: **11** · AV-only: **5** · Common: **0**
+WF labels: **11** · AV labels: **5** · WF-only: **11** · AV-only: **5** · Common: **0** · Density verdict: **High** (WF 16 / AV 8)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7119,7 +7149,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### EventFinalSerifFE7Form
-WF labels: **11** · AV labels: **2** · WF-only: **11** · AV-only: **2** · Common: **0**
+WF labels: **11** · AV labels: **2** · WF-only: **11** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 16 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7141,7 +7171,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Final Serif (FE7)`
 
 ### EventMoveDataFE7Form
-WF labels: **11** · AV labels: **5** · WF-only: **11** · AV-only: **5** · Common: **0**
+WF labels: **11** · AV labels: **5** · WF-only: **11** · AV-only: **5** · Common: **0** · Density verdict: **High** (WF 17 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7166,7 +7196,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### EventTemplate2Form
-WF labels: **11** · AV labels: **2** · WF-only: **11** · AV-only: **2** · Common: **0**
+WF labels: **11** · AV labels: **2** · WF-only: **11** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 12 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7188,7 +7218,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Event Template 2`
 
 ### EventTemplate3Form
-WF labels: **11** · AV labels: **2** · WF-only: **11** · AV-only: **2** · Common: **0**
+WF labels: **11** · AV labels: **2** · WF-only: **11** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 12 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7210,7 +7240,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Event Template 3`
 
 ### ExtraUnitFE8UForm
-WF labels: **11** · AV labels: **5** · WF-only: **11** · AV-only: **5** · Common: **0**
+WF labels: **11** · AV labels: **5** · WF-only: **11** · AV-only: **5** · Common: **0** · Density verdict: **High** (WF 16 / AV 8)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7235,7 +7265,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ItemRandomChestForm
-WF labels: **11** · AV labels: **5** · WF-only: **11** · AV-only: **5** · Common: **0**
+WF labels: **11** · AV labels: **6** · WF-only: **11** · AV-only: **6** · Common: **0** · Density verdict: **High** (WF 16 / AV 8)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7254,13 +7284,14 @@ WF-only labels (candidates for missing fields in AV):
 AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
+- `Click to open Item Editor`
 - `Item:`
 - `Probability %:`
 - `Random Chest Items`
 - `Write`
 
 ### MapLoadFunctionForm
-WF labels: **11** · AV labels: **6** · WF-only: **11** · AV-only: **6** · Common: **0**
+WF labels: **11** · AV labels: **6** · WF-only: **11** · AV-only: **6** · Common: **0** · Density verdict: **Medium** (WF 17 / AV 9)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7286,7 +7317,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### MapPointerForm
-WF labels: **11** · AV labels: **4** · WF-only: **11** · AV-only: **4** · Common: **0**
+WF labels: **11** · AV labels: **4** · WF-only: **11** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 16 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7310,7 +7341,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### MapTerrainBGLookupTableForm
-WF labels: **11** · AV labels: **4** · WF-only: **11** · AV-only: **4** · Common: **0**
+WF labels: **11** · AV labels: **4** · WF-only: **11** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 16 / AV 6)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7320,8 +7351,7 @@ WF-only labels (candidates for missing fields in AV):
 - `再取得`
 - `名前`
 - `戦闘アニメの床へJump`
-- `拡張された領域にデータが割り当てられていません。
-パッチ「戦闘床地形と戦闘背景のリストを拡張する」から、データを割り振ってください。`
+- `拡張された領域にデータが割り当てられていません。\r\nパッチ「戦闘床地形と戦闘背景のリストを拡張する」から、データを割り振ってください。`
 - `書き込み`
 - `条件:`
 - `読込数`
@@ -7335,7 +7365,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### MapTerrainFloorLookupTableForm
-WF labels: **11** · AV labels: **4** · WF-only: **11** · AV-only: **4** · Common: **0**
+WF labels: **11** · AV labels: **4** · WF-only: **11** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 16 / AV 6)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7345,8 +7375,7 @@ WF-only labels (candidates for missing fields in AV):
 - `再取得`
 - `名前`
 - `戦闘アニメの背景へJump`
-- `拡張された領域にデータが割り当てられていません。
-パッチ「戦闘床地形と戦闘背景のリストを拡張する」から、データを割り振ってください。`
+- `拡張された領域にデータが割り当てられていません。\r\nパッチ「戦闘床地形と戦闘背景のリストを拡張する」から、データを割り振ってください。`
 - `書き込み`
 - `条件:`
 - `読込数`
@@ -7360,7 +7389,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### OPClassAlphaNameForm
-WF labels: **11** · AV labels: **4** · WF-only: **11** · AV-only: **4** · Common: **0**
+WF labels: **11** · AV labels: **4** · WF-only: **11** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 34 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7384,7 +7413,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### SongInstrumentImportWaveForm
-WF labels: **11** · AV labels: **2** · WF-only: **11** · AV-only: **2** · Common: **0**
+WF labels: **11** · AV labels: **2** · WF-only: **11** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 18 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7406,7 +7435,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Wave Import`
 
 ### SoundFootStepsForm
-WF labels: **11** · AV labels: **4** · WF-only: **11** · AV-only: **4** · Common: **0**
+WF labels: **11** · AV labels: **4** · WF-only: **11** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 16 / AV 6)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7430,7 +7459,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### SummonUnitForm
-WF labels: **11** · AV labels: **5** · WF-only: **11** · AV-only: **5** · Common: **0**
+WF labels: **11** · AV labels: **6** · WF-only: **11** · AV-only: **6** · Common: **0** · Density verdict: **High** (WF 16 / AV 8)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7449,13 +7478,14 @@ WF-only labels (candidates for missing fields in AV):
 AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
+- `Click to open Unit Editor`
 - `Summon Unit Editor`
 - `Summoned Unit:`
 - `Summoner:`
 - `Write`
 
 ### ToolASMInsertForm
-WF labels: **11** · AV labels: **2** · WF-only: **11** · AV-only: **2** · Common: **0**
+WF labels: **11** · AV labels: **2** · WF-only: **11** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 19 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7476,8 +7506,38 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Address:`
 - `ASM Insertion Tool`
 
+### ToolDiffDebugSelectForm
+WF labels: **11** · AV labels: **10** · WF-only: **11** · AV-only: **10** · Common: **0** · Density verdict: **Medium** (WF 11 / AV 15)
+
+WF-only labels (candidates for missing fields in AV):
+
+- `..`
+- `↑最新`
+- `このROMが最後に安定していたROMとして、\r\n相違点を取得する`
+- `より古い↓`
+- `バックアップROMがある場所を追加`
+- `バックアップを利用して、バイナリ比較で問題点を推測するツールです。\n\n正しく動いていた最後のROM(OK ROM)と、その次の世代である正しく動かなくなった最初のROM(NG ROM)、そして現在のROM(CURRENT)から、3点DIFFを取得し、相違点を計算します。\n\n一番最後に正しく動作していたROMはどれでしょうか？\nROM名をダブルクリックすると、そのROMをエミュレータで動作… (truncated; see designer file)`
+- `バックアップ履歴(上が最新) `
+- `探索するprefix`
+- `無改造ROM`
+- `選択されているROM情報`
+- `選択しているROMをエミュレータでテストプレイする`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `...`
+- `Add backup ROM location`
+- `Backup History (newest on top)`
+- `Older ↓`
+- `Search prefix`
+- `Selected ROM Info`
+- `Test play selected ROM in emulator`
+- `Use this ROM as the last stable baseline and get differences`
+- `Vanilla ROM`
+- `↑ Newest`
+
 ### ToolWorkSupportForm
-WF labels: **12** · AV labels: **14** · WF-only: **11** · AV-only: **13** · Common: **1**
+WF labels: **12** · AV labels: **14** · WF-only: **11** · AV-only: **13** · Common: **1** · Density verdict: **Low** (WF 17 / AV 20)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7510,7 +7570,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Work Support`
 
 ### UnitIncreaseHeightForm
-WF labels: **11** · AV labels: **2** · WF-only: **11** · AV-only: **2** · Common: **0**
+WF labels: **11** · AV labels: **2** · WF-only: **11** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 17 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7532,7 +7592,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Unit Height Adjustment`
 
 ### AITilesForm
-WF labels: **10** · AV labels: **4** · WF-only: **10** · AV-only: **4** · Common: **0**
+WF labels: **10** · AV labels: **4** · WF-only: **10** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 14 / AV 6)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7555,7 +7615,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ClassOPFontForm
-WF labels: **10** · AV labels: **2** · WF-only: **10** · AV-only: **2** · Common: **0**
+WF labels: **10** · AV labels: **2** · WF-only: **10** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 16 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7576,7 +7636,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Class OP Font`
 
 ### EventFunctionPointerFE7Form
-WF labels: **10** · AV labels: **5** · WF-only: **10** · AV-only: **5** · Common: **0**
+WF labels: **10** · AV labels: **5** · WF-only: **10** · AV-only: **5** · Common: **0** · Density verdict: **Medium** (WF 15 / AV 8)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7600,7 +7660,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### EventFunctionPointerForm
-WF labels: **10** · AV labels: **4** · WF-only: **10** · AV-only: **4** · Common: **0**
+WF labels: **10** · AV labels: **4** · WF-only: **10** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 15 / AV 6)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7623,7 +7683,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### EventTalkGroupFE7Form
-WF labels: **10** · AV labels: **4** · WF-only: **10** · AV-only: **4** · Common: **0**
+WF labels: **10** · AV labels: **4** · WF-only: **10** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 14 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7646,7 +7706,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### EventTemplate1Form
-WF labels: **10** · AV labels: **2** · WF-only: **10** · AV-only: **2** · Common: **0**
+WF labels: **10** · AV labels: **2** · WF-only: **10** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 11 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7667,7 +7727,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Event Template 1`
 
 ### ExtraUnitForm
-WF labels: **10** · AV labels: **4** · WF-only: **10** · AV-only: **4** · Common: **0**
+WF labels: **10** · AV labels: **4** · WF-only: **10** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 15 / AV 6)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7690,7 +7750,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ImageSystemAreaForm
-WF labels: **13** · AV labels: **8** · WF-only: **10** · AV-only: **5** · Common: **3**
+WF labels: **13** · AV labels: **8** · WF-only: **10** · AV-only: **5** · Common: **3** · Density verdict: **Medium** (WF 22 / AV 13)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7714,7 +7774,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### LinkArenaDenyUnitForm
-WF labels: **10** · AV labels: **4** · WF-only: **10** · AV-only: **4** · Common: **0**
+WF labels: **10** · AV labels: **5** · WF-only: **10** · AV-only: **5** · Common: **0** · Density verdict: **High** (WF 14 / AV 6)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7732,12 +7792,13 @@ WF-only labels (candidates for missing fields in AV):
 AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
+- `Click to open Unit Editor`
 - `Link Arena Deny Unit Editor`
 - `Unit ID:`
 - `Write`
 
 ### SMEPromoListForm
-WF labels: **11** · AV labels: **9** · WF-only: **10** · AV-only: **8** · Common: **1**
+WF labels: **11** · AV labels: **9** · WF-only: **10** · AV-only: **8** · Common: **1** · Density verdict: **Medium** (WF 16 / AV 20)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7764,7 +7825,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### SomeClassListForm
-WF labels: **10** · AV labels: **5** · WF-only: **10** · AV-only: **5** · Common: **0**
+WF labels: **10** · AV labels: **5** · WF-only: **10** · AV-only: **5** · Common: **0** · Density verdict: **Medium** (WF 14 / AV 8)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7788,7 +7849,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### StatusOptionOrderForm
-WF labels: **10** · AV labels: **4** · WF-only: **10** · AV-only: **4** · Common: **0**
+WF labels: **10** · AV labels: **4** · WF-only: **10** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 14 / AV 6)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7810,38 +7871,8 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Status Option Order Editor`
 - `Write`
 
-### ToolDiffDebugSelectForm
-WF labels: **10** · AV labels: **10** · WF-only: **10** · AV-only: **10** · Common: **0**
-
-WF-only labels (candidates for missing fields in AV):
-
-- `..`
-- `↑最新`
-- `このROMが最後に安定していたROMとして、
-相違点を取得する`
-- `より古い↓`
-- `バックアップROMがある場所を追加`
-- `バックアップ履歴(上が最新) `
-- `探索するprefix`
-- `無改造ROM`
-- `選択されているROM情報`
-- `選択しているROMをエミュレータでテストプレイする`
-
-AV-only labels (usually fine — layout polish or rewording):
-
-- `...`
-- `Add backup ROM location`
-- `Backup History (newest on top)`
-- `Older ↓`
-- `Search prefix`
-- `Selected ROM Info`
-- `Test play selected ROM in emulator`
-- `Use this ROM as the last stable baseline and get differences`
-- `Vanilla ROM`
-- `↑ Newest`
-
 ### ToolROMRebuildForm
-WF labels: **10** · AV labels: **2** · WF-only: **10** · AV-only: **2** · Common: **0**
+WF labels: **10** · AV labels: **2** · WF-only: **10** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 17 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7862,7 +7893,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `ROM Rebuild Tool`
 
 ### UnitActionPointerForm
-WF labels: **10** · AV labels: **2** · WF-only: **10** · AV-only: **2** · Common: **0**
+WF labels: **10** · AV labels: **2** · WF-only: **10** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 14 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7883,7 +7914,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Unit Action Pointers`
 
 ### WelcomeForm
-WF labels: **10** · AV labels: **8** · WF-only: **10** · AV-only: **8** · Common: **0**
+WF labels: **10** · AV labels: **8** · WF-only: **10** · AV-only: **8** · Common: **0** · Density verdict: **Medium** (WF 13 / AV 9)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7910,7 +7941,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Recent Files`
 
 ### WorldMapEventPointerFE6Form
-WF labels: **10** · AV labels: **2** · WF-only: **10** · AV-only: **2** · Common: **0**
+WF labels: **10** · AV labels: **2** · WF-only: **10** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 14 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7931,7 +7962,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Event Pointer (FE6)`
 
 ### WorldMapImageFE6Form
-WF labels: **10** · AV labels: **2** · WF-only: **10** · AV-only: **2** · Common: **0**
+WF labels: **10** · AV labels: **2** · WF-only: **10** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 36 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7952,7 +7983,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `World Map Image (FE6)`
 
 ### AIMapSettingForm
-WF labels: **9** · AV labels: **7** · WF-only: **9** · AV-only: **7** · Common: **0**
+WF labels: **9** · AV labels: **7** · WF-only: **9** · AV-only: **7** · Common: **0** · Density verdict: **High** (WF 48 / AV 12)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -7962,8 +7993,7 @@ WF-only labels (candidates for missing fields in AV):
 - `再取得`
 - `名前`
 - `書き込み`
-- `章ごとにAIが実行できる行動を定義します。
-例えば、扉の鍵をドロップするAIがいるのに、敵AIが扉の鍵を利用可能にすると、敵は勝手に扉を開けてしまいます。`
+- `章ごとにAIが実行できる行動を定義します。\r\n例えば、扉の鍵をドロップするAIがいるのに、敵AIが扉の鍵を利用可能にすると、敵は勝手に扉を開けてしまいます。`
 - `読込数`
 - `選択アドレス:`
 
@@ -7978,13 +8008,11 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### AOERANGEForm
-WF labels: **9** · AV labels: **8** · WF-only: **9** · AV-only: **8** · Common: **0**
+WF labels: **9** · AV labels: **8** · WF-only: **9** · AV-only: **8** · Common: **0** · Density verdict: **Low** (WF 15 / AV 13)
 
 WF-only labels (candidates for missing fields in AV):
 
-- `AoE攻撃の範囲を指定します。
-中心点は、攻撃が炸裂する中心点です。
-攻撃するマスを1に、それ以外を0に指定してください。`
+- `AoE攻撃の範囲を指定します。\r\n中心点は、攻撃が炸裂する中心点です。\r\n攻撃するマスを1に、それ以外を0に指定してください。`
 - `中心点`
 - `中心点X`
 - `中心点Y`
@@ -8006,7 +8034,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ArenaEnemyWeaponForm
-WF labels: **9** · AV labels: **4** · WF-only: **9** · AV-only: **4** · Common: **0**
+WF labels: **9** · AV labels: **4** · WF-only: **9** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 28 / AV 6)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8028,7 +8056,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### Command85PointerForm
-WF labels: **9** · AV labels: **2** · WF-only: **9** · AV-only: **2** · Common: **0**
+WF labels: **9** · AV labels: **2** · WF-only: **9** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 13 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8048,7 +8076,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Command 0x85 Pointer`
 
 ### DisASMDumpAllForm
-WF labels: **9** · AV labels: **12** · WF-only: **9** · AV-only: **12** · Common: **0**
+WF labels: **9** · AV labels: **12** · WF-only: **9** · AV-only: **12** · Common: **0** · Density verdict: **High** (WF 9 / AV 14)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8056,10 +8084,8 @@ WF-only labels (candidates for missing fields in AV):
 - `IDAにimportできる形式でMAPファイルを生成します。`
 - `MAKE IDAMapFile`
 - `MAKE no$gba sym File`
-- `no$gba debuggerで利用できるsym形式のMAPファイルを作成します。
-ROMと同じディレクトリに設置してください。`
-- `このゲームのプログラムデータをすべてファイルに出力します。
-処理には時間がかかるものがあります。`
+- `no$gba debuggerで利用できるsym形式のMAPファイルを作成します。\r\nROMと同じディレクトリに設置してください。`
+- `このゲームのプログラムデータをすべてファイルに出力します。\r\n処理には時間がかかるものがあります。`
 - `すべてのコードを逆アセンブルしてファイルに保存します。`
 - `全部逆アセンブルして保存する`
 - `特定の関数の引数だけを抽出します。`
@@ -8080,7 +8106,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Select an output format and run the disassembly dump.`
 
 ### ErrorPaletteShowForm
-WF labels: **9** · AV labels: **2** · WF-only: **9** · AV-only: **2** · Common: **0**
+WF labels: **9** · AV labels: **2** · WF-only: **9** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 9 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8100,7 +8126,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Palette Error Display`
 
 ### EventAssemblerForm
-WF labels: **9** · AV labels: **2** · WF-only: **9** · AV-only: **2** · Common: **0**
+WF labels: **9** · AV labels: **2** · WF-only: **9** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 12 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8120,7 +8146,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Event Assembler`
 
 ### EventTemplate4Form
-WF labels: **9** · AV labels: **2** · WF-only: **9** · AV-only: **2** · Common: **0**
+WF labels: **9** · AV labels: **2** · WF-only: **9** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 10 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8140,7 +8166,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Event Template 4`
 
 ### ItemEffectPointerForm
-WF labels: **9** · AV labels: **5** · WF-only: **9** · AV-only: **5** · Common: **0**
+WF labels: **9** · AV labels: **5** · WF-only: **9** · AV-only: **5** · Common: **0** · Density verdict: **Medium** (WF 13 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8163,7 +8189,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### RAMRewriteToolMAPForm
-WF labels: **9** · AV labels: **10** · WF-only: **9** · AV-only: **10** · Common: **0**
+WF labels: **9** · AV labels: **10** · WF-only: **9** · AV-only: **10** · Common: **0** · Density verdict: **Low** (WF 11 / AV 10)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8191,7 +8217,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### SoundRoomCGForm
-WF labels: **10** · AV labels: **4** · WF-only: **9** · AV-only: **3** · Common: **1**
+WF labels: **10** · AV labels: **4** · WF-only: **9** · AV-only: **3** · Common: **1** · Density verdict: **High** (WF 14 / AV 6)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8212,7 +8238,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ToolFELintForm
-WF labels: **9** · AV labels: **2** · WF-only: **9** · AV-only: **2** · Common: **0**
+WF labels: **9** · AV labels: **2** · WF-only: **9** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 12 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8232,7 +8258,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `FELint GUI`
 
 ### UnitsShortTextForm
-WF labels: **9** · AV labels: **7** · WF-only: **9** · AV-only: **7** · Common: **0**
+WF labels: **9** · AV labels: **7** · WF-only: **9** · AV-only: **7** · Common: **0** · Density verdict: **Low** (WF 13 / AV 11)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8257,7 +8283,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### VennouWeaponLockForm
-WF labels: **9** · AV labels: **7** · WF-only: **9** · AV-only: **7** · Common: **0**
+WF labels: **9** · AV labels: **7** · WF-only: **9** · AV-only: **7** · Common: **0** · Density verdict: **Medium** (WF 15 / AV 11)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8282,12 +8308,11 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### DisASMDumpAllArgGrepForm
-WF labels: **8** · AV labels: **6** · WF-only: **8** · AV-only: **6** · Common: **0**
+WF labels: **8** · AV labels: **6** · WF-only: **8** · AV-only: **6** · Common: **0** · Density verdict: **Medium** (WF 11 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
-- `blまたはb呼び出しの関数名
-または、関数のアドレスを指定ください。`
+- `blまたはb呼び出しの関数名\r\nまたは、関数のアドレスを指定ください。`
 - `事前に逆アセンブラによって、ソースコードをすべて逆アセンブルしてください。`
 - `参照`
 - `探すレジスタ`
@@ -8306,7 +8331,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Search disassembly output by argument pattern.`
 
 ### MapMiniMapTerrainImageForm
-WF labels: **8** · AV labels: **2** · WF-only: **8** · AV-only: **2** · Common: **0**
+WF labels: **8** · AV labels: **2** · WF-only: **8** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 12 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8325,7 +8350,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Mini-Map Terrain`
 
 ### PatchFilterExForm
-WF labels: **8** · AV labels: **5** · WF-only: **8** · AV-only: **5** · Common: **0**
+WF labels: **8** · AV labels: **5** · WF-only: **8** · AV-only: **5** · Common: **0** · Density verdict: **Medium** (WF 9 / AV 5)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8347,7 +8372,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Patch Filter`
 
 ### ToolDiffForm
-WF labels: **8** · AV labels: **2** · WF-only: **8** · AV-only: **2** · Common: **0**
+WF labels: **8** · AV labels: **2** · WF-only: **8** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 15 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8366,7 +8391,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `ROM Diff Tool`
 
 ### ErrorPaletteMissMatchForm
-WF labels: **7** · AV labels: **2** · WF-only: **7** · AV-only: **2** · Common: **0**
+WF labels: **7** · AV labels: **2** · WF-only: **7** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 7 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8384,7 +8409,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Palette Mismatch`
 
 ### ErrorReportForm
-WF labels: **7** · AV labels: **2** · WF-only: **7** · AV-only: **2** · Common: **0**
+WF labels: **7** · AV labels: **2** · WF-only: **7** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 9 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8402,7 +8427,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Error Report`
 
 ### ErrorTSAErrorForm
-WF labels: **7** · AV labels: **2** · WF-only: **7** · AV-only: **2** · Common: **0**
+WF labels: **7** · AV labels: **2** · WF-only: **7** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 7 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8420,7 +8445,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `TSA Error`
 
 ### EventTemplate6Form
-WF labels: **7** · AV labels: **2** · WF-only: **7** · AV-only: **2** · Common: **0**
+WF labels: **7** · AV labels: **2** · WF-only: **7** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 8 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8438,7 +8463,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Event Template 6`
 
 ### MapEditorResizeDialogForm
-WF labels: **11** · AV labels: **11** · WF-only: **7** · AV-only: **7** · Common: **4**
+WF labels: **11** · AV labels: **11** · WF-only: **7** · AV-only: **7** · Common: **4** · Density verdict: **Low** (WF 19 / AV 19)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8461,7 +8486,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Top`
 
 ### MapPointerNewPLISTPopupForm
-WF labels: **7** · AV labels: **6** · WF-only: **7** · AV-only: **6** · Common: **0**
+WF labels: **7** · AV labels: **6** · WF-only: **7** · AV-only: **6** · Common: **0** · Density verdict: **Low** (WF 9 / AV 8)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8479,13 +8504,11 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Enter the PLIST number for the new map pointer entry.`
 - `Extend PLIST Range`
 - `OK`
-- `PLIST (Pointer List) assigns a numeric ID to each map.
-Choose an unused PLIST number to add a new map pointer entry.
-The PLIST ID is used internally to reference map data.`
+- `PLIST (Pointer List) assigns a numeric ID to each map.\nChoose an unused PLIST number to add a new map pointer entry.\nThe PLIST ID is used internally to reference map data.`
 - `PLIST ID:`
 
 ### MapTerrainNameEngForm
-WF labels: **7** · AV labels: **5** · WF-only: **7** · AV-only: **5** · Common: **0**
+WF labels: **7** · AV labels: **5** · WF-only: **7** · AV-only: **5** · Common: **0** · Density verdict: **Medium** (WF 12 / AV 8)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8506,7 +8529,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### MapTerrainNameForm
-WF labels: **7** · AV labels: **5** · WF-only: **7** · AV-only: **5** · Common: **0**
+WF labels: **7** · AV labels: **5** · WF-only: **7** · AV-only: **5** · Common: **0** · Density verdict: **Low** (WF 10 / AV 8)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8527,7 +8550,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### MapTerrainNameForm
-WF labels: **7** · AV labels: **5** · WF-only: **7** · AV-only: **5** · Common: **0**
+WF labels: **7** · AV labels: **5** · WF-only: **7** · AV-only: **5** · Common: **0** · Density verdict: **Low** (WF 10 / AV 8)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8548,7 +8571,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### OPClassAlphaNameFE6Form
-WF labels: **7** · AV labels: **5** · WF-only: **7** · AV-only: **5** · Common: **0**
+WF labels: **7** · AV labels: **5** · WF-only: **7** · AV-only: **5** · Common: **0** · Density verdict: **Low** (WF 10 / AV 9)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8569,7 +8592,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### RAMRewriteToolForm
-WF labels: **7** · AV labels: **9** · WF-only: **7** · AV-only: **9** · Common: **0**
+WF labels: **7** · AV labels: **9** · WF-only: **7** · AV-only: **9** · Common: **0** · Density verdict: **Low** (WF 8 / AV 9)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8594,13 +8617,12 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Value:`
 
 ### ToolFlagNameForm
-WF labels: **7** · AV labels: **2** · WF-only: **7** · AV-only: **2** · Common: **0**
+WF labels: **7** · AV labels: **2** · WF-only: **7** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 7 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
 - `ディフォルトに戻す`
-- `フラグに名前を設定すると、より理解しやすくなります。
-フラグの名前は、ROMごとに別ファイルに保存します。`
+- `フラグに名前を設定すると、より理解しやすくなります。\r\nフラグの名前は、ROMごとに別ファイルに保存します。`
 - `フラグの名前`
 - `リストの拡張`
 - `名前`
@@ -8613,7 +8635,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Flag Name Editor`
 
 ### DevTranslateForm
-WF labels: **6** · AV labels: **2** · WF-only: **6** · AV-only: **2** · Common: **0**
+WF labels: **6** · AV labels: **2** · WF-only: **6** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 10 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8630,7 +8652,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Developer Translation Tool`
 
 ### EventUnitColorForm
-WF labels: **6** · AV labels: **2** · WF-only: **6** · AV-only: **2** · Common: **0**
+WF labels: **6** · AV labels: **2** · WF-only: **6** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 14 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8647,7 +8669,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Unit Color Assignment`
 
 ### PointerToolCopyToForm
-WF labels: **6** · AV labels: **6** · WF-only: **6** · AV-only: **6** · Common: **0**
+WF labels: **6** · AV labels: **6** · WF-only: **6** · AV-only: **6** · Common: **0** · Density verdict: **Low** (WF 6 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8668,14 +8690,12 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Value:`
 
 ### SongTrackChangeTrackForm
-WF labels: **6** · AV labels: **2** · WF-only: **6** · AV-only: **2** · Common: **0**
+WF labels: **6** · AV labels: **2** · WF-only: **6** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 10 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
-- `このトラックのPANに、指定された値を足します。
-マイナスは左側、プラスは右側です。`
-- `このトラックの音量に、指定された値を足しこみます。
-大きくするほど、大きな音になります。`
+- `このトラックのPANに、指定された値を足します。\r\nマイナスは左側、プラスは右側です。`
+- `このトラックの音量に、指定された値を足しこみます。\r\n大きくするほど、大きな音になります。`
 - `アドレス`
 - `ベロシティも補正する`
 - `変更する`
@@ -8687,13 +8707,12 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Track Change`
 
 ### TextToSpeechForm
-WF labels: **6** · AV labels: **6** · WF-only: **6** · AV-only: **6** · Common: **0**
+WF labels: **6** · AV labels: **6** · WF-only: **6** · AV-only: **6** · Common: **0** · Density verdict: **Medium** (WF 10 / AV 6)
 
 WF-only labels (candidates for missing fields in AV):
 
 - `このサイズ以上の文字列を読み上げる`
-- `合成音声エンジンで自動的にテキストを読み上げます。
-タイプミスを見つけるには音読するのが一番です。`
+- `合成音声エンジンで自動的にテキストを読み上げます。\r\nタイプミスを見つけるには音読するのが一番です。`
 - `読み上げエンジン`
 - `読み上げ停止`
 - `読み上げ速度`
@@ -8709,7 +8728,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Text to Speech`
 
 ### ToolThreeMargeForm
-WF labels: **6** · AV labels: **14** · WF-only: **6** · AV-only: **14** · Common: **0**
+WF labels: **6** · AV labels: **14** · WF-only: **6** · AV-only: **14** · Common: **0** · Density verdict: **High** (WF 6 / AV 20)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8738,7 +8757,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Three-Way ROM Merge`
 
 ### ToolUpdateDialogForm
-WF labels: **6** · AV labels: **2** · WF-only: **6** · AV-only: **2** · Common: **0**
+WF labels: **6** · AV labels: **2** · WF-only: **6** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 7 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8747,10 +8766,7 @@ WF-only labels (candidates for missing fields in AV):
 - `ブラウザでURLを開きます`
 - `プログラム本体を更新します`
 - `全自動でアップデートします`
-- `最新版({0})があるようです。
-アップデートしますか？
-
-{1}`
+- `最新版({0})があるようです。\r\nアップデートしますか？\r\n\r\n{1}`
 
 AV-only labels (usually fine — layout polish or rewording):
 
@@ -8758,7 +8774,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Update Checker`
 
 ### AIASMCALLTALKForm
-WF labels: **5** · AV labels: **8** · WF-only: **5** · AV-only: **8** · Common: **0**
+WF labels: **5** · AV labels: **8** · WF-only: **5** · AV-only: **8** · Common: **0** · Density verdict: **Low** (WF 12 / AV 13)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8780,7 +8796,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### EventTemplate5Form
-WF labels: **5** · AV labels: **2** · WF-only: **5** · AV-only: **2** · Common: **0**
+WF labels: **5** · AV labels: **2** · WF-only: **5** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 6 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8796,7 +8812,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Event Template 5`
 
 ### HexEditorForm
-WF labels: **6** · AV labels: **6** · WF-only: **5** · AV-only: **5** · Common: **1**
+WF labels: **6** · AV labels: **6** · WF-only: **5** · AV-only: **5** · Common: **1** · Density verdict: **Medium** (WF 6 / AV 8)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8815,37 +8831,33 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Page Up`
 
 ### ImageBGSelectPopupForm
-WF labels: **5** · AV labels: **4** · WF-only: **5** · AV-only: **4** · Common: **0**
+WF labels: **5** · AV labels: **4** · WF-only: **5** · AV-only: **4** · Common: **0** · Density verdict: **Medium** (WF 7 / AV 5)
 
 WF-only labels (candidates for missing fields in AV):
 
 - `TSAを利用しないBG224色(会話用)`
 - `TSAを利用しないBG256色(カットシーン)`
 - `インポートするBGの形式を指定してください。`
-- `バニラの仕様であるTSAを利用した最大8パレットを指定します。
-減色ツールの「01=背景(BG,CG)」で減色した画像を指定してください。`
+- `バニラの仕様であるTSAを利用した最大8パレットを指定します。\r\n減色ツールの「01=背景(BG,CG)」で減色した画像を指定してください。`
 - `バニラ形式。TSA方式を利用する方法でインポートする`
 
 AV-only labels (usually fine — layout polish or rewording):
 
-- `Background Image Selector.
-Choose a background image from the available BG entries in the ROM.`
+- `Background Image Selector.\nChoose a background image from the available BG entries in the ROM.`
 - `BG Image Select`
 - `Cancel`
 - `Select`
 
 ### MapEditorAddMapChangeDialogForm
-WF labels: **5** · AV labels: **6** · WF-only: **5** · AV-only: **6** · Common: **0**
+WF labels: **5** · AV labels: **6** · WF-only: **5** · AV-only: **6** · Common: **0** · Density verdict: **Low** (WF 6 / AV 6)
 
 WF-only labels (candidates for missing fields in AV):
 
 - `キャンセル`
 - `マップ変化の設定画面を出します。`
-- `マップ変化を減らす場合は、設定画面から消去してください。
-変更したマップ変化は、マップを切り替えたときに読み込まれます。`
+- `マップ変化を減らす場合は、設定画面から消去してください。\r\n変更したマップ変化は、マップを切り替えたときに読み込まれます。`
 - `新規にマップ変化を割り当てます。`
-- `訪問村や、宝箱、壊れる壁、古木などのために、
-マップ変化を新規に割り当てる場合は、ここから新規にマップ変化を割り当ててください。`
+- `訪問村や、宝箱、壊れる壁、古木などのために、\r\nマップ変化を新規に割り当てる場合は、ここから新規にマップ変化を割り当ててください。`
 
 AV-only labels (usually fine — layout polish or rewording):
 
@@ -8857,7 +8869,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Open the map change configuration screen to edit existing map change entries.`
 
 ### MapSettingDifficultyForm
-WF labels: **5** · AV labels: **2** · WF-only: **5** · AV-only: **2** · Common: **0**
+WF labels: **5** · AV labels: **2** · WF-only: **5** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 10 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8873,7 +8885,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Difficulty Settings`
 
 ### MapStyleEditorImportImageOptionForm
-WF labels: **5** · AV labels: **5** · WF-only: **5** · AV-only: **5** · Common: **0**
+WF labels: **5** · AV labels: **5** · WF-only: **5** · AV-only: **5** · Common: **0** · Density verdict: **Low** (WF 5 / AV 5)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8892,7 +8904,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `One Picture Import`
 
 ### SongInstrumentDirectSoundForm
-WF labels: **7** · AV labels: **7** · WF-only: **5** · AV-only: **5** · Common: **2**
+WF labels: **7** · AV labels: **7** · WF-only: **5** · AV-only: **5** · Common: **2** · Density verdict: **Low** (WF 15 / AV 12)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8911,16 +8923,13 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### SongTrackAllChangeTrackForm
-WF labels: **5** · AV labels: **2** · WF-only: **5** · AV-only: **2** · Common: **0**
+WF labels: **5** · AV labels: **2** · WF-only: **5** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 9 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
-- `全トラックのPANに、指定された値を足します。
-マイナスは左側、プラスは右側です。`
-- `全トラックのテンポに、指定された値を足します。
-大きくするほど早くなります。`
-- `全トラックの音量に、指定された値を足しこみます。
-大きくするほど、大きな音になります。`
+- `全トラックのPANに、指定された値を足します。\r\nマイナスは左側、プラスは右側です。`
+- `全トラックのテンポに、指定された値を足します。\r\n大きくするほど早くなります。`
+- `全トラックの音量に、指定された値を足しこみます。\r\n大きくするほど、大きな音になります。`
 - `変更する`
 - `変更先`
 
@@ -8929,8 +8938,27 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Address:`
 - `Bulk Track Change`
 
+### TextBadCharPopupForm
+WF labels: **5** · AV labels: **5** · WF-only: **5** · AV-only: **5** · Common: **0** · Density verdict: **Low** (WF 5 / AV 5)
+
+WF-only labels (candidates for missing fields in AV):
+
+- `Error_MessageLabel`
+- `FEの文字コードはハフマン符号化テーブルに登録されている必要があります。\n\n・方法1.\nあきらめて、システムに登録されている別の文字に変更する。\n再編集して、別の利用します。\n\n・方法2.\nAnti-Huffman Patchを利用して符号テーブルを無視することができます。\nパッチ画面を開きますので、Anti-Huffman Patchを適用した上で、再書き込みしてください。\n\… (truncated; see designer file)`
+- `方法1  あきらめる`
+- `方法2 Anti-Huffman`
+- `方法3 符号テーブル`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Anti-Huffman`
+- `Bad Character Detected`
+- `Characters that cannot be encoded in the ROM's text encoding table will cause display errors in-game.\n\nCommon issues:\n  - Using characters outside the ROM's supported character set\n  - Pasting tex… (truncated; see designer file)`
+- `Encoding Table`
+- `Give Up`
+
 ### ToolCustomBuildForm
-WF labels: **5** · AV labels: **2** · WF-only: **5** · AV-only: **2** · Common: **0**
+WF labels: **5** · AV labels: **2** · WF-only: **5** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 10 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8946,7 +8974,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Custom Build Tool`
 
 ### ToolUPSOpenSimpleForm
-WF labels: **5** · AV labels: **2** · WF-only: **5** · AV-only: **2** · Common: **0**
+WF labels: **5** · AV labels: **2** · WF-only: **5** · AV-only: **2** · Common: **0** · Density verdict: **Medium** (WF 5 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8962,7 +8990,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `UPS Patch Applier`
 
 ### ToolUndoForm
-WF labels: **5** · AV labels: **2** · WF-only: **5** · AV-only: **2** · Common: **0**
+WF labels: **5** · AV labels: **2** · WF-only: **5** · AV-only: **2** · Common: **0** · Density verdict: **Medium** (WF 5 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -8978,12 +9006,11 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Undo History Viewer`
 
 ### EventUnitItemDropForm
-WF labels: **4** · AV labels: **2** · WF-only: **4** · AV-only: **2** · Common: **0**
+WF labels: **4** · AV labels: **2** · WF-only: **4** · AV-only: **2** · Common: **0** · Density verdict: **Medium** (WF 5 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
-- `この敵を倒すと、アイテムドロップするようにしますか？
-アイテムドロップする場合、一番最後に持っているアイテムが対象になります。`
+- `この敵を倒すと、アイテムドロップするようにしますか？\r\nアイテムドロップする場合、一番最後に持っているアイテムが対象になります。`
 - `アイテムドロップしない`
 - `アイテムドロップする`
 - `キャンセル`
@@ -8994,17 +9021,13 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Unit Item Drop Editor`
 
 ### EventUnitNewAllocForm
-WF labels: **4** · AV labels: **2** · WF-only: **4** · AV-only: **2** · Common: **0**
+WF labels: **4** · AV labels: **2** · WF-only: **4** · AV-only: **2** · Common: **0** · Density verdict: **Medium** (WF 5 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
-- `増援等で、追加で登場させたいユニットのために、
-新規に領域を確保します。`
+- `増援等で、追加で登場させたいユニットのために、\r\n新規に領域を確保します。`
 - `確保`
-- `確保した領域を使わないで、
-ユニット配置ウィンドウを閉じてしまうと、
-利用されない無駄データとなってしまうので
-注意してください。`
+- `確保した領域を使わないで、\r\nユニット配置ウィンドウを閉じてしまうと、\r\n利用されない無駄データとなってしまうので\r\n注意してください。`
 - `確保する人数`
 
 AV-only labels (usually fine — layout polish or rewording):
@@ -9013,7 +9036,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Unit Allocation Editor`
 
 ### HowDoYouLikePatch2Form
-WF labels: **4** · AV labels: **3** · WF-only: **4** · AV-only: **3** · Common: **0**
+WF labels: **4** · AV labels: **3** · WF-only: **4** · AV-only: **3** · Common: **0** · Density verdict: **Medium** (WF 6 / AV 4)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9029,7 +9052,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Skip`
 
 ### HowDoYouLikePatchForm
-WF labels: **4** · AV labels: **3** · WF-only: **4** · AV-only: **3** · Common: **0**
+WF labels: **4** · AV labels: **3** · WF-only: **4** · AV-only: **3** · Common: **0** · Density verdict: **Low** (WF 5 / AV 4)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9045,7 +9068,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Skip`
 
 ### MainSimpleMenuEventErrorIgnoreErrorForm
-WF labels: **4** · AV labels: **4** · WF-only: **4** · AV-only: **4** · Common: **0**
+WF labels: **4** · AV labels: **4** · WF-only: **4** · AV-only: **4** · Common: **0** · Density verdict: **Low** (WF 5 / AV 6)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9062,7 +9085,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Reason for hiding:`
 
 ### OAMSPForm
-WF labels: **4** · AV labels: **2** · WF-only: **4** · AV-only: **2** · Common: **0**
+WF labels: **4** · AV labels: **2** · WF-only: **4** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 6 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9077,7 +9100,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `OAM Sprite Editor`
 
 ### OtherTextForm
-WF labels: **4** · AV labels: **2** · WF-only: **4** · AV-only: **2** · Common: **0**
+WF labels: **4** · AV labels: **2** · WF-only: **4** · AV-only: **2** · Common: **0** · Density verdict: **Medium** (WF 5 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9092,7 +9115,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Other Text Strings`
 
 ### SkillAssignmentUnitFE8NForm
-WF labels: **4** · AV labels: **7** · WF-only: **4** · AV-only: **7** · Common: **0**
+WF labels: **4** · AV labels: **7** · WF-only: **4** · AV-only: **7** · Common: **0** · Density verdict: **High** (WF 31 / AV 11)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9108,39 +9131,11 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Skill Assignment - Unit (FE8N)`
 - `Skill Set 1:`
 - `Skill Set 2:`
-- `Skill system editors require a compatible skill patch to be installed.
-Use the Patch Manager to install a skill system patch first.
-
-Supported skill systems: CSkillSys, FE8N Skill System`
+- `Skill system editors require a compatible skill patch to be installed.\nUse the Patch Manager to install a skill system patch first.\n\nSupported skill systems: CSkillSys, FE8N Skill System`
 - `Write`
 
-### TextBadCharPopupForm
-WF labels: **4** · AV labels: **5** · WF-only: **4** · AV-only: **5** · Common: **0**
-
-WF-only labels (candidates for missing fields in AV):
-
-- `Error_MessageLabel`
-- `方法1  あきらめる`
-- `方法2 Anti-Huffman`
-- `方法3 符号テーブル`
-
-AV-only labels (usually fine — layout polish or rewording):
-
-- `Anti-Huffman`
-- `Bad Character Detected`
-- `Characters that cannot be encoded in the ROM's text encoding table will cause display errors in-game.
-
-Common issues:
-  - Using characters outside the ROM's supported character set
-  - Pasting text from external sources with special Unicode characters
-  - Using control characters that are not valid escape sequences
-
-Please choose one of the options below to resolve the issue.`
-- `Encoding Table`
-- `Give Up`
-
 ### TextRefAddDialogForm
-WF labels: **4** · AV labels: **6** · WF-only: **4** · AV-only: **6** · Common: **0**
+WF labels: **4** · AV labels: **6** · WF-only: **4** · AV-only: **6** · Common: **0** · Density verdict: **Medium** (WF 5 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9159,7 +9154,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Text ID:`
 
 ### ToolAutomaticRecoveryROMHeaderForm
-WF labels: **4** · AV labels: **3** · WF-only: **4** · AV-only: **3** · Common: **0**
+WF labels: **4** · AV labels: **3** · WF-only: **4** · AV-only: **3** · Common: **0** · Density verdict: **High** (WF 4 / AV 6)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9175,7 +9170,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Unmodified ROM`
 
 ### ToolBGMMuteDialogForm
-WF labels: **4** · AV labels: **2** · WF-only: **4** · AV-only: **2** · Common: **0**
+WF labels: **4** · AV labels: **2** · WF-only: **4** · AV-only: **2** · Common: **0** · Density verdict: **Low** (WF 4 / AV 4)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9190,15 +9185,14 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Play only this track`
 
 ### ToolUPSPatchSimpleForm
-WF labels: **4** · AV labels: **2** · WF-only: **4** · AV-only: **2** · Common: **0**
+WF labels: **4** · AV labels: **2** · WF-only: **4** · AV-only: **2** · Common: **0** · Density verdict: **Medium** (WF 4 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
 - `ファイル選択`
 - `差分をUPSパッチとして作成する`
 - `無改造ROM`
-- `現在のデータをUPSパッチとして保存します。
-特別な理由がない限り、通常の保存をしたあとで利用してください。`
+- `現在のデータをUPSパッチとして保存します。\r\n特別な理由がない限り、通常の保存をしたあとで利用してください。`
 
 AV-only labels (usually fine — layout polish or rewording):
 
@@ -9206,7 +9200,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `UPS Patch Creator`
 
 ### ToolWorkSupport_SelectUPSForm
-WF labels: **4** · AV labels: **3** · WF-only: **4** · AV-only: **3** · Common: **0**
+WF labels: **4** · AV labels: **3** · WF-only: **4** · AV-only: **3** · Common: **0** · Density verdict: **Medium** (WF 4 / AV 5)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9222,7 +9216,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Vanilla ROM`
 
 ### AIASMCoordinateForm
-WF labels: **5** · AV labels: **7** · WF-only: **3** · AV-only: **5** · Common: **2**
+WF labels: **5** · AV labels: **7** · WF-only: **3** · AV-only: **5** · Common: **2** · Density verdict: **Low** (WF 11 / AV 12)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9239,7 +9233,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### AIScriptCategorySelectForm
-WF labels: **3** · AV labels: **11** · WF-only: **3** · AV-only: **11** · Common: **0**
+WF labels: **3** · AV labels: **11** · WF-only: **3** · AV-only: **11** · Common: **0** · Density verdict: **High** (WF 3 / AV 13)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9262,7 +9256,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write to ROM`
 
 ### GraphicsToolPatchMakerForm
-WF labels: **3** · AV labels: **9** · WF-only: **3** · AV-only: **9** · Common: **0**
+WF labels: **3** · AV labels: **9** · WF-only: **3** · AV-only: **9** · Common: **0** · Density verdict: **High** (WF 3 / AV 14)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9283,7 +9277,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Save Patch File`
 
 ### LogForm
-WF labels: **3** · AV labels: **2** · WF-only: **3** · AV-only: **2** · Common: **0**
+WF labels: **3** · AV labels: **2** · WF-only: **3** · AV-only: **2** · Common: **0** · Density verdict: **Low** (WF 3 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9297,7 +9291,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Log Viewer`
 
 ### MainSimpleMenuEventErrorForm
-WF labels: **3** · AV labels: **2** · WF-only: **3** · AV-only: **2** · Common: **0**
+WF labels: **3** · AV labels: **2** · WF-only: **3** · AV-only: **2** · Common: **0** · Density verdict: **Medium** (WF 4 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9311,24 +9305,22 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Event Error Display`
 
 ### MapEditorMarSizeDialogForm
-WF labels: **3** · AV labels: **3** · WF-only: **3** · AV-only: **3** · Common: **0**
+WF labels: **3** · AV labels: **3** · WF-only: **3** · AV-only: **3** · Common: **0** · Density verdict: **Low** (WF 4 / AV 4)
 
 WF-only labels (candidates for missing fields in AV):
 
-- `データサイズが不一致。
-(データ数/2) % 幅 == 0 ではありません`
+- `データサイズが不一致。\r\n(データ数/2) % 幅 == 0 ではありません`
 - `幅`
 - `適応`
 
 AV-only labels (usually fine — layout polish or rewording):
 
 - `Apply`
-- `Data size mismatch.
-(DataCount/2) % Width != 0`
+- `Data size mismatch.\n(DataCount/2) % Width != 0`
 - `Width`
 
 ### MoveCostFE6Form
-WF labels: **3** · AV labels: **6** · WF-only: **3** · AV-only: **6** · Common: **0**
+WF labels: **3** · AV labels: **6** · WF-only: **3** · AV-only: **6** · Common: **0** · Density verdict: **High** (WF 57 / AV 10)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9346,7 +9338,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### MoveCostForm
-WF labels: **3** · AV labels: **4** · WF-only: **3** · AV-only: **4** · Common: **0**
+WF labels: **3** · AV labels: **4** · WF-only: **3** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 72 / AV 8)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9362,7 +9354,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### OpenLastSelectedFileForm
-WF labels: **3** · AV labels: **2** · WF-only: **3** · AV-only: **2** · Common: **0**
+WF labels: **3** · AV labels: **2** · WF-only: **3** · AV-only: **2** · Common: **0** · Density verdict: **Low** (WF 3 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9376,7 +9368,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Open Last Selected File`
 
 ### PaletteClipboardForm
-WF labels: **3** · AV labels: **8** · WF-only: **3** · AV-only: **8** · Common: **0**
+WF labels: **3** · AV labels: **8** · WF-only: **3** · AV-only: **8** · Common: **0** · Density verdict: **High** (WF 4 / AV 8)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9392,12 +9384,11 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Close`
 - `Copy Current`
 - `Palette Clipboard`
-- `Palette Clipboard Manager stores and retrieves palette data.
-Copy palettes between different graphics entries or save them for later use.`
+- `Palette Clipboard Manager stores and retrieves palette data.\nCopy palettes between different graphics entries or save them for later use.`
 - `Paste`
 
 ### PatchFormUninstallDialogForm
-WF labels: **3** · AV labels: **4** · WF-only: **3** · AV-only: **4** · Common: **0**
+WF labels: **3** · AV labels: **4** · WF-only: **3** · AV-only: **4** · Common: **0** · Density verdict: **Medium** (WF 4 / AV 5)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9407,18 +9398,13 @@ WF-only labels (candidates for missing fields in AV):
 
 AV-only labels (usually fine — layout polish or rewording):
 
-- `Please select the ROM from before this patch was installed for recovery.
-
-This feature does not guarantee a reliable uninstallation.
-It may fail, so please make a backup beforehand.
-Also, while the patch code can be removed, associated data may not always be removable.
-In that case, there may be a loss of a few hundred bytes. Please understand.`
+- `Please select the ROM from before this patch was installed for recovery.\n\nThis feature does not guarantee a reliable uninstallation.\nIt may fail, so please make a backup beforehand.\nAlso, while th… (truncated; see designer file)`
 - `ROM without patch`
 - `Select file`
 - `Uninstall`
 
 ### ProcsScriptCategorySelectForm
-WF labels: **3** · AV labels: **11** · WF-only: **3** · AV-only: **11** · Common: **0**
+WF labels: **3** · AV labels: **11** · WF-only: **3** · AV-only: **11** · Common: **0** · Density verdict: **High** (WF 3 / AV 13)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9441,14 +9427,11 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write to ROM`
 
 ### SongExchangeForm
-WF labels: **3** · AV labels: **2** · WF-only: **3** · AV-only: **2** · Common: **0**
+WF labels: **3** · AV labels: **2** · WF-only: **3** · AV-only: **2** · Common: **0** · Density verdict: **Medium** (WF 4 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
-- `<---------
-選択した曲を
-移植する
-<---------`
+- `<---------\r\n選択した曲を\r\n移植する\r\n<---------`
 - `サウンドテーブル`
 - `別ROMを開く`
 
@@ -9458,7 +9441,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Song Exchange Tool`
 
 ### SongTrackImportSelectInstrumentForm
-WF labels: **3** · AV labels: **8** · WF-only: **3** · AV-only: **8** · Common: **0**
+WF labels: **3** · AV labels: **8** · WF-only: **3** · AV-only: **8** · Common: **0** · Density verdict: **High** (WF 6 / AV 9)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9472,13 +9455,13 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Address:`
 - `Current Instrument Set`
 - `Instrument Selection`
-- `Instrument set selection is not yet available in the Avalonia UI. To select a different instrument set for MIDI import, please use the WinForms version. This feature requires porting PatchUtil.SearchInstrumentSet to the cross-platform Core library.`
+- `Instrument set selection is not yet available in the Avalonia UI. To select a different instrument set for MIDI import, please use the WinForms version. This feature requires porting PatchUtil.SearchI… (truncated; see designer file)`
 - `No song selected`
 - `Not Yet Implemented`
 - `This view allows selecting the instrument set (voicegroup) used when importing MIDI or .s files into the ROM. The instrument set determines which GBA sound samples are mapped to MIDI program changes.`
 
 ### ToolChangeProjectnameForm
-WF labels: **3** · AV labels: **4** · WF-only: **3** · AV-only: **4** · Common: **0**
+WF labels: **3** · AV labels: **4** · WF-only: **3** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 4 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9494,7 +9477,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `New Name:`
 
 ### ToolClickWriteFloatControlPanelButtonForm
-WF labels: **3** · AV labels: **3** · WF-only: **3** · AV-only: **3** · Common: **0**
+WF labels: **3** · AV labels: **3** · WF-only: **3** · AV-only: **3** · Common: **0** · Density verdict: **Low** (WF 4 / AV 4)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9509,14 +9492,13 @@ AV-only labels (usually fine — layout polish or rewording):
 - `❓`
 
 ### ToolEmulatorSetupMessageForm
-WF labels: **3** · AV labels: **2** · WF-only: **3** · AV-only: **2** · Common: **0**
+WF labels: **3** · AV labels: **2** · WF-only: **3** · AV-only: **2** · Common: **0** · Density verdict: **Low** (WF 3 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
 - `InitWizardで自動設定する`
 - `Option画面から手動で設定する`
-- `エミュレータが設定されていません。
-動作テストに利用するエミュレータを設定してください。`
+- `エミュレータが設定されていません。\r\n動作テストに利用するエミュレータを設定してください。`
 
 AV-only labels (usually fine — layout polish or rewording):
 
@@ -9524,7 +9506,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Manually configure from Options screen`
 
 ### ToolRunHintMessageForm
-WF labels: **3** · AV labels: **2** · WF-only: **3** · AV-only: **2** · Common: **0**
+WF labels: **3** · AV labels: **2** · WF-only: **3** · AV-only: **2** · Common: **0** · Density verdict: **Medium** (WF 3 / AV 4)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9538,7 +9520,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Start`
 
 ### ToolThreeMargeCloseAlertForm
-WF labels: **3** · AV labels: **3** · WF-only: **3** · AV-only: **3** · Common: **0**
+WF labels: **3** · AV labels: **3** · WF-only: **3** · AV-only: **3** · Common: **0** · Density verdict: **Medium** (WF 3 / AV 4)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9553,7 +9535,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Force close with current results.`
 
 ### ToolUndoPopupDialogForm
-WF labels: **3** · AV labels: **4** · WF-only: **3** · AV-only: **4** · Common: **0**
+WF labels: **3** · AV labels: **4** · WF-only: **3** · AV-only: **4** · Common: **0** · Density verdict: **Low** (WF 5 / AV 5)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9569,7 +9551,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `↩`
 
 ### AIASMRangeForm
-WF labels: **6** · AV labels: **8** · WF-only: **2** · AV-only: **4** · Common: **4**
+WF labels: **6** · AV labels: **8** · WF-only: **2** · AV-only: **4** · Common: **4** · Density verdict: **Low** (WF 12 / AV 13)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9584,7 +9566,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### CStringForm
-WF labels: **2** · AV labels: **2** · WF-only: **2** · AV-only: **2** · Common: **0**
+WF labels: **2** · AV labels: **2** · WF-only: **2** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 2 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9597,7 +9579,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `C-String Editor`
 
 ### DumpStructSelectToTextDialogForm
-WF labels: **2** · AV labels: **4** · WF-only: **2** · AV-only: **4** · Common: **0**
+WF labels: **2** · AV labels: **4** · WF-only: **2** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 3 / AV 6)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9612,7 +9594,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Save to File...`
 
 ### PackedMemorySlotForm
-WF labels: **2** · AV labels: **4** · WF-only: **2** · AV-only: **4** · Common: **0**
+WF labels: **2** · AV labels: **4** · WF-only: **2** · AV-only: **4** · Common: **0** · Density verdict: **Medium** (WF 5 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9627,7 +9609,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Packed Memory Slot`
 
 ### PointerToolBatchInputForm
-WF labels: **2** · AV labels: **3** · WF-only: **2** · AV-only: **3** · Common: **0**
+WF labels: **2** · AV labels: **3** · WF-only: **2** · AV-only: **3** · Common: **0** · Density verdict: **High** (WF 2 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9636,14 +9618,12 @@ WF-only labels (candidates for missing fields in AV):
 
 AV-only labels (usually fine — layout polish or rewording):
 
-- `0x08000000
-0x08000004
-...`
+- `0x08000000\n0x08000004\n...`
 - `Batch Address Convert`
 - `Value:`
 
 ### ResourceForm
-WF labels: **2** · AV labels: **5** · WF-only: **2** · AV-only: **5** · Common: **0**
+WF labels: **2** · AV labels: **5** · WF-only: **2** · AV-only: **5** · Common: **0** · Density verdict: **High** (WF 2 / AV 8)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9659,13 +9639,11 @@ AV-only labels (usually fine — layout polish or rewording):
 - `ROM Information`
 
 ### ToolProblemReportSearchSavForm
-WF labels: **3** · AV labels: **2** · WF-only: **2** · AV-only: **1** · Common: **1**
+WF labels: **3** · AV labels: **2** · WF-only: **2** · AV-only: **1** · Common: **1** · Density verdict: **Medium** (WF 3 / AV 4)
 
 WF-only labels (candidates for missing fields in AV):
 
-- `savファイルが含まれていないようです。
-問題を確実に再現するためには、savファイルが必要です。
-対応するsavがある場合は、パスを指定してください。`
+- `savファイルが含まれていないようです。\r\n問題を確実に再現するためには、savファイルが必要です。\r\n対応するsavがある場合は、パスを指定してください。`
 - `参照`
 
 AV-only labels (usually fine — layout polish or rewording):
@@ -9673,7 +9651,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Browse...`
 
 ### ToolUseFlagForm
-WF labels: **2** · AV labels: **2** · WF-only: **2** · AV-only: **2** · Common: **0**
+WF labels: **2** · AV labels: **2** · WF-only: **2** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 2 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9686,7 +9664,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Flag Usage Viewer`
 
 ### ToolWorkSupport_UpdateQuestionDialogForm
-WF labels: **2** · AV labels: **3** · WF-only: **2** · AV-only: **3** · Common: **0**
+WF labels: **2** · AV labels: **3** · WF-only: **2** · AV-only: **3** · Common: **0** · Density verdict: **Medium** (WF 3 / AV 4)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9700,7 +9678,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `❓`
 
 ### UbyteBitFlagForm
-WF labels: **2** · AV labels: **11** · WF-only: **2** · AV-only: **11** · Common: **0**
+WF labels: **2** · AV labels: **11** · WF-only: **2** · AV-only: **11** · Common: **0** · Density verdict: **Low** (WF 11 / AV 12)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9722,7 +9700,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Hex:`
 
 ### UshortBitFlagForm
-WF labels: **2** · AV labels: **20** · WF-only: **2** · AV-only: **20** · Common: **0**
+WF labels: **2** · AV labels: **20** · WF-only: **2** · AV-only: **20** · Common: **0** · Density verdict: **Low** (WF 20 / AV 22)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9753,7 +9731,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Short Bit Flags (16-bit)`
 
 ### UwordBitFlagForm
-WF labels: **2** · AV labels: **38** · WF-only: **2** · AV-only: **38** · Common: **0**
+WF labels: **2** · AV labels: **38** · WF-only: **2** · AV-only: **38** · Common: **0** · Density verdict: **Low** (WF 38 / AV 42)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9802,7 +9780,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Word Bit Flags (32-bit)`
 
 ### ErrorLongMessageDialogForm
-WF labels: **2** · AV labels: **2** · WF-only: **1** · AV-only: **1** · Common: **1**
+WF labels: **2** · AV labels: **2** · WF-only: **1** · AV-only: **1** · Common: **1** · Density verdict: **High** (WF 2 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9813,7 +9791,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `The following error has occurred.`
 
 ### EventScriptTemplateForm
-WF labels: **1** · AV labels: **2** · WF-only: **1** · AV-only: **2** · Common: **0**
+WF labels: **1** · AV labels: **2** · WF-only: **1** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 1 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9825,7 +9803,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Script Template Browser`
 
 ### ProcsScriptForm
-WF labels: **1** · AV labels: **2** · WF-only: **1** · AV-only: **2** · Common: **0**
+WF labels: **1** · AV labels: **2** · WF-only: **1** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 1 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9837,7 +9815,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Procs Script Editor`
 
 ### SkillSystemsEffectivenessReworkClassTypeForm
-WF labels: **1** · AV labels: **5** · WF-only: **1** · AV-only: **5** · Common: **0**
+WF labels: **1** · AV labels: **5** · WF-only: **1** · AV-only: **5** · Common: **0** · Density verdict: **Medium** (WF 10 / AV 7)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9848,14 +9826,11 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Address:`
 - `Class Type:`
 - `Effectiveness Rework - Class Type`
-- `Skill system editors require a compatible skill patch to be installed.
-Use the Patch Manager to install a skill system patch first.
-
-Supported skill systems: CSkillSys, FE8N Skill System`
+- `Skill system editors require a compatible skill patch to be installed.\nUse the Patch Manager to install a skill system patch first.\n\nSupported skill systems: CSkillSys, FE8N Skill System`
 - `Write`
 
 ### ToolASMEditForm
-WF labels: **1** · AV labels: **4** · WF-only: **1** · AV-only: **4** · Common: **0**
+WF labels: **1** · AV labels: **4** · WF-only: **1** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 1 / AV 4)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9869,7 +9844,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Enter ARM/Thumb ASM code here...`
 
 ### ToolAllWorkSupportForm
-WF labels: **1** · AV labels: **2** · WF-only: **1** · AV-only: **2** · Common: **0**
+WF labels: **1** · AV labels: **2** · WF-only: **1** · AV-only: **2** · Common: **0** · Density verdict: **Medium** (WF 4 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9881,7 +9856,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Work Support`
 
 ### ToolProblemReportSearchBackupForm
-WF labels: **2** · AV labels: **2** · WF-only: **1** · AV-only: **1** · Common: **1**
+WF labels: **2** · AV labels: **2** · WF-only: **1** · AV-only: **1** · Common: **1** · Density verdict: **Medium** (WF 3 / AV 4)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9892,7 +9867,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Browse...`
 
 ### ToolUnitTalkGroupForm
-WF labels: **1** · AV labels: **2** · WF-only: **1** · AV-only: **2** · Common: **0**
+WF labels: **1** · AV labels: **2** · WF-only: **1** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 1 / AV 3)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -9904,9 +9879,8 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Talk Group Editor`
 
 ### VersionForm
-WF labels: **1** · AV labels: **0** · WF-only: **1** · AV-only: **0** · Common: **0**
+WF labels: **1** · AV labels: **0** · WF-only: **1** · AV-only: **0** · Common: **0** · Density verdict: **High** (WF 2 / AV 1)
 
 WF-only labels (candidates for missing fields in AV):
 
 - `開発者機能: 翻訳`
-

--- a/docs/avalonia-gaps/README.md
+++ b/docs/avalonia-gaps/README.md
@@ -23,7 +23,7 @@ them as backlog instead of waiting for users to file them one at a time.
 |---|---|---|---|
 | 0 | Bootstrap (pair matcher + report writer) | (infrastructure) | [x] [#375](https://github.com/laqieer/FEBuilderGBA/pull/375) |
 | 1 | Control-density delta | `--gap-sweep-density` | [x] [#375](https://github.com/laqieer/FEBuilderGBA/pull/375) |
-| 2 | Field-label diff | `--gap-sweep-labels` | [ ] |
+| 2 | Field-label diff | `--gap-sweep-labels` | [x] [2026-05-22 baseline](2026-05-22-labels-sweep.md) |
 | 3 | Side-by-side screenshot gallery | (uses existing `--screenshot-all` × 2) | [ ] |
 | 4 | Headless jump/navigation parity | `--gap-sweep-jumps` | [ ] |
 | 5 | Undo coverage | `--gap-sweep-undo` | [ ] |
@@ -51,6 +51,10 @@ Each phase produces a markdown report under `docs/avalonia-gaps/<YYYY-MM-DD>-<sw
 dotnet run --project FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj -c Release `
     -- --gap-sweep-density --out=docs/avalonia-gaps/$(Get-Date -Format yyyy-MM-dd)-density-sweep.md
 
+# Phase 2 — field-label diff against the current worktree
+dotnet run --project FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj -c Release `
+    -- --gap-sweep-labels --out=docs/avalonia-gaps/$(Get-Date -Format yyyy-MM-dd)-labels-sweep.md
+
 # Dry-run (writes only the YAML front-matter — useful for checking write perms / CI plumbing)
 dotnet run --project FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj -c Release `
     -- --gap-sweep-density --dry-run --out=tmp/density-dry.md
@@ -74,6 +78,27 @@ The "Top-20 HIGH Gaps" subsections are placeholders for hand-written triage
 notes — fill them per the suggested `grep` snippets so each subsequent
 fix-PR can crib the field list directly from the baseline.
 
+## Reading the labels report
+
+The labels report complements the density report — density tells you WHICH
+pairs probably have gaps, labels tells you WHAT specific labels appear in
+the WinForms designer but are missing from the Avalonia view.
+
+- **WF-only labels** = candidates for missing fields in the AV migration.
+- **AV-only labels** = usually fine (rewording, language polish, layout change).
+- **Common labels** = labels that survived normalisation on both sides.
+
+Normalisation collapses whitespace, strips trailing colons, removes mnemonic
+markers (`&` for WinForms, `_` for Avalonia), and lowercases — so `Name:` /
+`&Name` / `_Name` / `Name` all collide to the same set key. The report
+preserves the original casing/punctuation; only the diff key is normalised.
+
+Per-pair sections are sorted by WF-only count descending so the biggest
+candidate-missing-field counts surface first. Top of the first labels baseline
+([2026-05-22](2026-05-22-labels-sweep.md)): `EmulatorMemoryForm` (174 WF-only),
+`MapSettingFE7UForm` (90), `SkillConfigFE8NSkillForm` (84), `EventCondForm` (81),
+`MapSettingForm` (78).
+
 ## Implementation entry points
 
 | File | Role |
@@ -81,6 +106,7 @@ fix-PR can crib the field list directly from the baseline.
 | `FEBuilderGBA.Avalonia/GapSweep/GapSweepCommon.cs` | `EditorPair` record + `PairMatcher.DiscoverAll` |
 | `FEBuilderGBA.Avalonia/GapSweep/ReportWriter.cs` | YAML front-matter + body emit |
 | `FEBuilderGBA.Avalonia/GapSweep/ControlDensityScanner.cs` | Phase 1 scanner |
+| `FEBuilderGBA.Avalonia/GapSweep/LabelDiffScanner.cs` | Phase 2 scanner |
 | `FEBuilderGBA.Avalonia/App.axaml.cs` | CLI flag plumbing (see `RunGapSweep`) |
 | `FEBuilderGBA.Avalonia.Tests/GapSweep/` | xunit coverage |
 


### PR DESCRIPTION
## Summary
Phase 2 of the gap-sweep methodology — produces qualitative per-form lists of WinForms labels missing from the paired Avalonia view (likely missing fields). Builds on the Phase 0 pair-matcher + Phase 1 density signal merged in #375.

Phase 1 (density) gives a quantitative gap signal: "this pair has 70 % fewer controls". Phase 2 (labels) is the qualitative follow-up: "and here are the specific labels Avalonia is missing". Each phase produces a baseline report that downstream gap-fix PRs use as the per-form backlog.

Refs #374 (tracking meta-issue).

## Changes
- New `FEBuilderGBA.Avalonia/GapSweep/LabelDiffScanner.cs` — Roslyn-extracts WF `.Text = "..."` initialisers on Label/GroupBox/Button/CheckBox/RadioButton/TabPage from `*Form.Designer.cs`; `XDocument`-extracts AV `Text=`/`Content=`/`Header=`/`ToolTip=`/`Watermark=` literals (skipping `{Binding}` etc. and template containers like `Style`/`DataTemplate`); normalised set diff per pair.
- `App.axaml.cs` — `--gap-sweep-labels` routes to the real implementation (was stub since Phase 0).
- `FEBuilderGBA.Avalonia.Tests/GapSweep/LabelDiffScannerTests.cs` — 32 new xunit cases (normalize, WF extract, AV extract, diff, format, edges, end-to-end).
- `docs/avalonia-gaps/2026-05-22-labels-sweep.md` — first labels baseline.
- `docs/avalonia-gaps/README.md` — Phase 2 checkbox ticked, labels report linked, "Reading the labels report" section added.

## Top-5 forms by WF-only label count (from the new baseline)
| Rank | WF Form | AV View | WF-only | AV-only | Common |
|---:|---|---|---:|---:|---:|
| 1 | `EmulatorMemoryForm` | `EmulatorMemoryView` | 174 | 4 | 1 |
| 2 | `MapSettingFE7UForm` | `MapSettingFE7UView` | 90 | 78 | 0 |
| 3 | `MapSettingFE7Form` | `MapSettingFE7View` | 87 | 78 | 0 |
| 4 | `SkillConfigFE8NSkillForm` | `SkillConfigFE8NSkillView` | 84 | 18 | 0 |
| 5 | `EventCondForm` | `EventCondView` | 81 | 21 | 0 |

These are the same forms Phase 1's density sweep flagged HIGH — confirms the methodology is surfacing signal aligned with the density delta.

## Scope
- Methodology only — does NOT fix the surfaced gaps (each becomes its own downstream PR per CLAUDE.md's standard flow).
- Out of scope: fixing any of the 4,645 WF-only labels found; renaming mismatched views; flipping the future CI advisory to blocking (deferred to Phase 7).

## Test plan
- [x] `dotnet build FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj -c Release` — succeeds with 0 errors
- [x] `dotnet build FEBuilderGBA.Avalonia.Tests/FEBuilderGBA.Avalonia.Tests.csproj -c Release` — succeeds with 0 errors
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests --filter "FullyQualifiedName~GapSweep"` — 113/113 passing (32 new LabelDiffScanner tests + 81 existing)
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` full suite — 4352/4352 passing (4320 before + 32 new)
- [x] `dotnet test FEBuilderGBA.Core.Tests` full suite — 1293/1293 passing (unchanged from baseline)
- [x] `--gap-sweep-labels --dry-run --out=tmp/labels-dry.md` writes header-only YAML front-matter report
- [x] `--gap-sweep-labels --out=docs/avalonia-gaps/2026-05-22-labels-sweep.md` produces a ranked report with 293 pairs having WF-only labels
- [x] Report front-matter contains `generated:` timestamp, `git-sha:`, `sweep-type: labels`
- [x] Top forms confirmed: `EmulatorMemoryForm` (174 WF-only), `MapSettingFE7UForm` (90), `SkillConfigFE8NSkillForm` (84), `EventCondForm` (81), `MapSettingForm` (78) — same forms Phase 1 density sweep flagged HIGH
- [x] Normalisation collides `Name:` / `&Name` / `_Name` / `Name` to the same set key (covered by `Normalize_AllVariantsCollideToSameKey` test)
- [x] Markup-extension values (`{Binding ...}`, `{StaticResource ...}`) are skipped (covered by `ExtractAvLabels_SkipsBindings` test)
- [x] Template content (`<DataTemplate>`, `<Style>`, …) is skipped (covered by `ExtractAvLabels_SkipsTemplateContent` test)
- [x] Per-pair sections ordered by WF-only count descending (covered by `FormatReport_OrdersByWfOnlyDescending` test)

## Screenshots
Non-GUI tooling PR — terminal/test output is the proof artifact per DEVELOPMENT-WORKFLOW.md.

```
GAPSWEEP[labels]: repo-root=...\.claude\worktrees\agent-... out=docs/avalonia-gaps/2026-05-22-labels-sweep.md dry-run=False
GAPSWEEP[labels]: discovered 370 editor pairs.
GAPSWEEP[labels]: scanned 298 pairs with both files; 293 have >=1 WF-only label.
GAPSWEEP[labels]: report written to docs/avalonia-gaps/2026-05-22-labels-sweep.md
```

```
Passed!  - Failed:     0, Passed:   113, Skipped:     0, Total:   113, Duration: 1 s - FEBuilderGBA.Avalonia.Tests.dll (net9.0)
Passed!  - Failed:     0, Passed:  4352, Skipped:     0, Total:  4352, Duration: 13 s - FEBuilderGBA.Avalonia.Tests.dll (net9.0)
Passed!  - Failed:     0, Passed:  1293, Skipped:     0, Total:  1293, Duration: 2 s - FEBuilderGBA.Core.Tests.dll (net9.0)
```

## GUI Test Report
This PR modifies only the gap-sweep tooling (`FEBuilderGBA.Avalonia/GapSweep/`) + CLI arg parsing in `App.axaml.cs` — no editor view files. CLI + tests are the proof per the non-GUI PR allowance in DEVELOPMENT-WORKFLOW.md (Phase 3 step 10).

| Test case | Status |
|---|---|
| `--gap-sweep-labels --dry-run` writes header-only file | PASS |
| `--gap-sweep-labels` full run produces ranked report | PASS |
| LabelDiffScanner unit tests (32 new) | PASS |
| Full Avalonia.Tests suite (4352) | PASS |
| Full Core.Tests suite (1293) | PASS |
| Normalisation strips mnemonics (`&` / `_`) and colons | PASS |
| Markup-extension values (`{Binding}` etc.) skipped | PASS |
| Template content (`<DataTemplate>` etc.) skipped | PASS |
| Per-pair sections ordered by WF-only count descending | PASS |
| Top-5 forms cross-correlate with Phase 1 density HIGH list | PASS |

---

Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-4-7[1m]).