### PR TITLE
feat(avalonia): chipset thumbnail (CHIPLIST) render in ImageTSAEditor (closes #819)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageTSAEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageTSAEditorParityTests.cs
@@ -443,10 +443,10 @@ public class ImageTSAEditorParityTests
         var rx = new Regex(@"KnownGap:\s*(\S+(?:\s+\S+)*?)\s+reason=(.+?)\s*-->",
             RegexOptions.Compiled);
         var matches = rx.Matches(axaml);
-        Assert.True(matches.Count >= 4,
-            $"AXAML must contain at least 4 KnownGap markers (ChipsetListRender, " +
-            $"TSAByteWrite, PaletteToClipboard, MainImageImportExport); " +
-            $"found {matches.Count}. (BattleCanvasRender was resolved in #808.)");
+        Assert.True(matches.Count >= 3,
+            $"AXAML must contain at least 3 KnownGap markers (TSAByteWrite, " +
+            $"PaletteToClipboard, MainImageImportExport); found {matches.Count}. " +
+            $"(BattleCanvasRender was resolved in #808; ChipsetListRender in #819.)");
         foreach (Match m in matches)
         {
             Assert.False(string.IsNullOrWhiteSpace(m.Groups[1].Value),
@@ -511,6 +511,34 @@ public class ImageTSAEditorParityTests
 
         // Image / TSA slots are NOT_FOUND -> render is skipped without throwing.
         Assert.Null(vm.RenderMainImage());
+    }
+
+    /// <summary>
+    /// #819: RenderChipList must return null (no throw) when there is no
+    /// context, and when the image pointer slot is NOT_FOUND even with a
+    /// loaded context. The chip list never reads the TSA stream, so a
+    /// NOT_FOUND tsaPointer is irrelevant; only the image slot gates it.
+    /// </summary>
+    [Fact]
+    public void ViewModel_RenderChipList_NotFoundImagePointer_ReturnsNull()
+    {
+        var vm = new ImageTSAEditorViewModel();
+        // No context yet -> null.
+        Assert.Null(vm.RenderChipList());
+
+        vm.Init(
+            width8: 32u,
+            height8: 20u,
+            zimgPointer: U.NOT_FOUND,
+            isHeaderTSA: false,
+            isLZ77TSA: true,
+            tsaPointer: U.NOT_FOUND,
+            palettePointer: U.NOT_FOUND,
+            paletteAddress: 0u,
+            paletteCount: 1);
+
+        // Image slot is NOT_FOUND -> render is skipped without throwing.
+        Assert.Null(vm.RenderChipList());
     }
 
     [Fact]

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageTSAEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageTSAEditorViewModel.cs
@@ -11,9 +11,12 @@
 //     16 ushort entries through rom.write_u16(...) so an ambient
 //     UndoService.Begin scope captures them.
 //
+// RESOLVED (#808): BattleCanvasRender — RenderMainImage delegates to
+//   ImageTSAEditorCore.TryRenderMainImage (read-only TSA-composited main image).
+// RESOLVED (#819): ChipsetListRender — RenderChipList delegates to
+//   ImageTSAEditorCore.RenderChipList (read-only orig/Hflip/Vflip/HVflip strip).
+//
 // Out-of-scope (KnownGap markers in the AXAML cover the labels-sweep audit):
-//   - BattleCanvasRender    — live LZ77 + TSA blit through ImageUtil.BitBlt
-//   - ChipsetListRender     — permuted (orig / Hflip / Vflip / HVflip) chipset
 //   - TSAByteWrite          — ImageFormRef.WriteImageData pointer-aware realloc
 //   - PaletteToClipboard    — system clipboard interop (WinForms-only API)
 //   - MainImageImportExport — image1_Import / image1_Export through ImageFormRef
@@ -188,6 +191,37 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             return ImageTSAEditorCore.TryRenderMainImage(
                 rom, _width8, _height8, imageAddr,
                 _isHeaderTSA, _isLZ77TSA, tsaAddr, paletteAddr);
+        }
+
+        /// <summary>
+        /// Render the chip-list thumbnail (read-only) for the
+        /// <c>ChipListPreview</c> control (#819). Resolves the SAME image +
+        /// palette addresses as <see cref="RenderMainImage"/> (the chip list is
+        /// a pure tile-strip, so there is NO TSA pointer) and delegates to
+        /// <see cref="ImageTSAEditorCore.RenderChipList"/>.
+        ///
+        /// Returns null (no throw) when there is no context, when the image
+        /// pointer slot is unset (U.NOT_FOUND), or when the underlying render
+        /// fails. A NOT_FOUND palette pointer is NOT a failure — it is the
+        /// expected raw-address fallback handled by
+        /// <see cref="ResolveActivePaletteAddress"/>.
+        /// </summary>
+        public IImage RenderChipList()
+        {
+            if (!IsContextLoaded) return null;
+
+            // The image pointer slot must be real before we follow it with p32;
+            // only the palette pointer has a raw-address fallback. The chip list
+            // never reads the TSA stream, so _tsaPointer is irrelevant here.
+            if (_zimgPointer == U.NOT_FOUND) return null;
+
+            ROM rom = CoreState.ROM;
+            if (rom == null) return null;
+
+            uint imageAddr = rom.p32(_zimgPointer);
+            uint paletteAddr = ResolveActivePaletteAddress();
+
+            return ImageTSAEditorCore.RenderChipList(rom, imageAddr, paletteAddr);
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml
@@ -31,7 +31,7 @@
   -->
 
   <!-- BattleCanvasRender RESOLVED (#808): the TSA-composited main image is now rendered cross-platform via ImageTSAEditorCore.TryRenderMainImage into BattlePreview, with a read-only Export PNG button. Note: export is intentionally NOT byte-identical to the WF canvas for TSA tile indices >= 0x100 because the Core decoder uses the full 10-bit index (& 0x3FF) like ImageUtil.ByteToImage16Tile, whereas the WF TSA canvas masks tile numbers to 8 bits (& 0xff). The 10-bit value is the on-ROM truth, so this is acceptable for a read-only export. -->
-  <!-- KnownGap: ChipsetListRender reason=PATHCHIPLIST permuted chipset (orig + H flip + V flip + HV flip) requires the same WinForms ImageUtil.Copy + BitBlt pipeline; deferred consistent with PR #577 and PR #513. -->
+  <!-- ChipsetListRender RESOLVED (#819): the chip-list thumbnail (WF MakeCHIPLIST / PATHCHIPLIST_Paint) is now rendered cross-platform via ImageTSAEditorCore.RenderChipList into ChipListPreview — the main-image tiles in WF's 4-column (orig / Hflip / Vflip / HVflip) single-palette-bank-0 strip, read-only. Follow-up to #808/#810 (shared TSA tile/palette loader) and #807 (the 8-col/2-bank battle-screen sibling). -->
   <!-- KnownGap: TSAByteWrite reason=ImageFormRef.WriteImageData does pointer-aware reallocation when LZ77 recompressed TSA exceeds the original allocation; mirroring that requires the full WinForms write pipeline. Deferred; only the palette-write path is exercised by the Write button in this PR. -->
   <!-- KnownGap: PaletteToClipboard reason=System.Windows.Forms.Clipboard interop is WinForms-only; Avalonia equivalent (TopLevel.Clipboard async API) is a separate cross-cutting refactor not in scope here. The Clipboard button (label クリップボード) renders as a disabled stub so the labels audit still passes. -->
   <!-- KnownGap: MainImageImportExport reason=image1_Import / image1_Export call into ImageFormRef.ImportImageHandler / ExportImageHandler which depend on the full WinForms ImageFormRef ROM-write pipeline; deferred consistent with #513's BatchPng deferral. The Image Import / Image Export buttons (labels 画像読込 / 画像取出) render as disabled stubs so the labels audit still passes. -->
@@ -98,7 +98,9 @@
       <controls:AddressListControl AutomationProperties.AutomationId="ImageTSAEditor_Entry_List"
                                    Grid.Row="0" Name="EntryList" />
       <Label Grid.Row="1" Content="Chipset Preview" Margin="0,4,0,0" />
-      <!-- Chipset thumbnail (CHIPLIST + PATHCHIPLIST_Paint) - KnownGap: ChipsetListRender -->
+      <!-- Chipset thumbnail (WF MakeCHIPLIST / PATHCHIPLIST_Paint) — RESOLVED (#819):
+           rendered via ImageTSAEditorCore.RenderChipList into ChipListPreview
+           on entry-load + after a successful write (see RefreshChipList). -->
       <Border Grid.Row="2" BorderBrush="DarkGray" BorderThickness="1" Margin="0,4,0,0">
         <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
           <controls:GbaImageControl AutomationProperties.AutomationId="ImageTSAEditor_ChipList_Image"

--- a/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml.cs
@@ -403,6 +403,14 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (CoreState.Undo != null)
                 {
                     CoreState.Undo.RunUndo();
+                    // RunUndo reverts ROM bytes (e.g. an undone palette write),
+                    // so reload the affected state and re-render the previews --
+                    // otherwise the spinners + ChipListPreview / BattlePreview
+                    // keep showing the pre-undo colors (mirrors how
+                    // ImageBattleScreenView refreshes after undo). Null-safe.
+                    ReloadPaletteIntoGrid();
+                    RefreshBattleCanvas();
+                    RefreshChipList();
                 }
             }
             catch (Exception ex)

--- a/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml.cs
@@ -113,6 +113,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
             UpdateInfoLabel();
             RefreshBattleCanvas();
+            RefreshChipList();
         }
 
         /// <summary>
@@ -220,6 +221,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.LoadEntry(addr);
                 UpdateInfoLabel();
                 RefreshBattleCanvas();
+                RefreshChipList();
             }
             catch (Exception ex)
             {
@@ -263,6 +265,30 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
+        /// <summary>
+        /// Render the chip-list thumbnail (#819) into the ChipListPreview
+        /// control — the main-image tiles in WF MakeCHIPLIST's 4-column
+        /// (orig / Hflip / Vflip / HVflip) single-bank-0 strip. Mirrors
+        /// <see cref="RefreshBattleCanvas"/>: on a successful render the image
+        /// is shown; on any failure (no context, unset pointers, corrupt data)
+        /// the preview is cleared (blank). Never throws. Invoked on entry-load
+        /// (Init / OnSelected) and after a successful palette write so the
+        /// thumbnail tracks palette-color changes.
+        /// </summary>
+        void RefreshChipList()
+        {
+            try
+            {
+                IImage img = _vm.RenderChipList();
+                ChipListPreview.SetImage(img);
+            }
+            catch (Exception ex)
+            {
+                ChipListPreview.SetImage(null);
+                Log.Error("ImageTSAEditorView.RefreshChipList failed: {0}", ex.Message);
+            }
+        }
+
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
 
@@ -286,6 +312,9 @@ namespace FEBuilderGBA.Avalonia.Views
                 PerformPaletteWrite();
                 _undoService.Commit();
                 _vm.MarkClean();
+                // A palette write changes the rendered colors -> refresh the
+                // read-only chip-list thumbnail so it tracks the new palette.
+                RefreshChipList();
             }
             catch (Exception ex)
             {
@@ -308,6 +337,9 @@ namespace FEBuilderGBA.Avalonia.Views
                 PerformPaletteWrite();
                 _undoService.Commit();
                 _vm.MarkClean();
+                // A palette write changes the rendered colors -> refresh the
+                // read-only chip-list thumbnail so it tracks the new palette.
+                RefreshChipList();
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Core.Tests/ImageTSAEditorCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ImageTSAEditorCoreTests.cs
@@ -446,6 +446,312 @@ namespace FEBuilderGBA.Core.Tests
             });
         }
 
