### PR TITLE
feat(avalonia): Portrait Import Wizard - eye/mouth block coords (#663 partial)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/PortraitImportHelperEyeMouthTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/PortraitImportHelperEyeMouthTests.cs
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for #663 Slice A — PortraitImportHelper eye/mouth block coords.
+//
+// Verifies the four nullable byte? parameters at the END of ImportSimple /
+// ImportSheet correctly persist to entry bytes B20-B23 on FE7/FE8 ROMs and
+// are silently skipped on FE6 (whose 16-byte entry layout reuses those bytes
+// for unrelated fields). The 0xFF case is exercised explicitly because the
+// API treats 0xFF as a valid byte value (NOT a sentinel) — Copilot CLI v2
+// review point 2.
+using System;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.SkiaSharp;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class PortraitImportHelperEyeMouthTests : IClassFixture<RomFixture>
+    {
+        readonly RomFixture _fixture;
+        readonly ITestOutputHelper _output;
+
+        public PortraitImportHelperEyeMouthTests(RomFixture fixture, ITestOutputHelper output)
+        {
+            _fixture = fixture;
+            _output = output;
+        }
+
+        static IDisposable EnsureImageService()
+        {
+            var prev = CoreState.ImageService;
+            if (prev == null) CoreState.ImageService = new SkiaImageService();
+            return new RestoreImageService(prev);
+        }
+
+        sealed class RestoreImageService : IDisposable
+        {
+            readonly IImageService _prev;
+            public RestoreImageService(IImageService prev) { _prev = prev; }
+            public void Dispose() { CoreState.ImageService = _prev; }
+        }
+
+        static byte[] BuildSimplePalette(int colors)
+        {
+            byte[] pal = new byte[colors * 2];
+            for (int i = 1; i < colors; i++)
+            {
+                int r = (i * 2) & 0x1F;
+                int g = (i * 3) & 0x1F;
+                int b = (i * 5) & 0x1F;
+                ushort gba = (ushort)((b << 10) | (g << 5) | r);
+                pal[i * 2] = (byte)(gba & 0xFF);
+                pal[i * 2 + 1] = (byte)((gba >> 8) & 0xFF);
+            }
+            return pal;
+        }
+
+        static ImageImportService.LoadResult MakeSimpleLoadResult()
+        {
+            const int w = 16, h = 16;
+            byte[] indexed = new byte[w * h];
+            for (int i = 0; i < indexed.Length; i++)
+                indexed[i] = (byte)((i / 8) % 16);
+            return new ImageImportService.LoadResult
+            {
+                Success = true,
+                Width = w,
+                Height = h,
+                IndexedPixels = indexed,
+                GBAPalette = BuildSimplePalette(16),
+                SourcePath = "C:\\tmp\\synthetic.png",
+            };
+        }
+
+        static ImageImportService.LoadResult MakeSheetLoadResult()
+        {
+            const int w = 128, h = 112;
+            byte[] indexed = new byte[w * h];
+            for (int i = 0; i < indexed.Length; i++)
+                indexed[i] = (byte)((i / 32) % 16);
+            return new ImageImportService.LoadResult
+            {
+                Success = true,
+                Width = w,
+                Height = h,
+                IndexedPixels = indexed,
+                GBAPalette = BuildSimplePalette(16),
+                SourcePath = "C:\\tmp\\synthetic_sheet.png",
+            };
+        }
+
+        // Pick a portrait entry far enough into the table that the
+        // pre-existing palette test bank (entries 0-7) is undisturbed.
+        const int TestEntryIndex = 9;
+
+        static uint GetEntryAddr(ROM rom, int index)
+        {
+            uint baseAddr = rom.p32(rom.RomInfo.portrait_pointer);
+            return baseAddr + (uint)(index * rom.RomInfo.portrait_datasize);
+        }
+
+        // ------------------------------------------------------------------
+        // Test 1: FE8U, all 4 NUDs supplied → B20-B23 contain the supplied
+        // values after Import (Copilot CLI v3 Slice A primary acceptance).
+        // ------------------------------------------------------------------
+        [Fact]
+        public void ImportSimple_FE8U_WritesB20B23()
+        {
+            if (!_fixture.IsAvailable || _fixture.Version != "FE8U")
+            {
+                _output.WriteLine($"SKIP: needs FE8U ROM (have {_fixture.Version})");
+                return;
+            }
+
+            using var _ = EnsureImageService();
+            var rom = _fixture.ROM;
+            uint entryAddr = GetEntryAddr(rom, TestEntryIndex);
+
+            var loadResult = MakeSimpleLoadResult();
+            var undo = new UndoService();
+            var outcome = PortraitImportHelper.ImportSimple(
+                rom, entryAddr, loadResult, undo,
+                PortraitPaletteMode.AutoQuantize, null, false,
+                "Import w/ B20-B23 (FE8U test)",
+                mouthBlockX: 10, mouthBlockY: 20, eyeBlockX: 30, eyeBlockY: 40);
+
+            Assert.True(outcome.Success, $"Import failed: {outcome.Error}");
+            Assert.Equal((uint)10, rom.u8(entryAddr + 20));
+            Assert.Equal((uint)20, rom.u8(entryAddr + 21));
+            Assert.Equal((uint)30, rom.u8(entryAddr + 22));
+            Assert.Equal((uint)40, rom.u8(entryAddr + 23));
+        }
+
+        // ------------------------------------------------------------------
+        // Test 2: FE6, all 4 NUDs supplied → B20-B23 UNCHANGED (the FE6
+        // 16-byte entry layout uses those bytes for unrelated fields, so
+        // the helper must NOT clobber them).
+        // ------------------------------------------------------------------
+        [Fact]
+        public void ImportSimple_FE6_SkipsB20B23()
+        {
+            if (!_fixture.IsAvailable || _fixture.Version != "FE6")
+            {
+                _output.WriteLine($"SKIP: needs FE6 ROM (have {_fixture.Version})");
+                return;
+            }
+
+            using var _ = EnsureImageService();
+            var rom = _fixture.ROM;
+            uint entryAddr = GetEntryAddr(rom, TestEntryIndex);
+
+            // Snapshot bytes that *would* be B20-B23 on an FE7/FE8 entry.
+            // On FE6 these are part of the NEXT entry — make sure we don't
+            // touch them.
+            byte before20 = (byte)rom.u8(entryAddr + 20);
+            byte before21 = (byte)rom.u8(entryAddr + 21);
+            byte before22 = (byte)rom.u8(entryAddr + 22);
+            byte before23 = (byte)rom.u8(entryAddr + 23);
+
+            var loadResult = MakeSimpleLoadResult();
+            var undo = new UndoService();
+            var outcome = PortraitImportHelper.ImportSimple(
+                rom, entryAddr, loadResult, undo,
+                PortraitPaletteMode.AutoQuantize, null, false,
+                "Import w/ B20-B23 (FE6 skip test)",
+                mouthBlockX: 10, mouthBlockY: 20, eyeBlockX: 30, eyeBlockY: 40);
+
+            Assert.True(outcome.Success, $"Import failed: {outcome.Error}");
+            Assert.Equal((uint)before20, rom.u8(entryAddr + 20));
+            Assert.Equal((uint)before21, rom.u8(entryAddr + 21));
+            Assert.Equal((uint)before22, rom.u8(entryAddr + 22));
+            Assert.Equal((uint)before23, rom.u8(entryAddr + 23));
+        }
+
+        // ------------------------------------------------------------------
+        // Test 3: FE7/FE8, all 4 params left as null → B20-B23 UNCHANGED.
+        // This proves backward compatibility for existing callers (Pick
+        // PNG/BMP, FE-Repo, drag-drop, batch import) that don't supply the
+        // new params.
+        // ------------------------------------------------------------------
+        [Fact]
+        public void ImportSimple_NullParams_DoesNotOverwrite()
+        {
+            if (!_fixture.IsAvailable)
+            {
+                _output.WriteLine("SKIP: no ROM available");
+                return;
+            }
+            if (_fixture.Version == "FE6")
+            {
+                _output.WriteLine("SKIP: this test needs FE7 or FE8");
+                return;
+            }
+
+            using var _ = EnsureImageService();
+            var rom = _fixture.ROM;
+            uint entryAddr = GetEntryAddr(rom, TestEntryIndex);
+
+            byte before20 = (byte)rom.u8(entryAddr + 20);
+            byte before21 = (byte)rom.u8(entryAddr + 21);
+            byte before22 = (byte)rom.u8(entryAddr + 22);
+            byte before23 = (byte)rom.u8(entryAddr + 23);
+
+            var loadResult = MakeSimpleLoadResult();
+            var undo = new UndoService();
+            // Call the mode-aware overload without supplying the new params
+            // (all default to null).
+            var outcome = PortraitImportHelper.ImportSimple(
+                rom, entryAddr, loadResult, undo,
+                PortraitPaletteMode.AutoQuantize, null, false,
+                "Import w/ null block coords (backward-compat test)");
+
+            Assert.True(outcome.Success, $"Import failed: {outcome.Error}");
+            Assert.Equal((uint)before20, rom.u8(entryAddr + 20));
+            Assert.Equal((uint)before21, rom.u8(entryAddr + 21));
+            Assert.Equal((uint)before22, rom.u8(entryAddr + 22));
+            Assert.Equal((uint)before23, rom.u8(entryAddr + 23));
+        }
+
+        // ------------------------------------------------------------------
+        // Test 4: FE7/FE8, 0xFF passed → B20-B23 == 0xFF after Import.
+        // 0xFF is NOT a sentinel; it must round-trip like any other byte
+        // value (Copilot CLI v2 review point 2).
+        // ------------------------------------------------------------------
+        [Fact]
+        public void ImportSimple_FF_WritesFF()
+        {
+            if (!_fixture.IsAvailable)
+            {
+                _output.WriteLine("SKIP: no ROM available");
+                return;
+            }
+            if (_fixture.Version == "FE6")
+            {
+                _output.WriteLine("SKIP: this test needs FE7 or FE8");
+                return;
+            }
+
+            using var _ = EnsureImageService();
+            var rom = _fixture.ROM;
+            uint entryAddr = GetEntryAddr(rom, TestEntryIndex);
+
+            var loadResult = MakeSimpleLoadResult();
+            var undo = new UndoService();
+            var outcome = PortraitImportHelper.ImportSimple(
+                rom, entryAddr, loadResult, undo,
+                PortraitPaletteMode.AutoQuantize, null, false,
+                "Import w/ 0xFF block coords",
+                mouthBlockX: 0xFF, mouthBlockY: 0xFF,
+                eyeBlockX:   0xFF, eyeBlockY:   0xFF);
+
+            Assert.True(outcome.Success, $"Import failed: {outcome.Error}");
+            Assert.Equal((uint)0xFF, rom.u8(entryAddr + 20));
+            Assert.Equal((uint)0xFF, rom.u8(entryAddr + 21));
+            Assert.Equal((uint)0xFF, rom.u8(entryAddr + 22));
+            Assert.Equal((uint)0xFF, rom.u8(entryAddr + 23));
+        }
+
+        // ------------------------------------------------------------------
+        // Test 5: ImportSheet (128x112 composite path), FE7/FE8 → B20-B23
+        // contain the supplied values. Mirrors the ImportSimple test but
+        // covers the second helper entrypoint.
+        // ------------------------------------------------------------------
+        [Fact]
+        public void ImportSheet_FE8U_WritesB20B23()
+        {
+            if (!_fixture.IsAvailable || _fixture.Version != "FE8U")
+            {
+                _output.WriteLine($"SKIP: needs FE8U ROM (have {_fixture.Version})");
+                return;
+            }
+
+            using var _ = EnsureImageService();
+            var rom = _fixture.ROM;
+            // Use a distinct entry so this test does not collide with the
+            // ImportSimple test if they run in the same process.
+            uint entryAddr = GetEntryAddr(rom, TestEntryIndex + 1);
+
+            var loadResult = MakeSheetLoadResult();
+            var undo = new UndoService();
+            var outcome = PortraitImportHelper.ImportSheet(
+                rom, entryAddr, loadResult, undo,
+                PortraitPaletteMode.AutoQuantize, null, false,
+                "Import Sheet w/ B20-B23 (FE8U test)",
+                mouthBlockX: 11, mouthBlockY: 22, eyeBlockX: 33, eyeBlockY: 44);
+
+            Assert.True(outcome.Success, $"Sheet import failed: {outcome.Error}");
+            Assert.Equal((uint)11, rom.u8(entryAddr + 20));
+            Assert.Equal((uint)22, rom.u8(entryAddr + 21));
+            Assert.Equal((uint)33, rom.u8(entryAddr + 22));
+            Assert.Equal((uint)44, rom.u8(entryAddr + 23));
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Services/PortraitImportHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/PortraitImportHelper.cs
@@ -122,6 +122,22 @@ namespace FEBuilderGBA.Avalonia.Services
         /// When <paramref name="fuchidori"/> is true the indexed-pixel buffer is
         /// post-processed by <see cref="ImageUtilCore.Fuchidori(byte[], int, int, byte)"/>
         /// to add a 1-pixel black outline.
+        ///
+        /// Slice A of #663 (mouth/eye block coords): when <paramref name="mouthBlockX"/>,
+        /// <paramref name="mouthBlockY"/>, <paramref name="eyeBlockX"/>, or
+        /// <paramref name="eyeBlockY"/> are non-null AND the ROM uses the 28-byte
+        /// FE7/FE8 portrait entry layout (see <see cref="IsFe7Or8EntryLayout"/>), each
+        /// non-null value is written to its corresponding byte inside the same undo
+        /// scope as the D0 / D8 writes:
+        ///   - <paramref name="mouthBlockX"/> -> entryAddr + 20 (B20)
+        ///   - <paramref name="mouthBlockY"/> -> entryAddr + 21 (B21)
+        ///   - <paramref name="eyeBlockX"/>   -> entryAddr + 22 (B22)
+        ///   - <paramref name="eyeBlockY"/>   -> entryAddr + 23 (B23)
+        /// A null parameter means "caller didn't ask"; the byte is left untouched
+        /// for backward compatibility (existing callers omit the parameters). Any
+        /// byte value (0x00 .. 0xFF) is written as-is — 0xFF is NOT a sentinel.
+        /// On FE6 ROMs the 16-byte entry layout reuses those bytes for unrelated
+        /// fields, so the writes are skipped silently.
         /// </summary>
         public static ImportOutcome ImportSimple(
             ROM rom,
@@ -131,7 +147,11 @@ namespace FEBuilderGBA.Avalonia.Services
             PortraitPaletteMode mode,
             byte[] customPaletteBytes,
             bool fuchidori,
-            string undoLabel = "Import Portrait Image")
+            string undoLabel = "Import Portrait Image",
+            byte? mouthBlockX = null,
+            byte? mouthBlockY = null,
+            byte? eyeBlockX = null,
+            byte? eyeBlockY = null)
         {
             if (rom == null) return ImportOutcome.Fail("ROM not loaded");
             if (loadResult == null || !loadResult.Success)
@@ -224,6 +244,13 @@ namespace FEBuilderGBA.Avalonia.Services
                     }
                 }
 
+                // #663 Slice A: persist optional mouth/eye block coords to
+                // bytes B20-B23. FE7/FE8 only — FE6's 16-byte entry layout uses
+                // those bytes for unrelated fields, so the writes are silently
+                // skipped on FE6 to keep callers version-agnostic.
+                WriteEyeMouthBlockCoords(rom, entryAddr, undoService,
+                    mouthBlockX, mouthBlockY, eyeBlockX, eyeBlockY);
+
                 undoService.Commit();
                 return ImportOutcome.Ok();
             }
