### PR TITLE
feat(avalonia): TSA editor — palette-to-clipboard, raw tilesheet export, Redo (#974)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageTSAEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageTSAEditorParityTests.cs
@@ -194,8 +194,14 @@ public class ImageTSAEditorParityTests
         Assert.Contains("IsEnabled=\"{Binding IsContextLoaded}\"", m.Value);
     }
 
+    /// <summary>
+    /// #974: the Palette Clipboard button is now WIRED — it packs the 16
+    /// palette entries to GBA 5-5-5 hex and copies to the clipboard. It is no
+    /// longer an IsEnabled=False stub; it is always enabled (reads the grid,
+    /// never writes ROM).
+    /// </summary>
     [Fact]
-    public void View_ClipboardButton_IsExplicitlyInert()
+    public void View_ClipboardButton_IsWiredAndEnabled()
     {
         string axaml = ReadAxaml();
         var rx = new Regex(
@@ -203,7 +209,28 @@ public class ImageTSAEditorParityTests
             RegexOptions.Compiled);
         Match m = rx.Match(axaml);
         Assert.True(m.Success, "Clipboard button tag not found");
-        Assert.Contains("IsEnabled=\"False\"", m.Value);
+        Assert.Contains("Click=\"PaletteClipboard_Click\"", m.Value);
+        Assert.DoesNotContain("IsEnabled=\"False\"", m.Value);
+    }
+
+    /// <summary>
+    /// #974: the PaletteClipboard_Click handler must call into the VM's
+    /// BuildPaletteClipboardHex packer and copy via the Avalonia
+    /// IClipboard.SetTextAsync async API (no longer a Log.Notify deferral stub).
+    /// </summary>
+    [Fact]
+    public void View_PaletteClipboardHandler_PacksAndCopies()
+    {
+        string source = ReadCodeBehind();
+        Assert.Matches(new Regex(
+            @"void\s+PaletteClipboard_Click[\s\S]*?BuildPaletteClipboardHex",
+            RegexOptions.Compiled), source);
+        Assert.Matches(new Regex(
+            @"void\s+PaletteClipboard_Click[\s\S]*?SetTextAsync",
+            RegexOptions.Compiled), source);
+        Assert.DoesNotMatch(new Regex(
+            @"void\s+PaletteClipboard_Click[\s\S]*?KnownGap:\s*PaletteToClipboard",
+            RegexOptions.Compiled), source);
     }
 
     /// <summary>
@@ -248,8 +275,12 @@ public class ImageTSAEditorParityTests
             RegexOptions.Compiled), source);
     }
 
+    /// <summary>
+    /// #974: the Main Image Export button is now WIRED (raw tilesheet PNG
+    /// export) and context-gated on IsContextLoaded — no longer an inert stub.
+    /// </summary>
     [Fact]
-    public void View_MainImageExportButton_IsExplicitlyInert()
+    public void View_MainImageExportButton_IsContextGated()
     {
         string axaml = ReadAxaml();
         var rx = new Regex(
@@ -257,7 +288,35 @@ public class ImageTSAEditorParityTests
             RegexOptions.Compiled);
         Match m = rx.Match(axaml);
         Assert.True(m.Success, "MainImage Export button tag not found");
-        Assert.Contains("IsEnabled=\"False\"", m.Value);
+        Assert.Contains("Click=\"MainImageExport_Click\"", m.Value);
+        Assert.Contains("IsEnabled=\"{Binding IsContextLoaded}\"", m.Value);
+        Assert.DoesNotContain("IsEnabled=\"False\"", m.Value);
+    }
+
+    /// <summary>
+    /// #974: the MainImageExport_Click handler must render via the VM's
+    /// RenderRawTilesheet seam and export via GbaImageControl.ExportPng — and
+    /// must NOT call ExportPng when the render returns null (Copilot plan-review
+    /// point 2). It must no longer be a Log.Notify deferral stub.
+    /// </summary>
+    [Fact]
+    public void View_MainImageExportHandler_RendersThenExports()
+    {
+        string source = ReadCodeBehind();
+        Assert.Matches(new Regex(
+            @"void\s+MainImageExport_Click[\s\S]*?RenderRawTilesheet",
+            RegexOptions.Compiled), source);
+        Assert.Matches(new Regex(
+            @"void\s+MainImageExport_Click[\s\S]*?ExportPng",
+            RegexOptions.Compiled), source);
+        // Null-render guard must precede the ExportPng call so a stale/previous
+        // bitmap is never exported.
+        Assert.Matches(new Regex(
+            @"void\s+MainImageExport_Click[\s\S]*?if\s*\(\s*img\s*==\s*null\s*\)[\s\S]*?return[\s\S]*?ExportPng",
+            RegexOptions.Compiled), source);
+        Assert.DoesNotMatch(new Regex(
+            @"void\s+MainImageExport_Click[\s\S]*?KnownGap:\s*MainImageExport",
+            RegexOptions.Compiled), source);
     }
 
     /// <summary>
@@ -436,9 +495,10 @@ public class ImageTSAEditorParityTests
             ["メイン画像"] = "Main Image",
             ["画像"] = "Image",
             ["画像読込"] = "Image Import",
-            ["画像取出"] = "Image Export",
-            // KnownGap-covered (no English direct counterpart - they cover deferred behaviour).
-            ["パレット"] = "KnownGap: PaletteToClipboard",
+            ["画像取出"] = "Image Export",     // #974: now a wired Export button caption.
+            // Palette tab header.
+            ["パレット"] = "Palette",
+            // #974: Clipboard is now a wired button caption (was a KnownGap stub).
             ["クリップボード"] = "Clipboard",
         };
 
@@ -465,6 +525,11 @@ public class ImageTSAEditorParityTests
     /// The KnownGap comment block must enumerate every deferred WF-only
     /// surface with a non-empty `reason=`. Mirrors the acceptance-criterion
     /// audit trail required by Copilot CLI.
+    ///
+    /// After #974 only ONE KnownGap remains in this editor: TSAByteWrite
+    /// (PaletteToClipboard / MainImageExport are now wired and RESOLVED;
+    /// BattleCanvasRender resolved in #808, ChipsetListRender in #819,
+    /// MainImageImport in #901).
     /// </summary>
     [Fact]
     public void View_KnownGapBlock_HasNonEmptyReasons()
@@ -473,17 +538,23 @@ public class ImageTSAEditorParityTests
         var rx = new Regex(@"KnownGap:\s*(\S+(?:\s+\S+)*?)\s+reason=(.+?)\s*-->",
             RegexOptions.Compiled);
         var matches = rx.Matches(axaml);
