### PR TITLE
feat(maptileanim2): BulkImport/BulkExport + table expand (closes #524)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MapTileAnimation2ParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MapTileAnimation2ParityTests.cs
@@ -126,40 +126,46 @@ public class MapTileAnimation2ParityTests
     }
 
     // -----------------------------------------------------------------
-    // Phase 5 (Copilot CLI #3) - deferred affordances must be visibly
-    // disabled and reference the follow-up Core extraction issue.
+    // Phase 2 (#524) inversion - the four deferred affordances
+    // (Bulk Import / Bulk Export / List Expand main + palette sub-list)
+    // are now wired against the Core helpers in MapTileAnimation2Core
+    // (BulkImport / BulkExport / ExpandEntryList / ExpandPaletteRowList).
+    // The buttons MUST be rendered enabled (no explicit IsEnabled="False")
+    // and the placeholder tooltip referencing the follow-up issue MUST be
+    // gone (#524 should no longer appear in the button element). The
+    // active tooltips describe the actual behavior.
     // -----------------------------------------------------------------
 
     /// <summary>
-    /// Each deferred affordance (Bulk Import / Bulk Export / List Expand
-    /// main + palette sub-list) must be rendered with <c>IsEnabled="False"</c>
-    /// and a tooltip referencing the follow-up Core-extraction issue (#524)
-    /// so density parity does not count enabled no-op controls (Copilot CLI
-    /// plan-review #3). The XAML is searched as text (mirrors how the
-    /// surrounding tests assert AutomationIds + Click handlers).
+    /// Each of the four affordances is now enabled (no IsEnabled="False"
+    /// attribute on the button element) and does NOT contain the #524
+    /// follow-up reference (the tooltip describes the live behavior
+    /// instead).
     /// </summary>
     [Theory]
     [InlineData("MapTileAnimation2_BulkImport_Button")]
     [InlineData("MapTileAnimation2_BulkExport_Button")]
     [InlineData("MapTileAnimation2_ListExpand_Button")]
     [InlineData("MapTileAnimation2_NListExpand_Button")]
-    public void View_DeferredButton_IsDisabledAndReferencesFollowupIssue(string automationId)
+    public void View_BulkAndExpandButton_IsEnabledAndNoFollowupTooltip(string automationId)
     {
         string axaml = ReadAxaml();
-        // Locate the Button element by its AutomationId.
         int idx = axaml.IndexOf($"AutomationId=\"{automationId}\"", StringComparison.Ordinal);
         Assert.True(idx >= 0, $"AutomationId {automationId} not found in AXAML");
 
         // Walk backwards to the previous '<' to find element start.
         int elementStart = axaml.LastIndexOf('<', idx);
         Assert.True(elementStart >= 0, "Could not find element start");
-        // Walk forward to the next '/>' or '>'.
+        // Walk forward to the closing '>' so we capture the full element.
         int elementEnd = axaml.IndexOfAny(new[] { '>' }, idx);
         Assert.True(elementEnd > elementStart, "Could not find element end");
         string element = axaml.Substring(elementStart, elementEnd - elementStart + 1);
 
-        Assert.Contains("IsEnabled=\"False\"", element);
-        Assert.Contains("#524", element);
+        // The button must NOT carry the deferred-state attribute or the
+        // follow-up issue reference. (Buttons default to enabled in AXAML
+        // when no explicit IsEnabled attribute is set.)
+        Assert.DoesNotContain("IsEnabled=\"False\"", element);
+        Assert.DoesNotContain("#524", element);
     }
 
     // -----------------------------------------------------------------
@@ -482,6 +488,146 @@ public class MapTileAnimation2ParityTests
             Assert.Equal(120u, vm.PaletteR);
             Assert.Equal(184u, vm.PaletteG);
             Assert.Equal(48u, vm.PaletteB);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 2 (#524) - ViewModel BulkExport / BulkImport / Expand
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_BulkExport_WritesFile()
+    {
+        var rom = MakeMinimalFE8URomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        string tmp = Path.GetTempFileName();
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation2ViewModel();
+            // BuildList walks the entry table from entryAddr.
+            vm.BuildList(entryAddr);
+            string err = vm.BulkExport(tmp);
+            Assert.Equal("", err);
+            string[] lines = File.ReadAllLines(tmp);
+            Assert.True(lines.Length >= 2, "Export must produce header + at least one row");
+            Assert.StartsWith("//wait", lines[0]);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            if (File.Exists(tmp)) File.Delete(tmp);
+        }
+    }
+
+    [Fact]
+    public void ViewModel_BulkImport_RoundTrips()
+    {
+        var rom = MakeMinimalFE8URomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        string tmp = Path.GetTempFileName();
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation2ViewModel();
+            vm.BuildList(entryAddr);
+
+            // Export and re-import via the VM (round-trip parity).
+            Assert.Equal("", vm.BulkExport(tmp));
+
+            // PointerSlot = PLIST table slot for plist=1 (planted at
+            // 0x900000 + 1*4 by MakeMinimalFE8URomWithEntry).
+            uint plistTableBase = rom.p32(rom.RomInfo.map_tileanime2_pointer);
+            uint pointerSlot = plistTableBase + 1 * 4;
+
+            // Open ambient undo so the import path can record into it.
+            var undo = new Undo.UndoData();
+            undo.list = new System.Collections.Generic.List<Undo.UndoPostion>();
+            undo.filesize = (uint)rom.Data.Length;
+            using (ROM.BeginUndoScope(undo))
+            {
+                string err = vm.BulkImport(tmp, pointerSlot);
+                Assert.Equal("", err);
+            }
+
+            // The pointer now resolves to a fresh table; that table's row 0
+            // must have the same WAIT/COUNT/STARTINDEX as the original
+            // (wait=0x13, count=4, startindex=0x3C).
+            uint newBase = rom.p32(pointerSlot);
+            Assert.NotEqual(0u, newBase);
+            Assert.Equal(0x13u, rom.u8(newBase + 4));
+            Assert.Equal(0x04u, rom.u8(newBase + 5));
+            Assert.Equal(0x3Cu, rom.u8(newBase + 6));
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            if (File.Exists(tmp)) File.Delete(tmp);
+        }
+    }
+
+    [Fact]
+    public void ViewModel_ExpandEntryList_GrowsTable()
+    {
+        var rom = MakeMinimalFE8URomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation2ViewModel();
+            vm.BuildList(entryAddr);
+            uint oldCount = vm.ReadCount;
+            Assert.True(oldCount > 0);
+
+            // PLIST table slot for plist=1.
+            uint plistTableBase = rom.p32(rom.RomInfo.map_tileanime2_pointer);
+            uint pointerSlot = plistTableBase + 1 * 4;
+
+            uint newBase;
+            var undo = new Undo.UndoData();
+            undo.list = new System.Collections.Generic.List<Undo.UndoPostion>();
+            undo.filesize = (uint)rom.Data.Length;
+            using (ROM.BeginUndoScope(undo))
+            {
+                newBase = vm.ExpandEntryListByOne(pointerSlot);
+            }
+            Assert.NotEqual(U.NOT_FOUND, newBase);
+            // ScanEntries returns oldCount + 1 (row-0 template clone of the
+            // first entry preserves isPointer(P0)).
+            var entries = MapTileAnimation2Core.ScanEntries(rom, newBase, maxRows: 16);
+            Assert.Equal((int)(oldCount + 1), entries.Count);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_ExpandPaletteRowList_GrowsBlock()
+    {
+        var rom = MakeMinimalFE8URomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation2ViewModel();
+            vm.LoadEntry(entryAddr);
+            uint oldCount = vm.DataCount;
+            Assert.True(oldCount > 0);
+
+            uint newBase;
+            var undo = new Undo.UndoData();
+            undo.list = new System.Collections.Generic.List<Undo.UndoPostion>();
+            undo.filesize = (uint)rom.Data.Length;
+            using (ROM.BeginUndoScope(undo))
+            {
+                newBase = vm.ExpandPaletteRowListByOne();
+            }
+            Assert.NotEqual(U.NOT_FOUND, newBase);
+            // The first oldCount colors are copied; the new row(s) are row-0
+            // template clones (per V1 plan-review #2 - WF parity, NOT zero).
+            ushort row0 = (ushort)rom.u16(newBase + 0);
+            ushort newRow = (ushort)rom.u16(newBase + (uint)(oldCount * 2));
+            Assert.Equal(row0, newRow);
         }
         finally { CoreState.ROM = prevRom; }
     }

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MapTileAnimation2ParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MapTileAnimation2ParityTests.cs
@@ -632,6 +632,52 @@ public class MapTileAnimation2ParityTests
         finally { CoreState.ROM = prevRom; }
     }
 
