### PR TITLE
fix(avalonia): render list icon for nonzero entities whose icon-slot is 0 (T1, #935)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/FirstRowIconSweepTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/FirstRowIconSweepTests.cs
@@ -160,13 +160,15 @@ namespace FEBuilderGBA.Avalonia.Tests
         {
             string src = ReadSource("FEBuilderGBA.Avalonia", "Services", "PreviewIconHelper.cs");
 
-            // The OLD slot==0 short-circuits must be gone.
-            Assert.DoesNotContain("if (waitIconIndex == 0) return null", src);
-            Assert.DoesNotContain("if (iconIndex == 0) return null", src);
+            // The OLD slot==0 short-circuits must be gone. Whitespace-tolerant
+            // regex (per Copilot review on #936) so a harmless reformat of the
+            // helper can't false-fail this regression guard.
+            Assert.DoesNotMatch(@"if\s*\(\s*waitIconIndex\s*==\s*0\s*\)\s*return\s+null", src);
+            Assert.DoesNotMatch(@"if\s*\(\s*iconIndex\s*==\s*0\s*\)\s*return\s+null", src);
 
-            // The NEW entity-id guards must be present.
-            Assert.Contains("if (classId == 0) return null", src);
-            Assert.Contains("if (itemId == 0) return null", src);
+            // The NEW entity-id guards must be present (whitespace-tolerant).
+            Assert.Matches(@"if\s*\(\s*classId\s*==\s*0\s*\)\s*return\s+null", src);
+            Assert.Matches(@"if\s*\(\s*itemId\s*==\s*0\s*\)\s*return\s+null", src);
 
             _output.WriteLine("OK: PreviewIconHelper has entity-id==0 guards and no icon-slot==0 short-circuits");
         }

--- a/FEBuilderGBA.Avalonia.Tests/FirstRowIconSweepTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/FirstRowIconSweepTests.cs
@@ -1,0 +1,271 @@
+using System;
+using System.IO;
+using System.Reflection;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.SkiaSharp;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// Issue #935 regression sweep: the list-icon By*Id helpers must guard on
+    /// the ENTITY id being 0 (the WinForms <c>ClassForm.DrawWaitIcon</c>
+    /// <c>cid&lt;=0</c> / <c>ItemForm.DrawIcon</c> <c>item_id&lt;=0</c>
+    /// semantic) and NOT on the per-entity icon-SLOT field being 0.
+    ///
+    /// The pre-#935 code short-circuited on the SLOT value being 0, so any
+    /// real (nonzero) class/item whose slot field happened to be 0 had its
+    /// icon hidden — collapsing the icon column across ~30 list editors
+    /// (Class / Item / Arena Enemy Weapon, etc.). The correct behaviour:
+    ///   * entity id 0 → null (the null entity stays blank);
+    ///   * a nonzero entity whose slot field == 0 → render icon-table slot 0
+    ///     (slot 0 is a real sprite/icon).
+    ///
+    /// Coverage layers:
+    ///   1. ROM-backed CLASS sweep — first nonzero class with waitIcon slot 0.
+    ///   2. ROM-backed ITEM sweep — first nonzero item with icon slot 0.
+    ///   3. id==0 → null (both helpers), per ROM.
+    ///   4. SOURCE scan (no ROM) — the removed slot==0 guards must be gone and
+    ///      the new entity-id guards present, so a regression that reintroduces
+    ///      the slot short-circuit fails even when no ROM is available.
+    ///
+    /// Tests skip gracefully (no failure) when no ROM is available.
+    /// </summary>
+    [Collection("SharedState")]
+    public class FirstRowIconSweepTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public FirstRowIconSweepTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        // ==================================================================
+        // Layer 1: CLASS — a nonzero class whose wait-icon SLOT field is 0
+        // must still render icon-table slot 0 (NOT be hidden).
+        // ==================================================================
+
+        [Theory]
+        [MemberData(nameof(TestRomLocator.AllRoms), MemberType = typeof(TestRomLocator))]
+        public void Class_NonzeroIdWithWaitIconSlot0_RendersSlot0(string version, string? romPath)
+        {
+            if (romPath == null) { _output.WriteLine($"Skipping {version}: ROM not available"); return; }
+
+            RomTestHelper.WithRom(version, () =>
+            {
+                EnsureImageService();
+
+                // Slot 0 of the wait-icon table must itself be renderable for
+                // this assertion to mean anything; otherwise there is nothing
+                // to compare against and we skip (don't fail).
+                using var slot0 = PreviewIconHelper.LoadClassWaitIcon(0);
+                if (slot0 == null)
+                {
+                    _output.WriteLine($"{version}: class wait-icon slot 0 not renderable — skipping");
+                    return;
+                }
+
+                uint classId = FindNonzeroClassWithWaitIcon0();
+                if (classId == 0)
+                {
+                    _output.WriteLine($"{version}: no nonzero class with waitIcon slot 0 — skipping");
+                    return;
+                }
+
+                using var byId = PreviewIconHelper.LoadClassWaitIconByClassId(classId);
+
+                // The fix: a nonzero class whose slot field is 0 renders slot 0.
+                Assert.NotNull(byId);
+                AssertSameImage(slot0, byId);
+
+                _output.WriteLine($"{version} class 0x{classId:X} (waitIcon slot 0) → " +
+                                  $"{byId.Width}x{byId.Height}, matches slot-0 loader");
+            });
+        }
+
+        // ==================================================================
+        // Layer 2: ITEM — a nonzero item whose icon SLOT field is 0 must still
+        // render icon-table slot 0.
+        // ==================================================================
+
+        [Theory]
+        [MemberData(nameof(TestRomLocator.AllRoms), MemberType = typeof(TestRomLocator))]
+        public void Item_NonzeroIdWithIconSlot0_RendersSlot0(string version, string? romPath)
+        {
+            if (romPath == null) { _output.WriteLine($"Skipping {version}: ROM not available"); return; }
+
+            RomTestHelper.WithRom(version, () =>
+            {
+                EnsureImageService();
+
+                using var slot0 = PreviewIconHelper.LoadItemIcon(0);
+                if (slot0 == null)
+                {
+                    _output.WriteLine($"{version}: item icon slot 0 not renderable — skipping");
+                    return;
+                }
+
+                uint itemId = FindNonzeroItemWithIcon0();
+                if (itemId == 0)
+                {
+                    _output.WriteLine($"{version}: no nonzero item with icon slot 0 — skipping");
+                    return;
+                }
+
+                using var byId = PreviewIconHelper.LoadItemIconByItemId(itemId);
+
+                Assert.NotNull(byId);
+                AssertSameImage(slot0, byId);
+
+                _output.WriteLine($"{version} item 0x{itemId:X} (icon slot 0) → " +
+                                  $"{byId.Width}x{byId.Height}, matches slot-0 loader");
+            });
+        }
+
+        // ==================================================================
+        // Layer 3: id==0 → null (the new entity-id guard), per ROM.
+        // ==================================================================
+
+        [Theory]
+        [MemberData(nameof(TestRomLocator.AllRoms), MemberType = typeof(TestRomLocator))]
+        public void Id0_BothHelpers_ReturnNull(string version, string? romPath)
+        {
+            if (romPath == null) { _output.WriteLine($"Skipping {version}: ROM not available"); return; }
+
+            RomTestHelper.WithRom(version, () =>
+            {
+                EnsureImageService();
+
+                using var c0 = PreviewIconHelper.LoadClassWaitIconByClassId(0);
+                using var i0 = PreviewIconHelper.LoadItemIconByItemId(0);
+
+                Assert.Null(c0);
+                Assert.Null(i0);
+
+                _output.WriteLine($"{version}: LoadClassWaitIconByClassId(0)=null, LoadItemIconByItemId(0)=null OK");
+            });
+        }
+
+        // ==================================================================
+        // Layer 4: SOURCE scan — no ROM needed. Asserts the removed slot==0
+        // short-circuits are gone and the new entity-id guards are present.
+        // Reintroducing the slot guard fails here even with no ROM available.
+        // ==================================================================
+
+        [Fact]
+        public void Source_PreviewIconHelper_HasEntityIdGuards_NotSlotGuards()
+        {
+            string src = ReadSource("FEBuilderGBA.Avalonia", "Services", "PreviewIconHelper.cs");
+
+            // The OLD slot==0 short-circuits must be gone.
+            Assert.DoesNotContain("if (waitIconIndex == 0) return null", src);
+            Assert.DoesNotContain("if (iconIndex == 0) return null", src);
+
+            // The NEW entity-id guards must be present.
+            Assert.Contains("if (classId == 0) return null", src);
+            Assert.Contains("if (itemId == 0) return null", src);
+
+            _output.WriteLine("OK: PreviewIconHelper has entity-id==0 guards and no icon-slot==0 short-circuits");
+        }
+
+        // ==================================================================
+        // Helpers
+        // ==================================================================
+
+        /// <summary>
+        /// Walk the class table; return the first class id &gt; 0 whose
+        /// wait-icon SLOT field (offset +6) is 0. Returns 0 if none found.
+        /// </summary>
+        private static uint FindNonzeroClassWithWaitIcon0()
+        {
+            var rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return 0;
+            uint classPtr = rom.RomInfo.class_pointer;
+            if (classPtr == 0) return 0;
+            uint classBase = rom.p32(classPtr);
+            if (!U.isSafetyOffset(classBase)) return 0;
+            uint classSize = rom.RomInfo.class_datasize;
+            if (classSize == 0) return 0;
+            for (uint id = 1; id < 0x100; id++)
+            {
+                uint classAddr = classBase + id * classSize;
+                if (classAddr + classSize > (uint)rom.Data.Length) break;
+                if (rom.u8(classAddr + 6) == 0)
+                    return id;
+            }
+            return 0;
+        }
+
+        /// <summary>
+        /// Walk the item table; return the first item id &gt; 0 whose icon
+        /// SLOT field (offset +29) is 0. Returns 0 if none found.
+        /// </summary>
+        private static uint FindNonzeroItemWithIcon0()
+        {
+            var rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return 0;
+            uint itemPtr = rom.RomInfo.item_pointer;
+            if (itemPtr == 0) return 0;
+            uint itemBase = rom.p32(itemPtr);
+            if (!U.isSafetyOffset(itemBase)) return 0;
+            uint itemSize = rom.RomInfo.item_datasize;
+            if (itemSize == 0) return 0;
+            for (uint id = 1; id < 0x100; id++)
+            {
+                uint itemAddr = itemBase + id * itemSize;
+                if (itemAddr + itemSize > (uint)rom.Data.Length) break;
+                if (rom.u8(itemAddr + 29) == 0)
+                    return id;
+            }
+            return 0;
+        }
+
+        /// <summary>
+        /// Assert two indexed images represent the same icon: same dimensions
+        /// and byte-identical pixel data. Confirms the By*Id helper produced
+        /// the exact slot-0 sprite (not merely "some non-null image").
+        /// </summary>
+        private static void AssertSameImage(IImage expected, IImage actual)
+        {
+            Assert.NotNull(expected);
+            Assert.NotNull(actual);
+            Assert.Equal(expected.Width, actual.Width);
+            Assert.Equal(expected.Height, actual.Height);
+            Assert.Equal(expected.GetPixelData(), actual.GetPixelData());
+        }
+
+        /// <summary>
+        /// Read a production source file from the repo, walking up from the
+        /// test assembly to locate FEBuilderGBA.sln then descending into the
+        /// named project subdirectory. Mirrors
+        /// <c>ListIconLoadersFirstRowTests.ReadSource</c>.
+        /// </summary>
+        private static string ReadSource(params string[] pathSegments)
+        {
+            string? dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            for (int i = 0; i < 10 && dir != null; i++)
+            {
+                if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                {
+                    string p = Path.Combine(pathSegments);
+                    string full = Path.Combine(dir, p);
+                    if (File.Exists(full))
+                        return File.ReadAllText(full);
+                    Assert.Fail($"Source file not found: {full}");
+                }
+                dir = Path.GetDirectoryName(dir);
+            }
+            Assert.Fail("Could not locate FEBuilderGBA.sln from test assembly");
+            return string.Empty;
+        }
+
+        private static void EnsureImageService()
+        {
+            if (CoreState.ImageService == null)
+                CoreState.ImageService = new SkiaImageService();
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/ListIconLoadersFirstRowTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ListIconLoadersFirstRowTests.cs
@@ -120,6 +120,12 @@ namespace FEBuilderGBA.Avalonia.Tests
         // MUST return non-null. The OLD code returned null regardless.
         // ==================================================================
 
+        // #935: the row whose prefix parses to id 0 is the NULL entity. The
+        // loader must agree with the By*Id helper, and BOTH must now be null
+        // for id 0 (WinForms guards cid<=0 / item_id<=0 → blank). The old
+        // assertion (`slot field != 0 ⟹ NotNull` for id 0) is the slot==0
+        // behaviour #935 reverses, so it is removed here.
+
         [Theory]
         [MemberData(nameof(TestRomLocator.AllRoms), MemberType = typeof(TestRomLocator))]
         public void ClassIconLoader_FirstRowId0_MatchesPreviewIconHelper(string version, string? romPath)
@@ -134,24 +140,18 @@ namespace FEBuilderGBA.Avalonia.Tests
                     new AddrResult(0x100, "00 PlaceholderClass", 0),
                 };
 
-                uint waitIcon = ReadClassWaitIconIndexForId0();
                 using var helperImg = PreviewIconHelper.LoadClassWaitIconByClassId(0);
                 using var bmp = ListIconLoaders.ClassIconLoader(items, 0);
 
-                // Differential: under old code, loader returned null even when
-                // helper would have returned an image. Their null-states MUST
-                // match post-fix.
+                // The loader resolves classId=0 from the "00" prefix and calls
+                // the By*Id helper; their null-states MUST match.
                 Assert.Equal(helperImg == null, bmp == null);
 
-                // Stronger differential: when ROM data is VALID (waitIcon
-                // non-zero), the loader must produce a real bitmap. Old code
-                // returned null here → would have failed.
-                if (waitIcon != 0)
-                {
-                    Assert.NotNull(helperImg);
-                    Assert.NotNull(bmp);
-                }
-                _output.WriteLine($"{version} ClassIconLoader(0): waitIcon=0x{waitIcon:X2}, " +
+                // #935: id 0 is the null class → both helper and loader null.
+                Assert.Null(helperImg);
+                Assert.Null(bmp);
+
+                _output.WriteLine($"{version} ClassIconLoader(0): id 0 → " +
                                   $"helper={(helperImg == null ? "null" : "Image")}, " +
                                   $"loader={(bmp == null ? "null" : "Bitmap")}");
             });
