### PR TITLE
feat(avalonia): Map Style Editor Redo + MapChip Export (#692 partial)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MapStyleEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MapStyleEditorParityTests.cs
@@ -192,19 +192,19 @@ public class MapStyleEditorParityTests
     /// </summary>
     static readonly string[] KnownGapButtonIds =
     {
-        // 4 buttons deferred to follow-up #692 (Redo, OBJ Import, MapChip
-        // Export/Import). PaletteExport/Import/Clipboard/ObjExport/Undo
-        // became functional in #672 Slice A (see View_<Name>_Button_IsEnabled
-        // + View_<Name>_Click_HandlerWired tests below).
+        // 2 buttons deferred to follow-up after #692 partial slice
+        // (OBJ Import + MapChip Import). PaletteExport/Import/Clipboard/
+        // ObjExport/Undo became functional in #672 Slice A; Redo and
+        // MapChip Export became functional in #692 partial slice (see
+        // View_<Name>_Button_IsEnabled + View_<Name>_Click_HandlerWired
+        // tests below).
         //
         // PaletteWrite is functional via #660 first slice (tracked positively
         // by View_FunctionalPaletteWriteButton_IsEnabled); CopyTile / CopyType /
         // Paste / ConfigWrite became functional in #671 (tracked positively
         // by View_ChipsetTab_FunctionalControls_AreEnabled_WhenCanEdit).
-        "MapStyleEditor_MapChipExport_Button",
         "MapStyleEditor_MapChipImport_Button",
         "MapStyleEditor_ObjImport_Button",
-        "MapStyleEditor_Redo_Button",
     };
 
     [Fact]
@@ -997,9 +997,11 @@ public class MapStyleEditorParityTests
     }
 
     // -----------------------------------------------------------------
-    // #672 Slice A — 5 newly-functional buttons (Palette Export / Import /
-    // Clipboard, OBJ Export, Undo). Remaining 4 buttons (Redo, OBJ Import,
-    // MapChip Export/Import) tracked by follow-up #692.
+    // #672 Slice A + #692 partial slice — 7 newly-functional buttons.
+    // #672 Slice A: PaletteExport / PaletteImport / PaletteClipboard /
+    // ObjExport / Undo. #692 partial slice: Redo + MapChip Export. The
+    // 2 remaining buttons (OBJ Import + MapChip Import) are tracked by
+    // the follow-up issue filed before the #692 partial-slice PR.
     // -----------------------------------------------------------------
 
     public static IEnumerable<object[]> Slice672ButtonIds()
@@ -1009,6 +1011,9 @@ public class MapStyleEditorParityTests
         yield return new object[] { "MapStyleEditor_PaletteClipboard_Button", "PaletteClipboard_Click" };
         yield return new object[] { "MapStyleEditor_ObjExport_Button", "ObjExport_Click" };
         yield return new object[] { "MapStyleEditor_Undo_Button", "Undo_Click" };
+        // #692 partial slice additions.
+        yield return new object[] { "MapStyleEditor_Redo_Button", "Redo_Click" };
+        yield return new object[] { "MapStyleEditor_MapChipExport_Button", "MapChipExport_Click" };
     }
 
     /// <summary>
@@ -1083,6 +1088,72 @@ public class MapStyleEditorParityTests
             "Undo_Click must reference Postion and RunUndo()");
         Assert.True(postionIdx < runUndoIdx,
             "Postion guard must precede RunUndo() call");
