### PR TITLE
fix(avalonia): key class/item list icons off the real class/item field, not the row index (T2, #939)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/IconLoaderWiringTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/IconLoaderWiringTests.cs
@@ -1,0 +1,260 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// #939 detection scanner. The Avalonia list-icon loaders
+    /// <c>ListIconLoaders.ClassIconLoader</c> / <c>ItemIconLoader</c> have two
+    /// overloads:
+    ///   - 2-arg <c>(items, i)</c>: parses the row text prefix via
+    ///     <c>U.atoh(items[i].name)</c> to get the class/item id. ONLY correct
+    ///     when the displayed prefix IS the entity id (the canonical
+    ///     index==id editors).
+    ///   - 3-arg <c>(items, i, selector)</c>: reads the real class/item id from
+    ///     the entry's ROM address via an explicit selector. Required when the
+    ///     prefix is the row INDEX (OP Class Demo / Arena Class), so the icon
+    ///     matches the entity, not the row position.
+    ///
+    /// The bug (#939): three "Category A" views fed a row-index-prefixed list to
+    /// the 2-arg loader → WRONG class icon; eight "Category B" views fed
+    /// non-class/non-item rows (font pointers, name pointers, synthetic section
+    /// labels) to a class/item loader → SPURIOUS icon.
+    ///
+    /// This scanner asserts:
+    ///   1. The 3 Category-A views now use the 3-arg idSelector overload.
+    ///   2. The 8 Category-B views no longer reference Class/ItemIconLoader at
+    ///      all (their icon column was removed).
+    ///   3. Every remaining 2-arg Class/ItemIconLoader call is on the explicit
+    ///      allow-list of canonical index==id editors (DO-NOT-TOUCH).
+    ///
+    /// Pure source-text scan — no ROM, no Avalonia runtime — so it stays fast
+    /// and deterministic in CI.
+    /// </summary>
+    public class IconLoaderWiringTests
+    {
+        private readonly ITestOutputHelper _output;
+        public IconLoaderWiringTests(ITestOutputHelper output) => _output = output;
+
+        // ----------------------------------------------------------------
+        // Source-root discovery (same walk-up pattern as the other source
+        // scanners in this project, e.g. BindingValidationTests).
+        // ----------------------------------------------------------------
+        private static string FindProjectRoot()
+        {
+            string dir = AppDomain.CurrentDomain.BaseDirectory;
+            for (int i = 0; i < 12; i++)
+            {
+                if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                    return dir;
+                string? parent = Path.GetDirectoryName(dir);
+                if (parent == null || parent == dir) break;
+                dir = parent;
+            }
+            string cwd = Directory.GetCurrentDirectory();
+            for (int i = 0; i < 12; i++)
+            {
+                if (File.Exists(Path.Combine(cwd, "FEBuilderGBA.sln")))
+                    return cwd;
+                string? parent = Path.GetDirectoryName(cwd);
+                if (parent == null || parent == cwd) break;
+                cwd = parent;
+            }
+            throw new InvalidOperationException("Could not find project root (FEBuilderGBA.sln)");
+        }
+
+        private static string ViewsDir()
+            => Path.Combine(FindProjectRoot(), "FEBuilderGBA.Avalonia", "Views");
+
+        // ----------------------------------------------------------------
+        // Matchers.
+        // 2-arg call: SetItemsWithIcons(<list>, i => ListIconLoaders.{Class|Item}IconLoader(<list>, i))
+        //   — the inner call has EXACTLY the (items, i) args, no trailing selector.
+        // 3-arg call: ...IconLoader(<list>, i, <selector>)
+        // ----------------------------------------------------------------
+        private static readonly Regex TwoArgCall = new(
+            @"ListIconLoaders\.(Class|Item)IconLoader\(\s*\w+\s*,\s*\w+\s*\)",
+            RegexOptions.Compiled);
+
+        private static readonly Regex ThreeArgCall = new(
+            @"ListIconLoaders\.(Class|Item)IconLoader\(\s*\w+\s*,\s*\w+\s*,",
+            RegexOptions.Compiled);
+
+        private static readonly Regex AnyIconLoaderRef = new(
+            @"ListIconLoaders\.(Class|Item)IconLoader\b",
+            RegexOptions.Compiled);
+
+        // ----------------------------------------------------------------
+        // The three Category-A views fixed in #939 — must use the 3-arg
+        // idSelector overload (and must NOT use the 2-arg overload).
+        // ----------------------------------------------------------------
+        private static readonly string[] CategoryAViews =
+        {
+            "ClassOPDemoView.axaml.cs",
+            "OPClassDemoViewerView.axaml.cs",
+            "ArenaClassViewerView.axaml.cs",
+        };
+
+        // ----------------------------------------------------------------
+        // The eight Category-B views fixed in #939 — rows are NOT a
+        // class/item table, so they must reference NEITHER icon loader.
+        // ----------------------------------------------------------------
+        private static readonly string[] CategoryBViews =
+        {
+            "OPClassFontViewerView.axaml.cs",
+            "OPClassFontFE8UView.axaml.cs",
+            "OPClassAlphaNameFE6View.axaml.cs",
+            "ItemEffectivenessMainView.axaml.cs",
+            "ItemStatBonusesVennoView.axaml.cs",
+            "ItemStatBonusesSkillSystemsView.axaml.cs",
+            "FE8SpellMenuExtendsView.axaml.cs",
+            "OPClassAlphaNameFE6ExtraView.axaml.cs",
+        };
+
+        // ----------------------------------------------------------------
+        // Allow-list of canonical index==id (or real-id-prefixed) editors
+        // that legitimately keep the 2-arg text-prefix overload. Their list
+        // builders emit the REAL class/item id as the row prefix, so
+        // U.atoh(name) yields the correct id. (DO-NOT-TOUCH set.)
+        // ----------------------------------------------------------------
+        private static readonly HashSet<string> TwoArgAllowList = new(StringComparer.OrdinalIgnoreCase)
+        {
+            // --- Class tables (prefix == real class id) ---
+            "ClassEditorView.axaml.cs",
+            "ClassFE6View.axaml.cs",
+            "CCBranchEditorView.axaml.cs",
+            "MoveCostEditorView.axaml.cs",
+            "MoveCostFE6View.axaml.cs",
+            "SkillAssignmentClassSkillSystemView.axaml.cs",
+            "OPClassAlphaNameView.axaml.cs",       // FE8J — prefixes real cid
+            "SomeClassListView.axaml.cs",          // prefix == rom.u8(addr)
+            "SoundFootStepsViewerView.axaml.cs",
+            // FE7/FE7U/FE8U OP Class Demo — VMs prefix the real cid
+            // (u8(addr+15) / u8(addr+11) / u8(addr+5)), verified in #939.
+            "OPClassDemoFE7View.axaml.cs",
+            "OPClassDemoFE7UView.axaml.cs",
+            "OPClassDemoFE8UView.axaml.cs",
+            // --- Item tables (prefix == real item id) ---
+            "ItemEditorView.axaml.cs",
+            "ItemFE6View.axaml.cs",
+            "ItemEffectivenessViewerView.axaml.cs",
+            "ItemEffectivenessSkillSystemsReworkView.axaml.cs",
+            "ItemStatBonusesViewerView.axaml.cs",
+            "ItemWeaponEffectViewerView.axaml.cs",
+            "ItemRandomChestView.axaml.cs",
+            "ItemUsagePointerViewerView.axaml.cs",
+            "ItemPromotionViewerView.axaml.cs",    // prefix == real item/class id
+            "ItemShopViewerView.axaml.cs",         // ItemShopCore prefixes real item id (#654)
+        };
+
+        /// <summary>
+        /// Category A: each of the three regressed views must now use the
+        /// 3-arg idSelector overload and must NOT use the 2-arg overload.
+        /// </summary>
+        [Fact]
+        public void CategoryA_Views_Use_ThreeArg_IdSelector_Overload()
+        {
+            string viewsDir = ViewsDir();
+            var failures = new List<string>();
+
+            foreach (string view in CategoryAViews)
+            {
+                string path = Path.Combine(viewsDir, view);
+                Assert.True(File.Exists(path), $"Expected Category-A view not found: {view}");
+                string src = File.ReadAllText(path);
+
+                if (!ThreeArgCall.IsMatch(src))
+                    failures.Add($"{view}: expected a 3-arg ClassIconLoader(items, i, selector) call but none found.");
+                if (TwoArgCall.IsMatch(src))
+                    failures.Add($"{view}: still uses the 2-arg ClassIconLoader(items, i) overload (prefix is the row INDEX → wrong icon).");
+            }
+
+            Assert.True(failures.Count == 0,
+                "Category-A icon wiring regressed:\n" + string.Join("\n", failures));
+        }
+
+        /// <summary>
+        /// Category B: each of the eight views whose rows are NOT a
+        /// class/item table must reference NEITHER Class/ItemIconLoader.
+        /// </summary>
+        [Fact]
+        public void CategoryB_Views_Do_Not_Reference_ClassOrItemIconLoader()
+        {
+            string viewsDir = ViewsDir();
+            var failures = new List<string>();
+
+            foreach (string view in CategoryBViews)
+            {
+                string path = Path.Combine(viewsDir, view);
+                Assert.True(File.Exists(path), $"Expected Category-B view not found: {view}");
+                string src = File.ReadAllText(path);
+
+                if (AnyIconLoaderRef.IsMatch(src))
+                    failures.Add($"{view}: still references ListIconLoaders.Class/ItemIconLoader (rows are not a class/item table → spurious icon).");
+            }
+
+            Assert.True(failures.Count == 0,
+                "Category-B icon wiring regressed:\n" + string.Join("\n", failures));
+        }
+
+        /// <summary>
+        /// Guard: every remaining 2-arg Class/ItemIconLoader call across ALL
+        /// Views/*.axaml.cs must come from a file on the canonical allow-list.
+        /// Any new view that text-prefixes a row INDEX but feeds the 2-arg
+        /// (text-parse) loader will trip this assertion — that is exactly the
+        /// #939 class of bug.
+        /// </summary>
+        [Fact]
+        public void All_TwoArg_IconLoader_Callsites_Are_AllowListed()
+        {
+            string viewsDir = ViewsDir();
+            Assert.True(Directory.Exists(viewsDir), $"Views dir not found: {viewsDir}");
+
+            var offenders = new List<string>();
+            foreach (string path in Directory.GetFiles(viewsDir, "*.axaml.cs", SearchOption.TopDirectoryOnly))
+            {
+                string fileName = Path.GetFileName(path);
+                string src = File.ReadAllText(path);
+                if (!TwoArgCall.IsMatch(src)) continue;
+                if (!TwoArgAllowList.Contains(fileName))
+                    offenders.Add(fileName);
+            }
+
+            if (offenders.Count > 0)
+                _output.WriteLine("Unexpected 2-arg icon-loader callsites: " + string.Join(", ", offenders));
+
+            Assert.True(offenders.Count == 0,
+                "Found 2-arg ClassIconLoader/ItemIconLoader callsites NOT on the canonical index==id allow-list " +
+                "(potential #939-style wrong/spurious icon). If a new view legitimately prefixes the REAL " +
+                "class/item id, add it to TwoArgAllowList; otherwise switch it to the 3-arg idSelector overload " +
+                "or drop the icon column:\n" + string.Join("\n", offenders));
+        }
+
+        /// <summary>
+        /// Sanity: the new 3-arg overloads actually exist in the source so the
+        /// scanner's premise holds (a typo'd overload would otherwise let the
+        /// Category-A views fail to compile while this test still passes on the
+        /// stale view source).
+        /// </summary>
+        [Fact]
+        public void ThreeArg_IdSelector_Overloads_Exist_In_Source()
+        {
+            string loaders = Path.Combine(
+                FindProjectRoot(), "FEBuilderGBA.Avalonia", "Services", "ListIconLoaders.cs");
+            Assert.True(File.Exists(loaders), "ListIconLoaders.cs not found.");
+            string src = File.ReadAllText(loaders);
+
+            Assert.Matches(
+                new Regex(@"ClassIconLoader\([^)]*Func<AddrResult,\s*uint>\s+\w+\)"),
+                src);
+            Assert.Matches(
+                new Regex(@"ItemIconLoader\([^)]*Func<AddrResult,\s*uint>\s+\w+\)"),
+                src);
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/IconLoaderWiringTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/IconLoaderWiringTests.cs
@@ -76,13 +76,33 @@ namespace FEBuilderGBA.Avalonia.Tests
         // 2-arg call: SetItemsWithIcons(<list>, i => ListIconLoaders.{Class|Item}IconLoader(<list>, i))
         //   — the inner call has EXACTLY the (items, i) args, no trailing selector.
         // 3-arg call: ...IconLoader(<list>, i, <selector>)
+        //
+        // An icon-loader argument (<list> / index) is NOT just a bare
+        // identifier: it can be a member-access chain (`_vm.Items`,
+        // `this._items`) or a no-arg method call (`GetItems()`). The Arg token
+        // below catches all three so the scanner can't be evaded by a
+        // non-trivial list expression (#940 auto-bot review). It still stops at
+        // a comma/paren, so the 2-arg pattern never swallows a 3-arg call's
+        // trailing selector.
         // ----------------------------------------------------------------
+        private const string Arg = @"[\w.]+(?:\(\s*\))?";
+
         private static readonly Regex TwoArgCall = new(
-            @"ListIconLoaders\.(Class|Item)IconLoader\(\s*\w+\s*,\s*\w+\s*\)",
+            @"ListIconLoaders\.(Class|Item)IconLoader\(\s*" + Arg + @"\s*,\s*" + Arg + @"\s*\)",
             RegexOptions.Compiled);
 
-        private static readonly Regex ThreeArgCall = new(
-            @"ListIconLoaders\.(Class|Item)IconLoader\(\s*\w+\s*,\s*\w+\s*,",
+        // Class-specific Category-A variants: those three views are ALL
+        // ClassIconLoader callsites, so an unrelated 3-arg *Item* loader in the
+        // same file must NOT satisfy the "3-arg overload present" check, and a
+        // residual 2-arg *Item* loader must NOT mask a class-loader regression
+        // (#940 auto-bot review). Matching ClassIconLoader explicitly avoids
+        // both false passes.
+        private static readonly Regex ClassThreeArgCall = new(
+            @"ListIconLoaders\.ClassIconLoader\(\s*" + Arg + @"\s*,\s*" + Arg + @"\s*,",
+            RegexOptions.Compiled);
+
+        private static readonly Regex ClassTwoArgCall = new(
+            @"ListIconLoaders\.ClassIconLoader\(\s*" + Arg + @"\s*,\s*" + Arg + @"\s*\)",
             RegexOptions.Compiled);
 
         private static readonly Regex AnyIconLoaderRef = new(
@@ -168,10 +188,10 @@ namespace FEBuilderGBA.Avalonia.Tests
                 Assert.True(File.Exists(path), $"Expected Category-A view not found: {view}");
                 string src = File.ReadAllText(path);
 
-                if (!ThreeArgCall.IsMatch(src))
-                    failures.Add($"{view}: expected a 3-arg ClassIconLoader(items, i, selector) call but none found.");
-                if (TwoArgCall.IsMatch(src))
-                    failures.Add($"{view}: still uses the 2-arg ClassIconLoader(items, i) overload (prefix is the row INDEX → wrong icon).");
+                if (!ClassThreeArgCall.IsMatch(src))
+                    failures.Add($"{view}: expected a 3-arg ListIconLoaders.ClassIconLoader(items, i, selector) call but none found.");
+                if (ClassTwoArgCall.IsMatch(src))
+                    failures.Add($"{view}: still uses the 2-arg ListIconLoaders.ClassIconLoader(items, i) overload (prefix is the row INDEX → wrong icon).");
             }
 
             Assert.True(failures.Count == 0,

--- a/FEBuilderGBA.Avalonia/Services/ListIconLoaders.cs
+++ b/FEBuilderGBA.Avalonia/Services/ListIconLoaders.cs
@@ -40,6 +40,33 @@ namespace FEBuilderGBA.Avalonia.Services
         }
 
         /// <summary>
+        /// Load class wait icon using an explicit class-id selector instead of
+        /// parsing the list-item text prefix. Use this when the displayed row
+        /// prefix is the row INDEX (not the class id) but the list still wants
+        /// the correct class icon — the prefix and the entity id diverge for
+        /// OP Class Demo / Arena Class lists (#939). The selector reads the
+        /// real class id directly from the entry's ROM address.
+        /// </summary>
+        /// <param name="items">The address list items.</param>
+        /// <param name="index">Index into the list.</param>
+        /// <param name="classIdSelector">
+        /// Resolves the real class id for an entry (e.g.
+        /// <c>r =&gt; CoreState.ROM.u8(r.addr + 14)</c>). Should guard against a
+        /// null ROM and return 0 (the loader then returns null).
+        /// </param>
+        public static Bitmap? ClassIconLoader(List<AddrResult> items, int index, Func<AddrResult, uint> classIdSelector)
+        {
+            if (index < 0 || index >= items.Count) return null;
+            try
+            {
+                uint id = classIdSelector(items[index]);
+                using var img = PreviewIconHelper.LoadClassWaitIconByClassId(id);
+                return ImageConversionHelper.ToAvaloniaBitmap(img);
+            }
+            catch { return null; }
+        }
+
+        /// <summary>
         /// Load item icon by extracting item ID from the list item text prefix.
         /// Matches WinForms DrawItemAndText which uses U.atoh(text) to get the item ID.
         /// </summary>
@@ -55,6 +82,31 @@ namespace FEBuilderGBA.Avalonia.Services
             {
                 uint itemId = U.atoh(items[index].name);
                 using var img = PreviewIconHelper.LoadItemIconByItemId(itemId);
+                return ImageConversionHelper.ToAvaloniaBitmap(img);
+            }
+            catch { return null; }
+        }
+
+        /// <summary>
+        /// Load item icon using an explicit item-id selector instead of parsing
+        /// the list-item text prefix. Use when the displayed row prefix is the
+        /// row INDEX (not the item id) but the correct item icon is still
+        /// wanted (#939). The selector reads the real item id directly from the
+        /// entry's ROM address.
+        /// </summary>
+        /// <param name="items">The address list items.</param>
+        /// <param name="index">Index into the list.</param>
+        /// <param name="itemIdSelector">
+        /// Resolves the real item id for an entry. Should guard against a null
+        /// ROM and return 0 (the loader then returns null).
+        /// </param>
+        public static Bitmap? ItemIconLoader(List<AddrResult> items, int index, Func<AddrResult, uint> itemIdSelector)
+        {
+            if (index < 0 || index >= items.Count) return null;
+            try
+            {
+                uint id = itemIdSelector(items[index]);
+                using var img = PreviewIconHelper.LoadItemIconByItemId(id);
                 return ImageConversionHelper.ToAvaloniaBitmap(img);
             }
             catch { return null; }

--- a/FEBuilderGBA.Avalonia/Views/ArenaClassViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ArenaClassViewerView.axaml.cs
@@ -46,7 +46,10 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 var items = _vm.LoadArenaClassList(typeIndex);
-                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ClassIconLoader(items, i));
+                // #939: the row prefix is the row INDEX, not the class id. Key
+                // the icon off the real class id (u8 at entry+0 — the value
+                // already shown in the row's "(0x..)" suffix).
+                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ClassIconLoader(items, i, ClassIdOf));
             }
             catch (Exception ex)
             {
@@ -91,6 +94,17 @@ namespace FEBuilderGBA.Avalonia.Views
                 CoreState.Services?.ShowInfo("Arena Class data written.");
             }
             catch (Exception ex) { _undoService.Rollback(); Log.Error("ArenaClassViewerView.Write: {0}", ex.Message); }
+        }
+
+        // #939: resolve the real class id (u8 at entry+0) for the list icon.
+        // Guards a null ROM by returning 0 → the loader returns null (no icon),
+        // never throws.
+        static uint ClassIdOf(AddrResult r)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return 0;
+            if (!U.isSafetyOffset(r.addr, rom)) return 0;
+            return rom.u8(r.addr);
         }
 
         // -- IdFieldControl handlers (#360) ----------------------------------

