### PR TITLE
fix(avalonia): remove stray Write label + align Palette tab R/G/B headers on Unit Palette Editor (#984)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteParityTests.cs
@@ -76,7 +76,10 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.NotNull(FindByAutomationId<TextBlock>(view, "ImageUnitPalette_Size_Label"));
             Assert.NotNull(FindByAutomationId<TextBlock>(view, "ImageUnitPalette_SelectedAddressPrefix_Label"));
             Assert.NotNull(FindByAutomationId<TextBlock>(view, "ImageUnitPalette_Address_Label"));
-            Assert.NotNull(FindByAutomationId<TextBlock>(view, "ImageUnitPalette_Write_Label"));
+            // ImageUnitPalette_Write_Label was an inert stray header label
+            // intentionally removed in #984 (it looked like a non-functional
+            // "Write" text after the Selected Address bar). The real Write
+            // affordance is the ImageUnitPalette_Write_Button on the Edit tab.
             Assert.NotNull(FindByAutomationId<TextBlock>(view, "ImageUnitPalette_FilterLabel_Label"));
             Assert.NotNull(FindByAutomationId<Button>(view, "ImageUnitPalette_Expand_Button"));
         }

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml
@@ -11,8 +11,8 @@
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Unit Palette Editor" FontSize="18" FontWeight="Bold" />
 
-        <!-- Header row: Address bar caption + Write caption -->
-        <Grid ColumnDefinitions="Auto,Auto,Auto,Auto,Auto" RowDefinitions="Auto">
+        <!-- Header row: Address bar caption + selected-address -->
+        <Grid ColumnDefinitions="Auto,Auto,Auto,Auto" RowDefinitions="Auto">
           <TextBlock AutomationProperties.AutomationId="ImageUnitPalette_Address_Label"
                      Grid.Row="0" Grid.Column="0" Text="Address" VerticalAlignment="Center" Margin="0,0,8,0" />
           <TextBlock AutomationProperties.AutomationId="ImageUnitPalette_Addr_Label"
@@ -22,8 +22,6 @@
                      Grid.Row="0" Grid.Column="2" Text="Selected Address:" VerticalAlignment="Center" Margin="0,0,8,0" />
           <TextBox AutomationProperties.AutomationId="ImageUnitPalette_SelectedAddress_Input"
                    Grid.Row="0" Grid.Column="3" Name="SelectedAddressBox" Width="120" IsReadOnly="True" Margin="0,0,16,0" />
-          <TextBlock AutomationProperties.AutomationId="ImageUnitPalette_Write_Label"
-                     Grid.Row="0" Grid.Column="4" Text="Write" VerticalAlignment="Center" />
         </Grid>
 
         <TabControl AutomationProperties.AutomationId="ImageUnitPalette_Main_TabControl" Name="MainTabs">
@@ -197,12 +195,10 @@
               <Grid ColumnDefinitions="*,*,*,*" Margin="0,8,0,0">
                 <!-- Column 1: indices 1-4 -->
                 <Grid Grid.Column="0" RowDefinitions="Auto,Auto,Auto,Auto,Auto">
-                  <Grid Grid.Row="0" ColumnDefinitions="Auto,Auto,Auto,Auto,40,60,60,60">
-                    <TextBlock Grid.Column="0" Text=" " />
-                    <TextBlock Grid.Column="4" Text=" " />
-                    <TextBlock AutomationProperties.AutomationId="ImageUnitPalette_R_Header_Label" Grid.Column="5" Text="R" HorizontalAlignment="Center" FontWeight="SemiBold" />
-                    <TextBlock AutomationProperties.AutomationId="ImageUnitPalette_G_Header_Label" Grid.Column="6" Text="G" HorizontalAlignment="Center" FontWeight="SemiBold" />
-                    <TextBlock AutomationProperties.AutomationId="ImageUnitPalette_B_Header_Label" Grid.Column="7" Text="B" HorizontalAlignment="Center" FontWeight="SemiBold" />
+                  <Grid Grid.Row="0" ColumnDefinitions="30,40,60,60,60">
+                    <TextBlock AutomationProperties.AutomationId="ImageUnitPalette_R_Header_Label" Grid.Column="2" Text="R" HorizontalAlignment="Center" FontWeight="SemiBold" />
+                    <TextBlock AutomationProperties.AutomationId="ImageUnitPalette_G_Header_Label" Grid.Column="3" Text="G" HorizontalAlignment="Center" FontWeight="SemiBold" />
+                    <TextBlock AutomationProperties.AutomationId="ImageUnitPalette_B_Header_Label" Grid.Column="4" Text="B" HorizontalAlignment="Center" FontWeight="SemiBold" />
                   </Grid>
                   <Grid Grid.Row="1" ColumnDefinitions="30,40,60,60,60" Margin="0,2">
                     <TextBlock AutomationProperties.AutomationId="ImageUnitPalette_Index1_Label" Grid.Column="0" Text="1" VerticalAlignment="Center" />

