### PR TITLE
fix(avalonia): real AI-script disassembly display instead of hex dump (#757)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/AIScriptDisassemblyTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/AIScriptDisassemblyTests.cs
@@ -1,0 +1,424 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// AIScriptViewModel.DisassembleScript regression tests (#757).
+//
+// Proves the Avalonia AI Script editor shows REAL opcode disassembly
+// (mnemonic + decoded args + comment) instead of a raw 16-byte hex dump,
+// and that AI scripts decode on a FIXED 16-byte instruction grid:
+//   - a known opcode renders its mnemonic / args (not a bare hex line);
+//   - an UNKNOWN opcode consumes exactly ONE 16-byte row (width-16
+//     regression — it would be four 4-byte rows if the unknown width
+//     were the default 4);
+//   - EXIT (0x03) followed by a 0x1B/0x1C continuation keeps BOTH slots
+//     (the CalcScriptLength range is respected, no early stop);
+//   - a ReadByteCount that is not a multiple of 16 surfaces an explicit
+//     [partial ...] row;
+//   - a malformed DisAseemble throw degrades to a [Disassembly error]
+//     row and terminates the loop (no hang).
+//
+// Marked [Collection("SharedState")] because these tests mutate
+// CoreState.ROM / CoreState.AIScript / CoreState.BaseDirectory.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using global::Avalonia.Controls;
+using global::Avalonia.Headless.XUnit;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class AIScriptDisassemblyTests
+    {
+        // The old hex-dump format every row used to take: "0xADDR: NN NN NN ...".
+        // Disassembled rows must NOT match this (they carry a mnemonic).
+        static readonly Regex OldHexDumpRow =
+            new Regex(@"^0x[0-9A-Fa-f]+: ([0-9A-Fa-f]{2} )+$");
+
+        // ----------------------------------------------------------------
+        // 1. Known opcode renders mnemonic + args (NOT a bare hex line).
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void DisassembleScript_KnownOpcode_RendersMnemonicAndArgs()
+        {
+            using var env = new AiDisasmEnv();
+
+            // EXIT opcode: 03 00 FF 11 + 12 zero bytes. byte[3]=0x11 is the
+            // EXIT "id" arg, so the row must show both "EXIT" and "id".
+            byte[] body = ExitOpcode(0x11);
+            var vm = env.LoadVmAt(body);
+
+            IReadOnlyList<string> rows = vm.DisassembleScript();
+
+            Assert.NotEmpty(rows);
+            string first = rows[0];
+            Assert.DoesNotMatch(OldHexDumpRow, first);
+            Assert.Contains("EXIT", first);
+            // Decoded arg name (id) and its value (0x11) must be present.
+            Assert.Contains("id=", first);
+            Assert.Contains("0x11", first);
+        }
+
+        [Fact]
+        public void DisassembleScript_KnownOpcode_DoNothing_RendersMnemonic()
+        {
+            using var env = new AiDisasmEnv();
+
+            // DoNothing opcode: 06 00 FF 00 + 12 zero bytes. No non-FIXED args.
+            byte[] body = DoNothingOpcode();
+            var vm = env.LoadVmAt(body);
+
+            IReadOnlyList<string> rows = vm.DisassembleScript();
+
+            Assert.Single(rows);
+            Assert.DoesNotMatch(OldHexDumpRow, rows[0]);
+            Assert.Contains("DoNothing", rows[0]);
+        }
+
+        // ----------------------------------------------------------------
+        // 2. Width-16 regression: an UNKNOWN opcode consumes ONE 16-byte row.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void DisassembleScript_UnknownOpcode_ConsumesExactlyOne16ByteRow()
+        {
+            using var env = new AiDisasmEnv();
+
+            // 0xEE is > the max AI opcode (0x1C) so it matches NO known
+            // script. All-0xEE fills also fail every pointer-arg match, so
+            // the row falls through to the Unknown script. With width-16,
+            // that's ONE row; with the (wrong) default width-4 it would be
+            // FOUR rows.
+            byte[] body = new byte[16];
+            for (int i = 0; i < 16; i++) body[i] = 0xEE;
+
+            var vm = env.LoadVmAt(body);
+            IReadOnlyList<string> rows = vm.DisassembleScript();
+
+            Assert.Single(rows);
+            Assert.Equal(16u, vm.ReadByteCount);
+        }
+
+        // ----------------------------------------------------------------
+        // 3. EXIT (0x03) + 0x1B / 0x1C continuation -> both slots present.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void DisassembleScript_ExitThen0x1BContinuation_KeepsBothSlots()
+        {
+            using var env = new AiDisasmEnv();
+
+            // EXIT (03 00 FF 00) followed by NoOp (1B 00 FF 22). CalcLength
+            // keeps walking past EXIT because 0x1B is a continuation opcode.
+            var body = new List<byte>();
+            body.AddRange(ExitOpcode(0x00));
+            body.AddRange(OpcodeWithArg(0x1B, 0x22)); // NoOp
+            body.AddRange(ExitOpcode(0x00));          // real terminator
+
+            var vm = env.LoadVmAt(body.ToArray());
+            IReadOnlyList<string> rows = vm.DisassembleScript();
+
+            // At least the EXIT slot and the 0x1B continuation slot must be
+            // present (range respected, no early stop on the first EXIT).
+            Assert.True(rows.Count >= 2,
+                $"Expected >=2 rows (EXIT + continuation), got {rows.Count}");
+            Assert.Contains("EXIT", rows[0]);
+            Assert.Contains(rows, r => r.Contains("NoOp"));
+        }
+
+        [Fact]
+        public void DisassembleScript_ExitThen0x1CContinuation_KeepsBothSlots()
+        {
+            using var env = new AiDisasmEnv();
+
+            var body = new List<byte>();
+            body.AddRange(ExitOpcode(0x00));
+            body.AddRange(OpcodeWithArg(0x1C, 0x05)); // FE8LABEL
+            body.AddRange(ExitOpcode(0x00));
+
+            var vm = env.LoadVmAt(body.ToArray());
+            IReadOnlyList<string> rows = vm.DisassembleScript();
+
+            Assert.True(rows.Count >= 2,
+                $"Expected >=2 rows (EXIT + 0x1C continuation), got {rows.Count}");
+            Assert.Contains("EXIT", rows[0]);
+            Assert.Contains(rows, r => r.Contains("FE8LABEL"));
+        }
+
+        // ----------------------------------------------------------------
+        // 4. ReadByteCount NOT a multiple of 16 -> explicit [partial ...] row.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void DisassembleScript_PartialRemainder_AppendsPartialRow()
+        {
+            using var env = new AiDisasmEnv();
+
+            // One full DoNothing (16 bytes) + 5 trailing bytes = 21 bytes.
+            byte[] body = DoNothingOpcode();
+            var vm = env.LoadVmAt(body);
+            // Force a ReadByteCount that is NOT a multiple of 16 (16 + 5).
+            vm.ReadByteCount = 21;
+
+            IReadOnlyList<string> rows = vm.DisassembleScript();
+
+            Assert.Equal(2, rows.Count);
+            Assert.Contains("DoNothing", rows[0]);
+            Assert.Contains("[partial 16-byte instruction", rows[1]);
+            Assert.Contains("5 bytes", rows[1]);
+        }
+
+        // ----------------------------------------------------------------
+        // 5. Malformed / DisAseemble-throws -> [Disassembly error] + stop.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void DisassembleScript_DisAseembleThrows_AddsErrorRowAndStops()
+        {
+            using var env = new AiDisasmEnv();
+
+            byte[] body = DoNothingOpcode();
+            var vm = env.LoadVmAt(body);
+            vm.ReadByteCount = 16;
+
+            // Drive a REAL throw through the production code path: the base
+            // EventScript.DisAseemble does `CoreState.CommentCache.At(addr)`
+            // on a match, so nulling the comment cache makes DisAseemble
+            // throw a NullReferenceException. The VM loop must catch it,
+            // append a [Disassembly error] row, and terminate (no hang).
+            IEtcCache? prev = CoreState.CommentCache;
+            try
+            {
+                CoreState.CommentCache = null;
+                IReadOnlyList<string> rows = vm.DisassembleScript();
+                Assert.Single(rows);
+                Assert.Contains("[Disassembly error]", rows[0]);
+            }
+            finally
+            {
+                CoreState.CommentCache = prev;
+            }
+        }
+
+        [Fact]
+        public void DisassembleScript_NotLoaded_ReturnsEmpty()
+        {
+            using var env = new AiDisasmEnv();
+            byte[] body = DoNothingOpcode();
+            var vm = env.LoadVmAt(body);
+
+            // Guard: IsLoaded == false short-circuits to an empty list.
+            vm.IsLoaded = false;
+            Assert.Empty(vm.DisassembleScript());
+
+            // Guard: CurrentAddr == 0 also short-circuits.
+            vm.IsLoaded = true;
+            vm.CurrentAddr = 0;
+            Assert.Empty(vm.DisassembleScript());
+        }
+
+        [Fact]
+        public void DisassembleScript_PathologicalRange_DoesNotOverflowOrCrash()
+        {
+            using var env = new AiDisasmEnv();
+            byte[] body = DoNothingOpcode();
+            var vm = env.LoadVmAt(body);
+
+            // Hand-typed worst case: CurrentAddr + ReadByteCount near
+            // uint.MaxValue. Naive `off + 16 <= end` would wrap and call
+            // DisAseemble out of bounds; the (ulong) clamp must keep `end`
+            // at the ROM length and skip the loop entirely (no row, no
+            // crash). CurrentAddr is non-zero / past ROM end here.
+            vm.CurrentAddr = 0xFFFFFFF0;
+            vm.ReadByteCount = 0x7FFFFFFF;
+
+            IReadOnlyList<string> rows = vm.DisassembleScript();
+            Assert.Empty(rows);
+        }
+
+        // ----------------------------------------------------------------
+        // 7. Headless UI: AIScriptView.ReloadList_Click populates the
+        //    Disassembly ListBox with REAL opcode rows (not the old hex dump).
+        // ----------------------------------------------------------------
+
+        [AvaloniaFact]
+        public void View_ReloadList_PopulatesDisassemblyWithDecodedRows()
+        {
+            using var env = new AiDisasmEnv();
+            // Plant a real EXIT opcode (03 00 FF 09) + a pointer slot to it.
+            env.PlantBody(ExitOpcode(0x09), out uint pointerSlotAddr);
+
+            var view = new AIScriptView();
+            var addressBox = view.FindControl<NumericUpDown>("AddressBox");
+            var byteCountBox = view.FindControl<NumericUpDown>("ReadByteCountBox");
+            var list = view.FindControl<ListBox>("DisassemblyList");
+            Assert.NotNull(addressBox);
+            Assert.NotNull(byteCountBox);
+            Assert.NotNull(list);
+
+            // Drive the view's own VM through LoadEntry (sets IsLoaded /
+            // CurrentAddr / ReadByteCount) exactly as a list selection would.
+            var vmField = typeof(AIScriptView).GetField(
+                "_vm",
+                System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.NonPublic);
+            Assert.NotNull(vmField);
+            var vm = (AIScriptViewModel)vmField!.GetValue(view)!;
+            vm.LoadEntry(pointerSlotAddr);
+            Assert.True(vm.IsLoaded);
+
+            // Mirror the UI: the boxes carry the resolved address / length.
+            addressBox!.Value = vm.CurrentAddr;
+            byteCountBox!.Value = vm.ReadByteCount;
+
+            // The "re-read" handler is private; invoke it the same way the
+            // Reload button click would.
+            var handler = typeof(AIScriptView).GetMethod(
+                "ReloadList_Click",
+                System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.NonPublic);
+            Assert.NotNull(handler);
+            handler!.Invoke(view, new object?[] { null, new global::Avalonia.Interactivity.RoutedEventArgs() });
+
+            var rows = (list!.ItemsSource as IEnumerable<string>)?.ToList()
+                       ?? new List<string>();
+            Assert.NotEmpty(rows);
+            // Rows must be decoded mnemonics, NOT the old bare hex dump.
+            Assert.All(rows, r => Assert.DoesNotMatch(OldHexDumpRow, r));
+            Assert.Contains(rows, r => r.Contains("EXIT"));
+        }
+
+        // ----------------------------------------------------------------
+        // Opcode body helpers (16-byte AI instruction slots, FE8 table).
+        // ----------------------------------------------------------------
+
+        // EXIT: 03 00 FF XX 00... -> "EXIT [XX::id]".
+        static byte[] ExitOpcode(byte id)
+        {
+            var b = new byte[16];
+            b[0] = 0x03; b[1] = 0x00; b[2] = 0xFF; b[3] = id;
+            return b;
+        }
+
+        // DoNothing: 06 00 FF 00 00... -> "DoNothing" (no non-FIXED args).
+        static byte[] DoNothingOpcode()
+        {
+            var b = new byte[16];
+            b[0] = 0x06; b[1] = 0x00; b[2] = 0xFF;
+            return b;
+        }
+
+        // Generic single-arg opcode: OP 00 FF XX 00... (matches the 0x1B /
+        // 0x1C continuation formats: "1B00FFXX..." / "1C00FFXX...").
+        static byte[] OpcodeWithArg(byte op, byte arg)
+        {
+            var b = new byte[16];
+            b[0] = op; b[1] = 0x00; b[2] = 0xFF; b[3] = arg;
+            return b;
+        }
+    }
+
+    /// <summary>
+    /// Self-contained synthetic FE8U environment for AI disassembly tests.
+    /// Sets CoreState.ROM to a tiny FE8 ROM, CoreState.BaseDirectory to the
+    /// test output dir (where config/ is copied), wires a HeadlessEtcCache
+    /// for the comment lookup DisAseemble does, and loads a fresh
+    /// width-16 CoreState.AIScript against the FE8 AI definitions. Restores
+    /// the prior CoreState on Dispose.
+    /// </summary>
+    sealed class AiDisasmEnv : IDisposable
+    {
+        const uint ScriptBase = 0x200000; // in-ROM offset for the script body
+
+        readonly ROM? _prevRom;
+        readonly EventScript? _prevAi;
+        readonly IEtcCache? _prevComment;
+        readonly string? _prevBaseDir;
+
+        readonly ROM _rom;
+
+        public AiDisasmEnv()
+        {
+            _prevRom = CoreState.ROM;
+            _prevAi = CoreState.AIScript;
+            _prevComment = CoreState.CommentCache;
+            _prevBaseDir = CoreState.BaseDirectory;
+
+            // BaseDirectory must point at the test output dir so the AI
+            // config (config/data/aiscript_FE8.*.txt) resolves.
+            string asmDir = Path.GetDirectoryName(
+                System.Reflection.Assembly.GetExecutingAssembly().Location) ?? ".";
+            CoreState.BaseDirectory = asmDir;
+
+            _rom = new ROM();
+            _rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01"); // FE8U
+
+            CoreState.ROM = _rom;
+            // DisAseemble reads CommentCache.At(offset); a HeadlessEtcCache
+            // returns "" and never NREs.
+            CoreState.CommentCache = new HeadlessEtcCache();
+
+            // Fresh width-16 AI script against THIS FE8 ROM (deterministic
+            // regardless of whatever ROM the shared fixture loaded).
+            var ai = new EventScript(16);
+            ai.Load(EventScript.EventScriptType.AI);
+            CoreState.AIScript = ai;
+        }
+
+        /// <summary>
+        /// Plant the given AI script body at the fixed in-ROM offset, build
+        /// an AIScriptViewModel pointing at it, and set IsLoaded /
+        /// CurrentAddr / ReadByteCount as LoadEntry would. Callers that need
+        /// a partial remainder simply override vm.ReadByteCount afterward
+        /// (the trailing ROM bytes are already valid zero bytes).
+        /// </summary>
+        public AIScriptViewModel LoadVmAt(byte[] body)
+        {
+            Array.Copy(body, 0, _rom.Data, (int)ScriptBase, body.Length);
+
+            var vm = new AIScriptViewModel
+            {
+                CurrentAddr = ScriptBase,
+                ReadByteCount = (uint)body.Length,
+                IsLoaded = true,
+            };
+            return vm;
+        }
+
+        const uint PointerSlot = 0x100000; // in-ROM pointer slot for LoadEntry
+
+        /// <summary>
+        /// Plant a body at the fixed in-ROM offset AND a pointer slot that
+        /// points at it (GBA address 0x08000000 + ScriptBase). Returns the
+        /// pointer-slot address so the headless view test can drive the
+        /// VM's LoadEntry (which follows the slot, computes the byte length
+        /// via CalcScriptLength, and sets IsLoaded). Used by the headless
+        /// view test, which drives the View instead of the VM directly.
+        /// </summary>
+        public void PlantBody(byte[] body, out uint pointerSlotAddr)
+        {
+            Array.Copy(body, 0, _rom.Data, (int)ScriptBase, body.Length);
+            // Plant the pointer slot -> 0x08000000 + ScriptBase.
+            uint gbaPtr = 0x08000000u + ScriptBase;
+            _rom.Data[PointerSlot + 0] = (byte)(gbaPtr & 0xFF);
+            _rom.Data[PointerSlot + 1] = (byte)((gbaPtr >> 8) & 0xFF);
+            _rom.Data[PointerSlot + 2] = (byte)((gbaPtr >> 16) & 0xFF);
+            _rom.Data[PointerSlot + 3] = (byte)((gbaPtr >> 24) & 0xFF);
+            pointerSlotAddr = PointerSlot;
+        }
+
+        public void Dispose()
+        {
+            CoreState.ROM = _prevRom;
+            CoreState.AIScript = _prevAi;
+            CoreState.CommentCache = _prevComment;
+            if (_prevBaseDir != null)
+                CoreState.BaseDirectory = _prevBaseDir;
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/AIScriptDisassemblyTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/AIScriptDisassemblyTests.cs
@@ -405,10 +405,12 @@ namespace FEBuilderGBA.Avalonia.Tests
             Array.Copy(body, 0, _rom.Data, (int)ScriptBase, body.Length);
             // Plant the pointer slot -> 0x08000000 + ScriptBase.
             uint gbaPtr = 0x08000000u + ScriptBase;
-            _rom.Data[PointerSlot + 0] = (byte)(gbaPtr & 0xFF);
-            _rom.Data[PointerSlot + 1] = (byte)((gbaPtr >> 8) & 0xFF);
-            _rom.Data[PointerSlot + 2] = (byte)((gbaPtr >> 16) & 0xFF);
-            _rom.Data[PointerSlot + 3] = (byte)((gbaPtr >> 24) & 0xFF);
+            // PointerSlot is uint; index with explicit (int) for clarity and to
+            // match the (int)ScriptBase cast used elsewhere in this file.
+            _rom.Data[(int)PointerSlot + 0] = (byte)(gbaPtr & 0xFF);
+            _rom.Data[(int)PointerSlot + 1] = (byte)((gbaPtr >> 8) & 0xFF);
+            _rom.Data[(int)PointerSlot + 2] = (byte)((gbaPtr >> 16) & 0xFF);
+            _rom.Data[(int)PointerSlot + 3] = (byte)((gbaPtr >> 24) & 0xFF);
             pointerSlotAddr = PointerSlot;
         }
 
@@ -417,8 +419,9 @@ namespace FEBuilderGBA.Avalonia.Tests
             CoreState.ROM = _prevRom;
             CoreState.AIScript = _prevAi;
             CoreState.CommentCache = _prevComment;
-            if (_prevBaseDir != null)
-                CoreState.BaseDirectory = _prevBaseDir;
+            // Restore unconditionally (including null) so a null prior value is
+            // not leaked as the overridden test dir into later tests.
+            CoreState.BaseDirectory = _prevBaseDir;
         }
     }
 }

