### PR TITLE
fix(gap-sweep): OPClassDemo parity (closes #419)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/OPClassDemoParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/OPClassDemoParityTests.cs
@@ -1,0 +1,412 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Phase 1+2+5+6 gap-sweep regression tests for OPClassDemoViewerView. (#419)
+//
+// Closes the 32 control gap + 27 WF-only labels surfaced by the gap-sweep
+// methodology on OPClassDemoForm (HIGH density 31/63, -50.8 %). After this
+// PR the view rebuilds to a three-pane master-detail editor (main list /
+// detail panel with previews / two sub-list panels) + a top read-config
+// bar + an address-write bar, with patch-aware affordances for
+// OPClassReelSort (ListExpand button) and OPClassReelAnimationIDOver255
+// (BattleAnime+1 label).
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.GapSweep;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests.GapSweep;
+
+/// <summary>
+/// Tests proving the OPClassDemo parity raise (#419) is permanent.
+/// Density target: AV ≥ ceil(WF * 0.75) = 48.
+///
+/// Marked [Collection("SharedState")] because the VM tests mutate
+/// CoreState.ROM to plant synthetic ROMs.
+/// </summary>
+[Collection("SharedState")]
+public class OPClassDemoParityTests
+{
+    // -----------------------------------------------------------------
+    // Density (Phase 1) — AV control count must reach MEDIUM verdict.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// The WF Designer reports 63 controls; the MEDIUM threshold is
+    /// `ceil(63 * 0.75) = 48`. Falling below this re-enters HIGH territory.
+    /// </summary>
+    [Fact]
+    public void View_AvControlCount_AtOrAboveMediumVerdict()
+    {
+        string repoRoot = FindRepoRoot();
+        string axamlPath = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "OPClassDemoViewerView.axaml");
+        Assert.True(File.Exists(axamlPath), $"AXAML not found at {axamlPath}");
+
+        var doc = XDocument.Load(axamlPath);
+        int avCount = ControlDensityScanner.CountAvControlsInDocument(doc);
+
+        const int WfControlCount = 63;
+        int mediumThreshold = (int)Math.Ceiling(WfControlCount * 0.75); // 48
+        Assert.True(avCount >= mediumThreshold,
+            $"AV control count {avCount} must be ≥ {mediumThreshold} (75% of WF={WfControlCount}) — got HIGH verdict");
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 5 — control surface assertions (static AXAML inspection).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_HasFilterAndReloadBar()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_ReadStart_Input\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_ReadCount_Input\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_ReloadList_Button\"", axaml);
+        Assert.Contains("Click=\"ReloadList_Click\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasAddressWriteBar()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_Addr_Input\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_BlockSize_Input\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_SelectedAddress_Input\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_Write_Button\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_Addr_Label\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasN1JpFontSublist()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_N1_List\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_N1_B0_Input\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_N1_SelectedAddress_Input\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_N1_Write_Button\"", axaml);
+        Assert.Contains("Click=\"N1_Write_Click\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasN2AnimeSublist()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_N2_List\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_N2_B0_Input\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_N2_B1_Input\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_N2_Cmd_Combo\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_N2_Write_Button\"", axaml);
+        Assert.Contains("Click=\"N2_Write_Click\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasListExpandButton()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_ListExpand_Button\"", axaml);
+        Assert.Contains("Click=\"ListExpand_Click\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasPatchNoticeAndPlus1Label()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_PatchNotice_Label\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_BattleAnimePlus1_Label\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasInlinePreviewLabels()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_PaletteId_Label\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_ClassName_Label\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_BattleAnime_Label\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_TerrainLeft_Label\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_TerrainRight_Label\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasComboBoxesForAllyAndMagic()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_AllyEnemyColor_Combo\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoViewer_MagicEffect_Combo\"", axaml);
+    }
+
+    // -----------------------------------------------------------------
+    // Roslyn AST walk — assert all four handlers use _undoService.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_WriteHandler_UsesUndoService()
+    {
+        string source = ReadCodeBehind();
+        Assert.Matches(new Regex(@"void\s+Write_Click[\s\S]*?_undoService\.Begin", RegexOptions.Compiled), source);
+        Assert.Matches(new Regex(@"void\s+Write_Click[\s\S]*?_undoService\.Commit", RegexOptions.Compiled), source);
+        Assert.Matches(new Regex(@"void\s+Write_Click[\s\S]*?_undoService\.Rollback", RegexOptions.Compiled), source);
+    }
+
+    [Fact]
+    public void View_N1WriteHandler_UsesUndoService()
+    {
+        string source = ReadCodeBehind();
+        Assert.Matches(new Regex(@"void\s+N1_Write_Click[\s\S]*?_undoService\.Begin", RegexOptions.Compiled), source);
+        Assert.Matches(new Regex(@"void\s+N1_Write_Click[\s\S]*?_undoService\.Commit", RegexOptions.Compiled), source);
+        Assert.Matches(new Regex(@"void\s+N1_Write_Click[\s\S]*?_undoService\.Rollback", RegexOptions.Compiled), source);
+    }
+
+    [Fact]
+    public void View_N2WriteHandler_UsesUndoService()
+    {
+        string source = ReadCodeBehind();
+        Assert.Matches(new Regex(@"void\s+N2_Write_Click[\s\S]*?_undoService\.Begin", RegexOptions.Compiled), source);
+        Assert.Matches(new Regex(@"void\s+N2_Write_Click[\s\S]*?_undoService\.Commit", RegexOptions.Compiled), source);
+        Assert.Matches(new Regex(@"void\s+N2_Write_Click[\s\S]*?_undoService\.Rollback", RegexOptions.Compiled), source);
+    }
+
+    [Fact]
+    public void View_ListExpandHandler_UsesUndoService()
+    {
+        string source = ReadCodeBehind();
+        Assert.Matches(new Regex(@"void\s+ListExpand_Click[\s\S]*?_undoService\.Begin", RegexOptions.Compiled), source);
+        Assert.Matches(new Regex(@"void\s+ListExpand_Click[\s\S]*?_undoService\.Commit", RegexOptions.Compiled), source);
+        Assert.Matches(new Regex(@"void\s+ListExpand_Click[\s\S]*?_undoService\.Rollback", RegexOptions.Compiled), source);
+    }
+
+    [Fact]
+    public void View_ListExpandHandler_CallsDataExpansionCore()
+    {
+        string source = ReadCodeBehind();
+        // The handler must delegate to _vm.ExpandList() which itself calls
+        // DataExpansionCore.ExpandTable; the regression here is that the
+        // view actually invokes the VM helper (not a stale stub).
+        Assert.Matches(new Regex(@"void\s+ListExpand_Click[\s\S]*?_vm\.ExpandList\(", RegexOptions.Compiled), source);
+    }
+
+    // -----------------------------------------------------------------
+    // ViewModel sublist walks (synthetic FE8U ROM)
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_LoadN1FontList_StopsAt0xFF()
+    {
+        ROM rom = MakeMinimalFe8uRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+
+            // Plant a glyph stream at 0x00820000: 5 bytes then 0xFF then junk.
+            byte[] bytes = rom.Data;
+            uint baseAddr = 0x00820000u;
+            for (int i = 0; i < 5; i++) bytes[baseAddr + i] = (byte)(0x10 + i);
+            bytes[baseAddr + 5] = 0xFF;
+            bytes[baseAddr + 6] = 0x42; // junk past terminator
+            // Plant a GBA pointer at slot 0x00830000 → 0x00820000.
+            uint slot = 0x00830000u;
+            BitConverter.GetBytes(baseAddr | 0x08000000u).CopyTo(bytes, slot);
+
+            var vm = new OPClassDemoViewerViewModel();
+            var rows = vm.LoadN1FontList(slot);
+            Assert.Equal(5, rows.Count);
+            Assert.Equal(0x10u, rows[0].GlyphId);
+            Assert.Equal(0x14u, rows[4].GlyphId);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_LoadN1FontList_RespectsMax16Cap()
+    {
+        ROM rom = MakeMinimalFe8uRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+
+            byte[] bytes = rom.Data;
+            uint baseAddr = 0x00820000u;
+            // Plant 32 non-FF bytes — walker must stop at index 16.
+            for (int i = 0; i < 32; i++) bytes[baseAddr + i] = (byte)(0x20 + i);
+            uint slot = 0x00830000u;
+            BitConverter.GetBytes(baseAddr | 0x08000000u).CopyTo(bytes, slot);
+
+            var vm = new OPClassDemoViewerViewModel();
+            var rows = vm.LoadN1FontList(slot);
+            Assert.Equal(16, rows.Count);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_LoadN1FontList_NullRom_ReturnsEmpty()
+    {
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = null;
+            var vm = new OPClassDemoViewerViewModel();
+            var rows = vm.LoadN1FontList(0x00830000u);
+            Assert.Empty(rows);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_LoadN2CommandList_StopsAt0x00()
+    {
+        ROM rom = MakeMinimalFe8uRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+
+            byte[] bytes = rom.Data;
+            uint baseAddr = 0x00840000u;
+            // Plant 3 (Cmd, Arg) rows then Cmd=0x00 terminator.
+            for (int i = 0; i < 3; i++)
+            {
+                bytes[baseAddr + i * 2] = (byte)(0x01 + i);     // Cmd
+                bytes[baseAddr + i * 2 + 1] = (byte)(0x10 * i); // Arg
+            }
+            bytes[baseAddr + 3 * 2] = 0x00; // terminator
+            bytes[baseAddr + 3 * 2 + 1] = 0x42; // junk
+            uint slot = 0x00850000u;
+            BitConverter.GetBytes(baseAddr | 0x08000000u).CopyTo(bytes, slot);
+
+            var vm = new OPClassDemoViewerViewModel();
+            var rows = vm.LoadN2CommandList(slot);
+            Assert.Equal(3, rows.Count);
+            Assert.Equal(0x01u, rows[0].Command);
+            Assert.Equal(0x00u, rows[0].Argument);
+            Assert.Equal(0x03u, rows[2].Command);
+            Assert.Equal(0x20u, rows[2].Argument);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    // -----------------------------------------------------------------
+    // Patch presence flags
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_PatchPresence_OPClassReelAnimationIDOver255_FE8J_PatchPresent()
+    {
+        ROM rom = MakeMinimalFe8jRom(plantOver255: true);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new OPClassDemoViewerViewModel();
+            Assert.True(vm.IsOver255PatchActive);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_PatchPresence_OPClassReelAnimationIDOver255_FE8U_AlwaysFalse()
+    {
+        ROM rom = MakeMinimalFe8uRom();
+        // Synthetic write of FE8J signature at FE8J offset — must NOT match on FE8U.
+        rom.Data[0xB86B0] = 0x59;
+        rom.Data[0xB86B0 + 1] = 0x8A;
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new OPClassDemoViewerViewModel();
+            Assert.False(vm.IsOver255PatchActive);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_PatchPresence_OPClassReelSort_FE8J_PatchPresent()
+    {
+        ROM rom = MakeMinimalFe8jRom(plantReelSort: true);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new OPClassDemoViewerViewModel();
+            Assert.True(vm.IsReelSortPatchActive);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_PatchPresence_OPClassReelSort_FE8U_PatchPresent()
+    {
+        // OPClassReelSort table has both FE8J AND FE8U entries.
+        ROM rom = MakeMinimalFe8uRom();
+        rom.Data[0xB40EC] = 0x04;
+        rom.Data[0xB40EC + 1] = 0x4B;
+        rom.Data[0xB40EC + 2] = 0x1B;
+        rom.Data[0xB40EC + 3] = 0x68;
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new OPClassDemoViewerViewModel();
+            Assert.True(vm.IsReelSortPatchActive);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    /// <summary>Minimal FE8U ROM (BE8E01 + 0x1100000 bytes).</summary>
+    static ROM MakeMinimalFe8uRom()
+    {
+        var rom = new ROM();
+        var data = new byte[0x1100000];
+        rom.LoadLow("synthetic-fe8u.gba", data, "BE8E01");
+        return rom;
+    }
+
+    /// <summary>Minimal FE8J ROM optionally seeded with the Over255 / ReelSort signatures.</summary>
+    static ROM MakeMinimalFe8jRom(bool plantOver255 = false, bool plantReelSort = false)
+    {
+        var rom = new ROM();
+        var data = new byte[0x1100000];
+        if (plantOver255)
+        {
+            data[0xB86B0] = 0x59;
+            data[0xB86B0 + 1] = 0x8A;
+        }
+        if (plantReelSort)
+        {
+            data[0xB8C80] = 0x04;
+            data[0xB8C80 + 1] = 0x4B;
+            data[0xB8C80 + 2] = 0x1B;
+            data[0xB8C80 + 3] = 0x68;
+        }
+        rom.LoadLow("synthetic-fe8j.gba", data, "BE8J01");
+        return rom;
+    }
+
+    static string ReadAxaml() => File.ReadAllText(Path.Combine(FindRepoRoot(),
+        "FEBuilderGBA.Avalonia", "Views", "OPClassDemoViewerView.axaml"));
+
+    static string ReadCodeBehind() => File.ReadAllText(Path.Combine(FindRepoRoot(),
+        "FEBuilderGBA.Avalonia", "Views", "OPClassDemoViewerView.axaml.cs"));
+
+    /// <summary>Walk parents from test bin dir until we find FEBuilderGBA.sln.</summary>
+    static string FindRepoRoot()
+    {
+        string? dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+        if (dir == null)
+            throw new InvalidOperationException("Could not find FEBuilderGBA.sln from test base directory");
+        return dir;
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/OPClassDemoParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/OPClassDemoParityTests.cs
@@ -187,6 +187,25 @@ public class OPClassDemoParityTests
         Assert.Matches(new Regex(@"void\s+ListExpand_Click[\s\S]*?_vm\.ExpandList\(", RegexOptions.Compiled), source);
     }
 
+    [Fact]
+    public void View_LoadN1Sublist_ResetsSelectedAddressOnEntryChange()
+    {
+        // Copilot CLI re-review on PR #544 #4 — Load*Sublist must reset
+        // _n*SelectedAddr before replacing the list so a stale selection
+        // from the previous row cannot land in a Write_Click against the
+        // wrong address. The handler regex looks for the explicit reset
+        // assignment at the top of each Load*Sublist body.
+        string source = ReadCodeBehind();
+        Assert.Matches(new Regex(@"void\s+LoadN1Sublist[\s\S]*?_n1SelectedAddr\s*=\s*0", RegexOptions.Compiled), source);
+    }
+
+    [Fact]
+    public void View_LoadN2Sublist_ResetsSelectedAddressOnEntryChange()
+    {
+        string source = ReadCodeBehind();
+        Assert.Matches(new Regex(@"void\s+LoadN2Sublist[\s\S]*?_n2SelectedAddr\s*=\s*0", RegexOptions.Compiled), source);
+    }
+
     // -----------------------------------------------------------------
     // ViewModel sublist walks (synthetic FE8U ROM)
     // -----------------------------------------------------------------
@@ -285,6 +304,111 @@ public class OPClassDemoParityTests
             Assert.Equal(0x00u, rows[0].Argument);
             Assert.Equal(0x03u, rows[2].Command);
             Assert.Equal(0x20u, rows[2].Argument);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    // -----------------------------------------------------------------
+    // Pointer-aware write semantics (P0 / P8 / P24) — issue raised by
+    // Copilot CLI re-review on PR #544. The VM must read JapaneseNamePointer /
+    // AnimePointer as offsets (via rom.p32) and write them back with the
+    // 0x08000000 high bit applied (via rom.write_p32).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_WriteOPClassDemo_StoresJapaneseNamePointer_AsGbaPointer()
+    {
+        ROM rom = MakeMinimalFe8uRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new OPClassDemoViewerViewModel();
+            // Plant a valid p0 at the entry so LoadOPClassDemo can be
+            // called later without tripping pointer-safety checks
+            // (not strictly needed here — we test the write path).
+            uint entryAddr = 0x00800000u;
+            vm.CurrentAddr = entryAddr;
+            vm.JapaneseNamePointer = 0x00200000u; // ROM offset, NO high bit.
+            vm.WriteOPClassDemo();
+
+            // Read raw u32: should have GBA 0x08000000 high bit.
+            uint raw = rom.u32(entryAddr + 8);
+            uint decoded = rom.p32(entryAddr + 8);
+            Assert.Equal(0x00200000u | 0x08000000u, raw);
+            Assert.Equal(0x00200000u, decoded);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_WriteOPClassDemo_StoresAnimePointer_AsGbaPointer()
+    {
+        ROM rom = MakeMinimalFe8uRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new OPClassDemoViewerViewModel();
+            uint entryAddr = 0x00800100u;
+            vm.CurrentAddr = entryAddr;
+            vm.AnimePointer = 0x00300000u;
+            vm.WriteOPClassDemo();
+
+            uint raw = rom.u32(entryAddr + 24);
+            uint decoded = rom.p32(entryAddr + 24);
+            Assert.Equal(0x00300000u | 0x08000000u, raw);
+            Assert.Equal(0x00300000u, decoded);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_WriteOPClassDemo_StoresEnglishNamePointer_AsGbaPointer()
+    {
+        ROM rom = MakeMinimalFe8uRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new OPClassDemoViewerViewModel();
+            uint entryAddr = 0x00800200u;
+            vm.CurrentAddr = entryAddr;
+            vm.EnglishNamePointer = 0x00400000u;
+            vm.WriteOPClassDemo();
+
+            uint raw = rom.u32(entryAddr + 0);
+            uint decoded = rom.p32(entryAddr + 0);
+            Assert.Equal(0x00400000u | 0x08000000u, raw);
+            Assert.Equal(0x00400000u, decoded);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_LoadOPClassDemo_ReadsPointersAsOffsets()
+    {
+        ROM rom = MakeMinimalFe8uRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+
+            // Plant raw GBA pointer bytes at the test address.
+            uint entryAddr = 0x00800300u;
+            uint gbaPointer = 0x08500000u;
+            BitConverter.GetBytes(gbaPointer).CopyTo(rom.Data, entryAddr + 0);  // P0
+            BitConverter.GetBytes(gbaPointer + 0x1000).CopyTo(rom.Data, entryAddr + 8);  // P8
+            BitConverter.GetBytes(gbaPointer + 0x2000).CopyTo(rom.Data, entryAddr + 24); // P24
+
+            var vm = new OPClassDemoViewerViewModel();
+            vm.LoadOPClassDemo(entryAddr);
+
+            // p32 strips the 0x08000000 high bit, so the ViewModel
+            // observable property must report the OFFSET only.
+            Assert.Equal(0x00500000u, vm.EnglishNamePointer);
+            Assert.Equal(0x00501000u, vm.JapaneseNamePointer);
+            Assert.Equal(0x00502000u, vm.AnimePointer);
         }
         finally { CoreState.ROM = prevRom; }
     }

--- a/FEBuilderGBA.Avalonia/ViewModels/OPClassDemoViewerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/OPClassDemoViewerViewModel.cs
@@ -221,12 +221,24 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// </summary>
         public List<N1Row> LoadN1FontList(uint pointerSlotAddr)
         {
+            ROM rom = CoreState.ROM;
+            if (rom == null) return new List<N1Row>();
+            if (pointerSlotAddr == 0 || pointerSlotAddr + 4 > (uint)rom.Data.Length) return new List<N1Row>();
+            uint baseAddr = rom.p32(pointerSlotAddr);
+            return LoadN1FontListFromOffset(baseAddr);
+        }
+
+        /// <summary>
+        /// Walk the Japanese-name font sub-list starting from a ROM offset
+        /// (already-dereferenced). Used when the caller wants to preview an
+        /// unsaved pointer value before it has been written to ROM.
+        /// (Copilot bot review thread PRRT_kwDOH0Mc1M6ETj_F on PR #544.)
+        /// </summary>
+        public List<N1Row> LoadN1FontListFromOffset(uint baseAddr)
+        {
             var result = new List<N1Row>();
             ROM rom = CoreState.ROM;
             if (rom == null) return result;
-            if (pointerSlotAddr == 0 || pointerSlotAddr + 4 > (uint)rom.Data.Length) return result;
-
-            uint baseAddr = rom.p32(pointerSlotAddr);
             if (!U.isSafetyOffset(baseAddr)) return result;
 
             for (uint i = 0; i < N1MaxEntries; i++)
@@ -247,12 +259,23 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// </summary>
         public List<N2Row> LoadN2CommandList(uint pointerSlotAddr)
         {
+            ROM rom = CoreState.ROM;
+            if (rom == null) return new List<N2Row>();
+            if (pointerSlotAddr == 0 || pointerSlotAddr + 4 > (uint)rom.Data.Length) return new List<N2Row>();
+            uint baseAddr = rom.p32(pointerSlotAddr);
+            return LoadN2CommandListFromOffset(baseAddr);
+        }
+
+        /// <summary>
+        /// Walk the animation command sub-list starting from a ROM offset
+        /// (already-dereferenced). Used when previewing an unsaved
+        /// pointer value (Copilot bot review thread PRRT_kwDOH0Mc1M6ETj_F).
+        /// </summary>
+        public List<N2Row> LoadN2CommandListFromOffset(uint baseAddr)
+        {
             var result = new List<N2Row>();
             ROM rom = CoreState.ROM;
             if (rom == null) return result;
-            if (pointerSlotAddr == 0 || pointerSlotAddr + 4 > (uint)rom.Data.Length) return result;
-
-            uint baseAddr = rom.p32(pointerSlotAddr);
             if (!U.isSafetyOffset(baseAddr)) return result;
 
             for (uint i = 0; i < N2MaxEntries; i++)

--- a/FEBuilderGBA.Avalonia/ViewModels/OPClassDemoViewerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/OPClassDemoViewerViewModel.cs
@@ -172,5 +172,154 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             ["TerrainRight"] = "u8@0x17_TerrainRight",
             ["AnimePointer"] = "u32@0x18_AnimePointer",
         };
+
+        // -----------------------------------------------------------------
+        // Sub-list walkers + patch presence flags (gap-sweep #419).
+        //
+        // WinForms OPClassDemoForm exposes two sub-lists:
+        //   N1_ — Japanese-name font glyph IDs at the pointer P8.
+        //         Block size 1 byte, max 16 entries, terminator 0xFF.
+        //   N2_ — Animation command rows at the pointer P24.
+        //         Block size 2 bytes (Cmd, Arg), terminator 0x00 in Cmd.
+        // The walkers dereference the pointer slot first (matching WF
+        // InputFormRef.ReInit semantics) so the caller can pass the
+        // pointer-slot address directly.
+        // -----------------------------------------------------------------
+
+        /// <summary>Maximum entries in the N1 Japanese-name font sub-list.</summary>
+        public const int N1MaxEntries = 16;
+
+        /// <summary>Maximum entries in the N2 animation command sub-list (sanity cap).</summary>
+        public const int N2MaxEntries = 256;
+
+        /// <summary>One row of the Japanese-name font sub-list (single byte glyph ID).</summary>
+        public sealed class N1Row
+        {
+            public uint Addr { get; init; }
+            public uint Index { get; init; }
+            public uint GlyphId { get; init; }
+        }
+
+        /// <summary>One row of the animation command sub-list.</summary>
+        public sealed class N2Row
+        {
+            public uint Addr { get; init; }
+            public uint Index { get; init; }
+            public uint Command { get; init; }
+            public uint Argument { get; init; }
+        }
+
+        /// <summary>
+        /// Walk the Japanese-name font sub-list at the dereferenced pointer.
+        /// Stops at the first 0xFF terminator or after <see cref="N1MaxEntries"/>.
+        /// Returns an empty list if the pointer is invalid.
+        /// </summary>
+        public List<N1Row> LoadN1FontList(uint pointerSlotAddr)
+        {
+            var result = new List<N1Row>();
+            ROM rom = CoreState.ROM;
+            if (rom == null) return result;
+            if (pointerSlotAddr == 0 || pointerSlotAddr + 4 > (uint)rom.Data.Length) return result;
+
+            uint baseAddr = rom.p32(pointerSlotAddr);
+            if (!U.isSafetyOffset(baseAddr)) return result;
+
+            for (uint i = 0; i < N1MaxEntries; i++)
+            {
+                uint addr = baseAddr + i;
+                if (addr >= (uint)rom.Data.Length) break;
+                uint b = rom.u8(addr);
+                if (b == 0xFF) break;
+                result.Add(new N1Row { Addr = addr, Index = i, GlyphId = b });
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Walk the animation command sub-list at the dereferenced pointer.
+        /// Each row is (Cmd, Arg) — 2 bytes. Stops at the first 0x00 Cmd
+        /// terminator or after <see cref="N2MaxEntries"/>.
+        /// </summary>
+        public List<N2Row> LoadN2CommandList(uint pointerSlotAddr)
+        {
+            var result = new List<N2Row>();
+            ROM rom = CoreState.ROM;
+            if (rom == null) return result;
+            if (pointerSlotAddr == 0 || pointerSlotAddr + 4 > (uint)rom.Data.Length) return result;
+
+            uint baseAddr = rom.p32(pointerSlotAddr);
+            if (!U.isSafetyOffset(baseAddr)) return result;
+
+            for (uint i = 0; i < N2MaxEntries; i++)
+            {
+                uint addr = baseAddr + i * 2;
+                if (addr + 2 > (uint)rom.Data.Length) break;
+                uint cmd = rom.u8(addr);
+                if (cmd == 0x00) break;
+                uint arg = rom.u8(addr + 1);
+                result.Add(new N2Row { Addr = addr, Index = i, Command = cmd, Argument = arg });
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Write a single byte (glyph ID) at the given N1 row address.
+        /// Caller must wrap in a <c>ROM.BeginUndoScope</c> so the change
+        /// is recorded.
+        /// </summary>
+        public void WriteN1Entry(uint addr, uint glyphId)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null) return;
+            if (addr + 1 > (uint)rom.Data.Length) return;
+            rom.write_u8(addr, glyphId);
+        }
+
+        /// <summary>
+        /// Write (Cmd, Arg) at the given N2 row address.
+        /// Caller must wrap in a <c>ROM.BeginUndoScope</c>.
+        /// </summary>
+        public void WriteN2Entry(uint addr, uint cmd, uint arg)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null) return;
+            if (addr + 2 > (uint)rom.Data.Length) return;
+            rom.write_u8(addr, cmd);
+            rom.write_u8(addr + 1, arg);
+        }
+
+        /// <summary>
+        /// True when the FE8J OPClassReelAnimationIDOver255 patch is
+        /// installed. When true the WF UI swapped the B16 byte and the
+        /// D18 dword field for the battle-anime ID (so the Avalonia
+        /// view should mirror that swap).
+        /// </summary>
+        public bool IsOver255PatchActive => PatchDetection.OPClassReelAnimationIDOver255Detect(CoreState.ROM);
+
+        /// <summary>
+        /// True when the OPClassReelSort patch (FE8J or FE8U) is installed.
+        /// When true the WF main-list "ListExpand" button was visible.
+        /// </summary>
+        public bool IsReelSortPatchActive => PatchDetection.OPClassReelSortPatchDetect(CoreState.ROM);
+
+        /// <summary>
+        /// Run a `DataExpansionCore.ExpandTable` call against the main
+        /// OPClassDemo table pointer and refresh internal state.
+        /// Caller is responsible for opening / committing the
+        /// <c>_undoService</c> scope.
+        /// </summary>
+        public DataExpansionCore.ExpandResult ExpandList()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null)
+                return new DataExpansionCore.ExpandResult { Success = false, Error = "ROM not loaded." };
+
+            uint ptrAddr = rom.RomInfo.op_class_demo_pointer;
+            if (ptrAddr == 0)
+                return new DataExpansionCore.ExpandResult { Success = false, Error = "op_class_demo_pointer not set." };
+
+            uint currentCount = (uint)LoadOPClassDemoList().Count;
+            return DataExpansionCore.ExpandTable(rom, ptrAddr, entrySize: 28, currentCount);
+        }
     }
 }

--- a/FEBuilderGBA.Avalonia/ViewModels/OPClassDemoViewerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/OPClassDemoViewerViewModel.cs
@@ -6,8 +6,13 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 {
     public class OPClassDemoViewerViewModel : ViewModelBase, IDataVerifiable
     {
+        // Pointer fields P0/P8/P24 use `rom.p32`/`write_p32` semantics
+        // — store ROM offset (without the 0x08000000 GBA bit). This
+        // mirrors WinForms `OPClassDemoForm` which uses InputFormRef
+        // P-prefix fields for the same slots. (Copilot CLI re-review
+        // on PR #544 flagged D8/D24 as bypassing pointer semantics.)
         static readonly List<EditorFormRef.FieldDef> _fields =
-            EditorFormRef.DetectFields(new[] { "D0", "D4", "D8", "B12", "B13", "B14", "B15", "B16", "B17", "D18", "B22", "B23", "D24" });
+            EditorFormRef.DetectFields(new[] { "P0", "D4", "P8", "B12", "B13", "B14", "B15", "B16", "B17", "D18", "B22", "B23", "P24" });
 
         uint _currentAddr;
         bool _canWrite;
@@ -78,9 +83,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (rom == null) return;
             CurrentAddr = addr;
             var v = EditorFormRef.ReadFields(rom, addr, _fields);
-            EnglishNamePointer = v["D0"];
+            EnglishNamePointer = v["P0"];
             DescriptionTextId = v["D4"];
-            JapaneseNamePointer = v["D8"];
+            JapaneseNamePointer = v["P8"];
             JapaneseNameLength = v["B12"];
             PaletteId = v["B13"];
             DisplayWeapon = v["B14"];
@@ -90,7 +95,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             Unknown18 = v["D18"];
             TerrainLeft = v["B22"];
             TerrainRight = v["B23"];
-            AnimePointer = v["D24"];
+            AnimePointer = v["P24"];
             CanWrite = true;
         }
 
@@ -100,10 +105,10 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (rom == null || CurrentAddr == 0) return;
             var values = new Dictionary<string, uint>
             {
-                ["D0"] = EnglishNamePointer, ["D4"] = DescriptionTextId, ["D8"] = JapaneseNamePointer,
+                ["P0"] = EnglishNamePointer, ["D4"] = DescriptionTextId, ["P8"] = JapaneseNamePointer,
                 ["B12"] = JapaneseNameLength, ["B13"] = PaletteId, ["B14"] = DisplayWeapon,
                 ["B15"] = AllyEnemyColor, ["B16"] = BattleAnime, ["B17"] = MagicEffect,
-                ["D18"] = Unknown18, ["B22"] = TerrainLeft, ["B23"] = TerrainRight, ["D24"] = AnimePointer,
+                ["D18"] = Unknown18, ["B22"] = TerrainLeft, ["B23"] = TerrainRight, ["P24"] = AnimePointer,
             };
             EditorFormRef.WriteFields(rom, CurrentAddr, values, _fields);
         }

--- a/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml
@@ -2,62 +2,261 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
         x:Class="FEBuilderGBA.Avalonia.Views.OPClassDemoViewerView"
-        Title="OP Class Demo Editor" Width="1429" Height="848"
+        Title="OP Class Demo Editor" Width="1534" Height="878"
         SizeToContent="WidthAndHeight">
-  <Grid ColumnDefinitions="250,*">
-    <controls:AddressListControl AutomationProperties.AutomationId="OPClassDemoViewer_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
-    <ScrollViewer Grid.Column="1" Margin="4">
+  <!-- Three-row layout: top bar (filter + reload), address bar, main 3-pane grid.
+       Mirrors WF panel1 (top), AddressPanel (mid), panel12+panel2 (bottom). -->
+  <Grid RowDefinitions="Auto,Auto,*" ColumnDefinitions="270,*">
+
+    <!-- ===== Row 0: Top filter / reload bar (mirrors WF panel1) ===== -->
+    <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
+      <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
+        <Label Content="Hex Address" VerticalAlignment="Center" />
+        <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_ReadStart_Input"
+                       FormatString="X8" Name="ReadStartAddressBox" Width="140"
+                       Minimum="0" Maximum="65535999"
+                       IsEnabled="False" VerticalAlignment="Center" />
+        <Label Content="Read Count" VerticalAlignment="Center" />
+        <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_ReadCount_Input"
+                       FormatString="0" Name="ReadCountBox" Width="80"
+                       Minimum="0" Maximum="500"
+                       IsEnabled="False" VerticalAlignment="Center" />
+        <Button AutomationProperties.AutomationId="OPClassDemoViewer_ReloadList_Button"
+                Name="ReloadListButton" Content="Reload" Click="ReloadList_Click" />
+        <TextBlock AutomationProperties.AutomationId="OPClassDemoViewer_PatchNotice_Label"
+                   Name="PatchNoticeText" Foreground="DarkOrange"
+                   TextWrapping="Wrap" VerticalAlignment="Center" Margin="12,0,0,0" />
+      </StackPanel>
+    </Border>
+
+    <!-- ===== Row 1: Main address-write bar (mirrors WF AddressPanel) ===== -->
+    <Border Grid.Row="1" Grid.Column="1" BorderBrush="Gray" BorderThickness="1" Margin="4">
+      <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
+        <Label Content="Address" VerticalAlignment="Center" />
+        <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_Addr_Input"
+                       FormatString="X8" Name="AddressBox" Width="140"
+                       Minimum="0" Maximum="65535999"
+                       IsEnabled="False" VerticalAlignment="Center" />
+        <Label Content="Size:" VerticalAlignment="Center" />
+        <TextBox AutomationProperties.AutomationId="OPClassDemoViewer_BlockSize_Input"
+                 Name="BlockSizeBox" IsReadOnly="True" Text="28" Width="80"
+                 VerticalAlignment="Center" />
+        <Label Content="Selected Address:" VerticalAlignment="Center" />
+        <TextBox AutomationProperties.AutomationId="OPClassDemoViewer_SelectedAddress_Input"
+                 Name="SelectedAddressBox" IsReadOnly="True" Width="140"
+                 VerticalAlignment="Center" />
+        <Button AutomationProperties.AutomationId="OPClassDemoViewer_Write_Button"
+                Name="WriteButton" Content="Write" Click="Write_Click"
+                Margin="20,0,0,0" />
+        <TextBlock AutomationProperties.AutomationId="OPClassDemoViewer_Addr_Label"
+                   Name="AddrLabel" VerticalAlignment="Center" Margin="20,0,0,0" />
+      </StackPanel>
+    </Border>
+
+    <!-- ===== Row 2 left: Main address list + List-Expand (mirrors WF panel12) ===== -->
+    <Border Grid.Row="2" Grid.Column="0" BorderBrush="Gray" BorderThickness="1" Margin="4">
+      <DockPanel>
+        <Label DockPanel.Dock="Top" Content="Name" />
+        <Button DockPanel.Dock="Bottom"
+                AutomationProperties.AutomationId="OPClassDemoViewer_ListExpand_Button"
+                Name="ListExpandButton" Content="Data Expansion"
+                Click="ListExpand_Click" HorizontalAlignment="Stretch"
+                IsVisible="False" />
+        <controls:AddressListControl AutomationProperties.AutomationId="OPClassDemoViewer_Entry_List"
+                                     Name="EntryList" Margin="2" />
+      </DockPanel>
+    </Border>
+
+    <!-- ===== Row 2 right: detail + two sub-lists ===== -->
+    <ScrollViewer Grid.Row="2" Grid.Column="1">
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="OP Class Demo Editor" FontSize="18" FontWeight="Bold" />
-        <Grid ColumnDefinitions="200,200,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="OPClassDemoViewer_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
 
-          <TextBlock Grid.Row="1" Grid.Column="0" Text="English Name Pointer:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_EnglishNamePtr_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="EnglishNamePtrBox" Minimum="0" Maximum="4294967295" />
+        <!-- Main detail grid (mirrors WF panel2 main fields) -->
+        <Border BorderBrush="Gray" BorderThickness="1" Padding="6">
+          <Grid ColumnDefinitions="200,140,80,200,*"
+                RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
 
-          <TextBlock Grid.Row="2" Grid.Column="0" Text="Description Text ID:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_DescTextId_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="DescTextIdBox" Minimum="0" Maximum="4294967295" />
-          <TextBlock AutomationProperties.AutomationId="OPClassDemoViewer_DescTextId_Label" Grid.Row="2" Grid.Column="2" Name="DescTextPreview" Foreground="Gray" FontSize="11"
-                     VerticalAlignment="Center" Margin="4,0,0,0"
-                     TextTrimming="CharacterEllipsis" MaxWidth="200" />
+            <!-- Row 0: English (alpha) name pointer -->
+            <Label Grid.Row="0" Grid.Column="0" Content="English Name Pointer:" VerticalAlignment="Center" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_EnglishNamePtr_Input"
+                           FormatString="X8" Grid.Row="0" Grid.Column="1"
+                           Name="EnglishNamePtrBox"
+                           Minimum="0" Maximum="4294967295" VerticalAlignment="Center" />
+            <TextBox AutomationProperties.AutomationId="OPClassDemoViewer_EnglishName_Label"
+                     Grid.Row="0" Grid.Column="3" Grid.ColumnSpan="2"
+                     Name="EnglishNamePreview" IsReadOnly="True" VerticalAlignment="Center" />
 
-          <TextBlock Grid.Row="3" Grid.Column="0" Text="Japanese Name Pointer:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_JpNamePtr_Input" FormatString="0" Grid.Row="3" Grid.Column="1" Name="JpNamePtrBox" Minimum="0" Maximum="4294967295" />
+            <!-- Row 1: Description Text ID -->
+            <Label Grid.Row="1" Grid.Column="0" Content="Description Text ID:" VerticalAlignment="Center" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_DescTextId_Input"
+                           FormatString="0" Grid.Row="1" Grid.Column="1"
+                           Name="DescTextIdBox"
+                           Minimum="0" Maximum="4294967295" VerticalAlignment="Center" />
+            <TextBox AutomationProperties.AutomationId="OPClassDemoViewer_DescTextId_Label"
+                     Grid.Row="1" Grid.Column="3" Grid.ColumnSpan="2"
+                     Name="DescTextPreview" IsReadOnly="True" VerticalAlignment="Center" />
 
-          <TextBlock Grid.Row="4" Grid.Column="0" Text="Japanese Name Length:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_JpNameLen_Input" FormatString="0" Grid.Row="4" Grid.Column="1" Name="JpNameLenBox" Minimum="0" Maximum="255" />
+            <!-- Row 2: Japanese Name Pointer -->
+            <Label Grid.Row="2" Grid.Column="0" Content="Japanese Name Pointer:" VerticalAlignment="Center" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_JpNamePtr_Input"
+                           FormatString="X8" Grid.Row="2" Grid.Column="1"
+                           Name="JpNamePtrBox"
+                           Minimum="0" Maximum="4294967295" VerticalAlignment="Center" />
 
-          <TextBlock Grid.Row="5" Grid.Column="0" Text="Palette ID:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_PaletteId_Input" FormatString="0" Grid.Row="5" Grid.Column="1" Name="PaletteIdBox" Minimum="0" Maximum="255" />
+            <!-- Row 3: Japanese Name Length -->
+            <Label Grid.Row="3" Grid.Column="0" Content="Japanese Name Length:" VerticalAlignment="Center" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_JpNameLen_Input"
+                           FormatString="0" Grid.Row="3" Grid.Column="1"
+                           Name="JpNameLenBox"
+                           Minimum="0" Maximum="255" VerticalAlignment="Center" />
 
-          <TextBlock Grid.Row="6" Grid.Column="0" Text="Display Weapon:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_DisplayWeapon_Input" FormatString="0" Grid.Row="6" Grid.Column="1" Name="DisplayWeaponBox" Minimum="0" Maximum="255" />
+            <!-- Row 4: Palette ID -->
+            <Label Grid.Row="4" Grid.Column="0" Content="Palette ID:" VerticalAlignment="Center" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_PaletteId_Input"
+                           FormatString="0" Grid.Row="4" Grid.Column="1"
+                           Name="PaletteIdBox"
+                           Minimum="0" Maximum="255" VerticalAlignment="Center" />
+            <TextBox AutomationProperties.AutomationId="OPClassDemoViewer_PaletteId_Label"
+                     Grid.Row="4" Grid.Column="3" Grid.ColumnSpan="2"
+                     Name="PalettePreview" IsReadOnly="True" VerticalAlignment="Center" />
 
-          <TextBlock Grid.Row="7" Grid.Column="0" Text="Ally/Enemy Color:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_AllyEnemyColor_Input" FormatString="0" Grid.Row="7" Grid.Column="1" Name="AllyEnemyColorBox" Minimum="0" Maximum="255" />
+            <!-- Row 5: Display Weapon (Class) -->
+            <Label Grid.Row="5" Grid.Column="0" Content="Display Weapon (Class):" VerticalAlignment="Center" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_DisplayWeapon_Input"
+                           FormatString="0" Grid.Row="5" Grid.Column="1"
+                           Name="DisplayWeaponBox"
+                           Minimum="0" Maximum="255" VerticalAlignment="Center" />
+            <TextBox AutomationProperties.AutomationId="OPClassDemoViewer_ClassName_Label"
+                     Grid.Row="5" Grid.Column="3" Grid.ColumnSpan="2"
+                     Name="ClassNamePreview" IsReadOnly="True" VerticalAlignment="Center" />
 
-          <TextBlock Grid.Row="8" Grid.Column="0" Text="Battle Anime:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_BattleAnime_Input" FormatString="0" Grid.Row="8" Grid.Column="1" Name="BattleAnimeBox" Minimum="0" Maximum="255" />
+            <!-- Row 6: Ally/Enemy Color -->
+            <Label Grid.Row="6" Grid.Column="0" Content="Ally / Enemy Color:" VerticalAlignment="Center" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_AllyEnemyColor_Input"
+                           FormatString="0" Grid.Row="6" Grid.Column="1"
+                           Name="AllyEnemyColorBox"
+                           Minimum="0" Maximum="255" VerticalAlignment="Center" />
+            <ComboBox AutomationProperties.AutomationId="OPClassDemoViewer_AllyEnemyColor_Combo"
+                      Grid.Row="6" Grid.Column="3" Grid.ColumnSpan="2"
+                      Name="AllyEnemyColorCombo" Width="200" VerticalAlignment="Center" />
 
-          <TextBlock Grid.Row="9" Grid.Column="0" Text="Magic Effect:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_MagicEffect_Input" FormatString="0" Grid.Row="9" Grid.Column="1" Name="MagicEffectBox" Minimum="0" Maximum="255" />
+            <!-- Row 7: Battle Anime -->
+            <Label Grid.Row="7" Grid.Column="0" Content="Battle Anime:" VerticalAlignment="Center" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_BattleAnime_Input"
+                           FormatString="0" Grid.Row="7" Grid.Column="1"
+                           Name="BattleAnimeBox"
+                           Minimum="0" Maximum="255" VerticalAlignment="Center" />
+            <TextBox AutomationProperties.AutomationId="OPClassDemoViewer_BattleAnime_Label"
+                     Grid.Row="7" Grid.Column="3" Grid.ColumnSpan="2"
+                     Name="BattleAnimePreview" IsReadOnly="True" VerticalAlignment="Center" />
 
-          <TextBlock Grid.Row="10" Grid.Column="0" Text="Unknown (0x12):" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_Unknown18_Input" FormatString="0" Grid.Row="10" Grid.Column="1" Name="Unknown18Box" Minimum="0" Maximum="4294967295" />
+            <!-- Row 8: Magic Effect -->
+            <Label Grid.Row="8" Grid.Column="0" Content="Magic Effect:" VerticalAlignment="Center" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_MagicEffect_Input"
+                           FormatString="0" Grid.Row="8" Grid.Column="1"
+                           Name="MagicEffectBox"
+                           Minimum="0" Maximum="255" VerticalAlignment="Center" />
+            <ComboBox AutomationProperties.AutomationId="OPClassDemoViewer_MagicEffect_Combo"
+                      Grid.Row="8" Grid.Column="3" Grid.ColumnSpan="2"
+                      Name="MagicEffectCombo" Width="200" VerticalAlignment="Center" />
 
-          <TextBlock Grid.Row="11" Grid.Column="0" Text="Terrain Left:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_TerrainLeft_Input" FormatString="0" Grid.Row="11" Grid.Column="1" Name="TerrainLeftBox" Minimum="0" Maximum="255" />
+            <!-- Row 9: Battle Anime PLUS1 (patch-aware D18 — Over255) -->
+            <Label Grid.Row="9" Grid.Column="0"
+                   AutomationProperties.AutomationId="OPClassDemoViewer_BattleAnimePlus1_Label"
+                   Content="Battle Anime (Patch +1):" VerticalAlignment="Center"
+                   Name="BattleAnimePlus1Label" IsVisible="False" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_Unknown18_Input"
+                           FormatString="X8" Grid.Row="9" Grid.Column="1"
+                           Name="Unknown18Box"
+                           Minimum="0" Maximum="4294967295" VerticalAlignment="Center" />
 
-          <TextBlock Grid.Row="12" Grid.Column="0" Text="Terrain Right:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_TerrainRight_Input" FormatString="0" Grid.Row="12" Grid.Column="1" Name="TerrainRightBox" Minimum="0" Maximum="255" />
+            <!-- Row 10: Terrain Left -->
+            <Label Grid.Row="10" Grid.Column="0" Content="Terrain (Left Half):" VerticalAlignment="Center" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_TerrainLeft_Input"
+                           FormatString="0" Grid.Row="10" Grid.Column="1"
+                           Name="TerrainLeftBox"
+                           Minimum="0" Maximum="255" VerticalAlignment="Center" />
+            <TextBox AutomationProperties.AutomationId="OPClassDemoViewer_TerrainLeft_Label"
+                     Grid.Row="10" Grid.Column="3" Grid.ColumnSpan="2"
+                     Name="TerrainLeftPreview" IsReadOnly="True" VerticalAlignment="Center" />
 
-          <TextBlock Grid.Row="13" Grid.Column="0" Text="Anime Pointer:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_AnimePtr_Input" FormatString="0" Grid.Row="13" Grid.Column="1" Name="AnimePtrBox" Minimum="0" Maximum="4294967295" />
-        </Grid>
-        <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,16,0,0">
-          <Button AutomationProperties.AutomationId="OPClassDemoViewer_Write_Button" Content="Write" Click="Write_Click" />
-        </StackPanel>
+            <!-- Row 11: Terrain Right -->
+            <Label Grid.Row="11" Grid.Column="0" Content="Terrain (Right Half):" VerticalAlignment="Center" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_TerrainRight_Input"
+                           FormatString="0" Grid.Row="11" Grid.Column="1"
+                           Name="TerrainRightBox"
+                           Minimum="0" Maximum="255" VerticalAlignment="Center" />
+            <TextBox AutomationProperties.AutomationId="OPClassDemoViewer_TerrainRight_Label"
+                     Grid.Row="11" Grid.Column="3" Grid.ColumnSpan="2"
+                     Name="TerrainRightPreview" IsReadOnly="True" VerticalAlignment="Center" />
+
+            <!-- Row 12: Anime Pointer (P24) -->
+            <Label Grid.Row="12" Grid.Column="0" Content="Anime Spec Pointer:" VerticalAlignment="Center" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_AnimePtr_Input"
+                           FormatString="X8" Grid.Row="12" Grid.Column="1"
+                           Name="AnimePtrBox"
+                           Minimum="0" Maximum="4294967295" VerticalAlignment="Center" />
+
+          </Grid>
+        </Border>
+
+        <!-- ===== N1 sub-list: Japanese Name Font Glyphs (mirrors WF groupBox2) ===== -->
+        <Border BorderBrush="DarkSlateGray" BorderThickness="1" Padding="6">
+          <DockPanel>
+            <Label DockPanel.Dock="Top" Content="Japanese Name Font Glyphs (pointer P8)"
+                   FontWeight="Bold" />
+            <Grid DockPanel.Dock="Bottom" ColumnDefinitions="Auto,Auto,Auto,Auto" Margin="0,4,0,0">
+              <Label Grid.Column="0" Content="Glyph:" VerticalAlignment="Center" />
+              <NumericUpDown Grid.Column="1"
+                             AutomationProperties.AutomationId="OPClassDemoViewer_N1_B0_Input"
+                             FormatString="X2" Name="N1B0Box"
+                             Minimum="0" Maximum="255" Width="80" Margin="4,0" />
+              <TextBox Grid.Column="2"
+                       AutomationProperties.AutomationId="OPClassDemoViewer_N1_SelectedAddress_Input"
+                       Name="N1SelectedAddressBox" IsReadOnly="True" Width="140" Margin="4,0"
+                       VerticalAlignment="Center" />
+              <Button Grid.Column="3"
+                      AutomationProperties.AutomationId="OPClassDemoViewer_N1_Write_Button"
+                      Name="N1WriteButton" Content="Write JP Name Pointer"
+                      Click="N1_Write_Click" Margin="8,0,0,0" />
+            </Grid>
+            <controls:AddressListControl
+                AutomationProperties.AutomationId="OPClassDemoViewer_N1_List"
+                Name="N1List" Height="160" Margin="2" />
+          </DockPanel>
+        </Border>
+
+        <!-- ===== N2 sub-list: Animation Commands (mirrors WF groupBox1) ===== -->
+        <Border BorderBrush="DarkSlateGray" BorderThickness="1" Padding="6">
+          <DockPanel>
+            <Label DockPanel.Dock="Top" Content="Animation Commands (pointer P24)"
+                   FontWeight="Bold" />
+            <Grid DockPanel.Dock="Bottom" ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" Margin="0,4,0,0">
+              <Label Grid.Column="0" Content="Command:" VerticalAlignment="Center" />
+              <NumericUpDown Grid.Column="1"
+                             AutomationProperties.AutomationId="OPClassDemoViewer_N2_B0_Input"
+                             FormatString="X2" Name="N2B0Box"
+                             Minimum="0" Maximum="255" Width="80" Margin="4,0" />
+              <ComboBox Grid.Column="2"
+                        AutomationProperties.AutomationId="OPClassDemoViewer_N2_Cmd_Combo"
+                        Name="N2CmdCombo" Width="200" Margin="4,0" />
+              <Label Grid.Column="3" Content="Arg (/60 sec):" VerticalAlignment="Center" Margin="8,0,0,0" />
+              <NumericUpDown Grid.Column="4"
+                             AutomationProperties.AutomationId="OPClassDemoViewer_N2_B1_Input"
+                             FormatString="0" Name="N2B1Box"
+                             Minimum="0" Maximum="255" Width="80" Margin="4,0" />
+              <Button Grid.Column="5"
+                      AutomationProperties.AutomationId="OPClassDemoViewer_N2_Write_Button"
+                      Name="N2WriteButton" Content="Write Anime Spec Pointer"
+                      Click="N2_Write_Click" Margin="8,0,0,0" />
+            </Grid>
+            <controls:AddressListControl
+                AutomationProperties.AutomationId="OPClassDemoViewer_N2_List"
+                Name="N2List" Height="160" Margin="2" />
+          </DockPanel>
+        </Border>
+
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml
@@ -161,7 +161,16 @@
                       Grid.Row="8" Grid.Column="3" Grid.ColumnSpan="2"
                       Name="MagicEffectCombo" Width="200" VerticalAlignment="Center" />
 
-            <!-- Row 9: Battle Anime PLUS1 (patch-aware D18 — Over255) -->
+            <!-- Row 9: Battle Anime PLUS1 (patch-aware D18 — Over255).
+                 Two stacked labels in slot 0: vanilla "Unknown (0x12):" is
+                 shown when the patch is absent, "Battle Anime (Patch +1):"
+                 takes over when the patch is active. Copilot bot review
+                 PRRT_kwDOH0Mc1M6ETj-6 on PR #544 caught the label-less
+                 vanilla case. -->
+            <Label Grid.Row="9" Grid.Column="0"
+                   AutomationProperties.AutomationId="OPClassDemoViewer_Unknown18Vanilla_Label"
+                   Content="Unknown (0x12):" VerticalAlignment="Center"
+                   Name="Unknown18VanillaLabel" />
             <Label Grid.Row="9" Grid.Column="0"
                    AutomationProperties.AutomationId="OPClassDemoViewer_BattleAnimePlus1_Label"
                    Content="Battle Anime (Patch +1):" VerticalAlignment="Center"
@@ -218,7 +227,7 @@
                        VerticalAlignment="Center" />
               <Button Grid.Column="3"
                       AutomationProperties.AutomationId="OPClassDemoViewer_N1_Write_Button"
-                      Name="N1WriteButton" Content="Write JP Name Pointer"
+                      Name="N1WriteButton" Content="Write Glyph Entry"
                       Click="N1_Write_Click" Margin="8,0,0,0" />
             </Grid>
             <controls:AddressListControl
@@ -248,7 +257,7 @@
                              Minimum="0" Maximum="255" Width="80" Margin="4,0" />
               <Button Grid.Column="5"
                       AutomationProperties.AutomationId="OPClassDemoViewer_N2_Write_Button"
-                      Name="N2WriteButton" Content="Write Anime Spec Pointer"
+                      Name="N2WriteButton" Content="Write Anime Command"
                       Click="N2_Write_Click" Margin="8,0,0,0" />
             </Grid>
             <controls:AddressListControl

--- a/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Services;
@@ -7,10 +8,24 @@ using FEBuilderGBA.Core;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
+    /// <summary>
+    /// OP Class Demo Editor — Avalonia parity for WinForms OPClassDemoForm.
+    /// Rebuilt for gap-sweep #419: three-pane master-detail layout with two
+    /// sub-lists (Japanese name font glyphs / animation commands) plus
+    /// patch-aware affordances for OPClassReelSort and OPClassReelAnimationIDOver255.
+    /// </summary>
     public partial class OPClassDemoViewerView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly OPClassDemoViewerViewModel _vm = new();
         readonly UndoService _undoService = new();
+
+        // N1 sub-list state — Japanese name font glyphs (1 byte each, terminator 0xFF).
+        List<OPClassDemoViewerViewModel.N1Row> _n1Rows = new();
+        uint _n1SelectedAddr;
+
+        // N2 sub-list state — animation commands (2 bytes: Cmd, Arg; terminator Cmd=0x00).
+        List<OPClassDemoViewerViewModel.N2Row> _n2Rows = new();
+        uint _n2SelectedAddr;
 
         public string ViewTitle => "OP Class Demo Editor";
         public bool IsLoaded => _vm.CanWrite;
@@ -20,8 +35,108 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
+            N1List.SelectedAddressChanged += OnN1Selected;
+            N2List.SelectedAddressChanged += OnN2Selected;
             DescTextIdBox.ValueChanged += OnDescTextIdChanged;
-            Opened += (_, _) => LoadList();
+            DisplayWeaponBox.ValueChanged += OnDisplayWeaponChanged;
+            EnglishNamePtrBox.ValueChanged += OnEnglishNamePtrChanged;
+            PaletteIdBox.ValueChanged += OnPaletteIdChanged;
+            TerrainLeftBox.ValueChanged += OnTerrainLeftChanged;
+            TerrainRightBox.ValueChanged += OnTerrainRightChanged;
+            BattleAnimeBox.ValueChanged += OnBattleAnimeChanged;
+            JpNamePtrBox.ValueChanged += OnJpNamePtrChanged;
+            AnimePtrBox.ValueChanged += OnAnimePtrChanged;
+            N2B0Box.ValueChanged += OnN2B0Changed;
+
+            // Populate combo boxes.
+            AllyEnemyColorCombo.Items.Add("00 = Player");
+            AllyEnemyColorCombo.Items.Add("01 = Enemy");
+            AllyEnemyColorCombo.Items.Add("02 = NPC");
+            AllyEnemyColorCombo.Items.Add("03 = Gray");
+
+            MagicEffectCombo.Items.Add("00 = None");
+            MagicEffectCombo.Items.Add("01 = Fire");
+            MagicEffectCombo.Items.Add("02 = Thunder");
+            MagicEffectCombo.Items.Add("03 = Live");
+            MagicEffectCombo.Items.Add("04 = Light");
+            MagicEffectCombo.Items.Add("05 = Mil");
+            MagicEffectCombo.Items.Add("06 = Manakete");
+            MagicEffectCombo.Items.Add("07 = Monster Magic");
+            MagicEffectCombo.Items.Add("08 = Stone");
+
+            N2CmdCombo.Items.Add("1 = Close-range attack animation");
+            N2CmdCombo.Items.Add("2 = Close-range critical animation");
+            N2CmdCombo.Items.Add("3 = Set anime state to 'hit effect applied'");
+            N2CmdCombo.Items.Add("4 = Long-range attack animation");
+            N2CmdCombo.Items.Add("5 = Wait N frames");
+            N2CmdCombo.Items.Add("6 = Close-range dodge animation");
+            N2CmdCombo.Items.Add("7 = (FE8 unused) Set anime state to 'hit effect applied'");
+            N2CmdCombo.Items.Add("8 = Wait until anime reaches C01/C02/C18");
+
+            AllyEnemyColorCombo.SelectionChanged += (_, _) =>
+            {
+                if (_vm.IsLoading) return;
+                if (AllyEnemyColorCombo.SelectedIndex >= 0)
+                    AllyEnemyColorBox.Value = AllyEnemyColorCombo.SelectedIndex;
+            };
+            AllyEnemyColorBox.ValueChanged += (_, _) =>
+            {
+                if (_vm.IsLoading) return;
+                int v = (int)(AllyEnemyColorBox.Value ?? 0);
+                AllyEnemyColorCombo.SelectedIndex = (v >= 0 && v < AllyEnemyColorCombo.ItemCount) ? v : -1;
+            };
+
+            MagicEffectCombo.SelectionChanged += (_, _) =>
+            {
+                if (_vm.IsLoading) return;
+                if (MagicEffectCombo.SelectedIndex >= 0)
+                    MagicEffectBox.Value = MagicEffectCombo.SelectedIndex;
+            };
+            MagicEffectBox.ValueChanged += (_, _) =>
+            {
+                if (_vm.IsLoading) return;
+                int v = (int)(MagicEffectBox.Value ?? 0);
+                MagicEffectCombo.SelectedIndex = (v >= 0 && v < MagicEffectCombo.ItemCount) ? v : -1;
+            };
+
+            N2CmdCombo.SelectionChanged += (_, _) =>
+            {
+                if (_vm.IsLoading) return;
+                int idx = N2CmdCombo.SelectedIndex;
+                if (idx >= 0)
+                    N2B0Box.Value = idx + 1; // combo entry "1=..." → value 1
+            };
+
+            Opened += (_, _) =>
+            {
+                ApplyPatchAwareUI();
+                LoadList();
+            };
+        }
+
+        // -----------------------------------------------------------------
+        // Patch-aware UI: show ListExpand button only when OPClassReelSort
+        // is installed; show the BattleAnime+1 label only when Over255 is
+        // active (mirrors WF OPClassDemoForm constructor logic).
+        // -----------------------------------------------------------------
+        void ApplyPatchAwareUI()
+        {
+            bool listExpand = _vm.IsReelSortPatchActive;
+            bool over255 = _vm.IsOver255PatchActive;
+            ListExpandButton.IsVisible = listExpand;
+            BattleAnimePlus1Label.IsVisible = over255;
+            if (over255)
+            {
+                PatchNoticeText.Text = "Patch: OPClassReelAnimationIDOver255 active. Battle Anime ID is read from D18.";
+            }
+            else if (listExpand)
+            {
+                PatchNoticeText.Text = "Patch: OPClassReelSort active. Data Expansion enabled.";
+            }
+            else
+            {
+                PatchNoticeText.Text = "";
+            }
         }
 
         void OnDescTextIdChanged(object? sender, NumericUpDownValueChangedEventArgs e)
@@ -32,10 +147,84 @@ namespace FEBuilderGBA.Avalonia.Views
             catch { DescTextPreview.Text = ""; }
         }
 
+        void OnDisplayWeaponChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            if (_vm.IsLoading) return;
+            uint id = (uint)(DisplayWeaponBox.Value ?? 0);
+            try { ClassNamePreview.Text = NameResolver.GetClassName(id); }
+            catch { ClassNamePreview.Text = ""; }
+        }
+
+        void OnEnglishNamePtrChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            if (_vm.IsLoading) return;
+            uint ptr = (uint)(EnglishNamePtrBox.Value ?? 0);
+            EnglishNamePreview.Text = ptr != 0 ? $"0x{ptr:X08}" : "";
+        }
+
+        void OnPaletteIdChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            if (_vm.IsLoading) return;
+            uint id = (uint)(PaletteIdBox.Value ?? 0);
+            PalettePreview.Text = id == 0xFF ? "Default palette" : $"Palette 0x{id:X02}";
+        }
+
+        void OnTerrainLeftChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            if (_vm.IsLoading) return;
+            uint id = (uint)(TerrainLeftBox.Value ?? 0);
+            TerrainLeftPreview.Text = $"Terrain 0x{id:X02}";
+        }
+
+        void OnTerrainRightChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            if (_vm.IsLoading) return;
+            uint id = (uint)(TerrainRightBox.Value ?? 0);
+            TerrainRightPreview.Text = $"Terrain 0x{id:X02}";
+        }
+
+        void OnBattleAnimeChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            if (_vm.IsLoading) return;
+            uint id = (uint)(BattleAnimeBox.Value ?? 0);
+            BattleAnimePreview.Text = $"Anime 0x{id:X02}";
+        }
+
+        void OnJpNamePtrChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            if (_vm.IsLoading) return;
+            LoadN1Sublist();
+        }
+
+        void OnAnimePtrChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            if (_vm.IsLoading) return;
+            LoadN2Sublist();
+        }
+
+        void OnN2B0Changed(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            if (_vm.IsLoading) return;
+            int val = (int)(N2B0Box.Value ?? 0);
+            // Map command byte → combo index (1..8 → 0..7; anything else → -1).
+            int idx = (val >= 1 && val <= 8) ? val - 1 : -1;
+            if (N2CmdCombo.SelectedIndex != idx)
+                N2CmdCombo.SelectedIndex = idx;
+        }
+
         void LoadList()
         {
             _vm.IsLoading = true;
-            try { var items = _vm.LoadOPClassDemoList(); EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ClassIconLoader(items, i)); }
+            try
+            {
+                var items = _vm.LoadOPClassDemoList();
+                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ClassIconLoader(items, i));
+                if (CoreState.ROM?.RomInfo != null)
+                {
+                    ReadStartAddressBox.Value = CoreState.ROM.RomInfo.op_class_demo_pointer;
+                    ReadCountBox.Value = items.Count;
+                }
+            }
             catch (Exception ex) { Log.Error($"OPClassDemoViewerView.LoadList: {ex.Message}"); }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -47,14 +236,89 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 _vm.LoadOPClassDemo(addr);
                 UpdateUI();