+        // =================================================================
+        // RenderChipList (#819) — the 4-column single-bank chip-list strip
+        // mirroring WF ImageTSAEditorForm.MakeCHIPLIST:
+        //   * Output = 32 x (tileCount*8): 4 columns of 8px (orig / Hflip /
+        //     Vflip / HVflip), one 8x8 cell per tile-row, SINGLE palette bank 0.
+        //   * index 0 renders OPAQUE.
+        // Reuses the #810 synthetic-ROM harness (MarkerTiles + StandardPalette).
+        // MarkerTiles() = 2 tiles: tile 0 all index 0, tile 1 index-1 fill with
+        // an index-2 marker at (0,0). So tile 1 sits on the SECOND row (tileY=8).
+        // bank0 idx1=red, idx2=green; bank1 idx1=blue, idx2=white; color 0 =
+        // black (unset) but OPAQUE.
+        // =================================================================
+
+        [Fact]
+        public void RenderChipList_RendersThirtyTwoByTileCountTimesEightDimensions()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());          // 2 tiles
+                PlantPalette(rom, StandardPalette());
+
+                IImage img = ImageTSAEditorCore.RenderChipList(
+                    rom, IMAGE_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                // 4 columns * 8px = 32 wide.
+                Assert.Equal(32, img.Width);
+                // 2 tiles * 8px = 16 tall.
+                Assert.Equal(16, img.Height);
+            });
+        }
+
+        [Fact]
+        public void RenderChipList_SingleTile_RendersThirtyTwoByEight()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, SingleMarkerTile());      // exactly 1 tile
+                PlantPalette(rom, StandardPalette());
+
+                IImage img = ImageTSAEditorCore.RenderChipList(
+                    rom, IMAGE_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                Assert.Equal(32, img.Width);   // 4 cols * 8
+                Assert.Equal(8, img.Height);   // 1 tile * 8
+            });
+        }
+
+        [Fact]
+        public void RenderChipList_OriginalColumn_HasMarkerTopLeft()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+
+                IImage img = ImageTSAEditorCore.RenderChipList(
+                    rom, IMAGE_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                // tile 1 is on the 2nd row -> tileY = 8. col 0 (orig, x base 0):
+                // marker src(0,0) stays at (0, 8) = green; neighbour (1, 8) = red.
+                AssertPixel(img, 0, 8, 0, 248, 0, 255);
+                AssertPixel(img, 1, 8, 248, 0, 0, 255);
+            });
+        }
+
+        [Fact]
+        public void RenderChipList_HFlipColumn_MovesMarkerToTopRight()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+
+                IImage img = ImageTSAEditorCore.RenderChipList(
+                    rom, IMAGE_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                // col 1 (Hflip, x base 8): src(0,0) -> local x=7 -> global (15, 8).
+                AssertPixel(img, 15, 8, 0, 248, 0, 255);
+                // The column's local (0,0) is now an index-1 (red) pixel.
+                AssertPixel(img, 8, 8, 248, 0, 0, 255);
+            });
+        }
+
+        [Fact]
+        public void RenderChipList_VFlipColumn_MovesMarkerToBottomLeft()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+
+                IImage img = ImageTSAEditorCore.RenderChipList(
+                    rom, IMAGE_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                // col 2 (Vflip, x base 16): src(0,0) -> local y=7 -> global (16, 15).
+                AssertPixel(img, 16, 15, 0, 248, 0, 255);
+            });
+        }
+
+        [Fact]
+        public void RenderChipList_HVFlipColumn_MovesMarkerToBottomRight()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+
+                IImage img = ImageTSAEditorCore.RenderChipList(
+                    rom, IMAGE_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                // col 3 (HVflip, x base 24): src(0,0) -> local (7,7) -> global (31, 15).
+                AssertPixel(img, 31, 15, 0, 248, 0, 255);
+            });
+        }
+
+        [Fact]
+        public void RenderChipList_UsesPaletteBank0_NotBank1()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+
+                IImage img = ImageTSAEditorCore.RenderChipList(
+                    rom, IMAGE_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                // The marker (index 2) renders as GREEN (bank 0 idx2 = 0x03E0),
+                // NOT white (bank 1 idx2 = 0x7FFF). This proves bank 0 is used.
+                AssertPixel(img, 0, 8, 0, 248, 0, 255);
+                // And the index-1 fill is RED (bank 0), not blue (bank 1).
+                AssertPixel(img, 1, 8, 248, 0, 0, 255);
+            });
+        }
+
+        [Fact]
+        public void RenderChipList_SingleBank_NoFifthThroughEighthColumns()
+        {
+            // The structural difference from #807's 8-col/2-bank chip list: this
+            // chip list is SINGLE bank, exactly 4 columns wide (32px). There is
+            // no bank-1 5th-8th column, so the canvas width must be 32 (not 64).
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+
+                IImage img = ImageTSAEditorCore.RenderChipList(
+                    rom, IMAGE_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                // Width is exactly the 4 single-bank columns -> 32. Were a 5th-8th
+                // bank-1 column present (the #807 layout) the width would be 64.
+                Assert.Equal(32, img.Width);
+                // Every RGBA pixel lives within the 32-wide buffer; the pixel data
+                // length equals exactly 32 * height * 4 (no extra bank-1 columns).
+                byte[] px = img.GetPixelData();
+                Assert.Equal(32 * img.Height * 4, px.Length);
+            });
+        }
+
+        [Fact]
+        public void RenderChipList_Index0_RendersOpaque()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());          // tile 0 = all index 0
+                PlantPalette(rom, StandardPalette());
+
+                IImage img = ImageTSAEditorCore.RenderChipList(
+                    rom, IMAGE_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                // tile 0 is on the FIRST row (tileY=0), entirely index 0. Per WF
+                // MakeCHIPLIST (transparent_index 0xFF + Blank color-0 bg), index 0
+                // must render OPAQUE (alpha 255). color 0 = 0x0000 = black.
+                byte[] px = img.GetPixelData();
+                Assert.Equal(255, px[(0 * img.Width + 0) * 4 + 3]);   // (0,0) alpha
+                Assert.Equal(255, px[(7 * img.Width + 7) * 4 + 3]);   // (7,7) alpha
+                AssertPixel(img, 0, 0, 0, 0, 0, 255);                 // opaque black
+            });
+        }
+
+        // ----- RenderChipList null / out-of-bounds safety -----
+
+        [Fact]
+        public void RenderChipList_NullRom_ReturnsNull()
+        {
+            WithImageService(() =>
+            {
+                Assert.Null(ImageTSAEditorCore.RenderChipList(
+                    null, IMAGE_OFFSET, PALETTE_OFFSET));
+            });
+        }
+
+        [Fact]
+        public void RenderChipList_NoImageService_ReturnsNull()
+        {
+            var rom = MakeRom();
+            PlantImage(rom, MarkerTiles());
+            PlantPalette(rom, StandardPalette());
+
+            var saved = CoreState.ImageService;
+            try
+            {
+                CoreState.ImageService = null;
+                Assert.Null(ImageTSAEditorCore.RenderChipList(
+                    rom, IMAGE_OFFSET, PALETTE_OFFSET));
+            }
+            finally { CoreState.ImageService = saved; }
+        }
+
+        [Fact]
+        public void RenderChipList_CorruptImagePointer_ReturnsNull()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantPalette(rom, StandardPalette());
+                // imageAddr at header (0) -> isSafetyOffset false.
+                Assert.Null(ImageTSAEditorCore.RenderChipList(
+                    rom, 0, PALETTE_OFFSET));
+                // imageAddr at a zero-filled region -> not a valid LZ77 stream.
+                Assert.Null(ImageTSAEditorCore.RenderChipList(
+                    rom, IMAGE_OFFSET, PALETTE_OFFSET));
+            });
+        }
+
+        [Fact]
+        public void RenderChipList_CorruptPalettePointer_ReturnsNull()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                // paletteAddr at header (0) -> isSafetyOffset false.
+                Assert.Null(ImageTSAEditorCore.RenderChipList(
+                    rom, IMAGE_OFFSET, 0));
+            });
+        }
+
+        [Fact]
+        public void RenderChipList_TruncatedLz77Image_ReturnsNull()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantPalette(rom, StandardPalette());
+                // Valid 0x10 header claiming 0x100 bytes, planted 4 bytes from the
+                // ROM end so the stream is truncated -> getCompressedSize == 0.
+                uint addr = (uint)rom.Data.Length - 4;
+                rom.Data[addr + 0] = 0x10;
+                rom.Data[addr + 1] = 0x00;
+                rom.Data[addr + 2] = 0x01;
+                rom.Data[addr + 3] = 0x00;
+                Assert.Equal(0u, LZ77.getCompressedSize(rom.Data, addr));
+                Assert.Null(ImageTSAEditorCore.RenderChipList(
+                    rom, addr, PALETTE_OFFSET));
+            });
+        }
+
+        [Fact]
+        public void RenderChipList_ImagePointerAtLastBytes_NoThrow_ReturnsNull()
+        {
+            // #818 last-bytes-pointer no-throw case: an image address within the
+            // final 4 bytes of ROM must not throw inside LZ77.getCompressedSize /
+            // the end-of-ROM bound guard -- it returns null gracefully.
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantPalette(rom, StandardPalette());
+                uint imageNearEnd = (uint)rom.Data.Length - 2;
+                IImage img = ImageTSAEditorCore.RenderChipList(
+                    rom, imageNearEnd, PALETTE_OFFSET);
+                Assert.Null(img); // no throw, bounded read
+            });
+        }
+
+        [Fact]
+        public void RenderChipList_PaletteNearRomEnd_ClampsWithoutThrowing()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                uint paletteNearEnd = (uint)rom.Data.Length - 10; // < 512 bytes left
+                IImage img = ImageTSAEditorCore.RenderChipList(
+                    rom, IMAGE_OFFSET, paletteNearEnd);
+                Assert.NotNull(img); // clamped palette read, no throw
+            });
+        }
+
         // -----------------------------------------------------------------
         // Helpers
         // -----------------------------------------------------------------