-        Assert.True(matches.Count >= 3,
-            $"AXAML must contain at least 3 KnownGap markers (TSAByteWrite, " +
-            $"PaletteToClipboard, MainImageImportExport); found {matches.Count}. " +
-            $"(BattleCanvasRender was resolved in #808; ChipsetListRender in #819.)");
+        Assert.True(matches.Count >= 1,
+            $"AXAML must contain the sole remaining KnownGap marker " +
+            $"(TSAByteWrite); found {matches.Count}.");
+        // The remaining KnownGap cluster for this editor is exactly TSAByteWrite.
+        bool hasTsaByteWrite = false;
         foreach (Match m in matches)
         {
             Assert.False(string.IsNullOrWhiteSpace(m.Groups[1].Value),
                 $"KnownGap entry must name a feature: '{m.Value}'");
             Assert.False(string.IsNullOrWhiteSpace(m.Groups[2].Value),
                 $"KnownGap entry must have a reason: '{m.Value}'");
+            if (m.Groups[1].Value.Contains("TSAByteWrite")) hasTsaByteWrite = true;
         }
+        Assert.True(hasTsaByteWrite, "The TSAByteWrite KnownGap marker must remain.");
+        // The two now-wired surfaces must NOT have lingering KnownGap markers.
+        Assert.DoesNotContain("KnownGap: PaletteToClipboard", axaml);
+        Assert.DoesNotContain("KnownGap: MainImageExport", axaml);
     }
 
     // -----------------------------------------------------------------
@@ -890,11 +961,13 @@ public class ImageTSAEditorParityTests
     }
 
     // -----------------------------------------------------------------
-    // Copilot review: Redo buttons must be explicitly inert in AXAML.
+    // #974: Redo buttons are now WIRED to the global Core Undo stack
+    // (CoreState.Undo.RunRedo()). They stay enabled; the handler guards on
+    // CanRedo at runtime (same pattern as the Map Style editor's Redo).
     // -----------------------------------------------------------------
 
     [Fact]
-    public void View_RedoButton_IsExplicitlyInert()
+    public void View_RedoButton_IsWiredAndEnabled()
     {
         string axaml = ReadAxaml();
         var rx = new Regex(
@@ -902,11 +975,12 @@ public class ImageTSAEditorParityTests
             RegexOptions.Compiled);
         Match m = rx.Match(axaml);
         Assert.True(m.Success, "Redo button tag not found");
-        Assert.Contains("IsEnabled=\"False\"", m.Value);
+        Assert.Contains("Click=\"Redo_Click\"", m.Value);
+        Assert.DoesNotContain("IsEnabled=\"False\"", m.Value);
     }
 
     [Fact]
-    public void View_PaletteRedoButton_IsExplicitlyInert()
+    public void View_PaletteRedoButton_IsWiredAndEnabled()
     {
         string axaml = ReadAxaml();
         var rx = new Regex(
@@ -914,7 +988,26 @@ public class ImageTSAEditorParityTests
             RegexOptions.Compiled);
         Match m = rx.Match(axaml);
         Assert.True(m.Success, "PaletteRedo button tag not found");
-        Assert.Contains("IsEnabled=\"False\"", m.Value);
+        Assert.Contains("Click=\"PaletteRedo_Click\"", m.Value);
+        Assert.DoesNotContain("IsEnabled=\"False\"", m.Value);
+    }
+
+    /// <summary>
+    /// #974: the Redo_Click handler must call CoreState.Undo.RunRedo() and
+    /// guard on CanRedo — it is no longer the stale "deferred until
+    /// Core.Undo.RunRedo lands" no-op stub.
+    /// </summary>
+    [Fact]
+    public void View_RedoHandler_CallsRunRedo()
+    {
+        string source = ReadCodeBehind();
+        Assert.Matches(new Regex(
+            @"void\s+Redo_Click[\s\S]*?CoreState\.Undo\.CanRedo",
+            RegexOptions.Compiled), source);
+        Assert.Matches(new Regex(
+            @"void\s+Redo_Click[\s\S]*?CoreState\.Undo\.RunRedo\(\)",
+            RegexOptions.Compiled), source);
+        Assert.DoesNotContain("deferred until Core.Undo.RunRedo lands", source);
     }
 
     // -----------------------------------------------------------------
@@ -956,12 +1049,18 @@ public class ImageTSAEditorParityTests
             RegexOptions.Compiled), source);
     }
 
+    /// <summary>
+    /// #974: the constructor no longer disables the Redo buttons (Redo is
+    /// wired to CoreState.Undo.RunRedo). The old
+    /// `RedoButton.IsEnabled = false` / `PaletteRedoButton.IsEnabled = false`
+    /// lines must be GONE.
+    /// </summary>
     [Fact]
-    public void View_RedoButtons_AreDisabledInConstructor()
+    public void View_RedoButtons_AreNotDisabledInConstructor()
     {
         string source = ReadCodeBehind();
-        Assert.Matches(new Regex(@"RedoButton\.IsEnabled\s*=\s*false", RegexOptions.Compiled), source);
-        Assert.Matches(new Regex(@"PaletteRedoButton\.IsEnabled\s*=\s*false", RegexOptions.Compiled), source);
+        Assert.DoesNotMatch(new Regex(@"RedoButton\.IsEnabled\s*=\s*false", RegexOptions.Compiled), source);
+        Assert.DoesNotMatch(new Regex(@"PaletteRedoButton\.IsEnabled\s*=\s*false", RegexOptions.Compiled), source);
     }
 
     [Fact]
@@ -972,6 +1071,80 @@ public class ImageTSAEditorParityTests
         // make sure a future edit doesn't accidentally re-add the dead using.
         string source = ReadCodeBehind();
         Assert.DoesNotContain("using global::Avalonia.Data;", source);
