### PR TITLE
feat(avalonia): Battle Animation Palette Import (closes #869)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
@@ -173,16 +173,44 @@ public class ImageBattleAnimePalletParityTests
             RegexOptions.Singleline), axaml);
     }
 
+    /// <summary>
+    /// #869: the Import button is now wired (not a stub). It opens a file
+    /// dialog, quantizes the image to 16 GBA RGB555 colors, and writes via
+    /// the existing Write path. The button must be enabled and carry a
+    /// Click handler; crucially it must NOT have IsEnabled="False" on the
+    /// same line/block (within 100 chars — not the neighboring Export button).
+    /// </summary>
     [Fact]
-    public void View_ImportButton_IsHonestlyDisabledKnownGap()
+    public void View_ImportButton_IsWiredAndEnabled()
     {
-        // Real PNG import is still WF PaletteFormRef-coupled (#399). The
-        // Import button is rendered but disabled. (Export is now wired — see
-        // View_ExportButton_WiredAndGated.)
         string axaml = ReadAxaml();
-        Assert.Matches(new Regex(
-            @"AutomationId=""ImageBattleAnimePallet_Import_Button""[\s\S]{0,400}IsEnabled=""False""",
+        // Narrow window (100 chars) ensures we don't match the adjacent
+        // ExportButton's IsEnabled="False" line which is ~150 chars away.
+        Assert.DoesNotMatch(new Regex(
+            @"AutomationId=""ImageBattleAnimePallet_Import_Button""[\s\S]{0,100}IsEnabled=""False""",
             RegexOptions.Singleline), axaml);
+        // The button must carry Click="Import_Click".
+        Assert.Matches(new Regex(
+            @"AutomationId=""ImageBattleAnimePallet_Import_Button""[\s\S]{0,200}Click=""Import_Click""",
+            RegexOptions.Singleline), axaml);
+    }
+
+    /// <summary>
+    /// #869: the code-behind must have an Import_Click handler (not a stub).
+    /// Verify both the handler and the DoImportFromFile injectable seam exist.
+    /// </summary>
+    [Fact]
+    public void View_ImportButton_HandlerExists()
+    {
+        string code = File.ReadAllText(CodeBehindPath());
+        // Handler must exist and not be empty.
+        Assert.Contains("async void Import_Click", code);
+        // The injectable seam must call DoImport on the VM.
+        Assert.Contains("_vm.DoImport", code);
+        // The handler must call Write() under an undo scope.
+        Assert.Matches(new Regex(
+            @"_undoService\.Begin[\s\S]{0,2000}_vm\.Write\(\)[\s\S]{0,200}_undoService\.(Commit|Rollback)\(\)",
+            RegexOptions.Singleline), code);
     }
 
     /// <summary>
@@ -759,6 +787,133 @@ public class ImageBattleAnimePalletParityTests
         // — matches the pattern in ClassEditorListPreviewTests.
         if (CoreState.ImageService == null)
             CoreState.ImageService = new SkiaImageService();
+    }
+
+    // -----------------------------------------------------------------
+    // #869 — DoImport injectable seam tests.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// ViewModel.DoImport populates all 16 R/G/B cells from a 32-byte
+    /// GBA palette (RGB555 u16 LE). This exercises the injectable seam
+    /// without a file dialog or ROM write.
+    /// </summary>
+    [Fact]
+    public void ViewModel_DoImport_PopulatesAllRgbFromGbaPalette()
+    {
+        var vm = new ImageBattleAnimePalletViewModel();
+
+        // Build a known 32-byte palette: color[0] = max R (0x001F),
+        // color[1] = max G (0x03E0), color[2] = max B (0x7C00),
+        // rest = 0.
+        byte[] palette = new byte[32];
+        // color 0: R=31, G=0, B=0 → 0x001F → bytes [0]=0x1F,[1]=0x00
+        palette[0] = 0x1F; palette[1] = 0x00;
+        // color 1: R=0, G=31, B=0 → 0x03E0 → bytes [2]=0xE0,[3]=0x03
+        palette[2] = 0xE0; palette[3] = 0x03;
+        // color 2: R=0, G=0, B=31 → 0x7C00 → bytes [4]=0x00,[5]=0x7C
+        palette[4] = 0x00; palette[5] = 0x7C;
+
+        bool ok = vm.DoImport(palette);
+        Assert.True(ok, "DoImport must return true for a valid 32-byte palette");
+
+        // (31 & 0x1F) << 3 = 31 << 3 = 248
+        Assert.Equal(248, vm.GetR(0));
+        Assert.Equal(0, vm.GetG(0));
+        Assert.Equal(0, vm.GetB(0));
+
+        Assert.Equal(0, vm.GetR(1));
+        Assert.Equal(248, vm.GetG(1));
+        Assert.Equal(0, vm.GetB(1));
+
+        Assert.Equal(0, vm.GetR(2));
+        Assert.Equal(0, vm.GetG(2));
+        Assert.Equal(248, vm.GetB(2));
+
+        // Colors 3..15 must be zero.
+        for (int i = 3; i < 16; i++)
+        {
+            Assert.Equal(0, vm.GetR(i));
+            Assert.Equal(0, vm.GetG(i));
+            Assert.Equal(0, vm.GetB(i));
+        }
+    }
+
+    [Fact]
+    public void ViewModel_DoImport_ReturnsFalse_WhenNull()
+    {
+        var vm = new ImageBattleAnimePalletViewModel();
+        Assert.False(vm.DoImport(null));
+    }
+
+    [Fact]
+    public void ViewModel_DoImport_ReturnsFalse_WhenTooShort()
+    {
+        var vm = new ImageBattleAnimePalletViewModel();
+        Assert.False(vm.DoImport(new byte[31])); // 31 < 32
+    }
+
+    [Fact]
+    public void ViewModel_DoImport_AcceptsLongerArray()
+    {
+        // DoImport must accept arrays > 32 bytes (quantizer may pad).
+        var vm = new ImageBattleAnimePalletViewModel();
+        byte[] palette = new byte[64]; // longer than 32 — should succeed
+        palette[0] = 0x1F; // R=31 in color[0]
+        bool ok = vm.DoImport(palette);
+        Assert.True(ok);
+        Assert.Equal(248, vm.GetR(0));
+    }
+
+    /// <summary>
+    /// Round-trip: DoImport a known palette, then Write to ROM, then
+    /// ReadPalette back — must match the original colors.
+    /// Covers the full injectable-seam → Core write path under undo.
+    /// </summary>
+    [Fact]
+    public void ViewModel_DoImport_RoundTrip_WritesExpectedBytesToRom()
+    {
+        var (rom, paletteOffset, sourceSlot) = MakeRomWithSingleSlotPalette(new ushort[16]);
+        var prevRom = CoreState.ROM;
+        var prevUndo = CoreState.Undo;
+        try
+        {
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+
+            var vm = new ImageBattleAnimePalletViewModel();
+            vm.LoadEntry(paletteOffset, sourceSlot, paletteIndex: 0);
+
+            // Build import palette: color[0] = max R, color[1] = max G.
+            byte[] importPalette = new byte[32];
+            importPalette[0] = 0x1F; importPalette[1] = 0x00; // R=31
+            importPalette[2] = 0xE0; importPalette[3] = 0x03; // G=31
+
+            bool applied = vm.DoImport(importPalette);
+            Assert.True(applied);
+
+            var undoService = new UndoService();
+            undoService.Begin("test import round-trip");
+            uint newOffset = vm.Write();
+            undoService.Commit();
+
+            Assert.NotEqual(U.NOT_FOUND, newOffset);
+
+            // Re-read: color[0] should have R=31, G=0, B=0.
+            ushort[] roundtrip = ImageBattleAnimePaletteCore.ReadPalette(rom, newOffset, 0);
+            Assert.NotNull(roundtrip);
+            Assert.Equal(31, roundtrip[0] & 0x1F);        // R=31
+            Assert.Equal(0,  (roundtrip[0] >> 5) & 0x1F); // G=0
+            Assert.Equal(0,  (roundtrip[0] >> 10) & 0x1F);// B=0
+
+            Assert.Equal(0,  roundtrip[1] & 0x1F);        // R=0
+            Assert.Equal(31, (roundtrip[1] >> 5) & 0x1F); // G=31
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.Undo = prevUndo;
+        }
     }
 
     // -----------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
@@ -1109,6 +1109,115 @@ public class ImageBattleAnimePalletParityTests
         return (rom, paletteOff, sourceSlot);
     }
 
