### PR TITLE
feat(avalonia): Map Style Editor MapChip Import (#704 partial)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MapStyleEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MapStyleEditorParityTests.cs
@@ -1014,8 +1014,16 @@ public class MapStyleEditorParityTests
 
     // -----------------------------------------------------------------
     // #672 Slice A — 5 newly-functional buttons (Palette Export / Import /
-    // Clipboard, OBJ Export, Undo). Remaining 4 buttons (Redo, OBJ Import,
-    // MapChip Export/Import) tracked by follow-up #692.
+    // Clipboard, OBJ Export, Undo). After #704 the remaining KnownGap set
+    // is just 3 buttons:
+    //   - MapChipExport_Button → #692
+    //   - ObjImport_Button     → #710 (new follow-up; needs option-dialog
+    //                                  port + 4bpp encoding + FE7 obj2)
+    //   - Redo_Button          → #692
+    // MapChipImport became functional via #704 — see the
+    // View_MapChipImport_Button_IsEnabled / View_MapChipImport_Click_HandlerWired
+    // positive parity tests near the end of this file. The authoritative
+    // issue mapping lives in `KnownGapTooltipIssue`.
     // -----------------------------------------------------------------
 
     public static IEnumerable<object[]> Slice672ButtonIds()

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MapStyleEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MapStyleEditorParityTests.cs
@@ -192,34 +192,32 @@ public class MapStyleEditorParityTests
     /// </summary>
     static readonly string[] KnownGapButtonIds =
     {
-        // 3 buttons remain deferred. Redo + MapChipExport track #692;
-        // ObjImport tracks the new #710 (#704 follow-up that needs the
-        // MapStyleEditorImportImageOptionForm port + 4bpp encoding + FE7
-        // obj2 handling). MapChipImport became functional in #704.
+        // 1 button remains deferred after #704 partial slice. ObjImport
+        // tracks the new follow-up #710 (needs MapStyleEditorImportImageOptionForm
+        // port + 4bpp encoding + FE7 obj2 split handling).
         // PaletteExport/Import/Clipboard/ObjExport/Undo became functional
-        // in #672 Slice A (see View_<Name>_Button_IsEnabled +
+        // in #672 Slice A; Redo and MapChip Export became functional in
+        // #692 partial slice; MapChip Import became functional in #704
+        // (see View_<Name>_Button_IsEnabled +
         // View_<Name>_Click_HandlerWired tests below).
         //
         // PaletteWrite is functional via #660 first slice (tracked positively
         // by View_FunctionalPaletteWriteButton_IsEnabled); CopyTile / CopyType /
         // Paste / ConfigWrite became functional in #671 (tracked positively
         // by View_ChipsetTab_FunctionalControls_AreEnabled_WhenCanEdit).
-        "MapStyleEditor_MapChipExport_Button",
         "MapStyleEditor_ObjImport_Button",
-        "MapStyleEditor_Redo_Button",
     };
 
     /// <summary>
-    /// Mapping of each remaining KnownGap button to the issue number its
-    /// follow-up tooltip must reference. OBJ Import was promoted from the
-    /// shared #692 bucket to its own follow-up #710 in #704 because it
-    /// needs substantially more work (option dialog + 4bpp + obj2).
+    /// Per-button mapping of remaining KnownGap buttons to the follow-up
+    /// issue their tooltip must reference. OBJ Import was promoted to its
+    /// own follow-up #710 in #704 because it needs substantially more work
+    /// (option dialog + 4bpp encoding + FE7 obj2) than the original #692
+    /// bucket assumed.
     /// </summary>
     static readonly System.Collections.Generic.Dictionary<string, string> KnownGapTooltipIssue = new()
     {
-        ["MapStyleEditor_MapChipExport_Button"] = "#692",
         ["MapStyleEditor_ObjImport_Button"] = "#710",
-        ["MapStyleEditor_Redo_Button"] = "#692",
     };
 
     [Fact]
@@ -235,8 +233,10 @@ public class MapStyleEditorParityTests
             Assert.Contains(idAttr, axaml);
 
             // Locate the <Button ... /> element containing this id and
-            // verify the element body has IsEnabled="False" and the
-            // tracked follow-up tooltip.
+            // verify the element body has IsEnabled="False" and the tracked
+            // follow-up tooltip. Per #704: OBJ Import moved from #692 to
+            // the new #710; KnownGapTooltipIssue is the per-button source
+            // of truth so future additions can carry their own issue.
             var elementPattern = new Regex(
                 @"<Button(?:\s[^/>]*?)?" + Regex.Escape(idAttr) + @"[\s\S]*?/?>",
                 RegexOptions.None);
@@ -1013,17 +1013,11 @@ public class MapStyleEditorParityTests
     }
 
     // -----------------------------------------------------------------
-    // #672 Slice A — 5 newly-functional buttons (Palette Export / Import /
-    // Clipboard, OBJ Export, Undo). After #704 the remaining KnownGap set
-    // is just 3 buttons:
-    //   - MapChipExport_Button → #692
-    //   - ObjImport_Button     → #710 (new follow-up; needs option-dialog
-    //                                  port + 4bpp encoding + FE7 obj2)
-    //   - Redo_Button          → #692
-    // MapChipImport became functional via #704 — see the
-    // View_MapChipImport_Button_IsEnabled / View_MapChipImport_Click_HandlerWired
-    // positive parity tests near the end of this file. The authoritative
-    // issue mapping lives in `KnownGapTooltipIssue`.
+    // #672 Slice A + #692 partial slice — 7 newly-functional buttons.
+    // #672 Slice A: PaletteExport / PaletteImport / PaletteClipboard /
+    // ObjExport / Undo. #692 partial slice: Redo + MapChip Export. The
+    // 2 remaining buttons (OBJ Import + MapChip Import) are tracked by
+    // the follow-up issue filed before the #692 partial-slice PR.
     // -----------------------------------------------------------------
 
     public static IEnumerable<object[]> Slice672ButtonIds()
@@ -1033,6 +1027,9 @@ public class MapStyleEditorParityTests
         yield return new object[] { "MapStyleEditor_PaletteClipboard_Button", "PaletteClipboard_Click" };
         yield return new object[] { "MapStyleEditor_ObjExport_Button", "ObjExport_Click" };
         yield return new object[] { "MapStyleEditor_Undo_Button", "Undo_Click" };
+        // #692 partial slice additions.
+        yield return new object[] { "MapStyleEditor_Redo_Button", "Redo_Click" };
+        yield return new object[] { "MapStyleEditor_MapChipExport_Button", "MapChipExport_Click" };
     }
 
     /// <summary>
@@ -1081,6 +1078,100 @@ public class MapStyleEditorParityTests
             RegexOptions.None), code);
     }
 
