### PR TITLE
feat(avalonia): Event Conditions Precise PLIST alloc + commit-back (closes #865)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/EventCondParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/EventCondParityTests.cs
@@ -1390,6 +1390,89 @@ public class EventCondParityTests
             source);
     }
 
+
+    // -----------------------------------------------------------------
+    // PR #867 review fixes: PreciseAlloc_Click navigation + GetPlistLimit DRY
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_PreciseAllocClick_SetsEventDataAddrToAllocatedOffset()
+    {
+        // FIX 1 (#867): After a successful AllocNewEventCondBlock +
+        // WriteEventPLIST, PreciseAlloc_Click must set _vm.EventDataAddr = off
+        // (the newly-allocated block) so ReloadRecordList shows the new block's
+        // slots rather than "No event data for this map".
+        //
+        // WF parity: WF EventCondForm.PreciseEevntCondArea returns write_addr
+        // and the caller displays it directly without re-reading the map-setting
+        // event-plist byte. The correct fix navigates to the new block address.
+        //
+        // We verify the fix by source-regex: the handler must assign
+        // _vm.EventDataAddr = off BEFORE calling ReloadRecordList(), and must
+        // NOT call ResolveEventDataAddr after the alloc succeeds.
+        string repoRoot = FindRepoRoot();
+        string codeBehindPath = System.IO.Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "EventCondView.axaml.cs");
+        string source = System.IO.File.ReadAllText(codeBehindPath);
+
+        // The PreciseAlloc_Click handler body must contain:
+        //   _vm.EventDataAddr = off;
+        //   ...
+        //   ReloadRecordList();
+        // (in that order, within the same try-block, after WriteEventPLIST).
+        Assert.Matches(
+            new System.Text.RegularExpressions.Regex(
+                @"WriteEventPLIST[\s\S]*?_vm\.EventDataAddr\s*=\s*off[\s\S]*?ReloadRecordList\(\)",
+                System.Text.RegularExpressions.RegexOptions.Singleline),
+            source);
+    }
+
+    [Fact]
+    public void View_PreciseAllocClick_DoesNotCallResolveEventDataAddrAfterAlloc()
+    {
+        // FIX 1 (#867): PreciseAlloc_Click must NOT call ResolveEventDataAddr
+        // after a successful alloc (doing so would re-read the current map's
+        // event-plist byte, losing the newly-allocated address). The handler
+        // sets _vm.EventDataAddr = off directly instead.
+        string repoRoot = FindRepoRoot();
+        string codeBehindPath = System.IO.Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "EventCondView.axaml.cs");
+        string source = System.IO.File.ReadAllText(codeBehindPath);
+
+        // The PreciseAlloc_Click handler must NOT call ResolveEventDataAddr
+        // after the WriteEventPLIST call — doing so re-reads the map's plist
+        // byte and would discard the newly-allocated address.
+        // We use a regex that spans WriteEventPLIST ... Commit to check the
+        // post-alloc success path does not re-resolve.
+        Assert.DoesNotMatch(
+            new System.Text.RegularExpressions.Regex(
+                @"WriteEventPLIST[\s\S]*?ResolveEventDataAddr[\s\S]*?_undoService\.Commit",
+                System.Text.RegularExpressions.RegexOptions.Singleline),
+            source);
+    }
+
+    [Fact]
+    public void Core_ResolveEventPlistSlotAddr_UsesGetPlistLimitNotInlineCalc()
+    {
+        // FIX 2 (#867): EventCondCore.ResolveEventPlistSlotAddr must call
+        // MapChangeCore.GetPlistLimit(rom) instead of the inline
+        // `IsPlistSplit(rom) ? 256u : rom.RomInfo.map_map_pointer_list_default_size`
+        // so the split-detection logic can't diverge from the canonical helper.
+        string repoRoot = FindRepoRoot();
+        string corePath = System.IO.Path.Combine(repoRoot, "FEBuilderGBA.Core", "EventCondCore.cs");
+        string source = System.IO.File.ReadAllText(corePath);
+
+        // Production must use GetPlistLimit (not the inline ternary).
+        Assert.Contains("MapChangeCore.GetPlistLimit(rom)", source);
+        // Production must NOT contain the old inline ternary inside
+        // ResolveEventPlistSlotAddr.
+        Assert.DoesNotMatch(
+            new System.Text.RegularExpressions.Regex(
+                @"ResolveEventPlistSlotAddr[\s\S]*?IsPlistSplit\(rom\)\s*\?\s*256u\s*:",
+                System.Text.RegularExpressions.RegexOptions.Singleline),
+            source);
+    }
+
     // -----------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia/Views/EventCondView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventCondView.axaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -845,19 +845,44 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