+                LoadN1Sublist();
+                LoadN2Sublist();
             }
             catch (Exception ex) { Log.Error($"OPClassDemoViewerView.OnSelected: {ex.Message}"); }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
 
+        void LoadN1Sublist()
+        {
+            try
+            {
+                if (_vm.CurrentAddr == 0) { _n1Rows = new(); N1List.SetItems(new List<AddrResult>()); return; }
+                _n1Rows = _vm.LoadN1FontList(_vm.CurrentAddr + 8);
+                var items = new List<AddrResult>();
+                for (int i = 0; i < _n1Rows.Count; i++)
+                {
+                    items.Add(new AddrResult(_n1Rows[i].Addr, $"{i:X2}: 0x{_n1Rows[i].GlyphId:X2}", (uint)i));
+                }
+                N1List.SetItems(items);
+            }
+            catch (Exception ex) { Log.Error($"OPClassDemoViewerView.LoadN1Sublist: {ex.Message}"); }
+        }
+
+        void LoadN2Sublist()
+        {
+            try
+            {
+                if (_vm.CurrentAddr == 0) { _n2Rows = new(); N2List.SetItems(new List<AddrResult>()); return; }
+                _n2Rows = _vm.LoadN2CommandList(_vm.CurrentAddr + 24);
+                var items = new List<AddrResult>();
+                for (int i = 0; i < _n2Rows.Count; i++)
+                {
+                    items.Add(new AddrResult(_n2Rows[i].Addr, $"{i:X2}: Cmd={_n2Rows[i].Command:X2} Arg={_n2Rows[i].Argument}", (uint)i));
+                }
+                N2List.SetItems(items);
+            }
+            catch (Exception ex) { Log.Error($"OPClassDemoViewerView.LoadN2Sublist: {ex.Message}"); }
+        }
+
+        void OnN1Selected(uint addr)
+        {
+            _n1SelectedAddr = addr;
+            N1SelectedAddressBox.Text = $"0x{addr:X08}";
+            try
+            {
+                var rom = CoreState.ROM;
+                if (rom != null && addr != 0 && addr < (uint)rom.Data.Length)
+                {
+                    _vm.IsLoading = true;
+                    try { N1B0Box.Value = rom.u8(addr); }
+                    finally { _vm.IsLoading = false; }
+                }
+            }
+            catch (Exception ex) { Log.Error($"OPClassDemoViewerView.OnN1Selected: {ex.Message}"); }
+        }
+
+        void OnN2Selected(uint addr)
+        {
+            _n2SelectedAddr = addr;
+            try
+            {
+                var rom = CoreState.ROM;
+                if (rom != null && addr != 0 && addr + 2 <= (uint)rom.Data.Length)
+                {
+                    _vm.IsLoading = true;
+                    try
+                    {
+                        N2B0Box.Value = rom.u8(addr);
+                        N2B1Box.Value = rom.u8(addr + 1);
+                        int val = (int)N2B0Box.Value;
+                        N2CmdCombo.SelectedIndex = (val >= 1 && val <= 8) ? val - 1 : -1;
+                    }
+                    finally { _vm.IsLoading = false; }
+                }
+            }
+            catch (Exception ex) { Log.Error($"OPClassDemoViewerView.OnN2Selected: {ex.Message}"); }
+        }
+
         void UpdateUI()
         {
             AddrLabel.Text = $"0x{_vm.CurrentAddr:X08}";
+            AddressBox.Value = _vm.CurrentAddr;
+            SelectedAddressBox.Text = $"0x{_vm.CurrentAddr:X08}";
             EnglishNamePtrBox.Value = _vm.EnglishNamePointer;
             DescTextIdBox.Value = _vm.DescriptionTextId;
             try { DescTextPreview.Text = _vm.DescriptionTextId != 0 ? NameResolver.GetTextById(_vm.DescriptionTextId) : ""; }
@@ -63,6 +327,8 @@ namespace FEBuilderGBA.Avalonia.Views
             JpNameLenBox.Value = _vm.JapaneseNameLength;
             PaletteIdBox.Value = _vm.PaletteId;
             DisplayWeaponBox.Value = _vm.DisplayWeapon;
+            try { ClassNamePreview.Text = NameResolver.GetClassName(_vm.DisplayWeapon); }
+            catch { ClassNamePreview.Text = ""; }
             AllyEnemyColorBox.Value = _vm.AllyEnemyColor;
             BattleAnimeBox.Value = _vm.BattleAnime;
             MagicEffectBox.Value = _vm.MagicEffect;
@@ -70,6 +336,12 @@ namespace FEBuilderGBA.Avalonia.Views
             TerrainLeftBox.Value = _vm.TerrainLeft;
             TerrainRightBox.Value = _vm.TerrainRight;
             AnimePtrBox.Value = _vm.AnimePointer;
+        }
+
+        void ReloadList_Click(object? sender, RoutedEventArgs e)
+        {
+            ApplyPatchAwareUI();
+            LoadList();
         }
 
         void Write_Click(object? sender, RoutedEventArgs e)
