### PR TITLE
feat(avalonia): migrate 5 read-only editors to EditorTopBar (#668 partial)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ClassOPDemoParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ClassOPDemoParityTests.cs
@@ -61,10 +61,16 @@ public class ClassOPDemoParityTests
     public void View_HasFilterAndReloadBar()
     {
         string axaml = ReadAxaml();
-        Assert.Contains("AutomationId=\"ClassOPDemo_ReadStart_Input\"", axaml);
-        Assert.Contains("AutomationId=\"ClassOPDemo_ReadCount_Input\"", axaml);
+        // #668: NUD-based ReadStart/ReadCount inputs became read-only
+        // TextBlock slots inside the unified EditorTopBar control. The
+        // *_Input AutomationIds are now *_Label; the ReloadList_Button id
+        // is preserved.
+        Assert.Contains("AutomationId=\"ClassOPDemo_ReadStart_Label\"", axaml);
+        Assert.Contains("AutomationId=\"ClassOPDemo_ReadCount_Label\"", axaml);
         Assert.Contains("AutomationId=\"ClassOPDemo_ReloadList_Button\"", axaml);
-        Assert.Contains("Click=\"ReloadList_Click\"", axaml);
+        // The Reload routed event now bubbles via EditorTopBar; the
+        // host code-behind wires it through OnTopBarReloadRequested.
+        Assert.Contains("ReloadRequested=\"OnTopBarReloadRequested\"", axaml);
     }
 
     [Fact]
@@ -444,11 +450,28 @@ public class ClassOPDemoParityTests
                 $"WF-only label '{wfLabel}' must be in the coverage map.");
 
             // The English label must appear in the AXAML (either as
-            // Content=, Header=, Text=, or inside a KnownGap reason).
+            // Content=, Header=, Text=, an EditorTopBar slot-label
+            // override, or inside a KnownGap reason).
+            // #668: Start Address / Read Count / Reload labels migrated
+            // into EditorTopBar styled-property overrides. Accept the
+            // *Label="<en>" / *Label="<en>:" / ReloadButtonText="<en>"
+            // forms; for "Reload" the EditorTopBar default ReloadButtonText
+            // is "Reload" so the presence of <controls:EditorTopBar>
+            // counts as covering that label.
+            bool labelInEditorTopBarDefault =
+                (enLabel == "Reload" || enLabel == "Start Address" || enLabel == "Read Count")
+                && axaml.Contains("<controls:EditorTopBar", StringComparison.Ordinal);
+
             bool found =
                 axaml.Contains($"Content=\"{enLabel}\"", StringComparison.Ordinal)
                 || axaml.Contains($"Header=\"{enLabel}\"", StringComparison.Ordinal)
                 || axaml.Contains($"Text=\"{enLabel}\"", StringComparison.Ordinal)