-        void PreciseAlloc_Click(object? sender, RoutedEventArgs e)
+        async void PreciseAlloc_Click(object? sender, RoutedEventArgs e)
         {
-            // Opens the MapPointerNewPLISTPopupView. The commit-back state-machine
-            // (writing the selected PLIST back to the current map's event PLIST)
-            // is documented as KnownGap in #386 — the popup opens so users see
-            // the new-allocation UI, but the WF-equivalent state restoration is
-            // deferred. The undo scope still wraps the open in case the popup
-            // itself decides to mutate anything before close.
-            _undoService.Begin("Open PLIST Allocation Popup");
+            // Mirror WF EventCondForm.PreciseEevntCondArea (lines 3117-3247):
+            // show PLIST picker, allocate version-exact block, write slot back.
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return;
+
+            var popup = new MapPointerNewPLISTPopupView();
+            uint? plist = await popup.ShowDialog<uint?>(this);
+
+            // WF guard: plist == 0 means cancelled or reserved sentinel slot.
+            if (plist is null || plist == 0) return;
+
+            // Open undo scope AFTER the modal returns (not around it).
+            // _undoService.Begin already calls ROM.BeginUndoScope internally,
+            // so EventCondCore ambient write_p32 calls are tracked automatically.
+            _undoService.Begin("Precise EventCondArea");
+            uint off = U.NOT_FOUND;
             try
             {
-                WindowManager.Instance.Navigate<MapPointerNewPLISTPopupView>(0);
+                off = EventCondCore.AllocNewEventCondBlock(rom, 0);
+                if (off == U.NOT_FOUND)
+                {
+                    _undoService.Rollback();
+                    CoreState.Services.ShowInfo("Could not allocate free space for the event condition block.");
+                    return;
+                }
+
+                if (!EventCondCore.WriteEventPLIST(rom, plist.Value, off))
+                {
+                    _undoService.Rollback();
+                    CoreState.Services.ShowInfo("Could not write the event PLIST slot (plist=0 or slot unsafe).");
+                    return;
+                }
+
+                ReloadRecordList();
                 _undoService.Commit();
+                CoreState.Services.ShowInfo("Precise event condition area allocated at 0x" + off.ToString("X08") + " and wired to PLIST " + plist.Value + ".");
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Avalonia/Views/EventCondView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventCondView.axaml.cs
@@ -880,6 +880,13 @@ namespace FEBuilderGBA.Avalonia.Views
                     return;
                 }
 
+                // Navigate the editor to the newly-allocated block so the user
+                // sees the new block's slots (turn/talk/object/always/...) rather
+                // than "No event data for this map" (WF parity: WF returns
+                // write_addr and the caller displays it directly, without
+                // re-reading the map-setting event-plist byte).
+                _vm.EventDataAddr = off;
+                UpdateTopBar();
                 ReloadRecordList();
                 _undoService.Commit();
                 CoreState.Services.ShowInfo("Precise event condition area allocated at 0x" + off.ToString("X08") + " and wired to PLIST " + plist.Value + ".");

--- a/FEBuilderGBA.Core.Tests/EventCondCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventCondCoreTests.cs
@@ -1,0 +1,197 @@
+﻿using System.Collections.Generic;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class EventCondCoreTests
+    {
+        static Undo.UndoData MakeUndoData(ROM rom) => new Undo.UndoData
+        {
+            time = System.DateTime.Now,
+            name = "test",
+            list = new List<Undo.UndoPostion>(),
+            filesize = (uint)rom.Data.Length,
+        };
+
+        [Fact]
+        public void Constants_FE8_MatchPlan()
+        {
+            Assert.Equal(20, EventCondCore.FE8SlotCount);
+            Assert.Equal(10, EventCondCore.FE8Active);
+            Assert.Equal(80, EventCondCore.FE8HeaderSize);
+            Assert.Equal(184, EventCondCore.FE8Total);
+        }
+
+        [Fact]
+        public void Constants_FE7_MatchPlan()
+        {
+            Assert.Equal(16, EventCondCore.FE7SlotCount);
+            Assert.Equal(6, EventCondCore.FE7Active);
+            Assert.Equal(64, EventCondCore.FE7HeaderSize);
+            Assert.Equal(132, EventCondCore.FE7Total);
+        }
+
+        [Fact]
+        public void Constants_FE6_MatchPlan()
+        {
+            Assert.Equal(7, EventCondCore.FE6SlotCount);
+            Assert.Equal(4, EventCondCore.FE6Active);
+            Assert.Equal(28, EventCondCore.FE6HeaderSize);
+            Assert.Equal(76, EventCondCore.FE6Total);
+        }
+
+        [Fact]
+        public void AllocNewEventCondBlock_NullRom_ReturnsNotFound()
+        {
+            uint result = EventCondCore.AllocNewEventCondBlock(null, 0);
+            Assert.Equal(U.NOT_FOUND, result);
+        }
+
+        [Fact]
+        public void AllocNewEventCondBlock_FE8_TotalIs184_And_ActiveSlotsCorrect()
+        {
+            var rom = MakeMinimalRom(8);
+            var ud = MakeUndoData(rom);
+            using (ROM.BeginUndoScope(ud))
+            {
+                uint off = EventCondCore.AllocNewEventCondBlock(rom, 0);
+                Assert.NotEqual(U.NOT_FOUND, off);
+                Assert.NotEqual(0u, off);
+                Assert.True(off + EventCondCore.FE8Total <= (uint)rom.Data.Length);
+                Assert.Equal(80u, (uint)(EventCondCore.FE8SlotCount * 4));
+                uint[] sub = { 80, 92, 108, 120, 132, 144, 156, 168, 172, 178 };
+                for (int i = 0; i < EventCondCore.FE8Active; i++)
+                    Assert.Equal(U.toPointer(off + sub[i]), rom.u32(off + (uint)(i * 4)));
+                for (int i = EventCondCore.FE8Active; i < EventCondCore.FE8SlotCount; i++)
+                    Assert.Equal(0u, rom.u32(off + (uint)(i * 4)));
+            }
+        }
+
+        [Fact]
+        public void AllocNewEventCondBlock_FE7_TotalIs132_And_ActiveSlotsCorrect()
+        {
+            var rom = MakeMinimalRom(7);
+            var ud = MakeUndoData(rom);
+            using (ROM.BeginUndoScope(ud))
+            {
+                uint off = EventCondCore.AllocNewEventCondBlock(rom, 0);
+                Assert.NotEqual(U.NOT_FOUND, off);
+                Assert.True(off + EventCondCore.FE7Total <= (uint)rom.Data.Length);
+                uint[] sub = { 64, 80, 96, 108, 120, 126 };
+                for (int i = 0; i < EventCondCore.FE7Active; i++)
+                    Assert.Equal(U.toPointer(off + sub[i]), rom.u32(off + (uint)(i * 4)));
+                for (int i = EventCondCore.FE7Active; i < EventCondCore.FE7SlotCount; i++)
+                    Assert.Equal(0u, rom.u32(off + (uint)(i * 4)));
+            }
+        }
+
+        [Fact]
+        public void AllocNewEventCondBlock_FE6_TotalIs76_And_ActiveSlotsCorrect()
+        {
+            var rom = MakeMinimalRom(6);
+            var ud = MakeUndoData(rom);
+            using (ROM.BeginUndoScope(ud))
+            {
+                uint off = EventCondCore.AllocNewEventCondBlock(rom, 0);
+                Assert.NotEqual(U.NOT_FOUND, off);
+                Assert.True(off + EventCondCore.FE6Total <= (uint)rom.Data.Length);
+                uint[] sub = { 28, 40, 52, 64 };
+                for (int i = 0; i < EventCondCore.FE6Active; i++)
+                    Assert.Equal(U.toPointer(off + sub[i]), rom.u32(off + (uint)(i * 4)));
+                for (int i = EventCondCore.FE6Active; i < EventCondCore.FE6SlotCount; i++)
+                    Assert.Equal(0u, rom.u32(off + (uint)(i * 4)));
+            }
+        }
+
+
+        [Fact]
+        public void AllocNewEventCondBlock_FE8_SubRegionsAreZeroed()
+        {
+            var rom = MakeMinimalRom(8);
+            var ud = MakeUndoData(rom);
+            using (ROM.BeginUndoScope(ud))
+            {
+                uint off = EventCondCore.AllocNewEventCondBlock(rom, 0);
+                Assert.NotEqual(U.NOT_FOUND, off);
+                uint hdr = (uint)(EventCondCore.FE8SlotCount * 4);
+                for (uint b = hdr; b < EventCondCore.FE8Total; b++)
+                    Assert.Equal(0, (int)rom.u8(off + b));
+            }
+        }
+
+        [Fact]
+        public void WriteEventPLIST_NullRom_ReturnsFalse()
+            => Assert.False(EventCondCore.WriteEventPLIST(null, 1, 0x1000));
+
+        [Fact]
+        public void WriteEventPLIST_Plist0_ReturnsFalse()
+            => Assert.False(EventCondCore.WriteEventPLIST(MakeMinimalRom(8), 0, 0x1000));
+
+        [Fact]
+        public void WriteEventPLIST_ValidPlist_WritesPointerToSlot_FE8()
+        {
+            var rom = MakeMinimalRom(8);
+            var ud = MakeUndoData(rom);
+            using (ROM.BeginUndoScope(ud))
+            {
+                uint ep = rom.RomInfo.map_event_pointer;
+                U.write_u32(rom.Data, ep, U.toPointer(0x20000));
+                Assert.True(EventCondCore.WriteEventPLIST(rom, 1, 0x30000));
+                Assert.Equal(U.toPointer(0x30000u), rom.u32(0x20000u + 4));
+            }
+        }
+
+        [Fact]
+        public void ResolveEventPlistSlotAddr_NullRom_ReturnsNotFound()
+            => Assert.Equal(U.NOT_FOUND, EventCondCore.ResolveEventPlistSlotAddr(null, 1));
+
+        [Fact]
+        public void ResolveEventPlistSlotAddr_Plist0_ReturnsNotFound()
+            => Assert.Equal(U.NOT_FOUND, EventCondCore.ResolveEventPlistSlotAddr(MakeMinimalRom(8), 0));
+
+
+        [Fact]
+        public void AllocAndWrite_AmbientUndo_RevertsOnRollback_FE8()
+        {
+            var rom = MakeMinimalRom(8);
+            var origRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = rom;
+                uint ep = rom.RomInfo.map_event_pointer;
+                U.write_u32(rom.Data, ep, U.toPointer(0x20000));
+                uint slot1 = 0x20000u + 4;
+                uint off;
+                var ud = MakeUndoData(rom);
+                using (ROM.BeginUndoScope(ud))
+                {
+                    off = EventCondCore.AllocNewEventCondBlock(rom, 0);
+                    Assert.NotEqual(U.NOT_FOUND, off);
+                    EventCondCore.WriteEventPLIST(rom, 1, off);
+                }
+                Assert.Equal(U.toPointer(off), rom.u32(slot1));
+                var undo = new Undo();
+                undo.Push(ud);
+                undo.RunUndo();
+                Assert.Equal(0u, rom.u32(slot1));
+            }
+            finally { CoreState.ROM = origRom; }
+        }
+
+        static ROM MakeMinimalRom(int version)
+        {
+            (string vs, int ms) = version switch {
+                6 => ("AFEJ01", 0x800000),
+                7 => ("AE7E01", 0x1000000),
+                _ => ("BE8E01", 0x1000000),
+            };
+            var data = new byte[ms];
+            var rom = new ROM();
+            rom.LoadLow("test.gba", data, vs);
+            return rom;
+        }
+    }
+}
+