@@ -171,18 +171,16 @@ namespace FEBuilderGBA.Avalonia.Tests
                     new AddrResult(0x100, "00 NullItem", 0),
                 };
 
-                uint iconIndex = ReadItemIconIndexForId0();
                 using var helperImg = PreviewIconHelper.LoadItemIconByItemId(0);
                 using var bmp = ListIconLoaders.ItemIconLoader(items, 0);
 
                 Assert.Equal(helperImg == null, bmp == null);
 
-                if (iconIndex != 0)
-                {
-                    Assert.NotNull(helperImg);
-                    Assert.NotNull(bmp);
-                }
-                _output.WriteLine($"{version} ItemIconLoader(0): iconIdx=0x{iconIndex:X2}, " +
+                // #935: id 0 is the null item → both helper and loader null.
+                Assert.Null(helperImg);
+                Assert.Null(bmp);
+
+                _output.WriteLine($"{version} ItemIconLoader(0): id 0 → " +
                                   $"helper={(helperImg == null ? "null" : "Image")}, " +
                                   $"loader={(bmp == null ? "null" : "Bitmap")}");
             });
@@ -260,53 +258,94 @@ namespace FEBuilderGBA.Avalonia.Tests
             });
         }
 
+        // #935 NEW CONTRACT: the By*Id helpers now guard ONLY on entity id 0
+        // (matching WinForms ClassForm.DrawWaitIcon `cid<=0` / ItemForm.DrawIcon
+        // `item_id<=0`), NOT on the per-entity icon-SLOT field being 0. So:
+        //   * id 0 → always null (the new entity-id guard).
+        //   * a NONZERO entity whose slot field == 0 → must render icon-table
+        //     slot 0, i.e. equal the direct slot-0 loader (non-null whenever
+        //     slot 0 itself is renderable, null only when slot 0 is not).
+        // These two tests previously asserted the OLD slot==0 behaviour
+        // (By*Id(0) tracked ReadXIconIndexForId0()); they now lock in the fix.
+
         [Theory]
         [MemberData(nameof(TestRomLocator.AllRoms), MemberType = typeof(TestRomLocator))]
