### PR TITLE
feat(avalonia): chipset preview render in ImageBattleScreen (closes #805)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleScreenParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleScreenParityTests.cs
@@ -115,8 +115,8 @@ public class ImageBattleScreenParityTests
     /// <summary>
     /// #802: the Battle preview is now rendered LIVE via a GbaImageControl
     /// (ImageBattleScreenCore.RenderBattleScreenPreview), replacing the old
-    /// deferred KnownGap placeholder label. The Chipset thumbnail remains
-    /// deferred (verified separately by View_HasChipsetPreviewKnownGapPlaceholder).
+    /// deferred KnownGap placeholder label. #805: the Chipset chip list is now
+    /// ALSO rendered live (verified by View_HasLiveChipsetPreviewImage).
     /// </summary>
     [Fact]
     public void View_HasLiveBattlePreviewImage()
@@ -135,11 +135,27 @@ public class ImageBattleScreenParityTests
             RegexOptions.Singleline), code);
     }
 
+    /// <summary>
+    /// #805: the Chipset chip list is now rendered LIVE via a GbaImageControl
+    /// (ImageBattleScreenCore.RenderChipsetPreview, mirroring WF MakeCHIPLIST),
+    /// replacing the old deferred KnownGap placeholder label. The new control
+    /// carries the ChipsetPreview_Image AutomationId; the old _Label is gone.
+    /// </summary>
     [Fact]
-    public void View_HasChipsetPreviewKnownGapPlaceholder()
+    public void View_HasLiveChipsetPreviewImage()
     {
         string axaml = ReadAxaml();
-        Assert.Contains("AutomationId=\"ImageBattleScreen_ChipsetPreview_Label\"", axaml);
+        // The live chip-list control carries the ChipsetPreview AutomationId and
+        // is a GbaImageControl (Image suffix per AutomationId convention).
+        Assert.Contains("AutomationId=\"ImageBattleScreen_ChipsetPreview_Image\"", axaml);
+        Assert.Contains("Name=\"ChipsetPreview\"", axaml);
+        // The old deferred placeholder label must be gone.
+        Assert.DoesNotContain("AutomationId=\"ImageBattleScreen_ChipsetPreview_Label\"", axaml);
+        // The code-behind must wire the render into the control.
+        string code = File.ReadAllText(CodeBehindPath());
+        Assert.Matches(new Regex(
+            @"ChipsetPreview\.SetImage\(\s*_vm\.RenderChipsetPreview\(\)\s*\)",
+            RegexOptions.Singleline), code);
     }
 
     [Fact]

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageBattleScreenViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageBattleScreenViewModel.cs
@@ -169,6 +169,19 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         }
 
         /// <summary>
+        /// Render the chipset chip-list preview (#805, follow-up to #802).
+        /// Delegates to <see cref="ImageBattleScreenCore.RenderChipsetPreview"/>
+        /// which mirrors the WF <c>MakeCHIPLIST()</c> 8-column flip/palette-bank
+        /// permutation grid (canvas <c>ChipCache.Width*4*2</c> x
+        /// <c>ChipCache.Height</c>). Returns <c>null</c> (caller shows a blank
+        /// surface) if any required source is missing/corrupt.
+        /// </summary>
+        public IImage RenderChipsetPreview()
+        {
+            return ImageBattleScreenCore.RenderChipsetPreview(CoreState.ROM);
+        }
+
+        /// <summary>
         /// Bulk-write the TSA grid + 5 image pointers to ROM. Caller MUST
         /// wrap this in <c>UndoService.Begin/Commit/Rollback</c>. Returns
         /// <c>true</c> on success.

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml
@@ -51,21 +51,27 @@
       </Border>
 
       <!-- ===========================================================
-           Battle preview row. The Battle preview is now rendered live via
-           ImageBattleScreenCore.RenderBattleScreenPreview (#802): a 256x160
-           IImage composited from the 5 LZ77 image strips + RAW 16-bank
-           palette + normalized TSA grid, displayed in a GbaImageControl.
-           The Chipset thumbnail (flip-permutation chip list) is still
-           deferred (WF-coupled ImageUtil.BitBlt): honest KnownGap (#393).
+           Preview row. BOTH previews are now rendered live cross-platform:
+             * Chipset chip-list (#805): the WF MakeCHIPLIST() flip/palette-bank
+               permutation grid. Canvas ChipCache.Width*4*2 (64px) wide x
+               ChipCache.Height tall IImage from
+               ImageBattleScreenCore.RenderChipsetPreview, in a GbaImageControl.
+               8 columns per tile row: orig/Hflip/Vflip/HVflip for palette bank 0,
+               then the same 4 for bank 1; palette index 0 opaque.
+             * Battle preview (#802): a 256x160 IImage composited from the 5
+               LZ77 image strips + RAW 16-bank palette + normalized TSA grid.
            =========================================================== -->
       <Border Grid.Row="1" BorderBrush="Gray" BorderThickness="1" Padding="4" Margin="0,0,0,4"
               MinHeight="80">
         <StackPanel Orientation="Horizontal" Spacing="6">
-          <TextBlock AutomationProperties.AutomationId="ImageBattleScreen_ChipsetPreview_Label"
-                     Name="ChipsetPreviewLabel"
-                     Text="Chipset Preview (deferred KnownGap): live LZ77 decode + flip permutations are WinForms-coupled (ImageUtil.BitBlt). Use the WinForms editor to paint TSA cells."
-                     TextWrapping="Wrap" Foreground="Gray" Width="280" VerticalAlignment="Center"
-                     ToolTip.Tip="KnownGap: chipset thumbnail rendering is WinForms-coupled (#393)." />
+          <!-- No ToolTip.Tip here: the BattlePreview (#802) carries none either,
+               and an English ToolTip literal would trip the L10n coverage gate.
+               The AutomationId + the comment above document the chip list. -->
+          <Border BorderBrush="DarkGray" BorderThickness="1" MinWidth="160" MinHeight="180"
+                  MaxHeight="360" Background="Black">
+            <controls:GbaImageControl AutomationProperties.AutomationId="ImageBattleScreen_ChipsetPreview_Image"
+                                      Name="ChipsetPreview" />
+          </Border>
           <Border BorderBrush="DarkGray" BorderThickness="1" MinWidth="280" MinHeight="180"
                   MaxHeight="360" Background="Black">
             <controls:GbaImageControl AutomationProperties.AutomationId="ImageBattleScreen_BattlePreview_Image"

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml.cs
@@ -179,6 +179,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.LoadEntry();
                 PopulateUI();
                 RefreshBattlePreview();
+                RefreshChipsetPreview();
             }
             catch (Exception ex)
             {
@@ -202,6 +203,27 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 Log.Error("ImageBattleScreenView.RefreshBattlePreview failed: {0}", ex.Message);
                 BattlePreview.SetImage(null);
+            }
+        }
+
+        /// <summary>
+        /// Render the chipset chip-list preview (#805) into the
+        /// <c>ChipsetPreview</c> GbaImageControl. Mirrors the WF
+        /// <c>MakeCHIPLIST()</c> flip/palette-bank permutation grid. Null-safe:
+        /// a corrupt/missing required source returns <c>null</c> from the Core
+        /// helper, which <c>SetImage(null)</c> turns into a blank surface
+        /// (no crash) -- same pattern as <see cref="RefreshBattlePreview"/>.
+        /// </summary>
+        void RefreshChipsetPreview()
+        {
+            try
+            {
+                ChipsetPreview.SetImage(_vm.RenderChipsetPreview());
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImageBattleScreenView.RefreshChipsetPreview failed: {0}", ex.Message);
+                ChipsetPreview.SetImage(null);
             }
         }
 
@@ -280,8 +302,11 @@ namespace FEBuilderGBA.Avalonia.Views
             }
 
             _undoService.Commit();
-            // Re-render the live preview from the freshly-written ROM (#802).
+            // Re-render BOTH live previews from the freshly-written ROM
+            // (#802 battle preview + #805 chipset chip list -- image pointer
+            // edits change the tileset the chip list renders).
             RefreshBattlePreview();
+            RefreshChipsetPreview();
         }
 
         void PaletteWrite_Click(object sender, RoutedEventArgs e)
@@ -319,8 +344,11 @@ namespace FEBuilderGBA.Avalonia.Views
             }
 
             _undoService.Commit();