--- a/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml.cs
@@ -139,7 +139,10 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 var items = _vm.LoadClassOPDemoList();
-                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ClassIconLoader(items, i));
+                // #939: the row prefix is the row INDEX, not the class id. Key
+                // the icon off the real Display Weapon class id at entry+14
+                // (the value the row's class name is resolved from in the VM).
+                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ClassIconLoader(items, i, ClassIdOf));
                 if (CoreState.ROM?.RomInfo != null && TopBar != null)
                 {
                     TopBar.StartAddressText = $"0x{CoreState.ROM.RomInfo.op_class_demo_pointer:X08}";
@@ -677,6 +680,17 @@ namespace FEBuilderGBA.Avalonia.Views
                 Log.Error("ClassOPDemoView.N1_ListExpand failed: {0}", ex.Message);
                 CoreState.Services?.ShowError(string.Format(R._("Failed to expand JP name font block: {0}"), ex.Message));
             }
+        }
+
+        // #939: resolve the real class id (Display Weapon, u8 at entry+14) for
+        // the list icon. Guards a null ROM by returning 0 → the loader returns
+        // null (no icon), never throws.
+        static uint ClassIdOf(AddrResult r)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return 0;
+            if (!U.isSafetyOffset(r.addr + 14, rom)) return 0;
+            return rom.u8(r.addr + 14);
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/FE8SpellMenuExtendsView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/FE8SpellMenuExtendsView.axaml.cs
@@ -25,7 +25,10 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 var items = _vm.LoadList();
-                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ItemIconLoader(items, i));
+                // #939: the single row is a synthetic section label, NOT an
+                // item — the prefix is not an item id, so the old item-icon
+                // loader showed a spurious icon. Drop the icon column entirely.
+                EntryList.SetItems(items);
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Avalonia/Views/ItemEffectivenessMainView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemEffectivenessMainView.axaml.cs
@@ -25,7 +25,10 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 var items = _vm.LoadList();
-                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ClassIconLoader(items, i));
+                // #939: the single row is a synthetic section label, NOT a
+                // class — the prefix is not a class id, so the old class-icon
+                // loader showed a spurious icon. Drop the icon column entirely.
+                EntryList.SetItems(items);
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Avalonia/Views/ItemStatBonusesSkillSystemsView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemStatBonusesSkillSystemsView.axaml.cs
@@ -27,7 +27,10 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 var items = _vm.LoadList();
-                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ItemIconLoader(items, i));
+                // #939: the single row is a synthetic section label, NOT an
+                // item — the prefix is not an item id, so the old item-icon
+                // loader showed a spurious icon. Drop the icon column entirely.
+                EntryList.SetItems(items);
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Avalonia/Views/ItemStatBonusesVennoView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemStatBonusesVennoView.axaml.cs
@@ -27,7 +27,10 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 var items = _vm.LoadList();
-                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ItemIconLoader(items, i));
+                // #939: the single row is a synthetic section label, NOT an
+                // item — the prefix is not an item id, so the old item-icon
+                // loader showed a spurious icon. Drop the icon column entirely.
+                EntryList.SetItems(items);
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Avalonia/Views/OPClassAlphaNameFE6ExtraView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPClassAlphaNameFE6ExtraView.axaml.cs
@@ -25,7 +25,10 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 var items = _vm.LoadList();
-                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ClassIconLoader(items, i));
+                // #939: the single row is a synthetic section label, NOT a
+                // class — the prefix is not a class id, so the old class-icon
+                // loader showed a spurious icon. Drop the icon column entirely.
+                EntryList.SetItems(items);
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Avalonia/Views/OPClassAlphaNameFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPClassAlphaNameFE6View.axaml.cs
@@ -28,7 +28,10 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 var items = _vm.LoadList();
-                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ClassIconLoader(items, i));
+                // #939: rows are name-string pointers, NOT classes — the prefix
+                // is the row index, so the old class-icon loader showed a
+                // spurious icon. Drop the icon column entirely.
+                EntryList.SetItems(items);
                 if (!string.IsNullOrEmpty(_vm.UnavailableMessage))
                     UnavailableLabel.Text = _vm.UnavailableMessage;
             }

