### PR TITLE
feat(avalonia): unify editor top-bar across 8 more editors (#743)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/EditorTopBarMigrationSweepTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EditorTopBarMigrationSweepTests.cs
@@ -87,6 +87,15 @@ public class EditorTopBarMigrationSweepTests
         "SongInstrumentView.axaml",
         "AIScriptView.axaml",
         "SMEPromoListView.axaml",
+        // Slice C migrations (#743):
+        "SkillConfigSkillSystemView.axaml",
+        "SkillConfigFE8NVer2SkillView.axaml",
+        "SkillConfigFE8NVer3SkillView.axaml",
+        "SkillConfigFE8UCSkillSys09xView.axaml",
+        "SkillAssignmentClassSkillSystemView.axaml",
+        "SkillAssignmentClassCSkillSysView.axaml",
+        "WorldMapEventPointerView.axaml",
+        "MonsterItemViewerView.axaml",
     };
 
     public static TheoryData<string> ReadOnlyMigratedViews => ToTheoryData(s_readOnlyMigratedViews);
@@ -212,9 +221,14 @@ public class EditorTopBarMigrationSweepTests
     public void MigratedView_HasTopBarAutomationId(string viewName)
     {
         // Every host sets a "..._TopBar" automation id on the unified
-        // control (mirrors UnitEditorView et al.).
+        // control (mirrors UnitEditorView et al.). Multi-bar hosts use
+        // composite ids like "MonsterItemViewer_Item_TopBar" or
+        // "WorldMapEventPointer_BeforeTopBar" (#743), so the prefix
+        // allows underscores. The trailing "_TopBar" stays required so
+        // the assertion can't false-positive on the inner-control ids
+        // (e.g. "..._Reload_Button").
         string axaml = ReadView(viewName);
-        Assert.Matches(new Regex("AutomationProperties\\.AutomationId=\"[A-Za-z0-9]+_TopBar\""),
+        Assert.Matches(new Regex("AutomationProperties\\.AutomationId=\"[A-Za-z0-9_]+_TopBar\""),
             axaml);
     }
 
@@ -261,15 +275,23 @@ public class EditorTopBarMigrationSweepTests
     [Fact]
     public void KnownDeferredEditor_NotInMigratedList()
     {
-        // SkillConfigSkillSystemView is explicitly deferred to Slice C
-        // (patch-detection coupling). It must NOT be claimed as migrated
-        // — if someone accidentally adds it to the AllMigratedViews list
-        // without doing the actual migration, this test catches it.
+        // After Slice C (#743) two formerly-deferred editors moved to the
+        // migrated list (SkillConfigSkillSystemView, MonsterItemViewerView).
+        // The genuinely-deferred remainder must NOT be claimed as migrated
+        // — if someone accidentally adds one of them to the
+        // AllMigratedViews list without doing the actual migration, this
+        // test catches it. ImageUnitPaletteView (2-column Grid topology)
+        // and SkillConfigFE8NSkillView (FilterCombo + ChangeType in the
+        // top bar) stay deferred until a per-editor decision lands; the
+        // Event* / MapTileAnimation2 cluster is tracked separately.
         foreach (string name in AllMigratedViewNames())
         {
-            Assert.NotEqual("SkillConfigSkillSystemView.axaml", name);
-            Assert.NotEqual("MonsterItemViewerView.axaml", name);
             Assert.NotEqual("ImageUnitPaletteView.axaml", name);
+            Assert.NotEqual("SkillConfigFE8NSkillView.axaml", name);
+            Assert.NotEqual("EventCondView.axaml", name);
+            Assert.NotEqual("EventUnitView.axaml", name);
+            Assert.NotEqual("EventUnitFE7View.axaml", name);
+            Assert.NotEqual("MapTileAnimation2View.axaml", name);
         }
     }
 

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillAssignmentClassCSkillSysParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillAssignmentClassCSkillSysParityTests.cs
@@ -38,11 +38,15 @@ public class SkillAssignmentClassCSkillSysParityTests
     }
 
     [Fact] public void View_HasFilterAndReloadBar() {
+        // #743: top bar migrated to EditorTopBarWithInputs — legacy
+        // AutomationIds are preserved via the *AutomationId overrides on
+        // the unified bar, and the Reload click is wired via the
+        // ReloadRequested routed event (not a direct Click= on a Button).
         string axaml = ReadAxaml();
         Assert.Contains("AutomationId=\"SkillAssignmentClassCSkillSys_ReadStart_Input\"", axaml);
         Assert.Contains("AutomationId=\"SkillAssignmentClassCSkillSys_ReadCount_Input\"", axaml);
         Assert.Contains("AutomationId=\"SkillAssignmentClassCSkillSys_ReloadList_Button\"", axaml);
-        Assert.Contains("Click=\"ReloadList_Click\"", axaml);
+        Assert.Contains("ReloadRequested=\"OnTopBarReloadRequested\"", axaml);
     }
 
     [Fact] public void View_HasMasterClassList() {

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillAssignmentClassSkillSystemParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillAssignmentClassSkillSystemParityTests.cs
@@ -250,9 +250,11 @@ public class SkillAssignmentClassSkillSystemParityTests
     [Fact]
     public void View_HasReloadButton_Wired()
     {
+        // #743: top bar migrated to EditorTopBarWithInputs — see
+        // SkillConfigSkillSystemParityTests for the migration pattern.
         string axaml = ReadAxaml();
         Assert.Contains("AutomationId=\"SkillAssignmentClassSkillSystem_ReloadList_Button\"", axaml);
-        Assert.Contains("Click=\"ReloadList_Click\"", axaml);
+        Assert.Contains("ReloadRequested=\"OnTopBarReloadRequested\"", axaml);
     }
 
     [Fact]

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigFE8NVer2SkillParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigFE8NVer2SkillParityTests.cs
@@ -505,9 +505,11 @@ public class SkillConfigFE8NVer2SkillParityTests
     [Fact]
     public void View_HasReloadButton_Wired()
     {
+        // #743: top bar migrated to EditorTopBarWithInputs — see
+        // SkillConfigSkillSystemParityTests for the migration pattern.
         string axaml = ReadAxaml();
         Assert.Contains("AutomationId=\"SkillConfigFE8NVer2Skill_ReloadList_Button\"", axaml);
-        Assert.Contains("Click=\"ReloadList_Click\"", axaml);
+        Assert.Contains("ReloadRequested=\"OnTopBarReloadRequested\"", axaml);
     }
 
     [Fact]

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigFE8NVer3SkillParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigFE8NVer3SkillParityTests.cs
@@ -560,9 +560,11 @@ public class SkillConfigFE8NVer3SkillParityTests
     [Fact]
     public void View_HasReloadButton_Wired()
     {
+        // #743: top bar migrated to EditorTopBarWithInputs — see
+        // SkillConfigSkillSystemParityTests for the migration pattern.
         string axaml = ReadAxaml();
         Assert.Contains("AutomationId=\"SkillConfigFE8NVer3Skill_ReloadList_Button\"", axaml);
-        Assert.Contains("Click=\"ReloadList_Click\"", axaml);
+        Assert.Contains("ReloadRequested=\"OnTopBarReloadRequested\"", axaml);
     }
 
     [Fact]

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigFE8UCSkillSys09xParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigFE8UCSkillSys09xParityTests.cs
@@ -290,9 +290,11 @@ public class SkillConfigFE8UCSkillSys09xParityTests
     [Fact]
     public void View_HasReloadButton_Wired()
     {
+        // #743: top bar migrated to EditorTopBarWithInputs — see
+        // SkillConfigSkillSystemParityTests for the migration pattern.
         string axaml = ReadAxaml();
         Assert.Contains("AutomationId=\"SkillConfigFE8UCSkillSys09x_ReloadList_Button\"", axaml);
-        Assert.Contains("Click=\"ReloadList_Click\"", axaml);
+        Assert.Contains("ReloadRequested=\"OnTopBarReloadRequested\"", axaml);
     }
 
     [Fact]

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigSkillSystemParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigSkillSystemParityTests.cs
@@ -389,9 +389,13 @@ public class SkillConfigSkillSystemParityTests
     [Fact]
     public void View_HasReloadButton_Wired()
     {
+        // #743: top bar migrated to EditorTopBarWithInputs — the Reload
+        // button's AutomationId is preserved via the ReloadAutomationId
+        // override, and its click is wired via the unified bar's
+        // ReloadRequested routed event (not a direct Click= on a Button).
         string axaml = ReadAxaml();
         Assert.Contains("AutomationId=\"SkillConfigSkillSystem_ReloadList_Button\"", axaml);
-        Assert.Contains("Click=\"ReloadList_Click\"", axaml);
+        Assert.Contains("ReloadRequested=\"OnTopBarReloadRequested\"", axaml);
     }
 
     [Fact]

--- a/FEBuilderGBA.Avalonia/GapSweep/ControlDensityScanner.cs
+++ b/FEBuilderGBA.Avalonia/GapSweep/ControlDensityScanner.cs
@@ -98,10 +98,18 @@ namespace FEBuilderGBA.Avalonia.GapSweep
         /// Address, Read Count, Size), 3 value TextBlocks (StartAddressValue,
         /// ReadCountValue, SizeValue), 1 TextBox (FilterInput), and 1 Button
         /// (Reload) = 9 controls.
+        ///
+        /// EditorTopBarWithInputs (#701 / #743) inlines: 3 label TextBlocks
+        /// (ReadStart, ReadCount, ReadSize), 3 NumericUpDown inputs
+        /// (ReadStartInput, ReadCountInput, ReadSizeInput), and 1 Button
+        /// (Reload) = 7 controls. Hosts that hide a slot (e.g.
+        /// ShowReadSize="False") still report 7 — the slot is just
+        /// IsVisible=false, the controls still exist in the tree.
         /// </summary>
         static readonly Dictionary<string, int> AvCompositeExpansions = new(StringComparer.Ordinal)
         {
             ["EditorTopBar"] = 9,
+            ["EditorTopBarWithInputs"] = 7,
         };
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml
@@ -30,27 +30,24 @@
           <StackPanel Spacing="8" Margin="8">
             <TextBlock Text="Item Table" FontSize="18" FontWeight="Bold" />
 
-            <!-- Reread bar — mirrors WF panel1 (Read Start Address / Read Count / Reload).
+            <!-- Reread bar — unified via EditorTopBarWithInputs (#743).
                  Read Start + Count are wired into LoadItemList via ApplyReadWindow:
                    - BOTH 0 (default): full list, no slicing.
                    - Either > 0: slice from Start for up to Count entries.
                      Count==0 with Start>0 reads to the end of the list.
                  See ApplyReadWindow in MonsterItemViewerView.axaml.cs for the
                  full clamping semantics. -->
-            <Border BorderBrush="Gray" BorderThickness="1" Padding="6">
-              <Grid ColumnDefinitions="120,140,80,80,Auto" RowDefinitions="Auto">
-                <TextBlock Grid.Column="0" Text="Read Start:" VerticalAlignment="Center" />
-                <NumericUpDown AutomationProperties.AutomationId="MonsterItemViewer_Item_ReadStart_Input"
-                               Grid.Column="1" Name="ItemReadStartBox" Minimum="0" Maximum="33554432"
-                               Value="0" VerticalAlignment="Center" />
-                <TextBlock Grid.Column="2" Text="Count:" VerticalAlignment="Center" Margin="8,0,0,0" />
-                <NumericUpDown AutomationProperties.AutomationId="MonsterItemViewer_Item_ReadCount_Input"
-                               Grid.Column="3" Name="ItemReadCountBox" Minimum="0" Maximum="512"
-                               Value="0" VerticalAlignment="Center" />
-                <Button AutomationProperties.AutomationId="MonsterItemViewer_Item_Reload_Button"
-                        Grid.Column="4" Name="ItemReloadButton" Content="Reload" Margin="8,0,0,0" Click="ItemReload_Click" />
-              </Grid>
-            </Border>
+            <controls:EditorTopBarWithInputs Name="ItemTopBar"
+                                             AutomationProperties.AutomationId="MonsterItemViewer_Item_TopBar"
+                                             ReadStartLabel="Read Start:"
+                                             ReadCountLabel="Count:"
+                                             ReadStartMaximum="33554432"
+                                             ReadCountMaximum="512"
+                                             ShowReadSize="False"
+                                             ReadStartAutomationId="MonsterItemViewer_Item_ReadStart_Input"
+                                             ReadCountAutomationId="MonsterItemViewer_Item_ReadCount_Input"
+                                             ReloadAutomationId="MonsterItemViewer_Item_Reload_Button"
+                                             ReloadRequested="OnItemTopBarReloadRequested" />
 
             <!-- Address bar — mirrors WF AddressPanel (Address / Block Size / Selected Address). -->
             <Border BorderBrush="Gray" BorderThickness="1" Padding="6">
@@ -149,20 +146,18 @@
           <StackPanel Spacing="8" Margin="8">
             <TextBlock Text="Probability Table" FontSize="18" FontWeight="Bold" />
 
-            <Border BorderBrush="Gray" BorderThickness="1" Padding="6">
-              <Grid ColumnDefinitions="120,140,80,80,Auto" RowDefinitions="Auto">
-                <TextBlock Grid.Column="0" Text="Read Start:" VerticalAlignment="Center" />
-                <NumericUpDown AutomationProperties.AutomationId="MonsterItemViewer_Prob_ReadStart_Input"
-                               Grid.Column="1" Name="ProbReadStartBox" Minimum="0" Maximum="33554432"
-                               Value="0" VerticalAlignment="Center" />
-                <TextBlock Grid.Column="2" Text="Count:" VerticalAlignment="Center" Margin="8,0,0,0" />
-                <NumericUpDown AutomationProperties.AutomationId="MonsterItemViewer_Prob_ReadCount_Input"
-                               Grid.Column="3" Name="ProbReadCountBox" Minimum="0" Maximum="512"
-                               Value="0" VerticalAlignment="Center" />
-                <Button AutomationProperties.AutomationId="MonsterItemViewer_Prob_Reload_Button"
-                        Grid.Column="4" Name="ProbReloadButton" Content="Reload" Margin="8,0,0,0" Click="ProbReload_Click" />
-              </Grid>
-            </Border>
+            <!-- Reread bar — unified via EditorTopBarWithInputs (#743). -->
+            <controls:EditorTopBarWithInputs Name="ProbTopBar"
+                                             AutomationProperties.AutomationId="MonsterItemViewer_Prob_TopBar"
+                                             ReadStartLabel="Read Start:"
+                                             ReadCountLabel="Count:"
+                                             ReadStartMaximum="33554432"
+                                             ReadCountMaximum="512"
+                                             ShowReadSize="False"
+                                             ReadStartAutomationId="MonsterItemViewer_Prob_ReadStart_Input"
+                                             ReadCountAutomationId="MonsterItemViewer_Prob_ReadCount_Input"
+                                             ReloadAutomationId="MonsterItemViewer_Prob_Reload_Button"
+                                             ReloadRequested="OnProbTopBarReloadRequested" />
 
             <Border BorderBrush="Gray" BorderThickness="1" Padding="6">
               <Grid ColumnDefinitions="120,140,100,100,Auto" RowDefinitions="Auto,Auto">
@@ -240,20 +235,18 @@
           <StackPanel Spacing="8" Margin="8">
             <TextBlock Text="Holdings Table" FontSize="18" FontWeight="Bold" />
 
-            <Border BorderBrush="Gray" BorderThickness="1" Padding="6">
-              <Grid ColumnDefinitions="120,140,80,80,Auto" RowDefinitions="Auto">
-                <TextBlock Grid.Column="0" Text="Read Start:" VerticalAlignment="Center" />
-                <NumericUpDown AutomationProperties.AutomationId="MonsterItemViewer_Holding_ReadStart_Input"
-                               Grid.Column="1" Name="HoldReadStartBox" Minimum="0" Maximum="33554432"
-                               Value="0" VerticalAlignment="Center" />
-                <TextBlock Grid.Column="2" Text="Count:" VerticalAlignment="Center" Margin="8,0,0,0" />
-                <NumericUpDown AutomationProperties.AutomationId="MonsterItemViewer_Holding_ReadCount_Input"
-                               Grid.Column="3" Name="HoldReadCountBox" Minimum="0" Maximum="512"
-                               Value="0" VerticalAlignment="Center" />
-                <Button AutomationProperties.AutomationId="MonsterItemViewer_Holding_Reload_Button"
-                        Grid.Column="4" Name="HoldReloadButton" Content="Reload" Margin="8,0,0,0" Click="HoldReload_Click" />
-              </Grid>
-            </Border>
+            <!-- Reread bar — unified via EditorTopBarWithInputs (#743). -->
+            <controls:EditorTopBarWithInputs Name="HoldTopBar"
+                                             AutomationProperties.AutomationId="MonsterItemViewer_Holding_TopBar"
+                                             ReadStartLabel="Read Start:"
+                                             ReadCountLabel="Count:"
+                                             ReadStartMaximum="33554432"
+                                             ReadCountMaximum="512"
+                                             ShowReadSize="False"
+                                             ReadStartAutomationId="MonsterItemViewer_Holding_ReadStart_Input"
+                                             ReadCountAutomationId="MonsterItemViewer_Holding_ReadCount_Input"
+                                             ReloadAutomationId="MonsterItemViewer_Holding_Reload_Button"
+                                             ReloadRequested="OnHoldTopBarReloadRequested" />
 
             <Border BorderBrush="Gray" BorderThickness="1" Padding="6">
               <Grid ColumnDefinitions="120,140,100,100,Auto" RowDefinitions="Auto,Auto">

--- a/FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml.cs
@@ -64,9 +64,10 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 var items = _vm.LoadMonsterItemList();
+                // #743: unified top-bar surfaces ReadStart / Count via CLR properties.
                 items = ApplyReadWindow(items,
-                    (uint)(ItemReadStartBox.Value ?? 0),
-                    (uint)(ItemReadCountBox.Value ?? 0));
+                    ItemTopBar?.ReadStartAddress ?? 0u,
+                    (uint)(ItemTopBar?.ReadCount ?? 0));
                 if (preserveAddress != 0)
                     EntryList.SetItemsPreserveSelection(items, preserveAddress);
                 else
@@ -140,6 +141,9 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void ItemReload_Click(object? sender, RoutedEventArgs e) => LoadItemList();
 
+        // #743: routed event from the unified EditorTopBarWithInputs Reload button (Tab 1).
+        void OnItemTopBarReloadRequested(object? sender, RoutedEventArgs e) => LoadItemList();
+
         void ItemExpand_Click(object? sender, RoutedEventArgs e)
         {
             var rom = CoreState.ROM;
@@ -180,9 +184,10 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 var items = _vm.LoadMonsterItemProbabilityList();
+                // #743: unified top-bar surfaces ReadStart / Count via CLR properties.
                 items = ApplyReadWindow(items,
-                    (uint)(ProbReadStartBox.Value ?? 0),
-                    (uint)(ProbReadCountBox.Value ?? 0));
+                    ProbTopBar?.ReadStartAddress ?? 0u,
+                    (uint)(ProbTopBar?.ReadCount ?? 0));
                 if (preserveAddress != 0)
                     ProbEntryList.SetItemsPreserveSelection(items, preserveAddress);
                 else
@@ -260,6 +265,9 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void ProbReload_Click(object? sender, RoutedEventArgs e) => LoadProbList();
 
+        // #743: routed event from the unified EditorTopBarWithInputs Reload button (Tab 2).
+        void OnProbTopBarReloadRequested(object? sender, RoutedEventArgs e) => LoadProbList();
+
         void ProbExpand_Click(object? sender, RoutedEventArgs e)
         {
             var rom = CoreState.ROM;
@@ -300,9 +308,10 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 var items = _vm.LoadMonsterItemHoldingsList();
+                // #743: unified top-bar surfaces ReadStart / Count via CLR properties.
                 items = ApplyReadWindow(items,
-                    (uint)(HoldReadStartBox.Value ?? 0),
-                    (uint)(HoldReadCountBox.Value ?? 0));
+                    HoldTopBar?.ReadStartAddress ?? 0u,
+                    (uint)(HoldTopBar?.ReadCount ?? 0));
                 if (preserveAddress != 0)
                     HoldingEntryList.SetItemsPreserveSelection(items, preserveAddress);
                 else
@@ -447,6 +456,9 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         void HoldReload_Click(object? sender, RoutedEventArgs e) => LoadHoldList();
+
+        // #743: routed event from the unified EditorTopBarWithInputs Reload button (Tab 3).
+        void OnHoldTopBarReloadRequested(object? sender, RoutedEventArgs e) => LoadHoldList();
 
         void HoldExpand_Click(object? sender, RoutedEventArgs e)
         {

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml
@@ -1,5 +1,6 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
         x:Class="FEBuilderGBA.Avalonia.Views.SkillAssignmentClassCSkillSysView"
         Title="Skill Assignment - Class (CSkillSys)" Width="1200" Height="900"
         SizeToContent="WidthAndHeight">
@@ -17,23 +18,22 @@
                    Text="Skill Assignment - Class (CSkillSys 3.00).&#10;This editor requires the CSkillSys 3.00+ skill system patch to be installed.&#10;Use the Patch Manager to install the CSkillSys 3.00 patch first." />
       </Border>
 
-      <Border BorderBrush="Gray" BorderThickness="1" Padding="6" CornerRadius="2">
-        <Grid ColumnDefinitions="Auto,150,Auto,90,Auto" Margin="0">
-          <TextBlock AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_ReadStartLabel"
-                     Grid.Column="0" Text="Start Address:" VerticalAlignment="Center" Margin="0,0,8,0" />
-          <NumericUpDown AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_ReadStart_Input"
-                         Grid.Column="1" Name="ReadStartAddressBox" FormatString="0"
-                         Minimum="0" Maximum="2147483647" Margin="0,0,12,0" />
-          <TextBlock AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_ReadCountLabel"
-                     Grid.Column="2" Text="Read Count:" VerticalAlignment="Center" Margin="0,0,8,0" />
-          <NumericUpDown AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_ReadCount_Input"
-                         Grid.Column="3" Name="ReadCountBox" FormatString="0"
-                         Minimum="0" Maximum="256" Margin="0,0,12,0" />
-          <Button AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_ReloadList_Button"
-                  Grid.Column="4" Name="ReloadListButton" Content="Reload"
-                  Click="ReloadList_Click" MinWidth="100" />
-        </Grid>
-      </Border>
+      <!-- Top read-config bar — unified via EditorTopBarWithInputs (#743).
+           Inputs stay editable (this view did NOT use the IsEnabled="False"
+           pattern). Pre-migration Maximums preserved via ReadStartMaximum /
+           ReadCountMaximum so the unified bar doesn't widen the accepted
+           range. -->
+      <controls:EditorTopBarWithInputs Name="TopBar"
+                                       AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_TopBar"
+                                       ReadStartLabel="Start Address:"
+                                       ReadCountLabel="Read Count:"
+                                       ReadStartMaximum="2147483647"
+                                       ReadCountMaximum="256"
+                                       ShowReadSize="False"
+                                       ReadStartAutomationId="SkillAssignmentClassCSkillSys_ReadStart_Input"
+                                       ReadCountAutomationId="SkillAssignmentClassCSkillSys_ReadCount_Input"
+                                       ReloadAutomationId="SkillAssignmentClassCSkillSys_ReloadList_Button"
+                                       ReloadRequested="OnTopBarReloadRequested" />
 
       <Grid ColumnDefinitions="260,*">
 

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml.cs
@@ -102,8 +102,9 @@ namespace FEBuilderGBA.Avalonia.Views
                 // ReadStartAddress / ReadCount overrides drive the list walk.
                 // Copilot CLI PR #552 review #2: previously the VM defaults
                 // were copied INTO the boxes, making the controls inert.
-                _vm.ReadStartAddress = (uint)(ReadStartAddressBox.Value ?? 0);
-                _vm.ReadCount = (uint)(ReadCountBox.Value ?? 0);
+                // #743: unified top-bar surfaces ReadStart / ReadCount via CLR properties.
+                _vm.ReadStartAddress = TopBar?.ReadStartAddress ?? 0u;
+                _vm.ReadCount = (uint)(TopBar?.ReadCount ?? 0);
                 _classItems = _vm.LoadClassList();
                 _classDisplayItems.Clear();
                 foreach (var item in _classItems) _classDisplayItems.Add(item.name);
@@ -120,8 +121,12 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             // Seed the boxes once on Initialize so the user sees the VM defaults,
             // but subsequent reloads READ from the boxes (not the VM).
-            ReadStartAddressBox.Value = _vm.ReadStartAddress;
-            ReadCountBox.Value = _vm.ReadCount;
+            // #743: unified top-bar surfaces ReadStart / ReadCount via CLR properties.
+            if (TopBar != null)
+            {
+                TopBar.ReadStartAddress = _vm.ReadStartAddress;
+                TopBar.ReadCount = (int)_vm.ReadCount;
+            }
             N1ReadCountBox.Value = _vm.N1ReadCount;
         }
 
@@ -129,6 +134,9 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             LoadClassList();
         }
+
+        // #743: routed event from the unified EditorTopBarWithInputs Reload button.
+        void OnTopBarReloadRequested(object? sender, RoutedEventArgs e) => LoadClassList();
 
         void OnClassSelected(AddrResult ar)
         {

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassSkillSystemView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassSkillSystemView.axaml
@@ -6,23 +6,18 @@
         SizeToContent="WidthAndHeight">
   <Grid ColumnDefinitions="260,*" RowDefinitions="Auto,Auto,*">
 
-    <!-- Row 0: top read-config bar (mirrors WF panel3) -->
-    <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
-      <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
-        <Label Content="Start Address:" VerticalAlignment="Center" />
-        <NumericUpDown AutomationProperties.AutomationId="SkillAssignmentClassSkillSystem_ReadStart_Input"
-                       FormatString="0" Name="ReadStartAddressBox" Width="120"
-                       Minimum="0" Maximum="4294967295"
-                       IsEnabled="False" VerticalAlignment="Center" />
-        <Label Content="Read Count:" VerticalAlignment="Center" />
-        <NumericUpDown AutomationProperties.AutomationId="SkillAssignmentClassSkillSystem_ReadCount_Input"
-                       FormatString="0" Name="ReadCountBox" Width="80"
-                       Minimum="0" Maximum="1024"
-                       IsEnabled="False" VerticalAlignment="Center" />
-        <Button AutomationProperties.AutomationId="SkillAssignmentClassSkillSystem_ReloadList_Button"
-                Name="ReloadListButton" Content="Reload" Click="ReloadList_Click" />
-      </StackPanel>
-    </Border>
+    <!-- Row 0: top read-config bar — unified via EditorTopBarWithInputs (#743). -->
+    <controls:EditorTopBarWithInputs Grid.Row="0" Grid.ColumnSpan="2" Name="TopBar"
+                                     AutomationProperties.AutomationId="SkillAssignmentClassSkillSystem_TopBar"
+                                     ReadStartLabel="Start Address:"
+                                     ReadCountLabel="Read Count:"
+                                     ReadCountMaximum="1024"
+                                     InputsEnabled="False"
+                                     ShowReadSize="False"
+                                     ReadStartAutomationId="SkillAssignmentClassSkillSystem_ReadStart_Input"
+                                     ReadCountAutomationId="SkillAssignmentClassSkillSystem_ReadCount_Input"
+                                     ReloadAutomationId="SkillAssignmentClassSkillSystem_ReloadList_Button"
+                                     ReloadRequested="OnTopBarReloadRequested" />
 
     <!-- Row 1: master-write bar (mirrors WF panel5) -->
     <Border Grid.Row="1" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4,0,4,0">

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassSkillSystemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassSkillSystemView.axaml.cs
@@ -61,8 +61,12 @@ namespace FEBuilderGBA.Avalonia.Views
                 // Use ClassIconLoader (one wait-icon per class index) to mirror the WF AddressList
                 // OwnerDraw=DrawClassAndText (Copilot bot review on PR #555).
                 EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ClassIconLoader(items, i));
-                ReadStartAddressBox.Value = _vm.ReadStartAddress;
-                ReadCountBox.Value = _vm.ReadCount;
+                // #743: unified top-bar surfaces ReadStart / ReadCount via CLR properties.
+                if (TopBar != null)
+                {
+                    TopBar.ReadStartAddress = _vm.ReadStartAddress;
+                    TopBar.ReadCount = (int)_vm.ReadCount;
+                }
                 UpdateMasterPanelVisibility();
             }
             catch (Exception ex)
@@ -73,6 +77,9 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         void ReloadList_Click(object sender, RoutedEventArgs e) => LoadList();
+
+        // #743: routed event from the unified EditorTopBarWithInputs Reload button.
+        void OnTopBarReloadRequested(object? sender, RoutedEventArgs e) => LoadList();
 
         void OnSelected(uint addr)
         {

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer2SkillView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer2SkillView.axaml
@@ -6,23 +6,18 @@
         SizeToContent="WidthAndHeight">
   <Grid ColumnDefinitions="260,*" RowDefinitions="Auto,Auto,*">
 
-    <!-- Row 0: top read-config bar (mirrors WF panel3: 先頭アドレス / 読込数 / 再取得) -->
-    <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
-      <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
-        <Label Content="Start Address:" VerticalAlignment="Center" />
-        <NumericUpDown AutomationProperties.AutomationId="SkillConfigFE8NVer2Skill_ReadStart_Input"
-                       FormatString="0" Name="ReadStartAddressBox" Width="120"
-                       Minimum="0" Maximum="4294967295"
-                       IsEnabled="False" VerticalAlignment="Center" />
-        <Label Content="Read Count:" VerticalAlignment="Center" />
-        <NumericUpDown AutomationProperties.AutomationId="SkillConfigFE8NVer2Skill_ReadCount_Input"
-                       FormatString="0" Name="ReadCountBox" Width="80"
-                       Minimum="0" Maximum="1024"
-                       IsEnabled="False" VerticalAlignment="Center" />
-        <Button AutomationProperties.AutomationId="SkillConfigFE8NVer2Skill_ReloadList_Button"
-                Name="ReloadListButton" Content="Reload" Click="ReloadList_Click" />
-      </StackPanel>
-    </Border>
+    <!-- Row 0: top read-config bar — unified via EditorTopBarWithInputs (#743). -->
+    <controls:EditorTopBarWithInputs Grid.Row="0" Grid.ColumnSpan="2" Name="TopBar"
+                                     AutomationProperties.AutomationId="SkillConfigFE8NVer2Skill_TopBar"
+                                     ReadStartLabel="Start Address:"
+                                     ReadCountLabel="Read Count:"
+                                     ReadCountMaximum="1024"
+                                     InputsEnabled="False"
+                                     ShowReadSize="False"
+                                     ReadStartAutomationId="SkillConfigFE8NVer2Skill_ReadStart_Input"
+                                     ReadCountAutomationId="SkillConfigFE8NVer2Skill_ReadCount_Input"
+                                     ReloadAutomationId="SkillConfigFE8NVer2Skill_ReloadList_Button"
+                                     ReloadRequested="OnTopBarReloadRequested" />
 
     <!-- Row 1: selection bar (mirrors WF panel5: アドレス / Size: / 選択アドレス / 書き込み) -->
     <Border Grid.Row="1" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4,0,4,0">

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer2SkillView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer2SkillView.axaml.cs
@@ -63,8 +63,12 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 var items = _vm.LoadList();
                 EntryList.SetItemsWithIcons(items, i => ListIconLoaders.FE8NVer2SkillIconLoader(items, i));
-                ReadStartAddressBox.Value = _vm.ReadStartAddress;
-                ReadCountBox.Value = _vm.ReadCount;
+                // #743: unified top-bar surfaces ReadStart / ReadCount via CLR properties.
+                if (TopBar != null)
+                {
+                    TopBar.ReadStartAddress = _vm.ReadStartAddress;
+                    TopBar.ReadCount = (int)_vm.ReadCount;
+                }
                 BlockSizeBox.Value = _vm.BlockSize;
 
                 // Show / hide the Item2 row + tab based on detected stride.
@@ -91,6 +95,9 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             LoadList();
         }
+
+        // #743: routed event from the unified EditorTopBarWithInputs Reload button.
+        void OnTopBarReloadRequested(object? sender, RoutedEventArgs e) => LoadList();
 
         void OnSelected(uint addr)
         {

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml
@@ -6,23 +6,18 @@
         SizeToContent="WidthAndHeight">
   <Grid ColumnDefinitions="260,*" RowDefinitions="Auto,Auto,*">
 
-    <!-- Row 0: top read-config bar (mirrors WF panel3: 先頭アドレス / 読込数 / 再取得) -->
-    <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
-      <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
-        <Label Content="Start Address:" VerticalAlignment="Center" />
-        <NumericUpDown AutomationProperties.AutomationId="SkillConfigFE8NVer3Skill_ReadStart_Input"
-                       FormatString="0" Name="ReadStartAddressBox" Width="120"
-                       Minimum="0" Maximum="4294967295"
-                       IsEnabled="False" VerticalAlignment="Center" />
-        <Label Content="Read Count:" VerticalAlignment="Center" />
-        <NumericUpDown AutomationProperties.AutomationId="SkillConfigFE8NVer3Skill_ReadCount_Input"
-                       FormatString="0" Name="ReadCountBox" Width="80"
-                       Minimum="0" Maximum="1024"
-                       IsEnabled="False" VerticalAlignment="Center" />
-        <Button AutomationProperties.AutomationId="SkillConfigFE8NVer3Skill_ReloadList_Button"
-                Name="ReloadListButton" Content="Reload" Click="ReloadList_Click" />
-      </StackPanel>
-    </Border>
+    <!-- Row 0: top read-config bar — unified via EditorTopBarWithInputs (#743). -->
+    <controls:EditorTopBarWithInputs Grid.Row="0" Grid.ColumnSpan="2" Name="TopBar"
+                                     AutomationProperties.AutomationId="SkillConfigFE8NVer3Skill_TopBar"
+                                     ReadStartLabel="Start Address:"
+                                     ReadCountLabel="Read Count:"
+                                     ReadCountMaximum="1024"
+                                     InputsEnabled="False"
+                                     ShowReadSize="False"
+                                     ReadStartAutomationId="SkillConfigFE8NVer3Skill_ReadStart_Input"
+                                     ReadCountAutomationId="SkillConfigFE8NVer3Skill_ReadCount_Input"
+                                     ReloadAutomationId="SkillConfigFE8NVer3Skill_ReloadList_Button"
+                                     ReloadRequested="OnTopBarReloadRequested" />
 
     <!-- Row 1: selection bar (mirrors WF panel5: アドレス / Size: / 選択アドレス / 書き込み) -->
     <Border Grid.Row="1" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4,0,4,0">

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml.cs
@@ -63,8 +63,12 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 var items = _vm.LoadList();
                 EntryList.SetItemsWithIcons(items, i => ListIconLoaders.FE8NVer3SkillIconLoader(items, i));
-                ReadStartAddressBox.Value = _vm.ReadStartAddress;
-                ReadCountBox.Value = _vm.ReadCount;
+                // #743: unified top-bar surfaces ReadStart / ReadCount via CLR properties.
+                if (TopBar != null)
+                {
+                    TopBar.ReadStartAddress = _vm.ReadStartAddress;
+                    TopBar.ReadCount = (int)_vm.ReadCount;
+                }
                 BlockSizeBox.Value = _vm.BlockSize;
 
                 _suppressZoomChange = true;
@@ -87,6 +91,9 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             LoadList();
         }
+
+        // #743: routed event from the unified EditorTopBarWithInputs Reload button.
+        void OnTopBarReloadRequested(object? sender, RoutedEventArgs e) => LoadList();
 
         void OnSelected(uint addr)
         {

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml
@@ -6,23 +6,18 @@
         SizeToContent="WidthAndHeight">
   <Grid ColumnDefinitions="260,*" RowDefinitions="Auto,Auto,*">
 
-    <!-- Row 0: top read-config bar (mirrors WF panel3: 先頭アドレス / 読込数 / 再取得) -->
-    <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
-      <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
-        <Label Content="Start Address:" VerticalAlignment="Center" />
-        <NumericUpDown AutomationProperties.AutomationId="SkillConfigFE8UCSkillSys09x_ReadStart_Input"
-                       FormatString="0" Name="ReadStartAddressBox" Width="120"
-                       Minimum="0" Maximum="4294967295"
-                       IsEnabled="False" VerticalAlignment="Center" />
-        <Label Content="Read Count:" VerticalAlignment="Center" />
-        <NumericUpDown AutomationProperties.AutomationId="SkillConfigFE8UCSkillSys09x_ReadCount_Input"
-                       FormatString="0" Name="ReadCountBox" Width="80"
-                       Minimum="0" Maximum="1024"
-                       IsEnabled="False" VerticalAlignment="Center" />
-        <Button AutomationProperties.AutomationId="SkillConfigFE8UCSkillSys09x_ReloadList_Button"
-                Name="ReloadListButton" Content="Reload" Click="ReloadList_Click" />
-      </StackPanel>
-    </Border>
+    <!-- Row 0: top read-config bar — unified via EditorTopBarWithInputs (#743). -->
+    <controls:EditorTopBarWithInputs Grid.Row="0" Grid.ColumnSpan="2" Name="TopBar"
+                                     AutomationProperties.AutomationId="SkillConfigFE8UCSkillSys09x_TopBar"
+                                     ReadStartLabel="Start Address:"
+                                     ReadCountLabel="Read Count:"
+                                     ReadCountMaximum="1024"
+                                     InputsEnabled="False"
+                                     ShowReadSize="False"
+                                     ReadStartAutomationId="SkillConfigFE8UCSkillSys09x_ReadStart_Input"
+                                     ReadCountAutomationId="SkillConfigFE8UCSkillSys09x_ReadCount_Input"
+                                     ReloadAutomationId="SkillConfigFE8UCSkillSys09x_ReloadList_Button"
+                                     ReloadRequested="OnTopBarReloadRequested" />
 
     <!-- Row 1: selection bar (mirrors WF panel5: アドレス / Size: / 選択アドレス / 書き込み) -->
     <Border Grid.Row="1" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4,0,4,0">

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml.cs
@@ -56,8 +56,12 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 var items = _vm.LoadList();
                 EntryList.SetItemsWithIcons(items, i => ListIconLoaders.CSkillSysSkillIconLoader(items, i));
-                ReadStartAddressBox.Value = _vm.ReadStartAddress;
-                ReadCountBox.Value = _vm.ReadCount;
+                // #743: unified top-bar surfaces ReadStart / ReadCount via CLR properties.
+                if (TopBar != null)
+                {
+                    TopBar.ReadStartAddress = _vm.ReadStartAddress;
+                    TopBar.ReadCount = (int)_vm.ReadCount;
+                }
 
                 _suppressZoomChange = true;
                 try
@@ -79,6 +83,9 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             LoadList();
         }
+
+        // #743: routed event from the unified EditorTopBarWithInputs Reload button.
+        void OnTopBarReloadRequested(object? sender, RoutedEventArgs e) => LoadList();
 
         void OnSelected(uint addr)
         {

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml
@@ -6,23 +6,20 @@
         SizeToContent="WidthAndHeight">
   <Grid ColumnDefinitions="260,*" RowDefinitions="Auto,Auto,*">
 
-    <!-- Row 0: top read-config bar (mirrors WF panel3: 先頭アドレス / 読込数 / 再取得) -->
-    <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
-      <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
-        <Label Content="Start Address:" VerticalAlignment="Center" />
-        <NumericUpDown AutomationProperties.AutomationId="SkillConfigSkillSystem_ReadStart_Input"
-                       FormatString="0" Name="ReadStartAddressBox" Width="120"
-                       Minimum="0" Maximum="4294967295"
-                       IsEnabled="False" VerticalAlignment="Center" />
-        <Label Content="Read Count:" VerticalAlignment="Center" />
-        <NumericUpDown AutomationProperties.AutomationId="SkillConfigSkillSystem_ReadCount_Input"
-                       FormatString="0" Name="ReadCountBox" Width="80"
-                       Minimum="0" Maximum="1024"
-                       IsEnabled="False" VerticalAlignment="Center" />
-        <Button AutomationProperties.AutomationId="SkillConfigSkillSystem_ReloadList_Button"
-                Name="ReloadListButton" Content="Reload" Click="ReloadList_Click" />
-      </StackPanel>
-    </Border>
+    <!-- Row 0: top read-config bar — unified via EditorTopBarWithInputs (#743).
+         The InputsEnabled="False" + legacy AutomationId overrides preserve the
+         pre-migration "disabled-as-display" UX and existing E2E selectors. -->
+    <controls:EditorTopBarWithInputs Grid.Row="0" Grid.ColumnSpan="2" Name="TopBar"
+                                     AutomationProperties.AutomationId="SkillConfigSkillSystem_TopBar"
+                                     ReadStartLabel="Start Address:"
+                                     ReadCountLabel="Read Count:"
+                                     ReadCountMaximum="1024"
+                                     InputsEnabled="False"
+                                     ShowReadSize="False"
+                                     ReadStartAutomationId="SkillConfigSkillSystem_ReadStart_Input"
+                                     ReadCountAutomationId="SkillConfigSkillSystem_ReadCount_Input"
+                                     ReloadAutomationId="SkillConfigSkillSystem_ReloadList_Button"
+                                     ReloadRequested="OnTopBarReloadRequested" />
 
     <!-- Row 1: selection bar (mirrors WF panel5: アドレス / Size: / 選択アドレス / 書き込み) -->
     <Border Grid.Row="1" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4,0,4,0">

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml.cs
@@ -63,8 +63,14 @@ namespace FEBuilderGBA.Avalonia.Views
                 // Copilot bot review on PR #525.
                 uint cachedIconBase = _vm.IconBaseAddress;
                 EntryList.SetItemsWithIcons(items, i => ListIconLoaders.SkillIconLoader(items, i, cachedIconBase));
-                ReadStartAddressBox.Value = _vm.ReadStartAddress;
-                ReadCountBox.Value = _vm.ReadCount;
+                // #743: unified top-bar surfaces ReadStart / ReadCount via the
+                // EditorTopBarWithInputs CLR properties; the legacy
+                // ReadStartAddressBox / ReadCountBox names are gone.
+                if (TopBar != null)
+                {
+                    TopBar.ReadStartAddress = _vm.ReadStartAddress;
+                    TopBar.ReadCount = (int)_vm.ReadCount;
+                }
 
                 _suppressZoomChange = true;
                 try
@@ -86,6 +92,9 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             LoadList();
         }
+
+        // #743: routed event from the unified EditorTopBarWithInputs Reload button.
+        void OnTopBarReloadRequested(object? sender, RoutedEventArgs e) => LoadList();
 
         void OnSelected(uint addr)
         {

--- a/FEBuilderGBA.Avalonia/Views/WorldMapEventPointerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapEventPointerView.axaml
@@ -21,23 +21,19 @@
       <StackPanel Spacing="8" Margin="8">
         <Label Content="World Map Event Editor" FontSize="18" FontWeight="Bold" />
 
-        <!-- Top read-config bar (mirrors WF panel1) -->
-        <Border BorderBrush="Gray" BorderThickness="1">
-          <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
-            <Label Content="Top Address" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="WorldMapEventPointer_Before_BaseAddr_Input"
-                           FormatString="0" Name="BeforeBaseAddrBox" Width="120"
-                           Minimum="0" Maximum="4294967295"
-                           IsReadOnly="True" VerticalAlignment="Center" />
-            <Label Content="Read Count" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="WorldMapEventPointer_Before_ReadCount_Input"
-                           FormatString="0" Name="BeforeReadCountBox" Width="80"
-                           Minimum="0" Maximum="512"
-                           IsReadOnly="True" VerticalAlignment="Center" />
-            <Button AutomationProperties.AutomationId="WorldMapEventPointer_Before_Reload_Button"
-                    Name="BeforeReloadButton" Content="Reload" Click="ReloadBefore_Click" />
-          </StackPanel>
-        </Border>
+        <!-- Top read-config bar — unified via EditorTopBarWithInputs (#743).
+             InputsEnabled="False" preserves the pre-migration IsReadOnly UX. -->
+        <controls:EditorTopBarWithInputs Name="BeforeTopBar"
+                                         AutomationProperties.AutomationId="WorldMapEventPointer_Before_TopBar"
+                                         ReadStartLabel="Top Address"
+                                         ReadCountLabel="Read Count"
+                                         ReadCountMaximum="512"
+                                         InputsEnabled="False"
+                                         ShowReadSize="False"
+                                         ReadStartAutomationId="WorldMapEventPointer_Before_BaseAddr_Input"
+                                         ReadCountAutomationId="WorldMapEventPointer_Before_ReadCount_Input"
+                                         ReloadAutomationId="WorldMapEventPointer_Before_Reload_Button"
+                                         ReloadRequested="OnBeforeTopBarReloadRequested" />
 
         <!-- Address bar (mirrors WF AddressPanel) -->
         <Border BorderBrush="Gray" BorderThickness="1">
@@ -136,23 +132,18 @@
     <!-- ============ After detail / write panel ============ -->
     <ScrollViewer Grid.Row="1" Grid.Column="1" Margin="4">
       <StackPanel Spacing="8" Margin="8">
-        <!-- After read-config bar (mirrors WF panel4) -->
-        <Border BorderBrush="Gray" BorderThickness="1">
-          <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
-            <Label Content="Top Address" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="WorldMapEventPointer_After_BaseAddr_Input"
-                           FormatString="0" Name="AfterBaseAddrBox" Width="120"
-                           Minimum="0" Maximum="4294967295"
-                           IsReadOnly="True" VerticalAlignment="Center" />
-            <Label Content="Read Count" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="WorldMapEventPointer_After_ReadCount_Input"
-                           FormatString="0" Name="AfterReadCountBox" Width="80"
-                           Minimum="0" Maximum="512"
-                           IsReadOnly="True" VerticalAlignment="Center" />
-            <Button AutomationProperties.AutomationId="WorldMapEventPointer_After_Reload_Button"
-                    Name="AfterReloadButton" Content="Reload" Click="ReloadAfter_Click" />
-          </StackPanel>
-        </Border>
+        <!-- After read-config bar — unified via EditorTopBarWithInputs (#743). -->
+        <controls:EditorTopBarWithInputs Name="AfterTopBar"
+                                         AutomationProperties.AutomationId="WorldMapEventPointer_After_TopBar"
+                                         ReadStartLabel="Top Address"
+                                         ReadCountLabel="Read Count"
+                                         ReadCountMaximum="512"
+                                         InputsEnabled="False"
+                                         ShowReadSize="False"
+                                         ReadStartAutomationId="WorldMapEventPointer_After_BaseAddr_Input"
+                                         ReadCountAutomationId="WorldMapEventPointer_After_ReadCount_Input"
+                                         ReloadAutomationId="WorldMapEventPointer_After_Reload_Button"
+                                         ReloadRequested="OnAfterTopBarReloadRequested" />
 
         <!-- After address bar (mirrors WF panel5) -->
         <Border BorderBrush="Gray" BorderThickness="1">

--- a/FEBuilderGBA.Avalonia/Views/WorldMapEventPointerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapEventPointerView.axaml.cs
@@ -97,6 +97,10 @@ namespace FEBuilderGBA.Avalonia.Views
         void ReloadBefore_Click(object? sender, RoutedEventArgs e) => ReloadBefore();
         void ReloadAfter_Click(object? sender, RoutedEventArgs e) => ReloadAfter();
 
+        // #743: routed events from the unified EditorTopBarWithInputs Reload buttons.
+        void OnBeforeTopBarReloadRequested(object? sender, RoutedEventArgs e) => ReloadBefore();
+        void OnAfterTopBarReloadRequested(object? sender, RoutedEventArgs e) => ReloadAfter();
+
         void OnBeforeSelected(uint addr)
         {
             // Save/restore the prior IsLoading state instead of forcing
@@ -157,10 +161,17 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void UpdateReadConfigUI()
         {
-            BeforeBaseAddrBox.Value = _vm.BeforeBaseAddr;
-            BeforeReadCountBox.Value = _vm.BeforeReadCount;
-            AfterBaseAddrBox.Value = _vm.AfterBaseAddr;
-            AfterReadCountBox.Value = _vm.AfterReadCount;
+            // #743: unified top-bars surface ReadStart / ReadCount via CLR properties.
+            if (BeforeTopBar != null)
+            {
+                BeforeTopBar.ReadStartAddress = _vm.BeforeBaseAddr;
+                BeforeTopBar.ReadCount = (int)_vm.BeforeReadCount;
+            }
+            if (AfterTopBar != null)
+            {
+                AfterTopBar.ReadStartAddress = _vm.AfterBaseAddr;
+                AfterTopBar.ReadCount = (int)_vm.AfterReadCount;
+            }
         }
 
         // ----------------------------------------------------------------


### PR DESCRIPTION
## Summary

Slice C follow-up of #649. Migrates **8 deferred editors** (11 top-bar instances) to the unified `EditorTopBarWithInputs` control, replacing each hand-rolled `<Border><StackPanel><NumericUpDown><Button></StackPanel></Border>` read-config bar with a single composite element while preserving every legacy AutomationId and the pre-migration disabled-as-display UX.

## Editors migrated (8 distinct, 11 instances)

| # | View | Top-bar shape | Instance ids |
|---|------|---------------|--------------|
| 1 | `SkillConfigSkillSystemView` | Start+Count+Reload, IsEnabled=False | `SkillConfigSkillSystem_TopBar` |
| 2 | `SkillConfigFE8NVer2SkillView` | Start+Count+Reload, IsEnabled=False | `SkillConfigFE8NVer2Skill_TopBar` |
| 3 | `SkillConfigFE8NVer3SkillView` | Start+Count+Reload, IsEnabled=False | `SkillConfigFE8NVer3Skill_TopBar` |
| 4 | `SkillConfigFE8UCSkillSys09xView` | Start+Count+Reload, IsEnabled=False | `SkillConfigFE8UCSkillSys09x_TopBar` |
| 5 | `SkillAssignmentClassSkillSystemView` | Start+Count+Reload, IsEnabled=False | `SkillAssignmentClassSkillSystem_TopBar` |
| 6 | `SkillAssignmentClassCSkillSysView` | Start+Count+Reload (editable) | `SkillAssignmentClassCSkillSys_TopBar` |
| 7 | `WorldMapEventPointerView` | 2 bars, IsReadOnly | `WorldMapEventPointer_Before_TopBar` + `WorldMapEventPointer_After_TopBar` |
| 8 | `MonsterItemViewerView` | 3 tabs, 3 bars | `MonsterItemViewer_Item_TopBar` + `MonsterItemViewer_Prob_TopBar` + `MonsterItemViewer_Holding_TopBar` |

All 8 set `ShowReadSize="False"` (Start + Count only). The five Skill* + WorldMap bars set `InputsEnabled="False"` to preserve the pre-migration disabled-input-as-display UX. Legacy AutomationIds are preserved via `ReadStartAutomationId` / `ReadCountAutomationId` / `ReloadAutomationId` overrides so every parity test continues to resolve them.

## Editors deferred (7 — per-cluster follow-ups)

| # | View | Reason |
|---|------|--------|
| 1 | `SkillConfigFE8NSkillView` | FE8N Page combo + Change Type combo in the top bar — needs slot extension or per-editor mini-bar |
| 2 | `EventCondView` | Top bar uses `<TextBox>` for `TopAddr` (not `NumericUpDown`) — migration would force UIAutomation control-type drift (per issue body's Copilot CLI caveat) |
| 3 | `EventUnitView` | Same TextBox top-addr issue |
| 4 | `EventUnitFE7View` | Same TextBox top-addr issue |
| 5 | `MapTileAnimation2View` | Inline `<ComboBox>` Filter slot AFTER the Reload button breaks the "Reload pinned right" contract |
| 6 | `ImageUnitPaletteView` | Top bar is a 2-column Grid inside the "Search Tools" tab, not a horizontal strip |
| 7 | `TextViewerView` | Already out-of-scope per the issue body (content-search bar, not address bar) |

## Test changes

- `EditorTopBarMigrationSweepTests.s_editableMigratedViews` extended to cover the 8 new views (62 → 224 sweep test passes across the migrated/deferred matrix).
- `KnownDeferredEditor_NotInMigratedList` updated: removed `SkillConfigSkillSystemView` + `MonsterItemViewerView` (now migrated), added the 4 Event* / SkillConfigFE8N / MapTileAnimation2 / ImageUnitPalette guards.
- `MigratedView_HasTopBarAutomationId` regex relaxed to accept multi-instance composite ids like `MonsterItemViewer_Item_TopBar` and `WorldMapEventPointer_Before_TopBar` (allows `_` in the prefix; still requires the `_TopBar` suffix).
- `ControlDensityScanner` learns the composite expansion for `EditorTopBarWithInputs` (7 inlined controls) so post-migration density assertions stay green.
- 8 GapSweep parity tests had their `Click="ReloadList_Click"` assertion updated to `ReloadRequested="OnTopBarReloadRequested"` — the new wiring goes through the unified bar's routed event, not a direct Button.Click.

## Screenshots

Skill Config (SkillSystem) — top bar replaces the old IsEnabled="False" trio:

![SkillConfigSkillSystem](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/pr-feat743-SkillConfigSkillSystem.png?raw=1)

Monster Item Viewer Tab 1 — first of three migrated top bars on the same view:

![MonsterItemViewer Tab 1](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/pr-feat743-MonsterItemViewer.png?raw=1)

World Map Event Editor — Before AND After top bars both migrated in the same view:

![WorldMapEventPointer](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/pr-feat743-WorldMapEventPointer.png?raw=1)

Skill Assignment (Class) — Start Address / Read Count / Reload trio at top:

![SkillAssignmentClassSkillSystem](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/pr-feat743-SkillAssignmentClassSkillSystem.png?raw=1)

Skill Configuration (FE8N v2) — unified top bar identical to other Skill Configs:

![SkillConfigFE8NVer2](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/pr-feat743-SkillConfigFE8NVer2.png?raw=1)

## GUI Test Report

**Environment:** Windows 11, .NET 9.0.314, Avalonia 11.2.3, ROM: `roms/FE8U.gba`
**Capture method:** `dotnet run --project FEBuilderGBA.Avalonia -c Release -- --rom roms/FE8U.gba --screenshot-all --screenshot-dir=/tmp/feat743-screenshots`
**Coverage:** All 325 editor views launched and rendered without crash; 5 of the migrated set (representative subset incl. the 3-tab MonsterItem and 2-bar WorldMapEvent multi-instance hosts) captured for visual proof.

| Editor | Launches | TopBar renders | InputsEnabled UX | Reload wired | Verdict |
|--------|----------|----------------|------------------|--------------|---------|
| SkillConfigSkillSystemView | YES | YES | Disabled inputs visible | YES (routed event) | PASS |
| SkillConfigFE8NVer2SkillView | YES | YES | Disabled inputs visible | YES (routed event) | PASS |
| SkillConfigFE8NVer3SkillView | YES | YES | Disabled inputs visible | YES (routed event) | PASS |
| SkillConfigFE8UCSkillSys09xView | YES | YES | Disabled inputs visible | YES (routed event) | PASS |
| SkillAssignmentClassSkillSystemView | YES | YES | Disabled inputs visible | YES (routed event) | PASS |
| SkillAssignmentClassCSkillSysView | YES | YES | Editable (was editable pre-migration) | YES (routed event) | PASS |
| WorldMapEventPointerView (Before + After) | YES | YES x2 | IsReadOnly via InputsEnabled=False | YES x2 (routed events) | PASS |
| MonsterItemViewerView (Item + Prob + Holding) | YES | YES x3 | Editable on all 3 tabs | YES x3 (routed events) | PASS |

## Scope

Ref #743 — this PR migrates **8 of the 15** deferred editors. The remaining 7 are deferred for per-cluster follow-up PRs (see Deferred table above), so the issue stays OPEN with the deferred remainder documented in the test allow-list (`EditorTopBarMigrationSweepTests.KnownDeferredEditor_NotInMigratedList`).

## Test plan

- [x] All 224 targeted tests pass locally (62 EditorTopBarMigrationSweep + 102 SkillConfig/Assignment + WorldMap parity + 28 MonsterItem + 8 updated parity tests)
- [x] Full Avalonia.Tests suite: 7042 passed, 3 skipped (no migration-related failures)
- [x] Core.Tests suite: 1988 passed
- [x] CLI builds clean (no errors)
- [x] Avalonia app launches against FE8U.gba and all 325 editors render via `--screenshot-all` without crash
- [x] Visual proof for 5 editors (incl. multi-instance MonsterItem + WorldMapEvent) captured on master via #744 + linked above
- [x] Pre-migration AutomationIds (e.g. `SkillConfigSkillSystem_ReloadList_Button`, `MonsterItemViewer_Item_ReadStart_Input`) verified preserved by re-running the existing GapSweep parity tests (which keep passing)

Original prompt: pua:pua — I checked the issues you resolved, left comments and reopened them, many are unresolved at all

Generated with Claude Code (claude-opus-4-7-1m)
