### PR TITLE
feat(avalonia): migrate secondary type-ID fields to IdFieldControl (#6,#14,#21,#22,#23b)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/IdFieldMigrationTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/IdFieldMigrationTests.cs
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #950 T4 regression detector.
+//
+// Catches the regression class this migration closes: a plain <NumericUpDown>
+// used for a STRONG entity-ID field (Unit ID / Class ID / Item ID / Text ID,
+// plus the "Item N" / "Class ID N" / "Summoned Unit" forms this PR migrated)
+// instead of a composite <IdFieldControl> (hyperlink label + numeric + name
+// preview + Jump + Pick).
+//
+// Algorithm (pure XML scan over Views/*.axaml — no ROM, no Avalonia runtime):
+//   For every label element (TextBlock Text="..." / Label Content="...") whose
+//   text EXACTLY matches a strong entity-ID pattern, find the input control
+//   ADJACENT to that label:
+//     - same parent + same Grid.Row (Grid layout), OR
+//     - the immediately-following sibling element (StackPanel layout).
+//   If that input is a <NumericUpDown>, it MUST be on the per-control ALLOW-LIST
+//   (keyed by {view, controlName} with a one-line reason). An <IdFieldControl>
+//   adjacency satisfies the assertion with no allow-list entry needed.
+//
+// Anti-stale guard: every allow-list entry's control Name must still EXIST in
+// its view (as a NumericUpDown). A removed/renamed allow-listed control fails
+// the test so a stale exception cannot silently mask a future regression.
+//
+// Strong-positive ONLY: the label text must match the curated entity-ID set,
+// so probabilities / Unknown* / coords / flags / pointers (which are NOT entity
+// IDs) never trip the scanner — no allow-list churn for them.
+//
+// SCOPE: the scan covers the set of views in this #950 T4 migration slice
+// (InScopeViews). App-wide entity-ID NumericUpDowns in OTHER editors are the
+// charter of the other #950 tiers / a separate sweep — pulling them in here
+// would be scope creep AND require a large speculative allow-list. The scoped
+// scan still guarantees the regression contract for the migrated views: a
+// future dev who re-introduces a plain NumericUpDown unit/class/item/text field
+// in any of these views (or who adds a new strong-ID field without migrating
+// it) trips the test. The forward-looking allow-list keeps working the same.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    public class IdFieldMigrationTests
+    {
+        private readonly ITestOutputHelper _output;
+        public IdFieldMigrationTests(ITestOutputHelper output) => _output = output;
+
+        // ---- Strong-positive entity-ID label patterns ----
+        // Anchored, whitespace/colon-tolerant. Each pattern denotes a field that
+        // SHOULD be an IdFieldControl (unit/class/item/text picker).
+        private static readonly Regex[] StrongIdLabels = new[]
+        {
+            new Regex(@"^\s*Unit\s*ID\s*:?\s*$", RegexOptions.IgnoreCase),
+            new Regex(@"^\s*Class\s*ID\s*\d*\s*:?\s*$", RegexOptions.IgnoreCase), // Class ID, Class ID 1..5
+            new Regex(@"^\s*Item\s*ID\s*:?\s*$", RegexOptions.IgnoreCase),
+            new Regex(@"^\s*Text\s*ID\s*:?\s*$", RegexOptions.IgnoreCase),
+            new Regex(@"^\s*Item\s*[2-5]\s*:?\s*$", RegexOptions.IgnoreCase),   // Item 2..5 (B1..B4 item ids)
+            new Regex(@"^\s*Summoned\s*Unit\s*:?\s*$", RegexOptions.IgnoreCase),
+        };
+
+        // ---- In-scope view set (#950 T4) ----
+        // The views this migration slice converted. The scan asserts each of
+        // these has ZERO un-migrated strong-ID NumericUpDowns. Adding a new
+        // strong-ID field to any of these (or regressing a migrated one back to
+        // a plain NumericUpDown) fails the test.
+        private static readonly HashSet<string> InScopeViews = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "MonsterItemViewerView.axaml",       // Tier 1 — Item 2..5 (item)
+            "MonsterProbabilityViewerView.axaml",// Tier 1 — Class ID 1..5 (class)
+            "SummonUnitViewerView.axaml",        // Tier 1 — Summoned Unit (unit)
+            "ClassOPDemoView.axaml",             // Tier 2 — Display Weapon B14 (class)
+            "OPClassDemoViewerView.axaml",       // Tier 2 — Display Weapon B14 (class)
+            "OPClassDemoFE7View.axaml",          // Tier 2 — already-migrated B14 (regression guard)
+            "OPClassDemoFE7UView.axaml",         // Tier 2 — already-migrated B14 (regression guard)
+            "OPClassDemoFE8UView.axaml",         // Tier 2 — already-migrated B14 (regression guard)
+            "EventCondView.axaml",               // Tier 3 — TALK Unit 1/2 (unit) + Chest Item (item)
+        };
+
+        // ---- ALLOW-LIST ----
+        // {view file, NumericUpDown Name} → one-line reason. A strong-ID-labelled
+        // NumericUpDown listed here is intentionally NOT an IdFieldControl. After
+        // the #950 migration there should be (close to) zero entries — any future
+        // addition needs an explicit justification here.
+        //
+        // NOTE: keep this EMPTY-by-default. If a legitimate exception arises, add
+        // {file, name, reason}; the stale-guard below then enforces that the
+        // control keeps existing as a NumericUpDown.
+        private static readonly Dictionary<(string file, string name), string> AllowList =
+            new()
+            {
+                // EventCond Tutorial-panel "Text ID:" is OUT of the T4 Tier-3
+                // scope (which is TALK Unit 1/2 + OBJECT Chest Item only). It is
+                // a tutorial-text id, not one of the migrated subfields; a focused
+                // follow-up can migrate it to a TextViewer Jump (ShowPick=False).
+                { ("EventCondView.axaml", "TextIdBox"),
+                  "Tutorial Text ID — out of #950 T4 Tier-3 scope (TALK Unit/Chest only); TextViewer-Jump migration deferred." },
+            };
+
+        private static string FindProjectRoot()
+        {
+            string dir = AppDomain.CurrentDomain.BaseDirectory;
+            for (int i = 0; i < 12; i++)
+            {
+                if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln"))) return dir;
+                string? parent = Path.GetDirectoryName(dir);
+                if (parent == null || parent == dir) break;
+                dir = parent;
+            }
+            string cwd = Directory.GetCurrentDirectory();
+            for (int i = 0; i < 12; i++)
+            {
+                if (File.Exists(Path.Combine(cwd, "FEBuilderGBA.sln"))) return cwd;
+                string? parent = Path.GetDirectoryName(cwd);
+                if (parent == null || parent == cwd) break;
+                cwd = parent;
+            }
+            throw new InvalidOperationException("Could not find project root (FEBuilderGBA.sln)");
+        }
+
+        private static string ViewsDir()
+            => Path.Combine(FindProjectRoot(), "FEBuilderGBA.Avalonia", "Views");
+
+        private static string? Attr(XElement e, string localName)
+            => e.Attributes().FirstOrDefault(a => a.Name.LocalName == localName)?.Value;
+
+        private static int AttrInt(XElement e, string localName, int fallback)
+        {
+            string? v = Attr(e, localName);
+            return v != null && int.TryParse(v.Trim(), out int r) ? r : fallback;
+        }
+
+        // The display text of a label element: TextBlock.Text or Label.Content.
+        private static string? LabelText(XElement e)
+        {
+            string ln = e.Name.LocalName;
+            if (ln == "TextBlock") return Attr(e, "Text");
+            if (ln == "Label") return Attr(e, "Content");
+            return null;
+        }
+
+        private static bool IsStrongIdLabel(string text)
+            => StrongIdLabels.Any(rx => rx.IsMatch(text));
+
+        // Find the input control associated with the given label by adjacency:
+        //   1) Grid layout: a sibling under the same parent with the SAME Grid.Row.
+        //   2) StackPanel/inline layout: the immediately-following sibling element.
+        // Returns the first NumericUpDown or IdFieldControl found.
+        private static XElement? FindAdjacentInput(XElement label)
+        {
+            var parent = label.Parent;
+            if (parent == null) return null;
+            var siblings = parent.Elements().ToList();
+            int idx = siblings.IndexOf(label);
+            if (idx < 0) return null;
+
+            bool IsInput(XElement e) =>
+                e.Name.LocalName == "NumericUpDown" || e.Name.LocalName == "IdFieldControl";
+
+            // 1) Same Grid.Row (Grid layout). The attached-property attribute
+            //    serializes with LocalName "Grid.Row" (no xmlns binds "Grid").
+            //    Column-aware: when a single row holds MULTIPLE label→input
+            //    pairs (e.g. "Unit ID:" col0 + "Class ID:" col3), bind the label
+            //    to the nearest input whose Grid.Column is strictly GREATER than
+            //    the label's, choosing the smallest such column so each label
+            //    maps to its own input — not the first input on the row.
+            string? rowAttr = Attr(label, "Grid.Row");
+            if (rowAttr != null && int.TryParse(rowAttr.Trim(), out int row))
+            {
+                int labelCol = AttrInt(label, "Grid.Column", 0);
+                var sameRow = siblings
+                    .Where(s => s != label && IsInput(s) && AttrInt(s, "Grid.Row", -999) == row)
+                    .ToList();
+                if (sameRow.Count > 0)
+                {
+                    var rightOf = sameRow
+                        .Where(s => AttrInt(s, "Grid.Column", 0) > labelCol)
+                        .OrderBy(s => AttrInt(s, "Grid.Column", 0))
+                        .ToList();
+                    if (rightOf.Count > 0) return rightOf[0];
+                    // No input strictly to the right (single-pair row where the
+                    // input shares/precedes the label column) → first on the row.
+                    return sameRow[0];
+                }
+            }
+
+            // 2) Immediately-following sibling (StackPanel / inline).
+            for (int i = idx + 1; i < siblings.Count; i++)
+            {
+                if (IsInput(siblings[i])) return siblings[i];
+                // Stop at the next label so we don't bind across unrelated rows.
+                if (LabelText(siblings[i]) != null) break;
+            }
+            return null;
+        }
+
+        [Fact]
+        public void EveryStrongEntityIdField_IsIdFieldControl_OrAllowListed()
+        {
+            string viewsDir = ViewsDir();
+            Assert.True(Directory.Exists(viewsDir), $"Views dir not found: {viewsDir}");
+
+            var offenders = new List<string>();
+            // Track which allow-list entries we actually matched (anti-stale).
+            var matchedAllow = new HashSet<(string, string)>();
+
+            foreach (string path in Directory.GetFiles(viewsDir, "*.axaml", SearchOption.TopDirectoryOnly))
+            {
+                XDocument doc;
+                string file = Path.GetFileName(path);
+                if (!InScopeViews.Contains(file)) continue; // scoped to the #950 T4 slice
+                try { doc = XDocument.Load(path); }
+                catch { continue; } // non-XML/partial views are covered by other scanners
+
+                foreach (var label in doc.Descendants())
+                {
+                    string? text = LabelText(label);
+                    if (text == null || !IsStrongIdLabel(text)) continue;
+
+                    XElement? input = FindAdjacentInput(label);
+                    if (input == null) continue;                       // no adjacent input → not analyzable here
+                    if (input.Name.LocalName == "IdFieldControl") continue; // migrated → OK
+
+                    // input is a NumericUpDown adjacent to a strong-ID label.
+                    string name = Attr(input, "Name") ?? "?";
+                    var key = (file, name);
+                    if (AllowList.ContainsKey(key))
+                    {
+                        matchedAllow.Add(key);
+                        continue;
+                    }
+                    offenders.Add(
+                        $"{file}: NumericUpDown '{name}' is labelled \"{text.Trim()}\" (a strong entity-ID field) " +
+                        $"but is NOT an IdFieldControl and NOT allow-listed. Migrate it to <IdFieldControl> " +
+                        $"or add a justified AllowList entry.");
+                }
+            }
+
+            // Anti-stale: every allow-list entry must have matched a live control.
+            var stale = AllowList.Keys
+                .Where(k => !matchedAllow.Contains(k))
+                .Select(k => $"{k.file}: allow-listed NumericUpDown '{k.name}' no longer exists " +
+                             $"(stale exception — remove it or fix the control).")
+                .ToList();
+
+            if (offenders.Count > 0)
+                _output.WriteLine("Un-migrated strong entity-ID NumericUpDowns:\n" + string.Join("\n", offenders));
+            if (stale.Count > 0)
+                _output.WriteLine("Stale allow-list entries:\n" + string.Join("\n", stale));
+
+            Assert.True(stale.Count == 0,
+                "Stale IdField migration allow-list entries (control gone/renamed):\n" + string.Join("\n", stale));
+            Assert.True(offenders.Count == 0,
+                "Strong entity-ID field(s) still rendered as plain NumericUpDown (should be IdFieldControl):\n" +
+                string.Join("\n", offenders));
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/UnifiedIdFieldMigrationTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/UnifiedIdFieldMigrationTests.cs
@@ -906,6 +906,169 @@ public class UnifiedIdFieldMigrationTests
         Assert.False(pickButton!.IsVisible);
     }
 
+    // ====================================================================
+    // #950 T4 — secondary type-ID fields migrated to IdFieldControl.
+    //   Tier 1: MonsterItemViewer Item 2..5 (item), MonsterProbabilityViewer
+    //           Class ID 1..5 (class), SummonUnitViewer Summoned Unit (unit).
+    //   Tier 2: ClassOPDemo / OPClassDemoViewer Display Weapon B14 (class).
+    //   Tier 3: EventCond TALK Unit 1/2 (unit) + OBJECT Chest Item (item).
+    // ====================================================================
+
+    // ---- Tier 1: MonsterItemViewer Item 2..5 (DropRate/Unknown1..3Box) ----
+
+    [AvaloniaTheory]
+    [InlineData("DropRateBox", "Item 2:")]
+    [InlineData("Unknown1Box", "Item 3:")]
+    [InlineData("Unknown2Box", "Item 4:")]
+    [InlineData("Unknown3Box", "Item 5:")]
+    public void MonsterItemViewer_SecondaryItemBoxes_AreIdFieldControls(string name, string label)
+    {
+        var view = new MonsterItemViewerView();
+        var ctrl = view.FindControl<IdFieldControl>(name);
+        Assert.NotNull(ctrl);
+        Assert.Equal(label, ctrl!.Label);
+        Assert.True(ctrl.ShowPick); // item fields keep Pick visible
+    }
+
+    [AvaloniaTheory]
+    [InlineData("MonsterItemViewer_Item_Item2_Input")]
+    [InlineData("MonsterItemViewer_Item_Item3_Input")]
+    [InlineData("MonsterItemViewer_Item_Item4_Input")]
+    [InlineData("MonsterItemViewer_Item_Item5_Input")]
+    public void MonsterItemViewer_SecondaryItem_AutomationIdResolvesToNumericUpDownUniquely(string automationId)
+    {
+        var view = new MonsterItemViewerView();
+        view.Show();
+        try { AssertAutomationIdResolvesToNumericUpDown(view, automationId); }
+        finally { view.Close(); }
+    }
+
+    // ---- Tier 1: MonsterProbabilityViewer Class ID 1..5 -------------------
+
+    [AvaloniaTheory]
+    [InlineData("ClassId1Box", "Class ID 1:")]
+    [InlineData("ClassId2Box", "Class ID 2:")]
+    [InlineData("ClassId3Box", "Class ID 3:")]
+    [InlineData("ClassId4Box", "Class ID 4:")]
+    [InlineData("ClassId5Box", "Class ID 5:")]
+    public void MonsterProbabilityViewer_ClassIdBoxes_AreIdFieldControls(string name, string label)
+    {
+        var view = new MonsterProbabilityViewerView();
+        var ctrl = view.FindControl<IdFieldControl>(name);
+        Assert.NotNull(ctrl);
+        Assert.Equal(label, ctrl!.Label);
+        Assert.True(ctrl.ShowPick); // class fields keep Pick visible
+    }
+
+    [AvaloniaTheory]
+    [InlineData("MonsterProbabilityViewer_ClassId1_Input")]
+    [InlineData("MonsterProbabilityViewer_ClassId2_Input")]
+    [InlineData("MonsterProbabilityViewer_ClassId3_Input")]
+    [InlineData("MonsterProbabilityViewer_ClassId4_Input")]
+    [InlineData("MonsterProbabilityViewer_ClassId5_Input")]
+    public void MonsterProbabilityViewer_ClassId_AutomationIdResolvesToNumericUpDownUniquely(string automationId)
+    {
+        var view = new MonsterProbabilityViewerView();
+        view.Show();
+        try { AssertAutomationIdResolvesToNumericUpDown(view, automationId); }
+        finally { view.Close(); }
+    }
+
+    // ---- Tier 1: SummonUnitViewer Summoned Unit (UnknownBox) --------------
+
+    [AvaloniaFact]
+    public void SummonUnitViewer_SummonedUnitBox_IsIdFieldControl()
+    {
+        var view = new SummonUnitViewerView();
+        var ctrl = view.FindControl<IdFieldControl>("UnknownBox");
+        Assert.NotNull(ctrl);
+        Assert.Equal("Summoned Unit:", ctrl!.Label);
+        Assert.True(ctrl.ShowPick);
+    }
+
+    [AvaloniaFact]
+    public void SummonUnitViewer_SummonedUnit_AutomationIdResolvesToNumericUpDownUniquely()
+    {
+        var view = new SummonUnitViewerView();
+        view.Show();
+        try { AssertAutomationIdResolvesToNumericUpDown(view, "SummonUnitViewer_SummonedUnit_Input"); }
+        finally { view.Close(); }
+    }
+
+    // ---- Tier 2: ClassOPDemo / OPClassDemoViewer Display Weapon (B14) -----
+
+    [AvaloniaFact]
+    public void ClassOPDemo_DisplayWeaponBox_IsIdFieldControl()
+    {
+        var view = new ClassOPDemoView();
+        var ctrl = view.FindControl<IdFieldControl>("DisplayWeaponBox");
+        Assert.NotNull(ctrl);
+        Assert.Equal("Class ID:", ctrl!.Label);
+        Assert.True(ctrl.ShowPick);
+    }
+
+    [AvaloniaFact]
+    public void ClassOPDemo_DisplayWeapon_AutomationIdResolvesToNumericUpDownUniquely()
+    {
+        var view = new ClassOPDemoView();
+        view.Show();
+        try { AssertAutomationIdResolvesToNumericUpDown(view, "ClassOPDemo_DisplayWeapon_Input"); }
+        finally { view.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void OPClassDemoViewer_DisplayWeaponBox_IsIdFieldControl()
+    {
+        var view = new OPClassDemoViewerView();
+        var ctrl = view.FindControl<IdFieldControl>("DisplayWeaponBox");
+        Assert.NotNull(ctrl);
+        Assert.Equal("Class ID:", ctrl!.Label);
+        Assert.True(ctrl.ShowPick);
+    }
+
+    [AvaloniaFact]
+    public void OPClassDemoViewer_DisplayWeapon_AutomationIdResolvesToNumericUpDownUniquely()
+    {
+        var view = new OPClassDemoViewerView();
+        view.Show();
+        try { AssertAutomationIdResolvesToNumericUpDown(view, "OPClassDemoViewer_DisplayWeapon_Input"); }
+        finally { view.Close(); }
+    }
+
+    // ---- Tier 3: EventCond TALK Unit 1/2 + OBJECT Chest Item -------------
+
+    [AvaloniaTheory]
+    [InlineData("Unit1Box")]
+    [InlineData("Unit2Box")]
+    public void EventCond_TalkUnitBoxes_AreIdFieldControls(string name)
+    {
+        var view = new EventCondView();
+        var ctrl = view.FindControl<IdFieldControl>(name);
+        Assert.NotNull(ctrl);
+        Assert.True(ctrl!.ShowPick); // unit fields keep Pick visible
+    }
+
+    [AvaloniaFact]
+    public void EventCond_ChestItemBox_IsIdFieldControl()
+    {
+        var view = new EventCondView();
+        var ctrl = view.FindControl<IdFieldControl>("ChestItemBox");
+        Assert.NotNull(ctrl);
+        Assert.True(ctrl!.ShowPick); // item field keeps Pick visible
+    }
+
+    [AvaloniaTheory]
+    [InlineData("EventCond_Unit1_Input")]
+    [InlineData("EventCond_Unit2_Input")]
+    [InlineData("EventCond_ChestItem_Input")]
+    public void EventCond_TalkObject_AutomationIdResolvesToNumericUpDownUniquely(string automationId)
+    {
+        var view = new EventCondView();
+        view.Show();
+        try { AssertAutomationIdResolvesToNumericUpDown(view, automationId); }
+        finally { view.Close(); }
+    }
+
     // ---- Helpers ------------------------------------------------------
 
     static void AssertAutomationIdResolvesToNumericUpDown(Window view, string automationId)

--- a/FEBuilderGBA.Avalonia.Tests/UnifiedIdFieldMigrationTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/UnifiedIdFieldMigrationTests.cs
@@ -1022,7 +1022,10 @@ public class UnifiedIdFieldMigrationTests
         var view = new OPClassDemoViewerView();
         var ctrl = view.FindControl<IdFieldControl>("DisplayWeaponBox");
         Assert.NotNull(ctrl);
-        Assert.Equal("Class ID:", ctrl!.Label);
+        // #951 layout-clip fix: the original caption was merged into the
+        // hyperlink Label (and the redundant separate caption Label removed)
+        // when the control moved to columns 0..2 for full width.
+        Assert.Equal("Display Weapon (Class):", ctrl!.Label);
         Assert.True(ctrl.ShowPick);
     }
 

--- a/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml
@@ -126,12 +126,19 @@
                  #950 T4: migrated from plain NumericUpDown to a class
                  IdFieldControl (hyperlink label + numeric + class-name preview
                  + Jump + Pick). Host Name="DisplayWeaponBox" + AutomationId
-                 (DisplayWeapon_Input) preserved. The separate ClassNamePreview
-                 TextBox is kept (the ClassName_Label AutomationId is asserted by
-                 ClassOPDemoParityTests) as the canonical class-name readout. -->
+                 (DisplayWeapon_Input) preserved.
+                 #951 review (layout-clip fix): the IdFieldControl needs ~420px,
+                 so it spans columns 1..3 (140+80+220 = 440px) instead of the
+                 too-narrow 1..2 (220px) that clipped the name preview / Pick
+                 button. The original caption Label is kept in column 0 (the
+                 ClassOPDemoParityTests "WF-only labels covered" check requires
+                 the Content="Display Weapon (Class):" string), and the
+                 ClassNamePreview readout moves to column 4 (the flexible '*')
+                 so it no longer collides with the wider IdFieldControl; its
+                 ClassName_Label AutomationId stays for the parity assertion. -->
             <Label Grid.Row="5" Grid.Column="0" Content="Display Weapon (Class):" VerticalAlignment="Center" />
             <controls:IdFieldControl AutomationProperties.AutomationId="ClassOPDemo_DisplayWeapon_Input"
-                                     Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2"
+                                     Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="3"
                                      Name="DisplayWeaponBox"
                                      Label="Class ID:"
                                      Maximum="255"
@@ -139,7 +146,7 @@
                                      PickRequested="ClassId_Pick"
                                      ValueChanged="ClassId_ValueChanged" />
             <TextBox AutomationProperties.AutomationId="ClassOPDemo_ClassName_Label"
-                     Grid.Row="5" Grid.Column="3" Grid.ColumnSpan="2"
+                     Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="1"
                      Name="ClassNamePreview" IsReadOnly="True" VerticalAlignment="Center" />
 
             <!-- Row 6: Ally / Enemy Color (B15) -->

--- a/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml
@@ -122,12 +122,22 @@
                      Grid.Row="4" Grid.Column="3" Grid.ColumnSpan="2"
                      Name="PalettePreview" IsReadOnly="True" VerticalAlignment="Center" />
 
-            <!-- Row 5: Display Weapon (Class) (B14) -->
+            <!-- Row 5: Display Weapon (Class) (B14, WF J_14_CLASS/L_14_CLASS).
+                 #950 T4: migrated from plain NumericUpDown to a class
+                 IdFieldControl (hyperlink label + numeric + class-name preview
+                 + Jump + Pick). Host Name="DisplayWeaponBox" + AutomationId
+                 (DisplayWeapon_Input) preserved. The separate ClassNamePreview
+                 TextBox is kept (the ClassName_Label AutomationId is asserted by
+                 ClassOPDemoParityTests) as the canonical class-name readout. -->
             <Label Grid.Row="5" Grid.Column="0" Content="Display Weapon (Class):" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="ClassOPDemo_DisplayWeapon_Input"
-                           FormatString="0" Grid.Row="5" Grid.Column="1"
-                           Name="DisplayWeaponBox"
-                           Minimum="0" Maximum="255" VerticalAlignment="Center" />
+            <controls:IdFieldControl AutomationProperties.AutomationId="ClassOPDemo_DisplayWeapon_Input"
+                                     Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2"
+                                     Name="DisplayWeaponBox"
+                                     Label="Class ID:"
+                                     Maximum="255"
+                                     JumpRequested="ClassId_Jump"
+                                     PickRequested="ClassId_Pick"
+                                     ValueChanged="ClassId_ValueChanged" />
             <TextBox AutomationProperties.AutomationId="ClassOPDemo_ClassName_Label"
                      Grid.Row="5" Grid.Column="3" Grid.ColumnSpan="2"
                      Name="ClassNamePreview" IsReadOnly="True" VerticalAlignment="Center" />

--- a/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
+using FEBuilderGBA.Avalonia.Controls;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 using FEBuilderGBA.Core;
@@ -58,7 +59,8 @@ namespace FEBuilderGBA.Avalonia.Views
             DescTextIdBox.ValueChanged += OnDescTextIdChanged;
             JpNamePtrBox.ValueChanged += OnJpNamePtrChanged;
             PaletteIdBox.ValueChanged += OnPaletteIdChanged;
-            DisplayWeaponBox.ValueChanged += OnDisplayWeaponChanged;
+            // #950 T4: DisplayWeaponBox is now an IdFieldControl — its routed
+            // ValueChanged (ClassId_ValueChanged) is wired in AXAML, not here.
             AnimePtrBox.ValueChanged += OnAnimePtrChanged;
             // N2B2 is the special-spec byte that the 3-choice combo maps to
             // — NOT N2B0 which is the fixed 0x05 marker (per the orphan
@@ -203,7 +205,12 @@ namespace FEBuilderGBA.Avalonia.Views
                 ? R._("Default palette") : $"Palette 0x{_vm.B13:X02}";
 
             DisplayWeaponBox.Value = _vm.B14;
-            try { ClassNamePreview.Text = NameResolver.GetClassName(_vm.B14); }
+            try
+            {
+                string className = NameResolver.GetClassName(_vm.B14);
+                ClassNamePreview.Text = className;
+                DisplayWeaponBox.NameText = className;
+            }
             catch { ClassNamePreview.Text = ""; }
 
             AllyEnemyColorBox.Value = _vm.B15;
@@ -262,11 +269,64 @@ namespace FEBuilderGBA.Avalonia.Views
                 ? R._("Default palette") : $"Palette 0x{id:X02}";
         }
 
-        void OnDisplayWeaponChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        // #950 T4: DisplayWeaponBox is the B14 class field (WF J_14_CLASS).
+        // Migrated to a class IdFieldControl — routed ValueChanged refreshes
+        // the ClassNamePreview readout AND the IdFieldControl's own inline name
+        // preview; Jump/Pick open the Class editor (ClassFE6View for FE6).
+        static uint ClassAddrFor(uint classId)
+        {
+            var rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return 0;
+            uint classPtr = rom.RomInfo.class_pointer;
+            if (classPtr == 0) return 0;
+            uint baseAddr = rom.p32(classPtr);
+            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
+            uint dataSize = rom.RomInfo.class_datasize;
+            if (dataSize == 0) return 0;
+            uint entryAddr = baseAddr + classId * dataSize;
+            if (!U.isSafetyOffset(entryAddr, rom)) return 0;
+            if (!U.isSafetyOffset(entryAddr + dataSize - 1, rom)) return 0;
+            return entryAddr;
+        }
+
+        void ClassId_Jump(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                uint addr = ClassAddrFor(DisplayWeaponBox.Value);
+                if (addr == 0) return;
+                if (CoreState.ROM?.RomInfo?.version == 6)
+                    WindowManager.Instance.Navigate<ClassFE6View>(addr);
+                else
+                    WindowManager.Instance.Navigate<ClassEditorView>(addr);
+            }
+            catch (Exception ex) { Log.Error("ClassOPDemoView.ClassId_Jump failed: {0}", ex.Message); }
+        }
+
+        async void ClassId_Pick(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                uint addr = ClassAddrFor(DisplayWeaponBox.Value);
+                PickResult? result;
+                if (CoreState.ROM?.RomInfo?.version == 6)
+                    result = await WindowManager.Instance.PickFromEditor<ClassFE6View>(addr, this);
+                else
+                    result = await WindowManager.Instance.PickFromEditor<ClassEditorView>(addr, this);
+                if (result != null) DisplayWeaponBox.Value = (uint)result.Index;
+            }
+            catch (Exception ex) { Log.Error("ClassOPDemoView.ClassId_Pick failed: {0}", ex.Message); }
+        }
+
+        void ClassId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
         {
             if (_vm.IsLoading) return;
-            uint id = (uint)(DisplayWeaponBox.Value ?? 0);
-            try { ClassNamePreview.Text = NameResolver.GetClassName(id); }
+            try
+            {
+                string name = NameResolver.GetClassName(e.NewValue);
+                ClassNamePreview.Text = name;
+                DisplayWeaponBox.NameText = name;
+            }
             catch { ClassNamePreview.Text = ""; }
         }
 