--- a/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml.cs
@@ -236,7 +236,10 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 var items = _vm.LoadOPClassDemoList();
-                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ClassIconLoader(items, i));
+                // #939: the row prefix is the row INDEX, not the class id. Key
+                // the icon off the real Display Weapon class id at entry+14
+                // (the value the row's class name is resolved from in the VM).
+                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ClassIconLoader(items, i, ClassIdOf));
                 if (CoreState.ROM?.RomInfo != null)
                 {
                     // #649: display via the unified EditorTopBar read-only slots.
@@ -535,6 +538,17 @@ namespace FEBuilderGBA.Avalonia.Views
                 CoreState.Services?.ShowInfo($"Table expanded. New base: 0x{result.NewBaseAddress:X08}, new count: {result.NewCount}.");
             }
             catch (Exception ex) { _undoService.Rollback(); Log.Error($"OPClassDemoViewerView.ListExpand: {ex.Message}"); }
+        }
+
+        // #939: resolve the real class id (Display Weapon, u8 at entry+14) for
+        // the list icon. Guards a null ROM by returning 0 → the loader returns
+        // null (no icon), never throws.
+        static uint ClassIdOf(AddrResult r)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return 0;
+            if (!U.isSafetyOffset(r.addr + 14, rom)) return 0;
+            return rom.u8(r.addr + 14);
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/OPClassFontFE8UView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPClassFontFE8UView.axaml.cs
@@ -28,7 +28,10 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 var items = _vm.LoadList();
-                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ClassIconLoader(items, i));
+                // #939: rows are font-image pointers, NOT classes — the prefix
+                // is the row index, so the old class-icon loader showed a
+                // spurious icon. Drop the icon column entirely.
+                EntryList.SetItems(items);
                 if (!string.IsNullOrEmpty(_vm.UnavailableMessage))
                     UnavailableLabel.Text = _vm.UnavailableMessage;
             }

