### PR TITLE
fix(avalonia): wire palette-edit Redo buttons to Core Undo.RunRedo() (#994)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
@@ -160,17 +160,49 @@ public class ImageBattleAnimePalletParityTests
             RegexOptions.Singleline), code);
     }
 
+    /// <summary>
+    /// #994: the Redo button is now wired to CoreState.Undo.RunRedo() — the
+    /// stale "#399 WinForms-coupled PaletteFormRef" blocker was removed.
+    /// The button must carry Click="Redo_Click" and must NOT contain IsEnabled="False".
+    /// </summary>
     [Fact]
-    public void View_RedoButton_IsHonestlyDisabledKnownGap()
+    public void View_RedoButton_IsWiredAndEnabled()
     {
-        // Per Plan v6 Finding #2: the local palette-edit redo buffer is
-        // WF PaletteFormRef-coupled. The Redo button is rendered but
-        // disabled with an explanatory tooltip.
         string axaml = ReadAxaml();
-        // Find the Redo button section.
+        var rx = new Regex(
+            "AutomationId=\"ImageBattleAnimePallet_Redo_Button\"[\\s\\S]*?/>",
+            RegexOptions.Compiled);
+        Match m = rx.Match(axaml);
+        Assert.True(m.Success, "Redo button tag not found");
+        Assert.Contains("Click=\"Redo_Click\"", m.Value);
+        Assert.DoesNotContain("IsEnabled=\"False\"", m.Value);
+    }
+
+    /// <summary>
+    /// #994: the Redo_Click handler must call CoreState.Undo.RunRedo() and
+    /// guard on CanRedo. CanRedo must appear textually before RunRedo()
+    /// within the Redo_Click method body.
+    /// The stale "#399" / "WinForms-coupled" strings must be gone.
+    /// </summary>
+    [Fact]
+    public void View_RedoHandler_CallsRunRedo()
+    {
+        string source = File.ReadAllText(CodeBehindPath());
         Assert.Matches(new Regex(
-            @"AutomationId=""ImageBattleAnimePallet_Redo_Button""[\s\S]{0,400}IsEnabled=""False""",
-            RegexOptions.Singleline), axaml);
+            @"void\s+Redo_Click[\s\S]*?CoreState\.Undo\.CanRedo",
+            RegexOptions.Compiled), source);
+        Assert.Matches(new Regex(
+            @"void\s+Redo_Click[\s\S]*?CoreState\.Undo\.RunRedo\(\)",
+            RegexOptions.Compiled), source);
+        // Extract only the Redo_Click method body to check ordering.
+        int methodStart = source.IndexOf("void Redo_Click(", StringComparison.Ordinal);
+        Assert.True(methodStart >= 0, "Redo_Click method not found");
+        int idxCanRedo = source.IndexOf("CoreState.Undo.CanRedo", methodStart, StringComparison.Ordinal);
+        int idxRunRedo = source.IndexOf("CoreState.Undo.RunRedo()", methodStart, StringComparison.Ordinal);
+        Assert.True(idxCanRedo >= 0 && idxRunRedo >= 0, "CanRedo and RunRedo must both be present");
+        Assert.True(idxCanRedo < idxRunRedo, "CanRedo must appear before RunRedo()");
+        // Stale strings must be gone.
+        Assert.DoesNotContain("WinForms-coupled", source);
     }
 
     /// <summary>
