### PR TITLE
fix(gap-sweep): EventUnit parity (closes #420)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/EventUnitParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/EventUnitParityTests.cs
@@ -1,0 +1,536 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Phase 1 / Phase 4 / Phase 5 gap-sweep regression tests for
+// EventUnitView (closes #420 via this PR).
+//
+// Covers the 56 gaps the issue called out:
+//   - 50 missing WF-only labels (density / labels)
+//   - 6 missing INavigationTargetSource manifest entries (jumps)
+//
+// The tests assert STABLE, HEADLESS contracts (XAML doc, VM reflection,
+// manifest entries) so CI stays cross-platform.
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using FEBuilderGBA.Avalonia.GapSweep;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests.GapSweep;
+
+[Collection("SharedState")]
+public class EventUnitParityTests
+{
+    // -----------------------------------------------------------------
+    // Density (Phase 1) — AV control count must clear the MEDIUM verdict.
+    //
+    // 2026-05-22 sweep reported WF=95 / AV=54. The MEDIUM threshold is
+    // ceil(0.75 * 95) = 72. After the new view design adds the Top
+    // read-config bar, B3+W4 sub-panels, After-coords display, Address
+    // bar, Comment, jump panel + dialog launcher, and Random Monster
+    // button, the new AV count should be well above 72.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_AvControlCount_AtOrAboveMediumVerdict()
+    {
+        string repoRoot = FindRepoRoot();
+        string axamlPath = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "EventUnitView.axaml");
+        Assert.True(File.Exists(axamlPath), $"AXAML not found at {axamlPath}");
+
+        var doc = XDocument.Load(axamlPath);
+        int avCount = ControlDensityScanner.CountAvControlsInDocument(doc);
+
+        // WF designer count from the 2026-05-22 density sweep — see issue #420.
+        const int WfControlCount = 95;
+        int mediumThreshold = (int)Math.Ceiling(WfControlCount * 0.75); // 72
+        Assert.True(avCount >= mediumThreshold,
+            $"AV control count {avCount} must be >= {mediumThreshold} (75% of WF={WfControlCount}) — got HIGH verdict");
+    }
+
+    // -----------------------------------------------------------------
+    // Navigation manifest (Phase 4) — all six jumps registered.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_DeclaresAllSixJumpTargets()
+    {
+        var vm = new EventUnitViewModel();
+        var targets = vm.GetNavigationTargets();
+
+        Assert.Equal(6, targets.Count);
+        Assert.Contains(targets, t => t.TargetViewType == typeof(EventBattleTalkView));
+        Assert.Contains(targets, t => t.TargetViewType == typeof(SoundBossBGMViewerView));
+        Assert.Contains(targets, t => t.TargetViewType == typeof(EventHaikuView));
+        Assert.Contains(targets, t => t.TargetViewType == typeof(EventUnitNewAllocView));
+        Assert.Contains(targets, t => t.TargetViewType == typeof(EventUnitItemDropView));
+        Assert.Contains(targets, t => t.TargetViewType == typeof(MonsterProbabilityViewerView));
+    }
+
+    [Fact]
+    public void ViewModel_NavigationTargets_AreNotMarkedAsKnownGaps()
+    {
+        // After this PR closes #420, NONE of the six rows should still
+        // carry an IssueRef — the behavior must exist, not be tracked-broken.
+        var vm = new EventUnitViewModel();
+        var targets = vm.GetNavigationTargets();
+        foreach (var t in targets)
+        {
+            Assert.Null(t.IssueRef);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 4 end-to-end: simulate the six WF callsites and confirm
+    // they MATCH the new manifest rows (no longer MissingAvManifest).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void JumpParityScanner_BattleTalk_NowMatchesManifest()
+    {
+        var wfCallsites = new[]
+        {
+            new WfJumpCallsite(
+                SourceForm: "EventUnitForm",
+                TargetForm: "EventBattleTalkForm",
+                HasAddressArgument: true),
+        };
+
+        var avManifests = new[]
+        {
+            new AvManifestEntry(
+                SourceVm: "EventUnitViewModel",
+                SourceView: "EventUnitView",
+                Command: "JumpToBattleTalk",
+                TargetView: "EventBattleTalkView",
+                IssueRef: null),
+        };
+
+        var rows = JumpParityScanner.ComputeJumpRows(wfCallsites, avManifests);
+        var match = rows.FirstOrDefault(r =>
+            r.SourceForm == "EventUnitForm" &&
+            r.TargetWfType == "EventBattleTalkForm");
+        Assert.NotNull(match);
+        Assert.Equal(JumpRowStatus.Match, match!.Status);
+        Assert.Equal("EventBattleTalkView", match.TargetAvType);
+    }
+
+    [Fact]
+    public void JumpParityScanner_BattleBGM_NowMatchesManifest()
+    {
+        var wfCallsites = new[]
+        {
+            new WfJumpCallsite(
+                SourceForm: "EventUnitForm",
+                TargetForm: "SoundBossBGMForm",
+                HasAddressArgument: true),
+        };
+
+        var avManifests = new[]
+        {
+            new AvManifestEntry(
+                SourceVm: "EventUnitViewModel",
+                SourceView: "EventUnitView",
+                Command: "JumpToBattleBGM",
+                TargetView: "SoundBossBGMViewerView",
+                IssueRef: null),
+        };
+
+        var rows = JumpParityScanner.ComputeJumpRows(wfCallsites, avManifests);
+        var match = rows.FirstOrDefault(r =>
+            r.SourceForm == "EventUnitForm" &&
+            r.TargetWfType == "SoundBossBGMForm");
+        Assert.NotNull(match);
+        Assert.Equal(JumpRowStatus.Match, match!.Status);
+        Assert.Equal("SoundBossBGMViewerView", match.TargetAvType);
+    }
+
+    [Fact]
+    public void JumpParityScanner_Haiku_NowMatchesManifest()
+    {
+        var wfCallsites = new[]
+        {
+            new WfJumpCallsite(
+                SourceForm: "EventUnitForm",
+                TargetForm: "EventHaikuForm",
+                HasAddressArgument: true),
+        };
+
+        var avManifests = new[]
+        {
+            new AvManifestEntry(
+                SourceVm: "EventUnitViewModel",
+                SourceView: "EventUnitView",
+                Command: "JumpToHaiku",
+                TargetView: "EventHaikuView",
+                IssueRef: null),
+        };
+
+        var rows = JumpParityScanner.ComputeJumpRows(wfCallsites, avManifests);
+        var match = rows.FirstOrDefault(r =>
+            r.SourceForm == "EventUnitForm" &&
+            r.TargetWfType == "EventHaikuForm");
+        Assert.NotNull(match);
+        Assert.Equal(JumpRowStatus.Match, match!.Status);
+        Assert.Equal("EventHaikuView", match.TargetAvType);
+    }
+
+    [Fact]
+    public void JumpParityScanner_NewAlloc_NowMatchesManifest()
+    {
+        var wfCallsites = new[]
+        {
+            new WfJumpCallsite(
+                SourceForm: "EventUnitForm",
+                TargetForm: "EventUnitNewAllocForm",
+                HasAddressArgument: false),
+        };
+
+        var avManifests = new[]
+        {
+            new AvManifestEntry(
+                SourceVm: "EventUnitViewModel",
+                SourceView: "EventUnitView",
+                Command: "JumpToNewAlloc",
+                TargetView: "EventUnitNewAllocView",
+                IssueRef: null),
+        };
+
+        var rows = JumpParityScanner.ComputeJumpRows(wfCallsites, avManifests);
+        var match = rows.FirstOrDefault(r =>
+            r.SourceForm == "EventUnitForm" &&
+            r.TargetWfType == "EventUnitNewAllocForm");
+        Assert.NotNull(match);
+        Assert.Equal(JumpRowStatus.Match, match!.Status);
+        Assert.Equal("EventUnitNewAllocView", match.TargetAvType);
+    }
+
+    [Fact]
+    public void JumpParityScanner_ItemDrop_NowMatchesManifest()
+    {
+        var wfCallsites = new[]
+        {
+            new WfJumpCallsite(
+                SourceForm: "EventUnitForm",
+                TargetForm: "EventUnitItemDropForm",
+                HasAddressArgument: false),
+        };
+
+        var avManifests = new[]
+        {
+            new AvManifestEntry(
+                SourceVm: "EventUnitViewModel",
+                SourceView: "EventUnitView",
+                Command: "JumpToItemDrop",
+                TargetView: "EventUnitItemDropView",
+                IssueRef: null),
+        };
+
+        var rows = JumpParityScanner.ComputeJumpRows(wfCallsites, avManifests);
+        var match = rows.FirstOrDefault(r =>
+            r.SourceForm == "EventUnitForm" &&
+            r.TargetWfType == "EventUnitItemDropForm");
+        Assert.NotNull(match);
+        Assert.Equal(JumpRowStatus.Match, match!.Status);
+        Assert.Equal("EventUnitItemDropView", match.TargetAvType);
+    }
+
+    [Fact]
+    public void JumpParityScanner_MonsterProbability_NowMatchesManifest()
+    {
+        var wfCallsites = new[]
+        {
+            new WfJumpCallsite(
+                SourceForm: "EventUnitForm",
+                TargetForm: "MonsterProbabilityForm",
+                HasAddressArgument: true),
+        };
+
+        var avManifests = new[]
+        {
+            new AvManifestEntry(
+                SourceVm: "EventUnitViewModel",
+                SourceView: "EventUnitView",
+                Command: "JumpToMonsterProbability",
+                TargetView: "MonsterProbabilityViewerView",
+                IssueRef: null),
+        };
+
+        var rows = JumpParityScanner.ComputeJumpRows(wfCallsites, avManifests);
+        var match = rows.FirstOrDefault(r =>
+            r.SourceForm == "EventUnitForm" &&
+            r.TargetWfType == "MonsterProbabilityForm");
+        Assert.NotNull(match);
+        Assert.Equal(JumpRowStatus.Match, match!.Status);
+        Assert.Equal("MonsterProbabilityViewerView", match.TargetAvType);
+    }
+
+    // -----------------------------------------------------------------
+    // ViewModel B3 round-trip — UnitInfoLV/Allegiance/Grow must be a
+    // lossless decomposition of the raw UnitInfo byte.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_UnitInfoLV_DecomposesAndComposes()
+    {
+        var vm = new EventUnitViewModel();
+        // Sample bit pattern: lv=20, assign=2 (Enemy), grow=1.
+        // 1 | (2<<1) | (20<<3) = 1 | 4 | 160 = 0xA5.
+        vm.UnitInfo = 0xA5;
+        Assert.Equal(20u, vm.UnitInfoLV);
+        Assert.Equal(2u, vm.UnitInfoAllegiance);
+        Assert.Equal(1u, vm.UnitInfoGrow);
+
+        // Setting LV alone preserves the other fields.
+        vm.UnitInfoLV = 5;
+        // 1 | (2<<1) | (5<<3) = 1 | 4 | 40 = 0x2D
+        Assert.Equal(0x2Du, vm.UnitInfo);
+        Assert.Equal(2u, vm.UnitInfoAllegiance);
+        Assert.Equal(1u, vm.UnitInfoGrow);
+    }
+
+    [Fact]
+    public void ViewModel_UnitInfoAllegiance_AllValuesRoundTrip()
+    {
+        var vm = new EventUnitViewModel();
+        for (uint allegiance = 0; allegiance < 4; allegiance++)
+        {
+            vm.UnitInfo = 0;
+            vm.UnitInfoAllegiance = allegiance;
+            Assert.Equal(allegiance, vm.UnitInfoAllegiance);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // ViewModel W4 round-trip — BeforeX/BeforeY/UnitPosExt must be a
+    // lossless decomposition of UnitGrowth.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_W4_DecomposesAndComposes()
+    {
+        var vm = new EventUnitViewModel();
+        // Sample W4: X=5, Y=10, Ext=2 (Item Drop).
+        // 5 | (10 << 6) | (2 << 12) = 5 | 640 | 8192 = 0x2285.
+        vm.UnitGrowth = 0x2285;
+        Assert.Equal(5u, vm.BeforeX);
+        Assert.Equal(10u, vm.BeforeY);
+        Assert.Equal(2u, vm.UnitPosExt);
+        Assert.True(vm.ItemDropFlag);
+
+        // Setting BeforeX alone preserves the others.
+        vm.BeforeX = 7;
+        Assert.Equal(7u, vm.BeforeX);
+        Assert.Equal(10u, vm.BeforeY);
+        Assert.Equal(2u, vm.UnitPosExt);
+        Assert.True(vm.ItemDropFlag);
+    }
+
+    [Fact]
+    public void ViewModel_ItemDropFlag_TogglesW4ExtBit2()
+    {
+        var vm = new EventUnitViewModel();
+        // Start with ext=0 (no drop).
+        vm.UnitGrowth = 0;
+        Assert.False(vm.ItemDropFlag);
+
+        vm.ItemDropFlag = true;
+        Assert.True(vm.ItemDropFlag);
+        Assert.Equal(2u, vm.UnitPosExt);
+        Assert.Equal(2u << 12, vm.UnitGrowth);
+
+        vm.ItemDropFlag = false;
+        Assert.False(vm.ItemDropFlag);
+        Assert.Equal(0u, vm.UnitPosExt);
+    }
+
+    [Fact]
+    public void ViewModel_ItemDropDisplay_ChangesWithW4ExtBit()
+    {
+        var vm = new EventUnitViewModel();
+        // No drop bit -> "doesn't drop"
+        vm.UnitGrowth = 0;
+        Assert.Contains("doesn't drop", vm.ItemDropDisplay);
+
+        // Set drop bit -> "drops"
+        vm.UnitGrowth = (2u << 12);
+        Assert.Contains("drops", vm.ItemDropDisplay);
+        // Must not contain "doesn't" — strict match (Copilot review v1 #2).
+        Assert.DoesNotContain("doesn't", vm.ItemDropDisplay);
+    }
+
+    // -----------------------------------------------------------------
+    // ViewModel Comment must round-trip through CoreState.CommentCache.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_Comment_RoundTripsThroughCommentCache()
+    {
+        if (CoreState.CommentCache == null)
+        {
+            CoreState.CommentCache = new HeadlessEtcCache();
+        }
+
+        var vm = new EventUnitViewModel();
+        const uint addr = 0x00BEEF00u;
+
+        // Seed the cache.
+        CoreState.CommentCache.Update(addr, "eventunit test comment");
+
+        // Build a synthetic ROM so LoadEntry can run without crashing.
+        ROM rom = MakeFe8uRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            vm.LoadEntry(addr);
+            Assert.Equal("eventunit test comment", vm.Comment);
+
+            // Round-trip: mutate then write, then re-load.
+            vm.Comment = "new value";
+            vm.WriteEntry();
+            vm.Comment = ""; // simulate fresh load
+            vm.LoadEntry(addr);
+            Assert.Equal("new value", vm.Comment);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    // -----------------------------------------------------------------
+    // Undo coverage — the View's Write_Click + ExpandList_Click + W4
+    // ItemDrop checkbox must open and commit UndoService scopes.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_WriteClick_WrapsInUndoScope()
+    {
+        string repoRoot = FindRepoRoot();
+        string codeBehindPath = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "EventUnitView.axaml.cs");
+        Assert.True(File.Exists(codeBehindPath), $"code-behind not found at {codeBehindPath}");
+
+        string source = File.ReadAllText(codeBehindPath);
+
+        Assert.Matches(
+            new Regex(@"void\s+Write_Click\([^)]*\)\s*\{[\s\S]*?_undoService\.Begin\(", RegexOptions.Singleline),
+            source);
+        Assert.Matches(
+            new Regex(@"void\s+Write_Click\([^)]*\)\s*\{[\s\S]*?_undoService\.Commit\(\)", RegexOptions.Singleline),
+            source);
+        Assert.Matches(
+            new Regex(@"void\s+Write_Click\([^)]*\)\s*\{[\s\S]*?_undoService\.Rollback\(\)", RegexOptions.Singleline),
+            source);
+    }
+
+    [Fact]
+    public void View_ExpandListClick_WrapsInUndoScope()
+    {
+        string repoRoot = FindRepoRoot();
+        string codeBehindPath = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "EventUnitView.axaml.cs");
+        string source = File.ReadAllText(codeBehindPath);
+
+        Assert.Matches(
+            new Regex(@"void\s+ExpandList_Click\([^)]*\)\s*\{[\s\S]*?_undoService\.Begin\(", RegexOptions.Singleline),
+            source);
+        Assert.Matches(
+            new Regex(@"void\s+ExpandList_Click\([^)]*\)\s*\{[\s\S]*?_undoService\.Commit\(\)", RegexOptions.Singleline),
+            source);
+        Assert.Matches(
+            new Regex(@"void\s+ExpandList_Click\([^)]*\)\s*\{[\s\S]*?_undoService\.Rollback\(\)", RegexOptions.Singleline),
+            source);
+    }
+
+    [Fact]
+    public void View_ExpandListClick_InvokesVmExpandHelper()
+    {
+        string repoRoot = FindRepoRoot();
+        string codeBehindPath = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "EventUnitView.axaml.cs");
+        string source = File.ReadAllText(codeBehindPath);
+
+        Assert.Matches(
+            new Regex(@"void\s+ExpandList_Click\([^)]*\)\s*\{[\s\S]*?_vm\.ExpandUnitListCurrent\(", RegexOptions.Singleline),
+            source);
+    }
+
+    [Fact]
+    public void ViewModel_ExpandUnitListCurrent_UsesFe8StarterByte()
+    {
+        // The VM's ExpandUnitListCurrent must invoke
+        // MapEventUnitCore.ExpandUnitList with starterB1=0x02 (FE8
+        // semantics) per WF EventUnitForm.AddressListExpandsEvent.
+        string repoRoot = FindRepoRoot();
+        string vmPath = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "ViewModels",
+            "EventUnitViewModel.cs");
+        string source = File.ReadAllText(vmPath);
+
+        // Look for the call: ExpandUnitList(...starterB1: 0x02)
+        Assert.Matches(
+            new Regex(@"MapEventUnitCore\.ExpandUnitList\([\s\S]*?starterB1:\s*0x02", RegexOptions.Singleline),
+            source);
+    }
+
+    // -----------------------------------------------------------------
+    // AutomationId presence — the new controls must have stable test ids
+    // so MCP / UIAutomation can target them for end-to-end validation.
+    // -----------------------------------------------------------------
+
+    [Theory]
+    [InlineData("EventUnit_TopAddr_Input")]
+    [InlineData("EventUnit_ReadCount_Input")]
+    [InlineData("EventUnit_ReloadList_Button")]
+    [InlineData("EventUnit_NewAlloc_Button")]
+    [InlineData("EventUnit_ExpandList_Button")]
+    [InlineData("EventUnit_BlockSize_Input")]
+    [InlineData("EventUnit_SelectedAddr_Input")]
+    [InlineData("EventUnit_Comment_Input")]
+    [InlineData("EventUnit_LV_Input")]
+    [InlineData("EventUnit_Allegiance_Combo")]
+    [InlineData("EventUnit_GrowthRate_Combo")]
+    [InlineData("EventUnit_BeforeX_Input")]
+    [InlineData("EventUnit_BeforeY_Input")]
+    [InlineData("EventUnit_ItemDropFlag_Check")]
+    [InlineData("EventUnit_JumpBattleTalk_Button")]
+    [InlineData("EventUnit_JumpBattleBGM_Button")]
+    [InlineData("EventUnit_JumpHaiku_Button")]
+    [InlineData("EventUnit_ItemDropDialog_Button")]
+    [InlineData("EventUnit_JumpMonsterProb_Button")]
+    [InlineData("EventUnit_ItemDrop_Label")]
+    public void View_DeclaresExpectedAutomationId(string automationId)
+    {
+        string repoRoot = FindRepoRoot();
+        string axamlPath = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "EventUnitView.axaml");
+        Assert.True(File.Exists(axamlPath), $"AXAML not found at {axamlPath}");
+        string content = File.ReadAllText(axamlPath);
+        Assert.Contains(automationId, content);
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    static ROM MakeFe8uRom()
+    {
+        var bytes = new byte[0x1100000];
+        var rom = new ROM();
+        rom.LoadLow("synthetic-fe8u.gba", bytes, "BE8E01");
+        return rom;
+    }
+
+    static string FindRepoRoot()
+    {
+        string? dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+        return dir ?? throw new InvalidOperationException("Couldn't locate FEBuilderGBA.sln");
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/EventUnitParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/EventUnitParityTests.cs
@@ -353,15 +353,21 @@ public class EventUnitParityTests
     public void ViewModel_ItemDropDisplay_ChangesWithW4ExtBit()
     {
         var vm = new EventUnitViewModel();
-        // No drop bit -> "doesn't drop"
+        // No drop bit -> R._("Item Drop: doesn't drop")
         vm.UnitGrowth = 0;
-        Assert.Contains("doesn't drop", vm.ItemDropDisplay);
+        string noDropDisplay = vm.ItemDropDisplay;
 
-        // Set drop bit -> "drops"
+        // Set drop bit -> R._("Item Drop: drops")
         vm.UnitGrowth = (2u << 12);
-        Assert.Contains("drops", vm.ItemDropDisplay);
-        // Must not contain "doesn't" — strict match (Copilot review v1 #2).
-        Assert.DoesNotContain("doesn't", vm.ItemDropDisplay);
+        string dropDisplay = vm.ItemDropDisplay;
+
+        // Both must match the localized R._-resolved strings (so the test
+        // stays green under ja/zh translations too — Copilot bot review
+        // round 2 #3).
+        Assert.Equal(R._("Item Drop: doesn't drop"), noDropDisplay);
+        Assert.Equal(R._("Item Drop: drops"), dropDisplay);
+        // The two states MUST produce different strings (regression guard).
+        Assert.NotEqual(noDropDisplay, dropDisplay);
     }
 
     // -----------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
@@ -513,6 +513,14 @@ namespace FEBuilderGBA.Avalonia.Services
             // under the BG256Color patch. Popup is a dialog (NoListEditor);
             // declare the WF↔AV form pair so JumpParityScanner can resolve it.
             { "ImageBGSelectPopupView", "ImageBGSelectPopupForm" },
+            // #420 — EventUnitForm jumps to the New Allocation modal dialog
+            // (sets unit count to allocate) and the Item Drop Yes/No/Cancel
+            // dialog. Both Avalonia views are stubs in ContextDependentEditors
+            // (sub-editors of EventUnit*View), so the EditorMap layer doesn't
+            // seed them. Declare the WF↔AV form pair so JumpParityScanner can
+            // resolve the cross-ref and the navigation manifest reaches Match.
+            { "EventUnitNewAllocView", "EventUnitNewAllocForm" },
+            { "EventUnitItemDropView", "EventUnitItemDropForm" },
         };
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/ViewModels/EventUnitViewModel.NavigationTargets.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EventUnitViewModel.NavigationTargets.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Navigation manifest for EventUnitViewModel (#420 / #374 Phase 4).
+//
+// Mirrors the six WF `EventUnitForm` jump callsites:
+//   - JUMP_BATTLETALK_Click -> EventBattleTalkForm
+//       (`f.JumpTo((uint)B0.Value, (uint)MAP_LISTBOX.SelectedIndex)` —
+//        passes unit id + map id)
+//   - JUMP_BATTLEBGM_Click  -> SoundBossBGMForm
+//       (`f.JumpTo((uint)B0.Value)` — passes unit id)
+//   - JUMP_HAIKU_Click       -> EventHaikuForm
+//       (`f.JumpTo((uint)B0.Value, (uint)MAP_LISTBOX.SelectedIndex)` —
+//        unit id + map id)
+//   - NewButton_Click        -> EventUnitNewAllocForm (modal dialog)
+//   - X_ITEMDROP_Click       -> EventUnitItemDropForm (modal dialog)
+//   - X_RANDOMMONSTER_DoubleClick -> MonsterProbabilityForm
+//       (`InputFormRef.JumpForm<MonsterProbabilityForm>(B1.Value)` —
+//        pre-selects the class_id row)
+//
+// `TargetAddress: null` is the sentinel for "computed at click time" — the
+// AV View code-behind dispatches to the Core search helpers
+// (`MapEventUnitCore.FindXxxFE8Address` etc.) and then opens the target
+// editor with the resolved byte address. Matches the precedent from
+// `EventUnitFE7ViewModel.NavigationTargets.cs`.
+using System.Collections.Generic;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.Views;
+
+namespace FEBuilderGBA.Avalonia.ViewModels
+{
+    public partial class EventUnitViewModel : INavigationTargetSource
+    {
+        public IReadOnlyList<NavigationTarget> GetNavigationTargets()
+        {
+            return new[]
+            {
+                new NavigationTarget(
+                    CommandName: "JumpToBattleTalk",
+                    TargetViewType: typeof(EventBattleTalkView),
+                    TargetAddress: null),
+                new NavigationTarget(
+                    CommandName: "JumpToBattleBGM",
+                    TargetViewType: typeof(SoundBossBGMViewerView),
+                    TargetAddress: null),
+                new NavigationTarget(
+                    CommandName: "JumpToHaiku",
+                    TargetViewType: typeof(EventHaikuView),
+                    TargetAddress: null),
+                new NavigationTarget(
+                    CommandName: "JumpToNewAlloc",
+                    TargetViewType: typeof(EventUnitNewAllocView),
+                    TargetAddress: null),
+                new NavigationTarget(
+                    CommandName: "JumpToItemDrop",
+                    TargetViewType: typeof(EventUnitItemDropView),
+                    TargetAddress: null),
+                new NavigationTarget(
+                    CommandName: "JumpToMonsterProbability",
+                    TargetViewType: typeof(MonsterProbabilityViewerView),
+                    TargetAddress: null),
+            };
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/EventUnitViewModel.NavigationTargets.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EventUnitViewModel.NavigationTargets.cs
@@ -16,11 +16,16 @@
 //       (`InputFormRef.JumpForm<MonsterProbabilityForm>(B1.Value)` —
 //        pre-selects the class_id row)
 //
-// `TargetAddress: null` is the sentinel for "computed at click time" — the
-// AV View code-behind dispatches to the Core search helpers
-// (`MapEventUnitCore.FindXxxFE8Address` etc.) and then opens the target
-// editor with the resolved byte address. Matches the precedent from
-// `EventUnitFE7ViewModel.NavigationTargets.cs`.
+// `TargetAddress: null` is the sentinel for "no static target address" —
+// the AV View code-behind dispatches at click time. For
+// JumpToBattleTalk/JumpToBattleBGM/JumpToHaiku, it calls the Core search
+// helpers (`MapEventUnitCore.FindXxxFE8Address` etc.) and opens the
+// target editor with the resolved byte address. For JumpToNewAlloc and
+// JumpToItemDrop, it opens the proxy dialog view with no address (modal
+// dialog flow). For JumpToMonsterProbability, it opens the viewer
+// without row pre-selection (the WF behavior of passing B1 = class_id
+// as a row index is documented as a known limitation — see PR body).
+// Matches the precedent from `EventUnitFE7ViewModel.NavigationTargets.cs`.
 using System.Collections.Generic;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.Views;

--- a/FEBuilderGBA.Avalonia/ViewModels/EventUnitViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EventUnitViewModel.cs
@@ -134,8 +134,19 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public string AI3Desc { get => _ai3Desc; set => SetField(ref _ai3Desc, value); }
         public string AI4Desc { get => _ai4Desc; set => SetField(ref _ai4Desc, value); }
 
-        /// <summary>Item-drop display string mirroring WF X_ITEMDROP label.</summary>
-        public string ItemDropDisplay { get => _itemDropDisplay; set => SetField(ref _itemDropDisplay, value); }
+        /// <summary>
+        /// Item-drop display string mirroring WF X_ITEMDROP label. Computed
+        /// from the current W4 (UnitPos) ext bit; <see cref="UnitGrowth"/>
+        /// setter raises <c>PropertyChanged(nameof(ItemDropDisplay))</c> so
+        /// bound controls refresh in lockstep with the underlying byte.
+        /// </summary>
+        public string ItemDropDisplay
+        {
+            get => ComputeItemDropDisplay(_unitGrowth);
+            // Setter retained for legacy callers but is a no-op aside from
+            // notification — the canonical source is the W4 ext bit.
+            set => _itemDropDisplay = value;
+        }
 
         /// <summary>
         /// User annotation persisted through <c>CoreState.CommentCache</c>
@@ -273,7 +284,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
         void RefreshItemDropDisplay()
         {
-            ItemDropDisplay = ComputeItemDropDisplay(_unitGrowth);
+            // ItemDropDisplay is computed from _unitGrowth; raise change
+            // notification so bound controls re-read.
+            OnPropertyChanged(nameof(ItemDropDisplay));
         }
 
         /// <summary>Build the map list (Level 1 navigation).</summary>

--- a/FEBuilderGBA.Avalonia/ViewModels/EventUnitViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EventUnitViewModel.cs
@@ -9,11 +9,28 @@ namespace FEBuilderGBA.Avalonia.ViewModels
     /// Provides 3-level navigation: Map -> Unit Group -> Unit.
     ///
     /// Layout: UnitID(B0), ClassID(B1), LeaderUnitID(B2), UnitInfo(B3),
-    ///         UnitGrowth(W4), Reserved6(B6), CoordCount(B7), CoordPointer(D8),
+    ///         UnitPos/W4(B4..B5), Reserved6(B6), AfterCoordCount(B7),
+    ///         AfterCoordPointer(D8..D11),
     ///         Item1(B12), Item2(B13), Item3(B14), Item4(B15),
-    ///         AI1Primary(B16), AI2Secondary(B17), AI3TargetRecovery(B18), AI4Retreat(B19).
+    ///         AI1Primary(B16), AI2Secondary(B17), AI3TargetRecovery(B18),
+    ///         AI4Retreat(B19).
+    ///
+    /// B3 (UnitInfo) decomposes into three packed sub-fields per WF
+    /// <c>InputFormRef.cs</c> (the UNITGROW binding):
+    ///   bit 0       — Growth flag (0 = no growth, 1 = class-dependent)
+    ///   bits 1-2    — Allegiance (0 = Player, 1 = Ally, 2 = Enemy, 3 = Disappear)
+    ///   bits 3-7    — Level (0-31)
+    ///
+    /// W4 (UnitPos) decomposes via U.MakeFe8UnitPos / U.ParseFe8UnitPos*:
+    ///   bits 0-5    — Before X (0-63)
+    ///   bits 6-11   — Before Y (0-63)
+    ///   bits 12-14  — Ext flags (bit 0x2 = Item Drop)
+    ///
+    /// B7/D8 hold the after-coord LIST (count + pointer). Editing the
+    /// LIST itself (multi-coord, the WF FE8CoordListBox) is OUT OF SCOPE
+    /// for this gap-sweep PR — the new view shows B7/D8 read-only.
     /// </summary>
-    public class EventUnitViewModel : ViewModelBase, IDataVerifiable
+    public partial class EventUnitViewModel : ViewModelBase, IDataVerifiable
     {
         // EditorFormRef field definitions
         static readonly string[] FieldNames = new[]
@@ -27,7 +44,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         bool _isLoaded;
 
         uint _unitID, _classID, _leaderUnitID, _unitInfo;
-        uint _unitGrowth;
+        uint _unitGrowth; // raw W4 (UnitPos)
         uint _reserved6, _coordCount;
         uint _coordPointer;
         uint _item1, _item2, _item3, _item4;
@@ -37,20 +54,62 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         uint _selectedMapId = uint.MaxValue;
         uint _selectedGroupAddr;
 
+        // Comment annotation
+        string _comment = "";
+
         // Resolved display names
         string _unitName = "";
         string _className = "";
         string _item1Name = "", _item2Name = "", _item3Name = "", _item4Name = "";
         string _ai1Desc = "", _ai2Desc = "", _ai3Desc = "", _ai4Desc = "";
+        string _itemDropDisplay = "";
 
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
 
-        public uint UnitID { get => _unitID; set => SetField(ref _unitID, value); }
-        public uint ClassID { get => _classID; set => SetField(ref _classID, value); }
+        public uint UnitID
+        {
+            get => _unitID;
+            set => SetField(ref _unitID, value);
+        }
+        public uint ClassID
+        {
+            get => _classID;
+            set => SetField(ref _classID, value);
+        }
         public uint LeaderUnitID { get => _leaderUnitID; set => SetField(ref _leaderUnitID, value); }
-        public uint UnitInfo { get => _unitInfo; set => SetField(ref _unitInfo, value); }
-        public uint UnitGrowth { get => _unitGrowth; set => SetField(ref _unitGrowth, value); }
+
+        public uint UnitInfo
+        {
+            get => _unitInfo;
+            set
+            {
+                if (SetField(ref _unitInfo, value))
+                {
+                    OnPropertyChanged(nameof(UnitInfoLV));
+                    OnPropertyChanged(nameof(UnitInfoAllegiance));
+                    OnPropertyChanged(nameof(UnitInfoGrow));
+                }
+            }
+        }
+        public uint UnitGrowth
+        {
+            // Backwards-compat alias for the W4 packed word. New view
+            // surfaces this as the "Unit Pos (W4)" raw input; the
+            // BeforeX/BeforeY/UnitPosExt properties decompose it.
+            get => _unitGrowth;
+            set
+            {
+                if (SetField(ref _unitGrowth, value))
+                {
+                    OnPropertyChanged(nameof(BeforeX));
+                    OnPropertyChanged(nameof(BeforeY));
+                    OnPropertyChanged(nameof(UnitPosExt));
+                    OnPropertyChanged(nameof(ItemDropFlag));
+                    RefreshItemDropDisplay();
+                }
+            }
+        }
         public uint Reserved6 { get => _reserved6; set => SetField(ref _reserved6, value); }
         public uint CoordCount { get => _coordCount; set => SetField(ref _coordCount, value); }
         public uint CoordPointer { get => _coordPointer; set => SetField(ref _coordPointer, value); }
@@ -75,6 +134,148 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public string AI3Desc { get => _ai3Desc; set => SetField(ref _ai3Desc, value); }
         public string AI4Desc { get => _ai4Desc; set => SetField(ref _ai4Desc, value); }
 
+        /// <summary>Item-drop display string mirroring WF X_ITEMDROP label.</summary>
+        public string ItemDropDisplay { get => _itemDropDisplay; set => SetField(ref _itemDropDisplay, value); }
+
+        /// <summary>
+        /// User annotation persisted through <c>CoreState.CommentCache</c>
+        /// (matches the WF InputFormRef Comment-cache pattern + the Avalonia
+        /// precedent established by ImageBattleBG / ImagePortraitFE6).
+        /// </summary>
+        public string Comment { get => _comment; set => SetField(ref _comment, value); }
+
+        /// <summary>
+        /// The currently-selected map id, used as the second key by jump
+        /// helpers (BattleTalk + Haiku take unit_id + map_id).
+        /// </summary>
+        public uint SelectedMapId { get => _selectedMapId; set => SetField(ref _selectedMapId, value); }
+
+        /// <summary>
+        /// Base address of the unit-list table for the currently-loaded
+        /// group. <see cref="ExpandUnitListCurrent"/> uses this to identify
+        /// which list to grow.
+        /// </summary>
+        public uint SelectedUnitListBase { get => _selectedGroupAddr; set => SetField(ref _selectedGroupAddr, value); }
+
+        // ---------------------------------------------------------------
+        // B3 (UnitInfo) sub-field properties — UI sugar over the raw byte.
+        // Each setter recomposes UnitInfo so the byte stays the source of truth.
+        // ---------------------------------------------------------------
+
+        public uint UnitInfoLV
+        {
+            get => U.ParseUnitGrowLV(_unitInfo);
+            set
+            {
+                uint b3 = U.MakeUnitGrowB3(
+                    lv: value,
+                    assign: U.ParseUnitGrowAssign(_unitInfo),
+                    grow: U.ParseUnitGrowGrow(_unitInfo));
+                UnitInfo = b3;
+            }
+        }
+
+        public uint UnitInfoAllegiance
+        {
+            get => U.ParseUnitGrowAssign(_unitInfo);
+            set
+            {
+                uint b3 = U.MakeUnitGrowB3(
+                    lv: U.ParseUnitGrowLV(_unitInfo),
+                    assign: value,
+                    grow: U.ParseUnitGrowGrow(_unitInfo));
+                UnitInfo = b3;
+            }
+        }
+
+        public uint UnitInfoGrow
+        {
+            get => U.ParseUnitGrowGrow(_unitInfo);
+            set
+            {
+                uint b3 = U.MakeUnitGrowB3(
+                    lv: U.ParseUnitGrowLV(_unitInfo),
+                    assign: U.ParseUnitGrowAssign(_unitInfo),
+                    grow: value);
+                UnitInfo = b3;
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // W4 (UnitPos / UnitGrowth alias) sub-field properties — decompose
+        // the packed word into BeforeX/BeforeY/Ext components via
+        // U.ParseFe8UnitPos* / U.MakeFe8UnitPos.
+        //
+        // Setting any sub-field recomposes UnitGrowth so the packed W4
+        // remains the source of truth. RefreshItemDropDisplay runs whenever
+        // ext changes so the FE8 "Item Drop: drops/doesn't drop" label
+        // stays honest while editing.
+        // ---------------------------------------------------------------
+
+        public uint BeforeX
+        {
+            get => U.ParseFe8UnitPosX(_unitGrowth);
+            set
+            {
+                uint w4 = U.MakeFe8UnitPos(
+                    x: value,
+                    y: U.ParseFe8UnitPosY(_unitGrowth),
+                    ext: U.ParseFe8UnitPosExt(_unitGrowth));
+                UnitGrowth = w4;
+            }
+        }
+
+        public uint BeforeY
+        {
+            get => U.ParseFe8UnitPosY(_unitGrowth);
+            set
+            {
+                uint w4 = U.MakeFe8UnitPos(
+                    x: U.ParseFe8UnitPosX(_unitGrowth),
+                    y: value,
+                    ext: U.ParseFe8UnitPosExt(_unitGrowth));
+                UnitGrowth = w4;
+            }
+        }
+
+        public uint UnitPosExt
+        {
+            get => U.ParseFe8UnitPosExt(_unitGrowth);
+            set
+            {
+                uint w4 = U.MakeFe8UnitPos(
+                    x: U.ParseFe8UnitPosX(_unitGrowth),
+                    y: U.ParseFe8UnitPosY(_unitGrowth),
+                    ext: value);
+                UnitGrowth = w4;
+            }
+        }
+
+        /// <summary>
+        /// Item Drop flag — bit 0x2 of the W4 ext field. Mirrors WF
+        /// EventUnitForm's UpdateItemDropLabel + X_ITEMDROP_Click logic
+        /// (the canonical FE8 source of truth, not unit/class
+        /// characteristics).
+        /// </summary>
+        public bool ItemDropFlag
+        {
+            get => (U.ParseFe8UnitPosExt(_unitGrowth) & 0x2) == 0x2;
+            set
+            {
+                uint ext = U.ParseFe8UnitPosExt(_unitGrowth);
+                if (value)
+                    ext |= 0x2;
+                else
+                    ext = ext & ~0x2u;
+                UnitPosExt = ext;
+            }
+        }
+
+        void RefreshItemDropDisplay()
+        {
+            ItemDropDisplay = ComputeItemDropDisplay(_unitGrowth);
+        }
+
         /// <summary>Build the map list (Level 1 navigation).</summary>
         public List<AddrResult> LoadMapList()
         {
@@ -84,7 +285,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// <summary>Build the unit group list for a map (Level 2 navigation).</summary>
         public List<AddrResult> LoadUnitGroups(uint mapId)
         {
-            _selectedMapId = mapId;
+            SelectedMapId = mapId;
             ROM rom = CoreState.ROM;
             if (rom == null) return new List<AddrResult>();
             return MapEventUnitCore.GetUnitGroupsForMap(rom, mapId);
@@ -93,7 +294,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// <summary>Build the unit list from a base address (Level 3 navigation).</summary>
         public List<AddrResult> LoadUnitList(uint baseAddr)
         {
-            _selectedGroupAddr = baseAddr;
+            SelectedUnitListBase = baseAddr;
             ROM rom = CoreState.ROM;
             if (rom == null) return new List<AddrResult>();
             return MapEventUnitCore.EnumerateUnits(rom, baseAddr);
@@ -102,11 +303,46 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// <summary>Load unit list from an arbitrary address (manual entry).</summary>
         public List<AddrResult> LoadUnitListFromAddress(uint baseAddr)
         {
-            _selectedMapId = uint.MaxValue;
-            _selectedGroupAddr = baseAddr;
+            SelectedMapId = uint.MaxValue;
+            SelectedUnitListBase = baseAddr;
             ROM rom = CoreState.ROM;
             if (rom == null) return new List<AddrResult>();
             return MapEventUnitCore.EnumerateUnits(rom, baseAddr);
+        }
+
+        /// <summary>
+        /// Expand the currently-loaded unit list by the given number of rows.
+        /// Mirrors the WF AddressListExpandsButton behavior with FE8 starter
+        /// bytes (B0=0x01, B1=0x02) per WF EventUnitForm.AddressListExpandsEvent.
+        /// Returns the new base ROM offset or <see cref="U.NOT_FOUND"/> on failure.
+        ///
+        /// Side-effects on success: <see cref="SelectedUnitListBase"/> updated
+        /// to the new base. The caller MUST open an ambient undo scope before
+        /// invoking this.
+        /// </summary>
+        public uint ExpandUnitListCurrent(uint addRows)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null) return U.NOT_FOUND;
+            if (SelectedUnitListBase == 0) return U.NOT_FOUND;
+            if (addRows == 0) return U.NOT_FOUND;
+
+            uint slot = MapEventUnitCore.FindEventPointerSlotForUnitList(
+                rom, SelectedMapId, SelectedUnitListBase);
+            if (slot == 0) return U.NOT_FOUND;
+
+            uint oldCount = MapEventUnitCore.CountEventUnitRows(rom, SelectedUnitListBase);
+            if (oldCount == 0) return U.NOT_FOUND;
+            uint newCount = oldCount + addRows;
+
+            // FE8 starter B1 = 0x02 per WF EventUnitForm.AddressListExpandsEvent
+            // (vs FE7's 0x01).
+            uint newBase = MapEventUnitCore.ExpandUnitList(
+                rom, slot, SelectedUnitListBase, oldCount, newCount, starterB1: 0x02);
+            if (newBase == U.NOT_FOUND) return U.NOT_FOUND;
+
+            SelectedUnitListBase = newBase;
+            return newBase;
         }
 
         /// <summary>IDataVerifiable fallback: returns the map list (Level 1) when no specific group is selected.</summary>
@@ -155,6 +391,23 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             AI3Desc = MapEventUnitCore.GetAI3Description((byte)AI3TargetRecovery);
             AI4Desc = MapEventUnitCore.GetAI4Description((byte)AI4Retreat);
 
+            // Update FE8 item-drop display from the W4 ext bit (NOT unit/
+            // class characteristic — the FE8 canonical source is W4@bit12+1).
+            RefreshItemDropDisplay();
+
+            // Load comment annotation from CoreState.CommentCache (matches the
+            // WF InputFormRef.cs Comment-cache pattern). Comments are keyed
+            // by the entry's byte address.
+            if (CoreState.CommentCache != null
+                && CoreState.CommentCache.TryGetValue(addr, out string commentValue))
+            {
+                Comment = commentValue ?? "";
+            }
+            else
+            {
+                Comment = "";
+            }
+
             IsLoaded = true;
         }
 
@@ -172,6 +425,25 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 ["B16"] = AI1Primary, ["B17"] = AI2Secondary, ["B18"] = AI3TargetRecovery, ["B19"] = AI4Retreat,
             };
             EditorFormRef.WriteFields(rom, addr, values, Fields);
+
+            // Persist the Comment to CoreState.CommentCache. The cache is a
+            // separate annotation store and lives OUTSIDE the ROM undo
+            // scope by precedent (ImagePortraitFE6View.WriteButton_Click,
+            // ImageBattleBGViewModel.WriteCommentToCache, PR #522).
+            CoreState.CommentCache?.Update(addr, Comment ?? "");
+        }
+
+        /// <summary>
+        /// Returns the localized FE8 Item Drop status string for the given
+        /// W4 (UnitPos) value. Mirrors WF EventUnitForm.UpdateItemDropLabel:
+        /// the drop bit is <c>ext &amp; 0x2</c> where ext = bits 12-14 of W4.
+        /// Pure UI affordance; ROM is read-only.
+        /// </summary>
+        public static string ComputeItemDropDisplay(uint w4Word)
+        {
+            uint ext = U.ParseFe8UnitPosExt(w4Word);
+            bool drops = (ext & 0x2) == 0x2;
+            return drops ? R._("Item Drop: drops") : R._("Item Drop: doesn't drop");
         }
 
         public int GetListCount() => LoadList().Count;

--- a/FEBuilderGBA.Avalonia/ViewModels/EventUnitViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EventUnitViewModel.cs
@@ -62,7 +62,6 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         string _className = "";
         string _item1Name = "", _item2Name = "", _item3Name = "", _item4Name = "";
         string _ai1Desc = "", _ai2Desc = "", _ai3Desc = "", _ai4Desc = "";
-        string _itemDropDisplay = "";
 
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
@@ -135,18 +134,16 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public string AI4Desc { get => _ai4Desc; set => SetField(ref _ai4Desc, value); }
 
         /// <summary>
-        /// Item-drop display string mirroring WF X_ITEMDROP label. Computed
-        /// from the current W4 (UnitPos) ext bit; <see cref="UnitGrowth"/>
-        /// setter raises <c>PropertyChanged(nameof(ItemDropDisplay))</c> so
-        /// bound controls refresh in lockstep with the underlying byte.
+        /// Item-drop display string mirroring WF X_ITEMDROP label. Get-only
+        /// computed property — the canonical source is the W4 ext bit;
+        /// <see cref="UnitGrowth"/> setter raises
+        /// <c>PropertyChanged(nameof(ItemDropDisplay))</c> via
+        /// <c>RefreshItemDropDisplay</c> so bound controls refresh in
+        /// lockstep with the underlying byte (Copilot bot review on PR
+        /// #540: a setter would be dead code since reads come from
+        /// <c>_unitGrowth</c> not from a cached backing field).
         /// </summary>
-        public string ItemDropDisplay
-        {
-            get => ComputeItemDropDisplay(_unitGrowth);
-            // Setter retained for legacy callers but is a no-op aside from
-            // notification — the canonical source is the W4 ext bit.
-            set => _itemDropDisplay = value;
-        }
+        public string ItemDropDisplay => ComputeItemDropDisplay(_unitGrowth);
 
         /// <summary>
         /// User annotation persisted through <c>CoreState.CommentCache</c>

--- a/FEBuilderGBA.Avalonia/Views/EventUnitView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventUnitView.axaml
@@ -2,31 +2,35 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
         x:Class="FEBuilderGBA.Avalonia.Views.EventUnitView"
-        Title="Event Unit Placement" Width="1730" Height="1052"
+        Title="Event Unit Placement" Width="1902" Height="1047"
         SizeToContent="WidthAndHeight">
-  <Grid ColumnDefinitions="220,220,220,*">
+  <Grid ColumnDefinitions="220,220,260,*">
 
-    <!-- Level 1: Map List -->
+    <!-- Level 1: Map Names list (mirrors WF MAP_LISTBOX) -->
     <DockPanel Grid.Column="0" Margin="4">
-      <TextBlock DockPanel.Dock="Top" Text="Maps" FontWeight="Bold" Margin="0,0,0,4" />
+      <TextBlock DockPanel.Dock="Top" Text="Map Names" FontWeight="Bold" Margin="0,0,0,4" />
       <ListBox AutomationProperties.AutomationId="EventUnit_MapList_List" Name="MapListBox" />
     </DockPanel>
 
-    <!-- Level 2: Unit Group List -->
+    <!-- Level 2: Event Names list + New Allocation (mirrors WF EVENT_LISTBOX + NewButton) -->
     <DockPanel Grid.Column="1" Margin="4">
-      <TextBlock DockPanel.Dock="Top" Text="Unit Groups" FontWeight="Bold" Margin="0,0,0,4" />
+      <TextBlock DockPanel.Dock="Top" Text="Event Names" FontWeight="Bold" Margin="0,0,0,4" />
+      <Button AutomationProperties.AutomationId="EventUnit_NewAlloc_Button"
+              DockPanel.Dock="Bottom" Content="New Allocation" Name="NewAllocBtn" Click="NewAlloc_Click" Margin="0,4,0,0" />
       <ListBox AutomationProperties.AutomationId="EventUnit_GroupList_List" Name="GroupListBox" />
     </DockPanel>
 
-    <!-- Level 3: Unit List -->
+    <!-- Level 3: Names list + Expand List (mirrors WF AddressList + AddressListExpandsButton) -->
     <DockPanel Grid.Column="2" Margin="4">
       <StackPanel DockPanel.Dock="Top" Spacing="4" Margin="0,0,0,4">
-        <TextBlock Text="Units" FontWeight="Bold" />
+        <TextBlock Text="Names" FontWeight="Bold" />
         <StackPanel Orientation="Horizontal" Spacing="4">
           <TextBox AutomationProperties.AutomationId="EventUnit_ManualAddr_Input" Name="ManualAddrBox" Width="120" Watermark="0x Address" />
           <Button AutomationProperties.AutomationId="EventUnit_LoadAddrBtn_Button" Content="Load" Name="LoadAddrBtn" Click="LoadAddr_Click" />
         </StackPanel>
       </StackPanel>
+      <Button AutomationProperties.AutomationId="EventUnit_ExpandList_Button"
+              DockPanel.Dock="Bottom" Content="Expand List" Name="ExpandListBtn" Click="ExpandList_Click" Margin="0,4,0,0" />
       <ListBox AutomationProperties.AutomationId="EventUnit_UnitList_List" Name="UnitListBox" />
     </DockPanel>
 
@@ -35,83 +39,137 @@
       <StackPanel Spacing="6" Margin="8">
         <TextBlock Text="Event Unit Placement (FE8)" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="160,120,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+        <!-- Top read-config bar (mirrors WF panel1) -->
+        <Border BorderBrush="Gray" BorderThickness="1" Padding="6">
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <TextBlock Text="Top Address" VerticalAlignment="Center" />
+            <TextBox AutomationProperties.AutomationId="EventUnit_TopAddr_Input" Name="TopAddrBox" Width="160" IsReadOnly="True" />
+            <TextBlock Text="Read Count" VerticalAlignment="Center" Margin="12,0,0,0" />
+            <NumericUpDown AutomationProperties.AutomationId="EventUnit_ReadCount_Input" FormatString="0" Name="ReadCountBox" Minimum="0" Maximum="999" Width="100" IsReadOnly="True" />
+            <Button AutomationProperties.AutomationId="EventUnit_ReloadList_Button" Content="Reload" Name="ReloadListBtn" Click="ReloadList_Click" Margin="12,0,0,0" />
+          </StackPanel>
+        </Border>
+
+        <Grid ColumnDefinitions="160,120,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
           <!-- Address -->
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,2" />
           <TextBlock AutomationProperties.AutomationId="EventUnit_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" Margin="0,2" />
 
-          <!-- Unit ID -->
-          <TextBlock Grid.Row="1" Grid.Column="0" Text="Unit ID:" VerticalAlignment="Center" Margin="0,2" />
+          <!-- Unit Number -->
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="Unit Number:" VerticalAlignment="Center" Margin="0,2" />
           <NumericUpDown AutomationProperties.AutomationId="EventUnit_UnitID_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="UnitIDBox" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
           <TextBlock AutomationProperties.AutomationId="EventUnit_UnitName_Label" Grid.Row="1" Grid.Column="2" Name="UnitNameLabel" VerticalAlignment="Center" Margin="8,2,0,2" Foreground="Gray" />
 
-          <!-- Class ID -->
-          <TextBlock Grid.Row="2" Grid.Column="0" Text="Class ID:" VerticalAlignment="Center" Margin="0,2" />
+          <!-- Class -->
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Class:" VerticalAlignment="Center" Margin="0,2" />
           <NumericUpDown AutomationProperties.AutomationId="EventUnit_ClassID_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="ClassIDBox" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="EventUnit_ClassName_Label" Grid.Row="2" Grid.Column="2" Name="ClassNameLabel" VerticalAlignment="Center" Margin="8,2,0,2" Foreground="Gray" />
+          <StackPanel Grid.Row="2" Grid.Column="2" Orientation="Horizontal" Spacing="6" Margin="8,2,0,2">
+            <TextBlock AutomationProperties.AutomationId="EventUnit_ClassName_Label" Name="ClassNameLabel" VerticalAlignment="Center" Foreground="Gray" />
+            <Button AutomationProperties.AutomationId="EventUnit_JumpMonsterProb_Button" Content="Random Monster" Name="JumpMonsterProbBtn" Click="JumpMonsterProb_Click" Margin="10,0,0,0" />
+          </StackPanel>
 
-          <!-- Leader Unit ID -->
-          <TextBlock Grid.Row="3" Grid.Column="0" Text="Leader Unit ID:" VerticalAlignment="Center" Margin="0,2" />
+          <!-- Commander (LeaderUnitID) -->
+          <TextBlock Grid.Row="3" Grid.Column="0" Text="Commander:" VerticalAlignment="Center" Margin="0,2" />
           <NumericUpDown AutomationProperties.AutomationId="EventUnit_LeaderUnitID_Input" FormatString="0" Grid.Row="3" Grid.Column="1" Name="LeaderUnitIDBox" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
 
-          <!-- Unit Info -->
+          <!-- Unit Info (B3) sub-panel (LV / Allegiance / Growth Rate / raw B3) -->
           <TextBlock Grid.Row="4" Grid.Column="0" Text="Unit Info:" VerticalAlignment="Center" Margin="0,2" />
           <NumericUpDown AutomationProperties.AutomationId="EventUnit_UnitInfo_Input" FormatString="0" Grid.Row="4" Grid.Column="1" Name="UnitInfoBox" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
+          <StackPanel Grid.Row="4" Grid.Column="2" Orientation="Horizontal" Spacing="6" Margin="8,2,0,2">
+            <TextBlock Text="LV:" VerticalAlignment="Center" />
+            <NumericUpDown AutomationProperties.AutomationId="EventUnit_LV_Input" FormatString="0" Name="LVBox" Minimum="0" Maximum="31" Width="80" />
+            <TextBlock Text="Allegiance:" VerticalAlignment="Center" Margin="8,0,0,0" />
+            <ComboBox AutomationProperties.AutomationId="EventUnit_Allegiance_Combo" Name="AllegianceCombo" Width="120" />
+            <TextBlock Text="Growth Rate:" VerticalAlignment="Center" Margin="8,0,0,0" />
+            <ComboBox AutomationProperties.AutomationId="EventUnit_GrowthRate_Combo" Name="GrowthRateCombo" Width="140" />
+          </StackPanel>
 
-          <!-- Unit Growth -->
-          <TextBlock Grid.Row="5" Grid.Column="0" Text="Unit Growth:" VerticalAlignment="Center" Margin="0,2" />
+          <!-- W4 (UnitPos) sub-panel (BeforeX/BeforeY/ItemDrop/raw W4) -->
+          <TextBlock Grid.Row="5" Grid.Column="0" Text="Before Coordinates:" VerticalAlignment="Center" Margin="0,2" />
           <NumericUpDown AutomationProperties.AutomationId="EventUnit_UnitGrowth_Input" FormatString="0" Grid.Row="5" Grid.Column="1" Name="UnitGrowthBox" Minimum="0" Maximum="65535" Width="120" HorizontalAlignment="Left" Margin="0,2" />
+          <StackPanel Grid.Row="5" Grid.Column="2" Orientation="Horizontal" Spacing="6" Margin="8,2,0,2">
+            <TextBlock Text="X:" VerticalAlignment="Center" />
+            <NumericUpDown AutomationProperties.AutomationId="EventUnit_BeforeX_Input" FormatString="0" Name="BeforeXBox" Minimum="0" Maximum="63" Width="80" />
+            <TextBlock Text="Y:" VerticalAlignment="Center" Margin="6,0,0,0" />
+            <NumericUpDown AutomationProperties.AutomationId="EventUnit_BeforeY_Input" FormatString="0" Name="BeforeYBox" Minimum="0" Maximum="63" Width="80" />
+            <CheckBox AutomationProperties.AutomationId="EventUnit_ItemDropFlag_Check" Content="Drop Item" Name="ItemDropCheck" Margin="10,0,0,0" />
+          </StackPanel>
+
+          <!-- After-coords read-only (B7 count + D8 pointer) -->
+          <TextBlock Grid.Row="6" Grid.Column="0" Text="After Coordinates:" VerticalAlignment="Center" Margin="0,2" />
+          <StackPanel Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="6" Margin="0,2">
+            <TextBlock Text="Count:" VerticalAlignment="Center" />
+            <NumericUpDown AutomationProperties.AutomationId="EventUnit_CoordCount_Input" FormatString="0" Name="CoordCountBox" Minimum="0" Maximum="255" Width="80" IsReadOnly="True" />
+            <TextBlock Text="Pointer:" VerticalAlignment="Center" Margin="6,0,0,0" />
+            <TextBox AutomationProperties.AutomationId="EventUnit_CoordPointer_Input" Name="CoordPointerBox" Width="120" IsReadOnly="True" />
+          </StackPanel>
 
           <!-- Reserved -->
-          <TextBlock Grid.Row="6" Grid.Column="0" Text="Reserved (0x06):" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="EventUnit_Reserved6_Input" FormatString="0" Grid.Row="6" Grid.Column="1" Name="Reserved6Box" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
-
-          <!-- Coord Count -->
-          <TextBlock Grid.Row="7" Grid.Column="0" Text="Coord Count:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="EventUnit_CoordCount_Input" FormatString="0" Grid.Row="7" Grid.Column="1" Name="CoordCountBox" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
-
-          <!-- Coord Pointer -->
-          <TextBlock Grid.Row="8" Grid.Column="0" Text="Coord Pointer:" VerticalAlignment="Center" Margin="0,2" />
-          <TextBox AutomationProperties.AutomationId="EventUnit_CoordPointer_Input" Grid.Row="8" Grid.Column="1" Name="CoordPointerBox" Width="120" HorizontalAlignment="Left" Margin="0,2" />
+          <TextBlock Grid.Row="7" Grid.Column="0" Text="Reserved (0x06):" VerticalAlignment="Center" Margin="0,2" />
+          <NumericUpDown AutomationProperties.AutomationId="EventUnit_Reserved6_Input" FormatString="0" Grid.Row="7" Grid.Column="1" Name="Reserved6Box" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
 
           <!-- Items -->
-          <TextBlock Grid.Row="9" Grid.Column="0" Text="Item 1:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="EventUnit_Item1_Input" FormatString="0" Grid.Row="9" Grid.Column="1" Name="Item1Box" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="EventUnit_Item1Name_Label" Grid.Row="9" Grid.Column="2" Name="Item1NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" Foreground="Gray" />
+          <TextBlock Grid.Row="8" Grid.Column="0" Text="Item 1:" VerticalAlignment="Center" Margin="0,2" />
+          <NumericUpDown AutomationProperties.AutomationId="EventUnit_Item1_Input" FormatString="0" Grid.Row="8" Grid.Column="1" Name="Item1Box" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
+          <TextBlock AutomationProperties.AutomationId="EventUnit_Item1Name_Label" Grid.Row="8" Grid.Column="2" Name="Item1NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" Foreground="Gray" />
 
-          <TextBlock Grid.Row="10" Grid.Column="0" Text="Item 2:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="EventUnit_Item2_Input" FormatString="0" Grid.Row="10" Grid.Column="1" Name="Item2Box" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="EventUnit_Item2Name_Label" Grid.Row="10" Grid.Column="2" Name="Item2NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" Foreground="Gray" />
+          <TextBlock Grid.Row="9" Grid.Column="0" Text="Item 2:" VerticalAlignment="Center" Margin="0,2" />
+          <NumericUpDown AutomationProperties.AutomationId="EventUnit_Item2_Input" FormatString="0" Grid.Row="9" Grid.Column="1" Name="Item2Box" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
+          <TextBlock AutomationProperties.AutomationId="EventUnit_Item2Name_Label" Grid.Row="9" Grid.Column="2" Name="Item2NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" Foreground="Gray" />
 
-          <TextBlock Grid.Row="11" Grid.Column="0" Text="Item 3:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="EventUnit_Item3_Input" FormatString="0" Grid.Row="11" Grid.Column="1" Name="Item3Box" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="EventUnit_Item3Name_Label" Grid.Row="11" Grid.Column="2" Name="Item3NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" Foreground="Gray" />
+          <TextBlock Grid.Row="10" Grid.Column="0" Text="Item 3:" VerticalAlignment="Center" Margin="0,2" />
+          <NumericUpDown AutomationProperties.AutomationId="EventUnit_Item3_Input" FormatString="0" Grid.Row="10" Grid.Column="1" Name="Item3Box" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
+          <TextBlock AutomationProperties.AutomationId="EventUnit_Item3Name_Label" Grid.Row="10" Grid.Column="2" Name="Item3NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" Foreground="Gray" />
 
-          <TextBlock Grid.Row="12" Grid.Column="0" Text="Item 4:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="EventUnit_Item4_Input" FormatString="0" Grid.Row="12" Grid.Column="1" Name="Item4Box" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="EventUnit_Item4Name_Label" Grid.Row="12" Grid.Column="2" Name="Item4NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" Foreground="Gray" />
+          <TextBlock Grid.Row="11" Grid.Column="0" Text="Item 4:" VerticalAlignment="Center" Margin="0,2" />
+          <NumericUpDown AutomationProperties.AutomationId="EventUnit_Item4_Input" FormatString="0" Grid.Row="11" Grid.Column="1" Name="Item4Box" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
+          <TextBlock AutomationProperties.AutomationId="EventUnit_Item4Name_Label" Grid.Row="11" Grid.Column="2" Name="Item4NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" Foreground="Gray" />
 
-          <!-- AI -->
-          <TextBlock Grid.Row="13" Grid.Column="0" Text="AI1 Primary:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="EventUnit_AI1Primary_Input" FormatString="0" Grid.Row="13" Grid.Column="1" Name="AI1PrimaryBox" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="EventUnit_AI1Desc_Label" Grid.Row="13" Grid.Column="2" Name="AI1DescLabel" VerticalAlignment="Center" Margin="8,2,0,2" Foreground="Gray" />
+          <!-- AI rows -->
+          <TextBlock Grid.Row="12" Grid.Column="0" Text="Primary AI:" VerticalAlignment="Center" Margin="0,2" />
+          <NumericUpDown AutomationProperties.AutomationId="EventUnit_AI1Primary_Input" FormatString="0" Grid.Row="12" Grid.Column="1" Name="AI1PrimaryBox" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
+          <TextBlock AutomationProperties.AutomationId="EventUnit_AI1Desc_Label" Grid.Row="12" Grid.Column="2" Name="AI1DescLabel" VerticalAlignment="Center" Margin="8,2,0,2" Foreground="Gray" />
 
-          <TextBlock Grid.Row="14" Grid.Column="0" Text="AI2 Secondary:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="EventUnit_AI2Secondary_Input" FormatString="0" Grid.Row="14" Grid.Column="1" Name="AI2SecondaryBox" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="EventUnit_AI2Desc_Label" Grid.Row="14" Grid.Column="2" Name="AI2DescLabel" VerticalAlignment="Center" Margin="8,2,0,2" Foreground="Gray" />
+          <TextBlock Grid.Row="13" Grid.Column="0" Text="Secondary AI:" VerticalAlignment="Center" Margin="0,2" />
+          <NumericUpDown AutomationProperties.AutomationId="EventUnit_AI2Secondary_Input" FormatString="0" Grid.Row="13" Grid.Column="1" Name="AI2SecondaryBox" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
+          <TextBlock AutomationProperties.AutomationId="EventUnit_AI2Desc_Label" Grid.Row="13" Grid.Column="2" Name="AI2DescLabel" VerticalAlignment="Center" Margin="8,2,0,2" Foreground="Gray" />
 
-          <TextBlock Grid.Row="15" Grid.Column="0" Text="AI3 Target/Recovery:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="EventUnit_AI3TargetRecovery_Input" FormatString="0" Grid.Row="15" Grid.Column="1" Name="AI3TargetRecoveryBox" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="EventUnit_AI3Desc_Label" Grid.Row="15" Grid.Column="2" Name="AI3DescLabel" VerticalAlignment="Center" Margin="8,2,0,2" Foreground="Gray" />
+          <TextBlock Grid.Row="14" Grid.Column="0" Text="Target/Recovery AI:" VerticalAlignment="Center" Margin="0,2" />
+          <NumericUpDown AutomationProperties.AutomationId="EventUnit_AI3TargetRecovery_Input" FormatString="0" Grid.Row="14" Grid.Column="1" Name="AI3TargetRecoveryBox" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
+          <TextBlock AutomationProperties.AutomationId="EventUnit_AI3Desc_Label" Grid.Row="14" Grid.Column="2" Name="AI3DescLabel" VerticalAlignment="Center" Margin="8,2,0,2" Foreground="Gray" />
 
-          <TextBlock Grid.Row="16" Grid.Column="0" Text="AI4 Retreat:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="EventUnit_AI4Retreat_Input" FormatString="0" Grid.Row="16" Grid.Column="1" Name="AI4RetreatBox" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="EventUnit_AI4Desc_Label" Grid.Row="16" Grid.Column="2" Name="AI4DescLabel" VerticalAlignment="Center" Margin="8,2,0,2" Foreground="Gray" />
+          <TextBlock Grid.Row="15" Grid.Column="0" Text="Retreat AI:" VerticalAlignment="Center" Margin="0,2" />
+          <NumericUpDown AutomationProperties.AutomationId="EventUnit_AI4Retreat_Input" FormatString="0" Grid.Row="15" Grid.Column="1" Name="AI4RetreatBox" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
+          <TextBlock AutomationProperties.AutomationId="EventUnit_AI4Desc_Label" Grid.Row="15" Grid.Column="2" Name="AI4DescLabel" VerticalAlignment="Center" Margin="8,2,0,2" Foreground="Gray" />
+
+          <!-- Comment row -->
+          <TextBlock Grid.Row="16" Grid.Column="0" Text="Comment:" VerticalAlignment="Center" Margin="0,2" />
+          <TextBox AutomationProperties.AutomationId="EventUnit_Comment_Input" Grid.Row="16" Grid.Column="1" Grid.ColumnSpan="2" Name="CommentBox" Margin="0,2" />
         </Grid>
 
-        <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
-          <Button AutomationProperties.AutomationId="EventUnit_WriteBtn_Button" Content="Write" Name="WriteBtn" Click="Write_Click" />
-        </StackPanel>
+        <!-- Address bar (Size / Selected Address / Write) -->
+        <Border BorderBrush="Gray" BorderThickness="1" Padding="6">
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <TextBlock Text="Size:" VerticalAlignment="Center" />
+            <TextBox AutomationProperties.AutomationId="EventUnit_BlockSize_Input" Name="BlockSizeBox" Width="80" IsReadOnly="True" Text="0x14" />
+            <TextBlock Text="Selected Address:" VerticalAlignment="Center" Margin="12,0,0,0" />
+            <TextBox AutomationProperties.AutomationId="EventUnit_SelectedAddr_Input" Name="SelectedAddrBox" Width="160" IsReadOnly="True" />
+            <Button AutomationProperties.AutomationId="EventUnit_WriteBtn_Button" Content="Write" Name="WriteBtn" Click="Write_Click" Margin="12,0,0,0" />
+          </StackPanel>
+        </Border>
+
+        <!-- Jump panel (mirrors WF panel10) + Item Drop display + dialog launcher -->
+        <Border BorderBrush="Gray" BorderThickness="1" Padding="6">
+          <StackPanel Spacing="6">
+            <StackPanel Orientation="Horizontal" Spacing="8">
+              <Button AutomationProperties.AutomationId="EventUnit_JumpBattleTalk_Button" Content="Battle Talk Jump" Name="JumpBattleTalkBtn" Click="JumpBattleTalk_Click" />
+              <Button AutomationProperties.AutomationId="EventUnit_JumpBattleBGM_Button" Content="Battle BGM Jump" Name="JumpBattleBGMBtn" Click="JumpBattleBGM_Click" />
+              <Button AutomationProperties.AutomationId="EventUnit_JumpHaiku_Button" Content="Death Quote Jump" Name="JumpHaikuBtn" Click="JumpHaiku_Click" />
+              <Button AutomationProperties.AutomationId="EventUnit_ItemDropDialog_Button" Content="Item Drop Dialog..." Name="ItemDropDialogBtn" Click="ItemDropDialog_Click" />
+            </StackPanel>
+            <TextBlock AutomationProperties.AutomationId="EventUnit_ItemDrop_Label" Name="ItemDropLabel" Foreground="Gray" />
+          </StackPanel>
+        </Border>
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/EventUnitView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventUnitView.axaml.cs
@@ -184,7 +184,18 @@ namespace FEBuilderGBA.Avalonia.Views
                     return;
                 }
                 TopAddrBox.Text = string.Format("0x{0:X08}", addr);
-                LoadUnitsFromAddress(addr);
+                // Manual-load path: use LoadUnitListFromAddress so the VM
+                // clears SelectedMapId (otherwise BattleTalk/Haiku jumps
+                // and ExpandList resolve against a stale map selection —
+                // Copilot bot review round 3 on PR #540).
+                _unitItems = _vm.LoadUnitListFromAddress(addr);
+                _unitDisplayItems.Clear();
+                foreach (var item in _unitItems)
+                    _unitDisplayItems.Add(item.name);
+                ReadCountBox.Value = _unitItems.Count;
+                ClearDetail();
+                if (_unitItems.Count > 0)
+                    UnitListBox.SelectedIndex = 0;
             }
             catch (Exception ex)
             {
@@ -213,6 +224,12 @@ namespace FEBuilderGBA.Avalonia.Views
             AI4DescLabel.Text = "";
             ItemDropLabel.Text = "";
             CommentBox.Text = "";
+            // Reset VM loaded state so Write_Click cannot commit changes
+            // against a stale CurrentAddr after the user moves to an empty
+            // group (Copilot bot review round 3 on PR #540: WriteEntry
+            // only guards CurrentAddr==0, so we must reset it here).
+            _vm.IsLoaded = false;
+            _vm.CurrentAddr = 0;
         }
 
         void UpdateUI()

--- a/FEBuilderGBA.Avalonia/Views/EventUnitView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventUnitView.axaml.cs
@@ -24,6 +24,8 @@ namespace FEBuilderGBA.Avalonia.Views
         public string ViewTitle => "Event Unit Placement";
         public bool IsLoaded => _vm.IsLoaded;
 
+        bool _suppressUiSync;
+
         public EventUnitView()
         {
             InitializeComponent();
@@ -34,6 +36,37 @@ namespace FEBuilderGBA.Avalonia.Views
             MapListBox.SelectionChanged += MapListBox_SelectionChanged;
             GroupListBox.SelectionChanged += GroupListBox_SelectionChanged;
             UnitListBox.SelectionChanged += UnitListBox_SelectionChanged;
+
+            // Populate combos with R._-translated entries so ja/zh users
+            // see localised labels.
+            AllegianceCombo.ItemsSource = new[]
+            {
+                R._("Player"),
+                R._("Ally"),
+                R._("Enemy"),
+                R._("Disappear"),
+            };
+            GrowthRateCombo.ItemsSource = new[]
+            {
+                R._("No Growth"),
+                R._("Class Dependent"),
+            };
+
+            // Wire B3 sub-field combos to live-update UnitInfoBox via the VM.
+            LVBox.ValueChanged += LVBox_ValueChanged;
+            AllegianceCombo.SelectionChanged += AllegianceCombo_SelectionChanged;
+            GrowthRateCombo.SelectionChanged += GrowthRateCombo_SelectionChanged;
+            // Wire the raw UnitInfoBox so that direct edits to the byte
+            // refresh the LV/Allegiance/Growth Rate sub-controls.
+            UnitInfoBox.ValueChanged += UnitInfoBox_ValueChanged;
+
+            // Wire W4 (UnitPos) sub-field controls. BeforeX/BeforeY/
+            // ItemDrop edits recompose the UnitGrowthBox raw word, and
+            // direct edits to UnitGrowthBox refresh the sub-controls.
+            BeforeXBox.ValueChanged += BeforeXBox_ValueChanged;
+            BeforeYBox.ValueChanged += BeforeYBox_ValueChanged;
+            ItemDropCheck.IsCheckedChanged += ItemDropCheck_IsCheckedChanged;
+            UnitGrowthBox.ValueChanged += UnitGrowthBox_ValueChanged;
 
             Opened += (_, _) => LoadMapList();
         }
@@ -46,6 +79,8 @@ namespace FEBuilderGBA.Avalonia.Views
                 _mapDisplayItems.Clear();
                 foreach (var item in _mapItems)
                     _mapDisplayItems.Add(item.name);
+
+                ReadCountBox.Value = _mapItems.Count;
 
                 if (_mapItems.Count > 0)
                     MapListBox.SelectedIndex = 0;
@@ -90,6 +125,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (idx < 0 || idx >= _groupItems.Count) return;
 
                 uint groupAddr = _groupItems[idx].addr;
+                TopAddrBox.Text = string.Format("0x{0:X08}", groupAddr);
                 LoadUnitsFromAddress(groupAddr);
             }
             catch (Exception ex)
@@ -138,6 +174,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     Log.Error("EventUnitView: Invalid address {0}", text);
                     return;
                 }
+                TopAddrBox.Text = string.Format("0x{0:X08}", addr);
                 LoadUnitsFromAddress(addr);
             }
             catch (Exception ex)
@@ -146,9 +183,15 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
+        void ReloadList_Click(object? sender, RoutedEventArgs e)
+        {
+            LoadMapList();
+        }
+
         void ClearDetail()
         {
             AddrLabel.Text = "";
+            SelectedAddrBox.Text = "";
             UnitNameLabel.Text = "";
             ClassNameLabel.Text = "";
             Item1NameLabel.Text = "";
@@ -159,39 +202,54 @@ namespace FEBuilderGBA.Avalonia.Views
             AI2DescLabel.Text = "";
             AI3DescLabel.Text = "";
             AI4DescLabel.Text = "";
+            ItemDropLabel.Text = "";
+            CommentBox.Text = "";
         }
 
         void UpdateUI()
         {
-            AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
-            UnitIDBox.Value = _vm.UnitID;
-            ClassIDBox.Value = _vm.ClassID;
-            LeaderUnitIDBox.Value = _vm.LeaderUnitID;
-            UnitInfoBox.Value = _vm.UnitInfo;
-            UnitGrowthBox.Value = _vm.UnitGrowth;
-            Reserved6Box.Value = _vm.Reserved6;
-            CoordCountBox.Value = _vm.CoordCount;
-            CoordPointerBox.Text = string.Format("0x{0:X08}", _vm.CoordPointer);
-            Item1Box.Value = _vm.Item1;
-            Item2Box.Value = _vm.Item2;
-            Item3Box.Value = _vm.Item3;
-            Item4Box.Value = _vm.Item4;
-            AI1PrimaryBox.Value = _vm.AI1Primary;
-            AI2SecondaryBox.Value = _vm.AI2Secondary;
-            AI3TargetRecoveryBox.Value = _vm.AI3TargetRecovery;
-            AI4RetreatBox.Value = _vm.AI4Retreat;
+            _suppressUiSync = true;
+            try
+            {
+                AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+                SelectedAddrBox.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+                UnitIDBox.Value = _vm.UnitID;
+                ClassIDBox.Value = _vm.ClassID;
+                LeaderUnitIDBox.Value = _vm.LeaderUnitID;
+                UnitInfoBox.Value = _vm.UnitInfo;
+                LVBox.Value = _vm.UnitInfoLV;
+                AllegianceCombo.SelectedIndex = (int)_vm.UnitInfoAllegiance;
+                GrowthRateCombo.SelectedIndex = (int)_vm.UnitInfoGrow;
+                UnitGrowthBox.Value = _vm.UnitGrowth;
+                BeforeXBox.Value = _vm.BeforeX;
+                BeforeYBox.Value = _vm.BeforeY;
+                ItemDropCheck.IsChecked = _vm.ItemDropFlag;
+                Reserved6Box.Value = _vm.Reserved6;
+                CoordCountBox.Value = _vm.CoordCount;
+                CoordPointerBox.Text = string.Format("0x{0:X08}", _vm.CoordPointer);
+                Item1Box.Value = _vm.Item1;
+                Item2Box.Value = _vm.Item2;
+                Item3Box.Value = _vm.Item3;
+                Item4Box.Value = _vm.Item4;
+                AI1PrimaryBox.Value = _vm.AI1Primary;
+                AI2SecondaryBox.Value = _vm.AI2Secondary;
+                AI3TargetRecoveryBox.Value = _vm.AI3TargetRecovery;
+                AI4RetreatBox.Value = _vm.AI4Retreat;
+                CommentBox.Text = _vm.Comment ?? "";
 
-            // Name labels
-            UnitNameLabel.Text = _vm.UnitName;
-            ClassNameLabel.Text = _vm.ClassName;
-            Item1NameLabel.Text = _vm.Item1Name;
-            Item2NameLabel.Text = _vm.Item2Name;
-            Item3NameLabel.Text = _vm.Item3Name;
-            Item4NameLabel.Text = _vm.Item4Name;
-            AI1DescLabel.Text = _vm.AI1Desc;
-            AI2DescLabel.Text = _vm.AI2Desc;
-            AI3DescLabel.Text = _vm.AI3Desc;
-            AI4DescLabel.Text = _vm.AI4Desc;
+                UnitNameLabel.Text = _vm.UnitName;
+                ClassNameLabel.Text = _vm.ClassName;
+                Item1NameLabel.Text = _vm.Item1Name;
+                Item2NameLabel.Text = _vm.Item2Name;
+                Item3NameLabel.Text = _vm.Item3Name;
+                Item4NameLabel.Text = _vm.Item4Name;
+                AI1DescLabel.Text = _vm.AI1Desc;
+                AI2DescLabel.Text = _vm.AI2Desc;
+                AI3DescLabel.Text = _vm.AI3Desc;
+                AI4DescLabel.Text = _vm.AI4Desc;
+                ItemDropLabel.Text = _vm.ItemDropDisplay;
+            }
+            finally { _suppressUiSync = false; }
         }
 
         void ReadFromUI()
@@ -212,6 +270,7 @@ namespace FEBuilderGBA.Avalonia.Views
             _vm.AI2Secondary = (uint)(AI2SecondaryBox.Value ?? 0);
             _vm.AI3TargetRecovery = (uint)(AI3TargetRecoveryBox.Value ?? 0);
             _vm.AI4Retreat = (uint)(AI4RetreatBox.Value ?? 0);
+            _vm.Comment = CommentBox.Text ?? "";
         }
 
         void Write_Click(object? sender, RoutedEventArgs e)
@@ -228,6 +287,295 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 _undoService.Rollback();
                 Log.Error("EventUnitView.Write failed: {0}", ex.Message);
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // B3 sub-field two-way sync (LV / Allegiance / Growth Rate <-> UnitInfo)
+        // ---------------------------------------------------------------
+
+        void LVBox_ValueChanged(object? sender, global::Avalonia.Controls.NumericUpDownValueChangedEventArgs e)
+        {
+            if (_suppressUiSync) return;
+            _suppressUiSync = true;
+            try
+            {
+                _vm.UnitInfoLV = (uint)(LVBox.Value ?? 0);
+                UnitInfoBox.Value = _vm.UnitInfo;
+            }
+            finally { _suppressUiSync = false; }
+        }
+
+        void AllegianceCombo_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressUiSync) return;
+            int idx = AllegianceCombo.SelectedIndex;
+            if (idx < 0) return;
+            _suppressUiSync = true;
+            try
+            {
+                _vm.UnitInfoAllegiance = (uint)idx;
+                UnitInfoBox.Value = _vm.UnitInfo;
+            }
+            finally { _suppressUiSync = false; }
+        }
+
+        void GrowthRateCombo_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressUiSync) return;
+            int idx = GrowthRateCombo.SelectedIndex;
+            if (idx < 0) return;
+            _suppressUiSync = true;
+            try
+            {
+                _vm.UnitInfoGrow = (uint)idx;
+                UnitInfoBox.Value = _vm.UnitInfo;
+            }
+            finally { _suppressUiSync = false; }
+        }
+
+        void UnitInfoBox_ValueChanged(object? sender, global::Avalonia.Controls.NumericUpDownValueChangedEventArgs e)
+        {
+            if (_suppressUiSync) return;
+            _suppressUiSync = true;
+            try
+            {
+                _vm.UnitInfo = (uint)(UnitInfoBox.Value ?? 0);
+                LVBox.Value = _vm.UnitInfoLV;
+                AllegianceCombo.SelectedIndex = (int)_vm.UnitInfoAllegiance;
+                GrowthRateCombo.SelectedIndex = (int)_vm.UnitInfoGrow;
+            }
+            finally { _suppressUiSync = false; }
+        }
+
+        // ---------------------------------------------------------------
+        // W4 sub-field two-way sync (BeforeX / BeforeY / ItemDrop <-> UnitGrowth)
+        // ---------------------------------------------------------------
+
+        void BeforeXBox_ValueChanged(object? sender, global::Avalonia.Controls.NumericUpDownValueChangedEventArgs e)
+        {
+            if (_suppressUiSync) return;
+            _suppressUiSync = true;
+            try
+            {
+                _vm.BeforeX = (uint)(BeforeXBox.Value ?? 0);
+                UnitGrowthBox.Value = _vm.UnitGrowth;
+                ItemDropLabel.Text = _vm.ItemDropDisplay;
+            }
+            finally { _suppressUiSync = false; }
+        }
+
+        void BeforeYBox_ValueChanged(object? sender, global::Avalonia.Controls.NumericUpDownValueChangedEventArgs e)
+        {
+            if (_suppressUiSync) return;
+            _suppressUiSync = true;
+            try
+            {
+                _vm.BeforeY = (uint)(BeforeYBox.Value ?? 0);
+                UnitGrowthBox.Value = _vm.UnitGrowth;
+                ItemDropLabel.Text = _vm.ItemDropDisplay;
+            }
+            finally { _suppressUiSync = false; }
+        }
+
+        void ItemDropCheck_IsCheckedChanged(object? sender, RoutedEventArgs e)
+        {
+            if (_suppressUiSync) return;
+            _suppressUiSync = true;
+            try
+            {
+                _vm.ItemDropFlag = ItemDropCheck.IsChecked == true;
+                UnitGrowthBox.Value = _vm.UnitGrowth;
+                ItemDropLabel.Text = _vm.ItemDropDisplay;
+            }
+            finally { _suppressUiSync = false; }
+        }
+
+        void UnitGrowthBox_ValueChanged(object? sender, global::Avalonia.Controls.NumericUpDownValueChangedEventArgs e)
+        {
+            if (_suppressUiSync) return;
+            _suppressUiSync = true;
+            try
+            {
+                _vm.UnitGrowth = (uint)(UnitGrowthBox.Value ?? 0);
+                BeforeXBox.Value = _vm.BeforeX;
+                BeforeYBox.Value = _vm.BeforeY;
+                ItemDropCheck.IsChecked = _vm.ItemDropFlag;
+                ItemDropLabel.Text = _vm.ItemDropDisplay;
+            }
+            finally { _suppressUiSync = false; }
+        }
+
+        // ---------------------------------------------------------------
+        // Cross-editor jumps. Each click handler dispatches to the Core
+        // search helpers + opens the target Avalonia view with the resolved
+        // address (or pre-selected class id, for MonsterProbability).
+        // ---------------------------------------------------------------
+
+        void JumpBattleTalk_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                uint unitId = (uint)(UnitIDBox.Value ?? 0);
+                uint mapId = _vm.SelectedMapId;
+                ROM rom = CoreState.ROM;
+                if (rom == null) return;
+                uint hitAddr = MapEventUnitCore.FindBattleTalkFE8UnitIdAddress(rom, unitId, mapId);
+                if (hitAddr == 0)
+                {
+                    Log.Notify("EventUnitView.JumpBattleTalk_Click: no BattleTalk entry found for unit " + unitId.ToString());
+                    return;
+                }
+                WindowManager.Instance.Navigate<EventBattleTalkView>(hitAddr);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("EventUnitView.JumpBattleTalk_Click failed: {0}", ex.Message);
+            }
+        }
+
+        void JumpBattleBGM_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                uint unitId = (uint)(UnitIDBox.Value ?? 0);
+                ROM rom = CoreState.ROM;
+                if (rom == null) return;
+                uint hitAddr = MapEventUnitCore.FindBossBGMFE8UnitIdAddress(rom, unitId);
+                if (hitAddr == 0)
+                {
+                    Log.Notify("EventUnitView.JumpBattleBGM_Click: no BossBGM entry found for unit " + unitId.ToString());
+                    return;
+                }
+                WindowManager.Instance.Navigate<SoundBossBGMViewerView>(hitAddr);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("EventUnitView.JumpBattleBGM_Click failed: {0}", ex.Message);
+            }
+        }
+
+        void JumpHaiku_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                uint unitId = (uint)(UnitIDBox.Value ?? 0);
+                uint mapId = _vm.SelectedMapId;
+                ROM rom = CoreState.ROM;
+                if (rom == null) return;
+                uint hitAddr = MapEventUnitCore.FindHaikuFE8Address(rom, unitId, mapId);
+                if (hitAddr == 0)
+                {
+                    Log.Notify("EventUnitView.JumpHaiku_Click: no Haiku entry found for unit " + unitId.ToString());
+                    return;
+                }
+                WindowManager.Instance.Navigate<EventHaikuView>(hitAddr);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("EventUnitView.JumpHaiku_Click failed: {0}", ex.Message);
+            }
+        }
+
+        void JumpMonsterProb_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                // WF: InputFormRef.JumpForm<MonsterProbabilityForm>((uint)this.B1.Value, "AddressList", this.B1)
+                // The class_id (B1) is used as the row index in MonsterProbability's
+                // AddressList for pre-selection. We open the viewer without
+                // an explicit address because the Avalonia equivalent does
+                // not currently expose row-index navigation (tracked as a
+                // known limitation — see PR body).
+                WindowManager.Instance.Open<MonsterProbabilityViewerView>();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("EventUnitView.JumpMonsterProb_Click failed: {0}", ex.Message);
+            }
+        }
+
+        void ItemDropDialog_Click(object? sender, RoutedEventArgs e)
+        {
+            // Open the existing Avalonia EventUnitItemDropView (UX-only
+            // launcher). The canonical Item Drop state is the ItemDropCheck
+            // bound to W4 ext bit 0x2; this dialog mirrors WF's
+            // X_ITEMDROP_Click for users who prefer the modal Yes/No flow.
+            try
+            {
+                WindowManager.Instance.Open<EventUnitItemDropView>();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("EventUnitView.ItemDropDialog_Click failed: {0}", ex.Message);
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // List allocation / expansion handlers (mirror WF NewButton +
+        // AddressListExpandsButton). Each opens a dedicated undo scope so
+        // partial failures roll back cleanly.
+        // ---------------------------------------------------------------
+
+        void NewAlloc_Click(object? sender, RoutedEventArgs e)
+        {
+            // Soft handoff to the existing Avalonia EventUnitNewAllocView
+            // stub — same precedent as FE7 PR #522. The full WF
+            // AllocEvent state machine is tracked as a follow-up to keep
+            // this gap-sweep PR focused on label/jump coverage.
+            Log.Notify("EventUnitView.NewAlloc_Click: opening Unit Allocation editor stub.");
+            try
+            {
+                WindowManager.Instance.Open<EventUnitNewAllocView>();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("EventUnitView.NewAlloc_Click failed: {0}", ex.Message);
+            }
+        }
+
+        void ExpandList_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (_unitItems.Count == 0) return;
+                if (_vm.SelectedUnitListBase == 0)
+                {
+                    Log.Notify("EventUnitView.ExpandList_Click: no unit list selected yet.");
+                    return;
+                }
+
+                _undoService.Begin("Expand Event Unit List FE8");
+                try
+                {
+                    uint newBase = _vm.ExpandUnitListCurrent(addRows: 1);
+                    if (newBase == U.NOT_FOUND)
+                    {
+                        _undoService.Rollback();
+                        Log.Notify("EventUnitView.ExpandList_Click: expansion failed (slot not found or no free space).");
+                        return;
+                    }
+                    _undoService.Commit();
+                    Log.Notify("EventUnitView.ExpandList_Click: expanded to new base " + string.Format("0x{0:X08}", newBase));
+                    // Update the cached group entry so re-selecting this
+                    // group doesn't load the stale orphaned table.
+                    int gi = GroupListBox.SelectedIndex;
+                    if (gi >= 0 && gi < _groupItems.Count)
+                    {
+                        var old = _groupItems[gi];
+                        _groupItems[gi] = new AddrResult(newBase, old.name, old.tag);
+                    }
+                    LoadUnitsFromAddress(newBase);
+                }
+                catch
+                {
+                    _undoService.Rollback();
+                    throw;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("EventUnitView.ExpandList_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EventUnitView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventUnitView.axaml.cs
@@ -80,6 +80,10 @@ namespace FEBuilderGBA.Avalonia.Views
                 foreach (var item in _mapItems)
                     _mapDisplayItems.Add(item.name);
 
+                // Initial Read Count = map count (will be overwritten when
+                // a unit-group list loads — see LoadUnitsFromAddress).
+                // The map count is the baseline shown on first load before
+                // any group is selected.
                 ReadCountBox.Value = _mapItems.Count;
 
                 if (_mapItems.Count > 0)
@@ -140,6 +144,11 @@ namespace FEBuilderGBA.Avalonia.Views
             _unitDisplayItems.Clear();
             foreach (var item in _unitItems)
                 _unitDisplayItems.Add(item.name);
+
+            // Update Read Count to reflect the currently-loaded unit list
+            // (Copilot bot review on PR #540 — the WF top read-config bar
+            // shows the count of the active list, not the map count).
+            ReadCountBox.Value = _unitItems.Count;
 
             ClearDetail();
 

--- a/FEBuilderGBA.Core.Tests/MapEventUnitCoreFE8JumpsTests.cs
+++ b/FEBuilderGBA.Core.Tests/MapEventUnitCoreFE8JumpsTests.cs
@@ -1,0 +1,493 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for the new MapEventUnitCore FE8-specific jump-target search helpers
+// and the version-aware ExpandUnitList overload, both required by the
+// Avalonia EventUnitView gap-sweep (closes #420).
+//
+// FE8 differs from FE7 (PR #522) in three ways the existing helpers do not
+// model:
+//   1. BattleTalk: 16-byte blocks, u16@0/u16@2 unit-id match, u16@4 map filter.
+//   2. Haiku: 12-byte blocks, u16@0 unit-id match, u8@3 map filter (0xFF = wildcard).
+//   3. BossBGM: 8-byte blocks, u8@0 unit-id match (same as FE7).
+//   4. List expansion: starter row B0=0x01, B1=0x02 (vs FE7's 0x01/0x01);
+//      after-coord fields B7/D8 explicitly cleared to zero.
+//
+// W4 (UnitPos) round-trip: tests for the new ParseFe8UnitPos{X,Y,Ext} helpers
+// in FEBuilderGBA.Core/U.cs that mirror the existing MakeFe8UnitPos packer.
+using System;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests;
+
+[Collection("SharedState")]
+public class MapEventUnitCoreFE8JumpsTests
+{
+    // -----------------------------------------------------------------
+    // ParseFe8UnitPos round-trip — W4 decomposition helpers.
+    // -----------------------------------------------------------------
+
+    [Theory]
+    [InlineData(0u, 0u, 0u)]
+    [InlineData(1u, 2u, 3u)]
+    [InlineData(15u, 22u, 5u)]
+    [InlineData(63u, 63u, 7u)]   // max values for each field
+    [InlineData(5u, 10u, 2u)]    // ItemDrop bit set
+    public void ParseFe8UnitPos_RoundTrip_RecoversComponents(uint x, uint y, uint ext)
+    {
+        uint packed = U.MakeFe8UnitPos(x, y, ext);
+        Assert.Equal(x, U.ParseFe8UnitPosX(packed));
+        Assert.Equal(y, U.ParseFe8UnitPosY(packed));
+        Assert.Equal(ext, U.ParseFe8UnitPosExt(packed));
+    }
+
+    [Fact]
+    public void ParseFe8UnitPos_MaskingIgnoresHighBits()
+    {
+        // Packed with full 16 bits — the parsers must mask to the
+        // canonical W4 layout: x (6 bits) | y << 6 (6 bits) | ext << 12 (3 bits).
+        uint packed = 0xFFFFu;
+        Assert.Equal(63u, U.ParseFe8UnitPosX(packed));
+        Assert.Equal(63u, U.ParseFe8UnitPosY(packed));
+        Assert.Equal(7u, U.ParseFe8UnitPosExt(packed));
+    }
+
+    // -----------------------------------------------------------------
+    // FindBattleTalkFE8UnitIdAddress
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void FindBattleTalkFE8UnitIdAddress_Column0Match_ReturnsRow()
+    {
+        ROM rom = MakeFe8uWithBattleTalkTable();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            // Row 0: u16@0 = 0x0001, u16@2 = 0x0002, u16@4 = 0x0010
+            uint hit = MapEventUnitCore.FindBattleTalkFE8UnitIdAddress(rom, unitId: 0x0001, mapId: 0x0010);
+            Assert.NotEqual(0u, hit);
+            Assert.Equal((ushort)0x0001, rom.u16(hit + 0));
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void FindBattleTalkFE8UnitIdAddress_Column2Match_ReturnsRow()
+    {
+        ROM rom = MakeFe8uWithBattleTalkTable();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            // Row 1: u16@0 = 0x0099, u16@2 = 0x00BB, u16@4 = 0x0020
+            // Searching for unitId=0xBB should match via column-2 (u16@2).
+            uint hit = MapEventUnitCore.FindBattleTalkFE8UnitIdAddress(rom, unitId: 0x00BB, mapId: 0x0020);
+            Assert.NotEqual(0u, hit);
+            Assert.Equal((ushort)0x00BB, rom.u16(hit + 2));
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void FindBattleTalkFE8UnitIdAddress_MapMismatch_FallsBackToUnitOnly()
+    {
+        ROM rom = MakeFe8uWithBattleTalkTable();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            // Row 1 has u16@4 = 0x0020. Searching with mapId=0x0099 (different)
+            // should fall back to the unit-only match.
+            uint hit = MapEventUnitCore.FindBattleTalkFE8UnitIdAddress(rom, unitId: 0x00BB, mapId: 0x0099);
+            Assert.NotEqual(0u, hit);
+            // Verify we landed on row 1 (the only row with 0xBB).
+            Assert.Equal((ushort)0x00BB, rom.u16(hit + 2));
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void FindBattleTalkFE8UnitIdAddress_NoMatch_ReturnsZero()
+    {
+        ROM rom = MakeFe8uWithBattleTalkTable();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            uint hit = MapEventUnitCore.FindBattleTalkFE8UnitIdAddress(rom, unitId: 0xCCCC, mapId: 0x0000);
+            Assert.Equal(0u, hit);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    static ROM MakeFe8uWithBattleTalkTable()
+    {
+        var bytes = new byte[0x1100000];
+        var rom = new ROM();
+        rom.LoadLow("synthetic-fe8u.gba", bytes, "BE8E01");
+
+        uint p = rom.RomInfo.event_ballte_talk_pointer;
+        Assert.True(p != 0, "ROMFE8U must define event_ballte_talk_pointer");
+
+        // FE8 BattleTalk: 16-byte blocks, terminator u16==0xFFFF.
+        // Row 0: u16@0=0x0001, u16@2=0x0002, u16@4=0x0010
+        // Row 1: u16@0=0x0099, u16@2=0x00BB, u16@4=0x0020
+        // Row 2: terminator (u16@0 == 0xFFFF)
+        const int block = 16;
+        uint t = 0x00B00000u;
+        bytes[t + 0 * block + 0] = 0x01; bytes[t + 0 * block + 1] = 0x00;
+        bytes[t + 0 * block + 2] = 0x02; bytes[t + 0 * block + 3] = 0x00;
+        bytes[t + 0 * block + 4] = 0x10; bytes[t + 0 * block + 5] = 0x00;
+
+        bytes[t + 1 * block + 0] = 0x99; bytes[t + 1 * block + 1] = 0x00;
+        bytes[t + 1 * block + 2] = 0xBB; bytes[t + 1 * block + 3] = 0x00;
+        bytes[t + 1 * block + 4] = 0x20; bytes[t + 1 * block + 5] = 0x00;
+
+        // Terminator
+        bytes[t + 2 * block + 0] = 0xFF; bytes[t + 2 * block + 1] = 0xFF;
+
+        BitConverter.GetBytes(t | 0x08000000u).CopyTo(bytes, checked((int)p));
+
+        rom.LoadLow("synthetic-fe8u.gba", bytes, "BE8E01");
+        return rom;
+    }
+
+    // -----------------------------------------------------------------
+    // FindHaikuFE8Address
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void FindHaikuFE8Address_FullMatch_ReturnsRow()
+    {
+        ROM rom = MakeFe8uWithHaikuTable();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            // Row 0: u16@0=0x0010, u8@3=0x05 (full match unit=0x10, map=5)
+            uint hit = MapEventUnitCore.FindHaikuFE8Address(rom, unitId: 0x0010, mapId: 0x05);
+            Assert.NotEqual(0u, hit);
+            Assert.Equal((ushort)0x0010, rom.u16(hit + 0));
+            Assert.Equal((byte)0x05, rom.Data[hit + 3]);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void FindHaikuFE8Address_WildcardMap0xFF_MatchesAnyMap()
+    {
+        ROM rom = MakeFe8uWithHaikuTable();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            // Row 1: u16@0=0x0020, u8@3=0xFF (wildcard map).
+            // Searching with any mapId should match.
+            uint hit = MapEventUnitCore.FindHaikuFE8Address(rom, unitId: 0x0020, mapId: 0x77);
+            Assert.NotEqual(0u, hit);
+            Assert.Equal((ushort)0x0020, rom.u16(hit + 0));
+            Assert.Equal((byte)0xFF, rom.Data[hit + 3]);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void FindHaikuFE8Address_UnitMatch_MapMismatch_FallsBackToFirstUnitOnly()
+    {
+        ROM rom = MakeFe8uWithHaikuTable();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            // Row 2: u16@0=0x0030, u8@3=0x05. With mapId=0x99 (mismatch),
+            // we should still get this row as the unit-only fallback.
+            uint hit = MapEventUnitCore.FindHaikuFE8Address(rom, unitId: 0x0030, mapId: 0x99);
+            Assert.NotEqual(0u, hit);
+            Assert.Equal((ushort)0x0030, rom.u16(hit + 0));
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void FindHaikuFE8Address_NoMatch_ReturnsZero()
+    {
+        ROM rom = MakeFe8uWithHaikuTable();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            uint hit = MapEventUnitCore.FindHaikuFE8Address(rom, unitId: 0xCCCC, mapId: 0x00);
+            Assert.Equal(0u, hit);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    static ROM MakeFe8uWithHaikuTable()
+    {
+        var bytes = new byte[0x1100000];
+        var rom = new ROM();
+        rom.LoadLow("synthetic-fe8u.gba", bytes, "BE8E01");
+
+        uint p = rom.RomInfo.event_haiku_pointer;
+        Assert.True(p != 0, "ROMFE8U must define event_haiku_pointer");
+
+        // FE8 Haiku: 12-byte blocks, terminator u16==0xFFFF.
+        // Row 0: u16@0=0x0010, u8@3=0x05 (full match candidate)
+        // Row 1: u16@0=0x0020, u8@3=0xFF (wildcard map)
+        // Row 2: u16@0=0x0030, u8@3=0x05 (unit-only fallback target)
+        // Row 3: terminator (u16==0xFFFF)
+        const int block = 12;
+        uint t = 0x00C00000u;
+        bytes[t + 0 * block + 0] = 0x10; bytes[t + 0 * block + 1] = 0x00;
+        bytes[t + 0 * block + 3] = 0x05;
+
+        bytes[t + 1 * block + 0] = 0x20; bytes[t + 1 * block + 1] = 0x00;
+        bytes[t + 1 * block + 3] = 0xFF;
+
+        bytes[t + 2 * block + 0] = 0x30; bytes[t + 2 * block + 1] = 0x00;
+        bytes[t + 2 * block + 3] = 0x05;
+
+        // Terminator
+        bytes[t + 3 * block + 0] = 0xFF; bytes[t + 3 * block + 1] = 0xFF;
+
+        BitConverter.GetBytes(t | 0x08000000u).CopyTo(bytes, checked((int)p));
+
+        rom.LoadLow("synthetic-fe8u.gba", bytes, "BE8E01");
+        return rom;
+    }
+
+    // -----------------------------------------------------------------
+    // FindBossBGMFE8UnitIdAddress
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void FindBossBGMFE8UnitIdAddress_Match_ReturnsRow()
+    {
+        ROM rom = MakeFe8uWithBossBGMTable();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            // Row 1 has u8@0 = 0x22.
+            uint hit = MapEventUnitCore.FindBossBGMFE8UnitIdAddress(rom, unitId: 0x22);
+            Assert.NotEqual(0u, hit);
+            Assert.Equal((byte)0x22, rom.Data[hit + 0]);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void FindBossBGMFE8UnitIdAddress_NoMatch_ReturnsZero()
+    {
+        ROM rom = MakeFe8uWithBossBGMTable();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            uint hit = MapEventUnitCore.FindBossBGMFE8UnitIdAddress(rom, unitId: 0xDE);
+            Assert.Equal(0u, hit);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void FindBossBGMFE8UnitIdAddress_TerminatorStops_FFFF()
+    {
+        // Ensure the iteration stops at the u16==0xFFFF terminator
+        // (data past the terminator is NOT searched).
+        var bytes = new byte[0x1100000];
+        var rom = new ROM();
+        rom.LoadLow("synthetic-fe8u.gba", bytes, "BE8E01");
+
+        uint p = rom.RomInfo.sound_boss_bgm_pointer;
+        Assert.True(p != 0, "ROMFE8U must define sound_boss_bgm_pointer");
+
+        const int block = 8;
+        uint t = 0x00D00000u;
+        // Row 0: terminator immediately.
+        bytes[t + 0] = 0xFF; bytes[t + 1] = 0xFF;
+        // Row 1 (past terminator) has u8@0=0x55 — must NOT be found.
+        bytes[t + block + 0] = 0x55;
+
+        BitConverter.GetBytes(t | 0x08000000u).CopyTo(bytes, checked((int)p));
+        rom.LoadLow("synthetic-fe8u.gba", bytes, "BE8E01");
+
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            uint hit = MapEventUnitCore.FindBossBGMFE8UnitIdAddress(rom, unitId: 0x55);
+            Assert.Equal(0u, hit);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    static ROM MakeFe8uWithBossBGMTable()
+    {
+        var bytes = new byte[0x1100000];
+        var rom = new ROM();
+        rom.LoadLow("synthetic-fe8u.gba", bytes, "BE8E01");
+
+        uint p = rom.RomInfo.sound_boss_bgm_pointer;
+        Assert.True(p != 0, "ROMFE8U must define sound_boss_bgm_pointer");
+
+        // FE8 BossBGM: 8-byte blocks, terminator u16==0xFFFF.
+        // Row 0: u8@0=0x11
+        // Row 1: u8@0=0x22
+        // Row 2: terminator
+        const int block = 8;
+        uint t = 0x00D00000u;
+        bytes[t + 0 * block + 0] = 0x11;
+        bytes[t + 1 * block + 0] = 0x22;
+        // Terminator
+        bytes[t + 2 * block + 0] = 0xFF;
+        bytes[t + 2 * block + 1] = 0xFF;
+
+        BitConverter.GetBytes(t | 0x08000000u).CopyTo(bytes, checked((int)p));
+
+        rom.LoadLow("synthetic-fe8u.gba", bytes, "BE8E01");
+        return rom;
+    }
+
+    // -----------------------------------------------------------------
+    // ExpandUnitList — FE8 starter variant (B0=0x01, B1=0x02).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ExpandUnitList_FE8_StarterB1Equals0x02()
+    {
+        ROM rom = MakeFe8uWithUnitTable(rowCount: 4);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            uint pointerSlot = 0x200;
+            uint tableAddr = 0x00900000u;
+            BitConverter.GetBytes(tableAddr | 0x08000000u).CopyTo(rom.Data, pointerSlot);
+
+            // Pass starterB1=0x02 explicitly for FE8 semantics.
+            uint newBase = MapEventUnitCore.ExpandUnitList(
+                rom,
+                eventPointerSlot: pointerSlot,
+                oldBase: tableAddr,
+                oldCount: 4,
+                newCount: 7,
+                starterB1: 0x02);
+
+            Assert.NotEqual(U.NOT_FOUND, newBase);
+
+            // New rows 4..6 must have B0=0x01, B1=0x02.
+            for (uint i = 4; i < 7; i++)
+            {
+                uint rowAddr = newBase + i * 20; // FE8 block size = 20
+                Assert.Equal((byte)0x01, rom.Data[rowAddr + 0]);
+                Assert.Equal((byte)0x02, rom.Data[rowAddr + 1]);
+                // B7 (after-coord count) and D8 (after-coord pointer) must be zero.
+                Assert.Equal((byte)0x00, rom.Data[rowAddr + 7]);
+                for (uint b = 8; b < 12; b++)
+                {
+                    Assert.Equal((byte)0x00, rom.Data[rowAddr + b]);
+                }
+            }
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ExpandUnitList_FE8_DefaultStarterB1_Is0x01_BackCompat()
+    {
+        // When starterB1 is omitted, the default is 0x01 (FE7 behavior).
+        // This guards backwards compatibility for existing FE7 callsites.
+        ROM rom = MakeFe7uWithUnitTable(rowCount: 4);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            uint pointerSlot = 0x200;
+            uint tableAddr = 0x00800000u;
+            BitConverter.GetBytes(tableAddr | 0x08000000u).CopyTo(rom.Data, pointerSlot);
+
+            uint newBase = MapEventUnitCore.ExpandUnitList(
+                rom,
+                eventPointerSlot: pointerSlot,
+                oldBase: tableAddr,
+                oldCount: 4,
+                newCount: 7);
+
+            Assert.NotEqual(U.NOT_FOUND, newBase);
+            // FE7 block size = 16, starter B1=0x01 by default.
+            uint rowAddr = newBase + 4u * 16u;
+            Assert.Equal((byte)0x01, rom.Data[rowAddr + 1]);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ExpandUnitList_FE8_OldRowsPreserved()
+    {
+        ROM rom = MakeFe8uWithUnitTable(rowCount: 4);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            uint pointerSlot = 0x200;
+            uint tableAddr = 0x00900000u;
+            BitConverter.GetBytes(tableAddr | 0x08000000u).CopyTo(rom.Data, pointerSlot);
+
+            // Snapshot original rows BEFORE expansion.
+            byte[] origRows = new byte[4 * 20];
+            Array.Copy(rom.Data, tableAddr, origRows, 0, 4 * 20);
+
+            uint newBase = MapEventUnitCore.ExpandUnitList(
+                rom,
+                eventPointerSlot: pointerSlot,
+                oldBase: tableAddr,
+                oldCount: 4,
+                newCount: 7,
+                starterB1: 0x02);
+            Assert.NotEqual(U.NOT_FOUND, newBase);
+
+            for (int i = 0; i < 4 * 20; i++)
+            {
+                Assert.Equal(origRows[i], rom.Data[newBase + i]);
+            }
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    static ROM MakeFe8uWithUnitTable(int rowCount, uint tableAddr = 0x00900000u)
+    {
+        var bytes = new byte[0x1100000];
+        var rom = new ROM();
+        rom.LoadLow("synthetic-fe8u.gba", bytes, "BE8E01");
+
+        // FE8 block size = 20. Lay out rowCount rows.
+        for (int i = 0; i < rowCount; i++)
+        {
+            int rowBase = checked((int)(tableAddr + (uint)(i * 20)));
+            bytes[rowBase + 0] = (byte)(0x10 + i);
+            bytes[rowBase + 1] = (byte)(0x20 + i);
+        }
+        // Terminator row is all zeros after rowCount rows.
+
+        rom.LoadLow("synthetic-fe8u.gba", bytes, "BE8E01");
+        return rom;
+    }
+
+    static ROM MakeFe7uWithUnitTable(int rowCount, uint tableAddr = 0x00800000u)
+    {
+        var bytes = new byte[0x1100000];
+        var rom = new ROM();
+        rom.LoadLow("synthetic-fe7u.gba", bytes, "AE7E01");
+
+        for (int i = 0; i < rowCount; i++)
+        {
+            int rowBase = checked((int)(tableAddr + (uint)(i * 16)));
+            bytes[rowBase + 0] = (byte)(0x10 + i);
+            bytes[rowBase + 1] = (byte)(0x20 + i);
+        }
+
+        rom.LoadLow("synthetic-fe7u.gba", bytes, "AE7E01");
+        return rom;
+    }
+}

--- a/FEBuilderGBA.Core/MapEventUnitCore.cs
+++ b/FEBuilderGBA.Core/MapEventUnitCore.cs
@@ -444,6 +444,11 @@ namespace FEBuilderGBA
         ///   so callers can pass synthesised values in tests.</param>
         /// <param name="oldCount">Currently-loaded number of rows.</param>
         /// <param name="newCount">Desired number of rows after expansion.</param>
+        /// <param name="starterB1">Starter byte planted in B1 of each new
+        ///   row. FE7 uses <c>0x01</c> (default); FE8 callers MUST pass
+        ///   <c>0x02</c> per WF <c>EventUnitForm.AddressListExpandsEvent</c>
+        ///   (which writes <c>B0=0x01, B1=0x02</c> for newly-allocated FE8
+        ///   rows). The B0 starter is always <c>0x01</c>.</param>
         /// <returns>New base ROM offset, or <see cref="U.NOT_FOUND"/> on
         ///   any failure (no partial writes).</returns>
         public static uint ExpandUnitList(
@@ -451,7 +456,8 @@ namespace FEBuilderGBA
             uint eventPointerSlot,
             uint oldBase,
             uint oldCount,
-            uint newCount)
+            uint newCount,
+            byte starterB1 = 0x01)
         {
             if (rom == null || rom.RomInfo == null)
                 return U.NOT_FOUND;
@@ -503,10 +509,15 @@ namespace FEBuilderGBA
             byte[] oldRows = rom.getBinaryData(oldBase, oldCount * blockSize);
             rom.write_range(newBase, oldRows);
 
-            // 2. Initialize new rows with B0=0x01, B1=0x01 (WF
-            // EventUnitFE7Form.cs:485-490). Remaining bytes already zero
-            // because FindFreeSpace returns regions filled with 0x00 or 0xFF;
-            // for 0xFF fill we need to explicitly zero the rest of each row.
+            // 2. Initialize new rows with B0=0x01 (always) and the
+            // caller-supplied starter B1 byte. FE7 callers use 0x01 (WF
+            // EventUnitFE7Form.cs:485-490); FE8 callers pass 0x02 per WF
+            // EventUnitForm.AddressListExpandsEvent. Remaining bytes are
+            // already zero because we write a full zeroBuffer first
+            // (handles 0xFF fill from FindFreeSpace). For FE8 rows the
+            // zeroBuffer also clears B7 (after-coord count) and D8
+            // (after-coord pointer) so the new row has no stale references
+            // to the old table's coord blocks.
             // Allocate the zero buffer ONCE (Copilot review #522 third pass —
             // cast the uint blockSize to int via checked() so the intent is
             // explicit, and reuse the buffer across iterations).
@@ -519,7 +530,7 @@ namespace FEBuilderGBA
                 // then plant the starter bytes.
                 rom.write_range(rowAddr, zeroBuffer);
                 rom.write_u8(rowAddr + 0, 0x01);
-                rom.write_u8(rowAddr + 1, 0x01);
+                rom.write_u8(rowAddr + 1, starterB1);
             }
 
             // 3. Write the zero terminator row after the expanded entries.
@@ -736,6 +747,123 @@ namespace FEBuilderGBA
                 }
             }
             return unitOnlyFallback;
+        }
+
+        // ---------------------------------------------------------------
+        // FE8 jump-target search helpers (#420 — EventUnit jumps)
+        //
+        // FE8 differs from FE7 (PR #522) in:
+        //   - BattleTalk: 16-byte blocks, u16@0/u16@2 unit-id match,
+        //                 u16@4 map filter. Terminator u16==0xFFFF.
+        //   - Haiku: 12-byte blocks, u16@0 unit-id match, u8@3 map filter
+        //            (0xFF = wildcard). Terminator u16==0xFFFF.
+        //   - BossBGM: 8-byte blocks, u8@0 unit-id match. Terminator
+        //              u16==0xFFFF.
+        // ---------------------------------------------------------------
+
+        /// <summary>
+        /// Mirrors <c>EventBattleTalkForm.JumpTo(unit_id, map_id)</c> (FE8):
+        /// search event_ballte_talk_pointer (16-byte blocks, terminator
+        /// u16@0 == 0xFFFF) for the first row whose <c>u16@0</c> OR
+        /// <c>u16@2</c> equals <paramref name="unitId"/>. Prefer full
+        /// (unit + map) match; fall back to unit-only match.
+        ///
+        /// Returns the byte address of the first hit row, or 0 on no match.
+        /// </summary>
+        public static uint FindBattleTalkFE8UnitIdAddress(ROM rom, uint unitId, uint mapId)
+        {
+            if (rom == null || rom.RomInfo == null)
+                return 0;
+
+            uint pointerSlot = rom.RomInfo.event_ballte_talk_pointer;
+            if (pointerSlot == 0) return 0;
+
+            uint baseAddr = rom.p32(pointerSlot);
+            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
+
+            uint romLen = (uint)rom.Data.Length;
+            const uint blockSize = 16;
+            uint unitOnlyFallback = 0;
+
+            for (int i = 0; i < 256; i++)
+            {
+                uint addr = baseAddr + (uint)(i * blockSize);
+                if (addr + blockSize > romLen) break;
+
+                uint u16Term = rom.u16(addr);
+                if (u16Term == 0xFFFF) break; // terminator
+
+                uint c0 = rom.u16(addr + 0);
+                uint c2 = rom.u16(addr + 2);
+                uint mid = rom.u16(addr + 4);
+                if (c0 == unitId || c2 == unitId)
+                {
+                    if (mid == mapId) return addr; // full match
+                    if (unitOnlyFallback == 0) unitOnlyFallback = addr;
+                }
+            }
+            return unitOnlyFallback;
+        }
+
+        /// <summary>
+        /// Mirrors <c>EventHaikuForm.JumpTo(unit_id, map_id)</c> (FE8):
+        /// search event_haiku_pointer (12-byte blocks, terminator
+        /// u16@0 == 0xFFFF) for the first row whose <c>u16@0</c> equals
+        /// <paramref name="unitId"/>. Prefer match where <c>u8@3</c> is
+        /// 0xFF (wildcard) or equals <paramref name="mapId"/>; fall back
+        /// to unit-only.
+        ///
+        /// Returns the byte address of the first hit row, or 0 on no match.
+        /// </summary>
+        public static uint FindHaikuFE8Address(ROM rom, uint unitId, uint mapId)
+        {
+            if (rom == null || rom.RomInfo == null)
+                return 0;
+
+            uint pointerSlot = rom.RomInfo.event_haiku_pointer;
+            if (pointerSlot == 0) return 0;
+
+            uint baseAddr = rom.p32(pointerSlot);
+            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
+
+            uint romLen = (uint)rom.Data.Length;
+            const uint blockSize = 12;
+            uint unitOnlyFallback = 0;
+
+            for (int i = 0; i < 256; i++)
+            {
+                uint addr = baseAddr + (uint)(i * blockSize);
+                if (addr + blockSize > romLen) break;
+
+                uint u16Term = rom.u16(addr);
+                if (u16Term == 0xFFFF) break; // terminator
+
+                uint unitU16 = rom.u16(addr + 0);
+                uint mapU8 = rom.u8(addr + 3);
+                if (unitU16 == unitId)
+                {
+                    if (mapU8 == 0xFF || mapU8 == mapId)
+                    {
+                        return addr; // full match
+                    }
+                    if (unitOnlyFallback == 0) unitOnlyFallback = addr;
+                }
+            }
+            return unitOnlyFallback;
+        }
+
+        /// <summary>
+        /// Mirrors <c>SoundBossBGMForm.JumpTo(unit_id)</c> (FE8 — schema
+        /// identical to FE7): 8-byte blocks, terminator u16@0 == 0xFFFF.
+        /// Searches u8@0 against <paramref name="unitId"/>.
+        ///
+        /// Returns the byte address of the first hit row, or 0 on no match.
+        /// </summary>
+        public static uint FindBossBGMFE8UnitIdAddress(ROM rom, uint unitId)
+        {
+            // FE8 schema identical to FE7 helper — delegate to the
+            // existing implementation to avoid duplicating the loop logic.
+            return FindBossBGMFE7UnitIdAddress(rom, unitId);
         }
     }
 }

--- a/FEBuilderGBA.Core/MapEventUnitCore.cs
+++ b/FEBuilderGBA.Core/MapEventUnitCore.cs
@@ -424,8 +424,10 @@ namespace FEBuilderGBA
         ///     <see cref="ROM.FindFreeSpace"/>.</item>
         ///   <item>Copy the <paramref name="oldCount"/> existing rows to
         ///     the new region byte-for-byte.</item>
-        ///   <item>Initialize each new row with <c>B0=0x01, B1=0x01</c>
-        ///     (matches EventUnitFE7Form.cs:485-490 starter bytes).</item>
+        ///   <item>Initialize each new row with <c>B0=0x01</c> (always) and
+        ///     <c>B1 = starterB1</c> (defaults to <c>0x01</c> for FE7 per
+        ///     EventUnitFE7Form.cs:485-490; FE8 callers pass <c>0x02</c>
+        ///     per WF EventUnitForm.AddressListExpandsEvent).</item>
         ///   <item>Repoint the <paramref name="eventPointerSlot"/> to the
         ///     new region via <see cref="ROM.write_p32(uint,uint)"/>.</item>
         /// </list>

--- a/FEBuilderGBA.Core/U.cs
+++ b/FEBuilderGBA.Core/U.cs
@@ -1113,6 +1113,13 @@ namespace FEBuilderGBA
         {
             return (x & 0x3F) | ((y & 0x3F) << 6) | ((ext & 0x7) << 12);
         }
+        // FE8 W4 (UnitPos) decomposition helpers — mirror MakeFe8UnitPos
+        // packing so callers can split a packed word back into its X, Y, and
+        // ext (flag) components. Used by EventUnitView's W4 sub-panel and by
+        // the ItemDrop status display (Item Drop bit = ext & 0x2).
+        public static uint ParseFe8UnitPosX(uint unitpos) { return unitpos & 0x3F; }
+        public static uint ParseFe8UnitPosY(uint unitpos) { return (unitpos >> 6) & 0x3F; }
+        public static uint ParseFe8UnitPosExt(uint unitpos) { return (unitpos >> 12) & 0x7; }
 
         // ---- Comparer helpers -------------------------------------------------
         public class FunctionalComparer<T> : IComparer<T>

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -7103,3 +7103,12 @@ fr=フランス語
 
 :eo=エスペランド語
 eo=エスペランド語
+
+:Random Monster
+ランダムモンスター
+
+:Drop Item
+アイテムドロップ
+
+:Item Drop Dialog...
+アイテムドロップダイアログ...

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -21005,3 +21005,12 @@ to:
 
 :Import Font
 导入字体
+
+:Random Monster
+随机怪物
+
+:Drop Item
+掉落物品
+
+:Item Drop Dialog...
+物品掉落对话框...


### PR DESCRIPTION
## Summary

- Closes the 56 EventUnit Avalonia gaps (50 missing WF-only labels + 6 missing INavigationTargetSource manifest entries) by rebuilding the Avalonia view, extending the VM with B3 (UnitInfo) + W4 (UnitPos) sub-field decomposition + CommentCache persistence, adding 3 new FE8-specific Core search helpers, and making `MapEventUnitCore.ExpandUnitList` version-aware via a `starterB1` parameter (FE8 plants `B0=0x01, B1=0x02`).
- All in-scope ROM writes wrapped in `UndoService.Begin/Commit/Rollback` (Write_Click + ExpandList_Click + W4 ItemDrop checkbox toggle path).
- 39 new tests across `MapEventUnitCoreFE8JumpsTests` (20 Core helpers) and `EventUnitParityTests` (39 Avalonia parity assertions). Full Core 1615/1615, Avalonia 5219/5222 (3 pre-existing skips), WinForms 1717/1717.
- 3 new ja+zh translation entries (`Random Monster`, `Drop Item`, `Item Drop Dialog...`). Other shared literals (Top Address, Read Count, Reload, Unit Info, LV/Allegiance/Growth Rate, Before/After Coordinates, Comment, Selected Address, jump button captions) are already in `ja.txt`/`zh.txt` from PR #522.

## Plan Reference

Implements the v2 plan accepted by Copilot CLI on https://github.com/laqieer/FEBuilderGBA/issues/420 (second pass, all 5 blocking concerns from v1 addressed).

## Scope

Closes #420
Ref #374

## Screenshots

![EventUnit editor populated against FE8U.gba](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr420-eventunit-editor.png)

Real Avalonia GUI capture via `PrintWindow` API + PowerShell `UIAutomationClient` against `roms/FE8U.gba`. The shot shows every new control surface:
- **3-pane navigator**: Map Names (FE8 chapters), Event Names (Player Placement), Names (Gilliam Paladin Lv:1).
- **Top read-config bar**: `Top Address=0x008B3C14`, `Read Count=79`, `Reload`.
- **Detail panel** populated for Gilliam:
  - `Unit Number=2`, `Class=7 (Paladin)`, `Commander=0`
  - `Unit Info=8` decomposed into `LV=1 / Allegiance=Player / Growth Rate=No Growth`
  - `Before Coordinates=589` (W4 raw) decomposed into `X=13, Y=9` + `Drop Item` checkbox unchecked
  - `After Coordinates: Count=6, Pointer=0x088B3BC4` (read-only — see Known Limitations)
  - `Item 1=3 (Steel Sword)`, `Item 2=23 (Silver Lance)`, `Item 3=108 (Vulnerary)`, `Item 4=0`
  - `Primary AI=0 (0x00 No AI)`, `Secondary AI=0`, `Target/Recovery AI=0`, `Retreat AI=0`
  - `Comment` textbox (empty for this slot)
- **Address bar**: `Size=0x14`, `Selected Address=0x008B3C14`, `Write` button.
- **Jump panel**: Battle Talk / Battle BGM / Death Quote Jump buttons + `Item Drop Dialog...` + `Random Monster` (next to Class field).
- **Item Drop status label**: `Item Drop: doesn't drop`.

Screenshot committed to master via the sister docs PR #539 so the URL survives feature-branch deletion.

## GUI Test Report

### Environment
- ROM: `roms/FE8U.gba` (Fire Emblem - The Sacred Stones, USA)
- View: `EventUnitView` (Avalonia)
- Capture method: PrintWindow API + PowerShell UIAutomationClient

### Steps Performed
1. Launched `FEBuilderGBA.Avalonia.exe --rom roms\FE8U.gba`.
2. Used UIAutomation to find the main FE8U window (`Name='FEBuilderGBA - FE8U.gba'`).
3. Located `Main_EventUnit_Button` via `AutomationIdProperty`, invoked it via `InvokePattern`.
4. Verified the opened window is `EventUnitView` (Name='Event Unit Placement').
5. Captured the editor via PrintWindow (`tools/WinCapture`).
6. Confirmed first chapter (`00 The Fall of Renais`) and first event group (`Player Placement`) auto-selected, populating the detail panel with the first unit (`00 Gilliam (Paladin) Lv:1`).

### Test Results

| Test | Expected | Actual | Status |
|---|---|---|---|
| Main menu "Event Unit" opens upgraded view | `EventUnitView` window with title "Event Unit Placement" | Window opened | PASS |
| Map Names list populates | FE8 chapters with hex prefixes | 30+ chapters visible | PASS |
| Event Names list populates per selected map | Player Placement / Player Placement (Hard) etc | 2 rows for Ch 00 | PASS |
| Names (unit) list populates per group | Multiple units with formatted display | 2 units `00 Gilliam (Paladin) Lv:1` + `01 Seth (Lord) Lv:1` | PASS |
| Top read-config bar | Top Address + Read Count + Reload | All 3 controls present | PASS |
| Detail panel fields auto-populate | UnitID/Class/Commander/UnitInfo/W4/Items/AI | All fields populated from ROM | PASS |
| B3 (UnitInfo) decomposition (UnitInfo=8) | LV=1, Allegiance=Player, Growth Rate=No Growth | LV=1, Allegiance=Player, Growth Rate=No Growth | PASS |
| W4 (UnitPos) decomposition (W4=589) | X=13, Y=9, Drop Item bit | X=13, Y=9, checkbox unchecked | PASS |
| After Coordinates display | Count + Pointer read-only | Count=6, Pointer=0x088B3BC4 | PASS |
| Item 1 name resolution | "Steel Sword" for ID 3 | Steel Sword | PASS |
| AI description resolution | Each AI ID gets a human description | All 4 AI rows show descriptions | PASS |
| Address bar (Size, Selected Address, Write) | Size=0x14, Selected Address=0x008B3C14, Write button | All match | PASS |
| Jump panel renders | 4 jump buttons + Item Drop label + Random Monster | All present | PASS |
| Comment textbox | Editable; loaded from CommentCache | Empty (no prior annotation) | PASS |
| L10nCoverageTest | 0 PartiallyTranslated literals | Passes (3 new ja+zh entries) | PASS |
| MapEventUnitCoreFE8JumpsTests | 20 passing | 20/20 PASS | PASS |
| EventUnitParityTests | 39 passing | 39/39 PASS | PASS |

### Verdict

**PASS** - every new control / field / jump renders, populates with live ROM data, and behaves as the WinForms editor does. All 59 new tests (20 Core + 39 Avalonia) pass.

## Test plan

- [x] `dotnet test FEBuilderGBA.Core.Tests/` - 1615/1615 pass (20 new MapEventUnitCoreFE8JumpsTests).
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests/` - 5219/5222 pass (3 pre-existing skips; 39 new EventUnitParityTests cases all pass).
- [x] `dotnet test FEBuilderGBA.Tests/` - 1717/1717 pass.
- [x] `dotnet build FEBuilderGBA.sln` - 0 errors, all projects build.
- [x] Gap-sweep label coverage: 50 WF-only labels addressed — most surfaced as new AV controls; remaining ~10 (FE8CoordListBox multi-coord LIST editor, EventUnitSim stat-preview, MapPictureBox overlay) documented as out-of-scope follow-ups (see Known limitations).
- [x] AV control density: AV `EventUnitView` now declares >= 72 candidates (MEDIUM threshold for WF=95) — verified by `View_AvControlCount_AtOrAboveMediumVerdict`.
- [x] All in-scope ROM-write paths wrapped in `_undoService.Begin/Commit` with `Rollback` on exception (verified by `View_WriteClick_WrapsInUndoScope` + `View_ExpandListClick_WrapsInUndoScope` regression tests).
- [x] FE8 expansion semantics: `MapEventUnitCore.ExpandUnitList` accepts `starterB1` parameter; FE8 wrapper passes `0x02` (verified by `ExpandUnitList_FE8_StarterB1Equals0x02` Core test + `ViewModel_ExpandUnitListCurrent_UsesFe8StarterByte` parity test).
- [x] FE8 ItemDrop semantics: `ItemDropFlag` reads/writes `(W4 ext) & 0x2` (NOT unit/class characteristic), with two-way sync to the W4 raw word (verified by `ViewModel_ItemDropFlag_TogglesW4ExtBit2` + `ViewModel_ItemDropDisplay_ChangesWithW4ExtBit`).
- [x] All 6 INavigationTargetSource entries declared (BattleTalk / BossBGM / Haiku / NewAlloc / ItemDrop / MonsterProbability) — verified by `ViewModel_DeclaresAllSixJumpTargets` + 6 `JumpParityScanner_*_NowMatchesManifest` cases.
- [x] ja/zh translations added for the 3 new English literals introduced by this PR (`Random Monster`, `Drop Item`, `Item Drop Dialog...`). Other new literals were already in `ja.txt`/`zh.txt` from PR #522. `L10nCoverageTest` stays green.
- [x] GUI screenshot captured via PrintWindow against the live Avalonia app with `roms/FE8U.gba` and committed to `pr-screenshots/` on master via #539.
- [x] Copilot CLI plan review accepted (v2 plan, no remaining blocking concerns) - https://github.com/laqieer/FEBuilderGBA/issues/420.

## Known limitations

- **FE8 after-coord LIST editor (N_InputFormRef + FE8CoordListBox)** is out of scope. The new view shows `Count` and `Pointer` (B7, D8) as read-only. Editing multi-coordinate placement lists requires a dedicated sub-editor that wraps the 8-byte coord blocks and the WF `MoveCallback` / map-click integration; this is a deeper sub-editor work item tracked separately.
- **MapPictureBox map preview overlay** (unit-sprite icons drawn on the live map) is out of scope. The WF `EventUnitForm` embeds a full map renderer with selectable unit icons; the Avalonia view does not yet have a map renderer with unit-icon support.
- **EventUnitSimUserControl** stat-preview gadget (the floating preview that shows simulated stats when hovering LV/Growth Rate) is out of scope (same as PR #522's limitation).
- **`EventUnitNewAllocForm` AllocEvent state machine** is not ported; the new view's `New Allocation` button opens the existing Avalonia `EventUnitNewAllocView` stub (same soft-handoff precedent as PR #522).
- **`EventUnitItemDropForm` Yes/No/Cancel dialog** is not ported; the new view's `Item Drop Dialog...` button opens the existing Avalonia `EventUnitItemDropView` stub. The canonical Item Drop state mutation happens via the new `Drop Item` checkbox bound to the W4 ext bit (verified to wrap in undo via `Write_Click`).
- **`MonsterProbabilityForm` row pre-selection** is not implemented (WF uses `JumpForm<MonsterProbabilityForm>(B1.Value, "AddressList", B1)` to select the class_id row). The new `Random Monster` button opens the existing Avalonia `MonsterProbabilityViewerView` without row pre-selection.
- **`ko.txt` does not exist in the repo** - ko translations are intentionally out of scope (project-wide condition; same convention as #511, #513, #517, #520, #522). All literals show `ko: x` across the gap-sweep l10n report; `L10nCoverageTest` only enforces `ja, zh`.

## Acceptance criteria checklist (from #420 body)

- [x] **WF-only labels covered or explicitly justified as out-of-scope** - ~40 of 50 WF-only Japanese labels surfaced as new AV controls (Top Address, Read Count, Reload, Unit Number, Class, Commander, Unit Info, LV, Allegiance, Growth Rate, Before Coordinates, X, Y, Drop Item, After Coordinates, Count, Pointer, Reserved (0x06), Items 1-4, Primary/Secondary/Target-Recovery/Retreat AI, Comment, Size, Selected Address, Write, Battle Talk Jump, Battle BGM Jump, Death Quote Jump, Item Drop Dialog..., Item Drop label, New Allocation, Expand List, Random Monster, Names header, Event Names header, Map Names header). Remaining ~10 (FE8CoordListBox multi-coord controls, EventUnitSim chrome, MapPictureBox overlay artifacts) documented as out-of-scope follow-ups.
- [x] **Avalonia view density brought within 25% of WF (MEDIUM verdict or better)** - `EventUnitParityTests.View_AvControlCount_AtOrAboveMediumVerdict` asserts AV >= ceil(0.75 * 95) = 72.
- [x] **All ROM writes in `EventUnitViewModel` wrapped in `_undoService.Begin/Commit`** (in-scope writes) - verified by `View_WriteClick_WrapsInUndoScope` + `View_ExpandListClick_WrapsInUndoScope` regression tests. Out-of-scope writes (FE8CoordListBox editor, AllocEvent state machine) documented as known limitations.
- [x] **Untranslated literals translated in ja/zh** (ko unmapped is a documented project-wide convention).
- [x] **Existing related issues referenced; this issue closed by the merging PR** - `Closes #420` and `Ref #374`.

Generated with Claude Code (claude-opus-4-7[1m])
