### PR TITLE
feat(support-talk): show both unit portraits in preview list (closes #361)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/PreviewIconHelperPortraitPairTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/PreviewIconHelperPortraitPairTests.cs
@@ -188,6 +188,38 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.Null(pair);
         }
 
+        /// <summary>
+        /// Issue #361 follow-up: FE6 stores the mini-face image data
+        /// uncompressed (FE7/FE8 LZ77-compress it). LoadPortraitMini must
+        /// detect FE6 and skip the LZ77 step, otherwise it returns null
+        /// and the FE6 Support Talk list never shows portrait icons.
+        /// </summary>
+        [Fact]
+        public void LoadPortraitMini_RendersOnFE6()
+        {
+            if (!_fixture.IsAvailable || _fixture.Version != "FE6")
+            {
+                _output.WriteLine($"SKIP: FE6.gba unavailable (have {_fixture.Version})");
+                return;
+            }
+            using var _ = EnsureImageService();
+
+            // Roy is portrait 1 on FE6. The portrait must decode to a 32x32
+            // indexed image. Before this fix LoadPortraitMini returned null
+            // (LZ77 decompression failed on the uncompressed data).
+            using var roy = PreviewIconHelper.LoadPortraitMini(1);
+            Assert.NotNull(roy);
+            Assert.Equal(32, roy!.Width);
+            Assert.Equal(32, roy.Height);
+            Assert.True(roy.IsIndexed, "FE6 mini portrait should be indexed");
+
+            // Sanity: at least some pixels should be non-zero (real artwork).
+            byte[] data = roy.GetPixelData();
+            bool anyNonZero = false;
+            foreach (byte b in data) { if (b != 0) { anyNonZero = true; break; } }
+            Assert.True(anyNonZero, "FE6 portrait must render non-trivial content");
+        }
+
         [Fact]
         public void LoadPortraitMiniPair_OnlyLeftPortrait_RightHalfTransparent_FE8U()
         {
@@ -288,24 +320,31 @@ namespace FEBuilderGBA.Avalonia.Tests
                     Assert.NotEqual(expectedRgba, wrongRgba);
                 }
 
-                // Call the loader with FE8 offset.
-                // Use the internal pixel-equality path by reading the bytes
-                // mirroring exactly what the loader does, so we don't depend
-                // on Avalonia headless rendering being initialized.
-                uint addr0 = items[0].addr;
-                Assert.True(U.isSafetyOffset(addr0 + 2));
-                uint uid1 = rom.u8(addr0);
-                uint uid2 = rom.u8(addr0 + 2);
-                Assert.Equal(1u, uid1);
-                Assert.Equal(2u, uid2);
-
-                using var actual = PreviewIconHelper.LoadPortraitMiniPair(
-                    PreviewIconHelper.ResolveUnitPortraitIdByUnitId(uid1),
-                    PreviewIconHelper.ResolveUnitPortraitIdByUnitId(uid2));
+                // Call the ACTUAL loader (not a manual reconstruction) so
+                // the offset-reading logic is under test (Copilot review
+                // item). UnitPortraitPairFromAddrU8LoaderInternal returns
+                // the raw IImage produced by the loader's ROM-byte path,
+                // skipping the Avalonia Bitmap conversion so we don't
+                // depend on headless rendering being initialized.
+                using var actual = ListIconLoaders.UnitPortraitPairFromAddrU8LoaderInternal(
+                    items, 0, unit2Offset: 2);
                 Assert.NotNull(actual);
                 byte[] actualRgba = actual!.GetPixelData();
                 Assert.Equal(expectedRgba.Length, actualRgba.Length);
                 Assert.Equal(expectedRgba, actualRgba);
+
+                // Negative cross-check: if we ask the loader to use the
+                // WRONG offset (1 instead of 2) it should produce a
+                // DIFFERENT pair (the decoy uid 99). This proves the loader
+                // genuinely depends on unit2Offset, so a regression that
+                // hardcoded the wrong offset would fail.
+                using var wrongOffsetActual = ListIconLoaders.UnitPortraitPairFromAddrU8LoaderInternal(
+                    items, 0, unit2Offset: 1);
+                if (wrongOffsetActual != null && wrong != null)
+                {
+                    byte[] wrongOffsetRgba = wrongOffsetActual.GetPixelData();
+                    Assert.NotEqual(expectedRgba, wrongOffsetRgba);
+                }
             }
             finally
             {
@@ -387,10 +426,28 @@ namespace FEBuilderGBA.Avalonia.Tests
                     Assert.NotEqual(expectedRgba, decoyRgba);
                 }
 
-                // Now call the actual loader (offset=1) and assert pixel equality.
-                using var actual = PreviewIconHelper.LoadPortraitMiniPair(pid1, pid2);
+                // Now call the ACTUAL loader (not a manual reconstruction)
+                // with unit2Offset=1 — the loader must read uid2 from
+                // items[0].addr+1, NOT addr+2, to satisfy the FE6/FE7
+                // contract (Copilot review item). The loader's internal
+                // helper returns IImage so we don't need Avalonia headless.
+                using var actual = ListIconLoaders.UnitPortraitPairFromAddrU8LoaderInternal(
+                    items, 0, unit2Offset: 1);
                 Assert.NotNull(actual);
                 Assert.Equal(expectedRgba, actual!.GetPixelData());
