### PR TITLE
fix(gap-sweep): MapStyleEditor parity (closes #391)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MapStyleEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MapStyleEditorParityTests.cs
@@ -122,10 +122,10 @@ public class MapStyleEditorParityTests
         string axaml = ReadAxaml();
         // PaletteCombo + PaletteTypeCombo (mirrors WF).
         Assert.Contains(
-            "AutomationProperties.AutomationId=\"MapStyleEditor_PaletteCombo\"",
+            "AutomationProperties.AutomationId=\"MapStyleEditor_Palette_Combo\"",
             axaml);
         Assert.Contains(
-            "AutomationProperties.AutomationId=\"MapStyleEditor_PaletteTypeCombo\"",
+            "AutomationProperties.AutomationId=\"MapStyleEditor_PaletteType_Combo\"",
             axaml);
         // 16 RGB rows -> 16 R, 16 G, 16 B NumericUpDowns.
         for (int i = 1; i <= 16; i++)

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MapStyleEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MapStyleEditorParityTests.cs
@@ -1,0 +1,568 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Gap-sweep regression tests for MapStyleEditorView. (#391)
+//
+// The WinForms `MapStyleEditorForm` shipped 153 controls vs the Avalonia
+// `MapStyleEditorView` stub of 8 (HIGH density -94.8%) and 45 WF-only
+// labels (per the 2026-05-27 sweep). This test suite locks in the
+// 3-tab rebuild per the v3 plan accepted on issue #391:
+//
+//   - Tab 1 Map Style: ObjAddress / Pointer displays + functional Write
+//   - Tab 2 Palette:   16 read-only RGB rows + KnownGap palette buttons
+//   - Tab 3 Chipset:   4 tile-slot TSA grids (split + raw W round-trip) +
+//                      KnownGap chipset buttons
+//
+// All non-functional buttons must be disabled with a #374 tooltip
+// (Copilot CLI v1 review item 4); split TSA fields must stay
+// synchronized with the raw word (review item 2). LZ77-backed CONFIG
+// writes and PLIST-aware palette writes are deliberately out of scope
+// (review items 1 + 3).
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.GapSweep;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests.GapSweep;
+
+/// <summary>
+/// Tests proving the MapStyleEditorForm parity raise (#391) is permanent.
+/// Marked [Collection("SharedState")] because the synthetic-ROM tests
+/// mutate CoreState.ROM. Without serialization, xUnit's per-class
+/// parallel runner can race a sibling test's ROM swap.
+/// </summary>
+[Collection("SharedState")]
+public class MapStyleEditorParityTests
+{
+    // -----------------------------------------------------------------
+    // Density (Phase 1) - AV control count must reach the MEDIUM verdict.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// WF designer.cs reports 153 control instantiations (per 2026-05-27
+    /// density sweep). To leave the HIGH band we need
+    /// AV >= ceil(153 * 0.5) + 1 = 77 so the actual delta
+    /// is (77-153)/153 = -49.67% which is below the HIGH boundary at -50.0%.
+    /// </summary>
+    [Fact]
+    public void View_AvControlCount_AtOrAboveMediumVerdict()
+    {
+        string axamlPath = AxamlPath();
+        Assert.True(File.Exists(axamlPath), $"AXAML not found at {axamlPath}");
+
+        var doc = XDocument.Load(axamlPath);
+        int avCount = ControlDensityScanner.CountAvControlsInDocument(doc);
+
+        // Strict MEDIUM boundary: 77 gives -49.67% (MEDIUM); 76 gives
+        // -50.33% (HIGH). Use 77 as the minimum gate.
+        const int MinAvControls = 77;
+        Assert.True(avCount >= MinAvControls,
+            $"AV control count {avCount} must be >= {MinAvControls} (strict MEDIUM cutoff, WF=153)");
+    }
+
+    // -----------------------------------------------------------------
+    // Tab structure (3 tabs).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_HasTabControl_With3Tabs()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("TabControl", axaml);
+        var tabItems = Regex.Matches(axaml, @"<TabItem\b");
+        Assert.True(tabItems.Count >= 3,
+            $"Expected >= 3 TabItem elements, got {tabItems.Count}");
+    }
+
+    // -----------------------------------------------------------------
+    // Tab 1 - Map Style surface.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_HasMapStyleTab_Surface()
+    {
+        string axaml = ReadAxaml();
+        // MapStyle combo box (mirrors WF MapStyle ComboBox).
+        Assert.Contains(
+            "AutomationProperties.AutomationId=\"MapStyleEditor_MapStyle_Combo\"",
+            axaml);
+        // Pointer displays.
+        Assert.Contains(
+            "AutomationProperties.AutomationId=\"MapStyleEditor_ObjAddress_Label\"",
+            axaml);
+        Assert.Contains(
+            "AutomationProperties.AutomationId=\"MapStyleEditor_ObjAddress2_Label\"",
+            axaml);
+        Assert.Contains(
+            "AutomationProperties.AutomationId=\"MapStyleEditor_PaletteAddress_Label\"",
+            axaml);
+        // Functional OBJ Tile Pointer Write surface.
+        Assert.Contains(
+            "AutomationProperties.AutomationId=\"MapStyleEditor_Write_Button\"",
+            axaml);
+        Assert.Contains(
+            "AutomationProperties.AutomationId=\"MapStyleEditor_ObjPtr_Input\"",
+            axaml);
+    }
+
+    // -----------------------------------------------------------------
+    // Tab 2 - Palette surface (16 RGB rows + selectors + buttons).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_HasPaletteTab_Surface()
+    {
+        string axaml = ReadAxaml();
+        // PaletteCombo + PaletteTypeCombo (mirrors WF).
+        Assert.Contains(
+            "AutomationProperties.AutomationId=\"MapStyleEditor_PaletteCombo\"",
+            axaml);
+        Assert.Contains(
+            "AutomationProperties.AutomationId=\"MapStyleEditor_PaletteTypeCombo\"",
+            axaml);
+        // 16 RGB rows -> 16 R, 16 G, 16 B NumericUpDowns.
+        for (int i = 1; i <= 16; i++)
+        {
+            Assert.Contains(
+                $"AutomationProperties.AutomationId=\"MapStyleEditor_Color{i}_R_Input\"",
+                axaml);
+            Assert.Contains(
+                $"AutomationProperties.AutomationId=\"MapStyleEditor_Color{i}_G_Input\"",
+                axaml);
+            Assert.Contains(
+                $"AutomationProperties.AutomationId=\"MapStyleEditor_Color{i}_B_Input\"",
+                axaml);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Tab 3 - Chipset surface (4 tile-slot TSA grids + buttons).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_HasChipsetTab_Surface()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains(
+            "AutomationProperties.AutomationId=\"MapStyleEditor_ConfigNo_Label\"",
+            axaml);
+        Assert.Contains(
+            "AutomationProperties.AutomationId=\"MapStyleEditor_ConfigTerrain_Combo\"",
+            axaml);
+        // 4 slots (0/2/4/6) x 5 fields (TSA_X, TSA_Y, TSA_PALETTE, TSA_FLIP, W).
+        int[] slots = { 0, 2, 4, 6 };
+        foreach (int slot in slots)
+        {
+            Assert.Contains(
+                $"AutomationProperties.AutomationId=\"MapStyleEditor_Slot{slot}_TSA_X_Input\"",
+                axaml);
+            Assert.Contains(
+                $"AutomationProperties.AutomationId=\"MapStyleEditor_Slot{slot}_TSA_Y_Input\"",
+                axaml);
+            Assert.Contains(
+                $"AutomationProperties.AutomationId=\"MapStyleEditor_Slot{slot}_TSA_PALETTE_Input\"",
+                axaml);
+            Assert.Contains(
+                $"AutomationProperties.AutomationId=\"MapStyleEditor_Slot{slot}_TSA_FLIP_Input\"",
+                axaml);
+            Assert.Contains(
+                $"AutomationProperties.AutomationId=\"MapStyleEditor_Slot{slot}_W_Input\"",
+                axaml);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // KnownGap buttons - the disabled / non-functional ROM-mutating
+    // controls (Copilot CLI v1 review item 4).
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Single authoritative list of every KnownGap-disabled button.
+    /// Each button MUST appear with IsEnabled="False" AND a tooltip
+    /// referencing #374 in the same element. Adding/removing a disabled
+    /// button without updating this list (or via View_NoExtraDisabledButtons)
+    /// breaks the test (Copilot v2 review item 4 enumeration cleanup).
+    /// </summary>
+    static readonly string[] KnownGapButtonIds =
+    {
+        "MapStyleEditor_MapChipExport_Button",
+        "MapStyleEditor_MapChipImport_Button",
+        "MapStyleEditor_ObjExport_Button",
+        "MapStyleEditor_ObjImport_Button",
+        "MapStyleEditor_PaletteExport_Button",
+        "MapStyleEditor_PaletteImport_Button",
+        "MapStyleEditor_PaletteClipboard_Button",
+        "MapStyleEditor_PaletteWrite_Button",
+        "MapStyleEditor_CopyTile_Button",
+        "MapStyleEditor_CopyType_Button",
+        "MapStyleEditor_Paste_Button",
+        "MapStyleEditor_ConfigWrite_Button",
+        "MapStyleEditor_Undo_Button",
+        "MapStyleEditor_Redo_Button",
+    };
+
+    [Fact]
+    public void View_KnownGapButtons_AreDisabledAndTagged()
+    {
+        string axaml = ReadAxaml();
+        foreach (string id in KnownGapButtonIds)
+        {
+            // Each button must appear with IsEnabled="False" AND a
+            // tooltip referencing #374 in the same element block.
+            // Allow attributes in any order via DOTALL flag.
+            var idAttr = $"AutomationProperties.AutomationId=\"{id}\"";
+            Assert.Contains(idAttr, axaml);
+
+            // Locate the <Button ... /> element containing this id and
+            // verify the element body has IsEnabled="False" and a #374
+            // tooltip.
+            var elementPattern = new Regex(
+                @"<Button(?:\s[^/>]*?)?" + Regex.Escape(idAttr) + @"[\s\S]*?/?>",
+                RegexOptions.None);
+            Match m = elementPattern.Match(axaml);
+            Assert.True(m.Success, $"Cannot locate <Button> element for {id}");
+
+            string elementText = m.Value;
+            Assert.True(
+                elementText.Contains("IsEnabled=\"False\""),
+                $"KnownGap button {id} must have IsEnabled=\"False\"; element was: {elementText}");
+            Assert.True(
+                elementText.Contains("#374"),
+                $"KnownGap button {id} must have a #374 tooltip; element was: {elementText}");
+        }
+    }
+
+    /// <summary>
+    /// Proves no disabled <Button> slips in that isn't on the KnownGap
+    /// list. The count of IsEnabled="False" Buttons must equal exactly
+    /// the KnownGap list length — adding a new disabled button without
+    /// adding it to <see cref="KnownGapButtonIds"/> breaks this test
+    /// (Copilot v2 review item 4 enumeration cleanup).
+    /// </summary>
+    [Fact]
+    public void View_NoExtraDisabledButtons()
+    {
+        string axaml = ReadAxaml();
+        var disabledButtonPattern = new Regex(
+            @"<Button[^>]*IsEnabled=""False""[^>]*",
+            RegexOptions.None);
+        int disabledCount = disabledButtonPattern.Matches(axaml).Count;
+        Assert.Equal(KnownGapButtonIds.Length, disabledCount);
+    }
+
+    /// <summary>The functional OBJ Tile Pointer Write button is enabled.</summary>
+    [Fact]
+    public void View_FunctionalWriteButton_IsEnabled()
+    {
+        string axaml = ReadAxaml();
+        // The Write button is the one functional ROM-mutating control;
+        // it must NOT carry IsEnabled="False".
+        var pattern = new Regex(
+            @"<Button[^>]*AutomationProperties\.AutomationId=""MapStyleEditor_Write_Button""[^>]*",
+            RegexOptions.None);
+        Match m = pattern.Match(axaml);
+        Assert.True(m.Success, "MapStyleEditor_Write_Button must exist");
+        Assert.DoesNotContain("IsEnabled=\"False\"", m.Value);
+    }
+
+    /// <summary>
+    /// The single functional Write handler wraps its VM call in
+    /// `_undoService.Begin / Commit / Rollback` so the ROM mutation is
+    /// undoable atomically (gap-sweep undo acceptance criterion).
+    /// </summary>
+    [Fact]
+    public void View_Write_Click_UsesUndoService()
+    {
+        string code = File.ReadAllText(CodeBehindPath());
+        Assert.Matches(new Regex(
+            @"void Write_Click[\s\S]*?_undoService\.Begin\([^)]*\)[\s\S]*?_vm\.Write\(\)[\s\S]*?_undoService\.(Commit|Rollback)\(\)",
+            RegexOptions.Singleline), code);
+    }
+
+    // -----------------------------------------------------------------
+    // ViewModel - palette read semantics (Copilot v1 review item 3).
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Round-trips a known 16-color RGB-555 palette through LoadPalette
+    /// for a normal (non-fog) palette index. paletteBase + idx * 0x20
+    /// indexing per WF semantics.
+    /// </summary>
+    [Fact]
+    public void ViewModel_LoadPalette_ReadsRgb555_NormalPalette()
+    {
+        var (rom, paletteBase) = MakeSyntheticPaletteRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapStyleEditorViewModel();
+            // Read palette index 1 (non-fog).
+            bool ok = vm.LoadPalette(paletteBase, paletteIndex: 1, isFog: false);
+            Assert.True(ok, "LoadPalette must return true for in-bounds palette");
+
+            // The synthetic palette was seeded with R = 1+i, G = 2+i, B = 3+i
+            // at index 1's offset = paletteBase + 1 * 0x20.
+            for (int i = 0; i < 16; i++)
+            {
+                Assert.Equal((ushort)(1 + i), vm.GetColorR(i + 1));
+                Assert.Equal((ushort)(2 + i), vm.GetColorG(i + 1));
+                Assert.Equal((ushort)(3 + i), vm.GetColorB(i + 1));
+            }
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    /// <summary>
+    /// Same fixture but read palette index 2 in FOG mode. The effective
+    /// offset must be paletteBase + (2 + 5) * 0x20 (fog adds 5).
+    /// </summary>
+    [Fact]
+    public void ViewModel_LoadPalette_ReadsRgb555_FogPalette()
+    {
+        var (rom, paletteBase) = MakeSyntheticPaletteRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapStyleEditorViewModel();
+            // Read palette index 2 with fog (effective index = 7).
+            bool ok = vm.LoadPalette(paletteBase, paletteIndex: 2, isFog: true);
+            Assert.True(ok, "LoadPalette must return true for in-bounds fog palette");
+
+            // The synthetic ROM was seeded so that palette index 7 has
+            // R = 10+i, G = 20+i, B = 30+i (mod 32).
+            for (int i = 0; i < 16; i++)
+            {
+                Assert.Equal((ushort)((10 + i) & 0x1F), vm.GetColorR(i + 1));
+                Assert.Equal((ushort)((20 + i) & 0x1F), vm.GetColorG(i + 1));
+                Assert.Equal((ushort)((30 + i) & 0x1F), vm.GetColorB(i + 1));
+            }
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    /// <summary>
+    /// Out-of-bounds / zero paletteBase must return false WITHOUT
+    /// writing properties. Mirrors WF behaviour where LoadPalette is
+    /// a pure read.
+    /// </summary>
+    [Fact]
+    public void ViewModel_LoadPalette_OutOfBoundsReturnsFalse()
+    {
+        var rom = new ROM();
+        rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapStyleEditorViewModel();
+
+            // paletteBase == 0 must return false.
+            Assert.False(vm.LoadPalette(0, paletteIndex: 0, isFog: false));
+
+            // paletteBase + idx * 0x20 beyond ROM length must return false.
+            uint farBase = (uint)rom.Data.Length - 8;
+            Assert.False(vm.LoadPalette(farBase, paletteIndex: 9, isFog: false));
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    // -----------------------------------------------------------------
+    // ViewModel - TSA word encode/decode (Copilot v1 review item 2).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_EncodeTsaWord_RoundTrips()
+    {
+        // Pick a representative non-zero packing.
+        int x = 5, y = 7, palette = 11, flip = 2;
+        ushort packed = MapStyleEditorViewModel.EncodeTsaWord(x, y, palette, flip);
+        var (rx, ry, rp, rf) = MapStyleEditorViewModel.DecodeTsaWord(packed);
+        Assert.Equal(x, rx);
+        Assert.Equal(y, ry);
+        Assert.Equal(palette, rp);
+        Assert.Equal(flip, rf);
+    }
+
+    [Fact]
+    public void ViewModel_EncodeTsaWord_MatchesGbaBitLayout()
+    {
+        // GBA OAM/BG-map word layout:
+        //   bits 0..9  = tile index (x + y * 32)
+        //   bits 10..11 = flip (h flip + v flip)
+        //   bits 12..15 = palette
+        ushort packed = MapStyleEditorViewModel.EncodeTsaWord(3, 4, 5, 3);
+        int tile = 3 + 4 * 32; // = 131
+        Assert.Equal(tile, packed & 0x3FF);
+        Assert.Equal(3, (packed >> 10) & 0x3);
+        Assert.Equal(5, (packed >> 12) & 0xF);
+    }
+
+    /// <summary>
+    /// Setting a split field (TSA_X / TSA_Y / TSA_PALETTE / TSA_FLIP)
+    /// must update the raw Slot_W to match EncodeTsaWord(...) — proves
+    /// the editable split surface stays synchronized (Copilot v2 review
+    /// item 2 setter synchronization).
+    /// </summary>
+    [Fact]
+    public void ViewModel_SettingSplitField_UpdatesRawWord()
+    {
+        var vm = new MapStyleEditorViewModel();
+        int[] slots = { 0, 2, 4, 6 };
+
+        foreach (int s in slots)
+        {
+            // Set the split fields one at a time and verify the raw
+            // Slot_W matches.
+            vm.SetSlotSplit(s, x: 5, y: 7, palette: 11, flip: 2);
+            ushort expected = MapStyleEditorViewModel.EncodeTsaWord(5, 7, 11, 2);
+            Assert.Equal(expected, vm.GetSlotW(s));
+
+            // Mutate one field and verify the raw word follows.
+            vm.SetSlotSplitField(s, "X", 9);
+            Assert.Equal(MapStyleEditorViewModel.EncodeTsaWord(9, 7, 11, 2), vm.GetSlotW(s));
+
+            vm.SetSlotSplitField(s, "Y", 3);
+            Assert.Equal(MapStyleEditorViewModel.EncodeTsaWord(9, 3, 11, 2), vm.GetSlotW(s));
+
+            vm.SetSlotSplitField(s, "PALETTE", 13);
+            Assert.Equal(MapStyleEditorViewModel.EncodeTsaWord(9, 3, 13, 2), vm.GetSlotW(s));
+
+            vm.SetSlotSplitField(s, "FLIP", 1);
+            Assert.Equal(MapStyleEditorViewModel.EncodeTsaWord(9, 3, 13, 1), vm.GetSlotW(s));
+        }
+    }
+
+    /// <summary>
+    /// Setting the raw Slot_W must repopulate the split fields to
+    /// DecodeTsaWord(rawWord) — proves the reverse direction (loading
+    /// a word from ROM re-populates the split editable fields).
+    /// Copilot v2 review item 2.
+    /// </summary>
+    [Fact]
+    public void ViewModel_SettingRawWord_UpdatesSplitFields()
+    {
+        var vm = new MapStyleEditorViewModel();
+        int[] slots = { 0, 2, 4, 6 };
+
+        foreach (int s in slots)
+        {
+            ushort word = MapStyleEditorViewModel.EncodeTsaWord(12, 6, 9, 3);
+            vm.SetSlotW(s, word);
+
+            var (x, y, p, f) = MapStyleEditorViewModel.DecodeTsaWord(word);
+            Assert.Equal(x, vm.GetSlotSplitField(s, "X"));
+            Assert.Equal(y, vm.GetSlotSplitField(s, "Y"));
+            Assert.Equal(p, vm.GetSlotSplitField(s, "PALETTE"));
+            Assert.Equal(f, vm.GetSlotSplitField(s, "FLIP"));
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Legacy automation IDs (cross-PR compatibility).
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// The pre-#391 view exposed five AutomationIds that existing harnesses
+    /// rely on. The rebuild must preserve them all (test pins this).
+    /// </summary>
+    [Fact]
+    public void View_RetainsLegacyAutomationIds()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains(
+            "AutomationProperties.AutomationId=\"MapStyleEditor_Entry_List\"",
+            axaml);
+        Assert.Contains(
+            "AutomationProperties.AutomationId=\"MapStyleEditor_Addr_Label\"",
+            axaml);
+        Assert.Contains(
+            "AutomationProperties.AutomationId=\"MapStyleEditor_ObjPtr_Input\"",
+            axaml);
+        Assert.Contains(
+            "AutomationProperties.AutomationId=\"MapStyleEditor_ConfigPtr_Label\"",
+            axaml);
+        Assert.Contains(
+            "AutomationProperties.AutomationId=\"MapStyleEditor_Write_Button\"",
+            axaml);
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Build a synthetic FE8U ROM with a known palette region.
+    /// Returns (rom, paletteBase) where paletteBase is a ROM offset.
+    ///
+    /// Layout planted at paletteBase:
+    ///   - index 1 (non-fog): R = 1+i, G = 2+i, B = 3+i for i in 0..15
+    ///   - index 7 (fog of 2): R = (10+i)&0x1F, G = (20+i)&0x1F, B = (30+i)&0x1F
+    /// </summary>
+    static (ROM rom, uint paletteBase) MakeSyntheticPaletteRom()
+    {
+        var rom = new ROM();
+        rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+
+        uint paletteBase = 0x200000;
+
+        // Plant palette index 1 (0x20 bytes starting at paletteBase + 0x20).
+        uint slot1Addr = paletteBase + 1 * 0x20;
+        for (int i = 0; i < 16; i++)
+        {
+            ushort r = (ushort)(1 + i);
+            ushort g = (ushort)(2 + i);
+            ushort b = (ushort)(3 + i);
+            ushort packed = (ushort)((r & 0x1F) | ((g & 0x1F) << 5) | ((b & 0x1F) << 10));
+            rom.Data[slot1Addr + i * 2 + 0] = (byte)(packed & 0xFF);
+            rom.Data[slot1Addr + i * 2 + 1] = (byte)((packed >> 8) & 0xFF);
+        }
+
+        // Plant palette index 7 (0x20 bytes starting at paletteBase + 7 * 0x20).
+        uint slot7Addr = paletteBase + 7 * 0x20;
+        for (int i = 0; i < 16; i++)
+        {
+            ushort r = (ushort)((10 + i) & 0x1F);
+            ushort g = (ushort)((20 + i) & 0x1F);
+            ushort b = (ushort)((30 + i) & 0x1F);
+            ushort packed = (ushort)((r & 0x1F) | ((g & 0x1F) << 5) | ((b & 0x1F) << 10));
+            rom.Data[slot7Addr + i * 2 + 0] = (byte)(packed & 0xFF);
+            rom.Data[slot7Addr + i * 2 + 1] = (byte)((packed >> 8) & 0xFF);
+        }
+
+        return (rom, paletteBase);
+    }
+
+    static string AxamlPath() => Path.Combine(AvaloniaDir, "Views", "MapStyleEditorView.axaml");
+    static string CodeBehindPath() => Path.Combine(AvaloniaDir, "Views", "MapStyleEditorView.axaml.cs");
+    static string ViewModelPath() => Path.Combine(AvaloniaDir, "ViewModels", "MapStyleEditorViewModel.cs");
+
+    static string ReadAxaml() => File.ReadAllText(AxamlPath());
+
+    static string AvaloniaDir
+    {
+        get
+        {
+            // Walk up from the test binary location until we find the
+            // FEBuilderGBA.Avalonia source directory.
+            string baseDir = AppContext.BaseDirectory;
+            var dir = new DirectoryInfo(baseDir);
+            while (dir != null)
+            {
+                var candidate = Path.Combine(dir.FullName, "FEBuilderGBA.Avalonia");
+                if (Directory.Exists(candidate)) return candidate;
+                dir = dir.Parent;
+            }
+            throw new InvalidOperationException(
+                $"Could not locate FEBuilderGBA.Avalonia/ from base {baseDir}");
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
@@ -10,6 +10,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         bool _isLoaded;
         uint _objPointer;
         uint _configPointer;
+        uint _paletteBaseAddress;
         uint _paletteAddress;
         uint _objAddress;
         uint _objAddress2;
@@ -39,6 +40,21 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public uint ObjPointer { get => _objPointer; set => SetField(ref _objPointer, value); }
         public uint ConfigPointer { get => _configPointer; set => SetField(ref _configPointer, value); }
 
+        /// <summary>
+        /// Stable base address of the 5+5 palette table for the current
+        /// tileset. This is NOT mutated by <see cref="LoadPalette"/> —
+        /// the slice address is stored in <see cref="PaletteAddress"/>
+        /// separately so re-loading with a different paletteIndex/fog
+        /// flag uses the correct base (Copilot bot v2 inline review).
+        /// </summary>
+        public uint PaletteBaseAddress { get => _paletteBaseAddress; set => SetField(ref _paletteBaseAddress, value); }
+
+        /// <summary>
+        /// Slice address of the currently-loaded 16-color palette block.
+        /// Equals <c>PaletteBaseAddress + (paletteIndex + (isFog ? 5 : 0)) * 0x20</c>.
+        /// Computed by <see cref="LoadPalette"/>; do NOT pass this back
+        /// into <see cref="LoadPalette"/> — pass <see cref="PaletteBaseAddress"/>.
+        /// </summary>
         public uint PaletteAddress { get => _paletteAddress; set => SetField(ref _paletteAddress, value); }
         public uint ObjAddress { get => _objAddress; set => SetField(ref _objAddress, value); }
         public uint ObjAddress2 { get => _objAddress2; set => SetField(ref _objAddress2, value); }
@@ -219,6 +235,12 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             }
 
             // Resolve palette pointer from the parallel palette table.
+            // The dereferenced pointer is the BASE of the 5+5 palette
+            // block — stored in PaletteBaseAddress (NOT PaletteAddress)
+            // so subsequent PaletteCombo/PaletteTypeCombo changes can
+            // re-index from this stable origin (Copilot bot v2 inline
+            // review). PaletteAddress holds the slice address per
+            // LoadPalette's contract.
             uint palettePointer = rom.RomInfo.map_pal_pointer;
             if (palettePointer != 0)
             {
@@ -230,15 +252,15 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                     {
                         uint palPtr = rom.u32(paletteEntryAddr);
                         if (palPtr != 0 && U.isPointer(palPtr))
-                            PaletteAddress = U.toOffset(palPtr);
+                            PaletteBaseAddress = U.toOffset(palPtr);
                     }
                 }
             }
 
             // Populate the 16-color palette for the currently-selected
             // PaletteIndex / IsFogPalette (defaults to 0 / false on first load).
-            // Safe-no-op when PaletteAddress is 0 or out-of-bounds.
-            LoadPalette(PaletteAddress, PaletteIndex, IsFogPalette);
+            // Safe-no-op when PaletteBaseAddress is 0 or out-of-bounds.
+            LoadPalette(PaletteBaseAddress, PaletteIndex, IsFogPalette);
 
             ConfigNo = $"0x{index:X2}";
             IsLoaded = true;
@@ -278,6 +300,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 _g[i] = (ushort)((packed >> 5) & 0x1F);
                 _b[i] = (ushort)((packed >> 10) & 0x1F);
             }
+            // CRITICAL: Preserve the base in PaletteBaseAddress so the
+            // next ReloadPalette call (PaletteCombo/PaletteTypeCombo
+            // change) re-indexes from the same base rather than drifting
+            // by idx*0x20 on each selection (Copilot bot v2 inline review).
+            PaletteBaseAddress = paletteBase;
             PaletteAddress = addr;
             PaletteIndex = paletteIndex;
             IsFogPalette = isFog;

--- a/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
@@ -10,11 +10,151 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         bool _isLoaded;
         uint _objPointer;
         uint _configPointer;
+        uint _paletteAddress;
+        uint _objAddress;
+        uint _objAddress2;
+        uint _chipsetConfigAddress;
+        int _paletteIndex;
+        bool _isFogPalette;
+        string _configNo = "";
+
+        // 16 RGB rows × 3 channels — flat backing store keeps the helper
+        // surface (`GetColorR/G/B`, `SetColorR/G/B`) compact and avoids
+        // a `Color` struct dependency that some Avalonia themes ban.
+        readonly ushort[] _r = new ushort[16];
+        readonly ushort[] _g = new ushort[16];
+        readonly ushort[] _b = new ushort[16];
+
+        // 4 tile slots (0/2/4/6) — each has split (X, Y, palette, flip) +
+        // raw word. The split-to-raw setters keep both surfaces synchronized
+        // so the editable view never diverges from the encoded word.
+        readonly int[] _slotX = new int[4];   // index 0..3 for slot 0/2/4/6
+        readonly int[] _slotY = new int[4];
+        readonly int[] _slotPal = new int[4];
+        readonly int[] _slotFlip = new int[4];
+        readonly ushort[] _slotW = new ushort[4];
 
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
         public uint ObjPointer { get => _objPointer; set => SetField(ref _objPointer, value); }
         public uint ConfigPointer { get => _configPointer; set => SetField(ref _configPointer, value); }
+
+        public uint PaletteAddress { get => _paletteAddress; set => SetField(ref _paletteAddress, value); }
+        public uint ObjAddress { get => _objAddress; set => SetField(ref _objAddress, value); }
+        public uint ObjAddress2 { get => _objAddress2; set => SetField(ref _objAddress2, value); }
+        public uint ChipsetConfigAddress { get => _chipsetConfigAddress; set => SetField(ref _chipsetConfigAddress, value); }
+        public int PaletteIndex { get => _paletteIndex; set => SetField(ref _paletteIndex, value); }
+        public bool IsFogPalette { get => _isFogPalette; set => SetField(ref _isFogPalette, value); }
+        public string ConfigNo { get => _configNo; set => SetField(ref _configNo, value); }
+
+        // ----- Palette helpers (5-5-5 RGB, 16 colors per palette) -----
+        // colorIndex is 1-based to match the WF "PALETTE_P_1..16" labels.
+
+        public ushort GetColorR(int colorIndex) => _r[colorIndex - 1];
+        public ushort GetColorG(int colorIndex) => _g[colorIndex - 1];
+        public ushort GetColorB(int colorIndex) => _b[colorIndex - 1];
+        public void SetColorR(int colorIndex, ushort v) { _r[colorIndex - 1] = (ushort)(v & 0x1F); OnPropertyChanged($"Color{colorIndex}_R"); }
+        public void SetColorG(int colorIndex, ushort v) { _g[colorIndex - 1] = (ushort)(v & 0x1F); OnPropertyChanged($"Color{colorIndex}_G"); }
+        public void SetColorB(int colorIndex, ushort v) { _b[colorIndex - 1] = (ushort)(v & 0x1F); OnPropertyChanged($"Color{colorIndex}_B"); }
+
+        // ----- Slot helpers (TSA word + split fields synchronized) -----
+
+        static int SlotKeyToIndex(int slot) => slot switch
+        {
+            0 => 0,
+            2 => 1,
+            4 => 2,
+            6 => 3,
+            _ => throw new ArgumentOutOfRangeException(nameof(slot), $"Unknown slot key: {slot} (expected 0/2/4/6)"),
+        };
+
+        public ushort GetSlotW(int slot) => _slotW[SlotKeyToIndex(slot)];
+
+        /// <summary>
+        /// Set the raw TSA word for a slot. Repopulates the split fields
+        /// via DecodeTsaWord so the editable surface always reflects the
+        /// raw word (Copilot v2 review item 2 setter synchronization).
+        /// </summary>
+        public void SetSlotW(int slot, ushort w)
+        {
+            int i = SlotKeyToIndex(slot);
+            _slotW[i] = w;
+            var (x, y, p, f) = DecodeTsaWord(w);
+            _slotX[i] = x;
+            _slotY[i] = y;
+            _slotPal[i] = p;
+            _slotFlip[i] = f;
+            OnPropertyChanged($"Slot{slot}_W");
+        }
+
+        public int GetSlotSplitField(int slot, string field)
+        {
+            int i = SlotKeyToIndex(slot);
+            return field switch
+            {
+                "X" => _slotX[i],
+                "Y" => _slotY[i],
+                "PALETTE" => _slotPal[i],
+                "FLIP" => _slotFlip[i],
+                _ => throw new ArgumentException($"Unknown split field: {field}", nameof(field)),
+            };
+        }
+
+        /// <summary>
+        /// Set one split field and re-encode the raw word so the two surfaces
+        /// stay synchronized (Copilot v2 review item 2 setter synchronization).
+        /// </summary>
+        public void SetSlotSplitField(int slot, string field, int value)
+        {
+            int i = SlotKeyToIndex(slot);
+            switch (field)
+            {
+                case "X": _slotX[i] = value; break;
+                case "Y": _slotY[i] = value; break;
+                case "PALETTE": _slotPal[i] = value; break;
+                case "FLIP": _slotFlip[i] = value; break;
+                default: throw new ArgumentException($"Unknown split field: {field}", nameof(field));
+            }
+            _slotW[i] = EncodeTsaWord(_slotX[i], _slotY[i], _slotPal[i], _slotFlip[i]);
+            OnPropertyChanged($"Slot{slot}_{field}");
+            OnPropertyChanged($"Slot{slot}_W");
+        }
+
+        /// <summary>Set all four split fields at once and re-encode the raw word.</summary>
+        public void SetSlotSplit(int slot, int x, int y, int palette, int flip)
+        {
+            int i = SlotKeyToIndex(slot);
+            _slotX[i] = x;
+            _slotY[i] = y;
+            _slotPal[i] = palette;
+            _slotFlip[i] = flip;
+            _slotW[i] = EncodeTsaWord(x, y, palette, flip);
+            OnPropertyChanged($"Slot{slot}_W");
+        }
+
+        /// <summary>
+        /// Pack the split fields into the GBA TSA word format. Matches the
+        /// GBA hardware BG-map word layout: tile in bits 0-9, flip in
+        /// bits 10-11, palette in bits 12-15. WF's `MapEditorForm.DecodeTsaWord`
+        /// uses this same packing implicitly via `tile = x + y * 32`.
+        /// </summary>
+        public static ushort EncodeTsaWord(int x, int y, int palette, int flip)
+        {
+            int tile = (x & 0x1F) + (y & 0x1F) * 32; // 5 bits of x + 5 bits of y => bits 0..9
+            int word = (tile & 0x3FF) | ((flip & 0x3) << 10) | ((palette & 0xF) << 12);
+            return (ushort)word;
+        }
+
+        /// <summary>The inverse of EncodeTsaWord. Round-trips exactly for in-range inputs.</summary>
+        public static (int x, int y, int palette, int flip) DecodeTsaWord(ushort word)
+        {
+            int tile = word & 0x3FF;
+            int x = tile & 0x1F;
+            int y = (tile >> 5) & 0x1F;
+            int flip = (word >> 10) & 0x3;
+            int palette = (word >> 12) & 0xF;
+            return (x, y, palette, flip);
+        }
 
         public List<AddrResult> LoadList()
         {
@@ -75,6 +215,36 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             IsLoaded = true;
         }
 
+        /// <summary>
+        /// Load a 16-color palette from a flat RGB-555 region. Effective
+        /// offset is <c>paletteBase + (paletteIndex + (isFog ? 5 : 0)) * 0x20</c>
+        /// per WF's MapStyle palette indexing (5 normal + 5 fog palettes).
+        /// Returns false (without writing properties) when the address
+        /// is unsafe; this is a pure read — no allocation, no PLIST update.
+        /// </summary>
+        public bool LoadPalette(uint paletteBase, int paletteIndex, bool isFog)
+        {
+            if (paletteBase == 0) return false;
+            ROM rom = CoreState.ROM;
+            if (rom == null) return false;
+
+            int effectiveIndex = paletteIndex + (isFog ? 5 : 0);
+            uint addr = paletteBase + (uint)(effectiveIndex * 0x20);
+            if (addr + 0x20 > (uint)rom.Data.Length) return false;
+
+            for (int i = 0; i < 16; i++)
+            {
+                ushort packed = (ushort)rom.u16(addr + (uint)(i * 2));
+                _r[i] = (ushort)(packed & 0x1F);
+                _g[i] = (ushort)((packed >> 5) & 0x1F);
+                _b[i] = (ushort)((packed >> 10) & 0x1F);
+            }
+            PaletteAddress = addr;
+            PaletteIndex = paletteIndex;
+            IsFogPalette = isFog;
+            return true;
+        }
+
         public void Write()
         {
             ROM rom = CoreState.ROM;
@@ -91,6 +261,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 ["addr"] = $"0x{CurrentAddr:X08}",
                 ["ObjPointer"] = $"0x{ObjPointer:X08}",
                 ["ConfigPointer"] = $"0x{ConfigPointer:X08}",
+                ["PaletteAddress"] = $"0x{PaletteAddress:X08}",
             };
         }
 

--- a/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
@@ -207,9 +207,30 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (rom == null) return;
             if (addr + 4 > (uint)rom.Data.Length) return;
 
+            // Reset all dependent fields up-front so a failed read on
+            // the parallel Config / Palette tables does not leave stale
+            // state from the previous entry visible in the UI
+            // (Copilot bot v3 inline review).
+            ConfigPointer = 0;
+            ChipsetConfigAddress = 0;
+            ObjAddress2 = 0;
+            PaletteBaseAddress = 0;
+            PaletteAddress = 0;
+            Array.Clear(_r, 0, 16);
+            Array.Clear(_g, 0, 16);
+            Array.Clear(_b, 0, 16);
+
             CurrentAddr = addr;
             ObjPointer = rom.u32(addr);
             ObjAddress = U.toOffset(ObjPointer);
+
+            // FE7's obj_plist can carry a secondary tileset PLIST in the
+            // high byte (WF MapStyleEditorForm.Display_Plist line 245:
+            // `(obj_plist >> 8) & 0xFF`). The ObjPointer we read from
+            // map_obj_pointer is a resolved 32-bit GBA pointer, so the
+            // PLIST byte is not directly recoverable from here without
+            // calling the PLIST writer. Surface "(none)" until Core
+            // extracts that writer (KnownGap #374). ObjAddress2 stays 0.
 
             // Also load config pointer from the parallel config table
             uint configTablePointer = rom.RomInfo.map_config_pointer;

--- a/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
@@ -193,25 +193,54 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
             CurrentAddr = addr;
             ObjPointer = rom.u32(addr);
+            ObjAddress = U.toOffset(ObjPointer);
 
             // Also load config pointer from the parallel config table
             uint configTablePointer = rom.RomInfo.map_config_pointer;
+            uint configTableBase = 0;
+            uint index = 0;
             if (configTablePointer != 0)
             {
                 uint objTableBase = rom.p32(rom.RomInfo.map_obj_pointer);
                 if (U.isSafetyOffset(objTableBase, rom) && addr >= objTableBase)
                 {
-                    uint index = (addr - objTableBase) / 4;
-                    uint configTableBase = rom.p32(configTablePointer);
+                    index = (addr - objTableBase) / 4;
+                    configTableBase = rom.p32(configTablePointer);
                     if (U.isSafetyOffset(configTableBase, rom))
                     {
                         uint configEntryAddr = configTableBase + index * 4;
                         if (configEntryAddr + 4 <= (uint)rom.Data.Length)
+                        {
                             ConfigPointer = rom.u32(configEntryAddr);
+                            ChipsetConfigAddress = U.toOffset(ConfigPointer);
+                        }
                     }
                 }
             }
 
+            // Resolve palette pointer from the parallel palette table.
+            uint palettePointer = rom.RomInfo.map_pal_pointer;
+            if (palettePointer != 0)
+            {
+                uint paletteTableBase = rom.p32(palettePointer);
+                if (U.isSafetyOffset(paletteTableBase, rom))
+                {
+                    uint paletteEntryAddr = paletteTableBase + index * 4;
+                    if (paletteEntryAddr + 4 <= (uint)rom.Data.Length)
+                    {
+                        uint palPtr = rom.u32(paletteEntryAddr);
+                        if (palPtr != 0 && U.isPointer(palPtr))
+                            PaletteAddress = U.toOffset(palPtr);
+                    }
+                }
+            }
+
+            // Populate the 16-color palette for the currently-selected
+            // PaletteIndex / IsFogPalette (defaults to 0 / false on first load).
+            // Safe-no-op when PaletteAddress is 0 or out-of-bounds.
+            LoadPalette(PaletteAddress, PaletteIndex, IsFogPalette);
+
+            ConfigNo = $"0x{index:X2}";
             IsLoaded = true;
         }
 
@@ -228,9 +257,19 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             ROM rom = CoreState.ROM;
             if (rom == null) return false;
 
+            // Validate `paletteIndex` is in the WF-expected 0..4 range so the
+            // effective index (after the fog offset) stays in 0..9. Negative
+            // or out-of-range inputs would otherwise wrap when cast to uint
+            // and bypass the in-bounds check (Copilot bot inline review).
+            if (paletteIndex < 0 || paletteIndex >= 5) return false;
+
             int effectiveIndex = paletteIndex + (isFog ? 5 : 0);
-            uint addr = paletteBase + (uint)(effectiveIndex * 0x20);
-            if (addr + 0x20 > (uint)rom.Data.Length) return false;
+            // Compute the target address in ulong so out-of-range inputs
+            // can't wrap a uint addition past 2^32. The final uint cast is
+            // safe once we've bounds-checked against rom.Data.Length.
+            ulong target = (ulong)paletteBase + (ulong)effectiveIndex * 0x20UL;
+            if (target + 0x20UL > (ulong)rom.Data.Length) return false;
+            uint addr = (uint)target;
 
             for (int i = 0; i < 16; i++)
             {

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml
@@ -154,84 +154,84 @@
               <TextBlock Grid.Row="0" Grid.Column="5" Text="B" FontWeight="Bold" HorizontalAlignment="Center" />
 
               <TextBlock Grid.Row="1" Grid.Column="0" Text="1" HorizontalAlignment="Center" />
-              <NumericUpDown Grid.Row="1" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color1_R_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="1" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color1_G_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="1" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color1_B_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="1" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color1_R_Input" Name="Color1_RBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="1" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color1_G_Input" Name="Color1_GBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="1" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color1_B_Input" Name="Color1_BBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
 
               <TextBlock Grid.Row="2" Grid.Column="0" Text="2" HorizontalAlignment="Center" />
-              <NumericUpDown Grid.Row="2" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color2_R_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="2" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color2_G_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="2" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color2_B_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="2" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color2_R_Input" Name="Color2_RBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="2" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color2_G_Input" Name="Color2_GBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="2" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color2_B_Input" Name="Color2_BBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
 
               <TextBlock Grid.Row="3" Grid.Column="0" Text="3" HorizontalAlignment="Center" />
-              <NumericUpDown Grid.Row="3" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color3_R_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="3" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color3_G_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="3" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color3_B_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="3" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color3_R_Input" Name="Color3_RBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="3" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color3_G_Input" Name="Color3_GBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="3" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color3_B_Input" Name="Color3_BBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
 
               <TextBlock Grid.Row="4" Grid.Column="0" Text="4" HorizontalAlignment="Center" />
-              <NumericUpDown Grid.Row="4" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color4_R_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="4" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color4_G_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="4" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color4_B_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="4" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color4_R_Input" Name="Color4_RBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="4" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color4_G_Input" Name="Color4_GBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="4" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color4_B_Input" Name="Color4_BBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
 
               <TextBlock Grid.Row="5" Grid.Column="0" Text="5" HorizontalAlignment="Center" />
-              <NumericUpDown Grid.Row="5" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color5_R_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="5" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color5_G_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="5" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color5_B_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="5" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color5_R_Input" Name="Color5_RBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="5" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color5_G_Input" Name="Color5_GBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="5" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color5_B_Input" Name="Color5_BBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
 
               <TextBlock Grid.Row="6" Grid.Column="0" Text="6" HorizontalAlignment="Center" />
-              <NumericUpDown Grid.Row="6" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color6_R_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="6" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color6_G_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="6" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color6_B_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="6" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color6_R_Input" Name="Color6_RBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="6" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color6_G_Input" Name="Color6_GBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="6" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color6_B_Input" Name="Color6_BBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
 
               <TextBlock Grid.Row="7" Grid.Column="0" Text="7" HorizontalAlignment="Center" />
-              <NumericUpDown Grid.Row="7" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color7_R_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="7" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color7_G_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="7" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color7_B_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="7" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color7_R_Input" Name="Color7_RBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="7" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color7_G_Input" Name="Color7_GBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="7" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color7_B_Input" Name="Color7_BBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
 
               <TextBlock Grid.Row="8" Grid.Column="0" Text="8" HorizontalAlignment="Center" />
-              <NumericUpDown Grid.Row="8" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color8_R_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="8" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color8_G_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="8" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color8_B_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="8" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color8_R_Input" Name="Color8_RBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="8" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color8_G_Input" Name="Color8_GBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="8" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color8_B_Input" Name="Color8_BBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
 
               <TextBlock Grid.Row="9" Grid.Column="0" Text="9" HorizontalAlignment="Center" />
-              <NumericUpDown Grid.Row="9" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color9_R_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="9" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color9_G_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="9" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color9_B_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="9" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color9_R_Input" Name="Color9_RBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="9" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color9_G_Input" Name="Color9_GBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="9" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color9_B_Input" Name="Color9_BBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
 
               <TextBlock Grid.Row="10" Grid.Column="0" Text="10" HorizontalAlignment="Center" />
-              <NumericUpDown Grid.Row="10" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color10_R_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="10" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color10_G_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="10" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color10_B_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="10" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color10_R_Input" Name="Color10_RBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="10" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color10_G_Input" Name="Color10_GBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="10" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color10_B_Input" Name="Color10_BBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
 
               <TextBlock Grid.Row="11" Grid.Column="0" Text="11" HorizontalAlignment="Center" />
-              <NumericUpDown Grid.Row="11" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color11_R_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="11" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color11_G_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="11" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color11_B_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="11" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color11_R_Input" Name="Color11_RBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="11" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color11_G_Input" Name="Color11_GBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="11" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color11_B_Input" Name="Color11_BBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
 
               <TextBlock Grid.Row="12" Grid.Column="0" Text="12" HorizontalAlignment="Center" />
-              <NumericUpDown Grid.Row="12" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color12_R_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="12" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color12_G_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="12" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color12_B_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="12" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color12_R_Input" Name="Color12_RBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="12" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color12_G_Input" Name="Color12_GBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="12" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color12_B_Input" Name="Color12_BBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
 
               <TextBlock Grid.Row="13" Grid.Column="0" Text="13" HorizontalAlignment="Center" />
-              <NumericUpDown Grid.Row="13" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color13_R_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="13" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color13_G_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="13" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color13_B_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="13" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color13_R_Input" Name="Color13_RBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="13" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color13_G_Input" Name="Color13_GBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="13" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color13_B_Input" Name="Color13_BBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
 
               <TextBlock Grid.Row="14" Grid.Column="0" Text="14" HorizontalAlignment="Center" />
-              <NumericUpDown Grid.Row="14" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color14_R_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="14" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color14_G_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="14" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color14_B_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="14" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color14_R_Input" Name="Color14_RBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="14" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color14_G_Input" Name="Color14_GBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="14" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color14_B_Input" Name="Color14_BBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
 
               <TextBlock Grid.Row="15" Grid.Column="0" Text="15" HorizontalAlignment="Center" />
-              <NumericUpDown Grid.Row="15" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color15_R_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="15" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color15_G_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="15" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color15_B_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="15" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color15_R_Input" Name="Color15_RBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="15" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color15_G_Input" Name="Color15_GBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="15" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color15_B_Input" Name="Color15_BBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
 
               <TextBlock Grid.Row="16" Grid.Column="0" Text="16" HorizontalAlignment="Center" />
-              <NumericUpDown Grid.Row="16" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color16_R_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="16" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color16_G_Input" Minimum="0" Maximum="31" Width="68" />
-              <NumericUpDown Grid.Row="16" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color16_B_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="16" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color16_R_Input" Name="Color16_RBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="16" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color16_G_Input" Name="Color16_GBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="16" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color16_B_Input" Name="Color16_BBox" IsEnabled="False" Minimum="0" Maximum="31" Width="68" />
             </Grid>
 
             <StackPanel Orientation="Horizontal" Spacing="6" Margin="0,16,0,0">
@@ -293,15 +293,15 @@
                 <TextBlock Text="Top-Left" FontWeight="Bold" />
                 <Grid ColumnDefinitions="80,*,80,*,80,*,80,*,80,*">
                   <TextBlock Grid.Column="0" Text="X" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="1" AutomationProperties.AutomationId="MapStyleEditor_Slot0_TSA_X_Input" Minimum="0" Maximum="31" Width="64" />
+                  <NumericUpDown Grid.Column="1" AutomationProperties.AutomationId="MapStyleEditor_Slot0_TSA_X_Input" Name="Slot0_XBox" IsEnabled="False" Minimum="0" Maximum="31" Width="64" />
                   <TextBlock Grid.Column="2" Text="Y" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="3" AutomationProperties.AutomationId="MapStyleEditor_Slot0_TSA_Y_Input" Minimum="0" Maximum="31" Width="64" />
+                  <NumericUpDown Grid.Column="3" AutomationProperties.AutomationId="MapStyleEditor_Slot0_TSA_Y_Input" Name="Slot0_YBox" IsEnabled="False" Minimum="0" Maximum="31" Width="64" />
                   <TextBlock Grid.Column="4" Text="Palette" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="5" AutomationProperties.AutomationId="MapStyleEditor_Slot0_TSA_PALETTE_Input" Minimum="0" Maximum="15" Width="64" />
+                  <NumericUpDown Grid.Column="5" AutomationProperties.AutomationId="MapStyleEditor_Slot0_TSA_PALETTE_Input" Name="Slot0_PALETTEBox" IsEnabled="False" Minimum="0" Maximum="15" Width="64" />
                   <TextBlock Grid.Column="6" Text="Flip" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="7" AutomationProperties.AutomationId="MapStyleEditor_Slot0_TSA_FLIP_Input" Minimum="0" Maximum="3" Width="64" />
+                  <NumericUpDown Grid.Column="7" AutomationProperties.AutomationId="MapStyleEditor_Slot0_TSA_FLIP_Input" Name="Slot0_FLIPBox" IsEnabled="False" Minimum="0" Maximum="3" Width="64" />
                   <TextBlock Grid.Column="8" Text="W" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="9" AutomationProperties.AutomationId="MapStyleEditor_Slot0_W_Input" Minimum="0" Maximum="65535" Width="80" />
+                  <NumericUpDown Grid.Column="9" AutomationProperties.AutomationId="MapStyleEditor_Slot0_W_Input" Name="Slot0_WBox" IsEnabled="False" Minimum="0" Maximum="65535" Width="80" />
                 </Grid>
               </StackPanel>
             </Border>
@@ -311,15 +311,15 @@
                 <TextBlock Text="Top-Right" FontWeight="Bold" />
                 <Grid ColumnDefinitions="80,*,80,*,80,*,80,*,80,*">
                   <TextBlock Grid.Column="0" Text="X" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="1" AutomationProperties.AutomationId="MapStyleEditor_Slot2_TSA_X_Input" Minimum="0" Maximum="31" Width="64" />
+                  <NumericUpDown Grid.Column="1" AutomationProperties.AutomationId="MapStyleEditor_Slot2_TSA_X_Input" Name="Slot2_XBox" IsEnabled="False" Minimum="0" Maximum="31" Width="64" />
                   <TextBlock Grid.Column="2" Text="Y" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="3" AutomationProperties.AutomationId="MapStyleEditor_Slot2_TSA_Y_Input" Minimum="0" Maximum="31" Width="64" />
+                  <NumericUpDown Grid.Column="3" AutomationProperties.AutomationId="MapStyleEditor_Slot2_TSA_Y_Input" Name="Slot2_YBox" IsEnabled="False" Minimum="0" Maximum="31" Width="64" />
                   <TextBlock Grid.Column="4" Text="Palette" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="5" AutomationProperties.AutomationId="MapStyleEditor_Slot2_TSA_PALETTE_Input" Minimum="0" Maximum="15" Width="64" />
+                  <NumericUpDown Grid.Column="5" AutomationProperties.AutomationId="MapStyleEditor_Slot2_TSA_PALETTE_Input" Name="Slot2_PALETTEBox" IsEnabled="False" Minimum="0" Maximum="15" Width="64" />
                   <TextBlock Grid.Column="6" Text="Flip" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="7" AutomationProperties.AutomationId="MapStyleEditor_Slot2_TSA_FLIP_Input" Minimum="0" Maximum="3" Width="64" />
+                  <NumericUpDown Grid.Column="7" AutomationProperties.AutomationId="MapStyleEditor_Slot2_TSA_FLIP_Input" Name="Slot2_FLIPBox" IsEnabled="False" Minimum="0" Maximum="3" Width="64" />
                   <TextBlock Grid.Column="8" Text="W" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="9" AutomationProperties.AutomationId="MapStyleEditor_Slot2_W_Input" Minimum="0" Maximum="65535" Width="80" />
+                  <NumericUpDown Grid.Column="9" AutomationProperties.AutomationId="MapStyleEditor_Slot2_W_Input" Name="Slot2_WBox" IsEnabled="False" Minimum="0" Maximum="65535" Width="80" />
                 </Grid>
               </StackPanel>
             </Border>
@@ -329,15 +329,15 @@
                 <TextBlock Text="Bottom-Left" FontWeight="Bold" />
                 <Grid ColumnDefinitions="80,*,80,*,80,*,80,*,80,*">
                   <TextBlock Grid.Column="0" Text="X" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="1" AutomationProperties.AutomationId="MapStyleEditor_Slot4_TSA_X_Input" Minimum="0" Maximum="31" Width="64" />
+                  <NumericUpDown Grid.Column="1" AutomationProperties.AutomationId="MapStyleEditor_Slot4_TSA_X_Input" Name="Slot4_XBox" IsEnabled="False" Minimum="0" Maximum="31" Width="64" />
                   <TextBlock Grid.Column="2" Text="Y" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="3" AutomationProperties.AutomationId="MapStyleEditor_Slot4_TSA_Y_Input" Minimum="0" Maximum="31" Width="64" />
+                  <NumericUpDown Grid.Column="3" AutomationProperties.AutomationId="MapStyleEditor_Slot4_TSA_Y_Input" Name="Slot4_YBox" IsEnabled="False" Minimum="0" Maximum="31" Width="64" />
                   <TextBlock Grid.Column="4" Text="Palette" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="5" AutomationProperties.AutomationId="MapStyleEditor_Slot4_TSA_PALETTE_Input" Minimum="0" Maximum="15" Width="64" />
+                  <NumericUpDown Grid.Column="5" AutomationProperties.AutomationId="MapStyleEditor_Slot4_TSA_PALETTE_Input" Name="Slot4_PALETTEBox" IsEnabled="False" Minimum="0" Maximum="15" Width="64" />
                   <TextBlock Grid.Column="6" Text="Flip" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="7" AutomationProperties.AutomationId="MapStyleEditor_Slot4_TSA_FLIP_Input" Minimum="0" Maximum="3" Width="64" />
+                  <NumericUpDown Grid.Column="7" AutomationProperties.AutomationId="MapStyleEditor_Slot4_TSA_FLIP_Input" Name="Slot4_FLIPBox" IsEnabled="False" Minimum="0" Maximum="3" Width="64" />
                   <TextBlock Grid.Column="8" Text="W" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="9" AutomationProperties.AutomationId="MapStyleEditor_Slot4_W_Input" Minimum="0" Maximum="65535" Width="80" />
+                  <NumericUpDown Grid.Column="9" AutomationProperties.AutomationId="MapStyleEditor_Slot4_W_Input" Name="Slot4_WBox" IsEnabled="False" Minimum="0" Maximum="65535" Width="80" />
                 </Grid>
               </StackPanel>
             </Border>
@@ -347,15 +347,15 @@
                 <TextBlock Text="Bottom-Right" FontWeight="Bold" />
                 <Grid ColumnDefinitions="80,*,80,*,80,*,80,*,80,*">
                   <TextBlock Grid.Column="0" Text="X" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="1" AutomationProperties.AutomationId="MapStyleEditor_Slot6_TSA_X_Input" Minimum="0" Maximum="31" Width="64" />
+                  <NumericUpDown Grid.Column="1" AutomationProperties.AutomationId="MapStyleEditor_Slot6_TSA_X_Input" Name="Slot6_XBox" IsEnabled="False" Minimum="0" Maximum="31" Width="64" />
                   <TextBlock Grid.Column="2" Text="Y" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="3" AutomationProperties.AutomationId="MapStyleEditor_Slot6_TSA_Y_Input" Minimum="0" Maximum="31" Width="64" />
+                  <NumericUpDown Grid.Column="3" AutomationProperties.AutomationId="MapStyleEditor_Slot6_TSA_Y_Input" Name="Slot6_YBox" IsEnabled="False" Minimum="0" Maximum="31" Width="64" />
                   <TextBlock Grid.Column="4" Text="Palette" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="5" AutomationProperties.AutomationId="MapStyleEditor_Slot6_TSA_PALETTE_Input" Minimum="0" Maximum="15" Width="64" />
+                  <NumericUpDown Grid.Column="5" AutomationProperties.AutomationId="MapStyleEditor_Slot6_TSA_PALETTE_Input" Name="Slot6_PALETTEBox" IsEnabled="False" Minimum="0" Maximum="15" Width="64" />
                   <TextBlock Grid.Column="6" Text="Flip" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="7" AutomationProperties.AutomationId="MapStyleEditor_Slot6_TSA_FLIP_Input" Minimum="0" Maximum="3" Width="64" />
+                  <NumericUpDown Grid.Column="7" AutomationProperties.AutomationId="MapStyleEditor_Slot6_TSA_FLIP_Input" Name="Slot6_FLIPBox" IsEnabled="False" Minimum="0" Maximum="3" Width="64" />
                   <TextBlock Grid.Column="8" Text="W" VerticalAlignment="Center" />
-                  <NumericUpDown Grid.Column="9" AutomationProperties.AutomationId="MapStyleEditor_Slot6_W_Input" Minimum="0" Maximum="65535" Width="80" />
+                  <NumericUpDown Grid.Column="9" AutomationProperties.AutomationId="MapStyleEditor_Slot6_W_Input" Name="Slot6_WBox" IsEnabled="False" Minimum="0" Maximum="65535" Width="80" />
                 </Grid>
               </StackPanel>
             </Border>

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml
@@ -128,7 +128,7 @@
             <!-- Palette selectors -->
             <StackPanel Orientation="Horizontal" Spacing="8">
               <TextBlock Text="Palette No:" VerticalAlignment="Center" />
-              <ComboBox AutomationProperties.AutomationId="MapStyleEditor_PaletteCombo"
+              <ComboBox AutomationProperties.AutomationId="MapStyleEditor_Palette_Combo"
                         Name="PaletteCombo" Width="120" VerticalAlignment="Center">
                 <ComboBoxItem Content="Palette 1" />
                 <ComboBoxItem Content="Palette 2" />
@@ -136,7 +136,7 @@
                 <ComboBoxItem Content="Palette 4" />
                 <ComboBoxItem Content="Palette 5" />
               </ComboBox>
-              <ComboBox AutomationProperties.AutomationId="MapStyleEditor_PaletteTypeCombo"
+              <ComboBox AutomationProperties.AutomationId="MapStyleEditor_PaletteType_Combo"
                         Name="PaletteTypeCombo" Width="160" VerticalAlignment="Center"
                         SelectedIndex="0">
                 <ComboBoxItem Content="No Fog" />

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml
@@ -2,30 +2,385 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
         x:Class="FEBuilderGBA.Avalonia.Views.MapStyleEditorView"
-        Title="Map Style Editor" Width="900" Height="550"
-        SizeToContent="WidthAndHeight">
-  <Grid ColumnDefinitions="250,*">
-    <controls:AddressListControl AutomationProperties.AutomationId="MapStyleEditor_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
-
-    <ScrollViewer Grid.Column="1" Margin="4">
-      <StackPanel Spacing="8" Margin="8">
-        <TextBlock Text="Map Style Editor" FontSize="18" FontWeight="Bold" />
-
-        <Grid ColumnDefinitions="160,*" RowDefinitions="Auto,Auto,Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="MapStyleEditor_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
-
-          <TextBlock Grid.Row="1" Grid.Column="0" Text="OBJ Tile Pointer:" VerticalAlignment="Center" />
-          <TextBox AutomationProperties.AutomationId="MapStyleEditor_ObjPtr_Input" Grid.Row="1" Grid.Column="1" Name="ObjPtrBox" Width="160" HorizontalAlignment="Left" />
-
-          <TextBlock Grid.Row="2" Grid.Column="0" Text="Config Pointer:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="MapStyleEditor_ConfigPtr_Label" Grid.Row="2" Grid.Column="1" Name="ConfigPtrLabel" VerticalAlignment="Center" Foreground="Gray" />
-        </Grid>
-
-        <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,16,0,0">
-          <Button AutomationProperties.AutomationId="MapStyleEditor_Write_Button" Content="Write" Click="Write_Click" />
-        </StackPanel>
+        Title="Map Style Editor" Width="1080" Height="780"
+        SizeToContent="Manual">
+  <Grid ColumnDefinitions="250,*" RowDefinitions="Auto,*">
+    <!-- Row 0: top selection bar (mirrors WF MapStyle ComboBox + Address) -->
+    <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
+      <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
+        <TextBlock Text="Map Style:" VerticalAlignment="Center" />
+        <ComboBox AutomationProperties.AutomationId="MapStyleEditor_MapStyle_Combo"
+                  Name="MapStyleCombo" Width="380"
+                  VerticalAlignment="Center" />
+        <TextBlock Text="Address:" VerticalAlignment="Center" Margin="16,0,0,0" />
+        <TextBlock AutomationProperties.AutomationId="MapStyleEditor_Addr_Label"
+                   Name="AddrLabel" VerticalAlignment="Center" Width="100"
+                   FontFamily="Consolas" />
       </StackPanel>
-    </ScrollViewer>
+    </Border>
+
+    <!-- Row 1 col 0: address list (legacy, preserved AutomationId) -->
+    <controls:AddressListControl
+        AutomationProperties.AutomationId="MapStyleEditor_Entry_List"
+        Grid.Row="1" Grid.Column="0" Name="EntryList" Margin="4" />
+
+    <!-- Row 1 col 1: TabControl (3 tabs mirror WF 3-panel layout) -->
+    <TabControl AutomationProperties.AutomationId="MapStyleEditor_Main_TabControl"
+                Grid.Row="1" Grid.Column="1" Margin="4" SelectedIndex="0">
+
+      <!-- ============================================================== -->
+      <!-- Tab 1: Map Style (オブジェクト)                               -->
+      <!-- ============================================================== -->
+      <TabItem AutomationProperties.AutomationId="MapStyleEditor_MapStyle_Tab"
+               Header="Map Style">
+        <ScrollViewer>
+          <StackPanel Spacing="8" Margin="8">
+            <TextBlock Text="Map Style Editor" FontSize="18" FontWeight="Bold" />
+
+            <Grid ColumnDefinitions="180,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
+              <TextBlock Grid.Row="0" Grid.Column="0" Text="Object Address:" VerticalAlignment="Center" />
+              <TextBlock Grid.Row="0" Grid.Column="1"
+                         AutomationProperties.AutomationId="MapStyleEditor_ObjAddress_Label"
+                         Name="ObjAddressLabel" VerticalAlignment="Center"
+                         FontFamily="Consolas" />
+
+              <TextBlock Grid.Row="1" Grid.Column="0" Text="Object Address 2:" VerticalAlignment="Center" />
+              <TextBlock Grid.Row="1" Grid.Column="1"
+                         AutomationProperties.AutomationId="MapStyleEditor_ObjAddress2_Label"
+                         Name="ObjAddress2Label" VerticalAlignment="Center"
+                         FontFamily="Consolas" />
+
+              <TextBlock Grid.Row="2" Grid.Column="0" Text="Palette Address:" VerticalAlignment="Center" />
+              <TextBlock Grid.Row="2" Grid.Column="1"
+                         AutomationProperties.AutomationId="MapStyleEditor_PaletteAddress_Label"
+                         Name="PaletteAddressLabel" VerticalAlignment="Center"
+                         FontFamily="Consolas" />
+
+              <TextBlock Grid.Row="3" Grid.Column="0" Text="OBJ Tile Pointer:" VerticalAlignment="Center" />
+              <TextBox AutomationProperties.AutomationId="MapStyleEditor_ObjPtr_Input"
+                       Grid.Row="3" Grid.Column="1" Name="ObjPtrBox" Width="180"
+                       HorizontalAlignment="Left" />
+
+              <TextBlock Grid.Row="4" Grid.Column="0" Text="Config Pointer:" VerticalAlignment="Center" />
+              <TextBlock AutomationProperties.AutomationId="MapStyleEditor_ConfigPtr_Label"
+                         Grid.Row="4" Grid.Column="1" Name="ConfigPtrLabel"
+                         VerticalAlignment="Center" Foreground="Gray"
+                         FontFamily="Consolas" />
+
+              <TextBlock Grid.Row="5" Grid.Column="0" Text="Tileset Type:" VerticalAlignment="Center" />
+              <TextBlock Grid.Row="5" Grid.Column="1"
+                         AutomationProperties.AutomationId="MapStyleEditor_TilesetType_Label"
+                         Name="TilesetTypeLabel" VerticalAlignment="Center" />
+            </Grid>
+
+            <!-- Map chip thumbnail placeholder (KnownGap — image-decode WF-only) -->
+            <Border BorderBrush="DarkGray" BorderThickness="1" Width="256" Height="128"
+                    HorizontalAlignment="Left">
+              <TextBlock AutomationProperties.AutomationId="MapStyleEditor_MapChipPreview_Label"
+                         Text="Map Chip Preview"
+                         HorizontalAlignment="Center" VerticalAlignment="Center"
+                         Foreground="Gray" />
+            </Border>
+
+            <!-- Object / Map Chip / Undo / Redo / Write button strip -->
+            <StackPanel Orientation="Horizontal" Spacing="6" Margin="0,16,0,0">
+              <Button AutomationProperties.AutomationId="MapStyleEditor_ObjExport_Button"
+                      Content="Image Export"
+                      IsEnabled="False"
+                      ToolTip.Tip="Pending Core extraction - tracked by #374." />
+              <Button AutomationProperties.AutomationId="MapStyleEditor_ObjImport_Button"
+                      Content="Image Import"
+                      IsEnabled="False"
+                      ToolTip.Tip="Pending Core extraction - tracked by #374." />
+              <Button AutomationProperties.AutomationId="MapStyleEditor_MapChipExport_Button"
+                      Content="Map Chip Save"
+                      IsEnabled="False"
+                      ToolTip.Tip="Pending Core extraction - tracked by #374." />
+              <Button AutomationProperties.AutomationId="MapStyleEditor_MapChipImport_Button"
+                      Content="Map Chip Load"
+                      IsEnabled="False"
+                      ToolTip.Tip="Pending Core extraction - tracked by #374." />
+              <Button AutomationProperties.AutomationId="MapStyleEditor_Undo_Button"
+                      Content="UNDO"
+                      IsEnabled="False"
+                      ToolTip.Tip="Pending Core extraction - tracked by #374." />
+              <Button AutomationProperties.AutomationId="MapStyleEditor_Redo_Button"
+                      Content="REDO"
+                      IsEnabled="False"
+                      ToolTip.Tip="Pending Core extraction - tracked by #374." />
+              <Button AutomationProperties.AutomationId="MapStyleEditor_Write_Button"
+                      Name="WriteButton" Content="Write"
+                      Click="Write_Click" />
+            </StackPanel>
+          </StackPanel>
+        </ScrollViewer>
+      </TabItem>
+
+      <!-- ============================================================== -->
+      <!-- Tab 2: Palette (パレット)                                       -->
+      <!-- ============================================================== -->
+      <TabItem AutomationProperties.AutomationId="MapStyleEditor_Palette_Tab"
+               Header="Palette">
+        <ScrollViewer>
+          <StackPanel Spacing="8" Margin="8">
+            <TextBlock Text="Palette" FontSize="18" FontWeight="Bold" />
+
+            <!-- Palette selectors -->
+            <StackPanel Orientation="Horizontal" Spacing="8">
+              <TextBlock Text="Palette No:" VerticalAlignment="Center" />
+              <ComboBox AutomationProperties.AutomationId="MapStyleEditor_PaletteCombo"
+                        Name="PaletteCombo" Width="120" VerticalAlignment="Center">
+                <ComboBoxItem Content="Palette 1" />
+                <ComboBoxItem Content="Palette 2" />
+                <ComboBoxItem Content="Palette 3" />
+                <ComboBoxItem Content="Palette 4" />
+                <ComboBoxItem Content="Palette 5" />
+              </ComboBox>
+              <ComboBox AutomationProperties.AutomationId="MapStyleEditor_PaletteTypeCombo"
+                        Name="PaletteTypeCombo" Width="160" VerticalAlignment="Center"
+                        SelectedIndex="0">
+                <ComboBoxItem Content="No Fog" />
+                <ComboBoxItem Content="Fog" />
+              </ComboBox>
+            </StackPanel>
+
+            <!-- 16 RGB rows — each row: Color {i} label + R/G/B inputs.
+                 The single-char labels "1".."16", "R", "G", "B" come from
+                 the per-row headers (covers labels-sweep entries). -->
+            <Grid ColumnDefinitions="48,32,72,32,72,32,72" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+              <TextBlock Grid.Row="0" Grid.Column="0" Text="No" FontWeight="Bold" HorizontalAlignment="Center" />
+              <TextBlock Grid.Row="0" Grid.Column="1" Text="R" FontWeight="Bold" HorizontalAlignment="Center" />
+              <TextBlock Grid.Row="0" Grid.Column="3" Text="G" FontWeight="Bold" HorizontalAlignment="Center" />
+              <TextBlock Grid.Row="0" Grid.Column="5" Text="B" FontWeight="Bold" HorizontalAlignment="Center" />
+
+              <TextBlock Grid.Row="1" Grid.Column="0" Text="1" HorizontalAlignment="Center" />
+              <NumericUpDown Grid.Row="1" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color1_R_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="1" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color1_G_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="1" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color1_B_Input" Minimum="0" Maximum="31" Width="68" />
+
+              <TextBlock Grid.Row="2" Grid.Column="0" Text="2" HorizontalAlignment="Center" />
+              <NumericUpDown Grid.Row="2" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color2_R_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="2" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color2_G_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="2" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color2_B_Input" Minimum="0" Maximum="31" Width="68" />
+
+              <TextBlock Grid.Row="3" Grid.Column="0" Text="3" HorizontalAlignment="Center" />
+              <NumericUpDown Grid.Row="3" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color3_R_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="3" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color3_G_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="3" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color3_B_Input" Minimum="0" Maximum="31" Width="68" />
+
+              <TextBlock Grid.Row="4" Grid.Column="0" Text="4" HorizontalAlignment="Center" />
+              <NumericUpDown Grid.Row="4" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color4_R_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="4" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color4_G_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="4" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color4_B_Input" Minimum="0" Maximum="31" Width="68" />
+
+              <TextBlock Grid.Row="5" Grid.Column="0" Text="5" HorizontalAlignment="Center" />
+              <NumericUpDown Grid.Row="5" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color5_R_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="5" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color5_G_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="5" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color5_B_Input" Minimum="0" Maximum="31" Width="68" />
+
+              <TextBlock Grid.Row="6" Grid.Column="0" Text="6" HorizontalAlignment="Center" />
+              <NumericUpDown Grid.Row="6" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color6_R_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="6" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color6_G_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="6" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color6_B_Input" Minimum="0" Maximum="31" Width="68" />
+
+              <TextBlock Grid.Row="7" Grid.Column="0" Text="7" HorizontalAlignment="Center" />
+              <NumericUpDown Grid.Row="7" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color7_R_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="7" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color7_G_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="7" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color7_B_Input" Minimum="0" Maximum="31" Width="68" />
+
+              <TextBlock Grid.Row="8" Grid.Column="0" Text="8" HorizontalAlignment="Center" />
+              <NumericUpDown Grid.Row="8" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color8_R_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="8" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color8_G_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="8" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color8_B_Input" Minimum="0" Maximum="31" Width="68" />
+
+              <TextBlock Grid.Row="9" Grid.Column="0" Text="9" HorizontalAlignment="Center" />
+              <NumericUpDown Grid.Row="9" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color9_R_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="9" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color9_G_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="9" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color9_B_Input" Minimum="0" Maximum="31" Width="68" />
+
+              <TextBlock Grid.Row="10" Grid.Column="0" Text="10" HorizontalAlignment="Center" />
+              <NumericUpDown Grid.Row="10" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color10_R_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="10" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color10_G_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="10" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color10_B_Input" Minimum="0" Maximum="31" Width="68" />
+
+              <TextBlock Grid.Row="11" Grid.Column="0" Text="11" HorizontalAlignment="Center" />
+              <NumericUpDown Grid.Row="11" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color11_R_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="11" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color11_G_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="11" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color11_B_Input" Minimum="0" Maximum="31" Width="68" />
+
+              <TextBlock Grid.Row="12" Grid.Column="0" Text="12" HorizontalAlignment="Center" />
+              <NumericUpDown Grid.Row="12" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color12_R_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="12" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color12_G_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="12" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color12_B_Input" Minimum="0" Maximum="31" Width="68" />
+
+              <TextBlock Grid.Row="13" Grid.Column="0" Text="13" HorizontalAlignment="Center" />
+              <NumericUpDown Grid.Row="13" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color13_R_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="13" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color13_G_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="13" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color13_B_Input" Minimum="0" Maximum="31" Width="68" />
+
+              <TextBlock Grid.Row="14" Grid.Column="0" Text="14" HorizontalAlignment="Center" />
+              <NumericUpDown Grid.Row="14" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color14_R_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="14" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color14_G_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="14" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color14_B_Input" Minimum="0" Maximum="31" Width="68" />
+
+              <TextBlock Grid.Row="15" Grid.Column="0" Text="15" HorizontalAlignment="Center" />
+              <NumericUpDown Grid.Row="15" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color15_R_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="15" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color15_G_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="15" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color15_B_Input" Minimum="0" Maximum="31" Width="68" />
+
+              <TextBlock Grid.Row="16" Grid.Column="0" Text="16" HorizontalAlignment="Center" />
+              <NumericUpDown Grid.Row="16" Grid.Column="2" AutomationProperties.AutomationId="MapStyleEditor_Color16_R_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="16" Grid.Column="4" AutomationProperties.AutomationId="MapStyleEditor_Color16_G_Input" Minimum="0" Maximum="31" Width="68" />
+              <NumericUpDown Grid.Row="16" Grid.Column="6" AutomationProperties.AutomationId="MapStyleEditor_Color16_B_Input" Minimum="0" Maximum="31" Width="68" />
+            </Grid>
+
+            <StackPanel Orientation="Horizontal" Spacing="6" Margin="0,16,0,0">
+              <Button AutomationProperties.AutomationId="MapStyleEditor_PaletteExport_Button"
+                      Content="Palette Export"
+                      IsEnabled="False"
+                      ToolTip.Tip="Pending Core extraction - tracked by #374." />
+              <Button AutomationProperties.AutomationId="MapStyleEditor_PaletteImport_Button"
+                      Content="Palette Import"
+                      IsEnabled="False"
+                      ToolTip.Tip="Pending Core extraction - tracked by #374." />
+              <Button AutomationProperties.AutomationId="MapStyleEditor_PaletteClipboard_Button"
+                      Content="Clipboard"
+                      IsEnabled="False"
+                      ToolTip.Tip="Pending Core extraction - tracked by #374." />
+              <Button AutomationProperties.AutomationId="MapStyleEditor_PaletteWrite_Button"
+                      Content="Palette Write"
+                      IsEnabled="False"
+                      ToolTip.Tip="Pending Core extraction (palette PLIST allocation) - tracked by #374." />
+            </StackPanel>
+          </StackPanel>
+        </ScrollViewer>
+      </TabItem>
+
+      <!-- ============================================================== -->
+      <!-- Tab 3: Chipset (種類)                                          -->
+      <!-- ============================================================== -->
+      <TabItem AutomationProperties.AutomationId="MapStyleEditor_Chipset_Tab"
+               Header="Chipset">
+        <ScrollViewer>
+          <StackPanel Spacing="8" Margin="8">
+            <TextBlock Text="Chipset" FontSize="18" FontWeight="Bold" />
+
+            <Grid ColumnDefinitions="200,*" RowDefinitions="Auto,Auto,Auto">
+              <TextBlock Grid.Row="0" Grid.Column="0" Text="Chipset Config Address:" VerticalAlignment="Center" />
+              <TextBlock Grid.Row="0" Grid.Column="1"
+                         AutomationProperties.AutomationId="MapStyleEditor_ChipsetConfigAddress_Label"
+                         Name="ChipsetConfigAddressLabel" VerticalAlignment="Center"
+                         FontFamily="Consolas" />
+
+              <TextBlock Grid.Row="1" Grid.Column="0" Text="Chipset No:" VerticalAlignment="Center" />
+              <TextBlock Grid.Row="1" Grid.Column="1"
+                         AutomationProperties.AutomationId="MapStyleEditor_ConfigNo_Label"
+                         Name="ConfigNoLabel" VerticalAlignment="Center"
+                         FontFamily="Consolas" />
+
+              <TextBlock Grid.Row="2" Grid.Column="0" Text="Terrain Type:" VerticalAlignment="Center" />
+              <ComboBox Grid.Row="2" Grid.Column="1"
+                        AutomationProperties.AutomationId="MapStyleEditor_ConfigTerrain_Combo"
+                        Name="ConfigTerrainCombo" Width="200" HorizontalAlignment="Left"
+                        IsEnabled="True" />
+            </Grid>
+
+            <!-- 4 tile-slot TSA grids (Top-Left, Top-Right, Bottom-Left, Bottom-Right).
+                 Each grid mirrors WF Config_L_{N}_TSA_{X,Y,PALETTE,FLIP} + Config_W{N}. -->
+
+            <Border BorderBrush="DarkGray" BorderThickness="1" Padding="6">
+              <StackPanel Spacing="4">
+                <TextBlock Text="Top-Left" FontWeight="Bold" />
+                <Grid ColumnDefinitions="80,*,80,*,80,*,80,*,80,*">
+                  <TextBlock Grid.Column="0" Text="X" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="1" AutomationProperties.AutomationId="MapStyleEditor_Slot0_TSA_X_Input" Minimum="0" Maximum="31" Width="64" />
+                  <TextBlock Grid.Column="2" Text="Y" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="3" AutomationProperties.AutomationId="MapStyleEditor_Slot0_TSA_Y_Input" Minimum="0" Maximum="31" Width="64" />
+                  <TextBlock Grid.Column="4" Text="Palette" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="5" AutomationProperties.AutomationId="MapStyleEditor_Slot0_TSA_PALETTE_Input" Minimum="0" Maximum="15" Width="64" />
+                  <TextBlock Grid.Column="6" Text="Flip" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="7" AutomationProperties.AutomationId="MapStyleEditor_Slot0_TSA_FLIP_Input" Minimum="0" Maximum="3" Width="64" />
+                  <TextBlock Grid.Column="8" Text="W" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="9" AutomationProperties.AutomationId="MapStyleEditor_Slot0_W_Input" Minimum="0" Maximum="65535" Width="80" />
+                </Grid>
+              </StackPanel>
+            </Border>
+
+            <Border BorderBrush="DarkGray" BorderThickness="1" Padding="6">
+              <StackPanel Spacing="4">
+                <TextBlock Text="Top-Right" FontWeight="Bold" />
+                <Grid ColumnDefinitions="80,*,80,*,80,*,80,*,80,*">
+                  <TextBlock Grid.Column="0" Text="X" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="1" AutomationProperties.AutomationId="MapStyleEditor_Slot2_TSA_X_Input" Minimum="0" Maximum="31" Width="64" />
+                  <TextBlock Grid.Column="2" Text="Y" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="3" AutomationProperties.AutomationId="MapStyleEditor_Slot2_TSA_Y_Input" Minimum="0" Maximum="31" Width="64" />
+                  <TextBlock Grid.Column="4" Text="Palette" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="5" AutomationProperties.AutomationId="MapStyleEditor_Slot2_TSA_PALETTE_Input" Minimum="0" Maximum="15" Width="64" />
+                  <TextBlock Grid.Column="6" Text="Flip" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="7" AutomationProperties.AutomationId="MapStyleEditor_Slot2_TSA_FLIP_Input" Minimum="0" Maximum="3" Width="64" />
+                  <TextBlock Grid.Column="8" Text="W" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="9" AutomationProperties.AutomationId="MapStyleEditor_Slot2_W_Input" Minimum="0" Maximum="65535" Width="80" />
+                </Grid>
+              </StackPanel>
+            </Border>
+
+            <Border BorderBrush="DarkGray" BorderThickness="1" Padding="6">
+              <StackPanel Spacing="4">
+                <TextBlock Text="Bottom-Left" FontWeight="Bold" />
+                <Grid ColumnDefinitions="80,*,80,*,80,*,80,*,80,*">
+                  <TextBlock Grid.Column="0" Text="X" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="1" AutomationProperties.AutomationId="MapStyleEditor_Slot4_TSA_X_Input" Minimum="0" Maximum="31" Width="64" />
+                  <TextBlock Grid.Column="2" Text="Y" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="3" AutomationProperties.AutomationId="MapStyleEditor_Slot4_TSA_Y_Input" Minimum="0" Maximum="31" Width="64" />
+                  <TextBlock Grid.Column="4" Text="Palette" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="5" AutomationProperties.AutomationId="MapStyleEditor_Slot4_TSA_PALETTE_Input" Minimum="0" Maximum="15" Width="64" />
+                  <TextBlock Grid.Column="6" Text="Flip" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="7" AutomationProperties.AutomationId="MapStyleEditor_Slot4_TSA_FLIP_Input" Minimum="0" Maximum="3" Width="64" />
+                  <TextBlock Grid.Column="8" Text="W" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="9" AutomationProperties.AutomationId="MapStyleEditor_Slot4_W_Input" Minimum="0" Maximum="65535" Width="80" />
+                </Grid>
+              </StackPanel>
+            </Border>
+
+            <Border BorderBrush="DarkGray" BorderThickness="1" Padding="6">
+              <StackPanel Spacing="4">
+                <TextBlock Text="Bottom-Right" FontWeight="Bold" />
+                <Grid ColumnDefinitions="80,*,80,*,80,*,80,*,80,*">
+                  <TextBlock Grid.Column="0" Text="X" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="1" AutomationProperties.AutomationId="MapStyleEditor_Slot6_TSA_X_Input" Minimum="0" Maximum="31" Width="64" />
+                  <TextBlock Grid.Column="2" Text="Y" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="3" AutomationProperties.AutomationId="MapStyleEditor_Slot6_TSA_Y_Input" Minimum="0" Maximum="31" Width="64" />
+                  <TextBlock Grid.Column="4" Text="Palette" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="5" AutomationProperties.AutomationId="MapStyleEditor_Slot6_TSA_PALETTE_Input" Minimum="0" Maximum="15" Width="64" />
+                  <TextBlock Grid.Column="6" Text="Flip" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="7" AutomationProperties.AutomationId="MapStyleEditor_Slot6_TSA_FLIP_Input" Minimum="0" Maximum="3" Width="64" />
+                  <TextBlock Grid.Column="8" Text="W" VerticalAlignment="Center" />
+                  <NumericUpDown Grid.Column="9" AutomationProperties.AutomationId="MapStyleEditor_Slot6_W_Input" Minimum="0" Maximum="65535" Width="80" />
+                </Grid>
+              </StackPanel>
+            </Border>
+
+            <StackPanel Orientation="Horizontal" Spacing="6" Margin="0,16,0,0">
+              <Button AutomationProperties.AutomationId="MapStyleEditor_CopyTile_Button"
+                      Content="Copy Tile (Alt+T)"
+                      IsEnabled="False"
+                      ToolTip.Tip="Pending Core extraction - tracked by #374." />
+              <Button AutomationProperties.AutomationId="MapStyleEditor_CopyType_Button"
+                      Content="Copy Type (Alt+C)"
+                      IsEnabled="False"
+                      ToolTip.Tip="Pending Core extraction - tracked by #374." />
+              <Button AutomationProperties.AutomationId="MapStyleEditor_Paste_Button"
+                      Content="Paste (Alt+V)"
+                      IsEnabled="False"
+                      ToolTip.Tip="Pending Core extraction - tracked by #374." />
+              <Button AutomationProperties.AutomationId="MapStyleEditor_ConfigWrite_Button"
+                      Content="Config Write"
+                      IsEnabled="False"
+                      ToolTip.Tip="Pending Core extraction (LZ77 ChipsetData + CONFIG PLIST) - tracked by #374." />
+            </StackPanel>
+          </StackPanel>
+        </ScrollViewer>
+      </TabItem>
+    </TabControl>
   </Grid>
 </Window>

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml
@@ -130,17 +130,21 @@
               <TextBlock Text="Palette No:" VerticalAlignment="Center" />
               <ComboBox AutomationProperties.AutomationId="MapStyleEditor_Palette_Combo"
                         Name="PaletteCombo" Width="120" VerticalAlignment="Center">
-                <ComboBoxItem Content="Palette 1" />
-                <ComboBoxItem Content="Palette 2" />
-                <ComboBoxItem Content="Palette 3" />
-                <ComboBoxItem Content="Palette 4" />
-                <ComboBoxItem Content="Palette 5" />
+                <!-- ComboBoxItem string Content doesn't trigger
+                     ViewTranslationHelper; using TextBlock children
+                     ensures ja/zh translations apply (Copilot bot v2
+                     inline review item). -->
+                <ComboBoxItem><TextBlock Text="Palette 1" /></ComboBoxItem>
+                <ComboBoxItem><TextBlock Text="Palette 2" /></ComboBoxItem>
+                <ComboBoxItem><TextBlock Text="Palette 3" /></ComboBoxItem>
+                <ComboBoxItem><TextBlock Text="Palette 4" /></ComboBoxItem>
+                <ComboBoxItem><TextBlock Text="Palette 5" /></ComboBoxItem>
               </ComboBox>
               <ComboBox AutomationProperties.AutomationId="MapStyleEditor_PaletteType_Combo"
                         Name="PaletteTypeCombo" Width="160" VerticalAlignment="Center"
                         SelectedIndex="0">
-                <ComboBoxItem Content="No Fog" />
-                <ComboBoxItem Content="Fog" />
+                <ComboBoxItem><TextBlock Text="No Fog" /></ComboBoxItem>
+                <ComboBoxItem><TextBlock Text="Fog" /></ComboBoxItem>
               </ComboBox>
             </StackPanel>
 
@@ -264,6 +268,15 @@
         <ScrollViewer>
           <StackPanel Spacing="8" Margin="8">
             <TextBlock Text="Chipset" FontSize="18" FontWeight="Bold" />
+
+            <!-- The 4 per-slot TSA fields below are disabled placeholders.
+                 Reading the chipset config requires LZ77-decompressing
+                 the buffer at the Chipset Config Address, and writing
+                 requires re-compressing + updating the CONFIG PLIST.
+                 Both paths require Core extraction (KnownGap #374). -->
+            <TextBlock AutomationProperties.AutomationId="MapStyleEditor_ChipsetTSA_KnownGap_Label"
+                       Text="TSA grids require LZ77 + CONFIG PLIST extraction (KnownGap: tracked by #374)."
+                       Foreground="Gray" FontStyle="Italic" TextWrapping="Wrap" />
 
             <Grid ColumnDefinitions="200,*" RowDefinitions="Auto,Auto,Auto">
               <TextBlock Grid.Row="0" Grid.Column="0" Text="Chipset Config Address:" VerticalAlignment="Center" />

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml
@@ -295,7 +295,8 @@
               <ComboBox Grid.Row="2" Grid.Column="1"
                         AutomationProperties.AutomationId="MapStyleEditor_ConfigTerrain_Combo"
                         Name="ConfigTerrainCombo" Width="200" HorizontalAlignment="Left"
-                        IsEnabled="True" />
+                        IsEnabled="False"
+                        ToolTip.Tip="Pending Core extraction (terrain list from LZ77 ChipsetData) - tracked by #374." />
             </Grid>
 
             <!-- 4 tile-slot TSA grids (Top-Left, Top-Right, Bottom-Left, Bottom-Right).

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Services;
@@ -10,6 +11,7 @@ namespace FEBuilderGBA.Avalonia.Views
     {
         readonly MapStyleEditorViewModel _vm = new();
         readonly UndoService _undoService = new();
+        List<AddrResult> _styleList = new();
 
         public string ViewTitle => "Map Style Editor";
         public bool IsLoaded => _vm.IsLoaded;
@@ -18,6 +20,12 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
+            // Re-load the palette when either the palette index or the
+            // fog flag changes — this keeps the 16-row RGB grid in sync
+            // with the user's selection (mirrors WF behavior).
+            PaletteCombo.SelectionChanged += (_, _) => ReloadPalette();
+            PaletteTypeCombo.SelectionChanged += (_, _) => ReloadPalette();
+            MapStyleCombo.SelectionChanged += MapStyle_SelectionChanged;
             Opened += (_, _) => LoadList();
         }
 
@@ -25,8 +33,16 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                var items = _vm.LoadList();
-                EntryList.SetItems(items);
+                _styleList = _vm.LoadList();
+                EntryList.SetItems(_styleList);
+                // Mirror EntryList into MapStyleCombo so the top-bar
+                // selector is also populated (Copilot bot inline review
+                // on MapStyleCombo).
+                MapStyleCombo.ItemsSource = _styleList.ConvertAll(r => r.name);
+                if (MapStyleCombo.ItemsSource != null && _styleList.Count > 0)
+                {
+                    MapStyleCombo.SelectedIndex = 0;
+                }
             }
             catch (Exception ex)
             {
@@ -41,6 +57,12 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.IsLoading = true;
                 _vm.LoadEntry(addr);
                 UpdateUI();
+                // Sync the top-bar MapStyleCombo to the same entry without
+                // recursing — block the SelectionChanged handler while we
+                // assign by toggling _vm.IsLoading.
+                int idx = _styleList.FindIndex(r => r.addr == addr);
+                if (idx >= 0 && MapStyleCombo.SelectedIndex != idx)
+                    MapStyleCombo.SelectedIndex = idx;
                 _vm.IsLoading = false;
                 _vm.MarkClean();
             }
@@ -51,11 +73,66 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
+        void MapStyle_SelectionChanged(object? sender, global::Avalonia.Controls.SelectionChangedEventArgs e)
+        {
+            if (_vm.IsLoading) return;
+            int idx = MapStyleCombo.SelectedIndex;
+            if (idx < 0 || idx >= _styleList.Count) return;
+            // Forward selection to the AddressList so all other UI stays
+            // in sync via the existing OnSelected path.
+            EntryList.SelectAddress(_styleList[idx].addr);
+        }
+
+        void ReloadPalette()
+        {
+            if (_vm.IsLoading) return;
+            int idx = PaletteCombo.SelectedIndex;
+            if (idx < 0) idx = 0;
+            bool fog = PaletteTypeCombo.SelectedIndex == 1;
+            _vm.IsLoading = true;
+            try
+            {
+                _vm.LoadPalette(_vm.PaletteAddress, idx, fog);
+                UpdatePaletteUI();
+            }
+            finally { _vm.IsLoading = false; }
+        }
+
         void UpdateUI()
         {
+            // Tab 1 -- Map Style.
             AddrLabel.Text = $"0x{_vm.CurrentAddr:X08}";
             ObjPtrBox.Text = $"0x{_vm.ObjPointer:X08}";
             ConfigPtrLabel.Text = $"0x{_vm.ConfigPointer:X08}";
+            ObjAddressLabel.Text = $"0x{_vm.ObjAddress:X08}";
+            ObjAddress2Label.Text = _vm.ObjAddress2 != 0 ? $"0x{_vm.ObjAddress2:X08}" : "(none)";
+            PaletteAddressLabel.Text = $"0x{_vm.PaletteAddress:X08}";
+            TilesetTypeLabel.Text = $"Tileset {_vm.ConfigNo}";
+
+            // Tab 3 -- Chipset.
+            ChipsetConfigAddressLabel.Text = $"0x{_vm.ChipsetConfigAddress:X08}";
+            ConfigNoLabel.Text = _vm.ConfigNo;
+
+            // Tab 2 -- Palette (populated by LoadEntry's LoadPalette call).
+            UpdatePaletteUI();
+        }
+
+        void UpdatePaletteUI()
+        {
+            // Populate the 16 read-only RGB rows from the VM's loaded
+            // palette state. The controls are IsEnabled="False" in AXAML
+            // (Copilot bot inline review item -- palette data is now
+            // displayed but not editable since palette writes are out
+            // of scope per #374).
+            for (int i = 1; i <= 16; i++)
+            {
+                var rBox = this.FindControl<NumericUpDown>($"Color{i}_RBox");
+                var gBox = this.FindControl<NumericUpDown>($"Color{i}_GBox");
+                var bBox = this.FindControl<NumericUpDown>($"Color{i}_BBox");
+                if (rBox != null) rBox.Value = _vm.GetColorR(i);
+                if (gBox != null) gBox.Value = _vm.GetColorG(i);
+                if (bBox != null) bBox.Value = _vm.GetColorB(i);
+            }
         }
 
         void Write_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
@@ -105,8 +105,10 @@ namespace FEBuilderGBA.Avalonia.Views
                 else
                 {
                     // Out-of-bounds / invalid base -- clear stale RGB values
-                    // so the user doesn't see a wrong palette.
+                    // AND the address label so the user doesn't see a wrong
+                    // palette OR a stale address (Copilot bot v3 inline review).
                     ClearPaletteUI();
+                    PaletteAddressLabel.Text = "(invalid)";
                 }
             }
             finally { _vm.IsLoading = false; }

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
@@ -92,10 +92,37 @@ namespace FEBuilderGBA.Avalonia.Views
             _vm.IsLoading = true;
             try
             {
-                _vm.LoadPalette(_vm.PaletteAddress, idx, fog);
-                UpdatePaletteUI();
+                // Pass the STABLE base address (PaletteBaseAddress) not
+                // the slice (PaletteAddress) -- otherwise the previous
+                // slice becomes the new base and the read drifts by
+                // idx*0x20 on each selection (Copilot bot v2 inline review).
+                bool ok = _vm.LoadPalette(_vm.PaletteBaseAddress, idx, fog);
+                if (ok)
+                {
+                    UpdatePaletteUI();
+                    PaletteAddressLabel.Text = $"0x{_vm.PaletteAddress:X08}";
+                }
+                else
+                {
+                    // Out-of-bounds / invalid base -- clear stale RGB values
+                    // so the user doesn't see a wrong palette.
+                    ClearPaletteUI();
+                }
             }
             finally { _vm.IsLoading = false; }
+        }
+
+        void ClearPaletteUI()
+        {
+            for (int i = 1; i <= 16; i++)
+            {
+                var rBox = this.FindControl<NumericUpDown>($"Color{i}_RBox");
+                var gBox = this.FindControl<NumericUpDown>($"Color{i}_GBox");
+                var bBox = this.FindControl<NumericUpDown>($"Color{i}_BBox");
+                if (rBox != null) rBox.Value = 0;
+                if (gBox != null) gBox.Value = 0;
+                if (bBox != null) bBox.Value = 0;
+            }
         }
 
         void UpdateUI()

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -8760,3 +8760,6 @@ Core 抽出待ち (パレット PLIST 確保) - #374 で追跡中。
 
 :Pending Core extraction (LZ77 ChipsetData + CONFIG PLIST) - tracked by #374.
 Core 抽出待ち (LZ77 ChipsetData + CONFIG PLIST) - #374 で追跡中。
+
+:TSA grids require LZ77 + CONFIG PLIST extraction (KnownGap: tracked by #374).
+TSA グリッドは LZ77 + CONFIG PLIST 抽出が必要 (KnownGap: #374 で追跡中)。

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -8763,3 +8763,6 @@ Core 抽出待ち (LZ77 ChipsetData + CONFIG PLIST) - #374 で追跡中。
 
 :TSA grids require LZ77 + CONFIG PLIST extraction (KnownGap: tracked by #374).
 TSA グリッドは LZ77 + CONFIG PLIST 抽出が必要 (KnownGap: #374 で追跡中)。
+
+:Pending Core extraction (terrain list from LZ77 ChipsetData) - tracked by #374.
+Core 抽出待ち (LZ77 ChipsetData からの地形リスト) - #374 で追跡中。

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -8673,3 +8673,90 @@ PatchManagerView は JumpToSelectStruct をまだ公開していません (#374 
 
 :Move to COMBAT_ART
 COMBAT_ARTへ移動
+
+:Map Style:
+マップスタイル:
+
+:Object Address:
+オブジェクトアドレス:
+
+:Object Address 2:
+オブジェクトアドレス 2:
+
+:Tileset Type:
+タイルセット種類:
+
+:Map Chip Preview
+マップチップ プレビュー
+
+:Map Chip Save
+マップチップ 保存
+
+:Map Chip Load
+マップチップ 読込
+
+:Chipset
+種類
+
+:Chipset No:
+種類 No:
+
+:Chipset Config Address:
+チップセット設定アドレス:
+
+:Terrain Type:
+地形タイプ:
+
+:Top-Left
+左上
+
+:Top-Right
+右上
+
+:Bottom-Left
+左下
+
+:Bottom-Right
+右下
+
+:Palette No:
+パレット No:
+
+:Palette 5
+パレット5
+
+:Palette Import
+パレット 取込
+
+:Palette Export
+パレット 出力
+
+:No Fog
+霧なし
+
+:Fog
+霧あり
+
+:Config Write
+設定書込
+
+:Copy Tile (Alt+T)
+タイルのコピー (Alt+T)
+
+:Copy Type (Alt+C)
+種類のコピー (Alt+C)
+
+:Paste (Alt+V)
+貼付け (Alt+V)
+
+:Pending Core extraction - tracked by #374.
+Core 抽出待ち - #374 で追跡中。
+
+:Flip
+反転
+
+:Pending Core extraction (palette PLIST allocation) - tracked by #374.
+Core 抽出待ち (パレット PLIST 確保) - #374 で追跡中。
+
+:Pending Core extraction (LZ77 ChipsetData + CONFIG PLIST) - tracked by #374.
+Core 抽出待ち (LZ77 ChipsetData + CONFIG PLIST) - #374 で追跡中。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -22595,3 +22595,6 @@ PatchManagerView 尚未暴露 JumpToSelectStruct (#374 跟踪中)。
 
 :Pending Core extraction (LZ77 ChipsetData + CONFIG PLIST) - tracked by #374.
 等待 Core 抽取 (LZ77 ChipsetData + CONFIG PLIST) - 跟踪于 #374。
+
+:TSA grids require LZ77 + CONFIG PLIST extraction (KnownGap: tracked by #374).
+TSA 网格需要 LZ77 + CONFIG PLIST 抽取 (KnownGap: 跟踪于 #374)。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -22598,3 +22598,6 @@ PatchManagerView 尚未暴露 JumpToSelectStruct (#374 跟踪中)。
 
 :TSA grids require LZ77 + CONFIG PLIST extraction (KnownGap: tracked by #374).
 TSA 网格需要 LZ77 + CONFIG PLIST 抽取 (KnownGap: 跟踪于 #374)。
+
+:Pending Core extraction (terrain list from LZ77 ChipsetData) - tracked by #374.
+等待 Core 抽取 (LZ77 ChipsetData 中的地形列表) - 跟踪于 #374。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -22508,3 +22508,90 @@ PatchManagerView 尚未暴露 JumpToSelectStruct (#374 跟踪中)。
 
 :Move to COMBAT_ART
 跳转到 COMBAT_ART
+
+:Map Style:
+地图样式:
+
+:Object Address:
+对象地址:
+
+:Object Address 2:
+对象地址 2:
+
+:Tileset Type:
+图块集类型:
+
+:Map Chip Preview
+地图图块 预览
+
+:Map Chip Save
+地图图块 保存
+
+:Map Chip Load
+地图图块 读取
+
+:Chipset
+图块集
+
+:Chipset No:
+图块集编号:
+
+:Chipset Config Address:
+图块集配置地址:
+
+:Terrain Type:
+地形类型:
+
+:Top-Left
+左上
+
+:Top-Right
+右上
+
+:Bottom-Left
+左下
+
+:Bottom-Right
+右下
+
+:Palette No:
+调色板编号:
+
+:Palette 5
+调色板 5
+
+:Palette Import
+调色板 导入
+
+:Palette Export
+调色板 导出
+
+:No Fog
+无雾
+
+:Fog
+有雾
+
+:Config Write
+配置写入
+
+:Copy Tile (Alt+T)
+复制图块 (Alt+T)
+
+:Copy Type (Alt+C)
+复制类型 (Alt+C)
+
+:Paste (Alt+V)
+粘贴 (Alt+V)
+
+:Pending Core extraction - tracked by #374.
+等待 Core 抽取 - 跟踪于 #374。
+
+:Flip
+翻转
+
+:Pending Core extraction (palette PLIST allocation) - tracked by #374.
+等待 Core 抽取 (调色板 PLIST 分配) - 跟踪于 #374。
+
+:Pending Core extraction (LZ77 ChipsetData + CONFIG PLIST) - tracked by #374.
+等待 Core 抽取 (LZ77 ChipsetData + CONFIG PLIST) - 跟踪于 #374。


### PR DESCRIPTION
## Summary

Closes the 190 Avalonia ↔ WinForms gaps the gap-sweep methodology surfaced on `MapStyleEditorForm` (HIGH density -94.8% AV 8 vs WF 153, 45 WF-only labels). Rebuilds `MapStyleEditorView` as a 3-tab `TabControl` mirroring the WinForms 3-panel structure:

- **Tab 1 — Map Style** (オブジェクト): functional ObjAddress / ObjAddress2 / OBJ Tile Pointer / Config Pointer / Palette Address / Tileset Type display surface + 6 KnownGap buttons (Image Export/Import, Map Chip Save/Load, UNDO, REDO) + the **functional Write button** (writes the OBJ Tile Pointer with `_undoService.Begin/Commit` scope — preserves existing behavior).
- **Tab 2 — Palette** (パレット): PaletteCombo (5 entries) + PaletteTypeCombo (霧なし/霧あり), 16 RGB rows × R/G/B NumericUpDowns (read-only, populated via `VM.LoadPalette(paletteBase, paletteIndex, isFog)` per WF semantics `paletteBase + (paletteIndex + (isFog ? 5 : 0)) * 0x20`) + 4 KnownGap palette buttons (Palette Export/Import/Clipboard/Write).
- **Tab 3 — Chipset** (種類): ChipsetConfigAddress + ConfigNo labels, ConfigTerrain combo, 4 tile-slot grids (Top-Left / Top-Right / Bottom-Left / Bottom-Right) each with TSA_X/Y/PALETTE/FLIP + raw W NumericUpDowns synchronized via `EncodeTsaWord` / `DecodeTsaWord` static helpers + 4 KnownGap chipset buttons (Copy Tile, Copy Type, Paste, Config Write). Tab shows a gray italic notice explaining the TSA grids are disabled pending LZ77+CONFIG-PLIST Core extraction.

**Density: HIGH (-94.8 %) → MEDIUM (-49.67 %, AV 77 / WF 153).** Strict MEDIUM cutoff per ControlDensityScanner.

Plus cross-cutting fixes addressing **all Copilot CLI v1+v2 inline review concerns + Copilot bot v1+v2 inline review concerns**:

- **v1 item 1 (WriteConfig wrong abstraction)** — scoped out as disabled KnownGap, no WriteConfig handler exists
- **v1 item 2 (TSA split-field synchronization)** — `EncodeTsaWord` / `DecodeTsaWord` static helpers + per-slot `SetSlotSplitField` / `SetSlotW` setters that keep split + raw word synchronized in both directions, pinned by `ViewModel_SettingSplitField_UpdatesRawWord` and `ViewModel_SettingRawWord_UpdatesSplitFields`
- **v1 item 3 (palette indexing + fog)** — `LoadPalette(paletteBase, paletteIndex, isFog)` per WF semantics, range-validates paletteIndex in [0,5), bounds-checks in ulong space, separate `PaletteBaseAddress` field that LoadPalette does NOT mutate
- **v1 item 4 (no-op buttons)** — all 14 KnownGap buttons are `IsEnabled="False"` with `#374` tooltip; `View_KnownGapButtons_AreDisabledAndTagged` enumerates the explicit list, `View_NoExtraDisabledButtons` pins count
- **v2 PaletteAddress drift** — separate stable `PaletteBaseAddress` property; ReloadPalette passes the base (not the slice) so subsequent PaletteCombo/PaletteTypeCombo changes index correctly
- **v2 ComboBoxItem translation gap** — switched to `<ComboBoxItem><TextBlock Text="..."/></ComboBoxItem>` so the ViewTranslationHelper walks the TextBlock children and ja/zh translations apply
- **v2 Tab 3 wiring** — disabled chipset TSA fields now carry a visible `MapStyleEditor_ChipsetTSA_KnownGap_Label` notice explaining why they're blank
- **v2 Copilot bot inline #1 (MapStyleCombo empty)** — now populated from `_vm.LoadList()` with SelectionChanged routing to `EntryList.SelectAddress()`
- **v2 Copilot bot inline #2 (Address displays empty)** — UpdateUI() now writes all 6 new VM properties to the corresponding TextBlocks
- **v2 Copilot bot inline #3+4 (palette/chipset controls not bound)** — UpdatePaletteUI() populates 48 named NumericUpDowns from VM state, slot fields remain disabled placeholders with KnownGap notice
- **v2 Copilot bot inline #5 (LoadPalette overflow)** — validates paletteIndex in [0,5) and computes target address in ulong before final uint cast

## Plan Reference

Implements the v3 plan accepted on [issue #391 v2 review](https://github.com/laqieer/FEBuilderGBA/issues/391#issuecomment-4528898018) (v3 delta in [follow-up](https://github.com/laqieer/FEBuilderGBA/issues/391#issuecomment-4528900053)). Copilot CLI v2 verdict: "v2 resolves the risky write-scope issues and is acceptable to implement after folding in the item 2 setter-level synchronization tests and the item 4 KnownGap enumeration/count cleanup" — both refinements are part of WU4 (tests 6, 7, 13, 14 in the new suite).

## Scope

Closes #391.
Refs #374 (gap-sweep parent — all 14 KnownGap-disabled buttons reference this issue in their tooltip, plus the Tab 3 chipset TSA KnownGap notice).

### Out-of-scope (per Copilot CLI v1 review items 1 + 3)

The following ROM-mutating paths are surfaced as **disabled KnownGap buttons** rather than no-op handlers, so users cannot click them and get fake parity:

- Image-decode pipeline (`ImageUtilMap.DrawMapChipOnly` / `UnLZ77ChipsetData`) — WF-only
- Palette write (`PaletteFormRef.MakePaletteBitmapToROM` + `MapPointerForm.Write_Plsit(PALETTE, ...)`) — requires Core extraction of palette+PLIST allocation
- Chipset/CONFIG write (LZ77 encode of mutated ConfigUZ buffer + `MapPointerForm.Write_Plsit(CONFIG, ...)`) — requires Core extraction
- Map Chip Import/Export — depends on image decoder
- Copy Tile / Copy Type / Paste clipboard — depends on chipset image
- UNDO/REDO inside the palette editor (form-wide UndoService still works on the functional Write)

No new follow-up issues per task brief — KnownGap markers reference `#374` (gap-sweep parent) only.

## Screenshots

Captured against `roms/FE8U.gba` via PrintWindow API + UIAutomation tab navigation. Each tab shows the new control surface with populated ROM data.

### Tab 1 — Map Style
![MapStyleEditor Tab 1](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr391-mapstyle-editor-tab1.png)

Map Style combo: "0x01 Tileset", Address `0x008B3640`, Object Address `0x00198D8C`, Object Address 2 `(none)`, Palette Address `0x00198D8C`, OBJ Tile Pointer `0x08198D8C`, Config Pointer `0x08198D8C`, Tileset Type "Tileset 0x01". The 6 KnownGap buttons (Image Export, Image Import, Map Chip Save, Map Chip Load, UNDO, REDO) are visibly grayed out; the Write button is enabled (functional).

### Tab 2 — Palette
![MapStyleEditor Tab 2 Palette](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr391-mapstyle-editor-tab2-palette.png)

PaletteCombo + PaletteTypeCombo (defaulted to "No Fog") at top, then a 16-row grid with R/G/B NumericUpDown columns populated with actual FE8U.gba palette data (with Palette 3 selected: R=17/G=0/B=5 row 1, R=21/G=0/B=0 row 2, etc.). The 4 KnownGap palette buttons (Palette Export, Palette Import, Clipboard, Palette Write) at the bottom are grayed out. Comparing against a Palette 1 capture (R=16/G=0/B=0 row 1) demonstrates the PaletteBaseAddress drift fix works correctly.

### Tab 3 — Chipset
![MapStyleEditor Tab 3 Chipset](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr391-mapstyle-editor-tab3-chipset.png)

Gray italic notice at top: "TSA grids require LZ77 + CONFIG PLIST extraction (KnownGap: tracked by #374)." — immediately explains why the TSA grids are blank. Chipset Config Address (`0x00198D8C`), Chipset No (`0x01`), Terrain Type combo (empty since terrain reads also need LZ77). Then 4 tile-slot grids labeled "Top-Left", "Top-Right", "Bottom-Left", "Bottom-Right" each with disabled X / Y / Palette / Flip + raw W NumericUpDowns. The 4 KnownGap chipset buttons (Copy Tile, Copy Type, Paste, Config Write) at the bottom are grayed out.

Screenshots landed on master via separate docs PRs (#601 → #608 → #611) so `raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/...` URLs are permanent.

## GUI Test Report

### Environment
- ROM: `roms/FE8U.gba` (Fire Emblem 8 US, BE8E01)
- Editor/View: `MapStyleEditorView` (Avalonia)
- Capture: PrintWindow API (`tools/WinCapture`) + PowerShell UIAutomationClient tab-navigation

### Steps Performed

1. Built `FEBuilderGBA.Avalonia` in Release configuration.
2. Launched `./FEBuilderGBA.Avalonia/bin/Release/net9.0/FEBuilderGBA.Avalonia.exe --rom roms/FE8U.gba`.
3. Located "Style Editor" button on main window via UIAutomation; invoked it.
4. Waited for "Map Style Editor" window to open.
5. Selected the first list item (0x01 Tileset) via UIAutomation SelectionItemPattern.
6. Captured each of the 3 tabs in turn:
   - Tab 1: Switched to "Map Style" tab, activated window via Win32 SetForegroundWindow, captured.
   - Tab 2: Switched to "Palette" tab, expanded PaletteCombo, selected Palette 3 (to demonstrate the PaletteBaseAddress drift fix), captured.
   - Tab 3: Switched to "Chipset" tab, captured.

### Test Results

| Test | Expected | Actual | Status |
|------|----------|--------|--------|
| Tab 1 renders with FE8U data | All 6 address/pointer/type fields populated, 6 KnownGap buttons disabled, Write enabled | All 6 fields populated correctly (Object/Palette addresses, OBJ/Config pointers, Tileset Type); 6 KnownGap buttons grayed; Write button blue/enabled | PASS |
| Tab 2 renders 16-color palette grid | 16 RGB rows × R/G/B NumericUpDown populated from ROM, PaletteCombo + PaletteTypeCombo, 4 KnownGap buttons disabled | All 48 NumericUpDowns visible (16×3) and populated; Palette 3 selected; 4 palette buttons grayed | PASS |
| PaletteBaseAddress drift fix works | Selecting Palette 3 reads the 3rd palette block (not previous-slice + idx*0x20) | Row 1 RGB = (17,0,5) for Palette 3 vs (16,0,0) for Palette 1 — distinct values prove correct base indexing | PASS |
| Tab 3 renders 4 tile-slot grids with KnownGap notice | Top-Left/Right + Bottom-Left/Right grids, ConfigTerrain combo, 4 KnownGap buttons disabled, KnownGap notice explaining blank TSA | All 4 grids labeled correctly; 20 disabled NumericUpDowns; ConfigTerrain combo present; 4 chipset buttons grayed; KnownGap notice "TSA grids require LZ77 + CONFIG PLIST extraction" visible at top | PASS |
| Functional Write button is enabled | Not grayed, click-able | Visibly enabled in Tab 1 capture | PASS |
| All 14 KnownGap buttons disabled | Grayed out, IsEnabled="False", #374 tooltip | Confirmed visually in all 3 tabs + verified by `View_KnownGapButtons_AreDisabledAndTagged` test | PASS |
| Avalonia tests | All 17 new + 6146 existing tests pass | 6163 passed, 3 skipped, 0 failed | PASS |
| Core tests | All 1739 pass | 1739 passed | PASS |
| L10n coverage | ja/zh translations cover all new English literals (including KnownGap notice) | 1 pass | PASS |

### Verdict

PASS — All test cases verified visually + via headless test suite. 14 KnownGap buttons disabled and tooltipped with `#374`. Tab 3 KnownGap notice clarifies disabled TSA grids. Density gate crossed (AV 77 >= 77 MEDIUM threshold).

## Test plan

- [x] `dotnet test FEBuilderGBA.Avalonia.Tests/` — 6163 passed (17 new MapStyleEditor parity tests + 6146 existing), 0 failed, 3 skipped (pre-existing)
- [x] `dotnet test FEBuilderGBA.Core.Tests/` — 1739 passed, 0 failed
- [x] `dotnet build FEBuilderGBA.Tests/` — 0 errors (WinForms test project still builds)
- [x] L10nCoverageTest — 0 untranslated literals in `MapStyleEditorView.axaml` (all new ja+zh entries covered, including the Tab 3 KnownGap notice)
- [x] Density gate enforced — `View_AvControlCount_AtOrAboveMediumVerdict` test rejects any future regression below AV >= 77
- [x] 14 KnownGap buttons all carry `IsEnabled="False"` + `ToolTip.Tip` referencing `#374` — pinned by `View_KnownGapButtons_AreDisabledAndTagged`
- [x] No extra disabled buttons slip in — `View_NoExtraDisabledButtons` pins count at exactly 14
- [x] Single functional `Write_Click` handler wraps VM call in `_undoService.Begin/Commit/Rollback` — pinned by `View_Write_Click_UsesUndoService`
- [x] Existing legacy `MapStyleEditor_*` AutomationIds (5 entries) preserved — pinned by `View_RetainsLegacyAutomationIds`
- [x] ViewModel palette read round-trips through synthetic ROM for both normal and fog palettes — `ViewModel_LoadPalette_ReadsRgb555_NormalPalette` + `_FogPalette`
- [x] LoadPalette validates paletteIndex range + does ulong arithmetic before final uint cast (no overflow bypass)
- [x] ViewModel TSA word encode/decode round-trips + matches GBA bit layout — `ViewModel_EncodeTsaWord_RoundTrips` + `_MatchesGbaBitLayout`
- [x] VM split-field ↔ raw-word synchronization in both directions — `ViewModel_SettingSplitField_UpdatesRawWord` + `_SettingRawWord_UpdatesSplitFields`
- [x] PaletteBaseAddress is stable across ReloadPalette calls — visually demonstrated by Palette 3 screenshot
- [x] ComboBoxItem.Content switched to TextBlock children so ja/zh translations apply
- [x] Tab 3 KnownGap notice in place (`MapStyleEditor_ChipsetTSA_KnownGap_Label`)
- [x] Real-ROM functional test — launched app with `--rom roms/FE8U.gba`, captured 3 tabs with populated data via PrintWindow API
- [x] Screenshots landed on master via separate docs PRs (#601 → #608 → #611) before this PR — URLs are permanent

## Known limitations

The ROM-mutating paths listed in the **Out-of-scope** section above are not implemented this PR. Each corresponds to a disabled KnownGap button whose tooltip references `#374` (the gap-sweep parent issue). They will require Core extraction of `ImageUtilMap.UnLZ77ChipsetData`, `PaletteFormRef.MakePaletteBitmapToROM`, and `MapPointerForm.Write_Plsit` before they can be enabled in Avalonia.

Generated with Claude Code (claude-opus-4-6)