@@ -487,7 +547,8 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.P8 = (uint)(JpNamePtrBox.Value ?? 0);
                 _vm.B12 = (uint)(JpNameLenBox.Value ?? 0);
                 _vm.B13 = (uint)(PaletteIdBox.Value ?? 0);
-                _vm.B14 = (uint)(DisplayWeaponBox.Value ?? 0);
+                // #950 T4: IdFieldControl.Value is a non-nullable uint.
+                _vm.B14 = DisplayWeaponBox.Value;
                 _vm.B15 = (uint)(AllyEnemyColorBox.Value ?? 0);
                 _vm.B16 = (uint)(BattleAnimeBox.Value ?? 0);
                 _vm.B17 = (uint)(MagicEffectBox.Value ?? 0);

--- a/FEBuilderGBA.Avalonia/Views/EventCondView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventCondView.axaml
@@ -152,14 +152,25 @@
         <Border AutomationProperties.AutomationId="EventCond_TalkPanel_Border" Name="TalkPanel" BorderBrush="LightGreen" BorderThickness="1" Padding="6" IsVisible="False">
           <StackPanel Spacing="6">
             <TextBlock AutomationProperties.AutomationId="EventCond_TalkHeader_Label" Text="Talk Condition" FontWeight="Bold" />
+            <!-- #950 T4: TALK Unit 1/2 (WF J_*_UNIT/L_*_UNIT, 1-based unit IDs)
+                 migrated from plain NumericUpDown to a unit IdFieldControl
+                 (label + numeric + unit-name preview + Jump + Pick). Host Names
+                 (Unit1Box/Unit2Box) + AutomationIds (Unit1_Input/Unit2_Input)
+                 preserved. The separate Unit1/2NameLabel readouts are kept (their
+                 IsVisible is toggled per TALK subtype and the EventCondParityTests
+                 assert their AutomationIds). The category Compose path is NOT
+                 dynamic for these fields — they are static inline AXAML controls
+                 inside an IsVisible-toggled panel, so the migration is clean. -->
             <StackPanel Orientation="Horizontal" Spacing="6">
               <TextBlock AutomationProperties.AutomationId="EventCond_Unit1_Label" Text="Unit 1 (Source):" VerticalAlignment="Center" Width="120" />
