### PR TITLE
fix(gap-sweep): ImagePallet parity (closes #400)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImagePalletParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImagePalletParityTests.cs
@@ -1,0 +1,409 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Phase 1/2/5 gap-sweep regression tests for ImagePalletView. (#400)
+//
+// Closes the 123 Avalonia <-> WinForms gaps the gap-sweep surfaced on
+// ImagePalletForm (HIGH density 3/98, -96.9%, 28 WF-only labels,
+// 0 common labels). Each assertion maps to an acceptance-criterion
+// bullet from issue #400 or to a Copilot CLI plan-review finding.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.GapSweep;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests.GapSweep;
+
+/// <summary>
+/// Tests proving the ImagePalletView parity raise (#400) is permanent.
+/// Marked [Collection("SharedState")] because the synthetic-ROM tests
+/// mutate CoreState.ROM.
+/// </summary>
+[Collection("SharedState")]
+public class ImagePalletParityTests
+{
+    // ===================================================================
+    // Density (Phase 1) - AV control count must reach the MEDIUM verdict.
+    // ===================================================================
+
+    /// <summary>
+    /// WF designer.cs reports 98 control instantiations. To leave the
+    /// HIGH verdict we need AV &gt;= ceil(98 * 0.75) = 74.
+    /// </summary>
+    [Fact]
+    public void View_AvControlCount_AtOrAboveMediumVerdict()
+    {
+        string axamlPath = AxamlPath();
+        Assert.True(File.Exists(axamlPath), $"AXAML not found at {axamlPath}");
+
+        var doc = XDocument.Load(axamlPath);
+        int avCount = ControlDensityScanner.CountAvControlsInDocument(doc);
+
+        const int WfControlCount = 98;
+        int mediumThreshold = (int)Math.Ceiling(WfControlCount * 0.75); // 74
+        Assert.True(avCount >= mediumThreshold,
+            $"AV control count {avCount} must be >= {mediumThreshold} (75% of WF={WfControlCount})");
+    }
+
+    // ===================================================================
+    // Phase 5 - control surface assertions (Roslyn-static AXAML read).
+    // ===================================================================
+
+    [Fact]
+    public void View_HasTopSelectionBar()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"ImagePallet_Address_Input\"", axaml);
+        Assert.Contains("AutomationId=\"ImagePallet_Address_Label\"", axaml);
+        Assert.Contains("AutomationId=\"ImagePallet_Zoom_Combo\"", axaml);
+        Assert.Contains("AutomationId=\"ImagePallet_Zoom_Label\"", axaml);
+        Assert.Contains("AutomationId=\"ImagePallet_Write_Button\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasPaletteIndexBar()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"ImagePallet_PaletteIndex_Combo\"", axaml);
+        Assert.Contains("AutomationId=\"ImagePallet_PaletteIndex_Label\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasSixteenColorCells()
+    {
+        // AutomationIds use the {Editor}_{Field}{N}_{Type} pattern so the
+        // AutomationIdTests.All_AutomationIds_Follow_Naming_Convention check
+        // recognises each suffix (Image for swatches, Input for NUDs).
+        string axaml = ReadAxaml();
+        for (int n = 1; n <= 16; n++)
+        {
+            Assert.Contains($"AutomationId=\"ImagePallet_P{n}_Image\"", axaml);
+            Assert.Contains($"AutomationId=\"ImagePallet_R{n}_Input\"", axaml);
+            Assert.Contains($"AutomationId=\"ImagePallet_G{n}_Input\"", axaml);
+            Assert.Contains($"AutomationId=\"ImagePallet_B{n}_Input\"", axaml);
+        }
+    }
+
+    [Fact]
+    public void View_HasNumericLabels_1Through16()
+    {
+        string axaml = ReadAxaml();
+        for (int n = 1; n <= 16; n++)
+            Assert.Contains($"AutomationId=\"ImagePallet_Index{n}_Label\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasRGBRowLabels()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"ImagePallet_R_Label\"", axaml);
+        Assert.Contains("AutomationId=\"ImagePallet_G_Label\"", axaml);
+        Assert.Contains("AutomationId=\"ImagePallet_B_Label\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasImagePreview()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"ImagePallet_Preview_Image\"", axaml);
+        Assert.Contains("AutomationId=\"ImagePallet_Preview_Label\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasButtonRow()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"ImagePallet_Import_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImagePallet_Export_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImagePallet_Clipboard_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImagePallet_Undo_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImagePallet_Redo_Button\"", axaml);
+    }
+
+    /// <summary>
+    /// Deferred affordances (Import/Export/Clipboard + Redo per plan
+    /// review #5) must be disabled and reference the open follow-up
+    /// issue #500. NOTE: Undo is intentionally NOT in this list - the
+    /// plan review-5 decision was Undo enabled, Redo deferred.
+    /// </summary>
+    [Theory]
+    [InlineData("ImagePallet_Import_Button")]
+    [InlineData("ImagePallet_Export_Button")]
+    [InlineData("ImagePallet_Clipboard_Button")]
+    [InlineData("ImagePallet_Redo_Button")]
+    public void View_DeferredButton_IsDisabledAndReferencesFollowupIssue(string automationId)
+    {
+        string axaml = ReadAxaml();
+        int idx = axaml.IndexOf($"AutomationId=\"{automationId}\"", StringComparison.Ordinal);
+        Assert.True(idx >= 0, $"AutomationId {automationId} not found in AXAML");
+
+        int elementStart = axaml.LastIndexOf('<', idx);
+        Assert.True(elementStart >= 0);
+        int elementEnd = FindElementEnd(axaml, elementStart);
+        Assert.True(elementEnd > elementStart);
+        string element = axaml.Substring(elementStart, elementEnd - elementStart + 1);
+
+        Assert.Contains("IsEnabled=\"False\"", element);
+        Assert.Contains("#500", element);
+    }
+
+    /// <summary>
+    /// Undo button MUST be enabled (Copilot CLI plan review #5). Check
+    /// by verifying the explicit `IsEnabled="False"` attribute is
+    /// absent from the Undo button's element.
+    /// </summary>
+    [Fact]
+    public void View_UndoButton_IsEnabled()
+    {
+        string axaml = ReadAxaml();
+        int idx = axaml.IndexOf("AutomationId=\"ImagePallet_Undo_Button\"", StringComparison.Ordinal);
+        Assert.True(idx >= 0);
+        int elementStart = axaml.LastIndexOf('<', idx);
+        int elementEnd = FindElementEnd(axaml, elementStart);
+        string element = axaml.Substring(elementStart, elementEnd - elementStart + 1);
+        Assert.DoesNotContain("IsEnabled=\"False\"", element);
+        Assert.Contains("Click=\"Undo_Click\"", element);
+    }
+
+    // ===================================================================
+    // Write handler must wrap ROM mutation in undo scope.
+    // ===================================================================
+
+    [Fact]
+    public void View_WriteHandler_WrapsInUndoScope()
+    {
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        Assert.Contains("_undoService.Begin(", source);
+        Assert.Contains("_undoService.Commit()", source);
+        Assert.Contains("_undoService.Rollback()", source);
+    }
+
+    /// <summary>
+    /// Undo button click handler must wire CoreState.Undo.RunUndo()
+    /// (Copilot CLI plan review #5).
+    /// </summary>
+    [Fact]
+    public void View_UndoHandler_CallsRunUndo()
+    {
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        Assert.Contains("CoreState.Undo?.RunUndo()", source);
+    }
+
+    // ===================================================================
+    // ViewModel state - round-trip semantics + JumpTo wiring.
+    // ===================================================================
+
+    [Fact]
+    public void ViewModel_LoadEntry_PopulatesAll48Properties()
+    {
+        var rom = MakeMinimalRomWithPaletteAt(0x100000u);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new ImagePalletViewModel();
+            vm.LoadEntry(0x100000u, 1, 0, null);
+
+            // Slot 0 was planted as white (R=248, G=248, B=248).
+            Assert.Equal(248, vm.R1);
+            Assert.Equal(248, vm.G1);
+            Assert.Equal(248, vm.B1);
+            // Slot 2 (index 1) was planted as red (R=248).
+            Assert.Equal(248, vm.R2);
+            Assert.Equal(0, vm.G2);
+            Assert.Equal(0, vm.B2);
+            // Slot 16 (last) was planted as blue.
+            Assert.Equal(0, vm.R16);
+            Assert.Equal(0, vm.G16);
+            Assert.Equal(248, vm.B16);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_Write_RoundTripsPaletteBytes()
+    {
+        var rom = MakeMinimalRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new ImagePalletViewModel();
+            vm.LoadEntry(0x100000u, 1, 0, null);
+
+            vm.R1 = 0xF8; vm.G1 = 0;    vm.B1 = 0;     // red
+            vm.R2 = 0;    vm.G2 = 0xF8; vm.B2 = 0;     // green
+            vm.R3 = 0;    vm.G3 = 0;    vm.B3 = 0xF8;  // blue
+            vm.Write();
+
+            vm.LoadEntry(0x100000u, 1, 0, null);
+            Assert.Equal(248, vm.R1); Assert.Equal(0, vm.G1); Assert.Equal(0, vm.B1);
+            Assert.Equal(0, vm.R2); Assert.Equal(248, vm.G2); Assert.Equal(0, vm.B2);
+            Assert.Equal(0, vm.R3); Assert.Equal(0, vm.G3); Assert.Equal(248, vm.B3);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    /// <summary>
+    /// Copilot CLI plan review #1: the JumpTo / LoadEntry path must
+    /// accept both raw offsets and GBA pointers identically.
+    /// </summary>
+    [Fact]
+    public void ViewModel_JumpTo_AcceptsGbaPointer_StoresAndReads()
+    {
+        var rom = MakeMinimalRomWithPaletteAt(0x100000u);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+
+            var vmPtr = new ImagePalletViewModel();
+            vmPtr.LoadEntry(0x08100000u, 1, 0, null);
+
+            var vmOff = new ImagePalletViewModel();
+            vmOff.LoadEntry(0x00100000u, 1, 0, null);
+
+            Assert.Equal(vmOff.R1, vmPtr.R1);
+            Assert.Equal(vmOff.G1, vmPtr.G1);
+            Assert.Equal(vmOff.B1, vmPtr.B1);
+            Assert.Equal(248, vmPtr.R1); // white slot
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    /// <summary>
+    /// Write at index 1 must leave index 0 bytes untouched. Index
+    /// arithmetic verified at the VM level (PaletteCore does the same
+    /// for unit tests; this exercises the VM wrapper).
+    /// </summary>
+    [Fact]
+    public void ViewModel_Write_NonZeroIndex_DoesNotOverwriteIndex0()
+    {
+        var rom = MakeMinimalRomWithPaletteAt(0x100000u);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            // index 0 already has the white/red/.../blue pattern.
+            ushort idx0Color0Before = (ushort)(rom.Data[0x100000] | (rom.Data[0x100001] << 8));
+
+            var vm = new ImagePalletViewModel();
+            vm.LoadEntry(0x100000u, 2, 1, null);
+            vm.R1 = 0xF8; vm.G1 = 0xF8; vm.B1 = 0;
+            vm.Write();
+
+            ushort idx0Color0After = (ushort)(rom.Data[0x100000] | (rom.Data[0x100001] << 8));
+            Assert.Equal(idx0Color0Before, idx0Color0After);
+            // Index 1 slot 0 reflects the yellow write (R+G).
+            ushort idx1Color0 = (ushort)(rom.Data[0x100020] | (rom.Data[0x100021] << 8));
+            Assert.Equal(0x03FF, idx1Color0); // R=0x1F | G<<5=0x3E0
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    /// <summary>
+    /// Copilot CLI plan review #2: caller wiring test. The
+    /// ImagePortraitView.JumpToPalette_Click MUST forward the
+    /// portrait's PalettePtr into the ImagePalletView so the rebuilt
+    /// editor opens with real data.
+    ///
+    /// Source-level test (no Avalonia headless instantiation): assert
+    /// the JumpToPalette_Click source contains the expected
+    /// JumpTo(_vm.PalettePtr, ...) invocation.
+    /// </summary>
+    [Fact]
+    public void ImagePortraitJumpToPalette_PassesPalettePtr_ToImagePalletView()
+    {
+        string source = File.ReadAllText(ImagePortraitCodeBehindPath());
+        // Locate the JumpToPalette_Click method body.
+        int idx = source.IndexOf("void JumpToPalette_Click", StringComparison.Ordinal);
+        Assert.True(idx > 0, "JumpToPalette_Click not found");
+        // The method must call JumpTo on the opened ImagePalletView
+        // window using PalettePtr.
+        int methodEnd = source.IndexOf("\n        }", idx, StringComparison.Ordinal);
+        Assert.True(methodEnd > idx);
+        string methodBody = source.Substring(idx, methodEnd - idx);
+        Assert.Contains("Open<ImagePalletView>()", methodBody);
+        Assert.Contains(".JumpTo(", methodBody);
+        Assert.Contains("PalettePtr", methodBody);
+    }
+
+    // ===================================================================
+    // Helpers
+    // ===================================================================
+
+    /// <summary>
+    /// Returns the offset of the closing `>` of an AXAML element start
+    /// tag at <paramref name="elementStart"/>, skipping over attribute
+    /// values that may contain literal `>` characters (rare but
+    /// possible in tooltips).
+    /// </summary>
+    static int FindElementEnd(string axaml, int elementStart)
+    {
+        bool inAttrValue = false;
+        for (int i = elementStart; i < axaml.Length; i++)
+        {
+            char c = axaml[i];
+            if (c == '"') inAttrValue = !inAttrValue;
+            else if (c == '>' && !inAttrValue) return i;
+        }
+        return -1;
+    }
+
+    /// <summary>Build a 16 MB ROM with FE8U signature and zero palette bytes.</summary>
+    static ROM MakeMinimalRom()
+    {
+        var rom = new ROM();
+        rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+        return rom;
+    }
+
+    /// <summary>
+    /// Build a synthetic ROM with two 16-color palettes planted at
+    /// <paramref name="addr"/>. Index 0 = white / red / 14 zeros /
+    /// blue at slot 16. Index 1 = all zeros (untouched).
+    /// </summary>
+    static ROM MakeMinimalRomWithPaletteAt(uint addr)
+    {
+        var rom = new ROM();
+        rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+
+        ushort[] colors = new ushort[16];
+        colors[0] = 0x7FFF;   // white
+        colors[1] = 0x001F;   // red
+        // colors[2..14] stay zero (black)
+        colors[15] = 0x7C00;  // blue (slot 16 in human terms)
+        for (int i = 0; i < 16; i++)
+        {
+            rom.Data[(int)(addr + i * 2)] = (byte)(colors[i] & 0xFF);
+            rom.Data[(int)(addr + i * 2 + 1)] = (byte)(colors[i] >> 8);
+        }
+        return rom;
+    }
+
+    static string ReadAxaml() => File.ReadAllText(AxamlPath());
+
+    static string AxamlPath() => Path.Combine(FindRepoRoot(),
+        "FEBuilderGBA.Avalonia", "Views", "ImagePalletView.axaml");
+
+    static string ViewCodeBehindPath() => Path.Combine(FindRepoRoot(),
+        "FEBuilderGBA.Avalonia", "Views", "ImagePalletView.axaml.cs");
+
+    static string ImagePortraitCodeBehindPath() => Path.Combine(FindRepoRoot(),
+        "FEBuilderGBA.Avalonia", "Views", "ImagePortraitView.axaml.cs");
+
+    static string FindRepoRoot()
+    {
+        string start = AppDomain.CurrentDomain.BaseDirectory;
+        for (var dir = new DirectoryInfo(start); dir != null; dir = dir.Parent)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "FEBuilderGBA.sln")))
+                return dir.FullName;
+        }
+        throw new InvalidOperationException($"Could not locate FEBuilderGBA.sln from {start}");
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImagePalletParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImagePalletParityTests.cs
@@ -193,6 +193,48 @@ public class ImagePalletParityTests
         Assert.Contains("CoreState.Undo?.RunUndo()", source);
     }
 
+    /// <summary>
+    /// Write_Click must honor _vm.Write()'s U.NOT_FOUND return value
+    /// (Copilot CLI round-2 review on PR #586). When PaletteCore.Write
+    /// no-ops (invalid address / overflow), the handler must rollback,
+    /// surface an error, and NOT show the success toast.
+    /// </summary>
+    [Fact]
+    public void View_WriteHandler_HonorsNoOpReturn()
+    {
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        // Capture the return value of _vm.Write() into a uint variable.
+        Assert.Contains("uint writtenOffset = _vm.Write()", source);
+        // Branch on U.NOT_FOUND and rollback rather than commit.
+        Assert.Contains("writtenOffset == U.NOT_FOUND", source);
+        // Error toast on no-op (uses the new "Invalid palette address" key).
+        Assert.Contains("Invalid palette address", source);
+    }
+
+    /// <summary>
+    /// ViewModel.Write() must return U.NOT_FOUND on a sentinel
+    /// PaletteAddress (Copilot CLI round-2 review on PR #586).
+    /// </summary>
+    [Fact]
+    public void ViewModel_Write_ReturnsNotFound_OnInvalidAddress()
+    {
+        var rom = MakeMinimalRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new ImagePalletViewModel();
+            // Plant a valid address first via LoadEntry, then mutate
+            // PaletteAddress to U.NOT_FOUND so the IsLoaded guard does
+            // not short-circuit.
+            vm.LoadEntry(0x100000u, 1, 0, null);
+            vm.PaletteAddress = U.NOT_FOUND;
+            uint result = vm.Write();
+            Assert.Equal(U.NOT_FOUND, result);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
     // ===================================================================
     // ViewModel state - round-trip semantics + JumpTo wiring.
     // ===================================================================

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImagePalletParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImagePalletParityTests.cs
@@ -212,6 +212,46 @@ public class ImagePalletParityTests
     }
 
     /// <summary>
+    /// View must wire ValueChanged handlers on all 48 R/G/B NUDs so
+    /// edits refresh the swatch immediately (Copilot bot round-3
+    /// inline review #1 on PR #586).
+    /// </summary>
+    [Fact]
+    public void View_NudChangeHandlers_RefreshSwatchesLive()
+    {
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        // The wire-up registers Nud_ValueChanged on every NUD.
+        Assert.Contains("WireNudChangeHandlers", source);
+        Assert.Contains("n.ValueChanged += Nud_ValueChanged", source);
+        // The handler refreshes swatches from the NUD values (NOT VM).
+        Assert.Contains("RefreshSwatchesFromNuds()", source);
+        Assert.Contains("NudByte(", source);
+    }
+
+    /// <summary>
+    /// View must cache the palette-name overrides passed via JumpTo
+    /// and pass them back into LoadEntry on every reload path (Write,
+    /// Undo) so the Palette Index combo labels survive (Copilot bot
+    /// round-3 inline reviews #2 + #3 on PR #586).
+    /// </summary>
+    [Fact]
+    public void View_ReloadPaths_PreservePaletteNames()
+    {
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        // Field caching the names.
+        Assert.Contains("_lastPaletteNames", source);
+        // JumpTo writes to the cache.
+        Assert.Contains("_lastPaletteNames = paletteNames", source);
+        // Both reload sites (Write + Undo) pass the cached names back.
+        // We assert there is NO LoadEntry(..., null) call after the
+        // JumpTo flow - all reloads use _lastPaletteNames.
+        Assert.DoesNotContain("LoadEntry(reloadAddr, reloadMax, reloadIdx, null)", source);
+        Assert.DoesNotContain("LoadEntry(addr, max, idx, null)", source);
+        Assert.Contains("LoadEntry(reloadAddr, reloadMax, reloadIdx, _lastPaletteNames)", source);
+        Assert.Contains("LoadEntry(addr, max, idx, _lastPaletteNames)", source);
+    }
+
+    /// <summary>
     /// ViewModel.Write() must return U.NOT_FOUND on a sentinel
     /// PaletteAddress (Copilot CLI round-2 review on PR #586).
     /// </summary>

--- a/FEBuilderGBA.Avalonia/ViewModels/ImagePalletViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImagePalletViewModel.cs
@@ -1,33 +1,266 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Avalonia counterpart of WinForms ImagePalletForm. Gap-sweep fix
+// (#400) replaces a 3-control stub with a full 16-color BGR15 palette
+// editor backed by FEBuilderGBA.Core/PaletteCore.cs.
+//
+// Each loaded entry has 16 (R, G, B) byte tuples surfaced as 48
+// individual properties (R1..R16, G1..G16, B1..B16) so the AXAML
+// NumericUpDown bindings can target each value directly.
+//
+// PaletteAddress is always stored as a GBA pointer (the value passed
+// in by callers like ImagePortraitView.JumpToPalette_Click); the
+// pointer-vs-offset normalization is centralized inside PaletteCore.
+
 using System;
 using System.Collections.Generic;
+using FEBuilderGBA.Avalonia.Services;
 
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
+    /// <summary>
+    /// ViewModel for the Avalonia palette editor (#400 gap-sweep fix).
+    ///
+    /// NOTE: deliberately does NOT participate in the --data-verify
+    /// sweep. The palette editor is opened directly via
+    /// <c>JumpTo(...)</c> from caller editors (eg. ImagePortraitView),
+    /// it is not on the FormMappings list, and it does not have an
+    /// iterable "load every entry" surface (LoadList returns a single
+    /// placeholder row).
+    /// </summary>
     public class ImagePalletViewModel : ViewModelBase
     {
-        uint _currentAddr;
-        bool _isLoaded;
+        // ---- backing fields ----
 
-        public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
+        uint _paletteAddress;
+        int _paletteIndex;
+        int _maxPaletteCount = PaletteCore.MAX_PALETTE_COUNT;
+        int _zoomIndex;
+        bool _isLoaded;
+        IReadOnlyList<string> _paletteIndexNames = Array.Empty<string>();
+
+        // 48 RGB fields - one byte per channel per slot.
+        byte _r1, _r2, _r3, _r4, _r5, _r6, _r7, _r8, _r9, _r10, _r11, _r12, _r13, _r14, _r15, _r16;
+        byte _g1, _g2, _g3, _g4, _g5, _g6, _g7, _g8, _g9, _g10, _g11, _g12, _g13, _g14, _g15, _g16;
+        byte _b1, _b2, _b3, _b4, _b5, _b6, _b7, _b8, _b9, _b10, _b11, _b12, _b13, _b14, _b15, _b16;
+
+        // ---- public properties ----
+
+        /// <summary>Palette base address (GBA pointer or raw offset).
+        /// Pointer/offset normalization happens inside PaletteCore.</summary>
+        public uint PaletteAddress { get => _paletteAddress; set => SetField(ref _paletteAddress, value); }
+
+        /// <summary>Index of the currently edited palette block (0..MaxPaletteCount-1).</summary>
+        public int PaletteIndex { get => _paletteIndex; set => SetField(ref _paletteIndex, value); }
+
+        /// <summary>Number of contiguous palettes at PaletteAddress (1..16).</summary>
+        public int MaxPaletteCount { get => _maxPaletteCount; set => SetField(ref _maxPaletteCount, value); }
+
+        /// <summary>Currently selected zoom mode (0..4) for the preview image.</summary>
+        public int ZoomIndex { get => _zoomIndex; set => SetField(ref _zoomIndex, value); }
+
+        /// <summary>True once LoadEntry has populated the ViewModel.</summary>
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
 
+        /// <summary>Display names for the palette-index combo box.</summary>
+        public IReadOnlyList<string> PaletteIndexNames
+        {
+            get => _paletteIndexNames;
+            set => SetField(ref _paletteIndexNames, value ?? Array.Empty<string>());
+        }
+
+        public byte R1 { get => _r1; set => SetField(ref _r1, value); }
+        public byte R2 { get => _r2; set => SetField(ref _r2, value); }
+        public byte R3 { get => _r3; set => SetField(ref _r3, value); }
+        public byte R4 { get => _r4; set => SetField(ref _r4, value); }
+        public byte R5 { get => _r5; set => SetField(ref _r5, value); }
+        public byte R6 { get => _r6; set => SetField(ref _r6, value); }
+        public byte R7 { get => _r7; set => SetField(ref _r7, value); }
+        public byte R8 { get => _r8; set => SetField(ref _r8, value); }
+        public byte R9 { get => _r9; set => SetField(ref _r9, value); }
+        public byte R10 { get => _r10; set => SetField(ref _r10, value); }
+        public byte R11 { get => _r11; set => SetField(ref _r11, value); }
+        public byte R12 { get => _r12; set => SetField(ref _r12, value); }
+        public byte R13 { get => _r13; set => SetField(ref _r13, value); }
+        public byte R14 { get => _r14; set => SetField(ref _r14, value); }
+        public byte R15 { get => _r15; set => SetField(ref _r15, value); }
+        public byte R16 { get => _r16; set => SetField(ref _r16, value); }
+
+        public byte G1 { get => _g1; set => SetField(ref _g1, value); }
+        public byte G2 { get => _g2; set => SetField(ref _g2, value); }
+        public byte G3 { get => _g3; set => SetField(ref _g3, value); }
+        public byte G4 { get => _g4; set => SetField(ref _g4, value); }
+        public byte G5 { get => _g5; set => SetField(ref _g5, value); }
+        public byte G6 { get => _g6; set => SetField(ref _g6, value); }
+        public byte G7 { get => _g7; set => SetField(ref _g7, value); }
+        public byte G8 { get => _g8; set => SetField(ref _g8, value); }
+        public byte G9 { get => _g9; set => SetField(ref _g9, value); }
+        public byte G10 { get => _g10; set => SetField(ref _g10, value); }
+        public byte G11 { get => _g11; set => SetField(ref _g11, value); }
+        public byte G12 { get => _g12; set => SetField(ref _g12, value); }
+        public byte G13 { get => _g13; set => SetField(ref _g13, value); }
+        public byte G14 { get => _g14; set => SetField(ref _g14, value); }
+        public byte G15 { get => _g15; set => SetField(ref _g15, value); }
+        public byte G16 { get => _g16; set => SetField(ref _g16, value); }
+
+        public byte B1 { get => _b1; set => SetField(ref _b1, value); }
+        public byte B2 { get => _b2; set => SetField(ref _b2, value); }
+        public byte B3 { get => _b3; set => SetField(ref _b3, value); }
+        public byte B4 { get => _b4; set => SetField(ref _b4, value); }
+        public byte B5 { get => _b5; set => SetField(ref _b5, value); }
+        public byte B6 { get => _b6; set => SetField(ref _b6, value); }
+        public byte B7 { get => _b7; set => SetField(ref _b7, value); }
+        public byte B8 { get => _b8; set => SetField(ref _b8, value); }
+        public byte B9 { get => _b9; set => SetField(ref _b9, value); }
+        public byte B10 { get => _b10; set => SetField(ref _b10, value); }
+        public byte B11 { get => _b11; set => SetField(ref _b11, value); }
+        public byte B12 { get => _b12; set => SetField(ref _b12, value); }
+        public byte B13 { get => _b13; set => SetField(ref _b13, value); }
+        public byte B14 { get => _b14; set => SetField(ref _b14, value); }
+        public byte B15 { get => _b15; set => SetField(ref _b15, value); }
+        public byte B16 { get => _b16; set => SetField(ref _b16, value); }
+
+        // ---- list / entry loading ----
+
+        /// <summary>
+        /// Returns a single placeholder entry. The palette editor is
+        /// opened directly via JumpTo(...) from caller editors (eg.
+        /// ImagePortraitView), so this list is a UI placeholder for
+        /// the AddressListControl - it has no functional meaning.
+        /// </summary>
         public List<AddrResult> LoadList()
         {
-            ROM rom = CoreState.ROM;
-            if (rom?.RomInfo == null) return new List<AddrResult>();
-
             var result = new List<AddrResult>();
-            result.Add(new AddrResult(0, "Palette Editor", 0));
+            result.Add(new AddrResult(0u, "Palette Editor", 0u));
             return result;
         }
 
-        public void LoadEntry(uint addr)
-        {
-            ROM rom = CoreState.ROM;
-            if (rom == null) return;
+        /// <summary>
+        /// Single-arg overload mirroring the generic ViewModel
+        /// contract used by the AddressListControl wiring. Uses
+        /// MAX_PALETTE_COUNT=16 default, PaletteIndex=0, no palette
+        /// names.
+        /// </summary>
+        public void LoadEntry(uint addr) => LoadEntry(addr, PaletteCore.MAX_PALETTE_COUNT, 0, null);
 
-            CurrentAddr = addr;
-            IsLoaded = true;
+        /// <summary>
+        /// Full LoadEntry mirrors WF ImagePalletForm.JumpTo. Reads 16
+        /// colors from ROM at <paramref name="paletteAddress"/> +
+        /// <paramref name="defaultSelectPalette"/> * 32 and exposes
+        /// them as R1..R16/G1..G16/B1..B16 (so AXAML NumericUpDown
+        /// bindings can target each value).
+        /// </summary>
+        public void LoadEntry(uint paletteAddress, int maxPaletteCount, int defaultSelectPalette, string[]? paletteNames)
+        {
+            var rom = CoreState.ROM;
+            if (rom == null) return;
+            if (maxPaletteCount < 1) maxPaletteCount = 1;
+            if (maxPaletteCount > PaletteCore.MAX_PALETTE_COUNT)
+                maxPaletteCount = PaletteCore.MAX_PALETTE_COUNT;
+            if (defaultSelectPalette < 0) defaultSelectPalette = 0;
+            if (defaultSelectPalette >= maxPaletteCount) defaultSelectPalette = maxPaletteCount - 1;
+
+            IsLoading = true;
+            try
+            {
+                PaletteAddress = paletteAddress;
+                MaxPaletteCount = maxPaletteCount;
+                PaletteIndex = defaultSelectPalette;
+                PaletteIndexNames = BuildIndexNames(maxPaletteCount, paletteNames);
+
+                ApplyPaletteFromRom();
+                IsLoaded = true;
+            }
+            finally
+            {
+                IsLoading = false;
+                MarkClean();
+            }
         }
+
+        /// <summary>
+        /// Re-read the palette from ROM at the current
+        /// (PaletteAddress, PaletteIndex) and refresh all 48 R/G/B
+        /// fields. Call after PaletteIndex changes so the displayed
+        /// values match the new slot.
+        /// </summary>
+        public void ApplyPaletteFromRom()
+        {
+            var rom = CoreState.ROM;
+            if (rom == null) return;
+            var colors = PaletteCore.ReadPalette(rom.Data, PaletteAddress, PaletteIndex);
+            for (int i = 0; i < 16; i++)
+                SetSlot(i, colors[i].r, colors[i].g, colors[i].b);
+        }
+
+        /// <summary>
+        /// Pack the 48 R/G/B fields into a 32-byte BGR15 blob and
+        /// write to ROM at (PaletteAddress, PaletteIndex). Returns
+        /// the destination offset (or U.NOT_FOUND when no-op).
+        /// </summary>
+        public uint Write()
+        {
+            var rom = CoreState.ROM;
+            if (rom == null) return U.NOT_FOUND;
+            if (PaletteAddress == 0) return U.NOT_FOUND;
+
+            var colors = GetSlots();
+            PaletteCore.WritePalette(rom, PaletteAddress, PaletteIndex, colors);
+            uint offset = U.toOffset(PaletteAddress) + (uint)(PaletteIndex * PaletteCore.PALETTE_BLOCK_SIZE);
+            return offset;
+        }
+
+        /// <summary>Return the current 16-tuple slot array (helper for tests + Write).</summary>
+        public (byte r, byte g, byte b)[] GetSlots()
+        {
+            return new (byte, byte, byte)[]
+            {
+                (_r1,  _g1,  _b1),  (_r2,  _g2,  _b2),
+                (_r3,  _g3,  _b3),  (_r4,  _g4,  _b4),
+                (_r5,  _g5,  _b5),  (_r6,  _g6,  _b6),
+                (_r7,  _g7,  _b7),  (_r8,  _g8,  _b8),
+                (_r9,  _g9,  _b9),  (_r10, _g10, _b10),
+                (_r11, _g11, _b11), (_r12, _g12, _b12),
+                (_r13, _g13, _b13), (_r14, _g14, _b14),
+                (_r15, _g15, _b15), (_r16, _g16, _b16),
+            };
+        }
+
+        /// <summary>Set slot N's R/G/B (N is 0-based, 0..15).</summary>
+        public void SetSlot(int n, byte r, byte g, byte b)
+        {
+            switch (n)
+            {
+                case 0:  R1  = r; G1  = g; B1  = b; break;
+                case 1:  R2  = r; G2  = g; B2  = b; break;
+                case 2:  R3  = r; G3  = g; B3  = b; break;
+                case 3:  R4  = r; G4  = g; B4  = b; break;
+                case 4:  R5  = r; G5  = g; B5  = b; break;
+                case 5:  R6  = r; G6  = g; B6  = b; break;
+                case 6:  R7  = r; G7  = g; B7  = b; break;
+                case 7:  R8  = r; G8  = g; B8  = b; break;
+                case 8:  R9  = r; G9  = g; B9  = b; break;
+                case 9:  R10 = r; G10 = g; B10 = b; break;
+                case 10: R11 = r; G11 = g; B11 = b; break;
+                case 11: R12 = r; G12 = g; B12 = b; break;
+                case 12: R13 = r; G13 = g; B13 = b; break;
+                case 13: R14 = r; G14 = g; B14 = b; break;
+                case 14: R15 = r; G15 = g; B15 = b; break;
+                case 15: R16 = r; G16 = g; B16 = b; break;
+            }
+        }
+
+        static IReadOnlyList<string> BuildIndexNames(int count, string[]? overrides)
+        {
+            var list = new List<string>(count);
+            for (int i = 0; i < count; i++)
+            {
+                if (overrides != null && i < overrides.Length && !string.IsNullOrEmpty(overrides[i]))
+                    list.Add(overrides[i]);
+                else
+                    list.Add($"Palette No {i}");
+            }
+            return list;
+        }
+
     }
 }

--- a/FEBuilderGBA.Avalonia/ViewModels/ImagePalletViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImagePalletViewModel.cs
@@ -129,8 +129,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// </summary>
         public List<AddrResult> LoadList()
         {
+            // The placeholder label goes through R._() so it picks up
+            // the ja/zh translations the rest of the editor uses
+            // (Copilot bot inline review #6 on PR #586).
             var result = new List<AddrResult>();
-            result.Add(new AddrResult(0u, "Palette Editor", 0u));
+            result.Add(new AddrResult(0u, R._("Palette Editor"), 0u));
             return result;
         }
 
@@ -195,16 +198,22 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// <summary>
         /// Pack the 48 R/G/B fields into a 32-byte BGR15 blob and
         /// write to ROM at (PaletteAddress, PaletteIndex). Returns
-        /// the destination offset (or U.NOT_FOUND when no-op).
+        /// the destination offset on success, or U.NOT_FOUND when the
+        /// write was a no-op (null ROM, invalid address, or overflow -
+        /// Copilot CLI round-1 review on PR #586).
         /// </summary>
         public uint Write()
         {
             var rom = CoreState.ROM;
             if (rom == null) return U.NOT_FOUND;
-            if (PaletteAddress == 0) return U.NOT_FOUND;
+            if (PaletteAddress == 0 || PaletteAddress == U.NOT_FOUND) return U.NOT_FOUND;
 
             var colors = GetSlots();
-            PaletteCore.WritePalette(rom, PaletteAddress, PaletteIndex, colors);
+            // Honor PaletteCore.WritePalette's success/fail return so we
+            // don't report a successful offset when Core skipped the
+            // write (e.g. overflow / invalid address).
+            if (!PaletteCore.WritePalette(rom, PaletteAddress, PaletteIndex, colors))
+                return U.NOT_FOUND;
             uint offset = U.toOffset(PaletteAddress) + (uint)(PaletteIndex * PaletteCore.PALETTE_BLOCK_SIZE);
             return offset;
         }
@@ -251,13 +260,16 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
         static IReadOnlyList<string> BuildIndexNames(int count, string[]? overrides)
         {
+            // Fallback labels are localized via R._() so the
+            // palette-index combo items pick up ja/zh translations
+            // (Copilot bot inline review #7 on PR #586).
             var list = new List<string>(count);
             for (int i = 0; i < count; i++)
             {
                 if (overrides != null && i < overrides.Length && !string.IsNullOrEmpty(overrides[i]))
                     list.Add(overrides[i]);
                 else
-                    list.Add($"Palette No {i}");
+                    list.Add(R._("Palette No {0}", i));
             }
             return list;
         }

--- a/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml
@@ -2,20 +2,319 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
         x:Class="FEBuilderGBA.Avalonia.Views.ImagePalletView"
-        Title="Palette Editor" Width="1241" Height="529"
+        Title="Palette Editor" Width="1280" Height="700"
         SizeToContent="WidthAndHeight">
-  <Grid ColumnDefinitions="250,*">
-    <controls:AddressListControl AutomationProperties.AutomationId="ImagePallet_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
+  <!-- Mirrors WF ImagePalletForm.panel1 (#400 gap-sweep).
+       Left: address list (placeholder). Right: top selection bar,
+       palette-index bar, 16-cell color grid (4 cols x 4 rows),
+       preview image + bottom button row. -->
+  <Grid ColumnDefinitions="250,*,300">
 
+    <!-- ==== left column: placeholder address list ==== -->
+    <controls:AddressListControl AutomationProperties.AutomationId="ImagePallet_Entry_List"
+                                 Grid.Column="0" Name="EntryList" Margin="4" />
+
+    <!-- ==== middle column: address + index + 16-cell grid ==== -->
     <ScrollViewer Grid.Column="1" Margin="4">
-      <StackPanel Spacing="8" Margin="8">
+      <StackPanel Spacing="6" Margin="4">
+
         <TextBlock Text="Palette Editor" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="ImagePallet_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+        <!-- Top selection bar (mirrors WF label5 + PALETTE_ADDRESS + label1 +
+             PaletteZoomComboBox + PaletteWriteButton + UNDOButton + REDOButton). -->
+        <Border BorderBrush="Gray" BorderThickness="1" Padding="6">
+          <StackPanel Orientation="Horizontal" Spacing="6">
+            <Label AutomationProperties.AutomationId="ImagePallet_Address_Label"
+                   Content="Palette Address:" VerticalAlignment="Center" />
+            <NumericUpDown AutomationProperties.AutomationId="ImagePallet_Address_Input"
+                           FormatString="0" Name="AddressBox" Width="140"
+                           Minimum="0" Maximum="4294967295"
+                           IsEnabled="False" VerticalAlignment="Center" />
+            <Label AutomationProperties.AutomationId="ImagePallet_Zoom_Label"
+                   Content="Zoom" VerticalAlignment="Center" />
+            <ComboBox AutomationProperties.AutomationId="ImagePallet_Zoom_Combo"
+                      Name="ZoomComboBox" Width="220"
+                      SelectionChanged="Zoom_SelectionChanged">
+              <ComboBoxItem><TextBlock Text="Fit to window" /></ComboBoxItem>
+              <ComboBoxItem><TextBlock Text="Original size" /></ComboBoxItem>
+              <ComboBoxItem><TextBlock Text="2x" /></ComboBoxItem>
+              <ComboBoxItem><TextBlock Text="3x" /></ComboBoxItem>
+              <ComboBoxItem><TextBlock Text="4x" /></ComboBoxItem>
+            </ComboBox>
+            <Button AutomationProperties.AutomationId="ImagePallet_Write_Button"
+                    Name="WriteButton" Content="Write Palette" Click="Write_Click" />
+            <Button AutomationProperties.AutomationId="ImagePallet_Undo_Button"
+                    Name="UndoButton" Content="Undo" Click="Undo_Click" />
+            <Button AutomationProperties.AutomationId="ImagePallet_Redo_Button"
+                    Name="RedoButton" Content="Redo"
+                    IsEnabled="False"
+                    ToolTip.Tip="Pending Core RunRedo API - tracked by #500." />
+          </StackPanel>
+        </Border>
+
+        <!-- Palette-index bar (mirrors WF PaletteIndexLabel + PaletteIndexComboBox). -->
+        <Border BorderBrush="Gray" BorderThickness="1" Padding="6">
+          <StackPanel Orientation="Horizontal" Spacing="6">
+            <Label AutomationProperties.AutomationId="ImagePallet_PaletteIndex_Label"
+                   Name="PaletteIndexLabel"
+                   Content="Palette Index" VerticalAlignment="Center" />
+            <ComboBox AutomationProperties.AutomationId="ImagePallet_PaletteIndex_Combo"
+                      Name="PaletteIndexComboBox" Width="240"
+                      SelectionChanged="PaletteIndex_SelectionChanged" />
+          </StackPanel>
+        </Border>
+
+        <!-- 16-cell color grid (4 cols x 4 rows). Each cell shows:
+             numeric label "N", swatch image, R/G/B NumericUpDowns. -->
+        <Grid
+              ColumnDefinitions="*,*,*,*" RowDefinitions="Auto,Auto,Auto,Auto" Margin="0,4,0,4">
+
+          <!-- Row 1: cells 1-4 -->
+          <Border Grid.Row="0" Grid.Column="0" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
+            <StackPanel Spacing="2">
+              <StackPanel Orientation="Horizontal" Spacing="4">
+                <Label AutomationProperties.AutomationId="ImagePallet_Index1_Label" Content="1" Width="20" />
+                <Image AutomationProperties.AutomationId="ImagePallet_P1_Image" Name="P1Swatch" Width="40" Height="20" />
+              </StackPanel>
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R1_Input" Name="R1Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_G1_Input" Name="G1Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_B1_Input" Name="B1Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+            </StackPanel>
+          </Border>
+
+          <Border Grid.Row="0" Grid.Column="1" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
+            <StackPanel Spacing="2">
+              <StackPanel Orientation="Horizontal" Spacing="4">
+                <Label AutomationProperties.AutomationId="ImagePallet_Index2_Label" Content="2" Width="20" />
+                <Image AutomationProperties.AutomationId="ImagePallet_P2_Image" Name="P2Swatch" Width="40" Height="20" />
+              </StackPanel>
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R2_Input" Name="R2Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_G2_Input" Name="G2Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_B2_Input" Name="B2Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+            </StackPanel>
+          </Border>
+
+          <Border Grid.Row="0" Grid.Column="2" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
+            <StackPanel Spacing="2">
+              <StackPanel Orientation="Horizontal" Spacing="4">
+                <Label AutomationProperties.AutomationId="ImagePallet_Index3_Label" Content="3" Width="20" />
+                <Image AutomationProperties.AutomationId="ImagePallet_P3_Image" Name="P3Swatch" Width="40" Height="20" />
+              </StackPanel>
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R3_Input" Name="R3Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_G3_Input" Name="G3Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_B3_Input" Name="B3Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+            </StackPanel>
+          </Border>
+
+          <Border Grid.Row="0" Grid.Column="3" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
+            <StackPanel Spacing="2">
+              <StackPanel Orientation="Horizontal" Spacing="4">
+                <Label AutomationProperties.AutomationId="ImagePallet_Index4_Label" Content="4" Width="20" />
+                <Image AutomationProperties.AutomationId="ImagePallet_P4_Image" Name="P4Swatch" Width="40" Height="20" />
+              </StackPanel>
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R4_Input" Name="R4Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_G4_Input" Name="G4Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_B4_Input" Name="B4Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+            </StackPanel>
+          </Border>
+
+          <!-- Row 2: cells 5-8 -->
+          <Border Grid.Row="1" Grid.Column="0" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
+            <StackPanel Spacing="2">
+              <StackPanel Orientation="Horizontal" Spacing="4">
+                <Label AutomationProperties.AutomationId="ImagePallet_Index5_Label" Content="5" Width="20" />
+                <Image AutomationProperties.AutomationId="ImagePallet_P5_Image" Name="P5Swatch" Width="40" Height="20" />
+              </StackPanel>
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R5_Input" Name="R5Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_G5_Input" Name="G5Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_B5_Input" Name="B5Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+            </StackPanel>
+          </Border>
+
+          <Border Grid.Row="1" Grid.Column="1" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
+            <StackPanel Spacing="2">
+              <StackPanel Orientation="Horizontal" Spacing="4">
+                <Label AutomationProperties.AutomationId="ImagePallet_Index6_Label" Content="6" Width="20" />
+                <Image AutomationProperties.AutomationId="ImagePallet_P6_Image" Name="P6Swatch" Width="40" Height="20" />
+              </StackPanel>
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R6_Input" Name="R6Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_G6_Input" Name="G6Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_B6_Input" Name="B6Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+            </StackPanel>
+          </Border>
+
+          <Border Grid.Row="1" Grid.Column="2" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
+            <StackPanel Spacing="2">
+              <StackPanel Orientation="Horizontal" Spacing="4">
+                <Label AutomationProperties.AutomationId="ImagePallet_Index7_Label" Content="7" Width="20" />
+                <Image AutomationProperties.AutomationId="ImagePallet_P7_Image" Name="P7Swatch" Width="40" Height="20" />
+              </StackPanel>
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R7_Input" Name="R7Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_G7_Input" Name="G7Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_B7_Input" Name="B7Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+            </StackPanel>
+          </Border>
+
+          <Border Grid.Row="1" Grid.Column="3" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
+            <StackPanel Spacing="2">
+              <StackPanel Orientation="Horizontal" Spacing="4">
+                <Label AutomationProperties.AutomationId="ImagePallet_Index8_Label" Content="8" Width="20" />
+                <Image AutomationProperties.AutomationId="ImagePallet_P8_Image" Name="P8Swatch" Width="40" Height="20" />
+              </StackPanel>
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R8_Input" Name="R8Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_G8_Input" Name="G8Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_B8_Input" Name="B8Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+            </StackPanel>
+          </Border>
+
+          <!-- Row 3: cells 9-12 -->
+          <Border Grid.Row="2" Grid.Column="0" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
+            <StackPanel Spacing="2">
+              <StackPanel Orientation="Horizontal" Spacing="4">
+                <Label AutomationProperties.AutomationId="ImagePallet_Index9_Label" Content="9" Width="20" />
+                <Image AutomationProperties.AutomationId="ImagePallet_P9_Image" Name="P9Swatch" Width="40" Height="20" />
+              </StackPanel>
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R9_Input" Name="R9Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_G9_Input" Name="G9Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_B9_Input" Name="B9Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+            </StackPanel>
+          </Border>
+
+          <Border Grid.Row="2" Grid.Column="1" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
+            <StackPanel Spacing="2">
+              <StackPanel Orientation="Horizontal" Spacing="4">
+                <Label AutomationProperties.AutomationId="ImagePallet_Index10_Label" Content="10" Width="20" />
+                <Image AutomationProperties.AutomationId="ImagePallet_P10_Image" Name="P10Swatch" Width="40" Height="20" />
+              </StackPanel>
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R10_Input" Name="R10Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_G10_Input" Name="G10Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_B10_Input" Name="B10Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+            </StackPanel>
+          </Border>
+
+          <Border Grid.Row="2" Grid.Column="2" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
+            <StackPanel Spacing="2">
+              <StackPanel Orientation="Horizontal" Spacing="4">
+                <Label AutomationProperties.AutomationId="ImagePallet_Index11_Label" Content="11" Width="20" />
+                <Image AutomationProperties.AutomationId="ImagePallet_P11_Image" Name="P11Swatch" Width="40" Height="20" />
+              </StackPanel>
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R11_Input" Name="R11Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_G11_Input" Name="G11Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_B11_Input" Name="B11Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+            </StackPanel>
+          </Border>
+
+          <Border Grid.Row="2" Grid.Column="3" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
+            <StackPanel Spacing="2">
+              <StackPanel Orientation="Horizontal" Spacing="4">
+                <Label AutomationProperties.AutomationId="ImagePallet_Index12_Label" Content="12" Width="20" />
+                <Image AutomationProperties.AutomationId="ImagePallet_P12_Image" Name="P12Swatch" Width="40" Height="20" />
+              </StackPanel>
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R12_Input" Name="R12Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_G12_Input" Name="G12Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_B12_Input" Name="B12Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+            </StackPanel>
+          </Border>
+
+          <!-- Row 4: cells 13-16 -->
+          <Border Grid.Row="3" Grid.Column="0" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
+            <StackPanel Spacing="2">
+              <StackPanel Orientation="Horizontal" Spacing="4">
+                <Label AutomationProperties.AutomationId="ImagePallet_Index13_Label" Content="13" Width="20" />
+                <Image AutomationProperties.AutomationId="ImagePallet_P13_Image" Name="P13Swatch" Width="40" Height="20" />
+              </StackPanel>
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R13_Input" Name="R13Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_G13_Input" Name="G13Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_B13_Input" Name="B13Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+            </StackPanel>
+          </Border>
+
+          <Border Grid.Row="3" Grid.Column="1" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
+            <StackPanel Spacing="2">
+              <StackPanel Orientation="Horizontal" Spacing="4">
+                <Label AutomationProperties.AutomationId="ImagePallet_Index14_Label" Content="14" Width="20" />
+                <Image AutomationProperties.AutomationId="ImagePallet_P14_Image" Name="P14Swatch" Width="40" Height="20" />
+              </StackPanel>
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R14_Input" Name="R14Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_G14_Input" Name="G14Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_B14_Input" Name="B14Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+            </StackPanel>
+          </Border>
+
+          <Border Grid.Row="3" Grid.Column="2" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
+            <StackPanel Spacing="2">
+              <StackPanel Orientation="Horizontal" Spacing="4">
+                <Label AutomationProperties.AutomationId="ImagePallet_Index15_Label" Content="15" Width="20" />
+                <Image AutomationProperties.AutomationId="ImagePallet_P15_Image" Name="P15Swatch" Width="40" Height="20" />
+              </StackPanel>
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R15_Input" Name="R15Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_G15_Input" Name="G15Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_B15_Input" Name="B15Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+            </StackPanel>
+          </Border>
+
+          <Border Grid.Row="3" Grid.Column="3" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
+            <StackPanel Spacing="2">
+              <StackPanel Orientation="Horizontal" Spacing="4">
+                <Label AutomationProperties.AutomationId="ImagePallet_Index16_Label" Content="16" Width="20" />
+                <Image AutomationProperties.AutomationId="ImagePallet_P16_Image" Name="P16Swatch" Width="40" Height="20" />
+              </StackPanel>
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R16_Input" Name="R16Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_G16_Input" Name="G16Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+              <NumericUpDown AutomationProperties.AutomationId="ImagePallet_B16_Input" Name="B16Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
+            </StackPanel>
+          </Border>
         </Grid>
+
+        <!-- Bottom button row (mirrors WF ImportButton + ExportButton +
+             PALETTE_TO_CLIPBOARD_BUTTON). All deferred to #500 - real
+             Bitmap import/export needs the WF ImageFormRef path. -->
+        <StackPanel Orientation="Horizontal" Spacing="6" Margin="0,4,0,0">
+          <Button AutomationProperties.AutomationId="ImagePallet_Import_Button"
+                  Name="ImportButton" Content="Import Image"
+                  IsEnabled="False"
+                  ToolTip.Tip="Pending Core extraction - tracked by #500."
+                  Click="Import_Click" />
+          <Button AutomationProperties.AutomationId="ImagePallet_Export_Button"
+                  Name="ExportButton" Content="Export Image"
+                  IsEnabled="False"
+                  ToolTip.Tip="Pending Core extraction - tracked by #500."
+                  Click="Export_Click" />
+          <Button AutomationProperties.AutomationId="ImagePallet_Clipboard_Button"
+                  Name="ClipboardButton" Content="Clipboard"
+                  IsEnabled="False"
+                  ToolTip.Tip="Pending Core extraction - tracked by #500."
+                  Click="Clipboard_Click" />
+        </StackPanel>
+
       </StackPanel>
     </ScrollViewer>
+
+    <!-- ==== right column: preview area + R/G/B row labels ==== -->
+    <Border Grid.Column="2" BorderBrush="Gray" BorderThickness="1" Margin="4" Padding="6">
+      <StackPanel Spacing="4">
+        <Label AutomationProperties.AutomationId="ImagePallet_Preview_Label"
+               Content="Preview" FontWeight="SemiBold" />
+        <Image AutomationProperties.AutomationId="ImagePallet_Preview_Image"
+               Name="PreviewImage" Width="260" Height="260"
+               Stretch="Uniform"
+               ToolTip.Tip="Live bitmap preview pending Core extraction - tracked by #500." />
+
+        <!-- R/G/B row labels (mirrors WF label53/label52/label51 +
+             label48/label49/label50). One axis label per channel so
+             callers know the NumericUpDown column meaning. -->
+        <Label AutomationProperties.AutomationId="ImagePallet_R_Label"
+               Content="R" FontWeight="Bold" Margin="0,8,0,0" />
+        <Label AutomationProperties.AutomationId="ImagePallet_G_Label"
+               Content="G" FontWeight="Bold" />
+        <Label AutomationProperties.AutomationId="ImagePallet_B_Label"
+               Content="B" FontWeight="Bold" />
+
+        <Label AutomationProperties.AutomationId="ImagePallet_Hint_Label"
+               Content="Edit R/G/B 0-248 (5-bit ticks)"
+               FontStyle="Italic" Margin="0,8,0,0" />
+      </StackPanel>
+    </Border>
+
   </Grid>
 </Window>

--- a/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml.cs
@@ -239,7 +239,13 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (writtenOffset == U.NOT_FOUND)
                 {
                     _undoService.Rollback();
-                    Log.Error("ImagePalletView.Write_Click: write was no-op (addr=0x{0:X08})", _vm.PaletteAddress.ToString("X8"));
+                    // Pre-format the address so we pass a single
+                    // already-rendered string into Log.Error's
+                    // params string[]. Using "{0:X08}" + a string
+                    // arg crashes Log.Error since the format spec
+                    // expects a uint (Copilot bot round-2 inline
+                    // review on PR #586).
+                    Log.Error("ImagePalletView.Write_Click: write was no-op (addr=0x" + _vm.PaletteAddress.ToString("X8") + ")");
                     CoreState.Services?.ShowError(R._("Write failed: {0}", R._("Invalid palette address")));
                     return;
                 }

--- a/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml.cs
@@ -1,6 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Avalonia counterpart of WinForms ImagePalletForm (#400 gap-sweep).
+// Provides a WF-equivalent JumpTo(...) entry point so callers like
+// ImagePortraitView.JumpToPalette_Click can carry the palette
+// address from the source editor.
+//
+// All ROM writes are wrapped in UndoService.Begin/Commit/Rollback;
+// Undo is wired to CoreState.Undo.RunUndo() + reload, Redo is
+// deferred behind #500 (Core has no RunRedo() API).
+
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
+using global::Avalonia.Media;
+using global::Avalonia.Media.Imaging;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 
@@ -9,6 +21,7 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class ImagePalletView : TranslatedWindow, IEditorView
     {
         readonly ImagePalletViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         public string ViewTitle => "Palette Editor";
         public bool IsLoaded => _vm.IsLoaded;
@@ -20,12 +33,15 @@ namespace FEBuilderGBA.Avalonia.Views
             Opened += (_, _) => LoadList();
         }
 
+        // ---- entry / list loading ----
+
         void LoadList()
         {
             try
             {
                 var items = _vm.LoadList();
                 EntryList.SetItems(items);
+                UpdateUI();
             }
             catch (Exception ex)
             {
@@ -35,23 +51,258 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void OnSelected(uint addr)
         {
+            // Address-list rows are placeholders here; selection is
+            // a no-op apart from refreshing the UI.
+            UpdateUI();
+        }
+
+        /// <summary>
+        /// WF-equivalent entry point. Callers (eg.
+        /// ImagePortraitView.JumpToPalette_Click) invoke this after
+        /// Open<ImagePalletView>() to carry the palette address +
+        /// multi-palette metadata (Copilot CLI plan review #2).
+        /// </summary>
+        public void JumpTo(uint paletteAddress, int maxPaletteCount = 1, int defaultSelectPalette = 0, string[]? paletteNames = null)
+        {
             try
             {
-                _vm.LoadEntry(addr);
+                _vm.LoadEntry(paletteAddress, maxPaletteCount, defaultSelectPalette, paletteNames);
                 UpdateUI();
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePalletView.OnSelected failed: {0}", ex.Message);
+                Log.Error("ImagePalletView.JumpTo failed: {0}", ex.Message);
             }
         }
 
+        // ---- UI sync ----
+
         void UpdateUI()
         {
-            AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            // Address bar (read-only; mirrors WF PALETTE_ADDRESS).
+            AddressBox.Value = _vm.PaletteAddress;
+
+            // Palette-index combo: rebuild items from VM, then select index.
+            // Hide when only one palette is available (mirrors WF JumpTo behavior).
+            PaletteIndexComboBox.Items.Clear();
+            foreach (var name in _vm.PaletteIndexNames)
+                PaletteIndexComboBox.Items.Add(new ComboBoxItem { Content = new TextBlock { Text = name } });
+            if (_vm.PaletteIndex >= 0 && _vm.PaletteIndex < PaletteIndexComboBox.Items.Count)
+                PaletteIndexComboBox.SelectedIndex = _vm.PaletteIndex;
+
+            bool showIndex = _vm.MaxPaletteCount > 1;
+            PaletteIndexComboBox.IsVisible = showIndex;
+            PaletteIndexLabel.IsVisible = showIndex;
+
+            ZoomComboBox.SelectedIndex = _vm.ZoomIndex;
+
+            // Mirror the 48 NUDs from VM state.
+            R1Box.Value = _vm.R1; G1Box.Value = _vm.G1; B1Box.Value = _vm.B1;
+            R2Box.Value = _vm.R2; G2Box.Value = _vm.G2; B2Box.Value = _vm.B2;
+            R3Box.Value = _vm.R3; G3Box.Value = _vm.G3; B3Box.Value = _vm.B3;
+            R4Box.Value = _vm.R4; G4Box.Value = _vm.G4; B4Box.Value = _vm.B4;
+            R5Box.Value = _vm.R5; G5Box.Value = _vm.G5; B5Box.Value = _vm.B5;
+            R6Box.Value = _vm.R6; G6Box.Value = _vm.G6; B6Box.Value = _vm.B6;
+            R7Box.Value = _vm.R7; G7Box.Value = _vm.G7; B7Box.Value = _vm.B7;
+            R8Box.Value = _vm.R8; G8Box.Value = _vm.G8; B8Box.Value = _vm.B8;
+            R9Box.Value = _vm.R9; G9Box.Value = _vm.G9; B9Box.Value = _vm.B9;
+            R10Box.Value = _vm.R10; G10Box.Value = _vm.G10; B10Box.Value = _vm.B10;
+            R11Box.Value = _vm.R11; G11Box.Value = _vm.G11; B11Box.Value = _vm.B11;
+            R12Box.Value = _vm.R12; G12Box.Value = _vm.G12; B12Box.Value = _vm.B12;
+            R13Box.Value = _vm.R13; G13Box.Value = _vm.G13; B13Box.Value = _vm.B13;
+            R14Box.Value = _vm.R14; G14Box.Value = _vm.G14; B14Box.Value = _vm.B14;
+            R15Box.Value = _vm.R15; G15Box.Value = _vm.G15; B15Box.Value = _vm.B15;
+            R16Box.Value = _vm.R16; G16Box.Value = _vm.G16; B16Box.Value = _vm.B16;
+
+            RefreshSwatches();
         }
 
-        public void NavigateTo(uint address) => EntryList.SelectAddress(address);
+        void RefreshSwatches()
+        {
+            // Render each swatch image with the current R/G/B color so the
+            // user can see the slot color preview without needing live
+            // Bitmap-pipeline support.
+            SetSwatch(P1Swatch,  _vm.R1,  _vm.G1,  _vm.B1);
+            SetSwatch(P2Swatch,  _vm.R2,  _vm.G2,  _vm.B2);
+            SetSwatch(P3Swatch,  _vm.R3,  _vm.G3,  _vm.B3);
+            SetSwatch(P4Swatch,  _vm.R4,  _vm.G4,  _vm.B4);
+            SetSwatch(P5Swatch,  _vm.R5,  _vm.G5,  _vm.B5);
+            SetSwatch(P6Swatch,  _vm.R6,  _vm.G6,  _vm.B6);
+            SetSwatch(P7Swatch,  _vm.R7,  _vm.G7,  _vm.B7);
+            SetSwatch(P8Swatch,  _vm.R8,  _vm.G8,  _vm.B8);
+            SetSwatch(P9Swatch,  _vm.R9,  _vm.G9,  _vm.B9);
+            SetSwatch(P10Swatch, _vm.R10, _vm.G10, _vm.B10);
+            SetSwatch(P11Swatch, _vm.R11, _vm.G11, _vm.B11);
+            SetSwatch(P12Swatch, _vm.R12, _vm.G12, _vm.B12);
+            SetSwatch(P13Swatch, _vm.R13, _vm.G13, _vm.B13);
+            SetSwatch(P14Swatch, _vm.R14, _vm.G14, _vm.B14);
+            SetSwatch(P15Swatch, _vm.R15, _vm.G15, _vm.B15);
+            SetSwatch(P16Swatch, _vm.R16, _vm.G16, _vm.B16);
+        }
+
+        static void SetSwatch(Image image, byte r, byte g, byte b)
+        {
+            // Lightweight 1x1 pixel rendered at the swatch's display size.
+            // Avalonia stretches it to the Image bounds automatically.
+            var bmp = new WriteableBitmap(
+                new global::Avalonia.PixelSize(1, 1),
+                new global::Avalonia.Vector(96, 96),
+                global::Avalonia.Platform.PixelFormat.Bgra8888,
+                global::Avalonia.Platform.AlphaFormat.Unpremul);
+            using (var fb = bmp.Lock())
+            {
+                unsafe
+                {
+                    byte* p = (byte*)fb.Address;
+                    p[0] = b; p[1] = g; p[2] = r; p[3] = 0xFF; // BGRA
+                }
+            }
+            image.Source = bmp;
+            image.Stretch = Stretch.Fill;
+        }
+
+        // ---- event handlers ----
+
+        void Zoom_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            // Persist the selected zoom into the VM (mirrors WF
+            // PaletteZoomComboBox_SelectedIndexChanged - WF re-renders
+            // the bitmap preview; live preview is #500-deferred here).
+            int idx = ZoomComboBox.SelectedIndex;
+            if (idx < 0) idx = 0;
+            _vm.ZoomIndex = idx;
+        }
+
+        void PaletteIndex_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            int idx = PaletteIndexComboBox.SelectedIndex;
+            if (idx < 0) return;
+            if (idx == _vm.PaletteIndex) return;
+            _vm.PaletteIndex = idx;
+            // Re-read the now-selected palette block from ROM.
+            _vm.IsLoading = true;
+            try
+            {
+                _vm.ApplyPaletteFromRom();
+            }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
+            }
+            UpdateUI();
+        }
+
+        void Write_Click(object? sender, RoutedEventArgs e)
+        {
+            if (!_vm.IsLoaded || _vm.PaletteAddress == 0) return;
+            uint reloadAddr = _vm.PaletteAddress;
+            int reloadMax = _vm.MaxPaletteCount;
+            int reloadIdx = _vm.PaletteIndex;
+
+            _undoService.Begin("Edit Palette");
+            try
+            {
+                ReadNudsIntoVm();
+                _vm.Write();
+                _undoService.Commit();
+                _vm.MarkClean();
+
+                // Reload so the swatch images reflect the post-write
+                // 5-bit-quantized values (mirrors the
+                // ImageMagicCSACreator pattern).
+                _vm.IsLoading = true;
+                try
+                {
+                    _vm.LoadEntry(reloadAddr, reloadMax, reloadIdx, null);
+                }
+                finally
+                {
+                    _vm.IsLoading = false;
+                    _vm.MarkClean();
+                }
+                UpdateUI();
+
+                CoreState.Services?.ShowInfo("Palette written.");
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("ImagePalletView.Write_Click failed: {0}", ex.Message);
+                CoreState.Services?.ShowError($"Write failed: {ex.Message}");
+            }
+        }
+
+        void ReadNudsIntoVm()
+        {
+            // Pull current NUD values back into the VM before packing.
+            // The NUD-to-VM direction is one-shot at Write time (no
+            // PropertyChanged round-trip needed for the gap-sweep PR
+            // since the swatches refresh on the reload after write).
+            _vm.R1  = (byte)(R1Box.Value  ?? 0); _vm.G1  = (byte)(G1Box.Value  ?? 0); _vm.B1  = (byte)(B1Box.Value  ?? 0);
+            _vm.R2  = (byte)(R2Box.Value  ?? 0); _vm.G2  = (byte)(G2Box.Value  ?? 0); _vm.B2  = (byte)(B2Box.Value  ?? 0);
+            _vm.R3  = (byte)(R3Box.Value  ?? 0); _vm.G3  = (byte)(G3Box.Value  ?? 0); _vm.B3  = (byte)(B3Box.Value  ?? 0);
+            _vm.R4  = (byte)(R4Box.Value  ?? 0); _vm.G4  = (byte)(G4Box.Value  ?? 0); _vm.B4  = (byte)(B4Box.Value  ?? 0);
+            _vm.R5  = (byte)(R5Box.Value  ?? 0); _vm.G5  = (byte)(G5Box.Value  ?? 0); _vm.B5  = (byte)(B5Box.Value  ?? 0);
+            _vm.R6  = (byte)(R6Box.Value  ?? 0); _vm.G6  = (byte)(G6Box.Value  ?? 0); _vm.B6  = (byte)(B6Box.Value  ?? 0);
+            _vm.R7  = (byte)(R7Box.Value  ?? 0); _vm.G7  = (byte)(G7Box.Value  ?? 0); _vm.B7  = (byte)(B7Box.Value  ?? 0);
+            _vm.R8  = (byte)(R8Box.Value  ?? 0); _vm.G8  = (byte)(G8Box.Value  ?? 0); _vm.B8  = (byte)(B8Box.Value  ?? 0);
+            _vm.R9  = (byte)(R9Box.Value  ?? 0); _vm.G9  = (byte)(G9Box.Value  ?? 0); _vm.B9  = (byte)(B9Box.Value  ?? 0);
+            _vm.R10 = (byte)(R10Box.Value ?? 0); _vm.G10 = (byte)(G10Box.Value ?? 0); _vm.B10 = (byte)(B10Box.Value ?? 0);
+            _vm.R11 = (byte)(R11Box.Value ?? 0); _vm.G11 = (byte)(G11Box.Value ?? 0); _vm.B11 = (byte)(B11Box.Value ?? 0);
+            _vm.R12 = (byte)(R12Box.Value ?? 0); _vm.G12 = (byte)(G12Box.Value ?? 0); _vm.B12 = (byte)(B12Box.Value ?? 0);
+            _vm.R13 = (byte)(R13Box.Value ?? 0); _vm.G13 = (byte)(G13Box.Value ?? 0); _vm.B13 = (byte)(B13Box.Value ?? 0);
+            _vm.R14 = (byte)(R14Box.Value ?? 0); _vm.G14 = (byte)(G14Box.Value ?? 0); _vm.B14 = (byte)(B14Box.Value ?? 0);
+            _vm.R15 = (byte)(R15Box.Value ?? 0); _vm.G15 = (byte)(G15Box.Value ?? 0); _vm.B15 = (byte)(B15Box.Value ?? 0);
+            _vm.R16 = (byte)(R16Box.Value ?? 0); _vm.G16 = (byte)(G16Box.Value ?? 0); _vm.B16 = (byte)(B16Box.Value ?? 0);
+        }
+
+        void Undo_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                CoreState.Undo?.RunUndo();
+                // Reload so the displayed values reflect the post-undo
+                // ROM state (Copilot CLI plan review #5 - Undo enabled).
+                if (_vm.IsLoaded)
+                {
+                    uint addr = _vm.PaletteAddress;
+                    int max = _vm.MaxPaletteCount;
+                    int idx = _vm.PaletteIndex;
+                    _vm.IsLoading = true;
+                    try
+                    {
+                        _vm.LoadEntry(addr, max, idx, null);
+                    }
+                    finally
+                    {
+                        _vm.IsLoading = false;
+                        _vm.MarkClean();
+                    }
+                    UpdateUI();
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImagePalletView.Undo_Click failed: {0}", ex.Message);
+            }
+        }
+
+        // Deferred affordances (all surface as disabled buttons with #500
+        // tooltip; the click handlers exist so AXAML wiring stays valid).
+
+        void Import_Click(object? sender, RoutedEventArgs e) =>
+            Log.Debug("ImagePalletView.Import_Click invoked - disabled until #500 lands");
+
+        void Export_Click(object? sender, RoutedEventArgs e) =>
+            Log.Debug("ImagePalletView.Export_Click invoked - disabled until #500 lands");
+
+        void Clipboard_Click(object? sender, RoutedEventArgs e) =>
+            Log.Debug("ImagePalletView.Clipboard_Click invoked - disabled until #500 lands");
+
+        // ---- IEditorView ----
+
+        public void NavigateTo(uint address) => JumpTo(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml.cs
@@ -231,7 +231,18 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 ReadNudsIntoVm();
-                _vm.Write();
+                // Honor PaletteCore.WritePalette's no-op return so an
+                // invalid/out-of-range destination surfaces as an
+                // error toast instead of a fake success path
+                // (Copilot CLI round-2 review on PR #586).
+                uint writtenOffset = _vm.Write();
+                if (writtenOffset == U.NOT_FOUND)
+                {
+                    _undoService.Rollback();
+                    Log.Error("ImagePalletView.Write_Click: write was no-op (addr=0x{0:X08})", _vm.PaletteAddress.ToString("X8"));
+                    CoreState.Services?.ShowError(R._("Write failed: {0}", R._("Invalid palette address")));
+                    return;
+                }
                 _undoService.Commit();
                 _vm.MarkClean();
 

--- a/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml.cs
@@ -90,7 +90,15 @@ namespace FEBuilderGBA.Avalonia.Views
             if (_vm.PaletteIndex >= 0 && _vm.PaletteIndex < PaletteIndexComboBox.Items.Count)
                 PaletteIndexComboBox.SelectedIndex = _vm.PaletteIndex;
 
-            bool showIndex = _vm.MaxPaletteCount > 1;
+            // Only show the palette-index bar once real palette data has
+            // been loaded AND there is more than one block to switch
+            // between. Without the IsLoaded gate, opening from the main
+            // menu (which leaves MaxPaletteCount at the 16 default and
+            // PaletteIndexNames empty) would render an empty combo
+            // (Copilot bot inline review #8 on PR #586).
+            bool showIndex = _vm.IsLoaded
+                && _vm.MaxPaletteCount > 1
+                && _vm.PaletteIndexNames.Count > 0;
             PaletteIndexComboBox.IsVisible = showIndex;
             PaletteIndexLabel.IsVisible = showIndex;
 
@@ -142,13 +150,27 @@ namespace FEBuilderGBA.Avalonia.Views
 
         static void SetSwatch(Image image, byte r, byte g, byte b)
         {
-            // Lightweight 1x1 pixel rendered at the swatch's display size.
-            // Avalonia stretches it to the Image bounds automatically.
-            var bmp = new WriteableBitmap(
-                new global::Avalonia.PixelSize(1, 1),
-                new global::Avalonia.Vector(96, 96),
-                global::Avalonia.Platform.PixelFormat.Bgra8888,
-                global::Avalonia.Platform.AlphaFormat.Unpremul);
+            // Allocate the 1x1 backing bitmap ONCE per Image control and
+            // reuse it on subsequent UpdateUI calls (Copilot bot inline
+            // review #9 on PR #586 - avoids per-slot WriteableBitmap
+            // churn across 16 swatches x N redraws).
+            WriteableBitmap bmp;
+            if (image.Source is WriteableBitmap existing
+                && existing.PixelSize.Width == 1
+                && existing.PixelSize.Height == 1)
+            {
+                bmp = existing;
+            }
+            else
+            {
+                bmp = new WriteableBitmap(
+                    new global::Avalonia.PixelSize(1, 1),
+                    new global::Avalonia.Vector(96, 96),
+                    global::Avalonia.Platform.PixelFormat.Bgra8888,
+                    global::Avalonia.Platform.AlphaFormat.Unpremul);
+                image.Source = bmp;
+                image.Stretch = Stretch.Fill;
+            }
             using (var fb = bmp.Lock())
             {
                 unsafe
@@ -157,8 +179,10 @@ namespace FEBuilderGBA.Avalonia.Views
                     p[0] = b; p[1] = g; p[2] = r; p[3] = 0xFF; // BGRA
                 }
             }
-            image.Source = bmp;
-            image.Stretch = Stretch.Fill;
+            // Force Avalonia to re-render the Image even though Source is
+            // the same instance (WriteableBitmap mutation does not raise
+            // the property-changed event by itself).
+            image.InvalidateVisual();
         }
 
         // ---- event handlers ----
@@ -200,7 +224,10 @@ namespace FEBuilderGBA.Avalonia.Views
             int reloadMax = _vm.MaxPaletteCount;
             int reloadIdx = _vm.PaletteIndex;
 
-            _undoService.Begin("Edit Palette");
+            // Undo name + user-facing messages routed through R._() so
+            // they pick up ja/zh translations (Copilot bot inline
+            // review #10 on PR #586).
+            _undoService.Begin(R._("Edit Palette"));
             try
             {
                 ReadNudsIntoVm();
@@ -223,13 +250,13 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 UpdateUI();
 
-                CoreState.Services?.ShowInfo("Palette written.");
+                CoreState.Services?.ShowInfo(R._("Palette written."));
             }
             catch (Exception ex)
             {
                 _undoService.Rollback();
                 Log.Error("ImagePalletView.Write_Click failed: {0}", ex.Message);
-                CoreState.Services?.ShowError($"Write failed: {ex.Message}");
+                CoreState.Services?.ShowError(R._("Write failed: {0}", ex.Message));
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml.cs
@@ -23,6 +23,12 @@ namespace FEBuilderGBA.Avalonia.Views
         readonly ImagePalletViewModel _vm = new();
         readonly UndoService _undoService = new();
 
+        // Cache the original paletteNames passed via JumpTo so the
+        // Palette Index combo labels survive a Write+reload or Undo
+        // round-trip (Copilot bot round-3 inline reviews #2 + #3 on
+        // PR #586).
+        string[]? _lastPaletteNames;
+
         public string ViewTitle => "Palette Editor";
         public bool IsLoaded => _vm.IsLoaded;
 
@@ -31,6 +37,36 @@ namespace FEBuilderGBA.Avalonia.Views
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
             Opened += (_, _) => LoadList();
+            // Wire all 48 R/G/B NumericUpDowns so an edit refreshes
+            // the swatches immediately (Copilot bot round-3 inline
+            // review #1 on PR #586).
+            WireNudChangeHandlers();
+        }
+
+        void WireNudChangeHandlers()
+        {
+            var nuds = new[]
+            {
+                R1Box, G1Box, B1Box, R2Box, G2Box, B2Box,
+                R3Box, G3Box, B3Box, R4Box, G4Box, B4Box,
+                R5Box, G5Box, B5Box, R6Box, G6Box, B6Box,
+                R7Box, G7Box, B7Box, R8Box, G8Box, B8Box,
+                R9Box, G9Box, B9Box, R10Box, G10Box, B10Box,
+                R11Box, G11Box, B11Box, R12Box, G12Box, B12Box,
+                R13Box, G13Box, B13Box, R14Box, G14Box, B14Box,
+                R15Box, G15Box, B15Box, R16Box, G16Box, B16Box,
+            };
+            foreach (var n in nuds) n.ValueChanged += Nud_ValueChanged;
+        }
+
+        void Nud_ValueChanged(object? sender, global::Avalonia.Controls.NumericUpDownValueChangedEventArgs e)
+        {
+            // Re-render the 16 swatches from current NUD values so the
+            // user-edit -> swatch reflection is live (Copilot bot
+            // round-3 inline review #1 on PR #586). The VM is NOT
+            // touched here - VM sync happens at Write time via
+            // ReadNudsIntoVm().
+            RefreshSwatchesFromNuds();
         }
 
         // ---- entry / list loading ----
@@ -66,6 +102,11 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                // Cache the names so subsequent reload paths (Write,
+                // Undo) keep the override labels - passing null to
+                // LoadEntry would drop them (Copilot bot round-3
+                // inline reviews #2 + #3 on PR #586).
+                _lastPaletteNames = paletteNames;
                 _vm.LoadEntry(paletteAddress, maxPaletteCount, defaultSelectPalette, paletteNames);
                 UpdateUI();
             }
@@ -146,6 +187,41 @@ namespace FEBuilderGBA.Avalonia.Views
             SetSwatch(P14Swatch, _vm.R14, _vm.G14, _vm.B14);
             SetSwatch(P15Swatch, _vm.R15, _vm.G15, _vm.B15);
             SetSwatch(P16Swatch, _vm.R16, _vm.G16, _vm.B16);
+        }
+
+        /// <summary>
+        /// Refresh swatches from the CURRENT NumericUpDown values rather
+        /// than the VM state. Used by Nud_ValueChanged so a user edit
+        /// updates the swatch immediately, before any Write/reload
+        /// pushes the value into the VM (Copilot bot round-3 inline
+        /// review #1 on PR #586).
+        /// </summary>
+        void RefreshSwatchesFromNuds()
+        {
+            SetSwatch(P1Swatch,  NudByte(R1Box),  NudByte(G1Box),  NudByte(B1Box));
+            SetSwatch(P2Swatch,  NudByte(R2Box),  NudByte(G2Box),  NudByte(B2Box));
+            SetSwatch(P3Swatch,  NudByte(R3Box),  NudByte(G3Box),  NudByte(B3Box));
+            SetSwatch(P4Swatch,  NudByte(R4Box),  NudByte(G4Box),  NudByte(B4Box));
+            SetSwatch(P5Swatch,  NudByte(R5Box),  NudByte(G5Box),  NudByte(B5Box));
+            SetSwatch(P6Swatch,  NudByte(R6Box),  NudByte(G6Box),  NudByte(B6Box));
+            SetSwatch(P7Swatch,  NudByte(R7Box),  NudByte(G7Box),  NudByte(B7Box));
+            SetSwatch(P8Swatch,  NudByte(R8Box),  NudByte(G8Box),  NudByte(B8Box));
+            SetSwatch(P9Swatch,  NudByte(R9Box),  NudByte(G9Box),  NudByte(B9Box));
+            SetSwatch(P10Swatch, NudByte(R10Box), NudByte(G10Box), NudByte(B10Box));
+            SetSwatch(P11Swatch, NudByte(R11Box), NudByte(G11Box), NudByte(B11Box));
+            SetSwatch(P12Swatch, NudByte(R12Box), NudByte(G12Box), NudByte(B12Box));
+            SetSwatch(P13Swatch, NudByte(R13Box), NudByte(G13Box), NudByte(B13Box));
+            SetSwatch(P14Swatch, NudByte(R14Box), NudByte(G14Box), NudByte(B14Box));
+            SetSwatch(P15Swatch, NudByte(R15Box), NudByte(G15Box), NudByte(B15Box));
+            SetSwatch(P16Swatch, NudByte(R16Box), NudByte(G16Box), NudByte(B16Box));
+        }
+
+        static byte NudByte(NumericUpDown nud)
+        {
+            decimal v = nud.Value ?? 0m;
+            if (v < 0) v = 0;
+            if (v > 255) v = 255;
+            return (byte)v;
         }
 
         static void SetSwatch(Image image, byte r, byte g, byte b)
