### PR TITLE
fix(gap-sweep): OPClassDemoFE7 parity (closes #414)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/OPClassDemoFE7ParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/OPClassDemoFE7ParityTests.cs
@@ -354,8 +354,12 @@ public class OPClassDemoFE7ParityTests
             // P28 points at 0x08100300 - synthetic anime block at 0x100300:
             //   row 0: cmd=0x01 arg=0x10 (ranged attack, wait 16)
             //   row 1: cmd=0x05 arg=0x20 (wait 32 frames)
-            //   row 2: cmd=0x08 arg=0x00 (wait for command - terminator)
-            // ScanN2 stops when cmd == 0x00, so we should see 3 entries.
+            //   row 2: cmd=0x08 arg=0x00 (real command "wait for cmd
+            //                              C01/C02/C18", arg unused)
+            //   row 3: cmd=0x00 arg=0x00 (TERMINATOR - iteration stops here)
+            // LoadN2List stops when cmd == 0x00, so we should see exactly 3
+            // entries (rows 0-2 inclusive; the row-3 terminator is the
+            // actual stop marker and is not enumerated).
             Assert.Equal(3, vm.N2Entries.Count);
             Assert.Equal(0x01u, vm.N2Entries[0].Command);
             Assert.Equal(0x10u, vm.N2Entries[0].Argument);

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/OPClassDemoFE7ParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/OPClassDemoFE7ParityTests.cs
@@ -1,0 +1,547 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Phase 1/2/5 gap-sweep regression tests for OPClassDemoFE7View. (#414)
+//
+// Closes the 60 Avalonia <-> WinForms gaps the gap-sweep methodology surfaced
+// on `OPClassDemoFE7Form` (HIGH density 64/32 == -50.0 %, 28 WF-only labels,
+// 0 common labels). FE7J variant: 32-byte entries, classId @ +15.
+//
+// Mirrors PR #537 (FE7U) and PR #544 (FE8U). Both pointer fields and the
+// N2 (animation command sequence) sub-list pattern were ported verbatim;
+// field semantics were re-verified against the WinForms designer labels +
+// `B17_ValueChanged` handler (B14 = Palette, B23 = Terrain Left,
+// B24 = Terrain Right — three of these were previously wrong in the VM).
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.GapSweep;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests.GapSweep;
+
+/// <summary>
+/// Tests proving the OPClassDemoFE7 parity raise (#414) is permanent.
+/// Marked [Collection("SharedState")] because the synthetic-ROM tests mutate
+/// CoreState.ROM. Without serialization, xUnit's per-class parallel runner can
+/// race a sibling test's ROM swap between LoadList / LoadEntry calls.
+/// </summary>
+[Collection("SharedState")]
+public class OPClassDemoFE7ParityTests
+{
+    // -----------------------------------------------------------------
+    // Density (Phase 1) - AV control count must reach the MEDIUM verdict.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// WF designer.cs reports 64 control instantiations. To leave the HIGH
+    /// verdict we need AV >= ceil(64 * 0.75) = 48.
+    /// </summary>
+    [Fact]
+    public void View_AvControlCount_AtOrAboveMediumVerdict()
+    {
+        string axamlPath = AxamlPath();
+        Assert.True(File.Exists(axamlPath), $"AXAML not found at {axamlPath}");
+
+        var doc = XDocument.Load(axamlPath);
+        int avCount = ControlDensityScanner.CountAvControlsInDocument(doc);
+
+        const int WfControlCount = 64;
+        int mediumThreshold = (int)Math.Ceiling(WfControlCount * 0.75); // 48
+        Assert.True(avCount >= mediumThreshold,
+            $"AV control count {avCount} must be >= {mediumThreshold} (75% of WF={WfControlCount})");
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 5 - control surface assertions (Roslyn-static AXAML read).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_HasSelectionBar()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_Address_Input\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_BlockSize_Input\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_SelectedAddress_Label\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_Write_Button\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasMainEditPanel_AllTwentyOneFields()
+    {
+        // All 21 FE7J main-entry fields must have a corresponding
+        // AutomationId input. P0/P8/P28 are pointer-aware (round-trip via
+        // rom.write_p32).
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_EnglishNamePtr_Input\"", axaml);     // P0
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_DescTextIdLow_Input\"", axaml);       // W4
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_Unknown6_Input\"", axaml);            // W6 (new)
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_JpNamePtr_Input\"", axaml);           // P8
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_JpNameStart_Input\"", axaml);         // B12 (new)
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_JpNameLen_Input\"", axaml);           // B13
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_PaletteId_Input\"", axaml);           // B14 (was DisplayWeapon)
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_ClassId_Input\"", axaml);             // B15
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_AllyEnemyColor_Input\"", axaml);      // B16
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_BattleAnime_Input\"", axaml);         // B17
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_MagicEffect_Input\"", axaml);         // B18
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_Unknown19_Input\"", axaml);           // B19
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_Unknown20_Input\"", axaml);           // B20
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_Unknown21_Input\"", axaml);           // B21
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_Unknown22_Input\"", axaml);           // B22 (new)
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_TerrainLeft_Input\"", axaml);         // B23 (corrected offset)
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_TerrainRight_Input\"", axaml);        // B24 (corrected offset)
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_Unknown25_Input\"", axaml);           // B25 (new)
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_Unknown26_Input\"", axaml);           // B26 (new)
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_Unknown27_Input\"", axaml);           // B27 (new)
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_AnimePtr_Input\"", axaml);            // P28
+    }
+
+    [Fact]
+    public void View_HasN2SubList_AllControls()
+    {
+        // The N2 (animation command sequence) sub-list mirrors the WF
+        // groupBox1: N2 selection bar (Address / BlockSize / SelectedAddress /
+        // Write button), N2 ListBox, N2 Command combo, N2 B0/B1 numerics,
+        // N2 Command/Wait labels.
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_N2_List\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_N2_Command_Combo\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_N2_Argument_Input\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_N2_CommandRaw_Input\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_N2_Address_Input\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_N2_BlockSize_Input\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_N2_SelectedAddress_Label\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_N2_Write_Button\"", axaml);
+        // Labels mirroring the WF "Command" header, "00", "/60 (秒)" labels:
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_N2_CommandHeader_Label\"", axaml);
+        Assert.Contains("AutomationId=\"OPClassDemoFE7_N2_WaitUnit_Label\"", axaml);
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 5 - Write/NWrite handlers must wrap ROM mutation in undo scope.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_WriteHandler_WrapsInUndoScope()
+    {
+        // Roslyn-static read of the code-behind source - no Avalonia head
+        // needed. Write_Click must open / commit / rollback an undo scope.
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        Assert.Contains("_undoService.Begin(", source);
+        Assert.Contains("_undoService.Commit()", source);
+        Assert.Contains("_undoService.Rollback()", source);
+    }
+
+    [Fact]
+    public void View_NWriteHandler_WrapsInOwnUndoScope()
+    {
+        // The N2 Write handler must open a SEPARATE undo scope (different
+        // scope name) from the main Write handler.
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        Assert.Contains("NWrite_Click", source);
+        Assert.Contains("Edit OP Class Demo Anime Command", source);
+    }
+
+    [Fact]
+    public void View_WriteHandlers_RoundTripThroughViewModel()
+    {
+        // Neither handler should call rom.SetU* / rom.write_u* directly -
+        // all ROM mutation must go through the ViewModel methods so the
+        // EditorFormRef pointer-aware codec runs.
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        Assert.DoesNotContain(".write_u8(", source);
+        Assert.DoesNotContain(".write_u16(", source);
+        Assert.DoesNotContain(".write_u32(", source);
+        Assert.DoesNotContain(".SetU8(", source);
+        Assert.DoesNotContain(".SetU16(", source);
+        Assert.DoesNotContain(".SetU32(", source);
+        Assert.Contains("_vm.WriteEntry(", source);
+        Assert.Contains("_vm.WriteN2Entry(", source);
+    }
+
+    [Fact]
+    public void View_WriteHandler_RefreshesN2List()
+    {
+        // Copilot CLI plan v2 finding: after the main Write_Click commits,
+        // the N2 sub-list must be reloaded so that a P28 change is
+        // reflected immediately instead of showing rows from the old block.
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        Assert.Contains("_vm.LoadN2List()", source);
+    }
+
+    // -----------------------------------------------------------------
+    // ViewModel state - pointer-aware fields (Copilot plan review #1).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_FieldDef_UsesPointerForP0P8P28()
+    {
+        // P0 (English name pointer), P8 (Japanese name image pointer) and
+        // P28 (animation pointer) must round-trip via rom.p32 / write_p32,
+        // not raw rom.write_u32. Without the pointer-aware codec, writes
+        // would persist the offset form (no 0x08000000 high bit) and
+        // corrupt the address (Copilot CLI plan review #1).
+        var fields = EditorFormRef.DetectFields(
+            new[] { "P0", "W4", "W6", "P8", "B12", "B13", "B14", "B15",
+                    "B16", "B17", "B18", "B19", "B20", "B21", "B22",
+                    "B23", "B24", "B25", "B26", "B27", "P28" });
+        var p0 = fields.First(f => f.Name == "P0");
+        var p8 = fields.First(f => f.Name == "P8");
+        var p28 = fields.First(f => f.Name == "P28");
+        Assert.Equal(EditorFormRef.FieldType.Pointer, p0.Type);
+        Assert.Equal(0u, p0.Offset);
+        Assert.Equal(EditorFormRef.FieldType.Pointer, p8.Type);
+        Assert.Equal(8u, p8.Offset);
+        Assert.Equal(EditorFormRef.FieldType.Pointer, p28.Type);
+        Assert.Equal(28u, p28.Offset);
+    }
+
+    [Fact]
+    public void ViewModel_Write_PersistsPointersAsGbaPointers()
+    {
+        var rom = MakeMinimalFE7JRomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new OPClassDemoFE7ViewModel();
+            vm.LoadEntry(entryAddr);
+
+            // Mutate all three pointer fields to a ROM offset (no high bit).
+            // Write() must encode them back with the 0x08000000 high bit so
+            // the raw u32 read after Write matches.
+            uint newOffsetP0 = 0x00200000u;
+            uint newOffsetP8 = 0x00250000u;
+            uint newOffsetP28 = 0x00300000u;
+            vm.EnglishNamePointer = newOffsetP0;
+            vm.JapaneseNamePointer = newOffsetP8;
+            vm.AnimePointer = newOffsetP28;
+            vm.WriteEntry();
+
+            uint rawP0 = rom.u32(entryAddr + 0);
+            uint decodedP0 = rom.p32(entryAddr + 0);
+            uint rawP8 = rom.u32(entryAddr + 8);
+            uint decodedP8 = rom.p32(entryAddr + 8);
+            uint rawP28 = rom.u32(entryAddr + 28);
+            uint decodedP28 = rom.p32(entryAddr + 28);
+            Assert.Equal(newOffsetP0 | 0x08000000u, rawP0);
+            Assert.Equal(newOffsetP0, decodedP0);
+            Assert.Equal(newOffsetP8 | 0x08000000u, rawP8);
+            Assert.Equal(newOffsetP8, decodedP8);
+            Assert.Equal(newOffsetP28 | 0x08000000u, rawP28);
+            Assert.Equal(newOffsetP28, decodedP28);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_LoadEntry_PopulatesAllTwentyOneFields()
+    {
+        var rom = MakeMinimalFE7JRomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new OPClassDemoFE7ViewModel();
+            vm.LoadEntry(entryAddr);
+
+            Assert.True(vm.CanWrite);
+            Assert.Equal(entryAddr, vm.CurrentAddr);
+            // Synthetic ROM plants known values for all 21 fields.
+            Assert.Equal(0x00100200u, vm.EnglishNamePointer);
+            Assert.Equal(0x0042u, vm.DescriptionTextIdLow);
+            Assert.Equal(0x0066u, vm.Unknown6);
+            Assert.Equal(0x00100250u, vm.JapaneseNamePointer);
+            Assert.Equal(0x12u, vm.JapaneseNameStart);
+            Assert.Equal(0x13u, vm.JapaneseNameLength);
+            Assert.Equal(0x14u, vm.PaletteId);
+            Assert.Equal(0x15u, vm.ClassId);
+            Assert.Equal(0x16u, vm.AllyEnemyColor);
+            Assert.Equal(0x17u, vm.BattleAnime);
+            Assert.Equal(0x18u, vm.MagicEffect);
+            Assert.Equal(0x19u, vm.Unknown19);
+            Assert.Equal(0x20u, vm.Unknown20);
+            Assert.Equal(0x21u, vm.Unknown21);
+            Assert.Equal(0x22u, vm.Unknown22);
+            Assert.Equal(0x23u, vm.TerrainLeft);
+            Assert.Equal(0x24u, vm.TerrainRight);
+            Assert.Equal(0x25u, vm.Unknown25);
+            Assert.Equal(0x26u, vm.Unknown26);
+            Assert.Equal(0x27u, vm.Unknown27);
+            Assert.Equal(0x00100300u, vm.AnimePointer);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_Write_PersistsAllFields_RoundTrip()
+    {
+        var rom = MakeMinimalFE7JRomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new OPClassDemoFE7ViewModel();
+            vm.LoadEntry(entryAddr);
+
+            // Set every field to a new known value.
+            vm.EnglishNamePointer = 0x00100500u;
+            vm.DescriptionTextIdLow = 0x0100;
+            vm.Unknown6 = 0x0066;
+            vm.JapaneseNamePointer = 0x00100550u;
+            vm.JapaneseNameStart = 0x42;
+            vm.JapaneseNameLength = 0x20;
+            vm.PaletteId = 0x55;
+            vm.ClassId = 0x33;
+            vm.AllyEnemyColor = 0x03;
+            vm.BattleAnime = 0x77;
+            vm.MagicEffect = 0x06;
+            vm.Unknown19 = 0xAA;
+            vm.Unknown20 = 0xBB;
+            vm.Unknown21 = 0xCC;
+            vm.Unknown22 = 0xDD;
+            vm.TerrainLeft = 0xEE;
+            vm.TerrainRight = 0xFF;
+            vm.Unknown25 = 0x55;
+            vm.Unknown26 = 0x66;
+            vm.Unknown27 = 0x77;
+            vm.AnimePointer = 0x00100400u;
+            vm.WriteEntry();
+
+            // Re-read and verify every byte at the expected offset.
+            Assert.Equal(0x00100500u | 0x08000000u, rom.u32(entryAddr + 0));
+            Assert.Equal(0x0100u, rom.u16(entryAddr + 4));
+            Assert.Equal(0x0066u, rom.u16(entryAddr + 6));
+            Assert.Equal(0x00100550u | 0x08000000u, rom.u32(entryAddr + 8));
+            Assert.Equal(0x42u, rom.u8(entryAddr + 12));
+            Assert.Equal(0x20u, rom.u8(entryAddr + 13));
+            Assert.Equal(0x55u, rom.u8(entryAddr + 14));
+            Assert.Equal(0x33u, rom.u8(entryAddr + 15));
+            Assert.Equal(0x03u, rom.u8(entryAddr + 16));
+            Assert.Equal(0x77u, rom.u8(entryAddr + 17));
+            Assert.Equal(0x06u, rom.u8(entryAddr + 18));
+            Assert.Equal(0xAAu, rom.u8(entryAddr + 19));
+            Assert.Equal(0xBBu, rom.u8(entryAddr + 20));
+            Assert.Equal(0xCCu, rom.u8(entryAddr + 21));
+            Assert.Equal(0xDDu, rom.u8(entryAddr + 22));
+            Assert.Equal(0xEEu, rom.u8(entryAddr + 23));
+            Assert.Equal(0xFFu, rom.u8(entryAddr + 24));
+            Assert.Equal(0x55u, rom.u8(entryAddr + 25));
+            Assert.Equal(0x66u, rom.u8(entryAddr + 26));
+            Assert.Equal(0x77u, rom.u8(entryAddr + 27));
+            Assert.Equal(0x00100400u | 0x08000000u, rom.u32(entryAddr + 28));
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    // -----------------------------------------------------------------
+    // N2 sub-list (animation command sequence) coverage.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_LoadN2List_ParsesAnimeBlock()
+    {
+        var rom = MakeMinimalFE7JRomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new OPClassDemoFE7ViewModel();
+            vm.LoadEntry(entryAddr);
+            // P28 points at 0x08100300 - synthetic anime block at 0x100300:
+            //   row 0: cmd=0x01 arg=0x10 (ranged attack, wait 16)
+            //   row 1: cmd=0x05 arg=0x20 (wait 32 frames)
+            //   row 2: cmd=0x08 arg=0x00 (wait for command - terminator)
+            // ScanN2 stops when cmd == 0x00, so we should see 3 entries.
+            Assert.Equal(3, vm.N2Entries.Count);
+            Assert.Equal(0x01u, vm.N2Entries[0].Command);
+            Assert.Equal(0x10u, vm.N2Entries[0].Argument);
+            Assert.Equal(0x05u, vm.N2Entries[1].Command);
+            Assert.Equal(0x20u, vm.N2Entries[1].Argument);
+            Assert.Equal(0x08u, vm.N2Entries[2].Command);
+            Assert.Equal(0x00u, vm.N2Entries[2].Argument);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_WriteN2Entry_PersistsCommandAndArg()
+    {
+        var rom = MakeMinimalFE7JRomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new OPClassDemoFE7ViewModel();
+            vm.LoadEntry(entryAddr);
+            // Mutate row 0 - change cmd 0x01 -> 0x04 and arg 0x10 -> 0x30.
+            vm.SelectedN2Index = 0;
+            vm.N2Command = 0x04;
+            vm.N2Argument = 0x30;
+            bool ok = vm.WriteN2Entry();
+            Assert.True(ok);
+
+            uint animeOffset = U.toOffset(vm.AnimePointer);
+            Assert.Equal(0x04u, rom.u8(animeOffset + 0));
+            Assert.Equal(0x30u, rom.u8(animeOffset + 1));
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_LoadN2Row_ClearsSelectionStateOnNegativeIndex()
+    {
+        // Copilot PR #537 review #2: when the ListBox loses its selection
+        // (idx == -1), LoadN2Row must clear SelectedN2Index AND the editor
+        // command/argument/address state so NWrite_Click doesn't silently
+        // write to a stale row.
+        var rom = MakeMinimalFE7JRomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new OPClassDemoFE7ViewModel();
+            vm.LoadEntry(entryAddr);
+            Assert.True(vm.N2Entries.Count > 0);
+            // Select row 1 and confirm the state is populated.
+            vm.LoadN2Row(1);
+            Assert.Equal(1, vm.SelectedN2Index);
+            Assert.NotEqual(0u, vm.N2SelectedAddress);
+            // Now clear with -1 — every field must reset.
+            vm.LoadN2Row(-1);
+            Assert.Equal(-1, vm.SelectedN2Index);
+            Assert.Equal(0u, vm.N2Command);
+            Assert.Equal(0u, vm.N2Argument);
+            Assert.Equal(0u, vm.N2SelectedAddress);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_LoadN2List_ClearsWhenAnimePointerInvalid()
+    {
+        var rom = MakeMinimalFE7JRomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new OPClassDemoFE7ViewModel();
+            vm.LoadEntry(entryAddr);
+            // Now switch the anime pointer to 0 (invalid) and reload.
+            vm.AnimePointer = 0;
+            vm.LoadN2List();
+            Assert.Empty(vm.N2Entries);
+            Assert.Equal(-1, vm.SelectedN2Index);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    static string AxamlPath()
+    {
+        string repoRoot = FindRepoRoot();
+        return Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "OPClassDemoFE7View.axaml");
+    }
+
+    static string ViewCodeBehindPath()
+    {
+        string repoRoot = FindRepoRoot();
+        return Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "OPClassDemoFE7View.axaml.cs");
+    }
+
+    static string ReadAxaml() => File.ReadAllText(AxamlPath());
+
+    /// <summary>
+    /// Build a tiny synthetic FE7J ROM with:
+    /// - op_class_demo_pointer -> 0x08100000 (entry table at 0x100000).
+    /// - One 32-byte entry with known field values for all 21 fields.
+    /// - Anime block at 0x100300: 3 rows (cmd 0x01/arg 0x10, cmd 0x05/arg 0x20,
+    ///   cmd 0x08/arg 0x00 - terminator).
+    /// Returns the first-entry address (0x100000) so tests can call
+    /// LoadEntry() directly.
+    /// </summary>
+    static ROM MakeMinimalFE7JRomWithEntry(out uint entryAddr)
+    {
+        var rom = new ROM();
+        // FE7J title is AE7J — synthesize an FE7J ROM.
+        rom.LoadLow("synth.gba", new byte[0x1000000], "AE7J01");
+
+        // op_class_demo_pointer -> 0x08100000.
+        uint ptrAddr = rom.RomInfo.op_class_demo_pointer;
+        WriteU32(rom.Data, (int)ptrAddr, 0x08100000u);
+
+        // Entry at 0x100000 — 32-byte FE7J entry with all 21 fields populated
+        // to distinct known values for the offset round-trip test.
+        entryAddr = 0x100000;
+        WriteU32(rom.Data, (int)entryAddr + 0, 0x08100200u);   // P0 EnglishName ptr
+        WriteU16(rom.Data, (int)entryAddr + 4, 0x0042);        // W4 DescTextIdLow
+        WriteU16(rom.Data, (int)entryAddr + 6, 0x0066);        // W6 Unknown6
+        WriteU32(rom.Data, (int)entryAddr + 8, 0x08100250u);   // P8 JpName ptr
+        rom.Data[entryAddr + 12] = 0x12;                       // B12 JpName start
+        rom.Data[entryAddr + 13] = 0x13;                       // B13 JpName length
+        rom.Data[entryAddr + 14] = 0x14;                       // B14 PaletteId
+        rom.Data[entryAddr + 15] = 0x15;                       // B15 ClassId
+        rom.Data[entryAddr + 16] = 0x16;                       // B16 AllyEnemyColor
+        rom.Data[entryAddr + 17] = 0x17;                       // B17 BattleAnime
+        rom.Data[entryAddr + 18] = 0x18;                       // B18 MagicEffect
+        rom.Data[entryAddr + 19] = 0x19;                       // B19 Unknown19
+        rom.Data[entryAddr + 20] = 0x20;                       // B20 Unknown20
+        rom.Data[entryAddr + 21] = 0x21;                       // B21 Unknown21
+        rom.Data[entryAddr + 22] = 0x22;                       // B22 Unknown22
+        rom.Data[entryAddr + 23] = 0x23;                       // B23 TerrainLeft
+        rom.Data[entryAddr + 24] = 0x24;                       // B24 TerrainRight
+        rom.Data[entryAddr + 25] = 0x25;                       // B25 Unknown25
+        rom.Data[entryAddr + 26] = 0x26;                       // B26 Unknown26
+        rom.Data[entryAddr + 27] = 0x27;                       // B27 Unknown27
+        WriteU32(rom.Data, (int)entryAddr + 28, 0x08100300u);  // P28 AnimePointer
+
+        // Anime block at 0x100300.
+        WriteAnimeRow(rom.Data, 0x100300, 0x01, 0x10);
+        WriteAnimeRow(rom.Data, 0x100302, 0x05, 0x20);
+        WriteAnimeRow(rom.Data, 0x100304, 0x08, 0x00);
+        // Terminator after row 2 (cmd == 0).
+        WriteAnimeRow(rom.Data, 0x100306, 0x00, 0x00);
+
+        return rom;
+    }
+
+    static void WriteU32(byte[] data, int offset, uint value)
+    {
+        data[offset + 0] = (byte)(value & 0xFF);
+        data[offset + 1] = (byte)((value >> 8) & 0xFF);
+        data[offset + 2] = (byte)((value >> 16) & 0xFF);
+        data[offset + 3] = (byte)((value >> 24) & 0xFF);
+    }
+
+    static void WriteU16(byte[] data, int offset, ushort value)
+    {
+        data[offset + 0] = (byte)(value & 0xFF);
+        data[offset + 1] = (byte)((value >> 8) & 0xFF);
+    }
+
+    static void WriteAnimeRow(byte[] data, int offset, byte cmd, byte arg)
+    {
+        data[offset + 0] = cmd;
+        data[offset + 1] = arg;
+    }
+
+    static string FindRepoRoot()
+    {
+        string? dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+        if (dir == null)
+            throw new InvalidOperationException("Could not find FEBuilderGBA.sln from test base directory");
+        return dir;
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/OPClassDemoFE7ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/OPClassDemoFE7ViewModel.cs
@@ -5,25 +5,85 @@ using FEBuilderGBA.Avalonia.Services;
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
     /// <summary>
-    /// OP Class Demo editor (FE7 Japanese / FE6 variant).
-    /// Data: op_class_demo_pointer, datasize=32, classId at offset 15.
-    /// Used by FE6 (MainFE6Form opens OPClassDemoFE7Form).
+    /// OP Class Demo editor (FE7J / FE6 variant).
+    /// Data: <c>op_class_demo_pointer</c>, datasize = 32, classId at offset 15.
+    /// Used by FE7J (MainFE7Form opens OPClassDemoFE7View when the ROM is
+    /// AE7J — the FE7U variant uses a separate 28-byte struct in
+    /// <see cref="OPClassDemoFE7UViewModel"/>).
+    ///
+    /// Pointer fields (P0 English-name, P8 Japanese-name-image, P28 anime
+    /// block) use <see cref="EditorFormRef.FieldType.Pointer"/> so they
+    /// round-trip through <c>rom.p32</c>/<c>write_p32</c>. Storing them as
+    /// raw DWords (D0/D8/D28) would write the offset form back to ROM
+    /// without the <c>0x08000000</c> high bit, corrupting the address
+    /// (gap-sweep #414 fix — same bug PR #537 fixed for FE7U).
+    ///
+    /// Field semantics re-verified against the WinForms designer labels +
+    /// <c>B17_ValueChanged</c> handler:
+    ///   P0  = English name pointer (J_0_TEXT "英語ポインタ")
+    ///   W4  = Description text ID low (J_4_TEXT "説明文ID")
+    ///   W6  = Unknown6 (J_6 "??")
+    ///   P8  = Japanese name image pointer (J_8 "日本語名アドレス")
+    ///   B12 = Japanese name start position (J_12 "日本語名 開始位置")
+    ///   B13 = Japanese name length (J_13 "日本語名の長さ")
+    ///   B14 = Palette ID (J_14_UNITPALETTE_PLUS1 "パレットID" — also used as
+    ///         palette index by B17_ValueChanged when calling DrawBattleAnime;
+    ///         was wrongly named "DisplayWeapon" in the previous VM)
+    ///   B15 = Class ID (init callback reads addr+15 for the list name)
+    ///   B16 = Ally/Enemy color (J_16 "敵味方カラー")
+    ///   B17 = Battle anime (J_17_BATTLEANIME "戦闘アニメ")
+    ///   B18 = Magic effect (J_18 "魔法エフェクト")
+    ///   B19/B20/B21/B22 = Unknown (J_19 "??" — 4 inputs share one label)
+    ///   B23 = Terrain left (J_23_TERRAINBATTLE "表示地形左半分")
+    ///   B24 = Terrain right (J_24_TERRAINBATTLE "表示地形右半分")
+    ///   B25/B26/B27 = Unknown (J_25 "??" — 3 inputs share one label)
+    ///   P28 = Anime block pointer (J_28 "アニメ指定のポインタ")
+    ///
+    /// The N2 sub-list (animation command sequence) is a separate variable-
+    /// length array of 2-byte entries: u8 command + u8 argument, terminated
+    /// by command == 0. The array starts at the address pointed to by P28.
+    /// Command set (from WF L_0_COMBO):
+    ///   1 = ranged attack anime              5 = wait N frames (arg = N/60 sec)
+    ///   2 = ranged critical anime            6 = ranged evade
+    ///   3 = "hit effect applied"             7 = unused in FE8 (hit effect)
+    ///   4 = ranged attack anime              8 = wait for cmd C01/C02/C18
     /// </summary>
     public class OPClassDemoFE7ViewModel : ViewModelBase, IDataVerifiable
     {
         static readonly List<EditorFormRef.FieldDef> _fields =
-            EditorFormRef.DetectFields(new[] { "D0", "W4", "W6", "D8", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "D28" });
+            EditorFormRef.DetectFields(new[] {
+                "P0", "W4", "W6", "P8",
+                "B12", "B13", "B14", "B15",
+                "B16", "B17", "B18", "B19",
+                "B20", "B21", "B22", "B23",
+                "B24", "B25", "B26", "B27",
+                "P28"
+            });
+
+        /// <summary>WF main block size constant (32 bytes per entry).</summary>
+        public const uint BLOCK_SIZE = 32;
+        /// <summary>WF N2 (anime command) block size constant (2 bytes per row).</summary>
+        public const uint N2_BLOCK_SIZE = 2;
+
+        /// <summary>One row of the N2 (animation command sequence) sub-list.</summary>
+        public class N2Row
+        {
+            public uint Index;
+            public uint Address;
+            public uint Command;
+            public uint Argument;
+        }
 
         uint _currentAddr;
         bool _canWrite;
         string _unavailableMessage = "";
         uint _englishNamePointer;
         uint _descriptionTextIdLow;
-        uint _descriptionTextIdHigh;
+        uint _unknown6;
         uint _japaneseNamePointer;
+        uint _japaneseNameStart;
         uint _japaneseNameLength;
         uint _paletteId;
-        uint _displayWeapon;
         uint _classId;
         uint _allyEnemyColor;
         uint _battleAnime;
@@ -31,24 +91,31 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         uint _unknown19;
         uint _unknown20;
         uint _unknown21;
+        uint _unknown22;
         uint _terrainLeft;
         uint _terrainRight;
-        uint _unknown24;
         uint _unknown25;
         uint _unknown26;
         uint _unknown27;
         uint _animePointer;
+
+        // N2 sub-list state.
+        List<N2Row> _n2Entries = new();
+        int _selectedN2Index = -1;
+        uint _n2Command;
+        uint _n2Argument;
+        uint _n2SelectedAddress;
 
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool CanWrite { get => _canWrite; set => SetField(ref _canWrite, value); }
         public string UnavailableMessage { get => _unavailableMessage; set => SetField(ref _unavailableMessage, value); }
         public uint EnglishNamePointer { get => _englishNamePointer; set => SetField(ref _englishNamePointer, value); }
         public uint DescriptionTextIdLow { get => _descriptionTextIdLow; set => SetField(ref _descriptionTextIdLow, value); }
-        public uint DescriptionTextIdHigh { get => _descriptionTextIdHigh; set => SetField(ref _descriptionTextIdHigh, value); }
+        public uint Unknown6 { get => _unknown6; set => SetField(ref _unknown6, value); }
         public uint JapaneseNamePointer { get => _japaneseNamePointer; set => SetField(ref _japaneseNamePointer, value); }
+        public uint JapaneseNameStart { get => _japaneseNameStart; set => SetField(ref _japaneseNameStart, value); }
         public uint JapaneseNameLength { get => _japaneseNameLength; set => SetField(ref _japaneseNameLength, value); }
         public uint PaletteId { get => _paletteId; set => SetField(ref _paletteId, value); }
-        public uint DisplayWeapon { get => _displayWeapon; set => SetField(ref _displayWeapon, value); }
         public uint ClassId { get => _classId; set => SetField(ref _classId, value); }
         public uint AllyEnemyColor { get => _allyEnemyColor; set => SetField(ref _allyEnemyColor, value); }
         public uint BattleAnime { get => _battleAnime; set => SetField(ref _battleAnime, value); }
@@ -56,13 +123,25 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public uint Unknown19 { get => _unknown19; set => SetField(ref _unknown19, value); }
         public uint Unknown20 { get => _unknown20; set => SetField(ref _unknown20, value); }
         public uint Unknown21 { get => _unknown21; set => SetField(ref _unknown21, value); }
+        public uint Unknown22 { get => _unknown22; set => SetField(ref _unknown22, value); }
         public uint TerrainLeft { get => _terrainLeft; set => SetField(ref _terrainLeft, value); }
         public uint TerrainRight { get => _terrainRight; set => SetField(ref _terrainRight, value); }
-        public uint Unknown24 { get => _unknown24; set => SetField(ref _unknown24, value); }
         public uint Unknown25 { get => _unknown25; set => SetField(ref _unknown25, value); }
         public uint Unknown26 { get => _unknown26; set => SetField(ref _unknown26, value); }
         public uint Unknown27 { get => _unknown27; set => SetField(ref _unknown27, value); }
         public uint AnimePointer { get => _animePointer; set => SetField(ref _animePointer, value); }
+
+        public List<N2Row> N2Entries
+        {
+            get => _n2Entries;
+            set => SetField(ref _n2Entries, value ?? new());
+        }
+        public int SelectedN2Index { get => _selectedN2Index; set => SetField(ref _selectedN2Index, value); }
+        public uint N2Command { get => _n2Command; set => SetField(ref _n2Command, value); }
+        public uint N2Argument { get => _n2Argument; set => SetField(ref _n2Argument, value); }
+        public uint N2SelectedAddress { get => _n2SelectedAddress; set => SetField(ref _n2SelectedAddress, value); }
+        public uint BlockSize => BLOCK_SIZE;
+        public uint N2BlockSize => N2_BLOCK_SIZE;
 
         public List<AddrResult> LoadList()
         {
@@ -96,7 +175,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
             UnavailableMessage = "";
             var result = new List<AddrResult>();
-            // datasize=32, up to 0x42 entries
+            // datasize=32, up to 0x42 entries (WF: i <= 0x41).
             for (uint i = 0; i <= 0x41; i++)
             {
                 uint addr = (uint)(baseAddr + i * 32);
@@ -118,13 +197,13 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
             CurrentAddr = addr;
             var v = EditorFormRef.ReadFields(rom, addr, _fields);
-            EnglishNamePointer = v["D0"];
+            EnglishNamePointer = v["P0"];
             DescriptionTextIdLow = v["W4"];
-            DescriptionTextIdHigh = v["W6"];
-            JapaneseNamePointer = v["D8"];
-            JapaneseNameLength = v["B12"];
-            PaletteId = v["B13"];
-            DisplayWeapon = v["B14"];
+            Unknown6 = v["W6"];
+            JapaneseNamePointer = v["P8"];
+            JapaneseNameStart = v["B12"];
+            JapaneseNameLength = v["B13"];
+            PaletteId = v["B14"];
             ClassId = v["B15"];
             AllyEnemyColor = v["B16"];
             BattleAnime = v["B17"];
@@ -132,14 +211,17 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             Unknown19 = v["B19"];
             Unknown20 = v["B20"];
             Unknown21 = v["B21"];
-            TerrainLeft = v["B22"];
-            TerrainRight = v["B23"];
-            Unknown24 = v["B24"];
+            Unknown22 = v["B22"];
+            TerrainLeft = v["B23"];
+            TerrainRight = v["B24"];
             Unknown25 = v["B25"];
             Unknown26 = v["B26"];
             Unknown27 = v["B27"];
-            AnimePointer = v["D28"];
+            AnimePointer = v["P28"];
             CanWrite = true;
+
+            // Rebuild the N2 (animation command) sub-list for the new entry.
+            LoadN2List();
         }
 
         public void WriteEntry()
@@ -148,15 +230,115 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (rom == null || CurrentAddr == 0) return;
             var values = new Dictionary<string, uint>
             {
-                ["D0"] = EnglishNamePointer, ["W4"] = DescriptionTextIdLow, ["W6"] = DescriptionTextIdHigh,
-                ["D8"] = JapaneseNamePointer, ["B12"] = JapaneseNameLength, ["B13"] = PaletteId,
-                ["B14"] = DisplayWeapon, ["B15"] = ClassId, ["B16"] = AllyEnemyColor,
+                ["P0"] = EnglishNamePointer, ["W4"] = DescriptionTextIdLow, ["W6"] = Unknown6,
+                ["P8"] = JapaneseNamePointer, ["B12"] = JapaneseNameStart, ["B13"] = JapaneseNameLength,
+                ["B14"] = PaletteId, ["B15"] = ClassId, ["B16"] = AllyEnemyColor,
                 ["B17"] = BattleAnime, ["B18"] = MagicEffect, ["B19"] = Unknown19,
-                ["B20"] = Unknown20, ["B21"] = Unknown21, ["B22"] = TerrainLeft,
-                ["B23"] = TerrainRight, ["B24"] = Unknown24, ["B25"] = Unknown25,
-                ["B26"] = Unknown26, ["B27"] = Unknown27, ["D28"] = AnimePointer,
+                ["B20"] = Unknown20, ["B21"] = Unknown21, ["B22"] = Unknown22,
+                ["B23"] = TerrainLeft, ["B24"] = TerrainRight, ["B25"] = Unknown25,
+                ["B26"] = Unknown26, ["B27"] = Unknown27, ["P28"] = AnimePointer,
             };
             EditorFormRef.WriteFields(rom, CurrentAddr, values, _fields);
+        }
+
+        /// <summary>
+        /// Scan the animation-command block at <see cref="AnimePointer"/>,
+        /// populating <see cref="N2Entries"/>. The block is a sequence of
+        /// 2-byte rows (u8 command + u8 argument); iteration stops when
+        /// command == 0 (mirrors WF <c>N2_Init</c>'s <c>isValid</c> predicate).
+        /// Safe to call when AnimePointer is 0 or out of range - clears the
+        /// list and selection state.
+        /// </summary>
+        public void LoadN2List()
+        {
+            ROM rom = CoreState.ROM;
+            var result = new List<N2Row>();
+            uint ptr = AnimePointer;
+            uint offset = U.toOffset(ptr);
+            if (rom == null || ptr == 0 || !U.isSafetyOffset(offset, rom))
+            {
+                N2Entries = result;
+                SelectedN2Index = -1;
+                N2Command = 0;
+                N2Argument = 0;
+                N2SelectedAddress = 0;
+                return;
+            }
+            // Iterate up to a safety cap. WF uses i <= 0xFF but the terminator
+            // (cmd == 0) almost always hits inside a few rows.
+            const int MaxRows = 0x100;
+            for (int i = 0; i < MaxRows; i++)
+            {
+                uint rowAddr = offset + (uint)(i * 2);
+                if (rowAddr + 2 > (uint)rom.Data.Length) break;
+                uint cmd = rom.u8(rowAddr + 0);
+                if (cmd == 0) break;
+                result.Add(new N2Row
+                {
+                    Index = (uint)i,
+                    Address = rowAddr,
+                    Command = cmd,
+                    Argument = rom.u8(rowAddr + 1),
+                });
+            }
+            N2Entries = result;
+            if (result.Count > 0)
+            {
+                SelectedN2Index = 0;
+                N2Command = result[0].Command;
+                N2Argument = result[0].Argument;
+                N2SelectedAddress = result[0].Address;
+            }
+            else
+            {
+                SelectedN2Index = -1;
+                N2Command = 0;
+                N2Argument = 0;
+                N2SelectedAddress = 0;
+            }
+        }
+
+        /// <summary>Load the selected N2 row's command/argument into the editor fields.</summary>
+        public void LoadN2Row(int rowIndex)
+        {
+            if (rowIndex < 0 || rowIndex >= N2Entries.Count)
+            {
+                SelectedN2Index = -1;
+                N2Command = 0;
+                N2Argument = 0;
+                N2SelectedAddress = 0;
+                return;
+            }
+            var row = N2Entries[rowIndex];
+            SelectedN2Index = rowIndex;
+            N2Command = row.Command;
+            N2Argument = row.Argument;
+            N2SelectedAddress = row.Address;
+        }
+
+        /// <summary>
+        /// Write the currently selected N2 row (Command + Argument) back to
+        /// ROM at <c>AnimePointer + 2 * SelectedN2Index</c>. Returns
+        /// <c>true</c> on success, <c>false</c> when the row index, anime
+        /// pointer, or row address is invalid. Caller should wrap the call
+        /// in <c>UndoService.Begin/Commit</c> for undo support.
+        /// </summary>
+        public bool WriteN2Entry()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null) return false;
+            if (SelectedN2Index < 0 || SelectedN2Index >= N2Entries.Count) return false;
+            uint offset = U.toOffset(AnimePointer);
+            if (AnimePointer == 0 || !U.isSafetyOffset(offset, rom)) return false;
+            uint rowAddr = offset + (uint)(SelectedN2Index * 2);
+            if (rowAddr + 2 > (uint)rom.Data.Length) return false;
+            rom.write_u8(rowAddr + 0, N2Command & 0xFF);
+            rom.write_u8(rowAddr + 1, N2Argument & 0xFF);
+            // Refresh the in-memory row so the list reflects the new bytes.
+            var row = N2Entries[SelectedN2Index];
+            row.Command = N2Command & 0xFF;
+            row.Argument = N2Argument & 0xFF;
+            return true;
         }
 
         public int GetListCount() => LoadList().Count;
@@ -168,11 +350,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 ["addr"] = $"0x{CurrentAddr:X08}",
                 ["EnglishNamePointer"] = $"0x{EnglishNamePointer:X08}",
                 ["DescriptionTextIdLow"] = $"0x{DescriptionTextIdLow:X04}",
-                ["DescriptionTextIdHigh"] = $"0x{DescriptionTextIdHigh:X04}",
+                ["Unknown6"] = $"0x{Unknown6:X04}",
                 ["JapaneseNamePointer"] = $"0x{JapaneseNamePointer:X08}",
+                ["JapaneseNameStart"] = $"0x{JapaneseNameStart:X02}",
                 ["JapaneseNameLength"] = $"0x{JapaneseNameLength:X02}",
                 ["PaletteId"] = $"0x{PaletteId:X02}",
-                ["DisplayWeapon"] = $"0x{DisplayWeapon:X02}",
                 ["ClassId"] = $"0x{ClassId:X02}",
                 ["AllyEnemyColor"] = $"0x{AllyEnemyColor:X02}",
                 ["BattleAnime"] = $"0x{BattleAnime:X02}",
@@ -180,13 +362,15 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 ["Unknown19"] = $"0x{Unknown19:X02}",
                 ["Unknown20"] = $"0x{Unknown20:X02}",
                 ["Unknown21"] = $"0x{Unknown21:X02}",
+                ["Unknown22"] = $"0x{Unknown22:X02}",
                 ["TerrainLeft"] = $"0x{TerrainLeft:X02}",
                 ["TerrainRight"] = $"0x{TerrainRight:X02}",
-                ["Unknown24"] = $"0x{Unknown24:X02}",
                 ["Unknown25"] = $"0x{Unknown25:X02}",
                 ["Unknown26"] = $"0x{Unknown26:X02}",
                 ["Unknown27"] = $"0x{Unknown27:X02}",
                 ["AnimePointer"] = $"0x{AnimePointer:X08}",
+                ["N2RowCount"] = N2Entries.Count.ToString(),
+                ["N2SelectedIndex"] = SelectedN2Index.ToString(),
             };
         }
 
@@ -200,11 +384,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 ["addr"] = $"0x{a:X08}",
                 ["u32@0x00_EnglishNamePointer"] = $"0x{rom.u32(a + 0):X08}",
                 ["u16@0x04_DescriptionTextIdLow"] = $"0x{rom.u16(a + 4):X04}",
-                ["u16@0x06_DescriptionTextIdHigh"] = $"0x{rom.u16(a + 6):X04}",
+                ["u16@0x06_Unknown6"] = $"0x{rom.u16(a + 6):X04}",
                 ["u32@0x08_JapaneseNamePointer"] = $"0x{rom.u32(a + 8):X08}",
-                ["u8@0x0C_JapaneseNameLength"] = $"0x{rom.u8(a + 12):X02}",
-                ["u8@0x0D_PaletteId"] = $"0x{rom.u8(a + 13):X02}",
-                ["u8@0x0E_DisplayWeapon"] = $"0x{rom.u8(a + 14):X02}",
+                ["u8@0x0C_JapaneseNameStart"] = $"0x{rom.u8(a + 12):X02}",
+                ["u8@0x0D_JapaneseNameLength"] = $"0x{rom.u8(a + 13):X02}",
+                ["u8@0x0E_PaletteId"] = $"0x{rom.u8(a + 14):X02}",
                 ["u8@0x0F_ClassId"] = $"0x{rom.u8(a + 15):X02}",
                 ["u8@0x10_AllyEnemyColor"] = $"0x{rom.u8(a + 16):X02}",
                 ["u8@0x11_BattleAnime"] = $"0x{rom.u8(a + 17):X02}",
@@ -212,9 +396,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 ["u8@0x13_Unknown19"] = $"0x{rom.u8(a + 19):X02}",
                 ["u8@0x14_Unknown20"] = $"0x{rom.u8(a + 20):X02}",
                 ["u8@0x15_Unknown21"] = $"0x{rom.u8(a + 21):X02}",
-                ["u8@0x16_TerrainLeft"] = $"0x{rom.u8(a + 22):X02}",
-                ["u8@0x17_TerrainRight"] = $"0x{rom.u8(a + 23):X02}",
-                ["u8@0x18_Unknown24"] = $"0x{rom.u8(a + 24):X02}",
+                ["u8@0x16_Unknown22"] = $"0x{rom.u8(a + 22):X02}",
+                ["u8@0x17_TerrainLeft"] = $"0x{rom.u8(a + 23):X02}",
+                ["u8@0x18_TerrainRight"] = $"0x{rom.u8(a + 24):X02}",
                 ["u8@0x19_Unknown25"] = $"0x{rom.u8(a + 25):X02}",
                 ["u8@0x1A_Unknown26"] = $"0x{rom.u8(a + 26):X02}",
                 ["u8@0x1B_Unknown27"] = $"0x{rom.u8(a + 27):X02}",
@@ -226,11 +410,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         {
             ["EnglishNamePointer"] = "u32@0x00_EnglishNamePointer",
             ["DescriptionTextIdLow"] = "u16@0x04_DescriptionTextIdLow",
-            ["DescriptionTextIdHigh"] = "u16@0x06_DescriptionTextIdHigh",
+            ["Unknown6"] = "u16@0x06_Unknown6",
             ["JapaneseNamePointer"] = "u32@0x08_JapaneseNamePointer",
-            ["JapaneseNameLength"] = "u8@0x0C_JapaneseNameLength",
-            ["PaletteId"] = "u8@0x0D_PaletteId",
-            ["DisplayWeapon"] = "u8@0x0E_DisplayWeapon",
+            ["JapaneseNameStart"] = "u8@0x0C_JapaneseNameStart",
+            ["JapaneseNameLength"] = "u8@0x0D_JapaneseNameLength",
+            ["PaletteId"] = "u8@0x0E_PaletteId",
             ["ClassId"] = "u8@0x0F_ClassId",
             ["AllyEnemyColor"] = "u8@0x10_AllyEnemyColor",
             ["BattleAnime"] = "u8@0x11_BattleAnime",
@@ -238,9 +422,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             ["Unknown19"] = "u8@0x13_Unknown19",
             ["Unknown20"] = "u8@0x14_Unknown20",
             ["Unknown21"] = "u8@0x15_Unknown21",
-            ["TerrainLeft"] = "u8@0x16_TerrainLeft",
-            ["TerrainRight"] = "u8@0x17_TerrainRight",
-            ["Unknown24"] = "u8@0x18_Unknown24",
+            ["Unknown22"] = "u8@0x16_Unknown22",
+            ["TerrainLeft"] = "u8@0x17_TerrainLeft",
+            ["TerrainRight"] = "u8@0x18_TerrainRight",
             ["Unknown25"] = "u8@0x19_Unknown25",
             ["Unknown26"] = "u8@0x1A_Unknown26",
             ["Unknown27"] = "u8@0x1B_Unknown27",

--- a/FEBuilderGBA.Avalonia/Views/OPClassDemoFE7View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/OPClassDemoFE7View.axaml
@@ -2,68 +2,246 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
         x:Class="FEBuilderGBA.Avalonia.Views.OPClassDemoFE7View"
-        Title="OP Class Demo (FE7) Editor" Width="1554" Height="867"
+        Title="OP Class Demo (FE7) Editor" Width="1580" Height="1020"
         SizeToContent="WidthAndHeight">
-  <Grid ColumnDefinitions="250,*">
-    <controls:AddressListControl AutomationProperties.AutomationId="OPClassDemoFE7_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
+  <Grid ColumnDefinitions="260,*" RowDefinitions="Auto,*">
 
-    <ScrollViewer Grid.Column="1" Margin="4">
+    <!-- Row 0: Selection bar (mirrors WF AddressPanel) -->
+    <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
+      <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
+        <Label Content="Address" VerticalAlignment="Center" />
+        <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_Address_Input"
+                       FormatString="0" Name="AddressBox" Width="120"
+                       Minimum="0" Maximum="4294967295"
+                       IsEnabled="False" VerticalAlignment="Center" />
+        <Label Content="Size:" VerticalAlignment="Center" />
+        <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_BlockSize_Input"
+                       FormatString="0" Name="BlockSizeBox" Width="50"
+                       Minimum="0" Maximum="65535"
+                       IsEnabled="False" VerticalAlignment="Center" Value="32" />
+        <Label Content="Selected Address:" VerticalAlignment="Center" />
+        <Label AutomationProperties.AutomationId="OPClassDemoFE7_SelectedAddress_Label"
+               Name="SelectedAddressLabel" Width="120" VerticalAlignment="Center"
+               FontFamily="Consolas" />
+        <Button AutomationProperties.AutomationId="OPClassDemoFE7_Write_Button"
+                Name="WriteButton" Content="Write to ROM" Click="Write_Click" />
+      </StackPanel>
+    </Border>
+
+    <!-- Row 1, Col 0: Address list panel -->
+    <Border Grid.Row="1" Grid.Column="0" BorderBrush="Gray" BorderThickness="1" Margin="4">
+      <controls:AddressListControl AutomationProperties.AutomationId="OPClassDemoFE7_Entry_List"
+                                   Name="EntryList" />
+    </Border>
+
+    <!-- Row 1, Col 1: edit panel + N2 sub-list -->
+    <ScrollViewer Grid.Row="1" Grid.Column="1" Margin="4">
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="OP Class Demo (FE7) Editor" FontSize="18" FontWeight="Bold" />
-        <TextBlock AutomationProperties.AutomationId="OPClassDemoFE7_Unavailable_Label" Name="UnavailableLabel" Text="" Foreground="Orange" />
+        <TextBlock AutomationProperties.AutomationId="OPClassDemoFE7_Unavailable_Label"
+                   Name="UnavailableLabel" Text="" Foreground="Orange" />
 
-        <Grid ColumnDefinitions="200,200,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="OPClassDemoFE7_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+        <!-- Main edit panel (mirrors WF panel2 left half: 21 main fields) -->
+        <Border BorderBrush="Gray" BorderThickness="1" Padding="8">
+          <Grid ColumnDefinitions="180,180,*"
+                RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
 
-          <TextBlock Grid.Row="1" Grid.Column="0" Text="English Name Pointer:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_EnglishNamePtr_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="EnglishNamePtrBox" Minimum="0" Maximum="4294967295" />
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,2" />
+            <TextBlock AutomationProperties.AutomationId="OPClassDemoFE7_Addr_Label"
+                       Grid.Row="0" Grid.Column="1" Name="AddrLabel"
+                       FontFamily="Consolas" VerticalAlignment="Center" />
 
-          <TextBlock Grid.Row="2" Grid.Column="0" Text="Description Text ID:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_DescTextIdLow_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="DescTextIdLowBox" Minimum="0" Maximum="65535" />
-          <TextBlock AutomationProperties.AutomationId="OPClassDemoFE7_DescTextIdLow_Label" Grid.Row="2" Grid.Column="2" Name="DescTextPreview" Foreground="Gray" FontSize="11"
-                     VerticalAlignment="Center" Margin="4,0,0,0"
-                     TextTrimming="CharacterEllipsis" MaxWidth="200" />
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="English Name Pointer:" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_EnglishNamePtr_Input"
+                           FormatString="0" Grid.Row="1" Grid.Column="1" Name="EnglishNamePtrBox"
+                           Minimum="0" Maximum="4294967295" />
 
-          <TextBlock Grid.Row="3" Grid.Column="0" Text="Japanese Name Pointer:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_JpNamePtr_Input" FormatString="0" Grid.Row="3" Grid.Column="1" Name="JpNamePtrBox" Minimum="0" Maximum="4294967295" />
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Description Text ID:" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_DescTextIdLow_Input"
+                           FormatString="0" Grid.Row="2" Grid.Column="1" Name="DescTextIdLowBox"
+                           Minimum="0" Maximum="65535" />
+            <TextBlock AutomationProperties.AutomationId="OPClassDemoFE7_DescTextIdLow_Label"
+                       Grid.Row="2" Grid.Column="2" Name="DescTextPreview"
+                       Foreground="Gray" FontSize="11" VerticalAlignment="Center" Margin="4,0,0,0"
+                       TextTrimming="CharacterEllipsis" MaxWidth="220" />
 
-          <TextBlock Grid.Row="4" Grid.Column="0" Text="Japanese Name Length:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_JpNameLen_Input" FormatString="0" Grid.Row="4" Grid.Column="1" Name="JpNameLenBox" Minimum="0" Maximum="255" />
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Unknown (0x06):" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_Unknown6_Input"
+                           FormatString="0" Grid.Row="3" Grid.Column="1" Name="Unknown6Box"
+                           Minimum="0" Maximum="65535" />
 
-          <TextBlock Grid.Row="5" Grid.Column="0" Text="Palette ID:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_PaletteId_Input" FormatString="0" Grid.Row="5" Grid.Column="1" Name="PaletteIdBox" Minimum="0" Maximum="255" />
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Japanese Name Pointer:" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_JpNamePtr_Input"
+                           FormatString="0" Grid.Row="4" Grid.Column="1" Name="JpNamePtrBox"
+                           Minimum="0" Maximum="4294967295" />
 
-          <TextBlock Grid.Row="6" Grid.Column="0" Text="Display Weapon:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_DisplayWeapon_Input" FormatString="0" Grid.Row="6" Grid.Column="1" Name="DisplayWeaponBox" Minimum="0" Maximum="255" />
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Japanese Name Start:" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_JpNameStart_Input"
+                           FormatString="0" Grid.Row="5" Grid.Column="1" Name="JpNameStartBox"
+                           Minimum="0" Maximum="255" />
 
-          <TextBlock Grid.Row="7" Grid.Column="0" Text="Class ID:" VerticalAlignment="Center" Margin="0,2"
-                     AutomationProperties.AutomationId="OPClassDemoFE7_ClassId_Link"
-                     Classes="Hyperlink" Name="ClassId_Link" PointerPressed="OnClassIdLinkClick"
-                     ToolTip.Tip="Click to open Class Editor" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_ClassId_Input" FormatString="0" Grid.Row="7" Grid.Column="1" Name="ClassIdBox" Minimum="0" Maximum="255" />
+            <TextBlock Grid.Row="6" Grid.Column="0" Text="Japanese Name Length:" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_JpNameLen_Input"
+                           FormatString="0" Grid.Row="6" Grid.Column="1" Name="JpNameLenBox"
+                           Minimum="0" Maximum="255" />
 
-          <TextBlock Grid.Row="8" Grid.Column="0" Text="Ally/Enemy Color:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_AllyEnemyColor_Input" FormatString="0" Grid.Row="8" Grid.Column="1" Name="AllyEnemyColorBox" Minimum="0" Maximum="255" />
+            <TextBlock Grid.Row="7" Grid.Column="0" Text="Palette ID:" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_PaletteId_Input"
+                           FormatString="0" Grid.Row="7" Grid.Column="1" Name="PaletteIdBox"
+                           Minimum="0" Maximum="255" />
 
-          <TextBlock Grid.Row="9" Grid.Column="0" Text="Battle Anime:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_BattleAnime_Input" FormatString="0" Grid.Row="9" Grid.Column="1" Name="BattleAnimeBox" Minimum="0" Maximum="255" />
+            <TextBlock Grid.Row="8" Grid.Column="0" Text="Class ID:" VerticalAlignment="Center" Margin="0,2"
+                       AutomationProperties.AutomationId="OPClassDemoFE7_ClassId_Link"
+                       Classes="Hyperlink" Name="ClassId_Link" PointerPressed="OnClassIdLinkClick"
+                       ToolTip.Tip="Click to open Class Editor" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_ClassId_Input"
+                           FormatString="0" Grid.Row="8" Grid.Column="1" Name="ClassIdBox"
+                           Minimum="0" Maximum="255" />
 
-          <TextBlock Grid.Row="10" Grid.Column="0" Text="Magic Effect:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_MagicEffect_Input" FormatString="0" Grid.Row="10" Grid.Column="1" Name="MagicEffectBox" Minimum="0" Maximum="255" />
+            <TextBlock Grid.Row="9" Grid.Column="0" Text="Ally/Enemy Color:" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_AllyEnemyColor_Input"
+                           FormatString="0" Grid.Row="9" Grid.Column="1" Name="AllyEnemyColorBox"
+                           Minimum="0" Maximum="255" />
 
-          <TextBlock Grid.Row="11" Grid.Column="0" Text="Terrain Left:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_TerrainLeft_Input" FormatString="0" Grid.Row="11" Grid.Column="1" Name="TerrainLeftBox" Minimum="0" Maximum="255" />
+            <TextBlock Grid.Row="10" Grid.Column="0" Text="Battle Anime:" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_BattleAnime_Input"
+                           FormatString="0" Grid.Row="10" Grid.Column="1" Name="BattleAnimeBox"
+                           Minimum="0" Maximum="255" />
 
-          <TextBlock Grid.Row="12" Grid.Column="0" Text="Terrain Right:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_TerrainRight_Input" FormatString="0" Grid.Row="12" Grid.Column="1" Name="TerrainRightBox" Minimum="0" Maximum="255" />
+            <TextBlock Grid.Row="11" Grid.Column="0" Text="Magic Effect:" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_MagicEffect_Input"
+                           FormatString="0" Grid.Row="11" Grid.Column="1" Name="MagicEffectBox"
+                           Minimum="0" Maximum="255" />
 
-          <TextBlock Grid.Row="13" Grid.Column="0" Text="Anime Pointer:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_AnimePtr_Input" FormatString="0" Grid.Row="13" Grid.Column="1" Name="AnimePtrBox" Minimum="0" Maximum="4294967295" />
-        </Grid>
-        <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,16,0,0">
-          <Button AutomationProperties.AutomationId="OPClassDemoFE7_Write_Button" Content="Write" Click="Write_Click" />
-        </StackPanel>
+            <TextBlock Grid.Row="12" Grid.Column="0" Text="Unknown (0x13):" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_Unknown19_Input"
+                           FormatString="0" Grid.Row="12" Grid.Column="1" Name="Unknown19Box"
+                           Minimum="0" Maximum="255" />
+
+            <TextBlock Grid.Row="13" Grid.Column="0" Text="Unknown (0x14):" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_Unknown20_Input"
+                           FormatString="0" Grid.Row="13" Grid.Column="1" Name="Unknown20Box"
+                           Minimum="0" Maximum="255" />
+
+            <TextBlock Grid.Row="14" Grid.Column="0" Text="Unknown (0x15):" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_Unknown21_Input"
+                           FormatString="0" Grid.Row="14" Grid.Column="1" Name="Unknown21Box"
+                           Minimum="0" Maximum="255" />
+
+            <TextBlock Grid.Row="15" Grid.Column="0" Text="Unknown (0x16):" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_Unknown22_Input"
+                           FormatString="0" Grid.Row="15" Grid.Column="1" Name="Unknown22Box"
+                           Minimum="0" Maximum="255" />
+
+            <TextBlock Grid.Row="16" Grid.Column="0" Text="Terrain Left:" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_TerrainLeft_Input"
+                           FormatString="0" Grid.Row="16" Grid.Column="1" Name="TerrainLeftBox"
+                           Minimum="0" Maximum="255" />
+
+            <TextBlock Grid.Row="17" Grid.Column="0" Text="Terrain Right:" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_TerrainRight_Input"
+                           FormatString="0" Grid.Row="17" Grid.Column="1" Name="TerrainRightBox"
+                           Minimum="0" Maximum="255" />
+
+            <TextBlock Grid.Row="18" Grid.Column="0" Text="Unknown (0x19):" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_Unknown25_Input"
+                           FormatString="0" Grid.Row="18" Grid.Column="1" Name="Unknown25Box"
+                           Minimum="0" Maximum="255" />
+
+            <TextBlock Grid.Row="19" Grid.Column="0" Text="Unknown (0x1A):" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_Unknown26_Input"
+                           FormatString="0" Grid.Row="19" Grid.Column="1" Name="Unknown26Box"
+                           Minimum="0" Maximum="255" />
+
+            <TextBlock Grid.Row="20" Grid.Column="0" Text="Unknown (0x1B):" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_Unknown27_Input"
+                           FormatString="0" Grid.Row="20" Grid.Column="1" Name="Unknown27Box"
+                           Minimum="0" Maximum="255" />
+
+            <TextBlock Grid.Row="21" Grid.Column="0" Text="Anime Pointer:" VerticalAlignment="Center" Margin="0,2" />
+            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_AnimePtr_Input"
+                           FormatString="0" Grid.Row="21" Grid.Column="1" Name="AnimePtrBox"
+                           Minimum="0" Maximum="4294967295" />
+          </Grid>
+        </Border>
+
+        <!-- N2 sub-list panel (mirrors WF groupBox1: animation command sequence) -->
+        <Border BorderBrush="Gray" BorderThickness="1" Padding="8">
+          <StackPanel Spacing="6">
+            <Label AutomationProperties.AutomationId="OPClassDemoFE7_N2Panel_Label"
+                   Content="Animation Pointer Target Block" FontWeight="SemiBold" />
+
+            <!-- N2 selection bar (mirrors WF panel3) -->
+            <Grid ColumnDefinitions="100,120,80,80,140,*" RowDefinitions="Auto">
+              <Label Grid.Column="0" Content="Address" VerticalAlignment="Center" />
+              <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_N2_Address_Input"
+                             Grid.Column="1" FormatString="0" Name="N2AddressBox"
+                             Minimum="0" Maximum="4294967295" IsEnabled="False" />
+              <Label Grid.Column="2" Content="Size:" VerticalAlignment="Center" />
+              <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_N2_BlockSize_Input"
+                             Grid.Column="3" FormatString="0" Name="N2BlockSizeBox"
+                             Minimum="0" Maximum="65535" IsEnabled="False" Value="2" />
+              <Label Grid.Column="4" Content="Selected Address:" VerticalAlignment="Center" />
+              <Label AutomationProperties.AutomationId="OPClassDemoFE7_N2_SelectedAddress_Label"
+                     Grid.Column="5" Name="N2SelectedAddressLabel"
+                     VerticalAlignment="Center" FontFamily="Consolas" />
+            </Grid>
+
+            <!-- N2 sub-list + command/argument editor row -->
+            <Grid ColumnDefinitions="280,*" RowDefinitions="Auto">
+
+              <!-- N2 list box -->
+              <ListBox AutomationProperties.AutomationId="OPClassDemoFE7_N2_List"
+                       Grid.Column="0" Name="N2ListBox" Height="200"
+                       SelectionChanged="N2List_SelectionChanged" />
+
+              <!-- N2 editor column: command combo + argument numeric -->
+              <Grid Grid.Column="1" ColumnDefinitions="180,*" RowDefinitions="Auto,Auto,Auto,Auto" Margin="8,0,0,0">
+                <Label Grid.Row="0" Grid.Column="0"
+                       AutomationProperties.AutomationId="OPClassDemoFE7_N2_CommandHeader_Label"
+                       Content="Command" VerticalAlignment="Center" />
+                <NumericUpDown Grid.Row="0" Grid.Column="1"
+                               AutomationProperties.AutomationId="OPClassDemoFE7_N2_CommandRaw_Input"
+                               FormatString="0" Name="N2CommandRawBox"
+                               Minimum="0" Maximum="255" />
+
+                <Label Grid.Row="1" Grid.Column="0" Content="Command Description:" VerticalAlignment="Center" Margin="0,4,0,0" />
+                <ComboBox Grid.Row="1" Grid.Column="1"
+                          AutomationProperties.AutomationId="OPClassDemoFE7_N2_Command_Combo"
+                          Name="N2CommandCombo" Margin="0,4,0,0" Width="420" HorizontalAlignment="Left"
+                          SelectionChanged="N2CommandCombo_SelectionChanged">
+                  <ComboBoxItem Content="1=Ranged attack anime" />
+                  <ComboBoxItem Content="2=Ranged critical anime" />
+                  <ComboBoxItem Content="3=Set anime state to 'hit effect applied'" />
+                  <ComboBoxItem Content="4=Ranged attack anime (alt)" />
+                  <ComboBoxItem Content="5=Wait N frames (arg = N/60 sec)" />
+                  <ComboBoxItem Content="6=Ranged evade anime" />
+                  <ComboBoxItem Content="7=Hit effect applied (FE8 unused)" />
+                  <ComboBoxItem Content="8=Wait for C01/C02/C18 cmd" />
+                </ComboBox>
+
+                <Label Grid.Row="2" Grid.Column="0"
+                       AutomationProperties.AutomationId="OPClassDemoFE7_N2_WaitLabel_Label"
+                       Name="N2WaitLabel"
+                       Content="Wait Frames" VerticalAlignment="Center" Margin="0,4,0,0" />
+                <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Horizontal" Spacing="4" Margin="0,4,0,0">
+                  <NumericUpDown AutomationProperties.AutomationId="OPClassDemoFE7_N2_Argument_Input"
+                                 FormatString="0" Name="N2ArgumentBox"
+                                 Minimum="0" Maximum="255" Width="100" />
+                  <Label AutomationProperties.AutomationId="OPClassDemoFE7_N2_WaitUnit_Label"
+                         Name="N2WaitUnitLabel" Content="/60 (sec)" VerticalAlignment="Center" />
+                </StackPanel>
+
+                <Button Grid.Row="3" Grid.Column="1"
+                        AutomationProperties.AutomationId="OPClassDemoFE7_N2_Write_Button"
+                        Name="N2WriteButton" Content="Write Animation Command" Margin="0,8,0,0"
+                        HorizontalAlignment="Left"
+                        Click="NWrite_Click" />
+              </Grid>
+            </Grid>
+          </StackPanel>
+        </Border>
+
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/OPClassDemoFE7View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/OPClassDemoFE7View.axaml
@@ -210,14 +210,18 @@
                           AutomationProperties.AutomationId="OPClassDemoFE7_N2_Command_Combo"
                           Name="N2CommandCombo" Margin="0,4,0,0" Width="420" HorizontalAlignment="Left"
                           SelectionChanged="N2CommandCombo_SelectionChanged">
-                  <ComboBoxItem Content="1=Ranged attack anime" />
-                  <ComboBoxItem Content="2=Ranged critical anime" />
-                  <ComboBoxItem Content="3=Set anime state to 'hit effect applied'" />
-                  <ComboBoxItem Content="4=Ranged attack anime (alt)" />
-                  <ComboBoxItem Content="5=Wait N frames (arg = N/60 sec)" />
-                  <ComboBoxItem Content="6=Ranged evade anime" />
-                  <ComboBoxItem Content="7=Hit effect applied (FE8 unused)" />
-                  <ComboBoxItem Content="8=Wait for C01/C02/C18 cmd" />
+                  <!-- Wrap each option in a TextBlock so ViewTranslationHelper
+                       (which scans TextBlock.Text + Label.Content) can localize
+                       these labels. Plain ComboBoxItem.Content strings are not
+                       scanned by the helper. -->
+                  <ComboBoxItem><TextBlock Text="1=Ranged attack anime" /></ComboBoxItem>
+                  <ComboBoxItem><TextBlock Text="2=Ranged critical anime" /></ComboBoxItem>
+                  <ComboBoxItem><TextBlock Text="3=Set anime state to 'hit effect applied'" /></ComboBoxItem>
+                  <ComboBoxItem><TextBlock Text="4=Ranged attack anime (alt)" /></ComboBoxItem>
+                  <ComboBoxItem><TextBlock Text="5=Wait N frames (arg = N/60 sec)" /></ComboBoxItem>
+                  <ComboBoxItem><TextBlock Text="6=Ranged evade anime" /></ComboBoxItem>
+                  <ComboBoxItem><TextBlock Text="7=Hit effect applied (FE8 unused)" /></ComboBoxItem>
+                  <ComboBoxItem><TextBlock Text="8=Wait for C01/C02/C18 cmd" /></ComboBoxItem>
                 </ComboBox>
 
                 <Label Grid.Row="2" Grid.Column="0"

--- a/FEBuilderGBA.Avalonia/Views/OPClassDemoFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPClassDemoFE7View.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using global::Avalonia.Controls;
 using global::Avalonia.Input;
 using global::Avalonia.Interactivity;
@@ -8,10 +9,30 @@ using FEBuilderGBA.Core;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
+    /// <summary>
+    /// Avalonia counterpart of WinForms <c>OPClassDemoFE7Form</c>.
+    /// Gap-sweep fix (#414) raises the AXAML control surface from 32 to
+    /// MEDIUM-verdict density (>= 48 of WF's 64 controls), exposes all 21
+    /// main-entry fields (including W6, B12 JP-name-start, B22, and B25-B27
+    /// which the prior view omitted), corrects three field-offset bugs
+    /// (B14 = Palette, B23 = Terrain Left, B24 = Terrain Right), and wires
+    /// the N2 (animation command sequence) sub-list.
+    ///
+    /// Both <c>Write_Click</c> and <c>NWrite_Click</c> open separate undo
+    /// scopes ("Edit OP Class Demo (FE7)" / "Edit OP Class Demo Anime
+    /// Command") so the two surfaces undo independently. After the main
+    /// Write commits, <c>LoadN2List()</c> refreshes the N2 sub-list in case
+    /// the anime pointer changed (Copilot CLI plan-review #2 finding).
+    ///
+    /// Pointer fields P0 (English name), P8 (Japanese name image) and P28
+    /// (anime block) round-trip through <c>rom.write_p32</c> via the
+    /// <c>EditorFormRef</c> <c>FieldType.Pointer</c> codec.
+    /// </summary>
     public partial class OPClassDemoFE7View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly OPClassDemoFE7ViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _suppressN2Change;
 
         public string ViewTitle => "OP Class Demo (FE7) Editor";
         public bool IsLoaded => _vm.CanWrite;
@@ -22,6 +43,7 @@ namespace FEBuilderGBA.Avalonia.Views
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
             DescTextIdLowBox.ValueChanged += OnDescTextIdLowChanged;
+            N2CommandRawBox.ValueChanged += OnN2CommandRawChanged;
             Opened += (_, _) => LoadList();
         }
 
@@ -31,6 +53,44 @@ namespace FEBuilderGBA.Avalonia.Views
             uint id = (uint)(DescTextIdLowBox.Value ?? 0);
             try { DescTextPreview.Text = id != 0 ? NameResolver.GetTextById(id) : ""; }
             catch { DescTextPreview.Text = ""; }
+        }
+
+        void OnN2CommandRawChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            if (_suppressN2Change) return;
+            // Sync the description combo + wait-unit label to the raw command.
+            uint cmd = (uint)(N2CommandRawBox.Value ?? 0);
+            SyncN2CommandDescription(cmd);
+        }
+
+        void SyncN2CommandDescription(uint cmd)
+        {
+            _suppressN2Change = true;
+            try
+            {
+                // Combo items are 1-indexed (item 0 = cmd 1, item 7 = cmd 8).
+                if (cmd >= 1 && cmd <= 8)
+                    N2CommandCombo.SelectedIndex = (int)cmd - 1;
+                else
+                    N2CommandCombo.SelectedIndex = -1;
+
+                // Per WF N2_AddressList_SelectedIndexChanged: cmd 3 and 8 use
+                // raw "00" argument (no wait); other commands display "/60 (sec)".
+                // Wrap in R._() so the runtime assignment stays localized after
+                // the initial TranslatedWindow.TranslateAll() pass (Copilot PR
+                // #537 finding).
+                if (cmd == 0x03 || cmd == 0x08)
+                {
+                    N2WaitLabel.Content = R._("Argument");
+                    N2WaitUnitLabel.Content = "00";
+                }
+                else
+                {
+                    N2WaitLabel.Content = R._("Wait Frames");
+                    N2WaitUnitLabel.Content = R._("/60 (sec)");
+                }
+            }
+            finally { _suppressN2Change = false; }
         }
 
         void LoadList()
@@ -68,21 +128,109 @@ namespace FEBuilderGBA.Avalonia.Views
         void UpdateUI()
         {
             AddrLabel.Text = $"0x{_vm.CurrentAddr:X08}";
+            AddressBox.Value = _vm.CurrentAddr;
+            SelectedAddressLabel.Content = $"0x{_vm.CurrentAddr:X08}";
+
             EnglishNamePtrBox.Value = _vm.EnglishNamePointer;
             DescTextIdLowBox.Value = _vm.DescriptionTextIdLow;
             try { DescTextPreview.Text = _vm.DescriptionTextIdLow != 0 ? NameResolver.GetTextById(_vm.DescriptionTextIdLow) : ""; }
             catch { DescTextPreview.Text = ""; }
+            Unknown6Box.Value = _vm.Unknown6;
             JpNamePtrBox.Value = _vm.JapaneseNamePointer;
+            JpNameStartBox.Value = _vm.JapaneseNameStart;
             JpNameLenBox.Value = _vm.JapaneseNameLength;
             PaletteIdBox.Value = _vm.PaletteId;
-            DisplayWeaponBox.Value = _vm.DisplayWeapon;
             ClassIdBox.Value = _vm.ClassId;
             AllyEnemyColorBox.Value = _vm.AllyEnemyColor;
             BattleAnimeBox.Value = _vm.BattleAnime;
             MagicEffectBox.Value = _vm.MagicEffect;
+            Unknown19Box.Value = _vm.Unknown19;
+            Unknown20Box.Value = _vm.Unknown20;
+            Unknown21Box.Value = _vm.Unknown21;
+            Unknown22Box.Value = _vm.Unknown22;
             TerrainLeftBox.Value = _vm.TerrainLeft;
             TerrainRightBox.Value = _vm.TerrainRight;
+            Unknown25Box.Value = _vm.Unknown25;
+            Unknown26Box.Value = _vm.Unknown26;
+            Unknown27Box.Value = _vm.Unknown27;
             AnimePtrBox.Value = _vm.AnimePointer;
+
+            RebuildN2ListBox();
+        }
+
+        void RebuildN2ListBox()
+        {
+            _suppressN2Change = true;
+            try
+            {
+                var items = new List<string>();
+                foreach (var row in _vm.N2Entries)
+                    items.Add($"{row.Index:X2}  cmd={row.Command:X2} arg={row.Argument:X2}");
+                N2ListBox.ItemsSource = items;
+                if (_vm.SelectedN2Index >= 0 && _vm.SelectedN2Index < items.Count)
+                    N2ListBox.SelectedIndex = _vm.SelectedN2Index;
+                else
+                    N2ListBox.SelectedIndex = -1;
+
+                N2AddressBox.Value = _vm.AnimePointer;
+                N2SelectedAddressLabel.Content = _vm.N2SelectedAddress != 0
+                    ? $"0x{_vm.N2SelectedAddress:X08}" : "";
+                N2CommandRawBox.Value = _vm.N2Command;
+                N2ArgumentBox.Value = _vm.N2Argument;
+                SyncN2CommandDescription(_vm.N2Command);
+            }
+            finally { _suppressN2Change = false; }
+        }
+
+        void N2List_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressN2Change) return;
+            int idx = N2ListBox.SelectedIndex;
+            // Clear the ViewModel selection state when the ListBox loses its
+            // selection (idx == -1) or the index is out of range. Without
+            // this, _vm.SelectedN2Index could keep pointing at a stale row
+            // and NWrite_Click would silently write to the wrong slot
+            // (Copilot PR #537 review finding).
+            if (idx < 0 || idx >= _vm.N2Entries.Count)
+            {
+                _vm.LoadN2Row(-1);
+                _suppressN2Change = true;
+                try
+                {
+                    N2SelectedAddressLabel.Content = "";
+                    N2CommandRawBox.Value = 0;
+                    N2ArgumentBox.Value = 0;
+                    SyncN2CommandDescription(0);
+                }
+                finally { _suppressN2Change = false; }
+                return;
+            }
+            _vm.LoadN2Row(idx);
+            _suppressN2Change = true;
+            try
+            {
+                N2SelectedAddressLabel.Content = $"0x{_vm.N2SelectedAddress:X08}";
+                N2CommandRawBox.Value = _vm.N2Command;
+                N2ArgumentBox.Value = _vm.N2Argument;
+                SyncN2CommandDescription(_vm.N2Command);
+            }
+            finally { _suppressN2Change = false; }
+        }
+
+        void N2CommandCombo_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressN2Change) return;
+            int idx = N2CommandCombo.SelectedIndex;
+            if (idx < 0) return;
+            // Combo index 0 maps to cmd 1, ..., index 7 maps to cmd 8.
+            uint cmd = (uint)(idx + 1);
+            _suppressN2Change = true;
+            try
+            {
+                N2CommandRawBox.Value = cmd;
+                SyncN2CommandDescription(cmd);
+            }
+            finally { _suppressN2Change = false; }
         }
 
         void Write_Click(object? sender, RoutedEventArgs e)