+    }
+
+    // -----------------------------------------------------------------
+    // #974: palette-to-clipboard hex packing (Win 1).
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// The clipboard hex string is 16 entries * 4 big-endian hex chars = 64
+    /// chars, mirroring WF PaletteFormRef.PALETTE_TO_CLIPBOARD_BUTTON_Click
+    /// (U.big16 byte-swap of the little-endian GBA 5-5-5 word).
+    /// </summary>
+    [Fact]
+    public void ViewModel_BuildPaletteClipboardHex_PacksBigEndian5_5_5()
+    {
+        // Build a known palette: entry 0 white, entry 1 pure red, entry 2 pure
+        // green, entry 3 pure blue, the rest black.
+        var rgb = new (byte R, byte G, byte B)[16];
+        rgb[0] = (255, 255, 255); // 0x7FFF -> LE bytes FF 7F -> big16 = FF7F
+        rgb[1] = (255, 0, 0);     // 0x001F -> LE bytes 1F 00 -> big16 = 1F00
+        rgb[2] = (0, 255, 0);     // 0x03E0 -> LE bytes E0 03 -> big16 = E003
+        rgb[3] = (0, 0, 255);     // 0x7C00 -> LE bytes 00 7C -> big16 = 007C
+        // entries 4..15 stay black -> 0x0000 -> big16 = 0000
+
+        string hex = ImageTSAEditorViewModel.BuildPaletteClipboardHex(rgb);
+
+        Assert.Equal(64, hex.Length);
+        Assert.Equal("FF7F", hex.Substring(0, 4));
+        Assert.Equal("1F00", hex.Substring(4, 4));
+        Assert.Equal("E003", hex.Substring(8, 4));
+        Assert.Equal("007C", hex.Substring(12, 4));
+        // Remaining 12 entries are all black "0000".
+        Assert.Equal(string.Concat(System.Linq.Enumerable.Repeat("0000", 12)),
+            hex.Substring(16));
+    }
+
+    [Fact]
+    public void ViewModel_BuildPaletteClipboardHex_ThrowsOnWrongLength()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            ImageTSAEditorViewModel.BuildPaletteClipboardHex(null!));
+        Assert.Throws<ArgumentException>(() =>
+            ImageTSAEditorViewModel.BuildPaletteClipboardHex(new (byte, byte, byte)[15]));
+    }
+
+    // -----------------------------------------------------------------
+    // #974: raw tilesheet export render seam (Win 2).
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// The VM RenderRawTilesheet wrapper returns null (no throw) when there is
+    /// no context, and when the image pointer slot is NOT_FOUND even with a
+    /// loaded context. The raw tilesheet never reads the TSA stream, so a
+    /// NOT_FOUND tsaPointer is irrelevant; only the image slot gates it.
+    /// </summary>
+    [Fact]
+    public void ViewModel_RenderRawTilesheet_NotFoundImagePointer_ReturnsNull()
+    {
+        var vm = new ImageTSAEditorViewModel();
+        // No context yet -> null.
+        Assert.Null(vm.RenderRawTilesheet());
+
+        vm.Init(
+            width8: 32u,
+            height8: 20u,
+            zimgPointer: U.NOT_FOUND,
+            isHeaderTSA: false,
+            isLZ77TSA: true,
+            tsaPointer: U.NOT_FOUND,
+            palettePointer: U.NOT_FOUND,
+            paletteAddress: 0u,
+            paletteCount: 1);
+
+        // Image slot is NOT_FOUND -> render is skipped without throwing.
+        Assert.Null(vm.RenderRawTilesheet());
     }
 
     [Fact]

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageTSAEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageTSAEditorViewModel.cs
@@ -228,6 +228,37 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         }
 
         /// <summary>
+        /// Render the RAW tilesheet (read-only) for the Main Image tab's
+        /// "Image Export" PNG (#974). Resolves the SAME image + palette
+        /// addresses as <see cref="RenderChipList"/> (the raw tilesheet is a
+        /// pure tile-strip, so there is NO TSA pointer) and delegates to
+        /// <see cref="ImageTSAEditorCore.RenderRawTilesheet"/>.
+        ///
+        /// Returns null (no throw) when there is no context, when the image
+        /// pointer slot is unset (U.NOT_FOUND), or when the underlying render
+        /// fails. A NOT_FOUND palette pointer is NOT a failure — it is the
+        /// expected raw-address fallback handled by
+        /// <see cref="ResolveActivePaletteAddress"/>.
+        /// </summary>
+        public IImage RenderRawTilesheet()
+        {
+            if (!IsContextLoaded) return null;
+
+            // The image pointer slot must be real before we follow it with p32;
+            // only the palette pointer has a raw-address fallback. The raw
+            // tilesheet never reads the TSA stream, so _tsaPointer is irrelevant.
+            if (_zimgPointer == U.NOT_FOUND) return null;
+
+            ROM rom = CoreState.ROM;
+            if (rom == null) return null;
+
+            uint imageAddr = rom.p32(_zimgPointer);
+            uint paletteAddr = ResolveActivePaletteAddress();
+
+            return ImageTSAEditorCore.RenderRawTilesheet(rom, imageAddr, paletteAddr);
+        }
+
+        /// <summary>
         /// Read 16 GBA 5-5-5 palette entries starting at
         /// <paramref name="paletteAddr"/> + <paramref name="paletteIndex"/> * 0x20.
         /// Each entry is a little-endian ushort: 0RRRRR GGGGG BBBBB.
@@ -355,6 +386,34 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             int g5 = (g >> 3) & 0x1F;
             int b5 = (b >> 3) & 0x1F;
             return (ushort)((b5 << 10) | (g5 << 5) | r5);
