### PR TITLE
feat(avalonia): Battle Screen per-image Import/Export (closes #872)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleScreenParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleScreenParityTests.cs
@@ -396,17 +396,32 @@ public class ImageBattleScreenParityTests
             RegexOptions.Singleline), axaml);
     }
 
+    /// <summary>
+    /// #872: per-image Import/Export buttons (Image1..5) are now fully wired —
+    /// they carry Click handlers (not IsEnabled="False" stubs). This replaces the
+    /// old "IsHonestlyDeferredKnownGap" assertion.
+    /// </summary>
     [Fact]
-    public void View_PerImageImportExport_IsHonestlyDeferredKnownGap()
+    public void View_PerImageImportExport_IsWiredAndEnabled()
     {
-        // Per-image Import/Export buttons (image1..5) are also WF-coupled.
+        // Per #872: buttons are wired with Click handlers and must NOT carry
+        // the old KnownGap IsEnabled="False" stub marker.
         string axaml = ReadAxaml();
         for (int i = 1; i <= 5; i++)
         {
+            // Import button must have a Click handler.
             Assert.Matches(new Regex(
+                $@"AutomationId=""ImageBattleScreen_Image{i}_Import_Button""[\s\S]{{0,200}}Click=""Image{i}Import_Click""",
+                RegexOptions.Singleline), axaml);
+            // Export button must have a Click handler.
+            Assert.Matches(new Regex(
+                $@"AutomationId=""ImageBattleScreen_Image{i}_Export_Button""[\s\S]{{0,200}}Click=""Image{i}Export_Click""",
+                RegexOptions.Singleline), axaml);
+            // The KnownGap IsEnabled="False" stub must be gone.
+            Assert.DoesNotMatch(new Regex(
                 $@"AutomationId=""ImageBattleScreen_Image{i}_Import_Button""[\s\S]{{0,400}}IsEnabled=""False""",
                 RegexOptions.Singleline), axaml);
-            Assert.Matches(new Regex(
+            Assert.DoesNotMatch(new Regex(
                 $@"AutomationId=""ImageBattleScreen_Image{i}_Export_Button""[\s\S]{{0,400}}IsEnabled=""False""",
                 RegexOptions.Singleline), axaml);
         }

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml
@@ -383,11 +383,13 @@
                              Name="Image1ZImage" Width="160" Minimum="0" Maximum="4294967295"
                              FormatString="0" VerticalAlignment="Center" />
               <Button AutomationProperties.AutomationId="ImageBattleScreen_Image1_Import_Button"
-                      Content="Image Import" Width="140" IsEnabled="False"
-                      ToolTip.Tip="KnownGap: per-image LZ77 Import (ImageFormRef.ImportFilenameDialog + ImageUtil.ImageToByte16Tile) is WinForms-coupled (#393)." />
+                      Name="Image1ImportButton"
+                      Content="Image Import" Width="140"
+                      Click="Image1Import_Click" />
               <Button AutomationProperties.AutomationId="ImageBattleScreen_Image1_Export_Button"
-                      Content="Image Export" Width="140" IsEnabled="False"
-                      ToolTip.Tip="KnownGap: per-image PNG Export (ImageFormRef.ExportImage) is WinForms-coupled (#393)." />
+                      Name="Image1ExportButton"
+                      Content="Image Export" Width="140"
+                      Click="Image1Export_Click" />
             </StackPanel>
             <!-- Image1 per-image preview (#816): rendered at its NATURAL W x H
                  (ImageBattleScreenCore.RenderSingleImagePreview(0), palette
@@ -416,11 +418,13 @@
                              Name="Image2ZImage" Width="160" Minimum="0" Maximum="4294967295"
                              FormatString="0" VerticalAlignment="Center" />
               <Button AutomationProperties.AutomationId="ImageBattleScreen_Image2_Import_Button"
-                      Content="Image Import" Width="140" IsEnabled="False"
-                      ToolTip.Tip="KnownGap: per-image LZ77 Import is WinForms-coupled (#393)." />
+                      Name="Image2ImportButton"
+                      Content="Image Import" Width="140"
+                      Click="Image2Import_Click" />
               <Button AutomationProperties.AutomationId="ImageBattleScreen_Image2_Export_Button"
-                      Content="Image Export" Width="140" IsEnabled="False"
-                      ToolTip.Tip="KnownGap: per-image PNG Export is WinForms-coupled (#393)." />
+                      Name="Image2ExportButton"
+                      Content="Image Export" Width="140"
+                      Click="Image2Export_Click" />
               <!-- Image2 per-image preview (#816): liner-width x 8px row
                    (RenderSingleImagePreview(1), palette bank 0, index 0 opaque). -->
               <Border BorderBrush="Gray" BorderThickness="1" Padding="4" MinHeight="40" Width="200"
@@ -439,11 +443,13 @@
                              Name="Image3ZImage" Width="160" Minimum="0" Maximum="4294967295"
                              FormatString="0" VerticalAlignment="Center" />
               <Button AutomationProperties.AutomationId="ImageBattleScreen_Image3_Import_Button"
-                      Content="Image Import" Width="140" IsEnabled="False"
-                      ToolTip.Tip="KnownGap: per-image LZ77 Import is WinForms-coupled (#393)." />
+                      Name="Image3ImportButton"
+                      Content="Image Import" Width="140"
+                      Click="Image3Import_Click" />
               <Button AutomationProperties.AutomationId="ImageBattleScreen_Image3_Export_Button"
-                      Content="Image Export" Width="140" IsEnabled="False"
-                      ToolTip.Tip="KnownGap: per-image PNG Export is WinForms-coupled (#393)." />
+                      Name="Image3ExportButton"
+                      Content="Image Export" Width="140"
+                      Click="Image3Export_Click" />
               <!-- Image3 per-image preview (#816): liner-width x 8px row
                    (RenderSingleImagePreview(2), palette bank 0, index 0 opaque). -->
               <Border BorderBrush="Gray" BorderThickness="1" Padding="4" MinHeight="40" Width="200"
@@ -469,11 +475,13 @@
                              Name="Image4ZImage" Width="160" Minimum="0" Maximum="4294967295"
                              FormatString="0" VerticalAlignment="Center" />
               <Button AutomationProperties.AutomationId="ImageBattleScreen_Image4_Import_Button"
-                      Content="Image Import" Width="140" IsEnabled="False"
-                      ToolTip.Tip="KnownGap: per-image LZ77 Import is WinForms-coupled (#393)." />
+                      Name="Image4ImportButton"
+                      Content="Image Import" Width="140"
+                      Click="Image4Import_Click" />
               <Button AutomationProperties.AutomationId="ImageBattleScreen_Image4_Export_Button"
-                      Content="Image Export" Width="140" IsEnabled="False"
-                      ToolTip.Tip="KnownGap: per-image PNG Export is WinForms-coupled (#393)." />
+                      Name="Image4ExportButton"
+                      Content="Image Export" Width="140"
+                      Click="Image4Export_Click" />
               <!-- Image4 per-image preview (#816): liner-width x 8px row
                    (RenderSingleImagePreview(3), palette bank 0, index 0 opaque). -->
               <Border BorderBrush="Gray" BorderThickness="1" Padding="4" MinHeight="40" Width="200"
@@ -492,11 +500,13 @@
                              Name="Image5ZImage" Width="160" Minimum="0" Maximum="4294967295"
                              FormatString="0" VerticalAlignment="Center" />
               <Button AutomationProperties.AutomationId="ImageBattleScreen_Image5_Import_Button"
-                      Content="Image Import" Width="140" IsEnabled="False"
-                      ToolTip.Tip="KnownGap: per-image LZ77 Import is WinForms-coupled (#393)." />
+                      Name="Image5ImportButton"
+                      Content="Image Import" Width="140"
+                      Click="Image5Import_Click" />
               <Button AutomationProperties.AutomationId="ImageBattleScreen_Image5_Export_Button"
-                      Content="Image Export" Width="140" IsEnabled="False"
-                      ToolTip.Tip="KnownGap: per-image PNG Export is WinForms-coupled (#393)." />
+                      Name="Image5ExportButton"
+                      Content="Image Export" Width="140"
+                      Click="Image5Export_Click" />
               <!-- Image5 per-image preview (#816): liner-width x 8px row
                    (RenderSingleImagePreview(4), palette bank 0, index 0 opaque). -->
               <Border BorderBrush="Gray" BorderThickness="1" Padding="4" MinHeight="40" Width="200"

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml.cs
@@ -537,31 +537,34 @@ namespace FEBuilderGBA.Avalonia.Views
         // -----------------------------------------------------------------
 
         // Image1
-        void Image1Export_Click(object? sender, RoutedEventArgs e) => ImageExport_Click(0, Image1Preview, "battle_screen_image1");
+        async void Image1Export_Click(object? sender, RoutedEventArgs e) => await ImageExport_Click(0, Image1Preview, "battle_screen_image1");
         async void Image1Import_Click(object? sender, RoutedEventArgs e) => await ImageImport_Click(0);
 
         // Image2
-        void Image2Export_Click(object? sender, RoutedEventArgs e) => ImageExport_Click(1, Image2Preview, "battle_screen_image2");
+        async void Image2Export_Click(object? sender, RoutedEventArgs e) => await ImageExport_Click(1, Image2Preview, "battle_screen_image2");
         async void Image2Import_Click(object? sender, RoutedEventArgs e) => await ImageImport_Click(1);
 
         // Image3
-        void Image3Export_Click(object? sender, RoutedEventArgs e) => ImageExport_Click(2, Image3Preview, "battle_screen_image3");
+        async void Image3Export_Click(object? sender, RoutedEventArgs e) => await ImageExport_Click(2, Image3Preview, "battle_screen_image3");
         async void Image3Import_Click(object? sender, RoutedEventArgs e) => await ImageImport_Click(2);
 
         // Image4
-        void Image4Export_Click(object? sender, RoutedEventArgs e) => ImageExport_Click(3, Image4Preview, "battle_screen_image4");
+        async void Image4Export_Click(object? sender, RoutedEventArgs e) => await ImageExport_Click(3, Image4Preview, "battle_screen_image4");
         async void Image4Import_Click(object? sender, RoutedEventArgs e) => await ImageImport_Click(3);
 
         // Image5
-        void Image5Export_Click(object? sender, RoutedEventArgs e) => ImageExport_Click(4, Image5Preview, "battle_screen_image5");
+        async void Image5Export_Click(object? sender, RoutedEventArgs e) => await ImageExport_Click(4, Image5Preview, "battle_screen_image5");
         async void Image5Import_Click(object? sender, RoutedEventArgs e) => await ImageImport_Click(4);
 
         /// <summary>
         /// Export one per-image strip as PNG. Reads the current rendered IImage
         /// from the GbaImageControl (same surface shown in the preview, so what
         /// the user sees is what gets exported). Read-only; no ROM write.
+        /// Mirrors <see cref="BattleExportPng_Click"/>: awaits ExportPng and
+        /// logs/surfaces any File.Create / bitmap.Save exception so it is never
+        /// swallowed as an unobserved task exception (#874 review fix).
         /// </summary>
-        void ImageExport_Click(int imageIndex, Controls.GbaImageControl previewControl, string suggestedName)
+        internal async System.Threading.Tasks.Task ImageExport_Click(int imageIndex, Controls.GbaImageControl previewControl, string suggestedName)
         {
             if (previewControl == null) return;
             if (!previewControl.HasImage)
@@ -569,9 +572,14 @@ namespace FEBuilderGBA.Avalonia.Views
                 Log.Notify($"ImageExport_Click({imageIndex}): no image rendered; cannot export.");
                 return;
             }
-            // ExportPng is async (file dialog) but we fire-and-forget here via
-            // async void at the public-facing thin wrappers (no result needed).
-            _ = previewControl.ExportPng(this, suggestedName);
+            try
+            {
+                await previewControl.ExportPng(this, suggestedName);
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"ImageBattleScreenView.ImageExport_Click({imageIndex}) failed: {ex.Message}");
+            }
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml.cs
@@ -4,11 +4,13 @@
 // `ImageBattleScreenCore` helper (which delegates palette I/O to PaletteCore)
 // for the TSA + palette + image-pointer write paths under the ambient
 // UndoService scope.
+// Per-image Import/Export wired in #872.
 using System;
 using System.Globalization;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using global::Avalonia.Media;
+using FEBuilderGBA.Avalonia.Dialogs;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 
@@ -514,6 +516,172 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 Log.Error("BulkUndo_Click failed: {0}", ex.Message);
             }
+        }
+
+        // -----------------------------------------------------------------
+        // Per-image Import/Export handlers (Image1..Image5, #872).
+        //
+        // Export: render the image strip via ImageBattleScreenCore
+        //   → GbaImageControl.ExportPng → save PNG.
+        //   Read-only; no ROM write; no undo scope needed.
+        //
+        // Import: open file dialog → LoadAndQuantizeFromFile (maps user pixels
+        //   to existing shared palette) → ImageBattleScreenCore.WritePerImageStrip
+        //   (EncodeDirectTiles4bpp → LZ77 → free-space write + repoint) → refresh
+        //   all previews. Wrapped in _undoService.Begin/Commit/Rollback so a
+        //   failed write leaves the ROM in the pre-import state.
+        //
+        // The shared palette is read-only during per-image import (it is shared
+        // across all 5 image strips -- mirroring the WF RevChipImage path which
+        // never writes the palette). The user must use the Palette tab for that.
+        // -----------------------------------------------------------------
+
+        // Image1
+        void Image1Export_Click(object? sender, RoutedEventArgs e) => ImageExport_Click(0, Image1Preview, "battle_screen_image1");
+        async void Image1Import_Click(object? sender, RoutedEventArgs e) => await ImageImport_Click(0);
+
+        // Image2
+        void Image2Export_Click(object? sender, RoutedEventArgs e) => ImageExport_Click(1, Image2Preview, "battle_screen_image2");
+        async void Image2Import_Click(object? sender, RoutedEventArgs e) => await ImageImport_Click(1);
+
+        // Image3
+        void Image3Export_Click(object? sender, RoutedEventArgs e) => ImageExport_Click(2, Image3Preview, "battle_screen_image3");
+        async void Image3Import_Click(object? sender, RoutedEventArgs e) => await ImageImport_Click(2);
+
+        // Image4
+        void Image4Export_Click(object? sender, RoutedEventArgs e) => ImageExport_Click(3, Image4Preview, "battle_screen_image4");
+        async void Image4Import_Click(object? sender, RoutedEventArgs e) => await ImageImport_Click(3);
+
+        // Image5
+        void Image5Export_Click(object? sender, RoutedEventArgs e) => ImageExport_Click(4, Image5Preview, "battle_screen_image5");
+        async void Image5Import_Click(object? sender, RoutedEventArgs e) => await ImageImport_Click(4);
+
+        /// <summary>
+        /// Export one per-image strip as PNG. Reads the current rendered IImage
+        /// from the GbaImageControl (same surface shown in the preview, so what
+        /// the user sees is what gets exported). Read-only; no ROM write.
+        /// </summary>
+        void ImageExport_Click(int imageIndex, Controls.GbaImageControl previewControl, string suggestedName)
+        {
+            if (previewControl == null) return;
+            if (!previewControl.HasImage)
+            {
+                Log.Notify($"ImageExport_Click({imageIndex}): no image rendered; cannot export.");
+                return;
+            }
+            // ExportPng is async (file dialog) but we fire-and-forget here via
+            // async void at the public-facing thin wrappers (no result needed).
+            _ = previewControl.ExportPng(this, suggestedName);
+        }
+
+        /// <summary>
+        /// Import a PNG/BMP file as one per-image strip (#872).
+        ///
+        /// Pipeline:
+        ///   1. Open file dialog.
+        ///   2. Read current strip dimensions from Core so the user-supplied
+        ///      image can be validated (strictSize=true).
+        ///   3. Quantize against the existing shared battle-screen palette
+        ///      (LoadAndRemapFromFile) -- import NEVER writes the palette.
+        ///   4. WritePerImageStrip under one UndoService scope.
+        ///   5. Reload the VM entry + refresh all previews so the new tiles
+        ///      appear immediately.
+        ///   6. On any failure, Rollback the scope and revert the VM state
+        ///      (snapshot-restore per the #871 lesson).
+        /// </summary>
+        internal async System.Threading.Tasks.Task ImageImport_Click(int imageIndex)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null || rom.RomInfo == null) return;
+            if (!_vm.IsLoaded)
+            {
+                Log.Notify($"ImageImport_Click({imageIndex}): no entry loaded; aborting.");
+                return;
+            }
+
+            // Resolve expected dimensions from Core (same as the preview render path).
+            if (!ImageBattleScreenCore.TryLoadSingleImageStrip(rom, imageIndex, out _, out int widthPx, out int heightPx))
+            {
+                Log.Notify($"ImageImport_Click({imageIndex}): could not determine strip dimensions; aborting.");
+                return;
+            }
+
+            // Read the shared battle-screen palette for quantization remapping.
+            // Returns null if the palette pointer is corrupt/out-of-bounds.
+            if (!ImageBattleScreenCore.TryLoadRawPalettePublic(rom, out byte[] gbaPalette))
+            {
+                Log.Notify($"ImageImport_Click({imageIndex}): could not read shared palette; aborting.");
+                return;
+            }
+
+            // Open file dialog and load+quantize (remap to existing palette so
+            // the user's image is forced to use the current battle-screen colors).
+            string? filePath = await FileDialogHelper.OpenImageFile(this);
+            if (string.IsNullOrEmpty(filePath)) return;
+
+            var loadResult = ImageImportService.LoadAndRemapFromFile(
+                filePath, widthPx, heightPx, gbaPalette, 16, strictSize: true);
+            if (loadResult == null || !loadResult.Success)
+            {
+                string err = loadResult?.Error ?? "Unknown error";
+                Log.Error($"ImageImport_Click({imageIndex}): load/quantize failed: {err}");
+                return;
+            }
+
+            // Snapshot VM state for rollback on write failure (per the #871 lesson:
+            // never leave the UI showing an image that wasn't persisted to ROM).
+            uint[] prevPointers = new uint[]
+            {
+                _vm.Image1Pointer, _vm.Image2Pointer, _vm.Image3Pointer,
+                _vm.Image4Pointer, _vm.Image5Pointer,
+            };
+
+            _undoService.Begin($"Import Image{imageIndex + 1}");
+            bool ok;
+            try
+            {
+                ok = ImageBattleScreenCore.WritePerImageStrip(rom, imageIndex,
+                    loadResult.IndexedPixels, widthPx, heightPx);
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"ImageImport_Click({imageIndex}): WritePerImageStrip threw: {ex.Message}");
+                _undoService.Rollback();
+                RestoreVmPointers(prevPointers);
+                return;
+            }
+
+            if (!ok)
+            {
+                Log.Notify($"ImageImport_Click({imageIndex}): write failed; rolling back.");
+                _undoService.Rollback();
+                RestoreVmPointers(prevPointers);
+                return;
+            }
+
+            _undoService.Commit();
+
+            // Reload so the VM reflects the new pointer written by WritePerImageStrip.
+            _vm.LoadEntry();
+            PopulateUI();
+            RefreshBattlePreview();
+            RefreshChipsetPreview();
+            RefreshImagePreviews();
+        }
+
+        /// <summary>
+        /// Restore VM image-pointer properties from a snapshot (snapshot-restore
+        /// per the #871 lesson: a failed write must not leave the UI showing an
+        /// unpersisted image). Called from the import failure paths.
+        /// </summary>
+        void RestoreVmPointers(uint[] snapshot)
+        {
+            if (snapshot == null || snapshot.Length < 5) return;
+            _vm.Image1Pointer = snapshot[0];
+            _vm.Image2Pointer = snapshot[1];
+            _vm.Image3Pointer = snapshot[2];
+            _vm.Image4Pointer = snapshot[3];
+            _vm.Image5Pointer = snapshot[4];
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Core.Tests/ImageBattleScreenPerImageImportTests.cs
+++ b/FEBuilderGBA.Core.Tests/ImageBattleScreenPerImageImportTests.cs
@@ -372,6 +372,147 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         // ---------------------------------------------------------------------------
+        // FIX 1 (#874 review): ImageExport_Click must be async + awaited so
+        // File.Create / bitmap.Save exceptions are never swallowed.
+        // ---------------------------------------------------------------------------
+
+        [Fact]
+        public void CodeBehind_ImageExport_Click_IsAsyncAndAwaited()
+        {
+            string code = System.IO.File.ReadAllText(CodeBehindPath());
+            // The shared ImageExport_Click helper (internal Task) must be async.
+            Assert.Matches(new System.Text.RegularExpressions.Regex(
+                @"async\s+.*?Task\s+ImageExport_Click\(",
+                System.Text.RegularExpressions.RegexOptions.Singleline), code);
+        }
+
+        [Fact]
+        public void CodeBehind_ImageExportWrappers_AwaitImageExport_Click()
+        {
+            string code = System.IO.File.ReadAllText(CodeBehindPath());
+            // All five thin wrappers (Image1..Image5Export_Click) must await
+            // ImageExport_Click rather than fire-and-forget.
+            for (int i = 1; i <= 5; i++)
+            {
+                Assert.Matches(new System.Text.RegularExpressions.Regex(
+                    $@"async\s+void\s+Image{i}Export_Click[\s\S]{{0,200}}await\s+ImageExport_Click\(",
+                    System.Text.RegularExpressions.RegexOptions.Singleline), code);
+            }
+        }
+
+        [Fact]
+        public void CodeBehind_ImageExport_Click_HasTryCatch()
+        {
+            string code = System.IO.File.ReadAllText(CodeBehindPath());
+            // The export handler must wrap ExportPng in a try/catch that logs
+            // failures (mirrors BattleExportPng_Click error-handling pattern).
+            Assert.Matches(new System.Text.RegularExpressions.Regex(
+                @"await\s+previewControl\.ExportPng[\s\S]{0,200}catch\s*\(\s*Exception",
+                System.Text.RegularExpressions.RegexOptions.Singleline), code);
+        }
+
+        // ---------------------------------------------------------------------------
+        // FIX 2 (#874 review): WritePerImageStrip with an unsafe pointerSlot
+        // (zero / out-of-bounds) must return false and NOT throw or corrupt.
+        //
+        // Strategy: use a ROMFE0 ("NAZO") ROM whose battle_screen_image1_pointer
+        // defaults to 0 (uninitialized). isSafetyOffset(0, rom) is false because
+        // 0 < 0x200, so IsRegionSafe(rom, 0, 4) returns false — the guard fires
+        // before any data is encoded or written.
+        // ---------------------------------------------------------------------------
+
+        /// <summary>
+        /// Build a NAZO ROM (ROMFE0) whose pointer properties are zero-initialized
+        /// so the image pointer slots are 0, which is below the isSafetyOffset
+        /// lower-bound (0x200) and therefore rejected by IsRegionSafe.
+        /// </summary>
+        static ROM MakeUnsafeSlotRom()
+        {
+            var rom = new ROM();
+            // NAZO version requires any size (no minimum). Use 1 MB.
+            byte[] data = new byte[0x100000];
+            // Fill with 0xFF so there are no false free-space hits.
+            Array.Fill(data, (byte)0xFF);
+            rom.LoadLow("nazo.gba", data, "NAZO");
+            // ROMFE0.battle_screen_image1_pointer == 0 (default for unset uint).
+            return rom;
+        }
+
+        [Fact]
+        public void WritePerImageStrip_UnsafePointerSlot_ReturnsFalseNoThrow()
+        {
+            // The NAZO ROM has battle_screen_image1_pointer == 0, which fails
+            // IsRegionSafe (0 < 0x200). WritePerImageStrip must return false
+            // without throwing and without calling WriteCompressedToROM.
+            ROM rom = MakeUnsafeSlotRom();
+            var prevRom = CoreState.ROM;
+            var prevUndo = CoreState.Undo;
+            try
+            {
+                CoreState.ROM = rom;
+                CoreState.Undo = new Undo();
+
+                int w = 8, h = 8;
+                byte[] pixels = MakeSolidIndexedPixels(w, h, palIndex: 1);
+
+                bool result = true; // set to true so we can detect it going false
+                var ex = Record.Exception(() =>
+                {
+                    Undo.UndoData ud = CoreState.Undo.NewUndoData("test unsafe slot");
+                    using (ROM.BeginUndoScope(ud))
+                    {
+                        result = ImageBattleScreenCore.WritePerImageStrip(rom, 0, pixels, w, h);
+                    }
+                });
+                Assert.Null(ex);
+                Assert.False(result);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.Undo = prevUndo;
+            }
+        }
+
+        [Fact]
+        public void WritePerImageStrip_UnsafePointerSlot_DoesNotCorruptROM()
+        {
+            // Same NAZO ROM. Verifies that NO ROM bytes change when the guard
+            // fires (early return before EncodeDirectTiles4bpp means
+            // WriteCompressedToROM is never reached).
+            ROM rom = MakeUnsafeSlotRom();
+            var prevRom = CoreState.ROM;
+            var prevUndo = CoreState.Undo;
+            try
+            {
+                CoreState.ROM = rom;
+                CoreState.Undo = new Undo();
+
+                // Snapshot ALL bytes.
+                byte[] before = (byte[])rom.Data.Clone();
+
+                int w = 8, h = 8;
+                byte[] pixels = MakeSolidIndexedPixels(w, h, palIndex: 2);
+
+                Undo.UndoData ud = CoreState.Undo.NewUndoData("test corrupt guard");
+                using (ROM.BeginUndoScope(ud))
+                {
+                    ImageBattleScreenCore.WritePerImageStrip(rom, 0, pixels, w, h);
+                }
+
+                // Every byte must be byte-for-byte identical — no partial write.
+                Assert.Equal(before.Length, rom.Data.Length);
+                for (int i = 0; i < before.Length; i++)
+                    Assert.Equal(before[i], rom.Data[i]);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.Undo = prevUndo;
+            }
+        }
+
+        // ---------------------------------------------------------------------------
         // Helpers
         // ---------------------------------------------------------------------------
 

--- a/FEBuilderGBA.Core.Tests/ImageBattleScreenPerImageImportTests.cs
+++ b/FEBuilderGBA.Core.Tests/ImageBattleScreenPerImageImportTests.cs
@@ -1,0 +1,482 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for ImageBattleScreenCore.WritePerImageStrip +
+// TryLoadRawPalettePublic (issue #872: per-image Import/Export).
+//
+// Pipeline under test (mirrors the Avalonia ImageImport_Click path):
+//   indexedPixels -> EncodeDirectTiles4bpp -> LZ77.compress
+//   -> free-space write + pointer update (WriteCompressedToROM)
+//
+// Round-trip proof: import tiles, then decompress at the new pointer and
+// compare raw 4bpp bytes. Export proof: RenderSingleImagePreview returns
+// a non-null IImage with the correct pixel color after import.
+// Rollback: RunUndo() restores the original pointer + ROM bytes.
+using System;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class ImageBattleScreenPerImageImportTests
+    {
+        // Storage offsets for the planted battle-screen sources.
+        const uint PALETTE_OFFSET = 0x105000;
+        const uint IMAGE1_OFFSET  = 0x110000;
+        const uint IMAGE2_OFFSET  = 0x114000;
+        const uint IMAGE3_OFFSET  = 0x118000;
+        const uint IMAGE4_OFFSET  = 0x11C000;
+        const uint IMAGE5_OFFSET  = 0x120000;
+
+        // Free-space region planted at 0x800000 for WriteCompressedToROM to find.
+        const uint FREE_SPACE_OFFSET = 0x800000;
+
+        // ---------------------------------------------------------------------------
+        // TryLoadRawPalettePublic
+        // ---------------------------------------------------------------------------
+
+        [Fact]
+        public void TryLoadRawPalettePublic_ValidRom_ReturnsTrueAndPaletteBytes()
+        {
+            ROM rom = MakeRom();
+            bool ok = ImageBattleScreenCore.TryLoadRawPalettePublic(rom, out byte[] pal);
+            Assert.True(ok);
+            Assert.NotNull(pal);
+            Assert.Equal(512, pal.Length); // 16 banks x 16 colors x 2 bytes
+        }
+
+        [Fact]
+        public void TryLoadRawPalettePublic_NullRom_ReturnsFalse()
+        {
+            bool ok = ImageBattleScreenCore.TryLoadRawPalettePublic(null, out byte[] pal);
+            Assert.False(ok);
+            Assert.Null(pal);
+        }
+
+        [Fact]
+        public void TryLoadRawPalettePublic_CorruptPalettePointer_ReturnsFalse()
+        {
+            ROM rom = MakeRom();
+            // Point palette at an out-of-bounds offset.
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_palette_pointer, U.toPointer(0x1FFFFFF0));
+            bool ok = ImageBattleScreenCore.TryLoadRawPalettePublic(rom, out byte[] pal);
+            Assert.False(ok);
+            Assert.Null(pal);
+        }
+
+        // ---------------------------------------------------------------------------
+        // WritePerImageStrip — argument validation
+        // ---------------------------------------------------------------------------
+
+        [Fact]
+        public void WritePerImageStrip_NullRom_ReturnsFalse()
+        {
+            byte[] pixels = new byte[8 * 8]; // 8x8 = 1 tile
+            bool ok = ImageBattleScreenCore.WritePerImageStrip(null, 0, pixels, 8, 8);
+            Assert.False(ok);
+        }
+
+        [Fact]
+        public void WritePerImageStrip_NullPixels_ReturnsFalse()
+        {
+            ROM rom = MakeRom();
+            bool ok = ImageBattleScreenCore.WritePerImageStrip(rom, 0, null, 8, 8);
+            Assert.False(ok);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(5)]
+        [InlineData(100)]
+        public void WritePerImageStrip_BadIndex_ReturnsFalse(int badIndex)
+        {
+            ROM rom = MakeRom();
+            byte[] pixels = new byte[8 * 8];
+            bool ok = ImageBattleScreenCore.WritePerImageStrip(rom, badIndex, pixels, 8, 8);
+            Assert.False(ok);
+        }
+
+        [Fact]
+        public void WritePerImageStrip_DimensionNotMultipleOf8_ReturnsFalse()
+        {
+            ROM rom = MakeRom();
+            byte[] pixels = new byte[7 * 8]; // width 7 is not a multiple of 8
+            bool ok = ImageBattleScreenCore.WritePerImageStrip(rom, 0, pixels, 7, 8);
+            Assert.False(ok);
+        }
+
+        [Fact]
+        public void WritePerImageStrip_PixelArrayWrongSize_ReturnsFalse()
+        {
+            ROM rom = MakeRom();
+            // Width x Height = 16x8 = 128 but we pass only 64 bytes.
+            byte[] pixels = new byte[64];
+            bool ok = ImageBattleScreenCore.WritePerImageStrip(rom, 0, pixels, 16, 8);
+            Assert.False(ok);
+        }
+
+        // ---------------------------------------------------------------------------
+        // WritePerImageStrip — round-trip: import -> decompress at new pointer ->
+        // compare raw 4bpp bytes (representative slots: image2 and image4).
+        // ---------------------------------------------------------------------------
+
+        [Fact]
+        public void WritePerImageStrip_Image2_RoundTrip_DecompressedBytesMatch()
+        {
+            ROM rom = MakeRom();
+            var prevRom = CoreState.ROM;
+            var prevUndo = CoreState.Undo;
+            try
+            {
+                CoreState.ROM = rom;
+                CoreState.Undo = new Undo();
+
+                // image2 is liner-width x 8px. Use 32x8 = 4 tiles.
+                int w = 32, h = 8;
+                byte[] indexedPixels = MakeSolidIndexedPixels(w, h, palIndex: 3); // red
+
+                Undo.UndoData undoData = CoreState.Undo.NewUndoData("test import image2");
+                using (ROM.BeginUndoScope(undoData))
+                {
+                    bool ok = ImageBattleScreenCore.WritePerImageStrip(rom, 1, indexedPixels, w, h);
+                    Assert.True(ok, "WritePerImageStrip(image2) should succeed");
+                }
+                if (undoData.list.Count > 0) CoreState.Undo.Push(undoData);
+
+                // Verify: decompress at the NEW pointer for image2 slot.
+                uint newAddr = rom.p32(rom.RomInfo.battle_screen_image2_pointer);
+                Assert.NotEqual(IMAGE2_OFFSET, newAddr); // pointer was repointed
+                byte[] decompressed = LZ77.decompress(rom.Data, newAddr);
+                Assert.NotNull(decompressed);
+
+                // Encode the same pixels ourselves and compare.
+                byte[] expected = ImageImportCore.EncodeDirectTiles4bpp(indexedPixels, w, h);
+                Assert.NotNull(expected);
+                Assert.Equal(expected.Length, decompressed.Length);
+                for (int i = 0; i < expected.Length; i++)
+                {
+                    Assert.Equal(expected[i], decompressed[i]);
+                }
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.Undo = prevUndo;
+            }
+        }
+
+        [Fact]
+        public void WritePerImageStrip_Image4_RoundTrip_DecompressedBytesMatch()
+        {
+            ROM rom = MakeRom();
+            var prevRom = CoreState.ROM;
+            var prevUndo = CoreState.Undo;
+            try
+            {
+                CoreState.ROM = rom;
+                CoreState.Undo = new Undo();
+
+                // image4 is liner-width x 8px. Use 16x8 = 2 tiles.
+                int w = 16, h = 8;
+                byte[] indexedPixels = MakeSolidIndexedPixels(w, h, palIndex: 5); // green
+
+                Undo.UndoData undoData = CoreState.Undo.NewUndoData("test import image4");
+                using (ROM.BeginUndoScope(undoData))
+                {
+                    bool ok = ImageBattleScreenCore.WritePerImageStrip(rom, 3, indexedPixels, w, h);
+                    Assert.True(ok, "WritePerImageStrip(image4) should succeed");
+                }
+                if (undoData.list.Count > 0) CoreState.Undo.Push(undoData);
+
+                uint newAddr = rom.p32(rom.RomInfo.battle_screen_image4_pointer);
+                Assert.NotEqual(IMAGE4_OFFSET, newAddr);
+                byte[] decompressed = LZ77.decompress(rom.Data, newAddr);
+                Assert.NotNull(decompressed);
+
+                byte[] expected = ImageImportCore.EncodeDirectTiles4bpp(indexedPixels, w, h);
+                Assert.Equal(expected.Length, decompressed.Length);
+                for (int i = 0; i < expected.Length; i++)
+                {
+                    Assert.Equal(expected[i], decompressed[i]);
+                }
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.Undo = prevUndo;
+            }
+        }
+
+        // ---------------------------------------------------------------------------
+        // WritePerImageStrip — export after import: RenderSingleImagePreview returns
+        // valid PNG-magic-equivalent (the IImage has non-zero pixel data and the
+        // correct per-pixel color from the imported tiles).
+        // ---------------------------------------------------------------------------
+
+        [Fact]
+        public void WritePerImageStrip_Image2_ExportAfterImport_RendersCorrectColor()
+        {
+            using var _ = EnsureImageService();
+            ROM rom = MakeRom();
+            var prevRom = CoreState.ROM;
+            var prevUndo = CoreState.Undo;
+            try
+            {
+                CoreState.ROM = rom;
+                CoreState.Undo = new Undo();
+
+                // Import: solid-red (index 3) 32x8 strip into image2 slot.
+                int w = 32, h = 8;
+                byte[] indexedPixels = MakeSolidIndexedPixels(w, h, palIndex: 3); // red
+
+                Undo.UndoData undoData = CoreState.Undo.NewUndoData("test export after import image2");
+                bool ok;
+                using (ROM.BeginUndoScope(undoData))
+                {
+                    ok = ImageBattleScreenCore.WritePerImageStrip(rom, 1, indexedPixels, w, h);
+                }
+                if (undoData.list.Count > 0) CoreState.Undo.Push(undoData);
+                Assert.True(ok);
+
+                // Export: render the strip and check the pixel color.
+                IImage img = ImageBattleScreenCore.RenderSingleImagePreview(rom, 1);
+                Assert.NotNull(img);
+                // palette bank 0 index 3 = GBA 0x001F = BGR15(R=31,G=0,B=0)
+                // -> RGB(248, 0, 0) opaque. GBA BGR15: bits0-4=R, bits5-9=G, bits10-14=B.
+                AssertPixel(img, 0, 0, 248, 0, 0, 255);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.Undo = prevUndo;
+            }
+        }
+
+        // ---------------------------------------------------------------------------
+        // WritePerImageStrip — rollback restores original pointer + ROM bytes
+        // (per the #871 lesson: a failed write leaves no residue).
+        // ---------------------------------------------------------------------------
+
+        [Fact]
+        public void WritePerImageStrip_Rollback_RestoresOriginalPointerAndBytes()
+        {
+            ROM rom = MakeRom();
+            var prevRom = CoreState.ROM;
+            var prevUndo = CoreState.Undo;
+            try
+            {
+                CoreState.ROM = rom;
+                CoreState.Undo = new Undo();
+
+                // Snapshot the original image3 pointer.
+                uint originalAddr = rom.p32(rom.RomInfo.battle_screen_image3_pointer);
+                // Snapshot 16 bytes of ROM at the original location.
+                byte[] before = new byte[16];
+                Array.Copy(rom.Data, originalAddr, before, 0, 16);
+
+                int w = 16, h = 8;
+                byte[] indexedPixels = MakeSolidIndexedPixels(w, h, palIndex: 5);
+
+                // Write, then roll back via Undo.RunUndo().
+                Undo.UndoData undoData = CoreState.Undo.NewUndoData("test rollback image3");
+                using (ROM.BeginUndoScope(undoData))
+                {
+                    bool ok = ImageBattleScreenCore.WritePerImageStrip(rom, 2, indexedPixels, w, h);
+                    Assert.True(ok); // write succeeded before rollback
+                }
+                if (undoData.list.Count > 0)
+                {
+                    CoreState.Undo.Push(undoData);
+                    CoreState.Undo.RunUndo(); // equivalent to UndoService.Rollback()
+                }
+
+                // Pointer must be restored to its original value.
+                uint afterRollback = rom.p32(rom.RomInfo.battle_screen_image3_pointer);
+                Assert.Equal(originalAddr, afterRollback);
+
+                // ROM bytes at the original pointer must be unchanged.
+                for (int i = 0; i < 16; i++)
+                {
+                    Assert.Equal(before[i], rom.Data[originalAddr + i]);
+                }
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.Undo = prevUndo;
+            }
+        }
+
+        // ---------------------------------------------------------------------------
+        // Parity: the 10 per-image buttons are wired (not stubs) in the AXAML.
+        // Static AXAML scan — no runtime dependency.
+        // ---------------------------------------------------------------------------
+
+        [Fact]
+        public void AxamlView_AllPerImageButtons_AreWiredAndEnabled()
+        {
+            string axaml = ReadAxaml();
+
+            for (int i = 1; i <= 5; i++)
+            {
+                // Import button must have a Click handler (not be a stub).
+                Assert.Matches(
+                    new System.Text.RegularExpressions.Regex(
+                        $@"AutomationId=""ImageBattleScreen_Image{i}_Import_Button""[\s\S]{{0,200}}Click=""Image{i}Import_Click"""),
+                    axaml);
+                // Export button must have a Click handler (not be a stub).
+                Assert.Matches(
+                    new System.Text.RegularExpressions.Regex(
+                        $@"AutomationId=""ImageBattleScreen_Image{i}_Export_Button""[\s\S]{{0,200}}Click=""Image{i}Export_Click"""),
+                    axaml);
+                // The KnownGap stub IsEnabled=False must be gone.
+                Assert.DoesNotMatch(
+                    new System.Text.RegularExpressions.Regex(
+                        $@"AutomationId=""ImageBattleScreen_Image{i}_Import_Button""[\s\S]{{0,400}}IsEnabled=""False"""),
+                    axaml);
+                Assert.DoesNotMatch(
+                    new System.Text.RegularExpressions.Regex(
+                        $@"AutomationId=""ImageBattleScreen_Image{i}_Export_Button""[\s\S]{{0,400}}IsEnabled=""False"""),
+                    axaml);
+            }
+        }
+
+        [Fact]
+        public void CodeBehind_ImageImport_Click_WrapsInUndoService()
+        {
+            string code = System.IO.File.ReadAllText(CodeBehindPath());
+            // The shared ImageImport_Click handler (internal, injectable) must
+            // wrap WritePerImageStrip in _undoService.Begin / Commit / Rollback.
+            Assert.Matches(new System.Text.RegularExpressions.Regex(
+                @"_undoService\.Begin\([^)]*\)[\s\S]*?WritePerImageStrip[\s\S]*?_undoService\.(Commit|Rollback)\(\)",
+                System.Text.RegularExpressions.RegexOptions.Singleline), code);
+        }
+
+        [Fact]
+        public void CodeBehind_ImageImport_Click_RollsBackOnWriteFailure()
+        {
+            string code = System.IO.File.ReadAllText(CodeBehindPath());
+            // The handler must call Rollback on the failure path.
+            Assert.Matches(new System.Text.RegularExpressions.Regex(
+                @"_undoService\.Rollback\(\)",
+                System.Text.RegularExpressions.RegexOptions.Singleline), code);
+        }
+
+        [Fact]
+        public void CodeBehind_ImageImport_Click_RestoresVmPointersOnFailure()
+        {
+            string code = System.IO.File.ReadAllText(CodeBehindPath());
+            // The handler must call RestoreVmPointers on failure paths.
+            Assert.Matches(new System.Text.RegularExpressions.Regex(
+                @"RestoreVmPointers\(",
+                System.Text.RegularExpressions.RegexOptions.Singleline), code);
+        }
+
+        // ---------------------------------------------------------------------------
+        // Helpers
+        // ---------------------------------------------------------------------------
+
+        static System.IDisposable EnsureImageService() => new ImageServiceScope();
+
+        sealed class ImageServiceScope : System.IDisposable
+        {
+            readonly IImageService _prev;
+            public ImageServiceScope()
+            {
+                _prev = CoreState.ImageService;
+                CoreState.ImageService = new StubImageService();
+            }
+            public void Dispose() { CoreState.ImageService = _prev; }
+        }
+
+        static void AssertPixel(IImage img, int x, int y, int r, int g, int b, int a)
+        {
+            byte[] px = img.GetPixelData();
+            int idx = (y * img.Width + x) * 4;
+            Assert.True(idx + 3 < px.Length, $"pixel ({x},{y}) out of range");
+            Assert.Equal((byte)r, px[idx + 0]);
+            Assert.Equal((byte)g, px[idx + 1]);
+            Assert.Equal((byte)b, px[idx + 2]);
+            Assert.Equal((byte)a, px[idx + 3]);
+        }
+
+        /// <summary>Build a flat indexed-pixel array filled with a single palette index.</summary>
+        static byte[] MakeSolidIndexedPixels(int width, int height, int palIndex)
+        {
+            byte[] pixels = new byte[width * height];
+            for (int i = 0; i < pixels.Length; i++) pixels[i] = (byte)(palIndex & 0x0f);
+            return pixels;
+        }
+
+        static ROM MakeRom()
+        {
+            var rom = new ROM();
+            byte[] data = new byte[0x2000000];
+            Array.Fill(data, (byte)0xFF);
+            rom.LoadLow("synth.gba", data, "BE8E01");
+
+            // Fill a large free-space region (0x800000+) with 0x00 so
+            // FindFreeSpace can locate it for WriteCompressedToROM.
+            for (uint i = 0; i < 0x100000; i++) rom.Data[FREE_SPACE_OFFSET + i] = 0x00;
+
+            // Palette: 16 banks x 16 colors x 2 bytes = 512 bytes.
+            U.write_u32(rom.Data, rom.RomInfo.battle_screen_palette_pointer, U.toPointer(PALETTE_OFFSET));
+            for (uint i = 0; i < 512; i++) rom.Data[PALETTE_OFFSET + i] = 0;
+            // bank 0 index 0 = white (0x7FFF), index 3 = red (0x001F), index 5 = green (0x03E0).
+            U.write_u16(rom.Data, PALETTE_OFFSET + (0 * 16 + 0) * 2, 0x7FFF);
+            U.write_u16(rom.Data, PALETTE_OFFSET + (0 * 16 + 3) * 2, 0x001F);
+            U.write_u16(rom.Data, PALETTE_OFFSET + (0 * 16 + 5) * 2, 0x03E0);
+
+            // image1: 33 green tiles -> natural (88, 24) = 11x3.
+            PlantImageStripTiles(rom, rom.RomInfo.battle_screen_image1_pointer, IMAGE1_OFFSET, 33, _ => 5);
+
+            // image2: 4 green tiles -> liner (32, 8).
+            PlantImageStripTiles(rom, rom.RomInfo.battle_screen_image2_pointer, IMAGE2_OFFSET, 4, _ => 5);
+
+            // image3: 16 green tiles -> liner (128, 8).
+            PlantImageStripTiles(rom, rom.RomInfo.battle_screen_image3_pointer, IMAGE3_OFFSET, 16, _ => 5);
+
+            // image4: 1 green tile -> liner (8, 8).
+            PlantImageStripTiles(rom, rom.RomInfo.battle_screen_image4_pointer, IMAGE4_OFFSET, 1, _ => 5);
+
+            // image5: 8 green tiles -> liner (64, 8).
+            PlantImageStripTiles(rom, rom.RomInfo.battle_screen_image5_pointer, IMAGE5_OFFSET, 8, _ => 5);
+
+            return rom;
+        }
+
+        static void PlantImageStripTiles(ROM rom, uint slot, uint offset, int tileCount, Func<int, int> colorOf)
+        {
+            byte[] raw = new byte[tileCount * 32];
+            for (int t = 0; t < tileCount; t++)
+            {
+                int idx = colorOf(t) & 0x0f;
+                byte packed = (byte)((idx << 4) | idx);
+                int baseOff = t * 32;
+                for (int i = 0; i < 32; i++) raw[baseOff + i] = packed;
+            }
+            byte[] comp = LZ77.compress(raw);
+            Array.Copy(comp, 0, rom.Data, offset, comp.Length);
+            U.write_u32(rom.Data, slot, U.toPointer(offset));
+        }
+
+        static string FindRepoRoot()
+        {
+            string dir = AppContext.BaseDirectory;
+            while (dir != null && !System.IO.File.Exists(System.IO.Path.Combine(dir, "FEBuilderGBA.sln")))
+                dir = System.IO.Path.GetDirectoryName(dir);
+            if (dir == null)
+                throw new InvalidOperationException("Could not find FEBuilderGBA.sln from test base directory");
+            return dir;
+        }
+
+        static string AxamlPath()
+            => System.IO.Path.Combine(FindRepoRoot(), "FEBuilderGBA.Avalonia", "Views",
+                "ImageBattleScreenView.axaml");
+
+        static string CodeBehindPath()
+            => System.IO.Path.Combine(FindRepoRoot(), "FEBuilderGBA.Avalonia", "Views",
+                "ImageBattleScreenView.axaml.cs");
+
+        static string ReadAxaml() => System.IO.File.ReadAllText(AxamlPath());
+    }
+}

--- a/FEBuilderGBA.Core/ImageBattleScreenCore.cs
+++ b/FEBuilderGBA.Core/ImageBattleScreenCore.cs
@@ -771,6 +771,17 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
+        /// Public wrapper around <see cref="TryLoadRawPalette"/> for callers
+        /// outside the Core assembly (e.g. the Avalonia view's per-image import
+        /// path, #872). Reads the RAW 16-bank battle-screen palette (512 bytes,
+        /// NOT LZ77) directly at <c>battle_screen_palette_pointer</c>.
+        /// Returns <c>false</c> (null output) if the pointer or its 512-byte
+        /// span is out of bounds.
+        /// </summary>
+        public static bool TryLoadRawPalettePublic(ROM rom, out byte[] gbaPalette)
+            => TryLoadRawPalette(rom, out gbaPalette);
+
+        /// <summary>
         /// Read the image pointer stored at <paramref name="pointerSlot"/>
         /// (e.g. <c>RomInfo.battle_screen_image1_pointer</c>). Returns the
         /// resolved ROM offset (0x... without the 0x08 prefix). Returns 0
@@ -797,6 +808,59 @@ namespace FEBuilderGBA
             // the 4-byte span before writing so we don't throw mid-undo-scope.
             if (!IsRegionSafe(rom, pointerSlot, 4)) return false;
             rom.write_p32(pointerSlot, newAddr);
+            return true;
+        }
+
+        /// <summary>
+        /// Import a single battle-screen image strip (imageIndex 0..4) by
+        /// writing new LZ77-compressed 4bpp tile data to ROM free space and
+        /// repointing the corresponding image pointer slot.
+        ///
+        /// This mirrors the WF <c>RevChipImage</c> per-iteration write path:
+        ///   1. The caller provides indexed pixel data already mapped to the
+        ///      shared battle-screen palette (palette is NOT written by this
+        ///      method -- it is shared across all 5 strips).
+        ///   2. The pixels are encoded to raw 4bpp tiles via
+        ///      <see cref="ImageImportCore.EncodeDirectTiles4bpp"/> (no TSA
+        ///      dedup -- each strip is a plain tile sheet laid out at the
+        ///      per-image width, exactly how
+        ///      <c>ByteToImage16Tile</c>/<c>DecodeTileToPixels</c> reads them).
+        ///   3. The tile bytes are LZ77-compressed and written to free space.
+        ///   4. The image pointer slot is updated to the new address.
+        ///
+        /// All writes run under the caller's ambient undo scope
+        /// (<see cref="ROM.BeginUndoScope"/>). Caller MUST wrap in
+        /// <c>UndoService.Begin/Commit/Rollback</c>. Returns <c>true</c> on
+        /// success; <c>false</c> on any validation or write failure (no partial
+        /// ROM state on false -- the undo scope reverts all writes so far).
+        ///
+        /// <paramref name="imageIndex"/> must be in [0..4]. Out-of-range or
+        /// null ROM/pixels returns false immediately without touching ROM.
+        /// </summary>
+        public static bool WritePerImageStrip(ROM rom, int imageIndex, byte[] indexedPixels,
+            int widthPx, int heightPx)
+        {
+            if (rom == null || rom.RomInfo == null) return false;
+            if (imageIndex < 0 || imageIndex > 4) return false;
+            if (indexedPixels == null) return false;
+            if (widthPx <= 0 || heightPx <= 0) return false;
+            if (widthPx % 8 != 0 || heightPx % 8 != 0) return false;
+            if (indexedPixels.Length != widthPx * heightPx) return false;
+
+            uint[] slots = ImagePointerSlots(rom);
+            uint pointerSlot = slots[imageIndex];
+
+            // Encode indexed pixels to raw 4bpp tile bytes (no TSA dedup --
+            // strips are plain tile sheets, matching DecodeTileToPixels layout).
+            byte[] tileBytes = ImageImportCore.EncodeDirectTiles4bpp(indexedPixels, widthPx, heightPx);
+            if (tileBytes == null || tileBytes.Length == 0) return false;
+
+            // LZ77-compress and write to ROM free space + update pointer.
+            // ImageImportCore.WriteCompressedToROM uses the ambient undo scope
+            // and returns U.NOT_FOUND on failure.
+            uint newAddr = ImageImportCore.WriteCompressedToROM(rom, tileBytes, pointerSlot);
+            if (newAddr == U.NOT_FOUND) return false;
+
             return true;
         }
     }

