### PR TITLE
feat(avalonia): render TSA-composited main image + read-only Export PNG in TSA editor (closes #808)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageTSAEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageTSAEditorParityTests.cs
@@ -230,6 +230,27 @@ public class ImageTSAEditorParityTests
         Assert.Contains("IsEnabled=\"False\"", m.Value);
     }
 
+    /// <summary>
+    /// #808: the read-only Battle "Export PNG" button must use a DISTINCT
+    /// AutomationId (not the inert MainImage Export button), be wired to a
+    /// Click handler, and gate IsEnabled on CanExportBattle (a successful
+    /// render) — NOT IsContextLoaded. Mirrors View_WriteButton_IsContextGated.
+    /// </summary>
+    [Fact]
+    public void View_ExportPngButton_IsRenderGated()
+    {
+        string axaml = ReadAxaml();
+        var rx = new Regex(
+            "AutomationId=\"ImageTSAEditor_Battle_ExportPng_Button\"[\\s\\S]*?/>",
+            RegexOptions.Compiled);
+        Match m = rx.Match(axaml);
+        Assert.True(m.Success, "Battle Export PNG button tag not found");
+        Assert.Contains("Click=\"BattleExportPng_Click\"", m.Value);
+        Assert.Contains("IsEnabled=\"{Binding CanExportBattle}\"", m.Value);
+        // Must be a different id than the inert MainImage Export button.
+        Assert.DoesNotContain("ImageTSAEditor_MainImage_Export_Button", m.Value);
+    }
+
     // -----------------------------------------------------------------
     // Roslyn-lite checks — Write / PaletteWrite handlers use UndoService.
     // -----------------------------------------------------------------
@@ -422,10 +443,10 @@ public class ImageTSAEditorParityTests
         var rx = new Regex(@"KnownGap:\s*(\S+(?:\s+\S+)*?)\s+reason=(.+?)\s*-->",
             RegexOptions.Compiled);
         var matches = rx.Matches(axaml);
-        Assert.True(matches.Count >= 5,
-            $"AXAML must contain at least 5 KnownGap markers (BattleCanvasRender, " +
-            $"ChipsetListRender, TSAByteWrite, PaletteToClipboard, MainImageImportExport); " +
-            $"found {matches.Count}.");
+        Assert.True(matches.Count >= 4,
+            $"AXAML must contain at least 4 KnownGap markers (ChipsetListRender, " +
+            $"TSAByteWrite, PaletteToClipboard, MainImageImportExport); " +
+            $"found {matches.Count}. (BattleCanvasRender was resolved in #808.)");
         foreach (Match m in matches)
         {
             Assert.False(string.IsNullOrWhiteSpace(m.Groups[1].Value),
@@ -462,6 +483,34 @@ public class ImageTSAEditorParityTests
         Assert.False(vm.IsHeaderTSA);
         Assert.True(vm.IsLZ77TSA);
         Assert.Equal(1, vm.PaletteCount);
+    }
+
+    /// <summary>
+    /// #808 review #4: RenderMainImage must return null (no throw) when the
+    /// image or TSA pointer slots are NOT_FOUND, even with a loaded context.
+    /// A NOT_FOUND palette pointer is the EXPECTED raw-address fallback and
+    /// must NOT by itself fail the render.
+    /// </summary>
+    [Fact]
+    public void ViewModel_RenderMainImage_AllNotFoundPointers_ReturnsNull()
+    {
+        var vm = new ImageTSAEditorViewModel();
+        // No context yet -> null.
+        Assert.Null(vm.RenderMainImage());
+
+        vm.Init(
+            width8: 32u,
+            height8: 20u,
+            zimgPointer: U.NOT_FOUND,
+            isHeaderTSA: false,
+            isLZ77TSA: true,
+            tsaPointer: U.NOT_FOUND,
+            palettePointer: U.NOT_FOUND,
+            paletteAddress: 0u,
+            paletteCount: 1);
+
+        // Image / TSA slots are NOT_FOUND -> render is skipped without throwing.
+        Assert.Null(vm.RenderMainImage());
     }
 
     [Fact]

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageTSAEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageTSAEditorViewModel.cs
@@ -60,6 +60,15 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// </summary>
         public bool IsContextLoaded { get => _isContextLoaded; set => SetField(ref _isContextLoaded, value); }
 
+        bool _canExportBattle;
+        /// <summary>
+        /// True only when the TSA-composited main image rendered successfully
+        /// (set by the View's RefreshBattleCanvas). The Export PNG button binds
+        /// IsEnabled to this -- a loaded context whose render failed must stay
+        /// disabled, so this is intentionally NOT just <see cref="IsContextLoaded"/>.
+        /// </summary>
+        public bool CanExportBattle { get => _canExportBattle; set => SetField(ref _canExportBattle, value); }
+
         // Caller-context, read by the view's Write_Click / PaletteWrite_Click
         // handlers and the static unit tests. Settable via Init only.
 
@@ -145,6 +154,40 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 return U.toOffset(_paletteAddress);
             }
             return rom.p32(_palettePointer);
