### PR TITLE
fix(avalonia): Support Talk IdFieldControl rows clip the Pick button — widen detail grid to 160,* (#941)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/IdFieldControlSpanLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/IdFieldControlSpanLayoutTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// #941 detection scanner. A wide composite <c>IdFieldControl</c> (Hyperlink
+    /// label + NumericUpDown + name preview + Jump + Pick buttons, ~420px minimum
+    /// content width) must not be boxed into a grid that hard-caps it below that
+    /// width. The reported regression (bug #2 in the 2026-06-04 sweep): the three
+    /// SupportTalk views laid their detail form out as
+    /// <c>ColumnDefinitions="160,200"</c> (=360px, no flexible column anywhere) and
+    /// spanned the IdFieldControl across BOTH columns, so the trailing Pick button
+    /// (and part of the name preview) clipped off the right edge.
+    ///
+    /// Precise predicate (kept narrow to avoid false positives on the many host
+    /// views that span a fixed PAIR inside a grid that DOES have a flexible column
+    /// elsewhere — e.g. OPClassDemoFE7View `180,180,*`, EDSensekiCommentView
+    /// `200,200,*`, UnitFE7View `180,200,20,180,200`): an IdFieldControl is flagged
+    /// iff it
+    ///   (1) spans the ENTIRE column set of its nearest ancestor Grid
+    ///       (Grid.Column == 0 AND Grid.ColumnSpan == column count), AND
+    ///   (2) EVERY column in that grid is a fixed pixel width (no '*' / 'Auto'), AND
+    ///   (3) the total fixed width is below MinIdFieldWidth.
+    /// That isolates exactly the "detail form hard-capped to a fixed narrow total
+    /// width" pathology and nothing else.
+    ///
+    /// Pure XML scan — no ROM, no Avalonia runtime — fast and deterministic.
+    /// </summary>
+    public class IdFieldControlSpanLayoutTests
+    {
+        private readonly ITestOutputHelper _output;
+        public IdFieldControlSpanLayoutTests(ITestOutputHelper output) => _output = output;
+
+        // Conservative minimum content width of an IdFieldControl:
+        //   Hyperlink label (~120) + NumericUpDown MinWidth 120 + NameLabel
+        //   MinWidth 80 + Jump (~38) + Pick (~45) + spacing ~16 ~= 421px.
+        private const double MinIdFieldWidth = 420.0;
+
+        private static string FindProjectRoot()
+        {
+            string dir = AppDomain.CurrentDomain.BaseDirectory;
+            for (int i = 0; i < 12; i++)
+            {
+                if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln"))) return dir;
+                string? parent = Path.GetDirectoryName(dir);
+                if (parent == null || parent == dir) break;
+                dir = parent;
+            }
+            string cwd = Directory.GetCurrentDirectory();
+            for (int i = 0; i < 12; i++)
+            {
+                if (File.Exists(Path.Combine(cwd, "FEBuilderGBA.sln"))) return cwd;
+                string? parent = Path.GetDirectoryName(cwd);
+                if (parent == null || parent == cwd) break;
+                cwd = parent;
+            }
+            throw new InvalidOperationException("Could not find project root (FEBuilderGBA.sln)");
+        }
+
+        private static string ViewsDir()
+            => Path.Combine(FindProjectRoot(), "FEBuilderGBA.Avalonia", "Views");
+
+        private static int GetAttachedInt(XElement e, string localName, int fallback)
+        {
+            var a = e.Attributes().FirstOrDefault(x => x.Name.LocalName == localName);
+            if (a == null) return fallback;
+            return int.TryParse(a.Value.Trim(), out int v) ? v : fallback;
+        }
+
+        private static string? GetNameAttr(XElement e)
+            => e.Attributes().FirstOrDefault(a => a.Name.LocalName == "Name")?.Value;
+
+        // Column-width tokens of a Grid, from either the ColumnDefinitions="..."
+        // attribute or the child <Grid.ColumnDefinitions> element form. null => the
+        // grid declares no column definitions.
+        private static List<string>? GetColumnTokens(XElement grid)
+        {
+            var attr = grid.Attributes().FirstOrDefault(a => a.Name.LocalName == "ColumnDefinitions");
+            if (attr != null)
+            {
+                return attr.Value.Split(',')
+                    .Select(s => s.Trim())
+                    .Where(s => s.Length > 0)
+                    .ToList();
+            }
+            var defsElem = grid.Elements()
+                .FirstOrDefault(el => el.Name.LocalName == "Grid.ColumnDefinitions");
+            if (defsElem != null)
+            {
+                var toks = defsElem.Elements()
+                    .Where(el => el.Name.LocalName == "ColumnDefinition")
+                    .Select(el =>
+                    {
+                        var w = el.Attributes().FirstOrDefault(a => a.Name.LocalName == "Width");
+                        return w?.Value.Trim() ?? "*"; // ColumnDefinition default Width is *
+                    })
+                    .ToList();
+                if (toks.Count > 0) return toks;
+            }
+            return null;
+        }
+
+        private static bool IsFlexible(string token)
+            => token.Contains('*') || token.Equals("Auto", StringComparison.OrdinalIgnoreCase);
+
+        // Sum fixed-pixel tokens; false if any token is non-fixed (flexible or unparseable).
+        private static bool TryFixedTotal(IEnumerable<string> tokens, out double total)
+        {
+            total = 0;
+            foreach (var t in tokens)
+            {
+                if (IsFlexible(t)) return false;
+                if (!double.TryParse(t, out double v)) return false;
+                total += v;
+            }
+            return true;
+        }
+
+        [Fact]
+        public void IdFieldControl_NotBoxedInFullyFixedNarrowGrid()
+        {
+            string viewsDir = ViewsDir();
+            Assert.True(Directory.Exists(viewsDir), $"Views dir not found: {viewsDir}");
+
+            var offenders = new List<string>();
+            var unanalyzable = new List<string>();
+
+            foreach (string path in Directory.GetFiles(viewsDir, "*.axaml", SearchOption.TopDirectoryOnly))
+            {
+                XDocument doc;
+                try { doc = XDocument.Load(path); }
+                catch { continue; } // non-XML/partial: other scanners cover parse health
+
+                string file = Path.GetFileName(path);
+
+                foreach (var idf in doc.Descendants().Where(e => e.Name.LocalName == "IdFieldControl"))
+                {
+                    int span = GetAttachedInt(idf, "Grid.ColumnSpan", 1);
+                    if (span < 2) continue;
+                    int col = GetAttachedInt(idf, "Grid.Column", 0);
+
+                    // Grid.Column/ColumnSpan apply to the DIRECT parent Grid; use the
+                    // nearest ancestor Grid and require parseable column definitions.
+                    XElement? grid = idf.Ancestors().FirstOrDefault(a => a.Name.LocalName == "Grid");
+                    if (grid == null)
+                    {
+                        unanalyzable.Add($"{file}: IdFieldControl '{GetNameAttr(idf) ?? "?"}' has ColumnSpan={span} but no ancestor Grid.");
+                        continue;
+                    }
+                    var cols = GetColumnTokens(grid);
+                    if (cols == null)
+                    {
+                        unanalyzable.Add($"{file}: IdFieldControl '{GetNameAttr(idf) ?? "?"}' (ColumnSpan={span}) parent Grid declares no parseable ColumnDefinitions.");
+                        continue;
+                    }
+
+                    bool spansFullSet = (col == 0 && span == cols.Count);
+                    if (!spansFullSet) continue;                  // subset spans are label-width dependent → out of scope
+                    if (!TryFixedTotal(cols, out double total)) continue; // a flexible col exists → grid can grow
+                    if (total >= MinIdFieldWidth) continue;        // wide enough → won't clip
+
+                    offenders.Add($"{file}: IdFieldControl '{GetNameAttr(idf) ?? "?"}' spans the full fixed grid [{string.Join(",", cols)}] = {total}px (< {MinIdFieldWidth}px IdFieldControl minimum) → Pick button / name preview will clip. Give the grid a flexible column (e.g. \"160,*\").");
+                }
+            }
+
+            if (unanalyzable.Count > 0)
+                _output.WriteLine("Unanalyzable IdFieldControl spans:\n" + string.Join("\n", unanalyzable));
+            if (offenders.Count > 0)
+                _output.WriteLine("Clipping IdFieldControl layouts:\n" + string.Join("\n", offenders));
+
+            Assert.True(unanalyzable.Count == 0,
+                "IdFieldControl(s) with ColumnSpan>=2 could not be analyzed (no ancestor Grid with ColumnDefinitions). " +
+                "Fix the scanner or the layout:\n" + string.Join("\n", unanalyzable));
+
+            Assert.True(offenders.Count == 0,
+                "IdFieldControl boxed into a fully-fixed narrow grid (will clip the Pick button / name preview). " +
+                "Give the containing grid a flexible ('*'/'Auto') column:\n" + string.Join("\n", offenders));
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Views/SupportTalkFE6View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SupportTalkFE6View.axaml
@@ -9,7 +9,7 @@
     <ScrollViewer Grid.Column="1" Margin="4">
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Support Talk (FE6)" FontSize="18" FontWeight="Bold" />
-        <Grid ColumnDefinitions="160,200" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+        <Grid ColumnDefinitions="160,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
           <TextBlock AutomationProperties.AutomationId="SupportTalkFE6_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
 

--- a/FEBuilderGBA.Avalonia/Views/SupportTalkFE7View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SupportTalkFE7View.axaml
@@ -9,7 +9,7 @@
     <ScrollViewer Grid.Column="1" Margin="4">
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Support Talk (FE7)" FontSize="18" FontWeight="Bold" />
-        <Grid ColumnDefinitions="160,200" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+        <Grid ColumnDefinitions="160,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
           <TextBlock AutomationProperties.AutomationId="SupportTalkFE7_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
 

--- a/FEBuilderGBA.Avalonia/Views/SupportTalkView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SupportTalkView.axaml
@@ -13,7 +13,7 @@
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Support Talk" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="160,200" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+        <Grid ColumnDefinitions="160,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
           <TextBlock AutomationProperties.AutomationId="SupportTalk_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
 


### PR DESCRIPTION
## Summary

Bug #2 from the 2026-06-04 Avalonia QA sweep: the **Support Talk** editor clips the `IdFieldControl` rows on the right — the `Pick...` button is cut off for Support Partner 1 & 2, and the inline name preview + `Jump` are crammed against the border.

**Root cause:** all three Support Talk views laid their detail form out in an inner `Grid ColumnDefinitions="160,200"` (=360px, **no flexible column**) and spanned each `IdFieldControl` across **both** columns (`Grid.Column="0" Grid.ColumnSpan="2"`). `IdFieldControl` is a horizontal `StackPanel` (Hyperlink label + `NumericUpDown` MinWidth 120 + NameLabel MinWidth 80 + Jump + Pick, **~420px** min content width), so it was hard-capped to 360px and the trailing `Pick...` clipped.

**Fix:** change the inner grid to `ColumnDefinitions="160,*"` — the established `IdFieldControl`-host convention (`ItemWeaponEffectViewerView`, `SoundRoomViewerView`, `CCBranchEditorView`, …). The spanning rows then fill the wide detail panel. Pure layout change — no code-behind / view-model / ROM logic touched.

Plan reference: #941 (plan reviewed by Copilot CLI — detector predicate refined per its false-positive finding).

## Scope

Closes #941.

Changed (3 views, one line each):
- `FEBuilderGBA.Avalonia/Views/SupportTalkView.axaml` (FE8)
- `FEBuilderGBA.Avalonia/Views/SupportTalkFE6View.axaml`
- `FEBuilderGBA.Avalonia/Views/SupportTalkFE7View.axaml`

Added (detector):
- `FEBuilderGBA.Avalonia.Tests/IdFieldControlSpanLayoutTests.cs`

## Detection (catch the whole class)

New XML-parsing scanner flags any `IdFieldControl` with `Grid.ColumnSpan >= 2` that **(1)** spans the **entire** column set of its nearest ancestor `<Grid>`, **(2)** where **every** column is a fixed pixel width, **(3)** totaling **< 420px**. This precisely isolates the "detail form hard-capped to a fixed narrow total width" pathology.

Validated **red → green**: with the views at `160,200` the test fails listing exactly the 3 SupportTalk views (15 controls); after `160,*` it passes. It does **not** flag the many hosts that span a fixed pair inside a grid that also has a flexible column (`OPClassDemoFE7/FE7U/FE8U` `…,*`, `EDSensekiCommentView` `200,200,*`, `UnitFE7View` `180,200,20,180,200` — subset spans). Namespace-insensitive; parses both attribute and child-element `ColumnDefinitions`; fails with a diagnostic (never silently passes) if a spanning control's grid can't be analyzed.

## Screenshots — Support Talk editor (FE8J)

| Before (bug #2 — `Pick...` clipped) | After (fixed — `Pick...` visible) |
|---|---|
| ![before](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/bugsweep/bug02-support-talk-clip.png?raw=1) | ![after](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug02-support-talk-after.png) |

Before: `Support Partner 1: [1] エイリーク [Jump]` — the `Pick...` after `Jump` is off-screen.
After: `Support Partner 1: [1] エイリーク [Jump] [Pick...]` — full row renders; C/B/A text rows show name preview + `Jump` cleanly.

## GUI Test Report

| Test | Result |
|------|--------|
| Support Talk (FE8J) renders all 5 `IdFieldControl` rows with `Pick...`/`Jump` fully visible (offscreen `--screenshot-all` render) | ✅ PASS |
| Support Partner 1/2 show inline unit-name preview (エイリーク / エフラム) + Jump + Pick, no clipping | ✅ PASS |
| C/B/A Support Text rows show text-content preview + Jump (ShowPick=False, no Pick — correct) | ✅ PASS |
| Detector `IdFieldControlSpanLayoutTests` fails on pre-fix XAML (exactly 3 SupportTalk views), passes post-fix | ✅ PASS |
| Full `FEBuilderGBA.Avalonia.Tests` suite (7387 passed / 0 failed / 3 skipped) | ✅ PASS |

Render method: offscreen `RenderTargetBitmap` via the app's `--screenshot-all` (locked-screen-safe, real pixels). ROM: `roms/FE8J.gba`.

## Test plan

- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` — full suite green (7387 passed, 0 failed, 3 skipped)
- [x] New `IdFieldControlSpanLayoutTests` red/green validated (fails pre-fix on the 3 SupportTalk views, passes post-fix)
- [x] Detector produces **no** false positives on the other ~19 `IdFieldControl`-host views (hand-verified + scanner run)
- [x] After-screenshot of the actual Support Talk editor (FE8J) confirms `Pick...` no longer clipped
- [x] No code-behind / view-model / ROM behavior changed (pure XAML layout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Code 2.1.162 · model claude-opus-4-8[1m]
