### PR TITLE
fix(tests): deterministic Avalonia.Tests via DisableTestParallelization

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/AssemblyInfo.cs
+++ b/FEBuilderGBA.Avalonia.Tests/AssemblyInfo.cs
@@ -1,0 +1,12 @@
+using Xunit;
+
+// Force all test collections to run sequentially.  xUnit serializes tests
+// *within* a single collection but runs different collections (and uncollected
+// classes) in parallel by default.  These tests share mutable global state on
+// CoreState (ROM, caches, encoders, BaseDirectory, AIScript, ...), and only a
+// subset of classes opt into [Collection("SharedState")].  Cross-collection
+// parallelism therefore interleaves shared-state mutations and produces
+// order-dependent, nondeterministic CI failures (see #811).  Disabling
+// cross-collection parallelization makes the suite deterministic.  Mirrors the
+// existing precedent in FEBuilderGBA.E2ETests/AssemblyInfo.cs.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
## Summary
Makes `FEBuilderGBA.Avalonia.Tests` deterministic by disabling xUnit **cross-collection** parallelization, eliminating order-dependent CI flakiness caused by races over global `CoreState` statics.

## Root cause
xUnit serializes tests *within* a collection but runs different collections (and uncollected classes) in **parallel** by default. Only ~117 of ~164 Avalonia test classes opt into `[Collection("SharedState")]`; the rest raced with shared-state tests over `CoreState.ROM`, caches, encoders, `AIScript`, `BaseDirectory`, etc. — yielding nondeterministic failures (e.g. `PointerToolParityTests`, `AIScriptDisassemblyTests`) that passed on re-run and forced manual CI job re-runs.

## Change
Add `FEBuilderGBA.Avalonia.Tests/AssemblyInfo.cs`:
```csharp
[assembly: CollectionBehavior(DisableTestParallelization = true)]
```
Mirrors the existing precedent in `FEBuilderGBA.E2ETests/AssemblyInfo.cs` (recommended over `xunit.runner.json` after Copilot CLI plan review: matches repo convention, avoids the `CopyToOutputDirectory` footgun, auto-covers future test classes).

## Scope
- Closes #811
- Ref #769 (campaign-critical test-flakiness item)
- Tests-infra only — **no product code touched**.

## Test plan
- [x] `dotnet build FEBuilderGBA.Avalonia.Tests -c Release` — 0 errors.
- [x] Full suite **run 1**: `Passed! Failed: 0, Passed: 7192, Skipped: 3` (53s).
- [x] Full suite **run 2** (determinism repeat): `Passed! Failed: 0, Passed: 7192, Skipped: 3` (55s).
- [x] Targeted previously-flaky classes `PointerToolParityTests`+`AIScriptDisassemblyTests`: `Passed! Failed: 0, Passed: 37` (811ms).
- [x] Wall-clock impact negligible (~53s vs ~49s) — suite was already mostly serialized via the `SharedState` collection.

## Screenshots
Non-GUI (tests-infra only) change — CLI test output above is the proof; no application GUI affected.

Copilot CLI: 1.0.57-2
Model: Claude Opus 4.8 (claude-opus-4.8)