+        }
+
+        /// <summary>
+        /// Render the TSA-composited main image (read-only) for the
+        /// <c>BattlePreview</c> control and PNG export (#808). Resolves the
+        /// pointer slots to data addresses exactly like WinForms
+        /// ImageTSAEditorForm, then delegates to
+        /// <see cref="ImageTSAEditorCore.TryRenderMainImage"/>.
+        ///
+        /// Returns null (no throw) when there is no context, when the image or
+        /// TSA pointer slots are unset (U.NOT_FOUND), or when the underlying
+        /// render fails. A NOT_FOUND palette pointer is NOT a failure -- it is
+        /// the expected raw-address fallback handled by
+        /// <see cref="ResolveActivePaletteAddress"/>.
+        /// </summary>
+        public IImage RenderMainImage()
+        {
+            if (!IsContextLoaded) return null;
+
+            // The image and TSA pointer slots must be real before we follow
+            // them with p32; only the palette pointer has a raw-address fallback.
+            if (_zimgPointer == U.NOT_FOUND) return null;
+            if (_tsaPointer == U.NOT_FOUND) return null;
+
+            ROM rom = CoreState.ROM;
+            if (rom == null) return null;
+
+            uint imageAddr = rom.p32(_zimgPointer);
+            uint tsaAddr = rom.p32(_tsaPointer);
+            uint paletteAddr = ResolveActivePaletteAddress();
+
+            return ImageTSAEditorCore.TryRenderMainImage(
+                rom, _width8, _height8, imageAddr,
+                _isHeaderTSA, _isLZ77TSA, tsaAddr, paletteAddr);
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/Views/GraphicsToolView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/GraphicsToolView.axaml
@@ -51,6 +51,7 @@
     <!-- Buttons -->
     <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Spacing="8" Margin="0,0,0,8">
       <Button AutomationProperties.AutomationId="GraphicsTool_Draw_Button" Content="Draw" Width="80" Click="Draw_Click" />
+      <Button AutomationProperties.AutomationId="GraphicsTool_TSAEditor_Button" x:Name="TSAEditorButton" Content="TSA Editor" Width="100" Click="TSAEditor_Click" IsEnabled="False" />
       <Button AutomationProperties.AutomationId="GraphicsTool_Close_Button" Content="Close" Width="80" Click="Close_Click" />
       <TextBlock Text="{Binding StatusMessage}" VerticalAlignment="Center" Margin="12,0,0,0" Foreground="Gray" />
     </StackPanel>

--- a/FEBuilderGBA.Avalonia/Views/GraphicsToolView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/GraphicsToolView.axaml.cs
@@ -10,6 +10,15 @@ namespace FEBuilderGBA.Avalonia.Views
     {
         readonly GraphicsToolViewViewModel _vm = new();
 
+        // Captured from the last Jump(...) call so the "TSA Editor" button can
+        // open ImageTSAEditorView with the same image/TSA/palette context. The
+        // WinForms equivalent reads these straight off the GraphicsToolForm
+        // controls in TSAEditorButton_Click; the Avalonia preview path keeps
+        // them here because the VM does not own a TSA field.
+        bool _tsaNavReady;
+        int _navWidth, _navHeight, _navPaletteCount, _navTsaType;
+        uint _navImageAddr, _navTsaAddr, _navPaletteAddr;
+
         public string ViewTitle => "Graphics Tool";
         public bool IsLoaded => _vm.IsLoaded;
         public ViewModelBase? DataViewModel => _vm;
@@ -39,6 +48,56 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         void Close_Click(object? sender, RoutedEventArgs e) => Close();
+
+        /// <summary>
+        /// Open the TSA Tile Editor pre-populated with the last Jump(...)
+        /// image/TSA/palette context. Mirrors WinForms
+        /// <c>GraphicsToolForm.TSAEditorButton_Click</c>: convert the direct
+        /// data addresses to pointer slots via <c>U.GrepPointer</c> (the WF
+        /// <c>refPointer</c> equivalent, which returns <c>U.NOT_FOUND</c> when
+        /// no slot references the address), map the TSA option index to the
+        /// header/LZ77 flags, then call <c>ImageTSAEditorView.Init</c>.
+        /// </summary>
+        void TSAEditor_Click(object? sender, RoutedEventArgs e)
+        {
+            if (!_tsaNavReady) return;
+
+            ROM rom = CoreState.ROM;
+            if (rom == null) return;
+
+            try
+            {
+                uint width8 = (uint)System.Math.Max(1, _navWidth / 8);
+                uint height8 = (uint)System.Math.Max(1, _navHeight / 8);
+
+                // refPointer(addr): find the pointer slot that references the
+                // data address, or U.NOT_FOUND when none does.
+                uint zimgPointer = U.GrepPointer(rom.Data, U.toPointer(_navImageAddr));
+                uint tsaPointer = U.GrepPointer(rom.Data, U.toPointer(_navTsaAddr));
+
+                // Mirror WF TSAOption.SelectedIndex mapping:
+                //   1 = LZ77; 2 = LZ77 + header; 3 = raw header; else raw.
+                bool isHeaderTSA = false;
+                bool isLZ77TSA = false;
+                if (_navTsaType == 1) { isLZ77TSA = true; }
+                else if (_navTsaType == 2) { isLZ77TSA = true; isHeaderTSA = true; }
+                else if (_navTsaType == 3) { isHeaderTSA = true; }
+
+                uint paletteOffset = U.toOffset(_navPaletteAddr);
+                uint palettePointer = U.GrepPointer(rom.Data, U.toPointer(_navPaletteAddr));
+
+                int paletteCount = _navPaletteCount;
+                if (paletteCount <= 0) paletteCount = 1;
+
+                var f = WindowManager.Instance.Open<ImageTSAEditorView>();
+                f.Init(width8, height8, zimgPointer, isHeaderTSA, isLZ77TSA,
+                       tsaPointer, palettePointer, paletteOffset, paletteCount);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("GraphicsToolView.TSAEditor_Click failed: {0}", ex.Message);
+            }
+        }
 
         public void NavigateTo(uint address) { }
         public void SelectFirstItem() { }
@@ -117,6 +176,16 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.IsCompressed = IsCompressedImageType(imageType);
                 // Battle-BG graphics are 4bpp.
                 _vm.Is4bpp = true;
+
+                // Snapshot the full TSA context for the "TSA Editor" button.
+                _navWidth = width;
+                _navHeight = height;
+                _navImageAddr = image;
+                _navTsaAddr = tsa;
+                _navTsaType = tsaType;
+                _navPaletteAddr = palette;
+                _navPaletteCount = paletteCount;
+                _tsaNavReady = true;
             }
             finally
             {
@@ -136,6 +205,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
             }
             catch { /* keep the view usable even if Draw fails */ }
+            TSAEditorButton.IsEnabled = _tsaNavReady;
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml
@@ -30,7 +30,7 @@
        audit-trail still passes.
   -->
 
-  <!-- KnownGap: BattleCanvasRender reason=Live LZ77 decode + per-tile H/V-flip blit into a Bitmap+Graphics canvas is a WinForms-only graphics pipeline (System.Drawing + ImageUtil.ByteToImage16Tile + ImageUtil.BitBlt); deferred consistent with PR #577 and PR #513. The static palette/main-image editor UI ships in this PR. -->
+  <!-- BattleCanvasRender RESOLVED (#808): the TSA-composited main image is now rendered cross-platform via ImageTSAEditorCore.TryRenderMainImage into BattlePreview, with a read-only Export PNG button. Note: export is intentionally NOT byte-identical to the WF canvas for TSA tile indices >= 0x100 because the Core decoder uses the full 10-bit index (& 0x3FF) like ImageUtil.ByteToImage16Tile, whereas the WF TSA canvas masks tile numbers to 8 bits (& 0xff). The 10-bit value is the on-ROM truth, so this is acceptable for a read-only export. -->
   <!-- KnownGap: ChipsetListRender reason=PATHCHIPLIST permuted chipset (orig + H flip + V flip + HV flip) requires the same WinForms ImageUtil.Copy + BitBlt pipeline; deferred consistent with PR #577 and PR #513. -->
   <!-- KnownGap: TSAByteWrite reason=ImageFormRef.WriteImageData does pointer-aware reallocation when LZ77 recompressed TSA exceeds the original allocation; mirroring that requires the full WinForms write pipeline. Deferred; only the palette-write path is exercised by the Write button in this PR. -->
   <!-- KnownGap: PaletteToClipboard reason=System.Windows.Forms.Clipboard interop is WinForms-only; Avalonia equivalent (TopLevel.Clipboard async API) is a separate cross-cutting refactor not in scope here. The Clipboard button (label クリップボード) renders as a disabled stub so the labels audit still passes. -->
@@ -110,7 +110,7 @@
     <!-- ===== Row 1 Col 1: Battle canvas + TSAInfo + TabControl ===== -->
     <Grid Grid.Row="1" Grid.Column="1" RowDefinitions="*,Auto,Auto" Margin="4">
 
-      <!-- Battle canvas (TSA-rendered image) - KnownGap: BattleCanvasRender + TSAByteWrite -->
+      <!-- Battle canvas (TSA-rendered main image, #808). Render is read-only; TSA byte write stays KnownGap: TSAByteWrite. -->
       <Border Grid.Row="0" BorderBrush="DarkGray" BorderThickness="1" Margin="0,0,0,4">
         <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
           <controls:GbaImageControl AutomationProperties.AutomationId="ImageTSAEditor_Battle_Image"
@@ -118,9 +118,15 @@
         </ScrollViewer>
       </Border>
 
-      <!-- TSAInfo readout strip (mirrors WF TSAInfo TextBoxEx) -->
-      <TextBox Grid.Row="1" AutomationProperties.AutomationId="ImageTSAEditor_TSAInfo_Input"
-               Name="TSAInfoBox" IsReadOnly="True" Margin="0,0,0,4" />
+      <!-- TSAInfo readout strip (mirrors WF TSAInfo TextBoxEx) + read-only Export PNG -->
+      <Grid Grid.Row="1" ColumnDefinitions="*,Auto" Margin="0,0,0,4">
+        <TextBox Grid.Column="0" AutomationProperties.AutomationId="ImageTSAEditor_TSAInfo_Input"
+                 Name="TSAInfoBox" IsReadOnly="True" Margin="0,0,4,0" />
+        <Button Grid.Column="1" AutomationProperties.AutomationId="ImageTSAEditor_Battle_ExportPng_Button"
+                Name="BattleExportPngButton" Content="Export PNG"
+                IsEnabled="{Binding CanExportBattle}"
+                Click="BattleExportPng_Click" />
+      </Grid>
 
       <!-- ===== Tabbed editor: Palette + Main Image ===== -->
       <TabControl Grid.Row="2" AutomationProperties.AutomationId="ImageTSAEditor_TabControl"

--- a/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml.cs
@@ -112,6 +112,7 @@ namespace FEBuilderGBA.Avalonia.Views
             ReloadPaletteIntoGrid();
 
             UpdateInfoLabel();
+            RefreshBattleCanvas();
         }
 
         /// <summary>
@@ -218,6 +219,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 _vm.LoadEntry(addr);
                 UpdateInfoLabel();
+                RefreshBattleCanvas();
             }
             catch (Exception ex)
             {
@@ -235,6 +237,29 @@ namespace FEBuilderGBA.Avalonia.Views
             else
             {
                 InfoBox.Text = string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Render the TSA-composited main image (#808) into the BattlePreview
+        /// control and gate the Export PNG button. On a successful render the
+        /// image is shown and <c>CanExportBattle</c> is set true; on any failure
+        /// (no context, unset pointers, corrupt data) the preview is cleared and
+        /// the Export button stays disabled. Never throws.
+        /// </summary>
+        void RefreshBattleCanvas()
+        {
+            try
+            {
+                IImage img = _vm.RenderMainImage();
+                BattlePreview.SetImage(img);
+                _vm.CanExportBattle = img != null;
+            }
+            catch (Exception ex)
+            {
+                BattlePreview.SetImage(null);
+                _vm.CanExportBattle = false;
+                Log.Error("ImageTSAEditorView.RefreshBattleCanvas failed: {0}", ex.Message);
             }
         }
 
@@ -419,6 +444,23 @@ namespace FEBuilderGBA.Avalonia.Views
         void MainImageExport_Click(object? sender, RoutedEventArgs e)
         {
             Log.Notify("ImageTSAEditor MainImageExport - deferred (KnownGap: MainImageImportExport)");
+        }
+
+        /// <summary>
+        /// Read-only Export PNG of the TSA-composited main image (#808). Saves
+        /// the BattlePreview image via the shared GbaImageControl save-file
+        /// dialog. Enabled only when CanExportBattle (a successful render).
+        /// </summary>
+        async void BattleExportPng_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                await BattlePreview.ExportPng(this, "tsa_main_image");
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImageTSAEditorView.BattleExportPng failed: {0}", ex.Message);
+            }
         }
     }
 }