@@ -97,6 +369,56 @@ namespace FEBuilderGBA.Avalonia.Views
                 CoreState.Services?.ShowInfo("OP Class Demo data written.");
             }
             catch (Exception ex) { _undoService.Rollback(); Log.Error($"OPClassDemoViewerView.Write: {ex.Message}"); }
+        }
+
+        void N1_Write_Click(object? sender, RoutedEventArgs e)
+        {
+            if (!_vm.CanWrite || _n1SelectedAddr == 0) return;
+            _undoService.Begin("Edit OP Class Demo (JP Name Font Glyph)");
+            try
+            {
+                uint glyph = (uint)(N1B0Box.Value ?? 0);
+                _vm.WriteN1Entry(_n1SelectedAddr, glyph);
+                _undoService.Commit();
+                LoadN1Sublist();
+                CoreState.Services?.ShowInfo("JP name font glyph written.");
+            }
+            catch (Exception ex) { _undoService.Rollback(); Log.Error($"OPClassDemoViewerView.N1_Write: {ex.Message}"); }
+        }
+
+        void N2_Write_Click(object? sender, RoutedEventArgs e)
+        {
+            if (!_vm.CanWrite || _n2SelectedAddr == 0) return;
+            _undoService.Begin("Edit OP Class Demo (Animation Command)");
+            try
+            {
+                uint cmd = (uint)(N2B0Box.Value ?? 0);
+                uint arg = (uint)(N2B1Box.Value ?? 0);
+                _vm.WriteN2Entry(_n2SelectedAddr, cmd, arg);
+                _undoService.Commit();
+                LoadN2Sublist();
+                CoreState.Services?.ShowInfo("Animation command written.");
+            }
+            catch (Exception ex) { _undoService.Rollback(); Log.Error($"OPClassDemoViewerView.N2_Write: {ex.Message}"); }
+        }
+
+        void ListExpand_Click(object? sender, RoutedEventArgs e)
+        {
+            _undoService.Begin("Expand OP Class Demo Table");
+            try
+            {
+                var result = _vm.ExpandList();
+                if (!result.Success)
+                {
+                    _undoService.Rollback();
+                    CoreState.Services?.ShowError(result.Error ?? "Expansion failed.");
+                    return;
+                }
+                _undoService.Commit();
+                LoadList();
+                CoreState.Services?.ShowInfo($"Table expanded. New base: 0x{result.NewBaseAddress:X08}, new count: {result.NewCount}.");
+            }
+            catch (Exception ex) { _undoService.Rollback(); Log.Error($"OPClassDemoViewerView.ListExpand: {ex.Message}"); }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml.cs
@@ -48,30 +48,33 @@ namespace FEBuilderGBA.Avalonia.Views
             AnimePtrBox.ValueChanged += OnAnimePtrChanged;
             N2B0Box.ValueChanged += OnN2B0Changed;
 
-            // Populate combo boxes.
-            AllyEnemyColorCombo.Items.Add("00 = Player");
-            AllyEnemyColorCombo.Items.Add("01 = Enemy");
-            AllyEnemyColorCombo.Items.Add("02 = NPC");
-            AllyEnemyColorCombo.Items.Add("03 = Gray");
+            // Populate combo boxes. ComboBox.Items strings are NOT scanned by
+            // ViewTranslationHelper (Copilot bot review thread
+            // PRRT_kwDOH0Mc1M6ETSJC on PR #544), so route them through R._()
+            // explicitly so ja/zh locales pick up the translation table entries.
+            AllyEnemyColorCombo.Items.Add(R._("00 = Player"));
+            AllyEnemyColorCombo.Items.Add(R._("01 = Enemy"));
+            AllyEnemyColorCombo.Items.Add(R._("02 = NPC"));
+            AllyEnemyColorCombo.Items.Add(R._("03 = Gray"));
 
-            MagicEffectCombo.Items.Add("00 = None");
-            MagicEffectCombo.Items.Add("01 = Fire");
-            MagicEffectCombo.Items.Add("02 = Thunder");
-            MagicEffectCombo.Items.Add("03 = Live");
-            MagicEffectCombo.Items.Add("04 = Light");
-            MagicEffectCombo.Items.Add("05 = Mil");
-            MagicEffectCombo.Items.Add("06 = Manakete");
-            MagicEffectCombo.Items.Add("07 = Monster Magic");
-            MagicEffectCombo.Items.Add("08 = Stone");
+            MagicEffectCombo.Items.Add(R._("00 = None"));
+            MagicEffectCombo.Items.Add(R._("01 = Fire"));
+            MagicEffectCombo.Items.Add(R._("02 = Thunder"));
+            MagicEffectCombo.Items.Add(R._("03 = Live"));
+            MagicEffectCombo.Items.Add(R._("04 = Light"));
+            MagicEffectCombo.Items.Add(R._("05 = Mil"));
+            MagicEffectCombo.Items.Add(R._("06 = Manakete"));
+            MagicEffectCombo.Items.Add(R._("07 = Monster Magic"));
+            MagicEffectCombo.Items.Add(R._("08 = Stone"));
 
-            N2CmdCombo.Items.Add("1 = Close-range attack animation");
-            N2CmdCombo.Items.Add("2 = Close-range critical animation");
-            N2CmdCombo.Items.Add("3 = Set anime state to 'hit effect applied'");
-            N2CmdCombo.Items.Add("4 = Long-range attack animation");
-            N2CmdCombo.Items.Add("5 = Wait N frames");
-            N2CmdCombo.Items.Add("6 = Close-range dodge animation");
-            N2CmdCombo.Items.Add("7 = (FE8 unused) Set anime state to 'hit effect applied'");
-            N2CmdCombo.Items.Add("8 = Wait until anime reaches C01/C02/C18");
+            N2CmdCombo.Items.Add(R._("1 = Close-range attack animation"));
+            N2CmdCombo.Items.Add(R._("2 = Close-range critical animation"));
+            N2CmdCombo.Items.Add(R._("3 = Set anime state to 'hit effect applied'"));
+            N2CmdCombo.Items.Add(R._("4 = Long-range attack animation"));
+            N2CmdCombo.Items.Add(R._("5 = Wait N frames"));
+            N2CmdCombo.Items.Add(R._("6 = Close-range dodge animation"));
+            N2CmdCombo.Items.Add(R._("7 = (FE8 unused) Set anime state to 'hit effect applied'"));
+            N2CmdCombo.Items.Add(R._("8 = Wait until anime reaches C01/C02/C18"));
 
             AllyEnemyColorCombo.SelectionChanged += (_, _) =>
             {
@@ -125,13 +128,16 @@ namespace FEBuilderGBA.Avalonia.Views
             bool over255 = _vm.IsOver255PatchActive;
             ListExpandButton.IsVisible = listExpand;
             BattleAnimePlus1Label.IsVisible = over255;
+            // Runtime sentences must be routed through R._() because
+            // ViewTranslationHelper only translates static XAML attributes
+            // (Copilot bot review thread PRRT_kwDOH0Mc1M6ETSJG on PR #544).
             if (over255)
             {
-                PatchNoticeText.Text = "Patch: OPClassReelAnimationIDOver255 active. Battle Anime ID is read from D18.";
+                PatchNoticeText.Text = R._("Patch: OPClassReelAnimationIDOver255 active. Battle Anime ID is read from D18.");
             }
             else if (listExpand)
             {
-                PatchNoticeText.Text = "Patch: OPClassReelSort active. Data Expansion enabled.";
+                PatchNoticeText.Text = R._("Patch: OPClassReelSort active. Data Expansion enabled.");
             }
             else
             {
@@ -330,8 +336,19 @@ namespace FEBuilderGBA.Avalonia.Views
             try { ClassNamePreview.Text = NameResolver.GetClassName(_vm.DisplayWeapon); }
             catch { ClassNamePreview.Text = ""; }
             AllyEnemyColorBox.Value = _vm.AllyEnemyColor;
+            // The ValueChanged handler is gated by IsLoading, so sync
+            // the combo SelectedIndex explicitly here. (Copilot bot
+            // review thread PRRT_kwDOH0Mc1M6ETSI- on PR #544.)
+            {
+                int v = (int)_vm.AllyEnemyColor;
+                AllyEnemyColorCombo.SelectedIndex = (v >= 0 && v < AllyEnemyColorCombo.ItemCount) ? v : -1;
+            }
             BattleAnimeBox.Value = _vm.BattleAnime;
             MagicEffectBox.Value = _vm.MagicEffect;
+            {
+                int v = (int)_vm.MagicEffect;
+                MagicEffectCombo.SelectedIndex = (v >= 0 && v < MagicEffectCombo.ItemCount) ? v : -1;
+            }
             Unknown18Box.Value = _vm.Unknown18;
             TerrainLeftBox.Value = _vm.TerrainLeft;
             TerrainRightBox.Value = _vm.TerrainRight;

--- a/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml.cs
@@ -172,7 +172,10 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             if (_vm.IsLoading) return;
             uint id = (uint)(PaletteIdBox.Value ?? 0);
-            PalettePreview.Text = id == 0xFF ? "Default palette" : $"Palette 0x{id:X02}";
+            // Route through R._() so the preview stays localized when the
+            // user edits the value interactively. (Copilot bot review
+            // thread PRRT_kwDOH0Mc1M6ETZ4a on PR #544.)
+            PalettePreview.Text = id == 0xFF ? R._("Default palette") : $"Palette 0x{id:X02}";
         }
 
         void OnTerrainLeftChanged(object? sender, NumericUpDownValueChangedEventArgs e)
@@ -327,7 +330,10 @@ namespace FEBuilderGBA.Avalonia.Views
                     {
                         N2B0Box.Value = rom.u8(addr);
                         N2B1Box.Value = rom.u8(addr + 1);
-                        int val = (int)N2B0Box.Value;
+                        // NumericUpDown.Value is decimal? — use the
+                        // null-safe form (Copilot bot review thread
+                        // PRRT_kwDOH0Mc1M6ETZ4X on PR #544).
+                        int val = (int)(N2B0Box.Value ?? 0);
                         N2CmdCombo.SelectedIndex = (val >= 1 && val <= 8) ? val - 1 : -1;
                     }
                     finally { _vm.IsLoading = false; }

--- a/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml.cs
@@ -128,6 +128,10 @@ namespace FEBuilderGBA.Avalonia.Views
             bool over255 = _vm.IsOver255PatchActive;
             ListExpandButton.IsVisible = listExpand;
             BattleAnimePlus1Label.IsVisible = over255;
+            // Show the vanilla label only when the Over255 patch is NOT
+            // installed so the slot always has a label. (Copilot bot
+            // review thread PRRT_kwDOH0Mc1M6ETj-6 on PR #544.)
+            Unknown18VanillaLabel.IsVisible = !over255;
             // Runtime sentences must be routed through R._() because
             // ViewTranslationHelper only translates static XAML attributes
             // (Copilot bot review thread PRRT_kwDOH0Mc1M6ETSJG on PR #544).
@@ -202,13 +206,18 @@ namespace FEBuilderGBA.Avalonia.Views
         void OnJpNamePtrChanged(object? sender, NumericUpDownValueChangedEventArgs e)
         {
             if (_vm.IsLoading) return;
-            LoadN1Sublist();
+            // Reload from the *unsaved* spinner value so the preview reflects
+            // the in-progress edit. (Copilot bot review thread
+            // PRRT_kwDOH0Mc1M6ETj_F on PR #544.)
+            uint offset = (uint)(JpNamePtrBox.Value ?? 0);
+            LoadN1SublistFromOffset(offset);
         }
 
         void OnAnimePtrChanged(object? sender, NumericUpDownValueChangedEventArgs e)
         {
             if (_vm.IsLoading) return;
-            LoadN2Sublist();
+            uint offset = (uint)(AnimePtrBox.Value ?? 0);
+            LoadN2SublistFromOffset(offset);
         }
 
         void OnN2B0Changed(object? sender, NumericUpDownValueChangedEventArgs e)
@@ -254,20 +263,63 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void LoadN1Sublist()
         {
+            // Default: walk from the pointer-slot at _vm.CurrentAddr + 8.
+            // Called on entry change.
+            if (_vm.CurrentAddr == 0) { ResetN1ListState(clearOnly: true); return; }
+            var rows = _vm.LoadN1FontList(_vm.CurrentAddr + 8);
+            ApplyN1Rows(rows);
+        }
+
+        void LoadN1SublistFromOffset(uint baseOffset)
+        {
+            // Walk from an explicit ROM offset (the unsaved spinner value).
+            // (Copilot bot review thread PRRT_kwDOH0Mc1M6ETj_F on PR #544.)
+            var rows = _vm.LoadN1FontListFromOffset(baseOffset);
+            ApplyN1Rows(rows);
+        }
+
+        void LoadN2Sublist()
+        {
+            if (_vm.CurrentAddr == 0) { ResetN2ListState(clearOnly: true); return; }
+            var rows = _vm.LoadN2CommandList(_vm.CurrentAddr + 24);
+            ApplyN2Rows(rows);
+        }
+
+        void LoadN2SublistFromOffset(uint baseOffset)
+        {
+            var rows = _vm.LoadN2CommandListFromOffset(baseOffset);
+            ApplyN2Rows(rows);
+        }
+
+        void ResetN1ListState(bool clearOnly)
+        {
+            // Reset the selected-address gate BEFORE replacing the
+            // list so a follow-up Write button click cannot land on
+            // a stale address from the previous row. (Copilot CLI
+            // re-review on PR #544 #4.)
+            _n1SelectedAddr = 0;
+            _vm.IsLoading = true;
+            try { N1B0Box.Value = 0; }
+            finally { _vm.IsLoading = false; }
+            N1SelectedAddressBox.Text = "";
+            if (clearOnly) { _n1Rows = new(); N1List.SetItems(new List<AddrResult>()); }
+        }
+
+        void ResetN2ListState(bool clearOnly)
+        {
+            _n2SelectedAddr = 0;
+            _vm.IsLoading = true;
+            try { N2B0Box.Value = 0; N2B1Box.Value = 0; N2CmdCombo.SelectedIndex = -1; }
+            finally { _vm.IsLoading = false; }
+            if (clearOnly) { _n2Rows = new(); N2List.SetItems(new List<AddrResult>()); }
+        }
+
+        void ApplyN1Rows(List<OPClassDemoViewerViewModel.N1Row> rows)
+        {
             try
             {
-                // Reset the selected-address gate BEFORE replacing the
-                // list so a follow-up Write button click cannot land on
-                // a stale address from the previous row. (Copilot CLI
-                // re-review on PR #544 #4.)
-                _n1SelectedAddr = 0;
-                _vm.IsLoading = true;
-                try { N1B0Box.Value = 0; }
-                finally { _vm.IsLoading = false; }
-                N1SelectedAddressBox.Text = "";
-
-                if (_vm.CurrentAddr == 0) { _n1Rows = new(); N1List.SetItems(new List<AddrResult>()); return; }
-                _n1Rows = _vm.LoadN1FontList(_vm.CurrentAddr + 8);
+                ResetN1ListState(clearOnly: false);
+                _n1Rows = rows;
                 var items = new List<AddrResult>();
                 for (int i = 0; i < _n1Rows.Count; i++)
                 {
@@ -275,21 +327,15 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 N1List.SetItems(items);
             }
-            catch (Exception ex) { Log.Error($"OPClassDemoViewerView.LoadN1Sublist: {ex.Message}"); }
+            catch (Exception ex) { Log.Error($"OPClassDemoViewerView.ApplyN1Rows: {ex.Message}"); }
         }
 
-        void LoadN2Sublist()
+        void ApplyN2Rows(List<OPClassDemoViewerViewModel.N2Row> rows)
         {
             try
             {
-                // Reset state before replacing the list — see LoadN1Sublist.
-                _n2SelectedAddr = 0;
-                _vm.IsLoading = true;
-                try { N2B0Box.Value = 0; N2B1Box.Value = 0; N2CmdCombo.SelectedIndex = -1; }
-                finally { _vm.IsLoading = false; }
-
-                if (_vm.CurrentAddr == 0) { _n2Rows = new(); N2List.SetItems(new List<AddrResult>()); return; }
-                _n2Rows = _vm.LoadN2CommandList(_vm.CurrentAddr + 24);
+                ResetN2ListState(clearOnly: false);
+                _n2Rows = rows;
                 var items = new List<AddrResult>();
                 for (int i = 0; i < _n2Rows.Count; i++)
                 {
@@ -297,7 +343,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 N2List.SetItems(items);
             }
-            catch (Exception ex) { Log.Error($"OPClassDemoViewerView.LoadN2Sublist: {ex.Message}"); }
+            catch (Exception ex) { Log.Error($"OPClassDemoViewerView.ApplyN2Rows: {ex.Message}"); }
         }
 
         void OnN1Selected(uint addr)

--- a/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml.cs
@@ -253,6 +253,16 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                // Reset the selected-address gate BEFORE replacing the
+                // list so a follow-up Write button click cannot land on
+                // a stale address from the previous row. (Copilot CLI
+                // re-review on PR #544 #4.)
+                _n1SelectedAddr = 0;
+                _vm.IsLoading = true;
+                try { N1B0Box.Value = 0; }
+                finally { _vm.IsLoading = false; }
+                N1SelectedAddressBox.Text = "";
+
                 if (_vm.CurrentAddr == 0) { _n1Rows = new(); N1List.SetItems(new List<AddrResult>()); return; }
                 _n1Rows = _vm.LoadN1FontList(_vm.CurrentAddr + 8);
                 var items = new List<AddrResult>();
@@ -269,6 +279,12 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                // Reset state before replacing the list — see LoadN1Sublist.
+                _n2SelectedAddr = 0;
+                _vm.IsLoading = true;
+                try { N2B0Box.Value = 0; N2B1Box.Value = 0; N2CmdCombo.SelectedIndex = -1; }
+                finally { _vm.IsLoading = false; }
+
                 if (_vm.CurrentAddr == 0) { _n2Rows = new(); N2List.SetItems(new List<AddrResult>()); return; }
                 _n2Rows = _vm.LoadN2CommandList(_vm.CurrentAddr + 24);
                 var items = new List<AddrResult>();
@@ -322,19 +338,33 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void UpdateUI()
         {
+            // Every derived preview / combo / inline label must be
+            // populated here because the ValueChanged handlers are
+            // gated by `_vm.IsLoading` during load. (Copilot CLI
+            // re-review on PR #544.)
             AddrLabel.Text = $"0x{_vm.CurrentAddr:X08}";
             AddressBox.Value = _vm.CurrentAddr;
             SelectedAddressBox.Text = $"0x{_vm.CurrentAddr:X08}";
+
             EnglishNamePtrBox.Value = _vm.EnglishNamePointer;
+            EnglishNamePreview.Text = _vm.EnglishNamePointer != 0
+                ? $"0x{_vm.EnglishNamePointer:X08}" : "";
+
             DescTextIdBox.Value = _vm.DescriptionTextId;
             try { DescTextPreview.Text = _vm.DescriptionTextId != 0 ? NameResolver.GetTextById(_vm.DescriptionTextId) : ""; }
             catch { DescTextPreview.Text = ""; }
+
             JpNamePtrBox.Value = _vm.JapaneseNamePointer;
             JpNameLenBox.Value = _vm.JapaneseNameLength;
+
             PaletteIdBox.Value = _vm.PaletteId;
+            PalettePreview.Text = _vm.PaletteId == 0xFF
+                ? R._("Default palette") : $"Palette 0x{_vm.PaletteId:X02}";
+
             DisplayWeaponBox.Value = _vm.DisplayWeapon;
             try { ClassNamePreview.Text = NameResolver.GetClassName(_vm.DisplayWeapon); }
             catch { ClassNamePreview.Text = ""; }
+
             AllyEnemyColorBox.Value = _vm.AllyEnemyColor;
             // The ValueChanged handler is gated by IsLoading, so sync
             // the combo SelectedIndex explicitly here. (Copilot bot
@@ -343,15 +373,24 @@ namespace FEBuilderGBA.Avalonia.Views
                 int v = (int)_vm.AllyEnemyColor;
                 AllyEnemyColorCombo.SelectedIndex = (v >= 0 && v < AllyEnemyColorCombo.ItemCount) ? v : -1;
             }
+
             BattleAnimeBox.Value = _vm.BattleAnime;
+            BattleAnimePreview.Text = $"Anime 0x{_vm.BattleAnime:X02}";
+
             MagicEffectBox.Value = _vm.MagicEffect;
             {
                 int v = (int)_vm.MagicEffect;
                 MagicEffectCombo.SelectedIndex = (v >= 0 && v < MagicEffectCombo.ItemCount) ? v : -1;
             }
+
             Unknown18Box.Value = _vm.Unknown18;
+
             TerrainLeftBox.Value = _vm.TerrainLeft;
+            TerrainLeftPreview.Text = $"Terrain 0x{_vm.TerrainLeft:X02}";
+
             TerrainRightBox.Value = _vm.TerrainRight;
+            TerrainRightPreview.Text = $"Terrain 0x{_vm.TerrainRight:X02}";
+
             AnimePtrBox.Value = _vm.AnimePointer;
         }
 

--- a/FEBuilderGBA.Core.Tests/DataExpansionCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/DataExpansionCoreTests.cs
@@ -339,5 +339,102 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Equal(0x33, rom.Data[nb + 6]);
             Assert.Equal(0x44, rom.Data[nb + 7]);
         }
+
+        // ────────────────────────────────────────────────
+        // ExpandTable undo completeness (gap-sweep #419)
+        //
+        // Copilot CLI plan review round 3 caught that the original
+        // ExpandTable implementation used Array.Copy + direct
+        // rom.Data[i] = ... mutations which bypass the ambient-undo
+        // recording. The fix routes the copy / zero-fill / wipe through
+        // rom.write_range / rom.write_fill so all three byte regions
+        // are restored on rollback, in addition to the pointer.
+        // ────────────────────────────────────────────────
+
+        /// <summary>
+        /// Plant the same fixture as <see cref="ExpandTable_PreservesOriginalEntryValues"/>
+        /// inside a `CoreState.ROM = rom` block so `BeginUndoScope`
+        /// records into the ambient slot.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "SharedState")]
+        public void ExpandTable_Rollback_RestoresAllByteRanges()
+        {
+            // We deliberately use Collection-style cleanup inside this
+            // single method to avoid promoting the whole class to
+            // [Collection("SharedState")].
+            ROM? savedRom = CoreState.ROM;
+            try
+            {
+                var rom = MakeRom(0x200000);
+                CoreState.ROM = rom;
+
+                uint pointerAddr = 0x10;
+                uint tableBase = 0x200;
+                uint entrySize = 4;
+                uint entryCount = 2;
+
+                WritePointer(rom, pointerAddr, tableBase);
+
+                // Entry 0 / 1 — recognizable patterns.
+                rom.Data[tableBase + 0] = 0xAA;
+                rom.Data[tableBase + 1] = 0xBB;
+                rom.Data[tableBase + 2] = 0xCC;
+                rom.Data[tableBase + 3] = 0xDD;
+                rom.Data[tableBase + 4] = 0x11;
+                rom.Data[tableBase + 5] = 0x22;
+                rom.Data[tableBase + 6] = 0x33;
+                rom.Data[tableBase + 7] = 0x44;
+
+                // Free space 256 bytes — enough for 12-byte expanded table.
+                for (int i = 0; i < 256; i++)
+                    rom.Data[0x100200 + i] = 0xFF;
+
+                // Take a deep snapshot of the ROM as the rollback target.
+                byte[] snapshot = new byte[rom.Data.Length];
+                System.Array.Copy(rom.Data, snapshot, rom.Data.Length);
+
+                // Run ExpandTable under BeginUndoScope so the mutations
+                // are tracked.
+                var ud = new Undo.UndoData
+                {
+                    time = System.DateTime.Now,
+                    name = "ExpandTable test",
+                    list = new System.Collections.Generic.List<Undo.UndoPostion>(),
+                    filesize = (uint)rom.Data.Length
+                };
+                DataExpansionCore.ExpandResult result;
+                using (ROM.BeginUndoScope(ud))
+                {
+                    result = DataExpansionCore.ExpandTable(rom, pointerAddr, entrySize, entryCount);
+                }
+                Assert.True(result.Success, result.Error);
+                Assert.NotEqual(tableBase, result.NewBaseAddress);
+
+                // Sanity check: after expansion, pointer should match new base.
+                Assert.Equal(result.NewBaseAddress, rom.p32(pointerAddr));
+
+                // Rollback the recorded UndoPositions in reverse order
+                // (mirrors Undo.RollbackROM).
+                for (int i = ud.list.Count - 1; i >= 0; i--)
+                {
+                    var up = ud.list[i];
+                    System.Array.Copy(up.data, 0, rom.Data, up.addr, up.data.Length);
+                }
+
+                // After rollback, every byte must match the pre-expansion snapshot.
+                for (int i = 0; i < snapshot.Length; i++)
+                {
+                    if (snapshot[i] != rom.Data[i])
+                    {
+                        Assert.Fail($"Byte mismatch at 0x{i:X06}: snapshot=0x{snapshot[i]:X02}, post-rollback=0x{rom.Data[i]:X02}");
+                    }
+                }
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+            }
+        }
     }
 }

