### PR TITLE
fix(avalonia): wire Magic CSA Creator Editor button to open ToolAnimationCreator (closes #892)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageMagicCSACreatorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageMagicCSACreatorParityTests.cs
@@ -138,18 +138,18 @@ public class ImageMagicCSACreatorParityTests
 
     // -----------------------------------------------------------------
     // Deferred affordances (#886 wired Export/OpenSource/SelectSource;
-    // Import + Editor remain stubs).
+    // #892 wired Editor; Import remains stub).
     // -----------------------------------------------------------------
 
     /// <summary>
-    /// Import (#886 part 2) and Editor (#500) are still stubs — must be
+    /// Import (#886 part 2) is still a stub — must be
     /// IsEnabled="False" in the AXAML element (no tooltip text required).
     /// </summary>
     [Theory]
     [InlineData("ImageMagicCSACreator_Import_Button")]
-    [InlineData("ImageMagicCSACreator_Editor_Button")]
     // NOTE: ListExpand_Button is NO LONGER deferred — wired in #837.
     // Export/OpenSource/SelectSource are NO LONGER deferred — wired in #886.
+    // Editor is NO LONGER deferred — wired in #892.
     public void View_StubButton_IsDisabled(string automationId)
     {
         string axaml = ReadAxaml();
@@ -163,6 +163,28 @@ public class ImageMagicCSACreatorParityTests
         string element = axaml.Substring(elementStart, elementEnd - elementStart + 1);
 
         Assert.Contains("IsEnabled=\"False\"", element);
+    }
+
+    /// <summary>
+    /// #892 — Editor button is now wired: AXAML element must NOT hard-code
+    /// IsEnabled="False" and must have the Click handler.
+    /// Mirrors the FEditor JumpEditor_Click parity (symmetric).
+    /// </summary>
+    [Fact]
+    public void View_EditorButton_IsWired()
+    {
+        string axaml = ReadAxaml();
+        int idx = axaml.IndexOf("AutomationId=\"ImageMagicCSACreator_Editor_Button\"",
+            StringComparison.Ordinal);
+        Assert.True(idx >= 0, "Editor button AutomationId not found in AXAML");
+        int elementStart = axaml.LastIndexOf('<', idx);
+        int elementEnd = axaml.IndexOf("/>", idx, StringComparison.Ordinal);
+        Assert.True(elementEnd > elementStart);
+        string element = axaml.Substring(elementStart, elementEnd - elementStart + 2);
+
+        // #892: Editor button must NOT be permanently disabled (mirrors FEditor JumpEditorButton).
+        Assert.DoesNotContain("IsEnabled=\"False\"", element);
+        Assert.Contains("Click=\"Editor_Click\"", element);
     }
 
     /// <summary>
@@ -235,6 +257,29 @@ public class ImageMagicCSACreatorParityTests
         Assert.DoesNotContain("IsEnabled=\"False\"", element);
         Assert.DoesNotContain("#500", element);
         Assert.Contains("Click=\"ListExpand_Click\"", element);
+    }
+
+    // -----------------------------------------------------------------
+    // #892 — NavigationTargets manifest (parity with FEditor).
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// #892: CSA Creator ViewModel must expose INavigationTargetSource with
+    /// a single JumpToToolAnimationCreator entry, exactly mirroring
+    /// ImageMagicFEditorViewModel.GetNavigationTargets().
+    /// </summary>
+    [Fact]
+    public void ViewModel_NavigationTargets_HasJumpToToolAnimationCreator()
+    {
+        var vm = new ImageMagicCSACreatorViewModel();
+        var source = (INavigationTargetSource)vm;
+        var targets = source.GetNavigationTargets();
+
+        Assert.Single(targets);
+        var t = targets[0];
+        Assert.Equal("JumpToToolAnimationCreator", t.CommandName);
+        Assert.Equal("ToolAnimationCreatorView", t.TargetViewType.Name);
+        Assert.Equal("#500", t.IssueRef);
     }
 
     // -----------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageMagicCSACreatorViewModel.NavigationTargets.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageMagicCSACreatorViewModel.NavigationTargets.cs
@@ -14,7 +14,7 @@
 // below points at #500 (open) so the jump-parity scanner reports
 // `KnownGap` rather than `MissingAvManifest`.
 //