--- a/FEBuilderGBA.Core/ImageBattleScreenCore.cs
+++ b/FEBuilderGBA.Core/ImageBattleScreenCore.cs
@@ -850,6 +850,12 @@ namespace FEBuilderGBA
             uint[] slots = ImagePointerSlots(rom);
             uint pointerSlot = slots[imageIndex];
 
+            // Validate the pointer slot BEFORE encoding or allocating any data
+            // so a truncated/invalid ROM leaves the ROM completely untouched and
+            // the caller's undo/rollback has nothing to revert (#874 review fix).
+            // Mirrors WriteImagePointer's identical guard (Copilot PR #594 round 2).
+            if (!IsRegionSafe(rom, pointerSlot, 4)) return false;
+
             // Encode indexed pixels to raw 4bpp tile bytes (no TSA dedup --
             // strips are plain tile sheets, matching DecodeTileToPixels layout).
             byte[] tileBytes = ImageImportCore.EncodeDirectTiles4bpp(indexedPixels, widthPx, heightPx);


### PR DESCRIPTION
## Summary

- Wire the 10 per-image Import/Export buttons (Image1-5, 2 buttons each) in
  `ImageBattleScreenView` that were previously `IsEnabled="False"` KnownGap stubs.
- Add `ImageBattleScreenCore.WritePerImageStrip()` (encode → LZ77 → free space →
  repoint) and `TryLoadRawPalettePublic()` to `FEBuilderGBA.Core`.