--- a/FEBuilderGBA.Core.Tests/DataExpansionCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/DataExpansionCoreTests.cs
@@ -340,31 +340,60 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Equal(0x44, rom.Data[nb + 7]);
         }
 
-        // ────────────────────────────────────────────────
-        // ExpandTable undo completeness (gap-sweep #419)
-        //
-        // Copilot CLI plan review round 3 caught that the original
-        // ExpandTable implementation used Array.Copy + direct
-        // rom.Data[i] = ... mutations which bypass the ambient-undo
-        // recording. The fix routes the copy / zero-fill / wipe through
-        // rom.write_range / rom.write_fill so all three byte regions
-        // are restored on rollback, in addition to the pointer.
-        // ────────────────────────────────────────────────
+    }
 
-        /// <summary>
-        /// Plant the same fixture as <see cref="ExpandTable_PreservesOriginalEntryValues"/>
-        /// inside a `CoreState.ROM = rom` block so `BeginUndoScope`
-        /// records into the ambient slot.
-        /// </summary>
+    // ────────────────────────────────────────────────
+    // ExpandTable undo completeness (gap-sweep #419)
+    //
+    // Copilot CLI plan review round 3 caught that the original
+    // ExpandTable implementation used Array.Copy + direct
+    // rom.Data[i] = ... mutations which bypass the ambient-undo
+    // recording. The fix routes the copy / zero-fill / wipe through
+    // rom.write_range / rom.write_fill so all three byte regions
+    // are restored on rollback, in addition to the pointer.
+    //
+    // This nested class is in [Collection("SharedState")] because the
+    // undo-rollback test mutates CoreState.ROM under a `BeginUndoScope`
+    // (Copilot bot review thread PRRT_kwDOH0Mc1M6ETSJK on PR #544).
+    // ────────────────────────────────────────────────
+    [Collection("SharedState")]
+    public class DataExpansionCoreUndoTests : IDisposable
+    {
+        readonly ROM? _savedRom;
+
+        public DataExpansionCoreUndoTests()
+        {
+            _savedRom = CoreState.ROM;
+        }
+
+        public void Dispose()
+        {
+            CoreState.ROM = _savedRom;
+        }
+
+        /// <summary>Helper: build a minimal ROM with LoadLow using ROMFE0 ("NAZO").</summary>
+        static ROM MakeRom(int size = 0x200000)
+        {
+            var rom = new ROM();
+            byte[] data = new byte[size];
+            rom.LoadLow("test.gba", data, "NAZO");
+            return rom;
+        }
+
+        static void WritePointer(ROM rom, uint addr, uint offset)
+        {
+            uint gbaPtr = offset + 0x08000000;
+            rom.Data[addr + 0] = (byte)(gbaPtr & 0xFF);
+            rom.Data[addr + 1] = (byte)((gbaPtr >> 8) & 0xFF);
+            rom.Data[addr + 2] = (byte)((gbaPtr >> 16) & 0xFF);
+            rom.Data[addr + 3] = (byte)((gbaPtr >> 24) & 0xFF);
+        }
+
         [Fact]
-        [Trait("Category", "SharedState")]
         public void ExpandTable_Rollback_RestoresAllByteRanges()
         {
-            // We deliberately use Collection-style cleanup inside this
-            // single method to avoid promoting the whole class to
-            // [Collection("SharedState")].
-            ROM? savedRom = CoreState.ROM;
-            try
+            // The class-level [Collection("SharedState")] + Dispose
+            // restoration of CoreState.ROM keep this test isolated.
             {
                 var rom = MakeRom(0x200000);
                 CoreState.ROM = rom;
@@ -430,10 +459,6 @@ namespace FEBuilderGBA.Core.Tests
                         Assert.Fail($"Byte mismatch at 0x{i:X06}: snapshot=0x{snapshot[i]:X02}, post-rollback=0x{rom.Data[i]:X02}");
                     }
                 }
-            }
-            finally
-            {
-                CoreState.ROM = savedRom;
             }
         }
     }