@@ -476,6 +782,17 @@ namespace FEBuilderGBA.Core.Tests
             byte[] tiles = new byte[2 * 32];
             FillTile(tiles, 1, 1);
             SetPixel(tiles, 1, 0, 0, 2);
+            return tiles;
+        }
+
+        /// <summary>Exactly 1 tile: index-1 fill with an index-2 marker at (0,0)
+        /// (the same shape as MarkerTiles()' tile 1, but as the sole tile so the
+        /// chip-list tileCount is 1).</summary>
+        static byte[] SingleMarkerTile()
+        {
+            byte[] tiles = new byte[1 * 32];
+            FillTile(tiles, 0, 1);
+            SetPixel(tiles, 0, 0, 0, 2);
             return tiles;
         }
 

--- a/FEBuilderGBA.Core.Tests/ImageTSAEditorCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ImageTSAEditorCoreTests.cs
@@ -710,14 +710,16 @@ namespace FEBuilderGBA.Core.Tests
                 PlantPalette(rom, StandardPalette());
                 // Valid 0x10 header claiming 0x100 bytes, planted 4 bytes from the
                 // ROM end so the stream is truncated -> getCompressedSize == 0.
-                uint addr = (uint)rom.Data.Length - 4;
+                // (addr is int for idiomatic array indexing; cast to uint at the
+                // LZ77 / RenderChipList call sites.)
+                int addr = rom.Data.Length - 4;
                 rom.Data[addr + 0] = 0x10;
                 rom.Data[addr + 1] = 0x00;
                 rom.Data[addr + 2] = 0x01;
                 rom.Data[addr + 3] = 0x00;