+                || axaml.Contains($"StartAddressLabel=\"{enLabel}\"", StringComparison.Ordinal)
+                || axaml.Contains($"StartAddressLabel=\"{enLabel}:\"", StringComparison.Ordinal)
+                || axaml.Contains($"ReadCountLabel=\"{enLabel}\"", StringComparison.Ordinal)
+                || axaml.Contains($"ReadCountLabel=\"{enLabel}:\"", StringComparison.Ordinal)
+                || axaml.Contains($"ReloadButtonText=\"{enLabel}\"", StringComparison.Ordinal)
+                || labelInEditorTopBarDefault
                 || axaml.Contains($"KnownGap: {wfLabel}", StringComparison.Ordinal);
 
             Assert.True(found,

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/EDFE7ParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/EDFE7ParityTests.cs
@@ -98,8 +98,8 @@ public class EDFE7ParityTests
         // and ed_3c_pointer is DIRECT BASE so we can't relocate the table).
         string axaml = ReadAxaml();
 
-        Assert.Contains("AutomationId=\"EDFE7_Lyn_TopAddress_Input\"", axaml);
-        Assert.Contains("AutomationId=\"EDFE7_Lyn_ReadCount_Input\"", axaml);
+        Assert.Contains("AutomationId=\"EDFE7_Lyn_TopAddress_Label\"", axaml);
+        Assert.Contains("AutomationId=\"EDFE7_Lyn_ReadCount_Label\"", axaml);
         Assert.Contains("AutomationId=\"EDFE7_Lyn_Reload_Button\"", axaml);
         Assert.Contains("AutomationId=\"EDFE7_Lyn_Address_Input\"", axaml);
         Assert.Contains("AutomationId=\"EDFE7_Lyn_BlockSize_Input\"", axaml);
@@ -128,8 +128,8 @@ public class EDFE7ParityTests
     {
         string axaml = ReadAxaml();
 
-        Assert.Contains("AutomationId=\"EDFE7_Retreat_TopAddress_Input\"", axaml);
-        Assert.Contains("AutomationId=\"EDFE7_Retreat_ReadCount_Input\"", axaml);
+        Assert.Contains("AutomationId=\"EDFE7_Retreat_TopAddress_Label\"", axaml);
+        Assert.Contains("AutomationId=\"EDFE7_Retreat_ReadCount_Label\"", axaml);
         Assert.Contains("AutomationId=\"EDFE7_Retreat_Reload_Button\"", axaml);
         Assert.Contains("AutomationId=\"EDFE7_Retreat_Address_Input\"", axaml);
         Assert.Contains("AutomationId=\"EDFE7_Retreat_BlockSize_Input\"", axaml);
@@ -155,8 +155,8 @@ public class EDFE7ParityTests
     {
         string axaml = ReadAxaml();
 
-        Assert.Contains("AutomationId=\"EDFE7_Epithet_TopAddress_Input\"", axaml);
-        Assert.Contains("AutomationId=\"EDFE7_Epithet_ReadCount_Input\"", axaml);
+        Assert.Contains("AutomationId=\"EDFE7_Epithet_TopAddress_Label\"", axaml);
+        Assert.Contains("AutomationId=\"EDFE7_Epithet_ReadCount_Label\"", axaml);
         Assert.Contains("AutomationId=\"EDFE7_Epithet_Reload_Button\"", axaml);
         Assert.Contains("AutomationId=\"EDFE7_Epithet_Address_Input\"", axaml);
         Assert.Contains("AutomationId=\"EDFE7_Epithet_BlockSize_Input\"", axaml);
@@ -177,8 +177,8 @@ public class EDFE7ParityTests
     {
         string axaml = ReadAxaml();
 
-        Assert.Contains("AutomationId=\"EDFE7_Epilogue_TopAddress_Input\"", axaml);
-        Assert.Contains("AutomationId=\"EDFE7_Epilogue_ReadCount_Input\"", axaml);
+        Assert.Contains("AutomationId=\"EDFE7_Epilogue_TopAddress_Label\"", axaml);
+        Assert.Contains("AutomationId=\"EDFE7_Epilogue_ReadCount_Label\"", axaml);
         Assert.Contains("AutomationId=\"EDFE7_Epilogue_Reload_Button\"", axaml);
         Assert.Contains("AutomationId=\"EDFE7_Epilogue_Address_Input\"", axaml);
         Assert.Contains("AutomationId=\"EDFE7_Epilogue_BlockSize_Input\"", axaml);

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/EDParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/EDParityTests.cs
@@ -89,8 +89,10 @@ public class EDParityTests
         string axaml = ReadAxaml();
 
         // Tab header bar
-        Assert.Contains("AutomationId=\"ED_Retreat_TopAddress_Input\"", axaml);
-        Assert.Contains("AutomationId=\"ED_Retreat_ReadCount_Input\"", axaml);
+        // #668: NUD-based TopAddress/ReadCount inputs migrated to read-only
+        // EditorTopBar slots; *_Input ids renamed to *_Label (display-only).
+        Assert.Contains("AutomationId=\"ED_Retreat_TopAddress_Label\"", axaml);
+        Assert.Contains("AutomationId=\"ED_Retreat_ReadCount_Label\"", axaml);
         Assert.Contains("AutomationId=\"ED_Retreat_Reload_Button\"", axaml);
         Assert.Contains("AutomationId=\"ED_Retreat_Address_Input\"", axaml);
         Assert.Contains("AutomationId=\"ED_Retreat_BlockSize_Input\"", axaml);
@@ -116,8 +118,10 @@ public class EDParityTests
         string axaml = ReadAxaml();
 
         // Tab header bar
-        Assert.Contains("AutomationId=\"ED_Epithet_TopAddress_Input\"", axaml);
-        Assert.Contains("AutomationId=\"ED_Epithet_ReadCount_Input\"", axaml);
+        // #668: NUD-based TopAddress/ReadCount inputs migrated to read-only
+        // EditorTopBar slots; *_Input ids renamed to *_Label.
+        Assert.Contains("AutomationId=\"ED_Epithet_TopAddress_Label\"", axaml);
+        Assert.Contains("AutomationId=\"ED_Epithet_ReadCount_Label\"", axaml);
         Assert.Contains("AutomationId=\"ED_Epithet_Reload_Button\"", axaml);
         Assert.Contains("AutomationId=\"ED_Epithet_Address_Input\"", axaml);
         Assert.Contains("AutomationId=\"ED_Epithet_BlockSize_Input\"", axaml);
@@ -143,8 +147,10 @@ public class EDParityTests
         string axaml = ReadAxaml();
 
         // Tab header bar
-        Assert.Contains("AutomationId=\"ED_Epilogue_TopAddress_Input\"", axaml);
-        Assert.Contains("AutomationId=\"ED_Epilogue_ReadCount_Input\"", axaml);
+        // #668: NUD-based TopAddress/ReadCount inputs migrated to read-only
+        // EditorTopBar slots; *_Input ids renamed to *_Label.
+        Assert.Contains("AutomationId=\"ED_Epilogue_TopAddress_Label\"", axaml);
+        Assert.Contains("AutomationId=\"ED_Epilogue_ReadCount_Label\"", axaml);
         Assert.Contains("AutomationId=\"ED_Epilogue_Reload_Button\"", axaml);
         Assert.Contains("AutomationId=\"ED_Epilogue_Address_Input\"", axaml);
         Assert.Contains("AutomationId=\"ED_Epilogue_BlockSize_Input\"", axaml);

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/EventMapChangeParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/EventMapChangeParityTests.cs
@@ -62,8 +62,11 @@ public class EventMapChangeParityTests
 
         string[] required = {
             // Read-config bar
-            "EventMapChange_ReadStart_Input",
-            "EventMapChange_ReadCount_Input",
+            // #668: NUD-based ReadStart/ReadCount inputs migrated to
+            // read-only EditorTopBar slots; *_Input ids renamed to
+            // *_Label.
+            "EventMapChange_ReadStart_Label",
+            "EventMapChange_ReadCount_Label",
             "EventMapChange_ReloadList_Button",
             // Address panel
             "EventMapChange_BlockSize_Input",

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/WorldMapImageParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/WorldMapImageParityTests.cs
@@ -141,8 +141,13 @@ public class WorldMapImageParityTests
         Assert.Contains("AutomationId=\"WorldMapImage_Border_BlockSize_Label\"", axaml);
         Assert.Contains("AutomationId=\"WorldMapImage_Border_Write_Button\"", axaml);
         // Read panel.
-        Assert.Contains("AutomationId=\"WorldMapImage_Border_ReadStartAddress_Input\"", axaml);
-        Assert.Contains("AutomationId=\"WorldMapImage_Border_ReadCount_Input\"", axaml);
+        // #668: NUD-based "ReadStartAddress" / "ReadCount" surfaces became
+        // read-only TextBlock slots inside the unified EditorTopBar, so the
+        // *_Input AutomationIds were renamed to *_Label (the values are
+        // now display-only). The Reload_Button and AddressListExpand_Button
+        // AutomationIds are preserved unchanged.
+        Assert.Contains("AutomationId=\"WorldMapImage_Border_ReadStartAddress_Label\"", axaml);
+        Assert.Contains("AutomationId=\"WorldMapImage_Border_ReadCount_Label\"", axaml);
         Assert.Contains("AutomationId=\"WorldMapImage_Border_Reload_Button\"", axaml);
         Assert.Contains("AutomationId=\"WorldMapImage_Border_AddressListExpand_Button\"", axaml);
     }
@@ -169,8 +174,10 @@ public class WorldMapImageParityTests
         Assert.Contains("AutomationId=\"WorldMapImage_IconData_SelectAddress_Label\"", axaml);
         Assert.Contains("AutomationId=\"WorldMapImage_IconData_BlockSize_Label\"", axaml);
         Assert.Contains("AutomationId=\"WorldMapImage_IconData_Write_Button\"", axaml);
-        Assert.Contains("AutomationId=\"WorldMapImage_IconData_ReadStartAddress_Input\"", axaml);
-        Assert.Contains("AutomationId=\"WorldMapImage_IconData_ReadCount_Input\"", axaml);
+        // #668: NUD inputs → EditorTopBar read-only Label slots (see
+        // Border-tab note above).
+        Assert.Contains("AutomationId=\"WorldMapImage_IconData_ReadStartAddress_Label\"", axaml);
+        Assert.Contains("AutomationId=\"WorldMapImage_IconData_ReadCount_Label\"", axaml);
         Assert.Contains("AutomationId=\"WorldMapImage_IconData_Reload_Button\"", axaml);
         Assert.Contains("AutomationId=\"WorldMapImage_IconData_AddressListExpand_Button\"", axaml);
     }

--- a/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml
@@ -22,23 +22,18 @@
   <!-- KnownGap: PatchAwareUI reason=Orphan ClassOPDemoForm constructor has zero PatchUtil calls; OPClassReelSort/Over255 affordances live in canonical OPClassDemoViewerView (PR #544). -->
   <Grid RowDefinitions="Auto,Auto,*" ColumnDefinitions="270,*">
 
-    <!-- ===== Row 0: Top filter / reload bar (mirrors WF panel1) ===== -->
-    <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
-      <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
-        <Label Content="Start Address" VerticalAlignment="Center" />
-        <NumericUpDown AutomationProperties.AutomationId="ClassOPDemo_ReadStart_Input"
-                       FormatString="0" Name="ReadStartAddressBox" Width="140"
-                       Minimum="0" Maximum="65535999"
-                       IsEnabled="False" VerticalAlignment="Center" />
-        <Label Content="Read Count" VerticalAlignment="Center" />
-        <NumericUpDown AutomationProperties.AutomationId="ClassOPDemo_ReadCount_Input"
-                       FormatString="0" Name="ReadCountBox" Width="80"
-                       Minimum="0" Maximum="500"
-                       IsEnabled="False" VerticalAlignment="Center" />
-        <Button AutomationProperties.AutomationId="ClassOPDemo_ReloadList_Button"
-                Name="ReloadListButton" Content="Reload" Click="ReloadList_Click" />
-      </StackPanel>
-    </Border>
+    <!-- ===== Row 0: Top filter / reload bar (mirrors WF panel1) =====
+         #668: migrated to unified EditorTopBar control. -->
+    <controls:EditorTopBar Grid.Row="0" Grid.ColumnSpan="2" Margin="4"
+                           Name="TopBar"
+                           AutomationProperties.AutomationId="ClassOPDemo_TopBar"
+                           ShowSize="False"
+                           StartAddressLabel="Start Address:"
+                           ReadCountLabel="Read Count:"
+                           StartAddressAutomationId="ClassOPDemo_ReadStart_Label"
+                           ReadCountAutomationId="ClassOPDemo_ReadCount_Label"
+                           ReloadAutomationId="ClassOPDemo_ReloadList_Button"
+                           ReloadRequested="OnTopBarReloadRequested" />
 
     <!-- ===== Row 1: Main address-write bar (mirrors WF AddressPanel) ===== -->
     <Border Grid.Row="1" Grid.Column="1" BorderBrush="Gray" BorderThickness="1" Margin="4">

--- a/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml.cs
@@ -140,10 +140,10 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 var items = _vm.LoadClassOPDemoList();
                 EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ClassIconLoader(items, i));
-                if (CoreState.ROM?.RomInfo != null)
+                if (CoreState.ROM?.RomInfo != null && TopBar != null)
                 {
-                    ReadStartAddressBox.Value = CoreState.ROM.RomInfo.op_class_demo_pointer;
-                    ReadCountBox.Value = items.Count;
+                    TopBar.StartAddressText = $"0x{CoreState.ROM.RomInfo.op_class_demo_pointer:X08}";
+                    TopBar.ReadCountText = items.Count.ToString();
                 }
             }
             catch (Exception ex)
@@ -470,7 +470,8 @@ namespace FEBuilderGBA.Avalonia.Views
         // Click handlers (all ROM writes wrapped in `_undoService`).
         // -----------------------------------------------------------------
 
-        void ReloadList_Click(object? sender, RoutedEventArgs e) => LoadList();
+        // #668: routed event from the unified EditorTopBar control.
+        void OnTopBarReloadRequested(object? sender, RoutedEventArgs e) => LoadList();
 
         void Write_Click(object? sender, RoutedEventArgs e)
         {

--- a/FEBuilderGBA.Avalonia/Views/EDFE7View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EDFE7View.axaml
@@ -22,24 +22,18 @@
     <TabItem AutomationProperties.AutomationId="EDFE7_Lyn_Tab" Header="Lyn Arc">
       <Grid RowDefinitions="Auto,Auto,*" ColumnDefinitions="260,*">
 
-        <!-- Row 0: Read-config bar (mirrors WF panel1) -->
-        <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
-          <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
-            <Label Content="Top Address" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="EDFE7_Lyn_TopAddress_Input"
-                           Name="Lyn_TopAddressBox" FormatString="0"
-                           Minimum="0" Maximum="4294967295" Width="130"
-                           IsEnabled="False" VerticalAlignment="Center" />
-            <Label Content="Read Count" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="EDFE7_Lyn_ReadCount_Input"
-                           Name="Lyn_ReadCountBox" FormatString="0"
-                           Minimum="0" Maximum="65535" Width="80"
-                           IsEnabled="False" VerticalAlignment="Center" />
-            <Button AutomationProperties.AutomationId="EDFE7_Lyn_Reload_Button"
-                    Name="Lyn_ReloadButton" Content="Reload"
-                    Click="ReloadLyn_Click" />
-          </StackPanel>
-        </Border>
+        <!-- Row 0: Read-config bar (mirrors WF panel1).
+             #668: migrated to unified EditorTopBar control. -->
+        <controls:EditorTopBar Grid.Row="0" Grid.ColumnSpan="2" Margin="4"
+                               Name="Lyn_TopBar"
+                               AutomationProperties.AutomationId="EDFE7_Lyn_TopBar"
+                               ShowSize="False"
+                               StartAddressLabel="Top Address:"
+                               ReadCountLabel="Read Count:"
+                               StartAddressAutomationId="EDFE7_Lyn_TopAddress_Label"
+                               ReadCountAutomationId="EDFE7_Lyn_ReadCount_Label"
+                               ReloadAutomationId="EDFE7_Lyn_Reload_Button"
+                               ReloadRequested="OnLynTopBarReloadRequested" />
 
         <!-- Row 1: Selection bar (mirrors WF AddressPanel) -->
         <Border Grid.Row="1" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4,0,4,4">
@@ -146,23 +140,17 @@
     <TabItem AutomationProperties.AutomationId="EDFE7_Retreat_Tab" Header="Retreat">
       <Grid RowDefinitions="Auto,Auto,*" ColumnDefinitions="260,*">
 
-        <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
-          <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
-            <Label Content="Top Address" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="EDFE7_Retreat_TopAddress_Input"
-                           Name="Retreat_TopAddressBox" FormatString="0"
-                           Minimum="0" Maximum="4294967295" Width="130"
-                           IsEnabled="False" VerticalAlignment="Center" />
-            <Label Content="Read Count" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="EDFE7_Retreat_ReadCount_Input"
-                           Name="Retreat_ReadCountBox" FormatString="0"
-                           Minimum="0" Maximum="65535" Width="80"
-                           IsEnabled="False" VerticalAlignment="Center" />
-            <Button AutomationProperties.AutomationId="EDFE7_Retreat_Reload_Button"
-                    Name="Retreat_ReloadButton" Content="Reload"
-                    Click="ReloadRetreat_Click" />
-          </StackPanel>
-        </Border>
+        <!-- #668: migrated to unified EditorTopBar control. -->
+        <controls:EditorTopBar Grid.Row="0" Grid.ColumnSpan="2" Margin="4"
+                               Name="Retreat_TopBar"
+                               AutomationProperties.AutomationId="EDFE7_Retreat_TopBar"
+                               ShowSize="False"
+                               StartAddressLabel="Top Address:"
+                               ReadCountLabel="Read Count:"
+                               StartAddressAutomationId="EDFE7_Retreat_TopAddress_Label"
+                               ReadCountAutomationId="EDFE7_Retreat_ReadCount_Label"
+                               ReloadAutomationId="EDFE7_Retreat_Reload_Button"
+                               ReloadRequested="OnRetreatTopBarReloadRequested" />
 
         <Border Grid.Row="1" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4,0,4,4">
           <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
@@ -254,23 +242,17 @@
     <TabItem AutomationProperties.AutomationId="EDFE7_Epithet_Tab" Header="Epithet">
       <Grid RowDefinitions="Auto,Auto,*" ColumnDefinitions="260,*">
 
-        <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
-          <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
-            <Label Content="Top Address" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="EDFE7_Epithet_TopAddress_Input"
-                           Name="Epithet_TopAddressBox" FormatString="0"
-                           Minimum="0" Maximum="4294967295" Width="130"
-                           IsEnabled="False" VerticalAlignment="Center" />
-            <Label Content="Read Count" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="EDFE7_Epithet_ReadCount_Input"
-                           Name="Epithet_ReadCountBox" FormatString="0"
-                           Minimum="0" Maximum="65535" Width="80"
-                           IsEnabled="False" VerticalAlignment="Center" />
-            <Button AutomationProperties.AutomationId="EDFE7_Epithet_Reload_Button"
-                    Name="Epithet_ReloadButton" Content="Reload"
-                    Click="ReloadEpithet_Click" />
-          </StackPanel>
-        </Border>
+        <!-- #668: migrated to unified EditorTopBar control. -->
+        <controls:EditorTopBar Grid.Row="0" Grid.ColumnSpan="2" Margin="4"
+                               Name="Epithet_TopBar"
+                               AutomationProperties.AutomationId="EDFE7_Epithet_TopBar"
+                               ShowSize="False"
+                               StartAddressLabel="Top Address:"
+                               ReadCountLabel="Read Count:"
+                               StartAddressAutomationId="EDFE7_Epithet_TopAddress_Label"
+                               ReadCountAutomationId="EDFE7_Epithet_ReadCount_Label"
+                               ReloadAutomationId="EDFE7_Epithet_Reload_Button"
+                               ReloadRequested="OnEpithetTopBarReloadRequested" />
 
         <Border Grid.Row="1" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4,0,4,4">
           <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
@@ -354,31 +336,33 @@
       <Grid RowDefinitions="Auto,Auto,*" ColumnDefinitions="260,*">
 
         <!-- Row 0: Read-config bar - includes Eliwood/Hector filter combo
-             (FE7-specific names - NOT Eirika/Ephraim from FE8). -->
-        <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
-          <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
-            <Label Content="Filter:" VerticalAlignment="Center" />
-            <ComboBox AutomationProperties.AutomationId="EDFE7_Epilogue_Filter_Combo"
-                      Name="Epilogue_FilterCombo" Width="160" SelectedIndex="0"
-                      SelectionChanged="EpilogueFilter_SelectionChanged">
-              <ComboBoxItem Name="Epilogue_FilterItem_Eliwood"><TextBlock Text="Eliwood Route" /></ComboBoxItem>
-              <ComboBoxItem Name="Epilogue_FilterItem_Hector"><TextBlock Text="Hector Route" /></ComboBoxItem>
-            </ComboBox>
-            <Label Content="Top Address" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="EDFE7_Epilogue_TopAddress_Input"
-                           Name="Epilogue_TopAddressBox" FormatString="0"
-                           Minimum="0" Maximum="4294967295" Width="130"
-                           IsEnabled="False" VerticalAlignment="Center" />
-            <Label Content="Read Count" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="EDFE7_Epilogue_ReadCount_Input"
-                           Name="Epilogue_ReadCountBox" FormatString="0"
-                           Minimum="0" Maximum="65535" Width="80"
-                           IsEnabled="False" VerticalAlignment="Center" />
-            <Button AutomationProperties.AutomationId="EDFE7_Epilogue_Reload_Button"
-                    Name="Epilogue_ReloadButton" Content="Reload"
-                    Click="ReloadEpilogue_Click" />
-          </StackPanel>
-        </Border>
+             (FE7-specific names - NOT Eirika/Ephraim from FE8).
+             #668: address/count/reload portion migrated to unified
+             EditorTopBar control; Filter combo stays external (it's a
+             route-picker combobox, not the inline-filter TextBox the
+             EditorTopBar exposes). -->
+        <StackPanel Grid.Row="0" Grid.ColumnSpan="2" Margin="4" Spacing="2">
+          <Border BorderBrush="Gray" BorderThickness="1">
+            <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
+              <Label Content="Filter:" VerticalAlignment="Center" />
+              <ComboBox AutomationProperties.AutomationId="EDFE7_Epilogue_Filter_Combo"
+                        Name="Epilogue_FilterCombo" Width="160" SelectedIndex="0"
+                        SelectionChanged="EpilogueFilter_SelectionChanged">
+                <ComboBoxItem Name="Epilogue_FilterItem_Eliwood"><TextBlock Text="Eliwood Route" /></ComboBoxItem>
+                <ComboBoxItem Name="Epilogue_FilterItem_Hector"><TextBlock Text="Hector Route" /></ComboBoxItem>
+              </ComboBox>
+            </StackPanel>
+          </Border>
+          <controls:EditorTopBar Name="Epilogue_TopBar"
+                                 AutomationProperties.AutomationId="EDFE7_Epilogue_TopBar"
+                                 ShowSize="False"
+                                 StartAddressLabel="Top Address:"
+                                 ReadCountLabel="Read Count:"
+                                 StartAddressAutomationId="EDFE7_Epilogue_TopAddress_Label"
+                                 ReadCountAutomationId="EDFE7_Epilogue_ReadCount_Label"
+                                 ReloadAutomationId="EDFE7_Epilogue_Reload_Button"
+                                 ReloadRequested="OnEpilogueTopBarReloadRequested" />
+        </StackPanel>
 
         <Border Grid.Row="1" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4,0,4,4">
           <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">

--- a/FEBuilderGBA.Avalonia/Views/EDFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EDFE7View.axaml.cs
@@ -70,12 +70,15 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             var items = _vm.LoadLynList();
             Lyn_EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitByIdLoader(items, i));
-            Lyn_ReadCountBox.Value = items.Count;
-            var rom = CoreState.ROM;
-            // For Lyn ed_3c_pointer IS the table base (NOT a pointer field);
-            // display it as the top address directly without p32().
-            if (rom?.RomInfo != null && rom.RomInfo.ed_3c_pointer != 0)
-                Lyn_TopAddressBox.Value = rom.RomInfo.ed_3c_pointer;
+            if (Lyn_TopBar != null)
+            {
+                Lyn_TopBar.ReadCountText = items.Count.ToString();
+                var rom = CoreState.ROM;
+                // For Lyn ed_3c_pointer IS the table base (NOT a pointer field);
+                // display it as the top address directly without p32().
+                if (rom?.RomInfo != null && rom.RomInfo.ed_3c_pointer != 0)
+                    Lyn_TopBar.StartAddressText = $"0x{rom.RomInfo.ed_3c_pointer:X08}";
+            }
         }
 
         void OnLynSelected(uint addr)
@@ -123,7 +126,8 @@ namespace FEBuilderGBA.Avalonia.Views
             catch { Lyn_RetreatTextLabel.Text = ""; }
         }
 
