### PR TITLE
feat(avalonia): Map Style Editor OBJ Image Import (#710)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MapStyleEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MapStyleEditorParityTests.cs
@@ -1255,6 +1255,31 @@ public class MapStyleEditorParityTests
     }
 
     /// <summary>
+    /// #710 + Copilot bot v2 review item 1 on PR #716: the OBJ Image
+    /// Import button is gated at runtime by
+    /// <see cref="MapStyleEditorViewModel.CanImportObj"/>. The code-behind
+    /// must subscribe to the VM <c>PropertyChanged</c> event for
+    /// <c>CanImportObj</c> and call <c>RefreshObjImportEnabled</c> so the
+    /// button's <c>IsEnabled</c> stays in sync with the predicate.
+    /// </summary>
+    [Fact]
+    public void View_ObjImport_Click_GatesIsEnabledOnCanImportObj()
+    {
+        string code = File.ReadAllText(CodeBehindPath());
+        // Subscribes to CanImportObj property changes.
+        Assert.Contains("nameof(_vm.CanImportObj)", code);
+        // Calls RefreshObjImportEnabled (declares + at least one call site).
+        Assert.Contains("RefreshObjImportEnabled", code);
+        // The refresh helper pushes _vm.CanImportObj onto IsEnabled.
+        var bodyMatch = Regex.Match(code,
+            @"void RefreshObjImportEnabled[\s\S]*?(?=\n\s{8}(static\s|public\s|void\s|async\s|/// |//))",
+            RegexOptions.Singleline);
+        Assert.True(bodyMatch.Success, "RefreshObjImportEnabled method not found");
+        Assert.Contains("_vm.CanImportObj", bodyMatch.Value);
+        Assert.Contains("ObjImportButton.IsEnabled", bodyMatch.Value);
+    }
+
+    /// <summary>
     /// #710: the OBJ Image Import button must wire Click to the
     /// ObjImport_Click handler in AXAML AND the handler method must exist
     /// in the code-behind, wrapped in an undo scope.

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MapStyleEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MapStyleEditorParityTests.cs
@@ -192,32 +192,26 @@ public class MapStyleEditorParityTests
     /// </summary>
     static readonly string[] KnownGapButtonIds =
     {
-        // 1 button remains deferred after #704 partial slice. ObjImport
-        // tracks the new follow-up #710 (needs MapStyleEditorImportImageOptionForm
-        // port + 4bpp encoding + FE7 obj2 split handling).
+        // After #710 ImageOnly slice, ALL Map Style Editor buttons are
+        // functional. ObjImport (the last remaining KnownGap entry)
+        // became functional in #710 — see
+        // View_ObjImport_Button_IsEnabled +
+        // View_ObjImport_Click_HandlerWired below.
+        //
         // PaletteExport/Import/Clipboard/ObjExport/Undo became functional
         // in #672 Slice A; Redo and MapChip Export became functional in
-        // #692 partial slice; MapChip Import became functional in #704
-        // (see View_<Name>_Button_IsEnabled +
-        // View_<Name>_Click_HandlerWired tests below).
-        //
-        // PaletteWrite is functional via #660 first slice (tracked positively
-        // by View_FunctionalPaletteWriteButton_IsEnabled); CopyTile / CopyType /
-        // Paste / ConfigWrite became functional in #671 (tracked positively
-        // by View_ChipsetTab_FunctionalControls_AreEnabled_WhenCanEdit).
-        "MapStyleEditor_ObjImport_Button",
+        // #692 partial slice; MapChip Import became functional in #704.
+        // PaletteWrite is functional via #660 first slice; CopyTile /
+        // CopyType / Paste / ConfigWrite became functional in #671.
     };
 
     /// <summary>
     /// Per-button mapping of remaining KnownGap buttons to the follow-up
-    /// issue their tooltip must reference. OBJ Import was promoted to its
-    /// own follow-up #710 in #704 because it needs substantially more work
-    /// (option dialog + 4bpp encoding + FE7 obj2) than the original #692
-    /// bucket assumed.
+    /// issue their tooltip must reference. The dictionary is empty after
+    /// #710 because every button is now functional.
     /// </summary>
     static readonly System.Collections.Generic.Dictionary<string, string> KnownGapTooltipIssue = new()
     {
-        ["MapStyleEditor_ObjImport_Button"] = "#710",
     };
 
     [Fact]
@@ -1227,6 +1221,68 @@ public class MapStyleEditorParityTests
         string body = bodyMatch.Value;
         Assert.Contains("_undoService.Begin", body);
         Assert.Contains("_vm.TryWriteConfigBuffer", body);
+        Assert.Contains("_undoService.Commit()", body);
+        Assert.Contains("_undoService.Rollback()", body);
+    }
+
+    // -----------------------------------------------------------------
+    // #710 — OBJ Image Import button parity tests.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// #710: the OBJ Image Import button must NOT carry IsEnabled="False"
+    /// or any stale #374 / #692 / #710 tooltip anymore — it became
+    /// functional via the ImageOnly slice (256-wide × ≥128-tall × multi-
+    /// of-8 height, remap against existing OBJ palette, OBJECT PLIST write).
+    /// </summary>
+    [Fact]
+    public void View_ObjImport_Button_IsEnabled()
+    {
+        string axaml = ReadAxaml();
+        var pattern = new Regex(
+            @"<Button[^>]*AutomationProperties\.AutomationId=""MapStyleEditor_ObjImport_Button""[^>]*",
+            RegexOptions.None);
+        Match m = pattern.Match(axaml);
+        Assert.True(m.Success, "MapStyleEditor_ObjImport_Button must exist");
+        Assert.False(m.Value.Contains("IsEnabled=\"False\""),
+            "MapStyleEditor_ObjImport_Button must not carry IsEnabled=\"False\" anymore (#710)");
+        Assert.False(m.Value.Contains("#374"),
+            "MapStyleEditor_ObjImport_Button must not advertise the legacy #374 tooltip");
+        Assert.False(m.Value.Contains("#692"),
+            "MapStyleEditor_ObjImport_Button must not advertise the stale #692 tooltip");
+        Assert.False(m.Value.Contains("Pending Core extraction"),
+            "MapStyleEditor_ObjImport_Button must not advertise the stale 'Pending Core extraction' tooltip");
+    }
+
+    /// <summary>
+    /// #710: the OBJ Image Import button must wire Click to the
+    /// ObjImport_Click handler in AXAML AND the handler method must exist
+    /// in the code-behind, wrapped in an undo scope.
+    /// </summary>
+    [Fact]
+    public void View_ObjImport_Click_HandlerWired()
+    {
+        string axaml = ReadAxaml();
+        var pattern = new Regex(
+            @"<Button[^>]*AutomationProperties\.AutomationId=""MapStyleEditor_ObjImport_Button""[^>]*",
+            RegexOptions.None);
+        Match m = pattern.Match(axaml);
+        Assert.True(m.Success, "MapStyleEditor_ObjImport_Button must exist");
+        Assert.Contains("Click=\"ObjImport_Click\"", m.Value);
+
+        string code = File.ReadAllText(CodeBehindPath());
+        Assert.Matches(new Regex(
+            @"void ObjImport_Click\(object\?",
+            RegexOptions.None), code);
+        // Handler must wrap the VM call in an undo scope (Begin / Commit /
+        // Rollback) so a failed write does not leave a half-applied import.
+        var bodyMatch = Regex.Match(code,
+            @"void ObjImport_Click[\s\S]*?(?=\n\s{8}(static\s|public\s|void\s|async\s|/// |//))",
+            RegexOptions.Singleline);
+        Assert.True(bodyMatch.Success, "ObjImport_Click method not found");
+        string body = bodyMatch.Value;
+        Assert.Contains("_undoService.Begin", body);
+        Assert.Contains("_vm.TryImportObjImage", body);
         Assert.Contains("_undoService.Commit()", body);
         Assert.Contains("_undoService.Rollback()", body);
     }

--- a/FEBuilderGBA.Avalonia.Tests/MapStyleEditorViewModelObjImportTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/MapStyleEditorViewModelObjImportTests.cs
@@ -141,10 +141,83 @@ public class MapStyleEditorViewModelObjImportTests
             vm.SetCachedPaletteBytesForTest(MakeFlatPalette32());
             byte[] rgba = MakeSolidRgba(256, 128, 0, 0, 255);
 
+            // Per-version limit (FE8U: 0xEC) — 0xFF triggers the more
+            // specific "past the per-version limit" branch added in PR
+            // #716 review item 2.
             Assert.False(vm.TryImportObjImage(rgba, 256, 128, out string err));
-            Assert.Contains("no valid OBJ PLIST", err);
+            Assert.Contains("past the per-version limit", err);
         }
         finally { CoreState.ROM = prevRom; }