--- a/FEBuilderGBA.Core.Tests/ImageTSAEditorCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ImageTSAEditorCoreTests.cs
@@ -1,0 +1,554 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for ImageTSAEditorCore.TryRenderMainImage (#808, #769 item 1).
+//
+// Verifies the read-only TSA-composited main-image render used by the Avalonia
+// ImageTSAEditorView: dimensions (tile-count vs pixel convention), planted-tile
+// placement, H/V flip, palette-bank selection, index-0 transparency, the
+// raw-non-header byte-offset path, the header-TSA path, the deliberate 10-bit
+// (vs WF 8-bit) tile-index mask, and null/out-of-bounds safety.
+//
+// Uses the in-assembly StubImageService/StubImage (defined in
+// BattleAnimeDetailTests.cs) which capture RGBA pixel data so we can assert the
+// exact composed output.
+using System;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class ImageTSAEditorCoreTests
+    {
+        const uint IMAGE_OFFSET   = 0x1000;
+        const uint TSA_OFFSET     = 0x4000;
+        const uint PALETTE_OFFSET = 0x8000;
+
+        // GBA 5-5-5 colors used in the planted palette.
+        const ushort RED   = 0x001F;
+        const ushort GREEN = 0x03E0;
+        const ushort BLUE  = 0x7C00;
+        const ushort WHITE = 0x7FFF;
+
+        // -----------------------------------------------------------------
+        // Dimensions + planted-tile placement (raw, non-header TSA)
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void RawTSA_RendersTileCountTimesEightDimensions()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+                PlantRawCells(rom, TSA_OFFSET, new ushort[]
+                {
+                    Cell(1, false, false, 0), Cell(1, false, false, 0),
+                    Cell(1, false, false, 0), Cell(1, false, false, 0),
+                });
+
+                IImage img = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 2, 2, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                Assert.Equal(16, img.Width);   // width8(2) * 8
+                Assert.Equal(16, img.Height);  // height8(2) * 8
+            });
+        }
+
+        [Fact]
+        public void RawTSA_PlantsMarkerTileAtExpectedPixels()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+                PlantRawCells(rom, TSA_OFFSET, new ushort[] { Cell(1, false, false, 0) });
+
+                IImage img = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                // Marker pixel (0,0) is color index 2 = green; neighbour (1,0) is
+                // color index 1 = red. (Bank 0.)
+                AssertPixel(img, 0, 0, 0, 248, 0, 255);
+                AssertPixel(img, 1, 0, 248, 0, 0, 255);
+            });
+        }
+
+        [Fact]
+        public void RawTSA_Index0_IsTransparent()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());     // tile 0 is all index 0
+                PlantPalette(rom, StandardPalette());
+                PlantRawCells(rom, TSA_OFFSET, new ushort[] { Cell(0, false, false, 0) });
+
+                IImage img = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                // tile 0 is entirely color index 0 -> alpha 0 everywhere.
+                byte[] px = img.GetPixelData();
+                Assert.Equal(0, px[(0 * img.Width + 0) * 4 + 3]);
+                Assert.Equal(0, px[(7 * img.Width + 7) * 4 + 3]);
+            });
+        }
+
+        [Fact]
+        public void RawTSA_HFlip_MapsMarkerToRightEdge()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+                // cell0 normal, cell1 H-flipped.
+                PlantRawCells(rom, TSA_OFFSET, new ushort[]
+                {
+                    Cell(1, false, false, 0), Cell(1, true, false, 0),
+                });
+
+                IImage img = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 2, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                // cell1 occupies x=[8..15]; H-flip moves the (0,0) marker to local
+                // x=7 -> global x=15, y=0 (green). Local (0,0) of cell1 -> red.
+                AssertPixel(img, 15, 0, 0, 248, 0, 255);
+                AssertPixel(img, 8, 0, 248, 0, 0, 255);
+            });
+        }
+
+        [Fact]
+        public void RawTSA_VFlip_MapsMarkerToBottomEdge()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+                // cell0 normal (top), cell1 V-flipped (bottom).
+                PlantRawCells(rom, TSA_OFFSET, new ushort[]
+                {
+                    Cell(1, false, false, 0), Cell(1, false, true, 0),
+                });
+
+                IImage img = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 2, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                // cell1 occupies y=[8..15]; V-flip moves the (0,0) marker to local
+                // y=7 -> global y=15, x=0 (green).
+                AssertPixel(img, 0, 15, 0, 248, 0, 255);
+            });
+        }
+
+        [Fact]
+        public void RawTSA_PaletteBank_SelectsCorrectBank()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+                // Use palette bank 1: color1 = blue, color2 = white.
+                PlantRawCells(rom, TSA_OFFSET, new ushort[] { Cell(1, false, false, 1) });
+
+                IImage img = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                // Marker pixel (0,0) = color2 of bank1 = white; (1,0) = color1 = blue.
+                AssertPixel(img, 0, 0, 248, 248, 248, 255);
+                AssertPixel(img, 1, 0, 0, 0, 248, 255);
+            });
+        }
+
+        [Fact]
+        public void RawNonHeader_HonoursByteOffset()
+        {
+            // Review #7: a positive nonzero TSA offset must decode from tsaAddr,
+            // not from offset 0. Plant a DIFFERENT (red) cell at ROM offset 0x200
+            // and the real (green-marker) cell at TSA_OFFSET; the render must
+            // reflect TSA_OFFSET.
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+                // Decoy cell at a low offset (would render tile 1 too, but if the
+                // offset were ignored we'd read this instead).
+                PlantRawCells(rom, 0x200, new ushort[] { Cell(0, false, false, 0) });
+                PlantRawCells(rom, TSA_OFFSET, new ushort[] { Cell(1, false, false, 0) });
+
+                IImage img = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                // The marker (green) proves the decode started at TSA_OFFSET.
+                AssertPixel(img, 0, 0, 0, 248, 0, 255);
+            });
+        }
+
+        // -----------------------------------------------------------------
+        // LZ77-compressed TSA + header TSA
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void Lz77TSA_RendersMarkerTile()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+                // Two cells (4 bytes) so the uncompressed LZ77 size is >= 3
+                // (getCompressedSize rejects payloads smaller than 3 bytes).
+                byte[] tsaRaw = CellsToBytes(new ushort[]
+                {
+                    Cell(1, false, false, 0), Cell(0, false, false, 0),
+                });
+                PlantBytes(rom, TSA_OFFSET, LZ77.compress(tsaRaw));
+
+                IImage img = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 2, 1, IMAGE_OFFSET, false, true, TSA_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                AssertPixel(img, 0, 0, 0, 248, 0, 255);
+            });
+        }
+
+        [Fact]
+        public void HeaderTSA_Renders()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+                // Header {x=0,y=0} + one cell -> tile[0] at (0,0).
+                byte[] tsa = new byte[] { 0x00, 0x00,
+                    (byte)(Cell(1, false, false, 0) & 0xFF),
+                    (byte)(Cell(1, false, false, 0) >> 8) };
+                PlantBytes(rom, TSA_OFFSET, tsa);
+
+                IImage img = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, true, false, TSA_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                Assert.Equal(8, img.Width);
+                Assert.Equal(8, img.Height);
+                // Header path renders tile[0] = marker tile.
+                AssertPixel(img, 0, 0, 0, 248, 0, 255);
+            });
+        }
+
+        // -----------------------------------------------------------------
+        // 10-bit tile index (documented divergence vs WF 8-bit canvas mask)
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void TileIndex0x100_UsesFull10BitIndex()
+        {
+            // Review #6: the Core decoder masks the TSA tile index to 10 bits
+            // (& 0x3FF), unlike the WF TSA canvas (& 0xff). Tile 0x100 must be
+            // read as tile 0x100, NOT tile 0 (which an 8-bit mask would produce).
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                byte[] tiles = new byte[0x101 * 32];
+                FillTile(tiles, 0, 1);              // tile 0   -> all red
+                FillTile(tiles, 0x100, 1);          // tile 256 -> all green-marker
+                SetPixel(tiles, 0x100, 0, 0, 2);
+                PlantImage(rom, tiles);
+                PlantPalette(rom, StandardPalette());
+                PlantRawCells(rom, TSA_OFFSET, new ushort[] { Cell(0x100, false, false, 0) });
+
+                IImage img = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                // Pixel (0,0) is the tile-0x100 marker (green). If the index were
+                // 8-bit masked to 0 we'd see tile 0 here (red at (0,0)).
+                AssertPixel(img, 0, 0, 0, 248, 0, 255);
+            });
+        }
+
+        // -----------------------------------------------------------------
+        // Graceful / bounded edge cases
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void PaletteBankAbovePlantedBanks_DoesNotThrow()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                // Only 2 banks planted; request bank 5.
+                PlantPalette(rom, StandardPalette());
+                PlantRawCells(rom, TSA_OFFSET, new ushort[] { Cell(1, false, false, 5) });
+
+                IImage img = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img); // out-of-range bank bytes are bounds-skipped
+            });
+        }
+
+        [Fact]
+        public void PaletteNearRomEnd_ClampsWithoutThrowing()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantRawCells(rom, TSA_OFFSET, new ushort[] { Cell(1, false, false, 0) });
+                uint paletteNearEnd = (uint)rom.Data.Length - 10; // < 512 bytes left
+
+                IImage img = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, paletteNearEnd);
+
+                Assert.NotNull(img); // clamped palette read, no throw
+            });
+        }
+
+        [Fact]
+        public void RawTSA_NearRomEnd_NoThrow_BoundedRead()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+                uint tsaNearEnd = (uint)rom.Data.Length - 4;
+
+                IImage img = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 32, 20, IMAGE_OFFSET, false, false, tsaNearEnd, PALETTE_OFFSET);
+
+                Assert.NotNull(img); // reads at most the bytes available, no throw
+            });
+        }
+
+        // -----------------------------------------------------------------
+        // Null / out-of-bounds safety
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void NullRom_ReturnsNull()
+        {
+            WithImageService(() =>
+            {
+                Assert.Null(ImageTSAEditorCore.TryRenderMainImage(
+                    null, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET));
+            });
+        }
+
+        [Fact]
+        public void NoImageService_ReturnsNull()
+        {
+            var rom = MakeRom();
+            PlantImage(rom, MarkerTiles());
+            PlantPalette(rom, StandardPalette());
+            PlantRawCells(rom, TSA_OFFSET, new ushort[] { Cell(1, false, false, 0) });
+
+            var saved = CoreState.ImageService;
+            try
+            {
+                CoreState.ImageService = null;
+                Assert.Null(ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET));
+            }
+            finally { CoreState.ImageService = saved; }
+        }
+
+        [Fact]
+        public void ZeroDimensions_ReturnNull()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+                Assert.Null(ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 0, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET));
+                Assert.Null(ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 0, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET));
+            });
+        }
+
+        [Fact]
+        public void CorruptImagePointer_ReturnsNull()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantPalette(rom, StandardPalette());
+                PlantRawCells(rom, TSA_OFFSET, new ushort[] { Cell(1, false, false, 0) });
+                // imageAddr at header (0) -> isSafetyOffset false.
+                Assert.Null(ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, 0, false, false, TSA_OFFSET, PALETTE_OFFSET));
+                // imageAddr at a zero-filled region -> not a valid LZ77 stream.
+                Assert.Null(ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET));
+            });
+        }
+
+        [Fact]
+        public void TruncatedLz77Image_ReturnsNull()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantPalette(rom, StandardPalette());
+                PlantRawCells(rom, TSA_OFFSET, new ushort[] { Cell(1, false, false, 0) });
+                // Valid 0x10 header claiming 0x100 bytes, planted 4 bytes from the
+                // ROM end so the stream is truncated -> getCompressedSize == 0.
+                uint addr = (uint)rom.Data.Length - 4;
+                rom.Data[addr + 0] = 0x10;
+                rom.Data[addr + 1] = 0x00;
+                rom.Data[addr + 2] = 0x01;
+                rom.Data[addr + 3] = 0x00;
+                Assert.Null(ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, addr, false, false, TSA_OFFSET, PALETTE_OFFSET));
+            });
+        }
+
+        [Fact]
+        public void CorruptPalettePointer_ReturnsNull()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantRawCells(rom, TSA_OFFSET, new ushort[] { Cell(1, false, false, 0) });
+                // paletteAddr at header (0) -> isSafetyOffset false.
+                Assert.Null(ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, 0));
+            });
+        }
+
+        [Fact]
+        public void CorruptTsaPointer_ReturnsNull()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+                // tsaAddr at header (0) -> isSafetyOffset false.
+                Assert.Null(ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, 0, PALETTE_OFFSET));
+            });
+        }
+
+        // -----------------------------------------------------------------
+        // Helpers
+        // -----------------------------------------------------------------
+
+        static void WithImageService(Action body)
+        {
+            var saved = CoreState.ImageService;
+            try
+            {
+                CoreState.ImageService = new StubImageService();
+                body();
+            }
+            finally { CoreState.ImageService = saved; }
+        }
+
+        static ROM MakeRom()
+        {
+            var rom = new ROM();
+            byte[] data = new byte[0x1000000]; // 16 MB (min for FE8U detection)
+            rom.LoadLow("synth.gba", data, "BE8E01");
+            return rom;
+        }
+
+        /// <summary>2 tiles: tile 0 = all index 0, tile 1 = mostly index 1 with a
+        /// single index-2 marker pixel at (0,0).</summary>
+        static byte[] MarkerTiles()
+        {
+            byte[] tiles = new byte[2 * 32];
+            FillTile(tiles, 1, 1);
+            SetPixel(tiles, 1, 0, 0, 2);
+            return tiles;
+        }
+
+        static byte[] StandardPalette()
+        {
+            byte[] pal = new byte[512];
+            SetColor(pal, 0, 1, RED);
+            SetColor(pal, 0, 2, GREEN);
+            SetColor(pal, 1, 1, BLUE);
+            SetColor(pal, 1, 2, WHITE);
+            return pal;
+        }
+
+        static void SetColor(byte[] pal, int bank, int index, ushort c)
+        {
+            int off = bank * 32 + index * 2;
+            pal[off] = (byte)(c & 0xFF);
+            pal[off + 1] = (byte)(c >> 8);
+        }
+
+        static void FillTile(byte[] tiles, int tile, int colorIndex)
+        {
+            for (int y = 0; y < 8; y++)
+                for (int x = 0; x < 8; x++)
+                    SetPixel(tiles, tile, x, y, colorIndex);
+        }
+
+        static void SetPixel(byte[] tiles, int tile, int x, int y, int colorIndex)
+        {
+            int pos = tile * 32 + y * 4 + x / 2;
+            byte b = tiles[pos];
+            if (x % 2 == 0) b = (byte)((b & 0xF0) | (colorIndex & 0x0F));
+            else b = (byte)((b & 0x0F) | ((colorIndex & 0x0F) << 4));
+            tiles[pos] = b;
+        }
+
+        static ushort Cell(int tileIndex, bool h, bool v, int bank)
+            => (ushort)((tileIndex & 0x3FF) | (h ? 0x400 : 0) | (v ? 0x800 : 0) | ((bank & 0xF) << 12));
+
+        static byte[] CellsToBytes(ushort[] cells)
+        {
+            byte[] b = new byte[cells.Length * 2];
+            for (int i = 0; i < cells.Length; i++)
+            {
+                b[i * 2] = (byte)(cells[i] & 0xFF);
+                b[i * 2 + 1] = (byte)(cells[i] >> 8);
+            }
+            return b;
+        }
+
+        static void PlantImage(ROM rom, byte[] tiles)
+            => PlantBytes(rom, IMAGE_OFFSET, LZ77.compress(tiles));
+
+        static void PlantPalette(ROM rom, byte[] palette)
+            => PlantBytes(rom, PALETTE_OFFSET, palette);
+
+        static void PlantRawCells(ROM rom, uint addr, ushort[] cells)
+        {
+            for (int i = 0; i < cells.Length; i++)
+                U.write_u16(rom.Data, addr + (uint)(i * 2), cells[i]);
+        }
+
+        static void PlantBytes(ROM rom, uint addr, byte[] bytes)
+            => Array.Copy(bytes, 0, rom.Data, addr, bytes.Length);
+
+        static void AssertPixel(IImage img, int x, int y, byte r, byte g, byte b, byte a)
+        {
+            byte[] px = img.GetPixelData();
+            int idx = (y * img.Width + x) * 4;
+            Assert.Equal(r, px[idx + 0]);
+            Assert.Equal(g, px[idx + 1]);
+            Assert.Equal(b, px[idx + 2]);
+            Assert.Equal(a, px[idx + 3]);
+        }
+    }
+}