--- a/FEBuilderGBA.Core/EventCondCore.cs
+++ b/FEBuilderGBA.Core/EventCondCore.cs
@@ -1,0 +1,147 @@
+using System;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Cross-platform helpers for the Event Condition block allocation and PLIST
+    /// write-back (Avalonia EventCond editor, issue #865).
+    ///
+    /// Ported byte-exact from WF EventCondForm.PreciseEevntCondArea
+    /// (lines 3117-3247) and MapPointerForm.Write_Plsit (lines 579-598).
+    /// </summary>
+    public static class EventCondCore
+    {
+        // Per-version constants (verified against WF PreciseEevntCondArea)
+
+        // FE8: MapCond.Count = 20, header = 80 bytes, 10 active slots, total = 184
+        internal const int FE8SlotCount  = 20;
+        internal const int FE8Active     = 10;
+        internal const int FE8HeaderSize = 80;
+        internal const int FE8Total      = 184;
+
+        // FE7: MapCond.Count = 16, header = 64 bytes, 6 active slots, total = 132
+        internal const int FE7SlotCount  = 16;
+        internal const int FE7Active     = 6;
+        internal const int FE7HeaderSize = 64;
+        internal const int FE7Total      = 132;
+
+        // FE6: MapCond.Count = 7, header = 28 bytes, 4 active slots, total = 76
+        internal const int FE6SlotCount  = 7;
+        internal const int FE6Active     = 4;
+        internal const int FE6HeaderSize = 28;
+        internal const int FE6Total      = 76;
+
+        public static uint AllocNewEventCondBlock(ROM rom, uint mapId)
+        {
+            if (rom?.RomInfo == null) return U.NOT_FOUND;
+
+            int ver = rom.RomInfo.version;
+
+            uint write_addr;
+            if (ver == 8)
+            {
+                uint eventSize = (uint)(FE8SlotCount * 4);
+                uint turn      = eventSize;
+                uint talk      = turn + 12;
+                uint mapobject = talk + 16;
+                uint always    = mapobject + 12;
+                uint always2   = always + 12;
+                uint always3   = always2 + 12;
+                uint always4   = always3 + 12;
+                uint tutorial  = always4 + 12;
+                uint trap      = tutorial + 4;
+                uint trap2     = trap + 6;
+                uint total     = trap2 + 6;
+
+                byte[] data = new byte[total];
+                write_addr = MapEventUnitCore.AppendBinaryDataHeadless(rom, data, null);
+                if (write_addr == U.NOT_FOUND || write_addr == 0) return U.NOT_FOUND;
+
+                rom.write_p32(write_addr +  0, write_addr + turn);
+                rom.write_p32(write_addr +  4, write_addr + talk);
+                rom.write_p32(write_addr +  8, write_addr + mapobject);
+                rom.write_p32(write_addr + 12, write_addr + always);
+                rom.write_p32(write_addr + 16, write_addr + always2);
+                rom.write_p32(write_addr + 20, write_addr + always3);
+                rom.write_p32(write_addr + 24, write_addr + always4);
+                rom.write_p32(write_addr + 28, write_addr + tutorial);
+                rom.write_p32(write_addr + 32, write_addr + trap);
+                rom.write_p32(write_addr + 36, write_addr + trap2);
+            }
+            else if (ver == 7)
+            {
+                uint eventSize = (uint)(FE7SlotCount * 4);
+                uint turn      = eventSize;
+                uint talk      = turn + 16;
+                uint mapobject = talk + 16;
+                uint always    = mapobject + 12;
+                uint trap      = always + 12;
+                uint trap2     = trap + 6;
+                uint total     = trap2 + 6;
+
+                byte[] data = new byte[total];
+                write_addr = MapEventUnitCore.AppendBinaryDataHeadless(rom, data, null);
+                if (write_addr == U.NOT_FOUND || write_addr == 0) return U.NOT_FOUND;
+
+                rom.write_p32(write_addr +  0, write_addr + turn);
+                rom.write_p32(write_addr +  4, write_addr + talk);
+                rom.write_p32(write_addr +  8, write_addr + mapobject);
+                rom.write_p32(write_addr + 12, write_addr + always);
+                rom.write_p32(write_addr + 16, write_addr + trap);
+                rom.write_p32(write_addr + 20, write_addr + trap2);
+            }
+            else
+            {
+                uint eventSize = (uint)(FE6SlotCount * 4);
+                uint turn      = eventSize;
+                uint talk      = turn + 12;
+                uint mapobject = talk + 12;
+                uint always    = mapobject + 12;
+                uint total     = always + 12;
+
+                byte[] data = new byte[total];
+                write_addr = MapEventUnitCore.AppendBinaryDataHeadless(rom, data, null);
+                if (write_addr == U.NOT_FOUND || write_addr == 0) return U.NOT_FOUND;
+
+                rom.write_p32(write_addr +  0, write_addr + turn);
+                rom.write_p32(write_addr +  4, write_addr + talk);
+                rom.write_p32(write_addr +  8, write_addr + mapobject);
+                rom.write_p32(write_addr + 12, write_addr + always);
+            }
+
+            return write_addr;
+        }
+
+        public static bool WriteEventPLIST(ROM rom, uint plist, uint newBlockOffset)
+        {
+            if (rom?.RomInfo == null) return false;
+            if (plist == 0) return false;
+
+            uint slotAddr = ResolveEventPlistSlotAddr(rom, plist);
+            if (slotAddr == U.NOT_FOUND) return false;
+            if (!U.isSafetyOffset(slotAddr, rom)) return false;
+
+            rom.write_p32(slotAddr, newBlockOffset);
+            return true;
+        }
+
+        public static uint ResolveEventPlistSlotAddr(ROM rom, uint plist)
+        {
+            if (rom?.RomInfo == null) return U.NOT_FOUND;
+            if (plist == 0u) return U.NOT_FOUND;
+
+            uint limit = MapChangeCore.IsPlistSplit(rom) ? 256u : rom.RomInfo.map_map_pointer_list_default_size;
+            if (limit == 0 || plist >= limit) return U.NOT_FOUND;
+
+            uint basePointer = rom.RomInfo.map_event_pointer;
+            if (basePointer == 0) return U.NOT_FOUND;
+
+            uint baseAddr = rom.p32(basePointer);
+            if (!U.isSafetyOffset(baseAddr, rom)) return U.NOT_FOUND;
+
+            uint slotAddr = baseAddr + plist * 4u;
+            if (slotAddr + 4u > (uint)rom.Data.Length) return U.NOT_FOUND;
+            return slotAddr;
+        }
+    }
+}

