### PR TITLE
feat(avalonia): enable the Text Editor Translate tab wired to TranslateManage (#12)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/TextViewerParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/TextViewerParityTests.cs
@@ -9,7 +9,8 @@
 //   - Search Tools tab: address-bar widgets (Read Start Address / Read Count /
 //     Size / Filter / Reload), Search Free Area button, status label.
 //   - Import/Export tab: filter combo + checkbox + limit text (DISABLED stubs).
-//   - Translate tab: from/to combos + Translate button (DISABLED stubs).
+//   - Translate tab: from/to combos populated from the shared ToolTranslateROM
+//     language arrays + ENABLED Translate button (#947 bug #12).
 //   - References tab: cross-references list, Add Reference button (DISABLED),
 //     status label.
 //   - Empty navigation manifest (no WF-side outgoing jumps wired by this PR).
@@ -211,33 +212,89 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.NotNull(FindByAutomationIdAny(view, "TextViewer_Translate_Tab"));
         }
 
+        // #947 bug #12: the Translate tab is no longer a disabled stub — the
+        // combos are enabled + populated from the shared ToolTranslateROM
+        // language arrays and the Translate button is enabled.
+
         [AvaloniaFact]
-        public void View_Hosts_TranslateFrom_Combo_DisabledByDefault()
+        public void View_Hosts_TranslateFrom_Combo_EnabledAndPopulated()
         {
             var view = new TextViewerView();
             var combo = FindByAutomationId<ComboBox>(view, "TextViewer_TranslateFrom_Combo");
             Assert.NotNull(combo);
-            Assert.False(combo!.IsEnabled);
+            Assert.True(combo!.IsEnabled);
             Assert.NotNull(FindByAutomationIdAny(view, "TextViewer_TranslateFromPrefix_Label"));
+
+            // Populated from the SHARED FromLanguageItemsRaw (3 entries) — never
+            // a duplicated local list.
+            var items = combo.ItemsSource?.Cast<object>().ToList();
+            Assert.NotNull(items);
+            Assert.Equal(ToolTranslateROMViewModel.FromLanguageItemsRaw.Length, items!.Count);
+            Assert.Equal(3, items.Count);
+            // Default index resolves to a real selection.
+            Assert.InRange(combo.SelectedIndex, 0, items.Count - 1);
         }
 
         [AvaloniaFact]
-        public void View_Hosts_TranslateTo_Combo_DisabledByDefault()
+        public void View_Hosts_TranslateTo_Combo_EnabledAndPopulated()
         {
             var view = new TextViewerView();
             var combo = FindByAutomationId<ComboBox>(view, "TextViewer_TranslateTo_Combo");
             Assert.NotNull(combo);
-            Assert.False(combo!.IsEnabled);
+            Assert.True(combo!.IsEnabled);
             Assert.NotNull(FindByAutomationIdAny(view, "TextViewer_TranslateToPrefix_Label"));
+
+            // Populated from the SHARED ToLanguageItemsRaw (11 entries).
+            var items = combo.ItemsSource?.Cast<object>().ToList();
+            Assert.NotNull(items);
+            Assert.Equal(ToolTranslateROMViewModel.ToLanguageItemsRaw.Length, items!.Count);
+            Assert.Equal(11, items.Count);
+            Assert.InRange(combo.SelectedIndex, 0, items.Count - 1);
         }
 
         [AvaloniaFact]
-        public void View_Hosts_Translate_Button_DisabledByDefault()
+        public void View_Hosts_Translate_Button_Enabled()
         {
             var view = new TextViewerView();
             var btn = FindByAutomationId<Button>(view, "TextViewer_Translate_Button");
             Assert.NotNull(btn);
-            Assert.False(btn!.IsEnabled);
+            Assert.True(btn!.IsEnabled);
+        }
+
+        [AvaloniaFact]
+        public void View_Hosts_TranslateStatus_Label()
+        {
+            var view = new TextViewerView();
+            Assert.NotNull(FindByAutomationIdAny(view, "TextViewer_TranslateStatus_Label"));
+        }
+
+        [Fact]
+        public void TranslateCombos_Use_Shared_RawArrays_With_ParseableCodes()
+        {
+            // The view MUST reuse the same canonical language arrays as the
+            // ROM↔ROM translate tool (single source of truth). Verify the
+            // expected counts AND that ParseLanguageKey extracts the expected
+            // language code from a sample item's `code=label` prefix.
+            Assert.Equal(3, ToolTranslateROMViewModel.FromLanguageItemsRaw.Length);
+            Assert.Equal(11, ToolTranslateROMViewModel.ToLanguageItemsRaw.Length);
+
+            Assert.Equal("ja", ToolTranslateROMCore.ParseLanguageKey(ToolTranslateROMViewModel.FromLanguageItemsRaw[0]));
+            Assert.Equal("en", ToolTranslateROMCore.ParseLanguageKey(ToolTranslateROMViewModel.FromLanguageItemsRaw[1]));
+            Assert.Equal("zh-CN", ToolTranslateROMCore.ParseLanguageKey(ToolTranslateROMViewModel.FromLanguageItemsRaw[2]));
+
+            Assert.Equal("ja", ToolTranslateROMCore.ParseLanguageKey(ToolTranslateROMViewModel.ToLanguageItemsRaw[0]));
+            Assert.Equal("zh-TW", ToolTranslateROMCore.ParseLanguageKey(ToolTranslateROMViewModel.ToLanguageItemsRaw[3]));
+        }
+
+        [Fact]
+        public void TranslateDefaultIndexes_Resolve_InRange()
+        {
+            // The view selects defaults via the SAME CalcDefaultLanguageIndexes
+            // logic. Verify the resolved indexes are valid for both arrays.
+            var (from, to) = ToolTranslateROMViewModel.CalcDefaultLanguageIndexes(
+                isMultibyte: false, CoreState.TextEncoding, CoreState.Language ?? "en");
+            Assert.InRange(from, 0, ToolTranslateROMViewModel.FromLanguageItemsRaw.Length - 1);
+            Assert.InRange(to, 0, ToolTranslateROMViewModel.ToLanguageItemsRaw.Length - 1);
         }
 
         // ---- References tab ----

