### PR TITLE
fix(avalonia): port full Unit Wait Icon Editor — fields, preview, import/export, jump (#991)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -718,7 +718,12 @@ Specialized utilities for different graphic types:
   (`GetClassIdWhereWaitIconId` @ class `+6`, `GetClassMoveIcon` @ class `+4`,
   `GetClassNameWhereWaitIconId` → `NameResolver.GetClassName`) and drive the
   list-label class name (lockstep `ListParityHelper.BuildImageUnitWaitIconList` ↔
-  VM `LoadList`, golden-test gated) + the Jump-to-Move-Icon button.
+  VM `LoadList`, golden-test gated) + the Jump-to-Move-Icon button. The
+  move-icon field (`u8 @ class+4`) is a 1-BASED id (WF
+  `PreviewIconHelper.LoadMoveIcon` uses `id - 1`; `ImageUnitMoveIconViewModel`
+  is 0-based by table index), so `ImageUnitWaitIconViewModel.ResolveMoveIconEntryAddress`
+  navigates to `moveIconBase + (id - 1) * 8` (id 0 → no jump) — PR #993 Copilot
+  off-by-one fix, headless-tested on the computed target address.
   **Documented residual gaps:** (1) animated-GIF IMPORT is not a WF feature (WF
   import is PNG/BMP single-frame; GIF is export-only); (2) the interactive
   palette reorder/force dialog (WF `CheckPalette`/`ErrorPaletteShowForm`) is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -696,10 +696,18 @@ Specialized utilities for different graphic types:
   the step-0 16x24@Y=8 list-preview parity. `GetPaletteColors(rom, paletteType)`
   maps 0=self/1=npc/2=enemy/3=gray/4=four/5=lightrune/6=sepia to the matching
   `unit_icon_*_palette_address` (`ImageUtilCore.GetPalette(addr,16)`; addr==0 →
-  null, so FE6 lightrune/sepia are blank). The Avalonia `ImageUnitWaitIconView`
-  (no longer a stub) hosts W0/W2/P4 fields + undo-safe Write, a 5-selectable
-  palette combo (自軍/友軍/敵軍/グレー/4軍) + 0..2 step preview (full sheet +
-  frame), Comment, jump-to-Move-Icon, and PNG/animated-GIF export.
+  null, so FE6 lightrune/sepia are blank). **rom-consistent palette read (#993
+  Copilot review):** `GetPaletteColors` reads via the new rom-aware
+  `ImageUtilCore.GetPalette(rom, offset, colorCount)` overload (the parameterless
+  one now delegates to it) so a Core seam never silently reads palette bytes from
+  a different ambient `CoreState.ROM` than the one it validated. The Avalonia
+  `ImageUnitWaitIconView` (no longer a stub) hosts W0/W2/P4 fields + undo-safe
+  Write, a 5-selectable palette combo (English-source `<TextBlock>` items
+  localized by `ViewTranslationHelper` via ja/en/zh `config/translate/`) + 0..2
+  step preview (full sheet + frame), Comment, jump-to-Move-Icon, and
+  PNG/animated-GIF export. The View `using`-disposes each freshly-rendered
+  `IImage` right after `SetImage` (which copies into a `WriteableBitmap`, not
+  retains) so the unmanaged SKBitmap is released without waiting for GC.
 - `WaitIconImportCore.cs` (Core, ROM-MUTATING) - Cross-platform static PNG/BMP
   wait-icon sheet import (#991; ports WF `ImageUnitWaitIconFrom.ImportButton_Click`
   write-back). `Import(rom, entryAddr, indexedPixels, width, height) → string`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -679,6 +679,56 @@ Specialized utilities for different graphic types:
   address (`U.isSafetyOffset`) — never throws. The Avalonia
   `ImageUnitPaletteView.OnSelected` calls it after `SelectedPaletteSlot` is set,
   before `UpdateUI`, then `RefreshSamplePreview` renders.
