### PR TITLE
feat(core+avalonia): real song-name resolver (Sound Room + SE list) + restore Boss BGM song name (#961 W2a)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ListParityHelperTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ListParityHelperTests.cs
@@ -353,4 +353,54 @@ public class ListParityHelperTests : IClassFixture<RomFixture>
             Assert.Equal(vmList[i].name, refList[i].name);
         }
     }
+
+    // ---------------------------------------------------------------
+    // SoundBossBGM — lockstep VM vs golden + unresolved-id label (#962)
+    // ---------------------------------------------------------------
+
+    /// <summary>
+    /// The Boss BGM VM list and the golden ListParityHelper builder must
+    /// stay byte-for-byte identical (the lockstep song-name restore, #961).
+    /// </summary>
+    [Fact]
+    public void BuildReferenceList_SoundBossBGM_MatchesViewModel()
+    {
+        if (!_rom.IsAvailable) return;
+
+        var vm = new SoundBossBGMViewerViewModel();
+        var vmList = vm.LoadSoundBossBGMList();
+        var refList = ListParityHelper.BuildReferenceList("SoundBossBGMViewerView");
+
+        Assert.NotNull(refList);
+        Assert.Equal(vmList.Count, refList.Count);
+        for (int i = 0; i < vmList.Count; i++)
+        {
+            Assert.Equal(vmList[i].addr, refList[i].addr);
+            Assert.Equal(vmList[i].name, refList[i].name);
+        }
+    }
+
+    /// <summary>
+    /// #962 review #2/#3: an unresolved song id must NOT duplicate the hex
+    /// with a "Song 0x.." placeholder (the old "1BSong 0x1B" bug). Every
+    /// Boss BGM label must contain " : " (the song-hex segment) and must NEVER
+    /// contain the "Song 0x" placeholder — for an unknown song the label
+    /// collapses to just the song hex (matching WinForms' empty-string append).
+    /// </summary>
+    [Fact]
+    public void SoundBossBGM_Labels_NeverContainSongPlaceholder()
+    {
+        if (!_rom.IsAvailable) return;
+
+        var vm = new SoundBossBGMViewerViewModel();
+        var vmList = vm.LoadSoundBossBGMList();
+
+        foreach (var row in vmList)
+        {
+            // The placeholder "Song 0x" must never leak into the label.
+            Assert.DoesNotContain("Song 0x", row.name);
+            // The colon-separated song-hex segment is always present.
+            Assert.Contains(" : ", row.name);
+        }
+    }
 }

--- a/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
@@ -1094,7 +1094,10 @@ namespace FEBuilderGBA.Avalonia.Services
                 uint songId = rom.u32(addr + 4);
                 // 1-based ROM-stored unit ID (matches SoundBossBGMViewerViewModel).
                 string unitName = NameResolver.GetUnitNameByOneBasedId(unitId);
-                string name = $"{U.ToHexString(unitId)} {unitName} : {U.ToHexString(songId)}";
+                // Lockstep with SoundBossBGMViewerViewModel — WinForms format:
+                //   "{unitHex} {unitName} : {songHex}{songName}" (#961 W2a).
+                string songName = NameResolver.GetSongName(songId);
+                string name = $"{U.ToHexString(unitId)} {unitName} : {U.ToHexString(songId)}{songName}";
                 result.Add(new AddrResult(addr, name, i));
             }
             return result;

--- a/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
@@ -1096,7 +1096,9 @@ namespace FEBuilderGBA.Avalonia.Services
                 string unitName = NameResolver.GetUnitNameByOneBasedId(unitId);
                 // Lockstep with SoundBossBGMViewerViewModel — WinForms format:
                 //   "{unitHex} {unitName} : {songHex}{songName}" (#961 W2a).
-                string songName = NameResolver.GetSongName(songId);
+                // Use the Core resolver DIRECTLY so an unresolved id yields "" (no
+                // "Song 0x.." placeholder duplication) — same as the VM (#962 review).
+                string songName = SongNameResolverCore.GetSongName(rom, songId);
                 string name = $"{U.ToHexString(unitId)} {unitName} : {U.ToHexString(songId)}{songName}";
                 result.Add(new AddrResult(addr, name, i));
             }