--- a/FEBuilderGBA.Avalonia/ViewModels/AIScriptCategorySelectViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/AIScriptCategorySelectViewModel.cs
@@ -107,7 +107,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             {
                 try
                 {
-                    es = new EventScript();
+                    // AI scripts use a FIXED 16-byte instruction grid — the
+                    // unknown-opcode width must be 16 (parity with WinForms
+                    // Program.cs `new EventScript(16)`), otherwise an
+                    // unrecognized opcode decodes as four 4-byte rows (#757).
+                    es = new EventScript(16);
                     es.Load(EventScript.EventScriptType.AI);
                     CoreState.AIScript = es;
                 }

--- a/FEBuilderGBA.Avalonia/ViewModels/AIScriptViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/AIScriptViewModel.cs
@@ -29,6 +29,13 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         bool _isLoaded;
         bool _isLoading;
 
+        // Display-only disassembly backing state (#757). Populated by
+        // DisassembleScript() and kept around for possible future row
+        // selection. NO edit/write state lives here — opcode write-back is
+        // still deferred (see Write()/Write_Click).
+        readonly List<EventScript.OneCode> _disassembled = new();
+        readonly List<uint> _rowOffsets = new();
+
         // ----------------------------------------------------------------
         // Public observable properties
         // ----------------------------------------------------------------
@@ -265,6 +272,143 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 }
             }
             return addr - start;