+        }
+
+        /// <summary>
+        /// Build the palette-to-clipboard hex string (#974): a 64-character
+        /// string of 16 entries, 4 big-endian hex chars each. Mirrors WinForms
+        /// <c>PaletteFormRef.PALETTE_TO_CLIPBOARD_BUTTON_Click</c>, which packs
+        /// each entry to its raw GBA bytes and formats with
+        /// <c>U.big16(...).ToString("X04")</c>. <c>U.big16</c> byte-swaps the
+        /// little-endian GBA 5-5-5 word into a big-endian display value, so the
+        /// emitted hex equals <c>byteswap(PackRgb555(...))</c> — e.g. white
+        /// (0x7FFF, LE bytes FF 7F) renders as "FF7F".
+        /// </summary>
+        /// <param name="rgb">Exactly 16 RGB triplets (the current palette UI).</param>
+        internal static string BuildPaletteClipboardHex((byte R, byte G, byte B)[] rgb)
+        {
+            if (rgb == null) throw new ArgumentNullException(nameof(rgb));
+            if (rgb.Length != 16)
+                throw new ArgumentException("BuildPaletteClipboardHex expects exactly 16 entries", nameof(rgb));
+
+            var sb = new System.Text.StringBuilder(64);
+            for (int i = 0; i < 16; i++)
+            {
+                ushort word = PackRgb555(rgb[i].R, rgb[i].G, rgb[i].B);
+                // U.big16-equivalent byte-swap of the little-endian GBA word.
+                uint big = (uint)(((word & 0xFF) << 8) | (word >> 8));
+                sb.Append(big.ToString("X04"));
+            }
+            return sb.ToString();
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml
@@ -32,10 +32,10 @@
 
   <!-- BattleCanvasRender RESOLVED (#808): the TSA-composited main image is now rendered cross-platform via ImageTSAEditorCore.TryRenderMainImage into BattlePreview, with a read-only Export PNG button. Note: export is intentionally NOT byte-identical to the WF canvas for TSA tile indices >= 0x100 because the Core decoder uses the full 10-bit index (& 0x3FF) like ImageUtil.ByteToImage16Tile, whereas the WF TSA canvas masks tile numbers to 8 bits (& 0xff). The 10-bit value is the on-ROM truth, so this is acceptable for a read-only export. -->
   <!-- ChipsetListRender RESOLVED (#819): the chip-list thumbnail (WF MakeCHIPLIST / PATHCHIPLIST_Paint) is now rendered cross-platform via ImageTSAEditorCore.RenderChipList into ChipListPreview — the main-image tiles in WF's 4-column (orig / Hflip / Vflip / HVflip) single-palette-bank-0 strip, read-only. Follow-up to #808/#810 (shared TSA tile/palette loader) and #807 (the 8-col/2-bank battle-screen sibling). -->
-  <!-- KnownGap: TSAByteWrite reason=ImageFormRef.WriteImageData does pointer-aware reallocation when LZ77 recompressed TSA exceeds the original allocation; mirroring that requires the full WinForms write pipeline. Deferred; only the palette-write path is exercised by the Write button in this PR. -->
-  <!-- KnownGap: PaletteToClipboard reason=System.Windows.Forms.Clipboard interop is WinForms-only; Avalonia equivalent (TopLevel.Clipboard async API) is a separate cross-cutting refactor not in scope here. The Clipboard button (label クリップボード) renders as a disabled stub so the labels audit still passes. -->
+  <!-- KnownGap: TSAByteWrite reason=ImageFormRef.WriteImageData does pointer-aware reallocation when LZ77 recompressed TSA exceeds the original allocation; mirroring that requires the full WinForms write pipeline. This is the SOLE remaining deferral in this editor: the Avalonia TSA editor has NO per-cell TSA-edit grid, so there is no edited TSA to write back (tilesheet import #901 already covers full image replacement). Becomes actionable only when a TSA cell-edit grid is added (separate future issue). Only the palette-write path is exercised by the Write button. -->
+  <!-- RESOLVED (#974): PaletteToClipboard — PaletteClipboard_Click now packs the 16 palette entries to GBA 5-5-5 big-endian hex (mirroring WF PaletteFormRef.PALETTE_TO_CLIPBOARD_BUTTON_Click) and copies to the system clipboard via the Avalonia IClipboard.SetTextAsync async API. See ImageTSAEditorViewModel.BuildPaletteClipboardHex + PaletteClipboard_Click. -->
   <!-- RESOLVED (#901): MainImageImport — image1_Import is now wired (tilesheet-only). The WF TSA editor builds its main-image ImageFormRef with tsa_pointer=0 and only the ZIMAGE control, so Import encodes a SAME-SIZE PNG to plain 4bpp tiles (ImageToByte16Tile via ImageImportCore.EncodeDirectTiles4bpp), LZ77-compresses, and repoints ONLY the ZImg pointer — TSA + palette are untouched. See TSAImageImportCore.ImportTSAImage + MainImageImport_Click. -->
-  <!-- KnownGap: MainImageExport reason=image1_Export calls into ImageFormRef.ExportImageHandler (the WinForms raw-tilesheet PNG export); deferred. The read-only TSA-composited Export PNG (#808, ImageTSAEditor_Battle_ExportPng_Button) is a DIFFERENT, already-wired export. The Image Export button (label 画像取出) renders as a disabled stub so the labels audit still passes. -->
+  <!-- RESOLVED (#974): MainImageExport — MainImageExport_Click now renders the raw 4bpp tilesheet (LZ77-decompressed ZImg, 8-tile-wide strip) via ImageTSAEditorCore.RenderRawTilesheet and saves it to PNG via GbaImageControl.ExportPng. DISTINCT from the read-only TSA-composited Export PNG (#808, ImageTSAEditor_Battle_ExportPng_Button). See ImageTSAEditorViewModel.RenderRawTilesheet + MainImageExport_Click. -->
 
 
   <Grid ColumnDefinitions="250,*" RowDefinitions="Auto,*">
@@ -78,14 +78,12 @@
         <Button AutomationProperties.AutomationId="ImageTSAEditor_Undo_Button"
                 Name="UndoButton" Content="Undo" Click="Undo_Click"
                 Margin="12,0,0,0" />
-        <!-- Redo is explicitly inert: Core Undo currently exposes only RunUndo
-             (no RunRedo). The button stays disabled in the AXAML so the user
-             sees the unavailability immediately (Copilot review feedback).
-             Click handler kept for the View_AllButtons_AreWiredOrExplicitlyInert
-             audit and for the programmatic-info-dialog fallback. -->
+        <!-- Redo is WIRED (#974) to the global Core Undo stack
+             (CoreState.Undo.RunRedo() + CanRedo already exist). The handler
+             guards on CanRedo at runtime, so the button stays enabled like the
+             Undo button and the Map Style editor's Redo. -->
         <Button AutomationProperties.AutomationId="ImageTSAEditor_Redo_Button"
-                Name="RedoButton" Content="Redo" Click="Redo_Click"
-                IsEnabled="False" />
+                Name="RedoButton" Content="Redo" Click="Redo_Click" />
         <!-- Write is gated on IsContextLoaded - disabled until a caller Init's -->
         <Button AutomationProperties.AutomationId="ImageTSAEditor_Write_Button"
                 Name="WriteButton" Content="Write" Click="Write_Click"
@@ -151,11 +149,14 @@
                 <NumericUpDown AutomationProperties.AutomationId="ImageTSAEditor_PaletteAddress_Input"
                                FormatString="0" Name="PaletteAddressBox" Width="140"
                                Minimum="0" Maximum="4294967295" VerticalAlignment="Center" />
-                <!-- Clipboard button is an explicit IsEnabled=False stub - KnownGap: PaletteToClipboard.
-                     Click handler is wired so the inert-buttons audit test passes. -->
+                <!-- Clipboard button is WIRED (#974): packs the 16 palette
+                     entries to GBA 5-5-5 big-endian hex and copies to the
+                     system clipboard. Always enabled (reads the grid, never
+                     writes ROM). -->
                 <Button AutomationProperties.AutomationId="ImageTSAEditor_PaletteClipboard_Button"
                         Name="PaletteClipboardButton" Content="Clipboard"
-                        Click="PaletteClipboard_Click" IsEnabled="False"
+                        ToolTip.Tip="Copy the 16 palette entries to the clipboard as GBA 5-5-5 hex."
+                        Click="PaletteClipboard_Click"
                         Margin="12,0,0,0" />
                 <Button AutomationProperties.AutomationId="ImageTSAEditor_PaletteWrite_Button"
                         Name="PaletteWriteButton" Content="Palette Write"
@@ -392,14 +393,14 @@
               </Grid>
 
               <!-- Palette UNDO/REDO sub-buttons (mirrors WF UndoPlaetteButton/RedoPaletteButton).
-                   Redo is IsEnabled=False at the AXAML level (Core.Undo has no
-                   RunRedo yet); Copilot review feedback. -->
+                   Redo is WIRED (#974) to the global Core Undo stack via
+                   PaletteRedo_Click -> Redo_Click (guards on CanRedo). -->
               <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Right">
                 <Button AutomationProperties.AutomationId="ImageTSAEditor_PaletteUndo_Button"
                         Name="PaletteUndoButton" Content="Undo" Click="PaletteUndo_Click" Width="130" />
                 <Button AutomationProperties.AutomationId="ImageTSAEditor_PaletteRedo_Button"
                         Name="PaletteRedoButton" Content="Redo" Click="PaletteRedo_Click"
-                        IsEnabled="False" Width="130" />
+                        Width="130" />
               </StackPanel>
 
             </StackPanel>
@@ -423,7 +424,10 @@
             <!-- Import button (RESOLVED #901): mirrors WF image1_Import=画像読込 —
                  tilesheet-only, repoints ONLY the ZImg pointer (TSA + palette
                  untouched). Gated on IsContextLoaded.
-                 Export remains an IsEnabled=False stub - KnownGap: MainImageExport. -->
+                 Export button (RESOLVED #974): mirrors WF image1_Export=画像取出 —
+                 the raw 4bpp tilesheet PNG (8-tile-wide strip), DISTINCT from the
+                 read-only TSA-composited Battle Export PNG (#808). Gated on
+                 IsContextLoaded. -->
             <StackPanel Orientation="Horizontal" Spacing="6">
               <Button AutomationProperties.AutomationId="ImageTSAEditor_MainImage_Import_Button"
                       Name="MainImageImportButton" Content="Image Import"
@@ -431,7 +435,8 @@
                       Click="MainImageImport_Click" IsEnabled="{Binding IsContextLoaded}" Width="167" />
               <Button AutomationProperties.AutomationId="ImageTSAEditor_MainImage_Export_Button"
                       Name="MainImageExportButton" Content="Image Export"
-                      Click="MainImageExport_Click" IsEnabled="False" Width="167" />
+                      ToolTip.Tip="Export the raw main tilesheet (LZ77-decompressed 4bpp tiles) as a PNG."
+                      Click="MainImageExport_Click" IsEnabled="{Binding IsContextLoaded}" Width="167" />
             </StackPanel>
 
             <!-- Image preview area -->

--- a/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml.cs
@@ -13,6 +13,7 @@
 // handlers short-circuit — covered by KnownGap markers in the AXAML.
 using System;
 using global::Avalonia.Controls;
+using global::Avalonia.Input.Platform;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
@@ -55,13 +56,10 @@ namespace FEBuilderGBA.Avalonia.Views
             // Same for changes to the Palette Address spinner — the spinner
             // is the WF-equivalent of the editable PaletteAddress field.
             PaletteAddressBox.ValueChanged += (_, _) => ReloadPaletteIntoGrid();
-            // Redo is unsupported by Core.Undo (RunRedo doesn't exist), so
-            // disable both Redo entry points up front. Their Click handlers
-            // remain wired only for the View_AllButtons_AreWiredOrExplicitlyInert
-            // audit; user-visible they render disabled rather than silently
-            // logging a no-op (Copilot review feedback).
-            RedoButton.IsEnabled = false;
-            PaletteRedoButton.IsEnabled = false;
+            // Redo is now wired to the global Core Undo stack (#974):
+            // CoreState.Undo.RunRedo() + CanRedo already exist (the Map Style
+            // editor's Redo_Click uses the same pattern). The buttons stay
+            // enabled and Redo_Click guards on CanRedo at runtime.
             Opened += (_, _) => LoadList();
         }
 
@@ -420,18 +418,40 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         /// <summary>
-        /// Redo button. Core Undo currently exposes only RunUndo (the
-        /// global redo stack is a WinForms-only extension), so the button
-        /// is disabled in the constructor (IsEnabled=false) and this handler
-        /// is reachable only via the audit-only Click wiring. A future Core
-        /// Undo.RunRedo will replace this stub and let us re-enable the
-        /// button. Defensive guard mirrors PaletteRedo_Click.
+        /// Redo button (#974). Runs <see cref="Undo.RunRedo"/> on the global
+        /// <see cref="CoreState.Undo"/> stack — the SAME pattern as the Map
+        /// Style editor's Redo_Click. Mirrors <see cref="Undo_Click"/>: guards
+        /// on <see cref="Undo.CanRedo"/>, verifies the redo actually advanced
+        /// (RunRedo's bool surfaces silent rollback failures), then reloads the
+        /// palette grid + re-renders the read-only previews so the spinners /
+        /// ChipListPreview / BattlePreview track the rolled-forward ROM bytes.
         /// </summary>
         void Redo_Click(object? sender, RoutedEventArgs e)
         {
-            // No-op: button is disabled at runtime. We surface a one-line
-            // info dialog if the handler is ever invoked programmatically.
-            CoreState.Services.ShowInfo("Redo is not yet available in the Avalonia TSA editor (deferred until Core.Undo.RunRedo lands).");
+            try
+            {
+                if (CoreState.Undo == null || !CoreState.Undo.CanRedo)
+                {
+                    CoreState.Services.ShowInfo("Nothing to redo.");
+                    return;
+                }
+                if (!CoreState.Undo.RunRedo())
+                {
+                    CoreState.Services.ShowError("Redo failed.");
+                    return;
+                }
+                // RunRedo rolls ROM bytes forward (e.g. a redone palette write),
+                // so reload the affected state and re-render the previews --
+                // otherwise the spinners + ChipListPreview / BattlePreview keep
+                // showing the pre-redo colors (mirrors Undo_Click).
+                ReloadPaletteIntoGrid();
+                RefreshBattleCanvas();
+                RefreshChipList();
+            }
+            catch (Exception ex)
+            {
+                CoreState.Services.ShowError($"Redo failed: {ex.Message}");
+            }
         }
 
         /// <summary>
@@ -456,14 +476,34 @@ namespace FEBuilderGBA.Avalonia.Views
         // -----------------------------------------------------------------
 
         /// <summary>
-        /// KnownGap: PaletteToClipboard. WinForms uses
-        /// System.Windows.Forms.Clipboard which is WinForms-only; the
-        /// Avalonia equivalent (TopLevel.Clipboard async API) is a
-        /// separate cross-cutting refactor not in scope here.
+        /// Palette-to-clipboard (#974). Mirrors WinForms
+        /// <c>PaletteFormRef.PALETTE_TO_CLIPBOARD_BUTTON_Click</c>: pack the 16
+        /// current palette entries to GBA 5-5-5 big-endian hex (4 chars/entry,
+        /// 64 chars total) and copy to the system clipboard via the Avalonia
+        /// <c>IClipboard.SetTextAsync</c> async API. The grid is always
+        /// populated, so this is enabled unconditionally; it never writes ROM.
         /// </summary>
-        void PaletteClipboard_Click(object? sender, RoutedEventArgs e)
+        async void PaletteClipboard_Click(object? sender, RoutedEventArgs e)
         {
-            Log.Notify("ImageTSAEditor PaletteClipboard - deferred (KnownGap: PaletteToClipboard)");
+            try
+            {
+                var rgb = ReadPaletteFromUI();
+                string hex = ImageTSAEditorViewModel.BuildPaletteClipboardHex(rgb);
+
+                IClipboard? clipboard = global::Avalonia.Controls.TopLevel.GetTopLevel(this)?.Clipboard;
+                if (clipboard == null)
+                {
+                    CoreState.Services.ShowError("Clipboard is not available.");
+                    return;
+                }
+                await clipboard.SetTextAsync(hex);
+                Log.Notify($"ImageTSAEditor: palette copied to clipboard ({hex}).");
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImageTSAEditorView.PaletteClipboard failed: {0}", ex.Message);
+                CoreState.Services.ShowError($"Palette to clipboard failed: {ex.Message}");
+            }
         }
 
         /// <summary>
@@ -574,15 +614,37 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         /// <summary>
-        /// KnownGap: MainImageExport. Mirrors WF image1_Export (the raw-
-        /// tilesheet PNG export) — would call into ImageFormRef.ExportImageHandler
-        /// which is WinForms-only. NOTE: the read-only TSA-composited Export PNG
-        /// (#808, BattleExportPng_Click) is a DIFFERENT, already-wired export;
-        /// this raw-tilesheet export stays deferred.
+        /// Raw tilesheet export (#974). Mirrors WF <c>image1_Export</c>: the
+        /// LZ77-decompressed ZImg tiles laid out as an 8-tile-wide 4bpp strip
+        /// (NOT the TSA-composited #808 canvas). Renders via the read-only
+        /// <see cref="ImageTSAEditorViewModel.RenderRawTilesheet"/> Core seam
+        /// into the Main Image tab's preview control, then saves it to PNG via
+        /// the shared <see cref="Controls.GbaImageControl.ExportPng"/> save-file
+        /// dialog. Read-only — no UndoService. Gated on IsContextLoaded.
         /// </summary>
-        void MainImageExport_Click(object? sender, RoutedEventArgs e)
+        async void MainImageExport_Click(object? sender, RoutedEventArgs e)
         {
-            Log.Notify("ImageTSAEditor MainImageExport - deferred (KnownGap: MainImageExport)");
+            if (!_vm.IsContextLoaded) return;
+
+            try
+            {
+                IImage img = _vm.RenderRawTilesheet();
+                if (img == null)
+                {
+                    CoreState.Services.ShowError(
+                        "TSA Image Export: could not decode the main tilesheet.");
+                    return;
+                }
+                // Show the rendered tilesheet in the Main Image preview so the
+                // user sees what is being exported, then save it to PNG.
+                MainImagePreview.SetImage(img);
+                await MainImagePreview.ExportPng(this, "tsa_tilesheet");
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImageTSAEditorView.MainImageExport failed: {0}", ex.Message);
+                CoreState.Services.ShowError($"TSA Image Export failed: {ex.Message}");
+            }
         }
 
         /// <summary>

--- a/FEBuilderGBA.Core.Tests/ImageTSAEditorCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ImageTSAEditorCoreTests.cs
@@ -788,6 +788,200 @@ namespace FEBuilderGBA.Core.Tests
             });
         }
 
+        // =================================================================
+        // RenderRawTilesheet (#974) — the raw 4bpp tilesheet PNG export:
+        //   * Output = 64 x (ceil(tileCount/8)*8): an 8-tile-wide strip,
+        //     left-to-right / top-to-bottom, SINGLE palette bank 0,
+        //     index 0 OPAQUE. NOT the TSA-composited canvas (#808), NOT the
+        //     4-column flip strip (#819).
+        // Reuses the same MarkerTiles + StandardPalette synthetic harness.
+        // =================================================================
+
+        [Fact]
+        public void RenderRawTilesheet_TwoTiles_RendersSixtyFourByEight()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());          // 2 tiles
+                PlantPalette(rom, StandardPalette());
+
+                IImage img = ImageTSAEditorCore.RenderRawTilesheet(
+                    rom, IMAGE_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                // 8 tiles wide * 8px = 64 wide.
+                Assert.Equal(64, img.Width);
+                // 2 tiles fit in 1 row -> ceil(2/8)=1 row * 8px = 8 tall.
+                Assert.Equal(8, img.Height);
+            });
+        }
+
+        [Fact]
+        public void RenderRawTilesheet_NineTiles_WrapsToSecondRow()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                // 9 tiles: 8 fill the first row, the 9th wraps to the 2nd row.
+                byte[] tiles = new byte[9 * 32];
+                FillTile(tiles, 0, 1);                   // tile 0 -> red
+                FillTile(tiles, 8, 1);                   // tile 8 -> red fill
+                SetPixel(tiles, 8, 0, 0, 2);             // tile 8 (0,0) -> green marker
+                PlantImage(rom, tiles);
+                PlantPalette(rom, StandardPalette());
+
+                IImage img = ImageTSAEditorCore.RenderRawTilesheet(
+                    rom, IMAGE_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                Assert.Equal(64, img.Width);
+                // ceil(9/8) = 2 rows * 8px = 16 tall.
+                Assert.Equal(16, img.Height);
+                // Tile 8 is the first tile of the 2nd row (col 0, y base 8); its
+                // (0,0) marker -> global (0, 8) = green.
+                AssertPixel(img, 0, 8, 0, 248, 0, 255);
+            });
+        }
+
+        [Fact]
+        public void RenderRawTilesheet_LaysTilesLeftToRight()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                // 2 tiles: tile 0 all index 0 (black/opaque), tile 1 red fill with
+                // a green marker at (0,0). The raw strip lays tile 0 at col 0 and
+                // tile 1 at col 1 (x base 8) — UNLIKE RenderChipList, which stacks
+                // tiles vertically. This pins the horizontal layout.
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+
+                IImage img = ImageTSAEditorCore.RenderRawTilesheet(
+                    rom, IMAGE_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                // Tile 1 sits at col 1 (x base 8) on the SAME row (y=0). Its (0,0)
+                // marker -> global (8, 0) = green; neighbour (9,0) = red.
+                AssertPixel(img, 8, 0, 0, 248, 0, 255);
+                AssertPixel(img, 9, 0, 248, 0, 0, 255);
+            });
+        }
+
+        [Fact]
+        public void RenderRawTilesheet_Index0_RendersOpaque()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());          // tile 0 = all index 0
+                PlantPalette(rom, StandardPalette());
+
+                IImage img = ImageTSAEditorCore.RenderRawTilesheet(
+                    rom, IMAGE_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                // Tile 0 sits at col 0 (x base 0), entirely index 0 -> OPAQUE black.
+                AssertPixel(img, 0, 0, 0, 0, 0, 255);
+                byte[] px = img.GetPixelData();
+                Assert.Equal(255, px[(7 * img.Width + 7) * 4 + 3]);
+            });
+        }
+
+        [Fact]
+        public void RenderRawTilesheet_UsesPaletteBank0()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+
+                IImage img = ImageTSAEditorCore.RenderRawTilesheet(
+                    rom, IMAGE_OFFSET, PALETTE_OFFSET);
+
+                Assert.NotNull(img);
+                // Tile 1 (col 1) marker (index 2) is GREEN (bank 0), NOT white
+                // (bank 1) — proving bank 0 is used.
+                AssertPixel(img, 8, 0, 0, 248, 0, 255);
+            });
+        }
+
+        // ----- RenderRawTilesheet null / out-of-bounds safety -----
+
+        [Fact]
+        public void RenderRawTilesheet_NullRom_ReturnsNull()
+        {
+            WithImageService(() =>
+            {
+                Assert.Null(ImageTSAEditorCore.RenderRawTilesheet(
+                    null, IMAGE_OFFSET, PALETTE_OFFSET));
+            });
+        }
+
+        [Fact]
+        public void RenderRawTilesheet_NoImageService_ReturnsNull()
+        {
+            var rom = MakeRom();
+            PlantImage(rom, MarkerTiles());
+            PlantPalette(rom, StandardPalette());
+
+            var saved = CoreState.ImageService;
+            try
+            {
+                CoreState.ImageService = null;
+                Assert.Null(ImageTSAEditorCore.RenderRawTilesheet(
+                    rom, IMAGE_OFFSET, PALETTE_OFFSET));
+            }
+            finally { CoreState.ImageService = saved; }
+        }
+
+        [Fact]
+        public void RenderRawTilesheet_CorruptImagePointer_ReturnsNull()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantPalette(rom, StandardPalette());
+                // imageAddr at header (0) -> isSafetyOffset false.
+                Assert.Null(ImageTSAEditorCore.RenderRawTilesheet(
+                    rom, 0, PALETTE_OFFSET));
+                // imageAddr at a zero-filled region -> not a valid LZ77 stream.
+                Assert.Null(ImageTSAEditorCore.RenderRawTilesheet(
+                    rom, IMAGE_OFFSET, PALETTE_OFFSET));
+            });
+        }
+
+        [Fact]
+        public void RenderRawTilesheet_CorruptPalettePointer_ReturnsNull()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                // paletteAddr at header (0) -> isSafetyOffset false.
+                Assert.Null(ImageTSAEditorCore.RenderRawTilesheet(
+                    rom, IMAGE_OFFSET, 0));
+            });
+        }
+
+        [Fact]
+        public void RenderRawTilesheet_TruncatedLz77Image_ReturnsNull()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantPalette(rom, StandardPalette());
+                int addr = rom.Data.Length - 4;
+                rom.Data[addr + 0] = 0x10;
+                rom.Data[addr + 1] = 0x00;
+                rom.Data[addr + 2] = 0x01;
+                rom.Data[addr + 3] = 0x00;
+                Assert.Null(ImageTSAEditorCore.RenderRawTilesheet(
+                    rom, (uint)addr, PALETTE_OFFSET));
+            });
+        }
+
         // -----------------------------------------------------------------
         // Helpers
         // -----------------------------------------------------------------