@@ -93,23 +241,59 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 _vm.EnglishNamePointer = (uint)(EnglishNamePtrBox.Value ?? 0);
                 _vm.DescriptionTextIdLow = (uint)(DescTextIdLowBox.Value ?? 0);
+                _vm.Unknown6 = (uint)(Unknown6Box.Value ?? 0);
                 _vm.JapaneseNamePointer = (uint)(JpNamePtrBox.Value ?? 0);
+                _vm.JapaneseNameStart = (uint)(JpNameStartBox.Value ?? 0);
                 _vm.JapaneseNameLength = (uint)(JpNameLenBox.Value ?? 0);
                 _vm.PaletteId = (uint)(PaletteIdBox.Value ?? 0);
-                _vm.DisplayWeapon = (uint)(DisplayWeaponBox.Value ?? 0);
                 _vm.ClassId = (uint)(ClassIdBox.Value ?? 0);
                 _vm.AllyEnemyColor = (uint)(AllyEnemyColorBox.Value ?? 0);
                 _vm.BattleAnime = (uint)(BattleAnimeBox.Value ?? 0);
                 _vm.MagicEffect = (uint)(MagicEffectBox.Value ?? 0);
+                _vm.Unknown19 = (uint)(Unknown19Box.Value ?? 0);
+                _vm.Unknown20 = (uint)(Unknown20Box.Value ?? 0);
+                _vm.Unknown21 = (uint)(Unknown21Box.Value ?? 0);
+                _vm.Unknown22 = (uint)(Unknown22Box.Value ?? 0);
                 _vm.TerrainLeft = (uint)(TerrainLeftBox.Value ?? 0);
                 _vm.TerrainRight = (uint)(TerrainRightBox.Value ?? 0);