--- a/FEBuilderGBA.Avalonia/Views/OPClassFontViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPClassFontViewerView.axaml.cs
@@ -25,7 +25,10 @@ namespace FEBuilderGBA.Avalonia.Views
         void LoadList()
         {
             _vm.IsLoading = true;
-            try { var items = _vm.LoadOPClassFontList(); EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ClassIconLoader(items, i)); }
+            // #939: rows are font-image pointers, NOT classes — the prefix is
+            // the row index, so the old class-icon loader showed a spurious
+            // icon. Drop the icon column entirely.
+            try { var items = _vm.LoadOPClassFontList(); EntryList.SetItems(items); }
             catch (Exception ex) { Log.Error($"OPClassFontViewerView.LoadList: {ex.Message}"); }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }


### PR DESCRIPTION
## Summary
`ListIconLoaders.ClassIconLoader`/`ItemIconLoader` keyed the icon off `U.atoh(items[i].name)` — the **row-index prefix** — which only equals the real entity id in the canonical Class/Item editors. Elsewhere the icon was for the wrong class (real class is a field) or spurious (rows aren't classes). **Fix:** new **`idSelector` overloads** so the icon source is the real class/item field (the displayed list text is unchanged — no surprise to the user); and **remove the icon** from views whose rows aren't classes. Closes #939 (reported #13 OP Class Demo, #15 OP Class Font, #18 Arena Class; +8 more sites via the audit).

## Screenshots (FE8J)
**Arena Class — icon now matches the real class id in the `(0x..)` suffix, not the index** (your #18: "02 剣士 (0x13)" now shows class `0x13`'s Myrmidon sprite, was class 2's):
| Before | After |
|---|---|
| ![b](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/bugsweep/bug18-arena-class-icon.png?raw=1) | ![a](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug18-arena-class-after.png) |

**OP Class Font — rows are font glyphs, not classes; the spurious class icon is removed:**
| Before | After |
|---|---|
| ![b](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/bugsweep/bug15-op-class-font.png?raw=1) | ![a](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug15-op-class-font-after.png) |

**OP Class Demo — icons now source from the Display Weapon (Class) field** (e.g. entry "00 ロード" → Display Weapon 2 → class 2's sprite):
| Before | After |
|---|---|
| ![b](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/bugsweep/bug13-14-op-class-demo.png?raw=1) | ![a](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug13-op-class-demo-after.png) |

## GUI Test Report
**Environment:** ROM `roms/FE8J.gba`; `--screenshot-all` offscreen `RenderTargetBitmap` (locked-session-safe); T2 worktree build.

| Test | Expected | Actual | Status |
|---|---|---|---|
| Arena Class list icons | match the `(0x..)` class id, not the index | each icon matches its class id (剣士 0x13 = Myrmidon, etc.) | PASS |
| OP Class Font list | no class icon (rows are glyphs) | plain text, no icon | PASS |
| OP Class Demo list icons | source from Display Weapon (Class) | icons reflect the class field | PASS |

**Verdict:** PASS.

## Test plan
- [x] New `IconLoaderWiringTests` scanner (4 `[Fact]`): the 3 Cat-A views use the 3-arg `idSelector` overload; the 8 Cat-B views reference no Class/ItemIconLoader; every remaining 2-arg loader call-site is on the canonical index==id allow-list; the overloads exist
- [x] The scanner caught a real call-site I'd missed (`ItemShopViewerView`) — verified it already prefixes the real item id (#654) and allow-listed it
- [x] FE7/FE7U/FE8U OP Class Demo verified already-correct (prefix the real cid `u8(addr+15/11/5)`) and left untouched
- [x] DO-NOT-TOUCH set (ClassEditor/ClassFE6/CCBranch/MoveCost*/SkillAssignment/OPClassAlphaName-FE8J/all Item-table editors/ItemIconViewer/SoundFootSteps) confirmed untouched
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` — 7386 passed / 0 failed / 3 skipped (incl. T1's FirstRowIconSweepTests); Release build green
- [x] GUI after-shots prove Arena Class (icon = real class id), OP Class Font (no icon), OP Class Demo (icon = Display Weapon field)

## Known limitations
- The displayed list **prefix** (the leading index) is intentionally unchanged (idSelector decouples display from icon source); only the icon is corrected. WinForms uses the class id as the prefix, but the user reported the icon, not the prefix — keeping the display avoids any downstream prefix-parse risk.
- After-shots on vanilla FE8J vs the user's hack ROM — the version-agnostic fix behavior is identical; Arena Class matches the reported case directly.
- The CLI plan-review was network-blocked; this PR was implemented on the audit + documented design decision, and the GitHub Copilot **auto-bot** review (which runs on every PR) is the independent gate.

Generated with Claude Code (claude-opus-4-8[1m])

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) · Claude Code 2.1.162 · model claude-opus-4-8[1m]