### PR TITLE
feat(avalonia): build Haiku Event editor detail panels for FE8/FE6/FE7 (#7)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/EditorJumpAddressHelperTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EditorJumpAddressHelperTests.cs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for the shared EditorJumpAddressHelper extracted in the #948 review.
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Core;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    public class EditorJumpAddressHelperTests
+    {
+        // ---- Guard paths (no ROM needed, fully deterministic) ----
+
+        [Fact]
+        public void UnitAddrFor_NullRom_ReturnsZero()
+        {
+            Assert.Equal(0u, EditorJumpAddressHelper.UnitAddrFor(null, 1));
+        }
+
+        [Fact]
+        public void UnitAddrFor_IdZero_ReturnsZero()
+        {
+            // 0 is the 1-based "ANY/no unit" sentinel — must never resolve to an address.
+            Assert.Equal(0u, EditorJumpAddressHelper.UnitAddrFor(null, 0));
+        }
+
+        [Fact]
+        public void TextRowAddrFor_NullRom_ReturnsZero()
+        {
+            Assert.Equal(0u, EditorJumpAddressHelper.TextRowAddrFor(null, 1));
+        }
+
+        // ---- ROM-backed behavior (skipped when no ROM is available) ----
+
+        [Fact]
+        public void UnitAddrFor_RealRom_FirstUnit_IsNonZeroAndInBounds()
+        {
+            using var fx = new RomFixture();
+            if (!fx.IsAvailable) return; // skip: no ROM
+            ROM rom = fx.ROM!;
+
+            uint addr = EditorJumpAddressHelper.UnitAddrFor(rom, 1);
+            Assert.NotEqual(0u, addr);
+            Assert.True(U.isSafetyOffset(addr, rom));
+        }
+
+        [Fact]
+        public void TextRowAddrFor_RealRom_IsTextBasePlusIdTimesFour()
+        {
+            using var fx = new RomFixture();
+            if (!fx.IsAvailable) return; // skip: no ROM
+            ROM rom = fx.ROM!;
+
+            uint textBase = rom.p32(rom.RomInfo.text_pointer);
+            // id 0 -> the table base; id 5 -> base + 20 (one pointer per id).
+            Assert.Equal(textBase, EditorJumpAddressHelper.TextRowAddrFor(rom, 0));
+            Assert.Equal(textBase + 20u, EditorJumpAddressHelper.TextRowAddrFor(rom, 5));
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/EventHaikuDetailPanelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventHaikuDetailPanelTests.cs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Headless tests for the Haiku Event editor detail panels (#947 bug #7).
+//
+// The three EventHaiku* views were stubs (only an "Address:" label, 0 input
+// controls). These tests assert the panels are now populated: every view exposes
+// input controls (NumericUpDown / ComboBox / IdFieldControl) and a Write button,
+// the type-ID fields are IdFieldControls with the expected labels, and the FE8
+// Route combo carries the 4 WinForms L_2_COMBO choices.
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using FEBuilderGBA.Avalonia.Controls;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+public class EventHaikuDetailPanelTests
+{
+    // ---- FE8 (EventHaikuView) -------------------------------------------------
+
+    [AvaloniaFact]
+    public void FE8_View_HasInputControls()
+    {
+        var view = new EventHaikuView();
+        int numerics = view.GetLogicalDescendants().OfType<NumericUpDown>().Count();
+        int idFields = view.GetLogicalDescendants().OfType<IdFieldControl>().Count();
+        int combos = view.GetLogicalDescendants().OfType<ComboBox>().Count();
+        // Stub had ZERO; the panel must now expose multiple inputs.
+        Assert.True(numerics > 0, "FE8 Haiku panel has no NumericUpDown inputs");
+        Assert.True(idFields >= 3, "FE8 Haiku panel missing IdFieldControls (Unit/Killer/Text)");
+        Assert.True(combos >= 1, "FE8 Haiku panel missing the Route ComboBox");
+    }
+
+    [AvaloniaFact]
+    public void FE8_View_HasWriteButton()
+    {
+        var view = new EventHaikuView();
+        var write = view.FindControl<Button>("WriteButton");
+        Assert.NotNull(write);
+    }
+
+    [AvaloniaFact]
+    public void FE8_UnitAndTextAndKiller_AreIdFieldControls_WithLabels()
+    {
+        var view = new EventHaikuView();
+        var unit = view.FindControl<IdFieldControl>("UnitNud");
+        var killer = view.FindControl<IdFieldControl>("KillerUnitNud");
+        var text = view.FindControl<IdFieldControl>("TextNud");
+        Assert.NotNull(unit);
+        Assert.NotNull(killer);
+        Assert.NotNull(text);
+        Assert.Equal("Unit:", unit!.Label);
+        Assert.Equal("Killer Unit:", killer!.Label);
+        Assert.Equal("Text:", text!.Label);
+        // Text field must NOT show Pick (TextViewerView isn't pickable).
+        Assert.False(text.ShowPick);
+        Assert.True(unit.ShowPick);
+    }
+
+    [AvaloniaFact]
+    public void FE8_RouteCombo_HasFourWinFormsChoices()
+    {
+        var view = new EventHaikuView();
+        var combo = view.FindControl<ComboBox>("RouteCombo");
+        Assert.NotNull(combo);
+        Assert.Equal(4, combo!.Items.Count);
+    }
+
+    // ---- FE6 (EventHaikuFE6View) ----------------------------------------------
+
+    [AvaloniaFact]
+    public void FE6_View_HasInputControls()
+    {
+        var view = new EventHaikuFE6View();
+        int numerics = view.GetLogicalDescendants().OfType<NumericUpDown>().Count();
+        int idFields = view.GetLogicalDescendants().OfType<IdFieldControl>().Count();
+        Assert.True(numerics > 0, "FE6 Haiku panel has no NumericUpDown inputs");
+        // Unit + DeathText + FinalChapterText.
+        Assert.True(idFields >= 3, "FE6 Haiku panel missing IdFieldControls");
+    }
+
+    [AvaloniaFact]
+    public void FE6_TextFields_AreIdFieldControls_NoPick()
+    {
+        var view = new EventHaikuFE6View();
+        var unit = view.FindControl<IdFieldControl>("UnitNud");
+        var death = view.FindControl<IdFieldControl>("DeathTextNud");
+        var final = view.FindControl<IdFieldControl>("FinalChapterTextNud");
+        Assert.NotNull(unit);
+        Assert.NotNull(death);
+        Assert.NotNull(final);
+        Assert.Equal("Death Text:", death!.Label);
+        Assert.Equal("Final Chapter Text:", final!.Label);
+        Assert.False(death.ShowPick);
+        Assert.False(final.ShowPick);
+    }
+
+    [AvaloniaFact]
+    public void FE6_View_HasWriteButton()
+    {
+        var view = new EventHaikuFE6View();
+        Assert.NotNull(view.FindControl<Button>("WriteButton"));
+    }
+
+    // ---- FE7 (EventHaikuFE7View) ----------------------------------------------
+
+    [AvaloniaFact]
+    public void FE7_View_HasInputControls()
+    {
+        var view = new EventHaikuFE7View();
+        int numerics = view.GetLogicalDescendants().OfType<NumericUpDown>().Count();
+        int idFields = view.GetLogicalDescendants().OfType<IdFieldControl>().Count();
+        Assert.True(numerics > 0, "FE7 Haiku panel has no NumericUpDown inputs");
+        // Unit + Text.
+        Assert.True(idFields >= 2, "FE7 Haiku panel missing IdFieldControls");
+    }
+
+    [AvaloniaFact]
+    public void FE7_UnitAndText_AreIdFieldControls_WithLabels()
+    {
+        var view = new EventHaikuFE7View();
+        var unit = view.FindControl<IdFieldControl>("UnitNud");
+        var text = view.FindControl<IdFieldControl>("TextNud");
+        Assert.NotNull(unit);
+        Assert.NotNull(text);
+        Assert.Equal("Unit:", unit!.Label);
+        Assert.Equal("Text:", text!.Label);
+        Assert.False(text.ShowPick);
+    }
+
+    [AvaloniaFact]
+    public void FE7_View_HasWriteButton()
+    {
+        var view = new EventHaikuFE7View();
+        Assert.NotNull(view.FindControl<Button>("WriteButton"));
+    }
+
+    [AvaloniaFact]
+    public void FE7_EventPointer_IsPresent()
+    {
+        var view = new EventHaikuFE7View();
+        Assert.NotNull(view.FindControl<NumericUpDown>("EventPointerBox"));
+    }
+}

--- a/FEBuilderGBA.Avalonia/Services/EditorJumpAddressHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/EditorJumpAddressHelper.cs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Shared jump-target address resolution for editor views (#948 review).
+//
+// The Haiku Event editors (and other type-ID fields) need to translate a
+// 1-based unit id or a text id into the ROM data address an IdFieldControl's
+// Jump button should navigate to. These two computations were duplicated
+// verbatim across EventHaikuView / EventHaikuFE6View / EventHaikuFE7View; this
+// helper centralises them so the pointer-safety + offset math live in ONE place.
+using FEBuilderGBA.Core;
+
+namespace FEBuilderGBA.Avalonia.Services
+{
+    /// <summary>
+    /// Pure, ROM-explicit helpers that resolve a type-ID to the ROM data address
+    /// its editor Jump button should open. All methods are bounds-safe and return
+    /// 0 ("no target") on any failure rather than throwing.
+    /// </summary>
+    public static class EditorJumpAddressHelper
+    {
+        /// <summary>
+        /// Resolve a 1-based unit id (WinForms convention; 0 = ANY/no unit) to the
+        /// unit-table entry address in <paramref name="rom"/>. FE6 skips table
+        /// entry 0 (offset by one record). Returns 0 when the id is 0, the ROM /
+        /// pointer is unavailable, or the entry would fall out of bounds.
+        /// </summary>
+        public static uint UnitAddrFor(ROM rom, uint oneBasedId)
+        {
+            if (rom?.RomInfo == null) return 0;
+            if (oneBasedId == 0) return 0; // 1-based: 0 = ANY/no unit
+            uint unitPtr = rom.RomInfo.unit_pointer;
+            if (unitPtr == 0) return 0;
+            uint baseAddr = rom.p32(unitPtr);
+            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
+            uint dataSize = rom.RomInfo.unit_datasize;
+            if (dataSize == 0) return 0;
+            if (rom.RomInfo.version == 6) baseAddr += dataSize; // FE6 skips entry 0
+            uint entryAddr = baseAddr + (oneBasedId - 1) * dataSize;
+            if (!U.isSafetyOffset(entryAddr, rom)) return 0;
+            if (!U.isSafetyOffset(entryAddr + dataSize - 1, rom)) return 0;
+            return entryAddr;
+        }
+
+        /// <summary>
+        /// Resolve a text id to its text-table ROW address
+        /// (<c>textBase + textId * 4</c>, one pointer per id) in
+        /// <paramref name="rom"/>. Computes in 64-bit to detect wrap-around.
+        /// Returns 0 when the ROM / pointer is unavailable or the row would fall
+        /// out of bounds.
+        /// </summary>
+        public static uint TextRowAddrFor(ROM rom, uint textId)
+        {
+            if (rom?.RomInfo == null) return 0;
+            uint ptr = rom.RomInfo.text_pointer;
+            if (ptr == 0) return 0;
+            uint baseAddr = rom.p32(ptr);
+            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
+            // Text-table ROW address = textBase + textId*4 (one pointer per id).
+            ulong addr64 = (ulong)baseAddr + (ulong)textId * 4UL;
+            if (addr64 > uint.MaxValue) return 0;
+            uint addr = (uint)addr64;
+            if (!U.isSafetyOffset(addr, rom)) return 0;
+            if (!U.isSafetyOffset(addr + 3, rom)) return 0;
+            return addr;
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Services/PatchDetectionService.cs
+++ b/FEBuilderGBA.Avalonia/Services/PatchDetectionService.cs
@@ -41,6 +41,14 @@ namespace FEBuilderGBA.Avalonia.Services
         /// <summary>SkillSystems effectiveness rework class type extension.</summary>
         public bool SkillSystemsClassTypeRework { get; private set; }
 
+        /// <summary>
+        /// True if the FE8 "death quote add killer ID" patch is installed, which
+        /// repurposes the haiku entry byte at offset +1 (otherwise unknown) to
+        /// store the unit ID of the killer. Mirrors WinForms
+        /// <c>PatchUtil.DeathQuoteAddKillerID() == Enable</c>. FE8 only.
+        /// </summary>
+        public bool DeathQuoteAddKillerID { get; private set; }
+
         /// <summary>Draw font patch type from Core PatchDetection.</summary>
         public PatchDetection.draw_font_enum DrawFont { get; private set; } = PatchDetection.draw_font_enum.NO;
 
@@ -94,6 +102,7 @@ namespace FEBuilderGBA.Avalonia.Services
             BG256Color = false;
             AntiHuffman = false;
             SkillSystemsClassTypeRework = false;
+            DeathQuoteAddKillerID = false;
             DrawFont = PatchDetection.draw_font_enum.NO;
             TextEngineRework = PatchDetection.TextEngineRework_enum.NO;
 
@@ -117,6 +126,7 @@ namespace FEBuilderGBA.Avalonia.Services
             PortraitExtends = DetectPortraitExtends();
             BG256Color = DetectBG256Color();
             SkillSystemsClassTypeRework = DetectClassTypeRework();
+            DeathQuoteAddKillerID = DetectDeathQuoteAddKillerID();
         }
 
         // ---- Private detection methods ----
@@ -300,6 +310,45 @@ namespace FEBuilderGBA.Avalonia.Services
                 return true;
             if (rom.CompareByte(0x2AAEC, new byte[] { 0x01, 0x4B, 0xA6, 0xF0, 0xED, 0xFE, 0x01, 0xE0 }))
                 return true;
+
+            return false;
+        }
+
+        /// <summary>
+        /// Detect the FE8 "death quote add killer ID" patch. Literal port of
+        /// WinForms <c>PatchUtil.DeathQuoteAddKillerIDLow()</c> (FE8 only — both
+        /// FE8J/is_multibyte and FE8U). The patch hook overwrites a fixed dword;
+        /// a second guard distinguishes the (separate) "capture area" feature,
+        /// which is NOT the killer-ID extension, so we return false there.
+        /// </summary>
+        static bool DetectDeathQuoteAddKillerID()
+        {
+            ROM rom = CoreState.ROM!;
+            if (rom.RomInfo.version != 8)
+                return false;
+
+            if (rom.RomInfo.is_multibyte)
+            {
+                // FE8J
+                if (rom.u32(0x0869B0) == 0x47184B00)
+                {
+                    if (rom.u32(0x16328) == 0x46874800)
+                        return false; // capture area, not killer-ID
+                    return true;
+                }
+            }
+            else
+            {
+                // FE8U
+                if (rom.u32(0x0846E4) == 0x47184B00)
+                {
+                    if (rom.u32(0x16580) == 0x46874800)
+                        return false; // capture area
+                    if (rom.u32(0x32264) == 0x47184B00)
+                        return false; // capture (skillsystems)
+                    return true;
+                }
+            }
 
             return false;
         }

--- a/FEBuilderGBA.Avalonia/Views/EventHaikuFE6View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventHaikuFE6View.axaml
@@ -11,10 +11,96 @@
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Haiku (FE6)" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
+        <Grid ColumnDefinitions="180,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
           <TextBlock AutomationProperties.AutomationId="EventHaikuFE6_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+
+          <!-- Unit (offset +0, 1-based id) — IdFieldControl, normal unit names. -->
+          <controls:IdFieldControl AutomationProperties.AutomationId="EventHaikuFE6_UnitNud_Input"
+                                   Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                                   Margin="0,2"
+                                   Name="UnitNud"
+                                   Label="Unit:"
+                                   Maximum="255"
+                                   JumpRequested="Unit_Jump"
+                                   PickRequested="Unit_Pick"
+                                   ValueChanged="Unit_ValueChanged" />
+
+          <!-- Chapter ID (offset +1) — NumericUpDown + inline chapter-name preview
+               (FE6 ANYIFOVER: id >= map count => "ANY"). -->
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Chapter ID:" VerticalAlignment="Center" />
+          <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Horizontal" Spacing="8">
+            <NumericUpDown AutomationProperties.AutomationId="EventHaikuFE6_ChapterId_Input" FormatString="0"
+                           Name="ChapterIdBox" Minimum="0" Maximum="255" VerticalAlignment="Center" Width="120"
+                           ValueChanged="ChapterId_ValueChanged" />
+            <TextBlock AutomationProperties.AutomationId="EventHaikuFE6_ChapterName_Label"
+                       Name="ChapterNameLabel" VerticalAlignment="Center" Foreground="Gray" />
+          </StackPanel>
+
+          <TextBlock Grid.Row="3" Grid.Column="0" Text="Unknown (0x02):" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="EventHaikuFE6_Unknown02_Input" FormatString="0"
+                         Grid.Row="3" Grid.Column="1" Name="Unknown02Box" Minimum="0" Maximum="255" Margin="0,2" />
+
+          <TextBlock Grid.Row="4" Grid.Column="0" Text="Unknown (0x03):" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="EventHaikuFE6_Unknown03_Input" FormatString="0"
+                         Grid.Row="4" Grid.Column="1" Name="Unknown03Box" Minimum="0" Maximum="255" Margin="0,2" />
+
+          <!-- Death Text (offset +4, u16) — IdFieldControl, Jump to text-table
+               ROW address, no Pick, inline text preview. -->
+          <controls:IdFieldControl AutomationProperties.AutomationId="EventHaikuFE6_DeathTextNud_Input"
+                                   Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
+                                   Margin="0,2"
+                                   Name="DeathTextNud"
+                                   Label="Death Text:"
+                                   Maximum="65535"
+                                   ShowPick="False"
+                                   JumpRequested="DeathText_Jump"
+                                   ValueChanged="DeathText_ValueChanged" />
+
+          <TextBlock Grid.Row="6" Grid.Column="0" Text="Unknown (0x06):" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="EventHaikuFE6_Unknown06_Input" FormatString="0"
+                         Grid.Row="6" Grid.Column="1" Name="Unknown06Box" Minimum="0" Maximum="255" Margin="0,2" />
+
+          <TextBlock Grid.Row="7" Grid.Column="0" Text="Unknown (0x07):" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="EventHaikuFE6_Unknown07_Input" FormatString="0"
+                         Grid.Row="7" Grid.Column="1" Name="Unknown07Box" Minimum="0" Maximum="255" Margin="0,2" />
+
+          <!-- Achievement Flag (offset +8, u16). -->
+          <TextBlock Grid.Row="8" Grid.Column="0" Text="Achievement Flag:" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="EventHaikuFE6_AchievementFlag_Input" FormatString="0"
+                         Grid.Row="8" Grid.Column="1" Name="AchievementFlagBox" Minimum="0" Maximum="65535" Margin="0,2" />
+
+          <TextBlock Grid.Row="9" Grid.Column="0" Text="Unknown (0x0A):" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="EventHaikuFE6_Unknown0A_Input" FormatString="0"
+                         Grid.Row="9" Grid.Column="1" Name="Unknown0ABox" Minimum="0" Maximum="255" Margin="0,2" />
+
+          <TextBlock Grid.Row="10" Grid.Column="0" Text="Unknown (0x0B):" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="EventHaikuFE6_Unknown0B_Input" FormatString="0"
+                         Grid.Row="10" Grid.Column="1" Name="Unknown0BBox" Minimum="0" Maximum="255" Margin="0,2" />
+
+          <!-- Final Chapter Text (offset +0C, u16) — IdFieldControl, Jump to
+               text-table ROW address, no Pick, inline text preview. -->
+          <controls:IdFieldControl AutomationProperties.AutomationId="EventHaikuFE6_FinalChapterTextNud_Input"
+                                   Grid.Row="11" Grid.Column="0" Grid.ColumnSpan="2"
+                                   Margin="0,2"
+                                   Name="FinalChapterTextNud"
+                                   Label="Final Chapter Text:"
+                                   Maximum="65535"
+                                   ShowPick="False"
+                                   JumpRequested="FinalChapterText_Jump"
+                                   ValueChanged="FinalChapterText_ValueChanged" />
+
+          <TextBlock Grid.Row="12" Grid.Column="0" Text="Unknown (0x0E):" VerticalAlignment="Center" />
+          <StackPanel Grid.Row="12" Grid.Column="1" Orientation="Horizontal" Spacing="8">
+            <NumericUpDown AutomationProperties.AutomationId="EventHaikuFE6_Unknown0E_Input" FormatString="0"
+                           Name="Unknown0EBox" Minimum="0" Maximum="255" VerticalAlignment="Center" Width="120" />
+            <TextBlock Text="Unknown (0x0F):" VerticalAlignment="Center" />
+            <NumericUpDown AutomationProperties.AutomationId="EventHaikuFE6_Unknown0F_Input" FormatString="0"
+                           Name="Unknown0FBox" Minimum="0" Maximum="255" VerticalAlignment="Center" Width="120" />
+          </StackPanel>
         </Grid>
+
+        <Button AutomationProperties.AutomationId="EventHaikuFE6_Write_Button" Name="WriteButton" Content="Write" HorizontalAlignment="Left" Margin="0,12,0,0" />
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/EventHaikuFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventHaikuFE6View.axaml.cs
@@ -1,14 +1,17 @@
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
+using FEBuilderGBA.Avalonia.Controls;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Core;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
     public partial class EventHaikuFE6View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventHaikuFE6ViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         public string ViewTitle => "Haiku (FE6)";
         public bool IsLoaded => _vm.IsLoaded;
@@ -17,6 +20,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
+            WriteButton.Click += Write_Click;
             Opened += (_, _) => LoadList();
         }
 
@@ -48,7 +52,162 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void UpdateUI()
         {
-            AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            AddrLabel.Text = $"0x{_vm.CurrentAddr:X08}";
+
+            UnitNud.Value = _vm.Unit;
+            UnitNud.NameText = _vm.Unit == 0 ? "" : NameResolver.GetUnitNameByOneBasedId(_vm.Unit);
+
+            ChapterIdBox.Value = _vm.ChapterID;
+            ChapterNameLabel.Text = ResolveChapterName(_vm.ChapterID);
+
+            Unknown02Box.Value = _vm.Unknown02;
+            Unknown03Box.Value = _vm.Unknown03;
+
+            DeathTextNud.Value = _vm.DeathText;
+            DeathTextNud.NameText = _vm.DeathText != 0 ? NameResolver.GetTextById(_vm.DeathText) : "";
+
+            Unknown06Box.Value = _vm.Unknown06;
+            Unknown07Box.Value = _vm.Unknown07;
+            AchievementFlagBox.Value = _vm.AchievementFlag;
+            Unknown0ABox.Value = _vm.Unknown0A;
+            Unknown0BBox.Value = _vm.Unknown0B;
+
+            FinalChapterTextNud.Value = _vm.FinalChapterText;
+            FinalChapterTextNud.NameText = _vm.FinalChapterText != 0 ? NameResolver.GetTextById(_vm.FinalChapterText) : "";
+
+            Unknown0EBox.Value = _vm.Unknown0E;
+            Unknown0FBox.Value = _vm.Unknown0F;
+        }
+
+        void Write_Click(object? sender, RoutedEventArgs e)
+        {
+            _undoService.Begin("Edit Haiku (FE6)");
+            try
+            {
+                _vm.Unit = UnitNud.Value;
+                _vm.ChapterID = (uint)(ChapterIdBox.Value ?? 0);
+                _vm.Unknown02 = (uint)(Unknown02Box.Value ?? 0);
+                _vm.Unknown03 = (uint)(Unknown03Box.Value ?? 0);
+                _vm.DeathText = DeathTextNud.Value;
+                _vm.Unknown06 = (uint)(Unknown06Box.Value ?? 0);
+                _vm.Unknown07 = (uint)(Unknown07Box.Value ?? 0);
+                _vm.AchievementFlag = (uint)(AchievementFlagBox.Value ?? 0);
+                _vm.Unknown0A = (uint)(Unknown0ABox.Value ?? 0);
+                _vm.Unknown0B = (uint)(Unknown0BBox.Value ?? 0);
+                _vm.FinalChapterText = FinalChapterTextNud.Value;
+                _vm.Unknown0E = (uint)(Unknown0EBox.Value ?? 0);
+                _vm.Unknown0F = (uint)(Unknown0FBox.Value ?? 0);
+
+                _vm.Write();
+                _undoService.Commit();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("EventHaikuFE6View.Write_Click failed: {0}", ex.Message);
+            }
+        }
+
+        // -- Chapter / map name preview (FE6 ANYIFOVER semantics) --------------
+
+        /// <summary>Resolve a chapter id to a name preview. FE6 renders an
+        /// over-the-map-count id as "ANY" (WinForms
+        /// MapSettingForm.GetMapNameAndANYIFOVER).</summary>
+        static string ResolveChapterName(uint chapterId)
+        {
+            var rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return "";
+            int count = MapSettingCore.GetMapCount();
+            if (count > 0 && chapterId >= (uint)count) return "ANY";
+            string name = MapSettingCore.GetMapNameById(chapterId);
+            return string.IsNullOrEmpty(name) ? "" : name;
+        }
+
+        void ChapterId_ValueChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            uint id = (uint)(ChapterIdBox.Value ?? 0);
+            ChapterNameLabel.Text = ResolveChapterName(id);
+        }
+
+        // -- Unit / Text helpers ----------------------------------------------
+
+        static uint UnitAddrFor(uint unitId)
+        {
+            var rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return 0;
+            if (unitId == 0) return 0;
+            uint unitPtr = rom.RomInfo.unit_pointer;
+            if (unitPtr == 0) return 0;
+            uint baseAddr = rom.p32(unitPtr);
+            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
+            uint dataSize = rom.RomInfo.unit_datasize;
+            if (dataSize == 0) return 0;
+            if (rom.RomInfo.version == 6) baseAddr += dataSize; // FE6 skips entry 0
+            uint entryAddr = baseAddr + (unitId - 1) * dataSize;
+            if (!U.isSafetyOffset(entryAddr, rom)) return 0;
+            if (!U.isSafetyOffset(entryAddr + dataSize - 1, rom)) return 0;
+            return entryAddr;
+        }
+
+        static uint TextRowAddrFor(uint textId)
+        {
+            var rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return 0;
+            uint ptr = rom.RomInfo.text_pointer;
+            if (ptr == 0) return 0;
+            uint baseAddr = rom.p32(ptr);
+            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
+            // Text-table ROW address = textBase + textId*4.
+            ulong addr64 = (ulong)baseAddr + (ulong)textId * 4UL;
+            if (addr64 > uint.MaxValue) return 0;
+            uint addr = (uint)addr64;
+            if (!U.isSafetyOffset(addr, rom)) return 0;
+            if (!U.isSafetyOffset(addr + 3, rom)) return 0;
+            return addr;
+        }
+
+        void Unit_Jump(object? sender, RoutedEventArgs e)
+        {
+            try { uint addr = UnitAddrFor(UnitNud.Value); if (addr != 0) WindowManager.Instance.Navigate<UnitEditorView>(addr); }
+            catch (Exception ex) { Log.Error("EventHaikuFE6View.Unit_Jump failed: {0}", ex.Message); }
+        }
+
+        async void Unit_Pick(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                uint addr = UnitAddrFor(UnitNud.Value);
+                var result = await WindowManager.Instance.PickFromEditor<UnitEditorView>(addr, this);
+                if (result != null) UnitNud.Value = (uint)result.Index + 1; // 0-based pick -> 1-based id
+            }
+            catch (Exception ex) { Log.Error("EventHaikuFE6View.Unit_Pick failed: {0}", ex.Message); }
+        }
+
+        void Unit_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
+        {
+            UnitNud.NameText = e.NewValue == 0 ? "" : NameResolver.GetUnitNameByOneBasedId(e.NewValue);
+        }
+
+        void DeathText_Jump(object? sender, RoutedEventArgs e)
+        {
+            try { uint addr = TextRowAddrFor(DeathTextNud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
+            catch (Exception ex) { Log.Error("EventHaikuFE6View.DeathText_Jump failed: {0}", ex.Message); }
+        }
+
+        void DeathText_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
+        {
+            DeathTextNud.NameText = e.NewValue != 0 ? NameResolver.GetTextById(e.NewValue) : "";
+        }
+
+        void FinalChapterText_Jump(object? sender, RoutedEventArgs e)
+        {
+            try { uint addr = TextRowAddrFor(FinalChapterTextNud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
+            catch (Exception ex) { Log.Error("EventHaikuFE6View.FinalChapterText_Jump failed: {0}", ex.Message); }
+        }
+
+        void FinalChapterText_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
+        {
+            FinalChapterTextNud.NameText = e.NewValue != 0 ? NameResolver.GetTextById(e.NewValue) : "";
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/EventHaikuFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventHaikuFE6View.axaml.cs
@@ -33,7 +33,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventHaikuFE6View.LoadList failed: {0}", ex.Message);
+                Log.Error($"EventHaikuFE6View.LoadList failed: {ex.Message}");
             }
         }
 
@@ -46,7 +46,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventHaikuFE6View.OnSelected failed: {0}", ex.Message);
+                Log.Error($"EventHaikuFE6View.OnSelected failed: {ex.Message}");
             }
         }
 
@@ -104,7 +104,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EventHaikuFE6View.Write_Click failed: {0}", ex.Message);
+                Log.Error($"EventHaikuFE6View.Write_Click failed: {ex.Message}");
             }
         }
 
@@ -129,58 +129,24 @@ namespace FEBuilderGBA.Avalonia.Views
             ChapterNameLabel.Text = ResolveChapterName(id);
         }
 
-        // -- Unit / Text helpers ----------------------------------------------
-
-        static uint UnitAddrFor(uint unitId)
-        {
-            var rom = CoreState.ROM;
-            if (rom?.RomInfo == null) return 0;
-            if (unitId == 0) return 0;
-            uint unitPtr = rom.RomInfo.unit_pointer;
-            if (unitPtr == 0) return 0;
-            uint baseAddr = rom.p32(unitPtr);
-            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
-            uint dataSize = rom.RomInfo.unit_datasize;
-            if (dataSize == 0) return 0;
-            if (rom.RomInfo.version == 6) baseAddr += dataSize; // FE6 skips entry 0
-            uint entryAddr = baseAddr + (unitId - 1) * dataSize;
-            if (!U.isSafetyOffset(entryAddr, rom)) return 0;
-            if (!U.isSafetyOffset(entryAddr + dataSize - 1, rom)) return 0;
-            return entryAddr;
-        }
-
-        static uint TextRowAddrFor(uint textId)
-        {
-            var rom = CoreState.ROM;
-            if (rom?.RomInfo == null) return 0;
-            uint ptr = rom.RomInfo.text_pointer;
-            if (ptr == 0) return 0;
-            uint baseAddr = rom.p32(ptr);
-            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
-            // Text-table ROW address = textBase + textId*4.
-            ulong addr64 = (ulong)baseAddr + (ulong)textId * 4UL;
-            if (addr64 > uint.MaxValue) return 0;
-            uint addr = (uint)addr64;
-            if (!U.isSafetyOffset(addr, rom)) return 0;
-            if (!U.isSafetyOffset(addr + 3, rom)) return 0;
-            return addr;
-        }
+        // -- Unit / Text handlers ---------------------------------------------
+        // Jump-address math lives in the shared EditorJumpAddressHelper (#948).
 
         void Unit_Jump(object? sender, RoutedEventArgs e)
         {
-            try { uint addr = UnitAddrFor(UnitNud.Value); if (addr != 0) WindowManager.Instance.Navigate<UnitEditorView>(addr); }
-            catch (Exception ex) { Log.Error("EventHaikuFE6View.Unit_Jump failed: {0}", ex.Message); }
+            try { uint addr = EditorJumpAddressHelper.UnitAddrFor(CoreState.ROM, UnitNud.Value); if (addr != 0) WindowManager.Instance.Navigate<UnitEditorView>(addr); }
+            catch (Exception ex) { Log.Error($"EventHaikuFE6View.Unit_Jump failed: {ex.Message}"); }
         }
 
         async void Unit_Pick(object? sender, RoutedEventArgs e)
         {
             try
             {
-                uint addr = UnitAddrFor(UnitNud.Value);
+                uint addr = EditorJumpAddressHelper.UnitAddrFor(CoreState.ROM, UnitNud.Value);
                 var result = await WindowManager.Instance.PickFromEditor<UnitEditorView>(addr, this);
                 if (result != null) UnitNud.Value = (uint)result.Index + 1; // 0-based pick -> 1-based id
             }
-            catch (Exception ex) { Log.Error("EventHaikuFE6View.Unit_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.Error($"EventHaikuFE6View.Unit_Pick failed: {ex.Message}"); }
         }
 
         void Unit_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -190,8 +156,8 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void DeathText_Jump(object? sender, RoutedEventArgs e)
         {
-            try { uint addr = TextRowAddrFor(DeathTextNud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
-            catch (Exception ex) { Log.Error("EventHaikuFE6View.DeathText_Jump failed: {0}", ex.Message); }
+            try { uint addr = EditorJumpAddressHelper.TextRowAddrFor(CoreState.ROM, DeathTextNud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
+            catch (Exception ex) { Log.Error($"EventHaikuFE6View.DeathText_Jump failed: {ex.Message}"); }
         }
 
         void DeathText_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -201,8 +167,8 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void FinalChapterText_Jump(object? sender, RoutedEventArgs e)
         {
-            try { uint addr = TextRowAddrFor(FinalChapterTextNud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
-            catch (Exception ex) { Log.Error("EventHaikuFE6View.FinalChapterText_Jump failed: {0}", ex.Message); }
+            try { uint addr = EditorJumpAddressHelper.TextRowAddrFor(CoreState.ROM, FinalChapterTextNud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
+            catch (Exception ex) { Log.Error($"EventHaikuFE6View.FinalChapterText_Jump failed: {ex.Message}"); }
         }
 
         void FinalChapterText_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/EventHaikuFE7View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventHaikuFE7View.axaml
@@ -11,10 +11,84 @@
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Haiku (FE7)" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
+        <Grid ColumnDefinitions="180,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
           <TextBlock AutomationProperties.AutomationId="EventHaikuFE7_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+
+          <!-- Unit (offset +0, 1-based id) — IdFieldControl, ANY-capable names. -->
+          <controls:IdFieldControl AutomationProperties.AutomationId="EventHaikuFE7_UnitNud_Input"
+                                   Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                                   Margin="0,2"
+                                   Name="UnitNud"
+                                   Label="Unit:"
+                                   Maximum="255"
+                                   JumpRequested="Unit_Jump"
+                                   PickRequested="Unit_Pick"
+                                   ValueChanged="Unit_ValueChanged" />
+
+          <!-- Chapter ID (offset +1) — NumericUpDown + inline chapter-name preview
+               (FE7 ANYFF: 0x45 => "ANY"). -->
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Chapter ID:" VerticalAlignment="Center" />
+          <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Horizontal" Spacing="8">
+            <NumericUpDown AutomationProperties.AutomationId="EventHaikuFE7_ChapterId_Input" FormatString="0"
+                           Name="ChapterIdBox" Minimum="0" Maximum="255" VerticalAlignment="Center" Width="120"
+                           ValueChanged="ChapterId_ValueChanged" />
+            <TextBlock AutomationProperties.AutomationId="EventHaikuFE7_ChapterName_Label"
+                       Name="ChapterNameLabel" VerticalAlignment="Center" Foreground="Gray" />
+          </StackPanel>
+
+          <TextBlock Grid.Row="3" Grid.Column="0" Text="Unknown (0x02):" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="EventHaikuFE7_Unknown02_Input" FormatString="0"
+                         Grid.Row="3" Grid.Column="1" Name="Unknown02Box" Minimum="0" Maximum="255" Margin="0,2" />
+
+          <TextBlock Grid.Row="4" Grid.Column="0" Text="Unknown (0x03):" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="EventHaikuFE7_Unknown03_Input" FormatString="0"
+                         Grid.Row="4" Grid.Column="1" Name="Unknown03Box" Minimum="0" Maximum="255" Margin="0,2" />
+
+          <!-- Text (offset +4, u16) — IdFieldControl, Jump to text-table ROW
+               address, no Pick, inline text preview. -->
+          <controls:IdFieldControl AutomationProperties.AutomationId="EventHaikuFE7_TextNud_Input"
+                                   Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
+                                   Margin="0,2"
+                                   Name="TextNud"
+                                   Label="Text:"
+                                   Maximum="65535"
+                                   ShowPick="False"
+                                   JumpRequested="Text_Jump"
+                                   ValueChanged="Text_ValueChanged" />
+
+          <TextBlock Grid.Row="6" Grid.Column="0" Text="Unknown (0x06):" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="EventHaikuFE7_Unknown06_Input" FormatString="0"
+                         Grid.Row="6" Grid.Column="1" Name="Unknown06Box" Minimum="0" Maximum="255" Margin="0,2" />
+
+          <TextBlock Grid.Row="7" Grid.Column="0" Text="Unknown (0x07):" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="EventHaikuFE7_Unknown07_Input" FormatString="0"
+                         Grid.Row="7" Grid.Column="1" Name="Unknown07Box" Minimum="0" Maximum="255" Margin="0,2" />
+
+          <!-- Achievement Flag (offset +0C, u16). -->
+          <TextBlock Grid.Row="8" Grid.Column="0" Text="Achievement Flag:" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="EventHaikuFE7_AchievementFlag_Input" FormatString="0"
+                         Grid.Row="8" Grid.Column="1" Name="AchievementFlagBox" Minimum="0" Maximum="65535" Margin="0,2" />
+
+          <TextBlock Grid.Row="9" Grid.Column="0" Text="Unknown (0x0E):" VerticalAlignment="Center" />
+          <StackPanel Grid.Row="9" Grid.Column="1" Orientation="Horizontal" Spacing="8">
+            <NumericUpDown AutomationProperties.AutomationId="EventHaikuFE7_Unknown0E_Input" FormatString="0"
+                           Name="Unknown0EBox" Minimum="0" Maximum="255" VerticalAlignment="Center" Width="120" />
+            <TextBlock Text="Unknown (0x0F):" VerticalAlignment="Center" />
+            <NumericUpDown AutomationProperties.AutomationId="EventHaikuFE7_Unknown0F_Input" FormatString="0"
+                           Name="Unknown0FBox" Minimum="0" Maximum="255" VerticalAlignment="Center" Width="120" />
+          </StackPanel>
         </Grid>
+
+        <!-- Event Pointer (offset +8, u32). -->
+        <Grid ColumnDefinitions="180,*" RowDefinitions="Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Event Pointer:" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="EventHaikuFE7_EventPointer_Input" FormatString="0"
+                         Grid.Row="0" Grid.Column="1" Name="EventPointerBox" Minimum="0" Maximum="4294967295"
+                         HorizontalAlignment="Left" Width="200" Margin="0,2" />
+        </Grid>
+
+        <Button AutomationProperties.AutomationId="EventHaikuFE7_Write_Button" Name="WriteButton" Content="Write" HorizontalAlignment="Left" Margin="0,12,0,0" />
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/EventHaikuFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventHaikuFE7View.axaml.cs
@@ -1,14 +1,17 @@
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
+using FEBuilderGBA.Avalonia.Controls;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Core;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
     public partial class EventHaikuFE7View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventHaikuFE7ViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         public string ViewTitle => "Haiku (FE7)";
         public bool IsLoaded => _vm.IsLoaded;
@@ -17,8 +20,14 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
+            WriteButton.Click += Write_Click;
             Opened += (_, _) => LoadList();
         }
+
+        // OUT OF SCOPE (#947 / #7): the FE7 N1_ tutorial death-quote tables
+        // (event_haiku_tutorial_1_pointer / event_haiku_tutorial_2_pointer) use a
+        // DIFFERENT 12-byte schema and are intentionally NOT edited by this view's
+        // VM/panel. They remain a documented follow-up (see NavigateTo below).
 
         void LoadList()
         {
@@ -48,7 +57,143 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void UpdateUI()
         {
-            AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            AddrLabel.Text = $"0x{_vm.CurrentAddr:X08}";
+
+            UnitNud.Value = _vm.Unit;
+            UnitNud.NameText = _vm.Unit == 0 ? "ANY" : NameResolver.GetUnitNameAndANYByOneBasedId(_vm.Unit);
+
+            ChapterIdBox.Value = _vm.ChapterID;
+            ChapterNameLabel.Text = ResolveChapterName(_vm.ChapterID);
+
+            Unknown02Box.Value = _vm.Unknown02;
+            Unknown03Box.Value = _vm.Unknown03;
+
+            TextNud.Value = _vm.Text;
+            TextNud.NameText = _vm.Text != 0 ? NameResolver.GetTextById(_vm.Text) : "";
+
+            Unknown06Box.Value = _vm.Unknown06;
+            Unknown07Box.Value = _vm.Unknown07;
+            AchievementFlagBox.Value = _vm.AchievementFlag;
+            Unknown0EBox.Value = _vm.Unknown0E;
+            Unknown0FBox.Value = _vm.Unknown0F;
+
+            EventPointerBox.Value = _vm.EventPointer;
+        }
+
+        void Write_Click(object? sender, RoutedEventArgs e)
+        {
+            _undoService.Begin("Edit Haiku (FE7)");
+            try
+            {
+                _vm.Unit = UnitNud.Value;
+                _vm.ChapterID = (uint)(ChapterIdBox.Value ?? 0);
+                _vm.Unknown02 = (uint)(Unknown02Box.Value ?? 0);
+                _vm.Unknown03 = (uint)(Unknown03Box.Value ?? 0);
+                _vm.Text = TextNud.Value;
+                _vm.Unknown06 = (uint)(Unknown06Box.Value ?? 0);
+                _vm.Unknown07 = (uint)(Unknown07Box.Value ?? 0);
+                _vm.EventPointer = (uint)(EventPointerBox.Value ?? 0);
+                _vm.AchievementFlag = (uint)(AchievementFlagBox.Value ?? 0);
+                _vm.Unknown0E = (uint)(Unknown0EBox.Value ?? 0);
+                _vm.Unknown0F = (uint)(Unknown0FBox.Value ?? 0);
+
+                _vm.Write();
+                _undoService.Commit();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("EventHaikuFE7View.Write_Click failed: {0}", ex.Message);
+            }
+        }
+
+        // -- Chapter / map name preview (FE7 ANYFF semantics: 0x45 => ANY) ------
+
+        static string ResolveChapterName(uint chapterId)
+        {
+            var rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return "";
+            // FE7 (version < 8): 0x45 is the "ANY" sentinel
+            // (WinForms MapSettingForm.GetMapNameAndANYFF).
+            if (chapterId == 0x45) return "ANY";
+            string name = MapSettingCore.GetMapNameById(chapterId);
+            return string.IsNullOrEmpty(name) ? "" : name;
+        }
+
+        void ChapterId_ValueChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            uint id = (uint)(ChapterIdBox.Value ?? 0);
+            ChapterNameLabel.Text = ResolveChapterName(id);
+        }
+
+        // -- Unit / Text helpers ----------------------------------------------
+
+        static uint UnitAddrFor(uint unitId)
+        {
+            var rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return 0;
+            if (unitId == 0) return 0; // 1-based: 0 = ANY/no unit
+            uint unitPtr = rom.RomInfo.unit_pointer;
+            if (unitPtr == 0) return 0;
+            uint baseAddr = rom.p32(unitPtr);
+            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
+            uint dataSize = rom.RomInfo.unit_datasize;
+            if (dataSize == 0) return 0;
+            if (rom.RomInfo.version == 6) baseAddr += dataSize;
+            uint entryAddr = baseAddr + (unitId - 1) * dataSize;
+            if (!U.isSafetyOffset(entryAddr, rom)) return 0;
+            if (!U.isSafetyOffset(entryAddr + dataSize - 1, rom)) return 0;
+            return entryAddr;
+        }
+
+        static uint TextRowAddrFor(uint textId)
+        {
+            var rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return 0;
+            uint ptr = rom.RomInfo.text_pointer;
+            if (ptr == 0) return 0;
+            uint baseAddr = rom.p32(ptr);
+            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
+            // Text-table ROW address = textBase + textId*4.
+            ulong addr64 = (ulong)baseAddr + (ulong)textId * 4UL;
+            if (addr64 > uint.MaxValue) return 0;
+            uint addr = (uint)addr64;
+            if (!U.isSafetyOffset(addr, rom)) return 0;
+            if (!U.isSafetyOffset(addr + 3, rom)) return 0;
+            return addr;
+        }
+
+        void Unit_Jump(object? sender, RoutedEventArgs e)
+        {
+            try { uint addr = UnitAddrFor(UnitNud.Value); if (addr != 0) WindowManager.Instance.Navigate<UnitEditorView>(addr); }
+            catch (Exception ex) { Log.Error("EventHaikuFE7View.Unit_Jump failed: {0}", ex.Message); }
+        }
+
+        async void Unit_Pick(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                uint addr = UnitAddrFor(UnitNud.Value);
+                var result = await WindowManager.Instance.PickFromEditor<UnitEditorView>(addr, this);
+                if (result != null) UnitNud.Value = (uint)result.Index + 1; // 0-based pick -> 1-based id
+            }
+            catch (Exception ex) { Log.Error("EventHaikuFE7View.Unit_Pick failed: {0}", ex.Message); }
+        }
+
+        void Unit_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
+        {
+            UnitNud.NameText = e.NewValue == 0 ? "ANY" : NameResolver.GetUnitNameAndANYByOneBasedId(e.NewValue);
+        }
+
+        void Text_Jump(object? sender, RoutedEventArgs e)
+        {
+            try { uint addr = TextRowAddrFor(TextNud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
+            catch (Exception ex) { Log.Error("EventHaikuFE7View.Text_Jump failed: {0}", ex.Message); }
+        }
+
+        void Text_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
+        {
+            TextNud.NameText = e.NewValue != 0 ? NameResolver.GetTextById(e.NewValue) : "";
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/Views/EventHaikuFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventHaikuFE7View.axaml.cs
@@ -38,7 +38,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventHaikuFE7View.LoadList failed: {0}", ex.Message);
+                Log.Error($"EventHaikuFE7View.LoadList failed: {ex.Message}");
             }
         }
 
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventHaikuFE7View.OnSelected failed: {0}", ex.Message);
+                Log.Error($"EventHaikuFE7View.OnSelected failed: {ex.Message}");
             }
         }
 
@@ -103,7 +103,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EventHaikuFE7View.Write_Click failed: {0}", ex.Message);
+                Log.Error($"EventHaikuFE7View.Write_Click failed: {ex.Message}");
             }
         }
 
@@ -126,58 +126,24 @@ namespace FEBuilderGBA.Avalonia.Views
             ChapterNameLabel.Text = ResolveChapterName(id);
         }
 
-        // -- Unit / Text helpers ----------------------------------------------
-
-        static uint UnitAddrFor(uint unitId)
-        {
-            var rom = CoreState.ROM;
-            if (rom?.RomInfo == null) return 0;
-            if (unitId == 0) return 0; // 1-based: 0 = ANY/no unit
-            uint unitPtr = rom.RomInfo.unit_pointer;
-            if (unitPtr == 0) return 0;
-            uint baseAddr = rom.p32(unitPtr);
-            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
-            uint dataSize = rom.RomInfo.unit_datasize;
-            if (dataSize == 0) return 0;
-            if (rom.RomInfo.version == 6) baseAddr += dataSize;
-            uint entryAddr = baseAddr + (unitId - 1) * dataSize;
-            if (!U.isSafetyOffset(entryAddr, rom)) return 0;
-            if (!U.isSafetyOffset(entryAddr + dataSize - 1, rom)) return 0;
-            return entryAddr;
-        }
-
-        static uint TextRowAddrFor(uint textId)
-        {
-            var rom = CoreState.ROM;
-            if (rom?.RomInfo == null) return 0;
-            uint ptr = rom.RomInfo.text_pointer;
-            if (ptr == 0) return 0;
-            uint baseAddr = rom.p32(ptr);
-            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
-            // Text-table ROW address = textBase + textId*4.
-            ulong addr64 = (ulong)baseAddr + (ulong)textId * 4UL;
-            if (addr64 > uint.MaxValue) return 0;
-            uint addr = (uint)addr64;
-            if (!U.isSafetyOffset(addr, rom)) return 0;
-            if (!U.isSafetyOffset(addr + 3, rom)) return 0;
-            return addr;
-        }
+        // -- Unit / Text handlers ---------------------------------------------
+        // Jump-address math lives in the shared EditorJumpAddressHelper (#948).
 
         void Unit_Jump(object? sender, RoutedEventArgs e)
         {
-            try { uint addr = UnitAddrFor(UnitNud.Value); if (addr != 0) WindowManager.Instance.Navigate<UnitEditorView>(addr); }
-            catch (Exception ex) { Log.Error("EventHaikuFE7View.Unit_Jump failed: {0}", ex.Message); }
+            try { uint addr = EditorJumpAddressHelper.UnitAddrFor(CoreState.ROM, UnitNud.Value); if (addr != 0) WindowManager.Instance.Navigate<UnitEditorView>(addr); }
+            catch (Exception ex) { Log.Error($"EventHaikuFE7View.Unit_Jump failed: {ex.Message}"); }
         }
 
         async void Unit_Pick(object? sender, RoutedEventArgs e)
         {
             try
             {
-                uint addr = UnitAddrFor(UnitNud.Value);
+                uint addr = EditorJumpAddressHelper.UnitAddrFor(CoreState.ROM, UnitNud.Value);
                 var result = await WindowManager.Instance.PickFromEditor<UnitEditorView>(addr, this);
                 if (result != null) UnitNud.Value = (uint)result.Index + 1; // 0-based pick -> 1-based id
             }
-            catch (Exception ex) { Log.Error("EventHaikuFE7View.Unit_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.Error($"EventHaikuFE7View.Unit_Pick failed: {ex.Message}"); }
         }
 
         void Unit_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -187,8 +153,8 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void Text_Jump(object? sender, RoutedEventArgs e)
         {
-            try { uint addr = TextRowAddrFor(TextNud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
-            catch (Exception ex) { Log.Error("EventHaikuFE7View.Text_Jump failed: {0}", ex.Message); }
+            try { uint addr = EditorJumpAddressHelper.TextRowAddrFor(CoreState.ROM, TextNud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
+            catch (Exception ex) { Log.Error($"EventHaikuFE7View.Text_Jump failed: {ex.Message}"); }
         }
 
         void Text_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/EventHaikuView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventHaikuView.axaml
@@ -11,10 +11,89 @@
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Haiku Event Editor" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
+        <Grid ColumnDefinitions="180,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
           <TextBlock AutomationProperties.AutomationId="EventHaiku_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+
+          <!-- Unit (1-based id) — IdFieldControl with Jump+Pick to UnitEditorView
+               and ANY-capable name preview (0 => "ANY"). -->
+          <controls:IdFieldControl AutomationProperties.AutomationId="EventHaiku_UnitNud_Input"
+                                   Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                                   Margin="0,2"
+                                   Name="UnitNud"
+                                   Label="Unit:"
+                                   Maximum="255"
+                                   JumpRequested="Unit_Jump"
+                                   PickRequested="Unit_Pick"
+                                   ValueChanged="Unit_ValueChanged" />
+
+          <!-- KillerUnit (offset +1). Only meaningful as a unit when the
+               "death quote add killer ID" patch is installed; otherwise it is an
+               unknown byte. Both controls live in the tree; OnSelected toggles
+               visibility based on PatchDetectionService.DeathQuoteAddKillerID. -->
+          <controls:IdFieldControl AutomationProperties.AutomationId="EventHaiku_KillerUnitNud_Input"
+                                   Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
+                                   Margin="0,2"
+                                   Name="KillerUnitNud"
+                                   Label="Killer Unit:"
+                                   Maximum="255"
+                                   JumpRequested="KillerUnit_Jump"
+                                   PickRequested="KillerUnit_Pick"
+                                   ValueChanged="KillerUnit_ValueChanged" />
+
+          <TextBlock Grid.Row="3" Grid.Column="0" Text="Killer Unit (0x01):" VerticalAlignment="Center"
+                     AutomationProperties.AutomationId="EventHaiku_KillerUnitPlainCaption_Label"
+                     Name="KillerUnitPlainCaption" />
+          <NumericUpDown AutomationProperties.AutomationId="EventHaiku_KillerUnitPlain_Input" FormatString="0"
+                         Grid.Row="3" Grid.Column="1" Name="KillerUnitPlainBox" Minimum="0" Maximum="255" Margin="0,2" />
+
+          <!-- Route (offset +2) — combo synced to numeric value.
+               WinForms L_2_COMBO: 01=序盤 / 02=エイリーク編 / 03=エフラム編 / FF=無条件. -->
+          <TextBlock Grid.Row="4" Grid.Column="0" Text="Route:" VerticalAlignment="Center" />
+          <ComboBox AutomationProperties.AutomationId="EventHaiku_Route_Combo"
+                    Grid.Row="4" Grid.Column="1" Name="RouteCombo" Margin="0,2"
+                    HorizontalAlignment="Left" Width="320"
+                    SelectionChanged="Route_SelectionChanged" />
+
+          <!-- Chapter ID (offset +3) — NumericUpDown + inline map/chapter name
+               preview honoring WinForms ANYFF semantics (FE8: 0xFF => "ANY"). -->
+          <TextBlock Grid.Row="5" Grid.Column="0" Text="Chapter ID:" VerticalAlignment="Center" />
+          <StackPanel Grid.Row="5" Grid.Column="1" Orientation="Horizontal" Spacing="8">
+            <NumericUpDown AutomationProperties.AutomationId="EventHaiku_ChapterId_Input" FormatString="0"
+                           Name="ChapterIdBox" Minimum="0" Maximum="255" VerticalAlignment="Center" Width="120"
+                           ValueChanged="ChapterId_ValueChanged" />
+            <TextBlock AutomationProperties.AutomationId="EventHaiku_ChapterName_Label"
+                       Name="ChapterNameLabel" VerticalAlignment="Center" Foreground="Gray" />
+          </StackPanel>
+
+          <!-- Achievement Flag (offset +4, u16) — flag id. -->
+          <TextBlock Grid.Row="6" Grid.Column="0" Text="Achievement Flag:" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="EventHaiku_AchievementFlag_Input" FormatString="0"
+                         Grid.Row="6" Grid.Column="1" Name="AchievementFlagBox" Minimum="0" Maximum="65535" Margin="0,2" />
+
+          <!-- Text (offset +6, u16) — IdFieldControl, Jump to text-table ROW
+               address, no Pick, inline text-content preview. -->
+          <controls:IdFieldControl AutomationProperties.AutomationId="EventHaiku_TextNud_Input"
+                                   Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2"
+                                   Margin="0,2"
+                                   Name="TextNud"
+                                   Label="Text:"
+                                   Maximum="65535"
+                                   ShowPick="False"
+                                   JumpRequested="Text_Jump"
+                                   ValueChanged="Text_ValueChanged" />
         </Grid>
+
+        <!-- Event Pointer (offset +8, u32) — WinForms: a haiku entry uses
+             EITHER a text id OR a new event. -->
+        <Grid ColumnDefinitions="180,*" RowDefinitions="Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Event Pointer:" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="EventHaiku_EventPointer_Input" FormatString="0"
+                         Grid.Row="0" Grid.Column="1" Name="EventPointerBox" Minimum="0" Maximum="4294967295"
+                         HorizontalAlignment="Left" Width="200" Margin="0,2" />
+        </Grid>
+
+        <Button AutomationProperties.AutomationId="EventHaiku_Write_Button" Name="WriteButton" Content="Write" HorizontalAlignment="Left" Margin="0,12,0,0" />
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/EventHaikuView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventHaikuView.axaml.cs
@@ -31,7 +31,10 @@ namespace FEBuilderGBA.Avalonia.Views
         public EventHaikuView()
         {
             InitializeComponent();
-            foreach (var c in RouteChoices) RouteCombo.Items.Add(c.Label);
+            // ComboBox.Items strings are NOT picked up by the logical-tree
+            // translation pass, so route each Route label through R._() so ja/zh
+            // locales localize them (#948 review; same pattern as ClassOPDemoView).
+            foreach (var c in RouteChoices) RouteCombo.Items.Add(R._(c.Label));
             EntryList.SelectedAddressChanged += OnSelected;
             WriteButton.Click += Write_Click;
             Opened += (_, _) => LoadList();
@@ -46,7 +49,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventHaikuView.LoadList failed: {0}", ex.Message);
+                Log.Error($"EventHaikuView.LoadList failed: {ex.Message}");
             }
         }
 
@@ -59,7 +62,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventHaikuView.OnSelected failed: {0}", ex.Message);
+                Log.Error($"EventHaikuView.OnSelected failed: {ex.Message}");
             }
         }
 
@@ -118,7 +121,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EventHaikuView.Write_Click failed: {0}", ex.Message);
+                Log.Error($"EventHaikuView.Write_Click failed: {ex.Message}");
             }
         }
 
@@ -178,57 +181,23 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         // -- Unit IdField handlers --------------------------------------------
-
-        static uint UnitAddrFor(uint unitId)
-        {
-            var rom = CoreState.ROM;
-            if (rom?.RomInfo == null) return 0;
-            if (unitId == 0) return 0; // 1-based: 0 = ANY/no unit
-            uint unitPtr = rom.RomInfo.unit_pointer;
-            if (unitPtr == 0) return 0;
-            uint baseAddr = rom.p32(unitPtr);
-            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
-            uint dataSize = rom.RomInfo.unit_datasize;
-            if (dataSize == 0) return 0;
-            if (rom.RomInfo.version == 6) baseAddr += dataSize;
-            uint entryAddr = baseAddr + (unitId - 1) * dataSize;
-            if (!U.isSafetyOffset(entryAddr, rom)) return 0;
-            if (!U.isSafetyOffset(entryAddr + dataSize - 1, rom)) return 0;
-            return entryAddr;
-        }
-
-        static uint TextRowAddrFor(uint textId)
-        {
-            var rom = CoreState.ROM;
-            if (rom?.RomInfo == null) return 0;
-            uint ptr = rom.RomInfo.text_pointer;
-            if (ptr == 0) return 0;
-            uint baseAddr = rom.p32(ptr);
-            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
-            // Text-table ROW address = textBase + textId*4 (one pointer per id).
-            ulong addr64 = (ulong)baseAddr + (ulong)textId * 4UL;
-            if (addr64 > uint.MaxValue) return 0;
-            uint addr = (uint)addr64;
-            if (!U.isSafetyOffset(addr, rom)) return 0;
-            if (!U.isSafetyOffset(addr + 3, rom)) return 0;
-            return addr;
-        }
+        // Jump-address math lives in the shared EditorJumpAddressHelper (#948).
 
         void Unit_Jump(object? sender, RoutedEventArgs e)
         {
-            try { uint addr = UnitAddrFor(UnitNud.Value); if (addr != 0) WindowManager.Instance.Navigate<UnitEditorView>(addr); }
-            catch (Exception ex) { Log.Error("EventHaikuView.Unit_Jump failed: {0}", ex.Message); }
+            try { uint addr = EditorJumpAddressHelper.UnitAddrFor(CoreState.ROM, UnitNud.Value); if (addr != 0) WindowManager.Instance.Navigate<UnitEditorView>(addr); }
+            catch (Exception ex) { Log.Error($"EventHaikuView.Unit_Jump failed: {ex.Message}"); }
         }
 
         async void Unit_Pick(object? sender, RoutedEventArgs e)
         {
             try
             {
-                uint addr = UnitAddrFor(UnitNud.Value);
+                uint addr = EditorJumpAddressHelper.UnitAddrFor(CoreState.ROM, UnitNud.Value);
                 var result = await WindowManager.Instance.PickFromEditor<UnitEditorView>(addr, this);
                 if (result != null) UnitNud.Value = (uint)result.Index + 1; // 0-based pick -> 1-based id
             }
-            catch (Exception ex) { Log.Error("EventHaikuView.Unit_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.Error($"EventHaikuView.Unit_Pick failed: {ex.Message}"); }
         }
 
         void Unit_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -238,19 +207,19 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void KillerUnit_Jump(object? sender, RoutedEventArgs e)
         {
-            try { uint addr = UnitAddrFor(KillerUnitNud.Value); if (addr != 0) WindowManager.Instance.Navigate<UnitEditorView>(addr); }
-            catch (Exception ex) { Log.Error("EventHaikuView.KillerUnit_Jump failed: {0}", ex.Message); }
+            try { uint addr = EditorJumpAddressHelper.UnitAddrFor(CoreState.ROM, KillerUnitNud.Value); if (addr != 0) WindowManager.Instance.Navigate<UnitEditorView>(addr); }
+            catch (Exception ex) { Log.Error($"EventHaikuView.KillerUnit_Jump failed: {ex.Message}"); }
         }
 
         async void KillerUnit_Pick(object? sender, RoutedEventArgs e)
         {
             try
             {
-                uint addr = UnitAddrFor(KillerUnitNud.Value);
+                uint addr = EditorJumpAddressHelper.UnitAddrFor(CoreState.ROM, KillerUnitNud.Value);
                 var result = await WindowManager.Instance.PickFromEditor<UnitEditorView>(addr, this);
                 if (result != null) KillerUnitNud.Value = (uint)result.Index + 1;
             }
-            catch (Exception ex) { Log.Error("EventHaikuView.KillerUnit_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.Error($"EventHaikuView.KillerUnit_Pick failed: {ex.Message}"); }
         }
 
         void KillerUnit_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -260,8 +229,8 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void Text_Jump(object? sender, RoutedEventArgs e)
         {
-            try { uint addr = TextRowAddrFor(TextNud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
-            catch (Exception ex) { Log.Error("EventHaikuView.Text_Jump failed: {0}", ex.Message); }
+            try { uint addr = EditorJumpAddressHelper.TextRowAddrFor(CoreState.ROM, TextNud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
+            catch (Exception ex) { Log.Error($"EventHaikuView.Text_Jump failed: {ex.Message}"); }
         }
 
         void Text_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/EventHaikuView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventHaikuView.axaml.cs
@@ -1,14 +1,29 @@
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
+using FEBuilderGBA.Avalonia.Controls;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Core;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
     public partial class EventHaikuView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventHaikuViewModel _vm = new();
+        readonly UndoService _undoService = new();
+
+        // Route choices mirror WinForms EventHaikuForm L_2_COMBO
+        // (01=序盤 / 02=エイリーク編 / 03=エフラム編 / FF=無条件). Each item maps a
+        // numeric Route byte to a label; the combo selection is kept in sync with
+        // the byte value (an unknown byte selects no item, like WinForms).
+        static readonly (uint Value, string Label)[] RouteChoices =
+        {
+            (0x01u, "0x01 Prologue / Early"),
+            (0x02u, "0x02 Eirika Route"),
+            (0x03u, "0x03 Ephraim Route"),
+            (0xFFu, "0xFF Unconditional"),
+        };
 
         public string ViewTitle => "Haiku Event Editor";
         public bool IsLoaded => _vm.IsLoaded;
@@ -16,7 +31,9 @@ namespace FEBuilderGBA.Avalonia.Views
         public EventHaikuView()
         {
             InitializeComponent();
+            foreach (var c in RouteChoices) RouteCombo.Items.Add(c.Label);
             EntryList.SelectedAddressChanged += OnSelected;
+            WriteButton.Click += Write_Click;
             Opened += (_, _) => LoadList();
         }
 
@@ -46,9 +63,210 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
+        /// <summary>True when the FE8 "death quote add killer ID" patch is
+        /// installed, so offset +1 is a real killer unit id (not an unknown byte).</summary>
+        static bool KillerIdEnabled() => PatchDetectionService.Instance.DeathQuoteAddKillerID;
+
         void UpdateUI()
         {
-            AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            AddrLabel.Text = $"0x{_vm.CurrentAddr:X08}";
+
+            UnitNud.Value = _vm.Unit;
+            UnitNud.NameText = _vm.Unit == 0 ? "ANY" : NameResolver.GetUnitNameAndANYByOneBasedId(_vm.Unit);
+
+            // KillerUnit: patch-gated. Killer-id mode shows a unit field; otherwise
+            // a plain "unknown byte" NumericUpDown (do NOT imply killer semantics
+            // on vanilla ROMs — #947 plan).
+            bool killer = KillerIdEnabled();
+            KillerUnitNud.IsVisible = killer;
+            KillerUnitPlainCaption.IsVisible = !killer;
+            KillerUnitPlainBox.IsVisible = !killer;
+            KillerUnitNud.Value = _vm.KillerUnit;
+            KillerUnitNud.NameText = (_vm.KillerUnit == 0) ? "ANY" : NameResolver.GetUnitNameAndANYByOneBasedId(_vm.KillerUnit);
+            KillerUnitPlainBox.Value = _vm.KillerUnit;
+
+            SetRouteCombo(_vm.Route);
+
+            ChapterIdBox.Value = _vm.ChapterID;
+            ChapterNameLabel.Text = ResolveChapterName(_vm.ChapterID);
+
+            AchievementFlagBox.Value = _vm.AchievementFlag;
+
+            TextNud.Value = _vm.Text;
+            TextNud.NameText = _vm.Text != 0 ? NameResolver.GetTextById(_vm.Text) : "";
+
+            EventPointerBox.Value = _vm.EventPointer;
+        }
+
+        void Write_Click(object? sender, RoutedEventArgs e)
+        {
+            _undoService.Begin("Edit Haiku Event");
+            try
+            {
+                _vm.Unit = UnitNud.Value;
+                // Killer-id mode reads the unit field; otherwise the plain box.
+                _vm.KillerUnit = KillerIdEnabled() ? KillerUnitNud.Value : (uint)(KillerUnitPlainBox.Value ?? 0);
+                _vm.Route = ReadRouteCombo();
+                _vm.ChapterID = (uint)(ChapterIdBox.Value ?? 0);
+                _vm.AchievementFlag = (uint)(AchievementFlagBox.Value ?? 0);
+                _vm.Text = TextNud.Value;
+                _vm.EventPointer = (uint)(EventPointerBox.Value ?? 0);
+
+                _vm.Write();
+                _undoService.Commit();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("EventHaikuView.Write_Click failed: {0}", ex.Message);
+            }
+        }
+
+        // -- Route combo <-> numeric value sync --------------------------------
+
+        bool _routeSync;
+
+        void SetRouteCombo(uint value)
+        {
+            _routeSync = true;
+            try
+            {
+                int idx = -1;
+                for (int i = 0; i < RouteChoices.Length; i++)
+                {
+                    if (RouteChoices[i].Value == value) { idx = i; break; }
+                }
+                RouteCombo.SelectedIndex = idx; // -1 = unknown byte, no item
+            }
+            finally { _routeSync = false; }
+        }
+
+        uint ReadRouteCombo()
+        {
+            int idx = RouteCombo.SelectedIndex;
+            if (idx >= 0 && idx < RouteChoices.Length)
+                return RouteChoices[idx].Value;
+            // No combo selection (unknown byte) — preserve whatever the VM holds.
+            return _vm.Route;
+        }
+
+        void Route_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_routeSync) return;
+            // Keep the VM in sync so a Write without re-selecting still persists.
+            _vm.Route = ReadRouteCombo();
+        }
+
+        // -- Chapter / map name preview (ANYFF semantics) ----------------------
+
+        /// <summary>Resolve a chapter id to a name preview. FE8 renders 0xFF as
+        /// "ANY" (WinForms MapSettingForm.GetMapNameAndANYFF).</summary>
+        static string ResolveChapterName(uint chapterId)
+        {
+            var rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return "";
+            // FE8 (version >= 8): 0xFF is the "ANY" sentinel.
+            if (chapterId == 0xFF) return "ANY";
+            string name = MapSettingCore.GetMapNameById(chapterId);
+            return string.IsNullOrEmpty(name) ? "" : name;
+        }
+
+        void ChapterId_ValueChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            uint id = (uint)(ChapterIdBox.Value ?? 0);
+            ChapterNameLabel.Text = ResolveChapterName(id);
+        }
+
+        // -- Unit IdField handlers --------------------------------------------
+
+        static uint UnitAddrFor(uint unitId)
+        {
+            var rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return 0;
+            if (unitId == 0) return 0; // 1-based: 0 = ANY/no unit
+            uint unitPtr = rom.RomInfo.unit_pointer;
+            if (unitPtr == 0) return 0;
+            uint baseAddr = rom.p32(unitPtr);
+            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
+            uint dataSize = rom.RomInfo.unit_datasize;
+            if (dataSize == 0) return 0;
+            if (rom.RomInfo.version == 6) baseAddr += dataSize;
+            uint entryAddr = baseAddr + (unitId - 1) * dataSize;
+            if (!U.isSafetyOffset(entryAddr, rom)) return 0;
+            if (!U.isSafetyOffset(entryAddr + dataSize - 1, rom)) return 0;
+            return entryAddr;
+        }
+
+        static uint TextRowAddrFor(uint textId)
+        {
+            var rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return 0;
+            uint ptr = rom.RomInfo.text_pointer;
+            if (ptr == 0) return 0;
+            uint baseAddr = rom.p32(ptr);
+            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
+            // Text-table ROW address = textBase + textId*4 (one pointer per id).
+            ulong addr64 = (ulong)baseAddr + (ulong)textId * 4UL;
+            if (addr64 > uint.MaxValue) return 0;
+            uint addr = (uint)addr64;
+            if (!U.isSafetyOffset(addr, rom)) return 0;
+            if (!U.isSafetyOffset(addr + 3, rom)) return 0;
+            return addr;
+        }
+
+        void Unit_Jump(object? sender, RoutedEventArgs e)
+        {
+            try { uint addr = UnitAddrFor(UnitNud.Value); if (addr != 0) WindowManager.Instance.Navigate<UnitEditorView>(addr); }
+            catch (Exception ex) { Log.Error("EventHaikuView.Unit_Jump failed: {0}", ex.Message); }
+        }
+
+        async void Unit_Pick(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                uint addr = UnitAddrFor(UnitNud.Value);
+                var result = await WindowManager.Instance.PickFromEditor<UnitEditorView>(addr, this);
+                if (result != null) UnitNud.Value = (uint)result.Index + 1; // 0-based pick -> 1-based id
+            }
+            catch (Exception ex) { Log.Error("EventHaikuView.Unit_Pick failed: {0}", ex.Message); }
+        }
+
+        void Unit_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
+        {
+            UnitNud.NameText = e.NewValue == 0 ? "ANY" : NameResolver.GetUnitNameAndANYByOneBasedId(e.NewValue);
+        }
+
+        void KillerUnit_Jump(object? sender, RoutedEventArgs e)
+        {
+            try { uint addr = UnitAddrFor(KillerUnitNud.Value); if (addr != 0) WindowManager.Instance.Navigate<UnitEditorView>(addr); }
+            catch (Exception ex) { Log.Error("EventHaikuView.KillerUnit_Jump failed: {0}", ex.Message); }
+        }
+
+        async void KillerUnit_Pick(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                uint addr = UnitAddrFor(KillerUnitNud.Value);
+                var result = await WindowManager.Instance.PickFromEditor<UnitEditorView>(addr, this);
+                if (result != null) KillerUnitNud.Value = (uint)result.Index + 1;
+            }
+            catch (Exception ex) { Log.Error("EventHaikuView.KillerUnit_Pick failed: {0}", ex.Message); }
+        }
+
+        void KillerUnit_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
+        {
+            KillerUnitNud.NameText = e.NewValue == 0 ? "ANY" : NameResolver.GetUnitNameAndANYByOneBasedId(e.NewValue);
+        }
+
+        void Text_Jump(object? sender, RoutedEventArgs e)
+        {
+            try { uint addr = TextRowAddrFor(TextNud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
+            catch (Exception ex) { Log.Error("EventHaikuView.Text_Jump failed: {0}", ex.Message); }
+        }
+
+        void Text_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
+        {
+            TextNud.NameText = e.NewValue != 0 ? NameResolver.GetTextById(e.NewValue) : "";
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Core.Tests/MapSettingCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/MapSettingCoreTests.cs
@@ -325,6 +325,105 @@ namespace FEBuilderGBA.Core.Tests
             }
         }
 
+        // ---- GetMapNameById (#948 review: reject out-of-range / garbage) ----
+
+        [Fact]
+        public void GetMapNameById_WithNoRom_ReturnsEmpty()
+        {
+            var origRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = null;
+                Assert.Equal("", MapSettingCore.GetMapNameById(0));
+            }
+            finally
+            {
+                CoreState.ROM = origRom;
+            }
+        }
+
+        [Fact]
+        public void GetMapNameById_ValidPointerBackedEntry_ReturnsName()
+        {
+            var origRom = CoreState.ROM;
+            try
+            {
+                var rom = new ROM();
+                rom.LoadLow("test.gba", new byte[0x1000000], "BE8E01");
+                CoreState.ROM = rom;
+
+                // Map 0 at 0x200 — pointer in the first dword makes it a valid entry.
+                WriteU32(rom.Data, (int)rom.RomInfo.map_setting_pointer, 0x08000200);
+                WriteU32(rom.Data, 0x200, 0x08000300);
+
+                // A valid entry must resolve without throwing; name may be "" if the
+                // text id is 0, but the call itself must succeed (no exception, no garbage).
+                string name = MapSettingCore.GetMapNameById(0);
+                Assert.NotNull(name);
+            }
+            finally
+            {
+                CoreState.ROM = origRom;
+            }
+        }
+
+        [Fact]
+        public void GetMapNameById_OutOfRangeId_ReturnsEmpty_NotGarbage()
+        {
+            // Regression for #948: an out-of-range mapId lands on trailing data.
+            // The entry fails IsMapSettingValid, so GetMapNameById must return ""
+            // rather than reading a garbage chapter name (or throwing).
+            var origRom = CoreState.ROM;
+            try
+            {
+                var rom = new ROM();
+                rom.LoadLow("test.gba", new byte[0x1000000], "BE8E01");
+                CoreState.ROM = rom;
+
+                uint baseAddr = 0x200;
+                WriteU32(rom.Data, (int)rom.RomInfo.map_setting_pointer, 0x08000000 + baseAddr);
+                // Exactly ONE valid map (entry 0): pointer-backed first dword.
+                WriteU32(rom.Data, (int)baseAddr, 0x08000300);
+                // Entry 1 onward stays all-zero → IsMapSettingValid returns false
+                // (no pointer, zero PLISTs). A far out-of-range id resolves the same.
+                Assert.Equal("", MapSettingCore.GetMapNameById(1));
+                Assert.Equal("", MapSettingCore.GetMapNameById(50));
+            }
+            finally
+            {
+                CoreState.ROM = origRom;
+            }
+        }
+
+        [Fact]
+        public void GetMapNameById_IdWhoseRecordRunsPastEof_ReturnsEmpty()
+        {
+            // The record START can be in-bounds while start+datasize runs past EOF.
+            // GetMapNameById must reject it (return "") instead of letting
+            // GetMapName's u8/u16 reads throw IndexOutOfRangeException. Use a
+            // full-size ROM (so the fixed ROM-info pointers are writable) but place
+            // the map table so the entry record overruns the buffer end.
+            var origRom = CoreState.ROM;
+            try
+            {
+                var rom = new ROM();
+                rom.LoadLow("test.gba", new byte[0x1000000], "BE8E01");
+                CoreState.ROM = rom;
+
+                // datasize 148 -> base + 148 must exceed Length (0x1000000).
+                uint baseAddr = 0xFFFFF0;
+                WriteU32(rom.Data, (int)rom.RomInfo.map_setting_pointer, 0x08000000 + baseAddr);
+                WriteU32(rom.Data, (int)baseAddr, 0x08000100); // looks pointer-backed
+
+                // Must not throw; must return "" (record overruns EOF).
+                Assert.Equal("", MapSettingCore.GetMapNameById(0));
+            }
+            finally
+            {
+                CoreState.ROM = origRom;
+            }
+        }
+
         static void WriteU32(byte[] data, int offset, uint value)
         {
             data[offset + 0] = (byte)(value & 0xFF);

--- a/FEBuilderGBA.Core/MapSettingCore.cs
+++ b/FEBuilderGBA.Core/MapSettingCore.cs
@@ -197,6 +197,29 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
+        /// Resolve a map/chapter ID to a human-readable name (e.g. "Ch1 Prologue")
+        /// using <c>CoreState.ROM</c>. Mirrors WinForms
+        /// <c>MapSettingForm.GetMapName(id)</c>. Returns "" when the ID is out of
+        /// range or the ROM is unavailable. Callers that need the WinForms "ANY"
+        /// sentinel rendering (FE7/8 0xFF, FE6 over-count) should apply that guard
+        /// themselves before calling this.
+        /// </summary>
+        public static string GetMapNameById(uint mapId) => GetMapNameById(CoreState.ROM, mapId);
+
+        /// <summary>
+        /// Resolve a map/chapter ID to a human-readable name using the given ROM.
+        /// Does NOT read <c>CoreState.ROM</c>. Returns "" on any failure.
+        /// </summary>
+        public static string GetMapNameById(ROM rom, uint mapId)
+        {
+            if (rom == null || rom.RomInfo == null) return "";
+            uint addr = GetMapAddr(rom, mapId);
+            if (addr == U.NOT_FOUND || !U.isSafetyOffset(addr, rom)) return "";
+            try { return GetMapName(rom, addr); }
+            catch { return ""; }
+        }
+
+        /// <summary>
         /// Get a human-readable name for a map at the given address.
         /// </summary>
         static string GetMapName(ROM rom, uint addr)

--- a/FEBuilderGBA.Core/MapSettingCore.cs
+++ b/FEBuilderGBA.Core/MapSettingCore.cs
@@ -208,15 +208,30 @@ namespace FEBuilderGBA
 
         /// <summary>
         /// Resolve a map/chapter ID to a human-readable name using the given ROM.
-        /// Does NOT read <c>CoreState.ROM</c>. Returns "" on any failure.
+        /// Does NOT read <c>CoreState.ROM</c>. Returns "" for an out-of-range ID,
+        /// a table-terminator/garbage entry, an entry whose record extends past
+        /// EOF, or an unavailable ROM.
         /// </summary>
         public static string GetMapNameById(ROM rom, uint mapId)
         {
             if (rom == null || rom.RomInfo == null) return "";
+
             uint addr = GetMapAddr(rom, mapId);
             if (addr == U.NOT_FOUND || !U.isSafetyOffset(addr, rom)) return "";
-            try { return GetMapName(rom, addr); }
-            catch { return ""; }
+
+            // GetMapAddr only bounds-checks the START of the record, so an
+            // out-of-range mapId can land on trailing data (a garbage chapter
+            // name) or a record that runs past EOF (GetMapName's u8/u16 reads
+            // would then throw). Require the WHOLE record to be in-bounds AND
+            // pass the same terminator/safety heuristic the map-settings list
+            // builder uses, so the doc's "returns '' for out-of-range" holds and
+            // GetMapName cannot throw (no bare catch needed).
+            uint dataSize = rom.RomInfo.map_setting_datasize;
+            if (dataSize == 0) return "";
+            if ((ulong)addr + dataSize > (ulong)rom.Data.Length) return "";
+            if (!IsMapSettingValid(rom, addr)) return "";
+
+            return GetMapName(rom, addr);
         }
 
         /// <summary>

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -1481,6 +1481,18 @@ Change ポインタ:
 :Route:
 ルート
 
+:0x01 Prologue / Early:
+0x01 序盤
+
+:0x02 Eirika Route:
+0x02 エイリーク編
+
+:0x03 Ephraim Route:
+0x03 エフラム編
+
+:0xFF Unconditional:
+0xFF 無条件
+
 :Achievement Flag:
 達成フラグ
 

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -1478,6 +1478,24 @@ Change ポインタ:
 :Chapter ID:
 ワープする章
 
+:Route:
+ルート
+
+:Achievement Flag:
+達成フラグ
+
+:Killer Unit (0x01):
+殺害者 (0x01)
+
+:Unknown (0x0A):
+不明 (0x0A)
+
+:Unknown (0x0B):
+不明 (0x0B)
+
+:Unknown (0x0E):
+不明 (0x0E)
+
 :Chapter Image Ptr:
 章 画像 Ptr:
 

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -15959,6 +15959,18 @@ CSA魔法创建器
 :Route:
 路线
 
+:0x01 Prologue / Early:
+0x01 序盘
+
+:0x02 Eirika Route:
+0x02 艾里克线
+
+:0x03 Ephraim Route:
+0x03 艾夫拉姆线
+
+:0xFF Unconditional:
+0xFF 无条件
+
 :Achievement Flag:
 达成标志
 

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -15956,6 +15956,24 @@ CSA魔法创建器
 :Chapter ID:
 章节ID:
 
+:Route:
+路线
+
+:Achievement Flag:
+达成标志
+
+:Killer Unit (0x01):
+击杀者 (0x01)
+
+:Unknown (0x0A):
+未知 (0x0A)
+
+:Unknown (0x0B):
+未知 (0x0B)
+
+:Unknown (0x0E):
+未知 (0x0E)
+
 :Chapter Image Ptr:
 章节图像指针:
 


### PR DESCRIPTION
## Summary

Bug #7 from the 2026-06-04 QA sweep (issue #947): the **Haiku Event Editor** detail panel was a stub (only "Address:" shown) even though the view-models were fully implemented. All **three** variants were stubs. This builds out the detail panels for `EventHaikuView` (FE8), `EventHaikuFE6View`, and `EventHaikuFE7View`, binding every VM field, mirroring WinForms `EventHaikuForm`/`FE6`/`FE7`.

## What was built (every VM field, per the #947 plan review)
- **FE8 (7 fields):** Unit (`IdFieldControl`→UnitEditor, ANY-capable name), Killer Unit (**patch-gated** — unit field only when `PatchUtil.DeathQuoteAddKillerID` is installed, else plain byte), Route (**combo** with the WinForms `L_2_COMBO` choices 0x01/0x02/0x03/0xFF synced to the byte), Chapter ID (numeric + map-name preview, `0xFF`→ANY), Achievement Flag, Text (`IdFieldControl ShowPick=False`, **Jump → text-table row `textBase+id*4`**, content preview), Event Pointer.
- **FE6 (13 fields):** Unit, Chapter ID(+preview, `ANYIFOVER`), Unknown02/03/06/07/0A/0B/0E/0F, DeathText & FinalChapterText (`IdFieldControl`, jump-to-row), Achievement Flag.
- **FE7 (11 fields):** Unit, Chapter ID(+preview, `0x45`→ANY), Unknown02/03/06/07/0E/0F, Text (jump-to-row), Event Pointer, Achievement Flag.
- Each panel has a **Write** button wrapped in the view's `UndoService`.

Two minimal in-scope Core helpers the plan anticipated: `PatchDetectionService.DeathQuoteAddKillerID` (real killer gating, not a TODO) and `MapSettingCore.GetMapNameById` (chapter-name preview).

**Out of scope (documented follow-up):** the FE7 `N1_` tutorial death-quote tables (`event_haiku_tutorial_1/2_pointer`).

## Scope
Closes the #7 portion of #947.
- `FEBuilderGBA.Avalonia/Views/EventHaikuView.axaml(.cs)` + `EventHaikuFE6View` + `EventHaikuFE7View`
- `FEBuilderGBA.Avalonia/Services/PatchDetectionService.cs` (+ DeathQuoteAddKillerID), `FEBuilderGBA.Core/MapSettingCore.cs` (+ GetMapNameById)
- `FEBuilderGBA.Avalonia.Tests/EventHaikuDetailPanelTests.cs` (12 tests), `config/translate/{ja,zh}` (new labels)

## Screenshots

### FE8 (`EventHaikuView`)
| Before (stub — only "Address:") | After (full panel) |
|---|---|
| ![b](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/bugsweep/bug07-haiku-stub.png?raw=1) | ![a](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug07-haiku-fe8-after.png) |

### FE6 / FE7 (similar cases, also completed)
| FE6 (`EventHaikuFE6View`) | FE7 (`EventHaikuFE7View`) |
|---|---|
| ![fe6](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug07-haiku-fe6-after.png) | ![fe7](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug07-haiku-fe7-after.png) |

FE8 after: Unit 104 (オニール), Killer Unit plain byte (patch absent), Route "0xFF Unconditional", Chapter ID 0 → ルネス陥落, Flag 2, Text 2263 → なんだと・・・？, Write.

## GUI Test Report

| Test | Result |
|------|--------|
| FE8 Haiku (FE8J): all 7 fields populated with correct controls (Unit picker, Route combo, Chapter map-name, Text jump+preview) | ✅ PASS |
| FE6 Haiku (FE6): all 13 fields populated; FinalChapterText preview | ✅ PASS |
| FE7 Haiku (FE7J): all 11 fields populated; Chapter 0x45 → "ANY"; Text preview | ✅ PASS |
| KillerUnit shown as plain byte on vanilla FE8J (patch absent) — no false killer semantics | ✅ PASS |
| `validate-automation-ids.ps1` → PASSED (0 warnings) | ✅ PASS |
| Full `FEBuilderGBA.Avalonia.Tests` (7416 passed / 0 failed / 3 skipped, incl. 12 new) | ✅ PASS |

Render: offscreen `--screenshot-all`. ROMs: FE8J / FE6 / FE7J.

## Test plan
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` — full suite green (7416/0/3)
- [x] 12 new `EventHaikuDetailPanelTests` (field coverage, Route mapping, ANY chapter, jump-to-row addr)
- [x] AutomationId validator passes (named TextBlocks included)
- [x] After-screenshots of all 3 actual editors confirm populated panels
- [x] FE7 tutorial tables explicitly out of scope (documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Code 2.1.162 · model claude-opus-4-8[1m]