+        }
+
+        // ----------------------------------------------------------------
+        // Disassembly (display-only, #757)
+        // ----------------------------------------------------------------
+
+        /// <summary>
+        /// Disassemble the currently-loaded AI script into human-readable
+        /// display lines (mnemonic + decoded args + comment), replacing the
+        /// raw hex dump the Avalonia editor used to show. Mirrors the
+        /// EventScriptViewModel.DisassembleAt rendering loop, but walks the
+        /// FIXED 16-byte AI instruction grid: WinForms AIScriptForm.CalcLength
+        /// steps by 16 and the shared CoreState.AIScript is built with
+        /// `new EventScript(16)` so an unrecognized opcode decodes as ONE
+        /// 16-byte WORD row (not four 4-byte rows).
+        ///
+        /// This is display-only: it populates the backing _disassembled /
+        /// _rowOffsets lists for possible future row selection but does NOT
+        /// touch any edit/write state. The byte range to walk is the
+        /// [CurrentAddr, CurrentAddr + ReadByteCount) window computed by
+        /// CalcScriptLength, which already encodes the EXIT / continuation
+        /// semantics — so we deliberately do NOT early-break on
+        /// ScriptHas.TERM and always advance by the 16-byte grid step.
+        /// </summary>
+        public IReadOnlyList<string> DisassembleScript()
+        {
+            _disassembled.Clear();
+            _rowOffsets.Clear();
+
+            var lines = new List<string>();
+
+            ROM rom = CoreState.ROM;
+            if (rom == null || rom.Data == null || !IsLoaded || CurrentAddr == 0)
+                return lines;
+
+            // Ensure the shared AI EventScript is loaded. Mirror
+            // EventScriptViewModel's lazy-load guard, but with the AI
+            // unknown-opcode width of 16 (#757).
+            EventScript es = CoreState.AIScript;
+            if (es == null || es.Scripts == null || es.Scripts.Length == 0)
+            {
+                try
+                {
+                    es = new EventScript(16);
+                    es.Load(EventScript.EventScriptType.AI);
+                    CoreState.AIScript = es;
+                }
+                catch (Exception ex)
+                {
+                    lines.Add($"[Error loading AI script definitions: {ex.Message}]");
+                    return lines;
+                }
+            }
+
+            // Clamp the end to the ROM length with overflow-safe (ulong)
+            // arithmetic — a hand-typed CurrentAddr + ReadByteCount near
+            // uint.MaxValue must NOT wrap (mirrors the old view guard's
+            // (ulong) cast that this method subsumes).
+            uint end = (uint)Math.Min(
+                (ulong)CurrentAddr + ReadByteCount, (ulong)rom.Data.Length);
+
+            // Walk COMPLETE 16-byte slots only. `stopped` tracks an early bail
+            // (disassembly error / decode failure) so we don't tack a bogus
+            // "partial" row onto a run we terminated mid-stream. The loop
+            // bound uses (ulong) so `off + 16` can't wrap past end.
+            uint off = CurrentAddr;
+            bool stopped = false;
+            for (; (ulong)off + 16 <= end; off += 16)
+            {
+                EventScript.OneCode code;
+                try
+                {
+                    code = es.DisAseemble(rom.Data, off);
+                }
+                catch
+                {
+                    lines.Add($"0x{off:X06}: [Disassembly error]");
+                    stopped = true;
+                    break;
+                }
+
+                if (code == null || code.ByteData == null)
+                {
+                    lines.Add($"0x{off:X06}: [Failed to decode]");
+                    stopped = true;
+                    break;
+                }
+
+                _disassembled.Add(code);
+                _rowOffsets.Add(off);
+                lines.Add(FormatAiRow(code, off));
+            }
+
+            // Trailing partial remainder: a ReadByteCount that is not a
+            // multiple of 16 leaves 1..15 bytes that can't form a full
+            // instruction. Only surfaced when the slot walk ran to completion
+            // (not after an early error/decode-failure break).
+            if (!stopped && off < end)
+            {
+                uint n = end - off;
+                lines.Add($"0x{off:X06}: [partial 16-byte instruction — {n} bytes]");
+            }
+
+            return lines;
+        }
+
+        /// <summary>
+        /// Render a single decoded AI opcode as a display line:
+        /// "0xADDR: MNEMONIC  [hex bytes]  argName=value, ...  // comment".
+        /// Mirrors the EventScriptViewModel row format. AI-specific only in
+        /// that it is fed 16-byte instruction slots.
+        /// </summary>
+        static string FormatAiRow(EventScript.OneCode code, uint off)
+        {
+            string cmdName = EventScript.makeCommandComboText(code.Script, false);
+            string hexBytes = U.HexDumpLiner(code.ByteData).Trim();
+            string line = $"0x{off:X06}: {cmdName}  [{hexBytes}]";
+
+            if (code.Script != null && code.Script.Args != null && code.Script.Args.Length > 0)
+            {
+                var argParts = new List<string>();
+                for (int i = 0; i < code.Script.Args.Length; i++)
+                {
+                    var arg = code.Script.Args[i];
+                    if (arg.Type == EventScript.ArgType.FIXED) continue;
+                    string argStr = EventScript.GetArg(code, i, out _);
+                    string name = arg.Name ?? arg.Symbol.ToString();
+                    argParts.Add($"{name}={argStr}");
+                }
+                if (argParts.Count > 0)
+                    line += "  " + string.Join(", ", argParts);
+            }
+
+            if (!string.IsNullOrEmpty(code.Comment))
+                line += $"  // {code.Comment}";
+
+            return line;
         }
 
         // ----------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia/ViewModels/EventScriptPopupViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EventScriptPopupViewModel.cs