--- a/FEBuilderGBA.Avalonia/ViewModels/SoundBossBGMViewerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SoundBossBGMViewerViewModel.cs
@@ -47,7 +47,12 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 uint songId = rom.u32(addr + 4);
                 // 1-based ROM-stored unit ID.
                 string unitName = NameResolver.GetUnitNameByOneBasedId(unitId);
-                string name = $"{U.ToHexString(unitId)} {unitName} : {U.ToHexString(songId)}";
+                // Match WinForms SoundBossBGMForm.cs:45 —
+                //   "{unitHex} {unitName} : {songHex}{songName}"
+                // GetSongName returns the name only (no hex prefix); it is
+                // appended directly after the variable-width song id (#961 W2a).
+                string songName = NameResolver.GetSongName(songId);
+                string name = $"{U.ToHexString(unitId)} {unitName} : {U.ToHexString(songId)}{songName}";
                 result.Add(new AddrResult(addr, name, i));
             }
             return result;

--- a/FEBuilderGBA.Avalonia/ViewModels/SoundBossBGMViewerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SoundBossBGMViewerViewModel.cs
@@ -49,9 +49,13 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 string unitName = NameResolver.GetUnitNameByOneBasedId(unitId);
                 // Match WinForms SoundBossBGMForm.cs:45 —
                 //   "{unitHex} {unitName} : {songHex}{songName}"
-                // GetSongName returns the name only (no hex prefix); it is
-                // appended directly after the variable-width song id (#961 W2a).
-                string songName = NameResolver.GetSongName(songId);
+                // Use the Core resolver DIRECTLY (not NameResolver.GetSongName,
+                // which substitutes the non-empty "Song 0x.." placeholder for an
+                // unknown id and would produce "1BSong 0x1B"). The Core resolver
+                // returns "" for an unresolved id, so the label collapses to just
+                // the hex — matching WinForms which appends an empty string for
+                // unknown songs (#961 W2a / #962 review).
+                string songName = SongNameResolverCore.GetSongName(rom, songId);
                 string name = $"{U.ToHexString(unitId)} {unitName} : {U.ToHexString(songId)}{songName}";
                 result.Add(new AddrResult(addr, name, i));
             }

--- a/FEBuilderGBA.Core.Tests/NameResolverTests.cs
+++ b/FEBuilderGBA.Core.Tests/NameResolverTests.cs
@@ -360,11 +360,23 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
-        public void GetSongName_ReturnsFormattedString()
+        public void GetSongName_NullRom_ReturnsFormattedFallback()
         {
-            NameResolver.ClearCache();
-            string result = NameResolver.GetSongName(0x1A);
-            Assert.StartsWith("Song", result);
+            // With no ROM loaded, GetSongName must fall back to the safe
+            // "Song 0x{id:X}" placeholder (the real-name resolver needs a ROM).
+            var saved = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = null!;
+                NameResolver.ClearCache();
+                string result = NameResolver.GetSongName(0x1A);
+                Assert.Equal("Song 0x1A", result);
+            }
+            finally
+            {
+                CoreState.ROM = saved;
+                NameResolver.ClearCache();
+            }
         }
 
         [Fact]

--- a/FEBuilderGBA.Core.Tests/SongNameResolverCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/SongNameResolverCoreTests.cs
@@ -257,5 +257,69 @@ namespace FEBuilderGBA.Core.Tests
         {
             Assert.Equal("", SongNameResolverCore.GetSongNameWhereSongID(null, 0x1B));
         }