- Add 18 new Core.Tests covering round-trip, export-after-import, rollback, and
  AXAML/code-behind static parity assertions.

## STEP 0 WF Verification Findings

Read `FEBuilderGBA/ImageBattleScreenForm.cs` in full before writing any code.

**(a) Encode used on import**: The WF per-image import does not exist as
individual buttons — WF only has a bulk import via `RevChipImage` which splits
a KeepTSA-processed full image into 5 strips. For the Avalonia per-image
implementation: raw 4bpp tiles (`EncodeDirectTiles4bpp`), no TSA dedup. Strips
are plain tile sheets, identical to how `DecodeTileToPixels` reads them back.

**(b) Per-image dimensions**: image1 = natural W x H (CalcImageToSize "nice
divisor" loop); image2..5 = liner-width x 8px. Resolved from existing
`TryLoadSingleImageStrip` in Core.

**(c) Per-image pointers**: `battle_screen_image{1..5}_pointer` in `RomInfo`.

**(d) Write path**: LZ77 compress → allocate free space → repoint
(`WriteCompressedToROM`). Size varies. The existing `ImageImportCore.WriteCompressedToROM`
handles this.

**(e) Palette**: Shared 16-bank raw 512-byte block at `battle_screen_palette_pointer`.
Per-image import remaps user pixels to the existing shared palette via
`LoadAndRemapFromFile`. The palette pointer is never written by per-image import.

**Confirmed**: mechanism matches "PNG → quantize against shared palette (no new
palette) → EncodeDirectTiles4bpp → LZ77 compress → write + repoint". **Proceeded
with implementation.**