-        void ReloadLyn_Click(object? sender, RoutedEventArgs e)
+        // #668: routed event from the unified EditorTopBar control.
+        void OnLynTopBarReloadRequested(object? sender, RoutedEventArgs e)
         {
             try { LoadLynList(); }
             catch (Exception ex) { Log.Error("EDFE7View.ReloadLyn failed: {0}", ex.Message); }
@@ -187,10 +191,13 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             var items = _vm.LoadRetreatList();
             Retreat_EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitByIdLoader(items, i));
-            Retreat_ReadCountBox.Value = items.Count;
-            var rom = CoreState.ROM;
-            if (rom?.RomInfo != null && rom.RomInfo.ed_1_pointer != 0)
-                Retreat_TopAddressBox.Value = rom.p32(rom.RomInfo.ed_1_pointer);
+            if (Retreat_TopBar != null)
+            {
+                Retreat_TopBar.ReadCountText = items.Count.ToString();
+                var rom = CoreState.ROM;
+                if (rom?.RomInfo != null && rom.RomInfo.ed_1_pointer != 0)
+                    Retreat_TopBar.StartAddressText = $"0x{rom.p32(rom.RomInfo.ed_1_pointer):X08}";
+            }
         }
 
         void OnRetreatSelected(uint addr)
@@ -213,7 +220,8 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
-        void ReloadRetreat_Click(object? sender, RoutedEventArgs e)
+        // #668: routed event from the unified EditorTopBar control.
+        void OnRetreatTopBarReloadRequested(object? sender, RoutedEventArgs e)
         {
             try { LoadRetreatList(); }
             catch (Exception ex) { Log.Error("EDFE7View.ReloadRetreat failed: {0}", ex.Message); }
@@ -301,10 +309,13 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             var items = _vm.LoadEpithetList();
             Epithet_EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitByIdLoader(items, i));