+
+        // ================================================================
+        // Cache retry-after-failure (#962 review #1)
+        // ================================================================
+
+        /// <summary>
+        /// A load FAILURE (here: CoreState.BaseDirectory == null, which makes
+        /// ConfigDataFilename throw inside Path.Combine) must NOT poison the
+        /// per-ROM cache with an empty SE list. A subsequent call after the
+        /// environment becomes valid (BaseDirectory set) must RETRY and load the
+        /// real SE list — not keep returning the cached-empty result.
+        /// </summary>
+        [Theory]
+        [InlineData("FE8J.gba")]
+        [InlineData("FE8U.gba")]
+        public void GetSoundEffectList_LoadFailure_DoesNotPoisonCache_RetriesLater(string romName)
+        {
+            string romPath = FindRom(romName);
+            if (romPath == null) return; // skip — no ROM
+
+            string root = FindRepoRoot();
+            if (root == null) return; // skip — need the repo root for the real load
+
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            var savedBase = CoreState.BaseDirectory;
+            try
+            {
+                var rom = new ROM();
+                if (!rom.Load(romPath, out string _)) return; // skip
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+                SongNameResolverCore.ClearCache();
+
+                // 1) Force the load to FAIL (null BaseDirectory → Path.Combine throws).
+                CoreState.BaseDirectory = null;
+                var failed = SongNameResolverCore.GetSoundEffectList(rom);
+                Assert.Empty(failed); // failure returns an empty dictionary
+
+                // 2) Make the environment valid and call again — the resolver
+                //    MUST retry the load (not return a cached-empty list).
+                CoreState.BaseDirectory = root;
+                var retried = SongNameResolverCore.GetSoundEffectList(rom);
+                Assert.NotEmpty(retried); // proves the failure was NOT cached
+
+                // And the SE fallback now actually works for an SE-list id.
+                uint anySeId = 0;
+                foreach (var kv in retried)
+                {
+                    if (!string.IsNullOrEmpty(kv.Value)) { anySeId = kv.Key; break; }
+                }
+                // (anySeId may legitimately be 0 → "NULL"; just assert resolution
+                //  of a known-present id reproduces its SE name.)
+                Assert.Equal(retried[anySeId], SongNameResolverCore.GetSoundEffectList(rom)[anySeId]);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+                CoreState.BaseDirectory = savedBase;
+                SongNameResolverCore.ClearCache();
+                NameResolver.ClearCache();
+            }
+        }
     }
 }