+    /// <summary>
+    /// Regression test for the Copilot CLI review on PR #634 (blocking
+    /// issue): `ExpandPaletteRowListByOne` must also write the entry's
+    /// DataCount (B5) and update the VM's DataCount so a subsequent
+    /// LoadEntry sees the new row count. Without this fix, the palette
+    /// sub-list reload would still show oldCount rows even though the new
+    /// allocation has oldCount+1 entries (WF parity with
+    /// `N_AddressListExpandsEvent`).
+    /// </summary>
+    [Fact]
+    public void ViewModel_ExpandPaletteRowList_UpdatesDataCountAndReloadShowsNewRow()
+    {
+        var rom = MakeMinimalFE8URomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation2ViewModel();
+            vm.LoadEntry(entryAddr);
+            uint oldCount = vm.DataCount;
+            Assert.True(oldCount > 0);
+
+            var undo = new Undo.UndoData();
+            undo.list = new System.Collections.Generic.List<Undo.UndoPostion>();
+            undo.filesize = (uint)rom.Data.Length;
+            using (ROM.BeginUndoScope(undo))
+            {
+                uint newBase = vm.ExpandPaletteRowListByOne();
+                Assert.NotEqual(U.NOT_FOUND, newBase);
+            }
+
+            // ROM byte at entryAddr+5 must reflect the new count (WF parity).
+            Assert.Equal(oldCount + 1, rom.u8(entryAddr + 5));
+            // VM must reflect the bumped count immediately (no second read).
+            Assert.Equal(oldCount + 1, vm.DataCount);
+
+            // After a fresh LoadEntry (simulating the view's reload path),
+            // DataCount and PaletteRows.Count must reflect the new row.
+            var vm2 = new MapTileAnimation2ViewModel();
+            vm2.LoadEntry(entryAddr);
+            Assert.Equal(oldCount + 1, vm2.DataCount);
+            Assert.Equal((int)(oldCount + 1), vm2.PaletteRows.Count);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
     // -----------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia/ViewModels/MapTileAnimation2ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapTileAnimation2ViewModel.cs
@@ -380,6 +380,12 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// <summary>
         /// Grow the palette sub-table by one row. The pointer slot is the
         /// +0 byte of the current entry row (the palette data pointer field).
+        /// Mirrors the WF `EventUnitForm.AddressListExpandsEvent` behavior of
+        /// also updating the entry's DataCount (B5 at <c>CurrentAddr+5</c>) so
+        /// the editor sees the new row on the next reload (Copilot bot
+        /// review on PR #634). The DataCount write happens within the same
+        /// ambient undo scope as the table allocation + repoint, so a rollback
+        /// reverts both.
         /// </summary>
         public uint ExpandPaletteRowListByOne()
         {
@@ -390,8 +396,20 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             uint paletteSlot = CurrentAddr + 0; // P0 field
             uint oldBase = U.toOffset(PaletteDataPointer);
             uint newCount = DataCount + 1;
-            return MapTileAnimation2Core.ExpandPaletteRowList(rom, paletteSlot,
-                oldBase, DataCount, newCount);
+            // The Core helper caps DataCount at 255 since B5 is one byte.
+            if (newCount > 0xFF) return U.NOT_FOUND;
+            uint newBase = MapTileAnimation2Core.ExpandPaletteRowList(rom,
+                paletteSlot, oldBase, DataCount, newCount);
+            if (newBase == U.NOT_FOUND) return U.NOT_FOUND;
+            // Also bump the entry's B5 (DataCount) so a reload picks up the
+            // new row. The ambient undo scope captures this write too.
+            rom.write_u8(CurrentAddr + 5, newCount);
+            // Update the VM's in-memory state so the view's reload picks up
+            // the new count without a fresh u8 read.
+            IsLoading = true;
+            try { DataCount = newCount; }
+            finally { IsLoading = false; }
+            return newBase;
         }
     }
 }

--- a/FEBuilderGBA.Avalonia/ViewModels/MapTileAnimation2ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapTileAnimation2ViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using FEBuilderGBA.Avalonia.Services;
 
@@ -303,5 +304,94 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             ["StartPaletteIndex"] = "StartPaletteIndex@0x06",
             ["Unknown7"] = "Unknown7@0x07",
         };
+
+        // ----------------------------------------------------------------
+        // Bulk Import / Bulk Export / Data Expansion (#524).
+        // ----------------------------------------------------------------
+
+        /// <summary>
+        /// Resolve the PLIST table slot address for the currently-selected
+        /// PLIST so the BulkImport / ExpandEntryList helpers can repoint it.
+        /// Returns 0 when no PLIST is selected or the table is unreachable.
+        /// Mirrors the WF <c>MapPointerForm.PlistToOffsetAddrFast(...)</c>
+        /// "out pointer" path: slot = plistTableBase + plist*4.
+        /// </summary>
+        public uint GetPlistTableSlot()
+        {
+            var rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return 0;
+            if (!SelectedPlist.HasValue || SelectedPlist.Value == 0) return 0;
+            uint plistTablePtr = rom.RomInfo.map_tileanime2_pointer;
+            if (plistTablePtr == 0) return 0;
+            uint plistTableBase = rom.p32(plistTablePtr);
+            if (!U.isSafetyOffset(plistTableBase, rom)) return 0;
+            uint slot = plistTableBase + SelectedPlist.Value * 4u;
+            if (!U.isSafetyOffset(slot, rom)) return 0;
+            return slot;
+        }
+
+
+        /// <summary>
+        /// Export the currently-selected PLIST's entry table to a
+        /// .mapanime2.txt file via <see cref="MapTileAnimation2Core.BulkExport"/>.
+        /// Returns the empty string on success, an error message otherwise.
+        /// </summary>
+        public string BulkExport(string filename)
+        {
+            var rom = CoreState.ROM;
+            if (rom == null) return "ROM is null.";
+            if (ReadStartAddress == 0) return "No PLIST selected.";
+            return MapTileAnimation2Core.BulkExport(rom, filename, ReadStartAddress, ReadCount);
+        }
+
+        /// <summary>
+        /// Import a .mapanime2.txt file into the currently-selected PLIST.
+        /// The caller is expected to have opened an undo scope via
+        /// <c>_undoService.Begin</c> in the view layer; the Core helper
+        /// records each ROM write into the ambient UndoData.
+        ///
+        /// Returns the empty string on success, an error message otherwise.
+        /// </summary>
+        public string BulkImport(string filename, uint pointerSlot)
+        {
+            var rom = CoreState.ROM;
+            if (rom == null) return "ROM is null.";
+            if (ReadStartAddress == 0) return "No PLIST selected.";
+            return MapTileAnimation2Core.BulkImport(rom, filename, pointerSlot,
+                ReadStartAddress, ReadCount);
+        }
+
+        /// <summary>
+        /// Grow the entry table by one row (oldCount + 1 = newCount).
+        /// The caller opens an undo scope; the Core helper records writes
+        /// into the ambient scope. Returns the new base offset (ROM offset)
+        /// or <see cref="U.NOT_FOUND"/> on failure.
+        /// </summary>
+        public uint ExpandEntryListByOne(uint pointerSlot)
+        {
+            var rom = CoreState.ROM;
+            if (rom == null) return U.NOT_FOUND;
+            if (ReadStartAddress == 0) return U.NOT_FOUND;
+            uint newCount = ReadCount + 1;
+            return MapTileAnimation2Core.ExpandEntryList(rom, pointerSlot,
+                ReadStartAddress, ReadCount, newCount);
+        }
+
+        /// <summary>
+        /// Grow the palette sub-table by one row. The pointer slot is the
+        /// +0 byte of the current entry row (the palette data pointer field).
+        /// </summary>
+        public uint ExpandPaletteRowListByOne()
+        {
+            var rom = CoreState.ROM;
+            if (rom == null) return U.NOT_FOUND;
+            if (CurrentAddr == 0) return U.NOT_FOUND;
+            if (PaletteDataPointer == 0) return U.NOT_FOUND;
+            uint paletteSlot = CurrentAddr + 0; // P0 field
+            uint oldBase = U.toOffset(PaletteDataPointer);
+            uint newCount = DataCount + 1;
+            return MapTileAnimation2Core.ExpandPaletteRowList(rom, paletteSlot,
+                oldBase, DataCount, newCount);
+        }
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml
@@ -59,8 +59,7 @@
         <Button DockPanel.Dock="Bottom"
                 AutomationProperties.AutomationId="MapTileAnimation2_ListExpand_Button"
                 Name="ListExpandButton" Content="Data Expansion"
-                IsEnabled="False"
-                ToolTip.Tip="Pending Core extraction - tracked by #524"
+                ToolTip.Tip="Grow the entry table by one row"
                 HorizontalAlignment="Stretch" Margin="2"
                 Click="ListExpand_Click" />
         <controls:AddressListControl AutomationProperties.AutomationId="MapTileAnimation2_Entry_List"
@@ -182,8 +181,7 @@
 
             <Button AutomationProperties.AutomationId="MapTileAnimation2_NListExpand_Button"
                     Name="NListExpandButton" Content="Data Expansion"
-                    IsEnabled="False"
-                    ToolTip.Tip="Pending Core extraction - tracked by #524"
+                    ToolTip.Tip="Grow the palette sub-table by one row"
                     HorizontalAlignment="Left" Margin="0,4,0,0"
                     Click="NListExpand_Click" />
           </StackPanel>
@@ -193,13 +191,11 @@
         <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
           <Button AutomationProperties.AutomationId="MapTileAnimation2_BulkImport_Button"
                   Name="BulkImportButton" Content="Bulk Import"
-                  IsEnabled="False"
-                  ToolTip.Tip="Pending Core extraction - tracked by #524"
+                  ToolTip.Tip="Import a .mapanime2.txt file into the current PLIST"
                   Click="BulkImport_Click" />
           <Button AutomationProperties.AutomationId="MapTileAnimation2_BulkExport_Button"
                   Name="BulkExportButton" Content="Bulk Export"
-                  IsEnabled="False"
-                  ToolTip.Tip="Pending Core extraction - tracked by #524"
+                  ToolTip.Tip="Export the current PLIST's entries to a .mapanime2.txt file"
                   Click="BulkExport_Click" />
         </StackPanel>
       </StackPanel>

--- a/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using global::Avalonia.Media;
+using global::Avalonia.Platform.Storage;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 
@@ -328,25 +329,168 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex) { _undoService.Rollback(); Log.Error("MapTileAnimation2View.NWrite: {0}", ex.Message); }
         }
 