+    }
+
+    /// <summary>
+    /// Copilot bot #2 on PR #716: plists above the per-version PLIST limit
+    /// (e.g. FE8U vanilla 0xEC) but below 0xFF must also be rejected —
+    /// without this gate, CanImportObj would enable the button for a slot
+    /// that <see cref="MapChangeCore.WritePlistData"/> would refuse,
+    /// surfacing a confusing UX.
+    /// </summary>
+    [Fact]
+    public void TryImportObjImage_RejectsPlistAboveVersionLimit()
+    {
+        var (rom, _, _, _) = MakeFe8uRomForObjImport();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapStyleEditorViewModel();
+            vm.ObjPointer = 0x08C00000u;
+            // 0xED is above the FE8U default limit (0xEC) but below the
+            // 0xFF sentinel — must still be rejected.
+            vm.SetCurrentObjPlistForTest(0xED);
+
+            vm.SetCachedPaletteBytesForTest(MakeFlatPalette32());
+            byte[] rgba = MakeSolidRgba(256, 128, 0, 0, 255);
+            Assert.False(vm.TryImportObjImage(rgba, 256, 128, out string err));
+            Assert.Contains("past the per-version limit", err);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    /// <summary>
+    /// Copilot bot #1 on PR #716: a null/zero OBJ pointer does NOT block
+    /// import — the slot is a valid write target (WF
+    /// <c>InputFormRef.WriteBinaryData</c> + <c>MapChangeCore.ResolvePlistSlotAddr</c>
+    /// both treat address 0 as "append new data"). Without this assertion
+    /// a future regression that re-introduces the <c>ObjPointer != 0</c>
+    /// gate would slip through.
+    /// </summary>
+    [Fact]
+    public void TryImportObjImage_AcceptsZeroObjPointer_AsAppend()
+    {
+        var (rom, objTableAddr, objPlist, palette32) = MakeFe8uRomForObjImport();
+        var prevRom = CoreState.ROM;
+        var prevImg = CoreState.ImageService;
+        try
+        {
+            CoreState.ROM = rom;
+            if (CoreState.ImageService == null) CoreState.ImageService = new SkiaImageService();
+
+            var vm = new MapStyleEditorViewModel();
+            // Explicitly leave ObjPointer at 0 — simulating a fresh PLIST
+            // slot that no Map Style entry has populated yet.
+            vm.ObjPointer = 0u;
+            vm.ObjAddress = 0u;
+            vm.SetCurrentObjPlistForTest(objPlist);
+            vm.SetCachedPaletteBytesForTest(palette32);
+
+            byte[] rgba = MakeSolidRgba(256, 128, 0, 0, 255);
+            Assert.True(vm.TryImportObjImage(rgba, 256, 128, out string err),
+                $"Import must succeed even when ObjPointer is 0; err = {err}");
+            // Slot must now hold a real pointer.
+            uint newPointer = rom.u32(objTableAddr + objPlist * 4u);
+            Assert.NotEqual(0u, newPointer);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.ImageService = prevImg;
+        }
     }
 
     [Fact]

--- a/FEBuilderGBA.Avalonia.Tests/MapStyleEditorViewModelObjImportTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/MapStyleEditorViewModelObjImportTests.cs
@@ -1,0 +1,412 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for the OBJ Image Import (ImageOnly) slice on
+// MapStyleEditorViewModel (#710): TryImportObjImage dimension contract,
+// FE7 obj2 rejection, palette-existence guard, and round-trip success
+// through ImageImportCore.RemapToExistingPalette + EncodeDirectTiles4bpp
+// + LZ77 + MapChangeCore.WritePlistData(OBJECT, ...).
+using System;
+using Xunit;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.SkiaSharp;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+/// <summary>
+/// Marked [Collection("SharedState")] because the import path mutates
+/// CoreState.ROM / CoreState.ImageService. Without serialization, xUnit's
+/// parallel runner could race a sibling test's CoreState swap.
+/// </summary>
+[Collection("SharedState")]
+public class MapStyleEditorViewModelObjImportTests
+{
+    // -----------------------------------------------------------------
+    // Dimension contract — Copilot CLI v1 review item 2 on plan v2.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void TryImportObjImage_RejectsWrongWidth()
+    {
+        var vm = new MapStyleEditorViewModel();
+        byte[] rgba = new byte[128 * 128 * 4];
+        Assert.False(vm.TryImportObjImage(rgba, width: 128, height: 128, out string err));
+        Assert.Contains("256", err);
+        Assert.Contains("wide", err);
+    }
+
+    [Fact]
+    public void TryImportObjImage_RejectsShortHeight()
+    {
+        var vm = new MapStyleEditorViewModel();
+        byte[] rgba = new byte[256 * 64 * 4];
+        Assert.False(vm.TryImportObjImage(rgba, width: 256, height: 64, out string err));
+        Assert.Contains("128", err);
+        Assert.Contains("tall", err);
+    }
+
+    [Fact]
+    public void TryImportObjImage_RejectsHeightNotMultipleOf8()
+    {
+        var vm = new MapStyleEditorViewModel();
+        byte[] rgba = new byte[256 * 130 * 4];
+        Assert.False(vm.TryImportObjImage(rgba, width: 256, height: 130, out string err));
+        Assert.Contains("multiple of 8", err);
+    }
+
+    [Fact]
+    public void TryImportObjImage_RejectsNullSource()
+    {
+        var vm = new MapStyleEditorViewModel();
+        Assert.False(vm.TryImportObjImage(null, width: 256, height: 128, out string err));
+        Assert.Contains("Invalid source", err);
+    }
+
+    [Fact]
+    public void TryImportObjImage_RejectsTruncatedSource()
+    {
+        var vm = new MapStyleEditorViewModel();
+        // Width/height pass but the RGBA buffer is too small.
+        byte[] rgba = new byte[10];
+        Assert.False(vm.TryImportObjImage(rgba, width: 256, height: 128, out string err));
+        Assert.Contains("Invalid source", err);
+    }
+
+    // -----------------------------------------------------------------
+    // FE7 obj2 rejection — actionable error wording.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void TryImportObjImage_RejectsObj2Style()
+    {
+        var (rom, _, _, _) = MakeFe8uRomForObjImport();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapStyleEditorViewModel();
+            // Stage a non-zero obj2 address to simulate an FE7 dual-tileset style.
+            vm.ObjPointer = 0x08C00000u;
+            vm.ObjAddress2 = 0x008C0000u;
+            vm.SetCurrentObjPlistForTest(1);
+
+            byte[] palette32 = MakeFlatPalette32();
+            vm.SetCachedPaletteBytesForTest(palette32);
+            byte[] rgba = MakeSolidRgba(256, 128, 0, 0, 255);
+
+            Assert.False(vm.TryImportObjImage(rgba, 256, 128, out string err));
+            Assert.Contains("obj2", err);
+            Assert.Contains("Tracked separately", err);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    // -----------------------------------------------------------------
+    // CanImportObj predicate — sentinel/no-PLIST gates.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void TryImportObjImage_RejectsZeroPlist()
+    {
+        var (rom, _, _, _) = MakeFe8uRomForObjImport();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapStyleEditorViewModel();
+            vm.ObjPointer = 0x08C00000u;
+            vm.SetCurrentObjPlistForTest(0); // reserved sentinel
+
+            vm.SetCachedPaletteBytesForTest(MakeFlatPalette32());
+            byte[] rgba = MakeSolidRgba(256, 128, 0, 0, 255);
+
+            Assert.False(vm.TryImportObjImage(rgba, 256, 128, out string err));
+            Assert.Contains("no valid OBJ PLIST", err);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void TryImportObjImage_RejectsPlistFF()
+    {
+        var (rom, _, _, _) = MakeFe8uRomForObjImport();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapStyleEditorViewModel();
+            vm.ObjPointer = 0x08C00000u;
+            vm.SetCurrentObjPlistForTest(0xFF); // no-PLIST marker
+
+            vm.SetCachedPaletteBytesForTest(MakeFlatPalette32());
+            byte[] rgba = MakeSolidRgba(256, 128, 0, 0, 255);
+
+            Assert.False(vm.TryImportObjImage(rgba, 256, 128, out string err));
+            Assert.Contains("no valid OBJ PLIST", err);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void TryImportObjImage_RequiresPaletteLoaded()
+    {
+        var (rom, _, _, _) = MakeFe8uRomForObjImport();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapStyleEditorViewModel();
+            vm.ObjPointer = 0x08C00000u;
+            vm.SetCurrentObjPlistForTest(1);
+            // No palette cache staged.
+
+            byte[] rgba = MakeSolidRgba(256, 128, 0, 0, 255);
+            Assert.False(vm.TryImportObjImage(rgba, 256, 128, out string err));
+            Assert.Contains("palette is not loaded", err);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    // -----------------------------------------------------------------
+    // Happy-path round-trip: write succeeds and the OBJECT PLIST slot
+    // now points at a region containing LZ77-compressed tile bytes.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void TryImportObjImage_FE8U_WritesTilesAndPointer()
+    {
+        var (rom, objTableAddr, objPlist, palette32) = MakeFe8uRomForObjImport();
+        var prevRom = CoreState.ROM;
+        var prevImg = CoreState.ImageService;
+        try
+        {
+            CoreState.ROM = rom;
+            if (CoreState.ImageService == null) CoreState.ImageService = new SkiaImageService();
+
+            var vm = new MapStyleEditorViewModel();
+            // Stage VM state the LoadEntry path would normally fill in.
+            vm.ObjPointer = 0x08C00000u;
+            vm.ObjAddress = 0x00C00000u;
+            vm.SetCurrentObjPlistForTest(objPlist);
+            vm.SetCachedPaletteBytesForTest(palette32);
+
+            // 256x128 solid blue image — every pixel will resolve to the
+            // nearest palette color != index 0 (palette index 0 is
+            // transparent per ImageImportCore.RemapToExistingPalette).
+            byte[] rgba = MakeSolidRgba(256, 128, 0, 0, 255);
+
+            Assert.True(vm.TryImportObjImage(rgba, 256, 128, out string err),
+                $"Import must succeed; err = {err}");
+
+            // ObjPointer / ObjAddress must point at the new region.
+            uint slotAddr = objTableAddr + objPlist * 4u;
+            uint newPointer = rom.u32(slotAddr);
+            Assert.Equal(newPointer, vm.ObjPointer);
+            Assert.Equal(U.toOffset(newPointer), vm.ObjAddress);
+            Assert.NotEqual(0u, newPointer);
+
+            // The new offset must hold LZ77 data — first byte = 0x10
+            // (GBA BIOS LZ77 magic).
+            uint newOffset = U.toOffset(newPointer);
+            Assert.Equal(0x10, rom.Data[newOffset]);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.ImageService = prevImg;
+        }
+    }
+
+    /// <summary>
+    /// The remap path must use the EXISTING palette (no quantization). With
+    /// a synthetic palette of {transparent, red, green}, a pure-blue source
+    /// pixel must round-trip to ONE of the non-transparent palette entries
+    /// (red or green), not introduce a new color.
+    /// </summary>
+    [Fact]
+    public void TryImportObjImage_RemapsAgainstExistingPalette()
+    {
+        var (rom, objTableAddr, objPlist, _) = MakeFe8uRomForObjImport();
+        var prevRom = CoreState.ROM;
+        var prevImg = CoreState.ImageService;
+        try
+        {
+            CoreState.ROM = rom;
+            if (CoreState.ImageService == null) CoreState.ImageService = new SkiaImageService();
+
+            // 16-color palette: idx 0 = transparent (0,0,0 → not selected
+            // for opaque pixels), idx 1 = red, idx 2 = green, idx 3..15 = 0
+            // (also valid candidates, but red/green are closest to most colors).
+            byte[] palette32 = new byte[32];
+            // idx 1: red 0x1F packed = 0x001F
+            palette32[2] = 0x1F; palette32[3] = 0x00;
+            // idx 2: green 0x1F << 5 = 0x03E0
+            palette32[4] = 0xE0; palette32[5] = 0x03;
+
+            var vm = new MapStyleEditorViewModel();
+            vm.ObjPointer = 0x08C00000u;
+            vm.ObjAddress = 0x00C00000u;
+            vm.SetCurrentObjPlistForTest(objPlist);
+            vm.SetCachedPaletteBytesForTest(palette32);
+
+            // Pure-blue source — neither palette entry exactly matches but
+            // the remap must still pick something (not throw, not return null).
+            byte[] rgba = MakeSolidRgba(256, 128, 0, 0, 255);
+            Assert.True(vm.TryImportObjImage(rgba, 256, 128, out string err),
+                $"Remap import must succeed; err = {err}");
+
+            // The new region must contain a valid LZ77-compressed tile sheet.
+            uint newPointer = rom.u32(objTableAddr + objPlist * 4u);
+            Assert.NotEqual(0u, newPointer);
+            uint newOffset = U.toOffset(newPointer);
+            Assert.Equal(0x10, rom.Data[newOffset]);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.ImageService = prevImg;
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Undo coverage — verifies the OBJECT slot write is undoable when
+    // wrapped in an ambient undo scope.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void TryImportObjImage_UndoableRestoresOriginalPointer()
+    {
+        var (rom, objTableAddr, objPlist, palette32) = MakeFe8uRomForObjImport();
+        var prevRom = CoreState.ROM;
+        var prevImg = CoreState.ImageService;
+        var prevUndo = CoreState.Undo;
+        try
+        {
+            CoreState.ROM = rom;
+            if (CoreState.ImageService == null) CoreState.ImageService = new SkiaImageService();
+            CoreState.Undo = new Undo();
+
+            // Pre-seed the OBJECT slot with a known pointer so undo has a
+            // value to restore.
+            uint slotAddr = objTableAddr + objPlist * 4u;
+            uint preSlot = 0x08C00000u;
+            rom.Data[slotAddr + 0] = 0x00;
+            rom.Data[slotAddr + 1] = 0x00;
+            rom.Data[slotAddr + 2] = 0xC0;
+            rom.Data[slotAddr + 3] = 0x08;
+            Assert.Equal(preSlot, rom.u32(slotAddr));
+
+            var vm = new MapStyleEditorViewModel();
+            vm.ObjPointer = preSlot;
+            vm.ObjAddress = U.toOffset(preSlot);
+            vm.SetCurrentObjPlistForTest(objPlist);
+            vm.SetCachedPaletteBytesForTest(palette32);
+
+            byte[] rgba = MakeSolidRgba(256, 128, 0, 0, 255);
+            var undoData = CoreState.Undo.NewUndoData("test obj import");
+            using (ROM.BeginUndoScope(undoData))
+            {
+                Assert.True(vm.TryImportObjImage(rgba, 256, 128, out _));
+            }
+            CoreState.Undo.Push(undoData);
+
+            // Confirm the slot moved.
+            Assert.NotEqual(preSlot, rom.u32(slotAddr));
+
+            // Run undo and verify the original pointer is restored.
+            CoreState.Undo.RunUndo();
+            Assert.Equal(preSlot, rom.u32(slotAddr));
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.ImageService = prevImg;
+            CoreState.Undo = prevUndo;
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // CanImportObj OnPropertyChanged wiring — ObjPointer / ObjAddress2
+    // changes must raise CanImportObj.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void CanImportObj_FiresPropertyChanged_OnObjAddress2()
+    {
+        var (rom, _, _, _) = MakeFe8uRomForObjImport();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapStyleEditorViewModel();
+            vm.ObjPointer = 0x08C00000u;
+            vm.SetCurrentObjPlistForTest(1);
+            Assert.True(vm.CanImportObj, "CanImportObj must be true for valid OBJ plist + no obj2");
+
+            bool fired = false;
+            vm.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(vm.CanImportObj)) fired = true; };
+            vm.ObjAddress2 = 0x008C0000u;
+            Assert.True(fired, "CanImportObj must fire OnPropertyChanged when ObjAddress2 changes");
+            Assert.False(vm.CanImportObj, "CanImportObj must be false when obj2 is present");
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Build a synthetic FE8U ROM with a populated map_obj_pointer table
+    /// at 0x00890000, an entry at slot 1 pointing at 0x08C00000, and a
+    /// flat 16-color palette buffer for the VM to remap against.
+    /// Returns (rom, objTableAddr, objPlistSlot, palette32).
+    /// </summary>
+    static (ROM rom, uint objTableAddr, uint objPlistSlot, byte[] palette32) MakeFe8uRomForObjImport()
+    {
+        var rom = new ROM();
+        rom.LoadLow("test-fe8u.gba", new byte[0x1100000], "BE8E01");
+        uint objTableAddr = 0x00890000u;
+        WriteU32(rom.Data, (int)rom.RomInfo.map_obj_pointer, objTableAddr | 0x08000000u);
+        // Plant a non-null slot at index 1 (so isSafetyOffset against the
+        // existing slot works for sanity checks).
+        WriteU32(rom.Data, (int)(objTableAddr + 1 * 4u), 0x08C00000u);
+        return (rom, objTableAddr, 1u, MakeFlatPalette32());
+    }
+
+    /// <summary>16 colors, idx 0 = transparent, idx 1..15 = stepped grayscale.</summary>
+    static byte[] MakeFlatPalette32()
+    {
+        byte[] pal = new byte[32];
+        // idx 0: transparent (0,0,0).
+        for (int i = 1; i < 16; i++)
+        {
+            byte v = (byte)(i & 0x1F);
+            ushort packed = (ushort)(v | (v << 5) | (v << 10));
+            pal[i * 2 + 0] = (byte)(packed & 0xFF);
+            pal[i * 2 + 1] = (byte)((packed >> 8) & 0xFF);
+        }
+        return pal;
+    }
+
+    static byte[] MakeSolidRgba(int width, int height, byte r, byte g, byte b)
+    {
+        byte[] rgba = new byte[width * height * 4];
+        for (int i = 0; i < width * height; i++)
+        {
+            rgba[i * 4 + 0] = r;
+            rgba[i * 4 + 1] = g;
+            rgba[i * 4 + 2] = b;
+            rgba[i * 4 + 3] = 0xFF;
+        }
+        return rgba;
+    }
+
+    static void WriteU32(byte[] data, int offset, uint value)
+    {
+        data[offset + 0] = (byte)(value & 0xFF);
+        data[offset + 1] = (byte)((value >> 8) & 0xFF);
+        data[offset + 2] = (byte)((value >> 16) & 0xFF);
+        data[offset + 3] = (byte)((value >> 24) & 0xFF);
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/MapStyleEditorViewModelObjImportTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/MapStyleEditorViewModelObjImportTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 using FEBuilderGBA;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
 using FEBuilderGBA.SkiaSharp;
 
 namespace FEBuilderGBA.Avalonia.Tests;
@@ -69,6 +70,31 @@ public class MapStyleEditorViewModelObjImportTests
         // Width/height pass but the RGBA buffer is too small.
         byte[] rgba = new byte[10];
         Assert.False(vm.TryImportObjImage(rgba, width: 256, height: 128, out string err));
+        Assert.Contains("Invalid source", err);
+    }
+
+    /// <summary>
+    /// Copilot bot #3 on PR #716: the pre-fix int multiplication
+    /// <c>width * height * 4</c> overflows for large heights, wrapping to a
+    /// negative value that lets a truncated buffer slip past the bounds
+    /// check. With width=256 and height=8_400_000, the int product is
+    /// 8_600_000_000 which wraps past int.MaxValue, so the old check
+    /// (<c>sourceRgba.Length &lt; required</c>) would pass for ANY
+    /// non-empty buffer. The long-arithmetic fix correctly rejects it.
+    /// Passing a 100-byte buffer keeps the test fast and memory-cheap.
+    /// </summary>
+    [Fact]
+    public void TryImportObjImage_RejectsOverflowingDimensions_LongCheck()
+    {
+        var vm = new MapStyleEditorViewModel();
+        // 100-byte buffer that the OLD int-arithmetic length check would
+        // accept (because the required-bytes calculation wrapped past
+        // int.MaxValue).
+        byte[] rgba = new byte[100];
+        // height = 8_400_000 is a multiple of 8 and passes the >=128
+        // floor, so the early dimension gates don't reject it before
+        // the length check fires. width=256 keeps the width gate happy.
+        Assert.False(vm.TryImportObjImage(rgba, width: 256, height: 8_400_000, out string err));
         Assert.Contains("Invalid source", err);
     }
 
@@ -423,6 +449,110 @@ public class MapStyleEditorViewModelObjImportTests
             Assert.False(vm.CanImportObj, "CanImportObj must be false when obj2 is present");
         }
         finally { CoreState.ROM = prevRom; }
+    }
+
+    // -----------------------------------------------------------------
+    // Indexed-image decode guards — Copilot bot #4 on PR #716.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Guard 1: indexData null or shorter than w*h must be rejected with a
+    /// "shorter than expected" error. Before the fix the View partially
+    /// converted the available bytes and left the rest of the output as
+    /// all-zero RGBA (silently transparent garbage).
+    /// </summary>
+    [Fact]
+    public void ConvertIndexedToRgba_RejectsShortIndexBuffer()
+    {
+        byte[] indexData = new byte[10]; // expected 256*128 = 32768
+        byte[] palRgba = new byte[] { 0xFF, 0x00, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF };
+        var result = MapStyleEditorView.ConvertIndexedToRgba(indexData, palRgba, 256, 128, out string err);
+        Assert.Null(result);
+        Assert.Contains("shorter than expected", err);
+    }
+
+    [Fact]
+    public void ConvertIndexedToRgba_RejectsNullIndexBuffer()
+    {
+        byte[] palRgba = new byte[] { 0xFF, 0x00, 0x00, 0xFF };
+        var result = MapStyleEditorView.ConvertIndexedToRgba(null, palRgba, 256, 128, out string err);
+        Assert.Null(result);
+        Assert.Contains("shorter than expected", err);
+    }
+
+    /// <summary>
+    /// Guard 2: a null / too-short palette buffer must be rejected with
+    /// "no usable palette". Before the fix every pixel silently fell
+    /// through to the `palOff + 3 &lt; palRgba.Length` branch and stayed
+    /// at 0 RGBA.
+    /// </summary>
+    [Fact]
+    public void ConvertIndexedToRgba_RejectsNullPalette()
+    {
+        byte[] indexData = new byte[256 * 128];
+        var result = MapStyleEditorView.ConvertIndexedToRgba(indexData, null, 256, 128, out string err);
+        Assert.Null(result);
+        Assert.Contains("no usable palette", err);
+    }
+
+    [Fact]
+    public void ConvertIndexedToRgba_RejectsTooShortPalette()
+    {
+        byte[] indexData = new byte[256 * 128];
+        byte[] palRgba = new byte[3]; // < 4 bytes ⇒ can't hold even one color
+        var result = MapStyleEditorView.ConvertIndexedToRgba(indexData, palRgba, 256, 128, out string err);
+        Assert.Null(result);
+        Assert.Contains("no usable palette", err);
+    }
+
+    /// <summary>
+    /// Guard 3: a pixel referencing a palette entry beyond the palette
+    /// buffer must be rejected with an actionable error. Before the fix
+    /// such pixels silently stayed at 0 RGBA — the user got an
+    /// apparently-successful import with large transparent regions where
+    /// out-of-range indices appeared.
+    /// </summary>
+    [Fact]
+    public void ConvertIndexedToRgba_RejectsOutOfRangePaletteIndex()
+    {
+        byte[] indexData = new byte[256 * 128];
+        // Seed pixel 5 with index 4 — but the palette only has 2 entries
+        // (8 bytes), so index 4 means palOff = 16 which is past palRgba.Length.
+        indexData[5] = 4;
+        byte[] palRgba = new byte[8]; // 2 colors only
+        var result = MapStyleEditorView.ConvertIndexedToRgba(indexData, palRgba, 256, 128, out string err);
+        Assert.Null(result);
+        // Verify the View-facing error wording: identifies the pixel
+        // index, the palette entry, and the actual palette size.
+        Assert.Contains("uses palette entry 4", err);
+        Assert.Contains("only 2 colors", err);
+    }
+
+    /// <summary>
+    /// Happy path: a sufficient indexData + palette must produce a
+    /// correctly-sized RGBA buffer with pixel 0's data sourced from the
+    /// palette entry it indexes.
+    /// </summary>
+    [Fact]
+    public void ConvertIndexedToRgba_HappyPath_DecodesPixels()
+    {
+        byte[] indexData = new byte[8 * 8];
+        // Pixel 0 → palette index 1 → RGB (0,255,0,255).
+        indexData[0] = 1;
+        byte[] palRgba = new byte[]
+        {
+            0xAA, 0xBB, 0xCC, 0xDD, // index 0
+            0x00, 0xFF, 0x00, 0xFF, // index 1
+        };
+        var result = MapStyleEditorView.ConvertIndexedToRgba(indexData, palRgba, 8, 8, out string err);
+        Assert.NotNull(result);
+        Assert.Equal("", err);
+        Assert.Equal(8 * 8 * 4, result!.Length);
+        // Pixel 0 RGBA should match palette index 1.
+        Assert.Equal(0x00, result[0]);
+        Assert.Equal(0xFF, result[1]);
+        Assert.Equal(0x00, result[2]);
+        Assert.Equal(0xFF, result[3]);
     }
 
     // -----------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
@@ -36,6 +36,13 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         // map-setting scan.
         byte[] _cachedConfigData;
         uint _currentConfigPlist;
+        // OBJ Image Import (#710): plist byte for the primary OBJ tileset.
+        // Resolved from the entry index inside the map_obj_pointer table at
+        // LoadEntry time so TryImportObjImage can rewrite the OBJECT PLIST
+        // slot without re-walking the map_setting list. 0 / >= 0xFF mean
+        // "no valid OBJ plist" (mirrors WF's reserved-sentinel semantics
+        // for plist 0 and the no-PLIST marker 0xFF).
+        uint _currentObjPlist;
         int _currentChipsetNo;
         int _currentTerrain;
 
@@ -66,7 +73,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
-        public uint ObjPointer { get => _objPointer; set => SetField(ref _objPointer, value); }
+        public uint ObjPointer
+        {
+            get => _objPointer;
+            set { if (SetField(ref _objPointer, value)) OnPropertyChanged(nameof(CanImportObj)); }
+        }
         public uint ConfigPointer { get => _configPointer; set => SetField(ref _configPointer, value); }
 
         /// <summary>
@@ -86,7 +97,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// </summary>
         public uint PaletteAddress { get => _paletteAddress; set => SetField(ref _paletteAddress, value); }
         public uint ObjAddress { get => _objAddress; set => SetField(ref _objAddress, value); }
-        public uint ObjAddress2 { get => _objAddress2; set => SetField(ref _objAddress2, value); }
+        public uint ObjAddress2
+        {
+            get => _objAddress2;
+            set { if (SetField(ref _objAddress2, value)) OnPropertyChanged(nameof(CanImportObj)); }
+        }
         public uint ChipsetConfigAddress { get => _chipsetConfigAddress; set => SetField(ref _chipsetConfigAddress, value); }
         public int PaletteIndex { get => _paletteIndex; set => SetField(ref _paletteIndex, value); }
         public bool IsFogPalette { get => _isFogPalette; set => SetField(ref _isFogPalette, value); }
@@ -104,6 +119,18 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         {
             get => _currentConfigPlist;
             set { _currentConfigPlist = value; OnPropertyChanged(nameof(CurrentConfigPlist)); OnPropertyChanged(nameof(CanEditChipsetConfig)); }
+        }
+
+        /// <summary>
+        /// OBJ Image Import (#710): plist byte for the primary OBJ tileset.
+        /// Derived from the position of the loaded entry inside
+        /// <c>map_obj_pointer</c>. <see cref="CanImportObj"/> rejects
+        /// 0 (reserved sentinel) / >= 0xFF (no-PLIST marker).
+        /// </summary>
+        public uint CurrentObjPlist
+        {
+            get => _currentObjPlist;
+            set { _currentObjPlist = value; OnPropertyChanged(nameof(CurrentObjPlist)); OnPropertyChanged(nameof(CanImportObj)); }
         }
 
         /// <summary>
@@ -137,6 +164,34 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             && _currentConfigPlist != 0
             && _currentConfigPlist != 0xFF
             && _chipsetConfigAddress != 0;
+
+        /// <summary>
+        /// True when the Map Style Editor OBJ Image Import button should
+        /// be enabled (#710 ImageOnly slice):
+        ///   - a ROM is loaded
+        ///   - the entry has a non-zero <see cref="ObjPointer"/> (a tile
+        ///     sheet currently exists at the resolved address)
+        ///   - the resolved OBJ plist is non-zero (sentinel) and below
+        ///     0xFF (no-PLIST marker)
+        ///   - the entry does NOT carry a secondary FE7 obj2 tileset
+        ///     (<see cref="ObjAddress2"/> == 0). The obj2-bearing case
+        ///     requires the dual-tileset split path which is intentionally
+        ///     deferred — TryImportObjImage produces a clear error message
+        ///     when called on such a style so the View can route the
+        ///     user to the follow-up tracking issue.
+        /// </summary>
+        public bool CanImportObj
+        {
+            get
+            {
+                var rom = CoreState.ROM;
+                return rom != null
+                    && _objPointer != 0
+                    && _currentObjPlist > 0
+                    && _currentObjPlist < 0xFF
+                    && _objAddress2 == 0;
+            }
+        }
 
         /// <summary>
         /// Returns a defensive clone of the cached decompressed CONFIG
@@ -343,6 +398,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             uint objTableBase = rom.p32(rom.RomInfo.map_obj_pointer);
             if (U.isSafetyOffset(objTableBase, rom) && addr >= objTableBase)
                 index = (addr - objTableBase) / 4;
+            // OBJ Image Import (#710): the OBJ PLIST byte == the entry
+            // index inside the map_obj_pointer table. CanImportObj rejects
+            // 0 / 0xFF so the sentinel/no-plist slots can't reach the
+            // write path.
+            _currentObjPlist = index;
 
             byte palettePlist = 0;
             byte configPlist = 0;
@@ -476,6 +536,10 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 catch { _cachedConfigData = null; }
             }
             OnPropertyChanged(nameof(CanEditChipsetConfig));
+            // OBJ Image Import (#710): notify the View that the import
+            // surface enablement may have changed (ObjPointer / ObjAddress2
+            // / _currentObjPlist all just got updated).
+            OnPropertyChanged(nameof(CanImportObj));
 
             ConfigNo = $"0x{index:X2}";
             IsLoaded = true;
@@ -492,8 +556,13 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         {
             _cachedConfigData = null;
             _currentConfigPlist = 0;
+            // OBJ Image Import (#710): clear the resolved OBJ PLIST on the
+            // same early-return paths so a previous style's plist can't
+            // leak into a row that fails to load.
+            _currentObjPlist = 0;
             ClearChipsetSlotState();
             OnPropertyChanged(nameof(CanEditChipsetConfig));
+            OnPropertyChanged(nameof(CanImportObj));
         }
 
         /// <summary>
@@ -762,6 +831,187 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             _cachedConfigData = (byte[])newConfigData.Clone();
             ChipsetConfigAddress = newAddr;
             return true;
+        }
+
+        /// <summary>
+        /// OBJ Image Import — ImageOnly slice (#710): remap a source
+        /// RGBA image against the currently-loaded OBJ palette (palette
+        /// row 0), pack it into 4bpp tile data, LZ77-compress, and write
+        /// the result to a free-space slot via the OBJECT PLIST table.
+        /// The OBJ palette in ROM is NOT modified — this slice covers
+        /// only the tile-sheet path.
+        ///
+        /// <para>WinForms parity contract: width MUST be exactly 256
+        /// pixels, height MUST be >= 128, and height MUST be a multiple
+        /// of 8. These bounds mirror the WF
+        /// <c>MapStyleEditorForm.ImportObj</c> validation. The remap
+        /// step uses the existing <c>_cachedPaletteBytes</c> palette
+        /// row 0 (32 bytes) so quantization color drift is avoided —
+        /// see Copilot CLI v1 review item 1 on the v2 plan.</para>
+        ///
+        /// <para>FE7 styles that carry a secondary OBJ tileset
+        /// (<see cref="ObjAddress2"/> != 0) are rejected with an
+        /// actionable error: this slice writes a single tile sheet
+        /// only. Tracked separately as a follow-up.</para>
+        ///
+        /// <para>Requires an ambient undo scope (opened by the view via
+        /// <c>UndoService.Begin</c>) so the LZ77 append + p32 write are
+        /// undoable atomically. On success swaps the cached OBJ tile
+        /// data + <see cref="ObjAddress"/> / <see cref="ObjPointer"/>
+        /// to the new offset so the chip preview reflects the new
+        /// import on the next refresh.</para>
+        ///
+        /// <para>Returns false (without ROM mutation past the ambient
+        /// undo scope's rollback range) when any validation fails;
+        /// <paramref name="error"/> carries a short human-readable
+        /// reason.</para>
+        /// </summary>
+        public bool TryImportObjImage(byte[] sourceRgba, int width, int height, out string error)
+        {
+            error = "";
+
+            // WF parity dimension contract (Copilot CLI v1 review item 2).
+            // Width MUST be 256, height MUST be >= 128 and a multiple of 8.
+            if (width != 256)
+            {
+                error = $"OBJ image must be exactly 256 pixels wide (got {width}).";
+                return false;
+            }
+            if (height < 128)
+            {
+                error = $"OBJ image must be at least 128 pixels tall (got {height}).";
+                return false;
+            }
+            if ((height % 8) != 0)
+            {
+                error = $"OBJ image height must be a multiple of 8 (got {height}).";
+                return false;
+            }
+            if (sourceRgba == null || sourceRgba.Length < width * height * 4)
+            {
+                error = "Invalid source pixel data.";
+                return false;
+            }
+
+            // Reject FE7 obj2-bearing styles before any encoding work.
+            // Distinguish "obj2 present" from "no plist resolved" so the
+            // error message guides the user to the tracking issue rather
+            // than the wrong follow-up.
+            if (_objAddress2 != 0)
+            {
+                error = "OBJ image import does not yet support FE7 styles with a secondary obj2 tileset. Tracked separately.";
+                return false;
+            }
+            if (!CanImportObj)
+            {
+                error = "Cannot import OBJ image — no valid OBJ PLIST is selected.";
+                return false;
+            }
+
+            if (_cachedPaletteBytes == null || _cachedPaletteBytes.Length < 32)
+            {
+                error = "OBJ palette is not loaded.";
+                return false;
+            }
+
+            var rom = CoreState.ROM;
+            if (rom == null) { error = "No ROM loaded."; return false; }
+
+            // Remap pixels against existing palette row 0 (32 bytes / 16
+            // colors). Using the loaded palette avoids re-quantization and
+            // preserves the on-disk palette per the ImageOnly slice
+            // contract (Copilot CLI v1 review item 1).
+            byte[] palette32 = new byte[32];
+            System.Array.Copy(_cachedPaletteBytes, 0, palette32, 0, 32);
+            byte[] indexed;
+            try
+            {
+                indexed = ImageImportCore.RemapToExistingPalette(sourceRgba, width, height, palette32, 16);
+            }
+            catch (System.Exception ex)
+            {
+                error = $"Palette remap failed: {ex.Message}";
+                return false;
+            }
+            if (indexed == null)
+            {
+                error = "Palette remap returned no data (image service unavailable?).";
+                return false;
+            }
+
+            byte[] tileData;
+            try
+            {
+                tileData = ImageImportCore.EncodeDirectTiles4bpp(indexed, width, height);
+            }
+            catch (System.Exception ex)
+            {
+                error = $"Tile encoding failed: {ex.Message}";
+                return false;
+            }
+            if (tileData == null || tileData.Length == 0)
+            {
+                error = "Tile encoding produced no data.";
+                return false;
+            }
+
+            byte[] compressed;
+            try
+            {
+                compressed = LZ77.compress(tileData);
+            }
+            catch (System.Exception ex)
+            {
+                error = $"LZ77 compression failed: {ex.Message}";
+                return false;
+            }
+            if (compressed == null || compressed.Length == 0)
+            {
+                error = "LZ77 compression produced empty output.";
+                return false;
+            }
+
+            uint newAddr = MapChangeCore.WritePlistData(rom, MapChangeCore.PlistType.OBJECT,
+                                                       _currentObjPlist, compressed, out error);
+            if (newAddr == U.NOT_FOUND) return false;
+
+            // Swap in the new cache + address only after the write
+            // succeeded so a failed write leaves preview state untouched.
+            _cachedObjData = tileData;
+            ObjAddress = newAddr;
+            ObjPointer = U.toPointer(newAddr);
+            return true;
+        }
+
+        // -----------------------------------------------------------------
+        // Test seams for #710. These are explicitly internal so unit tests
+        // can stage the in-memory caches that the LoadEntry path normally
+        // populates from ROM — without forcing the test to plant a full
+        // map_setting / map_obj_pointer / map_pal_pointer triple just to
+        // exercise the import write path.
+        // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Internal test seam: stage the cached 16-color OBJ palette
+        /// (32 bytes) so <see cref="TryImportObjImage"/> has palette data
+        /// to remap against without a full LoadEntry / LoadPalette call.
+        /// </summary>
+        internal void SetCachedPaletteBytesForTest(byte[] palette)
+        {
+            if (palette == null) { _cachedPaletteBytes = null; return; }
+            _cachedPaletteBytes = (byte[])palette.Clone();
+        }
+
+        /// <summary>
+        /// Internal test seam: stage the resolved OBJ PLIST byte so
+        /// <see cref="CanImportObj"/> reaches its happy-path branch
+        /// without needing a planted map_setting / map_obj_pointer pair.
+        /// </summary>
+        internal void SetCurrentObjPlistForTest(uint plist)
+        {
+            _currentObjPlist = plist;
+            OnPropertyChanged(nameof(CurrentObjPlist));
+            OnPropertyChanged(nameof(CanImportObj));
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapStyleEditorViewModel.cs
@@ -73,11 +73,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
-        public uint ObjPointer
-        {
-            get => _objPointer;
-            set { if (SetField(ref _objPointer, value)) OnPropertyChanged(nameof(CanImportObj)); }
-        }
+        public uint ObjPointer { get => _objPointer; set => SetField(ref _objPointer, value); }
         public uint ConfigPointer { get => _configPointer; set => SetField(ref _configPointer, value); }
 
         /// <summary>
@@ -169,27 +165,36 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// True when the Map Style Editor OBJ Image Import button should
         /// be enabled (#710 ImageOnly slice):
         ///   - a ROM is loaded
-        ///   - the entry has a non-zero <see cref="ObjPointer"/> (a tile
-        ///     sheet currently exists at the resolved address)
-        ///   - the resolved OBJ plist is non-zero (sentinel) and below
-        ///     0xFF (no-PLIST marker)
+        ///   - the resolved OBJ plist is non-zero (the reserved sentinel)
+        ///   - the plist is below the per-version PLIST limit returned by
+        ///     <see cref="MapChangeCore.GetPlistLimit"/> (Copilot bot #2
+        ///     on PR #716: 0xFF is too loose — FE8U vanilla limit is
+        ///     0xEC so an index of 0xED..0xFE would enable the button
+        ///     but <c>WritePlistData</c> would still reject it).
         ///   - the entry does NOT carry a secondary FE7 obj2 tileset
         ///     (<see cref="ObjAddress2"/> == 0). The obj2-bearing case
         ///     requires the dual-tileset split path which is intentionally
         ///     deferred — TryImportObjImage produces a clear error message
         ///     when called on such a style so the View can route the
         ///     user to the follow-up tracking issue.
+        ///
+        /// <para>Notably <see cref="ObjPointer"/> is NOT gated — a slot
+        /// that's currently null is a valid write target (WF
+        /// <c>InputFormRef.WriteBinaryData</c> + Core
+        /// <c>MapChangeCore.ResolvePlistSlotAddr</c> both treat address 0
+        /// as "append new data"). Copilot bot #1 on PR #716.</para>
         /// </summary>
         public bool CanImportObj
         {
             get
             {
                 var rom = CoreState.ROM;
-                return rom != null
-                    && _objPointer != 0
-                    && _currentObjPlist > 0
-                    && _currentObjPlist < 0xFF
-                    && _objAddress2 == 0;
+                if (rom == null) return false;
+                if (_currentObjPlist == 0) return false;
+                if (_objAddress2 != 0) return false;
+                uint limit = MapChangeCore.GetPlistLimit(rom);
+                if (limit == 0 || _currentObjPlist >= limit) return false;
+                return true;
             }
         }
 
@@ -887,7 +892,17 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 error = $"OBJ image height must be a multiple of 8 (got {height}).";
                 return false;
             }
-            if (sourceRgba == null || sourceRgba.Length < width * height * 4)
+            // Copilot bot #3 on PR #716: width * height * 4 uses int
+            // multiplication and overflows around height ≈ 2.1M. Use long
+            // arithmetic + LongLength to keep the bounds check honest even
+            // for large user inputs.
+            if (sourceRgba == null)
+            {
+                error = "Invalid source pixel data.";
+                return false;
+            }
+            long requiredBytes = (long)width * (long)height * 4L;
+            if (sourceRgba.LongLength < requiredBytes)
             {
                 error = "Invalid source pixel data.";
                 return false;
@@ -904,6 +919,19 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             }
             if (!CanImportObj)
             {
+                // Provide a more specific error when the plist exceeds
+                // the per-version limit so the user knows the data is
+                // technically valid but the slot index is out of range.
+                var rom2 = CoreState.ROM;
+                if (rom2 != null)
+                {
+                    uint limit = MapChangeCore.GetPlistLimit(rom2);
+                    if (limit > 0 && _currentObjPlist >= limit)
+                    {
+                        error = $"OBJ PLIST 0x{_currentObjPlist:X2} is past the per-version limit (0x{limit:X2}).";
+                        return false;
+                    }
+                }
                 error = "Cannot import OBJ image — no valid OBJ PLIST is selected.";
                 return false;
             }

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml
@@ -101,9 +101,9 @@
                       Content="Image Export"
                       Click="ObjExport_Click" />
               <Button AutomationProperties.AutomationId="MapStyleEditor_ObjImport_Button"
+                      Name="ObjImportButton"
                       Content="Image Import"
-                      IsEnabled="False"
-                      ToolTip.Tip="Pending Core extraction - tracked by #710." />
+                      Click="ObjImport_Click" />
               <Button AutomationProperties.AutomationId="MapStyleEditor_MapChipExport_Button"
                       Content="Map Chip Save"
                       Click="MapChipExport_Click" />

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
@@ -1066,14 +1066,137 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         // -----------------------------------------------------------------
+        // #710 — OBJ Image Import (ImageOnly slice): pick image, validate
+        // the WF dimension contract (256 wide × ≥128 tall × multiple-of-8
+        // height), remap against the existing OBJ palette (no palette
+        // change), 4bpp-encode + LZ77 + write via the new OBJECT PLIST
+        // path. FE7 obj2-bearing styles are rejected with an actionable
+        // error (tracked separately for the dual-tileset split path).
+        // -----------------------------------------------------------------
+        async void ObjImport_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (!_vm.CanImportObj)
+                {
+                    if (_vm.ObjAddress2 != 0)
+                    {
+                        CoreState.Services.ShowError(
+                            "OBJ image import does not yet support FE7 styles with a secondary obj2 tileset. Tracked separately.");
+                    }
+                    else
+                    {
+                        CoreState.Services.ShowError("OBJ image import requires a Map Style entry with a valid OBJ PLIST.");
+                    }
+                    return;
+                }
+
+                string? path = await FileDialogHelper.OpenImageFile(this);
+                if (string.IsNullOrEmpty(path)) return;
+
+                // Decode the source image through the shared SkiaSharp
+                // service used by every other Avalonia importer. We pull
+                // RGBA bytes (converting indexed → RGBA when needed) and
+                // hand them to the VM, which owns the remap-against-existing-
+                // palette step. This keeps the View thin (no Core-level
+                // import knowledge) and routes ALL color drift through the
+                // VM's remap path so behavior matches the Copilot CLI v1
+                // review item 1 (no quantize, no palette mutation).
+                byte[] rgba;
+                int w, h;
+                try
+                {
+                    var imgService = CoreState.ImageService;
+                    if (imgService == null)
+                    {
+                        CoreState.Services.ShowError("Image service not initialized.");
+                        return;
+                    }
+                    using var image = imgService.LoadImage(path);
+                    w = image.Width;
+                    h = image.Height;
+                    if (image.IsIndexed)
+                    {
+                        byte[] indexData = image.GetPixelData();
+                        byte[] palRgba = image.GetPaletteRGBA();
+                        rgba = new byte[w * h * 4];
+                        for (int i = 0; i < indexData.Length && i < w * h; i++)
+                        {
+                            int palIdx = indexData[i];
+                            int palOff = palIdx * 4;
+                            if (palOff + 3 < palRgba.Length)
+                            {
+                                rgba[i * 4 + 0] = palRgba[palOff + 0];
+                                rgba[i * 4 + 1] = palRgba[palOff + 1];
+                                rgba[i * 4 + 2] = palRgba[palOff + 2];
+                                rgba[i * 4 + 3] = palRgba[palOff + 3];
+                            }
+                        }
+                    }
+                    else
+                    {
+                        rgba = image.GetPixelData();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Error("MapStyleEditorView.ObjImport_Click decode failed: {0}", ex.Message);
+                    CoreState.Services.ShowError($"Image decode error: {ex.Message}");
+                    return;
+                }
+
+                _undoService.Begin("Import OBJ Image");
+                try
+                {
+                    if (!_vm.TryImportObjImage(rgba, w, h, out string err))
+                    {
+                        _undoService.Rollback();
+                        CoreState.Services.ShowError($"OBJ image import failed: {err}");
+                        return;
+                    }
+                    _undoService.Commit();
+                    _vm.MarkClean();
+                }
+                catch (Exception ex)
+                {
+                    _undoService.Rollback();
+                    Log.Error("MapStyleEditorView.ObjImport_Click write failed: {0}", ex.Message);
+                    CoreState.Services.ShowError($"OBJ image import error: {ex.Message}");
+                    return;
+                }
+
+                // -- Post-commit UI refresh (no rollback path; ROM bytes
+                // are already persisted). Failures here only affect the
+                // visible state, not durability — log + warn but don't roll
+                // back. Mirrors the MapChipImport_Click pattern.
+                try
+                {
+                    ObjAddressLabel.Text = $"0x{_vm.ObjAddress:X08}";
+                    ObjPtrBox.Text = $"0x{_vm.ObjPointer:X08}";
+                    RefreshChipPreview();
+                    CoreState.Services.ShowInfo($"OBJ image imported ({w}x{h}).");
+                }
+                catch (Exception ex)
+                {
+                    Log.Error("MapStyleEditorView.ObjImport_Click UI refresh failed: {0}", ex.Message);
+                    CoreState.Services.ShowError(
+                        $"OBJ image imported but UI refresh failed: {ex.Message}. " +
+                        "Re-select the Map Style entry to refresh the view.");
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("MapStyleEditorView.ObjImport_Click failed: {0}", ex.Message);
+                CoreState.Services.ShowError($"OBJ image import failed: {ex.Message}");
+            }
+        }
+
+        // -----------------------------------------------------------------
         // #704 — MapChip Import: read raw .MAPCHIP_CONFIG bytes (no header,
         // ≥ 9216 bytes per WF parity), persist via the CONFIG PLIST write
         // path. Palette bits in TSA words are preserved verbatim because
         // the buffer is written byte-for-byte (the VM's TryWriteConfigBuffer
         // never decodes TSA words during the write).
-        //
-        // OBJ Image Import remains a KnownGap — tracked by follow-up #710
-        // (needs option-dialog port + 4bpp encoding + FE7 obj2 handling).
         // -----------------------------------------------------------------
         async void MapChipImport_Click(object? sender, RoutedEventArgs e)
         {

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
@@ -1065,6 +1065,54 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
+        /// <summary>
+        /// Convert indexed pixel data + an RGBA palette into a flat RGBA
+        /// buffer of exactly <paramref name="w"/> × <paramref name="h"/>
+        /// pixels. Returns null + a human-readable <paramref name="error"/>
+        /// when any of the four #710 review-#4 guards fire:
+        ///   - <paramref name="indexData"/> is null or shorter than w*h
+        ///   - <paramref name="palRgba"/> is null or too short to hold a
+        ///     single 4-byte color
+        ///   - a pixel references a palette entry whose offset would
+        ///     run past the end of <paramref name="palRgba"/>.
+        ///
+        /// <para>Extracted out of <c>ObjImport_Click</c> so the indexed-
+        /// image decode guards can be exercised by unit tests without
+        /// driving the full file dialog path (Copilot CLI re-review on
+        /// PR #716).</para>
+        /// </summary>
+        internal static byte[]? ConvertIndexedToRgba(byte[]? indexData, byte[]? palRgba, int w, int h, out string error)
+        {
+            error = "";
+            int expected = w * h;
+            if (indexData == null || indexData.Length < expected)
+            {
+                error = $"indexed pixel data is shorter than expected ({indexData?.Length ?? 0} < {expected}).";
+                return null;
+            }
+            if (palRgba == null || palRgba.Length < 4)
+            {
+                error = "indexed image has no usable palette.";
+                return null;
+            }
+            byte[] rgba = new byte[expected * 4];
+            for (int i = 0; i < expected; i++)
+            {
+                int palIdx = indexData[i];
+                int palOff = palIdx * 4;
+                if (palOff + 3 >= palRgba.Length)
+                {
+                    error = $"indexed pixel {i} uses palette entry {palIdx} but palette has only {palRgba.Length / 4} colors.";
+                    return null;
+                }
+                rgba[i * 4 + 0] = palRgba[palOff + 0];
+                rgba[i * 4 + 1] = palRgba[palOff + 1];
+                rgba[i * 4 + 2] = palRgba[palOff + 2];
+                rgba[i * 4 + 3] = palRgba[palOff + 3];
+            }
+            return rgba;
+        }
+
         // -----------------------------------------------------------------
         // #710 — OBJ Image Import (ImageOnly slice): pick image, validate
         // the WF dimension contract (256 wide × ≥128 tall × multiple-of-8
@@ -1123,43 +1171,18 @@ namespace FEBuilderGBA.Avalonia.Views
                         // valid index. Without this, an incomplete decode
                         // silently produces large transparent/black regions
                         // and the user gets a "successful" import full of
-                        // garbage.
+                        // garbage. Logic extracted into ConvertIndexedToRgba
+                        // so it can be unit-tested without driving the full
+                        // dialog path.
                         byte[] indexData = image.GetPixelData();
                         byte[] palRgba = image.GetPaletteRGBA();
-                        int expected = w * h;
-                        if (indexData == null || indexData.Length < expected)
+                        byte[]? decoded = ConvertIndexedToRgba(indexData, palRgba, w, h, out string decErr);
+                        if (decoded == null)
                         {
-                            CoreState.Services.ShowError(
-                                $"Image decode error: indexed pixel data is shorter than expected ({indexData?.Length ?? 0} < {expected}).");
+                            CoreState.Services.ShowError($"Image decode error: {decErr}");
                             return;
                         }
-                        if (palRgba == null || palRgba.Length < 4)
-                        {
-                            CoreState.Services.ShowError(
-                                "Image decode error: indexed image has no usable palette.");
-                            return;
-                        }
-                        rgba = new byte[expected * 4];
-                        for (int i = 0; i < expected; i++)
-                        {
-                            int palIdx = indexData[i];
-                            int palOff = palIdx * 4;
-                            if (palOff + 3 < palRgba.Length)
-                            {
-                                rgba[i * 4 + 0] = palRgba[palOff + 0];
-                                rgba[i * 4 + 1] = palRgba[palOff + 1];
-                                rgba[i * 4 + 2] = palRgba[palOff + 2];
-                                rgba[i * 4 + 3] = palRgba[palOff + 3];
-                            }
-                            else
-                            {
-                                // Out-of-range palette index — fail rather
-                                // than silently pad with transparent.
-                                CoreState.Services.ShowError(
-                                    $"Image decode error: indexed pixel {i} uses palette entry {palIdx} but palette has only {palRgba.Length / 4} colors.");
-                                return;
-                            }
-                        }
+                        rgba = decoded;
                     }
                     else
                     {

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
@@ -50,6 +50,32 @@ namespace FEBuilderGBA.Avalonia.Views
             // CONFIG cache + plist (Copilot bot v2 inline review on PR #691).
             // Set synchronously now so we don't race the first OnSelected.
             SetChipsetEditingEnabled(false);
+
+            // OBJ Image Import button gating (Copilot bot v2 inline review
+            // item 1 on PR #716). Initially disabled; OnSelected refreshes
+            // it once an entry is loaded and the VM resolves a valid
+            // OBJ PLIST + OBJ palette. Listening to CanImportObj's
+            // OnPropertyChanged keeps the button in sync with both the
+            // entry-level reload (ObjAddress2 / _currentObjPlist updates)
+            // and the per-style ObjAddress2 mutation (FE7 dual-tileset).
+            if (ObjImportButton != null) ObjImportButton.IsEnabled = false;
+            _vm.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(_vm.CanImportObj))
+                    RefreshObjImportEnabled();
+            };
+        }
+
+        /// <summary>
+        /// Push the VM's current <see cref="MapStyleEditorViewModel.CanImportObj"/>
+        /// value onto the OBJ Image Import button's <c>IsEnabled</c>.
+        /// Called from <see cref="OnSelected"/> after every entry load and
+        /// from the VM <c>PropertyChanged</c> handler so the button reflects
+        /// the latest predicate state.
+        /// </summary>
+        void RefreshObjImportEnabled()
+        {
+            if (ObjImportButton != null) ObjImportButton.IsEnabled = _vm.CanImportObj;
         }
 
         /// <summary>
@@ -165,6 +191,11 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (chipsetLoaded) ReadSlotsFromVM();
                 else ClearChipsetUI();
                 SetChipsetEditingEnabled(chipsetLoaded);
+                // #710 / Copilot bot v2 item 1: re-evaluate the OBJ Import
+                // button after every entry load so it's disabled on
+                // unsupported entries (FE7 obj2, unresolved plist, ROM-less
+                // state).
+                RefreshObjImportEnabled();
 
                 // Sync the top-bar MapStyleCombo to the same entry without
                 // recursing — block the SelectionChanged handler while we
@@ -1084,10 +1115,34 @@ namespace FEBuilderGBA.Avalonia.Views
         internal static byte[]? ConvertIndexedToRgba(byte[]? indexData, byte[]? palRgba, int w, int h, out string error)
         {
             error = "";
-            int expected = w * h;
-            if (indexData == null || indexData.Length < expected)
+
+            // Negative dimensions are nonsensical and would make every
+            // downstream check unreliable (Copilot bot v2 inline review
+            // on PR #716).
+            if (w < 0 || h < 0)
             {
-                error = $"indexed pixel data is shorter than expected ({indexData?.Length ?? 0} < {expected}).";
+                error = $"negative image dimensions ({w}x{h}).";
+                return null;
+            }
+
+            // Use long arithmetic for the pixel-count + RGBA-buffer size
+            // computations so pathological inputs (e.g. width=256 × height=8M)
+            // can't wrap past int.MaxValue and turn the bounds check into a
+            // false negative (Copilot bot v2 inline review item 2 + 3 on PR
+            // #716). The actual byte[] allocation requires int — bound the
+            // RGBA size to int.MaxValue and fail early when over.
+            long expectedLong = (long)w * (long)h;
+            long rgbaSizeLong = expectedLong * 4L;
+            if (rgbaSizeLong > int.MaxValue)
+            {
+                error = $"image too large to decode (RGBA size {rgbaSizeLong} bytes > int.MaxValue).";
+                return null;
+            }
+            int expected = (int)expectedLong;
+
+            if (indexData == null || indexData.LongLength < expectedLong)
+            {
+                error = $"indexed pixel data is shorter than expected ({indexData?.LongLength ?? 0} < {expectedLong}).";
                 return null;
             }
             if (palRgba == null || palRgba.Length < 4)
@@ -1095,7 +1150,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 error = "indexed image has no usable palette.";
                 return null;
             }
-            byte[] rgba = new byte[expected * 4];
+            byte[] rgba = new byte[(int)rgbaSizeLong];
             for (int i = 0; i < expected; i++)
             {
                 int palIdx = indexData[i];
@@ -1105,10 +1160,11 @@ namespace FEBuilderGBA.Avalonia.Views
                     error = $"indexed pixel {i} uses palette entry {palIdx} but palette has only {palRgba.Length / 4} colors.";
                     return null;
                 }
-                rgba[i * 4 + 0] = palRgba[palOff + 0];
-                rgba[i * 4 + 1] = palRgba[palOff + 1];
-                rgba[i * 4 + 2] = palRgba[palOff + 2];
-                rgba[i * 4 + 3] = palRgba[palOff + 3];
+                int dstOff = i * 4;
+                rgba[dstOff + 0] = palRgba[palOff + 0];
+                rgba[dstOff + 1] = palRgba[palOff + 1];
+                rgba[dstOff + 2] = palRgba[palOff + 2];
+                rgba[dstOff + 3] = palRgba[palOff + 3];
             }
             return rgba;
         }

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
@@ -1117,10 +1117,30 @@ namespace FEBuilderGBA.Avalonia.Views
                     h = image.Height;
                     if (image.IsIndexed)
                     {
+                        // Copilot bot #4 on PR #716: fail early when the
+                        // indexed-image source can't fully cover w*h pixels
+                        // or its palette is too short to dereference any
+                        // valid index. Without this, an incomplete decode
+                        // silently produces large transparent/black regions
+                        // and the user gets a "successful" import full of
+                        // garbage.
                         byte[] indexData = image.GetPixelData();
                         byte[] palRgba = image.GetPaletteRGBA();
-                        rgba = new byte[w * h * 4];
-                        for (int i = 0; i < indexData.Length && i < w * h; i++)
+                        int expected = w * h;
+                        if (indexData == null || indexData.Length < expected)
+                        {
+                            CoreState.Services.ShowError(
+                                $"Image decode error: indexed pixel data is shorter than expected ({indexData?.Length ?? 0} < {expected}).");
+                            return;
+                        }
+                        if (palRgba == null || palRgba.Length < 4)
+                        {
+                            CoreState.Services.ShowError(
+                                "Image decode error: indexed image has no usable palette.");
+                            return;
+                        }
+                        rgba = new byte[expected * 4];
+                        for (int i = 0; i < expected; i++)
                         {
                             int palIdx = indexData[i];
                             int palOff = palIdx * 4;
@@ -1130,6 +1150,14 @@ namespace FEBuilderGBA.Avalonia.Views
                                 rgba[i * 4 + 1] = palRgba[palOff + 1];
                                 rgba[i * 4 + 2] = palRgba[palOff + 2];
                                 rgba[i * 4 + 3] = palRgba[palOff + 3];
+                            }
+                            else
+                            {
+                                // Out-of-range palette index — fail rather
+                                // than silently pad with transparent.
+                                CoreState.Services.ShowError(
+                                    $"Image decode error: indexed pixel {i} uses palette entry {palIdx} but palette has only {palRgba.Length / 4} colors.");
+                                return;
                             }
                         }
                     }

