### PR TITLE
fix(gap-sweep): ImageMagicFEditor parity (closes #418)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageMagicFEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageMagicFEditorParityTests.cs
@@ -154,7 +154,7 @@ public class ImageMagicFEditorParityTests
     {
         string axaml = ReadAxaml();
         Assert.Contains("ImageMagicFEditor_SamplePreview_Label", axaml);
-        Assert.Contains("ImageMagicFEditor_PreviewImage", axaml);
+        Assert.Contains("ImageMagicFEditor_Preview_Image", axaml);
     }
 
     // -----------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageMagicFEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageMagicFEditorParityTests.cs
@@ -363,6 +363,47 @@ public class ImageMagicFEditorParityTests
         finally { CoreState.ROM = prevRom; }
     }
 
+    /// <summary>
+    /// Regression test (Copilot CLI re-review on PR #554):
+    /// When the FEditor/SCA_Creator magic-system patch is NOT
+    /// detected, `Write()` must bail out and leave the
+    /// pointer-table slot untouched. Without the VM-level guard,
+    /// `DimPointerKind.Empty` would call `rom.write_u32(slot, 0)`
+    /// and wipe a vanilla magic-effect pointer.
+    /// </summary>
+    [Fact]
+    public void ViewModel_Write_NoPatch_LeavesPointerSlotUntouched()
+    {
+        ROM rom = MakeMinimalFe8uRom(); // no FEditor signature planted
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            uint pointerSlot = 0x00400000u;
+            uint csaEntry = 0x00410000u;
+            // Plant a known vanilla pointer (e.g. an existing GBA
+            // pointer to an in-bounds offset) so we can verify it
+            // survives the Write().
+            uint vanillaValue = 0x08200000u; // GBA pointer to 0x00200000.
+            BitConverter.GetBytes(vanillaValue).CopyTo(rom.Data, pointerSlot);
+
+            var vm = new ImageMagicFEditorViewModel();
+            vm.RefreshPatchState(); // sets _magicSystemDetected = false
+            Assert.False(vm.MagicSystemDetected);
+
+            vm.CurrentAddr = csaEntry;
+            vm.PointerSlotAddr = pointerSlot;
+            vm.DimPointer = ImageMagicFEditorViewModel.DimPointerKind.Empty;
+            vm.Write();
+
+            // VM-level guard MUST have short-circuited Write() so the
+            // pointer-slot value is unchanged.
+            uint afterWrite = rom.u32(pointerSlot);
+            Assert.Equal(vanillaValue, afterWrite);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
     [Fact]
     public void ViewModel_Write_PersistsCommentToCache()
     {
@@ -375,15 +416,22 @@ public class ImageMagicFEditorParityTests
         try
         {
             CoreState.ROM = rom;
+            // Plant FEditor signature so the VM-level patch guard
+            // doesn't bail out before persisting (Copilot CLI re-review
+            // on PR #554 #1).
+            PlantFEditorSignatureFe8u(rom);
             var fake = new FakeEtcCache();
             CoreState.CommentCache = fake;
 
             uint pointerSlot = 0x00400000u;
             uint csaEntry = 0x00410000u;
             var vm = new ImageMagicFEditorViewModel();
+            vm.RefreshPatchState();
             vm.CurrentAddr = csaEntry;
             vm.PointerSlotAddr = pointerSlot;
-            vm.DimPointer = ImageMagicFEditorViewModel.DimPointerKind.Empty;
+            // DimPc maps to DimAddr per WF semantics — safer than Empty
+            // because Empty writes 0 to the slot.
+            vm.DimPointer = ImageMagicFEditorViewModel.DimPointerKind.DimPc;
             vm.Comment = "test comment";
             vm.Write();
 

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageMagicFEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageMagicFEditorParityTests.cs
@@ -244,22 +244,26 @@ public class ImageMagicFEditorParityTests
             CoreState.ROM = rom;
             // Plant FE8U FEditor signature + CSA spell table so
             // `SearchMagicSystem` reports dimAddr = 0x95D7ED, no_dimAddr
-            // = 0x95D8EF. Per WF semantics (`AddressList_SelectedIndexChanged`
-            // in ImageMagicFEditorForm.cs:142-153) the entry's pointer
+            // = 0x95D8EF. Per WF semantics
+            // (`AddressList_SelectedIndexChanged` in
+            // ImageMagicFEditorForm.cs:142-153) the entry's pointer
             // value 0x95D7ED maps to DimComboBox index 0 = `dim_pc`
             // and 0x95D8EF maps to index 1 = `dim`. We plant 0x95D8EF
-            // here and assert the VM reports `Dim`.
+            // at the POINTER-SLOT and assert the VM reports `Dim`.
             PlantFEditorSignatureFe8u(rom);
-            uint entrySlot = 0x00400000u;
+            uint pointerSlot = 0x00400000u;
+            uint csaEntry = 0x00410000u;
             BitConverter.GetBytes(0x95D8EFu | 0x08000000u)
-                .CopyTo(rom.Data, entrySlot);
+                .CopyTo(rom.Data, pointerSlot);
 
             var vm = new ImageMagicFEditorViewModel();
             // The VM must initialize MagicSystemDetected lazily.
-            vm.LoadEntry(entrySlot);
+            vm.LoadEntry(csaEntry, pointerSlot);
 
             Assert.Equal(ImageMagicFEditorViewModel.DimPointerKind.Dim,
                 vm.DimPointer);
+            Assert.Equal(csaEntry, vm.CurrentAddr);
+            Assert.Equal(pointerSlot, vm.PointerSlotAddr);
             Assert.True(vm.IsLoaded);
         }
         finally { CoreState.ROM = prevRom; }
@@ -268,20 +272,21 @@ public class ImageMagicFEditorParityTests
     [Fact]
     public void ViewModel_LoadEntry_ReadsDimPointer_DimPc_Kind()
     {
-        // Complement to the Dim case: planting 0x95D7ED should map to
-        // DimComboBox index 0 = `dim_pc`.
+        // Complement to the Dim case: planting 0x95D7ED at the pointer
+        // slot should map to DimComboBox index 0 = `dim_pc`.
         ROM rom = MakeMinimalFe8uRom();
         var prevRom = CoreState.ROM;
         try
         {
             CoreState.ROM = rom;
             PlantFEditorSignatureFe8u(rom);
-            uint entrySlot = 0x00400000u;
+            uint pointerSlot = 0x00400000u;
+            uint csaEntry = 0x00410000u;
             BitConverter.GetBytes(0x95D7EDu | 0x08000000u)
-                .CopyTo(rom.Data, entrySlot);
+                .CopyTo(rom.Data, pointerSlot);
 
             var vm = new ImageMagicFEditorViewModel();
-            vm.LoadEntry(entrySlot);
+            vm.LoadEntry(csaEntry, pointerSlot);
             Assert.Equal(ImageMagicFEditorViewModel.DimPointerKind.DimPc,
                 vm.DimPointer);
         }
@@ -298,18 +303,61 @@ public class ImageMagicFEditorParityTests
             CoreState.ROM = rom;
             PlantFEditorSignatureFe8u(rom);
 
-            uint entrySlot = 0x00400000u;
+            uint pointerSlot = 0x00400000u;
+            uint csaEntry = 0x00410000u;
             var vm = new ImageMagicFEditorViewModel();
-            vm.CurrentAddr = entrySlot;
+            // Trigger patch detection before setting properties directly
+            // (LoadEntry would do this implicitly; here we test the Write
+            // path against a manually-set state).
+            vm.RefreshPatchState();
+            vm.CurrentAddr = csaEntry;
+            vm.PointerSlotAddr = pointerSlot;
             // `Dim` maps to NoDimAddr per WF WriteDim() semantics.
             vm.DimPointer = ImageMagicFEditorViewModel.DimPointerKind.Dim;
             vm.Write();
 
-            // The slot must now hold the GBA pointer (0x08-high bit) to
-            // the no_dim address (0x95D8EF) resolved from the FEditor
-            // signature row.
-            uint raw = rom.u32(entrySlot);
+            // The POINTER-SLOT (not the CSA entry) must now hold the
+            // GBA pointer to the no_dim address resolved from the
+            // FEditor signature row.
+            uint raw = rom.u32(pointerSlot);
             Assert.Equal(0x95D8EFu | 0x08000000u, raw);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_Write_PersistsP0ThroughP16_ToCsaEntry()
+    {
+        // The CSA spell-table entry holds five u32 fields at
+        // CurrentAddr+0/4/8/12/16. Write() must persist them so user
+        // edits to FrameData / OBJRightToLeft / OBJLeftToRight /
+        // OBJBGRightToLeft / OBBGLeftToRight aren't silently dropped
+        // (Copilot bot review on PR #554 #6).
+        ROM rom = MakeMinimalFe8uRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            PlantFEditorSignatureFe8u(rom);
+            uint pointerSlot = 0x00400000u;
+            uint csaEntry = 0x00410000u;
+            var vm = new ImageMagicFEditorViewModel();
+            vm.RefreshPatchState();
+            vm.CurrentAddr = csaEntry;
+            vm.PointerSlotAddr = pointerSlot;
+            vm.DimPointer = ImageMagicFEditorViewModel.DimPointerKind.Empty;
+            vm.P0 = 0x11111111u;
+            vm.P4 = 0x22222222u;
+            vm.P8 = 0x33333333u;
+            vm.P12 = 0x44444444u;
+            vm.P16 = 0x55555555u;
+            vm.Write();
+
+            Assert.Equal(0x11111111u, rom.u32(csaEntry + 0));
+            Assert.Equal(0x22222222u, rom.u32(csaEntry + 4));
+            Assert.Equal(0x33333333u, rom.u32(csaEntry + 8));
+            Assert.Equal(0x44444444u, rom.u32(csaEntry + 12));
+            Assert.Equal(0x55555555u, rom.u32(csaEntry + 16));
         }
         finally { CoreState.ROM = prevRom; }
     }
@@ -317,6 +365,9 @@ public class ImageMagicFEditorParityTests
     [Fact]
     public void ViewModel_Write_PersistsCommentToCache()
     {
+        // Comments key off the CSA entry address (mirrors WF
+        // CommentCache.Update(Address.Value, ...) where Address.Value
+        // is the CSA entry address, not the pointer slot).
         ROM rom = MakeMinimalFe8uRom();
         var prevRom = CoreState.ROM;
         var prevCache = CoreState.CommentCache;
@@ -326,14 +377,17 @@ public class ImageMagicFEditorParityTests
             var fake = new FakeEtcCache();
             CoreState.CommentCache = fake;
 
-            uint entrySlot = 0x00400000u;
+            uint pointerSlot = 0x00400000u;
+            uint csaEntry = 0x00410000u;
             var vm = new ImageMagicFEditorViewModel();
-            vm.CurrentAddr = entrySlot;
+            vm.CurrentAddr = csaEntry;
+            vm.PointerSlotAddr = pointerSlot;
             vm.DimPointer = ImageMagicFEditorViewModel.DimPointerKind.Empty;
             vm.Comment = "test comment";
             vm.Write();
 
-            Assert.Equal("test comment", fake.At(entrySlot));
+            Assert.Equal("test comment", fake.At(csaEntry));
+            Assert.Equal("", fake.At(pointerSlot)); // not keyed by slot.
         }
         finally
         {
@@ -352,12 +406,13 @@ public class ImageMagicFEditorParityTests
         {
             CoreState.ROM = rom;
             var fake = new FakeEtcCache();
-            uint entrySlot = 0x00400000u;
-            fake.Update(entrySlot, "planted comment");
+            uint pointerSlot = 0x00400000u;
+            uint csaEntry = 0x00410000u;
+            fake.Update(csaEntry, "planted comment");
             CoreState.CommentCache = fake;
 
             var vm = new ImageMagicFEditorViewModel();
-            vm.LoadEntry(entrySlot);
+            vm.LoadEntry(csaEntry, pointerSlot);
 
             Assert.Equal("planted comment", vm.Comment);
         }

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageMagicFEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageMagicFEditorParityTests.cs
@@ -194,6 +194,7 @@ public class ImageMagicFEditorParityTests
     [InlineData("ImageMagicFEditor_MagicAnimeExport_Button")]
     [InlineData("ImageMagicFEditor_OpenSource_Button")]
     [InlineData("ImageMagicFEditor_SelectSource_Button")]
+    [InlineData("ImageMagicFEditor_MagicListExpand_Button")]
     public void View_DeferredButton_IsDisabledAndReferencesFollowupIssue(string id)
     {
         // Simple regex check on the raw AXAML text — looks at the

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageMagicFEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageMagicFEditorParityTests.cs
@@ -1,0 +1,461 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Phase 1+2+4+5 gap-sweep regression tests for ImageMagicFEditorView (#418).
+//
+// Closes the 34-control / 25 WF-only-labels gap surfaced by the gap-sweep
+// methodology on ImageMagicFEditorForm (HIGH density 37/3, -91.9%). After
+// this PR the view rebuilds to a 3-row 2-column shell that mirrors the
+// WF panel3 / panel5 / panel8 / DragTargetPanel surfaces, with patch-aware
+// list-expansion and a KnownGap NavigationTarget for the
+// ToolAnimationCreator jump (tracked at #500).
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.GapSweep;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests.GapSweep;
+
+/// <summary>
+/// Tests proving the ImageMagicFEditor parity raise (#418) is permanent.
+/// Density target: AV control count ≥ ceil(WF * 0.75) = 28.
+///
+/// Marked [Collection("SharedState")] because the VM tests mutate
+/// CoreState.ROM and CoreState.CommentCache to plant synthetic ROMs.
+/// </summary>
+[Collection("SharedState")]
+public class ImageMagicFEditorParityTests
+{
+    // -----------------------------------------------------------------
+    // Density (Phase 1) — AV control count must reach MEDIUM verdict.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// The WF Designer reports 37 user-facing controls; the MEDIUM
+    /// threshold is `ceil(37 * 0.75) = 28`. Falling below this re-enters
+    /// HIGH territory.
+    /// </summary>
+    [Fact]
+    public void View_AvControlCount_AtOrAboveMediumVerdict()
+    {
+        string axamlPath = Path.Combine(FindRepoRoot(),
+            "FEBuilderGBA.Avalonia", "Views", "ImageMagicFEditorView.axaml");
+        Assert.True(File.Exists(axamlPath), $"AXAML not found at {axamlPath}");
+
+        var doc = XDocument.Load(axamlPath);
+        int avCount = ControlDensityScanner.CountAvControlsInDocument(doc);
+
+        const int WfControlCount = 37;
+        int mediumThreshold = (int)Math.Ceiling(WfControlCount * 0.75); // 28
+        Assert.True(avCount >= mediumThreshold,
+            $"AV control count {avCount} must be >= {mediumThreshold} (75% of WF={WfControlCount})");
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 5 — control surface assertions (static AXAML inspection).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_HasTopReadConfigBar()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("ImageMagicFEditor_ReadStart_Input", axaml);
+        Assert.Contains("ImageMagicFEditor_ReadCount_Input", axaml);
+        Assert.Contains("ImageMagicFEditor_ReloadList_Button", axaml);
+        Assert.Contains("Click=\"ReloadList_Click\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasAddressWriteBar()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("ImageMagicFEditor_Address_Input", axaml);
+        Assert.Contains("ImageMagicFEditor_BlockSize_Input", axaml);
+        Assert.Contains("ImageMagicFEditor_SelectedAddress_Input", axaml);
+        Assert.Contains("ImageMagicFEditor_Write_Button", axaml);
+        Assert.Contains("Click=\"Write_Click\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasMainEntryListPanel()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("ImageMagicFEditor_Entry_List", axaml);
+        Assert.Contains("ImageMagicFEditor_NameHeader_Label", axaml);
+        Assert.Contains("ImageMagicFEditor_MagicListExpand_Button", axaml);
+        Assert.Contains("Click=\"MagicListExpand_Click\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasFiveSpinners_P0_P4_P8_P12_P16()
+    {
+        string axaml = ReadAxaml();
+        // The five frame/anime spinners + their exact WF labels.
+        Assert.Contains("ImageMagicFEditor_P0_Input", axaml);
+        Assert.Contains("ImageMagicFEditor_P4_Input", axaml);
+        Assert.Contains("ImageMagicFEditor_P8_Input", axaml);
+        Assert.Contains("ImageMagicFEditor_P12_Input", axaml);
+        Assert.Contains("ImageMagicFEditor_P16_Input", axaml);
+        // Exact WF Designer label text.
+        Assert.Contains("FrameData", axaml);
+        Assert.Contains("OBJRightToLeft", axaml);
+        Assert.Contains("OBJLeftToRight", axaml);
+        Assert.Contains("OBJBGRightToLeft", axaml);
+        Assert.Contains("OBBGLeftToRight", axaml);
+    }
+
+    [Fact]
+    public void View_HasDimComboBox_AndZoomComboBox()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("ImageMagicFEditor_Dim_Combo", axaml);
+        Assert.Contains("ImageMagicFEditor_Zoom_Combo", axaml);
+    }
+
+    [Fact]
+    public void View_HasMagicCommentTextBox_AndFrameSpinner()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("ImageMagicFEditor_Comment_Input", axaml);
+        Assert.Contains("ImageMagicFEditor_Frame_Input", axaml);
+    }
+
+    [Fact]
+    public void View_HasOpenSource_SelectSource_Editor_LinkButtons()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("ImageMagicFEditor_JumpEditor_Button", axaml);
+        Assert.Contains("ImageMagicFEditor_OpenSource_Button", axaml);
+        Assert.Contains("ImageMagicFEditor_SelectSource_Button", axaml);
+        Assert.Contains("ImageMagicFEditor_LinkInternet_Label", axaml);
+    }
+
+    [Fact]
+    public void View_HasImportExport_Buttons()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("ImageMagicFEditor_MagicAnimeImport_Button", axaml);
+        Assert.Contains("ImageMagicFEditor_MagicAnimeExport_Button", axaml);
+    }
+
+    [Fact]
+    public void View_HasPatchNoticeLabel()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("ImageMagicFEditor_PatchNotice_Label", axaml);
+    }
+
+    [Fact]
+    public void View_HasSamplePreviewLabel_AndPreviewImage()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("ImageMagicFEditor_SamplePreview_Label", axaml);
+        Assert.Contains("ImageMagicFEditor_PreviewImage", axaml);
+    }
+
+    // -----------------------------------------------------------------
+    // Roslyn AST walk — assert write handlers use _undoService.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_WriteHandler_UsesUndoService()
+    {
+        string source = ReadCodeBehind();
+        Assert.Matches(new Regex(@"void\s+Write_Click[\s\S]*?_undoService\.Begin",
+            RegexOptions.Compiled), source);
+        Assert.Matches(new Regex(@"void\s+Write_Click[\s\S]*?_undoService\.Commit",
+            RegexOptions.Compiled), source);
+        Assert.Matches(new Regex(@"void\s+Write_Click[\s\S]*?_undoService\.Rollback",
+            RegexOptions.Compiled), source);
+    }
+
+    [Fact]
+    public void View_MagicListExpandHandler_UsesUndoService()
+    {
+        string source = ReadCodeBehind();
+        Assert.Matches(new Regex(@"void\s+MagicListExpand_Click[\s\S]*?_undoService\.Begin",
+            RegexOptions.Compiled), source);
+        Assert.Matches(new Regex(@"void\s+MagicListExpand_Click[\s\S]*?_undoService\.Commit",
+            RegexOptions.Compiled), source);
+        Assert.Matches(new Regex(@"void\s+MagicListExpand_Click[\s\S]*?_undoService\.Rollback",
+            RegexOptions.Compiled), source);
+    }
+
+    // -----------------------------------------------------------------
+    // Deferred buttons — disabled + tooltipped per scope discipline.
+    // -----------------------------------------------------------------
+
+    [Theory]
+    [InlineData("ImageMagicFEditor_MagicAnimeImport_Button")]
+    [InlineData("ImageMagicFEditor_MagicAnimeExport_Button")]
+    [InlineData("ImageMagicFEditor_OpenSource_Button")]
+    [InlineData("ImageMagicFEditor_SelectSource_Button")]
+    public void View_DeferredButton_IsDisabledAndReferencesFollowupIssue(string id)
+    {
+        // Simple regex check on the raw AXAML text — looks at the
+        // Button element with the given AutomationId AutomationId and
+        // verifies the same element carries IsEnabled="False" plus a
+        // ToolTip.Tip attribute mentioning #500.
+        string axaml = ReadAxaml();
+        // Match the <Button … AutomationId="<id>" … /> element body
+        // (everything between this opening tag's start and the next
+        // unrelated tag's start) so we can inspect its attributes.
+        var pattern = new Regex(
+            @"<Button[^>]*AutomationId=""" + Regex.Escape(id) + @"""[^>]*?/>",
+            RegexOptions.Singleline);
+        var match = pattern.Match(axaml);
+        Assert.True(match.Success,
+            $"Expected a <Button AutomationId=\"{id}\" .../> element");
+        Assert.Contains("IsEnabled=\"False\"", match.Value);
+        Assert.Contains("ToolTip.Tip=", match.Value);
+        Assert.Contains("#500", match.Value);
+    }
+
+    // -----------------------------------------------------------------
+    // ViewModel — synthetic ROM behavior tests.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_LoadEntry_NullRom_DoesNotThrow()
+    {
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = null;
+            var vm = new ImageMagicFEditorViewModel();
+            // Just make sure it tolerates a missing ROM.
+            vm.LoadEntry(0x100u);
+            Assert.False(vm.IsLoaded);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_LoadEntry_ReadsDimPointer_AsKind()
+    {
+        ROM rom = MakeMinimalFe8uRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            // Plant FE8U FEditor signature + CSA spell table so
+            // `SearchMagicSystem` reports dimAddr = 0x95D7ED, no_dimAddr
+            // = 0x95D8EF. Per WF semantics (`AddressList_SelectedIndexChanged`
+            // in ImageMagicFEditorForm.cs:142-153) the entry's pointer
+            // value 0x95D7ED maps to DimComboBox index 0 = `dim_pc`
+            // and 0x95D8EF maps to index 1 = `dim`. We plant 0x95D8EF
+            // here and assert the VM reports `Dim`.
+            PlantFEditorSignatureFe8u(rom);
+            uint entrySlot = 0x00400000u;
+            BitConverter.GetBytes(0x95D8EFu | 0x08000000u)
+                .CopyTo(rom.Data, entrySlot);
+
+            var vm = new ImageMagicFEditorViewModel();
+            // The VM must initialize MagicSystemDetected lazily.
+            vm.LoadEntry(entrySlot);
+
+            Assert.Equal(ImageMagicFEditorViewModel.DimPointerKind.Dim,
+                vm.DimPointer);
+            Assert.True(vm.IsLoaded);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_LoadEntry_ReadsDimPointer_DimPc_Kind()
+    {
+        // Complement to the Dim case: planting 0x95D7ED should map to
+        // DimComboBox index 0 = `dim_pc`.
+        ROM rom = MakeMinimalFe8uRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            PlantFEditorSignatureFe8u(rom);
+            uint entrySlot = 0x00400000u;
+            BitConverter.GetBytes(0x95D7EDu | 0x08000000u)
+                .CopyTo(rom.Data, entrySlot);
+
+            var vm = new ImageMagicFEditorViewModel();
+            vm.LoadEntry(entrySlot);
+            Assert.Equal(ImageMagicFEditorViewModel.DimPointerKind.DimPc,
+                vm.DimPointer);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_Write_PersistsDimPointer_AsGbaPointer()
+    {
+        ROM rom = MakeMinimalFe8uRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            PlantFEditorSignatureFe8u(rom);
+
+            uint entrySlot = 0x00400000u;
+            var vm = new ImageMagicFEditorViewModel();
+            vm.CurrentAddr = entrySlot;
+            // `Dim` maps to NoDimAddr per WF WriteDim() semantics.
+            vm.DimPointer = ImageMagicFEditorViewModel.DimPointerKind.Dim;
+            vm.Write();
+
+            // The slot must now hold the GBA pointer (0x08-high bit) to
+            // the no_dim address (0x95D8EF) resolved from the FEditor
+            // signature row.
+            uint raw = rom.u32(entrySlot);
+            Assert.Equal(0x95D8EFu | 0x08000000u, raw);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_Write_PersistsCommentToCache()
+    {
+        ROM rom = MakeMinimalFe8uRom();
+        var prevRom = CoreState.ROM;
+        var prevCache = CoreState.CommentCache;
+        try
+        {
+            CoreState.ROM = rom;
+            var fake = new FakeEtcCache();
+            CoreState.CommentCache = fake;
+
+            uint entrySlot = 0x00400000u;
+            var vm = new ImageMagicFEditorViewModel();
+            vm.CurrentAddr = entrySlot;
+            vm.DimPointer = ImageMagicFEditorViewModel.DimPointerKind.Empty;
+            vm.Comment = "test comment";
+            vm.Write();
+
+            Assert.Equal("test comment", fake.At(entrySlot));
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.CommentCache = prevCache;
+        }
+    }
+
+    [Fact]
+    public void ViewModel_LoadEntry_ReadsCommentFromCache()
+    {
+        ROM rom = MakeMinimalFe8uRom();
+        var prevRom = CoreState.ROM;
+        var prevCache = CoreState.CommentCache;
+        try
+        {
+            CoreState.ROM = rom;
+            var fake = new FakeEtcCache();
+            uint entrySlot = 0x00400000u;
+            fake.Update(entrySlot, "planted comment");
+            CoreState.CommentCache = fake;
+
+            var vm = new ImageMagicFEditorViewModel();
+            vm.LoadEntry(entrySlot);
+
+            Assert.Equal("planted comment", vm.Comment);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.CommentCache = prevCache;
+        }
+    }
+
+    [Fact]
+    public void ViewModel_NavigationTargets_HasJumpToToolAnimationCreator()
+    {
+        var vm = new ImageMagicFEditorViewModel();
+        var source = (INavigationTargetSource)vm;
+        var targets = source.GetNavigationTargets();
+
+        Assert.Single(targets);
+        var t = targets[0];
+        Assert.Equal("JumpToToolAnimationCreator", t.CommandName);
+        Assert.Equal("ToolAnimationCreatorView", t.TargetViewType.Name);
+        Assert.Equal("#500", t.IssueRef);
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    static ROM MakeMinimalFe8uRom()
+    {
+        var rom = new ROM();
+        var data = new byte[0x1100000];
+        rom.LoadLow("synthetic-fe8u.gba", data, "BE8E01");
+        return rom;
+    }
+
+    /// <summary>
+    /// Plant the FE8U FEditor magic signature + CSA spell table pattern
+    /// so `ImageUtilMagicCore.SearchMagicSystem` returns FEditorAdv with
+    /// dimAddr=0x95D7ED and no_dimAddr=0x95D8EF.
+    /// </summary>
+    static void PlantFEditorSignatureFe8u(ROM rom)
+    {
+        byte[] sig = {
+            0x01, 0x00, 0x00, 0x00, 0x90, 0xD7, 0x95, 0x08,
+            0x03, 0x00, 0x00, 0x00, 0x39, 0xD9, 0x95, 0x08,
+        };
+        Array.Copy(sig, 0, rom.Data, 0x95d780, sig.Length);
+
+        byte[] csaPat = {
+            0x01, 0xB4, 0x7D, 0xE7, 0x34, 0xFF, 0x03, 0x02,
+            0x80, 0xD7, 0x95, 0x08, 0x1A, 0xE1, 0x03, 0x02,
+        };
+        Array.Copy(csaPat, 0, rom.Data, 0x00200000, csaPat.Length);
+        BitConverter.GetBytes(0x00100000u | 0x08000000u)
+            .CopyTo(rom.Data, 0x00200000 + csaPat.Length);
+    }
+
+    static string ReadAxaml() => File.ReadAllText(Path.Combine(FindRepoRoot(),
+        "FEBuilderGBA.Avalonia", "Views", "ImageMagicFEditorView.axaml"));
+
+    static string ReadCodeBehind() => File.ReadAllText(Path.Combine(FindRepoRoot(),
+        "FEBuilderGBA.Avalonia", "Views", "ImageMagicFEditorView.axaml.cs"));
+
+    /// <summary>Walk parents from test bin dir until we find FEBuilderGBA.sln.</summary>
+    static string FindRepoRoot()
+    {
+        string? dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+        if (dir == null)
+            throw new InvalidOperationException("Could not find FEBuilderGBA.sln from test base directory");
+        return dir;
+    }
+
+    /// <summary>
+    /// In-memory IEtcCache used by the Comment round-trip tests so we
+    /// can exercise CoreState.CommentCache without depending on the
+    /// WinForms-only EtcCacheText file-backed implementation.
+    /// </summary>
+    class FakeEtcCache : IEtcCache
+    {
+        readonly System.Collections.Generic.Dictionary<uint, string> _map = new();
+        public void RemoveOverRange(uint range) { }
+        public void RemoveRange(uint start, uint end) { }
+        public bool CheckFast(uint num) => _map.ContainsKey(num);
+        public string At(uint num, string def = "")
+        {
+            return _map.TryGetValue(num, out string v) ? v : def;
+        }
+        public string S_At(uint num) => At(num);
+        public bool TryGetValue(uint num, out string out_data)
+        {
+            return _map.TryGetValue(num, out out_data!);
+        }
+        public void Update(uint addr, string comment) => _map[addr] = comment;
+        public void Remove(uint addr) => _map.Remove(addr);
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageMagicFEditorViewModel.NavigationTargets.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageMagicFEditorViewModel.NavigationTargets.cs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Navigation manifest for ImageMagicFEditorViewModel (#418 / #374 Phase 4).
+//
+// Mirrors the single WF cross-editor jump callsite in
+// `ImageMagicFEditorForm`:
+//   - `X_N_JumpEditor_Click` -> `ToolAnimationCreatorForm`
+//     (`InputFormRef.JumpFormLow<ToolAnimationCreatorForm>()` then
+//      `f.Init(MagicAnime_FEEDitor, ID, filehint, filename)`)
+//
+// The WF flow exports the current magic anime to a temp `.txt` file
+// and hands the path to ToolAnimationCreator. The Avalonia
+// ToolAnimationCreatorView exists but its `Init()` / Magic Anime
+// support is tracked separately by issue #500. The KnownGap row
+// below points at #500 (open) so the jump-parity scanner reports
+// `KnownGap` rather than `MissingAvManifest`.
+//
+// The other deferred actions on this view (Open Source / Select
+// Source / Magic Anime Import / Magic Anime Export) are NOT
+// cross-editor jumps — they are file/shell I/O. They are tracked
+// via the disabled-button + tooltip pattern in the AXAML, not via
+// NavigationTarget manifest rows (the JumpParityScanner contract
+// requires concrete `TargetViewType` references, which file-shell
+// actions do not have).
+using System.Collections.Generic;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.Views;
+
+namespace FEBuilderGBA.Avalonia.ViewModels
+{
+    public partial class ImageMagicFEditorViewModel : INavigationTargetSource
+    {
+        public IReadOnlyList<NavigationTarget> GetNavigationTargets()
+        {
+            return new[]
+            {
+                new NavigationTarget(
+                    CommandName: "JumpToToolAnimationCreator",
+                    TargetViewType: typeof(ToolAnimationCreatorView),
+                    TargetAddress: null,
+                    IssueRef: "#500"),
+            };
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageMagicFEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageMagicFEditorViewModel.cs
@@ -48,7 +48,18 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// <summary>Maximum FEditor slot index (vanilla cap is 0xFE).</summary>
         const int MAX_SLOTS = 0xFE;
 
+        // CSA spell-table entry address (mirrors WF AddrResult.addr). Holds
+        // P0..P16 + comment data. P0 = u32 at CurrentAddr+0, P4 = +4, etc.
         uint _currentAddr;
+
+        // Pointer-table slot address (mirrors WF AddrResult.tag). Holds the
+        // dim/no-dim/empty pointer (4 bytes). Separate from CurrentAddr
+        // because the WF AddressList row carries BOTH addresses (the
+        // pointer slot points at the CSA entry, but CommentCache + the
+        // user-facing Address spinner key off the CSA entry, while
+        // WriteDim writes to the slot itself).
+        uint _pointerSlotAddr;
+
         bool _isLoaded;
         uint _p0, _p4, _p8, _p12, _p16;
         uint _frame;
@@ -60,8 +71,13 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         ImageUtilMagicCore.MagicSystem _system = ImageUtilMagicCore.MagicSystem.No;
         uint _csaSpellTable = U.NOT_FOUND;
         uint _spellDataCount;
+        uint _magicEffectTableBase;
 
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
+        /// <summary>Pointer-table slot for the selected row (mirrors WF
+        /// `AddrResult.tag`). dim/no-dim/empty pointer lives here; setter
+        /// is internal because the view drives it via OnSelected.</summary>
+        public uint PointerSlotAddr { get => _pointerSlotAddr; set => SetField(ref _pointerSlotAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
         public uint P0 { get => _p0; set => SetField(ref _p0, value); }
         public uint P4 { get => _p4; set => SetField(ref _p4, value); }
@@ -71,6 +87,15 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public uint Frame { get => _frame; set => SetField(ref _frame, value); }
         public DimPointerKind DimPointer { get => _dimPointer; set => SetField(ref _dimPointer, value); }
         public string Comment { get => _comment; set => SetField(ref _comment, value ?? string.Empty); }
+
+        /// <summary>Pointer-table base address used by the top read-config
+        /// bar (mirrors WF panel3 ReadStartAddress).</summary>
+        public uint ReadStartAddress => _magicEffectTableBase;
+
+        /// <summary>How many magic-effect entries the editor surfaces (mirrors
+        /// WF panel3 ReadCount).</summary>
+        public uint ReadCount => _spellDataCount > 0 ? _spellDataCount
+            : (CoreState.ROM?.RomInfo?.magic_effect_original_data_count ?? 0u);
 
         /// <summary>True when one of the FEditorAdv / CSA_Creator
         /// signatures was found in the loaded ROM. When false the
@@ -144,6 +169,12 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// `ImageMagicFEditorForm.Init` callback — walks the
         /// magic-effect pointer table looking for valid dim/no_dim
         /// entries (and EMPTY slots beyond the original count).
+        ///
+        /// Each `AddrResult` exposed here uses the WF convention:
+        /// `addr = csaAddr` (CSA spell-table entry address — base of the
+        /// 20-byte struct that holds P0/P4/P8/P12/P16 + the comment key)
+        /// and `tag = slot` (pointer-table slot — the 4-byte location
+        /// where the dim/no-dim/empty pointer lives).
         /// </summary>
         public List<AddrResult> LoadList()
         {
@@ -155,6 +186,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             uint magicPointer = rom.RomInfo.magic_effect_pointer;
             uint baseAddr = rom.p32(magicPointer);
             if (!U.isSafetyOffset(baseAddr, rom)) return new List<AddrResult>();
+            _magicEffectTableBase = baseAddr;
 
             int count = (int)Math.Min((uint)MAX_SLOTS,
                 _magicSystemDetected ? _spellDataCount : 0u);
@@ -205,11 +237,13 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         }
 
         /// <summary>
-        /// Read one editor row. <paramref name="addr"/> is the
-        /// pointer-table slot (the WF "tag"). Reads the dim pointer
-        /// + comment from CoreState.CommentCache.
+        /// Read one editor row. The CSA entry address (mirrors WF
+        /// `AddrResult.addr`) carries the 20-byte struct holding
+        /// P0/P4/P8/P12/P16 + the comment key. The pointer-table
+        /// slot (mirrors WF `AddrResult.tag`) carries the
+        /// dim/no-dim/empty pointer.
         /// </summary>
-        public void LoadEntry(uint addr)
+        public void LoadEntry(uint csaEntryAddr, uint pointerSlotAddr)
         {
             ROM rom = CoreState.ROM;
             if (rom == null)
@@ -217,7 +251,8 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 IsLoaded = false;
                 return;
             }
-            if (addr + ENTRY_STRIDE > (uint)rom.Data.Length)
+            if (csaEntryAddr + 20 > (uint)rom.Data.Length ||
+                pointerSlotAddr + ENTRY_STRIDE > (uint)rom.Data.Length)
             {
                 IsLoaded = false;
                 return;
@@ -230,14 +265,17 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 RefreshPatchState();
             }
 
-            CurrentAddr = addr;
-            uint dataPtr = rom.p32(addr);
+            CurrentAddr = csaEntryAddr;
+            PointerSlotAddr = pointerSlotAddr;
 
+            // Read dim pointer from the pointer-table slot (WF
+            // AddressList_SelectedIndexChanged: `uint dim = Program.ROM.p32(ar.tag)`).
+            uint dataPtr = rom.p32(pointerSlotAddr);
             if (_magicSystemDetected && dataPtr == _dimAddr)
             {
-                // WF semantics: the FEditor signature's `dim` field is
-                // surfaced as `dim_pc` (player-cast); the FEditor
-                // signature's `no_dim` field is surfaced as `dim`.
+                // WF semantics: the FEditor signature's `dim` field
+                // surfaces as `dim_pc` (player-cast); `no_dim` surfaces
+                // as `dim`.
                 DimPointer = DimPointerKind.DimPc;
             }
             else if (_magicSystemDetected && dataPtr == _noDimAddr)
@@ -249,19 +287,36 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 DimPointer = DimPointerKind.Empty;
             }
 
-            // Comment is keyed on the entry slot itself (matches WF
-            // `MagicComment.Text = Program.CommentCache.At(ar.addr)` where
-            // ar.addr is the same slot returned in LoadList).
-            Comment = CoreState.CommentCache?.At(addr, "") ?? string.Empty;
+            // Read the P0..P16 fields from the CSA spell-table entry
+            // (20 bytes = 5x u32).
+            P0 = rom.u32(csaEntryAddr + 0);
+            P4 = rom.u32(csaEntryAddr + 4);
+            P8 = rom.u32(csaEntryAddr + 8);
+            P12 = rom.u32(csaEntryAddr + 12);
+            P16 = rom.u32(csaEntryAddr + 16);
+
+            // Comment is keyed on the CSA entry address (matches WF
+            // `MagicComment.Text = Program.CommentCache.At(ar.addr)`).
+            Comment = CoreState.CommentCache?.At(csaEntryAddr, "") ?? string.Empty;
 
             IsLoaded = true;
         }
 
         /// <summary>
+        /// Convenience overload — the view code-behind may only have the
+        /// CSA entry address (e.g. NavigateTo path). When the pointer
+        /// slot isn't provided, dim-pointer reads/writes are skipped.
+        /// </summary>
+        public void LoadEntry(uint addr) => LoadEntry(addr, _pointerSlotAddr);
+
+        /// <summary>
         /// Persist the editor row. Mirrors WF `N_WriteButton_Click`:
-        /// writes the dim pointer via rom.write_p32 and updates the
-        /// CoreState.CommentCache entry. The view wraps this in
-        /// `_undoService.Begin/Commit/Rollback`.
+        /// - writes the dim pointer to the pointer-table slot
+        ///   (`PointerSlotAddr`, WF `ar.tag`) via `rom.write_p32`.
+        /// - updates `CoreState.CommentCache` keyed by the CSA entry
+        ///   address (`CurrentAddr`, WF `Address.Value`).
+        /// - writes the P0..P16 fields to the CSA spell-table entry.
+        /// The view wraps this in `_undoService.Begin/Commit/Rollback`.
         /// </summary>
         public void Write()
         {
@@ -274,22 +329,39 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 RefreshPatchState();
             }
 
-            switch (DimPointer)
+            // Persist dim/no-dim/empty pointer to the pointer-table slot.
+            // WF: `Program.ROM.write_p32(ar.tag, this.DimAddr)` etc.
+            if (PointerSlotAddr != 0u)
             {
-                case DimPointerKind.DimPc:
-                    if (_dimAddr != U.NOT_FOUND)
-                        rom.write_p32(CurrentAddr, _dimAddr);
-                    break;
-                case DimPointerKind.Dim:
-                    if (_noDimAddr != U.NOT_FOUND)
-                        rom.write_p32(CurrentAddr, _noDimAddr);
-                    break;
-                case DimPointerKind.Empty:
-                    rom.write_u32(CurrentAddr, 0u);
-                    break;
+                switch (DimPointer)
+                {
+                    case DimPointerKind.DimPc:
+                        if (_dimAddr != U.NOT_FOUND)
+                            rom.write_p32(PointerSlotAddr, _dimAddr);
+                        break;
+                    case DimPointerKind.Dim:
+                        if (_noDimAddr != U.NOT_FOUND)
+                            rom.write_p32(PointerSlotAddr, _noDimAddr);
+                        break;
+                    case DimPointerKind.Empty:
+                        rom.write_u32(PointerSlotAddr, 0u);
+                        break;
+                }
             }
 
-            // Persist comment (WF: Program.CommentCache.Update(newaddr, MagicComment.Text)).
+            // Persist P0..P16 to the CSA spell-table entry (20 bytes).
+            // The view's editable spinners feed these properties.
+            if (CurrentAddr + 20 <= (uint)rom.Data.Length)
+            {
+                rom.write_u32(CurrentAddr + 0, P0);
+                rom.write_u32(CurrentAddr + 4, P4);
+                rom.write_u32(CurrentAddr + 8, P8);
+                rom.write_u32(CurrentAddr + 12, P12);
+                rom.write_u32(CurrentAddr + 16, P16);
+            }
+
+            // Persist comment keyed by the CSA entry address (WF:
+            // Program.CommentCache.Update(Address.Value, MagicComment.Text)).
             if (CoreState.CommentCache != null)
             {
                 CoreState.CommentCache.Update(CurrentAddr, Comment ?? string.Empty);
@@ -355,7 +427,10 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
         public Dictionary<string, string> GetFieldOffsetMap() => new()
         {
-            ["DimPointer"] = "u32@0",
+            // DimPointer lives in the pointer-table slot (PointerSlotAddr),
+            // not at CurrentAddr+0. Omitting it from the offset map prevents
+            // the field-completeness scanner from cross-checking it against
+            // u32@0 of CurrentAddr (which is the CSA entry's P0 field).
             ["P0"] = "u32@0",
             ["P4"] = "u32@4",
             ["P8"] = "u32@8",

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageMagicFEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageMagicFEditorViewModel.cs
@@ -412,11 +412,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (rom == null || CurrentAddr == 0) return new Dictionary<string, string>();
 
             uint a = CurrentAddr;
-            // CurrentAddr is the pointer-table slot; the P0..P16 fields
-            // shown in GetDataReport mirror the WF DragTargetPanel
-            // spinners. The completeness cross-check expects offsets
-            // 0/4/8/12/16 off CurrentAddr — these stay in-range and are
-            // valid ROM reads.
+            // CurrentAddr is the CSA spell-table entry address (mirrors
+            // WF AddrResult.addr) — the 20-byte struct holds P0..P16
+            // as u32 fields at offsets 0/4/8/12/16. The completeness
+            // cross-check uses these offsets directly. (PointerSlotAddr
+            // separately holds the WF AddrResult.tag value.)
             var result = new Dictionary<string, string>
             {
                 ["addr"] = string.Format("0x{0:X08}", a),

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageMagicFEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageMagicFEditorViewModel.cs
@@ -329,6 +329,14 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 RefreshPatchState();
             }
 
+            // VM-level patch-absence guard (Copilot CLI re-review on
+            // PR #554). The view's Write_Click already short-circuits,
+            // but Write() is public/test-callable and could otherwise
+            // wipe vanilla magic-effect pointer slots via the
+            // DimPointerKind.Empty branch. Mirrors WF WriteDim()'s
+            // assertion that ar.tag != 0 + the patch being present.
+            if (!_magicSystemDetected) return;
+
             // Persist dim/no-dim/empty pointer to the pointer-table slot.
             // WF: `Program.ROM.write_p32(ar.tag, this.DimAddr)` etc.
             if (PointerSlotAddr != 0u)

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageMagicFEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageMagicFEditorViewModel.cs
@@ -1,97 +1,312 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// ViewModel for ImageMagicFEditorView — the Avalonia counterpart of
+// WinForms ImageMagicFEditorForm. Gap-sweep fix (#418) extends this
+// from a 3-property stub into a full editor model:
+//
+// - LoadList scans the magic-effect pointer table for valid entries
+//   (with FEditorAdv / CSA_Creator patch detection via
+//   ImageUtilMagicCore).
+// - LoadEntry reads the per-row dim pointer (compared to the patch's
+//   dim/no-dim base addresses, mapped to DimPointerKind) plus the
+//   comment from CoreState.CommentCache.
+// - Write persists the dim pointer (rom.write_p32) AND the user
+//   comment (CoreState.CommentCache.Update), mirroring WF
+//   WriteDim() + WriteMagicName().
+// - DimPointerKind enum covers the three dim pointer states WF
+//   surfaces (dim_pc / dim / NULL(EMPTY)).
+//
+// The class is `partial` so the NavigationTargets manifest entry
+// (1 row pointing at ToolAnimationCreatorView, tagged with #500 as
+// the open follow-up tracker) can live in its own .NavigationTargets.cs
+// file.
 using System;
 using System.Collections.Generic;
 using FEBuilderGBA.Avalonia.Services;
 
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
-    public class ImageMagicFEditorViewModel : ViewModelBase, IDataVerifiable
+    public partial class ImageMagicFEditorViewModel : ViewModelBase, IDataVerifiable
     {
-        const uint SIZE = 20; // CSA spell table entry: 20 bytes (5 x u32)
+        /// <summary>
+        /// dim-pointer state surfaced by the magic-effect editor. The
+        /// integer values match the WF DimComboBox.Items ordering:
+        /// dim_pc=0, dim=1, NULL(EMPTY)=2.
+        /// </summary>
+        public enum DimPointerKind
+        {
+            /// <summary>Player-cast (dim_pc) animation.</summary>
+            DimPc = 0,
+            /// <summary>Enemy-cast (dim) animation.</summary>
+            Dim = 1,
+            /// <summary>Empty slot — entry deleted.</summary>
+            Empty = 2,
+        }
+
+        /// <summary>Pointer-table entry stride (4 bytes per slot).</summary>
+        const uint ENTRY_STRIDE = 4;
+
+        /// <summary>Maximum FEditor slot index (vanilla cap is 0xFE).</summary>
+        const int MAX_SLOTS = 0xFE;
 
         uint _currentAddr;
         bool _isLoaded;
         uint _p0, _p4, _p8, _p12, _p16;
+        uint _frame;
+        DimPointerKind _dimPointer = DimPointerKind.Empty;
+        string _comment = string.Empty;
+        bool _magicSystemDetected;
+        uint _dimAddr = U.NOT_FOUND;
+        uint _noDimAddr = U.NOT_FOUND;
+        ImageUtilMagicCore.MagicSystem _system = ImageUtilMagicCore.MagicSystem.No;
+        uint _csaSpellTable = U.NOT_FOUND;
+        uint _spellDataCount;
 
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
-
-        // P0: CSA spell table field 0
         public uint P0 { get => _p0; set => SetField(ref _p0, value); }
-        // P4: CSA spell table field 4
         public uint P4 { get => _p4; set => SetField(ref _p4, value); }
-        // P8: CSA spell table field 8
         public uint P8 { get => _p8; set => SetField(ref _p8, value); }
-        // P12: CSA spell table field 12
         public uint P12 { get => _p12; set => SetField(ref _p12, value); }
-        // P16: CSA spell table field 16
         public uint P16 { get => _p16; set => SetField(ref _p16, value); }
+        public uint Frame { get => _frame; set => SetField(ref _frame, value); }
+        public DimPointerKind DimPointer { get => _dimPointer; set => SetField(ref _dimPointer, value); }
+        public string Comment { get => _comment; set => SetField(ref _comment, value ?? string.Empty); }
 
-        /// <summary>
-        /// Find the CSA spell table address by scanning for the extended magic
-        /// spell table pattern (matches WinForms ImageUtilMagic.GetCSASpellTableAddr).
-        /// </summary>
-        static uint FindCSASpellTableAddr(ROM rom)
+        /// <summary>True when one of the FEditorAdv / CSA_Creator
+        /// signatures was found in the loaded ROM. When false the
+        /// editor controls render but are disabled and PatchNotice
+        /// explains why.</summary>
+        public bool MagicSystemDetected => _magicSystemDetected;
+
+        /// <summary>Magic system type detected (None when no patch).</summary>
+        public ImageUtilMagicCore.MagicSystem MagicSystem => _system;
+
+        /// <summary>Resolved dim address from the patch signature.</summary>
+        public uint DimAddr => _dimAddr;
+
+        /// <summary>Resolved no-dim address from the patch signature.</summary>
+        public uint NoDimAddr => _noDimAddr;
+
+        /// <summary>True when the spell-data table is expanded past the
+        /// original per-version magic count, i.e. the "List Expansion"
+        /// button should be hidden.</summary>
+        public bool IsListExpanded
         {
-            // The CSA spell table is found via binary pattern search in
-            // ImageUtilMagic.GetCSASpellTableAddr, but that's in WinForms.
-            // Approximate: the table is at a known offset after magic_effect_pointer.
-            // For data-verify, just compute from the pointer table.
-            uint pointer = rom.RomInfo.magic_effect_pointer;
-            if (pointer == 0) return 0;
-
-            uint ptrTableBase = rom.p32(pointer);
-            if (!U.isSafetyOffset(ptrTableBase, rom)) return 0;
-
-            // CSA spell table entries are typically right before or after the pointer table.
-            // Scan from the pointer table to find a 20-byte aligned structure.
-            // In practice, CSA spell table addr = pointer table base + count*4 (aligned).
-            // However, we can't know the exact count without scanning.
-            // Fallback: just use the pointer table entries as addresses directly.
-            return 0; // Will fall back to pointer-table mode
+            get
+            {
+                ROM rom = CoreState.ROM;
+                if (rom?.RomInfo == null) return false;
+                return _spellDataCount > rom.RomInfo.magic_effect_original_data_count;
+            }
         }
 
+        /// <summary>
+        /// Re-scan the loaded ROM for the magic-engine patch + CSA
+        /// spell table. Sets <see cref="MagicSystemDetected"/>,
+        /// <see cref="DimAddr"/>, <see cref="NoDimAddr"/>, and
+        /// <see cref="_csaSpellTable"/> as side effects.
+        /// </summary>
+        public void RefreshPatchState()
+        {
+            _magicSystemDetected = false;
+            _system = ImageUtilMagicCore.MagicSystem.No;
+            _dimAddr = U.NOT_FOUND;
+            _noDimAddr = U.NOT_FOUND;
+            _csaSpellTable = U.NOT_FOUND;
+            _spellDataCount = 0u;
+
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return;
+
+            uint baseAddr;
+            var system = ImageUtilMagicCore.SearchMagicSystem(
+                rom, out baseAddr, out _dimAddr, out _noDimAddr);
+            _system = system;
+            if (system == ImageUtilMagicCore.MagicSystem.No)
+            {
+                return;
+            }
+
+            uint csaPointer;
+            _csaSpellTable = ImageUtilMagicCore.FindCSASpellTable(
+                rom, system, out csaPointer);
+            if (_csaSpellTable == U.NOT_FOUND)
+            {
+                return;
+            }
+
+            _magicSystemDetected = true;
+            _spellDataCount = ImageUtilMagicCore.GetSpellDataCount(rom);
+        }
+
+        /// <summary>
+        /// Build the entry list for the editor. Mirrors WF
+        /// `ImageMagicFEditorForm.Init` callback — walks the
+        /// magic-effect pointer table looking for valid dim/no_dim
+        /// entries (and EMPTY slots beyond the original count).
+        /// </summary>
         public List<AddrResult> LoadList()
         {
+            RefreshPatchState();
+
             ROM rom = CoreState.ROM;
             if (rom?.RomInfo == null) return new List<AddrResult>();
 
-            uint pointer = rom.RomInfo.magic_effect_pointer;
-            if (pointer == 0) return new List<AddrResult>();
-
-            uint baseAddr = rom.p32(pointer);
+            uint magicPointer = rom.RomInfo.magic_effect_pointer;
+            uint baseAddr = rom.p32(magicPointer);
             if (!U.isSafetyOffset(baseAddr, rom)) return new List<AddrResult>();
 
-            var result = new List<AddrResult>();
-            // Each pointer table entry is 4 bytes.
-            // For data-verify, use the pointer table entries as the address list.
-            // The CSA spell table is not always available (requires FEditor patch).
-            // LoadEntry reads 20 bytes at each address from the pointer table base.
-            for (int i = 0; i < 0xFE; i++)
+            int count = (int)Math.Min((uint)MAX_SLOTS,
+                _magicSystemDetected ? _spellDataCount : 0u);
+            if (count == 0)
             {
-                uint addr = (uint)(baseAddr + i * SIZE);
-                if (addr + SIZE > (uint)rom.Data.Length) break;
+                // Pointer-table fallback so the list is at least
+                // browsable even without the FEditor patch.
+                count = (int)Math.Min((uint)MAX_SLOTS,
+                    rom.RomInfo.magic_effect_original_data_count);
+            }
 
-                string name = $"0x{i:X02} Magic Effect {i}";
-                result.Add(new AddrResult(addr, name, (uint)i));
+            var result = new List<AddrResult>();
+            uint dimAddr = _dimAddr;
+            uint noDimAddr = _noDimAddr;
+            uint origCount = rom.RomInfo.magic_effect_original_data_count;
+            for (int i = 0; i < count; i++)
+            {
+                uint slot = (uint)(baseAddr + i * ENTRY_STRIDE);
+                if (slot + ENTRY_STRIDE > (uint)rom.Data.Length) break;
+
+                uint dataPtr = rom.p32(slot);
+                uint csaAddr = _csaSpellTable != U.NOT_FOUND
+                    ? (uint)(_csaSpellTable + 20 * i)
+                    : slot;
+
+                string name = string.Format("0x{0:X02} Magic Effect", i);
+
+                if (dataPtr == 0)
+                {
+                    if ((uint)i < origCount) continue; // original slot, skipped
+                    result.Add(new AddrResult(csaAddr, name + " EMPTY", slot));
+                    continue;
+                }
+                if (_magicSystemDetected)
+                {
+                    if (dataPtr == dimAddr || dataPtr == noDimAddr)
+                    {
+                        result.Add(new AddrResult(csaAddr, name, slot));
+                    }
+                }
+                else
+                {
+                    // Best effort: still expose the row by its pointer.
+                    result.Add(new AddrResult(slot, name, slot));
+                }
             }
             return result;
         }
 
+        /// <summary>
+        /// Read one editor row. <paramref name="addr"/> is the
+        /// pointer-table slot (the WF "tag"). Reads the dim pointer
+        /// + comment from CoreState.CommentCache.
+        /// </summary>
         public void LoadEntry(uint addr)
         {
             ROM rom = CoreState.ROM;
-            if (rom == null) return;
-            if (addr + SIZE > (uint)rom.Data.Length) return;
+            if (rom == null)
+            {
+                IsLoaded = false;
+                return;
+            }
+            if (addr + ENTRY_STRIDE > (uint)rom.Data.Length)
+            {
+                IsLoaded = false;
+                return;
+            }
+
+            // Ensure patch state is current — caller may have set the ROM
+            // after constructing the VM.
+            if (!_magicSystemDetected && _system == ImageUtilMagicCore.MagicSystem.No)
+            {
+                RefreshPatchState();
+            }
 
             CurrentAddr = addr;
+            uint dataPtr = rom.p32(addr);
 
-            P0 = rom.u32(addr + 0);
-            P4 = rom.u32(addr + 4);
-            P8 = rom.u32(addr + 8);
-            P12 = rom.u32(addr + 12);
-            P16 = rom.u32(addr + 16);
+            if (_magicSystemDetected && dataPtr == _dimAddr)
+            {
+                // WF semantics: the FEditor signature's `dim` field is
+                // surfaced as `dim_pc` (player-cast); the FEditor
+                // signature's `no_dim` field is surfaced as `dim`.
+                DimPointer = DimPointerKind.DimPc;
+            }
+            else if (_magicSystemDetected && dataPtr == _noDimAddr)
+            {
+                DimPointer = DimPointerKind.Dim;
+            }
+            else
+            {
+                DimPointer = DimPointerKind.Empty;
+            }
+
+            // Comment is keyed on the entry slot itself (matches WF
+            // `MagicComment.Text = Program.CommentCache.At(ar.addr)` where
+            // ar.addr is the same slot returned in LoadList).
+            Comment = CoreState.CommentCache?.At(addr, "") ?? string.Empty;
 
             IsLoaded = true;
+        }
+
+        /// <summary>
+        /// Persist the editor row. Mirrors WF `N_WriteButton_Click`:
+        /// writes the dim pointer via rom.write_p32 and updates the
+        /// CoreState.CommentCache entry. The view wraps this in
+        /// `_undoService.Begin/Commit/Rollback`.
+        /// </summary>
+        public void Write()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null || CurrentAddr == 0u) return;
+
+            // Refresh patch state in case the ROM changed since LoadList.
+            if (_dimAddr == U.NOT_FOUND || _noDimAddr == U.NOT_FOUND)
+            {
+                RefreshPatchState();
+            }
+
+            switch (DimPointer)
+            {
+                case DimPointerKind.DimPc:
+                    if (_dimAddr != U.NOT_FOUND)
+                        rom.write_p32(CurrentAddr, _dimAddr);
+                    break;
+                case DimPointerKind.Dim:
+                    if (_noDimAddr != U.NOT_FOUND)
+                        rom.write_p32(CurrentAddr, _noDimAddr);
+                    break;
+                case DimPointerKind.Empty:
+                    rom.write_u32(CurrentAddr, 0u);
+                    break;
+            }
+
+            // Persist comment (WF: Program.CommentCache.Update(newaddr, MagicComment.Text)).
+            if (CoreState.CommentCache != null)
+            {
+                CoreState.CommentCache.Update(CurrentAddr, Comment ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Original per-version magic count (e.g. FE8U=0x48). Used by
+        /// the view to show/hide the List Expansion button.
+        /// </summary>
+        public uint OriginalMagicCount
+        {
+            get
+            {
+                ROM rom = CoreState.ROM;
+                return rom?.RomInfo?.magic_effect_original_data_count ?? 0u;
+            }
         }
 
         public int GetListCount() => LoadList().Count;
@@ -100,12 +315,14 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         {
             return new Dictionary<string, string>
             {
-                ["addr"] = $"0x{CurrentAddr:X08}",
-                ["P0"] = $"0x{P0:X08}",
-                ["P4"] = $"0x{P4:X08}",
-                ["P8"] = $"0x{P8:X08}",
-                ["P12"] = $"0x{P12:X08}",
-                ["P16"] = $"0x{P16:X08}",
+                ["addr"] = string.Format("0x{0:X08}", CurrentAddr),
+                ["DimPointer"] = DimPointer.ToString(),
+                ["Comment"] = Comment ?? string.Empty,
+                ["P0"] = string.Format("0x{0:X08}", P0),
+                ["P4"] = string.Format("0x{0:X08}", P4),
+                ["P8"] = string.Format("0x{0:X08}", P8),
+                ["P12"] = string.Format("0x{0:X08}", P12),
+                ["P16"] = string.Format("0x{0:X08}", P16),
             };
         }
 
@@ -115,19 +332,30 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (rom == null || CurrentAddr == 0) return new Dictionary<string, string>();
 
             uint a = CurrentAddr;
-            return new Dictionary<string, string>
+            // CurrentAddr is the pointer-table slot; the P0..P16 fields
+            // shown in GetDataReport mirror the WF DragTargetPanel
+            // spinners. The completeness cross-check expects offsets
+            // 0/4/8/12/16 off CurrentAddr — these stay in-range and are
+            // valid ROM reads.
+            var result = new Dictionary<string, string>
             {
-                ["addr"] = $"0x{a:X08}",
-                ["u32@0"] = $"0x{rom.u32(a + 0):X08}",
-                ["u32@4"] = $"0x{rom.u32(a + 4):X08}",
-                ["u32@8"] = $"0x{rom.u32(a + 8):X08}",
-                ["u32@12"] = $"0x{rom.u32(a + 12):X08}",
-                ["u32@16"] = $"0x{rom.u32(a + 16):X08}",
+                ["addr"] = string.Format("0x{0:X08}", a),
+                ["u32@0"] = string.Format("0x{0:X08}", rom.u32(a)),
             };
+            if (a + 4 + 4 <= (uint)rom.Data.Length)
+                result["u32@4"] = string.Format("0x{0:X08}", rom.u32(a + 4));
+            if (a + 8 + 4 <= (uint)rom.Data.Length)
+                result["u32@8"] = string.Format("0x{0:X08}", rom.u32(a + 8));
+            if (a + 12 + 4 <= (uint)rom.Data.Length)
+                result["u32@12"] = string.Format("0x{0:X08}", rom.u32(a + 12));
+            if (a + 16 + 4 <= (uint)rom.Data.Length)
+                result["u32@16"] = string.Format("0x{0:X08}", rom.u32(a + 16));
+            return result;
         }
 
         public Dictionary<string, string> GetFieldOffsetMap() => new()
         {
+            ["DimPointer"] = "u32@0",
             ["P0"] = "u32@0",
             ["P4"] = "u32@4",
             ["P8"] = "u32@8",

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageMagicFEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageMagicFEditorViewModel.cs
@@ -212,6 +212,13 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                     ? (uint)(_csaSpellTable + 20 * i)
                     : slot;
 
+                // Bounds-check the CSA entry address — a malformed ROM
+                // or unexpected table size could push csaAddr+20 past
+                // EOF (Copilot bot review on PR #554). Skipping such
+                // rows prevents LoadEntry from bailing out and leaving
+                // stale VM state.
+                if (csaAddr + 20 > (uint)rom.Data.Length) break;
+
                 string name = string.Format("0x{0:X02} Magic Effect", i);
 
                 if (dataPtr == 0)

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageMagicFEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageMagicFEditorViewModel.cs
@@ -270,21 +270,32 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
             // Read dim pointer from the pointer-table slot (WF
             // AddressList_SelectedIndexChanged: `uint dim = Program.ROM.p32(ar.tag)`).
-            uint dataPtr = rom.p32(pointerSlotAddr);
-            if (_magicSystemDetected && dataPtr == _dimAddr)
+            // When pointerSlotAddr == 0 (LoadEntry(uint) convenience
+            // overload), treat it as "unknown slot" and force Empty so
+            // we don't read ROM offset 0 (header data) and misinterpret
+            // it as a dim pointer (Copilot bot review on PR #554).
+            if (pointerSlotAddr == 0u)
             {
-                // WF semantics: the FEditor signature's `dim` field
-                // surfaces as `dim_pc` (player-cast); `no_dim` surfaces
-                // as `dim`.
-                DimPointer = DimPointerKind.DimPc;
-            }
-            else if (_magicSystemDetected && dataPtr == _noDimAddr)
-            {
-                DimPointer = DimPointerKind.Dim;
+                DimPointer = DimPointerKind.Empty;
             }
             else
             {
-                DimPointer = DimPointerKind.Empty;
+                uint dataPtr = rom.p32(pointerSlotAddr);
+                if (_magicSystemDetected && dataPtr == _dimAddr)
+                {
+                    // WF semantics: the FEditor signature's `dim` field
+                    // surfaces as `dim_pc` (player-cast); `no_dim`
+                    // surfaces as `dim`.
+                    DimPointer = DimPointerKind.DimPc;
+                }
+                else if (_magicSystemDetected && dataPtr == _noDimAddr)
+                {
+                    DimPointer = DimPointerKind.Dim;
+                }
+                else
+                {
+                    DimPointer = DimPointerKind.Empty;
+                }
             }
 
             // Read the P0..P16 fields from the CSA spell-table entry

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageMagicFEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageMagicFEditorViewModel.cs
@@ -304,10 +304,14 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
         /// <summary>
         /// Convenience overload — the view code-behind may only have the
-        /// CSA entry address (e.g. NavigateTo path). When the pointer
-        /// slot isn't provided, dim-pointer reads/writes are skipped.
+        /// CSA entry address (e.g. NavigateTo path). The pointer-slot
+        /// address is explicitly cleared to 0 so a stale
+        /// `_pointerSlotAddr` from a previous selection cannot leak
+        /// into dim-pointer reads/writes against the wrong row (Copilot
+        /// bot review #2 on PR #554). `Write()` skips the pointer-slot
+        /// branch when `PointerSlotAddr == 0`.
         /// </summary>
-        public void LoadEntry(uint addr) => LoadEntry(addr, _pointerSlotAddr);
+        public void LoadEntry(uint addr) => LoadEntry(addr, 0u);
 
         /// <summary>
         /// Persist the editor row. Mirrors WF `N_WriteButton_Click`:

--- a/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml
@@ -109,13 +109,13 @@
             <!-- Row 2: zoom combo -->
             <Label Grid.Row="2" Grid.Column="0" Content="Zoom" VerticalAlignment="Center"
                    Margin="0,4,0,0" />
+            <!-- Items populated from code-behind with R._(...) so
+                 ja/zh translations apply (ViewTranslationHelper doesn't
+                 translate ComboBoxItem.Content). -->
             <ComboBox Grid.Row="2" Grid.Column="1"
                       AutomationProperties.AutomationId="ImageMagicFEditor_Zoom_Combo"
-                      Name="ZoomCombo" Width="200" SelectedIndex="0"
-                      HorizontalAlignment="Left" Margin="0,4,0,0">
-              <ComboBoxItem Content="Zoom and Draw" />
-              <ComboBoxItem Content="Draw without enlarging" />
-            </ComboBox>
+                      Name="ZoomCombo" Width="200"
+                      HorizontalAlignment="Left" Margin="0,4,0,0" />
 
             <!-- Row 3: sample-preview label -->
             <Label Grid.Row="3" Grid.Column="0" Content="Display Example" VerticalAlignment="Center"
@@ -131,15 +131,13 @@
         <Border BorderBrush="Gray" BorderThickness="1" Padding="6">
           <Grid ColumnDefinitions="200,*" RowDefinitions="Auto,Auto">
             <Label Grid.Row="0" Grid.Column="0" Content="dim" VerticalAlignment="Center" />
+            <!-- Items populated from code-behind with R._(...) so
+                 ja/zh translations apply. -->
             <ComboBox Grid.Row="0" Grid.Column="1"
                       AutomationProperties.AutomationId="ImageMagicFEditor_Dim_Combo"
                       Name="DimCombo" Width="200"
-                      HorizontalAlignment="Left" SelectedIndex="0"
-                      SelectionChanged="DimCombo_SelectionChanged">
-              <ComboBoxItem Content="dim_pc" />
-              <ComboBoxItem Content="dim" />
-              <ComboBoxItem Content="NULL (EMPTY)" />
-            </ComboBox>
+                      HorizontalAlignment="Left"
+                      SelectionChanged="DimCombo_SelectionChanged" />
 
             <Label Grid.Row="1" Grid.Column="0" Content="Comment" VerticalAlignment="Center"
                    Margin="0,4,0,0" />

--- a/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml
@@ -93,7 +93,7 @@
             <Border Grid.Row="0" Grid.Column="1"
                     BorderBrush="DarkGray" BorderThickness="1"
                     Width="400" Height="188" HorizontalAlignment="Left">
-              <Image AutomationProperties.AutomationId="ImageMagicFEditor_PreviewImage"
+              <Image AutomationProperties.AutomationId="ImageMagicFEditor_Preview_Image"
                      Name="PreviewImage" Stretch="Uniform" />
             </Border>
 

--- a/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml
@@ -70,6 +70,8 @@
         <Button DockPanel.Dock="Bottom"
                 AutomationProperties.AutomationId="ImageMagicFEditor_MagicListExpand_Button"
                 Name="MagicListExpandButton" Content="Expand List"
+                IsEnabled="False"
+                ToolTip.Tip="Pending Core extraction - tracked by #500."
                 Click="MagicListExpand_Click" HorizontalAlignment="Stretch"
                 Margin="2" IsVisible="True" />
         <controls:AddressListControl

--- a/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml
@@ -2,19 +2,218 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
         x:Class="FEBuilderGBA.Avalonia.Views.ImageMagicFEditorView"
-        Title="Magic Effect Editor (FEditor)" Width="835" Height="403"
+        Title="Magic Effect Editor (FEditor)" Width="1080" Height="720"
         SizeToContent="WidthAndHeight">
-  <Grid ColumnDefinitions="250,*">
-    <controls:AddressListControl AutomationProperties.AutomationId="ImageMagicFEditor_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
+  <!-- Three-row layout: top read-config bar / address-write bar / main 3-pane grid.
+       Mirrors WF panel3 (top read), panel5 (address-write), panel8 (entry list +
+       list-expand), and DragTargetPanel (right detail surface). Gap-sweep fix
+       for #418 — raises AV control count from 3 to 30+. -->
+  <Grid RowDefinitions="Auto,Auto,*" ColumnDefinitions="250,*">
 
-    <ScrollViewer Grid.Column="1" Margin="4">
+    <!-- ===== Row 0: top read-config bar (mirrors WF panel3) ===== -->
+    <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
+      <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
+        <Label Content="Top Address" VerticalAlignment="Center" />
+        <NumericUpDown AutomationProperties.AutomationId="ImageMagicFEditor_ReadStart_Input"
+                       FormatString="0" Name="ReadStartAddressBox" Width="140"
+                       Minimum="0" Maximum="4294967295"
+                       IsEnabled="False" VerticalAlignment="Center" />
+        <Label Content="Read Count" VerticalAlignment="Center" />
+        <NumericUpDown AutomationProperties.AutomationId="ImageMagicFEditor_ReadCount_Input"
+                       FormatString="0" Name="ReadCountBox" Width="80"
+                       Minimum="0" Maximum="256"
+                       IsEnabled="False" VerticalAlignment="Center" />
+        <Button AutomationProperties.AutomationId="ImageMagicFEditor_ReloadList_Button"
+                Name="ReloadListButton" Content="Reload" Click="ReloadList_Click" />
+        <TextBlock AutomationProperties.AutomationId="ImageMagicFEditor_PatchNotice_Label"
+                   Name="PatchNoticeLabel" Foreground="DarkOrange"
+                   TextWrapping="Wrap" VerticalAlignment="Center" Margin="12,0,0,0" />
+      </StackPanel>
+    </Border>
+
+    <!-- ===== Row 1: main address-write bar (mirrors WF panel5) ===== -->
+    <Border Grid.Row="1" Grid.Column="1" BorderBrush="Gray" BorderThickness="1" Margin="4">
+      <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
+        <Label Content="Address" VerticalAlignment="Center" />
+        <NumericUpDown AutomationProperties.AutomationId="ImageMagicFEditor_Address_Input"
+                       FormatString="0" Name="AddressBox" Width="140"
+                       Minimum="0" Maximum="4294967295"
+                       IsEnabled="False" VerticalAlignment="Center" />
+        <Label Content="Size:" VerticalAlignment="Center" />
+        <TextBox AutomationProperties.AutomationId="ImageMagicFEditor_BlockSize_Input"
+                 Name="BlockSizeBox" IsReadOnly="True" Text="4" Width="60"
+                 VerticalAlignment="Center" />
+        <Label Content="Selected Address:" VerticalAlignment="Center" />
+        <TextBox AutomationProperties.AutomationId="ImageMagicFEditor_SelectedAddress_Input"
+                 Name="SelectedAddressBox" IsReadOnly="True" Width="140"
+                 VerticalAlignment="Center" />
+        <Button AutomationProperties.AutomationId="ImageMagicFEditor_Write_Button"
+                Name="WriteButton" Content="Write to ROM" Click="Write_Click"
+                Margin="20,0,0,0" />
+        <TextBlock AutomationProperties.AutomationId="ImageMagicFEditor_Addr_Label"
+                   Name="AddrLabel" VerticalAlignment="Center" Margin="20,0,0,0" />
+      </StackPanel>
+    </Border>
+
+    <!-- ===== Row 2 col 0: entry list + List-Expand (mirrors WF panel8) ===== -->
+    <Border Grid.Row="2" Grid.Column="0" BorderBrush="Gray" BorderThickness="1" Margin="4">
+      <DockPanel>
+        <Label DockPanel.Dock="Top"
+               AutomationProperties.AutomationId="ImageMagicFEditor_NameHeader_Label"
+               Content="Name" />
+        <TextBlock DockPanel.Dock="Bottom"
+                   AutomationProperties.AutomationId="ImageMagicFEditor_LinkInternet_Label"
+                   Name="LinkInternetLabel" Margin="2"
+                   Foreground="Blue" TextDecorations="Underline"
+                   Text="Search Internet for new resources"
+                   PointerPressed="LinkInternet_Click" />
+        <Button DockPanel.Dock="Bottom"
+                AutomationProperties.AutomationId="ImageMagicFEditor_MagicListExpand_Button"
+                Name="MagicListExpandButton" Content="Expand List"
+                Click="MagicListExpand_Click" HorizontalAlignment="Stretch"
+                Margin="2" IsVisible="True" />
+        <controls:AddressListControl
+            AutomationProperties.AutomationId="ImageMagicFEditor_Entry_List"
+            Name="EntryList" Margin="2" />
+      </DockPanel>
+    </Border>
+
+    <!-- ===== Row 2 col 1: main detail / preview / buttons (mirrors WF DragTargetPanel) ===== -->
+    <ScrollViewer Grid.Row="2" Grid.Column="1">
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Magic Effect Editor (FEditor)" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="ImageMagicFEditor_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
-        </Grid>
+        <!-- Preview pane + frame controls -->
+        <Border BorderBrush="Gray" BorderThickness="1" Padding="6">
+          <Grid ColumnDefinitions="200,*" RowDefinitions="Auto,Auto,Auto,Auto">
+            <!-- Row 0: preview image -->
+            <Label Grid.Row="0" Grid.Column="0" Content="Sample" VerticalAlignment="Top" />
+            <Border Grid.Row="0" Grid.Column="1"
+                    BorderBrush="DarkGray" BorderThickness="1"
+                    Width="400" Height="188" HorizontalAlignment="Left">
+              <Image AutomationProperties.AutomationId="ImageMagicFEditor_PreviewImage"
+                     Name="PreviewImage" Stretch="Uniform" />
+            </Border>
+
+            <!-- Row 1: frame controls -->
+            <Label Grid.Row="1" Grid.Column="0" Content="Frame" VerticalAlignment="Center"
+                   Margin="0,4,0,0" />
+            <NumericUpDown Grid.Row="1" Grid.Column="1"
+                           AutomationProperties.AutomationId="ImageMagicFEditor_Frame_Input"
+                           FormatString="0" Name="FrameBox" Width="100"
+                           Minimum="0" Maximum="255" HorizontalAlignment="Left"
+                           Margin="0,4,0,0" />
+
+            <!-- Row 2: zoom combo -->
+            <Label Grid.Row="2" Grid.Column="0" Content="Zoom" VerticalAlignment="Center"
+                   Margin="0,4,0,0" />
+            <ComboBox Grid.Row="2" Grid.Column="1"
+                      AutomationProperties.AutomationId="ImageMagicFEditor_Zoom_Combo"
+                      Name="ZoomCombo" Width="200" SelectedIndex="0"
+                      HorizontalAlignment="Left" Margin="0,4,0,0">
+              <ComboBoxItem Content="Zoom and Draw" />
+              <ComboBoxItem Content="Draw without enlarging" />
+            </ComboBox>
+
+            <!-- Row 3: sample-preview label -->
+            <Label Grid.Row="3" Grid.Column="0" Content="Display Example" VerticalAlignment="Center"
+                   Margin="0,4,0,0" />
+            <TextBlock Grid.Row="3" Grid.Column="1"
+                       AutomationProperties.AutomationId="ImageMagicFEditor_SamplePreview_Label"
+                       Name="SamplePreviewLabel" Text="(preview deferred - tracked by #500)"
+                       Foreground="DarkOrange" Margin="0,4,0,0" />
+          </Grid>
+        </Border>
+
+        <!-- dim + comment row -->
+        <Border BorderBrush="Gray" BorderThickness="1" Padding="6">
+          <Grid ColumnDefinitions="200,*" RowDefinitions="Auto,Auto">
+            <Label Grid.Row="0" Grid.Column="0" Content="dim" VerticalAlignment="Center" />
+            <ComboBox Grid.Row="0" Grid.Column="1"
+                      AutomationProperties.AutomationId="ImageMagicFEditor_Dim_Combo"
+                      Name="DimCombo" Width="200"
+                      HorizontalAlignment="Left" SelectedIndex="0"
+                      SelectionChanged="DimCombo_SelectionChanged">
+              <ComboBoxItem Content="dim_pc" />
+              <ComboBoxItem Content="dim" />
+              <ComboBoxItem Content="NULL (EMPTY)" />
+            </ComboBox>
+
+            <Label Grid.Row="1" Grid.Column="0" Content="Comment" VerticalAlignment="Center"
+                   Margin="0,4,0,0" />
+            <TextBox Grid.Row="1" Grid.Column="1"
+                     AutomationProperties.AutomationId="ImageMagicFEditor_Comment_Input"
+                     Name="CommentBox" Width="300" HorizontalAlignment="Left"
+                     Margin="0,4,0,0" />
+          </Grid>
+        </Border>
+
+        <!-- 5-row spinner grid for FrameData / OBJRightToLeft / OBJLeftToRight / OBJBGRightToLeft / OBBGLeftToRight -->
+        <Border BorderBrush="Gray" BorderThickness="1" Padding="6">
+          <Grid ColumnDefinitions="200,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+            <!-- Row 0: P0 — FrameData -->
+            <Label Grid.Row="0" Grid.Column="0" Content="FrameData" VerticalAlignment="Center" />
+            <NumericUpDown Grid.Row="0" Grid.Column="1"
+                           AutomationProperties.AutomationId="ImageMagicFEditor_P0_Input"
+                           FormatString="0" Name="P0Box" Width="160" HorizontalAlignment="Left"
+                           Minimum="0" Maximum="4294967295" />
+            <!-- Row 1: P4 — OBJRightToLeft -->
+            <Label Grid.Row="1" Grid.Column="0" Content="OBJRightToLeft" VerticalAlignment="Center"
+                   Margin="0,4,0,0" />
+            <NumericUpDown Grid.Row="1" Grid.Column="1"
+                           AutomationProperties.AutomationId="ImageMagicFEditor_P4_Input"
+                           FormatString="0" Name="P4Box" Width="160" HorizontalAlignment="Left"
+                           Minimum="0" Maximum="4294967295" Margin="0,4,0,0" />
+            <!-- Row 2: P8 — OBJLeftToRight -->
+            <Label Grid.Row="2" Grid.Column="0" Content="OBJLeftToRight" VerticalAlignment="Center"
+                   Margin="0,4,0,0" />
+            <NumericUpDown Grid.Row="2" Grid.Column="1"
+                           AutomationProperties.AutomationId="ImageMagicFEditor_P8_Input"
+                           FormatString="0" Name="P8Box" Width="160" HorizontalAlignment="Left"
+                           Minimum="0" Maximum="4294967295" Margin="0,4,0,0" />
+            <!-- Row 3: P12 — OBJBGRightToLeft -->
+            <Label Grid.Row="3" Grid.Column="0" Content="OBJBGRightToLeft" VerticalAlignment="Center"
+                   Margin="0,4,0,0" />
+            <NumericUpDown Grid.Row="3" Grid.Column="1"
+                           AutomationProperties.AutomationId="ImageMagicFEditor_P12_Input"
+                           FormatString="0" Name="P12Box" Width="160" HorizontalAlignment="Left"
+                           Minimum="0" Maximum="4294967295" Margin="0,4,0,0" />
+            <!-- Row 4: P16 — OBBGLeftToRight -->
+            <Label Grid.Row="4" Grid.Column="0" Content="OBBGLeftToRight" VerticalAlignment="Center"
+                   Margin="0,4,0,0" />
+            <NumericUpDown Grid.Row="4" Grid.Column="1"
+                           AutomationProperties.AutomationId="ImageMagicFEditor_P16_Input"
+                           FormatString="0" Name="P16Box" Width="160" HorizontalAlignment="Left"
+                           Minimum="0" Maximum="4294967295" Margin="0,4,0,0" />
+          </Grid>
+        </Border>
+
+        <!-- File / shell / editor action buttons (deferred - tracked by #500) -->
+        <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
+          <Button AutomationProperties.AutomationId="ImageMagicFEditor_MagicAnimeImport_Button"
+                  Name="MagicAnimeImportButton" Content="Import Magic Animation"
+                  IsEnabled="False"
+                  ToolTip.Tip="Pending Core extraction - tracked by #500."
+                  Click="MagicAnimeImport_Click" />
+          <Button AutomationProperties.AutomationId="ImageMagicFEditor_MagicAnimeExport_Button"
+                  Name="MagicAnimeExportButton" Content="Export Magic Animation"
+                  IsEnabled="False"
+                  ToolTip.Tip="Pending Core extraction - tracked by #500."
+                  Click="MagicAnimeExport_Click" />
+          <Button AutomationProperties.AutomationId="ImageMagicFEditor_JumpEditor_Button"
+                  Name="JumpEditorButton" Content="Editor"
+                  Click="JumpEditor_Click" />
+          <Button AutomationProperties.AutomationId="ImageMagicFEditor_OpenSource_Button"
+                  Name="OpenSourceButton" Content="Open Source File"
+                  IsEnabled="False"
+                  ToolTip.Tip="Pending Core extraction - tracked by #500."
+                  Click="OpenSource_Click" />
+          <Button AutomationProperties.AutomationId="ImageMagicFEditor_SelectSource_Button"
+                  Name="SelectSourceButton" Content="Open Source Folder"
+                  IsEnabled="False"
+                  ToolTip.Tip="Pending Core extraction - tracked by #500."
+                  Click="SelectSource_Click" />
+        </StackPanel>
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml.cs
@@ -69,7 +69,10 @@ namespace FEBuilderGBA.Avalonia.Views
             P12Box.IsEnabled = ok;
             P16Box.IsEnabled = ok;
             FrameBox.IsEnabled = ok;
-            MagicListExpandButton.IsEnabled = ok;
+            // MagicListExpandButton is intentionally NOT re-enabled here -
+            // the underlying ExpandsArea call is WF-coupled and tracked by
+            // #500 (Copilot CLI review on PR #554 #4). The AXAML keeps
+            // IsEnabled="False" + ToolTip.Tip referencing #500.
         }
 
         void UpdatePatchNotice()

--- a/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml.cs
@@ -182,12 +182,17 @@ namespace FEBuilderGBA.Avalonia.Views
                 _undoService.Commit();
                 _vm.MarkClean();
 
-                // Reload so the entry list / patch notice reflect the
-                // new state (e.g. switching from EMPTY to dim moves the
-                // row in/out of the listing).
+                // Reload the entry list AND the current entry so the
+                // listing reflects the new state (e.g. switching from
+                // EMPTY to dim adds/removes the row from the listing
+                // via LoadList's filter pass), then re-display the
+                // freshly-saved row. (Copilot CLI re-review on PR #554
+                // noted that reloading only the entry didn't refresh
+                // the list as the original comment claimed.)
                 _vm.IsLoading = true;
                 try
                 {
+                    EntryList.SetItems(_vm.LoadList());
                     _vm.LoadEntry(reloadCsa, reloadSlot);
                     UpdateUI();
                 }

--- a/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml.cs
@@ -26,6 +26,22 @@ namespace FEBuilderGBA.Avalonia.Views
         public ImageMagicFEditorView()
         {
             InitializeComponent();
+            // Populate ComboBox items via R._() so ja/zh translations
+            // apply (ViewTranslationHelper doesn't translate
+            // ComboBoxItem.Content). Copilot bot review #3/#4 on PR #554.
+            ZoomCombo.ItemsSource = new[]
+            {
+                R._("Zoom and Draw"),
+                R._("Draw without enlarging"),
+            };
+            ZoomCombo.SelectedIndex = 0;
+            DimCombo.ItemsSource = new[]
+            {
+                R._("dim_pc"),
+                R._("dim"),
+                R._("NULL (EMPTY)"),
+            };
+            DimCombo.SelectedIndex = 0;
             EntryList.SelectedAddressChanged += OnSelected;
             Opened += (_, _) => LoadList();
         }
@@ -200,7 +216,12 @@ namespace FEBuilderGBA.Avalonia.Views
                 try
                 {
                     EntryList.SetItems(_vm.LoadList());
-                    _vm.LoadEntry(reloadCsa, reloadSlot);
+                    // Re-select the row we just wrote so the entry list
+                    // selection stays in sync with the detail panel.
+                    // SelectAddress raises SelectedAddressChanged which
+                    // calls OnSelected → LoadEntry; no need for the
+                    // direct call (Copilot bot review on PR #554).
+                    EntryList.SelectAddress(reloadCsa);
                     UpdateUI();
                 }
                 finally { _vm.IsLoading = false; _vm.MarkClean(); }

--- a/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml.cs
@@ -37,14 +37,39 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 var items = _vm.LoadList();
                 EntryList.SetItems(items);
+                ReadStartAddressBox.Value = _vm.ReadStartAddress;
+                ReadCountBox.Value = _vm.ReadCount;
                 UpdatePatchNotice();
                 UpdateListExpandVisibility();
+                UpdateWriteControlsEnabled();
             }
             catch (Exception ex)
             {
                 Log.Error("ImageMagicFEditorView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
+        }
+
+        /// <summary>
+        /// When the FEditor/SCA_Creator patch is absent the editor must
+        /// not let the user trigger a Write — the dim/no-dim addresses
+        /// resolve to U.NOT_FOUND and the row pointer would be corrupted.
+        /// Mirrors the WF behavior of bailing out of `WriteDim()` when
+        /// the patch isn't detected (Copilot bot review on PR #554).
+        /// </summary>
+        void UpdateWriteControlsEnabled()
+        {
+            bool ok = _vm.MagicSystemDetected;
+            WriteButton.IsEnabled = ok;
+            DimCombo.IsEnabled = ok;
+            CommentBox.IsEnabled = ok;
+            P0Box.IsEnabled = ok;
+            P4Box.IsEnabled = ok;
+            P8Box.IsEnabled = ok;
+            P12Box.IsEnabled = ok;
+            P16Box.IsEnabled = ok;
+            FrameBox.IsEnabled = ok;
+            MagicListExpandButton.IsEnabled = ok;
         }
 
         void UpdatePatchNotice()
@@ -74,7 +99,15 @@ namespace FEBuilderGBA.Avalonia.Views
             _vm.IsLoading = true;
             try
             {
-                _vm.LoadEntry(addr);
+                // AddressListControl.SelectedAddressChanged fires with the
+                // AddrResult.addr value (CSA entry). The pointer-table slot
+                // lives in AddrResult.tag; we need both to drive the VM
+                // correctly (dim pointer goes to tag, comment + P0..P16 go
+                // to addr). Mirrors WF AddressList_SelectedIndexChanged.
+                AddrResult? selected = EntryList.SelectedItem;
+                uint csaEntry = selected?.addr ?? addr;
+                uint pointerSlot = selected?.tag ?? addr;
+                _vm.LoadEntry(csaEntry, pointerSlot);
                 UpdateUI();
             }
             catch (Exception ex)
@@ -86,9 +119,14 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void UpdateUI()
         {
+            // WF semantics:
+            //   - Address NumericUpDown shows the CSA entry address (ar.addr).
+            //   - Selected Address textbox shows the pointer-table slot (ar.tag).
+            // Both diverge once selection plumbing is correct (Copilot bot
+            // review on PR #554).
             AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
             AddressBox.Value = _vm.CurrentAddr;
-            SelectedAddressBox.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            SelectedAddressBox.Text = string.Format("0x{0:X08}", _vm.PointerSlotAddr);
             CommentBox.Text = _vm.Comment ?? string.Empty;
             DimCombo.SelectedIndex = (int)_vm.DimPointer;
             P0Box.Value = _vm.P0;
@@ -117,7 +155,12 @@ namespace FEBuilderGBA.Avalonia.Views
         void Write_Click(object? sender, RoutedEventArgs e)
         {
             if (!_vm.IsLoaded || _vm.CurrentAddr == 0u) return;
-            uint reloadAddr = _vm.CurrentAddr;
+            // Patch-absence guard: WF bails out of WriteDim() when the
+            // FEditor/SCA_Creator patch isn't detected; mirror that to
+            // avoid silently writing 0xFFFFFFFF as the dim pointer.
+            if (!_vm.MagicSystemDetected) return;
+            uint reloadCsa = _vm.CurrentAddr;
+            uint reloadSlot = _vm.PointerSlotAddr;
             _undoService.Begin("Edit Magic Effect (FEditor)");
             try
             {
@@ -127,6 +170,11 @@ namespace FEBuilderGBA.Avalonia.Views
                 int dimIdx = DimCombo.SelectedIndex;
                 if (dimIdx >= 0)
                     _vm.DimPointer = (ImageMagicFEditorViewModel.DimPointerKind)dimIdx;
+                _vm.P0 = (uint)(P0Box.Value ?? 0);
+                _vm.P4 = (uint)(P4Box.Value ?? 0);
+                _vm.P8 = (uint)(P8Box.Value ?? 0);
+                _vm.P12 = (uint)(P12Box.Value ?? 0);
+                _vm.P16 = (uint)(P16Box.Value ?? 0);
                 _vm.Write();
                 _undoService.Commit();
                 _vm.MarkClean();
@@ -137,7 +185,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.IsLoading = true;
                 try
                 {
-                    _vm.LoadEntry(reloadAddr);
+                    _vm.LoadEntry(reloadCsa, reloadSlot);
                     UpdateUI();
                 }
                 finally { _vm.IsLoading = false; _vm.MarkClean(); }

--- a/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml.cs
@@ -1,5 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Avalonia counterpart of WinForms ImageMagicFEditorForm. Gap-sweep
+// fix (#418) - rebuilds this view from a 3-control stub into a full
+// editor surface mirroring the WF panel3 / panel5 / panel8 /
+// DragTargetPanel layout.
 using System;
 using global::Avalonia.Controls;
+using global::Avalonia.Input;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
@@ -9,9 +15,13 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class ImageMagicFEditorView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ImageMagicFEditorViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
+        // Window title shown in editor docks + accessed by MCP /
+        // UIAutomation screenshot tooling.
         public string ViewTitle => "Magic Effect Editor (FEditor)";
         public bool IsLoaded => _vm.IsLoaded;
+        public ViewModelBase? DataViewModel => _vm;
 
         public ImageMagicFEditorView()
         {
@@ -22,19 +32,46 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void LoadList()
         {
+            _vm.IsLoading = true;
             try
             {
                 var items = _vm.LoadList();
                 EntryList.SetItems(items);
+                UpdatePatchNotice();
+                UpdateListExpandVisibility();
             }
             catch (Exception ex)
             {
                 Log.Error("ImageMagicFEditorView.LoadList failed: {0}", ex.Message);
             }
+            finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
+
+        void UpdatePatchNotice()
+        {
+            if (_vm.MagicSystemDetected)
+            {
+                PatchNoticeLabel.Text = "";
+            }
+            else
+            {
+                PatchNoticeLabel.Text = "FEditor / SCA_Creator magic-system patch not detected. Install the patch via the Patches manager.";
+            }
+        }
+
+        void UpdateListExpandVisibility()
+        {
+            // The List Expansion button is only useful while the
+            // spell-data table is at its original per-version size.
+            // Mirrors WF `MagicListExpandsButton.Enabled` check.
+            MagicListExpandButton.IsVisible = !_vm.IsListExpanded;
+        }
+
+        void ReloadList_Click(object? sender, RoutedEventArgs e) => LoadList();
 
         void OnSelected(uint addr)
         {
+            _vm.IsLoading = true;
             try
             {
                 _vm.LoadEntry(addr);
@@ -44,15 +81,145 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 Log.Error("ImageMagicFEditorView.OnSelected failed: {0}", ex.Message);
             }
+            finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
 
         void UpdateUI()
         {
             AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            AddressBox.Value = _vm.CurrentAddr;
+            SelectedAddressBox.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            CommentBox.Text = _vm.Comment ?? string.Empty;
+            DimCombo.SelectedIndex = (int)_vm.DimPointer;
+            P0Box.Value = _vm.P0;
+            P4Box.Value = _vm.P4;
+            P8Box.Value = _vm.P8;
+            P12Box.Value = _vm.P12;
+            P16Box.Value = _vm.P16;
+            FrameBox.Value = _vm.Frame;
+        }
+
+        void DimCombo_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            // The combo's SelectedIndex == 0/1/2 mapping matches
+            // DimPointerKind { DimPc=0, Dim=1, Empty=2 }. Use sender
+            // because the AXAML parser fires the event during EndInit
+            // BEFORE the AvaloniaNameSourceGenerator wires the named
+            // `DimCombo` field, so `DimCombo` would NPE here. The
+            // `_vm` guard tolerates the same EndInit-time invocation.
+            if (_vm == null) return;
+            if (sender is not ComboBox combo) return;
+            int idx = combo.SelectedIndex;
+            if (idx < 0) return;
+            _vm.DimPointer = (ImageMagicFEditorViewModel.DimPointerKind)idx;
+        }
+
+        void Write_Click(object? sender, RoutedEventArgs e)
+        {
+            if (!_vm.IsLoaded || _vm.CurrentAddr == 0u) return;
+            uint reloadAddr = _vm.CurrentAddr;
+            _undoService.Begin("Edit Magic Effect (FEditor)");
+            try
+            {
+                // Pull the editable fields back from the controls so
+                // user edits land on the VM before persistence.
+                _vm.Comment = CommentBox.Text ?? string.Empty;
+                int dimIdx = DimCombo.SelectedIndex;
+                if (dimIdx >= 0)
+                    _vm.DimPointer = (ImageMagicFEditorViewModel.DimPointerKind)dimIdx;
+                _vm.Write();
+                _undoService.Commit();
+                _vm.MarkClean();
+
+                // Reload so the entry list / patch notice reflect the
+                // new state (e.g. switching from EMPTY to dim moves the
+                // row in/out of the listing).
+                _vm.IsLoading = true;
+                try
+                {
+                    _vm.LoadEntry(reloadAddr);
+                    UpdateUI();
+                }
+                finally { _vm.IsLoading = false; _vm.MarkClean(); }
+
+                CoreState.Services?.ShowInfo("Magic effect written.");
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("ImageMagicFEditorView.Write: {0}", ex.Message);
+            }
+        }
+
+        void MagicListExpand_Click(object? sender, RoutedEventArgs e)
+        {
+            _undoService.Begin("Magic List Expansion");
+            try
+            {
+                // Real spell-data + CSA-table expansion is WF-coupled
+                // (InputFormRef.ExpandsArea) - tracked at #500. Logging
+                // the request keeps the undo scope wired so a later
+                // Core extraction can drop in without retrofitting.
+                Log.Debug("ImageMagicFEditorView.MagicListExpand_Click invoked - deferred until #500 lands");
+                _undoService.Commit();
+                _vm.MarkClean();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("ImageMagicFEditorView.MagicListExpand: {0}", ex.Message);
+            }
+        }
+
+        // Deferred file/shell actions - tracked by #500.
+        void MagicAnimeImport_Click(object? sender, RoutedEventArgs e)
+            => Log.Debug("ImageMagicFEditorView.MagicAnimeImport_Click - disabled until #500 lands");
+
+        void MagicAnimeExport_Click(object? sender, RoutedEventArgs e)
+            => Log.Debug("ImageMagicFEditorView.MagicAnimeExport_Click - disabled until #500 lands");
+
+        void OpenSource_Click(object? sender, RoutedEventArgs e)
+            => Log.Debug("ImageMagicFEditorView.OpenSource_Click - disabled until #500 lands");
+
+        void SelectSource_Click(object? sender, RoutedEventArgs e)
+            => Log.Debug("ImageMagicFEditorView.SelectSource_Click - disabled until #500 lands");
+
+        void JumpEditor_Click(object? sender, RoutedEventArgs e)
+        {
+            // Real cross-editor jump - opens ToolAnimationCreator. The
+            // Avalonia ToolAnimationCreatorView exists but its Init()
+            // flow for MagicAnime_FEEDitor isn't wired yet (#500). The
+            // open call still surfaces the editor so users discover it.
+            try
+            {
+                WindowManager.Instance.Open<ToolAnimationCreatorView>();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImageMagicFEditorView.JumpEditor: {0}", ex.Message);
+            }
+        }
+
+        void LinkInternet_Click(object? sender, PointerPressedEventArgs e)
+        {
+            // Opens the "Find new resources on the Internet" wiki page,
+            // mirroring WF MainFormUtil.GotoMoreData().
+            try
+            {
+                const string url = "https://github.com/laqieer/FEBuilderGBA/wiki/MoreData";
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = url,
+                    UseShellExecute = true,
+                });
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImageMagicFEditorView.LinkInternet: {0}", ex.Message);
+            }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
-        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml.cs
@@ -83,7 +83,9 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             else
             {
-                PatchNoticeLabel.Text = "FEditor / SCA_Creator magic-system patch not detected. Install the patch via the Patches manager.";
+                // Wrap in R._() so ja/zh translations apply
+                // (Copilot bot review #4 on PR #554).
+                PatchNoticeLabel.Text = R._("FEditor / SCA_Creator magic-system patch not detected. Install the patch via the Patches manager.");
             }
         }
 
@@ -108,9 +110,14 @@ namespace FEBuilderGBA.Avalonia.Views
                 // correctly (dim pointer goes to tag, comment + P0..P16 go
                 // to addr). Mirrors WF AddressList_SelectedIndexChanged.
                 AddrResult? selected = EntryList.SelectedItem;
-                uint csaEntry = selected?.addr ?? addr;
-                uint pointerSlot = selected?.tag ?? addr;
-                _vm.LoadEntry(csaEntry, pointerSlot);
+                if (selected == null)
+                {
+                    // Copilot bot review #1 on PR #554 — without an
+                    // AddrResult we have no pointer-slot address; bail
+                    // out so a stray Write_Click can't corrupt ROM.
+                    return;
+                }
+                _vm.LoadEntry(selected.addr, selected.tag);
                 UpdateUI();
             }
             catch (Exception ex)

--- a/FEBuilderGBA.Core.Tests/ImageUtilMagicCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ImageUtilMagicCoreTests.cs
@@ -142,19 +142,35 @@ public class ImageUtilMagicCoreTests
     // ---------------------------------------------------------------
 
     /// <summary>
-    /// When the magic effect pointer points at exactly the original
-    /// per-version count of valid pointer entries, GetSpellDataCount
-    /// returns that count minus 1 (the 0xFF reserved row), matching
-    /// WinForms ImageUtilMagicFEditor.SpellDataCount.
+    /// When the magic-effect pointer table has `rowCount` valid
+    /// pointers followed by a 0xFFFFFFFF sentinel, GetSpellDataCount
+    /// returns `rowCount - 1` (mirroring WF
+    /// ImageUtilMagicFEditor.SpellDataCount: count is computed from
+    /// the table base, then minus 1 for the 0xFF reserved row).
+    ///
+    /// Exact-value variant — Copilot bot review on PR #554 noted that
+    /// `>= 1` would pass for many incorrect implementations. With 80
+    /// pointers + sentinel, the helper returns 79.
     /// </summary>
     [Fact]
-    public void GetSpellDataCount_AtLeastOriginalCount()
+    public void GetSpellDataCount_ReturnsRowCountMinusOne()
     {
         var rom = MakeFe8uWithMagicEffectTable(rowCount: 80);
         uint count = ImageUtilMagicCore.GetSpellDataCount(rom);
-        // The helper returns (count - 1) on the row count it found; for
-        // a synthetic table of 80 pointer slots that's 79.
-        Assert.True(count >= 1, $"expected at least 1, got {count}");
+        Assert.Equal(79u, count);
+    }
+
+    /// <summary>
+    /// With exactly 0xFE (254) valid pointers + sentinel, the helper
+    /// returns 0xFD (253) — the cap WF enforces because 0xFE/0xFF are
+    /// reserved.
+    /// </summary>
+    [Fact]
+    public void GetSpellDataCount_CapsAt0xFD()
+    {
+        var rom = MakeFe8uWithMagicEffectTable(rowCount: 0xFE);
+        uint count = ImageUtilMagicCore.GetSpellDataCount(rom);
+        Assert.Equal(0xFDu, count);
     }
 
     /// <summary>
@@ -303,9 +319,10 @@ public class ImageUtilMagicCoreTests
     }
 
     /// <summary>
-    /// FE8U ROM with a synthetic magic-effect pointer table where
-    /// every pointer slot has a valid GBA-pointer value so
-    /// GetSpellDataCount counts them as in-bounds.
+    /// FE8U ROM with a synthetic magic-effect pointer table containing
+    /// `rowCount` valid GBA pointers, followed by a `0xFFFFFFFF`
+    /// sentinel that fails U.isPointerOrNULL so
+    /// GetSpellDataCount terminates predictably at the sentinel.
     /// </summary>
     static ROM MakeFe8uWithMagicEffectTable(int rowCount)
     {
@@ -326,6 +343,13 @@ public class ImageUtilMagicCoreTests
             uint val = (0x00100000u + (uint)(i * 4)) | 0x08000000u;
             BitConverter.GetBytes(val).CopyTo(data, (int)slot);
         }
+
+        // Sentinel: 0xFFFFFFFF is the canonical "end of pointer list"
+        // marker WF SpellDataCount checks for. Place it right after
+        // the last valid pointer so the walker has a deterministic
+        // stop point.
+        uint sentinelSlot = tableAddr + (uint)(rowCount * 4);
+        BitConverter.GetBytes(0xFFFFFFFFu).CopyTo(data, (int)sentinelSlot);
 
         var rom = new ROM();
         rom.LoadLow("synthetic-fe8u-magic.gba", data, "BE8E01");

--- a/FEBuilderGBA.Core.Tests/ImageUtilMagicCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ImageUtilMagicCoreTests.cs
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for ImageUtilMagicCore — the Core-side extraction of the
+// magic-system detection helpers WinForms uses to recognise the
+// FEditorAdv / SCA_Creator magic engines and the CSA spell table
+// position. Extracted from FEBuilderGBA/ImageUtilMagic.cs to support
+// the Avalonia ImageMagicFEditorView rebuild (#418).
+//
+// We use small synthetic ROMs (LoadLow with the version selector +
+// pre-planted signature bytes at the version-specific addresses) so
+// the detection logic can run without a real Fire Emblem ROM file.
+using System;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests;
+
+[Collection("SharedState")]
+public class ImageUtilMagicCoreTests
+{
+    // ---------------------------------------------------------------
+    // SearchMagicSystem signature scans
+    // ---------------------------------------------------------------
+
+    /// <summary>
+    /// A blank FE8U ROM has no magic-system signature; detection must
+    /// report `No` and not throw.
+    /// </summary>
+    [Fact]
+    public void SearchMagicSystem_FE8U_NoSignature_ReturnsNo()
+    {
+        var rom = MakeMinimalFe8uRom();
+        var result = ImageUtilMagicCore.SearchMagicSystem(
+            rom, out uint baseaddr, out uint dimaddr, out uint nodimaddr);
+        Assert.Equal(ImageUtilMagicCore.MagicSystem.No, result);
+        Assert.Equal(U.NOT_FOUND, baseaddr);
+        Assert.Equal(U.NOT_FOUND, dimaddr);
+        Assert.Equal(U.NOT_FOUND, nodimaddr);
+    }
+
+    /// <summary>
+    /// FE8U with the FEditor signature planted at 0x95d780 and the
+    /// matching CSA spell table planted later in the ROM must detect
+    /// FEditorAdv and report the expected dim/no_dim addresses.
+    /// </summary>
+    [Fact]
+    public void SearchMagicSystem_FE8U_FEditorPlanted_ReturnsFEditorAdv()
+    {
+        var rom = MakeFe8uWithFEditorSignature();
+        var result = ImageUtilMagicCore.SearchMagicSystem(
+            rom, out uint baseaddr, out uint dimaddr, out uint nodimaddr);
+        Assert.Equal(ImageUtilMagicCore.MagicSystem.FEditorAdv, result);
+        Assert.Equal(0x95d780u, baseaddr);
+        Assert.Equal(0x95D7EDu, dimaddr);
+        Assert.Equal(0x95D8EFu, nodimaddr);
+    }
+
+    /// <summary>
+    /// FE8U with the SCA_Creator signature planted (and matching CSA
+    /// table) must detect CsaCreator.
+    /// </summary>
+    [Fact]
+    public void SearchMagicSystem_FE8U_SCACreatorPlanted_ReturnsCsaCreator()
+    {
+        var rom = MakeFe8uWithSCACreatorSignature();
+        var result = ImageUtilMagicCore.SearchMagicSystem(
+            rom, out uint baseaddr, out uint dimaddr, out uint nodimaddr);
+        Assert.Equal(ImageUtilMagicCore.MagicSystem.CsaCreator, result);
+        Assert.Equal(0x95d780u, baseaddr);
+        Assert.Equal(0x95d7edu, dimaddr);
+        Assert.Equal(0x95d899u, nodimaddr);
+    }
+
+    /// <summary>
+    /// FE7U with the FEditor signature planted at 0xCB680 must detect
+    /// FEditorAdv on the FE7U-specific signature row.
+    /// </summary>
+    [Fact]
+    public void SearchMagicSystem_FE7U_FEditorPlanted_ReturnsFEditorAdv()
+    {
+        var rom = MakeFe7uWithFEditorSignature();
+        var result = ImageUtilMagicCore.SearchMagicSystem(
+            rom, out uint baseaddr, out uint dimaddr, out uint nodimaddr);
+        Assert.Equal(ImageUtilMagicCore.MagicSystem.FEditorAdv, result);
+        Assert.Equal(0xCB680u, baseaddr);
+    }
+
+    /// <summary>
+    /// FE6 with the FEditor signature planted at 0x2DC078 must detect
+    /// FEditorAdv on the FE6-specific signature row.
+    /// </summary>
+    [Fact]
+    public void SearchMagicSystem_FE6_FEditorPlanted_ReturnsFEditorAdv()
+    {
+        var rom = MakeFe6WithFEditorSignature();
+        var result = ImageUtilMagicCore.SearchMagicSystem(
+            rom, out uint baseaddr, out uint dimaddr, out uint nodimaddr);
+        Assert.Equal(ImageUtilMagicCore.MagicSystem.FEditorAdv, result);
+        Assert.Equal(0x2DC078u, baseaddr);
+    }
+
+    // ---------------------------------------------------------------
+    // FindCSASpellTable
+    // ---------------------------------------------------------------
+
+    /// <summary>
+    /// On a blank FE8U ROM (no CSA spell table planted), the helper
+    /// must return NOT_FOUND for both the table address and the pointer
+    /// without throwing.
+    /// </summary>
+    [Fact]
+    public void FindCSASpellTable_FE8U_NoSignature_ReturnsNotFound()
+    {
+        var rom = MakeMinimalFe8uRom();
+        uint addr = ImageUtilMagicCore.FindCSASpellTable(
+            rom, ImageUtilMagicCore.MagicSystem.FEditorAdv,
+            out uint outPointer);
+        Assert.Equal(U.NOT_FOUND, addr);
+        Assert.Equal(U.NOT_FOUND, outPointer);
+    }
+
+    /// <summary>
+    /// On a FE8U ROM with the FEditor CSA pattern + a valid 4-byte
+    /// pointer planted after it, the helper must find the table and
+    /// resolve the pointer to an in-ROM offset.
+    /// </summary>
+    [Fact]
+    public void FindCSASpellTable_FE8U_FEditor_FindsPointer()
+    {
+        var rom = MakeFe8uWithFEditorSignature();
+        uint addr = ImageUtilMagicCore.FindCSASpellTable(
+            rom, ImageUtilMagicCore.MagicSystem.FEditorAdv,
+            out uint outPointer);
+        Assert.NotEqual(U.NOT_FOUND, addr);
+        Assert.NotEqual(U.NOT_FOUND, outPointer);
+        // The pointer slot we planted resolves to 0x00100000 (an arbitrary
+        // safety-offset target we put inside the synthetic ROM).
+        Assert.Equal(0x00100000u, addr);
+    }
+
+    // ---------------------------------------------------------------
+    // GetSpellDataCount
+    // ---------------------------------------------------------------
+
+    /// <summary>
+    /// When the magic effect pointer points at exactly the original
+    /// per-version count of valid pointer entries, GetSpellDataCount
+    /// returns that count minus 1 (the 0xFF reserved row), matching
+    /// WinForms ImageUtilMagicFEditor.SpellDataCount.
+    /// </summary>
+    [Fact]
+    public void GetSpellDataCount_AtLeastOriginalCount()
+    {
+        var rom = MakeFe8uWithMagicEffectTable(rowCount: 80);
+        uint count = ImageUtilMagicCore.GetSpellDataCount(rom);
+        // The helper returns (count - 1) on the row count it found; for
+        // a synthetic table of 80 pointer slots that's 79.
+        Assert.True(count >= 1, $"expected at least 1, got {count}");
+    }
+
+    /// <summary>
+    /// A null ROM (no RomInfo loaded) returns 0 instead of throwing.
+    /// </summary>
+    [Fact]
+    public void GetSpellDataCount_NullRom_ReturnsZero()
+    {
+        Assert.Equal(0u, ImageUtilMagicCore.GetSpellDataCount(null));
+    }
+
+    // ---------------------------------------------------------------
+    // Synthetic ROM helpers
+    // ---------------------------------------------------------------
+
+    /// <summary>Minimal FE8U ROM (BE8E01 + 0x1100000 zero bytes).</summary>
+    static ROM MakeMinimalFe8uRom()
+    {
+        var rom = new ROM();
+        var data = new byte[0x1100000];
+        rom.LoadLow("synthetic-fe8u.gba", data, "BE8E01");
+        return rom;
+    }
+
+    /// <summary>
+    /// FE8U ROM with the FEditor magic signature planted at 0x95d780
+    /// plus a valid CSA spell table pattern + pointer planted after
+    /// it. The pointer resolves to 0x00100000 (an in-bounds safety
+    /// offset).
+    /// </summary>
+    static ROM MakeFe8uWithFEditorSignature()
+    {
+        var data = new byte[0x1100000];
+
+        // FEditor / FE8U signature (16 bytes at 0x95d780)
+        byte[] sig = {
+            0x01, 0x00, 0x00, 0x00, 0x90, 0xD7, 0x95, 0x08,
+            0x03, 0x00, 0x00, 0x00, 0x39, 0xD9, 0x95, 0x08,
+        };
+        Array.Copy(sig, 0, data, 0x95d780, sig.Length);
+
+        // Plant the FEditor CSA spell table pattern at 0x00200000 and
+        // a 4-byte pointer to 0x00100000 immediately after it.
+        byte[] csaPat = {
+            0x01, 0xB4, 0x7D, 0xE7, 0x34, 0xFF, 0x03, 0x02,
+            0x80, 0xD7, 0x95, 0x08, 0x1A, 0xE1, 0x03, 0x02,
+        };
+        Array.Copy(csaPat, 0, data, 0x00200000, csaPat.Length);
+        // The 4 bytes immediately after the pattern hold the
+        // little-endian GBA pointer that resolves (via rom.p32 → strip
+        // the 0x08000000 high bit) to 0x00100000.
+        BitConverter.GetBytes(0x00100000u | 0x08000000u)
+            .CopyTo(data, 0x00200000 + csaPat.Length);
+
+        var rom = new ROM();
+        rom.LoadLow("synthetic-fe8u.gba", data, "BE8E01");
+        return rom;
+    }
+
+    /// <summary>
+    /// FE8U ROM with the SCA_Creator magic signature planted at
+    /// 0x95d780 plus matching CSA spell table.
+    /// </summary>
+    static ROM MakeFe8uWithSCACreatorSignature()
+    {
+        var data = new byte[0x1100000];
+
+        // SCA_Creator / FE8U signature (16 bytes at 0x95d780)
+        byte[] sig = {
+            0x01, 0x00, 0x00, 0x00, 0x90, 0xD7, 0x95, 0x08,
+            0x03, 0x00, 0x00, 0x00, 0xD9, 0xD8, 0x95, 0x08,
+        };
+        Array.Copy(sig, 0, data, 0x95d780, sig.Length);
+
+        // SCA_Creator CSA spell table pattern at 0x00200000 + pointer.
+        byte[] csaPat = {
+            0x1C, 0x58, 0x05, 0x08, 0x00, 0x01, 0x00, 0x80,
+            0xED, 0xD7, 0x95, 0x08, 0x99, 0xD8, 0x95, 0x08,
+        };
+        Array.Copy(csaPat, 0, data, 0x00200000, csaPat.Length);
+        BitConverter.GetBytes(0x00100000u | 0x08000000u)
+            .CopyTo(data, 0x00200000 + csaPat.Length);
+
+        var rom = new ROM();
+        rom.LoadLow("synthetic-fe8u.gba", data, "BE8E01");
+        return rom;
+    }
+
+    /// <summary>
+    /// FE7U ROM with the FEditor signature planted at 0xCB680 plus a
+    /// matching CSA pattern. The FE7U FEditor signature has 0x00 bytes
+    /// where the SCA_Creator variant has a dim address.
+    /// </summary>
+    static ROM MakeFe7uWithFEditorSignature()
+    {
+        var data = new byte[0x1100000];
+
+        byte[] sig = {
+            0x19, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x03, 0x00, 0x00, 0x00, 0xD9, 0xB7, 0x0C, 0x08,
+        };
+        Array.Copy(sig, 0, data, 0xCB680, sig.Length);
+
+        // FE7U FEditor CSA pattern (28 bytes — longer than the FE8U one).
+        byte[] csaPat = {
+            0x00, 0x28, 0x17, 0xD1, 0x18, 0xE0, 0x70, 0xB5,
+            0x05, 0x1C, 0x00, 0x20, 0x01, 0xB4, 0x87, 0xE7,
+            0x34, 0xFF, 0x03, 0x02, 0x80, 0xB6, 0x0C, 0x08,
+            0x26, 0xE0, 0x03, 0x02,
+        };
+        Array.Copy(csaPat, 0, data, 0x00200000, csaPat.Length);
+        BitConverter.GetBytes(0x00100000u | 0x08000000u)
+            .CopyTo(data, 0x00200000 + csaPat.Length);
+
+        var rom = new ROM();
+        rom.LoadLow("synthetic-fe7u.gba", data, "AE7E01");
+        return rom;
+    }
+
+    /// <summary>
+    /// FE6 ROM with the FEditor signature planted at 0x2DC078 plus
+    /// matching CSA pattern.
+    /// </summary>
+    static ROM MakeFe6WithFEditorSignature()
+    {
+        var data = new byte[0x1100000];
+
+        byte[] sig = {
+            0x19, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x03, 0x00, 0x00, 0x00, 0xC5, 0xC1, 0x2D, 0x08,
+        };
+        Array.Copy(sig, 0, data, 0x2DC078, sig.Length);
+
+        // FE6 FEditor CSA pattern is the same shape as the FE8U one.
+        byte[] csaPat = {
+            0xE7, 0x7D, 0xB4, 0x01, 0x34, 0xFF, 0x03, 0x02,
+            0x80, 0xD7, 0x95, 0x08, 0x1A, 0xE1, 0x03, 0x02,
+        };
+        Array.Copy(csaPat, 0, data, 0x00200000, csaPat.Length);
+        BitConverter.GetBytes(0x00100000u | 0x08000000u)
+            .CopyTo(data, 0x00200000 + csaPat.Length);
+
+        var rom = new ROM();
+        rom.LoadLow("synthetic-fe6.gba", data, "AFEJ01");
+        return rom;
+    }
+
+    /// <summary>
+    /// FE8U ROM with a synthetic magic-effect pointer table where
+    /// every pointer slot has a valid GBA-pointer value so
+    /// GetSpellDataCount counts them as in-bounds.
+    /// </summary>
+    static ROM MakeFe8uWithMagicEffectTable(int rowCount)
+    {
+        var data = new byte[0x1100000];
+
+        // RomInfo.magic_effect_pointer for FE8U is 0x0005B3F8; populate it
+        // with a pointer to 0x00200000 (where we put the pointer table).
+        uint magicPointerSlot = 0x0005B3F8u;
+        uint tableAddr = 0x00200000u;
+        BitConverter.GetBytes(tableAddr | 0x08000000u)
+            .CopyTo(data, (int)magicPointerSlot);
+
+        // Plant `rowCount` valid GBA pointers (resolving to 0x00100000
+        // + i*4, which are all in-bounds safety offsets).
+        for (int i = 0; i < rowCount; i++)
+        {
+            uint slot = tableAddr + (uint)(i * 4);
+            uint val = (0x00100000u + (uint)(i * 4)) | 0x08000000u;
+            BitConverter.GetBytes(val).CopyTo(data, (int)slot);
+        }
+
+        var rom = new ROM();
+        rom.LoadLow("synthetic-fe8u-magic.gba", data, "BE8E01");
+        return rom;
+    }
+}

--- a/FEBuilderGBA.Core/ImageUtilMagicCore.cs
+++ b/FEBuilderGBA.Core/ImageUtilMagicCore.cs
@@ -225,35 +225,11 @@ namespace FEBuilderGBA
             return count - 1;
         }
 
-        /// <summary>
-        /// Original WF data accessor — used by the WF shim in
-        /// <c>FEBuilderGBA/ImageUtilMagic.cs</c> to keep its current
-        /// cache machinery while delegating the detection logic here.
-        /// </summary>
-        internal static (string name, string ver, uint addr, byte[] data, uint dim, uint no_dim)[] GetPatchSignatures()
-        {
-            var result = new (string, string, uint, byte[], uint, uint)[PatchSignatures.Length];
-            for (int i = 0; i < PatchSignatures.Length; i++)
-            {
-                var e = PatchSignatures[i];
-                result[i] = (e.name, e.ver, e.addr, e.data, e.dim, e.no_dim);
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// CSA signature accessor for the WF shim. See
-        /// <see cref="GetPatchSignatures"/>.
-        /// </summary>
-        internal static (string name, string ver, byte[] data)[] GetCsaSignatures()
-        {
-            var result = new (string, string, byte[])[CsaSignatures.Length];
-            for (int i = 0; i < CsaSignatures.Length; i++)
-            {
-                var e = CsaSignatures[i];
-                result[i] = (e.name, e.ver, e.data);
-            }
-            return result;
-        }
+        // NOTE: GetPatchSignatures / GetCsaSignatures accessor helpers
+        // were initially defined here for the WF shim but were never
+        // wired (Copilot CLI re-review on PR #554). The WF shim in
+        // FEBuilderGBA/ImageUtilMagic.cs delegates directly to
+        // SearchMagicSystem / FindCSASpellTable above, which already
+        // expose all the information the WF cache needs.
     }
 }

--- a/FEBuilderGBA.Core/ImageUtilMagicCore.cs
+++ b/FEBuilderGBA.Core/ImageUtilMagicCore.cs
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Core-side extraction of FEBuilderGBA/ImageUtilMagic.cs's read-only
+// helpers used by the Avalonia ImageMagicFEditorView rebuild (#418).
+//
+// The original WF file lives in FEBuilderGBA/ImageUtilMagic.cs and
+// depends on System.Windows.Forms (R.ShowWarning) and the static
+// Program.ROM accessor. This Core extraction removes those couplings
+// so the same detection logic can run from Avalonia / CLI / tests.
+//
+// The WF file retains a thin shim delegating to this Core helper to
+// preserve binary signatures consumed by the rest of WinForms.
+using System;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Detects which "magic engine" patch (if any) is installed in a
+    /// ROM and locates the CSA spell-table the patch uses to drive
+    /// the per-row magic-effect editor. Read-only: no ROM writes
+    /// happen here. Used by both `FEBuilderGBA/ImageUtilMagic.cs`
+    /// (WinForms) and `FEBuilderGBA.Avalonia` (#418).
+    /// </summary>
+    public static class ImageUtilMagicCore
+    {
+        /// <summary>
+        /// Magic-engine identifier. Mirrors WF
+        /// `ImageUtilMagic.magic_system_enum`.
+        /// </summary>
+        public enum MagicSystem
+        {
+            /// <summary>No magic-engine patch installed.</summary>
+            No = 0,
+            /// <summary>FEditorAdv patch (most common).</summary>
+            FEditorAdv = 1,
+            /// <summary>SCA_Creator patch.</summary>
+            CsaCreator = 2,
+        }
+
+        /// <summary>
+        /// One row in the static signature table. Matches the WF
+        /// `MagicPatchTableSt` struct.
+        /// </summary>
+        struct MagicPatchTableSt
+        {
+            public string name;
+            public string ver;
+            public uint addr;
+            public byte[] data;
+            public uint dim;
+            public uint no_dim;
+        }
+
+        /// <summary>
+        /// One row in the CSA spell-table signature table. Matches the
+        /// WF `SpellTableSt` struct.
+        /// </summary>
+        struct SpellTableSt
+        {
+            public string name;
+            public string ver;
+            public byte[] data;
+        }
+
+        /// <summary>
+        /// Static signature table — direct port from WF
+        /// `FEBuilderGBA/ImageUtilMagic.cs:57-67`. Keep in sync if the
+        /// WF table changes (the WF shim re-uses this same data via
+        /// the static accessor below).
+        /// </summary>
+        static readonly MagicPatchTableSt[] PatchSignatures = new MagicPatchTableSt[]
+        {
+            new MagicPatchTableSt{ name = "SCA_Creator", ver = "FE8U", addr = 0x95d780u, data = new byte[]{0x01, 0x00, 0x00, 0x00, 0x90, 0xD7, 0x95, 0x08, 0x03, 0x00, 0x00, 0x00, 0xD9, 0xD8, 0x95, 0x08}, dim = 0x95d7edu, no_dim = 0x95d899u },
+            new MagicPatchTableSt{ name = "FEditor",     ver = "FE8U", addr = 0x95d780u, data = new byte[]{0x01, 0x00, 0x00, 0x00, 0x90, 0xD7, 0x95, 0x08, 0x03, 0x00, 0x00, 0x00, 0x39, 0xD9, 0x95, 0x08}, dim = 0x95D7EDu, no_dim = 0x95D8EFu },
+            new MagicPatchTableSt{ name = "SCA_Creator", ver = "FE8J", addr = 0x9cd3bcu, data = new byte[]{0x01, 0x00, 0x00, 0x00, 0xCC, 0xD3, 0x9C, 0x08, 0x03, 0x00, 0x00, 0x00, 0x15, 0xD5, 0x9C, 0x08}, dim = 0x9CD429u, no_dim = 0x9CD4D5u },
+            new MagicPatchTableSt{ name = "SCA_Creator", ver = "FE8J", addr = 0x5BDC80u, data = new byte[]{0x01, 0x00, 0x00, 0x00, 0xCC, 0xD3, 0x9C, 0x08, 0x03, 0x00, 0x00, 0x00, 0x15, 0xD5, 0x9C, 0x08}, dim = 0x5BDCEDu, no_dim = 0x5BDD99u }, // fixed version
+            new MagicPatchTableSt{ name = "FEditor",     ver = "FE8J", addr = 0xEFBE00u, data = new byte[]{0x01, 0x00, 0x00, 0x00, 0x10, 0xBE, 0xEF, 0x08, 0x03, 0x00, 0x00, 0x00, 0xB9, 0xBF, 0xEF, 0x08}, dim = 0xEFBE6Du, no_dim = 0xEFBF6Fu },
+            new MagicPatchTableSt{ name = "SCA_Creator", ver = "FE7U", addr = 0xCB680u,  data = new byte[]{0x19, 0x00, 0x00, 0x00, 0x90, 0xB6, 0x0C, 0x08, 0x03, 0x00, 0x00, 0x00, 0xD9, 0xB7, 0x0C, 0x08}, dim = 0xCB6EDu, no_dim = 0xCB799u },
+            new MagicPatchTableSt{ name = "FEditor",     ver = "FE7U", addr = 0xCB680u,  data = new byte[]{0x19, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0xD9, 0xB7, 0x0C, 0x08}, dim = 0xCB699u, no_dim = 0xCB787u },
+            new MagicPatchTableSt{ name = "FEditor",     ver = "FE7J", addr = 0xC69B4u,  data = new byte[]{0x19, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x29, 0x6B, 0x0C, 0x08}, dim = 0xC69CDu, no_dim = 0xC69CDu },
+            new MagicPatchTableSt{ name = "SCA_Creator", ver = "FE6",  addr = 0x2DC078u, data = new byte[]{0x19, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x61, 0xC1, 0x2D, 0x08}, dim = 0x2DC091u, no_dim = 0x2DC129u },
+            new MagicPatchTableSt{ name = "FEditor",     ver = "FE6",  addr = 0x2DC078u, data = new byte[]{0x19, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0xC5, 0xC1, 0x2D, 0x08}, dim = 0x2DC091u, no_dim = 0x2DC17Fu },
+        };
+
+        /// <summary>
+        /// CSA spell-table signature pattern table — port from WF
+        /// `FEBuilderGBA/ImageUtilMagic.cs:138-148`.
+        /// </summary>
+        static readonly SpellTableSt[] CsaSignatures = new SpellTableSt[]
+        {
+            new SpellTableSt{ name = "SCA_Creator", ver = "FE8U", data = new byte[]{0x1C, 0x58, 0x05, 0x08, 0x00, 0x01, 0x00, 0x80, 0xED, 0xD7, 0x95, 0x08, 0x99, 0xD8, 0x95, 0x08}},
+            new SpellTableSt{ name = "FEditor",     ver = "FE8U", data = new byte[]{0x01, 0xB4, 0x7D, 0xE7, 0x34, 0xFF, 0x03, 0x02, 0x80, 0xD7, 0x95, 0x08, 0x1A, 0xE1, 0x03, 0x02}},
+            new SpellTableSt{ name = "SCA_Creator", ver = "FE8J", data = new byte[]{0xB8, 0x67, 0x05, 0x08, 0x00, 0x01, 0x00, 0x80, 0x29, 0xD4, 0x9C, 0x08, 0xD5, 0xD4, 0x9C, 0x08}},
+            new SpellTableSt{ name = "FEditor",     ver = "FE8J", data = new byte[]{0x01, 0xB4, 0x7D, 0xE7, 0x34, 0xFF, 0x03, 0x02, 0x00, 0xBE, 0xEF, 0x08, 0x16, 0xE1, 0x03, 0x02}},
+            new SpellTableSt{ name = "SCA_Creator", ver = "FE7U", data = new byte[]{0x0C, 0x06, 0x05, 0x08, 0x00, 0x01, 0x00, 0x80, 0xED, 0xB6, 0x0C, 0x08, 0x99, 0xB7, 0x0C, 0x08}},
+            new SpellTableSt{ name = "FEditor",     ver = "FE7U", data = new byte[]{0x00, 0x28, 0x17, 0xD1, 0x18, 0xE0, 0x70, 0xB5, 0x05, 0x1C, 0x00, 0x20, 0x01, 0xB4, 0x87, 0xE7, 0x34, 0xFF, 0x03, 0x02, 0x80, 0xB6, 0x0C, 0x08, 0x26, 0xE0, 0x03, 0x02}},
+            new SpellTableSt{ name = "FEditor",     ver = "FE7J", data = new byte[]{0x01, 0xB4, 0x79, 0xE7, 0x34, 0xFF, 0x03, 0x02, 0xB4, 0x69, 0x0C, 0x08, 0xFE, 0xDF, 0x03, 0x02}},
+            new SpellTableSt{ name = "SCA_Creator", ver = "FE6",  data = new byte[]{0x48, 0x19, 0x02, 0x02, 0x00, 0x01, 0x00, 0x80, 0x91, 0xC0, 0x2D, 0x08, 0x29, 0xC1, 0x2D, 0x08}},
+            new SpellTableSt{ name = "FEditor",     ver = "FE6",  data = new byte[]{0xE7, 0x7D, 0xB4, 0x01, 0x34, 0xFF, 0x03, 0x02, 0x80, 0xD7, 0x95, 0x08, 0x1A, 0xE1, 0x03, 0x02}},
+        };
+
+        /// <summary>
+        /// Scan the given ROM for one of the magic-engine signatures.
+        /// Returns the engine type, base / dim / no-dim addresses; on
+        /// "No" all the out params are set to <c>U.NOT_FOUND</c>.
+        ///
+        /// <para>
+        /// Mirrors WF <c>ImageUtilMagic.SearchMagicSystem(out baseaddr,
+        /// out dimaddr, out nodimaddr)</c> minus the cache writes
+        /// (the WF cache is owned by the WinForms-only static class).
+        /// </para>
+        /// </summary>
+        public static MagicSystem SearchMagicSystem(ROM rom,
+            out uint baseaddr, out uint dimaddr, out uint nodimaddr)
+        {
+            baseaddr = U.NOT_FOUND;
+            dimaddr = U.NOT_FOUND;
+            nodimaddr = U.NOT_FOUND;
+
+            if (rom == null || rom.RomInfo == null || rom.Data == null)
+                return MagicSystem.No;
+
+            string version = rom.RomInfo.VersionToFilename;
+
+            foreach (var entry in PatchSignatures)
+            {
+                if (entry.ver != version) continue;
+                if ((long)entry.addr + entry.data.Length > rom.Data.Length) continue;
+
+                byte[] data = rom.getBinaryData(entry.addr, (uint)entry.data.Length);
+                if (U.memcmp(entry.data, data) != 0) continue;
+
+                MagicSystem candidate = entry.name == "FEditor"
+                    ? MagicSystem.FEditorAdv
+                    : entry.name == "SCA_Creator"
+                        ? MagicSystem.CsaCreator
+                        : MagicSystem.No;
+                if (candidate == MagicSystem.No) continue;
+
+                // The WF code requires that the CSA spell table is also
+                // findable; otherwise the patch is "broken" and we keep
+                // scanning.
+                uint csaPointer;
+                uint csaAddr = FindCSASpellTable(rom, candidate, out csaPointer);
+                if (csaAddr == U.NOT_FOUND || csaPointer == U.NOT_FOUND) continue;
+
+                baseaddr = entry.addr;
+                dimaddr = entry.dim;
+                nodimaddr = entry.no_dim;
+                return candidate;
+            }
+            return MagicSystem.No;
+        }
+
+        /// <summary>
+        /// Scan the ROM for the CSA spell-table pattern matching the
+        /// detected magic system. Returns the table address (the
+        /// resolved p32 pointer) and the pointer slot itself
+        /// (<paramref name="outPointer"/>). Both are
+        /// <c>U.NOT_FOUND</c> on a non-match.
+        ///
+        /// <para>
+        /// Mirrors WF <c>ImageUtilMagic.FindCSASpellTableLow</c>.
+        /// </para>
+        /// </summary>
+        public static uint FindCSASpellTable(ROM rom, MagicSystem system,
+            out uint outPointer)
+        {
+            outPointer = U.NOT_FOUND;
+            if (rom == null || rom.RomInfo == null || rom.Data == null) return U.NOT_FOUND;
+            if (system == MagicSystem.No) return U.NOT_FOUND;
+
+            string version = rom.RomInfo.VersionToFilename;
+            string typeName = system == MagicSystem.FEditorAdv ? "FEditor" : "SCA_Creator";
+
+            foreach (var sig in CsaSignatures)
+            {
+                if (sig.name != typeName) continue;
+                if (sig.ver != version) continue;
+
+                uint hit = U.Grep(rom.Data, sig.data, 0x10000, 0, 4);
+                if (hit == U.NOT_FOUND) continue;
+
+                uint csaSpellTablePointer = hit + (uint)sig.data.Length;
+                if (csaSpellTablePointer + 4 > rom.Data.Length) continue;
+
+                uint csaSpellTable = rom.p32(csaSpellTablePointer);
+                if (!U.isSafetyOffset(csaSpellTable, rom)) continue;
+
+                outPointer = csaSpellTablePointer;
+                return csaSpellTable;
+            }
+            return U.NOT_FOUND;
+        }
+
+        /// <summary>
+        /// Count how many pointer-or-NULL entries follow the ROM's
+        /// `magic_effect_pointer` after the original count.
+        /// Mirrors WF <c>ImageUtilMagicFEditor.SpellDataCount</c>.
+        ///
+        /// <para>
+        /// Returns 0 when the ROM is null or when the pointer table
+        /// has been wiped. Returns at most 0xFD (0xFE/0xFF reserved).
+        /// </para>
+        /// </summary>
+        public static uint GetSpellDataCount(ROM rom)
+        {
+            if (rom == null || rom.RomInfo == null) return 0u;
+            uint baseaddr = rom.p32(rom.RomInfo.magic_effect_pointer);
+            if (!U.isSafetyOffset(baseaddr, rom)) return 0u;
+
+            uint baseid = rom.RomInfo.magic_effect_original_data_count;
+            uint search = baseaddr + (baseid * 4);
+            uint p = search;
+            uint dataLen = (uint)rom.Data.Length;
+            for (; p + 4 <= dataLen; p += 4)
+            {
+                uint d = rom.u32(p);
+                if (U.isPointerOrNULL(d)) continue;
+                break;
+            }
+            uint count = (p - baseaddr) / 4;
+            if (count == 0) return 0u;
+            uint a = count - 1;
+            if (a >= 0xFD) return 0xFD;
+            return count - 1;
+        }
+
+        /// <summary>
+        /// Original WF data accessor — used by the WF shim in
+        /// <c>FEBuilderGBA/ImageUtilMagic.cs</c> to keep its current
+        /// cache machinery while delegating the detection logic here.
+        /// </summary>
+        internal static (string name, string ver, uint addr, byte[] data, uint dim, uint no_dim)[] GetPatchSignatures()
+        {
+            var result = new (string, string, uint, byte[], uint, uint)[PatchSignatures.Length];
+            for (int i = 0; i < PatchSignatures.Length; i++)
+            {
+                var e = PatchSignatures[i];
+                result[i] = (e.name, e.ver, e.addr, e.data, e.dim, e.no_dim);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// CSA signature accessor for the WF shim. See
+        /// <see cref="GetPatchSignatures"/>.
+        /// </summary>
+        internal static (string name, string ver, byte[] data)[] GetCsaSignatures()
+        {
+            var result = new (string, string, byte[])[CsaSignatures.Length];
+            for (int i = 0; i < CsaSignatures.Length; i++)
+            {
+                var e = CsaSignatures[i];
+                result[i] = (e.name, e.ver, e.data);
+            }
+            return result;
+        }
+    }
+}

--- a/FEBuilderGBA/ImageUtilMagic.cs
+++ b/FEBuilderGBA/ImageUtilMagic.cs
@@ -58,6 +58,11 @@ namespace FEBuilderGBA
                 baseaddr = U.NOT_FOUND;
                 dimaddr = U.NOT_FOUND;
                 nodimaddr = U.NOT_FOUND;
+                // Reset CSA cache fields so a previously-populated cache
+                // doesn't leak stale addresses to callers if ClearCache()
+                // wasn't called (Copilot CLI re-review on PR #554).
+                g_Cache_CSASpellTableAddr = U.NOT_FOUND;
+                g_Cache_CSASpellTablePointer = U.NOT_FOUND;
                 g_Cache_magic_system_enum = magic_system_enum.NO;
                 return g_Cache_magic_system_enum;
             }

--- a/FEBuilderGBA/ImageUtilMagic.cs
+++ b/FEBuilderGBA/ImageUtilMagic.cs
@@ -43,76 +43,35 @@ namespace FEBuilderGBA
             return SearchMagicSystem(out baseaddr, out dimaddr, out nodimaddr);
         }
 
-        public struct MagicPatchTableSt
-        {
-            public string name;
-            public string ver;
-            public uint addr;
-            public byte[] data;
-            public uint dim;
-            public uint no_dim;
-        };
+        // MagicPatchTableSt struct moved to FEBuilderGBA.Core.ImageUtilMagicCore (#418).
         public static magic_system_enum SearchMagicSystem(out uint baseaddr, out uint dimaddr, out uint nodimaddr)
         {
-            MagicPatchTableSt[] table = new MagicPatchTableSt[] { 
-                new MagicPatchTableSt{ name="SCA_Creator",	ver = "FE8U", addr = 0x95d780,data = new byte[]{0x01 ,0x00 ,0x00 ,0x00 ,0x90 ,0xD7 ,0x95 ,0x08 ,0x03 ,0x00 ,0x00 ,0x00 ,0xD9 ,0xD8 ,0x95 ,0x08},dim = 0x95d7ed,no_dim = 0x95d899},
-                new MagicPatchTableSt{ name="FEditor",	ver = "FE8U", addr = 0x95d780,data = new byte[]{0x01 ,0x00 ,0x00 ,0x00 ,0x90 ,0xD7 ,0x95 ,0x08 ,0x03 ,0x00 ,0x00 ,0x00 ,0x39 ,0xD9 ,0x95 ,0x08},dim = 0x95D7ED,no_dim = 0x95D8EF},
-                new MagicPatchTableSt{ name="SCA_Creator",	ver = "FE8J", addr = 0x9cd3bc,data = new byte[]{0x01 ,0x00 ,0x00 ,0x00 ,0xCC ,0xD3 ,0x9C ,0x08 ,0x03 ,0x00 ,0x00 ,0x00 ,0x15 ,0xD5 ,0x9C ,0x08},dim = 0x9CD429,no_dim = 0x9CD4D5},
-                new MagicPatchTableSt{ name="SCA_Creator",	ver = "FE8J", addr = 0x5BDC80,data = new byte[]{0x01 ,0x00 ,0x00 ,0x00 ,0xCC ,0xD3 ,0x9C ,0x08 ,0x03 ,0x00 ,0x00 ,0x00 ,0x15 ,0xD5 ,0x9C ,0x08},dim = 0x5BDCED,no_dim = 0x5BDD99},	//fixed version
-                new MagicPatchTableSt{ name="FEditor",	ver = "FE8J", addr = 0xEFBE00,data = new byte[]{0x01 ,0x00 ,0x00 ,0x00 ,0x10 ,0xBE ,0xEF ,0x08 ,0x03 ,0x00 ,0x00 ,0x00 ,0xB9 ,0xBF ,0xEF ,0x08},dim = 0xEFBE6D,no_dim = 0xEFBF6F},
-                new MagicPatchTableSt{ name="SCA_Creator",	ver = "FE7U", addr = 0xCB680,data = new byte[]{0x19 ,0x00 ,0x00 ,0x00 ,0x90 ,0xB6 ,0x0C ,0x08 ,0x03 ,0x00 ,0x00 ,0x00 ,0xD9 ,0xB7 ,0x0C ,0x08},dim = 0xCB6ED,no_dim = 0xCB799},
-                new MagicPatchTableSt{ name="FEditor",	ver = "FE7U", addr = 0xCB680,data =     new byte[]{0x19, 0x00, 0x00, 0x00, 0x00 ,0x00 ,0x00 ,0x00 ,0x03 ,0x00 ,0x00 ,0x00 ,0xD9 ,0xB7 ,0x0C ,0x08},dim = 0xCB699,no_dim = 0xCB787},
-                new MagicPatchTableSt{ name="FEditor",	ver = "FE7J", addr = 0xC69B4,data = new byte[]{0x19 ,0x00 ,0x00 ,0x00 ,0x00 ,0x00 ,0x00 ,0x00 ,0x03 ,0x00 ,0x00 ,0x00 ,0x29 ,0x6B ,0x0C ,0x08},dim = 0xC69CD,no_dim = 0xC69CD},
-                new MagicPatchTableSt{ name="SCA_Creator",	ver = "FE6", addr = 0x2DC078,data = new byte[]{0x19 ,0x00 ,0x00 ,0x00 ,0x00 ,0x00 ,0x00 ,0x00 ,0x03 ,0x00 ,0x00 ,0x00 ,0x61 ,0xC1 ,0x2D ,0x08},dim = 0x2DC091,no_dim = 0x2dc129},
-                new MagicPatchTableSt{ name="FEditor",	ver = "FE6", addr = 0x2DC078,data = new byte[]{0x19 ,0x00 ,0x00 ,0x00 ,0x00 ,0x00 ,0x00 ,0x00 ,0x03 ,0x00 ,0x00 ,0x00 ,0xC5 ,0xC1 ,0x2D ,0x08},dim = 0x2dc091,no_dim = 0x2DC17F },
-            };
+            // Delegate detection to FEBuilderGBA.Core.ImageUtilMagicCore so
+            // the same logic runs from Avalonia / CLI (#418). We still
+            // populate the WinForms-side cache fields so cross-form lookups
+            // via GetCSASpellTableAddr() / GetCSASpellTablePointer() work.
+            var coreSystem = ImageUtilMagicCore.SearchMagicSystem(
+                Program.ROM, out baseaddr, out dimaddr, out nodimaddr);
 
-            string version = Program.ROM.RomInfo.VersionToFilename;
-            foreach(MagicPatchTableSt t in table)
+            if (coreSystem == ImageUtilMagicCore.MagicSystem.No)
             {
-                if (t.ver != version)
-                {
-                    continue;
-                }
-
-                byte[] data = Program.ROM.getBinaryData(t.addr, t.data.Length);
-                if (U.memcmp(t.data, data) != 0)
-                {
-                    continue;
-                }
-                if (t.name == "FEditor")
-                {
-                    g_Cache_CSASpellTableAddr = FindCSASpellTableLow("FEditor", out g_Cache_CSASpellTablePointer);
-                    if (g_Cache_CSASpellTablePointer == U.NOT_FOUND)
-                    {//テーブルが見つからないので、ぶっ壊れている
-                        continue;
-                    }
-
-                    baseaddr = t.addr;
-                    dimaddr = t.dim;
-                    nodimaddr = t.no_dim;
-                    g_Cache_magic_system_enum = magic_system_enum.FEDITOR_ADV;
-                    return g_Cache_magic_system_enum;
-                }
-                if (t.name == "SCA_Creator")
-                {
-                    g_Cache_CSASpellTableAddr = FindCSASpellTableLow("SCA_Creator", out g_Cache_CSASpellTablePointer);
-                    if (g_Cache_CSASpellTablePointer == U.NOT_FOUND)
-                    {//テーブルが見つからないので、ぶっ壊れている
-                        continue;
-                    }
-
-                    baseaddr = t.addr;
-                    dimaddr = t.dim;
-                    nodimaddr = t.no_dim;
-                    g_Cache_magic_system_enum = magic_system_enum.CSA_CREATOR;
-                    return g_Cache_magic_system_enum;
-                }
+                baseaddr = U.NOT_FOUND;
+                dimaddr = U.NOT_FOUND;
+                nodimaddr = U.NOT_FOUND;
+                g_Cache_magic_system_enum = magic_system_enum.NO;
+                return g_Cache_magic_system_enum;
             }
-            baseaddr = U.NOT_FOUND;
-            dimaddr = U.NOT_FOUND;
-            nodimaddr = U.NOT_FOUND;
-            g_Cache_magic_system_enum = magic_system_enum.NO;
+
+            // Re-resolve the CSA pointer so the WF cache stays in sync.
+            uint csaPointer;
+            uint csaAddr = ImageUtilMagicCore.FindCSASpellTable(
+                Program.ROM, coreSystem, out csaPointer);
+            g_Cache_CSASpellTableAddr = csaAddr;
+            g_Cache_CSASpellTablePointer = csaPointer;
+
+            g_Cache_magic_system_enum = coreSystem == ImageUtilMagicCore.MagicSystem.FEditorAdv
+                ? magic_system_enum.FEDITOR_ADV
+                : magic_system_enum.CSA_CREATOR;
             return g_Cache_magic_system_enum;
         }
 
@@ -127,60 +86,8 @@ namespace FEBuilderGBA
             return g_Cache_CSASpellTablePointer;
         }
         
-        public struct SpellTableSt
-        {
-            public string name;
-            public string ver;
-            public byte[] data;
-        };
-        static uint FindCSASpellTableLow(string type, out uint out_pointer)
-        {
-            SpellTableSt[] table = new SpellTableSt[] { 
-                new SpellTableSt{ name="SCA_Creator",	ver = "FE8U",data = new byte[]{0x1C ,0x58 ,0x05 ,0x08 ,0x00 ,0x01 ,0x00 ,0x80 ,0xED ,0xD7 ,0x95 ,0x08 ,0x99 ,0xD8 ,0x95 ,0x08}},
-                new SpellTableSt{ name="FEditor",	ver = "FE8U",data = new byte[]{0x01 ,0xB4 ,0x7D ,0xE7 ,0x34 ,0xFF ,0x03 ,0x02 ,0x80 ,0xD7 ,0x95 ,0x08 ,0x1A ,0xE1 ,0x03 ,0x02}},
-                new SpellTableSt{ name="SCA_Creator",	ver = "FE8J",data = new byte[]{0xB8 ,0x67 ,0x05 ,0x08 ,0x00 ,0x01 ,0x00 ,0x80 ,0x29 ,0xD4 ,0x9C ,0x08 ,0xD5 ,0xD4 ,0x9C ,0x08}},
-                new SpellTableSt{ name="FEditor",	ver = "FE8J",data = new byte[]{0x01 ,0xB4 ,0x7D ,0xE7 ,0x34 ,0xFF ,0x03 ,0x02 ,0x00 ,0xBE ,0xEF ,0x08 ,0x16 ,0xE1 ,0x03 ,0x02}},
-                new SpellTableSt{ name="SCA_Creator",	ver = "FE7U",data = new byte[]{0x0C ,0x06 ,0x05 ,0x08 ,0x00 ,0x01 ,0x00 ,0x80 ,0xED ,0xB6 ,0x0C ,0x08 ,0x99 ,0xB7 ,0x0C ,0x08}},
-                new SpellTableSt{ name="FEditor",	ver = "FE7U",data = new byte[]{0x00 ,0x28 ,0x17 ,0xD1 ,0x18 ,0xE0 ,0x70 ,0xB5 ,0x05 ,0x1C ,0x00 ,0x20 ,0x01 ,0xB4 ,0x87 ,0xE7 ,0x34 ,0xFF ,0x03 ,0x02 ,0x80 ,0xB6 ,0x0C ,0x08 ,0x26 ,0xE0 ,0x03 ,0x02}},
-                new SpellTableSt{ name="FEditor",	ver = "FE7J",data = new byte[]{0x01 ,0xB4 ,0x79 ,0xE7 ,0x34 ,0xFF ,0x03 ,0x02 ,0xB4 ,0x69 ,0x0C ,0x08 ,0xFE ,0xDF ,0x03 ,0x02}},
-                new SpellTableSt{ name="SCA_Creator",	ver = "FE6",data = new byte[]{0x48 ,0x19 ,0x02 ,0x02 ,0x00 ,0x01 ,0x00 ,0x80 ,0x91 ,0xC0 ,0x2D ,0x08 ,0x29 ,0xC1 ,0x2D ,0x08}},
-                new SpellTableSt{ name="FEditor",	ver = "FE6",data = new byte[]{0xE7 ,0x7D ,0xB4 ,0x01 ,0x34 ,0xFF ,0x03 ,0x02 ,0x80 ,0xD7 ,0x95 ,0x08 ,0x1A ,0xE1 ,0x03 ,0x02}},
-            };
-
-
-            out_pointer = U.NOT_FOUND;
-            string version = Program.ROM.RomInfo.VersionToFilename;
-            foreach (SpellTableSt t in table)
-            {
-                if (t.name != type)
-                {
-                    continue;
-                }
-                if (t.ver != version)
-                {
-                    continue;
-                }
-
-                //チェック開始アドレス
-                uint start = 0x10000;
-                uint f = U.Grep(Program.ROM.Data, t.data, start, 0, 4);
-                if (f == U.NOT_FOUND)
-                {
-                    continue;
-                }
-                uint csa_spell_table_pointer = f + (uint)t.data.Length;
-                out_pointer = csa_spell_table_pointer;
-
-                uint csa_spell_table = Program.ROM.p32(csa_spell_table_pointer);
-                if (!U.isSafetyOffset(csa_spell_table))
-                {
-                    continue;
-                }
-
-                return csa_spell_table;
-            }
-            return U.NOT_FOUND;
-        }
+        // SpellTableSt struct + FindCSASpellTableLow logic moved to
+        // FEBuilderGBA.Core.ImageUtilMagicCore.FindCSASpellTable (#418).
 
         //魔法拡張は大量の0x00地帯が生れるので、フリー領域と誤認しないように確認する.
         public static bool IsMagicArea(ref uint addr)

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -19863,3 +19863,27 @@ Hex Text Palette
 
 :JASC-PAL (Aseprite/GIMP)
 JASC-PAL (Aseprite/GIMP)
+
+:dim_pc
+dim_pc
+
+:dim
+dim
+
+:NULL (EMPTY)
+NULL (EMPTY)
+
+:FrameData
+FrameData
+
+:OBJRightToLeft
+OBJRightToLeft
+
+:OBJLeftToRight
+OBJLeftToRight
+
+:OBJBGRightToLeft
+OBJBGRightToLeft
+
+:OBBGLeftToRight
+OBBGLeftToRight

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -19887,3 +19887,6 @@ OBJBGRightToLeft
 
 :OBBGLeftToRight
 OBBGLeftToRight
+
+:FEditor / SCA_Creator magic-system patch not detected. Install the patch via the Patches manager.
+FEditor / SCA_Creator magic-system patch not detected. Install the patch via the Patches manager.

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -7337,3 +7337,47 @@ Hard only (LV+128)
 :Level-up Skill Top Address
 レベルアップで取得するスキルの先頭アドレス
 
+:サンプル
+サンプル
+
+:インターネットから新しいリソースを探す
+インターネットから新しいリソースを探す
+
+:拡大して描画
+拡大して描画
+
+:拡大しないで描画
+拡大しないで描画
+
+:表示例
+表示例
+
+:dim_pc
+dim_pc
+
+:dim
+dim
+
+:NULL (EMPTY)
+NULL (EMPTY)
+
+:FrameData
+FrameData
+
+:OBJRightToLeft
+OBJRightToLeft
+
+:OBJLeftToRight
+OBJLeftToRight
+
+:OBJBGRightToLeft
+OBJBGRightToLeft
+
+:OBBGLeftToRight
+OBBGLeftToRight
+
+:魔法アニメの書出し
+魔法アニメの書出し
+
+:魔法アニメの読込
+魔法アニメの読込

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -7381,3 +7381,6 @@ OBBGLeftToRight
 
 :魔法アニメの読込
 魔法アニメの読込
+
+:FEditor / SCA_Creator magic-system patch not detected. Install the patch via the Patches manager.
+FEditor / SCA_Creator 魔法システムパッチが検出されません。パッチマネージャーからパッチをインストールしてください。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -21277,3 +21277,6 @@ OBBGLeftToRight
 
 :魔法アニメの読込
 导入魔法动画
+
+:FEditor / SCA_Creator magic-system patch not detected. Install the patch via the Patches manager.
+未检测到 FEditor / SCA_Creator 魔法系统补丁。请通过补丁管理器安装补丁。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -21239,3 +21239,41 @@ to:
 :Level-up Skill Top Address
 等级提升获得技能的起始地址
 
+:拡大して描画
+缩放并绘制
+
+:拡大しないで描画
+不缩放绘制
+
+:表示例
+显示示例
+
+:dim_pc
+dim_pc
+
+:dim
+dim
+
+:NULL (EMPTY)
+NULL (EMPTY)
+
+:FrameData
+FrameData
+
+:OBJRightToLeft
+OBJRightToLeft
+
+:OBJLeftToRight
+OBJLeftToRight
+
+:OBJBGRightToLeft
+OBJBGRightToLeft
+
+:OBBGLeftToRight
+OBBGLeftToRight
+
+:魔法アニメの書出し
+导出魔法动画
+
+:魔法アニメの読込
+导入魔法动画

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -21272,11 +21272,5 @@ OBJBGRightToLeft
 :OBBGLeftToRight
 OBBGLeftToRight
 
-:魔法アニメの書出し
-导出魔法动画
-
-:魔法アニメの読込
-导入魔法动画
-
 :FEditor / SCA_Creator magic-system patch not detected. Install the patch via the Patches manager.
 未检测到 FEditor / SCA_Creator 魔法系统补丁。请通过补丁管理器安装补丁。

--- a/docs/avalonia-gaps/2026-05-23-density-sweep.md
+++ b/docs/avalonia-gaps/2026-05-23-density-sweep.md
@@ -1,6 +1,6 @@
 ---
-generated: "2026-05-23T05:32:54Z"
-git-sha: a35299ba6
+generated: "2026-05-23T16:06:29Z"
+git-sha: 1f20893bb
 sweep-type: density
 ---
 
@@ -20,9 +20,9 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-density --out=<path>`.
 
 | Verdict | Threshold | Count |
 |---|---|---|
-| HIGH | |Δ%| ≥ 50 | 230 |
+| HIGH | |Δ%| ≥ 50 | 223 |
 | MEDIUM | 25 ≤ |Δ%| < 50 | 84 |
-| LOW | |Δ%| < 25 | 56 |
+| LOW | |Δ%| < 25 | 63 |
 
 ## Ranked Density Deltas
 
@@ -56,10 +56,7 @@ Both represent pairing artifacts rather than real migration gaps.
 | High | `ImagePortraitImporterForm` | `ImagePortraitImporterView` | 42 | 3 | -39 | -92.9% | Heuristic |
 | High | `AIScriptForm` | `AIScriptView` | 37 | 3 | -34 | -91.9% | Heuristic |
 | High | `ImageMagicCSACreatorForm` | `ImageMagicCSACreatorView` | 37 | 3 | -34 | -91.9% | Heuristic |
-| High | `ImageMagicFEditorForm` | `ImageMagicFEditorView` | 37 | 3 | -34 | -91.9% | ListParityHelper |
-| High | `EventMapChangeForm` | `EventMapChangeView` | 36 | 3 | -33 | -91.7% | ListParityHelper |
 | High | `WorldMapImageFE6Form` | `WorldMapImageFE6View` | 36 | 3 | -33 | -91.7% | Heuristic |
-| High | `ToolTranslateROMForm` | `ToolTranslateROMView` | 35 | 3 | -32 | -91.4% | Heuristic |
 | High | `EventHaikuFE6Form` | `EventHaikuFE6View` | 34 | 3 | -31 | -91.2% | ListParityHelper |
 | High | `FE8SpellMenuExtendsForm` | `FE8SpellMenuExtendsView` | 34 | 3 | -31 | -91.2% | Heuristic |
 | High | `MonsterWMapProbabilityForm` | `MonsterWMapProbabilityViewerView` | 66 | 6 | -60 | -90.9% | ListParityHelper |
@@ -96,7 +93,6 @@ Both represent pairing artifacts rather than real migration gaps.
 | High | `ClassOPFontForm` | `ClassOPFontView` | 16 | 3 | -13 | -81.3% | Heuristic |
 | High | `EventFinalSerifFE7Form` | `EventFinalSerifFE7View` | 16 | 3 | -13 | -81.3% | ListParityHelper |
 | High | `MainSimpleMenuImageSubForm` | `MainSimpleMenuImageSubView` | 16 | 3 | -13 | -81.3% | Heuristic |
-| High | `MapExitPointForm` | `MapExitPointView` | 32 | 6 | -26 | -81.3% | ListParityHelper |
 | High | `SkillConfigFE8NSkillForm` | `SkillConfigFE8NSkillView` | 169 | 33 | -136 | -80.5% | Heuristic |
 | High | `SkillAssignmentUnitCSkillSysForm` | `SkillAssignmentUnitCSkillSysView` | 35 | 7 | -28 | -80.0% | Heuristic |
 | High | `SkillAssignmentUnitSkillSystemForm` | `SkillAssignmentUnitSkillSystemView` | 35 | 7 | -28 | -80.0% | Heuristic |
@@ -132,7 +128,6 @@ Both represent pairing artifacts rather than real migration gaps.
 | High | `ErrorPaletteShowForm` | `ErrorPaletteShowView` | 9 | 3 | -6 | -66.7% | Heuristic |
 | High | `ErrorReportForm` | `ErrorReportView` | 9 | 3 | -6 | -66.7% | Heuristic |
 | High | `SongTrackAllChangeTrackForm` | `SongTrackAllChangeTrackView` | 9 | 3 | -6 | -66.7% | Heuristic |
-| High | `MapTileAnimation2Form` | `MapTileAnimation2View` | 40 | 14 | -26 | -65.0% | ListParityHelper |
 | High | `SkillAssignmentUnitFE8NForm` | `SkillAssignmentUnitFE8NView` | 31 | 11 | -20 | -64.5% | Heuristic |
 | High | `UnitPaletteForm` | `UnitPaletteView` | 50 | 18 | -32 | -64.0% | ListParityHelper |
 | High | `EventTemplate6Form` | `EventTemplate6View` | 8 | 3 | -5 | -62.5% | Heuristic |
@@ -159,11 +154,9 @@ Both represent pairing artifacts rather than real migration gaps.
 | High | `ItemFE6Form` | `ItemFE6View` | 121 | 53 | -68 | -56.2% | Heuristic |
 | High | `TextDicForm` | `TextDicView` | 60 | 27 | -33 | -55.0% | ListParityHelper |
 | High | `ImageItemIconForm` | `ItemIconViewerView` | 22 | 10 | -12 | -54.5% | ListParityHelper |
-| High | `OPClassDemoFE7UForm` | `OPClassDemoFE7UView` | 56 | 26 | -30 | -53.6% | ListParityHelper |
 | High | `EDStaffRollForm` | `EDStaffRollView` | 17 | 8 | -9 | -52.9% | ListParityHelper |
 | High | `OPClassDemoFE8UForm` | `OPClassDemoFE8UView` | 50 | 24 | -26 | -52.0% | ListParityHelper |
 | High | `PaletteChangeColorsForm` | `PaletteChangeColorsView` | 25 | 12 | -13 | -52.0% | Heuristic |
-| High | `OPClassDemoForm` | `OPClassDemoViewerView` | 63 | 31 | -32 | -50.8% | Heuristic |
 | High | `AIUnitsForm` | `AIUnitsView` | 16 | 8 | -8 | -50.0% | Heuristic |
 | High | `EventTalkGroupFE7Form` | `EventTalkGroupFE7View` | 14 | 7 | -7 | -50.0% | Heuristic |
 | High | `EventTemplate5Form` | `EventTemplate5View` | 6 | 3 | -3 | -50.0% | Heuristic |
@@ -187,7 +180,6 @@ Both represent pairing artifacts rather than real migration gaps.
 | Medium | `WorldMapPathMoveEditorForm` | `WorldMapPathMoveEditorView` | 20 | 11 | -9 | -45.0% | Heuristic |
 | Medium | `PatchFilterExForm` | `PatchFilterExView` | 9 | 5 | -4 | -44.4% | Heuristic |
 | Medium | `ImageChapterTitleFE7Form` | `ImageChapterTitleFE7View` | 16 | 9 | -7 | -43.8% | ListParityHelper |
-| Medium | `EventUnitForm` | `EventUnitView` | 95 | 54 | -41 | -43.2% | ListParityHelper |
 | Medium | `SomeClassListForm` | `SomeClassListView` | 14 | 8 | -6 | -42.9% | Heuristic |
 | Medium | `AIPerformItemForm` | `AIPerformItemView` | 19 | 11 | -8 | -42.1% | ListParityHelper |
 | Medium | `AIPerformStaffForm` | `AIPerformStaffView` | 19 | 11 | -8 | -42.1% | ListParityHelper |
@@ -223,7 +215,6 @@ Both represent pairing artifacts rather than real migration gaps.
 | Medium | `SkillSystemsEffectivenessReworkClassTypeForm` | `SkillSystemsEffectivenessReworkClassTypeView` | 10 | 7 | -3 | -30.0% | Heuristic |
 | Medium | `WorldMapPathForm` | `WorldMapPathView` | 24 | 17 | -7 | -29.2% | ListParityHelper |
 | Medium | `ImageBGSelectPopupForm` | `ImageBGSelectPopupView` | 7 | 5 | -2 | -28.6% | Heuristic |
-| Medium | `ImagePortraitForm` | `ImagePortraitView` | 63 | 45 | -18 | -28.6% | ListParityHelper |
 | Medium | `SupportTalkForm` | `SupportTalkView` | 32 | 23 | -9 | -28.1% | ListParityHelper |
 | Medium | `ClassForm` | `ClassEditorView` | 211 | 154 | -57 | -27.0% | ListParityHelper |
 | Medium | `VennouWeaponLockForm` | `VennouWeaponLockView` | 15 | 11 | -4 | -26.7% | Heuristic |
@@ -251,6 +242,7 @@ Both represent pairing artifacts rather than real migration gaps.
 | Low | `ItemStatBonusesVennoForm` | `ItemStatBonusesVennoView` | 41 | 36 | -5 | -12.2% | Heuristic |
 | Low | `MapPointerNewPLISTPopupForm` | `MapPointerNewPLISTPopupView` | 9 | 8 | -1 | -11.1% | Heuristic |
 | Low | `UnitFE7Form` | `UnitFE7View` | 160 | 143 | -17 | -10.6% | ListParityHelper |
+| Low | `EventUnitForm` | `EventUnitView` | 95 | 85 | -10 | -10.5% | ListParityHelper |
 | Low | `OPClassAlphaNameFE6Form` | `OPClassAlphaNameFE6View` | 10 | 9 | -1 | -10.0% | ListParityHelper |
 | Low | `RAMRewriteToolMAPForm` | `RAMRewriteToolMAPView` | 11 | 10 | -1 | -9.1% | Heuristic |
 | Low | `ItemStatBonusesSkillSystemsForm` | `ItemStatBonusesSkillSystemsView` | 51 | 47 | -4 | -7.8% | Heuristic |
@@ -269,6 +261,7 @@ Both represent pairing artifacts rather than real migration gaps.
 | Low | `ToolClickWriteFloatControlPanelButtonForm` | `ToolClickWriteFloatControlPanelButtonView` | 4 | 4 | 0 | 0.0% | Heuristic |
 | Low | `ToolEmulatorSetupMessageForm` | `ToolEmulatorSetupMessageView` | 3 | 3 | 0 | 0.0% | Heuristic |
 | Low | `ToolUndoPopupDialogForm` | `ToolUndoPopupDialogView` | 5 | 5 | 0 | 0.0% | Heuristic |
+| Low | `OPClassDemoForm` | `OPClassDemoViewerView` | 63 | 65 | 2 | +3.2% | Heuristic |
 | Low | `MenuExtendSplitMenuForm` | `MenuExtendSplitMenuView` | 27 | 28 | 1 | +3.7% | ListParityHelper |
 | Low | `DumpStructSelectDialogForm` | `DumpStructSelectDialogView` | 19 | 20 | 1 | +5.3% | Heuristic |
 | Low | `ItemShopForm` | `ItemShopViewerView` | 17 | 18 | 1 | +5.9% | ListParityHelper |
@@ -279,15 +272,20 @@ Both represent pairing artifacts rather than real migration gaps.
 | Low | `AIASMRangeForm` | `AIASMRangeView` | 12 | 13 | 1 | +8.3% | Heuristic |
 | Low | `AIASMCoordinateForm` | `AIASMCoordinateView` | 11 | 12 | 1 | +9.1% | Heuristic |
 | Low | `UbyteBitFlagForm` | `UbyteBitFlagView` | 11 | 12 | 1 | +9.1% | Heuristic |
+| Low | `MapExitPointForm` | `MapExitPointView` | 32 | 35 | 3 | +9.4% | ListParityHelper |
 | Low | `UshortBitFlagForm` | `UshortBitFlagView` | 20 | 22 | 2 | +10.0% | Heuristic |
 | Low | `UwordBitFlagForm` | `UwordBitFlagView` | 38 | 42 | 4 | +10.5% | Heuristic |
+| Low | `OPClassDemoFE7UForm` | `OPClassDemoFE7UView` | 56 | 62 | 6 | +10.7% | ListParityHelper |
 | Low | `RAMRewriteToolForm` | `RAMRewriteToolView` | 8 | 9 | 1 | +12.5% | Heuristic |
 | Low | `ImageBattleBGForm` | `ImageBattleBGView` | 26 | 30 | 4 | +15.4% | ListParityHelper |
 | Low | `ItemEffectivenessForm` | `ItemEffectivenessViewerView` | 19 | 22 | 3 | +15.8% | ListParityHelper |
 | Low | `PointerToolCopyToForm` | `PointerToolCopyToView` | 6 | 7 | 1 | +16.7% | Heuristic |
 | Low | `ToolWorkSupportForm` | `ToolWorkSupportView` | 17 | 20 | 3 | +17.6% | Heuristic |
+| Low | `EventMapChangeForm` | `EventMapChangeView` | 36 | 43 | 7 | +19.4% | ListParityHelper |
 | Low | `MainSimpleMenuEventErrorIgnoreErrorForm` | `MainSimpleMenuEventErrorIgnoreErrorView` | 5 | 6 | 1 | +20.0% | Heuristic |
 | Low | `EventUnitFE7Form` | `EventUnitFE7View` | 66 | 80 | 14 | +21.2% | ListParityHelper |
+| Low | `ImageMagicFEditorForm` | `ImageMagicFEditorView` | 37 | 45 | 8 | +21.6% | ListParityHelper |
+| Low | `ImagePortraitForm` | `ImagePortraitView` | 63 | 77 | 14 | +22.2% | ListParityHelper |
 | Low | `WorldMapEventPointerForm` | `WorldMapEventPointerView` | 39 | 48 | 9 | +23.1% | ListParityHelper |
 | Low | `ImagePortraitFE6Form` | `ImagePortraitFE6View` | 34 | 42 | 8 | +23.5% | ListParityHelper |
 | Medium | `ItemPromotionForm` | `ItemPromotionViewerView` | 16 | 20 | 4 | +25.0% | ListParityHelper |
@@ -295,6 +293,7 @@ Both represent pairing artifacts rather than real migration gaps.
 | Medium | `SMEPromoListForm` | `SMEPromoListView` | 16 | 20 | 4 | +25.0% | Heuristic |
 | Medium | `ToolWorkSupport_SelectUPSForm` | `ToolWorkSupport_SelectUPSView` | 4 | 5 | 1 | +25.0% | Heuristic |
 | Medium | `ImageBGForm` | `ImageBGView` | 26 | 33 | 7 | +26.9% | ListParityHelper |
+| Medium | `MapTileAnimation2Form` | `MapTileAnimation2View` | 40 | 51 | 11 | +27.5% | ListParityHelper |
 | Medium | `HexEditorForm` | `HexEditorView` | 6 | 8 | 2 | +33.3% | Heuristic |
 | Medium | `SkillConfigSkillSystemForm` | `SkillConfigSkillSystemView` | 30 | 40 | 10 | +33.3% | Heuristic |
 | Medium | `ToolExportEAEventForm` | `ToolExportEAEventView` | 12 | 16 | 4 | +33.3% | Heuristic |
@@ -303,6 +302,7 @@ Both represent pairing artifacts rather than real migration gaps.
 | Medium | `ToolRunHintMessageForm` | `ToolRunHintMessageView` | 3 | 4 | 1 | +33.3% | Heuristic |
 | Medium | `ToolThreeMargeCloseAlertForm` | `ToolThreeMargeCloseAlertView` | 3 | 4 | 1 | +33.3% | Heuristic |
 | Medium | `ToolWorkSupport_UpdateQuestionDialogForm` | `ToolWorkSupport_UpdateQuestionDialogView` | 3 | 4 | 1 | +33.3% | Heuristic |
+| Medium | `ToolTranslateROMForm` | `ToolTranslateROMView` | 35 | 47 | 12 | +34.3% | Heuristic |
 | Medium | `ItemUsagePointerForm` | `ItemUsagePointerViewerView` | 23 | 31 | 8 | +34.8% | ListParityHelper |
 | Medium | `ToolDiffDebugSelectForm` | `ToolDiffDebugSelectView` | 11 | 15 | 4 | +36.4% | Heuristic |
 | Medium | `SkillConfigFE8UCSkillSys09xForm` | `SkillConfigFE8UCSkillSys09xView` | 29 | 40 | 11 | +37.9% | Heuristic |
@@ -512,20 +512,20 @@ WF count: **37** · AV count: **3** · Δ: **-34** (-91.9%).
   grep -E '(Text|Content|Header)=' FEBuilderGBA.Avalonia/Views/ImageMagicCSACreatorView.axaml
 -->
 
-### ImageMagicFEditorForm
-WF count: **37** · AV count: **3** · Δ: **-34** (-91.9%).
-
-<!-- Triage: list specific missing fields here. Suggested probe:
-  grep -E '\.Text\s*=' FEBuilderGBA/ImageMagicFEditorForm.Designer.cs
-  grep -E '(Text|Content|Header)=' FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml
--->
-
-### EventMapChangeForm
+### WorldMapImageFE6Form
 WF count: **36** · AV count: **3** · Δ: **-33** (-91.7%).
 
 <!-- Triage: list specific missing fields here. Suggested probe:
-  grep -E '\.Text\s*=' FEBuilderGBA/EventMapChangeForm.Designer.cs
-  grep -E '(Text|Content|Header)=' FEBuilderGBA.Avalonia/Views/EventMapChangeView.axaml
+  grep -E '\.Text\s*=' FEBuilderGBA/WorldMapImageFE6Form.Designer.cs
+  grep -E '(Text|Content|Header)=' FEBuilderGBA.Avalonia/Views/WorldMapImageFE6View.axaml
+-->
+
+### EventHaikuFE6Form
+WF count: **34** · AV count: **3** · Δ: **-31** (-91.2%).
+
+<!-- Triage: list specific missing fields here. Suggested probe:
+  grep -E '\.Text\s*=' FEBuilderGBA/EventHaikuFE6Form.Designer.cs
+  grep -E '(Text|Content|Header)=' FEBuilderGBA.Avalonia/Views/EventHaikuFE6View.axaml
 -->
 
 ## Unpaired Orphans

--- a/docs/avalonia-gaps/2026-05-23-jumps-sweep.md
+++ b/docs/avalonia-gaps/2026-05-23-jumps-sweep.md
@@ -1,6 +1,6 @@
 ---
-generated: "2026-05-23T05:33:57Z"
-git-sha: a35299ba6
+generated: "2026-05-23T16:07:49Z"
+git-sha: 1f20893bb
 sweep-type: jumps
 ---
 
@@ -37,10 +37,10 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-jumps --out=<path>`.
 | Metric | Count |
 |---|---:|
 | Total rows | 429 |
-| Match | 40 |
-| MissingAvManifest (backlog) | 347 |
+| Match | 49 |
+| MissingAvManifest (backlog) | 337 |
 | NoWfCallsite | 35 |
-| KnownGap (issue-tagged) | 7 |
+| KnownGap (issue-tagged) | 8 |
 
 ## Known Gaps (tracked by open issues)
 
@@ -48,6 +48,7 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-jumps --out=<path>`.
 |---|---|---|---|---|---|
 | `CCBranchForm` | `CCBranchEditorView` | `JumpToPromotionClass1` | `ClassForm` | `ClassEditorView` | [#365](https://github.com/laqieer/FEBuilderGBA/issues/365) |
 | `CCBranchForm` | `CCBranchEditorView` | `JumpToPromotionClass2` | `ClassForm` | `ClassEditorView` | [#365](https://github.com/laqieer/FEBuilderGBA/issues/365) |
+| `ImageMagicFEditorForm` | `ImageMagicFEditorView` | `JumpToToolAnimationCreator` | `ToolAnimationCreatorForm` | `ToolAnimationCreatorView` | [#500](https://github.com/laqieer/FEBuilderGBA/issues/500) |
 | `ImageMapActionAnimationForm` | `ImageMapActionAnimationView` | `JumpToAnimationCreator` | `ToolAnimationCreatorForm` | `ToolAnimationCreatorView` | [#500](https://github.com/laqieer/FEBuilderGBA/issues/500) |
 | `SkillConfigCSkillSystem09xForm` | `SkillConfigFE8UCSkillSys09xView` | `JumpToAnimationCreator` | `ToolAnimationCreatorForm` | `ToolAnimationCreatorView` | [#500](https://github.com/laqieer/FEBuilderGBA/issues/500) |
 | `SkillConfigSkillSystemForm` | `SkillConfigSkillSystemView` | `JumpToAnimationCreator` | `ToolAnimationCreatorForm` | `ToolAnimationCreatorView` | [#500](https://github.com/laqieer/FEBuilderGBA/issues/500) |
@@ -232,12 +233,6 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-jumps --out=<path>`.
 | `EventCondForm` | `EventCondView` | `—` | `MapPointerNewPLISTPopupForm` | `MapPointerNewPLISTPopupView` |
 | `EventUnitFE6Form` | `EventUnitFE6View` | `—` | `EventBattleTalkFE6Form` | `EventBattleTalkFE6View` |
 | `EventUnitFE6Form` | `EventUnitFE6View` | `—` | `EventHaikuFE6Form` | `EventHaikuFE6View` |
-| `EventUnitForm` | `EventUnitView` | `—` | `EventBattleTalkForm` | `EventBattleTalkView` |
-| `EventUnitForm` | `EventUnitView` | `—` | `EventHaikuForm` | `EventHaikuView` |
-| `EventUnitForm` | `EventUnitView` | `—` | `EventUnitItemDropForm` | `EventUnitItemDropView` |
-| `EventUnitForm` | `EventUnitView` | `—` | `EventUnitNewAllocForm` | `EventUnitNewAllocView` |
-| `EventUnitForm` | `EventUnitView` | `—` | `MonsterProbabilityForm` | `MonsterProbabilityViewerView` |
-| `EventUnitForm` | `EventUnitView` | `—` | `SoundBossBGMForm` | `SoundBossBGMViewerView` |
 | `GraphicsToolForm` | `GraphicsToolView` | `—` | `GraphicsToolPatchMakerForm` | `GraphicsToolPatchMakerView` |
 | `GraphicsToolForm` | `GraphicsToolView` | `—` | `ImagePalletForm` | `ImagePalletView` |
 | `GraphicsToolForm` | `GraphicsToolView` | `—` | `ImageTSAEditorForm` | `ImageTSAEditorView` |
@@ -257,12 +252,8 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-jumps --out=<path>`.
 | `ImageChapterTitleFE7Form` | `ImageChapterTitleFE7View` | `—` | `ErrorPaletteShowForm` | `ErrorPaletteShowView` |
 | `ImageGenericEnemyPortraitForm` | `ImageGenericEnemyPortraitView` | `—` | `PatchForm` | `PatchManagerView` |
 | `ImageMagicCSACreatorForm` | `ImageMagicCSACreatorView` | `—` | `ToolAnimationCreatorForm` | `ToolAnimationCreatorView` |
-| `ImageMagicFEditorForm` | `ImageMagicFEditorView` | `—` | `ToolAnimationCreatorForm` | `ToolAnimationCreatorView` |
 | `ImagePortraitFE6Form` | `ImagePortraitFE6View` | `—` | `ImagePalletForm` | `ImagePalletView` |
 | `ImagePortraitFE6Form` | `ImagePortraitFE6View` | `—` | `ImagePortraitImporterForm` | `ImagePortraitImporterView` |
-| `ImagePortraitForm` | `ImagePortraitView` | `—` | `ImagePalletForm` | `ImagePalletView` |
-| `ImagePortraitForm` | `ImagePortraitView` | `—` | `ImagePortraitImporterForm` | `ImagePortraitImporterView` |
-| `ImagePortraitForm` | `ImagePortraitView` | `—` | `UnitIncreaseHeightForm` | `UnitIncreaseHeightView` |
 | `ImageRomAnimeForm` | `ImageRomAnimeView` | `—` | `GraphicsToolForm` | `GraphicsToolView` |
 | `ImageTSAAnimeForm` | `ImageTSAAnimeView` | `—` | `DecreaseColorTSAToolForm` | `DecreaseColorTSAToolView` |
 | `ImageTSAAnimeForm` | `ImageTSAAnimeView` | `—` | `GraphicsToolForm` | `GraphicsToolView` |
@@ -458,11 +449,20 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-jumps --out=<path>`.
 | `EventUnitFE7Form` | `EventUnitFE7View` | `JumpToBattleTalk` | `EventBattleTalkFE7Form` | `EventBattleTalkFE7View` |
 | `EventUnitFE7Form` | `EventUnitFE7View` | `JumpToHaiku` | `EventHaikuFE7Form` | `EventHaikuFE7View` |
 | `EventUnitFE7Form` | `EventUnitFE7View` | `JumpToBattleBGM` | `SoundBossBGMForm` | `SoundBossBGMViewerView` |
+| `EventUnitForm` | `EventUnitView` | `JumpToBattleTalk` | `EventBattleTalkForm` | `EventBattleTalkView` |
+| `EventUnitForm` | `EventUnitView` | `JumpToHaiku` | `EventHaikuForm` | `EventHaikuView` |
+| `EventUnitForm` | `EventUnitView` | `JumpToItemDrop` | `EventUnitItemDropForm` | `EventUnitItemDropView` |
+| `EventUnitForm` | `EventUnitView` | `JumpToNewAlloc` | `EventUnitNewAllocForm` | `EventUnitNewAllocView` |
+| `EventUnitForm` | `EventUnitView` | `JumpToMonsterProbability` | `MonsterProbabilityForm` | `MonsterProbabilityViewerView` |
+| `EventUnitForm` | `EventUnitView` | `JumpToBattleBGM` | `SoundBossBGMForm` | `SoundBossBGMViewerView` |
 | `ImageBGForm` | `ImageBGView` | `JumpToDecreaseColor` | `DecreaseColorTSAToolForm` | `DecreaseColorTSAToolView` |
 | `ImageBGForm` | `ImageBGView` | `JumpToGraphicsTool` | `GraphicsToolForm` | `GraphicsToolView` |
 | `ImageBGForm` | `ImageBGView` | `JumpToBGSelectPopup` | `ImageBGSelectPopupForm` | `ImageBGSelectPopupView` |
 | `ImageBattleBGForm` | `ImageBattleBGView` | `JumpToDecreaseColor` | `DecreaseColorTSAToolForm` | `DecreaseColorTSAToolView` |
 | `ImageBattleBGForm` | `ImageBattleBGView` | `JumpToGraphicsTool` | `GraphicsToolForm` | `GraphicsToolView` |
+| `ImagePortraitForm` | `ImagePortraitView` | `JumpToPalette` | `ImagePalletForm` | `ImagePalletView` |
+| `ImagePortraitForm` | `ImagePortraitView` | `JumpToImporter` | `ImagePortraitImporterForm` | `ImagePortraitImporterView` |
+| `ImagePortraitForm` | `ImagePortraitView` | `JumpToStatusHeight` | `UnitIncreaseHeightForm` | `UnitIncreaseHeightView` |
 | `ItemUsagePointerForm` | `ItemUsagePointerViewerView` | `JumpToPromotion` | `ItemPromotionForm` | `ItemPromotionViewerView` |
 | `ItemUsagePointerForm` | `ItemUsagePointerViewerView` | `JumpToStatBonuses` | `ItemStatBonusesForm` | `ItemStatBonusesViewerView` |
 | `ItemUsagePointerForm` | `ItemUsagePointerViewerView` | `JumpToIerPatch` | `PatchForm` | `PatchManagerView` |

--- a/docs/avalonia-gaps/2026-05-23-l10n-sweep.md
+++ b/docs/avalonia-gaps/2026-05-23-l10n-sweep.md
@@ -1,6 +1,6 @@
 ---
-generated: "2026-05-23T05:33:42Z"
-git-sha: a35299ba6
+generated: "2026-05-23T16:07:41Z"
+git-sha: 1f20893bb
 sweep-type: l10n
 languages: ja,zh,ko
 ---
@@ -50,10 +50,10 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-l10n --out=<path>`.
 | Verdict | Count | % of total |
 |---|---:|---:|
 | Untranslated | 14 | 0.4 |
-| PartiallyTranslated | 3377 | 99.6 |
+| PartiallyTranslated | 3559 | 99.6 |
 | Translated | 0 | 0.0 |
 | NonEnglish | 0 | 0.0 |
-| **Total** | 3391 | 100.0 |
+| **Total** | 3573 | 100.0 |
 
 ## Per-language Coverage
 
@@ -61,9 +61,9 @@ Coverage is computed over the English-source literals only (excludes the `NonEng
 
 | Language | Translated | English-source total | % |
 |---|---:|---:|---:|
-| `ja` | 3377 | 3391 | 99.6 |
-| `zh` | 3377 | 3391 | 99.6 |
-| `ko` | 0 | 3391 | 0.0 |
+| `ja` | 3559 | 3573 | 99.6 |
+| `zh` | 3559 | 3573 | 99.6 |
+| `ko` | 0 | 3573 | 0.0 |
 
 ## Top 20 Files by Untranslated Literal Count
 
@@ -1133,6 +1133,104 @@ show which languages cover the literal.
 | 127 | `Lint Check` | ✓ | ✓ | ✗ |
 | 128 | `Pointer Tool` | ✓ | ✓ | ✗ |
 
+### `FEBuilderGBA.Avalonia/Views/ImagePortraitView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Portrait Image Editor` | ✓ | ✓ | ✗ |
+| 17 | `Start Address:` | ✓ | ✓ | ✗ |
+| 21 | `Read Count:` | ✓ | ✓ | ✗ |
+| 24 | `Size:` | ✓ | ✓ | ✗ |
+| 28 | `Reload` | ✓ | ✓ | ✗ |
+| 34 | `Import PNG` | ✓ | ✓ | ✗ |
+| 35 | `FE-Repo` | ✓ | ✓ | ✗ |
+| 36 | `Export Face` | ✓ | ✓ | ✗ |
+| 37 | `Export Mini` | ✓ | ✓ | ✗ |
+| 38 | `Export Sheet` | ✓ | ✓ | ✗ |
+| 39 | `Export PAL` | ✓ | ✓ | ✗ |
+| 40 | `Import PAL` | ✓ | ✓ | ✗ |
+| 42 | `Open Source File` | ✓ | ✓ | ✗ |
+| 45 | `Select Source Folder` | ✓ | ✓ | ✗ |
+| 52 | `Unit Face (96x80)` | ✓ | ✓ | ✗ |
+| 56 | `Map Face (32x32)` | ✓ | ✓ | ✗ |
+| 60 | `Class Card` | ✓ | ✓ | ✗ |
+| 65 | `Show Example (Frame 4)` | ✓ | ✓ | ✗ |
+| 72 | `Show Frame:` | ✓ | ✓ | ✗ |
+| 81 | `Mouth Frames (32x16 x6)` | ✓ | ✓ | ✗ |
+| 85 | `Eye Frames (32x16 x2)` | ✓ | ✓ | ✗ |
+| 93 | `Selected Address:` | ✓ | ✓ | ✗ |
+| 98 | `Write` | ✓ | ✓ | ✗ |
+| 104 | `Address:` | ✓ | ✓ | ✗ |
+| 108 | `Unit Face:` | ✓ | ✓ | ✗ |
+| 112 | `Map Face:` | ✓ | ✓ | ✗ |
+| 116 | `Palette:` | ✓ | ✓ | ✗ |
+| 120 | `Mouth Frames:` | ✓ | ✓ | ✗ |
+| 124 | `Class Card:` | ✓ | ✓ | ✗ |
+| 128 | `Mouth X:` | ✓ | ✓ | ✗ |
+| 133 | `Mouth Y:` | ✓ | ✓ | ✗ |
+| 139 | `Eye X:` | ✓ | ✓ | ✗ |
+| 144 | `Eye Y:` | ✓ | ✓ | ✗ |
+| 150 | `Status:` | ✓ | ✓ | ✗ |
+| 164 | `Unused (B25):` | ✓ | ✓ | ✗ |
+| 168 | `Unused (B26):` | ✓ | ✓ | ✗ |
+| 172 | `Unused (B27):` | ✓ | ✓ | ✗ |
+| 176 | `Comment:` | ✓ | ✓ | ✗ |
+| 188 | `Set mug_exceed tile positions:` | ✓ | ✓ | ✗ |
+| 191 | `Tile 1` | ✓ | ✓ | ✗ |
+| 192 | `MugExceed Tile1 X:` | ✓ | ✓ | ✗ |
+| 197 | `MugExceed Tile1 Y:` | ✓ | ✓ | ✗ |
+| 203 | `Tile 2` | ✓ | ✓ | ✗ |
+| 204 | `MugExceed Tile2 X:` | ✓ | ✓ | ✗ |
+| 209 | `MugExceed Tile2 Y:` | ✓ | ✓ | ✗ |
+| 221 | `Jump to Palette` | ✓ | ✓ | ✗ |
+| 223 | `Jump to Importer` | ✓ | ✓ | ✗ |
+| 226 | `Jump to Status Height` | ✓ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventUnitView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 11 | `Map Names` | ✓ | ✓ | ✗ |
+| 17 | `Event Names` | ✓ | ✓ | ✗ |
+| 19 | `New Allocation` | ✓ | ✓ | ✗ |
+| 26 | `Names` | ✓ | ✓ | ✗ |
+| 29 | `Load` | ✓ | ✓ | ✗ |
+| 33 | `Expand List` | ✓ | ✓ | ✗ |
+| 40 | `Event Unit Placement (FE8)` | ✓ | ✓ | ✗ |
+| 45 | `Top Address` | ✓ | ✓ | ✗ |
+| 47 | `Read Count` | ✓ | ✓ | ✗ |
+| 49 | `Reload` | ✓ | ✓ | ✗ |
+| 55 | `Address:` | ✓ | ✓ | ✗ |
+| 59 | `Unit Number:` | ✓ | ✓ | ✗ |
+| 64 | `Class:` | ✓ | ✓ | ✗ |
+| 68 | `Random Monster` | ✓ | ✓ | ✗ |
+| 72 | `Commander:` | ✓ | ✓ | ✗ |
+| 76 | `Unit Info:` | ✓ | ✓ | ✗ |
+| 81 | `Allegiance:` | ✓ | ✓ | ✗ |
+| 83 | `Growth Rate:` | ✓ | ✓ | ✗ |
+| 88 | `Before Coordinates:` | ✓ | ✓ | ✗ |
+| 95 | `Drop Item` | ✓ | ✓ | ✗ |
+| 99 | `After Coordinates:` | ✓ | ✓ | ✗ |
+| 101 | `Count:` | ✓ | ✓ | ✗ |
+| 103 | `Pointer:` | ✓ | ✓ | ✗ |
+| 108 | `Reserved (0x06):` | ✓ | ✓ | ✗ |
+| 112 | `Item 1:` | ✓ | ✓ | ✗ |
+| 116 | `Item 2:` | ✓ | ✓ | ✗ |
+| 120 | `Item 3:` | ✓ | ✓ | ✗ |
+| 124 | `Item 4:` | ✓ | ✓ | ✗ |
+| 129 | `Primary AI:` | ✓ | ✓ | ✗ |
+| 133 | `Secondary AI:` | ✓ | ✓ | ✗ |
+| 137 | `Target/Recovery AI:` | ✓ | ✓ | ✗ |
+| 141 | `Retreat AI:` | ✓ | ✓ | ✗ |
+| 146 | `Comment:` | ✓ | ✓ | ✗ |
+| 153 | `Size:` | ✓ | ✓ | ✗ |
+| 155 | `Selected Address:` | ✓ | ✓ | ✗ |
+| 157 | `Write` | ✓ | ✓ | ✗ |
+| 165 | `Battle Talk Jump` | ✓ | ✓ | ✗ |
+| 166 | `Battle BGM Jump` | ✓ | ✓ | ✗ |
+| 167 | `Death Quote Jump` | ✓ | ✓ | ✗ |
+| 168 | `Item Drop Dialog...` | ✓ | ✓ | ✗ |
+
 ### `FEBuilderGBA.Avalonia/Views/OptionsView.axaml`
 
 | Line | Literal | ja | zh | ko |
@@ -1303,6 +1401,45 @@ show which languages cover the literal.
 | 153 | `Battle BGM Jump` | ✓ | ✓ | ✗ |
 | 154 | `Death Quote Jump` | ✓ | ✓ | ✗ |
 
+### `FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 16 | `Top Address` | ✓ | ✓ | ✗ |
+| 21 | `Read Count` | ✓ | ✓ | ✗ |
+| 27 | `Reload` | ✓ | ✓ | ✗ |
+| 37 | `Address` | ✓ | ✓ | ✗ |
+| 42 | `Size:` | ✓ | ✓ | ✗ |
+| 46 | `Selected Address:` | ✓ | ✓ | ✗ |
+| 51 | `Write to ROM` | ✓ | ✓ | ✗ |
+| 63 | `Name` | ✓ | ✓ | ✗ |
+| 68 | `Search Internet for new resources` | ✓ | ✓ | ✗ |
+| 72 | `Expand List` | ✓ | ✓ | ✗ |
+| 84 | `Magic Effect Editor (FEditor)` | ✓ | ✓ | ✗ |
+| 90 | `Sample` | ✓ | ✓ | ✗ |
+| 99 | `Frame` | ✓ | ✓ | ✗ |
+| 108 | `Zoom` | ✓ | ✓ | ✗ |
+| 114 | `Zoom and Draw` | ✓ | ✓ | ✗ |
+| 115 | `Draw without enlarging` | ✓ | ✓ | ✗ |
+| 119 | `Display Example` | ✓ | ✓ | ✗ |
+| 137 | `dim_pc` | ✓ | ✓ | ✗ |
+| 139 | `NULL (EMPTY)` | ✓ | ✓ | ✗ |
+| 142 | `Comment` | ✓ | ✓ | ✗ |
+| 155 | `FrameData` | ✓ | ✓ | ✗ |
+| 161 | `OBJRightToLeft` | ✓ | ✓ | ✗ |
+| 168 | `OBJLeftToRight` | ✓ | ✓ | ✗ |
+| 175 | `OBJBGRightToLeft` | ✓ | ✓ | ✗ |
+| 182 | `OBBGLeftToRight` | ✓ | ✓ | ✗ |
+| 194 | `Import Magic Animation` | ✓ | ✓ | ✗ |
+| 196 | `Pending Core extraction - tracked by #500.` | ✓ | ✓ | ✗ |
+| 199 | `Export Magic Animation` | ✓ | ✓ | ✗ |
+| 201 | `Pending Core extraction - tracked by #500.` | ✓ | ✓ | ✗ |
+| 204 | `Editor` | ✓ | ✓ | ✗ |
+| 207 | `Open Source File` | ✓ | ✓ | ✗ |
+| 209 | `Pending Core extraction - tracked by #500.` | ✓ | ✓ | ✗ |
+| 212 | `Open Source Folder` | ✓ | ✓ | ✗ |
+| 214 | `Pending Core extraction - tracked by #500.` | ✓ | ✓ | ✗ |
+
 ### `FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml`
 
 | Line | Literal | ja | zh | ko |
@@ -1418,6 +1555,79 @@ show which languages cover the literal.
 | 203 | `Jump to World Map Points` | ✓ | ✓ | ✗ |
 | 208 | `Jump to World Map Paths (roads)` | ✓ | ✓ | ✗ |
 
+### `FEBuilderGBA.Avalonia/Views/OPClassDemoFE7UView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Address` | ✓ | ✓ | ✗ |
+| 17 | `Size:` | ✓ | ✓ | ✗ |
+| 22 | `Selected Address:` | ✓ | ✓ | ✗ |
+| 27 | `Write to ROM` | ✓ | ✓ | ✗ |
+| 40 | `OP Class Demo (FE7U) Editor` | ✓ | ✓ | ✗ |
+| 49 | `Address:` | ✓ | ✓ | ✗ |
+| 54 | `English Name Pointer:` | ✓ | ✓ | ✗ |
+| 59 | `Description Text ID:` | ✓ | ✓ | ✗ |
+| 68 | `Japanese Name Pointer:` | ✓ | ✓ | ✗ |
+| 73 | `Japanese Name Length:` | ✓ | ✓ | ✗ |
+| 78 | `Class ID:` | ✓ | ✓ | ✗ |
+| 81 | `Click to open Class Editor` | ✓ | ✓ | ✗ |
+| 86 | `Ally/Enemy Color:` | ✓ | ✓ | ✗ |
+| 91 | `Battle Anime:` | ✓ | ✓ | ✗ |
+| 96 | `Magic Effect:` | ✓ | ✓ | ✗ |
+| 101 | `Unknown (0x0F):` | ✓ | ✓ | ✗ |
+| 106 | `Unknown (0x10):` | ✓ | ✓ | ✗ |
+| 111 | `Unknown (0x11):` | ✓ | ✓ | ✗ |
+| 116 | `Unknown (0x13):` | ✓ | ✓ | ✗ |
+| 121 | `Terrain Left:` | ✓ | ✓ | ✗ |
+| 126 | `Terrain Right:` | ✓ | ✓ | ✗ |
+| 131 | `Unknown (0x16):` | ✓ | ✓ | ✗ |
+| 136 | `Unknown (0x17):` | ✓ | ✓ | ✗ |
+| 141 | `Anime Pointer:` | ✓ | ✓ | ✗ |
+| 152 | `Animation Pointer Target Block` | ✓ | ✓ | ✗ |
+| 156 | `Address` | ✓ | ✓ | ✗ |
+| 160 | `Size:` | ✓ | ✓ | ✗ |
+| 164 | `Selected Address:` | ✓ | ✓ | ✗ |
+| 182 | `Command` | ✓ | ✓ | ✗ |
+| 188 | `Command Description:` | ✓ | ✓ | ✗ |
+| 206 | `Wait Frames` | ✓ | ✓ | ✗ |
+| 217 | `Write Animation Command` | ✓ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 14 | `Address (decimal)` | ✓ | ✓ | ✗ |
+| 19 | `Read Count` | ✓ | ✓ | ✗ |
+| 25 | `Reload` | ✓ | ✓ | ✗ |
+| 35 | `Address` | ✓ | ✓ | ✗ |
+| 40 | `Size:` | ✓ | ✓ | ✗ |
+| 44 | `Selected Address:` | ✓ | ✓ | ✗ |
+| 49 | `Write` | ✓ | ✓ | ✗ |
+| 59 | `Name` | ✓ | ✓ | ✗ |
+| 62 | `Data Expansion` | ✓ | ✓ | ✗ |
+| 73 | `OP Class Demo Editor` | ✓ | ✓ | ✗ |
+| 81 | `English Name Pointer:` | ✓ | ✓ | ✗ |
+| 91 | `Description Text ID:` | ✓ | ✓ | ✗ |
+| 101 | `Japanese Name Pointer:` | ✓ | ✓ | ✗ |
+| 108 | `Japanese Name Length:` | ✓ | ✓ | ✗ |
+| 115 | `Palette ID:` | ✓ | ✓ | ✗ |
+| 125 | `Display Weapon (Class):` | ✓ | ✓ | ✗ |
+| 135 | `Ally / Enemy Color:` | ✓ | ✓ | ✗ |
+| 145 | `Battle Anime:` | ✓ | ✓ | ✗ |
+| 155 | `Magic Effect:` | ✓ | ✓ | ✗ |
+| 172 | `Unknown (0x12):` | ✓ | ✓ | ✗ |
+| 176 | `Battle Anime (Patch +1):` | ✓ | ✓ | ✗ |
+| 184 | `Terrain (Left Half):` | ✓ | ✓ | ✗ |
+| 194 | `Terrain (Right Half):` | ✓ | ✓ | ✗ |
+| 204 | `Anime Spec Pointer:` | ✓ | ✓ | ✗ |
+| 216 | `Japanese Name Font Glyphs (pointer P8)` | ✓ | ✓ | ✗ |
+| 219 | `Glyph:` | ✓ | ✓ | ✗ |
+| 230 | `Write Glyph Entry` | ✓ | ✓ | ✗ |
+| 242 | `Animation Commands (pointer P24)` | ✓ | ✓ | ✗ |
+| 245 | `Command:` | ✓ | ✓ | ✗ |
+| 253 | `Arg (/60 sec):` | ✓ | ✓ | ✗ |
+| 260 | `Write Anime Command` | ✓ | ✓ | ✗ |
+
 ### `FEBuilderGBA.Avalonia/Views/SongInstrumentView.axaml`
 
 | Line | Literal | ja | zh | ko |
@@ -1454,6 +1664,42 @@ show which languages cover the literal.
 | 120 | `Unknown instrument type. Raw 12-byte data is shown in the header byte field.` | ✓ | ✓ | ✗ |
 | 124 | `Write` | ✓ | ✓ | ✗ |
 
+### `FEBuilderGBA.Avalonia/Views/ToolTranslateROMView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 9 | `Simple` | ✓ | ✓ | ✗ |
+| 47 | `Extra Font ROM` | ✓ | ✓ | ✗ |
+| 62 | `Translation Data` | ✓ | ✓ | ✗ |
+| 68 | `Without a file, only static texts are translated.` | ✓ | ✓ | ✗ |
+| 76 | `Override JP Font` | ✓ | ✓ | ✗ |
+| 83 | `Start Translation` | ✓ | ✓ | ✗ |
+| 86 | `Pending Core extraction - tracked by #536` | ✓ | ✓ | ✗ |
+| 93 | `Translates the ROM. Uses Japanese and English ROMs to convert unchanged text automatically. Simple mode is fully automatic - it imports missing fonts, adjusts menu lengths, and similar. All processing… (truncated)` | ✓ | ✓ | ✗ |
+| 101 | `Detail` | ✓ | ✓ | ✗ |
+| 107 | `Export All Text` | ✓ | ✓ | ✗ |
+| 111 | `Writes all texts to a text file.` | ✓ | ✓ | ✗ |
+| 116 | `Translate before Export` | ✓ | ✓ | ✗ |
+| 119 | `Translate static texts (extract from FROM ROM and TO ROM, use as translation reference)` | ✓ | ✓ | ✗ |
+| 123 | `OneLiner` | ✓ | ✓ | ✗ |
+| 136 | `from:` | ✓ | ✓ | ✗ |
+| 183 | `Only acquire modified text` | ✓ | ✓ | ✗ |
+| 191 | `Export All Texts` | ✓ | ✓ | ✗ |
+| 194 | `Pending Core extraction - tracked by #536` | ✓ | ✓ | ✗ |
+| 202 | `Import All Text` | ✓ | ✓ | ✗ |
+| 206 | `Rewrites all texts with the contents of the specified file. Requires the anti-Huffman and DrawMultibyte/DrawSingleByte patches. After it finishes, import any missing fonts separately.` | ✓ | ✓ | ✗ |
+| 209 | `Override JP Font` | ✓ | ✓ | ✗ |
+| 215 | `Import All Texts` | ✓ | ✓ | ✗ |
+| 218 | `Pending Core extraction - tracked by #536` | ✓ | ✓ | ✗ |
+| 225 | `Font` | ✓ | ✓ | ✗ |
+| 229 | `Copies fonts that the current ROM is missing from the fonts in the ROM below.` | ✓ | ✓ | ✗ |
+| 244 | `Auto-Generate Missing Fonts` | ✓ | ✓ | ✗ |
+| 251 | `Use Font Name` | ✓ | ✓ | ✗ |
+| 259 | `Change` | ✓ | ✓ | ✗ |
+| 262 | `Pending Core extraction - tracked by #536` | ✓ | ✓ | ✗ |
+| 266 | `Import Font` | ✓ | ✓ | ✗ |
+| 269 | `Pending Core extraction - tracked by #536` | ✓ | ✓ | ✗ |
+
 ### `FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml`
 
 | Line | Literal | ja | zh | ko |
@@ -1488,6 +1734,41 @@ show which languages cover the literal.
 | 104 | `Use Effect (B30):` | ✓ | ✓ | ✗ |
 | 108 | `Dmg Effect (B31):` | ✓ | ✓ | ✗ |
 | 113 | `Write` | ✓ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Top Address` | ✓ | ✓ | ✗ |
+| 17 | `Read Count` | ✓ | ✓ | ✗ |
+| 23 | `Reload` | ✓ | ✓ | ✗ |
+| 24 | `Filter` | ✓ | ✓ | ✗ |
+| 34 | `Address` | ✓ | ✓ | ✗ |
+| 39 | `Size:` | ✓ | ✓ | ✗ |
+| 44 | `Selected Address:` | ✓ | ✓ | ✗ |
+| 49 | `Write to ROM` | ✓ | ✓ | ✗ |
+| 58 | `Name` | ✓ | ✓ | ✗ |
+| 61 | `Data Expansion` | ✓ | ✓ | ✗ |
+| 63 | `Pending Core extraction - tracked by #524` | ✓ | ✓ | ✗ |
+| 74 | `Map Tile Animation Type 2 (Palette)` | ✓ | ✓ | ✗ |
+| 79 | `Address:` | ✓ | ✓ | ✗ |
+| 83 | `Palette Data Pointer:` | ✓ | ✓ | ✗ |
+| 87 | `Animation Interval:` | ✓ | ✓ | ✗ |
+| 92 | `Data Count:` | ✓ | ✓ | ✗ |
+| 97 | `Start Palette Index:` | ✓ | ✓ | ✗ |
+| 102 | `Unknown (0x07):` | ✓ | ✓ | ✗ |
+| 113 | `Map Tile Animation Type 2 Palette Sub-Table` | ✓ | ✓ | ✗ |
+| 117 | `Address` | ✓ | ✓ | ✗ |
+| 121 | `Size:` | ✓ | ✓ | ✗ |
+| 126 | `Selected Address:` | ✓ | ✓ | ✗ |
+| 132 | `Write to ROM` | ✓ | ✓ | ✗ |
+| 153 | `GBA Color` | ✓ | ✓ | ✗ |
+| 184 | `Data Expansion` | ✓ | ✓ | ✗ |
+| 186 | `Pending Core extraction - tracked by #524` | ✓ | ✓ | ✗ |
+| 195 | `Bulk Import` | ✓ | ✓ | ✗ |
+| 197 | `Pending Core extraction - tracked by #524` | ✓ | ✓ | ✗ |
+| 200 | `Bulk Export` | ✓ | ✓ | ✗ |
+| 202 | `Pending Core extraction - tracked by #524` | ✓ | ✓ | ✗ |
 
 ### `FEBuilderGBA.Avalonia/Views/PointerToolView.axaml`
 
@@ -1557,40 +1838,6 @@ show which languages cover the literal.
 | 139 | `No animation data found for this ID (ID=0 or invalid pointer chain).` | ✓ | ✓ | ✗ |
 | 145 | `Animation Table Summary` | ✓ | ✓ | ✗ |
 | 146 | `Total animations: --` | ✓ | ✓ | ✗ |
-
-### `FEBuilderGBA.Avalonia/Views/ImagePortraitView.axaml`
-
-| Line | Literal | ja | zh | ko |
-|---:|---|:---:|:---:|:---:|
-| 12 | `Portrait Image Editor` | ✓ | ✓ | ✗ |
-| 15 | `Import PNG` | ✓ | ✓ | ✗ |
-| 16 | `FE-Repo` | ✓ | ✓ | ✗ |
-| 17 | `Export Face` | ✓ | ✓ | ✗ |
-| 18 | `Export Mini` | ✓ | ✓ | ✗ |
-| 19 | `Export Sheet` | ✓ | ✓ | ✗ |
-| 20 | `Export PAL` | ✓ | ✓ | ✗ |
-| 21 | `Import PAL` | ✓ | ✓ | ✗ |
-| 27 | `Unit Face (96x80)` | ✓ | ✓ | ✗ |
-| 31 | `Map Face (32x32)` | ✓ | ✓ | ✗ |
-| 35 | `Class Card` | ✓ | ✓ | ✗ |
-| 42 | `Show Frame:` | ✓ | ✓ | ✗ |
-| 51 | `Mouth Frames (32x16 x6)` | ✓ | ✓ | ✗ |
-| 55 | `Eye Frames (32x16 x2)` | ✓ | ✓ | ✗ |
-| 62 | `Address:` | ✓ | ✓ | ✗ |
-| 66 | `Unit Face:` | ✓ | ✓ | ✗ |
-| 70 | `Map Face:` | ✓ | ✓ | ✗ |
-| 74 | `Palette:` | ✓ | ✓ | ✗ |
-| 78 | `Mouth Frames:` | ✓ | ✓ | ✗ |
-| 82 | `Class Card:` | ✓ | ✓ | ✗ |
-| 86 | `Mouth X:` | ✓ | ✓ | ✗ |
-| 91 | `Mouth Y:` | ✓ | ✓ | ✗ |
-| 97 | `Eye X:` | ✓ | ✓ | ✗ |
-| 102 | `Eye Y:` | ✓ | ✓ | ✗ |
-| 108 | `Write Positions` | ✓ | ✓ | ✗ |
-| 112 | `Status:` | ✓ | ✓ | ✗ |
-| 116 | `Unused (B25):` | ✓ | ✓ | ✗ |
-| 120 | `Unused (B26):` | ✓ | ✓ | ✗ |
-| 124 | `Unused (B27):` | ✓ | ✓ | ✗ |
 
 ### `FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml`
 
@@ -1776,34 +2023,6 @@ show which languages cover the literal.
 | 95 | `AI4 Retreat:` | ✓ | ✓ | ✗ |
 | 101 | `Write` | ✓ | ✓ | ✗ |
 
-### `FEBuilderGBA.Avalonia/Views/EventUnitView.axaml`
-
-| Line | Literal | ja | zh | ko |
-|---:|---|:---:|:---:|:---:|
-| 11 | `Maps` | ✓ | ✓ | ✗ |
-| 17 | `Unit Groups` | ✓ | ✓ | ✗ |
-| 24 | `Units` | ✓ | ✓ | ✗ |
-| 27 | `Load` | ✓ | ✓ | ✗ |
-| 36 | `Event Unit Placement (FE8)` | ✓ | ✓ | ✗ |
-| 40 | `Address:` | ✓ | ✓ | ✗ |
-| 44 | `Unit ID:` | ✓ | ✓ | ✗ |
-| 49 | `Class ID:` | ✓ | ✓ | ✗ |
-| 54 | `Leader Unit ID:` | ✓ | ✓ | ✗ |
-| 58 | `Unit Info:` | ✓ | ✓ | ✗ |
-| 62 | `Unit Growth:` | ✓ | ✓ | ✗ |
-| 66 | `Reserved (0x06):` | ✓ | ✓ | ✗ |
-| 70 | `Coord Count:` | ✓ | ✓ | ✗ |
-| 74 | `Coord Pointer:` | ✓ | ✓ | ✗ |
-| 78 | `Item 1:` | ✓ | ✓ | ✗ |
-| 82 | `Item 2:` | ✓ | ✓ | ✗ |
-| 86 | `Item 3:` | ✓ | ✓ | ✗ |
-| 90 | `Item 4:` | ✓ | ✓ | ✗ |
-| 95 | `AI1 Primary:` | ✓ | ✓ | ✗ |
-| 99 | `AI2 Secondary:` | ✓ | ✓ | ✗ |
-| 103 | `AI3 Target/Recovery:` | ✓ | ✓ | ✗ |
-| 107 | `AI4 Retreat:` | ✓ | ✓ | ✗ |
-| 113 | `Write` | ✓ | ✓ | ✗ |
-
 ### `FEBuilderGBA.Avalonia/Views/PortraitViewerView.axaml`
 
 | Line | Literal | ja | zh | ko |
@@ -1864,7 +2083,7 @@ show which languages cover the literal.
 | Line | Literal | ja | zh | ko |
 |---:|---|:---:|:---:|:---:|
 | 12 | `Filter:` | ✓ | ✓ | ✗ |
-| 15 | `Hex Address` | ✓ | ✓ | ✗ |
+| 15 | `Address (decimal)` | ✓ | ✓ | ✗ |
 | 20 | `Count` | ✓ | ✓ | ✗ |
 | 26 | `Reload` | ✓ | ✓ | ✗ |
 | 33 | `Address:` | ✓ | ✓ | ✗ |
@@ -2017,7 +2236,7 @@ show which languages cover the literal.
 
 | Line | Literal | ja | zh | ko |
 |---:|---|:---:|:---:|:---:|
-| 12 | `Hex Address` | ✓ | ✓ | ✗ |
+| 12 | `Address (decimal)` | ✓ | ✓ | ✗ |
 | 17 | `Read Count` | ✓ | ✓ | ✗ |
 | 23 | `Reload` | ✓ | ✓ | ✗ |
 | 30 | `Address:` | ✓ | ✓ | ✗ |
@@ -2060,6 +2279,52 @@ show which languages cover the literal.
 | 54 | `Luck` | ✓ | ✓ | ✗ |
 | 68 | `Padding` | ✓ | ✓ | ✗ |
 | 78 | `Write` | ✓ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EventMapChangeView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 13 | `Top Address` | ✓ | ✓ | ✗ |
+| 18 | `Read Count` | ✓ | ✓ | ✗ |
+| 24 | `Reload` | ✓ | ✓ | ✗ |
+| 32 | `Address` | ✓ | ✓ | ✗ |
+| 37 | `Size:` | ✓ | ✓ | ✗ |
+| 41 | `Selected Address:` | ✓ | ✓ | ✗ |
+| 46 | `Write` | ✓ | ✓ | ✗ |
+| 53 | `Map Names` | ✓ | ✓ | ✗ |
+| 62 | `Map Change Event Editor` | ✓ | ✓ | ✗ |
+| 67 | `Address:` | ✓ | ✓ | ✗ |
+| 78 | `Number:` | ✓ | ✓ | ✗ |
+| 86 | `Coordinates:` | ✓ | ✓ | ✗ |
+| 99 | `Size:` | ✓ | ✓ | ✗ |
+| 132 | `Change Data Pointer` | ✓ | ✓ | ✗ |
+| 139 | `Comment` | ✓ | ✓ | ✗ |
+| 160 | `Names` | ✓ | ✓ | ✗ |
+| 167 | `Expand List (+1 slot)` | ✓ | ✓ | ✗ |
+| 176 | `Pointer Import` | ✓ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/MapExitPointView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Cond:` | ✓ | ✓ | ✗ |
+| 15 | `Address (decimal)` | ✓ | ✓ | ✗ |
+| 21 | `Reload` | ✓ | ✓ | ✗ |
+| 28 | `Leave Pointer` | ✓ | ✓ | ✗ |
+| 33 | `Count` | ✓ | ✓ | ✗ |
+| 39 | `Reload Exit Points` | ✓ | ✓ | ✗ |
+| 41 | `Write Off Pointer` | ✓ | ✓ | ✗ |
+| 48 | `Map Name` | ✓ | ✓ | ✗ |
+| 60 | `Name` | ✓ | ✓ | ✗ |
+| 63 | `Alloc New Space` | ✓ | ✓ | ✗ |
+| 66 | `Data Expansion` | ✓ | ✓ | ✗ |
+| 77 | `Map Exit Point Editor` | ✓ | ✓ | ✗ |
+| 81 | `Address` | ✓ | ✓ | ✗ |
+| 87 | `Size:` | ✓ | ✓ | ✗ |
+| 92 | `Selected Address` | ✓ | ✓ | ✗ |
+| 101 | `Coordinates` | ✓ | ✓ | ✗ |
+| 111 | `Direction` | ✓ | ✓ | ✗ |
+| 131 | `Write` | ✓ | ✓ | ✗ |
 
 ### `FEBuilderGBA.Avalonia/Views/SkillConfigFE8NSkillView.axaml`
 
@@ -2171,27 +2436,6 @@ show which languages cover the literal.
 | 74 | `Target/Recovery AI:` | ✓ | ✓ | ✗ |
 | 77 | `Retreat AI:` | ✓ | ✓ | ✗ |
 | 82 | `Write` | ✓ | ✓ | ✗ |
-
-### `FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml`
-
-| Line | Literal | ja | zh | ko |
-|---:|---|:---:|:---:|:---:|
-| 11 | `OP Class Demo Editor` | ✓ | ✓ | ✗ |
-| 13 | `Address:` | ✓ | ✓ | ✗ |
-| 16 | `English Name Pointer:` | ✓ | ✓ | ✗ |
-| 19 | `Description Text ID:` | ✓ | ✓ | ✗ |
-| 25 | `Japanese Name Pointer:` | ✓ | ✓ | ✗ |
-| 28 | `Japanese Name Length:` | ✓ | ✓ | ✗ |
-| 31 | `Palette ID:` | ✓ | ✓ | ✗ |
-| 34 | `Display Weapon:` | ✓ | ✓ | ✗ |
-| 37 | `Ally/Enemy Color:` | ✓ | ✓ | ✗ |
-| 40 | `Battle Anime:` | ✓ | ✓ | ✗ |
-| 43 | `Magic Effect:` | ✓ | ✓ | ✗ |
-| 46 | `Unknown (0x12):` | ✓ | ✓ | ✗ |
-| 49 | `Terrain Left:` | ✓ | ✓ | ✗ |
-| 52 | `Terrain Right:` | ✓ | ✓ | ✗ |
-| 55 | `Anime Pointer:` | ✓ | ✓ | ✗ |
-| 59 | `Write` | ✓ | ✓ | ✗ |
 
 ### `FEBuilderGBA.Avalonia/Views/TextDicView.axaml`
 
@@ -2351,25 +2595,6 @@ show which languages cover the literal.
 | 72 | `Remove Last Slot` | ✓ | ✓ | ✗ |
 | 74 | `Reload` | ✓ | ✓ | ✗ |
 | 75 | `Rescan the ROM for shops (use after editing events).` | ✓ | ✓ | ✗ |
-
-### `FEBuilderGBA.Avalonia/Views/OPClassDemoFE7UView.axaml`
-
-| Line | Literal | ja | zh | ko |
-|---:|---|:---:|:---:|:---:|
-| 12 | `OP Class Demo (FE7U) Editor` | ✓ | ✓ | ✗ |
-| 16 | `Address:` | ✓ | ✓ | ✗ |
-| 19 | `English Name Pointer:` | ✓ | ✓ | ✗ |
-| 22 | `Description Text ID:` | ✓ | ✓ | ✗ |
-| 28 | `Japanese Name Length:` | ✓ | ✓ | ✗ |
-| 31 | `Class ID:` | ✓ | ✓ | ✗ |
-| 34 | `Click to open Class Editor` | ✓ | ✓ | ✗ |
-| 37 | `Ally/Enemy Color:` | ✓ | ✓ | ✗ |
-| 40 | `Battle Anime:` | ✓ | ✓ | ✗ |
-| 43 | `Magic Effect:` | ✓ | ✓ | ✗ |
-| 46 | `Terrain Left:` | ✓ | ✓ | ✗ |
-| 49 | `Terrain Right:` | ✓ | ✓ | ✗ |
-| 52 | `Anime Pointer:` | ✓ | ✓ | ✗ |
-| 56 | `Write` | ✓ | ✓ | ✗ |
 
 ### `FEBuilderGBA.Avalonia/Views/SupportTalkView.axaml`
 
@@ -2661,7 +2886,7 @@ show which languages cover the literal.
 | Line | Literal | ja | zh | ko |
 |---:|---|:---:|:---:|:---:|
 | 12 | `Condition:` | ✓ | ✓ | ✗ |
-| 15 | `Hex Address` | ✓ | ✓ | ✗ |
+| 15 | `Address (decimal)` | ✓ | ✓ | ✗ |
 | 20 | `Count` | ✓ | ✓ | ✗ |
 | 26 | `Reload` | ✓ | ✓ | ✗ |
 | 35 | `Terrain BG Lookup Table` | ✓ | ✓ | ✗ |
@@ -2677,7 +2902,7 @@ show which languages cover the literal.
 | Line | Literal | ja | zh | ko |
 |---:|---|:---:|:---:|:---:|
 | 12 | `Condition:` | ✓ | ✓ | ✗ |
-| 15 | `Hex Address` | ✓ | ✓ | ✗ |
+| 15 | `Address (decimal)` | ✓ | ✓ | ✗ |
 | 20 | `Count` | ✓ | ✓ | ✗ |
 | 26 | `Reload` | ✓ | ✓ | ✗ |
 | 35 | `Terrain Floor Lookup Table` | ✓ | ✓ | ✗ |
@@ -3142,19 +3367,6 @@ show which languages cover the literal.
 | 25 | `Bonus:` | ✓ | ✓ | ✗ |
 | 28 | `Penalty:` | ✓ | ✓ | ✗ |
 | 33 | `Write` | ✓ | ✓ | ✗ |
-
-### `FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml`
-
-| Line | Literal | ja | zh | ko |
-|---:|---|:---:|:---:|:---:|
-| 12 | `Map Tile Animation Type 2 (Palette)` | ✓ | ✓ | ✗ |
-| 15 | `Address:` | ✓ | ✓ | ✗ |
-| 18 | `Palette Data Pointer:` | ✓ | ✓ | ✗ |
-| 21 | `Animation Interval:` | ✓ | ✓ | ✗ |
-| 24 | `Data Count:` | ✓ | ✓ | ✗ |
-| 27 | `Start Palette Index:` | ✓ | ✓ | ✗ |
-| 30 | `Unknown (0x07):` | ✓ | ✓ | ✗ |
-| 35 | `Write` | ✓ | ✓ | ✗ |
 
 ### `FEBuilderGBA.Avalonia/Views/SongTableView.axaml`
 
@@ -4089,15 +4301,6 @@ show which languages cover the literal.
 | 32 | `Probability %:` | ✓ | ✓ | ✗ |
 | 37 | `Write` | ✓ | ✓ | ✗ |
 
-### `FEBuilderGBA.Avalonia/Views/MapExitPointView.axaml`
-
-| Line | Literal | ja | zh | ko |
-|---:|---|:---:|:---:|:---:|
-| 12 | `Map Exit Point Editor` | ✓ | ✓ | ✗ |
-| 15 | `Address:` | ✓ | ✓ | ✗ |
-| 18 | `Exit Pointer:` | ✓ | ✓ | ✗ |
-| 22 | `Write` | ✓ | ✓ | ✗ |
-
 ### `FEBuilderGBA.Avalonia/Views/MapPointerView.axaml`
 
 | Line | Literal | ja | zh | ko |
@@ -4561,13 +4764,6 @@ show which languages cover the literal.
 | 12 | `Haiku Event Editor` | ✓ | ✓ | ✗ |
 | 15 | `Address:` | ✓ | ✓ | ✗ |
 
-### `FEBuilderGBA.Avalonia/Views/EventMapChangeView.axaml`
-
-| Line | Literal | ja | zh | ko |
-|---:|---|:---:|:---:|:---:|
-| 12 | `Map Change Event Editor` | ✓ | ✓ | ✗ |
-| 15 | `Address:` | ✓ | ✓ | ✗ |
-
 ### `FEBuilderGBA.Avalonia/Views/EventScriptCategorySelectView.axaml`
 
 | Line | Literal | ja | zh | ko |
@@ -4741,13 +4937,6 @@ show which languages cover the literal.
 | Line | Literal | ja | zh | ko |
 |---:|---|:---:|:---:|:---:|
 | 12 | `CSA Magic Creator` | ✓ | ✓ | ✗ |
-| 15 | `Address:` | ✓ | ✓ | ✗ |
-
-### `FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml`
-
-| Line | Literal | ja | zh | ko |
-|---:|---|:---:|:---:|:---:|
-| 12 | `Magic Effect Editor (FEditor)` | ✓ | ✓ | ✗ |
 | 15 | `Address:` | ✓ | ✓ | ✗ |
 
 ### `FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml`
@@ -5169,13 +5358,6 @@ show which languages cover the literal.
 |---:|---|:---:|:---:|:---:|
 | 18 | `Do not show this message again` | ✓ | ✓ | ✗ |
 | 20 | `Start` | ✓ | ✓ | ✗ |
-
-### `FEBuilderGBA.Avalonia/Views/ToolTranslateROMView.axaml`
-
-| Line | Literal | ja | zh | ko |
-|---:|---|:---:|:---:|:---:|
-| 12 | `ROM Translation Tool` | ✓ | ✓ | ✗ |
-| 15 | `Address:` | ✓ | ✓ | ✗ |
 
 ### `FEBuilderGBA.Avalonia/Views/ToolUPSOpenSimpleView.axaml`
 

--- a/docs/avalonia-gaps/2026-05-23-labels-sweep.md
+++ b/docs/avalonia-gaps/2026-05-23-labels-sweep.md
@@ -1,6 +1,6 @@
 ---
-generated: "2026-05-23T05:33:19Z"
-git-sha: a35299ba6
+generated: "2026-05-23T16:06:56Z"
+git-sha: 1f20893bb
 sweep-type: labels
 ---
 
@@ -36,9 +36,9 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-labels --out=<path>`.
 |---|---:|
 | Pairs scanned (both files exist) | 298 |
 | Pairs with ≥1 WF-only label | 293 |
-| Total WF-only labels | 4625 |
-| Total AV-only labels | 2803 |
-| Total common labels | 75 |
+| Total WF-only labels | 4593 |
+| Total AV-only labels | 2965 |
+| Total common labels | 107 |
 
 ## Top 20 Forms by WF-only Label Count
 
@@ -55,10 +55,10 @@ Cross-link to the [density sweep](2026-05-26-density-sweep.md) for quantitative 
 | 6 | `MapSettingForm` | `MapSettingView` | 78 | 116 | 0 |
 | 7 | `MapSettingFE6Form` | `MapSettingFE6View` | 65 | 2 | 0 |
 | 8 | `ClassForm` | `ClassEditorView` | 57 | 100 | 1 |
-| 9 | `EventUnitForm` | `EventUnitView` | 50 | 24 | 0 |
-| 10 | `SongInstrumentForm` | `SongInstrumentView` | 50 | 21 | 1 |
-| 11 | `TextForm` | `TextViewerView` | 48 | 13 | 0 |
-| 12 | `WorldMapImageForm` | `WorldMapImageView` | 47 | 2 | 0 |
+| 9 | `SongInstrumentForm` | `SongInstrumentView` | 50 | 21 | 1 |
+| 10 | `TextForm` | `TextViewerView` | 48 | 13 | 0 |
+| 11 | `WorldMapImageForm` | `WorldMapImageView` | 47 | 2 | 0 |
+| 12 | `EventUnitForm` | `EventUnitView` | 46 | 41 | 4 |
 | 13 | `ImageUnitPaletteForm` | `ImageUnitPaletteView` | 45 | 17 | 0 |
 | 14 | `ItemForm` | `ItemEditorView` | 45 | 71 | 0 |
 | 15 | `MapStyleEditorForm` | `MapStyleEditorView` | 45 | 5 | 0 |
@@ -1279,89 +1279,6 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Weapon Rank Levels (B44-B51)`
 - `Write`
 
-### EventUnitForm
-WF labels: **50** · AV labels: **24** · WF-only: **50** · AV-only: **24** · Common: **0** · Density verdict: **Medium** (WF 95 / AV 54)
-
-WF-only labels (candidates for missing fields in AV):
-
-- `/60秒`
-- `1次AI`
-- `2次AI`
-- `??`
-- `Close`
-- `FF`
-- `LV:`
-- `Size:`
-- `X:`
-- `Y:`
-- `↑`
-- `↓`
-- `アイテムドロップ`
-- `アドレス`
-- `イベント名前`
-- `クラス`
-- `コメント`
-- `マップ名前`
-- `ユニット情報`
-- `ユニット番号`
-- `リストの拡張`
-- `交戦時BGMへJump`
-- `交戦時セリフへJump`
-- `先頭アドレス`
-- `再取得`
-- `削除`
-- `名前`
-- `変更`
-- `座標`
-- `待機`
-- `成長率:`
-- `所属:`
-- `所持品1`
-- `所持品2`
-- `所持品3`
-- `所持品4`
-- `指揮官`
-- `新規挿入`
-- `新規領域の確保`
-- `書き込み`
-- `標的と回復AI`
-- `死亡時セリフへJump`
-- `特殊`
-- `移動後座標`
-- `移動速度`
-- `読込数`
-- `追従`
-- `退避AI`
-- `選択アドレス:`
-- `配置後座標格納アドレス`
-
-AV-only labels (usually fine — layout polish or rewording):
-
-- `0x Address`
-- `Address:`
-- `AI1 Primary:`
-- `AI2 Secondary:`
-- `AI3 Target/Recovery:`
-- `AI4 Retreat:`
-- `Class ID:`
-- `Coord Count:`
-- `Coord Pointer:`
-- `Event Unit Placement (FE8)`
-- `Item 1:`
-- `Item 2:`
-- `Item 3:`
-- `Item 4:`
-- `Leader Unit ID:`
-- `Load`
-- `Maps`
-- `Reserved (0x06):`
-- `Unit Groups`
-- `Unit Growth:`
-- `Unit ID:`
-- `Unit Info:`
-- `Units`
-- `Write`
-
 ### SongInstrumentForm
 WF labels: **51** · AV labels: **22** · WF-only: **50** · AV-only: **21** · Common: **1** · Density verdict: **High** (WF 323 / AV 54)
 
@@ -1569,6 +1486,102 @@ AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
 - `World Map Image`
+
+### EventUnitForm
+WF labels: **50** · AV labels: **45** · WF-only: **46** · AV-only: **41** · Common: **4** · Density verdict: **Low** (WF 95 / AV 85)
+
+WF-only labels (candidates for missing fields in AV):
+
+- `/60秒`
+- `1次AI`
+- `2次AI`
+- `??`
+- `Close`
+- `FF`
+- `↑`
+- `↓`
+- `アイテムドロップ`
+- `アドレス`
+- `イベント名前`
+- `クラス`
+- `コメント`
+- `マップ名前`
+- `ユニット情報`
+- `ユニット番号`
+- `リストの拡張`
+- `交戦時BGMへJump`
+- `交戦時セリフへJump`
+- `先頭アドレス`
+- `再取得`
+- `削除`
+- `名前`
+- `変更`
+- `座標`
+- `待機`
+- `成長率:`
+- `所属:`
+- `所持品1`
+- `所持品2`
+- `所持品3`
+- `所持品4`
+- `指揮官`
+- `新規挿入`
+- `新規領域の確保`
+- `書き込み`
+- `標的と回復AI`
+- `死亡時セリフへJump`
+- `特殊`
+- `移動後座標`
+- `移動速度`
+- `読込数`
+- `追従`
+- `退避AI`
+- `選択アドレス:`
+- `配置後座標格納アドレス`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `0x Address`
+- `0x14`
+- `Address:`
+- `After Coordinates:`
+- `Allegiance:`
+- `Battle BGM Jump`
+- `Battle Talk Jump`
+- `Before Coordinates:`
+- `Class:`
+- `Commander:`
+- `Comment:`
+- `Count:`
+- `Death Quote Jump`
+- `Drop Item`
+- `Event Names`
+- `Event Unit Placement (FE8)`
+- `Expand List`
+- `Growth Rate:`
+- `Item 1:`
+- `Item 2:`
+- `Item 3:`
+- `Item 4:`
+- `Item Drop Dialog...`
+- `Load`
+- `Map Names`
+- `Names`
+- `New Allocation`
+- `Pointer:`
+- `Primary AI:`
+- `Random Monster`
+- `Read Count`
+- `Reload`
+- `Reserved (0x06):`
+- `Retreat AI:`
+- `Secondary AI:`
+- `Selected Address:`
+- `Target/Recovery AI:`
+- `Top Address`
+- `Unit Info:`
+- `Unit Number:`
+- `Write`
 
 ### ImageUnitPaletteForm
 WF labels: **45** · AV labels: **17** · WF-only: **45** · AV-only: **17** · Common: **0** · Density verdict: **High** (WF 133 / AV 32)
@@ -2895,13 +2908,12 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write`
 
 ### ImagePortraitForm
-WF labels: **32** · AV labels: **28** · WF-only: **32** · AV-only: **28** · Common: **0** · Density verdict: **Medium** (WF 63 / AV 45)
+WF labels: **32** · AV labels: **50** · WF-only: **31** · AV-only: **49** · Common: **1** · Density verdict: **Low** (WF 63 / AV 77)
 
 WF-only labels (candidates for missing fields in AV):
 
 - `00`
 - `mug_exceed用のタイルをどこに配置するか設定してください`
-- `Size:`
 - `X:`
 - `Y:`
 - `アドレス`
@@ -2934,8 +2946,12 @@ WF-only labels (candidates for missing fields in AV):
 
 AV-only labels (usually fine — layout polish or rewording):
 
+- `0 = Close Mouth (deprecated)`
+- `1 = Normal`
+- `6 = Close Eyes`
 - `Address:`
 - `Class Card`
+- `Comment:`
 - `Export Face`
 - `Export Mini`
 - `Export PAL`
@@ -2946,22 +2962,39 @@ AV-only labels (usually fine — layout polish or rewording):
 - `FE-Repo`
 - `Import PAL`
 - `Import PNG`
+- `Jump to Importer`
+- `Jump to Palette`
+- `Jump to Status Height`
 - `Map Face:`
 - `Map Face (32x32)`
 - `Mouth Frames:`
 - `Mouth Frames (32x16 x6)`
 - `Mouth X:`
 - `Mouth Y:`
+- `MugExceed Tile1 X:`
+- `MugExceed Tile1 Y:`
+- `MugExceed Tile2 X:`
+- `MugExceed Tile2 Y:`
+- `Open Source File`
 - `Palette:`
 - `Portrait Image Editor`
+- `Read Count:`
+- `Reload`
+- `Select Source Folder`
+- `Selected Address:`
+- `Set mug_exceed tile positions:`
+- `Show Example (Frame 4)`
 - `Show Frame:`
+- `Start Address:`
 - `Status:`
+- `Tile 1`
+- `Tile 2`
 - `Unit Face:`
 - `Unit Face (96x80)`
 - `Unused (B25):`
 - `Unused (B26):`
 - `Unused (B27):`
-- `Write Positions`
+- `Write`
 
 ### SkillConfigFE8NVer2SkillForm
 WF labels: **31** · AV labels: **10** · WF-only: **31** · AV-only: **10** · Common: **0** · Density verdict: **High** (WF 136 / AV 17)
@@ -3303,7 +3336,7 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Yes Text ID:`
 
 ### OPClassDemoForm
-WF labels: **27** · AV labels: **16** · WF-only: **27** · AV-only: **16** · Common: **0** · Density verdict: **High** (WF 63 / AV 31)
+WF labels: **27** · AV labels: **32** · WF-only: **26** · AV-only: **31** · Common: **1** · Density verdict: **Low** (WF 63 / AV 65)
 
 WF-only labels (candidates for missing fields in AV):
 
@@ -3311,7 +3344,6 @@ WF-only labels (candidates for missing fields in AV):
 - `00`
 - `??`
 - `Commamd`
-- `Size:`
 - `アドレス`
 - `アニメ指定\r\nポインタ書き込み`
 - `アニメ指定のポインタ`
@@ -3337,22 +3369,37 @@ WF-only labels (candidates for missing fields in AV):
 
 AV-only labels (usually fine — layout polish or rewording):
 
-- `Address:`
-- `Ally/Enemy Color:`
-- `Anime Pointer:`
+- `28`
+- `Address`
+- `Address (decimal)`
+- `Ally / Enemy Color:`
+- `Animation Commands (pointer P24)`
+- `Anime Spec Pointer:`
+- `Arg (/60 sec):`
 - `Battle Anime:`
+- `Battle Anime (Patch +1):`
+- `Command:`
+- `Data Expansion`
 - `Description Text ID:`
-- `Display Weapon:`
+- `Display Weapon (Class):`
 - `English Name Pointer:`
+- `Glyph:`
+- `Japanese Name Font Glyphs (pointer P8)`
 - `Japanese Name Length:`
 - `Japanese Name Pointer:`
 - `Magic Effect:`
+- `Name`
 - `OP Class Demo Editor`
 - `Palette ID:`
-- `Terrain Left:`
-- `Terrain Right:`
+- `Read Count`
+- `Reload`
+- `Selected Address:`
+- `Terrain (Left Half):`
+- `Terrain (Right Half):`
 - `Unknown (0x12):`
 - `Write`
+- `Write Anime Command`
+- `Write Glyph Entry`
 
 ### ImageMagicCSACreatorForm
 WF labels: **25** · AV labels: **2** · WF-only: **25** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 37 / AV 3)
@@ -3390,42 +3437,6 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Address:`
 - `CSA Magic Creator`
 
-### ImageMagicFEditorForm
-WF labels: **25** · AV labels: **2** · WF-only: **25** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 37 / AV 3)
-
-WF-only labels (candidates for missing fields in AV):
-
-- `dim`
-- `FrameData`
-- `OBBGLeftToRight`
-- `OBJBGRightToLeft`
-- `OBJLeftToRight`
-- `OBJRightToLeft`
-- `Size:`
-- `アドレス`
-- `インターネットから新しいリソースを探す`
-- `エディタ`
-- `コメント`
-- `ソースファイルを開く`
-- `ソースフォルダーを開く`
-- `フレーム`
-- `リストの拡張`
-- `先頭アドレス`
-- `再取得`
-- `名前`
-- `拡大`
-- `書き込み`
-- `表示例`
-- `読込数`
-- `選択アドレス:`
-- `魔法アニメの書出し`
-- `魔法アニメの読込`
-
-AV-only labels (usually fine — layout polish or rewording):
-
-- `Address:`
-- `Magic Effect Editor (FEditor)`
-
 ### AIScriptForm
 WF labels: **24** · AV labels: **2** · WF-only: **24** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 37 / AV 3)
 
@@ -3460,53 +3471,6 @@ AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
 - `AI Script Editor`
-
-### OPClassDemoFE7UForm
-WF labels: **24** · AV labels: **14** · WF-only: **24** · AV-only: **14** · Common: **0** · Density verdict: **High** (WF 56 / AV 26)
-
-WF-only labels (candidates for missing fields in AV):
-
-- `/60 (秒)`
-- `00`
-- `??`
-- `Commamd`
-- `Size:`
-- `アドレス`
-- `アニメ指定\r\nポインタ書き込み`
-- `アニメ指定のポインタ`
-- `クラス`
-- `パレットID`
-- `リストの拡張`
-- `先頭アドレス`
-- `再取得`
-- `名前`
-- `戦闘アニメ`
-- `敵味方カラー`
-- `書き込み`
-- `英語ポインタ`
-- `表示地形右半分`
-- `表示地形左半分`
-- `説明文ID`
-- `読込数`
-- `選択アドレス:`
-- `魔法エフェクト`
-
-AV-only labels (usually fine — layout polish or rewording):
-
-- `Address:`
-- `Ally/Enemy Color:`
-- `Anime Pointer:`
-- `Battle Anime:`
-- `Class ID:`
-- `Click to open Class Editor`
-- `Description Text ID:`
-- `English Name Pointer:`
-- `Japanese Name Length:`
-- `Magic Effect:`
-- `OP Class Demo (FE7U) Editor`
-- `Terrain Left:`
-- `Terrain Right:`
-- `Write`
 
 ### SkillAssignmentClassCSkillSysForm
 WF labels: **24** · AV labels: **5** · WF-only: **24** · AV-only: **5** · Common: **0** · Density verdict: **High** (WF 43 / AV 7)
@@ -3671,6 +3635,74 @@ AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
 - `ED (FE7)`
+
+### OPClassDemoFE7UForm
+WF labels: **24** · AV labels: **37** · WF-only: **23** · AV-only: **36** · Common: **1** · Density verdict: **Low** (WF 56 / AV 62)
+
+WF-only labels (candidates for missing fields in AV):
+
+- `/60 (秒)`
+- `00`
+- `??`
+- `Commamd`
+- `アドレス`
+- `アニメ指定\r\nポインタ書き込み`
+- `アニメ指定のポインタ`
+- `クラス`
+- `パレットID`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `戦闘アニメ`
+- `敵味方カラー`
+- `書き込み`
+- `英語ポインタ`
+- `表示地形右半分`
+- `表示地形左半分`
+- `説明文ID`
+- `読込数`
+- `選択アドレス:`
+- `魔法エフェクト`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `/60 (sec)`
+- `1=Ranged attack anime`
+- `2=Ranged critical anime`
+- `3=Set anime state to 'hit effect applied'`
+- `4=Ranged attack anime (alt)`
+- `5=Wait N frames (arg = N/60 sec)`
+- `6=Ranged evade anime`
+- `7=Hit effect applied (FE8 unused)`
+- `8=Wait for C01/C02/C18 cmd`
+- `Address`
+- `Ally/Enemy Color:`
+- `Animation Pointer Target Block`
+- `Anime Pointer:`
+- `Battle Anime:`
+- `Class ID:`
+- `Click to open Class Editor`
+- `Command`
+- `Command Description:`
+- `Description Text ID:`
+- `English Name Pointer:`
+- `Japanese Name Length:`
+- `Japanese Name Pointer:`
+- `Magic Effect:`
+- `OP Class Demo (FE7U) Editor`
+- `Selected Address:`
+- `Terrain Left:`
+- `Terrain Right:`
+- `Unknown (0x0F):`
+- `Unknown (0x10):`
+- `Unknown (0x11):`
+- `Unknown (0x13):`
+- `Unknown (0x16):`
+- `Unknown (0x17):`
+- `Wait Frames`
+- `Write Animation Command`
+- `Write to ROM`
 
 ### OPClassDemoFE8UForm
 WF labels: **23** · AV labels: **12** · WF-only: **23** · AV-only: **12** · Common: **0** · Density verdict: **High** (WF 50 / AV 24)
@@ -3956,73 +3988,6 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Talk`
 - `Write`
 
-### ToolTranslateROMForm
-WF labels: **22** · AV labels: **2** · WF-only: **22** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 35 / AV 3)
-
-WF-only labels (candidates for missing fields in AV):
-
-- `..`
-- `from:`
-- `OneLiner`
-- `to:`
-- `すべてのテキストをテキストファイルに書きだします。`
-- `フォント取込`
-- `全テキストの書出し`
-- `全テキストの読込`
-- `利用フォント`
-- `変更`
-- `定型文ROM FROM`
-- `定型文ROM TO`
-- `定型文の翻訳(FROM ROMと TO ROMから、定型文を取得し、翻訳の参考にする)`
-- `改造されたテキストのみ取得する`
-- `日本語フォントの上書き`
-- `現行ROMに足りないフォントを、以下のROMにあるフォントからコピーする`
-- `簡易`
-- `翻訳データ`
-- `翻訳開始`
-- `詳細`
-- `足りないフォントの自動生成`
-- `追加フォント ROM`
-
-AV-only labels (usually fine — layout polish or rewording):
-
-- `Address:`
-- `ROM Translation Tool`
-
-### MapExitPointForm
-WF labels: **21** · AV labels: **4** · WF-only: **21** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 32 / AV 6)
-
-WF-only labels (candidates for missing fields in AV):
-
-- `00`
-- `Size:`
-- `X:`
-- `Y:`
-- `これは敵のエスケープポイントです。\r\nNPC用は、左上のコンボボックスを切り替えてください。`
-- `アドレス`
-- `マップ名`
-- `リストの拡張`
-- `先頭アドレス`
-- `再取得`
-- `名前`
-- `新規領域の確保`
-- `書き込み`
-- `条件:`
-- `消滅方法`
-- `読込数`
-- `選択アドレス:`
-- `離脱ポインタ`
-- `離脱ポインタ書き込み`
-- `離脱ポイント再取得`
-- `離脱座標`
-
-AV-only labels (usually fine — layout polish or rewording):
-
-- `Address:`
-- `Exit Pointer:`
-- `Map Exit Point Editor`
-- `Write`
-
 ### MenuCommandForm
 WF labels: **21** · AV labels: **13** · WF-only: **21** · AV-only: **13** · Common: **0** · Density verdict: **Medium** (WF 39 / AV 26)
 
@@ -4218,74 +4183,6 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Ending Event Editor`
 - `Unknown (0x02):`
 - `Unknown (0x03):`
-- `Write`
-
-### EventMapChangeForm
-WF labels: **20** · AV labels: **2** · WF-only: **20** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 36 / AV 3)
-
-WF-only labels (candidates for missing fields in AV):
-
-- `??`
-- `H:`
-- `size:`
-- `W:`
-- `X:`
-- `Y:`
-- `アドレス`
-- `サイズ`
-- `マップ名前`
-- `リストの拡張`
-- `先頭アドレス`
-- `再取得`
-- `名前`
-- `変化データ\r\nポインタ先へのインポート`
-- `変化データポインタ`
-- `座標`
-- `書き込み`
-- `番号`
-- `読込数`
-- `選択アドレス:`
-
-AV-only labels (usually fine — layout polish or rewording):
-
-- `Address:`
-- `Map Change Event Editor`
-
-### MapTileAnimation2Form
-WF labels: **20** · AV labels: **8** · WF-only: **20** · AV-only: **8** · Common: **0** · Density verdict: **High** (WF 40 / AV 14)
-
-WF-only labels (candidates for missing fields in AV):
-
-- `00`
-- `B`
-- `G`
-- `GBAカラー`
-- `R`
-- `Size:`
-- `アドレス`
-- `アニメーション間隔`
-- `データ個数`
-- `リストの拡張`
-- `一括インポート`
-- `一括エクスポート`
-- `先頭アドレス`
-- `再取得`
-- `名前`
-- `書き換えるパレットデータ`
-- `書き換え始めパレット番号`
-- `書き込み`
-- `読込数`
-- `選択アドレス:`
-
-AV-only labels (usually fine — layout polish or rewording):
-
-- `Address:`
-- `Animation Interval:`
-- `Data Count:`
-- `Map Tile Animation Type 2 (Palette)`
-- `Palette Data Pointer:`
-- `Start Palette Index:`
-- `Unknown (0x07):`
 - `Write`
 
 ### SongTableForm
@@ -4559,12 +4456,12 @@ WF-only labels (candidates for missing fields in AV):
 AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
+- `Address (decimal)`
 - `Animation Pointer (D0):`
 - `Comment:`
 - `Display example`
 - `Filter Name`
 - `Frame:`
-- `Hex Address`
 - `ID=00 is reserved as null data. Do not set any value other than 0x0.`
 - `List Expansion`
 - `Map Action Animation`
@@ -4988,6 +4885,60 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Title Image Ptr:`
 - `Write`
 
+### ImageMagicFEditorForm
+WF labels: **25** · AV labels: **34** · WF-only: **18** · AV-only: **27** · Common: **7** · Density verdict: **Low** (WF 37 / AV 45)
+
+WF-only labels (candidates for missing fields in AV):
+
+- `アドレス`
+- `インターネットから新しいリソースを探す`
+- `エディタ`
+- `コメント`
+- `ソースファイルを開く`
+- `ソースフォルダーを開く`
+- `フレーム`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `拡大`
+- `書き込み`
+- `表示例`
+- `読込数`
+- `選択アドレス:`
+- `魔法アニメの書出し`
+- `魔法アニメの読込`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `(preview deferred - tracked by #500)`
+- `4`
+- `Address`
+- `Comment`
+- `dim_pc`
+- `Display Example`
+- `Draw without enlarging`
+- `Editor`
+- `Expand List`
+- `Export Magic Animation`
+- `Frame`
+- `Import Magic Animation`
+- `Magic Effect Editor (FEditor)`
+- `Name`
+- `NULL (EMPTY)`
+- `Open Source File`
+- `Open Source Folder`
+- `Pending Core extraction - tracked by #500.`
+- `Read Count`
+- `Reload`
+- `Sample`
+- `Search Internet for new resources`
+- `Selected Address:`
+- `Top Address`
+- `Write to ROM`
+- `Zoom`
+- `Zoom and Draw`
+
 ### ItemStatBonusesForm
 WF labels: **19** · AV labels: **15** · WF-only: **18** · AV-only: **14** · Common: **1** · Density verdict: **Low** (WF 35 / AV 28)
 
@@ -5028,6 +4979,51 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Unknown (byte 11):`
 - `Unknown (byte 9):`
 - `Write`
+
+### MapExitPointForm
+WF labels: **21** · AV labels: **21** · WF-only: **18** · AV-only: **18** · Common: **3** · Density verdict: **Low** (WF 32 / AV 35)
+
+WF-only labels (candidates for missing fields in AV):
+
+- `00`
+- `これは敵のエスケープポイントです。\r\nNPC用は、左上のコンボボックスを切り替えてください。`
+- `アドレス`
+- `マップ名`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `新規領域の確保`
+- `書き込み`
+- `条件:`
+- `消滅方法`
+- `読込数`
+- `選択アドレス:`
+- `離脱ポインタ`
+- `離脱ポインタ書き込み`
+- `離脱ポイント再取得`
+- `離脱座標`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `00 (Flag)`
+- `Address`
+- `Address (decimal)`
+- `Alloc New Space`
+- `Cond:`
+- `Coordinates`
+- `Count`
+- `Data Expansion`
+- `Direction`
+- `Leave Pointer`
+- `Map Exit Point Editor`
+- `Map Name`
+- `Name`
+- `Reload`
+- `Reload Exit Points`
+- `Selected Address`
+- `Write`
+- `Write Off Pointer`
 
 ### PaletteChangeColorsForm
 WF labels: **21** · AV labels: **9** · WF-only: **18** · AV-only: **6** · Common: **3** · Density verdict: **High** (WF 25 / AV 12)
@@ -5132,6 +5128,57 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Support Attribute Editor`
 - `Unknown 7:`
 - `Write`
+
+### ToolTranslateROMForm
+WF labels: **22** · AV labels: **28** · WF-only: **18** · AV-only: **24** · Common: **4** · Density verdict: **Medium** (WF 35 / AV 47)
+
+WF-only labels (candidates for missing fields in AV):
+
+- `すべてのテキストをテキストファイルに書きだします。`
+- `フォント取込`
+- `全テキストの書出し`
+- `全テキストの読込`
+- `利用フォント`
+- `変更`
+- `定型文ROM FROM`
+- `定型文ROM TO`
+- `定型文の翻訳(FROM ROMと TO ROMから、定型文を取得し、翻訳の参考にする)`
+- `改造されたテキストのみ取得する`
+- `日本語フォントの上書き`
+- `現行ROMに足りないフォントを、以下のROMにあるフォントからコピーする`
+- `簡易`
+- `翻訳データ`
+- `翻訳開始`
+- `詳細`
+- `足りないフォントの自動生成`
+- `追加フォント ROM`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Auto-Generate Missing Fonts`
+- `Change`
+- `Copies fonts that the current ROM is missing from the fonts in the ROM below.`
+- `Detail`
+- `Export All Text`
+- `Export All Texts`
+- `Extra Font ROM`
+- `Font`
+- `Import All Text`
+- `Import All Texts`
+- `Import Font`
+- `Only acquire modified text`
+- `Override JP Font`
+- `Pending Core extraction - tracked by #536`
+- `Rewrites all texts with the contents of the specified file. Requires the anti-Huffman and DrawMultibyte/DrawSingleByte patches. After it finishes, import any missing fonts separately.`
+- `Simple`
+- `Start Translation`
+- `Translate before Export`
+- `Translate static texts (extract from FROM ROM and TO ROM, use as translation reference)`
+- `Translates the ROM. Uses Japanese and English ROMs to convert unchanged text automatically. Simple mode is fully automatic - it imports missing fonts, adjusts menu lengths, and similar. All processing… (truncated; see designer file)`
+- `Translation Data`
+- `Use Font Name`
+- `Without a file, only static texts are translated.`
+- `Writes all texts to a text file.`
 
 ### EventBattleTalkForm
 WF labels: **17** · AV labels: **2** · WF-only: **17** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 30 / AV 3)
@@ -5642,13 +5689,13 @@ WF-only labels (candidates for missing fields in AV):
 AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
+- `Address (decimal)`
 - `Block Size:`
 - `CC Item Editor`
 - `Count`
 - `Filter:`
 - `Function`
 - `Function pointers for item usability checks`
-- `Hex Address`
 - `IER patch detected — configure from Patch Manager.`
 - `Item ID Switch:`
 - `Item Usage Pointer Editor`
@@ -6009,6 +6056,51 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Address:`
 - `Effectiveness (Skill Systems Rework)`
 
+### MapTileAnimation2Form
+WF labels: **20** · AV labels: **26** · WF-only: **15** · AV-only: **21** · Common: **5** · Density verdict: **Medium** (WF 40 / AV 51)
+
+WF-only labels (candidates for missing fields in AV):
+
+- `GBAカラー`
+- `アドレス`
+- `アニメーション間隔`
+- `データ個数`
+- `リストの拡張`
+- `一括インポート`
+- `一括エクスポート`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `書き換えるパレットデータ`
+- `書き換え始めパレット番号`
+- `書き込み`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `(reserved)`
+- `Address`
+- `Animation Interval:`
+- `Bulk Export`
+- `Bulk Import`
+- `Data Count:`
+- `Data Expansion`
+- `Filter`
+- `GBA Color`
+- `Map Tile Animation Type 2 (Palette)`
+- `Map Tile Animation Type 2 Palette Sub-Table`
+- `Name`
+- `Palette Data Pointer:`
+- `Pending Core extraction - tracked by #524`
+- `Read Count`
+- `Reload`
+- `Selected Address:`
+- `Start Palette Index:`
+- `Top Address`
+- `Unknown (0x07):`
+- `Write to ROM`
+
 ### MonsterWMapProbabilityForm
 WF labels: **15** · AV labels: **4** · WF-only: **15** · AV-only: **4** · Common: **0** · Density verdict: **High** (WF 66 / AV 6)
 
@@ -6160,6 +6252,44 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Unknown 1:`
 - `Unknown 2:`
 - `Unknown 3:`
+- `Write`
+
+### EventMapChangeForm
+WF labels: **20** · AV labels: **21** · WF-only: **14** · AV-only: **15** · Common: **6** · Density verdict: **Low** (WF 36 / AV 43)
+
+WF-only labels (candidates for missing fields in AV):
+
+- `アドレス`
+- `サイズ`
+- `マップ名前`
+- `リストの拡張`
+- `先頭アドレス`
+- `再取得`
+- `名前`
+- `変化データ\r\nポインタ先へのインポート`
+- `変化データポインタ`
+- `座標`
+- `書き込み`
+- `番号`
+- `読込数`
+- `選択アドレス:`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `Address`
+- `Change Data Pointer`
+- `Comment`
+- `Coordinates:`
+- `Expand List (+1 slot)`
+- `Map Change Event Editor`
+- `Map Names`
+- `Names`
+- `Number:`
+- `Pointer Import`
+- `Read Count`
+- `Reload`
+- `Selected Address:`
+- `Top Address`
 - `Write`
 
 ### FontForm
@@ -7554,10 +7684,10 @@ WF-only labels (candidates for missing fields in AV):
 AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
+- `Address (decimal)`
 - `Battle BG:`
 - `Condition:`
 - `Count`
-- `Hex Address`
 - `Install Patch`
 - `Jump to the floor of battle animation`
 - `Reload`
@@ -7585,9 +7715,9 @@ WF-only labels (candidates for missing fields in AV):
 AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
+- `Address (decimal)`
 - `Condition:`
 - `Count`
-- `Hex Address`
 - `Install Patch`
 - `Jump to the background of battle animation`
 - `Reload`

--- a/docs/avalonia-gaps/2026-05-23-undo-sweep.md
+++ b/docs/avalonia-gaps/2026-05-23-undo-sweep.md
@@ -1,6 +1,6 @@
 ---
-generated: "2026-05-23T05:33:34Z"
-git-sha: a35299ba6
+generated: "2026-05-23T16:07:37Z"
+git-sha: 1f20893bb
 sweep-type: undo
 ---
 
@@ -79,11 +79,11 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-undo --out=<path>`.
 
 | Tier | Count | % of total |
 |---|---:|---:|
-| Total write callsites | 1045 | 100% |
-| NoUndoServiceField (no plumbing) | 198 | 18.9% |
-| MissingScope (unwrapped) | 2 | 0.2% |
+| Total write callsites | 1053 | 100% |
+| NoUndoServiceField (no plumbing) | 185 | 17.6% |
+| MissingScope (unwrapped) | 4 | 0.4% |
 | AmbiguousScope (verify) | 0 | 0.0% |
-| Covered (healthy) | 845 | 80.9% |
+| Covered (healthy) | 864 | 82.1% |
 
 ## Highest priority — VMs with NO undo plumbing at all
 
@@ -246,24 +246,6 @@ These ViewModels have no `UndoService` field/property/local. Every write here by
 | `FEBuilderGBA.Avalonia/ViewModels/UnitFE6ViewModel.cs` | 442 | `WriteUnit` | `rom.write_u8(addr + 42, Ability3)` | class 'UnitFE6ViewModel' has no UndoService field/property/local |
 | `FEBuilderGBA.Avalonia/ViewModels/UnitFE6ViewModel.cs` | 443 | `WriteUnit` | `rom.write_u8(addr + 43, Ability4)` | class 'UnitFE6ViewModel' has no UndoService field/property/local |
 | `FEBuilderGBA.Avalonia/ViewModels/UnitFE6ViewModel.cs` | 446 | `WriteUnit` | `rom.write_u32(addr + 44, SupportPtr)` | class 'UnitFE6ViewModel' has no UndoService field/property/local |
-
-### `ImagePortraitViewModel` — 13 callsites
-
-| File | Line | Method | Write | Note |
-|---|---:|---|---|---|
-| `FEBuilderGBA.Avalonia/ViewModels/ImagePortraitViewModel.cs` | 222 | `Write` | `rom.write_u32(addr + 0, PortraitImagePtr)` | class 'ImagePortraitViewModel' has no UndoService field/property/local |
-| `FEBuilderGBA.Avalonia/ViewModels/ImagePortraitViewModel.cs` | 223 | `Write` | `rom.write_u32(addr + 4, MiniPortraitPtr)` | class 'ImagePortraitViewModel' has no UndoService field/property/local |
-| `FEBuilderGBA.Avalonia/ViewModels/ImagePortraitViewModel.cs` | 224 | `Write` | `rom.write_u32(addr + 8, PalettePtr)` | class 'ImagePortraitViewModel' has no UndoService field/property/local |
-| `FEBuilderGBA.Avalonia/ViewModels/ImagePortraitViewModel.cs` | 225 | `Write` | `rom.write_u32(addr + 12, MouthFramesPtr)` | class 'ImagePortraitViewModel' has no UndoService field/property/local |
-| `FEBuilderGBA.Avalonia/ViewModels/ImagePortraitViewModel.cs` | 226 | `Write` | `rom.write_u32(addr + 16, ClassCardPtr)` | class 'ImagePortraitViewModel' has no UndoService field/property/local |
-| `FEBuilderGBA.Avalonia/ViewModels/ImagePortraitViewModel.cs` | 227 | `Write` | `rom.write_u8(addr + 20, MouthX)` | class 'ImagePortraitViewModel' has no UndoService field/property/local |
-| `FEBuilderGBA.Avalonia/ViewModels/ImagePortraitViewModel.cs` | 228 | `Write` | `rom.write_u8(addr + 21, MouthY)` | class 'ImagePortraitViewModel' has no UndoService field/property/local |
-| `FEBuilderGBA.Avalonia/ViewModels/ImagePortraitViewModel.cs` | 229 | `Write` | `rom.write_u8(addr + 22, EyeX)` | class 'ImagePortraitViewModel' has no UndoService field/property/local |
-| `FEBuilderGBA.Avalonia/ViewModels/ImagePortraitViewModel.cs` | 230 | `Write` | `rom.write_u8(addr + 23, EyeY)` | class 'ImagePortraitViewModel' has no UndoService field/property/local |
-| `FEBuilderGBA.Avalonia/ViewModels/ImagePortraitViewModel.cs` | 231 | `Write` | `rom.write_u8(addr + 24, Status)` | class 'ImagePortraitViewModel' has no UndoService field/property/local |
-| `FEBuilderGBA.Avalonia/ViewModels/ImagePortraitViewModel.cs` | 232 | `Write` | `rom.write_u8(addr + 25, Unused25)` | class 'ImagePortraitViewModel' has no UndoService field/property/local |
-| `FEBuilderGBA.Avalonia/ViewModels/ImagePortraitViewModel.cs` | 233 | `Write` | `rom.write_u8(addr + 26, Unused26)` | class 'ImagePortraitViewModel' has no UndoService field/property/local |
-| `FEBuilderGBA.Avalonia/ViewModels/ImagePortraitViewModel.cs` | 234 | `Write` | `rom.write_u8(addr + 27, Unused27)` | class 'ImagePortraitViewModel' has no UndoService field/property/local |
 
 ### `ImageCGFE7UViewModel` — 7 callsites
 
@@ -478,6 +460,13 @@ These classes already carry UndoService plumbing but a particular write was adde
 | `FEBuilderGBA.Avalonia/Views/BigCGViewerView.axaml.cs` | 126 | `ImportPng_Click` | `rom.write_p32(tableAddr, tileAddr)` | method 'ImportPng_Click' has an UndoService scope but this write is OUTSIDE it |
 | `FEBuilderGBA.Avalonia/Views/BigCGViewerView.axaml.cs` | 129 | `ImportPng_Click` | `rom.write_u32(tableAddr + (uint)(i * 4), 0)` | method 'ImportPng_Click' has an UndoService scope but this write is OUTSIDE it |
 
+### `MapExitPointView` — 2 callsites
+
+| File | Line | Method | Write | Note |
+|---|---:|---|---|---|
+| `FEBuilderGBA.Avalonia/Views/MapExitPointView.axaml.cs` | 246 | `WritePointer_Click` | `rom.write_u32(_vm.SelectedMapSlotAddr, 0u)` | method 'WritePointer_Click' has an UndoService scope but this write is OUTSIDE it |
+| `FEBuilderGBA.Avalonia/Views/MapExitPointView.axaml.cs` | 250 | `WritePointer_Click` | `rom.write_p32(_vm.SelectedMapSlotAddr, offset)` | method 'WritePointer_Click' has an UndoService scope but this write is OUTSIDE it |
+
 ## Ambiguous — covered by caller, please verify
 
 The write lives in a helper method; a caller in the same class wraps Begin/Commit. The scanner uses a one-level name-match heuristic, so manual review is required to confirm the helper is actually called from within an active scope at runtime.
@@ -486,7 +475,7 @@ _None._
 
 ## Covered (healthy)
 
-`845` callsites are inside a Begin/Commit (or Begin/Rollback) scope in the same method body, OR pass an explicit Undo argument. Covered classes: `MapSettingViewModel` (99), `MapSettingFE7UViewModel` (97), `MapSettingFE7ViewModel` (95), `ClassEditorViewModel` (75), `MoveCostFE6ViewModel` (51), `SongInstrumentViewModel` (46), `UnitEditorViewModel` (46), `UnitFE7ViewModel` (46), `ItemEditorViewModel` (26), `ItemFE6ViewModel` (22), `EventCondViewModel` (19), `BattleTerrainViewerViewModel` (15), `ImageUnitPaletteViewModel` (13), `PortraitViewerViewModel` (13), `TextViewerViewModel` (10), `TextDicViewModel` (8), `ImagePortraitFE6ViewModel` (7), `MapChangeViewModel` (7), `EventScriptPopupViewModel` (6), `ImageTSAAnime2ViewModel` (5), `SongTrackViewModel` (5), `WorldMapEventPointerViewModel` (5), `ImagePortraitView` (4), `BattleBGViewerViewModel` (3), `BigCGViewerViewModel` (3), `ChapterTitleViewerViewModel` (3), `ImageBGViewModel` (3), `ImageBattleAnimeViewModel` (3), `ImageBattleBGViewModel` (3), `ImageMapActionAnimationViewModel` (3), `SkillConfigFE8UCSkillSys09xViewModel` (3), `SMEPromoListViewModel` (2), `SkillConfigSkillSystemViewModel` (2), `SongTableViewModel` (2), `AIASMCALLTALKViewModel` (1), `AIASMCoordinateViewModel` (1), `AIASMRangeViewModel` (1), `AIMapSettingViewModel` (1), `AIPerformItemViewModel` (1), `AIPerformStaffViewModel` (1), `AIStealItemViewModel` (1), `AITargetViewModel` (1), `AITilesViewModel` (1), `AIUnitsViewModel` (1), `AOERANGEViewModel` (1), `ArenaClassViewerViewModel` (1), `ArenaEnemyWeaponViewerViewModel` (1), `CCBranchEditorViewModel` (1), `EDSensekiCommentViewModel` (1), `EDStaffRollViewModel` (1), `EDViewModel` (1), `EventUnitFE6ViewModel` (1), `EventUnitFE7ViewModel` (1), `EventUnitViewModel` (1), `ExtraUnitFE8UViewModel` (1), `ExtraUnitViewModel` (1), `ImageChapterTitleFE7ViewModel` (1), `ImageSystemAreaViewModel` (1), `ItemEffectPointerViewerViewModel` (1), `ItemRandomChestViewModel` (1), `ItemShopViewerViewModel` (1), `ItemStatBonusesSkillSystemsViewModel` (1), `ItemStatBonusesVennoViewModel` (1), `ItemStatBonusesViewerViewModel` (1), `ItemUsagePointerViewerViewModel` (1), `ItemWeaponEffectViewerViewModel` (1), `ItemWeaponTriangleViewerViewModel` (1), `LinkArenaDenyUnitViewerViewModel` (1), `MapEditorViewModel` (1), `MapExitPointViewModel` (1), `MapLoadFunctionViewModel` (1), `MapPointerViewModel` (1), `MapStyleEditorViewModel` (1), `MapTerrainBGLookupTableViewModel` (1), `MapTerrainFloorLookupTableViewModel` (1), `MapTerrainNameEngViewModel` (1), `MapTerrainNameViewModel` (1), `MapTileAnimation1ViewModel` (1), `MapTileAnimation2ViewModel` (1), `MapTileAnimationViewModel` (1), `MenuCommandViewModel` (1), `MenuDefinitionViewModel` (1), `MenuExtendSplitMenuViewModel` (1), `MonsterItemViewerViewModel` (1), `MonsterProbabilityViewerViewModel` (1), `MonsterWMapProbabilityViewerViewModel` (1), `MoveCostEditorViewModel` (1), `OPClassAlphaNameFE6ViewModel` (1), `OPClassAlphaNameViewModel` (1), `OPClassDemoFE7UViewModel` (1), `OPClassDemoFE7ViewModel` (1), `OPClassDemoFE8UViewModel` (1), `OPClassDemoViewerViewModel` (1), `OPClassFontFE8UViewModel` (1), `OPClassFontViewerViewModel` (1), `OPPrologueViewerView` (1), `OPPrologueViewerViewModel` (1), `PointerToolViewModel` (1), `SkillAssignmentClassSkillSystemViewModel` (1), `SomeClassListViewModel` (1), `SongInstrumentDirectSoundViewModel` (1), `SoundBossBGMViewerViewModel` (1), `SoundFootStepsViewerViewModel` (1), `SoundRoomCGViewModel` (1), `SoundRoomFE6ViewModel` (1), `SoundRoomViewerViewModel` (1), `StatusOptionOrderViewModel` (1), `StatusOptionViewModel` (1), `StatusParamViewModel` (1), `StatusRMenuViewModel` (1), `StatusUnitsMenuViewModel` (1), `SummonUnitViewerViewModel` (1), `SummonsDemonKingViewerViewModel` (1), `SupportAttributeViewModel` (1), `SupportTalkFE6ViewModel` (1), `SupportTalkFE7ViewModel` (1), `SupportTalkViewModel` (1), `SupportUnitEditorViewModel` (1), `SupportUnitFE6ViewModel` (1), `TerrainNameEditorViewModel` (1), `ToolASMEditView` (1), `ToolLZ77ViewModel` (1), `UnitCustomBattleAnimeViewModel` (1), `UnitPaletteViewModel` (1), `UnitsShortTextViewModel` (1), `WorldMapBGMViewModel` (1), `WorldMapPathMoveEditorViewModel` (1), `WorldMapPathViewModel` (1), `WorldMapPointViewModel` (1).
+`864` callsites are inside a Begin/Commit (or Begin/Rollback) scope in the same method body, OR pass an explicit Undo argument. Covered classes: `MapSettingViewModel` (99), `MapSettingFE7UViewModel` (97), `MapSettingFE7ViewModel` (95), `ClassEditorViewModel` (75), `MoveCostFE6ViewModel` (51), `SongInstrumentViewModel` (46), `UnitEditorViewModel` (46), `UnitFE7ViewModel` (46), `ItemEditorViewModel` (26), `ItemFE6ViewModel` (22), `EventCondViewModel` (19), `BattleTerrainViewerViewModel` (15), `ImagePortraitViewModel` (13), `ImageUnitPaletteViewModel` (13), `PortraitViewerViewModel` (13), `TextViewerViewModel` (10), `TextDicViewModel` (8), `ImagePortraitFE6ViewModel` (7), `MapChangeViewModel` (7), `EventScriptPopupViewModel` (6), `ImageTSAAnime2ViewModel` (5), `SongTrackViewModel` (5), `WorldMapEventPointerViewModel` (5), `OPClassDemoViewerViewModel` (4), `BattleBGViewerViewModel` (3), `BigCGViewerViewModel` (3), `ChapterTitleViewerViewModel` (3), `ImageBGViewModel` (3), `ImageBattleAnimeViewModel` (3), `ImageBattleBGViewModel` (3), `ImageMagicFEditorViewModel` (3), `ImageMapActionAnimationViewModel` (3), `OPClassDemoFE7UViewModel` (3), `SkillConfigFE8UCSkillSys09xViewModel` (3), `MapTileAnimation2ViewModel` (2), `SMEPromoListViewModel` (2), `SkillConfigSkillSystemViewModel` (2), `SongTableViewModel` (2), `AIASMCALLTALKViewModel` (1), `AIASMCoordinateViewModel` (1), `AIASMRangeViewModel` (1), `AIMapSettingViewModel` (1), `AIPerformItemViewModel` (1), `AIPerformStaffViewModel` (1), `AIStealItemViewModel` (1), `AITargetViewModel` (1), `AITilesViewModel` (1), `AIUnitsViewModel` (1), `AOERANGEViewModel` (1), `ArenaClassViewerViewModel` (1), `ArenaEnemyWeaponViewerViewModel` (1), `CCBranchEditorViewModel` (1), `EDSensekiCommentViewModel` (1), `EDStaffRollViewModel` (1), `EDViewModel` (1), `EventMapChangeViewModel` (1), `EventUnitFE6ViewModel` (1), `EventUnitFE7ViewModel` (1), `EventUnitViewModel` (1), `ExtraUnitFE8UViewModel` (1), `ExtraUnitViewModel` (1), `ImageChapterTitleFE7ViewModel` (1), `ImageSystemAreaViewModel` (1), `ItemEffectPointerViewerViewModel` (1), `ItemRandomChestViewModel` (1), `ItemShopViewerViewModel` (1), `ItemStatBonusesSkillSystemsViewModel` (1), `ItemStatBonusesVennoViewModel` (1), `ItemStatBonusesViewerViewModel` (1), `ItemUsagePointerViewerViewModel` (1), `ItemWeaponEffectViewerViewModel` (1), `ItemWeaponTriangleViewerViewModel` (1), `LinkArenaDenyUnitViewerViewModel` (1), `MapEditorViewModel` (1), `MapExitPointViewModel` (1), `MapLoadFunctionViewModel` (1), `MapPointerViewModel` (1), `MapStyleEditorViewModel` (1), `MapTerrainBGLookupTableViewModel` (1), `MapTerrainFloorLookupTableViewModel` (1), `MapTerrainNameEngViewModel` (1), `MapTerrainNameViewModel` (1), `MapTileAnimation1ViewModel` (1), `MapTileAnimationViewModel` (1), `MenuCommandViewModel` (1), `MenuDefinitionViewModel` (1), `MenuExtendSplitMenuViewModel` (1), `MonsterItemViewerViewModel` (1), `MonsterProbabilityViewerViewModel` (1), `MonsterWMapProbabilityViewerViewModel` (1), `MoveCostEditorViewModel` (1), `OPClassAlphaNameFE6ViewModel` (1), `OPClassAlphaNameViewModel` (1), `OPClassDemoFE7ViewModel` (1), `OPClassDemoFE8UViewModel` (1), `OPClassFontFE8UViewModel` (1), `OPClassFontViewerViewModel` (1), `OPPrologueViewerView` (1), `OPPrologueViewerViewModel` (1), `PointerToolViewModel` (1), `SkillAssignmentClassSkillSystemViewModel` (1), `SomeClassListViewModel` (1), `SongInstrumentDirectSoundViewModel` (1), `SoundBossBGMViewerViewModel` (1), `SoundFootStepsViewerViewModel` (1), `SoundRoomCGViewModel` (1), `SoundRoomFE6ViewModel` (1), `SoundRoomViewerViewModel` (1), `StatusOptionOrderViewModel` (1), `StatusOptionViewModel` (1), `StatusParamViewModel` (1), `StatusRMenuViewModel` (1), `StatusUnitsMenuViewModel` (1), `SummonUnitViewerViewModel` (1), `SummonsDemonKingViewerViewModel` (1), `SupportAttributeViewModel` (1), `SupportTalkFE6ViewModel` (1), `SupportTalkFE7ViewModel` (1), `SupportTalkViewModel` (1), `SupportUnitEditorViewModel` (1), `SupportUnitFE6ViewModel` (1), `TerrainNameEditorViewModel` (1), `ToolASMEditView` (1), `ToolLZ77ViewModel` (1), `UnitCustomBattleAnimeViewModel` (1), `UnitPaletteViewModel` (1), `UnitsShortTextViewModel` (1), `WorldMapBGMViewModel` (1), `WorldMapPathMoveEditorViewModel` (1), `WorldMapPathViewModel` (1), `WorldMapPointViewModel` (1).
 
 ## Registry cross-check
 
@@ -500,9 +489,9 @@ such a row almost always indicates the scanner's pattern set has missed a
 real write API (e.g. PR #380 review caught a `CoreState.ROM.write_u*`
 miss that surfaced as an unjustified zero-row warning before the fix).
 
-Classes with at least one detected write: 166.
+Classes with at least one detected write: 168.
 
-Writable VMs (matching the triplet convention): 140.  
+Writable VMs (matching the triplet convention): 141.  
 Writable VMs with zero detected ROM writes: 2.
 
 ### Writable VMs with zero detected ROM writes (warning)

--- a/docs/field-completeness-report.txt
+++ b/docs/field-completeness-report.txt
@@ -1,6 +1,6 @@
 === Field Completeness Report ===
 Total WinForms fields: 1563
-Total Avalonia fields: 1744
+Total Avalonia fields: 1738
 Total missing: 0
 Forms with gaps: 0 / 174
 

--- a/docs/field-completeness-report.txt
+++ b/docs/field-completeness-report.txt
@@ -1,6 +1,6 @@
 === Field Completeness Report ===
 Total WinForms fields: 1563
-Total Avalonia fields: 1738
+Total Avalonia fields: 1744
 Total missing: 0
 Forms with gaps: 0 / 174
 


### PR DESCRIPTION
## Summary

Closes the 37 / 3 HIGH density + 25 WF-only labels gap surfaced by
the gap-sweep methodology (#374) on `ImageMagicFEditorForm`. After
this PR `ImageMagicFEditorView` rebuilds to a 3-row 2-column shell
mirroring the WF panel3 (top read-config), panel5 (address-write bar),
panel8 (entry list + list-expand), and DragTargetPanel (right detail
surface) — raising density from **3 → 45** (HIGH -91.9% → **LOW +21.6%**).

Plus cross-cutting improvements addressing all three Copilot CLI
plan-review rounds:

1. **Core extraction.** New `FEBuilderGBA.Core/ImageUtilMagicCore.cs`
   hosts the read-only magic-system signature detection helpers
   (`SearchMagicSystem` / `FindCSASpellTable` / `GetSpellDataCount`)
   ported from WinForms-only `ImageUtilMagic.cs`. WF retains a thin
   shim delegating to Core so existing callsites stay unchanged.
2. **Comment persistence.** WriteDim now also calls
   `CoreState.CommentCache.Update(addr, Comment)`, mirroring WF
   `WriteMagicName()`. Round-trip covered by `ViewModel_Write_PersistsCommentToCache`
   + `ViewModel_LoadEntry_ReadsCommentFromCache`.
3. **NavigationTargets manifest.** New
   `ImageMagicFEditorViewModel.NavigationTargets.cs` declares the
   single `JumpToToolAnimationCreator` →
   `ToolAnimationCreatorView` row with `IssueRef: "#500"` (open
   tracker — KnownGap rows survive #418's close).

## Plan Reference

Implements the v3 plan accepted by Copilot CLI on
[issue #418 comment](https://github.com/laqieer/FEBuilderGBA/issues/418#issuecomment-4525719189)
(revised twice to address all 6 prior plan-review findings).

## Scope

Closes #418
Ref #374 (overarching gap-sweep effort)
Ref #500 (open follow-up: ToolAnimationCreator Init + Magic Anime
Import/Export Core extraction — deferred buttons + JumpEditor target
all reference this tracker)

## Screenshots

![ImageMagicFEditor editor (FE8U) - new 3-row 2-column surface](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr418-imagemagicfeditor.png)

Real Avalonia GUI capture via `PrintWindow` API against
`roms/FE8U.gba`, Release build of `FEBuilderGBA.Avalonia`.
Window: 1164x1620. Screenshot committed to master via sister docs PR
#551 so the URL survives feature-branch deletion.

The shot shows every new control surface:
- **Top read-config bar:** Top Address / Read Count / Reload button /
  patch-notice ("FEditor / SCA_Creator magic-system patch not detected").
- **Address-write bar:** Address (6114912) / Size: 4 / Selected
  Address (0x005D4E60) / Write to ROM button.
- **Left entry list:** 71 magic-effect entries populated from FE8U
  pointer table (0x00 - 0x21 visible), plus "Expand List" button at
  the bottom of the panel.
- **Right detail surface:** Sample preview pane (deferred — placeholder
  per #500) / Frame spinner / Zoom combo / Display Example label /
  dim combo (NULL EMPTY) / Comment textbox / 5-row spinner grid
  (FrameData / OBJRightToLeft / OBJLeftToRight / OBJBGRightToLeft /
  OBBGLeftToRight) / 5 action buttons (Import Magic Animation +
  Export Magic Animation + Open Source File + Open Source Folder
  disabled per #500; Editor enabled).
- **"Search Internet for new resources" link** at the bottom of the
  entry-list panel.

## GUI Test Report

### Environment
- ROM: `roms/FE8U.gba` (Fire Emblem - The Sacred Stones, USA)
- View: `ImageMagicFEditorView` (Avalonia)
- Capture method: PrintWindow API + PowerShell UIAutomationClient

### Steps Performed
1. Launched `FEBuilderGBA.Avalonia.exe --rom roms/FE8U.gba`.
2. Located main FE8U window via UIAutomation
   (`Name='FEBuilderGBA - FE8U.gba'`).
3. Located `Main_MagicFEditor_Button` by `AutomationIdProperty` and
   invoked it via `InvokePattern`.
4. Confirmed the editor window opened
   (`Name='Magic Effect Editor (FEditor)'`, handle resolved).
5. Captured via `tools/WinCapture` (PrintWindow `PW_RENDERFULLCONTENT`).

### Test Results

| Test | Expected | Actual | Status |
|---|---|---|---|
| Main menu "Magic FEditor" opens upgraded view | Window with title "Magic Effect Editor (FEditor)" | Window opened | PASS |
| Top read-config bar | Top Address + Read Count + Reload + patch notice | All 4 controls present | PASS |
| Patch notice text | Mentions FEditor / SCA_Creator not detected | "FEditor / SCA_Creator magic-system patch not detected." rendered | PASS |
| Address-write bar | Address + Size: + Selected Address + Write to ROM | All 4 controls present | PASS |
| Entry list populated | 71 entries from pointer table | 71 entries visible | PASS |
| Detail panel renders | Sample / Frame / Zoom / Display Example | All 4 rows visible | PASS |
| dim + Comment row | ComboBox + TextBox | Both rendered | PASS |
| 5-row spinner grid | FrameData / OBJ* spinners | All 5 rendered with exact WF labels | PASS |
| 5 action buttons render | Import/Export Magic Animation + Editor + Open Source File/Folder | All 5 rendered | PASS |
| Disabled buttons reference #500 | Tooltip mentions follow-up issue | ToolTip.Tip="Pending Core extraction - tracked by #500." set | PASS |
| Editor button enabled | Real WindowManager.Open<ToolAnimationCreatorView> | Button enabled (gray-bordered in screenshot) | PASS |
| Search Internet link | Visible at bottom of left panel | "Search Internet for new resources" label visible | PASS |
| L10nCoverageTest | 0 PartiallyTranslated literals | Passes | PASS |
| ImageUtilMagicCoreTests | 9 passing | 9/9 PASS | PASS |
| ImageMagicFEditorParityTests | 24 passing | 24/24 PASS | PASS |
| AvaloniaFieldCompletenessTests | All passing | 13/13 PASS | PASS |
| ViewInstantiationSweepTests | View_CanInstantiate(ImageMagicFEditorView) | PASS (was failing in WIP) | PASS |

### Verdict

**PASS** — every new control surface renders, deferred affordances
are visibly disabled and tooltip-referenced to follow-up #500, the
patch-detection wiring + comment persistence work against synthetic
ROMs, the WF shim continues to delegate to Core, and all 33 new tests
pass alongside the existing 5367+1634+1716 = 8717-test suite.

## Test plan

- [x] `dotnet test FEBuilderGBA.Core.Tests/` — 1634/1634 pass (+9
  ImageUtilMagicCore tests covering FE6/FE7U/FE8U signatures, no-sig
  fallback, SpellDataCount, FindCSASpellTable).
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests/` — 5367/5370 pass
  (3 pre-existing skips, +24 ImageMagicFEditorParityTests covering
  density, AutomationId presence, undo wiring, deferred-button
  [Theory], LoadEntry DimPc + Dim kinds, Write pointer round-trip,
  Comment cache round-trip, Navigation manifest).
- [x] `dotnet test FEBuilderGBA.Tests/` — 1716/1716 pass.
- [x] `dotnet build FEBuilderGBA.sln` — 0 errors.
- [x] Density verdict ImageMagicFEditorForm: HIGH (-91.9%) → LOW (+21.6%).
- [x] Labels-sweep: 25 WF-only labels → 18 (the 18 remaining are
  Japanese strings that have English equivalents in AV; the literal
  comparison scanner doesn't apply the translate map — same convention
  as PR #535 / #544).
- [x] All 4 write paths wrapped in `_undoService.Begin/Commit/Rollback`
  (verified by 2 Roslyn regex tests).
- [x] ja/zh translations added for new English literals; `L10nCoverageTest`
  stays green (0 PartiallyTranslated literals, 0 unallowed Untranslated).
- [x] GUI screenshot captured via PrintWindow against the live Avalonia
  app with `roms/FE8U.gba` and committed to `pr-screenshots/` on master
  via #551.
- [x] Copilot CLI plan review accepted (v3 plan, no remaining blocking
  concerns) — see #418.

## Known limitations

- **Real preview pane rendering** (`ImageUtilMagicFEditor.Draw` PNG
  output in the Sample box) is deferred — the placeholder label
  "(preview deferred - tracked by #500)" gives the same data hint.
  Tracked at #500.
- **Real `Magic Anime Import` / `Magic Anime Export` flat-file I/O**
  + **Open Source File / Open Source Folder** + **Editor jump's
  Init() flow** all remain disabled or no-op, referencing #500.
- **`ko.txt`** does not exist in the repo — Korean translations are
  intentionally out of scope (project-wide condition; verified by the
  same justification on #441 / #439 / #440 / #442 / #511 / #513 /
  #517 / #520 / #522 / #426 / #419). All literals show `ko: x` across
  the gap-sweep l10n report; `L10nCoverageTest` only enforces `ja, zh`.

## Acceptance criteria checklist (from #418 body)

- [x] **WF-only labels covered or explicitly justified as out-of-scope**
  — every WF Japanese label has an English equivalent in the new AV
  surface (the labels-sweep scanner does literal comparison and
  doesn't apply the translate map, but each label is functionally
  covered: アドレス → Address, 先頭アドレス → Top Address, 読込数 →
  Read Count, 再取得 → Reload, etc).
- [x] **Avalonia view density brought within 25% of WF (MEDIUM verdict
  or better)** — `ImageMagicFEditorParityTests.View_AvControlCount_AtOrAboveMediumVerdict`
  asserts AV >= ceil(37 * 0.75) = 28. Static AXAML count is 45 (LOW
  verdict, +21.6%).
- [x] **All ROM writes in `ImageMagicFEditorViewModel` wrapped in
  `_undoService.Begin/Commit`** — `View_WriteHandler_UsesUndoService`
  + `View_MagicListExpandHandler_UsesUndoService` regression tests.
- [x] **Untranslated literals translated in all of ja/zh** (ko is
  project-wide unmapped — see Known limitations).
- [x] **Existing related issues referenced; this issue closed by the
  merging PR** — `Closes #418`, `Ref #374`, `Ref #500`.

Generated with Claude Code (claude-opus-4-7[1m])
