### PR TITLE
fix(avalonia): AI-script opcode hex editing + in-place Write-back (#760)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/AIScriptDisassemblyTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/AIScriptDisassemblyTests.cs
@@ -342,6 +342,20 @@ namespace FEBuilderGBA.Avalonia.Tests
 
         readonly ROM _rom;
 
+        /// <summary>The synthetic FE8U ROM backing this environment (#760
+        /// edit/write tests inspect rom.Data directly to verify in-place
+        /// writes / undo).</summary>
+        public ROM Rom => _rom;
+
+        /// <summary>Copy a [addr, addr+length) slice of the ROM, for
+        /// before/after byte comparisons in the #760 write tests.</summary>
+        public byte[] RomSlice(uint addr, uint length)
+        {
+            var slice = new byte[length];
+            Array.Copy(_rom.Data, (int)addr, slice, 0, (int)length);
+            return slice;
+        }
+
         public AiDisasmEnv()
         {
             _prevRom = CoreState.ROM;

--- a/FEBuilderGBA.Avalonia.Tests/AIScriptDisassemblyTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/AIScriptDisassemblyTests.cs
@@ -351,7 +351,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         /// before/after byte comparisons in the #760 write tests.</summary>
         public byte[] RomSlice(uint addr, uint length)
         {
-            var slice = new byte[length];
+            var slice = new byte[(int)length];
             Array.Copy(_rom.Data, (int)addr, slice, 0, (int)length);
             return slice;
         }

--- a/FEBuilderGBA.Avalonia.Tests/AIScriptEditWriteTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/AIScriptEditWriteTests.cs
@@ -1,0 +1,464 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// AIScriptViewModel opcode hex-edit + in-place Write-back tests (#760).
+//
+// Proves the Avalonia AI Script editor can hand-edit an instruction's bytes
+// and persist a SAME-SIZE slice back to the ROM:
+//   - SerializeScript() is an EXACT concatenation of every decoded
+//     instruction's ByteData (no EXIT terminator append / normalization), so
+//     a freshly-loaded script round-trips to the original ReadByteCount bytes;
+//   - UpdateRow() re-decodes a hand-edited 16-byte instruction, mutating only
+//     the targeted row, and rejects over-length / non-hex input without
+//     touching the model;
+//   - WriteScript() writes the same-size slice through rom.write_u8 (so the
+//     surrounding UndoService scope tracks it), and refuses any length change
+//     or out-of-range slice;
+//   - an empty model never writes;
+//   - the write is undoable via CoreState.Undo.RunUndo();
+//   - DisassembleScript() re-read after a committed write reflects the
+//     persisted bytes.
+//
+// Reuses the AiDisasmEnv synthetic FE8U environment from
+// AIScriptDisassemblyTests.cs (#757). Marked [Collection("SharedState")]
+// because the suite mutates CoreState.ROM / CoreState.AIScript /
+// CoreState.CommentCache / CoreState.Undo / CoreState.BaseDirectory.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using global::Avalonia.Controls;
+using global::Avalonia.Headless.XUnit;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class AIScriptEditWriteTests
+    {
+        // 16-byte AI instruction helpers (FE8 table). Attack05's byte[1] is
+        // the PROBABILITY arg; byte[2]=0xFF is FIXED.
+        static byte[] Attack05(byte probability)
+        {
+            var b = new byte[16];
+            b[0] = 0x05; b[1] = probability; b[2] = 0xFF;
+            return b;
+        }
+
+        static byte[] ExitOpcode(byte id)
+        {
+            var b = new byte[16];
+            b[0] = 0x03; b[1] = 0x00; b[2] = 0xFF; b[3] = id;
+            return b;
+        }
+
+        // A space-separated hex dump of a 16-byte instruction (the form
+        // GetRowHex emits and the View pushes into the Binary Code box).
+        static string HexLine(params byte[] firstBytes)
+        {
+            var b = new byte[16];
+            Array.Copy(firstBytes, b, Math.Min(firstBytes.Length, 16));
+            return string.Join(" ", b.Select(x => x.ToString("X2")));
+        }
+
+        // ----------------------------------------------------------------
+        // 1. SerializeScript round-trip identity.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void SerializeScript_FreshLoad_EqualsOriginalRomBytes()
+        {
+            using var env = new AiDisasmEnv();
+
+            // Two real instructions: Attack05 + EXIT (32 bytes total).
+            var body = new List<byte>();
+            body.AddRange(Attack05(0x64));
+            body.AddRange(ExitOpcode(0x00));
+            var vm = env.LoadVmAt(body.ToArray());
+
+            // Must disassemble first to populate the editable model.
+            vm.DisassembleScript();
+
+            byte[] serialized = vm.SerializeScript();
+
+            Assert.Equal((int)vm.ReadByteCount, serialized.Length);
+            byte[] original = env.RomSlice(vm.CurrentAddr, vm.ReadByteCount);
+            Assert.Equal(original, serialized);
+        }
+
+        // ----------------------------------------------------------------
+        // 2. UpdateRow param edit (probability 0x64 -> 0x32) keeps length.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void UpdateRow_ProbabilityEdit_ReflectsValueAndKeepsLength()
+        {
+            using var env = new AiDisasmEnv();
+
+            var body = new List<byte>();
+            body.AddRange(Attack05(0x64));
+            body.AddRange(ExitOpcode(0x00));
+            var vm = env.LoadVmAt(body.ToArray());
+            vm.DisassembleScript();
+
+            int lenBefore = vm.SerializeScript().Length;
+
+            // Edit row 0's probability from 0x64 (100) to 0x32 (50).
+            string? line = vm.UpdateRow(0, HexLine(0x05, 0x32, 0xFF));
+            Assert.NotNull(line);
+            // PROBABILITY renders as decimal "50" or hex "0x32" depending on
+            // the arg's IsDecimal flag — accept either, both encode 0x32.
+            Assert.True(line!.Contains("0x32") || line.Contains("50"),
+                $"Expected edited probability (0x32/50) in row, got: {line}");
+            Assert.Contains("Attack05", line);
+
+            byte[] serialized = vm.SerializeScript();
+            Assert.Equal(0x32, serialized[1]);
+            // Same-size: editing a value must not change total length.
+            Assert.Equal(lenBefore, serialized.Length);
+            // The EXIT row (second slot) is untouched.
+            Assert.Equal(0x03, serialized[16]);
+        }
+
+        // ----------------------------------------------------------------
+        // 3. UpdateRow invalid input: no mutation.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void UpdateRow_InvalidInput_ReturnsNullAndLeavesModelUnchanged()
+        {
+            using var env = new AiDisasmEnv();
+
+            var body = new List<byte>();
+            body.AddRange(Attack05(0x64));
+            body.AddRange(ExitOpcode(0x00));
+            var vm = env.LoadVmAt(body.ToArray());
+            vm.DisassembleScript();
+
+            byte[] before = vm.SerializeScript();
+
+            // Too long: 17 bytes (> one 16-byte instruction) -> null, no change.
+            string tooLong = string.Join(" ",
+                Enumerable.Range(0, 17).Select(_ => "00"));
+            Assert.Null(vm.UpdateRow(0, tooLong));
+            Assert.Equal(before, vm.SerializeScript());
+
+            // Non-hex -> null, no change.
+            Assert.Null(vm.UpdateRow(0, "zz zz zz"));
+            Assert.Equal(before, vm.SerializeScript());
+
+            // Empty -> null, no change.
+            Assert.Null(vm.UpdateRow(0, ""));
+            Assert.Equal(before, vm.SerializeScript());
+
+            // Out-of-range index -> null, no change.
+            Assert.Null(vm.UpdateRow(99, HexLine(0x05, 0x32, 0xFF)));
+            Assert.Equal(before, vm.SerializeScript());
+        }
+
+        [Fact]
+        public void UpdateRow_ShortInstruction_RightPadsToSixteenBytes()
+        {
+            using var env = new AiDisasmEnv();
+
+            var vm = env.LoadVmAt(Attack05(0x64));
+            vm.DisassembleScript();
+
+            // Only 3 bytes typed: must right-pad to a full 16-byte slot.
+            string? line = vm.UpdateRow(0, "05 32 FF");
+            Assert.NotNull(line);
+
+            byte[] serialized = vm.SerializeScript();
+            Assert.Equal(16, serialized.Length);
+            Assert.Equal(0x05, serialized[0]);
+            Assert.Equal(0x32, serialized[1]);
+            Assert.Equal(0xFF, serialized[2]);
+            for (int i = 3; i < 16; i++)
+                Assert.Equal(0x00, serialized[i]);
+        }
+
+        // ----------------------------------------------------------------
+        // 4. WriteScript same-size success + forced mismatch refusal.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void WriteScript_SameSizeEdit_WritesBytes()
+        {
+            using var env = new AiDisasmEnv();
+            using var undo = new UndoScope();
+
+            var body = new List<byte>();
+            body.AddRange(Attack05(0x64));
+            body.AddRange(ExitOpcode(0x00));
+            var vm = env.LoadVmAt(body.ToArray());
+            vm.DisassembleScript();
+
+            Assert.NotNull(vm.UpdateRow(0, HexLine(0x05, 0x32, 0xFF)));
+
+            bool ok = vm.WriteScript();
+            Assert.True(ok);
+            Assert.Equal(0x32, env.Rom.Data[vm.CurrentAddr + 1]);
+        }
+
+        [Fact]
+        public void WriteScript_LengthMismatch_RefusesAndLeavesRomUnchanged()
+        {
+            using var env = new AiDisasmEnv();
+            using var undo = new UndoScope();
+
+            var vm = env.LoadVmAt(Attack05(0x64));
+            vm.DisassembleScript();
+
+            Assert.NotNull(vm.UpdateRow(0, HexLine(0x05, 0x32, 0xFF)));
+
+            // Snapshot the ROM slice, then force a length mismatch: the
+            // serialized model is 16 bytes but ReadByteCount now says 8.
+            byte[] snapshot = env.RomSlice(vm.CurrentAddr, 16);
+            vm.ReadByteCount = 8;
+
+            Assert.False(vm.WriteScript());
+            // Nothing written: the original 0x64 probability survives.
+            Assert.Equal(snapshot, env.RomSlice(vm.CurrentAddr, 16));
+            Assert.Equal(0x64, env.Rom.Data[vm.CurrentAddr + 1]);
+        }
+
+        [Fact]
+        public void WriteScript_OutOfRange_RefusesAndLeavesRomUnchanged()
+        {
+            using var env = new AiDisasmEnv();
+            using var undo = new UndoScope();
+
+            var vm = env.LoadVmAt(Attack05(0x64));
+            vm.DisassembleScript();
+            Assert.NotNull(vm.UpdateRow(0, HexLine(0x05, 0x32, 0xFF)));
+
+            // Point CurrentAddr so the 16-byte slice runs off the ROM end.
+            // ReadByteCount stays 16 (matches serialized) so only the
+            // bounds guard fires.
+            vm.CurrentAddr = (uint)env.Rom.Data.Length - 8;
+            Assert.False(vm.WriteScript());
+        }
+
+        // ----------------------------------------------------------------
+        // 5. Empty model never writes.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void WriteScript_EmptyModel_ReturnsFalse()
+        {
+            using var env = new AiDisasmEnv();
+            using var undo = new UndoScope();
+
+            // A VM that never disassembled has an empty model.
+            var vm = new AIScriptViewModel
+            {
+                CurrentAddr = 0x200000,
+                ReadByteCount = 0,
+                IsLoaded = true,
+            };
+            Assert.Empty(vm.SerializeScript());
+            Assert.False(vm.WriteScript());
+        }
+
+        // ----------------------------------------------------------------
+        // 6. Undo restores the original bytes.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void WriteScript_UnderUndoScope_IsUndoable()
+        {
+            using var env = new AiDisasmEnv();
+
+            IDisposable? scope = null;
+            Undo? prevUndo = CoreState.Undo;
+            CoreState.Undo = new Undo();
+            try
+            {
+                var body = new List<byte>();
+                body.AddRange(Attack05(0x64));
+                body.AddRange(ExitOpcode(0x00));
+                var vm = env.LoadVmAt(body.ToArray());
+                vm.DisassembleScript();
+
+                byte[] original = env.RomSlice(vm.CurrentAddr, vm.ReadByteCount);
+
+                Assert.NotNull(vm.UpdateRow(0, HexLine(0x05, 0x32, 0xFF)));
+
+                // Drive the UndoService exactly as the View does.
+                var u = new UndoService();
+                u.Begin("Edit AI Script");
+                bool ok = vm.WriteScript();
+                Assert.True(ok);
+                u.Commit();
+
+                // The edit is persisted.
+                Assert.Equal(0x32, env.Rom.Data[vm.CurrentAddr + 1]);
+
+                // Undo it: ROM bytes return to the original slice.
+                CoreState.Undo!.RunUndo();
+                Assert.Equal(original, env.RomSlice(vm.CurrentAddr, vm.ReadByteCount));
+                Assert.Equal(0x64, env.Rom.Data[vm.CurrentAddr + 1]);
+            }
+            finally
+            {
+                scope?.Dispose();
+                CoreState.Undo = prevUndo;
+            }
+        }
+
+        // ----------------------------------------------------------------
+        // 7. Re-disassemble after a committed write reflects persisted bytes.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void DisassembleScript_AfterCommittedWrite_ReflectsEditedValue()
+        {
+            using var env = new AiDisasmEnv();
+
+            Undo? prevUndo = CoreState.Undo;
+            CoreState.Undo = new Undo();
+            try
+            {
+                var body = new List<byte>();
+                body.AddRange(Attack05(0x64));
+                body.AddRange(ExitOpcode(0x00));
+                var vm = env.LoadVmAt(body.ToArray());
+                vm.DisassembleScript();
+
+                Assert.NotNull(vm.UpdateRow(0, HexLine(0x05, 0x32, 0xFF)));
+
+                var u = new UndoService();
+                u.Begin("Edit AI Script");
+                Assert.True(vm.WriteScript());
+                u.Commit();
+
+                // Re-read from ROM: the edited probability must persist.
+                IReadOnlyList<string> rows = vm.DisassembleScript();
+                Assert.NotEmpty(rows);
+                Assert.True(rows[0].Contains("0x32") || rows[0].Contains("50"),
+                    $"Re-read row must show the persisted probability, got: {rows[0]}");
+                Assert.Equal(0x32, vm.SerializeScript()[1]);
+            }
+            finally
+            {
+                CoreState.Undo = prevUndo;
+            }
+        }
+
+        // ----------------------------------------------------------------
+        // GetDisplayLines reflects in-memory edits (no ROM re-read).
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void GetDisplayLines_AfterUpdateRow_ReflectsEditWithoutRomReread()
+        {
+            using var env = new AiDisasmEnv();
+
+            var body = new List<byte>();
+            body.AddRange(Attack05(0x64));
+            body.AddRange(ExitOpcode(0x00));
+            var vm = env.LoadVmAt(body.ToArray());
+            vm.DisassembleScript();
+
+            // Edit in memory only (no Write). ROM still holds 0x64.
+            Assert.NotNull(vm.UpdateRow(0, HexLine(0x05, 0x32, 0xFF)));
+            Assert.Equal(0x64, env.Rom.Data[vm.CurrentAddr + 1]); // ROM unchanged
+
+            IReadOnlyList<string> lines = vm.GetDisplayLines();
+            Assert.Equal(2, lines.Count);
+            Assert.True(lines[0].Contains("0x32") || lines[0].Contains("50"),
+                $"GetDisplayLines must show the in-memory edit, got: {lines[0]}");
+        }
+
+        // ----------------------------------------------------------------
+        // Headless UI: select row 0 -> Binary Code box shows hex; Update +
+        // Write persist the edited byte to rom.Data.
+        // ----------------------------------------------------------------
+
+        [AvaloniaFact]
+        public void View_SelectRow_PopulatesBinaryCode_AndWritePersists()
+        {
+            using var env = new AiDisasmEnv();
+
+            Undo? prevUndo = CoreState.Undo;
+            CoreState.Undo = new Undo();
+            try
+            {
+                // Plant Attack05 + EXIT and a pointer slot to it.
+                var body = new List<byte>();
+                body.AddRange(Attack05(0x64));
+                body.AddRange(ExitOpcode(0x00));
+                env.PlantBody(body.ToArray(), out uint pointerSlotAddr);
+
+                var view = new AIScriptView();
+                var asmBox = view.FindControl<TextBox>("AsmBox");
+                var list = view.FindControl<ListBox>("DisassemblyList");
+                Assert.NotNull(asmBox);
+                Assert.NotNull(list);
+
+                // Drive the view's VM through LoadEntry as a list selection would.
+                var vmField = typeof(AIScriptView).GetField(
+                    "_vm",
+                    System.Reflection.BindingFlags.Instance |
+                    System.Reflection.BindingFlags.NonPublic);
+                Assert.NotNull(vmField);
+                var vm = (AIScriptViewModel)vmField!.GetValue(view)!;
+                vm.LoadEntry(pointerSlotAddr);
+                Assert.True(vm.IsLoaded);
+
+                var addressBox = view.FindControl<NumericUpDown>("AddressBox");
+                var byteCountBox = view.FindControl<NumericUpDown>("ReadByteCountBox");
+                addressBox!.Value = vm.CurrentAddr;
+                byteCountBox!.Value = vm.ReadByteCount;
+
+                // Re-read populates the Disassembly list (and the model).
+                Invoke(view, "ReloadList_Click");
+
+                // Select row 0 -> Binary Code box shows non-empty hex.
+                list!.SelectedIndex = 0;
+                Assert.False(string.IsNullOrWhiteSpace(asmBox!.Text));
+                Assert.Contains("05", asmBox.Text!);
+
+                // Hand-edit the probability and Update + Write.
+                asmBox.Text = HexLine(0x05, 0x32, 0xFF);
+                Invoke(view, "Update_Click");
+                Invoke(view, "Write_Click");
+
+                // The Write persisted the edited byte to the ROM.
+                Assert.Equal(0x32, env.Rom.Data[vm.CurrentAddr + 1]);
+            }
+            finally
+            {
+                CoreState.Undo = prevUndo;
+            }
+        }
+
+        static void Invoke(AIScriptView view, string method)
+        {
+            var m = typeof(AIScriptView).GetMethod(
+                method,
+                System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.NonPublic);
+            Assert.NotNull(m);
+            m!.Invoke(view, new object?[] { null, new global::Avalonia.Interactivity.RoutedEventArgs() });
+        }
+
+        /// <summary>
+        /// Sets a fresh CoreState.Undo for the duration of a write test and
+        /// restores the prior value on Dispose. WriteScript itself does not
+        /// require an undo (rom.write_u8 no-ops the ambient scope when none is
+        /// open), but tests that want a clean undo buffer use this.
+        /// </summary>
+        sealed class UndoScope : IDisposable
+        {
+            readonly Undo? _prev;
+            public UndoScope()
+            {
+                _prev = CoreState.Undo;
+                CoreState.Undo = new Undo();
+            }
+            public void Dispose() => CoreState.Undo = _prev;
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/AIScriptEditWriteTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/AIScriptEditWriteTests.cs
@@ -9,9 +9,9 @@
 //   - UpdateRow() re-decodes a hand-edited 16-byte instruction, mutating only
 //     the targeted row, and rejects over-length / non-hex input without
 //     touching the model;
-//   - WriteScript() writes the same-size slice through rom.write_u8 (so the
-//     surrounding UndoService scope tracks it), and refuses any length change
-//     or out-of-range slice;
+//   - WriteScript() writes the same-size slice through rom.write_range (so the
+//     surrounding UndoService scope tracks it as one entry), and refuses any
+//     length change, unsafe/header offset, or out-of-range slice;
 //   - an empty model never writes;
 //   - the write is undoable via CoreState.Undo.RunUndo();
 //   - DisassembleScript() re-read after a committed write reflects the
@@ -262,6 +262,32 @@ namespace FEBuilderGBA.Avalonia.Tests
         }
 
         // ----------------------------------------------------------------
+        // 5b. A header / low (unsafe) CurrentAddr is refused with no mutation.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void WriteScript_UnsafeHeaderOffset_RefusesAndDoesNotMutate()
+        {
+            using var env = new AiDisasmEnv();
+
+            var body = new List<byte>();
+            body.AddRange(Attack05(0x64));
+            body.AddRange(ExitOpcode(0x00));
+            var vm = env.LoadVmAt(body.ToArray()); // loaded at the safe ScriptBase
+            vm.DisassembleScript();
+
+            // Redirect the write target to a header/low offset below the
+            // U.isSafetyOffset floor (a mistyped Address box). Length stays equal
+            // to ReadByteCount, so only the safety-offset guard can reject it.
+            const uint unsafeAddr = 0x100;
+            vm.CurrentAddr = unsafeAddr;
+            byte[] before = env.RomSlice(unsafeAddr, vm.ReadByteCount);
+
+            Assert.False(vm.WriteScript());
+            Assert.Equal(before, env.RomSlice(unsafeAddr, vm.ReadByteCount));
+        }
+
+        // ----------------------------------------------------------------
         // 6. Undo restores the original bytes.
         // ----------------------------------------------------------------
 
@@ -453,8 +479,8 @@ namespace FEBuilderGBA.Avalonia.Tests
         /// <summary>
         /// Sets a fresh CoreState.Undo for the duration of a write test and
         /// restores the prior value on Dispose. WriteScript itself does not
-        /// require an undo (rom.write_u8 no-ops the ambient scope when none is
-        /// open), but tests that want a clean undo buffer use this.
+        /// require an undo (rom.write_range no-ops the ambient scope when none
+        /// is open), but tests that want a clean undo buffer use this.
         /// </summary>
         sealed class UndoScope : IDisposable
         {

--- a/FEBuilderGBA.Avalonia.Tests/AIScriptEditWriteTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/AIScriptEditWriteTests.cs
@@ -404,6 +404,12 @@ namespace FEBuilderGBA.Avalonia.Tests
                     System.Reflection.BindingFlags.NonPublic);
                 Assert.NotNull(vmField);
                 var vm = (AIScriptViewModel)vmField!.GetValue(view)!;
+                // Defensive: constructing the View re-enters list/VM init (the
+                // FilterCombo SelectionChanged fires LoadList). Re-assert the
+                // env's ROM as the active one before LoadEntry so the pointer
+                // slot follow resolves deterministically regardless of any
+                // cross-test CoreState churn in the shared collection.
+                CoreState.ROM = env.Rom;
                 vm.LoadEntry(pointerSlotAddr);
                 Assert.True(vm.IsLoaded);
 

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/AIScriptParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/AIScriptParityTests.cs
@@ -266,32 +266,27 @@ public class AIScriptParityTests
     // -----------------------------------------------------------------
 
     [Fact]
-    public void View_WriteHandler_IsHonestlyDeferred()
+    public void View_WriteHandler_WrapsUndoScopeAndWritesInPlace()
     {
-        // PR #571 Copilot bot review #1: AI script write-back is
-        // WinForms-coupled today (EventScript.DisAssemble +
-        // EventScriptUtil.JisageReorder live in the WinForms assembly).
-        // The Write_Click handler must NOT allocate an undo scope and
-        // emit a false "success" toast; instead it surfaces a clear
-        // "not yet implemented" message so users aren't misled. This
-        // test pins that honest state — when the WinForms write path is
-        // ported to Core, this test should change to assert
-        // `_undoService.Begin( / Commit(` wrap (parity with SongTrack /
-        // EDView).
+        // #760: AI script opcode write-back is now implemented as a
+        // SAME-SIZE in-place write. The Write_Click handler must wrap the
+        // write in a UndoService.Begin / Commit block (rolling back on a
+        // refused / failed write) and call the VM's WriteScript() — parity
+        // with SongTrack / EDView. This replaces the prior "honestly
+        // deferred" assertion (PR #571) per that test's own follow-up note.
         string codeBehindPath = CodeBehindPath();
         Assert.True(File.Exists(codeBehindPath), $"Code-behind not found at {codeBehindPath}");
         string code = File.ReadAllText(codeBehindPath);
 
-        // Write_Click must exist
+        // Write_Click must exist and drive the real write path.
         Assert.Contains("Write_Click", code);
-        // The undo scope helper exists in the file (e.g. for future use)
-        // but the Write_Click body must NOT call Begin without doing a
-        // real ROM mutation. Sanity: the code-behind owns an UndoService
-        // for future opcode editing, so the field reference is present
-        // but the handler short-circuits.
-        Assert.Contains("UndoService", code);
-        // The honest "not yet implemented" message must be present.
-        Assert.Contains("AI script Write is not yet implemented in Avalonia", code);
+        Assert.Contains("_undoService.Begin(", code);
+        Assert.Contains("_undoService.Commit(", code);
+        Assert.Contains("_undoService.Rollback(", code);
+        Assert.Contains("WriteScript()", code);
+
+        // The old "not yet implemented" Write message must be gone.
+        Assert.DoesNotContain("AI script Write is not yet implemented in Avalonia", code);
     }
 
     [Fact]

--- a/FEBuilderGBA.Avalonia/Services/UndoService.cs
+++ b/FEBuilderGBA.Avalonia/Services/UndoService.cs
@@ -71,6 +71,17 @@ namespace FEBuilderGBA.Avalonia.Services
         /// <summary>Notify the main window of the current unsaved-changes state.</summary>
         static void NotifyUnsavedChanges()
         {
+            // The dirty indicator lives on the MainWindow (an Avalonia UI object).
+            // Commit()/Rollback() are public and may run off the UI thread (e.g.
+            // headless tests, future async callers); touching the Window off the
+            // UI thread throws "Call from invalid thread". Marshal to the UI
+            // thread when we are not already on it.
+            var dispatcher = global::Avalonia.Threading.Dispatcher.UIThread;
+            if (!dispatcher.CheckAccess())
+            {
+                dispatcher.Post(NotifyUnsavedChanges);
+                return;
+            }
             if (WindowManager.Instance.MainWindow?.DataContext is ViewModels.MainWindowViewModel vm)
                 vm.HasUnsavedChanges = CoreState.Undo?.IsModified ?? false;
         }

--- a/FEBuilderGBA.Avalonia/ViewModels/AIScriptViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/AIScriptViewModel.cs
@@ -411,24 +411,217 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             return line;
         }
 
+        /// <summary>
+        /// Re-render the current _disassembled model into display lines WITHOUT
+        /// re-reading the ROM. Used by the View after UpdateRow so an in-memory
+        /// edit is reflected immediately (DisassembleScript() would re-read the
+        /// unmodified ROM bytes and discard the edit). Reuses the same row
+        /// formatter DisassembleScript() uses.
+        /// </summary>
+        public IReadOnlyList<string> GetDisplayLines()
+        {
+            var lines = new List<string>(_disassembled.Count);
+            for (int i = 0; i < _disassembled.Count; i++)
+            {
+                EventScript.OneCode code = _disassembled[i];
+                uint off = i < _rowOffsets.Count ? _rowOffsets[i] : 0;
+                lines.Add(FormatAiRow(code, off));
+            }
+            return lines;
+        }
+
         // ----------------------------------------------------------------
-        // Write-back (mirrors WF AIScriptForm.AllWriteButton_Click)
+        // Per-row edit accessors (#760). The View binds the Disassembly
+        // list selection to the Binary Code / Description boxes through
+        // these helpers, then re-decodes a hand-edited 16-byte instruction
+        // back into the model with UpdateRow.
         // ----------------------------------------------------------------
 
         /// <summary>
-        /// Write the current ScriptBytes back to the ROM at CurrentAddr.
-        /// Callers MUST wrap this call in a UndoService.Begin / Commit block.
-        /// Mirrors WF AIScriptForm.AllWriteButton_Click — the full byte
-        /// list write path lives in the view code-behind because it needs
-        /// AIScript.DisAssemble / EventScriptUtil.JisageReorder which are
-        /// WinForms-coupled. The VM exposes Write() only as the no-op header
-        /// commit so the test surface is stable.
+        /// Space-separated 2-digit hex dump of the instruction bytes at the
+        /// given row (matching the "[..]" hex in the Disassembly list rows).
+        /// Returns null on an out-of-range index.
+        /// </summary>
+        public string? GetRowHex(int index)
+        {
+            if (index < 0 || index >= _disassembled.Count) return null;
+            byte[] data = _disassembled[index].ByteData;
+            if (data == null) return null;
+            return U.HexDumpLiner(data).Trim();
+        }
+
+        /// <summary>
+        /// Human-readable script command name for the given row (the WF
+        /// "ScriptCodeName" hint). Returns null on an out-of-range index.
+        /// </summary>
+        public string? GetRowOpcodeName(int index)
+        {
+            if (index < 0 || index >= _disassembled.Count) return null;
+            return EventScript.makeCommandComboText(_disassembled[index].Script, false);
+        }
+
+        /// <summary>
+        /// Re-decode a hand-edited instruction at <paramref name="index"/> from
+        /// <paramref name="hexText"/> and replace the model row. Mirrors WF
+        /// AIScriptForm.OneLineDisassembler: parse the hex dump, pad a short
+        /// instruction with zero bytes up to the fixed 16-byte width, reject an
+        /// over-length / non-hex entry, then run AIScript.DisAseemble over the
+        /// 16 bytes. AI is a FIXED 16-byte grid, so exactly ONE instruction is
+        /// accepted (length &gt; 16 is rejected — multi-instruction edits and
+        /// EXIT normalization are out of scope, see #760 follow-up).
+        ///
+        /// Returns the refreshed display line on success, or null (leaving the
+        /// model untouched) on a bad index, empty / non-hex input, an
+        /// over-length entry, or a decode failure.
+        /// </summary>
+        public string? UpdateRow(int index, string hexText)
+        {
+            if (index < 0 || index >= _disassembled.Count) return null;
+
+            byte[]? bytes = ParseInstructionHex(hexText);
+            if (bytes == null) return null;
+
+            EventScript es = CoreState.AIScript;
+            if (es == null) return null;
+
+            EventScript.OneCode code;
+            try
+            {
+                code = es.DisAseemble(bytes, 0);
+            }
+            catch
+            {
+                return null;
+            }
+            if (code == null || code.ByteData == null) return null;
+
+            _disassembled[index] = code;
+            uint off = index < _rowOffsets.Count ? _rowOffsets[index] : 0;
+            return FormatAiRow(code, off);
+        }
+
+        /// <summary>
+        /// Parse a hex dump (with or without separating whitespace) into a
+        /// single AI instruction. Mirrors the WF OneLineDisassembler width
+        /// rule: short instructions are right-padded with zero bytes up to the
+        /// fixed 16-byte width; an instruction longer than 16 bytes, an empty
+        /// string, or any non-hex / odd-nibble content yields null. AI's fixed
+        /// grid is exactly one 16-byte instruction (CoreState.AIScript is
+        /// `new EventScript(16)`).
+        /// </summary>
+        static byte[]? ParseInstructionHex(string hexText)
+        {
+            if (hexText == null) return null;
+
+            // Strip ALL whitespace so the space-separated form emitted by
+            // GetRowHex ("05 32 FF ..") parses the same as a continuous dump.
+            var sb = new System.Text.StringBuilder(hexText.Length);
+            foreach (char c in hexText)
+            {
+                if (char.IsWhiteSpace(c)) continue;
+                bool isHex = (c >= '0' && c <= '9')
+                          || (c >= 'a' && c <= 'f')
+                          || (c >= 'A' && c <= 'F');
+                if (!isHex) return null; // non-hex content
+                sb.Append(c);
+            }
+
+            string cleaned = sb.ToString();
+            if (cleaned.Length == 0) return null;          // empty
+            if ((cleaned.Length & 1) != 0) return null;    // odd nibble count
+
+            int byteCount = cleaned.Length / 2;
+            if (byteCount > 16) return null;               // over one instruction
+
+            byte[] parsed = U.convertStringDumpToByte(cleaned);
+            if (parsed.Length == 16) return parsed;
+
+            // Right-pad a short instruction to the fixed 16-byte width.
+            byte[] padded = new byte[16];
+            Array.Copy(parsed, padded, parsed.Length);
+            return padded;
+        }
+
+        // ----------------------------------------------------------------
+        // Serialize + write-back (#760, mirrors WF AllWriteButton_Click).
+        // ----------------------------------------------------------------
+
+        /// <summary>
+        /// Exact concatenation of every decoded instruction's ByteData, in
+        /// row order. This is a SAME-SIZE, in-place serialization: NO EXIT
+        /// terminator is appended and NO normalization is performed — the
+        /// loaded ReadByteCount already includes the trailing EXIT because
+        /// CalcScriptLength reads through it. (EXIT normalization + free-space
+        /// realloc + New/Remove are deferred, see #760 follow-up.) Returns an
+        /// empty array when nothing has been disassembled.
+        /// </summary>
+        public byte[] SerializeScript()
+        {
+            int total = 0;
+            for (int i = 0; i < _disassembled.Count; i++)
+            {
+                byte[] b = _disassembled[i].ByteData;
+                if (b != null) total += b.Length;
+            }
+
+            byte[] result = new byte[total];
+            int pos = 0;
+            for (int i = 0; i < _disassembled.Count; i++)
+            {
+                byte[] b = _disassembled[i].ByteData;
+                if (b == null) continue;
+                Array.Copy(b, 0, result, pos, b.Length);
+                pos += b.Length;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Write the serialized instruction bytes back to the ROM at
+        /// CurrentAddr. Callers MUST wrap this call in a UndoService.Begin /
+        /// Commit block — the per-byte rom.write_u8 calls register into the
+        /// ambient undo scope the View opens.
+        ///
+        /// This is a strict SAME-SIZE in-place write: it refuses to write
+        /// (returns false, mutating nothing) when the serialized length does
+        /// not equal the loaded ReadByteCount, or when the write would run off
+        /// the end of the ROM. A length change means New/Remove territory,
+        /// which needs free-space reallocation (out of scope, #760 follow-up).
+        /// Returns true only when the full slice was written.
+        /// </summary>
+        public bool WriteScript()
+        {
+            if (_disassembled.Count == 0) return false;
+
+            ROM rom = CoreState.ROM;
+            if (rom == null || rom.Data == null) return false;
+
+            byte[] bytes = SerializeScript();
+
+            // No-partial-write guard: only a same-size, fully in-bounds slice
+            // is allowed. (ulong) arithmetic so a near-uint.MaxValue CurrentAddr
+            // cannot wrap past the ROM length.
+            if (bytes.Length != ReadByteCount) return false;
+            if ((ulong)CurrentAddr + (ulong)bytes.Length > (ulong)rom.Data.Length) return false;
+
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                rom.write_u8(CurrentAddr + (uint)i, bytes[i]);
+            }
+            return true;
+        }
+
+        // ----------------------------------------------------------------
+        // Legacy header-only commit (kept for the stable VM surface). The
+        // real opcode write-back now lives in WriteScript() (#760).
+        // ----------------------------------------------------------------
+
+        /// <summary>
+        /// Header-only commit retained for backward compatibility. Use
+        /// WriteScript() for the actual same-size in-place opcode write.
         /// </summary>
         public void Write()
         {
-            // Header-only commit: scope-level write tracking happens in the
-            // view code-behind. The VM marks IsLoaded so the next reload
-            // picks up persisted state.
             IsLoaded = true;
         }
     }

--- a/FEBuilderGBA.Avalonia/ViewModels/AIScriptViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/AIScriptViewModel.cs
@@ -484,6 +484,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             EventScript es = CoreState.AIScript;
             if (es == null) return null;
 
+            // Preserve the row's existing comment. DisAseemble(bytes, 0) would
+            // populate OneCode.Comment from CommentCache.At(0) (offset 0, wrong),
+            // dropping the row's real per-offset comment. The comment is keyed by
+            // ROM offset, which a same-size hex edit does not change.
+            string origComment = _disassembled[index].Comment;
             EventScript.OneCode code;
             try
             {
@@ -494,6 +499,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 return null;
             }
             if (code == null || code.ByteData == null) return null;
+            code.Comment = origComment;
 
             _disassembled[index] = code;
             uint off = index < _rowOffsets.Count ? _rowOffsets[index] : 0;
@@ -604,12 +610,17 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (bytes.Length != ReadByteCount) return false;
             if ((ulong)CurrentAddr + (ulong)bytes.Length > (ulong)rom.Data.Length) return false;
 
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                rom.write_u8(CurrentAddr + (uint)i, bytes[i]);
-            }
+            // Single-range write → one undo entry (registers into the ambient
+            // UndoService scope opened by the View), rather than one UndoPosition
+            // per byte.
+            rom.write_range(CurrentAddr, bytes);
             return true;
         }