--- a/FEBuilderGBA.Core.Tests/MapChangeCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/MapChangeCoreTests.cs
@@ -421,7 +421,7 @@ namespace FEBuilderGBA.Core.Tests
         /// #710: ResolvePlistSlotAddr accepts <see cref="MapChangeCore.PlistType.OBJECT"/>
         /// and returns the per-entry slot inside the <c>map_obj_pointer</c>
         /// table even when that slot currently holds a null pointer
-        /// (matches WF Write_Plsit's semantics: the dereferenced target
+        /// (matches WF Write_Plsit semantics: the dereferenced target
         /// is not inspected — only the slot's own address matters).
         /// </summary>
         [Fact]

--- a/FEBuilderGBA.Core.Tests/MapChangeCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/MapChangeCoreTests.cs
@@ -414,6 +414,74 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         // -------------------------------------------------------------
+        // OBJECT PlistType — #710 OBJ Image Import slice.
+        // -------------------------------------------------------------
+
+        /// <summary>
+        /// #710: ResolvePlistSlotAddr accepts <see cref="MapChangeCore.PlistType.OBJECT"/>
+        /// and returns the per-entry slot inside the <c>map_obj_pointer</c>
+        /// table even when that slot currently holds a null pointer
+        /// (matches WF Write_Plsit's semantics: the dereferenced target
+        /// is not inspected — only the slot's own address matters).
+        /// </summary>
+        [Fact]
+        public void ResolvePlistSlotAddr_OBJECT_AllowsNullSlot()
+        {
+            var rom = MakeFe8uRom();
+            uint objTableAddr = 0x00890000u;
+            WriteU32(rom.Data, (int)rom.RomInfo.map_obj_pointer, objTableAddr | 0x08000000u);
+            // Slot 5 is null — must still resolve to the slot's address.
+            WriteU32(rom.Data, (int)(objTableAddr + 5 * 4u), 0u);
+
+            uint slot = MapChangeCore.ResolvePlistSlotAddr(rom, MapChangeCore.PlistType.OBJECT, 5);
+            Assert.Equal(objTableAddr + 5 * 4u, slot);
+        }
+
+        /// <summary>
+        /// #710: round-trip a compressed OBJ tile sheet through
+        /// WritePlistData(OBJECT, ...) — assert the OBJECT PLIST slot
+        /// now points at the new offset and the new offset contains
+        /// the appended bytes.
+        /// </summary>
+        [Fact]
+        public void WritePlistData_OBJECT_UpdatesPointerAndAppendsCompressed()
+        {
+            var rom = MakeFe8uRom();
+            uint objTableAddr = 0x00890000u;
+            WriteU32(rom.Data, (int)rom.RomInfo.map_obj_pointer, objTableAddr | 0x08000000u);
+
+            byte[] payload = { 0x10, 0x80, 0x00, 0x00, 0xDE, 0xAD, 0xBE, 0xEF };
+            uint addr = MapChangeCore.WritePlistData(
+                rom, MapChangeCore.PlistType.OBJECT, 5, payload, out string err);
+            Assert.NotEqual(U.NOT_FOUND, addr);
+            Assert.Equal("", err);
+            // Slot now points at the new offset.
+            uint slot = objTableAddr + 5 * 4u;
+            Assert.Equal(addr, rom.p32(slot));
+            // Bytes were written at the new offset.
+            for (int i = 0; i < payload.Length; i++)
+                Assert.Equal(payload[i], rom.Data[addr + i]);
+        }
+
+        /// <summary>
+        /// #710 rejection symmetry with the CONFIG path: WritePlistData
+        /// for OBJECT must refuse PLIST 0 (the reserved sentinel slot).
+        /// </summary>
+        [Fact]
+        public void WritePlistData_OBJECT_FailsOn_PlistZero()
+        {
+            var rom = MakeFe8uRom();
+            uint objTableAddr = 0x00100000u;
+            WriteU32(rom.Data, (int)rom.RomInfo.map_obj_pointer, objTableAddr | 0x08000000u);
+
+            byte[] payload = { 0x10, 0x00, 0x00, 0x00 };
+            uint addr = MapChangeCore.WritePlistData(
+                rom, MapChangeCore.PlistType.OBJECT, 0, payload, out string err);
+            Assert.Equal(U.NOT_FOUND, addr);
+            Assert.NotEqual("", err);
+        }
+
+        // -------------------------------------------------------------
         // Helpers.
         // -------------------------------------------------------------
 

