### PR TITLE
fix(avalonia): Background Image Editor References list — port Core BG cross-reference finder (#990)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -691,8 +691,9 @@ Specialized utilities for different graphic types:
   shop=0x13-0x15), ALWAYS (fixed 12, ptr+4), TUTORIAL (fixed 4, ptr+0,
   `!isPointer` stop), START/END (the cond-slot addr itself), + FE7 tutorial.
   `FindAllArgReferences(rom, argType, keepZeroId)` GATES on
-  `CoreState.EventScript != null && ReferenceEquals(CoreState.ROM, rom)` (the
-  disasm path dereferences static `CoreState.ROM`/`CommentCache`), disassembles
+  `CoreState.EventScript != null && ReferenceEquals(CoreState.ROM, rom) &&
+  CoreState.CommentCache != null` (the disasm path dereferences static
+  `CoreState.ROM` AND `CoreState.CommentCache.At`), disassembles
   each entry (`es.DisAseemble`) iterating EVERY non-UNKNOWN command's args (10-
   UNKNOWN cutoff + 4096-step guard + EOF bound, IF/LABEL→lastBranchAddr for
   `IsExitCode`), recurses through `POINTER_EVENT` with a tracelist cycle guard,
@@ -712,7 +713,13 @@ Specialized utilities for different graphic types:
   bgId)` builds the full `bgId→refs` map once per loaded ROM (cache keyed by ROM
   instance identity — a new ROM load rebuilds; within-session edits don't
   invalidate, matching WF's own cache-staleness model) and returns a COPY of the
-  bucket. `ResetCache()` for tests. The Avalonia `ImageBGViewModel.RefreshXrefs(bgId)`
+  bucket. CACHE-POISONING GUARD (#992): it PRE-CHECKS the scanner prerequisites
+  (`EventScript` + `CommentCache` wired AND `rom` is the active `CoreState.ROM`)
+  and, when NOT satisfied, returns empty WITHOUT caching — so an early/headless
+  call before CoreState finished initializing can't pin the same ROM instance to
+  a permanently-empty cache (the References list would never populate). Only a
+  real scan (prereqs satisfied) sets `_cachedRom`. `ResetCache()` for tests. The
+  Avalonia `ImageBGViewModel.RefreshXrefs(bgId)`
   (mirroring `ImageBattleBGViewModel.RefreshXrefs`) calls it from `LoadEntry`; the
   View's existing `XRefList.ItemsSource = XRefEntries.Select(x=>x.name)` binding
   projects the populated list. Same residual gaps as the scanner.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -679,6 +679,43 @@ Specialized utilities for different graphic types:
   address (`U.isSafetyOffset`) — never throws. The Avalonia
   `ImageUnitPaletteView.OnSelected` calls it after `SelectedPaletteSlot` is set,
   before `UpdateUI`, then `RefreshSamplePreview` renders.
+- `EventScriptReferenceScanner.cs` (Core, READ-ONLY) - Generic cross-platform
+  event-script cross-reference scanner (#990). `EnumerateEventEntries(rom)` is a
+  faithful port of WinForms `EventCondForm.MakeEventScriptPointer` (+ the FE7-only
+  `MakeEventScriptForFE7Tutorial` table) — it walks every map's event-condition
+  table via `MapSettingCore.MakeMapIDList` + `MapEventUnitCore.GetEventAddrForMap`/
+  `GetCondSlots` and yields each event-script entry point with VERIFIED per-cond
+  geometry: TURN (stride `eventcond_tern_size`, ptr `p32(addr+4)`, FE7 short-turn
+  `type==1`→`addr+=12`), TALK (`eventcond_talk_size`, ptr+4), OBJECT (fixed 12,
+  ptr+4, SKIP shop/chest — FE8 chest=0x14 shop=0x16-0x18, FE6/7 chest=0x12
+  shop=0x13-0x15), ALWAYS (fixed 12, ptr+4), TUTORIAL (fixed 4, ptr+0,
+  `!isPointer` stop), START/END (the cond-slot addr itself), + FE7 tutorial.
+  `FindAllArgReferences(rom, argType, keepZeroId)` GATES on
+  `CoreState.EventScript != null && ReferenceEquals(CoreState.ROM, rom)` (the
+  disasm path dereferences static `CoreState.ROM`/`CommentCache`), disassembles
+  each entry (`es.DisAseemble`) iterating EVERY non-UNKNOWN command's args (10-
+  UNKNOWN cutoff + 4096-step guard + EOF bound, IF/LABEL→lastBranchAddr for
+  `IsExitCode`), recurses through `POINTER_EVENT` with a tracelist cycle guard,
+  buckets each `argType` ref by id value (`v>=0x7FFF` skipped, `v==0` dropped
+  unless `keepZeroId`), and DEDUPs each bucket by event-script-start address
+  (matches WF `UseValsID.RemoveDuplicates` for a single id). `ScanScriptForArg`
+  is exposed `internal` (InternalsVisibleTo Core.Tests) for synthetic tests.
+  DOCUMENTED RESIDUAL GAPS (event-script refs only): patch-config refs
+  (MULTICG/BGICON, the WF `PatchForm` struct-install scanner — WinForms-bound,
+  not ported) and ASM/MAP symbol refs (the WF `AsmMapFileAsmCache.GetVarsIDArray`
+  master list — headless ASM/MAP cache is a no-op) are NOT covered.
+- `BGReferenceFinder.cs` (Core, READ-ONLY) - Thin `ArgType.BG` wrapper over
+  `EventScriptReferenceScanner.FindAllArgReferences(rom, ArgType.BG,
+  keepZeroId:true)` with a per-ROM-instance cache (#990; restores the Avalonia
+  Background Image editor's always-empty References list, the WF
+  `InputFormRef.UpdateRef(X_REF, id, BG)` event-script source). `MakeListByUseBG(rom,
+  bgId)` builds the full `bgId→refs` map once per loaded ROM (cache keyed by ROM
+  instance identity — a new ROM load rebuilds; within-session edits don't
+  invalidate, matching WF's own cache-staleness model) and returns a COPY of the
+  bucket. `ResetCache()` for tests. The Avalonia `ImageBGViewModel.RefreshXrefs(bgId)`
+  (mirroring `ImageBattleBGViewModel.RefreshXrefs`) calls it from `LoadEntry`; the
+  View's existing `XRefList.ItemsSource = XRefEntries.Select(x=>x.name)` binding
+  projects the populated list. Same residual gaps as the scanner.
 
 ### Caching System
 

--- a/FEBuilderGBA.Avalonia.Tests/ImageBGViewXrefTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageBGViewXrefTests.cs
@@ -26,8 +26,6 @@ namespace FEBuilderGBA.Avalonia.Tests
     [Collection("SharedState")]
     public class ImageBGViewXrefTests
     {
-        const uint SIZE = 12; // ImageBGViewModel.SIZE
-
         [AvaloniaFact]
         public void XRefList_PopulatedForReferencedBg()
         {

--- a/FEBuilderGBA.Avalonia.Tests/ImageBGViewXrefTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageBGViewXrefTests.cs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Headless Avalonia regression test for the Background Image Editor References
+// list (#990). Proves the ImageBGView XRefList binding projects a POPULATED
+// list (not a permanent empty stub) for a runtime-discovered referenced BG id.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// Loads a real ROM, wires CoreState.EventScript, discovers a referenced BG
+    /// id via the Core BGReferenceFinder, selects that BG slot in ImageBGView,
+    /// and asserts XRefList.ItemsSource is non-null, its count matches the VM's
+    /// XRefEntries, and is > 0 for the discovered id.
+    /// </summary>
+    [Collection("SharedState")]
+    public class ImageBGViewXrefTests
+    {
+        const uint SIZE = 12; // ImageBGViewModel.SIZE
+
+        [AvaloniaFact]
+        public void XRefList_PopulatedForReferencedBg()
+        {
+            string romPath = FindRom("FE8U.gba") ?? FindRom("FE7U.gba") ?? FindRom("FE6.gba");
+            if (romPath == null) return; // skip when no ROM present
+
+            var savedRom = CoreState.ROM;
+            var savedEs = CoreState.EventScript;
+            var savedEnc = CoreState.SystemTextEncoder;
+            var savedComment = CoreState.CommentCache;
+            var savedBaseDir = CoreState.BaseDirectory;
+            var savedSvc = CoreState.ImageService;
+            try
+            {
+                string asmDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                CoreState.BaseDirectory = asmDir;
+
+                var rom = new ROM();
+                if (!rom.Load(romPath, out string _)) return;
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+                if (CoreState.CommentCache == null)
+                    CoreState.CommentCache = new HeadlessEtcCache();
+                if (CoreState.ImageService == null)
+                    CoreState.ImageService = new FEBuilderGBA.SkiaSharp.SkiaImageService();
+
+                var es = new EventScript();
+                es.Load(EventScript.EventScriptType.Event);
+                CoreState.EventScript = es;
+
+                BGReferenceFinder.ResetCache();
+
+                // BG table base (so we can map a bgId -> table-row address).
+                uint ptr = rom.RomInfo.bg_pointer;
+                Assert.NotEqual(0u, ptr);
+                uint baseAddr = rom.p32(ptr);
+                Assert.True(U.isSafetyOffset(baseAddr, rom));
+
+                // Show the view (Opened -> LoadList populates EntryList).
+                var view = new ImageBGView();
+                view.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var entryList = view.FindControl<FEBuilderGBA.Avalonia.Controls.AddressListControl>("EntryList");
+                Assert.NotNull(entryList);
+                var items = entryList!.GetItems();
+                Assert.NotEmpty(items);
+
+                // Find the FIRST list row (a valid BG table slot) whose bgId is
+                // referenced by an event script. The row tag == bgId == row index.
+                uint? targetAddr = null;
+                int expectedRefCount = 0;
+                foreach (var item in items)
+                {
+                    uint bgId = item.tag;
+                    var refs = BGReferenceFinder.MakeListByUseBG(rom, bgId);
+                    if (refs.Count > 0)
+                    {
+                        targetAddr = item.addr;
+                        expectedRefCount = refs.Count;
+                        break;
+                    }
+                }
+
+                Assert.True(targetAddr.HasValue,
+                    "Expected at least one listed BG slot to be referenced by an event script in a vanilla ROM");
+
+                // Drive the user-equivalent selection path.
+                entryList.SelectAddress(targetAddr!.Value);
+                Dispatcher.UIThread.RunJobs();
+
+                var xrefList = view.FindControl<ListBox>("XRefList");
+                Assert.NotNull(xrefList);
+                Assert.NotNull(xrefList!.ItemsSource);
+
+                int listCount = CountItems(xrefList.ItemsSource);
+                Assert.True(listCount > 0,
+                    "References list must be populated for the discovered referenced BG id");
+
+                // Count must equal the VM's XRefEntries (the binding projects the
+                // VM list 1:1).
+                var vm = GetViewModel(view);
+                Assert.NotNull(vm);
+                var xrefEntries = (System.Collections.IList)vm!.GetType()
+                    .GetProperty("XRefEntries")!.GetValue(vm)!;
+                Assert.Equal(xrefEntries.Count, listCount);
+                Assert.Equal(expectedRefCount, listCount);
+
+                view.Close();
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.EventScript = savedEs;
+                CoreState.SystemTextEncoder = savedEnc;
+                CoreState.CommentCache = savedComment;
+                CoreState.ImageService = savedSvc;
+                if (savedBaseDir != null)
+                    CoreState.BaseDirectory = savedBaseDir;
+                BGReferenceFinder.ResetCache();
+            }
+        }
+
+        static int CountItems(IEnumerable source)
+        {
+            int n = 0;
+            foreach (var _ in source) n++;
+            return n;
+        }
+
+        static object GetViewModel(ImageBGView view)
+        {
+            var f = typeof(ImageBGView).GetField("_vm",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            return f?.GetValue(view);
+        }
+
+        static string FindRom(string romName)
+        {
+            // Reuse TestRomLocator's resolved roms/ dir.
+            string dir = TestRomLocator.RomsDir;
+            if (dir == null) return null;
+            string path = Path.Combine(dir, romName);
+            return File.Exists(path) ? path : null;
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageBGViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageBGViewModel.cs
@@ -22,10 +22,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         uint _selectAddress;
 
         // Comment + cross-references (mirror the WinForms panel2 Comment +
-        // X_REF list). X_REF is scaffolded with an empty list — the WF
-        // path uses `InputFormRef.UpdateRef(..., BG)` which reads from
-        // AsmMapFileAsmCache (WinForms-bound); a future PR can port the
-        // Core scanner. See #429 plan.
+        // X_REF list). X_REF is populated from the Core event-script BG
+        // cross-reference finder (FEBuilderGBA.BGReferenceFinder), mirroring
+        // the WF `InputFormRef.UpdateRef(..., BG)` event-script source. Patch
+        // metadata + ASM/MAP symbol references remain documented residual gaps
+        // (see EventScriptReferenceScanner). #990.
         string _comment = string.Empty;
         List<AddrResult> _xrefEntries = new();
 
@@ -135,6 +136,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             IsBG256Patched = FEBuilderGBA.PatchDetection.HasBG256ColorPatch(rom);
 
             RefreshComment();
+            RefreshXrefs((uint)index);
             RefreshSourceFile((uint)index);
             RefreshWarningMessage((uint)index);
 
@@ -168,6 +170,24 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (cache == null) return;
             if (CurrentAddr == 0) return;
             cache.Update(CurrentAddr, Comment);
+        }
+
+        /// <summary>
+        /// Refresh the X_REF cross-reference list by finding every event-script
+        /// command that references BG slot <paramref name="bgId"/>. Delegates to
+        /// <see cref="FEBuilderGBA.BGReferenceFinder.MakeListByUseBG"/> (mirrors
+        /// the WinForms `InputFormRef.UpdateRef(..., BG)` event-script source).
+        /// Patch metadata + ASM/MAP references are documented residual gaps.
+        /// </summary>
+        public void RefreshXrefs(uint bgId)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null)
+            {
+                XRefEntries = new List<AddrResult>();
+                return;
+            }
+            XRefEntries = FEBuilderGBA.BGReferenceFinder.MakeListByUseBG(rom, bgId);
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/Views/ImageBGView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBGView.axaml.cs
@@ -267,7 +267,8 @@ namespace FEBuilderGBA.Avalonia.Views
             CommentBox.Text = _vm.Comment;
             BlockSizeBox.Text = $"0x{_vm.BlockSize:X}";
 
-            // X_REF list (scaffold — empty for now; see VM comment).
+            // X_REF list — populated from the Core event-script BG
+            // cross-reference finder via ImageBGViewModel.RefreshXrefs (#990).
             XRefList.ItemsSource = _vm.XRefEntries
                 .Select(x => x.name).ToList();
 

--- a/FEBuilderGBA.Core.Tests/BGReferenceFinderTests.cs
+++ b/FEBuilderGBA.Core.Tests/BGReferenceFinderTests.cs
@@ -119,6 +119,103 @@ namespace FEBuilderGBA.Core.Tests
             }
         }
 
+        /// <summary>
+        /// CACHE-POISONING regression (#992 Copilot review): calling the finder
+        /// BEFORE CoreState is fully wired (prereqs unsatisfied) must NOT cache
+        /// an empty result for that ROM instance. After CoreState is wired
+        /// (ROM active + EventScript + CommentCache), calling again with the SAME
+        /// rom instance must rebuild and return the real (non-empty) list.
+        /// </summary>
+        [Fact]
+        public void RealRom_FE8U_NotReadyThenReady_RebuildsAndPopulates()
+        {
+            string romPath = FindRom("FE8U.gba");
+            if (romPath == null) return; // skip
+
+            var savedRom = CoreState.ROM;
+            var savedEs = CoreState.EventScript;
+            var savedEnc = CoreState.SystemTextEncoder;
+            var savedComment = CoreState.CommentCache;
+            var savedBaseDir = CoreState.BaseDirectory;
+            try
+            {
+                string asmDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                CoreState.BaseDirectory = asmDir;
+
+                var rom = new ROM();
+                if (!rom.Load(romPath, out string _)) return;
+
+                BGReferenceFinder.ResetCache();
+
+                // PHASE 1 — prerequisites NOT ready: ROM is not the active
+                // CoreState.ROM, no EventScript, no CommentCache.
+                CoreState.ROM = null;
+                CoreState.EventScript = null;
+                CoreState.CommentCache = null;
+
+                // Discover a referenced BG id up-front (needs a wired scan), so
+                // we do a temporary full init just to find the id, then tear it
+                // back down to the not-ready state for the actual assertion.
+                uint referencedBg;
+                {
+                    CoreState.ROM = rom;
+                    CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+                    CoreState.CommentCache = new HeadlessEtcCache();
+                    var probeEs = new EventScript();
+                    probeEs.Load(EventScript.EventScriptType.Event);
+                    CoreState.EventScript = probeEs;
+
+                    var fullMap = EventScriptReferenceScanner.FindAllArgReferences(
+                        rom, EventScript.ArgType.BG, keepZeroId: true);
+                    referencedBg = 0;
+                    bool found = false;
+                    foreach (var kv in fullMap)
+                    {
+                        if (kv.Value != null && kv.Value.Count > 0)
+                        {
+                            referencedBg = kv.Key;
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found) return; // no referenced BG — nothing to assert
+                }
+
+                // Tear back down to NOT-READY and reset the finder cache.
+                CoreState.ROM = null;
+                CoreState.EventScript = null;
+                CoreState.CommentCache = null;
+                BGReferenceFinder.ResetCache();
+
+                // PHASE 1 call (prereqs unsatisfied) → empty AND must not cache.
+                var notReady = BGReferenceFinder.MakeListByUseBG(rom, referencedBg);
+                Assert.Empty(notReady);
+
+                // PHASE 2 — wire CoreState fully with the SAME rom instance.
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+                CoreState.CommentCache = new HeadlessEtcCache();
+                var es = new EventScript();
+                es.Load(EventScript.EventScriptType.Event);
+                CoreState.EventScript = es;
+
+                // Same rom instance — if PHASE 1 had cached the empty result,
+                // this would stay empty forever. It must rebuild and populate.
+                var ready = BGReferenceFinder.MakeListByUseBG(rom, referencedBg);
+                Assert.NotEmpty(ready);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.EventScript = savedEs;
+                CoreState.SystemTextEncoder = savedEnc;
+                CoreState.CommentCache = savedComment;
+                if (savedBaseDir != null)
+                    CoreState.BaseDirectory = savedBaseDir;
+                BGReferenceFinder.ResetCache();
+            }
+        }
+
         static string FindRom(string romName)
         {
             string thisAssembly = Assembly.GetExecutingAssembly().Location;

--- a/FEBuilderGBA.Core.Tests/BGReferenceFinderTests.cs
+++ b/FEBuilderGBA.Core.Tests/BGReferenceFinderTests.cs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for BGReferenceFinder (#990) — the thin ArgType.BG wrapper + per-ROM
+// cache over EventScriptReferenceScanner.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class BGReferenceFinderTests
+    {
+        [Fact]
+        public void MakeListByUseBG_NullRom_ReturnsEmpty()
+        {
+            BGReferenceFinder.ResetCache();
+            var list = BGReferenceFinder.MakeListByUseBG(null, 0);
+            Assert.NotNull(list);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void MakeListByUseBG_Gating_NonActiveRom_ReturnsEmpty()
+        {
+            BGReferenceFinder.ResetCache();
+            var prevRom = CoreState.ROM;
+            var prevEs = CoreState.EventScript;
+            try
+            {
+                CoreState.ROM = null; // no active ROM -> gating returns empty
+                CoreState.EventScript = null;
+
+                var rom = new ROM();
+                rom.LoadLow("bg-fe8u.gba", new byte[0x1000000], "BE8E01");
+                var list = BGReferenceFinder.MakeListByUseBG(rom, 1);
+                Assert.NotNull(list);
+                Assert.Empty(list);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.EventScript = prevEs;
+                BGReferenceFinder.ResetCache();
+            }
+        }
+
+        [Fact]
+        public void RealRom_FE8U_MakeListByUseBG_FindsReferencedBg_HighIdEmpty_CacheReuse()
+        {
+            string romPath = FindRom("FE8U.gba");
+            if (romPath == null) return; // skip
+
+            var savedRom = CoreState.ROM;
+            var savedEs = CoreState.EventScript;
+            var savedEnc = CoreState.SystemTextEncoder;
+            var savedComment = CoreState.CommentCache;
+            var savedBaseDir = CoreState.BaseDirectory;
+            try
+            {
+                string asmDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                CoreState.BaseDirectory = asmDir;
+
+                var rom = new ROM();
+                if (!rom.Load(romPath, out string _)) return;
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+                if (CoreState.CommentCache == null)
+                    CoreState.CommentCache = new HeadlessEtcCache();
+                var es = new EventScript();
+                es.Load(EventScript.EventScriptType.Event);
+                CoreState.EventScript = es;
+
+                BGReferenceFinder.ResetCache();
+
+                // Discover a referenced BG id directly from the full map.
+                var fullMap = EventScriptReferenceScanner.FindAllArgReferences(
+                    rom, EventScript.ArgType.BG, keepZeroId: true);
+                Assert.NotEmpty(fullMap);
+
+                uint referencedBg = 0;
+                bool found = false;
+                foreach (var kv in fullMap)
+                {
+                    if (kv.Value != null && kv.Value.Count > 0)
+                    {
+                        referencedBg = kv.Key;
+                        found = true;
+                        break;
+                    }
+                }
+                Assert.True(found, "a referenced BG id must exist in a vanilla FE8U ROM");
+
+                // The wrapper must return a non-empty list for that id.
+                var refs = BGReferenceFinder.MakeListByUseBG(rom, referencedBg);
+                Assert.NotEmpty(refs);
+
+                // The wrapper returns a COPY (mutating it must not corrupt the cache).
+                int before = refs.Count;
+                refs.Clear();
+                var refsAgain = BGReferenceFinder.MakeListByUseBG(rom, referencedBg);
+                Assert.Equal(before, refsAgain.Count);
+
+                // An unused high id must be empty.
+                var high = BGReferenceFinder.MakeListByUseBG(rom, 0x7000);
+                Assert.Empty(high);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.EventScript = savedEs;
+                CoreState.SystemTextEncoder = savedEnc;
+                CoreState.CommentCache = savedComment;
+                if (savedBaseDir != null)
+                    CoreState.BaseDirectory = savedBaseDir;
+                BGReferenceFinder.ResetCache();
+            }
+        }
+
+        static string FindRom(string romName)
+        {
+            string thisAssembly = Assembly.GetExecutingAssembly().Location;
+            string dir = Path.GetDirectoryName(thisAssembly);
+            for (int i = 0; i < 10 && dir != null; i++)
+            {
+                if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                {
+                    string path = Path.Combine(dir, "roms", romName);
+                    if (File.Exists(path)) return path;
+                    break;
+                }
+                dir = Path.GetDirectoryName(dir);
+            }
+            return null;
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/EventScriptReferenceScannerTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventScriptReferenceScannerTests.cs
@@ -60,7 +60,7 @@ namespace FEBuilderGBA.Core.Tests
             => EventScript.ParseScriptLine("03000000XXXXXXXX\tCALL [X:POINTER_EVENT:Target]");
 
         /// <summary>
-        /// Run an action with CoreState wired to a fresh 2MB synthetic ROM +
+        /// Run an action with CoreState wired to a fresh 16MB synthetic ROM +
         /// the given EventScript, restoring prior CoreState afterwards.
         /// </summary>
         static void WithSyntheticEnv(EventScript es, System.Action<ROM> body)
@@ -273,11 +273,99 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void FindAllArgReferences_Gating_NullCommentCache_ReturnsEmpty()
+        {
+            // #992 Copilot review #3: es.DisAseemble dereferences
+            // CoreState.CommentCache, so a null CommentCache must gate out (no
+            // NullRef) even when ROM + EventScript are wired.
+            var es = BuildEventScript(BgCommand(), TermCommand());
+            var prevRom = CoreState.ROM;
+            var prevEs = CoreState.EventScript;
+            var prevComment = CoreState.CommentCache;
+            try
+            {
+                var rom = new ROM();
+                rom.LoadLow("nocomment-fe8u.gba", new byte[0x1000000], "BE8E01");
+                CoreState.ROM = rom;
+                CoreState.EventScript = es;
+                CoreState.CommentCache = null;
+
+                var map = EventScriptReferenceScanner.FindAllArgReferences(
+                    rom, EventScript.ArgType.BG, keepZeroId: true);
+                Assert.Empty(map);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.EventScript = prevEs;
+                CoreState.CommentCache = prevComment;
+            }
+        }
+
+        [Fact]
         public void EnumerateEventEntries_NullRom_ReturnsEmpty()
         {
             var list = EventScriptReferenceScanner.EnumerateEventEntries(null);
             Assert.NotNull(list);
             Assert.Empty(list);
+        }
+
+        /// <summary>
+        /// #992 Copilot review #2: a TURN cond record sitting at the very end of
+        /// ROM must NOT throw (U.u32/u8 throw past EOF). WalkTurn now bounds-checks
+        /// the current record before reading. We plant a map whose TURN cond-slot
+        /// points at an address near EOF and assert EnumerateEventEntries (which
+        /// drives WalkTurn) never throws.
+        /// </summary>
+        [Fact]
+        public void EnumerateEventEntries_TurnRecordNearEOF_DoesNotThrow()
+        {
+            var prevRom = CoreState.ROM;
+            try
+            {
+                var rom = new ROM();
+                rom.LoadLow("eof-fe8u.gba", new byte[0x1000000], "BE8E01");
+                CoreState.ROM = rom;
+
+                uint romLen = (uint)rom.Data.Length;
+
+                // 1) Plant a valid map setting (id 0) with event_plist = 1.
+                uint mapTableBase = 0x00700000u;
+                uint dataSize = rom.RomInfo.map_setting_datasize;
+                WriteU32(rom, rom.RomInfo.map_setting_pointer, mapTableBase | 0x08000000u);
+                WriteU32(rom, mapTableBase + 0, 0x08123456u); // first dword = pointer → valid
+                rom.Data[mapTableBase + rom.RomInfo.map_setting_event_plist_pos] = 1;
+                // Terminator row: next record's first dword = 0 (non-pointer).
+                WriteU32(rom, mapTableBase + dataSize, 0x00000000u);
+
+                // 2) map_event_pointer table: entry[1] → cond block.
+                uint eventTableBase = 0x00710000u;
+                WriteU32(rom, rom.RomInfo.map_event_pointer, eventTableBase | 0x08000000u);
+                uint condBlock = 0x00720000u;
+                WriteU32(rom, eventTableBase + 1 * 4, condBlock | 0x08000000u);
+
+                // 3) Cond block slot 0 (Turn) → a turn record placed 2 bytes
+                //    before EOF, so the unguarded u32(addr) read would throw.
+                uint turnRec = romLen - 2;
+                WriteU32(rom, condBlock + 0, turnRec | 0x08000000u);
+
+                // Must NOT throw despite the near-EOF turn record.
+                var ex = Record.Exception(() =>
+                    EventScriptReferenceScanner.EnumerateEventEntries(rom));
+                Assert.Null(ex);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+            }
+        }
+
+        static void WriteU32(ROM rom, uint offset, uint value)
+        {
+            rom.Data[offset + 0] = (byte)(value & 0xFF);
+            rom.Data[offset + 1] = (byte)((value >> 8) & 0xFF);
+            rom.Data[offset + 2] = (byte)((value >> 16) & 0xFF);
+            rom.Data[offset + 3] = (byte)((value >> 24) & 0xFF);
         }
 
         // =================================================================

--- a/FEBuilderGBA.Core.Tests/EventScriptReferenceScannerTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventScriptReferenceScannerTests.cs
@@ -1,0 +1,410 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for EventScriptReferenceScanner (#990) — the generic READ-ONLY
+// event-script cross-reference scanner that backs BGReferenceFinder.
+//
+// Two layers:
+//   1. SYNTHETIC scratch-ROM scanner tests — build a minimal EventScript with a
+//      BG-typed arg command (+ POINTER_EVENT for recursion), plant the bytes in
+//      a scratch region of a loaded ROM, set it as CoreState.EventScript, and
+//      assert ScanScriptForArg (exposed internal via InternalsVisibleTo) finds
+//      the planted id. Covers BG match, POINTER_EVENT recursion, self-cycle
+//      (no hang), bgId 0 kept, keepZeroId:false drops 0, and the 0x7FFF skip.
+//   2. REAL-ROM enumeration / find tests — load FE6/FE7U/FE8U (skipped when
+//      absent), wire CoreState.EventScript from the shipped config, and assert
+//      FindAllArgReferences(BG) is non-empty (non-stub proof) and the FE7U
+//      enumeration includes a "Tutorial FE7" entry.
+//
+// NOTE: exhaustive per-cond-type synthetic ROM construction (Turn short-turn,
+// Talk, Object shop/chest skip, Always, Tutorial, Start/End geometry) is
+// approximated by the real-ROM enumeration tests — vanilla ROMs contain every
+// cond type — because hand-building a full multi-map cond table is far more
+// fragile than the disasm-level synthetic tests above.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class EventScriptReferenceScannerTests
+    {
+        // =================================================================
+        // Synthetic scratch-ROM scanner tests.
+        // =================================================================
+
+        // Scratch region inside the 16MB synthetic ROM where we plant events.
+        const uint Scratch = 0x00100000u;
+        const int RomSize = 0x1000000; // 16MB — FE8 LoadLow minimum.
+
+        static EventScript BuildEventScript(params EventScript.Script[] scripts)
+        {
+            var es = new EventScript();
+            var prop = typeof(EventScript).GetProperty("Scripts");
+            prop!.SetValue(es, scripts);
+            return es;
+        }
+
+        // A command "01 00 XXXX" — opcode 0x0001 then a 2-byte BG arg at byte 2.
+        static EventScript.Script BgCommand()
+            => EventScript.ParseScriptLine("0100XXXX\tSETBG [XXXX:BG:Background]");
+
+        // A terminator command "0A 00 00 00".
+        static EventScript.Script TermCommand()
+            => EventScript.ParseScriptLine("0A000000\tENDA [TERM]");
+
+        // A CALL command "03 00 00 00 XXXXXXXX" — a 4-byte POINTER_EVENT arg.
+        static EventScript.Script CallCommand()
+            => EventScript.ParseScriptLine("03000000XXXXXXXX\tCALL [X:POINTER_EVENT:Target]");
+
+        /// <summary>
+        /// Run an action with CoreState wired to a fresh 2MB synthetic ROM +
+        /// the given EventScript, restoring prior CoreState afterwards.
+        /// </summary>
+        static void WithSyntheticEnv(EventScript es, System.Action<ROM> body)
+        {
+            var prevRom = CoreState.ROM;
+            var prevEs = CoreState.EventScript;
+            var prevComment = CoreState.CommentCache;
+            try
+            {
+                var rom = new ROM();
+                rom.LoadLow("scratch-fe8u.gba", new byte[RomSize], "BE8E01");
+                CoreState.ROM = rom;
+                CoreState.EventScript = es;
+                // DisAseemble dereferences CoreState.CommentCache — always wire it.
+                CoreState.CommentCache = new HeadlessEtcCache();
+                body(rom);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.EventScript = prevEs;
+                CoreState.CommentCache = prevComment;
+            }
+        }
+
+        [Fact]
+        public void ScanScriptForArg_FindsPlantedBG()
+        {
+            var es = BuildEventScript(BgCommand(), TermCommand());
+            WithSyntheticEnv(es, rom =>
+            {
+                // SETBG bgId=0x0042 ; ENDA
+                rom.write_u16(Scratch + 0, 0x0001);
+                rom.write_u16(Scratch + 2, 0x0042);
+                rom.write_u32(Scratch + 4, 0x0000000A);
+
+                var bucket = new Dictionary<uint, List<AddrResult>>();
+                var trace = new List<uint>();
+                EventScriptReferenceScanner.ScanScriptForArg(
+                    rom, es, Scratch, "MAP 0 test",
+                    EventScript.ArgType.BG, keepZeroId: true, trace, bucket);
+
+                Assert.True(bucket.ContainsKey(0x42), "BG id 0x42 must be found");
+                Assert.Single(bucket[0x42]);
+                Assert.Equal(Scratch, bucket[0x42][0].addr);
+            });
+        }
+
+        [Fact]
+        public void ScanScriptForArg_RecursesThroughPointerEvent()
+        {
+            var es = BuildEventScript(CallCommand(), BgCommand(), TermCommand());
+            WithSyntheticEnv(es, rom =>
+            {
+                // Nested event at Scratch+0x100: SETBG 0x0077 ; ENDA
+                uint nested = Scratch + 0x100;
+                rom.write_u16(nested + 0, 0x0001);
+                rom.write_u16(nested + 2, 0x0077);
+                rom.write_u32(nested + 4, 0x0000000A);
+
+                // Root event: CALL nested ; ENDA
+                rom.write_u32(Scratch + 0, 0x00000003);
+                rom.write_u32(Scratch + 4, U.toPointer(nested));
+                rom.write_u32(Scratch + 8, 0x0000000A);
+
+                var bucket = new Dictionary<uint, List<AddrResult>>();
+                var trace = new List<uint>();
+                EventScriptReferenceScanner.ScanScriptForArg(
+                    rom, es, Scratch, "MAP 0 root",
+                    EventScript.ArgType.BG, keepZeroId: true, trace, bucket);
+
+                Assert.True(bucket.ContainsKey(0x77), "nested BG id 0x77 must be found via POINTER_EVENT recursion");
+                // The reference's event-start addr is the NESTED event start.
+                Assert.Equal(nested, bucket[0x77][0].addr);
+            });
+        }
+
+        [Fact]
+        public void ScanScriptForArg_SelfCyclePointerEvent_DoesNotHang()
+        {
+            var es = BuildEventScript(CallCommand(), TermCommand());
+            WithSyntheticEnv(es, rom =>
+            {
+                // CALL self ; (no real terminator reached on first command, but
+                // the tracelist guard must prevent infinite recursion).
+                rom.write_u32(Scratch + 0, 0x00000003);
+                rom.write_u32(Scratch + 4, U.toPointer(Scratch)); // points to itself
+                rom.write_u32(Scratch + 8, 0x0000000A);
+
+                var bucket = new Dictionary<uint, List<AddrResult>>();
+                var trace = new List<uint>();
+                // Must terminate (the test framework would hang otherwise).
+                EventScriptReferenceScanner.ScanScriptForArg(
+                    rom, es, Scratch, "MAP 0 cycle",
+                    EventScript.ArgType.BG, keepZeroId: true, trace, bucket);
+
+                Assert.Empty(bucket); // no BG arg present
+            });
+        }
+
+        [Fact]
+        public void ScanScriptForArg_BgIdZero_KeptWhenKeepZeroId()
+        {
+            var es = BuildEventScript(BgCommand(), TermCommand());
+            WithSyntheticEnv(es, rom =>
+            {
+                rom.write_u16(Scratch + 0, 0x0001);
+                rom.write_u16(Scratch + 2, 0x0000); // bgId 0
+                rom.write_u32(Scratch + 4, 0x0000000A);
+
+                var bucket = new Dictionary<uint, List<AddrResult>>();
+                var trace = new List<uint>();
+                EventScriptReferenceScanner.ScanScriptForArg(
+                    rom, es, Scratch, "MAP 0 zero",
+                    EventScript.ArgType.BG, keepZeroId: true, trace, bucket);
+
+                Assert.True(bucket.ContainsKey(0), "BG id 0 must be kept when keepZeroId:true");
+            });
+        }
+
+        [Fact]
+        public void ScanScriptForArg_BgIdZero_DroppedWhenNotKeepZeroId()
+        {
+            var es = BuildEventScript(BgCommand(), TermCommand());
+            WithSyntheticEnv(es, rom =>
+            {
+                rom.write_u16(Scratch + 0, 0x0001);
+                rom.write_u16(Scratch + 2, 0x0000); // bgId 0
+                rom.write_u32(Scratch + 4, 0x0000000A);
+
+                var bucket = new Dictionary<uint, List<AddrResult>>();
+                var trace = new List<uint>();
+                EventScriptReferenceScanner.ScanScriptForArg(
+                    rom, es, Scratch, "MAP 0 zero",
+                    EventScript.ArgType.BG, keepZeroId: false, trace, bucket);
+
+                Assert.False(bucket.ContainsKey(0), "BG id 0 must be dropped when keepZeroId:false");
+            });
+        }
+
+        [Fact]
+        public void ScanScriptForArg_HighId_Skipped()
+        {
+            var es = BuildEventScript(BgCommand(), TermCommand());
+            WithSyntheticEnv(es, rom =>
+            {
+                rom.write_u16(Scratch + 0, 0x0001);
+                rom.write_u16(Scratch + 2, 0x7FFF); // >= 0x7FFF, must be skipped
+                rom.write_u32(Scratch + 4, 0x0000000A);
+
+                var bucket = new Dictionary<uint, List<AddrResult>>();
+                var trace = new List<uint>();
+                EventScriptReferenceScanner.ScanScriptForArg(
+                    rom, es, Scratch, "MAP 0 high",
+                    EventScript.ArgType.BG, keepZeroId: true, trace, bucket);
+
+                Assert.Empty(bucket);
+            });
+        }
+
+        [Fact]
+        public void FindAllArgReferences_Gating_NullEventScript_ReturnsEmpty()
+        {
+            var prevRom = CoreState.ROM;
+            var prevEs = CoreState.EventScript;
+            try
+            {
+                var rom = new ROM();
+                rom.LoadLow("gate-fe8u.gba", new byte[0x1000000], "BE8E01");
+                CoreState.ROM = rom;
+                CoreState.EventScript = null;
+
+                var map = EventScriptReferenceScanner.FindAllArgReferences(
+                    rom, EventScript.ArgType.BG, keepZeroId: true);
+                Assert.Empty(map);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.EventScript = prevEs;
+            }
+        }
+
+        [Fact]
+        public void FindAllArgReferences_Gating_NonActiveRom_ReturnsEmpty()
+        {
+            var es = BuildEventScript(BgCommand(), TermCommand());
+            var prevRom = CoreState.ROM;
+            var prevEs = CoreState.EventScript;
+            try
+            {
+                var active = new ROM();
+                active.LoadLow("active-fe8u.gba", new byte[0x1000000], "BE8E01");
+                var other = new ROM();
+                other.LoadLow("other-fe8u.gba", new byte[0x1000000], "BE8E01");
+
+                CoreState.ROM = active;
+                CoreState.EventScript = es;
+
+                // Passing a ROM that is NOT the active CoreState.ROM must gate out.
+                var map = EventScriptReferenceScanner.FindAllArgReferences(
+                    other, EventScript.ArgType.BG, keepZeroId: true);
+                Assert.Empty(map);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.EventScript = prevEs;
+            }
+        }
+
+        [Fact]
+        public void EnumerateEventEntries_NullRom_ReturnsEmpty()
+        {
+            var list = EventScriptReferenceScanner.EnumerateEventEntries(null);
+            Assert.NotNull(list);
+            Assert.Empty(list);
+        }
+
+        // =================================================================
+        // Real-ROM enumeration / find tests (skipped when ROM absent).
+        // =================================================================
+
+        [Fact]
+        public void RealRom_FE8U_FindAllBG_NonEmpty()
+        {
+            RealRomFindBgNonEmpty("FE8U.gba");
+        }
+
+        [Fact]
+        public void RealRom_FE7U_FindAllBG_NonEmpty()
+        {
+            RealRomFindBgNonEmpty("FE7U.gba");
+        }
+
+        [Fact]
+        public void RealRom_FE6_FindAllBG_NonEmpty()
+        {
+            RealRomFindBgNonEmpty("FE6.gba");
+        }
+
+        [Fact]
+        public void RealRom_FE7U_Enumeration_IncludesTutorialFE7()
+        {
+            string romPath = FindRom("FE7U.gba");
+            if (romPath == null) return; // skip
+
+            WithRealRomEnv(romPath, rom =>
+            {
+                var entries = EventScriptReferenceScanner.EnumerateEventEntries(rom);
+                bool hasTutorial = false;
+                foreach (var e in entries)
+                {
+                    if (e.name == "Tutorial FE7") { hasTutorial = true; break; }
+                }
+                Assert.True(hasTutorial, "FE7U enumeration must include >=1 'Tutorial FE7' entry");
+            });
+        }
+
+        static void RealRomFindBgNonEmpty(string romName)
+        {
+            string romPath = FindRom(romName);
+            if (romPath == null) return; // skip
+
+            WithRealRomEnv(romPath, rom =>
+            {
+                var map = EventScriptReferenceScanner.FindAllArgReferences(
+                    rom, EventScript.ArgType.BG, keepZeroId: true);
+                Assert.NotEmpty(map);
+
+                // Non-stub proof: at least one bucket has at least one ref whose
+                // event-start address is a real in-ROM offset.
+                bool hasRealRef = false;
+                foreach (var kv in map)
+                {
+                    foreach (var r in kv.Value)
+                    {
+                        if (U.isSafetyOffset(r.addr, rom)) { hasRealRef = true; break; }
+                    }
+                    if (hasRealRef) break;
+                }
+                Assert.True(hasRealRef, $"{romName}: must find >=1 real BG reference");
+            });
+        }
+
+        // -----------------------------------------------------------------
+        // Real-ROM env: load ROM, wire CoreState (ROM/EventScript/caches/
+        // BaseDirectory) so the disasm path resolves the shipped event config.
+        // -----------------------------------------------------------------
+        static void WithRealRomEnv(string romPath, System.Action<ROM> body)
+        {
+            var savedRom = CoreState.ROM;
+            var savedEs = CoreState.EventScript;
+            var savedEnc = CoreState.SystemTextEncoder;
+            var savedComment = CoreState.CommentCache;
+            var savedBaseDir = CoreState.BaseDirectory;
+            try
+            {
+                // BaseDirectory must point at the test output dir (config/ is
+                // copied there) so EventScript.Load resolves the event config.
+                string asmDir = Path.GetDirectoryName(
+                    Assembly.GetExecutingAssembly().Location);
+                CoreState.BaseDirectory = asmDir;
+
+                var rom = new ROM();
+                if (!rom.Load(romPath, out string _)) return;
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+                if (CoreState.CommentCache == null)
+                    CoreState.CommentCache = new HeadlessEtcCache();
+
+                var es = new EventScript();
+                es.Load(EventScript.EventScriptType.Event);
+                CoreState.EventScript = es;
+
+                body(rom);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.EventScript = savedEs;
+                CoreState.SystemTextEncoder = savedEnc;
+                CoreState.CommentCache = savedComment;
+                if (savedBaseDir != null)
+                    CoreState.BaseDirectory = savedBaseDir;
+            }
+        }
+
+        // Walk up from the test assembly to find roms/<name>.
+        static string FindRom(string romName)
+        {
+            string thisAssembly = Assembly.GetExecutingAssembly().Location;
+            string dir = Path.GetDirectoryName(thisAssembly);
+            for (int i = 0; i < 10 && dir != null; i++)
+            {
+                if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                {
+                    string path = Path.Combine(dir, "roms", romName);
+                    if (File.Exists(path)) return path;
+                    break;
+                }
+                dir = Path.GetDirectoryName(dir);
+            }
+            return null;
+        }
+    }
+}

--- a/FEBuilderGBA.Core/BGReferenceFinder.cs
+++ b/FEBuilderGBA.Core/BGReferenceFinder.cs
@@ -29,19 +29,43 @@ namespace FEBuilderGBA
         /// <summary>
         /// Return the event-script references to BG slot <paramref name="bgId"/>
         /// (a fresh copy of the cached list, so the caller can't mutate the
-        /// cache). Empty when the ROM is null/invalid, the gating in
-        /// <see cref="EventScriptReferenceScanner.FindAllArgReferences"/> fails
-        /// (e.g. <paramref name="rom"/> is not the active <see cref="CoreState.ROM"/>),
-        /// or the BG id is unreferenced.
+        /// cache). Empty when the ROM is null/invalid, the scanner prerequisites
+        /// are not yet satisfied, or the BG id is unreferenced.
+        ///
+        /// CACHE-POISONING GUARD: the scanner's
+        /// <see cref="EventScriptReferenceScanner.FindAllArgReferences"/> returns
+        /// an EMPTY map both when a BG is genuinely unreferenced AND when its
+        /// prerequisites (an active <see cref="EventScript"/>, a wired
+        /// <see cref="CoreState.CommentCache"/>, and <paramref name="rom"/> being
+        /// the active <see cref="CoreState.ROM"/>) are not ready. If we cached
+        /// the latter, the SAME ROM instance would stay "cached empty" forever
+        /// even after CoreState finished initializing — so the References list
+        /// would never populate. We therefore pre-check the prerequisites here
+        /// and, when they are NOT satisfied, return a fresh empty list WITHOUT
+        /// caching (so a later fully-initialized call rebuilds for real).
         /// </summary>
         public static List<AddrResult> MakeListByUseBG(ROM rom, uint bgId)
         {
             if (rom?.RomInfo == null) return new List<AddrResult>();
 
+            // Prerequisites for a REAL scan (mirror the gate inside
+            // FindAllArgReferences + the CommentCache the disasm path needs).
+            bool prereqsReady = CoreState.EventScript != null
+                && CoreState.CommentCache != null
+                && CoreState.ROM != null
+                && ReferenceEquals(CoreState.ROM, rom);
+
             lock (_lock)
             {
                 if (!ReferenceEquals(_cachedRom, rom))
                 {
+                    if (!prereqsReady)
+                    {
+                        // Not ready — return empty WITHOUT poisoning the cache,
+                        // so the next (initialized) call for the same ROM scans.
+                        return new List<AddrResult>();
+                    }
+
                     _cache = EventScriptReferenceScanner.FindAllArgReferences(
                         rom, EventScript.ArgType.BG, keepZeroId: true);
                     _cachedRom = rom;

--- a/FEBuilderGBA.Core/BGReferenceFinder.cs
+++ b/FEBuilderGBA.Core/BGReferenceFinder.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Thin <see cref="EventScript.ArgType.BG"/> wrapper over
+    /// <see cref="EventScriptReferenceScanner.FindAllArgReferences"/>, with a
+    /// per-ROM-instance cache so the all-map disassembly runs at most once per
+    /// loaded ROM. Restores the Avalonia Background Image editor's References
+    /// list (the WinForms <c>InputFormRef.UpdateRef(X_REF, id, BG)</c> path,
+    /// for the event-script source).
+    ///
+    /// CACHE INVALIDATION: by ROM-instance identity (a new ROM load produces a
+    /// new <see cref="ROM"/> instance, triggering a rebuild). Within-session
+    /// event edits do NOT invalidate the cache — a documented residual that
+    /// matches the WinForms cache-staleness model (WF rebuilds
+    /// <c>AsmMapFileAsmCache</c> only on specific triggers, not on every edit).
+    ///
+    /// SCOPE: event-script BG references only. Patch-config (MULTICG/BGICON) and
+    /// ASM/MAP symbol references are documented residual gaps — see
+    /// <see cref="EventScriptReferenceScanner"/>.
+    /// </summary>
+    public static class BGReferenceFinder
+    {
+        static readonly object _lock = new object();
+        static ROM _cachedRom;
+        static Dictionary<uint, List<AddrResult>> _cache;
+
+        /// <summary>
+        /// Return the event-script references to BG slot <paramref name="bgId"/>
+        /// (a fresh copy of the cached list, so the caller can't mutate the
+        /// cache). Empty when the ROM is null/invalid, the gating in
+        /// <see cref="EventScriptReferenceScanner.FindAllArgReferences"/> fails
+        /// (e.g. <paramref name="rom"/> is not the active <see cref="CoreState.ROM"/>),
+        /// or the BG id is unreferenced.
+        /// </summary>
+        public static List<AddrResult> MakeListByUseBG(ROM rom, uint bgId)
+        {
+            if (rom?.RomInfo == null) return new List<AddrResult>();
+
+            lock (_lock)
+            {
+                if (!ReferenceEquals(_cachedRom, rom))
+                {
+                    _cache = EventScriptReferenceScanner.FindAllArgReferences(
+                        rom, EventScript.ArgType.BG, keepZeroId: true);
+                    _cachedRom = rom;
+                }
+
+                if (_cache != null && _cache.TryGetValue(bgId, out var l) && l != null)
+                {
+                    return new List<AddrResult>(l);
+                }
+                return new List<AddrResult>();
+            }
+        }
+
+        /// <summary>Reset the per-ROM cache. For tests only.</summary>
+        internal static void ResetCache()
+        {
+            lock (_lock)
+            {
+                _cachedRom = null;
+                _cache = null;
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Core/EventScriptReferenceScanner.cs
+++ b/FEBuilderGBA.Core/EventScriptReferenceScanner.cs
@@ -1,0 +1,430 @@
+using System;
+using System.Collections.Generic;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Cross-platform, strictly READ-ONLY scanner that finds every
+    /// event-script reference for a parameterized <see cref="EventScript.ArgType"/>.
+    ///
+    /// Two layers:
+    ///  1. <see cref="EnumerateEventEntries"/> — a faithful port of WinForms
+    ///     <c>EventCondForm.MakeEventScriptPointer</c> (+ the FE7 tutorial side
+    ///     path <c>MakeEventScriptForFE7Tutorial</c>) that walks every map's
+    ///     event-condition table and yields the event-script entry-point
+    ///     addresses (Turn / Talk / Object[skip shop+chest] / Always / Tutorial /
+    ///     Start / End conditions).
+    ///  2. <see cref="FindAllArgReferences"/> — disassembles each entry point
+    ///     (recursing through <see cref="EventScript.ArgType.POINTER_EVENT"/>
+    ///     args with a cycle guard) and buckets every <paramref name="argType"/>
+    ///     reference by its id value.
+    ///
+    /// This is the generic seam behind <see cref="BGReferenceFinder"/>
+    /// (<see cref="EventScript.ArgType.BG"/>); future TEXT/SONG cross-reference
+    /// parity work can reuse it with a different <see cref="EventScript.ArgType"/>.
+    ///
+    /// DOCUMENTED RESIDUAL GAPS (event-script references only; matches the
+    /// scope of the WinForms references list this seam restores):
+    ///  - Patch-config references (e.g. MULTICG / BGICON install metadata,
+    ///    WinForms <c>PatchForm</c> struct-install scanner) are NOT covered —
+    ///    that scanner is WinForms-bound and not yet ported to Core.
+    ///  - ASM/MAP symbol references (WinForms <c>AsmMapFileAsmCache.GetVarsIDArray</c>)
+    ///    are NOT covered — the headless ASM/MAP cache is a no-op.
+    /// A BG referenced ONLY by patch metadata or an ASM/MAP symbol will still
+    /// show an empty list; the common event-script "always empty" case is fixed.
+    /// </summary>
+    public static class EventScriptReferenceScanner
+    {
+        // WF cutoff: stop a single event-script walk after this many consecutive
+        // UNKNOWN commands (corrupt event guard). Mirrors
+        // MapEventUnitCore.ScanScriptForUnitPointers / EventCondForm.MakeVarsIDEventScan.
+        const int UnknownCutoff = 10;
+
+        // Defensive hard bound on the per-entry command walk so a pathological
+        // ROM can never hang. WF relies on exit/unknown cutoffs; we add a step
+        // cap for the same termination guarantee MapEventUnitCore uses.
+        const int MaxSteps = 4096;
+
+        /// <summary>
+        /// Faithful port of WinForms <c>EventCondForm.MakeEventScriptPointer</c>
+        /// over every map (plus the FE7-only tutorial table). Returns one
+        /// <see cref="AddrResult"/> per event-script entry point:
+        /// <c>addr</c> = the event-script start address, <c>name</c> =
+        /// <c>"MAP {mapidHex} {slotName}"</c>, <c>tag</c> = mapid. Strictly
+        /// read-only; every read is guarded and the method never throws.
+        /// </summary>
+        public static List<AddrResult> EnumerateEventEntries(ROM rom)
+        {
+            var list = new List<AddrResult>();
+            if (rom?.RomInfo == null) return list;
+
+            bool isFE7 = rom.RomInfo.version == 7;
+            uint romLen = (uint)rom.Data.Length;
+
+            // Per-version condition slot layout (Turn/Talk/Object/Always/...).
+            var slots = MapEventUnitCore.GetCondSlots(rom);
+            if (slots.Count == 0) return list;
+
+            var maps = MapSettingCore.MakeMapIDList(rom);
+            foreach (var map in maps)
+            {
+                uint mapid = map.tag;
+
+                // mapcond_addr = the map's event-condition block base.
+                // MapEventUnitCore.GetEventAddrForMap mirrors WF
+                // MapSettingForm.GetEventAddrWhereMapID (map setting -> event_plist
+                // -> PLIST -> cond block).
+                uint mapcond_addr = MapEventUnitCore.GetEventAddrForMap(rom, mapid);
+                if (mapcond_addr == U.NOT_FOUND || !U.isSafetyOffset(mapcond_addr, rom))
+                    continue;
+
+                for (int i = 0; i < slots.Count; i++)
+                {
+                    uint slotAddr = (uint)(mapcond_addr + 4 * i);
+                    if (slotAddr + 4 > romLen) break;
+
+                    var slot = slots[i];
+                    string info = "MAP " + U.ToHexString(mapid) + " " + slot.Name;
+
+                    if (slot.Type == MapEventUnitCore.CondType.StartEvent
+                        || slot.Type == MapEventUnitCore.CondType.EndEvent)
+                    {
+                        // START/END: the cond-slot address itself is the
+                        // event-script pointer (WF adds `addr`, the derefed
+                        // pointer, directly).
+                        uint eventAddr = rom.p32(slotAddr);
+                        if (!U.isSafetyOffset(eventAddr, rom)) continue;
+                        list.Add(new AddrResult(eventAddr, info, mapid));
+                        continue;
+                    }
+
+                    uint addr = rom.p32(slotAddr);
+                    if (!U.isSafetyOffset(addr, rom)) continue;
+
+                    switch (slot.Type)
+                    {
+                        case MapEventUnitCore.CondType.Turn:
+                            WalkTurn(rom, addr, info, mapid, isFE7, list);
+                            break;
+                        case MapEventUnitCore.CondType.Talk:
+                            WalkTalk(rom, addr, info, mapid, list);
+                            break;
+                        case MapEventUnitCore.CondType.Object:
+                            WalkObject(rom, addr, info, mapid, list);
+                            break;
+                        case MapEventUnitCore.CondType.Always:
+                            WalkAlways(rom, addr, info, mapid, list);
+                            break;
+                        case MapEventUnitCore.CondType.Tutorial:
+                            WalkTutorial(rom, addr, info, mapid, list);
+                            break;
+                        default:
+                            // Trap / PlayerUnit / EnemyUnit / Freemap*Unit /
+                            // Unknown — not event-script entry points in WF
+                            // MakeEventScriptPointer (handled elsewhere). Skip.
+                            break;
+                    }
+                }
+
+                if (isFE7)
+                {
+                    AppendFE7Tutorial(rom, mapid, list);
+                }
+            }
+
+            return list;
+        }
+
+        // TURN: stride eventcond_tern_size, event ptr p32(addr+4),
+        // stop u32(addr)==0 || u8(addr)==0; FE7 short-turn type==1 -> addr+=12.
+        static void WalkTurn(ROM rom, uint addr, string info, uint mapid, bool isFE7, List<AddrResult> list)
+        {
+            uint stride = rom.RomInfo.eventcond_tern_size;
+            if (stride == 0) return;
+            while (true)
+            {
+                if (rom.u32(addr) == 0) break;
+                uint type = rom.u8(addr);
+                if (type == 0) break;
+                if (!U.isSafetyOffset(addr + stride, rom)) break;
+
+                uint eventAddr = rom.p32(addr + 4);
+                if (U.isSafetyOffset(eventAddr, rom))
+                    list.Add(new AddrResult(eventAddr, info, mapid));
+
+                if (isFE7 && type == 1)
+                    addr += 12; // FE7 12-byte short-turn event
+                else
+                    addr += stride;
+            }
+        }
+
+        // TALK: stride eventcond_talk_size, ptr p32(addr+4), stop u32(addr)==0.
+        static void WalkTalk(ROM rom, uint addr, string info, uint mapid, List<AddrResult> list)
+        {
+            uint stride = rom.RomInfo.eventcond_talk_size;
+            if (stride == 0) return;
+            for (; true; addr += stride)
+            {
+                if (!U.isSafetyOffset(addr + stride, rom)) break;
+                if (rom.u32(addr) == 0) break;
+
+                uint eventAddr = rom.p32(addr + 4);
+                if (!U.isSafetyOffset(eventAddr, rom)) continue;
+                list.Add(new AddrResult(eventAddr, info, mapid));
+            }
+        }
+
+        // OBJECT: fixed 12-byte, ptr p32(addr+4), object_type=u8(addr+10),
+        // stop u32(addr)==0, SKIP shop/chest object types.
+        static void WalkObject(ROM rom, uint addr, string info, uint mapid, List<AddrResult> list)
+        {
+            for (; true; addr += 12)
+            {
+                if (!U.isSafetyOffset(addr + 12, rom)) break;
+                if (rom.u32(addr) == 0) break;
+
+                uint eventAddr = rom.p32(addr + 4);
+                if (!U.isSafetyOffset(eventAddr, rom)) continue;
+
+                uint objectType = rom.u8(addr + 10);
+                if (IsShopObjectType(rom, objectType) || IsChestObjectType(rom, objectType))
+                {
+                    // Shop or chest — WF skips these (their event scripts are
+                    // not part of the references walk).
+                }
+                else
+                {
+                    list.Add(new AddrResult(eventAddr, info, mapid));
+                }
+            }
+        }
+
+        // ALWAYS: fixed 12-byte, ptr p32(addr+4), stop u32(addr)==0.
+        static void WalkAlways(ROM rom, uint addr, string info, uint mapid, List<AddrResult> list)
+        {
+            for (; true; addr += 12)
+            {
+                if (!U.isSafetyOffset(addr + 12, rom)) break;
+                if (rom.u32(addr) == 0) break;
+
+                uint eventAddr = rom.p32(addr + 4);
+                if (!U.isSafetyOffset(eventAddr, rom)) continue;
+                list.Add(new AddrResult(eventAddr, info, mapid));
+            }
+        }
+
+        // TUTORIAL (FE8 cond slot): fixed 4-byte, ptr p32(addr+0),
+        // stop !isPointer(u32(addr)).
+        static void WalkTutorial(ROM rom, uint addr, string info, uint mapid, List<AddrResult> list)
+        {
+            for (; true; addr += 4)
+            {
+                if (!U.isSafetyOffset(addr + 4, rom)) break;
+                if (!U.isPointer(rom.u32(addr))) break;
+
+                uint eventAddr = rom.p32(addr + 0);
+                if (!U.isSafetyOffset(eventAddr, rom)) continue;
+                list.Add(new AddrResult(eventAddr, info, mapid));
+            }
+        }
+
+        // FE7-only tutorial table (WF MakeEventScriptForFE7Tutorial):
+        // base p32(event_tutorial_pointer)+mapid*4, mapid<=0x30, 12-byte records,
+        // ptr p32(addr+4), stop u32(addr)==0.
+        static void AppendFE7Tutorial(ROM rom, uint mapid, List<AddrResult> list)
+        {
+            if (mapid > 0x30) return;
+
+            uint tutorialPointer = rom.RomInfo.event_tutorial_pointer;
+            if (tutorialPointer == 0) return;
+
+            uint tutorialAddr = rom.p32(tutorialPointer);
+            tutorialAddr = tutorialAddr + (mapid * 4);
+            if (!U.isSafetyOffset(tutorialAddr, rom)) return;
+
+            uint addr = rom.p32(tutorialAddr);
+            if (!U.isSafetyOffset(addr, rom)) return;
+
+            for (; true; addr += 12)
+            {
+                if (!U.isSafetyOffset(addr + 12, rom)) break;
+                if (rom.u32(addr) == 0) break;
+
+                uint eventAddr = rom.p32(addr + 4);
+                if (!U.isSafetyOffset(eventAddr, rom)) continue;
+                list.Add(new AddrResult(eventAddr, "Tutorial FE7", mapid));
+            }
+        }
+
+        // WF EventCondForm.IsChestObjectType: FE8 chest=0x14, FE6/7 chest=0x12.
+        static bool IsChestObjectType(ROM rom, uint objectType)
+        {
+            if (rom.RomInfo.version == 8)
+                return objectType == 0x14;
+            return objectType == 0x12;
+        }
+
+        // WF EventCondForm.IsShopObjectType: FE8 shop=0x16-0x18, FE6/7 shop=0x13-0x15.
+        static bool IsShopObjectType(ROM rom, uint objectType)
+        {
+            if (rom.RomInfo.version == 8)
+                return objectType == 0x16 || objectType == 0x17 || objectType == 0x18;
+            return objectType == 0x13 || objectType == 0x14 || objectType == 0x15;
+        }
+
+        /// <summary>
+        /// Build a <c>bgId -&gt; refs</c> map for the given
+        /// <paramref name="argType"/> by disassembling every event-script entry
+        /// point from <see cref="EnumerateEventEntries"/>.
+        ///
+        /// GATING: the Core EventScript disassembly path dereferences the static
+        /// <see cref="CoreState.ROM"/> / <see cref="CoreState.EventScript"/> /
+        /// <see cref="CoreState.CommentCache"/>, NOT the <paramref name="rom"/>
+        /// parameter. To avoid mis-scanning (or a NullRef) when called with a ROM
+        /// that is not the active <see cref="CoreState.ROM"/>, this returns an
+        /// EMPTY map unless <paramref name="rom"/> IS the active
+        /// <see cref="CoreState.ROM"/> and an <see cref="EventScript"/> is wired.
+        /// (Same discipline as <c>MapEventUnitCore.ScanEventScriptSlots</c>.)
+        /// </summary>
+        /// <param name="rom">Target ROM (must be the active CoreState.ROM).</param>
+        /// <param name="argType">The event-script argument type to collect.</param>
+        /// <param name="keepZeroId">When false, id 0 references are dropped
+        /// (matches the WinForms behavior where id 0 is a "none" sentinel for
+        /// most types). BG keeps 0 (a valid BG slot).</param>
+        public static Dictionary<uint, List<AddrResult>> FindAllArgReferences(
+            ROM rom, EventScript.ArgType argType, bool keepZeroId)
+        {
+            var bucket = new Dictionary<uint, List<AddrResult>>();
+
+            var es = CoreState.EventScript;
+            if (es == null) return bucket;
+            // The disasm path dereferences the static CoreState.ROM; only scan
+            // when the passed ROM IS the active one so headless/multi-ROM
+            // callers can never mis-scan or NullRef.
+            if (CoreState.ROM == null || !ReferenceEquals(CoreState.ROM, rom)) return bucket;
+
+            var entries = EnumerateEventEntries(rom);
+            var tracelist = new List<uint>();
+
+            foreach (var entry in entries)
+            {
+                ScanScriptForArg(rom, es, entry.addr, entry.name, argType, keepZeroId, tracelist, bucket);
+            }
+
+            // Dedup each bucket by AddrResult.addr (event-script-start address),
+            // keeping the first occurrence — matches WF UseValsID.RemoveDuplicates
+            // for a single id (collapses the same script reached from multiple
+            // commands or maps into one entry).
+            foreach (var kv in bucket)
+            {
+                DedupByAddr(kv.Value);
+            }
+
+            return bucket;
+        }
+
+        static void DedupByAddr(List<AddrResult> refs)
+        {
+            var seen = new HashSet<uint>();
+            int write = 0;
+            for (int read = 0; read < refs.Count; read++)
+            {
+                if (seen.Add(refs[read].addr))
+                {
+                    refs[write++] = refs[read];
+                }
+            }
+            if (write < refs.Count)
+                refs.RemoveRange(write, refs.Count - write);
+        }
+
+        /// <summary>
+        /// Disassemble the event script at <paramref name="eventAddr"/> and
+        /// bucket every <paramref name="argType"/> reference. Recurses through
+        /// <see cref="EventScript.ArgType.POINTER_EVENT"/> args with a tracelist
+        /// cycle guard. Exposed <c>internal</c> for synthetic scanner tests
+        /// (InternalsVisibleTo FEBuilderGBA.Core.Tests). Strictly read-only.
+        /// </summary>
+        internal static void ScanScriptForArg(
+            ROM rom, EventScript es, uint eventAddr, string info,
+            EventScript.ArgType argType, bool keepZeroId,
+            List<uint> tracelist, Dictionary<uint, List<AddrResult>> bucket)
+        {
+            uint addr = eventAddr;
+            uint lastBranchAddr = 0;
+            int unknownCount = 0;
+
+            for (int guard = 0; guard < MaxSteps; guard++)
+            {
+                uint romLen = (uint)rom.Data.Length;
+                if (U.toOffset(addr) + 4 > romLen) break;
+
+                EventScript.OneCode code = es.DisAseemble(rom.Data, addr);
+                if (code?.Script == null) break;
+
+                if (EventScript.IsExitCode(code, addr, lastBranchAddr))
+                    break;
+
+                if (code.Script.Has == EventScript.ScriptHas.UNKNOWN)
+                {
+                    unknownCount++;
+                    if (unknownCount > UnknownCutoff) break;
+                }
+                else
+                {
+                    unknownCount = 0;
+
+                    if (code.Script.Has == EventScript.ScriptHas.IF_CONDITIONAL)
+                    {
+                        lastBranchAddr = addr;
+                    }
+                    else if (code.Script.Has == EventScript.ScriptHas.LABEL_CONDITIONAL)
+                    {
+                        lastBranchAddr = 0;
+                    }
+
+                    // WF MakeVarsIDEventScan scans EVERY command's args (not just
+                    // POINTER_UNIT_OR_EVENT). Mirror that.
+                    if (code.Script.Args != null)
+                    {
+                        for (int a = 0; a < code.Script.Args.Length; a++)
+                        {
+                            EventScript.Arg arg = code.Script.Args[a];
+
+                            if (arg.Type == EventScript.ArgType.POINTER_EVENT)
+                            {
+                                uint v = U.toOffset(EventScript.GetArgValue(code, arg));
+                                if (U.isSafetyOffset(v, rom) && tracelist.IndexOf(v) < 0)
+                                {
+                                    tracelist.Add(v);
+                                    ScanScriptForArg(rom, es, v, info, argType, keepZeroId, tracelist, bucket);
+                                }
+                            }
+                            else if (arg.Type == argType)
+                            {
+                                uint v = EventScript.GetArgValue(code, arg);
+                                if (v >= 0x7FFF) continue;
+                                if (v == 0 && !keepZeroId) continue;
+
+                                if (!bucket.TryGetValue(v, out var l))
+                                {
+                                    l = new List<AddrResult>();
+                                    bucket[v] = l;
+                                }
+                                // refCommandAddr (addr) is the referencing
+                                // command's address; the event-script start
+                                // (eventAddr) is the dedup key applied later.
+                                l.Add(new AddrResult(eventAddr, info, addr));
+                            }
+                        }
+                    }
+                }
+
+                int step = code.Script.Size;
+                if (step <= 0) break; // guard against a zero-size match loop
+                addr += (uint)step;
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Core/EventScriptReferenceScanner.cs
+++ b/FEBuilderGBA.Core/EventScriptReferenceScanner.cs
@@ -143,10 +143,14 @@ namespace FEBuilderGBA
             if (stride == 0) return;
             while (true)
             {
+                // Bounds-check the CURRENT record BEFORE any read so a near-EOF
+                // turn record can't throw (U.u32/u8 throw IndexOutOfRange past
+                // the end). Mirrors the other Walk* methods' guard ordering.
+                if (!U.isSafetyOffset(addr, rom)) break;
+                if (!U.isSafetyOffset(addr + stride, rom)) break;
                 if (rom.u32(addr) == 0) break;
                 uint type = rom.u8(addr);
                 if (type == 0) break;
-                if (!U.isSafetyOffset(addr + stride, rom)) break;
 
                 uint eventAddr = rom.p32(addr + 4);
                 if (U.isSafetyOffset(eventAddr, rom))
@@ -284,8 +288,10 @@ namespace FEBuilderGBA
         /// parameter. To avoid mis-scanning (or a NullRef) when called with a ROM
         /// that is not the active <see cref="CoreState.ROM"/>, this returns an
         /// EMPTY map unless <paramref name="rom"/> IS the active
-        /// <see cref="CoreState.ROM"/> and an <see cref="EventScript"/> is wired.
-        /// (Same discipline as <c>MapEventUnitCore.ScanEventScriptSlots</c>.)
+        /// <see cref="CoreState.ROM"/>, an <see cref="EventScript"/> is wired, AND
+        /// <see cref="CoreState.CommentCache"/> is wired (the disasm path
+        /// dereferences it). (Same discipline as
+        /// <c>MapEventUnitCore.ScanEventScriptSlots</c>.)
         /// </summary>
         /// <param name="rom">Target ROM (must be the active CoreState.ROM).</param>
         /// <param name="argType">The event-script argument type to collect.</param>
@@ -299,10 +305,13 @@ namespace FEBuilderGBA
 
             var es = CoreState.EventScript;
             if (es == null) return bucket;
-            // The disasm path dereferences the static CoreState.ROM; only scan
-            // when the passed ROM IS the active one so headless/multi-ROM
+            // The disasm path dereferences the static CoreState.ROM AND
+            // CoreState.CommentCache (EventScript.DisAseemble calls
+            // CoreState.CommentCache.At(addr)); only scan when the passed ROM IS
+            // the active one AND the comment cache is wired so headless/early
             // callers can never mis-scan or NullRef.
             if (CoreState.ROM == null || !ReferenceEquals(CoreState.ROM, rom)) return bucket;
+            if (CoreState.CommentCache == null) return bucket;
 
             var entries = EnumerateEventEntries(rom);
             var tracelist = new List<uint>();


### PR DESCRIPTION
## Summary

- The Avalonia **Background Image Editor** (`ImageBGView`) References list was always empty — `ImageBGViewModel.XRefEntries` was a scaffolded empty list nothing populated. WinForms fills it via `InputFormRef.UpdateRef(X_REF, id, BG)` reading the WinForms-only `AsmMapFileAsmCache` master list, with no Core/headless equivalent.
- New **`FEBuilderGBA.Core/EventScriptReferenceScanner.cs`** (READ-ONLY, generic): `EnumerateEventEntries(rom)` is a faithful port of WinForms `EventCondForm.MakeEventScriptPointer` (+ the FE7-only `MakeEventScriptForFE7Tutorial` table) over every map — Turn / Talk / Object [skip shop+chest] / Always / Tutorial / Start / End with verified per-cond geometry (FE7 12-byte short-turn included; FE8 chest=0x14 shop=0x16-0x18, FE6/7 chest=0x12 shop=0x13-0x15). `FindAllArgReferences(rom, argType, keepZeroId)` is gated on the active `CoreState.ROM` / `CoreState.EventScript`, disassembles each entry iterating **every** non-UNKNOWN command's args (10-UNKNOWN cutoff + 4096-step guard + EOF bound), recurses through `POINTER_EVENT` with a tracelist cycle guard, buckets each `argType` ref by id (`v>=0x7FFF` skipped, `v==0` dropped unless `keepZeroId`), and dedups each bucket by event-script-start address (matches WF `UseValsID.RemoveDuplicates`).
- New **`FEBuilderGBA.Core/BGReferenceFinder.cs`**: thin `ArgType.BG` wrapper with a per-ROM-instance cache. `MakeListByUseBG(rom, bgId)` builds the full `bgId→refs` map once per loaded ROM and returns a copy.
- **`ImageBGViewModel.RefreshXrefs(bgId)`** (mirroring `ImageBattleBGViewModel.RefreshXrefs`) is called from `LoadEntry`; the View's existing `XRefList.ItemsSource = XRefEntries.Select(x=>x.name)` binding projects the populated list (no axaml change; stale scaffold comments updated).
- Docs: CLAUDE.md "Graphics System" gains the two Core-seam bullets documenting the event-script source + residual gaps.

## Plan Reference

Implemented per the accepted v2 plan (Copilot-approved, no blocking concerns): https://github.com/laqieer/FEBuilderGBA/issues/990#issuecomment-4643642543

## Scope

Closes #990.

**Includes:** faithful event-script BG cross-references (Turn/Talk/Object[skip shop+chest]/Always/Tutorial/Start/End + FE7 tutorial), `POINTER_EVENT` recursion, WF-equivalent dedup, full VM/View wiring.

**Documented residual gaps** (event-script references only — inline in code + CLAUDE.md, per repo convention, no follow-up issue to keep zero open issues):
- **Patch-config BG refs** (MULTICG `u16<0x100` / BGICON `u8`) — needs the WinForms `PatchForm` struct-install metadata scanner ported to Core (WinForms-bound, not yet ported).
- **ASM/MAP symbol BG refs** — route through the unported `AsmMapFileAsmCache.GetVarsIDArray()`; the headless ASM/MAP cache is a no-op.

The event-script source fully fixes the "always empty" bug; the PR labels the result as event-script references for honesty. A BG referenced ONLY by patch metadata or an ASM/MAP symbol still shows an empty list.

## Screenshots

**Background Image Editor — References list now populated** (FE8U; BG slot `00 Background` selected). The right-hand **References** panel lists the event-script references to BG 00 — `MAP 01 Map Objects` x2 + `MAP 06 Map Objects` x3 (distinct OBJECT-cond events across maps 01/06). Before this fix the list was always empty/grey.

![Background Image Editor with populated References list](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr992-bg-references-populated.png)

> Layout note: the editor window is `SizeToContent`-constrained to ~644px (mirroring the WinForms `ImageBGForm`), so the narrow References column renders the labels truncated to `MAP ...`. The full reference strings (`MAP 01 Map Objects`, `MAP 06 Map Objects`) were confirmed via the live UIAutomation tree, and the `[AvaloniaFact]` test asserts the populated row count == `BGReferenceFinder.MakeListByUseBG`.

## GUI Test Report

Headless Avalonia validation via the new `[AvaloniaFact]` test (real `ImageBGView`, real ROM, real `SkiaImageService`, user-equivalent `AddressListControl.SelectAddress` selection path):

| Test | Expected | Actual | Status |
|------|----------|--------|--------|
| `ImageBGViewXrefTests.XRefList_PopulatedForReferencedBg` — load ROM, discover a referenced BG slot via `BGReferenceFinder`, select it in `ImageBGView` | `XRefList.ItemsSource` non-null | non-null | PASS |
| same | item count > 0 for the discovered referenced bgId | > 0 | PASS |
| same | `XRefList.ItemsSource.Count == _vm.XRefEntries.Count` | equal | PASS |
| same | count equals the `BGReferenceFinder.MakeListByUseBG` ref count for that id | equal | PASS |

## Test plan

All items run and passing:

- [x] `dotnet build FEBuilderGBA.Core/FEBuilderGBA.Core.csproj` — Build succeeded (0 errors)
- [x] `dotnet build FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj` — Build succeeded (0 errors)
- [x] **Core scanner synthetic tests** (`EventScriptReferenceScannerTests`): `ScanScriptForArg_FindsPlantedBG`, `_RecursesThroughPointerEvent`, `_SelfCyclePointerEvent_DoesNotHang`, `_BgIdZero_KeptWhenKeepZeroId`, `_BgIdZero_DroppedWhenNotKeepZeroId`, `_HighId_Skipped`, `FindAllArgReferences_Gating_NullEventScript_ReturnsEmpty`, `_Gating_NonActiveRom_ReturnsEmpty`, `EnumerateEventEntries_NullRom_ReturnsEmpty` — PASS
- [x] **Core scanner real-ROM tests** (non-stub proof): `RealRom_FE8U_FindAllBG_NonEmpty`, `RealRom_FE7U_FindAllBG_NonEmpty`, `RealRom_FE6_FindAllBG_NonEmpty`, `RealRom_FE7U_Enumeration_IncludesTutorialFE7` — PASS (ran against real `roms/`)
- [x] **BGReferenceFinder tests** (`BGReferenceFinderTests`): `MakeListByUseBG_NullRom_ReturnsEmpty`, `_Gating_NonActiveRom_ReturnsEmpty`, `RealRom_FE8U_MakeListByUseBG_FindsReferencedBg_HighIdEmpty_CacheReuse` — PASS
- [x] **Avalonia headless test** (`ImageBGViewXrefTests.XRefList_PopulatedForReferencedBg`) — PASS
- [x] Full **Core.Tests** suite: 2875 passed / 0 failed (16 new)
- [x] Full **Avalonia.Tests** suite: 7561 passed / 3 skipped / 0 failed (existing `ImageBGParityTests` green; additive — no signatures changed)

Note: the 10 `SkillSystems*`/`SkillConfig*` FE8U failures seen on a first run were purely the un-checked-out `config/patch2` submodule (`config/patch2 submodule not checked out`); after `git submodule update --init config/patch2` + rebuild the full Core suite is 2875/2875 green. Wholly unrelated to this change.

E2E: none (read-only display; no CLI surface).

Generated with Claude Code (claude-opus-4-8[1m])

