### PR TITLE
feat(lz77): Move + Recompress tabs (closes #371)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,6 +377,10 @@ Specialized utilities for different graphic types:
 - `ImageUtilMap.cs` - Map tiles
 - `ImageUtilMagic.cs` - Magic effects
 - `LZ77.cs` - GBA LZ77 compression (LZSS variant)
+- `LZ77ToolCore.cs` (Core) - Cross-platform helpers for the LZ77 Tool's Move + Recompress tabs.
+  Used by both WinForms `ToolLZ77Form` and Avalonia `ToolLZ77ViewModel`.
+  Uses ambient undo via `ROM.BeginUndoScope()`; LDR-first / raw-fallback pointer search
+  (event-aware path is explicitly out of scope — `MissingEventAwareCoverage` flag always set).
 
 ### Caching System
 

--- a/FEBuilderGBA.Avalonia.Tests/ToolLZ77ViewHeadlessTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ToolLZ77ViewHeadlessTests.cs
@@ -45,7 +45,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         }
 
         [AvaloniaFact]
-        public void ToolLZ77View_TabControl_HasFourTabs()
+        public void ToolLZ77View_TabControl_HasSixTabs()
         {
             var view = new ToolLZ77View();
             var tabs = view.GetLogicalDescendants().OfType<TabControl>().FirstOrDefault();
@@ -54,7 +54,7 @@ namespace FEBuilderGBA.Avalonia.Tests
             view.Show();
             view.Hide();
             var items = tabs.GetLogicalDescendants().OfType<TabItem>().ToList();
-            Assert.Equal(4, items.Count);
+            Assert.Equal(6, items.Count);
         }
 
         [AvaloniaFact]
@@ -69,6 +69,8 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.Contains("Compress", headers);
             Assert.Contains("Erase", headers);
             Assert.Contains("Base64", headers);
+            Assert.Contains("Move", headers);
+            Assert.Contains("Recompress", headers);
         }
 
         [AvaloniaFact]
@@ -85,6 +87,8 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.Contains("ToolLZ77_ZeroClear_Button", ids);
             Assert.Contains("ToolLZ77_Base64TextToFile_Button", ids);
             Assert.Contains("ToolLZ77_FileToBase64Text_Button", ids);
+            Assert.Contains("ToolLZ77_Move_Button", ids);
+            Assert.Contains("ToolLZ77_Recompress_Button", ids);
 
             // Input fields
             Assert.Contains("ToolLZ77_DecompressSrc_Input", ids);
@@ -95,6 +99,13 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.Contains("ToolLZ77_ZeroClearFrom_Input", ids);
             Assert.Contains("ToolLZ77_ZeroClearTo_Input", ids);
             Assert.Contains("ToolLZ77_Base64Text_Input", ids);
+            Assert.Contains("ToolLZ77_MoveFrom_Input", ids);
+            Assert.Contains("ToolLZ77_MoveTo_Input", ids);
+            Assert.Contains("ToolLZ77_MoveLength_Input", ids);
+
+            // Tabs
+            Assert.Contains("ToolLZ77_Move_Tab", ids);
+            Assert.Contains("ToolLZ77_Recompress_Tab", ids);
 
             // Status row
             Assert.Contains("ToolLZ77_Status_Label", ids);

--- a/FEBuilderGBA.Avalonia.Tests/ToolLZ77ViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ToolLZ77ViewModelTests.cs
@@ -348,5 +348,83 @@ namespace FEBuilderGBA.Avalonia.Tests
             }
             finally { CoreState.ROM = null; }
         }
+
+        // -------- MovePreflight early-validation (PR #481 review round 2) --------
+
+        [Fact]
+        public void MovePreflight_LengthExceedsLimit_FailsBeforePrompt()
+        {
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(new byte[0x10000]);
+            CoreState.ROM = rom;
+            try
+            {
+                var vm = new ToolLZ77ViewModel();
+                vm.MoveFromText = "0x1000";
+                vm.MoveToText = "0x2000";
+                vm.MoveLengthText = "0x300000"; // 3 MB > 2 MB limit
+                var result = vm.MovePreflight(out _, out _, out _, out _);
+                Assert.Equal(ToolLZ77ViewModel.MovePreflightResult.ErrorAlreadyShown, result);
+                Assert.Contains("LENGTH", vm.StatusText);
+            }
+            finally { CoreState.ROM = null; }
+        }
+
+        [Fact]
+        public void MovePreflight_SrcOutOfBounds_FailsBeforePrompt()
+        {
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(new byte[0x1000]);
+            CoreState.ROM = rom;
+            try
+            {
+                var vm = new ToolLZ77ViewModel();
+                vm.MoveFromText = "0xF00";
+                vm.MoveToText = "0x200";
+                vm.MoveLengthText = "0x500"; // 0xF00 + 0x500 = 0x1400 > 0x1000
+                var result = vm.MovePreflight(out _, out _, out _, out _);
+                Assert.Equal(ToolLZ77ViewModel.MovePreflightResult.ErrorAlreadyShown, result);
+                Assert.Contains("source range", vm.StatusText);
+            }
+            finally { CoreState.ROM = null; }
+        }
+
+        [Fact]
+        public void MovePreflight_DestOutOfBounds_FailsBeforePrompt()
+        {
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(new byte[0x1000]);
+            CoreState.ROM = rom;
+            try
+            {
+                var vm = new ToolLZ77ViewModel();
+                vm.MoveFromText = "0x100";
+                vm.MoveToText = "0xF80";
+                vm.MoveLengthText = "0x100"; // 0xF80 + 0x100 = 0x1080 > 0x1000
+                var result = vm.MovePreflight(out _, out _, out _, out _);
+                Assert.Equal(ToolLZ77ViewModel.MovePreflightResult.ErrorAlreadyShown, result);
+                Assert.Contains("destination range", vm.StatusText);
+            }
+            finally { CoreState.ROM = null; }
+        }
+
+        [Fact]
+        public void MovePreflight_OverlappingRanges_FailsBeforePrompt()
+        {
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(new byte[0x10000]);
+            CoreState.ROM = rom;
+            try
+            {
+                var vm = new ToolLZ77ViewModel();
+                vm.MoveFromText = "0x1000";
+                vm.MoveToText = "0x1080"; // overlaps source
+                vm.MoveLengthText = "0x100";
+                var result = vm.MovePreflight(out _, out _, out _, out _);
+                Assert.Equal(ToolLZ77ViewModel.MovePreflightResult.ErrorAlreadyShown, result);
+                Assert.Contains("overlap", vm.StatusText);
+            }
+            finally { CoreState.ROM = null; }
+        }
     }
 }

--- a/FEBuilderGBA.Avalonia.Tests/ToolLZ77ViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ToolLZ77ViewModelTests.cs
@@ -208,5 +208,145 @@ namespace FEBuilderGBA.Avalonia.Tests
             vm.RunZeroClear();
             Assert.Contains("no rom", vm.StatusText, StringComparison.OrdinalIgnoreCase);
         }
