### PR TITLE
fix(gap-sweep): MapTileAnimation2 parity (closes #426)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MapTileAnimation2ParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MapTileAnimation2ParityTests.cs
@@ -275,7 +275,7 @@ public class MapTileAnimation2ParityTests
             Assert.Equal(4, vm.PaletteRows.Count);
             Assert.Equal(0, vm.SelectedPaletteRowIndex);
             // Row 0 is white (0x7FFF) -> (248, 248, 248).
-            Assert.Equal((byte)0xF8, vm.PaletteRows[0].r);
+            Assert.Equal((byte)0xF8, vm.PaletteRows[0].R);
         }
         finally { CoreState.ROM = prevRom; }
     }
@@ -357,8 +357,8 @@ public class MapTileAnimation2ParityTests
             var vm = new MapTileAnimation2ViewModel();
             vm.LoadEntry(entryAddr);
             // After LoadEntry, row 0 should be white from 0x00800100.
-            Assert.Equal((byte)0xF8, vm.PaletteRows[0].r);
-            Assert.Equal((byte)0xF8, vm.PaletteRows[0].g);
+            Assert.Equal((byte)0xF8, vm.PaletteRows[0].R);
+            Assert.Equal((byte)0xF8, vm.PaletteRows[0].G);
 
             // Now mutate the pointer + count and Write (simulates the view's
             // Write_Click handler before the LoadEntry refresh).
@@ -373,9 +373,9 @@ public class MapTileAnimation2ParityTests
 
             Assert.Equal(2, vm.PaletteRows.Count);
             // Row 0 should now be red (0x001F decoded to 248, 0, 0).
-            Assert.Equal((byte)0xF8, vm.PaletteRows[0].r);
-            Assert.Equal((byte)0x00, vm.PaletteRows[0].g);
-            Assert.Equal((byte)0x00, vm.PaletteRows[0].b);
+            Assert.Equal((byte)0xF8, vm.PaletteRows[0].R);
+            Assert.Equal((byte)0x00, vm.PaletteRows[0].G);
+            Assert.Equal((byte)0x00, vm.PaletteRows[0].B);
             // NReadStartAddress should reflect the new pointer's offset.
             Assert.Equal(0x00800500u, vm.NReadStartAddress);
             // NReadCount should mirror DataCount.
@@ -401,6 +401,89 @@ public class MapTileAnimation2ParityTests
         string writeBody = source.Substring(writeClick, writeBodyEnd - writeClick);
         Assert.Contains("_vm.LoadEntry(", writeBody);
         Assert.Contains("UpdateUI()", writeBody);
+    }
+
+    /// <summary>
+    /// Regression test for the second Copilot CLI inline review on PR #534:
+    /// LoadEntry must CLEAR the N-address bar (NReadStartAddress/NReadCount)
+    /// and the R/G/B/GbaColor fields when the entry's palette block is empty
+    /// (DataCount==0 or unsafe pointer). Without the clear, switching from
+    /// an entry with palette rows to one without would leave the previous
+    /// entry's N-address and color values visible in the UI.
+    /// </summary>
+    [Fact]
+    public void ViewModel_LoadEntry_ClearsNStateWhenPaletteEmpty()
+    {
+        var rom = MakeMinimalFE8URomWithEntry(out uint entryAddr);
+        // Plant a second entry at entryAddr+8 with DataCount=0 so LoadEntry
+        // produces an empty palette sub-list.
+        uint secondEntry = entryAddr + 8;
+        WriteU32(rom.Data, (int)secondEntry + 0, 0x08800100u); // P0 valid
+        rom.Data[secondEntry + 4] = 0x10;
+        rom.Data[secondEntry + 5] = 0; // DataCount = 0 (empty palette)
+        rom.Data[secondEntry + 6] = 0x3C;
+        rom.Data[secondEntry + 7] = 0;
+        // Terminator after the second entry so ScanEntries stops cleanly.
+        WriteU32(rom.Data, (int)secondEntry + 8, 0u);
+
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation2ViewModel();
+
+            // First, load the entry WITH palette rows.
+            vm.LoadEntry(entryAddr);
+            Assert.True(vm.PaletteRows.Count > 0);
+            uint priorNAddr = vm.NReadStartAddress;
+            uint priorNCount = vm.NReadCount;
+            Assert.NotEqual(0u, priorNAddr);
+            Assert.NotEqual(0u, priorNCount);
+
+            // Now load the entry with DataCount=0 - all N-state must clear.
+            vm.LoadEntry(secondEntry);
+            Assert.Empty(vm.PaletteRows);
+            Assert.Equal(-1, vm.SelectedPaletteRowIndex);
+            Assert.Equal(0u, vm.NReadStartAddress);
+            Assert.Equal(0u, vm.NReadCount);
+            Assert.Equal(0u, vm.PaletteR);
+            Assert.Equal(0u, vm.PaletteG);
+            Assert.Equal(0u, vm.PaletteB);
+            Assert.Equal(0u, vm.PaletteGba);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    /// <summary>
+    /// WritePaletteRow must normalize the in-memory PaletteR/G/B to the
+    /// post-truncation (multiples of 8) values so the UI inputs match the
+    /// ROM bytes (Copilot CLI inline review on PR #534).
+    /// </summary>
+    [Fact]
+    public void ViewModel_WritePaletteRow_NormalizesRgbAfterTruncation()
+    {
+        var rom = MakeMinimalFE8URomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation2ViewModel();
+            vm.LoadEntry(entryAddr);
+            vm.SelectedPaletteRowIndex = 1;
+            // Pick a value that is NOT a multiple of 8 - e.g. R=125, G=190,
+            // B=49. After truncation to 5 bits + left-shift by 3 these
+            // become 120, 184, 48 (each rounded down to the nearest
+            // multiple of 8).
+            vm.PaletteR = 125;
+            vm.PaletteG = 190;
+            vm.PaletteB = 49;
+            Assert.True(vm.WritePaletteRow());
+            // After WritePaletteRow, R/G/B should be normalized.
+            Assert.Equal(120u, vm.PaletteR);
+            Assert.Equal(184u, vm.PaletteG);
+            Assert.Equal(48u, vm.PaletteB);
+        }
+        finally { CoreState.ROM = prevRom; }
     }
 
     // -----------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MapTileAnimation2ParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MapTileAnimation2ParityTests.cs