+    }
+
+    // -----------------------------------------------------------------
+    // #692 partial slice — Redo + MapChip Export specific shape checks.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Redo handler must guard on <see cref="Undo.CanRedo"/> before calling
+    /// <see cref="Undo.RunRedo"/> (mirrors <see cref="Undo_Click"/>'s
+    /// Postion-guard pattern) and emit a "Nothing to redo" toast on the
+    /// no-op path. The guard must precede RunRedo() in source order so a
+    /// silently no-op rollback never falsely claims "Redo applied".
+    /// </summary>
+    [Fact]
+    public void View_Redo_Click_GuardsOnCanRedo()
+    {
+        string code = File.ReadAllText(CodeBehindPath());
+        var bodyMatch = Regex.Match(code,
+            @"void Redo_Click[\s\S]*?(?=\n\s{8}(static\s|public\s|void\s|/// |\}))",
+            RegexOptions.Singleline);
+        Assert.True(bodyMatch.Success, "Redo_Click method not found");
+        string body = bodyMatch.Value;
+        Assert.Contains("CanRedo", body);
+        Assert.Contains("Nothing to redo", body);
+        int canRedoIdx = body.IndexOf("CanRedo", StringComparison.Ordinal);
+        int runRedoIdx = body.IndexOf("RunRedo()", StringComparison.Ordinal);
+        Assert.True(canRedoIdx >= 0 && runRedoIdx >= 0,
+            "Redo_Click must reference CanRedo and RunRedo()");
+        Assert.True(canRedoIdx < runRedoIdx,
+            "CanRedo guard must precede RunRedo() call");
+    }
+
+    /// <summary>
+    /// MapChip Export handler must access the VM's CONFIG buffer via the
+    /// public <c>GetCachedConfigClone</c> accessor (which clones the
+    /// internal cache to prevent caller mutation — Copilot CLI v2 review)
+    /// and use the shared <c>FileDialogHelper.SaveFile</c> wrapper for
+    /// picker parity with the rest of the Avalonia layer.
+    /// </summary>
+    [Fact]
+    public void View_MapChipExport_Click_UsesVmAccessorAndFileDialogHelper()
+    {
+        string code = File.ReadAllText(CodeBehindPath());
+        var bodyMatch = Regex.Match(code,
+            @"async void MapChipExport_Click[\s\S]*?(?=\n\s{8}(static\s|public\s|void\s|async\s|/// |\}))",
+            RegexOptions.Singleline);
+        Assert.True(bodyMatch.Success, "MapChipExport_Click method not found");
+        string body = bodyMatch.Value;
+        Assert.Contains("_vm.GetCachedConfigClone()", body);
+        Assert.Contains("FileDialogHelper.SaveFile", body);
+        Assert.Contains("*.MAPCHIP_CONFIG", body);
+        Assert.Contains("File.WriteAllBytes", body);
+    }
+
+    /// <summary>
+    /// The VM must expose <c>GetCachedConfigClone</c> as a public method
+    /// that returns a defensive clone (i.e. `.Clone()` appears in the
+    /// expression body). This catches direct field exposure regressions.
+    /// </summary>
+    [Fact]
+    public void ViewModel_GetCachedConfigClone_ReturnsDefensiveClone()
+    {
+        string vm = File.ReadAllText(ViewModelPath());
+        Assert.Matches(new Regex(
+            @"public\s+byte\[\]\??\s+GetCachedConfigClone\(\)[\s\S]*?Clone\(\)",
+            RegexOptions.Singleline), vm);
     }
 
     // -----------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
@@ -138,6 +138,17 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             && _currentConfigPlist != 0xFF
             && _chipsetConfigAddress != 0;
 
+        /// <summary>
+        /// Returns a defensive clone of the cached decompressed CONFIG
+        /// buffer for export (#692 partial slice — MapChip Export). Returns
+        /// null when no entry is loaded or the LZ77 decompression at
+        /// <see cref="LoadEntry"/> time produced no usable buffer. The
+        /// clone protects the VM's internal cache from caller mutation
+        /// (Copilot CLI v2 review on the v3 plan).
+        /// </summary>
+        public byte[]? GetCachedConfigClone() =>
+            _cachedConfigData == null ? null : (byte[])_cachedConfigData.Clone();
+
         // ----- Palette helpers (5-5-5 RGB, 16 colors per palette) -----
         // colorIndex is 1-based to match the WF "PALETTE_P_1..16" labels.
 

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml
@@ -106,8 +106,7 @@
                       ToolTip.Tip="Pending Core extraction - tracked by #692." />
               <Button AutomationProperties.AutomationId="MapStyleEditor_MapChipExport_Button"
                       Content="Map Chip Save"