-        // Deferred affordances - logged no-ops until follow-up #524 lands.
+        // -----------------------------------------------------------------
+        // #524 Core-extracted affordances: BulkImport / BulkExport /
+        // ExpandEntryList / ExpandPaletteRowList. Each handler wraps in
+        // _undoService.Begin/Commit/Rollback so ROM mutations record into
+        // the ambient undo scope (Core helpers use the no-undo
+        // RecycleAddress ambient overloads to avoid double-recording).
+        // -----------------------------------------------------------------
+
         void ListExpand_Click(object? sender, RoutedEventArgs e)
         {
-            Log.Debug("MapTileAnimation2View.ListExpand_Click invoked - disabled until #524 lands");
+            if (!_vm.IsLoaded || _vm.ReadStartAddress == 0) return;
+            uint slot = _vm.GetPlistTableSlot();
+            if (slot == 0)
+            {
+                CoreState.Services?.ShowError("Cannot resolve PLIST table slot.");
+                return;
+            }
+            _undoService.Begin("Expand Tile Animation Type 2 Entry List");
+            try
+            {
+                uint newBase = _vm.ExpandEntryListByOne(slot);
+                if (newBase == U.NOT_FOUND)
+                {
+                    _undoService.Rollback();
+                    CoreState.Services?.ShowError("Failed to expand entry list.");
+                    return;
+                }
+                _undoService.Commit();
+                _vm.MarkClean();
+                // Reload to surface the new row.
+                LoadList();
+                CoreState.Services?.ShowInfo($"Entry list expanded. New base: 0x{newBase:X08}");
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("MapTileAnimation2View.ListExpand_Click: {0}", ex.Message);
+            }
         }
 
         void NListExpand_Click(object? sender, RoutedEventArgs e)
         {
-            Log.Debug("MapTileAnimation2View.NListExpand_Click invoked - disabled until #524 lands");
+            if (!_vm.IsLoaded || _vm.CurrentAddr == 0) return;
+            if (_vm.PaletteDataPointer == 0)
+            {
+                CoreState.Services?.ShowError("No palette data pointer set on this entry.");
+                return;
+            }
+            uint reloadAddr = _vm.CurrentAddr;
+            _undoService.Begin("Expand Tile Animation Type 2 Palette Sub-List");
+            try
+            {
+                uint newBase = _vm.ExpandPaletteRowListByOne();
+                if (newBase == U.NOT_FOUND)
+                {
+                    _undoService.Rollback();
+                    CoreState.Services?.ShowError("Failed to expand palette sub-list.");
+                    return;
+                }
+                _undoService.Commit();
+                _vm.MarkClean();
+                // Reload the entry so the palette sub-list reflects the new
+                // base pointer + grown row count.
+                _vm.IsLoading = true;
+                try
+                {
+                    _vm.LoadEntry(reloadAddr);
+                    UpdateUI();
+                }
+                finally { _vm.IsLoading = false; _vm.MarkClean(); }
+                CoreState.Services?.ShowInfo($"Palette sub-list expanded. New base: 0x{newBase:X08}");
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("MapTileAnimation2View.NListExpand_Click: {0}", ex.Message);
+            }
         }
 
-        void BulkImport_Click(object? sender, RoutedEventArgs e)
+        async void BulkImport_Click(object? sender, RoutedEventArgs e)
         {
-            Log.Debug("MapTileAnimation2View.BulkImport_Click invoked - disabled until #524 lands");
+            if (!_vm.IsLoaded || _vm.ReadStartAddress == 0) return;
+            uint slot = _vm.GetPlistTableSlot();
+            if (slot == 0)
+            {
+                CoreState.Services?.ShowError("Cannot resolve PLIST table slot.");
+                return;
+            }
+            try
+            {
+                var txtType = new FilePickerFileType("Map Tile Animation 2 Files")
+                { Patterns = new[] { "*.mapanime2.txt", "*.txt" } };
+                var allType = new FilePickerFileType("All Files") { Patterns = new[] { "*" } };
+                var files = await this.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+                {
+                    Title = "Import Map Tile Animation Type 2",
+                    AllowMultiple = false,
+                    FileTypeFilter = new[] { txtType, allType },
+                });
+                if (files.Count == 0) return;
+                string? path = files[0].TryGetLocalPath();
+                if (string.IsNullOrEmpty(path)) return;
+
+                _undoService.Begin("Bulk Import Tile Animation Type 2");
+                try
+                {
+                    string err = _vm.BulkImport(path, slot);
+                    if (err != "")
+                    {
+                        _undoService.Rollback();
+                        CoreState.Services?.ShowError(err);
+                        return;
+                    }
+                    _undoService.Commit();
+                    _vm.MarkClean();
+                    // Reload so the filter combo / entry list / palette sub-
+                    // list reflect the newly-imported data.
+                    LoadList();
+                    CoreState.Services?.ShowInfo($"Imported from {path}.");
+                }
+                catch (Exception inner)
+                {
+                    _undoService.Rollback();
+                    Log.Error("MapTileAnimation2View.BulkImport: {0}", inner.Message);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("MapTileAnimation2View.BulkImport_Click: {0}", ex.Message);
+            }
         }
 
-        void BulkExport_Click(object? sender, RoutedEventArgs e)
+        async void BulkExport_Click(object? sender, RoutedEventArgs e)
         {
-            Log.Debug("MapTileAnimation2View.BulkExport_Click invoked - disabled until #524 lands");
+            if (!_vm.IsLoaded || _vm.ReadStartAddress == 0) return;
+            try
+            {
+                var txtType = new FilePickerFileType("Map Tile Animation 2 Files")
+                { Patterns = new[] { "*.mapanime2.txt", "*.txt" } };
+                var allType = new FilePickerFileType("All Files") { Patterns = new[] { "*" } };
+                var file = await this.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+                {
+                    Title = "Export Map Tile Animation Type 2",
+                    SuggestedFileName =
+                        $"maptileanim2_plist{_vm.SelectedPlist:X2}.mapanime2.txt",
+                    FileTypeChoices = new[] { txtType, allType },
+                });
+                string? path = file?.TryGetLocalPath();
+                if (string.IsNullOrEmpty(path)) return;
+
+                string err = _vm.BulkExport(path);
+                if (err != "")
+                {
+                    CoreState.Services?.ShowError(err);
+                    return;
+                }
+                CoreState.Services?.ShowInfo($"Exported to {path}.");
+            }
+            catch (Exception ex)
+            {
+                Log.Error("MapTileAnimation2View.BulkExport_Click: {0}", ex.Message);
+            }
         }
 
         static uint ParseHexText(string? text)

--- a/FEBuilderGBA.Core.Tests/MapTileAnimation2CoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/MapTileAnimation2CoreTests.cs
@@ -5,6 +5,17 @@
 // (MakeTileAnimation2, ExportAll/ImportAll palette enumeration) so the
 // Avalonia view can drive list population, palette decoding, and round-trip
 // validation without WinForms dependencies.
+//
+// Phase 2 (#524) follow-up: BulkImport / BulkExport / ExpandEntryList /
+// ExpandPaletteRowList. These four helpers extract the WF
+// MapTileAnimation2Form.ImportAll / ExportAll / InputFormRef.AppendBinaryData
+// repoint plumbing so the Avalonia view can drive bulk flows without the
+// WinForms dependency. Tests cover round-trip parity, malformed-line WF
+// parity, undo single-source recording (no double-recording when the helper
+// runs inside an ambient ROM.BeginUndoScope), and rollback fidelity.
+using System;
+using System.IO;
+using System.Linq;
 using Xunit;
 using FEBuilderGBA;
 
