### PR TITLE
fix(avalonia): Boss BGM song format + Map Exit stale detail on empty list (#16, #9)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SoundBossBGMAndMapExitPoint943Tests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SoundBossBGMAndMapExitPoint943Tests.cs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Issue #943 regression tests for two small Avalonia editor parity bugfixes:
+//
+//  Bug #16 — SoundBossBGMViewerViewModel (and the lockstep ListParityHelper
+//  golden builder) used a fixed 8-digit hex for the song ID:
+//    "Song:0x{songId:X08}"  (e.g. "Song:0x0000001B")
+//  WinForms SoundBossBGMForm uses U.ToHexString (variable-width):
+//    "{unitHex} {unitName} : {U.ToHexString(songId)}"  (e.g. "1B Eirika : 1B")
+//  Fix: match WinForms format in both files; song-NAME resolution is a
+//  separate global Avalonia gap (NameResolver returns a placeholder) and is
+//  intentionally out of scope here.
+//
+//  Bug #9 — MapExitPointView.OnMapSelected left the detail panel showing the
+//  previously-selected map's stale Address/coords/Direction/Flag when the
+//  newly selected map had an EMPTY exit-point sub-list (SetItems on an empty
+//  list fires no row-selection, so UpdateDetailUI never ran).
+//  Fix: ClearExitPointEntry() + UpdateDetailUI() are called when exits.Count == 0.
+//
+// Marked [Collection("SharedState")] for the VM tests that mutate CoreState.ROM.
+using System.IO;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests.GapSweep;
+
+// ======================================================================
+// Bug #16 — Boss BGM song-label format
+// ======================================================================
+
+/// <summary>
+/// Source-scan assertions proving the #16 format fix is permanent — the
+/// two files that must stay in lockstep contain the correct WinForms-style
+/// format and do NOT contain the old fixed-8-digit hex variant.
+/// These tests run without a real ROM so they pass everywhere (incl. CI).
+/// </summary>
+public class SoundBossBGMFormatTests
+{
+    static string FindRepoRoot()
+    {
+        string? dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+            dir = Path.GetDirectoryName(dir);
+        if (dir == null)
+            throw new InvalidOperationException("Could not find FEBuilderGBA.sln from test base directory");
+        return dir;
+    }
+
+    /// <summary>
+    /// SoundBossBGMViewerViewModel must NOT contain the old "Song:0x{songId:X08}"
+    /// format string that produced fixed-8-digit hex (e.g. "Song:0x0000001B").
+    /// </summary>
+    [Fact]
+    public void ViewModel_DoesNotContainOldFixedHexFormat()
+    {
+        string repoRoot = FindRepoRoot();
+        string path = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "ViewModels",
+            "SoundBossBGMViewerViewModel.cs");
+        Assert.True(File.Exists(path), $"File not found: {path}");
+        string source = File.ReadAllText(path);
+        Assert.DoesNotContain("Song:0x{songId:X08}", source);
+        Assert.DoesNotContain("Song:0x{songId:X07}", source);
+    }
+
+    /// <summary>
+    /// SoundBossBGMViewerViewModel MUST contain the WinForms-matching format:
+    /// " : {U.ToHexString(songId)}" (variable-width, colon separator).
+    /// </summary>
+    [Fact]
+    public void ViewModel_ContainsWinFormsStyleFormat()
+    {
+        string repoRoot = FindRepoRoot();
+        string path = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "ViewModels",
+            "SoundBossBGMViewerViewModel.cs");
+        string source = File.ReadAllText(path);
+        // The exact corrected interpolation.
+        Assert.Contains(" : {U.ToHexString(songId)}", source);
+    }
+
+    /// <summary>
+    /// ListParityHelper.BuildSoundBossBGMList must NOT contain the old
+    /// "Song:0x{songId:X08}" format string (lockstep with the VM).
+    /// </summary>
+    [Fact]
+    public void ListParityHelper_DoesNotContainOldFixedHexFormat()
+    {
+        string repoRoot = FindRepoRoot();
+        string path = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Services",
+            "ListParityHelper.cs");
+        Assert.True(File.Exists(path), $"File not found: {path}");
+        string source = File.ReadAllText(path);
+        // The method name is BuildSoundBossBGMList — assert the specific old format.
+        Assert.DoesNotContain("Song:0x{songId:X08}", source);
+    }
+
+    /// <summary>
+    /// ListParityHelper.BuildSoundBossBGMList MUST contain the WinForms-matching
+    /// format to stay in lockstep with SoundBossBGMViewerViewModel.
+    /// </summary>
+    [Fact]
+    public void ListParityHelper_ContainsWinFormsStyleFormat()
+    {
+        string repoRoot = FindRepoRoot();
+        string path = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Services",
+            "ListParityHelper.cs");
+        string source = File.ReadAllText(path);
+        Assert.Contains(" : {U.ToHexString(songId)}", source);
+    }
+}
+
+// ======================================================================
+// Bug #9 — MapExitPoint stale detail on empty sub-list
+// ======================================================================
+
+/// <summary>
+/// Unit tests for MapExitPointViewModel.ClearExitPointEntry (#9).
+/// These do NOT require a ROM — they exercise the VM in isolation.
+/// </summary>
+[Collection("SharedState")]
+public class MapExitPointClearEntryTests
+{
+    /// <summary>
+    /// ClearExitPointEntry must zero all detail fields and gate CanWrite=false.
+    /// This guards against the stale-data regression where selecting a map with
+    /// an empty sub-list left the detail panel showing the previous map's values.
+    /// </summary>
+    [Fact]
+    public void ClearExitPointEntry_ZerosAllDetailFields_AndDisablesWrite()
+    {
+        var vm = new MapExitPointViewModel();
+
+        // Simulate previously-loaded row (non-zero values from a prior selection).
+        vm.CurrentAddr = 0x08801234u;
+        vm.SelectedAddressDisplay = 0x08801234u;
+        vm.BlockSize = 4u;
+        vm.ExitX = 0x12u;
+        vm.ExitY = 0x34u;
+        vm.EscapeMethod = 0x03u;
+        vm.FlagId = 0x07u;
+        vm.CanWrite = true;
+
+        // Act: switching to a map with no exit points clears the detail panel.
+        vm.ClearExitPointEntry();
+
+        // Assert: all detail fields are zeroed.
+        Assert.Equal(0u, vm.CurrentAddr);
+        Assert.Equal(0u, vm.SelectedAddressDisplay);
+        Assert.Equal(0u, vm.BlockSize);
+        Assert.Equal(0u, vm.ExitX);
+        Assert.Equal(0u, vm.ExitY);
+        Assert.Equal(0u, vm.EscapeMethod);
+        Assert.Equal(0u, vm.FlagId);
+        // Write must be gated (no stale save).
+        Assert.False(vm.CanWrite);
+    }
+
+    /// <summary>
+    /// ClearExitPointEntry is idempotent — calling it on an already-zeroed VM
+    /// must leave all fields at zero and CanWrite=false without throwing.
+    /// </summary>
+    [Fact]
+    public void ClearExitPointEntry_OnAlreadyZeroedVm_IsIdempotent()
+    {
+        var vm = new MapExitPointViewModel();
+        // All fields are 0 / false by default after construction.
+
+        vm.ClearExitPointEntry(); // must not throw
+
+        Assert.Equal(0u, vm.CurrentAddr);
+        Assert.Equal(0u, vm.SelectedAddressDisplay);
+        Assert.Equal(0u, vm.BlockSize);
+        Assert.Equal(0u, vm.ExitX);
+        Assert.Equal(0u, vm.ExitY);
+        Assert.Equal(0u, vm.EscapeMethod);
+        Assert.Equal(0u, vm.FlagId);
+        Assert.False(vm.CanWrite);
+    }
+
+    /// <summary>
+    /// ClearExitPointEntry must NOT touch the filter/map state:
+    /// FilterIndex, SelectedMapSlotAddr, IsBlank, IsAllocated are
+    /// orthogonal to the per-row detail panel.
+    /// </summary>
+    [Fact]
+    public void ClearExitPointEntry_DoesNotTouchMapSelectionState()
+    {
+        var vm = new MapExitPointViewModel();
+        vm.FilterIndex = 1u;
+        vm.SelectedMapSlotAddr = 0x00800004u;
+        vm.IsBlank = true;
+        vm.IsAllocated = false;
+
+        vm.ClearExitPointEntry();
+
+        // Map-selection state is untouched.
+        Assert.Equal(1u, vm.FilterIndex);
+        Assert.Equal(0x00800004u, vm.SelectedMapSlotAddr);
+        Assert.True(vm.IsBlank);
+        Assert.False(vm.IsAllocated);
+    }
+}