-            // Palette edits change the rendered colors -- refresh preview (#802).
+            // Palette edits change the rendered colors in BOTH previews --
+            // refresh battle preview (#802) and chipset chip list (#805,
+            // both palette banks are shown in the chip-list columns).
             RefreshBattlePreview();
+            RefreshChipsetPreview();
         }
 
         void PaletteIndex_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -401,6 +429,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.LoadEntry();
                 PopulateUI();
                 RefreshBattlePreview();
+                RefreshChipsetPreview();
             }
             catch (Exception ex)
             {
@@ -416,6 +445,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.LoadEntry();
                 PopulateUI();
                 RefreshBattlePreview();
+                RefreshChipsetPreview();
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Core.Tests/ImageBattleScreenChipsetPreviewTests.cs
+++ b/FEBuilderGBA.Core.Tests/ImageBattleScreenChipsetPreviewTests.cs
@@ -1,0 +1,447 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for ImageBattleScreenCore.RenderChipsetPreview (#805, follow-up to #802):
+// the cross-platform chip-list render that mirrors the WinForms
+// ImageBattleScreenForm.MakeCHIPLIST() flip/palette-bank permutation grid.
+//
+// MakeCHIPLIST geometry (WF ImageBattleScreenForm.cs:187-227):
+//   * Canvas = ChipCache.Width * 4 * 2 (= 8*4*2 = 64) wide x ChipCache.Height tall,
+//     where ChipCache is the 8px-wide tile sheet (one 8x8 tile per 8px row).
+//   * For each tile row y, 8 adjacent 8px columns at x = 8*0 .. 8*7:
+//       col 0: original  (palette bank 0)    col 4: original  (palette bank 1)
+//       col 1: H-flip    (palette bank 0)    col 5: H-flip    (palette bank 1)
+//       col 2: V-flip    (palette bank 0)    col 6: V-flip    (palette bank 1)
+//       col 3: HV-flip   (palette bank 0)    col 7: HV-flip   (palette bank 1)
+//   * index 0 renders OPAQUE -- WF blits with transparent_index = 0xFF
+//     (never matches a 0..15 index), same as the battle-screen preview.
+//
+// Reuses the #802 synthetic-ROM harness (same StubImageService/StubImage as the
+// battle anime tests) so the rendered IImage carries real RGBA pixel data we can
+// assert on. The synthetic ROM plants image1..image5 each as exactly ONE 4bpp
+// tile, so the concatenated tileset is 5 tiles (tile indices 0..4):
+//   tile 0 (image1) = SolidTile(5)  -> green fill   (bank0 idx5 = 0x03E0)
+//   tile 1 (image2) = SolidTile(3)  -> red fill     (bank0 idx3 = 0x001F)
+//   tile 2 (image3) = CornerTile(5) -> green ONLY at src (0,0); else index 0
+//   tile 3 (image4) = SolidTile(0)  -> index-0 fill (bank0 idx0 = white 0x7FFF)
+//   tile 4 (image5) = SolidTile(5)  -> green fill
+// bank1 idx5 = blue (0x7C00).
+using System;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class ImageBattleScreenChipsetPreviewTests
+    {
+        // Storage offsets for the planted battle-screen sources (mirror #802 test).
+        const uint TSA1_OFFSET    = 0x100000;
+        const uint TSA2_OFFSET    = 0x101000;
+        const uint TSA3_OFFSET    = 0x102000;
+        const uint TSA4_OFFSET    = 0x103000;
+        const uint TSA5_OFFSET    = 0x104000;
+        const uint PALETTE_OFFSET = 0x105000;
+        const uint IMAGE1_OFFSET  = 0x110000;
+        const uint IMAGE2_OFFSET  = 0x111000;
+        const uint IMAGE3_OFFSET  = 0x112000;
+        const uint IMAGE4_OFFSET  = 0x113000;
+        const uint IMAGE5_OFFSET  = 0x114000;
+
+        // 5 image strips x 1 tile each -> 5 tiles in the concatenated sheet.
+        const int TILE_COUNT = 5;
+
+        // ----------------------------------------------------------------
+        // Dimensions -- Width*4*2 (= 64) x Height (= tileCount*8 = 40)
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void RenderChipsetPreview_ProducesExpectedDimensions()
+        {
+            using var _ = EnsureImageService();
+            var rom = MakeRom();
+
+            IImage img = ImageBattleScreenCore.RenderChipsetPreview(rom);
+            Assert.NotNull(img);
+            // ChipCache.Width=8 -> canvas width = 8*4*2 = 64.
+            Assert.Equal(8 * 4 * 2, img.Width);
+            // 5 tiles -> 5 * 8 = 40 px tall.
+            Assert.Equal(TILE_COUNT * 8, img.Height);
+        }
+
+        // ----------------------------------------------------------------
+        // Column order parity -- bank 0 {orig, Hflip, Vflip, HVflip}
+        // ----------------------------------------------------------------
+
+        // Use the asymmetric corner tile (tile 2 = image3) so each flip moves the
+        // single distinctive green pixel to a column-specific corner. Row y for
+        // tile 2 is tileY = 2*8 = 16.
+        [Fact]
+        public void RenderChipsetPreview_Bank0_OriginalColumn_HasCornerTopLeft()
+        {
+            using var _ = EnsureImageService();
+            var rom = MakeRom();
+
+            IImage img = ImageBattleScreenCore.RenderChipsetPreview(rom);
+            Assert.NotNull(img);
+
+            // col 0 (orig, bank 0): corner pixel src(0,0) stays at (0, 16). Green.
+            AssertPixel(img, 0, 16, 0, 248, 0, 255);
+        }
+
+        [Fact]
+        public void RenderChipsetPreview_Bank0_HFlipColumn_HasCornerTopRight()
+        {
+            using var _ = EnsureImageService();
+            var rom = MakeRom();
+
+            IImage img = ImageBattleScreenCore.RenderChipsetPreview(rom);
+            Assert.NotNull(img);
+
+            // col 1 (Hflip, bank 0) at x base 8: corner moves to x=8+7=15, y=16.
+            AssertPixel(img, 15, 16, 0, 248, 0, 255);
+            // And the un-flipped top-left of that column is now index 0 (blank).
+            // SolidTile? No -- CornerTile's other pixels are index 0 -> bank0 idx0
+            // is white & opaque. So just verify the green landed at the corner.
+        }
+
+        [Fact]
+        public void RenderChipsetPreview_Bank0_VFlipColumn_HasCornerBottomLeft()
+        {
+            using var _ = EnsureImageService();
+            var rom = MakeRom();
+
+            IImage img = ImageBattleScreenCore.RenderChipsetPreview(rom);
+            Assert.NotNull(img);
+
+            // col 2 (Vflip, bank 0) at x base 16: corner moves to x=16, y=16+7=23.
+            AssertPixel(img, 16, 23, 0, 248, 0, 255);
+        }
+
+        [Fact]
+        public void RenderChipsetPreview_Bank0_HVFlipColumn_HasCornerBottomRight()
+        {
+            using var _ = EnsureImageService();
+            var rom = MakeRom();
+
+            IImage img = ImageBattleScreenCore.RenderChipsetPreview(rom);
+            Assert.NotNull(img);
+
+            // col 3 (HVflip, bank 0) at x base 24: corner moves to x=24+7=31, y=23.
+            AssertPixel(img, 31, 23, 0, 248, 0, 255);
+        }
+
+        // ----------------------------------------------------------------
+        // Palette-bank selection -- columns 4..7 use bank 1
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void RenderChipsetPreview_Bank1_OriginalColumn_UsesBank1Palette()
+        {
+            using var _ = EnsureImageService();
+            var rom = MakeRom();
+
+            IImage img = ImageBattleScreenCore.RenderChipsetPreview(rom);
+            Assert.NotNull(img);
+
+            // col 4 (orig, bank 1) at x base 32. Tile 2 corner index 5 -> bank 1
+            // index 5 = blue (0x7C00). Corner stays top-left at (32, 16).
+            AssertPixel(img, 32, 16, 0, 0, 248, 255);
+        }
+
+        [Fact]
+        public void RenderChipsetPreview_Bank0VsBank1_SolidTile_DiffersByPalette()
+        {
+            using var _ = EnsureImageService();
+            var rom = MakeRom();
+
+            IImage img = ImageBattleScreenCore.RenderChipsetPreview(rom);
+            Assert.NotNull(img);
+
+            // Tile 0 (image1) = SolidTile(5). Row y = 0.
+            // col 0 (bank 0) -> green; col 4 (bank 1) -> blue. Same source tile,
+            // different palette bank, proving the bank selection works.
+            AssertPixel(img, 0, 0, 0, 248, 0, 255);    // bank0 idx5 green
+            AssertPixel(img, 32, 0, 0, 0, 248, 255);   // bank1 idx5 blue
+        }
+
+        // ----------------------------------------------------------------
+        // Distinct tile per row -- red (image2) sits on row 1
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void RenderChipsetPreview_SecondTileRow_RendersImage2Red()
+        {
+            using var _ = EnsureImageService();
+            var rom = MakeRom();
+
+            IImage img = ImageBattleScreenCore.RenderChipsetPreview(rom);
+            Assert.NotNull(img);
+
+            // Tile 1 (image2) = SolidTile(3) red, row y = 8. col 0 (orig, bank 0).
+            AssertPixel(img, 0, 8, 248, 0, 0, 255);
+            AssertPixel(img, 4, 8 + 4, 248, 0, 0, 255); // anywhere in the cell
+        }
+
+        // ----------------------------------------------------------------
+        // Alpha -- palette index 0 must be OPAQUE
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void RenderChipsetPreview_PaletteIndex0_RendersOpaque()
+        {
+            using var _ = EnsureImageService();
+            var rom = MakeRom();
+
+            IImage img = ImageBattleScreenCore.RenderChipsetPreview(rom);
+            Assert.NotNull(img);
+
+            // Tile 3 (image4) = SolidTile(0): index 0 fill. Row y = 24.
+            // bank0 idx0 = white (0x7FFF). Per WF MakeCHIPLIST transparent_index
+            // = 0xFF, so index 0 must render OPAQUE (alpha 255, not 0).
+            AssertPixel(img, 0, 24, 248, 248, 248, 255);
+            // Several pixels across the cell to confirm a full opaque fill.
+            AssertPixel(img, 7, 24 + 7, 248, 248, 248, 255);
+            AssertPixel(img, 3, 24 + 2, 248, 248, 248, 255);
+        }
+
+        // ----------------------------------------------------------------
+        // Null-safety
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void RenderChipsetPreview_NullRom_ReturnsNull()
+        {
+            using var _ = EnsureImageService();
+            Assert.Null(ImageBattleScreenCore.RenderChipsetPreview(null));
+        }
+
+        [Fact]
+        public void RenderChipsetPreview_CorruptImagePointer_ReturnsNull()
+        {
+            using var _ = EnsureImageService();
+            var rom = MakeRom();
+
+            // Point image3 at an out-of-bounds offset -> isSafetyOffset fails ->
+            // the shared loader fails -> render returns null (no crash).
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_image3_pointer, U.toPointer(0x1FFFFFF0));
+
+            Assert.Null(ImageBattleScreenCore.RenderChipsetPreview(rom));
+        }
+
+        [Fact]
+        public void RenderChipsetPreview_CorruptPalettePointer_ReturnsNull()
+        {
+            using var _ = EnsureImageService();
+            var rom = MakeRom();
+
+            // Palette pointer out of bounds -> loader fails -> null.
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_palette_pointer, U.toPointer(0x1FFFFFF0));
+
+            Assert.Null(ImageBattleScreenCore.RenderChipsetPreview(rom));
+        }
+
+        [Fact]
+        public void RenderChipsetPreview_TruncatedImageStream_ReturnsNull()
+        {
+            using var _ = EnsureImageService();
+            var rom = MakeRom();
+
+            // Plant a TRUNCATED LZ77 stream for image3 at the end of ROM: a valid
+            // header (0x10 + a 0x1000-byte advertised size) but only a few bytes
+            // before Data.Length. The shared loader's getCompressedSize guard
+            // returns 0 -> render returns null (matching the #802 contract).
+            uint imageAddr = (uint)rom.Data.Length - 8;
+            rom.Data[imageAddr + 0] = 0x10;
+            rom.Data[imageAddr + 1] = 0x00;
+            rom.Data[imageAddr + 2] = 0x10;
+            rom.Data[imageAddr + 3] = 0x00;
+            rom.Data[imageAddr + 4] = 0x00; // control: next 8 blocks are literals
+            rom.Data[imageAddr + 5] = 0xAA;
+            rom.Data[imageAddr + 6] = 0xBB;
+            rom.Data[imageAddr + 7] = 0xCC;
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_image3_pointer, U.toPointer(imageAddr));
+
+            // Sanity: confirm the truncation is real at the LZ77 level.
+            Assert.Equal(0u, LZ77.getCompressedSize(rom.Data, imageAddr));
+
+            Assert.Null(ImageBattleScreenCore.RenderChipsetPreview(rom));
+        }
+
+        [Fact]
+        public void RenderChipsetPreview_NoImageService_ReturnsNull()
+        {
+            // No ImageService scope -> RenderChipsetPreview must return null.
+            var prev = CoreState.ImageService;
+            CoreState.ImageService = null;
+            try
+            {
+                var rom = MakeRom();
+                Assert.Null(ImageBattleScreenCore.RenderChipsetPreview(rom));
+            }
+            finally { CoreState.ImageService = prev; }
+        }
+
+        // ----------------------------------------------------------------
+        // #802 regression -- the battle preview must stay green after the
+        // shared-loader extraction (behavior-preserving refactor).
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void RenderBattleScreenPreview_StillRendersAfterLoaderExtraction()
+        {
+            using var _ = EnsureImageService();
+            var rom = MakeRom();
+
+            // tile 0 (image1) green at cell (y=0, x=1) -> pixel (8, 0). This is the
+            // same assertion as ImageBattleScreenPreviewTests
+            // RenderBattleScreenPreview_TileFromImage1_RendersExpectedColor, kept
+            // here to prove TryLoadChipsetAndPalette is behavior-preserving.
+            ushort[] map = new ushort[ImageBattleScreenCore.MAP_SIZE];
+            map[0 * ImageBattleScreenCore.MAP_X + 1] = MakeCell(tile: 0, flip: 0, pal: 0);
+            PlantMap(rom, map);
+
+            IImage img = ImageBattleScreenCore.RenderBattleScreenPreview(rom);
+            Assert.NotNull(img);
+            Assert.Equal(256, img.Width);
+            Assert.Equal(160, img.Height);
+            AssertPixel(img, 8, 0, 0, 248, 0, 255); // bank0 idx5 green, opaque
+        }
+
+        // ----------------------------------------------------------------
+        // Helpers (mirror ImageBattleScreenPreviewTests)
+        // ----------------------------------------------------------------
+
+        static System.IDisposable EnsureImageService() => new ImageServiceScope();
+
+        sealed class ImageServiceScope : System.IDisposable
+        {
+            readonly IImageService _prev;
+            public ImageServiceScope()
+            {
+                _prev = CoreState.ImageService;
+                CoreState.ImageService = new StubImageService();
+            }
+            public void Dispose() { CoreState.ImageService = _prev; }
+        }
+
+        static ushort MakeCell(uint tile, uint flip, uint pal)
+        {
+            return (ushort)((tile & 0xff) | ((flip & 0x0f) << 8) | ((pal & 0x0f) << 12));
+        }
+
+        static void AssertPixel(IImage img, int x, int y, int r, int g, int b, int a)
+        {
+            byte[] px = img.GetPixelData();
+            int idx = (y * img.Width + x) * 4;
+            Assert.True(idx + 3 < px.Length, $"pixel ({x},{y}) out of range");
+            Assert.Equal((byte)r, px[idx + 0]);
+            Assert.Equal((byte)g, px[idx + 1]);
+            Assert.Equal((byte)b, px[idx + 2]);
+            Assert.Equal((byte)a, px[idx + 3]);
+        }
+
+        static ROM MakeRom()
+        {
+            var rom = new ROM();
+            byte[] data = new byte[0x2000000];
+            System.Array.Fill(data, (byte)0xFF);
+            rom.LoadLow("synth.gba", data, "BE8E01");
+
+            // TSA pointer slots -> our TSA storage offsets, regions zero-filled.
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_TSA1_pointer, U.toPointer(TSA1_OFFSET));
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_TSA2_pointer, U.toPointer(TSA2_OFFSET));
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_TSA3_pointer, U.toPointer(TSA3_OFFSET));
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_TSA4_pointer, U.toPointer(TSA4_OFFSET));
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_TSA5_pointer, U.toPointer(TSA5_OFFSET));
+            for (uint i = 0; i < 0x1000; i++)
+            {
+                rom.Data[TSA1_OFFSET + i] = 0;
+                rom.Data[TSA2_OFFSET + i] = 0;
+                rom.Data[TSA3_OFFSET + i] = 0;
+                rom.Data[TSA4_OFFSET + i] = 0;
+                rom.Data[TSA5_OFFSET + i] = 0;
+            }
+
+            // ---- Palette: 16 banks x 16 colors x 2 bytes = 512 bytes ----
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_palette_pointer, U.toPointer(PALETTE_OFFSET));
+            for (uint i = 0; i < 512; i++) rom.Data[PALETTE_OFFSET + i] = 0;
+            // bank 0 index 0 = white (0x7FFF), index 3 = red (0x001F),
+            //         index 5 = green (0x03E0).
+            U.write_u16(rom.Data, PALETTE_OFFSET + (0 * 16 + 0) * 2, 0x7FFF);
+            U.write_u16(rom.Data, PALETTE_OFFSET + (0 * 16 + 3) * 2, 0x001F);
+            U.write_u16(rom.Data, PALETTE_OFFSET + (0 * 16 + 5) * 2, 0x03E0);
+            // bank 1 index 5 = blue (0x7C00).
+            U.write_u16(rom.Data, PALETTE_OFFSET + (1 * 16 + 5) * 2, 0x7C00);
+
+            // ---- image1..5: each exactly ONE 4bpp tile (32 bytes) ----
+            //   image1 -> tile 0 (color index 5 fill, green)
+            //   image2 -> tile 1 (color index 3 fill, red)
+            //   image3 -> tile 2 (corner-only color index 5 at src (0,0))
+            //   image4 -> tile 3 (color index 0 fill, white/opaque test)
+            //   image5 -> tile 4 (color index 5 fill, green)
+            PlantImageStrip(rom, rom.RomInfo.battle_screen_image1_pointer, IMAGE1_OFFSET, SolidTile(5));
+            PlantImageStrip(rom, rom.RomInfo.battle_screen_image2_pointer, IMAGE2_OFFSET, SolidTile(3));
+            PlantImageStrip(rom, rom.RomInfo.battle_screen_image3_pointer, IMAGE3_OFFSET, CornerTile(5));
+            PlantImageStrip(rom, rom.RomInfo.battle_screen_image4_pointer, IMAGE4_OFFSET, SolidTile(0));
+            PlantImageStrip(rom, rom.RomInfo.battle_screen_image5_pointer, IMAGE5_OFFSET, SolidTile(5));
+
+            return rom;
+        }
+
+        static void PlantImageStrip(ROM rom, uint slot, uint offset, byte[] rawTile)
+        {
+            byte[] comp = LZ77.compress(rawTile);
+            Array.Copy(comp, 0, rom.Data, offset, comp.Length);
+            U.write_u32(rom.Data, slot, U.toPointer(offset));
+        }
+
+        static byte[] SolidTile(int index)
+        {
+            byte packed = (byte)(((index & 0x0f) << 4) | (index & 0x0f));
+            byte[] tile = new byte[32];
+            for (int i = 0; i < 32; i++) tile[i] = packed;
+            return tile;
+        }
+
+        static byte[] CornerTile(int index)
+        {
+            byte[] tile = new byte[32];
+            // src (0,0): row 0, byte 0, low nibble (even x => low nibble).
+            tile[0] = (byte)(index & 0x0f);
+            return tile;
+        }
+
+        static void PlantMap(ROM rom, ushort[] map)
+        {
+            uint addr;
+            int MAP_X = ImageBattleScreenCore.MAP_X;
+
+            addr = rom.p32(rom.RomInfo.battle_screen_TSA1_pointer);
+            for (int y = 0; y <= 5; y++)
+                for (int x = 1; x <= 15; x++)
+                { U.write_u16(rom.Data, addr, map[y * MAP_X + x]); addr += 2; }
+
+            addr = rom.p32(rom.RomInfo.battle_screen_TSA2_pointer);
+            for (int y = 0; y <= 5; y++)
+                for (int x = 16; x <= 30; x++)
+                { U.write_u16(rom.Data, addr, map[y * MAP_X + x]); addr += 2; }
+
+            addr = rom.p32(rom.RomInfo.battle_screen_TSA3_pointer);
+            for (int y = 13; y <= 19; y++)
+                for (int x = 1; x <= 15; x++)
+                { U.write_u16(rom.Data, addr, map[y * MAP_X + x]); addr += 2; }
+
+            addr = rom.p32(rom.RomInfo.battle_screen_TSA4_pointer);
+            for (int y = 13; y <= 19; y++)
+                for (int x = 16; x <= 31; x++)
+                { U.write_u16(rom.Data, addr, map[y * MAP_X + x]); addr += 2; }
+
+            addr = rom.p32(rom.RomInfo.battle_screen_TSA5_pointer);
+            for (int y = 0; y <= 19; y++)
+                for (int x = 31; x <= 32; x++)
+                {
+                    int xx = x == 32 ? 0 : x;
+                    U.write_u16(rom.Data, addr, map[y * MAP_X + xx]); addr += 2;
+                }
+        }
+    }
+}

