### PR TITLE
fix(avalonia): remove wrong death-quotes fallback in Unit Short Text Editor (#372)

### DIFF
--- a/FEBuilderGBA.Avalonia/ViewModels/UnitsShortTextViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/UnitsShortTextViewModel.cs
@@ -3,9 +3,22 @@ using FEBuilderGBA.Avalonia.Services;
 
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
-    /// <summary>Unit short text editor — maps each unit to a "description" text ID.
+    /// <summary>
+    /// Unit short text editor — maps each unit to a "description" text ID.
     /// WinForms: UnitsShortTextForm — DATAMAX = 0x46 entries, 2 bytes each (text ID u16).
-    /// Display: "0xNN UnitName" where NN is the unit index.</summary>
+    /// Display: "0xNN UnitName" where NN is the unit index.
+    ///
+    /// IMPORTANT (#372): this is a pointer-driven editor. There is no canonical
+    /// <c>RomInfo</c> field for the unit-short-text base address; a vanilla ROM does NOT
+    /// contain such a table. The data only exists when an event-script
+    /// <c>POINTER_UNITSSHORTTEXT</c> argument allocates one (e.g. the
+    /// <c>EVENTSCRIPT_SimpleEscape</c> patch). Callers must supply a base address via
+    /// <see cref="BuildList(uint)"/> / <see cref="LoadEntry(uint)"/>; opening this editor
+    /// standalone with no caller-supplied address yields an empty list. A previous version
+    /// of this view-model fell back to the death-quotes pointer when no address was
+    /// provided, but that pointer references a 12-byte struct array, not u16 text IDs —
+    /// reading it as text IDs displayed garbage data.
+    /// </summary>
     public class UnitsShortTextViewModel : ViewModelBase, IDataVerifiable
     {
         const int DATAMAX = 0x46;
@@ -23,6 +36,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public string TextPreview { get => _textPreview; set => SetField(ref _textPreview, value); }
         public string UnitName { get => _unitName; set => SetField(ref _unitName, value); }
         public int EntryIndex { get => _entryIndex; set => SetField(ref _entryIndex, value); }
+
+        /// <summary>True iff a valid base address has been loaded via <see cref="BuildList(uint)"/>.</summary>
+        public bool HasData => _baseAddr != 0;
 
         /// <summary>Build the unit short text list from a base address.</summary>
         public List<AddrResult> BuildList(uint baseAddr)
@@ -76,36 +92,10 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
         public int GetListCount()
         {
-            if (_baseAddr == 0)
-            {
-                // Standalone init: find a default address from event_haiku_pointer
-                // (death quotes) which has the same format: 0x46 u16 text IDs per unit.
-                uint defaultAddr = FindDefaultBaseAddr();
-                if (defaultAddr != 0)
-                    return BuildList(defaultAddr).Count;
-                return 0;
-            }
+            // Pointer-driven editor: no auto-discovery. A standalone open with no caller-supplied
+            // base address returns 0 entries; the view shows an empty-state explanation.
+            if (_baseAddr == 0) return 0;
             return BuildList(_baseAddr).Count;
-        }
-
-        /// <summary>
-        /// Find a default base address for unit short text from ROM.
-        /// Uses event_haiku_pointer (death quotes), which has the same
-        /// format: array of u16 text IDs indexed by unit ID.
-        /// </summary>
-        static uint FindDefaultBaseAddr()
-        {
-            ROM rom = CoreState.ROM;
-            if (rom?.RomInfo == null) return 0;
-
-            uint ptr = rom.RomInfo.event_haiku_pointer;
-            if (ptr == 0) return 0;
-
-            uint addr = rom.p32(ptr);
-            if (U.isSafetyOffset(addr, rom) && addr + DATAMAX * 2 <= (uint)rom.Data.Length)
-                return addr;
-
-            return 0;
         }
 
         public Dictionary<string, string> GetDataReport()

--- a/FEBuilderGBA.Avalonia/Views/UnitsShortTextView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/UnitsShortTextView.axaml
@@ -14,7 +14,20 @@
       <TextBlock Text="Units Short Text Editor" FontSize="18" FontWeight="Bold" />
       <TextBlock Text="Maps each unit index to a description text ID (2 bytes per entry)." Foreground="Gray" TextWrapping="Wrap" />
 
-      <Grid ColumnDefinitions="140,200,*" RowDefinitions="Auto,Auto,Auto,Auto" Margin="0,8,0,0">
+      <!-- Empty state (#372): shown when no base address has been supplied via NavigateTo().
+           A vanilla ROM has no unit-short-text table, so standalone open lands here. -->
+      <TextBlock AutomationProperties.AutomationId="UnitsShortText_EmptyState_Label"
+                 Name="EmptyStateLabel"
+                 IsVisible="False"
+                 TextWrapping="Wrap"
+                 Foreground="DarkSlateGray"
+                 Margin="0,8,0,0">
+        <Run Text="No data loaded." FontWeight="Bold" />
+        <LineBreak />
+        <Run Text="This editor edits a unit-short-text table referenced by a pointer; it must be opened from a POINTER_UNITSSHORTTEXT event-script argument or a FELint follow-up. A vanilla ROM has no such table — patches like EVENTSCRIPT_SimpleEscape add one." />
+      </TextBlock>
+
+      <Grid Name="EditorGrid" IsVisible="False" ColumnDefinitions="140,200,*" RowDefinitions="Auto,Auto,Auto,Auto" Margin="0,8,0,0">
         <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
         <TextBlock AutomationProperties.AutomationId="UnitsShortText_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
         <TextBlock Grid.Row="1" Grid.Column="0" Text="Unit:" VerticalAlignment="Center" Margin="0,4" />
@@ -24,7 +37,7 @@
         <TextBlock Grid.Row="3" Grid.Column="0" Text="Preview:" VerticalAlignment="Center" Margin="0,4" />
         <TextBlock AutomationProperties.AutomationId="UnitsShortText_TextPreview_Label" Grid.Row="3" Grid.Column="1" Name="TextPreviewLabel" VerticalAlignment="Center" TextWrapping="Wrap" Grid.ColumnSpan="2" />
       </Grid>
-      <Button AutomationProperties.AutomationId="UnitsShortText_Write_Button" Content="Write" Click="Write_Click" Width="168" Height="30" />
+      <Button AutomationProperties.AutomationId="UnitsShortText_Write_Button" Name="WriteButton" IsVisible="False" Content="Write" Click="Write_Click" Width="168" Height="30" />
     </StackPanel>
   </Grid>
   </ScrollViewer>

--- a/FEBuilderGBA.Avalonia/Views/UnitsShortTextView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/UnitsShortTextView.axaml.cs
@@ -19,29 +19,22 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
-            Opened += (_, _) => AutoInitIfNeeded();
+            // Issue #372: no auto-init from any ROM pointer. This editor is pointer-driven —
+            // a vanilla ROM has no unit-short-text table, so opening standalone shows an
+            // empty-state explanation until a caller supplies an address via NavigateTo().
+            Opened += (_, _) => UpdateEmptyState();
         }
 
         /// <summary>
-        /// If no external NavigateTo call provided a base address, try to find
-        /// a default unit short text table from ROM for standalone operation.
-        /// Uses event_haiku_pointer (death quotes) which has the same format.
+        /// Show the empty-state label when no base address has been supplied; otherwise show
+        /// the editor grid and Write button. Called on window open and on NavigateTo().
         /// </summary>
-        void AutoInitIfNeeded()
+        void UpdateEmptyState()
         {
-            if (_baseAddr != 0) return; // Already initialized via NavigateTo
-
-            ROM rom = CoreState.ROM;
-            if (rom?.RomInfo == null) return;
-
-            uint ptr = rom.RomInfo.event_haiku_pointer;
-            if (ptr == 0) return;
-
-            uint addr = rom.p32(ptr);
-            if (U.isSafetyOffset(addr, rom) && addr + 0x46 * 2 <= (uint)rom.Data.Length)
-            {
-                NavigateTo(addr);
-            }
+            bool hasData = _baseAddr != 0;
+            EmptyStateLabel.IsVisible = !hasData;
+            EditorGrid.IsVisible = hasData;
+            WriteButton.IsVisible = hasData;
         }
 
         public void NavigateTo(uint address)
@@ -49,6 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             _baseAddr = address;
             var items = _vm.BuildList(address);
             EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitByIdLoader(items, i));
+            UpdateEmptyState();
         }
 
         public void SelectFirstItem() => EntryList.SelectFirst();