@@ -908,6 +940,76 @@ public class ImageBattleAnimePalletParityTests
 
             Assert.Equal(0,  roundtrip[1] & 0x1F);        // R=0
             Assert.Equal(31, (roundtrip[1] >> 5) & 0x1F); // G=31
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.Undo = prevUndo;
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // #994: Functional edit->undo->redo round-trip for Battle Anime palette.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// #994: write a battle-anime palette color, undo it, verify CanRedo is
+    /// true, redo it, verify the palette bytes return to the edited state.
+    /// After redo, asserts the palette byte round-trip; full relocation-slot
+    /// re-resolve assertion is impractical with the synthetic ROM (no PLIST
+    /// rescan) — at minimum the palette-byte round-trip is validated.
+    /// </summary>
+    [Fact]
+    public void BattleAnimePalette_EditUndoRedo_RoundTrip()
+    {
+        var (rom, paletteOffset, sourceSlot) = MakeRomWithSingleSlotPalette(new ushort[16]);
+        var prevRom = CoreState.ROM;
+        var prevUndo = CoreState.Undo;
+        try
+        {
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+
+            var vm = new ImageBattleAnimePalletViewModel();
+            vm.LoadEntry(paletteOffset, sourceSlot, paletteIndex: 0);
+
+            // Capture original palette color[0].
+            ushort[] origColors = ImageBattleAnimePaletteCore.ReadPalette(rom, paletteOffset, 0);
+            Assert.NotNull(origColors);
+            int origR = origColors[0] & 0x1F;
+
+            // Edit color[0] to max R.
+            vm.SetR(0, 248); // 248 >> 3 = 31
+
+            var undoService = new UndoService();
+            undoService.Begin("Edit palette R0");
+            uint newOffset = vm.Write();
+            undoService.Commit();
+
+            Assert.NotEqual(U.NOT_FOUND, newOffset);
+
+            // Verify the write produced a different R value.
+            ushort[] editedColors = ImageBattleAnimePaletteCore.ReadPalette(rom, newOffset, 0);
+            Assert.NotNull(editedColors);
+            int editedR = editedColors[0] & 0x1F;
+            Assert.Equal(31, editedR);
+
+            // Undo — reload and verify palette is back to original.
+            CoreState.Undo.RunUndo();
+            // After undo the source slot points back to paletteOffset.
+            ushort[] undoneColors = ImageBattleAnimePaletteCore.ReadPalette(rom, paletteOffset, 0);
+            Assert.NotNull(undoneColors);
+            Assert.Equal(origR, undoneColors[0] & 0x1F);
+
+            // CanRedo must be true.
+            Assert.True(CoreState.Undo.CanRedo, "CanRedo must be true after undo");
+
+            // Redo — verify palette bytes return to the edited state.
+            CoreState.Undo.RunRedo();
+            // After redo the palette at newOffset has the edited color.
+            ushort[] redoneColors = ImageBattleAnimePaletteCore.ReadPalette(rom, newOffset, 0);
+            Assert.NotNull(redoneColors);
+            Assert.Equal(editedR, redoneColors[0] & 0x1F);
         }
         finally
         {

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
@@ -953,15 +953,23 @@ public class ImageBattleAnimePalletParityTests
     // -----------------------------------------------------------------
 
     /// <summary>
-    /// #994: write a battle-anime palette color, undo it, verify CanRedo is
-    /// true, redo it, verify the palette bytes return to the edited state.
-    /// After redo, asserts the palette byte round-trip; full relocation-slot
-    /// re-resolve assertion is impractical with the synthetic ROM (no PLIST
-    /// rescan) — at minimum the palette-byte round-trip is validated.
+    /// #994 (Copilot CLI review on PR #1041): exercises the HIGHEST-risk redo
+    /// path — `Redo_Click` reloads via `ReloadFromAuthoritativeSlot()`, which
+    /// re-reads `rom.p32(sourcePointerSlot)`. This test FORCES a relocation
+    /// (all 16 colors edited to distinct high-entropy values so the
+    /// recompressed block grows past the tiny all-zero original) and verifies
+    /// the AUTHORITATIVE source-pointer slot rolls BACK on undo and FORWARD on
+    /// redo, reading the palette THROUGH that slot (mirroring what
+    /// ReloadFromAuthoritativeSlot does) rather than a hardcoded offset. A
+    /// regression that restores the relocated bytes but fails to repoint the
+    /// source slot would reload from the wrong palette — and now fails here.
     /// </summary>
     [Fact]
     public void BattleAnimePalette_EditUndoRedo_RoundTrip()
     {
+        // All-zero original compresses to a tiny block; editing all 16 slots
+        // to distinct high-entropy colors forces the recompressed block to
+        // exceed the original => the RELOCATE branch.
         var (rom, paletteOffset, sourceSlot) = MakeRomWithSingleSlotPalette(new ushort[16]);
         var prevRom = CoreState.ROM;
         var prevUndo = CoreState.Undo;
@@ -973,43 +981,68 @@ public class ImageBattleAnimePalletParityTests
             var vm = new ImageBattleAnimePalletViewModel();
             vm.LoadEntry(paletteOffset, sourceSlot, paletteIndex: 0);
 
-            // Capture original palette color[0].
-            ushort[] origColors = ImageBattleAnimePaletteCore.ReadPalette(rom, paletteOffset, 0);
-            Assert.NotNull(origColors);
-            int origR = origColors[0] & 0x1F;
+            // The source slot must initially point at the original palette.
+            Assert.Equal(paletteOffset, U.toOffset(rom.p32(sourceSlot)));
 
-            // Edit color[0] to max R.
-            vm.SetR(0, 248); // 248 >> 3 = 31
+            // Capture the original palette read THROUGH the authoritative slot.
+            ushort[] origColors = ImageBattleAnimePaletteCore.ReadPalette(
+                rom, U.toOffset(rom.p32(sourceSlot)), 0);
+            Assert.NotNull(origColors);
+
+            // Edit ALL 16 colors to DISTINCT high-entropy values so the
+            // recompressed block is much larger than the all-zero original
+            // (one-color edits stay in-place and would NOT relocate).
+            var edited = new ushort[16];
+            for (int i = 0; i < 16; i++)
+            {
+                ushort c = (ushort)((0x7FFF - i * 0x111) & 0x7FFF);
+                edited[i] = c;
+                vm.SetR(i, (byte)(((c) & 0x1F) << 3));
+                vm.SetG(i, (byte)(((c >> 5) & 0x1F) << 3));
+                vm.SetB(i, (byte)(((c >> 10) & 0x1F) << 3));
+            }
 
             var undoService = new UndoService();
-            undoService.Begin("Edit palette R0");
+            undoService.Begin("Edit all 16 colors");
             uint newOffset = vm.Write();
             undoService.Commit();
 
+            // Relocation must actually have happened.
             Assert.NotEqual(U.NOT_FOUND, newOffset);
+            Assert.NotEqual(paletteOffset, newOffset);
 
-            // Verify the write produced a different R value.
-            ushort[] editedColors = ImageBattleAnimePaletteCore.ReadPalette(rom, newOffset, 0);
+            // The source slot must have been repointed to the new offset.
+            Assert.Equal(newOffset, U.toOffset(rom.p32(sourceSlot)));
+
+            // Palette read THROUGH the slot shows the edited colors.
+            ushort[] editedColors = ImageBattleAnimePaletteCore.ReadPalette(
+                rom, U.toOffset(rom.p32(sourceSlot)), 0);
             Assert.NotNull(editedColors);
-            int editedR = editedColors[0] & 0x1F;
-            Assert.Equal(31, editedR);
+            for (int i = 0; i < 16; i++)
+                Assert.Equal(edited[i] & 0x7FFF, editedColors[i] & 0x7FFF);
 
-            // Undo — reload and verify palette is back to original.
+            // -- Undo: the source slot pointer must roll BACK to paletteOffset.
             CoreState.Undo.RunUndo();
-            // After undo the source slot points back to paletteOffset.
-            ushort[] undoneColors = ImageBattleAnimePaletteCore.ReadPalette(rom, paletteOffset, 0);
+            Assert.Equal(paletteOffset, U.toOffset(rom.p32(sourceSlot)));
+            // And the palette read THROUGH the slot shows the ORIGINAL colors.
+            ushort[] undoneColors = ImageBattleAnimePaletteCore.ReadPalette(
+                rom, U.toOffset(rom.p32(sourceSlot)), 0);
             Assert.NotNull(undoneColors);
-            Assert.Equal(origR, undoneColors[0] & 0x1F);
+            for (int i = 0; i < 16; i++)
+                Assert.Equal(origColors[i] & 0x7FFF, undoneColors[i] & 0x7FFF);
 
-            // CanRedo must be true.
+            // CanRedo must be true after undo.
             Assert.True(CoreState.Undo.CanRedo, "CanRedo must be true after undo");
 
-            // Redo — verify palette bytes return to the edited state.
+            // -- Redo: the source slot pointer must roll FORWARD to newOffset.
             CoreState.Undo.RunRedo();
-            // After redo the palette at newOffset has the edited color.
-            ushort[] redoneColors = ImageBattleAnimePaletteCore.ReadPalette(rom, newOffset, 0);
+            Assert.Equal(newOffset, U.toOffset(rom.p32(sourceSlot)));
+            // And the palette read THROUGH the slot shows the EDITED colors.
+            ushort[] redoneColors = ImageBattleAnimePaletteCore.ReadPalette(
+                rom, U.toOffset(rom.p32(sourceSlot)), 0);
             Assert.NotNull(redoneColors);
-            Assert.Equal(editedR, redoneColors[0] & 0x1F);
+            for (int i = 0; i < 16; i++)
+                Assert.Equal(edited[i] & 0x7FFF, redoneColors[i] & 0x7FFF);
         }
         finally
         {

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleScreenParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleScreenParityTests.cs
@@ -428,6 +428,122 @@ public class ImageBattleScreenParityTests
     }
 
     // -----------------------------------------------------------------
+    // #994: PaletteRedo button wired, BulkRedo stays deferred.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// #994: the PaletteRedo button is now wired to CoreState.Undo.RunRedo().
+    /// Must carry Click="PaletteRedo_Click" and must NOT contain IsEnabled="False".
+    /// </summary>
+    [Fact]
+    public void View_PaletteRedoButton_IsWiredAndEnabled()
+    {
+        string axaml = ReadAxaml();
+        var rx = new Regex(
+            "AutomationId=\"ImageBattleScreen_PaletteRedo_Button\"[\\s\\S]*?/>",
+            RegexOptions.Compiled);
+        Match m = rx.Match(axaml);
+        Assert.True(m.Success, "PaletteRedo button tag not found");
+        Assert.Contains("Click=\"PaletteRedo_Click\"", m.Value);
+        Assert.DoesNotContain("IsEnabled=\"False\"", m.Value);
+    }
+
+    /// <summary>
+    /// #994: PaletteRedo_Click handler must call CoreState.Undo.RunRedo()
+    /// and guard on CanRedo. CanRedo must appear before RunRedo() within
+    /// the PaletteRedo_Click method body.
+    /// </summary>
+    [Fact]
+    public void View_PaletteRedoHandler_CallsRunRedo()
+    {
+        string source = File.ReadAllText(CodeBehindPath());
+        Assert.Matches(new Regex(
+            @"void\s+PaletteRedo_Click[\s\S]*?CoreState\.Undo\.CanRedo",
+            RegexOptions.Compiled), source);
+        Assert.Matches(new Regex(
+            @"void\s+PaletteRedo_Click[\s\S]*?CoreState\.Undo\.RunRedo\(\)",
+            RegexOptions.Compiled), source);
+        // Extract only the PaletteRedo_Click method body to check ordering.
+        int methodStart = source.IndexOf("void PaletteRedo_Click(", StringComparison.Ordinal);
+        Assert.True(methodStart >= 0, "PaletteRedo_Click method not found");
+        int idxCanRedo = source.IndexOf("CoreState.Undo.CanRedo", methodStart, StringComparison.Ordinal);
+        int idxRunRedo = source.IndexOf("CoreState.Undo.RunRedo()", methodStart, StringComparison.Ordinal);
+        Assert.True(idxCanRedo >= 0 && idxRunRedo >= 0);
+        Assert.True(idxCanRedo < idxRunRedo, "CanRedo must appear before RunRedo()");
+    }
+
+    /// <summary>
+    /// #994 regression guard: BulkRedo stays a documented deferral (#988) —
+    /// it must still have IsEnabled="False".
+    /// </summary>
+    [Fact]
+    public void View_BulkRedoButton_StaysDocumentedDeferral()
+    {
+        string axaml = ReadAxaml();
+        Assert.Matches(new Regex(
+            "AutomationId=\"ImageBattleScreen_BulkRedo_Button\"[\\s\\S]{0,400}IsEnabled=\"False\"",
+            RegexOptions.Compiled), axaml);
+    }
+
+    /// <summary>
+    /// #994: write a palette color via WritePalette, undo it, verify CanRedo
+    /// is true, redo it, verify the palette bytes return to the edited state.
+    /// </summary>
+    [Fact]
+    public void BattleScreenPalette_EditUndoRedo_RoundTrip()
+    {
+        var rom = MakeSyntheticRom();
+        var prevRom = CoreState.ROM;
+        var prevUndo = CoreState.Undo;
+        try
+        {
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+
+            var vm = new ImageBattleScreenViewModel();
+            vm.LoadEntry();
+
+            // Capture original palette color[0] from ROM.
+            byte origLo = rom.Data[0x105000];
+            byte origHi = rom.Data[0x105001];
+
+            // Edit slot 0 to a known color (pure green = R0, G248, B0).
+            vm.SetR(0, 0);
+            vm.SetG(0, 248);
+            vm.SetB(0, 0);
+
+            var undoService = new UndoService();
+            undoService.Begin("Edit Palette");
+            bool wrote = vm.WritePalette();
+            undoService.Commit();
+            Assert.True(wrote, "WritePalette must succeed");
+
+            byte editedLo = rom.Data[0x105000];
+            byte editedHi = rom.Data[0x105001];
+            Assert.False(editedLo == origLo && editedHi == origHi,
+                "ROM bytes should have changed after palette write");
+
+            // Undo.
+            CoreState.Undo.RunUndo();
+            Assert.Equal(origLo, rom.Data[0x105000]);
+            Assert.Equal(origHi, rom.Data[0x105001]);
+
+            // CanRedo must be true after undo.
+            Assert.True(CoreState.Undo.CanRedo, "CanRedo must be true after undo");
+
+            // Redo.
+            CoreState.Undo.RunRedo();
+            Assert.Equal(editedLo, rom.Data[0x105000]);
+            Assert.Equal(editedHi, rom.Data[0x105001]);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.Undo = prevUndo;
+        }
+    }
+
+    // -----------------------------------------------------------------
     // Phase 5 - Code-behind / write-handler assertions.
     // -----------------------------------------------------------------
 

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImagePalletParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImagePalletParityTests.cs
@@ -124,29 +124,56 @@ public class ImagePalletParityTests
         Assert.Contains("AutomationId=\"ImagePallet_Redo_Button\"", axaml);
     }
 
+    // ===================================================================
+    // #994: Redo button is now wired to CoreState.Undo.RunRedo()
+    // ===================================================================
+
     /// <summary>
-    /// Redo is the sole remaining deferred affordance (Core has no
-    /// RunRedo() API yet); it must stay disabled. NOTE: Import / Export /
-    /// Clipboard were wired to PaletteCore + PaletteFormatConverter in
-    /// #777 and are now enabled (see
-    /// <see cref="View_PaletteIoButtons_AreEnabled"/>).
+    /// #994: the Redo button is now wired (not disabled) — the stale "#500 Core
+    /// has no RunRedo() API" blocker was removed. The button must carry
+    /// Click="Redo_Click" and must NOT contain IsEnabled="False".
     /// </summary>
-    [Theory]
-    [InlineData("ImagePallet_Redo_Button")]
-    public void View_DeferredButton_IsDisabledAndReferencesFollowupIssue(string automationId)
+    [Fact]
+    public void View_RedoButton_IsWiredAndEnabled()
     {
         string axaml = ReadAxaml();
-        int idx = axaml.IndexOf($"AutomationId=\"{automationId}\"", StringComparison.Ordinal);
-        Assert.True(idx >= 0, $"AutomationId {automationId} not found in AXAML");
+        var rx = new System.Text.RegularExpressions.Regex(
+            "AutomationId=\"ImagePallet_Redo_Button\"[\\s\\S]*?/>",
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+        System.Text.RegularExpressions.Match m = rx.Match(axaml);
+        Assert.True(m.Success, "Redo button tag not found");
+        Assert.Contains("Click=\"Redo_Click\"", m.Value);
+        Assert.DoesNotContain("IsEnabled=\"False\"", m.Value);
+    }
 
-        int elementStart = axaml.LastIndexOf('<', idx);
-        Assert.True(elementStart >= 0);
-        int elementEnd = FindElementEnd(axaml, elementStart);
-        Assert.True(elementEnd > elementStart);
-        string element = axaml.Substring(elementStart, elementEnd - elementStart + 1);
-
-        Assert.Contains("IsEnabled=\"False\"", element);
-        Assert.Contains("#500", element);
+    /// <summary>
+    /// #994: the Redo_Click handler must call CoreState.Undo.RunRedo() and
+    /// guard on CanRedo. CanRedo must appear textually before RunRedo()
+    /// within the Redo_Click method body.
+    /// The stale "Core has no RunRedo" string must be gone.
+    /// </summary>
+    [Fact]
+    public void View_RedoHandler_CallsRunRedo()
+    {
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        // Verify both calls exist in the Redo_Click method.
+        Assert.Matches(new System.Text.RegularExpressions.Regex(
+            @"void\s+Redo_Click[\s\S]*?CoreState\.Undo\.CanRedo",
+            System.Text.RegularExpressions.RegexOptions.Compiled), source);
+        Assert.Matches(new System.Text.RegularExpressions.Regex(
+            @"void\s+Redo_Click[\s\S]*?CoreState\.Undo\.RunRedo\(\)",
+            System.Text.RegularExpressions.RegexOptions.Compiled), source);
+        // Extract only the Redo_Click method body to check ordering.
+        // Find the method start, then the matching close brace.
+        int methodStart = source.IndexOf("void Redo_Click(", StringComparison.Ordinal);
+        Assert.True(methodStart >= 0, "Redo_Click method not found");
+        // Find the first '!CoreState.Undo.CanRedo' after the method start.
+        int idxCanRedo = source.IndexOf("CoreState.Undo.CanRedo", methodStart, StringComparison.Ordinal);
+        int idxRunRedo = source.IndexOf("CoreState.Undo.RunRedo()", methodStart, StringComparison.Ordinal);
+        Assert.True(idxCanRedo >= 0 && idxRunRedo >= 0, "CanRedo and RunRedo must both be present");
+        Assert.True(idxCanRedo < idxRunRedo, "CanRedo must appear before RunRedo()");
+        // Stale strings must be gone.
+        Assert.DoesNotContain("Core has no RunRedo", source);
     }
 
     /// <summary>
@@ -433,6 +460,69 @@ public class ImagePalletParityTests
         Assert.Contains("Open<ImagePalletView>()", methodBody);
         Assert.Contains(".JumpTo(", methodBody);
         Assert.Contains("PalettePtr", methodBody);
+    }
+
+    // ===================================================================
+    // #994: Functional edit->undo->redo round-trip
+    // ===================================================================
+
+    /// <summary>
+    /// #994: write a palette, undo it, verify CanRedo is true, redo it,
+    /// verify the bytes are restored to the edited state.
+    /// </summary>
+    [Fact]
+    public void Palette_EditUndoRedo_RoundTrip()
+    {
+        var rom = MakeMinimalRomWithPaletteAt(0x100000u);
+        var prevRom = CoreState.ROM;
+        var prevUndo = CoreState.Undo;
+        try
+        {
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+
+            var vm = new ImagePalletViewModel();
+            vm.LoadEntry(0x100000u, 1, 0, null);
+
+            // Capture original bytes at slot 0.
+            byte origLo = rom.Data[0x100000];
+            byte origHi = rom.Data[0x100001];
+
+            // Edit slot 0 to a known color (pure green = 0, 248, 0).
+            var undoService = new UndoService();
+            undoService.Begin("Edit Palette");
+            vm.R1 = 0;
+            vm.G1 = 248;
+            vm.B1 = 0;
+            vm.Write();
+            undoService.Commit();
+
+            // ROM must have changed.
+            byte editedLo = rom.Data[0x100000];
+            byte editedHi = rom.Data[0x100001];
+            Assert.False(editedLo == origLo && editedHi == origHi,
+                "ROM bytes should have changed after the write");
+
+            // Undo — bytes must revert.
+            CoreState.Undo.RunUndo();
+            vm.LoadEntry(0x100000u, 1, 0, null);
+            Assert.Equal(origLo, rom.Data[0x100000]);
+            Assert.Equal(origHi, rom.Data[0x100001]);
+
+            // CanRedo must be true after undo.
+            Assert.True(CoreState.Undo.CanRedo, "CanRedo must be true after undo");
+
+            // Redo — bytes must return to the edited state.
+            CoreState.Undo.RunRedo();
+            vm.LoadEntry(0x100000u, 1, 0, null);
+            Assert.Equal(editedLo, rom.Data[0x100000]);
+            Assert.Equal(editedHi, rom.Data[0x100001]);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.Undo = prevUndo;
+        }
     }
 
     // ===================================================================

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml
@@ -370,8 +370,7 @@
                   Click="Undo_Click" />
           <Button AutomationProperties.AutomationId="ImageBattleAnimePallet_Redo_Button"
                   Name="RedoButton" Content="Redo" Width="100"
-                  IsEnabled="False"
-                  ToolTip.Tip="Deferred KnownGap: local palette-edit redo (PaletteFormRef redo buffer) is WinForms-coupled (#399). Use the main ROM-level Undo via the toolbar." />
+                  Click="Redo_Click" />
         </StackPanel>
       </Border>
 

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml.cs
@@ -608,6 +608,31 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
+        void Redo_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (CoreState.Undo == null || !CoreState.Undo.CanRedo)
+                {
+                    CoreState.Services.ShowInfo("Nothing to redo.");
+                    return;
+                }
+                if (!CoreState.Undo.RunRedo())
+                {
+                    CoreState.Services.ShowError("Redo failed.");
+                    return;
+                }
+                // Reload via the authoritative back-pointer slot (mirrors Undo_Click).
+                ReloadFromAuthoritativeSlot();
+                // Refresh the entry list so any post-redo address shifts are reflected.
+                RefreshListPreservingSelection();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("Redo_Click failed: {0}", ex.Message);
+            }
+        }
+
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
     }

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml
@@ -133,8 +133,7 @@
                         Click="PaletteUndo_Click" />
                 <Button AutomationProperties.AutomationId="ImageBattleScreen_PaletteRedo_Button"
                         Name="PaletteRedoButton" Content="Redo" Width="100"