--- a/FEBuilderGBA.Tests/Unit/ImageUnitPaletteLayoutTests.cs
+++ b/FEBuilderGBA.Tests/Unit/ImageUnitPaletteLayoutTests.cs
@@ -1,0 +1,117 @@
+using System.Text.RegularExpressions;
+
+namespace FEBuilderGBA.Tests.Unit
+{
+    /// <summary>
+    /// Static AXAML regression tests for issue #984 — two layout fixes on the
+    /// Avalonia Unit Palette Editor (<c>ImageUnitPaletteView.axaml</c>):
+    ///
+    /// B1: The header row after the "Selected Address" bar carried a stray,
+    /// inert <c>ImageUnitPalette_Write_Label</c> TextBlock with Text="Write".
+    /// It looked like a non-functional "Write" button next to the selected
+    /// address. It is removed; the header grid drops from 5 columns to 4.
+    /// The real Write affordance (<c>ImageUnitPalette_Write_Button</c> on the
+    /// Edit tab) and the Palette Write button
+    /// (<c>ImageUnitPalette_PaletteWrite_Button</c>) are untouched.
+    ///
+    /// B2: The Palette tab's Column-1 R/G/B header row used a mismatched
+    /// 8-column layout (<c>Auto,Auto,Auto,Auto,40,60,60,60</c>) that did not
+    /// line up with the swatch rows' <c>30,40,60,60,60</c> tracks, so the
+    /// R/G/B captions sat off to the right of the spinner columns. The header
+    /// now uses the same <c>30,40,60,60,60</c> tracks with the R/G/B labels at
+    /// columns 2/3/4 (directly over the R/G/B spinners).
+    /// </summary>
+    public class ImageUnitPaletteLayoutTests
+    {
+        private static string SolutionDir
+        {
+            get
+            {
+                var dir = AppContext.BaseDirectory;
+                while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                    dir = Path.GetDirectoryName(dir);
+                return dir ?? throw new InvalidOperationException("Cannot find solution root");
+            }
+        }
+
+        private static string AxamlPath
+        {
+            get
+            {
+                var viewsDir = Path.Combine(SolutionDir, "FEBuilderGBA.Avalonia", "Views");
+                var hit = Directory.GetFiles(viewsDir, "ImageUnitPaletteView.axaml", SearchOption.AllDirectories)
+                    .FirstOrDefault();
+                return hit ?? throw new FileNotFoundException(
+                    "Cannot locate ImageUnitPaletteView.axaml under FEBuilderGBA.Avalonia/Views");
+            }
+        }
+
+        private static string Src => File.ReadAllText(AxamlPath);
+
+        // ===== B1: stray "Write" header label removed =====
+
+        [Fact]
+        public void B1_StrayWriteHeaderLabel_IsRemoved()
+        {
+            var src = Src;
+
+            // The inert stray label must be gone entirely.
+            Assert.DoesNotContain("ImageUnitPalette_Write_Label", src);
+
+            // The header grid must no longer be the 5-column variant; it is now
+            // a 4-column grid (Address caption + addr + "Selected Address:" +
+            // the read-only selected-address box).
+            Assert.DoesNotContain("ColumnDefinitions=\"Auto,Auto,Auto,Auto,Auto\"", src);
+            Assert.Contains("ColumnDefinitions=\"Auto,Auto,Auto,Auto\"", src);
+        }
+
+        [Fact]
+        public void B1_FunctionalWriteButtons_AreStillPresent()
+        {
+            var src = Src;
+
+            // The real Write button (Edit tab) and Palette Write button
+            // (Palette tab) MUST remain.
+            Assert.Contains("ImageUnitPalette_Write_Button", src);
+            Assert.Contains("ImageUnitPalette_PaletteWrite_Button", src);
+        }
+
+        // ===== B2: palette R/G/B header aligned with spinner tracks =====
+
+        [Fact]
+        public void B2_MismatchedHeaderColumnDefinitions_AreRemoved()
+        {
+            // The old 8-column header definition that misaligned R/G/B must be gone.
+            Assert.DoesNotContain("ColumnDefinitions=\"Auto,Auto,Auto,Auto,40,60,60,60\"", Src);
+        }
+
+        [Theory]
+        [InlineData("ImageUnitPalette_R_Header_Label", "2")]
+        [InlineData("ImageUnitPalette_G_Header_Label", "3")]
+        [InlineData("ImageUnitPalette_B_Header_Label", "4")]
+        public void B2_HeaderLabel_SitsOverSpinnerColumn(string automationId, string expectedColumn)
+        {
+            var src = Src;
+
+            // Capture every <TextBlock ...> opening tag (XAML disallows '>' inside
+            // attribute values without escaping, so a non-greedy match to the next
+            // '>' is safe). Find the one carrying this header's AutomationId and
+            // assert its Grid.Column — order-independent so attribute re-orderings
+            // don't break the test.
+            var matches = Regex.Matches(src, @"<TextBlock\b[^>]*?>", RegexOptions.Singleline);
+            foreach (Match m in matches)
+            {
+                var tag = m.Value;
+                if (tag.Contains($"AutomationId=\"{automationId}\""))
+                {
+                    Assert.Contains($"Grid.Column=\"{expectedColumn}\"", tag);
+                    return;
+                }
+            }
+
+            Assert.Fail(
+                $"Expected a <TextBlock> with AutomationId=\"{automationId}\" "
+                + $"and Grid.Column=\"{expectedColumn}\", but none was found.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Two layout fixes on the Avalonia **Unit Palette Editor** (`ImageUnitPaletteView`):
- **B1:** removed the stray inert `Write` text label that sat after "Selected Address:" in the header bar (it was a `TextBlock`, not a button — the real actions are the Edit-tab **Write** button and the Palette-tab **Palette Write** button).
- **B2:** aligned the Palette-tab Column-1 `R`/`G`/`B` headers with their spinner columns. The header row used a mismatched 8-track `ColumnDefinitions="Auto,Auto,Auto,Auto,40,60,60,60"` (R/G/B at cols 5/6/7) while the swatch rows use `30,40,60,60,60` (R/G/B spinners at cols 2/3/4) — so the headers sat ~25px left of their columns. The header now uses the same `30,40,60,60,60` track with R/G/B at cols 2/3/4.

Closes #984. The preview/class-resolution part of the original report (empty Battle Animation + no sample preview) was split to **#985** because a faithful fix requires porting the WinForms `MakeClassList` palette→class reverse-mapping (per the Copilot plan review) — that's a port, scheduled for the ports phase.

Plan reviewed & accepted by Copilot CLI on the issue (the layout-only scope was explicitly approved: "stray header `Write` removal and first-column R/G/B header track alignment look correct as planned").

## Test plan
- [x] `dotnet build FEBuilderGBA.Avalonia` — 0 errors
- [x] New static AXAML tests `ImageUnitPaletteLayoutTests` (B1: `ImageUnitPalette_Write_Label` gone, header grid now 4-col `Auto,Auto,Auto,Auto`, real Write/PaletteWrite buttons present; B2: mismatched `Auto,Auto,Auto,Auto,40,60,60,60` gone, R/G/B headers at `Grid.Column 2/3/4`) — **6 passed**
- [x] `FEBuilderGBA.Avalonia.Tests` `~ImageUnitPalette` parity suite (stale `ImageUnitPalette_Write_Label` assertion removed) — **25 passed**
- [x] Repo-wide grep for `ImageUnitPalette_Write_Label` — only one stale test reference, updated; zero references remain
- [x] Launched the running Avalonia app on `roms/FE8U.gba`, opened the editor, selected the Palette tab, captured before/after of the live editor (below)

## GUI Test Report
| Case | Result |
|------|--------|
| Header bar no longer shows the inert "Write" label after Selected Address | PASS |
| Edit-tab **Write** button + Palette-tab **Palette Write** button still functional | PASS |
| Palette tab `R`/`G`/`B` headers centered over their respective spinner columns | PASS |
| Swatch indices 5–16 (palette columns 2–4) unchanged | PASS |
| First entry (`0x00 mer`) auto-loads with populated swatches | PASS |

Captured via UIAutomation navigation + PrintWindow (screen locked); the "after" is the worktree build (PID confirmed from the worktree path), the "before" is a clean master build.

## Screenshots
**Before** — inert "Write" label in header; `R`/`G`/`B` headers shifted left of their spinner columns:

![before](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr984-unitpalette-layout-before.png)

**After** — no stray "Write" label; `R`/`G`/`B` headers centered over their spinner columns:

![after](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr984-unitpalette-layout-after.png)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