@@ -1,0 +1,431 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Phase 1/2/5/6 gap-sweep regression tests for MapTileAnimation2View. (#426)
+//
+// Closes the 46 Avalonia <-> WinForms gaps the gap-sweep methodology surfaced
+// on MapTileAnimation2Form (HIGH density 14/40, 20 WF-only labels, 0 common
+// labels). Each assertion maps to a concrete acceptance-criterion bullet in
+// the issue body and to a Copilot CLI plan-review finding.
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using FEBuilderGBA.Avalonia.GapSweep;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests.GapSweep;
+
+/// <summary>
+/// Tests proving the MapTileAnimation2 parity raise (#426) is permanent.
+/// Marked [Collection("SharedState")] because the synthetic-ROM tests
+/// mutate CoreState.ROM.
+/// </summary>
+[Collection("SharedState")]
+public class MapTileAnimation2ParityTests
+{
+    // -----------------------------------------------------------------
+    // Density (Phase 1) - AV control count must reach the MEDIUM verdict.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// WF designer.cs reports 40 control instantiations. To leave the
+    /// HIGH verdict we need AV >= ceil(40 * 0.75) = 30.
+    /// </summary>
+    [Fact]
+    public void View_AvControlCount_AtOrAboveMediumVerdict()
+    {
+        string axamlPath = AxamlPath();
+        Assert.True(File.Exists(axamlPath), $"AXAML not found at {axamlPath}");
+
+        var doc = XDocument.Load(axamlPath);
+        int avCount = ControlDensityScanner.CountAvControlsInDocument(doc);
+
+        const int WfControlCount = 40;
+        int mediumThreshold = (int)Math.Ceiling(WfControlCount * 0.75); // 30
+        Assert.True(avCount >= mediumThreshold,
+            $"AV control count {avCount} must be >= {mediumThreshold} (75% of WF={WfControlCount})");
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 5 - control surface assertions (Roslyn-static AXAML read).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_HasReloadButton_Wired()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"MapTileAnimation2_ReloadList_Button\"", axaml);
+        Assert.Contains("Click=\"ReloadList_Click\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasFilterCombo()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"MapTileAnimation2_Filter_Combo\"", axaml);
+        Assert.Contains("SelectionChanged=\"FilterCombo_SelectionChanged\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasSelectionBar()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"MapTileAnimation2_Address_Input\"", axaml);
+        Assert.Contains("AutomationId=\"MapTileAnimation2_BlockSize_Input\"", axaml);
+        Assert.Contains("AutomationId=\"MapTileAnimation2_SelectedAddress_Label\"", axaml);
+        Assert.Contains("AutomationId=\"MapTileAnimation2_Write_Button\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasPaletteSubList()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"MapTileAnimation2_NList\"", axaml);
+        Assert.Contains("AutomationId=\"MapTileAnimation2_NW0_Input\"", axaml);
+        Assert.Contains("AutomationId=\"MapTileAnimation2_NR_Input\"", axaml);
+        Assert.Contains("AutomationId=\"MapTileAnimation2_NG_Input\"", axaml);
+        Assert.Contains("AutomationId=\"MapTileAnimation2_NB_Input\"", axaml);
+        Assert.Contains("AutomationId=\"MapTileAnimation2_GbaColor_Label\"", axaml);
+        Assert.Contains("AutomationId=\"MapTileAnimation2_NPanel_Label\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasBulkImportExportButtons()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"MapTileAnimation2_BulkImport_Button\"", axaml);
+        Assert.Contains("AutomationId=\"MapTileAnimation2_BulkExport_Button\"", axaml);
+        Assert.Contains("Click=\"BulkImport_Click\"", axaml);
+        Assert.Contains("Click=\"BulkExport_Click\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasNWriteButton_Wired()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"MapTileAnimation2_NWrite_Button\"", axaml);
+        Assert.Contains("Click=\"NWrite_Click\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasNListExpandButton_Wired()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"MapTileAnimation2_NListExpand_Button\"", axaml);
+        Assert.Contains("Click=\"NListExpand_Click\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasListExpandButton_Wired()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"MapTileAnimation2_ListExpand_Button\"", axaml);
+        Assert.Contains("Click=\"ListExpand_Click\"", axaml);
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 5 (Copilot CLI #3) - deferred affordances must be visibly
+    // disabled and reference the follow-up Core extraction issue.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Each deferred affordance (Bulk Import / Bulk Export / List Expand
+    /// main + palette sub-list) must be rendered with <c>IsEnabled="False"</c>
+    /// and a tooltip referencing the follow-up Core-extraction issue (#524)
+    /// so density parity does not count enabled no-op controls (Copilot CLI
+    /// plan-review #3). The XAML is searched as text (mirrors how the
+    /// surrounding tests assert AutomationIds + Click handlers).
+    /// </summary>
+    [Theory]
+    [InlineData("MapTileAnimation2_BulkImport_Button")]
+    [InlineData("MapTileAnimation2_BulkExport_Button")]
+    [InlineData("MapTileAnimation2_ListExpand_Button")]
+    [InlineData("MapTileAnimation2_NListExpand_Button")]
+    public void View_DeferredButton_IsDisabledAndReferencesFollowupIssue(string automationId)
+    {
+        string axaml = ReadAxaml();
+        // Locate the Button element by its AutomationId.
+        int idx = axaml.IndexOf($"AutomationId=\"{automationId}\"", StringComparison.Ordinal);
+        Assert.True(idx >= 0, $"AutomationId {automationId} not found in AXAML");
+
+        // Walk backwards to the previous '<' to find element start.
+        int elementStart = axaml.LastIndexOf('<', idx);
+        Assert.True(elementStart >= 0, "Could not find element start");
+        // Walk forward to the next '/>' or '>'.
+        int elementEnd = axaml.IndexOfAny(new[] { '>' }, idx);
+        Assert.True(elementEnd > elementStart, "Could not find element end");
+        string element = axaml.Substring(elementStart, elementEnd - elementStart + 1);
+
+        Assert.Contains("IsEnabled=\"False\"", element);
+        Assert.Contains("#524", element);
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 5 - Write/NWrite handlers must wrap ROM mutation in undo scope.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Write handler must wrap ROM mutation in <c>_undoService.Begin/Commit</c>.
+    /// Roslyn-static read of the code-behind source - no Avalonia head needed.
+    /// </summary>
+    [Fact]
+    public void View_WriteHandler_WrapsInUndoScope()
+    {
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        // The Write_Click + NWrite_Click handlers BOTH must call
+        // _undoService.Begin/Commit/Rollback. We assert all three keywords
+        // appear in the file.
+        Assert.Contains("_undoService.Begin(", source);
+        Assert.Contains("_undoService.Commit()", source);
+        Assert.Contains("_undoService.Rollback()", source);
+    }
+
+    [Fact]
+    public void View_NWriteHandler_ReferencesUndoService()
+    {
+        // The N_Write handler must be present and wrap in a separate
+        // Begin/Commit scope from the main Write handler.
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        Assert.Contains("NWrite_Click", source);
+        // Verify the N handler also opens an undo scope: search for
+        // "Edit Palette Row" which is the unique scope-name string used.
+        Assert.Contains("Edit Palette Row", source);
+    }
+
+    // -----------------------------------------------------------------
+    // ViewModel state - Phase 1 new fields populated, P0 (pointer-aware)
+    // round-trip (Copilot CLI #1).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_FieldDef_UsesPointerForP0()
+    {
+        // The internal _fields list must contain a P-prefixed entry at
+        // offset 0 so EditorFormRef round-trips via rom.write_p32 and not
+        // raw rom.write_u32 (gap-sweep #426, Copilot CLI plan-review #1).
+        var fields = EditorFormRef.DetectFields(new[] { "P0", "B4", "B5", "B6", "B7" });
+        Assert.Equal(EditorFormRef.FieldType.Pointer, fields[0].Type);
+        Assert.Equal(0u, fields[0].Offset);
+    }
+
+    [Fact]
+    public void ViewModel_Write_PersistsPaletteDataPointer_AsGbaPointer()
+    {
+        var rom = MakeMinimalFE8URomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation2ViewModel();
+            vm.LoadEntry(entryAddr);
+
+            // Mutate the palette data pointer to a ROM offset (no high bit).
+            // Write() must encode it back with the 0x08000000 high bit so
+            // the raw u32 read after Write matches.
+            uint newOffset = 0x00200000u;
+            vm.PaletteDataPointer = newOffset;
+            vm.Write();
+
+            uint raw = rom.u32(entryAddr + 0);
+            uint decoded = rom.p32(entryAddr + 0);
+            Assert.Equal(newOffset | 0x08000000u, raw);
+            Assert.Equal(newOffset, decoded);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_LoadEntry_PopulatesAllFields()
+    {
+        var rom = MakeMinimalFE8URomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation2ViewModel();
+            vm.LoadEntry(entryAddr);
+
+            Assert.True(vm.IsLoaded);
+            Assert.Equal(entryAddr, vm.CurrentAddr);
+            // Synthetic ROM plants P0=0x08800100 (offset 0x00800100), wait=0x13,
+            // count=4, startindex=0x3C, padding=0.
+            Assert.Equal(0x00800100u, vm.PaletteDataPointer);
+            Assert.Equal(0x13u, vm.AnimInterval);
+            Assert.Equal(4u, vm.DataCount);
+            Assert.Equal(0x3Cu, vm.StartPaletteIndex);
+            Assert.Equal(0u, vm.Unknown7);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_LoadEntry_PopulatesPaletteSubList()
+    {
+        var rom = MakeMinimalFE8URomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation2ViewModel();
+            vm.LoadEntry(entryAddr);
+
+            // Synthetic ROM plants 4 palette rows at 0x00800100.
+            Assert.Equal(4, vm.PaletteRows.Count);
+            Assert.Equal(0, vm.SelectedPaletteRowIndex);
+            // Row 0 is white (0x7FFF) -> (248, 248, 248).
+            Assert.Equal((byte)0xF8, vm.PaletteRows[0].r);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_PaletteRow_RgbToGba_RoundTrips()
+    {
+        var vm = new MapTileAnimation2ViewModel();
+        vm.PaletteR = 0xF8;
+        vm.PaletteG = 0x10;
+        vm.PaletteB = 0x80;
+        vm.RecomputeGbaColor();
+        Assert.Equal((uint)MapTileAnimation2Core.RgbToGba(0xF8, 0x10, 0x80), vm.PaletteGba);
+    }
+
+    [Fact]
+    public void ViewModel_WritePaletteRow_PersistsToRom()
+    {
+        var rom = MakeMinimalFE8URomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation2ViewModel();
+            vm.LoadEntry(entryAddr);
+            // Pick row 1; set RGB to a known unique color (0xF8, 0x10, 0x80
+            // = 0x405F GBA).
+            vm.SelectedPaletteRowIndex = 1;
+            vm.PaletteR = 0xF8;
+            vm.PaletteG = 0x10;
+            vm.PaletteB = 0x80;
+            bool ok = vm.WritePaletteRow();
+            Assert.True(ok);
+
+            uint dataOffset = U.toOffset(vm.PaletteDataPointer);
+            ushort raw = (ushort)rom.u16(dataOffset + 2 * 1);
+            Assert.Equal((ushort)0x405F, raw);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_LoadList_FallsBackToEmpty_WhenNoPlistEntries()
+    {
+        var rom = new ROM();
+        rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation2ViewModel();
+            var items = vm.LoadList();
+            Assert.Empty(items);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    static string AxamlPath()
+    {
+        string repoRoot = FindRepoRoot();
+        return Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "MapTileAnimation2View.axaml");
+    }
+
+    static string ViewCodeBehindPath()
+    {
+        string repoRoot = FindRepoRoot();
+        return Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "MapTileAnimation2View.axaml.cs");
+    }
+
+    static string ReadAxaml() => File.ReadAllText(AxamlPath());
+
+    /// <summary>
+    /// Build a tiny synthetic FE8U ROM with:
+    /// - map_setting_pointer -> 0x08800000 (map block at 0x00800000),
+    ///   one map entry with anime2_plist=1, terminator at index 1.
+    /// - map_tileanime2_pointer -> 0x08900000 (PLIST table at 0x00900000).
+    /// - PLIST table entry for plist=1 -> 0x08800200 (entry block at
+    ///   0x00800200), one 8-byte entry pointing at palette data at
+    ///   0x00800100 with wait=0x13, count=4, startindex=0x3C.
+    /// - Palette data at 0x00800100: 4 u16 GBA colors (white, red, green,
+    ///   blue) so palette sub-list has 4 rows.
+    /// Returns the entry address (0x00800200) so the test can call
+    /// LoadEntry() directly without going through the filter chain.
+    /// </summary>
+    static ROM MakeMinimalFE8URomWithEntry(out uint entryAddr)
+    {
+        var rom = new ROM();
+        rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+
+        // Map block at 0x00800000: D0=pointer, anime2_plist=1 at +10.
+        WriteU32(rom.Data, (int)rom.RomInfo.map_setting_pointer, 0x08800000u);
+        WriteU32(rom.Data, 0x800000, 0x08800200u); // D0 = pointer (valid)
+        rom.Data[0x800000 + 10] = 1; // anime2_plist = 1
+        // Map[1]: terminator (D0 = 0)
+        uint dataSize = rom.RomInfo.map_setting_datasize;
+        WriteU32(rom.Data, (int)(0x800000 + dataSize), 0u);
+
+        // PLIST table at 0x00900000. Slot 1 -> 0x08800200.
+        WriteU32(rom.Data, (int)rom.RomInfo.map_tileanime2_pointer, 0x08900000u);
+        WriteU32(rom.Data, 0x900000 + 1 * 4, 0x08800200u);
+
+        // Entry block at 0x00800200: P0=0x08800100, wait=0x13, count=4,
+        // startindex=0x3C, padding=0.
+        entryAddr = 0x800200;
+        WriteU32(rom.Data, (int)entryAddr + 0, 0x08800100u);
+        rom.Data[entryAddr + 4] = 0x13;
+        rom.Data[entryAddr + 5] = 4;
+        rom.Data[entryAddr + 6] = 0x3C;
+        rom.Data[entryAddr + 7] = 0;
+        // Entry[1] = zero P0 so ScanEntries stops cleanly.
+        WriteU32(rom.Data, (int)entryAddr + 8, 0u);
+
+        // Palette data at 0x00800100: 4 u16 GBA colors.
+        WriteU16(rom.Data, 0x800100 + 0, 0x7FFF); // white
+        WriteU16(rom.Data, 0x800100 + 2, 0x001F); // red
+        WriteU16(rom.Data, 0x800100 + 4, 0x03E0); // green
+        WriteU16(rom.Data, 0x800100 + 6, 0x7C00); // blue
+
+        return rom;
+    }
+
+    static void WriteU32(byte[] data, int offset, uint value)
+    {
+        data[offset + 0] = (byte)(value & 0xFF);
+        data[offset + 1] = (byte)((value >> 8) & 0xFF);
+        data[offset + 2] = (byte)((value >> 16) & 0xFF);
+        data[offset + 3] = (byte)((value >> 24) & 0xFF);
+    }
+
+    static void WriteU16(byte[] data, int offset, ushort value)
+    {
+        data[offset + 0] = (byte)(value & 0xFF);
+        data[offset + 1] = (byte)((value >> 8) & 0xFF);
+    }
+
+    static string FindRepoRoot()
+    {
+        string? dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+        if (dir == null)
+            throw new InvalidOperationException("Could not find FEBuilderGBA.sln from test base directory");
+        return dir;
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MapTileAnimation2ParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MapTileAnimation2ParityTests.cs
@@ -82,7 +82,7 @@ public class MapTileAnimation2ParityTests
     public void View_HasPaletteSubList()
     {
         string axaml = ReadAxaml();
-        Assert.Contains("AutomationId=\"MapTileAnimation2_NList\"", axaml);
+        Assert.Contains("AutomationId=\"MapTileAnimation2_NList_List\"", axaml);
         Assert.Contains("AutomationId=\"MapTileAnimation2_NW0_Input\"", axaml);
         Assert.Contains("AutomationId=\"MapTileAnimation2_NR_Input\"", axaml);
         Assert.Contains("AutomationId=\"MapTileAnimation2_NG_Input\"", axaml);

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MapTileAnimation2ParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MapTileAnimation2ParityTests.cs
@@ -333,6 +333,76 @@ public class MapTileAnimation2ParityTests
         finally { CoreState.ROM = prevRom; }
     }
 
+    /// <summary>
+    /// Regression test for the Copilot CLI inline review on PR #534:
+    /// Write_Click must rebuild the palette sub-list when the user changes
+    /// the Palette Data Pointer (and/or Data Count) and clicks Write to ROM.
+    /// We simulate the view's "set new pointer + Write + LoadEntry" sequence
+    /// and assert the palette rows reflect the NEW pointer's bytes, not the
+    /// pre-write data.
+    /// </summary>
+    [Fact]
+    public void ViewModel_Write_FollowedByLoadEntry_RefreshesPaletteSubList()
+    {
+        var rom = MakeMinimalFE8URomWithEntry(out uint entryAddr);
+        // Plant a DIFFERENT palette block at 0x00800500 with one color that
+        // differs from row 0 of 0x00800100 (which is white 0x7FFF).
+        WriteU16(rom.Data, 0x800500 + 0, 0x001F); // red instead of white
+        WriteU16(rom.Data, 0x800500 + 2, 0x03E0); // green
+
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation2ViewModel();
+            vm.LoadEntry(entryAddr);
+            // After LoadEntry, row 0 should be white from 0x00800100.
+            Assert.Equal((byte)0xF8, vm.PaletteRows[0].r);
+            Assert.Equal((byte)0xF8, vm.PaletteRows[0].g);
+
+            // Now mutate the pointer + count and Write (simulates the view's
+            // Write_Click handler before the LoadEntry refresh).
+            vm.PaletteDataPointer = 0x00800500u;
+            vm.DataCount = 2u;
+            vm.Write();
+
+            // The view's Write_Click now reloads the entry so the sub-list
+            // reflects the new pointer's data. Without the LoadEntry call,
+            // PaletteRows would still hold the old white-at-row-0 values.
+            vm.LoadEntry(entryAddr);
+
+            Assert.Equal(2, vm.PaletteRows.Count);
+            // Row 0 should now be red (0x001F decoded to 248, 0, 0).
+            Assert.Equal((byte)0xF8, vm.PaletteRows[0].r);
+            Assert.Equal((byte)0x00, vm.PaletteRows[0].g);
+            Assert.Equal((byte)0x00, vm.PaletteRows[0].b);
+            // NReadStartAddress should reflect the new pointer's offset.
+            Assert.Equal(0x00800500u, vm.NReadStartAddress);
+            // NReadCount should mirror DataCount.
+            Assert.Equal(2u, vm.NReadCount);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    /// <summary>
+    /// Roslyn-static check: Write_Click must call LoadEntry + UpdateUI after
+    /// Commit so the palette sub-list, N-address bar, color preview, and
+    /// SelectedAddress label do not stay stale (Copilot CLI inline review
+    /// on PR #534).
+    /// </summary>
+    [Fact]
+    public void View_WriteHandler_ReloadsEntryAfterCommit()
+    {
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        int writeClick = source.IndexOf("void Write_Click(", StringComparison.Ordinal);
+        Assert.True(writeClick >= 0, "Write_Click handler not found");
+        int writeBodyEnd = source.IndexOf("void NWrite_Click(", writeClick, StringComparison.Ordinal);
+        Assert.True(writeBodyEnd > writeClick, "NWrite_Click should come after Write_Click");
+        string writeBody = source.Substring(writeClick, writeBodyEnd - writeClick);
+        Assert.Contains("_vm.LoadEntry(", writeBody);
+        Assert.Contains("UpdateUI()", writeBody);
+    }
+
     // -----------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia/ViewModels/MapTileAnimation2ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapTileAnimation2ViewModel.cs
@@ -108,8 +108,8 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             for (int i = 0; i < entries.Count; i++)
             {
                 var e = entries[i];
-                string display = $"0x{i:X2} Palette Interval={e.wait:X2} Count={e.count:X2}";
-                result.Add(new AddrResult(e.addr, display, (uint)i));
+                string display = $"0x{i:X2} Palette Interval={e.Wait:X2} Count={e.Count:X2}";
+                result.Add(new AddrResult(e.Addr, display, (uint)i));
             }
             ReadCount = (uint)entries.Count;
             return result;
@@ -129,9 +129,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             var plistRows = LoadPlistList();
             foreach (var row in plistRows)
             {
-                if (row.isBroken) continue;
-                SelectedPlist = row.plist;
-                return BuildList(row.addr);
+                if (row.IsBroken) continue;
+                SelectedPlist = row.Plist;
+                return BuildList(row.Addr);
             }
             return new List<AddrResult>();
         }
@@ -158,12 +158,28 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (PaletteRows.Count > 0)
             {
                 var first = PaletteRows[0];
-                PaletteR = first.r;
-                PaletteG = first.g;
-                PaletteB = first.b;
-                PaletteGba = first.gba;
+                PaletteR = first.R;
+                PaletteG = first.G;
+                PaletteB = first.B;
+                PaletteGba = first.Gba;
                 NReadStartAddress = U.toOffset(PaletteDataPointer);
                 NReadCount = DataCount;
+            }
+            else
+            {
+                // Clear stale N-address bar / RGB editor state when the
+                // entry has DataCount==0 or an unsafe/empty palette pointer.
+                // Without this reset, switching from an entry with palette
+                // rows to one without (e.g., a freshly-zeroed DataCount)
+                // would leave the previous entry's N-address, R/G/B inputs,
+                // and GBA color preview visible (Copilot CLI inline review
+                // on PR #534).
+                NReadStartAddress = 0;
+                NReadCount = 0;
+                PaletteR = 0;
+                PaletteG = 0;
+                PaletteB = 0;
+                PaletteGba = 0;
             }
 
             IsLoaded = true;
@@ -175,15 +191,19 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public void LoadPaletteRow(int rowIndex)
         {
             if (rowIndex < 0 || rowIndex >= PaletteRows.Count) return;
+            // Suppress dirty marking while syncing the R/G/B / GBA fields
+            // from the selected palette row - this is a navigation event,
+            // not a user edit. Do NOT MarkClean() afterwards because that
+            // would wipe a pre-existing dirty state from prior edits to
+            // the main entry fields (Copilot CLI inline review on PR #534).
             IsLoading = true;
             var row = PaletteRows[rowIndex];
             SelectedPaletteRowIndex = rowIndex;
-            PaletteR = row.r;
-            PaletteG = row.g;
-            PaletteB = row.b;
-            PaletteGba = row.gba;
+            PaletteR = row.R;
+            PaletteG = row.G;
+            PaletteB = row.B;
+            PaletteGba = row.Gba;
             IsLoading = false;
-            MarkClean();
         }
 
         /// <summary>
@@ -213,7 +233,12 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// Write the currently selected palette row (R/G/B encoded as a 15-bit
         /// GBA word) back to ROM at <c>dataPointer + 2 * rowIndex</c>.
         /// Returns <c>true</c> on success, <c>false</c> if the row index or
-        /// data pointer is invalid.
+        /// data pointer is invalid. Also normalizes the in-memory
+        /// <see cref="PaletteR"/>/<see cref="PaletteG"/>/<see cref="PaletteB"/>
+        /// to the post-truncation (multiples of 8) values so the UI inputs
+        /// stay in sync with the ROM bytes (Copilot CLI inline review on
+        /// PR #534 - the 5-bit quantization drops the low 3 bits, so a
+        /// user-typed value like R=125 ends up persisted as 120).
         /// </summary>
         public bool WritePaletteRow()
         {
@@ -227,6 +252,12 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (addr + 2 > (uint)rom.Data.Length) return false;
             ushort gba = MapTileAnimation2Core.RgbToGba((byte)PaletteR, (byte)PaletteG, (byte)PaletteB);
             rom.write_u16(addr, gba);
+            // Normalize the UI fields to the truncated (multiples of 8)
+            // values so PaletteR/G/B match the bytes that ended up in ROM.
+            var (nr, ng, nb) = MapTileAnimation2Core.GbaToRgb(gba);
+            IsLoading = true;
+            try { PaletteR = nr; PaletteG = ng; PaletteB = nb; }
+            finally { IsLoading = false; }
             PaletteGba = gba;
             // Refresh palette rows so the sub-list reflects the new value.
             PaletteRows = MapTileAnimation2Core.BuildPaletteList(rom, PaletteDataPointer, DataCount);

--- a/FEBuilderGBA.Avalonia/ViewModels/MapTileAnimation2ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapTileAnimation2ViewModel.cs
@@ -4,13 +4,28 @@ using FEBuilderGBA.Avalonia.Services;
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
     /// <summary>Map tile animation type 2 editor (palette animation).
-    /// WinForms: MapTileAnimation2Form — block size 8, validated by isPointer(u32(addr+0)).
-    /// Fields: PaletteDataPointer (u32@0), AnimInterval (u8@4), DataCount (u8@5),
-    /// StartPaletteIndex (u8@6), Unknown7 (u8@7).</summary>
+    /// WinForms: <c>MapTileAnimation2Form</c> - block size 8, validated by
+    /// <c>isPointer(u32(addr+0))</c>. Fields: PaletteDataPointer (GBA pointer
+    /// at +0), AnimInterval (u8@4), DataCount (u8@5), StartPaletteIndex (u8@6),
+    /// Unknown7 (u8@7).
+    ///
+    /// The +0 field is a <see cref="EditorFormRef.FieldType.Pointer"/> (P0)
+    /// because WinForms uses <c>Program.ROM.p32</c>/<c>write_p32</c> which
+    /// strips and re-adds the <c>0x08000000</c> high bit. Storing it as a raw
+    /// DWord (D0) would write the offset form back to ROM without the high
+    /// bit, corrupting the address (gap-sweep #426, Copilot CLI plan-review
+    /// finding #1).
+    /// </summary>
     public class MapTileAnimation2ViewModel : ViewModelBase, IDataVerifiable
     {
         static readonly List<EditorFormRef.FieldDef> _fields =
-            EditorFormRef.DetectFields(new[] { "D0", "B4", "B5", "B6", "B7" });
+            EditorFormRef.DetectFields(new[] { "P0", "B4", "B5", "B6", "B7" });
+
+        /// <summary>WF block size constant (8 bytes per row).</summary>
+        public const uint BLOCK_SIZE = 8;
+
+        /// <summary>WF sub-list block size constant (2 bytes per palette row).</summary>
+        public const uint N_BLOCK_SIZE = 2;
 
         uint _currentAddr;
         bool _isLoaded;
@@ -20,6 +35,25 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         uint _startPaletteIndex;
         uint _unknown7;
 
+        // Filter panel (top read-config bar).
+        uint _readStartAddress;
+        uint _readCount;
+        uint? _selectedPlist;
+        List<MapTileAnimation2Core.PlistRow> _plistRows = new();
+
+        // Selection bar.
+        uint _selectedAddress;
+
+        // Palette sub-list (panel2).
+        List<MapTileAnimation2Core.PaletteRow> _paletteRows = new();
+        int _selectedPaletteRowIndex = -1;
+        uint _paletteR;
+        uint _paletteG;
+        uint _paletteB;
+        uint _paletteGba;
+        uint _nReadStartAddress;
+        uint _nReadCount;
+
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
         public uint PaletteDataPointer { get => _paletteDataPointer; set => SetField(ref _paletteDataPointer, value); }
@@ -28,93 +62,175 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public uint StartPaletteIndex { get => _startPaletteIndex; set => SetField(ref _startPaletteIndex, value); }
         public uint Unknown7 { get => _unknown7; set => SetField(ref _unknown7, value); }
 
-        /// <summary>Build list from a given base address (set via filter/JumpTo).</summary>
+        public uint BlockSize => BLOCK_SIZE;
+        public uint NBlockSize => N_BLOCK_SIZE;
+
+        public uint ReadStartAddress { get => _readStartAddress; set => SetField(ref _readStartAddress, value); }
+        public uint ReadCount { get => _readCount; set => SetField(ref _readCount, value); }
+        public uint? SelectedPlist { get => _selectedPlist; set => SetField(ref _selectedPlist, value); }
+        public List<MapTileAnimation2Core.PlistRow> PlistRows
+        {
+            get => _plistRows;
+            set => SetField(ref _plistRows, value ?? new());
+        }
+        public uint SelectedAddress { get => _selectedAddress; set => SetField(ref _selectedAddress, value); }
+
+        public List<MapTileAnimation2Core.PaletteRow> PaletteRows
+        {
+            get => _paletteRows;
+            set => SetField(ref _paletteRows, value ?? new());
+        }
+        public int SelectedPaletteRowIndex { get => _selectedPaletteRowIndex; set => SetField(ref _selectedPaletteRowIndex, value); }
+        public uint PaletteR { get => _paletteR; set => SetField(ref _paletteR, value); }
+        public uint PaletteG { get => _paletteG; set => SetField(ref _paletteG, value); }
+        public uint PaletteB { get => _paletteB; set => SetField(ref _paletteB, value); }
+        public uint PaletteGba { get => _paletteGba; set => SetField(ref _paletteGba, value); }
+        public uint NReadStartAddress { get => _nReadStartAddress; set => SetField(ref _nReadStartAddress, value); }
+        public uint NReadCount { get => _nReadCount; set => SetField(ref _nReadCount, value); }
+
+        /// <summary>Build the filter combo list - one row per distinct PLIST referenced by any map.</summary>
+        public List<MapTileAnimation2Core.PlistRow> LoadPlistList()
+        {
+            var rom = CoreState.ROM;
+            var rows = MapTileAnimation2Core.BuildPlistList(rom);
+            PlistRows = rows;
+            return rows;
+        }
+
+        /// <summary>Build the address-list for a specific PLIST root address.</summary>
         public List<AddrResult> BuildList(uint baseAddr)
         {
+            var rom = CoreState.ROM;
             var result = new List<AddrResult>();
-            ROM rom = CoreState.ROM;
             if (rom == null || baseAddr == 0) return result;
-
-            const uint blockSize = 8;
-            for (int i = 0; i < 256; i++)
+            ReadStartAddress = baseAddr;
+            var entries = MapTileAnimation2Core.ScanEntries(rom, baseAddr, maxRows: 256);
+            for (int i = 0; i < entries.Count; i++)
             {
-                uint addr = baseAddr + (uint)(i * blockSize);
-                if (addr + blockSize > (uint)rom.Data.Length) break;
-                // Validate: P0 must be a valid pointer
-                if (!U.isPointer(rom.u32(addr + 0))) break;
-
-                uint interval = rom.u8(addr + 4);
-                uint count = rom.u8(addr + 5);
-                string display = $"0x{i:X2} Palette Interval={interval:X2} Count={count:X2}";
-                result.Add(new AddrResult(addr, display, (uint)i));
+                var e = entries[i];
+                string display = $"0x{i:X2} Palette Interval={e.wait:X2} Count={e.count:X2}";
+                result.Add(new AddrResult(e.addr, display, (uint)i));
             }
+            ReadCount = (uint)entries.Count;
             return result;
         }
 
+        /// <summary>
+        /// Build the list shown when the editor opens with no PLIST chosen -
+        /// scan the PLIST list for the first valid entry. Kept for backwards
+        /// compatibility with the existing <c>DataVerifiable</c> contract that
+        /// calls <c>LoadList()</c> with no arguments.
+        /// </summary>
         public List<AddrResult> LoadList()
         {
-            ROM rom = CoreState.ROM;
+            var rom = CoreState.ROM;
             if (rom?.RomInfo == null) return new List<AddrResult>();
 
-            // map_tileanime2_pointer is a PLIST base pointer (array of 4-byte pointers).
-            // The WinForms MapTileAnimation2Form scans map settings for non-zero anime2_plist
-            // values and looks up data via PlistToOffsetAddr.  For data-verify, we scan the
-            // PLIST table for the first valid entry whose target contains valid animation data.
-            uint ptr = rom.RomInfo.map_tileanime2_pointer;
-            if (ptr == 0) return new List<AddrResult>();
-
-            uint plistBase = rom.p32(ptr);
-            if (!U.isSafetyOffset(plistBase, rom)) return new List<AddrResult>();
-
-            uint plistLimit = rom.RomInfo.map_map_pointer_list_default_size;
-            if (plistLimit == 0) plistLimit = 256;
-
-            // Scan PLIST entries for the first valid entry whose data passes BuildList validation
-            for (uint i = 0; i < plistLimit; i++)
+            var plistRows = LoadPlistList();
+            foreach (var row in plistRows)
             {
-                uint entryAddr = plistBase + i * 4;
-                if (entryAddr + 4 > (uint)rom.Data.Length) break;
-                uint entryPtr = rom.u32(entryAddr);
-                if (!U.isPointer(entryPtr)) continue;
-                uint dataAddr = U.toOffset(entryPtr);
-                if (!U.isSafetyOffset(dataAddr, rom)) continue;
-                var list = BuildList(dataAddr);
-                if (list.Count > 0) return list;
+                if (row.isBroken) continue;
+                SelectedPlist = row.plist;
+                return BuildList(row.addr);
             }
-
             return new List<AddrResult>();
         }
 
         public void LoadEntry(uint addr)
         {
-            ROM rom = CoreState.ROM;
+            var rom = CoreState.ROM;
             if (rom == null) return;
             if (addr + 8 > (uint)rom.Data.Length) return;
 
             IsLoading = true;
             CurrentAddr = addr;
+            SelectedAddress = addr;
             var values = EditorFormRef.ReadFields(rom, addr, _fields);
-            PaletteDataPointer = values["D0"];
+            PaletteDataPointer = values["P0"];
             AnimInterval = values["B4"];
             DataCount = values["B5"];
             StartPaletteIndex = values["B6"];
             Unknown7 = values["B7"];
+
+            // Rebuild palette sub-list for the new entry.
+            PaletteRows = MapTileAnimation2Core.BuildPaletteList(rom, PaletteDataPointer, DataCount);
+            SelectedPaletteRowIndex = PaletteRows.Count > 0 ? 0 : -1;
+            if (PaletteRows.Count > 0)
+            {
+                var first = PaletteRows[0];
+                PaletteR = first.r;
+                PaletteG = first.g;
+                PaletteB = first.b;
+                PaletteGba = first.gba;
+                NReadStartAddress = U.toOffset(PaletteDataPointer);
+                NReadCount = DataCount;
+            }
+
             IsLoaded = true;
             IsLoading = false;
             MarkClean();
         }
 
+        /// <summary>Load the R/G/B fields from a specific palette row index.</summary>
+        public void LoadPaletteRow(int rowIndex)
+        {
+            if (rowIndex < 0 || rowIndex >= PaletteRows.Count) return;
+            IsLoading = true;
+            var row = PaletteRows[rowIndex];
+            SelectedPaletteRowIndex = rowIndex;
+            PaletteR = row.r;
+            PaletteG = row.g;
+            PaletteB = row.b;
+            PaletteGba = row.gba;
+            IsLoading = false;
+            MarkClean();
+        }
+
+        /// <summary>
+        /// Recompute the encoded GBA color from the current R/G/B values.
+        /// Called by the view when R/G/B inputs change.
+        /// </summary>
+        public void RecomputeGbaColor()
+        {
+            PaletteGba = MapTileAnimation2Core.RgbToGba((byte)PaletteR, (byte)PaletteG, (byte)PaletteB);
+        }
+
+        /// <summary>Write the current main-entry fields to ROM via EditorFormRef.</summary>
         public void Write()
         {
-            ROM rom = CoreState.ROM;
+            var rom = CoreState.ROM;
             if (rom == null || CurrentAddr == 0) return;
             var values = new Dictionary<string, uint>
             {
-                ["D0"] = PaletteDataPointer, ["B4"] = AnimInterval,
+                ["P0"] = PaletteDataPointer, ["B4"] = AnimInterval,
                 ["B5"] = DataCount, ["B6"] = StartPaletteIndex,
                 ["B7"] = Unknown7,
             };
             EditorFormRef.WriteFields(rom, CurrentAddr, values, _fields);
+        }
+
+        /// <summary>
+        /// Write the currently selected palette row (R/G/B encoded as a 15-bit
+        /// GBA word) back to ROM at <c>dataPointer + 2 * rowIndex</c>.
+        /// Returns <c>true</c> on success, <c>false</c> if the row index or
+        /// data pointer is invalid.
+        /// </summary>
+        public bool WritePaletteRow()
+        {
+            var rom = CoreState.ROM;
+            if (rom == null) return false;
+            if (SelectedPaletteRowIndex < 0 || SelectedPaletteRowIndex >= PaletteRows.Count) return false;
+            if (PaletteDataPointer == 0) return false;
+            uint offset = U.toOffset(PaletteDataPointer);
+            if (!U.isSafetyOffset(offset, rom)) return false;
+            uint addr = offset + (uint)(SelectedPaletteRowIndex * 2);
+            if (addr + 2 > (uint)rom.Data.Length) return false;
+            ushort gba = MapTileAnimation2Core.RgbToGba((byte)PaletteR, (byte)PaletteG, (byte)PaletteB);
+            rom.write_u16(addr, gba);
+            PaletteGba = gba;
+            // Refresh palette rows so the sub-list reflects the new value.
+            PaletteRows = MapTileAnimation2Core.BuildPaletteList(rom, PaletteDataPointer, DataCount);
+            return true;
         }
 
         public int GetListCount() => LoadList().Count;
@@ -134,7 +250,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
         public Dictionary<string, string> GetRawRomReport()
         {
-            ROM rom = CoreState.ROM;
+            var rom = CoreState.ROM;
             if (rom == null || CurrentAddr == 0) return new Dictionary<string, string>();
             uint a = CurrentAddr;
             return new Dictionary<string, string>

--- a/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml
@@ -135,7 +135,7 @@
 
             <!-- N sub-list + RGB editor row -->
             <Grid ColumnDefinitions="300,140,140" RowDefinitions="Auto">
-              <ListBox AutomationProperties.AutomationId="MapTileAnimation2_NList"
+              <ListBox AutomationProperties.AutomationId="MapTileAnimation2_NList_List"
                        Grid.Column="0" Name="NPaletteListBox" Height="160"
                        SelectionChanged="NPaletteList_SelectionChanged" />
 

--- a/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml
@@ -2,37 +2,205 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
         x:Class="FEBuilderGBA.Avalonia.Views.MapTileAnimation2View"
-        Title="Tile Animation Type 2" Width="1238" Height="926"
+        Title="Map Tile Animation Type 2 (Palette)" Width="1238" Height="926"
         SizeToContent="WidthAndHeight">
-  <Grid ColumnDefinitions="250,*">
-    <controls:AddressListControl AutomationProperties.AutomationId="MapTileAnimation2_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
+  <Grid ColumnDefinitions="260,*" RowDefinitions="Auto,Auto,*">
 
-    <ScrollViewer Grid.Column="1" Margin="4">
+    <!-- Row 0: Top read-config bar (mirrors WF panel3) -->
+    <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
+      <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
+        <Label Content="Top Address" VerticalAlignment="Center" />
+        <NumericUpDown AutomationProperties.AutomationId="MapTileAnimation2_ReadStart_Input"
+                       FormatString="X8" Name="ReadStartAddressBox" Width="120"
+                       Minimum="0" Maximum="4294967295"
+                       IsEnabled="False" VerticalAlignment="Center" />
+        <Label Content="Read Count" VerticalAlignment="Center" />
+        <NumericUpDown AutomationProperties.AutomationId="MapTileAnimation2_ReadCount_Input"
+                       FormatString="0" Name="ReadCountBox" Width="80"
+                       Minimum="0" Maximum="1024"
+                       IsEnabled="False" VerticalAlignment="Center" />
+        <Button AutomationProperties.AutomationId="MapTileAnimation2_ReloadList_Button"
+                Name="ReloadListButton" Content="Reload" Click="ReloadList_Click" />
+        <Label Content="Filter" VerticalAlignment="Center" />
+        <ComboBox AutomationProperties.AutomationId="MapTileAnimation2_Filter_Combo"
+                  Name="FilterComboBox" Width="280"
+                  SelectionChanged="FilterCombo_SelectionChanged" />
+      </StackPanel>
+    </Border>
+
+    <!-- Row 1: selection bar (mirrors WF panel5) -->
+    <Border Grid.Row="1" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4,0,4,0">
+      <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
+        <Label Content="Address" VerticalAlignment="Center" />
+        <NumericUpDown AutomationProperties.AutomationId="MapTileAnimation2_Address_Input"
+                       FormatString="X8" Name="AddressBox" Width="120"
+                       Minimum="0" Maximum="4294967295"
+                       IsEnabled="False" VerticalAlignment="Center" />
+        <Label Content="Size:" VerticalAlignment="Center" />
+        <NumericUpDown AutomationProperties.AutomationId="MapTileAnimation2_BlockSize_Input"
+                       FormatString="0" Name="BlockSizeBox" Width="50"
+                       Minimum="0" Maximum="65535"
+                       IsEnabled="False" VerticalAlignment="Center" Value="8" />
+        <Label Content="Selected Address:" VerticalAlignment="Center" />
+        <Label AutomationProperties.AutomationId="MapTileAnimation2_SelectedAddress_Label"
+               Name="SelectedAddressLabel" Width="100" VerticalAlignment="Center"
+               FontFamily="Consolas" />
+        <Button AutomationProperties.AutomationId="MapTileAnimation2_Write_Button"
+                Name="WriteButton" Content="Write to ROM" Click="Write_Click" />
+      </StackPanel>
+    </Border>
+
+    <!-- Row 2 col 0: Address list panel (mirrors WF panel6) -->
+    <Border Grid.Row="2" Grid.Column="0" BorderBrush="Gray" BorderThickness="1" Margin="4">
+      <DockPanel>
+        <Label DockPanel.Dock="Top"
+               AutomationProperties.AutomationId="MapTileAnimation2_Name_Label"
+               Content="Name" HorizontalAlignment="Stretch" />
+        <Button DockPanel.Dock="Bottom"
+                AutomationProperties.AutomationId="MapTileAnimation2_ListExpand_Button"
+                Name="ListExpandButton" Content="Data Expansion"
+                IsEnabled="False"
+                ToolTip.Tip="Pending Core extraction - tracked by #524"
+                HorizontalAlignment="Stretch" Margin="2"
+                Click="ListExpand_Click" />
+        <controls:AddressListControl AutomationProperties.AutomationId="MapTileAnimation2_Entry_List"
+                                     Name="EntryList" />
+      </DockPanel>
+    </Border>
+
+    <!-- Row 2 col 1: edit panel + palette sub-list + bulk export -->
+    <ScrollViewer Grid.Row="2" Grid.Column="1" Margin="4">
       <StackPanel Spacing="8" Margin="8">
-        <TextBlock Text="Map Tile Animation Type 2 (Palette)" FontSize="18" FontWeight="Bold" />
+        <Label Content="Map Tile Animation Type 2 (Palette)" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="200,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="MapTileAnimation2_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+        <!-- Main edit panel (mirrors WF panel4 top half) -->
+        <Border BorderBrush="Gray" BorderThickness="1" Padding="8">
+          <Grid ColumnDefinitions="200,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
+            <TextBlock AutomationProperties.AutomationId="MapTileAnimation2_Addr_Label"
+                       Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
 
-          <TextBlock Grid.Row="1" Grid.Column="0" Text="Palette Data Pointer:" VerticalAlignment="Center" Margin="0,4,0,0" />
-          <TextBox AutomationProperties.AutomationId="MapTileAnimation2_PaletteDataPointer_Input" Grid.Row="1" Grid.Column="1" Name="PaletteDataPointerBox" Width="160" Margin="0,4,0,0" />
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Palette Data Pointer:" VerticalAlignment="Center" Margin="0,4,0,0" />
+            <TextBox AutomationProperties.AutomationId="MapTileAnimation2_PaletteDataPointer_Input"
+                     Grid.Row="1" Grid.Column="1" Name="PaletteDataPointerBox" Width="160" Margin="0,4,0,0" />
 
-          <TextBlock Grid.Row="2" Grid.Column="0" Text="Animation Interval:" VerticalAlignment="Center" Margin="0,4,0,0" />
-          <NumericUpDown AutomationProperties.AutomationId="MapTileAnimation2_AnimInterval_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="AnimIntervalBox" Minimum="0" Maximum="255" Margin="0,4,0,0" />
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Animation Interval:" VerticalAlignment="Center" Margin="0,4,0,0" />
+            <NumericUpDown AutomationProperties.AutomationId="MapTileAnimation2_AnimInterval_Input"
+                           FormatString="0" Grid.Row="2" Grid.Column="1" Name="AnimIntervalBox"
+                           Minimum="0" Maximum="255" Margin="0,4,0,0" />
 
-          <TextBlock Grid.Row="3" Grid.Column="0" Text="Data Count:" VerticalAlignment="Center" Margin="0,4,0,0" />
-          <NumericUpDown AutomationProperties.AutomationId="MapTileAnimation2_DataCount_Input" FormatString="0" Grid.Row="3" Grid.Column="1" Name="DataCountBox" Minimum="0" Maximum="255" Margin="0,4,0,0" />
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Data Count:" VerticalAlignment="Center" Margin="0,4,0,0" />
+            <NumericUpDown AutomationProperties.AutomationId="MapTileAnimation2_DataCount_Input"
+                           FormatString="0" Grid.Row="3" Grid.Column="1" Name="DataCountBox"
+                           Minimum="0" Maximum="255" Margin="0,4,0,0" />
 
-          <TextBlock Grid.Row="4" Grid.Column="0" Text="Start Palette Index:" VerticalAlignment="Center" Margin="0,4,0,0" />
-          <NumericUpDown AutomationProperties.AutomationId="MapTileAnimation2_StartPaletteIndex_Input" FormatString="0" Grid.Row="4" Grid.Column="1" Name="StartPaletteIndexBox" Minimum="0" Maximum="255" Margin="0,4,0,0" />
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Start Palette Index:" VerticalAlignment="Center" Margin="0,4,0,0" />
+            <NumericUpDown AutomationProperties.AutomationId="MapTileAnimation2_StartPaletteIndex_Input"
+                           FormatString="0" Grid.Row="4" Grid.Column="1" Name="StartPaletteIndexBox"
+                           Minimum="0" Maximum="255" Margin="0,4,0,0" />
 
-          <TextBlock Grid.Row="5" Grid.Column="0" Text="Unknown (0x07):" VerticalAlignment="Center" Margin="0,4,0,0" />
-          <NumericUpDown AutomationProperties.AutomationId="MapTileAnimation2_Unknown7_Input" FormatString="0" Grid.Row="5" Grid.Column="1" Name="Unknown7Box" Minimum="0" Maximum="255" Margin="0,4,0,0" />
-        </Grid>
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Unknown (0x07):" VerticalAlignment="Center" Margin="0,4,0,0" />
+            <NumericUpDown AutomationProperties.AutomationId="MapTileAnimation2_Unknown7_Input"
+                           FormatString="0" Grid.Row="5" Grid.Column="1" Name="Unknown7Box"
+                           Minimum="0" Maximum="255" Margin="0,4,0,0" />
+          </Grid>
+        </Border>
 
-        <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,16,0,0">
-          <Button AutomationProperties.AutomationId="MapTileAnimation2_Write_Button" Content="Write" Click="Write_Click" />
+        <!-- Palette sub-list panel (mirrors WF panel2) -->
+        <Border BorderBrush="Gray" BorderThickness="1" Padding="8">
+          <StackPanel Spacing="6">
+            <Label AutomationProperties.AutomationId="MapTileAnimation2_NPanel_Label"
+                   Content="Map Tile Animation Type 2 Palette Sub-Table" FontWeight="SemiBold" />
+
+            <!-- N selection bar (mirrors WF panel7) -->
+            <Grid ColumnDefinitions="80,120,80,80,120,*" RowDefinitions="Auto,Auto,Auto">
+              <Label Grid.Row="0" Grid.Column="0" Content="Address" VerticalAlignment="Center" />
+              <NumericUpDown AutomationProperties.AutomationId="MapTileAnimation2_NAddress_Input"
+                             Grid.Row="0" Grid.Column="1" FormatString="X8" Name="NAddressBox"
+                             Minimum="0" Maximum="4294967295" IsEnabled="False" />
+              <Label Grid.Row="0" Grid.Column="2" Content="Size:" VerticalAlignment="Center" />
+              <NumericUpDown AutomationProperties.AutomationId="MapTileAnimation2_NBlockSize_Input"
+                             Grid.Row="0" Grid.Column="3" FormatString="0" Name="NBlockSizeBox"
+                             Minimum="0" Maximum="65535" IsEnabled="False" Value="2" />
+
+              <Label Grid.Row="1" Grid.Column="0" Content="Selected Address:" VerticalAlignment="Center" />
+              <Label AutomationProperties.AutomationId="MapTileAnimation2_NSelectedAddress_Label"
+                     Grid.Row="1" Grid.Column="1" Name="NSelectedAddressLabel"
+                     VerticalAlignment="Center" FontFamily="Consolas" />
+              <Button Grid.Row="1" Grid.Column="3" Grid.ColumnSpan="2"
+                      AutomationProperties.AutomationId="MapTileAnimation2_NWrite_Button"
+                      Name="NWriteButton" Content="Write to ROM" Click="NWrite_Click"
+                      HorizontalAlignment="Left" />
+            </Grid>
+
+            <!-- N sub-list + RGB editor row -->
+            <Grid ColumnDefinitions="300,140,140" RowDefinitions="Auto">
+              <ListBox AutomationProperties.AutomationId="MapTileAnimation2_NList"
+                       Grid.Column="0" Name="NPaletteListBox" Height="160"
+                       SelectionChanged="NPaletteList_SelectionChanged" />
+
+              <!-- Color preview square + GBA color -->
+              <Border Grid.Column="1" BorderBrush="DarkGray" BorderThickness="1"
+                      HorizontalAlignment="Center" VerticalAlignment="Top"
+                      Width="80" Height="80" Margin="8,0,0,0">
+                <Panel Name="ColorPreview" />
+              </Border>
+
+              <!-- R/G/B + GBA editor column -->
+              <Grid Grid.Column="2" ColumnDefinitions="40,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" Margin="8,0,0,0">
+                <Label Grid.Row="0" Grid.Column="0"
+                       AutomationProperties.AutomationId="MapTileAnimation2_GbaColor_Label"
+                       Content="GBA Color" />
+                <NumericUpDown Grid.Row="0" Grid.Column="1"
+                               AutomationProperties.AutomationId="MapTileAnimation2_NW0_Input"
+                               FormatString="X4" Name="NGbaBox"
+                               Minimum="0" Maximum="65535" IsReadOnly="True" />
+                <Label Grid.Row="1" Grid.Column="0" Content="R" />
+                <NumericUpDown Grid.Row="1" Grid.Column="1"
+                               AutomationProperties.AutomationId="MapTileAnimation2_NR_Input"
+                               FormatString="0" Name="NRBox"
+                               Minimum="0" Maximum="255" Increment="8"
+                               ValueChanged="NRgb_ValueChanged" />
+                <Label Grid.Row="2" Grid.Column="0" Content="G" />
+                <NumericUpDown Grid.Row="2" Grid.Column="1"
+                               AutomationProperties.AutomationId="MapTileAnimation2_NG_Input"
+                               FormatString="0" Name="NGBox"
+                               Minimum="0" Maximum="255" Increment="8"
+                               ValueChanged="NRgb_ValueChanged" />
+                <Label Grid.Row="3" Grid.Column="0" Content="B" />
+                <NumericUpDown Grid.Row="3" Grid.Column="1"
+                               AutomationProperties.AutomationId="MapTileAnimation2_NB_Input"
+                               FormatString="0" Name="NBBox"
+                               Minimum="0" Maximum="255" Increment="8"
+                               ValueChanged="NRgb_ValueChanged" />
+                <Label Grid.Row="4" Grid.Column="0" Content="00" />
+                <Label Grid.Row="4" Grid.Column="1"
+                       AutomationProperties.AutomationId="MapTileAnimation2_Padding_Label"
+                       Content="(reserved)" />
+              </Grid>
+            </Grid>
+
+            <Button AutomationProperties.AutomationId="MapTileAnimation2_NListExpand_Button"
+                    Name="NListExpandButton" Content="Data Expansion"
+                    IsEnabled="False"
+                    ToolTip.Tip="Pending Core extraction - tracked by #524"
+                    HorizontalAlignment="Left" Margin="0,4,0,0"
+                    Click="NListExpand_Click" />
+          </StackPanel>
+        </Border>
+
+        <!-- Bulk Import/Export panel (mirrors WF panel8) -->
+        <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
+          <Button AutomationProperties.AutomationId="MapTileAnimation2_BulkImport_Button"
+                  Name="BulkImportButton" Content="Bulk Import"
+                  IsEnabled="False"
+                  ToolTip.Tip="Pending Core extraction - tracked by #524"
+                  Click="BulkImport_Click" />
+          <Button AutomationProperties.AutomationId="MapTileAnimation2_BulkExport_Button"
+                  Name="BulkExportButton" Content="Bulk Export"
+                  IsEnabled="False"
+                  ToolTip.Tip="Pending Core extraction - tracked by #524"
+                  Click="BulkExport_Click" />
         </StackPanel>
       </StackPanel>
     </ScrollViewer>

--- a/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml.cs
@@ -62,12 +62,50 @@ namespace FEBuilderGBA.Avalonia.Views
                 {
                     SelectPlist(plistRows[0]);
                 }
+                else
+                {
+                    // No PLIST entries - clear the entry list and read-config
+                    // bar so a Reload after switching ROMs (or a legitimately
+                    // empty result) doesn't leave the old list visible
+                    // (Copilot bot review on PR #535).
+                    EntryList.SetItemsWithIcons(new List<AddrResult>(), _ => null);
+                    ReadStartAddressBox.Value = 0;
+                    ReadCountBox.Value = 0;
+                    ClearDetailPanel();
+                    UpdateUI();
+                }
             }
             catch (Exception ex)
             {
                 Log.Error("MapTileAnimation2View.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
+        }
+
+        /// <summary>
+        /// Reset the right-hand detail panel and palette sub-list state.
+        /// Used by LoadList (zero PLIST entries) and SelectPlist (broken
+        /// PLIST). Mirrors the WF behavior of clearing the entire panel4
+        /// when no entry is selectable (Copilot bot review on PR #535).
+        /// </summary>
+        void ClearDetailPanel()
+        {
+            _vm.IsLoaded = false;
+            _vm.CurrentAddr = 0;
+            _vm.SelectedAddress = 0;
+            _vm.PaletteDataPointer = 0;
+            _vm.AnimInterval = 0;
+            _vm.DataCount = 0;
+            _vm.StartPaletteIndex = 0;
+            _vm.Unknown7 = 0;
+            _vm.PaletteRows = new List<MapTileAnimation2Core.PaletteRow>();
+            _vm.SelectedPaletteRowIndex = -1;
+            _vm.NReadStartAddress = 0;
+            _vm.NReadCount = 0;
+            _vm.PaletteR = 0;
+            _vm.PaletteG = 0;
+            _vm.PaletteB = 0;
+            _vm.PaletteGba = 0;
         }
 
         void ReloadList_Click(object? sender, RoutedEventArgs e) => LoadList();
@@ -109,19 +147,12 @@ namespace FEBuilderGBA.Avalonia.Views
                     EntryList.SetItemsWithIcons(new List<AddrResult>(), _ => null);
                     ReadStartAddressBox.Value = 0;
                     ReadCountBox.Value = 0;
-                    // Reset the right-hand detail panel so a broken PLIST
-                    // doesn't display the previously-selected entry's data
-                    // (Copilot CLI inline review on PR #534).
-                    _vm.IsLoaded = false;
-                    _vm.CurrentAddr = 0;
-                    _vm.PaletteRows = new List<MapTileAnimation2Core.PaletteRow>();
-                    _vm.SelectedPaletteRowIndex = -1;
-                    _vm.NReadStartAddress = 0;
-                    _vm.NReadCount = 0;
-                    _vm.PaletteR = 0;
-                    _vm.PaletteG = 0;
-                    _vm.PaletteB = 0;
-                    _vm.PaletteGba = 0;
+                    // Reset the right-hand detail panel - including the
+                    // main entry fields (PaletteDataPointer / AnimInterval
+                    // / DataCount / StartPaletteIndex / Unknown7) - so a
+                    // broken PLIST doesn't display the previously-selected
+                    // entry's data (Copilot bot review on PR #535).
+                    ClearDetailPanel();
                     UpdateUI();
                     return;
                 }

--- a/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml.cs
@@ -1,15 +1,32 @@
 using System;
+using System.Collections.Generic;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
+using global::Avalonia.Media;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
+    /// <summary>
+    /// Avalonia counterpart of WinForms <c>MapTileAnimation2Form</c>.
+    /// Gap-sweep fix (#426) raises the AXAML control surface from 14 to
+    /// MEDIUM-verdict density (&gt;=30 of WF's 40 controls), wires the
+    /// read-config / filter / selection-bar / palette sub-list /
+    /// bulk-export rows, and switches the palette pointer field to
+    /// <c>P0</c> (pointer-aware) so writes round-trip through
+    /// <c>rom.write_p32</c>. Real Bulk Import / Bulk Export / List
+    /// Expansion remain WF-coupled until the Core extraction follow-up
+    /// (#524) lands; those buttons render but are <c>IsEnabled=False</c>
+    /// with a tooltip referencing the follow-up.
+    /// </summary>
     public partial class MapTileAnimation2View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly MapTileAnimation2ViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _suppressRgbChange;
+        bool _suppressFilterChange;
+        bool _suppressNListChange;
 
         public string ViewTitle => "Map Tile Animation Type 2 (Palette)";
         public bool IsLoaded => _vm.IsLoaded;
@@ -27,14 +44,68 @@ namespace FEBuilderGBA.Avalonia.Views
             _vm.IsLoading = true;
             try
             {
-                var items = _vm.LoadList();
-                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ColorSwatchLoader(items, i));
+                // Populate the filter combo with the PLIST list mirroring WF
+                // MakeTileAnimation2.
+                var plistRows = _vm.LoadPlistList();
+                _suppressFilterChange = true;
+                try
+                {
+                    FilterComboBox.ItemsSource = MakeFilterItems(plistRows);
+                    FilterComboBox.SelectedIndex = plistRows.Count > 0 ? 0 : -1;
+                }
+                finally { _suppressFilterChange = false; }
+
+                // Drive list population from the selected PLIST.
+                if (plistRows.Count > 0)
+                {
+                    SelectPlist(plistRows[0]);
+                }
             }
             catch (Exception ex)
             {
                 Log.Error("MapTileAnimation2View.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
+        }
+
+        void ReloadList_Click(object? sender, RoutedEventArgs e) => LoadList();
+
+        static List<string> MakeFilterItems(List<MapTileAnimation2Core.PlistRow> rows)
+        {
+            var items = new List<string>(rows.Count);
+            foreach (var row in rows)
+            {
+                items.Add(row.display);
+            }
+            return items;
+        }
+
+        void FilterCombo_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressFilterChange) return;
+            int idx = FilterComboBox.SelectedIndex;
+            if (idx < 0 || idx >= _vm.PlistRows.Count) return;
+            SelectPlist(_vm.PlistRows[idx]);
+        }
+
+        void SelectPlist(MapTileAnimation2Core.PlistRow row)
+        {
+            _vm.SelectedPlist = row.plist;
+            if (row.isBroken)
+            {
+                EntryList.SetItemsWithIcons(new List<AddrResult>(), _ => null);
+                ReadStartAddressBox.Value = 0;
+                ReadCountBox.Value = 0;
+                return;
+            }
+            var items = _vm.BuildList(row.addr);
+            // ColorSwatchLoader renders a small palette swatch beside each
+            // entry, mirroring WF ListBoxEx.DrawColorAndText. The
+            // existing ListIconWiringTests.View_UsesColorSwatchLoader test
+            // asserts this wiring stays in place.
+            EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ColorSwatchLoader(items, i));
+            ReadStartAddressBox.Value = _vm.ReadStartAddress;
+            ReadCountBox.Value = _vm.ReadCount;
         }
 
         void OnSelected(uint addr)
@@ -55,16 +126,94 @@ namespace FEBuilderGBA.Avalonia.Views
         void UpdateUI()
         {
             AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            AddressBox.Value = _vm.CurrentAddr;
+            SelectedAddressLabel.Content = string.Format("0x{0:X08}", _vm.CurrentAddr);
             PaletteDataPointerBox.Text = string.Format("0x{0:X08}", _vm.PaletteDataPointer);
             AnimIntervalBox.Value = _vm.AnimInterval;
             DataCountBox.Value = _vm.DataCount;
             StartPaletteIndexBox.Value = _vm.StartPaletteIndex;
             Unknown7Box.Value = _vm.Unknown7;
+            NAddressBox.Value = _vm.NReadStartAddress;
+            NBlockSizeBox.Value = _vm.NBlockSize;
+
+            UpdatePaletteSubList();
+        }
+
+        void UpdatePaletteSubList()
+        {
+            _suppressNListChange = true;
+            try
+            {
+                var items = new List<string>(_vm.PaletteRows.Count);
+                foreach (var row in _vm.PaletteRows)
+                {
+                    items.Add(string.Format("0x{0:X2}  GBA=0x{1:X4}  R={2:X2} G={3:X2} B={4:X2}",
+                        row.index, row.gba, row.r, row.g, row.b));
+                }
+                NPaletteListBox.ItemsSource = items;
+                int idx = _vm.SelectedPaletteRowIndex;
+                NPaletteListBox.SelectedIndex = idx >= 0 && idx < items.Count ? idx : -1;
+            }
+            finally { _suppressNListChange = false; }
+
+            if (_vm.SelectedPaletteRowIndex >= 0 && _vm.SelectedPaletteRowIndex < _vm.PaletteRows.Count)
+            {
+                NSelectedAddressLabel.Content = string.Format("0x{0:X08}",
+                    _vm.NReadStartAddress + 2 * _vm.SelectedPaletteRowIndex);
+            }
+            else
+            {
+                NSelectedAddressLabel.Content = "";
+            }
+
+            SyncRgbFromVm();
+        }
+
+        void SyncRgbFromVm()
+        {
+            _suppressRgbChange = true;
+            try
+            {
+                NRBox.Value = _vm.PaletteR;
+                NGBox.Value = _vm.PaletteG;
+                NBBox.Value = _vm.PaletteB;
+                NGbaBox.Value = _vm.PaletteGba;
+            }
+            finally { _suppressRgbChange = false; }
+            ColorPreview.Background = new SolidColorBrush(Color.FromRgb(
+                (byte)_vm.PaletteR, (byte)_vm.PaletteG, (byte)_vm.PaletteB));
+        }
+
+        void NPaletteList_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressNListChange) return;
+            int idx = NPaletteListBox.SelectedIndex;
+            if (idx < 0 || idx >= _vm.PaletteRows.Count) return;
+            _vm.LoadPaletteRow(idx);
+            NSelectedAddressLabel.Content = string.Format("0x{0:X08}",
+                _vm.NReadStartAddress + 2 * idx);
+            SyncRgbFromVm();
+        }
+
+        void NRgb_ValueChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            if (_suppressRgbChange) return;
+            _vm.PaletteR = (uint)(NRBox.Value ?? 0);
+            _vm.PaletteG = (uint)(NGBox.Value ?? 0);
+            _vm.PaletteB = (uint)(NBBox.Value ?? 0);
+            _vm.RecomputeGbaColor();
+            _suppressRgbChange = true;
+            try { NGbaBox.Value = _vm.PaletteGba; }
+            finally { _suppressRgbChange = false; }
+            ColorPreview.Background = new SolidColorBrush(Color.FromRgb(
+                (byte)_vm.PaletteR, (byte)_vm.PaletteG, (byte)_vm.PaletteB));
         }
 
         void Write_Click(object? sender, RoutedEventArgs e)
         {
-            if (!_vm.IsLoaded) return;
+            // Early-guard so we don't create no-op undo entries when the VM
+            // hasn't loaded an entry yet (matches the #506 pattern).
+            if (!_vm.IsLoaded || _vm.CurrentAddr == 0) return;
             _undoService.Begin("Edit Tile Animation Type 2");
             try
             {
@@ -79,6 +228,52 @@ namespace FEBuilderGBA.Avalonia.Views
                 CoreState.Services?.ShowInfo("Tile Animation Type 2 data written.");
             }
             catch (Exception ex) { _undoService.Rollback(); Log.Error("MapTileAnimation2View.Write: {0}", ex.Message); }
+        }
+
+        void NWrite_Click(object? sender, RoutedEventArgs e)
+        {
+            // Early-guard mirrors Write_Click so we don't push empty undo
+            // entries when no palette row is selected.
+            if (!_vm.IsLoaded || _vm.CurrentAddr == 0) return;
+            if (_vm.SelectedPaletteRowIndex < 0) return;
+            _undoService.Begin("Edit Palette Row");
+            try
+            {
+                _vm.PaletteR = (uint)(NRBox.Value ?? 0);
+                _vm.PaletteG = (uint)(NGBox.Value ?? 0);
+                _vm.PaletteB = (uint)(NBBox.Value ?? 0);
+                if (!_vm.WritePaletteRow())
+                {
+                    _undoService.Rollback();
+                    return;
+                }
+                _undoService.Commit();
+                _vm.MarkClean();
+                UpdatePaletteSubList();
+                CoreState.Services?.ShowInfo("Palette row written.");
+            }
+            catch (Exception ex) { _undoService.Rollback(); Log.Error("MapTileAnimation2View.NWrite: {0}", ex.Message); }
+        }
+
+        // Deferred affordances - logged no-ops until follow-up #524 lands.
+        void ListExpand_Click(object? sender, RoutedEventArgs e)
+        {
+            Log.Debug("MapTileAnimation2View.ListExpand_Click invoked - disabled until #524 lands");
+        }
+
+        void NListExpand_Click(object? sender, RoutedEventArgs e)
+        {
+            Log.Debug("MapTileAnimation2View.NListExpand_Click invoked - disabled until #524 lands");
+        }
+
+        void BulkImport_Click(object? sender, RoutedEventArgs e)
+        {
+            Log.Debug("MapTileAnimation2View.BulkImport_Click invoked - disabled until #524 lands");
+        }
+
+        void BulkExport_Click(object? sender, RoutedEventArgs e)
+        {
+            Log.Debug("MapTileAnimation2View.BulkExport_Click invoked - disabled until #524 lands");
         }
 
         static uint ParseHexText(string? text)

--- a/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml.cs
@@ -28,6 +28,8 @@ namespace FEBuilderGBA.Avalonia.Views
         bool _suppressFilterChange;
         bool _suppressNListChange;
 
+        // Window title shown in the editor dock (matches the AXAML Title
+        // attribute so screenshot / UIAutomation tools can locate the view).
         public string ViewTitle => "Map Tile Animation Type 2 (Palette)";
         public bool IsLoaded => _vm.IsLoaded;
         public ViewModelBase? DataViewModel => _vm;

--- a/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml.cs
@@ -214,6 +214,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // Early-guard so we don't create no-op undo entries when the VM
             // hasn't loaded an entry yet (matches the #506 pattern).
             if (!_vm.IsLoaded || _vm.CurrentAddr == 0) return;
+            uint reloadAddr = _vm.CurrentAddr;
             _undoService.Begin("Edit Tile Animation Type 2");
             try
             {
@@ -225,6 +226,18 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.Write();
                 _undoService.Commit();
                 _vm.MarkClean();
+                // Reload the entry so the palette sub-list, N-address bar
+                // (NReadStartAddress / NReadCount), color preview, and
+                // SelectedAddress label all reflect the new
+                // PaletteDataPointer / DataCount instead of the stale
+                // pre-write state (Copilot CLI inline review on PR #534).
+                _vm.IsLoading = true;
+                try
+                {
+                    _vm.LoadEntry(reloadAddr);
+                    UpdateUI();
+                }
+                finally { _vm.IsLoading = false; _vm.MarkClean(); }
                 CoreState.Services?.ShowInfo("Tile Animation Type 2 data written.");
             }
             catch (Exception ex) { _undoService.Rollback(); Log.Error("MapTileAnimation2View.Write: {0}", ex.Message); }

--- a/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml.cs
@@ -77,7 +77,11 @@ namespace FEBuilderGBA.Avalonia.Views
             var items = new List<string>(rows.Count);
             foreach (var row in rows)
             {
-                items.Add(row.display);
+                // Display strings are constructed in MapTileAnimation2Core
+                // via string.Format so they could be localized in a future
+                // pass; for now they ship in English (the AXAML literal is
+                // covered by the L10n scanner via the en.txt reverse map).
+                items.Add(row.Display);
             }
             return items;
         }
@@ -92,22 +96,45 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void SelectPlist(MapTileAnimation2Core.PlistRow row)
         {
-            _vm.SelectedPlist = row.plist;
-            if (row.isBroken)
+            // Filter selection is a navigation event, NOT a user edit.
+            // Suppress dirty marking via _vm.IsLoading so changing the
+            // filter combo does not mark the editor as dirty (Copilot CLI
+            // inline review on PR #534).
+            _vm.IsLoading = true;
+            try
             {
-                EntryList.SetItemsWithIcons(new List<AddrResult>(), _ => null);
-                ReadStartAddressBox.Value = 0;
-                ReadCountBox.Value = 0;
-                return;
+                _vm.SelectedPlist = row.Plist;
+                if (row.IsBroken)
+                {
+                    EntryList.SetItemsWithIcons(new List<AddrResult>(), _ => null);
+                    ReadStartAddressBox.Value = 0;
+                    ReadCountBox.Value = 0;
+                    // Reset the right-hand detail panel so a broken PLIST
+                    // doesn't display the previously-selected entry's data
+                    // (Copilot CLI inline review on PR #534).
+                    _vm.IsLoaded = false;
+                    _vm.CurrentAddr = 0;
+                    _vm.PaletteRows = new List<MapTileAnimation2Core.PaletteRow>();
+                    _vm.SelectedPaletteRowIndex = -1;
+                    _vm.NReadStartAddress = 0;
+                    _vm.NReadCount = 0;
+                    _vm.PaletteR = 0;
+                    _vm.PaletteG = 0;
+                    _vm.PaletteB = 0;
+                    _vm.PaletteGba = 0;
+                    UpdateUI();
+                    return;
+                }
+                var items = _vm.BuildList(row.Addr);
+                // ColorSwatchLoader renders a small palette swatch beside
+                // each entry, mirroring WF ListBoxEx.DrawColorAndText. The
+                // existing ListIconWiringTests.View_UsesColorSwatchLoader
+                // test asserts this wiring stays in place.
+                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ColorSwatchLoader(items, i));
+                ReadStartAddressBox.Value = _vm.ReadStartAddress;
+                ReadCountBox.Value = _vm.ReadCount;
             }
-            var items = _vm.BuildList(row.addr);
-            // ColorSwatchLoader renders a small palette swatch beside each
-            // entry, mirroring WF ListBoxEx.DrawColorAndText. The
-            // existing ListIconWiringTests.View_UsesColorSwatchLoader test
-            // asserts this wiring stays in place.
-            EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ColorSwatchLoader(items, i));
-            ReadStartAddressBox.Value = _vm.ReadStartAddress;
-            ReadCountBox.Value = _vm.ReadCount;
+            finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
 
         void OnSelected(uint addr)
@@ -150,7 +177,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 foreach (var row in _vm.PaletteRows)
                 {
                     items.Add(string.Format("0x{0:X2}  GBA=0x{1:X4}  R={2:X2} G={3:X2} B={4:X2}",
-                        row.index, row.gba, row.r, row.g, row.b));
+                        row.Index, row.Gba, row.R, row.G, row.B));
                 }
                 NPaletteListBox.ItemsSource = items;
                 int idx = _vm.SelectedPaletteRowIndex;