-                        IsEnabled="False"
-                        ToolTip.Tip="KnownGap: local palette-edit redo (PaletteFormRef redo buffer) is WinForms-coupled (#393). Use the main ROM-level Undo via the toolbar." />
+                        Click="PaletteRedo_Click" />
               </StackPanel>
 
               <!-- RGB header row -->

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml.cs
@@ -514,6 +514,35 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
+        void PaletteRedo_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (CoreState.Undo == null || !CoreState.Undo.CanRedo)
+                {
+                    CoreState.Services.ShowInfo("Nothing to redo.");
+                    return;
+                }
+                if (!CoreState.Undo.RunRedo())
+                {
+                    CoreState.Services.ShowError("Redo failed.");
+                    return;
+                }
+                // This DELIBERATELY mirrors PaletteUndo_Click's full LoadEntry reload
+                // (redo = exact inverse of undo, WF parity) rather than the
+                // palette-only LoadPalette() refresh used for palette-index switches.
+                _vm.LoadEntry();
+                PopulateUI();
+                RefreshBattlePreview();
+                RefreshChipsetPreview();
+                RefreshImagePreviews();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("PaletteRedo_Click failed: {0}", ex.Message);
+            }
+        }
+
         void BulkUndo_Click(object sender, RoutedEventArgs e)
         {
             try

--- a/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml
@@ -47,8 +47,7 @@
                     Name="UndoButton" Content="Undo" Click="Undo_Click" />
             <Button AutomationProperties.AutomationId="ImagePallet_Redo_Button"
                     Name="RedoButton" Content="Redo"
-                    IsEnabled="False"
-                    ToolTip.Tip="Pending Core RunRedo API - tracked by #500." />
+                    Click="Redo_Click" />
           </StackPanel>
         </Border>
 

--- a/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml.cs
@@ -6,7 +6,9 @@
 //
 // All ROM writes are wrapped in UndoService.Begin/Commit/Rollback;
 // Undo is wired to CoreState.Undo.RunUndo() + reload, Redo is
-// deferred behind #500 (Core has no RunRedo() API).
+// wired to CoreState.Undo.RunRedo() (#994). The "#500 Core has no
+// RunRedo() API" blocker was stale — RunRedo()/CanRedo have existed
+// since #692.
 
 using System;
 using System.IO;
@@ -411,6 +413,46 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 Log.Error("ImagePalletView.Undo_Click failed: {0}", ex.Message);
+            }
+        }
+
+        void Redo_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (CoreState.Undo == null || !CoreState.Undo.CanRedo)
+                {
+                    CoreState.Services.ShowInfo("Nothing to redo.");
+                    return;
+                }
+                if (!CoreState.Undo.RunRedo())
+                {
+                    CoreState.Services.ShowError("Redo failed.");
+                    return;
+                }
+                // Reload so the displayed values reflect the post-redo ROM state.
+                // Preserve the palette-name overrides across reload.
+                if (_vm.IsLoaded)
+                {
+                    uint addr = _vm.PaletteAddress;
+                    int max = _vm.MaxPaletteCount;
+                    int idx = _vm.PaletteIndex;
+                    _vm.IsLoading = true;
+                    try
+                    {
+                        _vm.LoadEntry(addr, max, idx, _lastPaletteNames);
+                    }
+                    finally
+                    {
+                        _vm.IsLoading = false;
+                        _vm.MarkClean();
+                    }
+                    UpdateUI();
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImagePalletView.Redo_Click failed: {0}", ex.Message);
             }
         }
 