-        public void LoadClassWaitIconByClassId_Id0_RespectsRomData(string version, string? romPath)
+        public void LoadClassWaitIconByClassId_Id0_ReturnsNullAndSlot0EntityMatchesSlot0(string version, string? romPath)
         {
             if (romPath == null) { _output.WriteLine($"Skipping {version}: ROM not available"); return; }
 
             RomTestHelper.WithRom(version, () =>
             {
                 EnsureImageService();
-                uint waitIcon = ReadClassWaitIconIndexForId0();
-                using var c0 = PreviewIconHelper.LoadClassWaitIconByClassId(0);
 
-                if (waitIcon != 0)
-                {
-                    Assert.NotNull(c0);
-                }
-                else
+                // (1) id 0 → always null (new entity-id guard).
+                using (var c0 = PreviewIconHelper.LoadClassWaitIconByClassId(0))
                 {
                     Assert.Null(c0);
                 }
-                _output.WriteLine($"{version} LoadClassWaitIconByClassId(0): waitIcon=0x{waitIcon:X2}, " +
-                                  $"c0={(c0 == null ? "null" : "Image")}");
+
+                // (2) A nonzero class whose wait-icon SLOT field == 0 must
+                // render the SAME result as the direct slot-0 loader: non-null
+                // when slot 0 is renderable, null only when it is not.
+                using var slot0Direct = PreviewIconHelper.LoadClassWaitIcon(0);
+                bool slot0Renderable = slot0Direct != null;
+
+                uint nonzeroClassWithSlot0 = FindNonzeroClassWithWaitIcon0();
+                if (nonzeroClassWithSlot0 == 0)
+                {
+                    _output.WriteLine($"{version}: no nonzero class with waitIcon slot 0 — skipping slot-0 assertion");
+                    return;
+                }
+
+                using var entityImg = PreviewIconHelper.LoadClassWaitIconByClassId(nonzeroClassWithSlot0);
+                Assert.Equal(slot0Renderable, entityImg != null);
+                if (slot0Renderable)
+                {
+                    Assert.NotNull(entityImg);
+                }
+                _output.WriteLine($"{version} LoadClassWaitIconByClassId: id0=null OK; " +
+                                  $"class 0x{nonzeroClassWithSlot0:X} (slot0) → " +
+                                  $"{(entityImg == null ? "null" : "Image")}, slot0Renderable={slot0Renderable}");
             });
         }
 
         [Theory]
         [MemberData(nameof(TestRomLocator.AllRoms), MemberType = typeof(TestRomLocator))]
