### PR TITLE
fix(core): SplitEscapeSegments only treats @+4hex as a control code (#971)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -589,8 +589,13 @@ Specialized utilities for different graphic types:
   it splits into alternating literal-text and `@XXXX` (5-char hex) escape
   segments (bundling a `@0003` immediately followed by `\r\n` into ONE segment)
   and — unlike WF, which drops trailing literal after the last code — flushes the
-  tail so `string.Concat(SplitEscapeSegments(x)) == x` for ALL x. `IsEscapeSegment`
-  classifies a code as `@` + exactly four hex digits. `LoadFixedDic(from, to)`
+  tail so `string.Concat(SplitEscapeSegments(x)) == x` for ALL x. A `@` is only a
+  code boundary when it is followed by EXACTLY four hex digits (the position-based
+  `IsCodeAt` twin of `IsEscapeSegment`, single source of truth): a literal at-sign
+  in ordinary text (`email@example.com`, `hello@catworld`, a trailing `@`, or `@`
+  + fewer than four hex / non-hex chars) stays glued to its surrounding literal
+  segment instead of being fragmented (#971). `IsEscapeSegment` classifies a code
+  as `@` + exactly four hex digits. `LoadFixedDic(from, to)`
   loads the shipped glossary `config/translate/dic_<from>_<to>.txt` (the single
   `dic_ja_en.txt` serves both `ja→en` and reversed `en→ja`), tab-separated
   `source\ttarget`, keys upper-cased, `\r\n` un-escaped, first-wins on dups;

--- a/FEBuilderGBA.Core.Tests/TranslateTextUtilCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/TranslateTextUtilCoreTests.cs
@@ -34,6 +34,13 @@ namespace FEBuilderGBA.Core.Tests
             yield return new object[] { "@0001@0002@0003" };             // consecutive codes
             yield return new object[] { "line1@0003\r\nline2" };         // @0003 + CRLF bundle
             yield return new object[] { "前半@0001後半@0003\r\nつづき" }; // multibyte + codes
+            // #971 — literal '@' must NOT be sliced; round-trip still holds.
+            yield return new object[] { "email@example.com" };           // literal at-sign (non-hex tail)
+            yield return new object[] { "hello@catworld" };              // literal at-sign (non-hex tail)
+            yield return new object[] { "abc@" };                        // trailing bare '@'
+            yield return new object[] { "abc@123" };                     // '@' + fewer than 4 hex
+            yield return new object[] { "abc@12Z4" };                    // '@' + non-hex within 4 chars
+            yield return new object[] { "名前@0001は@example" };         // real code + literal '@'
         }
 
         [Theory]
@@ -78,6 +85,66 @@ namespace FEBuilderGBA.Core.Tests
             Assert.False(TranslateTextUtilCore.IsEscapeSegment("@XYZW"));
             Assert.False(TranslateTextUtilCore.IsEscapeSegment("hello"));
             Assert.False(TranslateTextUtilCore.IsEscapeSegment(""));
+        }
+
+        // ----------------------------------------------------------------
+        // #971 — literal '@' must NOT be fragmented by the splitter
+        // ----------------------------------------------------------------
+
+        [Theory]
+        [InlineData("email@example.com")] // non-hex tail after '@'
+        [InlineData("hello@catworld")]    // non-hex tail after '@'
+        [InlineData("abc@")]              // trailing bare '@'
+        [InlineData("abc@123")]           // '@' + fewer than 4 hex digits
+        [InlineData("abc@12Z4")]          // '@' + non-hex within the first 4 chars
+        public void SplitEscapeSegments_LiteralAtSign_StaysOneSegment(string input)
+        {
+            List<string> segs = TranslateTextUtilCore.SplitEscapeSegments(input);
+            // A literal '@' is not a control code, so the whole string is ONE
+            // literal segment (no artificial @XXXX slicing).
+            Assert.Equal(new[] { input }, segs);
+            Assert.False(TranslateTextUtilCore.IsEscapeSegment(input));
+        }
+
+        [Fact]
+        public void SplitEscapeSegments_RealCodeAndLiteralAtSign_SplitCorrectly()
+        {
+            // The real @0001 code is its own segment; the literal "@example"
+            // stays attached to its surrounding literal run (#971).
+            List<string> segs = TranslateTextUtilCore.SplitEscapeSegments("名前@0001は@example");
+            Assert.Equal(new[] { "名前", "@0001", "は@example" }, segs);
+            Assert.True(TranslateTextUtilCore.IsEscapeSegment("@0001"));
+            Assert.False(TranslateTextUtilCore.IsEscapeSegment("は@example"));
+        }
+
+        [Theory]
+        [InlineData("email@example.com")]
+        [InlineData("hello@catworld")]
+        public void TranslateText_LiteralAtSign_RoutedAsOneTranslatorCall(string input)
+        {
+            var stub = new RecordingTranslator();
+
+            string result = TranslateTextUtilCore.TranslateText(
+                input, "ja", "en", dic: null, useGoogle: true, translator: stub.Translate);
+
+            // The whole literal (with its '@') reaches the translator as ONE call,
+            // not fragmented into "email" + "@exam" + "ple.com" etc.
+            Assert.Equal(new[] { input }, stub.Calls);
+            Assert.Equal("[T:" + input + "]", result);
+        }
+
+        [Fact]
+        public void TranslateText_MixedRealCodeAndLiteralAtSign_ProtectsCodeOnly()
+        {
+            var stub = new RecordingTranslator();
+
+            string result = TranslateTextUtilCore.TranslateText(
+                "名前@0001は@example", "ja", "en", dic: null, useGoogle: true, translator: stub.Translate);
+
+            // @0001 is protected (never translated); the literal "@example" stays
+            // glued to "は" and is translated as a single segment.
+            Assert.Equal(new[] { "名前", "は@example" }, stub.Calls);
+            Assert.Equal("[T:名前]@0001[T:は@example]", result);
         }
 
         // ----------------------------------------------------------------