@@ -252,9 +279,14 @@ namespace FEBuilderGBA.Avalonia.Services
 
         /// <summary>
         /// Mode-aware overload (#662). Same palette-mode + Fuchidori semantics as
-        /// <see cref="ImportSimple(ROM, uint, ImageImportService.LoadResult, UndoService, PortraitPaletteMode, byte[], bool, string)"/>,
+        /// <see cref="ImportSimple(ROM, uint, ImageImportService.LoadResult, UndoService, PortraitPaletteMode, byte[], bool, string, byte?, byte?, byte?, byte?)"/>,
         /// but for 128x112 composite sheets. SharePalette dereferences D8 to
         /// re-use the existing palette; CustomPalette validates 32 bytes.
+        ///
+        /// Slice A of #663: same eye/mouth block-coord semantics as ImportSimple —
+        /// see that overload's XML doc. FE7/FE8 only (the ImportSheet entry is
+        /// already gated to that layout by <see cref="IsFe7Or8EntryLayout"/>, so
+        /// non-null values are always written here when supplied).
         /// </summary>
         public static ImportOutcome ImportSheet(
             ROM rom,
@@ -264,7 +296,11 @@ namespace FEBuilderGBA.Avalonia.Services
             PortraitPaletteMode mode,
             byte[] customPaletteBytes,
             bool fuchidori,
-            string undoLabel = "Import Portrait Sheet (128x112)")
+            string undoLabel = "Import Portrait Sheet (128x112)",
+            byte? mouthBlockX = null,
+            byte? mouthBlockY = null,
+            byte? eyeBlockX = null,
+            byte? eyeBlockY = null)
         {
             if (rom == null) return ImportOutcome.Fail("ROM not loaded");
             if (loadResult == null || !loadResult.Success)
@@ -397,6 +433,13 @@ namespace FEBuilderGBA.Avalonia.Services
                 if (mouthAddr == U.NOT_FOUND)
                 { undoService.Rollback(); return ImportOutcome.Fail("No free space for mouth data"); }
 
+                // #663 Slice A: persist optional mouth/eye block coords to
+                // bytes B20-B23 inside the same undo scope as the pointer writes.
+                // FE7/FE8 only — ImportSheet is already gated to that layout,
+                // so non-null values are always honored here.
+                WriteEyeMouthBlockCoords(rom, entryAddr, undoService,
+                    mouthBlockX, mouthBlockY, eyeBlockX, eyeBlockY);
+
                 undoService.Commit();
                 return ImportOutcome.Ok();
             }
