### PR TITLE
feat(avalonia): Export PNG of the battle-anime sample in ImageBattleAnimePallet (closes #828)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
@@ -14,7 +14,10 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using global::Avalonia.Headless.XUnit;
+using global::Avalonia.Media.Imaging;
 using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Controls;
 using FEBuilderGBA.Avalonia.GapSweep;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
@@ -171,17 +174,50 @@ public class ImageBattleAnimePalletParityTests
     }
 
     [Fact]
-    public void View_ImportExportButtons_AreHonestlyDisabledKnownGap()
+    public void View_ImportButton_IsHonestlyDisabledKnownGap()
     {
-        // Real PNG export/import are WF ImageFormRef-coupled (#399). Both
-        // buttons are rendered but disabled.
+        // Real PNG import is still WF PaletteFormRef-coupled (#399). The
+        // Import button is rendered but disabled. (Export is now wired — see
+        // View_ExportButton_WiredAndGated.)
         string axaml = ReadAxaml();
         Assert.Matches(new Regex(
             @"AutomationId=""ImageBattleAnimePallet_Import_Button""[\s\S]{0,400}IsEnabled=""False""",
             RegexOptions.Singleline), axaml);
+    }
+
+    /// <summary>
+    /// #828: the Export Image button now reuses <c>GbaImageControl.ExportPng</c>
+    /// (the merged read-only PNG primitive, #815) to export the rendered sample
+    /// grid. It is wired to a Click handler, starts disabled (gated until a
+    /// sample render succeeds), and the code-behind drives its IsEnabled from
+    /// <c>SamplePreview.HasImage</c> — the exact pattern
+    /// <c>ImageBattleScreenView</c> (#810) uses. The stale "Export requires…
+    /// WinForms-coupled DrawBattleAnime via ImageFormRef.ExportImage" marker
+    /// must be gone.
+    /// </summary>
+    [Fact]
+    public void View_ExportButton_WiredAndGated()
+    {
+        string axaml = ReadAxaml();
+        // Click handler is wired.
+        Assert.Matches(new Regex(
+            @"AutomationId=""ImageBattleAnimePallet_Export_Button""[\s\S]{0,400}Click=""Export_Click""",
+            RegexOptions.Singleline), axaml);
+        // Starts disabled until a render succeeds (gated like ImageBattleScreen).
         Assert.Matches(new Regex(
             @"AutomationId=""ImageBattleAnimePallet_Export_Button""[\s\S]{0,400}IsEnabled=""False""",
             RegexOptions.Singleline), axaml);
+        // The stale WinForms-coupled deferral marker must be gone.
+        Assert.DoesNotContain("ImageFormRef.ExportImage", axaml);
+
+        string code = File.ReadAllText(CodeBehindPath());
+        // Handler exports the rendered sample preview (no ROM write).
+        Assert.Matches(new Regex(
+            @"SamplePreview\.ExportPng\(\s*this", RegexOptions.Singleline), code);
+        // Gate is driven from HasImage and applied to the button.
+        Assert.Matches(new Regex(
+            @"ExportButton\.IsEnabled\s*=\s*SamplePreview\.HasImage",
+            RegexOptions.Singleline), code);
     }
 
     // -----------------------------------------------------------------
@@ -614,6 +650,107 @@ public class ImageBattleAnimePalletParityTests
             Assert.Equal(290, grid.Height);
         }
         finally { CoreState.ROM = prevRom; }