--- a/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
@@ -1058,7 +1058,7 @@ namespace FEBuilderGBA.Avalonia.Services
                 uint songId = rom.u32(addr + 4);
                 // 1-based ROM-stored unit ID (matches SoundBossBGMViewerViewModel).
                 string unitName = NameResolver.GetUnitNameByOneBasedId(unitId);
-                string name = $"{U.ToHexString(unitId)} {unitName} Song:0x{songId:X08}";
+                string name = $"{U.ToHexString(unitId)} {unitName} : {U.ToHexString(songId)}";
                 result.Add(new AddrResult(addr, name, i));
             }
             return result;

--- a/FEBuilderGBA.Avalonia/ViewModels/MapExitPointViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapExitPointViewModel.cs
@@ -191,6 +191,23 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         }
 
         /// <summary>
+        /// Reset the detail fields when the selected map has NO exit points,
+        /// so the panel doesn't show the previously-selected map's stale data
+        /// (#9). Gates the Write button via CanWrite=false.
+        /// </summary>
+        public void ClearExitPointEntry()
+        {
+            CurrentAddr = 0;
+            SelectedAddressDisplay = 0;
+            BlockSize = 0;
+            ExitX = 0;
+            ExitY = 0;
+            EscapeMethod = 0;
+            FlagId = 0;
+            CanWrite = false;
+        }
+
+        /// <summary>
         /// Write the detail fields back to the current row. Caller MUST have
         /// opened an undo scope (the View wraps this in
         /// `_undoService.Begin/Commit`).