--- a/FEBuilderGBA.Core.Tests/MapTileAnimation2CoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/MapTileAnimation2CoreTests.cs
@@ -88,9 +88,9 @@ namespace FEBuilderGBA.Core.Tests
 
             var entries = MapTileAnimation2Core.ScanEntries(rom, baseAddr, 256);
             Assert.Equal(3, entries.Count);
-            Assert.Equal(0x08800000u, entries[0].p0);
-            Assert.Equal(0x10u, entries[0].wait);
-            Assert.Equal(0x04u, entries[0].count);
+            Assert.Equal(0x08800000u, entries[0].P0);
+            Assert.Equal(0x10u, entries[0].Wait);
+            Assert.Equal(0x04u, entries[0].Count);
         }
 
         [Fact]
@@ -142,8 +142,9 @@ namespace FEBuilderGBA.Core.Tests
             // Build a single map setting with anime2_plist == 0 - it must not
             // appear in the result.
             var rom = MakeSyntheticFE8URom(out uint mapBase, out uint plistTableBase, out uint mapPtrBase);
+            int mapBaseI = (int)mapBase;
             // map[0]: anime2_plist == 0
-            rom.Data[mapBase + 10] = 0;
+            rom.Data[mapBaseI + 10] = 0;
             // Plant the rest of the map fields so MapSettingCore validates it
             // and stops enumeration cleanly. Setting D0 to a pointer is the
             // shortcut WinForms uses; subsequent map entries will then fail
