### PR TITLE
feat(gap-sweep): Phase 6 localisation sweep (#374, #356)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/L10nScannerTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/L10nScannerTests.cs
@@ -1,0 +1,600 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Phase 6 tests — L10nScanner literal detection + translation join + formatting. (#374, #356)
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FEBuilderGBA.Avalonia.GapSweep;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests.GapSweep;
+
+/// <summary>
+/// Tests for <see cref="L10nScanner"/>. Almost everything runs via in-memory
+/// XML strings plus hand-built translation maps so the suite is hermetic; a
+/// single end-to-end test exercises the on-disk parser to catch encoding /
+/// EOL regressions.
+/// </summary>
+public class L10nScannerTests
+{
+    // =====================================================================
+    // IsCandidateLiteral — heuristic gate for "should we record this as a
+    // literal?".
+    // =====================================================================
+
+    [Fact]
+    public void IsCandidateLiteral_DetectsMultiwordEnglish()
+    {
+        // Multi-word labels are the canonical case.
+        Assert.True(L10nScanner.IsCandidateLiteral("Base Stats", out bool ne));
+        Assert.False(ne);
+    }
+
+    [Fact]
+    public void IsCandidateLiteral_DetectsSingleWordEnglish()
+    {
+        // Single word with ≥ 4 chars and high ASCII-letter density.
+        Assert.True(L10nScanner.IsCandidateLiteral("Save", out bool ne));
+        Assert.False(ne);
+    }
+
+    [Fact]
+    public void IsCandidateLiteral_SkipsMarkupExtensions()
+    {
+        // Markup extensions are the most common false positive; binding
+        // syntax must be ignored entirely.
+        Assert.False(L10nScanner.IsCandidateLiteral("{Binding Text}", out _));
+        Assert.False(L10nScanner.IsCandidateLiteral("{StaticResource X}", out _));
+        Assert.False(L10nScanner.IsCandidateLiteral("{x:Static c:Strings.Foo}", out _));
+        Assert.False(L10nScanner.IsCandidateLiteral("{DynamicResource Y}", out _));
+        Assert.False(L10nScanner.IsCandidateLiteral("{TemplateBinding Z}", out _));
+    }
+
+    [Fact]
+    public void IsCandidateLiteral_SkipsEmptyAndPunctuation()
+    {
+        Assert.False(L10nScanner.IsCandidateLiteral("", out _));
+        Assert.False(L10nScanner.IsCandidateLiteral(" ", out _));
+        Assert.False(L10nScanner.IsCandidateLiteral("?", out _));
+        Assert.False(L10nScanner.IsCandidateLiteral("...", out _));
+        Assert.False(L10nScanner.IsCandidateLiteral(":", out _));
+    }
+
+    [Fact]
+    public void IsCandidateLiteral_SkipsSingleChar()
+    {
+        Assert.False(L10nScanner.IsCandidateLiteral("X", out _));
+        Assert.False(L10nScanner.IsCandidateLiteral("1", out _));
+    }
+
+    [Fact]
+    public void IsCandidateLiteral_SkipsPureDigits()
+    {
+        Assert.False(L10nScanner.IsCandidateLiteral("100", out _));
+        Assert.False(L10nScanner.IsCandidateLiteral("0x10", out _));
+        Assert.False(L10nScanner.IsCandidateLiteral("3.14", out _));
+    }
+
+    [Fact]
+    public void IsCandidateLiteral_FlagsCjkAsNonEnglish()
+    {
+        // Hiragana / Katakana / CJK Unified are all treated as already-localised
+        // source and tagged NonEnglish so the report can call them out separately.
+        Assert.True(L10nScanner.IsCandidateLiteral("保存", out bool ne));
+        Assert.True(ne);
+
+        Assert.True(L10nScanner.IsCandidateLiteral("セーブ", out bool ne2));
+        Assert.True(ne2);
+
+        Assert.True(L10nScanner.IsCandidateLiteral("저장", out bool ne3));
+        Assert.True(ne3);
+    }
+
+    [Fact]
+    public void IsCandidateLiteral_SkipsShortPseudoWords()
+    {
+        // 3-character single-word tokens without space — too noisy.
+        Assert.False(L10nScanner.IsCandidateLiteral("RGB", out _));
+    }
+
+    [Fact]
+    public void IsCandidateLiteral_RejectsLeadingPunctuation()
+    {
+        // ":Status" is a metadata-y leftover, not a label.
+        Assert.False(L10nScanner.IsCandidateLiteral(":Status", out _));
+    }
+
+    // =====================================================================
+    // Translation join — given an English literal and the maps, can we look
+    // up a translation in each language?
+    // =====================================================================
+
+    [Fact]
+    public void TranslationJoin_AllLanguagesHaveIt_Translated()
+    {
+        var (reverseEn, langMaps) = BuildMaps(
+            entries: new[]
+            {
+                ("書き込み", "Save", "保存", "保存", "저장"),
+            });
+
+        var xml = """
+            <UserControl xmlns="https://github.com/avaloniaui">
+                <Button Content="Save" />
+            </UserControl>
+            """;
+
+        var findings = L10nScanner.ScanXmlString(xml, "fake.axaml", reverseEn, langMaps);
+        var finding = Assert.Single(findings);
+        Assert.Equal(L10nVerdict.Translated, finding.Verdict);
+        Assert.True(finding.TranslationStatus["ja"]);
+        Assert.True(finding.TranslationStatus["zh"]);
+        Assert.True(finding.TranslationStatus["ko"]);
+    }
+
+    [Fact]
+    public void TranslationJoin_OnlyJaHasIt_PartiallyTranslated()
+    {
+        // Build maps where ja has a translation but zh/ko don't have an entry
+        // for "Save"'s pivot Japanese key.
+        var reverseEn = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["Save"] = "書き込み",
+        };
+        var jaMap = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["書き込み"] = "保存",
+        };
+        var zhMap = new Dictionary<string, string>(StringComparer.Ordinal);
+        var koMap = new Dictionary<string, string>(StringComparer.Ordinal);
+        var langMaps = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.Ordinal)
+        {
+            ["ja"] = jaMap,
+            ["zh"] = zhMap,
+            ["ko"] = koMap,
+        };
+
+        var xml = """
+            <UserControl xmlns="https://github.com/avaloniaui">
+                <Button Content="Save" />
+            </UserControl>
+            """;
+
+        var findings = L10nScanner.ScanXmlString(xml, "fake.axaml", reverseEn, langMaps);
+        var finding = Assert.Single(findings);
+        Assert.Equal(L10nVerdict.PartiallyTranslated, finding.Verdict);
+        Assert.True(finding.TranslationStatus["ja"]);
+        Assert.False(finding.TranslationStatus["zh"]);
+        Assert.False(finding.TranslationStatus["ko"]);
+    }
+
+    [Fact]
+    public void TranslationJoin_NoLanguageHasIt_Untranslated()
+    {
+        // Empty maps — every language reports "no translation".
+        var reverseEn = new Dictionary<string, string>(StringComparer.Ordinal);
+        var langMaps = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.Ordinal)
+        {
+            ["ja"] = new Dictionary<string, string>(StringComparer.Ordinal),
+            ["zh"] = new Dictionary<string, string>(StringComparer.Ordinal),
+            ["ko"] = new Dictionary<string, string>(StringComparer.Ordinal),
+        };
+
+        var xml = """
+            <UserControl xmlns="https://github.com/avaloniaui">
+                <TextBlock Text="Identity" />
+            </UserControl>
+            """;
+
+        var findings = L10nScanner.ScanXmlString(xml, "fake.axaml", reverseEn, langMaps);
+        var finding = Assert.Single(findings);
+        Assert.Equal(L10nVerdict.Untranslated, finding.Verdict);
+        Assert.False(finding.TranslationStatus["ja"]);
+        Assert.False(finding.TranslationStatus["zh"]);
+        Assert.False(finding.TranslationStatus["ko"]);
+    }
+
+    [Fact]
+    public void TranslationJoin_NormalisesTrailingColon()
+    {
+        // AXAML uses "Save", translation tables historically use "Save:".
+        // Normalisation must collide them to the same key. Build the maps via
+        // LoadReverseEnglishMap / LoadForwardMap so the trim-trailing-colon
+        // alias really exists (the in-disk parsers add both raw + normalised
+        // forms — direct-dictionary tests bypass that).
+        string tempDir = Path.Combine(Path.GetTempPath(), "L10nNormaliseTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            string enFile = Path.Combine(tempDir, "en.txt");
+            string jaFile = Path.Combine(tempDir, "ja.txt");
+            File.WriteAllText(enFile, ":書き込み:\nSave:\n\n");      // Both sides carry the trailing colon.
+            File.WriteAllText(jaFile, ":書き込み:\n保存\n\n");        // Translation under the colon-form key.
+
+            var reverseEn = L10nScanner.LoadReverseEnglishMap(enFile);
+            var jaMap = L10nScanner.LoadForwardMap(jaFile);
+            var langMaps = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.Ordinal)
+            {
+                ["ja"] = jaMap,
+            };
+
+            var xml = """
+                <UserControl xmlns="https://github.com/avaloniaui">
+                    <Button Content="Save" />
+                </UserControl>
+                """;
+
+            var findings = L10nScanner.ScanXmlString(xml, "fake.axaml", reverseEn, langMaps);
+            var finding = Assert.Single(findings);
+            Assert.True(finding.TranslationStatus["ja"], "Trailing-colon normalisation should match \"Save\" → \"Save:\" entry");
+            Assert.Equal(L10nVerdict.Translated, finding.Verdict);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); }
+            catch { /* best effort */ }
+        }
+    }
+
+    // =====================================================================
+    // AXAML attribute parsing — the gate that decides which attributes
+    // contribute candidates.
+    // =====================================================================
+
+    [Fact]
+    public void Scan_PicksUpButtonContent()
+    {
+        // Plain Content attribute.
+        var xml = """
+            <UserControl xmlns="https://github.com/avaloniaui">
+                <Button Content="Save" />
+            </UserControl>
+            """;
+        var findings = L10nScanner.ScanXmlString(xml, "fake.axaml", EmptyReverse(), EmptyLangs("ja"));
+        Assert.Single(findings, f => f.Literal == "Save" && f.AttributeName == "Content");
+    }
+
+    [Fact]
+    public void Scan_PicksUpTextBoxWatermark()
+    {
+        var xml = """
+            <UserControl xmlns="https://github.com/avaloniaui">
+                <TextBox Watermark="Search items..." />
+            </UserControl>
+            """;
+        var findings = L10nScanner.ScanXmlString(xml, "fake.axaml", EmptyReverse(), EmptyLangs("ja"));
+        Assert.Single(findings, f => f.Literal == "Search items..." && f.AttributeName == "Watermark");
+    }
+
+    [Fact]
+    public void Scan_PicksUpToolTipTipAttachedProperty()
+    {
+        // CRITICAL: ToolTip.Tip is the Avalonia attached-property form. PR
+        // #377 Phase 2 had a bug where this was missed until Copilot caught
+        // it. Do not regress.
+        var xml = """
+            <UserControl xmlns="https://github.com/avaloniaui">
+                <TextBlock Text="Foo" ToolTip.Tip="Help text" />
+            </UserControl>
+            """;
+        var findings = L10nScanner.ScanXmlString(xml, "fake.axaml", EmptyReverse(), EmptyLangs("ja"));
+        Assert.Contains(findings, f => f.AttributeName == "ToolTip.Tip" && f.Literal == "Help text");
+    }
+
+    [Fact]
+    public void Scan_PicksUpHeaderAttribute()
+    {
+        var xml = """
+            <UserControl xmlns="https://github.com/avaloniaui">
+                <Expander Header="Advanced Settings" />
+            </UserControl>
+            """;
+        var findings = L10nScanner.ScanXmlString(xml, "fake.axaml", EmptyReverse(), EmptyLangs("ja"));
+        Assert.Single(findings, f => f.Literal == "Advanced Settings" && f.AttributeName == "Header");
+    }
+
+    [Fact]
+    public void Scan_SkipsMarkupExtensionAttributes()
+    {
+        // Bindings, resources, static refs — must all be skipped at the
+        // attribute level (not just classified, but never appear in the
+        // findings list at all).
+        var xml = """
+            <UserControl xmlns="https://github.com/avaloniaui">
+                <Button Content="{Binding Text}" />
+                <TextBlock Text="{StaticResource X}" />
+                <TextBox Watermark="{DynamicResource Y}" />
+            </UserControl>
+            """;
+        var findings = L10nScanner.ScanXmlString(xml, "fake.axaml", EmptyReverse(), EmptyLangs("ja"));
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void Scan_SkipsInsideDataTemplate()
+    {
+        // Per-row DataTemplate Text isn't a label — it's a template. Skip.
+        var xml = """
+            <UserControl xmlns="https://github.com/avaloniaui">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="Per-row Label" />
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+                <Button Content="Outside Template" />
+            </UserControl>
+            """;
+        var findings = L10nScanner.ScanXmlString(xml, "fake.axaml", EmptyReverse(), EmptyLangs("ja"));
+        // The button outside the template counts; the TextBlock inside doesn't.
+        Assert.Single(findings, f => f.Literal == "Outside Template");
+        Assert.DoesNotContain(findings, f => f.Literal == "Per-row Label");
+    }
+
+    [Fact]
+    public void Scan_SkipsInsideStyle()
+    {
+        var xml = """
+            <UserControl xmlns="https://github.com/avaloniaui">
+                <UserControl.Styles>
+                    <Style>
+                        <Setter Property="TextBlock.Text" Value="Style Text" />
+                    </Style>
+                </UserControl.Styles>
+                <Button Content="Outside Style" />
+            </UserControl>
+            """;
+        var findings = L10nScanner.ScanXmlString(xml, "fake.axaml", EmptyReverse(), EmptyLangs("ja"));
+        // The button outside counts; setters inside don't (Setter has Value
+        // attribute which isn't in our CandidateAttributes list anyway, but
+        // belt-and-braces).
+        Assert.Single(findings, f => f.Literal == "Outside Style");
+    }
+
+    [Fact]
+    public void Scan_CapturesLineNumbers()
+    {
+        // Line numbers come from IXmlLineInfo via LoadOptions.SetLineInfo.
+        var xml = "<UserControl xmlns=\"https://github.com/avaloniaui\">\n"
+                + "    <Button Content=\"Save\" />\n"
+                + "    <Button Content=\"Cancel\" />\n"
+                + "</UserControl>";
+        var findings = L10nScanner.ScanXmlString(xml, "fake.axaml", EmptyReverse(), EmptyLangs("ja"));
+        Assert.Equal(2, findings.Count);
+        Assert.Equal(2, findings.First(f => f.Literal == "Save").LineNumber);
+        Assert.Equal(3, findings.First(f => f.Literal == "Cancel").LineNumber);
+    }
+
+    [Fact]
+    public void Scan_RecordsElementAndAttributeNames()
+    {
+        var xml = """
+            <UserControl xmlns="https://github.com/avaloniaui">
+                <TextBlock Text="Hello World" />
+            </UserControl>
+            """;
+        var findings = L10nScanner.ScanXmlString(xml, "fake.axaml", EmptyReverse(), EmptyLangs("ja"));
+        var f = Assert.Single(findings);
+        Assert.Equal("TextBlock", f.ElementName);
+        Assert.Equal("Text", f.AttributeName);
+        Assert.Equal("Hello World", f.Literal);
+    }
+
+    [Fact]
+    public void Scan_PreservesOriginalCasingAndPunctuation()
+    {
+        // The Literal field preserves the AXAML attribute value verbatim,
+        // not the normalised key.
+        var xml = """
+            <UserControl xmlns="https://github.com/avaloniaui">
+                <Button Content="  Save:  " />
+            </UserControl>
+            """;
+        var findings = L10nScanner.ScanXmlString(xml, "fake.axaml", EmptyReverse(), EmptyLangs("ja"));
+        var f = Assert.Single(findings);
+        Assert.Equal("  Save:  ", f.Literal);
+    }
+
+    // =====================================================================
+    // FormatReport — markdown layout, LF newlines, per-language coverage %.
+    // =====================================================================
+
+    [Fact]
+    public void FormatReport_UsesLfNewlinesOnly()
+    {
+        var findings = new[]
+        {
+            MakeFinding("a.axaml", 1, "Untranslated", new() { ["ja"] = false, ["zh"] = false, ["ko"] = false }, L10nVerdict.Untranslated),
+        };
+        string report = L10nScanner.FormatReport(findings, new[] { "ja", "zh", "ko" });
+        Assert.DoesNotContain("\r", report);
+    }
+
+    [Fact]
+    public void FormatReport_IncludesPerLanguageCoverage()
+    {
+        var findings = new[]
+        {
+            MakeFinding("a.axaml", 1, "Save",      new() { ["ja"] = true,  ["zh"] = true,  ["ko"] = true  }, L10nVerdict.Translated),
+            MakeFinding("a.axaml", 2, "Cancel",    new() { ["ja"] = true,  ["zh"] = false, ["ko"] = false }, L10nVerdict.PartiallyTranslated),
+            MakeFinding("a.axaml", 3, "Identity",  new() { ["ja"] = false, ["zh"] = false, ["ko"] = false }, L10nVerdict.Untranslated),
+        };
+        string report = L10nScanner.FormatReport(findings, new[] { "ja", "zh", "ko" });
+        // 2 / 3 ja-coverage = 66.7 %; 1 / 3 zh-coverage = 33.3 %; 1 / 3 ko-coverage = 33.3 %.
+        Assert.Contains("`ja`", report);
+        Assert.Contains("66.7", report);
+        Assert.Contains("33.3", report);
+        Assert.Contains("## Per-language Coverage", report);
+    }
+
+    [Fact]
+    public void FormatReport_HandlesEmptyFindings()
+    {
+        // Empty findings should produce a sensible report with "no untranslated" message.
+        var findings = Array.Empty<L10nFinding>();
+        string report = L10nScanner.FormatReport(findings, new[] { "ja" });
+        Assert.Contains("No untranslated literals", report);
+        // Body should still terminate with a single newline (trailing-blank trim).
+        Assert.EndsWith("\n", report);
+        Assert.DoesNotMatch(@"\n\n$", report);
+    }
+
+    [Fact]
+    public void FormatReport_GroupsUntranslatedByFile()
+    {
+        var findings = new[]
+        {
+            MakeFinding("Views/A.axaml", 1, "Foo", new() { ["ja"] = false }, L10nVerdict.Untranslated),
+            MakeFinding("Views/A.axaml", 5, "Bar", new() { ["ja"] = false }, L10nVerdict.Untranslated),
+            MakeFinding("Views/B.axaml", 1, "Qux", new() { ["ja"] = false }, L10nVerdict.Untranslated),
+        };
+        string report = L10nScanner.FormatReport(findings, new[] { "ja" });
+        Assert.Contains("### `Views/A.axaml`", report);
+        Assert.Contains("### `Views/B.axaml`", report);
+        // A has more untranslated than B → A appears first.
+        int idxA = report.IndexOf("### `Views/A.axaml`", StringComparison.Ordinal);
+        int idxB = report.IndexOf("### `Views/B.axaml`", StringComparison.Ordinal);
+        Assert.True(idxA < idxB, "Files with more Untranslated should sort first");
+    }
+
+    // =====================================================================
+    // End-to-end: synthetic AXAML + synthetic translation files on disk.
+    // =====================================================================
+
+    [Fact]
+    public void EndToEnd_OnDiskScanProducesExpectedFindings()
+    {
+        string tempRoot = Path.Combine(Path.GetTempPath(), "L10nScannerTests_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            // Build the directory layout the scanner expects.
+            string viewsDir = Path.Combine(tempRoot, "FEBuilderGBA.Avalonia", "Views");
+            string translateDir = Path.Combine(tempRoot, "config", "translate");
+            Directory.CreateDirectory(viewsDir);
+            Directory.CreateDirectory(translateDir);
+
+            File.WriteAllText(Path.Combine(viewsDir, "FakeView.axaml"), """
+                <UserControl xmlns="https://github.com/avaloniaui">
+                    <Button Content="Save" />
+                    <Button Content="Identity" />
+                    <Button Content="{Binding X}" />
+                    <TextBlock Text="保存" />
+                </UserControl>
+                """);
+
+            // en.txt — Japanese → English
+            File.WriteAllText(Path.Combine(translateDir, "en.txt"), ":書き込み\nSave\n\n");
+            // ja.txt — Japanese forward map; here it would normally be a no-op
+            // (key IS the source), but include it so the language has entries.
+            File.WriteAllText(Path.Combine(translateDir, "ja.txt"), ":書き込み\n保存\n\n");
+            // zh.txt — Japanese → Chinese
+            File.WriteAllText(Path.Combine(translateDir, "zh.txt"), ":書き込み\n保存\n\n");
+            // ko.txt — no entries; ko coverage stays at 0.
+
+            var findings = L10nScanner.Scan(tempRoot, new[] { "ja", "zh", "ko" });
+
+            // 3 candidates: "Save" (translated in ja+zh, not ko → Partial),
+            // "Identity" (no entries anywhere → Untranslated),
+            // "保存" (NonEnglish).
+            // The Binding attr is skipped entirely.
+            Assert.Equal(3, findings.Count);
+
+            var save = findings.Single(f => f.Literal == "Save");
+            Assert.Equal(L10nVerdict.PartiallyTranslated, save.Verdict);
+            Assert.True(save.TranslationStatus["ja"]);
+            Assert.True(save.TranslationStatus["zh"]);
+            Assert.False(save.TranslationStatus["ko"]);
+
+            var identity = findings.Single(f => f.Literal == "Identity");
+            Assert.Equal(L10nVerdict.Untranslated, identity.Verdict);
+
+            var jp = findings.Single(f => f.Literal == "保存");
+            Assert.Equal(L10nVerdict.NonEnglish, jp.Verdict);
+
+            // Repo-relative path uses forward slashes.
+            Assert.All(findings, f =>
+            {
+                Assert.DoesNotContain("\\", f.AxamlPath);
+                Assert.EndsWith("FakeView.axaml", f.AxamlPath);
+            });
+        }
+        finally
+        {
+            try { Directory.Delete(tempRoot, recursive: true); }
+            catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void LoadForwardMap_HandlesEscapedCrLf()
+    {
+        // The on-disk format encodes CRLF as `\r\n` (literal backslash-r-backslash-n).
+        // The parser must translate that back to real CRLF before the lookup.
+        string tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, ":line1\\r\\nline2\nvalue\n");
+            var map = L10nScanner.LoadForwardMap(tempFile);
+            Assert.True(map.ContainsKey("line1\r\nline2"));
+            Assert.Equal("value", map["line1\r\nline2"]);
+        }
+        finally
+        {
+            try { File.Delete(tempFile); }
+            catch { /* best effort */ }
+        }
+    }
+
+    // =====================================================================
+    // Helpers
+    // =====================================================================
+
+    static L10nFinding MakeFinding(
+        string path, int line, string literal,
+        Dictionary<string, bool> status, L10nVerdict verdict)
+    {
+        return new L10nFinding(
+            AxamlPath: path,
+            LineNumber: line,
+            ElementName: "TextBlock",
+            AttributeName: "Text",
+            Literal: literal,
+            TranslationStatus: status,
+            Verdict: verdict);
+    }
+
+    static IReadOnlyDictionary<string, string> EmptyReverse()
+        => new Dictionary<string, string>(StringComparer.Ordinal);
+
+    static IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> EmptyLangs(params string[] langs)
+    {
+        var dict = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.Ordinal);
+        foreach (string lang in langs)
+            dict[lang] = new Dictionary<string, string>(StringComparer.Ordinal);
+        return dict;
+    }
+
+    static (IReadOnlyDictionary<string, string> reverseEn,
+            IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> langMaps)
+        BuildMaps(
+            (string japaneseKey, string english, string japanese, string chinese, string korean)[] entries)
+    {
+        var reverseEn = new Dictionary<string, string>(StringComparer.Ordinal);
+        var jaMap = new Dictionary<string, string>(StringComparer.Ordinal);
+        var zhMap = new Dictionary<string, string>(StringComparer.Ordinal);
+        var koMap = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var e in entries)
+        {
+            reverseEn[e.english] = e.japaneseKey;
+            jaMap[e.japaneseKey] = e.japanese;
+            zhMap[e.japaneseKey] = e.chinese;
+            koMap[e.japaneseKey] = e.korean;
+        }
+        var langs = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.Ordinal)
+        {
+            ["ja"] = jaMap,
+            ["zh"] = zhMap,
+            ["ko"] = koMap,
+        };
+        return (reverseEn, langs);
+    }
+}

--- a/FEBuilderGBA.Avalonia/App.axaml.cs
+++ b/FEBuilderGBA.Avalonia/App.axaml.cs
@@ -82,6 +82,14 @@ namespace FEBuilderGBA.Avalonia
         /// <summary>Phase 3: ROM tag used as filename suffix (e.g. "FE8U") on both runners.</summary>
         public static string? GapSweepRomTag { get; set; }
 
+        /// <summary>
+        /// Phase 6: comma-separated list of target-language codes to join the AXAML
+        /// literal inventory against (e.g. "ja,zh,ko"). Defaults to
+        /// <see cref="L10nScanner.DefaultLanguages"/> when not supplied. English is
+        /// the source for AXAML literals so it never appears here.
+        /// </summary>
+        public static string? GapSweepLanguages { get; set; }
+
         public override void Initialize()
         {
             AvaloniaXamlLoader.Load(this);
@@ -192,6 +200,8 @@ namespace FEBuilderGBA.Avalonia
                         return RunUndoSweep(repoRoot, GapSweepOut!, GapSweepDryRun);
 
                     case "l10n":
+                        return RunL10nSweep(repoRoot, GapSweepOut!, GapSweepDryRun, GapSweepLanguages);
+
                     case "all":
                         // Phases 2-7 land in follow-up PRs. For Phase 0 we just
                         // write a header-only stub so callers can wire up CI now
@@ -373,6 +383,65 @@ namespace FEBuilderGBA.Avalonia
             string body = UndoCoverageScanner.FormatReport(rows);
             ReportWriter.WriteReport(outPath, "undo", new[] { body }, gitWorkingDir: repoRoot);
             Console.WriteLine($"GAPSWEEP[undo]: report written to {outPath}");
+            return 0;
+        }
+
+        /// <summary>
+        /// Phase 6: localisation sweep. Inventories every English-looking AXAML
+        /// literal under `FEBuilderGBA.Avalonia/Views/` and joins it against the
+        /// translation tables in `config/translate/<lang>.txt`. Returns 0 on
+        /// success.
+        ///
+        /// In dry-run mode we write only the YAML front-matter header (mirrors
+        /// every other sweep's dry-run shape) so callers can verify the CLI
+        /// plumbing without paying the XML-scan cost. The `languages` arg is a
+        /// comma-separated list (e.g. "ja,zh,ko"); when null we use
+        /// <see cref="L10nScanner.DefaultLanguages"/>.
+        /// </summary>
+        static int RunL10nSweep(string repoRoot, string outPath, bool dryRun, string? languagesArg)
+        {
+            // Parse the languages list once. Empty / null falls back to the
+            // default; we filter blank entries so "ja,,zh" still works.
+            IReadOnlyList<string> languages = string.IsNullOrEmpty(languagesArg)
+                ? L10nScanner.DefaultLanguages
+                : languagesArg.Split(',')
+                    .Select(s => s.Trim())
+                    .Where(s => s.Length > 0)
+                    .ToList();
+            if (languages.Count == 0)
+                languages = L10nScanner.DefaultLanguages;
+
+            // Front-matter extras: surface the languages set in the metadata so
+            // downstream tooling (Phase 7 CI) can introspect which targets the
+            // report covered without re-parsing the markdown body.
+            var extras = new Dictionary<string, string>
+            {
+                ["languages"] = string.Join(",", languages),
+            };
+
+            if (dryRun)
+            {
+                // Header-only — identical pattern to other dry-run paths.
+                string dir = Path.GetDirectoryName(Path.GetFullPath(outPath)) ?? "";
+                if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                    Directory.CreateDirectory(dir);
+                File.WriteAllText(outPath, ReportWriter.BuildFrontMatter("l10n", extras, gitWorkingDir: repoRoot));
+                Console.WriteLine($"GAPSWEEP[l10n]: dry-run header written (langs={string.Join(",", languages)}).");
+                return 0;
+            }
+
+            var findings = L10nScanner.Scan(repoRoot, languages);
+            int translated = findings.Count(f => f.Verdict == L10nVerdict.Translated);
+            int partial = findings.Count(f => f.Verdict == L10nVerdict.PartiallyTranslated);
+            int untranslated = findings.Count(f => f.Verdict == L10nVerdict.Untranslated);
+            int nonEnglish = findings.Count(f => f.Verdict == L10nVerdict.NonEnglish);
+            Console.WriteLine($"GAPSWEEP[l10n]: scanned {findings.Count} literals " +
+                $"(translated={translated} partial={partial} untranslated={untranslated} non-english={nonEnglish}; " +
+                $"langs={string.Join(",", languages)}).");
+
+            string body = L10nScanner.FormatReport(findings, languages);
+            ReportWriter.WriteReport(outPath, "l10n", new[] { body }, extras, gitWorkingDir: repoRoot);
+            Console.WriteLine($"GAPSWEEP[l10n]: report written to {outPath}");
             return 0;
         }
 