--- a/FEBuilderGBA.Core/ImageTSAEditorCore.cs
+++ b/FEBuilderGBA.Core/ImageTSAEditorCore.cs
@@ -212,8 +212,13 @@ namespace FEBuilderGBA
         /// isSafetyOffset / getCompressedSize / end-of-ROM truncation guards) and
         /// the 4bpp tiles are laid out left-to-right, top-to-bottom in an
         /// <b>8-tile-wide</b> strip — 64px wide, <c>ceil(tileCount / 8) * 8</c>
-        /// tall — exactly like a plain 4bpp tilesheet PNG. A partial final row is
-        /// rendered as transparent (index-0) padding cells.
+        /// tall — exactly like a plain 4bpp tilesheet PNG. The final row may be
+        /// partially filled; cells beyond the last tile are left as the
+        /// zero-initialized (blank/transparent) pixel-buffer background because
+        /// they are simply never drawn. Note the tiles themselves are decoded
+        /// with <c>opaqueIndex0:true</c>, so palette index 0 WITHIN a drawn tile
+        /// is opaque (it is only the never-drawn padding cells that stay
+        /// transparent).
         ///
         /// The raw tilesheet never reads the TSA stream, so this takes NO
         /// <c>tsaAddr</c>. Always renders in palette bank 0. Returns <c>null</c>