@@ -405,6 +448,32 @@ namespace FEBuilderGBA.Avalonia.Services
                 undoService.Rollback();
                 return ImportOutcome.Fail($"Sheet import failed: {ex.Message}");
             }
+        }
+
+        /// <summary>
+        /// #663 Slice A: write any non-null mouth/eye block coords to bytes
+        /// B20-B23 of the portrait entry. Called inside an open
+        /// <see cref="UndoService"/> scope so the writes participate in the
+        /// same rollback as the D0/D8/D12 writes above. Skipped silently on
+        /// FE6 (16-byte entry layout reuses those bytes for unrelated fields).
+        /// </summary>
+        static void WriteEyeMouthBlockCoords(
+            ROM rom, uint entryAddr, UndoService undoService,
+            byte? mouthBlockX, byte? mouthBlockY,
+            byte? eyeBlockX, byte? eyeBlockY)
+        {
+            if (rom == null) return;
+            if (!IsFe7Or8EntryLayout(rom)) return;
+            if (mouthBlockX == null && mouthBlockY == null
+                && eyeBlockX == null && eyeBlockY == null) return;
+
+            // ROM.BeginUndoScope (entered by UndoService.Begin) routes
+            // rom.write_u8 through the active undo buffer, so a single
+            // rollback after these writes also reverts them.
+            if (mouthBlockX.HasValue) rom.write_u8(entryAddr + 20, mouthBlockX.Value);
+            if (mouthBlockY.HasValue) rom.write_u8(entryAddr + 21, mouthBlockY.Value);
+            if (eyeBlockX.HasValue)   rom.write_u8(entryAddr + 22, eyeBlockX.Value);
+            if (eyeBlockY.HasValue)   rom.write_u8(entryAddr + 23, eyeBlockY.Value);
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/Views/ImagePortraitImporterView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImagePortraitImporterView.axaml
@@ -82,6 +82,42 @@
           </StackPanel>
         </Border>
 
+        <!-- Step 2b: Detail — eye/mouth block coords (#663 Slice A) -->
+        <Border BorderBrush="Gray" BorderThickness="0,0,0,1" Padding="0,4" Margin="0,0,0,4">
+          <Expander AutomationProperties.AutomationId="ImagePortraitImporter_Detail_Expander"
+                    Name="DetailExpander"
+                    Header="2b. Detail — eye/mouth block coords (FE7/FE8 only)"
+                    IsExpanded="False">
+            <StackPanel Spacing="6" Margin="8">
+              <TextBlock AutomationProperties.AutomationId="ImagePortraitImporter_Detail_Fe6Notice_Label"
+                         Name="DetailFe6Notice" IsVisible="False"
+                         Text="Not available on FE6 portraits."
+                         Foreground="DarkOrange" />
+              <Grid ColumnDefinitions="160,120,160,120" RowDefinitions="Auto,Auto">
+                <TextBlock Grid.Row="0" Grid.Column="0" Text="Mouth Block X (B20):" VerticalAlignment="Center" />
+                <NumericUpDown Grid.Row="0" Grid.Column="1"
+                               AutomationProperties.AutomationId="ImagePortraitImporter_MouthBlockX_Input"
+                               Name="MouthBlockXInput" Minimum="0" Maximum="255" FormatString="0" Value="0" />
+                <TextBlock Grid.Row="0" Grid.Column="2" Text="Mouth Block Y (B21):" VerticalAlignment="Center" Margin="8,0,0,0" />
+                <NumericUpDown Grid.Row="0" Grid.Column="3"
+                               AutomationProperties.AutomationId="ImagePortraitImporter_MouthBlockY_Input"
+                               Name="MouthBlockYInput" Minimum="0" Maximum="255" FormatString="0" Value="0" />
+                <TextBlock Grid.Row="1" Grid.Column="0" Text="Eye Block X (B22):" VerticalAlignment="Center" />
+                <NumericUpDown Grid.Row="1" Grid.Column="1"
+                               AutomationProperties.AutomationId="ImagePortraitImporter_EyeBlockX_Input"
+                               Name="EyeBlockXInput" Minimum="0" Maximum="255" FormatString="0" Value="0" />
+                <TextBlock Grid.Row="1" Grid.Column="2" Text="Eye Block Y (B23):" VerticalAlignment="Center" Margin="8,0,0,0" />
+                <NumericUpDown Grid.Row="1" Grid.Column="3"
+                               AutomationProperties.AutomationId="ImagePortraitImporter_EyeBlockY_Input"
+                               Name="EyeBlockYInput" Minimum="0" Maximum="255" FormatString="0" Value="0" />
+              </Grid>
+              <TextBlock AutomationProperties.AutomationId="ImagePortraitImporter_Detail_Help_Label"
+                         TextWrapping="Wrap" Foreground="Gray" FontSize="11"
+                         Text="These bytes mark the block coordinates inside the sprite sheet that the engine uses for mouth + eye animation. Values are pre-populated from the selected slot; tweak them to match a re-arranged sheet, then Import to persist." />
+            </StackPanel>
+          </Expander>
+        </Border>
+
         <!-- Step 3: Target slot -->
         <Border BorderBrush="Gray" BorderThickness="0,0,0,1" Padding="0,4" Margin="0,0,0,4">
           <StackPanel Spacing="6">
@@ -112,7 +148,7 @@
         <!-- Notes -->
         <TextBlock AutomationProperties.AutomationId="ImagePortraitImporter_Notes_Label"
                    TextWrapping="Wrap" Foreground="Gray" FontSize="11"
-                   Text="Notes: this wizard supports the simple single-image import (writes the sprite sheet at D0 and the palette at D8). When the source is a 128x112 composite sheet, the wizard also writes the mini face (D4) and mouth frames (D12) — FE7/FE8 only. Use 'Pick Folder (batch)...' to import a whole folder at once — name each file 0xNN.png or NN.png so the wizard knows which portrait slot to write. Palette options: Auto-quantize picks 16 best-fit colors from the image; Share with target slot re-uses the existing palette already in ROM at the chosen slot; Custom palette file imports a .pal/.act/.gpl palette. Tick 'Add black outline (Fuchidori)' to draw a 1-pixel outline around opaque areas. Advanced features (eye/mouth block sliders) are tracked under follow-up issues." />
+                   Text="Notes: this wizard supports the simple single-image import (writes the sprite sheet at D0 and the palette at D8). When the source is a 128x112 composite sheet, the wizard also writes the mini face (D4) and mouth frames (D12) — FE7/FE8 only. Use 'Pick Folder (batch)...' to import a whole folder at once — name each file 0xNN.png or NN.png so the wizard knows which portrait slot to write. Palette options: Auto-quantize picks 16 best-fit colors from the image; Share with target slot re-uses the existing palette already in ROM at the chosen slot; Custom palette file imports a .pal/.act/.gpl palette. Tick 'Add black outline (Fuchidori)' to draw a 1-pixel outline around opaque areas. The Detail expander (FE7/FE8 only) edits the mouth/eye block coords (bytes B20-B23) that ship in this slice (#663). Deferred to follow-up #707: per-frame live preview pane (eye crop, mouth crop, full face) and eye/mouth crop position/size NumericUpDowns + WF status label strings." />
 
       </StackPanel>
     </ScrollViewer>

--- a/FEBuilderGBA.Avalonia/Views/ImagePortraitImporterView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImagePortraitImporterView.axaml.cs
@@ -18,8 +18,12 @@
 //   - Auto-quantize (default), Share with target slot, Custom palette file...
 //   - Fuchidori (black outline) checkbox orthogonal to palette mode.
 //
+// Eye/mouth block coords (#663 Slice A) — implemented via the Detail
+// expander: 4 NumericUpDowns (MouthBlockX/Y, EyeBlockX/Y) that map to
+// portrait entry bytes B20-B23 on FE7/FE8 ROMs. FE6 hides the inputs.
+//
 // Out of scope (tracked under follow-ups):
-//   - Eye/mouth block configuration + per-frame preview (#663)
+//   - Per-frame live preview pane + crop position/size + status label (#707)
 using System;
 using System.IO;
 using System.Linq;
@@ -99,6 +103,45 @@ namespace FEBuilderGBA.Avalonia.Views
             AddrLabel.Text = _vm.CurrentAddr == 0
                 ? "(no slot selected)"
                 : string.Format("0x{0:X08}", _vm.CurrentAddr);
+
+            // #663 Slice A: pre-populate the 4 Detail NumericUpDowns from the
+            // selected slot's current B20-B23 bytes. On FE6 the bytes are
+            // unrelated (16-byte entry layout), so we disable the expander and
+            // surface a notice instead of reading bogus values.
+            UpdateDetailPanel();
+        }
+
+        // #663 Slice A: refresh the Detail expander's enabled state + 4
+        // NumericUpDowns to match the currently selected slot. Called from
+        // UpdateUI (on slot selection) and once at Opened time so the panel
+        // reflects whatever slot the wizard auto-selects on first show.
+        void UpdateDetailPanel()
+        {
+            ROM rom = CoreState.ROM;
+            uint addr = _vm.CurrentAddr;
+            bool isFe7Or8 = rom != null && PortraitImportHelper.IsFe7Or8EntryLayout(rom);
+
+            if (DetailFe6Notice != null)
+                DetailFe6Notice.IsVisible = rom != null && !isFe7Or8;
+
+            // Disable the NUDs when there's no slot selected or the ROM is
+            // FE6 — values are meaningless / dangerous in either case.
+            bool enableNuds = isFe7Or8 && addr != 0;
+            if (MouthBlockXInput != null) MouthBlockXInput.IsEnabled = enableNuds;
+            if (MouthBlockYInput != null) MouthBlockYInput.IsEnabled = enableNuds;
+            if (EyeBlockXInput   != null) EyeBlockXInput.IsEnabled   = enableNuds;
+            if (EyeBlockYInput   != null) EyeBlockYInput.IsEnabled   = enableNuds;
+
+            if (!enableNuds) return;
+
+            // Safe bounds check: 28-byte FE7/FE8 entries, addr+23 must fit
+            // inside ROM.Data.
+            if ((long)addr + 24 > rom.Data.Length) return;
+
+            if (MouthBlockXInput != null) MouthBlockXInput.Value = rom.u8(addr + 20);
+            if (MouthBlockYInput != null) MouthBlockYInput.Value = rom.u8(addr + 21);
+            if (EyeBlockXInput   != null) EyeBlockXInput.Value   = rom.u8(addr + 22);
+            if (EyeBlockYInput   != null) EyeBlockYInput.Value   = rom.u8(addr + 23);
         }
 
         // #664: drag-over handler — accept the drag if any file has a
@@ -360,6 +403,20 @@ namespace FEBuilderGBA.Avalonia.Views
                     return;
                 }
 