+
+        /// <summary>True once a script has been disassembled into the editable
+        /// model (i.e. Re-read has run). The View guards Write on this so an
+        /// empty/never-loaded model does not attempt a (misleading) write.</summary>
+        public bool HasDisassembly => _disassembled.Count > 0;
 
         // ----------------------------------------------------------------
         // Legacy header-only commit (kept for the stable VM surface). The

--- a/FEBuilderGBA.Avalonia/ViewModels/AIScriptViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/AIScriptViewModel.cs
@@ -585,15 +585,17 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// <summary>
         /// Write the serialized instruction bytes back to the ROM at
         /// CurrentAddr. Callers MUST wrap this call in a UndoService.Begin /
-        /// Commit block — the per-byte rom.write_u8 calls register into the
+        /// Commit block — the single rom.write_range call registers into the
         /// ambient undo scope the View opens.
         ///
         /// This is a strict SAME-SIZE in-place write: it refuses to write
         /// (returns false, mutating nothing) when the serialized length does
-        /// not equal the loaded ReadByteCount, or when the write would run off
-        /// the end of the ROM. A length change means New/Remove territory,
-        /// which needs free-space reallocation (out of scope, #760 follow-up).
-        /// Returns true only when the full slice was written.
+        /// not equal the loaded ReadByteCount, when the target is not a safe
+        /// ROM offset (rejects header / out-of-range addresses a mistyped
+        /// Address box could supply), or when the write would run off the end
+        /// of the ROM. A length change means New/Remove territory, which needs
+        /// free-space reallocation (out of scope, #760 follow-up). Returns true
+        /// only when the full slice was written.
         /// </summary>
         public bool WriteScript()
         {
@@ -609,6 +611,13 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             // cannot wrap past the ROM length.
             if (bytes.Length != ReadByteCount) return false;
             if ((ulong)CurrentAddr + (ulong)bytes.Length > (ulong)rom.Data.Length) return false;
+            // Safety-offset guard: refuse header / low / out-of-range targets so a
+            // mistyped Address box cannot mutate the ROM header under undo. Check
+            // both the start and the last byte of the slice.
+            if (bytes.Length > 0
+                && (!U.isSafetyOffset(CurrentAddr)
+                    || !U.isSafetyOffset(CurrentAddr + (uint)bytes.Length - 1)))
+                return false;
 
             // Single-range write → one undo entry (registers into the ambient
             // UndoService scope opened by the View), rather than one UndoPosition

--- a/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml
@@ -103,7 +103,8 @@
           <Grid RowDefinitions="Auto,*" Height="180">
             <TextBlock Grid.Row="0" Text="Disassembly" FontWeight="SemiBold" Margin="0,0,0,2" />
             <ListBox AutomationProperties.AutomationId="AIScript_Disassembly_List"
-                     Grid.Row="1" Name="DisassemblyList" />
+                     Grid.Row="1" Name="DisassemblyList"
+                     SelectionChanged="DisassemblyList_SelectionChanged" />
           </Grid>
         </Border>
 

--- a/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml.cs
@@ -193,6 +193,14 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void Write_Click(object? sender, RoutedEventArgs e)
         {
+            // Guard an empty/never-loaded model BEFORE opening the undo scope so
+            // we never produce a ghost undo entry or the misleading "length
+            // changed" error when the user hasn't pressed Re-read yet.
+            if (!_vm.HasDisassembly)
+            {
+                CoreState.Services.ShowInfo("Re-read the AI script before writing.");
+                return;
+            }
             _undoService.Begin("Edit AI Script");
             try
             {

--- a/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml.cs
@@ -181,19 +181,37 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         // -----------------------------------------------------------------
-        // Write-back. WF AllWriteButton_Click writes the full disassembled
-        // opcode list back; that path is WinForms-coupled via EventScript.
-        // DisAssemble + EventScriptUtil.JisageReorder. Without that, an
-        // Avalonia "Write" can't honestly mutate the ROM, so we tell the
-        // user and short-circuit BEFORE allocating an undo scope (per
-        // PR #571 Copilot bot review #1 — no ghost undo entry, no
-        // misleading "success" toast).
+        // Write-back (#760). Serializes the in-memory disassembled model
+        // (exact concatenation of each instruction's bytes — no EXIT
+        // normalization) and writes it back in-place under a UndoService
+        // scope. This is strictly SAME-SIZE: WriteScript() refuses (and we
+        // roll the scope back) if the length changed or the slice runs off
+        // the ROM, since a length change needs the New/Remove + free-space
+        // realloc path that stays deferred. Mirrors WF AllWriteButton_Click's
+        // concatenate-and-write core (minus the WinForms terminator append).
         // -----------------------------------------------------------------
 
         void Write_Click(object? sender, RoutedEventArgs e)
         {
-            CoreState.Services.ShowInfo(
-                "AI script Write is not yet implemented in Avalonia. The full opcode write-back requires the WinForms EventScript.DisAssemble pipeline, which is still WinForms-coupled. Use the WinForms editor for AI script writes.");
+            _undoService.Begin("Edit AI Script");
+            try
+            {
+                if (!_vm.WriteScript())
+                {
+                    _undoService.Rollback();
+                    CoreState.Services.ShowError(
+                        "Could not write (length changed or out of range — New/Remove not yet supported).");
+                    return;
+                }
+                _undoService.Commit();
+                CoreState.Services.ShowInfo("AI script written.");
+                ReloadList_Click(sender, e);
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("AIScriptView.Write: {0}", ex.Message);
+            }
         }
 
         // -----------------------------------------------------------------
@@ -239,26 +257,76 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         // -----------------------------------------------------------------
-        // Detail-row action buttons (no-op host parity placeholders).
-        // The fully functional Update / Remove / New flows require the WF
-        // EventScript.DisAssemble + EventScriptUtil.JisageReorder pipeline
-        // (WinForms-coupled). We emit informational dialogs so the surface
-        // matches the WF affordance set without misleading the user.
+        // Disassembly row selection (#760): mirror the selected instruction's
+        // bytes into the Binary Code box and its mnemonic into the Description
+        // label so the user can hand-edit the hex and re-decode via Update.
+        // -----------------------------------------------------------------
+
+        void DisassemblyList_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            try
+            {
+                int idx = DisassemblyList.SelectedIndex;
+                AsmBox.Text = _vm.GetRowHex(idx) ?? "";
+                ScriptCodeNameLabel.Text = _vm.GetRowOpcodeName(idx) ?? "";
+            }
+            catch (Exception ex)
+            {
+                Log.Error("AIScriptView.DisassemblyList_SelectionChanged failed: {0}", ex.Message);
+            }
+        }
+
+        // -----------------------------------------------------------------
+        // Update (#760): re-decode the hand-edited Binary Code hex for the
+        // selected row back into the model and refresh the Disassembly list
+        // from the in-memory model (NOT a ROM re-read, so the pending edit is
+        // reflected). Mirrors WF AIScriptForm.OneLineDisassembler. New /
+        // Remove stay deferred (explicit informational stubs below).
         // -----------------------------------------------------------------
 
         void Update_Click(object? sender, RoutedEventArgs e)
         {
-            CoreState.Services.ShowInfo("AI opcode editing is not yet fully implemented in Avalonia. Use the WinForms editor for opcode-level changes.");
+            try
+            {
+                int idx = DisassemblyList.SelectedIndex;
+                if (idx < 0)
+                {
+                    CoreState.Services.ShowInfo("Select an instruction first.");
+                    return;
+                }
+
+                string? line = _vm.UpdateRow(idx, AsmBox.Text);
+                if (line == null)
+                {
+                    CoreState.Services.ShowError(
+                        "Invalid instruction bytes (must be one 16-byte hex instruction).");
+                    return;
+                }
+
+                // Refresh from the in-memory model so the edit is visible
+                // before any Write (DisassembleScript would re-read the
+                // unmodified ROM and discard the pending edit).
+                DisassemblyList.ItemsSource = _vm.GetDisplayLines();
+                DisassemblyList.SelectedIndex = idx;
+            }
+            catch (Exception ex)
+            {
+                Log.Error("AIScriptView.Update_Click failed: {0}", ex.Message);
+            }
         }
 
+        // New / Remove stay deferred (#760 follow-up): inserting or deleting an
+        // instruction changes the script length, which needs the WF New/Remove
+        // + free-space reallocation path. Opcode-level VALUE edits go through
+        // Update_Click / Write_Click (same-size in-place) instead.
         void New_Click(object? sender, RoutedEventArgs e)
         {
-            CoreState.Services.ShowInfo("AI opcode editing is not yet fully implemented in Avalonia. Use the WinForms editor for opcode-level changes.");
+            CoreState.Services.ShowInfo("Inserting AI instructions is not yet supported in Avalonia (changes script length). Use the WinForms editor to add instructions; use Update to edit an existing instruction in place.");
         }
 
         void Remove_Click(object? sender, RoutedEventArgs e)
         {
-            CoreState.Services.ShowInfo("AI opcode editing is not yet fully implemented in Avalonia. Use the WinForms editor for opcode-level changes.");
+            CoreState.Services.ShowInfo("Removing AI instructions is not yet supported in Avalonia (changes script length). Use the WinForms editor to delete instructions; use Update to edit an existing instruction in place.");
         }
 
         void Close_Click(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- Builds on #757 (read-only AI disassembly) to make the Avalonia **AI Script editor** able to **edit and save** opcodes:
  - Selecting a disassembly row populates the **Binary Code** field with that instruction's 16-byte hex (+ decoded opcode name in Description).
  - **Update** re-decodes the (edited) hex via Core `EventScript.DisAseemble` and refreshes the row.
  - **Write** serializes the in-memory `OneCode` list and writes it back **in place** at the script address under a `UndoService` scope (fully undoable).
- Same-size, in-place only — mirrors WinForms `AIScriptForm.AllWriteButton_Click` minus the free-space realloc.

## Plan Reference
Implements the accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/760#issuecomment-4573015016 (Copilot CLI re-review: **no remaining blocking concerns**).

## Scope
Closes #760
Out of scope (explicit follow-up): New Insert / Remove (length change → free-space realloc + pointer repoint + EXIT-terminator normalization), and the per-argument Parameter-field widget binding (WF `ScriptEditSetTables`). New/Remove remain explicit stubs; editing is via the Binary Code hex field.

## Screenshots
AI Script Editor — disassembly row 0 selected → the **Binary Code** field is populated with the editable opcode hex (`05 64 FF 00 …` for `Attack05`, `Probability=100`), Description shows the decoded opcode, Update/Write enabled:

![AI Script Editor edit affordance](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/fix760-ai-edit-write.png?raw=1)

## GUI Test Report

### Environment
- ROM: `roms/FE8U.gba`
- Editor/View: Avalonia **AI Script Editor** (`AIScriptView`)
- Capture: PrintWindow (`tools/WinCapture`) + PowerShell UIAutomation navigation (locked-screen headless flow).

### Steps Performed
1. Launched the app (built from this branch) with FE8U; opened the AI Script Editor.
2. Clicked **Re-read** → disassembly populated (`Attack05 …`, `EXIT …`).
3. Selected disassembly row 0 via UIAutomation.
4. Read back the **Binary Code** field (`AIScript_Asm_Input`) value.

### Test Results
| Test | Expected | Actual | Status |
|------|----------|--------|--------|
| Row-select → Binary Code | Selected opcode's 16-byte hex appears in the editable field | `05 64 FF 00 00 00 00 00 00 00 00 00 00 00 00 00` | PASS |
| Description field | Decoded opcode name | `Attack05 attacking [PROBABILITY:Probability]` | PASS |
| Update / Write enabled | Buttons active, handlers wired (not stubs) | Wired (covered by headless + unit tests below) | PASS |

### Verdict
PASS — the edit affordance (row → Binary Code → Update → Write) is functional; Update/Write byte-level behavior + undo + persistence are covered by the automated tests below.

## Test plan
- [x] VM unit tests (`FEBuilderGBA.Avalonia.Tests/AIScriptEditWriteTests.cs`, 12 tests): `SerializeScript` round-trip identity; `UpdateRow` param edit (Attack05 prob `0x64`→`0x32`) reflected in row + serialized bytes; `UpdateRow` invalid input (too-long / non-hex → no mutation); `WriteScript` same-size updates ROM, length-mismatch/out-of-range refused (no partial write); empty list → no write; **undo** restores original ROM bytes; **persistence** (edit→Write→reload-from-ROM reflects change); `GetDisplayLines`; headless `[AvaloniaFact]` row-select→Binary-Code + Write — all pass.
- [x] Updated `GapSweep/AIScriptParityTests` assertion from "Write honestly deferred" → "Write wraps undo scope and writes in place" (per that test's own TODO once the write path landed).
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` — 7090 passed, 0 failed, 3 skipped.
- [x] `dotnet test FEBuilderGBA.Core.Tests` — 1988 passed, 0 failed.
- [x] `dotnet test FEBuilderGBA.Tests` (WinForms) — 1822 passed, 0 failed.
- [x] `dotnet build FEBuilderGBA.Avalonia -c Release` — 0 errors.
- [x] Manual GUI validation against FE8U — row-select populates Binary Code (screenshot + GUI Test Report above).

## Known limitations
- New Insert / Remove and per-argument Parameter-field editing remain explicit "not yet implemented" stubs (out of scope; tracked as the realloc follow-up). Editing is via the Binary Code hex field.

Generated with Claude Code v2.1.156 (model: claude-opus-4-8, Opus 4.8 1M context)
