### PR TITLE
fix(avalonia): AI-script New/Remove opcodes + any-size Write with realloc (#763)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/AIScriptDisassemblyTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/AIScriptDisassemblyTests.cs
@@ -341,11 +341,18 @@ namespace FEBuilderGBA.Avalonia.Tests
         readonly string? _prevBaseDir;
 
         readonly ROM _rom;
+        EventScript? _ai;
 
         /// <summary>The synthetic FE8U ROM backing this environment (#760
         /// edit/write tests inspect rom.Data directly to verify in-place
         /// writes / undo).</summary>
         public ROM Rom => _rom;
+
+        /// <summary>The fresh width-16 FE8 AI EventScript this env loaded (#763
+        /// realloc tests re-assert it as CoreState.AIScript before decoding so
+        /// a cross-test stale-but-populated script in the shared collection
+        /// cannot break DisassembleScript's lazy-load guard).</summary>
+        public EventScript? AiScript => _ai;
 
         /// <summary>Copy a [addr, addr+length) slice of the ROM, for
         /// before/after byte comparisons in the #760 write tests.</summary>
@@ -382,6 +389,7 @@ namespace FEBuilderGBA.Avalonia.Tests
             var ai = new EventScript(16);
             ai.Load(EventScript.EventScriptType.AI);
             CoreState.AIScript = ai;
+            _ai = ai;
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia.Tests/AIScriptEditWriteTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/AIScriptEditWriteTests.cs
@@ -235,13 +235,21 @@ namespace FEBuilderGBA.Avalonia.Tests
             using var env = new AiDisasmEnv();
             using var undo = new UndoScope();
 
-            var vm = env.LoadVmAt(Attack05(0x64));
+            // Fixture MUST end in EXIT so SerializeScript does NOT append a
+            // terminator — keeping serialized length == ReadByteCount (32) and
+            // forcing the SAME-SIZE in-place path, so this test exercises the
+            // intended out-of-range ROM-bounds guard (not the size-changed
+            // undoData==null short-circuit).
+            var body = new System.Collections.Generic.List<byte>();
+            body.AddRange(Attack05(0x64));
+            body.AddRange(ExitOpcode(0x00));
+            var vm = env.LoadVmAt(body.ToArray());
             vm.DisassembleScript();
             Assert.NotNull(vm.UpdateRow(0, HexLine(0x05, 0x32, 0xFF)));
+            Assert.Equal((int)vm.ReadByteCount, vm.SerializeScript().Length); // same-size
 
-            // Point CurrentAddr so the 16-byte slice runs off the ROM end.
-            // ReadByteCount stays 16 (matches serialized) so only the
-            // bounds guard fires.
+            // Point CurrentAddr so the 32-byte slice runs off the ROM end →
+            // the bounds guard rejects.
             vm.CurrentAddr = (uint)env.Rom.Data.Length - 8;
             Assert.False(vm.WriteScript());
         }

--- a/FEBuilderGBA.Avalonia.Tests/AIScriptEditWriteTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/AIScriptEditWriteTests.cs
@@ -760,6 +760,37 @@ namespace FEBuilderGBA.Avalonia.Tests
         }
 
         // ----------------------------------------------------------------
+        // Copilot review (stale-model data-loss): LoadEntry must reset the
+        // editable model, so opcodes from a previously-loaded entry cannot be
+        // serialized into / repointed onto the newly-selected entry.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void LoadEntry_ResetsEditableModel_PreventingStaleWrite()
+        {
+            using var env = new AiDisasmEnv();
+            CoreState.ROM = env.Rom;
+            CoreState.AIScript = env.AiScript;
+
+            // Load + disassemble an entry: the editable model is populated.
+            var body = new System.Collections.Generic.List<byte>();
+            body.AddRange(Attack05(0x64));
+            body.AddRange(ExitOpcode(0x00));
+            var vm = env.LoadVmAt(body.ToArray());
+            vm.DisassembleScript();
+            Assert.True(vm.HasDisassembly);
+
+            // Select a different entry via LoadEntry (as OnSelected does). The
+            // model must reset so a Write cannot carry the old opcodes over.
+            env.PlantBody(body.ToArray(), out uint slot);
+            vm.LoadEntry(slot);
+
+            Assert.False(vm.HasDisassembly);          // model cleared
+            Assert.Empty(vm.SerializeScript());        // nothing stale to write
+            Assert.False(vm.WriteScript(CoreState.Undo?.NewUndoData("x"))); // Write blocked
+        }
+
+        // ----------------------------------------------------------------
         // Copilot review: New on an UN-loaded model (no Re-read) must NOT
         // insert — otherwise a later Write would serialize just the new opcode
         // and repoint the AI slot, dropping all existing opcodes.

--- a/FEBuilderGBA.Avalonia.Tests/AIScriptEditWriteTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/AIScriptEditWriteTests.cs
@@ -169,13 +169,19 @@ namespace FEBuilderGBA.Avalonia.Tests
             string? line = vm.UpdateRow(0, "05 32 FF");
             Assert.NotNull(line);
 
+            // SerializeScript now appends a WF-parity EXIT terminator because
+            // the single Attack05 row does not end in 0x03 (#763), so the
+            // serialized length is 32 = 16 (padded Attack05) + 16 (EXIT).
             byte[] serialized = vm.SerializeScript();
-            Assert.Equal(16, serialized.Length);
+            Assert.Equal(32, serialized.Length);
+            // The edited row occupies the FIRST 16-byte slot, right-padded.
             Assert.Equal(0x05, serialized[0]);
             Assert.Equal(0x32, serialized[1]);
             Assert.Equal(0xFF, serialized[2]);
             for (int i = 3; i < 16; i++)
                 Assert.Equal(0x00, serialized[i]);
+            // The appended EXIT occupies the second slot.
+            Assert.Equal(0x03, serialized[16]);
         }
 
         // ----------------------------------------------------------------
@@ -395,6 +401,471 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.Equal(2, lines.Count);
             Assert.True(lines[0].Contains("0x32") || lines[0].Contains("50"),
                 $"GetDisplayLines must show the in-memory edit, got: {lines[0]}");
