### PR TITLE
chore: gitignore config/log/ runtime logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ ss-stderr.txt
 ss-stdout.txt
 docs/screenshots/*_test_output.txt
 cli-logs/
+config/log/
 
 # Prevent screenshots in project root (use pr-screenshots/ instead)
 /*.png


### PR DESCRIPTION
## Summary
Adds `config/log/` to `.gitignore`.

The application writes runtime logs to `config/log/log.txt` (~240 KB), which was showing up as an untracked directory in every `git status`. This mirrors the existing ignore entries for `cli-logs/` and `build.log`.

## Changes
- `.gitignore`: add `config/log/` alongside `cli-logs/` in the temporary-artifacts section.

## Verification
- `git check-ignore -v config/log/log.txt` → now matches `.gitignore:config/log/` (previously: not ignored).
- `git status` no longer lists `config/log/`.

## Notes
- `chore` change — screenshots N/A (workflow requires them for feat/fix only).
- A loose `test_skill_version.cs` scratch diagnostic was also removed from the working tree locally; it was untracked, so it is not part of this diff.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude Code 2.1.162 · model claude-opus-4-8[1m]