--- a/FEBuilderGBA.Core.Tests/DataExpansionCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/DataExpansionCoreTests.cs
@@ -352,9 +352,10 @@ namespace FEBuilderGBA.Core.Tests
     // rom.write_range / rom.write_fill so all three byte regions
     // are restored on rollback, in addition to the pointer.
     //
-    // This nested class is in [Collection("SharedState")] because the
+    // This sibling type is in [Collection("SharedState")] because the
     // undo-rollback test mutates CoreState.ROM under a `BeginUndoScope`
-    // (Copilot bot review thread PRRT_kwDOH0Mc1M6ETSJK on PR #544).
+    // (Copilot bot review thread PRRT_kwDOH0Mc1M6ETSJK on PR #544;
+    // wording fixed in thread PRRT_kwDOH0Mc1M6ETZ4j).
     // ────────────────────────────────────────────────
     [Collection("SharedState")]
     public class DataExpansionCoreUndoTests : IDisposable

--- a/FEBuilderGBA.Core.Tests/PatchDetectionTests.cs
+++ b/FEBuilderGBA.Core.Tests/PatchDetectionTests.cs
@@ -84,5 +84,124 @@ namespace FEBuilderGBA.Core.Tests
             CoreState.ROM = null;
             Assert.Equal(PatchDetection.draw_font_enum.NO, PatchDetection.SearchDrawFontPatch());
         }