+        }
+
+        // ================================================================
+        // #763 — New/Remove opcode editing + any-size Write (realloc + repoint)
+        // ================================================================
+
+        // ----------------------------------------------------------------
+        // 763.1 SerializeScript appends EXIT when the last opcode != 0x03;
+        //       no double-append when the script already ends in EXIT.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void SerializeScript_AppendsExit_WhenLastOpcodeNotExit()
+        {
+            using var env = new AiDisasmEnv();
+
+            // Single Attack05 (first byte 0x05 != 0x03) -> serialize must add a
+            // 16-byte EXIT terminator (WF parity).
+            var vm = env.LoadVmAt(Attack05(0x64));
+            vm.DisassembleScript();
+
+            byte[] serialized = vm.SerializeScript();
+            Assert.Equal(32, serialized.Length);          // 16 (Attack05) + 16 (EXIT)
+            Assert.Equal(0x05, serialized[0]);
+            Assert.Equal(0x03, serialized[16]);            // appended EXIT opcode
+            Assert.Equal(0xFF, serialized[18]);            // EXIT FIXED byte
+        }
+
+        [Fact]
+        public void SerializeScript_NoDoubleAppend_WhenAlreadyEndsInExit()
+        {
+            using var env = new AiDisasmEnv();
+
+            // Attack05 + EXIT: last opcode IS 0x03 -> no extra terminator.
+            var body = new List<byte>();
+            body.AddRange(Attack05(0x64));
+            body.AddRange(ExitOpcode(0x00));
+            var vm = env.LoadVmAt(body.ToArray());
+            vm.DisassembleScript();
+
+            byte[] serialized = vm.SerializeScript();
+            Assert.Equal(32, serialized.Length);           // unchanged — no double EXIT
+            Assert.Equal(0x05, serialized[0]);
+            Assert.Equal(0x03, serialized[16]);
+        }
+
+        // ----------------------------------------------------------------
+        // 763.2 InsertRow grows by one; decoded opcode placed AFTER index;
+        //       JisageReorder applied (row offsets re-laid contiguously).
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void InsertRow_AddsDecodedOpcodeAfterIndex_AndRebuildsOffsets()
+        {
+            using var env = new AiDisasmEnv();
+
+            var body = new List<byte>();
+            body.AddRange(Attack05(0x64));
+            body.AddRange(ExitOpcode(0x00));
+            var vm = env.LoadVmAt(body.ToArray());
+            vm.DisassembleScript();
+            Assert.Equal(2, vm.RowCount);
+
+            // Insert a DoNothing (06 00 FF) AFTER row 0.
+            string? line = vm.InsertRow(0, HexLine(0x06, 0x00, 0xFF));
+            Assert.NotNull(line);
+            Assert.Contains("DoNothing", line!);
+            Assert.Equal(3, vm.RowCount);
+
+            // The new row is index 1 (after index 0); the EXIT shifted to 2.
+            IReadOnlyList<string> rows = vm.GetDisplayLines();
+            Assert.Contains("Attack05", rows[0]);
+            Assert.Contains("DoNothing", rows[1]);
+            Assert.Contains("EXIT", rows[2]);
+
+            // Offsets are re-laid contiguously at CurrentAddr + i*16.
+            Assert.Contains($"0x{vm.CurrentAddr:X06}", rows[0]);
+            Assert.Contains($"0x{vm.CurrentAddr + 16:X06}", rows[1]);
+            Assert.Contains($"0x{vm.CurrentAddr + 32:X06}", rows[2]);
+        }
+
+        [Fact]
+        public void InsertRow_NegativeIndex_AppendsAtEnd()
+        {
+            using var env = new AiDisasmEnv();
+
+            var vm = env.LoadVmAt(Attack05(0x64));
+            vm.DisassembleScript();
+            Assert.Equal(1, vm.RowCount);
+
+            // SelectedIndex < 0 -> Add at the end (WF parity).
+            string? line = vm.InsertRow(-1, HexLine(0x06, 0x00, 0xFF));
+            Assert.NotNull(line);
+            Assert.Contains("DoNothing", line!);
+            Assert.Equal(2, vm.RowCount);
+            Assert.Contains("DoNothing", vm.GetDisplayLines()[1]);
+        }
+
+        [Fact]
+        public void InsertRow_InvalidBytes_ReturnsNullAndLeavesModelUnchanged()
+        {
+            using var env = new AiDisasmEnv();
+
+            var vm = env.LoadVmAt(Attack05(0x64));
+            vm.DisassembleScript();
+            int before = vm.RowCount;
+
+            Assert.Null(vm.InsertRow(0, ""));                 // empty
+            Assert.Null(vm.InsertRow(0, "zz"));               // non-hex
+            Assert.Null(vm.InsertRow(0,                       // over one instruction
+                string.Join(" ", Enumerable.Range(0, 17).Select(_ => "00"))));
+            Assert.Equal(before, vm.RowCount);
+        }
+
+        // ----------------------------------------------------------------
+        // 763.3 RemoveRow shrinks by one; refuses when only one opcode left.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void RemoveRow_ShrinksByOne_AndRefusesLastInstruction()
+        {
+            using var env = new AiDisasmEnv();
+
+            var body = new List<byte>();
+            body.AddRange(Attack05(0x64));
+            body.AddRange(ExitOpcode(0x00));
+            var vm = env.LoadVmAt(body.ToArray());
+            vm.DisassembleScript();
+            Assert.Equal(2, vm.RowCount);
+
+            // Remove row 0 -> only EXIT remains.
+            Assert.True(vm.RemoveRow(0));
+            Assert.Equal(1, vm.RowCount);
+            Assert.Contains("EXIT", vm.GetDisplayLines()[0]);
+
+            // Refuse to remove the last remaining instruction (never empty).
+            Assert.False(vm.RemoveRow(0));
+            Assert.Equal(1, vm.RowCount);
+
+            // Out-of-range index is also refused.
+            Assert.False(vm.RemoveRow(99));
+        }
+
+        // ----------------------------------------------------------------
+        // 763.4 Write after Insert (size grew) with a real UndoData → bytes
+        //       appended at a safe addr; rom.p32(BaseAddr) == newAddr;
+        //       CurrentAddr / ReadByteCount updated.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void WriteScript_AfterInsert_RelocatesAndRepointsSlot()
+        {
+            using var env = new AiDisasmEnv();
+
+            Undo? prevUndo = CoreState.Undo;
+            CoreState.Undo = new Undo();
+            try
+            {
+                AIScriptViewModel vm = LoadViaPointerSlot(env,
+                    Concat(Attack05(0x64), ExitOpcode(0x00)), out uint baseAddr);
+                vm.DisassembleScript();
+
+                uint origCurrent = vm.CurrentAddr;
+                uint origByteCount = vm.ReadByteCount; // 32
+
+                // Insert a DoNothing after row 0: 3 opcodes, still ends in EXIT
+                // -> serialized length = 48 (grew from 32).
+                Assert.NotNull(vm.InsertRow(0, HexLine(0x06, 0x00, 0xFF)));
+
+                var ud = CoreState.Undo!.NewUndoData("ins");
+                bool ok;
+                using (ROM.BeginUndoScope(ud))
+                {
+                    ok = vm.WriteScript(ud);
+                }
+                CoreState.Undo.Push(ud);
+
+                Assert.True(ok);
+                // Relocated: CurrentAddr moved off the original slot.
+                Assert.NotEqual(origCurrent, vm.CurrentAddr);
+                Assert.True(U.isSafetyOffset(vm.CurrentAddr));
+                Assert.Equal(48u, vm.ReadByteCount);
+                Assert.NotEqual(origByteCount, vm.ReadByteCount);
+
+                // The AI pointer slot now points at the new script location.
+                Assert.Equal(vm.CurrentAddr, env.Rom.p32(baseAddr));
+
+                // The relocated body carries the inserted DoNothing + EXIT.
+                Assert.Equal(0x05, env.Rom.Data[vm.CurrentAddr + 0]);
+                Assert.Equal(0x06, env.Rom.Data[vm.CurrentAddr + 16]);
+                Assert.Equal(0x03, env.Rom.Data[vm.CurrentAddr + 32]);
+            }
+            finally
+            {
+                CoreState.Undo = prevUndo;
+            }
+        }
+
+        // ----------------------------------------------------------------
+        // 763.5 Write after Remove (size shrank) → relocates + repoints.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void WriteScript_AfterRemove_RelocatesAndRepointsSlot()
+        {
+            using var env = new AiDisasmEnv();
+
+            Undo? prevUndo = CoreState.Undo;
+            CoreState.Undo = new Undo();
+            try
+            {
+                // Three opcodes ending in EXIT (48 bytes).
+                byte[] body = Concat(Attack05(0x64), DoNothingBody(), ExitOpcode(0x00));
+                AIScriptViewModel vm = LoadViaPointerSlot(env, body, out uint baseAddr);
+                vm.DisassembleScript();
+                Assert.Equal(3, vm.RowCount);
+                uint origByteCount = vm.ReadByteCount; // 48
+
+                // Remove the middle DoNothing -> 2 opcodes ending in EXIT = 32.
+                Assert.True(vm.RemoveRow(1));
+
+                var ud = CoreState.Undo!.NewUndoData("rem");
+                bool ok;
+                using (ROM.BeginUndoScope(ud))
+                {
+                    ok = vm.WriteScript(ud);
+                }
+                CoreState.Undo.Push(ud);
+
+                Assert.True(ok);
+                Assert.Equal(32u, vm.ReadByteCount);
+                Assert.NotEqual(origByteCount, vm.ReadByteCount);
+                Assert.True(U.isSafetyOffset(vm.CurrentAddr));
+                Assert.Equal(vm.CurrentAddr, env.Rom.p32(baseAddr));
+
+                // Relocated body: Attack05 then EXIT (DoNothing gone).
+                Assert.Equal(0x05, env.Rom.Data[vm.CurrentAddr + 0]);
+                Assert.Equal(0x03, env.Rom.Data[vm.CurrentAddr + 16]);
+            }
+            finally
+            {
+                CoreState.Undo = prevUndo;
+            }
+        }
+
+        // ----------------------------------------------------------------
+        // 763.6 Undo: a realloc Write under a Core undo scope → RunUndo()
+        //       restores rom.p32(BaseAddr) to the ORIGINAL slot value.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void WriteScript_Realloc_IsUndoable_RestoresOriginalSlot()
+        {
+            using var env = new AiDisasmEnv();
+
+            Undo? prevUndo = CoreState.Undo;
+            CoreState.Undo = new Undo();
+            try
+            {
+                AIScriptViewModel vm = LoadViaPointerSlot(env,
+                    Concat(Attack05(0x64), ExitOpcode(0x00)), out uint baseAddr);
+                vm.DisassembleScript();
+
+                uint origSlotValue = env.Rom.p32(baseAddr); // points at original script
+
+                Assert.NotNull(vm.InsertRow(0, HexLine(0x06, 0x00, 0xFF)));
+
+                var ud = CoreState.Undo!.NewUndoData("ins");
+                using (ROM.BeginUndoScope(ud))
+                {
+                    Assert.True(vm.WriteScript(ud));
+                }
+                CoreState.Undo.Push(ud);
+
+                // The slot was repointed away from the original.
+                Assert.NotEqual(origSlotValue, env.Rom.p32(baseAddr));
+
+                // Undo: the AI pointer slot returns to the ORIGINAL value.
+                CoreState.Undo.RunUndo();
+                Assert.Equal(origSlotValue, env.Rom.p32(baseAddr));
+            }
+            finally
+            {
+                CoreState.Undo = prevUndo;
+            }
+        }
+
+        // ----------------------------------------------------------------
+        // 763.7 Same-size Write (no structural edit) still in-place: no
+        //       relocation, CurrentAddr unchanged.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void WriteScript_SameSizeNoStructuralEdit_StaysInPlace()
+        {
+            using var env = new AiDisasmEnv();
+
+            Undo? prevUndo = CoreState.Undo;
+            CoreState.Undo = new Undo();
+            try
+            {
+                AIScriptViewModel vm = LoadViaPointerSlot(env,
+                    Concat(Attack05(0x64), ExitOpcode(0x00)), out uint baseAddr);
+                vm.DisassembleScript();
+
+                uint origCurrent = vm.CurrentAddr;
+                uint origByteCount = vm.ReadByteCount;
+                uint origSlotValue = env.Rom.p32(baseAddr);
+
+                // Value-only edit keeps the row count (ends in EXIT -> 32 bytes).
+                Assert.NotNull(vm.UpdateRow(0, HexLine(0x05, 0x32, 0xFF)));
+
+                var ud = CoreState.Undo!.NewUndoData("same");
+                using (ROM.BeginUndoScope(ud))
+                {
+                    Assert.True(vm.WriteScript(ud));
+                }
+                CoreState.Undo.Push(ud);
+
+                // Strictly in-place: no relocation, slot untouched.
+                Assert.Equal(origCurrent, vm.CurrentAddr);
+                Assert.Equal(origByteCount, vm.ReadByteCount);
+                Assert.Equal(origSlotValue, env.Rom.p32(baseAddr));
+                // The edited byte landed in place.
+                Assert.Equal(0x32, env.Rom.Data[origCurrent + 1]);
+            }
+            finally
+            {
+                CoreState.Undo = prevUndo;
+            }
+        }
+
+        // ----------------------------------------------------------------
+        // 763.8 Size-changed Write with undoData == null → false, no mutation.
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void WriteScript_SizeChanged_NullUndoData_RefusesNoMutation()
+        {
+            using var env = new AiDisasmEnv();
+
+            AIScriptViewModel vm = LoadViaPointerSlot(env,
+                Concat(Attack05(0x64), ExitOpcode(0x00)), out uint baseAddr);
+            vm.DisassembleScript();
+
+            uint origSlotValue = env.Rom.p32(baseAddr);
+            uint origLength = (uint)env.Rom.Data.Length;
+
+            // Grow the script (Insert) then attempt a Write with NO undoData.
+            Assert.NotNull(vm.InsertRow(0, HexLine(0x06, 0x00, 0xFF)));
+
+            Assert.False(vm.WriteScript(null));
+
+            // Nothing relocated, repointed, or grown.
+            Assert.Equal(origSlotValue, env.Rom.p32(baseAddr));
+            Assert.Equal(origLength, (uint)env.Rom.Data.Length);
+        }
+
+        // ----------------------------------------------------------------
+        // 763.9 [AvaloniaFact] View New -> Write persists a relocated script:
+        //       rom.p32(BaseAddr) changed + the list grew by one row.
+        // ----------------------------------------------------------------
+
+        [AvaloniaFact]
+        public void View_New_ThenWrite_RelocatesAndGrowsList()
+        {
+            using var env = new AiDisasmEnv();
+
+            Undo? prevUndo = CoreState.Undo;
+            CoreState.Undo = new Undo();
+            try
+            {
+                var body = new List<byte>();
+                body.AddRange(Attack05(0x64));
+                body.AddRange(ExitOpcode(0x00));
+                env.PlantBody(body.ToArray(), out uint pointerSlotAddr);
+
+                var view = new AIScriptView();
+                var asmBox = view.FindControl<TextBox>("AsmBox");
+                var list = view.FindControl<ListBox>("DisassemblyList");
+                Assert.NotNull(asmBox);
+                Assert.NotNull(list);
+
+                var vmField = typeof(AIScriptView).GetField(
+                    "_vm",
+                    System.Reflection.BindingFlags.Instance |
+                    System.Reflection.BindingFlags.NonPublic);
+                Assert.NotNull(vmField);
+                var vm = (AIScriptViewModel)vmField!.GetValue(view)!;
+
+                // Re-assert env's ROM as active (defensive vs shared-collection churn).
+                CoreState.ROM = env.Rom;
+                vm.LoadEntry(pointerSlotAddr);
+                Assert.True(vm.IsLoaded);
+
+                var addressBox = view.FindControl<NumericUpDown>("AddressBox");
+                var byteCountBox = view.FindControl<NumericUpDown>("ReadByteCountBox");
+                addressBox!.Value = vm.CurrentAddr;
+                byteCountBox!.Value = vm.ReadByteCount;
+
+                // Re-read populates the list + model.
+                Invoke(view, "ReloadList_Click");
+                int rowsBefore = (list!.ItemsSource as IEnumerable<string>)?.Count() ?? 0;
+                Assert.Equal(2, rowsBefore);
+
+                uint origSlotValue = env.Rom.p32(vm.BaseAddr);
+
+                // Select row 0, type a new 16-byte instruction, New -> Write.
+                list.SelectedIndex = 0;
+                asmBox!.Text = HexLine(0x06, 0x00, 0xFF); // DoNothing
+                Invoke(view, "New_Click");
+                Invoke(view, "Write_Click");
+
+                // The list grew by one row (Attack05 + DoNothing + EXIT = 3).
+                int rowsAfter = (list.ItemsSource as IEnumerable<string>)?.Count() ?? 0;
+                Assert.Equal(3, rowsAfter);
+
+                // The AI pointer slot was repointed to the relocated script.
+                Assert.NotEqual(origSlotValue, env.Rom.p32(vm.BaseAddr));
+                Assert.Equal(vm.CurrentAddr, env.Rom.p32(vm.BaseAddr));
+            }
+            finally
+            {
+                CoreState.Undo = prevUndo;
+            }
+        }
+
+        // ----------------------------------------------------------------
+        // Helpers for the #763 realloc tests.
+        // ----------------------------------------------------------------
+
+        // DoNothing 16-byte body (06 00 FF ...), distinct from ExitOpcode.
+        static byte[] DoNothingBody()
+        {
+            var b = new byte[16];
+            b[0] = 0x06; b[1] = 0x00; b[2] = 0xFF;
+            return b;
+        }
+
+        static byte[] Concat(params byte[][] parts)
+        {
+            var list = new List<byte>();
+            foreach (var p in parts) list.AddRange(p);
+            return list.ToArray();
+        }
+
+        // Plant a body + pointer slot, follow the slot via LoadEntry (sets
+        // BaseAddr / CurrentAddr / ReadByteCount / IsLoaded) and return the VM.
+        // The realloc Write path needs a real BaseAddr (the AI pointer slot),
+        // which LoadVmAt does NOT set.
+        static AIScriptViewModel LoadViaPointerSlot(AiDisasmEnv env, byte[] body, out uint baseAddr)
+        {
+            env.PlantBody(body, out uint pointerSlotAddr);
+            baseAddr = pointerSlotAddr;
+            // Defensive (matches the AvaloniaFact below): re-assert the env's
+            // ROM + fresh width-16 AI script as the active ones before LoadEntry
+            // / DisassembleScript, so the pointer-slot follow and opcode decode
+            // resolve deterministically regardless of any cross-test CoreState
+            // churn in the shared [Collection("SharedState")] (the full-suite
+            // run interleaves classes that reassign CoreState.ROM / AIScript).
+            CoreState.ROM = env.Rom;
+            CoreState.AIScript = env.AiScript;
+            var vm = new AIScriptViewModel();
+            vm.LoadEntry(pointerSlotAddr);
+            return vm;
         }
 
         // ----------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia.Tests/AIScriptEditWriteTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/AIScriptEditWriteTests.cs