+                // #663 Slice A: capture the 4 Detail block-coord values to pass
+                // through to the helper. Only send non-null values when the ROM
+                // is FE7/FE8 (the helper itself also skips FE6, but gating here
+                // keeps Slice A's intent self-documenting at the call site).
+                byte? mouthBlockX = null, mouthBlockY = null;
+                byte? eyeBlockX = null, eyeBlockY = null;
+                if (PortraitImportHelper.IsFe7Or8EntryLayout(rom))
+                {
+                    mouthBlockX = (byte)(MouthBlockXInput?.Value ?? 0);
+                    mouthBlockY = (byte)(MouthBlockYInput?.Value ?? 0);
+                    eyeBlockX   = (byte)(EyeBlockXInput?.Value   ?? 0);
+                    eyeBlockY   = (byte)(EyeBlockYInput?.Value   ?? 0);
+                }
+
                 // Single source of truth: PortraitImportHelper. Same path used
                 // by ImagePortraitView (drag-drop + Import PNG button).
                 ImportOutcome outcome;
@@ -367,13 +424,15 @@ namespace FEBuilderGBA.Avalonia.Views
                 {
                     outcome = PortraitImportHelper.ImportSheet(rom, addr, loadResult, _undoService,
                         mode, _customPaletteBytes, FuchidoriEnabled,
-                        "Import Portrait Sheet (Wizard)");
+                        "Import Portrait Sheet (Wizard)",
+                        mouthBlockX, mouthBlockY, eyeBlockX, eyeBlockY);
                 }
                 else
                 {
                     outcome = PortraitImportHelper.ImportSimple(rom, addr, loadResult, _undoService,
                         mode, _customPaletteBytes, FuchidoriEnabled,
-                        "Import Portrait Image (Wizard)");
+                        "Import Portrait Image (Wizard)",
+                        mouthBlockX, mouthBlockY, eyeBlockX, eyeBlockY);
                 }
 
                 if (!outcome.Success)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ dotnet publish tools/ColorzCore/ColorzCore/ColorzCore.csproj -c Release -r linux
 
 **Runtime note:** All releases (WinForms, CLI, Avalonia) ship ColorzCore as a self-contained executable, requiring no additional .NET runtime.
 