-                Assert.Equal(0u, LZ77.getCompressedSize(rom.Data, addr));
+                Assert.Equal(0u, LZ77.getCompressedSize(rom.Data, (uint)addr));
                 Assert.Null(ImageTSAEditorCore.RenderChipList(
-                    rom, addr, PALETTE_OFFSET));
+                    rom, (uint)addr, PALETTE_OFFSET));
             });
         }
 
@@ -735,6 +737,40 @@ namespace FEBuilderGBA.Core.Tests
                 IImage img = ImageTSAEditorCore.RenderChipList(
                     rom, imageNearEnd, PALETTE_OFFSET);
                 Assert.Null(img); // no throw, bounded read
+            });
+        }
+
+        [Fact]
+        public void ImagePointerThreeBytesFromEnd_WithMagic_NoThrow_BothReturnNull()
+        {
+            // PR #821 review (item 1): the LZ77 header is 4 bytes and
+            // getCompressedSize reads input[addr+3]. An image pointer 3 bytes
+            // from the ROM end (addr+3 == Data.Length, out of range) passes
+            // isSafetyOffset but would throw IndexOutOfRangeException inside
+            // getCompressedSize WITHOUT the explicit 4-byte-header guard. With
+            // the guard, BOTH RenderChipList and TryRenderMainImage must return
+            // null (a throw fails the test -- there is no try/catch here).
+            // Plant the 0x10 magic so the throw would otherwise be reached.
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantPalette(rom, StandardPalette());
+                PlantRawCells(rom, TSA_OFFSET, new ushort[] { Cell(1, false, false, 0) });
+
+                int addr = rom.Data.Length - 3;          // only 3 header bytes in-bounds
+                rom.Data[addr + 0] = 0x10;               // LZ77 magic
+                rom.Data[addr + 1] = 0x00;
+                rom.Data[addr + 2] = 0x01;
+                // addr+3 is out of range -- the 4-byte-header guard must reject
+                // BEFORE getCompressedSize touches input[addr+3].
+
+                // Chip-list path (no TSA): guard short-circuits -> null, no throw.
+                Assert.Null(ImageTSAEditorCore.RenderChipList(
+                    rom, (uint)addr, PALETTE_OFFSET));
+
+                // Main-image path (delegates to the SAME loader): also null, no throw.
+                Assert.Null(ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, (uint)addr, false, false, TSA_OFFSET, PALETTE_OFFSET));
             });
         }
 