+    /// <summary>
+    /// Undo handler must guard on <c>CoreState.Undo?.Postion &gt; 0</c>
+    /// before calling RunUndo (v2 Copilot review item 2 — silently no-op
+    /// when Position is 0 misleads the user with a false "Undo applied"
+    /// toast). The code-behind must read Postion before RunUndo.
+    /// </summary>
+    [Fact]
+    public void View_Undo_Click_GuardsOnPostion()
+    {
+        string code = File.ReadAllText(CodeBehindPath());
+        // The Undo_Click body must reference Postion and bail to ShowInfo
+        // ("Nothing to undo") before RunUndo() is called.
+        var bodyMatch = Regex.Match(code,
+            @"void Undo_Click[\s\S]*?(?=\n\s{8}(static\s|public\s|void\s|/// |\}))",
+            RegexOptions.Singleline);
+        Assert.True(bodyMatch.Success, "Undo_Click method not found");
+        string body = bodyMatch.Value;
+        Assert.Contains("Postion", body);
+        Assert.Contains("Nothing to undo", body);
+        // The guard must precede RunUndo() in source order.
+        int postionIdx = body.IndexOf("Postion", StringComparison.Ordinal);
+        int runUndoIdx = body.IndexOf("RunUndo()", StringComparison.Ordinal);
+        Assert.True(postionIdx >= 0 && runUndoIdx >= 0,
+            "Undo_Click must reference Postion and RunUndo()");
+        Assert.True(postionIdx < runUndoIdx,
+            "Postion guard must precede RunUndo() call");
+    }
+
+    // -----------------------------------------------------------------
+    // #692 partial slice — Redo + MapChip Export specific shape checks.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Redo handler must guard on <see cref="Undo.CanRedo"/> before calling
+    /// <see cref="Undo.RunRedo"/> (mirrors <see cref="Undo_Click"/>'s
+    /// Postion-guard pattern) and emit a "Nothing to redo" toast on the
+    /// no-op path. The guard must precede RunRedo() in source order so a
+    /// silently no-op rollback never falsely claims "Redo applied".
+    /// </summary>
+    [Fact]
+    public void View_Redo_Click_GuardsOnCanRedo()
+    {
+        string code = File.ReadAllText(CodeBehindPath());
+        var bodyMatch = Regex.Match(code,
+            @"void Redo_Click[\s\S]*?(?=\n\s{8}(static\s|public\s|void\s|/// |\}))",
+            RegexOptions.Singleline);
+        Assert.True(bodyMatch.Success, "Redo_Click method not found");
+        string body = bodyMatch.Value;
+        Assert.Contains("CanRedo", body);
+        Assert.Contains("Nothing to redo", body);
+        int canRedoIdx = body.IndexOf("CanRedo", StringComparison.Ordinal);
+        int runRedoIdx = body.IndexOf("RunRedo()", StringComparison.Ordinal);
+        Assert.True(canRedoIdx >= 0 && runRedoIdx >= 0,
+            "Redo_Click must reference CanRedo and RunRedo()");
+        Assert.True(canRedoIdx < runRedoIdx,
+            "CanRedo guard must precede RunRedo() call");
+    }
+
+    /// <summary>
+    /// MapChip Export handler must access the VM's CONFIG buffer via the
+    /// public <c>GetCachedConfigClone</c> accessor (which clones the
+    /// internal cache to prevent caller mutation — Copilot CLI v2 review)
+    /// and use the shared <c>FileDialogHelper.SaveFile</c> wrapper for
+    /// picker parity with the rest of the Avalonia layer.
+    /// </summary>
+    [Fact]
+    public void View_MapChipExport_Click_UsesVmAccessorAndFileDialogHelper()
+    {
+        string code = File.ReadAllText(CodeBehindPath());
+        var bodyMatch = Regex.Match(code,
+            @"async void MapChipExport_Click[\s\S]*?(?=\n\s{8}(static\s|public\s|void\s|async\s|/// |\}))",
+            RegexOptions.Singleline);
+        Assert.True(bodyMatch.Success, "MapChipExport_Click method not found");
+        string body = bodyMatch.Value;
+        Assert.Contains("_vm.GetCachedConfigClone()", body);
+        Assert.Contains("FileDialogHelper.SaveFile", body);
+        Assert.Contains("*.MAPCHIP_CONFIG", body);
+        Assert.Contains("File.WriteAllBytes", body);
+    }
+
+    /// <summary>
+    /// The VM must expose <c>GetCachedConfigClone</c> as a public method
+    /// that returns a defensive clone (i.e. `.Clone()` appears in the
+    /// expression body). This catches direct field exposure regressions.
+    /// </summary>
+    [Fact]
+    public void ViewModel_GetCachedConfigClone_ReturnsDefensiveClone()
+    {
+        string vm = File.ReadAllText(ViewModelPath());
+        Assert.Matches(new Regex(
+            @"public\s+byte\[\]\??\s+GetCachedConfigClone\(\)[\s\S]*?Clone\(\)",
+            RegexOptions.Singleline), vm);
+    }
+
     // -----------------------------------------------------------------
     // #704 — MapChip Import button parity tests.
     // -----------------------------------------------------------------
@@ -1110,7 +1201,7 @@ public class MapStyleEditorParityTests
     /// <summary>
     /// #704: the MapChip Import button must wire Click to the
     /// MapChipImport_Click handler in AXAML AND the handler method must
-    /// exist in the code-behind.
+    /// exist in the code-behind, wrapped in an undo scope.
     /// </summary>
     [Fact]
     public void View_MapChipImport_Click_HandlerWired()
@@ -1138,34 +1229,6 @@ public class MapStyleEditorParityTests
         Assert.Contains("_vm.TryWriteConfigBuffer", body);
         Assert.Contains("_undoService.Commit()", body);
         Assert.Contains("_undoService.Rollback()", body);
-    }
-
-    /// <summary>
-    /// Undo handler must guard on <c>CoreState.Undo?.Postion &gt; 0</c>
-    /// before calling RunUndo (v2 Copilot review item 2 — silently no-op
-    /// when Position is 0 misleads the user with a false "Undo applied"
-    /// toast). The code-behind must read Postion before RunUndo.
-    /// </summary>
-    [Fact]
-    public void View_Undo_Click_GuardsOnPostion()
-    {
-        string code = File.ReadAllText(CodeBehindPath());
-        // The Undo_Click body must reference Postion and bail to ShowInfo
-        // ("Nothing to undo") before RunUndo() is called.
-        var bodyMatch = Regex.Match(code,
-            @"void Undo_Click[\s\S]*?(?=\n\s{8}(static\s|public\s|void\s|/// |\}))",
-            RegexOptions.Singleline);
-        Assert.True(bodyMatch.Success, "Undo_Click method not found");
-        string body = bodyMatch.Value;
-        Assert.Contains("Postion", body);
-        Assert.Contains("Nothing to undo", body);
-        // The guard must precede RunUndo() in source order.
-        int postionIdx = body.IndexOf("Postion", StringComparison.Ordinal);
-        int runUndoIdx = body.IndexOf("RunUndo()", StringComparison.Ordinal);
-        Assert.True(postionIdx >= 0 && runUndoIdx >= 0,
-            "Undo_Click must reference Postion and RunUndo()");
-        Assert.True(postionIdx < runUndoIdx,
-            "Postion guard must precede RunUndo() call");
     }
 
     // -----------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MapStyleEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MapStyleEditorParityTests.cs
@@ -192,19 +192,34 @@ public class MapStyleEditorParityTests
     /// </summary>
     static readonly string[] KnownGapButtonIds =
     {
-        // 2 buttons deferred to follow-up after #692 partial slice
-        // (OBJ Import + MapChip Import). PaletteExport/Import/Clipboard/
-        // ObjExport/Undo became functional in #672 Slice A; Redo and
-        // MapChip Export became functional in #692 partial slice (see
-        // View_<Name>_Button_IsEnabled + View_<Name>_Click_HandlerWired
-        // tests below).
+        // 3 buttons remain deferred. Redo + MapChipExport track #692;
+        // ObjImport tracks the new #710 (#704 follow-up that needs the
+        // MapStyleEditorImportImageOptionForm port + 4bpp encoding + FE7
+        // obj2 handling). MapChipImport became functional in #704.
+        // PaletteExport/Import/Clipboard/ObjExport/Undo became functional
+        // in #672 Slice A (see View_<Name>_Button_IsEnabled +
+        // View_<Name>_Click_HandlerWired tests below).
         //
         // PaletteWrite is functional via #660 first slice (tracked positively
         // by View_FunctionalPaletteWriteButton_IsEnabled); CopyTile / CopyType /
         // Paste / ConfigWrite became functional in #671 (tracked positively
         // by View_ChipsetTab_FunctionalControls_AreEnabled_WhenCanEdit).
-        "MapStyleEditor_MapChipImport_Button",
+        "MapStyleEditor_MapChipExport_Button",
         "MapStyleEditor_ObjImport_Button",
+        "MapStyleEditor_Redo_Button",
+    };
+
+    /// <summary>
+    /// Mapping of each remaining KnownGap button to the issue number its
+    /// follow-up tooltip must reference. OBJ Import was promoted from the
+    /// shared #692 bucket to its own follow-up #710 in #704 because it
+    /// needs substantially more work (option dialog + 4bpp + obj2).
+    /// </summary>
+    static readonly System.Collections.Generic.Dictionary<string, string> KnownGapTooltipIssue = new()
+    {
+        ["MapStyleEditor_MapChipExport_Button"] = "#692",
+        ["MapStyleEditor_ObjImport_Button"] = "#710",
+        ["MapStyleEditor_Redo_Button"] = "#692",
     };
 
     [Fact]
@@ -214,15 +229,14 @@ public class MapStyleEditorParityTests
         foreach (string id in KnownGapButtonIds)
         {
             // Each button must appear with IsEnabled="False" AND a
-            // tooltip referencing the follow-up issue #692 in the same
+            // tooltip referencing its tracked follow-up issue in the same
             // element block. Allow attributes in any order via DOTALL flag.
             var idAttr = $"AutomationProperties.AutomationId=\"{id}\"";
             Assert.Contains(idAttr, axaml);
 
             // Locate the <Button ... /> element containing this id and
-            // verify the element body has IsEnabled="False" and a #692
-            // tooltip (post-#672 Slice A — old #374 retired for the 5
-            // landed buttons; the 4 remaining track #692).
+            // verify the element body has IsEnabled="False" and the
+            // tracked follow-up tooltip.
             var elementPattern = new Regex(
                 @"<Button(?:\s[^/>]*?)?" + Regex.Escape(idAttr) + @"[\s\S]*?/?>",
                 RegexOptions.None);
@@ -233,9 +247,11 @@ public class MapStyleEditorParityTests
             Assert.True(
                 elementText.Contains("IsEnabled=\"False\""),
                 $"KnownGap button {id} must have IsEnabled=\"False\"; element was: {elementText}");
+
+            string expectedIssue = KnownGapTooltipIssue[id];
             Assert.True(
-                elementText.Contains("#692"),
-                $"KnownGap button {id} must have a #692 follow-up tooltip; element was: {elementText}");
+                elementText.Contains(expectedIssue),
+                $"KnownGap button {id} must have a {expectedIssue} follow-up tooltip; element was: {elementText}");
         }
     }
 