-              <NumericUpDown AutomationProperties.AutomationId="EventCond_Unit1_Input" Name="Unit1Box" FormatString="0" Minimum="0" Maximum="255" Width="80" />
+              <controls:IdFieldControl AutomationProperties.AutomationId="EventCond_Unit1_Input" Name="Unit1Box"
+                                       Maximum="255" JumpRequested="Unit1_Jump" PickRequested="Unit1_Pick" ValueChanged="Unit1_ValueChanged" />
               <TextBlock AutomationProperties.AutomationId="EventCond_Unit1Name_Label" Name="Unit1NameLabel" VerticalAlignment="Center" Margin="8,0,0,0" Foreground="Gray" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Spacing="6">
               <TextBlock AutomationProperties.AutomationId="EventCond_Unit2_Label" Text="Unit 2 (Target):" VerticalAlignment="Center" Width="120" />
-              <NumericUpDown AutomationProperties.AutomationId="EventCond_Unit2_Input" Name="Unit2Box" FormatString="0" Minimum="0" Maximum="255" Width="80" />
+              <controls:IdFieldControl AutomationProperties.AutomationId="EventCond_Unit2_Input" Name="Unit2Box"
+                                       Maximum="255" JumpRequested="Unit2_Jump" PickRequested="Unit2_Pick" ValueChanged="Unit2_ValueChanged" />
               <TextBlock AutomationProperties.AutomationId="EventCond_Unit2Name_Label" Name="Unit2NameLabel" VerticalAlignment="Center" Margin="8,0,0,0" Foreground="Gray" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Spacing="6">