@@ -320,7 +320,15 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             {
                 try
                 {
-                    es = new EventScript();
+                    // AI scripts use a FIXED 16-byte instruction grid, so the
+                    // unknown-opcode width must be 16 for the AI case only
+                    // (parity with WinForms Program.cs `new EventScript(16)`).
+                    // Event/Procs keep the default 4-byte width. Without this,
+                    // an unrecognized AI opcode would decode as four 4-byte
+                    // rows instead of one 16-byte WORD row (#757).
+                    es = ScriptType == EventScript.EventScriptType.AI
+                        ? new EventScript(16)
+                        : new EventScript();
                     es.Load(ScriptType);
                     // Cache for future use
                     switch (ScriptType)

--- a/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml.cs
@@ -199,10 +199,13 @@ namespace FEBuilderGBA.Avalonia.Views
         // -----------------------------------------------------------------
         // Re-read mirrors WF N_ReloadListButton_Click: read `bytecount`
         // bytes starting at `Address` and disassemble them into the
-        // Disassembly list. The actual opcode disassembly path is
-        // WinForms-coupled today; we surface the raw byte dump in the list
-        // so the user has SOMETHING populated and the button does real work
-        // (per PR #571 Copilot bot review #2 — no no-op "re-read").
+        // Disassembly list. The VM's DisassembleScript() walks the FIXED
+        // 16-byte AI instruction grid and renders each opcode as a real
+        // mnemonic + decoded args + comment (parity with the WinForms
+        // AIScriptForm opcode list), replacing the previous raw byte dump
+        // (#757). The byte range comes from the VM's CurrentAddr /
+        // ReadByteCount; the ROM-bounds / safety guard lives inside
+        // DisassembleScript().
         // -----------------------------------------------------------------
 
         void ReloadList_Click(object? sender, RoutedEventArgs e)
@@ -212,32 +215,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.CurrentAddr = (uint)(AddressBox.Value ?? 0);
                 _vm.ReadByteCount = (uint)(ReadByteCountBox.Value ?? 0);
 
-                // Read the bytes from ROM at CurrentAddr (size = ReadByteCount)
-                // and populate the Disassembly list with 16-byte chunks.
-                // Range check uses inclusive end (<= rom.Data.Length) and
-                // overflow-safe arithmetic so a range that ends EXACTLY at
-                // the ROM boundary still scans correctly (PR #571 Copilot
-                // bot review on follow-up commit thread #3 — `isSafetyOffset`
-                // is strictly `< Data.Length` and would silently no-op at
-                // the boundary).
-                var rom = CoreState.ROM;
-                var items = new System.Collections.Generic.List<string>();
-                if (rom != null && U.isSafetyOffset(_vm.CurrentAddr)
-                    && (ulong)_vm.CurrentAddr + (ulong)_vm.ReadByteCount
-                        <= (ulong)rom.Data.Length)
-                {
-                    uint end = System.Math.Min(_vm.CurrentAddr + _vm.ReadByteCount,
-                                               (uint)rom.Data.Length);
-                    for (uint a = _vm.CurrentAddr; a + 16 <= end; a += 16)
-                    {
-                        var sb = new System.Text.StringBuilder();
-                        sb.Append($"0x{a:X06}: ");
-                        for (uint i = 0; i < 16; i++)
-                            sb.Append($"{rom.u8(a + i):X02} ");
-                        items.Add(sb.ToString());
-                    }
-                }
-                DisassemblyList.ItemsSource = items;
+                DisassemblyList.ItemsSource = _vm.DisassembleScript();
                 UpdateUI();
             }
             catch (Exception ex)

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
@@ -719,7 +719,12 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 if (CoreState.AIScript == null)
                 {
-                    CoreState.AIScript = new EventScript();
+                    // AI scripts use a FIXED 16-byte instruction grid, so the
+                    // unknown-opcode width must be 16 (mirrors WinForms
+                    // Program.cs `new EventScript(16)`). With the default width
+                    // of 4, an unrecognized opcode would wrongly decode as four
+                    // 4-byte rows instead of one 16-byte WORD row (#757).
+                    CoreState.AIScript = new EventScript(16);
                     CoreState.AIScript.Load(EventScript.EventScriptType.AI);
                 }
             }


