### PR TITLE
feat(avalonia): ImageBG BG255/BG224 255-color background import (closes #799)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBGParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBGParityTests.cs
@@ -360,20 +360,21 @@ public class ImageBGParityTests
     }
 
     /// <summary>
-    /// Per Copilot CLI v3 review (#517): a BG256-patched ROM entry
-    /// with P4 &lt;= 1 (255/224-color mode flag) MUST NOT accept a
-    /// 16-color import via either the file-picker or drag-drop path.
-    /// The Avalonia View now refuses such imports before any ROM
-    /// write with an explicit "use the WinForms editor" error. We
-    /// verify the underlying decision predicate here, since the
-    /// actual View handlers run modally and are out of headless reach.
+    /// A BG256-patched ROM entry with P4 &lt;= 1 (255/224-color mode flag)
+    /// is treated as a 255/224-color cutscene background, NOT a 16-color
+    /// header-TSA entry. The Avalonia View routes such entries to the 8bpp
+    /// 255/224 import path (<c>IsBG256ColorEntry</c> → <c>RunBG256Import</c>
+    /// → <c>ImageBG256ColorCore.Import255ColorBG</c>) instead of the 16-color
+    /// path (#799 — previously refused outright per #517). We verify the
+    /// underlying decision predicate here, since the actual View handlers run
+    /// modally and are out of headless reach.
     /// </summary>
     [Fact]
     public void ViewModel_BG256Patched_WithP4Flag_IsTreatedAs255_224Mode()
     {
         // Build a BG256-patched ROM and verify ImageBGCore.Is255BG +
         // the IsBG256Patched flag the VM exposes drive the View's
-        // pre-import gate correctly.
+        // import routing correctly.
         var bytes = new byte[0x1100000];
         var rom = new ROM();
         rom.LoadLow("bg256-fe8u.gba", bytes, "BE8E01");
@@ -392,7 +393,7 @@ public class ImageBGParityTests
             vm.P4 = 0u;
             vm.IsBG256Patched = FEBuilderGBA.PatchDetection.HasBG256ColorPatch(rom);
 
-            // The View's `PreImportGate` refuses when
+            // The View routes to the 255/224 path when
             // `IsBG256Patched && P4 <= 1`. Verify both halves:
             Assert.True(vm.IsBG256Patched, "BG256 patch must be detected");
             Assert.True(vm.P4 <= 1, "P4 must be a mode flag");
@@ -401,6 +402,78 @@ public class ImageBGParityTests
             Assert.True(FEBuilderGBA.ImageBGCore.Is255BG(rom, vm.P0, vm.P4));
         }
         finally { CoreState.ROM = prevRom; }
+    }
+
+    /// <summary>
+    /// End-to-end #799 preview check: write a real BG255 (P4=0) entry into a
+    /// BG256-patched ROM via the Core import path, then load it through the
+    /// ViewModel and confirm <c>TryLoadImage</c> decodes the 8bpp BG (via
+    /// <c>ImageBG256ColorCore.Decode255ColorBG</c>) rather than falling back
+    /// to the 4bpp path. Uses the real SkiaImageService so the encode/decode
+    /// round-trip is exercised end to end.
+    /// </summary>
+    [Fact]
+    public void ViewModel_TryLoadImage_BG255Entry_DecodesVia8bppPath()
+    {
+        var bytes = new byte[0x1100000];
+        // Fill the high half with 0xFF so the importer finds free space.
+        for (int i = bytes.Length / 2; i < bytes.Length; i++) bytes[i] = 0xFF;
+        var rom = new ROM();
+        rom.LoadLow("bg256-fe8u.gba", bytes, "BE8E01");
+        // Plant the BG256Color signature for FE8U.
+        bytes[0xE2DA] = 0xC0; bytes[0xE2DB] = 0x46;
+        bytes[0xE2DC] = 0xC0; bytes[0xE2DD] = 0x46;
+        rom.LoadLow("bg256-fe8u.gba", bytes, "BE8E01");
+
+        var prevRom = CoreState.ROM;
+        var prevSvc = CoreState.ImageService;
+        try
+        {
+            CoreState.ROM = rom;
+            if (CoreState.ImageService == null)
+                CoreState.ImageService = new FEBuilderGBA.SkiaSharp.SkiaImageService();
+
+            int w = FEBuilderGBA.ImageBG256ColorCore.Width;
+            int h = FEBuilderGBA.ImageBG256ColorCore.Height;
+
+            // Deterministic 256-color indexed image + 512-byte palette.
+            byte[] indexed = new byte[w * h];
+            for (int i = 0; i < indexed.Length; i++) indexed[i] = (byte)(i % 256);
+            byte[] pal = new byte[512];
+            for (int i = 0; i < 256; i++)
+            {
+                ushort c = (ushort)((i * 7 + 1) & 0x7FFF);
+                pal[i * 2] = (byte)(c & 0xFF);
+                pal[i * 2 + 1] = (byte)((c >> 8) & 0xFF);
+            }
+
+            // A BG entry triple lives at a safe ROM offset. Write a real
+            // BG255 entry: P0=image, P4=0 flag, P8=palette.
+            uint addr = 0x000200;
+            var undo = new Undo();
+            var result = FEBuilderGBA.ImageBG256ColorCore.Import255ColorBG(
+                rom, indexed, pal, w, h, addr + 0, addr + 4, addr + 8,
+                is224: false, CoreState.ImageService, undo.NewUndoData("bg255"));
+            Assert.True(result.Success, result.Error);
+
+            // Load the entry into the VM and decode the preview.
+            var vm = new ImageBGViewModel();
+            vm.LoadEntry(addr);
+            Assert.True(vm.IsBG256Patched);
+            Assert.Equal(0u, vm.P4);
+
+            IImage preview = vm.TryLoadImage();
+            Assert.NotNull(preview);
+            Assert.Equal(w, preview.Width);
+            Assert.Equal(h, preview.Height);
+            // 8bpp decode is deterministic — pixels reproduce the source image.
+            Assert.Equal(indexed, preview.GetPixelData());
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.ImageService = prevSvc;
+        }
     }
 
     [Fact]

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageBGViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageBGViewModel.cs
@@ -295,6 +295,19 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 uint palAddr = U.toOffset(P8);
                 if (!U.isSafetyOffset(imgAddr) || !U.isSafetyOffset(palAddr)) return null;
 
+                // BG255/BG224 cutscene background: under the BG256Color
+                // patch, P4 is a RAW mode flag (0 = 255-color, 1 = 224-color),
+                // NOT a TSA pointer. Decode via the 8bpp path that mirrors WF
+                // ImageBGForm.DrawBG (ByteToImage256Tile / ByteToImage224BGTile),
+                // NOT Decode4bppTiles. This must run before the P4-pointer
+                // branch below (#799). Previously these entries fell through to
+                // the 4bpp fallback and rendered garbage.
+                if (IsBG256Patched && P4 <= 1 && CoreState.ImageService != null)
+                {
+                    return ImageBG256ColorCore.Decode255ColorBG(
+                        rom, P0, P8, is224: P4 == 1, CoreState.ImageService);
+                }
+
                 byte[] tileData = LZ77.decompress(rom.Data, imgAddr);
                 if (tileData == null || tileData.Length == 0) return null;
 

--- a/FEBuilderGBA.Avalonia/Views/ImageBGView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBGView.axaml.cs
@@ -73,11 +73,13 @@ namespace FEBuilderGBA.Avalonia.Views
         ///      refuse if no entry is selected / loaded yet. Writing to
         ///      `CurrentAddr == 0` would corrupt the ROM header.
         ///   2. Reserve-BG confirmation (system black / random slots).
-        ///   3. BG255/BG224 explicit refusal: if the BG256Color patch is
-        ///      installed AND the current entry's P4 is &lt;= 1 (the
-        ///      255/224 mode flag), refuse the 16-color import path
-        ///      before any ROM write. Mirrors WF
-        ///      `ImageBGSelectPopupForm` "VanillaTSA only" gate.
+        ///
+        /// BG255/BG224 entries are no longer refused here (#799): when the
+        /// BG256Color patch is installed AND the entry's P4 is &lt;= 1 (the
+        /// 255/224 mode flag), the import is routed to the 8bpp 255/224 path
+        /// (<see cref="IsBG256ColorEntry"/> + <see cref="RunBG256Import"/>)
+        /// instead of the 16-color header-TSA path. Both import handlers
+        /// branch on <see cref="IsBG256ColorEntry"/> after this gate passes.
         /// </summary>
         /// <returns>true if import should proceed; false if cancelled
         ///   or refused.</returns>
@@ -109,19 +111,67 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (!proceed) return false;
             }
 
-            // Gate 2: BG256-patched + P4 flag (0 or 1) means this entry
-            // is a 255/224-color cutscene background. Refuse 16-color
-            // import here — silent 16-color writes would corrupt the
-            // entry (Copilot CLI v3 review on PR #517).
-            if (_vm.IsBG256Patched && _vm.P4 <= 1)
-            {
-                CoreState.Services?.ShowError(
-                    "BG255/BG224 import is not yet supported in the Avalonia editor. " +
-                    "Use the WinForms editor for 255/224-color cutscene backgrounds.");
-                return false;
-            }
-
             return true;
