### PR TITLE
feat(avalonia): wire AI-script Script Change opcode picker (#766)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/AIScriptChangePickerTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/AIScriptChangePickerTests.cs
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// AI Script "Script Change" opcode-picker wiring tests (#766).
+//
+// Proves the Avalonia AI Script editor's "Script Change" button copies a
+// category-picked command's DEFAULT bytes into its Binary Code box in the
+// exact format the in-place Update / New path round-trips:
+//   1. AIScriptViewModel.FormatInstructionHex is the SAME format GetRowHex
+//      emits, and the string it produces parses back through the production
+//      hex-parse path (UpdateRow -> ParseInstructionHex) and re-emits an
+//      identical hex line (format-stable round-trip);
+//   2. the picker VM (AIScriptCategorySelectViewModel) yields a non-null
+//      SelectedScript with non-empty Data when a valid command index is
+//      selected, ConfirmSelection() returns true, and an empty selection
+//      yields false / null;
+//   3. [AvaloniaFact]: the modal picker's Select returns the chosen Script
+//      (typed Close(result)), and AIScriptView.ApplyPickedScript drops that
+//      Script's Data into AsmBox as a hex line UpdateRow accepts.
+//
+// Reuses the AiDisasmEnv synthetic FE8U environment from
+// AIScriptDisassemblyTests.cs (#757) — it loads a real width-16 FE8 AI
+// EventScript so CoreState.AIScript.Scripts is populated with real opcode
+// templates (each Script.Data is the parsed default bytes). Marked
+// [Collection("SharedState")] because the suite mutates CoreState.ROM /
+// CoreState.AIScript / CoreState.CommentCache / CoreState.BaseDirectory.
+// Per the plan, no [Fact] commits a UndoService — these are read / UI-only.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using global::Avalonia.Controls;
+using global::Avalonia.Headless.XUnit;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class AIScriptChangePickerTests
+    {
+        // 16-byte AI instruction helpers (FE8 table), mirroring the other
+        // AIScript test fixtures. Attack05's byte[1] is PROBABILITY; byte[2]
+        // is the 0xFF FIXED marker.
+        static byte[] Attack05(byte probability)
+        {
+            var b = new byte[16];
+            b[0] = 0x05; b[1] = probability; b[2] = 0xFF;
+            return b;
+        }
+
+        static byte[] ExitOpcode(byte id)
+        {
+            var b = new byte[16];
+            b[0] = 0x03; b[1] = 0x00; b[2] = 0xFF; b[3] = id;
+            return b;
+        }
+
+        // ================================================================
+        // 1. FormatInstructionHex format-consistency + parse round-trip.
+        // ================================================================
+
+        [Fact]
+        public void FormatInstructionHex_MatchesGetRowHex_AndRoundTripsThroughUpdateRow()
+        {
+            using var env = new AiDisasmEnv();
+
+            // Load a real two-opcode script so GetRowHex has a row 0 to render.
+            var body = new List<byte>();
+            body.AddRange(Attack05(0x64));
+            body.AddRange(ExitOpcode(0x00));
+            var vm = env.LoadVmAt(body.ToArray());
+            vm.DisassembleScript();
+
+            // GetRowHex(0) and FormatInstructionHex(rowBytes) must be the SAME
+            // string — GetRowHex delegates to FormatInstructionHex (WU1).
+            byte[] row0Bytes = Attack05(0x64);
+            string viaFormatter = AIScriptViewModel.FormatInstructionHex(row0Bytes);
+            string? viaRow = vm.GetRowHex(0);
+            Assert.False(string.IsNullOrWhiteSpace(viaFormatter));
+            Assert.Equal(viaRow, viaFormatter);
+
+            // The formatter output is space-separated 2-digit upper hex.
+            Assert.Equal("05 64 FF 00 00 00 00 00 00 00 00 00 00 00 00 00", viaFormatter);
+
+            // Format-stable parse round-trip: feeding the formatted hex back
+            // through the production parse path (UpdateRow -> ParseInstructionHex
+            // -> DisAseemble) succeeds and re-emits an identical GetRowHex line.
+            string? updated = vm.UpdateRow(0, viaFormatter);
+            Assert.NotNull(updated);
+            Assert.Equal(viaFormatter, vm.GetRowHex(0));
+        }
+
+        [Fact]
+        public void FormatInstructionHex_NullBytes_ReturnsEmpty()
+        {
+            // Defensive: a null Data must not throw (ApplyPickedScript guards on
+            // the Script, but the formatter is also called directly).
+            Assert.Equal("", AIScriptViewModel.FormatInstructionHex(null!));
+        }
+
+        // ================================================================
+        // 2. Picker VM selection / confirm contract.
+        // ================================================================
+
+        [Fact]
+        public void PickerViewModel_ValidSelection_SetsScriptAndConfirms()
+        {
+            using var env = new AiDisasmEnv();
+
+            var vm = new AIScriptCategorySelectViewModel();
+            vm.Load();
+            Assert.True(vm.IsLoaded);
+            Assert.NotEmpty(vm.ScriptNames); // real FE8 AI commands loaded
+
+            // No selection yet: ConfirmSelection() is false, SelectedScript null.
+            Assert.False(vm.ConfirmSelection());
+            Assert.Null(vm.SelectedScript);
+
+            // Select a valid command index — UpdateInfo sets SelectedScript.
+            vm.SelectedScriptIndex = 0;
+            Assert.NotNull(vm.SelectedScript);
+            Assert.NotNull(vm.SelectedScript!.Data);
+            Assert.NotEmpty(vm.SelectedScript.Data); // real opcode default bytes
+
+            // ConfirmSelection() now returns true and re-resolves SelectedScript.
+            Assert.True(vm.ConfirmSelection());
+            Assert.NotNull(vm.SelectedScript);
+        }
+
+        [Fact]
+        public void PickerViewModel_ClearedSelection_DoesNotConfirm()
+        {
+            using var env = new AiDisasmEnv();
+
+            var vm = new AIScriptCategorySelectViewModel();
+            vm.Load();
+            Assert.NotEmpty(vm.ScriptNames);
+
+            // Select then clear: a -1 index clears SelectedScript and refuses.
+            vm.SelectedScriptIndex = 0;
+            Assert.NotNull(vm.SelectedScript);
+
+            vm.SelectedScriptIndex = -1;
+            Assert.Null(vm.SelectedScript);
+            Assert.False(vm.ConfirmSelection());
+        }
+
+        // ================================================================
+        // 3a. [AvaloniaFact] Modal picker Select returns the chosen Script.
+        // ================================================================
+
+        [AvaloniaFact]
+        public void Picker_Select_ReturnsChosenScript()
+        {
+            using var env = new AiDisasmEnv();
+            // Re-assert env's ROM / AI script as active (defensive vs shared
+            // collection churn) before constructing the picker, whose VM Load()
+            // reads CoreState.AIScript.Scripts.
+            CoreState.ROM = env.Rom;
+            CoreState.AIScript = env.AiScript;
+
+            var picker = new ScriptCommandPickerView(EventScript.EventScriptType.AI);
+            var scriptList = picker.FindControl<ListBox>("ScriptList");
+            Assert.NotNull(scriptList);
+
+            // Selecting a row drives the VM's SelectedScriptIndex via the
+            // SelectionChanged handler.
+            var items = scriptList!.ItemsSource as IEnumerable<string>;
+            Assert.NotNull(items);
+            Assert.NotEmpty(items!);
+            scriptList.SelectedIndex = 0;
+
+            // Invoke the private Select handler (mirrors a Select-button click).
+            // It confirms the selection and Close(result)s with the Script.
+            InvokePicker(picker, "Select_Click");
+
+            Assert.NotNull(picker.SelectedScript);
+            Assert.NotNull(picker.SelectedScript!.Data);
+            Assert.NotEmpty(picker.SelectedScript.Data);
+        }
+
+        [AvaloniaFact]
+        public void Picker_Select_NoSelection_DoesNotReturnAndShowsHint()
+        {
+            using var env = new AiDisasmEnv();
+            CoreState.ROM = env.Rom;
+            CoreState.AIScript = env.AiScript;
+
+            var picker = new ScriptCommandPickerView(EventScript.EventScriptType.AI);
+            var scriptList = picker.FindControl<ListBox>("ScriptList");
+            var info = picker.FindControl<TextBlock>("InfoLabel");
+            Assert.NotNull(scriptList);
+            Assert.NotNull(info);
+
+            // No command selected.
+            scriptList!.SelectedIndex = -1;
+            InvokePicker(picker, "Select_Click");
+
+            // No result returned; an inline hint is shown and the dialog stays.
+            Assert.Null(picker.SelectedScript);
+            Assert.False(string.IsNullOrWhiteSpace(info!.Text));
+        }
+
+        // ================================================================
+        // 3b. [AvaloniaFact] ApplyPickedScript drops Data into AsmBox as hex
+        //     that UpdateRow / ParseInstructionHex accepts.
+        // ================================================================
+
+        [AvaloniaFact]
+        public void View_ApplyPickedScript_PopulatesBinaryCodeWithParseableHex()
+        {
+            using var env = new AiDisasmEnv();
+            CoreState.ROM = env.Rom;
+            CoreState.AIScript = env.AiScript;
+
+            // Plant a real script + pointer slot, and drive the view's VM
+            // through LoadEntry so it has a populated, editable model whose
+            // row 0 we can re-decode the applied hex into.
+            var body = new List<byte>();
+            body.AddRange(Attack05(0x64));
+            body.AddRange(ExitOpcode(0x00));
+            env.PlantBody(body.ToArray(), out uint pointerSlotAddr);
+
+            var view = new AIScriptView();
+            var asmBox = view.FindControl<TextBox>("AsmBox");
+            var nameLabel = view.FindControl<TextBlock>("ScriptCodeNameLabel");
+            var list = view.FindControl<ListBox>("DisassemblyList");
+            Assert.NotNull(asmBox);
+            Assert.NotNull(nameLabel);
+            Assert.NotNull(list);
+
+            var vmField = typeof(AIScriptView).GetField(
+                "_vm",
+                System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.NonPublic);
+            Assert.NotNull(vmField);
+            var vm = (AIScriptViewModel)vmField!.GetValue(view)!;
+
+            // Re-assert ROM as active (constructing the view re-enters list/VM
+            // init), then load + re-read so the model has a row to edit.
+            CoreState.ROM = env.Rom;
+            vm.LoadEntry(pointerSlotAddr);
+            Assert.True(vm.IsLoaded);
+
+            var addressBox = view.FindControl<NumericUpDown>("AddressBox");
+            var byteCountBox = view.FindControl<NumericUpDown>("ReadByteCountBox");
+            addressBox!.Value = vm.CurrentAddr;
+            byteCountBox!.Value = vm.ReadByteCount;
+            Invoke(view, "ReloadList_Click");
+
+            // Pick a real command from the AI script table and apply it. Use a
+            // DoNothing-like template via the picker VM so Data is a real
+            // opcode default (non-empty).
+            var pickerVm = new AIScriptCategorySelectViewModel();
+            pickerVm.Load();
+            Assert.NotEmpty(pickerVm.ScriptNames);
+            pickerVm.SelectedScriptIndex = 0;
+            EventScript.Script? chosen = pickerVm.SelectedScript;
+            Assert.NotNull(chosen);
+            Assert.NotEmpty(chosen!.Data);
+
+            // Drive the factored apply-path (avoids relying on a live modal).
+            view.ApplyPickedScript(chosen);
+
+            // AsmBox now holds the chosen command's bytes as a hex line, and the
+            // name label shows its mnemonic.
+            Assert.False(string.IsNullOrWhiteSpace(asmBox!.Text));
+            Assert.Equal(AIScriptViewModel.FormatInstructionHex(chosen.Data), asmBox.Text);
+            Assert.False(string.IsNullOrWhiteSpace(nameLabel!.Text));
+
+            // The hex AsmBox now holds must be accepted by the production
+            // Update path (re-decodes row 0 from the applied hex).
+            list!.SelectedIndex = 0;
+            string? updated = vm.UpdateRow(0, asmBox.Text!);
+            Assert.NotNull(updated);
+        }
+
+        // ----------------------------------------------------------------
+        // Reflection helpers (the click handlers are private).
+        // ----------------------------------------------------------------
+
+        static void Invoke(AIScriptView view, string method)
+        {
+            var m = typeof(AIScriptView).GetMethod(
+                method,
+                System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.NonPublic);
+            Assert.NotNull(m);
+            m!.Invoke(view, new object?[] { null, new global::Avalonia.Interactivity.RoutedEventArgs() });
+        }
+
+        static void InvokePicker(ScriptCommandPickerView picker, string method)
+        {
+            var m = typeof(ScriptCommandPickerView).GetMethod(
+                method,
+                System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.NonPublic);
+            Assert.NotNull(m);
+            m!.Invoke(picker, new object?[] { null, new global::Avalonia.Interactivity.RoutedEventArgs() });
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/AIScriptViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/AIScriptViewModel.cs
@@ -455,7 +455,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// command's default <see cref="EventScript.Script.Data"/> bytes into the
         /// Binary Code box via this same formatter so they re-decode identically.
         /// </summary>
-        public static string FormatInstructionHex(byte[] bytes)
+        public static string FormatInstructionHex(byte[]? bytes)
         {
             if (bytes == null) return "";
             return U.HexDumpLiner(bytes).Trim();

--- a/FEBuilderGBA.Avalonia/ViewModels/AIScriptViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/AIScriptViewModel.cs
@@ -447,6 +447,21 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         // ----------------------------------------------------------------
 
         /// <summary>
+        /// Space-separated 2-digit upper-hex dump of an instruction's bytes —
+        /// the exact "Binary Code" format the Disassembly list rows show
+        /// (between the "[..]") and the form <see cref="ParseInstructionHex"/> /
+        /// Update / New round-trip. Shared by <see cref="GetRowHex"/> and the AI
+        /// Script "Script Change" opcode picker (#766), which copies a chosen
+        /// command's default <see cref="EventScript.Script.Data"/> bytes into the
+        /// Binary Code box via this same formatter so they re-decode identically.
+        /// </summary>
+        public static string FormatInstructionHex(byte[] bytes)
+        {
+            if (bytes == null) return "";
+            return U.HexDumpLiner(bytes).Trim();
+        }
+
+        /// <summary>
         /// Space-separated 2-digit hex dump of the instruction bytes at the
         /// given row (matching the "[..]" hex in the Disassembly list rows).
         /// Returns null on an out-of-range index.
@@ -456,7 +471,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (index < 0 || index >= _disassembled.Count) return null;
             byte[] data = _disassembled[index].ByteData;
             if (data == null) return null;
-            return U.HexDumpLiner(data).Trim();
+            return FormatInstructionHex(data);
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml.cs
@@ -442,7 +442,7 @@ namespace FEBuilderGBA.Avalonia.Views
         /// <see cref="AIScriptViewModel.FormatInstructionHex"/> form that
         /// Update/New parse.
         /// </summary>
-        internal void ApplyPickedScript(EventScript.Script script)
+        internal void ApplyPickedScript(EventScript.Script? script)
         {
             if (script == null) return;
             AsmBox.Text = AIScriptViewModel.FormatInstructionHex(script.Data);
@@ -455,12 +455,9 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 var picker = new ScriptCommandPickerView(EventScript.EventScriptType.AI);
 
-                // AIScriptView IS a Window, so it can own the modal. Guard the
-                // (theoretical) detached-window case to avoid a ShowDialog on a
-                // window with no toplevel.
-                EventScript.Script? result = (this as Window) != null
-                    ? await picker.ShowDialog<EventScript.Script?>(this)
-                    : null;
+                // AIScriptView IS a Window (TranslatedWindow : Window), so it can
+                // own the modal directly.
+                EventScript.Script? result = await picker.ShowDialog<EventScript.Script?>(this);
 
                 if (result != null)
                     ApplyPickedScript(result);

--- a/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml.cs
@@ -421,15 +421,55 @@ namespace FEBuilderGBA.Avalonia.Views
             ScriptCodeNameLabel.Text = "";
         }
 
-        void ScriptChange_Click(object? sender, RoutedEventArgs e)
+        // -----------------------------------------------------------------
+        // Script Change (#766): mirror WF AIScriptForm.ScriptChangeButton_Click.
+        // Open the category-based AI opcode picker modally; on a confirmed
+        // selection, copy the chosen command's DEFAULT bytes into the Binary
+        // Code box (and its mnemonic into the Description label) so the user can
+        // then Update/New it into the script. The picker
+        // (ScriptCommandPickerView, backed by AIScriptCategorySelectViewModel)
+        // is the FUNCTIONAL category browser; this is a read/UI-only copy — no
+        // ROM write happens here (the existing Update/New/Write path persists).
+        // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Copy a picked command's default bytes into the Binary Code box and its
+        /// name into the Description label — the WF parity for
+        /// <c>ASMTextBox.Text = U.convertByteToStringDump(script.Data)</c> +
+        /// <c>ScriptCodeName.Text = makeCommandComboText(script,false)</c>.
+        /// Factored out (internal) so headless tests can exercise the
+        /// apply-path without a live modal. The Binary Code text is the shared
+        /// <see cref="AIScriptViewModel.FormatInstructionHex"/> form that
+        /// Update/New parse.
+        /// </summary>
+        internal void ApplyPickedScript(EventScript.Script script)
         {
-            // The WF flow opens AIScriptCategorySelectForm modally and writes
-            // the chosen opcode bytes back into ASMTextBox. The Avalonia
-            // AIScriptCategorySelectView is a stub today; we surface the
-            // affordance without navigating to avoid putting the user on a
-            // dead-end screen. Per Copilot v2 #1 this jump deliberately stays
-            // OUT of the manifest (MissingAvManifest in the scanner output).
-            CoreState.Services.ShowInfo("Script category picker is not yet wired in Avalonia. Use the WinForms editor for category-based opcode selection.");
+            if (script == null) return;
+            AsmBox.Text = AIScriptViewModel.FormatInstructionHex(script.Data);
+            ScriptCodeNameLabel.Text = EventScript.makeCommandComboText(script, false);
+        }
+
+        async void ScriptChange_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var picker = new ScriptCommandPickerView(EventScript.EventScriptType.AI);
+
+                // AIScriptView IS a Window, so it can own the modal. Guard the
+                // (theoretical) detached-window case to avoid a ShowDialog on a
+                // window with no toplevel.
+                EventScript.Script? result = (this as Window) != null
+                    ? await picker.ShowDialog<EventScript.Script?>(this)
+                    : null;
+
+                if (result != null)
+                    ApplyPickedScript(result);
+                // Cancel / no selection -> leave the Binary Code box unchanged.
+            }
+            catch (Exception ex)
+            {
+                Log.Error("AIScriptView.ScriptChange_Click failed: {0}", ex.Message);
+            }
         }
 
         // -----------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia/Views/ScriptCommandPickerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ScriptCommandPickerView.axaml.cs
@@ -107,6 +107,10 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void Select_Click(object? sender, RoutedEventArgs e)
         {
+            // Clear any prior selection so SelectedScript / the returned result is
+            // null unless THIS confirmation succeeds (Copilot review: no stale
+            // result observable after a failed Select or Cancel).
+            _selectedScript = null;
             bool ok = false;
             if (_aiVm != null)
             {

--- a/FEBuilderGBA.Avalonia/Views/ScriptCommandPickerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ScriptCommandPickerView.axaml.cs
@@ -120,7 +120,19 @@ namespace FEBuilderGBA.Avalonia.Views
             }
 
             if (ok)
+            {
+                // Typed modal return (#766): hand the chosen Script back to the
+                // caller's ShowDialog<EventScript.Script?>. The AI Script editor's
+                // "Script Change" button copies the result's Data bytes into its
+                // Binary Code box.
                 Close(_selectedScript);
+            }
+            else
+            {
+                // No command selected — show an inline hint and stay open
+                // (do NOT return a result). VM is untouched (#766 WU2).
+                InfoLabel.Text = R._("Select a command from the list first.");
+            }
         }
 
         void Cancel_Click(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- Wires the AI Script editor's **Script Change** button (previously an "not yet wired" stub) to the existing `ScriptCommandPickerView` opcode picker: pick an opcode template → its default bytes populate the **Binary Code** box (and the opcode-name label), so users don't have to type raw hex. This is the **last affordance gap in the AI Script editor** (read #757, hex-edit #760, New/Remove + any-size Write #763 already shipped).
- Adds a shared `AIScriptViewModel.FormatInstructionHex(byte[])` (extracted from `GetRowHex`) so the picker's output is byte-identical to the disassembly format and round-trips through the existing `Update`/`New` parser.
- Read/UI-only: Script Change only fills the Binary Code box; no ROM write (the user then Writes via the #763 path).

## Plan Reference
Implements the accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/766#issuecomment-4575092551 (Copilot CLI: **NO blocking concerns**). Note: the functional picker turned out to be `ScriptCommandPickerView` (the VM the plan described, with the typed `ShowDialog<EventScript.Script?>`/`Close(result)` contract the review recommended) rather than the inert `AIScriptCategorySelectView` — so ScriptChange was wired to `ScriptCommandPickerView(AI)`.

## Scope
Closes #766
Out of scope: the WinForms `ScriptEditSetTables` per-argument floating-panel widgets (arg tuning is via the Binary Code hex + Update).

## Screenshots
The affected **AI Script Editor** with the **Script Change** button and the **Binary Code** box populated via the shared `FormatInstructionHex` (`03 00 FF 00 …` — the exact box and format the picker writes into):

![AI Script Editor — Script Change + Binary Code](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/fix766-ai-scriptchange.png?raw=1)

> **Capture note (honest):** Script Change opens a **modal** opcode picker (`ShowDialog`). Avalonia modal dialogs do **not** render / create a findable window on the locked, non-interactive CI desktop (only non-modal `Show` windows do, which is why the editor itself captures fine). The modal picker therefore can't be screenshot in this environment. Its behavior — selecting an opcode → its `Data` bytes appearing in the Binary Code box via `ApplyPickedScript` — is verified by the **headless `[AvaloniaFact]`** test below (which runs the real View code in CI) plus unit tests.

## GUI Test Report

### Environment
- ROM: `roms/FE8U.gba`; Editor: Avalonia **AI Script Editor** (`AIScriptView`).
- Capture: PrintWindow (`tools/WinCapture`) + PowerShell UIAutomation (locked-screen headless flow).

### Steps Performed
1. Opened the AI Script Editor; verified the **Script Change** button is present + invokable via UIAutomation (`AIScript_ScriptChange_Button`).
2. Confirmed invoking it constructs + shows the `ScriptCommandPickerView` modal (modal not capturable on the locked desktop — see note).
3. Selected a disassembly row → Binary Code box populated via `FormatInstructionHex` (`03 00 FF 00 …`) — the same box/format the picker writes into.

### Test Results
| Test | Expected | Actual | Status |
|------|----------|--------|--------|
| Script Change button wired | Present + invokable (not a stub dialog) | Invoked → constructs `ScriptCommandPickerView(AI)` modal | PASS |
| Binary Code format | Valid 16-byte hex parseable by Update/New | `03 00 FF 00 00 00 00 00 00 00 00 00 00 00 00 00` | PASS |
| Picker → Binary Code apply | Picked opcode's `Data` fills the box | Verified by headless `[AvaloniaFact]` (ApplyPickedScript) | PASS |

### Verdict
PASS — Script Change is wired; the picker→Binary-Code apply path is verified by the headless AvaloniaFact + unit tests (the modal itself isn't screenshot-able on a locked desktop).

## Test plan
- [x] Unit: `FormatInstructionHex` round-trips through `ParseInstructionHex` and equals `GetRowHex`'s output (format-consistency regression so the extraction is behavior-preserving).
- [x] Unit: picker VM returns a non-null `SelectedScript` with non-empty `Data` on a valid selection; `ConfirmSelection()` true/false as expected.
- [x] Headless `[AvaloniaFact]`: picker Select → confirmed non-null result; `AIScriptView.ApplyPickedScript(script)` populates `AsmBox` with non-empty valid hex accepted by `UpdateRow`. (7 new tests in `AIScriptChangePickerTests`.)
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` — 7112 passed, 0 failed, 3 skipped (full suite).
- [x] `dotnet test FEBuilderGBA.Core.Tests` — 1988 passed, 0 failed.
- [x] `dotnet test FEBuilderGBA.Tests` (WinForms) — 1822 passed, 0 failed.
- [x] `dotnet build FEBuilderGBA.Avalonia -c Release` — 0 errors.
- [x] Existing AIScript suite (63) still green — confirms the `FormatInstructionHex` extraction is behavior-preserving.

## Known limitations
- Modal picker dialog not screenshot-able on the locked CI desktop (verified via headless tests instead — see capture note).
- WinForms `ScriptEditSetTables` per-arg widgets remain out of scope.

Generated with Claude Code v2.1.156 (model: claude-opus-4-8, Opus 4.8 1M context)