@@ -193,9 +204,14 @@
               <TextBlock AutomationProperties.AutomationId="EventCond_EventType_Label" Text="Event Type:" VerticalAlignment="Center" Width="120" />
               <NumericUpDown AutomationProperties.AutomationId="EventCond_EventType_Input" Name="EventTypeBox" FormatString="0" Minimum="0" Maximum="255" Width="80" />
             </StackPanel>
+            <!-- #950 T4: OBJECT Chest Item (WF chest item id) migrated from plain
+                 NumericUpDown to an item IdFieldControl. Host Name="ChestItemBox"
+                 + AutomationId (ChestItem_Input) preserved; the ChestItemNameLabel
+                 readout is kept (its AutomationId is asserted by the parity tests). -->
             <StackPanel Orientation="Horizontal" Spacing="6">
               <TextBlock AutomationProperties.AutomationId="EventCond_ChestItem_Label" Text="Chest Item:" VerticalAlignment="Center" Width="120" />
-              <NumericUpDown AutomationProperties.AutomationId="EventCond_ChestItem_Input" Name="ChestItemBox" FormatString="0" Minimum="0" Maximum="255" Width="80" />
+              <controls:IdFieldControl AutomationProperties.AutomationId="EventCond_ChestItem_Input" Name="ChestItemBox"
+                                       Maximum="255" JumpRequested="ChestItem_Jump" PickRequested="ChestItem_Pick" ValueChanged="ChestItem_ValueChanged" />
               <TextBlock AutomationProperties.AutomationId="EventCond_ChestItemName_Label" Name="ChestItemNameLabel" VerticalAlignment="Center" Margin="8,0,0,0" Foreground="Gray" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Spacing="6">

--- a/FEBuilderGBA.Avalonia/Views/EventCondView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventCondView.axaml.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
+using FEBuilderGBA.Avalonia.Controls;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 
@@ -46,15 +47,15 @@ namespace FEBuilderGBA.Avalonia.Views
             // their parent panels are hidden.
             TurnStartBox.Value ??= 0;
             TurnEndBox.Value ??= 0;
-            Unit1Box.Value ??= 0;
-            Unit2Box.Value ??= 0;
+            // #950 T4: Unit1Box/Unit2Box are now IdFieldControls (Value is a
+            // non-nullable uint defaulting to 0) — no null-seed needed.
             AdditionalDecisionBox.Value ??= 0;
             DecisionFlagBox.Value ??= 0;
             TalkAsmFuncBox.Value ??= 0;
             ObjectXBox.Value ??= 0;
             ObjectYBox.Value ??= 0;
             EventTypeBox.Value ??= 0;
-            ChestItemBox.Value ??= 0;
+            // #950 T4: ChestItemBox is now an IdFieldControl (uint Value) — no null-seed.
             GoldBox.Value ??= 0;
             DurabilityBox.Value ??= 0;
             ShopTypeBox.Value ??= 0;
@@ -380,8 +381,12 @@ namespace FEBuilderGBA.Avalonia.Views
                     Unit1Box.Value = _vm.Unit1;
                     Unit2Box.Value = _vm.Unit2;
                     // 1-based ROM-stored unit IDs (matches Cond TALK convention).
+                    // #950 T4: keep the standalone name labels AND seed the
+                    // IdFieldControl inline previews.
                     Unit1NameLabel.Text = NameResolver.GetUnitNameByOneBasedId(_vm.Unit1);
                     Unit2NameLabel.Text = NameResolver.GetUnitNameByOneBasedId(_vm.Unit2);
+                    Unit1Box.NameText = Unit1NameLabel.Text;
+                    Unit2Box.NameText = Unit2NameLabel.Text;
                     AdditionalDecisionBox.Value = _vm.AdditionalDecision;
                     DecisionFlagBox.Value = _vm.DecisionFlag;
                     TalkAsmFuncBox.Value = _vm.AsmFunc;
@@ -419,7 +424,10 @@ namespace FEBuilderGBA.Avalonia.Views
                     ObjectYBox.Value = _vm.Y1;
                     EventTypeBox.Value = _vm.EventType;
                     ChestItemBox.Value = _vm.ItemId;
+                    // #950 T4: keep the standalone name label AND seed the
+                    // IdFieldControl inline preview.
                     ChestItemNameLabel.Text = NameResolver.GetItemName(_vm.ItemId);
+                    ChestItemBox.NameText = ChestItemNameLabel.Text;
                     GoldBox.Value = _vm.Gold;
                     DurabilityBox.Value = _vm.Durability;
                     ShopTypeBox.Value = _vm.ShopType;
@@ -725,8 +733,9 @@ namespace FEBuilderGBA.Avalonia.Views
                     // Hidden controls are not part of the current TALK subtype's
                     // layout, and copying them would leak stale state into bytes
                     // the Compose path doesn't touch.
-                    if (Unit1Box.IsVisible) _vm.Unit1 = (uint)(Unit1Box.Value ?? 0);
-                    if (Unit2Box.IsVisible) _vm.Unit2 = (uint)(Unit2Box.Value ?? 0);
+                    // #950 T4: Unit1Box/Unit2Box IdFieldControl.Value is uint.
+                    if (Unit1Box.IsVisible) _vm.Unit1 = Unit1Box.Value;
+                    if (Unit2Box.IsVisible) _vm.Unit2 = Unit2Box.Value;
                     if (AdditionalDecisionBox.IsVisible)
                         _vm.AdditionalDecision = (uint)(AdditionalDecisionBox.Value ?? 0);
                     if (DecisionFlagBox.IsVisible)
@@ -738,7 +747,8 @@ namespace FEBuilderGBA.Avalonia.Views
                     _vm.X1 = (uint)(ObjectXBox.Value ?? 0);
                     _vm.Y1 = (uint)(ObjectYBox.Value ?? 0);
                     _vm.EventType = (uint)(EventTypeBox.Value ?? 0);
-                    _vm.ItemId = (uint)(ChestItemBox.Value ?? 0);
+                    // #950 T4: ChestItemBox IdFieldControl.Value is uint.
+                    _vm.ItemId = ChestItemBox.Value;
                     _vm.Gold = (uint)(GoldBox.Value ?? 0);
                     _vm.Durability = (uint)(DurabilityBox.Value ?? 0);
                     _vm.ShopType = (uint)(ShopTypeBox.Value ?? 0);
@@ -945,6 +955,117 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 Log.Error("EventCondView.Reload_Click failed: {0}", ex.Message);
             }
+        }
+
+        // ============================================================
+        // IdFieldControl handlers (#950 T4).
+        //   TALK Unit 1/2 (1-based unit IDs) → UnitEditorView Jump/Pick.
+        //   OBJECT Chest Item (item ID) → ItemEditorView/ItemFE6View Jump/Pick.
+        // The Event Pointer (CODE pointer) keeps its existing cross-jump and is
+        // intentionally NOT migrated; the Type discriminant is also left alone.
+        // ============================================================
+
+        static uint ItemAddrFor(uint itemId)
+        {
+            var rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return 0;
+            uint itemPtr = rom.RomInfo.item_pointer;
+            if (itemPtr == 0) return 0;
+            uint baseAddr = rom.p32(itemPtr);
+            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
+            uint dataSize = rom.RomInfo.item_datasize;
+            if (dataSize == 0) return 0;
+            uint entryAddr = baseAddr + itemId * dataSize;
+            if (!U.isSafetyOffset(entryAddr, rom)) return 0;
+            if (!U.isSafetyOffset(entryAddr + dataSize - 1, rom)) return 0;
+            return entryAddr;
+        }
+
+        void JumpToUnitEditor(IdFieldControl box)
+        {
+            try
+            {
+                // TALK Unit IDs are 1-based (matches GetUnitNameByOneBasedId above).
+                uint addr = SupportUnitNavigation.UnitAddrForOneBased(CoreState.ROM, box.Value);
+                if (addr == 0) return;
+                WindowManager.Instance.Navigate<UnitEditorView>(addr);
+            }
+            catch (Exception ex) { Log.Error("EventCondView.JumpToUnitEditor failed: {0}", ex.Message); }
+        }
+
+        async System.Threading.Tasks.Task PickUnitInto(IdFieldControl box)
+        {
+            try
+            {
+                uint addr = SupportUnitNavigation.UnitAddrForOneBased(CoreState.ROM, box.Value);
+                var result = await WindowManager.Instance.PickFromEditor<UnitEditorView>(addr, this);
+                if (result != null)
+                    box.Value = SupportUnitNavigation.OneBasedIdFromPickIndex(result.Index);
+            }
+            catch (Exception ex) { Log.Error("EventCondView.PickUnitInto failed: {0}", ex.Message); }
+        }
+
+        void Unit1_Jump(object? sender, RoutedEventArgs e) => JumpToUnitEditor(Unit1Box);
+        async void Unit1_Pick(object? sender, RoutedEventArgs e) => await PickUnitInto(Unit1Box);
+        void Unit1_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
+        {
+            try
+            {
+                Unit1NameLabel.Text = NameResolver.GetUnitNameByOneBasedId(e.NewValue);
+                Unit1Box.NameText = Unit1NameLabel.Text;
+            }
+            catch { /* GetUnitNameByOneBasedId returns a fallback and never throws */ }
+        }
+
+        void Unit2_Jump(object? sender, RoutedEventArgs e) => JumpToUnitEditor(Unit2Box);
+        async void Unit2_Pick(object? sender, RoutedEventArgs e) => await PickUnitInto(Unit2Box);
+        void Unit2_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
+        {
+            try
+            {
+                Unit2NameLabel.Text = NameResolver.GetUnitNameByOneBasedId(e.NewValue);
+                Unit2Box.NameText = Unit2NameLabel.Text;
+            }
+            catch { /* GetUnitNameByOneBasedId returns a fallback and never throws */ }
+        }
+
+        void ChestItem_Jump(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                uint addr = ItemAddrFor(ChestItemBox.Value);
+                if (addr == 0) return;
+                if (CoreState.ROM?.RomInfo?.version == 6)
+                    WindowManager.Instance.Navigate<ItemFE6View>(addr);
+                else
+                    WindowManager.Instance.Navigate<ItemEditorView>(addr);
+            }
+            catch (Exception ex) { Log.Error("EventCondView.ChestItem_Jump failed: {0}", ex.Message); }
+        }
+
+        async void ChestItem_Pick(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                uint addr = ItemAddrFor(ChestItemBox.Value);
+                PickResult? result;
+                if (CoreState.ROM?.RomInfo?.version == 6)
+                    result = await WindowManager.Instance.PickFromEditor<ItemFE6View>(addr, this);
+                else
+                    result = await WindowManager.Instance.PickFromEditor<ItemEditorView>(addr, this);
+                if (result != null) ChestItemBox.Value = (uint)result.Index;
+            }
+            catch (Exception ex) { Log.Error("EventCondView.ChestItem_Pick failed: {0}", ex.Message); }
+        }
+
+        void ChestItem_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
+        {
+            try
+            {
+                ChestItemNameLabel.Text = NameResolver.GetItemName(e.NewValue);
+                ChestItemBox.NameText = ChestItemNameLabel.Text;
+            }
+            catch { /* NameResolver may fail without ROM */ }
         }
 
         public void NavigateTo(uint address)