--- a/FEBuilderGBA.Core.Tests/SongNameResolverCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/SongNameResolverCoreTests.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// Independent oracle tests for the cross-platform song-name resolver
+    /// (<see cref="SongNameResolverCore"/>) that powers
+    /// <see cref="NameResolver.GetSongName"/> (#961 W2a).
+    ///
+    /// These DO NOT compare against the Avalonia view-model / golden builder.
+    /// Instead they hand-derive expectations from raw ROM bytes (the sound-room
+    /// table) and from the shipped <c>config/data/sound_*.txt</c> SE list, then
+    /// assert the resolver reproduces them. They skip cleanly when no ROM is
+    /// available (CI without roms/).
+    /// </summary>
+    [Collection("SharedState")]
+    public class SongNameResolverCoreTests
+    {
+        // ----------------------------------------------------------------
+        // ROM / repo-root discovery (mirrors the other Core real-ROM tests)
+        // ----------------------------------------------------------------
+
+        static string FindRepoRoot()
+        {
+            string dir = AppContext.BaseDirectory;
+            for (int i = 0; i < 10 && dir != null; i++)
+            {
+                if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                    return dir;
+                dir = Path.GetDirectoryName(dir);
+            }
+            return null;
+        }
+
+        static string FindRom(string romName)
+        {
+            string root = FindRepoRoot();
+            if (root == null) return null;
+            string path = Path.Combine(root, "roms", romName);
+            return File.Exists(path) ? path : null;
+        }
+
+        /// <summary>
+        /// Load a real ROM fully enough for text decode (Huffman from the ROM +
+        /// a headless system encoder) with BaseDirectory pointed at the repo
+        /// root so the SE-list config file resolves. Skips (no-op) when the ROM
+        /// is missing.
+        /// </summary>
+        static void WithRealRom(string romName, Action<ROM> action)
+        {
+            string romPath = FindRom(romName);
+            if (romPath == null) return; // skip
+
+            string root = FindRepoRoot();
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            var savedBase = CoreState.BaseDirectory;
+            try
+            {
+                var rom = new ROM();
+                if (!rom.Load(romPath, out string _)) return; // skip
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+                if (root != null) CoreState.BaseDirectory = root;
+                NameResolver.ClearCache();
+                action(rom);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+                CoreState.BaseDirectory = savedBase;
+                NameResolver.ClearCache();
+            }
+        }
+
+        // ----------------------------------------------------------------
+        // Raw sound-room table walk (independent of SongNameResolverCore)
+        // ----------------------------------------------------------------
+
+        /// <summary>
+        /// Independently enumerate the sound-room table from raw bytes, yielding
+        /// (songId, roomTextId) for each entry, stopping at 0xFFFFFFFF. Mirrors
+        /// the WinForms layout (song id u32@+0; room-name text id u32@+12 for
+        /// FE7/8, u32@+4 for FE6) WITHOUT calling the resolver under test.
+        /// </summary>
+        static List<(uint songId, uint textId)> RawSoundRoomEntries(ROM rom)
+        {
+            var list = new List<(uint, uint)>();
+            uint pointer = rom.RomInfo.sound_room_pointer;
+            uint dataSize = rom.RomInfo.sound_room_datasize;
+            if (pointer == 0 || dataSize == 0) return list;
+
+            uint baseAddr = rom.p32(U.toOffset(pointer));
+            if (!U.isSafetyOffset(baseAddr, rom)) return list;
+
+            uint textOff = (rom.RomInfo.version == 6) ? 4u : 12u;
+            uint addr = baseAddr;
+            for (int i = 0; i < 0x400; i++, addr += dataSize)
+            {
+                if (addr + dataSize > (uint)rom.Data.Length) break;
+                if (rom.u32(addr) == 0xFFFFFFFF) break;
+                if (i > 10 && rom.IsEmpty(addr, dataSize * 10)) break;
+                uint songId = rom.u32(addr);
+                uint textId = rom.u32(addr + textOff);
+                list.Add((songId, textId));
+            }
+            return list;
+        }
+
+        // ================================================================
+        // Sound Room name resolution
+        // ================================================================
+
+        [Theory]
+        [InlineData("FE8J.gba")]
+        [InlineData("FE8U.gba")]
+        [InlineData("FE7U.gba")]
+        [InlineData("FE6.gba")]
+        public void SoundRoomSongIds_ResolveToTheirRealRoomNames(string romName)
+        {
+            WithRealRom(romName, rom =>
+            {
+                var entries = RawSoundRoomEntries(rom);
+                if (entries.Count == 0) return; // skip — no sound room
+
+                int checkedRows = 0;
+                foreach (var (songId, textId) in entries)
+                {
+                    if (textId == 0) continue; // no room name on this row
+
+                    // Independent expected name: decode the room text id directly
+                    // and strip control codes the same way the resolver does.
+                    string expected =
+                        NameResolver.StripControlCodes(FETextDecode.Direct(textId));
+                    if (string.IsNullOrEmpty(expected)) continue;
+
+                    string actual = SongNameResolverCore.GetSongName(rom, songId);
+
+                    // The resolver must surface the REAL room name, not the old
+                    // "Song 0x..." placeholder.
+                    Assert.Equal(expected, actual);
+                    Assert.DoesNotContain("Song 0x", actual);
+
+                    // And NameResolver.GetSongName (the routed public API) must
+                    // agree for the same id.
+                    Assert.Equal(actual, NameResolver.GetSongName(songId));
+
+                    if (++checkedRows >= 5) break; // a handful is plenty
+                }
+
+                // We expect at least ONE resolvable room name on a real ROM.
+                Assert.True(checkedRows > 0,
+                    "expected at least one sound-room entry with a decodable name");
+            });
+        }
+
+        // ================================================================
+        // SE-list fallback
+        // ================================================================
+
+        [Theory]
+        [InlineData("FE8J.gba")]
+        [InlineData("FE8U.gba")]
+        public void SeListId_NotInSoundRoom_ResolvesViaSeList(string romName)
+        {
+            WithRealRom(romName, rom =>
+            {
+                // Load the SE list independently (same loader the resolver uses).
+                string seFile = U.ConfigDataFilename("sound_", rom);
+                var seList = U.LoadDicResource(seFile);
+                Assert.NotEmpty(seList);
+
+                // Build the set of song ids that ARE in the sound room so we can
+                // pick an SE id that is NOT (forcing the SE-list fallback path).
+                var roomIds = new HashSet<uint>();
+                foreach (var (songId, _) in RawSoundRoomEntries(rom))
+                    roomIds.Add(songId);
+
+                int checkedIds = 0;
+                foreach (var kv in seList)
+                {
+                    uint id = kv.Key;
+                    string seName = kv.Value;
+                    if (string.IsNullOrEmpty(seName)) continue;
+                    if (roomIds.Contains(id)) continue; // would resolve via room, not SE
+
+                    string actual = SongNameResolverCore.GetSongName(rom, id);
+                    Assert.Equal(seName, actual);
+                    Assert.Equal(actual, NameResolver.GetSongName(id));
+
+                    if (++checkedIds >= 5) break;
+                }
+
+                Assert.True(checkedIds > 0,
+                    "expected at least one SE-list id outside the sound room");
+            });
+        }
+
+        // ================================================================
+        // Unknown-id fallback
+        // ================================================================
+
+        [Theory]
+        [InlineData("FE8J.gba")]
+        [InlineData("FE8U.gba")]
+        public void UnknownSongId_FallsBack(string romName)
+        {
+            WithRealRom(romName, rom =>
+            {
+                // Pick an id that is neither in the sound room nor the SE list.
+                var used = new HashSet<uint>();
+                foreach (var (songId, _) in RawSoundRoomEntries(rom))
+                    used.Add(songId);
+                foreach (var kv in U.LoadDicResource(U.ConfigDataFilename("sound_", rom)))
+                    used.Add(kv.Key);
+
+                uint unknown = 0;
+                for (uint candidate = 0xF000; candidate < 0xFFFF; candidate++)
+                {
+                    if (!used.Contains(candidate)) { unknown = candidate; break; }
+                }
+                Assert.NotEqual(0u, unknown);
+
+                // The Core resolver returns "" for an unresolved id.
+                Assert.Equal("", SongNameResolverCore.GetSongName(rom, unknown));
+
+                // The routed public API keeps a safe, identifiable placeholder.
+                Assert.Equal($"Song 0x{unknown:X}", NameResolver.GetSongName(unknown));
+            });
+        }
+
+        // ================================================================
+        // Null / guard behaviour (no ROM required)
+        // ================================================================
+
+        [Fact]
+        public void GetSongName_NullRom_ReturnsEmpty()
+        {
+            Assert.Equal("", SongNameResolverCore.GetSongName(null, 0x1B));
+        }
+
+        [Fact]
+        public void GetSoundEffectList_NullRom_ReturnsEmptyDictionary()
+        {
+            var dic = SongNameResolverCore.GetSoundEffectList(null);
+            Assert.NotNull(dic);
+            Assert.Empty(dic);
+        }
+
+        [Fact]
+        public void GetSongNameWhereSongID_NullRom_ReturnsEmpty()
+        {
+            Assert.Equal("", SongNameResolverCore.GetSongNameWhereSongID(null, 0x1B));
+        }
+    }
+}