-            Epithet_ReadCountBox.Value = items.Count;
-            var rom = CoreState.ROM;
-            if (rom?.RomInfo != null && rom.RomInfo.ed_2_pointer != 0)
-                Epithet_TopAddressBox.Value = rom.p32(rom.RomInfo.ed_2_pointer);
+            if (Epithet_TopBar != null)
+            {
+                Epithet_TopBar.ReadCountText = items.Count.ToString();
+                var rom = CoreState.ROM;
+                if (rom?.RomInfo != null && rom.RomInfo.ed_2_pointer != 0)
+                    Epithet_TopBar.StartAddressText = $"0x{rom.p32(rom.RomInfo.ed_2_pointer):X08}";
+            }
         }
 
         void OnEpithetSelected(uint addr)
@@ -338,7 +349,8 @@ namespace FEBuilderGBA.Avalonia.Views
             catch { Epithet_EpithetTextLabel.Text = ""; }
         }
 
-        void ReloadEpithet_Click(object? sender, RoutedEventArgs e)
+        // #668: routed event from the unified EditorTopBar control.
+        void OnEpithetTopBarReloadRequested(object? sender, RoutedEventArgs e)
         {
             try { LoadEpithetList(); }
             catch (Exception ex) { Log.Error("EDFE7View.ReloadEpithet failed: {0}", ex.Message); }
@@ -424,14 +436,16 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             var items = _vm.LoadEpilogueList();
             Epilogue_EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitByIdLoader(items, i));
-            Epilogue_ReadCountBox.Value = items.Count;
+            if (Epilogue_TopBar != null)
+                Epilogue_TopBar.ReadCountText = items.Count.ToString();
             var rom = CoreState.ROM;
-            if (rom?.RomInfo != null)
+            if (rom?.RomInfo != null && Epilogue_TopBar != null)
             {
                 uint ptr = _vm.EpilogueRoute == EDFE7ViewModel.EpilogueRouteKind.Hector
                     ? rom.RomInfo.ed_3b_pointer
                     : rom.RomInfo.ed_3a_pointer;
-                Epilogue_TopAddressBox.Value = ptr != 0 ? rom.p32(ptr) : 0;
+                uint resolved = ptr != 0 ? rom.p32(ptr) : 0;
+                Epilogue_TopBar.StartAddressText = $"0x{resolved:X08}";
             }
         }
 
@@ -502,7 +516,8 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex) { Log.Error("EDFE7View.EpilogueFilter_SelectionChanged failed: {0}", ex.Message); }
         }
 