### PR DESCRIPTION
## Summary
- The Avalonia **AI Script editor** now shows **real opcode disassembly** (mnemonic + decoded args + comment) instead of a raw 16-byte hex dump, matching the WinForms `AIScriptForm`.
- Reuses the Core `EventScript.DisAseemble` machinery (already used by the Avalonia Event editor) via the shared `CoreState.AIScript` instance — no new/bespoke disassembler.
- Fixes a latent correctness bug: the shared AI `EventScript` was created with the default **unknown-opcode width 4**; WinForms uses **16** (`Program.cs:770`). All three Avalonia AI init sites now use `new EventScript(16)`, so unknown AI opcodes decode as one 16-byte row and stay aligned to the fixed AI instruction grid.
- Read-only display change — no ROM-write / Undo paths touched.

## Plan Reference
Implements the accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/757#issuecomment-4572206812 (Copilot CLI re-review: **no blocking concerns**).

## Scope
Closes #757
(Out of scope, tracked separately: AI opcode Write / Update / New / Remove / category-picker; the analogous `ProcsScript` width-8 init bug.)

## Screenshots
The AI Script Editor with real disassembly populated (entry `00 AI1` @ `0x005A8870`, 32 bytes → two 16-byte instructions):

![AI Script Editor showing real disassembly](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/fix757-ai-disassembly.png?raw=1)