@@ -997,11 +1013,9 @@ public class MapStyleEditorParityTests
     }
 
     // -----------------------------------------------------------------
-    // #672 Slice A + #692 partial slice — 7 newly-functional buttons.
-    // #672 Slice A: PaletteExport / PaletteImport / PaletteClipboard /
-    // ObjExport / Undo. #692 partial slice: Redo + MapChip Export. The
-    // 2 remaining buttons (OBJ Import + MapChip Import) are tracked by
-    // the follow-up issue filed before the #692 partial-slice PR.
+    // #672 Slice A — 5 newly-functional buttons (Palette Export / Import /
+    // Clipboard, OBJ Export, Undo). Remaining 4 buttons (Redo, OBJ Import,
+    // MapChip Export/Import) tracked by follow-up #692.
     // -----------------------------------------------------------------
 
     public static IEnumerable<object[]> Slice672ButtonIds()
@@ -1011,9 +1025,6 @@ public class MapStyleEditorParityTests
         yield return new object[] { "MapStyleEditor_PaletteClipboard_Button", "PaletteClipboard_Click" };
         yield return new object[] { "MapStyleEditor_ObjExport_Button", "ObjExport_Click" };
         yield return new object[] { "MapStyleEditor_Undo_Button", "Undo_Click" };
-        // #692 partial slice additions.
-        yield return new object[] { "MapStyleEditor_Redo_Button", "Redo_Click" };
-        yield return new object[] { "MapStyleEditor_MapChipExport_Button", "MapChipExport_Click" };
     }
 
     /// <summary>
@@ -1062,6 +1073,65 @@ public class MapStyleEditorParityTests
             RegexOptions.None), code);
     }
 
+    // -----------------------------------------------------------------
+    // #704 — MapChip Import button parity tests.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// #704: the MapChip Import button must NOT carry IsEnabled="False"
+    /// or any stale #374/#692 tooltip anymore — it became functional via
+    /// the #704 raw .MAPCHIP_CONFIG read path.
+    /// </summary>
+    [Fact]
+    public void View_MapChipImport_Button_IsEnabled()
+    {
+        string axaml = ReadAxaml();
+        var pattern = new Regex(
+            @"<Button[^>]*AutomationProperties\.AutomationId=""MapStyleEditor_MapChipImport_Button""[^>]*",
+            RegexOptions.None);
+        Match m = pattern.Match(axaml);
+        Assert.True(m.Success, "MapStyleEditor_MapChipImport_Button must exist");
+        Assert.False(m.Value.Contains("IsEnabled=\"False\""),
+            "MapStyleEditor_MapChipImport_Button must not carry IsEnabled=\"False\" anymore (#704)");
+        Assert.False(m.Value.Contains("#374"),
+            "MapStyleEditor_MapChipImport_Button must not advertise the legacy #374 tooltip");
+        Assert.False(m.Value.Contains("#692"),
+            "MapStyleEditor_MapChipImport_Button must not advertise the stale #692 tooltip (functional in #704)");
+    }
+
+    /// <summary>
+    /// #704: the MapChip Import button must wire Click to the
+    /// MapChipImport_Click handler in AXAML AND the handler method must
+    /// exist in the code-behind.
+    /// </summary>
+    [Fact]
+    public void View_MapChipImport_Click_HandlerWired()
+    {
+        string axaml = ReadAxaml();
+        var pattern = new Regex(
+            @"<Button[^>]*AutomationProperties\.AutomationId=""MapStyleEditor_MapChipImport_Button""[^>]*",
+            RegexOptions.None);
+        Match m = pattern.Match(axaml);
+        Assert.True(m.Success, "MapStyleEditor_MapChipImport_Button must exist");
+        Assert.Contains("Click=\"MapChipImport_Click\"", m.Value);
+
+        string code = File.ReadAllText(CodeBehindPath());
+        Assert.Matches(new Regex(
+            @"void MapChipImport_Click\(object\?",
+            RegexOptions.None), code);
+        // Handler must wrap the VM call in an undo scope (Begin / Commit /
+        // Rollback) so a failed write does not leave a half-applied import.
+        var bodyMatch = Regex.Match(code,
+            @"void MapChipImport_Click[\s\S]*?(?=\n\s{8}(static\s|public\s|void\s|/// |\}))",
+            RegexOptions.Singleline);
+        Assert.True(bodyMatch.Success, "MapChipImport_Click method not found");
+        string body = bodyMatch.Value;
+        Assert.Contains("_undoService.Begin", body);
+        Assert.Contains("_vm.TryWriteConfigBuffer", body);
+        Assert.Contains("_undoService.Commit()", body);
+        Assert.Contains("_undoService.Rollback()", body);
+    }
+
     /// <summary>
     /// Undo handler must guard on <c>CoreState.Undo?.Postion &gt; 0</c>
     /// before calling RunUndo (v2 Copilot review item 2 — silently no-op
@@ -1088,72 +1158,6 @@ public class MapStyleEditorParityTests
             "Undo_Click must reference Postion and RunUndo()");
         Assert.True(postionIdx < runUndoIdx,
             "Postion guard must precede RunUndo() call");
-    }
-
-    // -----------------------------------------------------------------
-    // #692 partial slice — Redo + MapChip Export specific shape checks.
-    // -----------------------------------------------------------------
-
-    /// <summary>
-    /// Redo handler must guard on <see cref="Undo.CanRedo"/> before calling
-    /// <see cref="Undo.RunRedo"/> (mirrors <see cref="Undo_Click"/>'s
-    /// Postion-guard pattern) and emit a "Nothing to redo" toast on the
-    /// no-op path. The guard must precede RunRedo() in source order so a
-    /// silently no-op rollback never falsely claims "Redo applied".
-    /// </summary>
-    [Fact]
-    public void View_Redo_Click_GuardsOnCanRedo()
-    {
-        string code = File.ReadAllText(CodeBehindPath());
-        var bodyMatch = Regex.Match(code,
-            @"void Redo_Click[\s\S]*?(?=\n\s{8}(static\s|public\s|void\s|/// |\}))",
-            RegexOptions.Singleline);
-        Assert.True(bodyMatch.Success, "Redo_Click method not found");
-        string body = bodyMatch.Value;
-        Assert.Contains("CanRedo", body);
-        Assert.Contains("Nothing to redo", body);
-        int canRedoIdx = body.IndexOf("CanRedo", StringComparison.Ordinal);
-        int runRedoIdx = body.IndexOf("RunRedo()", StringComparison.Ordinal);
-        Assert.True(canRedoIdx >= 0 && runRedoIdx >= 0,
-            "Redo_Click must reference CanRedo and RunRedo()");
-        Assert.True(canRedoIdx < runRedoIdx,
-            "CanRedo guard must precede RunRedo() call");
-    }
-
-    /// <summary>
-    /// MapChip Export handler must access the VM's CONFIG buffer via the
-    /// public <c>GetCachedConfigClone</c> accessor (which clones the
-    /// internal cache to prevent caller mutation — Copilot CLI v2 review)
-    /// and use the shared <c>FileDialogHelper.SaveFile</c> wrapper for
-    /// picker parity with the rest of the Avalonia layer.
-    /// </summary>
-    [Fact]
-    public void View_MapChipExport_Click_UsesVmAccessorAndFileDialogHelper()
-    {
-        string code = File.ReadAllText(CodeBehindPath());
-        var bodyMatch = Regex.Match(code,
-            @"async void MapChipExport_Click[\s\S]*?(?=\n\s{8}(static\s|public\s|void\s|async\s|/// |\}))",
-            RegexOptions.Singleline);
-        Assert.True(bodyMatch.Success, "MapChipExport_Click method not found");
-        string body = bodyMatch.Value;
-        Assert.Contains("_vm.GetCachedConfigClone()", body);
-        Assert.Contains("FileDialogHelper.SaveFile", body);
-        Assert.Contains("*.MAPCHIP_CONFIG", body);
-        Assert.Contains("File.WriteAllBytes", body);
-    }
-
-    /// <summary>
-    /// The VM must expose <c>GetCachedConfigClone</c> as a public method
-    /// that returns a defensive clone (i.e. `.Clone()` appears in the
-    /// expression body). This catches direct field exposure regressions.
-    /// </summary>
-    [Fact]
-    public void ViewModel_GetCachedConfigClone_ReturnsDefensiveClone()
-    {
-        string vm = File.ReadAllText(ViewModelPath());
-        Assert.Matches(new Regex(
-            @"public\s+byte\[\]\??\s+GetCachedConfigClone\(\)[\s\S]*?Clone\(\)",
-            RegexOptions.Singleline), vm);
     }
 
     // -----------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia.Tests/MapStyleEditorViewModelChipsetTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/MapStyleEditorViewModelChipsetTests.cs