--- a/FEBuilderGBA.Avalonia.Tests/TextViewerTranslateTabScreenshotTest.cs
+++ b/FEBuilderGBA.Avalonia.Tests/TextViewerTranslateTabScreenshotTest.cs
@@ -1,0 +1,194 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using global::Avalonia;
+using global::Avalonia.Controls;
+using global::Avalonia.Headless.XUnit;
+using global::Avalonia.Media.Imaging;
+using global::Avalonia.Threading;
+using global::Avalonia.VisualTree;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// #947 bug #12: render the Avalonia <see cref="TextViewerView"/>'s
+    /// <c>Translate</c> tab to a PNG that proves the tab is no longer a disabled
+    /// stub — the two language combos are POPULATED (3 from-langs / 11 to-langs)
+    /// and the Translate button is ENABLED. Headless RenderTargetBitmap so it
+    /// works on locked desktops and in CI (the <c>--screenshot-all</c> CLI render
+    /// only captures the first/Edit tab, and MCP computer-use needs an unlocked
+    /// interactive desktop). Mirrors the proven render pattern in
+    /// <see cref="WorldMapImageListExpandScreenshotTest"/>.
+    ///
+    /// <para>Pinned to FE8J (the PR's reference ROM) via
+    /// <see cref="TestRomLocator.FindRom"/>; skips cleanly when the ROM isn't
+    /// present (CI without roms.zip). CoreState is snapshotted + restored in
+    /// place so this <c>[Collection("SharedState")]</c> test never leaks ROM
+    /// state into sibling tests.</para>
+    ///
+    /// <para>By default the PNG is written to a per-run temp directory so normal
+    /// runs don't dirty the repo; set <c>FEBUILDERGBA_SCREENSHOT_DIR</c> to write
+    /// it where the PR screenshot is collected (the orchestrator points it at the
+    /// ss947b temp dir). The PNG is never committed to git.</para>
+    /// </summary>
+    [Collection("SharedState")]
+    public class TextViewerTranslateTabScreenshotTest
+    {
+        readonly ITestOutputHelper _output;
+
+        public TextViewerTranslateTabScreenshotTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [AvaloniaFact]
+        public void TextViewerView_TranslateTab_EnabledPopulated_SavesScreenshot()
+        {
+            string? romPath = TestRomLocator.FindRom("FE8J");
+            if (romPath == null)
+            {
+                _output.WriteLine("SKIP: FE8J ROM not available (TestRomLocator.FindRom returned null)");
+                return;
+            }
+
+            // Snapshot CoreState so we can restore it (no shared-state leak).
+            var prevRom = CoreState.ROM;
+            var prevComment = CoreState.CommentCache;
+            var prevLint = CoreState.LintCache;
+            var prevWork = CoreState.WorkSupportCache;
+            var prevEncoder = CoreState.SystemTextEncoder;
+            var prevBaseDir = CoreState.BaseDirectory;
+            var prevServices = CoreState.Services;
+            var prevUndo = CoreState.Undo;
+
+            try
+            {
+                string assemblyDir = Path.GetDirectoryName(
+                    System.Reflection.Assembly.GetExecutingAssembly().Location) ?? ".";
+                CoreState.BaseDirectory = assemblyDir;
+                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+                string configPath = Path.Combine(assemblyDir, "config", "config.xml");
+                if (File.Exists(configPath))
+                {
+                    var config = new Config();
+                    config.Load(configPath);
+                    CoreState.Config = config;
+                }
+
+                var rom = new ROM();
+                bool ok = rom.Load(romPath, out string _);
+                if (!ok)
+                {
+                    _output.WriteLine($"SKIP: FE8J ROM failed to load from {romPath}");
+                    return;
+                }
+                CoreState.ROM = rom;
+                CoreState.CommentCache = new HeadlessEtcCache();
+                CoreState.LintCache = new HeadlessEtcCache();
+                CoreState.WorkSupportCache = new HeadlessEtcCache();
+                try { CoreState.SystemTextEncoder = new SystemTextEncoder(CoreState.TextEncoding, rom); }
+                catch { CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom); }
+                try { CoreState.FETextEncoder = new FETextEncode(); } catch { /* non-fatal */ }
+                CoreState.TextEscape ??= new TextEscape();
+                CoreState.Undo ??= new Undo();
+                CoreState.Services ??= new HeadlessAppServices();
+
+                // Build the real view; its constructor populates the Translate
+                // combos + enables the button (the code under test).
+                var view = new TextViewerView();
+
+                const int W = 900;
+                const int H = 500;
+                view.Measure(new Size(W, H));
+                view.Arrange(new Rect(0, 0, W, H));
+                Dispatcher.UIThread.RunJobs();
+
+                // Select the Translate tab so the render shows it.
+                var tabs = view.FindControl<TabControl>("EditorTabs");
+                var translateTab = view.FindControl<TabItem>("TranslateTab");
+                Assert.NotNull(tabs);
+                Assert.NotNull(translateTab);
+                tabs!.SelectedItem = translateTab;
+
+                // Settle layout so the tab content is materialized.
+                view.Measure(new Size(W, H));
+                view.Arrange(new Rect(0, 0, W, H));
+                Dispatcher.UIThread.RunJobs();
+
+                // Assert the actual feature state BEFORE we render: combos
+                // populated from the shared arrays + button enabled.
+                var fromCombo = view.FindControl<ComboBox>("TranslateFromCombo");
+                var toCombo = view.FindControl<ComboBox>("TranslateToCombo");
+                var button = view.FindControl<Button>("TranslateButton");
+                Assert.NotNull(fromCombo);
+                Assert.NotNull(toCombo);
+                Assert.NotNull(button);
+
+                int fromCount = fromCombo!.ItemsSource?.Cast<object>().Count() ?? 0;
+                int toCount = toCombo!.ItemsSource?.Cast<object>().Count() ?? 0;
+                _output.WriteLine($"From combo items: {fromCount}, To combo items: {toCount}, " +
+                    $"From.IsEnabled={fromCombo.IsEnabled}, To.IsEnabled={toCombo.IsEnabled}, " +
+                    $"Button.IsEnabled={button!.IsEnabled}, From.SelectedIndex={fromCombo.SelectedIndex}, " +
+                    $"To.SelectedIndex={toCombo.SelectedIndex}");
+                Assert.Equal(3, fromCount);
+                Assert.Equal(11, toCount);
+                Assert.True(fromCombo.IsEnabled);
+                Assert.True(toCombo.IsEnabled);
+                Assert.True(button.IsEnabled);
+                Assert.InRange(fromCombo.SelectedIndex, 0, fromCount - 1);
+                Assert.InRange(toCombo.SelectedIndex, 0, toCount - 1);
+
+                // Render the real Translate-tab visual to a PNG.
+                view.Measure(new Size(W, H));
+                view.Arrange(new Rect(0, 0, W, H));
+                Dispatcher.UIThread.RunJobs();
+
+                string outDir = ResolveScreenshotOutputDir();
+                Directory.CreateDirectory(outDir);
+                string outPath = Path.Combine(outDir, "Translate_tab_FE8J.png");
+                try
+                {
+                    using var bitmap = new RenderTargetBitmap(new PixelSize(W, H));
+                    bitmap.Render(view);
+                    bitmap.Save(outPath);
+                    _output.WriteLine($"Saved Translate-tab screenshot to: {outPath} ({new FileInfo(outPath).Length} bytes)");
+                    Assert.True(File.Exists(outPath));
+                }
+                catch (Exception ex)
+                {
+                    // The enablement assertions above already PASSED, so the
+                    // feature is proven even if the headless raster backend is
+                    // unavailable in this environment. Don't fail the test on a
+                    // render-backend hiccup.
+                    _output.WriteLine($"Headless render failed (environment, not the #12 fix): {ex.Message}");
+                }
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.CommentCache = prevComment;
+                CoreState.LintCache = prevLint;
+                CoreState.WorkSupportCache = prevWork;
+                CoreState.SystemTextEncoder = prevEncoder;
+                CoreState.BaseDirectory = prevBaseDir;
+                CoreState.Services = prevServices;
+                CoreState.Undo = prevUndo;
+            }
+        }
+
+        static string ResolveScreenshotOutputDir()
+        {
+            string? overrideDir = Environment.GetEnvironmentVariable("FEBUILDERGBA_SCREENSHOT_DIR");
+            if (!string.IsNullOrEmpty(overrideDir))
+                return overrideDir;
+            return Path.Combine(Path.GetTempPath(), "FEBuilderGBA-screenshots");
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/TextViewerTranslateTabScreenshotTest.cs
+++ b/FEBuilderGBA.Avalonia.Tests/TextViewerTranslateTabScreenshotTest.cs
@@ -1,15 +1,12 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Text;
 using global::Avalonia;
 using global::Avalonia.Controls;
 using global::Avalonia.Headless.XUnit;
 using global::Avalonia.Media.Imaging;
 using global::Avalonia.Threading;
-using global::Avalonia.VisualTree;
 using FEBuilderGBA;
-using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.Views;
 using Xunit;
 using Xunit.Abstractions;
@@ -26,11 +23,14 @@ namespace FEBuilderGBA.Avalonia.Tests
     /// interactive desktop). Mirrors the proven render pattern in
     /// <see cref="WorldMapImageListExpandScreenshotTest"/>.
     ///
-    /// <para>Pinned to FE8J (the PR's reference ROM) via
-    /// <see cref="TestRomLocator.FindRom"/>; skips cleanly when the ROM isn't
-    /// present (CI without roms.zip). CoreState is snapshotted + restored in
-    /// place so this <c>[Collection("SharedState")]</c> test never leaks ROM
-    /// state into sibling tests.</para>
+    /// <para>Pinned to FE8J (the PR's reference ROM); skips cleanly when the ROM
+    /// isn't present (CI without roms.zip). ROM loading + CoreState
+    /// snapshot/restore are delegated ENTIRELY to <see cref="RomTestHelper.WithRom"/>
+    /// (the canonical harness that captures + restores ALL of CoreState — ROM,
+    /// caches, encoders, TextEscape, Undo, BaseDirectory — and clears
+    /// version-sensitive caches on both entry and exit), so this
+    /// <c>[Collection("SharedState")]</c> test never leaks ROM state into sibling
+    /// tests.</para>
     ///
     /// <para>By default the PNG is written to a per-run temp directory so normal
     /// runs don't dirty the repo; set <c>FEBUILDERGBA_SCREENSHOT_DIR</c> to write
@@ -50,56 +50,17 @@ namespace FEBuilderGBA.Avalonia.Tests
         [AvaloniaFact]
         public void TextViewerView_TranslateTab_EnabledPopulated_SavesScreenshot()
         {
-            string? romPath = TestRomLocator.FindRom("FE8J");
-            if (romPath == null)
+            if (TestRomLocator.FindRom("FE8J") == null)
             {
                 _output.WriteLine("SKIP: FE8J ROM not available (TestRomLocator.FindRom returned null)");
                 return;
             }
 
-            // Snapshot CoreState so we can restore it (no shared-state leak).
-            var prevRom = CoreState.ROM;
-            var prevComment = CoreState.CommentCache;
-            var prevLint = CoreState.LintCache;
-            var prevWork = CoreState.WorkSupportCache;
-            var prevEncoder = CoreState.SystemTextEncoder;
-            var prevBaseDir = CoreState.BaseDirectory;
-            var prevServices = CoreState.Services;
-            var prevUndo = CoreState.Undo;
-
-            try
+            // RomTestHelper.WithRom owns the FULL CoreState snapshot/restore +
+            // cache-clearing; we add ZERO partial manual snapshot of our own
+            // (an incomplete duplicate was the #949 review finding).
+            RomTestHelper.WithRom("FE8J", () =>
             {
-                string assemblyDir = Path.GetDirectoryName(
-                    System.Reflection.Assembly.GetExecutingAssembly().Location) ?? ".";
-                CoreState.BaseDirectory = assemblyDir;
-                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-
-                string configPath = Path.Combine(assemblyDir, "config", "config.xml");
-                if (File.Exists(configPath))
-                {
-                    var config = new Config();
-                    config.Load(configPath);
-                    CoreState.Config = config;
-                }
-
-                var rom = new ROM();
-                bool ok = rom.Load(romPath, out string _);
-                if (!ok)
-                {
-                    _output.WriteLine($"SKIP: FE8J ROM failed to load from {romPath}");
-                    return;
-                }
-                CoreState.ROM = rom;
-                CoreState.CommentCache = new HeadlessEtcCache();
-                CoreState.LintCache = new HeadlessEtcCache();
-                CoreState.WorkSupportCache = new HeadlessEtcCache();
-                try { CoreState.SystemTextEncoder = new SystemTextEncoder(CoreState.TextEncoding, rom); }
-                catch { CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom); }
-                try { CoreState.FETextEncoder = new FETextEncode(); } catch { /* non-fatal */ }
-                CoreState.TextEscape ??= new TextEscape();
-                CoreState.Undo ??= new Undo();
-                CoreState.Services ??= new HeadlessAppServices();
-
                 // Build the real view; its constructor populates the Translate
                 // combos + enables the button (the code under test).
                 var view = new TextViewerView();
@@ -169,18 +130,7 @@ namespace FEBuilderGBA.Avalonia.Tests
                     // render-backend hiccup.
                     _output.WriteLine($"Headless render failed (environment, not the #12 fix): {ex.Message}");
                 }
-            }
-            finally
-            {
-                CoreState.ROM = prevRom;
-                CoreState.CommentCache = prevComment;
-                CoreState.LintCache = prevLint;
-                CoreState.WorkSupportCache = prevWork;
-                CoreState.SystemTextEncoder = prevEncoder;
-                CoreState.BaseDirectory = prevBaseDir;
-                CoreState.Services = prevServices;
-                CoreState.Undo = prevUndo;
-            }
+            });
         }
 
         static string ResolveScreenshotOutputDir()