+
+        // =============== Move tab ===============
+
+        [Fact]
+        public void Move_NoRomLoaded_SetsStatus()
+        {
+            var vm = new ToolLZ77ViewModel();
+            vm.MoveFromText = "0x1000";
+            vm.MoveToText = "0x2000";
+            vm.MoveLengthText = "0x10";
+            var result = vm.RunMove();
+            Assert.False(result.Ok);
+            Assert.Contains("no rom", vm.StatusText, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Move_InvalidFromHex_SetsStatus()
+        {
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(new byte[0x10000]);
+            CoreState.ROM = rom;
+            try
+            {
+                var vm = new ToolLZ77ViewModel();
+                vm.MoveFromText = "garbage";
+                vm.MoveToText = "0x2000";
+                vm.MoveLengthText = "0x10";
+                var result = vm.RunMove();
+                Assert.False(result.Ok);
+                Assert.Contains("from", vm.StatusText, StringComparison.OrdinalIgnoreCase);
+            }
+            finally { CoreState.ROM = null; }
+        }
+
+        [Fact]
+        public void Move_InvalidLengthHex_SetsStatus()
+        {
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(new byte[0x10000]);
+            CoreState.ROM = rom;
+            try
+            {
+                var vm = new ToolLZ77ViewModel();
+                vm.MoveFromText = "0x1000";
+                vm.MoveToText = "0x2000";
+                vm.MoveLengthText = "xyz";
+                var result = vm.RunMove();
+                Assert.False(result.Ok);
+                Assert.Contains("length", vm.StatusText, StringComparison.OrdinalIgnoreCase);
+            }
+            finally { CoreState.ROM = null; }
+        }
+
+        [Fact]
+        public void Move_LengthZero_SetsStatus()
+        {
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(new byte[0x10000]);
+            CoreState.ROM = rom;
+            try
+            {
+                var vm = new ToolLZ77ViewModel();
+                vm.MoveFromText = "0x1000";
+                vm.MoveToText = "0x2000";
+                vm.MoveLengthText = "0";
+                var result = vm.RunMove();
+                Assert.False(result.Ok);
+                Assert.Contains("length is 0", vm.StatusText, StringComparison.OrdinalIgnoreCase);
+            }
+            finally { CoreState.ROM = null; }
+        }
+
+        // =============== Recompress tab ===============
+
+        [Fact]
+        public void Recompress_NoRomLoaded_SetsStatus()
+        {
+            var vm = new ToolLZ77ViewModel();
+            var (size, count) = vm.RunRecompress();
+            Assert.Equal(0u, size);
+            Assert.Equal(0u, count);
+            Assert.Contains("no rom", vm.StatusText, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Recompress_RomModified_RequiresUserConfirmation()
+        {
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(new byte[0x10000]);
+            // Make rom Modified by writing to it.
+            using (ROM.BeginUndoScope(new Undo.UndoData
+            {
+                time = System.DateTime.Now,
+                name = "test",
+                list = new System.Collections.Generic.List<Undo.UndoPostion>(),
+                filesize = (uint)rom.Data.Length,
+            }))
+            {
+                rom.write_u8(0x100, 0xAA);
+            }
+            CoreState.ROM = rom;
+            try
+            {
+                var vm = new ToolLZ77ViewModel();
+                var preflight = vm.RecompressPreflight();
+                Assert.Equal(ToolLZ77ViewModel.RecompressPreflightResult.NeedRomModifiedAck, preflight);
+            }
+            finally { CoreState.ROM = null; }
+        }
+
+        [Fact]
+        public void Recompress_PreflightNeedsConfirmation_WhenCleanRom()
+        {
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(new byte[0x10000]);
+            CoreState.ROM = rom;
+            try
+            {
+                var vm = new ToolLZ77ViewModel();
+                var preflight = vm.RecompressPreflight();
+                Assert.Equal(ToolLZ77ViewModel.RecompressPreflightResult.NeedConfirm, preflight);
+            }
+            finally { CoreState.ROM = null; }
+        }
+
+        [Fact]
+        public void Recompress_PreflightProceeds_AfterConfirmation()
+        {
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(new byte[0x10000]);
+            CoreState.ROM = rom;
+            try
+            {
+                var vm = new ToolLZ77ViewModel();
+                vm.RecompressConfirmed = true;
+                var preflight = vm.RecompressPreflight();
+                Assert.Equal(ToolLZ77ViewModel.RecompressPreflightResult.ProceedNoPrompt, preflight);
+            }
+            finally { CoreState.ROM = null; }
+        }
     }
 }

--- a/FEBuilderGBA.Avalonia/ViewModels/ToolLZ77ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ToolLZ77ViewModel.cs
@@ -392,6 +392,41 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             dstOffset = toRaw == 0 ? 0u : U.toOffset(toRaw);
             length = lenRaw;
 
+            // Surface basic validation errors BEFORE prompting the user, so we
+            // don't walk the multi-prompt confirmation flow and then fail inside
+            // MoveCompressedData. Mirrors the same checks in the Core helper.
+            if (srcOffset == 0)
+            {
+                StatusText = R._("Move: source address is 0 (bad base address).");
+                return MovePreflightResult.ErrorAlreadyShown;
+            }
+            if (length >= LZ77ToolCore.MOVE_LENGTH_LIMIT)
+            {
+                StatusText = R._("Move: LENGTH 0x{0:X} exceeds 2 MB limit.", length);
+                return MovePreflightResult.ErrorAlreadyShown;
+            }
+            if (srcOffset + length > (uint)rom.Data.Length)
+            {
+                StatusText = R._("Move: source range 0x{0:X8}+0x{1:X} exceeds ROM end.", srcOffset, length);
+                return MovePreflightResult.ErrorAlreadyShown;
+            }
+            if (dstOffset != 0 && (dstOffset + length > (uint)rom.Data.Length))
+            {
+                StatusText = R._("Move: destination range 0x{0:X8}+0x{1:X} exceeds ROM end.", dstOffset, length);
+                return MovePreflightResult.ErrorAlreadyShown;
+            }
+            // Overlap check (only applies when caller supplied an explicit dst).
+            if (dstOffset != 0)
+            {
+                uint sEnd = srcOffset + length;
+                uint dEnd = dstOffset + length;
+                if (srcOffset < dEnd && dstOffset < sEnd)
+                {
+                    StatusText = R._("Move: source 0x{0:X8}+0x{1:X} and destination 0x{2:X8}+0x{1:X} overlap (not supported).", srcOffset, length, dstOffset);
+                    return MovePreflightResult.ErrorAlreadyShown;
+                }
+            }
+
             // Look up pointers (LDR-first, raw fallback) so the View can decide
             // what prompts to surface BEFORE the actual write.
             searchResult = LZ77ToolCore.SearchPointersForAddress(rom.Data, srcOffset);

--- a/FEBuilderGBA.Avalonia/ViewModels/ToolLZ77ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ToolLZ77ViewModel.cs
@@ -51,6 +51,15 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         bool _isBusy;
         bool _isLoaded;
         bool _zeroClearConfirmed;
+        // Move tab state
+        string _moveFromText = "0x0";
+        string _moveToText = "0x0";
+        string _moveLengthText = "0";
+        bool _moveRawFallbackConfirmed;
+        bool _movePointerCountConfirmed;
+        // Recompress tab state
+        bool _recompressConfirmed;
+        bool _recompressModifiedAcknowledged;
 
         readonly UndoService _undo = new();
 
@@ -66,6 +75,18 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public bool IsBusy { get => _isBusy; set => SetField(ref _isBusy, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
         public bool ZeroClearConfirmed { get => _zeroClearConfirmed; set => SetField(ref _zeroClearConfirmed, value); }
+
+        public string MoveFromText { get => _moveFromText; set => SetField(ref _moveFromText, value); }
+        public string MoveToText { get => _moveToText; set => SetField(ref _moveToText, value); }
+        public string MoveLengthText { get => _moveLengthText; set => SetField(ref _moveLengthText, value); }
+        /// <summary>Set by View after user confirms the raw-pointer fallback warning.</summary>
+        public bool MoveRawFallbackConfirmed { get => _moveRawFallbackConfirmed; set => SetField(ref _moveRawFallbackConfirmed, value); }
+        /// <summary>Set by View after user confirms the multi-pointer warning (pointerCount != 1).</summary>
+        public bool MovePointerCountConfirmed { get => _movePointerCountConfirmed; set => SetField(ref _movePointerCountConfirmed, value); }
+        /// <summary>Set by View after user confirms running recompress.</summary>
+        public bool RecompressConfirmed { get => _recompressConfirmed; set => SetField(ref _recompressConfirmed, value); }
+        /// <summary>Set by View after user acknowledges the rom-modified warning (allows continuation).</summary>
+        public bool RecompressModifiedAcknowledged { get => _recompressModifiedAcknowledged; set => SetField(ref _recompressModifiedAcknowledged, value); }
 
         public void Initialize()
         {
@@ -317,6 +338,227 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             {
                 StatusText = R._("Base64 read failed: {0}", ex.Message);
             }
+        }
+
+        // =================== Move tab ===================
+
+        /// <summary>Result enum for two-phase Move confirmation flow.</summary>
+        public enum MovePreflightResult
+        {
+            ProceedNoPrompt,
+            NeedRawFallbackConfirm,
+            NeedPointerCountConfirm,
+            ErrorAlreadyShown,
+        }
+
+        /// <summary>
+        /// Preflight check: parse inputs, search pointers, decide whether
+        /// confirmation is needed. Returns the action the View should take.
+        /// Sets StatusText on validation failures.
+        /// </summary>
+        public MovePreflightResult MovePreflight(out uint srcOffset, out uint dstOffset, out uint length, out LZ77ToolCore.SearchPointerResult searchResult)
+        {
+            srcOffset = 0; dstOffset = 0; length = 0;
+            searchResult = new LZ77ToolCore.SearchPointerResult();
+
+            var rom = CoreState.ROM;
+            if (rom == null)
+            {
+                StatusText = R._("Move: no ROM loaded.");
+                return MovePreflightResult.ErrorAlreadyShown;
+            }
+            if (!TryParseHex(MoveFromText, out uint fromRaw))
+            {
+                StatusText = R._("Move: FROM is not a valid hex value.");
+                return MovePreflightResult.ErrorAlreadyShown;
+            }
+            if (!TryParseHex(MoveToText, out uint toRaw))
+            {
+                StatusText = R._("Move: TO is not a valid hex value.");
+                return MovePreflightResult.ErrorAlreadyShown;
+            }
+            if (!TryParseHex(MoveLengthText, out uint lenRaw))
+            {
+                StatusText = R._("Move: LENGTH is not a valid hex value.");
+                return MovePreflightResult.ErrorAlreadyShown;
+            }
+            if (lenRaw == 0)
+            {
+                StatusText = R._("Move: LENGTH is 0 (cannot auto-detect length).");
+                return MovePreflightResult.ErrorAlreadyShown;
+            }
+
+            srcOffset = U.toOffset(fromRaw);
+            dstOffset = toRaw == 0 ? 0u : U.toOffset(toRaw);
+            length = lenRaw;
+
+            // Look up pointers (LDR-first, raw fallback) so the View can decide
+            // what prompts to surface BEFORE the actual write.
+            searchResult = LZ77ToolCore.SearchPointersForAddress(rom.Data, srcOffset);
+
+            if (searchResult.UsedRawFallback && !MoveRawFallbackConfirmed)
+                return MovePreflightResult.NeedRawFallbackConfirm;
+            if (searchResult.Pointers.Count != 1 && !MovePointerCountConfirmed)
+                return MovePreflightResult.NeedPointerCountConfirm;
+            return MovePreflightResult.ProceedNoPrompt;
+        }
+
+        /// <summary>
+        /// Apply the move. Caller is responsible for calling
+        /// <see cref="MovePreflight"/> first and handling the confirmation
+        /// prompts via <see cref="MoveRawFallbackConfirmed"/> +
+        /// <see cref="MovePointerCountConfirmed"/>.
+        /// </summary>
+        public LZ77ToolCore.MoveResult RunMove()
+        {
+            var rom = CoreState.ROM;
+            if (rom == null)
+            {
+                StatusText = R._("Move: no ROM loaded.");
+                return new LZ77ToolCore.MoveResult { Ok = false, ErrorMessage = "no ROM" };
+            }
+            var preflight = MovePreflight(out uint srcOffset, out uint dstOffset, out uint length, out _);
+            if (preflight == MovePreflightResult.ErrorAlreadyShown)
+            {
+                return new LZ77ToolCore.MoveResult { Ok = false, ErrorMessage = StatusText };
+            }
+            if (preflight != MovePreflightResult.ProceedNoPrompt)
+            {
+                StatusText = R._("Move: pending user confirmation — see prompt.");
+                return new LZ77ToolCore.MoveResult { Ok = false, ErrorMessage = "pending confirmation" };
+            }
+
+            LZ77ToolCore.MoveResult result;
+            try
+            {
+                _undo.Begin($"MoveLZ77 0x{srcOffset:X8} -> 0x{dstOffset:X8} ({length} bytes)");
+                result = LZ77ToolCore.MoveCompressedData(rom, srcOffset, dstOffset, length);
+                if (result.Ok) _undo.Commit();
+                else
+                {
+                    if (_undo.HasPendingUndo)
+                        try { _undo.Rollback(); } catch (Exception rbEx) { Log.Error("Move rollback failed: {0}", rbEx.Message); }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (_undo.HasPendingUndo)
+                    try { _undo.Rollback(); } catch (Exception rbEx) { Log.Error("Move rollback failed: {0}", rbEx.Message); }
+                StatusText = R._("Move failed: {0}", ex.Message);
+                return new LZ77ToolCore.MoveResult { Ok = false, ErrorMessage = ex.Message };
+            }
+            finally
+            {
+                // Reset confirmation flags so subsequent moves require fresh confirmation.
+                MoveRawFallbackConfirmed = false;
+                MovePointerCountConfirmed = false;
+            }
+
+            if (result.Ok)
+            {
+                StatusText = R._("Move: moved 0x{0:X} bytes from 0x{1:X8} to 0x{2:X8} ({3} pointers rewritten{4}).",
+                    length, srcOffset, result.NewAddress, result.PointersRewritten.Count,
+                    result.AutoAllocated ? ", auto-allocated" : "");
+            }
+            else
+            {
+                StatusText = R._("Move: {0}", result.ErrorMessage);
+            }
+            return result;
+        }
+
+        // =================== Recompress tab ===================
+
+        /// <summary>Result enum for two-phase Recompress confirmation flow.</summary>
+        public enum RecompressPreflightResult
+        {
+            ProceedNoPrompt,
+            NeedConfirm,
+            NeedRomModifiedAck,
+            ErrorAlreadyShown,
+        }
+
+        /// <summary>
+        /// Preflight check for Recompress: validates ROM is loaded and not
+        /// modified. Returns the action the View should take.
+        /// </summary>
+        public RecompressPreflightResult RecompressPreflight()
+        {
+            var rom = CoreState.ROM;
+            if (rom == null)
+            {
+                StatusText = R._("Recompress: no ROM loaded.");
+                return RecompressPreflightResult.ErrorAlreadyShown;
+            }
+            if (rom.Modified && !RecompressModifiedAcknowledged)
+                return RecompressPreflightResult.NeedRomModifiedAck;
+            if (!RecompressConfirmed)
+                return RecompressPreflightResult.NeedConfirm;
+            return RecompressPreflightResult.ProceedNoPrompt;
+        }
+
+        /// <summary>
+        /// Run recompress: scan, iterate candidates, recompress each.
+        /// Caller is responsible for calling <see cref="RecompressPreflight"/>
+        /// first and handling confirmation via <see cref="RecompressConfirmed"/>.
+        /// </summary>
+        public (uint totalSize, uint totalCount) RunRecompress()
+        {
+            var rom = CoreState.ROM;
+            if (rom == null)
+            {
+                StatusText = R._("Recompress: no ROM loaded.");
+                return (0, 0);
+            }
+            var preflight = RecompressPreflight();
+            if (preflight == RecompressPreflightResult.ErrorAlreadyShown)
+                return (0, 0);
+            if (preflight != RecompressPreflightResult.ProceedNoPrompt)
+            {
+                StatusText = R._("Recompress: pending user confirmation — see prompt.");
+                return (0, 0);
+            }
+
+            uint totalSize = 0;
+            uint totalCount = 0;
+            try
+            {
+                List<Address> candidates = LZ77ToolCore.ScanForLZ77Candidates(rom);
+                _undo.Begin("RecompressLZ77");
+                foreach (var a in candidates)
+                {
+                    var r = LZ77ToolCore.RecompressAt(rom, a.Addr, a.Length);
+                    if (r.Ok && r.SavedBytes > 0)
+                    {
+                        totalSize += r.SavedBytes;
+                        totalCount++;
+                    }
+                }
+                _undo.Commit();
+            }
+            catch (Exception ex)
+            {
+                if (_undo.HasPendingUndo)
+                    try { _undo.Rollback(); } catch (Exception rbEx) { Log.Error("Recompress rollback failed: {0}", rbEx.Message); }
+                StatusText = R._("Recompress failed: {0}", ex.Message);
+                return (0, 0);
+            }
+            finally
+            {
+                RecompressConfirmed = false;
+                RecompressModifiedAcknowledged = false;
+            }
+
+            if (totalSize == 0)
+            {
+                StatusText = R._("Recompress: no savings — all entries already optimally compressed.");
+            }
+            else
+            {
+                StatusText = R._("Recompress: {0} entries recompressed, {1} bytes saved. Heuristic scan — may miss entries WinForms catches.",
+                    totalCount, totalSize);
+            }
+            return (totalSize, totalCount);
         }
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ToolLZ77View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolLZ77View.axaml
@@ -95,6 +95,52 @@
         </DockPanel>
       </TabItem>
 
+      <TabItem Header="Move" AutomationProperties.AutomationId="ToolLZ77_Move_Tab">
+        <ScrollViewer>
+          <StackPanel Spacing="8" Margin="8">
+            <Grid ColumnDefinitions="140,8,*" RowDefinitions="Auto,8,Auto,8,Auto">
+              <TextBlock Grid.Row="0" Grid.Column="0" Text="FROM:" VerticalAlignment="Center" />
+              <TextBox AutomationProperties.AutomationId="ToolLZ77_MoveFrom_Input" Grid.Row="0" Grid.Column="2" Text="{Binding MoveFromText}" Watermark="0x0 (source offset)" />
+
+              <TextBlock Grid.Row="2" Grid.Column="0" Text="TO:" VerticalAlignment="Center" />
+              <TextBox AutomationProperties.AutomationId="ToolLZ77_MoveTo_Input" Grid.Row="2" Grid.Column="2" Text="{Binding MoveToText}" Watermark="0x0 (destination, 0 = auto-allocate)" />
+
+              <TextBlock Grid.Row="4" Grid.Column="0" Text="LENGTH:" VerticalAlignment="Center" />
+              <TextBox AutomationProperties.AutomationId="ToolLZ77_MoveLength_Input" Grid.Row="4" Grid.Column="2" Text="{Binding MoveLengthText}" Watermark="length in bytes (hex)" />
+            </Grid>
+
+            <Button AutomationProperties.AutomationId="ToolLZ77_Move_Button" Content="Move This Region" Click="Move_Click" Height="36" HorizontalAlignment="Stretch" />
+
+            <Border BorderBrush="LightGray" BorderThickness="1" Padding="8" CornerRadius="2">
+              <StackPanel Spacing="4">
+                <TextBlock Text="Move arbitrary binary data (LZ77 or otherwise) to a new address. TO = 0 auto-allocates from free space (or appends to end). Pointer references are rewritten."
+                           TextWrapping="Wrap" FontSize="11" Foreground="Gray" />
+                <TextBlock Text="Limitation: event-script-aware pointer search is not included (WinForms-only). If your data is referenced from event scripts or struct pointer tables, perform Move in WinForms."
+                           TextWrapping="Wrap" FontSize="11" Foreground="DarkOrange" />
+              </StackPanel>
+            </Border>
+          </StackPanel>
+        </ScrollViewer>
+      </TabItem>
+
+      <TabItem Header="Recompress" AutomationProperties.AutomationId="ToolLZ77_Recompress_Tab">
+        <ScrollViewer>
+          <StackPanel Spacing="8" Margin="8">
+            <Border BorderBrush="LightGray" BorderThickness="1" Padding="8" CornerRadius="2">
+              <StackPanel Spacing="4">
+                <TextBlock Text="LZ77 Recompress (since 2026)" FontWeight="Bold" />
+                <TextBlock Text="Walks ROM for LZ77-compressed entries and re-compresses each with the current encoder. Any savings can be reclaimed via Rebuild later. Process takes several minutes for a full ROM scan."
+                           TextWrapping="Wrap" FontSize="11" Foreground="Gray" />
+                <TextBlock Text="Heuristic scan: this tool does NOT use WinForms MakeAllStructPointersList — it may miss entries referenced only from event scripts or struct pointer tables. For best coverage, run Recompress in WinForms."
+                           TextWrapping="Wrap" FontSize="11" Foreground="DarkOrange" />
+              </StackPanel>
+            </Border>
+
+            <Button AutomationProperties.AutomationId="ToolLZ77_Recompress_Button" Content="Run LZ77 Recompress" Click="Recompress_Click" Height="36" HorizontalAlignment="Stretch" />
+          </StackPanel>
+        </ScrollViewer>
+      </TabItem>
+
     </TabControl>
   </DockPanel>
 </Window>

--- a/FEBuilderGBA.Avalonia/Views/ToolLZ77View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolLZ77View.axaml.cs
@@ -180,6 +180,11 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void Recompress_Click(object? sender, RoutedEventArgs e)
         {
+            // Always start a fresh confirmation flow — cancellation at any prompt
+            // below must NOT leave stale flags that auto-skip prompts on next click.
+            _vm.RecompressModifiedAcknowledged = false;
+            _vm.RecompressConfirmed = false;
+
             var preflight = _vm.RecompressPreflight();
             if (preflight == ToolLZ77ViewModel.RecompressPreflightResult.ErrorAlreadyShown)
                 return;
@@ -208,12 +213,27 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (dr != MessageBoxResult.Yes)
                 {
                     _vm.StatusText = R._("Recompress: canceled by user.");
+                    // Reset acknowledgement too — the user has not yet started a real run.
+                    _vm.RecompressModifiedAcknowledged = false;
                     return;
                 }
                 _vm.RecompressConfirmed = true;
             }
 
-            _vm.RunRecompress();
+            // Run the (potentially multi-minute) scan + recompress off the UI thread
+            // so the window stays responsive. IsBusy disables interactions and acts as
+            // a re-entrancy guard against double-clicks.
+            if (_vm.IsBusy) return;
+            _vm.IsBusy = true;
+            _vm.StatusText = R._("Recompress: running (this may take several minutes)...");
+            try
+            {
+                await System.Threading.Tasks.Task.Run(() => _vm.RunRecompress());
+            }
+            finally
+            {
+                _vm.IsBusy = false;
+            }
         }
 
         public void NavigateTo(uint address) { }

--- a/FEBuilderGBA.Avalonia/Views/ToolLZ77View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolLZ77View.axaml.cs
@@ -113,6 +113,101 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.RunFileToBase64Text(path);
         }
 
+        async void Move_Click(object? sender, RoutedEventArgs e)
+        {
+            // Two-phase: preflight, prompt as needed, then execute.
+            var preflight = _vm.MovePreflight(out uint srcOffset, out uint dstOffset, out uint length, out var sp);
+            if (preflight == ToolLZ77ViewModel.MovePreflightResult.ErrorAlreadyShown)
+                return;
+
+            // Optional raw-fallback warning.
+            if (preflight == ToolLZ77ViewModel.MovePreflightResult.NeedRawFallbackConfirm)
+            {
+                var dr = await MessageBoxWindow.Show(this,
+                    R._("LDR pointer search returned no hits. Falling back to a raw 4-byte binary pointer scan (may match unrelated bytes). Continue?"),
+                    R._("Confirm Raw Pointer Fallback"),
+                    MessageBoxMode.YesNo);
+                if (dr != MessageBoxResult.Yes)
+                {
+                    _vm.StatusText = R._("Move: canceled at raw-fallback prompt.");
+                    return;
+                }
+                _vm.MoveRawFallbackConfirmed = true;
+                // Re-run preflight after confirmation.
+                preflight = _vm.MovePreflight(out srcOffset, out dstOffset, out length, out sp);
+            }
+
+            // Optional pointer-count warning.
+            if (preflight == ToolLZ77ViewModel.MovePreflightResult.NeedPointerCountConfirm)
+            {
+                var dr = await MessageBoxWindow.Show(this,
+                    R._("{0} pointer reference(s) will be rewritten. Continue?", sp.Pointers.Count),
+                    R._("Confirm Multi-Pointer Move"),
+                    MessageBoxMode.YesNo);
+                if (dr != MessageBoxResult.Yes)
+                {
+                    _vm.StatusText = R._("Move: canceled at pointer-count prompt.");
+                    return;
+                }
+                _vm.MovePointerCountConfirmed = true;
+            }
+
+            // Final main-confirm prompt.
+            var confirm = await MessageBoxWindow.Show(this,
+                R._("Move 0x{0:X} bytes from 0x{1:X8} to 0x{2:X8}{3}?",
+                    length, srcOffset, dstOffset,
+                    dstOffset == 0 ? " (auto-allocate)" : ""),
+                R._("Confirm Move"),
+                MessageBoxMode.YesNo);
+            if (confirm != MessageBoxResult.Yes)
+            {
+                _vm.StatusText = R._("Move: canceled at final prompt.");
+                _vm.MoveRawFallbackConfirmed = false;
+                _vm.MovePointerCountConfirmed = false;
+                return;
+            }
+
+            _vm.RunMove();
+        }
+
+        async void Recompress_Click(object? sender, RoutedEventArgs e)
+        {
+            var preflight = _vm.RecompressPreflight();
+            if (preflight == ToolLZ77ViewModel.RecompressPreflightResult.ErrorAlreadyShown)
+                return;
+
+            if (preflight == ToolLZ77ViewModel.RecompressPreflightResult.NeedRomModifiedAck)
+            {
+                var dr = await MessageBoxWindow.Show(this,
+                    R._("ROM has unsaved modifications. Save first before recompressing? (Pressing No will proceed anyway, which is risky.)"),
+                    R._("Confirm Recompress"),
+                    MessageBoxMode.YesNo);
+                if (dr == MessageBoxResult.Yes)
+                {
+                    _vm.StatusText = R._("Recompress: save ROM and retry.");
+                    return;
+                }
+                _vm.RecompressModifiedAcknowledged = true;
+                preflight = _vm.RecompressPreflight();
+            }
+
+            if (preflight == ToolLZ77ViewModel.RecompressPreflightResult.NeedConfirm)
+            {
+                var dr = await MessageBoxWindow.Show(this,
+                    R._("Run LZ77 recompress? This walks the entire ROM (slow) and rewrites any entries that compress smaller. Heuristic scan — may miss entries WinForms catches."),
+                    R._("Confirm Recompress"),
+                    MessageBoxMode.YesNo);
+                if (dr != MessageBoxResult.Yes)
+                {
+                    _vm.StatusText = R._("Recompress: canceled by user.");
+                    return;
+                }
+                _vm.RecompressConfirmed = true;
+            }
+
+            _vm.RunRecompress();
+        }
+
         public void NavigateTo(uint address) { }
         public void SelectFirstItem() { }
     }

--- a/FEBuilderGBA.Avalonia/Views/ToolLZ77View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolLZ77View.axaml.cs
@@ -115,6 +115,11 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void Move_Click(object? sender, RoutedEventArgs e)
         {
+            // Always start a fresh confirmation flow — cancellation at any prompt
+            // below must NOT leave stale flags that auto-skip prompts on next click.
+            _vm.MoveRawFallbackConfirmed = false;
+            _vm.MovePointerCountConfirmed = false;
+
             // Two-phase: preflight, prompt as needed, then execute.
             var preflight = _vm.MovePreflight(out uint srcOffset, out uint dstOffset, out uint length, out var sp);
             if (preflight == ToolLZ77ViewModel.MovePreflightResult.ErrorAlreadyShown)
@@ -147,6 +152,9 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (dr != MessageBoxResult.Yes)
                 {
                     _vm.StatusText = R._("Move: canceled at pointer-count prompt.");
+                    // Reset BOTH flags — earlier raw-fallback approval is now stale.
+                    _vm.MoveRawFallbackConfirmed = false;
+                    _vm.MovePointerCountConfirmed = false;
                     return;
                 }
                 _vm.MovePointerCountConfirmed = true;

--- a/FEBuilderGBA.Core.Tests/LZ77ToolCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/LZ77ToolCoreTests.cs
@@ -159,6 +159,72 @@ namespace FEBuilderGBA.Core.Tests
             Assert.True(result.NewAddress < rom.Data.Length);
         }
 
+        // -------- Auto-allocate slack regression (PR #481 review point 1) --------
+
+        [Fact]
+        public void MoveCompressedData_AutoAllocate_ExactSizedFreeRun_DoesNotClobberSentinel()
+        {
+            // Regression: AutoAllocateDestination must request slack + payload bytes
+            // so that returning `freespace + 16` does NOT write past the free area.
+            // Place a sentinel just past an exact-sized free run and verify it's untouched.
+            var rom = CreateRom(0x10000);
+            // Fill most of ROM with 0xFF to leave only a small free run.
+            for (int i = 0x100; i < rom.Data.Length; i++) rom.Data[i] = 0xFF;
+            // Create a free run from 0x2000 to 0x2100 (256 bytes), surrounded by 0xFF.
+            uint runStart = 0x2000;
+            uint runSize = 0x100;
+            for (uint i = runStart; i < runStart + runSize; i++) rom.Data[i] = 0;
+            // Place a sentinel BYTE just past the free run.
+            uint sentinelAddr = runStart + runSize;
+            byte sentinel = 0xAB;
+            rom.Data[sentinelAddr] = sentinel;
+            // Mark source payload (small).
+            byte[] payload = { 1, 2, 3, 4 };
+            for (int i = 0; i < payload.Length; i++) rom.Data[0x500 + i] = payload[i];
+
+            var result = LZ77ToolCore.MoveCompressedData(rom, 0x500, 0, (uint)payload.Length);
+            // Regardless of where the allocator chose to land (free run + 16 or end-of-file),
+            // the sentinel just past the free run must NOT be clobbered.
+            Assert.True(result.Ok, result.ErrorMessage);
+            Assert.Equal(sentinel, rom.Data[sentinelAddr]);
+        }
+
+        // -------- Overlap rejection regression (PR #481 review point 2) --------
+
+        [Fact]
+        public void MoveCompressedData_OverlappingDestInsideSource_Rejects()
+        {
+            var rom = CreateRom(0x10000);
+            // Source: 0x1000..0x1100 (256 bytes).
+            for (int i = 0; i < 256; i++) rom.Data[0x1000 + i] = (byte)(i & 0xFF);
+            // Destination INSIDE source: 0x1080.
+            var result = LZ77ToolCore.MoveCompressedData(rom, 0x1000, 0x1080, 0x100);
+            Assert.False(result.Ok);
+            Assert.Contains("overlap", result.ErrorMessage, System.StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void MoveCompressedData_OverlappingSourceInsideDest_Rejects()
+        {
+            var rom = CreateRom(0x10000);
+            // Source: 0x2000..0x2010 (16 bytes) — inside larger destination 0x1F80..0x2080.
+            for (int i = 0; i < 16; i++) rom.Data[0x2000 + i] = (byte)(i + 1);
+            // Destination range overlapping with source.
+            var result = LZ77ToolCore.MoveCompressedData(rom, 0x2000, 0x1F80, 0x100);
+            Assert.False(result.Ok);
+            Assert.Contains("overlap", result.ErrorMessage, System.StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void MoveCompressedData_AdjacentNonOverlapping_Succeeds()
+        {
+            var rom = CreateRom(0x10000);
+            for (int i = 0; i < 16; i++) rom.Data[0x1000 + i] = (byte)(i + 1);
+            // Destination immediately AFTER source (no overlap: dest start == src end).
+            var result = LZ77ToolCore.MoveCompressedData(rom, 0x1000, 0x1010, 0x10);
+            Assert.True(result.Ok, result.ErrorMessage);
+        }
+
         // -------- Pointer-search gating (review point 2) --------
 
         [Fact]

--- a/FEBuilderGBA.Core.Tests/LZ77ToolCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/LZ77ToolCoreTests.cs
@@ -378,6 +378,19 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void RecompressAt_AllocatedLengthNotAligned_ReturnsError()
+        {
+            // PR #481 review point 4: allocatedLength must be 4-byte aligned
+            // because the helper docstring promises 4-aligned semantics.
+            var rom = CreateRom();
+            rom.Data[0x100] = 0x10;
+            // Use any non-4-aligned allocated length.
+            var r = LZ77ToolCore.RecompressAt(rom, 0x100, 0x101);
+            Assert.False(r.Ok);
+            Assert.Contains("not 4-byte aligned", r.ErrorMessage);
+        }
+
+        [Fact]
         public void RecompressAt_BadUncompressSize_ReturnsZero()
         {
             var rom = CreateRom();

--- a/FEBuilderGBA.Core.Tests/LZ77ToolCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/LZ77ToolCoreTests.cs
@@ -1,0 +1,420 @@
+using System.Collections.Generic;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// Tests for LZ77ToolCore — the cross-platform helpers powering the LZ77
+    /// Tool's Move + Recompress tabs. Closes the residual scope of issue #371
+    /// from PR #468.
+    /// </summary>
+    [Collection("SharedState")]
+    public class LZ77ToolCoreTests
+    {
+        static ROM CreateRom(int size = 0x10000)
+        {
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(new byte[size]);
+            CoreState.ROM = rom;
+            return rom;
+        }
+
+        static Undo.UndoData NewUndoData(ROM rom, string name = "test")
+        {
+            return new Undo.UndoData
+            {
+                time = System.DateTime.Now,
+                name = name,
+                list = new List<Undo.UndoPostion>(),
+                filesize = (uint)rom.Data.Length,
+            };
+        }
+
+        // -------- MoveCompressedData: validation paths --------
+
+        [Fact]
+        public void MoveCompressedData_NullRom_Fails()
+        {
+            var result = LZ77ToolCore.MoveCompressedData(null, 0x1000, 0x2000, 0x10);
+            Assert.False(result.Ok);
+            Assert.Contains("ROM is null", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void MoveCompressedData_ZeroSrcAddr_Fails()
+        {
+            var rom = CreateRom();
+            var result = LZ77ToolCore.MoveCompressedData(rom, 0, 0x2000, 0x10);
+            Assert.False(result.Ok);
+            Assert.Contains("source address is 0", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void MoveCompressedData_ZeroLength_Fails()
+        {
+            var rom = CreateRom();
+            var result = LZ77ToolCore.MoveCompressedData(rom, 0x1000, 0x2000, 0);
+            Assert.False(result.Ok);
+            Assert.Contains("length is 0", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void MoveCompressedData_LengthTooLarge_Fails()
+        {
+            var rom = CreateRom();
+            var result = LZ77ToolCore.MoveCompressedData(rom, 0x1000, 0x2000, LZ77ToolCore.MOVE_LENGTH_LIMIT);
+            Assert.False(result.Ok);
+            Assert.Contains("too large", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void MoveCompressedData_SrcOutOfBounds_Fails()
+        {
+            var rom = CreateRom(0x1000);
+            var result = LZ77ToolCore.MoveCompressedData(rom, 0xF00, 0x100, 0x500);
+            Assert.False(result.Ok);
+            Assert.Contains("source range", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void MoveCompressedData_DestOutOfBounds_Fails()
+        {
+            var rom = CreateRom(0x1000);
+            rom.Data[0x500] = 0x01; // make srcBytes not all-zero
+            var result = LZ77ToolCore.MoveCompressedData(rom, 0x500, 0xF80, 0x100);
+            Assert.False(result.Ok);
+            Assert.Contains("destination range", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void MoveCompressedData_AlreadyMoved_Fails()
+        {
+            var rom = CreateRom();
+            // 0x1000 + 0x10 of all-zeros -> "already moved" guard.
+            var result = LZ77ToolCore.MoveCompressedData(rom, 0x1000, 0x2000, 0x10);
+            Assert.False(result.Ok);
+            Assert.Contains("already moved", result.ErrorMessage);
+        }
+
+        // -------- MoveCompressedData: success paths --------
+
+        [Fact]
+        public void MoveCompressedData_BasicMove_CopiesAndZerosSource()
+        {
+            var rom = CreateRom();
+            // Source payload.
+            byte[] payload = { 0xDE, 0xAD, 0xBE, 0xEF, 0x12, 0x34, 0x56, 0x78 };
+            for (int i = 0; i < payload.Length; i++) rom.Data[0x1000 + i] = payload[i];
+
+            var result = LZ77ToolCore.MoveCompressedData(rom, 0x1000, 0x4000, (uint)payload.Length);
+            Assert.True(result.Ok, result.ErrorMessage);
+            Assert.Equal(0x4000u, result.NewAddress);
+            Assert.False(result.AutoAllocated);
+            // Source zeroed, destination has payload.
+            for (int i = 0; i < payload.Length; i++)
+            {
+                Assert.Equal(0, rom.Data[0x1000 + i]);
+                Assert.Equal(payload[i], rom.Data[0x4000 + i]);
+            }
+        }
+
+        [Fact]
+        public void MoveCompressedData_AutoAllocate_ZeroToAddr_AllocatesAtEnd()
+        {
+            // Small ROM where free space search fits at end-of-file.
+            var rom = CreateRom(0x800);
+            // Fill almost everything so FindFreeSpace doesn't find a hole.
+            for (int i = 0x100; i < rom.Data.Length; i++) rom.Data[i] = 0x55;
+            // Mark source payload.
+            byte[] payload = { 1, 2, 3, 4 };
+            for (int i = 0; i < payload.Length; i++) rom.Data[0x200 + i] = payload[i];
+
+            uint origLen = (uint)rom.Data.Length;
+            var result = LZ77ToolCore.MoveCompressedData(rom, 0x200, 0, (uint)payload.Length);
+
+            Assert.True(result.Ok, result.ErrorMessage);
+            Assert.True(result.AutoAllocated);
+            Assert.True(result.NewAddress >= origLen,
+                $"NewAddress 0x{result.NewAddress:X} should be at original end 0x{origLen:X}");
+            // Source zeroed.
+            for (int i = 0; i < payload.Length; i++) Assert.Equal(0, rom.Data[0x200 + i]);
+            // Destination has payload.
+            for (int i = 0; i < payload.Length; i++)
+                Assert.Equal(payload[i], rom.Data[result.NewAddress + i]);
+        }
+
+        [Fact]
+        public void MoveCompressedData_AutoAllocate_FindsFreeSpaceBeforeEnd()
+        {
+            var rom = CreateRom(0x10000);
+            // ROM is all zeros -> FindFreeSpace will return a low offset.
+            // Mark source payload.
+            byte[] payload = { 9, 8, 7, 6 };
+            for (int i = 0; i < payload.Length; i++) rom.Data[0x1000 + i] = payload[i];
+
+            var result = LZ77ToolCore.MoveCompressedData(rom, 0x1000, 0, (uint)payload.Length);
+            Assert.True(result.Ok, result.ErrorMessage);
+            Assert.True(result.AutoAllocated);
+            Assert.True(result.NewAddress < rom.Data.Length);
+        }
+
+        // -------- Pointer-search gating (review point 2) --------
+
+        [Fact]
+        public void SearchPointers_ZeroAddress_ReturnsEmpty()
+        {
+            var rom = CreateRom();
+            var r = LZ77ToolCore.SearchPointersForAddress(rom.Data, 0);
+            Assert.Empty(r.Pointers);
+            Assert.False(r.UsedRawFallback);
+            Assert.True(r.MissingEventAwareCoverage);
+        }
+
+        [Fact]
+        public void SearchPointers_LdrHits_DoesNotFallbackToRaw()
+        {
+            var rom = CreateRom();
+            // Place a synthetic LDR-style pointer reference at 0x500 -> 0x1000.
+            // GrepLDRData scans Thumb 0x4800..0x4Fxx + PC-relative target alignment.
+            // For test purposes the simpler check is: if LDR returns >=1, raw is NOT run.
+            // Inject the LDR pattern: at addr 0x500 put "01 48" (LDR r0, [pc, #4]) so
+            // PC-relative target = (0x500+4) aligned + 1*4 = 0x508. Place pointer 0x08001000 at 0x508.
+            rom.Data[0x500] = 0x01;
+            rom.Data[0x501] = 0x48;
+            U.write_u32(rom.Data, 0x508, 0x08001000);
+
+            // Also place a raw 4-byte pointer 0x08001000 somewhere else (would be a "raw hit").
+            U.write_u32(rom.Data, 0x800, 0x08001000);
+
+            var r = LZ77ToolCore.SearchPointersForAddress(rom.Data, 0x1000);
+            Assert.False(r.UsedRawFallback);
+            Assert.True(r.MissingEventAwareCoverage);
+            // LDR hit was at 0x508 (the data pointer location). Raw 0x800 hit should NOT appear.
+            Assert.Contains(0x508u, r.Pointers);
+            Assert.DoesNotContain(0x800u, r.Pointers);
+        }
+
+        [Fact]
+        public void SearchPointers_NoLdrHits_FallsBackToRawAndSetsFlag()
+        {
+            var rom = CreateRom();
+            // Place only a raw 4-byte pointer at 0x800 (no LDR pattern anywhere).
+            U.write_u32(rom.Data, 0x800, 0x08001000);
+
+            var r = LZ77ToolCore.SearchPointersForAddress(rom.Data, 0x1000);
+            Assert.True(r.UsedRawFallback);
+            Assert.True(r.MissingEventAwareCoverage);
+            Assert.Contains(0x800u, r.Pointers);
+        }
+
+        [Fact]
+        public void SearchPointers_AlwaysSetsMissingEventAwareCoverageFlag()
+        {
+            var rom = CreateRom();
+            // Empty result: still has MissingEventAwareCoverage = true.
+            var r = LZ77ToolCore.SearchPointersForAddress(rom.Data, 0x9999);
+            Assert.True(r.MissingEventAwareCoverage);
+        }
+
+        // -------- Move + pointer rewrite --------
+
+        [Fact]
+        public void MoveCompressedData_RewritesLDRPointer()
+        {
+            var rom = CreateRom();
+            // Source data at 0x1000.
+            byte[] payload = { 1, 2, 3, 4 };
+            for (int i = 0; i < payload.Length; i++) rom.Data[0x1000 + i] = payload[i];
+            // LDR pattern at 0x500 -> 0x508; the value at 0x508 is the pointer (0x08001000).
+            rom.Data[0x500] = 0x01;
+            rom.Data[0x501] = 0x48;
+            U.write_u32(rom.Data, 0x508, 0x08001000);
+
+            var result = LZ77ToolCore.MoveCompressedData(rom, 0x1000, 0x4000, (uint)payload.Length);
+            Assert.True(result.Ok, result.ErrorMessage);
+            // Pointer at 0x508 should now read 0x08004000.
+            uint rewritten = U.u32(rom.Data, 0x508);
+            Assert.Equal(0x08004000u, rewritten);
+            Assert.Contains(0x508u, result.PointersRewritten);
+        }
+
+        [Fact]
+        public void MoveCompressedData_RewritesRawPointer_WhenNoLDR()
+        {
+            var rom = CreateRom();
+            // Source data at 0x1000.
+            byte[] payload = { 1, 2, 3, 4 };
+            for (int i = 0; i < payload.Length; i++) rom.Data[0x1000 + i] = payload[i];
+            // Raw 4-byte pointer (no LDR pattern).
+            U.write_u32(rom.Data, 0x800, 0x08001000);
+
+            var result = LZ77ToolCore.MoveCompressedData(rom, 0x1000, 0x4000, (uint)payload.Length);
+            Assert.True(result.Ok, result.ErrorMessage);
+            Assert.True(result.UsedRawFallback);
+            uint rewritten = U.u32(rom.Data, 0x800);
+            Assert.Equal(0x08004000u, rewritten);
+            Assert.Contains(0x800u, result.PointersRewritten);
+        }
+
+        // -------- Undo non-duplication (review point 1) --------
+
+        [Fact]
+        public void MoveCompressedData_WithBeginUndoScope_RecordsPositionsOnceNoDuplicates()
+        {
+            var rom = CreateRom();
+            byte[] payload = { 0xAB, 0xCD, 0xEF, 0x01 };
+            for (int i = 0; i < payload.Length; i++) rom.Data[0x1000 + i] = payload[i];
+
+            var ud = NewUndoData(rom);
+            using (ROM.BeginUndoScope(ud))
+            {
+                var result = LZ77ToolCore.MoveCompressedData(rom, 0x1000, 0x4000, (uint)payload.Length);
+                Assert.True(result.Ok);
+            }
+
+            // Expected: 1 write_range(dest, 4) + 1 write_fill(src, 4) = 2 positions.
+            // No pointer rewrites in this test (no pointers placed) so it's just 2.
+            Assert.Equal(2, ud.list.Count);
+            // Verify all are unique pairs (no duplicate addr+length).
+            var unique = new HashSet<(uint, int)>();
+            foreach (var p in ud.list) unique.Add((p.addr, p.data.Length));
+            Assert.Equal(ud.list.Count, unique.Count);
+        }
+
+        // -------- RecompressAt validation --------
+
+        [Fact]
+        public void RecompressAt_NullRom_Fails()
+        {
+            var r = LZ77ToolCore.RecompressAt(null, 0x100, 0x100);
+            Assert.False(r.Ok);
+            Assert.Contains("ROM is null", r.ErrorMessage);
+        }
+
+        [Fact]
+        public void RecompressAt_NotAligned_ReturnsZero()
+        {
+            var rom = CreateRom();
+            var r = LZ77ToolCore.RecompressAt(rom, 0x101, 0x100);
+            Assert.False(r.Ok);
+            Assert.Contains("4-byte aligned", r.ErrorMessage);
+        }
+
+        [Fact]
+        public void RecompressAt_NotLZ77Magic_ReturnsZero()
+        {
+            var rom = CreateRom();
+            rom.Data[0x100] = 0x55; // not 0x10
+            var r = LZ77ToolCore.RecompressAt(rom, 0x100, 0x100);
+            Assert.False(r.Ok);
+            Assert.Contains("not LZ77 magic", r.ErrorMessage);
+        }
+
+        [Fact]
+        public void RecompressAt_BadUncompressSize_ReturnsZero()
+        {
+            var rom = CreateRom();
+            rom.Data[0x100] = 0x10;
+            // header size = 0 -> getUncompressSize returns 0.
+            rom.Data[0x101] = 0;
+            rom.Data[0x102] = 0;
+            rom.Data[0x103] = 0;
+            var r = LZ77ToolCore.RecompressAt(rom, 0x100, 0x100);
+            Assert.False(r.Ok);
+            Assert.Contains("getUncompressSize=0", r.ErrorMessage);
+        }
+
+        [Fact]
+        public void RecompressAt_WriteBoundedByAllocatedLength()
+        {
+            var rom = CreateRom();
+            // Build a valid LZ77 stream that's larger than necessary.
+            // Take a small, repetitive uncompressed payload, compress it, place it at 0x200.
+            byte[] uncompressed = new byte[64];
+            for (int i = 0; i < uncompressed.Length; i++) uncompressed[i] = (byte)(i % 4);
+            byte[] compressed = LZ77.compress(uncompressed);
+            // Place at 0x200 with extra padding (allocatedLength bigger than actual compressed size).
+            for (int i = 0; i < compressed.Length; i++) rom.Data[0x200 + i] = compressed[i];
+            // Pad after with non-zero sentinel so we can verify it gets zeroed.
+            uint allocatedLength = U.Padding4((uint)compressed.Length) + 32u;
+            for (uint i = (uint)compressed.Length; i < allocatedLength; i++)
+                rom.Data[0x200 + i] = 0xAA;
+            // Ensure post-allocation area has a sentinel that must NOT be touched.
+            uint postAddr = 0x200 + allocatedLength;
+            rom.Data[postAddr] = 0xFF;
+            rom.Data[postAddr + 1] = 0xFF;
+
+            var r = LZ77ToolCore.RecompressAt(rom, 0x200, allocatedLength);
+            // Either succeeded with savings or returned no-benefit; either way the
+            // post-allocation byte must be untouched.
+            Assert.True(r.Ok, r.ErrorMessage);
+            Assert.Equal(0xFF, rom.Data[postAddr]);
+            Assert.Equal(0xFF, rom.Data[postAddr + 1]);
+        }
+
+        [Fact]
+        public void RecompressAt_AlreadyOptimal_ReturnsZero()
+        {
+            var rom = CreateRom();
+            // Place an already-optimal compressed stream at 0x300 with exact allocatedLength.
+            byte[] uncompressed = new byte[16];
+            for (int i = 0; i < 16; i++) uncompressed[i] = (byte)i;
+            byte[] compressed = LZ77.compress(uncompressed);
+            for (int i = 0; i < compressed.Length; i++) rom.Data[0x300 + i] = compressed[i];
+
+            uint allocatedLength = U.Padding4((uint)compressed.Length);
+            var r = LZ77ToolCore.RecompressAt(rom, 0x300, allocatedLength);
+            // Same size -> savings = 0 -> Ok=true but SavedBytes=0.
+            Assert.True(r.Ok);
+            Assert.Equal(0u, r.SavedBytes);
+        }
+
+        // -------- ScanForLZ77Candidates --------
+
+        [Fact]
+        public void ScanForLZ77Candidates_FindsValidEntry()
+        {
+            var rom = CreateRom();
+            byte[] uncompressed = new byte[64];
+            for (int i = 0; i < 64; i++) uncompressed[i] = (byte)(i & 3);
+            byte[] compressed = LZ77.compress(uncompressed);
+
+            // Place at 0x400 (4-byte aligned).
+            for (int i = 0; i < compressed.Length; i++) rom.Data[0x400 + i] = compressed[i];
+
+            var list = LZ77ToolCore.ScanForLZ77Candidates(rom);
+            Assert.Contains(list, a => a.Addr == 0x400);
+        }
+
+        [Fact]
+        public void ScanForLZ77Candidates_DedupsByAddress()
+        {
+            var rom = CreateRom();
+            byte[] uncompressed = new byte[32];
+            for (int i = 0; i < 32; i++) uncompressed[i] = (byte)(i & 1);
+            byte[] compressed = LZ77.compress(uncompressed);
+            for (int i = 0; i < compressed.Length; i++) rom.Data[0x400 + i] = compressed[i];
+
+            var list = LZ77ToolCore.ScanForLZ77Candidates(rom);
+            int count = 0;
+            foreach (var a in list)
+                if (a.Addr == 0x400) count++;
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void ScanForLZ77Candidates_RejectsFalsePositives_BadHeader()
+        {
+            var rom = CreateRom();
+            // Place a fake 0x10 magic with a tiny garbage stream that won't decompress to the header size.
+            rom.Data[0x400] = 0x10;
+            rom.Data[0x401] = 0xFF; rom.Data[0x402] = 0xFF; rom.Data[0x403] = 0xFF;
+            // Following bytes are zero; LZ77.decompress would short-circuit or produce wrong length.
+
+            var list = LZ77ToolCore.ScanForLZ77Candidates(rom);
+            // 0x400 should NOT appear as a valid candidate (rejected by validation).
+            foreach (var a in list) Assert.NotEqual(0x400u, a.Addr);
+        }
+    }
+}

--- a/FEBuilderGBA.Core/LZ77ToolCore.cs
+++ b/FEBuilderGBA.Core/LZ77ToolCore.cs
@@ -1,0 +1,449 @@
+using System;
+using System.Collections.Generic;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Cross-platform Core helpers for the LZ77 Tool — Move and Recompress tabs.
+    /// Used by both WinForms <c>ToolLZ77Form</c> (move/recompress) and Avalonia
+    /// <c>ToolLZ77ViewModel</c> (move/recompress). Closes issue #371's residual
+    /// scope (Move + Recompress tabs) from PR #468.
+    ///
+    /// Undo model
+    /// ----------
+    /// Helpers DO NOT take an <c>Undo.UndoData</c> parameter. They rely
+    /// exclusively on <c>ROM.BeginUndoScope(undoData)</c> (ambient undo).
+    /// All writes use the no-undo <c>rom.write_*()</c> overloads — those
+    /// automatically record to the ambient scope when active, or skip
+    /// recording when not active. Callers wanting undo MUST set up a scope
+    /// (e.g., Avalonia <c>UndoService.Begin</c>) before calling. This avoids
+    /// the double-record bug where explicit + ambient undo both append.
+    ///
+    /// Pointer-search scope
+    /// --------------------
+    /// <see cref="SearchPointersForAddress"/> is explicitly scoped to LDR +
+    /// raw-pointer search only. It does NOT mirror full WinForms
+    /// <c>MoveToFreeSapceForm.SearchPointer</c> ordering. Specifically, it
+    /// omits the <c>GrepPointerAllOnEvent</c> path (which depends on
+    /// <c>U.MakeAllStructPointersList</c> — the Form-coupled aggregator that
+    /// cannot be ported to Core without dragging every WinForms editor's
+    /// <c>MakeAllDataLength</c> method along).
+    ///
+    /// Result flag <c>MissingEventAwareCoverage</c> is always true so the
+    /// caller can surface a clear "event-aware search not included" notice.
+    /// </summary>
+    public static class LZ77ToolCore
+    {
+        /// <summary>Sanity cap mirroring WinForms InputFormRef.MoveBinaryData (2 MB).</summary>
+        public const uint MOVE_LENGTH_LIMIT = 0x00200000;
+
+        /// <summary>Result of <see cref="SearchPointersForAddress"/>.</summary>
+        public class SearchPointerResult
+        {
+            /// <summary>Deduped list of pointer-write locations referring to the target address.</summary>
+            public List<uint> Pointers { get; set; } = new List<uint>();
+
+            /// <summary>
+            /// True when LDR search returned zero hits and the result came from
+            /// raw binary <c>GrepPointerAll</c>. Callers should surface an
+            /// explicit confirmation prompt before rewriting these.
+            /// </summary>
+            public bool UsedRawFallback { get; set; }
+
+            /// <summary>
+            /// Always true. Documents that the Core helper does not include
+            /// WinForms' event/struct-aware path (<c>GrepPointerAllOnEvent</c>
+            /// → <c>MakeAllStructPointersList</c>). Users who need that
+            /// coverage should perform Move/Recompress in WinForms.
+            /// </summary>
+            public bool MissingEventAwareCoverage { get; set; } = true;
+        }
+
+        /// <summary>Result of <see cref="MoveCompressedData"/>.</summary>
+        public class MoveResult
+        {
+            /// <summary>True iff the move was applied successfully.</summary>
+            public bool Ok { get; set; }
+
+            /// <summary>Destination offset of moved data (resolved if auto-allocated).</summary>
+            public uint NewAddress { get; set; }
+
+            /// <summary>Pointer-write locations rewritten by this move.</summary>
+            public List<uint> PointersRewritten { get; set; } = new List<uint>();
+
+            /// <summary>True when raw-pointer fallback was used (no LDR hits).</summary>
+            public bool UsedRawFallback { get; set; }
+
+            /// <summary>True when destination was auto-allocated (<paramref name="toAddr"/> was 0).</summary>
+            public bool AutoAllocated { get; set; }
+
+            /// <summary>User-facing error message when <see cref="Ok"/> is false.</summary>
+            public string ErrorMessage { get; set; } = string.Empty;
+        }
+
+        /// <summary>Result of <see cref="RecompressAt"/>.</summary>
+        public class RecompressResult
+        {
+            /// <summary>True iff a write occurred (or the validator confirmed no benefit and skipped cleanly).</summary>
+            public bool Ok { get; set; }
+
+            /// <summary>Bytes saved by the recompression (zero when no benefit).</summary>
+            public uint SavedBytes { get; set; }
+
+            /// <summary>Reason a write was skipped, or error message on failure.</summary>
+            public string ErrorMessage { get; set; } = string.Empty;
+        }
+
+        /// <summary>Search for pointer-write locations referring to <paramref name="addr"/>.</summary>
+        /// <param name="romData">Raw ROM bytes.</param>
+        /// <param name="addr">Target offset (NOT a pointer; will be converted internally).</param>
+        /// <returns>
+        /// <see cref="SearchPointerResult"/> with deduped pointer list. LDR hits
+        /// take priority — when LDR returns >= 1 entry, raw fallback is NOT run.
+        /// When LDR returns 0, raw <c>GrepPointerAll</c> is run and
+        /// <c>UsedRawFallback = true</c>. Returns empty list for invalid input.
+        /// </returns>
+        public static SearchPointerResult SearchPointersForAddress(byte[] romData, uint addr)
+        {
+            var result = new SearchPointerResult();
+            if (romData == null || addr == 0 || addr == U.NOT_FOUND)
+            {
+                return result;
+            }
+
+            // 1. LDR pointer search (Thumb code).
+            List<uint> ldrHits = DisassemblerTrumb.GrepLDRData(romData, addr);
+            if (ldrHits != null && ldrHits.Count > 0)
+            {
+                result.Pointers = Dedupe(ldrHits);
+                return result;
+            }
+
+            // 2. Fallback: raw binary 4-byte aligned pointer search.
+            List<uint> rawHits = U.GrepPointerAll(romData, addr);
+            if (rawHits == null)
+            {
+                return result;
+            }
+            result.Pointers = Dedupe(rawHits);
+            result.UsedRawFallback = true;
+            return result;
+        }
+
+        /// <summary>Local dedupe — Core doesn't expose U.Uniq, so inline a simple set-based dedupe.</summary>
+        static List<uint> Dedupe(List<uint> source)
+        {
+            var seen = new HashSet<uint>();
+            var ret = new List<uint>(source.Count);
+            foreach (uint v in source)
+            {
+                if (seen.Add(v)) ret.Add(v);
+            }
+            return ret;
+        }
+
+        /// <summary>
+        /// Move arbitrary binary data from <paramref name="srcAddr"/> to
+        /// <paramref name="toAddr"/> (or auto-allocate when <paramref name="toAddr"/>=0).
+        /// Rewrites pointer references, zero-fills source. Wrap in
+        /// <c>ROM.BeginUndoScope(undoData)</c> before calling to record undo.
+        /// </summary>
+        /// <param name="rom">Target ROM.</param>
+        /// <param name="srcAddr">Source offset (must be in ROM bounds, not 0).</param>
+        /// <param name="toAddr">Destination offset, or 0 to auto-allocate.</param>
+        /// <param name="length">Number of bytes to move (must be > 0 and &lt; 2 MB).</param>
+        /// <returns>
+        /// <see cref="MoveResult"/>. On failure, <c>Ok = false</c> and
+        /// <c>ErrorMessage</c> describes the reason. No writes are issued on
+        /// failure (caller-supplied undo scope will be empty).
+        /// </returns>
+        public static MoveResult MoveCompressedData(ROM rom, uint srcAddr, uint toAddr, uint length)
+        {
+            var result = new MoveResult();
+            if (rom == null)
+            {
+                result.ErrorMessage = "MoveCompressedData: ROM is null.";
+                return result;
+            }
+
+            // Normalize: caller may pass pointer or offset; downstream operates on offsets.
+            uint src = U.toOffset(srcAddr);
+            uint dest = toAddr == 0 ? 0u : U.toOffset(toAddr);
+
+            // -- Input validation (mirrors WinForms safety checks) --
+            if (src == 0)
+            {
+                result.ErrorMessage = "MoveCompressedData: source address is 0 (bad base address).";
+                return result;
+            }
+            if (length == 0)
+            {
+                result.ErrorMessage = "MoveCompressedData: length is 0 (cannot auto-detect length).";
+                return result;
+            }
+            if (length >= MOVE_LENGTH_LIMIT)
+            {
+                result.ErrorMessage = $"MoveCompressedData: length 0x{length:X} >= 0x{MOVE_LENGTH_LIMIT:X} (too large, likely corrupt).";
+                return result;
+            }
+            if (src + length > (uint)rom.Data.Length)
+            {
+                result.ErrorMessage = $"MoveCompressedData: source range 0x{src:X8}+0x{length:X} exceeds ROM end 0x{rom.Data.Length:X}.";
+                return result;
+            }
+            if (dest != 0 && (dest + length > (uint)rom.Data.Length))
+            {
+                result.ErrorMessage = $"MoveCompressedData: destination range 0x{dest:X8}+0x{length:X} exceeds ROM end 0x{rom.Data.Length:X}.";
+                return result;
+            }
+
+            // -- "Already moved" guard: refuse to move all-zero data --
+            byte[] srcBytes = rom.getBinaryData(src, length);
+            if (U.IsEmptyRange(srcBytes))
+            {
+                result.ErrorMessage = $"MoveCompressedData: source range at 0x{src:X8} is all zeros (already moved?).";
+                return result;
+            }
+
+            // -- Resolve / auto-allocate destination --
+            if (dest == 0)
+            {
+                uint allocated = AutoAllocateDestination(rom, length);
+                if (allocated == U.NOT_FOUND)
+                {
+                    result.ErrorMessage = "MoveCompressedData: no free space available (ROM is full).";
+                    return result;
+                }
+                dest = allocated;
+                result.AutoAllocated = true;
+            }
+
+            // -- Search for references to source --
+            SearchPointerResult sp = SearchPointersForAddress(rom.Data, src);
+            result.UsedRawFallback = sp.UsedRawFallback;
+
+            // -- Apply: rewrite pointers, copy data, zero source --
+            uint destPointer = U.toPointer(dest);
+            foreach (uint ptrAddr in sp.Pointers)
+            {
+                if (ptrAddr + 4 > (uint)rom.Data.Length)
+                {
+                    continue; // Defensive: skip out-of-range pointer addresses
+                }
+                rom.write_u32(ptrAddr, destPointer);
+                result.PointersRewritten.Add(ptrAddr);
+            }
+
+            // Write data to destination first, then zero source — order matters
+            // when src and dest overlap (we do NOT support overlap; the bounds
+            // checks above plus pointer-rewrite-first ordering keep us safe for
+            // the common non-overlapping case).
+            rom.write_range(dest, srcBytes);
+            rom.write_fill(src, length, 0);
+
+            result.NewAddress = dest;
+            result.Ok = true;
+            return result;
+        }
+
+        /// <summary>
+        /// Re-compress LZ77 data at <paramref name="addr"/> and write it back
+        /// in-place. Caller passes the original allocated length so writes
+        /// remain bounded.
+        /// </summary>
+        /// <param name="rom">Target ROM.</param>
+        /// <param name="addr">Offset of LZ77 stream (must be 4-byte aligned).</param>
+        /// <param name="allocatedLength">Bytes reserved for this entry in the ROM (4-aligned).</param>
+        /// <returns>
+        /// <see cref="RecompressResult"/>. <c>Ok = true, SavedBytes = 0</c> means
+        /// "validated successfully but no benefit, no write". <c>Ok = false</c>
+        /// means validation failed (bad LZ77 data) — no write was issued.
+        /// </returns>
+        public static RecompressResult RecompressAt(ROM rom, uint addr, uint allocatedLength)
+        {
+            var result = new RecompressResult();
+            if (rom == null)
+            {
+                result.ErrorMessage = "RecompressAt: ROM is null.";
+                return result;
+            }
+            if (!U.isPadding4(addr))
+            {
+                result.ErrorMessage = $"RecompressAt: 0x{addr:X8} not 4-byte aligned.";
+                return result;
+            }
+            if (addr + 4 > (uint)rom.Data.Length)
+            {
+                result.ErrorMessage = $"RecompressAt: 0x{addr:X8} out of bounds.";
+                return result;
+            }
+            if (rom.Data[addr] != 0x10)
+            {
+                result.ErrorMessage = $"RecompressAt: 0x{addr:X8} byte != 0x10 (not LZ77 magic).";
+                return result;
+            }
+            if (allocatedLength == 0 || addr + allocatedLength > (uint)rom.Data.Length)
+            {
+                result.ErrorMessage = $"RecompressAt: allocatedLength 0x{allocatedLength:X} out of bounds at 0x{addr:X8}.";
+                return result;
+            }
+
+            uint expectedUncompSize = LZ77.getUncompressSize(rom.Data, addr);
+            if (expectedUncompSize == 0)
+            {
+                result.ErrorMessage = $"RecompressAt: 0x{addr:X8} getUncompressSize=0 (bad header).";
+                return result;
+            }
+
+            // Decompress and verify header consistency.
+            byte[] uncompressed;
+            try
+            {
+                uncompressed = LZ77.decompress(rom.Data, addr);
+            }
+            catch (Exception ex)
+            {
+                result.ErrorMessage = $"RecompressAt: decompress failed at 0x{addr:X8}: {ex.Message}";
+                return result;
+            }
+            if (uncompressed == null || uncompressed.Length != (int)expectedUncompSize)
+            {
+                result.ErrorMessage = $"RecompressAt: 0x{addr:X8} decompressed length {uncompressed?.Length ?? 0} != header {expectedUncompSize}.";
+                return result;
+            }
+
+            // Re-compress.
+            byte[] recompressed;
+            try
+            {
+                recompressed = LZ77.compress(uncompressed);
+            }
+            catch (Exception ex)
+            {
+                result.ErrorMessage = $"RecompressAt: compress failed at 0x{addr:X8}: {ex.Message}";
+                return result;
+            }
+            if (recompressed == null || recompressed.Length == 0)
+            {
+                result.ErrorMessage = $"RecompressAt: compress produced empty output at 0x{addr:X8}.";
+                return result;
+            }
+
+            // Skip if not beneficial.
+            if ((uint)recompressed.Length >= allocatedLength)
+            {
+                result.Ok = true;
+                result.SavedBytes = 0;
+                result.ErrorMessage = "no benefit (new size >= allocated)";
+                return result;
+            }
+            uint saved = allocatedLength - (uint)recompressed.Length;
+            if (saved <= 3)
+            {
+                result.Ok = true;
+                result.SavedBytes = 0;
+                result.ErrorMessage = "no benefit (savings <= 3 bytes)";
+                return result;
+            }
+
+            // Apply: zero the entire allocated range first, then write new compressed data.
+            rom.write_fill(addr, allocatedLength, 0);
+            rom.write_range(addr, recompressed);
+
+            result.Ok = true;
+            result.SavedBytes = saved;
+            return result;
+        }
+
+        /// <summary>
+        /// Heuristic scan for LZ77 data entries in ROM. Walks 4-byte aligned
+        /// offsets, validates LZ77 magic + header + decompression consistency,
+        /// and returns deduped sorted candidates with <c>Address.DataTypeEnum.LZ77IMG</c>.
+        ///
+        /// LIMITATION: this scanner does NOT use <c>MakeAllStructPointersList</c>
+        /// (Form-coupled in WinForms). It may miss entries that WinForms catches
+        /// (e.g., LZ77 referenced only from event scripts or struct pointer
+        /// tables). For best coverage, run the Recompress tool in WinForms.
+        /// </summary>
+        public static List<Address> ScanForLZ77Candidates(ROM rom)
+        {
+            var ret = new List<Address>();
+            if (rom == null || rom.Data == null) return ret;
+
+            byte[] data = rom.Data;
+            uint length = (uint)data.Length;
+            if (length < 0x100) return ret;
+
+            // Constrain scan to ROM (not RAM); start past header.
+            uint scanLimit = length;
+
+            var seen = new HashSet<uint>();
+            for (uint addr = 0x100; addr + 4 < scanLimit; addr += 4)
+            {
+                if (data[addr] != 0x10) continue;
+
+                uint uncompSize = LZ77.getUncompressSize(data, addr);
+                if (uncompSize == 0) continue;
+
+                uint compSize = LZ77.getCompressedSize(data, addr);
+                if (compSize == 0) continue;
+
+                // Verify decompression produces expected length.
+                byte[] decompressed;
+                try { decompressed = LZ77.decompress(data, addr); }
+                catch { continue; }
+                if (decompressed == null || decompressed.Length != (int)uncompSize) continue;
+
+                // Allocated length is the next 4-byte aligned size of compressed stream.
+                uint allocatedLen = U.Padding4(compSize);
+                if (addr + allocatedLen > length) continue;
+
+                if (!seen.Add(addr)) continue;
+
+                ret.Add(new Address(addr, allocatedLen, U.NOT_FOUND,
+                    $"LZ77 candidate at 0x{addr:X8}", Address.DataTypeEnum.LZ77IMG));
+            }
+            ret.Sort((a, b) => a.Addr.CompareTo(b.Addr));
+            return ret;
+        }
+
+        /// <summary>
+        /// Auto-allocate a destination for moved data: find free space ahead of
+        /// end-of-file, or append to ROM end (resizing if necessary). Mirrors
+        /// the simple path of WinForms <c>InputFormRef.AppendBinaryData</c>
+        /// without the magic-area / skill-reserve / event-unit-reserve guards
+        /// (those are WinForms-form-coupled).
+        /// </summary>
+        static uint AutoAllocateDestination(ROM rom, uint length)
+        {
+            uint needSize = U.Padding4(length);
+
+            // Try to find a free run in extended area / existing ROM space.
+            uint start = 0x100;
+            if (rom.RomInfo != null)
+            {
+                start = U.toOffset(rom.RomInfo.extends_address);
+                if (start == 0 || start == U.NOT_FOUND) start = 0x100;
+            }
+            uint freespace = rom.FindFreeSpace(start, needSize);
+            if (freespace != U.NOT_FOUND)
+            {
+                // Skip first 16 bytes of slack like WinForms does to avoid collisions.
+                return freespace + 16;
+            }
+
+            // No free run found — append to end of file (resize ROM if needed).
+            uint endAddr = U.Padding4((uint)rom.Data.Length);
+            uint newEnd = endAddr + needSize;
+            if (newEnd >= 0x02000000)
+            {
+                return U.NOT_FOUND; // GBA 32 MB cap.
+            }
+            if (newEnd > (uint)rom.Data.Length)
+            {
+                if (!rom.write_resize_data(newEnd)) return U.NOT_FOUND;
+            }
+            return endAddr;
+        }
+    }
+}

--- a/FEBuilderGBA.Core/LZ77ToolCore.cs
+++ b/FEBuilderGBA.Core/LZ77ToolCore.cs
@@ -294,6 +294,11 @@ namespace FEBuilderGBA
                 result.ErrorMessage = $"RecompressAt: allocatedLength 0x{allocatedLength:X} out of bounds at 0x{addr:X8}.";
                 return result;
             }
+            if (!U.isPadding4(allocatedLength))
+            {
+                result.ErrorMessage = $"RecompressAt: allocatedLength 0x{allocatedLength:X} is not 4-byte aligned.";
+                return result;
+            }
 
             uint expectedUncompSize = LZ77.getUncompressSize(rom.Data, addr);
             if (expectedUncompSize == 0)

--- a/FEBuilderGBA.Core/LZ77ToolCore.cs
+++ b/FEBuilderGBA.Core/LZ77ToolCore.cs
@@ -196,6 +196,12 @@ namespace FEBuilderGBA
                 result.ErrorMessage = $"MoveCompressedData: destination range 0x{dest:X8}+0x{length:X} exceeds ROM end 0x{rom.Data.Length:X}.";
                 return result;
             }
+            // -- Reject overlapping src/dest ranges (overlap-unsafe write order) --
+            if (dest != 0 && RangesOverlap(src, length, dest, length))
+            {
+                result.ErrorMessage = $"MoveCompressedData: source 0x{src:X8}+0x{length:X} and destination 0x{dest:X8}+0x{length:X} overlap (not supported).";
+                return result;
+            }
 
             // -- "Already moved" guard: refuse to move all-zero data --
             byte[] srcBytes = rom.getBinaryData(src, length);
@@ -216,6 +222,7 @@ namespace FEBuilderGBA
                 }
                 dest = allocated;
                 result.AutoAllocated = true;
+                // Auto-allocated dest will never overlap source (free space, not source range).
             }
 
             // -- Search for references to source --
@@ -407,16 +414,29 @@ namespace FEBuilderGBA
             return ret;
         }
 
+        /// <summary>16-byte forward slack added before payload to avoid collisions with the prior run.</summary>
+        const uint AUTO_ALLOC_LTRIM_SLACK = 16;
+
         /// <summary>
         /// Auto-allocate a destination for moved data: find free space ahead of
         /// end-of-file, or append to ROM end (resizing if necessary). Mirrors
         /// the simple path of WinForms <c>InputFormRef.AppendBinaryData</c>
         /// without the magic-area / skill-reserve / event-unit-reserve guards
         /// (those are WinForms-form-coupled).
+        ///
+        /// IMPORTANT: When a free run is found, we return <c>freespace + 16</c>
+        /// (mirroring WinForms' LTRIM slack to avoid touching the previous run's
+        /// trailing bytes). The slack MUST be included in the requested free-run
+        /// size, otherwise the payload would be written past the validated free
+        /// area and clobber adjacent ROM data. PR #481 review fix.
         /// </summary>
         static uint AutoAllocateDestination(ROM rom, uint length)
         {
-            uint needSize = U.Padding4(length);
+            uint payload = U.Padding4(length);
+            // Include slack in the requested size so the discovered run is at
+            // least slack + payload bytes — guarantees writing `length` bytes at
+            // `freespace + slack` stays inside the validated free area.
+            uint needSize = U.Padding4(AUTO_ALLOC_LTRIM_SLACK + payload);
 
             // Try to find a free run in extended area / existing ROM space.
             uint start = 0x100;
@@ -428,13 +448,12 @@ namespace FEBuilderGBA
             uint freespace = rom.FindFreeSpace(start, needSize);
             if (freespace != U.NOT_FOUND)
             {
-                // Skip first 16 bytes of slack like WinForms does to avoid collisions.
-                return freespace + 16;
+                return freespace + AUTO_ALLOC_LTRIM_SLACK;
             }
 
             // No free run found — append to end of file (resize ROM if needed).
             uint endAddr = U.Padding4((uint)rom.Data.Length);
-            uint newEnd = endAddr + needSize;
+            uint newEnd = endAddr + payload;
             if (newEnd >= 0x02000000)
             {
                 return U.NOT_FOUND; // GBA 32 MB cap.
@@ -444,6 +463,15 @@ namespace FEBuilderGBA
                 if (!rom.write_resize_data(newEnd)) return U.NOT_FOUND;
             }
             return endAddr;
+        }
+
+        /// <summary>Returns true if [a, a+aLen) and [b, b+bLen) share any byte.</summary>
+        static bool RangesOverlap(uint a, uint aLen, uint b, uint bLen)
+        {
+            if (aLen == 0 || bLen == 0) return false;
+            uint aEnd = a + aLen;
+            uint bEnd = b + bLen;
+            return a < bEnd && b < aEnd;
         }
     }
 }

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -6338,3 +6338,42 @@ CC先（クラス）
 
 :Open Support
 支援を開く
+
+:LENGTH:
+LENGTH:
+
+:0x0 (source offset)
+0x0 (移動元オフセット)
+
+:0x0 (destination, 0 = auto-allocate)
+0x0 (移動先、0=自動割り当て)
+
+:length in bytes (hex)
+長さ (バイト数、16進)
+
+:Move This Region
+この領域を移動する
+
+:Run LZ77 Recompress
+LZ77再圧縮を実行する
+
+:Move arbitrary binary data (LZ77 or otherwise) to a new address. TO = 0 auto-allocates from free space (or appends to end). Pointer references are rewritten.
+任意のバイナリデータ (LZ77など) を新しいアドレスに移動します。TO=0で空き領域から自動割り当て (または末尾追記)。ポインタ参照は書き換えられます。
+
+:Limitation: event-script-aware pointer search is not included (WinForms-only). If your data is referenced from event scripts or struct pointer tables, perform Move in WinForms.
+制限: イベントスクリプト対応のポインタ検索は含まれません (WinFormsのみ)。データがイベントスクリプトや構造体ポインタテーブルから参照されている場合は、WinForms側で移動を実行してください。
+
+:LZ77 Recompress (since 2026)
+LZ77再圧縮 (2026以降)
+
+:Walks ROM for LZ77-compressed entries and re-compresses each with the current encoder. Any savings can be reclaimed via Rebuild later. Process takes several minutes for a full ROM scan.
+ROM内のLZ77圧縮エントリを走査し、現在のエンコーダで再圧縮します。生じた余白は後でRebuildにより回収できます。フルROMスキャンには数分かかります。
+
+:Heuristic scan: this tool does NOT use WinForms MakeAllStructPointersList — it may miss entries referenced only from event scripts or struct pointer tables. For best coverage, run Recompress in WinForms.
+ヒューリスティックスキャン: このツールはWinFormsのMakeAllStructPointersListを使わないため、イベントスクリプトや構造体ポインタテーブルからのみ参照されるエントリを取りこぼす可能性があります。最大限の網羅性が必要な場合はWinForms側で再圧縮を実行してください。
+
+:Move
+移動
+
+:Recompress
+再圧縮

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -20309,3 +20309,42 @@ Base64 文本 → 文件
 
 :Open Support
 打开支援
+
+:LENGTH:
+长度:
+
+:0x0 (source offset)
+0x0 (源偏移)
+
+:0x0 (destination, 0 = auto-allocate)
+0x0 (目标地址，0=自动分配)
+
+:length in bytes (hex)
+长度 (字节数，十六进制)
+
+:Move This Region
+移动该区域
+
+:Run LZ77 Recompress
+运行 LZ77 重新压缩
+
+:Move arbitrary binary data (LZ77 or otherwise) to a new address. TO = 0 auto-allocates from free space (or appends to end). Pointer references are rewritten.
+将任意二进制数据 (LZ77 等) 移动到新地址。TO=0 时从空闲区自动分配 (或追加到末尾)。指针引用会被重写。
+
+:Limitation: event-script-aware pointer search is not included (WinForms-only). If your data is referenced from event scripts or struct pointer tables, perform Move in WinForms.
+限制: 不包含支持事件脚本的指针搜索 (仅 WinForms)。如果你的数据从事件脚本或结构体指针表中被引用，请在 WinForms 中执行移动。
+
+:LZ77 Recompress (since 2026)
+LZ77 重新压缩 (2026 以后)
+
+:Walks ROM for LZ77-compressed entries and re-compresses each with the current encoder. Any savings can be reclaimed via Rebuild later. Process takes several minutes for a full ROM scan.
+扫描 ROM 中所有 LZ77 压缩条目，并用当前编码器重新压缩。生成的空间可在 Rebuild 时回收。完整扫描需要数分钟。
+
+:Heuristic scan: this tool does NOT use WinForms MakeAllStructPointersList — it may miss entries referenced only from event scripts or struct pointer tables. For best coverage, run Recompress in WinForms.
+启发式扫描: 本工具不使用 WinForms 的 MakeAllStructPointersList，可能漏掉仅被事件脚本或结构体指针表引用的条目。如需完整覆盖请在 WinForms 中运行重新压缩。
+
+:Move
+移动
+
+:Recompress
+重新压缩


### PR DESCRIPTION
## Summary

Closes #371. Delivers the deferred Move + Recompress tabs from PR #468.

**LZ77ToolCore** (new Core helper, ~340 lines):
- `MoveCompressedData(rom, srcAddr, toAddr, length)` — moves arbitrary binary data with pointer rewriting + source zero-fill. Validates bounds, length sanity (<2MB), all-zero "already moved" guard. Supports `toAddr=0` auto-allocation via free-space search + ROM end resize.
- `SearchPointersForAddress(romData, addr)` — LDR-first, raw-fallback pointer search. `MissingEventAwareCoverage = true` always (documents the WinForms-only `MakeAllStructPointersList` path as explicitly out of scope).
- `RecompressAt(rom, addr, allocatedLength)` — validates LZ77 magic + alignment + header consistency, recompresses, writes bounded by allocatedLength only when savings > 3 bytes.
- `ScanForLZ77Candidates(rom)` — heuristic scan returning sorted deduped candidates. Best-effort; documented limitations.

**Undo model**: Helpers do NOT take `Undo.UndoData`. They rely exclusively on `ROM.BeginUndoScope(undoData)` ambient undo, avoiding the double-record bug where explicit + ambient both append. Callers wrap in `BeginUndoScope` (Avalonia uses `UndoService.Begin/Commit`).

**Avalonia LZ77 Tool** (Move + Recompress tabs):
- Move tab: FROM / TO / LENGTH hex inputs + Move button + heuristic + event-aware-gap warning labels.
- Recompress tab: Heuristic-scan warning + Run button.
- Two-phase confirmation flow: `MovePreflight` / `RunMove` (raw-fallback prompt → multi-pointer prompt → final-confirm prompt); `RecompressPreflight` / `RunRecompress` (rom-modified ack → run-confirm).

**WinForms**: untouched (the existing `ToolLZ77Form` Move/Recompress logic continues to work as before — Core helper extraction is additive only).

## Plan Reference

Implements the v3 plan (Copilot CLI approved) from issue #371:
https://github.com/laqieer/FEBuilderGBA/issues/371#issuecomment-4520341396

## Scope

Closes #371

## Screenshots

LZ77 Move tab (with FROM / TO / LENGTH filled):
![lz77 move](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr-tools-371-lz77-move.png)

LZ77 Recompress tab (heuristic-scan warning + Run button):
![lz77 recompress](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr-tools-371-lz77-recompress.png)

LZ77 Recompress confirmation dialog (Yes/No prompt):
![lz77 recompress confirm](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr-tools-371-lz77-recompress-confirm.png)

Screenshots committed to `pr-screenshots/` on master via companion docs PR #480 (raw.githubusercontent master URLs are permanent).

## GUI Test Report

### Environment
- ROM: `roms/FE8U.gba`
- Editor/View: `ToolLZ77View` (Avalonia)
- Capture method: PrintWindow API + PowerShell UIAutomationClient

### Steps Performed
1. Built `FEBuilderGBA.Avalonia` Release with the new sources
2. Launched the app with `--rom roms/FE8U.gba`
3. Clicked `LZ77 Tool` button on main hub via UIAutomation → LZ77 Compression Tool window opened
4. Selected the **Move** tab via UIAutomation; filled FROM=`0x1A8FE0`, TO=`0x0`, LENGTH=`0x800`; captured the tab content via PrintWindow
5. Selected the **Recompress** tab via UIAutomation; captured the tab content via PrintWindow
6. Clicked Run LZ77 Recompress → confirmation dialog appeared; captured via PrintWindow

### Test Results
| Test | Expected | Actual | Status |
|------|----------|--------|--------|
| Move tab shows FROM / TO / LENGTH labels + inputs | All 3 labels + 3 input boxes | Visible (see screenshot) | PASS |
| Move tab has Move button | Single full-width button | Visible | PASS |
| Move tab shows heuristic + event-aware-gap warnings | 2 warning labels | Visible (gray + orange) | PASS |
| Move tab inputs accept hex values | `0x1A8FE0`, `0x0`, `0x800` enter without error | Inputs hold values | PASS |
| Recompress tab shows description + warning | Header + 2 paragraphs | Visible | PASS |
| Recompress tab has Run button | Single full-width button | Visible | PASS |
| Recompress button shows confirmation dialog | Modal with Yes/No | Modal opened with correct text | PASS |
| Recompress confirm message mentions heuristic scan | Text "may miss entries WinForms catches" | Present in dialog | PASS |
| TabControl has 6 tabs total | Decompress, Compress, Erase, Base64, Move, Recompress | All 6 present (headless test asserts) | PASS |

### Verdict
PASS. The Avalonia LZ77 Tool now matches WinForms parity for the in-scope feature set (`Decompress`, `Compress`, `Erase`, `Base64`, `Move`, `Recompress`). The remaining WinForms-only features (Recompress sub-tabs for portrait/battle-anime/song-goto-fine, Base64 → 7z → Emulator launcher, and `MakeAllStructPointersList`-backed event-aware pointer search) are documented in Known Limitations.

## Test plan

- [x] `LZ77ToolCoreTests` (26 tests) — `MoveCompressedData` validation paths, pointer-search gating (LDR-first / raw-fallback), undo non-duplication under `BeginUndoScope`, auto-allocation, `RecompressAt` validation (alignment, magic, header consistency, no-out-of-range writes), `ScanForLZ77Candidates` false-positive rejection — all pass (26/26)
- [x] `ToolLZ77ViewModelTests` — existing 16 + 8 new Move/Recompress tests (no-rom, invalid hex, length-zero, rom-modified-needs-ack, clean-rom-needs-confirm, proceeds-after-confirm) — all pass (24/24)
- [x] `ToolLZ77ViewHeadlessTests` — updated for 6 tabs (was 4), new AutomationIds (`ToolLZ77_Move_Tab`, `ToolLZ77_Recompress_Tab`, `MoveFrom/To/Length_Input`, `Move_Button`, `Recompress_Button`) — all pass (6/6)
- [x] Full Core.Tests suite passes: 1393/1393
- [x] Full Avalonia.Tests suite passes: 4752/4756 (4 pre-existing skipped, unrelated to this PR)
- [x] WinForms `FEBuilderGBA.csproj` builds cleanly (no regressions)
- [x] Real GUI screenshots captured via PrintWindow + UIAutomation (see Screenshots section)
- [x] Two-phase Move confirmation flow verified: preflight returns enum, View prompts via `MessageBoxWindow`, confirmation flags gate execution
- [x] Two-phase Recompress confirmation flow verified: preflight returns enum, View prompts for rom-modified ack and run-confirm
- [x] Ambient undo via `ROM.BeginUndoScope()` — no double-record (test asserts exact position count)
- [x] `CLAUDE.md` updated to document `LZ77ToolCore.cs` in the Core file list

## Known limitations

The following WinForms LZ77 sub-features remain deferred (out of scope for #371):
- **Event-aware pointer search** — Core helpers omit `MakeAllStructPointersList` / `GrepPointerAllOnEvent` (Form-coupled in WinForms; would require porting every editor's `MakeAllDataLength` method). `MissingEventAwareCoverage = true` is always set so the View surfaces this clearly. Users who need event-aware rewriting should perform Move/Recompress in WinForms.
- **`MoveToFreeSapceForm.RepointEtcData`** — comment / lint metadata fixup post-move (WinForms-coupled).
- **`InputFormRef.NotifyChangePointer`** — cache invalidation broadcast (WinForms-coupled).
- **Recompress sub-tabs (顔画像 / 戦闘アニメOAM / 音楽GOTO-FINE)** — call `ImagePortraitForm`, `ImageBattleAnimeForm`, `SongTableForm` (WinForms-only forms).
- **Base64 → 7z → Emulator launcher** — uses `ArchSevenZip` + `MainFormUtil.RunAs` (WinForms-only flow).

These items are documented in the helper XML docs, the Avalonia UI warning labels, and this section. A follow-up issue can track porting them if user demand arises.

Generated with Claude Code (claude-opus-4-7[1m])
