### PR TITLE
fix(jump): Avalonia jumps select target ID instead of always defaulting to 0 (closes #362)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/AvaloniaJumpParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/AvaloniaJumpParityTests.cs
@@ -185,13 +185,16 @@ public class AvaloniaJumpParityTests
         Assert.Empty(stillBroken);
     }
 
-    [Fact(Skip = "Tracked in #362 — Jump action always selects 1st item.")]
+    [Fact]
     [Trait("KnownGap", "362")]
     public void Issue362_ItemEditor_EffectivenessJumpSelectsCorrectItem()
     {
-        // When fixed: ItemEditor → ItemEffectiveness jump will pre-select
-        // the referenced effectiveness table entry rather than landing on
-        // index 0.
+        // Fixed in #362: ItemEditor → ItemEffectiveness (SkillSystems Rework
+        // variant) jump now pre-selects the referenced effectiveness table
+        // entry rather than landing on index 0. The receiving view-model
+        // enumerates items by their P16 pointer so the source's
+        // `ptr - 0x08000000` matches a real list row.
+        // Asserts the IssueRef tag has been dropped from the manifest.
         var manifests = JumpParityScanner.ScanAvManifests(typeof(INavigationTargetSource).Assembly);
         var stillBroken = manifests.Where(m =>
                 m.SourceVm == "ItemEditorViewModel"

--- a/FEBuilderGBA.Avalonia.Tests/ItemEffectivenessSkillSystemsReworkJumpTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ItemEffectivenessSkillSystemsReworkJumpTests.cs
@@ -1,0 +1,259 @@
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Controls;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+/// <summary>
+/// Regression tests for issue #362: the Item Editor's Effectiveness Jump
+/// (Skill Systems Rework variant) previously opened
+/// <see cref="ItemEffectivenessSkillSystemsReworkView"/> with a stub list
+/// containing a single <c>AddrResult(addr=0, ...)</c>. Any non-zero target
+/// address from <c>JumpToEffectiveness_Click</c> never matched, so
+/// <c>AddressListControl.SelectAddress</c> silently fell back to the initial
+/// <c>SelectFirst()</c> selection (the stub).
+///
+/// After the fix the view-model enumerates items by their P16 effectiveness
+/// pointer (mirroring the WinForms <c>ItemEffectivenessSkillSystemsReworkForm</c>
+/// data model), so the address passed by the source side resolves cleanly to
+/// the correct list row.
+///
+/// Note: the SkillSystems Rework patch is normally absent from a vanilla
+/// FE8U.gba, but the view-model's <c>LoadList()</c> only looks at item-pointer
+/// metadata that exists for every ROM version (the patch detection happens at
+/// the source side that picks the variant to open). The tests therefore drive
+/// it against the unmodified FE8U ROM that <see cref="RomFixture"/> loads.
+/// </summary>
+[Collection("SharedState")]
+public class ItemEffectivenessSkillSystemsReworkJumpTests : IClassFixture<RomFixture>
+{
+    private readonly RomFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public ItemEffectivenessSkillSystemsReworkJumpTests(RomFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    /// <summary>
+    /// T1 — Affirmative regression: navigating to a real item's P16 offset
+    /// must select THAT row in the receiving view's list, not silently fall
+    /// back to entry 0.
+    /// </summary>
+    [AvaloniaFact]
+    public void NavigateToValidItemAddress_SelectsThatItem_NotEntryZero()
+    {
+        if (!_fixture.IsAvailable) return;
+
+        var seedVm = new ItemEffectivenessSkillSystemsReworkViewModel();
+        var list = seedVm.LoadList();
+        // Need at least two rows with DIFFERENT addresses to prove we're not
+        // coincidentally on index 0. Vanilla ROMs commonly have multiple
+        // items sharing the same effectiveness pointer (e.g. Rapier and a
+        // dummy slot), so we pick the first row whose addr differs from
+        // list[0].
+        uint firstAddr = list[0].addr;
+        int targetIndex = -1;
+        for (int i = 1; i < list.Count; i++)
+        {
+            if (list[i].addr != firstAddr)
+            {
+                targetIndex = i;
+                break;
+            }
+        }
+        if (targetIndex < 0)
+        {
+            _output.WriteLine($"No row with distinct addr from list[0]=0x{firstAddr:X08}; skipping.");
+            return;
+        }
+        uint targetAddr = list[targetIndex].addr;
+
+        Assert.NotEqual(firstAddr, targetAddr);
+        Assert.NotEqual(0u, targetAddr);
+
+        var view = new ItemEffectivenessSkillSystemsReworkView();
+        view.Show();
+        try
+        {
+            view.NavigateTo(targetAddr);
+
+            var ctrl = view.FindControl<AddressListControl>("EntryList");
+            Assert.NotNull(ctrl);
+            Assert.NotNull(ctrl!.SelectedItem);
+
+            _output.WriteLine($"Selected addr=0x{ctrl.SelectedItem!.addr:X08}, target=0x{targetAddr:X08}");
+
+            Assert.Equal(targetAddr, ctrl.SelectedItem!.addr);
+            Assert.NotEqual(firstAddr, ctrl.SelectedItem!.addr);
+        }
+        finally
+        {
+            view.Close();
+        }
+    }
+
+    /// <summary>
+    /// T2 — After navigating to a target address, the receiving view-model's
+    /// <c>CurrentAddr</c> must match the navigated address (set via the
+    /// <c>SelectedAddressChanged → OnSelected → LoadEntry</c> chain).
+    /// Accesses the view-model via the newly-exposed <c>DataViewModel</c>
+    /// property.
+    /// </summary>
+    [AvaloniaFact]
+    public void NavigateToValidItemAddress_VmCurrentAddrMatchesTarget()
+    {
+        if (!_fixture.IsAvailable) return;
+
+        var seedVm = new ItemEffectivenessSkillSystemsReworkViewModel();
+        var list = seedVm.LoadList();
+        // Same selection logic as T1 — pick the first row whose addr differs
+        // from list[0] so the assertion is meaningful.
+        uint firstAddr = list.Count > 0 ? list[0].addr : 0;
+        int targetIndex = -1;
+        for (int i = 1; i < list.Count; i++)
+        {
+            if (list[i].addr != firstAddr)
+            {
+                targetIndex = i;
+                break;
+            }
+        }
+        if (targetIndex < 0)
+        {
+            _output.WriteLine($"No row with distinct addr from list[0]; skipping.");
+            return;
+        }
+        uint targetAddr = list[targetIndex].addr;
+
+        var view = new ItemEffectivenessSkillSystemsReworkView();
+        view.Show();
+        try
+        {
+            view.NavigateTo(targetAddr);
+
+            var ctrl = view.FindControl<AddressListControl>("EntryList");
+            Assert.NotNull(ctrl);
+            Assert.NotNull(ctrl!.SelectedItem);
+            Assert.Equal(targetAddr, ctrl.SelectedItem!.addr);
+
+            var vm = view.DataViewModel as ItemEffectivenessSkillSystemsReworkViewModel;
+            Assert.NotNull(vm);
+            Assert.Equal(targetAddr, vm!.CurrentAddr);
+        }
+        finally
+        {
+            view.Close();
+        }
+    }
+
+    /// <summary>
+    /// T3 — Proves the stub is gone: the list count must exceed 1 on FE8U
+    /// (which has many items with valid P16 pointers). Before the fix this
+    /// returned exactly 1 entry (the stub).
+    /// </summary>
+    [Fact]
+    public void LoadList_PopulatesMoreThanOneItem()
+    {
+        if (!_fixture.IsAvailable) return;
+        if (_fixture.Version != "FE8U")
+        {
+            _output.WriteLine($"This test is FE8U-specific (ROM is {_fixture.Version}); skipping.");
+            return;
+        }
+
+        var vm = new ItemEffectivenessSkillSystemsReworkViewModel();
+        var list = vm.LoadList();
+        _output.WriteLine($"LoadList returned {list.Count} entries on FE8U");
+        Assert.True(list.Count > 1,
+            $"Expected more than 1 entry on FE8U after fix; got {list.Count} (stub list?)");
+    }
+
+    /// <summary>
+    /// T4 — Every emitted entry's address must be non-zero AND inside the ROM
+    /// safety range. Catches any iteration regression that lets addr=0 entries
+    /// (the old stub shape) slip through.
+    /// </summary>
+    [Fact]
+    public void LoadList_EveryEntry_HasValidEffectivenessPointer()
+    {
+        if (!_fixture.IsAvailable) return;
+
+        var vm = new ItemEffectivenessSkillSystemsReworkViewModel();
+        var list = vm.LoadList();
+        foreach (var entry in list)
+        {
+            Assert.NotEqual(0u, entry.addr);
+            Assert.True(U.isSafetyOffset(entry.addr),
+                $"Entry name='{entry.name}' addr=0x{entry.addr:X08} fails U.isSafetyOffset");
+        }
+    }
+
+    /// <summary>
+    /// T5 — Defensive smoke test: <c>LoadList()</c> must return a usable
+    /// <c>List&lt;AddrResult&gt;</c> (possibly empty) regardless of ROM
+    /// version, without throwing. <c>RomFixture</c> prefers FE8U but the
+    /// view-model must remain safe to call on any of the five supported ROM
+    /// variants (the patch detection happens elsewhere; this VM only reads
+    /// item-pointer metadata that exists for every ROM).
+    /// </summary>
+    [Fact]
+    public void LoadList_OnAnyRom_DoesNotCrash()
+    {
+        if (!_fixture.IsAvailable) return;
+
+        var vm = new ItemEffectivenessSkillSystemsReworkViewModel();
+        var list = vm.LoadList();
+        Assert.NotNull(list);
+        _output.WriteLine($"ROM={_fixture.Version}, LoadList returned {list.Count} entries");
+    }
+
+    /// <summary>
+    /// T6 — Verify the source's <c>JumpToEffectiveness_Click</c> offset
+    /// (<c>ptr - 0x08000000</c>) matches at least one address in the new list
+    /// for items that have valid P16 pointers. This is the end-to-end address
+    /// alignment proof that #362 was failing on.
+    /// </summary>
+    [Fact]
+    public void JumpAddress_MatchesAnEntryInList_ForItemsWithEffectiveness()
+    {
+        if (!_fixture.IsAvailable) return;
+
+        var itemVm = new ItemEditorViewModel();
+        var items = itemVm.LoadItemList();
+
+        var effVm = new ItemEffectivenessSkillSystemsReworkViewModel();
+        var effList = effVm.LoadList();
+        if (effList.Count == 0)
+        {
+            _output.WriteLine("No effectiveness entries on this ROM; skipping.");
+            return;
+        }
+
+        int sampled = 0;
+        int matched = 0;
+        for (int i = 1; i < items.Count; i++)
+        {
+            itemVm.LoadItem(items[i].addr);
+            if (itemVm.EffectivenessPtr == 0) continue;
+            if (!U.isPointer(itemVm.EffectivenessPtr)) continue;
+            uint targetOffset = itemVm.EffectivenessPtr - 0x08000000;
+            if (!U.isSafetyOffset(targetOffset)) continue;
+
+            sampled++;
+            if (effList.Any(e => e.addr == targetOffset)) matched++;
+            if (sampled >= 10) break;
+        }
+
+        _output.WriteLine($"Sampled {sampled} items with valid P16, {matched} matched the new list");
+        Assert.True(sampled > 0, "Expected to sample at least one item with valid P16");
+        Assert.Equal(sampled, matched);
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/ItemEffectivenessSkillSystemsReworkJumpTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ItemEffectivenessSkillSystemsReworkJumpTests.cs
@@ -58,7 +58,13 @@ public class ItemEffectivenessSkillSystemsReworkJumpTests : IClassFixture<RomFix
         // coincidentally on index 0. Vanilla ROMs commonly have multiple
         // items sharing the same effectiveness pointer (e.g. Rapier and a
         // dummy slot), so we pick the first row whose addr differs from
-        // list[0].
+        // list[0]. Empty / single-row lists skip cleanly — they cannot
+        // demonstrate "select non-first" by construction.
+        if (list.Count < 2)
+        {
+            _output.WriteLine($"List has only {list.Count} entries; cannot test non-first selection.");
+            return;
+        }
         uint firstAddr = list[0].addr;
         int targetIndex = -1;
         for (int i = 1; i < list.Count; i++)

--- a/FEBuilderGBA.Avalonia/ViewModels/ItemEditorViewModel.NavigationTargets.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ItemEditorViewModel.NavigationTargets.cs
@@ -16,9 +16,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         // ----------------------------------------------------------------
         // INavigationTargetSource — Phase 4 (#374). Mirror the navigation
         // callsites in ItemEditorView.axaml.cs WITHOUT changing actual
-        // navigation behavior. Tagged jumps are known-broken per issues
-        // #362 (jump always selects 1st item) and #363 (Effectiveness jump
-        // takes wrong address + previews are wrong).
+        // navigation behavior. The Effectiveness jump for the vanilla path
+        // is still known-broken (#363 — wrong address + preview icons);
+        // the SkillSystems Rework path was fixed by #362.
         // ----------------------------------------------------------------
         public IReadOnlyList<NavigationTarget> GetNavigationTargets()
         {
@@ -54,16 +54,17 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                     TargetViewType: typeof(ItemStatBonusesViewerView),
                     TargetAddress: null),
 
-                // Known-broken (#362, #363): Effectiveness jump opens the
-                // right editor type but lands on the first entry instead of
-                // the referenced effectiveness table, and the preview icons
-                // are wrong. Two patch-conditional targets mirror the actual
-                // callsites in ItemEditorView.JumpToEffectiveness_Click.
+                // Effectiveness jumps split by patch state. The Skill Systems
+                // Rework path was fixed by #362 — the receiving view-model
+                // now enumerates items by their P16 pointer so the address
+                // passed by ItemEditorView.JumpToEffectiveness_Click matches
+                // a real list row. The vanilla path is still known-broken
+                // under #363 (sacred-weapons-table base address + wrong
+                // preview icons).
                 new NavigationTarget(
                     CommandName: "JumpToEffectivenessSkillSystem",
                     TargetViewType: typeof(ItemEffectivenessSkillSystemsReworkView),
-                    TargetAddress: null,
-                    IssueRef: "#362"),
+                    TargetAddress: null),
                 new NavigationTarget(
                     CommandName: "JumpToEffectivenessVanilla",
                     TargetViewType: typeof(ItemEffectivenessViewerView),

--- a/FEBuilderGBA.Avalonia/ViewModels/ItemEffectivenessSkillSystemsReworkViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ItemEffectivenessSkillSystemsReworkViewModel.cs
@@ -24,11 +24,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// (and the existing Avalonia <c>ItemStatBonusesViewerViewModel</c>)
         /// iteration semantics: walk the item table by
         /// <c>itemBase + i * item_datasize</c> using the dereferenced
-        /// <c>item_pointer</c>, <see cref="System.Linq.Enumerable.Break"/> on
-        /// the first row whose P12 or P16 is not pointer-or-null (mirroring
-        /// <c>InputFormRef.DataCount</c> termination), and
-        /// <see cref="System.Linq.Enumerable.Skip"/> rows whose P16 is null /
-        /// zero / out-of-range (item carries no effectiveness data).
+        /// <c>item_pointer</c>. The loop <c>break</c>s on the first row whose
+        /// P12 or P16 is not pointer-or-null (mirroring
+        /// <c>InputFormRef.DataCount</c> termination), and <c>continue</c>s
+        /// past rows whose P16 is null / zero / out-of-range (the item is
+        /// valid but carries no effectiveness data — nothing to navigate to).
         /// </summary>
         public List<AddrResult> LoadList()
         {

--- a/FEBuilderGBA.Avalonia/ViewModels/ItemEffectivenessSkillSystemsReworkViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ItemEffectivenessSkillSystemsReworkViewModel.cs
@@ -11,13 +11,65 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
 
+        /// <summary>
+        /// Enumerate items that have a valid P16 (item effectiveness) pointer.
+        /// Each emitted <see cref="AddrResult"/> uses the P16 ROM offset as its
+        /// <c>addr</c>, so the address passed by
+        /// <c>ItemEditorView.JumpToEffectiveness_Click</c> (which is
+        /// <c>ptr - 0x08000000</c>) matches a list row directly and the
+        /// receiving editor's selection lands on the correct item — not the
+        /// previous stub at index 0 (issue #362).
+        ///
+        /// Mirrors the WinForms <c>ItemEffectivenessSkillSystemsReworkForm</c>
+        /// (and the existing Avalonia <c>ItemStatBonusesViewerViewModel</c>)
+        /// iteration semantics: walk the item table by
+        /// <c>itemBase + i * item_datasize</c> using the dereferenced
+        /// <c>item_pointer</c>, <see cref="System.Linq.Enumerable.Break"/> on
+        /// the first row whose P12 or P16 is not pointer-or-null (mirroring
+        /// <c>InputFormRef.DataCount</c> termination), and
+        /// <see cref="System.Linq.Enumerable.Skip"/> rows whose P16 is null /
+        /// zero / out-of-range (item carries no effectiveness data).
+        /// </summary>
         public List<AddrResult> LoadList()
         {
             ROM rom = CoreState.ROM;
             if (rom?.RomInfo == null) return new List<AddrResult>();
 
+            uint itemPtr = rom.RomInfo.item_pointer;
+            if (itemPtr == 0) return new List<AddrResult>();
+
+            uint itemBase = rom.p32(itemPtr);
+            if (!U.isSafetyOffset(itemBase)) return new List<AddrResult>();
+
+            uint dataSize = rom.RomInfo.item_datasize;
+            if (dataSize == 0) return new List<AddrResult>();
+
             var result = new List<AddrResult>();
-            result.Add(new AddrResult(0, "Effectiveness (Skill Systems Rework)", 0));
+            for (uint i = 0; i < 0x200; i++)
+            {
+                uint itemAddr = (uint)(itemBase + i * dataSize);
+                if (itemAddr + dataSize > (uint)rom.Data.Length) break;
+
+                // Mirror WinForms InputFormRef.DataCount termination: data
+                // table ends on the first row whose P12 (offset +12) or P16
+                // (offset +16) is not pointer-or-null. Both must be valid for
+                // the row to count as an item.
+                if (!U.isPointerOrNULL(rom.u32(itemAddr + 12))) break;
+                if (!U.isPointerOrNULL(rom.u32(itemAddr + 16))) break;
+
+                // Skip rows where P16 is null/zero or not a real pointer —
+                // the item is valid but carries no effectiveness data, so
+                // there is nothing to navigate to.
+                uint criticalPtr = rom.u32(itemAddr + 16);
+                if (!U.isPointer(criticalPtr)) continue;
+
+                uint criticalAddr = U.toOffset(criticalPtr);
+                if (!U.isSafetyOffset(criticalAddr)) continue;
+
+                string itemName = NameResolver.GetItemName(i);
+                string name = $"{U.ToHexString(i)} {itemName}";
+                result.Add(new AddrResult(criticalAddr, name, i));
+            }
             return result;
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ItemEffectivenessSkillSystemsReworkView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemEffectivenessSkillSystemsReworkView.axaml.cs
@@ -13,6 +13,14 @@ namespace FEBuilderGBA.Avalonia.Views
         public string ViewTitle => "Effectiveness (Skill Systems Rework)";
         public bool IsLoaded => _vm.IsLoaded;
 
+        /// <summary>
+        /// Exposes the backing view-model for headless test access (issue #362
+        /// regression tests assert <c>vm.CurrentAddr</c> matches the navigated
+        /// address). Mirrors the <c>DataViewModel</c> pattern used by
+        /// <see cref="ItemStatBonusesViewerView"/> and the other editor views.
+        /// </summary>
+        public ViewModelBase? DataViewModel => _vm;
+
         public ItemEffectivenessSkillSystemsReworkView()
         {
             InitializeComponent();
@@ -25,7 +33,10 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 var items = _vm.LoadList();
-                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ClassIconLoader(items, i));
+                // Item-keyed list — render item icons, not class icons
+                // (the list rows are item names + IDs, mirroring the WinForms
+                // ItemEffectivenessSkillSystemsReworkForm outer list).
+                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ItemIconLoader(items, i));
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Avalonia/Views/ItemEffectivenessSkillSystemsReworkView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemEffectivenessSkillSystemsReworkView.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ItemEffectivenessSkillSystemsReworkView : TranslatedWindow, IEditorView
+    public partial class ItemEffectivenessSkillSystemsReworkView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ItemEffectivenessSkillSystemsReworkViewModel _vm = new();
 


### PR DESCRIPTION
## Summary

Fixes #362 — the Avalonia Item Editor's **Effectiveness (P16) Jump button** (Skill Systems Rework variant) was opening `ItemEffectivenessSkillSystemsReworkView` but always selecting the same single stub row regardless of which item the user came from. The receiving view-model's `LoadList()` returned a single placeholder `AddrResult(addr=0, "Effectiveness (Skill Systems Rework)", 0)`, so `AddressListControl.SelectAddress(<real ptr offset>)` linearly scanned the list, found no match, and silently left the initial `SelectFirst()` selection (the stub) in place.

This is the **same architectural failure mode as #344**: the receiving editor's list does not contain entries whose `AddrResult.addr` matches what the source jump passes. The vanilla `JumpToEffectivenessVanilla` path (sacred-weapons-table base address + wrong preview icons) is a sibling bug tracked separately by **#363** and is out of scope.

The fix mirrors the WinForms `ItemEffectivenessSkillSystemsReworkForm` data model — also identical to the existing Avalonia `ItemStatBonusesViewerViewModel.LoadItemStatBonusesList()` iteration but keyed on offset +16 instead of +12. The receiver's address space now aligns 1-to-1 with what `ItemEditorView.JumpToEffectiveness_Click` already passes (`ptr - 0x08000000`), so the SelectAddress linear scan finds a real row and the editor lands on the correct item.

Secondary defects fixed in the same commit (Copilot CLI plan-review v1 + v2 findings):

- The rework view was using `ListIconLoaders.ClassIconLoader` for an item-keyed list — switched to `ItemIconLoader` so each row renders its item icon instead of trying to look up a class icon by item ID.
- Exposed `DataViewModel` on the view (mirroring `ItemStatBonusesViewerView`) so headless tests can assert `vm.CurrentAddr` matches the navigated address.
- Updated the `ItemEditorViewModel.NavigationTargets.cs` block comment to remove the `#362` reference now that the SkillSystems path is fixed; only `#363` (vanilla path) remains documented as known-broken.

Plan: https://github.com/laqieer/FEBuilderGBA/issues/362#issuecomment-4516964709
Copilot CLI plan approval (v3): https://github.com/laqieer/FEBuilderGBA/issues/362#issuecomment-4517096780

## Plan Reference

Implements the v3 plan that incorporated both rounds of Copilot CLI feedback (6 findings total). Pattern matches the #344 -> #346 fix.

## Scope

Closes #362
Ref #363 (sibling — out of scope, separate PR)

## Screenshots

**Before** (single stub entry "Effectiveness (Skill Systems Rework)" — every jump silently lands on this row, regardless of source item):

![Before — single stub entry](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr362-effectiveness-rework-before.png)

**After** (40 items populated, each keyed on its real P16 offset; the receiver's `SelectAddress` can now resolve the source jump's address to the matching row):

![After — populated item list](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr362-effectiveness-rework-after.png)

(Companion docs PR #454 landed the images on `master` so the URLs above remain stable post-merge.)

## GUI Test Report

GUI files were modified (`FEBuilderGBA.Avalonia/Views/ItemEffectivenessSkillSystemsReworkView.axaml.cs`), so a GUI test report is required.

### Environment

- ROM: `roms/FE8U.gba`
- View: `ItemEffectivenessSkillSystemsReworkView` (opened via Main hub → Effectiveness (Rework) button)
- Tooling: PrintWindow API (`tools/WinCapture`) + PowerShell `UIAutomationClient`

### Steps performed

1. Launched `FEBuilderGBA.Avalonia.exe --rom roms/FE8U.gba`.
2. Used UIAutomation to click the `Main_EffectivenessRework_Button` button in the main hub.
3. Resized the view to 800x900 via `MoveWindow` for full readability of the list.
4. Captured the Effectiveness (Skill Systems Rework) window with `tools/WinCapture`.
5. Re-ran the same flow against `origin/master` (no fix) to capture the `before` baseline.

### Test results

| # | Test case | Expected | Actual | Status |
|---|---|---|---|---|
| 1 | Pre-fix: open Effectiveness (Rework) view | List shows one stub row "Effectiveness (Skill Systems Rework)" | Confirmed in `pr362-effectiveness-rework-before.png` — the list has exactly one row, selected by default | PASS |
| 2 | Post-fix: open Effectiveness (Rework) view on FE8U | List shows real items (Rapier, Dummy, Armorslayer, ...) with item icons | Confirmed in `pr362-effectiveness-rework-after.png` — list has 40 entries; first nine visible: 09 Rapier, 0A Dummy, 0E Armorslayer, 0F Wyrmslayer, 13 Zanbato, 1B Horseslayer, 25 Halberd, 26 Hammer, 2B Swordslayer | PASS |
| 3 | Post-fix: list items render correct icon (item icon, not class icon) | Each row shows the item's icon (sword/lance/axe sprite) | Confirmed in the `after` screenshot — every row has its item icon | PASS |
| 4 | Headless T1: `NavigateToValidItemAddress_SelectsThatItem_NotEntryZero` | Selecting addr != list[0].addr -> SelectedItem.addr == target AND != first | PASS (14 ms) | PASS |
| 5 | Headless T2: `NavigateToValidItemAddress_VmCurrentAddrMatchesTarget` | After NavigateTo, view-model CurrentAddr matches target | PASS (609 ms) | PASS |
| 6 | Headless T3: `LoadList_PopulatesMoreThanOneItem` | LoadList returns > 1 entries on FE8U | PASS (< 1 ms) — 40 entries | PASS |
| 7 | Headless T4: `LoadList_EveryEntry_HasValidEffectivenessPointer` | Every emitted entry has non-zero addr inside ROM safety range | PASS (< 1 ms) | PASS |
| 8 | Headless T5: `LoadList_OnAnyRom_DoesNotCrash` | Defensive smoke — list returns non-null on any ROM | PASS (< 1 ms) | PASS |
| 9 | Headless T6: `JumpAddress_MatchesAnEntryInList_ForItemsWithEffectiveness` | For items with valid P16, `ptr - 0x08000000` matches a list row | PASS (44 ms) — all sampled items matched | PASS |

### Verdict

PASS — the receiving view-model now produces a list whose `AddrResult.addr` values align with the source jump's address, so `SelectAddress` resolves to the correct row and the editor lands on the intended item instead of falling back to entry 0.

## Test plan

- [x] `dotnet build FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj -c Release` — 0 errors
- [x] `dotnet build FEBuilderGBA.Avalonia.Tests/FEBuilderGBA.Avalonia.Tests.csproj -c Release` — 0 errors
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests --filter "FullyQualifiedName~ItemEffectivenessSkillSystemsReworkJumpTests"` — 6/6 PASS
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests --filter "FullyQualifiedName~ClassEditorMoveCostJumpTests"` — 8/8 PASS (no regression on the #346 fix)
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests --filter "FullyQualifiedName~AvaloniaJumpParityTests"` — 41/41 PASS (now includes the previously-skipped `Issue362_ItemEditor_EffectivenessJumpSelectsCorrectItem` regression)
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests --filter "FullyQualifiedName~CrossEditorNavigationTests"` — full set passes
- [x] `dotnet test FEBuilderGBA.Core.Tests/FEBuilderGBA.Core.Tests.csproj` — 1293/1293 PASS
- [x] Manual GUI: opened the Effectiveness (Rework) view via Main hub on FE8U.gba — list shows 40 items with their icons (captured in `pr362-effectiveness-rework-after.png`)
- [x] Manual GUI baseline: same flow on `origin/master` — list shows the single stub row (captured in `pr362-effectiveness-rework-before.png`)

## Known limitations

- The Skill Systems Rework patch is normally absent from a vanilla FE8U ROM, so the receiving view is reachable in production GUIs only when the patch is installed. The view-model's `LoadList()` only reads item-pointer metadata that exists for every ROM version, so it's safe to call on any ROM — see test T5.
- `LoadEntry(addr)` in the rework view-model still only sets `CurrentAddr` / `IsLoaded` and does not parse the effectiveness array bytes; that's a separate gap (the rework data structure has 4-byte stride class-type entries). Selection is what #362 asks for and that's what this PR fixes.

---
Generated with Claude Code (claude-opus-4-7[1m])