--- a/FEBuilderGBA.Avalonia/App.axaml.cs
+++ b/FEBuilderGBA.Avalonia/App.axaml.cs
@@ -57,6 +57,14 @@ namespace FEBuilderGBA.Avalonia
         /// <summary>Directory to save screenshots. Defaults to ./screenshots beside the exe.</summary>
         public static string? ScreenshotDir { get; set; }
 
+        /// <summary>
+        /// Optional AutomationId of a <c>TabItem</c> the <c>--screenshot-all</c>
+        /// runner should select on each captured editor before rendering (so a
+        /// non-default tab is shown in the PNG). Null = capture the default tab.
+        /// Editors that don't host a matching tab are captured unchanged.
+        /// </summary>
+        public static string? ScreenshotTabAutomationId { get; set; }
+
         /// <summary>Gap-sweep mode (Phase 1 density, Phase 2 labels, …) or null if no gap-sweep flag was passed.</summary>
         public static string? GapSweepMode { get; set; }
 
@@ -1082,6 +1090,10 @@ namespace FEBuilderGBA.Avalonia
                 else if (args[i].StartsWith("--screenshot-dir="))
                 {
                     ScreenshotDir = args[i].Substring("--screenshot-dir=".Length);
+                }
+                else if (args[i].StartsWith("--screenshot-tab="))
+                {
+                    ScreenshotTabAutomationId = args[i].Substring("--screenshot-tab=".Length);
                 }
                 else if (args[i] == "--lastrom")
                 {

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
@@ -6,9 +6,11 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using global::Avalonia;
+using global::Avalonia.Automation;
 using global::Avalonia.Controls;
 using global::Avalonia.Input;
 using global::Avalonia.Interactivity;
+using global::Avalonia.LogicalTree;
 using global::Avalonia.Media.Imaging;
 using global::Avalonia.Platform.Storage;
 using global::Avalonia.Threading;
@@ -952,6 +954,16 @@ namespace FEBuilderGBA.Avalonia.Views
                         }
                         catch { /* Not all editors have SelectFirstItem */ }
 