@@ -160,16 +161,17 @@ namespace FEBuilderGBA.Core.Tests
             // Build two map settings BOTH pointing at anime2_plist == 1 - only
             // one row must appear.
             var rom = MakeSyntheticFE8URom(out uint mapBase, out uint plistTableBase, out uint mapPtrBase);
-            uint dataSize = rom.RomInfo.map_setting_datasize;
+            int mapBaseI = (int)mapBase;
+            int dataSizeI = (int)rom.RomInfo.map_setting_datasize;
 
             // map[0]: D0=pointer, anime2_plist=1
-            WriteU32(rom.Data, (int)mapBase + 0, 0x08800000u);
-            rom.Data[mapBase + 10] = 1;
+            WriteU32(rom.Data, mapBaseI + 0, 0x08800000u);
+            rom.Data[mapBaseI + 10] = 1;
             // map[1]: D0=pointer, anime2_plist=1 (duplicate)
-            WriteU32(rom.Data, (int)mapBase + (int)dataSize + 0, 0x08800100u);
-            rom.Data[mapBase + dataSize + 10] = 1;
+            WriteU32(rom.Data, mapBaseI + dataSizeI + 0, 0x08800100u);
+            rom.Data[mapBaseI + dataSizeI + 10] = 1;
             // map[2]: D0=0 (non-pointer) terminator that fails validation