-                      IsEnabled="False"
-                      ToolTip.Tip="Pending Core extraction - tracked by #692." />
+                      Click="MapChipExport_Click" />
               <Button AutomationProperties.AutomationId="MapStyleEditor_MapChipImport_Button"
                       Content="Map Chip Load"
                       IsEnabled="False"
@@ -117,8 +116,7 @@
                       Click="Undo_Click" />
               <Button AutomationProperties.AutomationId="MapStyleEditor_Redo_Button"
                       Content="REDO"
-                      IsEnabled="False"
-                      ToolTip.Tip="Pending Core extraction - tracked by #692." />
+                      Click="Redo_Click" />
               <Button AutomationProperties.AutomationId="MapStyleEditor_Write_Button"
                       Name="WriteButton" Content="Write"
                       Click="Write_Click" />

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
@@ -972,5 +972,91 @@ namespace FEBuilderGBA.Avalonia.Views
                 CoreState.Services.ShowError($"Undo failed: {ex.Message}");
             }
         }
+
+        /// <summary>
+        /// Per-editor Redo (#692 partial slice): runs
+        /// <see cref="Undo.RunRedo"/> on the global <see cref="CoreState.Undo"/>
+        /// buffer. Mirrors <see cref="Undo_Click"/>: guards on
+        /// <see cref="Undo.CanRedo"/>, then verifies the redo actually
+        /// advanced the cursor (RunRedo's bool surfaces silent
+        /// <see cref="Undo.RollbackROM"/> failures that
+        /// <see cref="Undo.Rollback(int)"/> would otherwise hide).
+        /// After a successful redo, reload the entry so palette /
+        /// chipset / preview reflect the rolled-forward ROM bytes.
+        /// </summary>
+        void Redo_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (CoreState.Undo == null || !CoreState.Undo.CanRedo)
+                {
+                    CoreState.Services.ShowInfo("Nothing to redo.");
+                    return;
+                }
+                if (!CoreState.Undo.RunRedo())
+                {
+                    CoreState.Services.ShowError("Redo failed.");
+                    return;
+                }
+                // Reload the current entry so palette / chipset / preview
+                // pick up the rolled-forward ROM bytes.
+                if (_vm.CurrentAddr != 0)
+                {
+                    _vm.IsLoading = true;
+                    try
+                    {
+                        _vm.LoadEntry(_vm.CurrentAddr);
+                        UpdateUI();
+                    }
+                    finally { _vm.IsLoading = false; }
+                    RefreshChipPreview();
+                }
+                CoreState.Services.ShowInfo("Redo applied.");
+            }
+            catch (Exception ex)
+            {
+                Log.Error("MapStyleEditorView.Redo_Click failed: {0}", ex.Message);
+                CoreState.Services.ShowError($"Redo failed: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Per-editor MapChip Export (#692 partial slice): writes the
+        /// VM's cached decompressed CONFIG buffer to a .MAPCHIP_CONFIG
+        /// file. Mirrors WF parity — raw ConfigUZ bytes, no magic header
+        /// (the WF importer reads raw bytes with only a 9216-byte
+        /// minimum check, so adding a header would break import parity).
+        /// Uses <see cref="FileDialogHelper.SaveFile"/> for picker parity
+        /// with the rest of the Avalonia layer.
+        /// </summary>
+        async void MapChipExport_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                byte[]? configClone = _vm.GetCachedConfigClone();
+                if (configClone == null || configClone.Length == 0)
+                {
+                    CoreState.Services.ShowError(
+                        "No chipset config loaded — select a Map Style entry first.");
+                    return;
+                }
+                string? path = await FileDialogHelper.SaveFile(
+                    this,
+                    "Export Map Chip Config",
+                    "Map Chip Config",
+                    "*.MAPCHIP_CONFIG",
+                    "mapchip.MAPCHIP_CONFIG");
+                if (path == null) return;
+
+                File.WriteAllBytes(path, configClone);
+                CoreState.Services.ShowInfo(
+                    $"Exported {configClone.Length} bytes to {System.IO.Path.GetFileName(path)}.");
+            }
+            catch (Exception ex)
+            {
+                Log.Error("MapStyleEditorView.MapChipExport_Click failed: {0}", ex.Message);
+                CoreState.Services.ShowError($"Map Chip export failed: {ex.Message}");
+            }
+        }
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
@@ -1046,7 +1046,12 @@ namespace FEBuilderGBA.Avalonia.Views
                     "Map Chip Config",
                     "*.MAPCHIP_CONFIG",
                     "mapchip.MAPCHIP_CONFIG");
