### PR TITLE
test(avalonia): detect IdFieldControl confined to a narrow fixed-subset grid (#951-class layout-clip gap)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/IdFieldControlSpanLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/IdFieldControlSpanLayoutTests.cs
@@ -30,6 +30,11 @@ namespace FEBuilderGBA.Avalonia.Tests
     /// That isolates exactly the "detail form hard-capped to a fixed narrow total
     /// width" pathology and nothing else.
     ///
+    /// A complementary subset rule (<see cref="IdFieldControl_NotConfinedToNarrowFixedSubset"/>)
+    /// catches the case where the control spans only a PARTIAL column range that is
+    /// entirely fixed-pixel and totals below <see cref="MinSubsetWidth"/> (300px).
+    /// This caught the #951 regression (OPClassDemoViewer / ClassOPDemo, 220px subset).
+    ///
     /// Pure XML scan — no ROM, no Avalonia runtime — fast and deterministic.
     /// </summary>
     public class IdFieldControlSpanLayoutTests
@@ -41,6 +46,15 @@ namespace FEBuilderGBA.Avalonia.Tests
         //   Hyperlink label (~120) + NumericUpDown MinWidth 120 + NameLabel
         //   MinWidth 80 + Jump (~38) + Pick (~45) + spacing ~16 ~= 421px.
         private const double MinIdFieldWidth = 420.0;
+
+        // Conservative minimum for the IdFieldControl's NON-LABEL core content
+        // when the label is provided by a sibling cell outside the span:
+        //   NumericUpDown MinWidth 120 + NameLabel MinWidth 80 + Jump (~40) +
+        //   Pick (~45) + spacing ~15 ≈ 300px.
+        // Using 300px (vs 420) avoids false-positives on borderline views whose
+        // subsets render acceptably: EDSensekiComment (400px), OPClassDemoFE7
+        // (360px), OPClassDemoFE8U (400px), UnitFE7 (380px).
+        private const double MinSubsetWidth = 300.0;
 
         private static string FindProjectRoot()
         {
@@ -181,6 +195,112 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.True(offenders.Count == 0,
                 "IdFieldControl boxed into a fully-fixed narrow grid (will clip the Pick button / name preview). " +
                 "Give the containing grid a flexible ('*'/'Auto') column:\n" + string.Join("\n", offenders));
+        }
+
+        /// <summary>
+        /// Complement to <see cref="IdFieldControl_NotBoxedInFullyFixedNarrowGrid"/>:
+        /// catches the subset-clip pathology where an <c>IdFieldControl</c> is placed
+        /// in a PARTIAL column range (e.g. <c>Grid.Column="1" Grid.ColumnSpan="2"</c>
+        /// in a wider grid) that is entirely fixed-pixel AND totals below
+        /// <see cref="MinSubsetWidth"/> (300px).
+        ///
+        /// Why 300px and not 420px: when an IdFieldControl occupies a subset of
+        /// columns, the label for the row is typically provided by a sibling cell
+        /// outside the span, so only the NumericUpDown (~120px) + name preview (~80px)
+        /// + Jump (~40px) + Pick (~45px) + spacing (~15px) core is needed — roughly
+        /// 300px minimum. The 300px threshold is intentionally LOWER than the full-set
+        /// 420px to stay conservative: borderline subset views that render acceptably
+        /// (EDSensekiComment 400px, OPClassDemoFE7 360px, UnitFE7 380px) are NOT
+        /// flagged, while an unambiguously too-narrow span like 220px IS flagged.
+        ///
+        /// This rule would have caught the #951 regression: OPClassDemoViewerView and
+        /// ClassOPDemoView placed their Display-Weapon IdFieldControl into a 220px
+        /// fixed subset (columns 1..2, widths 140+80), clipping the name preview and
+        /// Pick button. The fix widened those spans to 620px and 440px respectively.
+        /// </summary>
+        [Fact]
+        public void IdFieldControl_NotConfinedToNarrowFixedSubset()
+        {
+            string viewsDir = ViewsDir();
+            Assert.True(Directory.Exists(viewsDir), $"Views dir not found: {viewsDir}");
+
+            var offenders = new List<string>();
+            var unanalyzable = new List<string>();
+
+            foreach (string path in Directory.GetFiles(viewsDir, "*.axaml", SearchOption.TopDirectoryOnly))
+            {
+                XDocument doc;
+                try { doc = XDocument.Load(path); }
+                catch { continue; } // non-XML/partial: other scanners cover parse health
+
+                string file = Path.GetFileName(path);
+
+                foreach (var idf in doc.Descendants().Where(e => e.Name.LocalName == "IdFieldControl"))
+                {
+                    int span = GetAttachedInt(idf, "Grid.ColumnSpan", 1);
+                    if (span < 2) continue;
+                    int col = GetAttachedInt(idf, "Grid.Column", 0);
+
+                    XElement? grid = idf.Ancestors().FirstOrDefault(a => a.Name.LocalName == "Grid");
+                    if (grid == null)
+                    {
+                        // Already covered by the full-set rule's unanalyzable check;
+                        // don't double-report here.
+                        continue;
+                    }
+                    var cols = GetColumnTokens(grid);
+                    if (cols == null)
+                    {
+                        // Same: already surfaced by the full-set rule.
+                        continue;
+                    }
+
+                    // Only examine SUBSET spans — the full-set (col==0, span==all) case
+                    // is already handled by IdFieldControl_NotBoxedInFullyFixedNarrowGrid.
+                    bool spansFullSet = (col == 0 && span == cols.Count);
+                    if (spansFullSet) continue;
+
+                    // Out-of-bounds guard (malformed AXAML; other tests catch parse errors).
+                    if (col + span > cols.Count)
+                    {
+                        unanalyzable.Add($"{file}: IdFieldControl '{GetNameAttr(idf) ?? "?"}' col={col} ColumnSpan={span} exceeds declared column count ({cols.Count}).");
+                        continue;
+                    }
+
+                    // Extract only the columns covered by this span.
+                    var spannedCols = cols.GetRange(col, span);
+
+                    // If ANY column in the spanned range is flexible (*or Auto), the
+                    // control can grow with the window → not a clip risk.
+                    if (!TryFixedTotal(spannedCols, out double total)) continue;
+
+                    // Wide enough → no clip risk.
+                    if (total >= MinSubsetWidth) continue;
+
+                    offenders.Add(
+                        $"{file}: IdFieldControl '{GetNameAttr(idf) ?? "?"}' is confined to a " +
+                        $"narrow fixed-pixel subset of its grid — " +
+                        $"Grid.Column={col} Grid.ColumnSpan={span} over [{string.Join(",", spannedCols)}] " +
+                        $"= {total}px (< {MinSubsetWidth}px subset minimum; full grid is " +
+                        $"[{string.Join(",", cols)}]). " +
+                        $"Widen the span so it covers more fixed columns (total >= {MinSubsetWidth}px), " +
+                        $"OR add a flexible ('*') column within the span.");
+                }
+            }
+
+            if (unanalyzable.Count > 0)
+                _output.WriteLine("Out-of-bounds IdFieldControl column spans:\n" + string.Join("\n", unanalyzable));
+            if (offenders.Count > 0)
+                _output.WriteLine("Subset-clipping IdFieldControl layouts:\n" + string.Join("\n", offenders));
+
+            Assert.True(unanalyzable.Count == 0,
+                "IdFieldControl(s) with out-of-bounds ColumnSpan detected. " +
+                "Fix the AXAML column span:\n" + string.Join("\n", unanalyzable));
+
+            Assert.True(offenders.Count == 0,
+                "IdFieldControl confined to a fixed-pixel subset narrower than " +
+                $"{MinSubsetWidth}px (Pick button / name preview will clip). " +
+                "Widen the column span or add a flexible column:\n" + string.Join("\n", offenders));
         }
     }
 }