+    // -----------------------------------------------------------------
+    // #871 FIX 1 - palette import does not require tile-size multiples.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ImageImportService_RequireTileMultipleParam_ControlsDimensionCheck()
+    {
+        string svcCode = System.IO.File.ReadAllText(
+            FindRepoRoot() + "/FEBuilderGBA.Avalonia/Services/ImageImportService.cs");
+        Assert.Contains("bool requireTileMultiple = true", svcCode);
+        Assert.Contains("requireTileMultiple && (image.Width % 8", svcCode);
+        // DecreaseColorCore.Quantize handles arbitrary (non-8-multiple) dims.
+        byte[] rgba = new byte[10 * 10 * 4];
+        for (int i = 0; i < rgba.Length; i += 4) { rgba[i] = 255; rgba[i+3] = 255; }
+        var qr = DecreaseColorCore.Quantize(rgba, 10, 10, 16);
+        Assert.NotNull(qr);
+        byte[] padded = PadHelper(qr.GBAPalette);
+        Assert.Equal(32, padded.Length);
+    }
+
+    [Fact]
+    public void View_DoImportFromFile_PassesRequireTileMultipleFalse()
+    {
+        string code = System.IO.File.ReadAllText(CodeBehindPath());
+        Assert.Contains("requireTileMultiple: false", code);
+    }
+
+    // -----------------------------------------------------------------
+    // #871 FIX 2 - snapshot before DoImport; restore on write failure.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_DoImportFromFile_HasSnapshotAndRestoreBoilerplate()
+    {
+        string code = System.IO.File.ReadAllText(CodeBehindPath());
+        Assert.Contains("byte[] rSnap", code);
+        Assert.Contains("gSnap[si] = _vm.GetG(si)", code);
+        var matches = System.Text.RegularExpressions.Regex.Matches(code, "RestorePaletteSnapshot");
+        Assert.True(matches.Count >= 3,
+            $"RestorePaletteSnapshot must appear >= 3 times, got {matches.Count}");
+    }
+
+    [Fact]
+    public void ViewModel_DoImport_ThenWriteFails_VmStillHoldsImportedState()
+    {
+        var (rom, paletteOffset, sourceSlot) = MakeRomWithSingleSlotPalette(new ushort[16]);
+        var prevRom = CoreState.ROM; var prevUndo = CoreState.Undo;
+        try
+        {
+            CoreState.ROM = rom; CoreState.Undo = new Undo();
+            var vm = new ImageBattleAnimePalletViewModel();
+            vm.LoadEntry(paletteOffset, sourceSlot, paletteIndex: 0);
+            Assert.Equal(0, vm.GetR(0));
+            byte[] importPal = new byte[32];
+            importPal[0] = 0x1F; importPal[1] = 0x00;
+            bool applied = vm.DoImport(importPal);
+            Assert.True(applied);
+            Assert.Equal(248, vm.GetR(0));
+            vm.SetWriterOverrideForTests((r, data) => U.NOT_FOUND);
+            var undoService = new UndoService();
+            undoService.Begin("test fail");
+            uint result = vm.Write();
+            Assert.Equal(U.NOT_FOUND, result);
+            undoService.Rollback();
+            Assert.Equal(248, vm.GetR(0)); // VM holds imported; view restores it
+        }
+        finally { CoreState.ROM = prevRom; CoreState.Undo = prevUndo; }
+    }
+
+    // -----------------------------------------------------------------
+    // #871 FIX 3 - PadGBAPaletteTo16 returns exactly 32 bytes.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_PadGBAPaletteTo16_TruncatesOversizedInput_Returns32Bytes()
+    {
+        var method = typeof(ImageBattleAnimePalletView).GetMethod("PadGBAPaletteTo16",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(method);
+        byte[] input = new byte[64];
+        for (int i = 0; i < 64; i++) input[i] = (byte)((i + 1) % 256);
+        byte[] result = (byte[])method.Invoke(null, new object[] { input });
+        Assert.Equal(32, result.Length);
+        for (int i = 0; i < 32; i++) Assert.Equal(input[i], result[i]);
+    }
+
+    [Fact]
+    public void View_PadGBAPaletteTo16_PadsShortInput_Returns32Bytes()
+    {
+        var method = typeof(ImageBattleAnimePalletView).GetMethod("PadGBAPaletteTo16",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(method);
+        byte[] input = new byte[10];
+        input[0] = 0x1F;
+        byte[] result = (byte[])method.Invoke(null, new object[] { input });
+        Assert.Equal(32, result.Length);
+        Assert.Equal(0x1F, result[0]);
+        for (int i = 10; i < 32; i++) Assert.Equal(0, result[i]);
+    }
+
+    static byte[] PadHelper(byte[] gbaPalette)
+    {
+        const int needed = 32;
+        byte[] padded = new byte[needed];
+        if (gbaPalette != null)
+            System.Array.Copy(gbaPalette, padded, System.Math.Min(gbaPalette.Length, needed));
+        return padded;
+    }
+
     static void PlantLZ77(ROM rom, uint offset, byte[] raw)
     {
         byte[] comp = LZ77.compress(raw);

--- a/FEBuilderGBA.Avalonia/Services/ImageImportService.cs
+++ b/FEBuilderGBA.Avalonia/Services/ImageImportService.cs
@@ -47,8 +47,17 @@ namespace FEBuilderGBA.Avalonia.Services
         /// <summary>
         /// Load image from file path, validate dimensions, quantize.
         /// </summary>
+        /// <param name="requireTileMultiple">
+        /// When <c>true</c> (default), the image width and height must both be
+        /// multiples of 8 - required for tile-based sprite/graphic import.
+        /// Pass <c>false</c> for palette-only import where any image size is
+        /// acceptable (mirrors WinForms <c>PaletteFormRef.MakePaletteBitmapToUI</c>
+        /// which extracts <c>ColorPalette</c> from any bitmap with no dimension
+        /// restriction). Does NOT override <paramref name="strictSize"/> - both
+        /// flags apply independently. FIX 1 (#871).
+        /// </param>
         public static LoadResult LoadAndQuantizeFromFile(string filePath, int expectedWidth, int expectedHeight,
-            int maxColors = 16, bool strictSize = false)
+            int maxColors = 16, bool strictSize = false, bool requireTileMultiple = true)
         {
             var result = new LoadResult();
             var imgService = CoreState.ImageService;
@@ -77,7 +86,10 @@ namespace FEBuilderGBA.Avalonia.Services
                     return result;
                 }
 
-                if (image.Width % 8 != 0 || image.Height % 8 != 0)
+                // FIX 1 (#871): skip the tile-size check for palette-only import.
+                // Mirrors WF PaletteFormRef.MakePaletteBitmapToUI which extracts
+                // ColorPalette from any image with no dimension restriction.
+                if (requireTileMultiple && (image.Width % 8 != 0 || image.Height % 8 != 0))
                 {
                     result.Error = $"Image dimensions must be multiples of 8 (got {image.Width}x{image.Height})";
                     return result;

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageBattleAnimePalletViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageBattleAnimePalletViewModel.cs
@@ -293,6 +293,41 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         }
 
         /// <summary>
+        /// Apply a 16-color GBA palette (32 bytes, RGB555 u16 LE pairs) to
+        /// the VM R/G/B arrays. Mirrors WinForms
+        /// <c>PaletteFormRef.MakePaletteBitmapToUI(bitmap, palette_index:0)</c>.
+        ///
+        /// <para>This is the injectable seam used by the file-import path and
+        /// by unit tests (pass a hand-crafted 32-byte array instead of a
+        /// file-dialog result). Caller wraps <see cref="Write"/> in
+        /// <c>UndoService.Begin/Commit/Rollback</c> after this; this method
+        /// itself is pure-state (no ROM writes).</para>
+        /// </summary>
+        /// <param name="gbaPalette16">
+        /// 32 bytes: 16 GBA u16 colors in little-endian RGB555 format.
+        /// Must be non-null and at least 32 bytes. Excess bytes are ignored.
+        /// </param>
+        /// <returns>
+        /// <c>true</c> on success; <c>false</c> if null or shorter than 32 bytes.
+        /// </returns>
+        public bool DoImport(byte[] gbaPalette16)
+        {
+            if (gbaPalette16 == null || gbaPalette16.Length < ImageBattleAnimePaletteCore.SlotByteSize)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < ImageBattleAnimePaletteCore.ColorsPerSlot; i++)
+            {
+                ushort gba = (ushort)(gbaPalette16[i * 2] | (gbaPalette16[i * 2 + 1] << 8));
+                _r[i] = (byte)(((gba) & 0x1F) << 3);
+                _g[i] = (byte)(((gba >> 5) & 0x1F) << 3);
+                _b[i] = (byte)(((gba >> 10) & 0x1F) << 3);
+            }
+            return true;
+        }
+
+        /// <summary>
         /// Pack the UI R/G/B rows into GBA u16 colors and call
         /// <see cref="ImageBattleAnimePaletteCore.WritePalette"/>. Caller
         /// must wrap this in <c>UndoService.Begin/Commit/Rollback</c>.

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml
@@ -368,8 +368,8 @@
                   Click="Clipboard_Click" />
           <Button AutomationProperties.AutomationId="ImageBattleAnimePallet_Import_Button"
                   Name="ImportButton" Content="Import Image" Width="140"
-                  IsEnabled="False"
-                  ToolTip.Tip="Deferred KnownGap: Import requires the rendered sample bitmap (WinForms-coupled DrawBattleAnime via PaletteFormRef.MakePaletteBitmapToUIEx) (#399)." />
+                  IsEnabled="True"
+                  Click="Import_Click" />
           <Button AutomationProperties.AutomationId="ImageBattleAnimePallet_Export_Button"
                   Name="ExportButton" Content="Export Image" Width="140"
                   IsEnabled="False"

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml.cs
@@ -458,7 +458,8 @@ namespace FEBuilderGBA.Avalonia.Views
             var loadResult = ImageImportService.LoadAndQuantizeFromFile(filePath,
                 expectedWidth: 0, expectedHeight: 0,
                 maxColors: ImageBattleAnimePaletteCore.ColorsPerSlot,
-                strictSize: false);
+                strictSize: false,
+                requireTileMultiple: false); // FIX 1 (#871): palette-only accepts any image size
 
             if (loadResult == null || !loadResult.Success)
             {
@@ -469,6 +470,19 @@ namespace FEBuilderGBA.Avalonia.Views
 
             // Pad to exactly 32 bytes if fewer than 16 colors quantized.
             byte[] gbaPalette = PadGBAPaletteTo16(loadResult.GBAPalette);
+
+            // FIX 2 (#871): snapshot VM palette BEFORE DoImport so we can
+            // restore the VM/UI if the ROM write later fails or returns
+            // U.NOT_FOUND. Without this, the ROM is rolled back by
+            // UndoService but the VM still shows the imported (unpersisted)
+            // palette -- an inconsistent UI state.
+            byte[] rSnap = new byte[16], gSnap = new byte[16], bSnap = new byte[16];
+            for (int si = 0; si < 16; si++)
+            {
+                rSnap[si] = _vm.GetR(si);
+                gSnap[si] = _vm.GetG(si);
+                bSnap[si] = _vm.GetB(si);
+            }
 
             bool applied = _vm.DoImport(gbaPalette);
             if (!applied)
@@ -491,6 +505,8 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 Log.Error("Import_Click: Write threw: {0}", ex.Message);
                 _undoService.Rollback();
+                // FIX 2: restore pre-import VM state so the UI matches the rolled-back ROM.
+                RestorePaletteSnapshot(rSnap, gSnap, bSnap);
                 return;
             }
 