--- a/FEBuilderGBA.Core/NameResolver.cs
+++ b/FEBuilderGBA.Core/NameResolver.cs
@@ -12,7 +12,13 @@ namespace FEBuilderGBA
         static readonly ConcurrentDictionary<(string kind, uint id), string> _cache = new();
 
         /// <summary>Clear the name cache (e.g., after undo or ROM reload).</summary>
-        public static void ClearCache() => _cache.Clear();
+        public static void ClearCache()
+        {
+            _cache.Clear();
+            // The song resolver caches the SE list per ROM; drop it too so a
+            // ROM reload / version switch re-reads the matching sound_*.txt.
+            SongNameResolverCore.ClearCache();
+        }
 
         // Characters to trim from decoded names (matches WinForms TextForm.StripAllCode)
         static readonly char[] TrimChars = { ' ', '\0', (char)0x1F, '\r', '\n', '\u3000' };
@@ -278,11 +284,15 @@ namespace FEBuilderGBA
             try
             {
                 var rom = CoreState.ROM;
-                if (rom?.RomInfo == null) return $"Song {id}";
-                // Song table doesn't have text IDs, just return index-based name
-                return $"Song 0x{id:X}";
+                if (rom?.RomInfo == null) return $"Song 0x{id:X}";
+                // Resolve the real name: Sound Room name first, then SE-list
+                // fallback (mirrors WinForms SongTableForm.GetSongNameFast).
+                string name = SongNameResolverCore.GetSongName(rom, id);
+                // Keep the safe placeholder when the id resolves to nothing so
+                // callers always have a non-empty, identifiable label.
+                return string.IsNullOrEmpty(name) ? $"Song 0x{id:X}" : name;
             }