--- a/FEBuilderGBA.Core/ImageBattleScreenCore.cs
+++ b/FEBuilderGBA.Core/ImageBattleScreenCore.cs
@@ -210,62 +210,13 @@ namespace FEBuilderGBA
             ushort[] map = LoadBattleScreen(rom);
             if (map == null) return null;
 
-            // --- Blocker 1: RAW 16-bank palette (512 bytes, NO LZ77) ---
-            uint palAddr = rom.p32(rom.RomInfo.battle_screen_palette_pointer);
-            if (!U.isSafetyOffset(palAddr, rom)) return null;
-            ulong palLast = (ulong)palAddr + (ulong)BATTLE_SCREEN_PALETTE_BYTES - 1UL;
-            if (palLast >= (ulong)rom.Data.Length) return null;
-            byte[] gbaPalette = new byte[BATTLE_SCREEN_PALETTE_BYTES];
-            Array.Copy(rom.Data, palAddr, gbaPalette, 0, BATTLE_SCREEN_PALETTE_BYTES);
-
-            // --- Blocker 2: LZ77 image1..image5 concatenated vertically ---
-            uint[] imagePointerSlots = new uint[]
-            {
-                rom.RomInfo.battle_screen_image1_pointer,
-                rom.RomInfo.battle_screen_image2_pointer,
-                rom.RomInfo.battle_screen_image3_pointer,
-                rom.RomInfo.battle_screen_image4_pointer,
-                rom.RomInfo.battle_screen_image5_pointer,
-            };
-
-            int totalLength = 0;
-            byte[][] chunks = new byte[imagePointerSlots.Length][];
-            for (int i = 0; i < imagePointerSlots.Length; i++)
-            {
-                uint imageAddr = rom.p32(imagePointerSlots[i]);
-                // Each image1..5 is REQUIRED (WF blits all five): a bad pointer
-                // or LZ77 failure must fail the whole render, not skip a chunk.
-                if (!U.isSafetyOffset(imageAddr, rom)) return null;
-
-                // Validate the compressed stream BEFORE decompressing.
-                // LZ77.decompress does NOT distinguish a truncated stream: when
-                // the input ends early it breaks out and returns a ZERO-FILLED
-                // buffer of the advertised (header) size, which would silently
-                // render as a blank-but-plausible chunk and violate the
-                // "any corrupt REQUIRED source fails the whole render" contract
-                // (#802 PR #804 review fix). LZ77.getCompressedSize returns the
-                // ACTUAL consumed compressed length only when the full stream
-                // decodes within the ROM bounds, and 0 on any corruption /
-                // truncation / bad header. A defensive end-of-ROM bound check
-                // on (imageAddr + compressedSize) additionally guards an overrun.
-                uint compressedSize = LZ77.getCompressedSize(rom.Data, imageAddr);
-                if (compressedSize == 0) return null;
-                if ((ulong)imageAddr + (ulong)compressedSize > (ulong)rom.Data.Length) return null;
-
-                byte[] chunk = LZ77.decompress(rom.Data, imageAddr);
-                if (chunk == null || chunk.Length == 0) return null;
-                chunks[i] = chunk;
-                totalLength += chunk.Length;
-            }
-            if (totalLength == 0) return null;
-
-            byte[] tileData = new byte[totalLength];
-            int writePos = 0;
-            for (int i = 0; i < chunks.Length; i++)
-            {
-                Array.Copy(chunks[i], 0, tileData, writePos, chunks[i].Length);
-                writePos += chunks[i].Length;
-            }
+            // --- Blocker 1 + 2: RAW 16-bank palette + concatenated tileset ---
+            // Extracted into the shared TryLoadChipsetAndPalette helper (#805)
+            // so the chipset preview can reuse the EXACT same load path. A null
+            // return (any corrupt/missing REQUIRED source) fails the whole
+            // render -- no partial-render of a corrupt ROM.
+            if (!TryLoadChipsetAndPalette(rom, out byte[] tileData, out byte[] gbaPalette))
+                return null;
 
             // --- Blocker 3 (cont.): normalize RAW WF cells -> GBA-standard TSA ---
             // WF MakeBattleScreen: tile = m & 0xff, flip = (m >> 8) & 0x0f,