--- a/FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml
@@ -90,25 +90,46 @@
                                        PickRequested="ItemId_Pick"
                                        ValueChanged="ItemId_ValueChanged" />
 
-              <TextBlock Grid.Row="1" Grid.Column="0" Text="Item 2:" VerticalAlignment="Center" />
-              <NumericUpDown AutomationProperties.AutomationId="MonsterItemViewer_Item_Item2_Input"
-                             FormatString="0" Grid.Row="1" Grid.Column="1" Name="DropRateBox"
-                             Minimum="0" Maximum="255" VerticalAlignment="Center" />
+              <!-- #950 T4: Item 2..5 (B1..B4) are 5 ITEM IDs (WF L_1..4_ITEM),
+                   not the legacy DropRate/Unknown misnomers. Migrated from plain
+                   NumericUpDown to item IdFieldControl mirroring slot-1 ItemIdBox.
+                   Host Names (DropRateBox/Unknown1..3Box) + AutomationIds
+                   (Item_Item2..5_Input) preserved per the legacy alias contract. -->
+              <controls:IdFieldControl AutomationProperties.AutomationId="MonsterItemViewer_Item_Item2_Input"
+                                       Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                                       Name="DropRateBox"
+                                       Label="Item 2:"
+                                       Maximum="255"
+                                       JumpRequested="Item2_Jump"
+                                       PickRequested="Item2_Pick"
+                                       ValueChanged="Item2_ValueChanged" />
 
-              <TextBlock Grid.Row="2" Grid.Column="0" Text="Item 3:" VerticalAlignment="Center" />
-              <NumericUpDown AutomationProperties.AutomationId="MonsterItemViewer_Item_Item3_Input"
-                             FormatString="0" Grid.Row="2" Grid.Column="1" Name="Unknown1Box"
-                             Minimum="0" Maximum="255" VerticalAlignment="Center" />
+              <controls:IdFieldControl AutomationProperties.AutomationId="MonsterItemViewer_Item_Item3_Input"
+                                       Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
+                                       Name="Unknown1Box"
+                                       Label="Item 3:"
+                                       Maximum="255"
+                                       JumpRequested="Item3_Jump"
+                                       PickRequested="Item3_Pick"
+                                       ValueChanged="Item3_ValueChanged" />
 
-              <TextBlock Grid.Row="3" Grid.Column="0" Text="Item 4:" VerticalAlignment="Center" />
-              <NumericUpDown AutomationProperties.AutomationId="MonsterItemViewer_Item_Item4_Input"
-                             FormatString="0" Grid.Row="3" Grid.Column="1" Name="Unknown2Box"
-                             Minimum="0" Maximum="255" VerticalAlignment="Center" />
+              <controls:IdFieldControl AutomationProperties.AutomationId="MonsterItemViewer_Item_Item4_Input"
+                                       Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
+                                       Name="Unknown2Box"
+                                       Label="Item 4:"
+                                       Maximum="255"
+                                       JumpRequested="Item4_Jump"
+                                       PickRequested="Item4_Pick"
+                                       ValueChanged="Item4_ValueChanged" />
 
-              <TextBlock Grid.Row="4" Grid.Column="0" Text="Item 5:" VerticalAlignment="Center" />
-              <NumericUpDown AutomationProperties.AutomationId="MonsterItemViewer_Item_Item5_Input"
-                             FormatString="0" Grid.Row="4" Grid.Column="1" Name="Unknown3Box"
-                             Minimum="0" Maximum="255" VerticalAlignment="Center" />
+              <controls:IdFieldControl AutomationProperties.AutomationId="MonsterItemViewer_Item_Item5_Input"
+                                       Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
+                                       Name="Unknown3Box"
+                                       Label="Item 5:"
+                                       Maximum="255"
+                                       JumpRequested="Item5_Jump"
+                                       PickRequested="Item5_Pick"
+                                       ValueChanged="Item5_ValueChanged" />
 
               <TextBlock Grid.Row="5" Grid.Column="0" Text="Comment:" VerticalAlignment="Center" />
               <TextBox AutomationProperties.AutomationId="MonsterItemViewer_Item_Comment_Input"

--- a/FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml.cs
@@ -102,10 +102,20 @@ namespace FEBuilderGBA.Avalonia.Views
             ItemIdBox.Value = _vm.ItemId;
             try { ItemIdBox.NameText = NameResolver.GetItemName(_vm.ItemId); }
             catch (Exception ex) { Log.Error("MonsterItemViewerView.UpdateItemUI ItemName: {0}", ex.Message); }
+            // #950 T4: Item 2..5 (B1..B4) are item IDs; populate the IdFieldControl
+            // value + inline item-name preview just like slot-1 ItemIdBox.
             DropRateBox.Value = _vm.DropRate;
             Unknown1Box.Value = _vm.Unknown1;
             Unknown2Box.Value = _vm.Unknown2;
             Unknown3Box.Value = _vm.Unknown3;
+            try
+            {
+                DropRateBox.NameText = NameResolver.GetItemName(_vm.DropRate);
+                Unknown1Box.NameText = NameResolver.GetItemName(_vm.Unknown1);
+                Unknown2Box.NameText = NameResolver.GetItemName(_vm.Unknown2);
+                Unknown3Box.NameText = NameResolver.GetItemName(_vm.Unknown3);
+            }
+            catch (Exception ex) { Log.Error("MonsterItemViewerView.UpdateItemUI ItemName 2..5: {0}", ex.Message); }
             ItemCommentBox.Text = ReadComment(_vm.CurrentAddr);
         }
 
@@ -116,10 +126,11 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 _vm.ItemId = ItemIdBox.Value;
-                _vm.DropRate = (uint)(DropRateBox.Value ?? 0);
-                _vm.Unknown1 = (uint)(Unknown1Box.Value ?? 0);
-                _vm.Unknown2 = (uint)(Unknown2Box.Value ?? 0);
-                _vm.Unknown3 = (uint)(Unknown3Box.Value ?? 0);
+                // #950 T4: IdFieldControl.Value is a non-nullable uint.
+                _vm.DropRate = DropRateBox.Value;
+                _vm.Unknown1 = Unknown1Box.Value;
+                _vm.Unknown2 = Unknown2Box.Value;
+                _vm.Unknown3 = Unknown3Box.Value;
                 _vm.WriteMonsterItem();
                 uint preserve = _vm.CurrentAddr;
                 _undoService.Commit();