-            catch { return "???"; }
+            catch { return $"Song 0x{id:X}"; }
         }
 
         static string ResolveSkillName(uint id)

--- a/FEBuilderGBA.Core/SongNameResolverCore.cs
+++ b/FEBuilderGBA.Core/SongNameResolverCore.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Cross-platform port of the WinForms song-name resolution chain
+    /// (<c>SoundRoomForm.GetSongNameWhereSongID</c> + the SE-list fallback in
+    /// <c>SongTableForm.GetSongNameFast</c>). Resolves a song id to its
+    /// Sound Room name (read from the sound-room table) and, when the song is
+    /// not present in the Sound Room (i.e. it is a sound effect), falls back to
+    /// the SE list shipped in <c>config/data/sound_*.txt</c>.
+    ///
+    /// This is the real-name engine behind <see cref="NameResolver.GetSongName"/>
+    /// so every Avalonia song display (Boss BGM, Song Table, Sound Room,
+    /// World Map BGM) surfaces the same names WinForms shows instead of the old
+    /// <c>"Song 0x{id:X}"</c> placeholder.
+    /// </summary>
+    public static class SongNameResolverCore
+    {
+        // SE list cache, invalidated when the ROM instance changes (so a ROM
+        // reload / version switch re-reads the matching sound_{title}.txt file).
+        static readonly object _seLock = new object();
+        static ROM _seRom;
+        static Dictionary<uint, string> _seList;
+
+        /// <summary>Drop the cached SE list (call on ROM reload / undo / language change).</summary>
+        public static void ClearCache()
+        {
+            lock (_seLock)
+            {
+                _seRom = null;
+                _seList = null;
+            }
+        }
+
+        /// <summary>
+        /// The SE (sound-effect) name list, loaded lazily from
+        /// <c>config/data/sound_{title}.txt</c> via <see cref="U.ConfigDataFilename"/>
+        /// using the same loader (<see cref="U.LoadDicResource"/>) WinForms uses in
+        /// <c>SongTableForm.PreLoadResource</c>. Cached per ROM instance.
+        /// </summary>
+        public static Dictionary<uint, string> GetSoundEffectList(ROM rom)
+        {
+            if (rom == null) return new Dictionary<uint, string>();
+            lock (_seLock)
+            {
+                if (_seList != null && ReferenceEquals(_seRom, rom))
+                {
+                    return _seList;
+                }
+                Dictionary<uint, string> dic;
+                try
+                {
+                    string fullfilename = U.ConfigDataFilename("sound_", rom);
+                    dic = U.LoadDicResource(fullfilename);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error("SongNameResolverCore.GetSoundEffectList failed: " + ex.Message);
+                    dic = new Dictionary<uint, string>();
+                }
+                _seList = dic;
+                _seRom = rom;
+                return dic;
+            }
+        }
+
+        /// <summary>
+        /// Resolve a song id to a human-readable name. Mirrors the name-only path
+        /// of WinForms <c>SongTableForm.GetSongNameFast</c>:
+        /// <list type="number">
+        ///   <item>look the id up in the Sound Room table
+        ///     (<see cref="GetSongNameWhereSongID"/>); if found, return that room
+        ///     name (trimmed);</item>
+        ///   <item>otherwise fall back to the SE list
+        ///     (<c>config/data/sound_*.txt</c>);</item>
+        ///   <item>otherwise return <c>""</c>.</item>
+        /// </list>
+        /// The empty-track suffix and per-row comment that WinForms appends are
+        /// list-rendering concerns and are intentionally NOT included here so the
+        /// resolver stays a pure name lookup usable from any editor.
+        /// </summary>
+        public static string GetSongName(ROM rom, uint songId)
+        {
+            if (rom?.RomInfo == null) return "";
+            try
+            {
+                string name = GetSongNameWhereSongID(rom, songId);
+                if (!string.IsNullOrEmpty(name))
+                {
+                    return name.Trim();
+                }
+                // Songs not present in the Sound Room are sound effects — look
+                // them up in the SE list (same fallback as WinForms).
+                return U.at(GetSoundEffectList(rom), songId);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("SongNameResolverCore.GetSongName(" + songId + ") failed: " + ex.Message);
+                return "";
+            }
+        }
+
+        /// <summary>
+        /// Walk the Sound Room table looking for an entry whose song id (u32 at
+        /// offset 0) equals <paramref name="songId"/>; return that entry's room
+        /// name. Port of WinForms <c>SoundRoomForm.GetSongNameWhereSongID</c>.
+        /// Returns <c>""</c> when no Sound Room entry references the id.
+        /// </summary>
+        public static string GetSongNameWhereSongID(ROM rom, uint songId)
+        {
+            if (rom?.RomInfo == null) return "";
+
+            uint pointer = rom.RomInfo.sound_room_pointer;
+            uint dataSize = rom.RomInfo.sound_room_datasize;
+            if (pointer == 0 || pointer == U.NOT_FOUND || dataSize == 0) return "";
+
+            uint baseAddr = rom.p32(U.toOffset(pointer));
+            if (!U.isSafetyOffset(baseAddr, rom)) return "";
+
+            uint count = GetSoundRoomCount(rom, baseAddr, dataSize);
+
+            uint addr = baseAddr;
+            for (uint i = 0; i < count; i++, addr += dataSize)
+            {
+                uint a = rom.u32(addr);
+                if (songId == a)
+                {
+                    return GetSongNameLow(rom, addr);
+                }
+            }
+            return "";
+        }
+
+        /// <summary>
+        /// Decode the room-name text stored in a Sound Room entry. Mirrors
+        /// WinForms <c>SoundRoomForm.GetSongNameLow</c>: FE6 stores the name
+        /// text id as a u32 at offset +4; FE7/FE8 store it at offset +12.
+        /// Control codes are stripped via the shared <see cref="NameResolver"/>
+        /// text decoder so the result matches the names used elsewhere.
+        /// </summary>
+        public static string GetSongNameLow(ROM rom, uint addr)
+        {
+            if (rom?.RomInfo == null) return "";
+            uint textIdOffset = (rom.RomInfo.version == 6) ? addr + 4 : addr + 12;
+            if (!U.isSafetyOffset(textIdOffset + 3, rom)) return "";
+            uint textId = rom.u32(textIdOffset);
+            if (textId == 0) return "";
+            return NameResolver.GetTextById(textId);
+        }
+
+        /// <summary>
+        /// Count the Sound Room table entries the same way WinForms
+        /// <c>SoundRoomForm.Init</c>'s read-max callback does: stop at a
+        /// <c>0xFFFFFFFF</c> terminator, or after index 10 once 10 consecutive
+        /// blocks are empty.
+        /// </summary>
+        static uint GetSoundRoomCount(ROM rom, uint baseAddr, uint dataSize)
+        {
+            return rom.getBlockDataCount(baseAddr, dataSize, (int i, uint addr) =>
+            {
+                if (rom.u32(addr) == 0xFFFFFFFF)
+                {
+                    return false;
+                }
+                if (i > 10 && rom.IsEmpty(addr, dataSize * 10))
+                {
+                    return false;
+                }
+                return true;
+            });
+        }
+    }
+}