## Test plan

- [x] `WritePerImageStrip_Image2_RoundTrip_DecompressedBytesMatch` — import → decompress at new pointer → bytes match
- [x] `WritePerImageStrip_Image4_RoundTrip_DecompressedBytesMatch` — second representative slot
- [x] `WritePerImageStrip_Image2_ExportAfterImport_RendersCorrectColor` — export PNG (RenderSingleImagePreview) shows correct pixel color
- [x] `WritePerImageStrip_Rollback_RestoresOriginalPointerAndBytes` — rollback restores pointer + ROM bytes
- [x] `TryLoadRawPalettePublic_ValidRom_ReturnsTrueAndPaletteBytes` — palette loader
- [x] `AxamlView_AllPerImageButtons_AreWiredAndEnabled` — 10 buttons have Click handlers, no IsEnabled=False
- [x] `CodeBehind_ImageImport_Click_WrapsInUndoService` — undo scope coverage
- [x] `CodeBehind_ImageImport_Click_RollsBackOnWriteFailure` — rollback path
- [x] `CodeBehind_ImageImport_Click_RestoresVmPointersOnFailure` — snapshot-restore
- [x] Argument validation: null ROM, null pixels, bad index, wrong dimensions, wrong pixel array size
- [x] Full Core.Tests suite: 2410 pass (was 2392, +18 new)
- [x] Full Avalonia.Tests suite: 7285 pass, 0 failures
- [x] All builds: Core, CLI, SkiaSharp, Avalonia — 0 errors
- [x] `scripts/validate-automation-ids.ps1` — VALIDATION PASSED

## GUI Test Report

| Test | Result |
|------|--------|
| `--screenshot-all` headless render via RenderTargetBitmap | PASS |
| `Avalonia_ImageBattleScreenView_FE8U.png` generated (valid PNG magic bytes) | PASS |
| Chipset preview visible (left panel) | PASS |
| Battle preview visible (right panel, FE8U tiles rendered) | PASS |
| MCP computer-use unavailable (screen locked during CI run) | N/A — headless render used instead |

## Screenshots

![Battle Screen editor — per-image Import/Export buttons wired](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr872-battlescreen-perimage-io.png)

(Screenshot committed in docs PR #873.)

Closes #872

---
Generated with Claude Code v2.1.156 (model: claude-sonnet-4-6, Sonnet 4.6 1M context)