+- `WaitIconRenderCore.cs` (Core, READ-ONLY) - Cross-platform Unit Wait Icon
+  decode + crop seam (#991), extracted VERBATIM from the Avalonia
+  `PreviewIconHelper.LoadClassWaitIcon` decode pipeline (now a thin delegating
+  wrapper → single source of truth, zero drift). Resolves the 8-byte wait-icon
+  table entry (`unit_wait_icon_pointer` base; animType = raw byte @ `+2`, sprite
+  GBA pointer @ `+4`), LZ77-decompresses the strip, computes the strip height
+  (`CalcStripHeight` = WF `ImageUtil.CalcHeight(width, size, align=8)`), and
+  renders via `IImageService.Decode4bppTiles`. `RenderFrame(rom, idx, step, svc,
+  paletteType=0)` crops the step's frame per WF `DrawWaitUnitIcon`
+  (height16_limit=false): animType0 `(0,16*step,16,16)`, animType1
+  `(0,32*step+8,16,24)` (the #342/#667 Y=8 offset), animType2 `(0,32*step,32,32)`;
+  bounds-checked → null on short strip / unsafe ptr / null palette, NEVER throws.
+  `RenderFullSheet` returns the full decoded strip (no crop) for the editor's
+  X_PIC + PNG export. `RenderClassWaitIcon == RenderFrame(step:0, self)` preserves
+  the step-0 16x24@Y=8 list-preview parity. `GetPaletteColors(rom, paletteType)`
+  maps 0=self/1=npc/2=enemy/3=gray/4=four/5=lightrune/6=sepia to the matching
+  `unit_icon_*_palette_address` (`ImageUtilCore.GetPalette(addr,16)`; addr==0 →
+  null, so FE6 lightrune/sepia are blank). The Avalonia `ImageUnitWaitIconView`
+  (no longer a stub) hosts W0/W2/P4 fields + undo-safe Write, a 5-selectable
+  palette combo (自軍/友軍/敵軍/グレー/4軍) + 0..2 step preview (full sheet +
+  frame), Comment, jump-to-Move-Icon, and PNG/animated-GIF export.
+- `WaitIconImportCore.cs` (Core, ROM-MUTATING) - Cross-platform static PNG/BMP
+  wait-icon sheet import (#991; ports WF `ImageUnitWaitIconFrom.ImportButton_Click`
+  write-back). `Import(rom, entryAddr, indexedPixels, width, height) → string`
+  validates dims → animType byte b2 (16x48→0 / 16x96→1 / 32x96→2, else localized
+  error + NO mutation), encodes via `ImageImportCore.EncodeDirectTiles4bpp`,
+  LZ77-writes + repoints the entry's `+4` pointer (`WriteCompressedToROM` OWNS the
+  +4 slot), and writes b2 into W2 (`write_u16` @ `+2`) — all under the CALLER's
+  ambient undo scope (the View owns `UndoService.Begin/Commit/Rollback`). A
+  defensive `rom.Data` snapshot is restored byte-identical on ANY fault
+  (length-aware: down-resize to snap length BEFORE `Array.Copy` so a
+  free-space resize-append can't survive — the #885/#923 pattern). The WF
+  interactive force-palette dialog is replaced by a nearest-color remap onto the
+  shared self-army palette done by the View's `Import_Click`
+  (`ImageImportService.LoadAndRemapToExistingPalette`, the entry has NO palette
+  slot) BEFORE the seam. Class back-refs live in `ClassFormCore`
+  (`GetClassIdWhereWaitIconId` @ class `+6`, `GetClassMoveIcon` @ class `+4`,
+  `GetClassNameWhereWaitIconId` → `NameResolver.GetClassName`) and drive the
+  list-label class name (lockstep `ListParityHelper.BuildImageUnitWaitIconList` ↔
+  VM `LoadList`, golden-test gated) + the Jump-to-Move-Icon button.
+  **Documented residual gaps:** (1) animated-GIF IMPORT is not a WF feature (WF
+  import is PNG/BMP single-frame; GIF is export-only); (2) the interactive
+  palette reorder/force dialog (WF `CheckPalette`/`ErrorPaletteShowForm`) is
+  replaced by automatic nearest-color remap; (3) old-region recycle on import is
+  deferred (always-append never corrupts shared sprites, may leak freespace on
+  repeated import); (4) list-expand barista repoint + source-file Open/Select
+  conveniences are deferred (editor edits existing entries only). The shared
+  list-termination contract (first non-pointer `@+4`) is kept unchanged; WF's
+  `P4==0 && flags!=0` non-terminal nuance is a documented pre-existing residual
+  (test-asserted current vanilla behavior).
 
 ### Caching System
 

--- a/FEBuilderGBA.Avalonia.Tests/ImageUnitWaitIconViewTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageUnitWaitIconViewTests.cs
@@ -326,49 +326,41 @@ public class ImageUnitWaitIconViewTests : IClassFixture<RomFixture>
     {
         if (!TryRom()) return;
         ROM rom = _fixture.ROM!;
-
-        // Pick a wait-icon id that an owning class references.
-        uint classBase = rom.p32(rom.RomInfo.class_pointer);
-        uint classSize = rom.RomInfo.class_datasize;
-        uint ownedWaitId = 0;
-        for (uint c = 1; c <= 128; c++)
-        {
-            uint a = classBase + c * classSize;
-            if (a + classSize > (uint)rom.Data.Length) break;
-            uint w = rom.u8(a + 6);
-            if (w > 0) { ownedWaitId = w; break; }
-        }
-        if (ownedWaitId == 0) { _output.WriteLine("SKIP: no owned wait icon"); return; }
+        uint moveBase = rom.p32(rom.RomInfo.unit_move_icon_pointer);
 
         var view = new ImageUnitWaitIconView();
         view.Show();
         try
         {
             var list = view.FindControl<AddressListControl>("EntryList");
-            list!.SelectByIndex((int)ownedWaitId);
             var vm = view.DataViewModel as ImageUnitWaitIconViewModel;
+            Assert.NotNull(vm);
 
-            uint? moveIcon = vm!.ResolveMoveIconForSelection();
-            Assert.NotNull(moveIcon);
+            // Find a wait icon whose RESOLVED owning class has a move-icon
+            // (ResolveMoveIconForSelection returns null for id 0 / no class).
+            var items = list!.GetItems();
+            int probed = System.Math.Min(items.Count, 128);
+            uint? moveIcon = null;
+            for (int i = 1; i < probed; i++)
+            {
+                list.SelectByIndex(i);
+                moveIcon = vm!.ResolveMoveIconForSelection();
+                if (moveIcon != null) break;
+            }
+            if (moveIcon == null) { _output.WriteLine("SKIP: no wait icon resolves to a class with a move icon"); return; }
+
+            // A non-null move icon is always >= 1 (Copilot review on PR #993).
+            Assert.True(moveIcon!.Value >= 1);
 
             // The move-icon id is 1-BASED; the navigation target must be the
-            // 0-based table entry: baseAddr + (id - 1) * 8 (Copilot review on
-            // PR #993 — the off-by-one fix). id 0 ("no move icon") -> null.
-            uint moveBase = rom.p32(rom.RomInfo.unit_move_icon_pointer);
+            // 0-based table entry: baseAddr + (id - 1) * 8 (the off-by-one fix).
             uint? target = vm.ResolveMoveIconEntryAddress();
-            if (moveIcon!.Value == 0)
-            {
-                Assert.Null(target);
-            }
-            else
-            {
-                Assert.NotNull(target);
-                uint expected = moveBase + (moveIcon.Value - 1) * 8;
-                Assert.Equal(expected, target!.Value);
-                // The resolved row must NOT be the naive (id * 8) 0-based read —
-                // regression-fires if the off-by-one returns.
-                Assert.NotEqual(moveBase + moveIcon.Value * 8, target.Value);
-            }
+            Assert.NotNull(target);
+            uint expected = moveBase + (moveIcon.Value - 1) * 8;
+            Assert.Equal(expected, target!.Value);
+            // The resolved row must NOT be the naive (id * 8) 0-based read —
+            // regression-fires if the off-by-one returns.
+            Assert.NotEqual(moveBase + moveIcon.Value * 8, target.Value);
         }
         finally { view.Close(); }
     }

--- a/FEBuilderGBA.Avalonia.Tests/ImageUnitWaitIconViewTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageUnitWaitIconViewTests.cs
@@ -1,0 +1,466 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #991 headless Avalonia tests for the ported Unit Wait Icon Editor.
+//
+// Covers controls present + wired, ROM-backed field/preview population, palette
+// + step preview refresh, PNG/GIF export (GIF asserts exactly 3 frames), static
+// PNG import (16x48 -> b2 0 + repoint, wrong-size rejected with no mutation),
+// jump-to-move-icon resolution, comment save/reload. Also runs the real-pixel
+// render oracle (RenderClassWaitIcon == RenderFrame(step:0) pixel-identical)
+// and per-animType crop SIZES with the real SkiaSharp decoder (Core.Tests only
+// has a synthetic stub, so the real-pixel coverage lives here).
+//
+// ROM-backed tests skip when FE8U.gba is unavailable (matching the codebase
+// pattern). Control-presence tests run without a ROM.
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Controls;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using FEBuilderGBA.Core;
+using FEBuilderGBA.SkiaSharp;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+[Collection("SharedState")]
+public class ImageUnitWaitIconViewTests : IClassFixture<RomFixture>
+{
+    readonly RomFixture _fixture;
+    readonly ITestOutputHelper _output;
+
+    public ImageUnitWaitIconViewTests(RomFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    bool TryRom()
+    {
+        if (!_fixture.IsAvailable)
+        {
+            _output.WriteLine("RomFixture not available — skipping ROM-backed assertions.");
+            return false;
+        }
+        if (CoreState.ImageService == null)
+            CoreState.ImageService = new SkiaImageService();
+        return true;
+    }
+
+    static List<(Control Control, string Id)> CollectAutomationIds(Control root)
+    {
+        var result = new List<(Control, string)>();
+        foreach (var child in root.GetLogicalDescendants().OfType<Control>())
+        {
+            var id = AutomationProperties.GetAutomationId(child);
+            if (!string.IsNullOrEmpty(id)) result.Add((child, id));
+        }
+        return result;
+    }
+
+    // First wait-icon table index that holds a valid sprite pointer.
+    uint FirstValidWaitIndex(ROM rom)
+    {
+        uint baseAddr = rom.p32(rom.RomInfo.unit_wait_icon_pointer);
+        for (uint i = 1; i < 0x100; i++)
+        {
+            uint a = baseAddr + i * 8;
+            if (a + 8 > (uint)rom.Data.Length) break;
+            if (U.isPointer(rom.u32(a + 4))) return i;
+        }
+        return 1;
+    }
+
+    // ====================================================================
+    // Controls present + wired (no ROM needed)
+    // ====================================================================
+    [AvaloniaFact]
+    public void Controls_Present_And_Wired()
+    {
+        var view = new ImageUnitWaitIconView();
+
+        Assert.NotNull(view.FindControl<AddressListControl>("EntryList"));
+        Assert.NotNull(view.FindControl<NumericUpDown>("W0Box"));
+        Assert.NotNull(view.FindControl<NumericUpDown>("W2Box"));
+        Assert.NotNull(view.FindControl<NumericUpDown>("P4Box"));
+
+        var palette = view.FindControl<ComboBox>("PaletteCombo");
+        Assert.NotNull(palette);
+        Assert.Equal(5, palette!.Items.Count); // 自軍/友軍/敵軍/グレー/4軍
+
+        var step = view.FindControl<NumericUpDown>("StepBox");
+        Assert.NotNull(step);
+        Assert.Equal(0, step!.Minimum);
+        Assert.Equal(2, step.Maximum);
+
+        Assert.NotNull(view.FindControl<GbaImageControl>("SheetImage"));
+        Assert.NotNull(view.FindControl<GbaImageControl>("FrameImage"));
+        Assert.NotNull(view.FindControl<TextBox>("CommentBox"));
+
+        // All buttons present by AutomationId.
+        var ids = CollectAutomationIds(view).Select(x => x.Id).ToHashSet();
+        Assert.Contains("ImageUnitWaitIcon_Write_Button", ids);
+        Assert.Contains("ImageUnitWaitIcon_Import_Button", ids);
+        Assert.Contains("ImageUnitWaitIcon_Export_Button", ids);
+        Assert.Contains("ImageUnitWaitIcon_JumpMoveIcon_Button", ids);
+        Assert.Contains("ImageUnitWaitIcon_Palette_Combo", ids);
+        Assert.Contains("ImageUnitWaitIcon_Step_Input", ids);
+        Assert.Contains("ImageUnitWaitIcon_W0_Input", ids);
+        Assert.Contains("ImageUnitWaitIcon_W2_Input", ids);
+        Assert.Contains("ImageUnitWaitIcon_P4_Input", ids);
+    }
+
+    // ====================================================================
+    // ROM-backed: select populates fields + previews
+    // ====================================================================
+    [AvaloniaFact]
+    public void Select_Populates_Fields_And_Previews()
+    {
+        if (!TryRom()) return;
+        ROM rom = _fixture.ROM!;
+
+        var view = new ImageUnitWaitIconView();
+        view.Show();
+        try
+        {
+            var list = view.FindControl<AddressListControl>("EntryList");
+            Assert.NotNull(list);
+            list!.SelectFirst();
+
+            var vm = view.DataViewModel as ImageUnitWaitIconViewModel;
+            Assert.NotNull(vm);
+            Assert.True(vm!.IsLoaded);
+
+            // Fields reflect ROM data.
+            uint addr = vm.CurrentAddr;
+            Assert.Equal((ushort)rom.u16(addr + 0), vm.W0);
+            Assert.Equal((ushort)rom.u16(addr + 2), vm.W2);
+            Assert.Equal(rom.u32(addr + 4), vm.P4);
+
+            // Both previews render a non-null image for a valid entry.
+            using IImage sheet = vm.RenderFullSheet();
+            using IImage frame = vm.RenderFrame();
+            // First entry might be a placeholder; pick a known-valid entry too.
+            uint idx = FirstValidWaitIndex(rom);
+            list.SelectByIndex((int)idx);
+            using IImage sheet2 = vm.RenderFullSheet();
+            using IImage frame2 = vm.RenderFrame();
+            Assert.NotNull(sheet2);
+            Assert.NotNull(frame2);
+            Assert.True(frame2!.Width is 16 or 32);
+        }
+        finally { view.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void PaletteCombo_And_Step_RefreshSingleFramePreview()
+    {
+        if (!TryRom()) return;
+        ROM rom = _fixture.ROM!;
+
+        var view = new ImageUnitWaitIconView();
+        view.Show();
+        try
+        {
+            var list = view.FindControl<AddressListControl>("EntryList");
+            uint idx = FirstValidWaitIndex(rom);
+            list!.SelectByIndex((int)idx);
+
+            var vm = view.DataViewModel as ImageUnitWaitIconViewModel;
+            Assert.NotNull(vm);
+
+            // Drive the palette combo + step NUD; the single-frame render must
+            // still produce a valid image (palette type / step flow through).
+            var palette = view.FindControl<ComboBox>("PaletteCombo");
+            palette!.SelectedIndex = 2; // enemy
+            Assert.Equal(2, vm!.PaletteType);
+
+            var step = view.FindControl<NumericUpDown>("StepBox");
+            step!.Value = 1;
+            Assert.Equal(1, vm.Step);
+
+            using IImage frame = vm.RenderFrame();
+            // A short strip may legitimately fail step 1; just assert no throw +
+            // (when produced) a sane size.
+            if (frame != null)
+                Assert.True(frame.Width is 16 or 32);
+        }
+        finally { view.Close(); }
+    }
+
+    // ====================================================================
+    // ROM-backed: export
+    // ====================================================================
+    [AvaloniaFact]
+    public void Export_Png_Writes_File()
+    {
+        if (!TryRom()) return;
+        ROM rom = _fixture.ROM!;
+
+        var view = new ImageUnitWaitIconView();
+        view.Show();
+        try
+        {
+            var list = view.FindControl<AddressListControl>("EntryList");
+            list!.SelectByIndex((int)FirstValidWaitIndex(rom));
+            var vm = view.DataViewModel as ImageUnitWaitIconViewModel;
+
+            string path = Path.Combine(Path.GetTempPath(), $"waiticon_{System.Guid.NewGuid():N}.png");
+            try
+            {
+                Assert.True(vm!.ExportPng(path));
+                Assert.True(File.Exists(path));
+                Assert.True(new FileInfo(path).Length > 0);
+            }
+            finally { if (File.Exists(path)) File.Delete(path); }
+        }
+        finally { view.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void Export_Gif_Writes_File_With_3_Frames()
+    {
+        if (!TryRom()) return;
+        ROM rom = _fixture.ROM!;
+
+        var view = new ImageUnitWaitIconView();
+        view.Show();
+        try
+        {
+            var list = view.FindControl<AddressListControl>("EntryList");
+            list!.SelectByIndex((int)FirstValidWaitIndex(rom));
+            var vm = view.DataViewModel as ImageUnitWaitIconViewModel;
+
+            string path = Path.Combine(Path.GetTempPath(), $"waiticon_{System.Guid.NewGuid():N}.gif");
+            try
+            {
+                Assert.True(vm!.ExportGif(path));
+                Assert.True(File.Exists(path));
+                byte[] bytes = File.ReadAllBytes(path);
+                Assert.True(bytes.Length > 0);
+                // GIF89a header.
+                Assert.Equal((byte)'G', bytes[0]);
+                Assert.Equal((byte)'I', bytes[1]);
+                Assert.Equal((byte)'F', bytes[2]);
+                // Exactly 3 image-descriptor blocks (0x2C separators).
+                int imageBlocks = bytes.Count(b => b == 0x2C);
+                Assert.Equal(3, imageBlocks);
+            }
+            finally { if (File.Exists(path)) File.Delete(path); }
+        }
+        finally { view.Close(); }
+    }
+
+    // ====================================================================
+    // ROM-backed: import
+    // ====================================================================
+    [AvaloniaFact]
+    public void Import_16x48_Sets_B2_0_And_Writes_Pointer()
+    {
+        if (!TryRom()) return;
+        ROM rom = _fixture.ROM!;
+
+        var view = new ImageUnitWaitIconView();
+        view.Show();
+        try
+        {
+            var list = view.FindControl<AddressListControl>("EntryList");
+            uint idx = FirstValidWaitIndex(rom);
+            list!.SelectByIndex((int)idx);
+            var vm = view.DataViewModel as ImageUnitWaitIconViewModel;
+            uint addr = vm!.CurrentAddr;
+
+            // Drive the Core import seam directly (the View's Import_Click uses
+            // an OS file dialog we can't open headless; the seam is the unit
+            // under test). 16x48 indexed → b2 0 + repoint.
+            byte[] px = new byte[16 * 48];
+            for (int i = 0; i < px.Length; i++) px[i] = (byte)(i % 16);
+
+            uint p4Before = rom.u32(addr + 4);
+            using (ROM.BeginUndoScope(CoreState.Undo?.NewUndoData("test") ?? new Undo.UndoData()))
+            {
+                string err = WaitIconImportCore.Import(rom, addr, px, 16, 48);
+                Assert.Equal("", err);
+            }
+            Assert.Equal(0u, rom.u16(addr + 2));
+            Assert.True(U.isPointer(rom.u32(addr + 4)));
+            Assert.NotEqual(p4Before, rom.u32(addr + 4));
+        }
+        finally { view.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void Import_WrongSize_Rejected_NoMutation()
+    {
+        if (!TryRom()) return;
+        ROM rom = _fixture.ROM!;
+
+        var view = new ImageUnitWaitIconView();
+        view.Show();
+        try
+        {
+            var list = view.FindControl<AddressListControl>("EntryList");
+            list!.SelectByIndex((int)FirstValidWaitIndex(rom));
+            var vm = view.DataViewModel as ImageUnitWaitIconViewModel;
+            uint addr = vm!.CurrentAddr;
+
+            byte[] before = (byte[])rom.Data.Clone();
+            string err = WaitIconImportCore.Import(rom, addr, new byte[24 * 24], 24, 24);
+            Assert.False(string.IsNullOrEmpty(err));
+            Assert.Equal(before, rom.Data); // byte-identical
+        }
+        finally { view.Close(); }
+    }
+
+    // ====================================================================
+    // ROM-backed: jump-to-move-icon + comment
+    // ====================================================================
+    [AvaloniaFact]
+    public void JumpMoveIcon_Resolves_For_OwnedWaitIcon()
+    {
+        if (!TryRom()) return;
+        ROM rom = _fixture.ROM!;
+
+        // Pick a wait-icon id that an owning class references.
+        uint classBase = rom.p32(rom.RomInfo.class_pointer);
+        uint classSize = rom.RomInfo.class_datasize;
+        uint ownedWaitId = 0;
+        for (uint c = 1; c <= 128; c++)
+        {
+            uint a = classBase + c * classSize;
+            if (a + classSize > (uint)rom.Data.Length) break;
+            uint w = rom.u8(a + 6);
+            if (w > 0) { ownedWaitId = w; break; }
+        }
+        if (ownedWaitId == 0) { _output.WriteLine("SKIP: no owned wait icon"); return; }
+
+        var view = new ImageUnitWaitIconView();
+        view.Show();
+        try
+        {
+            var list = view.FindControl<AddressListControl>("EntryList");
+            list!.SelectByIndex((int)ownedWaitId);
+            var vm = view.DataViewModel as ImageUnitWaitIconViewModel;
+
+            uint? moveIcon = vm!.ResolveMoveIconForSelection();
+            Assert.NotNull(moveIcon);
+        }
+        finally { view.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void Comment_Saves_And_Reloads()
+    {
+        if (!TryRom()) return;
+        ROM rom = _fixture.ROM!;
+
+        var view = new ImageUnitWaitIconView();
+        view.Show();
+        try
+        {
+            var list = view.FindControl<AddressListControl>("EntryList");
+            list!.SelectByIndex((int)FirstValidWaitIndex(rom));
+            var vm = view.DataViewModel as ImageUnitWaitIconViewModel;
+
+            string text = "wait-icon-comment-" + System.Guid.NewGuid().ToString("N").Substring(0, 8);
+            vm!.SaveComment(text);
+            vm.Comment = string.Empty;
+            vm.LoadComment();
+            Assert.Equal(text, vm.Comment);
+        }
+        finally { view.Close(); }
+    }
+
+    // ====================================================================
+    // Real-pixel render oracle (SkiaSharp decoder) — proves the extracted
+    // WaitIconRenderCore is pixel-identical to the step-0 self render the
+    // delegating PreviewIconHelper relies on, and per-animType crop sizes.
+    // ====================================================================
+    [AvaloniaFact]
+    public void RenderClassWaitIcon_PixelEquals_RenderFrameStep0_RealDecoder()
+    {
+        if (!TryRom()) return;
+        ROM rom = _fixture.ROM!;
+        var svc = CoreState.ImageService;
+
+        int compared = 0;
+        for (uint idx = 1; idx < 60; idx++)
+        {
+            using IImage a = WaitIconRenderCore.RenderClassWaitIcon(rom, idx, svc, 0);
+            using IImage b = WaitIconRenderCore.RenderFrame(rom, idx, 0, svc, 0);
+            if (a == null && b == null) continue;
+            Assert.NotNull(a);
+            Assert.NotNull(b);
+            Assert.Equal(a!.Width, b!.Width);
+            Assert.Equal(a.Height, b.Height);
+            Assert.Equal(a.GetPixelData(), b.GetPixelData());     // REAL pixels
+            Assert.Equal(a.GetPaletteRGBA(), b.GetPaletteRGBA());
+            compared++;
+        }
+        Assert.True(compared > 0, "At least one wait icon should have been compared.");
+    }
+
+    // ====================================================================
+    // List termination (documented residual): the shared list-stop is the
+    // first non-pointer @+4 (ListParityHelper + sibling editors). WF accepts
+    // row 0 unconditionally and treats `P4==0 && flags!=0` as non-terminal;
+    // this PR keeps the shared contract. This test asserts the CURRENT vanilla
+    // behavior so a future change to the shared stop logic is visible.
+    // ====================================================================
+    [AvaloniaFact]
+    public void List_StopsAtFirstNonPointerP4_VanillaBehavior()
+    {
+        if (!TryRom()) return;
+        ROM rom = _fixture.ROM!;
+
+        var vm = new ImageUnitWaitIconViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        // Every listed row must have a pointer at +4 (the stop condition).
+        foreach (var row in list)
+            Assert.True(U.isPointer(rom.u32(row.addr + 4)),
+                $"Listed wait-icon row 0x{row.addr:X08} must have a pointer at +4.");
+
+        // The row immediately AFTER the last listed one is the terminator:
+        // its +4 is NOT a pointer (documents the shared first-non-pointer stop).
+        uint baseAddr = rom.p32(rom.RomInfo.unit_wait_icon_pointer);
+        uint termAddr = baseAddr + (uint)list.Count * 8;
+        if (termAddr + 8 <= (uint)rom.Data.Length)
+            Assert.False(U.isPointer(rom.u32(termAddr + 4)),
+                "The first unlisted row's +4 must be a non-pointer terminator.");
+    }
+
+    [AvaloniaTheory]
+    [InlineData((byte)0, 16, 16)]
+    [InlineData((byte)1, 16, 24)]
+    [InlineData((byte)2, 32, 32)]
+    public void RenderFrame_Step0_AnimType_HasExpectedSize_RealDecoder(byte animType, int w, int h)
+    {
+        if (!TryRom()) return;
+        ROM rom = _fixture.ROM!;
+        var svc = CoreState.ImageService;
+
+        uint baseAddr = rom.p32(rom.RomInfo.unit_wait_icon_pointer);
+        uint? found = null;
+        for (uint i = 1; i < 0x100; i++)
+        {
+            uint a = baseAddr + i * 8;
+            if (a + 8 > (uint)rom.Data.Length) break;
+            if (!U.isPointer(rom.u32(a + 4))) break;
+            if ((byte)rom.u8(a + 2) == animType) { found = i; break; }
+        }
+        if (found == null) { _output.WriteLine($"SKIP: no wait icon with animType {animType}"); return; }
+
+        using IImage img = WaitIconRenderCore.RenderFrame(rom, found.Value, 0, svc, 0);
+        Assert.NotNull(img);
+        Assert.Equal(w, img!.Width);
+        Assert.Equal(h, img.Height);
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/ImageUnitWaitIconViewTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageUnitWaitIconViewTests.cs
@@ -350,6 +350,69 @@ public class ImageUnitWaitIconViewTests : IClassFixture<RomFixture>
 
             uint? moveIcon = vm!.ResolveMoveIconForSelection();
             Assert.NotNull(moveIcon);
+
+            // The move-icon id is 1-BASED; the navigation target must be the
+            // 0-based table entry: baseAddr + (id - 1) * 8 (Copilot review on
+            // PR #993 — the off-by-one fix). id 0 ("no move icon") -> null.
+            uint moveBase = rom.p32(rom.RomInfo.unit_move_icon_pointer);
+            uint? target = vm.ResolveMoveIconEntryAddress();
+            if (moveIcon!.Value == 0)
+            {
+                Assert.Null(target);
+            }
+            else
+            {
+                Assert.NotNull(target);
+                uint expected = moveBase + (moveIcon.Value - 1) * 8;
+                Assert.Equal(expected, target!.Value);
+                // The resolved row must NOT be the naive (id * 8) 0-based read —
+                // regression-fires if the off-by-one returns.
+                Assert.NotEqual(moveBase + moveIcon.Value * 8, target.Value);
+            }
+        }
+        finally { view.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void ResolveMoveIconEntryAddress_IsOneBased_OffByOneRegression()
+    {
+        if (!TryRom()) return;
+        ROM rom = _fixture.ROM!;
+
+        // Find a wait icon whose RESOLVED owning class has a move-icon id >= 1
+        // (derive everything from the VM resolution so the off-by-one assertion
+        // uses the SAME class the View jumps to — first-match resolution may not
+        // be the class we scanned).
+        uint classBase = rom.p32(rom.RomInfo.class_pointer);
+        uint classSize = rom.RomInfo.class_datasize;
+        uint moveBase = rom.p32(rom.RomInfo.unit_move_icon_pointer);
+
+        var view = new ImageUnitWaitIconView();
+        view.Show();
+        try
+        {
+            var list = view.FindControl<AddressListControl>("EntryList");
+            var vm = view.DataViewModel as ImageUnitWaitIconViewModel;
+            Assert.NotNull(vm);
+
+            var items = list!.GetItems();
+            int probed = System.Math.Min(items.Count, 128);
+            bool checkedAny = false;
+            for (int i = 1; i < probed; i++)
+            {
+                list.SelectByIndex(i);
+                uint? moveId = vm!.ResolveMoveIconForSelection();
+                if (moveId == null || moveId.Value == 0) continue;
+
+                uint? target = vm.ResolveMoveIconEntryAddress();
+                Assert.NotNull(target);
+                Assert.Equal(moveBase + (moveId.Value - 1) * 8, target!.Value);
+                // Off-by-one regression guard: must NOT be the naive id*8 row.
+                Assert.NotEqual(moveBase + moveId.Value * 8, target.Value);
+                checkedAny = true;
+                break;
+            }
+            if (!checkedAny) _output.WriteLine("SKIP: no wait icon resolved to a class with move id >= 1");
         }
         finally { view.Close(); }
     }

--- a/FEBuilderGBA.Avalonia.Tests/ListParityHelperTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ListParityHelperTests.cs
@@ -354,6 +354,29 @@ public class ListParityHelperTests : IClassFixture<RomFixture>
         }
     }
 
+    /// <summary>
+    /// #991: the Unit Wait Icon VM list and the golden builder must stay
+    /// byte-for-byte identical — both now append the owning class name via
+    /// ClassFormCore.GetClassNameWhereWaitIconId (lockstep restore).
+    /// </summary>
+    [Fact]
+    public void BuildReferenceList_ImageUnitWaitIcon_MatchesViewModel()
+    {
+        if (!_rom.IsAvailable) return;
+
+        var vm = new ImageUnitWaitIconViewModel();
+        var vmList = vm.LoadList();
+        var refList = ListParityHelper.BuildReferenceList("ImageUnitWaitIconView");
+
+        Assert.NotNull(refList);
+        Assert.Equal(vmList.Count, refList.Count);
+        for (int i = 0; i < vmList.Count; i++)
+        {
+            Assert.Equal(vmList[i].addr, refList[i].addr);
+            Assert.Equal(vmList[i].name, refList[i].name);
+        }
+    }
+
     // ---------------------------------------------------------------
     // SoundBossBGM — lockstep VM vs golden + unresolved-id label (#962)
     // ---------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
@@ -2904,7 +2904,10 @@ namespace FEBuilderGBA.Avalonia.Services
                 uint imgPtr = rom.u32(addr + 4);
                 if (!U.isPointer(imgPtr)) break;
 
-                string name = U.ToHexString(i) + " WaitIcon";
+                // #991: append the owning class name (lockstep with
+                // ImageUnitWaitIconViewModel.LoadList — golden test gated).
+                string className = FEBuilderGBA.Core.ClassFormCore.GetClassNameWhereWaitIconId(rom, i);
+                string name = U.ToHexString(i) + U.SA(className) + " WaitIcon";
                 result.Add(new AddrResult(addr, name, i));
             }
             return result;

--- a/FEBuilderGBA.Avalonia/Services/PreviewIconHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/PreviewIconHelper.cs
@@ -568,6 +568,13 @@ namespace FEBuilderGBA.Avalonia.Services
         /// </summary>
         public static IImage LoadClassWaitIcon(uint waitIconIndex)
         {
+            // #991: the decode + per-animType crop pipeline moved VERBATIM into
+            // the cross-platform FEBuilderGBA.Core.WaitIconRenderCore (single
+            // source of truth — the Avalonia Unit Wait Icon editor reuses it).
+            // This wrapper preserves the existing behavior exactly: resolve the
+            // ambient CoreState ROM + ImageService and render the step-0 frame
+            // with the self palette (the #342/#667 16x24@Y=8 step-0 parity is
+            // baked into RenderClassWaitIcon == RenderFrame(step:0)).
             ROM rom = CoreState.ROM;
             if (rom?.RomInfo == null) return null;
             var svc = CoreState.ImageService;
@@ -575,147 +582,12 @@ namespace FEBuilderGBA.Avalonia.Services
 
             try
             {
-                uint ptr = rom.RomInfo.unit_wait_icon_pointer;
-                if (ptr == 0) return null;
-
-                uint baseAddr = rom.p32(ptr);
-                if (!U.isSafetyOffset(baseAddr)) return null;
-
-                // Each entry in the unit wait icon table is 8 bytes:
-                //   +0: flags (4 bytes), with byte at +2 indicating animation type
-                //   +4: sprite pointer (4 bytes, GBA pointer to LZ77-compressed tile data)
-                uint entryAddr = baseAddr + waitIconIndex * 8;
-                if (entryAddr + 8 > (uint)rom.Data.Length) return null;
-
-                // Read animation type from byte at offset +2 to determine sprite dimensions
-                byte animType = (byte)rom.u8(entryAddr + 2);
-
-                uint spriteGba = rom.u32(entryAddr + 4);
-                if (!U.isPointer(spriteGba)) return null;
-
-                uint spriteAddr = U.toOffset(spriteGba);
-                if (!U.isSafetyOffset(spriteAddr)) return null;
-
-                // Palette: use the unit icon palette address
-                uint palAddr = rom.RomInfo.unit_icon_palette_address;
-                if (palAddr == 0 || !U.isSafetyOffset(palAddr)) return null;
-
-                byte[] palette = ImageUtilCore.GetPalette(palAddr, 16);
-                if (palette == null) return null;
-
-                // Per-animType strip width and per-frame crop rectangle.
-                // Matches WinForms ImageUnitWaitIconFrom.LoadWaitUnitIcon (strip
-                // width = 32 for animType 2, 16 otherwise) and
-                // DrawWaitUnitIcon's first-frame crop for height16_limit=false.
-                int stripWidth;
-                int cropX, cropY, cropW, cropH;
-                if (animType == 2)
-                {
-                    stripWidth = 32;
-                    cropX = 0; cropY = 0; cropW = 32; cropH = 32;
-                }
-                else if (animType == 1)
-                {
-                    stripWidth = 16;
-                    // The strip starts with an 8-pixel padding tile at Y=0..7;
-                    // the actual 16x24 first frame begins at Y=8 (WinForms
-                    // line 138 + 142 in ImageUnitWaitIconFrom.cs).
-                    cropX = 0; cropY = 8; cropW = 16; cropH = 24;
-                }
-                else
-                {
-                    // animType 0 and any unknown value default to the 16x16
-                    // first-frame contract (WinForms line 165 - the `b2 == 0`
-                    // branch with 2*8 width and (2*8) + (b2*8) = 16 height).
-                    stripWidth = 16;
-                    cropX = 0; cropY = 0; cropW = 16; cropH = 16;
-                }
-
-                // Decompress the LZ77 strip and compute its full pixel height.
-                // Mirrors ImageUtil.CalcHeight(width, image_size, align=8):
-                //   ceil(image_size / (width/2)) aligned UP to a multiple of 8.
-                byte[] stripData = LZ77.decompress(rom.Data, spriteAddr);
-                if (stripData == null || stripData.Length == 0) return null;
-
-                int stripHeight = CalcStripHeight(stripWidth, stripData.Length);
-                if (stripHeight <= 0) return null;
-
-                // Bounds-check the crop rectangle against the actual strip size.
-                // If the strip is too short to satisfy the WF crop, bail rather
-                // than render a partial/corrupt image. Matches the null-safety
-                // contract this helper has on every other failure path.
-                if (cropX + cropW > stripWidth) return null;
-                if (cropY + cropH > stripHeight) return null;
-
-                using IImage strip = svc.Decode4bppTiles(
-                    stripData, 0, stripWidth, stripHeight, palette);
-                if (strip == null) return null;
-
-                return CropIndexedRegion(strip, cropX, cropY, cropW, cropH);
+                return FEBuilderGBA.Core.WaitIconRenderCore.RenderClassWaitIcon(rom, waitIconIndex, svc);
             }
             catch
             {
                 return null;
             }
-        }
-
-        /// <summary>
-        /// Compute the rendered strip height from an LZ77-decompressed 4bpp
-        /// byte length. Mirrors WinForms <c>ImageUtil.CalcHeight(width,
-        /// image_size, align=8)</c> exactly so the wait-icon Y=8 crop lines up
-        /// with the WinForms reference even on odd / partial / non-tile-aligned
-        /// decompression lengths.
-        /// </summary>
-        static int CalcStripHeight(int width, int imageSize)
-        {
-            if (width <= 0 || imageSize <= 0) return 0;
-            int half = width / 2;          // 4bpp = 2 pixels/byte
-            if (half <= 0) return 0;
-            int height = imageSize / half;
-            if (imageSize % half != 0) height++;
-            // Align UP to a multiple of 8 rows. WinForms' CalcHeight uses
-            // `if (h % align != 0) h += align;` then `h / align * align` which
-            // is equivalent to ceil(h / align) * align — implement directly.
-            const int align = 8;
-            int remainder = height % align;
-            if (remainder != 0) height += (align - remainder);
-            return height;
-        }
-
-        /// <summary>
-        /// Crop a sub-rectangle out of an indexed strip image, returning a
-        /// fresh indexed <see cref="IImage"/> sharing the strip's palette.
-        /// Used by <see cref="LoadClassWaitIcon"/> to apply the per-animType
-        /// first-frame WF crop rectangle (animType 1's <c>Y=8</c> in
-        /// particular).
-        /// </summary>
-        static IImage CropIndexedRegion(IImage src, int x, int y, int w, int h)
-        {
-            var svc = CoreState.ImageService;
-            if (svc == null) return null;
-            if (src == null) return null;
-            if (!src.IsIndexed) return null;
-
-            byte[] srcIdx = src.GetPixelData();
-            if (srcIdx == null) return null;
-            int srcW = src.Width;
-            int srcH = src.Height;
-            if (x < 0 || y < 0 || w <= 0 || h <= 0) return null;
-            if (x + w > srcW || y + h > srcH) return null;
-            if ((long)srcW * srcH > srcIdx.Length) return null;
-
-            byte[] dstIdx = new byte[w * h];
-            for (int row = 0; row < h; row++)
-            {
-                int srcOff = (y + row) * srcW + x;
-                int dstOff = row * w;
-                Buffer.BlockCopy(srcIdx, srcOff, dstIdx, dstOff, w);
-            }
-
-            IImage outImg = svc.CreateIndexedImage(w, h, src.GetPaletteGBA(), 16);
-            if (outImg == null) return null;
-            outImg.SetPixelData(dstIdx);
-            return outImg;
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageUnitWaitIconViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageUnitWaitIconViewModel.cs
@@ -216,9 +216,13 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         // Jump-to-Move-Icon (#991 WU4)
         // ----------------------------------------------------------------
         /// <summary>
-        /// Resolve the move-icon id for the current wait icon: waitIconId →
-        /// owning class id → that class's move-icon id. Returns null when the
-        /// wait icon has no owning class or the lookups fail.
+        /// Resolve the 1-BASED move-icon id for the current wait icon:
+        /// waitIconId → owning class id → that class's move-icon id (`u8 @
+        /// class+4`). Returns null when the wait icon has no owning class, the
+        /// lookups fail, OR the move-icon id is 0 ("no move icon" — the WF
+        /// sentinel). Returning null for 0 (rather than the raw 0) means a
+        /// caller can safely subtract 1 to get the 0-based table index without
+        /// underflowing (Copilot review on PR #993).
         /// </summary>
         public uint? ResolveMoveIconForSelection()
         {
@@ -228,6 +232,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (cid == U.NOT_FOUND) return null;
             uint moveIcon = ClassFormCore.GetClassMoveIcon(rom, cid);
             if (moveIcon == U.NOT_FOUND) return null;
+            if (moveIcon == 0) return null; // 0 = "no move icon" (WF sentinel)
             return moveIcon;
         }
 

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageUnitWaitIconViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageUnitWaitIconViewModel.cs
@@ -231,6 +231,32 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             return moveIcon;
         }
 
+        /// <summary>
+        /// Resolve the ROM ADDRESS of the Move Icon list entry the Jump button
+        /// should navigate to, or null when there is no owning class / move icon.
+        /// The class move-icon field (u8 @ class+4) is a 1-BASED id (WF
+        /// PreviewIconHelper.LoadMoveIcon uses `id - 1`; ImageUnitMoveIconViewModel
+        /// .LoadList is 0-based by table index), so the target entry is at
+        /// `baseAddr + (id - 1) * 8`. id 0 ("no move icon") → null. Guards every
+        /// pointer/address — never throws.
+        /// </summary>
+        public uint? ResolveMoveIconEntryAddress()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return null;
+            uint? moveIcon = ResolveMoveIconForSelection();
+            if (moveIcon == null || moveIcon.Value == 0) return null;
+
+            uint ptr = rom.RomInfo.unit_move_icon_pointer;
+            if (ptr == 0) return null;
+            uint baseAddr = rom.p32(ptr);
+            if (!U.isSafetyOffset(baseAddr)) return null;
+
+            uint entryAddr = baseAddr + (moveIcon.Value - 1) * 8;
+            if (entryAddr + 8 > (uint)rom.Data.Length) return null;
+            return entryAddr;
+        }
+
         public int GetListCount() => LoadList().Count;
 
         public Dictionary<string, string> GetDataReport()

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageUnitWaitIconViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageUnitWaitIconViewModel.cs
@@ -255,7 +255,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             uint ptr = rom.RomInfo.unit_move_icon_pointer;
             if (ptr == 0) return null;
             uint baseAddr = rom.p32(ptr);
-            if (!U.isSafetyOffset(baseAddr)) return null;
+            // rom-consistent guard (#993 Copilot review): validate against the
+            // local `rom` instance, not the ambient CoreState.ROM.
+            if (!U.isSafetyOffset(baseAddr, rom)) return null;
 
             uint entryAddr = baseAddr + (moveIcon.Value - 1) * 8;
             if (entryAddr + 8 > (uint)rom.Data.Length) return null;

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageUnitWaitIconViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageUnitWaitIconViewModel.cs
@@ -1,21 +1,38 @@
 using System;
 using System.Collections.Generic;
 using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Core;
 
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
     public class ImageUnitWaitIconViewModel : ViewModelBase, IDataVerifiable
     {
+        const uint SIZE = 8;
+
         uint _currentAddr;
+        int _currentIndex;
         bool _isLoaded;
         ushort _w0, _w2;
         uint _p4;
+        int _paletteType;
+        int _step;
+        string _comment = string.Empty;
 
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
+        public int CurrentIndex { get => _currentIndex; set => SetField(ref _currentIndex, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
         public ushort W0 { get => _w0; set => SetField(ref _w0, value); }
         public ushort W2 { get => _w2; set => SetField(ref _w2, value); }
         public uint P4 { get => _p4; set => SetField(ref _p4, value); }
+
+        /// <summary>0=self,1=npc,2=enemy,3=gray,4=four (the 5 selectable types).</summary>
+        public int PaletteType { get => _paletteType; set => SetField(ref _paletteType, value); }
+        /// <summary>Frame step 0..2 for the single-frame preview.</summary>
+        public int Step { get => _step; set => SetField(ref _step, value); }
+        public string Comment { get => _comment; set => SetField(ref _comment, value); }
+
+        /// <summary>The 8-byte table entry address of the loaded wait icon.</summary>
+        public uint EntryAddress => _currentAddr;
 
         public List<AddrResult> LoadList()
         {
@@ -31,13 +48,17 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             var result = new List<AddrResult>();
             for (uint i = 0; i < 0x100; i++)
             {
-                uint addr = (uint)(baseAddr + i * 8);
-                if (addr + 8 > (uint)rom.Data.Length) break;
+                uint addr = (uint)(baseAddr + i * SIZE);
+                if (addr + SIZE > (uint)rom.Data.Length) break;
 
                 uint imgPtr = rom.u32(addr + 4);
                 if (!U.isPointer(imgPtr)) break;
 
-                string name = U.ToHexString(i) + " WaitIcon";
+                // #991: append the owning class name (lockstep with
+                // ListParityHelper.BuildImageUnitWaitIconList — golden test
+                // gated). U.SA prefixes a single space iff the name is non-empty.
+                string className = ClassFormCore.GetClassNameWhereWaitIconId(rom, i);
+                string name = U.ToHexString(i) + U.SA(className) + " WaitIcon";
                 result.Add(new AddrResult(addr, name, i));
             }
             return result;
@@ -47,13 +68,167 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         {
             ROM rom = CoreState.ROM;
             if (rom == null) return;
-            if (addr + 8 > (uint)rom.Data.Length) return;
+            if (addr + SIZE > (uint)rom.Data.Length) return;
 
             CurrentAddr = addr;
             W0 = (ushort)rom.u16(addr + 0);
             W2 = (ushort)rom.u16(addr + 2);
             P4 = rom.u32(addr + 4);
+
+            // Row index relative to the wait-icon table base (= waitIconId).
+            uint ptr = rom.RomInfo.unit_wait_icon_pointer;
+            uint baseAddr = ptr != 0 ? rom.p32(ptr) : 0;
+            CurrentIndex = (baseAddr != 0 && addr >= baseAddr)
+                ? (int)((addr - baseAddr) / SIZE)
+                : 0;
+
+            LoadComment();
             IsLoaded = true;
+        }
+
+        /// <summary>Re-read the entry fields + comment from ROM (post-import refresh).</summary>
+        public void ReloadEntry()
+        {
+            if (CurrentAddr != 0) LoadEntry(CurrentAddr);
+        }
+
+        // ----------------------------------------------------------------
+        // Comment (mirror ImageBattleBGViewModel)
+        // ----------------------------------------------------------------
+        public void LoadComment()
+        {
+            var cache = CoreState.CommentCache;
+            Comment = (cache != null) ? (cache.S_At(CurrentAddr) ?? string.Empty) : string.Empty;
+        }
+
+        public void SaveComment(string text)
+        {
+            Comment = text ?? string.Empty;
+            var cache = CoreState.CommentCache;
+            if (cache == null || CurrentAddr == 0) return;
+            cache.Update(CurrentAddr, Comment);
+        }
+
+        // ----------------------------------------------------------------
+        // Write fields back (W0/W2 as u16, P4 as a RAW GBA pointer)
+        // ----------------------------------------------------------------
+        public void Write()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null || CurrentAddr == 0) return;
+
+            uint addr = CurrentAddr;
+            rom.write_u16(addr + 0, W0);
+            rom.write_u16(addr + 2, W2);
+            // P4 is a RAW GBA pointer field — write the value verbatim
+            // (write_u32, NOT write_p32 which would re-apply the 0x08000000
+            // offset).
+            rom.write_u32(addr + 4, P4);
+            SaveComment(Comment);
+        }
+
+        // ----------------------------------------------------------------
+        // Previews
+        // ----------------------------------------------------------------
+        /// <summary>Render the full decoded sprite sheet (no crop) for X_PIC.</summary>
+        public IImage RenderFullSheet()
+        {
+            ROM rom = CoreState.ROM;
+            var svc = CoreState.ImageService;
+            if (rom == null || svc == null) return null;
+            return WaitIconRenderCore.RenderFullSheet(rom, (uint)CurrentIndex, svc, PaletteType);
+        }
+
+        /// <summary>Render the single <see cref="Step"/> frame for X_ONE_PIC.</summary>
+        public IImage RenderFrame()
+        {
+            ROM rom = CoreState.ROM;
+            var svc = CoreState.ImageService;
+            if (rom == null || svc == null) return null;
+            return WaitIconRenderCore.RenderFrame(rom, (uint)CurrentIndex, Step, svc, PaletteType);
+        }
+
+        // ----------------------------------------------------------------
+        // Export (#991 WU2)
+        // ----------------------------------------------------------------
+        /// <summary>Export the full decoded sheet as an indexed PNG.</summary>
+        public bool ExportPng(string path)
+        {
+            using IImage img = RenderFullSheet();
+            if (img == null) return false;
+            img.Save(path);
+            return true;
+        }
+
+        /// <summary>
+        /// Export the 3 animation frames (step 0..2) as an animated GIF.
+        /// Mirrors WF <c>ImageUnitWaitIconFrom.SaveAnimeGif</c> (wait=10 game
+        /// frames per frame). Mirrors the SkillConfig export's GifEncoder usage.
+        /// </summary>
+        public bool ExportGif(string path)
+        {
+            ROM rom = CoreState.ROM;
+            var svc = CoreState.ImageService;
+            if (rom == null || svc == null) return false;
+
+            var gifFrames = new List<GifEncoderCore.GifFrame>();
+            var rendered = new List<IImage>();
+            try
+            {
+                for (int step = 0; step < 3; step++)
+                {
+                    IImage img = WaitIconRenderCore.RenderFrame(rom, (uint)CurrentIndex, step, svc, PaletteType);
+                    if (img == null) return false;
+                    rendered.Add(img);
+
+                    byte[] rgba;
+                    if (img.IsIndexed)
+                    {
+                        byte[] indexed = img.GetPixelData();
+                        byte[] palette = img.GetPaletteRGBA();
+                        rgba = GifEncoderCore.IndexedToRgba(indexed, palette, img.Width, img.Height);
+                    }
+                    else
+                    {
+                        rgba = img.GetPixelData();
+                    }
+
+                    gifFrames.Add(new GifEncoderCore.GifFrame
+                    {
+                        Width = img.Width,
+                        Height = img.Height,
+                        RgbaPixels = rgba,
+                        DelayCs = U.GameFrameSecToGifFrameSec(10),
+                    });
+                }
+
+                GifEncoderCore.Encode(gifFrames, path);
+                return true;
+            }
+            finally
+            {
+                // Each RenderFrame produces a fresh image — dispose all 3.
+                foreach (var img in rendered) img.Dispose();
+            }
+        }
+
+        // ----------------------------------------------------------------
+        // Jump-to-Move-Icon (#991 WU4)
+        // ----------------------------------------------------------------
+        /// <summary>
+        /// Resolve the move-icon id for the current wait icon: waitIconId →
+        /// owning class id → that class's move-icon id. Returns null when the
+        /// wait icon has no owning class or the lookups fail.
+        /// </summary>
+        public uint? ResolveMoveIconForSelection()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null) return null;
+            uint cid = ClassFormCore.GetClassIdWhereWaitIconId(rom, (uint)CurrentIndex);
+            if (cid == U.NOT_FOUND) return null;
+            uint moveIcon = ClassFormCore.GetClassMoveIcon(rom, cid);
+            if (moveIcon == U.NOT_FOUND) return null;
+            return moveIcon;
         }
 
         public int GetListCount() => LoadList().Count;

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitWaitIconView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitWaitIconView.axaml
@@ -42,14 +42,20 @@
         <!-- Preview controls: palette + step -->
         <Grid ColumnDefinitions="140,200" RowDefinitions="Auto,Auto">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Palette:" VerticalAlignment="Center" />
+          <!-- Palette items are English-source TextBlocks so the shared
+               ViewTranslationHelper (run on TranslatedWindow.Opened) localizes
+               them via R._() — raw ComboBoxItem string content is NOT scanned
+               (#993 Copilot review). Translations live in
+               config/translate/{ja,en,zh}.txt. Read by SelectedIndex (0..4 =
+               self/ally/enemy/gray/four), so the label text is display-only. -->
           <ComboBox AutomationProperties.AutomationId="ImageUnitWaitIcon_Palette_Combo"
                     Grid.Row="0" Grid.Column="1" Name="PaletteCombo"
                     SelectionChanged="Palette_Changed" HorizontalAlignment="Stretch">
-            <ComboBoxItem>自軍</ComboBoxItem>
-            <ComboBoxItem>友軍</ComboBoxItem>
-            <ComboBoxItem>敵軍</ComboBoxItem>
-            <ComboBoxItem>グレー</ComboBoxItem>
-            <ComboBoxItem>4軍</ComboBoxItem>
+            <ComboBoxItem><TextBlock Text="Self Army" /></ComboBoxItem>
+            <ComboBoxItem><TextBlock Text="Ally Army" /></ComboBoxItem>
+            <ComboBoxItem><TextBlock Text="Enemy Army" /></ComboBoxItem>
+            <ComboBoxItem><TextBlock Text="Gray Army" /></ComboBoxItem>
+            <ComboBoxItem><TextBlock Text="Four Army" /></ComboBoxItem>
           </ComboBox>
 
           <TextBlock Grid.Row="1" Grid.Column="0" Text="Frame Step:" VerticalAlignment="Center" />

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitWaitIconView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitWaitIconView.axaml
@@ -2,20 +2,100 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
         x:Class="FEBuilderGBA.Avalonia.Views.ImageUnitWaitIconView"
-        Title="Unit Wait Icon" Width="860" Height="383"
+        Title="Unit Wait Icon" Width="900" Height="520"
         SizeToContent="WidthAndHeight">
-  <Grid ColumnDefinitions="250,*">
-    <controls:AddressListControl AutomationProperties.AutomationId="ImageUnitWaitIcon_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
+  <Grid ColumnDefinitions="250,*" RowDefinitions="*,Auto">
+    <controls:AddressListControl AutomationProperties.AutomationId="ImageUnitWaitIcon_Entry_List"
+                                 Grid.Row="0" Grid.Column="0" Name="EntryList" Margin="4" />
 
-    <ScrollViewer Grid.Column="1" Margin="4">
+    <ScrollViewer Grid.Row="0" Grid.Column="1" Margin="4">
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Unit Wait Icon" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
+        <!-- Address + Write -->
+        <Grid ColumnDefinitions="140,200,Auto" RowDefinitions="Auto">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="ImageUnitWaitIcon_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+          <TextBlock AutomationProperties.AutomationId="ImageUnitWaitIcon_Addr_Label"
+                     Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+          <Button AutomationProperties.AutomationId="ImageUnitWaitIcon_Write_Button"
+                  Grid.Row="0" Grid.Column="2" Content="Write" Click="Write_Click" Margin="8,0,0,0" />
+        </Grid>
+
+        <!-- Field rows: W0 / W2 / P4 -->
+        <Grid ColumnDefinitions="140,200" RowDefinitions="Auto,Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Flags (W0):" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="ImageUnitWaitIcon_W0_Input"
+                         Grid.Row="0" Grid.Column="1" Name="W0Box"
+                         Minimum="0" Maximum="65535" Increment="1" FormatString="0" />
+
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="Anime Type (W2):" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="ImageUnitWaitIcon_W2_Input"
+                         Grid.Row="1" Grid.Column="1" Name="W2Box"
+                         Minimum="0" Maximum="65535" Increment="1" FormatString="0" />
+
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Image Pointer (P4):" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="ImageUnitWaitIcon_P4_Input"
+                         Grid.Row="2" Grid.Column="1" Name="P4Box"
+                         Minimum="0" Maximum="4294967295" Increment="1" FormatString="0" />
+        </Grid>
+
+        <!-- Preview controls: palette + step -->
+        <Grid ColumnDefinitions="140,200" RowDefinitions="Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Palette:" VerticalAlignment="Center" />
+          <ComboBox AutomationProperties.AutomationId="ImageUnitWaitIcon_Palette_Combo"
+                    Grid.Row="0" Grid.Column="1" Name="PaletteCombo"
+                    SelectionChanged="Palette_Changed" HorizontalAlignment="Stretch">
+            <ComboBoxItem>自軍</ComboBoxItem>
+            <ComboBoxItem>友軍</ComboBoxItem>
+            <ComboBoxItem>敵軍</ComboBoxItem>
+            <ComboBoxItem>グレー</ComboBoxItem>
+            <ComboBoxItem>4軍</ComboBoxItem>
+          </ComboBox>
+
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="Frame Step:" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="ImageUnitWaitIcon_Step_Input"
+                         Grid.Row="1" Grid.Column="1" Name="StepBox"
+                         Minimum="0" Maximum="2" Increment="1" FormatString="0"
+                         ValueChanged="Step_Changed" />
+        </Grid>
+
+        <!-- Previews: full sheet + single frame -->
+        <StackPanel Orientation="Horizontal" Spacing="16" Margin="0,8,0,0">
+          <StackPanel Spacing="4">
+            <TextBlock Text="Full Sheet" FontWeight="Bold" />
+            <Border BorderBrush="Gray" BorderThickness="1" MinWidth="64" MinHeight="64">
+              <controls:GbaImageControl AutomationProperties.AutomationId="ImageUnitWaitIcon_Sheet_Image"
+                                        Name="SheetImage" />
+            </Border>
+          </StackPanel>
+          <StackPanel Spacing="4">
+            <TextBlock Text="Frame" FontWeight="Bold" />
+            <Border BorderBrush="Gray" BorderThickness="1" MinWidth="64" MinHeight="64">
+              <controls:GbaImageControl AutomationProperties.AutomationId="ImageUnitWaitIcon_Frame_Image"
+                                        Name="FrameImage" />
+            </Border>
+          </StackPanel>
+        </StackPanel>
+
+        <!-- Comment -->
+        <Grid ColumnDefinitions="140,200" RowDefinitions="Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Comment:" VerticalAlignment="Center" />
+          <TextBox AutomationProperties.AutomationId="ImageUnitWaitIcon_Comment_Input"
+                   Grid.Row="0" Grid.Column="1" Name="CommentBox" />
         </Grid>
       </StackPanel>
     </ScrollViewer>
+
+    <!-- Bottom button bar -->
+    <Border Grid.Row="1" Grid.ColumnSpan="2" BorderBrush="Gray" BorderThickness="1" Margin="4">
+      <StackPanel Orientation="Horizontal" Spacing="8" Margin="4">
+        <Button AutomationProperties.AutomationId="ImageUnitWaitIcon_Import_Button"
+                Content="Import Image" Click="Import_Click" />
+        <Button AutomationProperties.AutomationId="ImageUnitWaitIcon_Export_Button"
+                Content="Export Image" Click="Export_Click" />
+        <Button AutomationProperties.AutomationId="ImageUnitWaitIcon_JumpMoveIcon_Button"
+                Content="Jump to Move Icon" Click="JumpMoveIcon_Click" />
+      </StackPanel>
+    </Border>
   </Grid>
 </Window>

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitWaitIconView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitWaitIconView.axaml.cs
@@ -208,22 +208,13 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                ROM rom = CoreState.ROM;
-                if (rom == null) return;
+                // VM owns the 1-based id -> 0-based Move Icon list-entry address
+                // conversion (single source of truth, headless-tested). null =>
+                // no owning class / no move icon / out-of-range.
+                uint? entryAddr = _vm.ResolveMoveIconEntryAddress();
+                if (entryAddr == null) return;
 
-                uint? moveIcon = _vm.ResolveMoveIconForSelection();
-                if (moveIcon == null) return; // no owning class / no move icon
-
-                // Compute the unit_move_icon_pointer list-entry address (8-byte
-                // entries; the move-icon id is the 0-based table index).
-                uint ptr = rom.RomInfo.unit_move_icon_pointer;
-                if (ptr == 0) return;
-                uint baseAddr = rom.p32(ptr);
-                if (!U.isSafetyOffset(baseAddr)) return;
-                uint entryAddr = baseAddr + moveIcon.Value * 8;
-                if (entryAddr + 8 > (uint)rom.Data.Length) return;
-
-                WindowManager.Instance.Navigate<ImageUnitMoveIconView>(entryAddr);
+                WindowManager.Instance.Navigate<ImageUnitMoveIconView>(entryAddr.Value);
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitWaitIconView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitWaitIconView.axaml.cs
@@ -1,14 +1,19 @@
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
+using FEBuilderGBA.Avalonia.Dialogs;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Core;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
     public partial class ImageUnitWaitIconView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ImageUnitWaitIconViewModel _vm = new();
+        readonly UndoService _undoService = new();
+        bool _suppressPreviewRefresh;
+        bool _initialized;
 
         public string ViewTitle => "Unit Wait Icon";
         public bool IsLoaded => _vm.IsLoaded;
@@ -18,6 +23,15 @@ namespace FEBuilderGBA.Avalonia.Views
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
             Opened += (_, _) => LoadList();
+
+            // Comment lost-focus → save (mirrors ImageBattleBGView).
+            CommentBox.LostFocus += (_, _) => _vm.SaveComment(CommentBox.Text ?? string.Empty);
+
+            // Default to the self-army palette; do it AFTER InitializeComponent
+            // (and with the init guard already armed by the handler) so the
+            // SelectionChanged handler doesn't fire mid-construction.
+            PaletteCombo.SelectedIndex = 0;
+            _initialized = true;
         }
 
         void LoadList()
@@ -38,6 +52,9 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 _vm.LoadEntry(addr);
+                // Reset to frame 0 on each new selection (mirrors WF
+                // X_ONE_STEP.Value = 0 in AddressList_SelectedIndexChanged).
+                _vm.Step = 0;
                 UpdateUI();
             }
             catch (Exception ex)
@@ -48,7 +65,170 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void UpdateUI()
         {
-            AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            _suppressPreviewRefresh = true;
+            try
+            {
+                AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+                W0Box.Value = _vm.W0;
+                W2Box.Value = _vm.W2;
+                P4Box.Value = _vm.P4;
+                StepBox.Value = _vm.Step;
+                CommentBox.Text = _vm.Comment;
+            }
+            finally
+            {
+                _suppressPreviewRefresh = false;
+            }
+            RefreshPreviews();
+        }
+
+        void RefreshPreviews()
+        {
+            try { SheetImage.SetImage(_vm.RenderFullSheet()); }
+            catch { SheetImage.SetImage(null); }
+            RefreshFramePreview();
+        }
+
+        void RefreshFramePreview()
+        {
+            try { FrameImage.SetImage(_vm.RenderFrame()); }
+            catch { FrameImage.SetImage(null); }
+        }
+
+        void Palette_Changed(object? sender, SelectionChangedEventArgs e)
+        {
+            if (!_initialized || _suppressPreviewRefresh) return;
+            _vm.PaletteType = PaletteCombo.SelectedIndex < 0 ? 0 : PaletteCombo.SelectedIndex;
+            // Both previews depend on the palette.
+            RefreshPreviews();
+        }
+
+        void Step_Changed(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            if (!_initialized || _suppressPreviewRefresh) return;
+            _vm.Step = (int)(StepBox.Value ?? 0);
+            RefreshFramePreview();
+        }
+
+        void Write_Click(object? sender, RoutedEventArgs e)
+        {
+            _undoService.Begin("Edit Unit Wait Icon");
+            try
+            {
+                _vm.W0 = (ushort)(W0Box.Value ?? 0);
+                _vm.W2 = (ushort)(W2Box.Value ?? 0);
+                _vm.P4 = (uint)(P4Box.Value ?? 0);
+                _vm.SaveComment(CommentBox.Text ?? string.Empty);
+                _vm.Write();
+                _undoService.Commit();
+                _vm.MarkClean();
+                RefreshPreviews();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                CoreState.Services?.ShowError($"Write failed: {ex.Message}");
+            }
+        }
+
+        async void Import_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                ROM rom = CoreState.ROM;
+                if (rom == null) return;
+                if (_vm.CurrentAddr == 0) { CoreState.Services?.ShowError("No wait icon selected."); return; }
+
+                // The wait-icon entry has NO palette slot — remap the imported
+                // sheet onto the shared self-army palette (nearest color), the
+                // same tradeoff WF's CheckPalette/ForcePalette interactive dialog
+                // resolves (plan v2 HIGH-1: remap, not quantize-to-fresh).
+                byte[] selfPalette = ImageUtilCore.GetPalette(rom.RomInfo.unit_icon_palette_address, 16);
+                if (selfPalette == null) { CoreState.Services?.ShowError("Failed to read unit icon palette."); return; }
+
+                var result = await ImageImportService.LoadAndRemapToExistingPalette(this, 0, 0, selfPalette, 16);
+                if (result == null) return; // cancelled
+                if (!result.Success) { CoreState.Services?.ShowError(result.Error); return; }
+
+                uint addr = _vm.CurrentAddr;
+                _undoService.Begin("Import Unit Wait Icon");
+                // WriteCompressedToROM OWNS the +4 pointer slot; do NOT call
+                // _vm.Write() afterwards (that would re-write a stale P4).
+                string err = WaitIconImportCore.Import(rom, addr, result.IndexedPixels, result.Width, result.Height);
+                if (!string.IsNullOrEmpty(err))
+                {
+                    _undoService.Rollback();
+                    CoreState.Services?.ShowError(err);
+                    return;
+                }
+                _undoService.Commit();
+                _vm.ReloadEntry(); // refresh P4 / W2 / previews
+                UpdateUI();
+                _vm.MarkClean();
+                CoreState.Services?.ShowInfo("Image imported successfully.");
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                CoreState.Services?.ShowError($"Import failed: {ex.Message}");
+            }
+        }
+
+        async void Export_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (CoreState.ROM == null) return;
+                if (_vm.CurrentAddr == 0) { CoreState.Services?.ShowError("No wait icon selected."); return; }
+
+                string suggested = $"wait_icon_{_vm.CurrentIndex:X02}.png";
+                string? path = await FileDialogHelper.SaveFile(this, "Export Wait Icon",
+                    new[]
+                    {
+                        ("PNG Image", "*.png"),
+                        ("Animated GIF", "*.gif"),
+                    },
+                    suggested);
+                if (string.IsNullOrEmpty(path)) return;
+
+                bool ok = path.EndsWith(".gif", StringComparison.OrdinalIgnoreCase)
+                    ? _vm.ExportGif(path)
+                    : _vm.ExportPng(path);
+
+                if (!ok) { CoreState.Services?.ShowError("Failed to render wait icon for export."); return; }
+                CoreState.Services?.ShowInfo($"Exported to: {path}");
+            }
+            catch (Exception ex)
+            {
+                CoreState.Services?.ShowError($"Export failed: {ex.Message}");
+            }
+        }
+
+        void JumpMoveIcon_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                ROM rom = CoreState.ROM;
+                if (rom == null) return;
+
+                uint? moveIcon = _vm.ResolveMoveIconForSelection();
+                if (moveIcon == null) return; // no owning class / no move icon
+
+                // Compute the unit_move_icon_pointer list-entry address (8-byte
+                // entries; the move-icon id is the 0-based table index).
+                uint ptr = rom.RomInfo.unit_move_icon_pointer;
+                if (ptr == 0) return;
+                uint baseAddr = rom.p32(ptr);
+                if (!U.isSafetyOffset(baseAddr)) return;
+                uint entryAddr = baseAddr + moveIcon.Value * 8;
+                if (entryAddr + 8 > (uint)rom.Data.Length) return;
+
+                WindowManager.Instance.Navigate<ImageUnitMoveIconView>(entryAddr);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImageUnitWaitIconView.JumpMoveIcon_Click: {0}", ex.Message);
+            }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitWaitIconView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitWaitIconView.axaml.cs
@@ -84,14 +84,29 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void RefreshPreviews()
         {
-            try { SheetImage.SetImage(_vm.RenderFullSheet()); }
+            // Each Render* call returns a FRESH SkiaSharp-backed IImage. SetImage
+            // copies its pixels into a WriteableBitmap (IconBitmapBuilder.FromImage
+            // reads GetPixelData/GetPaletteRGBA — it does NOT retain the IImage),
+            // so dispose the temporary right after to release the unmanaged
+            // SKBitmap immediately rather than waiting for GC (#993 Copilot
+            // review — frequent palette/step re-renders would otherwise balloon
+            // memory).
+            try
+            {
+                using IImage img = _vm.RenderFullSheet();
+                SheetImage.SetImage(img);
+            }
             catch { SheetImage.SetImage(null); }
             RefreshFramePreview();
         }
 
         void RefreshFramePreview()
         {
-            try { FrameImage.SetImage(_vm.RenderFrame()); }
+            try
+            {
+                using IImage img = _vm.RenderFrame();
+                FrameImage.SetImage(img);
+            }
             catch { FrameImage.SetImage(null); }
         }
 

--- a/FEBuilderGBA.Core.Tests/ClassFormCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ClassFormCoreTests.cs
@@ -32,5 +32,201 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Equal(0, sim.class_hp);
             Assert.Equal(0, sim.class_grow_hp);
         }
+
+        // ============================================================
+        // Unit Wait Icon <-> Class back-references (#991)
+        // ============================================================
+
+        static string? FindRom(string romName)
+        {
+            string thisAssembly = System.Reflection.Assembly.GetExecutingAssembly().Location;
+            string? dir = System.IO.Path.GetDirectoryName(thisAssembly);
+            for (int i = 0; i < 10 && dir != null; i++)
+            {
+                if (System.IO.File.Exists(System.IO.Path.Combine(dir, "FEBuilderGBA.sln")))
+                {
+                    string path = System.IO.Path.Combine(dir, "roms", romName);
+                    if (System.IO.File.Exists(path)) return path;
+                    break;
+                }
+                dir = System.IO.Path.GetDirectoryName(dir);
+            }
+            return null;
+        }
+
+        [Fact]
+        public void WaitIcon_To_Class_To_MoveIcon_RoundTrips_FE8U()
+        {
+            string? path = FindRom("FE8U.gba");
+            if (path == null) return; // skip when ROM absent
+
+            var saved = CoreState.ROM;
+            try
+            {
+                var rom = new ROM();
+                rom.Load(path, out _);
+                CoreState.ROM = rom;
+
+                uint classBase = rom.p32(rom.RomInfo.class_pointer);
+                uint classSize = rom.RomInfo.class_datasize;
+
+                // Find ANY class with a non-zero wait-icon id (ROM-content
+                // agnostic — works on vanilla or modified ROMs).
+                uint pickedClass = 0, waitId = 0;
+                for (uint c = 1; c <= 128; c++)
+                {
+                    uint a = classBase + c * classSize;
+                    if (a + classSize > (uint)rom.Data.Length) break;
+                    uint w = rom.u8(a + 6);
+                    if (w > 0) { pickedClass = c; waitId = w; break; }
+                }
+                Assert.True(pickedClass > 0, "At least one class should have a non-zero wait icon id.");
+
+                // Reverse: wait-icon id -> owning class id. First class wins, so
+                // the resolved class's wait-icon must equal waitId (round-trip
+                // invariant — the resolved class may differ from pickedClass if
+                // an earlier class shares the same wait icon).
+                uint cid = ClassFormCore.GetClassIdWhereWaitIconId(rom, waitId);
+                Assert.NotEqual(U.NOT_FOUND, cid);
+                uint cidWaitId = rom.u8(classBase + cid * classSize + 6);
+                Assert.Equal(waitId, cidWaitId);
+
+                // Move icon for that class = u8 @ class+4.
+                uint moveIcon = ClassFormCore.GetClassMoveIcon(rom, cid);
+                Assert.Equal((uint)rom.u8(classBase + cid * classSize + 4), moveIcon);
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void GetClassNameWhereWaitIconId_NonEmptyForOwnedIcon_FE8U()
+        {
+            string? path = FindRom("FE8U.gba");
+            if (path == null) return;
+
+            var saved = CoreState.ROM;
+            try
+            {
+                var rom = new ROM();
+                rom.Load(path, out _);
+                CoreState.ROM = rom;
+
+                uint classBase = rom.p32(rom.RomInfo.class_pointer);
+                uint classSize = rom.RomInfo.class_datasize;
+
+                // Find any class with a non-zero wait icon (ROM-content agnostic).
+                uint waitId = 0;
+                for (uint c = 1; c <= 128; c++)
+                {
+                    uint a = classBase + c * classSize;
+                    if (a + classSize > (uint)rom.Data.Length) break;
+                    uint w = rom.u8(a + 6);
+                    if (w > 0) { waitId = w; break; }
+                }
+                Assert.True(waitId > 0, "At least one class should own a wait icon.");
+
+                string name = ClassFormCore.GetClassNameWhereWaitIconId(rom, waitId);
+                Assert.False(string.IsNullOrEmpty(name), "Owned wait icon must resolve a class name.");
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void GetClassMoveIcon_ReadsPlusFour_Synthetic()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeSyntheticClassRom(out uint classBase, out uint classSize);
+                CoreState.ROM = rom;
+                // class 3's move icon byte was planted at class+4.
+                Assert.Equal(0x13u, ClassFormCore.GetClassMoveIcon(rom, 3));
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void GetClassMoveIcon_ClassZero_ReturnsNotFound()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeSyntheticClassRom(out _, out _);
+                CoreState.ROM = rom;
+                Assert.Equal(U.NOT_FOUND, ClassFormCore.GetClassMoveIcon(rom, 0));
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void GetClassIdWhereWaitIconId_RoundTrips_Synthetic()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeSyntheticClassRom(out _, out _);
+                CoreState.ROM = rom;
+                // Classes 1/2/3 have wait icons 0x11/0x22/0x33.
+                Assert.Equal(2u, ClassFormCore.GetClassIdWhereWaitIconId(rom, 0x22));
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void GetClassIdWhereWaitIconId_Miss_ReturnsNotFound_NoThrow()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeSyntheticClassRom(out _, out _);
+                CoreState.ROM = rom;
+                // No class has wait-icon 0xFE → NOT_FOUND, no throw.
+                Assert.Equal(U.NOT_FOUND, ClassFormCore.GetClassIdWhereWaitIconId(rom, 0xFE));
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void GetClassIdWhereWaitIconId_NullRom_ReturnsNotFound()
+        {
+            Assert.Equal(U.NOT_FOUND, ClassFormCore.GetClassIdWhereWaitIconId(null, 1));
+        }
+
+        // Build a tiny synthetic ROM with a 4-class table (each 0x10 bytes). The
+        // existence callback counts while u8(class+4) != 0, so classes 1..3 have
+        // a non-zero +4 (move-icon) byte; class 4's +4 is 0 → terminator.
+        static ROM MakeSyntheticClassRom(out uint classBase, out uint classSize)
+        {
+            const uint CLASS_PTR_SLOT = 0x100;
+            classBase = 0x1000;
+            classSize = 0x10;
+
+            var rom = new ROM();
+            byte[] data = new byte[0x10000];
+            rom.LoadLow("synth.gba", data, "BE8E01");
+            var info = new ClassStubRomInfo(CLASS_PTR_SLOT, classSize);
+            typeof(ROM).GetProperty("RomInfo")?.GetSetMethod(true)?.Invoke(rom, new object[] { info });
+
+            U.write_u32(rom.Data, CLASS_PTR_SLOT, U.toPointer(classBase));
+            // classes 1..3 exist (non-zero +4 = move-icon); class 0 always counts.
+            for (uint c = 1; c <= 3; c++)
+                rom.write_u8(classBase + c * classSize + 4, (byte)(0x10 + c));
+            // class 4 terminator (+4 == 0, already zero).
+            // Plant distinct wait-icon ids at +6 for classes 1..3.
+            rom.write_u8(classBase + 1 * classSize + 6, 0x11);
+            rom.write_u8(classBase + 2 * classSize + 6, 0x22);
+            rom.write_u8(classBase + 3 * classSize + 6, 0x33);
+            return rom;
+        }
+
+        sealed class ClassStubRomInfo : ROMFEINFO
+        {
+            public ClassStubRomInfo(uint classPointer, uint classDataSize)
+            {
+                this.version = 8;
+                this.class_pointer = classPointer;
+                this.class_datasize = classDataSize;
+            }
+        }
     }
 }

--- a/FEBuilderGBA.Core.Tests/ClassFormCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ClassFormCoreTests.cs
@@ -192,6 +192,31 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Equal(U.NOT_FOUND, ClassFormCore.GetClassIdWhereWaitIconId(null, 1));
         }
 
+        [Fact]
+        public void GetClassNameWhereWaitIconId_RomNotAmbient_ReturnsEmpty()
+        {
+            // #993 Copilot review: name resolution (NameResolver + text decode)
+            // is ambient-ROM-bound, so a rom instance that is NOT CoreState.ROM
+            // must return "" (never a mismatched label) rather than resolve
+            // against the wrong ROM.
+            var saved = CoreState.ROM;
+            try
+            {
+                ROM ambient = MakeSyntheticClassRom(out _, out _);
+                ROM other = MakeSyntheticClassRom(out _, out _);
+                Assert.NotSame(ambient, other);
+                CoreState.ROM = ambient; // ambient != other (distinct instances)
+                Assert.Equal(string.Empty, ClassFormCore.GetClassNameWhereWaitIconId(other, 0x11));
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void GetClassNameWhereWaitIconId_NullRom_ReturnsEmpty()
+        {
+            Assert.Equal(string.Empty, ClassFormCore.GetClassNameWhereWaitIconId(null, 1));
+        }
+
         // Build a tiny synthetic ROM with a 4-class table (each 0x10 bytes). The
         // existence callback counts while u8(class+4) != 0, so classes 1..3 have
         // a non-zero +4 (move-icon) byte; class 4's +4 is 0 → terminator.

--- a/FEBuilderGBA.Core.Tests/WaitIconImportCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/WaitIconImportCoreTests.cs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #991 Core tests for WaitIconImportCore — the static PNG/BMP wait-icon sheet
+// import seam (validate dims -> b2, encode + LZ77 write-back + repoint, with a
+// defensive length-aware snapshot restore on fault).
+//
+// Uses a synthetic ROM (no RomInfo needed — the seam only touches entryAddr+2 /
+// entryAddr+4 and ROM free space). Validates:
+//   * 16x48 import sets W2=0 and repoints P4 to a fresh pointer
+//   * a wrong-size image mutates ZERO bytes (byte-identical ROM + error string)
+//   * a forced fault (free-space exhaustion) restores byte-identical
+using System;
+using FEBuilderGBA;
+using FEBuilderGBA.Core;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class WaitIconImportCoreTests
+    {
+        // A wait-icon entry near the ROM START, with plenty of free 0xFF space
+        // after the midpoint for WriteCompressedToROM to land in.
+        const uint ENTRY_ADDR = 0x400;
+        const uint ROM_LEN = 0x20000; // 128 KiB
+
+        static ROM MakeRom()
+        {
+            var rom = new ROM();
+            byte[] data = new byte[ROM_LEN];
+            // Fill with 0xFF (free-space marker) so FindFreeSpace can place data.
+            Array.Fill(data, (byte)0xFF);
+            // Zero the entry region + header so reads are deterministic.
+            for (uint i = 0; i < 0x1000; i++) data[i] = 0x00;
+            rom.LoadLow("synth.gba", data, "BE8E01");
+            return rom;
+        }
+
+        static byte[] MakeIndexed(int w, int h)
+        {
+            byte[] px = new byte[w * h];
+            for (int i = 0; i < px.Length; i++) px[i] = (byte)(i % 16);
+            return px;
+        }
+
+        [Fact]
+        public void Import_16x48_SetsB2_0_RepointsP4()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+
+                uint p4Before = rom.u32(ENTRY_ADDR + 4);
+                string err = WaitIconImportCore.Import(rom, ENTRY_ADDR, MakeIndexed(16, 48), 16, 48);
+
+                Assert.Equal("", err);
+                // W2 (animType byte) set to 0 for 16x48.
+                Assert.Equal(0u, rom.u16(ENTRY_ADDR + 2));
+                // P4 repointed to a real GBA pointer (changed from the old value).
+                uint p4After = rom.u32(ENTRY_ADDR + 4);
+                Assert.True(U.isPointer(p4After), $"P4 not a pointer: 0x{p4After:X08}");
+                Assert.NotEqual(p4Before, p4After);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Theory]
+        [InlineData(16, 96, 1)]
+        [InlineData(32, 96, 2)]
+        public void Import_ValidSizes_SetCorrectB2(int w, int h, int expectedB2)
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                string err = WaitIconImportCore.Import(rom, ENTRY_ADDR, MakeIndexed(w, h), w, h);
+                Assert.Equal("", err);
+                Assert.Equal((uint)expectedB2, rom.u16(ENTRY_ADDR + 2));
+                Assert.True(U.isPointer(rom.u32(ENTRY_ADDR + 4)));
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void Import_WrongSize_NoMutation()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                byte[] before = (byte[])rom.Data.Clone();
+
+                string err = WaitIconImportCore.Import(rom, ENTRY_ADDR, MakeIndexed(24, 24), 24, 24);
+
+                Assert.False(string.IsNullOrEmpty(err));
+                Assert.Equal(before.Length, rom.Data.Length);
+                Assert.Equal(before, rom.Data); // byte-identical
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void Import_ForcedFault_RestoresByteIdentical()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                // Force WriteCompressedToROM -> U.NOT_FOUND: a ROM already at the
+                // 32MB max with NO free space at all. FindFreeSpace treats both
+                // 0x00 AND 0xFF runs as free, so the ROM is filled with 0x01
+                // (a non-free byte) to break every run; AppendToRomEnd then
+                // refuses (newEnd > 0x02000000). The import must restore
+                // byte-identical (length unchanged, no +2/+4 mutation) and
+                // return a non-empty error.
+                const uint MAX = 0x02000000;
+                var rom = new ROM();
+                byte[] data = new byte[MAX];
+                Array.Fill(data, (byte)0x01);    // no 0x00/0xFF free runs anywhere
+                rom.LoadLow("synth.gba", data, "BE8E01");
+                CoreState.ROM = rom;
+
+                byte[] before = (byte[])rom.Data.Clone();
+                string err = WaitIconImportCore.Import(rom, ENTRY_ADDR, MakeIndexed(16, 48), 16, 48);
+
+                Assert.False(string.IsNullOrEmpty(err));
+                Assert.Equal(before.Length, rom.Data.Length);
+                Assert.Equal(before, rom.Data); // byte-identical, ZERO mutation
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void Import_NullRom_ReturnsError_NoThrow()
+        {
+            string err = WaitIconImportCore.Import(null, ENTRY_ADDR, MakeIndexed(16, 48), 16, 48);
+            Assert.False(string.IsNullOrEmpty(err));
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/WaitIconRenderCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/WaitIconRenderCoreTests.cs
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #991 Core tests for WaitIconRenderCore — the cross-platform Unit Wait Icon
+// render seam extracted VERBATIM from PreviewIconHelper.LoadClassWaitIcon.
+//
+// Core.Tests does NOT reference SkiaSharp, so these tests use a minimal
+// IImageService stub (SyntheticImageService) that returns correctly-SIZED
+// indexed images and supports the crop SetPixelData/GetPixelData path. That
+// is enough to validate: per-animType crop RECTANGLES (sizes for steps 0/1/2),
+// palette-type resolution (0..4 non-null / FE6 lightrune/sepia blank),
+// invalid/non-pointer P4 → blank, and short-strip → blank. REAL-PIXEL decode
+// + the PreviewIconHelper oracle pixel-equality run in the Avalonia test suite
+// (which references SkiaSharp).
+//
+// Real-ROM tests skip when the ROM is unavailable (CI runners / dev machines
+// without the commercial ROM).
+using System;
+using System.IO;
+using System.Reflection;
+using FEBuilderGBA;
+using FEBuilderGBA.Core;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class WaitIconRenderCoreTests
+    {
+        readonly ITestOutputHelper _output;
+        public WaitIconRenderCoreTests(ITestOutputHelper output) => _output = output;
+
+        static string? FindRom(string romName)
+        {
+            string thisAssembly = Assembly.GetExecutingAssembly().Location;
+            string? dir = Path.GetDirectoryName(thisAssembly);
+            for (int i = 0; i < 10 && dir != null; i++)
+            {
+                if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                {
+                    string path = Path.Combine(dir, "roms", romName);
+                    if (File.Exists(path)) return path;
+                    break;
+                }
+                dir = Path.GetDirectoryName(dir);
+            }
+            return null;
+        }
+
+        ROM? LoadRom(string romName)
+        {
+            string? path = FindRom(romName);
+            if (path == null) { _output.WriteLine($"SKIP: {romName} not found"); return null; }
+            var rom = new ROM();
+            rom.Load(path, out _);
+            return rom;
+        }
+
+        static readonly IImageService Svc = new SyntheticImageService();
+
+        // Locate a wait-icon index of the given animType in the real ROM.
+        static uint? FindIndexWithAnimType(ROM rom, byte want)
+        {
+            uint ptr = rom.RomInfo.unit_wait_icon_pointer;
+            if (ptr == 0) return null;
+            uint baseAddr = rom.p32(ptr);
+            if (!U.isSafetyOffset(baseAddr, rom)) return null;
+            for (uint i = 0; i < 0x100; i++)
+            {
+                uint addr = baseAddr + i * 8;
+                if (addr + 8 > (uint)rom.Data.Length) break;
+                uint sprite = rom.u32(addr + 4);
+                if (!U.isPointer(sprite)) break;
+                if ((byte)rom.u8(addr + 2) == want) return i;
+            }
+            return null;
+        }
+
+        [Theory]
+        [InlineData((byte)0, 16, 16)]
+        [InlineData((byte)1, 16, 24)]
+        [InlineData((byte)2, 32, 32)]
+        public void RenderFrame_AnimType_ProducesExpectedSize_Steps012(byte animType, int w, int h)
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                ROM? rom = LoadRom("FE8U.gba");
+                if (rom == null) return;
+                CoreState.ROM = rom;
+
+                uint? idx = FindIndexWithAnimType(rom, animType);
+                if (idx == null) { _output.WriteLine($"SKIP: no wait icon with animType {animType}"); return; }
+
+                for (int step = 0; step <= 2; step++)
+                {
+                    using IImage img = WaitIconRenderCore.RenderFrame(rom, idx.Value, step, Svc, 0);
+                    // A short strip can legitimately fail the crop for higher
+                    // steps; assert size only when an image was produced. Step 0
+                    // must always render.
+                    if (step == 0)
+                        Assert.NotNull(img);
+                    if (img != null)
+                    {
+                        Assert.Equal(w, img.Width);
+                        Assert.Equal(h, img.Height);
+                    }
+                }
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void RenderFrame_Step0_Self_GeometryEquals_RenderClassWaitIcon()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                ROM? rom = LoadRom("FE8U.gba");
+                if (rom == null) return;
+                CoreState.ROM = rom;
+
+                // RenderClassWaitIcon MUST equal RenderFrame(step:0, self) — this
+                // is the delegation contract PreviewIconHelper.LoadClassWaitIcon
+                // relies on. With the synthetic decoder both share identical
+                // (blank) pixels, so this asserts the crop GEOMETRY is identical.
+                for (uint idx = 1; idx < 40; idx++)
+                {
+                    using IImage a = WaitIconRenderCore.RenderClassWaitIcon(rom, idx, Svc, 0);
+                    using IImage b = WaitIconRenderCore.RenderFrame(rom, idx, 0, Svc, 0);
+                    if (a == null && b == null) continue;
+                    Assert.NotNull(a);
+                    Assert.NotNull(b);
+                    Assert.Equal(a!.Width, b!.Width);
+                    Assert.Equal(a.Height, b.Height);
+                    Assert.Equal(a.GetPixelData(), b.GetPixelData());
+                }
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        public void GetPaletteColors_Types0to4_NonNull_FE8U(int paletteType)
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                ROM? rom = LoadRom("FE8U.gba");
+                if (rom == null) return;
+                CoreState.ROM = rom;
+                byte[] pal = WaitIconRenderCore.GetPaletteColors(rom, paletteType);
+                Assert.NotNull(pal);
+                Assert.True(pal!.Length > 0);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Theory]
+        [InlineData(5)] // lightrune
+        [InlineData(6)] // sepia
+        public void GetPaletteColors_LightruneSepia_BlankOnFE6(int paletteType)
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                ROM? rom = LoadRom("FE6.gba");
+                if (rom == null) return;
+                CoreState.ROM = rom;
+                // FE6 has no lightrune/sepia palette address (0) → null guard.
+                byte[] pal = WaitIconRenderCore.GetPaletteColors(rom, paletteType);
+                Assert.Null(pal);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void RenderFrame_OutOfRangeIndex_ReturnsNull_NoThrow()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                ROM? rom = LoadRom("FE8U.gba");
+                if (rom == null) return;
+                CoreState.ROM = rom;
+                // A huge index lands out of the table bounds → blank/null.
+                using IImage img = WaitIconRenderCore.RenderFrame(rom, 0xFFFFu, 0, Svc, 0);
+                Assert.Null(img);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void RenderFullSheet_FirstValidIndex_NonNull_FE8U()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                ROM? rom = LoadRom("FE8U.gba");
+                if (rom == null) return;
+                CoreState.ROM = rom;
+                using IImage img = WaitIconRenderCore.RenderFullSheet(rom, 1, Svc, 0);
+                Assert.NotNull(img);
+                Assert.True(img!.Width is 16 or 32);
+                Assert.True(img.Height > 0);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void GetPaletteColors_NullRom_ReturnsNull()
+        {
+            Assert.Null(WaitIconRenderCore.GetPaletteColors(null, 0));
+        }
+
+        [Fact]
+        public void RenderFrame_NullArgs_ReturnNull_NoThrow()
+        {
+            Assert.Null(WaitIconRenderCore.RenderFrame(null, 0, 0, Svc, 0));
+        }
+
+        // -----------------------------------------------------------------
+        // Minimal IImageService stub: correctly-sized indexed images + the
+        // SetPixelData/GetPixelData round-trip the crop path needs.
+        // -----------------------------------------------------------------
+        sealed class SyntheticImageService : IImageService
+        {
+            public IImage CreateImage(int width, int height) => new Img(width, height, null);
+            public IImage CreateIndexedImage(int width, int height, byte[] gbaPalette, int paletteColorCount)
+                => new Img(width, height, gbaPalette);
+            public IImage LoadImage(string filePath) => new Img(16, 16, null);
+            public IImage LoadImageFromBytes(byte[] pngData) => new Img(16, 16, null);
+            public void GBAColorToRGBA(ushort c, out byte r, out byte g, out byte b)
+            { r = (byte)((c & 0x1F) << 3); g = (byte)(((c >> 5) & 0x1F) << 3); b = (byte)(((c >> 10) & 0x1F) << 3); }
+            public ushort RGBAToGBAColor(byte r, byte g, byte b)
+                => (ushort)((r >> 3) | ((g >> 3) << 5) | ((b >> 3) << 10));
+            public IImage Decode4bppTiles(byte[] t, int o, int w, int h, byte[] p) => new Img(w, h, p);
+            public IImage Decode8bppTiles(byte[] t, int o, int w, int h, byte[] p) => new Img(w, h, p);
+            public IImage Decode8bppLinear(byte[] d, int o, int w, int h, byte[] p) => new Img(w, h, p);
+            public byte[] Encode4bppTiles(IImage image) => Array.Empty<byte>();
+            public byte[] Encode8bppTiles(IImage image) => Array.Empty<byte>();
+            public byte[] GBAPaletteToRGBA(byte[] gbaPalette, int colorCount) => new byte[colorCount * 4];
+            public byte[] RGBAPaletteToGBA(byte[] rgbaPalette, int colorCount) => new byte[colorCount * 2];
+        }
+
+        sealed class Img : IImage
+        {
+            public int Width { get; }
+            public int Height { get; }
+            public bool IsIndexed => true;
+            byte[] _pixels;
+            byte[] _palette;
+            public Img(int w, int h, byte[] pal) { Width = w; Height = h; _pixels = new byte[w * h]; _palette = pal ?? new byte[32]; }
+            public byte[] GetPixelData() => (byte[])_pixels.Clone();
+            public void SetPixelData(byte[] data) { _pixels = (byte[])data.Clone(); }
+            public byte[] GetPaletteGBA() => (byte[])_palette.Clone();
+            public void SetPaletteGBA(byte[] palette) { _palette = (byte[])palette.Clone(); }
+            public byte[] GetPaletteRGBA() => new byte[(_palette.Length / 2) * 4];
+            public void Save(string filePath) { File.WriteAllBytes(filePath, new byte[] { 0x89, 0x50, 0x4E, 0x47 }); }
+            public byte[] EncodePng() => new byte[] { 0x89, 0x50, 0x4E, 0x47 };
+            public void Dispose() { }
+        }
+    }
+}

--- a/FEBuilderGBA.Core/ClassFormCore.cs
+++ b/FEBuilderGBA.Core/ClassFormCore.cs
@@ -216,9 +216,27 @@ namespace FEBuilderGBA.Core
         /// <see cref="NameResolver.GetClassName"/>). Mirror of WF
         /// <c>ClassForm.GetClassNameWhereWaitIconID</c>. Returns "" on a miss.
         /// Guarded — never throws.
+        /// <para>
+        /// ROM-CONSISTENCY (#993 Copilot review): the cid is scanned from the
+        /// passed <paramref name="rom"/>, but <see cref="NameResolver.GetClassName"/>
+        /// (and the text decode it triggers) read from the ambient
+        /// <see cref="CoreState.ROM"/> and cache globally by id. If
+        /// <paramref name="rom"/> were a DIFFERENT instance, the name could be
+        /// resolved against the wrong ROM (a mismatched/stale label). Rather than
+        /// emit a wrong name, this method requires <paramref name="rom"/> to BE
+        /// the ambient <c>CoreState.ROM</c> (the established Core-seam pattern,
+        /// e.g. <c>SkillSystemsAnimeExportCore</c>) and returns "" otherwise. The
+        /// real callers (<c>ImageUnitWaitIconViewModel.LoadList</c> /
+        /// <c>ListParityHelper.BuildImageUnitWaitIconList</c>) both pass
+        /// <c>CoreState.ROM</c>, so labels are unaffected in practice.
+        /// </para>
         /// </summary>
         public static string GetClassNameWhereWaitIconId(ROM rom, uint waitIconId)
         {
+            if (rom == null) return string.Empty;
+            // Name resolution is ambient-ROM-bound; refuse to resolve against a
+            // different ROM instance (would produce a wrong label).
+            if (!ReferenceEquals(rom, CoreState.ROM)) return string.Empty;
             uint cid = GetClassIdWhereWaitIconId(rom, waitIconId);
             if (cid == U.NOT_FOUND) return string.Empty;
             try

--- a/FEBuilderGBA.Core/ClassFormCore.cs
+++ b/FEBuilderGBA.Core/ClassFormCore.cs
@@ -150,5 +150,103 @@ namespace FEBuilderGBA.Core
             if (settingPointer == U.NOT_FOUND) return 0;
             return GetAnimeIDByAnimeSettingPointer(rom, settingPointer);
         }
+
+        // ============================================================
+        // Unit Wait Icon <-> Class back-references (#991)
+        // Ports WF ClassForm.GetClassIDWhereWaitIconID /
+        // GetClassMoveIcon / GetClassNameWhereWaitIconID.
+        // ============================================================
+
+        /// <summary>
+        /// Scan the class table for the FIRST class whose wait-icon field
+        /// (<c>u8(classAddr + 6)</c>) equals <paramref name="waitIconId"/>, and
+        /// return its class id (0-based table index, matching WF). Returns
+        /// <see cref="U.NOT_FOUND"/> on a miss or an unresolvable ROM/table.
+        /// Mirror of WF <c>ClassForm.GetClassIDWhereWaitIconID</c>. Guarded —
+        /// never throws.
+        /// </summary>
+        public static uint GetClassIdWhereWaitIconId(ROM rom, uint waitIconId)
+        {
+            if (rom == null || rom.RomInfo == null) return U.NOT_FOUND;
+            uint classPtr = rom.RomInfo.class_pointer;
+            uint datasize = rom.RomInfo.class_datasize;
+            if (datasize == 0) return U.NOT_FOUND;
+            if (classPtr == 0 || (ulong)classPtr + 4 > (ulong)rom.Data.Length) return U.NOT_FOUND;
+            uint baseAddr = rom.p32(classPtr);
+            if (!U.isSafetyOffset(baseAddr, rom)) return U.NOT_FOUND;
+
+            int count = GetClassCount(rom, baseAddr, datasize);
+            uint addr = baseAddr;
+            for (int i = 0; i < count; i++, addr += datasize)
+            {
+                uint waitSlot = addr + 6;
+                if (!U.isSafetyOffset(waitSlot, rom)) break;
+                if (rom.u8(waitSlot) == waitIconId)
+                    return (uint)i;
+            }
+            return U.NOT_FOUND;
+        }
+
+        /// <summary>
+        /// Read the move-icon id for class <paramref name="classId"/>
+        /// (<c>u8(classAddr + 4)</c>). Mirror of WF
+        /// <c>ClassForm.GetClassMoveIcon</c>: returns <see cref="U.NOT_FOUND"/>
+        /// for class 0 or an unresolvable ROM/address. Guarded — never throws.
+        /// </summary>
+        public static uint GetClassMoveIcon(ROM rom, uint classId)
+        {
+            if (rom == null || rom.RomInfo == null) return U.NOT_FOUND;
+            if (classId == 0) return U.NOT_FOUND;
+            uint classPtr = rom.RomInfo.class_pointer;
+            uint datasize = rom.RomInfo.class_datasize;
+            if (datasize == 0) return U.NOT_FOUND;
+            if (classPtr == 0 || (ulong)classPtr + 4 > (ulong)rom.Data.Length) return U.NOT_FOUND;
+            uint baseAddr = rom.p32(classPtr);
+            if (!U.isSafetyOffset(baseAddr, rom)) return U.NOT_FOUND;
+
+            uint addr = baseAddr + classId * datasize;
+            uint moveSlot = addr + 4;
+            if (!U.isSafetyOffset(moveSlot, rom)) return U.NOT_FOUND;
+            return rom.u8(moveSlot);
+        }
+
+        /// <summary>
+        /// Resolve the class NAME that owns wait-icon <paramref name="waitIconId"/>
+        /// (via <see cref="GetClassIdWhereWaitIconId"/> →
+        /// <see cref="NameResolver.GetClassName"/>). Mirror of WF
+        /// <c>ClassForm.GetClassNameWhereWaitIconID</c>. Returns "" on a miss.
+        /// Guarded — never throws.
+        /// </summary>
+        public static string GetClassNameWhereWaitIconId(ROM rom, uint waitIconId)
+        {
+            uint cid = GetClassIdWhereWaitIconId(rom, waitIconId);
+            if (cid == U.NOT_FOUND) return string.Empty;
+            try
+            {
+                return NameResolver.GetClassName(cid) ?? string.Empty;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Class-table row count, mirroring <c>ClassForm.Init</c>'s read-max
+        /// callback: cid 0 always counts, then scan while <c>u8(addr+4) != 0</c>,
+        /// capped at 0xFF.
+        /// </summary>
+        static int GetClassCount(ROM rom, uint baseAddr, uint datasize)
+        {
+            uint count = rom.getBlockDataCount(baseAddr, datasize, (i, addr) =>
+            {
+                if (i == 0) return true;
+                if (i > 0xFF) return false;
+                uint flagAddr = addr + 4;
+                if (!U.isSafetyOffset(flagAddr, rom)) return false;
+                return rom.u8(flagAddr) != 0;
+            });
+            return (int)count;
+        }
     }
 }

--- a/FEBuilderGBA.Core/ImageUtilCore.cs
+++ b/FEBuilderGBA.Core/ImageUtilCore.cs
@@ -72,11 +72,25 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
-        /// Read a GBA palette from ROM (array of 16-bit colors).
+        /// Read a GBA palette from the ambient <see cref="CoreState.ROM"/>
+        /// (array of 16-bit colors). Prefer the explicit-<paramref name="rom"/>
+        /// overload in cross-platform Core seams so the read is consistent with
+        /// the ROM instance the caller is working on (non-global contexts).
         /// </summary>
         public static byte[] GetPalette(uint offset, int colorCount = 16)
         {
-            ROM rom = CoreState.ROM;
+            return GetPalette(CoreState.ROM, offset, colorCount);
+        }
+
+        /// <summary>
+        /// Read a GBA palette from the GIVEN <paramref name="rom"/> (array of
+        /// 16-bit colors). rom-consistent overload: a Core seam that already has
+        /// a <c>ROM</c> instance must use this so it never silently reads palette
+        /// bytes from a different ambient <see cref="CoreState.ROM"/> (#993
+        /// Copilot review; same class of latent bug as #992).
+        /// </summary>
+        public static byte[] GetPalette(ROM rom, uint offset, int colorCount = 16)
+        {
             if (rom == null) return null;
 
             int byteLen = colorCount * 2;

--- a/FEBuilderGBA.Core/WaitIconImportCore.cs
+++ b/FEBuilderGBA.Core/WaitIconImportCore.cs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Cross-platform Unit Wait Icon import seam (#991).
+//
+// Ports the write-back half of WinForms ImageUnitWaitIconFrom.ImportButton_Click:
+//   * validate the imported sheet dims -> animType byte (b2):
+//       16x48 -> 0,  16x96 -> 1,  32x96 -> 2  (else localized error, NO mutation)
+//   * encode the indexed pixels to 4bpp tiles (EncodeDirectTiles4bpp)
+//   * LZ77-compress + write to free space + repoint the entry's +4 pointer slot
+//     (WriteCompressedToROM owns the +4 GBA pointer)
+//   * write the animType byte into W2 (u16 @ +2)
+//
+// The WF "force palette" interactive dialog is replaced by a nearest-color
+// remap onto the shared self-army palette done by the caller BEFORE this seam
+// (the wait-icon entry has no palette slot — see plan v2 HIGH-1), so this seam
+// receives already-remapped indexed pixels.
+//
+// Atomicity: runs under the CALLER's ambient undo scope (the View owns
+// _undoService.Begin/Commit/Rollback). A defensive rom.Data snapshot is kept so
+// any fault — including a free-space resize-append inside WriteCompressedToROM —
+// is restored byte-identical (length-aware: down-resize to the snapshot length
+// BEFORE the in-place copy so a grown tail can't survive). Models the
+// #885/#923 snapshot-restore pattern.
+using System;
+using FEBuilderGBA; // ROM, U, LZ77, ImageImportCore, R live here.
+
+namespace FEBuilderGBA.Core
+{
+    /// <summary>
+    /// Cross-platform write-back seam for the Unit Wait Icon editor's static
+    /// PNG/BMP sheet import (#991). ROM-MUTATING; runs inside the caller's
+    /// ambient undo scope.
+    /// </summary>
+    public static class WaitIconImportCore
+    {
+        /// <summary>
+        /// Validate + import a static wait-icon sheet at <paramref name="entryAddr"/>
+        /// (the 8-byte table entry). On success the sprite pointer (+4) is
+        /// repointed to freshly-LZ77-written tile data and the animType byte
+        /// (W2 @ +2) is set to the resolved b2. Returns "" on success or a
+        /// localized error string on failure — with ZERO surviving mutation on
+        /// any failure (defensive length-aware snapshot restore).
+        /// </summary>
+        /// <param name="indexedPixels">Already-remapped indexed pixels (one byte
+        /// per pixel, row-major). The caller must remap to the shared self-army
+        /// palette first — the entry has no palette slot.</param>
+        public static string Import(ROM rom, uint entryAddr, byte[] indexedPixels, int width, int height)
+        {
+            if (rom == null) return R._("ROM is not loaded.");
+            if (indexedPixels == null) return R._("No image data.");
+
+            // Validate dims -> animType byte (b2). WF only accepts 16x48 / 16x96
+            // / 32x96; anything else is a hard error with NO mutation.
+            uint b2;
+            if (width == 16 && height == 48) b2 = 0;
+            else if (width == 16 && height == 96) b2 = 1;
+            else if (width == 32 && height == 96) b2 = 2;
+            else
+            {
+                return R._(
+                    "The image size is not correct.\r\nIt must be one of:\r\n16x48\r\n16x96\r\n32x96\r\n\r\nSelected image size Width:{0} Height:{1}",
+                    width, height);
+            }
+
+            // The entry must be in-bounds for the +2 / +4 writes.
+            if (entryAddr + 8 > (uint)rom.Data.Length)
+                return R._("The wait icon entry address is out of range.");
+
+            // The +4 pointer slot must itself be a safe, pre-existing pointer
+            // slot (WriteCompressedToROM owns it via write_p32). We do NOT
+            // pre-validate the OLD pointer target (WF appends new data + repoints
+            // regardless of the old value).
+            if (indexedPixels.Length < width * height)
+                return R._("Image data is too small for {0}x{1}.", width, height);
+
+            byte[] tiles = ImageImportCore.EncodeDirectTiles4bpp(indexedPixels, width, height);
+            if (tiles == null || tiles.Length == 0)
+                return R._("Failed to encode wait icon tiles.");
+
+            // Defensive snapshot for the byte-identical restore on fault. The
+            // caller's ambient undo scope captures the writes for UNDO; this
+            // snapshot guarantees a FAILED import mutates ZERO bytes.
+            byte[] snap = (byte[])rom.Data.Clone();
+            try
+            {
+                // WriteCompressedToROM: LZ77-compress, append to free space, and
+                // repoint the +4 GBA pointer slot — all through the ambient undo
+                // scope. NOT_FOUND => no free space / compression failure.
+                uint writeAddr = ImageImportCore.WriteCompressedToROM(rom, tiles, entryAddr + 4);
+                if (writeAddr == U.NOT_FOUND)
+                {
+                    RestoreSnapshot(rom, snap);
+                    return R._("Failed to write wait icon image. Check ROM free space.");
+                }
+
+                // Write the animType byte into W2 (u16 @ +2). Uses the ambient
+                // write_u16 overload so it composes into the caller's scope.
+                rom.write_u16(entryAddr + 2, (ushort)b2);
+                return "";
+            }
+            catch (Exception ex)
+            {
+                RestoreSnapshot(rom, snap);
+                return R._("Wait icon import failed: {0}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Length-aware byte-identical restore: a free-space resize-append can
+        /// GROW rom.Data, so down-resize back to the snapshot length BEFORE the
+        /// in-place copy (a naive Array.Copy would leave the grown tail alive).
+        /// </summary>
+        static void RestoreSnapshot(ROM rom, byte[] snap)
+        {
+            if (rom.Data.Length != snap.Length)
+                rom.write_resize_data((uint)snap.Length);
+            Array.Copy(snap, rom.Data, snap.Length);
+        }
+    }
+}

--- a/FEBuilderGBA.Core/WaitIconRenderCore.cs
+++ b/FEBuilderGBA.Core/WaitIconRenderCore.cs
@@ -57,7 +57,11 @@ namespace FEBuilderGBA.Core
                 default: palAddr = rom.RomInfo.unit_icon_palette_address; break;
             }
             if (palAddr == 0 || !U.isSafetyOffset(palAddr, rom)) return null;
-            return ImageUtilCore.GetPalette(palAddr, 16);
+            // rom-consistent read (#993 Copilot review): use the explicit-rom
+            // GetPalette overload so the palette bytes come from THIS rom, not a
+            // different ambient CoreState.ROM. The safety guard above already
+            // validated palAddr against `rom`.
+            return ImageUtilCore.GetPalette(rom, palAddr, 16);
         }
 
         /// <summary>

--- a/FEBuilderGBA.Core/WaitIconRenderCore.cs
+++ b/FEBuilderGBA.Core/WaitIconRenderCore.cs
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Cross-platform Unit Wait Icon render seam (#991).
+//
+// This is the single source of truth for decoding + cropping unit wait-icon
+// map sprites. It is a VERBATIM extraction of the decode pipeline that used to
+// live inside the Avalonia-side PreviewIconHelper.LoadClassWaitIcon (strip
+// LZ77-decompress + CalcStripHeight + per-animType crop + CropIndexedRegion).
+// PreviewIconHelper.LoadClassWaitIcon now delegates to RenderClassWaitIcon so
+// the WinForms-parity list-preview behavior (#342/#667: step-0 16x24@Y=8) is
+// preserved with zero drift, and the Avalonia ImageUnitWaitIconView reuses the
+// same seam for its full-sheet / per-frame previews + PNG/GIF export.
+//
+// Wait-icon table entry layout (8 bytes), mirrors WF
+// ImageUnitWaitIconFrom.DrawWaitUnitIcon / LoadWaitUnitIcon:
+//   +0: flags (4 bytes); byte at +2 = animation type (b2)
+//   +4: sprite pointer (GBA pointer to LZ77-compressed 4bpp tile strip)
+// animType 0 -> 16-wide strip, 16x16 per frame
+// animType 1 -> 16-wide strip, 16x24 per frame, first frame begins at Y=8
+// animType 2 -> 32-wide strip, 32x32 per frame
+using FEBuilderGBA; // ROM, U, LZ77, ImageUtilCore, IImage, IImageService live here.
+
+namespace FEBuilderGBA.Core
+{
+    /// <summary>
+    /// Cross-platform decoder + cropper for Unit Wait Icon map sprites (#991).
+    /// All methods are READ-ONLY and never throw — bad pointers / short strips /
+    /// missing palettes return a blank/null image (WF blank-dummy contract).
+    /// </summary>
+    public static class WaitIconRenderCore
+    {
+        /// <summary>
+        /// Resolve the 16-color palette bytes for the given palette TYPE.
+        /// Mirrors WF <c>ImageUnitWaitIconFrom.LoadWaitUnitIcon</c>'s palette
+        /// selection:
+        ///   0 = self  (unit_icon_palette_address)
+        ///   1 = npc   (unit_icon_npc_palette_address)
+        ///   2 = enemy (unit_icon_enemey_palette_address)
+        ///   3 = gray  (unit_icon_gray_palette_address)
+        ///   4 = four  (unit_icon_four_palette_address)
+        ///   5 = lightrune (unit_icon_lightrune_palette_address)
+        ///   6 = sepia (unit_icon_sepia_palette_address)
+        /// Returns null when the ROM is null, the resolved address is 0/unsafe
+        /// (FE6 has no lightrune/sepia → 0 → blank), or decode fails.
+        /// </summary>
+        public static byte[] GetPaletteColors(ROM rom, int paletteType)
+        {
+            if (rom == null || rom.RomInfo == null) return null;
+            uint palAddr;
+            switch (paletteType)
+            {
+                case 1: palAddr = rom.RomInfo.unit_icon_npc_palette_address; break;
+                case 2: palAddr = rom.RomInfo.unit_icon_enemey_palette_address; break;
+                case 3: palAddr = rom.RomInfo.unit_icon_gray_palette_address; break;
+                case 4: palAddr = rom.RomInfo.unit_icon_four_palette_address; break;
+                case 5: palAddr = rom.RomInfo.unit_icon_lightrune_palette_address; break;
+                case 6: palAddr = rom.RomInfo.unit_icon_sepia_palette_address; break;
+                default: palAddr = rom.RomInfo.unit_icon_palette_address; break;
+            }
+            if (palAddr == 0 || !U.isSafetyOffset(palAddr, rom)) return null;
+            return ImageUtilCore.GetPalette(palAddr, 16);
+        }
+
+        /// <summary>
+        /// Decode the full LZ77 sprite strip for a wait-icon entry and render it
+        /// as an indexed <see cref="IImage"/> (no crop). Returns null on any
+        /// ROM/service failure (unsafe pointer, empty strip, null palette).
+        /// </summary>
+        public static IImage RenderFullSheet(ROM rom, uint waitIconIndex, IImageService svc, int paletteType = 0)
+        {
+            if (rom == null || rom.RomInfo == null || svc == null) return null;
+            try
+            {
+                if (!TryResolveEntry(rom, waitIconIndex, out byte animType, out uint spriteAddr))
+                    return null;
+
+                byte[] palette = GetPaletteColors(rom, paletteType);
+                if (palette == null) return null;
+
+                int stripWidth = (animType == 2) ? 32 : 16;
+
+                byte[] stripData = LZ77.decompress(rom.Data, spriteAddr);
+                if (stripData == null || stripData.Length == 0) return null;
+
+                int stripHeight = CalcStripHeight(stripWidth, stripData.Length);
+                if (stripHeight <= 0) return null;
+
+                return svc.Decode4bppTiles(stripData, 0, stripWidth, stripHeight, palette);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Decode the strip and crop the <paramref name="step"/>'th frame per WF
+        /// <c>DrawWaitUnitIcon</c> (height16_limit=false):
+        ///   animType 0: Rectangle(0, 16*step,       16, 16)
+        ///   animType 1: Rectangle(0, 32*step + 8,   16, 24)  (Y offset = 8)
+        ///   animType 2: Rectangle(0, 32*step,       32, 32)
+        /// Bounds-checked against the actual strip (short strip / unsafe ptr /
+        /// null palette → null, never throws). animType is read as the raw byte
+        /// at <c>entry + 2</c> (NOT the u16 W2 field).
+        /// </summary>
+        public static IImage RenderFrame(ROM rom, uint waitIconIndex, int step, IImageService svc, int paletteType = 0)
+        {
+            if (rom == null || rom.RomInfo == null || svc == null) return null;
+            if (step < 0) return null;
+            try
+            {
+                if (!TryResolveEntry(rom, waitIconIndex, out byte animType, out uint spriteAddr))
+                    return null;
+
+                byte[] palette = GetPaletteColors(rom, paletteType);
+                if (palette == null) return null;
+
+                // Per-animType strip width + per-frame crop rectangle. Matches WF
+                // LoadWaitUnitIcon (width=32 for animType 2, else 16) and
+                // DrawWaitUnitIcon's full-size (height16_limit=false) crop:
+                //   b2==1 frame height = ((2*8)+16)*step + 8  =>  32*step + 8, 16x24
+                //   b2==2 frame height = 32*step               =>  32*step, 32x32
+                //   else   frame height = (2*8)*step           =>  16*step, 16x16
+                int stripWidth;
+                int cropX, cropY, cropW, cropH;
+                if (animType == 2)
+                {
+                    stripWidth = 32;
+                    cropX = 0; cropY = 32 * step; cropW = 32; cropH = 32;
+                }
+                else if (animType == 1)
+                {
+                    stripWidth = 16;
+                    cropX = 0; cropY = 32 * step + 8; cropW = 16; cropH = 24;
+                }
+                else
+                {
+                    stripWidth = 16;
+                    cropX = 0; cropY = 16 * step; cropW = 16; cropH = 16;
+                }
+
+                byte[] stripData = LZ77.decompress(rom.Data, spriteAddr);
+                if (stripData == null || stripData.Length == 0) return null;
+
+                int stripHeight = CalcStripHeight(stripWidth, stripData.Length);
+                if (stripHeight <= 0) return null;
+
+                if (cropX + cropW > stripWidth) return null;
+                if (cropY + cropH > stripHeight) return null;
+
+                using IImage strip = svc.Decode4bppTiles(stripData, 0, stripWidth, stripHeight, palette);
+                if (strip == null) return null;
+
+                return CropIndexedRegion(svc, strip, cropX, cropY, cropW, cropH);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Render the class wait-icon preview (step 0, self palette). Identical
+        /// to <c>RenderFrame(rom, waitIconIndex, step:0, svc, paletteType:0)</c>;
+        /// preserves the #342/#667 step-0 16x24@Y=8 parity that the WinForms list
+        /// preview relies on. <see cref="FEBuilderGBA.Avalonia.Services.PreviewIconHelper"/>
+        /// (or its WinForms equivalent) delegates here.
+        /// </summary>
+        public static IImage RenderClassWaitIcon(ROM rom, uint waitIconIndex, IImageService svc, int paletteType = 0)
+        {
+            return RenderFrame(rom, waitIconIndex, 0, svc, paletteType);
+        }
+
+        /// <summary>
+        /// Resolve the 8-byte wait-icon entry: animType (byte @ +2) and the
+        /// sprite ROM OFFSET (from the GBA pointer @ +4). Returns false (caller
+        /// → blank) on a zero/unsafe table pointer, out-of-bounds entry, or a
+        /// non-pointer / unsafe sprite slot.
+        /// </summary>
+        static bool TryResolveEntry(ROM rom, uint waitIconIndex, out byte animType, out uint spriteAddr)
+        {
+            animType = 0;
+            spriteAddr = 0;
+
+            uint ptr = rom.RomInfo.unit_wait_icon_pointer;
+            if (ptr == 0) return false;
+
+            uint baseAddr = rom.p32(ptr);
+            if (!U.isSafetyOffset(baseAddr, rom)) return false;
+
+            uint entryAddr = baseAddr + waitIconIndex * 8;
+            if (entryAddr + 8 > (uint)rom.Data.Length) return false;
+
+            animType = (byte)rom.u8(entryAddr + 2);
+
+            uint spriteGba = rom.u32(entryAddr + 4);
+            if (!U.isPointer(spriteGba)) return false;
+
+            uint addr = U.toOffset(spriteGba);
+            if (!U.isSafetyOffset(addr, rom)) return false;
+
+            spriteAddr = addr;
+            return true;
+        }
+
+        /// <summary>
+        /// Compute the rendered strip height from an LZ77-decompressed 4bpp byte
+        /// length. Mirrors WF <c>ImageUtil.CalcHeight(width, image_size,
+        /// align=8)</c>: ceil(image_size / (width/2)) aligned UP to a multiple of
+        /// 8 rows.
+        /// </summary>
+        static int CalcStripHeight(int width, int imageSize)
+        {
+            if (width <= 0 || imageSize <= 0) return 0;
+            int half = width / 2;          // 4bpp = 2 pixels/byte
+            if (half <= 0) return 0;
+            int height = imageSize / half;
+            if (imageSize % half != 0) height++;
+            const int align = 8;
+            int remainder = height % align;
+            if (remainder != 0) height += (align - remainder);
+            return height;
+        }
+
+        /// <summary>
+        /// Crop a sub-rectangle out of an indexed strip image, returning a fresh
+        /// indexed <see cref="IImage"/> sharing the strip's palette. Returns null
+        /// on any geometry / service failure.
+        /// </summary>
+        static IImage CropIndexedRegion(IImageService svc, IImage src, int x, int y, int w, int h)
+        {
+            if (svc == null || src == null) return null;
+            if (!src.IsIndexed) return null;
+
+            byte[] srcIdx = src.GetPixelData();
+            if (srcIdx == null) return null;
+            int srcW = src.Width;
+            int srcH = src.Height;
+            if (x < 0 || y < 0 || w <= 0 || h <= 0) return null;
+            if (x + w > srcW || y + h > srcH) return null;
+            if ((long)srcW * srcH > srcIdx.Length) return null;
+
+            byte[] dstIdx = new byte[w * h];
+            for (int row = 0; row < h; row++)
+            {
+                int srcOff = (y + row) * srcW + x;
+                int dstOff = row * w;
+                System.Buffer.BlockCopy(srcIdx, srcOff, dstIdx, dstOff, w);
+            }
+
+            IImage outImg = svc.CreateIndexedImage(w, h, src.GetPaletteGBA(), 16);
+            if (outImg == null) return null;
+            outImg.SetPixelData(dstIdx);
+            return outImg;
+        }
+    }
+}

--- a/FEBuilderGBA.Tests/Unit/AvaloniaEditorTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AvaloniaEditorTests.cs
@@ -1996,10 +1996,18 @@ namespace FEBuilderGBA.Tests.Unit
         [Fact]
         public void PreviewIconHelper_LoadClassWaitIcon_Uses8ByteEntries()
         {
-            var src = File.ReadAllText(Path.Combine(AvaloniaDir, "Services", "PreviewIconHelper.cs"));
-            // Verify 8-byte stride and pointer at offset +4 (matches WinForms)
-            Assert.Contains("waitIconIndex * 8", src);
-            Assert.Contains("entryAddr + 4", src);
+            // #991: the wait-icon decode pipeline (8-byte stride + sprite pointer
+            // at offset +4) MOVED VERBATIM into the cross-platform Core seam
+            // FEBuilderGBA.Core/WaitIconRenderCore.cs (single source of truth);
+            // PreviewIconHelper.LoadClassWaitIcon now DELEGATES to it. Assert the
+            // same 8-byte-stride / +4-pointer CONTRACT in the new seam, and that
+            // the helper still delegates (so behavior is byte-identical).
+            var coreSrc = File.ReadAllText(Path.Combine(SolutionDir, "FEBuilderGBA.Core", "WaitIconRenderCore.cs"));
+            Assert.Contains("waitIconIndex * 8", coreSrc);
+            Assert.Contains("entryAddr + 4", coreSrc);
+
+            var helperSrc = File.ReadAllText(Path.Combine(AvaloniaDir, "Services", "PreviewIconHelper.cs"));
+            Assert.Contains("WaitIconRenderCore.RenderClassWaitIcon", helperSrc);
         }
 
         [Fact]

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20013,3 +20013,13 @@ Export Image to PNG file
 
 :Import Image from PNG file
 Import Image from PNG file
+:Self Army
+Self Army
+:Ally Army
+Ally Army
+:Enemy Army
+Enemy Army
+:Gray Army
+Gray Army
+:Four Army
+Four Army

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -10231,3 +10231,15 @@ ROMに取り込む
 
 :Parse failed
 解析に失敗しました
+:Flags (W0):
+フラグ (W0):
+:Anime Type (W2):
+アニメタイプ (W2):
+:Image Pointer (P4):
+画像ポインタ (P4):
+:Frame Step:
+フレームステップ:
+:Full Sheet
+フルシート
+:Jump to Move Icon
+移動アイコンへジャンプ

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -10243,3 +10243,13 @@ ROMに取り込む
 フルシート
 :Jump to Move Icon
 移動アイコンへジャンプ
+:Self Army
+自軍
+:Ally Army
+友軍
+:Enemy Army
+敵軍
+:Gray Army
+グレー
+:Four Army
+4軍

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -24063,3 +24063,15 @@ AI脚本已导出到:
 
 :Parse failed
 解析失败
+:Flags (W0):
+标志 (W0):
+:Anime Type (W2):
+动画类型 (W2):
+:Image Pointer (P4):
+图像指针 (P4):
+:Frame Step:
+帧步:
+:Full Sheet
+完整图表
+:Jump to Move Icon
+跳转到移动图标

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -24075,3 +24075,13 @@ AI脚本已导出到:
 完整图表
 :Jump to Move Icon
 跳转到移动图标
+:Self Army
+自军
+:Ally Army
+友军
+:Enemy Army
+敌军
+:Gray Army
+灰色
+:Four Army
+第四军

--- a/docs/field-completeness-report.txt
+++ b/docs/field-completeness-report.txt
@@ -1,6 +1,6 @@
 === Field Completeness Report ===
 Total WinForms fields: 1563
-Total Avalonia fields: 1801
+Total Avalonia fields: 1809
 Total missing: 0
 Forms with gaps: 0 / 175
 


### PR DESCRIPTION
## Summary
Ports the full WinForms `ImageUnitWaitIconFrom` editor into the Avalonia `ImageUnitWaitIconView`, which was a stub showing only an "Address:" label. The editor now has editable W0/W2/P4 fields with undo-safe Write, a 5-selectable palette + 0..2 step preview (full sheet + single frame), PNG/animated-GIF export, static PNG/BMP import (16x48/16x96/32x96 validation + LZ77 write-back, remapped to the shared self-army palette), Comment, owning-class names in the list, and a Jump-to-Move-Icon button.

Two new cross-platform Core seams back the editor:
- `WaitIconRenderCore.cs` (READ-ONLY) — the decode + per-animType crop pipeline, MOVED verbatim out of `PreviewIconHelper.LoadClassWaitIcon` (now a thin delegating wrapper → single source of truth, render-oracle-gated for zero drift).
- `WaitIconImportCore.cs` (ROM-MUTATING) — validate dims → animType `b2`, encode + LZ77 write-back + repoint, under the caller's ambient undo scope with a length-aware byte-identical snapshot restore on any fault (`#885`/`#923` pattern).

`ClassFormCore` gains `GetClassIdWhereWaitIconId` / `GetClassMoveIcon` / `GetClassNameWhereWaitIconId` (class back-references), driving the list class-name label (lockstep with `ListParityHelper`, golden-test gated) and the Jump button.

## Plan Reference
Implements the accepted v2 plan (Copilot-reviewed, no blocking concerns) posted on issue #991: "## Plan (revised v2 after Copilot review)" — https://github.com/laqieer/FEBuilderGBA/issues/991

## Scope
**Closes #991** — W0/W2/P4 editable + undo-safe Write, 5-selectable palette + 0..2 step preview (sheet + frame), PNG + animated-GIF export, static PNG/BMP import with size validation + LZ77 write-back, Comment, jump-to-Move-Icon, owning-class names in the list. This is full WinForms parity (WF itself does not import animated GIFs).

Documented residual gaps (inline, no follow-up issue):
1. **Animated-GIF import** — not a WF feature (WF import is PNG/BMP single-frame; GIF is export-only).
2. **Interactive palette reorder/force dialog** (WF `CheckPalette`/`ErrorPaletteShowForm`) — replaced by automatic nearest-color remap onto the shared self-army palette.
3. **Old-region recycle on import** — always-append via `WriteCompressedToROM` (never corrupts shared sprites; may leak freespace on repeated import).
4. **List-expand barista repoint / >128 popup + source-file Open/Select** — WinForms-only conveniences; the editor edits existing entries only.
5. The shared list-termination contract (first non-pointer `@+4`) is kept unchanged; WF's `P4==0 && flags!=0` non-terminal nuance is a documented pre-existing residual (a test asserts current vanilla behavior).

## Screenshots
**Unit Wait Icon Editor — fully ported (no longer a stub)** (FE8U; `04 Cavalier WaitIcon` selected). The right pane now shows the editable **Flags (W0)=2**, **Anime Type (W2)=1**, **Image Pointer (P4)** fields, the 5-item **Palette** combo (`自軍`), the **Frame Step** spinner, and BOTH the **Full Sheet** preview (3 stacked cavalier frames) and the single **Frame** preview rendering the mounted-cavalier sprite. The address list shows resolved class-name labels (`00 #0 WaitIcon`, `01 Lord WaitIcon`, `04 Cavalier WaitIcon`, …). Before this PR the right pane showed only an "Address:" label.

![Unit Wait Icon Editor populated with fields and both previews](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr993-waiticon-populated.png)

> Captured live via UIAutomation navigation (`Main_WaitIcon_Button` → `Unit Wait Icon` window, select Cavalier) + WinCapture `PrintWindow` from the running app built on this branch. Export/Import/Write/Jump-to-Move-Icon buttons + Comment sit below the visible fold (window is `SizeToContent`-constrained ~644px); they are exercised by the headless `[AvaloniaFact]` tests in the GUI Test Report.

## GUI Test Report
Headless `[AvaloniaFact]` validation against `roms/FE8U.gba` (and a manual GUI launch confirming the populated editor renders fields + both previews + the 5-item palette combo + class-name list labels).

| Test | Result |
|------|--------|
| Controls_Present_And_Wired (palette combo count==5, step Max==2, all AutomationIds) | PASS |
| Select_Populates_Fields_And_Previews | PASS |
| PaletteCombo_And_Step_RefreshSingleFramePreview | PASS |
| Export_Png_Writes_File | PASS |
| Export_Gif_Writes_File_With_3_Frames (asserts exactly 3 image blocks) | PASS |
| Import_16x48_Sets_B2_0_And_Writes_Pointer | PASS |
| Import_WrongSize_Rejected_NoMutation (byte-identical) | PASS |
| JumpMoveIcon_Resolves_For_OwnedWaitIcon | PASS |
| Comment_Saves_And_Reloads | PASS |
| List_StopsAtFirstNonPointerP4_VanillaBehavior (documents shared list-stop residual) | PASS |
| RenderClassWaitIcon_PixelEquals_RenderFrameStep0_RealDecoder (SkiaSharp real pixels) | PASS |
| RenderFrame_Step0_AnimType_HasExpectedSize_RealDecoder (16x16 / 16x24 / 32x32) | PASS |
| BuildReferenceList_ImageUnitWaitIcon_MatchesViewModel (golden lockstep) | PASS |

Manual GUI: launched the Avalonia app on `roms/FE8U.gba`, opened the Wait Icon editor via the main-window "Wait Icon" button, selected an entry — fields populated (Flags=2, Anime Type=1, Image Pointer=136017960), both Full Sheet + Frame previews rendered, palette combo showed the 5 选项, and the list showed class names (Lord / Great Lord / Cavalier / Paladin / Knight WaitIcon). Captured locally for the orchestrator to attach.

## Test plan
- [x] `WaitIconRenderCoreTests` (Core): per-animType crop sizes for steps 0/1/2 (16x16 / 16x24 / 32x32), `RenderClassWaitIcon` == `RenderFrame(step:0)` geometry, palette types 0..4 non-null + FE6 lightrune/sepia blank, out-of-range index → blank no-throw, null guards — 30 Core tests PASS
- [x] `WaitIconImportCoreTests` (Core): `Import_16x48_SetsB2_0_RepointsP4`, 16x96/32x96 → b2 1/2, `Import_WrongSize_NoMutation` (byte-identical), `Import_ForcedFault_RestoresByteIdentical` (32MB no-free-space → byte-identical), null guard — PASS
- [x] `ClassFormCoreTests` (Core): wait→class→move-icon round-trip (FE8U), class-name non-empty for owned icon (FE8U), `GetClassMoveIcon` reads +4, class 0 → NOT_FOUND, wait-id miss → NOT_FOUND no-throw, null ROM — PASS
- [x] `ImageUnitWaitIconViewTests` (Avalonia headless): all 14 tests listed in the GUI Test Report above — PASS
- [x] `ListParityHelperTests.BuildReferenceList_ImageUnitWaitIcon_MatchesViewModel` golden lockstep (VM `LoadList` ↔ `BuildImageUnitWaitIconList`, both append the class name) — PASS
- [x] Existing `PreviewIconHelperWaitIconTests` still pass (the `LoadClassWaitIcon` delegation preserves behavior)
- [x] `FEBuilderGBA.Core`, `FEBuilderGBA.Avalonia`, `FEBuilderGBA.Core.Tests`, `FEBuilderGBA.Avalonia.Tests` all build clean
- [x] Manual GUI launch on `roms/FE8U.gba` confirming populated fields + both previews + 5-item palette combo + class-name list labels

Generated with Claude Code (claude-opus-4-8[1m])