-            WriteU32(rom.Data, (int)mapBase + (int)(2 * dataSize) + 0, 0u);
+            WriteU32(rom.Data, mapBaseI + 2 * dataSizeI + 0, 0u);
 
             // PLIST table entry for plist=1 -> a valid data block.
             uint plist1Slot = plistTableBase + 1 * 4;
@@ -184,8 +186,8 @@ namespace FEBuilderGBA.Core.Tests
 
             var rows = MapTileAnimation2Core.BuildPlistList(rom);
             Assert.Single(rows);
-            Assert.Equal(1u, rows[0].plist);
-            Assert.False(rows[0].isBroken);
+            Assert.Equal(1u, rows[0].Plist);
+            Assert.False(rows[0].IsBroken);
         }
 
         [Fact]
@@ -194,13 +196,14 @@ namespace FEBuilderGBA.Core.Tests
             // PLIST table entry for plist=2 dereferences to ZERO - row is
             // included with isBroken=true.
             var rom = MakeSyntheticFE8URom(out uint mapBase, out uint plistTableBase, out uint mapPtrBase);
-            uint dataSize = rom.RomInfo.map_setting_datasize;
+            int mapBaseI = (int)mapBase;
+            int dataSizeI = (int)rom.RomInfo.map_setting_datasize;
 
             // map[0]: D0=pointer, anime2_plist=2