--- a/FEBuilderGBA.Core/ImageTSAEditorCore.cs
+++ b/FEBuilderGBA.Core/ImageTSAEditorCore.cs
@@ -202,6 +202,69 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
+        /// Render the RAW tilesheet (read-only, #974) from the already-resolved
+        /// image + palette ROM addresses — the WinForms <c>image1_Export</c>
+        /// raw 4bpp tile dump, NOT the TSA-composited canvas (#808) and NOT the
+        /// 4-column flip strip (#819).
+        ///
+        /// The ZImg stream is LZ77-decompressed (via the shared
+        /// <see cref="TryLoadTSATileAndPalette"/> loader, inheriting the
+        /// isSafetyOffset / getCompressedSize / end-of-ROM truncation guards) and
+        /// the 4bpp tiles are laid out left-to-right, top-to-bottom in an
+        /// <b>8-tile-wide</b> strip — 64px wide, <c>ceil(tileCount / 8) * 8</c>
+        /// tall — exactly like a plain 4bpp tilesheet PNG. A partial final row is
+        /// rendered as transparent (index-0) padding cells.
+        ///
+        /// The raw tilesheet never reads the TSA stream, so this takes NO
+        /// <c>tsaAddr</c>. Always renders in palette bank 0. Returns <c>null</c>
+        /// (never throws) on any null / out-of-bounds / corrupt input or when no
+        /// <see cref="IImageService"/> is set.
+        /// </summary>
+        /// <param name="rom">Loaded ROM.</param>
+        /// <param name="imageAddr">Resolved ROM offset of the LZ77 tile image.</param>
+        /// <param name="paletteAddr">Resolved ROM offset of the palette block.</param>
+        public static IImage RenderRawTilesheet(ROM rom, uint imageAddr, uint paletteAddr)
+        {
+            if (rom == null || rom.RomInfo == null || rom.Data == null) return null;
+            if (CoreState.ImageService == null) return null;
+
+            // Same LZ77-image-decode + raw-palette read as TryRenderMainImage /
+            // RenderChipList. The raw tilesheet never reads the TSA stream.
+            if (!TryLoadTSATileAndPalette(rom, imageAddr, paletteAddr,
+                                          out byte[] tileData, out byte[] palette))
+            {
+                return null;
+            }
+
+            const int bytesPerTile = 32; // 4bpp = 32 bytes/tile
+            int tileCount = tileData.Length / bytesPerTile;
+            if (tileCount <= 0) return null;
+
+            // 8-tile-wide strip; height rounds up to a full row so the last
+            // (possibly partial) row of tiles is included.
+            const int tilesPerRow = 8;
+            int rows = (tileCount + tilesPerRow - 1) / tilesPerRow;
+            int width = tilesPerRow * 8;   // 64px
+            int height = rows * 8;
+
+            var image = CoreState.ImageService.CreateImage(width, height);
+            byte[] pixels = new byte[width * height * 4]; // RGBA, zero-filled = transparent padding
+
+            for (int tile = 0; tile < tileCount; tile++)
+            {
+                int col = tile % tilesPerRow;
+                int row = tile / tilesPerRow;
+                ImageUtilCore.DecodeTileToPixels(
+                    tileData, tile, palette, 0 /* palBank */,
+                    pixels, width, col * 8, row * 8,
+                    hFlip: false, vFlip: false, is4bpp: true, opaqueIndex0: true);
+            }
+
+            image.SetPixelData(pixels);
+            return image;
+        }
+
+        /// <summary>
         /// Shared loader extracted from <see cref="TryRenderMainImage"/> (#819):
         /// LZ77-decode the tile image and read the raw (≤512-byte) palette block
         /// from already-resolved ROM addresses. Behaviour-preserving -- returns

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -10210,3 +10210,9 @@ AIスクリプトをエクスポートしました:
 
 :Re-read the AI script before importing.
 インポートする前にAIスクリプトを再読み込みしてください。