@@ -498,6 +514,8 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 _undoService.Rollback();
                 Log.Notify("Import_Click: write failed; rollback applied.");
+                // FIX 2: restore pre-import VM state so the UI matches the rolled-back ROM.
+                RestorePaletteSnapshot(rSnap, gSnap, bSnap);
                 return;
             }
 
@@ -510,19 +528,33 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         /// <summary>
-        /// Pad or truncate a GBA palette byte array to exactly
+        /// Restore the VM R/G/B arrays from a pre-import snapshot and refresh
+        /// the spinners/swatches. Called when a ROM write fails so the UI stays
+        /// in sync with the rolled-back ROM state. FIX 2 (#871).
+        /// </summary>
+        void RestorePaletteSnapshot(byte[] rSnap, byte[] gSnap, byte[] bSnap)
+        {
+            for (int i = 0; i < 16; i++)
+            {
+                _vm.SetR(i, rSnap[i]);
+                _vm.SetG(i, gSnap[i]);
+                _vm.SetB(i, bSnap[i]);
+            }
+            PopulateAllSpinnersAndSwatches();
+        }
+
+        /// <summary>
+        /// Pad <em>or truncate</em> a GBA palette byte array to exactly
         /// <see cref="ImageBattleAnimePaletteCore.SlotByteSize"/> (32) bytes.
         /// Required because <see cref="DecreaseColorCore.Quantize"/> may
         /// return fewer than 16 colors when the source image has few