--- a/FEBuilderGBA.Core/ImageTSAEditorCore.cs
+++ b/FEBuilderGBA.Core/ImageTSAEditorCore.cs
@@ -225,7 +225,16 @@ namespace FEBuilderGBA
             // --- Tile data: LZ77 image (validate the compressed stream BEFORE
             // decompress; truncation guard via getCompressedSize==0 + end-of-ROM
             // bound check). ---
-            if (!U.isSafetyOffset(imageAddr, rom)) return false;
+            // The GBA LZ77 header is 4 bytes (0x10 + a 3-byte uncompressed size).
+            // LZ77.getCompressedSize reads input[offset+3] but only rejects when
+            // FEWER THAN 3 bytes remain, so a pointer to the LAST 1-3 bytes of the
+            // ROM passes isSafetyOffset yet makes that header read throw
+            // IndexOutOfRangeException. Require the FULL 4-byte header to be
+            // in-bounds BEFORE any LZ77 call (mirrors ImageBattleScreenCore's
+            // IsLZ77HeaderSafe / IsRegionSafe, #818) so this null-safe loader
+            // returns false instead of throwing -- this also hardens
+            // TryRenderMainImage (#810), which now delegates here.
+            if (!IsLZ77HeaderSafe(rom, imageAddr)) return false;
             uint imgCompressed = LZ77.getCompressedSize(rom.Data, imageAddr);
             if (imgCompressed == 0) return false;
             if ((ulong)imageAddr + imgCompressed > (ulong)rom.Data.Length) return false;
@@ -247,6 +256,33 @@ namespace FEBuilderGBA
             tiles = tileData;
             palette = palBuf;
             return true;