@@ -267,8 +278,451 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         // -----------------------------------------------------------------
+        // BulkExport - TSV mirror of WF MapTileAnimation2Form.ExportAll
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void BulkExport_WritesExpectedTsv()
+        {
+            // Plant 2 entries at 0x500000 pointing at distinct palette blocks.
+            var rom = MakeRomWithTwoEntries(out uint baseAddr);
+            string tmp = Path.GetTempFileName();
+            try
+            {
+                string err = MapTileAnimation2Core.BulkExport(rom, tmp, baseAddr, dataCount: 2);
+                Assert.Equal("", err);
+
+                string[] lines = File.ReadAllLines(tmp);
+                // Header + 2 data lines.
+                Assert.Equal(3, lines.Length);
+                Assert.StartsWith("//wait", lines[0]);
+                // Row 0: wait=0x10, startindex=0x20, 2 colors: white (0x7FFF -> 248,248,248), red (0x001F -> 248,0,0)
+                Assert.Contains("248,248,248", lines[1]);
+                Assert.Contains("248,0,0", lines[1]);
+                // Row 1: wait=0x05, startindex=0x3C, 1 color: blue (0x7C00 -> 0,0,248)
+                Assert.Contains("0,0,248", lines[2]);
+            }
+            finally { if (File.Exists(tmp)) File.Delete(tmp); }
+        }
+
+        [Fact]
+        public void BulkExport_WithUnsafeBase_ReturnsError()
+        {
+            var rom = new ROM();
+            rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+            string tmp = Path.GetTempFileName();
+            try
+            {
+                string err = MapTileAnimation2Core.BulkExport(rom, tmp, baseAddr: 0u, dataCount: 1);
+                Assert.NotEqual("", err);
+            }
+            finally { if (File.Exists(tmp)) File.Delete(tmp); }
+        }
+
+        // -----------------------------------------------------------------
+        // BulkImport - round-trip parity + WF malformed-line parity
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void BulkImport_RoundTripsViaExport()
+        {
+            // Plant 2 entries; export; mutate ROM; import; assert the round-
+            // trip restores the same WAIT/COUNT/STARTINDEX + palette bytes the
+            // export saw.
+            var rom = MakeRomWithTwoEntries(out uint baseAddr);
+            var prevRom = CoreState.ROM;
+            string tmp = Path.GetTempFileName();
+            try
+            {
+                CoreState.ROM = rom;
+                Assert.Equal("", MapTileAnimation2Core.BulkExport(rom, tmp, baseAddr, dataCount: 2));
+
+                // The export's "pointer" is the slot we'll repoint on import.
+                // In a real call site this is the slot that holds the entry-
+                // table pointer (e.g. PLIST table slot). For this test we
+                // allocate a writable slot in the ROM and point it at baseAddr.
+                uint pointerSlot = 0x400000;
+                rom.write_p32(pointerSlot, baseAddr);
+
+                // Open ambient undo so the import path records into it.
+                var undo = new Undo.UndoData();
+                undo.list = new System.Collections.Generic.List<Undo.UndoPostion>();
+                undo.filesize = (uint)rom.Data.Length;
+                using (ROM.BeginUndoScope(undo))
+                {
+                    Assert.Equal("",
+                        MapTileAnimation2Core.BulkImport(rom, tmp, pointerSlot, baseAddr, dataCount: 2));
+                }
+
+                // After import: the pointer slot now points at the new entry
+                // table; the new table has the same wait/count/startindex
+                // sequence (palette content matches via export -> import).
+                uint newBase = rom.p32(pointerSlot);
+                Assert.NotEqual(0u, newBase);
+                Assert.Equal(0x10u, rom.u8(newBase + 4)); // row 0 wait
+                Assert.Equal(0x02u, rom.u8(newBase + 5)); // row 0 count
+                Assert.Equal(0x20u, rom.u8(newBase + 6)); // row 0 startindex
+                Assert.Equal(0x05u, rom.u8(newBase + 12)); // row 1 wait
+                Assert.Equal(0x01u, rom.u8(newBase + 13)); // row 1 count
+                Assert.Equal(0x3Cu, rom.u8(newBase + 14)); // row 1 startindex
+                // Row 2 terminator (P0=0, wait=0, ...)
+                Assert.Equal(0u, rom.u32(newBase + 16));
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                if (File.Exists(tmp)) File.Delete(tmp);
+            }
+        }
+
+        [Fact]
+        public void BulkImport_SkipsMalformedLinesPerWfParity()
+        {
+            // WF MapTileAnimation2Form.ImportAll:523-527 silently skips lines
+            // with sp.Length < 2 (continues, no error). Core helper must mirror.
+            var rom = MakeRomWithTwoEntries(out uint baseAddr);
+            var prevRom = CoreState.ROM;
+            string tmp = Path.GetTempFileName();
+            try
+            {
+                CoreState.ROM = rom;
+                // Three lines: header, malformed (1 field), valid.
+                // WF MapTileAnimation2Form.ImportAll uses U.atoi (decimal)
+                // for wait/startindex and U.atoi0x (decimal-or-0x-hex) for
+                // the R/G/B triples, so the file format is decimal numbers.
+                File.WriteAllLines(tmp, new[]
+                {
+                    "//header",
+                    "onlyfield",
+                    "16\t32\t0xF8,0xF8,0xF8",
+                });
+
+                uint pointerSlot = 0x400000;
+                rom.write_p32(pointerSlot, baseAddr);
+
+                var undo = new Undo.UndoData();
+                undo.list = new System.Collections.Generic.List<Undo.UndoPostion>();
+                undo.filesize = (uint)rom.Data.Length;
+                using (ROM.BeginUndoScope(undo))
+                {
+                    string err = MapTileAnimation2Core.BulkImport(rom, tmp, pointerSlot, baseAddr, dataCount: 2);
+                    Assert.Equal("", err); // malformed line silently skipped
+                }
+
+                // Only one valid entry written, plus the terminator row.
+                uint newBase = rom.p32(pointerSlot);
+                Assert.Equal(16u, rom.u8(newBase + 4));      // wait = 16
+                Assert.Equal(0x01u, rom.u8(newBase + 5));    // 1 palette color
+                Assert.Equal(32u, rom.u8(newBase + 6));      // startindex = 32
+                Assert.Equal(0u, rom.u32(newBase + 8));      // terminator P0
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                if (File.Exists(tmp)) File.Delete(tmp);
+            }
+        }
+
+        [Fact]
+        public void BulkImport_WorksWithoutAppendBinaryDataCallback()
+        {
+            // V3 plan-review #1: when CoreState.AppendBinaryData is null and
+            // the existing recyclable blocks are insufficient, the helper must
+            // install a local freespace-backed callback so allocation still
+            // succeeds. We force the situation by ZEROING the existing entry
+            // table (no recyclable space), then importing a fresh file that
+            // requires a new allocation.
+            var rom = MakeRomWithTwoEntries(out uint baseAddr);
+            var prevRom = CoreState.ROM;
+            var prevAppend = CoreState.AppendBinaryData;
+            string tmp = Path.GetTempFileName();
+            try
+            {
+                CoreState.ROM = rom;
+                CoreState.AppendBinaryData = null; // global callback unset
+
+                // Zero the area around baseAddr so RecycleAddress has no
+                // reusable blocks for the new palette data.
+                for (uint i = 0; i < 64; i++) rom.Data[baseAddr + i] = 0;
+
+                // Decimal numbers for wait/startindex (WF parity); 0x-prefix
+                // allowed for R/G/B (U.atoi0x accepts both).
+                File.WriteAllLines(tmp, new[]
+                {
+                    "//header",
+                    "18\t52\t0xF8,0xF8,0xF8\t0,0,0xF8",
+                });
+
+                uint pointerSlot = 0x400000;
+                rom.write_p32(pointerSlot, baseAddr);
+
+                var undo = new Undo.UndoData();
+                undo.list = new System.Collections.Generic.List<Undo.UndoPostion>();
+                undo.filesize = (uint)rom.Data.Length;
+                using (ROM.BeginUndoScope(undo))
+                {
+                    string err = MapTileAnimation2Core.BulkImport(rom, tmp, pointerSlot, baseAddr, dataCount: 0);
+                    Assert.Equal("", err);
+                }
+
+                uint newBase = rom.p32(pointerSlot);
+                Assert.NotEqual(0u, newBase);
+                Assert.Equal(18u, rom.u8(newBase + 4));      // wait = 18
+                Assert.Equal(0x02u, rom.u8(newBase + 5));    // 2 palette colors
+                Assert.Equal(52u, rom.u8(newBase + 6));      // startindex = 52
+            }
+            finally
+            {
+                CoreState.AppendBinaryData = prevAppend;
+                CoreState.ROM = prevRom;
+                if (File.Exists(tmp)) File.Delete(tmp);
+            }
+        }
+
+        [Fact]
+        public void BulkImport_DoesNotDoubleRecordUndo()
+        {
+            // V3 plan-review #2: when the helper runs inside an ambient undo
+            // scope opened with the same UndoData, each write must record
+            // exactly ONCE in undo.list. The fix is the no-undo RecycleAddress
+            // overloads added by WU1; verify here by counting unique address
+            // entries before/after.
+            var rom = MakeRomWithTwoEntries(out uint baseAddr);
+            var prevRom = CoreState.ROM;
+            string tmp = Path.GetTempFileName();
+            try
+            {
+                CoreState.ROM = rom;
+                File.WriteAllLines(tmp, new[]
+                {
+                    "//header",
+                    "16\t32\t0xF8,0xF8,0xF8",
+                });
+
+                uint pointerSlot = 0x400000;
+                rom.write_p32(pointerSlot, baseAddr);
+
+                var undo = new Undo.UndoData();
+                undo.list = new System.Collections.Generic.List<Undo.UndoPostion>();
+                undo.filesize = (uint)rom.Data.Length;
+                using (ROM.BeginUndoScope(undo))
+                {
+                    Assert.Equal("",
+                        MapTileAnimation2Core.BulkImport(rom, tmp, pointerSlot, baseAddr, dataCount: 2));
+                }
+
+                // For each address, the count of UndoPostion entries must be
+                // <= 2 (palette block addr can recur if it's reused across
+                // multiple steps; the SAME address never records twice for
+                // the SAME write op). Group by addr and assert no address has
+                // > 2 entries - WF's ImportAll for two-entry input creates at
+                // most one record per ROM write op. With double-recording the
+                // count would be 2x what WF produces; here we cap at a sane
+                // small number per address.
+                var maxPerAddr = undo.list.GroupBy(p => p.addr).Max(g => g.Count());
+                Assert.True(maxPerAddr <= 2,
+                    $"Per-address undo records must be <= 2 (no double-recording); was {maxPerAddr}");
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                if (File.Exists(tmp)) File.Delete(tmp);
+            }
+        }
+
+        [Fact]
+        public void BulkImport_RollbackRestoresOriginalPointer()
+        {
+            // V3 plan-review #2: rollback must restore the ROM bytes around
+            // the pointer slot. Capture the slot's value pre-import, run
+            // import, rollback via the captured UndoData, assert the slot
+            // returns to its pre-import value.
+            var rom = MakeRomWithTwoEntries(out uint baseAddr);
+            var prevRom = CoreState.ROM;
+            string tmp = Path.GetTempFileName();
+            try
+            {
+                CoreState.ROM = rom;
+                File.WriteAllLines(tmp, new[]
+                {
+                    "//header",
+                    "16\t32\t0xF8,0xF8,0xF8",
+                });
+
+                uint pointerSlot = 0x400000;
+                rom.write_p32(pointerSlot, baseAddr);
+                uint origPointer = rom.u32(pointerSlot);
+
+                var undo = new Undo.UndoData();
+                undo.list = new System.Collections.Generic.List<Undo.UndoPostion>();
+                undo.filesize = (uint)rom.Data.Length;
+                using (ROM.BeginUndoScope(undo))
+                {
+                    Assert.Equal("",
+                        MapTileAnimation2Core.BulkImport(rom, tmp, pointerSlot, baseAddr, dataCount: 2));
+                }
+                Assert.NotEqual(origPointer, rom.u32(pointerSlot));
+
+                // Now rollback: walk the undo list in reverse and restore each
+                // address-range's pre-write bytes (matches Undo.Patch).
+                for (int i = undo.list.Count - 1; i >= 0; i--)
+                {
+                    var p = undo.list[i];
+                    if (p.data != null && p.data.Length > 0)
+                    {
+                        for (int j = 0; j < p.data.Length; j++)
+                        {
+                            rom.Data[p.addr + j] = p.data[j];
+                        }
+                    }
+                }
+                Assert.Equal(origPointer, rom.u32(pointerSlot));
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                if (File.Exists(tmp)) File.Delete(tmp);
+            }
+        }
+
+        // -----------------------------------------------------------------
+        // ExpandEntryList - grow main entry table, row-0 template copy
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void ExpandEntryList_AllocatesAndRepoints()
+        {
+            var rom = MakeRomWithTwoEntries(out uint baseAddr);
+            // Allocate a pointer slot that holds the entry table base.
+            uint pointerSlot = 0x400000;
+            rom.write_p32(pointerSlot, baseAddr);
+
+            uint newBase = MapTileAnimation2Core.ExpandEntryList(
+                rom, pointerSlot, oldBase: baseAddr, oldCount: 2, newCount: 5);
+
+            Assert.NotEqual(U.NOT_FOUND, newBase);
+            Assert.NotEqual(baseAddr, newBase);
+            // The new pointer slot dereferences to newBase.
+            Assert.Equal(newBase, rom.p32(pointerSlot));
+            // ScanEntries must return exactly 5 valid rows (V1 plan-review #2:
+            // row-0 template copy preserves isPointer(P0)).
+            var entries = MapTileAnimation2Core.ScanEntries(rom, newBase, maxRows: 16);
+            Assert.Equal(5, entries.Count);
+        }
+
+        [Fact]
+        public void ExpandEntryList_RefusesShrinks()
+        {
+            var rom = MakeRomWithTwoEntries(out uint baseAddr);
+            uint pointerSlot = 0x400000;
+            rom.write_p32(pointerSlot, baseAddr);
+            uint newBase = MapTileAnimation2Core.ExpandEntryList(
+                rom, pointerSlot, oldBase: baseAddr, oldCount: 5, newCount: 3);
+            Assert.Equal(U.NOT_FOUND, newBase);
+        }
+
+        [Fact]
+        public void ExpandEntryList_RefusesZeroOldCount()
+        {
+            var rom = MakeRomWithTwoEntries(out uint baseAddr);
+            uint pointerSlot = 0x400000;
+            rom.write_p32(pointerSlot, baseAddr);
+            uint newBase = MapTileAnimation2Core.ExpandEntryList(
+                rom, pointerSlot, oldBase: baseAddr, oldCount: 0, newCount: 2);
+            Assert.Equal(U.NOT_FOUND, newBase);
+        }
+
+        // -----------------------------------------------------------------
+        // ExpandPaletteRowList - grow palette sub-table, row-0 template copy
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void ExpandPaletteRowList_AllocatesAndRepoints()
+        {
+            var rom = MakeRomWithTwoEntries(out uint baseAddr);
+            // The entry at baseAddr+0..7 has P0 -> palette block at
+            // baseAddr+0x100 (planted by MakeRomWithTwoEntries). Use that
+            // slot as the palette data pointer slot.
+            uint paletteSlot = baseAddr + 0; // +0 is the palette pointer
+            uint oldPaletteBase = rom.p32(paletteSlot); // 0x500100
+
+            uint newBase = MapTileAnimation2Core.ExpandPaletteRowList(
+                rom, paletteSlot, oldBase: oldPaletteBase, oldCount: 2, newCount: 4);
+
+            Assert.NotEqual(U.NOT_FOUND, newBase);
+            Assert.NotEqual(oldPaletteBase, newBase);
+            Assert.Equal(newBase, rom.p32(paletteSlot));
+            // First 2 colors copied from old block (white, red).
+            Assert.Equal((ushort)0x7FFF, (ushort)rom.u16(newBase + 0));
+            Assert.Equal((ushort)0x001F, (ushort)rom.u16(newBase + 2));
+            // New rows 2 and 3 are clones of row 0 (white 0x7FFF) - NOT zero,
+            // per V1 plan-review #2 (WF row-0 template copy semantics).
+            Assert.Equal((ushort)0x7FFF, (ushort)rom.u16(newBase + 4));
+            Assert.Equal((ushort)0x7FFF, (ushort)rom.u16(newBase + 6));
+        }
+
+        [Fact]
+        public void ExpandPaletteRowList_RefusesShrinks()
+        {
+            var rom = MakeRomWithTwoEntries(out uint baseAddr);
+            uint paletteSlot = baseAddr + 0;
+            uint oldPaletteBase = rom.p32(paletteSlot);
+            uint newBase = MapTileAnimation2Core.ExpandPaletteRowList(
+                rom, paletteSlot, oldBase: oldPaletteBase, oldCount: 4, newCount: 2);
+            Assert.Equal(U.NOT_FOUND, newBase);
+        }
+
+        [Fact]
+        public void ExpandPaletteRowList_RefusesZeroOldCount()
+        {
+            var rom = MakeRomWithTwoEntries(out uint baseAddr);
+            uint paletteSlot = baseAddr + 0;
+            uint oldPaletteBase = rom.p32(paletteSlot);
+            uint newBase = MapTileAnimation2Core.ExpandPaletteRowList(
+                rom, paletteSlot, oldBase: oldPaletteBase, oldCount: 0, newCount: 4);
+            Assert.Equal(U.NOT_FOUND, newBase);
+        }
+
+        // -----------------------------------------------------------------
         // Helpers
         // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Build a ROM with two valid entries at <c>baseAddr</c>:
+        ///   - Row 0: P0=0x08500100, wait=0x10, count=2, startindex=0x20
+        ///     Palette block at 0x500100 (2 colors: white 0x7FFF, red 0x001F).
+        ///   - Row 1: P0=0x08500200, wait=0x05, count=1, startindex=0x3C
+        ///     Palette block at 0x500200 (1 color: blue 0x7C00).
+        ///   - Row 2: terminator (P0=0).
+        /// </summary>
+        static ROM MakeRomWithTwoEntries(out uint baseAddr)
+        {
+            var rom = new ROM();
+            rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+            baseAddr = 0x500000;
+            // Row 0: P0=0x08500100, wait=0x10, count=2, startindex=0x20.
+            WriteU32(rom.Data, (int)baseAddr + 0, 0x08500100u);
+            rom.Data[baseAddr + 4] = 0x10;
+            rom.Data[baseAddr + 5] = 0x02;
+            rom.Data[baseAddr + 6] = 0x20;
+            rom.Data[baseAddr + 7] = 0x00;
+            // Row 1: P0=0x08500200, wait=0x05, count=1, startindex=0x3C.
+            WriteU32(rom.Data, (int)baseAddr + 8, 0x08500200u);
+            rom.Data[baseAddr + 12] = 0x05;
+            rom.Data[baseAddr + 13] = 0x01;
+            rom.Data[baseAddr + 14] = 0x3C;
+            rom.Data[baseAddr + 15] = 0x00;
+            // Row 2: terminator.
+            WriteU32(rom.Data, (int)baseAddr + 16, 0u);
+
+            // Palette block at 0x500100 (row 0): 2 colors.
+            WriteU16(rom.Data, 0x500100 + 0, 0x7FFF); // white
+            WriteU16(rom.Data, 0x500100 + 2, 0x001F); // red
+            // Palette block at 0x500200 (row 1): 1 color.
+            WriteU16(rom.Data, 0x500200 + 0, 0x7C00); // blue
+
+            return rom;
+        }
 
         /// <summary>
         /// Build a tiny synthetic FE8U ROM. Sets the map_setting_pointer to