@@ -608,6 +608,58 @@ public class MapStyleEditorViewModelChipsetTests
     }
 
     /// <summary>
+    /// Copilot bot v2 inline review: import must work even when the existing
+    /// CONFIG cache is missing / decompression failed — as long as the
+    /// CONFIG plist id is valid. This is the recovery-from-corruption use
+    /// case: a user with a broken CONFIG block on the ROM should still be
+    /// able to drop a fresh .MAPCHIP_CONFIG file onto the editor.
+    /// </summary>
+    [Fact]
+    public void TryWriteConfigBuffer_SucceedsWithEmptyCacheWhenPlistIdValid()
+    {
+        byte[] configUz = BuildSyntheticConfig();
+        var (rom, entryAddr, _) = MakeFe8uRomWithConfig(configUz);
+        var prevRom = CoreState.ROM;
+        var prevUndo = CoreState.Undo;
+        try
+        {
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+            var vm = new MapStyleEditorViewModel();
+            vm.LoadEntry(entryAddr);
+            // Drop the cache via ClearCacheAndChipsetState — preserves the
+            // configPlist id but clears _cachedConfigData. Without the
+            // gate relaxation, TryWriteConfigBuffer would refuse here.
+            // Save the plist before clearing because ClearCacheAndChipsetState
+            // zeros _currentConfigPlist too — we just want to simulate the
+            // "decompress failed but plist is valid" scenario.
+            uint savedPlist = vm.CurrentConfigPlist;
+            vm.ClearCacheAndChipsetState();
+            vm.CurrentConfigPlist = savedPlist;
+            // CanEditChipsetConfig is now false (no cache, no address).
+            Assert.False(vm.CanEditChipsetConfig);
+
+            byte[] input = new byte[MapEditorTilesetCore.CHIPSET_SEP_BYTE + MapEditorTilesetCore.CHIPSET_COUNT];
+            for (int i = 0; i < input.Length; i++) input[i] = (byte)(i & 0xFF);
+
+            var undoData = CoreState.Undo.NewUndoData("recover from corrupt cache");
+            bool ok;
+            using (ROM.BeginUndoScope(undoData))
+                ok = vm.TryWriteConfigBuffer(input, out string err);
+            Assert.True(ok);
+            CoreState.Undo.Push(undoData);
+            // Sanity: post-write the cache + address are now populated so
+            // CanEditChipsetConfig flips back to true.
+            Assert.True(vm.CanEditChipsetConfig);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.Undo = prevUndo;
+        }
+    }
+
+    /// <summary>
     /// When the resolved CONFIG plist is 0 or 0xFF (no usable slot), the
     /// VM must refuse the import without touching ROM.
     /// </summary>

--- a/FEBuilderGBA.Avalonia.Tests/MapStyleEditorViewModelChipsetTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/MapStyleEditorViewModelChipsetTests.cs
@@ -415,6 +415,179 @@ public class MapStyleEditorViewModelChipsetTests
         Assert.Equal(0x55, vm.CurrentTerrain);
     }
 
