### PR TITLE
fix(avalonia): wire SkillConfig Jump buttons (5 views, navigate-only, FEditor parity) (#895)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigJumpWiringParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigJumpWiringParityTests.cs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #895 — navigate-only SkillConfig Jump-button wiring parity tests.
+//
+// Mirrors the merged ImageMagicFEditorView.JumpEditor_Click (#894)
+// navigate-only pattern across the 5 SkillConfig views:
+//   - JumpToEditor_Click  → WindowManager.Instance.Open<ToolAnimationCreatorView>()
+//   - JumpToCombatArt_Click (FE8NVer3 only) → WindowManager.Instance.Open<PatchManagerView>()
+//
+// These are Roslyn-static source-text assertions (no Avalonia head, no ROM):
+// each view's `.axaml.cs` JumpToEditor_Click body must now contain the
+// `WindowManager.Instance.Open<ToolAnimationCreatorView>` open call and must NO
+// LONGER contain a `Log.Debug` no-op for that handler. FE8NVer3's
+// JumpToCombatArt_Click must open PatchManagerView.
+//
+// NOTE: the NavigationTargets manifest / IssueRef KnownGap / button-wired
+// AutomationId tests already exist in the per-view parity files — this file
+// adds ONLY the new handler-body open-source assertion value (per the #895
+// approved-plan correction: do not duplicate the manifest/button tests).
+using System;
+using System.IO;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests.GapSweep;
+
+public class SkillConfigJumpWiringParityTests
+{
+    // -----------------------------------------------------------------
+    // JumpToEditor_Click → ToolAnimationCreatorView (all 5 views).
+    // -----------------------------------------------------------------
+
+    [Theory]
+    [InlineData("SkillConfigFE8NSkillView.axaml.cs")]
+    [InlineData("SkillConfigFE8NVer2SkillView.axaml.cs")]
+    [InlineData("SkillConfigFE8NVer3SkillView.axaml.cs")]
+    [InlineData("SkillConfigFE8UCSkillSys09xView.axaml.cs")]
+    [InlineData("SkillConfigSkillSystemView.axaml.cs")]
+    public void JumpToEditor_OpensAnimationCreator_NotLogDebugNoop(string viewFile)
+    {
+        string body = ExtractHandlerBody(ReadViewSource(viewFile), "JumpToEditor_Click");
+
+        // The body must now perform the navigate-only open via WindowManager.
+        Assert.Matches(@"WindowManager\.Instance\.Open<", body);
+        Assert.Contains("WindowManager.Instance.Open<ToolAnimationCreatorView>", body);
+
+        // The stub Log.Debug no-op must be gone from THIS handler.
+        Assert.DoesNotContain("Log.Debug", body);
+    }
+
+    // -----------------------------------------------------------------
+    // JumpToCombatArt_Click → PatchManagerView (FE8NVer3 only).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void FE8NVer3_JumpToCombatArt_OpensPatchManager_NotLogDebugNoop()
+    {
+        string body = ExtractHandlerBody(
+            ReadViewSource("SkillConfigFE8NVer3SkillView.axaml.cs"),
+            "JumpToCombatArt_Click");
+
+        Assert.Matches(@"WindowManager\.Instance\.Open<", body);
+        Assert.Contains("WindowManager.Instance.Open<PatchManagerView>", body);
+        Assert.DoesNotContain("Log.Debug", body);
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    static string ReadViewSource(string viewFile)
+    {
+        string repoRoot = FindRepoRoot();
+        string path = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views", viewFile);
+        Assert.True(File.Exists(path), $"View source not found at {path}");
+        return File.ReadAllText(path);
+    }
+
+    /// <summary>
+    /// Extract the brace-balanced body of the named click handler from the
+    /// code-behind source text. Returns the substring between the handler's
+    /// opening `{` and its matching `}` so source assertions are scoped to the
+    /// single handler (not the whole file).
+    /// </summary>
+    static string ExtractHandlerBody(string source, string handlerName)
+    {
+        string signature = $"void {handlerName}(object? sender, RoutedEventArgs e)";
+        int sigIdx = source.IndexOf(signature, StringComparison.Ordinal);
+        Assert.True(sigIdx >= 0, $"Handler '{handlerName}' not found in source");
+
+        int openBrace = source.IndexOf('{', sigIdx);
+        Assert.True(openBrace >= 0, $"Opening brace for '{handlerName}' not found");
+
+        int depth = 0;
+        for (int i = openBrace; i < source.Length; i++)
+        {
+            char c = source[i];
+            if (c == '{') depth++;
+            else if (c == '}')
+            {
+                depth--;
+                if (depth == 0)
+                    return source.Substring(openBrace + 1, i - openBrace - 1);
+            }
+        }
+        throw new InvalidOperationException(
+            $"Unbalanced braces extracting '{handlerName}' body");
+    }
+
+    /// <summary>
+    /// Walk parent directories from the test bin/ folder until we find the
+    /// repo root (identified by FEBuilderGBA.sln). Mirrors the existing
+    /// per-view parity tests' FindRepoRoot helper.
+    /// </summary>
+    static string FindRepoRoot()
+    {
+        string? dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+        if (dir == null)
+            throw new InvalidOperationException("Could not find FEBuilderGBA.sln from test base directory");
+        return dir;
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigJumpWiringParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigJumpWiringParityTests.cs
@@ -18,6 +18,7 @@
 // approved-plan correction: do not duplicate the manifest/button tests).
 using System;
 using System.IO;
+using System.Text.RegularExpressions;
 using Xunit;
 
 namespace FEBuilderGBA.Avalonia.Tests.GapSweep;
@@ -79,12 +80,17 @@ public class SkillConfigJumpWiringParityTests
     /// code-behind source text. Returns the substring between the handler's
     /// opening `{` and its matching `}` so source assertions are scoped to the
     /// single handler (not the whole file).
+    ///
+    /// The handler declaration is located by a regex on `void &lt;name&gt;(` rather
+    /// than a hard-coded full signature, so it stays robust to parameter
+    /// nullability/modifier/type changes (matches the regex-declaration style
+    /// the other GapSweep parity tests use, e.g. ClassOPDemoParityTests).
     /// </summary>
     static string ExtractHandlerBody(string source, string handlerName)
     {
-        string signature = $"void {handlerName}(object? sender, RoutedEventArgs e)";
-        int sigIdx = source.IndexOf(signature, StringComparison.Ordinal);
-        Assert.True(sigIdx >= 0, $"Handler '{handlerName}' not found in source");
+        Match decl = Regex.Match(source, $@"void\s+{Regex.Escape(handlerName)}\s*\(", RegexOptions.Compiled);
+        Assert.True(decl.Success, $"Handler '{handlerName}' not found in source");
+        int sigIdx = decl.Index;
 
         int openBrace = source.IndexOf('{', sigIdx);
         Assert.True(openBrace >= 0, $"Opening brace for '{handlerName}' not found");

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NSkillView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NSkillView.axaml.cs
@@ -514,7 +514,17 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void JumpToEditor_Click(object? sender, RoutedEventArgs e)
         {
-            Log.Debug("SkillConfigFE8NSkillView.JumpToEditor_Click invoked - disabled until ToolAnimationCreatorView.Init lands (#500)");
+            // Navigate-only open; full Init/struct-jump context is the
+            // symmetric #500/#374 follow-up. Mirrors the merged
+            // ImageMagicFEditorView.JumpEditor_Click (#894) pattern.
+            try
+            {
+                WindowManager.Instance.Open<ToolAnimationCreatorView>();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("SkillConfigFE8NSkillView.JumpToEditor_Click failed: {0}", ex.Message);
+            }
         }
 
         void ListExpand_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer2SkillView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer2SkillView.axaml.cs
@@ -277,7 +277,17 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void JumpToEditor_Click(object? sender, RoutedEventArgs e)
         {
-            Log.Debug("SkillConfigFE8NVer2SkillView.JumpToEditor_Click invoked - disabled until ToolAnimationCreatorView.Init lands (#500)");
+            // Navigate-only open; full Init/struct-jump context is the
+            // symmetric #500/#374 follow-up. Mirrors the merged
+            // ImageMagicFEditorView.JumpEditor_Click (#894) pattern.
+            try
+            {
+                WindowManager.Instance.Open<ToolAnimationCreatorView>();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("SkillConfigFE8NVer2SkillView.JumpToEditor_Click failed: {0}", ex.Message);
+            }
         }
 
         void ListExpand_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml.cs
@@ -308,12 +308,32 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void JumpToEditor_Click(object? sender, RoutedEventArgs e)
         {
-            Log.Debug("SkillConfigFE8NVer3SkillView.JumpToEditor_Click invoked - disabled until ToolAnimationCreatorView.Init lands (#500)");
+            // Navigate-only open; full Init/struct-jump context is the
+            // symmetric #500/#374 follow-up. Mirrors the merged
+            // ImageMagicFEditorView.JumpEditor_Click (#894) pattern.
+            try
+            {
+                WindowManager.Instance.Open<ToolAnimationCreatorView>();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("SkillConfigFE8NVer3SkillView.JumpToEditor_Click failed: {0}", ex.Message);
+            }
         }
 
         void JumpToCombatArt_Click(object? sender, RoutedEventArgs e)
         {
-            Log.Debug("SkillConfigFE8NVer3SkillView.JumpToCombatArt_Click invoked - disabled until PatchManagerView exposes JumpToSelectStruct (#374)");
+            // Navigate-only open; full Init/struct-jump context is the
+            // symmetric #500/#374 follow-up. Mirrors the merged
+            // ImageMagicFEditorView.JumpEditor_Click (#894) pattern.
+            try
+            {
+                WindowManager.Instance.Open<PatchManagerView>();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("SkillConfigFE8NVer3SkillView.JumpToCombatArt_Click failed: {0}", ex.Message);
+            }
         }
 
         void ListExpand_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml.cs
@@ -224,7 +224,17 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void JumpToEditor_Click(object? sender, RoutedEventArgs e)
         {
-            Log.Debug("SkillConfigFE8UCSkillSys09xView.JumpToEditor_Click invoked - disabled until ToolAnimationCreatorView.Init lands (#500)");
+            // Navigate-only open; full Init/struct-jump context is the
+            // symmetric #500/#374 follow-up. Mirrors the merged
+            // ImageMagicFEditorView.JumpEditor_Click (#894) pattern.
+            try
+            {
+                WindowManager.Instance.Open<ToolAnimationCreatorView>();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("SkillConfigFE8UCSkillSys09xView.JumpToEditor_Click failed: {0}", ex.Message);
+            }
         }
 
         void ShowFrameUpDown_ValueChanged(object? sender, NumericUpDownValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml.cs
@@ -243,7 +243,17 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void JumpToEditor_Click(object? sender, RoutedEventArgs e)
         {
-            Log.Debug("SkillConfigSkillSystemView.JumpToEditor_Click invoked - disabled until ToolAnimationCreatorView.Init lands (#500)");
+            // Navigate-only open; full Init/struct-jump context is the
+            // symmetric #500/#374 follow-up. Mirrors the merged
+            // ImageMagicFEditorView.JumpEditor_Click (#894) pattern.
+            try
+            {
+                WindowManager.Instance.Open<ToolAnimationCreatorView>();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("SkillConfigSkillSystemView.JumpToEditor_Click failed: {0}", ex.Message);
+            }
         }
 
         void BulkImport_Click(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary

Wires the **navigate-only** SkillConfig Jump buttons across all 5 SkillConfig Avalonia views, mirroring the already-merged `ImageMagicFEditorView.JumpEditor_Click` (#894) / CSA `Editor_Click` (#892) navigate-only pattern. Closes the cheapest, clearest slice of the SkillConfig I/O parity gap.

Closes #895.

## What changed (6 handlers, all previously `Log.Debug` no-ops)

| View | Handler | Now opens |
|---|---|---|
| `SkillConfigFE8NSkillView` | `JumpToEditor_Click` | `ToolAnimationCreatorView` |
| `SkillConfigFE8NVer2SkillView` | `JumpToEditor_Click` | `ToolAnimationCreatorView` |
| `SkillConfigFE8NVer3SkillView` | `JumpToEditor_Click` | `ToolAnimationCreatorView` |
| `SkillConfigFE8NVer3SkillView` | `JumpToCombatArt_Click` | `PatchManagerView` |
| `SkillConfigFE8UCSkillSys09xView` | `JumpToEditor_Click` | `ToolAnimationCreatorView` |
| `SkillConfigSkillSystemView` | `JumpToEditor_Click` | `ToolAnimationCreatorView` |

Each replaces the `Log.Debug` stub with `WindowManager.Instance.Open<T>()` in a try/catch (`Log.Error` on failure), mirroring the merged FEditor jump verbatim. `NavigationTargets` manifests already existed for all 5 views (confirm-only; `IssueRef` `#500`/`#374` rows retained).

## Scope boundary (symmetric deferral — NOT this PR)

The navigate-only open IS the parity fix. The target editors' **full context flow** — `ToolAnimationCreator.Init()` (#500) and PatchManager `JumpToSelectStruct` struct-targeting (#374) — is the deferral that is **symmetric with the already-accepted FEditor/CSA jumps** (#892/#894), out of scope here. The other SkillConfig stubs (Image/Anime I/O, ListExpand, Bulk) are separate follow-up PRs.

## Test plan

- [x] `dotnet build FEBuilderGBA.Avalonia` (Release) — 0 errors.
- [x] New `SkillConfigJumpWiringParityTests` (6 tests) — assert each `JumpToEditor_Click` body now contains `WindowManager.Instance.Open<ToolAnimationCreatorView>` and no `Log.Debug`; FE8NVer3 `JumpToCombatArt_Click` contains `Open<PatchManagerView>`. **6/6 pass.**
- [x] SkillConfig regression suite (existing manifest/`IssueRef`/button-wired tests) — **154/154 pass** (corrections #2/#3 intact).
- [x] `FEBuilderGBA.Core.Tests` — **2556/2556 pass.**

## Screenshots

Real RenderTargetBitmap render of the affected `SkillConfigFE8NVer3SkillView` (built from this branch, `FE8J_skill.gba`), showing the wired **Move to COMBATART** (`JumpToCombatArt`) button + Animation row:

![SkillConfig FE8NVer3 jump buttons](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr895-skillconfig-jump-fe8nver3.png)

![SkillConfig SkillSystem view](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr895-skillconfig-jump-skillsystem.png)

## GUI Test Report

| Editor | Action | Result |
|---|---|---|
| SkillConfigFE8NVer3SkillView | RenderTargetBitmap render (branch build) | PASS — view renders, **Move to COMBATART** + Animation buttons visible |
| SkillConfigSkillSystemView | RenderTargetBitmap render (branch build) | PASS — view renders |
| All 5 views | Source-text parity tests (handlers call `Open<>`, no `Log.Debug`) | PASS — 6/6 |
| All 5 views | Manifest/IssueRef regression tests | PASS — 154/154 |

---
_Generated with Claude Code v2.1.156 (model: claude-opus-4-8, Opus 4.8 1M context)_