+                _vm.Unknown25 = (uint)(Unknown25Box.Value ?? 0);
+                _vm.Unknown26 = (uint)(Unknown26Box.Value ?? 0);
+                _vm.Unknown27 = (uint)(Unknown27Box.Value ?? 0);
                 _vm.AnimePointer = (uint)(AnimePtrBox.Value ?? 0);
                 _vm.WriteEntry();
+                // Refresh the N2 sub-list in case the anime pointer changed
+                // (Copilot CLI plan v2 finding).
+                _vm.LoadN2List();
                 _undoService.Commit();
                 _vm.MarkClean();
+                UpdateUI();
                 CoreState.Services?.ShowInfo("OP Class Demo (FE7) data written.");
             }
             catch (Exception ex) { _undoService.Rollback(); Log.Error("OPClassDemoFE7View.Write: {0}", ex.Message); }
+        }
+
+        void NWrite_Click(object? sender, RoutedEventArgs e)
+        {
+            if (!_vm.CanWrite) return;
+            if (_vm.SelectedN2Index < 0) return;
+            _undoService.Begin("Edit OP Class Demo Anime Command");
+            try
+            {
+                _vm.N2Command = (uint)(N2CommandRawBox.Value ?? 0);
+                _vm.N2Argument = (uint)(N2ArgumentBox.Value ?? 0);
+                bool ok = _vm.WriteN2Entry();
+                if (!ok)
+                {
+                    _undoService.Rollback();
+                    Log.Error("OPClassDemoFE7View.NWrite: WriteN2Entry rejected (invalid row/pointer)");
+                    return;
+                }
+                _undoService.Commit();
+                _vm.MarkClean();
+                RebuildN2ListBox();
+                CoreState.Services?.ShowInfo("Animation command written.");
+            }
+            catch (Exception ex) { _undoService.Rollback(); Log.Error("OPClassDemoFE7View.NWrite: {0}", ex.Message); }
         }
 
         void OnClassIdLinkClick(object? sender, PointerPressedEventArgs e)