-        void ReloadEpilogue_Click(object? sender, RoutedEventArgs e)
+        // #668: routed event from the unified EditorTopBar control.
+        void OnEpilogueTopBarReloadRequested(object? sender, RoutedEventArgs e)
         {
             try { LoadEpilogueList(); }
             catch (Exception ex) { Log.Error("EDFE7View.ReloadEpilogue failed: {0}", ex.Message); }

--- a/FEBuilderGBA.Avalonia/Views/EDView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EDView.axaml
@@ -17,24 +17,18 @@
     <TabItem AutomationProperties.AutomationId="ED_Retreat_Tab" Header="Retreat">
       <Grid RowDefinitions="Auto,Auto,*" ColumnDefinitions="260,*">
 
-        <!-- Row 0: Read-config bar (mirrors WF panel1) -->
-        <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
-          <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
-            <Label Content="Top Address" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="ED_Retreat_TopAddress_Input"
-                           Name="Retreat_TopAddressBox" FormatString="0"
-                           Minimum="0" Maximum="4294967295" Width="130"
-                           IsEnabled="False" VerticalAlignment="Center" />
-            <Label Content="Read Count" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="ED_Retreat_ReadCount_Input"
-                           Name="Retreat_ReadCountBox" FormatString="0"
-                           Minimum="0" Maximum="65535" Width="80"
-                           IsEnabled="False" VerticalAlignment="Center" />
-            <Button AutomationProperties.AutomationId="ED_Retreat_Reload_Button"
-                    Name="Retreat_ReloadButton" Content="Reload"
-                    Click="ReloadRetreat_Click" />
-          </StackPanel>
-        </Border>
+        <!-- Row 0: Read-config bar (mirrors WF panel1).
+             #668: migrated to unified EditorTopBar control. -->
+        <controls:EditorTopBar Grid.Row="0" Grid.ColumnSpan="2" Margin="4"
+                               Name="Retreat_TopBar"
+                               AutomationProperties.AutomationId="ED_Retreat_TopBar"
+                               ShowSize="False"
+                               StartAddressLabel="Top Address:"
+                               ReadCountLabel="Read Count:"
+                               StartAddressAutomationId="ED_Retreat_TopAddress_Label"
+                               ReadCountAutomationId="ED_Retreat_ReadCount_Label"
+                               ReloadAutomationId="ED_Retreat_Reload_Button"
+                               ReloadRequested="OnRetreatTopBarReloadRequested" />
 
         <!-- Row 1: Selection bar (mirrors WF AddressPanel) -->
         <Border Grid.Row="1" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4,0,4,4">
@@ -127,24 +121,18 @@
     <TabItem AutomationProperties.AutomationId="ED_Epithet_Tab" Header="Epithet">
       <Grid RowDefinitions="Auto,Auto,*" ColumnDefinitions="260,*">
 
-        <!-- Row 0: Read-config bar -->
-        <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
-          <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
-            <Label Content="Top Address" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="ED_Epithet_TopAddress_Input"
-                           Name="Epithet_TopAddressBox" FormatString="0"
-                           Minimum="0" Maximum="4294967295" Width="130"
-                           IsEnabled="False" VerticalAlignment="Center" />
-            <Label Content="Read Count" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="ED_Epithet_ReadCount_Input"
-                           Name="Epithet_ReadCountBox" FormatString="0"
-                           Minimum="0" Maximum="65535" Width="80"
-                           IsEnabled="False" VerticalAlignment="Center" />
-            <Button AutomationProperties.AutomationId="ED_Epithet_Reload_Button"
-                    Name="Epithet_ReloadButton" Content="Reload"
-                    Click="ReloadEpithet_Click" />
-          </StackPanel>
-        </Border>
+        <!-- Row 0: Read-config bar.
+             #668: migrated to unified EditorTopBar control. -->
+        <controls:EditorTopBar Grid.Row="0" Grid.ColumnSpan="2" Margin="4"
+                               Name="Epithet_TopBar"
+                               AutomationProperties.AutomationId="ED_Epithet_TopBar"
+                               ShowSize="False"
+                               StartAddressLabel="Top Address:"
+                               ReadCountLabel="Read Count:"
+                               StartAddressAutomationId="ED_Epithet_TopAddress_Label"
+                               ReadCountAutomationId="ED_Epithet_ReadCount_Label"
+                               ReloadAutomationId="ED_Epithet_Reload_Button"
+                               ReloadRequested="OnEpithetTopBarReloadRequested" />
 
         <!-- Row 1: Selection bar -->
         <Border Grid.Row="1" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4,0,4,4">
@@ -233,31 +221,33 @@
     <TabItem AutomationProperties.AutomationId="ED_Epilogue_Tab" Header="Epilogue">
       <Grid RowDefinitions="Auto,Auto,*" ColumnDefinitions="260,*">
 
-        <!-- Row 0: Read-config bar - includes Eirika/Ephraim filter combo -->
-        <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
-          <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
-            <Label Content="Filter:" VerticalAlignment="Center" />
-            <ComboBox AutomationProperties.AutomationId="ED_Epilogue_Filter_Combo"
-                      Name="Epilogue_FilterCombo" Width="160" SelectedIndex="0"
-                      SelectionChanged="EpilogueFilter_SelectionChanged">
-              <ComboBoxItem Name="Epilogue_FilterItem_Eirika"><TextBlock Text="Eirika Route" /></ComboBoxItem>
-              <ComboBoxItem Name="Epilogue_FilterItem_Ephraim"><TextBlock Text="Ephraim Route" /></ComboBoxItem>
-            </ComboBox>
-            <Label Content="Top Address" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="ED_Epilogue_TopAddress_Input"
-                           Name="Epilogue_TopAddressBox" FormatString="0"
-                           Minimum="0" Maximum="4294967295" Width="130"
-                           IsEnabled="False" VerticalAlignment="Center" />
-            <Label Content="Read Count" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="ED_Epilogue_ReadCount_Input"
-                           Name="Epilogue_ReadCountBox" FormatString="0"
-                           Minimum="0" Maximum="65535" Width="80"
-                           IsEnabled="False" VerticalAlignment="Center" />
-            <Button AutomationProperties.AutomationId="ED_Epilogue_Reload_Button"
-                    Name="Epilogue_ReloadButton" Content="Reload"
-                    Click="ReloadEpilogue_Click" />
-          </StackPanel>
-        </Border>
+        <!-- Row 0: Read-config bar - includes Eirika/Ephraim filter combo.
+             #668: address/count/reload portion migrated to unified
+             EditorTopBar control; Filter combo stays external (it's a
+             route-picker combobox, not the inline-filter TextBox the
+             EditorTopBar exposes). -->
+        <StackPanel Grid.Row="0" Grid.ColumnSpan="2" Margin="4" Spacing="2">
+          <Border BorderBrush="Gray" BorderThickness="1">
+            <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
+              <Label Content="Filter:" VerticalAlignment="Center" />
+              <ComboBox AutomationProperties.AutomationId="ED_Epilogue_Filter_Combo"
+                        Name="Epilogue_FilterCombo" Width="160" SelectedIndex="0"
+                        SelectionChanged="EpilogueFilter_SelectionChanged">
+                <ComboBoxItem Name="Epilogue_FilterItem_Eirika"><TextBlock Text="Eirika Route" /></ComboBoxItem>
+                <ComboBoxItem Name="Epilogue_FilterItem_Ephraim"><TextBlock Text="Ephraim Route" /></ComboBoxItem>
+              </ComboBox>
+            </StackPanel>
+          </Border>
+          <controls:EditorTopBar Name="Epilogue_TopBar"
+                                 AutomationProperties.AutomationId="ED_Epilogue_TopBar"
+                                 ShowSize="False"
+                                 StartAddressLabel="Top Address:"
+                                 ReadCountLabel="Read Count:"
+                                 StartAddressAutomationId="ED_Epilogue_TopAddress_Label"
+                                 ReadCountAutomationId="ED_Epilogue_ReadCount_Label"
+                                 ReloadAutomationId="ED_Epilogue_Reload_Button"
+                                 ReloadRequested="OnEpilogueTopBarReloadRequested" />
+        </StackPanel>
 
         <!-- Row 1: Selection bar -->
         <Border Grid.Row="1" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4,0,4,4">

--- a/FEBuilderGBA.Avalonia/Views/EDView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EDView.axaml.cs
@@ -86,10 +86,13 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             var items = _vm.LoadRetreatList();
             Retreat_EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitByIdLoader(items, i));
-            Retreat_ReadCountBox.Value = items.Count;
-            var rom = CoreState.ROM;
-            if (rom?.RomInfo != null && rom.RomInfo.ed_1_pointer != 0)
-                Retreat_TopAddressBox.Value = rom.p32(rom.RomInfo.ed_1_pointer);
+            if (Retreat_TopBar != null)
+            {
+                Retreat_TopBar.ReadCountText = items.Count.ToString();
+                var rom = CoreState.ROM;
+                if (rom?.RomInfo != null && rom.RomInfo.ed_1_pointer != 0)
+                    Retreat_TopBar.StartAddressText = $"0x{rom.p32(rom.RomInfo.ed_1_pointer):X08}";
+            }
         }
 
         void OnRetreatSelected(uint addr)
@@ -112,7 +115,8 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
-        void ReloadRetreat_Click(object? sender, RoutedEventArgs e)
+        // #668: routed event from the unified EditorTopBar control.
+        void OnRetreatTopBarReloadRequested(object? sender, RoutedEventArgs e)
         {
             try { LoadRetreatList(); }
             catch (Exception ex) { Log.Error("EDView.ReloadRetreat failed: {0}", ex.Message); }
@@ -200,10 +204,13 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             var items = _vm.LoadEpithetList();
             Epithet_EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitByIdLoader(items, i));
-            Epithet_ReadCountBox.Value = items.Count;
-            var rom = CoreState.ROM;
-            if (rom?.RomInfo != null && rom.RomInfo.ed_2_pointer != 0)
-                Epithet_TopAddressBox.Value = rom.p32(rom.RomInfo.ed_2_pointer);
+            if (Epithet_TopBar != null)
+            {
+                Epithet_TopBar.ReadCountText = items.Count.ToString();
+                var rom = CoreState.ROM;
+                if (rom?.RomInfo != null && rom.RomInfo.ed_2_pointer != 0)
+                    Epithet_TopBar.StartAddressText = $"0x{rom.p32(rom.RomInfo.ed_2_pointer):X08}";
+            }
         }
 
         void OnEpithetSelected(uint addr)
@@ -237,7 +244,8 @@ namespace FEBuilderGBA.Avalonia.Views
             catch { Epithet_EpithetTextLabel.Text = ""; }
         }
 
-        void ReloadEpithet_Click(object? sender, RoutedEventArgs e)
+        // #668: routed event from the unified EditorTopBar control.
+        void OnEpithetTopBarReloadRequested(object? sender, RoutedEventArgs e)
         {
             try { LoadEpithetList(); }
             catch (Exception ex) { Log.Error("EDView.ReloadEpithet failed: {0}", ex.Message); }
@@ -323,14 +331,18 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             var items = _vm.LoadEpilogueList();
             Epilogue_EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitByIdLoader(items, i));
-            Epilogue_ReadCountBox.Value = items.Count;
-            var rom = CoreState.ROM;
-            if (rom?.RomInfo != null)
+            if (Epilogue_TopBar != null)
             {
-                uint ptr = _vm.EpilogueRoute == EDViewModel.EpilogueRouteKind.Ephraim
-                    ? rom.RomInfo.ed_3b_pointer
-                    : rom.RomInfo.ed_3a_pointer;
-                Epilogue_TopAddressBox.Value = ptr != 0 ? rom.p32(ptr) : 0;
+                Epilogue_TopBar.ReadCountText = items.Count.ToString();
+                var rom = CoreState.ROM;
+                if (rom?.RomInfo != null)
+                {
+                    uint ptr = _vm.EpilogueRoute == EDViewModel.EpilogueRouteKind.Ephraim
+                        ? rom.RomInfo.ed_3b_pointer
+                        : rom.RomInfo.ed_3a_pointer;
+                    uint resolved = ptr != 0 ? rom.p32(ptr) : 0;
+                    Epilogue_TopBar.StartAddressText = $"0x{resolved:X08}";
+                }
             }
         }
 