+        }
+
+        // The GBA LZ77 stream header is 4 bytes (0x10 + a 3-byte uncompressed
+        // size). LZ77.getCompressedSize reads input[offset + 3] but only rejects
+        // when FEWER THAN 3 bytes remain, so a pointer to the LAST 1-3 bytes of
+        // the ROM passes isSafetyOffset yet makes that header read throw
+        // IndexOutOfRangeException (Copilot PR #818 review). Require the FULL
+        // 4-byte header to be in-bounds BEFORE any LZ77 call. Mirrors
+        // ImageBattleScreenCore.IsLZ77HeaderSafe / IsRegionSafe.
+        const int LZ77_HEADER_BYTES = 4;
+        static bool IsLZ77HeaderSafe(ROM rom, uint addr) => IsRegionSafe(rom, addr, LZ77_HEADER_BYTES);
+
+        /// <summary>
+        /// True when <c>[addr, addr+bytes)</c> is a valid in-ROM region:
+        /// <see cref="U.isSafetyOffset(uint, ROM)"/> domain constraints (offset
+        /// in [0x200, 0x02000000) and within rom.Data) PLUS an explicit
+        /// end-of-range check using <c>ulong</c> arithmetic so the addition
+        /// cannot overflow on near-<see cref="uint.MaxValue"/> inputs. Mirrors
+        /// ImageBattleScreenCore.IsRegionSafe (#594/#818).
+        /// </summary>
+        static bool IsRegionSafe(ROM rom, uint addr, int bytes)
+        {
+            if (rom == null || rom.Data == null) return false;
+            if (!U.isSafetyOffset(addr, rom)) return false;
+            if (bytes <= 0) return false;
+            ulong lastByte = (ulong)addr + (ulong)bytes - 1UL;
+            return lastByte < (ulong)rom.Data.Length;
         }
     }
 }

--- a/FEBuilderGBA.Core/ImageTSAEditorCore.cs
+++ b/FEBuilderGBA.Core/ImageTSAEditorCore.cs
@@ -68,29 +68,14 @@ namespace FEBuilderGBA
             if (CoreState.ImageService == null) return null;
             if (width8 == 0 || height8 == 0) return null;
 
-            // --- Tile data: LZ77 image (validate the compressed stream BEFORE
-            // decompress; LZ77.decompress silently returns a zero-filled buffer
-            // on a truncated stream, so getCompressedSize==0 + an end-of-ROM
-            // bound check is the truncation guard -- mirrors ImageBattleScreenCore). ---
-            if (!U.isSafetyOffset(imageAddr, rom)) return null;
-            uint imgCompressed = LZ77.getCompressedSize(rom.Data, imageAddr);
-            if (imgCompressed == 0) return null;
-            if ((ulong)imageAddr + imgCompressed > (ulong)rom.Data.Length) return null;
-            byte[] tileData = LZ77.decompress(rom.Data, imageAddr);
-            if (tileData == null || tileData.Length == 0) return null;
-
-            // --- Palette: RAW up to 512 bytes (16 banks), clamped to ROM end
-            // (no LZ77). DecodeTileToPixels bounds-checks short palettes, so a
-            // clamped read is safe. ---
-            if (!U.isSafetyOffset(paletteAddr, rom)) return null;
-            int palBytes = PALETTE_BYTES;
-            if ((ulong)paletteAddr + (ulong)palBytes > (ulong)rom.Data.Length)
+            // Shared LZ77-image-decode + raw-palette read (with the truncation
+            // guards). Behaviour-preserving extraction -- see
+            // TryLoadTSATileAndPalette. RenderChipList reuses the SAME loader.
+            if (!TryLoadTSATileAndPalette(rom, imageAddr, paletteAddr,
+                                          out byte[] tileData, out byte[] palette))
             {
-                palBytes = (int)((ulong)rom.Data.Length - paletteAddr);
+                return null;
             }
-            if (palBytes <= 0) return null;
-            byte[] palette = new byte[palBytes];
-            Array.Copy(rom.Data, paletteAddr, palette, 0, palBytes);
 
             int wTiles = (int)width8;
             int hTiles = (int)height8;
@@ -128,6 +113,140 @@ namespace FEBuilderGBA
             // wTiles*hTiles entries, so pass rom.Data directly (no large slice).
             if (tsaAddr > int.MaxValue) return null;
             return ImageUtilCore.DecodeTSA(tileData, rom.Data, palette, wTiles, hTiles, true, (int)tsaAddr);