--- a/FEBuilderGBA.Core/MapChangeCore.cs
+++ b/FEBuilderGBA.Core/MapChangeCore.cs
@@ -20,13 +20,20 @@ namespace FEBuilderGBA
         /// <summary>
         /// Core-local equivalent of <c>MapPointerForm.PLIST_TYPE</c>.
         /// Only the values needed by Core helpers are surfaced; the
-        /// WinForms enum has additional types (ANIMATION, OBJECT, etc.)
-        /// that are not yet exposed to Core.
+        /// WinForms enum has additional types (ANIMATION, etc.) that
+        /// are not yet exposed to Core.
         /// </summary>
         public enum PlistType
         {
             CHANGE,
             CONFIG,
+            /// <summary>
+            /// OBJ tileset PLIST table (<c>map_obj_pointer</c>). Used by
+            /// the Map Style Editor OBJ Image Import path (#710) to
+            /// rewrite the per-style OBJ tileset slot with a newly
+            /// LZ77-compressed 4bpp tile sheet.
+            /// </summary>
+            OBJECT,
         }
 
         /// <summary>
@@ -149,6 +156,7 @@ namespace FEBuilderGBA
             {
                 PlistType.CHANGE => rom.RomInfo.map_mapchange_pointer,
                 PlistType.CONFIG => rom.RomInfo.map_config_pointer,
+                PlistType.OBJECT => rom.RomInfo.map_obj_pointer,
                 _ => 0u,
             };
         }