+
+        // ---------------------------------------------------------------
+        // OPClassReel patch detectors (added for gap-sweep #419)
+        // The signatures live exclusively in FE8J according to the
+        // original WinForms PatchUtil — FE8U / FE7 must always return false.
+        // ---------------------------------------------------------------
+
+        /// <summary>
+        /// Build a minimal FE8J ROM (BE8J01 signature, 0x1100000 bytes
+        /// so Rom.LoadLow assigns ROMFE8JP). Optionally plants the patch
+        /// signature bytes at the well-known addresses.
+        /// </summary>
+        static ROM MakeFe8jRom(bool plantOver255 = false, bool plantReelSort = false)
+        {
+            var rom = new ROM();
+            var data = new byte[0x1100000];
+            if (plantOver255)
+            {
+                // Source: PatchUtil.OPClassReelAnimationIDOver255Low — FE8J @ 0xB86B0 / {0x59, 0x8A}.
+                data[0xB86B0] = 0x59;
+                data[0xB86B0 + 1] = 0x8A;
+            }
+            if (plantReelSort)
+            {
+                // Source: PatchUtil.OPClassReelSortPatchLow — FE8J @ 0xB8C80 / {0x04, 0x4B, 0x1B, 0x68}.
+                data[0xB8C80] = 0x04;
+                data[0xB8C80 + 1] = 0x4B;
+                data[0xB8C80 + 2] = 0x1B;
+                data[0xB8C80 + 3] = 0x68;
+            }
+            rom.LoadLow("synthetic-fe8j.gba", data, "BE8J01");
+            return rom;
+        }
+
+        /// <summary>Build a minimal FE8U ROM (BE8E01) — Over255 must always be false here.</summary>
+        static ROM MakeFe8uRom()
+        {
+            var rom = new ROM();
+            var data = new byte[0x1100000];
+            rom.LoadLow("synthetic-fe8u.gba", data, "BE8E01");
+            return rom;
+        }
+
+        [Fact]
+        public void OPClassReelAnimationIDOver255Detect_NullRom_ReturnsFalse()
+        {
+            Assert.False(PatchDetection.OPClassReelAnimationIDOver255Detect(null));
+        }
+
+        [Fact]
+        public void OPClassReelAnimationIDOver255Detect_FE8J_PatchAbsent_ReturnsFalse()
+        {
+            var rom = MakeFe8jRom(plantOver255: false);
+            Assert.False(PatchDetection.OPClassReelAnimationIDOver255Detect(rom));
+        }
+
+        [Fact]
+        public void OPClassReelAnimationIDOver255Detect_FE8J_PatchPresent_ReturnsTrue()
+        {
+            var rom = MakeFe8jRom(plantOver255: true);
+            Assert.True(PatchDetection.OPClassReelAnimationIDOver255Detect(rom));
+        }
+
+        [Fact]
+        public void OPClassReelAnimationIDOver255Detect_FE8U_AlwaysFalse()
+        {
+            // The signature only matches "FE8J" — even if we synthetically
+            // wrote 0x59, 0x8A at 0xB86B0 on an FE8U ROM, the version
+            // filter rejects it.
+            var rom = MakeFe8uRom();
+            rom.Data[0xB86B0] = 0x59;
+            rom.Data[0xB86B0 + 1] = 0x8A;
+            Assert.False(PatchDetection.OPClassReelAnimationIDOver255Detect(rom));
+        }
+
+        [Fact]
+        public void OPClassReelSortPatchDetect_NullRom_ReturnsFalse()
+        {
+            Assert.False(PatchDetection.OPClassReelSortPatchDetect(null));
+        }
+
+        [Fact]
+        public void OPClassReelSortPatchDetect_FE8J_PatchAbsent_ReturnsFalse()
+        {
+            var rom = MakeFe8jRom(plantReelSort: false);
+            Assert.False(PatchDetection.OPClassReelSortPatchDetect(rom));
+        }
+
+        [Fact]
+        public void OPClassReelSortPatchDetect_FE8J_PatchPresent_ReturnsTrue()
+        {
+            var rom = MakeFe8jRom(plantReelSort: true);
+            Assert.True(PatchDetection.OPClassReelSortPatchDetect(rom));
+        }
+
+        [Fact]
+        public void OPClassReelSortPatchDetect_FE8U_PatchPresent_ReturnsTrue()
+        {
+            // OPClassReelSort has both FE8J and FE8U entries (FE8U @ 0xB40EC).
+            var rom = MakeFe8uRom();
+            rom.Data[0xB40EC] = 0x04;
+            rom.Data[0xB40EC + 1] = 0x4B;
+            rom.Data[0xB40EC + 2] = 0x1B;
+            rom.Data[0xB40EC + 3] = 0x68;
+            Assert.True(PatchDetection.OPClassReelSortPatchDetect(rom));
+        }
+
+        [Fact]
+        public void OPClassReelSortPatchDetect_FE8U_PatchAtJpOffset_StillFalse()
+        {
+            // Writing the FE8J signature at the FE8J offset on an FE8U
+            // ROM must NOT match — the version filter rejects it.
+            var rom = MakeFe8uRom();
+            rom.Data[0xB8C80] = 0x04;
+            rom.Data[0xB8C80 + 1] = 0x4B;
+            rom.Data[0xB8C80 + 2] = 0x1B;
+            rom.Data[0xB8C80 + 3] = 0x68;
+            Assert.False(PatchDetection.OPClassReelSortPatchDetect(rom));
+        }
     }
 }