@@ -634,6 +645,61 @@ namespace FEBuilderGBA.Avalonia.Views
         void ItemId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
         {
             try { ItemIdBox.NameText = NameResolver.GetItemName(e.NewValue); }
+            catch { /* NameResolver may fail without ROM */ }
+        }
+
+        // ============================================================
+        // Item 2..5 picker helpers (#950 T4). Each of the 4 secondary
+        // item-id slots (B1..B4) reuses the exact slot-1 Jump/Pick wiring
+        // (ItemAddrFor + ItemEditorView/ItemFE6View). The Jump routes to
+        // the matching ItemEditor entry; Pick opens it in pick mode and
+        // writes back the chosen item id; ValueChanged refreshes the
+        // inline item-name preview.
+        // ============================================================
+
+        void JumpToItemEditor(IdFieldControl box)
+        {
+            try
+            {
+                uint addr = ItemAddrFor(box.Value);
+                if (addr == 0) return;
+                if (CoreState.ROM?.RomInfo?.version == 6)
+                    WindowManager.Instance.Navigate<ItemFE6View>(addr);
+                else
+                    WindowManager.Instance.Navigate<ItemEditorView>(addr);
+            }
+            catch (Exception ex) { Log.Error("MonsterItemViewerView.JumpToItemEditor: {0}", ex.Message); }
+        }
+
+        void Item2_Jump(object? sender, RoutedEventArgs e) => JumpToItemEditor(DropRateBox);
+        async void Item2_Pick(object? sender, RoutedEventArgs e) => await PickItemIdInto(DropRateBox);
+        void Item2_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
+        {
+            try { DropRateBox.NameText = NameResolver.GetItemName(e.NewValue); }
+            catch { /* NameResolver may fail without ROM */ }
+        }
+
+        void Item3_Jump(object? sender, RoutedEventArgs e) => JumpToItemEditor(Unknown1Box);
+        async void Item3_Pick(object? sender, RoutedEventArgs e) => await PickItemIdInto(Unknown1Box);
+        void Item3_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
+        {
+            try { Unknown1Box.NameText = NameResolver.GetItemName(e.NewValue); }
+            catch { /* NameResolver may fail without ROM */ }
+        }
+
+        void Item4_Jump(object? sender, RoutedEventArgs e) => JumpToItemEditor(Unknown2Box);
+        async void Item4_Pick(object? sender, RoutedEventArgs e) => await PickItemIdInto(Unknown2Box);
+        void Item4_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
+        {
+            try { Unknown2Box.NameText = NameResolver.GetItemName(e.NewValue); }
+            catch { /* NameResolver may fail without ROM */ }
+        }
+
+        void Item5_Jump(object? sender, RoutedEventArgs e) => JumpToItemEditor(Unknown3Box);
+        async void Item5_Pick(object? sender, RoutedEventArgs e) => await PickItemIdInto(Unknown3Box);
+        void Item5_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
+        {
+            try { Unknown3Box.NameText = NameResolver.GetItemName(e.NewValue); }
             catch { /* NameResolver may fail without ROM */ }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MonsterProbabilityViewerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MonsterProbabilityViewerView.axaml
@@ -15,20 +15,35 @@
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
           <TextBlock AutomationProperties.AutomationId="MonsterProbabilityViewer_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
 
-          <TextBlock Grid.Row="1" Grid.Column="0" Text="Class ID 1:" VerticalAlignment="Center" />
-          <NumericUpDown AutomationProperties.AutomationId="MonsterProbabilityViewer_ClassId1_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="ClassId1Box" Minimum="0" Maximum="255" VerticalAlignment="Center" />
+          <!-- #950 T4: Class ID 1..5 (B0..B4, WF L_0..4_CLASS) are real class IDs.
+               Migrated from plain NumericUpDown to class IdFieldControl (hyperlink
+               label + numeric + class-name preview + Jump + Pick). Host Names
+               (ClassId1..5Box) + AutomationIds (ClassId1..5_Input) preserved;
+               the IdFieldControl spans both columns and carries its own label. -->
+          <controls:IdFieldControl AutomationProperties.AutomationId="MonsterProbabilityViewer_ClassId1_Input"
+                                   Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                                   Name="ClassId1Box" Label="Class ID 1:" Maximum="255"
+                                   JumpRequested="ClassId1_Jump" PickRequested="ClassId1_Pick" ValueChanged="ClassId1_ValueChanged" />
 
-          <TextBlock Grid.Row="2" Grid.Column="0" Text="Class ID 2:" VerticalAlignment="Center" />
-          <NumericUpDown AutomationProperties.AutomationId="MonsterProbabilityViewer_ClassId2_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="ClassId2Box" Minimum="0" Maximum="255" VerticalAlignment="Center" />
+          <controls:IdFieldControl AutomationProperties.AutomationId="MonsterProbabilityViewer_ClassId2_Input"
+                                   Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
+                                   Name="ClassId2Box" Label="Class ID 2:" Maximum="255"
+                                   JumpRequested="ClassId2_Jump" PickRequested="ClassId2_Pick" ValueChanged="ClassId2_ValueChanged" />
 
-          <TextBlock Grid.Row="3" Grid.Column="0" Text="Class ID 3:" VerticalAlignment="Center" />
-          <NumericUpDown AutomationProperties.AutomationId="MonsterProbabilityViewer_ClassId3_Input" FormatString="0" Grid.Row="3" Grid.Column="1" Name="ClassId3Box" Minimum="0" Maximum="255" VerticalAlignment="Center" />
+          <controls:IdFieldControl AutomationProperties.AutomationId="MonsterProbabilityViewer_ClassId3_Input"
+                                   Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
+                                   Name="ClassId3Box" Label="Class ID 3:" Maximum="255"
+                                   JumpRequested="ClassId3_Jump" PickRequested="ClassId3_Pick" ValueChanged="ClassId3_ValueChanged" />
 
-          <TextBlock Grid.Row="4" Grid.Column="0" Text="Class ID 4:" VerticalAlignment="Center" />
-          <NumericUpDown AutomationProperties.AutomationId="MonsterProbabilityViewer_ClassId4_Input" FormatString="0" Grid.Row="4" Grid.Column="1" Name="ClassId4Box" Minimum="0" Maximum="255" VerticalAlignment="Center" />
+          <controls:IdFieldControl AutomationProperties.AutomationId="MonsterProbabilityViewer_ClassId4_Input"
+                                   Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
+                                   Name="ClassId4Box" Label="Class ID 4:" Maximum="255"
+                                   JumpRequested="ClassId4_Jump" PickRequested="ClassId4_Pick" ValueChanged="ClassId4_ValueChanged" />
 
-          <TextBlock Grid.Row="5" Grid.Column="0" Text="Class ID 5:" VerticalAlignment="Center" />
-          <NumericUpDown AutomationProperties.AutomationId="MonsterProbabilityViewer_ClassId5_Input" FormatString="0" Grid.Row="5" Grid.Column="1" Name="ClassId5Box" Minimum="0" Maximum="255" VerticalAlignment="Center" />
+          <controls:IdFieldControl AutomationProperties.AutomationId="MonsterProbabilityViewer_ClassId5_Input"
+                                   Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
+                                   Name="ClassId5Box" Label="Class ID 5:" Maximum="255"
+                                   JumpRequested="ClassId5_Jump" PickRequested="ClassId5_Pick" ValueChanged="ClassId5_ValueChanged" />
 
           <TextBlock Grid.Row="6" Grid.Column="0" Text="Probability 1:" VerticalAlignment="Center" />
           <NumericUpDown AutomationProperties.AutomationId="MonsterProbabilityViewer_Prob1_Input" FormatString="0" Grid.Row="6" Grid.Column="1" Name="Prob1Box" Minimum="0" Maximum="255" VerticalAlignment="Center" />

--- a/FEBuilderGBA.Avalonia/Views/MonsterProbabilityViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MonsterProbabilityViewerView.axaml.cs
@@ -1,8 +1,10 @@
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
+using FEBuilderGBA.Avalonia.Controls;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Core;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
@@ -59,6 +61,16 @@ namespace FEBuilderGBA.Avalonia.Views
             ClassId3Box.Value = _vm.ClassId3;
             ClassId4Box.Value = _vm.ClassId4;
             ClassId5Box.Value = _vm.ClassId5;
+            // #950 T4: inline class-name preview for each migrated Class ID field.
+            try
+            {
+                ClassId1Box.NameText = NameResolver.GetClassName(_vm.ClassId1);
+                ClassId2Box.NameText = NameResolver.GetClassName(_vm.ClassId2);
+                ClassId3Box.NameText = NameResolver.GetClassName(_vm.ClassId3);
+                ClassId4Box.NameText = NameResolver.GetClassName(_vm.ClassId4);
+                ClassId5Box.NameText = NameResolver.GetClassName(_vm.ClassId5);
+            }
+            catch (Exception ex) { Log.Error("MonsterProbabilityViewerView.UpdateUI ClassName: {0}", ex.Message); }
             Prob1Box.Value = _vm.Prob1;
             Prob2Box.Value = _vm.Prob2;
             Prob3Box.Value = _vm.Prob3;
@@ -74,11 +86,12 @@ namespace FEBuilderGBA.Avalonia.Views
             _undoService.Begin("Edit Monster Probability");
             try
             {
-                _vm.ClassId1 = (uint)(ClassId1Box.Value ?? 0);
-                _vm.ClassId2 = (uint)(ClassId2Box.Value ?? 0);
-                _vm.ClassId3 = (uint)(ClassId3Box.Value ?? 0);
-                _vm.ClassId4 = (uint)(ClassId4Box.Value ?? 0);
-                _vm.ClassId5 = (uint)(ClassId5Box.Value ?? 0);
+                // #950 T4: IdFieldControl.Value is a non-nullable uint.
+                _vm.ClassId1 = ClassId1Box.Value;
+                _vm.ClassId2 = ClassId2Box.Value;
+                _vm.ClassId3 = ClassId3Box.Value;
+                _vm.ClassId4 = ClassId4Box.Value;
+                _vm.ClassId5 = ClassId5Box.Value;
                 _vm.Prob1 = (uint)(Prob1Box.Value ?? 0);
                 _vm.Prob2 = (uint)(Prob2Box.Value ?? 0);
                 _vm.Prob3 = (uint)(Prob3Box.Value ?? 0);
@@ -93,6 +106,84 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex) { _undoService.Rollback(); Log.Error("MonsterProbabilityViewerView.Write: {0}", ex.Message); }
         }
+
+        // ============================================================
+        // Class ID picker helpers (#950 T4). The 5 monster-class slots
+        // (B0..B4) each Jump to / Pick from the Class editor
+        // (ClassFE6View for FE6, ClassEditorView otherwise), mirroring the
+        // ItemPromotion/ArenaClass class IdFieldControl wiring.
+        // ============================================================
+
+        static uint ClassAddrFor(uint classId)
+        {
+            var rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return 0;
+            uint classPtr = rom.RomInfo.class_pointer;
+            if (classPtr == 0) return 0;
+            uint baseAddr = rom.p32(classPtr);
+            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
+            uint dataSize = rom.RomInfo.class_datasize;
+            if (dataSize == 0) return 0;
+            uint entryAddr = baseAddr + classId * dataSize;
+            if (!U.isSafetyOffset(entryAddr, rom)) return 0;
+            if (!U.isSafetyOffset(entryAddr + dataSize - 1, rom)) return 0;
+            return entryAddr;
+        }
+
+        void JumpToClassEditor(IdFieldControl box)
+        {
+            try
+            {
+                uint addr = ClassAddrFor(box.Value);
+                if (addr == 0) return;
+                if (CoreState.ROM?.RomInfo?.version == 6)
+                    WindowManager.Instance.Navigate<ClassFE6View>(addr);
+                else
+                    WindowManager.Instance.Navigate<ClassEditorView>(addr);
+            }
+            catch (Exception ex) { Log.Error("MonsterProbabilityViewerView.JumpToClassEditor: {0}", ex.Message); }
+        }
+
+        async System.Threading.Tasks.Task PickClassIdInto(IdFieldControl box)
+        {
+            try
+            {
+                uint addr = ClassAddrFor(box.Value);
+                PickResult? result;
+                if (CoreState.ROM?.RomInfo?.version == 6)
+                    result = await WindowManager.Instance.PickFromEditor<ClassFE6View>(addr, this);
+                else
+                    result = await WindowManager.Instance.PickFromEditor<ClassEditorView>(addr, this);
+                if (result != null) box.Value = (uint)result.Index;
+            }
+            catch (Exception ex) { Log.Error("MonsterProbabilityViewerView.PickClassIdInto: {0}", ex.Message); }
+        }
+
+        static void RefreshClassName(IdFieldControl box, uint value)
+        {
+            try { box.NameText = NameResolver.GetClassName(value); }
+            catch { /* NameResolver may fail without ROM */ }
+        }
+
+        void ClassId1_Jump(object? sender, RoutedEventArgs e) => JumpToClassEditor(ClassId1Box);
+        async void ClassId1_Pick(object? sender, RoutedEventArgs e) => await PickClassIdInto(ClassId1Box);
+        void ClassId1_ValueChanged(object? sender, IdFieldValueChangedEventArgs e) => RefreshClassName(ClassId1Box, e.NewValue);
+
+        void ClassId2_Jump(object? sender, RoutedEventArgs e) => JumpToClassEditor(ClassId2Box);
+        async void ClassId2_Pick(object? sender, RoutedEventArgs e) => await PickClassIdInto(ClassId2Box);
+        void ClassId2_ValueChanged(object? sender, IdFieldValueChangedEventArgs e) => RefreshClassName(ClassId2Box, e.NewValue);
+
+        void ClassId3_Jump(object? sender, RoutedEventArgs e) => JumpToClassEditor(ClassId3Box);
+        async void ClassId3_Pick(object? sender, RoutedEventArgs e) => await PickClassIdInto(ClassId3Box);
+        void ClassId3_ValueChanged(object? sender, IdFieldValueChangedEventArgs e) => RefreshClassName(ClassId3Box, e.NewValue);
+
+        void ClassId4_Jump(object? sender, RoutedEventArgs e) => JumpToClassEditor(ClassId4Box);
+        async void ClassId4_Pick(object? sender, RoutedEventArgs e) => await PickClassIdInto(ClassId4Box);
+        void ClassId4_ValueChanged(object? sender, IdFieldValueChangedEventArgs e) => RefreshClassName(ClassId4Box, e.NewValue);
+
+        void ClassId5_Jump(object? sender, RoutedEventArgs e) => JumpToClassEditor(ClassId5Box);
+        async void ClassId5_Pick(object? sender, RoutedEventArgs e) => await PickClassIdInto(ClassId5Box);
+        void ClassId5_ValueChanged(object? sender, IdFieldValueChangedEventArgs e) => RefreshClassName(ClassId5Box, e.NewValue);
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();