### PR DESCRIPTION
## Summary

Hardens the `IdFieldControlSpanLayoutTests` layout-clip detector to close a gap exposed during T4: in PR #951 an `IdFieldControl` was placed in a fixed-width SUBSET of a grid (`Grid.Column="1" Grid.ColumnSpan="2"` over `140+80 = 220px`), which clips the ~420px control — but it was NOT a full-grid span, so the existing detector (which only flags full-column-set all-fixed clips < 420px) missed it. The auto-bot caught it manually; this makes it deterministic.

## Change
New `[Fact] IdFieldControl_NotConfinedToNarrowFixedSubset`: flags any `IdFieldControl` (`ColumnSpan >= 2`) whose **spanned column range is a subset** of its grid, **entirely fixed-pixel**, totaling **< 300px**. Reuses the file's existing helpers (`GetColumnTokens` attribute+child-element forms, flexible/Auto detection, namespace-insensitive scan).

**Threshold 300px (vs the 420px full-set rule):** for a subset span the caption label is supplied by a sibling cell outside the span, so only the control's core content must fit (NumericUpDown ~120 + NameLabel ~80 + Jump ~40 + Pick ~45 + spacing ≈ 300). Staying at 300 (not 420) avoids false-positives on views that render acceptably at borderline sizes — `EDSensekiComment` (400), `OPClassDemoFE7/FE7U/FE8U` (360/400), `UnitFE7` (380), `ClassOPDemo` (440) — all ≥ 300, none flagged.

## Validation
- **Green on current master** (OPClassDemo was fixed in #951): the filtered run is 2/0; full `FEBuilderGBA.Avalonia.Tests` = **7466 passed / 0 failed / 3 skipped**. No false positives.
- **RED proof:** temporarily reverting `OPClassDemoViewerView` to the pre-#951 `Grid.Column="1" Grid.ColumnSpan="2"` (220px) makes the new fact fail with a precise message (`'DisplayWeaponBox' confined … over [140,80] = 220px (< 300px subset minimum) … Widen the span`); reverted before commit so the tree is green.

Closes the #951-class detection gap (no separate issue — this directly follows from the #951 review lesson).

## Test plan
- [x] New subset-clip fact added; full-set (<420) rule preserved
- [x] Green on current master (no false positives across all IdFieldControl-host views)
- [x] RED-proven against the OPClassDemo 220px regression
- [x] Full Avalonia.Tests green (7466/0/3)

This is a `test`-only change (no GUI/runtime behavior) — screenshots N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Code 2.1.162 · model claude-opus-4-8[1m]