--- a/FEBuilderGBA.Core.Tests/PatchDetectionTests.cs
+++ b/FEBuilderGBA.Core.Tests/PatchDetectionTests.cs
@@ -86,9 +86,14 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         // ---------------------------------------------------------------
-        // OPClassReel patch detectors (added for gap-sweep #419)
-        // The signatures live exclusively in FE8J according to the
-        // original WinForms PatchUtil — FE8U / FE7 must always return false.
+        // OPClassReel patch detectors (added for gap-sweep #419).
+        //
+        // - OPClassReelAnimationIDOver255 has ONLY an FE8J signature in
+        //   PatchUtil; FE8U must always return false.
+        // - OPClassReelSort has BOTH FE8J and FE8U signatures; tests
+        //   below assert both versions detect the patch correctly.
+        //   (Copilot bot review thread PRRT_kwDOH0Mc1M6ETZ4g on PR #544
+        //   flagged the previous wording as misleading.)
         // ---------------------------------------------------------------
 
         /// <summary>

--- a/FEBuilderGBA.Core/DataExpansionCore.cs
+++ b/FEBuilderGBA.Core/DataExpansionCore.cs
@@ -185,21 +185,21 @@ namespace FEBuilderGBA
                 newBase = U.Padding4((uint)rom.Data.Length - newTableSize);
             }
 
-            // Copy old table data to new location
-            Array.Copy(rom.Data, oldBase, rom.Data, newBase, oldTableSize);
+            // Copy old table data to new location.
+            // Route through rom.write_range so the ambient-undo scope
+            // captures the pre-copy bytes at newBase (#419 — undo
+            // completeness fix flagged by Copilot CLI plan-review round 3).
+            byte[] copyBytes = rom.getBinaryData(oldBase, oldTableSize);
+            rom.write_range(newBase, copyBytes);
 
-            // Zero-fill the new entry
+            // Zero-fill the new entry — route through rom.write_fill
+            // so the ambient-undo scope captures the bytes that were
+            // there before the fill.
             uint newEntryAddr = newBase + oldTableSize;
-            for (uint i = 0; i < entrySize; i++)
-            {
-                rom.Data[newEntryAddr + i] = 0x00;
-            }
+            rom.write_fill(newEntryAddr, entrySize, 0x00);
 
-            // Clear old table location with 0xFF (free it)
-            for (uint i = 0; i < oldTableSize; i++)
-            {
-                rom.Data[oldBase + i] = 0xFF;
-            }
+            // Clear old table location with 0xFF (free it) — same.
+            rom.write_fill(oldBase, oldTableSize, 0xFF);
 
             // Update the pointer to point to the new location (GBA pointer = offset + 0x08000000)
             rom.write_p32(pointerAddr, newBase);

--- a/FEBuilderGBA.Core/PatchDetection.cs
+++ b/FEBuilderGBA.Core/PatchDetection.cs
@@ -294,5 +294,43 @@ namespace FEBuilderGBA
             g_Cache_TextEngineRework_enum = TextEngineRework_enum.NoCache;
             g_Cache_ExtendsBattleBG = ExtendsBattleBG_extends.NoCache;
         }
+
+        // ---- OPClassReel patch detectors (extracted from PatchUtil for gap-sweep #419) ----
+        //
+        // The corresponding WinForms cache-bearing wrappers in PatchUtil.cs
+        // delegate to these methods so there's a single source of truth.
+        // No cache here — Avalonia callers re-evaluate per ROM load.
+
+        static readonly PatchTableSt[] OPClassReelAnimationIDOver255Table = new PatchTableSt[] {
+            new PatchTableSt{ name="Over255", ver = "FE8J", addr = 0xB86B0, data = new byte[]{0x59, 0x8A}},
+        };
+
+        /// <summary>
+        /// True when the "Over255" OPClassReel patch (FE8J only) is
+        /// installed in <paramref name="rom"/>. Mirrors WinForms
+        /// <c>PatchUtil.OPClassReelAnimationIDOver255() == Over255</c>.
+        ///
+        /// Returns false on null ROM and on any non-FE8J version
+        /// (signature table only contains FE8J).
+        /// </summary>
+        public static bool OPClassReelAnimationIDOver255Detect(ROM rom)
+        {
+            return SearchPatchBool(rom, OPClassReelAnimationIDOver255Table);
+        }
+
+        static readonly PatchTableSt[] OPClassReelSortPatchTable = new PatchTableSt[] {
+            new PatchTableSt{ name="OPClassReelSort", ver = "FE8J", addr = 0xB8C80, data = new byte[]{0x04, 0x4B, 0x1B, 0x68}},
+            new PatchTableSt{ name="OPClassReelSort", ver = "FE8U", addr = 0xB40EC, data = new byte[]{0x04, 0x4B, 0x1B, 0x68}},
+        };
+
+        /// <summary>
+        /// True when the "OPClassReelSort" patch (FE8J or FE8U) is
+        /// installed in <paramref name="rom"/>. Mirrors WinForms
+        /// <c>PatchUtil.OPClassReelSortPatch() == OPClassReelSort</c>.
+        /// </summary>
+        public static bool OPClassReelSortPatchDetect(ROM rom)
+        {
+            return SearchPatchBool(rom, OPClassReelSortPatchTable);
+        }
     }
 }

--- a/FEBuilderGBA.Tests/Unit/AvaloniaDialogViewTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AvaloniaDialogViewTests.cs
@@ -874,7 +874,9 @@ namespace FEBuilderGBA.Tests.Unit
         [InlineData("ChapterTitleViewerView.axaml", 1224, 564)]
         [InlineData("SystemIconViewerView.axaml", 966, 656)]
         [InlineData("SystemHoverColorViewerView.axaml", 1238, 604)]
-        [InlineData("OPClassDemoViewerView.axaml", 1429, 848)]
+        // #419 — Width/Height bumped to 1534x878 to accommodate the three-pane
+        // master-detail rebuild added by the gap-sweep parity raise.
+        [InlineData("OPClassDemoViewerView.axaml", 1534, 878)]
         [InlineData("OPClassFontViewerView.axaml", 1179, 475)]
         [InlineData("ItemWeaponEffectViewerView.axaml", 1302, 803)]
         [InlineData("ItemStatBonusesViewerView.axaml", 1291, 587)]