@@ -408,7 +420,8 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex) { Log.Error("EDView.EpilogueFilter_SelectionChanged failed: {0}", ex.Message); }
         }
 
-        void ReloadEpilogue_Click(object? sender, RoutedEventArgs e)
+        // #668: routed event from the unified EditorTopBar control.
+        void OnEpilogueTopBarReloadRequested(object? sender, RoutedEventArgs e)
         {
             try { LoadEpilogueList(); }
             catch (Exception ex) { Log.Error("EDView.ReloadEpilogue failed: {0}", ex.Message); }

--- a/FEBuilderGBA.Avalonia/Views/EventMapChangeView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventMapChangeView.axaml
@@ -7,23 +7,18 @@
   <Grid ColumnDefinitions="220,*,220" RowDefinitions="Auto,Auto,*,Auto">
 
     <!-- Row 0: Top read-config bar (mirrors WF panel1: Top Address /
-         Read Count / Reload List). Spans all 3 columns. -->
-    <Border Grid.Row="0" Grid.ColumnSpan="3" BorderBrush="Gray" BorderThickness="1" Margin="4">
-      <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
-        <Label Content="Top Address" VerticalAlignment="Center" />
-        <NumericUpDown AutomationProperties.AutomationId="EventMapChange_ReadStart_Input"
-                       FormatString="0" Name="ReadStartAddressBox" Width="120"
-                       Minimum="0" Maximum="65535999"
-                       IsEnabled="False" VerticalAlignment="Center" />
-        <Label Content="Read Count" VerticalAlignment="Center" />
-        <NumericUpDown AutomationProperties.AutomationId="EventMapChange_ReadCount_Input"
-                       FormatString="0" Name="ReadCountBox" Width="80"
-                       Minimum="0" Maximum="256"
-                       IsEnabled="False" VerticalAlignment="Center" />
-        <Button AutomationProperties.AutomationId="EventMapChange_ReloadList_Button"
-                Name="ReloadListButton" Content="Reload" Click="ReloadList_Click" />
-      </StackPanel>
-    </Border>
+         Read Count / Reload List). Spans all 3 columns.
+         #668: migrated to unified EditorTopBar control. -->
+    <controls:EditorTopBar Grid.Row="0" Grid.ColumnSpan="3" Margin="4"
+                           Name="TopBar"
+                           AutomationProperties.AutomationId="EventMapChange_TopBar"
+                           ShowSize="False"
+                           StartAddressLabel="Top Address:"
+                           ReadCountLabel="Read Count:"
+                           StartAddressAutomationId="EventMapChange_ReadStart_Label"
+                           ReadCountAutomationId="EventMapChange_ReadCount_Label"
+                           ReloadAutomationId="EventMapChange_ReloadList_Button"
+                           ReloadRequested="OnTopBarReloadRequested" />
 
     <!-- Row 1: AddressPanel (mirrors WF AddressPanel: Address / Size /
          Selected Address / Write button). Stretches across columns 1+2. -->

--- a/FEBuilderGBA.Avalonia/Views/EventMapChangeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventMapChangeView.axaml.cs
@@ -45,8 +45,11 @@ namespace FEBuilderGBA.Avalonia.Views
                 var entries = _vm.LoadList();
                 EntryList.SetItems(entries);
 
-                ReadStartAddressBox.Value = _vm.ReadStartAddress;
-                ReadCountBox.Value = _vm.ReadCount;
+                if (TopBar != null)
+                {
+                    TopBar.StartAddressText = $"0x{_vm.ReadStartAddress:X08}";
+                    TopBar.ReadCountText = _vm.ReadCount.ToString();
+                }
                 BlockSizeBox.Text = $"0x{_vm.BlockSize:X}";
 
                 if (_mapItems.Count > 0)
@@ -105,8 +108,11 @@ namespace FEBuilderGBA.Avalonia.Views
             // Refresh the read-config bar too — VM updates these per
             // selected change-data entry (mirrors WF's per-map ReInit;
             // Copilot bot review on issue #423).
-            ReadStartAddressBox.Value = _vm.ReadStartAddress;
-            ReadCountBox.Value = _vm.ReadCount;
+            if (TopBar != null)
+            {
+                TopBar.StartAddressText = $"0x{_vm.ReadStartAddress:X08}";
+                TopBar.ReadCountText = _vm.ReadCount.ToString();
+            }
             B0Box.Value = _vm.B0;
             B1Box.Value = _vm.B1;
             B2Box.Value = _vm.B2;
@@ -128,8 +134,11 @@ namespace FEBuilderGBA.Avalonia.Views
             // loaded" instead of carrying the previous map's stale
             // ReadStartAddress / ReadCount (Copilot bot 3rd-pass
             // review on issue #423).
-            ReadStartAddressBox.Value = 0;
-            ReadCountBox.Value = 0;
+            if (TopBar != null)
+            {
+                TopBar.StartAddressText = string.Empty;
+                TopBar.ReadCountText = string.Empty;
+            }
             BlockSizeBox.Text = "";
             SelectedAddressBox.Text = "";
             B0Box.Value = 0;
@@ -157,7 +166,8 @@ namespace FEBuilderGBA.Avalonia.Views
             _vm.P8 = ParseHexText(P8Box.Text);
         }
 