--- a/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml
@@ -122,20 +122,27 @@
                  #950 T4: migrated from plain NumericUpDown to a class
                  IdFieldControl (hyperlink label + numeric + class-name preview
                  + Jump + Pick). Host Name="DisplayWeaponBox" + AutomationId
-                 (DisplayWeapon_Input) preserved. The separate ClassNamePreview
-                 TextBox is kept (the ClassName_Label AutomationId is asserted by
-                 OPClassDemoParityTests) as the canonical class-name readout. -->
-            <Label Grid.Row="5" Grid.Column="0" Content="Display Weapon (Class):" VerticalAlignment="Center" />
+                 (DisplayWeapon_Input) preserved.
+                 #951 review (layout-clip fix): the IdFieldControl needs ~420px;
+                 spanning the bare-minimum 0..2 (=420px) still clipped the
+                 "Pick..." button text, so it now spans columns 0..3
+                 (200+140+80+200 = 620px) for comfortable headroom — well above
+                 the too-narrow 1..2 (220px) that originally clipped the name
+                 preview / Pick button. Its hyperlink Label carries the original
+                 caption ("Display Weapon (Class):") so the redundant separate
+                 caption Label is removed; the ClassNamePreview readout moves to
+                 the trailing flexible column 4 (its ClassName_Label AutomationId
+                 is asserted by OPClassDemoParityTests). -->
             <controls:IdFieldControl AutomationProperties.AutomationId="OPClassDemoViewer_DisplayWeapon_Input"
-                                     Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2"
+                                     Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="4"
                                      Name="DisplayWeaponBox"
-                                     Label="Class ID:"
+                                     Label="Display Weapon (Class):"
                                      Maximum="255"
                                      JumpRequested="ClassId_Jump"
                                      PickRequested="ClassId_Pick"
                                      ValueChanged="ClassId_ValueChanged" />
             <TextBox AutomationProperties.AutomationId="OPClassDemoViewer_ClassName_Label"
-                     Grid.Row="5" Grid.Column="3" Grid.ColumnSpan="2"
+                     Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="1"
                      Name="ClassNamePreview" IsReadOnly="True" VerticalAlignment="Center" />
 
             <!-- Row 6: Ally/Enemy Color -->

--- a/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml
@@ -118,12 +118,22 @@
                      Grid.Row="4" Grid.Column="3" Grid.ColumnSpan="2"
                      Name="PalettePreview" IsReadOnly="True" VerticalAlignment="Center" />
 
-            <!-- Row 5: Display Weapon (Class) -->
+            <!-- Row 5: Display Weapon (Class) — B14, WF J_14_CLASS/L_14_CLASS.
+                 #950 T4: migrated from plain NumericUpDown to a class
+                 IdFieldControl (hyperlink label + numeric + class-name preview
+                 + Jump + Pick). Host Name="DisplayWeaponBox" + AutomationId
+                 (DisplayWeapon_Input) preserved. The separate ClassNamePreview
+                 TextBox is kept (the ClassName_Label AutomationId is asserted by
+                 OPClassDemoParityTests) as the canonical class-name readout. -->
             <Label Grid.Row="5" Grid.Column="0" Content="Display Weapon (Class):" VerticalAlignment="Center" />
-            <NumericUpDown AutomationProperties.AutomationId="OPClassDemoViewer_DisplayWeapon_Input"
-                           FormatString="0" Grid.Row="5" Grid.Column="1"
-                           Name="DisplayWeaponBox"
-                           Minimum="0" Maximum="255" VerticalAlignment="Center" />
+            <controls:IdFieldControl AutomationProperties.AutomationId="OPClassDemoViewer_DisplayWeapon_Input"
+                                     Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2"
+                                     Name="DisplayWeaponBox"
+                                     Label="Class ID:"
+                                     Maximum="255"
+                                     JumpRequested="ClassId_Jump"
+                                     PickRequested="ClassId_Pick"
+                                     ValueChanged="ClassId_ValueChanged" />
             <TextBox AutomationProperties.AutomationId="OPClassDemoViewer_ClassName_Label"
                      Grid.Row="5" Grid.Column="3" Grid.ColumnSpan="2"
                      Name="ClassNamePreview" IsReadOnly="True" VerticalAlignment="Center" />

--- a/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPClassDemoViewerView.axaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
+using FEBuilderGBA.Avalonia.Controls;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 using FEBuilderGBA.Core;
@@ -38,7 +39,8 @@ namespace FEBuilderGBA.Avalonia.Views
             N1List.SelectedAddressChanged += OnN1Selected;
             N2List.SelectedAddressChanged += OnN2Selected;
             DescTextIdBox.ValueChanged += OnDescTextIdChanged;
-            DisplayWeaponBox.ValueChanged += OnDisplayWeaponChanged;
+            // #950 T4: DisplayWeaponBox is now an IdFieldControl — its routed
+            // ValueChanged (ClassId_ValueChanged) is wired in AXAML, not here.
             EnglishNamePtrBox.ValueChanged += OnEnglishNamePtrChanged;
             PaletteIdBox.ValueChanged += OnPaletteIdChanged;
             TerrainLeftBox.ValueChanged += OnTerrainLeftChanged;
@@ -157,11 +159,64 @@ namespace FEBuilderGBA.Avalonia.Views
             catch { DescTextPreview.Text = ""; }
         }
 
-        void OnDisplayWeaponChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        // #950 T4: DisplayWeaponBox is the B14 class field (WF J_14_CLASS).
+        // Migrated to a class IdFieldControl — routed ValueChanged refreshes
+        // the ClassNamePreview readout AND the IdFieldControl's own inline name
+        // preview; Jump/Pick open the Class editor (ClassFE6View for FE6).
+        static uint ClassAddrFor(uint classId)
+        {
+            var rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return 0;
+            uint classPtr = rom.RomInfo.class_pointer;
+            if (classPtr == 0) return 0;
+            uint baseAddr = rom.p32(classPtr);
+            if (!U.isSafetyOffset(baseAddr, rom)) return 0;
+            uint dataSize = rom.RomInfo.class_datasize;
+            if (dataSize == 0) return 0;
+            uint entryAddr = baseAddr + classId * dataSize;
+            if (!U.isSafetyOffset(entryAddr, rom)) return 0;
+            if (!U.isSafetyOffset(entryAddr + dataSize - 1, rom)) return 0;
+            return entryAddr;
+        }
+
+        void ClassId_Jump(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                uint addr = ClassAddrFor(DisplayWeaponBox.Value);
+                if (addr == 0) return;
+                if (CoreState.ROM?.RomInfo?.version == 6)
+                    WindowManager.Instance.Navigate<ClassFE6View>(addr);
+                else
+                    WindowManager.Instance.Navigate<ClassEditorView>(addr);
+            }
+            catch (Exception ex) { Log.Error($"OPClassDemoViewerView.ClassId_Jump: {ex.Message}"); }
+        }
+
+        async void ClassId_Pick(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                uint addr = ClassAddrFor(DisplayWeaponBox.Value);
+                PickResult? result;
+                if (CoreState.ROM?.RomInfo?.version == 6)
+                    result = await WindowManager.Instance.PickFromEditor<ClassFE6View>(addr, this);
+                else
+                    result = await WindowManager.Instance.PickFromEditor<ClassEditorView>(addr, this);
+                if (result != null) DisplayWeaponBox.Value = (uint)result.Index;
+            }
+            catch (Exception ex) { Log.Error($"OPClassDemoViewerView.ClassId_Pick: {ex.Message}"); }
+        }
+
+        void ClassId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
         {
             if (_vm.IsLoading) return;
-            uint id = (uint)(DisplayWeaponBox.Value ?? 0);
-            try { ClassNamePreview.Text = NameResolver.GetClassName(id); }
+            try
+            {
+                string name = NameResolver.GetClassName(e.NewValue);
+                ClassNamePreview.Text = name;
+                DisplayWeaponBox.NameText = name;
+            }
             catch { ClassNamePreview.Text = ""; }
         }
 
@@ -418,7 +473,12 @@ namespace FEBuilderGBA.Avalonia.Views
                 ? R._("Default palette") : $"Palette 0x{_vm.PaletteId:X02}";
 
             DisplayWeaponBox.Value = _vm.DisplayWeapon;
-            try { ClassNamePreview.Text = NameResolver.GetClassName(_vm.DisplayWeapon); }
+            try
+            {
+                string className = NameResolver.GetClassName(_vm.DisplayWeapon);
+                ClassNamePreview.Text = className;
+                DisplayWeaponBox.NameText = className;
+            }
             catch { ClassNamePreview.Text = ""; }
 
             AllyEnemyColorBox.Value = _vm.AllyEnemyColor;
@@ -474,7 +534,8 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.JapaneseNamePointer = (uint)(JpNamePtrBox.Value ?? 0);
                 _vm.JapaneseNameLength = (uint)(JpNameLenBox.Value ?? 0);
                 _vm.PaletteId = (uint)(PaletteIdBox.Value ?? 0);