--- a/FEBuilderGBA.Core/SongNameResolverCore.cs
+++ b/FEBuilderGBA.Core/SongNameResolverCore.cs
@@ -58,9 +58,14 @@ namespace FEBuilderGBA
                 }
                 catch (Exception ex)
                 {
+                    // Do NOT cache the failure — leave _seRom/_seList untouched so
+                    // a later call (e.g. after CoreState.BaseDirectory is set)
+                    // retries the load instead of being permanently poisoned with
+                    // an empty SE list until ClearCache().
                     Log.Error("SongNameResolverCore.GetSoundEffectList failed: " + ex.Message);
-                    dic = new Dictionary<uint, string>();
+                    return new Dictionary<uint, string>();
                 }
+                // Only cache a successfully-loaded list.
                 _seList = dic;
                 _seRom = rom;
                 return dic;

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ FEBuilderGBA.sln
 │   ├── SongExchangeCore.cs                Song exchange between ROMs
 │   ├── MapConvertCore.cs                  Map tile conversion
 │   ├── NameResolver.cs                    Entity name resolution with caching
+│   ├── SongNameResolverCore.cs            Song name resolution (Sound Room name + SE-list fallback)
 │   └── WriteValidator.cs                  ROM write validation utilities
 ├── FEBuilderGBA.CLI/            net9.0    (cross-platform CLI — 51 commands)
 ├── FEBuilderGBA.SkiaSharp/      net9.0    (image backend)