+    // -----------------------------------------------------------------
+    // #704 — TryWriteConfigBuffer (MapChip Import path).
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// WF parity: MapStyleEditorForm rejects .MAPCHIP_CONFIG inputs
+    /// shorter than 9216 bytes (0x2000 TSA + 0x400 terrain). The Avalonia
+    /// VM enforces the same minimum.
+    /// </summary>
+    [Fact]
+    public void TryWriteConfigBuffer_RejectsTooSmall()
+    {
+        byte[] configUz = BuildSyntheticConfig();
+        var (rom, entryAddr, _) = MakeFe8uRomWithConfig(configUz);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapStyleEditorViewModel();
+            vm.LoadEntry(entryAddr);
+
+            byte[] tooSmall = new byte[8000];
+            Assert.False(vm.TryWriteConfigBuffer(tooSmall, out string err));
+            Assert.Contains("8000", err);
+            Assert.Contains("9216", err);
+
+            // Null input is also rejected with the size error path.
+            Assert.False(vm.TryWriteConfigBuffer(null!, out string nullErr));
+            Assert.Contains("9216", nullErr);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    /// <summary>
+    /// Round-trip: write a 9216-byte buffer with a distinct fingerprint,
+    /// then re-decompress the new PLIST entry and verify every byte
+    /// matches the input. This proves the LZ77 compress/decompress
+    /// roundtrip preserves the raw bytes — the prerequisite for
+    /// preserving palette bits.
+    /// </summary>
+    [Fact]
+    public void TryWriteConfigBuffer_RoundTripsThroughLZ77()
+    {
+        byte[] configUz = BuildSyntheticConfig();
+        var (rom, entryAddr, _) = MakeFe8uRomWithConfig(configUz);
+        var prevRom = CoreState.ROM;
+        var prevUndo = CoreState.Undo;
+        try
+        {
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+            var vm = new MapStyleEditorViewModel();
+            vm.LoadEntry(entryAddr);
+            Assert.True(vm.CanEditChipsetConfig);
+
+            // Build a 9216-byte input with a recognizable per-byte fingerprint.
+            byte[] input = new byte[MapEditorTilesetCore.CHIPSET_SEP_BYTE + MapEditorTilesetCore.CHIPSET_COUNT];
+            for (int i = 0; i < input.Length; i++)
+                input[i] = (byte)((i * 31 + 7) & 0xFF);
+
+            var undoData = CoreState.Undo.NewUndoData("test config import");
+            bool ok;
+            string err;
+            using (ROM.BeginUndoScope(undoData))
+                ok = vm.TryWriteConfigBuffer(input, out err);
+            Assert.True(ok, err);
+            CoreState.Undo.Push(undoData);
+
+            // Re-decompress from the new ChipsetConfigAddress and verify
+            // the bytes survive the LZ77 round-trip.
+            byte[] roundTripped = LZ77.decompress(rom.Data, vm.ChipsetConfigAddress);
+            Assert.NotNull(roundTripped);
+            Assert.True(roundTripped.Length >= input.Length,
+                $"Round-tripped buffer too short: {roundTripped.Length} < {input.Length}");
+            for (int i = 0; i < input.Length; i++)
+                Assert.Equal(input[i], roundTripped[i]);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.Undo = prevUndo;
+        }
+    }
+
+    /// <summary>
+    /// #704 core acceptance: palette-index bits (bits 12-15 of a TSA u16)
+    /// must survive the import round-trip. Plant a buffer where every
+    /// chipset's slot-0 TSA word encodes palette index 15 (0xF000) and
+    /// verify those bits land in the decompressed output untouched.
+    /// </summary>
+    [Fact]
+    public void TryWriteConfigBuffer_PreservesPaletteIndexBits()
+    {
+        byte[] configUz = BuildSyntheticConfig();
+        var (rom, entryAddr, _) = MakeFe8uRomWithConfig(configUz);
+        var prevRom = CoreState.ROM;
+        var prevUndo = CoreState.Undo;
+        try
+        {
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+            var vm = new MapStyleEditorViewModel();
+            vm.LoadEntry(entryAddr);
+
+            // Build a buffer where every chipset slot 0 has palette index 15.
+            byte[] input = new byte[MapEditorTilesetCore.CHIPSET_SEP_BYTE + MapEditorTilesetCore.CHIPSET_COUNT];
+            // Palette index 15 in bits 12-15 = 0xF000. Plus a known tile id 0x123.
+            ushort w = (ushort)(0xF000 | 0x0123);
+            for (int c = 0; c < MapEditorTilesetCore.CHIPSET_COUNT; c++)
+            {
+                int tsaBase = c * 8;
+                input[tsaBase + 0] = (byte)(w & 0xFF);
+                input[tsaBase + 1] = (byte)((w >> 8) & 0xFF);
+            }
+
+            var undoData = CoreState.Undo.NewUndoData("preserve palette bits");
+            bool ok;
+            using (ROM.BeginUndoScope(undoData))
+                ok = vm.TryWriteConfigBuffer(input, out _);
+            Assert.True(ok);
+            CoreState.Undo.Push(undoData);
+
+            byte[] roundTripped = LZ77.decompress(rom.Data, vm.ChipsetConfigAddress);
+            Assert.NotNull(roundTripped);
+
+            // Sample a few chipsets to confirm the palette-index bits survived.
+            int[] sampleChipsets = { 0, 1, 50, 500, 1023 };
+            foreach (int c in sampleChipsets)
+            {
+                int off = c * 8;
+                ushort readBack = (ushort)(roundTripped[off] | (roundTripped[off + 1] << 8));
+                Assert.Equal(w, readBack);
+                // Explicitly assert the high nibble (palette index) is 0xF.
+                Assert.Equal(0xF, (readBack >> 12) & 0xF);
+            }
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.Undo = prevUndo;
+        }
+    }
+
+    /// <summary>
+    /// When the resolved CONFIG plist is 0 or 0xFF (no usable slot), the
+    /// VM must refuse the import without touching ROM.
+    /// </summary>
+    [Fact]
+    public void TryWriteConfigBuffer_FailsOnInvalidConfigPlist()
+    {
+        byte[] configUz = BuildSyntheticConfig();
+        var (rom, entryAddr, _) = MakeFe8uRomWithConfig(configUz);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapStyleEditorViewModel();
+            vm.LoadEntry(entryAddr);
+            Assert.True(vm.CanEditChipsetConfig);
+
+            byte[] input = new byte[MapEditorTilesetCore.CHIPSET_SEP_BYTE + MapEditorTilesetCore.CHIPSET_COUNT];
+
+            vm.CurrentConfigPlist = 0;
+            Assert.False(vm.TryWriteConfigBuffer(input, out string err0));
+            Assert.NotEqual("", err0);
+
+            vm.CurrentConfigPlist = 0xFF;
+            Assert.False(vm.TryWriteConfigBuffer(input, out string errFF));
+            Assert.NotEqual("", errFF);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
     /// <summary>
     /// Per v5 plan #1: WF parity Paste applies ALL four W values and
     /// the terrain, not just one slot. Verify each slot W and the

--- a/FEBuilderGBA.Avalonia.Tests/MapStyleEditorViewModelChipsetTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/MapStyleEditorViewModelChipsetTests.cs
@@ -559,6 +559,55 @@ public class MapStyleEditorViewModelChipsetTests
     }
 
     /// <summary>
+    /// Copilot bot v1 inline review: the VM must clone the caller-supplied
+    /// buffer before assigning it to the internal cache so a subsequent
+    /// caller-side mutation cannot reach into the VM's state. Without the
+    /// defensive clone, mutating <c>input</c> after a successful write
+    /// would silently corrupt the cached CONFIG buffer used by the next
+    /// chipset read.
+    /// </summary>
+    [Fact]
+    public void TryWriteConfigBuffer_StoresDefensiveClone_NotCallerBuffer()
+    {
+        byte[] configUz = BuildSyntheticConfig();
+        var (rom, entryAddr, _) = MakeFe8uRomWithConfig(configUz);
+        var prevRom = CoreState.ROM;
+        var prevUndo = CoreState.Undo;
+        try
+        {
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+            var vm = new MapStyleEditorViewModel();
+            vm.LoadEntry(entryAddr);
+
+            byte[] input = new byte[MapEditorTilesetCore.CHIPSET_SEP_BYTE + MapEditorTilesetCore.CHIPSET_COUNT];
+            // Seed chipset 0 TSA slot 0 with a known value.
+            ushort original = (ushort)(0xF000 | 0x0123);
+            input[0] = (byte)(original & 0xFF);
+            input[1] = (byte)((original >> 8) & 0xFF);
+
+            var undoData = CoreState.Undo.NewUndoData("defensive clone");
+            using (ROM.BeginUndoScope(undoData))
+                Assert.True(vm.TryWriteConfigBuffer(input, out _));
+            CoreState.Undo.Push(undoData);
+
+            // Mutate the caller's buffer AFTER the write — the VM's cache
+            // must not change. Read back via TryLoadChipsetTSA so we go
+            // through the public API (no reflection needed).
+            input[0] = 0xCD;
+            input[1] = 0xAB;
+
+            Assert.True(vm.TryLoadChipsetTSA(0));
+            Assert.Equal(original, vm.GetSlotW(0));
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.Undo = prevUndo;
+        }
+    }
+
+    /// <summary>
     /// When the resolved CONFIG plist is 0 or 0xFF (no usable slot), the
     /// VM must refuse the import without touching ROM.
     /// </summary>

--- a/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
@@ -727,7 +727,15 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 error = $"Config file too small ({(newConfigData?.Length ?? 0)} bytes); must be at least {MinConfigSize} bytes.";
                 return false;
             }
-            if (!CanEditChipsetConfig)
+            // Copilot bot v2 inline review: validate only the CONFIG plist id,
+            // NOT the full CanEditChipsetConfig predicate. CanEditChipsetConfig
+            // also requires `_cachedConfigData != null` and `ChipsetConfigAddress
+            // != 0`, which would block import-as-recovery when the existing
+            // CONFIG block is corrupt or missing but the plist id itself is
+            // still valid. Import only needs the plist id (and ROM with a
+            // populated map_config_pointer — WritePlistData enforces the
+            // latter).
+            if (_currentConfigPlist == 0 || _currentConfigPlist == 0xFF)
             {
                 error = "Map Style entry does not have a valid CONFIG PLIST.";
                 return false;

--- a/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
@@ -736,7 +736,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
             // Swap cache + address only after the write succeeded so a
             // failed write leaves the previous in-memory state untouched.
-            _cachedConfigData = newConfigData;
+            // Copilot bot v1 inline review: store a defensive clone so the
+            // caller cannot mutate our cache after we accept the bytes (and
+            // matches the WriteChipsetConfig "stage on a clone, then swap"
+            // ownership pattern).
+            _cachedConfigData = (byte[])newConfigData.Clone();
             ChipsetConfigAddress = newAddr;
             return true;
         }

--- a/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
@@ -138,6 +138,17 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             && _currentConfigPlist != 0xFF
             && _chipsetConfigAddress != 0;
 
+        /// <summary>
+        /// Returns a defensive clone of the cached decompressed CONFIG
+        /// buffer for export (#692 partial slice — MapChip Export). Returns
+        /// null when no entry is loaded or the LZ77 decompression at
+        /// <see cref="LoadEntry"/> time produced no usable buffer. The
+        /// clone protects the VM's internal cache from caller mutation
+        /// (Copilot CLI v2 review on the v3 plan).
+        /// </summary>
+        public byte[]? GetCachedConfigClone() =>
+            _cachedConfigData == null ? null : (byte[])_cachedConfigData.Clone();
+
         // ----- Palette helpers (5-5-5 RGB, 16 colors per palette) -----
         // colorIndex is 1-based to match the WF "PALETTE_P_1..16" labels.
 

--- a/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
@@ -138,17 +138,6 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             && _currentConfigPlist != 0xFF
             && _chipsetConfigAddress != 0;
 
-        /// <summary>
-        /// Returns a defensive clone of the cached decompressed CONFIG
-        /// buffer for export (#692 partial slice — MapChip Export). Returns
-        /// null when no entry is loaded or the LZ77 decompression at
-        /// <see cref="LoadEntry"/> time produced no usable buffer. The
-        /// clone protects the VM's internal cache from caller mutation
-        /// (Copilot CLI v2 review on the v3 plan).
-        /// </summary>
-        public byte[]? GetCachedConfigClone() =>
-            _cachedConfigData == null ? null : (byte[])_cachedConfigData.Clone();
-
         // ----- Palette helpers (5-5-5 RGB, 16 colors per palette) -----
         // colorIndex is 1-based to match the WF "PALETTE_P_1..16" labels.
 
@@ -690,6 +679,64 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
             // Swap in the new cache + address only after the write succeeded.
             _cachedConfigData = staged;