+    }
+
+    // -----------------------------------------------------------------
+    // #828 — Export PNG of the rendered sample. The export path is
+    // GbaImageControl.SetImage -> IconBitmapBuilder.FromImage -> WriteableBitmap
+    // (the pixel copy) -> ExportPng -> Save (PNG encode). This test exercises
+    // both halves: (a) IconBitmapBuilder.FromImage builds a 360x290 bitmap from
+    // the rendered IImage, and (b) the rendered sample IImage encodes to a valid
+    // 360x290 PNG (decoding the IHDR header). The cross-platform IImage->PNG
+    // encode (SkiaImage.EncodePng -> SKEncodedImageFormat.Png) is asserted
+    // directly rather than via WriteableBitmap.Save, which depends on Avalonia's
+    // platform render backend (the headless test app runs without Skia, so its
+    // WriteableBitmap.Save does not emit a real PNG — an environment quirk, not
+    // an export-path defect).
+    // -----------------------------------------------------------------
+
+    [AvaloniaFact]
+    public void Export_RenderedSample_EncodesValid360x290Png()
+    {
+        EnsureImageService();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            var (rom, paletteOffset, sourceSlot) = MakeRomWithFullAnimeRecord();
+            CoreState.ROM = rom;
+            var vm = new ImageBattleAnimePalletViewModel();
+            vm.LoadEntry(paletteOffset, sourceSlot, paletteIndex: 0);
+
+            using IImage grid = vm.RenderSampleBattleAnime();
+            Assert.NotNull(grid);
+            Assert.Equal(360, grid.Width);
+            Assert.Equal(290, grid.Height);
+
+            // (a) The SetImage pixel-copy step builds a 360x290 WriteableBitmap.
+            using WriteableBitmap bmp = IconBitmapBuilder.FromImage(grid);
+            Assert.NotNull(bmp);
+            Assert.Equal(360, bmp.PixelSize.Width);
+            Assert.Equal(290, bmp.PixelSize.Height);
+
+            // (b) The rendered sample encodes to a real 360x290 PNG via the
+            // cross-platform IImage->PNG primitive (SkiaImage.EncodePng).
+            byte[] png = grid.EncodePng();
+            Assert.True(IsPngSignature(png), "encoded bytes are not a PNG");
+            (int w, int h) = ReadPngIhdrDimensions(png);
+            Assert.Equal(360, w);
+            Assert.Equal(290, h);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [AvaloniaFact]
+    public void Export_NullSample_ProducesNoBitmap_NoCrash()
+    {
+        // Null-safety: a no-resolvable-anime record returns null from
+        // RenderSampleBattleAnime; IconBitmapBuilder.FromImage(null) returns
+        // null (no bitmap, no file written, button stays disabled). Mirrors
+        // GbaImageControl.ExportPng early-returning on a null bitmap.
+        EnsureImageService();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            // Palette-only record => unresolvable => null sample.
+            var (rom, paletteOffset, sourceSlot) = MakeRomWithSingleSlotPalette(new ushort[16]);
+            CoreState.ROM = rom;
+            var vm = new ImageBattleAnimePalletViewModel();
+            vm.LoadEntry(paletteOffset, sourceSlot, paletteIndex: 0);
+
+            IImage grid = vm.RenderSampleBattleAnime();
+            Assert.Null(grid);
+
+            // The builder is null-safe on a null image (no throw, no bitmap).
+            WriteableBitmap bmp = IconBitmapBuilder.FromImage(grid);
+            Assert.Null(bmp);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    /// <summary>True if the byte buffer starts with the 8-byte PNG signature.</summary>
+    static bool IsPngSignature(byte[] data)
+    {
+        if (data == null || data.Length < 8) return false;
+        ReadOnlySpan<byte> sig = stackalloc byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+        for (int i = 0; i < 8; i++) if (data[i] != sig[i]) return false;
+        return true;
+    }
+
+    /// <summary>
+    /// Read the width/height from a PNG's IHDR chunk. The IHDR is always the
+    /// first chunk: bytes [0..7] signature, [8..11] length, [12..15] "IHDR",
+    /// [16..19] width (big-endian), [20..23] height (big-endian).
+    /// </summary>
+    static (int width, int height) ReadPngIhdrDimensions(byte[] png)
+    {
+        Assert.True(png.Length >= 24, "PNG too small to contain IHDR");
+        // Confirm the IHDR chunk-type marker at offset 12.
+        Assert.True(png[12] == (byte)'I' && png[13] == (byte)'H'
+                 && png[14] == (byte)'D' && png[15] == (byte)'R',
+                 "first chunk is not IHDR");
+        int w = (png[16] << 24) | (png[17] << 16) | (png[18] << 8) | png[19];
+        int h = (png[20] << 24) | (png[21] << 16) | (png[22] << 8) | png[23];
+        return (w, h);
     }
 
     static void EnsureImageService()

--- a/FEBuilderGBA.Avalonia.Tests/ImageBattleAnimePalletExportScreenshotTest.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageBattleAnimePalletExportScreenshotTest.cs
@@ -1,0 +1,156 @@
+using System;
+using System.IO;
+using System.Linq;
+using global::Avalonia;
+using global::Avalonia.Controls;
+using global::Avalonia.Headless.XUnit;
+using global::Avalonia.Media.Imaging;
+using global::Avalonia.VisualTree;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Controls;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using FEBuilderGBA.SkiaSharp;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// Issue #828: render the Avalonia <see cref="ImageBattleAnimePalletView"/>
+    /// with a battle-animation entry selected to a PNG that proves the
+    /// <b>Export Image</b> button is now ENABLED beside the rendered 360x290
+    /// sample preview (#822 sample render + #815 ExportPng primitive). Headless
+    /// RenderTargetBitmap — does NOT require a visible desktop, so it works on
+    /// locked machines and in CI. Mirrors
+    /// <see cref="WorldMapImageListExpandScreenshotTest"/> /
+    /// <see cref="ItemShopFirstIconScreenshotTest"/>.
+    ///
+    /// <para>By default the PNG is written to a per-test temp directory (so
+    /// normal/CI runs do NOT dirty the repo's tracked <c>pr-screenshots/</c>);
+    /// set <c>FEBUILDERGBA_SCREENSHOT_DIR</c> to override — pointing it at the
+    /// repo's <c>pr-screenshots/</c> is how the canonical PR screenshot is
+    /// regenerated locally.</para>
+    ///
+    /// <para>The view is the REAL editor with REAL ROM data: the entry list is
+    /// loaded via the VM's <c>LoadList</c>, the first row that yields a non-null
+    /// sample is selected through the same <c>OnSelectedEntry</c> path the UI
+    /// runs, and the Export button's <c>IsEnabled</c> is asserted == the sample's
+    /// <c>HasImage</c> (the #828 gating contract).</para>
+    /// </summary>
+    [Collection("SharedState")]
+    public class ImageBattleAnimePalletExportScreenshotTest : IClassFixture<RomFixture>
+    {
+        readonly RomFixture _fixture;
+        readonly ITestOutputHelper _output;
+
+        public ImageBattleAnimePalletExportScreenshotTest(RomFixture fixture, ITestOutputHelper output)
+        {
+            _fixture = fixture;
+            _output = output;
+        }
+
+        [AvaloniaFact]
+        public void ImageBattleAnimePalletView_SampleRendered_ExportEnabled_SavesScreenshot()
+        {
+            if (!_fixture.IsAvailable)
+            {
+                _output.WriteLine("SKIP: no ROM available");
+                return;
+            }
+            // Battle-animation list + LZ77 palettes exist on every FE GBA ROM, but
+            // the sample render is exercised against the loaded ROM regardless of
+            // version. Use whatever ROM the fixture resolved.
+            if (CoreState.ImageService == null)
+                CoreState.ImageService = new SkiaImageService();
+
+            var view = new ImageBattleAnimePalletView();
+
+            // Load the entry list via the VM (the Opened handler does this on a
+            // real desktop; headless does not raise Opened on the same timeline).
+            var entryList = view.FindControl<AddressListControl>("EntryList");
+            Assert.NotNull(entryList);
+            var vmField = typeof(ImageBattleAnimePalletView).GetField("_vm",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            Assert.NotNull(vmField);
+            var vm = (ImageBattleAnimePalletViewModel)vmField!.GetValue(view)!;
+
+            var items = vm.LoadList();
+            entryList!.SetItems(items);
+            _output.WriteLine($"Battle-anime entries: {items.Count}");
+            if (items.Count == 0)
+            {
+                _output.WriteLine("SKIP: no battle-anime entries in this ROM");
+                return;
+            }
+
+            // Realize the visual tree so the SamplePreview + Export button exist.
+            const int W = 1180;
+            const int H = 820;
+            view.Measure(new Size(W, H));
+            view.Arrange(new Rect(0, 0, W, H));
+
+            var exportButton = view.FindControl<Button>("ExportButton");
+            var samplePreview = view.FindControl<GbaImageControl>("SamplePreview");
+            Assert.NotNull(exportButton);
+            Assert.NotNull(samplePreview);
+
+            // Select the first row that renders a non-null sample (mirrors WF
+            // DrawSample). OnSelectedEntry runs RefreshSamplePreview, which gates
+            // the Export button on SamplePreview.HasImage (#828).
+            bool rendered = false;
+            for (int i = 0; i < items.Count; i++)
+            {
+                entryList.SelectByIndex(i);
+                view.Measure(new Size(W, H));
+                view.Arrange(new Rect(0, 0, W, H));
+                if (samplePreview!.HasImage)
+                {
+                    rendered = true;
+                    _output.WriteLine($"Sample rendered for entry index {i}: '{items[i].name}'");
+                    break;
+                }
+            }
+
+            if (!rendered)
+            {
+                _output.WriteLine("SKIP: no entry produced a non-blank sample in this ROM");
+                return;
+            }
+
+            // #828 gating contract: a rendered sample => Export button enabled.
+            Assert.True(samplePreview!.HasImage, "sample preview must carry a bitmap");
+            Assert.True(exportButton!.IsEnabled,
+                "Export Image button must be enabled once a sample renders (#828)");
+
+            // Render the real view (entry selected, sample shown, Export enabled)
+            // to a PNG for the PR. Re-layout first so the latest state is measured.
+            try
+            {
+                view.Measure(new Size(W, H));
+                view.Arrange(new Rect(0, 0, W, H));
+                using var bitmap = new RenderTargetBitmap(new PixelSize(W, H));
+                bitmap.Render(view);
+
+                string outDir = ResolveScreenshotOutputDir();
+                Directory.CreateDirectory(outDir);
+                string outPath = Path.Combine(outDir, "pr828-export-png.png");
+                bitmap.Save(outPath);
+                _output.WriteLine($"Saved screenshot to: {outPath} ({new FileInfo(outPath).Length} bytes)");
+            }
+            catch (Exception ex)
+            {
+                _output.WriteLine($"Headless render failed (environment, not the #828 fix): {ex.Message}");
+            }
+        }
+
+        static string ResolveScreenshotOutputDir()
+        {
+            string? overrideDir = Environment.GetEnvironmentVariable("FEBUILDERGBA_SCREENSHOT_DIR");
+            if (!string.IsNullOrEmpty(overrideDir))
+                return overrideDir;
+            return Path.Combine(Path.GetTempPath(), "FEBuilderGBA-screenshots");
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml
@@ -373,7 +373,8 @@
           <Button AutomationProperties.AutomationId="ImageBattleAnimePallet_Export_Button"
                   Name="ExportButton" Content="Export Image" Width="140"
                   IsEnabled="False"
-                  ToolTip.Tip="Deferred KnownGap: Export requires the rendered sample bitmap (WinForms-coupled DrawBattleAnime via ImageFormRef.ExportImage) (#399)." />
+                  Click="Export_Click"
+                  ToolTip.Tip="Export the rendered battle-animation sample (360x290 grid) to a PNG file. Read-only — no ROM write. Enabled once a sample renders." />
           <Button AutomationProperties.AutomationId="ImageBattleAnimePallet_Undo_Button"
                   Name="UndoButton" Content="Undo" Width="100"
                   Click="Undo_Click" />

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml.cs
@@ -217,6 +217,49 @@ namespace FEBuilderGBA.Avalonia.Views
                 Log.Error("ImageBattleAnimePalletView.RefreshSamplePreview failed: {0}", ex.Message);
                 SamplePreview.SetImage(null);
             }
+            // #828: gate the Export Image button on a successful render.
+            // HasImage is true only when SetImage received a non-null IImage
+            // (a no-resolvable-anime / blank record clears the preview). Mirrors
+            // ImageBattleScreenView's `BattleExportPngButton.IsEnabled =
+            // _vm.CanExportBattle`. ExportPng is null-safe regardless, but this
+            // makes the disabled state visible instead of a silent no-op.
+            if (ExportButton != null)
+            {
+                ExportButton.IsEnabled = SamplePreview.HasImage;
+            }
+        }
+
+        /// <summary>
+        /// Export the rendered battle-animation sample grid to a PNG file via a
+        /// non-modal save dialog. #828: reuses <c>GbaImageControl.ExportPng</c>
+        /// — the identical read-only PNG primitive the merged battle-screen
+        /// (#810) and TSA (#810/#815) editors use. Read-only — no ROM write.
+        /// Enabled only when a render succeeded (<see cref="RefreshSamplePreview"/>
+        /// set <c>HasImage</c>); <c>ExportPng</c> early-returns on a null bitmap.
+        /// </summary>
+        async void Export_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                await SamplePreview.ExportPng(this, ExportSuggestedName());
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImageBattleAnimePalletView.Export_Click failed: {0}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Build a sensible suggested PNG filename for the current animation
+        /// sample, e.g. <c>anime_sample_03</c> for the row whose list index is
+        /// 3. The list index is the WF battle-animation id (the VM names rows
+        /// "{i:X2} BattleAnime"). Falls back to <c>anime_sample</c> when no row
+        /// is selected.
+        /// </summary>
+        string ExportSuggestedName()
+        {
+            int idx = EntryList.SelectedOriginalIndex;
+            return idx >= 0 ? $"anime_sample_{idx:X2}" : "anime_sample";
         }
 
         void PaletteIndexCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -8308,8 +8308,8 @@ REDO
 :Deferred KnownGap: Import requires the rendered sample bitmap (WinForms-coupled DrawBattleAnime via PaletteFormRef.MakePaletteBitmapToUIEx) (#399).
 保留中の既知ギャップ: Import は描画されたサンプルビットマップを必要とします (PaletteFormRef.MakePaletteBitmapToUIEx 経由の WinForms 依存 DrawBattleAnime) (#399)。
 
-:Deferred KnownGap: Export requires the rendered sample bitmap (WinForms-coupled DrawBattleAnime via ImageFormRef.ExportImage) (#399).
-保留中の既知ギャップ: Export は描画されたサンプルビットマップを必要とします (ImageFormRef.ExportImage 経由の WinForms 依存 DrawBattleAnime) (#399)。
+:Export the rendered battle-animation sample (360x290 grid) to a PNG file. Read-only — no ROM write. Enabled once a sample renders.
+描画されたバトルアニメサンプル (360x290 のグリッド) を PNG ファイルにエクスポートします。読み取り専用 — ROM への書き込みはありません。サンプルが描画されると有効になります。
 
 :Fit to window
 ウィンドウに合わせる

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -22143,8 +22143,8 @@ English
 :Deferred KnownGap: Import requires the rendered sample bitmap (WinForms-coupled DrawBattleAnime via PaletteFormRef.MakePaletteBitmapToUIEx) (#399).
 待支持的已知缺口: 导入需要渲染好的样本位图 (依赖 WinForms 的 PaletteFormRef.MakePaletteBitmapToUIEx -> DrawBattleAnime) (#399)。
 
-:Deferred KnownGap: Export requires the rendered sample bitmap (WinForms-coupled DrawBattleAnime via ImageFormRef.ExportImage) (#399).
-待支持的已知缺口: 导出需要渲染好的样本位图 (依赖 WinForms 的 ImageFormRef.ExportImage -> DrawBattleAnime) (#399)。
+:Export the rendered battle-animation sample (360x290 grid) to a PNG file. Read-only — no ROM write. Enabled once a sample renders.
+将渲染好的战斗动画样本 (360x290 网格) 导出为 PNG 文件。只读 — 不写入 ROM。样本渲染成功后启用。
 
 :Fit to window
 适应窗口


### PR DESCRIPTION
## Summary

Wires the deferred **Export Image** button in the Avalonia `ImageBattleAnimePallet` editor to export the rendered battle-animation sample grid to a PNG, reusing `GbaImageControl.ExportPng` — the identical read-only PNG primitive (#815) the merged battle-screen (#810) and TSA (#810/#815) editors already use.

The original "Export requires the rendered sample bitmap (WinForms-coupled DrawBattleAnime via `ImageFormRef.ExportImage`)" blocker was **stale**: since #822 the 360×290 sample `IImage` already renders live in the `SamplePreview` `GbaImageControl`. Exporting it is pure reuse — no new primitive, no ROM write, no undo.

### What changed
- **Wire the Export button:** `Export_Click` → `SamplePreview.ExportPng(this, "anime_sample_<id>")` (non-modal StorageProvider save; the suggested name carries the animation list id). Read-only.
- **Polish (Copilot CLI plan review):** `RefreshSamplePreview()` now sets `ExportButton.IsEnabled = SamplePreview.HasImage`, mirroring `ImageBattleScreenView`'s `BattleExportPngButton.IsEnabled = _vm.CanExportBattle`, so the button reflects whether a sample actually rendered (null/blank → disabled). `ExportPng` is null-safe regardless.
- **Marker + L10n:** removed the stale `ImageFormRef.ExportImage` deferral tooltip; the new tooltip is translated to ja + zh. `validate-automation-ids.ps1` exit 0 (the existing `_Export_Button` AutomationId is unchanged).

## Scope

- **Closes #828**
- **Refs** #769, #399 (the KnownGap), #822 (the sample render), #815 (the ExportPng primitive), #810 (the sibling merged Export PNG pattern)

## Screenshot

Real capture of the **ImageBattleAnimePallet** editor (FE8U), rendered via the project's `--screenshot-all` `RenderTargetBitmap` mechanism (Skia-backed real-app render — used because the interactive desktop session is locked, as anticipated by the plan; the native save dialog itself isn't screenshot-provable on a locked session). First battle-animation entry selected → 12-frame 360×290 sample rendered → **Export Image enabled** (Import Image / Redo grayed):

![pr828 export png](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr828-export-png.png)

(Screenshot committed to `master` via docs PR #829.)

## GUI Test Report

| # | Test case | Method | Result |
|---|-----------|--------|--------|
| 1 | Editor loads with real FE8U ROM; battle-anime list populates (201 entries) | `ImageBattleAnimePalletExportScreenshotTest` (headless `[AvaloniaFact]` + real ROM) | PASS |
| 2 | Selecting an entry renders the 360×290 sample into `SamplePreview` (`HasImage == true`) | same test | PASS |
| 3 | Export Image button becomes ENABLED once a sample renders (#828 gating contract) | `Assert.True(exportButton.IsEnabled)` in same test | PASS |
| 4 | Export Image / Import Image / Redo enabled-state contrast rendered correctly | `--screenshot-all` RenderTargetBitmap capture (screenshot above) | PASS |
| 5 | Stale `ImageFormRef.ExportImage` deferral marker removed; Click wired; gated on `HasImage` | `View_ExportButton_WiredAndGated` (AXAML + code-behind assertions) | PASS |
| 6 | New tooltip literal has ja + zh translations (no L10n regression) | `L10nCoverageTest.AvaloniaViews_HaveJaAndZhTranslations` | PASS |

## Test plan

- [x] `RenderSampleBattleAnime()` → `IconBitmapBuilder.FromImage` builds a 360×290 `WriteableBitmap`, and the `IImage`→PNG encode (`SkiaImage.EncodePng`) yields a valid 360×290 PNG (decoded IHDR signature + dims) — `Export_RenderedSample_EncodesValid360x290Png`
- [x] Null-safety: a no-resolvable-anime record → null sample → `IconBitmapBuilder.FromImage(null)` returns null, no bitmap, no crash — `Export_NullSample_ProducesNoBitmap_NoCrash`
- [x] Export button wired to `Export_Click`, starts disabled, gated on `SamplePreview.HasImage`; stale `ImageFormRef.ExportImage` marker gone — `View_ExportButton_WiredAndGated`
- [x] Import button stays an honest deferred KnownGap — `View_ImportButton_IsHonestlyDisabledKnownGap`
- [x] Functional (real FE8U): first entry renders a sample → `ExportButton.IsEnabled == true` — `ImageBattleAnimePalletExportScreenshotTest` (PASS with ROM)
- [x] `validate-automation-ids.ps1` exit 0; L10n coverage green (ja + zh for the new tooltip)
- [x] Core.Tests (2211) + Avalonia.Tests (7212 + 2 new = green) pass; Core/SkiaSharp/CLI/Avalonia/WinForms build 0 errors

Generated with Claude Code v2.1.156 (model: claude-opus-4-8, Opus 4.8 1M context)