### PR TITLE
feat(core): MapRenderCore.RenderMapImage chapter-map tile compositing (closes #855)

### DIFF
--- a/FEBuilderGBA.Core.Tests/MapRenderCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/MapRenderCoreTests.cs
@@ -1,0 +1,486 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for MapRenderCore.RenderMapImage (#855, NV6-PR1).
+//
+// Covers:
+//   * Real-ROM integration on FE6/FE7U/FE8U (skips gracefully when ROMs absent).
+//     -- Non-null result, correct pixel dimensions (width*16 × height*16).
+//     -- Bank-0/index-0 pixel is OPAQUE (guards MR5: opaqueIndex0=true fix).
+//   * Guard/edge-case paths (synthetic ROMs built with LZ77.compress):
+//     -- Null ROM → null (no throw).
+//     -- Missing ImageService → null (no throw).
+//     -- Truncated OBJ LZ77 stream → null.
+//     -- Truncated config LZ77 stream → null.
+//     -- Truncated MAR LZ77 stream → null.
+//     -- width/height == 0 → null.
+//     -- Near-EOF offsets → no throw.
+//     -- Out-of-range config descOff → no throw (no null; partial canvas returned).
+//
+// Pattern: [Collection("SharedState")] + IDisposable save/restore, StubImageService
+// (reused from BattleAnimeDetailTests), LZ77.compress for synthetic payloads,
+// int array indices throughout.
+
+using System;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class MapRenderCoreTests : IDisposable
+    {
+        readonly IImageService _prevService;
+        readonly ROM _prevRom;
+
+        public MapRenderCoreTests()
+        {
+            _prevService = CoreState.ImageService;
+            _prevRom = CoreState.ROM;
+            CoreState.ImageService = new StubImageService();
+        }
+
+        public void Dispose()
+        {
+            CoreState.ImageService = _prevService;
+            CoreState.ROM = _prevRom;
+        }
+
+        // ====================================================================
+        // Helper: find a named ROM file by walking up from the test assembly.
+        // Returns null when not found — all callers skip gracefully on null.
+        // ====================================================================
+        static string FindRom(string romName)
+        {
+            string thisAssembly = Assembly.GetExecutingAssembly().Location;
+            string dir = Path.GetDirectoryName(thisAssembly);
+            for (int i = 0; i < 10 && dir != null; i++)
+            {
+                if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                {
+                    string path = Path.Combine(dir, "roms", romName);
+                    if (File.Exists(path)) return path;
+                    break;
+                }
+                dir = Path.GetDirectoryName(dir);
+            }
+            return null;
+        }
+
+        // ====================================================================
+        // Helper: resolve the four map offsets for map index mapId from a ROM.
+        // Returns false when any resolution fails (caller skips the test).
+        // Maps the map-setting struct fields exactly as WF MapSettingForm.cs:
+        //   obj_plist      = u16(addr + 4)  → resolved via map_obj_pointer table
+        //   palette_plist  = u8(addr + 6)   → resolved via map_pal_pointer table
+        //   config_plist   = u8(addr + 7)   → resolved via map_config_pointer table
+        //   mappointer_plist = u8(addr + 8) → resolved via map_map_pointer_pointer table
+        // ====================================================================
+        static bool TryResolveMapOffsets(ROM rom, uint mapId,
+            out uint objOffset, out uint paletteOffset,
+            out uint configOffset, out uint mapOffset)
+        {
+            objOffset = paletteOffset = configOffset = mapOffset = 0;
+            if (rom?.RomInfo == null) return false;
+
+            // Get the map-setting struct address for mapId.
+            uint mapSettingBase = rom.p32(rom.RomInfo.map_setting_pointer);
+            if (!U.isSafetyOffset(mapSettingBase, rom)) return false;
+            uint addr = mapSettingBase + mapId * rom.RomInfo.map_setting_datasize;
+            if (!U.isSafetyOffset(addr, rom)) return false;
+
+            // Read plist indices from the struct (same offsets as WF:188-191).
+            uint objPlist      = rom.u16(addr + 4);
+            uint palPlist      = rom.u8(addr + 6);
+            uint cfgPlist      = rom.u8(addr + 7);
+            uint mapPlist      = rom.u8(addr + 8);
+
+            // Resolve each plist to a ROM data offset via its pointer table.
+            objOffset     = ResolvePlist(rom, rom.RomInfo.map_obj_pointer,        objPlist);
+            paletteOffset = ResolvePlist(rom, rom.RomInfo.map_pal_pointer,        palPlist);
+            configOffset  = ResolvePlist(rom, rom.RomInfo.map_config_pointer,     cfgPlist);
+            mapOffset     = ResolvePlist(rom, rom.RomInfo.map_map_pointer_pointer, mapPlist);
+
+            return objOffset     != U.NOT_FOUND && objOffset     != 0
+                && paletteOffset != U.NOT_FOUND && paletteOffset != 0
+                && configOffset  != U.NOT_FOUND && configOffset  != 0
+                && mapOffset     != U.NOT_FOUND && mapOffset     != 0;
+        }
+
+        // Resolve plist index → ROM data offset via the plist pointer table.
+        // Equivalent to MapChangeCore.PlistToOffsetAddr but also supports
+        // MAP and PALETTE tables (which MapChangeCore.PlistType doesn't enumerate).
+        static uint ResolvePlist(ROM rom, uint plistPointer, uint plist)
+        {
+            if (plistPointer == 0) return U.NOT_FOUND;
+            uint base_ = rom.p32(plistPointer);
+            if (!U.isSafetyOffset(base_, rom)) return U.NOT_FOUND;
+            uint entryAddr = base_ + plist * 4u;
+            if (entryAddr + 4u > (uint)rom.Data.Length) return U.NOT_FOUND;
+            uint target = rom.p32(entryAddr);
+            if (!U.isSafetyOffset(target, rom)) return U.NOT_FOUND;
+            return target;
+        }
+
+        // ====================================================================
+        // Real-ROM integration tests.
+        // Each version is skipped gracefully when the ROM is not in roms/.
+        // ====================================================================
+
+        [Fact]
+        public void RealRom_FE6_Map0_NonNullAndCorrectDimensions()
+        {
+            string romPath = FindRom("FE6.gba");
+            if (romPath == null) return; // skip
+
+            var rom = new ROM();
+            if (!rom.Load(romPath, out string _)) return;
+            CoreState.ROM = rom;
+
+            if (!TryResolveMapOffsets(rom, 0,
+                    out uint objOff, out uint palOff, out uint cfgOff, out uint mapOff))
+                return; // skip if map 0 can't be resolved
+
+            IImage img = MapRenderCore.RenderMapImage(rom, objOff, palOff, cfgOff, mapOff);
+            Assert.NotNull(img);
+
+            // Verify pixel dimensions = width*16 × height*16.
+            byte[] mar = LZ77.decompress(rom.Data, mapOff);
+            Assert.NotNull(mar);
+            int w = mar[0];
+            int h = mar[1];
+            Assert.Equal(w * 16, img.Width);
+            Assert.Equal(h * 16, img.Height);
+        }
+
+        [Fact]
+        public void RealRom_FE7U_Map0_NonNullAndCorrectDimensions()
+        {
+            string romPath = FindRom("FE7U.gba");
+            if (romPath == null) return;
+
+            var rom = new ROM();
+            if (!rom.Load(romPath, out string _)) return;
+            CoreState.ROM = rom;
+
+            if (!TryResolveMapOffsets(rom, 0,
+                    out uint objOff, out uint palOff, out uint cfgOff, out uint mapOff))
+                return;
+
+            IImage img = MapRenderCore.RenderMapImage(rom, objOff, palOff, cfgOff, mapOff);
+            Assert.NotNull(img);
+
+            byte[] mar = LZ77.decompress(rom.Data, mapOff);
+            Assert.NotNull(mar);
+            int w = mar[0];
+            int h = mar[1];
+            Assert.Equal(w * 16, img.Width);
+            Assert.Equal(h * 16, img.Height);
+        }
+
+        [Fact]
+        public void RealRom_FE8U_Map0_NonNullAndCorrectDimensions()
+        {
+            string romPath = FindRom("FE8U.gba");
+            if (romPath == null) return;
+
+            var rom = new ROM();
+            if (!rom.Load(romPath, out string _)) return;
+            CoreState.ROM = rom;
+
+            if (!TryResolveMapOffsets(rom, 0,
+                    out uint objOff, out uint palOff, out uint cfgOff, out uint mapOff))
+                return;
+
+            IImage img = MapRenderCore.RenderMapImage(rom, objOff, palOff, cfgOff, mapOff);
+            Assert.NotNull(img);
+
+            byte[] mar = LZ77.decompress(rom.Data, mapOff);
+            Assert.NotNull(mar);
+            int w = mar[0];
+            int h = mar[1];
+            Assert.Equal(w * 16, img.Width);
+            Assert.Equal(h * 16, img.Height);
+        }
+
+        // ====================================================================
+        // MR5 guard: bank-0 / index-0 pixel is OPAQUE (alpha 255).
+        //
+        // A synthetic map is rendered with a known palette where palette bank 0,
+        // color index 0 = GBA color 0x0001 (R=8, G=0, B=0). The map has a
+        // single 16×16 logical tile whose four subtile TSA entries all point to
+        // tile 0 with palette bank 0 and no flip. Every pixel in tile 0 is index
+        // 0. After rendering, the pixel at (0,0) must be opaque (alpha 255) and
+        // carry the decoded color — not transparent (alpha 0).
+        // ====================================================================
+
+        [Fact]
+        public void OpaqueIndex0_PaletteBank0Color0_IsOpaque()
+        {
+            var (rom, objOff, palOff, cfgOff, mapOff) = BuildOpaqueIndex0Rom();
+            CoreState.ROM = rom;
+
+            IImage img = MapRenderCore.RenderMapImage(rom, objOff, palOff, cfgOff, mapOff);
+            Assert.NotNull(img);
+            Assert.Equal(16, img.Width);
+            Assert.Equal(16, img.Height);
+
+            byte[] pixels = img.GetPixelData(); // RGBA
+
+            // Pixel (0,0) is in the top-left subtile, top-left pixel, index 0.
+            // With opaqueIndex0=true: alpha MUST be 255.
+            int idx = 0; // pixel (0,0) = offset 0
+            byte alpha = pixels[idx + 3];
+            Assert.Equal((byte)255, alpha);
+
+            // Verify the color is actually the palette color for index 0, bank 0.
+            // GBA color 0x0001: R = (1 & 0x1F) << 3 = 8, G = 0, B = 0.
+            Assert.Equal((byte)8,   pixels[idx + 0]); // R
+            Assert.Equal((byte)0,   pixels[idx + 1]); // G
+            Assert.Equal((byte)0,   pixels[idx + 2]); // B
+        }
+
+        // ====================================================================
+        // Guard / edge-case tests — all built from synthetic ROMs.
+        // ====================================================================
+
+        [Fact]
+        public void NullRom_ReturnsNull()
+        {
+            IImage img = MapRenderCore.RenderMapImage(null, 0x200, 0x400, 0x600, 0x800);
+            Assert.Null(img);
+        }
+
+        [Fact]
+        public void MissingImageService_ReturnsNull()
+        {
+            CoreState.ImageService = null;
+            var rom = BuildMinimalRom();
+
+            // Even with a valid ROM, no ImageService → null.
+            IImage img = MapRenderCore.RenderMapImage(rom, 0, 0, 0, 0);
+            Assert.Null(img);
+        }
+
+        [Fact]
+        public void TruncatedObjLZ77_ReturnsNull()
+        {
+            var rom = BuildMinimalRom();
+            CoreState.ROM = rom;
+            // Offset 0x200 in our ROM has zero data — LZ77 header is missing/invalid.
+            IImage img = MapRenderCore.RenderMapImage(rom, 0x200, 0x400, 0x600, 0x800);
+            Assert.Null(img);
+        }
+
+        [Fact]
+        public void TruncatedConfigLZ77_ReturnsNull()
+        {
+            var rom = BuildMinimalRom();
+            CoreState.ROM = rom;
+
+            // Plant a valid OBJ at 0x200 and palette at 0x400 but leave config at 0x600 as zeros.
+            byte[] objData = new byte[32 * 16]; // minimal tiles
+            byte[] objCompressed = LZ77.compress(objData);
+            PlantBytes(rom, 0x200, objCompressed);
+
+            // Palette: 512 bytes all zeros
+            // (address 0x400 in a zeroed ROM is fine for raw read — all zeros,
+            // which makes GBA color 0x0000 = black).
+
+            // config at 0x600 stays zeros → LZ77 header invalid → null.
+            IImage img = MapRenderCore.RenderMapImage(rom, 0x200, 0x400, 0x600, 0x800);
+            Assert.Null(img);
+        }
+
+        [Fact]
+        public void TruncatedMarLZ77_ReturnsNull()
+        {
+            var rom = BuildMinimalRom();
+            CoreState.ROM = rom;
+
+            byte[] objData = new byte[32 * 16];
+            byte[] objCompressed = LZ77.compress(objData);
+            PlantBytes(rom, 0x200, objCompressed);
+
+            byte[] cfgData = new byte[8 * 256]; // 256 descriptors of 8 bytes each
+            byte[] cfgCompressed = LZ77.compress(cfgData);
+            PlantBytes(rom, 0x600, cfgCompressed);
+
+            // mar at 0x800 stays zeros → LZ77 header invalid → null.
+            IImage img = MapRenderCore.RenderMapImage(rom, 0x200, 0x400, 0x600, 0x800);
+            Assert.Null(img);
+        }
+
+        [Fact]
+        public void ZeroWidthMap_ReturnsNull()
+        {
+            var rom = BuildMinimalRom();
+            CoreState.ROM = rom;
+
+            byte[] objData = new byte[32 * 16];
+            PlantBytes(rom, 0x200, LZ77.compress(objData));
+            byte[] cfgData = new byte[8];
+            PlantBytes(rom, 0x600, LZ77.compress(cfgData));
+
+            // MAR with width=0, height=5.
+            byte[] marData = new byte[] { 0, 5 };
+            PlantBytes(rom, 0x800, LZ77.compress(marData));
+
+            IImage img = MapRenderCore.RenderMapImage(rom, 0x200, 0x400, 0x600, 0x800);
+            Assert.Null(img);
+        }
+
+        [Fact]
+        public void ZeroHeightMap_ReturnsNull()
+        {
+            var rom = BuildMinimalRom();
+            CoreState.ROM = rom;
+
+            byte[] objData = new byte[32 * 16];
+            PlantBytes(rom, 0x200, LZ77.compress(objData));
+            byte[] cfgData = new byte[8];
+            PlantBytes(rom, 0x600, LZ77.compress(cfgData));
+
+            // MAR with width=5, height=0.
+            byte[] marData = new byte[] { 5, 0 };
+            PlantBytes(rom, 0x800, LZ77.compress(marData));
+
+            IImage img = MapRenderCore.RenderMapImage(rom, 0x200, 0x400, 0x600, 0x800);
+            Assert.Null(img);
+        }
+
+        [Fact]
+        public void NearEofOffsets_DoesNotThrow()
+        {
+            var rom = BuildMinimalRom();
+            CoreState.ROM = rom;
+
+            // Pass ROM-end offsets — must return null, never throw.
+            IImage img = null;
+            var ex = Record.Exception(() =>
+            {
+                img = MapRenderCore.RenderMapImage(rom,
+                    (uint)rom.Data.Length - 1,
+                    (uint)rom.Data.Length - 1,
+                    (uint)rom.Data.Length - 1,
+                    (uint)rom.Data.Length - 1);
+            });
+            Assert.Null(ex);
+            Assert.Null(img);
+        }
+
+        [Fact]
+        public void OutOfRangeConfigDescOff_DoesNotThrow_ReturnsImage()
+        {
+            // A map where every MAR entry points to a config offset that is
+            // beyond the end of configUZ. The algorithm should skip (treat as
+            // zero-filled) rather than returning null, producing a valid
+            // (all-zero-TSA) image with the correct dimensions.
+            var rom = BuildMinimalRom();
+            CoreState.ROM = rom;
+
+            // OBJ: 2 tiles (64 bytes of 4bpp data — tile 0 all zeros).
+            byte[] objData = new byte[32 * 2];
+            PlantBytes(rom, 0x200, LZ77.compress(objData));
+
+            // Config: only 4 bytes (too small for a full 8-byte descriptor).
+            // Any MAR value > 0 will produce descOff >= 2 which exceeds length 4
+            // when accessing +7.
+            byte[] cfgData = new byte[4];
+            PlantBytes(rom, 0x600, LZ77.compress(cfgData));
+
+            // MAR: 3×2 map, all tiles index 0xFFF (descOff = 0x1FFE >> configUZ.Length).
+            // width=3, height=2 → 6 tiles.
+            byte[] marData = new byte[2 + 6 * 2];
+            marData[0] = 3;  // width
+            marData[1] = 2;  // height
+            for (int i = 0; i < 6; i++)
+            {
+                marData[2 + i * 2 + 0] = 0xFF;
+                marData[2 + i * 2 + 1] = 0x0F; // value 0x0FFF → descOff = 0x1FFE
+            }
+            PlantBytes(rom, 0x800, LZ77.compress(marData));
+
+            IImage img = null;
+            var ex = Record.Exception(() =>
+            {
+                img = MapRenderCore.RenderMapImage(rom, 0x200, 0x400, 0x600, 0x800);
+            });
+            Assert.Null(ex);
+            // The image must be returned (not null) — the out-of-range entries
+            // are skipped and produce an all-zero (blank) canvas.
+            Assert.NotNull(img);
+            Assert.Equal(3 * 16, img.Width);
+            Assert.Equal(2 * 16, img.Height);
+        }
+
+        // ====================================================================
+        // Synthetic ROM construction helpers
+        // ====================================================================
+
+        /// <summary>
+        /// Build a minimal 32MB ROM (all-zero data, no version RomInfo) just for
+        /// testing guard paths that fail early (null ROM / bad offsets).
+        /// </summary>
+        static ROM BuildMinimalRom()
+        {
+            var rom = new ROM();
+            byte[] data = new byte[0x2000000]; // 32 MB
+            rom.LoadLow("synth.gba", data, "BE8E01");
+            return rom;
+        }
+
+        /// <summary>
+        /// Build a synthetic ROM for the MR5 opaque-index-0 test.
+        ///
+        /// Layout:
+        ///   0x200000  OBJ tiles — one 8×8 tile (32 bytes), all pixels index 0.
+        ///   0x201000  Palette — 512 raw bytes; color 0 in bank 0 = GBA 0x0001
+        ///             (R=8, G=0, B=0).
+        ///   0x202000  Config — one 8-byte descriptor: four TSA entries all = 0
+        ///             (tile 0, palette bank 0, no flip).
+        ///   0x203000  Map data — 1×1 logical tile, MAR value = 0 (index into
+        ///             config descriptor 0).
+        /// </summary>
+        static (ROM rom, uint objOff, uint palOff, uint cfgOff, uint mapOff)
+            BuildOpaqueIndex0Rom()
+        {
+            var rom = new ROM();
+            byte[] data = new byte[0x2000000];
+            rom.LoadLow("synth.gba", data, "BE8E01");
+
+            const uint OBJ_OFF = 0x200000;
+            const uint PAL_OFF = 0x201000;
+            const uint CFG_OFF = 0x202000;
+            const uint MAP_OFF = 0x203000;
+
+            // OBJ: one 8×8 4bpp tile (32 bytes); all pixels are index 0.
+            byte[] objRaw = new byte[32];
+            PlantBytes(rom, OBJ_OFF, LZ77.compress(objRaw));
+
+            // Palette (raw, 512 bytes): bank 0, color 0 = GBA 0x0001 (R bit only).
+            // GBA color 0x0001: bits 0-4 = R=1, 5-9 = G=0, 10-14 = B=0.
+            // Decoded via StubImageService: R = (1 & 0x1F) << 3 = 8, G = 0, B = 0.
+            byte[] pal = new byte[512]; // 16 banks × 16 colors × 2 bytes
+            pal[0] = 0x01; // GBA color 0x0001, low byte
+            pal[1] = 0x00; // GBA color 0x0001, high byte
+            Array.Copy(pal, 0, rom.Data, PAL_OFF, 512);
+
+            // Config: one descriptor at offset 0 (m=0 → descOff = 0<<1 = 0).
+            // Four TSA entries: all zeros (tile 0, palette bank 0, no flip).
+            byte[] cfgRaw = new byte[8];
+            PlantBytes(rom, CFG_OFF, LZ77.compress(cfgRaw));
+
+            // Map: 1×1 tile, MAR value = 0.
+            byte[] marRaw = new byte[] { 1, 1, 0, 0 }; // width=1, height=1, mar[0]=0
+            PlantBytes(rom, MAP_OFF, LZ77.compress(marRaw));
+
+            return (rom, OBJ_OFF, PAL_OFF, CFG_OFF, MAP_OFF);
+        }
+
+        static void PlantBytes(ROM rom, uint offset, byte[] bytes)
+        {
+            if (bytes == null) return;
+            Array.Copy(bytes, 0, rom.Data, offset, bytes.Length);
+        }
+    }
+}

--- a/FEBuilderGBA.Core/MapRenderCore.cs
+++ b/FEBuilderGBA.Core/MapRenderCore.cs
@@ -88,8 +88,28 @@ namespace FEBuilderGBA
         /// values that index into <paramref name="configOffset"/>.
         /// </param>
         /// <returns>
-        /// RGBA <see cref="IImage"/> of <c>width*16 × height*16</c> pixels, or
-        /// <c>null</c> on any failure.
+        /// RGBA <see cref="IImage"/> of <c>width*16 × height*16</c> pixels on success.
+        ///
+        /// Returns <c>null</c> when:
+        /// <list type="bullet">
+        ///   <item><description><paramref name="rom"/> is <c>null</c> or
+        ///   <c>rom.Data</c> is <c>null</c>.</description></item>
+        ///   <item><description><see cref="CoreState.ImageService"/> is
+        ///   <c>null</c>.</description></item>
+        ///   <item><description>Any of the four LZ77-compressed streams
+        ///   (<paramref name="objOffset"/>, <paramref name="configOffset"/>,
+        ///   <paramref name="mapOffset"/>) is truncated, has a zero compressed
+        ///   size, or decompresses to an empty result.</description></item>
+        ///   <item><description>The decompressed map data has zero
+        ///   <c>width</c> or <c>height</c>.</description></item>
+        /// </list>
+        ///
+        /// When an individual MAR tile's config descriptor index is out of range,
+        /// that tile is <b>skipped</b> (left as zero-filled blank), and a partial
+        /// image is still returned.  This differs from WF
+        /// <c>ImageUtilMap.DrawMap</c>, which bails to <c>BlankDummy()</c>
+        /// (blanks the whole map) on the first such tile; see the divergence note
+        /// in the implementation body.
         /// </returns>
         public static IImage RenderMapImage(ROM rom, uint objOffset, uint paletteOffset,
             uint configOffset, uint mapOffset)
@@ -100,7 +120,7 @@ namespace FEBuilderGBA
             }
             catch (Exception ex)
             {
-                Log.Error("MapRenderCore.RenderMapImage exception: " + ex.Message);
+                Log.Error($"MapRenderCore.RenderMapImage failed: {ex}");
                 return null;
             }
         }