+            ChipsetConfigAddress = newAddr;
+            return true;
+        }
+
+        /// <summary>
+        /// Replace the cached CONFIG buffer with raw bytes from a
+        /// <c>.MAPCHIP_CONFIG</c> file (WF parity: no magic header, the file
+        /// is the raw decompressed buffer). Validates the WF-parity minimum
+        /// of <c>9216</c> bytes (<see cref="MapEditorTilesetCore.CHIPSET_SEP_BYTE"/>
+        /// for TSA + <see cref="MapEditorTilesetCore.CHIPSET_COUNT"/> terrain
+        /// bytes), then LZ77-compresses the result and persists it via the
+        /// CONFIG PLIST write path (#671). Palette-index bits in TSA words
+        /// (bits 12-15 of each u16) are preserved verbatim because the buffer
+        /// is written byte-for-byte to ROM — there is no slot-by-slot decode
+        /// path that could strip them (#704 acceptance).
+        ///
+        /// <para>Requires an ambient undo scope (opened by the view via
+        /// <c>UndoService.Begin</c>) so the LZ77 append + p32 write are
+        /// tracked. On success, swaps the cached buffer and the
+        /// <see cref="ChipsetConfigAddress"/> to the new location.</para>
+        ///
+        /// <para>Returns false (without ROM mutation) when the supplied bytes
+        /// are null or too small, no ROM is loaded, or the resolved CONFIG
+        /// plist is invalid (0 / 0xFF / no entry). <paramref name="error"/>
+        /// carries a short human-readable reason.</para>
+        /// </summary>
+        public bool TryWriteConfigBuffer(byte[] newConfigData, out string error)
+        {
+            error = "";
+            // WF parity: MapStyleEditorForm.MapChipImportButton_Click rejects
+            // anything < 9216 bytes (0x2000 TSA + 0x400 terrain).
+            const int MinConfigSize = MapEditorTilesetCore.CHIPSET_SEP_BYTE + MapEditorTilesetCore.CHIPSET_COUNT;
+            if (newConfigData == null || newConfigData.Length < MinConfigSize)
+            {
+                error = $"Config file too small ({(newConfigData?.Length ?? 0)} bytes); must be at least {MinConfigSize} bytes.";
+                return false;
+            }
+            if (!CanEditChipsetConfig)
+            {
+                error = "Map Style entry does not have a valid CONFIG PLIST.";
+                return false;
+            }
+            ROM rom = CoreState.ROM;
+            if (rom == null) { error = "no ROM"; return false; }
+
+            byte[] compressed = LZ77.compress(newConfigData);
+            if (compressed == null || compressed.Length == 0)
+            {
+                error = "LZ77 compress failed";
+                return false;
+            }
+
+            uint newAddr = MapChangeCore.WritePlistData(rom, MapChangeCore.PlistType.CONFIG, _currentConfigPlist, compressed, out error);
+            if (newAddr == U.NOT_FOUND) return false;
+
+            // Swap cache + address only after the write succeeded so a
+            // failed write leaves the previous in-memory state untouched.
+            _cachedConfigData = newConfigData;
             ChipsetConfigAddress = newAddr;
             return true;
         }

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml
@@ -106,8 +106,7 @@
                       ToolTip.Tip="Pending Core extraction - tracked by #710." />
               <Button AutomationProperties.AutomationId="MapStyleEditor_MapChipExport_Button"
                       Content="Map Chip Save"
-                      IsEnabled="False"
-                      ToolTip.Tip="Pending Core extraction - tracked by #692." />
+                      Click="MapChipExport_Click" />
               <Button AutomationProperties.AutomationId="MapStyleEditor_MapChipImport_Button"
                       Content="Map Chip Load"
                       Click="MapChipImport_Click" />
@@ -116,8 +115,7 @@
                       Click="Undo_Click" />
               <Button AutomationProperties.AutomationId="MapStyleEditor_Redo_Button"
                       Content="REDO"
-                      IsEnabled="False"
-                      ToolTip.Tip="Pending Core extraction - tracked by #692." />
+                      Click="Redo_Click" />
               <Button AutomationProperties.AutomationId="MapStyleEditor_Write_Button"
                       Name="WriteButton" Content="Write"
                       Click="Write_Click" />

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml
@@ -103,20 +103,21 @@
               <Button AutomationProperties.AutomationId="MapStyleEditor_ObjImport_Button"
                       Content="Image Import"
                       IsEnabled="False"
-                      ToolTip.Tip="Pending Core extraction - tracked by #692." />
+                      ToolTip.Tip="Pending Core extraction - tracked by #710." />
               <Button AutomationProperties.AutomationId="MapStyleEditor_MapChipExport_Button"
                       Content="Map Chip Save"
-                      Click="MapChipExport_Click" />
-              <Button AutomationProperties.AutomationId="MapStyleEditor_MapChipImport_Button"
-                      Content="Map Chip Load"
                       IsEnabled="False"
                       ToolTip.Tip="Pending Core extraction - tracked by #692." />
+              <Button AutomationProperties.AutomationId="MapStyleEditor_MapChipImport_Button"
+                      Content="Map Chip Load"
+                      Click="MapChipImport_Click" />
               <Button AutomationProperties.AutomationId="MapStyleEditor_Undo_Button"
                       Content="UNDO"
                       Click="Undo_Click" />
               <Button AutomationProperties.AutomationId="MapStyleEditor_Redo_Button"
                       Content="REDO"
-                      Click="Redo_Click" />
+                      IsEnabled="False"
+                      ToolTip.Tip="Pending Core extraction - tracked by #692." />
               <Button AutomationProperties.AutomationId="MapStyleEditor_Write_Button"
                       Name="WriteButton" Content="Write"
                       Click="Write_Click" />

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
@@ -8,6 +8,7 @@ using global::Avalonia.Controls.Shapes;
 using global::Avalonia.Input;
 using global::Avalonia.Interactivity;
 using global::Avalonia.Media;
+using global::Avalonia.Platform.Storage;
 using FEBuilderGBA.Avalonia.Controls;
 using FEBuilderGBA.Avalonia.Dialogs;
 using FEBuilderGBA.Avalonia.Services;