-            WriteU32(rom.Data, (int)mapBase + 0, 0x08800000u);
-            rom.Data[mapBase + 10] = 2;
+            WriteU32(rom.Data, mapBaseI + 0, 0x08800000u);
+            rom.Data[mapBaseI + 10] = 2;
             // map[1]: terminator
-            WriteU32(rom.Data, (int)mapBase + (int)dataSize + 0, 0u);
+            WriteU32(rom.Data, mapBaseI + dataSizeI + 0, 0u);
 
             // PLIST table entry for plist=2 -> zero pointer (broken).
             uint plist2Slot = plistTableBase + 2 * 4;
@@ -208,9 +211,9 @@ namespace FEBuilderGBA.Core.Tests
 
             var rows = MapTileAnimation2Core.BuildPlistList(rom);
             Assert.Single(rows);
-            Assert.Equal(2u, rows[0].plist);
-            Assert.True(rows[0].isBroken);
-            Assert.Contains("broken", rows[0].display);
+            Assert.Equal(2u, rows[0].Plist);
+            Assert.True(rows[0].IsBroken);
+            Assert.Contains("broken", rows[0].Display);
         }
 
         // -----------------------------------------------------------------
@@ -236,15 +239,15 @@ namespace FEBuilderGBA.Core.Tests
             var rows = MapTileAnimation2Core.BuildPaletteList(rom, dataPointer, count: 3);
 
             Assert.Equal(3, rows.Count);
-            Assert.Equal((byte)0xF8, rows[0].r);
-            Assert.Equal((byte)0xF8, rows[0].g);
-            Assert.Equal((byte)0xF8, rows[0].b);
-            Assert.Equal((byte)0xF8, rows[1].r);
-            Assert.Equal((byte)0x00, rows[1].g);
-            Assert.Equal((byte)0x00, rows[1].b);
-            Assert.Equal((byte)0x00, rows[2].r);
-            Assert.Equal((byte)0x00, rows[2].g);
-            Assert.Equal((byte)0xF8, rows[2].b);
+            Assert.Equal((byte)0xF8, rows[0].R);
+            Assert.Equal((byte)0xF8, rows[0].G);
+            Assert.Equal((byte)0xF8, rows[0].B);
+            Assert.Equal((byte)0xF8, rows[1].R);
+            Assert.Equal((byte)0x00, rows[1].G);
+            Assert.Equal((byte)0x00, rows[1].B);
+            Assert.Equal((byte)0x00, rows[2].R);
+            Assert.Equal((byte)0x00, rows[2].G);
+            Assert.Equal((byte)0xF8, rows[2].B);
         }
 
         [Fact]

--- a/FEBuilderGBA.Core.Tests/MapTileAnimation2CoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/MapTileAnimation2CoreTests.cs
@@ -213,7 +213,14 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Single(rows);
             Assert.Equal(2u, rows[0].Plist);
             Assert.True(rows[0].IsBroken);
-            Assert.Contains("broken", rows[0].Display);
+            // Display is composed via R._() with the WF Japanese key
+            // "タイルアニメーション2 パレットアニメ:{0}" plus "(破損)". When the
+            // test runs headlessly without a translation table loaded,
+            // R._() returns the JP source string. Assert the broken
+            // suffix (open paren) is present rather than relying on
+            // a specific language form.
+            Assert.True(rows[0].Display.Contains("(") || rows[0].Display.Contains("破損"),
+                $"Display should contain WF broken suffix: '{rows[0].Display}'");
         }
 
         // -----------------------------------------------------------------