--- a/FEBuilderGBA.Core/MapTileAnimation2Core.cs
+++ b/FEBuilderGBA.Core/MapTileAnimation2Core.cs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Cross-platform helpers for the MapTileAnimation2 editor (#426).
+// Cross-platform helpers for the MapTileAnimation2 editor (#426, #524).
+using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 
 namespace FEBuilderGBA
 {
@@ -223,6 +226,331 @@ namespace FEBuilderGBA
                 result.Add(new PaletteRow((int)i, gba, r, g, b));
             }
             return result;
+        }
+
+        // ====================================================================
+        // BulkExport / BulkImport / ExpandEntryList / ExpandPaletteRowList
+        // (#524) - Core extraction of the WinForms ImportAll / ExportAll /
+        // InputFormRef.AppendBinaryData repoint plumbing so the Avalonia view
+        // can drive bulk flows headlessly. The WF form keeps its existing
+        // path (uses InputFormRef + the explicit-undo RecycleAddress
+        // overloads); these helpers use the ambient-undo RecycleAddress
+        // overloads (#524 WU1) so callers wrap them in ROM.BeginUndoScope
+        // and every write records exactly once.
+        // ====================================================================
+
+        /// <summary>
+        /// Export the 8-byte main animation entries rooted at
+        /// <paramref name="baseAddr"/> to a tab-separated text file. Mirrors
+        /// the WF <c>MapTileAnimation2Form.ExportAll</c> output format:
+        /// header line plus one row per entry as
+        /// <c>wait{TAB}startindex{TAB}R,G,B{TAB}R,G,B...</c>. Returns the
+        /// empty string on success, or an error message describing the
+        /// failure (e.g. unsafe base, unsafe palette pointer, IO error).
+        /// </summary>
+        public static string BulkExport(ROM rom, string filename, uint baseAddr, uint dataCount)
+        {
+            if (rom == null) return "ROM is null.";
+            if (!U.isSafetyOffset(baseAddr, rom)) return "baseAddr is not a safe ROM offset.";
+            if (string.IsNullOrEmpty(filename)) return "filename is empty.";
+
+            try
+            {
+                var lines = new List<string>();
+                // Header line - matches WF format byte-for-byte.
+                lines.Add("//wait\tstartindex\tR,G,B Colors...");
+
+                uint addr = baseAddr;
+                for (uint i = 0; i < dataCount; i++, addr += 8)
+                {
+                    if (addr + 8 > (uint)rom.Data.Length) break;
+                    uint p0 = rom.p32(addr + 0);
+                    uint wait = rom.u8(addr + 4);
+                    uint count = rom.u8(addr + 5);
+                    uint startindex = rom.u8(addr + 6);
+                    if (!U.isSafetyOffset(p0, rom)) continue;
+
+                    var sb = new StringBuilder();
+                    sb.Append(wait);
+                    sb.Append('\t');
+                    sb.Append(startindex);
+                    uint paladdr = p0;
+                    for (uint n = 0; n < count; n++, paladdr += 2)
+                    {
+                        if (paladdr + 2 > (uint)rom.Data.Length) break;
+                        ushort pal = (ushort)rom.u16(paladdr);
+                        var (r, g, b) = GbaToRgb(pal);
+                        sb.Append('\t');
+                        sb.Append(r);
+                        sb.Append(',');
+                        sb.Append(g);
+                        sb.Append(',');
+                        sb.Append(b);
+                    }
+                    lines.Add(sb.ToString());
+                }
+
+                File.WriteAllLines(filename, lines);
+                return "";
+            }
+            catch (Exception ex)
+            {
+                return "BulkExport failed: " + ex.Message;
+            }
+        }
+
+        /// <summary>
+        /// Import a tab-separated text file (produced by
+        /// <see cref="BulkExport"/>) into the main animation entry table.
+        /// The caller MUST open an ambient undo scope via
+        /// <see cref="ROM.BeginUndoScope"/> before calling this method; the
+        /// helper uses the ambient-undo <see cref="RecycleAddress"/> overloads
+        /// so every ROM write records exactly once into the active UndoData.
+        ///
+        /// Mirrors WF <c>MapTileAnimation2Form.ImportAll</c> step-for-step
+        /// including the malformed-line semantics: lines with fewer than 2
+        /// tab-separated fields are silently skipped (WF parity, V3
+        /// plan-review #4).
+        ///
+        /// <para>Parameters:</para>
+        /// <para><c>rom</c> — target ROM. The method temporarily swaps
+        /// <c>CoreState.ROM</c> for the duration so the <c>RecycleAddress</c>
+        /// helpers (which read CoreState.ROM directly) mutate the supplied
+        /// instance.</para>
+        /// <para><c>filename</c> — TSV path produced by <see cref="BulkExport"/>.</para>
+        /// <para><c>pointer</c> — the 4-byte slot that holds the entry-table
+        /// pointer; the helper repoints it to the freshly-written table.</para>
+        /// <para><c>baseAddr</c> — the entry-table base address before
+        /// import. Used to enumerate existing entries for the recycle pool
+        /// so the WF "free old palette blocks" behavior matches.</para>
+        /// <para><c>dataCount</c> — number of existing entries at
+        /// <paramref name="baseAddr"/>; the helper feeds them into the
+        /// RecycleAddress pool exactly as WF does.</para>
+        ///
+        /// Returns empty string on success, an error message on failure.
+        /// </summary>
+        public static string BulkImport(ROM rom, string filename, uint pointer, uint baseAddr, uint dataCount)
+        {
+            if (rom == null) return "ROM is null.";
+            if (!U.isSafetyOffset(pointer, rom)) return "pointer is not a safe ROM offset.";
+            if (string.IsNullOrEmpty(filename)) return "filename is empty.";
+            if (!File.Exists(filename)) return "filename does not exist: " + filename;
+
+            // Save & swap CoreState.ROM so RecycleAddress (which reads
+            // CoreState.ROM internally) mutates the passed ROM.
+            var prevRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = rom;
+                return BulkImportInner(rom, filename, pointer, baseAddr, dataCount);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+            }
+        }
+
+        static string BulkImportInner(ROM rom, string filename, uint pointer, uint baseAddr, uint dataCount)
+        {
+            // Build the recycle pool from existing entries (each row's
+            // palette block becomes a reusable region). Matches WF
+            // MapTileAnimation2Form.ImportAll:474-503.
+            var recycle = new List<Address>();
+            if (U.isSafetyOffset(baseAddr, rom))
+            {
+                for (uint i = 0; i < dataCount; i++)
+                {
+                    uint addr = baseAddr + i * 8;
+                    if (addr + 8 > (uint)rom.Data.Length) break;
+                    uint p0 = rom.p32(addr + 0);
+                    uint count = rom.u8(addr + 5);
+                    if (!U.isSafetyOffset(p0, rom)) continue;
+                    Address.AddPointer(recycle, addr + 0, count * 2, "", Address.DataTypeEnum.BIN);
+                }
+                // Also recycle the existing entry table itself.
+                Address.AddAddress(recycle, baseAddr, dataCount * 8 + 8, 0,
+                    "MapTileAnimation2.entryTable", Address.DataTypeEnum.BIN);
+            }
+
+            var ra = new RecycleAddress(recycle);
+
+            // Parse lines and build entries.
+            string[] lines;
+            try { lines = File.ReadAllLines(filename); }
+            catch (Exception ex) { return "BulkImport: failed to read file: " + ex.Message; }
+
+            var writedata = new List<byte>();
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string line = lines[i];
+                if (U.IsComment(line) || U.OtherLangLine(line)) continue;
+                line = U.ClipComment(line);
+                if (line == "") continue;
+                string[] sp = line.Split('\t');
+                if (sp.Length < 2) continue; // WF parity (V3 plan-review #4) - skip malformed.
+
+                uint wait = U.atoi(sp[0]);
+                uint startindex = U.atoi(sp[1]);
+                uint count = 0;
+
+                var palByte = new List<byte>();
+                for (int n = 2; n < sp.Length; n++, count++)
+                {
+                    string pal = sp[n];
+                    string[] rgbarray = pal.Split(',');
+                    int r = (int)U.atoi0x(U.at(rgbarray, 0));
+                    int g = (int)U.atoi0x(U.at(rgbarray, 1));
+                    int b = (int)U.atoi0x(U.at(rgbarray, 2));
+                    ushort gba = RgbToGba((byte)r, (byte)g, (byte)b);
+                    U.append_u16(palByte, gba);
+                }
+
+                uint newaddr = ra.WriteAmbient(palByte.ToArray());
+                if (newaddr == U.NOT_FOUND)
+                {
+                    return string.Format(
+                        "BulkImport: failed to write palette data at line {0} (file: {1}).",
+                        i, filename);
+                }
+
+                U.append_u32(writedata, U.toPointer(newaddr));
+                U.append_u8(writedata, wait);
+                U.append_u8(writedata, count);
+                U.append_u8(writedata, startindex);
+                U.append_u8(writedata, 0);
+            }
+
+            // Terminator row.
+            U.append_u32(writedata, 0);
+            U.append_u8(writedata, 0);
+            U.append_u8(writedata, 0);
+            U.append_u8(writedata, 0);
+            U.append_u8(writedata, 0);
+
+            uint newpointer = ra.WriteAndWritePointerAmbient(pointer, writedata.ToArray());
+            if (newpointer == U.NOT_FOUND)
+            {
+                return string.Format(
+                    "BulkImport: failed to repoint entry table (file: {0}).", filename);
+            }
+            ra.BlackOutAmbient();
+            return "";
+        }
+
+        /// <summary>
+        /// Grow the main 8-byte entry table from <paramref name="oldCount"/>
+        /// to <paramref name="newCount"/> rows. Allocates a fresh region in
+        /// free space, copies the existing rows, fills the new rows with
+        /// row-0 template clones (WF parity, V1 plan-review #2), and
+        /// repoints <paramref name="pointerSlot"/> to the new base.
+        ///
+        /// The caller MUST open an ambient undo scope via
+        /// <see cref="ROM.BeginUndoScope"/> so the ambient scope captures
+        /// every write exactly once.
+        ///
+        /// Returns the new base ROM offset (not a GBA pointer), or
+        /// <see cref="U.NOT_FOUND"/> on failure.
+        /// </summary>
+        public static uint ExpandEntryList(ROM rom, uint pointerSlot, uint oldBase, uint oldCount, uint newCount)
+        {
+            return ExpandTableCore(rom, pointerSlot, oldBase, oldCount, newCount, blockSize: 8);
+        }
+
+        /// <summary>
+        /// Compatibility overload that opens an ambient undo scope around
+        /// the supplied <paramref name="undo"/> (or reuses the active one
+        /// if it already matches), then dispatches to the parameterless
+        /// variant. Matches the two-overload pattern used by
+        /// <see cref="ImageBattleBGCore.ExpandList(ROM, uint, uint, Undo.UndoData)"/>.
+        /// </summary>
+        public static uint ExpandEntryList(ROM rom, uint pointerSlot, uint oldBase, uint oldCount, uint newCount, Undo.UndoData undo)
+        {
+            if (undo == null) return U.NOT_FOUND;
+            if (ROM.GetAmbientUndoData() == undo)
+            {
+                return ExpandEntryList(rom, pointerSlot, oldBase, oldCount, newCount);
+            }
+            using (ROM.BeginUndoScope(undo))
+            {
+                return ExpandEntryList(rom, pointerSlot, oldBase, oldCount, newCount);
+            }
+        }
+
+        /// <summary>
+        /// Grow the 2-byte palette sub-table from <paramref name="oldCount"/>
+        /// colors to <paramref name="newCount"/> colors. Allocates a fresh
+        /// region in free space, copies the existing colors, fills the new
+        /// slots with row-0 template clones (the first color of the existing
+        /// palette block), and repoints
+        /// <paramref name="paletteDataPointerSlot"/> to the new base.
+        ///
+        /// The caller MUST open an ambient undo scope.
+        /// </summary>
+        public static uint ExpandPaletteRowList(ROM rom, uint paletteDataPointerSlot, uint oldBase, uint oldCount, uint newCount)
+        {
+            return ExpandTableCore(rom, paletteDataPointerSlot, oldBase, oldCount, newCount, blockSize: 2);
+        }
+
+        /// <summary>Explicit-undo overload (mirrors <see cref="ExpandEntryList(ROM, uint, uint, uint, uint, Undo.UndoData)"/>).</summary>
+        public static uint ExpandPaletteRowList(ROM rom, uint paletteDataPointerSlot, uint oldBase, uint oldCount, uint newCount, Undo.UndoData undo)
+        {
+            if (undo == null) return U.NOT_FOUND;
+            if (ROM.GetAmbientUndoData() == undo)
+            {
+                return ExpandPaletteRowList(rom, paletteDataPointerSlot, oldBase, oldCount, newCount);
+            }
+            using (ROM.BeginUndoScope(undo))
+            {
+                return ExpandPaletteRowList(rom, paletteDataPointerSlot, oldBase, oldCount, newCount);
+            }
+        }
+
+        /// <summary>
+        /// Internal shared implementation for both ExpandEntryList (8 bytes)
+        /// and ExpandPaletteRowList (2 bytes). Uses row-0 template copy
+        /// semantics per V1 plan-review #2.
+        /// </summary>
+        static uint ExpandTableCore(ROM rom, uint pointerSlot, uint oldBase, uint oldCount, uint newCount, uint blockSize)
+        {
+            if (rom == null || rom.RomInfo == null) return U.NOT_FOUND;
+            if (oldCount == 0) return U.NOT_FOUND;
+            if (newCount <= oldCount) return U.NOT_FOUND;
+            if (blockSize == 0) return U.NOT_FOUND;
+            if (!U.isSafetyOffset(pointerSlot, rom)) return U.NOT_FOUND;
+            if (pointerSlot + 4 > (uint)rom.Data.Length) return U.NOT_FOUND;
+            if (!U.isSafetyOffset(oldBase, rom)) return U.NOT_FOUND;
+            if (oldBase + oldCount * blockSize > (uint)rom.Data.Length) return U.NOT_FOUND;
+
+            // Allocate (newCount + 1) * blockSize so the terminator row
+            // (all zeros) lives past the user-visible rows. Matches the WF
+            // pattern used by MapEventUnitCore.ExpandUnitList.
+            uint needSize = (newCount + 1) * blockSize;
+            uint searchStart = (uint)(rom.Data.Length / 2);
+            uint newBase = rom.FindFreeSpace(searchStart, needSize);
+            if (newBase == U.NOT_FOUND)
+            {
+                newBase = rom.FindFreeSpace(0x100u, needSize);
+            }
+            if (newBase == U.NOT_FOUND) return U.NOT_FOUND;
+
+            // 1. Copy existing rows.
+            byte[] oldRows = rom.getBinaryData(oldBase, oldCount * blockSize);
+            rom.write_range(newBase, oldRows);
+
+            // 2. Row-0 template clones for new rows.
+            byte[] row0 = rom.getBinaryData(oldBase, blockSize);
+            for (uint i = oldCount; i < newCount; i++)
+            {
+                rom.write_range(newBase + i * blockSize, row0);
+            }
+
+            // 3. Zero terminator row past newCount.
+            byte[] terminator = new byte[blockSize];
+            rom.write_range(newBase + newCount * blockSize, terminator);
+
+            // 4. Repoint the slot.
+            rom.write_p32(pointerSlot, newBase);
+            return newBase;
         }
     }
 }