@@ -973,94 +974,97 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
-        /// <summary>
-        /// Per-editor Redo (#692 partial slice): runs
-        /// <see cref="Undo.RunRedo"/> on the global <see cref="CoreState.Undo"/>
-        /// buffer. Mirrors <see cref="Undo_Click"/>: guards on
-        /// <see cref="Undo.CanRedo"/>, then verifies the redo actually
-        /// advanced the cursor (RunRedo's bool surfaces silent
-        /// <see cref="Undo.RollbackROM"/> failures that
-        /// <see cref="Undo.Rollback(int)"/> would otherwise hide).
-        /// After a successful redo, reload the entry so palette /
-        /// chipset / preview reflect the rolled-forward ROM bytes.
-        /// </summary>
-        void Redo_Click(object? sender, RoutedEventArgs e)
+        // -----------------------------------------------------------------
+        // #704 — MapChip Import: read raw .MAPCHIP_CONFIG bytes (no header,
+        // ≥ 9216 bytes per WF parity), persist via the CONFIG PLIST write
+        // path. Palette bits in TSA words are preserved verbatim because
+        // the buffer is written byte-for-byte (the VM's TryWriteConfigBuffer
+        // never decodes TSA words during the write).
+        //
+        // OBJ Image Import remains a KnownGap — tracked by follow-up #710
+        // (needs option-dialog port + 4bpp encoding + FE7 obj2 handling).
+        // -----------------------------------------------------------------
+        async void MapChipImport_Click(object? sender, RoutedEventArgs e)
         {
             try
             {
-                if (CoreState.Undo == null || !CoreState.Undo.CanRedo)
+                var topLevel = TopLevel.GetTopLevel(this);
+                if (topLevel?.StorageProvider == null)
                 {
-                    CoreState.Services.ShowInfo("Nothing to redo.");
+                    CoreState.Services.ShowError("Storage provider not available.");
                     return;
                 }
-                if (!CoreState.Undo.RunRedo())
+                var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
                 {
-                    CoreState.Services.ShowError("Redo failed.");
+                    Title = "Import Map Chip Config",
+                    AllowMultiple = false,
+                    FileTypeFilter = new[]
+                    {
+                        new FilePickerFileType("Map Chip Config") { Patterns = new[] { "*.MAPCHIP_CONFIG", "*.mapchip_config" } },
+                        new FilePickerFileType("All files") { Patterns = new[] { "*.*" } },
+                    },
+                });
+                if (files == null || files.Count == 0) return;
+
+                byte[] data;
+                try
+                {
+                    await using var s = await files[0].OpenReadAsync();
+                    using var ms = new MemoryStream();
+                    await s.CopyToAsync(ms);
+                    data = ms.ToArray();
+                }
+                catch (Exception ex)
+                {
+                    Log.Error("MapStyleEditorView.MapChipImport_Click read failed: {0}", ex.Message);
+                    CoreState.Services.ShowError($"Failed to read file: {ex.Message}");
                     return;
                 }
-                // Reload the current entry so palette / chipset / preview
-                // pick up the rolled-forward ROM bytes.
-                if (_vm.CurrentAddr != 0)
+
+                _undoService.Begin("Import Map Chip Config");
+                try
                 {
+                    if (!_vm.TryWriteConfigBuffer(data, out string err))
+                    {
+                        _undoService.Rollback();
+                        CoreState.Services.ShowError($"Import failed: {err}");
+                        return;
+                    }
+                    _undoService.Commit();
+                    _vm.MarkClean();
+
+                    // Refresh the Chipset Tab UI from the new buffer so the
+                    // user sees the imported chipset 0's TSA + terrain. The
+                    // ChipsetConfigAddress label, slot NUDs, terrain combo,
+                    // and preview all need to reflect the new write.
+                    ChipsetConfigAddressLabel.Text = $"0x{_vm.ChipsetConfigAddress:X08}";
                     _vm.IsLoading = true;
                     try
                     {
-                        _vm.LoadEntry(_vm.CurrentAddr);
-                        UpdateUI();
+                        _vm.CurrentChipsetNo = 0;
+                        bool chipsetLoaded = _vm.CanEditChipsetConfig && _vm.TryLoadChipsetTSA(0);
+                        if (ChipsetNoInput != null)
+                            ChipsetNoInput.Value = chipsetLoaded ? 0m : (decimal?)null;
+                        PopulateTerrainCombo();
+                        if (chipsetLoaded) ReadSlotsFromVM();
+                        else ClearChipsetUI();
+                        SetChipsetEditingEnabled(chipsetLoaded);
                     }
                     finally { _vm.IsLoading = false; }
                     RefreshChipPreview();
+                    CoreState.Services.ShowInfo($"Imported {data.Length} bytes of map chip config.");
                 }
-                CoreState.Services.ShowInfo("Redo applied.");
-            }
-            catch (Exception ex)
-            {
-                Log.Error("MapStyleEditorView.Redo_Click failed: {0}", ex.Message);
-                CoreState.Services.ShowError($"Redo failed: {ex.Message}");
-            }
-        }
-
-        /// <summary>
-        /// Per-editor MapChip Export (#692 partial slice): writes the
-        /// VM's cached decompressed CONFIG buffer to a .MAPCHIP_CONFIG
-        /// file. Mirrors WF parity — raw ConfigUZ bytes, no magic header
-        /// (the WF importer reads raw bytes with only a 9216-byte
-        /// minimum check, so adding a header would break import parity).
-        /// Uses <see cref="FileDialogHelper.SaveFile"/> for picker parity
-        /// with the rest of the Avalonia layer.
-        /// </summary>
-        async void MapChipExport_Click(object? sender, RoutedEventArgs e)
-        {
-            try
-            {
-                byte[]? configClone = _vm.GetCachedConfigClone();
-                if (configClone == null || configClone.Length == 0)
+                catch (Exception ex)
                 {
-                    CoreState.Services.ShowError(
-                        "No chipset config loaded — select a Map Style entry first.");
-                    return;
+                    _undoService.Rollback();
+                    Log.Error("MapStyleEditorView.MapChipImport_Click write failed: {0}", ex.Message);
+                    CoreState.Services.ShowError($"Import error: {ex.Message}");
                 }
-                string? path = await FileDialogHelper.SaveFile(
-                    this,
-                    "Export Map Chip Config",
-                    "Map Chip Config",
-                    "*.MAPCHIP_CONFIG",
-                    "mapchip.MAPCHIP_CONFIG");
-                // Treat null / empty / whitespace as cancel — FileDialogHelper.SaveFile
-                // can return an empty string in some flows, and File.WriteAllBytes
-                // would throw on it. Matches the guard pattern used by other
-                // Save-path callers (e.g. ToolTranslateROMView). Copilot bot
-                // inline review on PR #706.
-                if (string.IsNullOrWhiteSpace(path)) return;
-
-                File.WriteAllBytes(path, configClone);
-                CoreState.Services.ShowInfo(
-                    $"Exported {configClone.Length} bytes to {System.IO.Path.GetFileName(path)}.");
             }
             catch (Exception ex)
             {
-                Log.Error("MapStyleEditorView.MapChipExport_Click failed: {0}", ex.Message);
-                CoreState.Services.ShowError($"Map Chip export failed: {ex.Message}");
+                Log.Error("MapStyleEditorView.MapChipImport_Click failed: {0}", ex.Message);
+                CoreState.Services.ShowError($"Map chip import failed: {ex.Message}");
             }
         }
     }

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
@@ -1001,7 +1001,11 @@ namespace FEBuilderGBA.Avalonia.Views
                     FileTypeFilter = new[]
                     {
                         new FilePickerFileType("Map Chip Config") { Patterns = new[] { "*.MAPCHIP_CONFIG", "*.mapchip_config" } },
-                        new FilePickerFileType("All files") { Patterns = new[] { "*.*" } },
+                        // Copilot bot v1 inline review: use "*" (not "*.*") so the
+                        // filter truly matches every file on every platform —
+                        // `*.*` skips extension-less filenames on macOS/Linux,
+                        // and mirrors `FileDialogHelper.MakeAllFileType` parity.
+                        new FilePickerFileType("All files") { Patterns = new[] { "*" } },
                     },
                 });
                 if (files == null || files.Count == 0) return;

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
@@ -974,6 +974,97 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
+        /// <summary>
+        /// Per-editor Redo (#692 partial slice): runs
+        /// <see cref="Undo.RunRedo"/> on the global <see cref="CoreState.Undo"/>
+        /// buffer. Mirrors <see cref="Undo_Click"/>: guards on
+        /// <see cref="Undo.CanRedo"/>, then verifies the redo actually
+        /// advanced the cursor (RunRedo's bool surfaces silent
+        /// <see cref="Undo.RollbackROM"/> failures that
+        /// <see cref="Undo.Rollback(int)"/> would otherwise hide).
+        /// After a successful redo, reload the entry so palette /
+        /// chipset / preview reflect the rolled-forward ROM bytes.
+        /// </summary>
+        void Redo_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (CoreState.Undo == null || !CoreState.Undo.CanRedo)
+                {
+                    CoreState.Services.ShowInfo("Nothing to redo.");
+                    return;
+                }
+                if (!CoreState.Undo.RunRedo())
+                {
+                    CoreState.Services.ShowError("Redo failed.");
+                    return;
+                }
+                // Reload the current entry so palette / chipset / preview
+                // pick up the rolled-forward ROM bytes.
+                if (_vm.CurrentAddr != 0)
+                {
+                    _vm.IsLoading = true;
+                    try
+                    {
+                        _vm.LoadEntry(_vm.CurrentAddr);
+                        UpdateUI();
+                    }
+                    finally { _vm.IsLoading = false; }
+                    RefreshChipPreview();
+                }
+                CoreState.Services.ShowInfo("Redo applied.");
+            }
+            catch (Exception ex)
+            {
+                Log.Error("MapStyleEditorView.Redo_Click failed: {0}", ex.Message);
+                CoreState.Services.ShowError($"Redo failed: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Per-editor MapChip Export (#692 partial slice): writes the
+        /// VM's cached decompressed CONFIG buffer to a .MAPCHIP_CONFIG
+        /// file. Mirrors WF parity — raw ConfigUZ bytes, no magic header
+        /// (the WF importer reads raw bytes with only a 9216-byte
+        /// minimum check, so adding a header would break import parity).
+        /// Uses <see cref="FileDialogHelper.SaveFile"/> for picker parity
+        /// with the rest of the Avalonia layer.
+        /// </summary>
+        async void MapChipExport_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                byte[]? configClone = _vm.GetCachedConfigClone();
+                if (configClone == null || configClone.Length == 0)
+                {
+                    CoreState.Services.ShowError(
+                        "No chipset config loaded — select a Map Style entry first.");
+                    return;
+                }
+                string? path = await FileDialogHelper.SaveFile(
+                    this,
+                    "Export Map Chip Config",
+                    "Map Chip Config",
+                    "*.MAPCHIP_CONFIG",
+                    "mapchip.MAPCHIP_CONFIG");
+                // Treat null / empty / whitespace as cancel — FileDialogHelper.SaveFile
+                // can return an empty string in some flows, and File.WriteAllBytes
+                // would throw on it. Matches the guard pattern used by other
+                // Save-path callers (e.g. ToolTranslateROMView). Copilot bot
+                // inline review on PR #706.
+                if (string.IsNullOrWhiteSpace(path)) return;
+
+                File.WriteAllBytes(path, configClone);
+                CoreState.Services.ShowInfo(
+                    $"Exported {configClone.Length} bytes to {System.IO.Path.GetFileName(path)}.");
+            }
+            catch (Exception ex)
+            {
+                Log.Error("MapStyleEditorView.MapChipExport_Click failed: {0}", ex.Message);
+                CoreState.Services.ShowError($"Map Chip export failed: {ex.Message}");
+            }
+        }
+
         // -----------------------------------------------------------------
         // #704 — MapChip Import: read raw .MAPCHIP_CONFIG bytes (no header,
         // ≥ 9216 bytes per WF parity), persist via the CONFIG PLIST write

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
@@ -1116,6 +1116,11 @@ namespace FEBuilderGBA.Avalonia.Views
                     return;
                 }
 