@@ -254,11 +330,13 @@ namespace FEBuilderGBA.Avalonia.Views
 
                 // Reload so the swatch images reflect the post-write
                 // 5-bit-quantized values (mirrors the
-                // ImageMagicCSACreator pattern).
+                // ImageMagicCSACreator pattern). Preserve the
+                // palette-name overrides across reload (Copilot bot
+                // round-3 inline review #2 on PR #586).
                 _vm.IsLoading = true;
                 try
                 {
-                    _vm.LoadEntry(reloadAddr, reloadMax, reloadIdx, null);
+                    _vm.LoadEntry(reloadAddr, reloadMax, reloadIdx, _lastPaletteNames);
                 }
                 finally
                 {
@@ -308,6 +386,8 @@ namespace FEBuilderGBA.Avalonia.Views
                 CoreState.Undo?.RunUndo();
                 // Reload so the displayed values reflect the post-undo
                 // ROM state (Copilot CLI plan review #5 - Undo enabled).
+                // Preserve the palette-name overrides across reload
+                // (Copilot bot round-3 inline review #3 on PR #586).
                 if (_vm.IsLoaded)
                 {
                     uint addr = _vm.PaletteAddress;
@@ -316,7 +396,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     _vm.IsLoading = true;
                     try
                     {
-                        _vm.LoadEntry(addr, max, idx, null);
+                        _vm.LoadEntry(addr, max, idx, _lastPaletteNames);
                     }
                     finally
                     {

--- a/FEBuilderGBA.Avalonia/Views/ImagePortraitView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImagePortraitView.axaml.cs
@@ -826,7 +826,15 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void JumpToPalette_Click(object? sender, RoutedEventArgs e)
         {
-            try { WindowManager.Instance.Open<ImagePalletView>(); }
+            try
+            {
+                // Wire the portrait's palette address into the rebuilt
+                // ImagePalletView (#400 - Copilot CLI plan review #2).
+                // Portraits use a single palette block, so
+                // maxPaletteCount=1 hides the palette-index combo.
+                var window = WindowManager.Instance.Open<ImagePalletView>();
+                window.JumpTo(_vm.PalettePtr, maxPaletteCount: 1, defaultSelectPalette: 0, paletteNames: null);
+            }
             catch (Exception ex) { Log.Error("JumpToPalette failed: {0}", ex.Message); }
         }
 

--- a/FEBuilderGBA.Core.Tests/PaletteCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/PaletteCoreTests.cs
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for PaletteCore (#400) - cross-platform palette read/write helpers
+// for the Avalonia ImagePalletView (and any future WinForms reuse).
+//
+// Verifies:
+//   * Pointer (0x08xxxxxx) and raw-offset (0x00xxxxxx) both work via
+//     U.toOffset normalization (Copilot CLI plan review #1).
+//   * Bit-math delegates to PaletteFormatConverter (no parallel copy)
+//     (Copilot CLI plan review #3).
+//   * Palette-index offset arithmetic (paletteIndex * 32).
+//   * Overflow guards (zero tuples when data too small).
+using System;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    public class PaletteCoreTests
+    {
+        // --- helpers ---
+
+        static byte[] Make1MBuffer() => new byte[0x1_000_000];
+
+        static byte[] PaletteBytesFromColors(params ushort[] colors)
+        {
+            byte[] buf = new byte[colors.Length * 2];
+            for (int i = 0; i < colors.Length; i++)
+            {
+                buf[i * 2] = (byte)(colors[i] & 0xFF);
+                buf[i * 2 + 1] = (byte)(colors[i] >> 8);
+            }
+            return buf;
+        }
+
+        // --- constants ---
+
+        [Fact]
+        public void Constants_PaletteBlockSize_Is32()
+        {
+            Assert.Equal(32, PaletteCore.PALETTE_BLOCK_SIZE);
+        }
+
+        [Fact]
+        public void Constants_MaxPaletteCount_Is16()
+        {
+            Assert.Equal(16, PaletteCore.MAX_PALETTE_COUNT);
+        }
+
+        // --- ReadPalette ---
+
+        [Fact]
+        public void ReadPalette_RawOffset_ReadsCorrectBytes()
+        {
+            byte[] data = Make1MBuffer();
+            // Plant 16 BGR15 colors at offset 0x100000.
+            // Black, White, Red, Green, Blue, then 11 zero entries.
+            ushort[] colors = new ushort[16];
+            colors[0] = 0x0000;
+            colors[1] = 0x7FFF;
+            colors[2] = 0x001F;
+            colors[3] = 0x03E0;
+            colors[4] = 0x7C00;
+            byte[] palBytes = PaletteBytesFromColors(colors);
+            Buffer.BlockCopy(palBytes, 0, data, 0x100000, palBytes.Length);
+
+            var rgb = PaletteCore.ReadPalette(data, 0x100000u, 0);
+
+            Assert.Equal(16, rgb.Length);
+            Assert.Equal((0, 0, 0), rgb[0]);                  // Black
+            Assert.Equal((248, 248, 248), rgb[1]);            // White (5-bit max -> 248)
+            Assert.Equal((248, 0, 0), rgb[2]);                // Red
+            Assert.Equal((0, 248, 0), rgb[3]);                // Green
+            Assert.Equal((0, 0, 248), rgb[4]);                // Blue
+        }
+
+        [Fact]
+        public void ReadPalette_GbaPointer_NormalizedViaToOffset_ReadsSameBytes()
+        {
+            byte[] data = Make1MBuffer();
+            // Plant a marker color at offset 0x100000.
+            ushort[] colors = new ushort[16];
+            colors[0] = 0x7FFF;
+            byte[] palBytes = PaletteBytesFromColors(colors);
+            Buffer.BlockCopy(palBytes, 0, data, 0x100000, palBytes.Length);
+
+            // Passing GBA pointer (0x08100000) must hit the same offset.
+            var rgbPtr = PaletteCore.ReadPalette(data, 0x08100000u, 0);
+            // Passing raw offset (0x100000) - control case.
+            var rgbOff = PaletteCore.ReadPalette(data, 0x00100000u, 0);
+
+            Assert.Equal(rgbOff[0], rgbPtr[0]);
+            Assert.Equal((248, 248, 248), rgbPtr[0]);
+        }
+
+        [Fact]
+        public void ReadPalette_NonZeroIndex_ReadsFromIndexTimes32Offset()
+        {
+            byte[] data = Make1MBuffer();
+            // Index 0: 16 black colors at offset 0x100000.
+            // Index 1: starts at offset 0x100020. Plant white in slot 0 there.
+            ushort[] idx1 = new ushort[16];
+            idx1[0] = 0x7FFF;
+            byte[] idx1Bytes = PaletteBytesFromColors(idx1);
+            Buffer.BlockCopy(idx1Bytes, 0, data, 0x100020, idx1Bytes.Length);
+
+            var rgb0 = PaletteCore.ReadPalette(data, 0x100000u, 0);
+            var rgb1 = PaletteCore.ReadPalette(data, 0x100000u, 1);
+
+            Assert.Equal((0, 0, 0), rgb0[0]);            // black (default zeros)
+            Assert.Equal((248, 248, 248), rgb1[0]);      // white from index-1 slot
+        }
+
+        [Fact]
+        public void ReadPalette_PastEnd_ReturnsZeros()
+        {
+            byte[] data = new byte[16]; // too small for a full palette.
+            var rgb = PaletteCore.ReadPalette(data, 0u, 0);
+            Assert.Equal(16, rgb.Length);
+            foreach (var c in rgb)
+                Assert.Equal((0, 0, 0), c);
+        }
+
+        [Fact]
+        public void ReadPalette_NegativeIndex_ClampsToZero()
+        {
+            byte[] data = Make1MBuffer();
+            ushort[] colors = new ushort[16];
+            colors[0] = 0x7FFF;
+            byte[] palBytes = PaletteBytesFromColors(colors);
+            Buffer.BlockCopy(palBytes, 0, data, 0x100000, palBytes.Length);
+
+            var rgb = PaletteCore.ReadPalette(data, 0x100000u, -5);
+
+            Assert.Equal((248, 248, 248), rgb[0]); // read from index 0 (clamped).
+        }
+
+        // --- PackToBytes ---
+
+        [Fact]
+        public void PackToBytes_ProducesThirtyTwoBytes()
+        {
+            var colors = new (byte, byte, byte)[16];
+            byte[] bytes = PaletteCore.PackToBytes(colors);
+            Assert.Equal(32, bytes.Length);
+        }
+
+        [Fact]
+        public void PackToBytes_Black_AllZero()
+        {
+            var colors = new (byte, byte, byte)[16];
+            for (int i = 0; i < 16; i++)
+                colors[i] = (0, 0, 0);
+            byte[] bytes = PaletteCore.PackToBytes(colors);
+            foreach (byte b in bytes)
+                Assert.Equal(0, b);
+        }
+
+        [Fact]
+        public void PackToBytes_RedOnly_ProducesBGR15Red_0x001F()
+        {
+            var colors = new (byte, byte, byte)[16];
+            colors[0] = (0xF8, 0, 0); // 5-bit aligned red
+            byte[] bytes = PaletteCore.PackToBytes(colors);
+            ushort packed = (ushort)(bytes[0] | (bytes[1] << 8));
+            Assert.Equal(0x001F, packed);
+        }
+
+        [Fact]
+        public void PackToBytes_GreenOnly_ProducesBGR15Green_0x03E0()
+        {
+            var colors = new (byte, byte, byte)[16];
+            colors[0] = (0, 0xF8, 0);
+            byte[] bytes = PaletteCore.PackToBytes(colors);
+            ushort packed = (ushort)(bytes[0] | (bytes[1] << 8));
+            Assert.Equal(0x03E0, packed);
+        }
+
+        [Fact]
+        public void PackToBytes_BlueOnly_ProducesBGR15Blue_0x7C00()
+        {
+            var colors = new (byte, byte, byte)[16];
+            colors[0] = (0, 0, 0xF8);
+            byte[] bytes = PaletteCore.PackToBytes(colors);
+            ushort packed = (ushort)(bytes[0] | (bytes[1] << 8));
+            Assert.Equal(0x7C00, packed);
+        }
+
+        [Fact]
+        public void PackToBytes_White_ProducesBGR15White_0x7FFF()
+        {
+            var colors = new (byte, byte, byte)[16];
+            colors[0] = (0xF8, 0xF8, 0xF8);
+            byte[] bytes = PaletteCore.PackToBytes(colors);
+            ushort packed = (ushort)(bytes[0] | (bytes[1] << 8));
+            Assert.Equal(0x7FFF, packed);
+        }
+
+        // --- WritePalette ---
+
+        [Fact]
+        public void WritePalette_RawOffset_WritesCorrectBytes()
+        {
+            var rom = new ROM();
+            rom.LoadLow("synth.gba", Make1MBuffer(), "AE7E01"); // FE7U test ROM tag.
+
+            var colors = new (byte, byte, byte)[16];
+            colors[0] = (0xF8, 0, 0);
+            colors[1] = (0, 0xF8, 0);
+            colors[2] = (0, 0, 0xF8);
+
+            PaletteCore.WritePalette(rom, 0x100000u, 0, colors);
+
+            // Read back via ReadPalette to confirm round-trip.
+            var rgb = PaletteCore.ReadPalette(rom.Data, 0x100000u, 0);
+            Assert.Equal((248, 0, 0), rgb[0]);
+            Assert.Equal((0, 248, 0), rgb[1]);
+            Assert.Equal((0, 0, 248), rgb[2]);
+        }
+
+        [Fact]
+        public void WritePalette_GbaPointer_NormalizedViaToOffset_WritesSameBytes()
+        {
+            var rom = new ROM();
+            rom.LoadLow("synth.gba", Make1MBuffer(), "AE7E01");
+
+            var colors = new (byte, byte, byte)[16];
+            colors[0] = (0xF8, 0xF8, 0xF8);
+
+            // Write via GBA pointer.
+            PaletteCore.WritePalette(rom, 0x08100000u, 0, colors);
+
+            // The raw bytes at offset 0x100000 must reflect white (0x7FFF).
+            ushort packed = (ushort)(rom.Data[0x100000] | (rom.Data[0x100001] << 8));
+            Assert.Equal(0x7FFF, packed);
+        }
+
+        [Fact]
+        public void WritePalette_NonZeroIndex_LeavesIndex0Untouched()
+        {
+            var rom = new ROM();
+            rom.LoadLow("synth.gba", Make1MBuffer(), "AE7E01");
+
+            // Plant a marker at index 0 (offset 0x100000).
+            ushort[] marker = new ushort[16];
+            marker[0] = 0x1234; // distinctive
+            byte[] markerBytes = PaletteBytesFromColors(marker);
+            Buffer.BlockCopy(markerBytes, 0, rom.Data, 0x100000, markerBytes.Length);
+
+            // Write at index 1 (offset 0x100020).
+            var colors = new (byte, byte, byte)[16];
+            colors[0] = (0xF8, 0xF8, 0xF8);
+            PaletteCore.WritePalette(rom, 0x100000u, 1, colors);
+
+            // Index 0 bytes must remain 0x1234.
+            ushort idx0Word = (ushort)(rom.Data[0x100000] | (rom.Data[0x100001] << 8));
+            Assert.Equal(0x1234, idx0Word);
+            // Index 1 must reflect the write.
+            ushort idx1Word = (ushort)(rom.Data[0x100020] | (rom.Data[0x100021] << 8));
+            Assert.Equal(0x7FFF, idx1Word);
+        }
+
+        // --- delegation to PaletteFormatConverter ---
+
+        [Fact]
+        public void PackToBytes_BitPack_Matches_PaletteFormatConverter_ImportFromGbaRaw_Reverse()
+        {
+            // Build a 16-color palette via PaletteCore.PackToBytes.
+            var colors = new (byte, byte, byte)[16];
+            for (int i = 0; i < 16; i++)
+                colors[i] = ((byte)((i * 8) & 0xF8), (byte)((i * 16) & 0xF8), (byte)((i * 24) & 0xF8));
+            byte[] packedByCore = PaletteCore.PackToBytes(colors);
+
+            // The reverse path via PaletteFormatConverter must produce identical RGB
+            // tuples (proving Core delegates to the shared bit-math helpers).
+            byte[] reExported = PaletteFormatConverter.ExportToFormat(packedByCore, PaletteFormat.GbaRaw);
+            // GbaRaw export is a clone of the input - same length, same bytes.
+            Assert.Equal(packedByCore.Length, reExported.Length);
+            for (int i = 0; i < packedByCore.Length; i++)
+                Assert.Equal(packedByCore[i], reExported[i]);
+        }
+
+        // --- 5-bit lossy quantization documentation ---
+
+        [Fact]
+        public void Pack_LosesBottom3Bits_OfInputByte()
+        {
+            // Input 0xFF (255) should pack as if it were 0xF8 (248) — bottom 3 bits dropped.
+            var colors = new (byte, byte, byte)[16];
+            colors[0] = (0xFF, 0xFF, 0xFF);
+            byte[] bytes = PaletteCore.PackToBytes(colors);
+            ushort packed = (ushort)(bytes[0] | (bytes[1] << 8));
+            Assert.Equal(0x7FFF, packed); // same as if input had been (0xF8, 0xF8, 0xF8).
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/PaletteCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/PaletteCoreTests.cs
@@ -18,7 +18,7 @@ namespace FEBuilderGBA.Core.Tests
     {
         // --- helpers ---
 
-        static byte[] Make1MBuffer() => new byte[0x1_000_000];
+        static byte[] Make16MBuffer() => new byte[0x1_000_000];
 
         static byte[] PaletteBytesFromColors(params ushort[] colors)
         {
@@ -50,7 +50,7 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void ReadPalette_RawOffset_ReadsCorrectBytes()
         {
-            byte[] data = Make1MBuffer();
+            byte[] data = Make16MBuffer();
             // Plant 16 BGR15 colors at offset 0x100000.
             // Black, White, Red, Green, Blue, then 11 zero entries.
             ushort[] colors = new ushort[16];
@@ -75,7 +75,7 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void ReadPalette_GbaPointer_NormalizedViaToOffset_ReadsSameBytes()
         {
-            byte[] data = Make1MBuffer();
+            byte[] data = Make16MBuffer();
             // Plant a marker color at offset 0x100000.
             ushort[] colors = new ushort[16];
             colors[0] = 0x7FFF;
@@ -94,7 +94,7 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void ReadPalette_NonZeroIndex_ReadsFromIndexTimes32Offset()
         {
-            byte[] data = Make1MBuffer();
+            byte[] data = Make16MBuffer();
             // Index 0: 16 black colors at offset 0x100000.
             // Index 1: starts at offset 0x100020. Plant white in slot 0 there.
             ushort[] idx1 = new ushort[16];
@@ -113,16 +113,68 @@ namespace FEBuilderGBA.Core.Tests
         public void ReadPalette_PastEnd_ReturnsZeros()
         {
             byte[] data = new byte[16]; // too small for a full palette.
-            var rgb = PaletteCore.ReadPalette(data, 0u, 0);
+            // Use a non-zero but past-end address so the sentinel guards
+            // (0 / U.NOT_FOUND - Copilot bot inline review #2) don't
+            // short-circuit before the out-of-bounds check runs.
+            var rgb = PaletteCore.ReadPalette(data, 0x100u, 0);
             Assert.Equal(16, rgb.Length);
             foreach (var c in rgb)
                 Assert.Equal((0, 0, 0), c);
         }
 
+        // Regression: U.NOT_FOUND (0xFFFFFFFF) and uint.MaxValue must NOT
+        // crash ReadPalette/WritePalette via 32-bit wraparound. The
+        // bounds check uses ulong math (Copilot CLI round-1 review on
+        // PR #586).
+        [Theory]
+        [InlineData(uint.MaxValue)]
+        [InlineData(0xFFFFFFFFu)]            // alias for U.NOT_FOUND
+        [InlineData(0xFFFFFFE0u)]            // near MaxValue, edge case
+        public void ReadPalette_InvalidAddress_ReturnsZerosWithoutCrash(uint addr)
+        {
+            byte[] data = Make16MBuffer();
+            var rgb = PaletteCore.ReadPalette(data, addr, 0);
+            Assert.Equal(16, rgb.Length);
+            foreach (var c in rgb)
+                Assert.Equal((0, 0, 0), c);
+        }
+
+        [Theory]
+        [InlineData(uint.MaxValue)]
+        [InlineData(0xFFFFFFFFu)]
+        [InlineData(0xFFFFFFE0u)]
+        public void WritePalette_InvalidAddress_NoOpWithoutCrash(uint addr)
+        {
+            var rom = new ROM();
+            rom.LoadLow("synth.gba", Make16MBuffer(), "AE7E01");
+            // Capture a baseline byte at offset 0 so we can assert no
+            // accidental write happens.
+            rom.Data[0] = 0xAB;
+            var colors = new (byte, byte, byte)[16];
+            colors[0] = (0xF8, 0, 0);
+
+            PaletteCore.WritePalette(rom, addr, 0, colors);
+
+            Assert.Equal(0xAB, rom.Data[0]);
+        }
+
+        [Fact]
+        public void ReadPalette_BareZeroAddress_ReturnsZerosWithoutReading()
+        {
+            byte[] data = Make16MBuffer();
+            // Plant non-zero bytes at offset 0 so we can prove the
+            // sentinel guard short-circuited (without it, the read
+            // would unpack those bytes as BGR15).
+            data[0] = 0xFF;
+            data[1] = 0x7F;
+            var rgb = PaletteCore.ReadPalette(data, 0u, 0);
+            Assert.Equal((0, 0, 0), rgb[0]);
+        }
+
         [Fact]
         public void ReadPalette_NegativeIndex_ClampsToZero()
         {
-            byte[] data = Make1MBuffer();
+            byte[] data = Make16MBuffer();
             ushort[] colors = new ushort[16];
             colors[0] = 0x7FFF;
             byte[] palBytes = PaletteBytesFromColors(colors);
@@ -200,7 +252,7 @@ namespace FEBuilderGBA.Core.Tests
         public void WritePalette_RawOffset_WritesCorrectBytes()
         {
             var rom = new ROM();
-            rom.LoadLow("synth.gba", Make1MBuffer(), "AE7E01"); // FE7U test ROM tag.
+            rom.LoadLow("synth.gba", Make16MBuffer(), "AE7E01"); // FE7U test ROM tag.
 
             var colors = new (byte, byte, byte)[16];
             colors[0] = (0xF8, 0, 0);
@@ -220,7 +272,7 @@ namespace FEBuilderGBA.Core.Tests
         public void WritePalette_GbaPointer_NormalizedViaToOffset_WritesSameBytes()
         {
             var rom = new ROM();
-            rom.LoadLow("synth.gba", Make1MBuffer(), "AE7E01");
+            rom.LoadLow("synth.gba", Make16MBuffer(), "AE7E01");
 
             var colors = new (byte, byte, byte)[16];
             colors[0] = (0xF8, 0xF8, 0xF8);
@@ -237,7 +289,7 @@ namespace FEBuilderGBA.Core.Tests
         public void WritePalette_NonZeroIndex_LeavesIndex0Untouched()
         {
             var rom = new ROM();
-            rom.LoadLow("synth.gba", Make1MBuffer(), "AE7E01");
+            rom.LoadLow("synth.gba", Make16MBuffer(), "AE7E01");
 
             // Plant a marker at index 0 (offset 0x100000).
             ushort[] marker = new ushort[16];
@@ -261,21 +313,31 @@ namespace FEBuilderGBA.Core.Tests
         // --- delegation to PaletteFormatConverter ---
 
         [Fact]
-        public void PackToBytes_BitPack_Matches_PaletteFormatConverter_ImportFromGbaRaw_Reverse()
+        public void PackToBytes_BitPack_RoundTripsVia_PaletteFormatConverter_JascPal()
         {
-            // Build a 16-color palette via PaletteCore.PackToBytes.
+            // Build a 16-color palette via PaletteCore.PackToBytes, then
+            // round-trip through PaletteFormatConverter via the JascPal
+            // export+import path (which DOES exercise the bit-math
+            // helpers, unlike GbaRaw which is a clone). If
+            // PaletteCore.PackToBytes were to use different bit math
+            // than PaletteFormatConverter, the round-trip would
+            // diverge and this test would fail (Copilot bot inline
+            // review #5 on PR #586).
             var colors = new (byte, byte, byte)[16];
             for (int i = 0; i < 16; i++)
                 colors[i] = ((byte)((i * 8) & 0xF8), (byte)((i * 16) & 0xF8), (byte)((i * 24) & 0xF8));
             byte[] packedByCore = PaletteCore.PackToBytes(colors);
 
-            // The reverse path via PaletteFormatConverter must produce identical RGB
-            // tuples (proving Core delegates to the shared bit-math helpers).
-            byte[] reExported = PaletteFormatConverter.ExportToFormat(packedByCore, PaletteFormat.GbaRaw);
-            // GbaRaw export is a clone of the input - same length, same bytes.
-            Assert.Equal(packedByCore.Length, reExported.Length);
+            // Round-trip: GbaRaw -> JascPal -> GbaRaw. The intermediate
+            // JascPal export reads the GBA bytes via PaletteFormatConverter
+            // .GbaToRgb (the same helper PaletteCore uses), and the import
+            // re-packs via .RgbToGba. Result must be identical bytes.
+            byte[] jasc = PaletteFormatConverter.ExportToFormat(packedByCore, PaletteFormat.JascPal);
+            byte[] roundTripped = PaletteFormatConverter.ImportFromFormat(jasc, PaletteFormat.JascPal);
+
+            Assert.Equal(packedByCore.Length, roundTripped.Length);
             for (int i = 0; i < packedByCore.Length; i++)
-                Assert.Equal(packedByCore[i], reExported[i]);
+                Assert.Equal(packedByCore[i], roundTripped[i]);
         }
 
         // --- 5-bit lossy quantization documentation ---

--- a/FEBuilderGBA.Core/PaletteCore.cs
+++ b/FEBuilderGBA.Core/PaletteCore.cs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Cross-platform palette helpers for FEBuilderGBA. Extracted from the
+// WinForms PaletteFormRef so the Avalonia ImagePalletView can share the
+// ROM read/write + palette-index offset arithmetic without a WinForms
+// dependency. See issue #400.
+//
+// Design notes (from the accepted plan + Copilot CLI plan review):
+//
+//   * GBA palette format is BGR15: 16-bit little-endian with 5-bit
+//     R/G/B channels packed as R | G<<5 | B<<10. One 16-color palette
+//     is 32 bytes (16 colors x 2 bytes).
+//
+//   * Multiple palette tables can live contiguously in ROM: palette
+//     N starts at addr + N * 32. The original WF MakePaletteROMToUI
+//     uses the same arithmetic. PaletteCore.ReadPalette/WritePalette
+//     take a paletteIndex argument that adds N*32 to the base address.
+//
+//   * Address inputs are GBA pointers (high bit 0x08xxxxxx may be set).
+//     PaletteCore normalizes every address via U.toOffset(addr) before
+//     touching ROM bytes, so callers can pass either form (this was
+//     Copilot CLI plan-review finding #1).
+//
+//   * BGR15 bit-pack/unpack delegates to PaletteFormatConverter's
+//     internal helpers (Copilot CLI plan-review finding #3). PaletteCore
+//     does NOT carry a parallel copy of the bit-shift math; the
+//     converter is the single source of truth.
+//
+//   * The 5-bit channel format is lossy: input R=0xFF round-trips to
+//     R=0xF8 (loses bottom 3 bits). The Avalonia view enforces this
+//     via NumericUpDown.Increment=8.
+
+using System;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Cross-platform helpers for reading and writing 16-color GBA
+    /// palettes (BGR15) to/from raw ROM data. See file-level comment
+    /// for the bit-format spec and design notes.
+    /// </summary>
+    public static class PaletteCore
+    {
+        /// <summary>One 16-color palette is 32 bytes (16 colors x 2 bytes BGR15).</summary>
+        public const int PALETTE_BLOCK_SIZE = 32;
+
+        /// <summary>The maximum number of palettes WF expects in one editor session.</summary>
+        public const int MAX_PALETTE_COUNT = 16;
+
+        /// <summary>
+        /// Read a 16-color palette from <paramref name="data"/> at
+        /// <paramref name="paletteAddress"/> (GBA pointer or raw offset)
+        /// and the <paramref name="paletteIndex"/>-th palette block
+        /// (paletteIndex * 32 byte offset).
+        ///
+        /// Returns a 16-tuple array of (R, G, B) byte triples. On
+        /// overflow (data too small) or unreachable offset, returns
+        /// 16 black entries.
+        /// </summary>
+        public static (byte r, byte g, byte b)[] ReadPalette(byte[] data, uint paletteAddress, int paletteIndex)
+        {
+            var result = new (byte, byte, byte)[16];
+            if (data == null) return result;
+            if (paletteIndex < 0) paletteIndex = 0;
+
+            uint offset = U.toOffset(paletteAddress);
+            uint start = offset + (uint)(paletteIndex * PALETTE_BLOCK_SIZE);
+            // Guard against overflow / out-of-bounds reads.
+            if (start + PALETTE_BLOCK_SIZE > (uint)data.Length)
+                return result;
+
+            for (int i = 0; i < 16; i++)
+            {
+                uint cur = start + (uint)(i * 2);
+                ushort gba = (ushort)(data[cur] | (data[cur + 1] << 8));
+                PaletteFormatConverter.GbaToRgb(gba, out byte r, out byte g, out byte b);
+                result[i] = (r, g, b);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Pack 16 (R, G, B) tuples into a 32-byte BGR15 blob. Lossy
+        /// quantization: each 8-bit channel is reduced to 5-bit (loses
+        /// bottom 3 bits). The packer uses
+        /// <see cref="PaletteFormatConverter"/>'s shared bit-math so any
+        /// future converter improvement automatically applies here.
+        /// </summary>
+        public static byte[] PackToBytes((byte r, byte g, byte b)[] colors)
+        {
+            byte[] bytes = new byte[PALETTE_BLOCK_SIZE];
+            if (colors == null) return bytes;
+            int count = Math.Min(colors.Length, 16);
+            for (int i = 0; i < count; i++)
+            {
+                ushort gba = PaletteFormatConverter.RgbToGba(colors[i].r, colors[i].g, colors[i].b);
+                bytes[i * 2] = (byte)(gba & 0xFF);
+                bytes[i * 2 + 1] = (byte)(gba >> 8);
+            }
+            return bytes;
+        }
+
+        /// <summary>
+        /// Write 16 (R, G, B) tuples to <paramref name="rom"/> at
+        /// <paramref name="paletteAddress"/> (GBA pointer or raw offset)
+        /// + <paramref name="paletteIndex"/> * 32. No-op when
+        /// <paramref name="rom"/> is null or the destination would
+        /// overflow ROM data. The write is undo-tracked when the ROM
+        /// has an ambient undo scope active (see ROM.BeginUndoScope).
+        /// </summary>
+        public static void WritePalette(ROM rom, uint paletteAddress, int paletteIndex, (byte r, byte g, byte b)[] colors)
+        {
+            if (rom == null) return;
+            if (paletteIndex < 0) paletteIndex = 0;
+
+            uint offset = U.toOffset(paletteAddress);
+            uint start = offset + (uint)(paletteIndex * PALETTE_BLOCK_SIZE);
+            if (start + PALETTE_BLOCK_SIZE > (uint)rom.Data.Length)
+                return;
+
+            byte[] bytes = PackToBytes(colors);
+            rom.write_range(start, bytes);
+        }
+    }
+}

--- a/FEBuilderGBA.Core/PaletteCore.cs
+++ b/FEBuilderGBA.Core/PaletteCore.cs
@@ -53,24 +53,32 @@ namespace FEBuilderGBA
         /// (paletteIndex * 32 byte offset).
         ///
         /// Returns a 16-tuple array of (R, G, B) byte triples. On
-        /// overflow (data too small) or unreachable offset, returns
-        /// 16 black entries.
+        /// overflow (data too small), invalid address, or unreachable
+        /// offset, returns 16 black entries.
         /// </summary>
         public static (byte r, byte g, byte b)[] ReadPalette(byte[] data, uint paletteAddress, int paletteIndex)
         {
             var result = new (byte, byte, byte)[16];
             if (data == null) return result;
             if (paletteIndex < 0) paletteIndex = 0;
+            // Reject sentinel "no address" values - both bare 0 and the
+            // U.NOT_FOUND marker the rest of Core uses for "search failed"
+            // (Copilot bot inline review #2 on PR #586).
+            if (paletteAddress == 0 || paletteAddress == U.NOT_FOUND) return result;
 
             uint offset = U.toOffset(paletteAddress);
-            uint start = offset + (uint)(paletteIndex * PALETTE_BLOCK_SIZE);
-            // Guard against overflow / out-of-bounds reads.
-            if (start + PALETTE_BLOCK_SIZE > (uint)data.Length)
-                return result;
+            // Range check uses ulong arithmetic so the addition cannot
+            // wrap around even if paletteAddress is near uint.MaxValue
+            // (Copilot bot inline review #2 on PR #586).
+            ulong start = (ulong)offset + (ulong)paletteIndex * PALETTE_BLOCK_SIZE;
+            if (start + PALETTE_BLOCK_SIZE > (ulong)data.Length) return result;
 
+            int startInt = (int)start;
             for (int i = 0; i < 16; i++)
             {
-                uint cur = start + (uint)(i * 2);
+                int cur = startInt + i * 2;
+                // byte[] indexers require int, not uint - convert after
+                // bounds check (Copilot bot inline review #1 on PR #586).
                 ushort gba = (ushort)(data[cur] | (data[cur + 1] << 8));
                 PaletteFormatConverter.GbaToRgb(gba, out byte r, out byte g, out byte b);
                 result[i] = (r, g, b);
@@ -102,23 +110,32 @@ namespace FEBuilderGBA
         /// <summary>
         /// Write 16 (R, G, B) tuples to <paramref name="rom"/> at
         /// <paramref name="paletteAddress"/> (GBA pointer or raw offset)
-        /// + <paramref name="paletteIndex"/> * 32. No-op when
-        /// <paramref name="rom"/> is null or the destination would
-        /// overflow ROM data. The write is undo-tracked when the ROM
-        /// has an ambient undo scope active (see ROM.BeginUndoScope).
+        /// + <paramref name="paletteIndex"/> * 32. Returns true on
+        /// success, false when the write was a no-op (null ROM, invalid
+        /// address, or destination would overflow ROM data). The
+        /// write is undo-tracked when the ROM has an ambient undo
+        /// scope active (see ROM.BeginUndoScope).
+        ///
+        /// Callers MUST check the return value to know whether the
+        /// write landed - reporting a successful offset to the user
+        /// when WritePalette no-op'd would be a lie (Copilot CLI
+        /// round-1 review on PR #586).
         /// </summary>
-        public static void WritePalette(ROM rom, uint paletteAddress, int paletteIndex, (byte r, byte g, byte b)[] colors)
+        public static bool WritePalette(ROM rom, uint paletteAddress, int paletteIndex, (byte r, byte g, byte b)[] colors)
         {
-            if (rom == null) return;
+            if (rom == null) return false;
             if (paletteIndex < 0) paletteIndex = 0;
+            // Same sentinel guards + ulong range math as ReadPalette
+            // (Copilot bot inline review #3 on PR #586).
+            if (paletteAddress == 0 || paletteAddress == U.NOT_FOUND) return false;
 
             uint offset = U.toOffset(paletteAddress);
-            uint start = offset + (uint)(paletteIndex * PALETTE_BLOCK_SIZE);
-            if (start + PALETTE_BLOCK_SIZE > (uint)rom.Data.Length)
-                return;
+            ulong start = (ulong)offset + (ulong)paletteIndex * PALETTE_BLOCK_SIZE;
+            if (start + PALETTE_BLOCK_SIZE > (ulong)rom.Data.Length) return false;
 
             byte[] bytes = PackToBytes(colors);
-            rom.write_range(start, bytes);
+            rom.write_range((uint)start, bytes);
+            return true;
         }
     }
 }

--- a/FEBuilderGBA.Core/PaletteFormatConverter.cs
+++ b/FEBuilderGBA.Core/PaletteFormatConverter.cs
@@ -165,15 +165,23 @@ namespace FEBuilderGBA
         }
 
         // ===================== GBA ↔ RGB bit-shift math =====================
+        //
+        // These helpers are the SINGLE SOURCE OF TRUTH for BGR15 (a.k.a.
+        // BGR555) bit-pack/unpack across the codebase. They are `internal`
+        // so PaletteCore (and any future Core consumer) can call them
+        // directly without exposing a separate API to library callers
+        // outside FEBuilderGBA.Core. Plan review #3 on issue #400 flagged
+        // the risk of drift if PaletteCore copied this math; the fix is
+        // to share these instead of duplicating.
 
-        static void GbaToRgb(ushort gba, out byte r, out byte g, out byte b)
+        internal static void GbaToRgb(ushort gba, out byte r, out byte g, out byte b)
         {
             r = (byte)((gba & 0x1F) << 3);
             g = (byte)(((gba >> 5) & 0x1F) << 3);
             b = (byte)(((gba >> 10) & 0x1F) << 3);
         }
 
-        static ushort RgbToGba(byte r, byte g, byte b)
+        internal static ushort RgbToGba(byte r, byte g, byte b)
         {
             return (ushort)(
                 ((r >> 3) & 0x1F) |

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -4507,7 +4507,10 @@ Data 読込数:
 Battle Animation パレット
 
 :Palette Editor
-パレット Editor
+パレットエディタ
+
+:Palette No {0}
+パレット No{0}
 
 :Write Notification
 書き込み Notification
@@ -7973,3 +7976,12 @@ Core RunRedo API待ち - #500で追跡中。
 
 :Edit R/G/B 0-248 (5-bit ticks)
 R/G/Bを0-248で編集（5ビット刻み）
+
+:Edit Palette
+パレットを編集
+
+:Palette written.
+パレットを書き込みました。
+
+:Write failed: {0}
+書き込みに失敗しました: {0}

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -7985,3 +7985,6 @@ R/G/Bを0-248で編集（5ビット刻み）
 
 :Write failed: {0}
 書き込みに失敗しました: {0}
+
+:Invalid palette address
+無効なパレットアドレス

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -7952,3 +7952,24 @@ REDO
 
 :Battle Animation
 戦闘アニメ
+
+:Fit to window
+ウィンドウサイズで表示
+
+:Write Palette
+パレット書き込み
+
+:Redo
+やり直し
+
+:Pending Core RunRedo API - tracked by #500.
+Core RunRedo API待ち - #500で追跡中。
+
+:Palette Index
+パレット種類
+
+:Live bitmap preview pending Core extraction - tracked by #500.
+ライブビットマッププレビュー実装待ち - #500で追跡中。
+
+:Edit R/G/B 0-248 (5-bit ticks)
+R/G/Bを0-248で編集（5ビット刻み）

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -21805,3 +21805,18 @@ ED 关系
 
 :Edit R/G/B 0-248 (5-bit ticks)
 编辑 R/G/B 0-248 （5位刻度）
+
+:Palette Editor
+调色板编辑器
+
+:Palette No {0}
+调色板 No{0}
+
+:Edit Palette
+编辑调色板
+
+:Palette written.
+调色板已写入。
+
+:Write failed: {0}
+写入失败：{0}

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -21784,3 +21784,24 @@ ED 关系
 
 :Comment
 注释
+
+:Fit to window
+适应窗口
+
+:Write Palette
+写入调色板
+
+:Redo
+重做
+
+:Pending Core RunRedo API - tracked by #500.
+等待 Core RunRedo API - 由 #500 跟踪。
+
+:Palette Index
+调色板索引
+
+:Live bitmap preview pending Core extraction - tracked by #500.
+实时位图预览待 Core 提取 - 由 #500 跟踪。
+
+:Edit R/G/B 0-248 (5-bit ticks)
+编辑 R/G/B 0-248 （5位刻度）

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -21820,3 +21820,6 @@ ED 关系
 
 :Write failed: {0}
 写入失败：{0}
+
+:Invalid palette address
+无效的调色板地址

--- a/docs/avalonia-gaps/2026-05-24-density-sweep.md
+++ b/docs/avalonia-gaps/2026-05-24-density-sweep.md
@@ -1,6 +1,6 @@
 ---
-generated: "2026-05-24T06:43:46Z"
-git-sha: 9302e0016
+generated: "2026-05-24T08:41:55Z"
+git-sha: 4677149fb
 sweep-type: density
 ---
 
@@ -20,9 +20,9 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-density --out=<path>`.
 
 | Verdict | Threshold | Count |
 |---|---|---|
-| HIGH | |Δ%| ≥ 50 | 211 |
+| HIGH | |Δ%| ≥ 50 | 210 |
 | MEDIUM | 25 ≤ |Δ%| < 50 | 85 |
-| LOW | |Δ%| < 25 | 74 |
+| LOW | |Δ%| < 25 | 75 |
 
 ## Ranked Density Deltas
 
@@ -44,7 +44,6 @@ Both represent pairing artifacts rather than real migration gaps.
 | High | `WorldMapImageForm` | `WorldMapImageView` | 107 | 3 | -104 | -97.2% | Heuristic |
 | High | `ImageTSAEditorForm` | `ImageTSAEditorView` | 100 | 3 | -97 | -97.0% | Heuristic |
 | High | `ImageBattleAnimePalletForm` | `ImageBattleAnimePalletView` | 99 | 3 | -96 | -97.0% | Heuristic |
-| High | `ImagePalletForm` | `ImagePalletView` | 98 | 3 | -95 | -96.9% | Heuristic |
 | High | `ClassFE6Form` | `ClassFE6View` | 173 | 8 | -165 | -95.4% | Heuristic |
 | High | `EventBattleTalkFE7Form` | `EventBattleTalkFE7View` | 62 | 3 | -59 | -95.2% | ListParityHelper |
 | High | `EventBattleTalkFE6Form` | `EventBattleTalkFE6View` | 61 | 3 | -58 | -95.1% | ListParityHelper |
@@ -258,6 +257,7 @@ Both represent pairing artifacts rather than real migration gaps.
 | Low | `DumpStructSelectDialogForm` | `DumpStructSelectDialogView` | 19 | 20 | 1 | +5.3% | Heuristic |
 | Low | `ItemShopForm` | `ItemShopViewerView` | 17 | 18 | 1 | +5.9% | ListParityHelper |
 | Low | `ImageUnitPaletteForm` | `ImageUnitPaletteView` | 133 | 141 | 8 | +6.0% | ListParityHelper |
+| Low | `ImagePalletForm` | `ImagePalletView` | 98 | 104 | 6 | +6.1% | Heuristic |
 | Low | `MapTerrainBGLookupTableForm` | `MapTerrainBGLookupTableView` | 16 | 17 | 1 | +6.3% | ListParityHelper |
 | Low | `MapTerrainFloorLookupTableForm` | `MapTerrainFloorLookupTableView` | 16 | 17 | 1 | +6.3% | ListParityHelper |
 | Low | `ImageMapActionAnimationForm` | `ImageMapActionAnimationView` | 29 | 31 | 2 | +6.9% | ListParityHelper |
@@ -416,14 +416,6 @@ WF count: **99** · AV count: **3** · Δ: **-96** (-97.0%).
   grep -E '(Text|Content|Header)=' FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml
 -->
 
-### ImagePalletForm
-WF count: **98** · AV count: **3** · Δ: **-95** (-96.9%).
-
-<!-- Triage: list specific missing fields here. Suggested probe:
-  grep -E '\.Text\s*=' FEBuilderGBA/ImagePalletForm.Designer.cs
-  grep -E '(Text|Content|Header)=' FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml
--->
-
 ### ClassFE6Form
 WF count: **173** · AV count: **8** · Δ: **-165** (-95.4%).
 
@@ -526,6 +518,14 @@ WF count: **414** · AV count: **41** · Δ: **-373** (-90.1%).
 <!-- Triage: list specific missing fields here. Suggested probe:
   grep -E '\.Text\s*=' FEBuilderGBA/EventCondForm.Designer.cs
   grep -E '(Text|Content|Header)=' FEBuilderGBA.Avalonia/Views/EventCondView.axaml
+-->
+
+### EventBattleTalkForm
+WF count: **30** · AV count: **3** · Δ: **-27** (-90.0%).
+
+<!-- Triage: list specific missing fields here. Suggested probe:
+  grep -E '\.Text\s*=' FEBuilderGBA/EventBattleTalkForm.Designer.cs
+  grep -E '(Text|Content|Header)=' FEBuilderGBA.Avalonia/Views/EventBattleTalkView.axaml
 -->
 
 ## Unpaired Orphans

--- a/docs/avalonia-gaps/2026-05-24-jumps-sweep.md
+++ b/docs/avalonia-gaps/2026-05-24-jumps-sweep.md
@@ -1,6 +1,6 @@
 ---
-generated: "2026-05-24T02:20:10Z"
-git-sha: 4552097a3
+generated: "2026-05-24T08:41:59Z"
+git-sha: 4677149fb
 sweep-type: jumps
 ---
 
@@ -36,10 +36,10 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-jumps --out=<path>`.
 
 | Metric | Count |
 |---|---:|
-| Total rows | 431 |
-| Match | 60 |
-| MissingAvManifest (backlog) | 328 |
-| NoWfCallsite | 35 |
+| Total rows | 435 |
+| Match | 62 |
+| MissingAvManifest (backlog) | 326 |
+| NoWfCallsite | 39 |
 | KnownGap (issue-tagged) | 8 |
 
 ## Known Gaps (tracked by open issues)
@@ -254,8 +254,6 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-jumps --out=<path>`.
 | `ImageRomAnimeForm` | `ImageRomAnimeView` | `—` | `GraphicsToolForm` | `GraphicsToolView` |
 | `ImageTSAAnimeForm` | `ImageTSAAnimeView` | `—` | `DecreaseColorTSAToolForm` | `DecreaseColorTSAToolView` |
 | `ImageTSAAnimeForm` | `ImageTSAAnimeView` | `—` | `GraphicsToolForm` | `GraphicsToolView` |
-| `ItemFE6Form` | `ItemFE6View` | `—` | `ItemWeaponEffectForm` | `ItemWeaponEffectViewerView` |
-| `ItemFE6Form` | `ItemFE6View` | `—` | `PatchForm` | `PatchManagerView` |
 | `ImageItemIconForm` | `ItemIconViewerView` | `—` | `ImageSystemIconForm` | `—` |
 | `ImageItemIconForm` | `ItemIconViewerView` | `—` | `ErrorPaletteShowForm` | `ErrorPaletteShowView` |
 | `ItemPromotionForm` | `ItemPromotionViewerView` | `—` | `PatchForm` | `PatchManagerView` |
@@ -412,7 +410,11 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-jumps --out=<path>`.
 | `ItemForm` | `ItemEditorView` | `JumpToDescText` | `TextForm` | `TextViewerView` |
 | `ItemForm` | `ItemEditorView` | `JumpToNameText` | `TextForm` | `TextViewerView` |
 | `ItemForm` | `ItemEditorView` | `JumpToUseDescText` | `TextForm` | `TextViewerView` |
+| `—` | `ItemFE6View` | `JumpToEffectiveness` | `ItemEffectivenessForm` | `ItemEffectivenessViewerView` |
+| `—` | `ItemFE6View` | `JumpToStatBonuses` | `ItemStatBonusesForm` | `ItemStatBonusesViewerView` |
 | `—` | `ItemFE6View` | `JumpToDescText` | `TextForm` | `TextViewerView` |
+| `—` | `ItemFE6View` | `JumpToNameText` | `TextForm` | `TextViewerView` |
+| `—` | `ItemFE6View` | `JumpToUseDescText` | `TextForm` | `TextViewerView` |
 | `SupportTalkForm` | `SupportTalkView` | `JumpToTextA` | `TextForm` | `TextViewerView` |
 | `SupportTalkForm` | `SupportTalkView` | `JumpToTextB` | `TextForm` | `TextViewerView` |
 | `SupportTalkForm` | `SupportTalkView` | `JumpToTextC` | `TextForm` | `TextViewerView` |
@@ -462,6 +464,8 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-jumps --out=<path>`.
 | `ItemForm` | `ItemEditorView` | `JumpToHardcoding` | `PatchForm` | `PatchManagerView` |
 | `ItemForm` | `ItemEditorView` | `JumpToWeaponDebuffs` | `PatchForm` | `PatchManagerView` |
 | `ItemForm` | `ItemEditorView` | `JumpToWeaponDebuffs` | `PatchForm` | `PatchManagerView` |
+| `ItemFE6Form` | `ItemFE6View` | `JumpToWeaponEffect` | `ItemWeaponEffectForm` | `ItemWeaponEffectViewerView` |
+| `ItemFE6Form` | `ItemFE6View` | `JumpToHardcoding` | `PatchForm` | `PatchManagerView` |
 | `ItemUsagePointerForm` | `ItemUsagePointerViewerView` | `JumpToPromotion` | `ItemPromotionForm` | `ItemPromotionViewerView` |
 | `ItemUsagePointerForm` | `ItemUsagePointerViewerView` | `JumpToStatBonuses` | `ItemStatBonusesForm` | `ItemStatBonusesViewerView` |
 | `ItemUsagePointerForm` | `ItemUsagePointerViewerView` | `JumpToIerPatch` | `PatchForm` | `PatchManagerView` |

--- a/docs/avalonia-gaps/2026-05-24-l10n-sweep.md
+++ b/docs/avalonia-gaps/2026-05-24-l10n-sweep.md
@@ -1,6 +1,6 @@
 ---
-generated: "2026-05-24T02:20:15Z"
-git-sha: 4552097a3
+generated: "2026-05-24T08:42:04Z"
+git-sha: 4677149fb
 sweep-type: l10n
 languages: ja,zh,ko
 ---
@@ -49,11 +49,11 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-l10n --out=<path>`.
 
 | Verdict | Count | % of total |
 |---|---:|---:|
-| Untranslated | 14 | 0.4 |
-| PartiallyTranslated | 3884 | 99.6 |
+| Untranslated | 14 | 0.3 |
+| PartiallyTranslated | 4024 | 99.7 |
 | Translated | 0 | 0.0 |
 | NonEnglish | 0 | 0.0 |
-| **Total** | 3898 | 100.0 |
+| **Total** | 4038 | 100.0 |
 
 ## Per-language Coverage
 
@@ -61,9 +61,9 @@ Coverage is computed over the English-source literals only (excludes the `NonEng
 
 | Language | Translated | English-source total | % |
 |---|---:|---:|---:|
-| `ja` | 3884 | 3898 | 99.6 |
-| `zh` | 3884 | 3898 | 99.6 |
-| `ko` | 0 | 3898 | 0.0 |
+| `ja` | 4024 | 4038 | 99.7 |
+| `zh` | 4024 | 4038 | 99.7 |
+| `ko` | 0 | 4038 | 0.0 |
 
 ## Top 20 Files by Untranslated Literal Count
 
@@ -995,6 +995,83 @@ show which languages cover the literal.
 | 244 | `B147: ??` | ✓ | ✓ | ✗ |
 | 251 | `Write` | ✓ | ✓ | ✗ |
 
+### `FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 15 | `Filter:` | ✓ | ✓ | ✗ |
+| 17 | `Reload` | ✓ | ✓ | ✗ |
+| 20 | `Base Addr:` | ✓ | ✓ | ✗ |
+| 24 | `Count:` | ✓ | ✓ | ✗ |
+| 26 | `Size:` | ✓ | ✓ | ✗ |
+| 46 | `Item Editor (FE6)` | ✓ | ✓ | ✗ |
+| 51 | `Address:` | ✓ | ✓ | ✗ |
+| 67 | `This item is referenced by hardcoded ASM. Click to open the Patch Manager filtered on HARDCODING_ITEM=.` | ✓ | ✓ | ✗ |
+| 71 | `Basic Info` | ✓ | ✓ | ✗ |
+| 74 | `Name ID (W0):` | ✓ | ✓ | ✗ |
+| 77 | `Text ID for this item's display name (click to open Text Viewer)` | ✓ | ✓ | ✗ |
+| 79 | `Name:` | ✓ | ✓ | ✗ |
+| 82 | `Desc ID (W2):` | ✓ | ✓ | ✗ |
+| 85 | `Text ID for the item description (click to open Text Viewer)` | ✓ | ✓ | ✗ |
+| 90 | `Decoded description text` | ✓ | ✓ | ✗ |
+| 91 | `Desc` | ✓ | ✓ | ✗ |
+| 92 | `Open text viewer for this description` | ✓ | ✓ | ✗ |
+| 94 | `Use Desc (W4):` | ✓ | ✓ | ✗ |
+| 97 | `Text ID for the item usage description (click to open Text Viewer)` | ✓ | ✓ | ✗ |
+| 102 | `Decoded usage description text` | ✓ | ✓ | ✗ |
+| 103 | `Desc` | ✓ | ✓ | ✗ |
+| 104 | `Open text viewer for this usage description` | ✓ | ✓ | ✗ |
+| 107 | `Item # (B6):` | ✓ | ✓ | ✗ |
+| 108 | `Internal item number (unique ID)` | ✓ | ✓ | ✗ |
+| 110 | `Type (B7):` | ✓ | ✓ | ✗ |
+| 111 | `Weapon type (Sword, Lance, Axe, etc.)` | ✓ | ✓ | ✗ |
+| 114 | `Address:` | ✓ | ✓ | ✗ |
+| 121 | `Stats / Bonuses` | ✓ | ✓ | ✗ |
+| 124 | `Stat Bonus (P12):` | ✓ | ✓ | ✗ |
+| 125 | `Pointer to stat bonuses when equipped` | ✓ | ✓ | ✗ |
+| 128 | `Jump` | ✓ | ✓ | ✗ |
+| 130 | `Effective (P16):` | ✓ | ✓ | ✗ |
+| 131 | `Pointer to effectiveness list (bonus vs. classes)` | ✓ | ✓ | ✗ |
+| 134 | `Jump` | ✓ | ✓ | ✗ |
+| 137 | `Uses (B20):` | ✓ | ✓ | ✗ |
+| 138 | `Number of uses before the item breaks` | ✓ | ✓ | ✗ |
+| 140 | `Might (B21):` | ✓ | ✓ | ✗ |
+| 141 | `Attack power` | ✓ | ✓ | ✗ |
+| 144 | `Hit (B22):` | ✓ | ✓ | ✗ |
+| 145 | `Hit rate bonus` | ✓ | ✓ | ✗ |
+| 147 | `Weight (B23):` | ✓ | ✓ | ✗ |
+| 148 | `Item weight (reduces attack speed)` | ✓ | ✓ | ✗ |
+| 151 | `Crit (B24):` | ✓ | ✓ | ✗ |
+| 152 | `Critical hit rate bonus` | ✓ | ✓ | ✗ |
+| 154 | `Range (B25):` | ✓ | ✓ | ✗ |
+| 155 | `Attack range (encoded as min-max)` | ✓ | ✓ | ✗ |
+| 158 | `Price (W26):` | ✓ | ✓ | ✗ |
+| 159 | `Base item price` | ✓ | ✓ | ✗ |
+| 161 | `Rank (B28):` | ✓ | ✓ | ✗ |
+| 164 | `Buy Price:` | ✓ | ✓ | ✗ |
+| 166 | `Sell Price:` | ✓ | ✓ | ✗ |
+| 179 | `Shingeki Shop:` | ✓ | ✓ | ✗ |
+| 184 | `Weapon Properties` | ✓ | ✓ | ✗ |
+| 187 | `Icon (B29):` | ✓ | ✓ | ✗ |
+| 189 | `Use Effect (B30):` | ✓ | ✓ | ✗ |
+| 190 | `Effect when using the item` | ✓ | ✓ | ✗ |
+| 193 | `Dmg Effect (B31):` | ✓ | ✓ | ✗ |
+| 194 | `Special effect applied on hit` | ✓ | ✓ | ✗ |
+| 202 | `Indirect Weapon Effect` | ✓ | ✓ | ✗ |
+| 205 | `Open the indirect weapon effect table at the row for this item.` | ✓ | ✓ | ✗ |
+| 223 | `Warning: Stat Bonuses pointer is null (P12=0). Consider allocating.` | ✓ | ✓ | ✗ |
+| 224 | `Warning: Effectiveness pointer is null (P16=0). Consider allocating.` | ✓ | ✓ | ✗ |
+| 231 | `Stat Bonuses Preview` | ✓ | ✓ | ✗ |
+| 233 | `Decoded stat bonus values (read-only — edit through the Stat Bonus pointer above):` | ✓ | ✓ | ✗ |
+| 252 | `Effective Against` | ✓ | ✓ | ✗ |
+| 266 | `Trait Flags` | ✓ | ✓ | ✗ |
+| 270 | `Trait 1 (B8):` | ✓ | ✓ | ✗ |
+| 280 | `Trait 2 (B9):` | ✓ | ✓ | ✗ |
+| 290 | `Trait 3 (B10):` | ✓ | ✓ | ✗ |
+| 300 | `Trait 4 (B11):` | ✓ | ✓ | ✗ |
+| 318 | `Warnings` | ✓ | ✓ | ✗ |
+| 330 | `Write` | ✓ | ✓ | ✗ |
+
 ### `FEBuilderGBA.Avalonia/Views/UnitFE7View.axaml`
 
 | Line | Literal | ja | zh | ko |
@@ -1067,6 +1144,64 @@ show which languages cover the literal.
 | 290 | `Sim LCK:` | ✓ | ✓ | ✗ |
 | 294 | `Magic Ext:` | ✓ | ✓ | ✗ |
 | 299 | `Write` | ✓ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 12 | `Unit Palette Editor` | ✓ | ✓ | ✗ |
+| 17 | `Address` | ✓ | ✓ | ✗ |
+| 22 | `Selected Address:` | ✓ | ✓ | ✗ |
+| 26 | `Write` | ✓ | ✓ | ✗ |
+| 31 | `Edit` | ✓ | ✓ | ✗ |
+| 36 | `Identifier:` | ✓ | ✓ | ✗ |
+| 44 | `Id 0:` | ✓ | ✓ | ✗ |
+| 47 | `Id 1:` | ✓ | ✓ | ✗ |
+| 51 | `Id 2:` | ✓ | ✓ | ✗ |
+| 54 | `Id 3:` | ✓ | ✓ | ✗ |
+| 58 | `Id 4:` | ✓ | ✓ | ✗ |
+| 61 | `Id 5:` | ✓ | ✓ | ✗ |
+| 65 | `Id 6:` | ✓ | ✓ | ✗ |
+| 68 | `Id 7:` | ✓ | ✓ | ✗ |
+| 72 | `Id 8:` | ✓ | ✓ | ✗ |
+| 75 | `Id 9:` | ✓ | ✓ | ✗ |
+| 79 | `Id 10:` | ✓ | ✓ | ✗ |
+| 82 | `Id 11:` | ✓ | ✓ | ✗ |
+| 88 | `Comment:` | ✓ | ✓ | ✗ |
+| 90 | `Comment` | ✓ | ✓ | ✗ |
+| 94 | `Pointer (P12):` | ✓ | ✓ | ✗ |
+| 99 | `New Palette Allocation` | ✓ | ✓ | ✗ |
+| 100 | `KnownGap` | ✓ | ✓ | ✗ |
+| 103 | `Write` | ✓ | ✓ | ✗ |
+| 109 | `Class and Animation` | ✓ | ✓ | ✗ |
+| 118 | `Battle Animation:` | ✓ | ✓ | ✗ |
+| 122 | `KnownGap` | ✓ | ✓ | ✗ |
+| 135 | `Palette` | ✓ | ✓ | ✗ |
+| 138 | `Palette Address:` | ✓ | ✓ | ✗ |
+| 144 | `Palette Type:` | ✓ | ✓ | ✗ |
+| 155 | `Override all palette slots` | ✓ | ✓ | ✗ |
+| 156 | `KnownGap` | ✓ | ✓ | ✗ |
+| 161 | `Zoom:` | ✓ | ✓ | ✗ |
+| 164 | `KnownGap` | ✓ | ✓ | ✗ |
+| 322 | `Palette Write` | ✓ | ✓ | ✗ |
+| 324 | `Clipboard` | ✓ | ✓ | ✗ |
+| 325 | `KnownGap` | ✓ | ✓ | ✗ |
+| 327 | `Export Image` | ✓ | ✓ | ✗ |
+| 328 | `KnownGap` | ✓ | ✓ | ✗ |
+| 330 | `Import Image` | ✓ | ✓ | ✗ |
+| 331 | `KnownGap` | ✓ | ✓ | ✗ |
+| 333 | `UNDO` | ✓ | ✓ | ✗ |
+| 334 | `KnownGap` | ✓ | ✓ | ✗ |
+| 336 | `REDO` | ✓ | ✓ | ✗ |
+| 337 | `KnownGap` | ✓ | ✓ | ✗ |
+| 343 | `Search Tools` | ✓ | ✓ | ✗ |
+| 346 | `Filter` | ✓ | ✓ | ✗ |
+| 350 | `Start Address` | ✓ | ✓ | ✗ |
+| 355 | `Read Count` | ✓ | ✓ | ✗ |
+| 360 | `Size:` | ✓ | ✓ | ✗ |
+| 367 | `Reload List` | ✓ | ✓ | ✗ |
+| 369 | `Expand List` | ✓ | ✓ | ✗ |
+| 370 | `KnownGap` | ✓ | ✓ | ✗ |
 
 ### `FEBuilderGBA.Avalonia/Views/SupportUnitFE6View.axaml`
 
@@ -1282,6 +1417,58 @@ show which languages cover the literal.
 | 275 | `Sim LCK:` | ✓ | ✓ | ✗ |
 | 282 | `Write` | ✓ | ✓ | ✗ |
 | 283 | `Undo` | ✓ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/EDFE7View.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 22 | `Lyn Arc` | ✓ | ✓ | ✗ |
+| 28 | `Top Address` | ✓ | ✓ | ✗ |
+| 33 | `Read Count` | ✓ | ✓ | ✗ |
+| 39 | `Reload` | ✓ | ✓ | ✗ |
+| 47 | `Address` | ✓ | ✓ | ✗ |
+| 52 | `Size:` | ✓ | ✓ | ✗ |
+| 57 | `Selected Address:` | ✓ | ✓ | ✗ |
+| 63 | `Write` | ✓ | ✓ | ✗ |
+| 97 | `Cleared After` | ✓ | ✓ | ✗ |
+| 117 | `Retreat After` | ✓ | ✓ | ✗ |
+| 146 | `Retreat` | ✓ | ✓ | ✗ |
+| 151 | `Top Address` | ✓ | ✓ | ✗ |
+| 156 | `Read Count` | ✓ | ✓ | ✗ |
+| 162 | `Reload` | ✓ | ✓ | ✗ |
+| 169 | `Address` | ✓ | ✓ | ✗ |
+| 174 | `Size:` | ✓ | ✓ | ✗ |
+| 179 | `Selected Address:` | ✓ | ✓ | ✗ |
+| 185 | `Write` | ✓ | ✓ | ✗ |
+| 195 | `List Expand` | ✓ | ✓ | ✗ |
+| 217 | `Retreat Spec 02` | ✓ | ✓ | ✗ |
+| 225 | `Unknown (0x02):` | ✓ | ✓ | ✗ |
+| 232 | `Unknown (0x03):` | ✓ | ✓ | ✗ |
+| 254 | `Epithet` | ✓ | ✓ | ✗ |
+| 259 | `Top Address` | ✓ | ✓ | ✗ |
+| 264 | `Read Count` | ✓ | ✓ | ✗ |
+| 270 | `Reload` | ✓ | ✓ | ✗ |
+| 277 | `Address` | ✓ | ✓ | ✗ |
+| 282 | `Size:` | ✓ | ✓ | ✗ |
+| 287 | `Selected Address:` | ✓ | ✓ | ✗ |
+| 293 | `Write` | ✓ | ✓ | ✗ |
+| 303 | `List Expand` | ✓ | ✓ | ✗ |
+| 330 | `Epithet Text` | ✓ | ✓ | ✗ |
+| 353 | `Epilogue` | ✓ | ✓ | ✗ |
+| 360 | `Filter:` | ✓ | ✓ | ✗ |
+| 364 | `Eliwood Route` | ✓ | ✓ | ✗ |
+| 365 | `Hector Route` | ✓ | ✓ | ✗ |
+| 367 | `Top Address` | ✓ | ✓ | ✗ |
+| 372 | `Read Count` | ✓ | ✓ | ✗ |
+| 378 | `Reload` | ✓ | ✓ | ✗ |
+| 385 | `Address` | ✓ | ✓ | ✗ |
+| 390 | `Size:` | ✓ | ✓ | ✗ |
+| 395 | `Selected Address:` | ✓ | ✓ | ✗ |
+| 401 | `Write` | ✓ | ✓ | ✗ |
+| 411 | `List Expand` | ✓ | ✓ | ✗ |
+| 420 | `Designation` | ✓ | ✓ | ✗ |
+| 450 | `Story Flag` | ✓ | ✓ | ✗ |
+| 457 | `Epilogue Text` | ✓ | ✓ | ✗ |
 
 ### `FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml`
 
@@ -2100,41 +2287,6 @@ show which languages cover the literal.
 | 266 | `Import Font` | ✓ | ✓ | ✗ |
 | 269 | `Pending Core extraction - tracked by #536` | ✓ | ✓ | ✗ |
 
-### `FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml`
-
-| Line | Literal | ja | zh | ko |
-|---:|---|:---:|:---:|:---:|
-| 26 | `Item Editor (FE6)` | ✓ | ✓ | ✗ |
-| 30 | `Address:` | ✓ | ✓ | ✗ |
-| 32 | `Name:` | ✓ | ✓ | ✗ |
-| 36 | `Name ID (W0):` | ✓ | ✓ | ✗ |
-| 38 | `Desc ID (W2):` | ✓ | ✓ | ✗ |
-| 39 | `Text ID for the item's description` | ✓ | ✓ | ✗ |
-| 44 | `Decoded description text` | ✓ | ✓ | ✗ |
-| 45 | `Desc` | ✓ | ✓ | ✗ |
-| 46 | `Open text viewer for this description` | ✓ | ✓ | ✗ |
-| 50 | `Use Desc (W4):` | ✓ | ✓ | ✗ |
-| 52 | `Item # (B6):` | ✓ | ✓ | ✗ |
-| 56 | `Type (B7):` | ✓ | ✓ | ✗ |
-| 58 | `Trait 1 (B8):` | ✓ | ✓ | ✗ |
-| 62 | `Trait 2 (B9):` | ✓ | ✓ | ✗ |
-| 64 | `Trait 3 (B10):` | ✓ | ✓ | ✗ |
-| 68 | `Trait 4 (B11):` | ✓ | ✓ | ✗ |
-| 70 | `Stat Bonus (P12):` | ✓ | ✓ | ✗ |
-| 74 | `Effective (P16):` | ✓ | ✓ | ✗ |
-| 78 | `Uses (B20):` | ✓ | ✓ | ✗ |
-| 80 | `Might (B21):` | ✓ | ✓ | ✗ |
-| 84 | `Hit (B22):` | ✓ | ✓ | ✗ |
-| 86 | `Weight (B23):` | ✓ | ✓ | ✗ |
-| 90 | `Crit (B24):` | ✓ | ✓ | ✗ |
-| 92 | `Range (B25):` | ✓ | ✓ | ✗ |
-| 96 | `Price (W26):` | ✓ | ✓ | ✗ |
-| 98 | `Rank (B28):` | ✓ | ✓ | ✗ |
-| 102 | `Icon (B29):` | ✓ | ✓ | ✗ |
-| 104 | `Use Effect (B30):` | ✓ | ✓ | ✗ |
-| 108 | `Dmg Effect (B31):` | ✓ | ✓ | ✗ |
-| 113 | `Write` | ✓ | ✓ | ✗ |
-
 ### `FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml`
 
 | Line | Literal | ja | zh | ko |
@@ -2689,6 +2841,30 @@ show which languages cover the literal.
 | 107 | `Zoom:` | ✓ | ✓ | ✗ |
 | 117 | `Frame:` | ✓ | ✓ | ✗ |
 
+### `FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 21 | `Palette Editor` | ✓ | ✓ | ✗ |
+| 28 | `Palette Address:` | ✓ | ✓ | ✗ |
+| 34 | `Zoom` | ✓ | ✓ | ✗ |
+| 38 | `Fit to window` | ✓ | ✓ | ✗ |
+| 39 | `Original size` | ✓ | ✓ | ✗ |
+| 45 | `Write Palette` | ✓ | ✓ | ✗ |
+| 47 | `Undo` | ✓ | ✓ | ✗ |
+| 49 | `Redo` | ✓ | ✓ | ✗ |
+| 51 | `Pending Core RunRedo API - tracked by #500.` | ✓ | ✓ | ✗ |
+| 60 | `Palette Index` | ✓ | ✓ | ✗ |
+| 274 | `Import Image` | ✓ | ✓ | ✗ |
+| 276 | `Pending Core extraction - tracked by #500.` | ✓ | ✓ | ✗ |
+| 279 | `Export Image` | ✓ | ✓ | ✗ |
+| 281 | `Pending Core extraction - tracked by #500.` | ✓ | ✓ | ✗ |
+| 284 | `Clipboard` | ✓ | ✓ | ✗ |
+| 286 | `Pending Core extraction - tracked by #500.` | ✓ | ✓ | ✗ |
+| 297 | `Preview` | ✓ | ✓ | ✗ |
+| 301 | `Live bitmap preview pending Core extraction - tracked by #500.` | ✓ | ✓ | ✗ |
+| 314 | `Edit R/G/B 0-248 (5-bit ticks)` | ✓ | ✓ | ✗ |
+
 ### `FEBuilderGBA.Avalonia/Views/ItemStatBonusesSkillSystemsView.axaml`
 
 | Line | Literal | ja | zh | ko |
@@ -2781,28 +2957,6 @@ show which languages cover the literal.
 | 54 | `Condition Item 3:` | ✓ | ✓ | ✗ |
 | 57 | `Condition Item 4:` | ✓ | ✓ | ✗ |
 | 61 | `Write` | ✓ | ✓ | ✗ |
-
-### `FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml`
-
-| Line | Literal | ja | zh | ko |
-|---:|---|:---:|:---:|:---:|
-| 12 | `Unit Palette Editor` | ✓ | ✓ | ✗ |
-| 16 | `Address:` | ✓ | ✓ | ✗ |
-| 20 | `Identifier:` | ✓ | ✓ | ✗ |
-| 24 | `Id 0:` | ✓ | ✓ | ✗ |
-| 26 | `Id 1:` | ✓ | ✓ | ✗ |
-| 29 | `Id 2:` | ✓ | ✓ | ✗ |
-| 31 | `Id 3:` | ✓ | ✓ | ✗ |
-| 34 | `Id 4:` | ✓ | ✓ | ✗ |
-| 36 | `Id 5:` | ✓ | ✓ | ✗ |
-| 39 | `Id 6:` | ✓ | ✓ | ✗ |
-| 41 | `Id 7:` | ✓ | ✓ | ✗ |
-| 44 | `Id 8:` | ✓ | ✓ | ✗ |
-| 46 | `Id 9:` | ✓ | ✓ | ✗ |
-| 49 | `Id 10:` | ✓ | ✓ | ✗ |
-| 51 | `Id 11:` | ✓ | ✓ | ✗ |
-| 55 | `Palette Ptr (P12):` | ✓ | ✓ | ✗ |
-| 59 | `Write` | ✓ | ✓ | ✗ |
 
 ### `FEBuilderGBA.Avalonia/Views/ItemStatBonusesVennoView.axaml`
 
@@ -4970,13 +5124,6 @@ show which languages cover the literal.
 | 12 | `ED (FE6)` | ✓ | ✓ | ✗ |
 | 15 | `Address:` | ✓ | ✓ | ✗ |
 
-### `FEBuilderGBA.Avalonia/Views/EDFE7View.axaml`
-
-| Line | Literal | ja | zh | ko |
-|---:|---|:---:|:---:|:---:|
-| 12 | `ED (FE7)` | ✓ | ✓ | ✗ |
-| 15 | `Address:` | ✓ | ✓ | ✗ |
-
 ### `FEBuilderGBA.Avalonia/Views/ErrorLongMessageDialogView.axaml`
 
 | Line | Literal | ja | zh | ko |
@@ -5262,13 +5409,6 @@ show which languages cover the literal.
 | Line | Literal | ja | zh | ko |
 |---:|---|:---:|:---:|:---:|
 | 12 | `Image Form Reference` | ✓ | ✓ | ✗ |
-| 15 | `Address:` | ✓ | ✓ | ✗ |
-
-### `FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml`
-
-| Line | Literal | ja | zh | ko |
-|---:|---|:---:|:---:|:---:|
-| 12 | `Palette Editor` | ✓ | ✓ | ✗ |
 | 15 | `Address:` | ✓ | ✓ | ✗ |
 
 ### `FEBuilderGBA.Avalonia/Views/ImagePortraitImporterView.axaml`

--- a/docs/avalonia-gaps/2026-05-24-labels-sweep.md
+++ b/docs/avalonia-gaps/2026-05-24-labels-sweep.md
@@ -1,6 +1,6 @@
 ---
-generated: "2026-05-24T06:45:43Z"
-git-sha: 9302e0016
+generated: "2026-05-24T08:41:57Z"
+git-sha: 4677149fb
 sweep-type: labels
 ---
 
@@ -36,14 +36,14 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-labels --out=<path>`.
 |---|---:|
 | Pairs scanned (both files exist) | 298 |
 | Pairs with ≥1 WF-only label | 293 |
-| Total WF-only labels | 4511 |
-| Total AV-only labels | 3289 |
-| Total common labels | 189 |
+| Total WF-only labels | 4490 |
+| Total AV-only labels | 3305 |
+| Total common labels | 210 |
 
 ## Top 20 Forms by WF-only Label Count
 
 Each row's WF-only count is the upper bound on missing fields in the AV view.
-Cross-link to the [density sweep](2026-05-26-density-sweep.md) for quantitative context.
+Cross-link to the [density sweep](2026-05-24-density-sweep.md) for quantitative context.
 
 | Rank | WF Form | AV View | WF-only | AV-only | Common |
 |---:|---|---|---:|---:|---:|
@@ -3225,45 +3225,6 @@ AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
 - `Battle Animation Palette`
-
-### ImagePalletForm
-WF labels: **28** · AV labels: **2** · WF-only: **28** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 98 / AV 3)
-
-WF-only labels (candidates for missing fields in AV):
-
-- `1`
-- `10`
-- `11`
-- `12`
-- `13`
-- `14`
-- `15`
-- `16`
-- `2`
-- `3`
-- `4`
-- `5`
-- `6`
-- `7`
-- `8`
-- `9`
-- `B`
-- `G`
-- `R`
-- `REDO`
-- `UNDO`
-- `クリップボード`
-- `パレットアドレス`
-- `パレット書き込み`
-- `パレット種類`
-- `拡大`
-- `画像取出`
-- `画像読込`
-
-AV-only labels (usually fine — layout polish or rewording):
-
-- `Address:`
-- `Palette Editor`
 
 ### StatusOptionForm
 WF labels: **28** · AV labels: **22** · WF-only: **28** · AV-only: **22** · Common: **0** · Density verdict: **Low** (WF 50 / AV 47)
@@ -9051,6 +9012,40 @@ AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
 - `Event Template 6`
+
+### ImagePalletForm
+WF labels: **28** · AV labels: **39** · WF-only: **7** · AV-only: **18** · Common: **21** · Density verdict: **Low** (WF 98 / AV 104)
+
+WF-only labels (candidates for missing fields in AV):
+
+- `クリップボード`
+- `パレットアドレス`
+- `パレット書き込み`
+- `パレット種類`
+- `拡大`
+- `画像取出`
+- `画像読込`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `2x`
+- `3x`
+- `4x`
+- `Clipboard`
+- `Edit R/G/B 0-248 (5-bit ticks)`
+- `Export Image`
+- `Fit to window`
+- `Import Image`
+- `Live bitmap preview pending Core extraction - tracked by #500.`
+- `Original size`
+- `Palette Address:`
+- `Palette Editor`
+- `Palette Index`
+- `Pending Core extraction - tracked by #500.`
+- `Pending Core RunRedo API - tracked by #500.`
+- `Preview`
+- `Write Palette`
+- `Zoom`
 
 ### MapEditorResizeDialogForm
 WF labels: **11** · AV labels: **11** · WF-only: **7** · AV-only: **7** · Common: **4** · Density verdict: **Low** (WF 19 / AV 19)

--- a/docs/avalonia-gaps/2026-05-24-undo-sweep.md
+++ b/docs/avalonia-gaps/2026-05-24-undo-sweep.md
@@ -1,6 +1,6 @@
 ---
-generated: "2026-05-24T02:20:14Z"
-git-sha: 4552097a3
+generated: "2026-05-24T08:42:04Z"
+git-sha: 4677149fb
 sweep-type: undo
 ---
 
@@ -79,11 +79,11 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-undo --out=<path>`.
 
 | Tier | Count | % of total |
 |---|---:|---:|
-| Total write callsites | 1101 | 100% |
-| NoUndoServiceField (no plumbing) | 149 | 13.5% |
+| Total write callsites | 1106 | 100% |
+| NoUndoServiceField (no plumbing) | 150 | 13.6% |
 | MissingScope (unwrapped) | 4 | 0.4% |
 | AmbiguousScope (verify) | 0 | 0.0% |
-| Covered (healthy) | 948 | 86.1% |
+| Covered (healthy) | 952 | 86.1% |
 
 ## Highest priority — VMs with NO undo plumbing at all
 
@@ -253,14 +253,20 @@ These ViewModels have no `UndoService` field/property/local. Every write here by
 
 | File | Line | Method | Write | Note |
 |---|---:|---|---|---|
-| `FEBuilderGBA.Avalonia/ViewModels/TextCharCodeViewModel.cs` | 139 | `Write` | `rom.write_u16(CurrentAddr + 0, (ushort)CharCode)` | class 'TextCharCodeViewModel' has no UndoService field/property/local |
-| `FEBuilderGBA.Avalonia/ViewModels/TextCharCodeViewModel.cs` | 140 | `Write` | `rom.write_u16(CurrentAddr + 2, (ushort)TerminatorValue)` | class 'TextCharCodeViewModel' has no UndoService field/property/local |
+| `FEBuilderGBA.Avalonia/ViewModels/TextCharCodeViewModel.cs` | 143 | `Write` | `rom.write_u16(CurrentAddr + 0, (ushort)CharCode)` | class 'TextCharCodeViewModel' has no UndoService field/property/local |
+| `FEBuilderGBA.Avalonia/ViewModels/TextCharCodeViewModel.cs` | 144 | `Write` | `rom.write_u16(CurrentAddr + 2, (ushort)TerminatorValue)` | class 'TextCharCodeViewModel' has no UndoService field/property/local |
 
 ### `Command85PointerViewModel` — 1 callsite
 
 | File | Line | Method | Write | Note |
 |---|---:|---|---|---|
 | `FEBuilderGBA.Avalonia/ViewModels/Command85PointerViewModel.cs` | 66 | `Write` | `EditorFormRef.WriteFields(rom, CurrentAddr, values, _fields)` | class 'Command85PointerViewModel' has no UndoService field/property/local |
+
+### `EDFE7ViewModel` — 1 callsite
+
+| File | Line | Method | Write | Note |
+|---|---:|---|---|---|
+| `FEBuilderGBA.Avalonia/ViewModels/EDFE7ViewModel.cs` | 606 | `ExpandTerminatedTable` | `rom.write_u8(newRowAddr, seed)` | class 'EDFE7ViewModel' has no UndoService field/property/local |
 
 ### `EDViewModel` — 1 callsite
 
@@ -444,7 +450,7 @@ _None._
 
 ## Covered (healthy)
 
-`948` callsites are inside a Begin/Commit (or Begin/Rollback) scope in the same method body, OR pass an explicit Undo argument. Covered classes: `MapSettingViewModel` (99), `MapSettingFE7UViewModel` (97), `MapSettingFE7ViewModel` (95), `ClassEditorViewModel` (75), `MoveCostFE6ViewModel` (51), `SongInstrumentViewModel` (46), `UnitEditorViewModel` (46), `UnitFE7ViewModel` (46), `UnitFE6ViewModel` (42), `ItemEditorViewModel` (26), `ItemFE6ViewModel` (22), `EventCondViewModel` (19), `BattleTerrainViewerViewModel` (15), `ImagePortraitViewModel` (13), `ImageUnitPaletteViewModel` (13), `PortraitViewerViewModel` (13), `SkillAssignmentClassSkillSystemViewModel` (11), `TextViewerViewModel` (10), `SkillAssignmentClassCSkillSysViewModel` (9), `ClassOPDemoViewModel` (8), `ImageMagicFEditorViewModel` (8), `TextDicViewModel` (8), `ImagePortraitFE6ViewModel` (7), `MapChangeViewModel` (7), `EventScriptPopupViewModel` (6), `ImageTSAAnime2ViewModel` (5), `SongTrackViewModel` (5), `WorldMapEventPointerViewModel` (5), `ImageMagicCSACreatorViewModel` (4), `OPClassDemoViewerViewModel` (4), `BattleBGViewerViewModel` (3), `BigCGViewerViewModel` (3), `ChapterTitleViewerViewModel` (3), `EDViewModel` (3), `ImageBGViewModel` (3), `ImageBattleAnimeViewModel` (3), `ImageBattleBGViewModel` (3), `ImageMapActionAnimationViewModel` (3), `OPClassDemoFE7UViewModel` (3), `OPClassDemoFE7ViewModel` (3), `SkillConfigFE8UCSkillSys09xViewModel` (3), `ClassOPDemoView` (2), `MapTileAnimation2ViewModel` (2), `SMEPromoListViewModel` (2), `SkillConfigSkillSystemViewModel` (2), `SongTableViewModel` (2), `AIASMCALLTALKViewModel` (1), `AIASMCoordinateViewModel` (1), `AIASMRangeViewModel` (1), `AIMapSettingViewModel` (1), `AIPerformItemViewModel` (1), `AIPerformStaffViewModel` (1), `AIStealItemViewModel` (1), `AITargetViewModel` (1), `AITilesViewModel` (1), `AIUnitsViewModel` (1), `AOERANGEViewModel` (1), `ArenaClassViewerViewModel` (1), `ArenaEnemyWeaponViewerViewModel` (1), `CCBranchEditorViewModel` (1), `EDSensekiCommentViewModel` (1), `EDStaffRollViewModel` (1), `EventMapChangeViewModel` (1), `EventUnitFE6ViewModel` (1), `EventUnitFE7ViewModel` (1), `EventUnitViewModel` (1), `ExtraUnitFE8UViewModel` (1), `ExtraUnitViewModel` (1), `ImageChapterTitleFE7ViewModel` (1), `ImageSystemAreaViewModel` (1), `ItemEffectPointerViewerViewModel` (1), `ItemRandomChestViewModel` (1), `ItemShopViewerViewModel` (1), `ItemStatBonusesSkillSystemsViewModel` (1), `ItemStatBonusesVennoViewModel` (1), `ItemStatBonusesViewerViewModel` (1), `ItemUsagePointerViewerViewModel` (1), `ItemWeaponEffectViewerViewModel` (1), `ItemWeaponTriangleViewerViewModel` (1), `LinkArenaDenyUnitViewerViewModel` (1), `MapEditorViewModel` (1), `MapExitPointViewModel` (1), `MapLoadFunctionViewModel` (1), `MapPointerViewModel` (1), `MapStyleEditorViewModel` (1), `MapTerrainBGLookupTableViewModel` (1), `MapTerrainFloorLookupTableViewModel` (1), `MapTerrainNameEngViewModel` (1), `MapTerrainNameViewModel` (1), `MapTileAnimation1ViewModel` (1), `MapTileAnimationViewModel` (1), `MenuCommandViewModel` (1), `MenuDefinitionViewModel` (1), `MenuExtendSplitMenuViewModel` (1), `MonsterItemViewerViewModel` (1), `MonsterProbabilityViewerViewModel` (1), `MonsterWMapProbabilityViewerViewModel` (1), `MoveCostEditorViewModel` (1), `OPClassAlphaNameFE6ViewModel` (1), `OPClassAlphaNameViewModel` (1), `OPClassDemoFE8UViewModel` (1), `OPClassFontFE8UViewModel` (1), `OPClassFontViewerViewModel` (1), `OPPrologueViewerView` (1), `OPPrologueViewerViewModel` (1), `PointerToolViewModel` (1), `SomeClassListViewModel` (1), `SongInstrumentDirectSoundViewModel` (1), `SoundBossBGMViewerViewModel` (1), `SoundFootStepsViewerViewModel` (1), `SoundRoomCGViewModel` (1), `SoundRoomFE6ViewModel` (1), `SoundRoomViewerViewModel` (1), `StatusOptionOrderViewModel` (1), `StatusOptionViewModel` (1), `StatusParamViewModel` (1), `StatusRMenuViewModel` (1), `StatusUnitsMenuViewModel` (1), `SummonUnitViewerViewModel` (1), `SummonsDemonKingViewerViewModel` (1), `SupportAttributeViewModel` (1), `SupportTalkFE6ViewModel` (1), `SupportTalkFE7ViewModel` (1), `SupportTalkViewModel` (1), `SupportUnitEditorViewModel` (1), `SupportUnitFE6ViewModel` (1), `TerrainNameEditorViewModel` (1), `ToolASMEditView` (1), `ToolLZ77ViewModel` (1), `UnitCustomBattleAnimeViewModel` (1), `UnitPaletteViewModel` (1), `UnitsShortTextViewModel` (1), `WorldMapBGMViewModel` (1), `WorldMapPathMoveEditorViewModel` (1), `WorldMapPathViewModel` (1), `WorldMapPointViewModel` (1).
+`952` callsites are inside a Begin/Commit (or Begin/Rollback) scope in the same method body, OR pass an explicit Undo argument. Covered classes: `MapSettingViewModel` (99), `MapSettingFE7UViewModel` (97), `MapSettingFE7ViewModel` (95), `ClassEditorViewModel` (75), `MoveCostFE6ViewModel` (51), `SongInstrumentViewModel` (46), `UnitEditorViewModel` (46), `UnitFE7ViewModel` (46), `UnitFE6ViewModel` (42), `ItemEditorViewModel` (26), `ItemFE6ViewModel` (22), `EventCondViewModel` (19), `BattleTerrainViewerViewModel` (15), `ImagePortraitViewModel` (13), `ImageUnitPaletteViewModel` (13), `PortraitViewerViewModel` (13), `SkillAssignmentClassSkillSystemViewModel` (11), `TextViewerViewModel` (10), `SkillAssignmentClassCSkillSysViewModel` (9), `ClassOPDemoViewModel` (8), `ImageMagicFEditorViewModel` (8), `TextDicViewModel` (8), `ImagePortraitFE6ViewModel` (7), `MapChangeViewModel` (7), `EventScriptPopupViewModel` (6), `ImageTSAAnime2ViewModel` (5), `SongTrackViewModel` (5), `WorldMapEventPointerViewModel` (5), `EDFE7ViewModel` (4), `ImageMagicCSACreatorViewModel` (4), `OPClassDemoViewerViewModel` (4), `BattleBGViewerViewModel` (3), `BigCGViewerViewModel` (3), `ChapterTitleViewerViewModel` (3), `EDViewModel` (3), `ImageBGViewModel` (3), `ImageBattleAnimeViewModel` (3), `ImageBattleBGViewModel` (3), `ImageMapActionAnimationViewModel` (3), `OPClassDemoFE7UViewModel` (3), `OPClassDemoFE7ViewModel` (3), `SkillConfigFE8UCSkillSys09xViewModel` (3), `ClassOPDemoView` (2), `MapTileAnimation2ViewModel` (2), `SMEPromoListViewModel` (2), `SkillConfigSkillSystemViewModel` (2), `SongTableViewModel` (2), `AIASMCALLTALKViewModel` (1), `AIASMCoordinateViewModel` (1), `AIASMRangeViewModel` (1), `AIMapSettingViewModel` (1), `AIPerformItemViewModel` (1), `AIPerformStaffViewModel` (1), `AIStealItemViewModel` (1), `AITargetViewModel` (1), `AITilesViewModel` (1), `AIUnitsViewModel` (1), `AOERANGEViewModel` (1), `ArenaClassViewerViewModel` (1), `ArenaEnemyWeaponViewerViewModel` (1), `CCBranchEditorViewModel` (1), `EDSensekiCommentViewModel` (1), `EDStaffRollViewModel` (1), `EventMapChangeViewModel` (1), `EventUnitFE6ViewModel` (1), `EventUnitFE7ViewModel` (1), `EventUnitViewModel` (1), `ExtraUnitFE8UViewModel` (1), `ExtraUnitViewModel` (1), `ImageChapterTitleFE7ViewModel` (1), `ImageSystemAreaViewModel` (1), `ItemEffectPointerViewerViewModel` (1), `ItemRandomChestViewModel` (1), `ItemShopViewerViewModel` (1), `ItemStatBonusesSkillSystemsViewModel` (1), `ItemStatBonusesVennoViewModel` (1), `ItemStatBonusesViewerViewModel` (1), `ItemUsagePointerViewerViewModel` (1), `ItemWeaponEffectViewerViewModel` (1), `ItemWeaponTriangleViewerViewModel` (1), `LinkArenaDenyUnitViewerViewModel` (1), `MapEditorViewModel` (1), `MapExitPointViewModel` (1), `MapLoadFunctionViewModel` (1), `MapPointerViewModel` (1), `MapStyleEditorViewModel` (1), `MapTerrainBGLookupTableViewModel` (1), `MapTerrainFloorLookupTableViewModel` (1), `MapTerrainNameEngViewModel` (1), `MapTerrainNameViewModel` (1), `MapTileAnimation1ViewModel` (1), `MapTileAnimationViewModel` (1), `MenuCommandViewModel` (1), `MenuDefinitionViewModel` (1), `MenuExtendSplitMenuViewModel` (1), `MonsterItemViewerViewModel` (1), `MonsterProbabilityViewerViewModel` (1), `MonsterWMapProbabilityViewerViewModel` (1), `MoveCostEditorViewModel` (1), `OPClassAlphaNameFE6ViewModel` (1), `OPClassAlphaNameViewModel` (1), `OPClassDemoFE8UViewModel` (1), `OPClassFontFE8UViewModel` (1), `OPClassFontViewerViewModel` (1), `OPPrologueViewerView` (1), `OPPrologueViewerViewModel` (1), `PointerToolViewModel` (1), `SomeClassListViewModel` (1), `SongInstrumentDirectSoundViewModel` (1), `SoundBossBGMViewerViewModel` (1), `SoundFootStepsViewerViewModel` (1), `SoundRoomCGViewModel` (1), `SoundRoomFE6ViewModel` (1), `SoundRoomViewerViewModel` (1), `StatusOptionOrderViewModel` (1), `StatusOptionViewModel` (1), `StatusParamViewModel` (1), `StatusRMenuViewModel` (1), `StatusUnitsMenuViewModel` (1), `SummonUnitViewerViewModel` (1), `SummonsDemonKingViewerViewModel` (1), `SupportAttributeViewModel` (1), `SupportTalkFE6ViewModel` (1), `SupportTalkFE7ViewModel` (1), `SupportTalkViewModel` (1), `SupportUnitEditorViewModel` (1), `SupportUnitFE6ViewModel` (1), `TerrainNameEditorViewModel` (1), `ToolASMEditView` (1), `ToolLZ77ViewModel` (1), `UnitCustomBattleAnimeViewModel` (1), `UnitPaletteViewModel` (1), `UnitsShortTextViewModel` (1), `WorldMapBGMViewModel` (1), `WorldMapPathMoveEditorViewModel` (1), `WorldMapPathViewModel` (1), `WorldMapPointViewModel` (1).
 
 ## Registry cross-check
 
@@ -458,9 +464,9 @@ such a row almost always indicates the scanner's pattern set has missed a
 real write API (e.g. PR #380 review caught a `CoreState.ROM.write_u*`
 miss that surfaced as an unjustified zero-row warning before the fix).
 
-Classes with at least one detected write: 173.
+Classes with at least one detected write: 174.
 
-Writable VMs (matching the triplet convention): 145.
+Writable VMs (matching the triplet convention): 146.  
 Writable VMs with zero detected ROM writes: 3.
 
 ### Writable VMs with zero detected ROM writes (warning)


### PR DESCRIPTION
## Summary

Closes the 123 Avalonia ↔ WinForms gaps on `ImagePalletForm` (HIGH
density 3/98, -96.9%, 28 WF-only labels, 0 common labels) by
replacing the 3-control stub with a full 16-color BGR15 palette
editor wired to a new cross-platform `FEBuilderGBA.Core/PaletteCore.cs`.

- **Density verdict:** HIGH → **LOW** (104/98, +6.1 %).
- **Labels:** WF-only 28 → 7; common 0 → 21; AV labels 2 → 39.
- **PaletteCore** delegates BGR15 bit-math to the existing
  `PaletteFormatConverter` (no parallel copy — Copilot CLI plan
  review #3).
- **Address handling** is normalized via `U.toOffset` for both
  pointer (`0x08xxxxxx`) and raw-offset (`0x00xxxxxx`) inputs
  (Copilot CLI plan review #1).
- **Caller wiring:** `ImagePortraitView.JumpToPalette_Click` now
  forwards `_vm.PalettePtr` into a new
  `ImagePalletView.JumpTo(...)` mirroring WF
  `ImagePalletForm.JumpTo(...)` (Copilot CLI plan review #2).
- **Undo button enabled** — Redo deferred behind `#500`
  (Core has no `RunRedo` API; Copilot CLI plan review #5).
- **38 new tests** (18 PaletteCore + 20 ImagePalletView parity).
- **7 new ja+zh translations**; `ko.txt` remains unmapped per repo
  convention (#441/#511/#517/#520/#522/#535/#540/#542/#544/#547/#580).

## Plan Reference

Implements the plan accepted on the
[plan comment](https://github.com/laqieer/FEBuilderGBA/issues/400#issuecomment-4527533352)
after a 4-round Copilot CLI plan review.

## Scope

Closes #400
Ref #500 (deferred: live Bitmap preview, Bitmap Import/Export,
Clipboard, color picker, color swap, color variant, eyedropper,
drag-drop, LZ77-compressed palette, Core `RunRedo`).

## Screenshots

### Palette Editor with real FE8U portrait palette (loaded via JumpToPalette → ImagePalletView.JumpTo)

![Palette Editor — real FE8U portrait palette](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr-imagepallet-400-real.png)

Cell 1: dark red `(112, 8, 0)`. Cell 2: blue `(0, 128, 208)`. Cell 3:
cyan `(32, 200, 248)`. Cell 4: purple `(112, 104, 160)`. Cell 5–16:
greens, reds, neutrals. RGB NumericUpDowns show the unpacked 8-bit
values; swatch images show the rendered color. Palette Index combo
is hidden (single-palette block, mirroring WF behavior). Captured
via `tools/WinCapture` (`PrintWindow` API) so the image is the
actual running GUI.

### Palette Editor empty state (initial render)

![Palette Editor — empty initial state](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr-imagepallet-400-empty.png)

All 16 cells rendered as a 4×4 grid with index labels, swatch images,
and R/G/B NumericUpDowns. Top selection bar (Palette Address + Zoom +
Write Palette / Undo / Redo). Right column: Preview area + R/G/B
row labels + 5-bit ticks hint. Bottom row: Import / Export /
Clipboard (all deferred behind `#500`).

## GUI Test Report

### Environment
- ROM: `roms/FE8U.gba`
- Editor / View: `ImagePalletView` (Palette Editor)
- Caller: `ImagePortraitView.JumpToPalette_Click` → `WindowManager
  .Open<ImagePalletView>()` → `window.JumpTo(_vm.PalettePtr, 1, 0, null)`

### Steps Performed
1. Launched Avalonia with `--rom roms/FE8U.gba`.
2. Clicked **Main_PortraitEditor_Button** → opened `Portrait Image
   Editor` (`ImagePortraitView`).
3. Selected `0x00 Eirika` in the AddressListControl.
4. Clicked **Jump to Palette** → `ImagePalletView` opened with the
   portrait's palette address.
5. Verified all 16 cells display real BGR15 colors read from ROM.
6. Verified `Palette Index` combo is hidden (maxPaletteCount=1).
7. Captured via `tools/WinCapture` (PrintWindow API).

### Test Results
| Test | Expected | Actual | Status |
|------|----------|--------|--------|
| Window opens via Main_Palette_Button | Empty Palette Editor renders | Renders with 16 zero-RGB cells | PASS |
| Window opens via Portrait JumpToPalette | Palette Editor opens with real BGR15 colors | All 16 cells show portrait palette | PASS |
| 16 swatches render | One Image control per slot, color matches RGB NUDs | Verified visually | PASS |
| Palette Index combo hidden when maxPaletteCount=1 | PaletteIndexLabel/Combo IsVisible=false | Verified — combo bar empty | PASS |
| Undo button enabled | Undo IsEnabled=true; click runs CoreState.Undo.RunUndo() | Enabled state visible | PASS |
| Redo button disabled with #500 tooltip | Redo IsEnabled=false + #500 tooltip | Greyed-out, hover tooltip references #500 | PASS |
| Import/Export/Clipboard disabled with #500 tooltip | Same | All three greyed-out + #500 tooltip | PASS |

### Verdict
**PASS** — All 7 manual test cases pass. Palette Editor renders real
BGR15 data via the caller-wiring path, density verdict is LOW
(104/98), and deferred affordances are correctly disabled with the
`#500` follow-up signpost.

## Test plan

- [x] `PaletteCoreTests` (18 tests): pointer/offset normalization,
      palette-index offset arithmetic, write/read round-trip, 5-bit
      lossy quantization, delegation-to-PaletteFormatConverter.
- [x] `ImagePalletParityTests` (20 tests): density >= 74, all
      AutomationIds, Write undo scope, Undo button enabled, Redo
      deferred, ViewModel round-trip, JumpTo accepts GBA pointer,
      caller-wiring source-level test.
- [x] `dotnet test FEBuilderGBA.Core.Tests` — 1,690 tests passing.
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` — 5,845 tests passing.
- [x] `dotnet test FEBuilderGBA.Tests` — 1,716 tests passing.
- [x] `L10nCoverageTest` passes (7 new ja+zh entries added).
- [x] `AutomationIdTests.All_AutomationIds_Follow_Naming_Convention`
      passes — every new ID ends with `_Image` / `_Input` / `_Label`
      / `_Combo` / `_Button`.
- [x] `AvaloniaFieldCompletenessTests.NoOrphanVMs_ImplementIDataVerifiable`
      passes — `ImagePalletViewModel` deliberately does not
      participate in the --data-verify sweep (placeholder
      `LoadList`).
- [x] `NoAxamlFile_UsesHexFormatString_OnNumericUpDown` passes —
      `AddressBox` uses `FormatString="0"`, not hex.
- [x] Real GUI screenshots captured via `tools/WinCapture`
      (`PrintWindow` API) — not fabricated.
- [x] Gap-sweep baselines refreshed (density / labels / jumps / undo
      / l10n) — `ImagePalletForm` row drops from HIGH to LOW.

## Known limitations

Deferred behind `#500` (open follow-up — surfaced as disabled
buttons + tooltip in this PR):

- Live `Bitmap` sample preview (`X_PIC.Image` requires Core
  extraction of `ImageUtil.CloneBitmap`).
- Import Image / Export Image (`ImageFormRef.OpenFilenameDialog
  FullColor` + `ImageUtil.OpenBitmap`).
- Color-picker dialog on swatch left-click (WF `ColorDialog`).
- Color-swap right-click context menu (WF `PaletteSwapForm`).
- "Generate color variant" menu (WF `PaletteChangeColorsForm`).
- Eyedropper tool (`SpoitTool_SelectPalette`).
- Drag-drop image import.
- LZ77-compressed palette path (`isCompress=true`).
- Clipboard read/write of palette hex text.
- Redo button (Core has no `RunRedo` API; WF redo is form-local
  via `PaletteFormRef` snapshot stack — out of scope per Copilot
  CLI plan review #5).

The sister form `ImageBattleAnimePallet` (#399) is being addressed
in a parallel PR; that PR will reuse `PaletteCore` and ship a
separate `ImageBattleAnimePalletView` rebuild.

Generated with Claude Code (claude-opus-4-7[1m])