### PR TITLE
feat(avalonia): migrate EventCond tutorial Text ID to IdFieldControl + add --screenshot-show-panel flag (#957 W1a)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/EventCondParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/EventCondParityTests.cs
@@ -1474,6 +1474,66 @@ public class EventCondParityTests
     }
 
     // -----------------------------------------------------------------
+    // #957 W1a — Tutorial Text ID is now an IdFieldControl.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// EventCondView Tutorial Text ID must be wired as IdFieldControl (not plain
+    /// NumericUpDown). ShowPick=False, JumpRequested and ValueChanged must be set.
+    /// This mirrors the pattern used for TALK Unit1/2 and OBJECT ChestItem (#951).
+    /// Note: AXAML attached-property attributes serialize as
+    ///   "AutomationProperties.AutomationId" (full LocalName, default namespace),
+    ///   so we search by Name="TextIdBox" and validate attributes directly.
+    /// </summary>
+    [Fact]
+    public void TutorialTextId_IsIdFieldControl_WithJumpAndValueChanged()
+    {
+        string repoRoot = FindRepoRoot();
+        string axamlPath = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "EventCondView.axaml");
+        Assert.True(File.Exists(axamlPath), $"AXAML not found at {axamlPath}");
+
+        var doc = XDocument.Load(axamlPath);
+
+        // Find by Name="TextIdBox" — preserved from original NUD.
+        var ctrl = doc.Descendants()
+            .FirstOrDefault(e =>
+                e.Name.LocalName == "IdFieldControl" &&
+                e.Attributes().Any(a => a.Name.LocalName == "Name"
+                                        && a.Value == "TextIdBox"));
+
+        Assert.NotNull(ctrl);
+
+        // ShowPick must be "False".
+        string? showPick = ctrl!.Attributes()
+            .FirstOrDefault(a => a.Name.LocalName == "ShowPick")?.Value;
+        Assert.Equal("False", showPick);
+
+        // JumpRequested must be wired.
+        string? jump = ctrl.Attributes()
+            .FirstOrDefault(a => a.Name.LocalName == "JumpRequested")?.Value;
+        Assert.False(string.IsNullOrWhiteSpace(jump),
+            "IdFieldControl TextIdBox must have JumpRequested wired");
+
+        // ValueChanged must be wired.
+        string? vc = ctrl.Attributes()
+            .FirstOrDefault(a => a.Name.LocalName == "ValueChanged")?.Value;
+        Assert.False(string.IsNullOrWhiteSpace(vc),
+            "IdFieldControl TextIdBox must have ValueChanged wired");
+
+        // Confirm no plain NumericUpDown still carries Name="TextIdBox".
+        bool legacyNud = doc.Descendants()
+            .Any(e => e.Name.LocalName == "NumericUpDown" &&
+                      e.Attributes().Any(a => a.Name.LocalName == "Name"
+                                              && a.Value == "TextIdBox"));
+        Assert.False(legacyNud, "Legacy NumericUpDown Name='TextIdBox' must be removed");
+
+        // Raw content check: AutomationId string must still be present somewhere.
+        string content = File.ReadAllText(axamlPath);
+        Assert.Contains("EventCond_TextId_Input", content);
+    }
+
+    // -----------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------
 

--- a/FEBuilderGBA.Avalonia.Tests/IdFieldMigrationTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/IdFieldMigrationTests.cs
@@ -89,15 +89,12 @@ namespace FEBuilderGBA.Avalonia.Tests
         // NOTE: keep this EMPTY-by-default. If a legitimate exception arises, add
         // {file, name, reason}; the stale-guard below then enforces that the
         // control keeps existing as a NumericUpDown.
+        // #957 W1a: EventCondView.axaml "TextIdBox" (Tutorial Text ID) was migrated
+        // to IdFieldControl; the allow-list entry is removed here.
         private static readonly Dictionary<(string file, string name), string> AllowList =
             new()
             {
-                // EventCond Tutorial-panel "Text ID:" is OUT of the T4 Tier-3
-                // scope (which is TALK Unit 1/2 + OBJECT Chest Item only). It is
-                // a tutorial-text id, not one of the migrated subfields; a focused
-                // follow-up can migrate it to a TextViewer Jump (ShowPick=False).
-                { ("EventCondView.axaml", "TextIdBox"),
-                  "Tutorial Text ID — out of #950 T4 Tier-3 scope (TALK Unit/Chest only); TextViewer-Jump migration deferred." },
+                // (empty — no outstanding exceptions after #957 W1a)
             };
 
         private static string FindProjectRoot()