@@ -760,6 +760,36 @@ namespace FEBuilderGBA.Avalonia.Tests
         }
 
         // ----------------------------------------------------------------
+        // Copilot review: New on an UN-loaded model (no Re-read) must NOT
+        // insert — otherwise a later Write would serialize just the new opcode
+        // and repoint the AI slot, dropping all existing opcodes.
+        // ----------------------------------------------------------------
+
+        [AvaloniaFact]
+        public void View_New_WithoutReadList_DoesNotInsert()
+        {
+            using var env = new AiDisasmEnv();
+            CoreState.ROM = env.Rom;
+            CoreState.AIScript = env.AiScript;
+
+            var view = new AIScriptView();
+            var list = view.FindControl<ListBox>("DisassemblyList");
+            var asmBox = view.FindControl<TextBox>("AsmBox");
+            Assert.NotNull(list);
+            Assert.NotNull(asmBox);
+
+            // No Re-read: the model is empty. Provide a valid opcode anyway.
+            asmBox!.Text = HexLine(0x05, 0x32, 0xFF);
+            Invoke(view, "New_Click");
+
+            // Guard fired: nothing was inserted.
+            var items = list!.ItemsSource as System.Collections.IEnumerable;
+            int count = 0;
+            if (items != null) foreach (var _ in items) count++;
+            Assert.Equal(0, count);
+        }
+
+        // ----------------------------------------------------------------
         // 763.9 [AvaloniaFact] View New -> Write persists a relocated script:
         //       rom.p32(BaseAddr) changed + the list grew by one row.
         // ----------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/AIScriptParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/AIScriptParityTests.cs
