### PR TITLE
feat(avalonia): resolve PLIST labels in MapTileAnimation editors (#11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -509,9 +509,10 @@ Specialized utilities for different graphic types:
 - `MapPListResolverCore.cs` (Core, READ-ONLY) - Cross-platform port of the
   WinForms map-PLIST label resolver (`MapPointerForm.GetPListNameSplited` /
   `GetPListNameNotSplite` / `ConvertBaseAddrToType` + `MapSettingForm.PLists` /
-  `GetMapPListsWhereAddr`) used by the MapPointer + MapChange Avalonia editors to
-  show resolved map names (`MAP Ch1`, `MAPCHANGE Ch5`, `ANIME1 Prologue`, `OBJ …`,
-  `NULL`, `-EMPTY-`, `UNK`) instead of raw `0x08……` pointers (#952). `PLists`
+  `GetMapPListsWhereAddr`) used by the MapPointer + MapChange + MapTileAnimation
+  Avalonia editors to show resolved map names (`MAP Ch1`, `MAPCHANGE Ch5`,
+  `ANIME1 Prologue`, `ANIME2 Ch18 …`, `OBJ …`, `NULL`, `-EMPTY-`, `UNK`) instead
+  of raw `0x08……` pointers / PLIST-hex labels (#952). `PLists`
   reads each field from its REAL per-version source — `event_plist` from
   `RomInfo.map_setting_event_plist_pos`, FE6 worldmap from
   `map_setting_worldmap_plist_pos`, and the **PAL2 offset (146 vs 45) from the
@@ -530,6 +531,18 @@ Specialized utilities for different graphic types:
   `BuildMapChangeList` golden builders call the SAME resolver in lockstep;
   independent Core oracle tests (`MapPListResolverCoreTests`) hand-build
   expectations from raw map bytes on synthetic + real FE6/FE7U/FE8U ROMs.
+  MapTileAnimation rewire (#952 T5 slice B, bug #11): `MapTileAnimationView`
+  (the simple, menu-reachable editor) resolves each `map_tileanime1_pointer`
+  slot index — an ANIMATION PLIST id — via `ResolveLabel(rom, ANIMATION, i)`
+  (ANIME1 and ANIME2 both match under ANIMATION); `MapTileAnimation2Core.BuildPlistList`
+  resolves each FILTER-combo row via `ResolveLabel(rom, ANIMATION2, plist)` (the
+  broken-PLIST `(破損)` suffix is still appended). Lockstep golden builders:
+  `ListParityHelper.BuildMapTileAnimationList` + the new public
+  `BuildMapTileAnimation2FilterList`. **`MapTileAnimation1` is DEFERRED**: it has
+  no PLIST filter at all (its list shows DATA fields, not a raw label), so WF
+  parity there is a STRUCTURAL feature addition (filter-from-map-settings +
+  selected-PLIST data, mirroring MapTileAnimation2), tracked for a focused
+  follow-up — out of scope for the #11 label-resolution bug.
 
 ### Caching System
 

--- a/FEBuilderGBA.Avalonia.Tests/MapTileAnimationResolverParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/MapTileAnimationResolverParityTests.cs
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// VM + golden-builder parity tests for the MapTileAnimation PLIST-label rewire
+// (#952, T5 slice B = bug #11).
+//
+//  * MapTileAnimationView (STEP 1): LoadMapTileAnimationList resolves each
+//    slot index (an ANIMATION PLIST id) to "ANIME1/ANIME2 MapName" /
+//    NULL / -EMPTY- / UNK — never a bare 0x… pointer or the old
+//    "{id} TileAnim 0x…" string. Lockstep with the golden builder
+//    ListParityHelper.BuildMapTileAnimationList (reached via BuildReferenceList).
+//  * MapTileAnimation2 (STEP 2): LoadPlistList filter labels resolve to
+//    "ANIME2 MapName" via the shared resolver — never the old raw
+//    "タイルアニメーション2 パレットアニメ:{plist}" PLIST-hex string. Lockstep with
+//    the golden builder ListParityHelper.BuildMapTileAnimation2FilterList.
+//  * Smoke guard: the list-building / filter-building source no longer emits a
+//    bare 0x{...:X08} row label or the old raw label strings.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+public class MapTileAnimationResolverParityTests : IClassFixture<RomFixture>
+{
+    readonly RomFixture _rom;
+
+    public MapTileAnimationResolverParityTests(RomFixture rom)
+    {
+        _rom = rom;
+    }
+
+    // -----------------------------------------------------------------
+    // STEP 1: MapTileAnimationView (the simple, menu-reachable editor).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void MapTileAnimationView_List_ProducesResolvedLabels()
+    {
+        if (!_rom.IsAvailable) return; // skip
+
+        var vm = new MapTileAnimationViewModel();
+        List<AddrResult> rows = vm.LoadMapTileAnimationList();
+        Assert.NotEmpty(rows);
+        foreach (AddrResult r in rows)
+        {
+            AssertResolvedLabel(r.name, "MapTileAnimationView list");
+            // The old format was "{id} TileAnim 0x…" — must be gone.
+            Assert.DoesNotContain("TileAnim", r.name);
+        }
+
+        // Prove the resolver actually named at least one ANIME slot (split) or
+        // resolved to NULL/-EMPTY-/UNK (non-split / empty) rather than a raw row.
+        bool anyResolved = rows.Exists(r =>
+            r.name.Contains(" ANIME1 ") || r.name.Contains(" ANIME2 ") ||
+            r.name.EndsWith(" NULL") || r.name.Contains(" -EMPTY-") ||
+            r.name.Contains(" UNK"));
+        Assert.True(anyResolved,
+            "expected at least one ANIME1/ANIME2/NULL/-EMPTY-/UNK resolved label");
+    }
+
+    [Fact]
+    public void MapTileAnimationView_VM_And_GoldenBuilder_Lockstep()
+    {
+        if (!_rom.IsAvailable) return;
+
+        var vm = new MapTileAnimationViewModel();
+        List<AddrResult> vmRows = vm.LoadMapTileAnimationList();
+        List<AddrResult> golden = ListParityHelper.BuildReferenceList("MapTileAnimationView");
+
+        Assert.Equal(golden.Count, vmRows.Count);
+        for (int i = 0; i < vmRows.Count; i++)
+        {
+            Assert.Equal(golden[i].name, vmRows[i].name);
+            Assert.Equal(golden[i].addr, vmRows[i].addr);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // STEP 2: MapTileAnimation2 filter labels.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void MapTileAnimation2_FilterLabels_ProduceResolvedAnime2Labels()
+    {
+        if (!_rom.IsAvailable) return;
+
+        var vm = new MapTileAnimation2ViewModel();
+        List<MapTileAnimation2Core.PlistRow> rows = vm.LoadPlistList();
+        // Some ROMs may legitimately have no anime2 PLISTs; only assert on the
+        // rows that exist.
+        foreach (var row in rows)
+        {
+            // The old raw label must be gone.
+            Assert.DoesNotContain("パレットアニメ", row.Display);
+            AssertResolvedLabel(row.Display, "MapTileAnimation2 filter");
+        }
+
+        // When rows exist, at least one should resolve to an ANIME2 map name
+        // (the non-broken case) or carry the broken suffix.
+        if (rows.Count > 0)
+        {
+            bool anyResolved = rows.Exists(r =>
+                r.Display.StartsWith("ANIME2 ") || r.Display.Contains("("));
+            Assert.True(anyResolved,
+                "expected at least one resolved ANIME2 / broken-suffix filter label");
+        }
+    }
+
+    [Fact]
+    public void MapTileAnimation2_FilterVM_And_GoldenBuilder_Lockstep()
+    {
+        if (!_rom.IsAvailable) return;
+
+        var vm = new MapTileAnimation2ViewModel();
+        List<MapTileAnimation2Core.PlistRow> vmRows = vm.LoadPlistList();
+        List<AddrResult> golden = ListParityHelper.BuildMapTileAnimation2FilterList(_rom.ROM!);
+
+        Assert.Equal(vmRows.Count, golden.Count);
+        for (int i = 0; i < vmRows.Count; i++)
+        {
+            // The golden filter builder copies PlistRow.Display verbatim, so the
+            // VM filter combo strings and the golden labels must match exactly.
+            Assert.Equal(vmRows[i].Display, golden[i].name);
+            Assert.Equal(vmRows[i].Plist, golden[i].tag);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Smoke guard: list/filter builders must not emit raw labels.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void Builders_DoNotEmit_RawLabels()
+    {
+        string root = FindRepoRoot();
+
+        // MapTileAnimationViewModel.LoadMapTileAnimationList — no raw 0x…X08
+        // pointer label, no "TileAnim" string.
+        string vmSrc = Path.Combine(root, "FEBuilderGBA.Avalonia", "ViewModels", "MapTileAnimationViewModel.cs");
+        string loadBody = ExtractMethodBody(File.ReadAllText(vmSrc), "LoadMapTileAnimationList");
+        Assert.False(string.IsNullOrEmpty(loadBody), "LoadMapTileAnimationList not found");
+        Assert.DoesNotContain("\" TileAnim \"", loadBody);
+        Assert.DoesNotContain(":X08}", loadBody);
+
+        // ListParityHelper.BuildMapTileAnimationList — same.
+        string parity = Path.Combine(root, "FEBuilderGBA.Avalonia", "Services", "ListParityHelper.cs");
+        string goldenBody = ExtractMethodBody(File.ReadAllText(parity), "BuildMapTileAnimationList");
+        Assert.False(string.IsNullOrEmpty(goldenBody), "BuildMapTileAnimationList not found");
+        Assert.DoesNotContain("\" TileAnim \"", goldenBody);
+        Assert.DoesNotContain(".ToString(\"X08\")", goldenBody);
+
+        // MapTileAnimation2Core.BuildPlistList — old raw PLIST-hex key gone.
+        string coreSrc = Path.Combine(root, "FEBuilderGBA.Core", "MapTileAnimation2Core.cs");
+        string plistBody = ExtractMethodBody(File.ReadAllText(coreSrc), "BuildPlistList");
+        Assert.False(string.IsNullOrEmpty(plistBody), "BuildPlistList not found");
+        Assert.DoesNotContain("パレットアニメ:{0}", plistBody);
+    }
+
+    // =================================================================
+    // Helpers (mirror MapPListResolverParityTests).
+    // =================================================================
+
+    static void AssertResolvedLabel(string label, string ctx)
+    {
+        Assert.NotNull(label);
+        // A resolved row is "{idHex} {TYPE MapName}" / "{idHex} NULL" /
+        // "{idHex} -EMPTY-" / "{idHex} UNK" (filter labels omit the id prefix).
+        // The id prefix uses U.ToHexString (e.g. "0x01"), which is allowed; what
+        // is forbidden is an 8-digit raw POINTER like "0x08123456" as the value.
+        Assert.DoesNotContain("0x08", label);
+        Assert.False(Regex.IsMatch(label, @"0x[0-9A-Fa-f]{8}"),
+            $"{ctx}: row label still contains a raw 0x… pointer: '{label}'");
+    }
+
+    static string ExtractMethodBody(string src, string methodName)
+    {
+        int sig = src.IndexOf(methodName + "(");
+        if (sig < 0) return "";
+        int open = src.IndexOf('{', sig);
+        if (open < 0) return "";
+        int depth = 0;
+        for (int i = open; i < src.Length; i++)
+        {
+            if (src[i] == '{') depth++;
+            else if (src[i] == '}')
+            {
+                depth--;
+                if (depth == 0) return src.Substring(open, i - open + 1);
+            }
+        }
+        return "";
+    }
+
+    static string FindRepoRoot()
+    {
+        string dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        for (int i = 0; i < 12; i++)
+        {
+            if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                return dir;
+            dir = Path.GetDirectoryName(dir)!;
+        }
+        throw new System.InvalidOperationException("Repo root not found");
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/MapTileAnimationResolverParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/MapTileAnimationResolverParityTests.cs
@@ -169,10 +169,12 @@ public class MapTileAnimationResolverParityTests : IClassFixture<RomFixture>
         Assert.NotNull(label);
         // A resolved row is "{idHex} {TYPE MapName}" / "{idHex} NULL" /
         // "{idHex} -EMPTY-" / "{idHex} UNK" (filter labels omit the id prefix).
-        // The id prefix uses U.ToHexString (e.g. "0x01"), which is allowed; what
-        // is forbidden is an 8-digit raw POINTER like "0x08123456" as the value.
-        Assert.DoesNotContain("0x08", label);
-        Assert.False(Regex.IsMatch(label, @"0x[0-9A-Fa-f]{8}"),
+        // The id prefix uses U.ToHexString (e.g. "0x01"), which is allowed, and a
+        // legitimate map name could even contain a short "0x08" substring — so we
+        // forbid ONLY a FULL GBA pointer literal: a word-bounded 8-hex-digit 0x
+        // value like "0x08123456" (#954 review — the old bare "0x08" substring
+        // check was over-aggressive and could reject a valid label).
+        Assert.False(Regex.IsMatch(label, @"\b0x[0-9A-Fa-f]{8}\b"),
             $"{ctx}: row label still contains a raw 0x… pointer: '{label}'");
     }
 

--- a/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
@@ -2067,13 +2067,19 @@ namespace FEBuilderGBA.Avalonia.Services
         }
 
         /// <summary>Build map tile animation list matching MapTileAnimationViewModel.
-        /// Uses map_tileanime1_pointer — 4-byte pointer entries, stops at 0xFFFFFFFF.</summary>
+        /// Uses map_tileanime1_pointer — 4-byte pointer entries, stops at 0xFFFFFFFF.
+        /// Lockstep with MapTileAnimationViewModel.LoadMapTileAnimationList (#952,
+        /// #11): each slot index IS the ANIMATION PLIST id, resolved to an
+        /// "ANIME1/ANIME2 MapName" label via the shared resolver instead of a
+        /// raw 0x… pointer.</summary>
         static List<AddrResult> BuildMapTileAnimationList(ROM rom)
         {
             uint ptr = rom.RomInfo.map_tileanime1_pointer;
             if (ptr == 0) return new List<AddrResult>();
             uint baseAddr = rom.p32(ptr);
             if (!U.isSafetyOffset(baseAddr)) return new List<AddrResult>();
+
+            var cache = MapPListResolverCore.BuildCache(rom);
 
             const uint blockSize = 4;
             var result = new List<AddrResult>();
@@ -2085,11 +2091,9 @@ namespace FEBuilderGBA.Avalonia.Services
                 uint pointer = rom.u32(addr);
                 if (pointer == 0xFFFFFFFF) break;
 
-                // Match Avalonia VM format
-                string ptrStr = U.isPointer(pointer)
-                    ? "0x" + pointer.ToString("X08")
-                    : (pointer == 0 ? "NULL" : "0x" + pointer.ToString("X08"));
-                string name = U.ToHexString(i) + " TileAnim " + ptrStr;
+                string label = MapPListResolverCore.ResolveLabel(
+                    rom, MapChangeCore.PlistType.ANIMATION, i, cache);
+                string name = U.ToHexString(i) + " " + label;
                 result.Add(new AddrResult(addr, name, i));
             }
             return result;
@@ -3773,6 +3777,26 @@ namespace FEBuilderGBA.Avalonia.Services
             }
 
             return new List<AddrResult>();
+        }
+
+        /// <summary>Build the MapTileAnimation2 FILTER-combo list (the PLIST
+        /// filter rows shown above the entry list), in lockstep with
+        /// MapTileAnimation2ViewModel.LoadPlistList() →
+        /// MapTileAnimation2Core.BuildPlistList(). Each filter row's Display is
+        /// the resolved "ANIME2 MapName" label via the shared resolver (#952,
+        /// #11), not the raw "タイルアニメーション2 パレットアニメ:{plist}" string.
+        /// Returns one AddrResult per filter row (addr = resolved data offset,
+        /// name = resolved Display, tag = PLIST id) so parity tests can compare
+        /// the VM filter labels against this golden builder.</summary>
+        public static List<AddrResult> BuildMapTileAnimation2FilterList(ROM rom)
+        {
+            var rows = MapTileAnimation2Core.BuildPlistList(rom);
+            var result = new List<AddrResult>(rows.Count);
+            foreach (var row in rows)
+            {
+                result.Add(new AddrResult(row.Addr, row.Display, row.Plist));
+            }
+            return result;
         }
 
         /// <summary>Build map terrain name (English) list — from map_terrain_name_pointer.

--- a/FEBuilderGBA.Avalonia/ViewModels/MapTileAnimation1ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapTileAnimation1ViewModel.cs
@@ -5,7 +5,22 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 {
     /// <summary>Map tile animation type 1 editor.
     /// WinForms: MapTileAnimation1Form — block size 8, validated by isPointer(u32(addr+4)).
-    /// Fields: AnimInterval (u16@0), DataCount (u16@2), MapTileDataPointer (u32@4).</summary>
+    /// Fields: AnimInterval (u16@0), DataCount (u16@2), MapTileDataPointer (u32@4).
+    ///
+    /// <para>PLIST-RESOLUTION DEFERRED (#952, #11): the sibling editors
+    /// MapTileAnimationView (STEP 1) and MapTileAnimation2 (STEP 2) were rewired
+    /// to show resolved "ANIME1/ANIME2 MapName" labels via
+    /// <see cref="MapPListResolverCore"/>. MapTileAnimation1 is NOT a simple
+    /// label swap: this VM has no PLIST filter at all — its entry list already
+    /// shows DATA fields ("0x.. Interval=.. Count=..", correct WF parity for the
+    /// inner data table), so there is no raw 0x…/PLIST-hex label to resolve here.
+    /// Reaching WF parity (the filter-from-map-settings → PlistToOffsetAddr(
+    /// ANIMATION, anime1_plist) → selected-PLIST data structure that WF
+    /// MapTileAnimation1Form.MakeTileAnimation1 builds) is a STRUCTURAL feature
+    /// addition (new filter combo + Core BuildPlistList for anime1 + view
+    /// wiring), out of scope for the #11 label-resolution bug. Tracked for a
+    /// focused follow-up issue. The clean template already exists in
+    /// MapTileAnimation2Core/View if/when that follow-up lands.</para></summary>
     public class MapTileAnimation1ViewModel : ViewModelBase, IDataVerifiable
     {
         static readonly List<EditorFormRef.FieldDef> _fields =

--- a/FEBuilderGBA.Avalonia/ViewModels/MapTileAnimationViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapTileAnimationViewModel.cs
@@ -35,6 +35,16 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             uint baseAddr = rom.p32(ptr);
             if (!U.isSafetyOffset(baseAddr)) return new List<AddrResult>();
 
+            // map_tileanime1_pointer is the ANIMATION PLIST table base, so each
+            // 4-byte slot index IS the PLIST id. Resolve each row to a
+            // "ANIME1/ANIME2 MapName" label via the shared resolver (#952, #11)
+            // instead of a raw 0x… pointer. ANIME1 and ANIME2 both resolve under
+            // PlistType.ANIMATION (they share this table); GetPListNameSplited
+            // returns whichever map field equals the id. The lockstep golden
+            // builder ListParityHelper.BuildMapTileAnimationList calls the SAME
+            // resolver.
+            var cache = MapPListResolverCore.BuildCache(rom);
+
             var result = new List<AddrResult>();
             for (uint i = 0; i < 0x100; i++)
             {
@@ -45,10 +55,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 // Stop if we hit clearly invalid data
                 if (pointer == 0xFFFFFFFF) break;
 
-                string ptrStr = U.isPointer(pointer)
-                    ? "0x" + pointer.ToString("X08")
-                    : (pointer == 0 ? "NULL" : "0x" + pointer.ToString("X08"));
-                string name = U.ToHexString(i) + " TileAnim " + ptrStr;
+                string label = MapPListResolverCore.ResolveLabel(
+                    rom, MapChangeCore.PlistType.ANIMATION, i, cache);
+                string name = U.ToHexString(i) + " " + label;
                 result.Add(new AddrResult(addr, name, i));
             }
             return result;

--- a/FEBuilderGBA.Core.Tests/MapTileAnimation2CoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/MapTileAnimation2CoreTests.cs
@@ -235,6 +235,70 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         // -----------------------------------------------------------------
+        // BuildPlistList resolved-label semantics (#952, #11)
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void BuildPlistList_ResolvesFilterLabelToAnime2MapName()
+        {
+            // A single map with anime2_plist == 1 resolving to a valid data
+            // block. The filter row's Display must be the RESOLVED
+            // "ANIME2 MapName" label, NOT the old raw
+            // "タイルアニメーション2 パレットアニメ:{plist}" PLIST-hex string.
+            var rom = MakeSyntheticFE8URom(out uint mapBase, out uint plistTableBase, out uint mapPtrBase);
+            int mapBaseI = (int)mapBase;
+            int dataSizeI = (int)rom.RomInfo.map_setting_datasize;
+
+            // map[0]: D0=pointer (valid), anime2_plist=1
+            WriteU32(rom.Data, mapBaseI + 0, 0x08800000u);
+            rom.Data[mapBaseI + 10] = 1;
+            // map[1]: terminator (non-pointer D0)
+            WriteU32(rom.Data, mapBaseI + dataSizeI + 0, 0u);
+
+            // PLIST table entry for plist=1 -> valid data block.
+            uint plist1Slot = plistTableBase + 1 * 4;
+            WriteU32(rom.Data, (int)plist1Slot, 0x08900000u);
+            WriteU32(rom.Data, (int)0x900000 + 0, 0x08A00000u);
+
+            var rows = MapTileAnimation2Core.BuildPlistList(rom);
+            Assert.Single(rows);
+            Assert.Equal(1u, rows[0].Plist);
+            Assert.False(rows[0].IsBroken);
+
+            // Must NOT be the old raw PLIST-hex label.
+            Assert.DoesNotContain("パレットアニメ", rows[0].Display);
+            // Must be the resolved ANIME2 label (split layout: anime2_plist==1
+            // matches under ANIMATION2; non-split: first matching field is
+            // anime2_plist so still "ANIME2 ...").
+            Assert.StartsWith("ANIME2 ", rows[0].Display);
+        }
+
+        [Fact]
+        public void BuildPlistList_BrokenRow_KeepsResolvedLabelPlusBrokenSuffix()
+        {
+            // Broken PLIST: Display = resolved label + "(破損)". The resolved
+            // prefix must not be the old raw PLIST-hex string, and the broken
+            // suffix paren must still be present (repair affordance).
+            var rom = MakeSyntheticFE8URom(out uint mapBase, out uint plistTableBase, out uint mapPtrBase);
+            int mapBaseI = (int)mapBase;
+            int dataSizeI = (int)rom.RomInfo.map_setting_datasize;
+
+            WriteU32(rom.Data, mapBaseI + 0, 0x08800000u);
+            rom.Data[mapBaseI + 10] = 2;
+            WriteU32(rom.Data, mapBaseI + dataSizeI + 0, 0u);
+            // plist=2 slot -> zero (broken).
+            WriteU32(rom.Data, (int)(plistTableBase + 2 * 4), 0u);
+
+            var rows = MapTileAnimation2Core.BuildPlistList(rom);
+            Assert.Single(rows);
+            Assert.True(rows[0].IsBroken);
+            Assert.DoesNotContain("パレットアニメ", rows[0].Display);
+            // Broken suffix still present (R._("(破損)") returns the JP source
+            // when no translation table is loaded; assert the open paren).
+            Assert.Contains("(", rows[0].Display);
+        }
+
+        // -----------------------------------------------------------------
         // BuildPaletteList - decodes per-row RGB
         // -----------------------------------------------------------------
 

--- a/FEBuilderGBA.Core/MapTileAnimation2Core.cs
+++ b/FEBuilderGBA.Core/MapTileAnimation2Core.cs
@@ -144,11 +144,13 @@ namespace FEBuilderGBA
             // shared resolver (#952, #11) instead of the raw
             // "タイルアニメーション2 パレットアニメ:{plist}" PLIST-hex string.
             // Built once and reused across the loop (per-call local cache).
+            // The cache already enumerated every map via MapSettingCore.MakeMapIDList,
+            // so reuse cache.Maps for the filter scan instead of a second
+            // MakeMapIDList allocation/scan (#954 review).
             var resolveCache = MapPListResolverCore.BuildCache(rom);
 
             var seen = new HashSet<uint>();
-            var maps = MapSettingCore.MakeMapIDList(rom);
-            foreach (var map in maps)
+            foreach (var map in resolveCache.Maps)
             {
                 if (map.addr + 11 > (uint)rom.Data.Length) continue;
                 uint plist = rom.u8(map.addr + 10);

--- a/FEBuilderGBA.Core/MapTileAnimation2Core.cs
+++ b/FEBuilderGBA.Core/MapTileAnimation2Core.cs
@@ -140,6 +140,12 @@ namespace FEBuilderGBA
             uint plistTableBase = rom.p32(plistTablePtr);
             if (!U.isSafetyOffset(plistTableBase, rom)) return result;
 
+            // Resolve each filter row to an "ANIME2 MapName" label via the
+            // shared resolver (#952, #11) instead of the raw
+            // "タイルアニメーション2 パレットアニメ:{plist}" PLIST-hex string.
+            // Built once and reused across the loop (per-call local cache).
+            var resolveCache = MapPListResolverCore.BuildCache(rom);
+
             var seen = new HashSet<uint>();
             var maps = MapSettingCore.MakeMapIDList(rom);
             foreach (var map in maps)
@@ -189,13 +195,17 @@ namespace FEBuilderGBA
                     }
                 }
 
-                // Localize the display label via R._() against the
-                // existing WF translation keys ("タイルアニメーション2
-                // パレットアニメ:{0}" + "(破損)") so the filter combo stays
-                // translatable across ja / zh - matches the WinForms
-                // MapTileAnimation2Form.MakeTileAnimation2 behavior
-                // (Copilot bot review on PR #535).
-                string baseLabel = R._("タイルアニメーション2 パレットアニメ:{0}", U.ToHexString(plist));
+                // Resolve the filter label to "ANIME2 MapName" via the shared
+                // resolver (#952, #11) — the same enhancement #953 applied to
+                // the MapPointer / MapChange editors. WinForms historically
+                // showed "タイルアニメーション2 パレットアニメ:{plist}"; the
+                // resolved map name is far more useful, and the lockstep golden
+                // builder ListParityHelper.BuildMapTileAnimation2FilterList
+                // copies this Display verbatim. The "(破損)" suffix is still
+                // appended on a broken PLIST so the repair affordance stays
+                // discoverable.
+                string baseLabel = MapPListResolverCore.ResolveLabel(
+                    rom, MapChangeCore.PlistType.ANIMATION2, plist, resolveCache);
                 string display = broken
                     ? baseLabel + R._("(破損)")
                     : baseLabel;


### PR DESCRIPTION
## Summary

Bug #11 from the 2026-06-04 QA sweep (issue #952, slice B): the **MapTileAnimation** editors dumped raw `0x…` / PLIST-hex labels. This rewires them to the shared `MapPListResolverCore` (merged in #953) so they show `ANIME1/ANIME2 MapName`.

## Changes
- **`MapTileAnimationView`** (reachable from MainWindow): each row's `{id} TileAnim 0x…` → `MapPListResolverCore.ResolveLabel(rom, PlistType.ANIMATION, i)` → `ANIME1/ANIME2 MapName` / `NULL` / `-EMPTY-`. (`map_tileanime1_pointer` is the ANIMATION PLIST base; verified via `MapChangeCore.GetPlistBasePointer`.) Lockstep golden `BuildMapTileAnimationList`.
- **`MapTileAnimation2`**: the entry rows already resolved, but the FILTER-combo labels were raw `タイルアニメーション2 パレットアニメ:{plist}` → now `ResolveLabel(rom, PlistType.ANIMATION2, plist)` → `ANIME2 MapName` (keeping the `(破損)` broken-PLIST suffix for the repair affordance). New `BuildMapTileAnimation2FilterList` golden + a VM↔golden lockstep test for the filter labels.
- **`MapTileAnimation1`** — **deferred** (documented). Assessed against WinForms: this view has NO PLIST filter — its list correctly shows the inner data table (`Interval=… Count=…`), so there's no raw label to resolve. The WF "filter-from-map-settings → selected-PLIST-data" structure is a separate **structural feature addition** (new filter combo + a Core anime1 `BuildPlistList`), out of scope for the #11 label bug. Left a clear code comment; the MapTileAnimation2 pattern is the clean template for a focused follow-up.

## Scope
Closes the #11 portion of #952. (MapTileAnimation1 structural filter = documented follow-up.)

## Screenshots — MapTileAnimation editors (FE8J)

| Before (raw labels) | After (`ANIME1 MapName`) |
|---|---|
| ![b](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/bugsweep/bug11-map-tile-anim.png?raw=1) | ![a](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug11-tileanim-after.png) |

| MapTileAnimation2 filter (resolved `ANIME2 MapName`) |
|---|
| ![a2](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/bug11-tileanim2-after.png) |

After: `MapTileAnimationView` shows `05 ANIME1 ルネス陥落`, `12 ANIME1 Ch3 ボルゴ峠の山賊`, etc.; `MapTileAnimation2` filter shows `ANIME2 Ch18 魔の双面` (no raw `0x…`/PLIST-hex).

## GUI Test Report

| Test | Result |
|------|--------|
| MapTileAnimationView (FE8J) rows resolve to `ANIME1/ANIME2 MapName` (no raw `0x`) | ✅ PASS |
| MapTileAnimation2 filter combo resolves to `ANIME2 MapName` (keeps `(破損)` suffix) | ✅ PASS |
| MapTileAnimation1 confirmed: no PLIST filter; data-field list is correct WF parity (deferral justified) | ✅ PASS |
| VM↔golden lockstep tests for both editors' resolved labels | ✅ PASS |
| `FEBuilderGBA.Tests` (WinForms) 1822 / `FEBuilderGBA.Avalonia.Tests` 7465 / Core map+PList tests — all green | ✅ PASS |

Render: offscreen `--screenshot-all`. ROM: FE8J.

## Test plan
- [x] All THREE test projects run: `FEBuilderGBA.Tests` (1822/0), `FEBuilderGBA.Avalonia.Tests` (7465/0/3), `FEBuilderGBA.Core.Tests` (Map/PList green; +2 new)
- [x] VM resolved-label + VM↔golden lockstep + smoke-guard tests for both editors
- [x] After-screenshots confirm resolved labels
- [x] MapTileAnimation1 deferral documented (no label bug; structural follow-up)

> Note: 10 `SkillSystemsAnime*` Core.Tests fail locally (uninitialized `config/patch2` submodule) — pre-existing & unrelated; CI checks out submodules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Code 2.1.162 · model claude-opus-4-8[1m]