### PR DESCRIPTION
## Summary

Implements the ImageOnly slice of the Map Style Editor's OBJ Image Import path (issue #710). Adds `MapChangeCore.PlistType.OBJECT`, a `TryImportObjImage` method on `MapStyleEditorViewModel`, and the `ObjImport_Click` handler. FE7 styles with a secondary obj2 tileset are rejected with an actionable error pointing at the follow-up tracking the dual-tileset split.

Key implementation notes (addressing Copilot CLI v1 review of plan v2):
1. Source pixels remapped against the existing OBJ palette (palette row 0, 32 bytes) via `ImageImportCore.RemapToExistingPalette` — the on-disk ROM palette is NOT modified, avoiding the re-quantization color drift the v1 review flagged.
2. WF parity dimension contract enforced: width MUST be 256, height MUST be ≥ 128 and a multiple of 8.

Closes #710.

## Test plan

- [x] `dotnet test FEBuilderGBA.Core.Tests` — 1967 passed (includes 3 new MapChangeCore OBJECT cases).
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` — 6861 passed, 3 pre-existing skips (includes 10 new MapStyleEditorViewModelObjImportTests cases + 2 new parity tests).
- [x] Build: `dotnet build FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj -c Release` — succeeded.
- [x] Avalonia launched against `roms/FE8U.gba`; UIAutomation confirmed `MapStyleEditor_ObjImport_Button.IsEnabled == True` on Map Style 0x01 Tileset.
- [x] Screenshot captured via PrintWindow against the live Map Style Editor window (not fabricated, not the generic main window).

## GUI Test Report

| # | Test case | Result | Evidence |
|---|---|---|---|
| 1 | App launches with `roms/FE8U.gba` | PASS | UIAutomation found window "FEBuilderGBA - FE8U.gba" |
| 2 | Map Style Editor opens via main-menu Style Editor button | PASS | UIAutomation: `Map Style Editor opened: Map Style Editor` |
| 3 | OBJ Image Import button is enabled on a vanilla FE8U style (0x01 Tileset) | PASS | UIAutomation: `OBJ Image Import: enabled=True name=Image Import` |
| 4 | OBJ Image Import button stays wired to ObjImport_Click | PASS | View_ObjImport_Click_HandlerWired parity test passes |
| 5 | TryImportObjImage rejects width != 256 | PASS | TryImportObjImage_RejectsWrongWidth |
| 6 | TryImportObjImage rejects height < 128 | PASS | TryImportObjImage_RejectsShortHeight |
| 7 | TryImportObjImage rejects height not multiple of 8 | PASS | TryImportObjImage_RejectsHeightNotMultipleOf8 |
| 8 | TryImportObjImage rejects FE7 obj2 styles with actionable message | PASS | TryImportObjImage_RejectsObj2Style |
| 9 | TryImportObjImage rejects plist 0 / 0xFF sentinels | PASS | RejectsZeroPlist + RejectsPlistFF |
| 10 | TryImportObjImage requires palette cache loaded | PASS | RequiresPaletteLoaded |
| 11 | Happy-path: writes LZ77 tile data + updates OBJECT PLIST slot | PASS | TryImportObjImage_FE8U_WritesTilesAndPointer (rom.Data[newOffset]==0x10 LZ77 magic) |
| 12 | Remap uses existing palette — no quantization | PASS | TryImportObjImage_RemapsAgainstExistingPalette |
| 13 | Import is undoable via ambient undo scope | PASS | TryImportObjImage_UndoableRestoresOriginalPointer |

## Screenshots

![Map Style Editor OBJ Image Import](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/pr710-map-style-obj-import.png?raw=1)

The screenshot shows the Map Style Editor with Map Style 0x01 Tileset selected (FE8U), Object Address 2 = (none) so `CanImportObj` is satisfied, and the **Image Import** button now enabled in the button strip (was `IsEnabled="False"` before #710). Captured via PrintWindow against the live Avalonia editor window (1216×819).

Generated with Claude Code (claude-opus-4-7-1m)