@@ -268,12 +268,12 @@ public class AIScriptParityTests
     [Fact]
     public void View_WriteHandler_WrapsUndoScopeAndWritesInPlace()
     {
-        // #760: AI script opcode write-back is now implemented as a
-        // SAME-SIZE in-place write. The Write_Click handler must wrap the
+        // #760/#763: AI script opcode write-back drives the VM's WriteScript,
+        // which now handles BOTH a same-size in-place write AND a New/Remove
+        // realloc + pointer-repoint. The Write_Click handler must wrap the
         // write in a UndoService.Begin / Commit block (rolling back on a
-        // refused / failed write) and call the VM's WriteScript() — parity
-        // with SongTrack / EDView. This replaces the prior "honestly
-        // deferred" assertion (PR #571) per that test's own follow-up note.
+        // refused / failed write) and pass the active undoData so the realloc
+        // path is undo-tracked — parity with SongTrack / EDView.
         string codeBehindPath = CodeBehindPath();
         Assert.True(File.Exists(codeBehindPath), $"Code-behind not found at {codeBehindPath}");
         string code = File.ReadAllText(codeBehindPath);
@@ -283,7 +283,8 @@ public class AIScriptParityTests
         Assert.Contains("_undoService.Begin(", code);
         Assert.Contains("_undoService.Commit(", code);
         Assert.Contains("_undoService.Rollback(", code);
-        Assert.Contains("WriteScript()", code);
+        // The realloc path requires the active undoData (#763).
+        Assert.Contains("WriteScript(_undoService.GetActiveUndoData())", code);
 
         // The old "not yet implemented" Write message must be gone.
         Assert.DoesNotContain("AI script Write is not yet implemented in Avalonia", code);

--- a/FEBuilderGBA.Avalonia/ViewModels/AIScriptViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/AIScriptViewModel.cs
@@ -220,6 +220,15 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             ROM rom = CoreState.ROM;
             if (rom == null) return;
 
+            // Loading a (possibly different) entry invalidates the editable
+            // model: clear it so a stale disassembly from a previously-loaded
+            // entry can't be serialized into / repointed onto this one (Copilot
+            // review — stale-model data-loss path). The View re-disassembles for
+            // the newly-loaded entry immediately after; until then HasDisassembly
+            // is false and Write/New/Remove are blocked.
+            _disassembled.Clear();
+            _rowOffsets.Clear();
+
             BaseAddr = pointerSlotAddr;
             if (!U.isSafetyOffset(pointerSlotAddr + 3))
             {

--- a/FEBuilderGBA.Avalonia/ViewModels/AIScriptViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/AIScriptViewModel.cs
@@ -780,12 +780,22 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 || (ulong)BaseAddr + 4 > (ulong)rom.Data.Length)
                 return false;
 
+            uint oldAddr = CurrentAddr;
+            uint oldSize = ReadByteCount;
+
             uint newAddr = AppendBinaryDataHeadless(rom, bytes, undoData);
             if (!U.isSafetyOffset(newAddr)) return false;
 
             // Repoint the AI table slot at the new script location — same
             // undoData/transaction as the append so RunUndo reverses both.
             rom.write_p32(BaseAddr, newAddr, undoData);
+
+            // Move the per-row comment / lint annotations to the new location so
+            // a relocate does not orphan them at the old offset (mirrors WF
+            // AllWriteButton's CommentCache update; same RepointEtcData pattern
+            // DataExpansionCore.ExpandTableTo uses on table relocation).
+            CoreState.CommentCache?.RepointEtcData(oldAddr, oldSize, newAddr);
+            CoreState.LintCache?.RepointEtcData(oldAddr, oldSize, newAddr);
 
             CurrentAddr = newAddr;
             ReadByteCount = (uint)bytes.Length;

--- a/FEBuilderGBA.Avalonia/ViewModels/AIScriptViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/AIScriptViewModel.cs
@@ -549,55 +549,188 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         }
 
         // ----------------------------------------------------------------