--- a/FEBuilderGBA/PatchUtil.cs
+++ b/FEBuilderGBA/PatchUtil.cs
@@ -2086,11 +2086,9 @@ namespace FEBuilderGBA
         }
         static OPClassReelSortExtends OPClassReelSortPatchLow()
         {
-            PatchTableSt[] table = new PatchTableSt[] { 
-                new PatchTableSt{ name="OPClassReelSort",	ver = "FE8J", addr = 0xB8C80,data = new byte[]{0x04, 0x4B, 0x1B, 0x68}},
-                new PatchTableSt{ name="OPClassReelSort",	ver = "FE8U", addr = 0xB40EC,data = new byte[]{0x04, 0x4B, 0x1B, 0x68}},
-            };
-            if (SearchPatchBool(table))
+            // Delegates to Core PatchDetection.OPClassReelSortPatchDetect
+            // (single source of truth for both WinForms and Avalonia — #419).
+            if (PatchDetection.OPClassReelSortPatchDetect(Program.ROM))
             {
                 return OPClassReelSortExtends.OPClassReelSort;
             }
@@ -2115,10 +2113,9 @@ namespace FEBuilderGBA
         }
         static OPClassReelAnimationIDOver255Patch OPClassReelAnimationIDOver255Low()
         {
-            PatchTableSt[] table = new PatchTableSt[] { 
-                new PatchTableSt{ name="Over255",	ver = "FE8J", addr = 0xB86B0,data = new byte[]{0x59, 0x8A}},
-            };
-            if (SearchPatchBool(table))
+            // Delegates to Core PatchDetection.OPClassReelAnimationIDOver255Detect
+            // (single source of truth for both WinForms and Avalonia — #419).
+            if (PatchDetection.OPClassReelAnimationIDOver255Detect(Program.ROM))
             {
                 return OPClassReelAnimationIDOver255Patch.Over255;
             }

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -7112,3 +7112,74 @@ eo=エスペランド語
 
 :Item Drop Dialog...
 アイテムドロップダイアログ...
+:Command:
+コマンド:
+
+:Display Weapon (Class):
+表示武器 (クラス):
+
+:Ally / Enemy Color:
+自軍/敵軍 カラー:
+
+:Anime Spec Pointer:
+アニメ指定のポインタ:
+
+:Arg (/60 sec):
+引数 (/60 秒):
+
+:Battle Anime (Patch +1):
+戦闘アニメ (パッチ +1):
+
+:Battle Anime:
+戦闘アニメ:
+
+:Data Expansion
+データ拡張
+
+:Description Text ID:
+説明文ID:
+
+:English Name Pointer:
+英語名ポインタ:
+
+:Glyph:
+グリフ:
+
+:Hex Address
+Hex アドレス
+
+:Japanese Name Font Glyphs (pointer P8)
+日本語名フォントグリフ (ポインタ P8)
+
+:Japanese Name Length:
+日本語名の長さ:
+
+:Japanese Name Pointer:
+日本語名ポインタ:
+
+:Magic Effect:
+魔法エフェクト:
+
+:Palette ID:
+パレットID:
+
+:Read Count
+読込数
+
+:Selected Address:
+選択アドレス:
+
+:Terrain (Left Half):
+地形 (左半分):
+
+:Terrain (Right Half):
+地形 (右半分):
+
+:Write Anime Spec Pointer
+アニメ指定ポインタを書き込み
+
+:Write JP Name Pointer
+日本語名ポインタを書き込み
+
+:Animation Commands (pointer P24)
+アニメコマンド (ポインタ P24)

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -7183,3 +7183,72 @@ Hex アドレス
 
 :Animation Commands (pointer P24)
 アニメコマンド (ポインタ P24)
+
+:00 = Player
+00 = 自軍
+
+:01 = Enemy
+01 = 敵軍
+
+:02 = NPC
+02 = NPC
+
+:03 = Gray
+03 = グレー
+
+:00 = None
+00 = なし
+
+:01 = Fire
+01 = ファイアー
+
+:02 = Thunder
+02 = サンダー
+
+:03 = Live
+03 = ライブ
+
+:04 = Light
+04 = ライト
+
+:05 = Mil
+05 = ミィル
+
+:06 = Manakete
+06 = マムクート変身
+
+:07 = Monster Magic
+07 = 魔物の魔法
+
+:08 = Stone
+08 = ストーン
+
+:1 = Close-range attack animation
+1 = 近距離攻撃アニメを実行
+
+:2 = Close-range critical animation
+2 = 近距離必殺アニメを実行
+
+:3 = Set anime state to 'hit effect applied'
+3 = アニメの状態を「hit effect applied」にする
+
+:4 = Long-range attack animation
+4 = 遠距離攻撃アニメを実行
+
+:5 = Wait N frames
+5 = オプション引数で指定したnフレーム秒待つ
+
+:6 = Close-range dodge animation
+6 = 近距離で回避アニメーションを行う
+
+:7 = (FE8 unused) Set anime state to 'hit effect applied'
+7 = FE8では未使用。アニメーションの状態を「hit effect applied」にする
+
+:8 = Wait until anime reaches C01/C02/C18
+8 = アニメがコマンドC01、C02、C18のどれかに到達するまで待つ
+
+:Patch: OPClassReelAnimationIDOver255 active. Battle Anime ID is read from D18.
+パッチ: OPClassReelAnimationIDOver255 が有効。戦闘アニメIDは D18 から読み取られます。
+
+:Patch: OPClassReelSort active. Data Expansion enabled.
+パッチ: OPClassReelSort が有効。データ拡張が利用可能です。

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -7252,3 +7252,6 @@ Hex アドレス
 
 :Patch: OPClassReelSort active. Data Expansion enabled.
 パッチ: OPClassReelSort が有効。データ拡張が利用可能です。
+
+:Default palette
+標準パレット

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -7255,3 +7255,12 @@ Hex アドレス
 
 :Default palette
 標準パレット
+
+:Write Glyph Entry
+グリフを書き込み
+
+:Write Anime Command
+アニメコマンドを書き込み
+
+:Unknown (0x12):
+不明 (0x12):

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -21157,3 +21157,12 @@ to:
 
 :Default palette
 默认调色板
+
+:Write Glyph Entry
+写入字形
+
+:Write Anime Command
+写入动画指令
+
+:Unknown (0x12):
+未知 (0x12):

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -21154,3 +21154,6 @@ to:
 
 :Patch: OPClassReelSort active. Data Expansion enabled.
 补丁: OPClassReelSort 已启用。数据扩展可用。
+
+:Default palette
+默认调色板

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -21085,3 +21085,72 @@ to:
 
 :Animation Commands (pointer P24)
 动画指令 (指针 P24)
+
+:00 = Player
+00 = 我军
+
+:01 = Enemy
+01 = 敌军
+
+:02 = NPC
+02 = NPC
+
+:03 = Gray
+03 = 灰色
+
+:00 = None
+00 = 无
+
+:01 = Fire
+01 = 火
+
+:02 = Thunder
+02 = 雷
+
+:03 = Live
+03 = 治愈
+
+:04 = Light
+04 = 光
+
+:05 = Mil
+05 = 米尔
+
+:06 = Manakete
+06 = 龙人变身
+
+:07 = Monster Magic
+07 = 魔物魔法
+
+:08 = Stone
+08 = 石化
+
+:1 = Close-range attack animation
+1 = 近距离攻击动画
+
+:2 = Close-range critical animation
+2 = 近距离必杀动画
+
+:3 = Set anime state to 'hit effect applied'
+3 = 将动画状态设为 'hit effect applied'
+
+:4 = Long-range attack animation
+4 = 远距离攻击动画
+
+:5 = Wait N frames
+5 = 等待 N 帧
+
+:6 = Close-range dodge animation
+6 = 近距离回避动画
+
+:7 = (FE8 unused) Set anime state to 'hit effect applied'
+7 = (FE8 未使用) 将动画状态设为 'hit effect applied'
+
+:8 = Wait until anime reaches C01/C02/C18
+8 = 等待动画到达 C01/C02/C18
+
+:Patch: OPClassReelAnimationIDOver255 active. Battle Anime ID is read from D18.
+补丁: OPClassReelAnimationIDOver255 已启用。战斗动画ID 从 D18 读取。
+
+:Patch: OPClassReelSort active. Data Expansion enabled.
+补丁: OPClassReelSort 已启用。数据扩展可用。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -21014,3 +21014,74 @@ to:
 
 :Item Drop Dialog...
 物品掉落对话框...
+:Command:
+指令：
+
+:Display Weapon (Class):
+显示武器 (职业):
+
+:Ally / Enemy Color:
+我军/敌军 颜色:
+
+:Anime Spec Pointer:
+动画指定指针:
+
+:Arg (/60 sec):
+参数 (/60 秒):
+
+:Battle Anime (Patch +1):
+战斗动画 (补丁 +1):
+
+:Battle Anime:
+战斗动画:
+
+:Data Expansion
+数据扩展
+
+:Description Text ID:
+说明文本ID:
+
+:English Name Pointer:
+英文名指针:
+
+:Glyph:
+字形:
+
+:Hex Address
+十六进制地址
+
+:Japanese Name Font Glyphs (pointer P8)
+日文名字体字形 (指针 P8)
+
+:Japanese Name Length:
+日文名长度:
+
+:Japanese Name Pointer:
+日文名指针:
+
+:Magic Effect:
+魔法效果:
+
+:Palette ID:
+调色板ID:
+
+:Read Count
+读取数
+
+:Selected Address:
+所选地址:
+
+:Terrain (Left Half):
+地形 (左半部):
+
+:Terrain (Right Half):
+地形 (右半部):
+
+:Write Anime Spec Pointer
+写入动画指定指针
+
+:Write JP Name Pointer
+写入日文名指针
+
+:Animation Commands (pointer P24)
+动画指令 (指针 P24)

--- a/docs/field-completeness-report.txt
+++ b/docs/field-completeness-report.txt
@@ -1,6 +1,6 @@
 === Field Completeness Report ===
 Total WinForms fields: 1563
-Total Avalonia fields: 1725
+Total Avalonia fields: 1726
 Total missing: 0
 Forms with gaps: 0 / 174
 


### PR DESCRIPTION
## Summary

Closes the 32 control gap + 27 WF-only labels surfaced by the gap-sweep
methodology on `OPClassDemoForm` (HIGH density 31/63, -50.8 %). After this
PR the `OPClassDemoViewerView` rebuilds to a three-pane master-detail
editor with full WF parity.

- Top filter / read-config bar + address-write bar
- Main detail grid with 13 rows + inline preview labels for class /
  palette / battle anime / terrain.
- ComboBoxes for Ally/Enemy Color and Magic Effect.
- N1 sub-list panel for Japanese Name Font Glyphs (P8, 0xFF terminator).
- N2 sub-list panel for Animation Commands (P24, Cmd/Arg, 0x00 terminator).
- Patch-aware affordances:
  - OPClassReelSort → "Data Expansion" button visible.
  - OPClassReelAnimationIDOver255 → "Battle Anime (+1)" label.

Plus cross-cutting improvements addressing all three Copilot CLI plan
review rounds:

1. **Core patch detectors** — `OPClassReelSortPatchDetect(ROM)` and
   `OPClassReelAnimationIDOver255Detect(ROM)` extracted into
   `FEBuilderGBA.Core/PatchDetection.cs`; WinForms `PatchUtil` delegates.
2. **`DataExpansionCore.ExpandTable` undo completeness fix** — the table
   copy / new-entry zero-fill / old-location 0xFF wipe now go through
   `rom.write_range` / `rom.write_fill`, so ambient-undo scopes record
   the original bytes. Without this fix `Undo.RunUndo` would only
   restore the pointer repoint, not the table bytes.
3. **ListExpand button** uses `DataExpansionCore.ExpandTable(rom,
   op_class_demo_pointer, 28, currentCount)` inside
   `_undoService.Begin / Commit / Rollback`.
4. **L10n** — 23 new English labels translated in both `ja.txt` and `zh.txt`.

## Plan Reference
Implements the accepted plan at
[issue #419 comment](https://github.com/laqieer/FEBuilderGBA/issues/419#issuecomment-4525097897)
(revised 3 times to address every Copilot CLI plan-review finding).

## Scope
Closes #419
Ref #421 (separate PR — OPClassDemoFE7U, same pattern)
Ref #414 (separate PR — OPClassDemoFE7, same pattern)

## Screenshots

![OPClassDemo editor (FE8U) — new three-pane master-detail surface](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr-opclassdemo-419-editor.png)

Captured via `tools/WinCapture` PrintWindow API against FE8U.gba, Release
build of `FEBuilderGBA.Avalonia`. Window: 1137 x 1111. Shows the new
top filter/reload bar, address-write bar with Address / Size: 28 /
Selected Address / Write button, main entry list on the left, detail
grid with 13 rows of fields and inline preview labels, the two
sub-list panels (Japanese Name Font Glyphs (P8) and Animation Commands
(P24)) each with their own input controls + Write button.

## GUI Test Report

### Environment
- ROM: `roms/FE8U.gba` (BE8E01 — FE8U)
- Editor/View: `FEBuilderGBA.Avalonia.Views.OPClassDemoViewerView`
- Build: Release / net9.0

### Steps Performed
1. Launched Avalonia app with `--rom FE8U.gba` (no patches installed, so
   `IsReelSortPatchActive` and `IsOver255PatchActive` both false).
2. Opened `OP Class Demo Editor` from the FE8 main hub.
3. Verified all new controls render: top filter/reload bar, address-write
   bar, main detail grid (13 rows), N1 sub-list (P8), N2 sub-list (P24).
4. Verified ListExpand button is HIDDEN (no OPClassReelSort patch).
5. Verified Battle Anime+1 label is HIDDEN (no Over255 patch).

### Test Results
| Test | Expected | Actual | Status |
|------|----------|--------|--------|
| Top read-config bar renders | Hex Address / Read Count / Reload | Hex Address / Read Count (0) / Reload | PASS |
| Address-write bar renders | Address / Size 28 / Selected / Write | Address / Size 28 / Selected / Write | PASS |
| Detail grid: 13 rows | All field labels + spinners + preview boxes | All present | PASS |
| N1 sub-list panel renders | "Japanese Name Font Glyphs (pointer P8)" header + list + Glyph + Write button | All present | PASS |
| N2 sub-list panel renders | "Animation Commands (pointer P24)" header + list + Command combo + Arg + Write button | All present | PASS |
| ListExpand button — patch absent | Hidden (IsReelSortPatchActive == false) | Hidden | PASS |
| Battle Anime+1 label — patch absent | Hidden (IsOver255PatchActive == false) | Hidden | PASS |

### Verdict
PASS — new surface is functional, all WF-parity controls present and
patch-aware affordances hidden for vanilla FE8U.

## Test plan
- [x] All 1605 Core tests pass (`dotnet test FEBuilderGBA.Core.Tests/`).
- [x] All 1717 WinForms tests pass (`dotnet test FEBuilderGBA.Tests/`).
- [x] All 5196 Avalonia tests pass, 3 pre-existing skips
  (`dotnet test FEBuilderGBA.Avalonia.Tests/`).
- [x] New `OPClassDemoParityTests` (22 tests) — density ≥ 48 (64 actual),
  AutomationId presence, undo wiring on all 4 handlers, sub-list walks,
  patch presence flags.
- [x] New `PatchDetectionTests` (9 tests) — Over255/ReelSort detectors
  for null ROM / FE8J absent / FE8J present / FE8U handling.
- [x] New `DataExpansionCoreTests.ExpandTable_Rollback_RestoresAllByteRanges`
  — verifies undo completeness fix.
- [x] Updated `AvaloniaDialogViewTests` window-size assertion to 1534x878.
- [x] Density verdict: HIGH (31, -50.8 %) → LOW (64, +1.6 %).
- [x] L10n test passes — 23 new English labels translated in ja + zh.
- [x] GUI smoke test against FE8U.gba — editor window renders, all new
  controls present, patch-aware controls correctly hidden.

## Known limitations
- Live `ImageBattleAnimeForm.DrawBattleAnime` PNG rendering in a preview
  pane is deferred (numeric preview only). Tracked as follow-up — large
  WinForms-only dependency. Inline numeric label gives an equivalent
  hint at parity with the new master-detail surface.

Generated with Claude Code (claude-opus-4-7[1m])
