### PR TITLE
feat(core+avalonia): add anime1 PLIST filter to MapTileAnimation1 (closes #955)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -538,11 +538,23 @@ Specialized utilities for different graphic types:
   resolves each FILTER-combo row via `ResolveLabel(rom, ANIMATION2, plist)` (the
   broken-PLIST `(破損)` suffix is still appended). Lockstep golden builders:
   `ListParityHelper.BuildMapTileAnimationList` + the new public
-  `BuildMapTileAnimation2FilterList`. **`MapTileAnimation1` is DEFERRED**: it has
-  no PLIST filter at all (its list shows DATA fields, not a raw label), so WF
-  parity there is a STRUCTURAL feature addition (filter-from-map-settings +
-  selected-PLIST data, mirroring MapTileAnimation2), tracked for a focused
-  follow-up — out of scope for the #11 label-resolution bug.
+  `BuildMapTileAnimation2FilterList`. **`MapTileAnimation1` anime1 PLIST filter
+  (#955, #957 W1c) — DONE** (the former deferral is CLOSED): the new
+  `MapTileAnimation1Core.BuildPlistList` enumerates the distinct anime1 PLISTs
+  referenced by the map settings (`anime1_plist` at map-setting `+9`), resolves
+  each FILTER-combo row via `ResolveLabel(rom, ANIMATION, plist)` → `ANIME1
+  MapName` (ANIME1/ANIME2 share the `map_tileanime1_pointer` base; both match
+  under ANIMATION), and resolves the selected PLIST's data table via
+  `MapChangeCore.PlistToOffsetAddr(ANIMATION, plist)` (broken-PLIST `(破損)`
+  suffix appended). `MapTileAnimation1Core.ScanEntries` walks the SELECTED
+  PLIST's 8-byte data records — **the anime1 schema is the inverse of anime2**:
+  `wait = u16@+0`, `length = u16@+2`, `imagePointer = p32@+4`, terminated by
+  `!isPointer(u32(addr+4))` (the image pointer is at `+4`, NOT `+0`). The
+  Avalonia `MapTileAnimation1View` now hosts the filter combo + selection bar
+  (mirroring anime2); the VM no longer treats `map_tileanime1_pointer` (the
+  PLIST TABLE) as a flat entry table. Lockstep golden builders:
+  `ListParityHelper.BuildMapTileAnimation1List` (rewired to PLIST-based) + the
+  new public `BuildMapTileAnimation1FilterList`.
 
 ### Caching System
 

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MapTileAnimation1FilterTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MapTileAnimation1FilterTests.cs
@@ -134,6 +134,86 @@ public class MapTileAnimation1FilterTests
     }
 
     // -----------------------------------------------------------------
+    // #960 fix 1 - empty non-broken PLIST must CLEAR stale detail.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_ClearEntry_ResetsFieldsAndGatesWrite()
+    {
+        var rom = MakeMinimalFE8URomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation1ViewModel();
+            vm.LoadEntry(entryAddr);
+            Assert.True(vm.IsLoaded);
+            Assert.NotEqual(0u, vm.CurrentAddr);
+
+            vm.ClearEntry();
+            Assert.False(vm.IsLoaded); // Write_Click early-returns on !IsLoaded
+            Assert.Equal(0u, vm.CurrentAddr);
+            Assert.Equal(0u, vm.SelectedAddress);
+            Assert.Equal(0u, vm.AnimInterval);
+            Assert.Equal(0u, vm.DataCount);
+            Assert.Equal(0u, vm.MapTileDataPointer);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_BuildList_OnEmptyPlist_ReturnsEmpty()
+    {
+        // A non-broken PLIST whose data table is EMPTY (first record's +4 is
+        // NOT a pointer) must yield zero entries — the view then clears the
+        // stale detail panel (#960).
+        var rom = MakeFE8URomWithEmptyFirstPlist(out uint emptyDataAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation1ViewModel();
+            var items = vm.BuildList(emptyDataAddr);
+            Assert.Empty(items);
+            Assert.Equal(emptyDataAddr, vm.ReadStartAddress);
+            Assert.Equal(0u, vm.ReadCount);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    // -----------------------------------------------------------------
+    // #960 fix 2 - golden builder lockstep with VM on empty first PLIST.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void GoldenBuilder_And_VM_Lockstep_WhenFirstNonBrokenPlistIsEmpty()
+    {
+        // When the FIRST non-broken PLIST resolves to an EMPTY entry table the
+        // VM's LoadList() returns that PLIST's (empty) scan rather than falling
+        // through to a later PLIST. The golden builder must match exactly (it
+        // previously did `if (entries.Count == 0) continue;`, diverging).
+        var rom = MakeFE8URomWithEmptyFirstPlist(out uint _);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation1ViewModel();
+            var vmRows = vm.LoadList();
+            var golden = FEBuilderGBA.Avalonia.Services.ListParityHelper
+                .BuildReferenceList("MapTileAnimation1View");
+
+            Assert.Empty(vmRows);  // empty first PLIST -> empty list
+            Assert.Equal(golden.Count, vmRows.Count);
+            for (int i = 0; i < vmRows.Count; i++)
+            {
+                Assert.Equal(golden[i].name, vmRows[i].name);
+                Assert.Equal(golden[i].addr, vmRows[i].addr);
+            }
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    // -----------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------
 
@@ -171,6 +251,40 @@ public class MapTileAnimation1FilterTests
         WriteU32(rom.Data, (int)entryAddr + 4, 0x08800100u);
         // Entry[1] = zero P4 so ScanEntries stops cleanly.
         WriteU32(rom.Data, (int)entryAddr + 8 + 4, 0u);
+
+        return rom;
+    }
+
+    /// <summary>
+    /// Build a synthetic FE8U ROM whose FIRST (and only) non-broken anime1
+    /// PLIST resolves to a SAFE, non-zero data offset (so BuildPlistList marks
+    /// it non-broken) but whose entry table is EMPTY — the first 8-byte
+    /// record's image pointer at +4 is NOT a pointer, so ScanEntries returns
+    /// zero rows. Returns the resolved (empty) data offset.
+    /// </summary>
+    static ROM MakeFE8URomWithEmptyFirstPlist(out uint emptyDataAddr)
+    {
+        var rom = new ROM();
+        rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+
+        // Map block at 0x00800000: D0=pointer, anime1_plist=1 at +9.
+        WriteU32(rom.Data, (int)rom.RomInfo.map_setting_pointer, 0x08800000u);
+        WriteU32(rom.Data, 0x800000, 0x08800200u); // D0 = pointer (valid)
+        rom.Data[0x800000 + 9] = 1; // anime1_plist = 1
+        // Map[1]: terminator (D0 = 0)
+        uint dataSize = rom.RomInfo.map_setting_datasize;
+        WriteU32(rom.Data, (int)(0x800000 + dataSize), 0u);
+
+        // PLIST table at 0x00900000. Slot 1 -> 0x08800300 (SAFE, non-zero ->
+        // non-broken), but the data block there has a non-pointer at +4 so the
+        // entry table is empty.
+        emptyDataAddr = 0x800300;
+        WriteU32(rom.Data, (int)rom.RomInfo.map_tileanime1_pointer, 0x08900000u);
+        WriteU32(rom.Data, 0x900000 + 1 * 4, 0x08800300u);
+        // Data block at 0x00800300: image pointer at +4 = 0 (NOT a pointer) so
+        // ScanEntries stops immediately -> empty table.
+        WriteU32(rom.Data, (int)emptyDataAddr + 0, 0u);
+        WriteU32(rom.Data, (int)emptyDataAddr + 4, 0u);
 
         return rom;
     }

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MapTileAnimation1FilterTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MapTileAnimation1FilterTests.cs
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Structural + VM tests for the MapTileAnimation1 anime1 PLIST filter (#955,
+// #957 W1c). Mirrors the MapTileAnimation2ParityTests filter assertions: the
+// View must carry the anime1 Filter combo + top bar + selection bar, and the VM
+// must drive the entry list off the SELECTED PLIST's data table (instead of
+// treating map_tileanime1_pointer — the PLIST table — as a flat entry table).
+using System;
+using System.IO;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests.GapSweep;
+
+[Collection("SharedState")]
+public class MapTileAnimation1FilterTests
+{
+    // -----------------------------------------------------------------
+    // Structural - View must carry the anime1 filter combo + bars.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_HasFilterCombo()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"MapTileAnimation1_Filter_Combo\"", axaml);
+        Assert.Contains("SelectionChanged=\"FilterCombo_SelectionChanged\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasReloadButton_Wired()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"MapTileAnimation1_ReloadList_Button\"", axaml);
+        Assert.Contains("ReloadRequested=\"OnTopBarReloadRequested\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasSelectionBar()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("AutomationId=\"MapTileAnimation1_Address_Input\"", axaml);
+        Assert.Contains("AutomationId=\"MapTileAnimation1_BlockSize_Input\"", axaml);
+        Assert.Contains("AutomationId=\"MapTileAnimation1_SelectedAddress_Label\"", axaml);
+    }
+
+    [Fact]
+    public void View_WriteHandler_WrapsInUndoScope()
+    {
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        Assert.Contains("_undoService.Begin(", source);
+        Assert.Contains("_undoService.Commit()", source);
+        Assert.Contains("_undoService.Rollback()", source);
+    }
+
+    // -----------------------------------------------------------------
+    // VM - filter builds + selected-PLIST entry scan (8-byte, +4 pointer).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_LoadPlistList_BuildsFilterRows()
+    {
+        var rom = MakeMinimalFE8URomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation1ViewModel();
+            var rows = vm.LoadPlistList();
+            Assert.Single(rows);
+            Assert.Equal(1u, rows[0].Plist);
+            Assert.False(rows[0].IsBroken);
+            Assert.StartsWith("ANIME1 ", rows[0].Display);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_BuildList_ScansSelectedPlistDataTable()
+    {
+        var rom = MakeMinimalFE8URomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation1ViewModel();
+            // The PLIST table slot for plist=1 points at the entry block.
+            var items = vm.BuildList(entryAddr);
+            Assert.Single(items);
+            Assert.Equal(entryAddr, items[0].addr);
+            Assert.Equal(entryAddr, vm.ReadStartAddress);
+            Assert.Equal(1u, vm.ReadCount);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_LoadList_DerivesEntriesFromFirstNonBrokenPlist()
+    {
+        var rom = MakeMinimalFE8URomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation1ViewModel();
+            var items = vm.LoadList();
+            Assert.Single(items);
+            Assert.Equal(entryAddr, items[0].addr);
+            Assert.Equal(1u, vm.SelectedPlist);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_LoadEntry_PopulatesFields()
+    {
+        var rom = MakeMinimalFE8URomWithEntry(out uint entryAddr);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new MapTileAnimation1ViewModel();
+            vm.LoadEntry(entryAddr);
+            Assert.True(vm.IsLoaded);
+            Assert.Equal(entryAddr, vm.CurrentAddr);
+            // Entry: wait=0x13, length=0x1000, imgPtr raw GBA pointer 0x08800100
+            // (the field is a raw DWord D4, so it carries the high bit — the
+            // view renders it directly as 0x{...:X08}).
+            Assert.Equal(0x13u, vm.AnimInterval);
+            Assert.Equal(0x1000u, vm.DataCount);
+            Assert.Equal(0x08800100u, vm.MapTileDataPointer);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Build a tiny synthetic FE8U ROM with:
+    /// - map_setting_pointer -> 0x08800000 (map block at 0x00800000), one map
+    ///   entry with anime1_plist=1 at +9, terminator at index 1.
+    /// - map_tileanime1_pointer -> 0x08900000 (PLIST table at 0x00900000).
+    /// - PLIST table entry for plist=1 -> 0x08800200 (entry block at
+    ///   0x00800200), one 8-byte entry: wait=0x13, length=0x1000, imgPtr at +4
+    ///   = 0x08800100.
+    /// Returns the entry address (0x00800200).
+    /// </summary>
+    static ROM MakeMinimalFE8URomWithEntry(out uint entryAddr)
+    {
+        var rom = new ROM();
+        rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+
+        // Map block at 0x00800000: D0=pointer, anime1_plist=1 at +9.
+        WriteU32(rom.Data, (int)rom.RomInfo.map_setting_pointer, 0x08800000u);
+        WriteU32(rom.Data, 0x800000, 0x08800200u); // D0 = pointer (valid)
+        rom.Data[0x800000 + 9] = 1; // anime1_plist = 1
+        // Map[1]: terminator (D0 = 0)
+        uint dataSize = rom.RomInfo.map_setting_datasize;
+        WriteU32(rom.Data, (int)(0x800000 + dataSize), 0u);
+
+        // PLIST table at 0x00900000. Slot 1 -> 0x08800200.
+        WriteU32(rom.Data, (int)rom.RomInfo.map_tileanime1_pointer, 0x08900000u);
+        WriteU32(rom.Data, 0x900000 + 1 * 4, 0x08800200u);
+
+        // Entry block at 0x00800200: wait=0x13, length=0x1000, imgPtr@4=0x08800100.
+        entryAddr = 0x800200;
+        WriteU16(rom.Data, (int)entryAddr + 0, 0x13);
+        WriteU16(rom.Data, (int)entryAddr + 2, 0x1000);
+        WriteU32(rom.Data, (int)entryAddr + 4, 0x08800100u);
+        // Entry[1] = zero P4 so ScanEntries stops cleanly.
+        WriteU32(rom.Data, (int)entryAddr + 8 + 4, 0u);
+
+        return rom;
+    }
+
+    static string AxamlPath()
+    {
+        string repoRoot = FindRepoRoot();
+        return Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "MapTileAnimation1View.axaml");
+    }
+
+    static string ViewCodeBehindPath()
+    {
+        string repoRoot = FindRepoRoot();
+        return Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "MapTileAnimation1View.axaml.cs");
+    }
+
+    static string ReadAxaml() => File.ReadAllText(AxamlPath());
+
+    static void WriteU32(byte[] data, int offset, uint value)
+    {
+        data[offset + 0] = (byte)(value & 0xFF);
+        data[offset + 1] = (byte)((value >> 8) & 0xFF);
+        data[offset + 2] = (byte)((value >> 16) & 0xFF);
+        data[offset + 3] = (byte)((value >> 24) & 0xFF);
+    }
+
+    static void WriteU16(byte[] data, int offset, ushort value)
+    {
+        data[offset + 0] = (byte)(value & 0xFF);
+        data[offset + 1] = (byte)((value >> 8) & 0xFF);
+    }
+
+    static string FindRepoRoot()
+    {
+        string? dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+        if (dir == null)
+            throw new InvalidOperationException("Could not find FEBuilderGBA.sln from test base directory");
+        return dir;
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/MapTileAnimationResolverParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/MapTileAnimationResolverParityTests.cs
@@ -130,6 +130,75 @@ public class MapTileAnimationResolverParityTests : IClassFixture<RomFixture>
     }
 
     // -----------------------------------------------------------------
+    // #955 W1c: MapTileAnimation1 anime1 PLIST filter labels.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void MapTileAnimation1_FilterLabels_ProduceResolvedAnime1Labels()
+    {
+        if (!_rom.IsAvailable) return;
+
+        var vm = new MapTileAnimation1ViewModel();
+        List<MapTileAnimation1Core.PlistRow> rows = vm.LoadPlistList();
+        // Some ROMs may legitimately have no anime1 PLISTs; only assert on the
+        // rows that exist.
+        foreach (var row in rows)
+        {
+            AssertResolvedLabel(row.Display, "MapTileAnimation1 filter");
+        }
+
+        // When rows exist, at least one should resolve to an ANIME1 map name
+        // (the non-broken case) or carry the broken suffix.
+        if (rows.Count > 0)
+        {
+            bool anyResolved = rows.Exists(r =>
+                r.Display.StartsWith("ANIME1 ") || r.Display.Contains("("));
+            Assert.True(anyResolved,
+                "expected at least one resolved ANIME1 / broken-suffix filter label");
+        }
+    }
+
+    [Fact]
+    public void MapTileAnimation1_FilterVM_And_GoldenBuilder_Lockstep()
+    {
+        if (!_rom.IsAvailable) return;
+
+        var vm = new MapTileAnimation1ViewModel();
+        List<MapTileAnimation1Core.PlistRow> vmRows = vm.LoadPlistList();
+        List<AddrResult> golden = ListParityHelper.BuildMapTileAnimation1FilterList(_rom.ROM!);
+
+        Assert.Equal(vmRows.Count, golden.Count);
+        for (int i = 0; i < vmRows.Count; i++)
+        {
+            // The golden filter builder copies PlistRow.Display verbatim, so the
+            // VM filter combo strings and the golden labels must match exactly.
+            Assert.Equal(vmRows[i].Display, golden[i].name);
+            Assert.Equal(vmRows[i].Plist, golden[i].tag);
+        }
+    }
+
+    [Fact]
+    public void MapTileAnimation1_List_And_GoldenBuilder_Lockstep()
+    {
+        if (!_rom.IsAvailable) return;
+
+        // The VM's no-arg LoadList() (used by the IDataVerifiable contract)
+        // picks the first non-broken PLIST and scans its data table. The golden
+        // builder BuildMapTileAnimation1List (reached via BuildReferenceList)
+        // must match it byte-for-byte.
+        var vm = new MapTileAnimation1ViewModel();
+        List<AddrResult> vmRows = vm.LoadList();
+        List<AddrResult> golden = ListParityHelper.BuildReferenceList("MapTileAnimation1View");
+
+        Assert.Equal(golden.Count, vmRows.Count);
+        for (int i = 0; i < vmRows.Count; i++)
+        {
+            Assert.Equal(golden[i].name, vmRows[i].name);
+            Assert.Equal(golden[i].addr, vmRows[i].addr);
+        }
+    }
+
+    // -----------------------------------------------------------------
     // Smoke guard: list/filter builders must not emit raw labels.
     // -----------------------------------------------------------------
 

--- a/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
@@ -3712,26 +3712,48 @@ namespace FEBuilderGBA.Avalonia.Services
             return result;
         }
 
-        /// <summary>Build map tile animation 1 list — from map_tileanime1_pointer.
-        /// Matches MapTileAnimation1ViewModel.LoadList()/BuildList(): 8-byte blocks, validated by isPointer(u32(addr+4)).</summary>
+        /// <summary>Build map tile animation 1 list — PLIST-based (#955).
+        /// Matches MapTileAnimation1ViewModel.LoadList(): build the anime1 PLIST
+        /// filter via MapTileAnimation1Core.BuildPlistList, pick the first
+        /// non-broken PLIST, then scan its resolved data table (8-byte blocks,
+        /// validated by isPointer(u32(addr+4))). Lockstep with
+        /// MapTileAnimation1Core.ScanEntries.</summary>
         static List<AddrResult> BuildMapTileAnimation1List(ROM rom)
         {
-            uint ptr = rom.RomInfo.map_tileanime1_pointer;
-            if (ptr == 0) return new List<AddrResult>();
-            uint baseAddr = rom.p32(ptr);
-            if (!U.isSafetyOffset(baseAddr, rom)) return new List<AddrResult>();
-
-            const uint blockSize = 8;
-            var result = new List<AddrResult>();
-            for (int i = 0; i < 256; i++)
+            var plistRows = MapTileAnimation1Core.BuildPlistList(rom);
+            foreach (var row in plistRows)
             {
-                uint addr = baseAddr + (uint)(i * blockSize);
-                if (addr + blockSize > (uint)rom.Data.Length) break;
-                // Validate: P4 must be a valid pointer (same as VM)
-                if (!U.isPointer(rom.u32(addr + 4))) break;
+                if (row.IsBroken) continue;
+                var entries = MapTileAnimation1Core.ScanEntries(rom, row.Addr, maxRows: 256);
+                if (entries.Count == 0) continue;
+                var result = new List<AddrResult>(entries.Count);
+                for (int i = 0; i < entries.Count; i++)
+                {
+                    var e = entries[i];
+                    string display = $"0x{i:X2} Interval={e.Wait:X4} Count={e.Length:X4}";
+                    result.Add(new AddrResult(e.Addr, display, (uint)i));
+                }
+                return result;
+            }
+            return new List<AddrResult>();
+        }
 
-                string display = $"0x{i:X2} Interval={rom.u16(addr):X4} Count={rom.u16(addr + 2):X4}";
-                result.Add(new AddrResult(addr, display, (uint)i));
+        /// <summary>Build the MapTileAnimation1 FILTER-combo list (the anime1
+        /// PLIST filter rows shown above the entry list), in lockstep with
+        /// MapTileAnimation1ViewModel.LoadPlistList() →
+        /// MapTileAnimation1Core.BuildPlistList(). Each filter row's Display is
+        /// the resolved "ANIME1 MapName" label via the shared resolver (#952,
+        /// #955), mirroring the anime2 "ANIME2 MapName" filter. Returns one
+        /// AddrResult per filter row (addr = resolved data offset, name =
+        /// resolved Display, tag = PLIST id) so parity tests can compare the VM
+        /// filter labels against this golden builder.</summary>
+        public static List<AddrResult> BuildMapTileAnimation1FilterList(ROM rom)
+        {
+            var rows = MapTileAnimation1Core.BuildPlistList(rom);
+            var result = new List<AddrResult>(rows.Count);
+            foreach (var row in rows)
+            {
+                result.Add(new AddrResult(row.Addr, row.Display, row.Plist));
             }
             return result;
         }

--- a/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
@@ -3713,19 +3713,26 @@ namespace FEBuilderGBA.Avalonia.Services
         }
 
         /// <summary>Build map tile animation 1 list — PLIST-based (#955).
-        /// Matches MapTileAnimation1ViewModel.LoadList(): build the anime1 PLIST
-        /// filter via MapTileAnimation1Core.BuildPlistList, pick the first
-        /// non-broken PLIST, then scan its resolved data table (8-byte blocks,
-        /// validated by isPointer(u32(addr+4))). Lockstep with
-        /// MapTileAnimation1Core.ScanEntries.</summary>
+        /// Matches MapTileAnimation1ViewModel.LoadList() EXACTLY: build the
+        /// anime1 PLIST filter via MapTileAnimation1Core.BuildPlistList, pick
+        /// the FIRST non-broken PLIST (regardless of whether its data table is
+        /// empty — the VM returns on the first non-broken row), then scan that
+        /// PLIST's resolved data table (8-byte blocks, validated by
+        /// isPointer(u32(addr+4))). #960: an earlier version skipped a
+        /// non-broken-but-empty PLIST (`if (entries.Count == 0) continue;`),
+        /// which the VM does NOT do — that mismatch made the VM↔golden lockstep
+        /// test flaky on ROMs whose first non-broken PLIST is empty. Lockstep
+        /// with MapTileAnimation1Core.ScanEntries.</summary>
         static List<AddrResult> BuildMapTileAnimation1List(ROM rom)
         {
             var plistRows = MapTileAnimation1Core.BuildPlistList(rom);
             foreach (var row in plistRows)
             {
                 if (row.IsBroken) continue;
+                // First non-broken PLIST wins — return its scan even when empty
+                // (mirrors the VM's `return BuildList(row.Addr);` on the first
+                // non-broken row).
                 var entries = MapTileAnimation1Core.ScanEntries(rom, row.Addr, maxRows: 256);
-                if (entries.Count == 0) continue;
                 var result = new List<AddrResult>(entries.Count);
                 for (int i = 0; i < entries.Count; i++)
                 {

--- a/FEBuilderGBA.Avalonia/ViewModels/MapTileAnimation1ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapTileAnimation1ViewModel.cs
@@ -127,6 +127,24 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             MarkClean();
         }
 
+        /// <summary>
+        /// Reset the detail fields when the selected PLIST has NO entries (an
+        /// empty data table) or is broken, so the panel doesn't show the
+        /// previously-selected entry's stale data (#960, same class as the #9
+        /// Map Exit stale-detail bug). Gates the Write button via
+        /// <see cref="IsLoaded"/>=false (the view's Write_Click early-returns
+        /// when <c>!IsLoaded</c>).
+        /// </summary>
+        public void ClearEntry()
+        {
+            CurrentAddr = 0;
+            SelectedAddress = 0;
+            AnimInterval = 0;
+            DataCount = 0;
+            MapTileDataPointer = 0;
+            IsLoaded = false;
+        }
+
         public void Write()
         {
             ROM rom = CoreState.ROM;

--- a/FEBuilderGBA.Avalonia/ViewModels/MapTileAnimation1ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapTileAnimation1ViewModel.cs
@@ -7,24 +7,25 @@ namespace FEBuilderGBA.Avalonia.ViewModels
     /// WinForms: MapTileAnimation1Form — block size 8, validated by isPointer(u32(addr+4)).
     /// Fields: AnimInterval (u16@0), DataCount (u16@2), MapTileDataPointer (u32@4).
     ///
-    /// <para>PLIST-RESOLUTION DEFERRED (#952, #11): the sibling editors
-    /// MapTileAnimationView (STEP 1) and MapTileAnimation2 (STEP 2) were rewired
-    /// to show resolved "ANIME1/ANIME2 MapName" labels via
-    /// <see cref="MapPListResolverCore"/>. MapTileAnimation1 is NOT a simple
-    /// label swap: this VM has no PLIST filter at all — its entry list already
-    /// shows DATA fields ("0x.. Interval=.. Count=..", correct WF parity for the
-    /// inner data table), so there is no raw 0x…/PLIST-hex label to resolve here.
-    /// Reaching WF parity (the filter-from-map-settings → PlistToOffsetAddr(
-    /// ANIMATION, anime1_plist) → selected-PLIST data structure that WF
-    /// MapTileAnimation1Form.MakeTileAnimation1 builds) is a STRUCTURAL feature
-    /// addition (new filter combo + Core BuildPlistList for anime1 + view
-    /// wiring), out of scope for the #11 label-resolution bug. Tracked for a
-    /// focused follow-up issue. The clean template already exists in
-    /// MapTileAnimation2Core/View if/when that follow-up lands.</para></summary>
+    /// <para>ANIME1 PLIST FILTER (#955, #957 W1c): this editor now mirrors
+    /// MapTileAnimation2 — a filter combo enumerates the distinct anime1 PLISTs
+    /// referenced by the map settings (<see cref="LoadPlistList"/> →
+    /// <see cref="MapTileAnimation1Core.BuildPlistList"/>), and selecting a PLIST
+    /// drives the entry list off that PLIST's resolved data table
+    /// (<see cref="BuildList"/> → <see cref="MapTileAnimation1Core.ScanEntries"/>).
+    /// Previously the VM treated <c>map_tileanime1_pointer</c> (the PLIST TABLE)
+    /// as a flat 8-byte entry table, which was structurally wrong — the WF form
+    /// resolves the SELECTED PLIST to its own data table via
+    /// <c>PlistToOffsetAddr(ANIMATION, anime1_plist)</c>. ANIME1 resolves under
+    /// <see cref="MapChangeCore.PlistType.ANIMATION"/> (ANIME1/ANIME2 share that
+    /// base in vanilla ROMs).</para></summary>
     public class MapTileAnimation1ViewModel : ViewModelBase, IDataVerifiable
     {
         static readonly List<EditorFormRef.FieldDef> _fields =
             EditorFormRef.DetectFields(new[] { "W0", "W2", "D4" });
+
+        /// <summary>WF block size constant (8 bytes per row).</summary>
+        public const uint BLOCK_SIZE = 8;
 
         uint _currentAddr;
         bool _isLoaded;
@@ -32,44 +33,80 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         uint _dataCount;
         uint _mapTileDataPointer;
 
+        // Filter panel (top read-config bar) — mirrors MapTileAnimation2ViewModel.
+        uint _readStartAddress;
+        uint _readCount;
+        uint? _selectedPlist;
+        List<MapTileAnimation1Core.PlistRow> _plistRows = new();
+
+        // Selection bar.
+        uint _selectedAddress;
+
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
         public uint AnimInterval { get => _animInterval; set => SetField(ref _animInterval, value); }
         public uint DataCount { get => _dataCount; set => SetField(ref _dataCount, value); }
         public uint MapTileDataPointer { get => _mapTileDataPointer; set => SetField(ref _mapTileDataPointer, value); }
 
-        /// <summary>Build list from a given base address (set via filter/JumpTo).</summary>
+        public uint BlockSize => BLOCK_SIZE;
+
+        public uint ReadStartAddress { get => _readStartAddress; set => SetField(ref _readStartAddress, value); }
+        public uint ReadCount { get => _readCount; set => SetField(ref _readCount, value); }
+        public uint? SelectedPlist { get => _selectedPlist; set => SetField(ref _selectedPlist, value); }
+        public List<MapTileAnimation1Core.PlistRow> PlistRows
+        {
+            get => _plistRows;
+            set => SetField(ref _plistRows, value ?? new());
+        }
+        public uint SelectedAddress { get => _selectedAddress; set => SetField(ref _selectedAddress, value); }
+
+        /// <summary>Build the filter combo list — one row per distinct anime1
+        /// PLIST referenced by any map (mirrors WF MakeTileAnimation1).</summary>
+        public List<MapTileAnimation1Core.PlistRow> LoadPlistList()
+        {
+            var rom = CoreState.ROM;
+            var rows = MapTileAnimation1Core.BuildPlistList(rom);
+            PlistRows = rows;
+            return rows;
+        }
+
+        /// <summary>Build the address-list for a specific PLIST root address.</summary>
         public List<AddrResult> BuildList(uint baseAddr)
         {
+            var rom = CoreState.ROM;
             var result = new List<AddrResult>();
-            ROM rom = CoreState.ROM;
             if (rom == null || baseAddr == 0) return result;
-
-            const uint blockSize = 8;
-            for (int i = 0; i < 256; i++)
+            ReadStartAddress = baseAddr;
+            var entries = MapTileAnimation1Core.ScanEntries(rom, baseAddr, maxRows: 256);
+            for (int i = 0; i < entries.Count; i++)
             {
-                uint addr = baseAddr + (uint)(i * blockSize);
-                if (addr + blockSize > (uint)rom.Data.Length) break;
-                // Validate: P4 must be a valid pointer
-                if (!U.isPointer(rom.u32(addr + 4))) break;
-
-                string display = $"0x{i:X2} Interval={rom.u16(addr):X4} Count={rom.u16(addr + 2):X4}";
-                result.Add(new AddrResult(addr, display, (uint)i));
+                var e = entries[i];
+                string display = $"0x{i:X2} Interval={e.Wait:X4} Count={e.Length:X4}";
+                result.Add(new AddrResult(e.Addr, display, (uint)i));
             }
+            ReadCount = (uint)entries.Count;
             return result;
         }
 
+        /// <summary>
+        /// Build the list shown when the editor opens with no PLIST chosen —
+        /// scan the PLIST list for the first valid (non-broken) entry. Kept for
+        /// the <c>IDataVerifiable</c> contract that calls <c>LoadList()</c> with
+        /// no arguments. Mirrors MapTileAnimation2ViewModel.LoadList().
+        /// </summary>
         public List<AddrResult> LoadList()
         {
-            ROM rom = CoreState.ROM;
+            var rom = CoreState.ROM;
             if (rom?.RomInfo == null) return new List<AddrResult>();
 
-            // Use map_tileanime1_pointer as default base
-            uint ptr = rom.RomInfo.map_tileanime1_pointer;
-            if (ptr == 0) return new List<AddrResult>();
-            uint baseAddr = rom.p32(ptr);
-            if (!U.isSafetyOffset(baseAddr, rom)) return new List<AddrResult>();
-            return BuildList(baseAddr);
+            var plistRows = LoadPlistList();
+            foreach (var row in plistRows)
+            {
+                if (row.IsBroken) continue;
+                SelectedPlist = row.Plist;
+                return BuildList(row.Addr);
+            }
+            return new List<AddrResult>();
         }
 
         public void LoadEntry(uint addr)
@@ -80,6 +117,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
             IsLoading = true;
             CurrentAddr = addr;
+            SelectedAddress = addr;
             var values = EditorFormRef.ReadFields(rom, addr, _fields);
             AnimInterval = values["W0"];
             DataCount = values["W2"];

--- a/FEBuilderGBA.Avalonia/Views/MapTileAnimation1View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapTileAnimation1View.axaml
@@ -2,12 +2,60 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
         x:Class="FEBuilderGBA.Avalonia.Views.MapTileAnimation1View"
-        Title="Tile Animation Type 1" Width="1238" Height="866"
+        Title="Map Tile Animation Type 1" Width="1238" Height="866"
         SizeToContent="WidthAndHeight">
-  <Grid ColumnDefinitions="250,*">
-    <controls:AddressListControl AutomationProperties.AutomationId="MapTileAnimation1_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
+  <Grid ColumnDefinitions="250,*" RowDefinitions="Auto,Auto,*">
 
-    <ScrollViewer Grid.Column="1" Margin="4">
+    <!-- Row 0: Top read-config bar with the anime1 PLIST filter combo
+         (#955). Mirrors MapTileAnimation2View: the Filter ComboBox lives in
+         the TrailingContent slot, before the Reload button. -->
+    <controls:EditorTopBarWithInputs Grid.Row="0" Grid.ColumnSpan="2" Name="TopBar"
+                                     AutomationProperties.AutomationId="MapTileAnimation1_TopBar"
+                                     ReadStartLabel="Top Address"
+                                     ReadCountLabel="Read Count"
+                                     ReadCountMaximum="1024"
+                                     InputsEnabled="False"
+                                     ShowReadSize="False"
+                                     ReadStartAutomationId="MapTileAnimation1_ReadStart_Input"
+                                     ReadCountAutomationId="MapTileAnimation1_ReadCount_Input"
+                                     ReloadAutomationId="MapTileAnimation1_ReloadList_Button"
+                                     ReloadRequested="OnTopBarReloadRequested">
+      <controls:EditorTopBarWithInputs.TrailingContent>
+        <StackPanel Orientation="Horizontal" Spacing="6">
+          <Label Content="Filter" VerticalAlignment="Center" />
+          <ComboBox AutomationProperties.AutomationId="MapTileAnimation1_Filter_Combo"
+                    Name="FilterComboBox" Width="280"
+                    SelectionChanged="FilterCombo_SelectionChanged" />
+        </StackPanel>
+      </controls:EditorTopBarWithInputs.TrailingContent>
+    </controls:EditorTopBarWithInputs>
+
+    <!-- Row 1: selection bar (mirrors MapTileAnimation2View) -->
+    <Border Grid.Row="1" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4,0,4,0">
+      <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
+        <Label Content="Address" VerticalAlignment="Center" />
+        <NumericUpDown AutomationProperties.AutomationId="MapTileAnimation1_Address_Input"
+                       FormatString="0" Name="AddressBox" Width="120"
+                       Minimum="0" Maximum="4294967295"
+                       IsEnabled="False" VerticalAlignment="Center" />
+        <Label Content="Size:" VerticalAlignment="Center" />
+        <NumericUpDown AutomationProperties.AutomationId="MapTileAnimation1_BlockSize_Input"
+                       FormatString="0" Name="BlockSizeBox" Width="50"
+                       Minimum="0" Maximum="65535"
+                       IsEnabled="False" VerticalAlignment="Center" Value="8" />
+        <Label Content="Selected Address:" VerticalAlignment="Center" />
+        <Label AutomationProperties.AutomationId="MapTileAnimation1_SelectedAddress_Label"
+               Name="SelectedAddressLabel" Width="100" VerticalAlignment="Center"
+               FontFamily="Consolas" />
+      </StackPanel>
+    </Border>
+
+    <!-- Row 2 col 0: Address list panel -->
+    <controls:AddressListControl AutomationProperties.AutomationId="MapTileAnimation1_Entry_List"
+                                 Grid.Row="2" Grid.Column="0" Name="EntryList" Margin="4" />
+
+    <!-- Row 2 col 1: edit panel -->
+    <ScrollViewer Grid.Row="2" Grid.Column="1" Margin="4">
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Map Tile Animation Type 1" FontSize="18" FontWeight="Bold" />
 

--- a/FEBuilderGBA.Avalonia/Views/MapTileAnimation1View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapTileAnimation1View.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Services;
@@ -6,10 +7,19 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
+    /// <summary>
+    /// Avalonia counterpart of WinForms <c>MapTileAnimation1Form</c>.
+    /// The anime1 PLIST filter (#955) mirrors <c>MapTileAnimation2View</c>: the
+    /// top bar's Filter combo enumerates the distinct anime1 PLISTs referenced
+    /// by the map settings, and selecting a PLIST drives the entry list off that
+    /// PLIST's resolved data table (instead of treating the
+    /// <c>map_tileanime1_pointer</c> PLIST table as a flat entry table).
+    /// </summary>
     public partial class MapTileAnimation1View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly MapTileAnimation1ViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _suppressFilterChange;
 
         public string ViewTitle => "Map Tile Animation Type 1";
         public bool IsLoaded => _vm.IsLoaded;
@@ -27,12 +37,90 @@ namespace FEBuilderGBA.Avalonia.Views
             _vm.IsLoading = true;
             try
             {
-                var items = _vm.LoadList();
-                EntryList.SetItems(items);
+                // Populate the filter combo with the anime1 PLIST list
+                // (mirrors WF MakeTileAnimation1).
+                var plistRows = _vm.LoadPlistList();
+                _suppressFilterChange = true;
+                try
+                {
+                    FilterComboBox.ItemsSource = MakeFilterItems(plistRows);
+                    FilterComboBox.SelectedIndex = plistRows.Count > 0 ? 0 : -1;
+                }
+                finally { _suppressFilterChange = false; }
+
+                // Drive list population from the selected PLIST.
+                if (plistRows.Count > 0)
+                {
+                    SelectPlist(plistRows[0]);
+                }
+                else
+                {
+                    EntryList.SetItems(new List<AddrResult>());
+                    TopBar.ReadStartAddress = 0;
+                    TopBar.ReadCount = 0;
+                    ClearDetailPanel();
+                    UpdateUI();
+                }
             }
             catch (Exception ex)
             {
                 Log.Error("MapTileAnimation1View.LoadList failed: {0}", ex.Message);
+            }
+            finally { _vm.IsLoading = false; _vm.MarkClean(); }
+        }
+
+        /// <summary>Reset the right-hand detail panel state. Used by LoadList
+        /// (zero PLIST entries) and SelectPlist (broken PLIST).</summary>
+        void ClearDetailPanel()
+        {
+            _vm.IsLoaded = false;
+            _vm.CurrentAddr = 0;
+            _vm.SelectedAddress = 0;
+            _vm.AnimInterval = 0;
+            _vm.DataCount = 0;
+            _vm.MapTileDataPointer = 0;
+        }
+
+        void OnTopBarReloadRequested(object? sender, RoutedEventArgs e) => LoadList();
+
+        static List<string> MakeFilterItems(List<MapTileAnimation1Core.PlistRow> rows)
+        {
+            var items = new List<string>(rows.Count);
+            foreach (var row in rows)
+            {
+                items.Add(row.Display);
+            }
+            return items;
+        }
+
+        void FilterCombo_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressFilterChange) return;
+            int idx = FilterComboBox.SelectedIndex;
+            if (idx < 0 || idx >= _vm.PlistRows.Count) return;
+            SelectPlist(_vm.PlistRows[idx]);
+        }
+
+        void SelectPlist(MapTileAnimation1Core.PlistRow row)
+        {
+            // Filter selection is a navigation event, NOT a user edit.
+            _vm.IsLoading = true;
+            try
+            {
+                _vm.SelectedPlist = row.Plist;
+                if (row.IsBroken)
+                {
+                    EntryList.SetItems(new List<AddrResult>());
+                    TopBar.ReadStartAddress = 0;
+                    TopBar.ReadCount = 0;
+                    ClearDetailPanel();
+                    UpdateUI();
+                    return;
+                }
+                var items = _vm.BuildList(row.Addr);
+                EntryList.SetItems(items);
+                TopBar.ReadStartAddress = _vm.ReadStartAddress;
+                TopBar.ReadCount = (int)_vm.ReadCount;
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -55,6 +143,8 @@ namespace FEBuilderGBA.Avalonia.Views
         void UpdateUI()
         {
             AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            AddressBox.Value = _vm.CurrentAddr;
+            SelectedAddressLabel.Content = string.Format("0x{0:X08}", _vm.CurrentAddr);
             AnimIntervalBox.Value = _vm.AnimInterval;
             DataCountBox.Value = _vm.DataCount;
             MapTileDataPointerBox.Text = string.Format("0x{0:X08}", _vm.MapTileDataPointer);
@@ -62,7 +152,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void Write_Click(object? sender, RoutedEventArgs e)
         {
-            if (!_vm.IsLoaded) return;
+            if (!_vm.IsLoaded || _vm.CurrentAddr == 0) return;
             _undoService.Begin("Edit Tile Animation Type 1");
             try
             {

--- a/FEBuilderGBA.Avalonia/Views/MapTileAnimation1View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapTileAnimation1View.axaml.cs
@@ -70,16 +70,11 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         /// <summary>Reset the right-hand detail panel state. Used by LoadList
-        /// (zero PLIST entries) and SelectPlist (broken PLIST).</summary>
-        void ClearDetailPanel()
-        {
-            _vm.IsLoaded = false;
-            _vm.CurrentAddr = 0;
-            _vm.SelectedAddress = 0;
-            _vm.AnimInterval = 0;
-            _vm.DataCount = 0;
-            _vm.MapTileDataPointer = 0;
-        }
+        /// (zero PLIST entries), SelectPlist (broken PLIST OR a non-broken
+        /// PLIST resolving to an EMPTY entry table, #960). Delegates to the
+        /// VM's ClearEntry() so the field-reset + Write-gating lives in one
+        /// place.</summary>
+        void ClearDetailPanel() => _vm.ClearEntry();
 
         void OnTopBarReloadRequested(object? sender, RoutedEventArgs e) => LoadList();
 
@@ -121,6 +116,18 @@ namespace FEBuilderGBA.Avalonia.Views
                 EntryList.SetItems(items);
                 TopBar.ReadStartAddress = _vm.ReadStartAddress;
                 TopBar.ReadCount = (int)_vm.ReadCount;
+
+                // #960: a non-broken PLIST can still resolve to an EMPTY entry
+                // table. SetItems fires no selection on an empty list, so the
+                // detail panel would otherwise keep showing the PREVIOUSLY-
+                // selected entry. Clear the detail VM state + refresh the UI so
+                // the stale entry is gone and Write is gated (same class as the
+                // #9 Map Exit stale-detail bug).
+                if (items.Count == 0)
+                {
+                    ClearDetailPanel();
+                    UpdateUI();
+                }
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }

--- a/FEBuilderGBA.Core.Tests/MapTileAnimation1CoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/MapTileAnimation1CoreTests.cs
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for MapTileAnimation1Core (#955, #957 W1c).
+//
+// Headless mirror of WinForms MapTileAnimation1Form's anime1 PLIST-filter
+// structure (MakeTileAnimation1) + the 8-byte data-table record scanned for the
+// SELECTED PLIST (Init: isPointer(u32(addr+4)); wait@0, length@2, imgPtr@4).
+// Mirrors MapTileAnimation2CoreTests one-for-one with the anime1 schema
+// differences: anime1_plist at +9 (not anime2_plist at +10), PlistType.ANIMATION
+// (map_tileanime1_pointer), and the image pointer at +4 (not +0).
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class MapTileAnimation1CoreTests
+    {
+        // -----------------------------------------------------------------
+        // ScanEntries - stops at first non-pointer P4 (mirrors WF
+        // InputFormRef predicate: isPointer(u32(addr+4)))
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void ScanEntries_StopsAtFirstNonPointer()
+        {
+            var rom = new ROM();
+            rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+
+            // Plant 3 valid 8-byte entries at base 0x200, then a zero P4 at row 3.
+            // Schema: wait@0 (u16), length@2 (u16), imgPtr@4 (u32).
+            uint baseAddr = 0x200;
+            for (int i = 0; i < 3; i++)
+            {
+                uint addr = baseAddr + (uint)(i * 8);
+                WriteU16(rom.Data, (int)addr + 0, (ushort)(0x10 + i)); // wait
+                WriteU16(rom.Data, (int)addr + 2, (ushort)0x1000);     // length
+                WriteU32(rom.Data, (int)addr + 4, 0x08800000u + (uint)(i * 0x100)); // imgPtr
+            }
+            // Row 3: zero P4 - scan should stop here.
+            WriteU32(rom.Data, (int)(baseAddr + 3 * 8) + 4, 0u);
+
+            var entries = MapTileAnimation1Core.ScanEntries(rom, baseAddr, 256);
+            Assert.Equal(3, entries.Count);
+            Assert.Equal(baseAddr, entries[0].Addr);
+            Assert.Equal(0x10u, entries[0].Wait);
+            Assert.Equal(0x1000u, entries[0].Length);
+            Assert.Equal(0x08800000u, entries[0].P4);
+        }
+
+        [Fact]
+        public void ScanEntries_HonorsMaxRows()
+        {
+            var rom = new ROM();
+            rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+
+            uint baseAddr = 0x200;
+            for (int i = 0; i < 10; i++)
+            {
+                uint addr = baseAddr + (uint)(i * 8);
+                WriteU32(rom.Data, (int)addr + 4, 0x08800000u + (uint)(i * 0x100));
+            }
+            var entries = MapTileAnimation1Core.ScanEntries(rom, baseAddr, maxRows: 4);
+            Assert.Equal(4, entries.Count);
+        }
+
+        [Fact]
+        public void ScanEntries_NullRom_ReturnsEmpty()
+        {
+            var entries = MapTileAnimation1Core.ScanEntries(null, 0x200, 256);
+            Assert.NotNull(entries);
+            Assert.Empty(entries);
+        }
+
+        // -----------------------------------------------------------------
+        // BuildPlistList - mirrors WF MakeTileAnimation1 semantics
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void BuildPlistList_WithNullRom_ReturnsEmpty()
+        {
+            var rows = MapTileAnimation1Core.BuildPlistList(null);
+            Assert.NotNull(rows);
+            Assert.Empty(rows);
+        }
+
+        [Fact]
+        public void BuildPlistList_WithZeroPointer_ReturnsEmpty()
+        {
+            var rom = new ROM();
+            rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+            WriteU32(rom.Data, (int)rom.RomInfo.map_tileanime1_pointer, 0u);
+
+            var rows = MapTileAnimation1Core.BuildPlistList(rom);
+            Assert.NotNull(rows);
+            Assert.Empty(rows);
+        }
+
+        [Fact]
+        public void BuildPlistList_OmitsZeroAnime1Plist()
+        {
+            // Build a single map setting with anime1_plist == 0 (offset +9) - it
+            // must not appear in the result.
+            var rom = MakeSyntheticFE8URom(out uint mapBase, out uint plistTableBase, out uint mapPtrBase);
+            int mapBaseI = (int)mapBase;
+            rom.Data[mapBaseI + 9] = 0; // anime1_plist == 0
+            WriteU32(rom.Data, (int)mapBase + 0, 0x08800000u); // D0=pointer => valid map
+
+            var rows = MapTileAnimation1Core.BuildPlistList(rom);
+            Assert.Empty(rows);
+        }
+
+        [Fact]
+        public void BuildPlistList_DedupesDuplicateMapReferences()
+        {
+            // Two map settings BOTH pointing at anime1_plist == 1 - only one row.
+            var rom = MakeSyntheticFE8URom(out uint mapBase, out uint plistTableBase, out uint mapPtrBase);
+            int mapBaseI = (int)mapBase;
+            int dataSizeI = (int)rom.RomInfo.map_setting_datasize;
+
+            // map[0]: D0=pointer, anime1_plist=1 (offset +9)
+            WriteU32(rom.Data, mapBaseI + 0, 0x08800000u);
+            rom.Data[mapBaseI + 9] = 1;
+            // map[1]: D0=pointer, anime1_plist=1 (duplicate)
+            WriteU32(rom.Data, mapBaseI + dataSizeI + 0, 0x08800100u);
+            rom.Data[mapBaseI + dataSizeI + 9] = 1;
+            // map[2]: D0=0 (non-pointer) terminator that fails validation
+            WriteU32(rom.Data, mapBaseI + 2 * dataSizeI + 0, 0u);
+
+            // PLIST table entry for plist=1 -> a valid data block.
+            uint plist1Slot = plistTableBase + 1 * 4;
+            WriteU32(rom.Data, (int)plist1Slot, 0x08900000u);
+            // Plant a valid 8-byte entry at 0x900000 (imgPtr at +4) so the block
+            // dereferences cleanly.
+            WriteU32(rom.Data, (int)0x900000 + 4, 0x08A00000u);
+
+            var rows = MapTileAnimation1Core.BuildPlistList(rom);
+            Assert.Single(rows);
+            Assert.Equal(1u, rows[0].Plist);
+            Assert.False(rows[0].IsBroken);
+        }
+
+        [Fact]
+        public void BuildPlistList_MarksBrokenPlistAddress()
+        {
+            // PLIST table entry for plist=2 dereferences to ZERO - row is
+            // included with isBroken=true.
+            var rom = MakeSyntheticFE8URom(out uint mapBase, out uint plistTableBase, out uint mapPtrBase);
+            int mapBaseI = (int)mapBase;
+            int dataSizeI = (int)rom.RomInfo.map_setting_datasize;
+
+            WriteU32(rom.Data, mapBaseI + 0, 0x08800000u);
+            rom.Data[mapBaseI + 9] = 2; // anime1_plist = 2
+            WriteU32(rom.Data, mapBaseI + dataSizeI + 0, 0u); // terminator
+
+            // PLIST table entry for plist=2 -> zero pointer (broken).
+            WriteU32(rom.Data, (int)(plistTableBase + 2 * 4), 0u);
+
+            var rows = MapTileAnimation1Core.BuildPlistList(rom);
+            Assert.Single(rows);
+            Assert.Equal(2u, rows[0].Plist);
+            Assert.True(rows[0].IsBroken);
+            // Broken suffix (R._("(破損)")) appended - assert the open paren.
+            Assert.True(rows[0].Display.Contains("(") || rows[0].Display.Contains("破損"),
+                $"Display should contain WF broken suffix: '{rows[0].Display}'");
+        }
+
+        // -----------------------------------------------------------------
+        // BuildPlistList resolved-label semantics (#952, #955)
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void BuildPlistList_ResolvesFilterLabelToAnime1MapName()
+        {
+            var rom = MakeSyntheticFE8URom(out uint mapBase, out uint plistTableBase, out uint mapPtrBase);
+            int mapBaseI = (int)mapBase;
+            int dataSizeI = (int)rom.RomInfo.map_setting_datasize;
+
+            // map[0]: D0=pointer (valid), anime1_plist=1
+            WriteU32(rom.Data, mapBaseI + 0, 0x08800000u);
+            rom.Data[mapBaseI + 9] = 1;
+            // map[1]: terminator
+            WriteU32(rom.Data, mapBaseI + dataSizeI + 0, 0u);
+
+            // PLIST table entry for plist=1 -> valid data block.
+            WriteU32(rom.Data, (int)(plistTableBase + 1 * 4), 0x08900000u);
+            WriteU32(rom.Data, (int)0x900000 + 4, 0x08A00000u);
+
+            var rows = MapTileAnimation1Core.BuildPlistList(rom);
+            Assert.Single(rows);
+            Assert.Equal(1u, rows[0].Plist);
+            Assert.False(rows[0].IsBroken);
+
+            // Must be the resolved ANIME1 label (split layout: anime1_plist==1
+            // matches under ANIMATION; non-split: first matching field is
+            // anime1_plist so still "ANIME1 ...").
+            Assert.StartsWith("ANIME1 ", rows[0].Display);
+            // Must NOT be a raw 0x pointer label.
+            Assert.DoesNotContain("0x08", rows[0].Display);
+        }
+
+        [Fact]
+        public void BuildPlistList_BrokenRow_KeepsResolvedLabelPlusBrokenSuffix()
+        {
+            var rom = MakeSyntheticFE8URom(out uint mapBase, out uint plistTableBase, out uint mapPtrBase);
+            int mapBaseI = (int)mapBase;
+            int dataSizeI = (int)rom.RomInfo.map_setting_datasize;
+
+            WriteU32(rom.Data, mapBaseI + 0, 0x08800000u);
+            rom.Data[mapBaseI + 9] = 2;
+            WriteU32(rom.Data, mapBaseI + dataSizeI + 0, 0u);
+            // plist=2 slot -> zero (broken).
+            WriteU32(rom.Data, (int)(plistTableBase + 2 * 4), 0u);
+
+            var rows = MapTileAnimation1Core.BuildPlistList(rom);
+            Assert.Single(rows);
+            Assert.True(rows[0].IsBroken);
+            // Resolved prefix + broken suffix paren.
+            Assert.Contains("(", rows[0].Display);
+        }
+
+        // -----------------------------------------------------------------
+        // Helpers
+        // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Build a tiny synthetic FE8U ROM. Sets the map_setting_pointer to
+        /// 0x08800000 (map data at 0x800000) and the map_tileanime1_pointer to
+        /// dereference to a PLIST table at 0x900000.
+        /// </summary>
+        static ROM MakeSyntheticFE8URom(out uint mapBase, out uint plistTableBase, out uint mapPtrBase)
+        {
+            var rom = new ROM();
+            rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+
+            mapPtrBase = rom.RomInfo.map_setting_pointer;
+            mapBase = 0x800000;
+            plistTableBase = 0x900000;
+
+            WriteU32(rom.Data, (int)mapPtrBase, 0x08000000u | mapBase);
+            WriteU32(rom.Data, (int)rom.RomInfo.map_tileanime1_pointer, 0x08000000u | plistTableBase);
+
+            return rom;
+        }
+
+        static void WriteU32(byte[] data, int offset, uint value)
+        {
+            data[offset + 0] = (byte)(value & 0xFF);
+            data[offset + 1] = (byte)((value >> 8) & 0xFF);
+            data[offset + 2] = (byte)((value >> 16) & 0xFF);
+            data[offset + 3] = (byte)((value >> 24) & 0xFF);
+        }
+
+        static void WriteU16(byte[] data, int offset, ushort value)
+        {
+            data[offset + 0] = (byte)(value & 0xFF);
+            data[offset + 1] = (byte)((value >> 8) & 0xFF);
+        }
+    }
+}

--- a/FEBuilderGBA.Core/MapTileAnimation1Core.cs
+++ b/FEBuilderGBA.Core/MapTileAnimation1Core.cs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Cross-platform helpers for the MapTileAnimation1 editor (#955, #957 W1c).
+using System;
+using System.Collections.Generic;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Cross-platform helpers for map tile animation type 1 (tile-image
+    /// animation), extracted from <c>WinForms MapTileAnimation1Form</c> so the
+    /// Avalonia view can drive the editor without WinForms dependencies (#955).
+    ///
+    /// <para>The WF form builds a <b>filter list of anime1 PLISTs</b> referenced
+    /// by any map setting (<see cref="BuildPlistList"/>, mirroring WF
+    /// <c>MakeTileAnimation1</c>), then reads the SELECTED PLIST's resolved data
+    /// table (<see cref="ScanEntries"/>, mirroring WF <c>Init</c>'s 8-byte
+    /// record). This is the structural counterpart of
+    /// <see cref="MapTileAnimation2Core.BuildPlistList"/> /
+    /// <see cref="MapTileAnimation2Core.ScanEntries"/>; the only differences are
+    /// the per-map PLIST field read (<c>anime1_plist</c> at <c>+9</c> instead of
+    /// <c>anime2_plist</c> at <c>+10</c>), the PLIST type
+    /// (<see cref="MapChangeCore.PlistType.ANIMATION"/> →
+    /// <c>map_tileanime1_pointer</c>; ANIME1/ANIME2 share that base in vanilla
+    /// ROMs and both resolve under the WF "ANIMATION" filter), and the entry
+    /// record schema.</para>
+    ///
+    /// <para><b>Entry schema</b> (8 bytes per row, WF <c>Init</c> +
+    /// <c>ExportAll</c>): <c>wait = u16@+0</c>, <c>length = u16@+2</c>,
+    /// <c>imagePointer = p32@+4</c>. The termination predicate is
+    /// <c>isPointer(u32(addr+4))</c> — the image pointer lives at <c>+4</c>, NOT
+    /// <c>+0</c> (the inverse of anime2). The Avalonia VM already used this
+    /// schema for the inner data fields; the gap (#955) was the MISSING PLIST
+    /// filter and the WRONG base resolution (the old VM treated
+    /// <c>map_tileanime1_pointer</c> — the PLIST TABLE — as the flat entry
+    /// table).</para>
+    /// </summary>
+    public static class MapTileAnimation1Core
+    {
+        /// <summary>
+        /// One row in the filter combo. Matches
+        /// <see cref="MapTileAnimation2Core.PlistRow"/> field-for-field so the
+        /// Avalonia view + golden builder can share the wiring shape.
+        /// </summary>
+        /// <param name="Plist">The map setting's <c>anime1_plist</c> value.</param>
+        /// <param name="Addr">The ROM offset the PLIST resolves to, or
+        /// <see cref="U.NOT_FOUND"/> when the PLIST table entry dereferences to
+        /// zero or to an unsafe offset (<see cref="IsBroken"/> == true).</param>
+        /// <param name="Display">Resolved "ANIME1 MapName" label via
+        /// <see cref="MapPListResolverCore.ResolveLabel"/> (mirroring how anime2
+        /// uses <see cref="MapChangeCore.PlistType.ANIMATION2"/>), with the
+        /// WF "(破損)" suffix appended on a broken PLIST.</param>
+        /// <param name="IsBroken">Set when the row dereferences to an unusable
+        /// address — the row is kept so the user can repair it.</param>
+        public record PlistRow(uint Plist, uint Addr, string Display, bool IsBroken);
+
+        /// <summary>
+        /// One entry in the main animation list (8 bytes per row in WF).
+        /// </summary>
+        /// <param name="Addr">Absolute ROM offset of the entry.</param>
+        /// <param name="Wait">u16 at <c>addr+0</c> — animation interval.</param>
+        /// <param name="Length">u16 at <c>addr+2</c> — image byte length.</param>
+        /// <param name="P4">Raw u32 at <c>addr+4</c> (GBA image pointer; the
+        /// termination predicate <c>isPointer(P4)</c> gates the row).</param>
+        public record EntryRow(uint Addr, uint Wait, uint Length, uint P4);
+
+        /// <summary>
+        /// Walk the 8-byte entry table rooted at <paramref name="baseAddr"/>
+        /// and return every row whose <c>P4</c> (image pointer at <c>+4</c>) is
+        /// a valid GBA pointer. Stops at the first non-pointer row (mirrors the
+        /// WF <c>InputFormRef</c> termination predicate
+        /// <c>isPointer(u32(addr+4))</c>) or after <paramref name="maxRows"/>
+        /// iterations.
+        /// </summary>
+        public static List<EntryRow> ScanEntries(ROM rom, uint baseAddr, int maxRows = 256)
+        {
+            var result = new List<EntryRow>();
+            if (rom == null) return result;
+            const uint blockSize = 8;
+            for (int i = 0; i < maxRows; i++)
+            {
+                uint addr = baseAddr + (uint)(i * blockSize);
+                if (addr + blockSize > (uint)rom.Data.Length) break;
+                // WF predicate: the image pointer at +4 must be a valid pointer.
+                if (!U.isPointer(rom.u32(addr + 4))) break;
+                uint wait = rom.u16(addr + 0);
+                uint length = rom.u16(addr + 2);
+                uint p4 = rom.u32(addr + 4);
+                result.Add(new EntryRow(addr, wait, length, p4));
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Build the filter list shown at the top of the WF editor (mirrors WF
+        /// <c>MapTileAnimation1Form.MakeTileAnimation1</c>). Walks every valid
+        /// map setting, reads <c>anime1_plist</c> at <c>+9</c> (skip zero,
+        /// dedupe), and resolves each PLIST through the
+        /// <c>map_tileanime1_pointer</c> table via
+        /// <see cref="MapChangeCore.PlistToOffsetAddr"/> with
+        /// <see cref="MapChangeCore.PlistType.ANIMATION"/>. Rows whose PLIST
+        /// table entry dereferences to zero / an unsafe offset / past the
+        /// version-specific limit are kept with <see cref="PlistRow.IsBroken"/>
+        /// set so the editor can offer a repair affordance.
+        /// </summary>
+        public static List<PlistRow> BuildPlistList(ROM rom)
+        {
+            var result = new List<PlistRow>();
+            if (rom?.RomInfo == null) return result;
+
+            uint plistTablePtr = rom.RomInfo.map_tileanime1_pointer;
+            if (plistTablePtr == 0) return result;
+            uint plistTableBase = rom.p32(plistTablePtr);
+            if (!U.isSafetyOffset(plistTableBase, rom)) return result;
+
+            // Resolve each filter row to an "ANIME1 MapName" label via the
+            // shared resolver (#952, #11) — the same resolver anime2 uses with
+            // ANIMATION2. Built once and reused across the loop (per-call local
+            // cache). The cache already enumerated every map via
+            // MapSettingCore.MakeMapIDList, so reuse cache.Maps for the filter
+            // scan instead of a second MakeMapIDList allocation/scan.
+            var resolveCache = MapPListResolverCore.BuildCache(rom);
+
+            var seen = new HashSet<uint>();
+            foreach (var map in resolveCache.Maps)
+            {
+                // anime1_plist is the u8 at map setting +9.
+                if (map.addr + 10 > (uint)rom.Data.Length) continue;
+                uint plist = rom.u8(map.addr + 9);
+                if (plist == 0) continue;
+                if (!seen.Add(plist)) continue;
+
+                // Resolve the PLIST to a data offset via the same WF
+                // PlistToOffsetAddr(ANIMATION, plist) path the WF anime1 form
+                // uses. The Core helper applies the version-specific PLIST
+                // limit + safety guards and returns U.NOT_FOUND on a broken
+                // entry — exactly WF's "(破損)" trigger.
+                uint dataAddr = MapChangeCore.PlistToOffsetAddr(
+                    rom, MapChangeCore.PlistType.ANIMATION, plist, out uint _);
+                bool broken = dataAddr == U.NOT_FOUND;
+
+                string baseLabel = MapPListResolverCore.ResolveLabel(
+                    rom, MapChangeCore.PlistType.ANIMATION, plist, resolveCache);
+                string display = broken
+                    ? baseLabel + R._("(破損)")
+                    : baseLabel;
+                result.Add(new PlistRow(plist, dataAddr, display, broken));
+            }
+            return result;
+        }
+    }
+}

--- a/docs/field-completeness-report.txt
+++ b/docs/field-completeness-report.txt
@@ -1,6 +1,6 @@
 === Field Completeness Report ===
 Total WinForms fields: 1563
-Total Avalonia fields: 1799
+Total Avalonia fields: 1801
 Total missing: 0
 Forms with gaps: 0 / 175
 


### PR DESCRIPTION
## Summary

Closes **#955** (deferred from T5 PR #954). `MapTileAnimation1` treated `map_tileanime1_pointer` as a flat 8-byte entry table; WinForms `MapTileAnimation1Form` instead builds an **anime1 PLIST filter from the map settings**, then reads the SELECTED PLIST's data table. This adds that structure, mirroring the already-correct anime2 editor.

## Changes
- **New `FEBuilderGBA.Core/MapTileAnimation1Core.cs`** (mirrors `MapTileAnimation2Core`): `BuildPlistList(rom)` enumerates the distinct anime1 PLISTs the maps reference (`anime1_plist` at map-setting `+9`), resolves each filter row via `MapPListResolverCore.ResolveLabel(rom, PlistType.ANIMATION, plist)` → **`ANIME1 MapName`** (with the WF `(破損)` broken-PLIST suffix), and resolves the selected PLIST's data offset via `MapChangeCore.PlistToOffsetAddr`. `ScanEntries` walks the records.
- **Data-schema correction:** the anime1 record is `{ wait u16@+0, length u16@+2, imagePointer p32@+4 }` (image pointer at **+4**, the inverse of anime2), terminated by `!isPointer(u32(+4))`. The entry list now reads through the selected PLIST's resolved data table instead of the flat PLIST table.
- **View/VM:** `MapTileAnimation1View` gains a filter combo (in `EditorTopBarWithInputs.TrailingContent`) + selection bar; `MapTileAnimation1ViewModel` gains the filter state mirroring anime2. `ListParityHelper` adds `BuildMapTileAnimation1FilterList` and rewires `BuildMapTileAnimation1List` to the PLIST-based path.
- Confirmed `ANIMATION` is the correct PlistType (`GetPlistBasePointer(ANIMATION) == map_tileanime1_pointer`).

## Tests (21 new)
- `MapTileAnimation1CoreTests` (10): `ScanEntries` +4-pointer termination/maxRows/null; `BuildPlistList` null/zero-ptr/zero-plist/dedupe/broken/resolved-`ANIME1`-label.
- `MapTileAnimationResolverParityTests` (+3): anime1 resolved-label, filter + list VM↔golden lockstep.
- `MapTileAnimation1FilterTests` (8): combo/reload/selection-bar structural, undo-scoped Write, VM flow.

## Scope
Closes #955.

## Screenshot — MapTileAnimation1 anime1 PLIST filter (FE8J)

![after](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/w1c-maptileanim1-after.png)

The new **Filter** combo (top-right) reads `ANIME1 ルネス陥落` (ANIME1 + map name, like anime2's `ANIME2 MapName`); the selection bar shows Address/Size 8/Selected Address; the entry list is populated from the selected PLIST's data table (`0x00 Interval=001C Count=1000` …).

## GUI Test Report

| Test | Result |
|------|--------|
| anime1 PLIST filter combo resolves to `ANIME1 MapName` (matches anime2) | ✅ PASS |
| Entry list reads the selected PLIST's data table with the +4 image-pointer schema | ✅ PASS |
| Filter + list VM↔golden lockstep; undo-scoped Write | ✅ PASS |
| Core `MapTileAnimation1Core` oracle (10) + filter VM tests (8) | ✅ PASS |
| `Core.Tests` map tests / `Avalonia.Tests` 7477 / `FEBuilderGBA.Tests` 1822 — all green | ✅ PASS |

## Test plan
- [x] 21 new tests (Core oracle + parity lockstep + filter VM flow)
- [x] All 3 test projects green; AutomationId validator passes
- [x] After-screenshot shows the resolved anime1 filter + selected-PLIST data list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Code 2.1.162 · model claude-opus-4-8[1m]
