### PR TITLE
fix(winforms): guard ToolThreeMargeForm close against null ChangeDataList (#746)

### DIFF
--- a/FEBuilderGBA.Tests/Unit/ToolThreeMargeFormCloseTests.cs
+++ b/FEBuilderGBA.Tests/Unit/ToolThreeMargeFormCloseTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.ComponentModel;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Windows.Forms;
+using Xunit;
+
+namespace FEBuilderGBA.Tests.Unit
+{
+    /// <summary>
+    /// Regression coverage for issue #746 — scheduled E2E (FE6) crashed with
+    /// <see cref="NullReferenceException"/> when the screenshot runner closed
+    /// <see cref="FEBuilderGBA.ToolThreeMargeForm"/> without first running a
+    /// three-way merge. The form's <c>FormClosing</c> handler iterates
+    /// <c>ChangeDataList.Count</c>, but the list is only populated by the real
+    /// merge-setup paths — so the smoke-opened form blew up on close.
+    ///
+    /// These tests exercise the two private helpers and the closing handler on
+    /// a freshly-constructed form (no merge init) and confirm that the null
+    /// guards make them safe.
+    /// </summary>
+    [Collection("SharedState")]
+    public class ToolThreeMargeFormCloseTests
+    {
+        [Fact]
+        public void IsAllMethodNone_ReturnsTrue_WhenChangeDataListIsNull()
+        {
+            RunOnStaThread(() =>
+            {
+                using var form = new ToolThreeMargeForm();
+                var method = typeof(ToolThreeMargeForm).GetMethod(
+                    "isAllMethodNone",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.NotNull(method);
+
+                var result = method!.Invoke(form, Array.Empty<object>());
+                Assert.IsType<bool>(result);
+                Assert.True((bool)result!,
+                    "isAllMethodNone() must return true for a never-initialized form so FormClosing can exit cleanly.");
+            });
+        }
+
+        [Fact]
+        public void IsAllMethodNotNone_ReturnsTrue_WhenChangeDataListIsNull()
+        {
+            RunOnStaThread(() =>
+            {
+                using var form = new ToolThreeMargeForm();
+                var method = typeof(ToolThreeMargeForm).GetMethod(
+                    "isAllMethodNotNone",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.NotNull(method);
+
+                var result = method!.Invoke(form, Array.Empty<object>());
+                Assert.IsType<bool>(result);
+                Assert.True((bool)result!,
+                    "isAllMethodNotNone() must return true for a never-initialized form so FormClosing can exit cleanly.");
+            });
+        }
+
+        [Fact]
+        public void FormClosing_DoesNotThrow_OnEmptyForm()
+        {
+            RunOnStaThread(() =>
+            {
+                using var form = new ToolThreeMargeForm();
+                var handler = typeof(ToolThreeMargeForm).GetMethod(
+                    "ToolThreeMargeForm_FormClosing",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.NotNull(handler);
+
+                // Invoke the handler directly with a non-cancelling close event.
+                // Pre-#746 this threw NullReferenceException from isAllMethodNone()
+                // because ChangeDataList was null.
+                var args = new FormClosingEventArgs(CloseReason.UserClosing, cancel: false);
+                var ex = Record.Exception(() =>
+                    handler!.Invoke(form, new object[] { form, args }));
+
+                Assert.Null(ex);
+                // The empty-form path returns early — cancel must remain false
+                // so the screenshot runner can actually close the window.
+                Assert.False(args.Cancel,
+                    "FormClosing on an uninitialized form must not cancel — there is no merge state to protect.");
+            });
+        }
+
+        /// <summary>
+        /// WinForms requires single-threaded apartment. Mirrors the helper
+        /// used by <c>OptionFormLayoutTests</c>.
+        /// </summary>
+        private static void RunOnStaThread(Action body)
+        {
+            ExceptionDispatchInfo? edi = null;
+            var thread = new Thread(() =>
+            {
+                try { body(); }
+                catch (Exception ex) { edi = ExceptionDispatchInfo.Capture(ex); }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.IsBackground = true;
+            thread.Start();
+
+            if (!thread.Join(TimeSpan.FromSeconds(30)))
+                throw new TimeoutException("STA thread did not complete within 30 seconds");
+
+            edi?.Throw();
+        }
+    }
+}

--- a/FEBuilderGBA.Tests/Unit/ToolThreeMargeFormCloseTests.cs
+++ b/FEBuilderGBA.Tests/Unit/ToolThreeMargeFormCloseTests.cs
@@ -1,9 +1,9 @@
 using System;
-using System.ComponentModel;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Windows.Forms;
+using FEBuilderGBA;
 using Xunit;
 
 namespace FEBuilderGBA.Tests.Unit

--- a/FEBuilderGBA/ToolThreeMargeForm.cs
+++ b/FEBuilderGBA/ToolThreeMargeForm.cs
@@ -782,6 +782,11 @@ namespace FEBuilderGBA
 
         bool isAllMethodNone()
         {
+            // Guard for screenshot/smoke-mode runs that open the form without
+            // initializing a merge (#746). With no rows there is nothing to
+            // confirm on close, so treat null as "all none" — FormClosing then
+            // exits early without showing the close-alert dialog.
+            if (this.ChangeDataList == null) return true;
             for (int i = 0; i < this.ChangeDataList.Count; i++)
             {
                 if (this.ChangeDataList[i].method != MargeMethod.NONE)
@@ -794,6 +799,8 @@ namespace FEBuilderGBA
 
         bool isAllMethodNotNone()
         {
+            // Guard for screenshot/smoke-mode runs (#746); see isAllMethodNone.
+            if (this.ChangeDataList == null) return true;
             for (int i = 0; i < this.ChangeDataList.Count; i++)
             {
                 if (this.ChangeDataList[i].method == MargeMethod.NONE)


### PR DESCRIPTION
## Summary

Fixes the daily FE6 scheduled-E2E pipeline crash reported in #746.

The screenshot-runner opens every WinForms editor in turn and then closes it. Closing `ToolThreeMargeForm` (the Three-Way Merge tool) threw `NullReferenceException` because its `FormClosing` handler called `isAllMethodNone()` / `isAllMethodNotNone()`, both of which iterated `this.ChangeDataList.Count` — but `ChangeDataList` is only populated by the real three-way merge initialization path. For a smoke-opened form it was `null`.

### Root cause

```
ERROR: System.NullReferenceException: Object reference not set to an instance of an object.
   at FEBuilderGBA.ToolThreeMargeForm.isAllMethodNone() in FEBuilderGBA/ToolThreeMargeForm.cs:line 785
   at FEBuilderGBA.ToolThreeMargeForm.ToolThreeMargeForm_FormClosing(...) in FEBuilderGBA/ToolThreeMargeForm.cs:line 809
```

Failing run: https://github.com/laqieer/FEBuilderGBA/actions/runs/26605463898

### Fix

Two null guards in `FEBuilderGBA/ToolThreeMargeForm.cs`. If `ChangeDataList` is null, treat it as "no rows" — return `true` from both helpers. The combined check in `FormClosing` is `if (isAllMethodNone() || isAllMethodNotNone()) return;`, so both returning `true` means the close-alert dialog is never shown for an empty form. Correct behavior — there is no pending merge state to protect.

```csharp
bool isAllMethodNone()
{
    if (this.ChangeDataList == null) return true;
    // ...existing loop...
}

bool isAllMethodNotNone()
{
    if (this.ChangeDataList == null) return true;
    // ...existing loop...
}
```

The populated-form path (real three-way merge in progress) is unchanged.

### Plan + Copilot review

Implementation plan + Copilot CLI accept: https://github.com/laqieer/FEBuilderGBA/issues/746#issuecomment-4569024971

## Scope

Closes #746

## Screenshot proof

Three new regression tests pass — captured from a real console window via PrintWindow (not fabricated):

![Test output proof](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/pr-fix746-test-output.png?raw=1)

Screenshot landed on master first via #749 so the URL is stable.

## GUI Test Report

This is a WinForms-only fix; the bug only surfaces when the WinForms screenshot-runner closes `ToolThreeMargeForm` without first invoking a three-way merge. The repository's primary GUI surface for new development is the Avalonia app, so MCP computer-use against the WinForms editor is not the right tool here. Coverage and proof are provided via the regression tests below, captured running on a real console window.

| Step | Result | Notes |
| --- | --- | --- |
| `IsAllMethodNone_ReturnsTrue_WhenChangeDataListIsNull` | PASS | Reflects the private helper on a freshly-constructed `ToolThreeMargeForm`. Without the fix, this throws `NullReferenceException` from the helper. |
| `IsAllMethodNotNone_ReturnsTrue_WhenChangeDataListIsNull` | PASS | Same coverage for the second helper. |
| `FormClosing_DoesNotThrow_OnEmptyForm` | PASS | Drives the actual `ToolThreeMargeForm_FormClosing` handler via reflection with a non-cancelling `FormClosingEventArgs`. Asserts no exception, and that `Cancel` stays false so the screenshot runner can actually close the window. Reproduces the E2E NRE against the un-patched source; passes with the fix. |
| Manual verification: re-ran tests against un-patched source | PASS | Tests fail (3/3 NRE); restoring the fix makes them pass (3/3). Pinning is real, not vacuous. |

The FE6 scheduled-E2E pipeline is the natural integration smoke for this fix — once merged, the daily schedule will exercise the same `ToolThreeMargeForm` open-then-close path with a real ROM and confirm the regression is gone end-to-end.

## Test plan

- [x] Added `FEBuilderGBA.Tests/Unit/ToolThreeMargeFormCloseTests.cs` with 3 regression tests on an STA thread (matching `OptionFormLayoutTests`).
- [x] Verified all 3 tests fail against the un-patched source with `NullReferenceException` thrown from the relevant frame.
- [x] Verified all 3 tests pass with the fix applied.
- [x] Ran the broader related-tests set (`ToolThreeMarge|ThreeMarge|ScreenshotMode|OptionFormLayout|WinFormsScreenshotRegistry`) — 19/19 passed, no regressions.
- [x] Confirmed the populated-form path (with a real merge in progress) is unchanged — guards are no-ops when `ChangeDataList` is non-null.
- [x] Screenshot proof captured from a real console window via PrintWindow, no synthetic Bitmap drawing.
- [x] Screenshot landed on master via docs PR #749 so the link survives squash-merge of this branch.

Original prompt: pua:pua — I checked the issues you resolved, left comments and reopened them, many are unresolved at all

Generated with Claude Code (claude-opus-4-7-1m)