+                        // Optionally select a specific tab (by AutomationId) so a
+                        // non-default tab is shown in the PNG. Opt-in via
+                        // --screenshot-tab=<AutomationId>; editors without a
+                        // matching tab are captured unchanged.
+                        if (!string.IsNullOrEmpty(App.ScreenshotTabAutomationId)
+                            && SelectTabByAutomationId(window, App.ScreenshotTabAutomationId!))
+                        {
+                            await Task.Delay(100); // Let the tab content realize
+                        }
+
                         // Capture screenshot via RenderTargetBitmap
                         var pixelSize = new PixelSize(
                             Math.Max((int)window.Width, 100),
@@ -988,6 +1000,33 @@ namespace FEBuilderGBA.Avalonia.Views
                 Environment.ExitCode = failed > 0 ? 1 : 0;
                 Close();
             }, DispatcherPriority.Background);
+        }
+
+        /// <summary>
+        /// Select the first <c>TabItem</c> in <paramref name="root"/> whose
+        /// <c>AutomationProperties.AutomationId</c> equals
+        /// <paramref name="automationId"/>, by walking the logical tree and
+        /// setting its parent <see cref="TabControl"/>'s <c>SelectedItem</c>.
+        /// Returns true when a matching tab was found + selected. Used by the
+        /// opt-in <c>--screenshot-tab=</c> screenshot mode.
+        /// </summary>
+        static bool SelectTabByAutomationId(Control root, string automationId)
+        {
+            foreach (var descendant in root.GetLogicalDescendants())
+            {
+                if (descendant is TabItem tab
+                    && AutomationProperties.GetAutomationId(tab) == automationId)
+                {
+                    if (tab.Parent is TabControl tc)
+                    {
+                        tc.SelectedItem = tab;
+                        return true;
+                    }
+                    tab.IsSelected = true;
+                    return true;
+                }
+            }
+            return false;
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/Views/TextViewerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/TextViewerView.axaml
@@ -157,7 +157,9 @@
         </ScrollViewer>
       </TabItem>
 
-      <!-- Tab 4: Translate — disabled stub (mirror WF translatePage) -->
+      <!-- Tab 4: Translate — online machine-translation of the selected text
+           (mirror WF translatePage). Combos are populated + defaults selected
+           in code-behind from the shared ToolTranslateROM language arrays. -->
       <TabItem Header="Translate" Name="TranslateTab" AutomationProperties.AutomationId="TextViewer_Translate_Tab">
         <ScrollViewer Margin="4">
           <StackPanel Spacing="10" Margin="8">
@@ -167,21 +169,25 @@
               <TextBlock AutomationProperties.AutomationId="TextViewer_TranslateFromPrefix_Label"
                          Text="Translate from:" VerticalAlignment="Center" Width="160" />
               <ComboBox AutomationProperties.AutomationId="TextViewer_TranslateFrom_Combo"
-                        Name="TranslateFromCombo" IsEnabled="False" Width="240"
-                        ToolTip.Tip="Out-of-scope: requires UX review of SaaS-call disclaimer" />
+                        Name="TranslateFromCombo" Width="240"
+                        ToolTip.Tip="Source language of the currently-selected text" />
             </StackPanel>
 
             <StackPanel Orientation="Horizontal" Spacing="6">
               <TextBlock AutomationProperties.AutomationId="TextViewer_TranslateToPrefix_Label"
                          Text="Translate to:" VerticalAlignment="Center" Width="160" />
               <ComboBox AutomationProperties.AutomationId="TextViewer_TranslateTo_Combo"
-                        Name="TranslateToCombo" IsEnabled="False" Width="240"
-                        ToolTip.Tip="Out-of-scope: requires UX review of SaaS-call disclaimer" />
+                        Name="TranslateToCombo" Width="240"
+                        ToolTip.Tip="Target language to translate the selected text into" />
             </StackPanel>
 
-            <Button AutomationProperties.AutomationId="TextViewer_Translate_Button"
-                    Name="TranslateButton" Content="Translate" IsEnabled="False"
-                    ToolTip.Tip="Out-of-scope: requires UX review of SaaS-call disclaimer" />
+            <StackPanel Orientation="Horizontal" Spacing="8">
+              <Button AutomationProperties.AutomationId="TextViewer_Translate_Button"
+                      Name="TranslateButton" Content="Translate"
+                      ToolTip.Tip="Translate the selected text online; the result is placed in the Edit box for review before writing" />
+              <TextBlock AutomationProperties.AutomationId="TextViewer_TranslateStatus_Label"
+                         Name="TranslateStatusLabel" VerticalAlignment="Center" Foreground="Gray" />
+            </StackPanel>
           </StackPanel>
         </ScrollViewer>
       </TabItem>

--- a/FEBuilderGBA.Avalonia/Views/TextViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/TextViewerView.axaml.cs
@@ -30,6 +30,10 @@ namespace FEBuilderGBA.Avalonia.Views
             TextList.SelectedAddressChanged += OnTextSelected;
             WriteTextButton.Click += OnWriteTextClick;
             EditTextBox.TextChanged += OnEditTextChanged;
+            // Translate tab (#947 bug #12): populate the from/to language combos
+            // from the shared ToolTranslateROM arrays + wire the Translate button.
+            PopulateTranslateCombos();
+            TranslateButton.Click += OnTranslateClick;
             // Bind the conversation viewer tab's card collection ONCE. The
             // VM mutates the same ObservableCollection in place so we never
             // need to re-wire ItemsSource again.
@@ -420,6 +424,135 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 FreeAreaStatusLabel.Text = R._("Error: {0}", ex.Message);
                 Log.Error("SearchFreeArea failed: {0}", ex.Message);
+            }
+        }
+
+        // ============================================================
+        // Translate tab (#947 bug #12)
+        // ============================================================
+
+        /// <summary>
+        /// Populate the from/to language combos from the SHARED
+        /// <see cref="ToolTranslateROMViewModel"/> language arrays (single
+        /// source of truth — never duplicated here). Display values are routed
+        /// through <c>R._(...)</c> so the visible labels follow the active UI
+        /// language while the underlying <c>code=label</c> items keep their
+        /// <c>ParseLanguageKey</c>-parseable prefix. Default indexes come from
+        /// the same <see cref="ToolTranslateROMViewModel.CalcDefaultLanguageIndexes"/>
+        /// logic as the ROM↔ROM translate tool.
+        /// </summary>
+        void PopulateTranslateCombos()
+        {
+            try
+            {
+                var fromRaw = ToolTranslateROMViewModel.FromLanguageItemsRaw;
+                var toRaw = ToolTranslateROMViewModel.ToLanguageItemsRaw;
+
+                var fromItems = new string[fromRaw.Length];
+                for (int i = 0; i < fromRaw.Length; i++) fromItems[i] = R._(fromRaw[i]);
+                var toItems = new string[toRaw.Length];
+                for (int i = 0; i < toRaw.Length; i++) toItems[i] = R._(toRaw[i]);
+
+                TranslateFromCombo.ItemsSource = fromItems;
+                TranslateToCombo.ItemsSource = toItems;
+
+                // Default selection mirrors the ROM↔ROM translate tool: derive
+                // from the current ROM multibyte flag, text encoding + UI lang.
+                var rom = CoreState.ROM;
+                bool isMultibyte = rom?.RomInfo?.is_multibyte ?? false;
+                var (from, to) = ToolTranslateROMViewModel.CalcDefaultLanguageIndexes(
+                    isMultibyte, CoreState.TextEncoding, CoreState.Language ?? "en");
+
+                if (from >= 0 && from < fromItems.Length) TranslateFromCombo.SelectedIndex = from;
+                else if (fromItems.Length > 0) TranslateFromCombo.SelectedIndex = 0;
+
+                if (to >= 0 && to < toItems.Length) TranslateToCombo.SelectedIndex = to;
+                else if (toItems.Length > 0) TranslateToCombo.SelectedIndex = 0;
+            }
+            catch (Exception ex)
+            {
+                Log.Error("TextViewerView.PopulateTranslateCombos failed: {0}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Resolve the language code (e.g. "ja", "en", "zh-CN") for the given
+        /// combo by re-parsing the RAW array entry at the selected index via
+        /// <see cref="ToolTranslateROMCore.ParseLanguageKey"/>. We parse the raw
+        /// (untranslated) item rather than the displayed text so the
+        /// <c>code=label</c> prefix is always present regardless of UI language.
+        /// </summary>
+        static string ResolveLanguageCode(ComboBox combo, string[] raw)
+        {
+            int idx = combo.SelectedIndex;
+            if (idx < 0 || idx >= raw.Length) return string.Empty;
+            return ToolTranslateROMCore.ParseLanguageKey(raw[idx]);
+        }
+
+        /// <summary>
+        /// Translate the currently-selected text from the source to the target
+        /// language and drop the result into the Edit box for review (the user
+        /// then writes it back via the existing Edit-tab Write flow). Mirrors WF
+        /// <c>TextForm.TranslateButton_Click</c>.
+        ///
+        /// NOTE: WF actually routes through <c>TranslateTextUtil.TranslateText</c>
+        /// (fixed-dictionary + control-code aware). Direct
+        /// <c>TranslateManage.Trans</c> is the accepted MVP for this tab; the
+        /// richer dictionary path is a follow-up.
+        /// </summary>
+        async void OnTranslateClick(object? sender, RoutedEventArgs e)
+        {
+            string fromCode = ResolveLanguageCode(TranslateFromCombo, ToolTranslateROMViewModel.FromLanguageItemsRaw);
+            string toCode = ResolveLanguageCode(TranslateToCombo, ToolTranslateROMViewModel.ToLanguageItemsRaw);
+
+            string text = EditTextBox.Text ?? "";
+            // No-op guards: nothing to translate, or source == target.
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                TranslateStatusLabel.Text = R._("(No text to translate)");
+                return;
+            }
+            if (string.IsNullOrEmpty(fromCode) || string.IsNullOrEmpty(toCode) || fromCode == toCode)
+            {
+                TranslateStatusLabel.Text = R._("(Source and target language are the same)");
+                return;
+            }
+
+            TranslateButton.IsEnabled = false;
+            TranslateStatusLabel.Text = R._("Translating...");
+            try
+            {
+                // TranslateManage.Trans is a SYNCHRONOUS online (Google) call —
+                // run it off the UI thread so the window stays responsive.
+                string result = await Task.Run(() => new TranslateManage().Trans(text, fromCode, toCode));
+
+                // Reject empty/garbage results — never overwrite EditTextBox with
+                // an empty or error-shaped string.
+                if (string.IsNullOrWhiteSpace(result))
+                {
+                    Log.Error("TextViewerView.OnTranslateClick: translation returned empty for {0}->{1}", fromCode, toCode);
+                    CoreState.Services?.ShowError(R._("Translation failed: the service returned no result."));
+                    return;
+                }
+
+                // Success: put the translated text in the Edit box for review.
+                // The existing OnEditTextChanged handler re-validates length.
+                EditTextBox.Text = result;
+            }
+            catch (System.Net.WebException wex)
+            {
+                Log.Error("TextViewerView.OnTranslateClick WebException: {0}", wex.Message);
+                CoreState.Services?.ShowError(R._("Google translation returned an error. You may have sent too many requests.\r\n\r\n{0}", wex.Message));
+            }
+            catch (Exception ex)
+            {
+                Log.Error("TextViewerView.OnTranslateClick failed: {0}", ex.Message);
+                CoreState.Services?.ShowError(R._("Translation failed: {0}", ex.Message));
+            }
+            finally
+            {
+                TranslateButton.IsEnabled = true;
+                TranslateStatusLabel.Text = "";
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/TextViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/TextViewerView.axaml.cs
@@ -506,13 +506,23 @@ namespace FEBuilderGBA.Avalonia.Views
             string toCode = ResolveLanguageCode(TranslateToCombo, ToolTranslateROMViewModel.ToLanguageItemsRaw);
 
             string text = EditTextBox.Text ?? "";
-            // No-op guards: nothing to translate, or source == target.
+            // No-op guards (each with a DISTINCT status so the user can tell
+            // which precondition failed):
+            //   1. nothing to translate,
+            //   2. missing/invalid language selection (e.g. a combo never got
+            //      populated or has no selection — empty parsed code),
+            //   3. source language == target language (both non-empty + equal).
             if (string.IsNullOrWhiteSpace(text))
             {
                 TranslateStatusLabel.Text = R._("(No text to translate)");
                 return;
             }
-            if (string.IsNullOrEmpty(fromCode) || string.IsNullOrEmpty(toCode) || fromCode == toCode)
+            if (string.IsNullOrEmpty(fromCode) || string.IsNullOrEmpty(toCode))
+            {
+                TranslateStatusLabel.Text = R._("(Select a source and target language)");
+                return;
+            }
+            if (fromCode == toCode)
             {
                 TranslateStatusLabel.Text = R._("(Source and target language are the same)");
                 return;

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ dotnet run --project FEBuilderGBA.Avalonia -- --rom path/to/rom.gba --data-verif
 # Capture Avalonia screenshots of all editors (saves PNGs to --screenshot-dir)
 dotnet run --project FEBuilderGBA.Avalonia -- --rom path/to/rom.gba --screenshot-all --screenshot-dir=./screenshots
 
+# Optionally select a non-default tab (by AutomationId) before each capture, so a
+# specific tab is shown in the PNG (editors without a matching tab are unchanged)
+dotnet run --project FEBuilderGBA.Avalonia -- --rom path/to/rom.gba --screenshot-all --screenshot-tab=TextViewer_Translate_Tab --screenshot-dir=./screenshots
+
 # Capture WinForms screenshots of all editors (saves PNGs for side-by-side comparison with Avalonia)
 FEBuilderGBA.exe --rom path/to/rom.gba --screenshot-all --screenshot-dir=./screenshots
 

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -8004,6 +8004,9 @@ AI用に登場人物のヒントを追加
 :(No text to translate)
 (翻訳するテキストがありません)
 
+:(Select a source and target language)
+(翻訳元と翻訳先の言語を選択してください)
+
 :(Source and target language are the same)
 (翻訳元と翻訳先の言語が同じです)
 

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -7992,6 +7992,33 @@ AI用に登場人物のヒントを追加
 :Out-of-scope: requires UX review of SaaS-call disclaimer
 範囲外: SaaS 呼び出し免責事項の UX レビューが必要
 
+:Source language of the currently-selected text
+選択中のテキストの翻訳元言語
+
+:Target language to translate the selected text into
+選択中のテキストを翻訳する先の言語
+
+:Translate the selected text online; the result is placed in the Edit box for review before writing
+選択中のテキストをオンラインで翻訳します。結果は書き込み前に確認できるよう編集ボックスに表示されます
+
+:(No text to translate)
+(翻訳するテキストがありません)
+
+:(Source and target language are the same)
+(翻訳元と翻訳先の言語が同じです)
+
+:Translating...
+翻訳中...
+
+:Translation failed: the service returned no result.
+翻訳に失敗しました: サービスから結果が返されませんでした。
+
+:Google translation returned an error. You may have sent too many requests.\r\n\r\n{0}
+Google翻訳がエラーを返しました。翻訳リクエストの送りすぎの可能性があります。\r\n\r\n{0}
+
+:Translation failed: {0}
+翻訳に失敗しました: {0}
+
 :Out-of-scope: requires UseTextIDCache.Update Core extraction
 範囲外: UseTextIDCache.Update Core 抽出が必要
 

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -21848,6 +21848,9 @@ ED 关系
 :(No text to translate)
 (没有可翻译的文本)
 
+:(Select a source and target language)
+(请选择源语言和目标语言)
+
 :(Source and target language are the same)
 (源语言与目标语言相同)
 

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -21836,6 +21836,33 @@ ED 关系
 :Out-of-scope: requires UX review of SaaS-call disclaimer
 超出范围：需要 SaaS 调用免责声明的 UX 评审
 
+:Source language of the currently-selected text
+当前所选文本的源语言
+
+:Target language to translate the selected text into
+将所选文本翻译成的目标语言
+
+:Translate the selected text online; the result is placed in the Edit box for review before writing
+在线翻译所选文本；结果会放入编辑框，便于写入前检查
+
+:(No text to translate)
+(没有可翻译的文本)
+
+:(Source and target language are the same)
+(源语言与目标语言相同)
+
+:Translating...
+正在翻译...
+
+:Translation failed: the service returned no result.
+翻译失败：服务未返回任何结果。
+
+:Google translation returned an error. You may have sent too many requests.\r\n\r\n{0}
+Google翻译返回了错误。你可能发送了过多请求。\r\n\r\n{0}
+
+:Translation failed: {0}
+翻译失败：{0}
+
 :Out-of-scope: requires UseTextIDCache.Update Core extraction
 超出范围：需要 UseTextIDCache.Update Core 提取
 


### PR DESCRIPTION
## Summary

Bug #12 from the 2026-06-04 QA sweep (issue #947): the Text Editor's **Translate** tab was hard-disabled — empty "Translate from"/"Translate to" combos and a disabled Translate button. This enables it and wires it to the existing Core translation API.

## What changed (per the #947 plan review)
- **Language combos** are populated from the SHARED parity source — `ToolTranslateROMViewModel.FromLanguageItemsRaw` (3) / `ToLanguageItemsRaw` (11) + `CalcDefaultLanguageIndexes` (default `ja=Japanese`→`en=English` on a multibyte ROM) + `ToolTranslateROMCore.ParseLanguageKey` for the `code=label` prefix — so the two translate UIs can't drift. Both combos + the button are now enabled.
- **Translate button** (`OnTranslateClick`): reads the current `EditTextBox` text; **no-ops** on empty text or `from==to`; disables the button + shows a "Translating…" status; runs `new TranslateManage().Trans(text, fromCode, toCode)` **off the UI thread** (`Task.Run`); on success puts the result into `EditTextBox` (the user reviews + Writes via the existing Edit flow — never auto-written to ROM); on `WebException`/HTTP/empty/any error it logs + `ShowError` and **leaves `EditTextBox` unchanged**; re-enables in `finally`. (The Core class is `TranslateManage`, not `TranslateManager`.) WinForms' richer `TranslateTextUtil.TranslateText` (dictionary + control-code handling) is noted as a follow-up.
- **Screenshot tooling:** added an opt-in `--screenshot-tab=<AutomationId>` flag to the existing `--screenshot-all` runner (default behavior unchanged) so per-tab PR screenshots are capturable; documented in README.

## Scope
Closes the #12 portion of #947.
- `FEBuilderGBA.Avalonia/Views/TextViewerView.axaml(.cs)`
- `FEBuilderGBA.Avalonia/App.axaml.cs` + `MainWindow.axaml.cs` (opt-in `--screenshot-tab`)
- `FEBuilderGBA.Avalonia.Tests/TextViewerParityTests.cs` + `TextViewerTranslateTabScreenshotTest.cs`
- `README.md`, `config/translate/{ja,zh}`

## Screenshots — Text Editor → Translate tab (FE8J)

| Before (combos empty + disabled, button greyed) | After (`ja=Japanese` → `en=English`, button enabled) |
|---|---|
| ![b](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/bugsweep/bug12-translate-stub.png?raw=1) | ![a](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug12-translate-after.png) |

## GUI Test Report

| Test | Result |
|------|--------|
| Translate tab (FE8J): from-combo populated (3, default `ja=Japanese`), to-combo populated (11, default `en=English`), both combos + Translate button ENABLED | ✅ PASS |
| Translate button no-ops on empty text / same source==target language | ✅ PASS (structural) |
| Translate runs `TranslateManage.Trans` off the UI thread; on WebException/error leaves `EditTextBox` unchanged | ✅ PASS (structural; live Google call not exercised in CI) |
| `validate-automation-ids.ps1` → PASSED | ✅ PASS |
| Full `FEBuilderGBA.Avalonia.Tests` (7409 passed / 0 failed / 3 skipped) | ✅ PASS |

Render: real app process via the new opt-in `--screenshot-tab=TextViewer_Translate_Tab` (Skia). ROM: `roms/FE8J.gba`.

## Test plan
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` — full suite green (7409/0/3)
- [x] `TextViewerTranslateTabScreenshotTest` + flipped `TextViewerParityTests` assert combos populated + enabled + default indexes + `ParseLanguageKey`
- [x] AutomationId validator passes
- [x] After-screenshot of the actual Translate tab (FE8J) confirms enabled+populated
- [x] Network-error path leaves the edit box unchanged (no empty/error overwrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Code 2.1.162 · model claude-opus-4-8[1m]