-                if (path == null) return;
+                // Treat null / empty / whitespace as cancel — FileDialogHelper.SaveFile
+                // can return an empty string in some flows, and File.WriteAllBytes
+                // would throw on it. Matches the guard pattern used by other
+                // Save-path callers (e.g. ToolTranslateROMView). Copilot bot
+                // inline review on PR #706.
+                if (string.IsNullOrWhiteSpace(path)) return;
 
                 File.WriteAllBytes(path, configClone);
                 CoreState.Services.ShowInfo(

--- a/FEBuilderGBA.Core.Tests/UndoRedoTests.cs
+++ b/FEBuilderGBA.Core.Tests/UndoRedoTests.cs
@@ -1,0 +1,150 @@
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// Tests for the forward-step (redo) path on <see cref="Undo"/> added
+    /// for #692 partial slice (Avalonia Map Style Editor Redo button).
+    ///
+    /// The tests verify:
+    /// - <see cref="Undo.CanRedo"/> reports the cursor position correctly.
+    /// - <see cref="Undo.RunRedo"/> replays a record and advances the cursor.
+    /// - <see cref="Undo.RunRedo"/> returns false at the end of the buffer
+    ///   (so the editor's "Nothing to redo" path fires).
+    /// - <see cref="Undo.RunRedo"/> restores the post-write state when called
+    ///   after a matching <see cref="Undo.RunUndo"/> (round-trip).
+    /// </summary>
+    [Collection("SharedState")]
+    public class UndoRedoTests
+    {
+        static ROM CreateTestRom()
+        {
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(new byte[256]);
+            CoreState.ROM = rom;
+            return rom;
+        }
+
+        /// <summary>
+        /// Empty buffer + Postion 0 should NOT permit redo and RunRedo should
+        /// return false (no rollback attempted).
+        /// </summary>
+        [Fact]
+        public void CanRedo_EmptyStack_ReturnsFalse()
+        {
+            var undo = new Undo();
+            Assert.False(undo.CanRedo);
+            Assert.False(undo.RunRedo());
+        }
+
+        /// <summary>
+        /// After a single Push, the cursor is at the end so CanRedo is false
+        /// and RunRedo returns false (mirrors WF behavior — redo only fires
+        /// after at least one undo step).
+        /// </summary>
+        [Fact]
+        public void CanRedo_AtMaxPosition_ReturnsFalse()
+        {
+            var savedRom = CoreState.ROM;
+            var savedUndo = CoreState.Undo;
+            try
+            {
+                CreateTestRom();
+                var undo = new Undo();
+                CoreState.Undo = undo;
+
+                var ud = undo.NewUndoData("test");
+                ud.list.Add(new Undo.UndoPostion(0, new byte[] { 0xAA }));
+                undo.Push(ud);
+
+                // Postion == UndoBuffer.Count == 1 after Push → no redo possible.
+                Assert.False(undo.CanRedo);
+                Assert.False(undo.RunRedo());
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.Undo = savedUndo;
+            }
+        }
+
+        /// <summary>
+        /// Write a byte through Undo, then undo (cursor moves back to 0),
+        /// then redo and assert the post-write byte is restored. This is the
+        /// primary correctness guarantee for the Map Style Editor Redo
+        /// button — without it, the user would see the pre-write byte after
+        /// pressing Redo.
+        /// </summary>
+        [Fact]
+        public void RunRedo_AfterUndo_RestoresOriginalState()
+        {
+            var savedRom = CoreState.ROM;
+            var savedUndo = CoreState.Undo;
+            try
+            {
+                var rom = CreateTestRom();
+                var undo = new Undo();
+                CoreState.Undo = undo;
+
+                // Snapshot the pre-write byte (0x00) into an UndoData
+                // record, mutate ROM directly to 0xAA, then Push so the
+                // buffer holds the pre-write byte at Postion 1.
+                var ud = undo.NewUndoData("test");
+                ud.list.Add(new Undo.UndoPostion(addr: 0x10, size: 1));
+                rom.write_u8(0x10, 0xAA);
+                undo.Push(ud);
+
+                Assert.Equal(0xAA, rom.Data[0x10]);
+                Assert.Equal(1, undo.Postion);
+                Assert.False(undo.CanRedo);
+
+                // Undo → ROM byte returns to 0x00, cursor moves to 0.
+                undo.RunUndo();
+                Assert.Equal(0x00, rom.Data[0x10]);
+                Assert.Equal(0, undo.Postion);
+                Assert.True(undo.CanRedo);
+
+                // Redo → ROM byte returns to 0xAA, cursor advances to 1,
+                // and RunRedo reports success.
+                bool redoOk = undo.RunRedo();
+                Assert.True(redoOk);
+                Assert.Equal(0xAA, rom.Data[0x10]);
+                Assert.Equal(1, undo.Postion);
+                Assert.False(undo.CanRedo);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.Undo = savedUndo;
+            }
+        }
+
+        /// <summary>
+        /// Empty buffer scenario: with a real ROM but no Push, RunRedo
+        /// must short-circuit on the CanRedo guard and not attempt any
+        /// rollback (which would Debug.Assert on the underlying
+        /// <see cref="Undo.Rollback(int)"/>).
+        /// </summary>
+        [Fact]
+        public void RunRedo_EmptyStack_ReturnsFalse()
+        {
+            var savedRom = CoreState.ROM;
+            var savedUndo = CoreState.Undo;
+            try
+            {
+                CreateTestRom();
+                var undo = new Undo();
+                CoreState.Undo = undo;
+
+                Assert.False(undo.RunRedo());
+                Assert.Equal(0, undo.Postion);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.Undo = savedUndo;
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Core/Undo.cs
+++ b/FEBuilderGBA.Core/Undo.cs
@@ -157,6 +157,35 @@ namespace FEBuilderGBA
             }
             Rollback(this.Postion - 1);
         }
+
+        /// <summary>
+        /// True when there is a forward step available — i.e. the current
+        /// <see cref="Postion"/> is strictly less than the buffer length, so
+        /// <see cref="Rollback(int)"/> can replay one more record.
+        /// </summary>
+        public bool CanRedo => this.Postion < this.UndoBuffer.Count;
+
+        /// <summary>
+        /// Forward-step the undo cursor by one record (the inverse of
+        /// <see cref="RunUndo"/>). Returns false when the cursor is already
+        /// at the end of the buffer, or when the underlying
+        /// <see cref="Rollback(int)"/> silently fails (its internal
+        /// <see cref="RollbackROM(int, ROM)"/> success bool is discarded
+        /// before reaching the caller). This method verifies <see cref="Postion"/>
+        /// actually advanced after the rollback so a hidden failure surfaces
+        /// as a false return.
+        /// </summary>
+        public bool RunRedo()
+        {
+            if (!CanRedo)
+            {
+                return false;
+            }
+            int posBeforeRedo = this.Postion;
+            Rollback(this.Postion + 1);
+            return this.Postion > posBeforeRedo;
+        }
+
         public void Rollback(int pos)
         {
             if (pos < 0)


### PR DESCRIPTION
## Summary

Implements 2 of the 4 deferred Map Style Editor buttons:

- **Redo** button — wraps new Core `Undo.RunRedo()` + `Undo.CanRedo`. The bool return reflects whether the cursor actually advanced (the underlying `Rollback(int)` discards `RollbackROM`'s success bool, so we verify `Postion` post-call). Guards on `CanRedo` so a no-op redo does not falsely toast "Redo applied" (mirrors the `Undo_Click` Postion-guard).
- **MapChip Export** button — writes the VM's cached LZ77-decompressed CONFIG buffer to a `.MAPCHIP_CONFIG` file. Raw `ConfigUZ` bytes only — **no magic header** — to preserve WF parity (the WF importer reads raw bytes with only a 9216-byte minimum check). Uses `FileDialogHelper.SaveFile` for picker parity with the rest of the Avalonia layer. Cache access goes through a new VM accessor `GetCachedConfigClone()` that returns a defensive `Clone()` so the view can't mutate the VM's internal cache.

OBJ Import + MapChip Import deferred to follow-up **#704**.

## Scope

Ref #692 (partial — 2 buttons remain in #704).

## Test plan

- [x] `dotnet test FEBuilderGBA.Core.Tests/FEBuilderGBA.Core.Tests.csproj` — all 1964 pass (includes 4 new `UndoRedoTests`: `CanRedo_EmptyStack_ReturnsFalse`, `CanRedo_AtMaxPosition_ReturnsFalse`, `RunRedo_AfterUndo_RestoresOriginalState`, `RunRedo_EmptyStack_ReturnsFalse`).
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests/FEBuilderGBA.Avalonia.Tests.csproj` — all 6833 pass (includes updated `MapStyleEditorParityTests`: Redo + MapChipExport removed from `KnownGapButtonIds`, added to `Slice672ButtonIds` theory, plus 3 new shape checks: `View_Redo_Click_GuardsOnCanRedo`, `View_MapChipExport_Click_UsesVmAccessorAndFileDialogHelper`, `ViewModel_GetCachedConfigClone_ReturnsDefensiveClone`).
- [x] Manual GUI verification on FE8U.gba: launched Avalonia, opened Map Style Editor, selected tileset 0x03 — REDO button enabled, Map Chip Save button enabled (see screenshot). Image Import + Map Chip Load remain disabled as expected (KnownGap → #704).
- [x] `dotnet build FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj` — 0 errors.

## GUI Test Report

| Case | Result | Notes |
|------|--------|-------|
| Launch Avalonia with FE8U ROM | PASS | Main window opens; Style Editor button reachable from Maps group |
| Open Map Style Editor | PASS | Window titled "Map Style Editor" opens with 254 entries |
| Select tileset 0x03 | PASS | Address resolves to 0x008B3648; OBJ + Config pointers populate |
| REDO button enabled state | PASS | No longer carries `IsEnabled="False"`; click wired to `Redo_Click` |
| Map Chip Save button enabled state | PASS | No longer carries `IsEnabled="False"`; click wired to `MapChipExport_Click` |
| Image Import button still KnownGap | PASS | Stays `IsEnabled="False"` (tracked by #704) |
| Map Chip Load button still KnownGap | PASS | Stays `IsEnabled="False"` (tracked by #704) |

## Screenshot

![Map Style Editor with REDO + Map Chip Save enabled](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr692-redo-mapchip-export.png)

Captured via PrintWindow (tools/WinCapture) from the running Avalonia GUI on FE8U.gba. Screenshot landed on master via docs PR #705 so the link survives feature-branch deletion.

Generated with Claude Code (claude-opus-4-7-1m)