--- a/FEBuilderGBA.Core/ImageTSAEditorCore.cs
+++ b/FEBuilderGBA.Core/ImageTSAEditorCore.cs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Cross-platform render helper for the TSA Tile Editor (#808, follow-up to #769
+// item 1). Renders the TSA-composited "main image" (the WinForms
+// ImageTSAEditorForm Battle canvas) so the Avalonia ImageTSAEditorView can show
+// it and export it to PNG read-only -- no System.Drawing / WinForms dependency.
+//
+// WinForms reference (FEBuilderGBA/ImageTSAEditorForm.cs):
+//   * GetChipImage:    image = rom.p32(zimgPointer); tileData = LZ77.decompress
+//                      (rom.Data, image) -> 4bpp tiles, 0x20 bytes each.
+//   * palette base:    palettePointer==NOT_FOUND ? toOffset(paletteAddress)
+//                      : rom.p32(palettePointer).  Read RAW (no LZ77).
+//   * LoadBattleScreen: LZ77 TSA -> decompress then ByteToTSA/ByteToHeaderTSA at
+//                       offset 0; raw TSA -> ByteToTSA/ByteToHeaderTSA(rom.Data,
+//                       tsapos).
+//
+// This helper takes ALREADY-RESOLVED data addresses (ROM offsets) so the
+// read-only render carries no pointer-slot / repoint coupling; the ViewModel
+// resolves the slots exactly like WF before calling in.
+//
+// Decode reuse (FEBuilderGBA.Core/ImageUtilCore.cs):
+//   * DecodeTSA       (mirrors ByteToTSA, has a byte tsaOffset parameter)
+//   * DecodeHeaderTSA (mirrors ByteToHeaderTSA, has NO offset parameter)
+//   * DecodeTileToPixels (4bpp, per-cell palette bank, index0 = transparent)
+//
+// Note: DecodeTSA uses the full 10-bit TSA tile index (& 0x3FF) like the generic
+// ImageUtil.ByteToImage16Tile, whereas the WF TSA *canvas* masks tile numbers to
+// 8 bits (m & 0xff). For TSA entries whose tile index is >= 0x100 the exported
+// image is therefore intentionally NOT byte-identical to the WF canvas. This is
+// acceptable for a read-only export (the 10-bit value is the on-ROM truth).
+
+using System;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Cross-platform render helper for the TSA Tile Editor main image (#808).
+    /// See the file-level comment for the WinForms reference semantics and the
+    /// documented 10-bit-vs-8-bit tile-index divergence.
+    /// </summary>
+    public static class ImageTSAEditorCore
+    {
+        // 16 palette banks * 16 colors * 2 bytes = 512 bytes (full 4bpp palette).
+        const int PALETTE_BYTES = 16 * 16 * 2;
+
+        // Largest possible header-TSA payload: 2 header bytes + 32 x 32 u16 cells.
+        // DecodeHeaderTSA accepts header dimensions up to 32 x 32, so slicing this
+        // many bytes covers every valid header regardless of width8/height8.
+        const int HEADER_TSA_MAX_BYTES = 2 + (32 * 32 * 2);
+
+        /// <summary>
+        /// Render the TSA-composited main image from already-resolved ROM data
+        /// addresses. Returns the composed <see cref="IImage"/> sized
+        /// <paramref name="width8"/>*8 x <paramref name="height8"/>*8 pixels, or
+        /// <c>null</c> on any null/out-of-bounds/corrupt input (never throws).
+        /// </summary>
+        /// <param name="rom">Loaded ROM.</param>
+        /// <param name="width8">Canvas width in 8-pixel tiles.</param>
+        /// <param name="height8">Canvas height in 8-pixel tiles.</param>
+        /// <param name="imageAddr">Resolved ROM offset of the LZ77 tile image.</param>
+        /// <param name="isHeaderTSA">True if the TSA stream carries a {w,h} header.</param>
+        /// <param name="isLZ77TSA">True if the TSA stream is LZ77-compressed.</param>
+        /// <param name="tsaAddr">Resolved ROM offset of the TSA stream.</param>
+        /// <param name="paletteAddr">Resolved ROM offset of the palette block.</param>
+        public static IImage TryRenderMainImage(ROM rom, uint width8, uint height8,
+            uint imageAddr, bool isHeaderTSA, bool isLZ77TSA, uint tsaAddr, uint paletteAddr)
+        {
+            if (rom == null || rom.RomInfo == null || rom.Data == null) return null;
+            if (CoreState.ImageService == null) return null;
+            if (width8 == 0 || height8 == 0) return null;
+
+            // --- Tile data: LZ77 image (validate the compressed stream BEFORE
+            // decompress; LZ77.decompress silently returns a zero-filled buffer
+            // on a truncated stream, so getCompressedSize==0 + an end-of-ROM
+            // bound check is the truncation guard -- mirrors ImageBattleScreenCore). ---
+            if (!U.isSafetyOffset(imageAddr, rom)) return null;
+            uint imgCompressed = LZ77.getCompressedSize(rom.Data, imageAddr);
+            if (imgCompressed == 0) return null;
+            if ((ulong)imageAddr + imgCompressed > (ulong)rom.Data.Length) return null;
+            byte[] tileData = LZ77.decompress(rom.Data, imageAddr);
+            if (tileData == null || tileData.Length == 0) return null;
+
+            // --- Palette: RAW up to 512 bytes (16 banks), clamped to ROM end
+            // (no LZ77). DecodeTileToPixels bounds-checks short palettes, so a
+            // clamped read is safe. ---
+            if (!U.isSafetyOffset(paletteAddr, rom)) return null;
+            int palBytes = PALETTE_BYTES;
+            if ((ulong)paletteAddr + (ulong)palBytes > (ulong)rom.Data.Length)
+            {
+                palBytes = (int)((ulong)rom.Data.Length - paletteAddr);
+            }
+            if (palBytes <= 0) return null;
+            byte[] palette = new byte[palBytes];
+            Array.Copy(rom.Data, paletteAddr, palette, 0, palBytes);
+
+            int wTiles = (int)width8;
+            int hTiles = (int)height8;
+
+            if (!U.isSafetyOffset(tsaAddr, rom)) return null;
+
+            // --- TSA data ---
+            if (isLZ77TSA)
+            {
+                uint tsaCompressed = LZ77.getCompressedSize(rom.Data, tsaAddr);
+                if (tsaCompressed == 0) return null;
+                if ((ulong)tsaAddr + tsaCompressed > (ulong)rom.Data.Length) return null;
+                byte[] tsaData = LZ77.decompress(rom.Data, tsaAddr);
+                if (tsaData == null || tsaData.Length == 0) return null;
+
+                return isHeaderTSA
+                    ? ImageUtilCore.DecodeHeaderTSA(tileData, tsaData, palette, wTiles, hTiles, true, 0, 0)
+                    : ImageUtilCore.DecodeTSA(tileData, tsaData, palette, wTiles, hTiles, true, 0);
+            }
+
+            // RAW (uncompressed) TSA stored in ROM at tsaAddr.
+            if (isHeaderTSA)
+            {
+                // DecodeHeaderTSA has no byte-offset parameter, so slice a bounded
+                // window from tsaAddr instead of copying the whole ROM tail.
+                long tail = (long)rom.Data.Length - tsaAddr;
+                if (tail <= 0) return null;
+                int sliceLen = (int)Math.Min((long)HEADER_TSA_MAX_BYTES, tail);
+                byte[] tsaData = new byte[sliceLen];
+                Array.Copy(rom.Data, tsaAddr, tsaData, 0, sliceLen);
+                return ImageUtilCore.DecodeHeaderTSA(tileData, tsaData, palette, wTiles, hTiles, true, 0, 0);
+            }
+
+            // RAW non-header: DecodeTSA accepts a byte offset and caps reads to
+            // wTiles*hTiles entries, so pass rom.Data directly (no large slice).
+            if (tsaAddr > int.MaxValue) return null;
+            return ImageUtilCore.DecodeTSA(tileData, rom.Data, palette, wTiles, hTiles, true, (int)tsaAddr);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Resolve the `BattleCanvasRender` KnownGap in the Avalonia **TSA Tile Editor** (`ImageTSAEditorView`) by rendering the **TSA-composited main image** into the existing `BattlePreview` `GbaImageControl` and adding a **distinct read-only `Export PNG`** button. No ROM write — purely a parity/read-only improvement.

Implementation plan: see issue #808 (approved after Copilot CLI plan review).

## Scope
- Closes #808
- Ref #769 (item 1 — read-only export, "ship first")

## What changed
- **Core** (`FEBuilderGBA.Core/ImageTSAEditorCore.cs`, new): `TryRenderMainImage(...)` — works on already-resolved ROM addresses. Handles LZ77/raw × header/non-header TSA, with full null/`isSafetyOffset`/LZ77-truncation guards and a clamped 512-byte raw palette read. Documents the deliberate 10-bit (`&0x3FF`) tile-index vs WF 8-bit-mask divergence (acceptable for read-only export).
- **ViewModel**: `RenderMainImage()` resolves pointer slots → data addresses exactly like WinForms (early-out on `NOT_FOUND` image/TSA slots); `CanExportBattle` gate.
- **View**: `RefreshBattleCanvas()` wiring (Init + entry select) + `Export PNG` button (`ImageTSAEditor_Battle_ExportPng_Button`, gated on `CanExportBattle`). Main-Image-tab import/export buttons stay inert KnownGaps.
- **GraphicsToolView**: new `TSA Editor` nav button; converts the form's direct data addresses → pointer slots via `U.GrepPointer` and opens the editor (reachable from Battle BG Edit → Graphics Tool).

## Test plan
- [x] `FEBuilderGBA.Core.Tests/ImageTSAEditorCoreTests.cs` — 20 new render tests (dims, marker placement, hflip/vflip, palette bank, index0 transparency, raw nonzero-offset, LZ77 TSA, header TSA, tileIndex 0x100 10-bit lock, palette/TSA near ROM end, null/corrupt safety). All pass.
- [x] `ImageTSAEditorParityTests` updated: `View_KnownGapBlock_HasNonEmptyReasons` threshold lowered (BattleCanvasRender resolved); new `View_ExportPngButton_IsRenderGated`; new VM `ViewModel_RenderMainImage_AllNotFoundPointers_ReturnsNull`. All pass.
- [x] Full `dotnet test FEBuilderGBA.Avalonia.Tests` — 7192 passed, 0 failed.
- [x] Full `dotnet test FEBuilderGBA.Core.Tests` — 2136 passed, 0 failed.
- [x] `scripts/validate-automation-ids.ps1` — VALIDATION PASSED.
- [x] Builds clean: Core, Avalonia, CLI, SkiaSharp (Release).
- [x] L10n: `Export PNG` / `TSA Editor` literals already localized in ja/zh/en (verified) — no new keys needed.

## Screenshot
TSA Tile Editor opened via Battle BG Edit → Graphics Tool → TSA Editor against FE8U, showing the populated TSA-composited 240×160 main image and the enabled `Export PNG` button:

![TSA Tile Editor with rendered main image](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr808-tsa-editor.png)

## GUI Test Report
| Scenario | Steps | Result |
| --- | --- | --- |
| TSA main-image render | Open FE8U → Battle BG Edit → Graphics Tool → TSA Editor | PASS — 240×160 TSA-composited battle background rendered in BattlePreview |
| Export gating | Inspect `Export PNG` button after successful render | PASS — `ImageTSAEditor_Battle_ExportPng_Button` enabled (`CanExportBattle=true`) |
| Nav caller | `TSA Editor` button enabled only after Graphics Tool `Jump` populates addresses | PASS — disabled by default, enabled post-Jump |
| Safety | All-NOT_FOUND pointers / corrupt addrs | PASS — `RenderMainImage()` returns null, no throw (unit-tested) |

Copilot CLI: 1.0.57-2
Model: Claude Opus 4.8 (claude-opus-4.8)