### PR TITLE
feat(core): NullTerminatedByteListCore — editable per-skill sub-list primitives (#926)

### DIFF
--- a/FEBuilderGBA.Core.Tests/NullTerminatedByteListCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/NullTerminatedByteListCoreTests.cs
@@ -1,0 +1,556 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="NullTerminatedByteListCore"/> — the id-neutral
+    /// cross-platform Core helper for null-terminated 1-byte-ID lists (issue #926,
+    /// #769 bucket 2 slice 1). All tests run on synthetic in-memory ROMs; the
+    /// ROM-mutating tests set <see cref="CoreState.ROM"/> (Undo needs it) and
+    /// restore it in a finally. Mirrors <c>ItemClassListCoreTests</c>.
+    /// </summary>
+    [Collection("SharedState")]
+    public class NullTerminatedByteListCoreTests
+    {
+        readonly ITestOutputHelper _output;
+
+        public NullTerminatedByteListCoreTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        // ---------------------------------------------------------------------
+        // ScanByteList
+        // ---------------------------------------------------------------------
+
+        [Fact]
+        public void ScanByteList_EmptyOnZeroAddress()
+        {
+            // baseAddr=0 is treated as a null pointer even when offset 0 holds data.
+            byte[] data = new byte[64];
+            data[0] = 0x10;
+            data[1] = 0x20;
+            data[2] = 0x00;
+            var rom = MakeRom(data);
+            var list = NullTerminatedByteListCore.ScanByteList(rom, baseAddr: 0);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void ScanByteList_TerminatesOnFirstZero()
+        {
+            byte[] data = new byte[64];
+            data[4] = 0x10;
+            data[5] = 0x20;
+            data[6] = 0x30;
+            data[7] = 0x00; // terminator
+            data[8] = 0x40; // beyond terminator — must not be returned
+
+            var rom = MakeRom(data);
+            var list = NullTerminatedByteListCore.ScanByteList(rom, baseAddr: 4);
+            Assert.Equal(3, list.Count);
+            Assert.Equal(0x10u, list[0]);
+            Assert.Equal(0x20u, list[1]);
+            Assert.Equal(0x30u, list[2]);
+        }
+
+        [Fact]
+        public void ScanByteList_EmptyOnOutOfBounds()
+        {
+            byte[] data = new byte[16];
+            for (int i = 0; i < data.Length; i++) data[i] = 0x42;
+            var rom = MakeRom(data);
+            // baseAddr beyond the ROM => empty list, no throw.
+            var list = NullTerminatedByteListCore.ScanByteList(rom, baseAddr: 0x1000);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void ScanByteList_HandlesBoundsSafely()
+        {
+            // Array that fills the entire ROM and never hits a terminator.
+            byte[] data = new byte[8];
+            for (int i = 0; i < data.Length; i++) data[i] = 0x42;
+            var rom = MakeRom(data);
+            var list = NullTerminatedByteListCore.ScanByteList(rom, baseAddr: 1);
+            Assert.Equal(7, list.Count); // 7 bytes from offset 1 to end of ROM
+        }
+
+        [Fact]
+        public void ScanByteList_HonorsIterationCap()
+        {
+            // A ROM larger than the 0x200 cap with no terminator. ScanByteList must
+            // return at most 0x200 entries (not run to the end of a huge ROM).
+            byte[] data = new byte[0x400];
+            for (int i = 0; i < data.Length; i++) data[i] = 0x55;
+            var rom = MakeRom(data);
+            var list = NullTerminatedByteListCore.ScanByteList(rom, baseAddr: 1);
+            Assert.Equal(0x200, list.Count);
+        }
+
+        // ---------------------------------------------------------------------
+        // WriteByte
+        // ---------------------------------------------------------------------
+
+        [Fact]
+        public void WriteByte_UpdatesByteAndUndoRestoresExactly()
+        {
+            byte[] data = new byte[16];
+            data[3] = 0x11; // original value
+            var rom = MakeRom(data);
+            var prevRomState = CoreState.ROM;
+            CoreState.ROM = rom; // Undo needs CoreState.ROM
+            try
+            {
+                var undo = NewUndo(rom);
+
+                NullTerminatedByteListCore.WriteByte(rom, addr: 3, value: 0x55, undo: undo);
+
+                Assert.Equal(0x55, rom.Data[3]);
+                Assert.Single(undo.list);
+                Assert.Equal(3u, undo.list[0].addr);
+                Assert.Equal(1, undo.list[0].data.Length);
+
+                // Undo restores the byte exactly.
+                RollbackAll(rom, undo);
+                Assert.Equal(0x11, rom.Data[3]);
+            }
+            finally
+            {
+                CoreState.ROM = prevRomState;
+            }
+        }
+
+        // ---------------------------------------------------------------------
+        // WriteByteList
+        // ---------------------------------------------------------------------
+
+        [Fact]
+        public void WriteByteList_WritesExactListWithSingleTerminator()
+        {
+            // B1 guard: a 3-entry list must scan back as EXACTLY 3 (no interior 0x00,
+            // no placeholder/zero-fill heuristic).
+            byte[] data = MakeRomWithListAt(out uint pointerAddr, out _, 64, new uint[] { 0x10, 0x20 });
+            var rom = MakeRom(data);
+            var prevRomState = CoreState.ROM;
+            CoreState.ROM = rom;
+            try
+            {
+                var undo = NewUndo(rom);
+
+                uint newBase = NullTerminatedByteListCore.WriteByteList(
+                    rom, pointerAddr, new uint[] { 0xAA, 0xBB, 0xCC }, undo);
+
+                Assert.NotEqual(0u, newBase);
+                Assert.NotEqual(U.NOT_FOUND, newBase);
+
+                // Pointer repointed to the new array.
+                Assert.Equal(newBase | 0x08000000u, rom.u32(pointerAddr));
+
+                // Exact bytes: [0xAA, 0xBB, 0xCC, 0x00].
+                Assert.Equal(0xAA, rom.Data[newBase + 0]);
+                Assert.Equal(0xBB, rom.Data[newBase + 1]);
+                Assert.Equal(0xCC, rom.Data[newBase + 2]);
+                Assert.Equal(0x00, rom.Data[newBase + 3]);
+
+                // Scan returns EXACTLY 3.
+                var scanned = NullTerminatedByteListCore.ScanByteList(rom, newBase);
+                Assert.Equal(3, scanned.Count);
+                Assert.Equal(0xAAu, scanned[0]);
+                Assert.Equal(0xBBu, scanned[1]);
+                Assert.Equal(0xCCu, scanned[2]);
+
+                // OLD bytes preserved at old base 64: [0x10, 0x20, 0x00].
+                Assert.Equal(0x10, rom.Data[64]);
+                Assert.Equal(0x20, rom.Data[65]);
+                Assert.Equal(0x00, rom.Data[66]);
+            }
+            finally
+            {
+                CoreState.ROM = prevRomState;
+            }
+        }
+
+        [Fact]
+        public void WriteByteList_EmptyListWritesTerminatorOnly()
+        {
+            byte[] data = MakeRomWithListAt(out uint pointerAddr, out _, 64, new uint[] { 0x10, 0x20, 0x30 });
+            var rom = MakeRom(data);
+            var prevRomState = CoreState.ROM;
+            CoreState.ROM = rom;
+            try
+            {
+                var undo = NewUndo(rom);
+
+                uint newBase = NullTerminatedByteListCore.WriteByteList(
+                    rom, pointerAddr, Array.Empty<uint>(), undo);
+
+                Assert.Equal(0x00, rom.Data[newBase]); // terminator-only
+                var scanned = NullTerminatedByteListCore.ScanByteList(rom, newBase);
+                Assert.Empty(scanned);
+            }
+            finally
+            {
+                CoreState.ROM = prevRomState;
+            }
+        }
+
+        [Fact]
+        public void WriteByteList_ReorderAndReplaceRoundTrips()
+        {
+            byte[] data = MakeRomWithListAt(out uint pointerAddr, out _, 64, new uint[] { 0x01, 0x02, 0x03 });
+            var rom = MakeRom(data);
+            var prevRomState = CoreState.ROM;
+            CoreState.ROM = rom;
+            try
+            {
+                var undo = NewUndo(rom);
+
+                // Reorder + replace one element.
+                uint newBase = NullTerminatedByteListCore.WriteByteList(
+                    rom, pointerAddr, new uint[] { 0x03, 0x99, 0x01 }, undo);
+
+                var scanned = NullTerminatedByteListCore.ScanByteList(rom, newBase);
+                Assert.Equal(new List<uint> { 0x03u, 0x99u, 0x01u }, scanned);
+            }
+            finally
+            {
+                CoreState.ROM = prevRomState;
+            }
+        }
+
+        [Fact]
+        public void WriteByteList_RejectsListLongerThan255()
+        {
+            byte[] data = MakeRomWithListAt(out uint pointerAddr, out _, 64, new uint[] { 0x10 });
+            var rom = MakeRom(data);
+            var prevRomState = CoreState.ROM;
+            CoreState.ROM = rom;
+            try
+            {
+                var undo = NewUndo(rom);
+                var tooLong = new uint[0x100];
+                Assert.Throws<ArgumentException>(() =>
+                    NullTerminatedByteListCore.WriteByteList(rom, pointerAddr, tooLong, undo));
+            }
+            finally
+            {
+                CoreState.ROM = prevRomState;
+            }
+        }
+
+        // ---------------------------------------------------------------------
+        // ExpandByteList
+        // ---------------------------------------------------------------------
+
+        [Fact]
+        public void ExpandByteList_AppendsPlaceholderBeforeTerminator()
+        {
+            byte[] data = MakeRomWithListAt(out uint pointerAddr, out _, 32, new uint[] { 0x10, 0x20 });
+            var rom = MakeRom(data);
+            var prevRomState = CoreState.ROM;
+            CoreState.ROM = rom;
+            try
+            {
+                var undo = NewUndo(rom);
+
+                uint newBase = NullTerminatedByteListCore.ExpandByteList(rom, pointerAddr, undo);
+
+                Assert.NotEqual(0u, newBase);
+                Assert.NotEqual(U.NOT_FOUND, newBase);
+                Assert.NotEqual(32u, newBase); // relocated
+
+                // Pointer repointed.
+                Assert.Equal(newBase | 0x08000000u, rom.u32(pointerAddr));
+
+                // Layout: [0x10, 0x20, placeholder, 0x00].
+                Assert.Equal(0x10, rom.Data[newBase + 0]);
+                Assert.Equal(0x20, rom.Data[newBase + 1]);
+                Assert.Equal((byte)NullTerminatedByteListCore.NewSlotPlaceholder, rom.Data[newBase + 2]);
+                Assert.Equal(0x00, rom.Data[newBase + 3]);
+
+                // Scan shows the new placeholder row (count = oldCount + 1).
+                var scanned = NullTerminatedByteListCore.ScanByteList(rom, newBase);
+                Assert.Equal(3, scanned.Count);
+                Assert.Equal(0x10u, scanned[0]);
+                Assert.Equal(0x20u, scanned[1]);
+                Assert.Equal(NullTerminatedByteListCore.NewSlotPlaceholder, scanned[2]);
+
+                // OLD bytes preserved.
+                Assert.Equal(0x10, rom.Data[32]);
+                Assert.Equal(0x20, rom.Data[33]);
+                Assert.Equal(0x00, rom.Data[34]);
+            }
+            finally
+            {
+                CoreState.ROM = prevRomState;
+            }
+        }
+
+        // ---------------------------------------------------------------------
+        // Shared-array preservation (implicit fork)
+        // ---------------------------------------------------------------------
+
+        [Fact]
+        public void ExpandByteList_OnSharedArray_OtherOwnerUnchanged()
+        {
+            // Two owner pointers (offsets 0 and 8) reference the same array at 96.
+            byte[] data = new byte[1024];
+            for (int i = 0; i < data.Length; i++) data[i] = 0xFF;
+            data[96] = 0x42;
+            data[97] = 0x00; // [0x42, 0]
+            uint sharedPtr = 96u | 0x08000000u;
+            WritePtr(data, 0, sharedPtr);
+            WritePtr(data, 8, sharedPtr);
+
+            var rom = MakeRom(data);
+            var prevRomState = CoreState.ROM;
+            CoreState.ROM = rom;
+            try
+            {
+                var undo = NewUndo(rom);
+
+                uint newBaseA = NullTerminatedByteListCore.ExpandByteList(rom, pointerAddr: 0, undo: undo);
+
+                // Owner A scans [0x42, placeholder].
+                var scanA = NullTerminatedByteListCore.ScanByteList(rom, newBaseA);
+                Assert.Equal(2, scanA.Count);
+                Assert.Equal(0x42u, scanA[0]);
+                Assert.Equal(NullTerminatedByteListCore.NewSlotPlaceholder, scanA[1]);
+
+                // Owner B's pointer + scan unchanged (implicit fork).
+                Assert.Equal(sharedPtr, rom.u32(8));
+                var scanB = NullTerminatedByteListCore.ScanByteList(rom, 96);
+                Assert.Single(scanB);
+                Assert.Equal(0x42u, scanB[0]);
+            }
+            finally
+            {
+                CoreState.ROM = prevRomState;
+            }
+        }
+
+        [Fact]
+        public void WriteByteList_OnSharedArray_OtherOwnerUnchanged()
+        {
+            byte[] data = new byte[1024];
+            for (int i = 0; i < data.Length; i++) data[i] = 0xFF;
+            data[64] = 0x10;
+            data[65] = 0x20;
+            data[66] = 0x00; // [0x10, 0x20, 0]
+            uint sharedPtr = 64u | 0x08000000u;
+            WritePtr(data, 0, sharedPtr);
+            WritePtr(data, 8, sharedPtr);
+
+            var rom = MakeRom(data);
+            var prevRomState = CoreState.ROM;
+            CoreState.ROM = rom;
+            try
+            {
+                var undo = NewUndo(rom);
+
+                NullTerminatedByteListCore.WriteByteList(rom, pointerAddr: 0, new uint[] { 0x77 }, undo);
+
+                // Owner B unchanged.
+                Assert.Equal(sharedPtr, rom.u32(8));
+                var scanB = NullTerminatedByteListCore.ScanByteList(rom, 64);
+                Assert.Equal(2, scanB.Count);
+                Assert.Equal(0x10u, scanB[0]);
+                Assert.Equal(0x20u, scanB[1]);
+            }
+            finally
+            {
+                CoreState.ROM = prevRomState;
+            }
+        }
+
+        // ---------------------------------------------------------------------
+        // MakeIndependentCopy
+        // ---------------------------------------------------------------------
+
+        [Fact]
+        public void MakeIndependentCopy_RelocatesAndRepointsOwnerOnly()
+        {
+            byte[] data = new byte[1024];
+            for (int i = 0; i < data.Length; i++) data[i] = 0xFF;
+            data[64] = 0x10;
+            data[65] = 0x20;
+            data[66] = 0x30;
+            data[67] = 0x00;
+            uint sharedPtr = 64u | 0x08000000u;
+            WritePtr(data, 0, sharedPtr); // owner 1
+            WritePtr(data, 4, sharedPtr); // owner 2
+
+            var rom = MakeRom(data);
+            var prevRomState = CoreState.ROM;
+            CoreState.ROM = rom;
+            try
+            {
+                var undo = NewUndo(rom);
+
+                uint newBase = NullTerminatedByteListCore.MakeIndependentCopy(
+                    rom, sourceAddr: 64, ownerPointerAddr: 0, undo: undo);
+
+                Assert.NotEqual(0u, newBase);
+                Assert.NotEqual(U.NOT_FOUND, newBase);
+                Assert.NotEqual(64u, newBase);
+
+                // Owner 1 repointed; owner 2 still on the shared original.
+                Assert.Equal(newBase | 0x08000000u, rom.u32(0));
+                Assert.Equal(sharedPtr, rom.u32(4));
+
+                // New copy equals the source (incl terminator).
+                Assert.Equal(0x10, rom.Data[newBase + 0]);
+                Assert.Equal(0x20, rom.Data[newBase + 1]);
+                Assert.Equal(0x30, rom.Data[newBase + 2]);
+                Assert.Equal(0x00, rom.Data[newBase + 3]);
+
+                // Source untouched.
+                Assert.Equal(0x10, rom.Data[64]);
+                Assert.Equal(0x20, rom.Data[65]);
+                Assert.Equal(0x30, rom.Data[66]);
+                Assert.Equal(0x00, rom.Data[67]);
+            }
+            finally
+            {
+                CoreState.ROM = prevRomState;
+            }
+        }
+
+        // ---------------------------------------------------------------------
+        // Alloc-failure path: throws + undo restores original length + bytes
+        // ---------------------------------------------------------------------
+
+        [Fact]
+        public void WriteByteList_ThrowsWhenNoFreeSpace_UndoRestores()
+        {
+            // Fill the whole ROM with non-free bytes so FindFreeSpace cannot satisfy
+            // any allocation. The list at 8 has a real terminator so the scan/realloc
+            // path runs but the alloc fails.
+            byte[] data = new byte[64];
+            for (int i = 0; i < data.Length; i++) data[i] = 0x55; // no 0xFF/0x00 free runs
+            uint listPtr = 8u | 0x08000000u;
+            WritePtr(data, 0, listPtr);
+            data[8] = 0x12;
+            data[9] = 0x00; // terminator so ScanByteList is well-formed
+
+            var rom = MakeRom(data);
+            byte[] before = (byte[])rom.Data.Clone();
+            int beforeLen = rom.Data.Length;
+            var prevRomState = CoreState.ROM;
+            CoreState.ROM = rom;
+            try
+            {
+                var undo = NewUndo(rom);
+
+                Assert.Throws<InvalidOperationException>(() =>
+                    NullTerminatedByteListCore.WriteByteList(rom, pointerAddr: 0, new uint[] { 0xAA, 0xBB }, undo));
+
+                // Roll back whatever partial writes were recorded.
+                RollbackAll(rom, undo);
+                Assert.Equal(beforeLen, rom.Data.Length);
+                Assert.Equal(before, rom.Data);
+            }
+            finally
+            {
+                CoreState.ROM = prevRomState;
+            }
+        }
+
+        [Fact]
+        public void ExpandByteList_ThrowsWhenNoFreeSpace_UndoRestores()
+        {
+            byte[] data = new byte[64];
+            for (int i = 0; i < data.Length; i++) data[i] = 0x55;
+            uint listPtr = 8u | 0x08000000u;
+            WritePtr(data, 0, listPtr);
+            data[8] = 0x12;
+            data[9] = 0x00;
+
+            var rom = MakeRom(data);
+            byte[] before = (byte[])rom.Data.Clone();
+            int beforeLen = rom.Data.Length;
+            var prevRomState = CoreState.ROM;
+            CoreState.ROM = rom;
+            try
+            {
+                var undo = NewUndo(rom);
+
+                Assert.Throws<InvalidOperationException>(() =>
+                    NullTerminatedByteListCore.ExpandByteList(rom, pointerAddr: 0, undo: undo));
+
+                RollbackAll(rom, undo);
+                Assert.Equal(beforeLen, rom.Data.Length);
+                Assert.Equal(before, rom.Data);
+            }
+            finally
+            {
+                CoreState.ROM = prevRomState;
+            }
+        }
+
+        // ---------------------------------------------------------------------
+        // Helpers
+        // ---------------------------------------------------------------------
+
+        /// <summary>Create a minimal in-memory ROM wrapping a synthetic buffer.</summary>
+        static ROM MakeRom(byte[] data)
+        {
+            var rom = new ROM();
+            typeof(ROM).GetProperty("Data")!.SetValue(rom, data);
+            return rom;
+        }
+
+        static Undo.UndoData NewUndo(ROM rom) => new Undo.UndoData
+        {
+            name = "test",
+            list = new List<Undo.UndoPostion>(),
+            filesize = (uint)rom.Data.Length,
+        };
+
+        /// <summary>Write a GBA pointer little-endian into <paramref name="data"/>.</summary>
+        static void WritePtr(byte[] data, int at, uint gbaPtr)
+        {
+            for (int i = 0; i < 4; i++)
+                data[at + i] = (byte)((gbaPtr >> (i * 8)) & 0xFF);
+        }
+
+        /// <summary>
+        /// Build a 1KB 0xFF-filled ROM with an owner pointer at offset 0 referencing
+        /// a null-terminated list at <paramref name="listOffset"/> holding
+        /// <paramref name="ids"/>. Returns the buffer; out-params expose the pointer
+        /// address (0) and the list base offset.
+        /// </summary>
+        static byte[] MakeRomWithListAt(out uint pointerAddr, out uint listBase, uint listOffset, uint[] ids)
+        {
+            byte[] data = new byte[1024];
+            for (int i = 0; i < data.Length; i++) data[i] = 0xFF;
+            for (int i = 0; i < ids.Length; i++) data[listOffset + i] = (byte)(ids[i] & 0xFF);
+            data[listOffset + (uint)ids.Length] = 0x00; // terminator
+            WritePtr(data, 0, listOffset | 0x08000000u);
+            pointerAddr = 0;
+            listBase = listOffset;
+            return data;
+        }
+
+        /// <summary>
+        /// Roll back every recorded write by restoring each position's captured
+        /// prior bytes, in REVERSE order (last write undone first). Each
+        /// <see cref="Undo.UndoPostion"/> records the bytes that were present BEFORE
+        /// the corresponding <c>write_*</c> ran, so replaying them in reverse
+        /// reconstructs the original ROM (mirrors what <c>Undo.Patch</c> does for a
+        /// single record, without needing the private method or a full Undo buffer).
+        /// </summary>
+        static void RollbackAll(ROM rom, Undo.UndoData undo)
+        {
+            for (int i = undo.list.Count - 1; i >= 0; i--)
+            {
+                var p = undo.list[i];
+                rom.write_range(p.addr, p.data);
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/NullTerminatedByteListCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/NullTerminatedByteListCoreTests.cs
@@ -290,6 +290,74 @@ namespace FEBuilderGBA.Core.Tests
             }
         }
 
+        [Fact]
+        public void ExpandByteList_OnNullOwnerPointer_AllocatesFreshList()
+        {
+            // FE8N Ver2/Ver3 per-skill sub-list pointers (P4/P8/P12/P16/P20) are 0
+            // until the skill grows its first entry. ExpandByteList must treat a NULL
+            // owner pointer as an UNSET/empty list and allocate a fresh
+            // [placeholder, 0x00] list (mirrors WriteByteList) rather than throwing.
+            byte[] data = new byte[1024];
+            for (int i = 0; i < data.Length; i++) data[i] = 0xFF; // free space everywhere
+            WritePtr(data, 0, 0u); // owner pointer slot is NULL
+
+            var rom = MakeRom(data);
+            var prevRomState = CoreState.ROM;
+            CoreState.ROM = rom;
+            try
+            {
+                var undo = NewUndo(rom);
+
+                uint newBase = 0;
+                var ex = Record.Exception(() =>
+                    newBase = NullTerminatedByteListCore.ExpandByteList(rom, pointerAddr: 0, undo: undo));
+                Assert.Null(ex); // does NOT throw on a null owner pointer
+
+                Assert.NotEqual(0u, newBase);
+                Assert.NotEqual(U.NOT_FOUND, newBase);
+
+                // Slot now points to the fresh array.
+                Assert.Equal(newBase | 0x08000000u, rom.u32(0));
+
+                // Fresh layout: [placeholder, 0x00] — one placeholder entry + terminator.
+                Assert.Equal((byte)NullTerminatedByteListCore.NewSlotPlaceholder, rom.Data[newBase + 0]);
+                Assert.Equal(0x00, rom.Data[newBase + 1]); // terminator present
+
+                // ScanByteList returns exactly [0x01] (count 1).
+                var scanned = NullTerminatedByteListCore.ScanByteList(rom, newBase);
+                Assert.Single(scanned);
+                Assert.Equal(NullTerminatedByteListCore.NewSlotPlaceholder, scanned[0]);
+            }
+            finally
+            {
+                CoreState.ROM = prevRomState;
+            }
+        }
+
+        [Fact]
+        public void ExpandByteList_OnGarbageNonNullPointer_Throws()
+        {
+            // A NON-zero owner pointer that is not a ROM address is genuine garbage and
+            // must still throw (the null relaxation does not weaken this guard).
+            byte[] data = new byte[1024];
+            for (int i = 0; i < data.Length; i++) data[i] = 0xFF;
+            WritePtr(data, 0, 0x12345678u); // non-zero, below 0x08000000 => not a pointer
+
+            var rom = MakeRom(data);
+            var prevRomState = CoreState.ROM;
+            CoreState.ROM = rom;
+            try
+            {
+                var undo = NewUndo(rom);
+                Assert.Throws<InvalidOperationException>(() =>
+                    NullTerminatedByteListCore.ExpandByteList(rom, pointerAddr: 0, undo: undo));
+            }
+            finally
+            {
+                CoreState.ROM = prevRomState;
+            }
+        }
+
         // ---------------------------------------------------------------------
         // Shared-array preservation (implicit fork)
         // ---------------------------------------------------------------------

--- a/FEBuilderGBA.Core/NullTerminatedByteListCore.cs
+++ b/FEBuilderGBA.Core/NullTerminatedByteListCore.cs
@@ -112,18 +112,27 @@ namespace FEBuilderGBA
         /// </summary>
         /// <returns>The new array base offset (a ROM offset, not a GBA pointer).</returns>
         /// <exception cref="InvalidOperationException">
-        /// Thrown when the owner pointer is not a ROM address or no free space large
-        /// enough is available (alloc failure). On any failure no relocation is
+        /// Thrown when the owner pointer is NON-zero but is not a ROM address, or when
+        /// no free space large enough is available (alloc failure). A NULL (<c>0</c>)
+        /// owner pointer is NOT an error — see remarks. On any failure no relocation is
         /// committed beyond the writes already recorded on <paramref name="undo"/>,
         /// which a single rollback reverts.
         /// </exception>
         /// <remarks>
+        /// A NULL (<c>0</c>) owner pointer is treated as an UNSET/empty list rather than
+        /// an error: the method allocates a fresh single-entry list
+        /// (<c>[0x01, 0x00]</c>) and repoints the owner to it. This lets the UI add the
+        /// FIRST entry to a skill whose FE8N Ver2/Ver3 sub-list pointer
+        /// (<c>P4/P8/P12/P16/P20</c>) is still <c>0</c>, and matches
+        /// <see cref="WriteByteList"/>, which also accepts a null owner.
+        /// <para>
         /// The array layout grows from <c>[a, b, 0]</c> to <c>[a, b, 1, 0]</c>: the
         /// appended slot is initialized to the non-zero placeholder (<c>0x01</c>) so
         /// it remains visible in <see cref="ScanByteList"/> after a reload (a
         /// <c>0</c> there would be the terminator and the new slot would be invisible
         /// to the UI). Callers can immediately edit the new slot at
         /// <c>newBase + oldCount</c>.
+        /// </para>
         /// <para>
         /// The original bytes at <c>oldBase</c> are intentionally LEFT INTACT so any
         /// other owners still pointing at <c>oldBase</c> keep working; this means
@@ -140,19 +149,38 @@ namespace FEBuilderGBA
                 throw new ArgumentOutOfRangeException(nameof(pointerAddr));
 
             uint oldPtr = rom.u32(pointerAddr);
-            if (!U.isPointer(oldPtr))
-                throw new InvalidOperationException("Owner pointer does not reference a ROM address.");
 
-            uint oldBase = U.toOffset(oldPtr);
-            if (oldBase >= (uint)rom.Data.Length)
-                throw new InvalidOperationException("Owner pointer references an out-of-range address.");
+            // Resolve the owner pointer into an existing list + a FindFreeSpace start
+            // hint. A NULL (0) owner pointer is a legitimate UNSET/empty state — FE8N
+            // Ver2/Ver3 per-skill sub-list pointers (P4/P8/P12/P16/P20) are 0 until the
+            // skill grows its first entry — so treat it as an empty list and allocate a
+            // fresh one (mirrors the 0x100 start hint WriteByteList already uses for a
+            // null owner). A NON-zero pointer that is not a ROM address is genuine
+            // garbage and still throws.
+            List<uint> oldList;
+            uint startHint;
+            if (oldPtr == 0)
+            {
+                oldList = new List<uint>();
+                startHint = 0x100;
+            }
+            else
+            {
+                if (!U.isPointer(oldPtr))
+                    throw new InvalidOperationException("Owner pointer does not reference a ROM address.");
 
-            var oldList = ScanByteList(rom, oldBase);
+                uint oldBase = U.toOffset(oldPtr);
+                if (oldBase >= (uint)rom.Data.Length)
+                    throw new InvalidOperationException("Owner pointer references an out-of-range address.");
+
+                oldList = ScanByteList(rom, oldBase);
+                startHint = oldBase;
+            }
             uint oldCount = (uint)oldList.Count;
 
             // New array layout: [old0, old1, ..., placeholder, 0]  (oldCount + 2 bytes)
             uint newSize = oldCount + 2;
-            uint newBase = rom.FindFreeSpace(oldBase, newSize);
+            uint newBase = rom.FindFreeSpace(startHint, newSize);
             if (newBase == U.NOT_FOUND)
                 newBase = rom.FindFreeSpace(0x100, newSize);
             if (newBase == U.NOT_FOUND)

--- a/FEBuilderGBA.Core/NullTerminatedByteListCore.cs
+++ b/FEBuilderGBA.Core/NullTerminatedByteListCore.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Collections.Generic;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Cross-platform helper for editing null-terminated arrays of 1-byte IDs
+    /// referenced through a 32-bit ROM pointer (issue #926, #769 bucket 2 slice 1).
+    /// It backs the SkillConfig FE8N Ver2/Ver3 per-skill sub-lists (re-pointed via
+    /// <c>P4/P8/P12/P16/P20</c>) but is intentionally id-neutral so any
+    /// null-terminated 1-byte-ID list (unit / class / item / skill IDs) can reuse it.
+    ///
+    /// This is the id-neutral generalization of <see cref="ItemClassListCore"/>: it
+    /// mirrors that class's proven null-terminated-u8-array mechanics
+    /// (<c>0x00</c> terminator, non-zero new-slot placeholder, realloc + repoint,
+    /// shared-array preservation) without any item-effectiveness assumptions. The
+    /// item-effectiveness editor keeps using <see cref="ItemClassListCore"/>
+    /// untouched.
+    ///
+    /// Mechanics:
+    ///   * Scan a null-terminated byte array of IDs (<see cref="ScanByteList"/>).
+    ///   * Write a single ID byte through Undo (<see cref="WriteByte"/>).
+    ///   * Append one slot before the terminator (<see cref="ExpandByteList"/>).
+    ///   * Replace the whole list with an exact, caller-owned set of IDs
+    ///     (<see cref="WriteByteList"/> — handles add/delete/reorder/set).
+    ///   * Fork a shared array into an independent copy
+    ///     (<see cref="MakeIndependentCopy"/>).
+    ///
+    /// <para><b>Error contract:</b> the realloc methods
+    /// (<see cref="ExpandByteList"/>, <see cref="WriteByteList"/>,
+    /// <see cref="MakeIndependentCopy"/>) <b>throw</b>
+    /// <see cref="InvalidOperationException"/> on allocation failure — there is no
+    /// <c>U.NOT_FOUND</c> sentinel (mirrors
+    /// <see cref="ItemClassListCore.ExpandClassList"/>). Slice-2 callers wrap each
+    /// op in <c>try/catch</c> + <c>UndoService.Rollback</c> + <c>ShowError</c>. All
+    /// mutations are undo-aware <c>rom.write_*</c>/<c>write_p32</c> recorded on the
+    /// passed <see cref="Undo.UndoData"/>, so a single rollback fully reverts both
+    /// the bytes and the repoint (no <c>write_resize_data</c> side effects).</para>
+    ///
+    /// <para><b>Shared-array preservation:</b> the realloc methods relocate the
+    /// list to fresh free space and leave the ORIGINAL bytes intact, so any other
+    /// owner still pointing at the old base keeps working — an
+    /// <c>ExpandByteList</c>/<c>WriteByteList</c> on a shared array implicitly forks
+    /// the caller's owner pointer.</para>
+    /// </summary>
+    public static class NullTerminatedByteListCore
+    {
+        /// <summary>
+        /// Placeholder ID written into the new slot by <see cref="ExpandByteList"/>.
+        /// Must be non-zero so the slot survives the null-terminator scan in
+        /// <see cref="ScanByteList"/> (a <c>0x00</c> there would be read as the
+        /// terminator and the new slot would be invisible to the UI). The value is
+        /// arbitrary but valid — the caller edits it immediately after the grow.
+        /// Mirrors <see cref="ItemClassListCore.NewSlotPlaceholder"/>.
+        /// </summary>
+        public const uint NewSlotPlaceholder = 0x01;
+
+        /// <summary>
+        /// Scan a null-terminated array of 1-byte IDs starting at
+        /// <paramref name="baseAddr"/> and return the IDs encountered up to (but not
+        /// including) the first <c>0x00</c> terminator. Stops at the end of
+        /// <c>rom.Data</c>. Returns an empty list if <paramref name="baseAddr"/> is
+        /// zero (treated as a null pointer) or beyond the ROM. Iteration is capped at
+        /// <c>0x200</c> entries (a 1-byte ID list longer than that is bogus).
+        /// </summary>
+        public static List<uint> ScanByteList(ROM rom, uint baseAddr)
+        {
+            var result = new List<uint>();
+            if (rom == null || rom.Data == null) return result;
+            // Pointer semantics: address 0 represents a null pointer and yields an
+            // empty list (ROM data tables never legitimately point at offset 0).
+            // Combined with the bounds check below this guards against scanning
+            // unrelated data when the owner pointer is null.
+            if (baseAddr == 0) return result;
+            if (baseAddr >= (uint)rom.Data.Length) return result;
+
+            // Hard cap: 1-byte IDs cannot exceed 0xFF so any list of > 0x200 is
+            // bogus. Every read is bounds-checked individually.
+            for (uint i = 0; i < 0x200; i++)
+            {
+                uint a = baseAddr + i;
+                if (a >= (uint)rom.Data.Length) break;
+                uint c = rom.u8(a);
+                if (c == 0) break;
+                result.Add(c);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Write a single ID byte to <paramref name="addr"/> and record the undo.
+        /// Use during single-slot in-place edits. Mirrors
+        /// <see cref="ItemClassListCore.WriteClassByte"/>.
+        /// </summary>
+        public static void WriteByte(ROM rom, uint addr, uint value, Undo.UndoData undo)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (undo == null) throw new ArgumentNullException(nameof(undo));
+            if (addr >= (uint)rom.Data.Length)
+                throw new ArgumentOutOfRangeException(nameof(addr), "Address is out of ROM bounds.");
+            rom.write_u8(addr, value & 0xFFu, undo);
+        }
+
+        /// <summary>
+        /// Expand the null-terminated ID array referenced by
+        /// <paramref name="pointerAddr"/> by one slot. Copies the existing array to
+        /// free space, writes a new <see cref="NewSlotPlaceholder"/> (<c>0x01</c>)
+        /// slot just before the terminator (so the user can edit it in place), and
+        /// updates the owning pointer to reference the new array. All writes are
+        /// recorded on <paramref name="undo"/>. Mirrors
+        /// <see cref="ItemClassListCore.ExpandClassList"/>.
+        /// </summary>
+        /// <returns>The new array base offset (a ROM offset, not a GBA pointer).</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the owner pointer is not a ROM address or no free space large
+        /// enough is available (alloc failure). On any failure no relocation is
+        /// committed beyond the writes already recorded on <paramref name="undo"/>,
+        /// which a single rollback reverts.
+        /// </exception>
+        /// <remarks>
+        /// The array layout grows from <c>[a, b, 0]</c> to <c>[a, b, 1, 0]</c>: the
+        /// appended slot is initialized to the non-zero placeholder (<c>0x01</c>) so
+        /// it remains visible in <see cref="ScanByteList"/> after a reload (a
+        /// <c>0</c> there would be the terminator and the new slot would be invisible
+        /// to the UI). Callers can immediately edit the new slot at
+        /// <c>newBase + oldCount</c>.
+        /// <para>
+        /// The original bytes at <c>oldBase</c> are intentionally LEFT INTACT so any
+        /// other owners still pointing at <c>oldBase</c> keep working; this means
+        /// <c>ExpandByteList</c> on a shared array implicitly forks the caller's
+        /// owner pointer (other owners retain the original list). The orphaned bytes
+        /// are negligible and a ROM rebuild reclaims them.
+        /// </para>
+        /// </remarks>
+        public static uint ExpandByteList(ROM rom, uint pointerAddr, Undo.UndoData undo)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (undo == null) throw new ArgumentNullException(nameof(undo));
+            if (pointerAddr + 4 > (uint)rom.Data.Length)
+                throw new ArgumentOutOfRangeException(nameof(pointerAddr));
+
+            uint oldPtr = rom.u32(pointerAddr);
+            if (!U.isPointer(oldPtr))
+                throw new InvalidOperationException("Owner pointer does not reference a ROM address.");
+
+            uint oldBase = U.toOffset(oldPtr);
+            if (oldBase >= (uint)rom.Data.Length)
+                throw new InvalidOperationException("Owner pointer references an out-of-range address.");
+
+            var oldList = ScanByteList(rom, oldBase);
+            uint oldCount = (uint)oldList.Count;
+
+            // New array layout: [old0, old1, ..., placeholder, 0]  (oldCount + 2 bytes)
+            uint newSize = oldCount + 2;
+            uint newBase = rom.FindFreeSpace(oldBase, newSize);
+            if (newBase == U.NOT_FOUND)
+                newBase = rom.FindFreeSpace(0x100, newSize);
+            if (newBase == U.NOT_FOUND)
+                throw new InvalidOperationException("No free space large enough to expand byte list.");
+
+            // Write the relocated array byte-by-byte through undo.
+            for (uint i = 0; i < oldCount; i++)
+            {
+                rom.write_u8(newBase + i, oldList[(int)i] & 0xFFu, undo);
+            }
+            // Append the non-zero placeholder (visible after reload) then the
+            // trailing 0 terminator.
+            rom.write_u8(newBase + oldCount, NewSlotPlaceholder, undo);
+            rom.write_u8(newBase + oldCount + 1, 0u, undo);
+
+            // Update the owning pointer (write_p32 takes a ROM offset).
+            rom.write_p32(pointerAddr, newBase, undo);
+
+            // INTENTIONAL: do not clear the old bytes. Other owners may still point
+            // at oldBase (shared sub-lists); zeroing/0xFF-filling here would corrupt
+            // their data. The orphaned bytes are negligible and a rebuild reclaims them.
+            return newBase;
+        }
+
+        /// <summary>
+        /// Replace the ENTIRE list referenced by <paramref name="pointerAddr"/> with
+        /// exactly <paramref name="ids"/> (each masked to a byte) followed by a single
+        /// <c>0x00</c> terminator, then repoint the owner to the new array. The caller
+        /// owns every byte: there is NO placeholder and NO zero-fill heuristic, so a
+        /// list of N IDs scans back as exactly N (with no interior <c>0x00</c> except
+        /// the terminator). This is the add / delete / reorder / set primitive — the
+        /// UI builds the list it wants (add ⇒ <c>ids + [placeholder]</c>; delete ⇒
+        /// remove an index; reorder ⇒ permute) and persists it here. Passing an empty
+        /// <paramref name="ids"/> writes a terminator-only list (scan returns 0).
+        /// All writes are recorded on <paramref name="undo"/>.
+        /// </summary>
+        /// <returns>The new array base offset (a ROM offset, not a GBA pointer).</returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="ids"/> has more than <c>0xFF</c> entries (a
+        /// 1-byte-ID null-terminated list cannot exceed that).
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when no free space large enough is available (alloc failure). On
+        /// failure the operation is reverted by a single rollback of
+        /// <paramref name="undo"/>.
+        /// </exception>
+        /// <remarks>
+        /// Like <see cref="ExpandByteList"/>, the original bytes are LEFT INTACT so a
+        /// <c>WriteByteList</c> on a shared array implicitly forks the caller's owner
+        /// pointer (other owners retain the original list).
+        /// </remarks>
+        public static uint WriteByteList(ROM rom, uint pointerAddr, IReadOnlyList<uint> ids, Undo.UndoData undo)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (undo == null) throw new ArgumentNullException(nameof(undo));
+            if (ids == null) throw new ArgumentNullException(nameof(ids));
+            if (pointerAddr + 4 > (uint)rom.Data.Length)
+                throw new ArgumentOutOfRangeException(nameof(pointerAddr));
+            if (ids.Count > 0xFF)
+                throw new ArgumentException("A null-terminated 1-byte-ID list cannot exceed 0xFF entries.", nameof(ids));
+
+            // Use the current array base as the FindFreeSpace start hint (mirrors
+            // ItemClassListCore). A null/out-of-range owner pointer just starts the
+            // scan at 0x100 below.
+            uint oldPtr = rom.u32(pointerAddr);
+            uint startHint = 0x100;
+            if (U.isPointer(oldPtr))
+            {
+                uint oldBase = U.toOffset(oldPtr);
+                if (oldBase < (uint)rom.Data.Length)
+                    startHint = oldBase;
+            }
+
+            uint count = (uint)ids.Count;
+            // New array layout: [id0, id1, ..., 0]  (count + 1 bytes)
+            uint newSize = count + 1;
+            uint newBase = rom.FindFreeSpace(startHint, newSize);
+            if (newBase == U.NOT_FOUND)
+                newBase = rom.FindFreeSpace(0x100, newSize);
+            if (newBase == U.NOT_FOUND)
+                throw new InvalidOperationException("No free space large enough to write byte list.");
+
+            // Write the caller's IDs verbatim (no placeholder, no zero-fill).
+            for (uint i = 0; i < count; i++)
+            {
+                rom.write_u8(newBase + i, ids[(int)i] & 0xFFu, undo);
+            }
+            // Single terminator.
+            rom.write_u8(newBase + count, 0u, undo);
+
+            // Update the owning pointer (write_p32 takes a ROM offset).
+            rom.write_p32(pointerAddr, newBase, undo);
+
+            // INTENTIONAL: leave the old bytes intact (shared-array preservation).
+            return newBase;
+        }
+
+        /// <summary>
+        /// Copy the null-terminated ID array at <paramref name="sourceAddr"/>
+        /// (including its <c>0x00</c> terminator) to a new free location and rewrite
+        /// <paramref name="ownerPointerAddr"/> to reference the new copy. Leaves the
+        /// original bytes untouched so other owners that still point at
+        /// <paramref name="sourceAddr"/> continue to work. All writes are recorded on
+        /// <paramref name="undo"/>. Mirrors
+        /// <see cref="ItemClassListCore.MakeIndependentCopy"/>.
+        /// </summary>
+        /// <returns>The new array base offset (a ROM offset, not a GBA pointer).</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when no free space large enough is available (alloc failure). On
+        /// failure the operation is reverted by a single rollback of
+        /// <paramref name="undo"/>.
+        /// </exception>
+        public static uint MakeIndependentCopy(ROM rom, uint sourceAddr, uint ownerPointerAddr, Undo.UndoData undo)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (undo == null) throw new ArgumentNullException(nameof(undo));
+            if (ownerPointerAddr + 4 > (uint)rom.Data.Length)
+                throw new ArgumentOutOfRangeException(nameof(ownerPointerAddr));
+            if (sourceAddr >= (uint)rom.Data.Length)
+                throw new ArgumentOutOfRangeException(nameof(sourceAddr));
+
+            var list = ScanByteList(rom, sourceAddr);
+            uint count = (uint)list.Count;
+
+            // New copy size: count + 1 (terminator).
+            uint newSize = count + 1;
+            uint newBase = rom.FindFreeSpace(sourceAddr, newSize);
+            if (newBase == U.NOT_FOUND)
+                newBase = rom.FindFreeSpace(0x100, newSize);
+            if (newBase == U.NOT_FOUND)
+                throw new InvalidOperationException("No free space large enough to fork byte list.");
+
+            for (uint i = 0; i < count; i++)
+            {
+                rom.write_u8(newBase + i, list[(int)i] & 0xFFu, undo);
+            }
+            rom.write_u8(newBase + count, 0u, undo); // terminator
+
+            // Re-point only the requested owner. Other owners still point at sourceAddr.
+            rom.write_p32(ownerPointerAddr, newBase, undo);
+
+            return newBase;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `FEBuilderGBA.Core/NullTerminatedByteListCore.cs` — a cross-platform Core primitive for editing **null-terminated arrays of 1-byte IDs** addressed by a pointer slot, the data shape of the FE8N Ver2/Ver3 per-skill sub-lists. Mirrors the proven `ItemClassListCore` mechanics with id-neutral naming (`ItemClassListCore` untouched).
- API: `ScanByteList` (read), `WriteByte` (in-place edit), `ExpandByteList` (+1, `0x01` placeholder), `WriteByteList` (set exact list for add/delete/reorder), `MakeIndependentCopy` (fork shared array). All realloc ops: `FindFreeSpace(oldBase)`→`FindFreeSpace(0x100)`→**throw `InvalidOperationException`** (no `write_resize_data`), undo-aware, shared-array-preserving.
- This is **slice 1 of #769 bucket 2** — the Core dependency. Slice 2 (the Avalonia Ver2/Ver3 sub-list editor UI) consumes it.
- Pure `feat(core)` — 2 new files only. No Avalonia/WinForms, no edits to existing Core files.

## Plan Reference
Implements the accepted plan (Revisions v2 + "Ready to implement — no blocking concerns"): https://github.com/laqieer/FEBuilderGBA/issues/926#issuecomment-4612426864

## Scope
Closes #926.
Ref #769 (bucket 2 slice 1).

## Proof (pure-Core PR — CLI/test output)
New `NullTerminatedByteListCoreTests`: **16 passed, 0 failed.** Full `dotnet test FEBuilderGBA.Core.Tests`: **2658 passed, 0 failed, 0 skipped.** `dotnet build FEBuilderGBA.Core` clean.

```
ScanByteList_EmptyOnZeroAddress / _TerminatesOnFirstZero / _EmptyOnOutOfBounds / _HandlesBoundsSafely / _HonorsIterationCap ... PASS
WriteByte_UpdatesByteAndUndoRestoresExactly ............................................. PASS
WriteByteList_WritesExactListWithSingleTerminator / _EmptyListWritesTerminatorOnly ...... PASS
WriteByteList_ReorderAndReplaceRoundTrips / _RejectsListLongerThan255 ................... PASS
ExpandByteList_AppendsPlaceholderBeforeTerminator ...................................... PASS
ExpandByteList_OnSharedArray_OtherOwnerUnchanged / WriteByteList_OnSharedArray_... ..... PASS
MakeIndependentCopy_RelocatesAndRepointsOwnerOnly ..................................... PASS
WriteByteList_ThrowsWhenNoFreeSpace_UndoRestores / ExpandByteList_ThrowsWhenNoFreeSpace_ PASS
```

## Test plan
- [x] `ScanByteList` terminates at `0x00`; empty on `baseAddr==0` and out-of-bounds; 0x200 iteration cap honored
- [x] `WriteByteList` round-trips an exact 3-entry list (scan returns exactly 3 — the B1 null-terminated-grow guard); set-empty ⇒ scan 0; reorder/replace round-trips
- [x] `WriteByteList` rejects a list longer than 255 entries
- [x] `ExpandByteList` appends a visible `0x01` placeholder before the terminator, repoints, preserves old bytes
- [x] Shared-array safety: expand/write on a 2-owner array leaves the other owner's pointer + scan unchanged (implicit fork)
- [x] `MakeIndependentCopy` relocates + repoints owner only; source untouched
- [x] `WriteByte` single-slot edit; undo restores byte-identical
- [x] Alloc-failure: `WriteByteList` and `ExpandByteList` throw `InvalidOperationException` when free space is exhausted; undo restores original length + bytes
- [x] Full `dotnet test FEBuilderGBA.Core.Tests` green (2658/2658); `dotnet build FEBuilderGBA.Core` clean
- [x] `ItemClassListCore`, Avalonia, WinForms, `SkillSystemsAnimeImportCore` all untouched (only 2 new files)

## Known limitations
- Slice-2 (the Avalonia Ver2/Ver3 sub-list editor UI consuming this primitive) is a follow-up PR.

Generated with Claude Code (claude-opus-4-8)