--- a/FEBuilderGBA.Avalonia/ViewModels/SoundBossBGMViewerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SoundBossBGMViewerViewModel.cs
@@ -47,7 +47,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 uint songId = rom.u32(addr + 4);
                 // 1-based ROM-stored unit ID.
                 string unitName = NameResolver.GetUnitNameByOneBasedId(unitId);
-                string name = $"{U.ToHexString(unitId)} {unitName} Song:0x{songId:X08}";
+                string name = $"{U.ToHexString(unitId)} {unitName} : {U.ToHexString(songId)}";
                 result.Add(new AddrResult(addr, name, i));
             }
             return result;

--- a/FEBuilderGBA.Avalonia/Views/MapExitPointView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapExitPointView.axaml.cs
@@ -106,6 +106,14 @@ namespace FEBuilderGBA.Avalonia.Views
                     : _vm.CurrentExitPointAddr;
                 // Show NewAlloc affordance when the slot is unallocated.
                 NewAllocButton.IsVisible = _vm.IsBlank;
+                // #9: when the map has no exit points the sub-list is empty and
+                // no row-selection fires — clear the detail panel instead of
+                // leaving the previous map's stale values.
+                if (exits.Count == 0)
+                {
+                    _vm.ClearExitPointEntry();
+                    UpdateDetailUI();
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary

Two small, independent Avalonia editor parity bugfixes from the 2026-06-04 QA sweep (issue #943, bugs #16 and #9).

### Bug #16 — Boss BGM song display format (`SoundBossBGMViewerView`)
The list showed the song as `Song:0x0000001B` (fixed 8-digit hex). WinForms `SoundBossBGMForm.cs:45` shows `{unitHex} {unitName} : {U.ToHexString(songId)}…` — `U.ToHexString` is **variable-width** (`0x1B`→`1B`). Fixed the format in both the VM (`SoundBossBGMViewerViewModel.cs`) **and** the lockstep golden builder `ListParityHelper.BuildSoundBossBGMList` (which mirrored the same bug, so the parity test passed vacuously). The real song *name* (Sound Room/SE) is a **separate global Avalonia gap** — `NameResolver.ResolveSongName` returns a generic `"Song 0x{id:X}"` placeholder — so it's intentionally omitted here rather than printing misleading text (tracked as a follow-up).

### Bug #9 — Map Exit Point stale detail on empty child list (`MapExitPointView`)
Selecting a map whose exit-point sub-list is empty left the detail panel showing the **previous** map's Address/coords/Direction/Flag (`SetItems` on an empty list fires no row-selection, so `UpdateDetailUI()` never ran). Added `MapExitPointViewModel.ClearExitPointEntry()` and call it + `UpdateDetailUI()` when `exits.Count == 0`, gating Write via `CanWrite=false`.

## Scope
Closes the #16 and #9 portion of #943.
- `FEBuilderGBA.Avalonia/ViewModels/SoundBossBGMViewerViewModel.cs`
- `FEBuilderGBA.Avalonia/Services/ListParityHelper.cs` (BuildSoundBossBGMList, lockstep)
- `FEBuilderGBA.Avalonia/ViewModels/MapExitPointViewModel.cs` (+ ClearExitPointEntry)
- `FEBuilderGBA.Avalonia/Views/MapExitPointView.axaml.cs` (empty-list branch)
- `FEBuilderGBA.Avalonia.Tests/GapSweep/SoundBossBGMAndMapExitPoint943Tests.cs` (7 new tests)

## Screenshots

### #16 Boss BGM
| Before (`Song:0x0000001B`) | After (`: 1B` / `: 1C`) |
|---|---|
| ![b](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/bugsweep/bug16-boss-bgm-format.png?raw=1) | ![a](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug16-boss-bgm-after.png) |

### #9 Map Exit Point (map "00 ルネス陥落" has an empty exit list)
| Before (stale detail: `0x000DD1D0`, Y=13, Dir=5) | After (cleared: `0x00000000`, all zeros) |
|---|---|
| ![b](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/bugsweep/bug09-map-exit-stale.png?raw=1) | ![a](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug09-map-exit-after.png) |

## GUI Test Report

| Test | Result |
|------|--------|
| Boss BGM list (FE8J) shows `{hex} {name} : {U.ToHexString(songId)}` — `68 オニール : 1B`, `4D ティラード : 1C`; no `Song:0x0000001B` | ✅ PASS |
| Map Exit Point: selecting map "00 ルネス陥落" (empty exit list) clears the detail (Selected Address `0x00000000`, Size `0x00`, coords/dir/flag = 0) | ✅ PASS |
| `ListParityHelper` Boss BGM parity test (VM == golden builder, both corrected) | ✅ PASS |
| Full `FEBuilderGBA.Avalonia.Tests` (7394 passed / 0 failed / 3 skipped, incl. 7 new) | ✅ PASS |

Render method: offscreen `RenderTargetBitmap` via `--screenshot-all` (locked-screen-safe). ROM: `roms/FE8J.gba`.

## Test plan
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` — full suite green (7394 passed, 0 failed, 3 skipped)
- [x] 4 source-scan tests assert neither the VM nor the golden builder retains `Song:0x{songId:X08}` and both use the corrected format
- [x] 3 VM tests assert `ClearExitPointEntry()` zeroes all detail fields + sets `CanWrite=false`
- [x] After-screenshots of both actual editors (FE8J) confirm the fixes
- [x] No ROM write-path changed (#16 display-only; #9 clears in-memory VM state only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Code 2.1.162 · model claude-opus-4-8[1m]