--- a/FEBuilderGBA.Core/TranslateTextUtilCore.cs
+++ b/FEBuilderGBA.Core/TranslateTextUtilCore.cs
@@ -53,6 +53,14 @@ namespace FEBuilderGBA
         /// <c>abc@0001def</c> loses <c>def</c>). This version flushes that
         /// trailing literal so the segments always round-trip exactly:
         /// <c>string.Concat(SplitEscapeSegments(x)) == x</c> for ALL <paramref name="text"/>.
+        ///
+        /// A <c>@</c> is only treated as the start of an escape code when it is
+        /// followed by EXACTLY four hex digits (the same <c>@</c>+4-hex rule
+        /// <see cref="IsEscapeSegment"/> enforces — see <see cref="IsCodeAt"/>).
+        /// A literal at-sign in ordinary text — <c>email@example.com</c>,
+        /// <c>hello@catworld</c>, a trailing <c>@</c>, or <c>@</c> followed by
+        /// fewer than four hex / non-hex chars — stays attached to its
+        /// surrounding literal run instead of being fragmented (#971).
         /// </summary>
         public static List<string> SplitEscapeSegments(string text)
         {
@@ -66,7 +74,10 @@ namespace FEBuilderGBA
             int i = 0;
             while (i < text.Length)
             {
-                if (text[i] == '@')
+                // Only a real "@XXXX" control code (4 hex digits) is an escape
+                // boundary; a literal '@' falls through and stays in the literal
+                // run (#971).
+                if (text[i] == '@' && IsCodeAt(text, i))
                 {
                     // Flush the pending literal run before this code.
                     if (i - textstart > 0)
@@ -107,6 +118,31 @@ namespace FEBuilderGBA
             }
 
             return list;
+        }
+
+        /// <summary>
+        /// True when an escape code begins AT position <paramref name="i"/> in
+        /// <paramref name="text"/>: a <c>@</c> immediately followed by exactly
+        /// four hex digits (so the full 5-char <c>@XXXX</c> token fits). This is
+        /// the position-based twin of <see cref="IsEscapeSegment"/> — both enforce
+        /// the identical <c>@</c>+4-hex rule so the splitter and the classifier
+        /// never disagree about what counts as a control code (#971).
+        /// </summary>
+        static bool IsCodeAt(string text, int i)
+        {
+            // Need '@' plus 4 trailing hex digits → indices i+1..i+4 must exist.
+            if (i + 4 >= text.Length || text[i] != '@')
+            {
+                return false;
+            }
+            for (int k = 1; k <= 4; k++)
+            {
+                if (!U.ishex(text[i + k]))
+                {
+                    return false;
+                }
+            }
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
`TranslateTextUtilCore.SplitEscapeSegments` (added by #968 / #967) treated **every** `@` as the start of a 5-char `@XXXX` escape code **before** validating that the next four chars are hex. A literal at-sign in ordinary text was therefore fragmented into artificial chunks:

- `email@example.com` → `email` + `@exam` + `ple.com`
- `hello@catworld` → `hello` + `@catw` + `orld`

Each fragment was then translated / glossary-checked independently, producing a possibly different user-visible translation than translating the whole literal — even though only real `@XXXX` control codes are supposed to be protected. (`Concat(Split(x)) == x` still held, but the *segmentation* was wrong.)

## Fix
Gate the `@`-branch in `SplitEscapeSegments` on a new private position-based predicate **`IsCodeAt(text, i)`** that returns true only when `@` is immediately followed by **exactly four hex digits** — the identical `@`+4-hex rule `IsEscapeSegment` already enforces (single source of truth, so the splitter and classifier never disagree). A literal `@` (trailing, or followed by fewer than four hex / non-hex chars) now falls through to the literal run instead of being sliced.

Unchanged behavior:
- `@0003` immediately followed by `\r\n` still bundles into ONE segment.
- Real `@0001` / `@0003` / `@ABCD` codes still split out as their own segments.
- `string.Concat(SplitEscapeSegments(x)) == x` still holds for **all** x.
- No public API change.

This is a **Core-only correctness fix** — no GUI change.

## Scope
Closes #971
Follow-up to #967 / #968. Plan: https://github.com/laqieer/FEBuilderGBA/issues/971#issuecomment-4630117159 (Copilot CLI plan review: approved, no blocking concerns; its non-blocking boundary-literal test suggestion was incorporated).

## Test plan
All automated in `FEBuilderGBA.Core.Tests/TranslateTextUtilCoreTests.cs` (39/39 pass):
- [x] `email@example.com` → exactly ONE literal segment (no `@` split); via `TranslateText` + recording stub → exactly one translator call with the whole string.
- [x] `hello@catworld` → likewise one segment / one translator call.
- [x] Mixed `名前@0001は@example` → `@0001` is its own code segment while `@example` stays literal (asserted segment list `["名前","@0001","は@example"]` + stub-call set `["名前","は@example"]`).
- [x] Boundary literals `abc@`, `abc@123`, `abc@12Z4` each stay ONE literal segment (Copilot plan-review suggestion — guards the `i+4 < length` bound and short/non-hex tokens).
- [x] Real `@0001`, `@0003`, and `@0003\r\n` CRLF bundle STILL split correctly (existing isolation/bundle facts remain green).
- [x] Round-trip `Concat(Split(x)) == x` extended with all new at-sign cases + empty string (Theory `RoundTripCases`).
- [x] `IsEscapeSegment` `@`+4-hex classification facts remain green.

### Full-suite results (3 projects)
- [x] `FEBuilderGBA.Core.Tests`: **Failed: 10, Passed: 2779** — the 10 failures are the pre-existing `SkillSystemsAnime*` / `SkillConfigSkillSystemBulkImport` FE8U-template tests (depend on local `.dmp` files), unrelated to this change. **Zero** TranslateTextUtilCore failures; no NEW failures.
- [x] `FEBuilderGBA.Tests` (WinForms): **Failed: 0, Passed: 1822**.
- [x] `FEBuilderGBA.E2ETests`: **Failed: 0, Passed: 103, Skipped: 194** (stable across two consecutive runs; one transient Avalonia-launch flake on the first run cleared on re-run).

## Screenshots
N/A — Core-only correctness fix with no GUI change. Per dev-flow's non-GUI rule, proof is the unit-test output above (39/39 TranslateTextUtilCore tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Claude Code 2.1.162 · model claude-opus-4-8[1m]_