@@ -114,7 +134,10 @@ namespace FEBuilderGBA
             uint configOffset, uint mapOffset)
         {
             // --- Guard 1: null checks ---
-            if (rom == null || rom.Data == null || rom.RomInfo == null) return null;
+            // rom.RomInfo is intentionally NOT checked: RenderMapImage only uses
+            // rom.Data + the explicit offsets passed by the caller, so synthetic/unknown
+            // ROMs with valid offsets and Data can render without a matched RomInfo.
+            if (rom == null || rom.Data == null) return null;
             if (CoreState.ImageService == null) return null;
 
             // --- Step 2 (MR3): OBJ tiles — LZ77 raw bytes ---
@@ -188,12 +211,16 @@ namespace FEBuilderGBA
 
                 if (descOff + 7 >= configUZ.Length)
                 {
-                    // Out-of-bounds config descriptor: treat as zeros (do NOT
-                    // throw). WF DrawMap returns BlankDummy here; we skip the tile
-                    // so the canvas stays zero-initialized (all-zero TSA entries
-                    // map to tile 0, palette bank 0, no flip — benign blank tile).
-                    // This matches the plan's "treat as 0/skip — match WF" note
-                    // while avoiding abrupt null return mid-render.
+                    // DIVERGENCE from WF: WF `ImageUtilMap.DrawMap` (line 284-287)
+                    // calls `return ImageUtil.BlankDummy()` when a tile's descriptor
+                    // offset is out of range, blanking the ENTIRE map output.
+                    // For a read-only preview we instead skip only the offending tile
+                    // (the zero-initialized canvas slot stays zero, mapping to
+                    // tile 0, palette bank 0, no flip — a benign blank tile) and
+                    // continue rendering the rest of the map.  A partial image is
+                    // more useful than a fully-blank preview for a single corrupt
+                    // descriptor.  Each tile writes to independent subtile slots, so
+                    // skipping one tile cannot corrupt the rest of the render.
                 }
                 else
                 {

--- a/FEBuilderGBA.Core/MapRenderCore.cs
+++ b/FEBuilderGBA.Core/MapRenderCore.cs
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Cross-platform chapter-map composite render (NV6-PR1, issue #855).
+//
+// WinForms reference (FEBuilderGBA/ImageUtilMap.cs):
+//   * DrawMap (~L230-323): LZ77-decode OBJ tiles (raw bytes), RAW-read 512-byte
+//     palette (16 banks × 16 colors × 2), LZ77-decode config chipset, LZ77-decode
+//     map data; build expanded ushort[] TSA array then call ImageUtil.BitBltTSA.
+//   * DrawMapChipOnly (~L21-90): LZ77-decode OBJ bytes + RAW palette;
+//     optional OBJ2 appended (FE7 only, obj_plist high byte — see MR4 note below).
+//   * UnLZ77ChipsetData (~L93-107): LZ77-decompress the config stream.
+//   * UnLZ77MapData (~L179-193): LZ77-decompress the map data stream.
+//
+// Algorithm divergence from WF DrawMap (by plan-review corrections):
+//   MR1: config byte-offset = m << 1 (WF identical: tile_tsa_index = m << 1).
+//   MR3: OBJ tiles = RAW LZ77-decompressed bytes; do NOT pass through
+//        LoadROMTiles4bpp (which returns IImage, not byte[]).
+//   MR4 (deferred): FE7 has an optional second OBJ tileset (obj2, encoded in the
+//        high byte of obj_plist) that is U.ArrayAppend-ed onto the primary bytes
+//        before the final render in WF DrawMapChipOnly. PR1 takes a SINGLE
+//        objOffset. A follow-up PR should add obj2Offset + Array.concat before
+//        DecodeTSA when the caller resolves a non-zero obj2 plist.
+//   MR5: opaqueIndex0 = true; GBA map tiles are an opaque background — palette
+//        index 0 renders as the real palette color (alpha 255), not transparent.
+//        WF BitBltTSA calls BitBlt with transparent_index=0xFF, which never
+//        matches a 4-bit index (0..15), so all pixels including index 0 are
+//        blitted opaque.
+//
+// LZ77 truncation guard pattern mirrors ImageTSAEditorCore.TryLoadTSATileAndPalette
+// (PR #818/#819): isSafetyOffset + getCompressedSize == 0 check +
+// end-of-ROM bound check BEFORE decompress, to avoid silent zero-fill on truncated
+// streams.
+
+using System;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Cross-platform chapter-map tile composite renderer (issue #855, NV6-PR1).
+    /// Ports WinForms <c>ImageUtilMap.DrawMap</c> to the Core library using
+    /// <see cref="ImageUtilCore.DecodeTSA"/> with <c>opaqueIndex0=true</c>.
+    ///
+    /// <para><b>FE7 OBJ2 deferred (MR4):</b> FE7 maps may specify a second OBJ
+    /// tileset (encoded in the high byte of <c>obj_plist</c>) that WF appends
+    /// via <c>U.ArrayAppend</c> before the render. This PR takes a single
+    /// <paramref name="objOffset"/>. A follow-up must add an <c>obj2Offset</c>
+    /// parameter and concat the two byte arrays before calling
+    /// <see cref="ImageUtilCore.DecodeTSA"/> when the caller supplies a valid
+    /// second tileset offset.</para>
+    /// </summary>
+    public static class MapRenderCore
+    {
+        // 16 palette banks × 16 colors × 2 bytes each = 512 bytes.
+        const int PALETTE_BYTES = 16 * 16 * 2;
+
+        // GBA LZ77 stream header is 4 bytes (0x10 marker + 3-byte uncompressed size).
+        const int LZ77_HEADER_BYTES = 4;
+
+        /// <summary>
+        /// Composite a full chapter-map image from its four already-resolved ROM
+        /// data offsets, mirroring WinForms <c>ImageUtilMap.DrawMap</c>.
+        ///
+        /// <para><b>Returned image dimensions:</b>
+        /// <c>width * 16 × height * 16</c> pixels, where
+        /// <c>width</c>/<c>height</c> are the logical tile counts stored in the
+        /// first two bytes of the decompressed map data.</para>
+        ///
+        /// <para><b>Never throws.</b> Returns <c>null</c> on any null/out-of-bounds/
+        /// corrupt input or missing <see cref="CoreState.ImageService"/>.</para>
+        /// </summary>
+        /// <param name="rom">Loaded ROM (read-only; never written).</param>
+        /// <param name="objOffset">
+        /// ROM offset of the LZ77-compressed OBJ tile data (primary tileset only;
+        /// see MR4 note in the file header for FE7 obj2 deferral).
+        /// </param>
+        /// <param name="paletteOffset">
+        /// ROM offset of the RAW (uncompressed) 512-byte palette block
+        /// (16 banks × 16 colors × 2 bytes, BGR555 little-endian).
+        /// </param>
+        /// <param name="configOffset">
+        /// ROM offset of the LZ77-compressed config (chipset descriptor) data.
+        /// Each logical-tile descriptor is 8 bytes: four u16 TSA entries
+        /// (lefttop, righttop, leftbottom, rightbottom).
+        /// </param>
+        /// <param name="mapOffset">
+        /// ROM offset of the LZ77-compressed map arrangement data. The first two
+        /// bytes of the decompressed stream are <c>width</c> and <c>height</c>
+        /// in logical tiles; the remainder is a width×height array of u16 MAR
+        /// values that index into <paramref name="configOffset"/>.
+        /// </param>
+        /// <returns>
+        /// RGBA <see cref="IImage"/> of <c>width*16 × height*16</c> pixels, or
+        /// <c>null</c> on any failure.
+        /// </returns>
+        public static IImage RenderMapImage(ROM rom, uint objOffset, uint paletteOffset,
+            uint configOffset, uint mapOffset)
+        {
+            try
+            {
+                return RenderMapImageCore(rom, objOffset, paletteOffset, configOffset, mapOffset);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("MapRenderCore.RenderMapImage exception: " + ex.Message);
+                return null;
+            }
+        }
+
+        // =====================================================================
+        // Internal implementation — same contract as the public surface above,
+        // but allowed to throw (the public wrapper catches all exceptions).
+        // =====================================================================
+
+        static IImage RenderMapImageCore(ROM rom, uint objOffset, uint paletteOffset,
+            uint configOffset, uint mapOffset)
+        {
+            // --- Guard 1: null checks ---
+            if (rom == null || rom.Data == null || rom.RomInfo == null) return null;
+            if (CoreState.ImageService == null) return null;
+
+            // --- Step 2 (MR3): OBJ tiles — LZ77 raw bytes ---
+            // Validate the compressed stream BEFORE decompress (truncation guard
+            // mirrors ImageTSAEditorCore.TryLoadTSATileAndPalette, PR #818/#819).
+            if (!IsLZ77HeaderSafe(rom, objOffset)) return null;
+            uint objCompressedSize = LZ77.getCompressedSize(rom.Data, objOffset);
+            if (objCompressedSize == 0) return null;
+            if ((ulong)objOffset + objCompressedSize > (ulong)rom.Data.Length) return null;
+            byte[] objBytes = LZ77.decompress(rom.Data, objOffset);
+            if (objBytes == null || objBytes.Length == 0) return null;
+
+            // --- Step 3 (CORRECTION): Palette — RAW 512 bytes from passed rom ---
+            // Use the passed `rom` directly (NOT CoreState.ROM / GetPalette) so
+            // the call is authoritative on the ROM instance the caller controls.
+            if (!U.isSafetyOffset(paletteOffset, rom)) return null;
+            int palBytes = PALETTE_BYTES;
+            if ((ulong)paletteOffset + (ulong)palBytes > (ulong)rom.Data.Length)
+            {
+                // Clamp to ROM end (matching ImageTSAEditorCore's palette truncation
+                // tolerance — DecodeTileToPixels bounds-checks short palettes).
+                palBytes = (int)((ulong)rom.Data.Length - paletteOffset);
+            }
+            if (palBytes <= 0) return null;
+            byte[] palette = new byte[palBytes];
+            Array.Copy(rom.Data, paletteOffset, palette, 0, palBytes);
+
+            // --- Step 4: Config (chipset) — LZ77 decompress ---
+            if (!IsLZ77HeaderSafe(rom, configOffset)) return null;
+            uint cfgCompressedSize = LZ77.getCompressedSize(rom.Data, configOffset);
+            if (cfgCompressedSize == 0) return null;
+            if ((ulong)configOffset + cfgCompressedSize > (ulong)rom.Data.Length) return null;
+            byte[] configUZ = LZ77.decompress(rom.Data, configOffset);
+            if (configUZ == null || configUZ.Length == 0) return null;
+
+            // --- Step 5: Map data — LZ77 decompress; extract width/height ---
+            if (!IsLZ77HeaderSafe(rom, mapOffset)) return null;
+            uint mapCompressedSize = LZ77.getCompressedSize(rom.Data, mapOffset);
+            if (mapCompressedSize == 0) return null;
+            if ((ulong)mapOffset + mapCompressedSize > (ulong)rom.Data.Length) return null;
+            byte[] mar = LZ77.decompress(rom.Data, mapOffset);
+            if (mar == null || mar.Length < 2) return null;
+
+            int width = mar[0];  // logical tile count (TILES, not pixels)
+            int height = mar[1];
+            if (width <= 0 || height <= 0) return null;
+
+            // The u16 tile-index array starts at mar[2].
+            // Total bytes needed: 2 header + width*height u16 entries.
+            if (2 + width * height * 2 > mar.Length) return null;
+
+            // --- Step 6 (MR1): Build expanded per-subtile TSA byte[] ---
+            // Each logical tile (16×16 px) expands to 2×2 subtiles (8×8 px each),
+            // so the canvas is (width*2) × (height*2) subtiles.
+            // expandedTSA stores each subtile TSA entry as 2 bytes (little-endian).
+            int canvasW = width * 2;  // subtile columns
+            int canvasH = height * 2; // subtile rows
+            byte[] expandedTSA = new byte[canvasW * canvasH * 2];
+
+            // Iterate logical tiles using the same x/y pattern as WF DrawMap
+            // (lines 277-318) to stay bug-for-bug identical with the reference.
+            int x = 0;  // subtile x (increments by 2 per logical tile)
+            int y = 0;  // subtile y
+            for (int i = 2; i + 1 < mar.Length; i += 2)
+            {
+                // Read the MAR u16 for this logical tile (little-endian).
+                int m = mar[i] | ((int)mar[i + 1] << 8);
+
+                // MR1: config byte-offset = m << 1 (WF: tile_tsa_index = m << 1).
+                int descOff = m << 1;
+
+                if (descOff + 7 >= configUZ.Length)
+                {
+                    // Out-of-bounds config descriptor: treat as zeros (do NOT
+                    // throw). WF DrawMap returns BlankDummy here; we skip the tile
+                    // so the canvas stays zero-initialized (all-zero TSA entries
+                    // map to tile 0, palette bank 0, no flip — benign blank tile).
+                    // This matches the plan's "treat as 0/skip — match WF" note
+                    // while avoiding abrupt null return mid-render.
+                }
+                else
+                {
+                    // Read four u16 subtile TSA descriptors (already in GBA TSA
+                    // format: bits 0-9 = tile index, 10 = hflip, 11 = vflip,
+                    // 12-15 = palette bank).
+                    ushort lt = (ushort)(configUZ[descOff]     | (configUZ[descOff + 1] << 8));
+                    ushort rt = (ushort)(configUZ[descOff + 2] | (configUZ[descOff + 3] << 8));
+                    ushort lb = (ushort)(configUZ[descOff + 4] | (configUZ[descOff + 5] << 8));
+                    ushort rb = (ushort)(configUZ[descOff + 6] | (configUZ[descOff + 7] << 8));
+
+                    // Write into expandedTSA at the four subtile positions.
+                    // Subtile (sx, sy) -> byte offset (sy * canvasW + sx) * 2.
+                    WriteTSAEntry(expandedTSA, canvasW, x,     y,     lt);
+                    WriteTSAEntry(expandedTSA, canvasW, x + 1, y,     rt);
+                    WriteTSAEntry(expandedTSA, canvasW, x,     y + 1, lb);
+                    WriteTSAEntry(expandedTSA, canvasW, x + 1, y + 1, rb);
+                }
+
+                // Advance x/y exactly as WF DrawMap (lines 308-317).
+                x += 2;
+                if (x >= canvasW)
+                {
+                    x = 0;
+                    y += 2;
+                    if (y >= canvasH)
+                        break;
+                }
+            }
+
+            // --- Step 7 (MR5): Composite via DecodeTSA with opaqueIndex0:true ---
+            // DecodeTSA signature (confirmed from ImageUtilCore.cs):
+            //   DecodeTSA(byte[] tileData, byte[] tsaData, byte[] gbaPalette,
+            //             int screenWidthTiles, int screenHeightTiles,
+            //             bool is4bpp = true, int tsaOffset = 0,
+            //             bool opaqueIndex0 = false)
+            // 7th arg = tsaOffset (pass 0 — our expandedTSA starts at index 0).
+            // 8th arg = opaqueIndex0 (pass true — maps are opaque backgrounds).
+            return ImageUtilCore.DecodeTSA(objBytes, expandedTSA, palette,
+                canvasW, canvasH, is4bpp: true, tsaOffset: 0, opaqueIndex0: true);
+        }
+
+        // =====================================================================
+        // Private helpers
+        // =====================================================================
+
+        /// <summary>
+        /// Write a 16-bit TSA entry as little-endian bytes into <paramref name="tsaBuffer"/>
+        /// at the position corresponding to subtile (<paramref name="sx"/>, <paramref name="sy"/>).
+        /// Bounds-checks silently (out-of-range writes are no-ops).
+        /// </summary>
+        static void WriteTSAEntry(byte[] tsaBuffer, int canvasWidthTiles, int sx, int sy, ushort entry)
+        {
+            int byteOff = (sy * canvasWidthTiles + sx) * 2;
+            if ((uint)(byteOff + 1) >= (uint)tsaBuffer.Length) return;
+            tsaBuffer[byteOff]     = (byte)(entry & 0xFF);
+            tsaBuffer[byteOff + 1] = (byte)(entry >> 8);
+        }
+
+        /// <summary>
+        /// True when the 4-byte GBA LZ77 stream header starting at
+        /// <paramref name="addr"/> fits within the ROM data.
+        /// <c>LZ77.getCompressedSize</c> reads <c>input[offset+3]</c> but only
+        /// rejects fewer-than-3-byte tails, so a 1-3 byte tail passes isSafetyOffset
+        /// yet makes the header read throw. Require the full 4-byte header to be
+        /// in-bounds BEFORE any LZ77 call. Mirrors ImageTSAEditorCore.IsLZ77HeaderSafe
+        /// (#818).
+        /// </summary>
+        static bool IsLZ77HeaderSafe(ROM rom, uint addr) =>
+            U.isSafetyOffset(addr, rom) &&
+            (ulong)addr + LZ77_HEADER_BYTES <= (ulong)rom.Data.Length;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `FEBuilderGBA.Core/MapRenderCore.cs` — a new cross-platform, read-only chapter-map render primitive
- `public static IImage RenderMapImage(ROM rom, uint objOffset, uint paletteOffset, uint configOffset, uint mapOffset)` composites a full chapter map (`width*16 × height*16` px), returns `null` on any failure, **never throws**
- Ports WinForms `ImageUtilMap.DrawMap` faithfully with all five plan-review corrections (MR1/MR3/MR4/MR5) applied
- Core-only change — no Avalonia/WinForms/GUI files touched, no `.png` files

**Algorithm corrections applied:**
- **MR1**: config byte-offset = `m << 1` (identical to WF `tile_tsa_index = m << 1`)
- **MR3**: OBJ tiles = raw LZ77-decompressed `byte[]`; NOT `LoadROMTiles4bpp` (which returns `IImage`)
- **MR4** (deferred): FE7 obj2 second tileset documented as follow-up; PR1 takes a single `objOffset` parameter
- **MR5**: `opaqueIndex0: true` — map is an opaque background; WF `BitBltTSA` uses `transparent_index=0xFF` which never matches a 4-bit index so index 0 is opaque

**DecodeTSA signature used (confirmed from source):**
```csharp
ImageUtilCore.DecodeTSA(byte[] tileData, byte[] tsaData, byte[] gbaPalette,
    int screenWidthTiles, int screenHeightTiles, bool is4bpp = true,
    int tsaOffset = 0, bool opaqueIndex0 = false)
```
7th arg = `tsaOffset` = 0 (expandedTSA starts at index 0). 8th arg = `opaqueIndex0` = `true`.

Closes #855

## Test plan

- [x] `MapRenderCoreTests.cs` — 13 new tests, all pass
- [x] Real-ROM integration: FE6/FE7U/FE8U map-0 renders (skips gracefully when ROMs absent)
- [x] Dimension assert: result width = `mapWidth*16`, height = `mapHeight*16`
- [x] MR5 guard: bank-0/index-0 pixel is OPAQUE (alpha 255, color from palette[bank0][0])
- [x] Null ROM → null (no throw)
- [x] Missing `ImageService` → null (no throw)
- [x] Truncated OBJ LZ77 stream → null
- [x] Truncated config LZ77 stream → null
- [x] Truncated MAR LZ77 stream → null
- [x] `width/height == 0` → null
- [x] Near-EOF offsets → no throw
- [x] Out-of-range config `descOff` → no throw, partial canvas returned
- [x] `Core.Tests`: 2357 pass (was 2344, +13 new), 0 fail
- [x] `Avalonia.Tests`: 7255 pass, 0 fail, 3 pre-existing skips
- [x] Build: Core + CLI + SkiaSharp + Avalonia — 0 errors
- [x] `scripts/validate-automation-ids.ps1` — VALIDATION PASSED
- [x] No GUI changed — no GUI Test Report / screenshot required (Core-only PR)
- [x] ROM versions covered: FE6, FE7U, FE8U (all present in `roms/`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code) v2.1.156 (model: claude-sonnet-4-6)