### PR TITLE
fix(avalonia): auto-select Item Usage Function combo for the loaded pointer (#4)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ItemUsagePointerComboRepro943Tests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ItemUsagePointerComboRepro943Tests.cs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Repro + regression tests for bug #4 of issue #943:
+// In the Item Usage Pointer editor, after a list row loads, the "Function"
+// combo box stays BLANK — it should auto-select the named-function entry
+// whose hex key matches the current pointer.
+//
+// These tests load a MULTIBYTE ROM (FE8J) — the version where the original
+// FE8 offscreen render confirmed the combo was empty — and exercise the
+// EXACT logic the view uses, split into separate assertions so the failing
+// one pins the root cause.
+using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class ItemUsagePointerComboRepro943Tests
+    {
+        readonly ITestOutputHelper _output;
+
+        public ItemUsagePointerComboRepro943Tests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        /// <summary>
+        /// Replicates the EXACT hex-token extraction the view's UpdateUI match
+        /// loop and FunctionCombo_SelectionChanged use, so the test pins the
+        /// real production behavior.
+        /// </summary>
+        static uint ParseHexKey(string line)
+        {
+            int eq = line.IndexOf('=');
+            string hexToken = eq >= 0 ? line.Substring(0, eq).Trim() : line.Trim();
+            return U.atoh(hexToken);
+        }
+
+        /// <summary>The same match index the view computes in UpdateUI.</summary>
+        static int ComputeMatchIndex(IReadOnlyList<string> lines, uint pointer)
+        {
+            for (int i = 0; i < lines.Count; i++)
+            {
+                if (ParseHexKey(lines[i]) == pointer)
+                    return i;
+            }
+            return -1;
+        }
+
+        // -------------------------------------------------------------------
+        // Assertion 1: LoadFunctionLines returns a NON-empty list for FE8J.
+        // (candidate a: config-resolution / lang / ClipComment failure)
+        // -------------------------------------------------------------------
+        [Fact]
+        public void Assertion1_LoadFunctionLines_NonEmpty_ForMultibyteRom()
+        {
+            RomTestHelper.WithRom("FE8J", () =>
+            {
+                Assert.True(CoreState.ROM.RomInfo.is_multibyte,
+                    "FE8J must be multibyte for this repro");
+
+                var vm = new ItemUsagePointerViewerViewModel();
+                var lines = vm.LoadFunctionLines(0); // 0 = Usability
+
+                _output.WriteLine($"LoadFunctionLines(0) returned {lines.Count} lines");
+                if (lines.Count > 0)
+                    _output.WriteLine($"first line = '{lines[0]}'");
+
+                Assert.NotEmpty(lines);
+            });
+        }
+
+        // -------------------------------------------------------------------
+        // Assertion 2: at least one parsed hex key equals a real row pointer.
+        // (candidate b: hex token mangled / pointer mismatch)
+        // -------------------------------------------------------------------
+        [Fact]
+        public void Assertion2_SomeFunctionLineMatches_FirstRowPointer()
+        {
+            RomTestHelper.WithRom("FE8J", () =>
+            {
+                var vm = new ItemUsagePointerViewerViewModel();
+                var rows = vm.LoadList(0);
+                Assert.NotEmpty(rows);
+
+                var lines = vm.LoadFunctionLines(0);
+
+                uint firstRowAddr = rows[0].addr;
+                vm.LoadEntry(firstRowAddr);
+                uint ptr = vm.UsabilityPointer;
+                _output.WriteLine($"first row addr=0x{firstRowAddr:X08} UsabilityPointer=0x{ptr:X08}");
+
+                bool any = false;
+                foreach (var line in lines)
+                {
+                    if (ParseHexKey(line) == ptr) { any = true; _output.WriteLine($"match: '{line}'"); break; }
+                }
+                Assert.True(any,
+                    $"No function line's hex key equals the first row pointer 0x{ptr:X08}");
+            });
+        }
+
+        // -------------------------------------------------------------------
+        // Assertion 3: the match index the VIEW computes is >= 0 for the
+        // loaded pointer. (candidate c/d: view-layer selection / binding)
+        // -------------------------------------------------------------------
+        [Fact]
+        public void Assertion3_ViewMatchIndex_IsNonNegative_ForLoadedPointer()
+        {
+            RomTestHelper.WithRom("FE8J", () =>
+            {
+                var vm = new ItemUsagePointerViewerViewModel();
+                var rows = vm.LoadList(0);
+                Assert.NotEmpty(rows);
+
+                // _currentFunctionLines is loaded in LoadListForFilter BEFORE
+                // the first row selection fires UpdateUI — replicate that.
+                var lines = vm.LoadFunctionLines(0);
+
+                vm.LoadEntry(rows[0].addr);
+                int matchIdx = ComputeMatchIndex(lines, vm.UsabilityPointer);
+                _output.WriteLine($"matchIdx={matchIdx} for pointer=0x{vm.UsabilityPointer:X08}");
+
+                Assert.True(matchIdx >= 0,
+                    $"View match loop produced no selection (matchIdx={matchIdx}) " +
+                    $"for pointer 0x{vm.UsabilityPointer:X08}");
+            });
+        }
+
+        // -------------------------------------------------------------------
+        // Assertion 4 (END-TO-END, view-level): after the WHOLE view opens
+        // (InitialLoad -> LoadListForFilter -> SelectFirst -> OnSelected ->
+        // UpdateUI), the FunctionCombo must have a selected item that matches
+        // the loaded UsabilityPointer. This is the actual user-visible bug.
+        // -------------------------------------------------------------------
+        [AvaloniaFact]
+        public void Assertion4_ViewLevel_FunctionComboSelected_AfterOpen()
+        {
+            RomTestHelper.WithRom("FE8J", () =>
+            {
+                var view = new ItemUsagePointerViewerView();
+                view.Show();
+                // Pump deferred dispatcher work + layout so the view's open flow
+                // (InitialLoad -> LoadListForFilter -> SelectFirst -> OnSelected
+                // -> UpdateUI) fully settles, mirroring a live frame.
+                global::Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+                try
+                {
+                    var combo = view.FindControl<ComboBox>("FunctionCombo");
+                    Assert.NotNull(combo);
+
+                    var pointerBox = view.FindControl<NumericUpDown>("UsabilityPointerBox");
+                    Assert.NotNull(pointerBox);
+                    uint loadedPtr = (uint)(pointerBox!.Value ?? 0m);
+
+                    _output.WriteLine(
+                        $"FunctionCombo.SelectedIndex={combo!.SelectedIndex} " +
+                        $"ItemCount={(combo.ItemsSource as IReadOnlyList<string>)?.Count ?? -1} " +
+                        $"loadedPtr=0x{loadedPtr:X08} " +
+                        $"SelectedItem='{combo.SelectedItem}'");
+
+                    // BUG #4: this is blank (SelectedIndex == -1) on master.
+                    Assert.True(combo.SelectedIndex >= 0,
+                        $"FunctionCombo is BLANK after view open " +
+                        $"(SelectedIndex={combo.SelectedIndex}) for pointer 0x{loadedPtr:X08}");
+
+                    // The selected entry's hex key must equal the loaded pointer.
+                    string selected = combo.SelectedItem as string ?? "";
+                    Assert.Equal(loadedPtr, ParseHexKey(selected));
+                }
+                finally
+                {
+                    view.Close();
+                }
+            });
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/ItemUsagePointerComboRepro943Tests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ItemUsagePointerComboRepro943Tests.cs
@@ -59,6 +59,12 @@ namespace FEBuilderGBA.Avalonia.Tests
         [Fact]
         public void Assertion1_LoadFunctionLines_NonEmpty_ForMultibyteRom()
         {
+            string? romPath = TestRomLocator.FindRom("FE8J");
+            if (romPath == null)
+            {
+                _output.WriteLine("SKIP: FE8J ROM not available (roms/FE8J.gba or ROMS_DIR) — #4 repro did NOT execute.");
+                return;
+            }
             RomTestHelper.WithRom("FE8J", () =>
             {
                 Assert.True(CoreState.ROM.RomInfo.is_multibyte,
@@ -82,6 +88,12 @@ namespace FEBuilderGBA.Avalonia.Tests
         [Fact]
         public void Assertion2_SomeFunctionLineMatches_FirstRowPointer()
         {
+            string? romPath = TestRomLocator.FindRom("FE8J");
+            if (romPath == null)
+            {
+                _output.WriteLine("SKIP: FE8J ROM not available (roms/FE8J.gba or ROMS_DIR) — #4 repro did NOT execute.");
+                return;
+            }
             RomTestHelper.WithRom("FE8J", () =>
             {
                 var vm = new ItemUsagePointerViewerViewModel();
@@ -112,6 +124,12 @@ namespace FEBuilderGBA.Avalonia.Tests
         [Fact]
         public void Assertion3_ViewMatchIndex_IsNonNegative_ForLoadedPointer()
         {
+            string? romPath = TestRomLocator.FindRom("FE8J");
+            if (romPath == null)
+            {
+                _output.WriteLine("SKIP: FE8J ROM not available (roms/FE8J.gba or ROMS_DIR) — #4 repro did NOT execute.");
+                return;
+            }
             RomTestHelper.WithRom("FE8J", () =>
             {
                 var vm = new ItemUsagePointerViewerViewModel();
@@ -141,6 +159,12 @@ namespace FEBuilderGBA.Avalonia.Tests
         [AvaloniaFact]
         public void Assertion4_ViewLevel_FunctionComboSelected_AfterOpen()
         {
+            string? romPath = TestRomLocator.FindRom("FE8J");
+            if (romPath == null)
+            {
+                _output.WriteLine("SKIP: FE8J ROM not available (roms/FE8J.gba or ROMS_DIR) — #4 repro did NOT execute.");
+                return;
+            }
             RomTestHelper.WithRom("FE8J", () =>
             {
                 var view = new ItemUsagePointerViewerView();

--- a/FEBuilderGBA.Avalonia/Views/ItemUsagePointerViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemUsagePointerViewerView.axaml.cs
@@ -83,9 +83,18 @@ namespace FEBuilderGBA.Avalonia.Views
                 // re-fire OnSelected because the index is already 0).
                 _currentFunctionLines = _vm.LoadFunctionLines(filterIndex);
                 _suppressFunctionComboChange = true;
-                FunctionCombo.ItemsSource = _currentFunctionLines;
-                FunctionCombo.SelectedItem = null;
-                _suppressFunctionComboChange = false;
+                try
+                {
+                    FunctionCombo.ItemsSource = _currentFunctionLines;
+                    FunctionCombo.SelectedItem = null;
+                }
+                finally
+                {
+                    // try/finally so an exception during the ItemsSource/SelectedItem
+                    // assignment can't leave the suppress flag stuck true, which would
+                    // permanently mute user-driven FunctionCombo writes for this view.
+                    _suppressFunctionComboChange = false;
+                }
 
                 EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ItemIconLoader(items, i));
 

--- a/FEBuilderGBA.Avalonia/Views/ItemUsagePointerViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemUsagePointerViewerView.axaml.cs
@@ -70,6 +70,23 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 var items = _vm.LoadList(filterIndex);
+
+                // #943 bug #4: populate the L_0_COMBO equivalent BEFORE loading
+                // the address list. SetItemsWithIcons() calls SelectFirst()
+                // internally, which synchronously fires the row-selection chain
+                // (OnSelected -> UpdateUI) that needs _currentFunctionLines and
+                // FunctionCombo.ItemsSource already in place to resolve the
+                // matching function entry. If we populated the combo AFTER
+                // SetItemsWithIcons, UpdateUI ran with an empty
+                // _currentFunctionLines and a null ItemsSource, so the combo
+                // stayed blank (the later EntryList.SelectFirst() does not
+                // re-fire OnSelected because the index is already 0).
+                _currentFunctionLines = _vm.LoadFunctionLines(filterIndex);
+                _suppressFunctionComboChange = true;
+                FunctionCombo.ItemsSource = _currentFunctionLines;
+                FunctionCombo.SelectedItem = null;
+                _suppressFunctionComboChange = false;
+
                 EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ItemIconLoader(items, i));
 
                 // Refresh the read-only top/select bar indicators from VM state.
@@ -79,14 +96,6 @@ namespace FEBuilderGBA.Avalonia.Views
                 AsmSwitchBox.Text = _vm.AsmSwitchText;
                 BlockSizeBox.Text = _vm.BlockSize.ToString();
                 ItemAddressBox.Value = (decimal)_vm.CurrentArrayAddr;
-
-                // Populate the L_0_COMBO equivalent — named function entries
-                // for this filter (loaded from config/data/item_*_array_FE*.txt).
-                _currentFunctionLines = _vm.LoadFunctionLines(filterIndex);
-                _suppressFunctionComboChange = true;
-                FunctionCombo.ItemsSource = _currentFunctionLines;
-                FunctionCombo.SelectedIndex = -1;
-                _suppressFunctionComboChange = false;
 
                 // Promotion/StatBooster panels visibility — mirrors WinForms.
                 bool isPromo = filterIndex == (int)ItemUsagePointerCore.FilterKind.Promotion1
@@ -200,22 +209,40 @@ namespace FEBuilderGBA.Avalonia.Views
 
             // Sync the FunctionCombo selection to the current pointer (if a
             // line in the config data matches). Mirrors WF L_0_COMBO behavior.
+            ApplyFunctionComboSelection();
+        }
+
+        /// <summary>
+        /// Select the FunctionCombo entry whose hex key matches the current
+        /// UsabilityPointer (or clear it when nothing matches). Mirrors the
+        /// WinForms L_0_COMBO read-link behavior.
+        ///
+        /// #943 bug #4: this relies on <see cref="_currentFunctionLines"/> and
+        /// <c>FunctionCombo.ItemsSource</c> already being populated — which
+        /// LoadListForFilter now guarantees by setting them up BEFORE the
+        /// address-list load that triggers the first row selection. We select
+        /// by item reference (SelectedItem), which the ComboBox resolves by
+        /// value against its ItemsSource.
+        /// </summary>
+        void ApplyFunctionComboSelection()
+        {
+            string? matchLine = null;
+            for (int i = 0; i < _currentFunctionLines.Count; i++)
+            {
+                string line = _currentFunctionLines[i];
+                int eq = line.IndexOf('=');
+                string hexToken = eq >= 0 ? line.Substring(0, eq).Trim() : line.Trim();
+                if (U.atoh(hexToken) == _vm.UsabilityPointer)
+                {
+                    matchLine = line;
+                    break;
+                }
+            }
+
             _suppressFunctionComboChange = true;
             try
             {
-                int matchIdx = -1;
-                for (int i = 0; i < _currentFunctionLines.Count; i++)
-                {
-                    string line = _currentFunctionLines[i];
-                    int eq = line.IndexOf('=');
-                    string hexToken = eq >= 0 ? line.Substring(0, eq).Trim() : line.Trim();
-                    if (U.atoh(hexToken) == _vm.UsabilityPointer)
-                    {
-                        matchIdx = i;
-                        break;
-                    }
-                }
-                FunctionCombo.SelectedIndex = matchIdx;
+                FunctionCombo.SelectedItem = matchLine;
             }
             finally { _suppressFunctionComboChange = false; }
         }


### PR DESCRIPTION
## Summary

Bug #4 from the 2026-06-04 QA sweep (issue #943): in the **Item Usage Pointer Editor**, after a row loads (Usability Pointer `0x08028A38`) the **"Function" combo is blank** — it should auto-select the named function whose hex key matches the pointer.

## Diagnosis (ROM-backed repro test first)

A repro test pinned the cause to the **view layer**, not the match logic (the 3 VM-level assertions all passed: `LoadFunctionLines` returns 31 lines, a line's hex key equals the row pointer, and the match index is found):

`AddressListControl.SetItemsWithIcons()` calls `SelectFirst()` **internally**, which synchronously fires `OnSelected → UpdateUI` **before** `LoadListForFilter` had populated `_currentFunctionLines` / `FunctionCombo.ItemsSource` (those were set *after* the `SetItemsWithIcons` call). The later explicit `EntryList.SelectFirst()` doesn't re-fire `OnSelected` (index is already 0), so `UpdateUI` never re-ran with the populated lines — the combo stayed blank.

## Fix
`ItemUsagePointerViewerView.axaml.cs`:
1. Populate the Function combo (`_currentFunctionLines` + `FunctionCombo.ItemsSource`) **before** `EntryList.SetItemsWithIcons(...)`, so the internal `SelectFirst → UpdateUI` sees the lines.
2. Extract the match into `ApplyFunctionComboSelection()` and select by **item reference** (`FunctionCombo.SelectedItem = matchLine`) instead of `SelectedIndex`. The existing `FunctionCombo_SelectionChanged` write-back is unchanged.

The repro test is kept as a **regression guard**.

## Scope
Closes the #4 portion of #943.
- `FEBuilderGBA.Avalonia/Views/ItemUsagePointerViewerView.axaml.cs`
- `FEBuilderGBA.Avalonia.Tests/ItemUsagePointerComboRepro943Tests.cs`

## Screenshots — Item Usage Pointer Editor (FE8J)

| Before (Function combo blank) | After (`08028A38=Heal, Mend, Recover`) |
|---|---|
| ![b](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/bugsweep/bug04-item-usage-combo.png?raw=1) | ![a](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug04-item-usage-after.png) |

After: with row `4B` selected (Usability Pointer `134384184` = `0x08028A38`), the Function combo now shows `08028A38=Heal, Mend, Recover`.

## GUI Test Report

| Test | Result |
|------|--------|
| Item Usage Pointer Editor (FE8J): selecting the first row auto-selects the matching Function entry (`08028A38=Heal, Mend, Recover`) | ✅ PASS |
| Repro test: `LoadFunctionLines` non-empty, parsed hex key == row pointer, match index found, combo selection resolves | ✅ PASS |
| `ItemUsagePointer` test scope (regression + parity/sweep) — 14 passed / 0 failed | ✅ PASS |

Render: offscreen `--screenshot-all` (locked-screen-safe). ROM: `roms/FE8J.gba`.

## Test plan
- [x] ROM-backed repro test added FIRST; pinned the root cause (view-layer ordering)
- [x] Repro test passes after the fix (kept as regression guard)
- [x] `ItemUsagePointer` scope green (14/0)
- [x] After-screenshot of the actual editor (FE8J) confirms the combo populates
- [x] No VM / ROM logic changed (view-layer ordering + selection-by-item only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Code 2.1.162 · model claude-opus-4-8[1m]