--- a/FEBuilderGBA.Avalonia/App.axaml.cs
+++ b/FEBuilderGBA.Avalonia/App.axaml.cs
@@ -65,6 +65,16 @@ namespace FEBuilderGBA.Avalonia
         /// </summary>
         public static string? ScreenshotTabAutomationId { get; set; }
 
+        /// <summary>
+        /// Optional AutomationId of a <see cref="global::Avalonia.Controls.Control"/>
+        /// (typically an <c>IsVisible</c>-toggled panel) the <c>--screenshot-all</c>
+        /// runner should force visible on each captured editor before rendering, so
+        /// a category panel normally hidden behind a selection state shows up in the
+        /// PNG. Null = no panel forced. Editors without a matching control are
+        /// captured unchanged. Opt-in via <c>--screenshot-show-panel=&lt;AutomationId&gt;</c>.
+        /// </summary>
+        public static string? ScreenshotShowPanelAutomationId { get; set; }
+
         /// <summary>Gap-sweep mode (Phase 1 density, Phase 2 labels, …) or null if no gap-sweep flag was passed.</summary>
         public static string? GapSweepMode { get; set; }
 
@@ -1094,6 +1104,10 @@ namespace FEBuilderGBA.Avalonia
                 else if (args[i].StartsWith("--screenshot-tab="))
                 {
                     ScreenshotTabAutomationId = args[i].Substring("--screenshot-tab=".Length);
+                }
+                else if (args[i].StartsWith("--screenshot-show-panel="))
+                {
+                    ScreenshotShowPanelAutomationId = args[i].Substring("--screenshot-show-panel=".Length);
                 }
                 else if (args[i] == "--lastrom")
                 {

--- a/FEBuilderGBA.Avalonia/Views/EventCondView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventCondView.axaml
@@ -315,10 +315,14 @@
               <TextBlock AutomationProperties.AutomationId="EventCond_RepeatTimer_Label" Text="Repeat Timer:" VerticalAlignment="Center" Width="120" />
               <NumericUpDown AutomationProperties.AutomationId="EventCond_RepeatTimer_Input" Name="RepeatTimerBox" FormatString="0" Minimum="0" Maximum="255" Width="80" />
             </StackPanel>
-            <StackPanel Orientation="Horizontal" Spacing="6">
-              <TextBlock AutomationProperties.AutomationId="EventCond_TextId_Label" Text="Text ID:" VerticalAlignment="Center" Width="120" />
-              <NumericUpDown AutomationProperties.AutomationId="EventCond_TextId_Input" Name="TextIdBox" FormatString="0" Minimum="0" Maximum="65535" Width="100" />
-            </StackPanel>
+            <!-- #957 W1a: Tutorial Text ID migrated from plain NumericUpDown to
+                 IdFieldControl (ShowPick=False, Jump→TextViewerView at the text-table
+                 ROW address). Name="TextIdBox" + AutomationId preserved. -->
+            <controls:IdFieldControl AutomationProperties.AutomationId="EventCond_TextId_Input" Name="TextIdBox"
+                                     Label="Text ID:" Maximum="65535"
+                                     ShowPick="False"
+                                     JumpRequested="TutorialTextId_Jump"
+                                     ValueChanged="TutorialTextId_ValueChanged" />
           </StackPanel>
         </Border>
 

--- a/FEBuilderGBA.Avalonia/Views/EventCondView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventCondView.axaml.cs
@@ -78,7 +78,7 @@ namespace FEBuilderGBA.Avalonia.Views
             VeinEffectIdBox.Value ??= 0;
             InitialTimerBox.Value ??= 0;
             RepeatTimerBox.Value ??= 0;
-            TextIdBox.Value ??= 0;
+            // #957 W1a: TextIdBox is now an IdFieldControl (uint Value) — no null-seed needed.
         }
 
         void LoadAll()