--- a/FEBuilderGBA.Core/EventCondCore.cs
+++ b/FEBuilderGBA.Core/EventCondCore.cs
@@ -130,7 +130,7 @@ namespace FEBuilderGBA
             if (rom?.RomInfo == null) return U.NOT_FOUND;
             if (plist == 0u) return U.NOT_FOUND;
 
-            uint limit = MapChangeCore.IsPlistSplit(rom) ? 256u : rom.RomInfo.map_map_pointer_list_default_size;
+            uint limit = MapChangeCore.GetPlistLimit(rom);
             if (limit == 0 || plist >= limit) return U.NOT_FOUND;
 
             uint basePointer = rom.RomInfo.map_event_pointer;


### PR DESCRIPTION
## Summary

- New `EventCondCore` (Core library) with `AllocNewEventCondBlock`, `WriteEventPLIST`, and `ResolveEventPlistSlotAddr` — byte-exact port of WF `EventCondForm.PreciseEevntCondArea` + `MapPointerForm.Write_Plsit`.
- `PreciseAlloc_Click` in `EventCondView` rewritten to `async void`: shows `MapPointerNewPLISTPopupView` as a real modal dialog, captures PLIST from `Close(value)`, then allocates the block and commits it via `_undoService`.
- All writes use ambient undo (no double-recording); undo rollback reverts both the block allocation and the PLIST slot write.
- Removes the old `WindowManager.Navigate<...>(0)` stub that discarded the return value.