-                _vm.DisplayWeapon = (uint)(DisplayWeaponBox.Value ?? 0);
+                // #950 T4: IdFieldControl.Value is a non-nullable uint.
+                _vm.DisplayWeapon = DisplayWeaponBox.Value;
                 _vm.AllyEnemyColor = (uint)(AllyEnemyColorBox.Value ?? 0);
                 _vm.BattleAnime = (uint)(BattleAnimeBox.Value ?? 0);
                 _vm.MagicEffect = (uint)(MagicEffectBox.Value ?? 0);

--- a/FEBuilderGBA.Avalonia/Views/SummonUnitViewerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SummonUnitViewerView.axaml
@@ -28,8 +28,19 @@
                                    PickRequested="UnitId_Pick"
                                    ValueChanged="UnitId_ValueChanged" />
 
-          <TextBlock Grid.Row="2" Grid.Column="0" Text="Summoned Unit:" VerticalAlignment="Center" />
-          <NumericUpDown AutomationProperties.AutomationId="SummonUnitViewer_SummonedUnit_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="UnknownBox" Minimum="0" Maximum="255" VerticalAlignment="Center" />
+          <!-- #950 T4: "Summoned Unit" (B1, WF J_1_UNIT/L_1_UNIT) is a real unit ID.
+               Migrated from plain NumericUpDown to a unit IdFieldControl mirroring
+               the "Summoner" (B0/UnitIdBox) field. Host Name="UnknownBox" +
+               AutomationId (SummonUnitViewer_SummonedUnit_Input) preserved; the
+               1-based unit-ID conversion follows the sibling field's helpers. -->
+          <controls:IdFieldControl AutomationProperties.AutomationId="SummonUnitViewer_SummonedUnit_Input"
+                                   Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
+                                   Name="UnknownBox"
+                                   Label="Summoned Unit:"
+                                   Maximum="255"
+                                   JumpRequested="SummonedUnit_Jump"
+                                   PickRequested="SummonedUnit_Pick"
+                                   ValueChanged="SummonedUnit_ValueChanged" />
         </Grid>
 
         <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,16,0,0">

--- a/FEBuilderGBA.Avalonia/Views/SummonUnitViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SummonUnitViewerView.axaml.cs
@@ -62,7 +62,11 @@ namespace FEBuilderGBA.Avalonia.Views
             // the 0/bounds cases and the 1-based → 0-based conversion (#937).
             try { UnitIdBox.NameText = NameResolver.GetUnitNameByOneBasedId(_vm.UnitId); }
             catch { /* GetUnitNameByOneBasedId returns a fallback and never throws; defensive only */ }
+            // #950 T4: Summoned Unit (B1) is also a 1-based unit ID; populate the
+            // IdFieldControl value + inline unit-name preview like Summoner (B0).
             UnknownBox.Value = _vm.Unknown;
+            try { UnknownBox.NameText = NameResolver.GetUnitNameByOneBasedId(_vm.Unknown); }
+            catch { /* GetUnitNameByOneBasedId returns a fallback and never throws; defensive only */ }
         }
 
         void Write_Click(object? sender, RoutedEventArgs e)
@@ -72,7 +76,8 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 _vm.UnitId = UnitIdBox.Value;
-                _vm.Unknown = (uint)(UnknownBox.Value ?? 0);
+                // #950 T4: IdFieldControl.Value is a non-nullable uint.
+                _vm.Unknown = UnknownBox.Value;
                 _vm.WriteSummonUnit();
                 _undoService.Commit();
                 _vm.MarkClean();
@@ -115,6 +120,42 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             // 1-based Unit ID → name via GetUnitNameByOneBasedId (#937).
             try { UnitIdBox.NameText = NameResolver.GetUnitNameByOneBasedId(e.NewValue); }
+            catch { /* GetUnitNameByOneBasedId returns a fallback and never throws; defensive only */ }
+        }
+
+        // -- Summoned Unit IdFieldControl handlers (#950 T4) -----------------
+        // B1 is a 1-based unit ID, identical handling to Summoner (B0): the
+        // 1-based (id-1)+FE6-dummy-skip nav helper for Jump, and the
+        // OneBasedIdFromPickIndex conversion on the Pick result.
+
+        void SummonedUnit_Jump(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                uint addr = SupportUnitNavigation.UnitAddrForOneBased(CoreState.ROM, UnknownBox.Value);
+                if (addr == 0) return;
+                WindowManager.Instance.Navigate<UnitEditorView>(addr);
+            }
+            catch (Exception ex) { Log.Error("SummonUnitViewerView.SummonedUnit_Jump failed: {0}", ex.Message); }
+        }
+
+        async void SummonedUnit_Pick(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                uint addr = SupportUnitNavigation.UnitAddrForOneBased(CoreState.ROM, UnknownBox.Value);
+                var result = await WindowManager.Instance.PickFromEditor<UnitEditorView>(addr, this);
+                if (result != null)
+                {
+                    UnknownBox.Value = SupportUnitNavigation.OneBasedIdFromPickIndex(result.Index);
+                }
+            }
+            catch (Exception ex) { Log.Error("SummonUnitViewerView.SummonedUnit_Pick failed: {0}", ex.Message); }
+        }
+
+        void SummonedUnit_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
+        {
+            try { UnknownBox.NameText = NameResolver.GetUnitNameByOneBasedId(e.NewValue); }
             catch { /* GetUnitNameByOneBasedId returns a fallback and never throws; defensive only */ }
         }
 


### PR DESCRIPTION
## Summary

Bugs #6, #14, #21, #22, #23b from the 2026-06-04 QA sweep (issue #950): the recurring pattern where a record's FIRST type-ID field got the `IdFieldControl` affordance (label + numeric + name preview + Jump + Pick) but its SIBLING type-ID fields were left as bare `NumericUpDown`s. This migrates the remaining secondary type-ID fields, validated against the WinForms `J_/L_*` designer markers.

## Migrated (entity ID → Jump/Pick target)
- **#22 `MonsterItemViewerView`** Item 2/3/4/5 (B1–B4, WF `L_1..4_ITEM`) → **item** → ItemEditor (ItemFE6 on FE6).
- **#21 `MonsterProbabilityViewerView`** Class ID 1–5 (B0–B4, WF `L_0..4_CLASS`) → **class** → ClassEditor.
- **#23b `SummonUnitViewerView`** Summoned Unit (B1, WF `J_1_UNIT`, 1-based) → **unit** → UnitEditor (same one-based handling as Summoner).
- **#14 `ClassOPDemoView` + `OPClassDemoViewerView`** Display Weapon class field (B14, WF `J_14_CLASS`) → **class** → ClassEditor. (FE7/FE7U/FE8U variants were already migrated — verified per-view.)
- **#6 `EventCondView`** TALK Unit 1/2 → **unit**; OBJECT Chest Item → **item**. (These are static `IsVisible`-toggled inline panels, not a dynamic compose path, so no compose rework needed. The `Event Pointer` (code pointer) and `Type` discriminant are correctly left as-is.)

Each migration preserves the old control `Name` + AutomationId (forwarded onto the inner NumericUpDown) so `FindControl<>` + E2E selectors keep working.

## NOT migrated (per the plan review's exclusions)
Monster Item holdings `Candidate`/`HoldingItem1..10` (1-based row indices into local tabs, not FE item IDs); all probabilities/percentages, `Unknown*`, flags, coords, turn ranges, pointers/ASM slots, OPClassDemo pointer/glyph/enum/palette/anime/terrain fields. EventCond tutorial Text ID is allow-listed for a focused follow-up.

## Detector — `IdFieldMigrationTests.cs`
A conservative pure-XML scanner: flags any `NumericUpDown` whose ADJACENT label (same Grid-row/StackPanel sibling) matches a strong entity-ID pattern (`Unit ID`, `Class ID[ N]`, `Item ID`, `Text ID`, `Item 2..5`, `Summoned Unit`) and is neither an `IdFieldControl` nor on a per-control allow-list (keyed by `{view, controlName}` with a reason; **fails if an allow-listed control disappears** so stale exceptions can't mask regressions). **Validated red→green** (flags the un-allow-listed EventCond TextIdBox, green with the entry restored). 1 allow-list entry (EventCond tutorial Text ID — deferred).

## Scope
Closes #21, #22, #23b, #14, and the #6 (Talk Unit / Chest Item) portion of #950.

## Screenshots

| Bug | Before | After |
|---|---|---|
| #22 Monster Item (Item 2–5) | ![b](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/bugsweep/bug22-monster-item.png?raw=1) | ![a](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug22-monster-item-after.png) |
| #21 Monster Probability (Class ID 1–5) | ![b](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/bugsweep/bug21-monster-probability.png?raw=1) | ![a](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug21-monster-prob-after.png) |
| #23b Summon (Summoned Unit) | ![b](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/bugsweep/bug23-summon-unit.png?raw=1) | ![a](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug23-summon-unit-after.png) |
| #14 OP Class Demo (Display Weapon class) | — | ![a](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug14-opclassdemo-after.png) |

After (FE8J): Monster Item shows Item 2–5 as item pickers with name previews; Monster Probability shows Class ID 1–5 with class-name previews (ゾンビ/マミー/スケルトン); Summon shows Summoned Unit with unit-name preview (ユアン/亡霊戦士). EventCond TALK Unit/Chest Item are in `IsVisible`-toggled panels (proven by the `EventCond_TalkUnitBoxes_AreIdFieldControls` / `EventCond_ChestItemBox_IsIdFieldControl` tests rather than the default-state render).

## GUI Test Report

| Test | Result |
|------|--------|
| Monster Item Item 2–5 are item `IdFieldControl`s (Jump/Pick → ItemEditor) | ✅ PASS |
| Monster Probability Class ID 1–5 are class `IdFieldControl`s | ✅ PASS |
| Summon Summoned Unit is a unit `IdFieldControl` (1-based) | ✅ PASS |
| OP Class Demo Display Weapon class field migrated (FE7/FE7U/FE8U already done) | ✅ PASS |
| EventCond TALK Unit 1/2 + Chest Item migrated; Event Pointer/Type untouched | ✅ PASS |
| Excluded fields (holdings indices, probabilities, pointers) untouched | ✅ PASS |
| Detector validated red→green | ✅ PASS |
| `validate-automation-ids.ps1` → PASSED | ✅ PASS |
| Full `FEBuilderGBA.Avalonia.Tests` (7456 passed / 0 failed / 3 skipped, incl. 18 new + detector) | ✅ PASS |

Render: offscreen `--screenshot-all`. ROM: `roms/FE8J.gba`.

## Test plan
- [x] 18 per-field assertions (IsIdFieldControl + Label + AutomationId-unique + ShowPick) across all migrated fields
- [x] Detector red→green validated; per-control allow-list with anti-stale guard
- [x] Excluded fields confirmed untouched (holdings/probabilities/pointers)
- [x] Full Avalonia.Tests green (7456/0/3); AutomationId validator green
- [x] After-screenshots of the actual editors (FE8J) with name previews

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Code 2.1.162 · model claude-opus-4-8[1m]