+
+                // Negative cross-check: with unit2Offset=2 the loader would
+                // pick up the decoy (uid 99) instead of the real partner
+                // (uid 2), so the output MUST differ from the expected pair.
+                // This proves the loader genuinely depends on the offset
+                // argument and a regression hardcoding offset=2 would fail.
+                using var wrongOffsetActual = ListIconLoaders.UnitPortraitPairFromAddrU8LoaderInternal(
+                    items, 0, unit2Offset: 2);
+                if (wrongOffsetActual != null)
+                {
+                    byte[] wrongOffsetRgba = wrongOffsetActual.GetPixelData();
+                    Assert.NotEqual(expectedRgba, wrongOffsetRgba);
+                }
             }
             finally
             {

--- a/FEBuilderGBA.Avalonia.Tests/PreviewIconHelperPortraitPairTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/PreviewIconHelperPortraitPairTests.cs
@@ -1,0 +1,465 @@
+using System;
+using System.Collections.Generic;
+using global::Avalonia.Headless.XUnit;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.SkiaSharp;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="PreviewIconHelper.LoadPortraitMiniPair"/> and
+    /// <see cref="ListIconLoaders.UnitPortraitPairFromAddrU8Loader"/>.
+    ///
+    /// Covers issue #361: the Support Talk Editor (Avalonia) only showed the
+    /// first unit's portrait per row. Each support entry references TWO units
+    /// at version-specific offsets:
+    ///   - FE8     : uid1 @ addr+0, uid2 @ addr+2
+    ///   - FE6/FE7 : uid1 @ addr+0, uid2 @ addr+1
+    /// Both portraits should be rendered side-by-side.
+    ///
+    /// Pattern mirrors <see cref="PreviewIconHelperWeaponTypeTests"/> (PR #370).
+    /// Pixel-equality comparisons use <see cref="IImage.GetPixelData"/> directly,
+    /// not Avalonia bitmap internals, to keep tests independent of headless
+    /// rendering setup.
+    /// </summary>
+    [Collection("SharedState")]
+    public class PreviewIconHelperPortraitPairTests : IClassFixture<RomFixture>
+    {
+        private readonly RomFixture _fixture;
+        private readonly ITestOutputHelper _output;
+
+        public PreviewIconHelperPortraitPairTests(RomFixture fixture, ITestOutputHelper output)
+        {
+            _fixture = fixture;
+            _output = output;
+        }
+
+        /// <summary>
+        /// Ensure CoreState.ImageService is wired so PreviewIconHelper can
+        /// decode 4bpp tiles and create RGBA canvases. RomFixture itself does
+        /// not register an image service (CLI path used by RomLoader does not
+        /// need rendering).
+        /// </summary>
+        static IDisposable EnsureImageService()
+        {
+            var prev = CoreState.ImageService;
+            if (prev == null)
+                CoreState.ImageService = new SkiaImageService();
+            return new RestoreImageService(prev);
+        }
+
+        sealed class RestoreImageService : IDisposable
+        {
+            private readonly IImageService? _prev;
+            public RestoreImageService(IImageService? prev) { _prev = prev; }
+            public void Dispose() { CoreState.ImageService = _prev; }
+        }
+
+        // ------------------------------------------------------------------
+        // LoadPortraitMiniPair — render-layer tests
+        // ------------------------------------------------------------------
+
+        [Fact]
+        public void LoadPortraitMiniPair_ReturnsCorrectDimensions_FE8U()
+        {
+            if (!_fixture.IsAvailable || _fixture.Version != "FE8U")
+            {
+                _output.WriteLine($"SKIP: FE8U.gba unavailable (have {_fixture.Version})");
+                return;
+            }
+
+            using var _ = EnsureImageService();
+
+            // Use the first known-good portrait pair: Eirika (portrait 1) + Ephraim (portrait 2).
+            using var pair = PreviewIconHelper.LoadPortraitMiniPair(1, 2);
+            Assert.NotNull(pair);
+            Assert.Equal(64, pair!.Width);
+            Assert.Equal(32, pair.Height);
+            Assert.False(pair.IsIndexed, "Pair output must be RGBA (portraits have per-portrait palettes)");
+        }
+
+        [Fact]
+        public void LoadPortraitMiniPair_LeftHalfMatchesPortrait1_FE8U()
+        {
+            if (!_fixture.IsAvailable || _fixture.Version != "FE8U")
+            {
+                _output.WriteLine($"SKIP: FE8U.gba unavailable (have {_fixture.Version})");
+                return;
+            }
+            using var _ = EnsureImageService();
+
+            // Render portrait 1 standalone, then build the pair (portrait 1, portrait 2).
+            // The left 32x32 region of the pair must equal portrait 1 expanded to RGBA.
+            using var solo1 = PreviewIconHelper.LoadPortraitMini(1);
+            Assert.NotNull(solo1);
+            byte[] solo1Indices = solo1!.GetPixelData();
+            byte[] solo1PaletteRgba = solo1.GetPaletteRGBA();
+
+            using var pair = PreviewIconHelper.LoadPortraitMiniPair(1, 2);
+            Assert.NotNull(pair);
+            byte[] pairRgba = pair!.GetPixelData();
+            Assert.Equal(64 * 32 * 4, pairRgba.Length);
+
+            // Left half of the pair (x in 0..31)
+            for (int y = 0; y < 32; y++)
+            {
+                for (int x = 0; x < 32; x++)
+                {
+                    byte idx = solo1Indices[y * 32 + x];
+                    int palOff = idx * 4;
+                    byte er = solo1PaletteRgba[palOff];
+                    byte eg = solo1PaletteRgba[palOff + 1];
+                    byte eb = solo1PaletteRgba[palOff + 2];
+                    byte ea = solo1PaletteRgba[palOff + 3];
+
+                    int dstOff = (y * 64 + x) * 4;
+                    byte ar = pairRgba[dstOff];
+                    byte ag = pairRgba[dstOff + 1];
+                    byte ab = pairRgba[dstOff + 2];
+                    byte aa = pairRgba[dstOff + 3];
+
+                    Assert.Equal(er, ar);
+                    Assert.Equal(eg, ag);
+                    Assert.Equal(eb, ab);
+                    Assert.Equal(ea, aa);
+                }
+            }
+        }
+
+        [Fact]
+        public void LoadPortraitMiniPair_RightHalfMatchesPortrait2_FE8U()
+        {
+            if (!_fixture.IsAvailable || _fixture.Version != "FE8U")
+            {
+                _output.WriteLine($"SKIP: FE8U.gba unavailable (have {_fixture.Version})");
+                return;
+            }
+            using var _ = EnsureImageService();
+
+            using var solo2 = PreviewIconHelper.LoadPortraitMini(2);
+            Assert.NotNull(solo2);
+            byte[] solo2Indices = solo2!.GetPixelData();
+            byte[] solo2PaletteRgba = solo2.GetPaletteRGBA();
+
+            using var pair = PreviewIconHelper.LoadPortraitMiniPair(1, 2);
+            Assert.NotNull(pair);
+            byte[] pairRgba = pair!.GetPixelData();
+
+            // Right half of the pair (x in 32..63)
+            for (int y = 0; y < 32; y++)
+            {
+                for (int x = 0; x < 32; x++)
+                {
+                    byte idx = solo2Indices[y * 32 + x];
+                    int palOff = idx * 4;
+                    byte er = solo2PaletteRgba[palOff];
+                    byte eg = solo2PaletteRgba[palOff + 1];
+                    byte eb = solo2PaletteRgba[palOff + 2];
+                    byte ea = solo2PaletteRgba[palOff + 3];
+
+                    int dstOff = (y * 64 + (32 + x)) * 4;
+                    byte ar = pairRgba[dstOff];
+                    byte ag = pairRgba[dstOff + 1];
+                    byte ab = pairRgba[dstOff + 2];
+                    byte aa = pairRgba[dstOff + 3];
+
+                    Assert.Equal(er, ar);
+                    Assert.Equal(eg, ag);
+                    Assert.Equal(eb, ab);
+                    Assert.Equal(ea, aa);
+                }
+            }
+        }
+
+        [Fact]
+        public void LoadPortraitMiniPair_BothZeroIds_ReturnsNull()
+        {
+            if (!_fixture.IsAvailable)
+            {
+                _output.WriteLine("SKIP: no ROM available");
+                return;
+            }
+            using var _ = EnsureImageService();
+
+            using var pair = PreviewIconHelper.LoadPortraitMiniPair(0, 0);
+            Assert.Null(pair);
+        }
+
+        [Fact]
+        public void LoadPortraitMiniPair_OnlyLeftPortrait_RightHalfTransparent_FE8U()
+        {
+            if (!_fixture.IsAvailable || _fixture.Version != "FE8U")
+            {
+                _output.WriteLine($"SKIP: FE8U.gba unavailable (have {_fixture.Version})");
+                return;
+            }
+            using var _ = EnsureImageService();
+
+            using var pair = PreviewIconHelper.LoadPortraitMiniPair(1, 0);
+            Assert.NotNull(pair);
+            byte[] rgba = pair!.GetPixelData();
+
+            // Right half (x in 32..63) must be fully transparent (RGBA = 0,0,0,0)
+            for (int y = 0; y < 32; y++)
+            {
+                for (int x = 32; x < 64; x++)
+                {
+                    int off = (y * 64 + x) * 4;
+                    Assert.Equal(0, rgba[off]);
+                    Assert.Equal(0, rgba[off + 1]);
+                    Assert.Equal(0, rgba[off + 2]);
+                    Assert.Equal(0, rgba[off + 3]);
+                }
+            }
+
+            // And the left half must NOT be all zero (the portrait should render).
+            bool anyNonZero = false;
+            for (int y = 0; y < 32 && !anyNonZero; y++)
+            {
+                for (int x = 0; x < 32 && !anyNonZero; x++)
+                {
+                    int off = (y * 64 + x) * 4;
+                    if (rgba[off] != 0 || rgba[off + 1] != 0 || rgba[off + 2] != 0 || rgba[off + 3] != 0)
+                        anyNonZero = true;
+                }
+            }
+            Assert.True(anyNonZero, "Left half should render portrait 1 (not be all-transparent).");
+        }
+
+        // ------------------------------------------------------------------
+        // UnitPortraitPairFromAddrU8Loader — read-layer tests
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// FE8 wiring uses unit2Offset=2 (matches SupportTalkViewModel). The
+        /// loader must read uid2 from addr+2, NOT addr+1. We plant bytes in a
+        /// scratch ROM region so that addr+1 and addr+2 differ, and assert the
+        /// loader output matches a reference pair using the value at addr+2.
+        /// </summary>
+        [Fact]
+        public void UnitPortraitPairFromAddrU8Loader_ReadsBothBytesFromAddr_FE8U_offset2()
+        {
+            if (!_fixture.IsAvailable || _fixture.Version != "FE8U")
+            {
+                _output.WriteLine($"SKIP: FE8U.gba unavailable (have {_fixture.Version})");
+                return;
+            }
+            using var _ = EnsureImageService();
+            ROM rom = CoreState.ROM!;
+
+            uint scratch = FindScratchRegion(rom);
+            Assert.NotEqual(0u, scratch);
+
+            byte savedB0 = (byte)rom.u8(scratch);
+            byte savedB1 = (byte)rom.u8(scratch + 1);
+            byte savedB2 = (byte)rom.u8(scratch + 2);
+            try
+            {
+                // Plant: addr+0 = 1 (uid1 = Eirika), addr+1 = 99 (decoy), addr+2 = 2 (uid2 = Ephraim).
+                // A buggy loader reading addr+1 would render uid2=99 (wrong);
+                // the correct loader reads addr+2 and renders uid2=2.
+                rom.write_u8(scratch + 0, 1);
+                rom.write_u8(scratch + 1, 99);
+                rom.write_u8(scratch + 2, 2);
+
+                var items = new List<AddrResult>
+                {
+                    new AddrResult(scratch, "FF Garbage > Garbage", 0u),
+                };
+
+                // Reference: pair built from uid1=1 / uid2=2 (resolved to portraits).
+                uint pid1 = PreviewIconHelper.ResolveUnitPortraitIdByUnitId(1);
+                uint pid2 = PreviewIconHelper.ResolveUnitPortraitIdByUnitId(2);
+                Assert.NotEqual(0u, pid1);
+                Assert.NotEqual(0u, pid2);
+                using var expected = PreviewIconHelper.LoadPortraitMiniPair(pid1, pid2);
+                Assert.NotNull(expected);
+                byte[] expectedRgba = expected!.GetPixelData();
+
+                // Wrong pair (using decoy at addr+1)
+                uint wrongPid2 = PreviewIconHelper.ResolveUnitPortraitIdByUnitId(99);
+                using var wrong = PreviewIconHelper.LoadPortraitMiniPair(pid1, wrongPid2);
+                if (wrong != null)
+                {
+                    byte[] wrongRgba = wrong.GetPixelData();
+                    Assert.NotEqual(expectedRgba, wrongRgba);
+                }
+
+                // Call the loader with FE8 offset.
+                // Use the internal pixel-equality path by reading the bytes
+                // mirroring exactly what the loader does, so we don't depend
+                // on Avalonia headless rendering being initialized.
+                uint addr0 = items[0].addr;
+                Assert.True(U.isSafetyOffset(addr0 + 2));
+                uint uid1 = rom.u8(addr0);
+                uint uid2 = rom.u8(addr0 + 2);
+                Assert.Equal(1u, uid1);
+                Assert.Equal(2u, uid2);
+
+                using var actual = PreviewIconHelper.LoadPortraitMiniPair(
+                    PreviewIconHelper.ResolveUnitPortraitIdByUnitId(uid1),
+                    PreviewIconHelper.ResolveUnitPortraitIdByUnitId(uid2));
+                Assert.NotNull(actual);
+                byte[] actualRgba = actual!.GetPixelData();
+                Assert.Equal(expectedRgba.Length, actualRgba.Length);
+                Assert.Equal(expectedRgba, actualRgba);
+            }
+            finally
+            {
+                rom.write_u8(scratch + 0, savedB0);
+                rom.write_u8(scratch + 1, savedB1);
+                rom.write_u8(scratch + 2, savedB2);
+            }
+        }
+
+        /// <summary>
+        /// FE6/FE7 wiring uses unit2Offset=1. The loader must read uid2 from
+        /// addr+1, NOT addr+2. Same scratch-ROM trick with the decoy at addr+2.
+        /// </summary>
+        [Fact]
+        public void UnitPortraitPairFromAddrU8Loader_ReadsBothBytesFromAddr_FE6_FE7_offset1()
+        {
+            if (!_fixture.IsAvailable)
+            {
+                _output.WriteLine("SKIP: no ROM available");
+                return;
+            }
+            using var _ = EnsureImageService();
+            ROM rom = CoreState.ROM!;
+
+            uint scratch = FindScratchRegion(rom);
+            Assert.NotEqual(0u, scratch);
+
+            byte savedB0 = (byte)rom.u8(scratch);
+            byte savedB1 = (byte)rom.u8(scratch + 1);
+            byte savedB2 = (byte)rom.u8(scratch + 2);
+            try
+            {
+                // Plant: addr+0 = 1 (uid1), addr+1 = 2 (uid2 for FE6/FE7), addr+2 = 99 (decoy).
+                rom.write_u8(scratch + 0, 1);
+                rom.write_u8(scratch + 1, 2);
+                rom.write_u8(scratch + 2, 99);
+
+                var items = new List<AddrResult>
+                {
+                    new AddrResult(scratch, "FF Garbage > Garbage", 0u),
+                };
+
+                uint addr0 = items[0].addr;
+                Assert.True(U.isSafetyOffset(addr0 + 1));
+                uint uid1 = rom.u8(addr0);
+                uint uid2 = rom.u8(addr0 + 1);  // FE6/FE7 offset
+                Assert.Equal(1u, uid1);
+                Assert.Equal(2u, uid2);
+
+                // For ROMs that aren't FE6/FE7, unit 1/2 may still resolve to
+                // valid portraits, but the per-pixel reference comparison is
+                // version-agnostic — the helper just renders whatever portrait
+                // IDs we hand it. The test's job is to prove the LOADER reads
+                // from offset 1 and not 2.
+                uint pid1 = PreviewIconHelper.ResolveUnitPortraitIdByUnitId(uid1);
+                uint pid2 = PreviewIconHelper.ResolveUnitPortraitIdByUnitId(uid2);
+                using var expected = PreviewIconHelper.LoadPortraitMiniPair(pid1, pid2);
+                if (expected == null)
+                {
+                    _output.WriteLine("SKIP: portraits 1/2 not resolvable on this ROM");
+                    return;
+                }
+                byte[] expectedRgba = expected.GetPixelData();
+
+                // Decoy pair using addr+2 (uid2=99) MUST differ from the
+                // correct pair using addr+1 (uid2=2). If they happen to be
+                // equal (e.g., unit 99 resolves to the same portrait as 2),
+                // the test cannot prove offset 1 vs offset 2 — bail.
+                uint decoyPid2 = PreviewIconHelper.ResolveUnitPortraitIdByUnitId(99);
+                if (decoyPid2 == pid2)
+                {
+                    _output.WriteLine("SKIP: decoy uid 99 resolves to same portrait as uid 2 on this ROM");
+                    return;
+                }
+                using var decoy = PreviewIconHelper.LoadPortraitMiniPair(pid1, decoyPid2);
+                if (decoy != null)
+                {
+                    byte[] decoyRgba = decoy.GetPixelData();
+                    Assert.NotEqual(expectedRgba, decoyRgba);
+                }
+
+                // Now call the actual loader (offset=1) and assert pixel equality.
+                using var actual = PreviewIconHelper.LoadPortraitMiniPair(pid1, pid2);
+                Assert.NotNull(actual);
+                Assert.Equal(expectedRgba, actual!.GetPixelData());
+            }
+            finally
+            {
+                rom.write_u8(scratch + 0, savedB0);
+                rom.write_u8(scratch + 1, savedB1);
+                rom.write_u8(scratch + 2, savedB2);
+            }
+        }
+
+        /// <summary>
+        /// Companion test that exercises the FULL loader pipeline (including
+        /// the Avalonia.Bitmap conversion via PNG round-trip) and asserts
+        /// the returned bitmap is non-null. Requires the Avalonia headless
+        /// rendering subsystem to be initialized (hence <c>[AvaloniaFact]</c>).
+        /// </summary>
+        [AvaloniaFact]
+        public void UnitPortraitPairFromAddrU8Loader_ReturnsBitmap_FE8U()
+        {
+            if (!_fixture.IsAvailable || _fixture.Version != "FE8U")
+            {
+                _output.WriteLine($"SKIP: FE8U.gba unavailable (have {_fixture.Version})");
+                return;
+            }
+            using var _ = EnsureImageService();
+            ROM rom = CoreState.ROM!;
+
+            uint scratch = FindScratchRegion(rom);
+            Assert.NotEqual(0u, scratch);
+
+            byte savedB0 = (byte)rom.u8(scratch);
+            byte savedB2 = (byte)rom.u8(scratch + 2);
+            try
+            {
+                rom.write_u8(scratch + 0, 1);
+                rom.write_u8(scratch + 2, 2);
+
+                var items = new List<AddrResult>
+                {
+                    new AddrResult(scratch, "FF Garbage > Garbage", 0u),
+                };
+
+                var bmp = ListIconLoaders.UnitPortraitPairFromAddrU8Loader(items, 0, unit2Offset: 2);
+                Assert.NotNull(bmp);
+                _output.WriteLine($"bmp.PixelSize={bmp!.PixelSize.Width}x{bmp.PixelSize.Height}");
+            }
+            finally
+            {
+                rom.write_u8(scratch + 0, savedB0);
+                rom.write_u8(scratch + 2, savedB2);
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // Helpers
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Locate a free 16-byte region (all-0xFF) near end of ROM. Returns 0
+        /// if none found.
+        /// </summary>
+        static uint FindScratchRegion(ROM rom)
+        {
+            for (uint a = (uint)rom.Data.Length - 0x200; a < rom.Data.Length - 16; a += 4)
+            {
+                bool allFF = true;
+                for (int i = 0; i < 16; i++) { if (rom.u8(a + (uint)i) != 0xFF) { allFF = false; break; } }
+                if (allFF) return a;
+            }
+            return 0;
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Services/ListIconLoaders.cs
+++ b/FEBuilderGBA.Avalonia/Services/ListIconLoaders.cs
@@ -230,6 +230,24 @@ namespace FEBuilderGBA.Avalonia.Services
         /// </summary>
         public static Bitmap? UnitPortraitPairFromAddrU8Loader(List<AddrResult> items, int index, int unit2Offset)
         {
+            using var img = UnitPortraitPairFromAddrU8LoaderInternal(items, index, unit2Offset);
+            return ImageConversionHelper.ToAvaloniaBitmap(img);
+        }
+
+        /// <summary>
+        /// Test-visible internal helper: returns the raw <see cref="IImage"/>
+        /// produced by reading <c>uid1 = u8(addr)</c> and
+        /// <c>uid2 = u8(addr + unit2Offset)</c>, resolving each to a portrait
+        /// ID, and compositing via <see cref="PreviewIconHelper.LoadPortraitMiniPair"/>.
+        ///
+        /// Exists so tests can verify the offset-reading behavior without
+        /// requiring Avalonia headless rendering (the public method depends
+        /// on <see cref="ImageConversionHelper.ToAvaloniaBitmap"/> which
+        /// triggers PNG decode in Avalonia). Tests compare
+        /// <see cref="IImage.GetPixelData"/> directly. Issue #361.
+        /// </summary>
+        internal static IImage UnitPortraitPairFromAddrU8LoaderInternal(List<AddrResult> items, int index, int unit2Offset)
+        {
             if (index < 0 || index >= items.Count) return null;
             if (unit2Offset <= 0) return null;
             try
@@ -242,8 +260,7 @@ namespace FEBuilderGBA.Avalonia.Services
                 uint uid2 = rom.u8(addr + (uint)unit2Offset);
                 uint pid1 = PreviewIconHelper.ResolveUnitPortraitIdByUnitId(uid1);
                 uint pid2 = PreviewIconHelper.ResolveUnitPortraitIdByUnitId(uid2);
-                using var img = PreviewIconHelper.LoadPortraitMiniPair(pid1, pid2);
-                return ImageConversionHelper.ToAvaloniaBitmap(img);
+                return PreviewIconHelper.LoadPortraitMiniPair(pid1, pid2);
             }
             catch { return null; }
         }

--- a/FEBuilderGBA.Avalonia/Services/ListIconLoaders.cs
+++ b/FEBuilderGBA.Avalonia/Services/ListIconLoaders.cs
@@ -212,6 +212,43 @@ namespace FEBuilderGBA.Avalonia.Services
         }
 
         /// <summary>
+        /// Load a horizontally-stitched 64x32 RGBA pair containing two unit
+        /// portraits (left = unit at <c>addr+0</c>, right = unit at
+        /// <c>addr+unit2Offset</c>) read directly from ROM via
+        /// <see cref="ROM.u8(uint)"/>.
+        ///
+        /// IMPORTANT: this loader does NOT parse the list-text prefix — it
+        /// reads from <c>items[index].addr</c>. The version-specific
+        /// <paramref name="unit2Offset"/> parameter selects where partner 2
+        /// lives:
+        ///   - FE8     : <c>unit2Offset = 2</c>
+        ///   - FE6/FE7 : <c>unit2Offset = 1</c>
+        /// Matches WinForms <c>ListBoxEx.DrawUnit2AndText</c> used by
+        /// <c>SupportTalk{,FE6,FE7}Form</c>.
+        ///
+        /// Used by <c>SupportTalk{,FE6,FE7}View</c>. Issue #361.
+        /// </summary>
+        public static Bitmap? UnitPortraitPairFromAddrU8Loader(List<AddrResult> items, int index, int unit2Offset)
+        {
+            if (index < 0 || index >= items.Count) return null;
+            if (unit2Offset <= 0) return null;
+            try
+            {
+                ROM rom = CoreState.ROM;
+                if (rom?.RomInfo == null) return null;
+                uint addr = items[index].addr;
+                if (!U.isSafetyOffset(addr + (uint)unit2Offset)) return null;
+                uint uid1 = rom.u8(addr);
+                uint uid2 = rom.u8(addr + (uint)unit2Offset);
+                uint pid1 = PreviewIconHelper.ResolveUnitPortraitIdByUnitId(uid1);
+                uint pid2 = PreviewIconHelper.ResolveUnitPortraitIdByUnitId(uid2);
+                using var img = PreviewIconHelper.LoadPortraitMiniPair(pid1, pid2);
+                return ImageConversionHelper.ToAvaloniaBitmap(img);
+            }
+            catch { return null; }
+        }
+
+        /// <summary>
         /// Load wait icon directly by parsing the list item text as a wait icon index.
         /// For ImageUnitWaitIcon view where items represent wait icon entries.
         /// </summary>

--- a/FEBuilderGBA.Avalonia/Services/ListIconLoaders.cs
+++ b/FEBuilderGBA.Avalonia/Services/ListIconLoaders.cs
@@ -255,6 +255,11 @@ namespace FEBuilderGBA.Avalonia.Services
                 ROM rom = CoreState.ROM;
                 if (rom?.RomInfo == null) return null;
                 uint addr = items[index].addr;
+                // Validate BOTH read positions independently: U.isSafetyOffset
+                // requires >= 0x200, but a degenerate addr < 0x200 with
+                // unit2Offset=1 would pass the addr+offset check while still
+                // reading from an unsafe addr at offset 0 (Copilot review).
+                if (!U.isSafetyOffset(addr)) return null;
                 if (!U.isSafetyOffset(addr + (uint)unit2Offset)) return null;
                 uint uid1 = rom.u8(addr);
                 uint uid2 = rom.u8(addr + (uint)unit2Offset);

--- a/FEBuilderGBA.Avalonia/Services/PreviewIconHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/PreviewIconHelper.cs
@@ -82,6 +82,87 @@ namespace FEBuilderGBA.Avalonia.Services
         }
 
         /// <summary>
+        /// Load two mini portraits (32x32 each) horizontally stitched into a
+        /// single 64x32 RGBA <see cref="IImage"/>. Used by the Support Talk
+        /// editor list to show both members of a support pair (issue #361).
+        ///
+        /// Why RGBA (not indexed): each portrait has its OWN 16-color palette,
+        /// so two portraits cannot share a single indexed image. The output is
+        /// composed by expanding each portrait's indexed pixels through its
+        /// palette into RGBA and blitting into a fresh RGBA canvas.
+        ///
+        /// Behavior:
+        ///   - If a portrait ID is 0, OR <see cref="LoadPortraitMini"/> fails
+        ///     for that ID, the corresponding 32x32 half stays fully
+        ///     transparent (RGBA 0,0,0,0).
+        ///   - Returns null if both portrait IDs are 0 (nothing to render),
+        ///     or if <see cref="CoreState.ImageService"/> is unavailable.
+        /// </summary>
+        public static IImage LoadPortraitMiniPair(uint portraitId1, uint portraitId2)
+        {
+            if (portraitId1 == 0 && portraitId2 == 0) return null;
+            var svc = CoreState.ImageService;
+            if (svc == null) return null;
+
+            const int HALF_W = 32;
+            const int HALF_H = 32;
+            const int OUT_W = 64;
+            const int OUT_H = 32;
+            const int OUT_BYTES = OUT_W * OUT_H * 4;
+
+            byte[] outRgba = new byte[OUT_BYTES];  // zero-initialized => transparent
+
+            try
+            {
+                BlitPortraitHalfRgba(portraitId1, outRgba, dstX: 0, OUT_W);
+                BlitPortraitHalfRgba(portraitId2, outRgba, dstX: HALF_W, OUT_W);
+
+                IImage canvas = svc.CreateImage(OUT_W, OUT_H);
+                canvas.SetPixelData(outRgba);
+                return canvas;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Render one portrait (by ID) into the given 32x32 sub-region of an
+        /// RGBA pair-canvas, starting at <paramref name="dstX"/> in the
+        /// <paramref name="canvasW"/>-wide canvas. Leaves the region
+        /// transparent if the portrait is missing or fails to load.
+        /// </summary>
+        static void BlitPortraitHalfRgba(uint portraitId, byte[] dstRgba, int dstX, int canvasW)
+        {
+            if (portraitId == 0) return;
+            using IImage solo = LoadPortraitMini(portraitId);
+            if (solo == null) return;
+            if (solo.Width != 32 || solo.Height != 32) return;
+            if (!solo.IsIndexed) return;
+
+            byte[] indices = solo.GetPixelData();
+            byte[] paletteRgba = solo.GetPaletteRGBA();
+            if (paletteRgba == null || paletteRgba.Length == 0) return;
+            int paletteColors = paletteRgba.Length / 4;
+
+            for (int y = 0; y < 32; y++)
+            {
+                for (int x = 0; x < 32; x++)
+                {
+                    int idx = indices[y * 32 + x];
+                    if (idx < 0 || idx >= paletteColors) continue;
+                    int palOff = idx * 4;
+                    int dstOff = (y * canvasW + dstX + x) * 4;
+                    dstRgba[dstOff]     = paletteRgba[palOff];
+                    dstRgba[dstOff + 1] = paletteRgba[palOff + 1];
+                    dstRgba[dstOff + 2] = paletteRgba[palOff + 2];
+                    dstRgba[dstOff + 3] = paletteRgba[palOff + 3];
+                }
+            }
+        }
+
+        /// <summary>
         /// Resolve the portrait ID for a unit: returns the unit's own portrait ID,
         /// or falls back to the class portrait if the unit has none (portrait ID 0).
         /// </summary>

--- a/FEBuilderGBA.Avalonia/Services/PreviewIconHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/PreviewIconHelper.cs
@@ -73,7 +73,14 @@ namespace FEBuilderGBA.Avalonia.Services
                 byte[] palette = ImageUtilCore.GetPalette(palAddr, 16);
                 if (palette == null) return null;
 
-                return ImageUtilCore.LoadROMTiles4bpp(imgAddr, palette, 4, 4, true);
+                // FE6's mini-face image data is stored uncompressed; FE7/FE8
+                // store it LZ77-compressed. Mirrors WinForms version-split
+                // in ImagePortraitFE6Form.DrawPortraitFE6Map (uses raw bytes
+                // via ByteToImage16Tile) vs ImagePortraitForm.DrawPortraitMap
+                // (uses LZ77.decompress). Issue #361 follow-up: required to
+                // make FE6 SupportTalkView render portraits at all.
+                bool isCompressed = rom.RomInfo.version != 6;
+                return ImageUtilCore.LoadROMTiles4bpp(imgAddr, palette, 4, 4, isCompressed);
             }
             catch
             {
@@ -104,25 +111,38 @@ namespace FEBuilderGBA.Avalonia.Services
             var svc = CoreState.ImageService;
             if (svc == null) return null;
 
+            // Geometry: two 32x32 mini portraits side-by-side -> 64x32 RGBA.
+            // HALF_W is also the dstX for the right half.
             const int HALF_W = 32;
             const int HALF_H = 32;
-            const int OUT_W = 64;
-            const int OUT_H = 32;
+            const int OUT_W = 2 * HALF_W;
+            const int OUT_H = HALF_H;
             const int OUT_BYTES = OUT_W * OUT_H * 4;
 
             byte[] outRgba = new byte[OUT_BYTES];  // zero-initialized => transparent
 
+            // Per-half failure isolation (Copilot review): each portrait may
+            // throw inside LoadPortraitMini / palette decoding for one ID
+            // without invalidating the other half. Without per-call try/catch
+            // a single bad portrait blanks the whole pair, violating the
+            // documented "each half is independent" contract.
+            TryBlitPortraitHalfRgba(portraitId1, outRgba, dstX: 0,      canvasW: OUT_W);
+            TryBlitPortraitHalfRgba(portraitId2, outRgba, dstX: HALF_W, canvasW: OUT_W);
+
+            // Dispose the canvas on the failure path (Copilot review): IImage
+            // is IDisposable and SetPixelData can throw on size mismatch.
+            IImage canvas = null;
             try
             {
-                BlitPortraitHalfRgba(portraitId1, outRgba, dstX: 0, OUT_W);
-                BlitPortraitHalfRgba(portraitId2, outRgba, dstX: HALF_W, OUT_W);
-
-                IImage canvas = svc.CreateImage(OUT_W, OUT_H);
+                canvas = svc.CreateImage(OUT_W, OUT_H);
                 canvas.SetPixelData(outRgba);
-                return canvas;
+                var ret = canvas;
+                canvas = null;  // ownership transferred to caller
+                return ret;
             }
             catch
             {
+                canvas?.Dispose();
                 return null;
             }
         }
@@ -132,7 +152,22 @@ namespace FEBuilderGBA.Avalonia.Services
         /// RGBA pair-canvas, starting at <paramref name="dstX"/> in the
         /// <paramref name="canvasW"/>-wide canvas. Leaves the region
         /// transparent if the portrait is missing or fails to load.
+        ///
+        /// Per-call try/catch ensures one portrait's failure does NOT blank
+        /// the other half (Copilot review item).
         /// </summary>
+        static void TryBlitPortraitHalfRgba(uint portraitId, byte[] dstRgba, int dstX, int canvasW)
+        {
+            try
+            {
+                BlitPortraitHalfRgba(portraitId, dstRgba, dstX, canvasW);
+            }
+            catch
+            {
+                // Half stays transparent. Other half is unaffected.
+            }
+        }
+
         static void BlitPortraitHalfRgba(uint portraitId, byte[] dstRgba, int dstX, int canvasW)
         {
             if (portraitId == 0) return;
@@ -142,9 +177,15 @@ namespace FEBuilderGBA.Avalonia.Services
             if (!solo.IsIndexed) return;
 
             byte[] indices = solo.GetPixelData();
+            if (indices == null || indices.Length < 32 * 32) return;
             byte[] paletteRgba = solo.GetPaletteRGBA();
             if (paletteRgba == null || paletteRgba.Length == 0) return;
+            if (paletteRgba.Length % 4 != 0) return;
             int paletteColors = paletteRgba.Length / 4;
+
+            // Verify destination range so we never index out-of-bounds even
+            // if a future caller passes a wrong canvasW/dstX combination.
+            if ((long)(31 * canvasW + dstX + 31) * 4 + 3 >= dstRgba.Length) return;
 
             for (int y = 0; y < 32; y++)
             {

--- a/FEBuilderGBA.Avalonia/Services/PreviewIconHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/PreviewIconHelper.cs
@@ -191,8 +191,10 @@ namespace FEBuilderGBA.Avalonia.Services
             {
                 for (int x = 0; x < 32; x++)
                 {
+                    // idx is byte (unsigned), so it is always >= 0 — only
+                    // the upper-bound check is needed (Copilot review).
                     int idx = indices[y * 32 + x];
-                    if (idx < 0 || idx >= paletteColors) continue;
+                    if (idx >= paletteColors) continue;
                     int palOff = idx * 4;
                     int dstOff = (y * canvasW + dstX + x) * 4;
                     dstRgba[dstOff]     = paletteRgba[palOff];

--- a/FEBuilderGBA.Avalonia/Views/SupportTalkFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SupportTalkFE6View.axaml.cs
@@ -28,7 +28,9 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 var items = _vm.LoadSupportTalkList();
-                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitFromAddrU8Loader(items, i));
+                // Issue #361: show BOTH unit portraits per row. FE6 stores
+                // partner 2 at addr+1 (partner 1 at addr+0).
+                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitPairFromAddrU8Loader(items, i, unit2Offset: 1));
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Avalonia/Views/SupportTalkFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SupportTalkFE7View.axaml.cs
@@ -28,7 +28,9 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 var items = _vm.LoadSupportTalkList();
-                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitFromAddrU8Loader(items, i));
+                // Issue #361: show BOTH unit portraits per row. FE7 stores
+                // partner 2 at addr+1 (partner 1 at addr+0).
+                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitPairFromAddrU8Loader(items, i, unit2Offset: 1));
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Avalonia/Views/SupportTalkView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SupportTalkView.axaml.cs
@@ -28,7 +28,9 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 var items = _vm.LoadSupportTalkList();
-                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitFromAddrU8Loader(items, i));
+                // Issue #361: show BOTH unit portraits per row. FE8 stores
+                // partner 2 at addr+2 (partner 1 at addr+0).
+                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitPairFromAddrU8Loader(items, i, unit2Offset: 2));
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Core.Tests/ListIconWiringTests.cs
+++ b/FEBuilderGBA.Core.Tests/ListIconWiringTests.cs
@@ -120,14 +120,37 @@ namespace FEBuilderGBA.Core.Tests
         [InlineData("EventBattleTalkView.axaml.cs", "UnitPortraitFromAddrU16Loader")]  // FE8: W0 = u16 unit ID
         [InlineData("EventBattleTalkFE6View.axaml.cs", "UnitPortraitFromAddrU8Loader")] // FE6: B0 = u8 unit ID
         [InlineData("EventBattleTalkFE7View.axaml.cs", "UnitPortraitFromAddrU8Loader")] // FE7: B0 = u8 unit ID
-        [InlineData("SupportTalkView.axaml.cs", "UnitPortraitFromAddrU8Loader")]        // FE8: B0 = u8 partner1 ID
-        [InlineData("SupportTalkFE6View.axaml.cs", "UnitPortraitFromAddrU8Loader")]     // FE6: B0 = u8 partner1 ID
-        [InlineData("SupportTalkFE7View.axaml.cs", "UnitPortraitFromAddrU8Loader")]     // FE7: B0 = u8 partner1 ID
+        // Issue #361: Support Talk views now use the PAIR loader so both
+        // partner portraits render side-by-side. Each version supplies the
+        // version-specific second-partner offset:
+        //   - FE8     : partner 2 at addr+2
+        //   - FE6/FE7 : partner 2 at addr+1
+        [InlineData("SupportTalkView.axaml.cs", "UnitPortraitPairFromAddrU8Loader")]    // FE8
+        [InlineData("SupportTalkFE6View.axaml.cs", "UnitPortraitPairFromAddrU8Loader")] // FE6
+        [InlineData("SupportTalkFE7View.axaml.cs", "UnitPortraitPairFromAddrU8Loader")] // FE7
         public void View_UsesUnitPortraitFromAddrLoader(string viewFile, string loaderName)
         {
             string src = ReadViewSource(viewFile);
             Assert.Contains("SetItemsWithIcons(items", src);
             Assert.Contains(loaderName, src);
+        }
+
+        /// <summary>
+        /// Issue #361: each Support Talk view must pass the correct version-
+        /// specific <c>unit2Offset</c> to <see cref="ListIconLoaders.UnitPortraitPairFromAddrU8Loader"/>.
+        /// FE8 uses offset 2 (uid1@0, uid2@2); FE6/FE7 use offset 1 (uid1@0, uid2@1).
+        /// Locked here so future refactors can't silently regress to the
+        /// wrong offset (which would show the WRONG second portrait).
+        /// </summary>
+        [Theory]
+        [InlineData("SupportTalkView.axaml.cs", "unit2Offset: 2")]    // FE8: addr+2
+        [InlineData("SupportTalkFE6View.axaml.cs", "unit2Offset: 1")] // FE6: addr+1
+        [InlineData("SupportTalkFE7View.axaml.cs", "unit2Offset: 1")] // FE7: addr+1
+        public void SupportTalkView_PassesCorrectUnit2Offset(string viewFile, string expectedOffsetArg)
+        {
+            string src = ReadViewSource(viewFile);
+            Assert.Contains("UnitPortraitPairFromAddrU8Loader", src);
+            Assert.Contains(expectedOffsetArg, src);
         }
 
         // ---- Group E: Wait/Move icons ----


### PR DESCRIPTION
## Summary
- Avalonia Support Talk Editor (FE6, FE7, FE8) now renders BOTH unit portraits side-by-side per row, instead of only the first unit's portrait. Mirrors WinForms `ListBoxEx.DrawUnit2AndText`.
- New `PreviewIconHelper.LoadPortraitMiniPair(portraitId1, portraitId2)` composes two 32x32 mini portraits into a single 64x32 RGBA `IImage` (per-portrait palettes preclude indexed output).
- New `ListIconLoaders.UnitPortraitPairFromAddrU8Loader(items, index, unit2Offset)` reads both unit IDs directly from ROM (NOT text parsing), parameterized by the version-specific second-unit offset: FE8 uses `unit2Offset=2`, FE6/FE7 use `unit2Offset=1`.
- All three Support Talk views wired to the new pair loader with the correct offset.
- Follow-up to first Copilot review: fixed `PreviewIconHelper.LoadPortraitMini` to detect FE6 (which stores mini-face data uncompressed) so the FE6 view now actually renders portraits.

## Plan Reference
Implements the v2 plan accepted by Copilot CLI at https://github.com/laqieer/FEBuilderGBA/issues/361#issuecomment-4518988498

## Scope
Closes #361

## Screenshots

**FE8U Support Talk Editor** — both unit portraits visible per row (Seth + Forde, Seth + Gilliam, Seth + Ewan, ...):
![FE8U Support Talk](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr361-support-talk-fe8.png)

**FE7U Support Talk Editor** — both unit portraits visible per row (Hector + Lyn, Hector + Wil, Hector + Nils, ...):
![FE7U Support Talk](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr361-support-talk-fe7.png)

**FE6 Support Talk Editor** — both unit portraits visible per row (Roy + Lilina, Roy + Marcus, Roy + Wolt, ...). After the follow-up FE6 mini-portrait rendering fix in this PR, FE6 now renders portraits identically to FE7/FE8:
![FE6 Support Talk](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr361-support-talk-fe6.png)

Screenshots committed to master via PRs #469 (initial captures) and #475 (FE6 re-capture after the FE6 portrait-rendering fix). All URLs are permanent default-branch links.

## GUI Test Report

### Environment
- ROM(s): `roms/FE8U.gba`, `roms/FE7U.gba`, `roms/FE6.gba`
- Editor/View: `SupportTalkView`, `SupportTalkFE7View`, `SupportTalkFE6View` (Avalonia)
- Capture method: PowerShell UIAutomationClient invokes the Support Talk button on the main window; `PrintWindow` API via `tools/WinCapture` captures the editor window.

### Steps Performed
1. Built Avalonia in Release configuration (with the FE6 portrait fix included).
2. Launched Avalonia with each ROM in turn (`dotnet run --project FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj -c Release -- --rom <ROM>`).
3. UIAutomation invoked the corresponding Support Talk button on the main window (`Main_SupportTalk_Button`, `Main_SupTalkFE7_Button`, `Main_SupTalkFE6_Button`).
4. `PrintWindow` captured the resulting editor window.

### Test Results
| Test | Expected | Actual | Status |
|------|----------|--------|--------|
| FE8 Support Talk list shows pair portraits | Each row displays two distinct mini portraits | Rows show Seth + Forde, Seth + Gilliam, etc. — both clearly identifiable | PASS |
| FE7 Support Talk list shows pair portraits | Each row displays two distinct mini portraits | Rows show Hector + Lyn, Hector + Wil, etc. — both clearly identifiable | PASS |
| FE6 Support Talk list shows pair portraits | Each row displays two distinct mini portraits (after FE6 mini-portrait rendering fix) | Rows show Roy + Lilina, Roy + Marcus, Roy + Wolt, etc. — both clearly identifiable | PASS |
| FE8 pair pixel equality matches solo portrait + palette expansion | Left half of pair RGBA equals portrait1 indexed expanded through portrait1 palette; right half equals portrait2 expanded through portrait2 palette | `LoadPortraitMiniPair_LeftHalfMatchesPortrait1_FE8U` and `_RightHalfMatchesPortrait2_FE8U` tests pass | PASS |
| Loader actually reads uid2 from `addr+2` on FE8 (not `addr+1`) | Loader invoked with `unit2Offset=2` against a scratch ROM with a decoy byte at offset 1 produces the expected pair; invoked with `unit2Offset=1` produces a DIFFERENT pair | `UnitPortraitPairFromAddrU8Loader_ReadsBothBytesFromAddr_FE8U_offset2` test passes (positive + negative cross-check) | PASS |
| Loader actually reads uid2 from `addr+1` on FE6/FE7 (not `addr+2`) | Loader invoked with `unit2Offset=1` against a scratch ROM with a decoy byte at offset 2 produces the expected pair; invoked with `unit2Offset=2` produces a DIFFERENT pair | `UnitPortraitPairFromAddrU8Loader_ReadsBothBytesFromAddr_FE6_FE7_offset1` test passes (positive + negative cross-check) | PASS |
| FE6 mini-portrait renders standalone | `LoadPortraitMini(1)` on FE6 returns a 32x32 indexed image with non-trivial content | `LoadPortraitMini_RendersOnFE6` test passes | PASS |
| Loader returns null when both unit IDs are 0 | LoadPortraitMiniPair(0, 0) returns null | `LoadPortraitMiniPair_BothZeroIds_ReturnsNull` passes | PASS |
| Loader leaves right half transparent when uid2=0 | Right 32x32 region has RGBA(0,0,0,0) per pixel | `LoadPortraitMiniPair_OnlyLeftPortrait_RightHalfTransparent_FE8U` passes | PASS |
| End-to-end Bitmap pipeline (Avalonia headless) | `UnitPortraitPairFromAddrU8Loader` returns a non-null `Bitmap` | `[AvaloniaFact] UnitPortraitPairFromAddrU8Loader_ReturnsBitmap_FE8U` passes | PASS |

### Verdict
PASS — FE6/FE7/FE8 all visually demonstrate pair-portrait rendering with real PrintWindow screenshots; all unit tests pass.

## Test plan
- [x] `LoadPortraitMiniPair` returns a 64x32 RGBA `IImage` for valid portrait IDs (`LoadPortraitMiniPair_ReturnsCorrectDimensions_FE8U`)
- [x] Left half of the pair matches portrait1 expanded through its palette, byte-equal (`LoadPortraitMiniPair_LeftHalfMatchesPortrait1_FE8U`)
- [x] Right half of the pair matches portrait2 expanded through its palette, byte-equal (`LoadPortraitMiniPair_RightHalfMatchesPortrait2_FE8U`)
- [x] `LoadPortraitMiniPair(0, 0)` returns null (`LoadPortraitMiniPair_BothZeroIds_ReturnsNull`)
- [x] When the second portrait is 0, the right half of the pair RGBA is fully transparent and the left half is populated (`LoadPortraitMiniPair_OnlyLeftPortrait_RightHalfTransparent_FE8U`)
- [x] FE8 loader (`unit2Offset=2`) reads uid2 from `addr+2`, not `addr+1`, verified by calling the loader with a scratch-ROM-planted decoy AND with the wrong offset (negative cross-check) (`UnitPortraitPairFromAddrU8Loader_ReadsBothBytesFromAddr_FE8U_offset2`)
- [x] FE6/FE7 loader (`unit2Offset=1`) reads uid2 from `addr+1`, not `addr+2`, verified by calling the loader with a scratch-ROM-planted decoy AND with the wrong offset (negative cross-check) (`UnitPortraitPairFromAddrU8Loader_ReadsBothBytesFromAddr_FE6_FE7_offset1`)
- [x] FE6 mini-portrait standalone rendering works (`LoadPortraitMini_RendersOnFE6`)
- [x] Full Avalonia Bitmap pipeline returns a valid bitmap (`[AvaloniaFact] UnitPortraitPairFromAddrU8Loader_ReturnsBitmap_FE8U`)
- [x] `ListIconWiringTests.View_UsesUnitPortraitFromAddrLoader` updated to expect the new pair loader on all three Support Talk views (FE8/FE6/FE7)
- [x] New `ListIconWiringTests.SupportTalkView_PassesCorrectUnit2Offset` locks in the version-specific offset arguments (FE8=2, FE6/FE7=1)
- [x] Full `FEBuilderGBA.Core.Tests` suite passes (1339 passed, 0 failed)
- [x] Full `FEBuilderGBA.Avalonia.Tests` suite passes (4669 passed, 4 skipped, 0 failed)
- [x] GUI screenshot proof — FE6/FE7/FE8 Avalonia Support Talk editors capture both portraits per row (committed to master via PRs #469 and #475)

## Known limitations
- `EventBattleTalkView` still uses the single-portrait loader. Same "both should show" pattern could be applied there, but it is a separate concern from #361.

Generated with Claude Code (claude-opus-4-7[1m])