+        }
+
+        /// <summary>
+        /// Render the chip-list thumbnail (read-only) from the already-resolved
+        /// image + palette ROM addresses (#819, follow-up to #808/#810/#807).
+        ///
+        /// Mirrors the WinForms <c>ImageTSAEditorForm.MakeCHIPLIST</c> grid: the
+        /// LZ77 main-image tiles laid out in a 4-column permutation strip --
+        /// col0=original, col1=H-flip, col2=V-flip, col3=HV-flip -- one 8x8 cell
+        /// per tile-row, all in the <b>default palette bank 0</b> (WF reads the
+        /// selected palette index; live re-render on palette change is out of
+        /// scope -- the read-only thumbnail shows bank 0). Index 0 renders
+        /// OPAQUE: WF blits col0 with transparent index 0 and cols1-3 opaque,
+        /// but both resolve to palette color 0 over WF's Blank(color0)
+        /// background, so an opaque index-0 render reproduces the WF thumbnail
+        /// (same choice as the #807 8-column battle-screen sibling).
+        ///
+        /// The chip list is a pure tile-strip -- it never touches the TSA
+        /// stream -- so this takes NO <c>tsaAddr</c>.
+        ///
+        /// Output size is <c>32 x (tileCount * 8)</c> pixels (4 cols * 8px = 32
+        /// wide; tileCount rows * 8px tall), exactly WF's
+        /// <c>Blank(ChipCache.Width * 4, ChipCache.Height)</c>. Returns
+        /// <c>null</c> (never throws) on any null/out-of-bounds/corrupt input or
+        /// when no <see cref="IImageService"/> is set.
+        /// </summary>
+        /// <param name="rom">Loaded ROM.</param>
+        /// <param name="imageAddr">Resolved ROM offset of the LZ77 tile image.</param>
+        /// <param name="paletteAddr">Resolved ROM offset of the palette block.</param>
+        public static IImage RenderChipList(ROM rom, uint imageAddr, uint paletteAddr)
+        {
+            if (rom == null || rom.RomInfo == null || rom.Data == null) return null;
+            if (CoreState.ImageService == null) return null;
+
+            // Same LZ77-image-decode + raw-palette read as TryRenderMainImage
+            // (inherits the isSafetyOffset / getCompressedSize / end-of-ROM
+            // truncation guards). The chip list never reads the TSA stream.
+            if (!TryLoadTSATileAndPalette(rom, imageAddr, paletteAddr,
+                                          out byte[] tileData, out byte[] palette))
+            {
+                return null;
+            }
+
+            // WF ChipCache is an 8px-wide tile sheet (one 8x8 tile per 8px row).
+            // tile count = tileData.Length / 32 (4bpp = 32 bytes/tile).
+            const int bytesPerTile = 32;
+            int tileCount = tileData.Length / bytesPerTile;
+            if (tileCount <= 0) return null;
+
+            // WF MakeCHIPLIST: ChipDisplayCache = Blank(ChipCache.Width * 4,
+            // ChipCache.Height) -> 8*4 = 32 wide, tileCount*8 tall. SINGLE bank
+            // (this is the structural difference from the #807 8-col/2-bank
+            // battle-screen chip list).
+            int width = 8 * 4;          // 4 columns of 8px
+            int height = tileCount * 8;
+
+            var image = CoreState.ImageService.CreateImage(width, height);
+            byte[] pixels = new byte[width * height * 4]; // RGBA
+
+            // Column layout: {orig, Hflip, Vflip, HVflip}, all palette bank 0 --
+            // exactly WF MakeCHIPLIST's blit order (Copy / Copy(true) /
+            // Copy(false,true) / Copy(true,true)).
+            // (hFlip, vFlip)
+            (bool h, bool v)[] columns =
+            {
+                (false, false), // col 0 = original
+                (true,  false), // col 1 = H-flip
+                (false, true),  // col 2 = V-flip
+                (true,  true),  // col 3 = HV-flip
+            };
+
+            for (int tile = 0; tile < tileCount; tile++)
+            {
+                int tileY = tile * 8;
+                for (int col = 0; col < columns.Length; col++)
+                {
+                    var (h, v) = columns[col];
+                    ImageUtilCore.DecodeTileToPixels(
+                        tileData, tile, palette, 0 /* palBank */,
+                        pixels, width, col * 8, tileY,
+                        h, v, is4bpp: true, opaqueIndex0: true);
+                }
+            }
+
+            image.SetPixelData(pixels);
+            return image;
+        }
+
+        /// <summary>
+        /// Shared loader extracted from <see cref="TryRenderMainImage"/> (#819):
+        /// LZ77-decode the tile image and read the raw (≤512-byte) palette block
+        /// from already-resolved ROM addresses. Behaviour-preserving -- returns
+        /// <c>false</c> exactly where the inline block previously returned
+        /// <c>null</c> (the #810 <see cref="TryRenderMainImage"/> tests pin this).
+        ///
+        /// Validates the compressed image stream BEFORE decompressing:
+        /// <c>LZ77.decompress</c> silently returns a zero-filled buffer on a
+        /// truncated stream, so <c>getCompressedSize == 0</c> + an end-of-ROM
+        /// bound check is the truncation guard (mirrors ImageBattleScreenCore's
+        /// TryLoadChipsetAndPalette). The palette read is RAW (no LZ77), clamped
+        /// to ROM end; <c>DecodeTileToPixels</c> bounds-checks short palettes so
+        /// a clamped read is safe.
+        /// </summary>
+        static bool TryLoadTSATileAndPalette(ROM rom, uint imageAddr, uint paletteAddr,
+            out byte[] tiles, out byte[] palette)
+        {
+            tiles = null;
+            palette = null;
+
+            // --- Tile data: LZ77 image (validate the compressed stream BEFORE
+            // decompress; truncation guard via getCompressedSize==0 + end-of-ROM
+            // bound check). ---
+            if (!U.isSafetyOffset(imageAddr, rom)) return false;
+            uint imgCompressed = LZ77.getCompressedSize(rom.Data, imageAddr);
+            if (imgCompressed == 0) return false;
+            if ((ulong)imageAddr + imgCompressed > (ulong)rom.Data.Length) return false;
+            byte[] tileData = LZ77.decompress(rom.Data, imageAddr);
+            if (tileData == null || tileData.Length == 0) return false;
+
+            // --- Palette: RAW up to 512 bytes (16 banks), clamped to ROM end
+            // (no LZ77). ---
+            if (!U.isSafetyOffset(paletteAddr, rom)) return false;
+            int palBytes = PALETTE_BYTES;
+            if ((ulong)paletteAddr + (ulong)palBytes > (ulong)rom.Data.Length)
+            {
+                palBytes = (int)((ulong)rom.Data.Length - paletteAddr);
+            }
+            if (palBytes <= 0) return false;
+            byte[] palBuf = new byte[palBytes];
+            Array.Copy(rom.Data, paletteAddr, palBuf, 0, palBytes);
+
+            tiles = tileData;
+            palette = palBuf;
+            return true;
         }
     }
 }


### PR DESCRIPTION
## Summary