--- a/FEBuilderGBA.Core/MapTileAnimation2Core.cs
+++ b/FEBuilderGBA.Core/MapTileAnimation2Core.cs
@@ -329,6 +329,14 @@ namespace FEBuilderGBA
         ///
         /// Returns empty string on success, an error message on failure.
         /// </summary>
+        // Serialise the CoreState.ROM swap below so two concurrent BulkImport
+        // calls cannot interleave their save/restore (Copilot bot review on
+        // PR #634). CoreState.ROM is a static global, not thread-local, so
+        // the swap inside BulkImport is not thread-safe on its own. The lock
+        // narrows the race to a per-call serialisation - acceptable because
+        // ROM editing is itself inherently single-writer.
+        static readonly object _coreStateRomSwapLock = new object();
+
         public static string BulkImport(ROM rom, string filename, uint pointer, uint baseAddr, uint dataCount)
         {
             if (rom == null) return "ROM is null.";
@@ -337,16 +345,21 @@ namespace FEBuilderGBA
             if (!File.Exists(filename)) return "filename does not exist: " + filename;
 
             // Save & swap CoreState.ROM so RecycleAddress (which reads
-            // CoreState.ROM internally) mutates the passed ROM.
-            var prevRom = CoreState.ROM;
-            try
+            // CoreState.ROM internally) mutates the passed ROM. The lock
+            // prevents two concurrent BulkImport calls from racing on the
+            // global (Copilot bot review on PR #634).
+            lock (_coreStateRomSwapLock)
             {
-                CoreState.ROM = rom;
-                return BulkImportInner(rom, filename, pointer, baseAddr, dataCount);
-            }
-            finally
-            {
-                CoreState.ROM = prevRom;
+                var prevRom = CoreState.ROM;
+                try
+                {
+                    CoreState.ROM = rom;
+                    return BulkImportInner(rom, filename, pointer, baseAddr, dataCount);
+                }
+                finally
+                {
+                    CoreState.ROM = prevRom;
+                }
             }
         }
 

--- a/FEBuilderGBA.Core/RecycleAddress.cs
+++ b/FEBuilderGBA.Core/RecycleAddress.cs
@@ -280,11 +280,15 @@ namespace FEBuilderGBA
                 }
             }
 
