### PR TITLE
chore(avalonia): add EditorTopBarWithInputs foundational control (#701 partial)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/EditorTopBarWithInputsTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EditorTopBarWithInputsTests.cs
@@ -15,10 +15,13 @@
 // FilterBox, ListExpandButton, etc.) so per-editor migration is properly
 // scoped as a follow-up. These tests guarantee the API is stable for those
 // downstream migration PRs to consume.
+using System.Linq;
 using FEBuilderGBA.Avalonia.Controls;
+using global::Avalonia.Automation;
 using global::Avalonia.Controls;
 using global::Avalonia.Headless.XUnit;
 using global::Avalonia.Interactivity;
+using global::Avalonia.LogicalTree;
 using Xunit;
 
 namespace FEBuilderGBA.Avalonia.Tests;
@@ -124,6 +127,149 @@ public class EditorTopBarWithInputsTests
             Assert.NotNull(btn);
             btn!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
             Assert.True(firedAtWindow);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void HostAutomationId_PropagatesDerivedIdsToInnerControls()
+    {
+        // Hosts set ONE id on the control; inner inputs/button get derived
+        // suffixes so E2E selectors can address each independently.
+        var window = new Window { Width = 200, Height = 100 };
+        var ctrl = new EditorTopBarWithInputs();
+        AutomationProperties.SetAutomationId(ctrl, "MonsterItem_TopBar");
+        window.Content = ctrl;
+        window.Show();
+        try
+        {
+            var start = ctrl.FindControl<NumericUpDown>("ReadStartInput");
+            var count = ctrl.FindControl<NumericUpDown>("ReadCountInput");
+            var size = ctrl.FindControl<NumericUpDown>("ReadSizeInput");
+            var reload = ctrl.FindControl<Button>("ReloadButton");
+            Assert.NotNull(start);
+            Assert.NotNull(count);
+            Assert.NotNull(size);
+            Assert.NotNull(reload);
+            // "_TopBar" suffix is stripped from the host id before deriving.
+            Assert.Equal("MonsterItem_ReadStart_Input", AutomationProperties.GetAutomationId(start));
+            Assert.Equal("MonsterItem_ReadCount_Input", AutomationProperties.GetAutomationId(count));
+            Assert.Equal("MonsterItem_ReadSize_Input", AutomationProperties.GetAutomationId(size));
+            Assert.Equal("MonsterItem_Reload_Button", AutomationProperties.GetAutomationId(reload));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void ExplicitAutomationIdOverride_TakesPrecedence()
+    {
+        // Migrated editors set explicit *AutomationId styled-properties to
+        // preserve pre-#701 selectors that the existing E2E tests rely on
+        // (e.g. SongInstrument_ReadStartAddress_Input — a non-standard
+        // legacy id from the SongInstrument editor).
+        var window = new Window { Width = 200, Height = 100 };
+        var ctrl = new EditorTopBarWithInputs();
+        AutomationProperties.SetAutomationId(ctrl, "SongInstrument_TopBar");
+        ctrl.ReadStartAutomationId = "SongInstrument_ReadStartAddress_Input";
+        ctrl.ReadCountAutomationId = "SongInstrument_ReadCount_Input";
+        ctrl.ReadSizeAutomationId = "SongInstrument_ReadSize_Input";
+        ctrl.ReloadAutomationId = "SongInstrument_ReloadList_Button";
+        window.Content = ctrl;
+        window.Show();
+        try
+        {
+            var start = ctrl.FindControl<NumericUpDown>("ReadStartInput");
+            var count = ctrl.FindControl<NumericUpDown>("ReadCountInput");
+            var size = ctrl.FindControl<NumericUpDown>("ReadSizeInput");
+            var reload = ctrl.FindControl<Button>("ReloadButton");
+            Assert.NotNull(start);
+            Assert.NotNull(count);
+            Assert.NotNull(size);
+            Assert.NotNull(reload);
+            Assert.Equal("SongInstrument_ReadStartAddress_Input", AutomationProperties.GetAutomationId(start));
+            Assert.Equal("SongInstrument_ReadCount_Input", AutomationProperties.GetAutomationId(count));
+            Assert.Equal("SongInstrument_ReadSize_Input", AutomationProperties.GetAutomationId(size));
+            Assert.Equal("SongInstrument_ReloadList_Button", AutomationProperties.GetAutomationId(reload));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void TwoInstancesInSameVisualTree_HaveDistinctAutomationIds()
+    {
+        // The MonsterItemViewer hosts 3 read-bars in 3 tabs — must NOT
+        // produce duplicate AutomationIds in the visual tree (would break
+        // the AutomationIdTests sweep and any UIAutomation lookup).
+        var window = new Window { Width = 400, Height = 200 };
+        var panel = new StackPanel();
+        var a = new EditorTopBarWithInputs();
+        var b = new EditorTopBarWithInputs();
+        AutomationProperties.SetAutomationId(a, "MonsterTab1_TopBar");
+        AutomationProperties.SetAutomationId(b, "MonsterTab2_TopBar");
+        panel.Children.Add(a);
+        panel.Children.Add(b);
+        window.Content = panel;
+        window.Show();
+        try
+        {
+            // Pull every NumericUpDown / Button under the window and prove
+            // no derived id is shared between the two instances.
+            var ids = window
+                .GetLogicalDescendants()
+                .OfType<Control>()
+                .Select(AutomationProperties.GetAutomationId)
+                .Where(id => !string.IsNullOrEmpty(id))
+                .ToList();
+            // The core invariant: NO duplicates across the two instances.
+            // (Host UserControls themselves also expose their own ids
+            // "MonsterTab1_TopBar" / "MonsterTab2_TopBar", so total count
+            // depends on tree shape — we assert distinctness, not exact size.)
+            Assert.Equal(ids.Count, ids.Distinct().Count());
+            // All 8 derived ids are present and unique.
+            Assert.Contains("MonsterTab1_ReadStart_Input", ids);
+            Assert.Contains("MonsterTab1_ReadCount_Input", ids);
+            Assert.Contains("MonsterTab1_ReadSize_Input", ids);
+            Assert.Contains("MonsterTab1_Reload_Button", ids);
+            Assert.Contains("MonsterTab2_ReadStart_Input", ids);
+            Assert.Contains("MonsterTab2_ReadCount_Input", ids);
+            Assert.Contains("MonsterTab2_ReadSize_Input", ids);
+            Assert.Contains("MonsterTab2_Reload_Button", ids);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void NoHostAutomationId_LeavesInnerIdsEmpty()
+    {
+        // If the host never set an AutomationId on the control, the inner
+        // ids must stay empty (NOT a hard-coded "ETBI_*" that would collide
+        // across instances).
+        var window = new Window { Width = 200, Height = 100 };
+        var ctrl = new EditorTopBarWithInputs();
+        window.Content = ctrl;
+        window.Show();
+        try
+        {
+            var start = ctrl.FindControl<NumericUpDown>("ReadStartInput");
+            var count = ctrl.FindControl<NumericUpDown>("ReadCountInput");
+            var size = ctrl.FindControl<NumericUpDown>("ReadSizeInput");
+            var reload = ctrl.FindControl<Button>("ReloadButton");
+            Assert.True(string.IsNullOrEmpty(AutomationProperties.GetAutomationId(start!)));
+            Assert.True(string.IsNullOrEmpty(AutomationProperties.GetAutomationId(count!)));
+            Assert.True(string.IsNullOrEmpty(AutomationProperties.GetAutomationId(size!)));
+            Assert.True(string.IsNullOrEmpty(AutomationProperties.GetAutomationId(reload!)));
         }
         finally
         {

--- a/FEBuilderGBA.Avalonia.Tests/EditorTopBarWithInputsTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EditorTopBarWithInputsTests.cs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Headless UI tests for EditorTopBarWithInputs (#701 Slice A).
+//
+// EditorTopBarWithInputs is the editable variant of EditorTopBar — surfaces
+// the Read Start / Read Count / Read Size as user-editable NumericUpDowns +
+// a Reload button. This test suite locks in the foundational API:
+//
+//   - ReadStartAddress (uint)  — round-trips through inner NumericUpDown
+//   - ReadCount        (int)   — round-trips through inner NumericUpDown
+//   - ReadSize         (int)   — round-trips through inner NumericUpDown
+//   - ReloadRequested          — raised by Reload button click
+//
+// NO editor migrates in this PR — Copilot CLI plan review of #701 surfaced
+// that each editor's top strip has unique extras (FilterCombo, ChangeType,
+// FilterBox, ListExpandButton, etc.) so per-editor migration is properly
+// scoped as a follow-up. These tests guarantee the API is stable for those
+// downstream migration PRs to consume.
+using FEBuilderGBA.Avalonia.Controls;
+using global::Avalonia.Controls;
+using global::Avalonia.Headless.XUnit;
+using global::Avalonia.Interactivity;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+public class EditorTopBarWithInputsTests
+{
+    [AvaloniaFact]
+    public void Control_Constructs_WithExpectedChildren()
+    {
+        var ctrl = new EditorTopBarWithInputs();
+        Assert.NotNull(ctrl);
+        // After InitializeComponent, named inputs should be reachable via FindControl.
+        Assert.NotNull(ctrl.FindControl<NumericUpDown>("ReadStartInput"));
+        Assert.NotNull(ctrl.FindControl<NumericUpDown>("ReadCountInput"));
+        Assert.NotNull(ctrl.FindControl<NumericUpDown>("ReadSizeInput"));
+        Assert.NotNull(ctrl.FindControl<Button>("ReloadButton"));
+    }
+
+    [AvaloniaFact]
+    public void ReadStartAddress_SetGet_RoundTrips()
+    {
+        var ctrl = new EditorTopBarWithInputs();
+        ctrl.ReadStartAddress = 0x08000000;
+        Assert.Equal(0x08000000u, ctrl.ReadStartAddress);
+    }
+
+    [AvaloniaFact]
+    public void ReadStartAddress_Zero_RoundTrips()
+    {
+        var ctrl = new EditorTopBarWithInputs();
+        ctrl.ReadStartAddress = 0u;
+        Assert.Equal(0u, ctrl.ReadStartAddress);
+    }
+
+    [AvaloniaFact]
+    public void ReadCount_SetGet_RoundTrips()
+    {
+        var ctrl = new EditorTopBarWithInputs();
+        ctrl.ReadCount = 42;
+        Assert.Equal(42, ctrl.ReadCount);
+    }
+
+    [AvaloniaFact]
+    public void ReadSize_SetGet_RoundTrips()
+    {
+        var ctrl = new EditorTopBarWithInputs();
+        ctrl.ReadSize = 28;
+        Assert.Equal(28, ctrl.ReadSize);
+    }
+
+    [AvaloniaFact]
+    public void ReadStartAddress_SetGet_ReflectsInNumericUpDown()
+    {
+        // Programmatic Set must propagate to the inner NumericUpDown so that
+        // automation can read it back via the standard Avalonia value.
+        var ctrl = new EditorTopBarWithInputs();
+        ctrl.ReadStartAddress = 0x12345678u;
+        var box = ctrl.FindControl<NumericUpDown>("ReadStartInput");
+        Assert.NotNull(box);
+        Assert.Equal((decimal)0x12345678u, box!.Value);
+    }
+
+    [AvaloniaFact]
+    public void ReadCount_NumericUpDownChange_ReflectsInProperty()
+    {
+        // User-typed NumericUpDown value must be visible through the public
+        // property without any extra "reload" trip.
+        var ctrl = new EditorTopBarWithInputs();
+        var box = ctrl.FindControl<NumericUpDown>("ReadCountInput");
+        Assert.NotNull(box);
+        box!.Value = 17m;
+        Assert.Equal(17, ctrl.ReadCount);
+    }
+
+    [AvaloniaFact]
+    public void ReloadButton_Click_FiresReloadRequested()
+    {
+        var ctrl = new EditorTopBarWithInputs();
+        bool fired = false;
+        ctrl.ReloadRequested += (_, _) => fired = true;
+
+        var btn = ctrl.FindControl<Button>("ReloadButton");
+        Assert.NotNull(btn);
+        btn!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+        Assert.True(fired);
+    }
+
+    [AvaloniaFact]
+    public void ReloadRequested_BubblesAsRoutedEvent()
+    {
+        // The event is registered Bubble so an outer host (Window/Panel) can
+        // subscribe at a higher level without having to wire each editor.
+        var window = new Window { Width = 200, Height = 100 };
+        var ctrl = new EditorTopBarWithInputs();
+        window.Content = ctrl;
+        bool firedAtWindow = false;
+        window.AddHandler(EditorTopBarWithInputs.ReloadRequestedEvent,
+            (object? s, RoutedEventArgs e) => firedAtWindow = true);
+        window.Show();
+        try
+        {
+            var btn = ctrl.FindControl<Button>("ReloadButton");
+            Assert.NotNull(btn);
+            btn!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+            Assert.True(firedAtWindow);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Controls/EditorTopBarWithInputs.axaml
+++ b/FEBuilderGBA.Avalonia/Controls/EditorTopBarWithInputs.axaml
@@ -1,0 +1,42 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="FEBuilderGBA.Avalonia.Controls.EditorTopBarWithInputs">
+  <!--
+    Editable variant of EditorTopBar (#701 Slice A foundation).
+
+    Whereas EditorTopBar (#649) renders Start Address / Read Count / Size as
+    read-only display values, this control surfaces them as user-editable
+    NumericUpDown inputs plus a Reload button. Intended for editors that let
+    the user type a Read Start / Read Count / Read Size and click Reload to
+    re-read the table from a different address (e.g. table-of-tables editors,
+    debug viewers).
+
+    NO editor migrates to this control in the same PR — investigation per
+    Copilot CLI plan review of #701 showed each editor's top strip has unique
+    additional controls (FilterCombo, ChangeType, FilterBox, ListExpandButton,
+    etc.) requiring per-editor decisions. Per-editor migration is tracked as
+    a follow-up issue so this PR establishes the canonical API in isolation.
+  -->
+  <Border BorderBrush="Gray" BorderThickness="1" Padding="4">
+    <StackPanel Orientation="Horizontal" Spacing="6">
+      <TextBlock Text="Read Start:" VerticalAlignment="Center" />
+      <NumericUpDown AutomationProperties.AutomationId="ETBI_ReadStart_Input"
+                     Name="ReadStartInput" Width="120" FormatString="0"
+                     Minimum="0" Maximum="4294967295"
+                     VerticalAlignment="Center" />
+      <TextBlock Text="Read Count:" VerticalAlignment="Center" />
+      <NumericUpDown AutomationProperties.AutomationId="ETBI_ReadCount_Input"
+                     Name="ReadCountInput" Width="80" FormatString="0"
+                     Minimum="0" Maximum="65535"
+                     VerticalAlignment="Center" />
+      <TextBlock Text="Read Size:" VerticalAlignment="Center" />
+      <NumericUpDown AutomationProperties.AutomationId="ETBI_ReadSize_Input"
+                     Name="ReadSizeInput" Width="80" FormatString="0"
+                     Minimum="0" Maximum="65535"
+                     VerticalAlignment="Center" />
+      <Button AutomationProperties.AutomationId="ETBI_Reload_Button"
+              Name="ReloadButton" Content="Reload" Click="OnReloadClick"
+              VerticalAlignment="Center" />
+    </StackPanel>
+  </Border>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Controls/EditorTopBarWithInputs.axaml
+++ b/FEBuilderGBA.Avalonia/Controls/EditorTopBarWithInputs.axaml
@@ -17,25 +17,28 @@
     etc.) requiring per-editor decisions. Per-editor migration is tracked as
     a follow-up issue so this PR establishes the canonical API in isolation.
   -->
+  <!--
+    AutomationIds are NOT hard-coded here. Code-behind derives them from the
+    host AutomationId (e.g. "MonsterItem_ReadBar" -> "MonsterItem_ReadStart_Input")
+    on AttachedToVisualTree, with explicit per-slot overrides for legacy E2E
+    selectors. This mirrors EditorTopBar (#649) so multiple instances in the
+    same view (e.g. MonsterItemViewer's 3 tabs) don't collide.
+  -->
   <Border BorderBrush="Gray" BorderThickness="1" Padding="4">
     <StackPanel Orientation="Horizontal" Spacing="6">
       <TextBlock Text="Read Start:" VerticalAlignment="Center" />
-      <NumericUpDown AutomationProperties.AutomationId="ETBI_ReadStart_Input"
-                     Name="ReadStartInput" Width="120" FormatString="0"
+      <NumericUpDown Name="ReadStartInput" Width="120" FormatString="0"
                      Minimum="0" Maximum="4294967295"
                      VerticalAlignment="Center" />
       <TextBlock Text="Read Count:" VerticalAlignment="Center" />
-      <NumericUpDown AutomationProperties.AutomationId="ETBI_ReadCount_Input"
-                     Name="ReadCountInput" Width="80" FormatString="0"
+      <NumericUpDown Name="ReadCountInput" Width="80" FormatString="0"
                      Minimum="0" Maximum="65535"
                      VerticalAlignment="Center" />
       <TextBlock Text="Read Size:" VerticalAlignment="Center" />
-      <NumericUpDown AutomationProperties.AutomationId="ETBI_ReadSize_Input"
-                     Name="ReadSizeInput" Width="80" FormatString="0"
+      <NumericUpDown Name="ReadSizeInput" Width="80" FormatString="0"
                      Minimum="0" Maximum="65535"
                      VerticalAlignment="Center" />
-      <Button AutomationProperties.AutomationId="ETBI_Reload_Button"
-              Name="ReloadButton" Content="Reload" Click="OnReloadClick"
+      <Button Name="ReloadButton" Content="Reload" Click="OnReloadClick"
               VerticalAlignment="Center" />
     </StackPanel>
   </Border>

--- a/FEBuilderGBA.Avalonia/Controls/EditorTopBarWithInputs.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Controls/EditorTopBarWithInputs.axaml.cs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Editable variant of EditorTopBar (#701 Slice A foundation).
+//
+// This control bundles the Read Start / Read Count / Read Size NumericUpDown
+// inputs + a Reload button that several Avalonia editor views ship as ad-hoc
+// inline Grids. By centralising the layout, automation ids, and event surface,
+// per-editor migrations become mechanical follow-ups.
+//
+// Currently used by NO editor — added in PR for #701 Slice A to establish the
+// API. Per-editor migration is deferred to a separate follow-up issue because
+// investigation revealed each editor has unique additional controls
+// (FilterCombo, ChangeType combo, FilterBox, ListExpandButton, etc.) in its
+// top strip that don't fit a uniform replacement.
+using global::Avalonia;
+using global::Avalonia.Controls;
+using global::Avalonia.Interactivity;
+
+namespace FEBuilderGBA.Avalonia.Controls
+{
+    /// <summary>
+    /// Editable variant of EditorTopBar for editors that allow the user
+    /// to type a Read Start / Read Count / Read Size and trigger Reload.
+    ///
+    /// <para>Currently used by no editor — added in PR for #701 Slice A
+    /// to establish the API. Per-editor migration is tracked in a follow-up
+    /// issue once each editor's additional controls (FilterCombo, ChangeType,
+    /// FilterBox, ListExpandButton, etc.) have been audited.</para>
+    /// </summary>
+    public partial class EditorTopBarWithInputs : UserControl
+    {
+        /// <summary>
+        /// Routed event raised when the user clicks the Reload button. Hosts
+        /// subscribe via <see cref="ReloadRequested"/> to refresh their list
+        /// from the address/count/size currently in the inputs.
+        /// </summary>
+        public static readonly RoutedEvent<RoutedEventArgs> ReloadRequestedEvent =
+            RoutedEvent.Register<EditorTopBarWithInputs, RoutedEventArgs>(
+                nameof(ReloadRequested), RoutingStrategies.Bubble);
+
+        /// <summary>
+        /// Raised when the Reload button is clicked. Bubbles like a normal
+        /// routed event so a parent view-host can handle it without having
+        /// to wire each editor explicitly.
+        /// </summary>
+        public event System.EventHandler<RoutedEventArgs>? ReloadRequested
+        {
+            add => AddHandler(ReloadRequestedEvent, value);
+            remove => RemoveHandler(ReloadRequestedEvent, value);
+        }
+
+        public EditorTopBarWithInputs()
+        {
+            InitializeComponent();
+        }
+
+        /// <summary>
+        /// Current Read Start address as a uint. Round-trips through the inner
+        /// NumericUpDown so the value reflects exactly what the user has typed.
+        /// Setter clamps to the NumericUpDown's Minimum/Maximum bounds.
+        /// </summary>
+        public uint ReadStartAddress
+        {
+            get => (uint)(ReadStartInput?.Value ?? 0);
+            set { if (ReadStartInput != null) ReadStartInput.Value = value; }
+        }
+
+        /// <summary>
+        /// Current Read Count as an int. Round-trips through the inner
+        /// NumericUpDown. Negative inner values clamp to 0 in the getter since
+        /// a row count is never meaningfully negative.
+        /// </summary>
+        public int ReadCount
+        {
+            get
+            {
+                var v = ReadCountInput?.Value ?? 0;
+                return v < 0 ? 0 : (int)v;
+            }
+            set { if (ReadCountInput != null) ReadCountInput.Value = value; }
+        }
+
+        /// <summary>
+        /// Current Read Size (per-entry byte length) as an int. Round-trips
+        /// through the inner NumericUpDown. Negative inner values clamp to 0.
+        /// </summary>
+        public int ReadSize
+        {
+            get
+            {
+                var v = ReadSizeInput?.Value ?? 0;
+                return v < 0 ? 0 : (int)v;
+            }
+            set { if (ReadSizeInput != null) ReadSizeInput.Value = value; }
+        }
+
+        void OnReloadClick(object? sender, RoutedEventArgs e)
+        {
+            RaiseEvent(new RoutedEventArgs(ReloadRequestedEvent));
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Controls/EditorTopBarWithInputs.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Controls/EditorTopBarWithInputs.axaml.cs
@@ -8,11 +8,26 @@
 // per-editor migrations become mechanical follow-ups.
 //
 // Currently used by NO editor — added in PR for #701 Slice A to establish the
-// API. Per-editor migration is deferred to a separate follow-up issue because
+// API. Per-editor migration is deferred to follow-up issue #713 because
 // investigation revealed each editor has unique additional controls
 // (FilterCombo, ChangeType combo, FilterBox, ListExpandButton, etc.) in its
 // top strip that don't fit a uniform replacement.
+//
+// AutomationId mapping
+//   Hosts set ONE AutomationId on the EditorTopBarWithInputs (e.g.
+//   "MonsterItem_TopBar") and the control derives suffixed ids on the inner
+//   controls so E2E tests can address them and so multiple instances in the
+//   same visual tree never collide:
+//     {base}_ReadStart_Input, {base}_ReadCount_Input,
+//     {base}_ReadSize_Input,  {base}_Reload_Button.
+//   "{base}" strips a trailing "_TopBar" if present, mirroring EditorTopBar.
+//
+//   To preserve legacy ids pre-#701 selectors rely on (e.g.
+//   "SongInstrument_ReadStartAddress_Input"), hosts may set any of the
+//   *AutomationId styled properties — those override the derived id wholesale.
+using System;
 using global::Avalonia;
+using global::Avalonia.Automation;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 
@@ -23,12 +38,65 @@ namespace FEBuilderGBA.Avalonia.Controls
     /// to type a Read Start / Read Count / Read Size and trigger Reload.
     ///
     /// <para>Currently used by no editor — added in PR for #701 Slice A
-    /// to establish the API. Per-editor migration is tracked in a follow-up
-    /// issue once each editor's additional controls (FilterCombo, ChangeType,
+    /// to establish the API. Per-editor migration is tracked in follow-up
+    /// #713 once each editor's additional controls (FilterCombo, ChangeType,
     /// FilterBox, ListExpandButton, etc.) have been audited.</para>
     /// </summary>
     public partial class EditorTopBarWithInputs : UserControl
     {
+        // -----------------------------------------------------------------
+        // AutomationId overrides (for back-compat with pre-#701 E2E ids)
+        // -----------------------------------------------------------------
+
+        public static readonly StyledProperty<string> ReadStartAutomationIdProperty =
+            AvaloniaProperty.Register<EditorTopBarWithInputs, string>(nameof(ReadStartAutomationId), defaultValue: "");
+
+        public static readonly StyledProperty<string> ReadCountAutomationIdProperty =
+            AvaloniaProperty.Register<EditorTopBarWithInputs, string>(nameof(ReadCountAutomationId), defaultValue: "");
+
+        public static readonly StyledProperty<string> ReadSizeAutomationIdProperty =
+            AvaloniaProperty.Register<EditorTopBarWithInputs, string>(nameof(ReadSizeAutomationId), defaultValue: "");
+
+        public static readonly StyledProperty<string> ReloadAutomationIdProperty =
+            AvaloniaProperty.Register<EditorTopBarWithInputs, string>(nameof(ReloadAutomationId), defaultValue: "");
+
+        /// <summary>
+        /// Optional explicit AutomationId override for the Read Start input.
+        /// When non-empty this is set on the inner NumericUpDown instead of
+        /// the derived "{base}_ReadStart_Input" id, letting a migrated view
+        /// keep its legacy selector (e.g. "SongInstrument_ReadStartAddress_Input").
+        /// </summary>
+        public string ReadStartAutomationId
+        {
+            get => GetValue(ReadStartAutomationIdProperty);
+            set => SetValue(ReadStartAutomationIdProperty, value);
+        }
+
+        /// <summary>Explicit AutomationId override for the Read Count input.</summary>
+        public string ReadCountAutomationId
+        {
+            get => GetValue(ReadCountAutomationIdProperty);
+            set => SetValue(ReadCountAutomationIdProperty, value);
+        }
+
+        /// <summary>Explicit AutomationId override for the Read Size input.</summary>
+        public string ReadSizeAutomationId
+        {
+            get => GetValue(ReadSizeAutomationIdProperty);
+            set => SetValue(ReadSizeAutomationIdProperty, value);
+        }
+
+        /// <summary>Explicit AutomationId override for the Reload button.</summary>
+        public string ReloadAutomationId
+        {
+            get => GetValue(ReloadAutomationIdProperty);
+            set => SetValue(ReloadAutomationIdProperty, value);
+        }
+
+        // -----------------------------------------------------------------
+        // Routed events
+        // -----------------------------------------------------------------
+
         /// <summary>
         /// Routed event raised when the user clicks the Reload button. Hosts
         /// subscribe via <see cref="ReloadRequested"/> to refresh their list
@@ -52,6 +120,21 @@ namespace FEBuilderGBA.Avalonia.Controls
         public EditorTopBarWithInputs()
         {
             InitializeComponent();
+
+            AttachedToVisualTree += (_, _) => PropagateInnerAutomationIds();
+        }
+
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property == ReadStartAutomationIdProperty
+             || change.Property == ReadCountAutomationIdProperty
+             || change.Property == ReadSizeAutomationIdProperty
+             || change.Property == ReloadAutomationIdProperty)
+            {
+                PropagateInnerAutomationIds();
+            }
         }
 
         /// <summary>
@@ -97,6 +180,45 @@ namespace FEBuilderGBA.Avalonia.Controls
         void OnReloadClick(object? sender, RoutedEventArgs e)
         {
             RaiseEvent(new RoutedEventArgs(ReloadRequestedEvent));
+        }
+
+        /// <summary>
+        /// Derive AutomationIds for the inner controls from the host's id.
+        /// Explicit overrides take precedence so legacy E2E ids survive
+        /// migration. Idempotent — strips a trailing "_TopBar" suffix so the
+        /// derived ids stay stable across re-attaches.
+        /// </summary>
+        void PropagateInnerAutomationIds()
+        {
+            string hostId = AutomationProperties.GetAutomationId(this) ?? string.Empty;
+            string baseId = hostId;
+            if (baseId.EndsWith("_TopBar", StringComparison.Ordinal))
+                baseId = baseId.Substring(0, baseId.Length - "_TopBar".Length);
+
+            SetInnerId(ReadStartInput, ReadStartAutomationId, baseId, "_ReadStart_Input");
+            SetInnerId(ReadCountInput, ReadCountAutomationId, baseId, "_ReadCount_Input");
+            SetInnerId(ReadSizeInput, ReadSizeAutomationId, baseId, "_ReadSize_Input");
+            SetInnerId(ReloadButton, ReloadAutomationId, baseId, "_Reload_Button");
+        }
+
+        static void SetInnerId(Control? target, string explicitId, string baseId, string suffix)
+        {
+            if (target == null) return;
+            if (!string.IsNullOrEmpty(explicitId))
+            {
+                AutomationProperties.SetAutomationId(target, explicitId);
+            }
+            else if (!string.IsNullOrEmpty(baseId))
+            {
+                AutomationProperties.SetAutomationId(target, baseId + suffix);
+            }
+            else
+            {
+                // Host hasn't set an id and no explicit override → clear any
+                // previously derived id so a re-attach can't leave a stale
+                // value behind. Critical when multiple instances coexist.
+                AutomationProperties.SetAutomationId(target, string.Empty);
+            }
         }
     }
 }

--- a/scripts/validate-automation-ids.ps1
+++ b/scripts/validate-automation-ids.ps1
@@ -33,6 +33,7 @@ $exemptInternalFiles = @(
     "Controls\IconPreviewControl.axaml",
     "Controls\IdFieldControl.axaml",
     "Controls\EditorTopBar.axaml",
+    "Controls\EditorTopBarWithInputs.axaml",
     "App.axaml"
 )
 
@@ -52,7 +53,7 @@ $interactiveControlTypes = @(
 
 $customControlTypes = @(
     'controls:BitFlagPanel', 'controls:AddressListControl', 'controls:GbaImageControl',
-    'controls:IdFieldControl', 'controls:EditorTopBar'
+    'controls:IdFieldControl', 'controls:EditorTopBar', 'controls:EditorTopBarWithInputs'
 )
 
 $totalErrors = 0


### PR DESCRIPTION
## Summary

Add `FEBuilderGBA.Avalonia/Controls/EditorTopBarWithInputs.axaml(.cs)` -- an editable variant of `EditorTopBar` (#649) that surfaces Read Start / Read Count / Read Size as user-editable `NumericUpDown` inputs + a `Reload` button + `ReloadRequested` routed event.

**This is a `chore` PR: foundation-only, no GUI surface, no editor migrations.** Investigation during Copilot CLI plan review of #701 surfaced that each editor's top strip has unique additional controls (FilterCombo, ChangeType combo, FilterBox, ListExpandButton, etc.) requiring per-editor decisions. Per-editor migration is tracked in follow-up issue #713 so future PRs can use this stable API.

Updated #701 plan comment: https://github.com/laqieer/FEBuilderGBA/issues/701#issuecomment-4559209460

Ref #701 (control added; per-editor migration in #713).

## Why this is a meaningful slice

- Establishes the canonical API (`ReadStartAddress` / `ReadCount` / `ReadSize` / `ReloadRequested`) downstream migrations will consume.
- Provides a working control with full headless-test coverage (13 tests).
- Doesn't break any existing editor (none migrated yet).
- Cleanly scopes the per-editor work that was previously underestimated.

## AutomationId model (host-derived + override)

Mirroring `EditorTopBar` (#649): hosts set ONE id on the control (e.g. `MonsterItem_TopBar`) and the inner inputs/button get derived suffixes:
- `{base}_ReadStart_Input`
- `{base}_ReadCount_Input`
- `{base}_ReadSize_Input`
- `{base}_Reload_Button`

A trailing `_TopBar` is stripped from `{base}` so derived ids stay stable across re-attaches. Per-slot `*AutomationId` styled properties let migrated editors preserve legacy E2E selectors (e.g. `SongInstrument_ReadStartAddress_Input`). Two instances in the same visual tree never collide -- critical for the planned MonsterItemViewer 3-tab migration.

## Test plan

- [x] `dotnet build FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj` -- succeeds (0 errors).
- [x] `dotnet test ... --filter \"FullyQualifiedName~EditorTopBarWithInputsTests\"` -- 13/13 PASS.
- [x] Control_Constructs_WithExpectedChildren -- PASS (inner named controls reachable).
- [x] ReadStartAddress_SetGet_RoundTrips -- PASS (0x08000000 round-trips).
- [x] ReadStartAddress_Zero_RoundTrips -- PASS (boundary).
- [x] ReadCount_SetGet_RoundTrips -- PASS.
- [x] ReadSize_SetGet_RoundTrips -- PASS.
- [x] ReadStartAddress_SetGet_ReflectsInNumericUpDown -- PASS (property -> inner control).
- [x] ReadCount_NumericUpDownChange_ReflectsInProperty -- PASS (inner control -> property).
- [x] ReloadButton_Click_FiresReloadRequested -- PASS.
- [x] ReloadRequested_BubblesAsRoutedEvent -- PASS (Bubble routing reaches outer Window handler).
- [x] HostAutomationId_PropagatesDerivedIdsToInnerControls -- PASS (\"MonsterItem_TopBar\" -> \"MonsterItem_ReadStart_Input\" etc.).
- [x] ExplicitAutomationIdOverride_TakesPrecedence -- PASS (legacy \"SongInstrument_ReadStartAddress_Input\" preserved).
- [x] TwoInstancesInSameVisualTree_HaveDistinctAutomationIds -- PASS (no duplicate ids between Tab1 and Tab2).
- [x] NoHostAutomationId_LeavesInnerIdsEmpty -- PASS (no hard-coded fallback collision).
- [x] `dotnet test ... --filter \"FullyQualifiedName~AutomationIdTests\"` -- 9/9 PASS (no regressions in the broader AutomationId sweep).

## Proof of correctness (test output)

This is a `chore` PR adding a foundational control with no editor using it yet, so screenshots of a running editor are not applicable per the Copilot CLI screenshot policy (\"For docs/chore PRs, screenshots are optional\"). Proof is the headless test suite:

```
Passed!  - Failed:     0, Passed:    13, Skipped:     0, Total:    13, Duration: 630 ms - FEBuilderGBA.Avalonia.Tests.dll (net9.0)
```

Per CLAUDE.md Pre-Commit Checklist step 5: \"For docs/chore PRs, screenshots are optional.\" When per-editor migrations begin in follow-up PRs against #713, those PRs will be `feat`/`fix` and will include real GUI screenshots of the affected editors.

Generated with Claude Code (claude-opus-4-7-1m)