-        void ReloadList_Click(object? sender, RoutedEventArgs e) => LoadList();
+        // #668: routed event from the unified EditorTopBar control.
+        void OnTopBarReloadRequested(object? sender, RoutedEventArgs e) => LoadList();
 
         void Write_Click(object? sender, RoutedEventArgs e)
         {

--- a/FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml
@@ -308,28 +308,29 @@
       <TabItem AutomationProperties.AutomationId="WorldMapImage_Border_Tab" Header="Border">
         <Grid RowDefinitions="Auto,Auto,*" ColumnDefinitions="240,*">
 
-          <!-- Row 0: Read-config bar (mirrors WF panel4) -->
-          <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
-            <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
-              <Label Content="Start Address" VerticalAlignment="Center" />
-              <NumericUpDown AutomationProperties.AutomationId="WorldMapImage_Border_ReadStartAddress_Input"
-                             Name="Border_ReadStartAddressBox" FormatString="0"
-                             Minimum="0" Maximum="4294967295" Width="130"
-                             IsEnabled="False" VerticalAlignment="Center" />
-              <Label Content="Read Count" VerticalAlignment="Center" />
-              <NumericUpDown AutomationProperties.AutomationId="WorldMapImage_Border_ReadCount_Input"
-                             Name="Border_ReadCountBox" FormatString="0"
-                             Minimum="0" Maximum="65535" Width="80"
-                             IsEnabled="False" VerticalAlignment="Center" />
-              <Button AutomationProperties.AutomationId="WorldMapImage_Border_Reload_Button"
-                      Name="Border_ReloadButton" Content="Reload"
-                      Click="BorderReload_Click" />
-              <Button AutomationProperties.AutomationId="WorldMapImage_Border_AddressListExpand_Button"
-                      Name="Border_AddressListExpandButton" Content="List Expand"
-                      IsEnabled="False"
-                      ToolTip.Tip="KnownGap: list-expand requires DataExpansionCore wiring not yet ported." />
-            </StackPanel>
-          </Border>
+          <!-- Row 0: Read-config bar (mirrors WF panel4).
+               #668: start address / count / reload migrated to unified
+               EditorTopBar control. The List Expand button stays external
+               (not a standard top-bar slot) — Grid keeps EditorTopBar
+               stretched and pins List Expand to the right. -->
+          <Grid Grid.Row="0" Grid.ColumnSpan="2" Margin="4"
+                ColumnDefinitions="*,Auto">
+            <controls:EditorTopBar Grid.Column="0"
+                                   Name="Border_TopBar"
+                                   AutomationProperties.AutomationId="WorldMapImage_Border_TopBar"
+                                   ShowSize="False"
+                                   StartAddressLabel="Start Address:"
+                                   ReadCountLabel="Read Count:"
+                                   StartAddressAutomationId="WorldMapImage_Border_ReadStartAddress_Label"
+                                   ReadCountAutomationId="WorldMapImage_Border_ReadCount_Label"
+                                   ReloadAutomationId="WorldMapImage_Border_Reload_Button"
+                                   ReloadRequested="OnBorderTopBarReloadRequested" />
+            <Button Grid.Column="1"
+                    AutomationProperties.AutomationId="WorldMapImage_Border_AddressListExpand_Button"
+                    Name="Border_AddressListExpandButton" Content="List Expand"
+                    IsEnabled="False" Margin="4,0,0,0" VerticalAlignment="Center"
+                    ToolTip.Tip="KnownGap: list-expand requires DataExpansionCore wiring not yet ported." />
+          </Grid>
 
           <!-- Row 1: Selection bar (mirrors WF AddressPanel) -->
           <Border Grid.Row="1" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4,0,4,4">
@@ -426,28 +427,27 @@
       <TabItem AutomationProperties.AutomationId="WorldMapImage_IconData_Tab" Header="Icon Data">
         <Grid RowDefinitions="Auto,Auto,*" ColumnDefinitions="240,*">
 
-          <!-- Row 0: Read-config bar -->
-          <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
-            <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
-              <Label Content="Start Address" VerticalAlignment="Center" />
-              <NumericUpDown AutomationProperties.AutomationId="WorldMapImage_IconData_ReadStartAddress_Input"
-                             Name="IconData_ReadStartAddressBox" FormatString="0"
-                             Minimum="0" Maximum="4294967295" Width="130"
-                             IsEnabled="False" VerticalAlignment="Center" />
-              <Label Content="Read Count" VerticalAlignment="Center" />
-              <NumericUpDown AutomationProperties.AutomationId="WorldMapImage_IconData_ReadCount_Input"
-                             Name="IconData_ReadCountBox" FormatString="0"
-                             Minimum="0" Maximum="65535" Width="80"
-                             IsEnabled="False" VerticalAlignment="Center" />
-              <Button AutomationProperties.AutomationId="WorldMapImage_IconData_Reload_Button"
-                      Name="IconData_ReloadButton" Content="Reload"
-                      Click="IconDataReload_Click" />
-              <Button AutomationProperties.AutomationId="WorldMapImage_IconData_AddressListExpand_Button"
-                      Name="IconData_AddressListExpandButton" Content="List Expand"
-                      IsEnabled="False"
-                      ToolTip.Tip="KnownGap: list-expand requires DataExpansionCore wiring not yet ported." />
-            </StackPanel>
-          </Border>
+          <!-- Row 0: Read-config bar.
+               #668: migrated to unified EditorTopBar control. List Expand
+               kept external. -->
+          <Grid Grid.Row="0" Grid.ColumnSpan="2" Margin="4"
+                ColumnDefinitions="*,Auto">
+            <controls:EditorTopBar Grid.Column="0"
+                                   Name="IconData_TopBar"
+                                   AutomationProperties.AutomationId="WorldMapImage_IconData_TopBar"
+                                   ShowSize="False"
+                                   StartAddressLabel="Start Address:"
+                                   ReadCountLabel="Read Count:"
+                                   StartAddressAutomationId="WorldMapImage_IconData_ReadStartAddress_Label"
+                                   ReadCountAutomationId="WorldMapImage_IconData_ReadCount_Label"
+                                   ReloadAutomationId="WorldMapImage_IconData_Reload_Button"
+                                   ReloadRequested="OnIconDataTopBarReloadRequested" />
+            <Button Grid.Column="1"
+                    AutomationProperties.AutomationId="WorldMapImage_IconData_AddressListExpand_Button"
+                    Name="IconData_AddressListExpandButton" Content="List Expand"
+                    IsEnabled="False" Margin="4,0,0,0" VerticalAlignment="Center"
+                    ToolTip.Tip="KnownGap: list-expand requires DataExpansionCore wiring not yet ported." />
+          </Grid>
 
           <!-- Row 1: Selection bar -->
           <Border Grid.Row="1" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4,0,4,4">

--- a/FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml.cs
@@ -146,8 +146,11 @@ namespace FEBuilderGBA.Avalonia.Views
                 Border_EntryList.SetItems(items);
                 // Mirror WF InputFormRef BaseAddress + DataCount in the
                 // read panel (Copilot bot inline review on PR #592 round 2).
-                Border_ReadStartAddressBox.Value = _vm.BorderReadStartAddress;
-                Border_ReadCountBox.Value = _vm.BorderReadCount;
+                if (Border_TopBar != null)
+                {
+                    Border_TopBar.StartAddressText = $"0x{_vm.BorderReadStartAddress:X08}";
+                    Border_TopBar.ReadCountText = _vm.BorderReadCount.ToString();
+                }
             }
             finally { _vm.IsLoading = prevLoading; _vm.MarkClean(); }
         }
@@ -203,7 +206,8 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
-        void BorderReload_Click(object? sender, RoutedEventArgs e)
+        // #668: routed event from the unified EditorTopBar control.
+        void OnBorderTopBarReloadRequested(object? sender, RoutedEventArgs e)
         {
             try { LoadBorderList(); }
             catch (Exception ex) { Log.Error("BorderReload failed: {0}", ex.Message); }
@@ -225,8 +229,11 @@ namespace FEBuilderGBA.Avalonia.Views
                 IconData_EntryList.SetItems(items);
                 // Mirror WF InputFormRef BaseAddress + DataCount in the
                 // read panel (Copilot bot inline review on PR #592 round 2).
-                IconData_ReadStartAddressBox.Value = _vm.IconReadStartAddress;
-                IconData_ReadCountBox.Value = _vm.IconReadCount;
+                if (IconData_TopBar != null)
+                {
+                    IconData_TopBar.StartAddressText = $"0x{_vm.IconReadStartAddress:X08}";
+                    IconData_TopBar.ReadCountText = _vm.IconReadCount.ToString();
+                }
             }
             finally { _vm.IsLoading = prevLoading; _vm.MarkClean(); }
         }
@@ -298,7 +305,8 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
-        void IconDataReload_Click(object? sender, RoutedEventArgs e)
+        // #668: routed event from the unified EditorTopBar control.
+        void OnIconDataTopBarReloadRequested(object? sender, RoutedEventArgs e)
         {
             try { LoadIconList(); }
             catch (Exception ex) { Log.Error("IconDataReload failed: {0}", ex.Message); }

--- a/FEBuilderGBA.Tests/Unit/EditorTopBarTests.cs
+++ b/FEBuilderGBA.Tests/Unit/EditorTopBarTests.cs
@@ -154,6 +154,7 @@ namespace FEBuilderGBA.Tests.Unit
 
         public static IEnumerable<object[]> MigratedEditorAxaml => new[]
         {
+            // PR #669 (issue #649) — original 10 representative editors.
             new object[] { "UnitEditorView.axaml" },
             new object[] { "ClassEditorView.axaml" },
             new object[] { "ItemFE6View.axaml" },
@@ -164,6 +165,13 @@ namespace FEBuilderGBA.Tests.Unit
             new object[] { "ImagePortraitFE6View.axaml" },
             new object[] { "ItemEffectivenessViewerView.axaml" },
             new object[] { "ItemPromotionViewerView.axaml" },
+            // Issue #668 Slice A — 5 additional read-only editors covering
+            // 9 EditorTopBar instances across single-tab + multi-tab views.
+            new object[] { "ClassOPDemoView.axaml" },
+            new object[] { "EDFE7View.axaml" },
+            new object[] { "EDView.axaml" },
+            new object[] { "EventMapChangeView.axaml" },
+            new object[] { "WorldMapImageView.axaml" },
         };
 
         [Theory]
@@ -178,6 +186,7 @@ namespace FEBuilderGBA.Tests.Unit
 
         public static IEnumerable<object[]> MigratedEditorCodeBehind => new[]
         {
+            // PR #669 (issue #649).
             new object[] { "UnitEditorView.axaml.cs" },
             new object[] { "ClassEditorView.axaml.cs" },
             new object[] { "ItemFE6View.axaml.cs" },
@@ -188,6 +197,12 @@ namespace FEBuilderGBA.Tests.Unit
             new object[] { "ImagePortraitFE6View.axaml.cs" },
             new object[] { "ItemEffectivenessViewerView.axaml.cs" },
             new object[] { "ItemPromotionViewerView.axaml.cs" },
+            // Issue #668 Slice A (this PR).
+            new object[] { "ClassOPDemoView.axaml.cs" },
+            new object[] { "EDFE7View.axaml.cs" },
+            new object[] { "EDView.axaml.cs" },
+            new object[] { "EventMapChangeView.axaml.cs" },
+            new object[] { "WorldMapImageView.axaml.cs" },
         };
 
         [Theory]
@@ -197,7 +212,11 @@ namespace FEBuilderGBA.Tests.Unit
             string path = Path.Combine(AvaloniaDir, "Views", codeBehindFile);
             Assert.True(File.Exists(path), $"Code-behind not found: {path}");
             string src = File.ReadAllText(path);
-            Assert.Contains("OnTopBarReloadRequested", src);
+            // Multi-tab editors name their reload handlers per-tab (e.g.
+            // OnLynTopBarReloadRequested); single-tab editors use the
+            // generic "OnTopBarReloadRequested" name. The "TopBarReloadRequested"
+            // suffix is the common substring across both shapes.
+            Assert.Contains("TopBarReloadRequested", src);
         }
 
         // -----------------------------------------------------------------