-            // Recycle pool didn't satisfy the request. Try the
-            // CoreState.AppendBinaryData hook first (so consumers wired by
-            // WinForms / Avalonia keep their hooks active), then fall back
-            // to a direct rom.FindFreeSpace + write_range so #524 BulkImport
-            // works even when AppendBinaryData is not wired.
+            // Recycle pool didn't satisfy the request. We deliberately do NOT
+            // call CoreState.AppendBinaryData here - that seam is WinForms-
+            // specific (its signature takes an explicit undodata which would
+            // double-record against the ambient scope, the very condition
+            // these Ambient-suffix methods exist to avoid). Fall back to
+            // rom.FindFreeSpace + no-undo write_range so #524 BulkImport works
+            // headlessly. The tail-resize special case below mirrors
+            // Write(_, undodata) for the case where the last recycle range
+            // reaches ROM.Data.Length.
             if (this.Recycle.Count <= 0)
             {
                 return AllocFreeSpace(write_data);
@@ -295,7 +299,14 @@ namespace FEBuilderGBA
             if (lastP.Addr + lastP.Length >= CoreState.ROM.Data.Length)
             {
                 // Tail-resize special case (matches Write(_,undodata)).
-                CoreState.ROM.write_resize_data(U.Padding4(lastP.Addr + (uint)write_data.Length));
+                // Bail out on a failed resize (e.g., >32MB) so the caller
+                // gets U.NOT_FOUND instead of a crashing write_range
+                // (Copilot bot review on PR #634).
+                uint newRomSize = U.Padding4(lastP.Addr + (uint)write_data.Length);
+                if (!CoreState.ROM.write_resize_data(newRomSize))
+                {
+                    return U.NOT_FOUND;
+                }
                 CoreState.ROM.write_range(lastP.Addr, write_data);
                 this.Recycle.RemoveAt(lastI);
                 return lastP.Addr;

--- a/FEBuilderGBA.Core/RecycleAddress.cs
+++ b/FEBuilderGBA.Core/RecycleAddress.cs
@@ -189,6 +189,167 @@ namespace FEBuilderGBA
 
             return use_addr;
         }
+
+        // -----------------------------------------------------------------
+        // Ambient-undo overloads (#524) — these mirror the explicit-undo
+        // methods above but route through the no-undo rom.write_* overloads.
+        // Callers wrap them in ROM.BeginUndoScope so the ambient scope
+        // captures every write exactly once into the active UndoData. Mixing
+        // these methods with the explicit-undo overloads while an ambient
+        // scope is active would double-record (see Rom.cs:849-883 - the
+        // explicit overload appends to undodata.list AND delegates to the
+        // no-undo overload which appends to _ambientUndoData.list when they
+        // refer to the same UndoData instance).
+        // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Repoint <paramref name="write_pointer"/> at <paramref name="content_addr"/>
+        /// using the no-undo <c>write_p32</c> overload. The active
+        /// <see cref="ROM.BeginUndoScope"/> captures the write into the
+        /// ambient UndoData. Returns <paramref name="content_addr"/> (the
+        /// caller's input) so this method composes with Write below.
+        /// </summary>
+        public uint WritePointerOnlyAmbient(uint write_pointer, uint content_addr)
+        {
+            CoreState.ROM.write_p32(write_pointer, content_addr);
+            return content_addr;
+        }
+
+        /// <summary>
+        /// Same as <see cref="WriteAndWritePointer"/> but the write
+        /// is routed through the no-undo overloads so the active ambient
+        /// undo scope captures each write exactly once.
+        /// </summary>
+        public uint WriteAndWritePointerAmbient(uint write_pointer, byte[] write_data)
+        {
+            uint use_addr = WriteAmbient(write_data);
+            if (use_addr == U.NOT_FOUND)
+            {
+                return U.NOT_FOUND;
+            }
+            CoreState.ROM.write_p32(write_pointer, use_addr);
+            return use_addr;
+        }
+
+        /// <summary>
+        /// Allocate <paramref name="write_data"/> from the recycle pool (or
+        /// freespace fallback) and emit the bytes via the no-undo
+        /// <c>rom.write_range</c> overload. The active ambient
+        /// <see cref="ROM.BeginUndoScope"/> captures each write exactly once.
+        /// Mirrors <see cref="Write(byte[], Undo.UndoData)"/> step-for-step
+        /// but without the explicit undodata parameter on the inner calls.
+        /// </summary>
+        public uint WriteAmbient(byte[] write_data)
+        {
+            for (int i = 0; i < this.Recycle.Count; i++)
+            {
+                Address p = this.Recycle[i];
+                if (p.Length >= write_data.Length)
+                {
+                    uint use_addr = p.Addr;
+                    uint left_size = p.Length;
+                    if (!U.isPadding4(use_addr))
+                    {
+                        if (left_size < 4)
+                        {
+                            Log.Notify("アドレスが端数値なので補正しようとしましたが、サイズが4未満なので利用しません", U.To0xHexString(p.Addr));
+                            continue;
+                        }
+                        uint diff = 4 - (use_addr % 4);
+                        use_addr += diff;
+                        left_size -= diff;
+                        if (left_size < write_data.Length)
+                        {
+                            Log.Notify("アドレスが端数値なので補正しようとしたらサイズ不足になりました", U.To0xHexString(p.Addr));
+                            continue;
+                        }
+                        Log.Notify("アドレスが端数値なので補正します。", U.To0xHexString(p.Addr));
+                    }
+
+                    CoreState.ROM.write_range(use_addr, write_data);
+                    uint next_addr = U.Padding4(use_addr + (uint)write_data.Length);
+                    left_size = U.Sub(left_size, (next_addr - use_addr));
+
+                    p.ResizeAddress(next_addr, left_size);
+                    if (p.Length < 4)
+                    {
+                        this.Recycle.RemoveAt(i);
+                    }
+
+                    return use_addr;
+                }
+            }
+
+            // Recycle pool didn't satisfy the request. Try the
+            // CoreState.AppendBinaryData hook first (so consumers wired by
+            // WinForms / Avalonia keep their hooks active), then fall back
+            // to a direct rom.FindFreeSpace + write_range so #524 BulkImport
+            // works even when AppendBinaryData is not wired.
+            if (this.Recycle.Count <= 0)
+            {
+                return AllocFreeSpace(write_data);
+            }
+
+            int lastI = this.Recycle.Count - 1;
+            Address lastP = this.Recycle[lastI];
+            if (lastP.Addr + lastP.Length >= CoreState.ROM.Data.Length)
+            {
+                // Tail-resize special case (matches Write(_,undodata)).
+                CoreState.ROM.write_resize_data(U.Padding4(lastP.Addr + (uint)write_data.Length));
+                CoreState.ROM.write_range(lastP.Addr, write_data);
+                this.Recycle.RemoveAt(lastI);
+                return lastP.Addr;
+            }
+
+            return AllocFreeSpace(write_data);
+        }
+
+        /// <summary>
+        /// Find free space and write the bytes (no undo). Used by
+        /// <see cref="WriteAmbient"/> when the recycle pool is exhausted.
+        /// Uses rom.FindFreeSpace (upper half then lower half), and finally
+        /// resizes the ROM. The active ambient undo scope captures the
+        /// no-undo <c>rom.write_range</c> call. We deliberately do NOT call
+        /// CoreState.AppendBinaryData here - that seam is WinForms-specific
+        /// (its signature takes an explicit undodata which would double-record
+        /// against the ambient scope, the very condition the Ambient-suffix
+        /// methods exist to avoid).
+        /// </summary>
+        uint AllocFreeSpace(byte[] write_data)
+        {
+            var rom = CoreState.ROM;
+            uint searchStart = (uint)(rom.Data.Length / 2);
+            uint addr = rom.FindFreeSpace(searchStart, (uint)write_data.Length);
+            if (addr == U.NOT_FOUND)
+            {
+                addr = rom.FindFreeSpace(0x100u, (uint)write_data.Length);
+            }
+            if (addr == U.NOT_FOUND)
+            {
+                // ROM is full - resize and place at the tail.
+                uint newSize = U.Padding4((uint)rom.Data.Length + (uint)write_data.Length);
+                if (newSize > 0x02000000u) return U.NOT_FOUND;
+                uint tail = (uint)rom.Data.Length;
+                if (!rom.write_resize_data(newSize)) return U.NOT_FOUND;
+                addr = tail;
+            }
+            rom.write_range(addr, write_data);
+            return addr;
+        }
+
+        /// <summary>
+        /// No-undo BlackOut: clears every remaining recycle range with 0x00.
+        /// The active ambient undo scope captures each fill once.
+        /// </summary>
+        public void BlackOutAmbient()
+        {
+            foreach (Address p in Recycle)
+            {
+                CoreState.ROM.write_fill(p.Addr, p.Length, 0x00);
+            }
+            this.Recycle.Clear();
+        }
+
         public uint Write(byte[] write_data, Undo.UndoData undodata)
         {
             for (int i = 0; i < this.Recycle.Count; i++)

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -6933,6 +6933,18 @@ GBAカラー
 :Pending Core extraction - tracked by #524
 Core 抽出待ち - #524 で追跡中
 
+:Grow the entry table by one row
+エントリ表を1行拡張する
+
+:Grow the palette sub-table by one row
+パレットサブ表を1行拡張する
+
+:Import a .mapanime2.txt file into the current PLIST
+.mapanime2.txt ファイルを現在の PLIST にインポート
+
+:Export the current PLIST's entries to a .mapanime2.txt file
+現在の PLIST のエントリを .mapanime2.txt ファイルにエクスポート
+
 :Map Tile Animation Type 2 Palette Sub-Table
 マップ タイルアニメ タイプ 2 パレット サブテーブル
 

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -20868,6 +20868,18 @@ GBA颜色
 :Pending Core extraction - tracked by #524
 Core 抽取待中 - 追踪于 #524
 
+:Grow the entry table by one row
+将条目表扩展一行
+
+:Grow the palette sub-table by one row
+将调色板子表扩展一行
+
+:Import a .mapanime2.txt file into the current PLIST
+将 .mapanime2.txt 文件导入当前 PLIST
+
+:Export the current PLIST's entries to a .mapanime2.txt file
+将当前 PLIST 的条目导出为 .mapanime2.txt 文件
+
 :Map Tile Animation Type 2 Palette Sub-Table
 地图图块动画类型2 调色板子表
 


### PR DESCRIPTION
## Summary
- Extracts four static Core helpers from WinForms `MapTileAnimation2Form` so the Avalonia view can drive `Bulk Import` / `Bulk Export` / `Data Expansion (entry)` / `Data Expansion (palette)` headlessly (closes #524).
- Adds three no-undo overloads to `RecycleAddress` (`WriteAmbient`, `WriteAndWritePointerAmbient`, `BlackOutAmbient`) so the new helpers consume the ambient undo scope and avoid the double-record pitfall the explicit-undo overloads produce when run inside `ROM.BeginUndoScope`.
- Flips the four affordance buttons in `MapTileAnimation2View.axaml` to enabled, wires the click handlers against the Core helpers via `_undoService.Begin/Commit/Rollback`, and inverts the parity test that previously required `IsEnabled="False"`.

## Plan Reference
Implements the accepted plan (v4) at https://github.com/laqieer/FEBuilderGBA/issues/524#issuecomment-4533045133.

Copilot CLI signed off the plan: https://github.com/laqieer/FEBuilderGBA/issues/524#issuecomment-4533210250.

## Scope
Closes #524.
Ref #426 (gap-sweep parity fix), #374 (gap-sweep methodology).

## Screenshots
![MapTileAnimation2 editor on FE8U](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/pr-524-maptileanim2-bulk.png?raw=1)

Real Avalonia GUI capture of `MapTileAnimation2View` against `roms/FE8U.gba`, taken via `tools/WinCapture` (PrintWindow API). Shows the populated filter combo / address list with palette color swatches, the selection bar, the edit panel (Palette Data Pointer / Animation Interval / Data Count / Start Palette Index / Unknown), and the start of the Palette Sub-Table (`0x00 GBA=0x0016`). The four Bulk + Expand affordance buttons sit below this viewport on a 1764x2060 (DPI-scaled) editor — their enabled state is asserted by the `View_BulkAndExpandButton_IsEnabledAndNoFollowupTooltip` parity test (all 30 MapTileAnimation2 tests passing).

Screenshot committed to master via docs PR #632.

## GUI Test Report

### Environment
- ROM: `roms/FE8U.gba`
- Editor/View: `MapTileAnimation2View` (Map Tile Animation Type 2 - Palette)
- Build: `dotnet build -c Release`

### Steps Performed
1. Launched the Avalonia app with `roms/FE8U.gba`.
2. Used PowerShell `UIAutomationClient` to locate the main window (process 67308) and invoke `Main_TileAnim2_Button` to open the MapTileAnimation2View.
3. Queried UIAutomation for the four affordance buttons by AutomationId and verified each one reports `IsEnabled=True` plus a non-zero bounding rectangle (so the buttons render and are clickable).
4. Captured the editor window via `tools/WinCapture` (PrintWindow API, works on locked screens).

### Test Results
| Test | Expected | Actual | Status |
|------|----------|--------|--------|
| MapTileAnimation2View opens against FE8U | Editor window appears with filter combo populated | Window opened; 15 PLIST entries listed with color swatches | PASS |
| `MapTileAnimation2_BulkImport_Button` enabled state | `IsEnabled=True` | UIAutomation: `enabled=True` rect=(949,1858,180x64) | PASS |
| `MapTileAnimation2_BulkExport_Button` enabled state | `IsEnabled=True` | UIAutomation: `enabled=True` rect=(1145,1858,176x64) | PASS |
| `MapTileAnimation2_ListExpand_Button` enabled state | `IsEnabled=True` | UIAutomation: `enabled=True` rect=(419,2432,492x64) | PASS |
| `MapTileAnimation2_NListExpand_Button` enabled state | `IsEnabled=True` | UIAutomation: `enabled=True` rect=(967,1744,226x64) | PASS |
| First PLIST entry loaded with palette data | List displays `0x00 Palette Interval=13` etc. | Screenshot confirms | PASS |
| Palette color swatches render | `ColorSwatchLoader` paints each row's first palette color | Visible in screenshot (teal, mauve, pink, green) | PASS |

### Verdict
PASS — editor opens, populates real ROM data, and the four #524 affordance buttons are visibly enabled per UIAutomation. The Core helpers + view wiring drive the bulk and expansion flows. Headless tests cover the BulkImport / BulkExport / Expand round-trip + the undo single-source recording.

## Test plan
- [x] `MapTileAnimation2Core.BulkExport` headless test passes (`BulkExport_WritesExpectedTsv`, `BulkExport_WithUnsafeBase_ReturnsError`)
- [x] `MapTileAnimation2Core.BulkImport` round-trip headless test passes (`BulkImport_RoundTripsViaExport`)
- [x] `MapTileAnimation2Core.BulkImport` WF parity for malformed lines (`BulkImport_SkipsMalformedLinesPerWfParity`)
- [x] `MapTileAnimation2Core.BulkImport` works with no `CoreState.AppendBinaryData` callback (`BulkImport_WorksWithoutAppendBinaryDataCallback`)
- [x] `MapTileAnimation2Core.BulkImport` records each ROM write once (no double-record) under an ambient undo scope (`BulkImport_DoesNotDoubleRecordUndo`)
- [x] `MapTileAnimation2Core.BulkImport` rollback restores the original pointer (`BulkImport_RollbackRestoresOriginalPointer`)
- [x] `MapTileAnimation2Core.ExpandEntryList` grows the table + `ScanEntries` returns `newCount` rows (`ExpandEntryList_AllocatesAndRepoints`)
- [x] `MapTileAnimation2Core.ExpandEntryList` refuses shrinks and zero-oldCount (`ExpandEntryList_RefusesShrinks`, `ExpandEntryList_RefusesZeroOldCount`)
- [x] `MapTileAnimation2Core.ExpandPaletteRowList` grows palette block with row-0 clones (`ExpandPaletteRowList_AllocatesAndRepoints`)
- [x] `MapTileAnimation2Core.ExpandPaletteRowList` refuses shrinks and zero-oldCount (`ExpandPaletteRowList_RefusesShrinks`, `ExpandPaletteRowList_RefusesZeroOldCount`)
- [x] Avalonia parity test inverted: `View_BulkAndExpandButton_IsEnabledAndNoFollowupTooltip` passes (4 InlineData rows)
- [x] Avalonia VM tests `ViewModel_BulkExport_WritesFile`, `ViewModel_BulkImport_RoundTrips`, `ViewModel_ExpandEntryList_GrowsTable`, `ViewModel_ExpandPaletteRowList_GrowsBlock` all pass
- [x] All 1796 Core tests pass (no regressions in `dotnet test FEBuilderGBA.Core.Tests/`)
- [x] All 6583 Avalonia tests pass (no regressions in `dotnet test FEBuilderGBA.Avalonia.Tests/`)
- [x] `MapTileAnimation2View` opens with real ROM data and the four affordance buttons render enabled (UIAutomation verification + screenshot)
- [x] `config/translate/{ja,zh}.txt` updated with translations for the 4 new tooltip strings (L10nCoverageTest passes)

## Known limitations
- The MapTileAnimation2View window is 1764x2060 (DPI-scaled) which exceeds the test machine's 1080-tall screen, so the screenshot shows the top half of the editor. The bulk + expand button states are verified via UIAutomation queries (see GUI Test Report) and the inverted parity test.
- GIF export of the animation remains WinForms-coupled (uses `System.Drawing.Bitmap` + `ImageUtilAnimeGif`) — explicitly out of scope per the issue body.
- The PLIST table repoint (WF `MapPointerForm.Write_Plsit`) is not extracted; only the entry-table + palette-row expansion is in scope per the issue body.

Generated with Claude Code (claude-opus-4-7[1m])