--- a/FEBuilderGBA.Tests/Unit/AvaloniaEditorTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AvaloniaEditorTests.cs
@@ -2384,5 +2384,72 @@ namespace FEBuilderGBA.Tests.Unit
             }
             Assert.True(tipCount >= 5, $"Expected at least 5 ToolTip.Tip attributes in ItemEditorView, found {tipCount}");
         }
+
+        // ------------------------------------------------------------------ UnitsShortText (#372)
+
+        [Fact]
+        public void UnitsShortTextViewModel_DoesNotUseEventHaikuFallback()
+        {
+            // Issue #372: event_haiku_pointer (death quotes, 12-byte struct array) was incorrectly
+            // used as a fallback base address for unit short text (u16 text-id array). The two data
+            // structures are not compatible — reading death-quote bytes as text IDs displays nonsense.
+            // The fallback must be removed entirely; this view is pointer-driven only.
+            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "ViewModels", "UnitsShortTextViewModel.cs"));
+            Assert.DoesNotContain("event_haiku_pointer", src);
+            Assert.DoesNotContain("FindDefaultBaseAddr", src);
+        }
+
+        [Fact]
+        public void UnitsShortTextViewModel_GetListCountReturnsZeroWhenNoBaseAddr()
+        {
+            // GetListCount() must return 0 when _baseAddr == 0, instead of trying to auto-discover
+            // a default base address. Standalone open with no NavigateTo() => empty list.
+            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "ViewModels", "UnitsShortTextViewModel.cs"));
+            // Either an explicit early return or HasData check
+            bool hasZeroReturn = src.Contains("if (_baseAddr == 0) return 0")
+                || src.Contains("if (_baseAddr == 0)\n                return 0")
+                || src.Contains("_baseAddr == 0 ? 0");
+            Assert.True(hasZeroReturn,
+                "UnitsShortTextViewModel.GetListCount must return 0 when _baseAddr == 0");
+        }
+
+        [Fact]
+        public void UnitsShortTextViewModel_HasHasDataProperty()
+        {
+            // Public HasData property — true iff a valid base address is loaded.
+            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "ViewModels", "UnitsShortTextViewModel.cs"));
+            Assert.Contains("public bool HasData", src);
+        }
+
+        [Fact]
+        public void UnitsShortTextView_DoesNotHaveAutoInitEventHaiku()
+        {
+            // The AutoInitIfNeeded() shim that derived a base address from event_haiku_pointer
+            // is the bug being fixed. It must not remain in the code-behind.
+            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "Views", "UnitsShortTextView.axaml.cs"));
+            Assert.DoesNotContain("event_haiku_pointer", src);
+            Assert.DoesNotContain("AutoInitIfNeeded", src);
+        }
+
+        [Fact]
+        public void UnitsShortTextView_HasEmptyStateAndEditorGrid()
+        {
+            // The axaml must declare both the empty-state TextBlock and the editor grid container
+            // so the code-behind can flip visibility between them.
+            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "Views", "UnitsShortTextView.axaml"));
+            Assert.Contains("EmptyStateLabel", src);
+            Assert.Contains("EditorGrid", src);
+        }
+
+        [Fact]
+        public void UnitsShortTextView_HidesEditorGridWhenNoBaseAddr()
+        {
+            // Behavior assertion (Copilot review #3): when no base address is set, the editor grid
+            // and Write button are hidden; the empty-state label is shown. NavigateTo() flips them.
+            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "Views", "UnitsShortTextView.axaml.cs"));
+            Assert.Contains("EditorGrid.IsVisible", src);
+            Assert.Contains("EmptyStateLabel.IsVisible", src);
+            Assert.Contains("WriteButton.IsVisible", src);
+        }
     }
 }