@@ -729,6 +798,10 @@ namespace FEBuilderGBA.Avalonia
                 else if (args[i].StartsWith("--rom-tag="))
                 {
                     GapSweepRomTag = args[i].Substring("--rom-tag=".Length);
+                }
+                else if (args[i].StartsWith("--languages="))
+                {
+                    GapSweepLanguages = args[i].Substring("--languages=".Length);
                 }
                 else if (args[i].StartsWith("--screenshot-dir="))
                 {

--- a/FEBuilderGBA.Avalonia/GapSweep/L10nScanner.cs
+++ b/FEBuilderGBA.Avalonia/GapSweep/L10nScanner.cs
@@ -1,0 +1,988 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// FEBuilderGBA gap-sweep tooling (#374) — Phase 6: localisation sweep.
+//
+// Issue #356 traces the user-visible symptom: when the Avalonia GUI is set to
+// Japanese or Chinese, several labels (`Identity`, `Base Stats`, `Weapon
+// Levels`, `Growth Rates (%)`, …) stay in English. Most of those literals
+// live as plain AXAML attribute values (no `{x:Static c:Strings.Foo}` binding,
+// no `R._()` call) so the translation layer never sees them.
+//
+// This scanner produces a mechanical inventory of every English-looking AXAML
+// literal in `FEBuilderGBA.Avalonia/Views/**/*.axaml` and joins it against
+// each language's translation table in `config/translate/<lang>.txt`. Each
+// literal lands in one of four buckets:
+//
+//   Translated         — every target language has a translation
+//   PartiallyTranslated — some languages have it, others don't
+//   Untranslated       — no target language has a translation (the backlog)
+//   NonEnglish         — source literal already contains CJK / Hangul (out
+//                        of scope: someone wrote it in the target language
+//                        directly, which is fine but flagged for sanity)
+//
+// Translation files have the format (see `MyTranslateResourceLow.LoadResource`):
+//
+//   :Japanese source string
+//   Translated string
+//   <blank line>
+//
+// `config/translate/en.txt` translates Japanese → English. For Avalonia
+// (which uses English literals directly) we follow the same reverse-lookup
+// chain the runtime uses:
+//
+//   AXAML literal "Save" → en.txt reverse map → Japanese key "書き込み"
+//                       → ja.txt forward map → Japanese translation
+//                       → zh.txt forward map → Chinese translation
+//
+// An AXAML literal counts as "translated" in a target language iff that
+// chain produces a non-empty result. The scanner is deliberately a static
+// analyzer: it does not modify any AXAML or translation file. The report is
+// the per-file backlog for follow-up gap-fix PRs.
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace FEBuilderGBA.Avalonia.GapSweep
+{
+    /// <summary>
+    /// How a literal scored against the joined translation tables.
+    /// Ordered roughly by "actionability" — the buckets that the report
+    /// surfaces in descending order of "you should look at this".
+    /// </summary>
+    public enum L10nVerdict
+    {
+        /// <summary>Source literal contains CJK / Hangul characters — already localized in-line.</summary>
+        NonEnglish,
+        /// <summary>Every target language has a non-empty translation entry.</summary>
+        Translated,
+        /// <summary>Some languages have a translation, others don't.</summary>
+        PartiallyTranslated,
+        /// <summary>No target language has a translation entry — the backlog.</summary>
+        Untranslated,
+    }
+
+    /// <summary>
+    /// One AXAML literal finding. The translation-status dictionary maps
+    /// language code → has-non-empty-entry (true/false). Original casing /
+    /// punctuation of <see cref="Literal"/> is preserved verbatim from the
+    /// AXAML attribute value — the report's normalisation key is internal.
+    /// </summary>
+    /// <param name="AxamlPath">Repo-relative AXAML file path with forward slashes.</param>
+    /// <param name="LineNumber">1-based source line of the element carrying the attribute (best-effort via IXmlLineInfo).</param>
+    /// <param name="ElementName">Element local-name (e.g. "Button", "TextBox", "TextBlock").</param>
+    /// <param name="AttributeName">Attribute local-name (e.g. "Text", "Content", "ToolTip.Tip").</param>
+    /// <param name="Literal">Original-cased literal value.</param>
+    /// <param name="TranslationStatus">Language code → did the lookup chain produce a non-empty translation.</param>
+    /// <param name="Verdict">Bucket classification.</param>
+    public record L10nFinding(
+        string AxamlPath,
+        int LineNumber,
+        string ElementName,
+        string AttributeName,
+        string Literal,
+        IReadOnlyDictionary<string, bool> TranslationStatus,
+        L10nVerdict Verdict);
+
+    /// <summary>
+    /// Phase 6: scan every Avalonia AXAML view for unbound English-looking
+    /// literals and join against the project's translation tables.
+    /// </summary>
+    public static class L10nScanner
+    {
+        /// <summary>
+        /// AXAML attribute local-names that carry user-visible labels.
+        /// Mirrors <c>LabelDiffScanner.AvLabelAttributes</c> so the two
+        /// scanners stay in sync. `ToolTip.Tip` is the Avalonia attached-
+        /// property form (this was a real bug surfaced in PR #377 Phase 2
+        /// before Copilot caught it — do NOT regress).
+        /// </summary>
+        static readonly HashSet<string> CandidateAttributes = new(StringComparer.Ordinal)
+        {
+            "Text",
+            "Content",
+            "Header",
+            "ToolTip",
+            "ToolTip.Tip",
+            "Watermark",
+        };
+
+        /// <summary>
+        /// Template containers — same set as <c>LabelDiffScanner.AvTemplateContainers</c>.
+        /// Elements nested inside any of these describe templates rather than the realised
+        /// layout; their literals never appear as actual UI text in the running app.
+        /// </summary>
+        static readonly HashSet<string> TemplateContainers = new(StringComparer.Ordinal)
+        {
+            "Design.DataContext",
+            "Style",
+            "Styles",
+            "DataTemplate",
+            "ControlTemplate",
+            "ItemTemplate",
+            "ItemsPanelTemplate",
+            "HierarchicalDataTemplate",
+        };
+
+        /// <summary>
+        /// Default language set the Phase 6 sweep joins against. English is the
+        /// SOURCE for AXAML literals so it never appears here — these are the
+        /// target translations we look up.
+        /// </summary>
+        public static readonly IReadOnlyList<string> DefaultLanguages = new[] { "ja", "zh", "ko" };
+
+        /// <summary>
+        /// Run the full Phase 6 scan over <paramref name="repoRoot"/>. Loads
+        /// translation tables for each language in <paramref name="languages"/>
+        /// (plus the reverse-English map from en.txt), then walks every
+        /// `*.axaml` under `FEBuilderGBA.Avalonia/Views/` looking for literal
+        /// attribute values that pass the "English-looking" heuristic.
+        ///
+        /// Returns findings ordered by (AxamlPath asc, LineNumber asc) so the
+        /// report is stable across runs.
+        /// </summary>
+        public static IReadOnlyList<L10nFinding> Scan(
+            string repoRoot,
+            IReadOnlyList<string>? languages = null)
+        {
+            if (string.IsNullOrEmpty(repoRoot))
+                throw new ArgumentException("repoRoot must be non-empty", nameof(repoRoot));
+            if (!Directory.Exists(repoRoot))
+                throw new DirectoryNotFoundException($"repo root not found: {repoRoot}");
+
+            languages ??= DefaultLanguages;
+
+            // Load reverse English → Japanese map from en.txt. en.txt is the
+            // pivot: AXAML uses English literals; en.txt maps Japanese key
+            // → English value; the reverse map flips it so we can find the
+            // Japanese key from an Avalonia literal, then forward-lookup in
+            // ja.txt / zh.txt / ko.txt.
+            string translateDir = Path.Combine(repoRoot, "config", "translate");
+            string enPath = Path.Combine(translateDir, "en.txt");
+            var reverseEnMap = LoadReverseEnglishMap(enPath);
+
+            // Load forward maps (Japanese key → translated value) per target
+            // language. Languages with no corresponding *.txt simply produce
+            // an empty dictionary — every literal is marked "not translated"
+            // in that language.
+            var languageMaps = new Dictionary<string, Dictionary<string, string>>(StringComparer.Ordinal);
+            foreach (string lang in languages)
+            {
+                string langPath = Path.Combine(translateDir, lang + ".txt");
+                languageMaps[lang] = LoadForwardMap(langPath);
+            }
+
+            // Walk the views.
+            var viewsDir = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views");
+            var findings = new List<L10nFinding>();
+            if (!Directory.Exists(viewsDir))
+                return findings;
+
+            foreach (string axamlPath in Directory.EnumerateFiles(viewsDir, "*.axaml", SearchOption.AllDirectories)
+                                                 .OrderBy(p => p, StringComparer.Ordinal))
+            {
+                string relPath = ToRelative(repoRoot, axamlPath);
+                ScanFile(axamlPath, relPath, reverseEnMap, languageMaps, languages, findings);
+            }
+
+            // Stable ordering: by file then by line.
+            return findings
+                .OrderBy(f => f.AxamlPath, StringComparer.Ordinal)
+                .ThenBy(f => f.LineNumber)
+                .ThenBy(f => f.Literal, StringComparer.Ordinal)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Scan a single AXAML file in-place. Internal entry point used by
+        /// <see cref="Scan"/>; exposed only for unit tests that want to drive
+        /// the per-file path without round-tripping through Scan's directory
+        /// glob.
+        /// </summary>
+        public static IReadOnlyList<L10nFinding> ScanAxaml(
+            string axamlPath,
+            string axamlRelPath,
+            IReadOnlyDictionary<string, string> reverseEnglishMap,
+            IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> languageMaps)
+        {
+            var findings = new List<L10nFinding>();
+            var maps = languageMaps.ToDictionary(
+                kv => kv.Key,
+                kv => kv.Value.ToDictionary(p => p.Key, p => p.Value, StringComparer.Ordinal),
+                StringComparer.Ordinal);
+            ScanFile(
+                axamlPath,
+                axamlRelPath,
+                reverseEnglishMap.ToDictionary(p => p.Key, p => p.Value, StringComparer.Ordinal),
+                maps,
+                languageMaps.Keys.ToList(),
+                findings);
+            return findings;
+        }
+
+        /// <summary>
+        /// In-memory variant for unit tests: takes the AXAML as an XML string
+        /// (or arbitrary path label) plus already-loaded translation maps.
+        /// Avoids any disk I/O so tests run hermetic.
+        /// </summary>
+        public static IReadOnlyList<L10nFinding> ScanXmlString(
+            string xmlContent,
+            string axamlRelPath,
+            IReadOnlyDictionary<string, string> reverseEnglishMap,
+            IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> languageMaps)
+        {
+            var findings = new List<L10nFinding>();
+            XDocument doc;
+            try
+            {
+                doc = XDocument.Parse(xmlContent, LoadOptions.SetLineInfo);
+            }
+            catch (XmlException)
+            {
+                return findings;
+            }
+            ScanDocument(
+                doc,
+                axamlRelPath,
+                reverseEnglishMap,
+                languageMaps,
+                languageMaps.Keys.ToList(),
+                findings);
+            return findings;
+        }
+
+        static void ScanFile(
+            string axamlPath,
+            string axamlRelPath,
+            IReadOnlyDictionary<string, string> reverseEnMap,
+            IReadOnlyDictionary<string, Dictionary<string, string>> languageMaps,
+            IReadOnlyList<string> languages,
+            List<L10nFinding> findings)
+        {
+            XDocument doc;
+            try
+            {
+                doc = XDocument.Load(axamlPath, LoadOptions.SetLineInfo);
+            }
+            catch
+            {
+                // Malformed AXAML — skip silently. Phase 7 will surface
+                // parse failures explicitly; for Phase 6 we just want a
+                // best-effort literal inventory.
+                return;
+            }
+
+            // Re-key languageMaps as IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>>
+            // so ScanDocument's signature works for both internal callers and the test seam.
+            var asReadOnly = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.Ordinal);
+            foreach (var kv in languageMaps)
+                asReadOnly[kv.Key] = kv.Value;
+            ScanDocument(doc, axamlRelPath, reverseEnMap, asReadOnly, languages, findings);
+        }
+
+        static void ScanDocument(
+            XDocument doc,
+            string axamlRelPath,
+            IReadOnlyDictionary<string, string> reverseEnMap,
+            IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> languageMaps,
+            IReadOnlyList<string> languages,
+            List<L10nFinding> findings)
+        {
+            if (doc.Root == null)
+                return;
+
+            foreach (XElement el in doc.Descendants())
+            {
+                if (IsInsideTemplate(el))
+                    continue;
+
+                foreach (XAttribute attr in el.Attributes())
+                {
+                    if (!CandidateAttributes.Contains(attr.Name.LocalName))
+                        continue;
+
+                    string raw = attr.Value;
+                    if (!IsCandidateLiteral(raw, out bool isNonEnglish))
+                        continue;
+
+                    var status = new Dictionary<string, bool>(StringComparer.Ordinal);
+                    int hit = 0;
+                    foreach (string lang in languages)
+                    {
+                        bool ok = false;
+                        if (languageMaps.TryGetValue(lang, out var map))
+                            ok = HasTranslation(raw, reverseEnMap, map);
+                        status[lang] = ok;
+                        if (ok) hit++;
+                    }
+
+                    L10nVerdict verdict;
+                    if (isNonEnglish)
+                    {
+                        verdict = L10nVerdict.NonEnglish;
+                    }
+                    else if (languages.Count == 0)
+                    {
+                        // No target languages requested — treat every literal
+                        // as Untranslated (defensive: avoids the "0/0 = 100 %"
+                        // false positive that would otherwise classify
+                        // everything as Translated).
+                        verdict = L10nVerdict.Untranslated;
+                    }
+                    else if (hit == languages.Count)
+                    {
+                        verdict = L10nVerdict.Translated;
+                    }
+                    else if (hit == 0)
+                    {
+                        verdict = L10nVerdict.Untranslated;
+                    }
+                    else
+                    {
+                        verdict = L10nVerdict.PartiallyTranslated;
+                    }
+
+                    int line = 0;
+                    if (attr is IXmlLineInfo lineInfo && lineInfo.HasLineInfo())
+                        line = lineInfo.LineNumber;
+                    else if (el is IXmlLineInfo elLineInfo && elLineInfo.HasLineInfo())
+                        line = elLineInfo.LineNumber;
+
+                    findings.Add(new L10nFinding(
+                        AxamlPath: axamlRelPath,
+                        LineNumber: line,
+                        ElementName: el.Name.LocalName,
+                        AttributeName: attr.Name.LocalName,
+                        Literal: raw,
+                        TranslationStatus: status,
+                        Verdict: verdict));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Walk up the ancestor chain looking for a known template container.
+        /// Same logic as <c>LabelDiffScanner.IsInsideTemplate</c>.
+        /// </summary>
+        static bool IsInsideTemplate(XElement el)
+        {
+            for (XElement? cur = el.Parent; cur != null; cur = cur.Parent)
+            {
+                if (TemplateContainers.Contains(cur.Name.LocalName))
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Quick classification: is <paramref name="value"/> a candidate
+        /// English-looking literal that we should record? Sets
+        /// <paramref name="isNonEnglish"/> true when the value contains any
+        /// CJK / Hangul character (caller will tag it as <see cref="L10nVerdict.NonEnglish"/>
+        /// and skip the translation join).
+        ///
+        /// Excludes:
+        ///   - empty / whitespace-only
+        ///   - markup extensions (starts with `{`)
+        ///   - pure numeric / pure punctuation
+        ///   - single-char values
+        ///   - short pseudo-words that aren't real labels (length &lt; 2)
+        ///
+        /// Accepts:
+        ///   - any value with at least 1 letter AND a space (multi-word labels)
+        ///   - any value ≥ 4 chars and ≥ 80% ASCII letters (single-word labels)
+        ///   - non-English values (caller flags them NonEnglish via the out-param)
+        /// </summary>
+        public static bool IsCandidateLiteral(string value, out bool isNonEnglish)
+        {
+            isNonEnglish = false;
+            if (string.IsNullOrEmpty(value))
+                return false;
+            string trimmed = value.Trim();
+            if (trimmed.Length == 0)
+                return false;
+            // Markup extension — skip.
+            if (trimmed[0] == '{')
+                return false;
+            // Single character: too noisy (think `?`, `:`, `…`).
+            if (trimmed.Length < 2)
+                return false;
+
+            // CJK / Hangul detection. If ANY character in the literal lies in
+            // these blocks, treat it as already-localised source (NonEnglish).
+            // We accept it as a candidate (so it shows up in the report's
+            // NonEnglish section for sanity) but skip the translation join.
+            foreach (char c in trimmed)
+            {
+                if (IsCjkOrHangul(c))
+                {
+                    isNonEnglish = true;
+                    return true;
+                }
+            }
+
+            // Pure-digit / pure-punct: not a label.
+            bool hasLetter = false;
+            int letterCount = 0;
+            int asciiLetterCount = 0;
+            foreach (char c in trimmed)
+            {
+                if (char.IsLetter(c))
+                {
+                    hasLetter = true;
+                    letterCount++;
+                    if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'))
+                        asciiLetterCount++;
+                }
+            }
+            if (!hasLetter)
+                return false;
+
+            // Must start with an ASCII letter (proper English labels do; this
+            // filters out `:Status`, `(Optional)`, etc. that would otherwise
+            // sneak in as Untranslated noise).
+            if (!((trimmed[0] >= 'A' && trimmed[0] <= 'Z') || (trimmed[0] >= 'a' && trimmed[0] <= 'z')))
+                return false;
+
+            // Multi-word labels: at least one space and at least one letter.
+            bool hasSpace = trimmed.IndexOf(' ') >= 0;
+            if (hasSpace)
+                return true;
+
+            // Single-word labels: at least 4 chars AND ≥ 80 % ASCII-letter
+            // density. The density check kills things like `0x10`, `FF00`,
+            // `RGB16` that are technical strings, not localizable labels.
+            if (trimmed.Length >= 4 && (double)asciiLetterCount / trimmed.Length >= 0.8)
+                return true;
+
+            return false;
+        }
+
+        /// <summary>
+        /// True if <paramref name="c"/> is in a CJK / Hangul / Hiragana /
+        /// Katakana Unicode block. Used as the "already localised in-line"
+        /// heuristic — if the source AXAML literal already contains any of
+        /// these characters, it's not a translation gap.
+        /// </summary>
+        static bool IsCjkOrHangul(char c)
+        {
+            // Hiragana 3040-309F, Katakana 30A0-30FF, CJK Unified Ideographs
+            // 4E00-9FFF, CJK Compatibility 3400-4DBF, Hangul Syllables AC00-D7AF,
+            // Hangul Jamo 1100-11FF, Halfwidth/Fullwidth FF00-FFEF.
+            if (c >= 0x3040 && c <= 0x309F) return true;
+            if (c >= 0x30A0 && c <= 0x30FF) return true;
+            if (c >= 0x4E00 && c <= 0x9FFF) return true;
+            if (c >= 0x3400 && c <= 0x4DBF) return true;
+            if (c >= 0xAC00 && c <= 0xD7AF) return true;
+            if (c >= 0x1100 && c <= 0x11FF) return true;
+            if (c >= 0xFF00 && c <= 0xFFEF) return true;
+            return false;
+        }
+
+        /// <summary>
+        /// Lookup chain: AXAML English literal → en.txt reverse-map → Japanese key
+        /// → forward map → translated value. Returns true iff the chain yields a
+        /// non-empty target-language string.
+        ///
+        /// Falls back to a forward-map direct lookup using the English literal
+        /// itself as the key — some translation files (like ja.txt) use English
+        /// keys directly for menu items, so the direct lookup catches those too.
+        /// </summary>
+        static bool HasTranslation(
+            string englishLiteral,
+            IReadOnlyDictionary<string, string> reverseEnMap,
+            IReadOnlyDictionary<string, string> forwardMap)
+        {
+            // 1. Direct lookup — some entries are keyed by English directly.
+            string normalised = NormalizeKey(englishLiteral);
+            if (TryLookup(forwardMap, englishLiteral, normalised, out var direct) &&
+                !string.IsNullOrWhiteSpace(direct))
+                return true;
+
+            // 2. Reverse chain via en.txt.
+            if (TryLookup(reverseEnMap, englishLiteral, normalised, out var jpKey))
+            {
+                if (forwardMap.TryGetValue(jpKey, out var translated) &&
+                    !string.IsNullOrWhiteSpace(translated))
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Two-step lookup: try the raw key first, then the trim-trailing-colon
+        /// normalised key. Returns true if either succeeded.
+        /// </summary>
+        static bool TryLookup(
+            IReadOnlyDictionary<string, string> map,
+            string raw,
+            string normalised,
+            out string value)
+        {
+            if (map.TryGetValue(raw, out value!))
+                return true;
+            if (!ReferenceEquals(raw, normalised) && map.TryGetValue(normalised, out value!))
+                return true;
+            value = string.Empty;
+            return false;
+        }
+
+        /// <summary>
+        /// Trim outer whitespace and any trailing colon — AXAML labels use the
+        /// short form ("Save") while WinForms designer literals use the colon
+        /// form ("Save:"). Translation tables historically reflect the WinForms
+        /// convention.
+        /// </summary>
+        public static string NormalizeKey(string raw)
+        {
+            if (string.IsNullOrEmpty(raw))
+                return string.Empty;
+            string s = raw.Trim();
+            while (s.EndsWith(":", StringComparison.Ordinal))
+                s = s.Substring(0, s.Length - 1).TrimEnd();
+            return s;
+        }
+
+        // ---------------------------------------------------------------------
+        // Translation table loaders
+        //
+        // The file format mirrors `MyTranslateResourceLow.LoadResource`:
+        //   :Japanese key
+        //   Translated value
+        //   <blank>
+        //
+        // Lines that don't start with `:` are translation values; the line
+        // immediately before them was the key. Blank lines reset the parser.
+        // ---------------------------------------------------------------------
+
+        /// <summary>
+        /// Parse `config/translate/&lt;lang&gt;.txt` into a Japanese-key →
+        /// translated-value dictionary. Adds both the raw key AND the
+        /// trim-trailing-colon normalised form so callers can look up either.
+        /// Returns an empty dictionary if the file does not exist.
+        /// </summary>
+        public static Dictionary<string, string> LoadForwardMap(string path)
+        {
+            var dict = new Dictionary<string, string>(StringComparer.Ordinal);
+            if (string.IsNullOrEmpty(path) || !File.Exists(path))
+                return dict;
+
+            ParseTranslateFile(path, (key, value) =>
+            {
+                if (string.IsNullOrEmpty(key))
+                    return;
+                if (!dict.ContainsKey(key))
+                    dict[key] = value;
+                string norm = NormalizeKey(key);
+                if (norm.Length > 0 && !dict.ContainsKey(norm))
+                    dict[norm] = value;
+            });
+
+            return dict;
+        }
+
+        /// <summary>
+        /// Parse `config/translate/en.txt` into a reverse English-value →
+        /// Japanese-key dictionary. This is the pivot map: en.txt's forward
+        /// direction is Japanese → English, but Avalonia uses English literals
+        /// directly so we need the reverse direction to find the Japanese key.
+        /// Adds both raw and trim-trailing-colon normalised forms.
+        /// </summary>
+        public static Dictionary<string, string> LoadReverseEnglishMap(string enPath)
+        {
+            var dict = new Dictionary<string, string>(StringComparer.Ordinal);
+            if (string.IsNullOrEmpty(enPath) || !File.Exists(enPath))
+                return dict;
+
+            ParseTranslateFile(enPath, (jaKey, enValue) =>
+            {
+                if (string.IsNullOrEmpty(enValue))
+                    return;
+                string trimmed = enValue.TrimEnd();
+                if (!dict.ContainsKey(trimmed))
+                    dict[trimmed] = jaKey;
+                string norm = NormalizeKey(trimmed);
+                if (norm.Length > 0 && !dict.ContainsKey(norm))
+                    dict[norm] = jaKey;
+            });
+
+            return dict;
+        }
+
+        /// <summary>
+        /// Stream a translate-format text file and invoke <paramref name="onPair"/>
+        /// for every (key, value) pair. The parser is forgiving: it tolerates
+        /// missing blank-line separators, extra whitespace, and skips lines that
+        /// don't look like keys or follow-up values.
+        ///
+        /// Format (literal):
+        ///
+        ///     :SourceKey1
+        ///     Translation1
+        ///     &lt;blank&gt;
+        ///     :SourceKey2
+        ///     Translation2
+        ///     &lt;blank&gt;
+        ///
+        /// `\r\n` escape sequences in the file are translated to real CRLF
+        /// (matching the runtime parser at `MyTranslateResourceLow.LoadResource`).
+        /// </summary>
+        static void ParseTranslateFile(string path, Action<string, string> onPair)
+        {
+            try
+            {
+                using var reader = new StreamReader(path);
+                string? src = null;
+                string? line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    if (line.Length == 0)
+                    {
+                        src = null;
+                        continue;
+                    }
+                    if (src == null)
+                    {
+                        if (line[0] != ':')
+                            continue;
+                        src = line.Substring(1).Replace("\\r\\n", "\r\n");
+                    }
+                    else
+                    {
+                        string value = line.Replace("\\r\\n", "\r\n");
+                        onPair(src, value);
+                        src = null;
+                    }
+                }
+            }
+            catch
+            {
+                // Best-effort parsing — corrupt files produce a partial map.
+            }
+        }
+
+        /// <summary>
+        /// Convert an absolute path into a repo-relative path with forward
+        /// slashes. Falls back to the original path if the rel-path calculation
+        /// fails (rare — happens when the file isn't under the repo root, which
+        /// shouldn't occur in practice but we don't want to crash the report).
+        /// </summary>
+        static string ToRelative(string repoRoot, string absolutePath)
+        {
+            try
+            {
+                string rel = Path.GetRelativePath(repoRoot, absolutePath);
+                return rel.Replace('\\', '/');
+            }
+            catch
+            {
+                return absolutePath.Replace('\\', '/');
+            }
+        }
+
+        /// <summary>
+        /// Format the markdown body of the localisation report (sans front-matter
+        /// — that is added by <see cref="ReportWriter"/>). Layout:
+        ///
+        ///  1. Methodology header
+        ///  2. Summary table with per-verdict counts
+        ///  3. Per-language coverage table (% translated)
+        ///  4. "Untranslated literals" section grouped by file
+        ///  5. "Partially translated literals" with per-language tick columns
+        ///  6. "Already translated" collapsed summary
+        ///  7. "Non-English source literals" small sanity section
+        ///
+        /// LF newlines only (matches other GapSweep reports).
+        /// </summary>
+        public static string FormatReport(
+            IReadOnlyList<L10nFinding> findings,
+            IReadOnlyList<string> languages)
+        {
+            if (findings == null) throw new ArgumentNullException(nameof(findings));
+            if (languages == null) throw new ArgumentNullException(nameof(languages));
+
+            var sb = new StringBuilder();
+            sb.Append("# Avalonia — Localisation Sweep\n\n");
+            sb.Append("Phase 6 of the gap-sweep methodology surfaces every English-looking AXAML\n");
+            sb.Append("literal in `FEBuilderGBA.Avalonia/Views/` that ISN'T bound to a localized\n");
+            sb.Append("resource AND isn't already present in the project's translation tables.\n\n");
+            sb.Append("Issue [#356](https://github.com/laqieer/FEBuilderGBA/issues/356) reports the\n");
+            sb.Append("user-visible symptom: when the Avalonia GUI is set to Japanese or Chinese,\n");
+            sb.Append("several labels stay in English. This report inventories every such literal\n");
+            sb.Append("so follow-up gap-fix PRs can add the missing translation entries one file at\n");
+            sb.Append("a time.\n\n");
+            sb.Append("**Methodology:**\n\n");
+            sb.Append("- Glob `FEBuilderGBA.Avalonia/Views/**/*.axaml`; parse each with `XDocument`\n");
+            sb.Append("  using `LoadOptions.SetLineInfo` so we get per-attribute line numbers.\n");
+            sb.Append("- Inspect attribute values for `Text` / `Content` / `Header` / `ToolTip` /\n");
+            sb.Append("  `Watermark` / `ToolTip.Tip` (the Avalonia attached-property form).\n");
+            sb.Append("- Skip markup extensions (`{Binding ...}`, `{StaticResource ...}`,\n");
+            sb.Append("  `{x:Static ...}`, `{DynamicResource ...}`, `{TemplateBinding ...}`) and\n");
+            sb.Append("  elements nested under `Style` / `DataTemplate` / `ControlTemplate` /\n");
+            sb.Append("  `ItemTemplate` / `Design.DataContext`.\n");
+            sb.Append("- Heuristic accepts: any value starting with an ASCII letter, length ≥ 2,\n");
+            sb.Append("  containing at least one space OR ≥ 4 chars with ≥ 80 % ASCII-letter\n");
+            sb.Append("  density. Values containing CJK / Hangul characters are recorded as\n");
+            sb.Append("  `NonEnglish` (out-of-scope sanity row, not a gap).\n");
+            sb.Append("- Translation join: for each candidate literal, look it up in each target\n");
+            sb.Append("  language's `config/translate/<lang>.txt` table via the same reverse-English\n");
+            sb.Append("  chain the runtime uses (English value → Japanese key → translated value).\n\n");
+            sb.Append("**Verdict tiers:**\n\n");
+            sb.Append("- `Untranslated` — no target language has a translation. The backlog.\n");
+            sb.Append("- `PartiallyTranslated` — some languages have it, others don't.\n");
+            sb.Append("- `Translated` — every target language has a translation.\n");
+            sb.Append("- `NonEnglish` — source literal already contains CJK / Hangul (out of scope).\n\n");
+            sb.Append("Methodology lives in `FEBuilderGBA.Avalonia/GapSweep/L10nScanner.cs`.\n");
+            sb.Append("Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-l10n --out=<path>`.\n\n");
+
+            // ---- Summary table ----
+            int total = findings.Count;
+            int translated = findings.Count(f => f.Verdict == L10nVerdict.Translated);
+            int partial = findings.Count(f => f.Verdict == L10nVerdict.PartiallyTranslated);
+            int untranslated = findings.Count(f => f.Verdict == L10nVerdict.Untranslated);
+            int nonEnglish = findings.Count(f => f.Verdict == L10nVerdict.NonEnglish);
+
+            sb.Append("## Summary\n\n");
+            sb.Append("| Verdict | Count | % of total |\n");
+            sb.Append("|---|---:|---:|\n");
+            AppendSummaryRow(sb, "Untranslated", untranslated, total);
+            AppendSummaryRow(sb, "PartiallyTranslated", partial, total);
+            AppendSummaryRow(sb, "Translated", translated, total);
+            AppendSummaryRow(sb, "NonEnglish", nonEnglish, total);
+            AppendSummaryRow(sb, "**Total**", total, total);
+            sb.Append('\n');
+
+            // ---- Per-language coverage ----
+            // For each language, count how many "English-source" findings (i.e.
+            // excluding the NonEnglish ones, which are already localised) have a
+            // translation in that language. Denominator excludes NonEnglish so
+            // the percentage measures "real coverage of in-scope literals".
+            int englishOnly = total - nonEnglish;
+            sb.Append("## Per-language Coverage\n\n");
+            sb.Append("Coverage is computed over the English-source literals only ");
+            sb.Append("(excludes the `NonEnglish` rows, which are out of scope).\n\n");
+            sb.Append("| Language | Translated | English-source total | % |\n");
+            sb.Append("|---|---:|---:|---:|\n");
+            foreach (string lang in languages)
+            {
+                int langTranslated = findings.Count(f =>
+                    f.Verdict != L10nVerdict.NonEnglish &&
+                    f.TranslationStatus.TryGetValue(lang, out bool ok) && ok);
+                string pct = englishOnly > 0
+                    ? ((100.0 * langTranslated) / englishOnly).ToString("F1", CultureInfo.InvariantCulture)
+                    : "—";
+                sb.Append("| `").Append(lang)
+                  .Append("` | ").Append(langTranslated.ToString(CultureInfo.InvariantCulture))
+                  .Append(" | ").Append(englishOnly.ToString(CultureInfo.InvariantCulture))
+                  .Append(" | ").Append(pct).Append(" |\n");
+            }
+            sb.Append('\n');
+
+            // ---- Top 20 files by Untranslated count ----
+            var untranslatedByFile = findings
+                .Where(f => f.Verdict == L10nVerdict.Untranslated)
+                .GroupBy(f => f.AxamlPath, StringComparer.Ordinal)
+                .Select(g => new { File = g.Key, Count = g.Count() })
+                .OrderByDescending(x => x.Count)
+                .ThenBy(x => x.File, StringComparer.Ordinal)
+                .ToList();
+
+            sb.Append("## Top 20 Files by Untranslated Literal Count\n\n");
+            sb.Append("Each row's count is the upper bound on the localisation backlog for that\n");
+            sb.Append("file. Files are sorted by Untranslated count descending.\n\n");
+            if (untranslatedByFile.Count == 0)
+            {
+                sb.Append("_No untranslated literals — every English-looking AXAML literal has a translation entry._\n\n");
+            }
+            else
+            {
+                sb.Append("| Rank | File | Untranslated |\n");
+                sb.Append("|---:|---|---:|\n");
+                int rank = 0;
+                foreach (var f in untranslatedByFile.Take(20))
+                {
+                    rank++;
+                    sb.Append("| ").Append(rank.ToString(CultureInfo.InvariantCulture))
+                      .Append(" | `").Append(f.File).Append("` | ")
+                      .Append(f.Count.ToString(CultureInfo.InvariantCulture)).Append(" |\n");
+                }
+                sb.Append('\n');
+            }
+
+            // ---- Per-file untranslated section ----
+            sb.Append("## Untranslated Literals (No Language Has Them)\n\n");
+            if (untranslatedByFile.Count == 0)
+            {
+                sb.Append("_None._\n\n");
+            }
+            else
+            {
+                sb.Append("Each row is a literal that has no translation in ANY of the target\n");
+                sb.Append("languages. Fix these by adding entries to `config/translate/<lang>.txt`.\n\n");
+                foreach (var fileGroup in findings
+                    .Where(f => f.Verdict == L10nVerdict.Untranslated)
+                    .GroupBy(f => f.AxamlPath, StringComparer.Ordinal)
+                    .OrderByDescending(g => g.Count())
+                    .ThenBy(g => g.Key, StringComparer.Ordinal))
+                {
+                    sb.Append("### `").Append(fileGroup.Key).Append("`\n\n");
+                    sb.Append("| Line | Element | Attribute | Literal |\n");
+                    sb.Append("|---:|---|---|---|\n");
+                    foreach (var f in fileGroup.OrderBy(x => x.LineNumber).ThenBy(x => x.Literal, StringComparer.Ordinal))
+                    {
+                        sb.Append("| ").Append(f.LineNumber.ToString(CultureInfo.InvariantCulture))
+                          .Append(" | `").Append(f.ElementName).Append("`")
+                          .Append(" | `").Append(f.AttributeName).Append("`")
+                          .Append(" | ").Append(RenderLiteral(f.Literal)).Append(" |\n");
+                    }
+                    sb.Append('\n');
+                }
+            }
+
+            // ---- Partially translated section ----
+            sb.Append("## Partially Translated Literals\n\n");
+            var partialList = findings.Where(f => f.Verdict == L10nVerdict.PartiallyTranslated).ToList();
+            if (partialList.Count == 0)
+            {
+                sb.Append("_None._\n\n");
+            }
+            else
+            {
+                sb.Append("Some target languages have a translation, others don't. The tick columns\n");
+                sb.Append("show which languages cover the literal.\n\n");
+                foreach (var fileGroup in partialList
+                    .GroupBy(f => f.AxamlPath, StringComparer.Ordinal)
+                    .OrderByDescending(g => g.Count())
+                    .ThenBy(g => g.Key, StringComparer.Ordinal))
+                {
+                    sb.Append("### `").Append(fileGroup.Key).Append("`\n\n");
+                    sb.Append("| Line | Literal |");
+                    foreach (string lang in languages)
+                        sb.Append(' ').Append(lang).Append(" |");
+                    sb.Append('\n');
+                    sb.Append("|---:|---|");
+                    foreach (var _ in languages)
+                        sb.Append(":---:|");
+                    sb.Append('\n');
+                    foreach (var f in fileGroup.OrderBy(x => x.LineNumber).ThenBy(x => x.Literal, StringComparer.Ordinal))
+                    {
+                        sb.Append("| ").Append(f.LineNumber.ToString(CultureInfo.InvariantCulture))
+                          .Append(" | ").Append(RenderLiteral(f.Literal)).Append(" |");
+                        foreach (string lang in languages)
+                        {
+                            bool ok = f.TranslationStatus.TryGetValue(lang, out var v) && v;
+                            sb.Append(' ').Append(ok ? "✓" : "✗").Append(" |");
+                        }
+                        sb.Append('\n');
+                    }
+                    sb.Append('\n');
+                }
+            }
+
+            // ---- Already-translated counts ----
+            sb.Append("## Already Translated (Summary)\n\n");
+            sb.Append("Literals that have a translation in every target language. Surfaced as a\n");
+            sb.Append("count per file so the report stays scannable; the per-literal detail is\n");
+            sb.Append("intentionally not listed (they're already covered).\n\n");
+            var translatedByFile = findings
+                .Where(f => f.Verdict == L10nVerdict.Translated)
+                .GroupBy(f => f.AxamlPath, StringComparer.Ordinal)
+                .Select(g => new { File = g.Key, Count = g.Count() })
+                .OrderByDescending(x => x.Count)
+                .ThenBy(x => x.File, StringComparer.Ordinal)
+                .ToList();
+            if (translatedByFile.Count == 0)
+            {
+                sb.Append("_No fully-translated literals._\n\n");
+            }
+            else
+            {
+                sb.Append("| File | Translated |\n");
+                sb.Append("|---|---:|\n");
+                foreach (var t in translatedByFile)
+                {
+                    sb.Append("| `").Append(t.File).Append("` | ")
+                      .Append(t.Count.ToString(CultureInfo.InvariantCulture)).Append(" |\n");
+                }
+                sb.Append('\n');
+            }
+
+            // ---- Non-English literals ----
+            sb.Append("## Non-English Source Literals (Out of Scope)\n\n");
+            sb.Append("AXAML literals that already contain CJK / Hangul characters — someone wrote\n");
+            sb.Append("them directly in the target language instead of routing them through the\n");
+            sb.Append("translation tables. This is fine when the literal IS the canonical form\n");
+            sb.Append("(matches the user's locale), but flagged for sanity in case any are stray\n");
+            sb.Append("leftovers from a partial localisation attempt.\n\n");
+            var nonEnglishList = findings.Where(f => f.Verdict == L10nVerdict.NonEnglish).ToList();
+            if (nonEnglishList.Count == 0)
+            {
+                sb.Append("_None._\n\n");
+            }
+            else
+            {
+                sb.Append("| File | Line | Element | Attribute | Literal |\n");
+                sb.Append("|---|---:|---|---|---|\n");
+                foreach (var f in nonEnglishList
+                    .OrderBy(x => x.AxamlPath, StringComparer.Ordinal)
+                    .ThenBy(x => x.LineNumber))
+                {
+                    sb.Append("| `").Append(f.AxamlPath).Append("` | ")
+                      .Append(f.LineNumber.ToString(CultureInfo.InvariantCulture))
+                      .Append(" | `").Append(f.ElementName).Append("`")
+                      .Append(" | `").Append(f.AttributeName).Append("`")
+                      .Append(" | ").Append(RenderLiteral(f.Literal)).Append(" |\n");
+                }
+                sb.Append('\n');
+            }
+
+            // Trim trailing blank lines so the body ends in a single `\n`
+            // (same discipline as the other GapSweep scanners).
+            while (sb.Length >= 2 && sb[sb.Length - 1] == '\n' && sb[sb.Length - 2] == '\n')
+                sb.Length--;
+            return sb.ToString();
+        }
+
+        static void AppendSummaryRow(StringBuilder sb, string label, int count, int total)
+        {
+            string pct = total > 0
+                ? ((100.0 * count) / total).ToString("F1", CultureInfo.InvariantCulture)
+                : "—";
+            sb.Append("| ").Append(label).Append(" | ")
+              .Append(count.ToString(CultureInfo.InvariantCulture)).Append(" | ")
+              .Append(pct).Append(" |\n");
+        }
+
+        /// <summary>
+        /// Render a literal as an inline-code markdown span safely. Mirrors
+        /// <c>LabelDiffScanner.RenderLabelLiteral</c>'s discipline: escape
+        /// embedded CR/LF, truncate at 200 chars, choose a backtick fence that
+        /// won't collide with embedded backticks. Also escapes pipe chars (`|`)
+        /// because we're rendering into a markdown table cell.
+        /// </summary>
+        static string RenderLiteral(string literal)
+        {
+            string escaped = literal
+                .Replace("\r", "\\r")
+                .Replace("\n", "\\n");
+
+            const int MaxLen = 200;
+            if (escaped.Length > MaxLen)
+                escaped = escaped.Substring(0, MaxLen) + "… (truncated)";
+
+            // Replace pipe with a Unicode lookalike INSIDE the code-span so the
+            // markdown table cell doesn't break. CommonMark doesn't escape `|`
+            // inside `` `code` `` spans inside table cells, so we substitute
+            // U+FF5C FULLWIDTH VERTICAL LINE instead.
+            escaped = escaped.Replace("|", "｜");
+
+            if (escaped.IndexOf('`') < 0)
+                return "`" + escaped + "`";
+            return "`` " + escaped + " ``";
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/GapSweep/L10nScanner.cs
+++ b/FEBuilderGBA.Avalonia/GapSweep/L10nScanner.cs
@@ -525,7 +525,16 @@ namespace FEBuilderGBA.Avalonia.GapSweep
         {
             if (map.TryGetValue(raw, out value!))
                 return true;
-            if (!ReferenceEquals(raw, normalised) && map.TryGetValue(normalised, out value!))
+            // Skip the normalised retry when the normalisation was a no-op
+            // (raw and normalised carry the same content) — saves a second
+            // dictionary probe in the common case where the AXAML literal
+            // had no trailing whitespace / colon. Use ordinal content
+            // comparison: most callers DO pass `NormalizeKey(raw)` so the
+            // common path has DIFFERENT references with EQUAL content, and
+            // a `ReferenceEquals` skip would always be false (Copilot review
+            // PR #381 caught this).
+            if (!string.Equals(raw, normalised, StringComparison.Ordinal) &&
+                map.TryGetValue(normalised, out value!))
                 return true;
             value = string.Empty;
             return false;

--- a/README.md
+++ b/README.md
@@ -160,15 +160,18 @@ dotnet run --project FEBuilderGBA.Avalonia -- --rom path/to/rom.gba --validate-i
 # Import: format auto-detected from file content/header, then extension, then GBA raw fallback
 dotnet run --project FEBuilderGBA.Avalonia -- --rom path/to/rom.gba --validate-palette
 
-# Avalonia ↔ WinForms gap-sweep — Phases 1/2/4 (static analysis, no ROM needed)
+# Avalonia ↔ WinForms gap-sweep — Phases 1/2/4/5/6 (static analysis, no ROM needed)
 # Generates markdown reports under docs/avalonia-gaps/ ranking every paired editor
-# by control-count delta, label-set diff, and cross-editor navigation parity. See
-# docs/avalonia-gaps/README.md for the multi-axis methodology (Phase 1 = density,
-# Phase 2 = label diff, Phase 3 = side-by-side screenshot gallery,
-# Phase 4 = headless jump/navigation parity, Phases 5-7 = undo, l10n, meta-CI).
+# by control-count delta, label-set diff, cross-editor navigation parity, undo
+# coverage, and localisation. See docs/avalonia-gaps/README.md for the multi-axis
+# methodology (Phase 1 = density, Phase 2 = label diff, Phase 3 = side-by-side
+# screenshot gallery, Phase 4 = headless jump/navigation parity, Phase 5 = undo
+# coverage, Phase 6 = localisation, Phase 7 = meta-CI).
 dotnet run --project FEBuilderGBA.Avalonia -- --gap-sweep-density --out=docs/avalonia-gaps/$(date +%F)-density-sweep.md
 dotnet run --project FEBuilderGBA.Avalonia -- --gap-sweep-labels  --out=docs/avalonia-gaps/$(date +%F)-labels-sweep.md
 dotnet run --project FEBuilderGBA.Avalonia -- --gap-sweep-jumps   --out=docs/avalonia-gaps/$(date +%F)-jumps-sweep.md
+dotnet run --project FEBuilderGBA.Avalonia -- --gap-sweep-undo    --out=docs/avalonia-gaps/$(date +%F)-undo-sweep.md
+dotnet run --project FEBuilderGBA.Avalonia -- --gap-sweep-l10n --languages=ja,zh,ko --out=docs/avalonia-gaps/$(date +%F)-l10n-sweep.md
 dotnet run --project FEBuilderGBA.Avalonia -- --gap-sweep-density --dry-run --out=tmp/density.md
 
 # Avalonia ↔ WinForms gap-sweep — Phase 3 (requires ROM — drives both

--- a/docs/avalonia-gaps/2026-05-22-l10n-sweep.md
+++ b/docs/avalonia-gaps/2026-05-22-l10n-sweep.md
@@ -1,0 +1,5256 @@
+---
+generated: "2026-05-21T21:58:54Z"
+git-sha: 65bf91ea2
+sweep-type: l10n
+languages: ja,zh,ko
+---
+
+# Avalonia — Localisation Sweep
+
+Phase 6 of the gap-sweep methodology surfaces every English-looking AXAML
+literal in `FEBuilderGBA.Avalonia/Views/` that ISN'T bound to a localized
+resource AND isn't already present in the project's translation tables.
+
+Issue [#356](https://github.com/laqieer/FEBuilderGBA/issues/356) reports the
+user-visible symptom: when the Avalonia GUI is set to Japanese or Chinese,
+several labels stay in English. This report inventories every such literal
+so follow-up gap-fix PRs can add the missing translation entries one file at
+a time.
+
+**Methodology:**
+
+- Glob `FEBuilderGBA.Avalonia/Views/**/*.axaml`; parse each with `XDocument`
+  using `LoadOptions.SetLineInfo` so we get per-attribute line numbers.
+- Inspect attribute values for `Text` / `Content` / `Header` / `ToolTip` /
+  `Watermark` / `ToolTip.Tip` (the Avalonia attached-property form).
+- Skip markup extensions (`{Binding ...}`, `{StaticResource ...}`,
+  `{x:Static ...}`, `{DynamicResource ...}`, `{TemplateBinding ...}`) and
+  elements nested under `Style` / `DataTemplate` / `ControlTemplate` /
+  `ItemTemplate` / `Design.DataContext`.
+- Heuristic accepts: any value starting with an ASCII letter, length ≥ 2,
+  containing at least one space OR ≥ 4 chars with ≥ 80 % ASCII-letter
+  density. Values containing CJK / Hangul characters are recorded as
+  `NonEnglish` (out-of-scope sanity row, not a gap).
+- Translation join: for each candidate literal, look it up in each target
+  language's `config/translate/<lang>.txt` table via the same reverse-English
+  chain the runtime uses (English value → Japanese key → translated value).
+
+**Verdict tiers:**
+
+- `Untranslated` — no target language has a translation. The backlog.
+- `PartiallyTranslated` — some languages have it, others don't.
+- `Translated` — every target language has a translation.
+- `NonEnglish` — source literal already contains CJK / Hangul (out of scope).
+
+Methodology lives in `FEBuilderGBA.Avalonia/GapSweep/L10nScanner.cs`.
+Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-l10n --out=<path>`.
+
+## Summary
+
+| Verdict | Count | % of total |
+|---|---:|---:|
+| Untranslated | 158 | 5.1 |
+| PartiallyTranslated | 2941 | 94.9 |
+| Translated | 0 | 0.0 |
+| NonEnglish | 0 | 0.0 |
+| **Total** | 3099 | 100.0 |
+
+## Per-language Coverage
+
+Coverage is computed over the English-source literals only (excludes the `NonEnglish` rows, which are out of scope).
+
+| Language | Translated | English-source total | % |
+|---|---:|---:|---:|
+| `ja` | 371 | 3099 | 12.0 |
+| `zh` | 2941 | 3099 | 94.9 |
+| `ko` | 0 | 3099 | 0.0 |
+
+## Top 20 Files by Untranslated Literal Count
+
+Each row's count is the upper bound on the localisation backlog for that
+file. Files are sorted by Untranslated count descending.
+
+| Rank | File | Untranslated |
+|---:|---|---:|
+| 1 | `FEBuilderGBA.Avalonia/Views/ClassEditorView.axaml` | 35 |
+| 2 | `FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml` | 26 |
+| 3 | `FEBuilderGBA.Avalonia/Views/UnitEditorView.axaml` | 21 |
+| 4 | `FEBuilderGBA.Avalonia/Views/UnitFE6View.axaml` | 7 |
+| 5 | `FEBuilderGBA.Avalonia/Views/UnitFE7View.axaml` | 6 |
+| 6 | `FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml` | 4 |
+| 7 | `FEBuilderGBA.Avalonia/Views/PointerToolView.axaml` | 4 |
+| 8 | `FEBuilderGBA.Avalonia/Views/MoveToFreeSpaceView.axaml` | 3 |
+| 9 | `FEBuilderGBA.Avalonia/Views/OptionsView.axaml` | 3 |
+| 10 | `FEBuilderGBA.Avalonia/Views/RAMRewriteToolMAPView.axaml` | 3 |
+| 11 | `FEBuilderGBA.Avalonia/Views/SoundBossBGMViewerView.axaml` | 3 |
+| 12 | `FEBuilderGBA.Avalonia/Views/RAMRewriteToolView.axaml` | 2 |
+| 13 | `FEBuilderGBA.Avalonia/Views/SummonsDemonKingViewerView.axaml` | 2 |
+| 14 | `FEBuilderGBA.Avalonia/Views/TextDicView.axaml` | 2 |
+| 15 | `FEBuilderGBA.Avalonia/Views/TextViewerView.axaml` | 2 |
+| 16 | `FEBuilderGBA.Avalonia/Views/ArenaClassViewerView.axaml` | 1 |
+| 17 | `FEBuilderGBA.Avalonia/Views/EDSensekiCommentView.axaml` | 1 |
+| 18 | `FEBuilderGBA.Avalonia/Views/EDView.axaml` | 1 |
+| 19 | `FEBuilderGBA.Avalonia/Views/ImageBGSelectPopupView.axaml` | 1 |
+| 20 | `FEBuilderGBA.Avalonia/Views/ImageMapActionAnimationView.axaml` | 1 |
+
+## Untranslated Literals (No Language Has Them)
+
+Each row is a literal that has no translation in ANY of the target
+languages. Fix these by adding entries to `config/translate/<lang>.txt`.
+
+### `FEBuilderGBA.Avalonia/Views/ClassEditorView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 43 | `TextBlock` | `ToolTip.Tip` | `Text ID for this class's display name (click to open Text Viewer)` |
+| 48 | `TextBlock` | `ToolTip.Tip` | `Text ID for this class's description (click to open Text Viewer)` |
+| 53 | `TextBlock` | `ToolTip.Tip` | `Decoded description text` |
+| 54 | `Button` | `Content` | `Desc` |
+| 55 | `Button` | `ToolTip.Tip` | `Open text viewer for this description` |
+| 59 | `TextBlock` | `ToolTip.Tip` | `Internal class number` |
+| 62 | `TextBlock` | `ToolTip.Tip` | `Level required for promotion (0=unpromoted)` |
+| 66 | `TextBlock` | `ToolTip.Tip` | `Map sprite index when idle` |
+| 69 | `TextBlock` | `ToolTip.Tip` | `Walking speed on the map` |
+| 75 | `TextBlock` | `ToolTip.Tip` | `Portrait graphic index (click to open Portrait Viewer)` |
+| 77 | `TextBlock` | `Text` | `Sort Order (B10):` |
+| 78 | `TextBlock` | `ToolTip.Tip` | `Sort order for class list` |
+| 89 | `TextBlock` | `ToolTip.Tip` | `Base HP for this class` |
+| 104 | `TextBlock` | `Text` | `Con (B17):` |
+| 105 | `TextBlock` | `ToolTip.Tip` | `Base constitution` |
+| 107 | `TextBlock` | `Text` | `Mov (B18):` |
+| 108 | `TextBlock` | `ToolTip.Tip` | `Base movement range` |
+| 115 | `Expander` | `Header` | `Stat Caps (Max Values)` |
+| 118 | `TextBlock` | `Text` | `Max HP (B19):` |
+| 119 | `TextBlock` | `ToolTip.Tip` | `Maximum HP stat cap for this class` |
+| 121 | `TextBlock` | `Text` | `Max Str (B20):` |
+| 124 | `TextBlock` | `Text` | `Max Skl (B21):` |
+| 126 | `TextBlock` | `Text` | `Max Spd (B22):` |
+| 129 | `TextBlock` | `Text` | `Max Def (B23):` |
+| 131 | `TextBlock` | `Text` | `Max Res (B24):` |
+| 134 | `TextBlock` | `Text` | `Max Con (B25):` |
+| 136 | `TextBlock` | `Text` | `Power (B26):` |
+| 137 | `TextBlock` | `ToolTip.Tip` | `Class power / EXP correction value` |
+| 169 | `Expander` | `Header` | `Promotion Gains (CC Bonus)` |
+| 173 | `TextBlock` | `ToolTip.Tip` | `HP bonus gained on class change` |
+| 264 | `TextBlock` | `ToolTip.Tip` | `Pointer to battle animation data` |
+| 267 | `TextBlock` | `ToolTip.Tip` | `Pointer to terrain movement cost table` |
+| 335 | `Button` | `ToolTip.Tip` | `Export all classes to a TSV file` |
+| 337 | `Button` | `ToolTip.Tip` | `Import classes from a TSV file` |
+| 341 | `Button` | `ToolTip.Tip` | `Open skill assignment editor for this class` |
+
+### `FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 41 | `TextBlock` | `ToolTip.Tip` | `Text ID for this item's display name (click to open Text Viewer)` |
+| 49 | `TextBlock` | `ToolTip.Tip` | `Text ID for the item description (click to open Text Viewer)` |
+| 54 | `TextBlock` | `ToolTip.Tip` | `Decoded description text` |
+| 55 | `Button` | `Content` | `Desc` |
+| 56 | `Button` | `ToolTip.Tip` | `Open text viewer for this description` |
+| 61 | `TextBlock` | `ToolTip.Tip` | `Text ID for the item usage description (click to open Text Viewer)` |
+| 66 | `TextBlock` | `ToolTip.Tip` | `Decoded usage description text` |
+| 67 | `Button` | `Content` | `Desc` |
+| 68 | `Button` | `ToolTip.Tip` | `Open text viewer for this usage description` |
+| 72 | `TextBlock` | `ToolTip.Tip` | `Internal item number (unique ID)` |
+| 75 | `TextBlock` | `ToolTip.Tip` | `Weapon type (Sword, Lance, Axe, etc.)` |
+| 86 | `TextBlock` | `ToolTip.Tip` | `Pointer to stat bonuses when equipped` |
+| 92 | `TextBlock` | `ToolTip.Tip` | `Pointer to effectiveness list (bonus vs. classes)` |
+| 99 | `TextBlock` | `ToolTip.Tip` | `Number of uses before the item breaks` |
+| 102 | `TextBlock` | `ToolTip.Tip` | `Attack power` |
+| 106 | `TextBlock` | `ToolTip.Tip` | `Hit rate bonus` |
+| 109 | `TextBlock` | `ToolTip.Tip` | `Item weight (reduces attack speed)` |
+| 113 | `TextBlock` | `ToolTip.Tip` | `Critical hit rate bonus` |
+| 116 | `TextBlock` | `ToolTip.Tip` | `Attack range (encoded as min-max)` |
+| 120 | `TextBlock` | `ToolTip.Tip` | `Base item price` |
+| 140 | `TextBlock` | `ToolTip.Tip` | `Effect when using the item` |
+| 144 | `TextBlock` | `ToolTip.Tip` | `Special effect applied on hit` |
+| 147 | `TextBlock` | `ToolTip.Tip` | `Weapon experience gained per use` |
+| 235 | `Button` | `ToolTip.Tip` | `Export all items to a TSV file` |
+| 237 | `Button` | `ToolTip.Tip` | `Import items from a TSV file` |
+| 241 | `Button` | `ToolTip.Tip` | `Open skill configuration editor` |
+
+### `FEBuilderGBA.Avalonia/Views/UnitEditorView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 44 | `TextBlock` | `ToolTip.Tip` | `Text ID for the unit's display name (click to open Text Viewer)` |
+| 51 | `TextBlock` | `ToolTip.Tip` | `Text ID for the unit's description (click to open Text Viewer)` |
+| 56 | `TextBlock` | `ToolTip.Tip` | `Decoded description text` |
+| 57 | `Button` | `Content` | `Desc` |
+| 58 | `Button` | `ToolTip.Tip` | `Open text viewer for this description` |
+| 62 | `TextBlock` | `ToolTip.Tip` | `Unique identifier for this unit` |
+| 67 | `TextBlock` | `ToolTip.Tip` | `The unit's class (click to open Class Editor)` |
+| 71 | `Button` | `ToolTip.Tip` | `Pick class from editor` |
+| 76 | `TextBlock` | `ToolTip.Tip` | `Portrait graphic index (click to open Portrait Viewer)` |
+| 80 | `TextBlock` | `ToolTip.Tip` | `Unit or class name associated with this portrait ID` |
+| 82 | `Button` | `ToolTip.Tip` | `Pick portrait from editor` |
+| 86 | `TextBlock` | `ToolTip.Tip` | `Map sprite face index` |
+| 89 | `TextBlock` | `ToolTip.Tip` | `Elemental affinity for support bonuses` |
+| 108 | `TextBlock` | `ToolTip.Tip` | `Starting level of this unit` |
+| 111 | `TextBlock` | `ToolTip.Tip` | `Base Hit Points (signed offset from class base)` |
+| 114 | `TextBlock` | `ToolTip.Tip` | `Base Strength/Magic (signed offset from class base)` |
+| 173 | `TextBlock` | `ToolTip.Tip` | `Percent chance of HP increasing on level up` |
+| 224 | `Expander` | `Header` | `Support & Other` |
+| 287 | `Button` | `ToolTip.Tip` | `Export all units to a TSV file` |
+| 289 | `Button` | `ToolTip.Tip` | `Import units from a TSV file` |
+| 293 | `Button` | `ToolTip.Tip` | `Open skill assignment editor for this unit` |
+
+### `FEBuilderGBA.Avalonia/Views/UnitFE6View.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 33 | `TextBlock` | `ToolTip.Tip` | `Text ID for the unit's description` |
+| 38 | `TextBlock` | `ToolTip.Tip` | `Decoded description text` |
+| 39 | `Button` | `Content` | `Desc` |
+| 40 | `Button` | `ToolTip.Tip` | `Open text viewer for this description` |
+| 48 | `TextBlock` | `ToolTip.Tip` | `Click to open Class Editor` |
+| 53 | `TextBlock` | `ToolTip.Tip` | `Click to open Portrait Viewer` |
+| 163 | `TextBlock` | `Text` | `Support & Other` |
+
+### `FEBuilderGBA.Avalonia/Views/UnitFE7View.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 25 | `TextBlock` | `ToolTip.Tip` | `Text ID for the unit's description` |
+| 30 | `TextBlock` | `ToolTip.Tip` | `Decoded description text` |
+| 31 | `Button` | `Content` | `Desc` |
+| 32 | `Button` | `ToolTip.Tip` | `Open text viewer for this description` |
+| 41 | `TextBlock` | `ToolTip.Tip` | `Click to open Class Editor` |
+| 46 | `TextBlock` | `ToolTip.Tip` | `Click to open Portrait Viewer` |
+
+### `FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 39 | `TextBlock` | `ToolTip.Tip` | `Text ID for the item's description` |
+| 44 | `TextBlock` | `ToolTip.Tip` | `Decoded description text` |
+| 45 | `Button` | `Content` | `Desc` |
+| 46 | `Button` | `ToolTip.Tip` | `Open text viewer for this description` |
+
+### `FEBuilderGBA.Avalonia/Views/PointerToolView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 25 | `TextBox` | `Watermark` | `e.g. 0x08000000` |
+| 52 | `TextBlock` | `Text` | `Data Address\n(if pointer)` |
+| 64 | `TextBlock` | `Text` | `Other ROM\nData Address` |
+| 120 | `TextBlock` | `Text` | `Compare current ROM against another version to locate\nspecific data such as images or programs that are\nshared between FE7 and FE8.` |
+
+### `FEBuilderGBA.Avalonia/Views/MoveToFreeSpaceView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 18 | `TextBox` | `Watermark` | `e.g. 0x08000000` |
+| 20 | `TextBox` | `Watermark` | `e.g. 0x08F00000` |
+| 22 | `TextBox` | `Watermark` | `e.g. 0x100` |
+
+### `FEBuilderGBA.Avalonia/Views/OptionsView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 39 | `TextBox` | `Watermark` | `https://github.com/laqieer/FEBuilderGBA-patch2.git` |
+| 41 | `TextBox` | `Watermark` | `https://github.com/Klokinator/FE-Repo` |
+| 43 | `TextBox` | `Watermark` | `https://github.com/laqieer/FE-Repo-Music-No-Preview` |
+
+### `FEBuilderGBA.Avalonia/Views/RAMRewriteToolMAPView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 18 | `TextBox` | `Watermark` | `e.g. 0x01` |
+| 20 | `TextBox` | `Watermark` | `e.g. 0x02000000` |
+| 22 | `TextBox` | `Watermark` | `e.g. 0xFF` |
+
+### `FEBuilderGBA.Avalonia/Views/SoundBossBGMViewerView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 21 | `TextBlock` | `ToolTip.Tip` | `Click to open Unit Editor` |
+| 25 | `Button` | `ToolTip.Tip` | `Pick unit from editor` |
+| 40 | `TextBlock` | `ToolTip.Tip` | `Click to open Song Table` |
+
+### `FEBuilderGBA.Avalonia/Views/RAMRewriteToolView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 25 | `TextBox` | `Watermark` | `e.g. 0x02000000` |
+| 27 | `TextBox` | `Watermark` | `e.g. 0xFF` |
+
+### `FEBuilderGBA.Avalonia/Views/SummonsDemonKingViewerView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 21 | `TextBlock` | `ToolTip.Tip` | `Click to open Unit Editor` |
+| 27 | `TextBlock` | `ToolTip.Tip` | `Click to open Class Editor` |
+
+### `FEBuilderGBA.Avalonia/Views/TextDicView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 42 | `TextBlock` | `ToolTip.Tip` | `Click to open Unit Editor` |
+| 50 | `TextBlock` | `ToolTip.Tip` | `Click to open Class Editor` |
+
+### `FEBuilderGBA.Avalonia/Views/TextViewerView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 46 | `TextBlock` | `Text` | `References (units, classes, items):` |
+| 56 | `TextBlock` | `Text` | `Other reference sources (maps, events, supports, …) not yet ported. Track full parity in a follow-up issue.` |
+
+### `FEBuilderGBA.Avalonia/Views/ArenaClassViewerView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 24 | `TextBlock` | `ToolTip.Tip` | `Click to open Class Editor` |
+
+### `FEBuilderGBA.Avalonia/Views/EDSensekiCommentView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 21 | `TextBlock` | `ToolTip.Tip` | `Click to open Unit Editor` |
+
+### `FEBuilderGBA.Avalonia/Views/EDView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 21 | `TextBlock` | `ToolTip.Tip` | `Click to open Unit Editor` |
+
+### `FEBuilderGBA.Avalonia/Views/ImageBGSelectPopupView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 12 | `TextBlock` | `Text` | `Background Image Selector.\nChoose a background image from the available BG entries in the ROM.` |
+
+### `FEBuilderGBA.Avalonia/Views/ImageMapActionAnimationView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 34 | `TextBlock` | `Text` | `Preview (Frame 0):` |
+
+### `FEBuilderGBA.Avalonia/Views/ItemEffectivenessViewerView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 22 | `TextBlock` | `ToolTip.Tip` | `Click to open Class Editor` |
+
+### `FEBuilderGBA.Avalonia/Views/ItemPromotionViewerView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 22 | `TextBlock` | `ToolTip.Tip` | `Click to open Class Editor` |
+
+### `FEBuilderGBA.Avalonia/Views/ItemRandomChestView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 21 | `TextBlock` | `ToolTip.Tip` | `Click to open Item Editor` |
+
+### `FEBuilderGBA.Avalonia/Views/ItemShopViewerView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 22 | `TextBlock` | `ToolTip.Tip` | `Click to open Item Editor` |
+
+### `FEBuilderGBA.Avalonia/Views/ItemWeaponEffectViewerView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 21 | `TextBlock` | `ToolTip.Tip` | `Click to open Item Editor` |
+
+### `FEBuilderGBA.Avalonia/Views/LinkArenaDenyUnitViewerView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 21 | `TextBlock` | `ToolTip.Tip` | `Click to open Unit Editor` |
+
+### `FEBuilderGBA.Avalonia/Views/MapEditorMarSizeDialogView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 22 | `TextBlock` | `Text` | `Data size mismatch.\n(DataCount/2) % Width != 0` |
+
+### `FEBuilderGBA.Avalonia/Views/MapPointerNewPLISTPopupView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 17 | `TextBlock` | `Text` | `PLIST (Pointer List) assigns a numeric ID to each map.\nChoose an unused PLIST number to add a new map pointer entry.\nThe PLIST ID is used internally to reference map data.` |
+
+### `FEBuilderGBA.Avalonia/Views/MapSettingDifficultyDialogView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 55 | `TextBox` | `Text` | `Set the difficulty adjustment value.\nHard Boost increases enemy stats in Hard mode.\nPenalties reduce enemy stats in Normal and Easy modes.\n\nReference: feuniverse.us difficulty stat changes` |
+
+### `FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 21 | `TextBlock` | `ToolTip.Tip` | `Click to open Item Editor` |
+
+### `FEBuilderGBA.Avalonia/Views/OPClassDemoFE7UView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 34 | `TextBlock` | `ToolTip.Tip` | `Click to open Class Editor` |
+
+### `FEBuilderGBA.Avalonia/Views/OPClassDemoFE7View.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 43 | `TextBlock` | `ToolTip.Tip` | `Click to open Class Editor` |
+
+### `FEBuilderGBA.Avalonia/Views/OPClassDemoFE8UView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 31 | `TextBlock` | `ToolTip.Tip` | `Click to open Class Editor` |
+
+### `FEBuilderGBA.Avalonia/Views/PaletteChangeColorsView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 12 | `TextBlock` | `Text` | `Palette Color Editor allows editing individual colors in a 16-color GBA palette.\nSelect a palette slot to modify its RGB values.` |
+
+### `FEBuilderGBA.Avalonia/Views/PaletteClipboardView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 12 | `TextBlock` | `Text` | `Palette Clipboard Manager stores and retrieves palette data.\nCopy palettes between different graphics entries or save them for later use.` |
+
+### `FEBuilderGBA.Avalonia/Views/PaletteSwapView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 12 | `TextBlock` | `Text` | `Palette Swap exchanges palette assignments between entries.\nSelect source and destination palette slots to exchange their color data.` |
+
+### `FEBuilderGBA.Avalonia/Views/PatchFormUninstallDialogView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 23 | `TextBlock` | `Text` | `Please select the ROM from before this patch was installed for recovery.\n\nThis feature does not guarantee a reliable uninstallation.\nIt may fail, so please make a backup beforehand.\nAlso, while th… (truncated)` |
+
+### `FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 11 | `TextBlock` | `Text` | `Skill system editors require a compatible skill patch to be installed.\nUse the Patch Manager to install a skill system patch first.\n\nSupported skill systems: CSkillSys, FE8N Skill System` |
+
+### `FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitCSkillSysView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 11 | `TextBlock` | `Text` | `Skill system editors require a compatible skill patch to be installed.\nUse the Patch Manager to install a skill system patch first.\n\nSupported skill systems: CSkillSys, FE8N Skill System` |
+
+### `FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitFE8NView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 11 | `TextBlock` | `Text` | `Skill system editors require a compatible skill patch to be installed.\nUse the Patch Manager to install a skill system patch first.\n\nSupported skill systems: CSkillSys, FE8N Skill System` |
+
+### `FEBuilderGBA.Avalonia/Views/SkillConfigFE8NSkillView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 11 | `TextBlock` | `Text` | `Skill system editors require a compatible skill patch to be installed.\nUse the Patch Manager to install a skill system patch first.\n\nSupported skill systems: CSkillSys, FE8N Skill System` |
+
+### `FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer2SkillView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 11 | `TextBlock` | `Text` | `Skill system editors require a compatible skill patch to be installed.\nUse the Patch Manager to install a skill system patch first.\n\nSupported skill systems: CSkillSys, FE8N Skill System` |
+
+### `FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 11 | `TextBlock` | `Text` | `Skill system editors require a compatible skill patch to be installed.\nUse the Patch Manager to install a skill system patch first.\n\nSupported skill systems: CSkillSys, FE8N Skill System` |
+
+### `FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 11 | `TextBlock` | `Text` | `Skill system editors require a compatible skill patch to be installed.\nUse the Patch Manager to install a skill system patch first.\n\nSupported skill systems: CSkillSys, FE8N Skill System` |
+
+### `FEBuilderGBA.Avalonia/Views/SkillSystemsEffectivenessReworkClassTypeView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 11 | `TextBlock` | `Text` | `Skill system editors require a compatible skill patch to be installed.\nUse the Patch Manager to install a skill system patch first.\n\nSupported skill systems: CSkillSys, FE8N Skill System` |
+
+### `FEBuilderGBA.Avalonia/Views/SoundRoomViewerView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 21 | `TextBlock` | `ToolTip.Tip` | `Click to open Song Table` |
+
+### `FEBuilderGBA.Avalonia/Views/SummonUnitViewerView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 21 | `TextBlock` | `ToolTip.Tip` | `Click to open Unit Editor` |
+
+### `FEBuilderGBA.Avalonia/Views/TextBadCharPopupView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 17 | `TextBlock` | `Text` | `Characters that cannot be encoded in the ROM's text encoding table will cause display errors in-game.\n\nCommon issues:\n  - Using characters outside the ROM's supported character set\n  - Pasting tex… (truncated)` |
+
+### `FEBuilderGBA.Avalonia/Views/ToolAnimationCreatorView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 19 | `TextBox` | `Watermark` | `e.g. 8` |
+
+### `FEBuilderGBA.Avalonia/Views/WorldMapPathMoveEditorView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 29 | `TextBlock` | `Text` | `Elapsed Time controls how long the unit pauses at this node. Lower values = longer pause. Total movement uses 4096 time units. Sum of all elapsed times across nodes must be <= 4095, otherwise instant … (truncated)` |
+
+## Partially Translated Literals
+
+Some target languages have a translation, others don't. The tick columns
+show which languages cover the literal.
+
+### `FEBuilderGBA.Avalonia/Views/MainWindow.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 13 | `Open _Last ROM` | ✓ | ✓ | ✗ |
+| 17 | `Save _As...` | ✓ | ✓ | ✗ |
+| 19 | `E_xit` | ✓ | ✓ | ✗ |
+| 24 | `Re_fresh` | ✓ | ✓ | ✗ |
+| 27 | `Toggle _Easy Mode` | ✓ | ✓ | ✗ |
+| 31 | `Toggle _Dark Mode` | ✓ | ✓ | ✗ |
+| 38 | `Run _Emulator...` | ✓ | ✓ | ✗ |
+| 39 | `Run Emulator _2...` | ✓ | ✓ | ✗ |
+| 40 | `Run _Binary Editor...` | ✓ | ✓ | ✗ |
+| 41 | `Run _Sappy...` | ✓ | ✓ | ✗ |
+| 43 | `Run Program _1...` | ✓ | ✓ | ✗ |
+| 44 | `Run Program _2...` | ✓ | ✓ | ✗ |
+| 45 | `Run Program _3...` | ✓ | ✓ | ✗ |
+| 65 | `No ROM loaded` | ✓ | ✓ | ✗ |
+| 72 | `Easy Mode` | ✓ | ✓ | ✗ |
+| 87 | `FEBuilderGBA` | ✓ | ✓ | ✗ |
+| 88 | `Cross-Platform Preview (Avalonia)` | ✗ | ✓ | ✗ |
+| 92 | `Open a ROM file to begin editing.` | ✓ | ✓ | ✗ |
+| 97 | `Filter:` | ✓ | ✓ | ✗ |
+| 98 | `Clear` | ✓ | ✓ | ✗ |
+| 99 | `Type to filter editors...` | ✓ | ✓ | ✗ |
+| 109 | `Characters` | ✓ | ✓ | ✗ |
+| 111 | `Units` | ✓ | ✓ | ✗ |
+| 112 | `Classes` | ✓ | ✓ | ✗ |
+| 113 | `Support Units` | ✓ | ✓ | ✗ |
+| 114 | `Support Attribute` | ✓ | ✓ | ✗ |
+| 115 | `Support Talk` | ✓ | ✓ | ✗ |
+| 120 | `Items` | ✓ | ✓ | ✗ |
+| 122 | `Items` | ✓ | ✓ | ✗ |
+| 123 | `CC Branch` | ✓ | ✓ | ✗ |
+| 124 | `Weapon Effect` | ✓ | ✓ | ✗ |
+| 125 | `Stat Bonuses` | ✓ | ✓ | ✗ |
+| 126 | `Effectiveness` | ✓ | ✓ | ✗ |
+| 127 | `Promotion` | ✓ | ✓ | ✗ |
+| 128 | `Shop` | ✓ | ✓ | ✗ |
+| 129 | `Weapon Triangle` | ✓ | ✓ | ✗ |
+| 130 | `Usage Pointer` | ✓ | ✓ | ✗ |
+| 131 | `Effect Pointer` | ✓ | ✓ | ✗ |
+| 136 | `Maps` | ✓ | ✓ | ✗ |
+| 138 | `Map Settings` | ✓ | ✓ | ✗ |
+| 139 | `Terrain Names` | ✓ | ✓ | ✗ |
+| 140 | `Move Cost` | ✓ | ✓ | ✗ |
+| 141 | `Event Conditions` | ✓ | ✓ | ✗ |
+| 142 | `Map Changes` | ✓ | ✓ | ✗ |
+| 143 | `Exit Points` | ✓ | ✓ | ✗ |
+| 144 | `Map Pointers` | ✓ | ✓ | ✗ |
+| 145 | `Tile Animation` | ✓ | ✓ | ✗ |
+| 150 | `Text` | ✓ | ✓ | ✗ |
+| 152 | `Text Viewer` | ✓ | ✓ | ✗ |
+| 157 | `Graphics` | ✓ | ✓ | ✗ |
+| 159 | `Portraits` | ✓ | ✓ | ✗ |
+| 160 | `System Icons` | ✓ | ✓ | ✗ |
+| 161 | `Item Icons` | ✓ | ✓ | ✗ |
+| 162 | `Hover Colors` | ✓ | ✓ | ✗ |
+| 163 | `Battle BG` | ✓ | ✓ | ✗ |
+| 164 | `Battle Terrain` | ✓ | ✓ | ✗ |
+| 165 | `Chapter Title` | ✓ | ✓ | ✗ |
+| 166 | `CG Viewer` | ✓ | ✓ | ✗ |
+| 167 | `OP Class Demo` | ✓ | ✓ | ✗ |
+| 168 | `OP Class Font` | ✓ | ✓ | ✗ |
+| 169 | `OP Prologue` | ✓ | ✓ | ✗ |
+| 174 | `Audio` | ✓ | ✓ | ✗ |
+| 176 | `Song Table` | ✓ | ✓ | ✗ |
+| 177 | `Boss BGM` | ✓ | ✓ | ✗ |
+| 178 | `Footsteps` | ✓ | ✓ | ✗ |
+| 179 | `Sound Room` | ✓ | ✓ | ✗ |
+| 184 | `Arena` | ✓ | ✓ | ✗ |
+| 186 | `Arena Class` | ✓ | ✓ | ✗ |
+| 187 | `Arena Enemy Weapon` | ✓ | ✓ | ✗ |
+| 188 | `Link Arena Deny` | ✓ | ✓ | ✗ |
+| 193 | `Monsters` | ✓ | ✓ | ✗ |
+| 195 | `Monster Probability` | ✓ | ✓ | ✗ |
+| 196 | `Monster Items` | ✓ | ✓ | ✗ |
+| 197 | `WMap Probability` | ✓ | ✓ | ✗ |
+| 202 | `Summons` | ✓ | ✓ | ✗ |
+| 204 | `Summon Unit` | ✓ | ✓ | ✗ |
+| 205 | `Demon King` | ✓ | ✓ | ✗ |
+| 210 | `Items (Specialized)` | ✓ | ✓ | ✗ |
+| 212 | `Stat Bonuses (Skill)` | ✓ | ✓ | ✗ |
+| 213 | `Stat Bonuses (Venno)` | ✓ | ✓ | ✗ |
+| 214 | `Effectiveness (Rework)` | ✓ | ✓ | ✗ |
+| 215 | `Random Chest` | ✓ | ✓ | ✗ |
+| 220 | `Menus` | ✓ | ✓ | ✗ |
+| 222 | `Menu Definition` | ✓ | ✓ | ✗ |
+| 223 | `Menu Command` | ✓ | ✓ | ✗ |
+| 224 | `Split Menu Ext` | ✓ | ✓ | ✗ |
+| 229 | `Credits` | ✓ | ✓ | ✗ |
+| 231 | `Ending Events` | ✓ | ✓ | ✗ |
+| 232 | `Staff Roll` | ✓ | ✓ | ✗ |
+| 233 | `ED (FE6)` | ✓ | ✓ | ✗ |
+| 234 | `ED (FE7)` | ✓ | ✓ | ✗ |
+| 235 | `Senseki Comment` | ✓ | ✓ | ✗ |
+| 240 | `World Map` | ✓ | ✓ | ✗ |
+| 242 | `Map Points` | ✓ | ✓ | ✗ |
+| 243 | `Map BGM` | ✓ | ✓ | ✗ |
+| 244 | `Map Events` | ✓ | ✓ | ✗ |
+| 249 | `Image Editors` | ✓ | ✓ | ✗ |
+| 251 | `Portrait Editor` | ✓ | ✓ | ✗ |
+| 252 | `Portrait (FE6)` | ✓ | ✓ | ✗ |
+| 253 | `Portrait Import` | ✓ | ✓ | ✗ |
+| 254 | `BG Editor` | ✓ | ✓ | ✗ |
+| 255 | `Battle Anim` | ✓ | ✓ | ✗ |
+| 256 | `Battle Anim Pal` | ✓ | ✓ | ✗ |
+| 257 | `Battle BG Edit` | ✓ | ✓ | ✗ |
+| 258 | `Battle Screen` | ✓ | ✓ | ✗ |
+| 259 | `CG Editor` | ✓ | ✓ | ✗ |
+| 260 | `CG (FE7U)` | ✓ | ✓ | ✗ |
+| 261 | `Unit Palette` | ✓ | ✓ | ✗ |
+| 262 | `Wait Icon` | ✓ | ✓ | ✗ |
+| 263 | `Move Icon` | ✓ | ✓ | ✗ |
+| 264 | `System Area` | ✓ | ✓ | ✗ |
+| 265 | `Generic Enemy` | ✓ | ✓ | ✗ |
+| 266 | `ROM Anime` | ✓ | ✓ | ✗ |
+| 267 | `TSA Editor` | ✓ | ✓ | ✗ |
+| 268 | `TSA Anime` | ✓ | ✓ | ✗ |
+| 269 | `TSA Anime 2` | ✓ | ✓ | ✗ |
+| 270 | `Palette` | ✓ | ✓ | ✗ |
+| 271 | `Magic FEditor` | ✓ | ✓ | ✗ |
+| 272 | `CSA Creator` | ✓ | ✓ | ✗ |
+| 273 | `Map Action Anim` | ✓ | ✓ | ✗ |
+| 274 | `Color Reduce` | ✓ | ✓ | ✗ |
+| 279 | `Event Scripts` | ✓ | ✓ | ✗ |
+| 281 | `Event Script` | ✓ | ✓ | ✗ |
+| 282 | `Event Unit` | ✓ | ✓ | ✗ |
+| 283 | `Event Unit (FE6)` | ✓ | ✓ | ✗ |
+| 284 | `Event Unit (FE7)` | ✓ | ✓ | ✗ |
+| 285 | `Unit Color` | ✓ | ✓ | ✗ |
+| 286 | `Item Drop` | ✓ | ✓ | ✗ |
+| 287 | `New Alloc` | ✓ | ✓ | ✗ |
+| 288 | `Battle Talk` | ✓ | ✓ | ✗ |
+| 289 | `Battle Talk (FE6)` | ✓ | ✓ | ✗ |
+| 290 | `Battle Talk (FE7)` | ✓ | ✓ | ✗ |
+| 291 | `Battle Data (FE7)` | ✓ | ✓ | ✗ |
+| 292 | `Haiku` | ✓ | ✓ | ✗ |
+| 293 | `Haiku (FE6)` | ✓ | ✓ | ✗ |
+| 294 | `Haiku (FE7)` | ✓ | ✓ | ✗ |
+| 295 | `Map Change Evt` | ✓ | ✓ | ✗ |
+| 296 | `Force Sortie` | ✓ | ✓ | ✗ |
+| 297 | `Force Sortie (FE7)` | ✓ | ✓ | ✗ |
+| 298 | `Func Pointer` | ✓ | ✓ | ✗ |
+| 299 | `Func Ptr (FE7)` | ✓ | ✓ | ✗ |
+| 300 | `Event Assembler` | ✓ | ✓ | ✗ |
+| 301 | `Procs Script` | ✓ | ✓ | ✗ |
+| 302 | `Templates` | ✓ | ✓ | ✗ |
+| 303 | `Template 1` | ✓ | ✓ | ✗ |
+| 304 | `Template 2` | ✓ | ✓ | ✗ |
+| 305 | `Template 3` | ✓ | ✓ | ✗ |
+| 306 | `Template 4` | ✓ | ✓ | ✗ |
+| 307 | `Template 5` | ✓ | ✓ | ✗ |
+| 308 | `Template 6` | ✓ | ✓ | ✗ |
+| 309 | `Final Serif (FE7)` | ✓ | ✓ | ✗ |
+| 310 | `Move Data (FE7)` | ✓ | ✓ | ✗ |
+| 311 | `Talk Group (FE7)` | ✓ | ✓ | ✗ |
+| 316 | `AI Scripts` | ✓ | ✓ | ✗ |
+| 318 | `AI Script` | ✓ | ✓ | ✗ |
+| 319 | `AI ASM Call` | ✓ | ✓ | ✗ |
+| 320 | `AI Coordinate` | ✓ | ✓ | ✗ |
+| 321 | `AI Range` | ✓ | ✓ | ✗ |
+| 322 | `AI Map Setting` | ✓ | ✓ | ✗ |
+| 323 | `AI Item` | ✓ | ✓ | ✗ |
+| 324 | `AI Staff` | ✓ | ✓ | ✗ |
+| 325 | `AI Steal` | ✓ | ✓ | ✗ |
+| 326 | `AI Target` | ✓ | ✓ | ✗ |
+| 327 | `AI Tiles` | ✓ | ✓ | ✗ |
+| 328 | `AI Units` | ✓ | ✓ | ✗ |
+| 329 | `AOE Range` | ✓ | ✓ | ✗ |
+| 334 | `Map Editors` | ✓ | ✓ | ✗ |
+| 336 | `Map Editor` | ✓ | ✓ | ✗ |
+| 337 | `Map Settings (FE6)` | ✓ | ✓ | ✗ |
+| 338 | `Map Settings (FE7)` | ✓ | ✓ | ✗ |
+| 339 | `Map Settings (FE7U)` | ✓ | ✓ | ✗ |
+| 340 | `Difficulty` | ✓ | ✓ | ✗ |
+| 341 | `Style Editor` | ✓ | ✓ | ✗ |
+| 342 | `Terrain BG` | ✓ | ✓ | ✗ |
+| 343 | `Terrain Floor` | ✓ | ✓ | ✗ |
+| 344 | `Mini Map` | ✓ | ✓ | ✗ |
+| 345 | `Tile Anim 1` | ✓ | ✓ | ✗ |
+| 346 | `Tile Anim 2` | ✓ | ✓ | ✗ |
+| 347 | `Load Function` | ✓ | ✓ | ✗ |
+| 348 | `Terrain Eng` | ✓ | ✓ | ✗ |
+| 353 | `Audio (Advanced)` | ✓ | ✓ | ✗ |
+| 355 | `Song Track` | ✓ | ✓ | ✗ |
+| 356 | `Instrument` | ✓ | ✓ | ✗ |
+| 357 | `Direct Sound` | ✓ | ✓ | ✗ |
+| 358 | `Wave Import` | ✓ | ✓ | ✗ |
+| 359 | `MIDI Import` | ✓ | ✓ | ✗ |
+| 360 | `Song Exchange` | ✓ | ✓ | ✗ |
+| 361 | `Sound Room (FE6)` | ✓ | ✓ | ✗ |
+| 362 | `Sound Room CG` | ✓ | ✓ | ✗ |
+| 363 | `Change Track` | ✓ | ✓ | ✗ |
+| 364 | `All Change Track` | ✓ | ✓ | ✗ |
+| 365 | `Select Instrument` | ✓ | ✓ | ✗ |
+| 366 | `Import Wave` | ✓ | ✓ | ✗ |
+| 371 | `Unit/Class Specialized` | ✓ | ✓ | ✗ |
+| 373 | `Unit (FE6)` | ✓ | ✓ | ✗ |
+| 374 | `Action Pointer` | ✓ | ✓ | ✗ |
+| 375 | `Custom Anim` | ✓ | ✓ | ✗ |
+| 376 | `Height` | ✓ | ✓ | ✗ |
+| 377 | `Unit Palette` | ✓ | ✓ | ✗ |
+| 378 | `Class (FE6)` | ✓ | ✓ | ✗ |
+| 379 | `Class OP Demo` | ✓ | ✓ | ✗ |
+| 380 | `Class OP Font` | ✓ | ✓ | ✗ |
+| 381 | `Extra Unit` | ✓ | ✓ | ✗ |
+| 382 | `Extra (FE8U)` | ✓ | ✓ | ✗ |
+| 387 | `Text/Translation` | ✓ | ✓ | ✗ |
+| 389 | `Text Editor` | ✓ | ✓ | ✗ |
+| 390 | `Other Text` | ✓ | ✓ | ✗ |
+| 391 | `C-String` | ✓ | ✓ | ✗ |
+| 392 | `Font Editor` | ✓ | ✓ | ✗ |
+| 393 | `Font ZH` | ✓ | ✓ | ✗ |
+| 394 | `Dev Translate` | ✓ | ✓ | ✗ |
+| 395 | `ROM Translate` | ✓ | ✓ | ✗ |
+| 396 | `Text Escape` | ✓ | ✓ | ✗ |
+| 401 | `Patches` | ✓ | ✓ | ✗ |
+| 403 | `Patch Manager` | ✓ | ✓ | ✗ |
+| 404 | `Custom Build` | ✓ | ✓ | ✗ |
+| 409 | `Skill Systems` | ✓ | ✓ | ✗ |
+| 411 | `Skill Unit` | ✓ | ✓ | ✗ |
+| 412 | `Skill Class` | ✓ | ✓ | ✗ |
+| 413 | `Skill Config` | ✓ | ✓ | ✗ |
+| 418 | `World Map (Advanced)` | ✓ | ✓ | ✗ |
+| 420 | `Map Paths` | ✓ | ✓ | ✗ |
+| 421 | `Path Editor` | ✓ | ✓ | ✗ |
+| 422 | `Map Image` | ✓ | ✓ | ✗ |
+| 423 | `Map Image (FE6)` | ✓ | ✓ | ✗ |
+| 424 | `Map Image (FE7)` | ✓ | ✓ | ✗ |
+| 425 | `Events (FE6)` | ✓ | ✓ | ✗ |
+| 426 | `Events (FE7)` | ✓ | ✓ | ✗ |
+| 431 | `Structural Data` | ✓ | ✓ | ✗ |
+| 433 | `Cmd85 Pointer` | ✓ | ✓ | ✗ |
+| 434 | `Spell Menu Ext` | ✓ | ✓ | ✗ |
+| 435 | `Status Option` | ✓ | ✓ | ✗ |
+| 436 | `OAM Sprite` | ✓ | ✓ | ✗ |
+| 437 | `Struct Dump` | ✓ | ✓ | ✗ |
+| 442 | `Tools` | ✓ | ✓ | ✗ |
+| 444 | `Run Lint` | ✓ | ✓ | ✗ |
+| 445 | `Undo History` | ✓ | ✓ | ✗ |
+| 446 | `FELint GUI` | ✓ | ✓ | ✗ |
+| 447 | `ROM Rebuild` | ✓ | ✓ | ✗ |
+| 448 | `LZ77 Tool` | ✓ | ✓ | ✗ |
+| 449 | `ROM Diff` | ✓ | ✓ | ✗ |
+| 450 | `UPS Create` | ✓ | ✓ | ✗ |
+| 451 | `UPS Apply` | ✓ | ✓ | ✗ |
+| 452 | `Flag Names` | ✓ | ✓ | ✗ |
+| 453 | `Flag Usage` | ✓ | ✓ | ✗ |
+| 454 | `Talk Groups` | ✓ | ✓ | ✗ |
+| 455 | `ASM Insert` | ✓ | ✓ | ✗ |
+| 456 | `Hex Editor` | ✓ | ✓ | ✗ |
+| 457 | `Disassembler` | ✓ | ✓ | ✗ |
+| 458 | `Log Viewer` | ✓ | ✓ | ✗ |
+| 459 | `Grow Sim` | ✓ | ✓ | ✗ |
+| 460 | `Options` | ✓ | ✓ | ✗ |
+| 461 | `Pointer Tool` | ✓ | ✓ | ✗ |
+| 462 | `Free Space` | ✓ | ✓ | ✗ |
+| 463 | `Graphics Tool` | ✓ | ✓ | ✗ |
+| 464 | `BGM Mute` | ✓ | ✓ | ✗ |
+| 469 | `Status Screen` | ✓ | ✓ | ✗ |
+| 471 | `Status Param` | ✓ | ✓ | ✗ |
+| 472 | `Status R-Menu` | ✓ | ✓ | ✗ |
+| 473 | `Status Units` | ✓ | ✓ | ✗ |
+| 474 | `Status Options` | ✓ | ✓ | ✗ |
+| 479 | `Skill Systems (Extended)` | ✓ | ✓ | ✗ |
+| 481 | `Unit CSkillSys` | ✓ | ✓ | ✗ |
+| 482 | `Class CSkillSys` | ✓ | ✓ | ✗ |
+| 483 | `Unit FE8N` | ✓ | ✓ | ✗ |
+| 484 | `Config FE8N` | ✓ | ✓ | ✗ |
+| 485 | `Config FE8N v2` | ✓ | ✓ | ✗ |
+| 486 | `Config FE8N v3` | ✓ | ✓ | ✗ |
+| 487 | `Config CSkill09x` | ✓ | ✓ | ✗ |
+| 488 | `Eff Rework` | ✓ | ✓ | ✗ |
+| 493 | `Version-Specific` | ✓ | ✓ | ✗ |
+| 495 | `Items (FE6)` | ✓ | ✓ | ✗ |
+| 496 | `Move Cost (FE6)` | ✓ | ✓ | ✗ |
+| 497 | `Support (FE6)` | ✓ | ✓ | ✗ |
+| 498 | `Sup Talk (FE6)` | ✓ | ✓ | ✗ |
+| 499 | `Sup Talk (FE7)` | ✓ | ✓ | ✗ |
+| 500 | `Units (FE7)` | ✓ | ✓ | ✗ |
+| 501 | `OP Demo (FE7)` | ✓ | ✓ | ✗ |
+| 502 | `OP Demo (FE7U)` | ✓ | ✓ | ✗ |
+| 503 | `OP Demo (FE8U)` | ✓ | ✓ | ✗ |
+| 504 | `OP Font (FE8U)` | ✓ | ✓ | ✗ |
+| 505 | `Alpha Name` | ✓ | ✓ | ✗ |
+| 506 | `Alpha (FE6)` | ✓ | ✓ | ✗ |
+| 507 | `Class List` | ✓ | ✓ | ✗ |
+| 508 | `Weapon Lock` | ✓ | ✓ | ✗ |
+| 509 | `Short Text` | ✓ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapSettingView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Settings` | ✓ | ✓ | ✗ |
+| 18 | `CP / Pointer` | ✗ | ✓ | ✗ |
+| 20 | `D0: CP` | ✗ | ✓ | ✗ |
+| 29 | `Map Style / PLIST` | ✗ | ✓ | ✗ |
+| 31 | `W4: Object type (PLIST)` | ✗ | ✓ | ✗ |
+| 34 | `B6: Palette (PLIST)` | ✗ | ✓ | ✗ |
+| 37 | `B7: Chipset config (PLIST)` | ✗ | ✓ | ✗ |
+| 40 | `B8: Map pointer (PLIST)` | ✗ | ✓ | ✗ |
+| 43 | `B9: Tile animation 1 (PLIST)` | ✗ | ✓ | ✗ |
+| 46 | `B10: Tile animation 2 (PLIST)` | ✗ | ✓ | ✗ |
+| 49 | `B11: Map change (PLIST)` | ✗ | ✓ | ✗ |
+| 58 | `Map Properties` | ✗ | ✓ | ✗ |
+| 60 | `B12: Fog level` | ✗ | ✓ | ✗ |
+| 63 | `B13: Battle preparation (X)` | ✗ | ✓ | ✗ |
+| 66 | `B14: Chapter title image` | ✗ | ✓ | ✗ |
+| 69 | `B15: Chapter title image 2 (X)` | ✗ | ✓ | ✗ |
+| 72 | `B16: Initial X coordinate` | ✗ | ✓ | ✗ |
+| 75 | `B17: Initial Y coordinate` | ✗ | ✓ | ✗ |
+| 78 | `B18: Weather` | ✗ | ✓ | ✗ |
+| 81 | `B19: Battle BG lookup` | ✗ | ✓ | ✗ |
+| 90 | `BGM / Music` | ✗ | ✓ | ✗ |
+| 92 | `W20: Difficulty adjustment` | ✗ | ✓ | ✗ |
+| 95 | `W22: Player phase BGM` | ✗ | ✓ | ✗ |
+| 98 | `W24: Enemy phase BGM` | ✗ | ✓ | ✗ |
+| 101 | `W26: NPC phase BGM` | ✗ | ✓ | ✗ |
+| 104 | `W28: Player phase BGM 2 (X)` | ✗ | ✓ | ✗ |
+| 107 | `W30: Enemy phase BGM 2 (X)` | ✗ | ✓ | ✗ |
+| 110 | `W32: NPC phase BGM 2 (X)` | ✗ | ✓ | ✗ |
+| 113 | `W34: Player phase BGM flag 4` | ✗ | ✓ | ✗ |
+| 116 | `W36: Enemy phase BGM flag 4` | ✗ | ✓ | ✗ |
+| 119 | `W38: ???` | ✗ | ✓ | ✗ |
+| 122 | `W40: ???` | ✗ | ✓ | ✗ |
+| 125 | `W42: ???` | ✗ | ✓ | ✗ |
+| 134 | `Breakable Wall HP / Difficulty Ratings` | ✗ | ✓ | ✗ |
+| 138 | `B44: Breakable wall HP` | ✗ | ✓ | ✗ |
+| 143 | `Difficulty Ratings` | ✗ | ✓ | ✗ |
+| 146 | `Asset Rating` | ✗ | ✓ | ✗ |
+| 148 | `B45: A Eliwood Normal` | ✗ | ✓ | ✗ |
+| 150 | `W62: A Eliwood Normal` | ✗ | ✓ | ✗ |
+| 153 | `B46: A Eliwood Hard` | ✗ | ✓ | ✗ |
+| 155 | `W64: A Eliwood Hard` | ✗ | ✓ | ✗ |
+| 158 | `B47: A Hector Normal` | ✗ | ✓ | ✗ |
+| 160 | `W66: A Hector Normal` | ✗ | ✓ | ✗ |
+| 163 | `B48: A Hector Hard` | ✗ | ✓ | ✗ |
+| 165 | `W68: A Hector Hard` | ✗ | ✓ | ✗ |
+| 170 | `Strategy Rating` | ✗ | ✓ | ✗ |
+| 172 | `B49: B Eliwood Normal` | ✗ | ✓ | ✗ |
+| 174 | `W70: B Eliwood Normal` | ✗ | ✓ | ✗ |
+| 177 | `B50: B Eliwood Hard` | ✗ | ✓ | ✗ |
+| 179 | `W72: B Eliwood Hard` | ✗ | ✓ | ✗ |
+| 182 | `B51: B Hector Normal` | ✗ | ✓ | ✗ |
+| 184 | `W74: B Hector Normal` | ✗ | ✓ | ✗ |
+| 187 | `B52: B Hector Hard` | ✗ | ✓ | ✗ |
+| 189 | `W76: B Hector Hard` | ✗ | ✓ | ✗ |
+| 194 | `Experience Rating` | ✗ | ✓ | ✗ |
+| 196 | `B53: C Eliwood Normal` | ✗ | ✓ | ✗ |
+| 198 | `W78: C Eliwood Normal` | ✗ | ✓ | ✗ |
+| 201 | `B54: C Eliwood Hard` | ✗ | ✓ | ✗ |
+| 203 | `W80: C Eliwood Hard` | ✗ | ✓ | ✗ |
+| 206 | `B55: C Hector Normal` | ✗ | ✓ | ✗ |
+| 208 | `W82: C Hector Normal` | ✗ | ✓ | ✗ |
+| 211 | `B56: C Hector Hard` | ✗ | ✓ | ✗ |
+| 213 | `W84: C Hector Hard` | ✗ | ✓ | ✗ |
+| 218 | `D Rating` | ✗ | ✓ | ✗ |
+| 220 | `B57: D Eliwood Normal` | ✗ | ✓ | ✗ |
+| 222 | `W86: D Eliwood Normal` | ✗ | ✓ | ✗ |
+| 225 | `B58: D Eliwood Hard` | ✗ | ✓ | ✗ |
+| 227 | `W88: D Eliwood Hard` | ✗ | ✓ | ✗ |
+| 230 | `B59: D Hector Normal` | ✗ | ✓ | ✗ |
+| 232 | `W90: D Hector Normal` | ✗ | ✓ | ✗ |
+| 235 | `B60: D Hector Hard` | ✗ | ✓ | ✗ |
+| 237 | `W92: D Hector Hard` | ✗ | ✓ | ✗ |
+| 240 | `B61: ??` | ✗ | ✓ | ✗ |
+| 242 | `W94: ??` | ✗ | ✓ | ✗ |
+| 251 | `Pointers (D96-D108)` | ✗ | ✓ | ✗ |
+| 253 | `Eliwood Normal (D96):` | ✗ | ✓ | ✗ |
+| 256 | `Eliwood Hard (D100):` | ✗ | ✓ | ✗ |
+| 259 | `Hector Normal (D104):` | ✗ | ✓ | ✗ |
+| 262 | `Hector Hard (D108):` | ✗ | ✓ | ✗ |
+| 271 | `Map Name Text IDs` | ✗ | ✓ | ✗ |
+| 273 | `W112: Map name 1` | ✗ | ✓ | ✗ |
+| 277 | `W114: Map name 2 (X)` | ✗ | ✓ | ✗ |
+| 287 | `Event / World Map (B116-B135)` | ✗ | ✓ | ✗ |
+| 289 | `B116: Event ID (PLIST)` | ✗ | ✓ | ✗ |
+| 291 | `B117: World map auto event` | ✗ | ✓ | ✗ |
+| 294 | `B118: ??` | ✗ | ✓ | ✗ |
+| 319 | `Chapter number (B128):` | ✗ | ✓ | ✗ |
+| 334 | `B134: Enemies for victory BGM` | ✗ | ✓ | ✗ |
+| 336 | `B135: Blackout before start` | ✗ | ✓ | ✗ |
+| 345 | `Clear Condition (display only)` | ✗ | ✓ | ✗ |
+| 347 | `W136: Clear condition (display only)` | ✗ | ✓ | ✗ |
+| 351 | `W138: Detail clear condition (display only)` | ✗ | ✓ | ✗ |
+| 361 | `Display Flags (B140-B147)` | ✗ | ✓ | ✗ |
+| 363 | `B140: Special display` | ✗ | ✓ | ✗ |
+| 365 | `B141: Turn count display` | ✗ | ✓ | ✗ |
+| 368 | `B142: Defense unit mark` | ✗ | ✓ | ✗ |
+| 370 | `B143: Escape marker X` | ✗ | ✓ | ✗ |
+| 373 | `B144: Escape marker Y` | ✗ | ✓ | ✗ |
+| 375 | `B145: ??` | ✗ | ✓ | ✗ |
+| 378 | `B146: ??` | ✗ | ✓ | ✗ |
+| 380 | `B147: ??` | ✗ | ✓ | ✗ |
+| 387 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapSettingFE7UView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Settings (FE7U)` | ✓ | ✓ | ✗ |
+| 18 | `CP / Pointer` | ✗ | ✓ | ✗ |
+| 20 | `D0: CP` | ✗ | ✓ | ✗ |
+| 29 | `Map Style / PLIST` | ✗ | ✓ | ✗ |
+| 31 | `W4: Object type (PLIST)` | ✗ | ✓ | ✗ |
+| 33 | `B6: Palette (PLIST)` | ✗ | ✓ | ✗ |
+| 35 | `B7: Chipset config (PLIST)` | ✗ | ✓ | ✗ |
+| 37 | `B8: Map pointer (PLIST)` | ✗ | ✓ | ✗ |
+| 39 | `B9: Tile animation 1 (PLIST)` | ✗ | ✓ | ✗ |
+| 41 | `B10: Tile animation 2 (PLIST)` | ✗ | ✓ | ✗ |
+| 43 | `B11: Map change (PLIST)` | ✗ | ✓ | ✗ |
+| 52 | `Map Properties` | ✗ | ✓ | ✗ |
+| 54 | `B12: Fog level` | ✗ | ✓ | ✗ |
+| 56 | `B13: Battle preparation` | ✗ | ✓ | ✗ |
+| 58 | `B14: Chapter title image` | ✗ | ✓ | ✗ |
+| 60 | `B15: Chapter title image 2` | ✗ | ✓ | ✗ |
+| 62 | `B16: Padding` | ✗ | ✓ | ✗ |
+| 64 | `B17: Padding` | ✗ | ✓ | ✗ |
+| 66 | `B18: Weather` | ✗ | ✓ | ✗ |
+| 68 | `B19: Battle BG` | ✗ | ✓ | ✗ |
+| 77 | `BGM / Music` | ✗ | ✓ | ✗ |
+| 79 | `W20: Difficulty adjustment` | ✗ | ✓ | ✗ |
+| 81 | `W22: Player phase BGM` | ✗ | ✓ | ✗ |
+| 83 | `W24: Enemy phase BGM` | ✗ | ✓ | ✗ |
+| 85 | `W26: NPC phase BGM` | ✗ | ✓ | ✗ |
+| 87 | `W28: Player phase BGM 2` | ✗ | ✓ | ✗ |
+| 89 | `W30: Enemy phase BGM 2` | ✗ | ✓ | ✗ |
+| 91 | `W32: NPC phase BGM 2` | ✗ | ✓ | ✗ |
+| 93 | `W34: Player phase BGM flag 4` | ✗ | ✓ | ✗ |
+| 95 | `W36: Enemy phase BGM flag 4` | ✗ | ✓ | ✗ |
+| 97 | `W38: Prologue BGM (Common)` | ✗ | ✓ | ✗ |
+| 99 | `W40: Prologue BGM (Eliwood)` | ✗ | ✓ | ✗ |
+| 101 | `W42: Prologue BGM (Hector)` | ✗ | ✓ | ✗ |
+| 110 | `Breakable Wall HP / Unknowns` | ✗ | ✓ | ✗ |
+| 112 | `B44: Breakable wall HP` | ✗ | ✓ | ✗ |
+| 114 | `B61: ??` | ✗ | ✓ | ✗ |
+| 116 | `W94: ??` | ✗ | ✓ | ✗ |
+| 125 | `Difficulty Pointers (D96-D108)` | ✗ | ✓ | ✗ |
+| 127 | `Eliwood Normal (D96):` | ✗ | ✓ | ✗ |
+| 129 | `Eliwood Hard (D100):` | ✗ | ✓ | ✗ |
+| 131 | `Hector Normal (D104):` | ✗ | ✓ | ✗ |
+| 133 | `Hector Hard (D108):` | ✗ | ✓ | ✗ |
+| 142 | `Chapter Title Text IDs` | ✗ | ✓ | ✗ |
+| 144 | `W112: Eliwood title text` | ✗ | ✓ | ✗ |
+| 147 | `W114: Hector title text` | ✗ | ✓ | ✗ |
+| 150 | `W116: Eliwood title text 2` | ✗ | ✓ | ✗ |
+| 153 | `W118: Hector title text 2` | ✗ | ✓ | ✗ |
+| 163 | `Event / Fortune Teller` | ✗ | ✓ | ✗ |
+| 165 | `B120: Event ID (PLIST)` | ✗ | ✓ | ✗ |
+| 167 | `B121: World map auto event` | ✗ | ✓ | ✗ |
+| 169 | `W122: Fortune text (opening)` | ✗ | ✓ | ✗ |
+| 171 | `W124: Fortune text (Eliwood)` | ✗ | ✓ | ✗ |
+| 173 | `W126: Fortune text (Hector)` | ✗ | ✓ | ✗ |
+| 175 | `W128: Fortune text (confirm)` | ✗ | ✓ | ✗ |
+| 177 | `B130: Fortune portrait` | ✗ | ✓ | ✗ |
+| 179 | `B131: Fortune fee` | ✗ | ✓ | ✗ |
+| 188 | `Chapter / Transporter / Victory` | ✗ | ✓ | ✗ |
+| 190 | `B132: Prep screen Ch no. 1` | ✗ | ✓ | ✗ |
+| 192 | `B133: Prep screen Ch no. 2` | ✗ | ✓ | ✗ |
+| 194 | `B134: Transporter Eliwood X` | ✗ | ✓ | ✗ |
+| 196 | `B135: Transporter Hector X` | ✗ | ✓ | ✗ |
+| 198 | `B136: Transporter Eliwood Y` | ✗ | ✓ | ✗ |
+| 200 | `B137: Transporter Hector Y` | ✗ | ✓ | ✗ |
+| 202 | `B138: Victory BGM enemy count` | ✗ | ✓ | ✗ |
+| 204 | `B139: Darken before start` | ✗ | ✓ | ✗ |
+| 213 | `Clear Conditions` | ✗ | ✓ | ✗ |
+| 215 | `W140: Clear condition text` | ✗ | ✓ | ✗ |
+| 218 | `W142: Detail clear condition` | ✗ | ✓ | ✗ |
+| 228 | `Display Flags (B144-B151)` | ✗ | ✓ | ✗ |
+| 230 | `B144: Special display` | ✗ | ✓ | ✗ |
+| 232 | `B145: Turn count display` | ✗ | ✓ | ✗ |
+| 234 | `B146: Defense unit mark` | ✗ | ✓ | ✗ |
+| 236 | `B147: Escape marker X` | ✗ | ✓ | ✗ |
+| 238 | `B148: Escape marker Y` | ✗ | ✓ | ✗ |
+| 240 | `B149: ??` | ✗ | ✓ | ✗ |
+| 242 | `B150: ??` | ✗ | ✓ | ✗ |
+| 244 | `B151: ??` | ✗ | ✓ | ✗ |
+| 251 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapSettingFE7View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Settings (FE7JP)` | ✗ | ✓ | ✗ |
+| 18 | `CP / Pointer` | ✗ | ✓ | ✗ |
+| 20 | `D0: CP` | ✗ | ✓ | ✗ |
+| 29 | `Map Style / PLIST` | ✗ | ✓ | ✗ |
+| 31 | `W4: Object type (PLIST)` | ✗ | ✓ | ✗ |
+| 33 | `B6: Palette (PLIST)` | ✗ | ✓ | ✗ |
+| 35 | `B7: Chipset config (PLIST)` | ✗ | ✓ | ✗ |
+| 37 | `B8: Map pointer (PLIST)` | ✗ | ✓ | ✗ |
+| 39 | `B9: Tile animation 1 (PLIST)` | ✗ | ✓ | ✗ |
+| 41 | `B10: Tile animation 2 (PLIST)` | ✗ | ✓ | ✗ |
+| 43 | `B11: Map change (PLIST)` | ✗ | ✓ | ✗ |
+| 52 | `Map Properties` | ✗ | ✓ | ✗ |
+| 54 | `B12: Fog level` | ✗ | ✓ | ✗ |
+| 56 | `B13: Battle preparation` | ✗ | ✓ | ✗ |
+| 58 | `B14: Chapter title image` | ✗ | ✓ | ✗ |
+| 60 | `B15: Chapter title image 2` | ✗ | ✓ | ✗ |
+| 62 | `B16: Initial X coordinate` | ✗ | ✓ | ✗ |
+| 64 | `B17: Initial Y coordinate` | ✗ | ✓ | ✗ |
+| 66 | `B18: Weather` | ✗ | ✓ | ✗ |
+| 68 | `B19: Battle BG lookup` | ✗ | ✓ | ✗ |
+| 77 | `BGM / Music` | ✗ | ✓ | ✗ |
+| 79 | `W20: Difficulty adjustment` | ✗ | ✓ | ✗ |
+| 81 | `W22: Player phase BGM` | ✗ | ✓ | ✗ |
+| 83 | `W24: Enemy phase BGM` | ✗ | ✓ | ✗ |
+| 85 | `W26: NPC phase BGM` | ✗ | ✓ | ✗ |
+| 87 | `W28: Player phase BGM 2` | ✗ | ✓ | ✗ |
+| 89 | `W30: Enemy phase BGM 2` | ✗ | ✓ | ✗ |
+| 91 | `W32: NPC phase BGM 2` | ✗ | ✓ | ✗ |
+| 93 | `W34: Player phase BGM flag 4` | ✗ | ✓ | ✗ |
+| 95 | `W36: Enemy phase BGM flag 4` | ✗ | ✓ | ✗ |
+| 97 | `W38: ???` | ✗ | ✓ | ✗ |
+| 99 | `W40: ???` | ✗ | ✓ | ✗ |
+| 101 | `W42: ???` | ✗ | ✓ | ✗ |
+| 110 | `Breakable Wall HP / Difficulty Ratings` | ✗ | ✓ | ✗ |
+| 112 | `B44: Breakable wall HP` | ✗ | ✓ | ✗ |
+| 115 | `B61: Unknown` | ✗ | ✓ | ✗ |
+| 117 | `B61: ??` | ✗ | ✓ | ✗ |
+| 120 | `W94: Unknown` | ✗ | ✓ | ✗ |
+| 122 | `W94: ??` | ✗ | ✓ | ✗ |
+| 131 | `Difficulty Pointers (D96-D108)` | ✗ | ✓ | ✗ |
+| 133 | `Eliwood Normal (D96):` | ✗ | ✓ | ✗ |
+| 135 | `Eliwood Hard (D100):` | ✗ | ✓ | ✗ |
+| 137 | `Hector Normal (D104):` | ✗ | ✓ | ✗ |
+| 139 | `Hector Hard (D108):` | ✗ | ✓ | ✗ |
+| 148 | `Map Name Text IDs` | ✗ | ✓ | ✗ |
+| 150 | `W112: Map name 1` | ✗ | ✓ | ✗ |
+| 153 | `W114: Map name 2` | ✗ | ✓ | ✗ |
+| 163 | `Event / Fortune Teller` | ✗ | ✓ | ✗ |
+| 165 | `B116: Event ID (PLIST)` | ✗ | ✓ | ✗ |
+| 167 | `B117: World map auto event` | ✗ | ✓ | ✗ |
+| 169 | `W118: Fortune text (opening)` | ✗ | ✓ | ✗ |
+| 171 | `W120: Fortune text (Eliwood)` | ✗ | ✓ | ✗ |
+| 173 | `W122: Fortune text (Hector)` | ✗ | ✓ | ✗ |
+| 175 | `W124: Fortune text (confirm)` | ✗ | ✓ | ✗ |
+| 177 | `B126: Fortune portrait` | ✗ | ✓ | ✗ |
+| 179 | `B127: Fortune fee` | ✗ | ✓ | ✗ |
+| 188 | `Chapter / Transporter / Victory` | ✗ | ✓ | ✗ |
+| 190 | `B128: Chapter number` | ✗ | ✓ | ✗ |
+| 192 | `B129: Prep screen Ch no. 1` | ✗ | ✓ | ✗ |
+| 194 | `B130: Transporter Eliwood X` | ✗ | ✓ | ✗ |
+| 196 | `B131: Transporter Hector X` | ✗ | ✓ | ✗ |
+| 198 | `B132: Transporter Eliwood Y` | ✗ | ✓ | ✗ |
+| 200 | `B133: Transporter Hector Y` | ✗ | ✓ | ✗ |
+| 202 | `B134: Victory BGM enemy count` | ✗ | ✓ | ✗ |
+| 204 | `B135: Blackout before start` | ✗ | ✓ | ✗ |
+| 213 | `Clear Conditions` | ✗ | ✓ | ✗ |
+| 215 | `W136: Clear condition text` | ✗ | ✓ | ✗ |
+| 218 | `W138: Detail clear condition` | ✗ | ✓ | ✗ |
+| 228 | `Display Flags (B140-B147)` | ✗ | ✓ | ✗ |
+| 230 | `B140: Special display` | ✗ | ✓ | ✗ |
+| 232 | `B141: Turn count display` | ✗ | ✓ | ✗ |
+| 234 | `B142: Defense unit mark` | ✗ | ✓ | ✗ |
+| 236 | `B143: Escape marker X` | ✗ | ✓ | ✗ |
+| 238 | `B144: Escape marker Y` | ✗ | ✓ | ✗ |
+| 240 | `B145: ??` | ✗ | ✓ | ✗ |
+| 242 | `B146: ??` | ✗ | ✓ | ✗ |
+| 244 | `B147: ??` | ✗ | ✓ | ✗ |
+| 251 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ClassEditorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 26 | `Class Editor` | ✓ | ✓ | ✗ |
+| 30 | `Address:` | ✗ | ✓ | ✗ |
+| 32 | `Name:` | ✗ | ✓ | ✗ |
+| 37 | `Identity / Misc` | ✗ | ✓ | ✗ |
+| 40 | `Name ID (W0):` | ✗ | ✓ | ✗ |
+| 45 | `Desc ID (W2):` | ✗ | ✓ | ✗ |
+| 58 | `Class # (B4):` | ✗ | ✓ | ✗ |
+| 61 | `Promo Lv (B5):` | ✗ | ✓ | ✗ |
+| 65 | `Wait Icon (B6):` | ✗ | ✓ | ✗ |
+| 68 | `Walk Spd (B7):` | ✗ | ✓ | ✗ |
+| 72 | `Portrait (W8):` | ✗ | ✓ | ✗ |
+| 85 | `Base Stats` | ✗ | ✓ | ✗ |
+| 88 | `HP (B11):` | ✗ | ✓ | ✗ |
+| 91 | `Str (B12):` | ✗ | ✓ | ✗ |
+| 94 | `Skl (B13):` | ✗ | ✓ | ✗ |
+| 96 | `Spd (B14):` | ✗ | ✓ | ✗ |
+| 99 | `Def (B15):` | ✗ | ✓ | ✗ |
+| 101 | `Res (B16):` | ✗ | ✓ | ✗ |
+| 144 | `Growth Rates` | ✗ | ✓ | ✗ |
+| 147 | `HP (B27):` | ✗ | ✓ | ✗ |
+| 149 | `Str (B28):` | ✗ | ✓ | ✗ |
+| 152 | `Skl (B29):` | ✗ | ✓ | ✗ |
+| 154 | `Spd (B30):` | ✗ | ✓ | ✗ |
+| 157 | `Def (B31):` | ✗ | ✓ | ✗ |
+| 159 | `Res (B32):` | ✗ | ✓ | ✗ |
+| 162 | `Lck (B33):` | ✗ | ✓ | ✗ |
+| 172 | `HP (b34):` | ✗ | ✓ | ✗ |
+| 175 | `Str (b35):` | ✗ | ✓ | ✗ |
+| 179 | `Skl (b36):` | ✗ | ✓ | ✗ |
+| 181 | `Spd (b37):` | ✗ | ✓ | ✗ |
+| 184 | `Def (b38):` | ✗ | ✓ | ✗ |
+| 186 | `Res (b39):` | ✗ | ✓ | ✗ |
+| 193 | `Ability Flags` | ✗ | ✓ | ✗ |
+| 196 | `Ability 1 (B40):` | ✗ | ✓ | ✗ |
+| 198 | `Ability 2 (B41):` | ✗ | ✓ | ✗ |
+| 200 | `Ability 3 (B42):` | ✗ | ✓ | ✗ |
+| 202 | `Ability 4 (B43):` | ✗ | ✓ | ✗ |
+| 209 | `Weapon Rank Levels (B44-B51)` | ✗ | ✓ | ✗ |
+| 212 | `Sword (B44):` | ✗ | ✓ | ✗ |
+| 217 | `Lance (B45):` | ✗ | ✓ | ✗ |
+| 223 | `Axe (B46):` | ✗ | ✓ | ✗ |
+| 228 | `Bow (B47):` | ✗ | ✓ | ✗ |
+| 234 | `Staff (B48):` | ✗ | ✓ | ✗ |
+| 239 | `Anima (B49):` | ✗ | ✓ | ✗ |
+| 245 | `Light (B50):` | ✗ | ✓ | ✗ |
+| 250 | `Dark (B51):` | ✗ | ✓ | ✗ |
+| 260 | `Pointers / Movement / Terrain` | ✗ | ✓ | ✗ |
+| 263 | `Battle Anime (P52):` | ✗ | ✓ | ✗ |
+| 266 | `Move Cost (P56):` | ✗ | ✓ | ✗ |
+| 270 | `Jump` | ✗ | ✓ | ✗ |
+| 273 | `Move Cost Rain (P60):` | ✗ | ✓ | ✗ |
+| 275 | `Move Cost Snow (P64):` | ✗ | ✓ | ✗ |
+| 281 | `Terrain Avoid (P68):` | ✗ | ✓ | ✗ |
+| 283 | `Terrain Def (P72):` | ✗ | ✓ | ✗ |
+| 291 | `Terrain Res (P76):` | ✗ | ✓ | ✗ |
+| 302 | `Growth Simulator` | ✗ | ✓ | ✗ |
+| 306 | `Calculate Growth` | ✗ | ✓ | ✗ |
+| 307 | `Sim Level:` | ✗ | ✓ | ✗ |
+| 320 | `Warnings` | ✗ | ✓ | ✗ |
+| 332 | `Write` | ✗ | ✓ | ✗ |
+| 334 | `Export TSV` | ✗ | ✓ | ✗ |
+| 336 | `Import TSV` | ✗ | ✓ | ✗ |
+| 339 | `Edit Skills` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EasyModePanel.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 7 | `Easy Mode` | ✓ | ✓ | ✗ |
+| 8 | `Common editing tasks organized by category. Click any button to open its editor.` | ✗ | ✓ | ✗ |
+| 12 | `Search editors...` | ✗ | ✓ | ✗ |
+| 18 | `Characters` | ✓ | ✓ | ✗ |
+| 19 | `Edit playable and enemy unit stats, class data, and support relationships.` | ✗ | ✓ | ✗ |
+| 22 | `Edit Units` | ✗ | ✓ | ✗ |
+| 23 | `Edit Classes` | ✗ | ✓ | ✗ |
+| 24 | `Support Units` | ✓ | ✓ | ✗ |
+| 25 | `Support Talk` | ✓ | ✓ | ✗ |
+| 33 | `Items` | ✓ | ✓ | ✗ |
+| 34 | `Edit weapons, items, their effects, shops, and promotions.` | ✗ | ✓ | ✗ |
+| 37 | `Edit Items` | ✗ | ✓ | ✗ |
+| 38 | `Weapon Effect` | ✓ | ✓ | ✗ |
+| 39 | `Shops` | ✗ | ✓ | ✗ |
+| 40 | `Promotions` | ✗ | ✓ | ✗ |
+| 48 | `Maps` | ✓ | ✓ | ✗ |
+| 49 | `Configure chapter settings, map layouts, terrain, and movement costs.` | ✗ | ✓ | ✗ |
+| 52 | `Map Settings` | ✓ | ✓ | ✗ |
+| 53 | `Map Editor` | ✓ | ✓ | ✗ |
+| 54 | `Terrain Names` | ✓ | ✓ | ✗ |
+| 55 | `Move Costs` | ✗ | ✓ | ✗ |
+| 63 | `Events` | ✗ | ✓ | ✗ |
+| 64 | `Edit event scripts that control story scenes, cutscenes, and gameplay triggers.` | ✗ | ✓ | ✗ |
+| 67 | `Event Scripts` | ✓ | ✓ | ✗ |
+| 68 | `Event Conditions` | ✓ | ✓ | ✗ |
+| 69 | `Event Units` | ✗ | ✓ | ✗ |
+| 77 | `Graphics` | ✓ | ✓ | ✗ |
+| 78 | `Edit character portraits, battle animations, CGs, and sprite graphics.` | ✗ | ✓ | ✗ |
+| 81 | `Portraits` | ✓ | ✓ | ✗ |
+| 82 | `Battle Animations` | ✗ | ✓ | ✗ |
+| 83 | `CG Viewer` | ✓ | ✓ | ✗ |
+| 84 | `Image Viewer` | ✗ | ✓ | ✗ |
+| 85 | `OAM Sprite Viewer` | ✗ | ✓ | ✗ |
+| 93 | `Music` | ✗ | ✓ | ✗ |
+| 94 | `Manage background music, sound effects, and the in-game sound room.` | ✗ | ✓ | ✗ |
+| 97 | `Song Table` | ✓ | ✓ | ✗ |
+| 98 | `Song Tracks` | ✗ | ✓ | ✗ |
+| 99 | `Sound Room` | ✓ | ✓ | ✗ |
+| 107 | `Text` | ✓ | ✓ | ✗ |
+| 108 | `Edit in-game dialogue, menus, and all text strings in the ROM.` | ✗ | ✓ | ✗ |
+| 111 | `Text Editor` | ✓ | ✓ | ✗ |
+| 112 | `Export Text (TSV)` | ✗ | ✓ | ✗ |
+| 113 | `Import Text (TSV)` | ✗ | ✓ | ✗ |
+| 121 | `Tools` | ✓ | ✓ | ✗ |
+| 122 | `Advanced utilities: hex editing, patching, ROM diagnostics, and more.` | ✗ | ✓ | ✗ |
+| 125 | `Hex Editor` | ✓ | ✓ | ✗ |
+| 126 | `Patch Manager` | ✓ | ✓ | ✗ |
+| 127 | `Lint Check` | ✗ | ✓ | ✗ |
+| 128 | `Pointer Tool` | ✓ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 26 | `Item Editor` | ✓ | ✓ | ✗ |
+| 30 | `Address:` | ✗ | ✓ | ✗ |
+| 35 | `Basic Info` | ✗ | ✓ | ✗ |
+| 38 | `Name ID (W0):` | ✗ | ✓ | ✗ |
+| 43 | `Name:` | ✗ | ✓ | ✗ |
+| 46 | `Desc ID (W2):` | ✗ | ✓ | ✗ |
+| 58 | `Use Desc (W4):` | ✗ | ✓ | ✗ |
+| 71 | `Item # (B6):` | ✗ | ✓ | ✗ |
+| 74 | `Type (B7):` | ✗ | ✓ | ✗ |
+| 82 | `Stats / Bonuses` | ✗ | ✓ | ✗ |
+| 85 | `Stat Bonus (P12):` | ✗ | ✓ | ✗ |
+| 89 | `Jump` | ✗ | ✓ | ✗ |
+| 91 | `Effective (P16):` | ✗ | ✓ | ✗ |
+| 95 | `Jump` | ✗ | ✓ | ✗ |
+| 98 | `Uses (B20):` | ✗ | ✓ | ✗ |
+| 101 | `Might (B21):` | ✗ | ✓ | ✗ |
+| 105 | `Hit (B22):` | ✗ | ✓ | ✗ |
+| 108 | `Weight (B23):` | ✗ | ✓ | ✗ |
+| 112 | `Crit (B24):` | ✗ | ✓ | ✗ |
+| 115 | `Range (B25):` | ✗ | ✓ | ✗ |
+| 119 | `Price (W26):` | ✗ | ✓ | ✗ |
+| 122 | `Rank (B28):` | ✗ | ✓ | ✗ |
+| 125 | `Buy Price:` | ✗ | ✓ | ✗ |
+| 127 | `Sell Price:` | ✗ | ✓ | ✗ |
+| 134 | `Weapon Properties` | ✗ | ✓ | ✗ |
+| 137 | `Icon (B29):` | ✗ | ✓ | ✗ |
+| 139 | `Use Effect (B30):` | ✗ | ✓ | ✗ |
+| 143 | `Dmg Effect (B31):` | ✗ | ✓ | ✗ |
+| 146 | `Wep Exp (B32):` | ✗ | ✓ | ✗ |
+| 150 | `Unk33 (B33):` | ✗ | ✓ | ✗ |
+| 152 | `Unk34 (B34):` | ✗ | ✓ | ✗ |
+| 155 | `Unk35 (B35):` | ✗ | ✓ | ✗ |
+| 157 | `Forge Price:` | ✗ | ✓ | ✗ |
+| 164 | `Warning: Stat Bonuses pointer is null (P12=0). Consider allocating.` | ✗ | ✓ | ✗ |
+| 165 | `Warning: Effectiveness pointer is null (P16=0). Consider allocating.` | ✗ | ✓ | ✗ |
+| 170 | `Stat Bonuses Preview` | ✗ | ✓ | ✗ |
+| 188 | `Effective Against` | ✗ | ✓ | ✗ |
+| 200 | `Trait Flags` | ✗ | ✓ | ✗ |
+| 203 | `Trait 1 (B8):` | ✗ | ✓ | ✗ |
+| 205 | `Trait 2 (B9):` | ✗ | ✓ | ✗ |
+| 207 | `Trait 3 (B10):` | ✗ | ✓ | ✗ |
+| 209 | `Trait 4 (B11):` | ✗ | ✓ | ✗ |
+| 220 | `Warnings` | ✗ | ✓ | ✗ |
+| 232 | `Write` | ✗ | ✓ | ✗ |
+| 234 | `Export TSV` | ✗ | ✓ | ✗ |
+| 236 | `Import TSV` | ✗ | ✓ | ✗ |
+| 239 | `Edit Skill Config` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/UnitFE7View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 11 | `Units (FE7) Editor` | ✗ | ✓ | ✗ |
+| 14 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Name:` | ✗ | ✓ | ✗ |
+| 20 | `Decoded:` | ✗ | ✓ | ✗ |
+| 24 | `Description:` | ✗ | ✓ | ✗ |
+| 34 | `Unit ID:` | ✗ | ✓ | ✗ |
+| 38 | `Support Class:` | ✗ | ✓ | ✗ |
+| 43 | `Portrait:` | ✗ | ✓ | ✗ |
+| 50 | `Map Face:` | ✗ | ✓ | ✗ |
+| 52 | `Affinity:` | ✗ | ✓ | ✗ |
+| 56 | `Sort Order:` | ✗ | ✓ | ✗ |
+| 58 | `Level:` | ✗ | ✓ | ✗ |
+| 62 | `Base Stats:` | ✗ | ✓ | ✗ |
+| 89 | `Weapon Ranks:` | ✗ | ✓ | ✗ |
+| 92 | `Sword:` | ✗ | ✓ | ✗ |
+| 94 | `Lance:` | ✗ | ✓ | ✗ |
+| 104 | `Staff:` | ✗ | ✓ | ✗ |
+| 106 | `Anima:` | ✗ | ✓ | ✗ |
+| 110 | `Light:` | ✗ | ✓ | ✗ |
+| 112 | `Dark:` | ✗ | ✓ | ✗ |
+| 116 | `Growth Rates (%):` | ✗ | ✓ | ✗ |
+| 119 | `HP Growth:` | ✗ | ✓ | ✗ |
+| 121 | `STR Growth:` | ✗ | ✓ | ✗ |
+| 125 | `SKL Growth:` | ✗ | ✓ | ✗ |
+| 127 | `SPD Growth:` | ✗ | ✓ | ✗ |
+| 131 | `DEF Growth:` | ✗ | ✓ | ✗ |
+| 133 | `RES Growth:` | ✗ | ✓ | ✗ |
+| 137 | `LCK Growth:` | ✗ | ✓ | ✗ |
+| 141 | `Palette / Custom Animation:` | ✗ | ✓ | ✗ |
+| 144 | `Lower Class Palette:` | ✗ | ✓ | ✗ |
+| 146 | `Upper Class Palette:` | ✗ | ✓ | ✗ |
+| 150 | `Lower Class Anime:` | ✗ | ✓ | ✗ |
+| 152 | `Upper Class Anime:` | ✗ | ✓ | ✗ |
+| 156 | `Unknown 39:` | ✗ | ✓ | ✗ |
+| 160 | `Ability Flags:` | ✗ | ✓ | ✗ |
+| 163 | `Ability 1:` | ✗ | ✓ | ✗ |
+| 165 | `Ability 2:` | ✗ | ✓ | ✗ |
+| 169 | `Ability 3:` | ✗ | ✓ | ✗ |
+| 171 | `Ability 4:` | ✗ | ✓ | ✗ |
+| 175 | `Support / Talk:` | ✗ | ✓ | ✗ |
+| 178 | `Support Data Ptr:` | ✗ | ✓ | ✗ |
+| 182 | `Talk Group:` | ✗ | ✓ | ✗ |
+| 186 | `Unknown Fields:` | ✗ | ✓ | ✗ |
+| 189 | `Unknown 49:` | ✗ | ✓ | ✗ |
+| 191 | `Unknown 50:` | ✗ | ✓ | ✗ |
+| 195 | `Unknown 51:` | ✗ | ✓ | ✗ |
+| 200 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/OptionsView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 13 | `General` | ✗ | ✓ | ✗ |
+| 18 | `Language` | ✗ | ✓ | ✗ |
+| 24 | `Git Executable Path` | ✗ | ✓ | ✗ |
+| 32 | `Auto-backup ROM before saving` | ✗ | ✓ | ✗ |
+| 35 | `Submodule Remote URLs (advanced)` | ✗ | ✓ | ✗ |
+| 37 | `Leave blank for defaults. Set custom URLs for forks/mirrors.` | ✗ | ✓ | ✗ |
+| 38 | `Patch2 Remote URL` | ✗ | ✓ | ✗ |
+| 40 | `FE-Repo Remote URL` | ✗ | ✓ | ✗ |
+| 42 | `FE-Repo-Music Remote URL` | ✗ | ✓ | ✗ |
+| 48 | `Enable auto-save (saves to .autosave.gba sidecar file)` | ✗ | ✓ | ✗ |
+| 50 | `Interval (minutes):` | ✗ | ✓ | ✗ |
+| 58 | `External Tools` | ✗ | ✓ | ✗ |
+| 64 | `Emulation` | ✗ | ✓ | ✗ |
+| 65 | `Emulator` | ✗ | ✓ | ✗ |
+| 70 | `Emulator 2` | ✗ | ✓ | ✗ |
+| 79 | `Editors` | ✗ | ✓ | ✗ |
+| 80 | `Binary Editor` | ✗ | ✓ | ✗ |
+| 89 | `Custom Programs` | ✗ | ✓ | ✗ |
+| 90 | `Program 1` | ✗ | ✓ | ✗ |
+| 95 | `Program 2` | ✗ | ✓ | ✗ |
+| 100 | `Program 3` | ✗ | ✓ | ✗ |
+| 109 | `Audio Tools` | ✗ | ✓ | ✗ |
+| 110 | `Sappy (Sound Editor)` | ✗ | ✓ | ✗ |
+| 115 | `mid2agb` | ✗ | ✓ | ✗ |
+| 120 | `gba_mus_riper` | ✗ | ✓ | ✗ |
+| 125 | `SoX (Sound eXchange)` | ✗ | ✓ | ✗ |
+| 130 | `midfix4agb` | ✗ | ✓ | ✗ |
+| 139 | `Development Tools` | ✗ | ✓ | ✗ |
+| 140 | `Event Assembler` | ✓ | ✓ | ✗ |
+| 145 | `DevkitPro ARM EABI` | ✗ | ✓ | ✗ |
+| 150 | `GoldRoad ASM` | ✗ | ✓ | ✗ |
+| 155 | `CFLAGS` | ✗ | ✓ | ✗ |
+| 157 | `RetDec Decompiler` | ✗ | ✓ | ✗ |
+| 162 | `Python 3` | ✗ | ✓ | ✗ |
+| 167 | `FECLIB` | ✗ | ✓ | ✗ |
+| 176 | `Source Code` | ✗ | ✓ | ✗ |
+| 177 | `Text Editor` | ✓ | ✓ | ✗ |
+| 182 | `Source Directory` | ✗ | ✓ | ✗ |
+| 197 | `Cancel` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/UnitEditorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 27 | `Unit Editor` | ✓ | ✓ | ✗ |
+| 31 | `Address:` | ✗ | ✓ | ✗ |
+| 36 | `Identity` | ✗ | ✓ | ✗ |
+| 41 | `Name ID:` | ✗ | ✓ | ✗ |
+| 46 | `Name:` | ✗ | ✓ | ✗ |
+| 48 | `Desc ID:` | ✗ | ✓ | ✗ |
+| 61 | `Unit ID:` | ✗ | ✓ | ✗ |
+| 64 | `Class ID:` | ✗ | ✓ | ✗ |
+| 70 | `Jump` | ✗ | ✓ | ✗ |
+| 73 | `Portrait:` | ✗ | ✓ | ✗ |
+| 81 | `Jump` | ✗ | ✓ | ✗ |
+| 85 | `Map Face:` | ✗ | ✓ | ✗ |
+| 88 | `Affinity:` | ✗ | ✓ | ✗ |
+| 91 | `Sort:` | ✗ | ✓ | ✗ |
+| 104 | `Base Stats` | ✗ | ✓ | ✗ |
+| 135 | `Weapon Levels` | ✗ | ✓ | ✗ |
+| 138 | `Sword:` | ✗ | ✓ | ✗ |
+| 141 | `Lance:` | ✗ | ✓ | ✗ |
+| 151 | `Staff:` | ✗ | ✓ | ✗ |
+| 154 | `Anima:` | ✗ | ✓ | ✗ |
+| 158 | `Light:` | ✗ | ✓ | ✗ |
+| 161 | `Dark:` | ✗ | ✓ | ✗ |
+| 169 | `Growth Rates (%)` | ✗ | ✓ | ✗ |
+| 194 | `Growth Simulator` | ✗ | ✓ | ✗ |
+| 198 | `Simulate to LV:` | ✗ | ✓ | ✗ |
+| 200 | `Calculate Growth` | ✗ | ✓ | ✗ |
+| 208 | `Ability Flags` | ✗ | ✓ | ✗ |
+| 211 | `Byte 1:` | ✗ | ✓ | ✗ |
+| 213 | `Byte 2:` | ✗ | ✓ | ✗ |
+| 215 | `Byte 3:` | ✗ | ✓ | ✗ |
+| 217 | `Byte 4:` | ✗ | ✓ | ✗ |
+| 228 | `Support Ptr:` | ✗ | ✓ | ✗ |
+| 250 | `Talk:` | ✗ | ✓ | ✗ |
+| 270 | `Warnings` | ✗ | ✓ | ✗ |
+| 283 | `Write` | ✗ | ✓ | ✗ |
+| 284 | `Undo` | ✗ | ✓ | ✗ |
+| 286 | `Export TSV` | ✗ | ✓ | ✗ |
+| 288 | `Import TSV` | ✗ | ✓ | ✗ |
+| 291 | `Edit Skills` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SupportUnitFE6View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 11 | `Support Units (FE6)` | ✗ | ✓ | ✗ |
+| 15 | `Support Partners` | ✗ | ✓ | ✗ |
+| 17 | `Partner 1:` | ✗ | ✓ | ✗ |
+| 19 | `Partner 2:` | ✗ | ✓ | ✗ |
+| 22 | `Partner 3:` | ✗ | ✓ | ✗ |
+| 24 | `Partner 4:` | ✗ | ✓ | ✗ |
+| 27 | `Partner 5:` | ✗ | ✓ | ✗ |
+| 29 | `Partner 6:` | ✗ | ✓ | ✗ |
+| 32 | `Partner 7:` | ✗ | ✓ | ✗ |
+| 34 | `Partner 8:` | ✗ | ✓ | ✗ |
+| 37 | `Partner 9:` | ✗ | ✓ | ✗ |
+| 39 | `Partner 10:` | ✗ | ✓ | ✗ |
+| 44 | `Initial Values` | ✗ | ✓ | ✗ |
+| 46 | `Initial Value 1:` | ✗ | ✓ | ✗ |
+| 48 | `Initial Value 2:` | ✗ | ✓ | ✗ |
+| 51 | `Initial Value 3:` | ✗ | ✓ | ✗ |
+| 53 | `Initial Value 4:` | ✗ | ✓ | ✗ |
+| 56 | `Initial Value 5:` | ✗ | ✓ | ✗ |
+| 58 | `Initial Value 6:` | ✗ | ✓ | ✗ |
+| 61 | `Initial Value 7:` | ✗ | ✓ | ✗ |
+| 63 | `Initial Value 8:` | ✗ | ✓ | ✗ |
+| 66 | `Initial Value 9:` | ✗ | ✓ | ✗ |
+| 68 | `Initial Value 10:` | ✗ | ✓ | ✗ |
+| 73 | `Growth Rates` | ✗ | ✓ | ✗ |
+| 75 | `Growth Rate 1:` | ✗ | ✓ | ✗ |
+| 77 | `Growth Rate 2:` | ✗ | ✓ | ✗ |
+| 80 | `Growth Rate 3:` | ✗ | ✓ | ✗ |
+| 82 | `Growth Rate 4:` | ✗ | ✓ | ✗ |
+| 85 | `Growth Rate 5:` | ✗ | ✓ | ✗ |
+| 87 | `Growth Rate 6:` | ✗ | ✓ | ✗ |
+| 90 | `Growth Rate 7:` | ✗ | ✓ | ✗ |
+| 92 | `Growth Rate 8:` | ✗ | ✓ | ✗ |
+| 95 | `Growth Rate 9:` | ✗ | ✓ | ✗ |
+| 97 | `Growth Rate 10:` | ✗ | ✓ | ✗ |
+| 102 | `Partner Count / Separator` | ✗ | ✓ | ✗ |
+| 104 | `Partner Count:` | ✗ | ✓ | ✗ |
+| 106 | `Separator:` | ✗ | ✓ | ✗ |
+| 110 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/UwordBitFlagView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 13 | `Word Bit Flags (32-bit)` | ✗ | ✓ | ✗ |
+| 16 | `Apply` | ✗ | ✓ | ✗ |
+| 27 | `Byte 0:` | ✗ | ✓ | ✗ |
+| 30 | `Bit 0  (0x01)` | ✗ | ✓ | ✗ |
+| 31 | `Bit 1  (0x02)` | ✗ | ✓ | ✗ |
+| 32 | `Bit 2  (0x04)` | ✗ | ✓ | ✗ |
+| 33 | `Bit 3  (0x08)` | ✗ | ✓ | ✗ |
+| 34 | `Bit 4  (0x10)` | ✗ | ✓ | ✗ |
+| 35 | `Bit 5  (0x20)` | ✗ | ✓ | ✗ |
+| 36 | `Bit 6  (0x40)` | ✗ | ✓ | ✗ |
+| 37 | `Bit 7  (0x80)` | ✗ | ✓ | ✗ |
+| 45 | `Byte 1:` | ✗ | ✓ | ✗ |
+| 48 | `Bit 8  (0x01)` | ✗ | ✓ | ✗ |
+| 49 | `Bit 9  (0x02)` | ✗ | ✓ | ✗ |
+| 50 | `Bit 10 (0x04)` | ✗ | ✓ | ✗ |
+| 51 | `Bit 11 (0x08)` | ✗ | ✓ | ✗ |
+| 52 | `Bit 12 (0x10)` | ✗ | ✓ | ✗ |
+| 53 | `Bit 13 (0x20)` | ✗ | ✓ | ✗ |
+| 54 | `Bit 14 (0x40)` | ✗ | ✓ | ✗ |
+| 55 | `Bit 15 (0x80)` | ✗ | ✓ | ✗ |
+| 63 | `Byte 2:` | ✗ | ✓ | ✗ |
+| 66 | `Bit 16 (0x01)` | ✗ | ✓ | ✗ |
+| 67 | `Bit 17 (0x02)` | ✗ | ✓ | ✗ |
+| 68 | `Bit 18 (0x04)` | ✗ | ✓ | ✗ |
+| 69 | `Bit 19 (0x08)` | ✗ | ✓ | ✗ |
+| 70 | `Bit 20 (0x10)` | ✗ | ✓ | ✗ |
+| 71 | `Bit 21 (0x20)` | ✗ | ✓ | ✗ |
+| 72 | `Bit 22 (0x40)` | ✗ | ✓ | ✗ |
+| 73 | `Bit 23 (0x80)` | ✗ | ✓ | ✗ |
+| 81 | `Byte 3:` | ✗ | ✓ | ✗ |
+| 84 | `Bit 24 (0x01)` | ✗ | ✓ | ✗ |
+| 85 | `Bit 25 (0x02)` | ✗ | ✓ | ✗ |
+| 86 | `Bit 26 (0x04)` | ✗ | ✓ | ✗ |
+| 87 | `Bit 27 (0x08)` | ✗ | ✓ | ✗ |
+| 88 | `Bit 28 (0x10)` | ✗ | ✓ | ✗ |
+| 89 | `Bit 29 (0x20)` | ✗ | ✓ | ✗ |
+| 90 | `Bit 30 (0x40)` | ✗ | ✓ | ✗ |
+| 91 | `Bit 31 (0x80)` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SongInstrumentView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Instrument Editor` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 19 | `Header Byte:` | ✗ | ✓ | ✗ |
+| 22 | `Type:` | ✗ | ✓ | ✗ |
+| 30 | `Wave Pointer + ADSR` | ✗ | ✓ | ✗ |
+| 32 | `Wave Pointer:` | ✗ | ✓ | ✗ |
+| 35 | `Attack:` | ✗ | ✓ | ✗ |
+| 38 | `Decay:` | ✗ | ✓ | ✗ |
+| 41 | `Sustain:` | ✗ | ✓ | ✗ |
+| 44 | `Release:` | ✗ | ✓ | ✗ |
+| 51 | `Square Wave Parameters + ADSR` | ✗ | ✓ | ✗ |
+| 53 | `Sweep:` | ✗ | ✓ | ✗ |
+| 56 | `Duty / Length:` | ✗ | ✓ | ✗ |
+| 59 | `Envelope Step:` | ✗ | ✓ | ✗ |
+| 62 | `Attack:` | ✗ | ✓ | ✗ |
+| 65 | `Decay:` | ✗ | ✓ | ✗ |
+| 68 | `Sustain:` | ✗ | ✓ | ✗ |
+| 71 | `Release:` | ✗ | ✓ | ✗ |
+| 78 | `Noise Parameters + ADSR` | ✗ | ✓ | ✗ |
+| 80 | `Period:` | ✗ | ✓ | ✗ |
+| 83 | `Attack:` | ✗ | ✓ | ✗ |
+| 86 | `Decay:` | ✗ | ✓ | ✗ |
+| 89 | `Sustain:` | ✗ | ✓ | ✗ |
+| 92 | `Release:` | ✗ | ✓ | ✗ |
+| 99 | `Multi Sample Pointers` | ✗ | ✓ | ✗ |
+| 101 | `Key Map Pointer:` | ✗ | ✓ | ✗ |
+| 104 | `Sub-Instrument Ptr:` | ✗ | ✓ | ✗ |
+| 111 | `Drum Part Pointer` | ✗ | ✓ | ✗ |
+| 113 | `Sub-Instrument Ptr:` | ✗ | ✓ | ✗ |
+| 120 | `Unknown instrument type. Raw 12-byte data is shown in the header byte field.` | ✗ | ✓ | ✗ |
+| 124 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SupportUnitEditorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Support Unit Editor` | ✗ | ✓ | ✗ |
+| 16 | `Support Partners` | ✗ | ✓ | ✗ |
+| 18 | `Partner 1:` | ✗ | ✓ | ✗ |
+| 20 | `Partner 2:` | ✗ | ✓ | ✗ |
+| 23 | `Partner 3:` | ✗ | ✓ | ✗ |
+| 25 | `Partner 4:` | ✗ | ✓ | ✗ |
+| 28 | `Partner 5:` | ✗ | ✓ | ✗ |
+| 30 | `Partner 6:` | ✗ | ✓ | ✗ |
+| 33 | `Partner 7:` | ✗ | ✓ | ✗ |
+| 38 | `Initial Values` | ✗ | ✓ | ✗ |
+| 40 | `Initial Value 1:` | ✗ | ✓ | ✗ |
+| 42 | `Initial Value 2:` | ✗ | ✓ | ✗ |
+| 45 | `Initial Value 3:` | ✗ | ✓ | ✗ |
+| 47 | `Initial Value 4:` | ✗ | ✓ | ✗ |
+| 50 | `Initial Value 5:` | ✗ | ✓ | ✗ |
+| 52 | `Initial Value 6:` | ✗ | ✓ | ✗ |
+| 55 | `Initial Value 7:` | ✗ | ✓ | ✗ |
+| 60 | `Growth Rates` | ✗ | ✓ | ✗ |
+| 62 | `Growth Rate 1:` | ✗ | ✓ | ✗ |
+| 64 | `Growth Rate 2:` | ✗ | ✓ | ✗ |
+| 67 | `Growth Rate 3:` | ✗ | ✓ | ✗ |
+| 69 | `Growth Rate 4:` | ✗ | ✓ | ✗ |
+| 72 | `Growth Rate 5:` | ✗ | ✓ | ✗ |
+| 74 | `Growth Rate 6:` | ✗ | ✓ | ✗ |
+| 77 | `Growth Rate 7:` | ✗ | ✓ | ✗ |
+| 82 | `Partner Count / Separator` | ✗ | ✓ | ✗ |
+| 84 | `Partner Count:` | ✗ | ✓ | ✗ |
+| 86 | `Separator 1:` | ✗ | ✓ | ✗ |
+| 88 | `Separator 2:` | ✗ | ✓ | ✗ |
+| 92 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageBattleAnimeView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Battle Animation Editor` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 20 | `Weapon Type (B0):` | ✗ | ✓ | ✗ |
+| 22 | `Special (B1):` | ✗ | ✓ | ✗ |
+| 26 | `Animation # (W2):` | ✗ | ✓ | ✗ |
+| 28 | `Resolved:` | ✗ | ✓ | ✗ |
+| 33 | `Write` | ✗ | ✓ | ✗ |
+| 40 | `Animation Data Details` | ✗ | ✓ | ✗ |
+| 44 | `Name:` | ✗ | ✓ | ✗ |
+| 48 | `Data Address:` | ✗ | ✓ | ✗ |
+| 52 | `Section Ptr:` | ✗ | ✓ | ✗ |
+| 56 | `Frame Ptr:` | ✗ | ✓ | ✗ |
+| 60 | `OAM (R→L) Ptr:` | ✗ | ✓ | ✗ |
+| 64 | `OAM (L→R) Ptr:` | ✗ | ✓ | ✗ |
+| 68 | `Palette Ptr:` | ✗ | ✓ | ✗ |
+| 72 | `Frame Data:` | ✗ | ✓ | ✗ |
+| 76 | `OAM Data:` | ✗ | ✓ | ✗ |
+| 86 | `Sprite Tile Sheet` | ✗ | ✓ | ✗ |
+| 92 | `Export Tile Sheet PNG...` | ✗ | ✓ | ✗ |
+| 101 | `Animation Frame Viewer` | ✗ | ✓ | ✗ |
+| 105 | `Section:` | ✗ | ✓ | ✗ |
+| 110 | `Frame:` | ✗ | ✓ | ✗ |
+| 114 | `Prev` | ✗ | ✓ | ✗ |
+| 116 | `Next` | ✗ | ✓ | ✗ |
+| 121 | `Play` | ✗ | ✓ | ✗ |
+| 122 | `Speed:` | ✗ | ✓ | ✗ |
+| 139 | `No animation data found for this ID (ID=0 or invalid pointer chain).` | ✗ | ✓ | ✗ |
+| 145 | `Animation Table Summary` | ✗ | ✓ | ✗ |
+| 146 | `Total animations: --` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImagePortraitView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Portrait Image Editor` | ✗ | ✓ | ✗ |
+| 15 | `Import PNG` | ✗ | ✓ | ✗ |
+| 16 | `FE-Repo` | ✗ | ✓ | ✗ |
+| 17 | `Export Face` | ✗ | ✓ | ✗ |
+| 18 | `Export Mini` | ✗ | ✓ | ✗ |
+| 19 | `Export Sheet` | ✗ | ✓ | ✗ |
+| 20 | `Export PAL` | ✗ | ✓ | ✗ |
+| 21 | `Import PAL` | ✗ | ✓ | ✗ |
+| 27 | `Unit Face (96x80)` | ✗ | ✓ | ✗ |
+| 31 | `Map Face (32x32)` | ✗ | ✓ | ✗ |
+| 35 | `Class Card` | ✗ | ✓ | ✗ |
+| 42 | `Show Frame:` | ✗ | ✓ | ✗ |
+| 51 | `Mouth Frames (32x16 x6)` | ✗ | ✓ | ✗ |
+| 55 | `Eye Frames (32x16 x2)` | ✗ | ✓ | ✗ |
+| 62 | `Address:` | ✗ | ✓ | ✗ |
+| 66 | `Unit Face:` | ✗ | ✓ | ✗ |
+| 70 | `Map Face:` | ✗ | ✓ | ✗ |
+| 74 | `Palette:` | ✓ | ✓ | ✗ |
+| 78 | `Mouth Frames:` | ✗ | ✓ | ✗ |
+| 82 | `Class Card:` | ✗ | ✓ | ✗ |
+| 86 | `Mouth X:` | ✗ | ✓ | ✗ |
+| 91 | `Mouth Y:` | ✗ | ✓ | ✗ |
+| 97 | `Eye X:` | ✗ | ✓ | ✗ |
+| 102 | `Eye Y:` | ✗ | ✓ | ✗ |
+| 108 | `Write Positions` | ✗ | ✓ | ✗ |
+| 112 | `Status:` | ✗ | ✓ | ✗ |
+| 116 | `Unused (B25):` | ✗ | ✓ | ✗ |
+| 120 | `Unused (B26):` | ✗ | ✓ | ✗ |
+| 124 | `Unused (B27):` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/UnitFE6View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 14 | `Unit Editor (FE6)` | ✗ | ✓ | ✗ |
+| 18 | `Address:` | ✗ | ✓ | ✗ |
+| 23 | `Identity` | ✗ | ✓ | ✗ |
+| 28 | `Name ID:` | ✗ | ✓ | ✗ |
+| 30 | `Name:` | ✗ | ✓ | ✗ |
+| 32 | `Desc ID:` | ✗ | ✓ | ✗ |
+| 43 | `Unit ID:` | ✗ | ✓ | ✗ |
+| 45 | `Class ID:` | ✗ | ✓ | ✗ |
+| 50 | `Portrait:` | ✗ | ✓ | ✗ |
+| 56 | `Map Face:` | ✗ | ✓ | ✗ |
+| 58 | `Affinity:` | ✗ | ✓ | ✗ |
+| 60 | `Sort:` | ✗ | ✓ | ✗ |
+| 72 | `Base Stats` | ✗ | ✓ | ✗ |
+| 99 | `Weapon Levels` | ✗ | ✓ | ✗ |
+| 102 | `Sword:` | ✗ | ✓ | ✗ |
+| 104 | `Lance:` | ✗ | ✓ | ✗ |
+| 111 | `Staff:` | ✗ | ✓ | ✗ |
+| 113 | `Anima:` | ✗ | ✓ | ✗ |
+| 116 | `Light:` | ✗ | ✓ | ✗ |
+| 118 | `Dark:` | ✗ | ✓ | ✗ |
+| 124 | `Growth Rates (%)` | ✗ | ✓ | ✗ |
+| 147 | `Ability Flags` | ✗ | ✓ | ✗ |
+| 167 | `Support Ptr:` | ✗ | ✓ | ✗ |
+| 173 | `Lower Class Anim Color` | ✗ | ✓ | ✗ |
+| 175 | `Upper Class Anim Color` | ✗ | ✓ | ✗ |
+| 190 | `Write` | ✗ | ✓ | ✗ |
+| 191 | `Undo` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 26 | `Item Editor (FE6)` | ✗ | ✓ | ✗ |
+| 30 | `Address:` | ✗ | ✓ | ✗ |
+| 32 | `Name:` | ✗ | ✓ | ✗ |
+| 36 | `Name ID (W0):` | ✗ | ✓ | ✗ |
+| 38 | `Desc ID (W2):` | ✗ | ✓ | ✗ |
+| 50 | `Use Desc (W4):` | ✗ | ✓ | ✗ |
+| 52 | `Item # (B6):` | ✗ | ✓ | ✗ |
+| 56 | `Type (B7):` | ✗ | ✓ | ✗ |
+| 58 | `Trait 1 (B8):` | ✗ | ✓ | ✗ |
+| 62 | `Trait 2 (B9):` | ✗ | ✓ | ✗ |
+| 64 | `Trait 3 (B10):` | ✗ | ✓ | ✗ |
+| 68 | `Trait 4 (B11):` | ✗ | ✓ | ✗ |
+| 70 | `Stat Bonus (P12):` | ✗ | ✓ | ✗ |
+| 74 | `Effective (P16):` | ✗ | ✓ | ✗ |
+| 78 | `Uses (B20):` | ✗ | ✓ | ✗ |
+| 80 | `Might (B21):` | ✗ | ✓ | ✗ |
+| 84 | `Hit (B22):` | ✗ | ✓ | ✗ |
+| 86 | `Weight (B23):` | ✗ | ✓ | ✗ |
+| 90 | `Crit (B24):` | ✗ | ✓ | ✗ |
+| 92 | `Range (B25):` | ✗ | ✓ | ✗ |
+| 96 | `Price (W26):` | ✗ | ✓ | ✗ |
+| 98 | `Rank (B28):` | ✗ | ✓ | ✗ |
+| 102 | `Icon (B29):` | ✗ | ✓ | ✗ |
+| 104 | `Use Effect (B30):` | ✗ | ✓ | ✗ |
+| 108 | `Dmg Effect (B31):` | ✗ | ✓ | ✗ |
+| 113 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/AITargetView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `AI Targeting` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Lethal Damage Priority:` | ✗ | ✓ | ✗ |
+| 21 | `Enemy Remaining HP Priority:` | ✗ | ✓ | ✗ |
+| 24 | `Enemy Distance Priority:` | ✗ | ✓ | ✗ |
+| 27 | `Enemy Class Priority:` | ✗ | ✓ | ✗ |
+| 30 | `Current Turn Priority:` | ✗ | ✓ | ✗ |
+| 33 | `Counter Damage Warning:` | ✗ | ✓ | ✗ |
+| 36 | `Surround Warning:` | ✗ | ✓ | ✗ |
+| 39 | `Self Remaining HP Warning:` | ✗ | ✓ | ✗ |
+| 42 | `Unknown 8:` | ✗ | ✓ | ✗ |
+| 45 | `Unknown 9:` | ✗ | ✓ | ✗ |
+| 48 | `Unknown 10:` | ✗ | ✓ | ✗ |
+| 51 | `Unknown 11:` | ✗ | ✓ | ✗ |
+| 54 | `Unknown 12:` | ✗ | ✓ | ✗ |
+| 57 | `Unknown 13:` | ✗ | ✓ | ✗ |
+| 60 | `Unknown 14:` | ✗ | ✓ | ✗ |
+| 63 | `Unknown 15:` | ✗ | ✓ | ✗ |
+| 66 | `Unknown 16:` | ✗ | ✓ | ✗ |
+| 69 | `Unknown 17:` | ✗ | ✓ | ✗ |
+| 72 | `Unknown 18:` | ✗ | ✓ | ✗ |
+| 75 | `Unknown 19:` | ✗ | ✓ | ✗ |
+| 79 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/BattleTerrainViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 11 | `Battle Terrain Editor` | ✗ | ✓ | ✗ |
+| 13 | `Address:` | ✗ | ✓ | ✗ |
+| 15 | `Terrain Name:` | ✗ | ✓ | ✗ |
+| 17 | `Name Char 0:` | ✗ | ✓ | ✗ |
+| 19 | `Name Char 1:` | ✗ | ✓ | ✗ |
+| 21 | `Name Char 2:` | ✗ | ✓ | ✗ |
+| 23 | `Name Char 3:` | ✗ | ✓ | ✗ |
+| 25 | `Name Char 4:` | ✗ | ✓ | ✗ |
+| 27 | `Name Char 5:` | ✗ | ✓ | ✗ |
+| 29 | `Name Char 6:` | ✗ | ✓ | ✗ |
+| 31 | `Name Char 7:` | ✗ | ✓ | ✗ |
+| 33 | `Name Char 8:` | ✗ | ✓ | ✗ |
+| 35 | `Name Char 9:` | ✗ | ✓ | ✗ |
+| 37 | `Name Char 10:` | ✗ | ✓ | ✗ |
+| 39 | `Name Char 11:` | ✗ | ✓ | ✗ |
+| 41 | `Image Pointer:` | ✗ | ✓ | ✗ |
+| 43 | `Palette Pointer:` | ✗ | ✓ | ✗ |
+| 45 | `Unknown (D20):` | ✗ | ✓ | ✗ |
+| 49 | `Write` | ✗ | ✓ | ✗ |
+| 50 | `Export PNG` | ✗ | ✓ | ✗ |
+| 51 | `Import PNG` | ✗ | ✓ | ✗ |
+| 52 | `Export PAL` | ✗ | ✓ | ✗ |
+| 53 | `Import PAL` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventUnitFE6View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 10 | `Maps` | ✓ | ✓ | ✗ |
+| 16 | `Unit Groups` | ✗ | ✓ | ✗ |
+| 23 | `Units` | ✓ | ✓ | ✗ |
+| 26 | `Load` | ✗ | ✓ | ✗ |
+| 35 | `Event Unit (FE6)` | ✓ | ✓ | ✗ |
+| 38 | `Address:` | ✗ | ✓ | ✗ |
+| 41 | `Unit ID:` | ✗ | ✓ | ✗ |
+| 45 | `Class ID:` | ✗ | ✓ | ✗ |
+| 49 | `Leader Unit ID:` | ✗ | ✓ | ✗ |
+| 52 | `Unit Info:` | ✗ | ✓ | ✗ |
+| 55 | `Start X:` | ✗ | ✓ | ✗ |
+| 58 | `Start Y:` | ✗ | ✓ | ✗ |
+| 61 | `End X:` | ✗ | ✓ | ✗ |
+| 64 | `End Y:` | ✗ | ✓ | ✗ |
+| 67 | `Item 1:` | ✗ | ✓ | ✗ |
+| 71 | `Item 2:` | ✗ | ✓ | ✗ |
+| 75 | `Item 3:` | ✗ | ✓ | ✗ |
+| 79 | `Item 4:` | ✗ | ✓ | ✗ |
+| 83 | `AI1 Primary:` | ✗ | ✓ | ✗ |
+| 87 | `AI2 Secondary:` | ✗ | ✓ | ✗ |
+| 91 | `AI3 Target/Recovery:` | ✗ | ✓ | ✗ |
+| 95 | `AI4 Retreat:` | ✗ | ✓ | ✗ |
+| 101 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventUnitFE7View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 10 | `Maps` | ✓ | ✓ | ✗ |
+| 16 | `Unit Groups` | ✗ | ✓ | ✗ |
+| 23 | `Units` | ✓ | ✓ | ✗ |
+| 26 | `Load` | ✗ | ✓ | ✗ |
+| 35 | `Event Unit (FE7)` | ✓ | ✓ | ✗ |
+| 38 | `Address:` | ✗ | ✓ | ✗ |
+| 41 | `Unit ID:` | ✗ | ✓ | ✗ |
+| 45 | `Class ID:` | ✗ | ✓ | ✗ |
+| 49 | `Leader Unit ID:` | ✗ | ✓ | ✗ |
+| 52 | `Unit Info:` | ✗ | ✓ | ✗ |
+| 55 | `Start X:` | ✗ | ✓ | ✗ |
+| 58 | `Start Y:` | ✗ | ✓ | ✗ |
+| 61 | `End X:` | ✗ | ✓ | ✗ |
+| 64 | `End Y:` | ✗ | ✓ | ✗ |
+| 67 | `Item 1:` | ✗ | ✓ | ✗ |
+| 71 | `Item 2:` | ✗ | ✓ | ✗ |
+| 75 | `Item 3:` | ✗ | ✓ | ✗ |
+| 79 | `Item 4:` | ✗ | ✓ | ✗ |
+| 83 | `AI1 Primary:` | ✗ | ✓ | ✗ |
+| 87 | `AI2 Secondary:` | ✗ | ✓ | ✗ |
+| 91 | `AI3 Target/Recovery:` | ✗ | ✓ | ✗ |
+| 95 | `AI4 Retreat:` | ✗ | ✓ | ✗ |
+| 101 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventUnitView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 11 | `Maps` | ✓ | ✓ | ✗ |
+| 17 | `Unit Groups` | ✗ | ✓ | ✗ |
+| 24 | `Units` | ✓ | ✓ | ✗ |
+| 27 | `Load` | ✗ | ✓ | ✗ |
+| 36 | `Event Unit Placement (FE8)` | ✗ | ✓ | ✗ |
+| 40 | `Address:` | ✗ | ✓ | ✗ |
+| 44 | `Unit ID:` | ✗ | ✓ | ✗ |
+| 49 | `Class ID:` | ✗ | ✓ | ✗ |
+| 54 | `Leader Unit ID:` | ✗ | ✓ | ✗ |
+| 58 | `Unit Info:` | ✗ | ✓ | ✗ |
+| 62 | `Unit Growth:` | ✗ | ✓ | ✗ |
+| 66 | `Reserved (0x06):` | ✗ | ✓ | ✗ |
+| 70 | `Coord Count:` | ✗ | ✓ | ✗ |
+| 74 | `Coord Pointer:` | ✗ | ✓ | ✗ |
+| 78 | `Item 1:` | ✗ | ✓ | ✗ |
+| 82 | `Item 2:` | ✗ | ✓ | ✗ |
+| 86 | `Item 3:` | ✗ | ✓ | ✗ |
+| 90 | `Item 4:` | ✗ | ✓ | ✗ |
+| 95 | `AI1 Primary:` | ✗ | ✓ | ✗ |
+| 99 | `AI2 Secondary:` | ✗ | ✓ | ✗ |
+| 103 | `AI3 Target/Recovery:` | ✗ | ✓ | ✗ |
+| 107 | `AI4 Retreat:` | ✗ | ✓ | ✗ |
+| 113 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/PortraitViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Portrait Editor` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Image Pointer:` | ✗ | ✓ | ✗ |
+| 21 | `Map Pointer:` | ✗ | ✓ | ✗ |
+| 24 | `Palette Pointer:` | ✗ | ✓ | ✗ |
+| 27 | `Mouth:` | ✗ | ✓ | ✗ |
+| 30 | `Class Card:` | ✗ | ✓ | ✗ |
+| 33 | `Mouth X:` | ✗ | ✓ | ✗ |
+| 36 | `Mouth Y:` | ✗ | ✓ | ✗ |
+| 39 | `Eye X:` | ✗ | ✓ | ✗ |
+| 42 | `Eye Y:` | ✗ | ✓ | ✗ |
+| 45 | `State:` | ✗ | ✓ | ✗ |
+| 48 | `Padding (B25):` | ✗ | ✓ | ✗ |
+| 51 | `Padding (B26):` | ✗ | ✓ | ✗ |
+| 54 | `Padding (B27):` | ✗ | ✓ | ✗ |
+| 59 | `Write` | ✗ | ✓ | ✗ |
+| 60 | `Import PNG` | ✗ | ✓ | ✗ |
+| 61 | `Export PNG` | ✗ | ✓ | ✗ |
+| 62 | `Export PAL` | ✗ | ✓ | ✗ |
+| 63 | `Import PAL` | ✗ | ✓ | ✗ |
+| 68 | `Main Portrait` | ✗ | ✓ | ✗ |
+| 72 | `Mini Portrait` | ✗ | ✓ | ✗ |
+| 76 | `Class Card` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/StatusOptionView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Status Screen Options` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `ID Text:` | ✗ | ✓ | ✗ |
+| 24 | `Name Text ID:` | ✗ | ✓ | ✗ |
+| 30 | `Help Text ID:` | ✗ | ✓ | ✗ |
+| 36 | `X Position:` | ✗ | ✓ | ✗ |
+| 39 | `Y Position:` | ✗ | ✓ | ✗ |
+| 42 | `Selection Text 1:` | ✗ | ✓ | ✗ |
+| 45 | `Selection Text 2:` | ✗ | ✓ | ✗ |
+| 48 | `Columns:` | ✗ | ✓ | ✗ |
+| 51 | `Rows:` | ✗ | ✓ | ✗ |
+| 54 | `Default Text ID:` | ✗ | ✓ | ✗ |
+| 60 | `Yes Text ID:` | ✗ | ✓ | ✗ |
+| 66 | `Min Value:` | ✗ | ✓ | ✗ |
+| 69 | `Max Value:` | ✗ | ✓ | ✗ |
+| 72 | `On/Off Text 1:` | ✗ | ✓ | ✗ |
+| 75 | `On/Off Text 2:` | ✗ | ✓ | ✗ |
+| 78 | `Default Value:` | ✗ | ✓ | ✗ |
+| 81 | `Option Type:` | ✗ | ✓ | ✗ |
+| 84 | `Icon ID:` | ✗ | ✓ | ✗ |
+| 87 | `ASM Pointer:` | ✗ | ✓ | ✗ |
+| 92 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/WorldMapPointView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `World Map Point Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Always Accessible:` | ✗ | ✓ | ✗ |
+| 21 | `Free Map Type:` | ✗ | ✓ | ✗ |
+| 24 | `Pre-Clear Icon:` | ✗ | ✓ | ✗ |
+| 27 | `Post-Clear Icon:` | ✗ | ✓ | ✗ |
+| 30 | `Chapter ID 1:` | ✗ | ✓ | ✗ |
+| 33 | `Chapter ID 2:` | ✗ | ✓ | ✗ |
+| 36 | `Event Branch Flag:` | ✗ | ✓ | ✗ |
+| 39 | `Next Node (Eirika):` | ✗ | ✓ | ✗ |
+| 42 | `Next Node (Ephraim):` | ✗ | ✓ | ✗ |
+| 45 | `Next Node (Eirika 2nd):` | ✗ | ✓ | ✗ |
+| 48 | `Next Node (Ephraim 2nd):` | ✗ | ✓ | ✗ |
+| 51 | `Armory Pointer:` | ✗ | ✓ | ✗ |
+| 54 | `Vendor Pointer:` | ✗ | ✓ | ✗ |
+| 57 | `Secret Shop Pointer:` | ✗ | ✓ | ✗ |
+| 60 | `Coordinate X:` | ✗ | ✓ | ✗ |
+| 63 | `Coordinate Y:` | ✗ | ✓ | ✗ |
+| 66 | `Name Text ID:` | ✗ | ✓ | ✗ |
+| 72 | `Ship Setting:` | ✗ | ✓ | ✗ |
+| 77 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/UshortBitFlagView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 13 | `Short Bit Flags (16-bit)` | ✗ | ✓ | ✗ |
+| 16 | `Apply` | ✗ | ✓ | ✗ |
+| 27 | `Low byte:` | ✗ | ✓ | ✗ |
+| 30 | `Bit 0  (0x01)` | ✗ | ✓ | ✗ |
+| 31 | `Bit 1  (0x02)` | ✗ | ✓ | ✗ |
+| 32 | `Bit 2  (0x04)` | ✗ | ✓ | ✗ |
+| 33 | `Bit 3  (0x08)` | ✗ | ✓ | ✗ |
+| 34 | `Bit 4  (0x10)` | ✗ | ✓ | ✗ |
+| 35 | `Bit 5  (0x20)` | ✗ | ✓ | ✗ |
+| 36 | `Bit 6  (0x40)` | ✗ | ✓ | ✗ |
+| 37 | `Bit 7  (0x80)` | ✗ | ✓ | ✗ |
+| 45 | `High byte:` | ✗ | ✓ | ✗ |
+| 48 | `Bit 8  (0x01)` | ✗ | ✓ | ✗ |
+| 49 | `Bit 9  (0x02)` | ✗ | ✓ | ✗ |
+| 50 | `Bit 10 (0x04)` | ✗ | ✓ | ✗ |
+| 51 | `Bit 11 (0x08)` | ✗ | ✓ | ✗ |
+| 52 | `Bit 12 (0x10)` | ✗ | ✓ | ✗ |
+| 53 | `Bit 13 (0x20)` | ✗ | ✓ | ✗ |
+| 54 | `Bit 14 (0x40)` | ✗ | ✓ | ✗ |
+| 55 | `Bit 15 (0x80)` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ItemStatBonusesSkillSystemsView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Stat Bonuses (Skill Systems)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 20 | `Stat Bonuses` | ✓ | ✓ | ✗ |
+| 23 | `Str/Mag` | ✗ | ✓ | ✗ |
+| 24 | `Skill` | ✗ | ✓ | ✗ |
+| 25 | `Speed` | ✗ | ✓ | ✗ |
+| 26 | `Defense` | ✗ | ✓ | ✗ |
+| 27 | `Resistance` | ✗ | ✓ | ✗ |
+| 28 | `Luck` | ✗ | ✓ | ✗ |
+| 29 | `Move` | ✗ | ✓ | ✗ |
+| 46 | `Growth Rate Bonuses` | ✗ | ✓ | ✗ |
+| 49 | `Str/Mag` | ✗ | ✓ | ✗ |
+| 50 | `Skill` | ✗ | ✓ | ✗ |
+| 51 | `Speed` | ✗ | ✓ | ✗ |
+| 52 | `Defense` | ✗ | ✓ | ✗ |
+| 53 | `Resistance` | ✗ | ✓ | ✗ |
+| 54 | `Luck` | ✗ | ✓ | ✗ |
+| 68 | `Padding` | ✗ | ✓ | ✗ |
+| 78 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SummonsDemonKingViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Demon King Summon Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Unit ID:` | ✗ | ✓ | ✗ |
+| 24 | `Class ID:` | ✗ | ✓ | ✗ |
+| 30 | `Commander:` | ✗ | ✓ | ✗ |
+| 33 | `Level/Growth:` | ✗ | ✓ | ✗ |
+| 36 | `Coordinates:` | ✗ | ✓ | ✗ |
+| 39 | `Special:` | ✗ | ✓ | ✗ |
+| 42 | `Padding (B7):` | ✗ | ✓ | ✗ |
+| 45 | `AI Pointer:` | ✗ | ✓ | ✗ |
+| 48 | `Item 1:` | ✗ | ✓ | ✗ |
+| 51 | `Item 2:` | ✗ | ✓ | ✗ |
+| 54 | `Item 3:` | ✗ | ✓ | ✗ |
+| 57 | `Item 4:` | ✗ | ✓ | ✗ |
+| 60 | `AI 1:` | ✗ | ✓ | ✗ |
+| 63 | `AI 2:` | ✗ | ✓ | ✗ |
+| 66 | `Target/Recovery AI:` | ✗ | ✓ | ✗ |
+| 69 | `Retreat AI:` | ✗ | ✓ | ✗ |
+| 74 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Unit Palette Editor` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 20 | `Identifier:` | ✗ | ✓ | ✗ |
+| 24 | `Id 0:` | ✗ | ✓ | ✗ |
+| 26 | `Id 1:` | ✗ | ✓ | ✗ |
+| 29 | `Id 2:` | ✗ | ✓ | ✗ |
+| 31 | `Id 3:` | ✗ | ✓ | ✗ |
+| 34 | `Id 4:` | ✗ | ✓ | ✗ |
+| 36 | `Id 5:` | ✗ | ✓ | ✗ |
+| 39 | `Id 6:` | ✗ | ✓ | ✗ |
+| 41 | `Id 7:` | ✗ | ✓ | ✗ |
+| 44 | `Id 8:` | ✗ | ✓ | ✗ |
+| 46 | `Id 9:` | ✗ | ✓ | ✗ |
+| 49 | `Id 10:` | ✗ | ✓ | ✗ |
+| 51 | `Id 11:` | ✗ | ✓ | ✗ |
+| 55 | `Palette Ptr (P12):` | ✗ | ✓ | ✗ |
+| 59 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ItemStatBonusesVennoView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Stat Bonuses (Venno)` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 20 | `Stat Bonuses` | ✓ | ✓ | ✗ |
+| 23 | `Str/Mag` | ✗ | ✓ | ✗ |
+| 24 | `Skill` | ✗ | ✓ | ✗ |
+| 25 | `Speed` | ✗ | ✓ | ✗ |
+| 26 | `Defense` | ✗ | ✓ | ✗ |
+| 27 | `Resistance` | ✗ | ✓ | ✗ |
+| 28 | `Luck` | ✗ | ✓ | ✗ |
+| 29 | `Move` | ✗ | ✓ | ✗ |
+| 44 | `Growth Rate Bonuses` | ✗ | ✓ | ✗ |
+| 47 | `Str/Mag` | ✗ | ✓ | ✗ |
+| 48 | `Skill` | ✗ | ✓ | ✗ |
+| 49 | `Speed` | ✗ | ✓ | ✗ |
+| 50 | `Defense` | ✗ | ✓ | ✗ |
+| 51 | `Resistance` | ✗ | ✓ | ✗ |
+| 62 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SkillConfigFE8NSkillView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Skill Configuration (FE8N)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Icon:` | ✗ | ✓ | ✗ |
+| 21 | `Description:` | ✗ | ✓ | ✗ |
+| 24 | `Condition Unit 1:` | ✗ | ✓ | ✗ |
+| 27 | `Condition Unit 2:` | ✗ | ✓ | ✗ |
+| 30 | `Condition Unit 3:` | ✗ | ✓ | ✗ |
+| 33 | `Condition Unit 4:` | ✗ | ✓ | ✗ |
+| 36 | `Condition Class 1:` | ✗ | ✓ | ✗ |
+| 39 | `Condition Class 2:` | ✗ | ✓ | ✗ |
+| 42 | `Condition Class 3:` | ✗ | ✓ | ✗ |
+| 45 | `Condition Class 4:` | ✗ | ✓ | ✗ |
+| 48 | `Condition Item 1:` | ✗ | ✓ | ✗ |
+| 51 | `Condition Item 2:` | ✗ | ✓ | ✗ |
+| 54 | `Condition Item 3:` | ✗ | ✓ | ✗ |
+| 57 | `Condition Item 4:` | ✗ | ✓ | ✗ |
+| 61 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/OPClassDemoFE7View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `OP Class Demo (FE7) Editor` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 19 | `English Name Pointer:` | ✗ | ✓ | ✗ |
+| 22 | `Description Text ID:` | ✗ | ✓ | ✗ |
+| 28 | `Japanese Name Pointer:` | ✗ | ✓ | ✗ |
+| 31 | `Japanese Name Length:` | ✗ | ✓ | ✗ |
+| 34 | `Palette ID:` | ✗ | ✓ | ✗ |
+| 37 | `Display Weapon:` | ✗ | ✓ | ✗ |
+| 40 | `Class ID:` | ✗ | ✓ | ✗ |
+| 46 | `Ally/Enemy Color:` | ✗ | ✓ | ✗ |
+| 49 | `Battle Anime:` | ✗ | ✓ | ✗ |
+| 52 | `Magic Effect:` | ✗ | ✓ | ✗ |
+| 55 | `Terrain Left:` | ✗ | ✓ | ✗ |
+| 58 | `Terrain Right:` | ✗ | ✓ | ✗ |
+| 61 | `Anime Pointer:` | ✗ | ✓ | ✗ |
+| 65 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 11 | `OP Class Demo Editor` | ✗ | ✓ | ✗ |
+| 13 | `Address:` | ✗ | ✓ | ✗ |
+| 16 | `English Name Pointer:` | ✗ | ✓ | ✗ |
+| 19 | `Description Text ID:` | ✗ | ✓ | ✗ |
+| 25 | `Japanese Name Pointer:` | ✗ | ✓ | ✗ |
+| 28 | `Japanese Name Length:` | ✗ | ✓ | ✗ |
+| 31 | `Palette ID:` | ✗ | ✓ | ✗ |
+| 34 | `Display Weapon:` | ✗ | ✓ | ✗ |
+| 37 | `Ally/Enemy Color:` | ✗ | ✓ | ✗ |
+| 40 | `Battle Anime:` | ✗ | ✓ | ✗ |
+| 43 | `Magic Effect:` | ✗ | ✓ | ✗ |
+| 46 | `Unknown (0x12):` | ✗ | ✓ | ✗ |
+| 49 | `Terrain Left:` | ✗ | ✓ | ✗ |
+| 52 | `Terrain Right:` | ✗ | ✓ | ✗ |
+| 55 | `Anime Pointer:` | ✗ | ✓ | ✗ |
+| 59 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/PointerToolView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Batch` | ✗ | ✓ | ✗ |
+| 13 | `What Is` | ✗ | ✓ | ✗ |
+| 14 | `Close` | ✗ | ✓ | ✗ |
+| 23 | `Address` | ✗ | ✓ | ✗ |
+| 31 | `Pointer` | ✗ | ✓ | ✗ |
+| 38 | `Little Endian` | ✗ | ✓ | ✗ |
+| 45 | `First Reference` | ✗ | ✓ | ✗ |
+| 72 | `Other ROM Ref` | ✗ | ✓ | ✗ |
+| 77 | `Use ASM Map for search` | ✗ | ✓ | ✗ |
+| 83 | `Search Options` | ✗ | ✓ | ✗ |
+| 86 | `Comparison Size` | ✗ | ✓ | ✗ |
+| 92 | `Content Type` | ✗ | ✓ | ✗ |
+| 98 | `Match Method` | ✗ | ✓ | ✗ |
+| 104 | `Slide Search` | ✗ | ✓ | ✗ |
+| 110 | `Auto Tracking` | ✗ | ✓ | ✗ |
+| 116 | `Warning Level` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MenuDefinitionView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Menu Definition Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `X Position:` | ✗ | ✓ | ✗ |
+| 21 | `Y Position:` | ✗ | ✓ | ✗ |
+| 24 | `Width:` | ✗ | ✓ | ✗ |
+| 27 | `Height:` | ✓ | ✓ | ✗ |
+| 30 | `Style Data:` | ✗ | ✓ | ✗ |
+| 33 | `Menu Command Ptr:` | ✗ | ✓ | ✗ |
+| 36 | `OnInit Routine:` | ✗ | ✓ | ✗ |
+| 39 | `OnEnd Routine:` | ✗ | ✓ | ✗ |
+| 42 | `Unknown Routine:` | ✗ | ✓ | ✗ |
+| 45 | `On B Press Routine:` | ✗ | ✓ | ✗ |
+| 48 | `On R Press Routine:` | ✗ | ✓ | ✗ |
+| 51 | `On HelpBox Routine:` | ✗ | ✓ | ✗ |
+| 56 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MenuExtendSplitMenuView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Split Menu Definition` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `X Position:` | ✗ | ✓ | ✗ |
+| 21 | `Y Position:` | ✗ | ✓ | ✗ |
+| 24 | `Width:` | ✗ | ✓ | ✗ |
+| 27 | `Style:` | ✗ | ✓ | ✗ |
+| 30 | `String 0:` | ✗ | ✓ | ✗ |
+| 33 | `String 1:` | ✗ | ✓ | ✗ |
+| 36 | `String 2:` | ✗ | ✓ | ✗ |
+| 39 | `String 3:` | ✗ | ✓ | ✗ |
+| 42 | `String 4:` | ✗ | ✓ | ✗ |
+| 45 | `String 5:` | ✗ | ✓ | ✗ |
+| 48 | `String 6:` | ✗ | ✓ | ✗ |
+| 51 | `String 7:` | ✗ | ✓ | ✗ |
+| 56 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MonsterProbabilityViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Monster Probability Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Class ID 1:` | ✗ | ✓ | ✗ |
+| 21 | `Class ID 2:` | ✗ | ✓ | ✗ |
+| 24 | `Class ID 3:` | ✗ | ✓ | ✗ |
+| 27 | `Class ID 4:` | ✗ | ✓ | ✗ |
+| 30 | `Class ID 5:` | ✗ | ✓ | ✗ |
+| 33 | `Probability 1:` | ✗ | ✓ | ✗ |
+| 36 | `Probability 2:` | ✗ | ✓ | ✗ |
+| 39 | `Probability 3:` | ✗ | ✓ | ✗ |
+| 42 | `Probability 4:` | ✗ | ✓ | ✗ |
+| 45 | `Probability 5:` | ✗ | ✓ | ✗ |
+| 48 | `Unknown 1:` | ✗ | ✓ | ✗ |
+| 51 | `Unknown 2:` | ✗ | ✓ | ✗ |
+| 56 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SupportTalkFE7View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 11 | `Support Talk (FE7)` | ✗ | ✓ | ✗ |
+| 13 | `Address:` | ✗ | ✓ | ✗ |
+| 16 | `Support Partner 1:` | ✗ | ✓ | ✗ |
+| 19 | `Support Partner 2:` | ✗ | ✓ | ✗ |
+| 22 | `C Support Text:` | ✗ | ✓ | ✗ |
+| 25 | `Jump` | ✗ | ✓ | ✗ |
+| 28 | `B Support Text:` | ✗ | ✓ | ✗ |
+| 31 | `Jump` | ✗ | ✓ | ✗ |
+| 34 | `A Support Text:` | ✗ | ✓ | ✗ |
+| 37 | `Jump` | ✗ | ✓ | ✗ |
+| 40 | `C Support Song:` | ✗ | ✓ | ✗ |
+| 43 | `B Support Song:` | ✗ | ✓ | ✗ |
+| 46 | `A Support Song:` | ✗ | ✓ | ✗ |
+| 49 | `Padding:` | ✗ | ✓ | ✗ |
+| 53 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ItemWeaponEffectViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Item Weapon Effect Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Item ID:` | ✗ | ✓ | ✗ |
+| 24 | `Anim Type:` | ✗ | ✓ | ✗ |
+| 27 | `Effect ID:` | ✗ | ✓ | ✗ |
+| 30 | `Map Effect Pointer:` | ✗ | ✓ | ✗ |
+| 33 | `Damage Effect:` | ✗ | ✓ | ✗ |
+| 36 | `Motion:` | ✗ | ✓ | ✗ |
+| 39 | `Hit Color:` | ✗ | ✓ | ✗ |
+| 42 | `Unknown (byte 1):` | ✗ | ✓ | ✗ |
+| 45 | `Unknown (byte 3):` | ✗ | ✓ | ✗ |
+| 48 | `Unknown (bytes 6-7):` | ✗ | ✓ | ✗ |
+| 51 | `Unknown (byte 15):` | ✗ | ✓ | ✗ |
+| 56 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SupportTalkView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Support Talk` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Support Partner 1:` | ✗ | ✓ | ✗ |
+| 21 | `Support Partner 2:` | ✗ | ✓ | ✗ |
+| 24 | `C Support Text:` | ✗ | ✓ | ✗ |
+| 27 | `Jump` | ✗ | ✓ | ✗ |
+| 30 | `B Support Text:` | ✗ | ✓ | ✗ |
+| 33 | `Jump` | ✗ | ✓ | ✗ |
+| 36 | `A Support Text:` | ✗ | ✓ | ✗ |
+| 39 | `Jump` | ✗ | ✓ | ✗ |
+| 42 | `C Support Song:` | ✗ | ✓ | ✗ |
+| 45 | `B Support Song:` | ✗ | ✓ | ✗ |
+| 48 | `A Support Song:` | ✗ | ✓ | ✗ |
+| 52 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/TextDicView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 15 | `Text Dictionary` | ✗ | ✓ | ✗ |
+| 19 | `Title Index:` | ✗ | ✓ | ✗ |
+| 21 | `Chapter Index:` | ✗ | ✓ | ✗ |
+| 24 | `Text ID 1:` | ✗ | ✓ | ✗ |
+| 26 | `Preview:` | ✗ | ✓ | ✗ |
+| 29 | `Text ID 2:` | ✗ | ✓ | ✗ |
+| 31 | `Preview:` | ✗ | ✓ | ✗ |
+| 34 | `Flag 1:` | ✗ | ✓ | ✗ |
+| 36 | `Flag 2:` | ✗ | ✓ | ✗ |
+| 39 | `Unit ID:` | ✗ | ✓ | ✗ |
+| 44 | `Unit:` | ✗ | ✓ | ✗ |
+| 47 | `Class ID:` | ✗ | ✓ | ✗ |
+| 52 | `Class:` | ✗ | ✓ | ✗ |
+| 57 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolExportEAEventView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 13 | `Map Name` | ✗ | ✓ | ✗ |
+| 24 | `Export events in EA format.` | ✗ | ✓ | ✗ |
+| 27 | `Add EndGuards on export` | ✗ | ✓ | ✗ |
+| 31 | `Export Events in EA format` | ✗ | ✓ | ✗ |
+| 35 | `Export World Map Events in EA format` | ✗ | ✓ | ✗ |
+| 39 | `Export World Map Events (selected) in EA format` | ✗ | ✓ | ✗ |
+| 44 | `The latest EA may not dump extended area data. In that case, use EA ver9.` | ✗ | ✓ | ✗ |
+| 49 | `Data` | ✗ | ✓ | ✗ |
+| 50 | `Export Main Tables` | ✗ | ✓ | ✗ |
+| 52 | `Dumps unit, class, item, and other tables.` | ✗ | ✓ | ✗ |
+| 59 | `Undo Buffer` | ✗ | ✓ | ✗ |
+| 60 | `Export Undo Buffer` | ✗ | ✓ | ✗ |
+| 62 | `Export changes made to the ROM in this session.` | ✗ | ✓ | ✗ |
+| 71 | `For import, use Run > Event Assembler Add.` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolWorkSupportView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Work Support` | ✗ | ✓ | ✗ |
+| 12 | `Reload` | ✗ | ✓ | ✗ |
+| 13 | `Close` | ✗ | ✓ | ✗ |
+| 21 | `Project Information` | ✗ | ✓ | ✗ |
+| 23 | `Name:` | ✗ | ✓ | ✗ |
+| 25 | `Author:` | ✗ | ✓ | ✗ |
+| 27 | `Version:` | ✗ | ✓ | ✗ |
+| 29 | `Community:` | ✗ | ✓ | ✗ |
+| 38 | `Actions` | ✗ | ✓ | ✗ |
+| 40 | `Check Update` | ✗ | ✓ | ✗ |
+| 41 | `Open Community` | ✗ | ✓ | ✗ |
+| 42 | `Open Info File` | ✗ | ✓ | ✗ |
+| 43 | `Show All Works` | ✗ | ✓ | ✗ |
+| 51 | `Status` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapChangeView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 13 | `Change Records` | ✗ | ✓ | ✗ |
+| 20 | `Map Change Editor` | ✗ | ✓ | ✗ |
+| 23 | `Map Pointer` | ✗ | ✓ | ✗ |
+| 25 | `Address:` | ✗ | ✓ | ✗ |
+| 28 | `Change Pointer:` | ✗ | ✓ | ✗ |
+| 32 | `Write Pointer` | ✗ | ✓ | ✗ |
+| 38 | `Selected Record` | ✗ | ✓ | ✗ |
+| 40 | `Record Address:` | ✗ | ✓ | ✗ |
+| 43 | `Change ID:` | ✗ | ✓ | ✗ |
+| 52 | `Width:` | ✗ | ✓ | ✗ |
+| 55 | `Height:` | ✓ | ✓ | ✗ |
+| 58 | `Tile Data Ptr:` | ✗ | ✓ | ✗ |
+| 62 | `Write Record` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MenuCommandView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Menu Command Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Japanese Name Pointer:` | ✗ | ✓ | ✗ |
+| 21 | `Name Text ID:` | ✗ | ✓ | ✗ |
+| 27 | `Help Text ID:` | ✗ | ✓ | ✗ |
+| 33 | `Color/ID (u32@8):` | ✗ | ✓ | ✗ |
+| 36 | `Usability Routine:` | ✗ | ✓ | ✗ |
+| 39 | `Draw Routine:` | ✗ | ✓ | ✗ |
+| 42 | `Effect Routine:` | ✗ | ✓ | ✗ |
+| 45 | `Per-Turn Callback:` | ✗ | ✓ | ✗ |
+| 48 | `Cursor Select Action:` | ✗ | ✓ | ✗ |
+| 51 | `Cancel Action:` | ✗ | ✓ | ✗ |
+| 56 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/OPClassDemoFE7UView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `OP Class Demo (FE7U) Editor` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 19 | `English Name Pointer:` | ✗ | ✓ | ✗ |
+| 22 | `Description Text ID:` | ✗ | ✓ | ✗ |
+| 28 | `Japanese Name Length:` | ✗ | ✓ | ✗ |
+| 31 | `Class ID:` | ✗ | ✓ | ✗ |
+| 37 | `Ally/Enemy Color:` | ✗ | ✓ | ✗ |
+| 40 | `Battle Anime:` | ✗ | ✓ | ✗ |
+| 43 | `Magic Effect:` | ✗ | ✓ | ✗ |
+| 46 | `Terrain Left:` | ✗ | ✓ | ✗ |
+| 49 | `Terrain Right:` | ✗ | ✓ | ✗ |
+| 52 | `Anime Pointer:` | ✗ | ✓ | ✗ |
+| 56 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/OPClassDemoFE8UView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `OP Class Demo (FE8U) Editor` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 19 | `Description Text ID:` | ✗ | ✓ | ✗ |
+| 25 | `Display Weapon:` | ✗ | ✓ | ✗ |
+| 28 | `Class ID:` | ✗ | ✓ | ✗ |
+| 34 | `Ally/Enemy Color:` | ✗ | ✓ | ✗ |
+| 37 | `Battle Anime:` | ✗ | ✓ | ✗ |
+| 40 | `Terrain Left:` | ✗ | ✓ | ✗ |
+| 43 | `Terrain Right:` | ✗ | ✓ | ✗ |
+| 46 | `Magic Effect:` | ✗ | ✓ | ✗ |
+| 49 | `Anime Type:` | ✗ | ✓ | ✗ |
+| 52 | `Anime Pointer:` | ✗ | ✓ | ✗ |
+| 56 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/PatchManagerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Filter patches by name, tag, or author...` | ✗ | ✓ | ✗ |
+| 40 | `Patch Details` | ✗ | ✓ | ✗ |
+| 44 | `Name:` | ✗ | ✓ | ✗ |
+| 50 | `Status:` | ✗ | ✓ | ✗ |
+| 56 | `Author:` | ✗ | ✓ | ✗ |
+| 62 | `Type:` | ✗ | ✓ | ✗ |
+| 68 | `Tags:` | ✗ | ✓ | ✗ |
+| 74 | `Directory:` | ✗ | ✓ | ✗ |
+| 84 | `Unmet Dependencies` | ✗ | ✓ | ✗ |
+| 95 | `Install Patch` | ✗ | ✓ | ✗ |
+| 97 | `Install Anyway` | ✗ | ✓ | ✗ |
+| 99 | `Uninstall Patch` | ✗ | ✓ | ✗ |
+| 111 | `Description` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SupportTalkFE6View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 11 | `Support Talk (FE6)` | ✗ | ✓ | ✗ |
+| 13 | `Address:` | ✗ | ✓ | ✗ |
+| 16 | `Support Partner 1:` | ✗ | ✓ | ✗ |
+| 19 | `Support Partner 2:` | ✗ | ✓ | ✗ |
+| 22 | `C Support Text:` | ✗ | ✓ | ✗ |
+| 25 | `Jump` | ✗ | ✓ | ✗ |
+| 28 | `B Support Text:` | ✗ | ✓ | ✗ |
+| 31 | `Jump` | ✗ | ✓ | ✗ |
+| 34 | `A Support Text:` | ✗ | ✓ | ✗ |
+| 37 | `Jump` | ✗ | ✓ | ✗ |
+| 40 | `Padding 1:` | ✗ | ✓ | ✗ |
+| 43 | `Padding 2:` | ✗ | ✓ | ✗ |
+| 47 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolThreeMargeView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Three-Way ROM Merge` | ✗ | ✓ | ✗ |
+| 13 | `Original ROM:` | ✗ | ✓ | ✗ |
+| 17 | `My ROM:` | ✗ | ✓ | ✗ |
+| 21 | `Their ROM:` | ✗ | ✓ | ✗ |
+| 28 | `Merge` | ✗ | ✓ | ✗ |
+| 29 | `Save Merged ROM` | ✗ | ✓ | ✗ |
+| 31 | `Close` | ✗ | ✓ | ✗ |
+| 42 | `Merge Statistics` | ✗ | ✓ | ✗ |
+| 45 | `My changes: ` | ✗ | ✓ | ✗ |
+| 48 | `Their changes: ` | ✗ | ✓ | ✗ |
+| 51 | `Both (same): ` | ✗ | ✓ | ✗ |
+| 54 | `Conflict bytes: ` | ✗ | ✓ | ✗ |
+| 64 | `Conflicts (resolve each: Mine or Theirs)` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventCondView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 10 | `Maps` | ✓ | ✓ | ✗ |
+| 16 | `Condition Slot` | ✗ | ✓ | ✗ |
+| 18 | `Records` | ✗ | ✓ | ✗ |
+| 25 | `Event Condition Editor` | ✗ | ✓ | ✗ |
+| 30 | `Record Address:` | ✗ | ✓ | ✗ |
+| 34 | `Record Size:` | ✗ | ✓ | ✗ |
+| 37 | `Type Name:` | ✗ | ✓ | ✗ |
+| 42 | `Type:` | ✗ | ✓ | ✗ |
+| 50 | `Flag ID:` | ✗ | ✓ | ✗ |
+| 54 | `Event Pointer:` | ✗ | ✓ | ✗ |
+| 96 | `Write` | ✗ | ✓ | ✗ |
+| 100 | `Raw Hex:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImagePortraitFE6View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Portrait Editor (FE6)` | ✗ | ✓ | ✗ |
+| 15 | `Import PNG` | ✗ | ✓ | ✗ |
+| 16 | `Export PNG` | ✗ | ✓ | ✗ |
+| 17 | `Export PAL` | ✗ | ✓ | ✗ |
+| 18 | `Import PAL` | ✗ | ✓ | ✗ |
+| 25 | `Address:` | ✗ | ✓ | ✗ |
+| 29 | `Unit Face:` | ✗ | ✓ | ✗ |
+| 33 | `Map Face:` | ✗ | ✓ | ✗ |
+| 37 | `Palette:` | ✓ | ✓ | ✗ |
+| 41 | `Mouth Coord:` | ✗ | ✓ | ✗ |
+| 50 | `Unused (B14):` | ✗ | ✓ | ✗ |
+| 54 | `Unused (B15):` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ItemStatBonusesViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Item Stat Bonuses Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 24 | `Skill:` | ✗ | ✓ | ✗ |
+| 27 | `Speed:` | ✗ | ✓ | ✗ |
+| 30 | `Defense:` | ✗ | ✓ | ✗ |
+| 33 | `Resistance:` | ✗ | ✓ | ✗ |
+| 36 | `Luck:` | ✗ | ✓ | ✗ |
+| 39 | `Move:` | ✗ | ✓ | ✗ |
+| 45 | `Unknown (byte 9):` | ✗ | ✓ | ✗ |
+| 48 | `Unknown (byte 10):` | ✗ | ✓ | ✗ |
+| 51 | `Unknown (byte 11):` | ✗ | ✓ | ✗ |
+| 56 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/StatusRMenuView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Status R-Menu Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Up RMenuPointer:` | ✗ | ✓ | ✗ |
+| 21 | `Down RMenuPointer:` | ✗ | ✓ | ✗ |
+| 24 | `Left RMenuPointer:` | ✗ | ✓ | ✗ |
+| 27 | `Right RMenuPointer:` | ✗ | ✓ | ✗ |
+| 30 | `X Position:` | ✗ | ✓ | ✗ |
+| 33 | `Y Position:` | ✗ | ✓ | ✗ |
+| 36 | `Text ID (TID):` | ✗ | ✓ | ✗ |
+| 42 | `Loop Routine:` | ✗ | ✓ | ✗ |
+| 45 | `Getter Routine:` | ✗ | ✓ | ✗ |
+| 50 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SongTrackView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Song Track Editor` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 19 | `Track Count:` | ✗ | ✓ | ✗ |
+| 22 | `NumBlks:` | ✗ | ✓ | ✗ |
+| 25 | `Priority:` | ✗ | ✓ | ✗ |
+| 28 | `Reverb:` | ✗ | ✓ | ✗ |
+| 31 | `Instrument Set:` | ✗ | ✓ | ✗ |
+| 36 | `Write` | ✗ | ✓ | ✗ |
+| 37 | `Export MIDI` | ✗ | ✓ | ✗ |
+| 38 | `Import MIDI` | ✗ | ✓ | ✗ |
+| 43 | `Tracks` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SupportAttributeView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Support Attribute Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Affinity Type:` | ✗ | ✓ | ✗ |
+| 21 | `Attack Bonus:` | ✗ | ✓ | ✗ |
+| 24 | `Defense Bonus:` | ✗ | ✓ | ✗ |
+| 27 | `Hit Bonus:` | ✗ | ✓ | ✗ |
+| 30 | `Avoid Bonus:` | ✗ | ✓ | ✗ |
+| 33 | `Crit Bonus:` | ✗ | ✓ | ✗ |
+| 36 | `Crit Avoid Bonus:` | ✗ | ✓ | ✗ |
+| 39 | `Unknown 7:` | ✗ | ✓ | ✗ |
+| 44 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/BattleBGViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 11 | `Battle Background Editor` | ✗ | ✓ | ✗ |
+| 13 | `Address:` | ✗ | ✓ | ✗ |
+| 15 | `Image Pointer:` | ✗ | ✓ | ✗ |
+| 17 | `TSA Pointer:` | ✗ | ✓ | ✗ |
+| 19 | `Palette Pointer:` | ✗ | ✓ | ✗ |
+| 23 | `Write` | ✗ | ✓ | ✗ |
+| 24 | `Import PNG` | ✗ | ✓ | ✗ |
+| 25 | `Export PNG` | ✗ | ✓ | ✗ |
+| 26 | `Export PAL` | ✗ | ✓ | ✗ |
+| 27 | `Import PAL` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/BigCGViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 11 | `Big CG Editor` | ✗ | ✓ | ✗ |
+| 13 | `Address:` | ✗ | ✓ | ✗ |
+| 15 | `Table Pointer:` | ✗ | ✓ | ✗ |
+| 17 | `TSA Pointer:` | ✗ | ✓ | ✗ |
+| 19 | `Palette Pointer:` | ✗ | ✓ | ✗ |
+| 23 | `Write` | ✗ | ✓ | ✗ |
+| 24 | `Export PNG` | ✗ | ✓ | ✗ |
+| 25 | `Import PNG` | ✗ | ✓ | ✗ |
+| 26 | `Export PAL` | ✗ | ✓ | ✗ |
+| 27 | `Import PAL` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/DisASMDumpAllView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Disassembly Dump All` | ✗ | ✓ | ✗ |
+| 10 | `Select an output format and run the disassembly dump.` | ✗ | ✓ | ✗ |
+| 12 | `DisASM` | ✗ | ✓ | ✗ |
+| 13 | `IDA MAP` | ✗ | ✓ | ✗ |
+| 14 | `No$GBA SYM` | ✗ | ✓ | ✗ |
+| 15 | `Address Range` | ✗ | ✓ | ✗ |
+| 18 | `Address:` | ✗ | ✓ | ✗ |
+| 20 | `Length:` | ✗ | ✓ | ✗ |
+| 24 | `Run Dump` | ✗ | ✓ | ✗ |
+| 25 | `Close` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/GraphicsToolView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 10 | `Graphics Tool` | ✓ | ✓ | ✗ |
+| 11 | `View tile graphics from ROM. Enter addresses and click Draw.` | ✗ | ✓ | ✗ |
+| 28 | `Image Address:` | ✗ | ✓ | ✗ |
+| 31 | `Palette Address:` | ✗ | ✓ | ✗ |
+| 35 | `Tiles X:` | ✗ | ✓ | ✗ |
+| 38 | `Tiles Y:` | ✗ | ✓ | ✗ |
+| 44 | `LZ77 Compressed` | ✗ | ✓ | ✗ |
+| 45 | `Zoom:` | ✗ | ✓ | ✗ |
+| 53 | `Draw` | ✗ | ✓ | ✗ |
+| 54 | `Close` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/OPPrologueViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 11 | `OP Prologue Editor` | ✗ | ✓ | ✗ |
+| 13 | `Address:` | ✗ | ✓ | ✗ |
+| 15 | `Image Pointer:` | ✗ | ✓ | ✗ |
+| 17 | `TSA Pointer:` | ✗ | ✓ | ✗ |
+| 19 | `Palette Address:` | ✗ | ✓ | ✗ |
+| 23 | `Write` | ✗ | ✓ | ✗ |
+| 24 | `Export PNG` | ✗ | ✓ | ✗ |
+| 25 | `Import PNG` | ✗ | ✓ | ✗ |
+| 26 | `Export PAL` | ✗ | ✓ | ✗ |
+| 27 | `Import PAL` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SMEPromoListView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 13 | `Address:` | ✗ | ✓ | ✗ |
+| 16 | `Count:` | ✗ | ✓ | ✗ |
+| 19 | `Reload` | ✗ | ✓ | ✗ |
+| 25 | `Name` | ✗ | ✓ | ✗ |
+| 27 | `Expand List` | ✗ | ✓ | ✗ |
+| 38 | `Address:` | ✗ | ✓ | ✗ |
+| 41 | `Size:` | ✗ | ✓ | ✗ |
+| 46 | `Write` | ✗ | ✓ | ✗ |
+| 53 | `Base Class` | ✗ | ✓ | ✗ |
+| 62 | `Promo Class` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Skill Configuration (FE8N v3)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Text Detail:` | ✗ | ✓ | ✗ |
+| 21 | `Palette:` | ✓ | ✓ | ✗ |
+| 24 | `Unit/Class Pointer:` | ✗ | ✓ | ✗ |
+| 27 | `Class Skill Pointer:` | ✗ | ✓ | ✗ |
+| 30 | `Weapon Item Skill Pointer:` | ✗ | ✓ | ✗ |
+| 33 | `Held Item Skill Pointer:` | ✗ | ✓ | ✗ |
+| 36 | `Composite Skill Pointer:` | ✗ | ✓ | ✗ |
+| 40 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SoundBossBGMViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Boss BGM Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Unit ID:` | ✗ | ✓ | ✗ |
+| 24 | `Jump` | ✗ | ✓ | ✗ |
+| 28 | `Unknown 1:` | ✗ | ✓ | ✗ |
+| 31 | `Unknown 2:` | ✗ | ✓ | ✗ |
+| 34 | `Unknown 3:` | ✗ | ✓ | ✗ |
+| 37 | `Song ID:` | ✗ | ✓ | ✗ |
+| 43 | `Jump` | ✗ | ✓ | ✗ |
+| 48 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/UbyteBitFlagView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 13 | `Byte Bit Flags (8-bit)` | ✗ | ✓ | ✗ |
+| 16 | `Apply` | ✗ | ✓ | ✗ |
+| 26 | `Bit 0 (0x01)` | ✗ | ✓ | ✗ |
+| 27 | `Bit 1 (0x02)` | ✗ | ✓ | ✗ |
+| 28 | `Bit 2 (0x04)` | ✗ | ✓ | ✗ |
+| 29 | `Bit 3 (0x08)` | ✗ | ✓ | ✗ |
+| 30 | `Bit 4 (0x10)` | ✗ | ✓ | ✗ |
+| 31 | `Bit 5 (0x20)` | ✗ | ✓ | ✗ |
+| 32 | `Bit 6 (0x40)` | ✗ | ✓ | ✗ |
+| 33 | `Bit 7 (0x80)` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/UnitPaletteView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Unit Palette Assignment` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Trainee Class (trainee only):` | ✗ | ✓ | ✗ |
+| 21 | `Base Class 1:` | ✗ | ✓ | ✗ |
+| 24 | `Base Class 2 (trainee only):` | ✗ | ✓ | ✗ |
+| 27 | `Advanced Class 1:` | ✗ | ✓ | ✗ |
+| 30 | `Advanced Class 2:` | ✗ | ✓ | ✗ |
+| 33 | `Advanced Class 3:` | ✗ | ✓ | ✗ |
+| 36 | `Advanced Class 4:` | ✗ | ✓ | ✗ |
+| 41 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/AIScriptCategorySelectView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `AI Script Editor` | ✗ | ✓ | ✗ |
+| 12 | `Address:` | ✗ | ✓ | ✗ |
+| 15 | `Disassemble` | ✗ | ✓ | ✗ |
+| 16 | `Insert Command...` | ✗ | ✓ | ✗ |
+| 22 | `Close` | ✗ | ✓ | ✗ |
+| 29 | `Commands` | ✗ | ✓ | ✗ |
+| 38 | `Parameters` | ✗ | ✓ | ✗ |
+| 48 | `Write to ROM` | ✗ | ✓ | ✗ |
+| 50 | `Refresh` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ChapterTitleViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 11 | `Chapter Title Editor` | ✗ | ✓ | ✗ |
+| 13 | `Address:` | ✗ | ✓ | ✗ |
+| 15 | `Save Image Ptr:` | ✗ | ✓ | ✗ |
+| 17 | `Chapter Image Ptr:` | ✗ | ✓ | ✗ |
+| 19 | `Title Image Ptr:` | ✗ | ✓ | ✗ |
+| 23 | `Write` | ✗ | ✓ | ✗ |
+| 24 | `Export PNG` | ✗ | ✓ | ✗ |
+| 25 | `Export PAL` | ✗ | ✓ | ✗ |
+| 26 | `Import PNG` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageBattleBGView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Battle Background Editor` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 20 | `Image (D0):` | ✗ | ✓ | ✗ |
+| 24 | `TSA (D4):` | ✗ | ✓ | ✗ |
+| 28 | `Palette (D8):` | ✗ | ✓ | ✗ |
+| 33 | `Write` | ✗ | ✓ | ✗ |
+| 34 | `Import PNG` | ✗ | ✓ | ✗ |
+| 35 | `Export PAL` | ✗ | ✓ | ✗ |
+| 36 | `Import PAL` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageCGFE7UView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `CG Editor (FE7U)` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 20 | `Image Type:` | ✗ | ✓ | ✗ |
+| 24 | `Reserved (B1-B3):` | ✗ | ✓ | ✗ |
+| 36 | `Palette:` | ✓ | ✓ | ✗ |
+| 40 | `Import PNG` | ✗ | ✓ | ✗ |
+| 41 | `Export PNG` | ✗ | ✓ | ✗ |
+| 42 | `Export PAL` | ✗ | ✓ | ✗ |
+| 43 | `Import PAL` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageTSAAnime2View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `TSA Animation Editor v2` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 20 | `Unknown 0 (W0):` | ✗ | ✓ | ✗ |
+| 22 | `Unknown 2 (W2):` | ✗ | ✓ | ✗ |
+| 26 | `Unknown 4 (W4):` | ✗ | ✓ | ✗ |
+| 28 | `Unknown 6 (W6):` | ✗ | ✓ | ✗ |
+| 32 | `TSA w/ Header (P8):` | ✗ | ✓ | ✗ |
+| 36 | `Write` | ✗ | ✓ | ✗ |
+| 37 | `Import PNG` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/OAMSpriteViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 13 | `OAM Sprite Viewer` | ✗ | ✓ | ✗ |
+| 14 | `Select an animation to view OAM sprites.` | ✗ | ✓ | ✗ |
+| 19 | `Section:` | ✗ | ✓ | ✗ |
+| 29 | `Frame:` | ✗ | ✓ | ✗ |
+| 31 | `Prev` | ✗ | ✓ | ✗ |
+| 32 | `Next` | ✗ | ✓ | ✗ |
+| 39 | `Rendered Frame:` | ✗ | ✓ | ✗ |
+| 46 | `Tile Sheet (Reference):` | ✗ | ✓ | ✗ |
+| 55 | `Export Frame PNG` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ProcsScriptCategorySelectView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Procs Script Editor` | ✗ | ✓ | ✗ |
+| 12 | `Address:` | ✗ | ✓ | ✗ |
+| 15 | `Disassemble` | ✗ | ✓ | ✗ |
+| 16 | `Insert Command...` | ✗ | ✓ | ✗ |
+| 22 | `Close` | ✗ | ✓ | ✗ |
+| 29 | `Commands` | ✗ | ✓ | ✗ |
+| 38 | `Parameters` | ✗ | ✓ | ✗ |
+| 48 | `Write to ROM` | ✗ | ✓ | ✗ |
+| 50 | `Refresh` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer2SkillView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Skill Configuration (FE8N v2)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Text Detail:` | ✗ | ✓ | ✗ |
+| 21 | `Palette:` | ✓ | ✓ | ✗ |
+| 24 | `Unit Skill Pointer:` | ✗ | ✓ | ✗ |
+| 27 | `Class Skill Pointer:` | ✗ | ✓ | ✗ |
+| 30 | `Weapon Item Skill Pointer:` | ✗ | ✓ | ✗ |
+| 33 | `Held Item Skill Pointer:` | ✗ | ✓ | ✗ |
+| 37 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/StatusParamView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 15 | `Status Parameters Editor` | ✗ | ✓ | ✗ |
+| 18 | `Address:` | ✗ | ✓ | ✗ |
+| 21 | `StatusMenuTextStruct:` | ✗ | ✓ | ✗ |
+| 24 | `Bitmap:` | ✗ | ✓ | ✗ |
+| 27 | `Color:` | ✗ | ✓ | ✗ |
+| 30 | `Indent:` | ✗ | ✓ | ✗ |
+| 39 | `String Pointer:` | ✗ | ✓ | ✗ |
+| 42 | `String Text:` | ✗ | ✓ | ✗ |
+| 47 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SystemIconViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 11 | `System Icon Viewer` | ✗ | ✓ | ✗ |
+| 13 | `Icon Index:` | ✗ | ✓ | ✗ |
+| 15 | `Image Address:` | ✗ | ✓ | ✗ |
+| 17 | `Image Pointer:` | ✗ | ✓ | ✗ |
+| 19 | `Palette Pointer:` | ✗ | ✓ | ✗ |
+| 21 | `Tile Offset:` | ✗ | ✓ | ✗ |
+| 25 | `Export PNG` | ✗ | ✓ | ✗ |
+| 26 | `Export PAL` | ✗ | ✓ | ✗ |
+| 27 | `Import PNG` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolAnimationCreatorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Animation Creator` | ✗ | ✓ | ✗ |
+| 10 | `Create` | ✗ | ✓ | ✗ |
+| 11 | `Close` | ✗ | ✓ | ✗ |
+| 16 | `Animation Name:` | ✗ | ✓ | ✗ |
+| 17 | `Enter animation name` | ✗ | ✓ | ✗ |
+| 18 | `Frame Count:` | ✗ | ✓ | ✗ |
+| 20 | `Image Source:` | ✗ | ✓ | ✗ |
+| 22 | `Select source image...` | ✗ | ✓ | ✗ |
+| 27 | `Animation preview area` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/WorldMapPathView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `World Map Paths` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Path Data Pointer:` | ✗ | ✓ | ✗ |
+| 21 | `Start Base Point ID:` | ✗ | ✓ | ✗ |
+| 24 | `End Base Point ID:` | ✗ | ✓ | ✗ |
+| 27 | `Padding (B6):` | ✗ | ✓ | ✗ |
+| 30 | `Padding (B7):` | ✗ | ✓ | ✗ |
+| 33 | `Path Move Pointer:` | ✗ | ✓ | ✗ |
+| 40 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/AIASMCALLTALKView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `AI ASM Call Talk` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `From Unit:` | ✗ | ✓ | ✗ |
+| 21 | `To Unit:` | ✗ | ✓ | ✗ |
+| 24 | `Unused 2:` | ✗ | ✓ | ✗ |
+| 27 | `Unused 3:` | ✗ | ✓ | ✗ |
+| 31 | `Configures enemy AI to trigger a talk event (like FE7 Farina).` | ✗ | ✓ | ✗ |
+| 33 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/AOERANGEView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Area of Effect Range` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Width:` | ✗ | ✓ | ✗ |
+| 21 | `Height:` | ✓ | ✓ | ✗ |
+| 24 | `Center X:` | ✗ | ✓ | ✗ |
+| 27 | `Center Y:` | ✗ | ✓ | ✗ |
+| 31 | `Specifies the AoE attack range mask. Center point is where the attack detonates. Set attacked tiles to 1, others to 0.` | ✗ | ✓ | ✗ |
+| 33 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EDView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Ending Event Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Unit ID:` | ✗ | ✓ | ✗ |
+| 24 | `Condition:` | ✗ | ✓ | ✗ |
+| 27 | `Unknown (0x02):` | ✗ | ✓ | ✗ |
+| 30 | `Unknown (0x03):` | ✗ | ✓ | ✗ |
+| 34 | `Condition: 00=Died, 01=Wounded/Left, 02=Wounded/Stayed` | ✗ | ✓ | ✗ |
+| 37 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ErrorUnknownROMView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Unknown ROM Version` | ✗ | ✓ | ✗ |
+| 23 | `Cancel` | ✗ | ✓ | ✗ |
+| 26 | `Load as FE8U (Sacred Stones - US)` | ✗ | ✓ | ✗ |
+| 29 | `Load as FE8J (Sacred Stones - Japan)` | ✗ | ✓ | ✗ |
+| 32 | `Load as FE7U (Blazing Blade - US)` | ✗ | ✓ | ✗ |
+| 35 | `Load as FE7J (Blazing Blade - Japan)` | ✗ | ✓ | ✗ |
+| 38 | `Load as FE6 (Binding Blade - Japan)` | ✗ | ✓ | ✗ |
+| 41 | `Load as Other (Unknown)` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventForceSortieFE7View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Force Sortie (FE7)` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Unit List Pointer:` | ✗ | ✓ | ✗ |
+| 22 | `Unit ID:` | ✗ | ✓ | ✗ |
+| 26 | `Unknown 1:` | ✗ | ✓ | ✗ |
+| 30 | `Unknown 2:` | ✗ | ✓ | ✗ |
+| 34 | `Unknown 3:` | ✗ | ✓ | ✗ |
+| 39 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventScriptPopupView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Event Script Editor` | ✗ | ✓ | ✗ |
+| 12 | `Address:` | ✗ | ✓ | ✗ |
+| 15 | `Disassemble` | ✗ | ✓ | ✗ |
+| 21 | `Close` | ✗ | ✓ | ✗ |
+| 28 | `Commands` | ✗ | ✓ | ✗ |
+| 37 | `Parameters` | ✗ | ✓ | ✗ |
+| 47 | `Write to ROM` | ✗ | ✓ | ✗ |
+| 49 | `Refresh` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/GraphicsToolPatchMakerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Compare two ROMs and generate a patch of changed regions` | ✗ | ✓ | ✗ |
+| 19 | `Original ROM:` | ✗ | ✓ | ✗ |
+| 26 | `Modified ROM:` | ✗ | ✓ | ✗ |
+| 36 | `Generate Patch` | ✗ | ✓ | ✗ |
+| 45 | `Regions: ` | ✗ | ✓ | ✗ |
+| 48 | `Changed bytes: ` | ✗ | ✓ | ✗ |
+| 55 | `Close` | ✗ | ✓ | ✗ |
+| 57 | `Save Patch File` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ItemWeaponTriangleViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Weapon Triangle Editor` | ✗ | ✓ | ✗ |
+| 13 | `Weapon triangle bonus/penalty data` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 19 | `Weapon Type 1:` | ✗ | ✓ | ✗ |
+| 22 | `Weapon Type 2:` | ✗ | ✓ | ✗ |
+| 25 | `Bonus:` | ✗ | ✓ | ✗ |
+| 28 | `Penalty:` | ✗ | ✓ | ✗ |
+| 33 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Tile Animation Type 2 (Palette)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Palette Data Pointer:` | ✗ | ✓ | ✗ |
+| 21 | `Animation Interval:` | ✗ | ✓ | ✗ |
+| 24 | `Data Count:` | ✗ | ✓ | ✗ |
+| 27 | `Start Palette Index:` | ✗ | ✓ | ✗ |
+| 30 | `Unknown (0x07):` | ✗ | ✓ | ✗ |
+| 35 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Monster Item Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Item ID:` | ✗ | ✓ | ✗ |
+| 24 | `Drop Rate:` | ✗ | ✓ | ✗ |
+| 27 | `Unknown 1:` | ✗ | ✓ | ✗ |
+| 30 | `Unknown 2:` | ✗ | ✓ | ✗ |
+| 33 | `Unknown 3:` | ✗ | ✓ | ✗ |
+| 38 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SongTableView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Song Table Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Song Header Pointer:` | ✗ | ✓ | ✗ |
+| 21 | `Priority (PlayerType):` | ✗ | ✓ | ✗ |
+| 24 | `Track Count:` | ✗ | ✓ | ✗ |
+| 27 | `Header Priority:` | ✗ | ✓ | ✗ |
+| 30 | `Header Reverb:` | ✗ | ✓ | ✗ |
+| 35 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SongTrackImportMidiView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `MIDI Import` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 21 | `Browse MIDI File...` | ✗ | ✓ | ✗ |
+| 22 | `No file selected` | ✗ | ✓ | ✗ |
+| 29 | `MIDI File Metadata` | ✗ | ✓ | ✗ |
+| 39 | `Note` | ✗ | ✓ | ✗ |
+| 40 | `MIDI write-back to ROM is not yet fully implemented. You can preview MIDI file metadata above, but importing MIDI data into the ROM may produce unexpected results.` | ✗ | ✓ | ✗ |
+| 47 | `Import to ROM (Experimental)` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SongTrackImportSelectInstrumentView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Instrument Selection` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 23 | `About Instrument Selection` | ✗ | ✓ | ✗ |
+| 25 | `This view allows selecting the instrument set (voicegroup) used when importing MIDI or .s files into the ROM. The instrument set determines which GBA sound samples are mapped to MIDI program changes.` | ✗ | ✓ | ✗ |
+| 32 | `Current Instrument Set` | ✗ | ✓ | ✗ |
+| 33 | `No song selected` | ✗ | ✓ | ✗ |
+| 41 | `Not Yet Implemented` | ✗ | ✓ | ✗ |
+| 43 | `Instrument set selection is not yet available in the Avalonia UI. To select a different instrument set for MIDI import, please use the WinForms version. This feature requires porting PatchUtil.SearchI… (truncated)` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SoundRoomViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Sound Room Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Song ID:` | ✗ | ✓ | ✗ |
+| 24 | `Jump` | ✗ | ✓ | ✗ |
+| 27 | `Song Length:` | ✗ | ✓ | ✗ |
+| 30 | `Display Cond ASM:` | ✗ | ✓ | ✗ |
+| 33 | `Text ID:` | ✗ | ✓ | ✗ |
+| 43 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/TextCharCodeView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Character Code Table` | ✗ | ✓ | ✗ |
+| 10 | `Lists all character codes in the ROM's text encoding table.` | ✗ | ✓ | ✗ |
+| 14 | `Char Code (ASCII):` | ✗ | ✓ | ✗ |
+| 16 | `Terminator (FFFF):` | ✗ | ✓ | ✗ |
+| 18 | `Character Display:` | ✗ | ✓ | ✗ |
+| 25 | `Item Font` | ✗ | ✓ | ✗ |
+| 33 | `Serif Font` | ✗ | ✓ | ✗ |
+| 43 | `Close` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/TextViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Text Editor` | ✓ | ✓ | ✗ |
+| 15 | `Export All Texts (TSV)` | ✗ | ✓ | ✗ |
+| 16 | `Import Texts (TSV)` | ✗ | ✓ | ✗ |
+| 21 | `Search in text content...` | ✗ | ✓ | ✗ |
+| 22 | `Search Content` | ✗ | ✓ | ✗ |
+| 23 | `Show All` | ✗ | ✓ | ✗ |
+| 33 | `Edit Text:` | ✗ | ✓ | ✗ |
+| 41 | `Write Text` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolDiffDebugSelectView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 13 | `Backup History (newest on top)` | ✗ | ✓ | ✗ |
+| 17 | `Vanilla ROM` | ✗ | ✓ | ✗ |
+| 26 | `Search prefix` | ✗ | ✓ | ✗ |
+| 32 | `Add backup ROM location` | ✗ | ✓ | ✗ |
+| 47 | `Older ↓` | ✗ | ✓ | ✗ |
+| 55 | `Selected ROM Info` | ✗ | ✓ | ✗ |
+| 62 | `Test play selected ROM in emulator` | ✗ | ✓ | ✗ |
+| 67 | `Use this ROM as the last stable baseline and get differences` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolInitWizardView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Setup Wizard` | ✗ | ✓ | ✗ |
+| 10 | `Initial Configuration` | ✗ | ✓ | ✗ |
+| 12 | `Setup Steps` | ✗ | ✓ | ✗ |
+| 14 | `Step 1: Select your clean Fire Emblem GBA ROM file.` | ✗ | ✓ | ✗ |
+| 16 | `Step 2: Choose your preferred language for the editor interface.` | ✗ | ✓ | ✗ |
+| 18 | `Step 3: Configure paths for external tools (emulators, assemblers).` | ✗ | ✓ | ✗ |
+| 20 | `Step 4: Review settings and begin editing.` | ✗ | ✓ | ✗ |
+| 23 | `You can change these settings later from the Options menu.` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/WelcomeView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 13 | `FEBuilderGBA` | ✓ | ✓ | ✗ |
+| 15 | `Avalonia Cross-Platform Edition` | ✗ | ✓ | ✗ |
+| 25 | `Open Last ROM` | ✓ | ✓ | ✗ |
+| 27 | `Open ROM` | ✗ | ✓ | ✗ |
+| 29 | `Check for Updates` | ✗ | ✓ | ✗ |
+| 31 | `Online Manual` | ✗ | ✓ | ✗ |
+| 39 | `Recent Files` | ✗ | ✓ | ✗ |
+| 40 | `No recent files` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/AIMapSettingView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `AI Map Settings` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Trait 1 (flags):` | ✗ | ✓ | ✗ |
+| 21 | `Trait 2 (flags):` | ✗ | ✓ | ✗ |
+| 24 | `Trait 3 (flags):` | ✗ | ✓ | ✗ |
+| 27 | `Trait 4 (flags):` | ✗ | ✓ | ✗ |
+| 31 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/AIPerformItemView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `AI Item Performance` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Item:` | ✗ | ✓ | ✗ |
+| 21 | `Unused:` | ✗ | ✓ | ✗ |
+| 24 | `ASM Pointer:` | ✗ | ✓ | ✗ |
+| 28 | `Specifies the function that determines whether AI will use an item.` | ✗ | ✓ | ✗ |
+| 30 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/AIPerformStaffView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `AI Staff Performance` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Item (Staff):` | ✗ | ✓ | ✗ |
+| 21 | `Unused:` | ✗ | ✓ | ✗ |
+| 24 | `ASM Pointer:` | ✗ | ✓ | ✗ |
+| 28 | `Specifies the function that determines whether AI will use a staff.` | ✗ | ✓ | ✗ |
+| 30 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EDSensekiCommentView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `ED Senseki Comment` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Unit ID:` | ✗ | ✓ | ✗ |
+| 24 | `Conversation Text 1:` | ✗ | ✓ | ✗ |
+| 27 | `Conversation Text 2:` | ✗ | ✓ | ✗ |
+| 30 | `Conversation Text 3:` | ✗ | ✓ | ✗ |
+| 35 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageChapterTitleFE7View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 11 | `Chapter Title FE7 Editor` | ✗ | ✓ | ✗ |
+| 13 | `Address:` | ✗ | ✓ | ✗ |
+| 15 | `Save Image Ptr:` | ✗ | ✓ | ✗ |
+| 20 | `Write` | ✗ | ✓ | ✗ |
+| 21 | `Export PNG` | ✗ | ✓ | ✗ |
+| 22 | `Export PAL` | ✗ | ✓ | ✗ |
+| 23 | `Import PNG` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ItemIconViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 11 | `Item/Weapon Icon Viewer` | ✗ | ✓ | ✗ |
+| 13 | `Address:` | ✗ | ✓ | ✗ |
+| 15 | `Image Pointer:` | ✗ | ✓ | ✗ |
+| 17 | `Palette Pointer:` | ✗ | ✓ | ✗ |
+| 21 | `Export PNG` | ✗ | ✓ | ✗ |
+| 22 | `Export PAL` | ✗ | ✓ | ✗ |
+| 23 | `Import PNG` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapEditorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 13 | `Visual Map Editor` | ✗ | ✓ | ✗ |
+| 16 | `Zoom:` | ✗ | ✓ | ✗ |
+| 27 | `Tile Editor (click on map to select)` | ✗ | ✓ | ✗ |
+| 29 | `No tile selected` | ✗ | ✓ | ✗ |
+| 31 | `Tile ID (hex):` | ✗ | ✓ | ✗ |
+| 33 | `Write Tile` | ✗ | ✓ | ✗ |
+| 34 | `Refresh Map` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapTileAnimationView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Tile Animation Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Animation Interval:` | ✗ | ✓ | ✗ |
+| 21 | `Data Count:` | ✗ | ✓ | ✗ |
+| 24 | `Animation Pointer:` | ✗ | ✓ | ✗ |
+| 27 | `Raw Bytes:` | ✗ | ✓ | ✗ |
+| 32 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MoveToFreeSpaceView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Move to Free Space` | ✗ | ✓ | ✗ |
+| 10 | `Move` | ✗ | ✓ | ✗ |
+| 11 | `Close` | ✗ | ✓ | ✗ |
+| 15 | `This tool relocates data to free ROM space.` | ✗ | ✓ | ✗ |
+| 17 | `Current Address:` | ✗ | ✓ | ✗ |
+| 19 | `Free Space Address:` | ✗ | ✓ | ✗ |
+| 21 | `Data Size:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/RAMRewriteToolMAPView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `RAM Rewrite Tool (MAP)` | ✗ | ✓ | ✗ |
+| 10 | `Write` | ✗ | ✓ | ✗ |
+| 11 | `Close` | ✗ | ✓ | ✗ |
+| 15 | `Rewrite RAM values for map data in a running emulator.` | ✗ | ✓ | ✗ |
+| 17 | `Map ID:` | ✗ | ✓ | ✗ |
+| 19 | `Address:` | ✗ | ✓ | ✗ |
+| 21 | `Value:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/RAMRewriteToolView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `RAM Rewrite Tool` | ✗ | ✓ | ✗ |
+| 11 | `Close` | ✗ | ✓ | ✗ |
+| 16 | `Platform Notice` | ✗ | ✓ | ✗ |
+| 18 | `RAM rewriting requires Windows P/Invoke to access emulator process memory and is not available in the cross-platform Avalonia version.` | ✗ | ✓ | ✗ |
+| 20 | `Please use the Windows (WinForms) version of FEBuilderGBA for this functionality.` | ✗ | ✓ | ✗ |
+| 24 | `Address:` | ✗ | ✓ | ✗ |
+| 26 | `Value:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SongInstrumentDirectSoundView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Direct Sound Instruments` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Header:` | ✗ | ✓ | ✗ |
+| 21 | `Frequency Hz*1024:` | ✗ | ✓ | ✗ |
+| 24 | `Loop Start Byte:` | ✗ | ✓ | ✗ |
+| 27 | `Length Byte:` | ✗ | ✓ | ✗ |
+| 32 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/StatusUnitsMenuView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Status Units Menu Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Order:` | ✗ | ✓ | ✗ |
+| 21 | `Item Name Text ID:` | ✗ | ✓ | ✗ |
+| 27 | `Reference Data:` | ✗ | ✓ | ✗ |
+| 30 | `RMenu Text ID:` | ✗ | ✓ | ✗ |
+| 38 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/UnitsShortTextView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 14 | `Units Short Text Editor` | ✗ | ✓ | ✗ |
+| 15 | `Maps each unit index to a description text ID (2 bytes per entry).` | ✗ | ✓ | ✗ |
+| 18 | `Address:` | ✗ | ✓ | ✗ |
+| 20 | `Unit:` | ✗ | ✓ | ✗ |
+| 22 | `Text ID:` | ✗ | ✓ | ✗ |
+| 24 | `Preview:` | ✗ | ✓ | ✗ |
+| 27 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/VennouWeaponLockView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 14 | `Weapon Lock (Vennou) Editor` | ✗ | ✓ | ✗ |
+| 15 | `First byte = type (0-3), rest = unit/class IDs. Null-terminated.` | ✗ | ✓ | ✗ |
+| 18 | `Address:` | ✗ | ✓ | ✗ |
+| 20 | `Lock Type / ID:` | ✗ | ✓ | ✗ |
+| 22 | `Linked Name:` | ✗ | ✓ | ✗ |
+| 24 | `Description:` | ✗ | ✓ | ✗ |
+| 28 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/WorldMapBGMView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `World Map BGM Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Song ID 1 (u16@0):` | ✗ | ✓ | ✗ |
+| 21 | `Jump` | ✗ | ✓ | ✗ |
+| 24 | `Song ID 2 (u16@2):` | ✗ | ✓ | ✗ |
+| 27 | `Jump` | ✗ | ✓ | ✗ |
+| 32 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/AIStealItemView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `AI Steal Item Logic` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Item:` | ✗ | ✓ | ✗ |
+| 21 | `Unused 1:` | ✗ | ✓ | ✗ |
+| 25 | `Sets the priority of items that thief AI will try to steal. Items at the top of the list have the highest priority.` | ✗ | ✓ | ✗ |
+| 27 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/CCBranchEditorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `CC Branch Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Promotion Class 1:` | ✗ | ✓ | ✗ |
+| 22 | `Promotion Class 2:` | ✗ | ✓ | ✗ |
+| 28 | `Write` | ✗ | ✓ | ✗ |
+| 32 | `Upstream Chain (classes that promote to this one):` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/DisASMDumpAllArgGrepView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Disassembly Argument Grep` | ✗ | ✓ | ✗ |
+| 10 | `Search disassembly output by argument pattern.` | ✗ | ✓ | ✗ |
+| 12 | `Pattern:` | ✗ | ✓ | ✗ |
+| 13 | `Enter search pattern...` | ✗ | ✓ | ✗ |
+| 14 | `Search` | ✗ | ✓ | ✗ |
+| 15 | `Close` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventForceSortieView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Force Sortie Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Unit:` | ✗ | ✓ | ✗ |
+| 22 | `Squad:` | ✗ | ✓ | ✗ |
+| 26 | `Chapter ID:` | ✗ | ✓ | ✗ |
+| 31 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventScriptView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Event Script Editor` | ✗ | ✓ | ✗ |
+| 12 | `Address:` | ✗ | ✓ | ✗ |
+| 15 | `Disassemble` | ✗ | ✓ | ✗ |
+| 16 | `Select Category...` | ✗ | ✓ | ✗ |
+| 24 | `Commands` | ✗ | ✓ | ✗ |
+| 33 | `Disassembled Script` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageBGView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Background Image Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 19 | `Import PNG` | ✗ | ✓ | ✗ |
+| 20 | `Export PNG` | ✗ | ✓ | ✗ |
+| 21 | `Export PAL` | ✗ | ✓ | ✗ |
+| 22 | `Import PAL` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageCGView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `CG Image Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 19 | `Import PNG` | ✗ | ✓ | ✗ |
+| 20 | `Export PNG` | ✗ | ✓ | ✗ |
+| 21 | `Export PAL` | ✗ | ✓ | ✗ |
+| 22 | `Import PAL` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageMapActionAnimationView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Action Animation` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 20 | `Animation Ptr (D0):` | ✗ | ✓ | ✗ |
+| 24 | `Padding 1 (W4):` | ✗ | ✓ | ✗ |
+| 26 | `Padding 2 (W6):` | ✗ | ✓ | ✗ |
+| 30 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageTSAAnimeView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `TSA Animation Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 19 | `Import PNG` | ✗ | ✓ | ✗ |
+| 20 | `Export PNG` | ✗ | ✓ | ✗ |
+| 21 | `Export PAL` | ✗ | ✓ | ✗ |
+| 22 | `Import PAL` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ItemShopViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Item Shop Editor` | ✗ | ✓ | ✗ |
+| 13 | `Preparation shop item list` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 19 | `Item ID:` | ✗ | ✓ | ✗ |
+| 25 | `Quantity/Uses:` | ✗ | ✓ | ✗ |
+| 30 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapEditorAddMapChangeDialogView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Do you want to create additional map changes?` | ✗ | ✓ | ✗ |
+| 16 | `Assign new map change` | ✗ | ✓ | ✗ |
+| 19 | `Assign a new map change ID. A new PLIST entry will be allocated automatically.` | ✗ | ✓ | ✗ |
+| 22 | `Open map change settings` | ✗ | ✓ | ✗ |
+| 25 | `Open the map change configuration screen to edit existing map change entries.` | ✗ | ✓ | ✗ |
+| 28 | `Cancel` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapLoadFunctionView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Load Functions (FE8)` | ✗ | ✓ | ✗ |
+| 13 | `Function pointers called when entering each map chapter.` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 19 | `Function Pointer:` | ✗ | ✓ | ✗ |
+| 22 | `Info:` | ✗ | ✓ | ✗ |
+| 26 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapTileAnimation1View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Tile Animation Type 1` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Animation Interval:` | ✗ | ✓ | ✗ |
+| 21 | `Data Count:` | ✗ | ✓ | ✗ |
+| 24 | `Map Tile Data Pointer:` | ✗ | ✓ | ✗ |
+| 29 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MoveCostFE6View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 11 | `Move Cost (FE6) Editor` | ✗ | ✓ | ✗ |
+| 13 | `Address:` | ✗ | ✓ | ✗ |
+| 16 | `Class Name:` | ✗ | ✓ | ✗ |
+| 20 | `Cost Type:` | ✗ | ✓ | ✗ |
+| 23 | `Terrain Move Costs (51 entries):` | ✗ | ✓ | ✗ |
+| 27 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/PaletteClipboardView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Palette Clipboard` | ✗ | ✓ | ✗ |
+| 15 | `Copy Current` | ✗ | ✓ | ✗ |
+| 16 | `Paste` | ✗ | ✓ | ✗ |
+| 17 | `Clear` | ✓ | ✓ | ✗ |
+| 18 | `Close` | ✗ | ✓ | ✗ |
+| 21 | `Clipboard Contents:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/PointerToolCopyToView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Value:` | ✗ | ✓ | ✗ |
+| 16 | `Copy as Pointer` | ✗ | ✓ | ✗ |
+| 18 | `Copy to Clipboard` | ✗ | ✓ | ✗ |
+| 20 | `Copy as Little Endian` | ✗ | ✓ | ✗ |
+| 22 | `Copy as Hex` | ✗ | ✓ | ✗ |
+| 24 | `Copy (No $ / GBA / Rad / BreakPoint)` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitFE8NView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Skill Assignment - Unit (FE8N)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Personal Skill:` | ✗ | ✓ | ✗ |
+| 21 | `Skill Set 1:` | ✗ | ✓ | ✗ |
+| 24 | `Skill Set 2:` | ✗ | ✓ | ✗ |
+| 28 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SoundRoomFE6View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Sound Room (FE6)` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `BGM ID:` | ✗ | ✓ | ✗ |
+| 21 | `Song Name (Text ID):` | ✗ | ✓ | ✗ |
+| 25 | `Description (Text ID):` | ✗ | ✓ | ✗ |
+| 31 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/TextToSpeechView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Text to Speech` | ✗ | ✓ | ✗ |
+| 10 | `Enter or paste text to have it read aloud using the system TTS engine.` | ✗ | ✓ | ✗ |
+| 12 | `Ready` | ✗ | ✓ | ✗ |
+| 14 | `Speak` | ✗ | ✓ | ✗ |
+| 15 | `Close` | ✗ | ✓ | ✗ |
+| 18 | `Enter text here...` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolSubtitleOverlayView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Subtitle Overlay` | ✗ | ✓ | ✗ |
+| 11 | `Apply` | ✗ | ✓ | ✗ |
+| 12 | `Close` | ✗ | ✓ | ✗ |
+| 15 | `Subtitle Text:` | ✗ | ✓ | ✗ |
+| 17 | `Enter subtitle text...` | ✗ | ✓ | ✗ |
+| 18 | `Preview:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolSubtitleSettingDialogView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Template ROM FROM` | ✗ | ✓ | ✗ |
+| 21 | `Template ROM TO` | ✗ | ✓ | ✗ |
+| 30 | `Translation Data` | ✗ | ✓ | ✗ |
+| 37 | `Show subtitle window even when there are no subtitles` | ✗ | ✓ | ✗ |
+| 42 | `Show Subtitles` | ✗ | ✓ | ✗ |
+| 44 | `Hide` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/UnitCustomBattleAnimeView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Custom Battle Animation` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Weapon Type:` | ✗ | ✓ | ✗ |
+| 21 | `Special:` | ✗ | ✓ | ✗ |
+| 24 | `Animation Number:` | ✗ | ✓ | ✗ |
+| 29 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/WorldMapPathMoveEditorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Path Movement Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Elapsed Time:` | ✗ | ✓ | ✗ |
+| 21 | `Coordinate X:` | ✗ | ✓ | ✗ |
+| 24 | `Coordinate Y:` | ✗ | ✓ | ✗ |
+| 32 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/AIASMCoordinateView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `AI Coordinate Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 24 | `Unused 2:` | ✗ | ✓ | ✗ |
+| 27 | `Unused 3:` | ✗ | ✓ | ✗ |
+| 31 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/AIUnitsView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `AI Units Evaluation` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Unit:` | ✗ | ✓ | ✗ |
+| 21 | `Unknown 1:` | ✗ | ✓ | ✗ |
+| 25 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EDStaffRollView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Staff Roll Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Image Pointer:` | ✗ | ✓ | ✗ |
+| 21 | `TSA Pointer:` | ✗ | ✓ | ✗ |
+| 26 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EmulatorMemoryView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Emulator Memory` | ✗ | ✓ | ✗ |
+| 11 | `Close` | ✗ | ✓ | ✗ |
+| 15 | `Platform Notice` | ✗ | ✓ | ✗ |
+| 17 | `Emulator memory reading requires Windows P/Invoke and is not available in the cross-platform Avalonia version.` | ✗ | ✓ | ✗ |
+| 19 | `This feature uses Windows-specific APIs to read the memory of a running GBA emulator process for live debugging. Please use the Windows (WinForms) version of FEBuilderGBA for this functionality.` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventFunctionPointerFE7View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Event Command Function Pointer Table (FE7)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Event Command Function Pointer:` | ✗ | ✓ | ✗ |
+| 22 | `Unknown (offset 4):` | ✗ | ✓ | ✗ |
+| 27 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventMoveDataFE7View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Move Data (FE7)` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Move Direction:` | ✗ | ✓ | ✗ |
+| 23 | `Direction values: 00=Left, 01=Right, 02=Down, 03=Up, 04=End, 09=Highlight, 0A=Collision mark, 0C=Speed change` | ✗ | ✓ | ✗ |
+| 26 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ExtraUnitFE8UView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Extra Unit (FE8U)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Flag ID:` | ✗ | ✓ | ✗ |
+| 21 | `Unit Info Pointer:` | ✗ | ✓ | ✗ |
+| 26 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageSystemAreaView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `System Area Graphics` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 20 | `GBA Color (W0):` | ✗ | ✓ | ✗ |
+| 34 | `Preview:` | ✗ | ✓ | ✗ |
+| 39 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ItemEffectPointerViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Item Effect Pointer Editor` | ✗ | ✓ | ✗ |
+| 13 | `Indirect effect pointer table` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 19 | `Effect Pointer:` | ✓ | ✓ | ✗ |
+| 24 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ItemEffectivenessViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Item Effectiveness Editor` | ✗ | ✓ | ✗ |
+| 13 | `Weapon effectiveness 2x/3x class list (FE8 only)` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 19 | `Class ID:` | ✗ | ✓ | ✗ |
+| 27 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ItemPromotionViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Item Promotion Editor` | ✗ | ✓ | ✗ |
+| 13 | `Promotion target class per source class` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 19 | `Target Class ID:` | ✗ | ✓ | ✗ |
+| 27 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ItemRandomChestView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Random Chest Items` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Item:` | ✗ | ✓ | ✗ |
+| 24 | `Probability %:` | ✗ | ✓ | ✗ |
+| 29 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ItemUsagePointerViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Item Usage Pointer Editor` | ✗ | ✓ | ✗ |
+| 13 | `Function pointers for item usability checks` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 19 | `Usability Pointer:` | ✗ | ✓ | ✗ |
+| 24 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MainSimpleMenuEventErrorIgnoreErrorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Do you want to hide this error?` | ✗ | ✓ | ✗ |
+| 17 | `Reason for hiding:` | ✗ | ✓ | ✗ |
+| 19 | `Reason for hiding` | ✗ | ✓ | ✗ |
+| 22 | `Cancel` | ✗ | ✓ | ✗ |
+| 24 | `Hide this error` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapEditorResizeDialogView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 14 | `Position` | ✗ | ✓ | ✗ |
+| 33 | `Size` | ✗ | ✓ | ✗ |
+| 60 | `Left` | ✗ | ✓ | ✗ |
+| 66 | `Right` | ✗ | ✓ | ✗ |
+| 78 | `Resize` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapSettingDifficultyDialogView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 18 | `Hard Boost` | ✗ | ✓ | ✗ |
+| 27 | `Normal Mode Penalty` | ✗ | ✓ | ✗ |
+| 36 | `Easy Mode Penalty` | ✗ | ✓ | ✗ |
+| 47 | `Difficulty Value` | ✗ | ✓ | ✗ |
+| 58 | `Apply` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapStyleEditorImportImageOptionView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Chip Import` | ✗ | ✓ | ✗ |
+| 14 | `Import image with palette (recommended)` | ✗ | ✓ | ✗ |
+| 17 | `Import image only (do not import palette)` | ✗ | ✓ | ✗ |
+| 21 | `One Picture Import` | ✗ | ✓ | ✗ |
+| 23 | `Import as one picture (auto-generate map_config from this image)` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Style Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `OBJ Tile Pointer:` | ✗ | ✓ | ✗ |
+| 21 | `Config Pointer:` | ✗ | ✓ | ✗ |
+| 26 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapTerrainNameEngView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Terrain Name (English)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Terrain Name Text ID:` | ✗ | ✓ | ✗ |
+| 21 | `Resolved Name:` | ✗ | ✓ | ✗ |
+| 26 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapTerrainNameView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Terrain Name Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Name Pointer:` | ✗ | ✓ | ✗ |
+| 21 | `Name:` | ✗ | ✓ | ✗ |
+| 26 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/OPClassAlphaNameFE6View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `OP Class Alpha Name (FE6) Editor` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 19 | `Name Pointer:` | ✗ | ✓ | ✗ |
+| 22 | `Alpha Name:` | ✓ | ✓ | ✗ |
+| 26 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/OPClassFontViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 11 | `OP Class Font Editor` | ✗ | ✓ | ✗ |
+| 13 | `Address:` | ✗ | ✓ | ✗ |
+| 15 | `Image Pointer:` | ✗ | ✓ | ✗ |
+| 19 | `Write` | ✗ | ✓ | ✗ |
+| 20 | `Export PNG` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/PaletteSwapView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Palette Swap` | ✗ | ✓ | ✗ |
+| 15 | `Swap` | ✗ | ✓ | ✗ |
+| 16 | `Cancel` | ✗ | ✓ | ✗ |
+| 19 | `Source Palette:` | ✗ | ✓ | ✗ |
+| 21 | `Destination Palette:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ResourceView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Resources` | ✗ | ✓ | ✗ |
+| 10 | `ROM and Configuration Information` | ✗ | ✓ | ✗ |
+| 13 | `ROM Information` | ✗ | ✓ | ✗ |
+| 19 | `ROM Data Sections` | ✗ | ✓ | ✗ |
+| 25 | `Configuration` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SkillAssignmentClassSkillSystemView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Skill Assignment (Class)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Class Skill:` | ✗ | ✓ | ✗ |
+| 22 | `Assigns a skill to each class via the SkillSystem patch.` | ✗ | ✓ | ✗ |
+| 24 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitSkillSystemView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Skill Assignment (Unit)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Unit Skill:` | ✗ | ✓ | ✗ |
+| 22 | `Assigns a skill to each unit via the SkillSystem patch.` | ✗ | ✓ | ✗ |
+| 24 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Skill Configuration (CSkillSys 0.9.x)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Skill Name:` | ✗ | ✓ | ✗ |
+| 21 | `Description:` | ✗ | ✓ | ✗ |
+| 25 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Skill Config (SkillSystem)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Text Detail:` | ✗ | ✓ | ✗ |
+| 22 | `Configures skill text details for the SkillSystem patch.` | ✗ | ✓ | ✗ |
+| 24 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SomeClassListView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 14 | `Class List Editor` | ✗ | ✓ | ✗ |
+| 15 | `Null-terminated list of class IDs (1 byte per entry).` | ✗ | ✓ | ✗ |
+| 18 | `Address:` | ✗ | ✓ | ✗ |
+| 20 | `Class ID (u8):` | ✗ | ✓ | ✗ |
+| 24 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SummonUnitViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Summon Unit Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Summoner:` | ✗ | ✓ | ✗ |
+| 24 | `Summoned Unit:` | ✗ | ✓ | ✗ |
+| 29 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/TerrainNameEditorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Terrain Name Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Text ID:` | ✗ | ✓ | ✗ |
+| 21 | `Name:` | ✗ | ✓ | ✗ |
+| 26 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/TextRefAddDialogView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Add Text Reference` | ✗ | ✓ | ✗ |
+| 12 | `Cancel` | ✗ | ✓ | ✗ |
+| 15 | `Text ID:` | ✗ | ✓ | ✗ |
+| 17 | `Reference Text:` | ✗ | ✓ | ✗ |
+| 18 | `Enter reference text...` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/AIASMRangeView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `AI Range Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 31 | `Checks if a unit is within the range from (X1,Y1) to (X2,Y2).` | ✗ | ✓ | ✗ |
+| 33 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/AITilesView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `AI Tiles Evaluation` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Tile:` | ✗ | ✓ | ✗ |
+| 22 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ArenaClassViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 15 | `Arena Class Editor` | ✗ | ✓ | ✗ |
+| 18 | `Address:` | ✗ | ✓ | ✗ |
+| 21 | `Class ID:` | ✗ | ✓ | ✗ |
+| 29 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ArenaEnemyWeaponViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Arena Enemy Weapon Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Weapon ID:` | ✗ | ✓ | ✗ |
+| 23 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ClassFE6View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Class Editor (FE6)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 24 | `Calculate Growth` | ✗ | ✓ | ✗ |
+| 25 | `Sim Level:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/DisASMView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Disassembler` | ✓ | ✓ | ✗ |
+| 12 | `Address:` | ✗ | ✓ | ✗ |
+| 14 | `Length:` | ✗ | ✓ | ✗ |
+| 16 | `Disassemble` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/DumpStructSelectToTextDialogView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Dump Struct to Text` | ✗ | ✓ | ✗ |
+| 11 | `File name: ` | ✗ | ✓ | ✗ |
+| 15 | `Save to File...` | ✗ | ✓ | ✗ |
+| 16 | `Close` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventFunctionPointerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Event Command Function Pointer Table` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Event Command Function Pointer:` | ✗ | ✓ | ✗ |
+| 23 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventTalkGroupFE7View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Talk Group (FE7)` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Text ID:` | ✗ | ✓ | ✗ |
+| 27 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ExtraUnitView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Extra Unit Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Unit Data Pointer:` | ✗ | ✓ | ✗ |
+| 23 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/HexEditorSearchView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 13 | `Search:` | ✗ | ✓ | ✗ |
+| 19 | `Reverse search` | ✗ | ✓ | ✗ |
+| 22 | `Little Endian` | ✗ | ✓ | ✗ |
+| 28 | `Search` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/HexEditorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 10 | `Address:` | ✗ | ✓ | ✗ |
+| 13 | `Search` | ✗ | ✓ | ✗ |
+| 14 | `Page Up` | ✗ | ✓ | ✗ |
+| 15 | `Page Down` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/LinkArenaDenyUnitViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Link Arena Deny Unit Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Unit ID:` | ✗ | ✓ | ✗ |
+| 26 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapExitPointView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Exit Point Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Exit Pointer:` | ✗ | ✓ | ✗ |
+| 22 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapPointerNewPLISTPopupView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Enter the PLIST number for the new map pointer entry.` | ✗ | ✓ | ✗ |
+| 19 | `Extend PLIST Range` | ✗ | ✓ | ✗ |
+| 24 | `PLIST ID:` | ✗ | ✓ | ✗ |
+| 33 | `Cancel` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapPointerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 15 | `Map Pointer Editor` | ✗ | ✓ | ✗ |
+| 18 | `Address:` | ✗ | ✓ | ✗ |
+| 21 | `Map Data Pointer:` | ✗ | ✓ | ✗ |
+| 25 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapStyleEditorAppendPopupView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Append Map Style` | ✗ | ✓ | ✗ |
+| 10 | `Do you want to append a new map style entry? This will add a new tileset configuration at the end of the list.` | ✗ | ✓ | ✗ |
+| 12 | `Append` | ✗ | ✓ | ✗ |
+| 13 | `Cancel` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapStyleEditorWarningOverrideView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Warning` | ✗ | ✓ | ✗ |
+| 10 | `Overriding map style data may cause visual artifacts. Are you sure?` | ✗ | ✓ | ✗ |
+| 12 | `Override` | ✗ | ✓ | ✗ |
+| 13 | `Cancel` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapTerrainBGLookupTableView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Terrain BG Lookup Table` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Battle BG:` | ✓ | ✓ | ✗ |
+| 23 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapTerrainBGLookupView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Terrain BG Lookup` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Battle BG:` | ✓ | ✓ | ✗ |
+| 23 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapTerrainFloorLookupTableView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Terrain Floor Lookup Table` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Terrain Battle Floor:` | ✗ | ✓ | ✗ |
+| 23 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapTerrainFloorLookupView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Terrain Floor Lookup` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Terrain Battle Floor:` | ✗ | ✓ | ✗ |
+| 23 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MonsterWMapProbabilityViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `World Map Monster Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Base Point ID:` | ✗ | ✓ | ✗ |
+| 23 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MoveCostEditorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Move Cost Editor` | ✗ | ✓ | ✗ |
+| 21 | `Cost Type:` | ✗ | ✓ | ✗ |
+| 25 | `Write` | ✗ | ✓ | ✗ |
+| 27 | `Terrain Move Costs (65 terrains: 0x00 - 0x40):` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/OPClassAlphaNameView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `OP Class Alpha Name Editor` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 19 | `Alpha Name:` | ✓ | ✓ | ✗ |
+| 23 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/OPClassFontFE8UView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `OP Class Font (FE8U) Editor` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 19 | `Image Pointer:` | ✗ | ✓ | ✗ |
+| 23 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/PaletteChangeColorsView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Palette Change Colors` | ✗ | ✓ | ✗ |
+| 15 | `Apply` | ✗ | ✓ | ✗ |
+| 16 | `Close` | ✗ | ✓ | ✗ |
+| 19 | `Color Grid (16 colors):` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/PatchFilterExView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Patch Filter` | ✗ | ✓ | ✗ |
+| 12 | `Cancel` | ✗ | ✓ | ✗ |
+| 15 | `Filter text:` | ✗ | ✓ | ✗ |
+| 16 | `Enter filter keywords...` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ScriptCommandPickerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 10 | `Select` | ✗ | ✓ | ✗ |
+| 11 | `Cancel` | ✗ | ✓ | ✗ |
+| 26 | `Categories` | ✗ | ✓ | ✗ |
+| 35 | `Filter commands...` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Skill Assignment - Class (CSkillSys)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Class Skill:` | ✗ | ✓ | ✗ |
+| 22 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitCSkillSysView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Skill Assignment - Unit (CSkillSys)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Unit Skill:` | ✗ | ✓ | ✗ |
+| 22 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SkillSystemsEffectivenessReworkClassTypeView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Effectiveness Rework - Class Type` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Class Type:` | ✗ | ✓ | ✗ |
+| 22 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SoundFootStepsViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Footstep Sounds Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Data Pointer:` | ✗ | ✓ | ✗ |
+| 23 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/StatusOptionOrderView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Status Option Order Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Option ID (u8@0):` | ✗ | ✓ | ✗ |
+| 23 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/TextBadCharPopupView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Bad Character Detected` | ✗ | ✓ | ✗ |
+| 20 | `Give Up` | ✗ | ✓ | ✗ |
+| 22 | `Anti-Huffman` | ✗ | ✓ | ✗ |
+| 24 | `Encoding Table` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolASMEditView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `ASM Code Editor` | ✗ | ✓ | ✗ |
+| 11 | `Compile` | ✗ | ✓ | ✗ |
+| 12 | `Close` | ✗ | ✓ | ✗ |
+| 16 | `Enter ARM/Thumb ASM code here...` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolChangeProjectnameView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Current Name:` | ✗ | ✓ | ✗ |
+| 17 | `New Name:` | ✗ | ✓ | ✗ |
+| 18 | `Enter new project name` | ✗ | ✓ | ✗ |
+| 21 | `Change Project Name` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/WorldMapEventPointerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `World Map Event Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 18 | `Event Pointer (u32@0):` | ✗ | ✓ | ✗ |
+| 23 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/DataExportView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Table:` | ✗ | ✓ | ✗ |
+| 20 | `Export TSV...` | ✗ | ✓ | ✗ |
+| 21 | `Import TSV...` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/HexEditorJumpView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 13 | `Address:` | ✗ | ✓ | ✗ |
+| 19 | `Force Little Endian` | ✗ | ✓ | ✗ |
+| 22 | `Jump` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/HowDoYouLikePatch2View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Patch Review` | ✗ | ✓ | ✗ |
+| 10 | `Apply` | ✗ | ✓ | ✗ |
+| 11 | `Skip` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/HowDoYouLikePatchView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Patch Review` | ✗ | ✓ | ✗ |
+| 10 | `Apply` | ✗ | ✓ | ✗ |
+| 11 | `Skip` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageBGSelectPopupView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `BG Image Select` | ✗ | ✓ | ✗ |
+| 15 | `Select` | ✗ | ✓ | ✗ |
+| 16 | `Cancel` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageGenericEnemyPortraitView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Generic Enemy Portraits` | ✗ | ✓ | ✗ |
+| 16 | `Address:` | ✗ | ✓ | ✗ |
+| 20 | `Image Pointer:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Zoom:` | ✗ | ✓ | ✗ |
+| 12 | `Export PNG` | ✗ | ✓ | ✗ |
+| 13 | `Export PAL` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/PatchFormUninstallDialogView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 14 | `ROM without patch` | ✗ | ✓ | ✗ |
+| 16 | `Select file` | ✗ | ✓ | ✗ |
+| 25 | `Uninstall` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SoundRoomCGView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Sound Room CG` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+| 23 | `Write` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SystemHoverColorViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 10 | `Filter:` | ✓ | ✓ | ✗ |
+| 17 | `System Area Gradation Color Viewer` | ✗ | ✓ | ✗ |
+| 18 | `GBA 15-bit color palette entries for move/attack/staff range display.` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolAutomaticRecoveryROMHeaderView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 14 | `Unmodified ROM` | ✗ | ✓ | ✗ |
+| 16 | `Select File` | ✗ | ✓ | ✗ |
+| 25 | `Recover ROM Header` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolDecompileResultView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Decompile Result` | ✗ | ✓ | ✗ |
+| 10 | `Copy to Clipboard` | ✗ | ✓ | ✗ |
+| 11 | `Close` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolThreeMargeCloseAlertView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 13 | `Continue merging without closing.` | ✗ | ✓ | ✗ |
+| 15 | `Abort merge. Cancel all merge changes.` | ✗ | ✓ | ✗ |
+| 17 | `Force close with current results.` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolUndoPopupDialogView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 22 | `Test Play in Emulator` | ✗ | ✓ | ✗ |
+| 25 | `Revert to This Version` | ✗ | ✓ | ✗ |
+| 28 | `Cancel` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolWorkSupport_SelectUPSView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 19 | `Vanilla ROM` | ✗ | ✓ | ✗ |
+| 24 | `Select File` | ✗ | ✓ | ✗ |
+| 28 | `Open UPS Patch` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/AIScriptView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `AI Script Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/CStringView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `C-String Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Class OP Demo` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ClassOPFontView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Class OP Font` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/Command85PointerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Command 0x85 Pointer` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/DecreaseColorTSAToolView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Color Reduction Tool` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/DevTranslateView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Developer Translation Tool` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/DumpStructSelectDialogView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Struct Dump Selector` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EDFE6View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `ED (FE6)` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EDFE7View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `ED (FE7)` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ErrorLongMessageDialogView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `The following error has occurred.` | ✗ | ✓ | ✗ |
+| 15 | `Close` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ErrorPaletteMissMatchView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Palette Mismatch` | ✗ | ✓ | ✗ |
+| 10 | `Close` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ErrorPaletteShowView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Palette Error Display` | ✗ | ✓ | ✗ |
+| 10 | `Close` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ErrorPaletteTransparentView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Palette Transparency Error` | ✗ | ✓ | ✗ |
+| 10 | `Close` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ErrorReportView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `Error Report` | ✗ | ✓ | ✗ |
+| 10 | `Close` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ErrorTSAErrorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 8 | `TSA Error` | ✗ | ✓ | ✗ |
+| 10 | `Close` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventAssemblerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Event Assembler` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventBattleDataFE7View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Battle Data (FE7)` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventBattleTalkFE6View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Battle Dialogue (FE6)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventBattleTalkFE7View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Battle Dialogue (FE7)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventBattleTalkMainView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Battle Talk (Main)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventBattleTalkView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Battle Dialogue Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventCondMainView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Event Conditions (Main)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventFinalSerifFE7View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Final Serif (FE7)` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventHaikuFE6View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Haiku (FE6)` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventHaikuFE7View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Haiku (FE7)` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventHaikuView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Haiku Event Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventMapChangeView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Change Event Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventScriptCategorySelectView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Select Event Script Category` | ✗ | ✓ | ✗ |
+| 12 | `Cancel` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventScriptInnerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Event Script Inner Control` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventScriptMainView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Event Script (Main)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventScriptTemplateView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Script Template Browser` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventTemplate1View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Event Template 1` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventTemplate2View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Event Template 2` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventTemplate3View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Event Template 3` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventTemplate4View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Event Template 4` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventTemplate5View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Event Template 5` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventTemplate6View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Event Template 6` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventTemplateImplView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Event Template Implementation` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventUnitColorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Unit Color Assignment` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventUnitItemDropView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Unit Item Drop Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventUnitNewAllocView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Unit Allocation Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventUnitSimView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Unit Simulation Control` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/FE8SpellMenuExtendsView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Spell Menu Extensions` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/FERepoResourceBrowserWindow.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 21 | `Insert` | ✗ | ✓ | ✗ |
+| 23 | `Cancel` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/FontEditorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Font Editor` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/FontZHView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Font Editor (Chinese)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/GrowSimulatorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Growth Simulator` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/HexEditorMarkView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 14 | `Marked Addresses` | ✗ | ✓ | ✗ |
+| 18 | `Jump To` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Battle Animation Palette` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Battle Screen Layout` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageFormRefViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Image Form Reference` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageMagicCSACreatorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `CSA Magic Creator` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Magic Effect Editor (FEditor)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Palette Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImagePortraitImporterView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Portrait Import Wizard` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageRomAnimeView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `ROM Animation Viewer` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `TSA Tile Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageUnitMoveIconView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Unit Move Icon` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageUnitWaitIconView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Unit Wait Icon` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/InterpolatedPictureBoxViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Interpolated Picture Box` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ItemEffectivenessMainView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Item Effectiveness (Main)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ItemEffectivenessSkillSystemsReworkView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Effectiveness (Skill Systems Rework)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/LogViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Log Viewer` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MainSimpleMenuEventErrorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Event Error Display` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MainSimpleMenuImageSubView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Image Sub-Menu` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MainSimpleMenuView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Simple Menu (Easy Mode)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MantAnimationView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Mant Animation` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapChangeMainView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Change (Main)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapEditorAddMapChangeView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Add Map Change` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapEditorMarSizeDialogView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 14 | `Width` | ✗ | ✓ | ✗ |
+| 26 | `Apply` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapEditorMarSizeView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Size` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapEditorResizeView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Resize` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapExitPointMainView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Exit Point (Main)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapMiniMapTerrainImageView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Mini-Map Terrain` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapPictureBoxViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Picture Box` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapPointerMainView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Pointer (Main)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapPointerNewPLISTView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `New PLIST Popup` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapSettingDifficultyExtraView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Setting Difficulty Extra` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapSettingDifficultyView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Difficulty Settings` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapSettingFE6View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Settings (FE6)` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapSettingMainView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Map Settings (Main)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapStyleEditorAppendView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Tileset Append` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapStyleEditorWarningView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Tile Override Warning` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/NotifyDirectInjectionView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Direct Injection Notify` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/NotifyWriteView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Write Notification` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/OAMSPView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `OAM Sprite Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/OPClassAlphaNameFE6ExtraView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `OP Class Alpha Name (FE6 Extra)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/OpenLastSelectedFileView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Open Last Selected File` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/OtherTextView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Other Text Strings` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/PackedMemorySlotView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 13 | `Packed Memory Slot` | ✗ | ✓ | ✗ |
+| 16 | `Apply` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/PatchUninstallDialogView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Patch Uninstall` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/PointerToolBatchInputView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 10 | `Value:` | ✗ | ✓ | ✗ |
+| 12 | `Batch Address Convert` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ProcsScriptView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Procs Script Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SkillSystemsCSkillRechainView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `C-Skill Rechain` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SongExchangeView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Song Exchange Tool` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SongInstrumentImportWaveView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Wave Import` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SongTableMainView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Song Table (Main)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SongTrackAllChangeTrackView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Bulk Track Change` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SongTrackChangeTrackView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Track Change` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/SongTrackImportWaveView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Wave Track Import` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/TextEscapeEditorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Text Escape Sequences` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/TextMainView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Text Editor` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/TextScriptCategorySelectView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Select Text Script Category` | ✗ | ✓ | ✗ |
+| 12 | `Cancel` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolASMInsertView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `ASM Insertion Tool` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolAllWorkSupportView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Work Support` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolBGMMuteDialogView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 18 | `Play only this track` | ✗ | ✓ | ✗ |
+| 22 | `Play all tracks` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolClickWriteFloatControlPanelButtonView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 22 | `Update` | ✗ | ✓ | ✗ |
+| 24 | `Insert New` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolCustomBuildView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Custom Build Tool` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolDiffView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `ROM Diff Tool` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolEmulatorSetupMessageView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 13 | `Automatically configure with Init Wizard` | ✗ | ✓ | ✗ |
+| 15 | `Manually configure from Options screen` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolFELintView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `FELint GUI` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolFlagNameView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Flag Name Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolLZ77View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `LZ77 Compression Tool` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolProblemReportView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Problem Reporter` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolROMRebuildView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `ROM Rebuild Tool` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolRunHintMessageView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 18 | `Do not show this message again` | ✗ | ✓ | ✗ |
+| 20 | `Start` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolTranslateROMView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `ROM Translation Tool` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolUPSOpenSimpleView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `UPS Patch Applier` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolUPSPatchSimpleView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `UPS Patch Creator` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolUndoView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Undo History Viewer` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolUnitTalkGroupView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Talk Group Editor` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolUpdateDialogView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Update Checker` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolUseFlagView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Flag Usage Viewer` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ToolWorkSupport_UpdateQuestionDialogView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 23 | `Close` | ✗ | ✓ | ✗ |
+| 25 | `Force Update` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/UnitActionPointerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Unit Action Pointers` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/UnitIncreaseHeightView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Unit Height Adjustment` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/UnitMainView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Unit Editor (Main)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/WorldMapEventPointerFE6View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Event Pointer (FE6)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/WorldMapEventPointerFE7View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Event Pointer (FE7)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/WorldMapImageFE6View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `World Map Image (FE6)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/WorldMapImageFE7View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `World Map Image (FE7)` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `World Map Image` | ✗ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/WorldMapPathEditorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Path Editor` | ✓ | ✓ | ✗ |
+| 15 | `Address:` | ✗ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/NotifyPleaseWaitView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 31 | `Cancel` | ✗ | ✓ | ✗ |
+
+## Already Translated (Summary)
+
+Literals that have a translation in every target language. Surfaced as a
+count per file so the report stays scannable; the per-literal detail is
+intentionally not listed (they're already covered).
+
+_No fully-translated literals._
+
+## Non-English Source Literals (Out of Scope)
+
+AXAML literals that already contain CJK / Hangul characters — someone wrote
+them directly in the target language instead of routing them through the
+translation tables. This is fine when the literal IS the canonical form
+(matches the user's locale), but flagged for sanity in case any are stray
+leftovers from a partial localisation attempt.
+
+_None._

--- a/docs/avalonia-gaps/README.md
+++ b/docs/avalonia-gaps/README.md
@@ -27,7 +27,7 @@ them as backlog instead of waiting for users to file them one at a time.
 | 3 | Side-by-side screenshot gallery | `--gap-sweep-gallery` + `--screenshot-all` × 2 | [x] [2026-05-22 FE8U baseline](2026-05-22-screenshots/FE8U/index.md) |
 | 4 | Headless jump/navigation parity | `--gap-sweep-jumps` | [x] [2026-05-22 baseline](2026-05-22-jumps-sweep.md) |
 | 5 | Undo coverage | `--gap-sweep-undo` | [x] [2026-05-22 baseline](2026-05-22-undo-sweep.md) |
-| 6 | Localisation sweep | `--gap-sweep-l10n` | [ ] |
+| 6 | Localisation sweep | `--gap-sweep-l10n` | [x] [2026-05-22 baseline](2026-05-22-l10n-sweep.md) |
 | 7 | Meta-tracking + advisory CI | `--gap-sweep-all` | [ ] |
 
 Each phase produces a markdown report under `docs/avalonia-gaps/<YYYY-MM-DD>-<sweep>.md`.
@@ -66,6 +66,12 @@ dotnet run --project FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj -c Relea
 dotnet run --project FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj -c Release `
     -- --gap-sweep-undo --out=docs/avalonia-gaps/$(Get-Date -Format yyyy-MM-dd)-undo-sweep.md
 
+# Phase 6 — localisation sweep (XDocument scan over Views/**/*.axaml;
+# joins each English-looking literal against config/translate/<lang>.txt).
+dotnet run --project FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj -c Release `
+    -- --gap-sweep-l10n --languages=ja,zh,ko `
+       --out=docs/avalonia-gaps/$(Get-Date -Format yyyy-MM-dd)-l10n-sweep.md
+
 # Phase 3 — full side-by-side screenshot gallery (drives both --screenshot-all
 # runners then pairs the captured PNGs). PNGs are gitignored; only index.md
 # is committed.
@@ -96,6 +102,10 @@ The `--gap-sweep-gallery` flag additionally requires:
 - `--wf-dir=<path>` — directory of WinForms `--screenshot-all` PNG output.
 - `--av-dir=<path>` — directory of Avalonia `--screenshot-all` PNG output.
 - `--rom-tag=<name>` — ROM tag suffix that both runners used (e.g. `FE8U`); pairs filenames by `WinForms_<editor>_<tag>.png` ↔ `Avalonia_<editor>_<tag>.png`.
+
+The `--gap-sweep-l10n` flag accepts:
+
+- `--languages=<comma-list>` — target-language codes the translation join runs against. Defaults to `ja,zh,ko` (English is the source for AXAML literals so it never appears here).
 
 ## Reading the density report
 
@@ -272,6 +282,60 @@ haven't been updated to wrap `_vm.WriteX()` yet), and 0.2% are
 `MissingScope` (BigCGViewerView's `ImportPng_Click` early-exit-Rollback
 case, a conservative false-positive of the strict bracketing model).
 
+## Reading the localisation report
+
+Phase 6 emits `docs/avalonia-gaps/<date>-l10n-sweep.md`. The report
+inventories every English-looking AXAML literal under
+`FEBuilderGBA.Avalonia/Views/` that isn't bound to a localized resource AND
+isn't already present in the project's translation tables. Issue
+[#356](https://github.com/laqieer/FEBuilderGBA/issues/356) traces the
+user-visible symptom (Avalonia GUI labels stay in English when the
+application language is set to Japanese or Chinese); this report is the
+mechanical inventory of every literal that needs a translation entry.
+
+**Methodology:**
+
+- `XDocument` parses each `*.axaml` with `LoadOptions.SetLineInfo` so we
+  get per-attribute line numbers.
+- Inspect attribute values for `Text` / `Content` / `Header` / `ToolTip` /
+  `Watermark` / `ToolTip.Tip` (the Avalonia attached-property form, also
+  consumed by the Phase 2 label-diff scanner).
+- Skip markup extensions (`{Binding ...}`, `{StaticResource ...}`,
+  `{x:Static ...}`, `{DynamicResource ...}`, `{TemplateBinding ...}`) and
+  elements nested inside `Style` / `DataTemplate` / `ControlTemplate` /
+  `ItemTemplate` / `Design.DataContext`.
+- Heuristic accepts: any value starting with an ASCII letter, length ≥ 2,
+  containing at least one space OR ≥ 4 chars with ≥ 80 % ASCII-letter
+  density.
+- Translation join: for each candidate literal, look it up in each target
+  language's `config/translate/<lang>.txt` table via the same reverse-English
+  chain the runtime uses (`MyTranslateResourceLow.LoadReverseEnglishMap` →
+  English value → Japanese key → forward map → translated value). Both raw
+  and trim-trailing-colon normalised forms are tried.
+
+**Verdict tiers:**
+
+- `Untranslated` — no target language has a translation. The backlog.
+- `PartiallyTranslated` — some languages have it, others don't (typical
+  for `ja.txt` (English-keyed, menu only) ↔ `zh.txt` (Japanese-keyed, much
+  larger).
+- `Translated` — every target language has a translation.
+- `NonEnglish` — source literal already contains CJK / Hangul (out of scope
+  sanity row).
+
+Phase 6 is intentionally a **static analyzer**. It does NOT modify any AXAML
+or translation file — it just inventories them. Follow-up PRs use the report
+as a per-file backlog to add the missing translation entries one editor at a
+time.
+
+Methodology lives in `FEBuilderGBA.Avalonia/GapSweep/L10nScanner.cs`.
+The 2026-05-22 baseline reports **3099 literals** across all AXAML views;
+`Untranslated`, `PartiallyTranslated`, `Translated`, `NonEnglish` counts plus
+per-language coverage percentages are in the summary tables at the top of
+the report. Top files by untranslated count: `ClassEditorView.axaml`,
+`ItemEditorView.axaml`, `UnitEditorView.axaml` — the same three editors
+where the original issue #356 screenshot showed the symptom.
+
 ## Implementation entry points
 
 | File | Role |
@@ -284,6 +348,7 @@ case, a conservative false-positive of the strict bracketing model).
 | `FEBuilderGBA.Avalonia/GapSweep/JumpParityScanner.cs` | Phase 4 scanner |
 | `FEBuilderGBA.Avalonia/Services/INavigationTargetSource.cs` | Phase 4 manifest seam |
 | `FEBuilderGBA.Avalonia/GapSweep/UndoCoverageScanner.cs` | Phase 5 scanner |
+| `FEBuilderGBA.Avalonia/GapSweep/L10nScanner.cs` | Phase 6 scanner |
 | `FEBuilderGBA.Avalonia/App.axaml.cs` | CLI flag plumbing (see `RunGapSweep`) |
 | `scripts/make-screenshots.ps1` | Phase 3 wrapper — drives both `--screenshot-all` runners then `--gap-sweep-gallery` |
 | `FEBuilderGBA.Avalonia.Tests/GapSweep/` | xunit coverage |


### PR DESCRIPTION
## Summary

Phase 6 of the gap-sweep methodology (issue #374) surfaces every English-looking AXAML literal under `FEBuilderGBA.Avalonia/Views/` that ISN'T bound to a localised resource AND isn't already present in the project's translation tables. Issue #356 traces the user-visible symptom (Avalonia GUI labels stay in English when the application language is set to Japanese or Chinese) — this PR's report mechanically inventories every literal that needs a translation entry.

## Changes

- **`FEBuilderGBA.Avalonia/GapSweep/L10nScanner.cs`** (new): `XDocument` scan over `Views/**/*.axaml` using `LoadOptions.SetLineInfo` for per-attribute line numbers. Inspects `Text` / `Content` / `Header` / `ToolTip` / `Watermark` / `ToolTip.Tip` (the Avalonia attached-property form). Skips markup extensions (`{Binding}`, `{StaticResource}`, `{x:Static}`, `{DynamicResource}`, `{TemplateBinding}`) and elements nested under `Style` / `DataTemplate` / `ControlTemplate` / `ItemTemplate` / `Design.DataContext`. Translation join uses the same reverse-English chain the runtime uses (`MyTranslateResourceLow.LoadReverseEnglishMap`): English value → Japanese key → forward map → translated value. Both raw and trim-trailing-colon normalised forms are tried.
- **`FEBuilderGBA.Avalonia.Tests/GapSweep/L10nScannerTests.cs`** (new, 29 cases): heuristic gate, attribute coverage including `ToolTip.Tip` regression guard, markup-extension skip, template-container skip, line-number capture, translation join variants (`Translated` / `PartiallyTranslated` / `Untranslated` / `NonEnglish`), trailing-colon normalisation, LF-only report newlines, and an end-to-end synthetic-AXAML + synthetic-translate-file test.
- **`FEBuilderGBA.Avalonia/App.axaml.cs`**: wires `--gap-sweep-l10n` through new `RunL10nSweep` (mirrors `RunDensitySweep` / `RunLabelsSweep` / `RunJumpsSweep` / `RunUndoSweep` patterns). Adds `--languages=<comma-list>` arg (default `ja,zh,ko`); pushes the languages set into the report's YAML front-matter.
- **`docs/avalonia-gaps/2026-05-22-l10n-sweep.md`** (new): first baseline report — **3099 literals** scanned (158 `Untranslated`, 2941 `PartiallyTranslated`, 0 `Translated`, 0 `NonEnglish`); per-language coverage: `ja` 12.0 %, `zh` 94.9 %, `ko` 0.0 %. Top untranslated files: `ClassEditorView.axaml` (35), `ItemEditorView.axaml` (26), `UnitEditorView.axaml` (21) — the same three editors where the original #356 screenshot showed the symptom.
- **`docs/avalonia-gaps/README.md`**: ticks Phase 6 checkbox, documents the `--gap-sweep-l10n` flag and `--languages=` arg, adds a "Reading the localisation report" section, adds `L10nScanner.cs` to the implementation-entry-points table.
- **`README.md`**: surfaces `--gap-sweep-l10n` in the cross-platform Avalonia command list.

Closes part of #374 (Phase 6); refs #356 (the user-visible symptom this report measures).

## Test plan

- [x] `dotnet build FEBuilderGBA.sln` — clean (0 errors).
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests --filter L10nScanner` — 29/29 pass.
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests --filter GapSweep` — 291/291 pass (+29 new).
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` (full) — 4530/4530 pass, 5 pre-existing skipped.
- [x] `dotnet test FEBuilderGBA.Core.Tests` — 1293/1293 pass.
- [x] Regenerated `docs/avalonia-gaps/2026-05-22-l10n-sweep.md` from `--gap-sweep-l10n --languages=ja,zh,ko` against the worktree HEAD; report committed.
- [x] Verified `--gap-sweep-l10n --dry-run` writes header-only file (defensive CLI plumbing check).
- [x] Verified the `ToolTip.Tip` attached-property form is captured by an explicit test (regression guard for the bug originally surfaced in PR #377 Phase 2).
- [x] Verified report uses LF newlines only (asserted by `FormatReport_UsesLfNewlinesOnly`).

## GUI Test Report

This PR adds static-analysis tooling and a report file; it does not modify any AXAML or ViewModel code. The Avalonia GUI is unaffected at runtime.

| Test case | Result | Notes |
|---|---|---|
| Build (`dotnet build FEBuilderGBA.sln`) | PASS | 0 errors, 33 pre-existing warnings |
| Avalonia tests (full) | PASS | 4530 passed, 5 pre-existing skipped |
| GapSweep tests (filter) | PASS | 291 passed (+29 new L10nScanner cases) |
| L10nScanner tests (filter) | PASS | 29/29 |
| Core tests | PASS | 1293/1293 |
| Report generation (`--gap-sweep-l10n`) | PASS | 3099 literals scanned in ~3 s; report written to `docs/avalonia-gaps/2026-05-22-l10n-sweep.md` |
| Dry-run plumbing (`--dry-run`) | PASS | Header-only file written; no scan executed |

Per the methodology note in `docs/avalonia-gaps/README.md`, Phase 6 is intentionally a static analyser — it does NOT modify any AXAML or translation file. Screenshot proof of an AXAML-only / docs-only / tests-only PR is captured by the CLI / test output above; no GUI regression surface is introduced. The output of the `--gap-sweep-l10n` invocation that produced the committed baseline:

```
GAPSWEEP[l10n]: repo-root=<worktree> out=docs/avalonia-gaps/2026-05-22-l10n-sweep.md dry-run=False
GAPSWEEP[l10n]: scanned 3099 literals (translated=0 partial=2941 untranslated=158 non-english=0; langs=ja,zh,ko).
GAPSWEEP[l10n]: report written to docs/avalonia-gaps/2026-05-22-l10n-sweep.md
```

Refs: #374, #356
Builds on: #375 (Phase 0+1), #377 (Phase 2), #378 (Phase 3), #379 (Phase 4), #380 (Phase 5)

Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-4-7[1m]).