-**Public Resources:** [FE-Repo](https://github.com/Klokinator/FE-Repo) (graphics) and [FE-Repo-Music-No-Preview](https://github.com/laqieer/FE-Repo-Music-No-Preview) (music) are included as submodules in `resources/`. Browse and insert resources directly from the portrait editor (FE-Repo button), the Portrait Import Wizard (FE-Repo button + PNG/BMP drag-and-drop + advanced palette options: Auto-quantize / Share with target slot / Custom palette file + Fuchidori black-outline checkbox — #662), and song exchange form (FE-Repo Music button) in both WinForms and Avalonia.
+**Public Resources:** [FE-Repo](https://github.com/Klokinator/FE-Repo) (graphics) and [FE-Repo-Music-No-Preview](https://github.com/laqieer/FE-Repo-Music-No-Preview) (music) are included as submodules in `resources/`. Browse and insert resources directly from the portrait editor (FE-Repo button), the Portrait Import Wizard (FE-Repo button + PNG/BMP drag-and-drop + advanced palette options: Auto-quantize / Share with target slot / Custom palette file + Fuchidori black-outline checkbox — #662 + Detail expander for eye/mouth block coords B20-B23 on FE7/FE8 — #663 Slice A), and song exchange form (FE-Repo Music button) in both WinForms and Avalonia.
 
 ### Cross-Platform Build (Linux / macOS / Windows)
 

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -9759,8 +9759,8 @@ FE-Repo...
 :4. Write to ROM
 4. ROM に書き込み
 
-:Notes: this wizard supports the simple single-image import (writes the sprite sheet at D0 and the palette at D8). When the source is a 128x112 composite sheet, the wizard also writes the mini face (D4) and mouth frames (D12) — FE7/FE8 only. Use 'Pick Folder (batch)...' to import a whole folder at once — name each file 0xNN.png or NN.png so the wizard knows which portrait slot to write. Palette options: Auto-quantize picks 16 best-fit colors from the image; Share with target slot re-uses the existing palette already in ROM at the chosen slot; Custom palette file imports a .pal/.act/.gpl palette. Tick 'Add black outline (Fuchidori)' to draw a 1-pixel outline around opaque areas. Advanced features (eye/mouth block sliders) are tracked under follow-up issues.
-備考: このウィザードはシングル画像のインポート（D0 にスプライトシート、D8 にパレットを書き込む）に対応します。128x112 の合成シートの場合は、ミニフェイス（D4）と口アニメ（D12）も書き込みます — FE7 / FE8 のみ。「Pick Folder (batch)...」でフォルダ内のファイルを一括インポートできます — 各ファイル名を 0xNN.png または NN.png にすると、ウィザードが書き込み先スロットを判別します。パレットオプション: Auto-quantize は画像から最適な 16 色を選びます; Share with target slot は ROM の対象スロットにある既存パレットを再利用します; Custom palette file は .pal/.act/.gpl パレットをインポートします。「Add black outline (Fuchidori)」をチェックすると、不透明部の周りに 1 ピクセルの黒い縁取りを描きます。高度な機能（目・口ブロックスライダー）は follow-up issue で追跡しています。
+:Notes: this wizard supports the simple single-image import (writes the sprite sheet at D0 and the palette at D8). When the source is a 128x112 composite sheet, the wizard also writes the mini face (D4) and mouth frames (D12) — FE7/FE8 only. Use 'Pick Folder (batch)...' to import a whole folder at once — name each file 0xNN.png or NN.png so the wizard knows which portrait slot to write. Palette options: Auto-quantize picks 16 best-fit colors from the image; Share with target slot re-uses the existing palette already in ROM at the chosen slot; Custom palette file imports a .pal/.act/.gpl palette. Tick 'Add black outline (Fuchidori)' to draw a 1-pixel outline around opaque areas. The Detail expander (FE7/FE8 only) edits the mouth/eye block coords (bytes B20-B23) that ship in this slice (#663). Deferred to follow-up #707: per-frame live preview pane (eye crop, mouth crop, full face) and eye/mouth crop position/size NumericUpDowns + WF status label strings.
+備考: このウィザードはシングル画像のインポート（D0 にスプライトシート、D8 にパレットを書き込む）に対応します。128x112 の合成シートの場合は、ミニフェイス（D4）と口アニメ（D12）も書き込みます — FE7 / FE8 のみ。「Pick Folder (batch)...」でフォルダ内のファイルを一括インポートできます — 各ファイル名を 0xNN.png または NN.png にすると、ウィザードが書き込み先スロットを判別します。パレットオプション: Auto-quantize は画像から最適な 16 色を選びます; Share with target slot は ROM の対象スロットにある既存パレットを再利用します; Custom palette file は .pal/.act/.gpl パレットをインポートします。「Add black outline (Fuchidori)」をチェックすると、不透明部の周りに 1 ピクセルの黒い縁取りを描きます。Detail エキスパンダ（FE7 / FE8 のみ）では、本スライス（#663）で同梱した口・目ブロック座標バイト B20〜B23 を編集できます。フォローアップ #707 に延期: フレームごとのライブプレビュー（目クロップ、口クロップ、フルフェイス）と、目・口クロップ位置／サイズの NumericUpDown、および WF のステータスラベル文字列。
 
 :2a. Palette options
 2a. パレットオプション
@@ -9782,6 +9782,27 @@ FE-Repo...
 
 :Add black outline (Fuchidori)
 縁を黒どりする (Fuchidori)
+
+:2b. Detail — eye/mouth block coords (FE7/FE8 only)
+2b. 詳細 — 目・口ブロック座標 (FE7 / FE8 のみ)
+
+:Not available on FE6 portraits.
+FE6 の顔画像では使用できません。
+
+:Mouth Block X (B20):
+口ブロック X (B20):
+
+:Mouth Block Y (B21):
+口ブロック Y (B21):
+
+:Eye Block X (B22):
+目ブロック X (B22):
+
+:Eye Block Y (B23):
+目ブロック Y (B23):
+
+:These bytes mark the block coordinates inside the sprite sheet that the engine uses for mouth + eye animation. Values are pre-populated from the selected slot; tweak them to match a re-arranged sheet, then Import to persist.
+これらのバイトは、エンジンが口・目アニメに使用するスプライトシート内のブロック座標を示します。値は選択中のスロットからプリロードされます。シートを再配置した場合はここで調整し、Import で書き込んでください。
 
 :Pick PNG/BMP...
 PNG / BMP を選択...

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -23591,8 +23591,8 @@ FE-Repo...
 :4. Write to ROM
 4. 写入 ROM
 
-:Notes: this wizard supports the simple single-image import (writes the sprite sheet at D0 and the palette at D8). When the source is a 128x112 composite sheet, the wizard also writes the mini face (D4) and mouth frames (D12) — FE7/FE8 only. Use 'Pick Folder (batch)...' to import a whole folder at once — name each file 0xNN.png or NN.png so the wizard knows which portrait slot to write. Palette options: Auto-quantize picks 16 best-fit colors from the image; Share with target slot re-uses the existing palette already in ROM at the chosen slot; Custom palette file imports a .pal/.act/.gpl palette. Tick 'Add black outline (Fuchidori)' to draw a 1-pixel outline around opaque areas. Advanced features (eye/mouth block sliders) are tracked under follow-up issues.
-说明：此向导支持简单的单图导入（在 D0 写入精灵图，在 D8 写入调色板）。当源是 128x112 合成图时，向导还会写入 mini 脸（D4）和嘴部帧（D12）—— 仅限 FE7/FE8。使用「Pick Folder (batch)...」可一次性导入整个文件夹 —— 每个文件按 0xNN.png 或 NN.png 命名，向导即可识别目标槽位。调色板选项：Auto-quantize 从图像中选取 16 个最佳匹配颜色；Share with target slot 复用 ROM 中目标槽位已有的调色板；Custom palette file 导入 .pal/.act/.gpl 调色板。勾选「Add black outline (Fuchidori)」可在不透明区域周围绘制 1 像素的黑色描边。高级功能（眼睛/嘴部块滑块）已记录到后续 issue 中。
+:Notes: this wizard supports the simple single-image import (writes the sprite sheet at D0 and the palette at D8). When the source is a 128x112 composite sheet, the wizard also writes the mini face (D4) and mouth frames (D12) — FE7/FE8 only. Use 'Pick Folder (batch)...' to import a whole folder at once — name each file 0xNN.png or NN.png so the wizard knows which portrait slot to write. Palette options: Auto-quantize picks 16 best-fit colors from the image; Share with target slot re-uses the existing palette already in ROM at the chosen slot; Custom palette file imports a .pal/.act/.gpl palette. Tick 'Add black outline (Fuchidori)' to draw a 1-pixel outline around opaque areas. The Detail expander (FE7/FE8 only) edits the mouth/eye block coords (bytes B20-B23) that ship in this slice (#663). Deferred to follow-up #707: per-frame live preview pane (eye crop, mouth crop, full face) and eye/mouth crop position/size NumericUpDowns + WF status label strings.
+说明：此向导支持简单的单图导入（在 D0 写入精灵图，在 D8 写入调色板）。当源是 128x112 合成图时，向导还会写入 mini 脸（D4）和嘴部帧（D12）—— 仅限 FE7/FE8。使用「Pick Folder (batch)...」可一次性导入整个文件夹 —— 每个文件按 0xNN.png 或 NN.png 命名，向导即可识别目标槽位。调色板选项：Auto-quantize 从图像中选取 16 个最佳匹配颜色；Share with target slot 复用 ROM 中目标槽位已有的调色板；Custom palette file 导入 .pal/.act/.gpl 调色板。勾选「Add black outline (Fuchidori)」可在不透明区域周围绘制 1 像素的黑色描边。Detail 展开器（仅限 FE7/FE8）可编辑本切片（#663）随附的口/眼块坐标字节 B20-B23。延期至后续 #707：每帧实时预览面板（眼睛裁剪、嘴部裁剪、完整脸部）以及眼睛/嘴部裁剪位置/尺寸 NumericUpDown 与 WF 状态标签字符串。
 
 :2a. Palette options
 2a. 调色板选项
@@ -23614,6 +23614,27 @@ FE-Repo...
 
 :Add black outline (Fuchidori)
 添加黑色描边 (Fuchidori)
+
+:2b. Detail — eye/mouth block coords (FE7/FE8 only)
+2b. 详细 — 眼/口块坐标（仅限 FE7/FE8）
+
+:Not available on FE6 portraits.
+FE6 头像不支持此功能。
+
+:Mouth Block X (B20):
+口块 X (B20):
+
+:Mouth Block Y (B21):
+口块 Y (B21):
+
+:Eye Block X (B22):
+眼块 X (B22):
+
+:Eye Block Y (B23):
+眼块 Y (B23):
+
+:These bytes mark the block coordinates inside the sprite sheet that the engine uses for mouth + eye animation. Values are pre-populated from the selected slot; tweak them to match a re-arranged sheet, then Import to persist.
+这些字节标记引擎用于口/眼动画的精灵图块坐标。数值会从所选槽预填充；如果重新排列了精灵图，请在此处调整后通过 Import 写入。
 
 :Pick PNG/BMP...
 选择 PNG/BMP...


### PR DESCRIPTION
## Summary

Slice A of #663 — adds the 4 eye/mouth block-coord NumericUpDowns (MouthBlockX/Y at B20-B21, EyeBlockX/Y at B22-B23) to the Portrait Import Wizard's new \"2b. Detail\" expander. Values persist to the selected portrait entry on Import. FE7/FE8 only (FE6 16-byte entry layout reuses those bytes for unrelated fields, so the expander disables with a notice on FE6).

The remaining acceptance criteria from #663 (per-frame live preview pane, eye/mouth crop position/size NumericUpDowns, WF status-label strings, GenEye/GenMouth/GenPreview/GenPreviewMainChar port) are tracked in follow-up #707.

## Approach

- **WU1** — Extend `PortraitImportHelper.ImportSimple` + `ImportSheet` with 4 nullable `byte?` params at the END of each signature:
  - `null` = \"don't write\" (backward compat — all existing callers omit them)
  - any byte value 0x00-0xFF is written as-is; 0xFF is NOT a sentinel
  - writes go inside the existing undo scope (rollback reverts them too)
  - FE6 silently skipped via `IsFe7Or8EntryLayout` gate
- **WU2** — Add a `Detail` expander to `ImagePortraitImporterView.axaml` with 4 NumericUpDowns (Min=0, Max=255). Code-behind pre-populates from `rom.u8(addr + 20..23)` on slot selection (FE7/8) and passes the 4 values into the helper on Import.
- **WU3** — 5 new tests in `FEBuilderGBA.Avalonia.Tests/PortraitImportHelperEyeMouthTests.cs`, all passing locally.
- **WU4** — Follow-up issue #707 filed BEFORE this PR enumerating every deferred AC item (preview pane, crop position/size, status labels, GenEye/GenMouth/GenPreview port).

## Plan + reviews

- Plan v3 posted as a comment on #663 (addresses Copilot CLI v2's 3 blocking concerns: wrong API surface, dropped AC tracking, 0xFF semantics).

## Test plan

- [x] \`dotnet build FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj\` — 0 errors
- [x] \`dotnet build FEBuilderGBA.Avalonia.Tests/FEBuilderGBA.Avalonia.Tests.csproj\` — 0 errors
- [x] \`dotnet test FEBuilderGBA.Avalonia.Tests --filter PortraitImportHelperEyeMouthTests\` — 5/5 pass
- [x] \`dotnet test FEBuilderGBA.Avalonia.Tests --filter PortraitImport\` — 51/51 pass (all existing portrait-import tests still green)
- [x] \`dotnet test FEBuilderGBA.Core.Tests\` — 1964/1964 pass (no Core regressions)
- [x] GUI validation: launched Avalonia with FE8U ROM, opened wizard, expanded Detail panel, confirmed all 4 NumericUpDowns render and pre-populate from selected slot (Eirika at 0x008ACBC4)

## GUI Test Report

| Step | Action | Expected | Result |
| --- | --- | --- | --- |
| 1 | Launch Avalonia with FE8U ROM | Main window opens | PASS |
| 2 | Click Portrait Import menu item | Wizard opens | PASS |
| 3 | Default Eirika slot (0x00) is selected | AddrLabel shows 0x008ACBC4 | PASS |
| 4 | New \"2b. Detail — eye/mouth block coords (FE7/FE8 only)\" expander present | Expander visible between Palette options + Target slot | PASS |
| 5 | Expand the Detail expander | 4 NumericUpDowns appear (Mouth Block X (B20), Mouth Block Y (B21), Eye Block X (B22), Eye Block Y (B23)) | PASS |
| 6 | NumericUpDowns pre-populated from rom.u8(addr+20..23) | Values reflect existing ROM bytes | PASS |
| 7 | Notes text references #707 follow-up | Notes block mentions deferred preview + crop + status | PASS |

## Screenshot

![Portrait Import Wizard Detail expander with 4 NumericUpDowns](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/pr663-portrait-wizard-detail.png?raw=1)

Captured via \`tools/WinCapture\` PrintWindow API against the live Avalonia app on FE8U. Image shows the Portrait Import Wizard with the new \"2b. Detail\" expander expanded, all 4 NumericUpDowns visible (MouthBlockX/Y/B20-B21, EyeBlockX/Y/B22-B23) on the Eirika slot. Screenshot is committed to master in docs PR #708 to avoid feature-branch URLs that 404 after merge.

Ref #663 (partial — preview + crop + status remain in follow-up #707).
Depends on docs PR #708 (screenshot file landing on master).

Generated with Claude Code (claude-opus-4-7-1m)