+
+:Copy the 16 palette entries to the clipboard as GBA 5-5-5 hex.
+16色のパレットをGBA 5-5-5 16進数としてクリップボードにコピーします。
+
+:Export the raw main tilesheet (LZ77-decompressed 4bpp tiles) as a PNG.
+メインタイルシート（LZ77展開した4bppタイル）をPNGとして取り出します。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -24042,3 +24042,9 @@ AI脚本已导出到:
 
 :Re-read the AI script before importing.
 导入前请重新读取AI脚本。
+
+:Copy the 16 palette entries to the clipboard as GBA 5-5-5 hex.
+将16色调色板作为GBA 5-5-5十六进制复制到剪贴板。
+
+:Export the raw main tilesheet (LZ77-decompressed 4bpp tiles) as a PNG.
+将主图块表（LZ77解压的4bpp图块）导出为PNG。


### PR DESCRIPTION
## Summary
Enable three previously-stubbed affordances in the **Avalonia Image TSA Editor** (`ImageTSAEditorView` + `ImageTSAEditorViewModel` + Core `ImageTSAEditorCore`). The TSA byte-write path stays an explicit, justified deferral.

Plan: https://github.com/laqieer/FEBuilderGBA/issues/974#issuecomment-4630411563 (Copilot CLI plan review accepted; both tightening points implemented).