@@ -508,13 +508,17 @@ namespace FEBuilderGBA.Avalonia.Views
                     {
                         InitialTimerBox.Value = 1; // canonical "blank" marker
                         RepeatTimerBox.Value = 0;
+                        // #957 W1a: IdFieldControl — seed value + inline preview.
                         TextIdBox.Value = 0;
+                        TextIdBox.NameText = "";
                     }
                     else
                     {
                         InitialTimerBox.Value = 0;
                         RepeatTimerBox.Value = 0;
+                        // #957 W1a: IdFieldControl — seed value + inline preview.
                         TextIdBox.Value = 0;
+                        TextIdBox.NameText = "";
                     }
                     break;
             }
@@ -1065,6 +1069,27 @@ namespace FEBuilderGBA.Avalonia.Views
                 ChestItemNameLabel.Text = NameResolver.GetItemName(e.NewValue);
                 ChestItemBox.NameText = ChestItemNameLabel.Text;
             }
+            catch { /* NameResolver may fail without ROM */ }
+        }
+
+        // ============================================================
+        // #957 W1a: Tutorial Text ID (Huffman text id → TextViewerView Jump).
+        //   ShowPick=False — there is no text-picker; Jump only.
+        // ============================================================
+
+        void TutorialTextId_Jump(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                uint addr = EditorJumpAddressHelper.TextRowAddrFor(CoreState.ROM, TextIdBox.Value);
+                if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr);
+            }
+            catch (Exception ex) { Log.Error("EventCondView.TutorialTextId_Jump failed: {0}", ex.Message); }
+        }
+
+        void TutorialTextId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
+        {
+            try { TextIdBox.NameText = e.NewValue != 0 ? NameResolver.GetTextById(e.NewValue) : ""; }
             catch { /* NameResolver may fail without ROM */ }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
@@ -964,6 +964,17 @@ namespace FEBuilderGBA.Avalonia.Views
                             await Task.Delay(100); // Let the tab content realize
                         }
 
+                        // Optionally force an IsVisible-toggled panel visible (by
+                        // AutomationId) so a category sub-panel normally hidden
+                        // behind a selection state shows up in the PNG. Opt-in via
+                        // --screenshot-show-panel=<AutomationId>; editors without a
+                        // matching control are captured unchanged.
+                        if (!string.IsNullOrEmpty(App.ScreenshotShowPanelAutomationId)
+                            && ShowPanelByAutomationId(window, App.ScreenshotShowPanelAutomationId!))
+                        {
+                            await Task.Delay(100); // Let the panel content realize
+                        }
+
                         // Capture screenshot via RenderTargetBitmap
                         var pixelSize = new PixelSize(
                             Math.Max((int)window.Width, 100),
@@ -1023,6 +1034,29 @@ namespace FEBuilderGBA.Avalonia.Views
                         return true;
                     }
                     tab.IsSelected = true;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Force the <see cref="Control.IsVisible"/> of the first descendant