### PR DESCRIPTION
## Summary

Follow-up #961 W2a: `NameResolver.ResolveSongName` returned the placeholder `"Song 0x{id:X}"`, so **every** Avalonia song-ID display (Boss BGM, Song Table, Sound Room, World Map BGM) showed the index instead of the real name. This ports the WinForms resolution to Core so real names surface everywhere, and restores the Boss BGM song name that #944 intentionally omitted pending this.

## Changes
- **New `FEBuilderGBA.Core/SongNameResolverCore.cs`** — ports the WinForms chain: `SoundRoomForm.GetSongNameWhereSongID` (walks the sound-room table by song id @+0, decodes the room-name text id @+12 FE7/8 / +4 FE6) + the `SongTableForm.GetSongNameFast` **SE-list fallback** (`config/data/sound_{title}.txt`, loaded via the same `U.ConfigDataFilename("sound_")` + `U.LoadDicResource` WinForms uses). `GetSongName(rom, songId)` → Sound Room name → SE-list → `""`. Reuses `NameResolver.GetTextById`/`FETextDecode` (no duplication); lazy per-ROM SE cache cleared by `NameResolver.ClearCache`.
- **`NameResolver.ResolveSongName` delegates** to the new resolver (safe placeholder fallback kept).
- **Restored Boss BGM label** — `SoundBossBGMViewerViewModel` + lockstep `ListParityHelper.BuildSoundBossBGMList` → `{unitHex} {unitName} : {U.ToHexString(songId)}{songName}`, matching WF `SoundBossBGMForm.cs:45`.

## Tests
New `SongNameResolverCoreTests` — **independent hand-built oracle** on real FE8J/FE8U/FE7U/FE6 ROMs: known sound-room ids resolve to room names decoded directly from bytes; an SE-list id resolves via the SE list; unknown ids fall back; null/guard cases. 45 NameResolver/SongNameResolver tests pass. Existing `SoundBossBGMFormatTests` stay green.

## Scope
Follow-up to #944 (the global song-name gap).

## Screenshots

### Boss BGM (FE8J)
| Before (`Song:0x0000001B`, no name) | After (`: 1B負けられぬ戦い`) |
|---|---|
| ![b](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/bugsweep/bug16-boss-bgm-format.png?raw=1) | ![a](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/w2a-bossbgm-after.png) |

### Song Table (FE8J — now real Sound Room titles)
![songtable](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/w2a-songtable-after.png)

After: Boss BGM shows `68 オニール : 1B負けられぬ戦い`, `4D ティラード : 1C強敵奮現る`; Song Table shows `01 勇ましき者たち`, `02 メインテーマ`, `04 すべては始まりのとき`, `08 希望の光（メインテーマアレンジ）` (previously `Song 0x01`…).

## GUI Test Report

| Test | Result |
|------|--------|
| Boss BGM / Song Table / Sound Room / WorldMap BGM show REAL song names (Sound Room + SE list) | ✅ PASS |
| Boss BGM label restored to WF format `{hex} {unit} : {songHex}{songName}` (golden lockstep) | ✅ PASS |
| Independent Core oracle (sound-room name, SE fallback, unknown fallback) on FE8J/U/FE7U/FE6 | ✅ PASS |
| `FEBuilderGBA.Tests` 1822 / `Avalonia.Tests` 7497 / Core resolver tests (45) — all green | ✅ PASS |

## Test plan
- [x] Independent hand-built Core oracle (not VM==golden) across 4 ROM versions
- [x] All 3 test projects green; restored BossBGM label golden-lockstep
- [x] After-screenshots show real song names in Boss BGM + Song Table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Code 2.1.162 · model claude-opus-4-8[1m]