+        }
+
+        /// <summary>
+        /// True when the current entry is a 255/224-color cutscene background:
+        /// the BG256Color patch is installed AND P4 is the raw mode flag
+        /// (0 = 255-color, 1 = 224-color), not a TSA pointer. Such entries use
+        /// the 8bpp <see cref="RunBG256Import"/> path instead of the 16-color
+        /// header-TSA path (#799). The 255-vs-224 mode is preserved from the
+        /// entry's current P4 (no popup — mirrors WF defaulting to the
+        /// existing mode).
+        /// </summary>
+        bool IsBG256ColorEntry() => _vm.IsBG256Patched && _vm.P4 <= 1;
+
+        /// <summary>
+        /// Import an 8bpp 255/224-color background (already quantized) into the
+        /// current entry, under the shared <see cref="UndoService"/> scope.
+        /// Mirrors WF <c>ImageBGForm.ImportButton255</c>: P0 = LZ77 8bpp tiles,
+        /// P4 = raw mode flag, P8 = raw 512-byte palette. The 255-vs-224 mode
+        /// is taken from the entry's current P4 (preserve).
+        /// </summary>
+        void RunBG256Import(ImageImportService.LoadResult loadResult, string sourcePath, string undoLabel)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null) return;
+
+            bool is224 = _vm.P4 == 1;
+            uint addr = _vm.CurrentAddr;
+            _undoService.Begin(undoLabel);
+            try
+            {
+                // Begin() already opened ROM.BeginUndoScope(undo); pass the
+                // same UndoData so Import255ColorBG reuses the ambient scope
+                // (no double-snapshot) and all P0/P4/P8 writes are captured.
+                var undo = _undoService.GetActiveUndoData();
+                var importResult = FEBuilderGBA.ImageBG256ColorCore.Import255ColorBG(
+                    rom, loadResult.IndexedPixels, loadResult.GBAPalette,
+                    loadResult.Width, loadResult.Height,
+                    addr + 0, addr + 4, addr + 8, is224,
+                    CoreState.ImageService, undo);
+
+                if (!importResult.Success)
+                {
+                    _undoService.Rollback();
+                    CoreState.Services.ShowError(importResult.Error);
+                    return;
+                }
+
+                _undoService.Commit();
+                _vm.LoadEntry(addr);
+                if (!string.IsNullOrEmpty(sourcePath)) _vm.RecordSourceFile(sourcePath);
+                UpdateUI();
+                LoadImage();
+                _vm.MarkClean();
+                CoreState.Services.ShowInfo("Image imported successfully.");
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                CoreState.Services.ShowError($"Import failed: {ex.Message}");
+            }
         }
 
         void ImportImageFromFile(string filePath)
@@ -129,6 +179,17 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 if (!PreImportGate()) return;
+
+                // BG255/BG224 entries take the 8bpp 255/224 path (#799).
+                if (IsBG256ColorEntry())
+                {
+                    int maxColors = _vm.P4 == 1 ? 224 : 256;
+                    var bg256Load = ImageImportService.LoadAndQuantizeFromFile(filePath, 256, 160, maxColors, strictSize: true);
+                    if (bg256Load == null) return;
+                    if (!bg256Load.Success) { CoreState.Services.ShowError(bg256Load.Error); return; }
+                    RunBG256Import(bg256Load, filePath, "Import BG255 Image (Drop)");
+                    return;
+                }
 
                 // strictSize=true mirrors WF's 256x160 expectation (see
                 // ImportPng_Click comment for rationale).
@@ -290,12 +351,25 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                // Both safety gates (reserve-BG confirmation + BG256
-                // P4-flag refusal) live in `PreImportGate` so the
-                // drag-drop import path applies them too. Copilot CLI
-                // v3 review (#517) flagged the drop-import bypassing
-                // the BG256 guard — sharing the gate eliminates that.
+                // The reserve-BG confirmation + entry-loaded guards live in
+                // `PreImportGate` so the drag-drop import path applies them
+                // too. Copilot CLI v3 review (#517) flagged the drop-import
+                // bypassing the gate — sharing it eliminates that.
                 if (!PreImportGate()) return;
+
+                // BG255/BG224 entries take the 8bpp 255/224 path (#799):
+                // quantize to 256 (255-color) or 224 (224-color) colors and
+                // write P0 = LZ77 8bpp tiles, P4 = raw mode flag, P8 = raw
+                // 512-byte palette. The mode is preserved from the entry's P4.
+                if (IsBG256ColorEntry())
+                {
+                    int maxColors = _vm.P4 == 1 ? 224 : 256;
+                    var bg256Load = await ImageImportService.LoadAndQuantize(this, 256, 160, maxColors, strictSize: true);
+                    if (bg256Load == null) return;
+                    if (!bg256Load.Success) { CoreState.Services.ShowError(bg256Load.Error); return; }
+                    RunBG256Import(bg256Load, bg256Load.SourcePath, "Import BG255 Image");
+                    return;
+                }
 
                 // Single-sub-palette quantization. WF uses palette_count=8
                 // for normal BG (8 × 16-color sub-palettes, addressed by