--- a/docs/avalonia-gap-analysis.md
+++ b/docs/avalonia-gap-analysis.md
@@ -117,7 +117,7 @@ The follow-up fix pass for issues `#48`-`#51` removed several false-negative val
 | UnitCustomBattleAnimeForm / UnitCustomBattleAnimeVM | **40%** | ~~List stub~~ **FIXED** — BuildList with weapon/anim display. Missing: SP Names, Preview |
 | UnitIncreaseHeightForm / UnitIncreaseHeightVM | 25% | Write, Proper List, Switch2, Height Options |
 | UnitPaletteForm / UnitPaletteVM | **40%** | ~~List stub~~ **FIXED** — list from unit_palette_color_pointer with unit names. Missing: Dual Tables, Preview |
-| UnitsShortTextForm / UnitsShortTextVM | **50%** | ~~Proper List~~ **FIXED** — AddressListControl with unit names, text ID decode/preview. Missing: Alloc, Recycling |
+| UnitsShortTextForm / UnitsShortTextVM | **50%** | ~~Proper List~~ **FIXED** — AddressListControl with unit names, text ID decode/preview. Pointer-driven (no auto-init from any ROM pointer; the death-quotes fallback that displayed garbage data was removed in #372). Missing: Alloc, Recycling, event-script/FELint navigation. |
 
 ### Cross-Cutting Gaps
 - ~~**No undo**~~ **FIXED** -- All write handlers wrapped with `UndoService.Begin/Commit/Rollback`

--- a/docs/field-completeness-report.txt
+++ b/docs/field-completeness-report.txt
@@ -1,6 +1,6 @@
 === Field Completeness Report ===
-Total WinForms fields: 1562
-Total Avalonia fields: 1709
+Total WinForms fields: 1563
+Total Avalonia fields: 1718
 Total missing: 0
-Forms with gaps: 0 / 173
+Forms with gaps: 0 / 174
 


### PR DESCRIPTION
## Summary

Fixes #372: the Avalonia Unit Short Text Editor previously displayed garbage values for every unit (0x00 Eirika onward) because it used `RomInfo.event_haiku_pointer` (Death Quotes — a 12-byte struct array) as a fallback base address when no caller supplied one. Reading those bytes as u16 text IDs interpreted the low/high bytes of `{Unit, KillerUnit}` as text IDs, producing nonsense.

WinForms `UnitsShortTextForm` is a pointer-driven editor — opened only via event-script `POINTER_UNITSSHORTTEXT` references (`EventScriptInnerControl.cs`) or FELint follow-ups (`MainSimpleMenuEventErrorForm.cs`). There is no canonical `RomInfo` field for the unit-short-text base address, and a vanilla ROM does NOT contain such a table — only patches like `EVENTSCRIPT_SimpleEscape` add one.

The fix removes the death-quotes fallback entirely. When opened standalone with no caller-supplied address, the view shows an explanatory empty-state label and hides the editor grid + Write button. `NavigateTo(address)` still works for future event-script / FELint callers.

Closes #372.

## Plan Reference

Implements the plan from https://github.com/laqieer/FEBuilderGBA/issues/372#issuecomment-4516913185 — accepted by Copilot CLI with no blocking concerns: https://github.com/laqieer/FEBuilderGBA/issues/372#issuecomment-4516952830

## Files Changed

- `FEBuilderGBA.Avalonia/ViewModels/UnitsShortTextViewModel.cs` — remove `FindDefaultBaseAddr()`; `GetListCount()` returns 0 when `_baseAddr == 0`; add public `HasData` property.
- `FEBuilderGBA.Avalonia/Views/UnitsShortTextView.axaml.cs` — remove `AutoInitIfNeeded()`; add `UpdateEmptyState()` that flips `EmptyStateLabel` / `EditorGrid` / `WriteButton` visibility based on `_baseAddr != 0`; call from `Opened` and `NavigateTo()`.
- `FEBuilderGBA.Avalonia/Views/UnitsShortTextView.axaml` — add `EmptyStateLabel` TextBlock with empty-state message; name the editor grid `EditorGrid` and Write button `WriteButton`; both start with `IsVisible="False"`.
- `FEBuilderGBA.Tests/Unit/AvaloniaEditorTests.cs` — 6 new regression-guard tests.
- `docs/avalonia-gap-analysis.md` — note the pointer-driven nature.
- `docs/field-completeness-report.txt` — auto-regenerated counts (174 forms).
- `pr-screenshots/pr372-fix-empty-state.png` — proof screenshot.

## Scope

Closes #372.

Out of scope (separate gaps tracked in `docs/avalonia-gap-analysis.md`):
- Wiring `POINTER_UNITSSHORTTEXT` in the Avalonia EventScript editor (no existing Avalonia event-script editor)
- Scanning event scripts for `POINTER_UNITSSHORTTEXT` references
- `AllocIfNeed` / `RecycleOldData` parity for new-table creation

## Screenshots

Empty-state proof (standalone open of the Unit Short Text Editor on `roms/FE8U.gba` — the bug previously showed garbage values for every unit; the fix now shows a clear explanation that no data is loaded):

![Empty state](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr372-fix-empty-state.png)

## GUI Test Report

### Environment
- ROM: `roms/FE8U.gba`
- Editor: `UnitsShortTextView` (Avalonia)

### Steps Performed
1. Built `FEBuilderGBA.Avalonia` (Release).
2. Launched `FEBuilderGBA.Avalonia.exe --rom roms/FE8U.gba`.
3. Used PowerShell `UIAutomationClient` to scroll the main menu to the "Short Text" button (`AutomationId=Main_ShortText_Button`) and invoke its `InvokePattern`.
4. Captured the resulting `Units Short Text Editor` window with `tools/WinCapture` (`PrintWindow` API).
5. Inspected the captured window via UIAutomation — confirmed `EmptyStateLabel.IsOffscreen == False`; `EditorGrid` and `WriteButton` are hidden (auto-sized window shrank from 1622x1095 with garbage data to 1600x500 with the empty-state message only).

### Test Results
| Test | Expected | Actual | Status |
|------|----------|--------|--------|
| Standalone open of UnitsShortTextView on vanilla FE8U | List empty + "No data loaded." message + editor grid hidden | List empty + "No data loaded." message visible at y=292; editor grid hidden; Write button hidden | PASS |
| List shows real unit names (0x00 Eirika etc.) before fix | Garbage text IDs from death-quotes struct array interpreted as u16 text IDs | (Issue #372 screenshot — wrong data displayed) | (BEFORE — bug reproduced) |
| After fix: list returns 0 entries when standalone (no NavigateTo) | `GetListCount()` returns 0 | Empty `EntryList`; no items | PASS |
| Window auto-sizes correctly when empty | SizeToContent shrinks to empty-state message dimensions | 1600x500 with header + subtitle + "No data loaded." paragraph | PASS |

### Verdict
PASS — the death-quotes fallback is removed; the editor now shows a clear empty-state explanation instead of garbage data. `NavigateTo(address)` is preserved for future event-script / FELint callers.

## Test plan

- [x] 6 new regression-guard tests added in `FEBuilderGBA.Tests/Unit/AvaloniaEditorTests.cs` (`UnitsShortTextViewModel_DoesNotUseEventHaikuFallback`, `_GetListCountReturnsZeroWhenNoBaseAddr`, `_HasHasDataProperty`, `UnitsShortTextView_DoesNotHaveAutoInitEventHaiku`, `_HasEmptyStateAndEditorGrid`, `_HidesEditorGridWhenNoBaseAddr`) — all 6 fail on `origin/master` (RED) and pass on this branch (GREEN).
- [x] `dotnet build FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj -c Release` → 0 errors.
- [x] `dotnet test FEBuilderGBA.Tests/FEBuilderGBA.Tests.csproj` → 1709/1709 pass (1703 baseline + 6 new).
- [x] `dotnet test FEBuilderGBA.Core.Tests/FEBuilderGBA.Core.Tests.csproj` → 1293/1293 pass.
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests/FEBuilderGBA.Avalonia.Tests.csproj` → 4557/4562 pass (5 pre-existing skipped — unrelated).
- [x] GUI validation: launched Avalonia with `roms/FE8U.gba`, opened Unit Short Text Editor via UIAutomation, captured `PrintWindow` screenshot showing empty-state label + hidden editor grid.
- [x] WinForms `UnitsShortTextForm` untouched (pointer-driven contract preserved).
- [x] `AutomationProperties.AutomationId` preserved on existing controls; new `EmptyStateLabel` gets `UnitsShortText_EmptyState_Label`.
- [x] `AvaloniaDialogViewTests` UnitsShortTextView dimensions (1155x551) unchanged; `AvaloniaFieldCompletenessTests` field count regenerated (174 forms, 0 missing).

## Known limitations

- Avalonia's main-menu "Short Text" button still opens the editor standalone (no pointer). This is intentional in this PR: the editor now correctly reports "no data" instead of showing garbage. Wiring `POINTER_UNITSSHORTTEXT` from a future Avalonia event-script editor is out of scope (`docs/avalonia-gap-analysis.md` UnitsShortTextForm row updated to note this).

Generated with Claude Code (claude-opus-4-7[1m])
