### PR TITLE
fix(avalonia): Portrait Import Wizard list shows portrait owners (#656)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ImagePortraitImporterViewModelLoadListTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImagePortraitImporterViewModelLoadListTests.cs
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Regression tests for issue #656 (round 2): Portrait Import Wizard left
+// list shows incorrect unit names. Root cause: ImagePortraitImporterViewModel
+// .LoadList called NameResolver.GetUnitName((uint)i) where i is the PORTRAIT
+// INDEX, not a unit-table row. The fix replaces it with
+// NameResolver.GetPortraitName((uint)i) which scans the unit/class tables
+// for an entry whose portrait field matches i (mirroring the editor fix
+// from #654/#673 and WinForms ImagePortraitForm.GetPortraitNameFast).
+//
+// These tests are DIFFERENTIAL: they compare what NameResolver.GetUnitName(i)
+// (old buggy path) would have produced versus NameResolver.GetPortraitName(i)
+// (new fixed path) for indices where the two resolvers disagree. The
+// assertions pin the wizard label to the NEW value and explicitly reject the
+// OLD value. Running these tests against the pre-fix code MUST fail; running
+// against the post-fix code MUST pass.
+//
+// Mirrors ImagePortraitViewModelLoadListTests for parity, plus a parity test
+// that pins importer labels to the main editor labels so the two list views
+// cannot drift again.
+using System.Collections.Generic;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class ImagePortraitImporterViewModelLoadListTests : IClassFixture<RomFixture>
+    {
+        private readonly RomFixture _fixture;
+        private readonly ITestOutputHelper _output;
+
+        public ImagePortraitImporterViewModelLoadListTests(RomFixture fixture, ITestOutputHelper output)
+        {
+            _fixture = fixture;
+            _output = output;
+        }
+
+        /// <summary>
+        /// Differential regression test for #656 (round 2).
+        ///
+        /// On FE8U:
+        ///   - Portrait index 1 is owned by Eirika (unit-table row 0).
+        ///   - Unit-table row 1 (0-based) is Ephraim.
+        /// Therefore:
+        ///   - OLD buggy wizard: GetUnitName(1) returned Ephraim's name → label
+        ///     "0x01 Ephraim".
+        ///   - NEW fixed wizard: GetPortraitName(1) reverse-scans for the unit/
+        ///     class whose portrait field == 1 → returns Eirika's name → label
+        ///     "0x01 Eirika".
+        ///
+        /// The test scans the FE8U list, finds a portrait index where the two
+        /// resolvers disagree, and asserts the wizard label contains the NEW
+        /// value and does NOT contain the OLD value.
+        /// </summary>
+        [Fact]
+        public void LoadList_FE8U_LabelUsesPortraitOwnerNotZeroBasedUnitTable()
+        {
+            if (!_fixture.IsAvailable || _fixture.Version != "FE8U")
+            {
+                _output.WriteLine($"SKIP: FE8U.gba unavailable (have {_fixture.Version})");
+                return;
+            }
+
+            var vm = new ImagePortraitImporterViewModel();
+            List<AddrResult> list = vm.LoadList();
+            Assert.NotEmpty(list);
+
+            // Find a portrait index where the OLD buggy resolver (GetUnitName(i),
+            // i.e. unit-table[i] 0-based) returns something different from the
+            // NEW correct resolver (GetPortraitName(i), reverse-scan).
+            int differentialIndex = -1;
+            string newName = null!;
+            string oldName = null!;
+            for (int i = 1; i < list.Count && i < 64; i++)
+            {
+                string n = FEBuilderGBA.NameResolver.GetPortraitName((uint)i);
+                string o = FEBuilderGBA.NameResolver.GetUnitName((uint)i);
+
+                // Skip indices where the OLD resolver returned a no-op ("???" / "#i")
+                // because the old code already filtered those out before appending —
+                // those indices do not produce differential labels.
+                if (string.IsNullOrEmpty(n)) continue;
+                if (o == "???" || o == $"#{i}") continue;
+                if (n == o) continue;
+
+                differentialIndex = i;
+                newName = n;
+                oldName = o;
+                break;
+            }
+
+            Assert.True(differentialIndex >= 0,
+                "expected at least one portrait index where GetPortraitName and " +
+                "GetUnitName disagree on FE8U (e.g. portrait 1 = Eirika vs " +
+                "unit-table[1] = Ephraim) — without such an index this test " +
+                "cannot distinguish old vs new behavior");
+
+            string label = list[differentialIndex].name;
+            _output.WriteLine($"differentialIndex={differentialIndex} label='{label}' " +
+                $"newName='{newName}' oldName='{oldName}'");
+
+            Assert.StartsWith($"0x{differentialIndex:X2}", label);
+
+            // The fix's contract: label MUST contain the portrait OWNER's name
+            // (GetPortraitName), not the 0-based unit-table row's name (GetUnitName).
+            Assert.Contains(newName, label);
+            Assert.DoesNotContain(oldName, label);
+        }
+
+        /// <summary>
+        /// Differential regression test (#656 round 2) — sweep all list entries
+        /// and verify that for every index where GetPortraitName and GetUnitName
+        /// disagree, the rendered wizard label uses the GetPortraitName value
+        /// (new behavior) and NEVER the GetUnitName value (old buggy behavior).
+        ///
+        /// This is the broad version of the targeted test above: it pins the fix
+        /// across ALL differential indices, not just one. Running this against
+        /// the pre-fix code fails because labels would contain GetUnitName values.
+        /// </summary>
+        [Fact]
+        public void LoadList_AllDifferentialIndices_UsePortraitNameNotUnitName()
+        {
+            if (!_fixture.IsAvailable)
+            {
+                _output.WriteLine("SKIP: no ROM available");
+                return;
+            }
+
+            var vm = new ImagePortraitImporterViewModel();
+            List<AddrResult> list = vm.LoadList();
+            Assert.NotEmpty(list);
+
+            int differentialChecks = 0;
+            for (int i = 0; i < list.Count; i++)
+            {
+                string portraitName = FEBuilderGBA.NameResolver.GetPortraitName((uint)i);
+                string unitName = FEBuilderGBA.NameResolver.GetUnitName((uint)i);
+
+                if (string.IsNullOrEmpty(portraitName)) continue;
+                if (unitName == "???" || unitName == $"#{i}") continue;
+                if (portraitName == unitName) continue;
+
+                // Both resolvers return a usable name AND they differ → this
+                // index is differential. The fixed label MUST use portraitName.
+                differentialChecks++;
+                string label = list[i].name;
+                Assert.Contains(portraitName, label);
+                Assert.DoesNotContain(unitName, label);
+            }
+
+            _output.WriteLine($"differentialChecks={differentialChecks} " +
+                $"(ROM={_fixture.Version}, listCount={list.Count})");
+            Assert.True(differentialChecks > 0,
+                "expected at least one portrait index where GetPortraitName and " +
+                "GetUnitName disagree — without any differential indices this " +
+                "test would silently pass on both old and new behavior");
+        }
+
+        /// <summary>
+        /// Parity regression test (#656 round 2) — the wizard's left list must
+        /// show the SAME labels as the main Portrait Image Editor's left list
+        /// for every entry. Both view-models enumerate the same portrait_pointer
+        /// table with the same datasize, so any drift between them (like the
+        /// pre-fix wizard calling GetUnitName instead of GetPortraitName) means
+        /// users see different names in two views of the same data.
+        ///
+        /// Pins the importer to the editor permanently — if a future change
+        /// regresses one but not the other, this test catches it immediately.
+        /// </summary>
+        [Fact]
+        public void LoadList_MatchesMainEditor()
+        {
+            if (!_fixture.IsAvailable)
+            {
+                _output.WriteLine("SKIP: no ROM available");
+                return;
+            }
+
+            var importerVm = new ImagePortraitImporterViewModel();
+            var editorVm = new ImagePortraitViewModel();
+
+            List<AddrResult> importerList = importerVm.LoadList();
+            List<AddrResult> editorList = editorVm.LoadList();
+
+            Assert.NotEmpty(importerList);
+            Assert.NotEmpty(editorList);
+            Assert.Equal(editorList.Count, importerList.Count);
+
+            for (int i = 0; i < importerList.Count; i++)
+            {
+                Assert.Equal(editorList[i].addr, importerList[i].addr);
+                Assert.Equal(editorList[i].name, importerList[i].name);
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/ImagePortraitImporterViewModelLoadListTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImagePortraitImporterViewModelLoadListTests.cs
@@ -39,19 +39,21 @@ namespace FEBuilderGBA.Avalonia.Tests
         /// <summary>
         /// Differential regression test for #656 (round 2).
         ///
-        /// On FE8U:
-        ///   - Portrait index 1 is owned by Eirika (unit-table row 0).
-        ///   - Unit-table row 1 (0-based) is Ephraim.
+        /// On FE8U (verified empirically from the wizard's rendered list):
+        ///   - Portrait index 1 is owned by Queen (class-table entry whose
+        ///     portrait field == 1).
+        ///   - Unit-table row 1 (0-based) is Seth.
         /// Therefore:
-        ///   - OLD buggy wizard: GetUnitName(1) returned Ephraim's name → label
-        ///     "0x01 Ephraim".
+        ///   - OLD buggy wizard: GetUnitName(1) returned Seth's name → label
+        ///     "0x01 Seth".
         ///   - NEW fixed wizard: GetPortraitName(1) reverse-scans for the unit/
-        ///     class whose portrait field == 1 → returns Eirika's name → label
-        ///     "0x01 Eirika".
+        ///     class whose portrait field == 1 → returns Queen's name → label
+        ///     "0x01 Queen".
         ///
         /// The test scans the FE8U list, finds a portrait index where the two
-        /// resolvers disagree, and asserts the wizard label contains the NEW
-        /// value and does NOT contain the OLD value.
+        /// resolvers disagree (the differential index is discovered dynamically
+        /// rather than hardcoded), and asserts the wizard label contains the
+        /// NEW value and does NOT contain the OLD value.
         /// </summary>
         [Fact]
         public void LoadList_FE8U_LabelUsesPortraitOwnerNotZeroBasedUnitTable()
@@ -92,8 +94,8 @@ namespace FEBuilderGBA.Avalonia.Tests
 
             Assert.True(differentialIndex >= 0,
                 "expected at least one portrait index where GetPortraitName and " +
-                "GetUnitName disagree on FE8U (e.g. portrait 1 = Eirika vs " +
-                "unit-table[1] = Ephraim) — without such an index this test " +
+                "GetUnitName disagree on FE8U (e.g. portrait 1 = Queen vs " +
+                "unit-table[1] = Seth) — without such an index this test " +
                 "cannot distinguish old vs new behavior");
 
             string label = list[differentialIndex].name;

--- a/FEBuilderGBA.Avalonia/ViewModels/ImagePortraitImporterViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImagePortraitImporterViewModel.cs
@@ -60,14 +60,19 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 else nullCount = 0;
 
                 string name = $"0x{i:X2}";
+                // #656 — resolve the portrait OWNER's name (scans unit/class tables
+                // for a unit/class with portrait_id == i) instead of treating the
+                // portrait index as a 0-based unit-table row. Mirrors the editor
+                // fix at ImagePortraitViewModel.LoadList (#654/#673) and the
+                // WinForms reference ImagePortraitForm.GetPortraitNameFast.
                 try
                 {
-                    string uname = NameResolver.GetUnitName((uint)i);
-                    if (uname != "???" && uname != $"#{i}") name += $" {uname}";
+                    string pname = NameResolver.GetPortraitName((uint)i);
+                    if (!string.IsNullOrEmpty(pname)) name += $" {pname}";
                 }
                 catch (System.Exception ex)
                 {
-                    Log.Error("ImagePortraitImporterViewModel.LoadList unit name resolve: {0}", ex.Message);
+                    Log.Error("ImagePortraitImporterViewModel.LoadList portrait name resolve: {0}", ex.Message);
                 }
                 result.Add(new AddrResult(addr, name, (uint)i));
             }


### PR DESCRIPTION
## Summary

- Portrait Import Wizard's left list was calling `NameResolver.GetUnitName((uint)i)` where `i` is the portrait slot index. That treats `i` as a 0-based unit-table row, so the names shown were the units sitting at rows 0..N — completely unrelated to the portrait at slot `i`.
- Switched to `NameResolver.GetPortraitName((uint)i)`, which scans the unit table for an entry whose `+6` portrait field equals `i` (with class-table fallback on `+8`). Mirrors the editor fix from #654/#673 and the WinForms reference `ImagePortraitForm.GetPortraitNameFast`.
- Also switched the guard from the unit-resolver sentinels (`"???"` / `"#i"`) to `!string.IsNullOrEmpty(pname)`, matching `GetPortraitName`'s "no owner" return contract.

### Root cause

`FEBuilderGBA.Avalonia/ViewModels/ImagePortraitImporterViewModel.cs:65` used `GetUnitName`, so on FE8U the wizard showed `0x00 Eirika, 0x01 Seth, 0x02 Gilliam, 0x03 Franz, 0x04 Moulder, …` (unit-table rows). The bug screenshot the user attached on round 2 of #656 matches that exact sequence. The main Portrait Image Editor view-model was already fixed under #654/#673; only the wizard remained buggy.

### Editor-side investigation

`NameResolver.ResolvePortraitName` was checked against the WinForms reference chain (`ImagePortraitForm.GetPortraitNameFast` -> `UnitForm.GetUnitNameWhereFaceID` -> `ClassForm.GetClassNameWhereFaceID`). Behavior matches:

| Aspect | WinForms | Core `ResolvePortraitName` | Verdict |
|---|---|---|---|
| Unit-table scan bound | `InputFormRef.DataCount` (= `i < unit_maxcount`) | `unit_maxcount`, fallback 0x100 | Equivalent. |
| Class-table scan bound | `DataCount`, stops at `u8(addr+4)==0` | 0x100 cap, breaks on safety-offset overrun | Equivalent in practice. |
| Unit/class match field | `u16(addr+6)` / `u16(addr+8)` | same | Same. |
| FE6 dummy row skip | `ifr.ReInit(base + datasize)` | row 0 visited but `textId==0` early-out | Functionally equivalent. |
| Per-row comment append | `InputFormRef.GetCommentSA(addr)` | not appended | Cosmetic only; out of scope. |

No editor-side change needed.

## Screenshots

After fix:

**Portrait Import Wizard (FE8U) — now shows portrait owners:**

![wizard fix](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/pr732-portrait-wizard-fix656.png?raw=1)

**Portrait Image Editor (FE8U) — identical labels to the wizard (parity):**

![editor parity](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/pr732-portrait-editor-fix656.png?raw=1)

Both views now show `0x00 Enemy, 0x01 Queen, 0x02 Eirika, 0x03 Fire, 0x04 Seth, 0x05 Gilliam, 0x06 Franz, 0x07 Moulder, 0x08 Vanessa, 0x09 Ross, 0x0A Neimi, …`. Compare to the bug screenshot on #656 which showed `0x00 Eirika, 0x01 Seth, 0x02 Gilliam, …` in the wizard.

Screenshots are landed on `master` via #736 to ensure the URLs remain valid after this branch is deleted.

## GUI Test Report

| Environment |  |
|---|---|
| OS | Windows 11 Enterprise 10.0.22631 |
| .NET | net9.0 Release x64 |
| ROM | `roms/FE8U.gba` (16 MB, header BE8E01) |
| App | FEBuilderGBA.Avalonia, Release build, post-fix code |
| Capture | UIAutomation invoke + tools/WinCapture PrintWindow |

| Step | Action | Expected | Result |
|---|---|---|---|
| 1 | Launch app with `--rom roms/FE8U.gba` | Main window shows "FEBuilderGBA - FE8U.gba" | PASS |
| 2 | Invoke "Portrait Import" button (`Main_PortraitImport_Button`) | Wizard window opens | PASS |
| 3 | Inspect left list rows 0x00..0x0A | Shows portrait owners (Enemy, Queen, Eirika, Fire, Seth, Gilliam, Franz, Moulder, Vanessa, Ross, Neimi) | PASS |
| 4 | Invoke "Portrait Editor" button (`Main_PortraitEditor_Button`) | Editor window opens | PASS |
| 5 | Inspect left list rows 0x00..0x0A | Identical labels to wizard (parity) | PASS |

## Test plan

- [x] Build `FEBuilderGBA.Avalonia.csproj` Release with the fix applied (no errors)
- [x] Build `FEBuilderGBA.Avalonia.Tests.csproj` Release with new test file (no errors)
- [x] Run new tests on POST-fix code: all 3 pass (`ROMS_DIR=…/roms`)
  - `LoadList_FE8U_LabelUsesPortraitOwnerNotZeroBasedUnitTable`
  - `LoadList_AllDifferentialIndices_UsePortraitNameNotUnitName`
  - `LoadList_MatchesMainEditor`
- [x] Run new tests on PRE-fix code (stash + rebuild Avalonia.dll, no-incremental): all 3 fail with the expected differential assertion error (`Assert.Contains: "0x01 Seth" / "Queen" not found`) — proves the tests are genuine regression catchers
- [x] Run existing `ImagePortraitViewModelLoadListTests` (2 tests) — still pass
- [x] Run Core `NameResolverTests` and Portrait-named Core tests (95 tests) — all pass
- [x] Run full `FullyQualifiedName~Portrait` sweep — 5 pre-existing flaky failures (`PortraitImportHelperBatchTests.ImportFolderAsync_*`, `PreviewIconHelperPortraitPairTests.*`, `ClassEditorClassCardTests.ClassWithPortrait_PopulatesCardPortrait_FE8U`); identical pass/fail count on master, so zero regressions introduced
- [x] Functional GUI test on FE8U.gba — wizard list shows portrait OWNERS not unit-table rows (screenshot above)
- [x] Functional GUI parity check — wizard list matches Portrait Image Editor list (screenshot above)

## Scope

Closes #656
Depends on #736 (screenshot landing branch on master)

---

User prompt: Fix GitHub issue #656 in laqieer/FEBuilderGBA — "Avalonia GUI: Portrait Image Editor shows incorrect unit name in the list". The wizard still calls GetUnitName instead of GetPortraitName; investigate whether the editor still needs further changes vs the WinForms reference; add unit tests under FEBuilderGBA.Avalonia.Tests; land screenshot on master via docs PR first; full Copilot CLI plan + PR review loop.

Generated with Claude Code (claude-opus-4-7-1m)