-        // Serialize + write-back (#760, mirrors WF AllWriteButton_Click).
+        // Structural edits (#763): insert / remove a 16-byte AI instruction.
+        // Mirror WF AIScriptForm.NewButton_Click / RemoveButton_Click — both
+        // mutate the in-memory list then run EventScriptUtil.JisageReorder.
+        // These change the script length, so a subsequent WriteScript() takes
+        // the free-space realloc + pointer-repoint path rather than the
+        // same-size in-place path.
         // ----------------------------------------------------------------
 
         /// <summary>
-        /// Exact concatenation of every decoded instruction's ByteData, in
-        /// row order. This is a SAME-SIZE, in-place serialization: NO EXIT
-        /// terminator is appended and NO normalization is performed — the
-        /// loaded ReadByteCount already includes the trailing EXIT because
-        /// CalcScriptLength reads through it. (EXIT normalization + free-space
-        /// realloc + New/Remove are deferred, see #760 follow-up.) Returns an
-        /// empty array when nothing has been disassembled.
+        /// Insert a hand-typed 16-byte instruction AFTER the row at
+        /// <paramref name="index"/> (mirrors WF NewButton_Click:
+        /// AIAsm.Insert(SelectedIndex + 1, code), or Add when nothing is
+        /// selected). The bytes are parsed via the same width rule as the
+        /// per-row hex edit (one 16-byte instruction; short input is
+        /// zero-padded). After inserting, EventScriptUtil.JisageReorder is run
+        /// (WF parity) and _rowOffsets is rebuilt as CurrentAddr + i*16 so the
+        /// display lines carry the right per-row addresses.
+        ///
+        /// Returns the formatted display line for the newly-inserted row on
+        /// success (non-null = success), or null (leaving the model untouched)
+        /// on empty / non-hex / over-length input or a decode failure.
+        /// </summary>
+        public string? InsertRow(int index, string hexText)
+        {
+            byte[]? bytes = ParseInstructionHex(hexText);
+            if (bytes == null) return null;
+
+            EventScript es = CoreState.AIScript;
+            if (es == null) return null;
+
+            EventScript.OneCode code;
+            try
+            {
+                code = es.DisAseemble(bytes, 0);
+            }
+            catch
+            {
+                return null;
+            }
+            if (code == null || code.ByteData == null) return null;
+
+            int insertAt;
+            if (index < 0 || index >= _disassembled.Count)
+            {
+                _disassembled.Add(code);
+                insertAt = _disassembled.Count - 1;
+            }
+            else
+            {
+                insertAt = index + 1;
+                _disassembled.Insert(insertAt, code);
+            }
+
+            // WF parity: re-run the auto-indent / label reorder pass.
+            EventScriptUtil.JisageReorder(_disassembled);
+            RebuildRowOffsets();
+
+            uint off = insertAt < _rowOffsets.Count ? _rowOffsets[insertAt] : CurrentAddr;
+            return FormatAiRow(_disassembled[insertAt], off);
+        }
+
+        /// <summary>
+        /// Remove the instruction at <paramref name="index"/> (mirrors WF
+        /// RemoveButton_Click: AIAsm.RemoveAt(SelectedIndex)). Refuses to
+        /// remove the LAST remaining instruction so the script never becomes
+        /// empty (an empty script has no EXIT terminator and cannot be
+        /// written safely). After removal, EventScriptUtil.JisageReorder is run
+        /// and _rowOffsets is rebuilt. Returns true when a row was removed,
+        /// false on an out-of-range index or when only one row remains.
+        /// </summary>
+        public bool RemoveRow(int index)
+        {
+            if (index < 0 || index >= _disassembled.Count) return false;
+            if (_disassembled.Count <= 1) return false; // never empty
+
+            _disassembled.RemoveAt(index);
+            EventScriptUtil.JisageReorder(_disassembled);
+            RebuildRowOffsets();
+            return true;
+        }
+
+        /// <summary>
+        /// Recompute the per-row offsets as CurrentAddr + i*16 for the current
+        /// row count. AI is a FIXED 16-byte grid, so after a structural edit the
+        /// rows are simply re-laid-out contiguously from CurrentAddr. (The real
+        /// ROM offsets only matter once WriteScript relocates the script; until
+        /// then these drive the display-line addresses.)
+        /// </summary>
+        void RebuildRowOffsets()
+        {
+            _rowOffsets.Clear();
+            for (int i = 0; i < _disassembled.Count; i++)
+                _rowOffsets.Add(CurrentAddr + (uint)i * 16);
+        }
+
+        // ----------------------------------------------------------------
+        // Serialize + write-back (#760/#763, mirrors WF AllWriteButton_Click).
+        // ----------------------------------------------------------------
+
+        /// <summary>16-byte AI EXIT terminator (opcode 0x03). Appended by
+        /// SerializeScript when the script does not already end in EXIT,
+        /// matching WF AllWriteButton_Click's terminal-code append.</summary>
+        static readonly byte[] ExitTerminator = new byte[16]
+        {
+            0x03, 0x00, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        };
+
+        /// <summary>
+        /// Concatenate every decoded instruction's ByteData, in row order,
+        /// then guarantee the script ends in an EXIT (0x03) terminator —
+        /// mirroring WF AIScriptForm.AllWriteButton_Click, which appends a
+        /// 16-byte EXIT when the last opcode's first byte is not 0x03. This
+        /// keeps the New/Remove realloc path from writing a script that runs
+        /// off its end into whatever follows in free space. No double-append:
+        /// when the model already ends in EXIT, nothing extra is added.
+        /// Returns an empty array when nothing has been disassembled.
         /// </summary>
         public byte[] SerializeScript()
         {
             int total = 0;
+            byte lastFirstByte = 0;
+            bool any = false;
             for (int i = 0; i < _disassembled.Count; i++)
             {
                 byte[] b = _disassembled[i].ByteData;
-                if (b != null) total += b.Length;
+                if (b == null || b.Length == 0) continue;
+                total += b.Length;
+                lastFirstByte = b[0];
+                any = true;
             }
+
+            // WF parity: append a 16-byte EXIT when the script is non-empty and
+            // does not already terminate with opcode 0x03.
+            bool appendExit = any && lastFirstByte != 0x03;
+            if (appendExit) total += ExitTerminator.Length;
 
             byte[] result = new byte[total];
             int pos = 0;
             for (int i = 0; i < _disassembled.Count; i++)
             {
                 byte[] b = _disassembled[i].ByteData;
-                if (b == null) continue;
+                if (b == null || b.Length == 0) continue;
                 Array.Copy(b, 0, result, pos, b.Length);
                 pos += b.Length;
             }
+            if (appendExit)
+                Array.Copy(ExitTerminator, 0, result, pos, ExitTerminator.Length);
             return result;
         }
 
         /// <summary>