Rows rendered (read back from the live `DisassemblyList` via UIAutomation):
```
0x5A8870: Attack05 attacking [PROBABILITY:Probability]  [05 64 FF 00 00 00 00 00 00 00 00 00 00 00 00 00]  Probability=100
0x5A8880: EXIT [id]  [03 00 FF 00 00 00 00 00 00 00 00 00 00 00 00 00]  id=0x0
```
(Previously these rows were raw hex chunks like `0x5A8870: 05 64 FF 00 …` with no opcode meaning.)

## GUI Test Report

### Environment
- ROM: `roms/FE8U.gba`
- Editor/View: Avalonia **AI Script Editor** (`AIScriptView`)
- Capture: PrintWindow (`tools/WinCapture`) + PowerShell UIAutomation navigation (screen was locked; MCP screen-capture returns black on a locked session, so PrintWindow was used per the documented headless flow).

### Steps Performed
1. Launched the Avalonia app (built from this branch) with FE8U.
2. Invoked the main-window **AI Script** button via UIAutomation → AI Script Editor opened; entry `00 AI1` auto-selected (Detail Address `0x005A8870`, Script Bytes 32).
3. Invoked the **Re-read** button via UIAutomation.
4. Read back the `DisassemblyList` items and captured the window.

### Test Results
| Test | Expected | Actual | Status |
|------|----------|--------|--------|
| Disassembly content | Opcode mnemonics + decoded args, not hex chunks | `Attack05 attacking [PROBABILITY:Probability] … Probability=100`; `EXIT [id] … id=0x0` | PASS |
| Instruction count | 32-byte script → 2 × 16-byte rows | 2 rows (Attack05, EXIT) | PASS |
| Grid alignment | Each row spans exactly 16 bytes | Each row shows 16 hex bytes; advance = 16 | PASS |
| Terminator | EXIT (0x03) present, range respected | EXIT row present at 0x5A8880 | PASS |