--- a/FEBuilderGBA.Tests/Unit/AvaloniaDialogViewTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AvaloniaDialogViewTests.cs
@@ -946,7 +946,7 @@ namespace FEBuilderGBA.Tests.Unit
         [InlineData("ClassOPFontView.axaml", 1179, 475)]
         [InlineData("ExtraUnitView.axaml", 1121, 735)]
         [InlineData("ExtraUnitFE8UView.axaml", 1121, 735)]
-        [InlineData("OPClassDemoFE7View.axaml", 1554, 867)]
+        [InlineData("OPClassDemoFE7View.axaml", 1580, 1020)]
         [InlineData("OPClassDemoFE7UView.axaml", 1580, 980)]
         [InlineData("OPClassDemoFE8UView.axaml", 1579, 898)]
         [InlineData("OPClassFontFE8UView.axaml", 1179, 849)]

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -7267,3 +7267,24 @@ Hex アドレス
 
 :Unknown (0x12):
 不明 (0x12):
+
+:Unknown (0x06):
+不明 (0x06):
+
+:Unknown (0x14):
+不明 (0x14):
+
+:Unknown (0x15):
+不明 (0x15):
+
+:Unknown (0x19):
+不明 (0x19):
+
+:Unknown (0x1A):
+不明 (0x1A):
+
+:Unknown (0x1B):
+不明 (0x1B):
+
+:Japanese Name Start:
+日本語名 開始位置:

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -21169,3 +21169,24 @@ to:
 
 :Unknown (0x12):
 未知 (0x12):