@@ -299,6 +250,176 @@ namespace FEBuilderGBA
                 tileData, tsaData, gbaPalette,
                 BATTLE_SCREEN_WIDTH_TILES, BATTLE_SCREEN_HEIGHT_TILES,
                 is4bpp: true, tsaOffset: 0, opaqueIndex0: true);
+        }
+
+        /// <summary>
+        /// Shared loader (#805) for the battle-screen tileset + palette. Pulled
+        /// verbatim out of <see cref="RenderBattleScreenPreview"/> (#802) so the
+        /// chipset preview (<see cref="RenderChipsetPreview"/>) reuses the EXACT
+        /// same load path: behavior is preserved, not re-implemented.
+        ///
+        /// Outputs on success:
+        ///   * <paramref name="tileData"/> -- image1..image5 LZ77-decompressed
+        ///     (each 8px wide), concatenated vertically in order into one
+        ///     4bpp tileset.
+        ///   * <paramref name="palette"/> -- the RAW 16-bank GBA palette
+        ///     (512 bytes) read directly at <c>battle_screen_palette_pointer</c>
+        ///     (NOT LZ77 -- WF passes the palette offset straight to
+        ///     ByteToImage16Tile).
+        ///
+        /// Returns <c>false</c> (and null outputs) if ANY of the five REQUIRED
+        /// image strips or the palette is missing / out-of-bounds / corrupt /
+        /// truncated. Each LZ77 stream is validated with
+        /// <c>LZ77.getCompressedSize</c> BEFORE decompressing: a truncated but
+        /// header-valid chunk (which <c>LZ77.decompress</c> would otherwise
+        /// return as a zero-filled buffer) fails the whole load instead of
+        /// silently yielding a blank chunk (#802 PR #804 review contract).
+        /// </summary>
+        static bool TryLoadChipsetAndPalette(ROM rom, out byte[] tileData, out byte[] palette)
+        {
+            tileData = null;
+            palette = null;
+            if (rom == null || rom.RomInfo == null || rom.Data == null) return false;
+
+            // --- Blocker 1: RAW 16-bank palette (512 bytes, NO LZ77) ---
+            uint palAddr = rom.p32(rom.RomInfo.battle_screen_palette_pointer);
+            if (!U.isSafetyOffset(palAddr, rom)) return false;
+            ulong palLast = (ulong)palAddr + (ulong)BATTLE_SCREEN_PALETTE_BYTES - 1UL;
+            if (palLast >= (ulong)rom.Data.Length) return false;
+            byte[] gbaPalette = new byte[BATTLE_SCREEN_PALETTE_BYTES];
+            Array.Copy(rom.Data, palAddr, gbaPalette, 0, BATTLE_SCREEN_PALETTE_BYTES);
+
+            // --- Blocker 2: LZ77 image1..image5 concatenated vertically ---
+            uint[] imagePointerSlots = new uint[]
+            {
+                rom.RomInfo.battle_screen_image1_pointer,
+                rom.RomInfo.battle_screen_image2_pointer,
+                rom.RomInfo.battle_screen_image3_pointer,
+                rom.RomInfo.battle_screen_image4_pointer,
+                rom.RomInfo.battle_screen_image5_pointer,
+            };
+
+            int totalLength = 0;
+            byte[][] chunks = new byte[imagePointerSlots.Length][];
+            for (int i = 0; i < imagePointerSlots.Length; i++)
+            {
+                uint imageAddr = rom.p32(imagePointerSlots[i]);
+                // Each image1..5 is REQUIRED (WF blits all five): a bad pointer
+                // or LZ77 failure must fail the whole render, not skip a chunk.
+                if (!U.isSafetyOffset(imageAddr, rom)) return false;
+
+                // Validate the compressed stream BEFORE decompressing.
+                // LZ77.decompress does NOT distinguish a truncated stream: when
+                // the input ends early it breaks out and returns a ZERO-FILLED
+                // buffer of the advertised (header) size, which would silently
+                // render as a blank-but-plausible chunk and violate the
+                // "any corrupt REQUIRED source fails the whole render" contract
+                // (#802 PR #804 review fix). LZ77.getCompressedSize returns the
+                // ACTUAL consumed compressed length only when the full stream
+                // decodes within the ROM bounds, and 0 on any corruption /
+                // truncation / bad header. A defensive end-of-ROM bound check
+                // on (imageAddr + compressedSize) additionally guards an overrun.
+                uint compressedSize = LZ77.getCompressedSize(rom.Data, imageAddr);
+                if (compressedSize == 0) return false;
+                if ((ulong)imageAddr + (ulong)compressedSize > (ulong)rom.Data.Length) return false;
+
+                byte[] chunk = LZ77.decompress(rom.Data, imageAddr);
+                if (chunk == null || chunk.Length == 0) return false;
+                chunks[i] = chunk;
+                totalLength += chunk.Length;
+            }
+            if (totalLength == 0) return false;
+
+            byte[] tiles = new byte[totalLength];
+            int writePos = 0;
+            for (int i = 0; i < chunks.Length; i++)
+            {
+                Array.Copy(chunks[i], 0, tiles, writePos, chunks[i].Length);
+                writePos += chunks[i].Length;
+            }
+
+            tileData = tiles;
+            palette = gbaPalette;
+            return true;
+        }
+
+        /// <summary>
+        /// Render the WinForms <c>ImageBattleScreenForm.MakeCHIPLIST()</c> chip
+        /// list cross-platform (#805, follow-up to #802). The chip list shows
+        /// every 8x8 tile of the concatenated battle-screen tileset in 8
+        /// adjacent columns of flip/palette-bank permutations -- the reference
+        /// grid the WF editor draws above the TSA paint area.
+        ///
+        /// Mirrors WF MakeCHIPLIST EXACTLY:
+        ///   * Canvas = <c>ChipCache.Width * 4 * 2</c> wide x
+        ///     <c>ChipCache.Height</c> tall, where <c>ChipCache</c> is the 8px
+        ///     wide tile sheet (one tile per 8px row). So width = 8*4*2 = 64,
+        ///     height = (tile count) * 8.
+        ///   * For each tile row y, 8 columns at x = 8*0 .. 8*7:
+        ///       col 0: original  (bank 0)   col 4: original  (bank 1)
+        ///       col 1: H-flip    (bank 0)   col 5: H-flip    (bank 1)
+        ///       col 2: V-flip    (bank 0)   col 6: V-flip    (bank 1)
+        ///       col 3: HV-flip   (bank 0)   col 7: HV-flip   (bank 1)
+        ///   * index 0 renders OPAQUE -- WF MakeCHIPLIST blits with
+        ///     <c>transparent_index = 0xFF</c> (never matches a 0..15 index),
+        ///     same as the battle-screen preview (#802 Blocker 4).
+        ///
+        /// Returns <c>null</c> (no crash) if <see cref="TryLoadChipsetAndPalette"/>
+        /// fails (missing/corrupt required source) or no ImageService is set.
+        /// Deterministic; no <c>Program.*</c> / System.Drawing dependency.
+        /// </summary>
+        public static IImage RenderChipsetPreview(ROM rom)
+        {
+            if (rom == null || rom.RomInfo == null || rom.Data == null) return null;
+            if (CoreState.ImageService == null) return null;
+
+            if (!TryLoadChipsetAndPalette(rom, out byte[] tileData, out byte[] gbaPalette))
+                return null;
+
+            // ChipCache (WF) is an 8px-wide tile sheet: one 8x8 tile per 8px
+            // row. tile count = tileData.Length / 32 (4bpp = 32 bytes/tile).
+            const int bytesPerTile = 32;
+            int tileCount = tileData.Length / bytesPerTile;
+            if (tileCount <= 0) return null;
+
+            // ChipCache.Width = 8, ChipCache.Height = tileCount * 8.
+            // Chip-list canvas = ChipCache.Width * 4 * 2 (= 64) x ChipCache.Height.
+            int width = 8 * 4 * 2;        // 8 columns of 8px
+            int height = tileCount * 8;
+
+            var image = CoreState.ImageService.CreateImage(width, height);
+            byte[] pixels = new byte[width * height * 4]; // RGBA
+
+            // Column layout: {orig, Hflip, Vflip, HVflip} for bank 0, then the
+            // same 4 for bank 1 -- exactly WF MakeCHIPLIST's blit order.
+            // (hFlip, vFlip, palBank)
+            (bool h, bool v, int bank)[] columns =
+            {
+                (false, false, 0), // col 0
+                (true,  false, 0), // col 1
+                (false, true,  0), // col 2
+                (true,  true,  0), // col 3
+                (false, false, 1), // col 4
+                (true,  false, 1), // col 5
+                (false, true,  1), // col 6
+                (true,  true,  1), // col 7
+            };
+
+            for (int tile = 0; tile < tileCount; tile++)
+            {
+                int tileY = tile * 8;
+                for (int col = 0; col < columns.Length; col++)
+                {
+                    var (h, v, bank) = columns[col];
+                    ImageUtilCore.DecodeTileToPixels(
+                        tileData, tile, gbaPalette, bank,
+                        pixels, width, col * 8, tileY,
+                        h, v, is4bpp: true, opaqueIndex0: true);
+                }
+            }
+
+            image.SetPixelData(pixels);
+            return image;
         }
 
         /// <summary>

