### PR TITLE
chore: add .claude.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ docs/avalonia-gaps/*-screenshots/**/av/
 # IDE / editor
 .vs/
 .claude/*
+.claude.json
 !.claude/skills/
 FEBuilderGBA/FEBuilderGBA.csproj.user
 


### PR DESCRIPTION
## Summary

Adds the literal filename `.claude.json` to the root `.gitignore`, right after the existing `.claude/*` rule. Claude Code auto-creates this session-state file at the repo root, and the existing rule only matched the `.claude/` directory — so the file kept appearing as untracked in `git status`.

Closes #646.

## Scope

- One-line change in `.gitignore` (+1, -0)
- No code, no tests, no docs, no CI changes

## Plan

See [plan comment on #646](https://github.com/laqieer/FEBuilderGBA/issues/646#issuecomment-4544336375).

**Copilot CLI plan-review skipped** — per the workflow, plan-review is optional for one-line chore changes (no logic, no functional impact). Noted here in the PR body.

## Test plan

- [x] `git check-ignore -v .claude.json` resolves to `.gitignore:77:.claude.json` (verified locally — see commit message and worktree output)
- [x] `git status` in a clean checkout no longer lists `.claude.json` as untracked (verified locally)
- [x] No unit/E2E tests required — pure ignore-rule change, no runtime code touched
- [x] Screenshot waived — chore PR per `feedback_screenshot_proof.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 4.7 (1M context)