-        /// Write the serialized instruction bytes back to the ROM at
-        /// CurrentAddr. Callers MUST wrap this call in a UndoService.Begin /
-        /// Commit block — the single rom.write_range call registers into the
-        /// ambient undo scope the View opens.
+        /// Write the serialized instruction bytes back to the ROM. Callers MUST
+        /// wrap this call in a UndoService.Begin / Commit block so the writes
+        /// register into the ambient undo scope the View opens.
         ///
-        /// This is a strict SAME-SIZE in-place write: it refuses to write
-        /// (returns false, mutating nothing) when the serialized length does
-        /// not equal the loaded ReadByteCount, when the target is not a safe
-        /// ROM offset (rejects header / out-of-range addresses a mistyped
-        /// Address box could supply), or when the write would run off the end
-        /// of the ROM. A length change means New/Remove territory, which needs
-        /// free-space reallocation (out of scope, #760 follow-up). Returns true
-        /// only when the full slice was written.
+        /// Two paths, chosen by the serialized length vs the loaded
+        /// ReadByteCount (mirrors WF AIScriptForm.AllWriteButton_Click, whose
+        /// WriteBinaryData reuses the slot in place when the size matches and
+        /// reallocates to free space otherwise):
+        ///
+        /// • SAME-SIZE (bytes.Length == ReadByteCount): a strict in-place write
+        ///   at CurrentAddr via rom.write_range. Refuses (returns false,
+        ///   mutating nothing) when the target is not a safe ROM offset (rejects
+        ///   header / out-of-range addresses a mistyped Address box could
+        ///   supply) or when the slice would run off the end of the ROM. No
+        ///   relocation — CurrentAddr / ReadByteCount are unchanged.
+        ///
+        /// • SIZE-CHANGED (New/Remove edited the row count, so SerializeScript
+        ///   now appends/omits the EXIT terminator): the script is appended to
+        ///   free space (AppendBinaryDataHeadless) and the AI pointer slot
+        ///   (BaseAddr) is repointed via rom.write_p32 — both signed against the
+        ///   SAME undoData so the realloc + repoint commit (and roll back) as one
+        ///   transaction. Requires a non-null undoData (the realloc must be
+        ///   undo-tracked) and a BaseAddr that is itself a safe 4-byte pointer
+        ///   slot, validated BEFORE the allocation so we never allocate then fail
+        ///   to repoint. On success CurrentAddr / ReadByteCount are updated to the
+        ///   new location / length.
+        ///
+        /// Returns true only when the write fully succeeded.
         /// </summary>
-        public bool WriteScript()
+        public bool WriteScript(Undo.UndoData? undoData = null)
         {
             if (_disassembled.Count == 0) return false;
 
@@ -606,30 +739,92 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
             byte[] bytes = SerializeScript();
 
-            // No-partial-write guard: only a same-size, fully in-bounds slice
-            // is allowed. (ulong) arithmetic so a near-uint.MaxValue CurrentAddr
-            // cannot wrap past the ROM length.
-            if (bytes.Length != ReadByteCount) return false;
-            if ((ulong)CurrentAddr + (ulong)bytes.Length > (ulong)rom.Data.Length) return false;
-            // Safety-offset guard: refuse header / low / out-of-range targets so a
-            // mistyped Address box cannot mutate the ROM header under undo. Check
-            // both the start and the last byte of the slice.
-            if (bytes.Length > 0
-                && (!U.isSafetyOffset(CurrentAddr)
-                    || !U.isSafetyOffset(CurrentAddr + (uint)bytes.Length - 1)))
+            if (bytes.Length == ReadByteCount)
+            {
+                // ---- SAME-SIZE in-place path (strictly no relocation) ----
+                // (ulong) arithmetic so a near-uint.MaxValue CurrentAddr cannot
+                // wrap past the ROM length.
+                if ((ulong)CurrentAddr + (ulong)bytes.Length > (ulong)rom.Data.Length) return false;
+                // Safety-offset guard: refuse header / low / out-of-range targets
+                // so a mistyped Address box cannot mutate the ROM header under
+                // undo. Check both the start and the last byte of the slice.
+                if (bytes.Length > 0
+                    && (!U.isSafetyOffset(CurrentAddr)
+                        || !U.isSafetyOffset(CurrentAddr + (uint)bytes.Length - 1)))
+                    return false;
+
+                // Single-range write → one undo entry (registers into the ambient
+                // UndoService scope opened by the View).
+                rom.write_range(CurrentAddr, bytes);
+                return true;
+            }
+
+            // ---- SIZE-CHANGED realloc + repoint path ----
+            // The realloc MUST be undo-tracked: a null undoData means the caller
+            // is not inside an undo transaction, so refuse rather than allocate
+            // an orphan region with no way to roll it back.
+            if (undoData == null) return false;
+
+            // Validate the pointer slot BEFORE appending so we never allocate
+            // free space and then fail to repoint it (leaking the allocation).
+            if (!U.isSafetyOffset(BaseAddr)
+                || (ulong)BaseAddr + 4 > (ulong)rom.Data.Length)
                 return false;
 
-            // Single-range write → one undo entry (registers into the ambient
-            // UndoService scope opened by the View), rather than one UndoPosition
-            // per byte.
-            rom.write_range(CurrentAddr, bytes);
+            uint newAddr = AppendBinaryDataHeadless(rom, bytes, undoData);
+            if (!U.isSafetyOffset(newAddr)) return false;
+
+            // Repoint the AI table slot at the new script location — same
+            // undoData/transaction as the append so RunUndo reverses both.
+            rom.write_p32(BaseAddr, newAddr, undoData);
+
+            CurrentAddr = newAddr;
+            ReadByteCount = (uint)bytes.Length;
             return true;
+        }
+
+        /// <summary>
+        /// Headless equivalent of InputFormRef.AppendBinaryData. Routes through
+        /// the registered CoreState.AppendBinaryData delegate when wired
+        /// (WinForms registers InputFormRef.AppendBinaryData → free-space
+        /// search). When no delegate is wired (Avalonia today / headless tests),
+        /// falls back to appending at the current ROM end, growing rom.Data to
+        /// fit, and signing the appended range into <paramref name="undoData"/>.
+        /// Returns the new data OFFSET (not a GBA pointer) — write_p32 applies
+        /// the toPointer conversion — or U.NOT_FOUND on failure.
+        /// </summary>
+        static uint AppendBinaryDataHeadless(ROM rom, byte[] buffer, Undo.UndoData undoData)
+        {
+            if (buffer == null || buffer.Length == 0) return U.NOT_FOUND;
+
+            // Prefer the wired allocator (free-space search) when present.
+            var allocator = CoreState.AppendBinaryData;
+            if (allocator != null)
+                return allocator(buffer, undoData);
+
+            // ROM-end fallback: grow rom.Data and append at the old end. The
+            // undoData captured the pre-grow file size at NewUndoData time, so
+            // RunUndo resizes the ROM back (discarding the appended bytes). We
+            // still record the written range for parity.
+            uint appendAt = (uint)rom.Data.Length;
+            if (!rom.write_resize_data((uint)(appendAt + buffer.Length)))
+                return U.NOT_FOUND;
+
+            // Sign the appended range into the same transaction (after the grow,
+            // so the offset is in-bounds for the UndoPostion before-image read).
+            rom.write_range(appendAt, buffer, undoData);
+            return appendAt;
         }
 
         /// <summary>True once a script has been disassembled into the editable
         /// model (i.e. Re-read has run). The View guards Write on this so an
         /// empty/never-loaded model does not attempt a (misleading) write.</summary>
         public bool HasDisassembly => _disassembled.Count > 0;