Closes #865

## Block layout verified against WF source (`PreciseEevntCondArea` lines 3117-3247)

| Version | Slot count | Active | Header | Total |
|---------|-----------|--------|--------|-------|
| FE8     | 20        | 10     | 80     | 184   |
| FE7     | 16        | 6      | 64     | 132   |
| FE6     | 7         | 4      | 28     | 76    |

FE8 active order: turn @80, talk @92, mapobject @108, always @120, always2 @132, always3 @144, always4 @156, tutorial @168, trap @172, trap2 @178.

## Test plan

- [x] `Constants_FE8_MatchPlan` — 20 slots / 10 active / header 80 / total 184
- [x] `Constants_FE7_MatchPlan` — 16 slots / 6 active / header 64 / total 132
- [x] `Constants_FE6_MatchPlan` — 7 slots / 4 active / header 28 / total 76
- [x] `AllocNewEventCondBlock_NullRom_ReturnsNotFound`
- [x] `AllocNewEventCondBlock_FE8_TotalIs184_And_ActiveSlotsCorrect` — all 10 active slots point to correct sub-regions; trailing 10 are 0
- [x] `AllocNewEventCondBlock_FE7_TotalIs132_And_ActiveSlotsCorrect` — all 6 active slots correct; trailing 10 are 0
- [x] `AllocNewEventCondBlock_FE6_TotalIs76_And_ActiveSlotsCorrect` — all 4 active slots correct; trailing 3 are 0
- [x] `AllocNewEventCondBlock_FE8_SubRegionsAreZeroed` — bytes beyond header are all 0
- [x] `WriteEventPLIST_NullRom_ReturnsFalse`
- [x] `WriteEventPLIST_Plist0_ReturnsFalse` — WF plist==0 guard
- [x] `WriteEventPLIST_ValidPlist_WritesPointerToSlot_FE8` — split-aware slot resolved, `u32(slot) == toPointer(off)`
- [x] `ResolveEventPlistSlotAddr_NullRom_ReturnsNotFound`
- [x] `ResolveEventPlistSlotAddr_Plist0_ReturnsNotFound`
- [x] `AllocAndWrite_AmbientUndo_RevertsOnRollback_FE8` — one undo scope reverts both block + slot write
- [x] `PreciseAlloc_Click` is `async void` + captures PLIST + commits (not the old navigate-only stub)
- [x] `dotnet build FEBuilderGBA.Core` — 0 errors
- [x] `dotnet build FEBuilderGBA.Avalonia` — 0 errors
- [x] `dotnet test FEBuilderGBA.Core.Tests` — 2392 passed, 0 failed
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` — 7270 passed, 0 failed
- [x] `scripts/validate-automation-ids.ps1` — VALIDATION PASSED

## GUI Test Report

| Test | Result |
|------|--------|
| EventCondView renders with FE8U ROM | PASS |
| PreciseAlloc button present | PASS |
| Screenshot captured via `--screenshot-all` (RenderTargetBitmap, not screen-grab) | PASS |
| Build 0 errors (Core + Avalonia) | PASS |
| All 2392 Core.Tests pass | PASS |
| All 7270 Avalonia.Tests pass | PASS |
| validate-automation-ids.ps1 exit 0 | PASS |

## Screenshots

EventCondView editor with FE8U ROM (off-screen render via RenderTargetBitmap):

![EventCond editor screenshot](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr865-eventcond-precise-alloc.png)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) v2.1.156 (model: claude-opus-4-8)