### PR DESCRIPTION
## Summary
Wires the inert palette-edit **Redo** buttons in three Avalonia editors to the Core `Undo.RunRedo()` API, porting the proven **#974** TSA pattern. The Palette Editor's stated blocker — *"Core has no RunRedo() API"* — was **stale**: `Undo.RunRedo()` + `Undo.CanRedo` have existed since #692 (`FEBuilderGBA.Core/Undo.cs:166`/`:178`) and are already used by `MapStyleEditorView` + `ImageTSAEditorView`. This is Avalonia wiring only — **no Core changes**.

Plan + Copilot CLI review: see issue #994 comment thread (approach approved, no blocking concerns; three refinements folded in).

## Scope
Closes #994.

Wired (ROM-level Core redo):
- **Palette Editor** (`ImagePalletView`) — `Redo_Click`
- **Battle Screen Layout** (`ImageBattleScreenView`) — `PaletteRedo_Click`
- **Battle Animation Palette** (`ImageBattleAnimePalletView`) — `Redo_Click`

Intentionally kept deferred (per the issue's acceptance criteria):
- Battle Screen **Bulk** TSA Redo — local-TSA-only buffer, WinForms-coupled (#988). Tooltip unchanged; a regression guard test now pins it disabled.

## Changes
- Each editor's Redo button: removed `IsEnabled="False"` + the stale `#500`/`#393`/`#399` tooltip; added the `Click` handler.
- Each handler mirrors its editor's existing `Undo_Click` reload chain, gated with the #974 guard pattern: `CanRedo` check → `RunRedo()` bool check → reload + re-render. `CanRedo` is evaluated before `RunRedo()`.
- `ImageBattleScreenView.PaletteRedo_Click` documents the deliberate full-`LoadEntry` reload symmetry with `PaletteUndo_Click` (redo = exact inverse of undo).
- Removed the stale "Core has no RunRedo() API" header comment.

## Test plan
- [x] `dotnet build FEBuilderGBA.Avalonia` — Release, 0 errors
- [x] `FEBuilderGBA.Avalonia.Tests` — 7586/7589 pass (3 skipped, **0 failures**)
- [x] `FEBuilderGBA.Tests` (net9.0-windows, cross-project source/L10n assertions) — 1851/1851 pass
- [x] `FEBuilderGBA.Core.Tests` — palette views untouched by the 10 unrelated `SkillSystemsAnimeImportCore` env failures (master CI is green; those need test fixtures absent from the isolated worktree). All redo/undo Core tests pass.
- [x] Updated the two stale disabled-button assertions (`ImagePalletParityTests.View_DeferredButton_IsDisabledAndReferencesFollowupIssue`, `ImageBattleAnimePalletParityTests.View_RedoButton_IsHonestlyDisabledKnownGap`) to assert the buttons are now enabled + wired
- [x] Added `View_RedoButton_IsWiredAndEnabled` + `View_RedoHandler_CallsRunRedo` (CanRedo-before-RunRedo ordering) per editor
- [x] Added `View_BulkRedoButton_StaysDocumentedDeferral` regression guard (Battle Screen)
- [x] Added edit→undo→redo functional round-trips through the real `UndoService`/`ROM.BeginUndoScope` path for **all three** palette write paths (`ImagePalletViewModel`, `ImageBattleScreenViewModel.WritePalette`, `ImageBattleAnimePalletViewModel.Write`)
- [x] Manual GUI test on `roms/FE8U.gba` (worktree Release build) — see GUI Test Report + screenshots

## GUI Test Report
| Editor | Test | Result |
|---|---|---|
| Palette Editor | Redo button rendered enabled next to Undo/Write | ✅ PASS (screenshot) |
| Battle Animation Palette | Redo button enabled with fully populated palette + sprite data | ✅ PASS (screenshot) |
| Battle Screen Layout | Editor opens populated; Palette tab Redo wired | ✅ PASS (screenshot) |
| All three | edit → undo → redo ROM-byte round-trip | ✅ PASS (automated functional tests) |

Method: app launched against `roms/FE8U.gba`; editors opened via UIAutomation `InvokePattern`; captured via `tools/WinCapture` PrintWindow (locked-session safe).

## Screenshots
**Palette Editor — Redo now enabled (was greyed/disabled):**
![Palette Editor](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr994-palette-editor.png)

**Battle Animation Palette — Redo enabled, populated palette + sprites:**
![Battle Animation Palette](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr994-battle-anime-palette.png)

**Battle Screen Layout — populated editor, Palette tab:**
![Battle Screen Layout](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr994-battle-screen.png)

---
Original request: *"set ralph loop to resolve all open GitHub issues in laqieer/FEBuilderGBA"* — first issue in the autonomous sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.168` · model `claude-opus-4-8[1m]`
