### PR TITLE
feat(avalonia): Event Map Change List Expand (closes #862)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/EventMapChangeListExpandTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/EventMapChangeListExpandTests.cs
@@ -1,0 +1,552 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #862 — EventMapChange "List Expand" wiring tests.
+//
+// Proves the previously-inert ListExpands_Click stub now grows the 12-byte
+// map-change record list via
+//   EventMapChangeViewModel.ExpandEventMapChangeList
+//     -> DataExpansionCore.ExpandTableTo   (move + copy + 0xFFFFFFFF terminator
+//                                            + wipe old + single-slot repoint of
+//                                            the canonical PLIST pointer)
+//     -> DataExpansionCore.RepointAllReferences (raw 32-bit pointers + ARM-Thumb
+//                                            LDR literal-pool loads to the old base)
+// mirroring WF InputFormRef.ExpandsArea -> MoveToFreeSapceForm.SearchPointer's
+// all-reference rescan (NV1a all-reference pattern from WorldMapImageListExpandTests).
+//
+// CORRECTION G2a-1: the pointerSlot captured from GetMapChangeAddrWhereMapID
+//   is passed as the `pointerAddr` argument to ExpandTableTo so the PLIST entry
+//   (not just an arbitrary raw-pointer slot) is correctly repointed.
+// CORRECTION G2a-2: RepointAllReferences then repoints all OTHER raw/LDR refs.
+// CORRECTION G2a-4: refusal cases (no map, empty list, count 0, unterminated).
+//
+// The NV1a assertion: plant a SECOND raw pointer AND an ARM LDR literal-pool
+// load to the same oldBase and assert both are repointed to newBase (same as
+// WorldMapImageListExpandTests "AllThreeRefs" assertion). This distinguishes the
+// all-reference repoint from single-slot.
+//
+// Test ROM construction: synthetic FE8U (header "BE8E01", 16 MB) using the same
+// MakeSyntheticFe8uRomWithOneMapAndChangeData helper pattern from
+// EventMapChangeParityTests, extended with a free region + secondary refs.
+//
+// Marked [Collection("SharedState")] because the tests mutate CoreState.ROM /
+// CoreState.Undo (matches the sibling suites).
+using System;
+using System.IO;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests.GapSweep;
+
+[Collection("SharedState")]
+public class EventMapChangeListExpandTests : IDisposable
+{
+    const uint SIZE = 12u; // 12-byte map-change record
+
+    // Synthetic-ROM layout constants (all ROM offsets; GBA pointers add 0x08000000).
+    // Map setting at 0x800000, CHANGE plist table at 0x880000, plist[3] -> TableBase.
+    const uint TableBase   = 0x00900000u;  // change-data block (the table we expand)
+    const uint FreeRegion  = 0x00980000u;  // known 0xFF run -> ExpandTableTo lands here
+    const uint RawSlot     = 0x00004000u;  // SECOND raw 32-bit pointer to TableBase
+    const uint LdrInstr    = 0x00005000u;  // ARM Thumb LDR r0,[pc,#0] (0x4800)
+    const uint LdrSlot     = LdrInstr + 4; // its literal-pool slot
+
+    const byte MapChangePlist = 3;         // the plist index used for map 0
+
+    readonly ROM? _savedRom;
+    readonly Undo? _savedUndo;
+
+    public EventMapChangeListExpandTests()
+    {
+        _savedRom = CoreState.ROM;
+        _savedUndo = CoreState.Undo;
+    }
+
+    public void Dispose()
+    {
+        CoreState.ROM = _savedRom;
+        CoreState.Undo = _savedUndo;
+    }
+
+    // ------------------------------------------------------------------
+    // Happy-path: expand N -> N+k, verify count/terminator/rows/all-refs.
+    // This is the NV1a assertion (canonical PLIST slot + raw + LDR).
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void ExpandEventMapChangeList_GrowsCount_WritesTerminator_CopiesRows_RepointsAllThreeRefs()
+    {
+        ROM rom = MakeRom();
+        CoreState.ROM = rom;
+        CoreState.Undo = new Undo();
+
+        const int currentCount = 3;
+        PlantChangeTable(rom, TableBase, currentCount);
+        PlantSecondaryRefs(rom, TableBase);
+        PlantFreeRegion(rom, FreeRegion, 0x4000);
+
+        // Resolve the PLIST slot so we can verify the canonical repoint.
+        uint pointerSlot;
+        uint changeAddr = MapChangeCore.GetMapChangeAddrWhereMapID(rom, 0u, out pointerSlot);
+        Assert.Equal(TableBase, changeAddr);
+        Assert.NotEqual(U.NOT_FOUND, pointerSlot);
+
+        // Sanity: all three references resolve to TableBase before expand.
+        Assert.Equal(TableBase, rom.p32(pointerSlot));
+        Assert.Equal(TableBase, rom.p32(RawSlot));
+        Assert.Equal(TableBase, rom.p32(LdrSlot));
+
+        var vm = new EventMapChangeViewModel();
+        bool loaded = vm.LoadEntryForMap(0u);
+        Assert.True(loaded, "VM must load the change entry for map 0");
+        Assert.Equal(currentCount, vm.ReadCount);
+
+        const uint newCount = (uint)(currentCount + 2); // delta = +2
+        string err = Expand(vm, newCount);
+        Assert.Equal("", err);
+
+        // NOTE B: NewCount honored on the VM — no re-scan undercount.
+        Assert.Equal((int)newCount, vm.ReadCount);
+        uint newBase = vm.ReadStartAddress;
+        Assert.NotEqual(TableBase, newBase);
+
+        // The list (built WITHOUT re-scanning) shows the full count.
+        var after = vm.BuildChangeListForCount(newBase, vm.ReadCount);
+        Assert.Equal((int)newCount, after.Count);
+
+        // 0xFFFFFFFF terminator at newBase + newCount*12.
+        uint termAddr = newBase + newCount * SIZE;
+        Assert.Equal(0xFFFFFFFFu, rom.u32(termAddr));
+
+        // Existing rows copied verbatim (distinct per-row marker byte at offset 0).
+        for (int i = 0; i < currentCount; i++)
+        {
+            uint a = newBase + (uint)(i * (int)SIZE);
+            Assert.Equal((uint)(i + 1), rom.u8(a)); // row marker
+        }
+        // New rows are zero-filled.
+        for (int i = currentCount; i < (int)newCount; i++)
+        {
+            uint a = newBase + (uint)(i * (int)SIZE);
+            Assert.Equal(0u, rom.u8(a));
+        }
+
+        // ALL THREE references now point at the new base (NV1a assertion).
+        Assert.Equal(newBase, rom.p32(pointerSlot)); // canonical PLIST slot (ExpandTableTo)
+        Assert.Equal(newBase, rom.p32(RawSlot));     // raw secondary (RepointAllReferences)
+        Assert.Equal(newBase, rom.p32(LdrSlot));     // LDR literal (RepointAllReferences)
+    }
+
+    [Fact]
+    public void ExpandEventMapChangeList_Rollback_RestoresAllThreeRefs_AndOldRegion()
+    {
+        ROM rom = MakeRom();
+        CoreState.ROM = rom;
+        CoreState.Undo = new Undo();
+
+        const int currentCount = 3;
+        PlantChangeTable(rom, TableBase, currentCount);
+        PlantSecondaryRefs(rom, TableBase);
+        PlantFreeRegion(rom, FreeRegion, 0x4000);
+
+        uint pointerSlot;
+        MapChangeCore.GetMapChangeAddrWhereMapID(rom, 0u, out pointerSlot);
+
+        byte[] oldRegion = rom.getBinaryData(TableBase, (uint)(currentCount * (int)SIZE));
+
+        var vm = new EventMapChangeViewModel();
+        vm.LoadEntryForMap(0u);
+        Assert.Equal(currentCount, vm.ReadCount);
+
+        string err = Expand(vm, (uint)(currentCount + 2));
+        Assert.Equal("", err);
+        Assert.NotEqual(TableBase, rom.p32(pointerSlot)); // moved away
+
+        CoreState.Undo.RunUndo();
+
+        // Every reference restored to the old base.
+        Assert.Equal(TableBase, rom.p32(pointerSlot));
+        Assert.Equal(TableBase, rom.p32(RawSlot));
+        Assert.Equal(TableBase, rom.p32(LdrSlot));
+        // Old region bytes restored verbatim (ExpandTableTo had wiped them to 0x00).
+        Assert.Equal(oldRegion, rom.getBinaryData(TableBase, (uint)(currentCount * (int)SIZE)));
+    }
+
+    // ------------------------------------------------------------------
+    // NOTE A — a CLEAN ROM (only the canonical PLIST pointer, no secondary
+    // refs) expands successfully; RepointAllReferences returns 0 (no further
+    // slots) and that is NOT treated as a rollback. NewCount is set.
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void ExpandEventMapChangeList_CleanRom_NoSecondaryRefs_SucceedsWithZeroRepoint_AndSetsNewCount()
+    {
+        ROM rom = MakeRom();
+        CoreState.ROM = rom;
+        CoreState.Undo = new Undo();
+
+        const int currentCount = 2;
+        PlantChangeTable(rom, TableBase, currentCount);
+        // Deliberately NO secondary references (only the canonical PLIST slot).
+        PlantFreeRegion(rom, FreeRegion, 0x2000);
+
+        uint pointerSlot;
+        uint changeAddr = MapChangeCore.GetMapChangeAddrWhereMapID(rom, 0u, out pointerSlot);
+        Assert.Equal(TableBase, changeAddr);
+
+        var vm = new EventMapChangeViewModel();
+        vm.LoadEntryForMap(0u);
+        Assert.Equal(currentCount, vm.ReadCount);
+
+        const uint newCount = (uint)(currentCount + 1);
+        string err = Expand(vm, newCount);
+
+        // Expand succeeded despite RepointAllReferences returning 0 (NOTE A).
+        Assert.Equal("", err);
+        Assert.Equal((int)newCount, vm.ReadCount); // NOTE B: set from result
+        uint newBase = vm.ReadStartAddress;
+        Assert.NotEqual(TableBase, newBase);
+        // The canonical pointer resolves to the new base — not orphaned.
+        Assert.Equal(newBase, rom.p32(pointerSlot));
+
+        // Cross-check: a direct RepointAllReferences for the now-stale oldBase
+        // (post-move) finds no references and returns 0 without throwing.
+        int n = DataExpansionCore.RepointAllReferences(rom, TableBase, newBase, null);
+        Assert.Equal(0, n);
+    }
+
+    // ------------------------------------------------------------------
+    // Refusal cases (CORRECTION G2a-4) — NO mutation must occur.
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void ExpandEventMapChangeList_NoMapSelected_ReturnsError()
+    {
+        ROM rom = MakeRom();
+        CoreState.ROM = rom;
+        CoreState.Undo = new Undo();
+
+        // Do NOT call LoadEntryForMap — _currentMapId stays uint.MaxValue.
+        var vm = new EventMapChangeViewModel();
+        byte[] snap = (byte[])rom.Data.Clone();
+
+        var ud = CoreState.Undo.NewUndoData("test");
+        string err = vm.ExpandEventMapChangeList(5u, ud);
+        Assert.False(string.IsNullOrEmpty(err), "Should refuse with no map selected");
+        // ROM must not be mutated.
+        Assert.Equal(snap, rom.Data);
+    }
+
+    [Fact]
+    public void ExpandEventMapChangeList_EmptyList_FirstByteFF_ReturnsError()
+    {
+        ROM rom = MakeRom();
+        CoreState.ROM = rom;
+        CoreState.Undo = new Undo();
+
+        // Plant the plist entry pointing at TableBase, but plant 0xFF as first byte
+        // (empty list marker per WF predicate).
+        PlantChangeTable(rom, TableBase, 0); // 0 rows -> first byte is left as default 0xFF
+        rom.Data[(int)TableBase] = 0xFF; // explicit empty marker
+
+        var vm = new EventMapChangeViewModel();
+        // Must still load so _currentMapId is set.
+        // Because first byte is 0xFF, LoadEntryForMap will return false (plist
+        // resolves but first byte fails the validity check inside LoadEntryForMap).
+        // However our ExpandEventMapChangeList must also refuse when it resolves
+        // the address and finds 0xFF at the start.
+        // We need to force the VM into "map selected but empty list" state.
+        // Direct the CoreState.ROM to answer 0xFF at the change address.
+        // Since LoadEntryForMap will return false (0xFF check in LoadEventMapChangeList),
+        // we call it, then force _currentMapId via a workaround: call LoadEntryForMap
+        // which sets _currentMapId internally even on failure in some paths.
+        // Actually the WF form and our ExpandEventMapChangeList both guard independently.
+        // The simplest way: plant a record with 0x00 first byte for LoadEntryForMap,
+        // then mutate ROM to 0xFF after loading.
+        rom.Data[(int)TableBase] = 0x01; // temporarily valid
+        bool loaded = vm.LoadEntryForMap(0u);
+        // Now force 0xFF at the start (simulating a post-load situation).
+        rom.Data[(int)TableBase] = 0xFF;
+
+        byte[] snap = (byte[])rom.Data.Clone();
+        var ud = CoreState.Undo.NewUndoData("test");
+        string err = vm.ExpandEventMapChangeList(5u, ud);
+        Assert.False(string.IsNullOrEmpty(err), "Should refuse when first byte is 0xFF (empty list)");
+        // ROM must not be mutated (no ExpandTableTo called).
+        Assert.Equal(snap, rom.Data);
+    }
+
+    [Fact]
+    public void ExpandEventMapChangeList_Unterminated_ReturnsError_NoMutation()
+    {
+        ROM rom = MakeRom();
+        CoreState.ROM = rom;
+        CoreState.Undo = new Undo();
+
+        // Plant 257 rows with no 0xFF terminator (all first bytes != 0xFF).
+        // The 256-row scan cap will be hit without finding a terminator.
+        // We only need to fill enough to guarantee no 0xFF within 256 rows.
+        uint addr = TableBase;
+        for (int i = 0; i < 260; i++)
+        {
+            if (addr + SIZE <= (uint)rom.Data.Length)
+            {
+                rom.Data[(int)addr] = 0x01; // non-0xFF first byte
+                addr += SIZE;
+            }
+        }
+        PlantPlistPointer(rom, TableBase);
+
+        var vm = new EventMapChangeViewModel();
+        vm.LoadEntryForMap(0u);
+
+        byte[] snap = (byte[])rom.Data.Clone();
+        var ud = CoreState.Undo.NewUndoData("test");
+        string err = vm.ExpandEventMapChangeList(10u, ud);
+        Assert.False(string.IsNullOrEmpty(err), "Should refuse when list is unterminated");
+        // ROM must not be mutated.
+        Assert.Equal(snap, rom.Data);
+    }
+
+    [Fact]
+    public void ExpandEventMapChangeList_CountZero_ReturnsError()
+    {
+        ROM rom = MakeRom();
+        CoreState.ROM = rom;
+        CoreState.Undo = new Undo();
+
+        // Plant a plist entry that resolves but has 0 valid rows (terminated immediately).
+        PlantChangeTable(rom, TableBase, 0);
+        // First byte must be 0x01 (not 0xFF) so LoadEntryForMap succeeds...
+        // but wait: 0 rows means the first byte IS 0xFF (the terminator).
+        // Since we guard 0xFF in ExpandEventMapChangeList, this case is handled
+        // by the empty-list guard. We test the count==0 guard separately by
+        // constructing a scenario where changeAddr resolves and firstByte != 0xFF
+        // but CountChangeRecordsTerminated returns 0 with terminated=true.
+        // That happens when the terminator is at address TableBase itself
+        // (first byte == 0xFF), which is already covered by the EmptyList test.
+        // In practice count==0 with terminated==true can only happen if first byte == 0xFF.
+        // The guard is belt-and-suspenders. Test it by directly calling the VM
+        // method with a loaded state that has ReadCount=0.
+        rom.Data[(int)TableBase] = 0x01; // non-0xFF so LoadEntryForMap works
+        rom.Data[(int)(TableBase + SIZE)] = 0xFF; // immediate terminator -> count=1 after one row
+        PlantPlistPointer(rom, TableBase);
+
+        var vm = new EventMapChangeViewModel();
+        vm.LoadEntryForMap(0u);
+        // ReadCount is 1 in this case. For the zero-count refusal, we'd need
+        // first byte == 0xFF, which is the empty-list test. The zero-count guard
+        // is belt-and-suspenders; instead verify the no-op equal-count path.
+        var ud = CoreState.Undo.NewUndoData("test");
+        string err = vm.ExpandEventMapChangeList((uint)vm.ReadCount, ud); // newCount == currentCount
+        Assert.Equal("", err); // no-op is still success
+    }
+
+    // ------------------------------------------------------------------
+    // Button-wiring parity: ListExpands_Click must NOT be the old stub.
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void View_ListExpands_Click_IsWiredNotStub()
+    {
+        string repoRoot = FindRepoRoot();
+        string codeBehindPath = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "EventMapChangeView.axaml.cs");
+        Assert.True(File.Exists(codeBehindPath));
+        string source = File.ReadAllText(codeBehindPath);
+
+        // The old stub contained "not yet implemented". Must be gone.
+        Assert.DoesNotContain("List expansion is not yet implemented", source);
+
+        // The new implementation must reference ExpandEventMapChangeList.
+        Assert.Contains("ExpandEventMapChangeList", source);
+
+        // Must open an undo scope.
+        Assert.Contains("_undoService.Begin(", source);
+
+        // Must call NumberInputDialog.Show.
+        Assert.Contains("NumberInputDialog.Show", source);
+    }
+
+    [Fact]
+    public void View_ListExpands_Click_HasRollbackOnError()
+    {
+        string repoRoot = FindRepoRoot();
+        string codeBehindPath = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "EventMapChangeView.axaml.cs");
+        string source = File.ReadAllText(codeBehindPath);
+
+        // The handler must rollback when an error string is returned.
+        Assert.Contains("_undoService.Rollback()", source);
+    }
+
+    // ------------------------------------------------------------------
+    // ViewModel — ExpandEventMapChangeList method exists and is public.
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_ExpandEventMapChangeList_MethodExists_IsPublic()
+    {
+        var method = typeof(EventMapChangeViewModel).GetMethod(
+            "ExpandEventMapChangeList",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(method);
+        Assert.Equal(typeof(string), method!.ReturnType);
+    }
+
+    [Fact]
+    public void ViewModel_BuildChangeListForCount_MethodExists_IsPublic()
+    {
+        var method = typeof(EventMapChangeViewModel).GetMethod(
+            "BuildChangeListForCount",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(method);
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Run the expand inside an ambient undo scope (mirrors the View's
+    /// UndoService.Begin / Commit), pushing the transaction so
+    /// CoreState.Undo.RunUndo() can roll it back.
+    /// </summary>
+    static string Expand(EventMapChangeViewModel vm, uint newCount)
+    {
+        var ud = CoreState.Undo!.NewUndoData("EventMapChange ExpandList test");
+        string err;
+        using (ROM.BeginUndoScope(ud))
+        {
+            err = vm.ExpandEventMapChangeList(newCount, ud);
+        }
+        if (string.IsNullOrEmpty(err))
+            CoreState.Undo.Push(ud);
+        return err;
+    }
+
+    /// <summary>
+    /// Build a synthetic FE8U ROM (header "BE8E01", 16 MB) with:
+    ///   - Map setting at 0x800000 with plist[11] = 3 (MapChangePlist)
+    ///   - CHANGE plist table at 0x880000 with entry 3 -> TableBase
+    ///   - TableBase left as 0xFF (caller plants change rows)
+    /// </summary>
+    static ROM MakeRom()
+    {
+        var bytes = new byte[0x1100000];
+
+        uint mapTableBase = 0x00800000u;
+        uint plistTableBase = 0x00880000u;
+
+        // Plant FE8U signature (same pattern as EventMapChangeParityTests).
+        uint[] mapSettingCandidates = { 0x0B5F98u, 0x0B61C0u, 0x0B6328u, 0x0B6500u, 0x03462Cu, 0xB5E68u };
+        foreach (var slot in mapSettingCandidates)
+            WriteU32(bytes, (int)slot, mapTableBase | 0x08000000u);
+
+        // Single map setting record at mapTableBase.
+        uint mapSettingDataSize = 148u;
+        int mapRecordBase = (int)mapTableBase;
+        WriteU32(bytes, mapRecordBase + 0, 0x08123456u); // valid pointer first dword
+        WriteU32(bytes, mapRecordBase + 4, 0x00000001u);
+        WriteU32(bytes, mapRecordBase + 8, 0x00000001u);
+        bytes[mapRecordBase + 11] = MapChangePlist; // plist byte
+        bytes[mapRecordBase + 12] = 0x00;
+
+        // Terminator at next slot.
+        int termBase = (int)(mapTableBase + mapSettingDataSize);
+        WriteU32(bytes, termBase + 0, 0x00000000u);
+        WriteU32(bytes, termBase + 4, 0x00000000u);
+        WriteU32(bytes, termBase + 8, 0x00000000u);
+        bytes[termBase + 12] = 0xFF;
+
+        // Plant CHANGE plist pointer table.
+        WriteU32(bytes, (int)0x0346ACu, plistTableBase | 0x08000000u);
+        // Entry 0/1/2 = 0; entry 3 = pointer to TableBase.
+        for (int i = 0; i < 4; i++)
+            WriteU32(bytes, (int)(plistTableBase + i * 4u), 0u);
+        WriteU32(bytes, (int)(plistTableBase + 3 * 4u), TableBase | 0x08000000u);
+
+        // TableBase left 0xFF by default (caller plants change rows).
+
+        var rom = new ROM();
+        rom.LoadLow("synth-fe8u-862.gba", bytes, "BE8E01");
+        return rom;
+    }
+
+    /// <summary>
+    /// Plant a change-data table with <paramref name="count"/> valid rows at
+    /// <paramref name="baseAddr"/>. Each row has a distinct non-0xFF first byte.
+    /// Appends a 0xFF terminator row immediately after.
+    /// </summary>
+    static void PlantChangeTable(ROM rom, uint baseAddr, int count)
+    {
+        // The canonical plist pointer was planted by MakeRom (entry 3 -> TableBase).
+        // If baseAddr differs, we need to update the plist slot.
+        // For these tests baseAddr == TableBase always, so no extra planting needed.
+        for (int i = 0; i < count; i++)
+        {
+            uint row = baseAddr + (uint)(i * (int)SIZE);
+            // Distinct non-0xFF first byte per row (used to verify copy).
+            rom.Data[(int)row] = (byte)(i + 1);
+        }
+        // 0xFF terminator after the last row.
+        rom.Data[(int)(baseAddr + (uint)(count * (int)SIZE))] = 0xFF;
+    }
+
+    /// <summary>
+    /// Re-plant the PLIST entry for MapChangePlist=3 to point at baseAddr.
+    /// Used when TableBase differs from what MakeRom planted.
+    /// </summary>
+    static void PlantPlistPointer(ROM rom, uint baseAddr)
+    {
+        uint plistTableBase = 0x00880000u;
+        PlantU32(rom, plistTableBase + MapChangePlist * 4u, U.toPointer(baseAddr));
+    }
+
+    /// <summary>
+    /// Plant a SECOND raw 32-bit pointer + an ARM Thumb LDR literal-pool load,
+    /// both referencing <paramref name="baseAddr"/>. Same pattern as
+    /// WorldMapImageListExpandTests.PlantSecondaryRefs.
+    /// </summary>
+    static void PlantSecondaryRefs(ROM rom, uint baseAddr)
+    {
+        PlantU32(rom, RawSlot, U.toPointer(baseAddr));  // raw 32-bit pointer
+        int ldrIdx = (int)LdrInstr;
+        rom.Data[ldrIdx + 0] = 0x00;  // ldr r0,[pc,#0]
+        rom.Data[ldrIdx + 1] = 0x48;  // = 0x4800
+        PlantU32(rom, LdrSlot, U.toPointer(baseAddr)); // literal-pool slot
+    }
+
+    static void PlantFreeRegion(ROM rom, uint start, int length)
+    {
+        int baseIdx = (int)start;
+        for (int i = 0; i < length; i++)
+            rom.Data[baseIdx + i] = 0xFF;
+    }
+
+    static void PlantU32(ROM rom, uint addr, uint value)
+    {
+        int idx = (int)addr;
+        rom.Data[idx + 0] = (byte)(value & 0xFF);
+        rom.Data[idx + 1] = (byte)((value >> 8) & 0xFF);
+        rom.Data[idx + 2] = (byte)((value >> 16) & 0xFF);
+        rom.Data[idx + 3] = (byte)((value >> 24) & 0xFF);
+    }
+
+    static void WriteU32(byte[] data, int offset, uint value)
+    {
+        data[offset + 0] = (byte)(value & 0xFF);
+        data[offset + 1] = (byte)((value >> 8) & 0xFF);
+        data[offset + 2] = (byte)((value >> 16) & 0xFF);
+        data[offset + 3] = (byte)((value >> 24) & 0xFF);
+    }
+
+    static string FindRepoRoot()
+    {
+        string? dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+            dir = Path.GetDirectoryName(dir);
+        if (dir == null)
+            throw new InvalidOperationException("Could not find FEBuilderGBA.sln");
+        return dir;
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/EventMapChangeListExpandTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/EventMapChangeListExpandTests.cs
@@ -308,37 +308,30 @@ public class EventMapChangeListExpandTests : IDisposable
     }
 
     [Fact]
-    public void ExpandEventMapChangeList_CountZero_ReturnsError()
+    public void ExpandEventMapChangeList_NewCountEqualsCurrent_IsNoOpSuccess()
     {
         ROM rom = MakeRom();
         CoreState.ROM = rom;
         CoreState.Undo = new Undo();
 
-        // Plant a plist entry that resolves but has 0 valid rows (terminated immediately).
+        // Set up a list with a single valid row followed by a 0xFF terminator so
+        // LoadEntryForMap succeeds and ReadCount == 1.
+        // (count-zero with first byte != 0xFF is unreachable in practice -- the
+        // count-zero refusal is belt-and-suspenders; the genuine zero-count path
+        // requires first byte == 0xFF, already covered by
+        // ExpandEventMapChangeList_EmptyList_FirstByteFF_ReturnsError.)
         PlantChangeTable(rom, TableBase, 0);
-        // First byte must be 0x01 (not 0xFF) so LoadEntryForMap succeeds...
-        // but wait: 0 rows means the first byte IS 0xFF (the terminator).
-        // Since we guard 0xFF in ExpandEventMapChangeList, this case is handled
-        // by the empty-list guard. We test the count==0 guard separately by
-        // constructing a scenario where changeAddr resolves and firstByte != 0xFF
-        // but CountChangeRecordsTerminated returns 0 with terminated=true.
-        // That happens when the terminator is at address TableBase itself
-        // (first byte == 0xFF), which is already covered by the EmptyList test.
-        // In practice count==0 with terminated==true can only happen if first byte == 0xFF.
-        // The guard is belt-and-suspenders. Test it by directly calling the VM
-        // method with a loaded state that has ReadCount=0.
         rom.Data[(int)TableBase] = 0x01; // non-0xFF so LoadEntryForMap works
         rom.Data[(int)(TableBase + SIZE)] = 0xFF; // immediate terminator -> count=1 after one row
         PlantPlistPointer(rom, TableBase);
 
         var vm = new EventMapChangeViewModel();
         vm.LoadEntryForMap(0u);
-        // ReadCount is 1 in this case. For the zero-count refusal, we'd need
-        // first byte == 0xFF, which is the empty-list test. The zero-count guard
-        // is belt-and-suspenders; instead verify the no-op equal-count path.
+        // Passing newCount == currentCount (ReadCount == 1) exercises the no-op
+        // equal-count path, which returns "" (success) without writing anything to ROM.
         var ud = CoreState.Undo.NewUndoData("test");
         string err = vm.ExpandEventMapChangeList((uint)vm.ReadCount, ud); // newCount == currentCount
-        Assert.Equal("", err); // no-op is still success
+        Assert.Equal("", err); // no-op equal-count returns success (empty error string)
     }
 
     // ------------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia/ViewModels/EventMapChangeViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EventMapChangeViewModel.cs
@@ -251,6 +251,151 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         }
 
         /// <summary>
+        /// Count map-change records starting at <paramref name="startAddr"/>
+        /// until the 0xFF terminator byte, with an explicit termination flag.
+        /// Returns true when a real 0xFF terminator was found within the 256-row
+        /// cap; false when the scan hit the cap without finding one (unterminated
+        /// list guard — CORRECTION G2a-4).
+        /// </summary>
+        static int CountChangeRecordsTerminated(ROM rom, uint startAddr, out bool terminated)
+        {
+            terminated = false;
+            if (rom == null) return 0;
+            uint romLen = (uint)rom.Data.Length;
+            int count = 0;
+            for (uint i = 0; i < 256; i++)
+            {
+                uint a = startAddr + i * SIZE;
+                if (a + SIZE > romLen) break;
+                if (rom.u8(a) == 0xFF)
+                {
+                    terminated = true;
+                    break;
+                }
+                count++;
+            }
+            return count;
+        }
+
+        /// <summary>
+        /// Expand the event map-change list for the currently selected map to
+        /// <paramref name="newCount"/> rows, using
+        /// <see cref="DataExpansionCore.ExpandTableTo"/> for the single-slot
+        /// move + copy + wipe + canonical-pointer repoint, then
+        /// <see cref="DataExpansionCore.RepointAllReferences"/> for all other
+        /// raw-pointer / ARM LDR references (NV1a all-reference pattern —
+        /// mirrors <c>WorldMapImageViewModel.ExpandTableHelper</c>).
+        ///
+        /// <para><b>Refusal conditions (CORRECTION G2a-4):</b> no map selected;
+        /// change address not found; empty list (first byte == 0xFF); count == 0;
+        /// or the list scan hit the 256-row cap without a real 0xFF terminator
+        /// (unterminated-list guard).</para>
+        ///
+        /// <para><b>NOTE A:</b> <see cref="DataExpansionCore.RepointAllReferences"/>
+        /// returning 0 is SUCCESS — <c>ExpandTableTo</c> already repointed the
+        /// canonical PLIST slot. Do NOT roll back on 0.</para>
+        ///
+        /// <para><b>NOTE B:</b> sets <see cref="ReadStartAddress"/> and
+        /// <see cref="ReadCount"/> from the <see cref="DataExpansionCore.ExpandResult"/>
+        /// directly (not by re-scanning), because zero-filled rows satisfy the
+        /// <c>firstByte != 0xFF</c> predicate and a rescan would continue to the
+        /// new terminator, correctly giving newCount — but using result.NewCount
+        /// is cleaner and avoids the ambiguity.</para>
+        ///
+        /// <para>The caller MUST open ONE ambient undo scope via
+        /// <c>UndoService.Begin</c> before invoking this method and pass the
+        /// active <see cref="Undo.UndoData"/> so both <c>ExpandTableTo</c> (ambient)
+        /// and <c>RepointAllReferences</c> (explicit) record into the same
+        /// transaction.</para>
+        /// </summary>
+        /// <param name="newCount">Target row count (must be &gt;= current count).</param>
+        /// <param name="undo">The active undo buffer from
+        /// <c>UndoService.GetActiveUndoData()</c>.</param>
+        /// <returns>Empty string on success; human-readable error otherwise.</returns>
+        public string ExpandEventMapChangeList(uint newCount, Undo.UndoData? undo)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return R._("ROM not loaded.");
+
+            // CORRECTION G2a-4: no map selected.
+            if (_currentMapId == uint.MaxValue) return R._("No map selected.");
+
+            // CORRECTION G2a-1: capture BOTH changeAddr AND pointerSlot from
+            // GetMapChangeAddrWhereMapID (previously discarded as out _).
+            uint changeAddr = MapChangeCore.GetMapChangeAddrWhereMapID(rom, _currentMapId, out uint pointerSlot);
+            if (changeAddr == U.NOT_FOUND || !U.isSafetyOffset(changeAddr, rom))
+                return R._("No change-data for the selected map (plist 0/0xFF or resolution failed).");
+
+            // CORRECTION G2a-4: empty list guard (first byte == 0xFF).
+            if (rom.u8(changeAddr) == 0xFF)
+                return R._("Cannot expand: change list is empty (first byte is 0xFF).");
+
+            // CORRECTION G2a-4: also guard the resolved pointerSlot.
+            if (pointerSlot == U.NOT_FOUND)
+                return R._("Cannot expand: the CHANGE PLIST slot could not be resolved.");
+
+            // CORRECTION G2a-4: unterminated-list guard — if the scan reaches
+            // the 256-row cap without finding a 0xFF terminator, the list is
+            // corrupt or unbounded. Refuse rather than expanding from bogus 256.
+            int currentCount = CountChangeRecordsTerminated(rom, changeAddr, out bool terminated);
+            if (!terminated)
+                return R._("Cannot expand: the change list appears unterminated (no 0xFF within 256 rows). " +
+                            "Expanding an unterminated list may corrupt the ROM.");
+
+            if (currentCount == 0)
+                return R._("Cannot expand: change list has 0 records.");
+
+            if (newCount < (uint)currentCount)
+                return R._("New count ({0}) must be >= current count ({1}).", newCount, currentCount);
+
+            if (newCount == (uint)currentCount) return ""; // no-op success
+
+            // CORRECTION G2a-1: capture the old base BEFORE the move.
+            uint oldBase = changeAddr;
+
+            // CORRECTION G2a-2 (ALL-REFERENCE — mandatory, mirrors WorldMapImageViewModel):
+            // Step 1: ExpandTableTo uses the PLIST slot (pointerSlot) as the pointer address
+            // so it repoints the canonical PLIST entry to the new base.
+            var result = DataExpansionCore.ExpandTableTo(rom, pointerSlot, SIZE, (uint)currentCount, newCount);
+            if (!result.Success)
+                return result.Error ?? R._("Table expansion failed.");
+
+            uint newBase = result.NewBaseAddress;
+
+            // Step 2: Repoint EVERY other raw-pointer / LDR reference to the old base.
+            // NOTE A: RepointAllReferences returning 0 is SUCCESS (canonical already
+            // repointed by ExpandTableTo). Do NOT roll back on 0.
+            DataExpansionCore.RepointAllReferences(rom, oldBase, newBase, undo);
+
+            // NOTE B: set the editor's read-state from the ExpandResult directly,
+            // not by re-scanning.
+            ReadStartAddress = newBase;
+            ReadCount = (int)result.NewCount;
+
+            return "";
+        }
+
+        /// <summary>
+        /// Build the change AddressList for exactly <paramref name="count"/>
+        /// rows starting at <paramref name="baseAddr"/> (an offset). Used after
+        /// an expand to render the grown list WITHOUT re-scanning past the
+        /// zero-filled new rows (NOTE B). Mirrors WorldMapImageViewModel.BuildBorderListForCount.
+        /// </summary>
+        public List<AddrResult> BuildChangeListForCount(uint baseAddr, int count)
+        {
+            var result = new List<AddrResult>();
+            ROM rom = CoreState.ROM;
+            if (rom?.Data == null || count <= 0) return result;
+            uint addr = baseAddr;
+            for (int i = 0; i < count && i < 256; i++, addr += SIZE)
+            {
+                if (addr + SIZE > (uint)rom.Data.Length) break;
+                result.Add(new AddrResult(addr, U.ToHexString(i), (uint)i));
+            }
+            return result;
+        }
+
+        /// <summary>
         /// Write the current B0-B7 + P8 fields back to ROM at
         /// <see cref="CurrentAddr"/>. The caller MUST have opened an
         /// ambient <see cref="UndoService"/> scope (the View's

--- a/FEBuilderGBA.Avalonia/Views/EventMapChangeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventMapChangeView.axaml.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Controls;
+using FEBuilderGBA.Avalonia.Dialogs;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 
@@ -262,12 +263,103 @@ namespace FEBuilderGBA.Avalonia.Views
             CoreState.Services?.ShowError("Pointer import is not yet implemented in the Avalonia editor.");
         }
 
-        void ListExpands_Click(object? sender, RoutedEventArgs e)
+        // #862 — wire the List Expand button to grow the 12-byte map-change
+        // record list via DataExpansionCore.ExpandTableTo + RepointAllReferences,
+        // mirroring WorldMapImageView.BorderListExpand_Click (NV1a all-reference
+        // pattern).
+        async void ListExpands_Click(object? sender, RoutedEventArgs e)
         {
-            // List-expansion (mirrors WF `AddressListExpandsButton`) is
-            // not yet implemented in the Avalonia editor. Same follow-up
-            // status as PointerImport above.
-            CoreState.Services?.ShowError("List expansion is not yet implemented in the Avalonia editor.");
+            try
+            {
+                if (!_vm.IsLoaded || _vm.CurrentAddr == 0)
+                {
+                    CoreState.Services?.ShowInfo(R._("Select a map with change-data before expanding."));
+                    return;
+                }
+                if (_vm.ReadCount == 0)
+                {
+                    CoreState.Services?.ShowInfo(R._("Cannot expand: change list is empty."));
+                    return;
+                }
+
+                // Default = current + 1, max 255 (mirrors WF
+                // AddressListExpandsButton_255 convention).
+                uint current = (uint)_vm.ReadCount;
+                uint defaultCount = current + 1;
+                if (defaultCount > 255) defaultCount = 255;
+                uint? chosen = await NumberInputDialog.Show(
+                    this,
+                    R._("Enter the new entry count for the event map-change list (current: {0}, max: 255).", current),
+                    R._("List Expansion"),
+                    defaultCount,
+                    current,
+                    255);
+                if (chosen == null) return; // cancelled
+                uint newCount = chosen.Value;
+                if (newCount == current)
+                {
+                    CoreState.Services?.ShowInfo(R._("No change: new count equals current count."));
+                    return;
+                }
+
+                _undoService.Begin("Expand Event Map Change List");
+                try
+                {
+                    string err = _vm.ExpandEventMapChangeList(newCount, _undoService.GetActiveUndoData());
+                    if (!string.IsNullOrEmpty(err))
+                    {
+                        _undoService.Rollback();
+                        CoreState.Services?.ShowError(err);
+                        return;
+                    }
+                    _undoService.Commit();
+                    _vm.MarkClean();
+
+                    // NOTE B: render the grown list directly from the new base +
+                    // new count (the VM already set ReadStartAddress/ReadCount from
+                    // the ExpandResult). Re-scanning would still be correct here
+                    // (zero-filled rows have firstByte==0 != 0xFF) but using the
+                    // result directly is cleaner.
+                    RefreshChangeListFromReadConfig();
+                    CoreState.Services?.ShowInfo(
+                        R._("Expanded event map-change list to {0} entries.", newCount));
+                }
+                catch (Exception inner)
+                {
+                    _undoService.Rollback();
+                    Log.Error($"EventMapChangeView.ListExpands inner failed: {inner.Message}");
+                    CoreState.Services?.ShowError(R._("List expansion failed: {0}", inner.Message));
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"EventMapChangeView.ListExpands failed: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Refresh the EntryList from the VM's post-expand read-config
+        /// (ReadStartAddress = new base offset; ReadCount = new row count)
+        /// WITHOUT re-scanning (NOTE B). Mirrors
+        /// WorldMapImageView.RefreshBorderListFromReadConfig.
+        /// </summary>
+        void RefreshChangeListFromReadConfig()
+        {
+            try
+            {
+                uint baseAddr = _vm.ReadStartAddress;
+                var items = _vm.BuildChangeListForCount(baseAddr, _vm.ReadCount);
+                EntryList.SetItems(items);
+                if (TopBar != null)
+                {
+                    TopBar.StartAddressText = $"0x{baseAddr:X08}";
+                    TopBar.ReadCountText = _vm.ReadCount.ToString();
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"EventMapChangeView.RefreshChangeListFromReadConfig failed: {ex.Message}");
+            }
         }
 
         static uint ParseHexText(string? text)


### PR DESCRIPTION
## Summary

- Wire the EventMapChange "Expand List" button (previously a stub showing "not yet implemented") to grow the 12-byte map-change record list to a user-prompted count, undoable, via `DataExpansionCore` — zero new Core code.
- Implement `EventMapChangeViewModel.ExpandEventMapChangeList` with the NV1a all-reference repoint pattern (mirrors `WorldMapImageViewModel.ExpandTableHelper`).
- Add `CountChangeRecordsTerminated` helper with an explicit `out bool terminated` flag for the unterminated-list guard (CORRECTION G2a-4).
- Add `BuildChangeListForCount` helper to refresh the entry list after expand without re-scanning zero-filled rows.
- 11 new tests in `EventMapChangeListExpandTests` covering the NV1a second-reference assertion, rollback, refusal cases, and button wiring.

Closes #862

## Implementation details

**CORRECTION G2a-1:** `GetMapChangeAddrWhereMapID` `out pointerSlot` is now captured (was `out _`) and passed as `pointerAddr` to `ExpandTableTo`, so the canonical PLIST entry is correctly single-slot repointed.

**CORRECTION G2a-2 (ALL-REFERENCE):** `RepointAllReferences(rom, oldBase, newBase, undo)` follows `ExpandTableTo`. Return of 0 = SUCCESS (ExpandTableTo already repointed the canonical slot). Same NOTE A semantics as WorldMapImage border/icon expand.

**CORRECTION G2a-4 (refusal):** Refuses before any mutation when: no map selected; `changeAddr == U.NOT_FOUND`; first byte is `0xFF` (empty list); `pointerSlot == U.NOT_FOUND`; or the 256-row scan cap is hit without a `0xFF` terminator (unterminated-list guard).

**NOTE B:** `ReadStartAddress` and `ReadCount` are set from `result.NewBaseAddress` / `result.NewCount` directly (not by re-scanning), because zero-filled rows satisfy `firstByte != 0xFF` and would give a valid rescan count equal to `newCount` — but using the result directly is cleaner and avoids ambiguity.

## Test plan

- [x] Build: Core, CLI, SkiaSharp, Avalonia — 0 errors
- [x] `dotnet test FEBuilderGBA.Core.Tests` — 2378 passed, 0 failed
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` — 7270 passed, 3 skipped (pre-existing), 0 failed
- [x] `scripts/validate-automation-ids.ps1` — VALIDATION PASSED (0 duplicate IDs, 0 naming errors)
- [x] `ExpandEventMapChangeList_GrowsCount_WritesTerminator_CopiesRows_RepointsAllThreeRefs` — canonical PLIST slot + SECOND raw pointer + ARM LDR literal-pool all repointed to newBase (NV1a assertion)
- [x] `ExpandEventMapChangeList_Rollback_RestoresAllThreeRefs_AndOldRegion` — rollback restores canonical PLIST, raw, LDR, and old region bytes
- [x] `ExpandEventMapChangeList_CleanRom_NoSecondaryRefs_SucceedsWithZeroRepoint_AndSetsNewCount` — NOTE A: RepointAllReferences returning 0 is not treated as failure; NOTE B: NewCount set on VM
- [x] `ExpandEventMapChangeList_NoMapSelected_ReturnsError` — refusal, no mutation
- [x] `ExpandEventMapChangeList_EmptyList_FirstByteFF_ReturnsError` — refusal, no mutation
- [x] `ExpandEventMapChangeList_Unterminated_ReturnsError_NoMutation` — refusal, no mutation
- [x] `View_ListExpands_Click_IsWiredNotStub` — button handler references `ExpandEventMapChangeList`, `NumberInputDialog.Show`, `_undoService.Begin`
- [x] `View_ListExpands_Click_HasRollbackOnError` — handler rollbacks on error

## GUI Test Report

| Test | Result | Notes |
|------|--------|-------|
| App launches with FE8U.gba | N/A | MCP screen locked at test time |
| Event Map Change editor opens | N/A | MCP screen locked at test time |
| List Expand button visible | PASS (structural) | AutomationId `EventMapChange_ListExpands_Button` confirmed in AXAML |
| List Expand button wired (not stub) | PASS | Test `View_ListExpands_Click_IsWiredNotStub` |
| Undo/rollback path wired | PASS | Test `View_ListExpands_Click_HasRollbackOnError` |

MCP screen was locked at GUI test time. Functional proof via 11/11 test-suite assertions.

## Screenshots

Real EventMapChange editor render via Avalonia `--screenshot-all` / `RenderTargetBitmap` (locked-screen-safe, NOT a screen grab):

![EventMapChange editor with List Expand button](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr862-eventmapchange-listexpand.png)

The PNG shows the actual EventMapChangeView visual tree: Map Names list (FE8U chapter names), Map Change Event Editor panel (Address, Number, Coordinates, Size, Change Data Pointer, Comment fields), Names list with 49 items, and the **Expand List (+1 slot)** button visible in the bottom-right panel.

Capture used `RenderTargetBitmap` which renders the Avalonia visual tree off-screen — it works even when the desktop screen is locked. The 11 logic tests (incl. the all-reference second-ref + rollback) are the behavioral proof; this render confirms the editor UI and button are present.

(Committed via docs PR #863.)

---
Generated with Claude Code v2.1.156 (model: claude-sonnet-4-6, Sonnet 4.6)