@@ -282,6 +301,63 @@ namespace FEBuilderGBA.Tests.Unit
             string src = File.ReadAllText(Path.Combine(AvaloniaDir, "Views", "ItemFE6View.axaml"));
             Assert.DoesNotContain("Name=\"FilterBox\"", src);
             Assert.DoesNotContain("Name=\"ReloadButton\"", src);
+        }
+
+        // -----------------------------------------------------------------
+        // Issue #668 Slice A — per-editor invariants
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void ClassOPDemoView_PreservesReloadAutomationId()
+        {
+            string src = File.ReadAllText(Path.Combine(AvaloniaDir, "Views", "ClassOPDemoView.axaml"));
+            Assert.Contains("ReloadAutomationId=\"ClassOPDemo_ReloadList_Button\"", src);
+            // Pre-migration NUD-based top-bar should be gone.
+            Assert.DoesNotContain("Name=\"ReadStartAddressBox\"", src);
+            Assert.DoesNotContain("Name=\"ReadCountBox\"", src);
+        }
+
+        [Fact]
+        public void EventMapChangeView_PreservesReloadAutomationId()
+        {
+            string src = File.ReadAllText(Path.Combine(AvaloniaDir, "Views", "EventMapChangeView.axaml"));
+            Assert.Contains("ReloadAutomationId=\"EventMapChange_ReloadList_Button\"", src);
+            Assert.DoesNotContain("Name=\"ReadStartAddressBox\"", src);
+            Assert.DoesNotContain("Name=\"ReadCountBox\"", src);
+        }
+
+        [Fact]
+        public void EDView_PreservesPerTabReloadAutomationIds()
+        {
+            string src = File.ReadAllText(Path.Combine(AvaloniaDir, "Views", "EDView.axaml"));
+            Assert.Contains("ReloadAutomationId=\"ED_Retreat_Reload_Button\"", src);
+            Assert.Contains("ReloadAutomationId=\"ED_Epithet_Reload_Button\"", src);
+            Assert.Contains("ReloadAutomationId=\"ED_Epilogue_Reload_Button\"", src);
+            // Epilogue filter combo is preserved externally (not merged into
+            // the EditorTopBar inline-filter slot — different semantics).
+            Assert.Contains("ED_Epilogue_Filter_Combo", src);
+        }
+
+        [Fact]
+        public void EDFE7View_PreservesPerTabReloadAutomationIds()
+        {
+            string src = File.ReadAllText(Path.Combine(AvaloniaDir, "Views", "EDFE7View.axaml"));
+            Assert.Contains("ReloadAutomationId=\"EDFE7_Lyn_Reload_Button\"", src);
+            Assert.Contains("ReloadAutomationId=\"EDFE7_Retreat_Reload_Button\"", src);
+            Assert.Contains("ReloadAutomationId=\"EDFE7_Epithet_Reload_Button\"", src);
+            Assert.Contains("ReloadAutomationId=\"EDFE7_Epilogue_Reload_Button\"", src);
+            Assert.Contains("EDFE7_Epilogue_Filter_Combo", src);
+        }
+
+        [Fact]
+        public void WorldMapImageView_PreservesBorderAndIconDataReloadAutomationIds()
+        {
+            string src = File.ReadAllText(Path.Combine(AvaloniaDir, "Views", "WorldMapImageView.axaml"));
+            Assert.Contains("ReloadAutomationId=\"WorldMapImage_Border_Reload_Button\"", src);
+            Assert.Contains("ReloadAutomationId=\"WorldMapImage_IconData_Reload_Button\"", src);
+            // List Expand stays external to the EditorTopBar.
+            Assert.Contains("WorldMapImage_Border_AddressListExpand_Button", src);
+            Assert.Contains("WorldMapImage_IconData_AddressListExpand_Button", src);
         }
     }
 }


### PR DESCRIPTION
## Summary

Migrate 5 Avalonia read-only editors to the unified `EditorTopBar` control introduced in PR #669, covering 9 EditorTopBar instances across single-tab and multi-tab views.

- `ClassOPDemoView` (1 top-bar)
- `EDFE7View` (4 top-bars: Lyn / Retreat / Epithet / Epilogue)
- `EDView` (3 top-bars: Retreat / Epithet / Epilogue)
- `EventMapChangeView` (1 top-bar)
- `WorldMapImageView` (2 top-bars: Border + IconData tabs)

**Ref #668 (partial — 21 editors remain in follow-up #701).**

## Scope decisions (per Copilot CLI plan-review #1, #3)

The original #668 list contained 12 candidate editors. After per-editor verification, 5 were skipped because their top-bars are semantically different from the standard `EditorTopBar` contract:

| Editor | Reason skipped |
|---|---|
| `MapTerrainBGLookupView` | No top-bar at all (just AddressList + detail) |
| `MapTerrainFloorLookupView` | Same as above |
| `ItemShopViewerView` | Reload sits in a bottom action bar; no dedicated top-bar |
| `ItemUsagePointerViewerView` | Has a populated Filter ComboBox (different semantics from EditorTopBar's inline-filter TextBox) |
| `MonsterItemViewerView` | Read Start / Read Count are EDITABLE NumericUpDown inputs feeding `ApplyReadWindow` — belongs to the editable-input group |

These 5 plus the 19 editable-input editors flagged in #668 are tracked in follow-up issue #701 for an `EditorTopBarWithInputs` variant.

## Migration details

- Epilogue tabs of `EDView` / `EDFE7View` keep their Eirika/Ephraim and Eliwood/Hector route-picker Filter combos external to EditorTopBar (semantically different from the inline-filter TextBox the control exposes).
- `WorldMapImageView` Border + IconData tabs keep the List Expand button external; a `ColumnDefinitions="*,Auto"` wrapper Grid stretches EditorTopBar and pins List Expand to the right.
- NUD-based `ReadStartAddress` / `ReadCount` surfaces became read-only TextBlock slots inside EditorTopBar; legacy `*_Input` AutomationIds were renamed to `*_Label` (display-only). `Reload_Button` ids are preserved unchanged so existing E2E selectors keep working.

## Test plan

- [x] 5 new EditorTopBarTests (one per migrated view) covering preserved AutomationIds for `ClassOPDemoView`, `EventMapChangeView`, `EDView`, `EDFE7View`, `WorldMapImageView`
- [x] `MigratedEditorAxaml` / `MigratedEditorCodeBehind` theories extended to cover the 5 new editors (now 15 entries total)
- [x] Reload-handler theory assertion broadened to match per-tab handlers (`OnLynTopBarReloadRequested`, `OnRetreatTopBarReloadRequested`, etc.) used by multi-tab editors
- [x] 12 Avalonia parity test failures from the `*_Input` → `*_Label` rename fixed in `ClassOPDemoParityTests`, `EDFE7ParityTests`, `EDParityTests`, `EventMapChangeParityTests`, `WorldMapImageParityTests`
- [x] `FEBuilderGBA.Tests` (WinForms suite) — 1807 / 1807 passing
- [x] `FEBuilderGBA.Core.Tests` — 1960 / 1960 passing
- [x] `FEBuilderGBA.Avalonia.Tests` — 6826 / 6826 passing (3 skipped pre-existing)
- [x] Avalonia Release build (`dotnet build FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj -c Release`) — 0 errors
- [x] Real GUI screenshot captured against `roms/FE8U.gba` via PrintWindow API (works with locked screen)

Total: 10,593 tests, 0 failures.

## GUI Test Report

| Editor | AXAML migrated | Code-behind migrated | Avalonia build | Parity tests |
|---|---|---|---|---|
| `ClassOPDemoView` | PASS | PASS | PASS | PASS |
| `EDFE7View` (Lyn) | PASS | PASS | PASS | PASS |
| `EDFE7View` (Retreat) | PASS | PASS | PASS | PASS |
| `EDFE7View` (Epithet) | PASS | PASS | PASS | PASS |
| `EDFE7View` (Epilogue) | PASS | PASS | PASS | PASS |
| `EDView` (Retreat) | PASS | PASS | PASS | PASS |
| `EDView` (Epithet) | PASS | PASS | PASS | PASS |
| `EDView` (Epilogue) | PASS | PASS | PASS | PASS |
| `EventMapChangeView` | PASS | PASS | PASS | PASS |
| `WorldMapImageView` (Border) | PASS | PASS | PASS | PASS |
| `WorldMapImageView` (IconData) | PASS | PASS | PASS | PASS |

## Screenshot

EDView "Retreat" tab with the unified EditorTopBar visible (Top Address `0x00A3D2C0`, Read Count `33`, Reload button right-aligned) above the populated unit list. Captured via `tools/WinCapture` PrintWindow utility against `roms/FE8U.gba`. Landed on master via docs PR #703.

![EditorTopBar migration — EDView Retreat tab](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr668-editor-topbar-edview.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-4-7-1m)