-        public void LoadItemIconByItemId_Id0_RespectsRomData(string version, string? romPath)
+        public void LoadItemIconByItemId_Id0_ReturnsNullAndSlot0EntityMatchesSlot0(string version, string? romPath)
         {
             if (romPath == null) { _output.WriteLine($"Skipping {version}: ROM not available"); return; }
 
             RomTestHelper.WithRom(version, () =>
             {
                 EnsureImageService();
-                uint iconIndex = ReadItemIconIndexForId0();
-                using var i0 = PreviewIconHelper.LoadItemIconByItemId(0);
 
-                if (iconIndex != 0)
-                {
-                    Assert.NotNull(i0);
-                }
-                else
+                // (1) id 0 → always null (new entity-id guard).
+                using (var i0 = PreviewIconHelper.LoadItemIconByItemId(0))
                 {
                     Assert.Null(i0);
                 }
-                _output.WriteLine($"{version} LoadItemIconByItemId(0): iconIdx=0x{iconIndex:X2}, " +
-                                  $"i0={(i0 == null ? "null" : "Image")}");
+
+                // (2) A nonzero item whose icon SLOT field == 0 must render the
+                // SAME result as the direct slot-0 loader.
+                using var slot0Direct = PreviewIconHelper.LoadItemIcon(0);
+                bool slot0Renderable = slot0Direct != null;
+
+                uint nonzeroItemWithSlot0 = FindNonzeroItemWithIcon0();
+                if (nonzeroItemWithSlot0 == 0)
+                {
+                    _output.WriteLine($"{version}: no nonzero item with icon slot 0 — skipping slot-0 assertion");
+                    return;
+                }
+
+                using var entityImg = PreviewIconHelper.LoadItemIconByItemId(nonzeroItemWithSlot0);
+                Assert.Equal(slot0Renderable, entityImg != null);
+                if (slot0Renderable)
+                {
+                    Assert.NotNull(entityImg);
+                }
+                _output.WriteLine($"{version} LoadItemIconByItemId: id0=null OK; " +
+                                  $"item 0x{nonzeroItemWithSlot0:X} (slot0) → " +
+                                  $"{(entityImg == null ? "null" : "Image")}, slot0Renderable={slot0Renderable}");
             });
         }
 