--- a/FEBuilderGBA.Core.Tests/MapTileAnimation2CoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/MapTileAnimation2CoreTests.cs
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Phase 1 gap-sweep tests for MapTileAnimation2Core (#426).
+//
+// Headless mirror of WinForms MapTileAnimation2Form's static helpers
+// (MakeTileAnimation2, ExportAll/ImportAll palette enumeration) so the
+// Avalonia view can drive list population, palette decoding, and round-trip
+// validation without WinForms dependencies.
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// Tests proving MapTileAnimation2Core mirrors the WF MakeTileAnimation2 /
+    /// per-PLIST scan / RGB-to-GBA conversion semantics. Mutates CoreState.ROM
+    /// in several cases (Avalonia view path) and direct ROM in others.
+    /// </summary>
+    [Collection("SharedState")]
+    public class MapTileAnimation2CoreTests
+    {
+        // -----------------------------------------------------------------
+        // GbaToRgb / RgbToGba round-trip
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void RgbToGba_Encodes15BitColor()
+        {
+            // R=0xF8 (top 5 bits), G=0x10 (top 5 bits = 2), B=0x80 (top 5 bits = 16)
+            // Expected: r5=31 (0x1F), g5=2 (0x02), b5=16 (0x10)
+            // GBA layout: bbbbbgggggrrrrr -> (16 << 10) | (2 << 5) | 31
+            //          = 0x4000 | 0x0040 | 0x001F = 0x405F
+            ushort encoded = MapTileAnimation2Core.RgbToGba(0xF8, 0x10, 0x80);
+            Assert.Equal((ushort)0x405F, encoded);
+        }
+
+        [Fact]
+        public void GbaToRgb_Decodes15BitColor()
+        {
+            // From the previous round: 0x405F -> r5=31, g5=2, b5=16
+            // Decoded with 3-bit shift: r=248, g=16, b=128
+            var (r, g, b) = MapTileAnimation2Core.GbaToRgb(0x405F);
+            Assert.Equal((byte)0xF8, r);
+            Assert.Equal((byte)0x10, g);
+            Assert.Equal((byte)0x80, b);
+        }
+
+        [Fact]
+        public void RgbToGba_GbaToRgb_RoundTrips_AcrossKnownColors()
+        {
+            // Truncate-to-3 round-trip: (r,g,b) where each is already a multiple of 8.
+            byte[] testValues = { 0, 8, 0x40, 0x80, 0xF8 };
+            foreach (byte r in testValues)
+                foreach (byte g in testValues)
+                    foreach (byte b in testValues)
+                    {
+                        ushort gba = MapTileAnimation2Core.RgbToGba(r, g, b);
+                        var (rb, gb, bb) = MapTileAnimation2Core.GbaToRgb(gba);
+                        Assert.Equal(r, rb);
+                        Assert.Equal(g, gb);
+                        Assert.Equal(b, bb);
+                    }
+        }
+
+        // -----------------------------------------------------------------
+        // ScanEntries - stops at first non-pointer P0 (mirrors WF
+        // InputFormRef predicate: isPointer(u32(addr+0)))
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void ScanEntries_StopsAtFirstNonPointer()
+        {
+            var rom = new ROM();
+            rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+
+            // Plant 3 valid 8-byte entries at base 0x200, then a zero P0 at row 3.
+            uint baseAddr = 0x200;
+            for (int i = 0; i < 3; i++)
+            {
+                uint addr = baseAddr + (uint)(i * 8);
+                WriteU32(rom.Data, (int)addr, 0x08800000u + (uint)(i * 0x100)); // valid GBA pointer
+                rom.Data[(int)addr + 4] = 0x10; // wait
+                rom.Data[(int)addr + 5] = 0x04; // count
+                rom.Data[(int)addr + 6] = 0x00; // startindex
+                rom.Data[(int)addr + 7] = 0x00; // padding
+            }
+            // Row 3: zero P0 - scan should stop here.
+            WriteU32(rom.Data, (int)(baseAddr + 3 * 8), 0u);
+
+            var entries = MapTileAnimation2Core.ScanEntries(rom, baseAddr, 256);
+            Assert.Equal(3, entries.Count);
+            Assert.Equal(0x08800000u, entries[0].p0);
+            Assert.Equal(0x10u, entries[0].wait);
+            Assert.Equal(0x04u, entries[0].count);
+        }
+
+        [Fact]
+        public void ScanEntries_HonorsMaxRows()
+        {
+            var rom = new ROM();
+            rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+
+            // Plant 10 valid entries.
+            uint baseAddr = 0x200;
+            for (int i = 0; i < 10; i++)
+            {
+                uint addr = baseAddr + (uint)(i * 8);
+                WriteU32(rom.Data, (int)addr, 0x08800000u + (uint)(i * 0x100));
+            }
+            var entries = MapTileAnimation2Core.ScanEntries(rom, baseAddr, maxRows: 4);
+            Assert.Equal(4, entries.Count);
+        }
+
+        // -----------------------------------------------------------------
+        // BuildPlistList - mirrors WF MakeTileAnimation2 semantics
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void BuildPlistList_WithNullRom_ReturnsEmpty()
+        {
+            var rows = MapTileAnimation2Core.BuildPlistList(null);
+            Assert.NotNull(rows);
+            Assert.Empty(rows);
+        }
+
+        [Fact]
+        public void BuildPlistList_WithZeroPointer_ReturnsEmpty()
+        {
+            // ROM where map_tileanime2_pointer dereferences to zero.
+            var rom = new ROM();
+            rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+            // Leave map_tileanime2_pointer area pointing to zero.
+            WriteU32(rom.Data, (int)rom.RomInfo.map_tileanime2_pointer, 0u);
+
+            var rows = MapTileAnimation2Core.BuildPlistList(rom);
+            Assert.NotNull(rows);
+            Assert.Empty(rows);
+        }
+
+        [Fact]
+        public void BuildPlistList_OmitsZeroAnime2Plist()
+        {
+            // Build a single map setting with anime2_plist == 0 - it must not
+            // appear in the result.
+            var rom = MakeSyntheticFE8URom(out uint mapBase, out uint plistTableBase, out uint mapPtrBase);
+            // map[0]: anime2_plist == 0
+            rom.Data[mapBase + 10] = 0;
+            // Plant the rest of the map fields so MapSettingCore validates it
+            // and stops enumeration cleanly. Setting D0 to a pointer is the
+            // shortcut WinForms uses; subsequent map entries will then fail
+            // validation and stop the loop.
+            WriteU32(rom.Data, (int)mapBase + 0, 0x08800000u); // D0=pointer => valid
+
+            var rows = MapTileAnimation2Core.BuildPlistList(rom);
+            Assert.Empty(rows);
+        }
+
+        [Fact]
+        public void BuildPlistList_DedupesDuplicateMapReferences()
+        {
+            // Build two map settings BOTH pointing at anime2_plist == 1 - only
+            // one row must appear.
+            var rom = MakeSyntheticFE8URom(out uint mapBase, out uint plistTableBase, out uint mapPtrBase);
+            uint dataSize = rom.RomInfo.map_setting_datasize;
+
+            // map[0]: D0=pointer, anime2_plist=1
+            WriteU32(rom.Data, (int)mapBase + 0, 0x08800000u);
+            rom.Data[mapBase + 10] = 1;
+            // map[1]: D0=pointer, anime2_plist=1 (duplicate)
+            WriteU32(rom.Data, (int)mapBase + (int)dataSize + 0, 0x08800100u);
+            rom.Data[mapBase + dataSize + 10] = 1;
+            // map[2]: D0=0 (non-pointer) terminator that fails validation
+            WriteU32(rom.Data, (int)mapBase + (int)(2 * dataSize) + 0, 0u);
+
+            // PLIST table entry for plist=1 -> a valid data block.
+            uint plist1Slot = plistTableBase + 1 * 4;
+            uint plist1DataPtr = 0x08900000u;
+            WriteU32(rom.Data, (int)plist1Slot, plist1DataPtr);
+            // Plant a valid 8-byte entry at offset 0x900000 so the data block
+            // dereferences cleanly. (The dedupe check happens BEFORE the
+            // address-resolution check, so even a missing block would still
+            // dedupe; this just makes the row not flagged broken.)
+            uint dataBlockOffset = 0x900000;
+            WriteU32(rom.Data, (int)dataBlockOffset + 0, 0x08A00000u);
+
+            var rows = MapTileAnimation2Core.BuildPlistList(rom);
+            Assert.Single(rows);
+            Assert.Equal(1u, rows[0].plist);
+            Assert.False(rows[0].isBroken);
+        }
+
+        [Fact]
+        public void BuildPlistList_MarksBrokenPlistAddress()
+        {
+            // PLIST table entry for plist=2 dereferences to ZERO - row is
+            // included with isBroken=true.
+            var rom = MakeSyntheticFE8URom(out uint mapBase, out uint plistTableBase, out uint mapPtrBase);
+            uint dataSize = rom.RomInfo.map_setting_datasize;
+
+            // map[0]: D0=pointer, anime2_plist=2
+            WriteU32(rom.Data, (int)mapBase + 0, 0x08800000u);
+            rom.Data[mapBase + 10] = 2;
+            // map[1]: terminator
+            WriteU32(rom.Data, (int)mapBase + (int)dataSize + 0, 0u);
+
+            // PLIST table entry for plist=2 -> zero pointer (broken).
+            uint plist2Slot = plistTableBase + 2 * 4;
+            WriteU32(rom.Data, (int)plist2Slot, 0u);
+
+            var rows = MapTileAnimation2Core.BuildPlistList(rom);
+            Assert.Single(rows);
+            Assert.Equal(2u, rows[0].plist);
+            Assert.True(rows[0].isBroken);
+            Assert.Contains("broken", rows[0].display);
+        }
+
+        // -----------------------------------------------------------------
+        // BuildPaletteList - decodes per-row RGB
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void BuildPaletteList_ConvertsRgb555Rows()
+        {
+            // Plant 3 u16 GBA colors at 0x800000 and check decoded RGB tuples.
+            var rom = new ROM();
+            rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+            uint dataOffset = 0x800000;
+
+            // Row 0: white (0x7FFF -> 248, 248, 248)
+            WriteU16(rom.Data, (int)dataOffset + 0, 0x7FFF);
+            // Row 1: red (0x001F -> 248, 0, 0)
+            WriteU16(rom.Data, (int)dataOffset + 2, 0x001F);
+            // Row 2: blue (0x7C00 -> 0, 0, 248)
+            WriteU16(rom.Data, (int)dataOffset + 4, 0x7C00);
+
+            uint dataPointer = 0x08000000u | dataOffset;
+            var rows = MapTileAnimation2Core.BuildPaletteList(rom, dataPointer, count: 3);
+
+            Assert.Equal(3, rows.Count);
+            Assert.Equal((byte)0xF8, rows[0].r);
+            Assert.Equal((byte)0xF8, rows[0].g);
+            Assert.Equal((byte)0xF8, rows[0].b);
+            Assert.Equal((byte)0xF8, rows[1].r);
+            Assert.Equal((byte)0x00, rows[1].g);
+            Assert.Equal((byte)0x00, rows[1].b);
+            Assert.Equal((byte)0x00, rows[2].r);
+            Assert.Equal((byte)0x00, rows[2].g);
+            Assert.Equal((byte)0xF8, rows[2].b);
+        }
+
+        [Fact]
+        public void BuildPaletteList_WithUnsafePointer_ReturnsEmpty()
+        {
+            var rom = new ROM();
+            rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+            var rows = MapTileAnimation2Core.BuildPaletteList(rom, dataPointer: 0u, count: 4);
+            Assert.Empty(rows);
+        }
+
+        // -----------------------------------------------------------------
+        // Helpers
+        // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Build a tiny synthetic FE8U ROM. Sets the map_setting_pointer to
+        /// 0x08800000 (so map_setting data starts at 0x800000) and the
+        /// map_tileanime2_pointer to dereference to a PLIST table at
+        /// 0x900000. Returns the map-data base offset, the PLIST table base
+        /// offset, and the raw mapPtrBase address.
+        /// </summary>
+        static ROM MakeSyntheticFE8URom(out uint mapBase, out uint plistTableBase, out uint mapPtrBase)
+        {
+            var rom = new ROM();
+            rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+
+            mapPtrBase = rom.RomInfo.map_setting_pointer;
+            mapBase = 0x800000;
+            plistTableBase = 0x900000;
+
+            // Plant: map_setting_pointer -> 0x08800000 (mapBase + 0x08000000)
+            WriteU32(rom.Data, (int)mapPtrBase, 0x08000000u | mapBase);
+            // Plant: map_tileanime2_pointer -> 0x08900000 (plistTableBase + 0x08000000)
+            WriteU32(rom.Data, (int)rom.RomInfo.map_tileanime2_pointer, 0x08000000u | plistTableBase);
+
+            return rom;
+        }
+
+        static void WriteU32(byte[] data, int offset, uint value)
+        {
+            data[offset + 0] = (byte)(value & 0xFF);
+            data[offset + 1] = (byte)((value >> 8) & 0xFF);
+            data[offset + 2] = (byte)((value >> 16) & 0xFF);
+            data[offset + 3] = (byte)((value >> 24) & 0xFF);
+        }
+
+        static void WriteU16(byte[] data, int offset, ushort value)
+        {
+            data[offset + 0] = (byte)(value & 0xFF);
+            data[offset + 1] = (byte)((value >> 8) & 0xFF);
+        }
+    }
+}

--- a/FEBuilderGBA.Core/MapTileAnimation2Core.cs
+++ b/FEBuilderGBA.Core/MapTileAnimation2Core.cs
@@ -160,13 +160,17 @@ namespace FEBuilderGBA
                 }
                 else
                 {
+                    // WinForms PlistToOffsetAddr (MapPointerForm.cs:425)
+                    // calls rom.p32(slotAddr) which silently strips the
+                    // 0x08000000 high bit. It accepts both GBA-pointer
+                    // form (0x08800000) AND raw ROM offset form
+                    // (0x00800000) - it just runs U.toOffset on whatever
+                    // is stored. Treating non-pointer values as broken
+                    // would incorrectly hide valid PLIST entries whose
+                    // slot stores a raw offset (Copilot bot review on
+                    // PR #535).
                     uint dataPtr = rom.u32(plistSlot);
                     if (dataPtr == 0)
-                    {
-                        dataAddr = U.NOT_FOUND;
-                        broken = true;
-                    }
-                    else if (!U.isPointer(dataPtr))
                     {
                         dataAddr = U.NOT_FOUND;
                         broken = true;
@@ -182,9 +186,16 @@ namespace FEBuilderGBA
                     }
                 }
 
+                // Localize the display label via R._() against the
+                // existing WF translation keys ("タイルアニメーション2
+                // パレットアニメ:{0}" + "(破損)") so the filter combo stays
+                // translatable across ja / zh - matches the WinForms
+                // MapTileAnimation2Form.MakeTileAnimation2 behavior
+                // (Copilot bot review on PR #535).
+                string baseLabel = R._("タイルアニメーション2 パレットアニメ:{0}", U.ToHexString(plist));
                 string display = broken
-                    ? string.Format("Tile Animation 2 Palette: 0x{0:X2} (broken)", plist)
-                    : string.Format("Tile Animation 2 Palette: 0x{0:X2}", plist);
+                    ? baseLabel + R._("(破損)")
+                    : baseLabel;
                 result.Add(new PlistRow(plist, dataAddr, display, broken));
             }
             return result;

--- a/FEBuilderGBA.Core/MapTileAnimation2Core.cs
+++ b/FEBuilderGBA.Core/MapTileAnimation2Core.cs
@@ -24,42 +24,42 @@ namespace FEBuilderGBA
         /// warning glyph instead of duplicating the WF "(broken)" string
         /// suffix.
         /// </summary>
-        /// <param name="plist">The map setting's <c>anime2_plist</c> value.</param>
-        /// <param name="addr">The ROM offset the PLIST resolves to, or
+        /// <param name="Plist">The map setting's <c>anime2_plist</c> value.</param>
+        /// <param name="Addr">The ROM offset the PLIST resolves to, or
         /// <c>U.NOT_FOUND</c> if the PLIST table entry dereferences to zero
-        /// or an unsafe offset (<c>isBroken == true</c>).</param>
-        /// <param name="display">Human-readable label for the row, mirroring
+        /// or an unsafe offset (<c>IsBroken == true</c>).</param>
+        /// <param name="Display">Human-readable label for the row, mirroring
         /// the WF <c>"タイルアニメーション2 パレットアニメ:{plist}"</c> format
         /// (English here: <c>"Tile Animation 2 Palette: 0x{plist:X2}"</c>).</param>
-        /// <param name="isBroken">Set when the row dereferences to an
+        /// <param name="IsBroken">Set when the row dereferences to an
         /// unusable address - the row is kept so the user can repair it.</param>
-        public record PlistRow(uint plist, uint addr, string display, bool isBroken);
+        public record PlistRow(uint Plist, uint Addr, string Display, bool IsBroken);
 
         /// <summary>
         /// One row in the palette sub-list. The WF view shows R/G/B sliders
         /// plus the encoded 15-bit GBA word; this record holds all three so
         /// the headless caller does not need to re-decode.
         /// </summary>
-        /// <param name="index">Row index (0-based).</param>
-        /// <param name="gba">Raw 15-bit GBA color word read from ROM.</param>
-        /// <param name="r">Decoded red channel, top 5 bits left-shifted to 8
+        /// <param name="Index">Row index (0-based).</param>
+        /// <param name="Gba">Raw 15-bit GBA color word read from ROM.</param>
+        /// <param name="R">Decoded red channel, top 5 bits left-shifted to 8
         /// bits (i.e. <c>(gba &amp; 0x1F) &lt;&lt; 3</c>).</param>
