### PR TITLE
fix(readme): correct malformed Gitee Go Build badge img src

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ README
 [![codecov](https://codecov.io/gh/laqieer/FEBuilderGBA/branch/master/graph/badge.svg)](https://codecov.io/gh/laqieer/FEBuilderGBA)
 [![Cross-Platform](https://github.com/laqieer/FEBuilderGBA/actions/workflows/crossplatform.yml/badge.svg)](https://github.com/laqieer/FEBuilderGBA/actions/workflows/crossplatform.yml)
 
-Mirrors for Chinese mainland users (面向中国大陆用户的镜像发布地址): [![Gitee Release](https://gitee-badge.vercel.app/svg/release/laqieer/FEBuilderGBA?style=flat)](https://gitee.com/laqieer/FEBuilderGBA/releases/latest) [<img src="[https://raw.githubusercontent.com/oprypin/nightly.link/master/logo.svg](https://gitee.com/laqieer/FEBuilderGBA/widgets/widget_5.svg)" height="16" style="height: 16px; vertical-align: sub">Gitee Go Build](https://gitee.com/laqieer/FEBuilderGBA/gitee_go/pipelines?tab=release)
+Mirrors for Chinese mainland users (面向中国大陆用户的镜像发布地址): [![Gitee Release](https://gitee-badge.vercel.app/svg/release/laqieer/FEBuilderGBA?style=flat)](https://gitee.com/laqieer/FEBuilderGBA/releases/latest) [![Gitee Go Build](https://gitee.com/laqieer/FEBuilderGBA/widgets/widget_5.svg)](https://gitee.com/laqieer/FEBuilderGBA/gitee_go/pipelines?tab=release)
 
 ## 🚀 Getting Started
 


### PR DESCRIPTION
## Summary

The Gitee Go Build badge on line 16 had a malformed `<img src>` attribute embedding markdown-link syntax inside the URL, causing the image to not render.

**Before (broken):**
`[img src="[svg_url](widget_url)" ...>Gitee Go Build](pipelines_url)`

**After (fixed):**
`[![Gitee Go Build](https://gitee.com/laqieer/FEBuilderGBA/widgets/widget_5.svg)](https://gitee.com/laqieer/FEBuilderGBA/gitee_go/pipelines?tab=release)`

## Changes
- 1 line changed: replaced broken HTML img badge with proper markdown image syntax
- Used correct widget SVG URL from gitee.com
- Link target preserved (Gitee pipelines page)

Closes #376