--- a/FEBuilderGBA.Core.Tests/ImageBG256ColorCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ImageBG256ColorCoreTests.cs
@@ -1,0 +1,585 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for ImageBG256ColorCore — the Core-side 255/224-color cutscene
+// background import + preview-decode pipeline under the FE8 "BG256Color"
+// patch (#799).
+//
+// Acceptance gates (from the approved plan v2):
+//   * Import255 (255): P0 LZ77 round-trips to source tiles; P4 == 0 as RAW
+//     u32 at p4Addr; P8 == 512-byte palette; undo rollback restores all three.
+//   * Import224: indices 0..223 → exact forward-map output; P4 == 1; a
+//     pre-remap index >= 224 returns Error (no silent blackout).
+//   * Short palette pads to exactly 512 bytes.
+//   * Convert255ColorTo224Color / Convert224ColorTo255Color parity across
+//     {0,31,32,223,224,255} (round-trip where defined).
+//   * Decode255ColorBG parity for P4=0 and P4=1 reproduces the indexed image
+//     (224 applies inverse remap) — exact-byte (8bpp is deterministic).
+using System;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests;
+
+[Collection("SharedState")]
+public class ImageBG256ColorCoreTests
+{
+    // -----------------------------------------------------------------
+    // Functional 8bpp image service (deterministic — no AA). Mirrors the
+    // exact tile order of SkiaImageService.Encode8bppTiles /
+    // Decode8bppTiles (row-major tiles, row-major within each 8x8 tile)
+    // so the encode/decode round-trip is byte-exact. The MinimalImageService
+    // / StubImageService doubles return null/no-op for encode/decode, which
+    // is insufficient for these round-trip assertions.
+    // -----------------------------------------------------------------
+
+    sealed class Bg8bppImage : IImage
+    {
+        public int Width { get; }
+        public int Height { get; }
+        public bool IsIndexed => true;
+        byte[] _pixels;
+        byte[] _palGba;
+
+        public Bg8bppImage(int w, int h, byte[] palGba)
+        {
+            Width = w; Height = h;
+            _pixels = new byte[w * h];
+            _palGba = palGba ?? Array.Empty<byte>();
+        }
+
+        public byte[] GetPixelData() => _pixels;
+        public void SetPixelData(byte[] data) => _pixels = data;
+        public byte[] GetPaletteGBA() => _palGba;
+        public void SetPaletteGBA(byte[] gbaPalette) => _palGba = gbaPalette;
+        public byte[] GetPaletteRGBA() => Array.Empty<byte>();
+        public void Save(string filePath) { }
+        public byte[] EncodePng() => Array.Empty<byte>();
+        public void Dispose() { }
+    }
+
+    sealed class Bg8bppImageService : IImageService
+    {
+        public IImage CreateImage(int w, int h) => new Bg8bppImage(w, h, null);
+        public IImage CreateIndexedImage(int w, int h, byte[] p, int c) => new Bg8bppImage(w, h, p);
+        public IImage LoadImage(string f) => null;
+        public IImage LoadImageFromBytes(byte[] d) => null;
+
+        public void GBAColorToRGBA(ushort gbaColor, out byte r, out byte g, out byte b)
+        {
+            r = (byte)((gbaColor & 0x1F) << 3);
+            g = (byte)(((gbaColor >> 5) & 0x1F) << 3);
+            b = (byte)(((gbaColor >> 10) & 0x1F) << 3);
+        }
+        public ushort RGBAToGBAColor(byte r, byte g, byte b)
+            => (ushort)((r >> 3) | ((g >> 3) << 5) | ((b >> 3) << 10));
+
+        public IImage Decode4bppTiles(byte[] t, int o, int w, int h, byte[] p) => null;
+
+        public IImage Decode8bppTiles(byte[] tileData, int offset, int width, int height, byte[] gbaPalette)
+        {
+            var image = new Bg8bppImage(width, height, gbaPalette);
+            byte[] pixels = new byte[width * height];
+            int tileW = width / 8, tileH = height / 8, pos = offset;
+            for (int ty = 0; ty < tileH; ty++)
+                for (int tx = 0; tx < tileW; tx++)
+                    for (int py = 0; py < 8; py++)
+                        for (int px = 0; px < 8; px++)
+                        {
+                            if (pos >= tileData.Length) goto done;
+                            int x = tx * 8 + px, y = ty * 8 + py;
+                            if (x < width && y < height) pixels[y * width + x] = tileData[pos];
+                            pos++;
+                        }
+            done:
+            image.SetPixelData(pixels);
+            return image;
+        }
+
+        public IImage Decode8bppLinear(byte[] d, int o, int w, int h, byte[] p) => null;
+        public byte[] Encode4bppTiles(IImage i) => null;
+
+        public byte[] Encode8bppTiles(IImage image)
+        {
+            byte[] pixels = image.GetPixelData();
+            int width = image.Width, height = image.Height;
+            int tileW = width / 8, tileH = height / 8;
+            byte[] result = new byte[tileW * tileH * 64];
+            int pos = 0;
+            for (int ty = 0; ty < tileH; ty++)
+                for (int tx = 0; tx < tileW; tx++)
+                    for (int py = 0; py < 8; py++)
+                        for (int px = 0; px < 8; px++)
+                        {
+                            int x = tx * 8 + px, y = ty * 8 + py;
+                            if (pos < result.Length)
+                                result[pos++] = (x < width && y < height) ? pixels[y * width + x] : (byte)0;
+                        }
+            return result;
+        }
+
+        public byte[] GBAPaletteToRGBA(byte[] p, int c) => null;
+        public byte[] RGBAPaletteToGBA(byte[] p, int c) => null;
+    }
+
+    static Undo.UndoData NewUndo(string name = "test") => new Undo.UndoData
+    {
+        time = DateTime.Now,
+        name = name,
+        list = new System.Collections.Generic.List<Undo.UndoPostion>(),
+        filesize = 0,
+    };
+
+    /// <summary>
+    /// ROM with the second half filled with 0xFF so the import helpers find
+    /// free space for P0/P8.
+    /// </summary>
+    static ROM MakeFreeSpaceRom(int size = 0x200000)
+    {
+        var rom = new ROM();
+        var data = new byte[size];
+        for (int i = size / 2; i < size; i++) data[i] = 0xFF;
+        rom.SwapNewROMDataDirect(data);
+        return rom;
+    }
+
+    /// <summary>BG dimensions used by every test (32x20 tiles = 256x160).</summary>
+    const int W = ImageBG256ColorCore.Width;
+    const int H = ImageBG256ColorCore.Height;
+
+    /// <summary>Build a deterministic 256x160 indexed image with indices in [0, maxIndex].</summary>
+    static byte[] MakeIndexedImage(int maxIndex)
+    {
+        byte[] px = new byte[W * H];
+        for (int i = 0; i < px.Length; i++)
+            px[i] = (byte)(i % (maxIndex + 1));
+        return px;
+    }
+
+    /// <summary>Build a deterministic 512-byte (256-color) GBA palette.</summary>
+    static byte[] Make512Palette()
+    {
+        byte[] pal = new byte[512];
+        for (int i = 0; i < 256; i++)
+        {
+            ushort c = (ushort)((i * 7 + 1) & 0x7FFF);
+            pal[i * 2] = (byte)(c & 0xFF);
+            pal[i * 2 + 1] = (byte)((c >> 8) & 0xFF);
+        }
+        return pal;
+    }
+
+    // =================================================================
+    // Forward / inverse 224 remap parity
+    // =================================================================
+
+    [Theory]
+    [InlineData(0, 0)]     // < 32 keep
+    [InlineData(31, 31)]   // < 32 keep
+    [InlineData(32, 64)]   // 32..223 -> +32
+    [InlineData(223, 255)] // 32..223 -> +32 (top of range)
+    [InlineData(224, 0)]   // >= 224 -> 0
+    [InlineData(255, 0)]   // >= 224 -> 0
+    public void Convert255To224_MatchesWFRemap(int input, int expected)
+    {
+        byte[] img = { (byte)input };
+        ImageBG256ColorCore.Convert255ColorTo224Color(img);
+        Assert.Equal((byte)expected, img[0]);
+    }
+
+    [Theory]
+    [InlineData(0, 0)]     // < 32 keep
+    [InlineData(31, 31)]   // < 32 keep
+    [InlineData(32, 0)]    // >= 32 -> -32
+    [InlineData(64, 32)]   // >= 32 -> -32
+    [InlineData(255, 223)] // >= 32 -> -32
+    public void Convert224To255_MatchesWFInverse(int input, int expected)
+    {
+        byte[] img = { (byte)input };
+        ImageBG256ColorCore.Convert224ColorTo255Color(img);
+        Assert.Equal((byte)expected, img[0]);
+    }
+
+    [Theory]
+    [InlineData(32)]   // forward 32 -> 64 -> inverse -> 32
+    [InlineData(100)]  // forward 100 -> 132 -> inverse -> 100
+    [InlineData(223)]  // forward 223 -> 255 -> inverse -> 223
+    public void RemapRoundTrip_DefinedDomain_32To223(int input)
+    {
+        // Forward map is defined+invertible on 32..223 (it lands in 64..255).
+        byte[] img = { (byte)input };
+        ImageBG256ColorCore.Convert255ColorTo224Color(img);
+        ImageBG256ColorCore.Convert224ColorTo255Color(img);
+        Assert.Equal((byte)input, img[0]);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(31)]
+    public void RemapRoundTrip_LowReservedColors_AreUnchanged(int input)
+    {
+        byte[] img = { (byte)input };
+        ImageBG256ColorCore.Convert255ColorTo224Color(img);
+        Assert.Equal((byte)input, img[0]); // forward keeps < 32
+        ImageBG256ColorCore.Convert224ColorTo255Color(img);
+        Assert.Equal((byte)input, img[0]); // inverse keeps < 32
+    }
+
+    // =================================================================
+    // PadPaletteTo512
+    // =================================================================
+
+    [Fact]
+    public void PadPaletteTo512_ShortPalette_ZeroExtendsTo512()
+    {
+        byte[] shortPal = new byte[32]; // 16 colors
+        for (int i = 0; i < shortPal.Length; i++) shortPal[i] = (byte)(i + 1);
+        byte[] padded = ImageBG256ColorCore.PadPaletteTo512(shortPal);
+
+        Assert.Equal(512, padded.Length);
+        for (int i = 0; i < 32; i++) Assert.Equal(shortPal[i], padded[i]);
+        for (int i = 32; i < 512; i++) Assert.Equal(0, padded[i]);
+    }
+
+    [Fact]
+    public void PadPaletteTo512_LongPalette_TruncatesTo512()
+    {
+        byte[] longPal = new byte[600];
+        for (int i = 0; i < longPal.Length; i++) longPal[i] = (byte)(i & 0xFF);
+        byte[] padded = ImageBG256ColorCore.PadPaletteTo512(longPal);
+
+        Assert.Equal(512, padded.Length);
+        for (int i = 0; i < 512; i++) Assert.Equal(longPal[i], padded[i]);
+    }
+
+    [Fact]
+    public void PadPaletteTo512_Null_ReturnsZeroed512()
+    {
+        byte[] padded = ImageBG256ColorCore.PadPaletteTo512(null);
+        Assert.Equal(512, padded.Length);
+        Assert.All(padded, b => Assert.Equal(0, b));
+    }
+
+    // =================================================================
+    // Import255ColorBG — 255-color (P4 = 0)
+    // =================================================================
+
+    [Fact]
+    public void Import255_WritesP0Lz77_P4RawZero_P8Palette512_AndRoundTrips()
+    {
+        ROM rom = MakeFreeSpaceRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var svc = new Bg8bppImageService();
+
+            byte[] indexed = MakeIndexedImage(255);     // full 0..255 range
+            byte[] pal = Make512Palette();
+
+            uint p0 = 0x000100, p4 = 0x000104, p8 = 0x000108;
+
+            var undo = NewUndo();
+            var result = ImageBG256ColorCore.Import255ColorBG(
+                rom, indexed, pal, W, H, p0, p4, p8, is224: false, svc, undo);
+
+            Assert.True(result.Success, result.Error);
+
+            // P4 == 0 as a RAW u32 (NOT a relocated pointer).
+            Assert.Equal(0u, rom.u32(p4));
+
+            // P8 → 512-byte palette, byte-for-byte.
+            uint palPtr = rom.u32(p8);
+            Assert.True(U.isPointer(palPtr));
+            uint palOff = U.toOffset(palPtr);
+            for (int i = 0; i < 512; i++) Assert.Equal(pal[i], rom.Data[palOff + i]);
+
+            // P0 → LZ77 data that decompresses back to the encoded 8bpp tiles.
+            uint imgPtr = rom.u32(p0);
+            Assert.True(U.isPointer(imgPtr));
+            byte[] decompressed = LZ77.decompress(rom.Data, U.toOffset(imgPtr));
+
+            // Expected = svc.Encode8bppTiles(image with indexed pixels).
+            var expectImage = svc.CreateIndexedImage(W, H, pal, 256);
+            expectImage.SetPixelData(indexed);
+            byte[] expectedTiles = svc.Encode8bppTiles(expectImage);
+            Assert.Equal(expectedTiles.Length, decompressed.Length);
+            Assert.Equal(expectedTiles, decompressed);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void Import255_UndoRollback_RestoresP0_P4_P8()
+    {
+        // UndoPostion(addr,size) captures the "before" bytes from
+        // CoreState.ROM, and Undo.Rollback patches them back into
+        // CoreState.ROM — so the rollback path requires CoreState.ROM to be
+        // the same ROM we import into.
+        ROM rom = MakeFreeSpaceRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var svc = new Bg8bppImageService();
+            byte[] indexed = MakeIndexedImage(200);
+            byte[] pal = Make512Palette();
+
+            uint p0 = 0x000100, p4 = 0x000104, p8 = 0x000108;
+
+            // Snapshot the full image region before import so we can verify a
+            // total restore (pointers + data blobs).
+            byte[] before = (byte[])rom.Data.Clone();
+
+            var undo = new Undo();
+            var undoData = undo.NewUndoData("bg255-rollback");
+            var result = ImageBG256ColorCore.Import255ColorBG(
+                rom, indexed, pal, W, H, p0, p4, p8, is224: false, svc, undoData);
+            Assert.True(result.Success, result.Error);
+
+            // Something actually changed.
+            Assert.NotEqual(0u, rom.u32(p0));
+
+            // Roll back the recorded write set.
+            Assert.True(undoData.list.Count > 0);
+            undo.Rollback(undoData);
+
+            // All three pointer slots + the data regions are restored.
+            Assert.Equal(before.Length, rom.Data.Length);
+            for (int i = 0; i < before.Length; i++)
+                Assert.Equal(before[i], rom.Data[i]);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void Import255_CapturesUndo_EvenWithoutAmbientScope()
+    {
+        // The method must open its own ambient scope when none is active, so
+        // WriteCompressedToROM / WriteRawToROM writes (which use the no-undo
+        // rom.write_* overloads) are still captured (reviewer reminder).
+        ROM rom = MakeFreeSpaceRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var svc = new Bg8bppImageService();
+            byte[] indexed = MakeIndexedImage(100);
+            byte[] pal = Make512Palette();
+
+            Assert.Null(ROM.GetAmbientUndoData()); // no scope open
+
+            var undo = NewUndo();
+            var result = ImageBG256ColorCore.Import255ColorBG(
+                rom, indexed, pal, W, H, 0x100, 0x104, 0x108, is224: false, svc, undo);
+            Assert.True(result.Success, result.Error);
+
+            // P0 (image), P4 (flag), P8 (palette) + their data blobs all recorded.
+            Assert.True(undo.list.Count >= 3);
+
+            // Scope must be closed again after the call returns.
+            Assert.Null(ROM.GetAmbientUndoData());
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    // =================================================================
+    // Import255ColorBG — 224-color (P4 = 1)
+    // =================================================================
+
+    [Fact]
+    public void Import224_AppliesForwardMap_AndWritesP4One()
+    {
+        ROM rom = MakeFreeSpaceRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var svc = new Bg8bppImageService();
+
+            // Indices 0..223 only (the BG224 contract).
+            byte[] indexed = MakeIndexedImage(223);
+            byte[] pal = Make512Palette();
+
+            uint p0 = 0x000100, p4 = 0x000104, p8 = 0x000108;
+
+            var undo = NewUndo();
+            var result = ImageBG256ColorCore.Import255ColorBG(
+                rom, indexed, pal, W, H, p0, p4, p8, is224: true, svc, undo);
+            Assert.True(result.Success, result.Error);
+
+            // P4 == 1 (224-color mode flag), raw u32.
+            Assert.Equal(1u, rom.u32(p4));
+
+            // P0 must hold the FORWARD-mapped tiles. Build the expected output by
+            // applying Convert255ColorTo224Color to a copy then encoding.
+            byte[] expectIdx = (byte[])indexed.Clone();
+            ImageBG256ColorCore.Convert255ColorTo224Color(expectIdx);
+            var expectImage = svc.CreateIndexedImage(W, H, pal, 256);
+            expectImage.SetPixelData(expectIdx);
+            byte[] expectedTiles = svc.Encode8bppTiles(expectImage);
+
+            uint imgPtr = rom.u32(p0);
+            byte[] decompressed = LZ77.decompress(rom.Data, U.toOffset(imgPtr));
+            Assert.Equal(expectedTiles, decompressed);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void Import224_PreRemapIndexAt224OrAbove_ReturnsError_NoBlackout()
+    {
+        ROM rom = MakeFreeSpaceRom();
+        var svc = new Bg8bppImageService();
+
+        // Inject an index 224 somewhere — this would silently map to 0.
+        byte[] indexed = MakeIndexedImage(223);
+        indexed[1000] = 224;
+        byte[] pal = Make512Palette();
+
+        uint p0 = 0x000100, p4 = 0x000104, p8 = 0x000108;
+        uint origP4 = rom.u32(p4);
+
+        var undo = NewUndo();
+        var result = ImageBG256ColorCore.Import255ColorBG(
+            rom, indexed, pal, W, H, p0, p4, p8, is224: true, svc, undo);
+
+        Assert.False(result.Success);
+        Assert.Contains("224", result.Error);
+        // No writes should have happened — P4 slot unchanged.
+        Assert.Equal(origP4, rom.u32(p4));
+        Assert.Empty(undo.list);
+    }
+
+    [Fact]
+    public void Import255_ShortPalette_PadsP8To512Bytes()
+    {
+        ROM rom = MakeFreeSpaceRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var svc = new Bg8bppImageService();
+            byte[] indexed = MakeIndexedImage(15);
+            byte[] shortPal = new byte[32]; // only 16 colors
+            for (int i = 0; i < shortPal.Length; i++) shortPal[i] = (byte)(i + 1);
+
+            uint p0 = 0x000100, p4 = 0x000104, p8 = 0x000108;
+
+            var undo = NewUndo();
+            var result = ImageBG256ColorCore.Import255ColorBG(
+                rom, indexed, shortPal, W, H, p0, p4, p8, is224: false, svc, undo);
+            Assert.True(result.Success, result.Error);
+
+            uint palOff = U.toOffset(rom.u32(p8));
+            // First 32 bytes are the supplied colors; bytes 32..511 are zero.
+            for (int i = 0; i < 32; i++) Assert.Equal(shortPal[i], rom.Data[palOff + i]);
+            for (int i = 32; i < 512; i++) Assert.Equal(0, rom.Data[palOff + i]);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    // =================================================================
+    // Import255ColorBG — argument guards
+    // =================================================================
+
+    [Fact]
+    public void Import255_NullRom_ReturnsError()
+    {
+        var svc = new Bg8bppImageService();
+        var result = ImageBG256ColorCore.Import255ColorBG(
+            null, MakeIndexedImage(15), Make512Palette(), W, H, 0x100, 0x104, 0x108, false, svc, NewUndo());
+        Assert.False(result.Success);
+    }
+
+    [Fact]
+    public void Import255_WrongPixelCount_ReturnsError()
+    {
+        ROM rom = MakeFreeSpaceRom();
+        var svc = new Bg8bppImageService();
+        byte[] tooSmall = new byte[W * H - 1];
+        var result = ImageBG256ColorCore.Import255ColorBG(
+            rom, tooSmall, Make512Palette(), W, H, 0x100, 0x104, 0x108, false, svc, NewUndo());
+        Assert.False(result.Success);
+    }
+
+    // =================================================================
+    // Decode255ColorBG — preview parity for P4=0 and P4=1
+    // =================================================================
+
+    [Fact]
+    public void Decode255_P4Zero_ReproducesIndexedImage_ExactBytes()
+    {
+        ROM rom = MakeFreeSpaceRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom; // Decode255ColorBG uses single-arg U.isSafetyOffset
+            var svc = new Bg8bppImageService();
+            byte[] indexed = MakeIndexedImage(255);
+            byte[] pal = Make512Palette();
+
+            uint p0 = 0x000100, p4 = 0x000104, p8 = 0x000108;
+            var result = ImageBG256ColorCore.Import255ColorBG(
+                rom, indexed, pal, W, H, p0, p4, p8, is224: false, svc, NewUndo());
+            Assert.True(result.Success, result.Error);
+
+            IImage decoded = ImageBG256ColorCore.Decode255ColorBG(rom, rom.u32(p0), rom.u32(p8), is224: false, svc);
+            Assert.NotNull(decoded);
+            Assert.Equal(W, decoded.Width);
+            Assert.Equal(H, decoded.Height);
+            // 8bpp decode is deterministic — pixel indices match exactly.
+            Assert.Equal(indexed, decoded.GetPixelData());
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void Decode224_P4One_AppliesInverseRemap_ReproducesForwardMappedImage()
+    {
+        ROM rom = MakeFreeSpaceRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom; // Decode255ColorBG uses single-arg U.isSafetyOffset
+            var svc = new Bg8bppImageService();
+            byte[] indexed = MakeIndexedImage(223); // <= 224-color contract
+            byte[] pal = Make512Palette();
+
+            uint p0 = 0x000100, p4 = 0x000104, p8 = 0x000108;
+            var result = ImageBG256ColorCore.Import255ColorBG(
+                rom, indexed, pal, W, H, p0, p4, p8, is224: true, svc, NewUndo());
+            Assert.True(result.Success, result.Error);
+
+            IImage decoded = ImageBG256ColorCore.Decode255ColorBG(rom, rom.u32(p0), rom.u32(p8), is224: true, svc);
+            Assert.NotNull(decoded);
+
+            // The ROM stored forward-mapped indices; Decode applies the inverse
+            // remap, so the decoded pixels equal forward(indexed) then inverse,
+            // which equals the original indexed image on the 0..223 domain.
+            byte[] forward = (byte[])indexed.Clone();
+            ImageBG256ColorCore.Convert255ColorTo224Color(forward);
+            byte[] expected = (byte[])forward.Clone();
+            ImageBG256ColorCore.Convert224ColorTo255Color(expected);
+            Assert.Equal(expected, decoded.GetPixelData());
+
+            // And because forward/inverse round-trips on 0..223, the decoded
+            // image reproduces the ORIGINAL indexed image exactly.
+            Assert.Equal(indexed, decoded.GetPixelData());
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void Decode255_NullRom_ReturnsNull()
+    {
+        var svc = new Bg8bppImageService();
+        Assert.Null(ImageBG256ColorCore.Decode255ColorBG(null, 0x08000100, 0x08000200, false, svc));
+    }
+
+    [Fact]
+    public void Decode255_NonPointerP0_ReturnsNull()
+    {
+        ROM rom = MakeFreeSpaceRom();
+        var svc = new Bg8bppImageService();
+        Assert.Null(ImageBG256ColorCore.Decode255ColorBG(rom, 0, 0x08000200, false, svc));
+    }
+}

--- a/FEBuilderGBA.Core.Tests/ImageBG256ColorCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ImageBG256ColorCoreTests.cs
@@ -381,6 +381,104 @@ public class ImageBG256ColorCoreTests
         finally { CoreState.ROM = prevRom; }
     }
 
+    [Fact]
+    public void Import255_NestSafe_OuterAmbientScopeWithDifferentUndo_StaysIntact()
+    {
+        // ROM.BeginUndoScope is NOT stacked. If a DIFFERENT outer ambient scope
+        // is already active, Import255ColorBG must NOT clobber it: after the call,
+        // the outer scope must still be active and recording, AND the import's own
+        // writes must have been captured by the passed inner `undo` (Copilot
+        // review #801, blocker 2).
+        ROM rom = MakeFreeSpaceRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var svc = new Bg8bppImageService();
+            byte[] indexed = MakeIndexedImage(255);
+            byte[] pal = Make512Palette();
+
+            var undoMgr = new Undo();
+            var outerUndo = undoMgr.NewUndoData("outer");
+            var innerUndo = undoMgr.NewUndoData("inner");
+
+            uint p0 = 0x000100, p4 = 0x000104, p8 = 0x000108;
+            // A sentinel slot the OUTER scope will write after the import to prove
+            // the outer scope is still recording.
+            uint sentinelAddr = 0x000200;
+            uint sentinelBefore = rom.u32(sentinelAddr);
+
+            using (ROM.BeginUndoScope(outerUndo))
+            {
+                Assert.Same(outerUndo, ROM.GetAmbientUndoData());
+
+                var result = ImageBG256ColorCore.Import255ColorBG(
+                    rom, indexed, pal, W, H, p0, p4, p8, is224: false, svc, innerUndo);
+                Assert.True(result.Success, result.Error);
+
+                // 1) Outer scope is restored exactly (same instance) after the call.
+                Assert.Same(outerUndo, ROM.GetAmbientUndoData());
+
+                // 2) The import's writes went to the INNER undo, not the outer.
+                Assert.True(innerUndo.list.Count >= 3);
+                Assert.Empty(outerUndo.list);
+
+                // 3) The outer scope is still recording: a write here lands in it.
+                rom.write_u32(sentinelAddr, 0xABCD1234u);
+                Assert.Single(outerUndo.list);
+            }
+
+            // The import's writes actually landed.
+            Assert.NotEqual(0u, rom.u32(p0));
+            Assert.Equal(0u, rom.u32(p4));
+
+            // Rolling back the inner undo restores P0/P4/P8 (but leaves the
+            // sentinel, which belongs to the outer scope).
+            undoMgr.Rollback(innerUndo);
+            Assert.Equal(0xABCD1234u, rom.u32(sentinelAddr)); // sentinel untouched by inner rollback
+
+            // Rolling back the outer undo restores the sentinel.
+            undoMgr.Rollback(outerUndo);
+            Assert.Equal(sentinelBefore, rom.u32(sentinelAddr));
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void Import255_ReusesActiveAmbientScope_WhenSameUndoAlreadyOpen()
+    {
+        // When the caller already opened an ambient scope for the SAME UndoData
+        // (the Avalonia UndoService path), Import255ColorBG must reuse it and
+        // leave it open afterward (it does not own/close it).
+        ROM rom = MakeFreeSpaceRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var svc = new Bg8bppImageService();
+            byte[] indexed = MakeIndexedImage(255);
+            byte[] pal = Make512Palette();
+
+            var undoMgr = new Undo();
+            var sharedUndo = undoMgr.NewUndoData("shared");
+
+            using (ROM.BeginUndoScope(sharedUndo))
+            {
+                var result = ImageBG256ColorCore.Import255ColorBG(
+                    rom, indexed, pal, W, H, 0x100, 0x104, 0x108, is224: false, svc, sharedUndo);
+                Assert.True(result.Success, result.Error);
+
+                // The shared scope is still active (we did not close the caller's scope).
+                Assert.Same(sharedUndo, ROM.GetAmbientUndoData());
+                // The writes were captured by the shared undo.
+                Assert.True(sharedUndo.list.Count >= 3);
+            }
+            // After the using-scope closes, ambient is null again.
+            Assert.Null(ROM.GetAmbientUndoData());
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
     // =================================================================
     // Import255ColorBG — 224-color (P4 = 1)
     // =================================================================
@@ -501,6 +599,40 @@ public class ImageBG256ColorCoreTests
         Assert.False(result.Success);
     }
 
+    [Theory]
+    [InlineData(240, 160)] // wrong width (30 tiles)
+    [InlineData(256, 144)] // wrong height (18 tiles)
+    [InlineData(512, 320)] // 2x — multiple of 8 but not the fixed size
+    [InlineData(8, 8)]     // tiny
+    public void Import255_WrongSize_ReturnsError_NoWrites(int w, int h)
+    {
+        // BG255/BG224 is fixed 256x160 — any other size can never round-trip
+        // through Decode255ColorBG (Copilot review #801).
+        ROM rom = MakeFreeSpaceRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var svc = new Bg8bppImageService();
+            byte[] indexed = new byte[w * h]; // matches w*h so size is the only fault
+            byte[] pal = Make512Palette();
+
+            uint p0 = 0x000100, p4 = 0x000104, p8 = 0x000108;
+            uint origP4 = rom.u32(p4);
+
+            var undo = NewUndo();
+            var result = ImageBG256ColorCore.Import255ColorBG(
+                rom, indexed, pal, w, h, p0, p4, p8, is224: false, svc, undo);
+
+            Assert.False(result.Success);
+            Assert.Contains("256x160", result.Error);
+            // Rejected before any ROM write.
+            Assert.Equal(origP4, rom.u32(p4));
+            Assert.Empty(undo.list);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
     // =================================================================
     // Decode255ColorBG — preview parity for P4=0 and P4=1
     // =================================================================
@@ -512,7 +644,7 @@ public class ImageBG256ColorCoreTests
         var prevRom = CoreState.ROM;
         try
         {
-            CoreState.ROM = rom; // Decode255ColorBG uses single-arg U.isSafetyOffset
+            CoreState.ROM = rom; // only for the import's undo capture
             var svc = new Bg8bppImageService();
             byte[] indexed = MakeIndexedImage(255);
             byte[] pal = Make512Palette();
@@ -522,6 +654,9 @@ public class ImageBG256ColorCoreTests
                 rom, indexed, pal, W, H, p0, p4, p8, is224: false, svc, NewUndo());
             Assert.True(result.Success, result.Error);
 
+            // Decode255ColorBG must use only the passed rom — clear CoreState.ROM
+            // to prove it does not depend on global state (Copilot review #801).
+            CoreState.ROM = null;
             IImage decoded = ImageBG256ColorCore.Decode255ColorBG(rom, rom.u32(p0), rom.u32(p8), is224: false, svc);
             Assert.NotNull(decoded);
             Assert.Equal(W, decoded.Width);
@@ -539,7 +674,7 @@ public class ImageBG256ColorCoreTests
         var prevRom = CoreState.ROM;
         try
         {
-            CoreState.ROM = rom; // Decode255ColorBG uses single-arg U.isSafetyOffset
+            CoreState.ROM = rom; // only for the import's undo capture
             var svc = new Bg8bppImageService();
             byte[] indexed = MakeIndexedImage(223); // <= 224-color contract
             byte[] pal = Make512Palette();
@@ -549,6 +684,9 @@ public class ImageBG256ColorCoreTests
                 rom, indexed, pal, W, H, p0, p4, p8, is224: true, svc, NewUndo());
             Assert.True(result.Success, result.Error);
 
+            // Decode255ColorBG must use only the passed rom — clear CoreState.ROM
+            // to prove it does not depend on global state (Copilot review #801).
+            CoreState.ROM = null;
             IImage decoded = ImageBG256ColorCore.Decode255ColorBG(rom, rom.u32(p0), rom.u32(p8), is224: true, svc);
             Assert.NotNull(decoded);
 
@@ -563,6 +701,41 @@ public class ImageBG256ColorCoreTests
 
             // And because forward/inverse round-trips on 0..223, the decoded
             // image reproduces the ORIGINAL indexed image exactly.
+            Assert.Equal(indexed, decoded.GetPixelData());
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void Decode255_WorksWithDifferentCoreStateRom()
+    {
+        // Stronger variant of the global-state guard: import into `rom`, then
+        // point CoreState.ROM at a SMALL, unrelated ROM and decode. If decode
+        // used the single-arg U.isSafetyOffset (CoreState.ROM) the offsets would
+        // be rejected against the tiny ROM and the decode would wrongly return
+        // null. The 2-arg overload bound to `rom` keeps it correct.
+        ROM rom = MakeFreeSpaceRom();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var svc = new Bg8bppImageService();
+            byte[] indexed = MakeIndexedImage(255);
+            byte[] pal = Make512Palette();
+
+            uint p0 = 0x000100, p4 = 0x000104, p8 = 0x000108;
+            var result = ImageBG256ColorCore.Import255ColorBG(
+                rom, indexed, pal, W, H, p0, p4, p8, is224: false, svc, NewUndo());
+            Assert.True(result.Success, result.Error);
+            uint imgPtr = rom.u32(p0), palPtr = rom.u32(p8);
+
+            // A different, much smaller ROM whose length would reject the offsets.
+            var otherRom = new ROM();
+            otherRom.SwapNewROMDataDirect(new byte[0x1000]);
+            CoreState.ROM = otherRom;
+
+            IImage decoded = ImageBG256ColorCore.Decode255ColorBG(rom, imgPtr, palPtr, is224: false, svc);
+            Assert.NotNull(decoded);
             Assert.Equal(indexed, decoded.GetPixelData());
         }
         finally { CoreState.ROM = prevRom; }

--- a/FEBuilderGBA.Core/ImageBG256ColorCore.cs
+++ b/FEBuilderGBA.Core/ImageBG256ColorCore.cs
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Core-side import + preview-decode pipeline for 255/224-color cutscene
+// backgrounds under the FE8 "BG256Color" patch (#799).
+//
+// This is the 8bpp sibling of the 16-color BG path
+// (`ImageImportCore.Import3PointerHeaderTSA`). A BG255/BG224 entry stores:
+//
+//   +0  u32 image   pointer (LZ77-compressed 8bpp tiles)
+//   +4  u32 flag     = 0 (255-color) or 1 (224-color) — RAW u32, NOT a pointer
+//   +8  u32 palette  pointer (RAW 512-byte palette = 256 colors)
+//
+// It mirrors WinForms `ImageBGForm.ImportButton255` (ImageBGForm.cs:164-205)
+// for import and `ImageBGForm.DrawBG` (ImageBGForm.cs:101-133) for preview:
+//   * 255-color: `ByteToImage256Tile` (8bpp tile decode), P4 = 0.
+//   * 224-color: `ByteToImage224BGTile` (8bpp decode after an index remap),
+//     P4 = 1.
+//
+// The 224 forward/inverse index remaps are byte-exact ports of
+// `ImageUtil.Convert255ColorTo224Color` (ImageUtil.cs:4670) and the inverse
+// pre-pass inside `ImageUtil.ByteToImage224BGTile` (ImageUtil.cs:666-687).
+using System;
+
+namespace FEBuilderGBA
+{
+    public static class ImageBG256ColorCore
+    {
+        /// <summary>
+        /// Number of bytes a full BG255/BG224 palette occupies in ROM:
+        /// 256 colors x 2 bytes = 512 bytes (16 sub-palettes x 16 colors).
+        /// </summary>
+        public const int PaletteByteSize = 256 * 2;
+
+        /// <summary>BG width in pixels (32 tiles).</summary>
+        public const int Width = 32 * 8;
+
+        /// <summary>BG height in pixels (20 tiles).</summary>
+        public const int Height = 20 * 8;
+
+        /// <summary>
+        /// Matches WinForms `ImageUtil.BG224StartPaletteIndex` (= 2). The
+        /// 224-color mode reserves the bottom <c>2 * 16 = 32</c> palette
+        /// indices for the system, so user colors live in indices
+        /// <c>32..255</c> of the 255-color image but are remapped down so
+        /// the ROM never stores an index in the reserved range.
+        /// </summary>
+        const int BG224StartPaletteIndex = 2;
+
+        /// <summary>Result of an <see cref="Import255ColorBG"/> call.</summary>
+        public readonly struct ImportResult
+        {
+            public bool Success { get; init; }
+            public string Error { get; init; }
+
+            public static ImportResult Ok() => new ImportResult { Success = true, Error = string.Empty };
+            public static ImportResult Fail(string error) => new ImportResult { Success = false, Error = error };
+        }
+
+        /// <summary>
+        /// Byte-exact port of WinForms <c>ImageUtil.Convert255ColorTo224Color</c>
+        /// (ImageUtil.cs:4670). Remaps the reserved top palette indices so a
+        /// 255-color indexed image can be stored as a 224-color background.
+        /// Operates in-place on the image indices ONLY — the palette is NOT
+        /// touched (mirrors WF).
+        ///
+        /// Per index <c>a</c> (with <see cref="BG224StartPaletteIndex"/> = 2):
+        /// <list type="bullet">
+        ///   <item><c>a &lt; 32</c>  → keep (reserved low colors).</item>
+        ///   <item><c>a &gt;= 224</c> → <c>0</c> (the top 32 colors are not
+        ///     representable in 224-color mode).</item>
+        ///   <item>otherwise        → <c>a + 32</c> (so <c>32..223</c> → <c>64..255</c>).</item>
+        /// </list>
+        /// </summary>
+        public static void Convert255ColorTo224Color(byte[] image)
+        {
+            if (image == null) return;
+            for (int i = 0; i < image.Length; i += 1)
+            {
+                byte a = image[i];
+                if (a < BG224StartPaletteIndex * 16)
+                {
+                    continue;
+                }
+
+                if (a >= (16 - 2) * 16)
+                {
+                    a = 0;
+                }
+                else
+                {
+                    a += 16 * 2;
+                }
+                image[i] = a;
+            }
+        }
+
+        /// <summary>
+        /// Byte-exact inverse of the 224-color remap, mirroring the pre-pass
+        /// inside WinForms <c>ImageUtil.ByteToImage224BGTile</c>
+        /// (ImageUtil.cs:666-687). Applied to a COPY of the decompressed
+        /// image indices before an 8bpp tile decode so the BG224 preview is
+        /// correct.
+        ///
+        /// Per index <c>a</c> (with <see cref="BG224StartPaletteIndex"/> = 2):
+        /// <list type="bullet">
+        ///   <item><c>a &gt;= 32</c> → <c>a - 32</c> (so <c>64..255</c> → <c>32..223</c>).</item>
+        ///   <item>otherwise       → keep.</item>
+        /// </list>
+        /// Note this is the literal WF inverse pass; it is not a strict
+        /// mathematical inverse of the forward map on the unused
+        /// <c>32..63</c>/<c>224..255</c> domains (the forward map never emits
+        /// those), but it reproduces WF preview output exactly.
+        /// </summary>
+        public static void Convert224ColorTo255Color(byte[] image)
+        {
+            if (image == null) return;
+            for (int i = 0; i < image.Length; i++)
+            {
+                byte a = image[i];
+                if (a >= BG224StartPaletteIndex * 16)
+                {
+                    a -= 2 * 16;
+                }
+                image[i] = a;
+            }
+        }
+
+        /// <summary>
+        /// Pad (or trim) a GBA palette to exactly <see cref="PaletteByteSize"/>
+        /// (512) bytes. Short palettes are zero-extended; over-long palettes
+        /// are truncated. Mirrors WF, which always writes a full 512-byte
+        /// (256-color) palette for a BG255/BG224 entry.
+        /// </summary>
+        public static byte[] PadPaletteTo512(byte[] gbaPalette)
+        {
+            byte[] pal = new byte[PaletteByteSize];
+            if (gbaPalette != null)
+            {
+                int n = Math.Min(gbaPalette.Length, PaletteByteSize);
+                Array.Copy(gbaPalette, 0, pal, 0, n);
+            }
+            return pal;
+        }
+
+        /// <summary>
+        /// Write a 255/224-color cutscene background.
+        ///
+        /// <paramref name="indexed8bpp"/> is one byte per pixel (0..255 into
+        /// <paramref name="gbaPalette512"/>), laid out as a linear bitmap
+        /// (row-major, <paramref name="w"/> x <paramref name="h"/>).
+        ///
+        /// Steps (mirroring WF <c>ImageBGForm.ImportButton255</c>):
+        /// <list type="number">
+        ///   <item>If <paramref name="is224"/>: reject any pre-remap index
+        ///     &gt;= 224 (would silently black out under the 224 remap), then
+        ///     apply <see cref="Convert255ColorTo224Color"/> in place.</item>
+        ///   <item>Wrap the indices as an 8bpp <see cref="IImage"/> →
+        ///     <c>svc.Encode8bppTiles</c> → 8bpp tile bytes.</item>
+        ///   <item>P0: LZ77-compress the tiles and write via
+        ///     <see cref="ImageImportCore.WriteCompressedToROM"/>.</item>
+        ///   <item>P4: write the RAW u32 mode flag (0 or 1) at
+        ///     <paramref name="p4Addr"/> — never a pointer write.</item>
+        ///   <item>P8: pad the palette to exactly 512 bytes and write RAW via
+        ///     <see cref="ImageImportCore.WriteRawToROM"/>.</item>
+        /// </list>
+        ///
+        /// All three writes are captured for undo: this method opens an
+        /// ambient <c>ROM.BeginUndoScope(undo)</c> for its entire body, so
+        /// the no-undo writes inside <c>WriteCompressedToROM</c> /
+        /// <c>WriteRawToROM</c> record into <paramref name="undo"/> even when
+        /// called outside the Avalonia call path. If an ambient scope for the
+        /// same UndoData is already active (the Avalonia path opens one via
+        /// <c>UndoService</c>), it is reused rather than nested.
+        /// </summary>
+        public static ImportResult Import255ColorBG(
+            ROM rom, byte[] indexed8bpp, byte[] gbaPalette512, int w, int h,
+            uint p0Addr, uint p4Addr, uint p8Addr, bool is224,
+            IImageService svc, Undo.UndoData undo)
+        {
+            if (rom == null) return ImportResult.Fail("ROM is null");
+            if (indexed8bpp == null) return ImportResult.Fail("Indexed pixel data is null");
+            if (svc == null) return ImportResult.Fail("Image service is not available");
+            if (w <= 0 || h <= 0 || w % 8 != 0 || h % 8 != 0)
+                return ImportResult.Fail("Width/height must be positive multiples of 8");
+            if (indexed8bpp.Length != w * h)
+                return ImportResult.Fail($"Indexed pixel count ({indexed8bpp.Length}) does not match width*height ({w * h})");
+
+            // Reuse an already-open ambient scope (Avalonia path) or open one
+            // so every helper write below is undo-captured.
+            bool ownsScope = undo != null && ROM.GetAmbientUndoData() != undo;
+            IDisposable scope = ownsScope ? ROM.BeginUndoScope(undo) : null;
+            try
+            {
+                // Operate on a copy so the caller's buffer is not mutated by
+                // the 224 remap.
+                byte[] indexed = (byte[])indexed8bpp.Clone();
+
+                if (is224)
+                {
+                    // The 224 forward map sends indices >= 224 to 0 — silently
+                    // dropping up to 32 colors. Refuse rather than black out
+                    // (Copilot CLI v2 blocker 1 / acceptance gate).
+                    byte max = 0;
+                    for (int i = 0; i < indexed.Length; i++)
+                        if (indexed[i] > max) max = indexed[i];
+                    if (max >= (16 - 2) * 16)
+                        return ImportResult.Fail("BG224 needs <=224 colors (an index >= 224 was found)");
+
+                    Convert255ColorTo224Color(indexed);
+                }
+
+                // Wrap as an 8bpp indexed image and encode to GBA tiles.
+                byte[] pal512 = PadPaletteTo512(gbaPalette512);
+                IImage image = svc.CreateIndexedImage(w, h, pal512, PaletteByteSize / 2);
+                if (image == null) return ImportResult.Fail("Failed to create indexed image");
+                byte[] tiles;
+                try
+                {
+                    image.SetPixelData(indexed);
+                    tiles = svc.Encode8bppTiles(image);
+                }
+                finally { image.Dispose(); }
+                if (tiles == null || tiles.Length == 0)
+                    return ImportResult.Fail("Failed to encode 8bpp tiles");
+
+                // P0: LZ77-compressed tiles.
+                uint imgAddr = ImageImportCore.WriteCompressedToROM(rom, tiles, p0Addr);
+                if (imgAddr == U.NOT_FOUND)
+                    return ImportResult.Fail("Failed to write compressed image data (no free space)");
+
+                // P4: RAW u32 mode flag (0 = 255-color, 1 = 224-color). This
+                // slot is NOT a pointer under the BG256Color patch.
+                rom.write_u32(p4Addr, is224 ? 1u : 0u);
+
+                // P8: RAW 512-byte palette.
+                uint palAddr = ImageImportCore.WriteRawToROM(rom, pal512, p8Addr);
+                if (palAddr == U.NOT_FOUND)
+                    return ImportResult.Fail("Failed to write palette (no free space)");
+
+                return ImportResult.Ok();
+            }
+            finally
+            {
+                scope?.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Decode a 255/224-color background to an <see cref="IImage"/> for
+        /// preview. Mirrors WF <c>ImageBGForm.DrawBG</c>:
+        /// <list type="bullet">
+        ///   <item>LZ77-decompress the P0 image.</item>
+        ///   <item>Read the RAW 512-byte palette at P8.</item>
+        ///   <item>255-color (<paramref name="is224"/> = false): decode the
+        ///     8bpp tiles directly (<c>ByteToImage256Tile</c>).</item>
+        ///   <item>224-color (<paramref name="is224"/> = true): apply
+        ///     <see cref="Convert224ColorTo255Color"/> to a copy of the indices,
+        ///     zero the top 32 palette colors (WF copies only 224 colors into
+        ///     the decode palette), then decode
+        ///     (<c>ByteToImage224BGTile</c>).</item>
+        /// </list>
+        /// Returns <c>null</c> on any failure (caller renders a blank).
+        /// </summary>
+        public static IImage Decode255ColorBG(ROM rom, uint p0Addr, uint p8Addr, bool is224, IImageService svc)
+        {
+            if (rom == null || svc == null) return null;
+            if (!U.isPointer(p0Addr) || !U.isPointer(p8Addr)) return null;
+
+            uint imgOff = U.toOffset(p0Addr);
+            uint palOff = U.toOffset(p8Addr);
+            if (!U.isSafetyOffset(imgOff) || !U.isSafetyOffset(palOff)) return null;
+
+            byte[] tiles = LZ77.decompress(rom.Data, imgOff);
+            if (tiles == null || tiles.Length == 0) return null;
+
+            // Read the raw 512-byte palette (256 colors). Pad/clip so the
+            // decode always sees a full 512-byte palette.
+            byte[] pal512 = new byte[PaletteByteSize];
+            int palCopy = (int)Math.Min((uint)PaletteByteSize, (uint)rom.Data.Length - palOff);
+            if (palCopy > 0)
+                Array.Copy(rom.Data, palOff, pal512, 0, palCopy);
+
+            if (is224)
+            {
+                // WF ByteToImage224BGTile remaps the indices down, then decodes
+                // against a palette where only the first 224 colors are kept
+                // (top 32 zeroed).
+                Convert224ColorTo255Color(tiles);
+                for (int i = 16 * 14 * 2; i < PaletteByteSize; i++)
+                    pal512[i] = 0;
+            }
+
+            return svc.Decode8bppTiles(tiles, 0, Width, Height, pal512);
+        }
+    }
+}

--- a/FEBuilderGBA.Core/ImageBG256ColorCore.cs
+++ b/FEBuilderGBA.Core/ImageBG256ColorCore.cs
@@ -179,14 +179,27 @@ namespace FEBuilderGBA
             if (rom == null) return ImportResult.Fail("ROM is null");
             if (indexed8bpp == null) return ImportResult.Fail("Indexed pixel data is null");
             if (svc == null) return ImportResult.Fail("Image service is not available");
-            if (w <= 0 || h <= 0 || w % 8 != 0 || h % 8 != 0)
-                return ImportResult.Fail("Width/height must be positive multiples of 8");
+            // BG255/BG224 entries are a fixed 256x160 (32x20 tiles) — Decode255ColorBG
+            // always decodes with those constants, so a different size could never
+            // round-trip. Reject up front (Copilot review on PR #801).
+            if (w != Width || h != Height)
+                return ImportResult.Fail($"BG255/BG224 must be {Width}x{Height}");
             if (indexed8bpp.Length != w * h)
                 return ImportResult.Fail($"Indexed pixel count ({indexed8bpp.Length}) does not match width*height ({w * h})");
 
-            // Reuse an already-open ambient scope (Avalonia path) or open one
-            // so every helper write below is undo-captured.
-            bool ownsScope = undo != null && ROM.GetAmbientUndoData() != undo;
+            // Undo capture must be nest-safe (Copilot review on PR #801):
+            // ROM.BeginUndoScope is NOT stacked — its IDisposable.Dispose() clears
+            // the ambient scope to null rather than restoring the previous one. So
+            // we save the caller's prior ambient scope, set our own only when it
+            // differs, and on exit RESTORE the prior scope (re-opening it) instead
+            // of nulling it. The invariant: after this method returns, any
+            // pre-existing ambient scope from the caller is intact, AND the
+            // P0/P4/P8 writes were captured by `undo`.
+            //   - prior == undo  → reuse the existing scope (do not re-open).
+            //   - prior == null  → open our scope; restore to null (dispose) on exit.
+            //   - prior != undo  → open our scope; restore the prior scope on exit.
+            Undo.UndoData priorAmbient = ROM.GetAmbientUndoData();
+            bool ownsScope = undo != null && priorAmbient != undo;
             IDisposable scope = ownsScope ? ROM.BeginUndoScope(undo) : null;
             try
             {
@@ -240,7 +253,18 @@ namespace FEBuilderGBA
             }
             finally
             {
-                scope?.Dispose();
+                if (ownsScope)
+                {
+                    // Dispose our scope (sets ambient to null), then re-open the
+                    // caller's prior scope if there was one so their undo tracking
+                    // survives. ROM.BeginUndoScope is not stacked, so a plain
+                    // Dispose() would otherwise wipe a different outer scope.
+                    scope.Dispose();
+                    if (priorAmbient != null)
+                    {
+                        ROM.BeginUndoScope(priorAmbient);
+                    }
+                }
             }
         }
 
@@ -267,7 +291,11 @@ namespace FEBuilderGBA
 
             uint imgOff = U.toOffset(p0Addr);
             uint palOff = U.toOffset(p8Addr);
-            if (!U.isSafetyOffset(imgOff) || !U.isSafetyOffset(palOff)) return null;
+            // Bind the safety check to the PASSED rom (2-arg overload). The
+            // single-arg U.isSafetyOffset reads CoreState.ROM, which would make
+            // this depend on global state and could NRE when CoreState.ROM is null
+            // (Copilot review on PR #801).
+            if (!U.isSafetyOffset(imgOff, rom) || !U.isSafetyOffset(palOff, rom)) return null;
 
             byte[] tiles = LZ77.decompress(rom.Data, imgOff);
             if (tiles == null || tiles.Length == 0) return null;

--- a/FEBuilderGBA/ImageUtil.cs
+++ b/FEBuilderGBA/ImageUtil.cs
@@ -4667,26 +4667,14 @@ namespace FEBuilderGBA
 
         const int BG224StartPaletteIndex = 2;
 
+        // Single source of truth: the 255->224 index remap lives in
+        // FEBuilderGBA.Core (ImageBG256ColorCore) so the Avalonia/CLI BG255
+        // import and the WinForms ImageBGForm.ImportButton255 path stay
+        // byte-identical (#799). This forwards to the Core port; behavior is
+        // unchanged (keep <32; >=224 -> 0; else += 32).
         public static void Convert255ColorTo224Color(byte[] image)
         {
-            for (int i = 0; i < image.Length; i += 1)
-            {
-                byte a = image[i];
-                if (a < BG224StartPaletteIndex * 16)
-                {
-                    continue;
-                }
-
-                if (a >= (16 - 2) * 16)
-                {
-                    a = 0;
-                }
-                else
-                {
-                    a += 16 * 2;
-                }
-                image[i] = a;
-            }
+            FEBuilderGBA.ImageBG256ColorCore.Convert255ColorTo224Color(image);
         }
 
     }

--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ FEBuilderGBA.exe --rom path/to/rom.gba --export-editor-images --screenshot-dir=.
 # Shared palette detection: If a palette pointer is referenced by multiple entries,
 # the import remaps pixel indices to the existing palette instead of overwriting it,
 # preserving visual consistency for all entries sharing that palette.
+# BG255/BG224 (255-color cutscene backgrounds): on ROMs with the BG256Color patch,
+# the Avalonia ImageBG editor imports and previews 255/224-color backgrounds (8bpp
+# LZ77 tiles + 512-byte palette + P4 mode flag), mirroring WinForms ImportButton255
+# via the cross-platform ImageBG256ColorCore (224-color mode rejects >224 colors
+# rather than silently blacking them out).
 dotnet run --project FEBuilderGBA.Avalonia -- --rom path/to/rom.gba --validate-import
 
 # Validate palette roundtrip (export palette→import palette→re-export→binary compare)

--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ FEBuilderGBA.exe --rom path/to/rom.gba --export-editor-images --screenshot-dir=.
 # BG255/BG224 (255-color cutscene backgrounds): on ROMs with the BG256Color patch,
 # the Avalonia ImageBG editor imports and previews 255/224-color backgrounds (8bpp
 # LZ77 tiles + 512-byte palette + P4 mode flag), mirroring WinForms ImportButton255
-# via the cross-platform ImageBG256ColorCore (224-color mode rejects >224 colors
-# rather than silently blacking them out).
+# via the cross-platform ImageBG256ColorCore (224-color mode rejects any pre-remap
+# pixel index >= 224 — indices must be 0..223 — rather than silently blacking them
+# out; the import is fixed to 256x160).
 dotnet run --project FEBuilderGBA.Avalonia -- --rom path/to/rom.gba --validate-import
 
 # Validate palette roundtrip (export palette→import palette→re-export→binary compare)


### PR DESCRIPTION
## Summary

Resolves the Avalonia↔WinForms parity gap (#769 family) where the Avalonia **ImageBG** editor refused 255/224-color cutscene backgrounds (FE8 BG256Color patch) and mis-decoded their preview as 4bpp. Adds a cross-platform Core seam that mirrors WinForms `ImageBGForm.ImportButton255` / `DrawBG` **byte-exact**.

### New: `FEBuilderGBA.Core/ImageBG256ColorCore.cs`
- **`Convert255ColorTo224Color`** — exact port of `ImageUtil.cs:4670` (`<32` keep; `>=224` → `0`; else `+=32`). WinForms `ImageUtil.Convert255ColorTo224Color` now **forwards to this Core port** (single source of truth).
- **`Convert224ColorTo255Color`** — exact inverse from `ByteToImage224BGTile` (`ImageUtil.cs:666-687`: `>=32` → `-=32`; else keep).
- **`Import255ColorBG`** — BG224 rejects any pre-remap index `>=224` (no silent blackout); wraps indices as an 8bpp `IImage` → `Encode8bppTiles`; **P0** = LZ77 (`WriteCompressedToROM`); **P4** = RAW `u32` `0/1` at `addr+4` (never a pointer write); **P8** = RAW 512-byte palette (short palettes padded). Opens an ambient `ROM.BeginUndoScope(undo)` for the whole body (reusing the Avalonia `UndoService` scope when already active), so **all** P0/P4/P8 writes are undo-captured even off the Avalonia path — rollback restores all three.
- **`Decode255ColorBG`** — LZ77-decompress P0; 224 applies the inverse remap to a copy + zeroes the top-32 palette colors (matches WF `ByteToImage224BGTile`); `Decode8bppTiles` 256×160.

### Avalonia
- `ImageBGViewModel.TryLoadImage` now decodes BG256-patched `P4<=1` entries via `Decode255ColorBG` (was `Decode4bppTiles` → garbage), so the post-import preview is correct.
- `ImageBGView` removes the 255/224 refusal gate and routes such entries to `RunBG256Import` (quantize to 256/224 colors; 255-vs-224 preserved from the entry's current P4) under the shared `UndoService`.

### Constraint (post-#798)
Based on `origin/master`: `FEBuilderGBA.SkiaSharp` pinned **SkiaSharp 2.88.9**, `CoreState.AppendBinaryData` wired. No 3.x-only SkiaSharp APIs.

Closes #799. Refs #769.

## GUI Test Report

Real Avalonia GUI capture (PrintWindow) of the **Background Image Editor** on a BG256Color-patched FE8U ROM. BG slot 0 was written as a real BG255 entry via `ImageBG256ColorCore.Import255ColorBG`, then loaded through the ViewModel.

| # | Check | Result |
|---|-------|--------|
| 1 | BG256Color patch detected; list shows all 54 BG entries (BG255 rows not truncated) | PASS |
| 2 | Entry 0 = BG255: Image (P0) `0x08B2A608`, **Header TSA (P4) `0x00000000`** raw mode flag, Palette (P8) `0x0882D21C` | PASS |
| 3 | Preview renders the correct 255-color image (8bpp `Decode255ColorBG`, not 4bpp garbage) | PASS |
| 4 | "This entry is a 255-color cutscene background." warning banner shown | PASS |

![ImageBG BG255 import](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr799-imagebg255.png)

> Screenshot committed to master via docs PR #800.

## Test plan

- [x] `Import255ColorBG` (255): P0 LZ77 round-trips to source tiles; **P4 == 0 raw u32 at addr+4**; P8 == 512-byte palette; undo rollback restores all three (Core.Tests)
- [x] `Import255ColorBG` (224): indices 0..223 → exact forward-map output; P4 == 1; **a pre-remap index >= 224 returns Error (no silent blackout)** (Core.Tests)
- [x] Short palette pads P8 to exactly 512 bytes (Core.Tests)
- [x] `Convert255ColorTo224Color` / `Convert224ColorTo255Color` parity across {0,31,32,223,224,255} + round-trip on 32..223 (Core.Tests)
- [x] `Decode255ColorBG` preview parity for P4=0 and P4=1 reproduces the indexed image exact-byte (224 applies inverse remap) (Core.Tests)
- [x] `Import255ColorBG` captures undo even with no pre-existing ambient scope; scope closed after return (Core.Tests)
- [x] Avalonia 255/224 routing predicate + end-to-end preview decode via SkiaImageService (Avalonia.Tests)
- [x] All 5 projects (Core, SkiaSharp, Avalonia, CLI, WinForms) build with 0 errors
- [x] `dotnet test FEBuilderGBA.Core.Tests` green — 2075 passed (+31 new)
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` green — 7190 passed (+2 new)
- [x] `scripts/validate-automation-ids.ps1` exit 0; L10n scanner green; no new AXAML literals (ja/zh unchanged)
- [x] Functional: Avalonia ImageBG imports/previews a BG255 entry on a BG256-patched ROM (editor screenshot above)

<sub>Generated with Claude Code v2.1.156 (model: claude-opus-4-8, Opus 4.8 1M context)</sub>