### PR TITLE
fix(gap-sweep): ImageBattleScreen parity (closes #393)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleScreenParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleScreenParityTests.cs
@@ -72,7 +72,44 @@ public class ImageBattleScreenParityTests
         string axaml = ReadAxaml();
         Assert.Contains("AutomationId=\"ImageBattleScreen_AllWrite_Button\"", axaml);
         Assert.Contains("AutomationId=\"ImageBattleScreen_Zoom_Combo\"", axaml);
-        Assert.Contains("AutomationId=\"ImageBattleScreen_TSAInfo_Label\"", axaml);
+        // Per Copilot bot PR #594 round 5 thread #1: TSAInfo is split into
+        // two separate translatable TextBlocks (Selected + Canvas) so each
+        // fragment goes through ViewTranslationHelper independently.
+        Assert.Contains("AutomationId=\"ImageBattleScreen_TSAInfoSelected_Label\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_TSAInfoCanvas_Label\"", axaml);
+    }
+
+    /// <summary>
+    /// Per Copilot bot PR #594 round 5 thread #2: WriteButton_Click must
+    /// refuse to write if the VM has not been loaded yet (default zeros
+    /// would wipe the ROM TSA + image pointer slots).
+    /// </summary>
+    [Fact]
+    public void View_WriteHandler_GuardsAgainstUnloadedVM()
+    {
+        string code = File.ReadAllText(CodeBehindPath());
+        // The handler must check _vm.IsLoaded before invoking Write().
+        var match = Regex.Match(code,
+            @"void\s+WriteButton_Click[\s\S]*?(?=\n\s{4,}void\s|\n\s{0,4}\})",
+            RegexOptions.Singleline);
+        Assert.True(match.Success, "Could not locate WriteButton_Click handler");
+        Assert.Matches(new Regex(@"if\s*\(\s*!_vm\.IsLoaded", RegexOptions.Singleline), match.Value);
+    }
+
+    /// <summary>
+    /// Per Copilot bot PR #594 round 5 thread #3: PaletteWrite_Click must
+    /// refuse to write if the VM has not been loaded yet (default zero
+    /// R/G/B arrays would write a black palette over the existing one).
+    /// </summary>
+    [Fact]
+    public void View_PaletteWriteHandler_GuardsAgainstUnloadedVM()
+    {
+        string code = File.ReadAllText(CodeBehindPath());
+        var match = Regex.Match(code,
+            @"void\s+PaletteWrite_Click[\s\S]*?(?=\n\s{4,}void\s|\n\s{0,4}\})",
+            RegexOptions.Singleline);
+        Assert.True(match.Success, "Could not locate PaletteWrite_Click handler");
+        Assert.Matches(new Regex(@"if\s*\(\s*!_vm\.IsLoaded", RegexOptions.Singleline), match.Value);
     }
 
     [Fact]

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleScreenParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleScreenParityTests.cs
@@ -1,0 +1,654 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Phase 1/2/4/5 gap-sweep regression tests for ImageBattleScreenView (#393).
+//
+// Closes the 130 Avalonia ↔ WinForms gaps the gap-sweep methodology surfaced
+// on `ImageBattleScreenForm` (HIGH density 133/3 == -97.7 %, 42 WF-only labels).
+// After this PR `ImageBattleScreenView` rebuilds to the 5-tab battle-screen
+// layout editor the WinForms form exposes, with the TSA + palette + image
+// pointer I/O extracted to FEBuilderGBA.Core/ImageBattleScreenCore.cs.
+//
+// Copilot CLI plan-review v1 issues addressed:
+//   1. Image label swap: image2/4 = Name, image3/5 = Item. Verified via the
+//      WF Designer.cs L1971-2202.
+//   2. Undo ownership: Core methods take NO Undo.UndoData parameter — they
+//      rely on the ambient ROM.BeginUndoScope only. Tests verify the view
+//      wraps Write() in _undoService.Begin/Commit/Rollback.
+//   3. PaletteCore reuse: ReadPaletteBlock / WritePaletteBlock delegate to
+//      PaletteCore — single source of truth for BGR15 packing.
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.GapSweep;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests.GapSweep;
+
+/// <summary>
+/// Tests proving the ImageBattleScreenForm parity raise (#393) is permanent.
+/// Marked [Collection("SharedState")] because the synthetic-ROM tests mutate
+/// CoreState.ROM. Without serialization, xUnit's per-class parallel runner
+/// can race a sibling test's ROM swap.
+/// </summary>
+[Collection("SharedState")]
+public class ImageBattleScreenParityTests
+{
+    // -----------------------------------------------------------------
+    // Density (Phase 1) - AV control count must reach the MEDIUM verdict.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// WF designer.cs reports 133 control instantiations (per 2026-05-21
+    /// density sweep). To leave the HIGH verdict we need
+    /// AV >= ceil(133 * 0.75) = 100.
+    /// </summary>
+    [Fact]
+    public void View_AvControlCount_AtOrAboveMediumVerdict()
+    {
+        string axamlPath = AxamlPath();
+        Assert.True(File.Exists(axamlPath), $"AXAML not found at {axamlPath}");
+
+        var doc = XDocument.Load(axamlPath);
+        int avCount = ControlDensityScanner.CountAvControlsInDocument(doc);
+
+        const int WfControlCount = 133;
+        int mediumThreshold = (int)Math.Ceiling(WfControlCount * 0.75); // 100
+        Assert.True(avCount >= mediumThreshold,
+            $"AV control count {avCount} must be >= {mediumThreshold} " +
+            $"(75 % of WF={WfControlCount}) to leave the HIGH verdict.");
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 5 - control surface assertions per tab.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_HasTopToolbar()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"ImageBattleScreen_AllWrite_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Zoom_Combo\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_TSAInfo_Label\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasBattlePreviewKnownGapPlaceholder()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"ImageBattleScreen_BattlePreview_Label\"", axaml);
+        // The placeholder text must explain the deferral honestly.
+        Assert.Contains("deferred", axaml, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void View_HasChipsetPreviewKnownGapPlaceholder()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"ImageBattleScreen_ChipsetPreview_Label\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasPaletteTab()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"ImageBattleScreen_PaletteAddress_Input\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_PaletteIndex_Combo\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_PaletteWrite_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_PaletteClipboard_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_PaletteUndo_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_PaletteRedo_Button\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasPalette16RowGrid()
+    {
+        string axaml = ReadAxaml();
+        for (int i = 1; i <= 16; i++)
+        {
+            Assert.Contains($"AutomationId=\"ImageBattleScreen_R{i}_Input\"", axaml);
+            Assert.Contains($"AutomationId=\"ImageBattleScreen_G{i}_Input\"", axaml);
+            Assert.Contains($"AutomationId=\"ImageBattleScreen_B{i}_Input\"", axaml);
+            Assert.Contains($"AutomationId=\"ImageBattleScreen_Swatch{i}_Label\"", axaml);
+            Assert.Contains($"AutomationId=\"ImageBattleScreen_Index{i}_Label\"", axaml);
+        }
+    }
+
+    [Fact]
+    public void View_HasMainImageTab()
+    {
+        string axaml = ReadAxaml();
+        // Tab title + tile labels 1..5 + image1 ZIMAGE + Import/Export + image preview.
+        for (int i = 1; i <= 5; i++)
+        {
+            Assert.Contains($"AutomationId=\"ImageBattleScreen_Tile{i}_Label\"", axaml);
+        }
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image1_ZIMAGE_Input\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image1_Import_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image1_Export_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image1_Preview_Label\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasLeftSideTab_Image2IsName_Image3IsItem()
+    {
+        // Per Copilot CLI plan-review round 1 #1: image2 = Name (左/名前),
+        // image3 = Item (左/アイテム). Verified via WF Designer.cs L1971-2072.
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image2_ZIMAGE_Input\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image2_Import_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image2_Export_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image2_Name_Label\"", axaml);
+
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image3_ZIMAGE_Input\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image3_Import_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image3_Export_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image3_Item_Label\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasRightSideTab_Image4IsName_Image5IsItem()
+    {
+        // Per Copilot CLI plan-review round 1 #1: image4 = Name (右/名前),
+        // image5 = Item (右/アイテム). Verified via WF Designer.cs L2096-2202.
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image4_ZIMAGE_Input\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image4_Import_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image4_Export_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image4_Name_Label\"", axaml);
+
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image5_ZIMAGE_Input\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image5_Import_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image5_Export_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_Image5_Item_Label\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasImportExportTab()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"ImageBattleScreen_BulkImport_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_BulkExport_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_BulkUndo_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_BulkRedo_Button\"", axaml);
+        Assert.Contains("AutomationId=\"ImageBattleScreen_BulkDescription_Label\"", axaml);
+    }
+
+    [Fact]
+    public void View_AllNumericsHaveIncrement8()
+    {
+        // All 48 R/G/B NumericUpDowns must have Increment="8" (matches WF
+        // 5-bit step pattern).
+        string axaml = ReadAxaml();
+        var increment8Count = Regex.Matches(axaml,
+            @"Name=""[RGB]\d+""[^/]*Increment=""8""", RegexOptions.Singleline).Count;
+        Assert.True(increment8Count >= 48,
+            $"Expected at least 48 R/G/B NumericUpDowns with Increment=8, got {increment8Count}");
+    }
+
+    [Fact]
+    public void View_AllNumericsHaveMaximum255()
+    {
+        string axaml = ReadAxaml();
+        var max255Count = Regex.Matches(axaml,
+            @"Name=""[RGB]\d+""[^/]*Maximum=""255""", RegexOptions.Singleline).Count;
+        Assert.True(max255Count >= 48,
+            $"Expected at least 48 R/G/B NumericUpDowns with Maximum=255, got {max255Count}");
+    }
+
+    /// <summary>
+    /// Per Copilot bot PR #594 review round 2 #5: ZoomCombo only affects
+    /// the deferred Battle/Chipset preview rendering. Until that rendering
+    /// lands, the combo is disabled with an explanatory tooltip.
+    /// </summary>
+    [Fact]
+    public void View_ZoomCombo_IsHonestlyDeferredKnownGap()
+    {
+        string axaml = ReadAxaml();
+        Assert.Matches(new Regex(
+            @"AutomationId=""ImageBattleScreen_Zoom_Combo""[\s\S]{0,400}IsEnabled=""False""",
+            RegexOptions.Singleline), axaml);
+    }
+
+    [Fact]
+    public void View_BulkImportExport_IsHonestlyDeferredKnownGap()
+    {
+        // Per Plan v2: bulk Import/Export are WF-coupled. Buttons are
+        // rendered but disabled with explanatory tooltips.
+        string axaml = ReadAxaml();
+        Assert.Matches(new Regex(
+            @"AutomationId=""ImageBattleScreen_BulkImport_Button""[\s\S]{0,400}IsEnabled=""False""",
+            RegexOptions.Singleline), axaml);
+        Assert.Matches(new Regex(
+            @"AutomationId=""ImageBattleScreen_BulkExport_Button""[\s\S]{0,400}IsEnabled=""False""",
+            RegexOptions.Singleline), axaml);
+    }
+
+    [Fact]
+    public void View_PerImageImportExport_IsHonestlyDeferredKnownGap()
+    {
+        // Per-image Import/Export buttons (image1..5) are also WF-coupled.
+        string axaml = ReadAxaml();
+        for (int i = 1; i <= 5; i++)
+        {
+            Assert.Matches(new Regex(
+                $@"AutomationId=""ImageBattleScreen_Image{i}_Import_Button""[\s\S]{{0,400}}IsEnabled=""False""",
+                RegexOptions.Singleline), axaml);
+            Assert.Matches(new Regex(
+                $@"AutomationId=""ImageBattleScreen_Image{i}_Export_Button""[\s\S]{{0,400}}IsEnabled=""False""",
+                RegexOptions.Singleline), axaml);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 5 - Code-behind / write-handler assertions.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Per acceptance criterion #3: ALL write paths in the view MUST wrap
+    /// the VM Write call in _undoService.Begin / Commit / Rollback. The
+    /// WriteButton_Click handler is the bulk write.
+    /// </summary>
+    [Fact]
+    public void View_WriteHandler_UsesUndoService()
+    {
+        string code = File.ReadAllText(CodeBehindPath());
+        Assert.Matches(new Regex(
+            @"WriteButton_Click[\s\S]*?_undoService\.Begin\([^)]*\)[\s\S]*?_vm\.Write\(\)[\s\S]*?_undoService\.(Commit|Rollback)\(\)",
+            RegexOptions.Singleline), code);
+    }
+
+    /// <summary>
+    /// The PaletteWrite_Click handler MUST also wrap its write call in
+    /// the UndoService scope so palette changes are atomic.
+    /// </summary>
+    [Fact]
+    public void View_PaletteWriteHandler_UsesUndoService()
+    {
+        string code = File.ReadAllText(CodeBehindPath());
+        Assert.Matches(new Regex(
+            @"PaletteWrite_Click[\s\S]*?_undoService\.Begin\([^)]*\)[\s\S]*?_vm\.WritePalette\(\)[\s\S]*?_undoService\.(Commit|Rollback)\(\)",
+            RegexOptions.Singleline), code);
+    }
+
+    [Fact]
+    public void View_WriteHandler_RollsBackOnFailure()
+    {
+        string code = File.ReadAllText(CodeBehindPath());
+        // The handler must check for a failure and call Rollback.
+        Assert.Matches(new Regex(
+            @"_undoService\.Rollback\(\)",
+            RegexOptions.Singleline), code);
+    }
+
+    [Fact]
+    public void View_PaletteIndexCombo_HasFourEntries()
+    {
+        string code = File.ReadAllText(CodeBehindPath());
+        var matches = Regex.Matches(code, @"PaletteIndexCombo\.Items\.Add\(");
+        Assert.Equal(4, matches.Count);
+    }
+
+    [Fact]
+    public void View_ZoomCombo_HasFourEntries()
+    {
+        // 1x..4x zoom matches WF's 1/2/3/4 zoom indices.
+        string code = File.ReadAllText(CodeBehindPath());
+        var matches = Regex.Matches(code, @"ZoomCombo\.Items\.Add\(");
+        Assert.Equal(4, matches.Count);
+    }
+
+    // -----------------------------------------------------------------
+    // ViewModel behavior tests (synthetic ROM).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_LoadEntry_ReadsMapAndPalette()
+    {
+        var rom = MakeSyntheticRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new ImageBattleScreenViewModel();
+            vm.LoadEntry();
+            Assert.True(vm.IsLoaded);
+            Assert.NotNull(vm.Map);
+            Assert.Equal(640, vm.Map.Length);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_Write_RoundTripsThroughCoreUnderUndo()
+    {
+        var rom = MakeSyntheticRom();
+        var prevRom = CoreState.ROM;
+        var prevUndo = CoreState.Undo;
+        try
+        {
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+
+            var vm = new ImageBattleScreenViewModel();
+            vm.LoadEntry();
+
+            // Mutate one TSA cell so the write is non-trivial.
+            vm.Map[0 * 32 + 1] = 0xABCD;
+
+            var undoService = new UndoService();
+            undoService.Begin("test write");
+            bool ok = vm.Write();
+            undoService.Commit();
+
+            Assert.True(ok);
+
+            // Re-load and verify the mutation survived.
+            var roundtrip = new ImageBattleScreenViewModel();
+            roundtrip.LoadEntry();
+            Assert.Equal((ushort)0xABCD, roundtrip.Map[0 * 32 + 1]);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.Undo = prevUndo;
+        }
+    }
+
+    [Fact]
+    public void ViewModel_Write_TrackedWriteFails_RollbackRunsUndoAndRestoresRom()
+    {
+        var rom = MakeSyntheticRom();
+        var prevRom = CoreState.ROM;
+        var prevUndo = CoreState.Undo;
+        try
+        {
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+
+            // Snapshot the TSA1 region.
+            uint tsa1Addr = rom.p32(rom.RomInfo.battle_screen_TSA1_pointer);
+            byte[] before = new byte[16];
+            for (int i = 0; i < 16; i++) before[i] = rom.Data[tsa1Addr + i];
+
+            int initialCount = CoreState.Undo.UndoBuffer.Count;
+            int initialPostion = CoreState.Undo.Postion;
+
+            var vm = new ImageBattleScreenViewModel();
+            vm.LoadEntry();
+            vm.Map[0 * 32 + 1] = 0xABCD;
+
+            // Inject a writer that performs a tracked write THEN returns false.
+            vm.SetWriterOverrideForTests((r, m) =>
+            {
+                r.write_u16(tsa1Addr, 0xFFFF); // partial tracked write
+                return false;
+            });
+
+            var undoService = new UndoService();
+            undoService.Begin("test failing write");
+            bool result = vm.Write();
+            Assert.False(result);
+            undoService.Rollback();
+
+            // ROM bytes at tsa1Addr must be restored.
+            for (int i = 0; i < 16; i++)
+            {
+                Assert.Equal(before[i], rom.Data[tsa1Addr + i]);
+            }
+            // Postion returned to initial; buffer grew by 1 (Push happened).
+            Assert.Equal(initialPostion, CoreState.Undo.Postion);
+            Assert.Equal(initialCount + 1, CoreState.Undo.UndoBuffer.Count);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.Undo = prevUndo;
+        }
+    }
+
+    /// <summary>
+    /// Static guard (per Copilot CLI PR #594 round 3 finding): VM.Write()
+    /// must return false (not true) when any of the 5 WriteImagePointer
+    /// calls returns false. Roslyn regex over the VM source ensures each
+    /// call is wrapped in 'if (!...) return false;'.
+    ///
+    /// We assert via static code analysis rather than runtime injection
+    /// because RomInfo.battle_screen_imageN_pointer values are protected
+    /// constants on the ROMFE8U class -- there is no test-friendly way to
+    /// force WriteImagePointer to return false at runtime without
+    /// reflection-against-protected-setters or shrinking rom.Data
+    /// (which collapses the entire test ROM). The Core-level tests
+    /// (WriteImagePointer_InvalidPointerSlot_ReturnsFalse) exercise the
+    /// false-return path directly; this guard ensures the VM consumes it.
+    /// </summary>
+    [Fact]
+    public void ViewModel_Write_PropagatesImagePointerFailures()
+    {
+        string vmCode = File.ReadAllText(ViewModelPath());
+        // Each of the 5 WriteImagePointer calls must be guarded by a
+        // `if (!...) return false;` so a failing slot bails out.
+        for (int i = 1; i <= 5; i++)
+        {
+            Assert.Matches(new Regex(
+                @"if\s*\(\s*!ImageBattleScreenCore\.WriteImagePointer\(rom,\s*rom\.RomInfo\.battle_screen_image" + i + @"_pointer,\s*_image" + i + @"Pointer\)\s*\)\s*return\s+false",
+                RegexOptions.Singleline), vmCode);
+        }
+    }
+
+    static string ViewModelPath()
+    {
+        string repoRoot = FindRepoRoot();
+        return Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "ViewModels",
+            "ImageBattleScreenViewModel.cs");
+    }
+
+    /// <summary>
+    /// Per Copilot CLI PR review round 1 finding #2: switching palette
+    /// type must reload ONLY the palette R/G/B rows -- pending image
+    /// pointer edits in the VM must survive. WF
+    /// PaletteFormRef.MakePaletteROMToUI only updates the palette UI on
+    /// palette-index changes, not the image pointer fields.
+    /// </summary>
+    [Fact]
+    public void ViewModel_LoadPalette_PreservesPendingImagePointerEdits()
+    {
+        var rom = MakeSyntheticRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new ImageBattleScreenViewModel();
+            vm.LoadEntry();
+
+            // Stash original pointer values for comparison.
+            uint originalImage1 = vm.Image1Pointer;
+            uint originalImage5 = vm.Image5Pointer;
+
+            // Simulate the user typing new image-pointer values into the UI
+            // (which mutates the VM via the property setters).
+            const uint pendingImage1 = 0x12345678u;
+            const uint pendingImage5 = 0x87654321u;
+            vm.Image1Pointer = pendingImage1;
+            vm.Image5Pointer = pendingImage5;
+            Assert.NotEqual(originalImage1, vm.Image1Pointer);
+            Assert.NotEqual(originalImage5, vm.Image5Pointer);
+
+            // Switch palette type and call LoadPalette() -- the equivalent
+            // of what PaletteIndex_SelectionChanged does after this fix.
+            vm.PaletteIndex = 1;
+            vm.LoadPalette();
+
+            // Image pointers MUST still hold the pending edits.
+            Assert.Equal(pendingImage1, vm.Image1Pointer);
+            Assert.Equal(pendingImage5, vm.Image5Pointer);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    /// <summary>
+    /// Static check: the view's PaletteIndex_SelectionChanged handler must
+    /// call _vm.LoadPalette(), not _vm.LoadEntry(), so it cannot clobber
+    /// the image-pointer fields.
+    /// </summary>
+    [Fact]
+    public void View_PaletteIndexHandler_CallsLoadPaletteNotLoadEntry()
+    {
+        string code = File.ReadAllText(CodeBehindPath());
+        // The handler must use LoadPalette(), not LoadEntry().
+        Assert.Matches(new Regex(
+            @"PaletteIndex_SelectionChanged[\s\S]*?_vm\.LoadPalette\(\)",
+            RegexOptions.Singleline), code);
+        // And the handler section MUST NOT call _vm.LoadEntry().
+        var match = Regex.Match(code,
+            @"void\s+PaletteIndex_SelectionChanged[\s\S]*?(?=\n\s{4,}void\s|\n\s{0,4}\})",
+            RegexOptions.Singleline);
+        Assert.True(match.Success, "Could not locate PaletteIndex_SelectionChanged handler");
+        Assert.DoesNotContain("_vm.LoadEntry()", match.Value);
+    }
+
+    /// <summary>
+    /// Per Copilot bot PR #594 inline review #3: AddrLabel (under "TSA1
+    /// Address" bar) must reflect the TSA1 offset, not the palette
+    /// address. Static regression guard so the wiring stays correct.
+    /// </summary>
+    [Fact]
+    public void View_AddrLabel_DisplaysTSA1AddressNotPaletteAddress()
+    {
+        string code = File.ReadAllText(CodeBehindPath());
+        // The PopulateUI helper must format the TSA1 address into AddrLabel.
+        Assert.Matches(new Regex(
+            @"AddrLabel\.Text\s*=\s*string\.Format\([^)]*_vm\.TSA1Address",
+            RegexOptions.Singleline), code);
+        // And it must NOT format PaletteAddress into AddrLabel.
+        Assert.DoesNotMatch(new Regex(
+            @"AddrLabel\.Text\s*=\s*string\.Format\([^)]*_vm\.PaletteAddress",
+            RegexOptions.Singleline), code);
+    }
+
+    [Fact]
+    public void ViewModel_LoadEntry_PopulatesTSA1AddressFromRom()
+    {
+        var rom = MakeSyntheticRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new ImageBattleScreenViewModel();
+            vm.LoadEntry();
+            Assert.Equal((uint)0x100000, vm.TSA1Address);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_Write_NoTrackedWriteFails_RollbackIsNoOp()
+    {
+        var rom = MakeSyntheticRom();
+        var prevRom = CoreState.ROM;
+        var prevUndo = CoreState.Undo;
+        try
+        {
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+
+            int initialCount = CoreState.Undo.UndoBuffer.Count;
+            int initialPostion = CoreState.Undo.Postion;
+
+            var vm = new ImageBattleScreenViewModel();
+            vm.LoadEntry();
+            // Inject a writer that immediately fails (no writes).
+            vm.SetWriterOverrideForTests((r, m) => false);
+
+            var undoService = new UndoService();
+            undoService.Begin("test no-write failing write");
+            bool result = vm.Write();
+            undoService.Rollback();
+
+            Assert.False(result);
+            // No spurious Push must happen.
+            Assert.Equal(initialPostion, CoreState.Undo.Postion);
+            Assert.Equal(initialCount, CoreState.Undo.UndoBuffer.Count);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.Undo = prevUndo;
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    static string AxamlPath()
+    {
+        string repoRoot = FindRepoRoot();
+        return Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "ImageBattleScreenView.axaml");
+    }
+
+    static string CodeBehindPath()
+    {
+        string repoRoot = FindRepoRoot();
+        return Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "ImageBattleScreenView.axaml.cs");
+    }
+
+    static string ReadAxaml() => File.ReadAllText(AxamlPath());
+
+    static string FindRepoRoot()
+    {
+        string dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+        if (dir == null)
+            throw new InvalidOperationException("Could not find FEBuilderGBA.sln from test base directory");
+        return dir;
+    }
+
+    /// <summary>
+    /// Build a synthetic FE8U ROM with planted TSA/palette/image pointers
+    /// so the VM Load/Write paths can execute end-to-end.
+    /// </summary>
+    static ROM MakeSyntheticRom()
+    {
+        var rom = new ROM();
+        byte[] data = new byte[0x2000000];
+        // Use Array.Fill for the 32MB free-space init (Copilot bot
+        // PR #594 round 3 finding #2 perf/readability).
+        Array.Fill(data, (byte)0xFF);
+        rom.LoadLow("synth.gba", data, "BE8E01");
+
+        // Plant the 5 TSA pointer slots at arbitrary offsets.
+        WriteU32(rom.Data, rom.RomInfo.battle_screen_TSA1_pointer, U.toPointer(0x100000));
+        WriteU32(rom.Data, rom.RomInfo.battle_screen_TSA2_pointer, U.toPointer(0x101000));
+        WriteU32(rom.Data, rom.RomInfo.battle_screen_TSA3_pointer, U.toPointer(0x102000));
+        WriteU32(rom.Data, rom.RomInfo.battle_screen_TSA4_pointer, U.toPointer(0x103000));
+        WriteU32(rom.Data, rom.RomInfo.battle_screen_TSA5_pointer, U.toPointer(0x104000));
+        WriteU32(rom.Data, rom.RomInfo.battle_screen_palette_pointer, U.toPointer(0x105000));
+        WriteU32(rom.Data, rom.RomInfo.battle_screen_image1_pointer, U.toPointer(0x106000));
+        WriteU32(rom.Data, rom.RomInfo.battle_screen_image2_pointer, U.toPointer(0x107000));
+        WriteU32(rom.Data, rom.RomInfo.battle_screen_image3_pointer, U.toPointer(0x108000));
+        WriteU32(rom.Data, rom.RomInfo.battle_screen_image4_pointer, U.toPointer(0x109000));
+        WriteU32(rom.Data, rom.RomInfo.battle_screen_image5_pointer, U.toPointer(0x10A000));
+
+        // Zero-fill the TSA + palette regions.
+        for (uint i = 0; i < 0x5000; i++) rom.Data[0x100000 + i] = 0;
+        for (uint i = 0; i < 0x80; i++) rom.Data[0x105000 + i] = 0;
+        return rom;
+    }
+
+    static void WriteU32(byte[] data, uint offset, uint value)
+    {
+        data[offset + 0] = (byte)(value & 0xFF);
+        data[offset + 1] = (byte)((value >> 8) & 0xFF);
+        data[offset + 2] = (byte)((value >> 16) & 0xFF);
+        data[offset + 3] = (byte)((value >> 24) & 0xFF);
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageBattleScreenViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageBattleScreenViewModel.cs
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// ImageBattleScreen VM rebuild for #393 gap-sweep parity. Mirrors the WF
+// `ImageBattleScreenForm` battle-screen layout editor.
+//
+// Per Plan v2 + Copilot CLI plan-review round 1:
+//   - Read/Write paths use FEBuilderGBA.Core/ImageBattleScreenCore which
+//     delegates palette work to PaletteCore (Finding #3) and uses the
+//     ambient ROM.BeginUndoScope only (Finding #2 -- no Undo.UndoData
+//     parameter anywhere).
+//   - Image2/4 = Name, Image3/5 = Item per WF designer (Finding #1).
 using System;
 using System.Collections.Generic;
 
@@ -5,29 +15,197 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 {
     public class ImageBattleScreenViewModel : ViewModelBase
     {
-        uint _currentAddr;
+        /// <summary>Total cells in the TSA map (32 * 20 = 640).</summary>
+        public const int MAP_SIZE = ImageBattleScreenCore.MAP_SIZE;
+
+        ushort[] _map = new ushort[MAP_SIZE];
+        uint _tsa1Addr;
+        uint _paletteAddr;
+        int _paletteIndex;
+        int _zoomIndex;
+        uint _image1Pointer;
+        uint _image2Pointer;
+        uint _image3Pointer;
+        uint _image4Pointer;
+        uint _image5Pointer;
         bool _isLoaded;
 
-        public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
+        // 16 R/G/B value cells (0..255) -- packed into BGR15 5-bit channels on write.
+        readonly byte[] _r = new byte[16];
+        readonly byte[] _g = new byte[16];
+        readonly byte[] _b = new byte[16];
+
+        // Test injection point. The override receives (ROM, map) and returns
+        // success/failure. When set, the VM forwards Write() through it
+        // instead of calling ImageBattleScreenCore.WriteBattleScreen directly.
+        Func<ROM, ushort[], bool> _writerOverride;
+
+        public ushort[] Map => _map;
+        /// <summary>Resolved offset of the TSA1 region (top-left corner). Display-only.</summary>
+        public uint TSA1Address { get => _tsa1Addr; set => SetField(ref _tsa1Addr, value); }
+        public uint PaletteAddress { get => _paletteAddr; set => SetField(ref _paletteAddr, value); }
+        public int PaletteIndex { get => _paletteIndex; set => SetField(ref _paletteIndex, value); }
+        public int ZoomIndex { get => _zoomIndex; set => SetField(ref _zoomIndex, value); }
+        public uint Image1Pointer { get => _image1Pointer; set => SetField(ref _image1Pointer, value); }
+        public uint Image2Pointer { get => _image2Pointer; set => SetField(ref _image2Pointer, value); }
+        public uint Image3Pointer { get => _image3Pointer; set => SetField(ref _image3Pointer, value); }
+        public uint Image4Pointer { get => _image4Pointer; set => SetField(ref _image4Pointer, value); }
+        public uint Image5Pointer { get => _image5Pointer; set => SetField(ref _image5Pointer, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
 
+        public byte GetR(int index) => _r[index];
+        public byte GetG(int index) => _g[index];
+        public byte GetB(int index) => _b[index];
+
+        public void SetR(int index, byte value) => _r[index] = ClampToFiveBit(value);
+        public void SetG(int index, byte value) => _g[index] = ClampToFiveBit(value);
+        public void SetB(int index, byte value) => _b[index] = ClampToFiveBit(value);
+
+        static byte ClampToFiveBit(byte value) => (byte)((value >> 3) << 3);
+
+        /// <summary>Test-only writer override.</summary>
+        public void SetWriterOverrideForTests(Func<ROM, ushort[], bool> writer)
+        {
+            _writerOverride = writer;
+        }
+
+        /// <summary>
+        /// Address-list adapter -- returns a single entry representing the
+        /// one battle-screen layout (there's only one per ROM). Lets the
+        /// view's `AddressListControl` participate in the parity gap-sweep.
+        /// </summary>
         public List<AddrResult> LoadList()
         {
-            ROM rom = CoreState.ROM;
-            if (rom?.RomInfo == null) return new List<AddrResult>();
-
             var result = new List<AddrResult>();
-            result.Add(new AddrResult(0, "Battle Screen Layout", 0));
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return result;
+
+            // The "address" is the TSA1 pointer (acts as the canonical
+            // battle-screen identifier -- the editor's top-left corner).
+            uint tsa1 = rom.p32(rom.RomInfo.battle_screen_TSA1_pointer);
+            result.Add(new AddrResult(tsa1, "Battle Screen Layout", 0));
             return result;
         }
 
-        public void LoadEntry(uint addr)
+        /// <summary>
+        /// Load the battle-screen TSA grid + palette block + 5 image pointers
+        /// from CoreState.ROM into the VM properties.
+        /// </summary>
+        public void LoadEntry()
         {
             ROM rom = CoreState.ROM;
-            if (rom == null) return;
+            if (rom?.RomInfo == null) return;
 
-            CurrentAddr = addr;
+            ushort[] map = ImageBattleScreenCore.LoadBattleScreen(rom);
+            if (map != null) _map = map;
+
+            _tsa1Addr = rom.p32(rom.RomInfo.battle_screen_TSA1_pointer);
+            _paletteAddr = rom.p32(rom.RomInfo.battle_screen_palette_pointer);
+
+            var colors = ImageBattleScreenCore.ReadPaletteBlock(rom, _paletteIndex);
+            if (colors != null)
+            {
+                for (int i = 0; i < 16; i++)
+                {
+                    _r[i] = colors[i].r;
+                    _g[i] = colors[i].g;
+                    _b[i] = colors[i].b;
+                }
+            }
+
+            _image1Pointer = ImageBattleScreenCore.ReadImagePointer(rom, rom.RomInfo.battle_screen_image1_pointer);
+            _image2Pointer = ImageBattleScreenCore.ReadImagePointer(rom, rom.RomInfo.battle_screen_image2_pointer);
+            _image3Pointer = ImageBattleScreenCore.ReadImagePointer(rom, rom.RomInfo.battle_screen_image3_pointer);
+            _image4Pointer = ImageBattleScreenCore.ReadImagePointer(rom, rom.RomInfo.battle_screen_image4_pointer);
+            _image5Pointer = ImageBattleScreenCore.ReadImagePointer(rom, rom.RomInfo.battle_screen_image5_pointer);
+
             IsLoaded = true;
+            OnPropertyChanged(nameof(Map));
+            OnPropertyChanged(nameof(TSA1Address));
+            OnPropertyChanged(nameof(PaletteAddress));
+            OnPropertyChanged(nameof(Image1Pointer));
+            OnPropertyChanged(nameof(Image2Pointer));
+            OnPropertyChanged(nameof(Image3Pointer));
+            OnPropertyChanged(nameof(Image4Pointer));
+            OnPropertyChanged(nameof(Image5Pointer));
+        }
+
+        /// <summary>
+        /// Reload ONLY the palette R/G/B rows at the current
+        /// <see cref="PaletteIndex"/>. Does NOT touch the TSA map or the
+        /// 5 image pointers -- this preserves any in-flight image-pointer
+        /// edits when the user switches palette types (Copilot CLI PR
+        /// review round 1 finding #2: WF
+        /// PaletteFormRef.MakePaletteROMToUI only reloads the palette UI
+        /// on palette-index changes, not the image pointer fields).
+        /// </summary>
+        public void LoadPalette()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return;
+
+            var colors = ImageBattleScreenCore.ReadPaletteBlock(rom, _paletteIndex);
+            if (colors != null)
+            {
+                for (int i = 0; i < 16; i++)
+                {
+                    _r[i] = colors[i].r;
+                    _g[i] = colors[i].g;
+                    _b[i] = colors[i].b;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Bulk-write the TSA grid + 5 image pointers to ROM. Caller MUST
+        /// wrap this in <c>UndoService.Begin/Commit/Rollback</c>. Returns
+        /// <c>true</c> on success.
+        /// </summary>
+        public bool Write()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return false;
+
+            bool ok = _writerOverride != null
+                ? _writerOverride(rom, _map)
+                : ImageBattleScreenCore.WriteBattleScreen(rom, _map);
+
+            if (!ok) return false;
+
+            // Image pointer writes are also part of the bulk Write per WF
+            // ImageBattleScreenForm.WriteButton_Click. They run under the
+            // same ambient undo scope so the entire batch is atomic.
+            //
+            // Per Copilot CLI PR #594 round 3: propagate each WriteImagePointer
+            // boolean result. If any of the 5 pointer slot writes fails
+            // bounds validation (slot 0 / NOT_FOUND / out-of-range), return
+            // false so WriteButton_Click rolls back the entire scope rather
+            // than committing a partial write.
+            if (!ImageBattleScreenCore.WriteImagePointer(rom, rom.RomInfo.battle_screen_image1_pointer, _image1Pointer)) return false;
+            if (!ImageBattleScreenCore.WriteImagePointer(rom, rom.RomInfo.battle_screen_image2_pointer, _image2Pointer)) return false;
+            if (!ImageBattleScreenCore.WriteImagePointer(rom, rom.RomInfo.battle_screen_image3_pointer, _image3Pointer)) return false;
+            if (!ImageBattleScreenCore.WriteImagePointer(rom, rom.RomInfo.battle_screen_image4_pointer, _image4Pointer)) return false;
+            if (!ImageBattleScreenCore.WriteImagePointer(rom, rom.RomInfo.battle_screen_image5_pointer, _image5Pointer)) return false;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Write the palette block at <c>PaletteIndex</c> to ROM. Caller
+        /// MUST wrap this in <c>UndoService.Begin/Commit/Rollback</c>.
+        /// Returns <c>true</c> on success.
+        /// </summary>
+        public bool WritePalette()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return false;
+
+            var colors = new (byte r, byte g, byte b)[16];
+            for (int i = 0; i < 16; i++)
+            {
+                colors[i] = (_r[i], _g[i], _b[i]);
+            }
+            return ImageBattleScreenCore.WritePaletteBlock(rom, _paletteIndex, colors);
         }
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml
@@ -32,9 +32,16 @@
                     Name="ZoomCombo" Width="120" VerticalAlignment="Center" SelectedIndex="1"
                     IsEnabled="False"
                     ToolTip.Tip="KnownGap: zoom only affects the deferred Battle/Chipset preview rendering (WinForms-coupled, #393). Re-enabled once the live preview lands." />
-          <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_TSAInfo_Label"
-                     Name="TSAInfoLabel" VerticalAlignment="Center"
-                     Margin="20,0,0,0" Foreground="DarkGray" />
+          <!-- TSAInfo split into separate TextBlocks so each fragment goes
+               through ViewTranslationHelper independently (a composite
+               'Selected: 00   Canvas:' string has no translation entry).
+               Per Copilot bot PR #594 round 5 thread #1. -->
+          <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_TSAInfoSelected_Label"
+                     Name="TSAInfoSelectedLabel" Text="Selected: 00"
+                     VerticalAlignment="Center" Margin="20,0,0,0" Foreground="DarkGray" />
+          <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_TSAInfoCanvas_Label"
+                     Name="TSAInfoCanvasLabel" Text="Canvas:"
+                     VerticalAlignment="Center" Margin="12,0,0,0" Foreground="DarkGray" />
         </StackPanel>
       </Border>
 

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml
@@ -5,17 +5,480 @@
         Title="Battle Screen Layout" Width="1411" Height="939"
         SizeToContent="WidthAndHeight">
   <Grid ColumnDefinitions="250,*">
-    <controls:AddressListControl AutomationProperties.AutomationId="ImageBattleScreen_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
 
-    <ScrollViewer Grid.Column="1" Margin="4">
-      <StackPanel Spacing="8" Margin="8">
-        <TextBlock Text="Battle Screen Layout" FontSize="18" FontWeight="Bold" />
+    <!-- ===========================================================
+         Master list panel (mirrors WF entry navigation - single
+         battle-screen entry per ROM).
+         =========================================================== -->
+    <Grid Grid.Column="0" RowDefinitions="Auto,*" Margin="4">
+      <TextBlock Grid.Row="0" Text="Battle Screen" FontWeight="SemiBold" Margin="0,0,0,4" />
+      <controls:AddressListControl AutomationProperties.AutomationId="ImageBattleScreen_Entry_List"
+                                   Grid.Row="1" Name="EntryList" Margin="0,0,0,4" />
+    </Grid>
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
-        </Grid>
-      </StackPanel>
-    </ScrollViewer>
+    <Grid Grid.Column="1" RowDefinitions="Auto,Auto,Auto,*" Margin="4">
+
+      <!-- ===========================================================
+           Top toolbar: AllWrite button + Zoom combo + TSA info label.
+           Mirrors WF AllWriteButton + Zoom + TSAInfo.
+           =========================================================== -->
+      <Border Grid.Row="0" BorderBrush="Gray" BorderThickness="1" Padding="4" Margin="0,0,0,4">
+        <StackPanel Orientation="Horizontal" Spacing="6">
+          <Button AutomationProperties.AutomationId="ImageBattleScreen_AllWrite_Button"
+                  Name="WriteButton" Content="Write" Width="140"
+                  Click="WriteButton_Click" />
+          <TextBlock Text="Zoom" VerticalAlignment="Center" Width="50" />
+          <ComboBox AutomationProperties.AutomationId="ImageBattleScreen_Zoom_Combo"
+                    Name="ZoomCombo" Width="120" VerticalAlignment="Center" SelectedIndex="1"
+                    IsEnabled="False"
+                    ToolTip.Tip="KnownGap: zoom only affects the deferred Battle/Chipset preview rendering (WinForms-coupled, #393). Re-enabled once the live preview lands." />
+          <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_TSAInfo_Label"
+                     Name="TSAInfoLabel" VerticalAlignment="Center"
+                     Margin="20,0,0,0" Foreground="DarkGray" />
+        </StackPanel>
+      </Border>
+
+      <!-- ===========================================================
+           Battle preview row (mirrors WF panel1 chipset + Battle preview).
+           Both are WF-coupled (live LZ77 decode + per-tile palette blit
+           requires System.Drawing + ImageUtil.BitBlt). Honestly deferred
+           with KnownGap placeholder labels (#393).
+           =========================================================== -->
+      <Border Grid.Row="1" BorderBrush="Gray" BorderThickness="1" Padding="4" Margin="0,0,0,4"
+              MinHeight="80">
+        <StackPanel Orientation="Horizontal" Spacing="6">
+          <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_ChipsetPreview_Label"
+                     Name="ChipsetPreviewLabel"
+                     Text="Chipset Preview (deferred KnownGap): live LZ77 decode + flip permutations are WinForms-coupled (ImageUtil.BitBlt). Use the WinForms editor to paint TSA cells."
+                     TextWrapping="Wrap" Foreground="Gray" Width="280" VerticalAlignment="Center"
+                     ToolTip.Tip="KnownGap: chipset thumbnail rendering is WinForms-coupled (#393)." />
+          <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_BattlePreview_Label"
+                     Name="BattlePreviewLabel"
+                     Text="Battle Preview (deferred KnownGap): rendering the 32x20 TSA grid with the live palette requires System.Drawing + ImageUtil.BitBlt. The numeric fields and palette/image pointer write paths in this editor are functional under the ambient undo scope."
+                     TextWrapping="Wrap" Foreground="Gray" Width="600" VerticalAlignment="Center"
+                     ToolTip.Tip="KnownGap: battle-screen bitmap rendering is WinForms-coupled (#393)." />
+        </StackPanel>
+      </Border>
+
+      <!-- ===========================================================
+           Address bar (mirrors WF AllWriteButton context).
+           =========================================================== -->
+      <Border Grid.Row="2" BorderBrush="Gray" BorderThickness="1" Padding="4" Margin="0,0,0,4">
+        <StackPanel Orientation="Horizontal" Spacing="6">
+          <TextBlock Text="TSA1 Address" VerticalAlignment="Center" Width="100" />
+          <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_Addr_Label"
+                     Name="AddrLabel" Text="0x00000000" VerticalAlignment="Center" />
+        </StackPanel>
+      </Border>
+
+      <!-- ===========================================================
+           Tab control (mirrors WF tabControl1 + 5 tabPages).
+           =========================================================== -->
+      <TabControl AutomationProperties.AutomationId="ImageBattleScreen_Tabs_TabControl"
+                  Grid.Row="3" Margin="0,0,0,4">
+
+        <!-- Tab 1: Palette -->
+        <TabItem AutomationProperties.AutomationId="ImageBattleScreen_PaletteTab_Tab"
+                 Header="Palette">
+          <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+            <StackPanel Margin="8" Spacing="6">
+
+              <!-- Palette toolbar -->
+              <StackPanel Orientation="Horizontal" Spacing="6">
+                <TextBlock Text="Palette Address" VerticalAlignment="Center" Width="120" />
+                <NumericUpDown AutomationProperties.AutomationId="ImageBattleScreen_PaletteAddress_Input"
+                               Name="PaletteAddressBox" Width="160" Minimum="0" Maximum="4294967295"
+                               FormatString="0" VerticalAlignment="Center" IsReadOnly="True" />
+                <TextBlock Text="Palette Type" VerticalAlignment="Center" Width="100" Margin="20,0,0,0" />
+                <ComboBox AutomationProperties.AutomationId="ImageBattleScreen_PaletteIndex_Combo"
+                          Name="PaletteIndexCombo" Width="120" VerticalAlignment="Center" SelectedIndex="0"
+                          SelectionChanged="PaletteIndex_SelectionChanged" />
+                <Button AutomationProperties.AutomationId="ImageBattleScreen_PaletteWrite_Button"
+                        Name="PaletteWriteButton" Content="Palette Write" Width="140"
+                        Click="PaletteWrite_Click" />
+                <Button AutomationProperties.AutomationId="ImageBattleScreen_PaletteClipboard_Button"
+                        Name="PaletteClipboardButton" Content="Clipboard" Width="120"
+                        Click="PaletteClipboard_Click" />
+                <Button AutomationProperties.AutomationId="ImageBattleScreen_PaletteUndo_Button"
+                        Name="PaletteUndoButton" Content="Undo" Width="100"
+                        Click="PaletteUndo_Click" />
+                <Button AutomationProperties.AutomationId="ImageBattleScreen_PaletteRedo_Button"
+                        Name="PaletteRedoButton" Content="Redo" Width="100"
+                        IsEnabled="False"
+                        ToolTip.Tip="KnownGap: local palette-edit redo (PaletteFormRef redo buffer) is WinForms-coupled (#393). Use the main ROM-level Undo via the toolbar." />
+              </StackPanel>
+
+              <!-- RGB header row -->
+              <Grid Margin="0,0,0,2">
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition Width="36" />
+                  <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" Orientation="Vertical" Spacing="0">
+                  <TextBlock Text=" " Height="36" />
+                  <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_RHeader_Label"
+                             Text="R" Width="20" Height="28" TextAlignment="Center" />
+                  <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_GHeader_Label"
+                             Text="G" Width="20" Height="28" TextAlignment="Center" />
+                  <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_BHeader_Label"
+                             Text="B" Width="20" Height="28" TextAlignment="Center" />
+                </StackPanel>
+              </Grid>
+
+              <!-- 16-column palette grid (Swatch + Index + R/G/B) -->
+              <Grid Name="PaletteGrid">
+                <Grid.RowDefinitions>
+                  <RowDefinition Height="36" />
+                  <RowDefinition Height="32" />
+                  <RowDefinition Height="32" />
+                  <RowDefinition Height="32" />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition Width="60" />
+                  <ColumnDefinition Width="60" />
+                  <ColumnDefinition Width="60" />
+                  <ColumnDefinition Width="60" />
+                  <ColumnDefinition Width="60" />
+                  <ColumnDefinition Width="60" />
+                  <ColumnDefinition Width="60" />
+                  <ColumnDefinition Width="60" />
+                  <ColumnDefinition Width="60" />
+                  <ColumnDefinition Width="60" />
+                  <ColumnDefinition Width="60" />
+                  <ColumnDefinition Width="60" />
+                  <ColumnDefinition Width="60" />
+                  <ColumnDefinition Width="60" />
+                  <ColumnDefinition Width="60" />
+                  <ColumnDefinition Width="60" />
+                </Grid.ColumnDefinitions>
+
+                <!-- Column 1 -->
+                <Border Grid.Row="0" Grid.Column="0" Name="Swatch1" Margin="2"
+                        AutomationProperties.AutomationId="ImageBattleScreen_Swatch1_Label" />
+                <TextBlock Grid.Row="0" Grid.Column="0" Text="1" TextAlignment="Center" VerticalAlignment="Bottom"
+                           AutomationProperties.AutomationId="ImageBattleScreen_Index1_Label" />
+                <NumericUpDown Grid.Row="1" Grid.Column="0" Name="R1" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_R1_Input" />
+                <NumericUpDown Grid.Row="2" Grid.Column="0" Name="G1" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_G1_Input" />
+                <NumericUpDown Grid.Row="3" Grid.Column="0" Name="B1" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_B1_Input" />
+                <!-- Column 2 -->
+                <Border Grid.Row="0" Grid.Column="1" Name="Swatch2" Margin="2"
+                        AutomationProperties.AutomationId="ImageBattleScreen_Swatch2_Label" />
+                <TextBlock Grid.Row="0" Grid.Column="1" Text="2" TextAlignment="Center" VerticalAlignment="Bottom"
+                           AutomationProperties.AutomationId="ImageBattleScreen_Index2_Label" />
+                <NumericUpDown Grid.Row="1" Grid.Column="1" Name="R2" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_R2_Input" />
+                <NumericUpDown Grid.Row="2" Grid.Column="1" Name="G2" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_G2_Input" />
+                <NumericUpDown Grid.Row="3" Grid.Column="1" Name="B2" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_B2_Input" />
+                <!-- Column 3 -->
+                <Border Grid.Row="0" Grid.Column="2" Name="Swatch3" Margin="2"
+                        AutomationProperties.AutomationId="ImageBattleScreen_Swatch3_Label" />
+                <TextBlock Grid.Row="0" Grid.Column="2" Text="3" TextAlignment="Center" VerticalAlignment="Bottom"
+                           AutomationProperties.AutomationId="ImageBattleScreen_Index3_Label" />
+                <NumericUpDown Grid.Row="1" Grid.Column="2" Name="R3" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_R3_Input" />
+                <NumericUpDown Grid.Row="2" Grid.Column="2" Name="G3" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_G3_Input" />
+                <NumericUpDown Grid.Row="3" Grid.Column="2" Name="B3" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_B3_Input" />
+                <!-- Column 4 -->
+                <Border Grid.Row="0" Grid.Column="3" Name="Swatch4" Margin="2"
+                        AutomationProperties.AutomationId="ImageBattleScreen_Swatch4_Label" />
+                <TextBlock Grid.Row="0" Grid.Column="3" Text="4" TextAlignment="Center" VerticalAlignment="Bottom"
+                           AutomationProperties.AutomationId="ImageBattleScreen_Index4_Label" />
+                <NumericUpDown Grid.Row="1" Grid.Column="3" Name="R4" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_R4_Input" />
+                <NumericUpDown Grid.Row="2" Grid.Column="3" Name="G4" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_G4_Input" />
+                <NumericUpDown Grid.Row="3" Grid.Column="3" Name="B4" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_B4_Input" />
+                <!-- Column 5 -->
+                <Border Grid.Row="0" Grid.Column="4" Name="Swatch5" Margin="2"
+                        AutomationProperties.AutomationId="ImageBattleScreen_Swatch5_Label" />
+                <TextBlock Grid.Row="0" Grid.Column="4" Text="5" TextAlignment="Center" VerticalAlignment="Bottom"
+                           AutomationProperties.AutomationId="ImageBattleScreen_Index5_Label" />
+                <NumericUpDown Grid.Row="1" Grid.Column="4" Name="R5" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_R5_Input" />
+                <NumericUpDown Grid.Row="2" Grid.Column="4" Name="G5" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_G5_Input" />
+                <NumericUpDown Grid.Row="3" Grid.Column="4" Name="B5" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_B5_Input" />
+                <!-- Column 6 -->
+                <Border Grid.Row="0" Grid.Column="5" Name="Swatch6" Margin="2"
+                        AutomationProperties.AutomationId="ImageBattleScreen_Swatch6_Label" />
+                <TextBlock Grid.Row="0" Grid.Column="5" Text="6" TextAlignment="Center" VerticalAlignment="Bottom"
+                           AutomationProperties.AutomationId="ImageBattleScreen_Index6_Label" />
+                <NumericUpDown Grid.Row="1" Grid.Column="5" Name="R6" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_R6_Input" />
+                <NumericUpDown Grid.Row="2" Grid.Column="5" Name="G6" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_G6_Input" />
+                <NumericUpDown Grid.Row="3" Grid.Column="5" Name="B6" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_B6_Input" />
+                <!-- Column 7 -->
+                <Border Grid.Row="0" Grid.Column="6" Name="Swatch7" Margin="2"
+                        AutomationProperties.AutomationId="ImageBattleScreen_Swatch7_Label" />
+                <TextBlock Grid.Row="0" Grid.Column="6" Text="7" TextAlignment="Center" VerticalAlignment="Bottom"
+                           AutomationProperties.AutomationId="ImageBattleScreen_Index7_Label" />
+                <NumericUpDown Grid.Row="1" Grid.Column="6" Name="R7" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_R7_Input" />
+                <NumericUpDown Grid.Row="2" Grid.Column="6" Name="G7" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_G7_Input" />
+                <NumericUpDown Grid.Row="3" Grid.Column="6" Name="B7" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_B7_Input" />
+                <!-- Column 8 -->
+                <Border Grid.Row="0" Grid.Column="7" Name="Swatch8" Margin="2"
+                        AutomationProperties.AutomationId="ImageBattleScreen_Swatch8_Label" />
+                <TextBlock Grid.Row="0" Grid.Column="7" Text="8" TextAlignment="Center" VerticalAlignment="Bottom"
+                           AutomationProperties.AutomationId="ImageBattleScreen_Index8_Label" />
+                <NumericUpDown Grid.Row="1" Grid.Column="7" Name="R8" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_R8_Input" />
+                <NumericUpDown Grid.Row="2" Grid.Column="7" Name="G8" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_G8_Input" />
+                <NumericUpDown Grid.Row="3" Grid.Column="7" Name="B8" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_B8_Input" />
+                <!-- Column 9 -->
+                <Border Grid.Row="0" Grid.Column="8" Name="Swatch9" Margin="2"
+                        AutomationProperties.AutomationId="ImageBattleScreen_Swatch9_Label" />
+                <TextBlock Grid.Row="0" Grid.Column="8" Text="9" TextAlignment="Center" VerticalAlignment="Bottom"
+                           AutomationProperties.AutomationId="ImageBattleScreen_Index9_Label" />
+                <NumericUpDown Grid.Row="1" Grid.Column="8" Name="R9" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_R9_Input" />
+                <NumericUpDown Grid.Row="2" Grid.Column="8" Name="G9" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_G9_Input" />
+                <NumericUpDown Grid.Row="3" Grid.Column="8" Name="B9" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_B9_Input" />
+                <!-- Column 10 -->
+                <Border Grid.Row="0" Grid.Column="9" Name="Swatch10" Margin="2"
+                        AutomationProperties.AutomationId="ImageBattleScreen_Swatch10_Label" />
+                <TextBlock Grid.Row="0" Grid.Column="9" Text="10" TextAlignment="Center" VerticalAlignment="Bottom"
+                           AutomationProperties.AutomationId="ImageBattleScreen_Index10_Label" />
+                <NumericUpDown Grid.Row="1" Grid.Column="9" Name="R10" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_R10_Input" />
+                <NumericUpDown Grid.Row="2" Grid.Column="9" Name="G10" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_G10_Input" />
+                <NumericUpDown Grid.Row="3" Grid.Column="9" Name="B10" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_B10_Input" />
+                <!-- Column 11 -->
+                <Border Grid.Row="0" Grid.Column="10" Name="Swatch11" Margin="2"
+                        AutomationProperties.AutomationId="ImageBattleScreen_Swatch11_Label" />
+                <TextBlock Grid.Row="0" Grid.Column="10" Text="11" TextAlignment="Center" VerticalAlignment="Bottom"
+                           AutomationProperties.AutomationId="ImageBattleScreen_Index11_Label" />
+                <NumericUpDown Grid.Row="1" Grid.Column="10" Name="R11" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_R11_Input" />
+                <NumericUpDown Grid.Row="2" Grid.Column="10" Name="G11" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_G11_Input" />
+                <NumericUpDown Grid.Row="3" Grid.Column="10" Name="B11" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_B11_Input" />
+                <!-- Column 12 -->
+                <Border Grid.Row="0" Grid.Column="11" Name="Swatch12" Margin="2"
+                        AutomationProperties.AutomationId="ImageBattleScreen_Swatch12_Label" />
+                <TextBlock Grid.Row="0" Grid.Column="11" Text="12" TextAlignment="Center" VerticalAlignment="Bottom"
+                           AutomationProperties.AutomationId="ImageBattleScreen_Index12_Label" />
+                <NumericUpDown Grid.Row="1" Grid.Column="11" Name="R12" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_R12_Input" />
+                <NumericUpDown Grid.Row="2" Grid.Column="11" Name="G12" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_G12_Input" />
+                <NumericUpDown Grid.Row="3" Grid.Column="11" Name="B12" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_B12_Input" />
+                <!-- Column 13 -->
+                <Border Grid.Row="0" Grid.Column="12" Name="Swatch13" Margin="2"
+                        AutomationProperties.AutomationId="ImageBattleScreen_Swatch13_Label" />
+                <TextBlock Grid.Row="0" Grid.Column="12" Text="13" TextAlignment="Center" VerticalAlignment="Bottom"
+                           AutomationProperties.AutomationId="ImageBattleScreen_Index13_Label" />
+                <NumericUpDown Grid.Row="1" Grid.Column="12" Name="R13" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_R13_Input" />
+                <NumericUpDown Grid.Row="2" Grid.Column="12" Name="G13" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_G13_Input" />
+                <NumericUpDown Grid.Row="3" Grid.Column="12" Name="B13" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_B13_Input" />
+                <!-- Column 14 -->
+                <Border Grid.Row="0" Grid.Column="13" Name="Swatch14" Margin="2"
+                        AutomationProperties.AutomationId="ImageBattleScreen_Swatch14_Label" />
+                <TextBlock Grid.Row="0" Grid.Column="13" Text="14" TextAlignment="Center" VerticalAlignment="Bottom"
+                           AutomationProperties.AutomationId="ImageBattleScreen_Index14_Label" />
+                <NumericUpDown Grid.Row="1" Grid.Column="13" Name="R14" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_R14_Input" />
+                <NumericUpDown Grid.Row="2" Grid.Column="13" Name="G14" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_G14_Input" />
+                <NumericUpDown Grid.Row="3" Grid.Column="13" Name="B14" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_B14_Input" />
+                <!-- Column 15 -->
+                <Border Grid.Row="0" Grid.Column="14" Name="Swatch15" Margin="2"
+                        AutomationProperties.AutomationId="ImageBattleScreen_Swatch15_Label" />
+                <TextBlock Grid.Row="0" Grid.Column="14" Text="15" TextAlignment="Center" VerticalAlignment="Bottom"
+                           AutomationProperties.AutomationId="ImageBattleScreen_Index15_Label" />
+                <NumericUpDown Grid.Row="1" Grid.Column="14" Name="R15" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_R15_Input" />
+                <NumericUpDown Grid.Row="2" Grid.Column="14" Name="G15" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_G15_Input" />
+                <NumericUpDown Grid.Row="3" Grid.Column="14" Name="B15" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_B15_Input" />
+                <!-- Column 16 -->
+                <Border Grid.Row="0" Grid.Column="15" Name="Swatch16" Margin="2"
+                        AutomationProperties.AutomationId="ImageBattleScreen_Swatch16_Label" />
+                <TextBlock Grid.Row="0" Grid.Column="15" Text="16" TextAlignment="Center" VerticalAlignment="Bottom"
+                           AutomationProperties.AutomationId="ImageBattleScreen_Index16_Label" />
+                <NumericUpDown Grid.Row="1" Grid.Column="15" Name="R16" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_R16_Input" />
+                <NumericUpDown Grid.Row="2" Grid.Column="15" Name="G16" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_G16_Input" />
+                <NumericUpDown Grid.Row="3" Grid.Column="15" Name="B16" Minimum="0" Maximum="255" Increment="8" Margin="2" FormatString="0"
+                               AutomationProperties.AutomationId="ImageBattleScreen_B16_Input" />
+              </Grid>
+            </StackPanel>
+          </ScrollViewer>
+        </TabItem>
+
+        <!-- Tab 2: Main Image -->
+        <TabItem AutomationProperties.AutomationId="ImageBattleScreen_MainImageTab_Tab"
+                 Header="Main Image">
+          <StackPanel Margin="8" Spacing="6">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+              <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_Tile1_Label"
+                         Text="Tile1" Width="60" VerticalAlignment="Center" />
+              <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_Tile2_Label"
+                         Text="Tile2" Width="60" VerticalAlignment="Center" />
+              <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_Tile3_Label"
+                         Text="Tile3" Width="60" VerticalAlignment="Center" />
+              <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_Tile4_Label"
+                         Text="Tile4" Width="60" VerticalAlignment="Center" />
+              <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_Tile5_Label"
+                         Text="Tile5" Width="60" VerticalAlignment="Center" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Spacing="6">
+              <TextBlock Text="Image" Width="60" VerticalAlignment="Center" />
+              <NumericUpDown AutomationProperties.AutomationId="ImageBattleScreen_Image1_ZIMAGE_Input"
+                             Name="Image1ZImage" Width="160" Minimum="0" Maximum="4294967295"
+                             FormatString="0" VerticalAlignment="Center" />
+              <Button AutomationProperties.AutomationId="ImageBattleScreen_Image1_Import_Button"
+                      Content="Image Import" Width="140" IsEnabled="False"
+                      ToolTip.Tip="KnownGap: per-image LZ77 Import (ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByte16Tile) is WinForms-coupled (#393)." />
+              <Button AutomationProperties.AutomationId="ImageBattleScreen_Image1_Export_Button"
+                      Content="Image Export" Width="140" IsEnabled="False"
+                      ToolTip.Tip="KnownGap: per-image PNG Export (ImageFormRef.ExportImage) is WinForms-coupled (#393)." />
+            </StackPanel>
+            <Border BorderBrush="Gray" BorderThickness="1" Padding="8" MinHeight="60">
+              <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_Image1_Preview_Label"
+                         Text="Image1 Preview (deferred KnownGap): per-tile LZ77 decompress + palette blit is WinForms-coupled (#393)."
+                         TextWrapping="Wrap" Foreground="Gray" VerticalAlignment="Center" />
+            </Border>
+          </StackPanel>
+        </TabItem>
+
+        <!-- Tab 3: Left Side (image2 = Name, image3 = Item per WF designer) -->
+        <TabItem AutomationProperties.AutomationId="ImageBattleScreen_LeftSideTab_Tab"
+                 Header="Left Side">
+          <StackPanel Margin="8" Spacing="6">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+              <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_Image2_Name_Label"
+                         Text="Name" Width="80" VerticalAlignment="Center" HorizontalAlignment="Center"
+                         TextAlignment="Center" />
+              <NumericUpDown AutomationProperties.AutomationId="ImageBattleScreen_Image2_ZIMAGE_Input"
+                             Name="Image2ZImage" Width="160" Minimum="0" Maximum="4294967295"
+                             FormatString="0" VerticalAlignment="Center" />
+              <Button AutomationProperties.AutomationId="ImageBattleScreen_Image2_Import_Button"
+                      Content="Image Import" Width="140" IsEnabled="False"
+                      ToolTip.Tip="KnownGap: per-image LZ77 Import is WinForms-coupled (#393)." />
+              <Button AutomationProperties.AutomationId="ImageBattleScreen_Image2_Export_Button"
+                      Content="Image Export" Width="140" IsEnabled="False"
+                      ToolTip.Tip="KnownGap: per-image PNG Export is WinForms-coupled (#393)." />
+              <Border BorderBrush="Gray" BorderThickness="1" Padding="4" MinHeight="40" Width="200">
+                <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_Image2_Preview_Label"
+                           Text="Image2 Preview (deferred)" Foreground="Gray" VerticalAlignment="Center" />
+              </Border>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Spacing="6">
+              <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_Image3_Item_Label"
+                         Text="Item" Width="80" VerticalAlignment="Center" HorizontalAlignment="Center"
+                         TextAlignment="Center" />
+              <NumericUpDown AutomationProperties.AutomationId="ImageBattleScreen_Image3_ZIMAGE_Input"
+                             Name="Image3ZImage" Width="160" Minimum="0" Maximum="4294967295"
+                             FormatString="0" VerticalAlignment="Center" />
+              <Button AutomationProperties.AutomationId="ImageBattleScreen_Image3_Import_Button"
+                      Content="Image Import" Width="140" IsEnabled="False"
+                      ToolTip.Tip="KnownGap: per-image LZ77 Import is WinForms-coupled (#393)." />
+              <Button AutomationProperties.AutomationId="ImageBattleScreen_Image3_Export_Button"
+                      Content="Image Export" Width="140" IsEnabled="False"
+                      ToolTip.Tip="KnownGap: per-image PNG Export is WinForms-coupled (#393)." />
+              <Border BorderBrush="Gray" BorderThickness="1" Padding="4" MinHeight="40" Width="200">
+                <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_Image3_Preview_Label"
+                           Text="Image3 Preview (deferred)" Foreground="Gray" VerticalAlignment="Center" />
+              </Border>
+            </StackPanel>
+          </StackPanel>
+        </TabItem>
+
+        <!-- Tab 4: Right Side (image4 = Name, image5 = Item per WF designer) -->
+        <TabItem AutomationProperties.AutomationId="ImageBattleScreen_RightSideTab_Tab"
+                 Header="Right Side">
+          <StackPanel Margin="8" Spacing="6">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+              <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_Image4_Name_Label"
+                         Text="Name" Width="80" VerticalAlignment="Center" HorizontalAlignment="Center"
+                         TextAlignment="Center" />
+              <NumericUpDown AutomationProperties.AutomationId="ImageBattleScreen_Image4_ZIMAGE_Input"
+                             Name="Image4ZImage" Width="160" Minimum="0" Maximum="4294967295"
+                             FormatString="0" VerticalAlignment="Center" />
+              <Button AutomationProperties.AutomationId="ImageBattleScreen_Image4_Import_Button"
+                      Content="Image Import" Width="140" IsEnabled="False"
+                      ToolTip.Tip="KnownGap: per-image LZ77 Import is WinForms-coupled (#393)." />
+              <Button AutomationProperties.AutomationId="ImageBattleScreen_Image4_Export_Button"
+                      Content="Image Export" Width="140" IsEnabled="False"
+                      ToolTip.Tip="KnownGap: per-image PNG Export is WinForms-coupled (#393)." />
+              <Border BorderBrush="Gray" BorderThickness="1" Padding="4" MinHeight="40" Width="200">
+                <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_Image4_Preview_Label"
+                           Text="Image4 Preview (deferred)" Foreground="Gray" VerticalAlignment="Center" />
+              </Border>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Spacing="6">
+              <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_Image5_Item_Label"
+                         Text="Item" Width="80" VerticalAlignment="Center" HorizontalAlignment="Center"
+                         TextAlignment="Center" />
+              <NumericUpDown AutomationProperties.AutomationId="ImageBattleScreen_Image5_ZIMAGE_Input"
+                             Name="Image5ZImage" Width="160" Minimum="0" Maximum="4294967295"
+                             FormatString="0" VerticalAlignment="Center" />
+              <Button AutomationProperties.AutomationId="ImageBattleScreen_Image5_Import_Button"
+                      Content="Image Import" Width="140" IsEnabled="False"
+                      ToolTip.Tip="KnownGap: per-image LZ77 Import is WinForms-coupled (#393)." />
+              <Button AutomationProperties.AutomationId="ImageBattleScreen_Image5_Export_Button"
+                      Content="Image Export" Width="140" IsEnabled="False"
+                      ToolTip.Tip="KnownGap: per-image PNG Export is WinForms-coupled (#393)." />
+              <Border BorderBrush="Gray" BorderThickness="1" Padding="4" MinHeight="40" Width="200">
+                <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_Image5_Preview_Label"
+                           Text="Image5 Preview (deferred)" Foreground="Gray" VerticalAlignment="Center" />
+              </Border>
+            </StackPanel>
+          </StackPanel>
+        </TabItem>
+
+        <!-- Tab 5: Import/Export (bulk) -->
+        <TabItem AutomationProperties.AutomationId="ImageBattleScreen_ImportExportTab_Tab"
+                 Header="Import/Export">
+          <StackPanel Margin="8" Spacing="6">
+            <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_BulkDescription_Label"
+                       Text="Bulk import/export the battle screen as a single image. TSA layout means common tiles must be deduplicated."
+                       TextWrapping="Wrap" />
+            <StackPanel Orientation="Horizontal" Spacing="6">
+              <Button AutomationProperties.AutomationId="ImageBattleScreen_BulkImport_Button"
+                      Content="Image Import" Width="160" IsEnabled="False"
+                      ToolTip.Tip="KnownGap: bulk image Import requires ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByteKeepTSA (WinForms-coupled, #393)." />
+              <Button AutomationProperties.AutomationId="ImageBattleScreen_BulkExport_Button"
+                      Content="Image Export" Width="160" IsEnabled="False"
+                      ToolTip.Tip="KnownGap: bulk image Export requires ImageFormRef.ExportImage + live battle-screen bitmap (WinForms-coupled, #393)." />
+              <Button AutomationProperties.AutomationId="ImageBattleScreen_BulkUndo_Button"
+                      Content="Undo" Width="100"
+                      Click="BulkUndo_Click" />
+              <Button AutomationProperties.AutomationId="ImageBattleScreen_BulkRedo_Button"
+                      Content="Redo" Width="100" IsEnabled="False"
+                      ToolTip.Tip="KnownGap: local TSA redo buffer is WinForms-coupled. Use the main ROM-level Undo via the toolbar (#393)." />
+            </StackPanel>
+          </StackPanel>
+        </TabItem>
+      </TabControl>
+    </Grid>
   </Grid>
 </Window>

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml.cs
@@ -1,6 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// ImageBattleScreenView -- Avalonia parity rebuild for #393. Mirrors the WF
+// `ImageBattleScreenForm` 5-tab battle-screen layout editor. Uses the
+// `ImageBattleScreenCore` helper (which delegates palette I/O to PaletteCore)
+// for the TSA + palette + image-pointer write paths under the ambient
+// UndoService scope.
 using System;
+using System.Globalization;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
+using global::Avalonia.Media;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 
@@ -9,15 +17,146 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class ImageBattleScreenView : TranslatedWindow, IEditorView
     {
         readonly ImageBattleScreenViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         public string ViewTitle => "Battle Screen Layout";
         public bool IsLoaded => _vm.IsLoaded;
 
+        // Cached references to the 48 numeric cells + 16 swatch borders so
+        // we don't have to walk the visual tree on every reload.
+        readonly NumericUpDown[] _rBoxes = new NumericUpDown[16];
+        readonly NumericUpDown[] _gBoxes = new NumericUpDown[16];
+        readonly NumericUpDown[] _bBoxes = new NumericUpDown[16];
+        readonly Border[] _swatchBoxes = new Border[16];
+
+        bool _suppressSpinnerEvents;
+
         public ImageBattleScreenView()
         {
             InitializeComponent();
+
+            // Populate combos via R._() so they pick up ja/zh translations.
+            PaletteIndexCombo.Items.Add(R._("Palette 1"));
+            PaletteIndexCombo.Items.Add(R._("Palette 2"));
+            PaletteIndexCombo.Items.Add(R._("Palette 3"));
+            PaletteIndexCombo.Items.Add(R._("Palette 4"));
+            PaletteIndexCombo.SelectedIndex = 0;
+
+            ZoomCombo.Items.Add(R._("1x Zoom"));
+            ZoomCombo.Items.Add(R._("2x Zoom"));
+            ZoomCombo.Items.Add(R._("3x Zoom"));
+            ZoomCombo.Items.Add(R._("4x Zoom"));
+            ZoomCombo.SelectedIndex = 1;
+
+            CachePaletteCells();
+            InitializeSwatches();
+            WireSpinnerHandlers();
+
+            // Default TSA info text. Set via code-behind so the translation
+            // chain picks it up (see PR #589 ComboBoxItem.Content pattern
+            // -- ViewTranslationHelper does not touch dynamic Text values
+            // populated from code, so we feed it through R._() ourselves).
+            TSAInfoLabel.Text = R._("Selected: 00") + "   " + R._("Canvas:");
+
             EntryList.SelectedAddressChanged += OnSelected;
             Opened += (_, _) => LoadList();
+        }
+
+        void CachePaletteCells()
+        {
+            for (int i = 0; i < 16; i++)
+            {
+                int n = i + 1;
+                _rBoxes[i] = this.FindControl<NumericUpDown>($"R{n}");
+                _gBoxes[i] = this.FindControl<NumericUpDown>($"G{n}");
+                _bBoxes[i] = this.FindControl<NumericUpDown>($"B{n}");
+                _swatchBoxes[i] = this.FindControl<Border>($"Swatch{n}");
+            }
+        }
+
+        void InitializeSwatches()
+        {
+            var defaultBrush = new SolidColorBrush(Color.FromRgb(0, 0, 0));
+            for (int i = 0; i < 16; i++)
+            {
+                if (_swatchBoxes[i] != null) _swatchBoxes[i].Background = defaultBrush;
+            }
+        }
+
+        void WireSpinnerHandlers()
+        {
+            for (int i = 0; i < 16; i++)
+            {
+                int idx = i;
+                if (_rBoxes[i] != null) _rBoxes[i].ValueChanged += (s, e) => OnRgbChanged(idx, 'R');
+                if (_gBoxes[i] != null) _gBoxes[i].ValueChanged += (s, e) => OnRgbChanged(idx, 'G');
+                if (_bBoxes[i] != null) _bBoxes[i].ValueChanged += (s, e) => OnRgbChanged(idx, 'B');
+            }
+        }
+
+        void OnRgbChanged(int index, char channel)
+        {
+            if (_suppressSpinnerEvents) return;
+            NumericUpDown box = channel == 'R' ? _rBoxes[index]
+                              : channel == 'G' ? _gBoxes[index]
+                              : _bBoxes[index];
+            if (box == null) return;
+            byte rawValue = (byte)((int)(box.Value ?? 0));
+            switch (channel)
+            {
+                case 'R': _vm.SetR(index, rawValue); break;
+                case 'G': _vm.SetG(index, rawValue); break;
+                case 'B': _vm.SetB(index, rawValue); break;
+            }
+            // Snap to 5-bit (multiples of 8); push snapped value back.
+            byte snappedValue = channel == 'R' ? _vm.GetR(index)
+                              : channel == 'G' ? _vm.GetG(index)
+                              : _vm.GetB(index);
+            if (rawValue != snappedValue)
+            {
+                _suppressSpinnerEvents = true;
+                try { box.Value = snappedValue; }
+                finally { _suppressSpinnerEvents = false; }
+            }
+            UpdateSwatch(index);
+        }
+
+        void UpdateSwatch(int index)
+        {
+            if (_swatchBoxes[index] == null) return;
+            byte r = _vm.GetR(index);
+            byte g = _vm.GetG(index);
+            byte b = _vm.GetB(index);
+            _swatchBoxes[index].Background = new SolidColorBrush(Color.FromRgb(r, g, b));
+        }
+
+        void PopulateUI()
+        {
+            _suppressSpinnerEvents = true;
+            try
+            {
+                for (int i = 0; i < 16; i++)
+                {
+                    if (_rBoxes[i] != null) _rBoxes[i].Value = _vm.GetR(i);
+                    if (_gBoxes[i] != null) _gBoxes[i].Value = _vm.GetG(i);
+                    if (_bBoxes[i] != null) _bBoxes[i].Value = _vm.GetB(i);
+                    UpdateSwatch(i);
+                }
+                PaletteAddressBox.Value = _vm.PaletteAddress;
+                // AddrLabel shows TSA1 address (under the "TSA1 Address" bar
+                // in AXAML). Per Copilot bot PR #594 inline review: the
+                // earlier wiring incorrectly showed the palette address here.
+                AddrLabel.Text = string.Format("0x{0:X08}", _vm.TSA1Address);
+                Image1ZImage.Value = _vm.Image1Pointer;
+                Image2ZImage.Value = _vm.Image2Pointer;
+                Image3ZImage.Value = _vm.Image3Pointer;
+                Image4ZImage.Value = _vm.Image4Pointer;
+                Image5ZImage.Value = _vm.Image5Pointer;
+            }
+            finally
+            {
+                _suppressSpinnerEvents = false;
+            }
         }
 
         void LoadList()
@@ -37,8 +176,8 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                _vm.LoadEntry(addr);
-                UpdateUI();
+                _vm.LoadEntry();
+                PopulateUI();
             }
             catch (Exception ex)
             {
@@ -46,9 +185,171 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
-        void UpdateUI()
+        // -----------------------------------------------------------------
+        // Write paths - all wrap the VM call in _undoService.Begin/Commit/Rollback
+        // so the ambient ROM.BeginUndoScope captures every rom.write_* call
+        // inside the Core helper (Plan v2 Finding #2).
+        // -----------------------------------------------------------------
+        void WriteButton_Click(object sender, RoutedEventArgs e)
         {
-            AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            ROM rom = CoreState.ROM;
+            if (rom == null) return;
+
+            // Pull the ZIMAGE numerics back into the VM so they are part of
+            // the write batch.
+            _vm.Image1Pointer = (uint)((double)(Image1ZImage.Value ?? 0));
+            _vm.Image2Pointer = (uint)((double)(Image2ZImage.Value ?? 0));
+            _vm.Image3Pointer = (uint)((double)(Image3ZImage.Value ?? 0));
+            _vm.Image4Pointer = (uint)((double)(Image4ZImage.Value ?? 0));
+            _vm.Image5Pointer = (uint)((double)(Image5ZImage.Value ?? 0));
+
+            _undoService.Begin("Edit Battle Screen");
+            bool ok;
+            try
+            {
+                ok = _vm.Write();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImageBattleScreenView.Write threw: {0}", ex.Message);
+                _undoService.Rollback();
+                return;
+            }
+
+            if (!ok)
+            {
+                _undoService.Rollback();
+                Log.Notify("WriteButton_Click: write failed; rollback applied.");
+                return;
+            }
+
+            _undoService.Commit();
+        }
+
+        void PaletteWrite_Click(object sender, RoutedEventArgs e)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null) return;
+
+            _undoService.Begin("Edit Battle Screen Palette");
+            bool ok;
+            try
+            {
+                ok = _vm.WritePalette();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImageBattleScreenView.WritePalette threw: {0}", ex.Message);
+                _undoService.Rollback();
+                return;
+            }
+
+            if (!ok)
+            {
+                _undoService.Rollback();
+                Log.Notify("PaletteWrite_Click: write failed; rollback applied.");
+                return;
+            }
+
+            _undoService.Commit();
+        }
+
+        void PaletteIndex_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            try
+            {
+                int newIndex = PaletteIndexCombo.SelectedIndex;
+                if (newIndex < 0 || newIndex == _vm.PaletteIndex) return;
+                _vm.PaletteIndex = newIndex;
+                // Re-read ONLY the palette block at the new index so pending
+                // image-pointer edits are preserved. Per Copilot CLI PR review
+                // round 1 finding #2: WF PaletteFormRef.MakePaletteROMToUI only
+                // reloads the palette UI on palette-index changes, not the
+                // image pointer fields.
+                _vm.LoadPalette();
+                PopulatePaletteUI();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImageBattleScreenView.PaletteIndex_SelectionChanged failed: {0}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Populate ONLY the palette R/G/B spinners + swatches from the VM.
+        /// Does NOT touch the image-pointer NumericUpDowns -- preserves any
+        /// in-flight edits when the user switches palette types (Copilot CLI
+        /// PR review round 1 finding #2).
+        /// </summary>
+        void PopulatePaletteUI()
+        {
+            _suppressSpinnerEvents = true;
+            try
+            {
+                for (int i = 0; i < 16; i++)
+                {
+                    if (_rBoxes[i] != null) _rBoxes[i].Value = _vm.GetR(i);
+                    if (_gBoxes[i] != null) _gBoxes[i].Value = _vm.GetG(i);
+                    if (_bBoxes[i] != null) _bBoxes[i].Value = _vm.GetB(i);
+                    UpdateSwatch(i);
+                }
+            }
+            finally
+            {
+                _suppressSpinnerEvents = false;
+            }
+        }
+
+        void PaletteClipboard_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                // Build "RRGGBB,RRGGBB,..." line of 16 colors and copy.
+                var sb = new System.Text.StringBuilder();
+                for (int i = 0; i < 16; i++)
+                {
+                    if (i > 0) sb.Append(',');
+                    sb.AppendFormat(CultureInfo.InvariantCulture, "{0:X2}{1:X2}{2:X2}",
+                        _vm.GetR(i), _vm.GetG(i), _vm.GetB(i));
+                }
+                if (TopLevel.GetTopLevel(this) is { Clipboard: { } clipboard })
+                {
+                    _ = clipboard.SetTextAsync(sb.ToString());
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("PaletteClipboard_Click failed: {0}", ex.Message);
+            }
+        }
+
+        void PaletteUndo_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                CoreState.Undo?.RunUndo();
+                // Reload so the spinners reflect the rolled-back palette.
+                _vm.LoadEntry();
+                PopulateUI();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("PaletteUndo_Click failed: {0}", ex.Message);
+            }
+        }
+
+        void BulkUndo_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                CoreState.Undo?.RunUndo();
+                _vm.LoadEntry();
+                PopulateUI();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("BulkUndo_Click failed: {0}", ex.Message);
+            }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml.cs
@@ -52,12 +52,6 @@ namespace FEBuilderGBA.Avalonia.Views
             InitializeSwatches();
             WireSpinnerHandlers();
 
-            // Default TSA info text. Set via code-behind so the translation
-            // chain picks it up (see PR #589 ComboBoxItem.Content pattern
-            // -- ViewTranslationHelper does not touch dynamic Text values
-            // populated from code, so we feed it through R._() ourselves).
-            TSAInfoLabel.Text = R._("Selected: 00") + "   " + R._("Canvas:");
-
             EntryList.SelectedAddressChanged += OnSelected;
             Opened += (_, _) => LoadList();
         }
@@ -195,6 +189,15 @@ namespace FEBuilderGBA.Avalonia.Views
             ROM rom = CoreState.ROM;
             if (rom == null) return;
 
+            // Per Copilot bot PR #594 round 5 thread #2: refuse to write if
+            // no entry has been loaded -- default zeros would wipe TSA
+            // regions and write 0x08000000 into image pointer slots.
+            if (!_vm.IsLoaded)
+            {
+                Log.Notify("WriteButton_Click: no entry loaded; refusing to write defaults.");
+                return;
+            }
+
             // Pull the ZIMAGE numerics back into the VM so they are part of
             // the write batch.
             _vm.Image1Pointer = (uint)((double)(Image1ZImage.Value ?? 0));
@@ -230,6 +233,15 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             ROM rom = CoreState.ROM;
             if (rom == null) return;
+
+            // Per Copilot bot PR #594 round 5 thread #3: refuse to write if
+            // no entry has been loaded -- all-zero R/G/B arrays would
+            // write a black palette over the existing one.
+            if (!_vm.IsLoaded || _vm.PaletteAddress == 0)
+            {
+                Log.Notify("PaletteWrite_Click: no entry loaded; refusing to write defaults.");
+                return;
+            }
 
             _undoService.Begin("Edit Battle Screen Palette");
             bool ok;

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml.cs
@@ -199,12 +199,15 @@ namespace FEBuilderGBA.Avalonia.Views
             }
 
             // Pull the ZIMAGE numerics back into the VM so they are part of
-            // the write batch.
-            _vm.Image1Pointer = (uint)((double)(Image1ZImage.Value ?? 0));
-            _vm.Image2Pointer = (uint)((double)(Image2ZImage.Value ?? 0));
-            _vm.Image3Pointer = (uint)((double)(Image3ZImage.Value ?? 0));
-            _vm.Image4Pointer = (uint)((double)(Image4ZImage.Value ?? 0));
-            _vm.Image5Pointer = (uint)((double)(Image5ZImage.Value ?? 0));
+            // the write batch. Per Copilot bot PR #594 round 6 thread #1:
+            // match the cast pattern from other Avalonia views
+            // (e.g. AIASMCALLTALKView.axaml.cs uses (uint)(Box.Value ?? 0))
+            // instead of the surprising double round-trip.
+            _vm.Image1Pointer = (uint)(Image1ZImage.Value ?? 0);
+            _vm.Image2Pointer = (uint)(Image2ZImage.Value ?? 0);
+            _vm.Image3Pointer = (uint)(Image3ZImage.Value ?? 0);
+            _vm.Image4Pointer = (uint)(Image4ZImage.Value ?? 0);
+            _vm.Image5Pointer = (uint)(Image5ZImage.Value ?? 0);
 
             _undoService.Begin("Edit Battle Screen");
             bool ok;

--- a/FEBuilderGBA.Core.Tests/ImageBattleScreenCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ImageBattleScreenCoreTests.cs
@@ -1,0 +1,509 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Phase 1/2/4/5 gap-sweep regression tests for ImageBattleScreenView (#393).
+//
+// Covers FEBuilderGBA.Core/ImageBattleScreenCore — the TSA + palette + image-pointer
+// I/O helpers extracted from the WinForms ImageBattleScreenForm. Tests verify:
+//   - LoadBattleScreen reads the 32x20 TSA map correctly across the 5 TSA regions.
+//   - WriteBattleScreen round-trips the map and respects the ambient UndoScope.
+//   - WriteBattleScreen + RunUndo restores the original bytes (push-then-undo).
+//   - ReadPaletteBlock / WritePaletteBlock delegate to PaletteCore (uncompressed 16-color block).
+//   - WriteImagePointer stores GBA-prefixed (0x08...) pointers.
+//
+// Per Plan v2 Finding #2: ImageBattleScreenCore methods take NO Undo.UndoData
+// parameter — they rely on the [ThreadStatic] ROM.BeginUndoScope ambient
+// context (matches PaletteCore, ImageBattleAnimePaletteCore precedent).
+using System.Collections.Generic;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class ImageBattleScreenCoreTests
+    {
+        // ROM offsets for the 5 TSA regions + palette block + 5 image pointers
+        // planted into a synthetic FE8U ROM. These are arbitrary offsets in the
+        // ROM body (well past the header) chosen so we have predictable storage
+        // for the test.
+        const uint TSA1_OFFSET     = 0x100000;
+        const uint TSA2_OFFSET     = 0x101000;
+        const uint TSA3_OFFSET     = 0x102000;
+        const uint TSA4_OFFSET     = 0x103000;
+        const uint TSA5_OFFSET     = 0x104000;
+        const uint PALETTE_OFFSET  = 0x105000;
+        const uint IMAGE1_OFFSET   = 0x106000;
+        const uint IMAGE2_OFFSET   = 0x107000;
+        const uint IMAGE3_OFFSET   = 0x108000;
+        const uint IMAGE4_OFFSET   = 0x109000;
+        const uint IMAGE5_OFFSET   = 0x10A000;
+
+        // -----------------------------------------------------------------
+        // LoadBattleScreen
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void LoadBattleScreen_ReadsCorrectMap()
+        {
+            var rom = MakeRom();
+            // Plant distinct u16 markers in each TSA region.
+            //  TSA1 covers y=[0..5], x=[1..15] → 90 cells, 0x10..0x69
+            //  TSA2 covers y=[0..5], x=[16..30] → 90 cells, 0x70..0xC9
+            //  TSA3 covers y=[13..19], x=[1..15] → 105 cells, 0xD0..0x138
+            //  TSA4 covers y=[13..19], x=[16..31] → 112 cells, 0x140..0x1AF
+            //  TSA5 covers y=[0..19], x=[31..32] → 40 cells, 0x200..0x227 (x=32 wraps to x=0)
+            PlantTSA1(rom);
+            PlantTSA2(rom);
+            PlantTSA3(rom);
+            PlantTSA4(rom);
+            PlantTSA5(rom);
+
+            ushort[] map = ImageBattleScreenCore.LoadBattleScreen(rom);
+            Assert.NotNull(map);
+            Assert.Equal(32 * 20, map.Length);
+
+            // Spot-check one cell from each region.
+            Assert.Equal((ushort)0x0010, map[0 * 32 + 1]);   // TSA1 first cell (y=0, x=1)
+            Assert.Equal((ushort)0x0070, map[0 * 32 + 16]);  // TSA2 first cell (y=0, x=16)
+            Assert.Equal((ushort)0x00D0, map[13 * 32 + 1]);  // TSA3 first cell (y=13, x=1)
+            Assert.Equal((ushort)0x0140, map[13 * 32 + 16]); // TSA4 first cell (y=13, x=16)
+            Assert.Equal((ushort)0x0200, map[0 * 32 + 31]);  // TSA5 first cell (y=0, x=31)
+            // TSA5 also wraps the x=32 column back to x=0.
+            Assert.Equal((ushort)0x0201, map[0 * 32 + 0]);   // TSA5 second cell (y=0, x=32 → x=0)
+        }
+
+        [Fact]
+        public void LoadBattleScreen_NullRom_ReturnsNull()
+        {
+            ushort[] map = ImageBattleScreenCore.LoadBattleScreen(null);
+            Assert.Null(map);
+        }
+
+        // -----------------------------------------------------------------
+        // WriteBattleScreen
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void WriteBattleScreen_RoundTripsThroughCore_UnderAmbientScope()
+        {
+            var rom = MakeRom();
+            PlantTSA1(rom); PlantTSA2(rom); PlantTSA3(rom); PlantTSA4(rom); PlantTSA5(rom);
+
+            ushort[] map = ImageBattleScreenCore.LoadBattleScreen(rom);
+            Assert.NotNull(map);
+
+            // Mutate every cell that the editor controls.
+            map[0 * 32 + 1] = 0xABCD;        // TSA1
+            map[0 * 32 + 16] = 0xDEF0;       // TSA2
+            map[13 * 32 + 1] = 0x1234;       // TSA3
+            map[13 * 32 + 16] = 0x5678;      // TSA4
+            map[0 * 32 + 31] = 0x9ABC;       // TSA5 (x=31)
+            map[0 * 32 + 0] = 0xCAFE;        // TSA5 (x=32 wraps)
+
+            var ud = new Undo.UndoData
+            {
+                time = System.DateTime.Now,
+                name = "test",
+                list = new List<Undo.UndoPostion>(),
+                filesize = (uint)rom.Data.Length
+            };
+            bool ok;
+            using (ROM.BeginUndoScope(ud))
+            {
+                ok = ImageBattleScreenCore.WriteBattleScreen(rom, map);
+            }
+            Assert.True(ok);
+
+            // The ambient scope should have captured a write for every changed cell.
+            // We don't assert exact count (90+90+105+112+40 = 437 cells) but it
+            // must be at least 6 (the 6 we mutated, conservatively).
+            Assert.True(ud.list.Count >= 6,
+                $"Ambient scope expected at least 6 tracked writes; got {ud.list.Count}");
+
+            // Round-trip: re-read the map; mutated cells survive.
+            ushort[] roundtrip = ImageBattleScreenCore.LoadBattleScreen(rom);
+            Assert.NotNull(roundtrip);
+            Assert.Equal((ushort)0xABCD, roundtrip[0 * 32 + 1]);
+            Assert.Equal((ushort)0xDEF0, roundtrip[0 * 32 + 16]);
+            Assert.Equal((ushort)0x1234, roundtrip[13 * 32 + 1]);
+            Assert.Equal((ushort)0x5678, roundtrip[13 * 32 + 16]);
+            Assert.Equal((ushort)0x9ABC, roundtrip[0 * 32 + 31]);
+            Assert.Equal((ushort)0xCAFE, roundtrip[0 * 32 + 0]);
+        }
+
+        [Fact]
+        public void WriteBattleScreen_RestoresViaRunUndoAfterPush()
+        {
+            var rom = MakeRom();
+            PlantTSA1(rom); PlantTSA2(rom); PlantTSA3(rom); PlantTSA4(rom); PlantTSA5(rom);
+
+            // Undo.NewUndoData needs CoreState.ROM (it reads .Data.Length for filesize).
+            var prevRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = rom;
+
+                var undo = new Undo();
+                var undoBefore = new byte[8];
+                uint readAddr = rom.RomInfo.battle_screen_TSA1_pointer;
+                uint tsa1Addr = rom.p32(readAddr);
+                for (int i = 0; i < 8; i++) undoBefore[i] = rom.Data[tsa1Addr + i];
+
+                ushort[] map = ImageBattleScreenCore.LoadBattleScreen(rom);
+                map[0 * 32 + 1] = 0xABCD;
+                map[0 * 32 + 2] = 0xCAFE;
+
+                var ud = undo.NewUndoData("test");
+                using (ROM.BeginUndoScope(ud))
+                {
+                    ImageBattleScreenCore.WriteBattleScreen(rom, map);
+                }
+                Assert.NotEmpty(ud.list);
+                undo.Push(ud);
+
+                // After write the bytes differ from the original.
+                Assert.NotEqual(undoBefore[0], rom.Data[tsa1Addr + 0]);
+
+                // RunUndo restores the original bytes.
+                undo.RunUndo();
+                for (int i = 0; i < 8; i++)
+                {
+                    Assert.Equal(undoBefore[i], rom.Data[tsa1Addr + i]);
+                }
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+            }
+        }
+
+        [Fact]
+        public void WriteBattleScreen_NullArgs_ReturnsFalse()
+        {
+            var rom = MakeRom();
+            Assert.False(ImageBattleScreenCore.WriteBattleScreen(null, new ushort[640]));
+            Assert.False(ImageBattleScreenCore.WriteBattleScreen(rom, null));
+            Assert.False(ImageBattleScreenCore.WriteBattleScreen(rom, new ushort[100])); // wrong size
+        }
+
+        /// <summary>
+        /// Per Copilot bot PR #594 review: a corrupt TSA pointer slot
+        /// (zero, NOT_FOUND, or out-of-bounds) must not crash the editor.
+        /// LoadBattleScreen returns the map with that region zero-filled.
+        /// </summary>
+        [Fact]
+        public void LoadBattleScreen_CorruptTsa1Pointer_ReturnsZeroMapWithoutThrowing()
+        {
+            var rom = MakeRom();
+            // Zero out the TSA1 pointer slot.
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_TSA1_pointer, U.toPointer(0));
+            ushort[] map = ImageBattleScreenCore.LoadBattleScreen(rom);
+            Assert.NotNull(map);
+            Assert.Equal(640, map.Length);
+            // TSA1 region cells must all be 0 (skipped); other regions
+            // should not be affected.
+            for (int y = 0; y <= 5; y++)
+            {
+                for (int x = 1; x <= 15; x++)
+                {
+                    Assert.Equal((ushort)0, map[y * 32 + x]);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Per Copilot bot PR #594 review: a corrupt TSA pointer slot must
+        /// cause WriteBattleScreen to return false BEFORE any byte is
+        /// written (so the editor stays consistent inside its undo scope).
+        /// </summary>
+        [Fact]
+        public void WriteBattleScreen_CorruptTsa1Pointer_ReturnsFalseWithoutPartialWrites()
+        {
+            var rom = MakeRom();
+            PlantTSA1(rom); PlantTSA2(rom); PlantTSA3(rom); PlantTSA4(rom); PlantTSA5(rom);
+
+            // Stash original bytes from each TSA region so we can detect any partial write.
+            uint tsa1Addr = rom.p32(rom.RomInfo.battle_screen_TSA1_pointer);
+            uint tsa2Addr = rom.p32(rom.RomInfo.battle_screen_TSA2_pointer);
+            byte[] tsa1Before = new byte[16];
+            byte[] tsa2Before = new byte[16];
+            for (int i = 0; i < 16; i++) tsa1Before[i] = rom.Data[tsa1Addr + i];
+            for (int i = 0; i < 16; i++) tsa2Before[i] = rom.Data[tsa2Addr + i];
+
+            // Corrupt TSA3 to an out-of-bounds offset.
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_TSA3_pointer, U.toPointer(0x1FFFFFE0));
+
+            ushort[] map = new ushort[640];
+            for (int i = 0; i < 640; i++) map[i] = 0xABCD;
+
+            var ud = new Undo.UndoData
+            {
+                time = System.DateTime.Now,
+                name = "test",
+                list = new List<Undo.UndoPostion>(),
+                filesize = (uint)rom.Data.Length
+            };
+            bool ok;
+            using (ROM.BeginUndoScope(ud))
+            {
+                ok = ImageBattleScreenCore.WriteBattleScreen(rom, map);
+            }
+            Assert.False(ok);
+
+            // The pre-validation must have rejected the call before ANY
+            // tracked write happened.
+            Assert.Empty(ud.list);
+            // TSA1/TSA2 regions must be unchanged.
+            for (int i = 0; i < 16; i++)
+            {
+                Assert.Equal(tsa1Before[i], rom.Data[tsa1Addr + i]);
+                Assert.Equal(tsa2Before[i], rom.Data[tsa2Addr + i]);
+            }
+        }
+
+        // -----------------------------------------------------------------
+        // Palette I/O (delegating to PaletteCore)
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void ReadPaletteBlock_DelegatesToPaletteCore()
+        {
+            var rom = MakeRom();
+            // Plant 4 GBA u16 palette colors at the palette slot 0.
+            // Slot 0 colors: red, green, blue, white.
+            uint paletteAddr = rom.p32(rom.RomInfo.battle_screen_palette_pointer);
+            U.write_u16(rom.Data, paletteAddr + 0, 0x001F);   // R=31 G=0 B=0
+            U.write_u16(rom.Data, paletteAddr + 2, 0x03E0);   // R=0 G=31 B=0
+            U.write_u16(rom.Data, paletteAddr + 4, 0x7C00);   // R=0 G=0 B=31
+            U.write_u16(rom.Data, paletteAddr + 6, 0x7FFF);   // R=31 G=31 B=31
+
+            var colors = ImageBattleScreenCore.ReadPaletteBlock(rom, paletteIndex: 0);
+            Assert.NotNull(colors);
+            Assert.Equal(16, colors.Length);
+            Assert.Equal(248, colors[0].r); // 31 << 3 = 248
+            Assert.Equal(0, colors[0].g);
+            Assert.Equal(0, colors[0].b);
+            Assert.Equal(0, colors[1].r);
+            Assert.Equal(248, colors[1].g);
+            Assert.Equal(0, colors[2].r);
+            Assert.Equal(0, colors[2].g);
+            Assert.Equal(248, colors[2].b);
+            Assert.Equal(248, colors[3].r);
+            Assert.Equal(248, colors[3].g);
+            Assert.Equal(248, colors[3].b);
+        }
+
+        [Fact]
+        public void WritePaletteBlock_RoundTrip_PreservesAllChannels()
+        {
+            var rom = MakeRom();
+            var colors = new (byte r, byte g, byte b)[16];
+            colors[0] = (248, 0, 0);
+            colors[1] = (0, 248, 0);
+            colors[2] = (0, 0, 248);
+            colors[15] = (248, 248, 248);
+
+            var ud = new Undo.UndoData
+            {
+                time = System.DateTime.Now,
+                name = "test",
+                list = new List<Undo.UndoPostion>(),
+                filesize = (uint)rom.Data.Length
+            };
+            bool ok;
+            using (ROM.BeginUndoScope(ud))
+            {
+                ok = ImageBattleScreenCore.WritePaletteBlock(rom, paletteIndex: 1, colors);
+            }
+            Assert.True(ok);
+            // The ambient scope should have captured the write_range call.
+            Assert.NotEmpty(ud.list);
+
+            var roundtrip = ImageBattleScreenCore.ReadPaletteBlock(rom, paletteIndex: 1);
+            Assert.Equal(248, roundtrip[0].r);
+            Assert.Equal(248, roundtrip[1].g);
+            Assert.Equal(248, roundtrip[2].b);
+            Assert.Equal(248, roundtrip[15].r);
+            Assert.Equal(248, roundtrip[15].g);
+            Assert.Equal(248, roundtrip[15].b);
+        }
+
+        // -----------------------------------------------------------------
+        // WriteImagePointer
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void WriteImagePointer_WritesGbaPointer()
+        {
+            var rom = MakeRom();
+            uint slot = rom.RomInfo.battle_screen_image1_pointer;
+            uint newAddr = 0x123456;
+
+            var ud = new Undo.UndoData
+            {
+                time = System.DateTime.Now,
+                name = "test",
+                list = new List<Undo.UndoPostion>(),
+                filesize = (uint)rom.Data.Length
+            };
+            bool ok;
+            using (ROM.BeginUndoScope(ud))
+            {
+                ok = ImageBattleScreenCore.WriteImagePointer(rom, slot, newAddr);
+            }
+            Assert.True(ok);
+            Assert.NotEmpty(ud.list);
+
+            // Pointer slot should store the GBA-prefixed pointer (0x08...).
+            uint stored = rom.u32(slot);
+            Assert.Equal(U.toPointer(newAddr), stored);
+            // Resolving the pointer brings us back to the original offset.
+            uint resolved = rom.p32(slot);
+            Assert.Equal(newAddr, resolved);
+        }
+
+        /// <summary>
+        /// Per Copilot bot PR #594 review round 2: WriteImagePointer must
+        /// validate the pointerSlot is a safe ROM offset before calling
+        /// rom.write_p32 (which would otherwise throw).
+        /// </summary>
+        [Fact]
+        public void WriteImagePointer_InvalidPointerSlot_ReturnsFalse()
+        {
+            var rom = MakeRom();
+            // pointerSlot at 0 (header), at NOT_FOUND, near end of ROM.
+            Assert.False(ImageBattleScreenCore.WriteImagePointer(rom, 0x00, 0x123456));
+            Assert.False(ImageBattleScreenCore.WriteImagePointer(rom, U.NOT_FOUND, 0x123456));
+            // 4-byte span overflowing the ROM end.
+            uint nearEnd = (uint)rom.Data.Length - 3;
+            Assert.False(ImageBattleScreenCore.WriteImagePointer(rom, nearEnd, 0x123456));
+        }
+
+        [Fact]
+        public void ReadImagePointer_ReadsPointerSlot()
+        {
+            var rom = MakeRom();
+            uint slot = rom.RomInfo.battle_screen_image1_pointer;
+            uint expected = rom.p32(slot);
+            uint actual = ImageBattleScreenCore.ReadImagePointer(rom, slot);
+            Assert.Equal(expected, actual);
+        }
+
+        // -----------------------------------------------------------------
+        // Helpers
+        // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Build a synthetic FE8U ROM with planted TSA/palette/image pointers.
+        /// </summary>
+        static ROM MakeRom()
+        {
+            var rom = new ROM();
+            byte[] data = new byte[0x2000000];
+            // 0xFF-fill the entire ROM. The pointer slots live in ROMFE8U's
+            // hardcoded constant table; we cannot relocate them, so we plant
+            // pointers in the slots themselves and the data at our chosen
+            // offsets.
+            // Use Array.Fill for the 32MB free-space init (Copilot bot
+            // PR #594 round 3 finding #3 perf/readability).
+            System.Array.Fill(data, (byte)0xFF);
+            rom.LoadLow("synth.gba", data, "BE8E01");
+
+            // Plant the 5 TSA pointer slots → our TSA storage offsets.
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_TSA1_pointer, U.toPointer(TSA1_OFFSET));
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_TSA2_pointer, U.toPointer(TSA2_OFFSET));
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_TSA3_pointer, U.toPointer(TSA3_OFFSET));
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_TSA4_pointer, U.toPointer(TSA4_OFFSET));
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_TSA5_pointer, U.toPointer(TSA5_OFFSET));
+
+            // Plant the palette pointer slot.
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_palette_pointer, U.toPointer(PALETTE_OFFSET));
+            // Plant a 0x80-byte palette block (4 slots x 0x20 bytes) zero-filled.
+            for (uint i = 0; i < 0x80; i++) rom.Data[PALETTE_OFFSET + i] = 0;
+
+            // Plant the 5 image pointer slots.
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_image1_pointer, U.toPointer(IMAGE1_OFFSET));
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_image2_pointer, U.toPointer(IMAGE2_OFFSET));
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_image3_pointer, U.toPointer(IMAGE3_OFFSET));
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_image4_pointer, U.toPointer(IMAGE4_OFFSET));
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_image5_pointer, U.toPointer(IMAGE5_OFFSET));
+
+            // Clear out the TSA blocks at our planted offsets (4KB per region
+            // is plenty for the small actual blocks).
+            for (uint i = 0; i < 0x1000; i++)
+            {
+                rom.Data[TSA1_OFFSET + i] = 0;
+                rom.Data[TSA2_OFFSET + i] = 0;
+                rom.Data[TSA3_OFFSET + i] = 0;
+                rom.Data[TSA4_OFFSET + i] = 0;
+                rom.Data[TSA5_OFFSET + i] = 0;
+            }
+            return rom;
+        }
+
+        static void PlantTSA1(ROM rom)
+        {
+            uint addr = rom.p32(rom.RomInfo.battle_screen_TSA1_pointer);
+            ushort marker = 0x0010;
+            for (int y = 0; y <= 5; y++)
+            {
+                for (int x = 1; x <= 15; x++)
+                {
+                    U.write_u16(rom.Data, addr, marker++);
+                    addr += 2;
+                }
+            }
+        }
+        static void PlantTSA2(ROM rom)
+        {
+            uint addr = rom.p32(rom.RomInfo.battle_screen_TSA2_pointer);
+            ushort marker = 0x0070;
+            for (int y = 0; y <= 5; y++)
+            {
+                for (int x = 16; x <= 30; x++)
+                {
+                    U.write_u16(rom.Data, addr, marker++);
+                    addr += 2;
+                }
+            }
+        }
+        static void PlantTSA3(ROM rom)
+        {
+            uint addr = rom.p32(rom.RomInfo.battle_screen_TSA3_pointer);
+            ushort marker = 0x00D0;
+            for (int y = 13; y <= 19; y++)
+            {
+                for (int x = 1; x <= 15; x++)
+                {
+                    U.write_u16(rom.Data, addr, marker++);
+                    addr += 2;
+                }
+            }
+        }
+        static void PlantTSA4(ROM rom)
+        {
+            uint addr = rom.p32(rom.RomInfo.battle_screen_TSA4_pointer);
+            ushort marker = 0x0140;
+            for (int y = 13; y <= 19; y++)
+            {
+                for (int x = 16; x <= 31; x++)
+                {
+                    U.write_u16(rom.Data, addr, marker++);
+                    addr += 2;
+                }
+            }
+        }
+        static void PlantTSA5(ROM rom)
+        {
+            uint addr = rom.p32(rom.RomInfo.battle_screen_TSA5_pointer);
+            ushort marker = 0x0200;
+            for (int y = 0; y <= 19; y++)
+            {
+                for (int x = 31; x <= 32; x++)
+                {
+                    U.write_u16(rom.Data, addr, marker++);
+                    addr += 2;
+                }
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Core/ImageBattleScreenCore.cs
+++ b/FEBuilderGBA.Core/ImageBattleScreenCore.cs
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Cross-platform helpers for the battle-screen layout editor (#393).
+//
+// Extracted from the WinForms ImageBattleScreenForm so the Avalonia
+// ImageBattleScreenView can share the TSA + palette + image-pointer read
+// and write paths without a System.Windows.Forms or System.Drawing
+// dependency. See issue #393.
+//
+// Design notes (from accepted plan v2 + Copilot CLI plan review round 1):
+//
+//   * The battle-screen layout is a 32 x 20 cell TSA grid (640 u16 cells).
+//     The grid is split across 5 ROM TSA regions:
+//       TSA1: y=[0..5],  x=[1..15]   → 90 cells (top-left)
+//       TSA2: y=[0..5],  x=[16..30]  → 90 cells (top-right)
+//       TSA3: y=[13..19], x=[1..15]  → 105 cells (bottom-left)
+//       TSA4: y=[13..19], x=[16..31] → 112 cells (bottom-right)
+//       TSA5: y=[0..19],  x=[31..32] → 40 cells; x=32 wraps to x=0.
+//     The mid-vertical strip y=[6..12] is the live battle area, drawn by
+//     the engine — no TSA entries.
+//
+//   * Address inputs are GBA pointers in ROM (0x08...). The core
+//     dereferences via rom.p32() and writes back via rom.write_u16 / write_p32,
+//     which automatically pick up the [ThreadStatic] ROM.BeginUndoScope
+//     ambient undo data (Plan v2 Finding #2: no Undo.UndoData parameter
+//     anywhere — single undo model).
+//
+//   * Palette I/O delegates to PaletteCore.ReadPalette / WritePalette
+//     for the BGR15 packing and paletteIndex * 0x20 offset arithmetic
+//     (Plan v2 Finding #3: reuse the existing helper).
+
+using System;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Cross-platform helpers for the battle-screen layout editor (#393).
+    /// See file-level comment for the TSA region layout and design notes.
+    /// </summary>
+    public static class ImageBattleScreenCore
+    {
+        /// <summary>Width of the TSA map in cells.</summary>
+        public const int MAP_X = 32;
+
+        /// <summary>Height of the TSA map in cells.</summary>
+        public const int MAP_Y = 20;
+
+        /// <summary>Total cells in the TSA map (32 * 20 = 640).</summary>
+        public const int MAP_SIZE = MAP_X * MAP_Y;
+
+        // Byte sizes of each TSA region (cells * 2 bytes per cell).
+        const int TSA1_BYTES = 6 * 15 * 2;   // 180
+        const int TSA2_BYTES = 6 * 15 * 2;   // 180
+        const int TSA3_BYTES = 7 * 15 * 2;   // 210
+        const int TSA4_BYTES = 7 * 16 * 2;   // 224
+        const int TSA5_BYTES = 20 * 2 * 2;   // 80
+
+        /// <summary>
+        /// Validate that <paramref name="addr"/> is a safe ROM offset and
+        /// that reading/writing <paramref name="bytes"/> bytes starting at
+        /// it stays inside <c>rom.Data</c>.
+        ///
+        /// Combines <see cref="U.isSafetyOffset(uint, ROM)"/>'s domain
+        /// constraints (offset in [0x200, 0x02000000) and within rom.Data)
+        /// with an explicit end-of-range check that uses <c>ulong</c>
+        /// arithmetic so the addition cannot overflow even on near-uint.MaxValue
+        /// inputs. Sentinel <see cref="U.NOT_FOUND"/> is implicitly rejected
+        /// via the upper bound. Per Copilot bot PR #594 review round 2.
+        /// </summary>
+        static bool IsRegionSafe(ROM rom, uint addr, int bytes)
+        {
+            if (rom == null || rom.Data == null) return false;
+            if (!U.isSafetyOffset(addr, rom)) return false;
+            if (bytes <= 0) return false;
+            // Last byte that will be touched: addr + bytes - 1. Use ulong
+            // to guard against overflow on huge bytes values.
+            ulong lastByte = (ulong)addr + (ulong)bytes - 1UL;
+            return lastByte < (ulong)rom.Data.Length;
+        }
+
+        /// <summary>
+        /// Read the 32 x 20 TSA map from the 5 TSA regions in <paramref name="rom"/>.
+        /// Returns a <see cref="ushort"/> array of length <see cref="MAP_SIZE"/>;
+        /// cells not covered by any TSA region (the central battle area y=[6..12])
+        /// are zero. On corrupt/out-of-bounds pointers in any region, that region
+        /// is skipped (leaves zeros) rather than throwing -- matches the
+        /// PaletteCore graceful-failure convention (Copilot bot PR #594 review).
+        /// </summary>
+        public static ushort[] LoadBattleScreen(ROM rom)
+        {
+            if (rom == null || rom.RomInfo == null) return null;
+            ushort[] map = new ushort[MAP_SIZE];
+
+            uint addr;
+
+            // TSA1: y=[0..5], x=[1..15] (180 bytes)
+            addr = rom.p32(rom.RomInfo.battle_screen_TSA1_pointer);
+            if (IsRegionSafe(rom, addr, TSA1_BYTES))
+            {
+                for (int y = 0; y <= 5; y++)
+                {
+                    for (int x = 1; x <= 15; x++)
+                    {
+                        map[y * MAP_X + x] = (ushort)rom.u16(addr);
+                        addr += 2;
+                    }
+                }
+            }
+
+            // TSA2: y=[0..5], x=[16..30] (180 bytes)
+            addr = rom.p32(rom.RomInfo.battle_screen_TSA2_pointer);
+            if (IsRegionSafe(rom, addr, TSA2_BYTES))
+            {
+                for (int y = 0; y <= 5; y++)
+                {
+                    for (int x = 16; x <= 30; x++)
+                    {
+                        map[y * MAP_X + x] = (ushort)rom.u16(addr);
+                        addr += 2;
+                    }
+                }
+            }
+
+            // TSA3: y=[13..19], x=[1..15] (210 bytes)
+            addr = rom.p32(rom.RomInfo.battle_screen_TSA3_pointer);
+            if (IsRegionSafe(rom, addr, TSA3_BYTES))
+            {
+                for (int y = 13; y <= 19; y++)
+                {
+                    for (int x = 1; x <= 15; x++)
+                    {
+                        map[y * MAP_X + x] = (ushort)rom.u16(addr);
+                        addr += 2;
+                    }
+                }
+            }
+
+            // TSA4: y=[13..19], x=[16..31] (224 bytes)
+            addr = rom.p32(rom.RomInfo.battle_screen_TSA4_pointer);
+            if (IsRegionSafe(rom, addr, TSA4_BYTES))
+            {
+                for (int y = 13; y <= 19; y++)
+                {
+                    for (int x = 16; x <= 31; x++)
+                    {
+                        map[y * MAP_X + x] = (ushort)rom.u16(addr);
+                        addr += 2;
+                    }
+                }
+            }
+
+            // TSA5: y=[0..19], x=[31..32]. x=32 wraps to x=0. (80 bytes)
+            addr = rom.p32(rom.RomInfo.battle_screen_TSA5_pointer);
+            if (IsRegionSafe(rom, addr, TSA5_BYTES))
+            {
+                for (int y = 0; y <= 19; y++)
+                {
+                    for (int x = 31; x <= 32; x++)
+                    {
+                        int xx = x == 32 ? 0 : x;
+                        map[y * MAP_X + xx] = (ushort)rom.u16(addr);
+                        addr += 2;
+                    }
+                }
+            }
+
+            return map;
+        }
+
+        /// <summary>
+        /// Write the 32 x 20 TSA map back to the 5 TSA regions in
+        /// <paramref name="rom"/>. Writes go through <c>rom.write_u16</c>
+        /// which honors the ambient <see cref="ROM.BeginUndoScope"/>
+        /// so the caller's <c>UndoService.Begin/Commit/Rollback</c>
+        /// envelope captures every byte change.
+        /// </summary>
+        /// <returns><c>true</c> on success; <c>false</c> if inputs are invalid.</returns>
+        public static bool WriteBattleScreen(ROM rom, ushort[] map)
+        {
+            if (rom == null || rom.RomInfo == null) return false;
+            if (map == null || map.Length != MAP_SIZE) return false;
+
+            // Pre-validate ALL 5 region addresses + their byte spans BEFORE
+            // any write so a corrupt pointer cannot crash the editor
+            // mid-undo-scope (Copilot bot PR #594 review).
+            uint tsa1 = rom.p32(rom.RomInfo.battle_screen_TSA1_pointer);
+            uint tsa2 = rom.p32(rom.RomInfo.battle_screen_TSA2_pointer);
+            uint tsa3 = rom.p32(rom.RomInfo.battle_screen_TSA3_pointer);
+            uint tsa4 = rom.p32(rom.RomInfo.battle_screen_TSA4_pointer);
+            uint tsa5 = rom.p32(rom.RomInfo.battle_screen_TSA5_pointer);
+            if (!IsRegionSafe(rom, tsa1, TSA1_BYTES)) return false;
+            if (!IsRegionSafe(rom, tsa2, TSA2_BYTES)) return false;
+            if (!IsRegionSafe(rom, tsa3, TSA3_BYTES)) return false;
+            if (!IsRegionSafe(rom, tsa4, TSA4_BYTES)) return false;
+            if (!IsRegionSafe(rom, tsa5, TSA5_BYTES)) return false;
+
+            uint addr;
+
+            addr = tsa1;
+            for (int y = 0; y <= 5; y++)
+            {
+                for (int x = 1; x <= 15; x++)
+                {
+                    rom.write_u16(addr, map[y * MAP_X + x]);
+                    addr += 2;
+                }
+            }
+
+            addr = tsa2;
+            for (int y = 0; y <= 5; y++)
+            {
+                for (int x = 16; x <= 30; x++)
+                {
+                    rom.write_u16(addr, map[y * MAP_X + x]);
+                    addr += 2;
+                }
+            }
+
+            addr = tsa3;
+            for (int y = 13; y <= 19; y++)
+            {
+                for (int x = 1; x <= 15; x++)
+                {
+                    rom.write_u16(addr, map[y * MAP_X + x]);
+                    addr += 2;
+                }
+            }
+
+            addr = tsa4;
+            for (int y = 13; y <= 19; y++)
+            {
+                for (int x = 16; x <= 31; x++)
+                {
+                    rom.write_u16(addr, map[y * MAP_X + x]);
+                    addr += 2;
+                }
+            }
+
+            addr = tsa5;
+            for (int y = 0; y <= 19; y++)
+            {
+                for (int x = 31; x <= 32; x++)
+                {
+                    int xx = x == 32 ? 0 : x;
+                    rom.write_u16(addr, map[y * MAP_X + xx]);
+                    addr += 2;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Read a 16-color uncompressed palette block from the
+        /// battle-screen palette pointer. Delegates to
+        /// <see cref="PaletteCore.ReadPalette"/> with the
+        /// <paramref name="paletteIndex"/> argument controlling which
+        /// 0x20-byte slot is read (Plan v2 Finding #3: reuse PaletteCore
+        /// rather than duplicate the BGR15 packing math).
+        /// </summary>
+        public static (byte r, byte g, byte b)[] ReadPaletteBlock(ROM rom, int paletteIndex)
+        {
+            if (rom == null || rom.RomInfo == null) return new (byte, byte, byte)[16];
+            uint paletteAddr = rom.p32(rom.RomInfo.battle_screen_palette_pointer);
+            return PaletteCore.ReadPalette(rom.Data, paletteAddr, paletteIndex);
+        }
+
+        /// <summary>
+        /// Write a 16-color uncompressed palette block to the battle-screen
+        /// palette pointer at <paramref name="paletteIndex"/> * 0x20 offset.
+        /// Delegates to <see cref="PaletteCore.WritePalette"/> which honors
+        /// the ambient undo scope. Returns <c>true</c> on success.
+        /// </summary>
+        public static bool WritePaletteBlock(ROM rom, int paletteIndex, (byte r, byte g, byte b)[] colors)
+        {
+            if (rom == null || rom.RomInfo == null) return false;
+            uint paletteAddr = rom.p32(rom.RomInfo.battle_screen_palette_pointer);
+            return PaletteCore.WritePalette(rom, paletteAddr, paletteIndex, colors);
+        }
+
+        /// <summary>
+        /// Read the image pointer stored at <paramref name="pointerSlot"/>
+        /// (e.g. <c>RomInfo.battle_screen_image1_pointer</c>). Returns the
+        /// resolved ROM offset (0x... without the 0x08 prefix). Returns 0
+        /// on null ROM.
+        /// </summary>
+        public static uint ReadImagePointer(ROM rom, uint pointerSlot)
+        {
+            if (rom == null) return 0;
+            return rom.p32(pointerSlot);
+        }
+
+        /// <summary>
+        /// Write the image pointer at <paramref name="pointerSlot"/> with
+        /// <paramref name="newAddr"/>. The GBA pointer prefix (0x08...) is
+        /// added automatically via <c>rom.write_p32</c>. Honors the ambient
+        /// undo scope. Returns <c>true</c> on success, <c>false</c> if
+        /// <paramref name="pointerSlot"/> or its 4-byte span are not safe
+        /// ROM offsets (Copilot bot PR #594 review round 2).
+        /// </summary>
+        public static bool WriteImagePointer(ROM rom, uint pointerSlot, uint newAddr)
+        {
+            if (rom == null) return false;
+            // pointerSlot+3 is the last byte touched by write_p32. Validate
+            // the 4-byte span before writing so we don't throw mid-undo-scope.
+            if (!IsRegionSafe(rom, pointerSlot, 4)) return false;
+            rom.write_p32(pointerSlot, newAddr);
+            return true;
+        }
+    }
+}

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -19890,3 +19890,114 @@ OBBGLeftToRight
 
 :FEditor / SCA_Creator magic-system patch not detected. Install the patch via the Patches manager.
 FEditor / SCA_Creator magic-system patch not detected. Install the patch via the Patches manager.
+
+:Chipset Preview (deferred KnownGap): live LZ77 decode + flip permutations are WinForms-coupled (ImageUtil.BitBlt). Use the WinForms editor to paint TSA cells.
+Chipset Preview (deferred KnownGap): live LZ77 decode + flip permutations are WinForms-coupled (ImageUtil.BitBlt). Use the WinForms editor to paint TSA cells.
+
+:KnownGap: chipset thumbnail rendering is WinForms-coupled (#393).
+KnownGap: chipset thumbnail rendering is WinForms-coupled (#393).
+
+:Battle Preview (deferred KnownGap): rendering the 32x20 TSA grid with the live palette requires System.Drawing + ImageUtil.BitBlt. The numeric fields and palette/image pointer write paths in this editor are functional under the ambient undo scope.
+Battle Preview (deferred KnownGap): rendering the 32x20 TSA grid with the live palette requires System.Drawing + ImageUtil.BitBlt. The numeric fields and palette/image pointer write paths in this editor are functional under the ambient undo scope.
+
+:KnownGap: battle-screen bitmap rendering is WinForms-coupled (#393).
+KnownGap: battle-screen bitmap rendering is WinForms-coupled (#393).
+
+:TSA1 Address
+TSA1 Address
+
+:KnownGap: local palette-edit redo (PaletteFormRef redo buffer) is WinForms-coupled (#393). Use the main ROM-level Undo via the toolbar.
+KnownGap: local palette-edit redo (PaletteFormRef redo buffer) is WinForms-coupled (#393). Use the main ROM-level Undo via the toolbar.
+
+:Main Image
+Main Image
+
+:Tile1
+Tile1
+
+:Tile2
+Tile2
+
+:Tile3
+Tile3
+
+:Tile4
+Tile4
+
+:Tile5
+Tile5
+
+:KnownGap: per-image LZ77 Import (ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByte16Tile) is WinForms-coupled (#393).
+KnownGap: per-image LZ77 Import (ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByte16Tile) is WinForms-coupled (#393).
+
+:KnownGap: per-image PNG Export (ImageFormRef.ExportImage) is WinForms-coupled (#393).
+KnownGap: per-image PNG Export (ImageFormRef.ExportImage) is WinForms-coupled (#393).
+
+:Image1 Preview (deferred KnownGap): per-tile LZ77 decompress + palette blit is WinForms-coupled (#393).
+Image1 Preview (deferred KnownGap): per-tile LZ77 decompress + palette blit is WinForms-coupled (#393).
+
+:Left Side
+Left Side
+
+:KnownGap: per-image LZ77 Import is WinForms-coupled (#393).
+KnownGap: per-image LZ77 Import is WinForms-coupled (#393).
+
+:KnownGap: per-image PNG Export is WinForms-coupled (#393).
+KnownGap: per-image PNG Export is WinForms-coupled (#393).
+
+:Image2 Preview (deferred)
+Image2 Preview (deferred)
+
+:Image3 Preview (deferred)
+Image3 Preview (deferred)
+
+:Right Side
+Right Side
+
+:Image4 Preview (deferred)
+Image4 Preview (deferred)
+
+:Image5 Preview (deferred)
+Image5 Preview (deferred)
+
+:Bulk import/export the battle screen as a single image. TSA layout means common tiles must be deduplicated.
+Bulk import/export the battle screen as a single image. TSA layout means common tiles must be deduplicated.
+
+:KnownGap: bulk image Import requires ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByteKeepTSA (WinForms-coupled, #393).
+KnownGap: bulk image Import requires ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByteKeepTSA (WinForms-coupled, #393).
+
+:KnownGap: bulk image Export requires ImageFormRef.ExportImage + live battle-screen bitmap (WinForms-coupled, #393).
+KnownGap: bulk image Export requires ImageFormRef.ExportImage + live battle-screen bitmap (WinForms-coupled, #393).
+
+:KnownGap: local TSA redo buffer is WinForms-coupled. Use the main ROM-level Undo via the toolbar (#393).
+KnownGap: local TSA redo buffer is WinForms-coupled. Use the main ROM-level Undo via the toolbar (#393).
+
+:Palette 1
+Palette 1
+
+:Palette 2
+Palette 2
+
+:Palette 3
+Palette 3
+
+:Palette 4
+Palette 4
+
+:1x Zoom
+1x Zoom
+
+:Selected: 00
+Selected: 00
+
+:Canvas:
+Canvas:
+
+:Edit Battle Screen
+Edit Battle Screen
+
+:Edit Battle Screen Palette
+Edit Battle Screen Palette
+
+:KnownGap: zoom only affects the deferred Battle/Chipset preview rendering (WinForms-coupled, #393). Re-enabled once the live preview lands.
+KnownGap: zoom only affects the deferred Battle/Chipset preview rendering (WinForms-coupled, #393). Re-enabled once the live preview lands.

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -8343,3 +8343,111 @@ KnownGap: リスト拡張はDataExpansionCoreの未移植配線が必要。
 KnownGap: DecreaseColorTSAToolFormは未移植。
 :KnownGap: ResourceCache source-file feature not yet wired in Avalonia.
 KnownGap: ResourceCacheのソースファイル機能はAvaloniaでは未配線。
+
+:Chipset Preview (deferred KnownGap): live LZ77 decode + flip permutations are WinForms-coupled (ImageUtil.BitBlt). Use the WinForms editor to paint TSA cells.
+チップセットプレビュー (KnownGap 延期): ライブ LZ77 デコード + 反転置換は WinForms 依存 (ImageUtil.BitBlt) です。WinForms エディタを使用して TSA セルを描画してください。
+
+:KnownGap: chipset thumbnail rendering is WinForms-coupled (#393).
+KnownGap: チップセットサムネイル描画は WinForms 依存 (#393) です。
+
+:Battle Preview (deferred KnownGap): rendering the 32x20 TSA grid with the live palette requires System.Drawing + ImageUtil.BitBlt. The numeric fields and palette/image pointer write paths in this editor are functional under the ambient undo scope.
+戦闘プレビュー (KnownGap 延期): ライブパレットによる 32x20 TSA グリッドの描画には System.Drawing + ImageUtil.BitBlt が必要です。このエディタの数値フィールドとパレット/画像ポインタの書き込みパスは、アンビエント Undo スコープ下で機能します。
+
+:KnownGap: battle-screen bitmap rendering is WinForms-coupled (#393).
+KnownGap: 戦闘画面ビットマップ描画は WinForms 依存 (#393) です。
+
+:TSA1 Address
+TSA1 アドレス
+
+:KnownGap: local palette-edit redo (PaletteFormRef redo buffer) is WinForms-coupled (#393). Use the main ROM-level Undo via the toolbar.
+KnownGap: ローカルパレット編集の Redo (PaletteFormRef redo バッファ) は WinForms 依存 (#393) です。ツールバーのメイン ROM レベルの Undo を使用してください。
+
+:Tile1
+Tile1
+
+:Tile2
+Tile2
+
+:Tile3
+Tile3
+
+:Tile4
+Tile4
+
+:Tile5
+Tile5
+
+:KnownGap: per-image LZ77 Import (ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByte16Tile) is WinForms-coupled (#393).
+KnownGap: 画像ごとの LZ77 インポート (ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByte16Tile) は WinForms 依存 (#393) です。
+
+:KnownGap: per-image PNG Export (ImageFormRef.ExportImage) is WinForms-coupled (#393).
+KnownGap: 画像ごとの PNG エクスポート (ImageFormRef.ExportImage) は WinForms 依存 (#393) です。
+
+:Image1 Preview (deferred KnownGap): per-tile LZ77 decompress + palette blit is WinForms-coupled (#393).
+画像1 プレビュー (KnownGap 延期): タイルごとの LZ77 展開 + パレット blit は WinForms 依存 (#393) です。
+
+:Left Side
+左側
+
+:KnownGap: per-image LZ77 Import is WinForms-coupled (#393).
+KnownGap: 画像ごとの LZ77 インポートは WinForms 依存 (#393) です。
+
+:KnownGap: per-image PNG Export is WinForms-coupled (#393).
+KnownGap: 画像ごとの PNG エクスポートは WinForms 依存 (#393) です。
+
+:Image2 Preview (deferred)
+画像2 プレビュー (延期)
+
+:Image3 Preview (deferred)
+画像3 プレビュー (延期)
+
+:Right Side
+右側
+
+:Image4 Preview (deferred)
+画像4 プレビュー (延期)
+
+:Image5 Preview (deferred)
+画像5 プレビュー (延期)
+
+:Bulk import/export the battle screen as a single image. TSA layout means common tiles must be deduplicated.
+戦闘画面を 1 つの画像として一括インポート/エクスポートします。TSA レイアウトのため、共通タイルは重複排除する必要があります。
+
+:KnownGap: bulk image Import requires ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByteKeepTSA (WinForms-coupled, #393).
+KnownGap: 一括画像インポートには ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByteKeepTSA (WinForms 依存, #393) が必要です。
+
+:KnownGap: bulk image Export requires ImageFormRef.ExportImage + live battle-screen bitmap (WinForms-coupled, #393).
+KnownGap: 一括画像エクスポートには ImageFormRef.ExportImage + ライブ戦闘画面ビットマップ (WinForms 依存, #393) が必要です。
+
+:KnownGap: local TSA redo buffer is WinForms-coupled. Use the main ROM-level Undo via the toolbar (#393).
+KnownGap: ローカル TSA Redo バッファは WinForms 依存です。ツールバーのメイン ROM レベルの Undo を使用してください (#393)。
+
+:Palette 1
+パレット 1
+
+:Palette 2
+パレット 2
+
+:Palette 3
+パレット 3
+
+:Palette 4
+パレット 4
+
+:1x Zoom
+1 倍ズーム
+
+:Selected: 00
+選択: 00
+
+:Canvas:
+キャンバス:
+
+:Edit Battle Screen
+戦闘画面を編集
+
+:Edit Battle Screen Palette
+戦闘画面パレットを編集
+
+:KnownGap: zoom only affects the deferred Battle/Chipset preview rendering (WinForms-coupled, #393). Re-enabled once the live preview lands.
+KnownGap: ズームは延期された戦闘/チップセットプレビュー描画にのみ影響します (WinForms 依存, #393)。ライブプレビューが実装されると再有効化されます。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -22178,3 +22178,111 @@ KnownGap: 列表扩展需要 DataExpansionCore 接线尚未移植。
 KnownGap: DecreaseColorTSAToolForm 尚未移植。
 :KnownGap: ResourceCache source-file feature not yet wired in Avalonia.
 KnownGap: ResourceCache 源文件功能在 Avalonia 中尚未接线。
+
+:Chipset Preview (deferred KnownGap): live LZ77 decode + flip permutations are WinForms-coupled (ImageUtil.BitBlt). Use the WinForms editor to paint TSA cells.
+图块集预览（已知缺口已延期）：实时 LZ77 解码 + 翻转置换依赖 WinForms (ImageUtil.BitBlt)。请使用 WinForms 编辑器绘制 TSA 单元格。
+
+:KnownGap: chipset thumbnail rendering is WinForms-coupled (#393).
+已知缺口：图块集缩略图渲染依赖 WinForms (#393)。
+
+:Battle Preview (deferred KnownGap): rendering the 32x20 TSA grid with the live palette requires System.Drawing + ImageUtil.BitBlt. The numeric fields and palette/image pointer write paths in this editor are functional under the ambient undo scope.
+战斗预览（已知缺口已延期）：使用实时调色板渲染 32x20 TSA 网格需要 System.Drawing + ImageUtil.BitBlt。此编辑器中的数值字段以及调色板/图像指针写入路径在环境 Undo 作用域下可用。
+
+:KnownGap: battle-screen bitmap rendering is WinForms-coupled (#393).
+已知缺口：战斗画面位图渲染依赖 WinForms (#393)。
+
+:TSA1 Address
+TSA1 地址
+
+:KnownGap: local palette-edit redo (PaletteFormRef redo buffer) is WinForms-coupled (#393). Use the main ROM-level Undo via the toolbar.
+已知缺口：本地调色板编辑的 Redo (PaletteFormRef redo 缓冲区) 依赖 WinForms (#393)。请使用工具栏中的主 ROM 级 Undo。
+
+:Tile1
+Tile1
+
+:Tile2
+Tile2
+
+:Tile3
+Tile3
+
+:Tile4
+Tile4
+
+:Tile5
+Tile5
+
+:KnownGap: per-image LZ77 Import (ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByte16Tile) is WinForms-coupled (#393).
+已知缺口：每图像 LZ77 导入 (ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByte16Tile) 依赖 WinForms (#393)。
+
+:KnownGap: per-image PNG Export (ImageFormRef.ExportImage) is WinForms-coupled (#393).
+已知缺口：每图像 PNG 导出 (ImageFormRef.ExportImage) 依赖 WinForms (#393)。
+
+:Image1 Preview (deferred KnownGap): per-tile LZ77 decompress + palette blit is WinForms-coupled (#393).
+图像1 预览（已知缺口已延期）：每图块 LZ77 解压 + 调色板 blit 依赖 WinForms (#393)。
+
+:Left Side
+左侧
+
+:KnownGap: per-image LZ77 Import is WinForms-coupled (#393).
+已知缺口：每图像 LZ77 导入依赖 WinForms (#393)。
+
+:KnownGap: per-image PNG Export is WinForms-coupled (#393).
+已知缺口：每图像 PNG 导出依赖 WinForms (#393)。
+
+:Image2 Preview (deferred)
+图像2 预览（已延期）
+
+:Image3 Preview (deferred)
+图像3 预览（已延期）
+
+:Right Side
+右侧
+
+:Image4 Preview (deferred)
+图像4 预览（已延期）
+
+:Image5 Preview (deferred)
+图像5 预览（已延期）
+
+:Bulk import/export the battle screen as a single image. TSA layout means common tiles must be deduplicated.
+将战斗画面作为单个图像批量导入/导出。TSA 布局意味着公共图块必须去重。
+
+:KnownGap: bulk image Import requires ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByteKeepTSA (WinForms-coupled, #393).
+已知缺口：批量图像导入需要 ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByteKeepTSA（WinForms 依赖，#393）。
+
+:KnownGap: bulk image Export requires ImageFormRef.ExportImage + live battle-screen bitmap (WinForms-coupled, #393).
+已知缺口：批量图像导出需要 ImageFormRef.ExportImage + 实时战斗画面位图（WinForms 依赖，#393）。
+
+:KnownGap: local TSA redo buffer is WinForms-coupled. Use the main ROM-level Undo via the toolbar (#393).
+已知缺口：本地 TSA Redo 缓冲区依赖 WinForms。请使用工具栏中的主 ROM 级 Undo (#393)。
+
+:Palette 1
+调色板 1
+
+:Palette 2
+调色板 2
+
+:Palette 3
+调色板 3
+
+:Palette 4
+调色板 4
+
+:1x Zoom
+1倍缩放
+
+:Selected: 00
+已选: 00
+
+:Canvas:
+画布:
+
+:Edit Battle Screen
+编辑战斗画面
+
+:Edit Battle Screen Palette
+编辑战斗画面调色板
+
+:KnownGap: zoom only affects the deferred Battle/Chipset preview rendering (WinForms-coupled, #393). Re-enabled once the live preview lands.
+已知缺口：缩放仅影响已延期的战斗/图块集预览渲染（WinForms 依赖，#393）。实时预览实现后将重新启用。

--- a/docs/avalonia-gaps/2026-05-24-density-sweep.md
+++ b/docs/avalonia-gaps/2026-05-24-density-sweep.md
@@ -1,6 +1,6 @@
 ---
-generated: "2026-05-24T10:36:19Z"
-git-sha: 81ad8040b
+generated: "2026-05-24T11:54:59Z"
+git-sha: cedbf79ee
 sweep-type: density
 ---
 
@@ -20,9 +20,9 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-density --out=<path>`.
 
 | Verdict | Threshold | Count |
 |---|---|---|
-| HIGH | |Δ%| ≥ 50 | 207 |
+| HIGH | |Δ%| ≥ 50 | 205 |
 | MEDIUM | 25 ≤ |Δ%| < 50 | 86 |
-| LOW | |Δ%| < 25 | 77 |
+| LOW | |Δ%| < 25 | 79 |
 
 ## Ranked Density Deltas
 
@@ -39,9 +39,7 @@ Both represent pairing artifacts rather than real migration gaps.
 | Verdict | WF Form | AV View | WF | AV | Δ | Δ% | Match |
 |---|---|---|---:|---:|---:|---:|---|
 | High | `EmulatorMemoryForm` | `EmulatorMemoryView` | 353 | 5 | -348 | -98.6% | Heuristic |
-| High | `ImageBattleScreenForm` | `ImageBattleScreenView` | 133 | 3 | -130 | -97.7% | Heuristic |
 | High | `MapSettingFE6Form` | `MapSettingFE6View` | 126 | 3 | -123 | -97.6% | ListParityHelper |
-| High | `ImageTSAEditorForm` | `ImageTSAEditorView` | 100 | 3 | -97 | -97.0% | Heuristic |
 | High | `ClassFE6Form` | `ClassFE6View` | 173 | 8 | -165 | -95.4% | Heuristic |
 | High | `EventBattleTalkFE7Form` | `EventBattleTalkFE7View` | 62 | 3 | -59 | -95.2% | ListParityHelper |
 | High | `EventBattleTalkFE6Form` | `EventBattleTalkFE6View` | 61 | 3 | -58 | -95.1% | ListParityHelper |
@@ -234,6 +232,7 @@ Both represent pairing artifacts rather than real migration gaps.
 | Low | `RAMRewriteToolMAPForm` | `RAMRewriteToolMAPView` | 11 | 10 | -1 | -9.1% | Heuristic |
 | Low | `ItemStatBonusesSkillSystemsForm` | `ItemStatBonusesSkillSystemsView` | 51 | 47 | -4 | -7.8% | Heuristic |
 | Low | `UnitsShortTextForm` | `UnitsShortTextView` | 13 | 12 | -1 | -7.7% | Heuristic |
+| Low | `ImageBattleScreenForm` | `ImageBattleScreenView` | 133 | 125 | -8 | -6.0% | Heuristic |
 | Low | `StatusOptionForm` | `StatusOptionView` | 50 | 47 | -3 | -6.0% | ListParityHelper |
 | Low | `ToolLZ77Form` | `ToolLZ77View` | 50 | 48 | -2 | -4.0% | Heuristic |
 | Low | `MapSettingForm` | `MapSettingView` | 224 | 220 | -4 | -1.8% | ListParityHelper |
@@ -252,6 +251,7 @@ Both represent pairing artifacts rather than real migration gaps.
 | Low | `OPClassDemoForm` | `OPClassDemoViewerView` | 63 | 65 | 2 | +3.2% | Heuristic |
 | Low | `EDFE7Form` | `EDFE7View` | 81 | 84 | 3 | +3.7% | Heuristic |
 | Low | `MenuExtendSplitMenuForm` | `MenuExtendSplitMenuView` | 27 | 28 | 1 | +3.7% | ListParityHelper |
+| Low | `ImageTSAEditorForm` | `ImageTSAEditorView` | 100 | 105 | 5 | +5.0% | Heuristic |
 | Low | `DumpStructSelectDialogForm` | `DumpStructSelectDialogView` | 19 | 20 | 1 | +5.3% | Heuristic |
 | Low | `ItemShopForm` | `ItemShopViewerView` | 17 | 18 | 1 | +5.9% | ListParityHelper |
 | Low | `ImageUnitPaletteForm` | `ImageUnitPaletteView` | 133 | 141 | 8 | +6.0% | ListParityHelper |
@@ -376,28 +376,12 @@ WF count: **353** · AV count: **5** · Δ: **-348** (-98.6%).
   grep -E '(Text|Content|Header)=' FEBuilderGBA.Avalonia/Views/EmulatorMemoryView.axaml
 -->
 
-### ImageBattleScreenForm
-WF count: **133** · AV count: **3** · Δ: **-130** (-97.7%).
-
-<!-- Triage: list specific missing fields here. Suggested probe:
-  grep -E '\.Text\s*=' FEBuilderGBA/ImageBattleScreenForm.Designer.cs
-  grep -E '(Text|Content|Header)=' FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml
--->
-
 ### MapSettingFE6Form
 WF count: **126** · AV count: **3** · Δ: **-123** (-97.6%).
 
 <!-- Triage: list specific missing fields here. Suggested probe:
   grep -E '\.Text\s*=' FEBuilderGBA/MapSettingFE6Form.Designer.cs
   grep -E '(Text|Content|Header)=' FEBuilderGBA.Avalonia/Views/MapSettingFE6View.axaml
--->
-
-### ImageTSAEditorForm
-WF count: **100** · AV count: **3** · Δ: **-97** (-97.0%).
-
-<!-- Triage: list specific missing fields here. Suggested probe:
-  grep -E '\.Text\s*=' FEBuilderGBA/ImageTSAEditorForm.Designer.cs
-  grep -E '(Text|Content|Header)=' FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml
 -->
 
 ### ClassFE6Form
@@ -526,6 +510,22 @@ WF count: **72** · AV count: **8** · Δ: **-64** (-88.9%).
 <!-- Triage: list specific missing fields here. Suggested probe:
   grep -E '\.Text\s*=' FEBuilderGBA/MoveCostForm.Designer.cs
   grep -E '(Text|Content|Header)=' FEBuilderGBA.Avalonia/Views/MoveCostEditorView.axaml
+-->
+
+### SkillConfigFE8NVer3SkillForm
+WF count: **166** · AV count: **19** · Δ: **-147** (-88.6%).
+
+<!-- Triage: list specific missing fields here. Suggested probe:
+  grep -E '\.Text\s*=' FEBuilderGBA/SkillConfigFE8NVer3SkillForm.Designer.cs
+  grep -E '(Text|Content|Header)=' FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml
+-->
+
+### SkillConfigFE8NVer2SkillForm
+WF count: **136** · AV count: **17** · Δ: **-119** (-87.5%).
+
+<!-- Triage: list specific missing fields here. Suggested probe:
+  grep -E '\.Text\s*=' FEBuilderGBA/SkillConfigFE8NVer2SkillForm.Designer.cs
+  grep -E '(Text|Content|Header)=' FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer2SkillView.axaml
 -->
 
 ## Unpaired Orphans

--- a/docs/avalonia-gaps/2026-05-24-jumps-sweep.md
+++ b/docs/avalonia-gaps/2026-05-24-jumps-sweep.md
@@ -1,6 +1,6 @@
 ---
-generated: "2026-05-24T10:36:28Z"
-git-sha: 81ad8040b
+generated: "2026-05-24T11:55:04Z"
+git-sha: cedbf79ee
 sweep-type: jumps
 ---
 

--- a/docs/avalonia-gaps/2026-05-24-l10n-sweep.md
+++ b/docs/avalonia-gaps/2026-05-24-l10n-sweep.md
@@ -1,6 +1,6 @@
 ---
-generated: "2026-05-24T10:36:34Z"
-git-sha: 81ad8040b
+generated: "2026-05-24T11:55:07Z"
+git-sha: cedbf79ee
 sweep-type: l10n
 languages: ja,zh,ko
 ---
@@ -49,11 +49,11 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-l10n --out=<path>`.
 
 | Verdict | Count | % of total |
 |---|---:|---:|
-| Untranslated | 14 | 0.3 |
-| PartiallyTranslated | 4202 | 99.6 |
+| Untranslated | 60 | 1.4 |
+| PartiallyTranslated | 4232 | 98.6 |
 | Translated | 0 | 0.0 |
 | NonEnglish | 2 | 0.0 |
-| **Total** | 4218 | 100.0 |
+| **Total** | 4294 | 100.0 |
 
 ## Per-language Coverage
 
@@ -61,9 +61,9 @@ Coverage is computed over the English-source literals only (excludes the `NonEng
 
 | Language | Translated | English-source total | % |
 |---|---:|---:|---:|
-| `ja` | 4202 | 4216 | 99.7 |
-| `zh` | 4202 | 4216 | 99.7 |
-| `ko` | 0 | 4216 | 0.0 |
+| `ja` | 4221 | 4292 | 98.3 |
+| `zh` | 4232 | 4292 | 98.6 |
+| `ko` | 0 | 4292 | 0.0 |
 
 ## Top 20 Files by Untranslated Literal Count
 
@@ -72,17 +72,69 @@ file. Files are sorted by Untranslated count descending.
 
 | Rank | File | Untranslated |
 |---:|---|---:|
-| 1 | `FEBuilderGBA.Avalonia/Views/MoveToFreeSpaceView.axaml` | 3 |
-| 2 | `FEBuilderGBA.Avalonia/Views/OptionsView.axaml` | 3 |
-| 3 | `FEBuilderGBA.Avalonia/Views/RAMRewriteToolMAPView.axaml` | 3 |
-| 4 | `FEBuilderGBA.Avalonia/Views/PointerToolView.axaml` | 2 |
-| 5 | `FEBuilderGBA.Avalonia/Views/RAMRewriteToolView.axaml` | 2 |
-| 6 | `FEBuilderGBA.Avalonia/Views/ToolAnimationCreatorView.axaml` | 1 |
+| 1 | `FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml` | 45 |
+| 2 | `FEBuilderGBA.Avalonia/Views/MoveToFreeSpaceView.axaml` | 3 |
+| 3 | `FEBuilderGBA.Avalonia/Views/OptionsView.axaml` | 3 |
+| 4 | `FEBuilderGBA.Avalonia/Views/RAMRewriteToolMAPView.axaml` | 3 |
+| 5 | `FEBuilderGBA.Avalonia/Views/PointerToolView.axaml` | 2 |
+| 6 | `FEBuilderGBA.Avalonia/Views/RAMRewriteToolView.axaml` | 2 |
+| 7 | `FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml` | 1 |
+| 8 | `FEBuilderGBA.Avalonia/Views/ToolAnimationCreatorView.axaml` | 1 |
 
 ## Untranslated Literals (No Language Has Them)
 
 Each row is a literal that has no translation in ANY of the target
 languages. Fix these by adding entries to `config/translate/<lang>.txt`.
+
+### `FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 34 | `Button` | `Content` | `Write Pointers` |
+| 85 | `Button` | `ToolTip.Tip` | `KnownGap: pending Core extraction.` |
+| 89 | `Button` | `ToolTip.Tip` | `KnownGap: pending Core extraction.` |
+| 94 | `Button` | `Content` | `Dark Map Import (Palette)` |
+| 96 | `Button` | `ToolTip.Tip` | `KnownGap: pending Core extraction.` |
+| 98 | `Button` | `Content` | `Dark Map Export` |
+| 100 | `Button` | `ToolTip.Tip` | `KnownGap: pending Core extraction.` |
+| 103 | `Button` | `Content` | `Decrease Color Tool` |
+| 105 | `Button` | `ToolTip.Tip` | `KnownGap: DecreaseColorTSAToolForm not yet ported.` |
+| 109 | `Button` | `ToolTip.Tip` | `KnownGap: ResourceCache source-file feature not yet wired in Avalonia.` |
+| 113 | `Button` | `ToolTip.Tip` | `KnownGap: ResourceCache source-file feature not yet wired in Avalonia.` |
+| 120 | `Image` | `ToolTip.Tip` | `KnownGap: live bitmap preview pending Core extraction.` |
+| 157 | `Button` | `ToolTip.Tip` | `KnownGap: pending Core extraction.` |
+| 161 | `Button` | `ToolTip.Tip` | `KnownGap: pending Core extraction.` |
+| 163 | `Button` | `Content` | `Decrease Color Tool` |
+| 165 | `Button` | `ToolTip.Tip` | `KnownGap: DecreaseColorTSAToolForm not yet ported.` |
+| 171 | `Image` | `ToolTip.Tip` | `KnownGap: live bitmap preview pending Core extraction.` |
+| 201 | `Button` | `ToolTip.Tip` | `KnownGap: pending Core extraction.` |
+| 205 | `Button` | `ToolTip.Tip` | `KnownGap: pending Core extraction.` |
+| 211 | `Image` | `ToolTip.Tip` | `KnownGap: live bitmap preview pending Core extraction.` |
+| 219 | `TabItem` | `Header` | `Point Icon` |
+| 225 | `Label` | `Content` | `Point Image 1` |
+| 233 | `Button` | `ToolTip.Tip` | `KnownGap: pending Core extraction.` |
+| 237 | `Button` | `ToolTip.Tip` | `KnownGap: pending Core extraction.` |
+| 242 | `Label` | `Content` | `Point Image 2` |
+| 250 | `Button` | `ToolTip.Tip` | `KnownGap: pending Core extraction.` |
+| 254 | `Button` | `ToolTip.Tip` | `KnownGap: pending Core extraction.` |
+| 267 | `Button` | `ToolTip.Tip` | `KnownGap: pending Core extraction.` |
+| 271 | `Button` | `ToolTip.Tip` | `KnownGap: pending Core extraction.` |
+| 276 | `Label` | `Content` | `Icon Palette` |
+| 283 | `Label` | `Content` | `Point 1 Preview` |
+| 287 | `Image` | `ToolTip.Tip` | `KnownGap: live bitmap preview pending Core extraction.` |
+| 289 | `Label` | `Content` | `Point 2 Preview` |
+| 293 | `Image` | `ToolTip.Tip` | `KnownGap: live bitmap preview pending Core extraction.` |
+| 295 | `Label` | `Content` | `Road Preview` |
+| 299 | `Image` | `ToolTip.Tip` | `KnownGap: live bitmap preview pending Core extraction.` |
+| 330 | `Button` | `ToolTip.Tip` | `KnownGap: list-expand requires DataExpansionCore wiring not yet ported.` |
+| 401 | `Label` | `Content` | `Draw Example` |
+| 405 | `Image` | `ToolTip.Tip` | `KnownGap: live bitmap preview pending Core extraction.` |
+| 412 | `Button` | `ToolTip.Tip` | `KnownGap: pending Core extraction.` |
+| 416 | `Button` | `ToolTip.Tip` | `KnownGap: pending Core extraction.` |
+| 426 | `TabItem` | `Header` | `Icon Data` |
+| 448 | `Button` | `ToolTip.Tip` | `KnownGap: list-expand requires DataExpansionCore wiring not yet ported.` |
+| 525 | `Label` | `Content` | `OAMTable entry` |
+| 570 | `Label` | `Content` | `tcs params??` |
 
 ### `FEBuilderGBA.Avalonia/Views/MoveToFreeSpaceView.axaml`
 
@@ -121,6 +173,12 @@ languages. Fix these by adding entries to `config/translate/<lang>.txt`.
 |---:|---|---|---|
 | 25 | `TextBox` | `Watermark` | `e.g. 0x02000000` |
 | 27 | `TextBox` | `Watermark` | `e.g. 0xFF` |
+
+### `FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml`
+
+| Line | Element | Attribute | Literal |
+|---:|---|---|---|
+| 100 | `Label` | `Content` | `Chipset Preview` |
 
 ### `FEBuilderGBA.Avalonia/Views/ToolAnimationCreatorView.axaml`
 
@@ -660,109 +718,6 @@ show which languages cover the literal.
 | 378 | `B146: ??` | ✓ | ✓ | ✗ |
 | 380 | `B147: ??` | ✓ | ✓ | ✗ |
 | 387 | `Write` | ✓ | ✓ | ✗ |
-
-### `FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml`
-
-| Line | Literal | ja | zh | ko |
-|---:|---|:---:|:---:|:---:|
-| 34 | `Write Pointers` | ✓ | ✓ | ✗ |
-| 37 | `Undo` | ✓ | ✓ | ✗ |
-| 48 | `Main Field Map` | ✓ | ✓ | ✗ |
-| 55 | `Image` | ✓ | ✓ | ✗ |
-| 62 | `Palette` | ✓ | ✓ | ✗ |
-| 69 | `Dark Palette` | ✓ | ✓ | ✗ |
-| 76 | `Palette Map` | ✓ | ✓ | ✗ |
-| 83 | `Import Image` | ✓ | ✓ | ✗ |
-| 85 | `KnownGap: pending Core extraction.` | ✓ | ✓ | ✗ |
-| 87 | `Export Image` | ✓ | ✓ | ✗ |
-| 89 | `KnownGap: pending Core extraction.` | ✓ | ✓ | ✗ |
-| 92 | `Dark Map` | ✓ | ✓ | ✗ |
-| 94 | `Dark Map Import (Palette)` | ✓ | ✓ | ✗ |
-| 96 | `KnownGap: pending Core extraction.` | ✓ | ✓ | ✗ |
-| 98 | `Dark Map Export` | ✓ | ✓ | ✗ |
-| 100 | `KnownGap: pending Core extraction.` | ✓ | ✓ | ✗ |
-| 103 | `Decrease Color Tool` | ✓ | ✓ | ✗ |
-| 105 | `KnownGap: DecreaseColorTSAToolForm not yet ported.` | ✓ | ✓ | ✗ |
-| 107 | `Open Source File` | ✓ | ✓ | ✗ |
-| 109 | `KnownGap: ResourceCache source-file feature not yet wired in Avalonia.` | ✓ | ✓ | ✗ |
-| 111 | `Open Source Folder` | ✓ | ✓ | ✗ |
-| 113 | `KnownGap: ResourceCache source-file feature not yet wired in Avalonia.` | ✓ | ✓ | ✗ |
-| 120 | `KnownGap: live bitmap preview pending Core extraction.` | ✓ | ✓ | ✗ |
-| 128 | `Event` | ✓ | ✓ | ✗ |
-| 134 | `Image` | ✓ | ✓ | ✗ |
-| 141 | `Palette` | ✓ | ✓ | ✗ |
-| 155 | `Import Image` | ✓ | ✓ | ✗ |
-| 157 | `KnownGap: pending Core extraction.` | ✓ | ✓ | ✗ |
-| 159 | `Export Image` | ✓ | ✓ | ✗ |
-| 161 | `KnownGap: pending Core extraction.` | ✓ | ✓ | ✗ |
-| 163 | `Decrease Color Tool` | ✓ | ✓ | ✗ |
-| 165 | `KnownGap: DecreaseColorTSAToolForm not yet ported.` | ✓ | ✓ | ✗ |
-| 171 | `KnownGap: live bitmap preview pending Core extraction.` | ✓ | ✓ | ✗ |
-| 179 | `Mini Map` | ✓ | ✓ | ✗ |
-| 185 | `Image` | ✓ | ✓ | ✗ |
-| 192 | `Palette` | ✓ | ✓ | ✗ |
-| 199 | `Import Image` | ✓ | ✓ | ✗ |
-| 201 | `KnownGap: pending Core extraction.` | ✓ | ✓ | ✗ |
-| 203 | `Export Image` | ✓ | ✓ | ✗ |
-| 205 | `KnownGap: pending Core extraction.` | ✓ | ✓ | ✗ |
-| 211 | `KnownGap: live bitmap preview pending Core extraction.` | ✓ | ✓ | ✗ |
-| 219 | `Point Icon` | ✓ | ✓ | ✗ |
-| 225 | `Point Image 1` | ✓ | ✓ | ✗ |
-| 231 | `Import` | ✓ | ✓ | ✗ |
-| 233 | `KnownGap: pending Core extraction.` | ✓ | ✓ | ✗ |
-| 235 | `Export` | ✓ | ✓ | ✗ |
-| 237 | `KnownGap: pending Core extraction.` | ✓ | ✓ | ✗ |
-| 242 | `Point Image 2` | ✓ | ✓ | ✗ |
-| 248 | `Import` | ✓ | ✓ | ✗ |
-| 250 | `KnownGap: pending Core extraction.` | ✓ | ✓ | ✗ |
-| 252 | `Export` | ✓ | ✓ | ✗ |
-| 254 | `KnownGap: pending Core extraction.` | ✓ | ✓ | ✗ |
-| 259 | `Road Image` | ✓ | ✓ | ✗ |
-| 265 | `Import` | ✓ | ✓ | ✗ |
-| 267 | `KnownGap: pending Core extraction.` | ✓ | ✓ | ✗ |
-| 269 | `Export` | ✓ | ✓ | ✗ |
-| 271 | `KnownGap: pending Core extraction.` | ✓ | ✓ | ✗ |
-| 276 | `Icon Palette` | ✓ | ✓ | ✗ |
-| 283 | `Point 1 Preview` | ✓ | ✓ | ✗ |
-| 287 | `KnownGap: live bitmap preview pending Core extraction.` | ✓ | ✓ | ✗ |
-| 289 | `Point 2 Preview` | ✓ | ✓ | ✗ |
-| 293 | `KnownGap: live bitmap preview pending Core extraction.` | ✓ | ✓ | ✗ |
-| 295 | `Road Preview` | ✓ | ✓ | ✗ |
-| 299 | `KnownGap: live bitmap preview pending Core extraction.` | ✓ | ✓ | ✗ |
-| 308 | `Border` | ✓ | ✓ | ✗ |
-| 314 | `Start Address` | ✓ | ✓ | ✗ |
-| 319 | `Read Count` | ✓ | ✓ | ✗ |
-| 325 | `Reload` | ✓ | ✓ | ✗ |
-| 328 | `List Expand` | ✓ | ✓ | ✗ |
-| 330 | `KnownGap: list-expand requires DataExpansionCore wiring not yet ported.` | ✓ | ✓ | ✗ |
-| 337 | `Address` | ✓ | ✓ | ✗ |
-| 342 | `Size:` | ✓ | ✓ | ✗ |
-| 346 | `Selected Address:` | ✓ | ✓ | ✗ |
-| 352 | `Write` | ✓ | ✓ | ✗ |
-| 369 | `Image` | ✓ | ✓ | ✗ |
-| 401 | `Draw Example` | ✓ | ✓ | ✗ |
-| 405 | `KnownGap: live bitmap preview pending Core extraction.` | ✓ | ✓ | ✗ |
-| 410 | `Import Image` | ✓ | ✓ | ✗ |
-| 412 | `KnownGap: pending Core extraction.` | ✓ | ✓ | ✗ |
-| 414 | `Export Image` | ✓ | ✓ | ✗ |
-| 416 | `KnownGap: pending Core extraction.` | ✓ | ✓ | ✗ |
-| 426 | `Icon Data` | ✓ | ✓ | ✗ |
-| 432 | `Start Address` | ✓ | ✓ | ✗ |
-| 437 | `Read Count` | ✓ | ✓ | ✗ |
-| 443 | `Reload` | ✓ | ✓ | ✗ |
-| 446 | `List Expand` | ✓ | ✓ | ✗ |
-| 448 | `KnownGap: list-expand requires DataExpansionCore wiring not yet ported.` | ✓ | ✓ | ✗ |
-| 455 | `Address` | ✓ | ✓ | ✗ |
-| 460 | `Size:` | ✓ | ✓ | ✗ |
-| 464 | `Selected Address:` | ✓ | ✓ | ✗ |
-| 470 | `Write` | ✓ | ✓ | ✗ |
-| 489 | `Image Sheet Number` | ✓ | ✓ | ✗ |
-| 525 | `OAMTable entry` | ✓ | ✓ | ✗ |
-| 534 | `Center X` | ✓ | ✓ | ✗ |
-| 543 | `Center Y` | ✓ | ✓ | ✗ |
-| 552 | `Width` | ✓ | ✓ | ✗ |
-| 561 | `Height` | ✓ | ✓ | ✗ |
-| 570 | `tcs params??` | ✓ | ✓ | ✗ |
 
 ### `FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml`
 
@@ -1329,6 +1284,75 @@ show which languages cover the literal.
 | 294 | `Magic Ext:` | ✓ | ✓ | ✗ |
 | 299 | `Write` | ✓ | ✓ | ✗ |
 
+### `FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 14 | `Battle Screen` | ✓ | ✓ | ✗ |
+| 28 | `Write` | ✓ | ✓ | ✗ |
+| 30 | `Zoom` | ✓ | ✓ | ✗ |
+| 34 | `KnownGap: zoom only affects the deferred Battle/Chipset preview rendering (WinForms-coupled, #393). Re-enabled once the live preview lands.` | ✓ | ✓ | ✗ |
+| 52 | `Chipset Preview (deferred KnownGap): live LZ77 decode + flip permutations are WinForms-coupled (ImageUtil.BitBlt). Use the WinForms editor to paint TSA cells.` | ✓ | ✓ | ✗ |
+| 54 | `KnownGap: chipset thumbnail rendering is WinForms-coupled (#393).` | ✓ | ✓ | ✗ |
+| 57 | `Battle Preview (deferred KnownGap): rendering the 32x20 TSA grid with the live palette requires System.Drawing + ImageUtil.BitBlt. The numeric fields and palette/image pointer write paths in this edit… (truncated)` | ✓ | ✓ | ✗ |
+| 59 | `KnownGap: battle-screen bitmap rendering is WinForms-coupled (#393).` | ✓ | ✓ | ✗ |
+| 68 | `TSA1 Address` | ✓ | ✓ | ✗ |
+| 82 | `Palette` | ✓ | ✓ | ✗ |
+| 88 | `Palette Address` | ✓ | ✓ | ✗ |
+| 92 | `Palette Type` | ✓ | ✓ | ✗ |
+| 97 | `Palette Write` | ✓ | ✓ | ✗ |
+| 100 | `Clipboard` | ✓ | ✓ | ✗ |
+| 103 | `Undo` | ✓ | ✓ | ✗ |
+| 106 | `Redo` | ✓ | ✓ | ✗ |
+| 108 | `KnownGap: local palette-edit redo (PaletteFormRef redo buffer) is WinForms-coupled (#393). Use the main ROM-level Undo via the toolbar.` | ✓ | ✓ | ✗ |
+| 338 | `Main Image` | ✓ | ✓ | ✗ |
+| 342 | `Tile1` | ✓ | ✓ | ✗ |
+| 344 | `Tile2` | ✓ | ✓ | ✗ |
+| 346 | `Tile3` | ✓ | ✓ | ✗ |
+| 348 | `Tile4` | ✓ | ✓ | ✗ |
+| 350 | `Tile5` | ✓ | ✓ | ✗ |
+| 353 | `Image` | ✓ | ✓ | ✗ |
+| 358 | `Image Import` | ✓ | ✓ | ✗ |
+| 359 | `KnownGap: per-image LZ77 Import (ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByte16Tile) is WinForms-coupled (#393).` | ✓ | ✓ | ✗ |
+| 361 | `Image Export` | ✓ | ✓ | ✗ |
+| 362 | `KnownGap: per-image PNG Export (ImageFormRef.ExportImage) is WinForms-coupled (#393).` | ✓ | ✓ | ✗ |
+| 366 | `Image1 Preview (deferred KnownGap): per-tile LZ77 decompress + palette blit is WinForms-coupled (#393).` | ✓ | ✓ | ✗ |
+| 374 | `Left Side` | ✓ | ✓ | ✗ |
+| 378 | `Name` | ✓ | ✓ | ✗ |
+| 384 | `Image Import` | ✓ | ✓ | ✗ |
+| 385 | `KnownGap: per-image LZ77 Import is WinForms-coupled (#393).` | ✓ | ✓ | ✗ |
+| 387 | `Image Export` | ✓ | ✓ | ✗ |
+| 388 | `KnownGap: per-image PNG Export is WinForms-coupled (#393).` | ✓ | ✓ | ✗ |
+| 391 | `Image2 Preview (deferred)` | ✓ | ✓ | ✗ |
+| 396 | `Item` | ✓ | ✓ | ✗ |
+| 402 | `Image Import` | ✓ | ✓ | ✗ |
+| 403 | `KnownGap: per-image LZ77 Import is WinForms-coupled (#393).` | ✓ | ✓ | ✗ |
+| 405 | `Image Export` | ✓ | ✓ | ✗ |
+| 406 | `KnownGap: per-image PNG Export is WinForms-coupled (#393).` | ✓ | ✓ | ✗ |
+| 409 | `Image3 Preview (deferred)` | ✓ | ✓ | ✗ |
+| 417 | `Right Side` | ✓ | ✓ | ✗ |
+| 421 | `Name` | ✓ | ✓ | ✗ |
+| 427 | `Image Import` | ✓ | ✓ | ✗ |
+| 428 | `KnownGap: per-image LZ77 Import is WinForms-coupled (#393).` | ✓ | ✓ | ✗ |
+| 430 | `Image Export` | ✓ | ✓ | ✗ |
+| 431 | `KnownGap: per-image PNG Export is WinForms-coupled (#393).` | ✓ | ✓ | ✗ |
+| 434 | `Image4 Preview (deferred)` | ✓ | ✓ | ✗ |
+| 439 | `Item` | ✓ | ✓ | ✗ |
+| 445 | `Image Import` | ✓ | ✓ | ✗ |
+| 446 | `KnownGap: per-image LZ77 Import is WinForms-coupled (#393).` | ✓ | ✓ | ✗ |
+| 448 | `Image Export` | ✓ | ✓ | ✗ |
+| 449 | `KnownGap: per-image PNG Export is WinForms-coupled (#393).` | ✓ | ✓ | ✗ |
+| 452 | `Image5 Preview (deferred)` | ✓ | ✓ | ✗ |
+| 460 | `Import/Export` | ✓ | ✓ | ✗ |
+| 463 | `Bulk import/export the battle screen as a single image. TSA layout means common tiles must be deduplicated.` | ✓ | ✓ | ✗ |
+| 467 | `Image Import` | ✓ | ✓ | ✗ |
+| 468 | `KnownGap: bulk image Import requires ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByteKeepTSA (WinForms-coupled, #393).` | ✓ | ✓ | ✗ |
+| 470 | `Image Export` | ✓ | ✓ | ✗ |
+| 471 | `KnownGap: bulk image Export requires ImageFormRef.ExportImage + live battle-screen bitmap (WinForms-coupled, #393).` | ✓ | ✓ | ✗ |
+| 473 | `Undo` | ✓ | ✓ | ✗ |
+| 476 | `Redo` | ✓ | ✓ | ✗ |
+| 477 | `KnownGap: local TSA redo buffer is WinForms-coupled. Use the main ROM-level Undo via the toolbar (#393).` | ✓ | ✓ | ✗ |
+
 ### `FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml`
 
 | Line | Literal | ja | zh | ko |
@@ -1386,6 +1410,64 @@ show which languages cover the literal.
 | 367 | `Reload List` | ✓ | ✓ | ✗ |
 | 369 | `Expand List` | ✓ | ✓ | ✗ |
 | 370 | `KnownGap` | ✓ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 37 | `Undo` | ✓ | ✓ | ✗ |
+| 48 | `Main Field Map` | ✗ | ✓ | ✗ |
+| 55 | `Image` | ✓ | ✓ | ✗ |
+| 62 | `Palette` | ✓ | ✓ | ✗ |
+| 69 | `Dark Palette` | ✗ | ✓ | ✗ |
+| 76 | `Palette Map` | ✗ | ✓ | ✗ |
+| 83 | `Import Image` | ✓ | ✓ | ✗ |
+| 87 | `Export Image` | ✓ | ✓ | ✗ |
+| 92 | `Dark Map` | ✗ | ✓ | ✗ |
+| 107 | `Open Source File` | ✓ | ✓ | ✗ |
+| 111 | `Open Source Folder` | ✓ | ✓ | ✗ |
+| 128 | `Event` | ✗ | ✓ | ✗ |
+| 134 | `Image` | ✓ | ✓ | ✗ |
+| 141 | `Palette` | ✓ | ✓ | ✗ |
+| 155 | `Import Image` | ✓ | ✓ | ✗ |
+| 159 | `Export Image` | ✓ | ✓ | ✗ |
+| 179 | `Mini Map` | ✓ | ✓ | ✗ |
+| 185 | `Image` | ✓ | ✓ | ✗ |
+| 192 | `Palette` | ✓ | ✓ | ✗ |
+| 199 | `Import Image` | ✓ | ✓ | ✗ |
+| 203 | `Export Image` | ✓ | ✓ | ✗ |
+| 231 | `Import` | ✓ | ✓ | ✗ |
+| 235 | `Export` | ✗ | ✓ | ✗ |
+| 248 | `Import` | ✓ | ✓ | ✗ |
+| 252 | `Export` | ✗ | ✓ | ✗ |
+| 259 | `Road Image` | ✗ | ✓ | ✗ |
+| 265 | `Import` | ✓ | ✓ | ✗ |
+| 269 | `Export` | ✗ | ✓ | ✗ |
+| 308 | `Border` | ✗ | ✓ | ✗ |
+| 314 | `Start Address` | ✓ | ✓ | ✗ |
+| 319 | `Read Count` | ✓ | ✓ | ✗ |
+| 325 | `Reload` | ✓ | ✓ | ✗ |
+| 328 | `List Expand` | ✓ | ✓ | ✗ |
+| 337 | `Address` | ✓ | ✓ | ✗ |
+| 342 | `Size:` | ✓ | ✓ | ✗ |
+| 346 | `Selected Address:` | ✓ | ✓ | ✗ |
+| 352 | `Write` | ✓ | ✓ | ✗ |
+| 369 | `Image` | ✓ | ✓ | ✗ |
+| 410 | `Import Image` | ✓ | ✓ | ✗ |
+| 414 | `Export Image` | ✓ | ✓ | ✗ |
+| 432 | `Start Address` | ✓ | ✓ | ✗ |
+| 437 | `Read Count` | ✓ | ✓ | ✗ |
+| 443 | `Reload` | ✓ | ✓ | ✗ |
+| 446 | `List Expand` | ✓ | ✓ | ✗ |
+| 455 | `Address` | ✓ | ✓ | ✗ |
+| 460 | `Size:` | ✓ | ✓ | ✗ |
+| 464 | `Selected Address:` | ✓ | ✓ | ✗ |
+| 470 | `Write` | ✓ | ✓ | ✗ |
+| 489 | `Image Sheet Number` | ✗ | ✓ | ✗ |
+| 534 | `Center X` | ✓ | ✓ | ✗ |
+| 543 | `Center Y` | ✓ | ✓ | ✗ |
+| 552 | `Width` | ✓ | ✓ | ✗ |
+| 561 | `Height` | ✓ | ✓ | ✗ |
 
 ### `FEBuilderGBA.Avalonia/Views/SupportUnitFE6View.axaml`
 
@@ -3227,6 +3309,26 @@ show which languages cover the literal.
 | 50 | `Click to open Class Editor` | ✓ | ✓ | ✗ |
 | 52 | `Class:` | ✓ | ✓ | ✗ |
 | 57 | `Write` | ✓ | ✓ | ✗ |
+
+### `FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml`
+
+| Line | Literal | ja | zh | ko |
+|---:|---|:---:|:---:|:---:|
+| 45 | `Palette Index` | ✓ | ✓ | ✗ |
+| 68 | `Zoom` | ✓ | ✓ | ✗ |
+| 78 | `Undo` | ✓ | ✓ | ✗ |
+| 86 | `Redo` | ✓ | ✓ | ✗ |
+| 90 | `Write` | ✓ | ✓ | ✗ |
+| 130 | `Palette` | ✓ | ✓ | ✗ |
+| 139 | `Palette Address:` | ✓ | ✓ | ✗ |
+| 148 | `Clipboard` | ✓ | ✓ | ✗ |
+| 152 | `Palette Write` | ✓ | ✓ | ✗ |
+| 390 | `Undo` | ✓ | ✓ | ✗ |
+| 392 | `Redo` | ✓ | ✓ | ✗ |
+| 401 | `Main Image` | ✓ | ✓ | ✗ |
+| 406 | `Image` | ✓ | ✓ | ✗ |
+| 418 | `Image Import` | ✓ | ✓ | ✗ |
+| 421 | `Image Export` | ✓ | ✓ | ✗ |
 
 ### `FEBuilderGBA.Avalonia/Views/ItemEffectivenessViewerView.axaml`
 
@@ -5582,13 +5684,6 @@ show which languages cover the literal.
 | 14 | `Marked Addresses` | ✓ | ✓ | ✗ |
 | 18 | `Jump To` | ✓ | ✓ | ✗ |
 
-### `FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml`
-
-| Line | Literal | ja | zh | ko |
-|---:|---|:---:|:---:|:---:|
-| 12 | `Battle Screen Layout` | ✓ | ✓ | ✗ |
-| 15 | `Address:` | ✓ | ✓ | ✗ |
-
 ### `FEBuilderGBA.Avalonia/Views/ImageFormRefViewerView.axaml`
 
 | Line | Literal | ja | zh | ko |
@@ -5608,13 +5703,6 @@ show which languages cover the literal.
 | Line | Literal | ja | zh | ko |
 |---:|---|:---:|:---:|:---:|
 | 12 | `ROM Animation Viewer` | ✓ | ✓ | ✗ |
-| 15 | `Address:` | ✓ | ✓ | ✗ |
-
-### `FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml`
-
-| Line | Literal | ja | zh | ko |
-|---:|---|:---:|:---:|:---:|
-| 12 | `TSA Tile Editor` | ✓ | ✓ | ✗ |
 | 15 | `Address:` | ✓ | ✓ | ✗ |
 
 ### `FEBuilderGBA.Avalonia/Views/ImageUnitMoveIconView.axaml`

--- a/docs/avalonia-gaps/2026-05-24-labels-sweep.md
+++ b/docs/avalonia-gaps/2026-05-24-labels-sweep.md
@@ -1,6 +1,6 @@
 ---
-generated: "2026-05-24T10:36:26Z"
-git-sha: 81ad8040b
+generated: "2026-05-24T11:55:02Z"
+git-sha: cedbf79ee
 sweep-type: labels
 ---
 
@@ -36,9 +36,9 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-labels --out=<path>`.
 |---|---:|
 | Pairs scanned (both files exist) | 298 |
 | Pairs with ≥1 WF-only label | 293 |
-| Total WF-only labels | 4441 |
-| Total AV-only labels | 3400 |
-| Total common labels | 259 |
+| Total WF-only labels | 4393 |
+| Total AV-only labels | 3451 |
+| Total common labels | 307 |
 
 ## Top 20 Forms by WF-only Label Count
 
@@ -61,12 +61,12 @@ Cross-link to the [density sweep](2026-05-24-density-sweep.md) for quantitative 
 | 12 | `ItemForm` | `ItemEditorView` | 44 | 77 | 1 |
 | 13 | `ClassFE6Form` | `ClassFE6View` | 43 | 5 | 0 |
 | 14 | `ClassForm` | `ClassEditorView` | 43 | 107 | 15 |
-| 15 | `ImageBattleScreenForm` | `ImageBattleScreenView` | 42 | 2 | 0 |
-| 16 | `ItemFE6Form` | `ItemFE6View` | 42 | 68 | 2 |
-| 17 | `MonsterItemForm` | `MonsterItemViewerView` | 37 | 7 | 0 |
-| 18 | `SkillConfigFE8NVer3SkillForm` | `SkillConfigFE8NVer3SkillView` | 37 | 11 | 0 |
-| 19 | `ImageBattleAnimeForm` | `ImageBattleAnimeView` | 35 | 29 | 0 |
-| 20 | `UnitFE7Form` | `UnitFE7View` | 35 | 76 | 4 |
+| 15 | `ItemFE6Form` | `ItemFE6View` | 42 | 68 | 2 |
+| 16 | `MonsterItemForm` | `MonsterItemViewerView` | 37 | 7 | 0 |
+| 17 | `SkillConfigFE8NVer3SkillForm` | `SkillConfigFE8NVer3SkillView` | 37 | 11 | 0 |
+| 18 | `ImageBattleAnimeForm` | `ImageBattleAnimeView` | 35 | 29 | 0 |
+| 19 | `UnitFE7Form` | `UnitFE7View` | 35 | 76 | 4 |
+| 20 | `EventUnitFE6Form` | `EventUnitFE6View` | 34 | 24 | 0 |
 
 ## Per-pair WF-only Labels (gaps)
 
@@ -1781,59 +1781,6 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Weapon Rank Levels (B44-B51)`
 - `Write`
 
-### ImageBattleScreenForm
-WF labels: **42** · AV labels: **2** · WF-only: **42** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 133 / AV 3)
-
-WF-only labels (candidates for missing fields in AV):
-
-- `1`
-- `10`
-- `11`
-- `12`
-- `13`
-- `14`
-- `15`
-- `16`
-- `2`
-- `3`
-- `4`
-- `5`
-- `6`
-- `7`
-- `8`
-- `9`
-- `B`
-- `G`
-- `Import/Export`
-- `R`
-- `REDO`
-- `Tile1`
-- `Tile2`
-- `Tile3`
-- `Tile4`
-- `Tile5`
-- `UNDO`
-- `アイテム`
-- `クリップボード`
-- `パレット`
-- `パレットアドレス`
-- `パレット書き込み`
-- `パレット種類`
-- `メイン画像`
-- `右側`
-- `名前`
-- `左側`
-- `戦闘画面を一括でインポートします。\r\nTSAがあるので、共通タイルは1つにまとめられるという制約があります。`
-- `書き込み`
-- `画像`
-- `画像取出`
-- `画像読込`
-
-AV-only labels (usually fine — layout polish or rewording):
-
-- `Address:`
-- `Battle Screen Layout`
-
 ### ItemFE6Form
 WF labels: **44** · AV labels: **70** · WF-only: **42** · AV-only: **68** · Common: **2** · Density verdict: **Low** (WF 121 / AV 97)
 
@@ -2958,47 +2905,6 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Write Anime Tuple`
 - `Write Glyph Entry`
 - `Write JP Name Pointer`
-
-### ImageTSAEditorForm
-WF labels: **30** · AV labels: **2** · WF-only: **30** · AV-only: **2** · Common: **0** · Density verdict: **High** (WF 100 / AV 3)
-
-WF-only labels (candidates for missing fields in AV):
-
-- `1`
-- `10`
-- `11`
-- `12`
-- `13`
-- `14`
-- `15`
-- `16`
-- `2`
-- `3`
-- `4`
-- `5`
-- `6`
-- `7`
-- `8`
-- `9`
-- `B`
-- `G`
-- `R`
-- `REDO`
-- `UNDO`
-- `クリップボード`
-- `パレット`
-- `パレットアドレス`
-- `パレット書き込み`
-- `メイン画像`
-- `書き込み`
-- `画像`
-- `画像取出`
-- `画像読込`
-
-AV-only labels (usually fine — layout polish or rewording):
-
-- `Address:`
-- `TSA Tile Editor`
 
 ### SummonsDemonKingForm
 WF labels: **30** · AV labels: **17** · WF-only: **30** · AV-only: **17** · Common: **0** · Density verdict: **Medium** (WF 60 / AV 32)
@@ -6216,6 +6122,67 @@ AV-only labels (usually fine — layout polish or rewording):
 - `Address:`
 - `Haiku (FE6)`
 
+### ImageBattleScreenForm
+WF labels: **42** · AV labels: **64** · WF-only: **15** · AV-only: **37** · Common: **27** · Density verdict: **Low** (WF 133 / AV 125)
+
+WF-only labels (candidates for missing fields in AV):
+
+- `アイテム`
+- `クリップボード`
+- `パレット`
+- `パレットアドレス`
+- `パレット書き込み`
+- `パレット種類`
+- `メイン画像`
+- `右側`
+- `名前`
+- `左側`
+- `戦闘画面を一括でインポートします。\r\nTSAがあるので、共通タイルは1つにまとめられるという制約があります。`
+- `書き込み`
+- `画像`
+- `画像取出`
+- `画像読込`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `0x00000000`
+- `Battle Preview (deferred KnownGap): rendering the 32x20 TSA grid with the live palette requires System.Drawing + ImageUtil.BitBlt. The numeric fields and palette/image pointer write paths in this edit… (truncated; see designer file)`
+- `Battle Screen`
+- `Bulk import/export the battle screen as a single image. TSA layout means common tiles must be deduplicated.`
+- `Chipset Preview (deferred KnownGap): live LZ77 decode + flip permutations are WinForms-coupled (ImageUtil.BitBlt). Use the WinForms editor to paint TSA cells.`
+- `Clipboard`
+- `Image`
+- `Image Export`
+- `Image Import`
+- `Image1 Preview (deferred KnownGap): per-tile LZ77 decompress + palette blit is WinForms-coupled (#393).`
+- `Image2 Preview (deferred)`
+- `Image3 Preview (deferred)`
+- `Image4 Preview (deferred)`
+- `Image5 Preview (deferred)`
+- `Item`
+- `KnownGap: battle-screen bitmap rendering is WinForms-coupled (#393).`
+- `KnownGap: bulk image Export requires ImageFormRef.ExportImage + live battle-screen bitmap (WinForms-coupled, #393).`
+- `KnownGap: bulk image Import requires ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByteKeepTSA (WinForms-coupled, #393).`
+- `KnownGap: chipset thumbnail rendering is WinForms-coupled (#393).`
+- `KnownGap: local palette-edit redo (PaletteFormRef redo buffer) is WinForms-coupled (#393). Use the main ROM-level Undo via the toolbar.`
+- `KnownGap: local TSA redo buffer is WinForms-coupled. Use the main ROM-level Undo via the toolbar (#393).`
+- `KnownGap: per-image LZ77 Import (ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByte16Tile) is WinForms-coupled (#393).`
+- `KnownGap: per-image LZ77 Import is WinForms-coupled (#393).`
+- `KnownGap: per-image PNG Export (ImageFormRef.ExportImage) is WinForms-coupled (#393).`
+- `KnownGap: per-image PNG Export is WinForms-coupled (#393).`
+- `KnownGap: zoom only affects the deferred Battle/Chipset preview rendering (WinForms-coupled, #393). Re-enabled once the live preview lands.`
+- `Left Side`
+- `Main Image`
+- `Name`
+- `Palette`
+- `Palette Address`
+- `Palette Type`
+- `Palette Write`
+- `Right Side`
+- `TSA1 Address`
+- `Write`
+- `Zoom`
+
 ### ImageTSAAnimeForm
 WF labels: **15** · AV labels: **6** · WF-only: **15** · AV-only: **6** · Common: **0** · Density verdict: **High** (WF 22 / AV 7)
 
@@ -8714,6 +8681,42 @@ AV-only labels (usually fine — layout polish or rewording):
 
 - `Address:`
 - `Event Template 4`
+
+### ImageTSAEditorForm
+WF labels: **30** · AV labels: **39** · WF-only: **9** · AV-only: **18** · Common: **21** · Density verdict: **Low** (WF 100 / AV 105)
+
+WF-only labels (candidates for missing fields in AV):
+
+- `クリップボード`
+- `パレット`
+- `パレットアドレス`
+- `パレット書き込み`
+- `メイン画像`
+- `書き込み`
+- `画像`
+- `画像取出`
+- `画像読込`
+
+AV-only labels (usually fine — layout polish or rewording):
+
+- `0`
+- `A`
+- `C`
+- `Chipset Preview`
+- `Clipboard`
+- `D`
+- `E`
+- `F`
+- `Image`
+- `Image Export`
+- `Image Import`
+- `Main Image`
+- `Palette`
+- `Palette Address:`
+- `Palette Index`
+- `Palette Write`
+- `Write`
+- `Zoom`
 
 ### ItemEffectPointerForm
 WF labels: **9** · AV labels: **5** · WF-only: **9** · AV-only: **5** · Common: **0** · Density verdict: **Medium** (WF 13 / AV 7)

--- a/docs/avalonia-gaps/2026-05-24-undo-sweep.md
+++ b/docs/avalonia-gaps/2026-05-24-undo-sweep.md
@@ -1,6 +1,6 @@
 ---
-generated: "2026-05-24T10:36:32Z"
-git-sha: 81ad8040b
+generated: "2026-05-24T11:55:07Z"
+git-sha: cedbf79ee
 sweep-type: undo
 ---
 
@@ -79,11 +79,11 @@ Regenerate with `FEBuilderGBA.Avalonia --gap-sweep-undo --out=<path>`.
 
 | Tier | Count | % of total |
 |---|---:|---:|
-| Total write callsites | 1134 | 100% |
-| NoUndoServiceField (no plumbing) | 150 | 13.2% |
+| Total write callsites | 1135 | 100% |
+| NoUndoServiceField (no plumbing) | 151 | 13.3% |
 | MissingScope (unwrapped) | 4 | 0.4% |
 | AmbiguousScope (verify) | 0 | 0.0% |
-| Covered (healthy) | 980 | 86.4% |
+| Covered (healthy) | 980 | 86.3% |
 
 ## Highest priority — VMs with NO undo plumbing at all
 
@@ -358,6 +358,12 @@ These ViewModels have no `UndoService` field/property/local. Every write here by
 |---|---:|---|---|---|
 | `FEBuilderGBA.Avalonia/ViewModels/ImageGenericEnemyPortraitViewModel.cs` | 63 | `Write` | `rom.write_u32(addr + 0, ImagePointer)` | class 'ImageGenericEnemyPortraitViewModel' has no UndoService field/property/local |
 
+### `ImageTSAEditorViewModel` — 1 callsite
+
+| File | Line | Method | Write | Note |
+|---|---:|---|---|---|
+| `FEBuilderGBA.Avalonia/ViewModels/ImageTSAEditorViewModel.cs` | 263 | `WritePalette` | `rom.write_u16(baseAddr + (uint)(i * 2), word)` | class 'ImageTSAEditorViewModel' has no UndoService field/property/local |
+
 ### `SkillAssignmentUnitCSkillSysViewViewModel` — 1 callsite
 
 | File | Line | Method | Write | Note |
@@ -464,7 +470,7 @@ such a row almost always indicates the scanner's pattern set has missed a
 real write API (e.g. PR #380 review caught a `CoreState.ROM.write_u*`
 miss that surfaced as an unjustified zero-row warning before the fix).
 
-Classes with at least one detected write: 175.
+Classes with at least one detected write: 176.
 
 Writable VMs (matching the triplet convention): 146.  
 Writable VMs with zero detected ROM writes: 3.


### PR DESCRIPTION
## Summary

Closes the **130 Avalonia ↔ WinForms gaps** the gap-sweep methodology surfaced on `ImageBattleScreenForm` (HIGH density 133/3 == **-97.7 %**, 42 WF-only labels). Rebuilds `ImageBattleScreenView` from the 3-control address-list stub to a 125-control 5-tab editor mirroring the WinForms `panel2` + 5 tabPages.

**Density: HIGH (-97.7%) -> LOW (-6.0%).** Labels-sweep: Common labels **0 -> 27**, WF-only **42 -> 15** (remaining 15 are Japanese strings with English equivalents in AV; the label-diff scanner does literal comparison and does not apply the translate map — same convention as PR #571 / #589).

Plus cross-cutting improvements addressing **all 4 Copilot CLI plan-review findings (v1 -> v2)**:

1. **Image label swap fixed.** The WF Designer has `image2_ZIMAGE`/`image4_ZIMAGE` = Name (名前) and `image3_ZIMAGE`/`image5_ZIMAGE` = Item (アイテム) — not the inverse the v1 plan listed. Verified via `ImageBattleScreenForm.Designer.cs` L1971-2202. The AV view + parity tests now encode the correct mapping.
2. **Undo ownership clarified.** `ImageBattleScreenCore` methods take NO `Undo.UndoData` parameter — they rely solely on `ROM.BeginUndoScope` (started by `UndoService.Begin` in the view). All ROM writes go through `rom.write_u16` / `rom.write_p32` / `rom.write_range` which automatically pick up the `[ThreadStatic] _ambientUndoData`. No double-tracking risk.
3. **PaletteCore reuse.** `ImageBattleScreenCore.ReadPaletteBlock` / `WritePaletteBlock` **delegate to `PaletteCore.ReadPalette` / `WritePalette`** for the 0x80-byte uncompressed palette block. No BGR15 bit-math duplication. Single source of truth for palette I/O.
4. **L10n scope clarified.** WU6 covers `ja.txt` + `zh.txt` only (the two `.txt` translation files in the repo; `ko_tbl` / `kr_tbl` are encoding tables, not translation files). `L10nCoverageTest` only enforces ja+zh and stays green after the 30 new translation entries land.

WF surface mirrored:
- **Master list** (left, 250px): `AddressListControl` with single 'Battle Screen Layout' entry.
- **Top toolbar**: `AllWriteButton` ("Write") + `ZoomCombo` (4 entries 1x..4x) + `TSAInfoLabel` (mirrors WF `TSAInfo`).
- **Battle/Chipset preview placeholders**: deferred KnownGap labels with explanatory tooltips (live LZ77 decode + per-tile palette blit requires `System.Drawing` + `ImageUtil.BitBlt`).
- **TabControl** with 5 tabs (mirrors WF `tabPage1..5`):
  - **Palette**: `PALETTE_ADDRESS` `NumericUpDown` + `PaletteIndexCombo` (4 entries) + `PaletteWriteButton` + `PaletteClipboardButton` + `PaletteUndoButton` + `PaletteRedoButton` (disabled KnownGap) + 16-col R/G/B grid (Swatch + Index `1..16` + R/G/B `NumericUpDown`, `Increment=8`, `Maximum=255`).
  - **Main Image**: `Tile1..Tile5` labels + `image1_ZIMAGE` `NumericUpDown` + Import/Export buttons (disabled KnownGap) + image preview placeholder.
  - **Left Side**: `image2_ZIMAGE` ("Name") + `image3_ZIMAGE` ("Item") + 2 Import/Export pairs + 2 image previews.
  - **Right Side**: `image4_ZIMAGE` ("Name") + `image5_ZIMAGE` ("Item") + 2 Import/Export pairs + 2 image previews.
  - **Import/Export**: Bulk Import / Export buttons (disabled KnownGap) + Undo / Redo (Redo disabled KnownGap) + description label.

Deferred surfaces (KnownGap markers with non-empty reasons; no follow-up issues per SCOPE DISCIPLINE):
- **Battle/Chipset preview rendering**: live LZ77 decode + per-tile palette blit requires `System.Drawing` + `ImageUtil.BitBlt` (WinForms-only).
- **Per-image + bulk Import/Export**: requires `ImageFormRef.ImportFilenameDialog` + `ImageUtil.ImageToByteKeepTSA` (WinForms-coupled).
- **Local Palette Redo + Bulk Redo**: WF `PaletteFormRef` redo buffer is WinForms-coupled. ROM-level Undo via the toolbar remains functional.

## Plan Reference

Implements the v2 plan accepted by Copilot CLI on [issue #393 comment](https://github.com/laqieer/FEBuilderGBA/issues/393#issuecomment-4528037232) with all 4 prior plan-review findings addressed.

## Scope

Closes #393
Ref #374 (overarching gap-sweep effort)

## Screenshots

![ImageBattleScreen editor (FE8U) -- new 5-tab parity surface with real palette](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr393-battlescreen-editor.png)

Real Avalonia GUI capture via `PrintWindow` API against `roms/FE8U.gba`, Release build of `FEBuilderGBA.Avalonia`. Window: 1338x595 (restored from maximize so the GPU-rendered content captures correctly). Screenshot committed to `master` via docs PR #593 so the URL survives feature-branch deletion post-merge.

The shot shows every new control surface:
- **Master list (left):** Single 'Battle Screen Layout' entry (1 items).
- **Top toolbar:** Write button, Zoom (2x Zoom), Selected: 00 / Canvas: TSA info.
- **Battle/Chipset preview:** KnownGap placeholders with explanatory text.
- **Address bar:** `TSA1 Address` = `0x00802558` (real FE8U pointer).
- **Palette tab (selected):** Palette Address = 8398168, Palette Type = Palette 1, Palette Write / Clipboard / Undo buttons (enabled), Redo button (disabled = KnownGap).
- **Palette grid:** 16 real FE8U GBA colors (greens / browns / blues / purples), R/G/B numerics with the WF-parity `Increment=8`, `Maximum=255` semantics (visible: 144/112/88, 248/248/248, 80/40/0, 240/232/184, 232/248/240, 224/200/240 ...).
- **Tab strip:** Palette / Main Image / Left Side / Right Side / Import/Export (5 tabs).

## GUI Test Report

### Environment
- ROM: `roms/FE8U.gba` (Fire Emblem - The Sacred Stones, USA)
- View: `ImageBattleScreenView` (Avalonia)
- Capture method: PrintWindow API + PowerShell UIAutomationClient

### Steps Performed
1. Launched `dotnet run --project FEBuilderGBA.Avalonia -c Release -- --rom roms/FE8U.gba`.
2. Located main FE8U window via UIAutomation (`Name='FEBuilderGBA - FE8U.gba'`).
3. Located `Main_BattleScreen_Button` by AutomationIdProperty and invoked it via InvokePattern.
4. Confirmed the editor window opened (`Name='Battle Screen Layout'`).
5. Located the `AddressList` ListBox and selected the first item via `SelectionItemPattern.Select()` so palette swatches/spinners populate.
6. Captured via `tools/WinCapture` (PrintWindow `PW_RENDERFULLCONTENT`).

### Test Results

| Test | Expected | Actual | Status |
|---|---|---|---|
| Main menu "Battle Screen" opens upgraded view | Window with title "Battle Screen Layout" | Window opened | PASS |
| Master list populated | Single 'Battle Screen Layout' entry | 1 entry visible | PASS |
| Top toolbar | Write button + Zoom + TSA info | All 3 controls present | PASS |
| Battle/Chipset preview KnownGap | Placeholder labels with explanatory tooltips | Both visible with deferred text | PASS |
| TSA1 Address bar | Address label with real FE8U pointer | `0x00802558` rendered | PASS |
| 5-tab TabControl | Palette / Main Image / Left Side / Right Side / Import/Export | All 5 tabs visible, Palette selected | PASS |
| Palette grid | 16 cols x (Swatch + Index 1..16 + R/G/B numerics) | All 64 cells rendered with real GBA colors | PASS |
| Palette numerics | Increment=8, Maximum=255 | Values shown (144/112/88, 248/248/248, etc.) snap to 5-bit | PASS |
| Image2/4 = Name vs Image3/5 = Item | Per WF Designer L1971-2202 | Labels match WF mapping | PASS |
| Redo button disabled (KnownGap) | Button visible but `IsEnabled=False` | Lighter color confirms disabled | PASS |
| Per-image + Bulk Import/Export disabled | Buttons visible but `IsEnabled=False` | Lighter color confirms disabled | PASS |
| `dotnet test FEBuilderGBA.Core.Tests/` | 1736/1736 pass (+9 ImageBattleScreenCoreTests) | 1736/1736 PASS | PASS |
| `dotnet test FEBuilderGBA.Avalonia.Tests/` | 5996 pass (5993 + 3 pre-existing skips, +23 ImageBattleScreenParityTests) | 5993 pass / 3 skip | PASS |
| `dotnet test FEBuilderGBA.Tests/` | 1716/1716 pass | 1716/1716 PASS | PASS |
| `L10nCoverageTest` | 0 PartiallyTranslated literals | Passes after 30 ja/zh/en additions | PASS |

### Verdict

**PASS** — every new control surface renders, deferred affordances are visibly disabled with tooltip explanations, the palette grid shows real ROM-derived GBA colors, and all test suites pass (Core 1736/1736, Avalonia 5993 pass / 3 skip, WinForms 1716/1716).

## Test plan

- [x] `dotnet test FEBuilderGBA.Core.Tests/` — 1736/1736 pass (+9 `ImageBattleScreenCoreTests` covering TSA map round-trip, ambient-undo Push+RunUndo restore, PaletteCore delegation, GBA pointer write).
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests/` — 5993 pass / 3 pre-existing skips (+23 `ImageBattleScreenParityTests` covering density floor at 75% of WF=133, AutomationId surface coverage on 5 tabs, write handler undo envelope via Roslyn regex, image2/4=Name vs image3/5=Item label assertions, VM round-trip under undo with both rollback variants, deferred KnownGap surfaces).
- [x] `dotnet test FEBuilderGBA.Tests/` — 1716/1716 pass.
- [x] `dotnet build FEBuilderGBA.sln` (Avalonia + Core) — 0 errors.
- [x] Density verdict ImageBattleScreenForm: HIGH (-97.7%) -> LOW (-6.0%). AV control count 3 -> 125.
- [x] Labels-sweep: Common labels 0 -> 27, WF-only 42 -> 15 (remaining 15 are Japanese strings with English equivalents in AV; literal scanner does not apply translate map — same convention as PR #571 / #589).
- [x] All write paths wrapped in `_undoService.Begin/Commit/Rollback` (verified by Roslyn regex test `View_WriteHandler_UsesUndoService` and `View_PaletteWriteHandler_UsesUndoService`).
- [x] ja/zh translations added for 30 new English literals; `L10nCoverageTest` stays green.
- [x] GUI screenshot captured via PrintWindow against the live Avalonia app with `roms/FE8U.gba` and committed to `pr-screenshots/pr393-battlescreen-editor.png` on master via docs PR #593.
- [x] Copilot CLI plan review accepted (v2 plan, no remaining blocking concerns) — see #393 comment thread.

## Known limitations

- Battle-screen bitmap rendering remains a KnownGap (System.Drawing + ImageUtil.BitBlt coupling).
- Chipset thumbnail rendering remains a KnownGap (same coupling).
- Per-image + bulk Import/Export remain KnownGaps (ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByteKeepTSA coupling).
- Local Palette Redo + Bulk Redo remain KnownGaps (PaletteFormRef redo buffer coupling). ROM-level Undo via the toolbar remains functional.

User prompt: Drive GitHub issue #393 (gap-sweep) on `laqieer/FEBuilderGBA` from OPEN -> MERGED.

Generated with Claude Code (claude-opus-4-7[1m])