-        /// <param name="g">Decoded green channel.</param>
-        /// <param name="b">Decoded blue channel.</param>
-        public record PaletteRow(int index, ushort gba, byte r, byte g, byte b);
+        /// <param name="G">Decoded green channel.</param>
+        /// <param name="B">Decoded blue channel.</param>
+        public record PaletteRow(int Index, ushort Gba, byte R, byte G, byte B);
 
         /// <summary>
         /// One entry in the main animation list (8 bytes per row in WF).
         /// </summary>
-        /// <param name="addr">Absolute ROM offset of the entry.</param>
-        /// <param name="p0">Raw u32 at <c>addr+0</c> (GBA pointer).</param>
-        /// <param name="wait">u8 at <c>addr+4</c> - animation interval.</param>
-        /// <param name="count">u8 at <c>addr+5</c> - data count (number of
+        /// <param name="Addr">Absolute ROM offset of the entry.</param>
+        /// <param name="P0">Raw u32 at <c>addr+0</c> (GBA pointer).</param>
+        /// <param name="Wait">u8 at <c>addr+4</c> - animation interval.</param>
+        /// <param name="Count">u8 at <c>addr+5</c> - data count (number of
         /// palette rows).</param>
-        /// <param name="startindex">u8 at <c>addr+6</c> - start palette
+        /// <param name="StartIndex">u8 at <c>addr+6</c> - start palette
         /// index.</param>
-        /// <param name="padding">u8 at <c>addr+7</c> - opaque.</param>
-        public record EntryRow(uint addr, uint p0, uint wait, uint count, uint startindex, uint padding);
+        /// <param name="Padding">u8 at <c>addr+7</c> - opaque.</param>
+        public record EntryRow(uint Addr, uint P0, uint Wait, uint Count, uint StartIndex, uint Padding);
 
         /// <summary>
         /// Encode an 8-bit RGB triple into the 15-bit GBA color word.
@@ -123,7 +123,7 @@ namespace FEBuilderGBA
         /// <c>anime2_plist</c> at <c>+10</c> (skip zero, dedupe), and resolves
         /// each PLIST through the <c>map_tileanime2_pointer</c> table.
         /// Rows whose PLIST table entry dereferences to zero or to an unsafe
-        /// offset are kept with <see cref="PlistRow.isBroken"/> set to
+        /// offset are kept with <see cref="PlistRow.IsBroken"/> set to
         /// <c>true</c> so the editor can offer a repair affordance.
         /// </summary>
         public static List<PlistRow> BuildPlistList(ROM rom)

--- a/FEBuilderGBA.Core/MapTileAnimation2Core.cs
+++ b/FEBuilderGBA.Core/MapTileAnimation2Core.cs
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Collections.Generic;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Cross-platform helpers for map tile animation type 2 (palette animation),
+    /// extracted from <c>WinForms MapTileAnimation2Form</c> so the Avalonia view
+    /// can drive the editor without WinForms dependencies (gap-sweep #426).
+    ///
+    /// The WF form combines four responsibilities: (a) build the filter list of
+    /// PLISTs referenced by any map setting, (b) iterate the 8-byte entries
+    /// rooted at a PLIST's data pointer, (c) decode the per-row palette bytes
+    /// into RGB, and (d) round-trip RGB through the 15-bit GBA format used by
+    /// the BG palette engine. (a)-(d) all live here; the import/export and
+    /// list-expansion plumbing remains WF-coupled (follow-up #524).
+    /// </summary>
+    public static class MapTileAnimation2Core
+    {
+        /// <summary>
+        /// One row in the filter combo / address list. Matches the WF
+        /// <c>AddrResult(addr, name, tag)</c> tuple but adds the explicit
+        /// <c>isBroken</c> flag so the Avalonia view can render the row with a
+        /// warning glyph instead of duplicating the WF "(broken)" string
+        /// suffix.
+        /// </summary>
+        /// <param name="plist">The map setting's <c>anime2_plist</c> value.</param>
+        /// <param name="addr">The ROM offset the PLIST resolves to, or
+        /// <c>U.NOT_FOUND</c> if the PLIST table entry dereferences to zero
+        /// or an unsafe offset (<c>isBroken == true</c>).</param>
+        /// <param name="display">Human-readable label for the row, mirroring
+        /// the WF <c>"タイルアニメーション2 パレットアニメ:{plist}"</c> format
+        /// (English here: <c>"Tile Animation 2 Palette: 0x{plist:X2}"</c>).</param>
+        /// <param name="isBroken">Set when the row dereferences to an
+        /// unusable address - the row is kept so the user can repair it.</param>
+        public record PlistRow(uint plist, uint addr, string display, bool isBroken);
+
+        /// <summary>
+        /// One row in the palette sub-list. The WF view shows R/G/B sliders
+        /// plus the encoded 15-bit GBA word; this record holds all three so
+        /// the headless caller does not need to re-decode.
+        /// </summary>
+        /// <param name="index">Row index (0-based).</param>
+        /// <param name="gba">Raw 15-bit GBA color word read from ROM.</param>
+        /// <param name="r">Decoded red channel, top 5 bits left-shifted to 8
+        /// bits (i.e. <c>(gba &amp; 0x1F) &lt;&lt; 3</c>).</param>
+        /// <param name="g">Decoded green channel.</param>
+        /// <param name="b">Decoded blue channel.</param>
+        public record PaletteRow(int index, ushort gba, byte r, byte g, byte b);
+
+        /// <summary>
+        /// One entry in the main animation list (8 bytes per row in WF).
+        /// </summary>
+        /// <param name="addr">Absolute ROM offset of the entry.</param>
+        /// <param name="p0">Raw u32 at <c>addr+0</c> (GBA pointer).</param>
+        /// <param name="wait">u8 at <c>addr+4</c> - animation interval.</param>
+        /// <param name="count">u8 at <c>addr+5</c> - data count (number of
+        /// palette rows).</param>
+        /// <param name="startindex">u8 at <c>addr+6</c> - start palette
+        /// index.</param>
+        /// <param name="padding">u8 at <c>addr+7</c> - opaque.</param>
+        public record EntryRow(uint addr, uint p0, uint wait, uint count, uint startindex, uint padding);
+
+        /// <summary>
+        /// Encode an 8-bit RGB triple into the 15-bit GBA color word.
+        /// Top 5 bits of each channel are kept, ordered <c>rrrrr gggggbbbbb</c>
+        /// from LSB. Matches the WF <c>ImageUtil.ColorToGBARGB</c> formula
+        /// <c>(r&gt;&gt;3) | ((g&gt;&gt;3)&lt;&lt;5) | ((b&gt;&gt;3)&lt;&lt;10)</c>.
+        /// </summary>
+        public static ushort RgbToGba(byte r, byte g, byte b)
+        {
+            int r5 = (r >> 3) & 0x1F;
+            int g5 = (g >> 3) & 0x1F;
+            int b5 = (b >> 3) & 0x1F;
+            return (ushort)((b5 << 10) | (g5 << 5) | r5);
+        }
+
+        /// <summary>
+        /// Decode a 15-bit GBA color word into an 8-bit RGB triple.
+        /// Bits 0-4 = red, 5-9 = green, 10-14 = blue. Each channel is
+        /// left-shifted by 3 to fill the high 5 bits of the byte.
+        /// </summary>
+        public static (byte r, byte g, byte b) GbaToRgb(ushort gba)
+        {
+            byte r = (byte)((gba & 0x1F) << 3);
+            byte g = (byte)(((gba >> 5) & 0x1F) << 3);
+            byte b = (byte)(((gba >> 10) & 0x1F) << 3);
+            return (r, g, b);
+        }
+
+        /// <summary>
+        /// Walk the 8-byte entry table rooted at <paramref name="baseAddr"/>
+        /// and return every row whose <c>P0</c> is a valid GBA pointer. Stops
+        /// at the first non-pointer row (mirrors the WF
+        /// <c>InputFormRef</c> termination predicate
+        /// <c>isPointer(u32(addr+0))</c>) or after <paramref name="maxRows"/>
+        /// iterations.
+        /// </summary>
+        public static List<EntryRow> ScanEntries(ROM rom, uint baseAddr, int maxRows = 256)
+        {
+            var result = new List<EntryRow>();
+            if (rom == null) return result;
+            const uint blockSize = 8;
+            for (int i = 0; i < maxRows; i++)
+            {
+                uint addr = baseAddr + (uint)(i * blockSize);
+                if (addr + blockSize > (uint)rom.Data.Length) break;
+                uint p0 = rom.u32(addr + 0);
+                if (!U.isPointer(p0)) break;
+                uint wait = rom.u8(addr + 4);
+                uint count = rom.u8(addr + 5);
+                uint startindex = rom.u8(addr + 6);
+                uint padding = rom.u8(addr + 7);
+                result.Add(new EntryRow(addr, p0, wait, count, startindex, padding));
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Build the filter list shown at the top of the WF editor. Walks
+        /// every valid map setting via
+        /// <see cref="MapSettingCore.MakeMapIDList(ROM)"/>, reads
+        /// <c>anime2_plist</c> at <c>+10</c> (skip zero, dedupe), and resolves
+        /// each PLIST through the <c>map_tileanime2_pointer</c> table.
+        /// Rows whose PLIST table entry dereferences to zero or to an unsafe
+        /// offset are kept with <see cref="PlistRow.isBroken"/> set to
+        /// <c>true</c> so the editor can offer a repair affordance.
+        /// </summary>
+        public static List<PlistRow> BuildPlistList(ROM rom)
+        {
+            var result = new List<PlistRow>();
+            if (rom?.RomInfo == null) return result;
+
+            uint plistTablePtr = rom.RomInfo.map_tileanime2_pointer;
+            if (plistTablePtr == 0) return result;
+            uint plistTableBase = rom.p32(plistTablePtr);
+            if (!U.isSafetyOffset(plistTableBase, rom)) return result;
+
+            var seen = new HashSet<uint>();
+            var maps = MapSettingCore.MakeMapIDList(rom);
+            foreach (var map in maps)
+            {
+                if (map.addr + 11 > (uint)rom.Data.Length) continue;
+                uint plist = rom.u8(map.addr + 10);
+                if (plist == 0) continue;
+                if (!seen.Add(plist)) continue;
+
+                // Resolve the PLIST to a data offset via the WF
+                // PlistToOffsetAddr path: entry slot = plistTableBase + plist*4
+                // and the data offset is the dereferenced u32 (with the high
+                // bit stripped).
+                uint plistSlot = plistTableBase + plist * 4;
+                bool broken = false;
+                uint dataAddr;
+                if (plistSlot + 4 > (uint)rom.Data.Length)
+                {
+                    dataAddr = U.NOT_FOUND;
+                    broken = true;
+                }
+                else
+                {
+                    uint dataPtr = rom.u32(plistSlot);
+                    if (dataPtr == 0)
+                    {
+                        dataAddr = U.NOT_FOUND;
+                        broken = true;
+                    }
+                    else if (!U.isPointer(dataPtr))
+                    {
+                        dataAddr = U.NOT_FOUND;
+                        broken = true;
+                    }
+                    else
+                    {
+                        dataAddr = U.toOffset(dataPtr);
+                        if (!U.isSafetyOffset(dataAddr, rom))
+                        {
+                            dataAddr = U.NOT_FOUND;
+                            broken = true;
+                        }
+                    }
+                }
+
+                string display = broken
+                    ? string.Format("Tile Animation 2 Palette: 0x{0:X2} (broken)", plist)
+                    : string.Format("Tile Animation 2 Palette: 0x{0:X2}", plist);
+                result.Add(new PlistRow(plist, dataAddr, display, broken));
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Decode a palette data block into the per-row R/G/B triples used
+        /// by the Avalonia palette sub-list. Reads <c>2 * count</c> bytes from
+        /// <c>U.toOffset(dataPointer)</c>. Returns an empty list if the
+        /// pointer cannot be resolved to a safe ROM offset.
+        /// </summary>
+        public static List<PaletteRow> BuildPaletteList(ROM rom, uint dataPointer, uint count)
+        {
+            var result = new List<PaletteRow>();
+            if (rom == null) return result;
+            if (dataPointer == 0) return result;
+            uint offset = U.toOffset(dataPointer);
+            if (!U.isSafetyOffset(offset, rom)) return result;
+            for (uint i = 0; i < count; i++)
+            {
+                uint addr = offset + i * 2;
+                if (addr + 2 > (uint)rom.Data.Length) break;
+                ushort gba = (ushort)rom.u16(addr);
+                var (r, g, b) = GbaToRgb(gba);
+                result.Add(new PaletteRow((int)i, gba, r, g, b));
+            }
+            return result;
+        }
+    }
+}

--- a/FEBuilderGBA.Core/MapTileAnimation2Core.cs
+++ b/FEBuilderGBA.Core/MapTileAnimation2Core.cs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Cross-platform helpers for the MapTileAnimation2 editor (#426).
 using System.Collections.Generic;
 
 namespace FEBuilderGBA

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -6896,3 +6896,21 @@ mug_exceed用のタイルをどこに配置するか設定してください:
 
 :05=その場
 05=その場
+
+:Data Expansion
+リストの拡張
+
+:GBA Color
+GBAカラー
+
+:Pending Core extraction - tracked by #524
+Core 抽出待ち - #524 で追跡中
+
+:Map Tile Animation Type 2 Palette Sub-Table
+マップ タイルアニメ タイプ 2 パレット サブテーブル
+
+:Bulk Import
+一括インポート
+
+:Bulk Export
+一括エクスポート

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -20834,3 +20834,21 @@ mug_exceed 图块2 Y:
 
 :6 = Close Eyes
 6 = 闭眼
+
+:Data Expansion
+扩展列表
+
+:GBA Color
+GBA颜色
+
+:Pending Core extraction - tracked by #524
+Core 抽取待中 - 追踪于 #524
+
+:Map Tile Animation Type 2 Palette Sub-Table
+地图图块动画类型2 调色板子表
+
+:Bulk Import
+批量导入
+
+:Bulk Export
+批量导出

--- a/docs/field-completeness-report.txt
+++ b/docs/field-completeness-report.txt
@@ -1,6 +1,6 @@
 === Field Completeness Report ===
 Total WinForms fields: 1563
-Total Avalonia fields: 1720
+Total Avalonia fields: 1721
 Total missing: 0
 Forms with gaps: 0 / 174
 

--- a/docs/field-completeness-report.txt
+++ b/docs/field-completeness-report.txt
@@ -1,6 +1,6 @@
 === Field Completeness Report ===
 Total WinForms fields: 1563
-Total Avalonia fields: 1721
+Total Avalonia fields: 1725
 Total missing: 0
 Forms with gaps: 0 / 174
 


### PR DESCRIPTION
Recreated PR #534 (CI was stuck on the previous one). Plan / scope / screenshots / GUI test report / test plan are identical to the original PR; see https://github.com/laqieer/FEBuilderGBA/pull/534 for the full body content.

Closes #426
Ref #374
Ref #524

Generated with Claude Code (claude-opus-4-7[1m])