### Win 1 — Palette-to-clipboard
`PaletteClipboard_Click` now packs the 16 current palette entries to GBA 5-5-5 **big-endian** hex (64 chars, mirroring WF `PaletteFormRef.PALETTE_TO_CLIPBOARD_BUTTON_Click` / `U.big16`) via the new `ImageTSAEditorViewModel.BuildPaletteClipboardHex` helper, and copies them with the Avalonia `IClipboard.SetTextAsync` async API. Button enabled. Per Copilot review: `async void` + `await` inside the try/catch, and a user-visible error when no clipboard is available.

### Win 2 — Raw tilesheet export
New read-only Core seam `ImageTSAEditorCore.RenderRawTilesheet` decompresses the ZImg pointer (`LZ77.decompress`, reusing the existing `TryLoadTSATileAndPalette` truncation/safety guards) and renders the raw 4bpp tiles as an **8-tile-wide strip** via `IImageService.Decode4bppTiles` (auto height, bank 0, opaque index 0). `MainImageExport_Click` renders into `MainImagePreview` **only after a non-null check** (Copilot review point 2 — no stale bitmap export), then saves a PNG via `GbaImageControl.ExportPng`. Distinct from the #808 read-only TSA-composited Battle export. Button enabled (context-gated).

### Win 3 — Redo
The "deferred until Core.Undo.RunRedo lands" comment was **stale** — `CoreState.Undo.RunRedo()` / `CanRedo` already exist. `Redo_Click` now mirrors the Map Style editor: guards on `CanRedo`, runs `RunRedo()`, and reloads the palette grid + re-renders the previews on success. `PaletteRedo_Click` delegates to it. Removed the constructor disabling + stale comment; both Redo buttons enabled.

### Deferred (out of scope — `KnownGap: TSAByteWrite` retained)
The Avalonia TSA editor has **no per-cell TSA edit grid**, so there is no edited TSA to write back; tilesheet import (#901) already covers full image replacement. The `KnownGap: TSAByteWrite` marker is kept verbatim; this becomes actionable only when a TSA cell-edit grid is added (separate future issue).

Closes #974

## Test plan
- [x] **Core.Tests** — 10 new `RenderRawTilesheet` tests: 64×8 dimensions for 2 tiles, 64×16 row-wrap for 9 tiles, left-to-right tile layout, opaque index 0, palette bank 0, and null / no-ImageService / corrupt-image-pointer / corrupt-palette-pointer / truncated-LZ77 safety. `ImageTSAEditorCoreTests` = **47 passed**.
- [x] **Avalonia.Tests** — `ViewModel_BuildPaletteClipboardHex_PacksBigEndian5_5_5` (white→`FF7F`, red→`1F00`, green→`E003`, blue→`007C`, 64-char length) + `_ThrowsOnWrongLength`; `ViewModel_RenderRawTilesheet_NotFoundImagePointer_ReturnsNull`. Flipped audits: Clipboard/Export/Redo/PaletteRedo now assert wired (no `IsEnabled="False"`); `View_PaletteClipboardHandler_PacksAndCopies`, `View_MainImageExportHandler_RendersThenExports` (null-guard precedes export), `View_RedoHandler_CallsRunRedo`; `View_RedoButtons_AreNotDisabledInConstructor`; KnownGap inventory now requires only `TSAByteWrite` and asserts the other two markers are gone. `ImageTSAEditorParityTests` = **57 passed**.
- [x] **Avalonia.Tests (full suite)** — **7538 passed, 0 failed, 3 skipped** (incl. the `L10nCoverageTest` gate after adding ja/zh translations for the 2 new ToolTip strings).
- [x] **Core.Tests (full suite)** — **2774 passed, 10 failed**. The 10 failures are the **pre-existing** FE8U `SkillSystemsAnime`/`SkillConfig` `.dmp`-template tests (missing `config/patch2/FE8U/skill/skillanimtemplate*.dmp` in the worktree submodule) — unchanged, NONE in changed classes.
- [x] **FEBuilderGBA.Tests** — builds against the Core change (0 errors); image/TSA/LZ77 subset = **59 passed**.
- [x] **Build** — Core + Avalonia (Debug + Release) build with 0 errors.

## GUI Test Report
| Case | Steps | Result |
| --- | --- | --- |
| Open TSA editor (FE8U) | `--screenshot-all --screenshot-tab=ImageTSAEditor_Palette_Tab` | PASS — editor opens on the Palette tab |
| Redo button enabled | Inspect top toolbar | PASS — Redo renders enabled (guards on `CanRedo` at runtime) |
| Palette Redo button enabled | Inspect Palette-tab Undo/Redo bar | PASS — Palette Redo renders enabled |
| Clipboard button enabled | Inspect Palette-tab top bar | PASS — Clipboard renders enabled (was a disabled stub) |
| Context-gated buttons disabled w/o Init | Inspect Write / Palette Write / Export PNG | PASS — correctly greyed in standalone open (gate on `IsContextLoaded` / `CanExportBattle`) |

Render harness: offscreen `RenderTargetBitmap` (`--screenshot-all`, 325 captured / 0 failed). The standalone open path has no Init seed, so the context-gated write/export buttons are correctly greyed; the three newly-enabled buttons (Redo, Palette Redo, Clipboard) render enabled. Clipboard copy / raw-tilesheet export / Redo logic are pinned by the unit tests above.

## Screenshots
![TSA editor — Redo + Clipboard + Palette Redo now enabled](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/w3c-tsa-editor.png)

The Palette-tab view shows the now-enabled **Redo** (top toolbar), **Clipboard** (palette top bar), and **Palette Redo** (bottom-right) buttons. Write / Palette Write / Export PNG stay greyed because no caller has invoked `Init(...)` in standalone screenshot mode (their `IsContextLoaded` / `CanExportBattle` gating is unchanged and correct).

## Note — TSA byte-write stays deferred
TSA cell byte-write + LZ77 realloc is intentionally **out of scope**: the Avalonia TSA editor exposes no per-cell TSA editing UI, so there is no edited TSA to persist. The `KnownGap: TSAByteWrite` marker is retained and the parity audit now requires it as the sole remaining KnownGap for this editor.

_Claude Code 2.1.162 · model claude-opus-4-8[1m]_