+        /// <see cref="Control"/> whose <c>AutomationProperties.AutomationId</c>
+        /// equals <paramref name="automationId"/> to <c>true</c>, by walking the
+        /// logical tree. Returns true when a matching control was found. Used by
+        /// the opt-in <c>--screenshot-show-panel=</c> screenshot mode to render an
+        /// <c>IsVisible</c>-toggled category panel that the default selection state
+        /// would otherwise hide.
+        /// </summary>
+        static bool ShowPanelByAutomationId(Control root, string automationId)
+        {
+            foreach (var descendant in root.GetLogicalDescendants())
+            {
+                if (descendant is Control ctrl
+                    && AutomationProperties.GetAutomationId(ctrl) == automationId)
+                {
+                    ctrl.IsVisible = true;
                     return true;
                 }
             }

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ dotnet run --project FEBuilderGBA.Avalonia -- --rom path/to/rom.gba --screenshot
 # specific tab is shown in the PNG (editors without a matching tab are unchanged)
 dotnet run --project FEBuilderGBA.Avalonia -- --rom path/to/rom.gba --screenshot-all --screenshot-tab=TextViewer_Translate_Tab --screenshot-dir=./screenshots
 
+# Optionally force an IsVisible-toggled panel visible (by AutomationId) before each
+# capture, so a category sub-panel normally hidden behind a selection state shows up
+# in the PNG (editors without a matching control are unchanged). E.g. render the
+# EventCond TUTORIAL panel (where the Text ID IdFieldControl lives):
+dotnet run --project FEBuilderGBA.Avalonia -- --rom path/to/rom.gba --screenshot-all --screenshot-show-panel=EventCond_TutorialPanel_Border --screenshot-dir=./screenshots
+
 # Capture WinForms screenshots of all editors (saves PNGs for side-by-side comparison with Avalonia)
 FEBuilderGBA.exe --rom path/to/rom.gba --screenshot-all --screenshot-dir=./screenshots
 

--- a/docs/field-completeness-report.txt
+++ b/docs/field-completeness-report.txt
@@ -1,6 +1,6 @@
 === Field Completeness Report ===
 Total WinForms fields: 1563
-Total Avalonia fields: 1799
+Total Avalonia fields: 1801
 Total missing: 0
 Forms with gaps: 0 / 175
 


### PR DESCRIPTION
## Summary

Follow-up #957 W1a: the EventCond editor's **tutorial Text ID** field was a bare `NumericUpDown` — explicitly allow-listed for follow-up in the T4 `IdFieldMigrationTests` detector (PR #951). This migrates it to an `IdFieldControl` (consistent with the 5 fields migrated in #951) and adds a small **reusable screenshot flag** so panel-gated fields can be captured.

## Changes
- **`EventCondView` tutorial Text ID** → `IdFieldControl`: hyperlink "Text ID:" label, `ShowPick="False"`, `JumpRequested` → `WindowManager.Navigate<TextViewerView>(EditorJumpAddressHelper.TextRowAddrFor(rom, id))` (text-table row address), inline `NameResolver.GetTextById` preview. Preserves the `TextIdBox` Name + AutomationId.
- **Removed the now-stale `IdFieldMigrationTests` allow-list entry** `(EventCondView.axaml, TextIdBox)` — its anti-stale guard requires the listed control to exist, so once migrated the entry must go.
- **New reusable `--screenshot-show-panel=<AutomationId>` flag** (`App.axaml.cs` + `MainWindow.axaml.cs`, documented in README): forces an `IsVisible`-toggled panel visible before the `--screenshot-all` capture, so category/panel-gated editor content (like this Tutorial panel) can be rendered for PR proof. Complements the existing `--screenshot-tab` flag.

## Scope
Follow-up to #951 (completes the one allow-listed IdFieldControl deferral).

## Screenshot — EventCond Tutorial panel (FE8J), forced visible via the new flag

![after](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/w1a-eventcond-tutorial-after.png)

In the Tutorial panel, the **Text ID** row now renders as an IdFieldControl — hyperlink "Text ID:" + numeric + "Jump" (NO "Pick", per `ShowPick=False`) — contrasting with the plain "Initial Timer:" / "Repeat Timer:" rows above it (bare label + NumericUpDown, no Jump). Inline preview is empty because the forced-visible panel sits over a value-0 slot (honest: `NameText` is empty for id 0).

## GUI Test Report

| Test | Result |
|------|--------|
| EventCond tutorial Text ID renders as IdFieldControl with Jump, ShowPick=False (new `EventCondParityTests.TutorialTextId_IsIdFieldControl...`) | ✅ PASS |
| `IdFieldMigrationTests` green after removing the allow-list entry (anti-stale guard satisfied) | ✅ PASS |
| `--screenshot-show-panel` renders the Tutorial panel (325/325 captured) | ✅ PASS |
| `FEBuilderGBA.Avalonia.Tests` 7467 / `FEBuilderGBA.Tests` 1822 / Core map tests green | ✅ PASS |

## Test plan
- [x] New parity test asserts the migrated IdFieldControl (Jump + ShowPick=False)
- [x] Allow-list entry removed; detector still green
- [x] All 3 test projects green; AutomationId validator passes
- [x] Real render of the Tutorial panel (via the new reusable flag) confirms the migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Code 2.1.162 · model claude-opus-4-8[1m]