--- a/FEBuilderGBA.Core/ImageUtilCore.cs
+++ b/FEBuilderGBA.Core/ImageUtilCore.cs
@@ -377,7 +377,11 @@ namespace FEBuilderGBA
             return bestIndex;
         }
 
-        static void DecodeTileToPixels(byte[] tileData, int tileIndex, byte[] gbaPalette, int palIndex,
+        // internal (not private) so cross-platform editor helpers in the same
+        // assembly -- e.g. ImageBattleScreenCore.RenderChipsetPreview (#805) --
+        // can render a single tile with explicit flip + palette-bank +
+        // opaque-index-0 control WITHOUT duplicating the 4bpp/8bpp decode loop.
+        internal static void DecodeTileToPixels(byte[] tileData, int tileIndex, byte[] gbaPalette, int palIndex,
             byte[] pixels, int imageWidth, int tileX, int tileY, bool hFlip, bool vFlip, bool is4bpp,
             bool opaqueIndex0 = false)
         {


### PR DESCRIPTION
## Summary

Follow-up to #802. Renders the WinForms `ImageBattleScreenForm.MakeCHIPLIST()` **chipset chip list** cross-platform in the Avalonia **ImageBattleScreen** editor, replacing the last deferred placeholder label so **both** previews are now live: the battle-screen preview (#802) on the right and the chipset chip list (#805) in the narrow left column.

The chip list shows every 8×8 tile of the concatenated battle-screen tileset in the 8-column flip/palette-bank permutation grid the WF editor draws above the TSA paint area — deterministically, with no `Program.*` / `System.Drawing` coupling.

### Core (`FEBuilderGBA.Core`)
- **Shared loader (pure refactor):** extracted the tile/palette load block out of `RenderBattleScreenPreview` (#802) into a private helper `TryLoadChipsetAndPalette(rom, out tileData, out palette)`. Preserves EXACTLY the RAW 512-byte palette read (no LZ77), all five `image1..5` REQUIRED + concatenated vertically, the `isSafetyOffset` + end-span checks, and the `LZ77.getCompressedSize==0` (+ `addr+cs > Data.Length`) truncation guard BEFORE each decompress. `RenderBattleScreenPreview` now calls it — no behavior change.
- **`public static IImage RenderChipsetPreview(ROM)`:** composes a `ChipCache.Width*4*2` (= 64) × `ChipCache.Height` (= `tileCount*8`) image. Per tile row, renders 8 variant columns mirroring `MakeCHIPLIST` exactly: bank0 `{orig, HFlip, VFlip, HVFlip}` then bank1 `{same 4}`, each via `DecodeTileToPixels(..., hFlip, vFlip, palBank, opaqueIndex0: true)` so palette index 0 is OPAQUE (matches WF `transparent_index = 0xFF`). Null-safe.
- **`DecodeTileToPixels` visibility:** promoted from `private` to `internal` so the chipset render reuses the exact 4bpp decode loop instead of duplicating it (`FEBuilderGBA.Core.Tests` already sees internals via `InternalsVisibleTo`).

### Avalonia (`FEBuilderGBA.Avalonia`)
- Replaced the `ChipsetPreviewLabel` placeholder with a `GbaImageControl` named `ChipsetPreview` (mirrors #802's `BattlePreview`), new `_Image` AutomationId.
- VM: `IImage RenderChipsetPreview() => ImageBattleScreenCore.RenderChipsetPreview(CoreState.ROM)`.
- Code-behind `RefreshChipsetPreview()`: `ChipsetPreview.SetImage(...)` on entry load and after every successful write / undo, null-safe (same pattern as `RefreshBattlePreview`). Updated the KnownGap comment (both previews now live).

### WinForms
- `MakeCHIPLIST` left as-is.

## Closes / Ref
- Closes #805
- Follow-up to #802
- Ref #769, #393

## GUI Test Report

PrintWindow capture of the **ImageBattleScreen** editor (Avalonia), `roms/FE8U.gba`, first entry selected.

| # | Test | Result |
|---|------|--------|
| 1 | App launches with FE8U.gba; ImageBattleScreen editor opens | PASS |
| 2 | Selecting a battle-screen entry renders the **chipset chip list** in the left `GbaImageControl` (tiles visible, distinct colors/flips) | PASS |
| 3 | The battle-screen preview (#802) still renders beside it on the right | PASS |
| 4 | Chip list shows the 8-column flip/palette-bank permutation grid (`Width*4*2` wide) | PASS |
| 5 | No crash / no blank surface; TSA1 + palette addresses populate | PASS |

![chipset preview](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr805-chipset-preview.png)

> Screenshot committed to `pr-screenshots/` on `master` via docs PR #806 (stable raw URL; renders once that PR merges).

## Test plan
- [x] `dotnet build` Core, SkiaSharp, Avalonia, CLI, WinForms — 0 errors
- [x] New `ImageBattleScreenChipsetPreviewTests` (Core.Tests): expected 64×40 dims
- [x] Planted corner tile — orig / HFlip / VFlip / HVFlip columns land the distinctive pixel in the correct corner
- [x] bank0 vs bank1 columns select the correct palette colors (green vs blue on the same source tile)
- [x] Index-0 pixel renders OPAQUE (alpha 255)
- [x] Null-safety: null rom / corrupt image pointer / corrupt palette pointer / truncated LZ77 stream / no ImageService → null, no crash
- [x] #802 regression: `RenderBattleScreenPreview` + `ImageBattleScreenPreviewTests` stay green (proves the loader extraction is behavior-preserving) — ran explicitly
- [x] Parity test updated: `View_HasChipsetPreviewKnownGapPlaceholder` → `View_HasLiveChipsetPreviewImage` (asserts live control + SetImage wiring)
- [x] `dotnet test FEBuilderGBA.Core.Tests` — 2116 pass
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` — 7190 pass (3 pre-existing skips)
- [x] `pwsh -File scripts/validate-automation-ids.ps1` — exit 0
- [x] L10n coverage test — green (no untranslated literal added)
- [x] Functional GUI capture against `roms/FE8U.gba` — chipset chip list rendered (see GUI Test Report)

Generated with Claude Code v2.1.156 (model: claude-opus-4-8, Opus 4.8 1M context)