+
+        /// <summary>Number of instruction rows currently in the editable model.
+        /// The View uses this to pick a post-edit selection after New/Remove
+        /// without re-materializing the display lines.</summary>
+        public int RowCount => _disassembled.Count;
 
         // ----------------------------------------------------------------
         // Legacy header-only commit (kept for the stable VM surface). The

--- a/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml.cs
@@ -340,6 +340,16 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                // Require a loaded script first (mirror the Write guard). Without
+                // this, New on an empty model would create a 1-opcode script with
+                // no CurrentAddr/BaseAddr loaded, and a subsequent Write would
+                // serialize only that opcode + EXIT and repoint the AI slot —
+                // silently dropping all existing opcodes.
+                if (!_vm.HasDisassembly)
+                {
+                    CoreState.Services.ShowInfo("Re-read the AI script before inserting an instruction.");
+                    return;
+                }
                 if (string.IsNullOrWhiteSpace(AsmBox.Text))
                 {
                     CoreState.Services.ShowInfo("Enter instruction bytes in Binary Code first.");

--- a/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml.cs
@@ -181,21 +181,21 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         // -----------------------------------------------------------------
-        // Write-back (#760). Serializes the in-memory disassembled model
-        // (exact concatenation of each instruction's bytes — no EXIT
-        // normalization) and writes it back in-place under a UndoService
-        // scope. This is strictly SAME-SIZE: WriteScript() refuses (and we
-        // roll the scope back) if the length changed or the slice runs off
-        // the ROM, since a length change needs the New/Remove + free-space
-        // realloc path that stays deferred. Mirrors WF AllWriteButton_Click's
-        // concatenate-and-write core (minus the WinForms terminator append).
+        // Write-back (#760/#763). Serializes the in-memory disassembled model
+        // (with a WF-parity EXIT terminator append) and writes it back under a
+        // UndoService scope. Same-size edits write in place at CurrentAddr; a
+        // length change from New/Remove reallocates to free space and repoints
+        // the AI pointer slot — both signed against the active undoData so the
+        // whole operation commits / rolls back as one transaction. Mirrors WF
+        // AllWriteButton_Click. The Rollback-on-false path discards any orphan
+        // free-space allocation.
         // -----------------------------------------------------------------
 
         void Write_Click(object? sender, RoutedEventArgs e)
         {
             // Guard an empty/never-loaded model BEFORE opening the undo scope so
-            // we never produce a ghost undo entry or the misleading "length
-            // changed" error when the user hasn't pressed Re-read yet.
+            // we never produce a ghost undo entry or the misleading error when
+            // the user hasn't pressed Re-read yet.
             if (!_vm.HasDisassembly)
             {
                 CoreState.Services.ShowInfo("Re-read the AI script before writing.");
@@ -204,15 +204,22 @@ namespace FEBuilderGBA.Avalonia.Views
             _undoService.Begin("Edit AI Script");
             try
             {
-                if (!_vm.WriteScript())
+                if (!_vm.WriteScript(_undoService.GetActiveUndoData()))
                 {
                     _undoService.Rollback();
                     CoreState.Services.ShowError(
-                        "Could not write (length changed or out of range — New/Remove not yet supported).");
+                        "Could not write (out of range or the AI pointer slot is unsafe).");
                     return;
                 }
                 _undoService.Commit();
                 CoreState.Services.ShowInfo("AI script written.");
+                // Sync the Address / byte-count boxes to the VM FIRST: a
+                // realloc Write moves CurrentAddr / ReadByteCount, and
+                // ReloadList_Click re-reads from those boxes — so without this
+                // the re-read would disassemble the OLD (pre-relocation)
+                // location. UpdateUI() pushes the VM's new address/length back
+                // into the boxes before the re-read.
+                UpdateUI();
                 ReloadList_Click(sender, e);
             }
             catch (Exception ex)
@@ -323,18 +330,70 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
-        // New / Remove stay deferred (#760 follow-up): inserting or deleting an
-        // instruction changes the script length, which needs the WF New/Remove
-        // + free-space reallocation path. Opcode-level VALUE edits go through
-        // Update_Click / Write_Click (same-size in-place) instead.
+        // New / Remove (#763): insert / delete a 16-byte AI instruction in the
+        // in-memory model (mirrors WF NewButton_Click / RemoveButton_Click).
+        // These change the script length, so the next Write takes the
+        // realloc + pointer-repoint path. The list is refreshed from the model
+        // (GetDisplayLines), NOT a ROM re-read, so the pending structural edit
+        // stays visible until Write persists it.
         void New_Click(object? sender, RoutedEventArgs e)
         {
-            CoreState.Services.ShowInfo("Inserting AI instructions is not yet supported in Avalonia (changes script length). Use the WinForms editor to add instructions; use Update to edit an existing instruction in place.");
+            try
+            {
+                if (string.IsNullOrWhiteSpace(AsmBox.Text))
+                {
+                    CoreState.Services.ShowInfo("Enter instruction bytes in Binary Code first.");
+                    return;
+                }
+
+                string? line = _vm.InsertRow(DisassemblyList.SelectedIndex, AsmBox.Text);
+                if (line == null)
+                {
+                    CoreState.Services.ShowError(
+                        "Invalid instruction bytes (one 16-byte hex instruction).");
+                    return;
+                }
+
+                // Refresh from the in-memory model and select the inserted row.
+                int insertedAt = DisassemblyList.SelectedIndex < 0
+                    ? _vm.RowCount - 1
+                    : DisassemblyList.SelectedIndex + 1;
+                DisassemblyList.ItemsSource = _vm.GetDisplayLines();
+                if (insertedAt >= 0 && insertedAt < _vm.RowCount)
+                    DisassemblyList.SelectedIndex = insertedAt;
+            }
+            catch (Exception ex)
+            {
+                Log.Error("AIScriptView.New_Click failed: {0}", ex.Message);
+            }
         }
 
         void Remove_Click(object? sender, RoutedEventArgs e)
         {
-            CoreState.Services.ShowInfo("Removing AI instructions is not yet supported in Avalonia (changes script length). Use the WinForms editor to delete instructions; use Update to edit an existing instruction in place.");
+            try
+            {
+                int idx = DisassemblyList.SelectedIndex;
+                if (idx < 0)
+                {
+                    CoreState.Services.ShowInfo("Select an instruction to remove.");
+                    return;
+                }
+                if (!_vm.RemoveRow(idx))
+                {
+                    CoreState.Services.ShowInfo("Cannot remove the last instruction.");
+                    return;
+                }
+
+                DisassemblyList.ItemsSource = _vm.GetDisplayLines();
+                // Re-select a sensible neighbour (the row that shifted up into idx).
+                int next = idx < _vm.RowCount ? idx : _vm.RowCount - 1;
+                if (next >= 0)
+                    DisassemblyList.SelectedIndex = next;
+            }
+            catch (Exception ex)
+            {
+                Log.Error("AIScriptView.Remove_Click failed: {0}", ex.Message);
+            }
         }
 
         void Close_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml.cs
@@ -157,6 +157,11 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 _vm.LoadEntry(addr);
                 UpdateUI();
+                // Re-disassemble for the newly-selected entry. LoadEntry cleared
+                // the editable model; this repopulates it for THIS entry so the
+                // list shows the right opcodes and a later New/Remove/Write
+                // operates on the loaded entry (not a stale one).
+                DisassemblyList.ItemsSource = _vm.DisassembleScript();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- Completes the Avalonia **AI Script editor**'s structural editing (after #757 read + #760 hex-edit):
  - **New Insert** disassembles the Binary Code box and inserts it after the selected opcode (`InsertRow`).
  - **Remove** deletes the selected opcode (`RemoveRow`; the last opcode is protected).
  - Both apply `EventScriptUtil.JisageReorder` (Core), matching WinForms.
  - **Write** is now any-size: same-size → in-place (unchanged); size changed → `AppendBinaryDataHeadless` to free space + `write_p32(BaseAddr, …)` to repoint the AI pointer slot, all under **one** `UndoService` transaction (undo restores the original slot pointer).
  - `SerializeScript()` now appends the WF `EXIT (0x03)` terminator when missing (the normalization deferred in #760 — safe now that growth reallocates).
- Mirrors WF `AIScriptForm` (NewButton/RemoveButton + AllWriteButton_Click).

## Plan Reference
Implements the accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/763#issuecomment-4574080314 (Copilot CLI: **NO blocking concerns**; non-blocking cautions — validate `BaseAddr` before appending, keep same-size strictly in-place, roll back on failure — all incorporated).

## Scope
Closes #763
Out of scope (separate follow-up): the per-argument Parameter-field widget binding (WF `ScriptEditSetTables`) and the `ScriptChange` category picker. Editing remains via the Binary Code hex box.

## Screenshots
AI Script Editor after **New Insert** — the disassembly list grew from 2 to 3 opcodes (a second `Attack05` inserted at `0x5A8880`, highlighted; `EXIT` shifted to `0x5A8890`; offsets recomputed):

![AI Script Editor New Insert](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/fix763-ai-newremove.png?raw=1)

## GUI Test Report

### Environment
- ROM: `roms/FE8U.gba`
- Editor/View: Avalonia **AI Script Editor** (`AIScriptView`)
- Capture: PrintWindow (`tools/WinCapture`) + PowerShell UIAutomation (locked-screen headless flow).

### Steps Performed
1. Opened the AI Script Editor; **Re-read** → 2 opcodes (`Attack05`, `EXIT`).
2. Selected row 0 → Binary Code box auto-filled `05 64 FF 00 …`.
3. Invoked **New Insert** (`AIScript_New_Button`).
4. Read back the disassembly list.

### Test Results
| Test | Expected | Actual | Status |
|------|----------|--------|--------|
| New Insert grows list | 2 → 3 opcodes, inserted after selection | 3 rows: `Attack05`@5A8870, `Attack05`@5A8880 (inserted), `EXIT`@5A8890 | PASS |
| Offsets recomputed | sequential 16-byte grid | 0x5A8870 / 0x5A8880 / 0x5A8890 | PASS |
| Remove / realloc Write / undo | covered by automated tests | see Test plan (incl. undo-restores-pointer) | PASS |

### Verdict
PASS — New Insert is functional in the GUI; Remove + any-size realloc Write + undo are covered by the automated tests below.

## Test plan
- [x] VM unit tests (`AIScriptEditWriteTests`, +9): `SerializeScript` EXIT-append (and no double-append); `InsertRow` grows + JisageReorder; `RemoveRow` shrinks + protects the last opcode; `WriteScript` after Insert reallocates + `rom.p32(BaseAddr)` == new addr + updates CurrentAddr/ReadByteCount; after Remove relocates+repoints; **undo restores the original slot pointer**; same-size Write still in-place (no relocation); size-changed with `undoData==null` → false/no mutation — all pass.
- [x] `[AvaloniaFact]`: New (with a Binary Code value) → Write → `rom.p32(BaseAddr)` changed + list grew.
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` — 7103 passed, 0 failed, 3 skipped (full suite).
- [x] `dotnet test FEBuilderGBA.Core.Tests` — 1988 passed, 0 failed.
- [x] `dotnet test FEBuilderGBA.Tests` (WinForms) — 1822 passed, 0 failed.
- [x] `dotnet build FEBuilderGBA.Avalonia -c Release` — 0 errors.
- [x] Manual GUI validation against FE8U — New Insert grows the list (screenshot + GUI Test Report above).
- [x] Bug found+fixed during impl: after a realloc relocates the script, `Write_Click` now `UpdateUI()`s the Address/byte-count boxes before re-reading so the re-read targets the new address (caught by the AvaloniaFact test).

## Known limitations
- Parameter-field widget editing and the category picker remain stubs (out of scope; future follow-up).
- Unrelated pre-existing flaky test `GapSweep.PointerToolParityTests.ViewModel_RunSearch_NoOtherRom_PopulatesCurrentRomFields` (shared-state ordering) occasionally fails on Windows CI; a re-run passes. Not touched by this PR.

Generated with Claude Code v2.1.156 (model: claude-opus-4-8, Opus 4.8 1M context)