+
+:Unknown (0x06):
+未知 (0x06):
+
+:Unknown (0x14):
+未知 (0x14):
+
+:Unknown (0x15):
+未知 (0x15):
+
+:Unknown (0x19):
+未知 (0x19):
+
+:Unknown (0x1A):
+未知 (0x1A):
+
+:Unknown (0x1B):
+未知 (0x1B):
+
+:Japanese Name Start:
+日文名起始位置:

--- a/docs/field-completeness-report.txt
+++ b/docs/field-completeness-report.txt
@@ -1,6 +1,6 @@
 === Field Completeness Report ===
 Total WinForms fields: 1563
-Total Avalonia fields: 1726
+Total Avalonia fields: 1738
 Total missing: 0
 Forms with gaps: 0 / 174
 


### PR DESCRIPTION
## Summary

Closes #414 — fixes the 60 Avalonia ↔ WinForms parity gaps the gap-sweep methodology (#374) surfaced on `OPClassDemoFE7Form` (FE7J variant, HIGH density 64/32 == -50.0 %, 28 WF-only labels, 0 common labels).

- Raises Avalonia control surface from 32 to MEDIUM-verdict density (>= 48 of WF's 64 controls).
- Exposes all 21 main-entry fields (including W6, B12 JP-name-start, B22, and B25-B27 which the prior view omitted).
- Switches P0 (English name pointer), P8 (Japanese name image pointer) and P28 (anime block pointer) to `EditorFormRef.FieldType.Pointer` so they round-trip via `rom.write_p32` with the `0x08000000` high bit (was raw `D0`/`D8`/`D28`, which would corrupt the address — same bug PR #537 fixed for FE7U).
- Wires the N2 (animation command sequence) sub-list panel (`Animation Pointer Target Block`) with its own selection bar, list box, Command combo, raw command/argument numerics, and Write button.
- Wraps `Write_Click` and `NWrite_Click` in **separate** undo scopes (`"Edit OP Class Demo (FE7)"` / `"Edit OP Class Demo Anime Command"`) so the two surfaces undo independently.
- Main `Write_Click` now reloads the N2 sub-list after `WriteEntry()` so changing P28 doesn't leave stale animation-command rows visible (Copilot CLI plan v2 finding).

Three field-semantics bugs in the prior ViewModel also fixed:

1. **`B14` was exposed as `DisplayWeapon`** but the WF designer label (J_14_UNITPALETTE_PLUS1 "パレットID") and the `B17_ValueChanged` handler (uses `B14` as palette index for `DrawBattleAnime`) show `B14` is the **Palette ID**. Renamed `PaletteId`.
2. **`TerrainLeft` was reading offset 22** (Unknown22) instead of 23 — the WF `J_23_TERRAINBATTLE` label "表示地形左半分" paired with `B23`. Fixed.
3. **`TerrainRight` was reading offset 23** instead of 24. Similar fix.

## Plan reference

See accepted plan: [issue #414 v3 comment](https://github.com/laqieer/FEBuilderGBA/issues/414#issuecomment-4525698761). Copilot CLI plan review marked v3 as acceptable with no blocking concerns.

## Scope

Closes #414

## Screenshot

![OPClassDemoFE7 editor with all 21 fields, N2 sub-list, and address list populated from roms/FE7J.gba](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr414-opclassdemofe7-editor.png)

Captured via `tools/WinCapture` PrintWindow API against `roms/FE7J.gba`, Release build of `FEBuilderGBA.Avalonia`. Window: 1206x1620. Shows the new top selection bar (Address / Size: 32 / Selected Address / Write to ROM), 29-item address list on the left, main detail panel with all 21 fields (English Name Pointer through Anime Pointer with the corrected Palette ID + Terrain Left/Right + Unknown 0x06/0x14/0x15/0x19/0x1A/0x1B fields), and the N2 "Animation Pointer Target Block" sub-list panel showing 5 parsed anime command rows (cmd=05 arg=1E, cmd=01 arg=00, cmd=08 arg=00, cmd=05 arg=28, cmd=03 arg=00) with Command combo, Command Description ("5=Wait N frames"), Wait Frames input (30 / 60 (sec)), and Write Animation Command button.

## GUI Test Report

### Environment

- ROM: `roms/FE7J.gba` (AE7J — Fire Emblem 7 Japanese / Blazing Sword)
- Editor/View: `FEBuilderGBA.Avalonia.Views.OPClassDemoFE7View`
- Build: Release / net9.0

### Steps Performed

1. Built `FEBuilderGBA.Avalonia` in Release.
2. Launched the Avalonia app via `dotnet run --project FEBuilderGBA.Avalonia --no-build -- --rom roms/FE7J.gba`.
3. Used UIAutomation to click the "OP Demo (FE7)" button on the FE7J main hub.
4. Selected the first entry in the 29-item address list (02 Lord, 0x00DAF9A8).
5. Verified all controls render: top selection bar, address list, main detail panel (21 fields), N2 sub-list (5 anime command rows).
6. Captured the screenshot via `tools/WinCapture` PrintWindow.

### Test Results

| Test | Expected | Actual | Status |
|------|----------|--------|--------|
| Editor opens via "OP Demo (FE7)" main-menu button | Window with title "OP Class Demo (FE7) Editor" | Opened | PASS |
| Address list populates with class entries | 29-30 class entries with class names + icons | 29 entries (02 Lord, 28 Social Knight, ..., 22 Sage) | PASS |
| Top selection bar | Address / Size: 32 / Selected Address / Write to ROM | All present | PASS |
| Main edit panel renders 21 fields | All 21 from English Name Pointer through Anime Pointer | All present including new Unknown 0x06/0x14/0x15/0x19/0x1A/0x1B + JP Name Start | PASS |
| B14 displays as Palette ID (not DisplayWeapon) | Field labeled "Palette ID:" | "Palette ID:" with value 255 | PASS |
| B23 displays as Terrain Left | Field labeled "Terrain Left:" reading offset 23 | "Terrain Left:" with value 20 | PASS |
| B24 displays as Terrain Right | Field labeled "Terrain Right:" reading offset 24 | "Terrain Right:" with value 20 | PASS |
| Class ID hyperlink | "Class ID:" rendered as clickable link | Present (Hyperlink style) | PASS |
| N2 panel renders | "Animation Pointer Target Block" header + Address/Size:2/SelectedAddress + list + Command/Argument/Write controls | All present | PASS |
| N2 list parses anime block | 5 rows displayed (cmd 0x05/0x01/0x08/0x05/0x03 + 0x00 terminator skipped) | 5 rows shown | PASS |
| N2 command description sync | Selecting cmd=05 shows "5=Wait N frames (arg = N/60 sec)" + "Wait Frames" + "/60 (sec)" labels | All synced | PASS |
| No exceptions during open / select / close | Clean log output | Clean | PASS |

### Verdict

PASS — new surface is functional, all 21 WF-parity fields present, three field-offset semantic bugs fixed (B14 = Palette, B23 = Terrain Left, B24 = Terrain Right), N2 sub-list parses and renders correctly.

## Test plan

- [x] `View_AvControlCount_AtOrAboveMediumVerdict` — Avalonia counts >= 48 controls (75 % of WF 64).
- [x] `View_HasSelectionBar` — Address / BlockSize / SelectedAddress / Write button present.
- [x] `View_HasMainEditPanel_AllTwentyOneFields` — all 21 AutomationIds present (including the new W6, B12, B22, B25-B27).
- [x] `View_HasN2SubList_AllControls` — N2 list / Command combo / argument input / command raw input / N2 selection bar / N2 Write button + Command header / Wait-unit labels present.
- [x] `View_WriteHandler_WrapsInUndoScope` — code-behind opens `_undoService.Begin/Commit/Rollback`.
- [x] `View_NWriteHandler_WrapsInOwnUndoScope` — separate scope name `"Edit OP Class Demo Anime Command"`.
- [x] `View_WriteHandlers_RoundTripThroughViewModel` — neither handler calls `rom.write_u*` / `rom.SetU*` directly; both go through `_vm.WriteEntry()` / `_vm.WriteN2Entry()`.
- [x] `View_WriteHandler_RefreshesN2List` — `Write_Click` calls `_vm.LoadN2List()` so a P28 change refreshes the sub-list (Copilot v2 finding).
- [x] `ViewModel_FieldDef_UsesPointerForP0P8P28` — all three pointer fields detected as `FieldType.Pointer`.
- [x] `ViewModel_Write_PersistsPointersAsGbaPointers` — synthetic ROM round-trip proves `rom.u32(P0)`, `rom.u32(P8)`, `rom.u32(P28)` read back with the `0x08000000` high bit.
- [x] `ViewModel_LoadEntry_PopulatesAllTwentyOneFields` — every main-entry field reads correctly with the corrected offset semantics (B14=Palette, B23=Terrain Left, B24=Terrain Right).
- [x] `ViewModel_Write_PersistsAllFields_RoundTrip` — every field re-reads correctly at the expected byte offset after Write.
- [x] `ViewModel_LoadN2List_ParsesAnimeBlock` — 3-row anime block parses with terminator (cmd=0).
- [x] `ViewModel_WriteN2Entry_PersistsCommandAndArg` — N2 row write hits ROM at the expected offset.
- [x] `ViewModel_LoadN2Row_ClearsSelectionStateOnNegativeIndex` — clearing selection resets all N2 editor state.
- [x] `ViewModel_LoadN2List_ClearsWhenAnimePointerInvalid` — N2 list clears + selection resets when pointer is 0/unsafe.
- [x] All 5357/5360 Avalonia tests pass (3 pre-existing skips, no failures introduced).
- [x] All 1625/1625 Core tests pass.
- [x] All 1716/1716 WinForms tests pass (`AvaloniaDialogViewTests.ImageViewerForm_HasCorrectWindowSize` updated to 1580x1020 to match new view dimensions).
- [x] L10n CI gate green — `L10nCoverageTest.AvaloniaViews_HaveJaAndZhTranslations` passes with new ja/zh entries (`Unknown (0x06):`, `Unknown (0x14):`, `Unknown (0x15):`, `Unknown (0x19):`, `Unknown (0x1A):`, `Unknown (0x1B):`, `Japanese Name Start:`).
- [x] Manual GUI: Avalonia app launched with `roms/FE7J.gba`, OP Demo (FE7) editor opened from main menu, address list populated with 29 class entries, all 21 fields + N2 sub-list section rendered with no exceptions.

## Known limitations

- Live battle-anime preview rendering (`ImageBattleAnimeForm.DrawBattleAnime`), Japanese name PNG preview, and "Graphics Tool" jump are deferred — large WinForms-only deps, mirrors what PR #537 (FE7U) and PR #544 (FE8U) also deferred.
- No `AddressListExpand` button: FE7 has no `OPClassReelSort` patch detector (distinct from FE8 PR #544).
- `ko.txt` does not exist in this repo; localization is scoped to ja+zh, same as PRs #537 + #544.

Generated with Claude Code (claude-opus-4-7[1m])