+                // Copilot bot v2 inline review: split write/commit from
+                // UI-refresh so an exception during post-commit UI work
+                // can't trigger a no-op Rollback on an already-committed
+                // undo group (which would lie to the user about "import
+                // failed" while ROM bytes are already persisted).
                 _undoService.Begin("Import Map Chip Config");
                 try
                 {
@@ -1127,11 +1132,21 @@ namespace FEBuilderGBA.Avalonia.Views
                     }
                     _undoService.Commit();
                     _vm.MarkClean();
+                }
+                catch (Exception ex)
+                {
+                    _undoService.Rollback();
+                    Log.Error("MapStyleEditorView.MapChipImport_Click write failed: {0}", ex.Message);
+                    CoreState.Services.ShowError($"Import error: {ex.Message}");
+                    return;
+                }
 
-                    // Refresh the Chipset Tab UI from the new buffer so the
-                    // user sees the imported chipset 0's TSA + terrain. The
-                    // ChipsetConfigAddress label, slot NUDs, terrain combo,
-                    // and preview all need to reflect the new write.
+                // -- Post-commit UI refresh (no rollback path; ROM is
+                // already persisted at this point). Failures here only
+                // affect the visible state, not durability — log + warn
+                // but don't roll back.
+                try
+                {
                     ChipsetConfigAddressLabel.Text = $"0x{_vm.ChipsetConfigAddress:X08}";
                     _vm.IsLoading = true;
                     try
@@ -1151,9 +1166,12 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 catch (Exception ex)
                 {
-                    _undoService.Rollback();
-                    Log.Error("MapStyleEditorView.MapChipImport_Click write failed: {0}", ex.Message);
-                    CoreState.Services.ShowError($"Import error: {ex.Message}");
+                    // Import succeeded but UI refresh failed — tell the user
+                    // their data is safe and ask them to reload.
+                    Log.Error("MapStyleEditorView.MapChipImport_Click UI refresh failed: {0}", ex.Message);
+                    CoreState.Services.ShowError(
+                        $"Import succeeded ({data.Length} bytes) but UI refresh failed: {ex.Message}. " +
+                        "Re-select the Map Style entry to refresh the view.");
                 }
             }
             catch (Exception ex)

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -6840,6 +6840,9 @@ Core 抽出待ち - #500 で追跡中。
 :Pending Core extraction - tracked by #692.
 Core 抽出待ち - #692 で追跡中。
 
+:Pending Core extraction - tracked by #710.
+Core 抽出待ち - #710 で追跡中。
+
 :Animation @ 0x{0:X08} ({1})
 アニメーション @ 0x{0:X08} ({1})
 

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -20823,6 +20823,9 @@ ID=00 Empty 已预留为空数据。\r\n请勿设置 0x0 之外的值。
 :Pending Core extraction - tracked by #692.
 等待 Core 抽取 - 跟踪于 #692。
 
+:Pending Core extraction - tracked by #710.
+等待 Core 抽取 - 跟踪于 #710。
+
 :Animation @ 0x{0:X08} ({1})
 动画 @ 0x{0:X08} ({1})
 


### PR DESCRIPTION
## Summary

Implements the **MapChip Import** button on the Avalonia Map Style Editor (#704 partial slice). Reads raw `.MAPCHIP_CONFIG` files (WF parity: no magic header, 9216-byte minimum) and writes via the CONFIG PLIST path. Palette-index bits in TSA words are preserved verbatim through the LZ77 round-trip — the write path is byte-for-byte, never decoded per-slot.

OBJ Image Import is deferred to new follow-up **#710** because it needs substantial additional work (option-dialog port + 4bpp encoding + FE7 obj2 split handling).

## Scope

Ref #704 (partial — OBJ Image Import remains in #710).

## Approach

- **WU1 — VM write path.** Add `MapStyleEditorViewModel.TryWriteConfigBuffer(byte[] data, out string error)`:
  - Validate `data.Length >= 9216` (matches WF `MapStyleEditorForm.MapChipImportButton_Click` ≥ 9216 check; `CHIPSET_SEP_BYTE` + `CHIPSET_COUNT` = 0x2000 + 0x400).
  - Reject when `CanEditChipsetConfig` is false (no usable CONFIG PLIST).
  - `LZ77.compress(data)` → `MapChangeCore.WritePlistData(CONFIG, _currentConfigPlist, compressed, out err)`.
  - Swap `_cachedConfigData` + `ChipsetConfigAddress` only after the write succeeds.

- **WU2 — View handler.** Replace `IsEnabled=\"False\"` + #692 tooltip on `MapStyleEditor_MapChipImport_Button` with `Click=\"MapChipImport_Click\"`. Handler:
  - `OpenFilePickerAsync` for `*.MAPCHIP_CONFIG`.
  - `_undoService.Begin(\"Import Map Chip Config\")`, call `TryWriteConfigBuffer`, Rollback on failure / Commit on success.
  - Refresh Chipset tab: `ChipsetConfigAddressLabel`, `CurrentChipsetNo = 0`, `TryLoadChipsetTSA(0)`, `PopulateTerrainCombo()`, `ReadSlotsFromVM()`, `SetChipsetEditingEnabled(...)`, `RefreshChipPreview()`.
  - Show success toast with byte count.

- **WU3 — Tests.** 4 new VM tests covering the size minimum, LZ77 round-trip, palette-index-bit preservation, and invalid-plist refusal. 2 new parity tests (`View_MapChipImport_Button_IsEnabled` + `View_MapChipImport_Click_HandlerWired` — the latter verifies the handler wraps `TryWriteConfigBuffer` in `Begin/Commit/Rollback`). `MapStyleEditor_MapChipImport_Button` removed from `KnownGapButtonIds`. `KnownGapTooltipIssue` map added so OBJ Import can carry the new #710 reference while MapChip Export + Redo stay on #692.

- **WU4 — Follow-up issue filed.** #710 enumerates the remaining OBJ Image Import acceptance: `MapStyleEditorImportImageOptionForm` modes, dimension validation, 4bpp tile encoding, FE7 obj2 split handling, full palette-block semantics.

- **L10n.** Added `\"Pending Core extraction - tracked by #710.\"` to `ja.txt` + `zh.txt` so `L10nCoverageTest.AvaloniaViews_HaveJaAndZhTranslations` stays green.

## Plan + reviews

Plan v2 posted on #704 (narrowed from v1 per Copilot CLI reviews — OBJ Image Import dropped to #710 because full WF parity needs significant additional work).

## Test plan

- [x] `dotnet build FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj` — 0 errors.
- [x] `dotnet test FEBuilderGBA.Core.Tests/FEBuilderGBA.Core.Tests.csproj` — 1964 / 1964 pass.
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests/FEBuilderGBA.Avalonia.Tests.csproj` — 6837 pass, 3 pre-existing skips, 0 failures.
- [x] Manual GUI verification on FE8U.gba via PrintWindow capture (see screenshot below): launched Avalonia Release, opened Map Style Editor on Tileset 0x01. The `Map Chip Load` button is now ENABLED in the button strip (Image Export | Image Import [disabled / #710] | Map Chip Save [disabled / #692] | **Map Chip Load** | UNDO | REDO | Write).

## GUI Test Report

| Case | Result |
| --- | --- |
| Launch Avalonia on FE8U.gba | PASS |
| Open Map Style Editor (Tab \"Map Style\") | PASS |
| Tileset 0x01 loaded with full preview + addresses | PASS |
| \"Map Chip Load\" button is ENABLED (no greyed-out style) | PASS |
| \"Image Import\" button remains disabled (KnownGap → #710) | PASS |
| \"Map Chip Save\" button remains disabled (KnownGap → #692) | PASS |
| Other functional buttons (Image Export, UNDO, Write) still enabled | PASS |

## Screenshot

![Map Style Editor with Map Chip Load enabled](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr704-map-style-mapchip-import.png)

Captured via `tools/WinCapture` (PrintWindow) from the running Avalonia Release build on FE8U.gba — not a fabricated or synthetic image. Lives on master (landed via docs PR #711) so the link survives feature-branch deletion.

Ref #704 (partial — OBJ Image Import remains in #710).

Generated with Claude Code (claude-opus-4-7-1m)