-        /// distinct hues. Extra bytes are zero-filled.
+        /// distinct hues; extra colors beyond 16 are dropped. FIX 3 (#871).
         /// </summary>
         static byte[] PadGBAPaletteTo16(byte[] gbaPalette)
         {
             int needed = ImageBattleAnimePaletteCore.SlotByteSize; // 32
-            if (gbaPalette != null && gbaPalette.Length >= needed)
-            {
-                return gbaPalette; // Already big enough.
-            }
+            // FIX 3 (#871): always copy into a fresh 32-byte buffer (truncate when longer,
+            // zero-fill when shorter or null). Prior impl returned array unchanged >= 32 bytes.
             byte[] padded = new byte[needed];
             if (gbaPalette != null)
             {

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using global::Avalonia.Media;
+using FEBuilderGBA.Avalonia.Dialogs;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 
@@ -408,6 +409,126 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 Log.Error("ImageBattleAnimePalletView.RefreshListPreservingSelection failed: {0}", ex.Message);
             }
+        }
+
+        // -----------------------------------------------------------------
+        // Import path — mirrors WF PaletteFormRef.MakePaletteBitmapToUIEx
+        // (file-picker → quantize → load palette into VM → write to ROM).
+        // No dependency on DrawBattleAnime — the WF tooltip was wrong.
+        // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Open a file picker, load and quantize the chosen image to 16 GBA
+        /// RGB555 colors, apply them to the VM, then write to ROM under a
+        /// single <see cref="UndoService"/> scope. Mirrors WinForms
+        /// <c>ImportButton_Click</c>: PaletteFormRef.MakePaletteBitmapToUIEx
+        /// (file open → palette extract) + PaletteWriteButton.PerformClick().
+        /// </summary>
+        async void Import_Click(object sender, RoutedEventArgs e)
+        {
+            if (!_vm.IsLoaded || _vm.PaletteAddress == 0)
+            {
+                Log.Notify("Import_Click: no palette loaded.");
+                return;
+            }
+
+            // Open file dialog — mirrors WF ImageFormRef.OpenFilenameDialogFullColor.
+            string filePath = await FileDialogHelper.OpenImageFile(this);
+            if (string.IsNullOrEmpty(filePath))
+            {
+                return; // User cancelled.
+            }
+
+            DoImportFromFile(filePath);
+        }
+
+        /// <summary>
+        /// Load, quantize, apply, and write the palette from
+        /// <paramref name="filePath"/>. Extracted so tests can inject a path
+        /// without a file dialog (injectable seam — calls <see cref="_vm.DoImport"/>
+        /// which is the VM-level seam).
+        /// </summary>
+        internal void DoImportFromFile(string filePath)
+        {
+            // Quantize to 16 GBA colors — no dimension validation needed;
+            // only the palette matters for this editor.
+            // Use a 1x1 dummy size to skip the "must be multiples of 8" guard
+            // by passing 0 for expected dimensions (ImageImportService skips
+            // the strict-size check when strictSize=false and expectedWidth/Height=0).
+            var loadResult = ImageImportService.LoadAndQuantizeFromFile(filePath,
+                expectedWidth: 0, expectedHeight: 0,
+                maxColors: ImageBattleAnimePaletteCore.ColorsPerSlot,
+                strictSize: false);
+
+            if (loadResult == null || !loadResult.Success)
+            {
+                string err = loadResult?.Error ?? "Unknown error";
+                Log.Error("Import_Click: image load/quantize failed: {0}", err);
+                return;
+            }
+
+            // Pad to exactly 32 bytes if fewer than 16 colors quantized.
+            byte[] gbaPalette = PadGBAPaletteTo16(loadResult.GBAPalette);
+
+            bool applied = _vm.DoImport(gbaPalette);
+            if (!applied)
+            {
+                Log.Error("Import_Click: DoImport rejected palette bytes (null or < 32 bytes)");
+                return;
+            }
+
+            // Sync spinners + swatches to the new VM colors before writing.
+            PopulateAllSpinnersAndSwatches();
+
+            // Write to ROM under a single undo scope — same flow as PaletteWrite_Click.
+            _undoService.Begin("Import Battle Anime Palette");
+            uint newOffset;
+            try
+            {
+                newOffset = _vm.Write();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("Import_Click: Write threw: {0}", ex.Message);
+                _undoService.Rollback();
+                return;
+            }
+
+            if (newOffset == U.NOT_FOUND)
+            {
+                _undoService.Rollback();
+                Log.Notify("Import_Click: write failed; rollback applied.");
+                return;
+            }
+
+            _undoService.Commit();
+            AddressBox.Value = _vm.PaletteAddress;
+            if (newOffset != U.NOT_FOUND)
+            {
+                RefreshListPreservingSelection();
+            }
+        }
+
+        /// <summary>
+        /// Pad or truncate a GBA palette byte array to exactly
+        /// <see cref="ImageBattleAnimePaletteCore.SlotByteSize"/> (32) bytes.
+        /// Required because <see cref="DecreaseColorCore.Quantize"/> may
+        /// return fewer than 16 colors when the source image has few
+        /// distinct hues. Extra bytes are zero-filled.
+        /// </summary>
+        static byte[] PadGBAPaletteTo16(byte[] gbaPalette)
+        {
+            int needed = ImageBattleAnimePaletteCore.SlotByteSize; // 32
+            if (gbaPalette != null && gbaPalette.Length >= needed)
+            {
+                return gbaPalette; // Already big enough.
+            }
+            byte[] padded = new byte[needed];
+            if (gbaPalette != null)
+            {
+                System.Array.Copy(gbaPalette, padded, Math.Min(gbaPalette.Length, needed));
+            }
+            return padded;
         }
 
         void Clipboard_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary

- Wire the Import button in `ImageBattleAnimePalletView` (was `IsEnabled="False"` stub since #399)
- Correct the mechanism: WF `PaletteFormRef.MakePaletteBitmapToUIEx` is a **file picker import** (not a sample-bitmap extract — the old stub tooltip was wrong)
- `FileDialogHelper.OpenImageFile` → `ImageImportService.LoadAndQuantizeFromFile` → `PadGBAPaletteTo16` → `_vm.DoImport(palette)` → `_vm.Write()` under `_undoService.Begin/Commit/Rollback`
- Injectable seam: `ImageBattleAnimePalletViewModel.DoImport(byte[])` accepts a raw 32-byte GBA palette — tests bypass the file dialog

Closes #869

## STEP 0 Verification

`PaletteFormRef.MakePaletteBitmapToUIEx` (WF line 374–488) opens `ImageFormRef.OpenFilenameDialogFullColor` — a standard file picker dialog for PNG/BMP. It does NOT extract colors from the rendered `DrawBitmap` sample. The "DrawBattleAnime coupling" in the old stub tooltip was incorrect. Implementation proceeds.

## Test plan

- [x] Build Core, CLI, SkiaSharp, Avalonia: 0 errors
- [x] `dotnet test FEBuilderGBA.Core.Tests` — 2392/2392 passed
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` — 7279/7282 passed (3 pre-existing skips)
- [x] `scripts/validate-automation-ids.ps1` exits 0 (VALIDATION PASSED)
- [x] Import button: `IsEnabled="True"`, `Click="Import_Click"` wired in AXAML
- [x] `View_ImportButton_IsWiredAndEnabled` — PASS
- [x] `View_ImportButton_HandlerExists` — PASS
- [x] `ViewModel_DoImport_PopulatesAllRgbFromGbaPalette` — PASS
- [x] `ViewModel_DoImport_ReturnsFalse_WhenNull` — PASS
- [x] `ViewModel_DoImport_ReturnsFalse_WhenTooShort` — PASS
- [x] `ViewModel_DoImport_AcceptsLongerArray` — PASS
- [x] `ViewModel_DoImport_RoundTrip_WritesExpectedBytesToRom` — PASS
- [x] L10n coverage: `AvaloniaViews_HaveJaAndZhTranslations` — PASS (tooltip removed, no new untranslated strings)
- [x] Screenshot captured via `--screenshot-all` with FE8U.gba (real render, not fabricated)

## GUI Test Report

| Test | Result |
|------|--------|
| Editor opens with animation list | PASS |
| Import Image button visible + enabled | PASS |
| Export Image button visible (gated) | PASS |
| Clipboard button wired | PASS |
| Undo button wired | PASS |
| Palette type combo (Player/Enemy/Other/4th Army) | PASS |
| Palette Write button | PASS |
| Battle anime sample renders in preview | PASS |
| 16 R/G/B palette sliders shown | PASS |

## Screenshots

![Battle Animation Palette Import — editor with Import Image enabled](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr869-battleanimepallet-import.png)

*Screenshot from docs PR #870 (committed to master so URL survives branch deletion).*

---
*Generated with [Claude Code](https://claude.ai/code) v2.1.156 (model: claude-sonnet-4-6)*