Renders the TSA editor's **chipset thumbnail (CHIPLIST / PATHCHIPLIST)** cross-platform, read-only, in the Avalonia `ImageTSAEditorView` — resolving the `ChipsetListRender` KnownGap. This is the **4-column single-palette-bank** sibling of the already-merged #807 `ImageBattleScreenCore.RenderChipsetPreview` (8-col/2-bank), and a follow-up to #810 (`ImageTSAEditorCore.TryRenderMainImage`) / #808 (TSA main-image render).

The chip list is the main-image tiles laid out in WinForms `ImageTSAEditorForm.MakeCHIPLIST`'s exact grid: **col0=original, col1=H-flip, col2=V-flip, col3=HV-flip**, one 8×8 cell per tile-row, **single palette bank 0**, index-0 opaque. Output dims are `32 × (tileCount*8)` — exactly WF's `Blank(ChipCache.Width*4, ChipCache.Height)`.

### Core
- **Factored the shared load**: extracted the LZ77-image-decode + raw-≤512-byte-palette read (with the `isSafetyOffset` / `getCompressedSize` / 4-byte-header / end-of-ROM truncation guards) out of `TryRenderMainImage` into a private `TryLoadTSATileAndPalette(rom, imageAddr, paletteAddr, out tiles, out palette)`. `TryRenderMainImage` now calls it — **behaviour-preserving**, the #810 tests stay green (verified 36/36).
- Added `public static IImage RenderChipList(ROM rom, uint imageAddr, uint paletteAddr)` — **no `tsaAddr`** (the chip list is a pure tile-strip and never touches the TSA stream). Renders the 4 flip columns via `DecodeTileToPixels(palBank:0, opaqueIndex0:true)`. Null-safe (load fails → null, never throws).

### Avalonia
- Wired the **existing (previously unwired)** `ChipListPreview` `GbaImageControl`: VM `RenderChipList()` resolves the same image + palette addresses as `RenderMainImage`; code-behind `RefreshChipList()` sets `ChipListPreview.SetImage(...)` on entry-load (Init / OnSelected) and after a successful palette write — mirroring the `BattlePreview` (#808) wiring, null-safe → blank on failure.
- Removed the `ChipsetListRender` KnownGap markers (now RESOLVED, like `BattleCanvasRender` in #808).

### WF
- `MakeCHIPLIST` left as-is (additive for Avalonia).

## Scope

- Closes #819
- Refs #769, #398 (resolves the `ChipsetListRender` item); builds on #807 / #808 / #810 / #816 / #818

## GUI Test Report

Captured against `roms/FE8U.gba`. The live desktop session was locked (raw screen-buffer reads return black and injected clicks don't register on a locked Windows session), so the editor was driven via a throwaway `RenderTargetBitmap` capture of the **real** `ImageTSAEditorView` with a populated FE8U `Init` context — the same headless render mechanism the project's `--screenshot-all` mode uses (the throwaway capture flag + render harness were reverted/removed; this PR contains **zero** shipping-code harness). `RenderTargetBitmap` renders the live visual tree directly, unaffected by the screen lock.

| # | Test | Result |
|---|------|--------|
| 1 | App launches and loads FE8U.gba (real Avalonia GUI, PrintWindow-verified) | PASS |
| 2 | `ImageTSAEditorView` opens with a real `Init` context (FE8U battle-screen image1 + palette pointer slots) | PASS |
| 3 | **Chipset Preview** panel shows the rendered chip-list thumbnail (orig / Hflip / Vflip / HVflip strip, single palette bank 0) beside the main image | PASS |
| 4 | Chip-list is 32 px wide (single bank — no bank-1 5th–8th columns) and scrolls vertically in its bordered ScrollViewer | PASS |
| 5 | Palette grid + entry list ("TSA Tile Editor", 1 item) + info ("256x160") populate from the real ROM | PASS |

![TSA editor chip-list render](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr819-tsa-chiplist.png)

> Screenshot hosted on `master` via docs PR #820 (stable raw URL).

## Test plan

- [x] Core `RenderChipList` exact dims `32 × tileCount*8` (1-tile → 32×8; 2-tile → 32×16) — Core unit
- [x] Core `RenderChipList` 4 flip-variant pixel parity (orig top-left, Hflip top-right, Vflip bottom-left, HVflip bottom-right) — Core unit
- [x] Core `RenderChipList` **single-bank** assertion: width is exactly 32, pixel buffer length == 32·height·4, no 5th–8th / bank-1 columns (the structural difference from #807's 8-col) — Core unit
- [x] Core `RenderChipList` palette bank 0 (marker renders green/bank-0, not white/bank-1) + index-0 opaque (alpha 255) — Core unit
- [x] Core `RenderChipList` null-safety: null rom / no ImageService / corrupt image ptr / corrupt palette ptr / truncated LZ77 / #818 last-bytes-pointer no-throw / palette-near-ROM-end clamp — Core unit
- [x] #810 `TryRenderMainImage` regression green after the behaviour-preserving load extraction (36/36 in the same class) — Core unit
- [x] Avalonia VM `RenderChipList()` returns null (no throw) with no context / NOT_FOUND image pointer — Avalonia unit
- [x] Avalonia parity: KnownGap marker count 4→3 (ChipsetListRender resolved); `ChipList_Image` AutomationId present; `validate-automation-ids.ps1` exit 0; L10n scan clean — Avalonia unit + scripts
- [x] Full suites green: Core.Tests 2185/2185, Avalonia.Tests 7196/7196; Core + SkiaSharp + Avalonia + CLI + WinForms all build 0 errors
- [x] Functional: real `ImageTSAEditorView` shows the rendered chip-list thumbnail (screenshot above)

Generated with Claude Code v2.1.156 (model: claude-opus-4-8, Opus 4.8 1M context)