### Verdict
PASS — the AI Script editor renders real disassembly identical in form to WinForms.

## Test plan
- [x] New VM unit tests (10) in `FEBuilderGBA.Avalonia.Tests/AIScriptDisassemblyTests.cs`: known opcode → mnemonic+args (not hex); **width-16 regression** (unknown opcode = exactly one 16-byte row); EXIT+`0x1B` and EXIT+`0x1C` continuations keep both slots; non-multiple-of-16 `ReadByteCount` → explicit `[partial …]` row; `DisAseemble`-throws → `[Disassembly error]` + stop; `!IsLoaded`/`CurrentAddr==0` guards; pathological-range overflow safety — all pass.
- [x] Headless `[AvaloniaFact]` UI test: loading an entry populates `DisassemblyList` with non-empty rows that do NOT match the old hex-dump regex `^0x[0-9A-Fa-f]+: ([0-9A-Fa-f]{2} )+$` — passes.
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` — 7078 passed, 0 failed, 3 skipped.
- [x] `dotnet test FEBuilderGBA.Core.Tests` — 1988 passed, 0 failed.
- [x] `dotnet test FEBuilderGBA.Tests` (WinForms) — 1822 passed, 0 failed.
- [x] `dotnet build FEBuilderGBA.Avalonia -c Release` — 0 errors.
- [x] Manual GUI validation against FE8U — AI Script Editor shows real disassembly (screenshot + GUI Test Report above).
- [x] Read-only: confirmed no ROM-write / Undo code paths modified.

## Known limitations
- AI opcode editing (Write / Update / New / Remove) and the script-category picker remain informational stubs — out of scope for this read-only display fix; tracked separately.

Generated with Claude Code v2.1.156 (model: claude-opus-4-8, Opus 4.8 1M context)