@@ -408,11 +447,13 @@ namespace FEBuilderGBA.Avalonia.Tests
         }
 
         /// <summary>
-        /// Read the wait-icon index for class id 0 directly from ROM (the
-        /// same field <see cref="PreviewIconHelper.LoadClassWaitIconByClassId"/>
-        /// reads). Returns 0 if the lookup itself can't be performed.
+        /// Walk the class table and return the first class id &gt; 0 whose
+        /// wait-icon SLOT field (offset +6) is 0. This is the exact case the
+        /// #935 fix targets: a real (nonzero) class whose slot field happens to
+        /// be 0 must still render icon-table slot 0. Returns 0 if no such class
+        /// exists on the current ROM (caller skips the slot-0 assertion).
         /// </summary>
-        private static uint ReadClassWaitIconIndexForId0()
+        private static uint FindNonzeroClassWithWaitIcon0()
         {
             var rom = CoreState.ROM;
             if (rom?.RomInfo == null) return 0;
@@ -422,16 +463,23 @@ namespace FEBuilderGBA.Avalonia.Tests
             if (!U.isSafetyOffset(classBase)) return 0;
             uint classSize = rom.RomInfo.class_datasize;
             if (classSize == 0) return 0;
-            uint classAddr = classBase + 0 * classSize;
-            if (classAddr + classSize > (uint)rom.Data.Length) return 0;
-            return rom.u8(classAddr + 6);
+            // Scan a generous upper bound; bail at the end of ROM data.
+            for (uint id = 1; id < 0x100; id++)
+            {
+                uint classAddr = classBase + id * classSize;
+                if (classAddr + classSize > (uint)rom.Data.Length) break;
+                if (rom.u8(classAddr + 6) == 0)
+                    return id;
+            }
+            return 0;
         }
 
         /// <summary>