-// This mirrors ImageMagicFEditorViewModel.NavigationTargets.cs exactly
+// This mirrors the behavior of ImageMagicFEditorViewModel.NavigationTargets.cs
 // (symmetric parity, #892 — last bucket-A gap).
 using System.Collections.Generic;
 using FEBuilderGBA.Avalonia.Services;

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageMagicCSACreatorViewModel.NavigationTargets.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageMagicCSACreatorViewModel.NavigationTargets.cs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Navigation manifest for ImageMagicCSACreatorViewModel (#892 / #374 Phase 4).
+//
+// Mirrors the single WF cross-editor jump callsite in
+// `ImageMagicCSACreatorForm`:
+//   - `X_N_JumpEditor_Click` -> `ToolAnimationCreatorForm`
+//     (`InputFormRef.JumpFormLow<ToolAnimationCreatorForm>()` then
+//      `f.Init(MagicAnime_CSACreator, ID, filehint, filename)`)
+//
+// The WF flow exports the current CSA magic anime to a temp `.txt` file
+// and hands the path to ToolAnimationCreator. The Avalonia
+// ToolAnimationCreatorView exists but its `Init()` / Magic Anime
+// support is tracked separately by issue #500. The KnownGap row
+// below points at #500 (open) so the jump-parity scanner reports
+// `KnownGap` rather than `MissingAvManifest`.
+//
+// This mirrors ImageMagicFEditorViewModel.NavigationTargets.cs exactly
+// (symmetric parity, #892 — last bucket-A gap).
+using System.Collections.Generic;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.Views;
+
+namespace FEBuilderGBA.Avalonia.ViewModels
+{
+    public partial class ImageMagicCSACreatorViewModel : INavigationTargetSource
+    {
+        public IReadOnlyList<NavigationTarget> GetNavigationTargets()
+        {
+            return new[]
+            {
+                new NavigationTarget(
+                    CommandName: "JumpToToolAnimationCreator",
+                    TargetViewType: typeof(ToolAnimationCreatorView),
+                    TargetAddress: null,
+                    IssueRef: "#500"),
+            };
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageMagicCSACreatorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageMagicCSACreatorViewModel.cs
@@ -15,7 +15,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
     /// Gap-sweep fix (#417) raises density from 3 to MEDIUM verdict and
     /// wires the tag-aware Dim/NoDim/Empty round-trip.
     /// </summary>
-    public class ImageMagicCSACreatorViewModel : ViewModelBase, IDataVerifiable
+    public partial class ImageMagicCSACreatorViewModel : ViewModelBase, IDataVerifiable
     {
         // Block size for the CSA struct: 5 x 4-byte pointers = 20 bytes.
         public const uint BLOCK_SIZE = 20;

--- a/FEBuilderGBA.Avalonia/Views/ImageMagicCSACreatorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageMagicCSACreatorView.axaml
@@ -169,10 +169,8 @@
                   Name="SelectSourceButton" Content="Open Source Folder"
                   IsVisible="False"
                   Click="SelectSource_Click" />
-          <!-- Editor: follow-up to #500 -->
           <Button AutomationProperties.AutomationId="ImageMagicCSACreator_Editor_Button"
                   Name="EditorButton" Content="Editor"
-                  IsEnabled="False"
                   Click="Editor_Click" />
         </StackPanel>
       </StackPanel>

--- a/FEBuilderGBA.Avalonia/Views/ImageMagicCSACreatorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageMagicCSACreatorView.axaml.cs
@@ -704,8 +704,8 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void Editor_Click(object? sender, RoutedEventArgs e)
         {
-            // Real cross-editor jump — opens ToolAnimationCreator. Mirrors
-            // ImageMagicFEditorView.JumpEditor_Click exactly (symmetric parity, #892).
+            // Real cross-editor jump — opens ToolAnimationCreator. Mirrors the
+            // behavior of ImageMagicFEditorView.JumpEditor_Click (symmetric parity, #892).
             // The full export-temp-file + Init(MagicAnime_CSACreator) flow is a
             // documented #500 follow-up for BOTH FEditor and CSACreator — symmetric.
             try

--- a/FEBuilderGBA.Avalonia/Views/ImageMagicCSACreatorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageMagicCSACreatorView.axaml.cs
@@ -702,9 +702,21 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
-        // Editor: follow-up to #500
-        void Editor_Click(object? sender, RoutedEventArgs e) =>
-            Log.Debug("ImageMagicCSACreatorView.Editor_Click - follow-up to #500");
+        void Editor_Click(object? sender, RoutedEventArgs e)
+        {
+            // Real cross-editor jump — opens ToolAnimationCreator. Mirrors
+            // ImageMagicFEditorView.JumpEditor_Click exactly (symmetric parity, #892).
+            // The full export-temp-file + Init(MagicAnime_CSACreator) flow is a
+            // documented #500 follow-up for BOTH FEditor and CSACreator — symmetric.
+            try
+            {
+                WindowManager.Instance.Open<ToolAnimationCreatorView>();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImageMagicCSACreatorView.Editor_Click: {0}", ex.Message);
+            }
+        }
 
         static uint ParseHexText(string? text)
         {


### PR DESCRIPTION
## Summary

- Wires the previously-stub `Editor_Click` handler in `ImageMagicCSACreatorView` to call `WindowManager.Instance.Open<ToolAnimationCreatorView>()`, mirroring `ImageMagicFEditorView.JumpEditor_Click` exactly.
- Removes `IsEnabled="False"` from the Editor button (always enabled, matching FEditor's `JumpEditorButton` which has no disabled state).
- Adds `INavigationTargetSource` manifest to `ImageMagicCSACreatorViewModel` (mirrors `ImageMagicFEditorViewModel.NavigationTargets.cs` exactly — symmetric parity).
- Closes #892 — the last bucket-A parity gap.

## STEP-0 Findings (how FEditor's JumpEditor_Click works)

`ImageMagicFEditorView.JumpEditor_Click` (line 772):
```csharp
WindowManager.Instance.Open<ToolAnimationCreatorView>();
```
- Simple `try/catch` — no context/gating, no CSA-kind gate
- `JumpEditorButton` has no `IsEnabled="False"` in AXAML — always enabled
- Comment documents #500 (export-temp-file + `Init()` flow) as the follow-up for BOTH editors
- VM implements `INavigationTargetSource` with `JumpToToolAnimationCreator → ToolAnimationCreatorView, IssueRef="#500"`

CSA's `Editor_Click` now does the same, symmetrically.

## Full export+Init() flow

The WF `X_N_JumpEditor_Click` exports magic animation to a temp `.txt` then calls `f.Init(MagicAnime_CSACreator, ...)`. This is **the #500 follow-up** for BOTH FEditor and CSACreator (symmetric, documented in comments) — out of scope for this fix.

## Closes

Closes #892

## Test plan

- [x] `dotnet build FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj`: 0 errors
- [x] `dotnet build FEBuilderGBA.Core/FEBuilderGBA.Core.csproj`: 0 errors
- [x] `dotnet build FEBuilderGBA.CLI/FEBuilderGBA.CLI.csproj`: 0 errors
- [x] `dotnet build FEBuilderGBA.SkiaSharp/FEBuilderGBA.SkiaSharp.csproj`: 0 errors
- [x] `dotnet test FEBuilderGBA.Core.Tests/`: 2556 passed, 0 failed
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests/`: 7293 passed, 0 failed (new tests: `View_EditorButton_IsWired`, `ViewModel_NavigationTargets_HasJumpToToolAnimationCreator`)
- [x] `scripts/validate-automation-ids.ps1`: VALIDATION PASSED
- [x] `View_StubButton_IsDisabled` theory no longer includes Editor button (no longer a stub)
- [x] `View_EditorButton_IsWired`: Editor button AXAML has no `IsEnabled="False"` + has `Click="Editor_Click"`
- [x] `ViewModel_NavigationTargets_HasJumpToToolAnimationCreator`: CSA VM exposes same manifest as FEditor VM

## GUI Test Report

| Test | Result |
|------|--------|
| ImageMagicCSACreatorView renders via `--screenshot-all` | PASS |
| Editor button is NOT grayed out (enabled state visible) | PASS |
| Editor button appears in button row with Import/Export | PASS |
| All 325 editors rendered without crash | PASS |

## Screenshots

![CSA Magic Creator Editor button enabled (PR #892)](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr892-csa-editor.png)

The "Editor" button (bottom-right, next to "Export Magic Animation") is now **enabled** — previously it was grayed out. This matches FEditor's "Editor" button behavior exactly.

---
_Generated with Claude Code v2.1.156 (model: claude-sonnet-4-6)_