-        /// Read the icon index for item id 0 directly from ROM (the same
-        /// field <see cref="PreviewIconHelper.LoadItemIconByItemId"/> reads).
+        /// Walk the item table and return the first item id &gt; 0 whose icon
+        /// SLOT field (offset +29) is 0. The #935 fix means such an item must
+        /// still render icon-table slot 0. Returns 0 if none found.
         /// </summary>
-        private static uint ReadItemIconIndexForId0()
+        private static uint FindNonzeroItemWithIcon0()
         {
             var rom = CoreState.ROM;
             if (rom?.RomInfo == null) return 0;
@@ -441,9 +489,14 @@ namespace FEBuilderGBA.Avalonia.Tests
             if (!U.isSafetyOffset(itemBase)) return 0;
             uint itemSize = rom.RomInfo.item_datasize;
             if (itemSize == 0) return 0;
-            uint itemAddr = itemBase + 0 * itemSize;
-            if (itemAddr + itemSize > (uint)rom.Data.Length) return 0;
-            return rom.u8(itemAddr + 29);
+            for (uint id = 1; id < 0x100; id++)
+            {
+                uint itemAddr = itemBase + id * itemSize;
+                if (itemAddr + itemSize > (uint)rom.Data.Length) break;
+                if (rom.u8(itemAddr + 29) == 0)
+                    return id;
+            }
+            return 0;
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/Services/PreviewIconHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/PreviewIconHelper.cs
@@ -474,16 +474,20 @@ namespace FEBuilderGBA.Avalonia.Services
         /// Load a class wait icon by class ID. Resolves class ID -> wait icon index (offset +6) -> loads icon.
         /// </summary>
         /// <remarks>
-        /// #654: removed <c>classId == 0</c> early return so class 0 (the
-        /// first row in every class-prefixed list) gets a lookup. The class
-        /// struct at offset 0 may legitimately have <c>waitIconIndex == 0</c>
-        /// (no map sprite), in which case we still bail — but for any other
-        /// class-0 row the icon now renders.
+        /// #935: mirrors WinForms <c>ClassForm.DrawWaitIcon</c>, which guards
+        /// only <c>cid &lt;= 0</c> (class 0 = the "null class" → blank) and then,
+        /// for any class &gt;= 1, reads the wait-icon-table slot from offset +6
+        /// and renders it directly — WITHOUT short-circuiting when that slot
+        /// value is 0. Slot 0 of the wait-icon table is a real sprite, so a
+        /// nonzero class whose <c>waitIconIndex</c> field happens to be 0 must
+        /// still render slot 0 (the old <c>waitIconIndex == 0</c> bail hid the
+        /// first real row's icon across ~30 class-prefixed list editors).
         /// </remarks>
         public static IImage LoadClassWaitIconByClassId(uint classId)
         {
             ROM rom = CoreState.ROM;
             if (rom?.RomInfo == null) return null;
+            if (classId == 0) return null;
             try
             {
                 uint classPtr = rom.RomInfo.class_pointer;
@@ -494,7 +498,6 @@ namespace FEBuilderGBA.Avalonia.Services
                 uint classAddr = classBase + classId * classSize;
                 if (classAddr + classSize > (uint)rom.Data.Length) return null;
                 uint waitIconIndex = rom.u8(classAddr + 6);
-                if (waitIconIndex == 0) return null;
                 return LoadClassWaitIcon(waitIconIndex);
             }
             catch { return null; }
@@ -504,17 +507,20 @@ namespace FEBuilderGBA.Avalonia.Services
         /// Load an item icon by item ID. Resolves item ID -> icon index (offset +29) -> loads icon.
         /// </summary>
         /// <remarks>
-        /// #654: removed <c>itemId == 0</c> early return. Item 0 (the first
-        /// row in every item-prefixed list) is a real ROM entry on every
-        /// supported version — for FE8U it is the "null item" placeholder
-        /// whose icon at offset +29 is 0 (we still bail when that happens),
-        /// but on FE6 / FE7 item 0 has a real icon and was incorrectly
-        /// hidden. Aligns with WinForms which never short-circuits on item ID.
+        /// #935: mirrors WinForms <c>ItemForm.DrawIcon</c>, which guards only
+        /// <c>item_id &lt;= 0</c> (item 0 = the "null item" → blank) and then,
+        /// for any item &gt;= 1, reads the icon-table slot from offset +29 and
+        /// renders it directly — WITHOUT short-circuiting when that slot value
+        /// is 0. Slot 0 of the icon table is a real icon, so a nonzero item
+        /// whose <c>iconIndex</c> field happens to be 0 must still render slot 0
+        /// (the old <c>iconIndex == 0</c> bail hid the first real row's icon
+        /// across the item-prefixed list editors).
         /// </remarks>
         public static IImage LoadItemIconByItemId(uint itemId)
         {
             ROM rom = CoreState.ROM;
             if (rom?.RomInfo == null) return null;
+            if (itemId == 0) return null;
             try
             {
                 uint itemPtr = rom.RomInfo.item_pointer;
@@ -525,11 +531,6 @@ namespace FEBuilderGBA.Avalonia.Services
                 uint itemAddr = itemBase + itemId * itemSize;
                 if (itemAddr + itemSize > (uint)rom.Data.Length) return null;
                 uint iconIndex = rom.u8(itemAddr + 29);
-                // The icon index at +29 is the per-item "icon slot" field;
-                // value 0 means "no icon" (null item placeholder). Bailing
-                // here matches the remarks above and prevents rendering a
-                // phantom icon from slot 0 of the icon table.
-                if (iconIndex == 0) return null;
                 return LoadItemIcon(iconIndex);
             }
             catch { return null; }


### PR DESCRIPTION
## Summary
Avalonia list-icon loaders hid the row icon for any entity whose **icon-slot field** is 0 — even though icon-table slot 0 is a real icon. `PreviewIconHelper.LoadClassWaitIconByClassId`/`LoadItemIconByItemId` short-circuited on the **slot value**. WinForms `ClassForm.DrawWaitIcon`/`ItemForm.DrawIcon` guard only the **entity id** (`cid<=0`/`item_id<=0`) and render slot 0.

**Fix:** replace the slot-value guard with an early **`id==0`** guard (WinForms parity) — id 0 stays blank, id ≥ 1 renders its icon. One shared helper → repairs ~30 list editors. Closes #935 (reported #1 Class, #3 Item, #19 Arena Enemy Weapon).

## Screenshots (FE6)
**Class Editor — class 1 ロード** (B6 wait-icon = 0):
| Before | After |
|---|---|
| ![b](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/bugsweep/bug01-class-list-icon.png?raw=1) | ![a](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug01-class-list-icon-after.png) |

**Item Editor — item 1 てつの剣** (icon-slot +29 = 0):
| Before | After |
|---|---|
| ![b](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/bugsweep/bug03-item-list-icon.png?raw=1) | ![a](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug03-item-list-icon-after.png) |

**Arena Enemy Weapon — てつの剣** (item 1):
| Before | After |
|---|---|
| ![b](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/bugsweep/bug19-arena-enemy-weapon.png?raw=1) | ![a](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug19-arena-enemy-weapon-after.png) |

First real row now renders its icon; the null row (id 0 / `#0 (0x00)`) stays blank.

## GUI Test Report
**Environment:** ROM `roms/FE6.gba`; captured via `--screenshot-all` offscreen `RenderTargetBitmap` (the session screen was locked — offscreen render is locked-safe, no fabricated images); editors built from this branch.

| Test | Expected | Actual | Status |
|---|---|---|---|
| Class 1 ロード (B6=0) | icon renders | renders | PASS |
| Item 1 てつの剣 (slot=0) | icon renders | sword renders | PASS |
| Arena てつの剣 (item 1) | icon renders | sword renders | PASS |
| Null row (id 0 / #0) | stays blank | blank | PASS |

**Verdict:** PASS.

## Test plan
- [x] `FirstRowIconSweepTests`: nonzero class with B6=0 → non-null icon == slot-0 loader (all 5 ROMs)
- [x] `FirstRowIconSweepTests`: nonzero item with +29=0 → non-null
- [x] `LoadClassWaitIconByClassId(0)`/`LoadItemIconByItemId(0)` return null (id==0 guard, WF parity)
- [x] Source-scan: slot guards removed, `classId==0`/`itemId==0` guards present
- [x] Flipped the two `*_Id0_RespectsRomData` assertions + two Layer-1 loader tests that locked in slot==0
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` — affected 49 passed/0 failed; full suite (ROMs disabled) 7382 passed/0 failed
- [x] GUI after-shots captured (offscreen) proving class 1 / item 1 / weapon 1 icons render

## Known limitations
- After-shots use `roms/FE6.gba` (modified FE6); names differ from the user's ROM but the version-agnostic fix behavior is identical.
- Full suite with local (modified) ROMs has 42 pre-existing unrelated failures (ROM-data assertions); ROMs-disabled run is green → no regression.

Generated with Claude Code (claude-opus-4-8[1m])

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) · Claude Code 2.1.162 · model claude-opus-4-8[1m]