### PR TITLE
fix(avalonia): System Area Hover Color editor — add Write path (#1007)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SystemHoverColorViewerParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SystemHoverColorViewerParityTests.cs
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Regression tests for SystemHoverColorViewerView write path (#1007).
+//
+// Verifies the editor's write round-trip, guard conditions, color-list
+// loading, and View structural requirements (AutomationIds, Write_Click
+// wiring, UndoService scope).
+
+using System;
+using System.IO;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests.GapSweep;
+
+/// <summary>
+/// Tests proving the SystemHoverColorViewerView write path (#1007) is
+/// permanent.  Marked [Collection("SharedState")] because tests that
+/// exercise CoreState.ROM / CoreState.Undo must serialize with all other
+/// CoreState-mutating tests.
+/// </summary>
+[Collection("SharedState")]
+public class SystemHoverColorViewerParityTests
+{
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Build a minimal synthetic FE8U ROM (17 MB) and stamp a u16 at
+    /// <paramref name="addr"/> with <paramref name="value"/>.
+    /// </summary>
+    static ROM MakeRomWithU16(uint addr, ushort value)
+    {
+        var bytes = new byte[0x1100000];
+        BitConverter.GetBytes(value).CopyTo(bytes, (int)addr);
+        var rom = new ROM();
+        rom.LoadLow("synthetic-fe8u.gba", bytes, "BE8E01");
+        return rom;
+    }
+
+    /// <summary>
+    /// Minimal FE8U ROM with a populated
+    /// <c>systemarea_move_gradation_palette_pointer</c> table.
+    ///
+    /// Layout:
+    ///   bytes[pointerSlot .. +4] = GBA pointer to colorBase
+    ///   bytes[colorBase .. +20]  = 10 u16 color entries
+    /// </summary>
+    static ROM MakeRomWithColorTable(out uint colorBase)
+    {
+        var bytes = new byte[0x1100000];
+        var tmpRom = new ROM();
+        tmpRom.LoadLow("tmp.gba", bytes, "BE8E01");
+
+        // Pick a safe raw ROM address and convert to a GBA pointer.
+        colorBase = 0x00200000u; // raw offset = 0x200000
+        uint gbaPtr = colorBase | 0x08000000u;
+
+        // Plant 10 u16 color entries: 0x0001, 0x0002, … 0x000A
+        for (int i = 0; i < 10; i++)
+        {
+            uint off = colorBase + (uint)(i * 2);
+            BitConverter.GetBytes((ushort)(i + 1)).CopyTo(bytes, (int)off);
+        }
+
+        // Write the GBA pointer into the pointer slot that
+        // systemarea_move_gradation_palette_pointer points to.
+        uint pointerSlot = tmpRom.RomInfo.systemarea_move_gradation_palette_pointer;
+        BitConverter.GetBytes(gbaPtr).CopyTo(bytes, (int)pointerSlot);
+
+        var rom = new ROM();
+        rom.LoadLow("synthetic-fe8u.gba", bytes, "BE8E01");
+        return rom;
+    }
+
+    // -----------------------------------------------------------------------
+    // VM write round-trip (including undo)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void VM_WriteRoundTrip_UpdatesRomAndRestoresOnUndo()
+    {
+        const uint ColorAddr = 0x00100000u;
+        const ushort Original = 0x1234;
+        const ushort NewValue = 0x5678;
+
+        ROM rom = MakeRomWithU16(ColorAddr, Original);
+
+        var prevRom = CoreState.ROM;
+        var prevUndo = CoreState.Undo;
+        try
+        {
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+
+            var vm = new SystemHoverColorViewerViewModel();
+            vm.LoadHoverColor(ColorAddr);
+
+            // GBAColor should be set to the planted value after LoadHoverColor.
+            Assert.Equal(Original, (ushort)vm.GBAColor);
+
+            // Verify decoded R/G/B
+            Assert.Equal((byte)((Original & 0x1F) * 8), vm.ColorR);
+            Assert.Equal((byte)(((Original >> 5) & 0x1F) * 8), vm.ColorG);
+            Assert.Equal((byte)(((Original >> 10) & 0x1F) * 8), vm.ColorB);
+
+            // Open undo scope, modify GBAColor, write.
+            var undoSvc = new UndoService();
+            undoSvc.Begin("TestWrite");
+            vm.GBAColor = NewValue;
+            uint res = vm.Write();
+            undoSvc.Commit();
+
+            // Write must return the packed value.
+            Assert.Equal((ushort)NewValue, (ushort)res);
+            Assert.NotEqual(U.NOT_FOUND, res);
+
+            // ROM must reflect the new value.
+            Assert.Equal(NewValue, (ushort)rom.u16(ColorAddr));
+
+            // ColorR/G/B must be updated.
+            Assert.Equal((byte)((NewValue & 0x1F) * 8), vm.ColorR);
+            Assert.Equal((byte)(((NewValue >> 5) & 0x1F) * 8), vm.ColorG);
+            Assert.Equal((byte)(((NewValue >> 10) & 0x1F) * 8), vm.ColorB);
+
+            // Undo must restore original value.
+            CoreState.Undo.RunUndo();
+            Assert.Equal(Original, (ushort)rom.u16(ColorAddr));
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.Undo = prevUndo;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // VM guard: Write returns NOT_FOUND when CanWrite==false or addr==0
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void VM_Write_GuardFailsWhenCanWriteFalse()
+    {
+        ROM rom = MakeRomWithU16(0x100000, 0xABCD);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+
+            // Fresh VM: CanWrite is false, CurrentAddr is 0.
+            var vm = new SystemHoverColorViewerViewModel();
+            Assert.False(vm.CanWrite);
+            Assert.Equal(0u, vm.CurrentAddr);
+
+            uint res = vm.Write();
+            Assert.Equal(U.NOT_FOUND, res);
+
+            // ROM must not be touched.
+            Assert.Equal((ushort)0xABCD, (ushort)rom.u16(0x100000));
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+        }
+    }
+
+    [Fact]
+    public void VM_Write_GuardFailsWhenCurrentAddrIsZero()
+    {
+        ROM rom = MakeRomWithU16(0x100000, 0x0001);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+
+            var vm = new SystemHoverColorViewerViewModel();
+            // Manually set CanWrite but leave CurrentAddr = 0.
+            vm.CanWrite = true;
+            vm.GBAColor = 0x7FFF;
+
+            uint res = vm.Write();
+            Assert.Equal(U.NOT_FOUND, res);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // VM list: LoadColorList returns 10 entries with correct addresses
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void VM_LoadColorList_Returns10EntriesWithCorrectAddresses()
+    {
+        ROM rom = MakeRomWithColorTable(out uint colorBase);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+
+            var vm = new SystemHoverColorViewerViewModel();
+            var list = vm.LoadColorList(0); // filter 0 = Move Range
+
+            Assert.Equal(10, list.Count);
+            for (int i = 0; i < 10; i++)
+            {
+                uint expectedAddr = colorBase + (uint)(i * 2);
+                Assert.Equal(expectedAddr, list[i].addr);
+                // tag carries the raw u16 color value planted above.
+                Assert.Equal((uint)(i + 1), list[i].tag);
+            }
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // View static checks: AXAML has the required AutomationIds and code-behind
+    // has the required Write_Click wiring.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void View_Axaml_ContainsRequiredAutomationIds()
+    {
+        string repoRoot = FindRepoRoot();
+        string axamlPath = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "SystemHoverColorViewerView.axaml");
+        Assert.True(File.Exists(axamlPath), $"AXAML not found: {axamlPath}");
+
+        string content = File.ReadAllText(axamlPath);
+        string[] required =
+        {
+            "SystemHoverColorViewer_GBAColor_Input",
+            "SystemHoverColorViewer_ColorR_Input",
+            "SystemHoverColorViewer_ColorG_Input",
+            "SystemHoverColorViewer_ColorB_Input",
+            "SystemHoverColorViewer_Write_Button",
+        };
+        foreach (string id in required)
+            Assert.Contains(id, content);
+    }
+
+    [Fact]
+    public void View_Axaml_WriteButton_HasCanWriteBinding_And_WriteClickHandler()
+    {
+        string repoRoot = FindRepoRoot();
+        string axamlPath = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "SystemHoverColorViewerView.axaml");
+        string content = File.ReadAllText(axamlPath);
+
+        Assert.Contains("Click=\"Write_Click\"", content);
+        Assert.Contains("IsEnabled=\"{Binding CanWrite}\"", content);
+    }
+
+    [Fact]
+    public void View_CodeBehind_WritesViaUndoServicePattern()
+    {
+        string repoRoot = FindRepoRoot();
+        string csPath = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "SystemHoverColorViewerView.axaml.cs");
+        Assert.True(File.Exists(csPath), $"Code-behind not found: {csPath}");
+
+        string content = File.ReadAllText(csPath);
+
+        // Must have an UndoService field.
+        Assert.Contains("_undoService", content);
+        // Write_Click must exist.
+        Assert.Contains("Write_Click", content);
+        // UndoService scope: Begin + Commit + Rollback.
+        Assert.Contains("_undoService.Begin(", content);
+        Assert.Contains("Commit()", content);
+        Assert.Contains("Rollback()", content);
+        // Must call _vm.Write().
+        Assert.Contains("_vm.Write(", content);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper
+    // -----------------------------------------------------------------------
+
+    static string FindRepoRoot()
+    {
+        string? dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+            dir = Path.GetDirectoryName(dir);
+        if (dir == null)
+            throw new InvalidOperationException("Could not find FEBuilderGBA.sln from test base directory");
+        return dir;
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SystemHoverColorViewerParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SystemHoverColorViewerParityTests.cs
@@ -137,6 +137,30 @@ public class SystemHoverColorViewerParityTests
     }
 
     // -----------------------------------------------------------------------
+    // VM live-sync: setting GBAColor keeps ColorR/G/B decoded in sync (#1044)
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData((ushort)0x0000)]   // black
+    [InlineData((ushort)0x7FFF)]   // white (R=G=B=31)
+    [InlineData((ushort)0x001F)]   // pure red  (R=31)
+    [InlineData((ushort)0x03E0)]   // pure green (G=31)
+    [InlineData((ushort)0x7C00)]   // pure blue  (B=31)
+    [InlineData((ushort)0x5678)]   // mixed
+    public void VM_SetGBAColor_KeepsColorChannelsInSync(ushort value)
+    {
+        // No ROM / CurrentAddr needed: this proves the property setter re-decodes
+        // ColorR/G/B live, so the View's bound NUDs update while editing — before
+        // any Write. (Copilot bot review on PR #1044.)
+        var vm = new SystemHoverColorViewerViewModel();
+        vm.GBAColor = value;
+
+        Assert.Equal((byte)((value & 0x1F) * 8), vm.ColorR);
+        Assert.Equal((byte)(((value >> 5) & 0x1F) * 8), vm.ColorG);
+        Assert.Equal((byte)(((value >> 10) & 0x1F) * 8), vm.ColorB);
+    }
+
+    // -----------------------------------------------------------------------
     // VM guard: Write returns NOT_FOUND when CanWrite==false or addr==0
     // -----------------------------------------------------------------------
 

--- a/FEBuilderGBA.Avalonia/ViewModels/SystemHoverColorViewerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SystemHoverColorViewerViewModel.cs
@@ -16,6 +16,10 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         int _selectedFilterIndex;
         uint _currentAddr;
         uint _currentColor;
+        uint _gbaColor;
+        byte _colorR;
+        byte _colorG;
+        byte _colorB;
         readonly string[] _filterNames = { "Move Range", "Attack Range", "Staff Range" };
 
         public bool CanWrite { get => _canWrite; set => SetField(ref _canWrite, value); }
@@ -24,6 +28,18 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public uint CurrentColor { get => _currentColor; set => SetField(ref _currentColor, value); }
         public string[] FilterNames => _filterNames;
+
+        /// <summary>Editable GBA BGR555 color value (0–65535).</summary>
+        public uint GBAColor { get => _gbaColor; set => SetField(ref _gbaColor, value); }
+
+        /// <summary>Read-only decoded red channel (0–248, step 8).</summary>
+        public byte ColorR { get => _colorR; set => SetField(ref _colorR, value); }
+
+        /// <summary>Read-only decoded green channel (0–248, step 8).</summary>
+        public byte ColorG { get => _colorG; set => SetField(ref _colorG, value); }
+
+        /// <summary>Read-only decoded blue channel (0–248, step 8).</summary>
+        public byte ColorB { get => _colorB; set => SetField(ref _colorB, value); }
 
         uint GetPointerForFilter(int filterIndex)
         {
@@ -85,6 +101,21 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             CurrentAddr = addr;
             uint color = rom.u16(addr);
             CurrentColor = color;
+            GBAColor = color;
+            DecodeAndSetRGB(color);
+            RebuildStatusMessage(addr, color);
+            CanWrite = true;
+        }
+
+        void DecodeAndSetRGB(uint color)
+        {
+            ColorR = (byte)((color & 0x1F) * 8);
+            ColorG = (byte)(((color >> 5) & 0x1F) * 8);
+            ColorB = (byte)(((color >> 10) & 0x1F) * 8);
+        }
+
+        void RebuildStatusMessage(uint addr, uint color)
+        {
             int r = (int)(color & 0x1F) * 8;
             int g = (int)((color >> 5) & 0x1F) * 8;
             int b = (int)((color >> 10) & 0x1F) * 8;
@@ -95,9 +126,27 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             sb.AppendLine($"GBA RGB5:  R={color & 0x1F}, G={(color >> 5) & 0x1F}, B={(color >> 10) & 0x1F}");
             sb.AppendLine($"RGB888:    R={r}, G={g}, B={b}");
             sb.AppendLine($"Hex RGB:   #{r:X2}{g:X2}{b:X2}");
-
             StatusMessage = sb.ToString();
-            CanWrite = true;
+        }
+
+        /// <summary>
+        /// Write the current GBAColor value to ROM at CurrentAddr.
+        /// Returns the written packed u16 value, or U.NOT_FOUND on any guard failure.
+        /// Caller is responsible for wrapping in an UndoService scope.
+        /// </summary>
+        public uint Write()
+        {
+            ROM rom = CoreState.ROM;
+            if (!CanWrite || rom == null || CurrentAddr == 0) return U.NOT_FOUND;
+            if (CurrentAddr + 2 > (uint)rom.Data.Length || !U.isSafetyOffset(CurrentAddr, rom)) return U.NOT_FOUND;
+
+            ushort packed = (ushort)(GBAColor & 0xFFFF);
+            rom.write_u16(CurrentAddr, packed);
+            CurrentColor = packed;
+            GBAColor = packed;
+            DecodeAndSetRGB(packed);
+            RebuildStatusMessage(CurrentAddr, packed);
+            return packed;
         }
 
         static string GbaColorToHex(uint color)
@@ -118,6 +167,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             {
                 ["addr"] = $"0x{CurrentAddr:X08}",
                 ["Color"] = $"0x{CurrentColor:X04}",
+                ["GBAColor"] = $"0x{GBAColor:X04}",
             };
         }
 

--- a/FEBuilderGBA.Avalonia/ViewModels/SystemHoverColorViewerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SystemHoverColorViewerViewModel.cs
@@ -29,8 +29,21 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public uint CurrentColor { get => _currentColor; set => SetField(ref _currentColor, value); }
         public string[] FilterNames => _filterNames;
 
-        /// <summary>Editable GBA BGR555 color value (0–65535).</summary>
-        public uint GBAColor { get => _gbaColor; set => SetField(ref _gbaColor, value); }
+        /// <summary>
+        /// Editable GBA BGR555 color value (0–65535).
+        /// Setting it keeps the read-only ColorR/G/B channels in sync so the
+        /// bound NumericUpDowns + swatch update live while the user edits, without
+        /// touching ROM or the persisted StatusMessage breakdown.
+        /// </summary>
+        public uint GBAColor
+        {
+            get => _gbaColor;
+            set
+            {
+                if (SetField(ref _gbaColor, value))
+                    DecodeAndSetRGB(value);
+            }
+        }
 
         /// <summary>Read-only decoded red channel (0–248, step 8).</summary>
         public byte ColorR { get => _colorR; set => SetField(ref _colorR, value); }

--- a/FEBuilderGBA.Avalonia/Views/SystemHoverColorViewerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SystemHoverColorViewerView.axaml
@@ -19,6 +19,45 @@
         <TextBox AutomationProperties.AutomationId="SystemHoverColorViewer_Status_Input" Name="StatusLabel" IsReadOnly="True" AcceptsReturn="True"
                  FontFamily="Consolas, Courier New, monospace" FontSize="13"
                  MinHeight="100" TextWrapping="Wrap" Margin="0,16,0,0" />
+
+        <Grid ColumnDefinitions="180,200,20,180,200" RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+          <!-- Row 0: GBA Color raw value -->
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="GBA Color:" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="SystemHoverColorViewer_GBAColor_Input"
+                         FormatString="0" Grid.Row="0" Grid.Column="1" Name="GBAColorBox"
+                         Minimum="0" Maximum="65535" />
+
+          <!-- Row 1: R / G -->
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="R:" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="SystemHoverColorViewer_ColorR_Input"
+                         FormatString="0" Grid.Row="1" Grid.Column="1" Name="ColorRBox"
+                         Minimum="0" Maximum="255" Increment="8" IsReadOnly="True"
+                         Value="{Binding ColorR}" />
+          <TextBlock Grid.Row="1" Grid.Column="3" Text="G:" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="SystemHoverColorViewer_ColorG_Input"
+                         FormatString="0" Grid.Row="1" Grid.Column="4" Name="ColorGBox"
+                         Minimum="0" Maximum="255" Increment="8" IsReadOnly="True"
+                         Value="{Binding ColorG}" />
+
+          <!-- Row 2: B -->
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="B:" VerticalAlignment="Center" />
+          <NumericUpDown AutomationProperties.AutomationId="SystemHoverColorViewer_ColorB_Input"
+                         FormatString="0" Grid.Row="2" Grid.Column="1" Name="ColorBBox"
+                         Minimum="0" Maximum="255" Increment="8" IsReadOnly="True"
+                         Value="{Binding ColorB}" />
+
+          <!-- Row 3: Color preview swatch -->
+          <TextBlock Grid.Row="3" Grid.Column="0" Text="Preview:" VerticalAlignment="Center" />
+          <Border AutomationProperties.AutomationId="SystemHoverColorViewer_Swatch_Control"
+                  Grid.Row="3" Grid.Column="1" Name="ColorPreview"
+                  Width="60" Height="40" BorderBrush="Gray" BorderThickness="1" Margin="0,4,0,4" />
+
+          <!-- Row 4: Write button -->
+          <Button AutomationProperties.AutomationId="SystemHoverColorViewer_Write_Button"
+                  Grid.Row="4" Grid.Column="0" Content="Write" Name="WriteButton"
+                  Click="Write_Click" Margin="0,8,0,0"
+                  IsEnabled="{Binding CanWrite}" />
+        </Grid>
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/SystemHoverColorViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SystemHoverColorViewerView.axaml.cs
@@ -62,13 +62,12 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void GBAColorBox_ValueChanged(object? sender, NumericUpDownValueChangedEventArgs e)
         {
-            // Live-preview: update swatch from current GBAColorBox value without writing to ROM.
-            uint c = (uint)(GBAColorBox.Value ?? 0);
-            uint r5 = c & 0x1F;
-            uint g5 = (c >> 5) & 0x1F;
-            uint b5 = (c >> 10) & 0x1F;
-            ColorPreview.Background = new SolidColorBrush(
-                Color.FromRgb((byte)(r5 * 8), (byte)(g5 * 8), (byte)(b5 * 8)));
+            // Live-preview: push the edited GBA Color into the VM so the bound
+            // read-only R/G/B NumericUpDowns re-decode and update, then refresh
+            // the swatch. The VM's GBAColor setter re-decodes ColorR/G/B; no ROM
+            // write happens here (that's deferred to Write_Click).
+            _vm.GBAColor = (uint)(GBAColorBox.Value ?? 0);
+            RefreshSwatch();
         }
 
         void RefreshSwatch()

--- a/FEBuilderGBA.Avalonia/Views/SystemHoverColorViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SystemHoverColorViewerView.axaml.cs
@@ -1,5 +1,7 @@
 using System;
 using global::Avalonia.Controls;
+using global::Avalonia.Interactivity;
+using global::Avalonia.Media;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 
@@ -8,6 +10,7 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class SystemHoverColorViewerView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly SystemHoverColorViewerViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         public string ViewTitle => "System Area Color Viewer";
         public bool IsLoaded => _vm.CanWrite;
@@ -16,10 +19,12 @@ namespace FEBuilderGBA.Avalonia.Views
         public SystemHoverColorViewerView()
         {
             InitializeComponent();
+            DataContext = _vm;
             FilterCombo.ItemsSource = _vm.FilterNames;
             FilterCombo.SelectedIndex = 0;
             FilterCombo.SelectionChanged += FilterCombo_SelectionChanged;
             EntryList.SelectedAddressChanged += OnSelected;
+            GBAColorBox.ValueChanged += GBAColorBox_ValueChanged;
             Opened += (_, _) => LoadList();
         }
 
@@ -48,9 +53,60 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 _vm.LoadHoverColor(addr);
                 StatusLabel.Text = _vm.StatusMessage;
+                GBAColorBox.Value = _vm.GBAColor;
+                RefreshSwatch();
             }
             catch (Exception ex) { Log.Error("SystemHoverColorViewerView.OnSelected: {0}", ex.Message); }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
+        }
+
+        void GBAColorBox_ValueChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            // Live-preview: update swatch from current GBAColorBox value without writing to ROM.
+            uint c = (uint)(GBAColorBox.Value ?? 0);
+            uint r5 = c & 0x1F;
+            uint g5 = (c >> 5) & 0x1F;
+            uint b5 = (c >> 10) & 0x1F;
+            ColorPreview.Background = new SolidColorBrush(
+                Color.FromRgb((byte)(r5 * 8), (byte)(g5 * 8), (byte)(b5 * 8)));
+        }
+
+        void RefreshSwatch()
+        {
+            uint c = _vm.GBAColor;
+            uint r5 = c & 0x1F;
+            uint g5 = (c >> 5) & 0x1F;
+            uint b5 = (c >> 10) & 0x1F;
+            ColorPreview.Background = new SolidColorBrush(
+                Color.FromRgb((byte)(r5 * 8), (byte)(g5 * 8), (byte)(b5 * 8)));
+        }
+
+        void Write_Click(object? sender, RoutedEventArgs e)
+        {
+            _undoService.Begin("Edit System Area Color");
+            try
+            {
+                _vm.GBAColor = (uint)(GBAColorBox.Value ?? 0);
+                uint res = _vm.Write();
+                if (res == U.NOT_FOUND)
+                {
+                    _undoService.Rollback();
+                    CoreState.Services?.ShowError("Write failed: address not valid or ROM not loaded.");
+                    return;
+                }
+                _undoService.Commit();
+                _vm.MarkClean();
+                // Reload list label + swatch to reflect the written value.
+                StatusLabel.Text = _vm.StatusMessage;
+                GBAColorBox.Value = _vm.GBAColor;
+                RefreshSwatch();
+                LoadList();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("SystemHoverColorViewerView.Write_Click: {0}", ex.Message);
+            }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);


### PR DESCRIPTION
## Summary
Makes the Avalonia **System Area Hover Color** editor ("Hover Colors" menu) writable. It was a pure read-only viewer of the `systemarea_*` move/attack/staff gradation colors (first 10 per range). This adds an editable `GBA Color` (u16) field + read-only derived R/G/B + swatch + a **Write** button → `rom.write_u16` under an `UndoService` scope.

### Important parity note (investigated during review)
The issue referenced WF `ImageSystemHoverColorForm`, but that form is **dead code** — excluded from the WF build (`<Compile Remove>` in `FEBuilderGBA.csproj`) and references `systemhover_gradation_palette_pointer`, which is **not declared in Core** (an existing test comment confirms it's WinForms-only). So this PR instead mirrors the **real, compiled** `ImageSystemAreaForm` / Avalonia `ImageSystemAreaView` write path, keeping this editor's existing `systemarea_*` data. (This editor is the focused 10-color view; `ImageSystemAreaView` is the full 30-color editor of the same ranges.) No Core changes; no phantom pointer added.

Plan + Copilot CLI review (with the blocking-finding investigation + accepted revision): issue #1007 comment thread.

## Scope
Closes #1007.

## Test plan
- [x] `dotnet build FEBuilderGBA.Avalonia` — Release, 0 errors
- [x] `FEBuilderGBA.Avalonia.Tests` — 7619/7622 pass (3 skipped, **0 failures**); +7 new tests
- [x] `FEBuilderGBA.Tests` (net9.0-windows; AutomationId-naming + completeness) — 1851/1851 pass (new ids follow `{Editor}_{Field}_{Type}`)
- [x] `FEBuilderGBA.Core.Tests` — VM untouched by the 10 unrelated `SkillSystemsAnimeImportCore` env failures (master CI green)
- [x] `VM_WriteRoundTrip_UpdatesRomAndRestoresOnUndo` — plant u16 → LoadHoverColor → set GBAColor → Write under undo → `rom.u16` updated → RunUndo restores
- [x] `VM_Write_GuardFailsWhenCanWriteFalse` / `..WhenCurrentAddrIsZero` — returns `U.NOT_FOUND`, no ROM mutation
- [x] `VM_LoadColorList_Returns10EntriesWithCorrectAddresses` — 10 entries at `base + i*2`
- [x] `View_Axaml_ContainsRequiredAutomationIds` / `..WriteButton_HasCanWriteBinding_And_WriteClickHandler` / `View_CodeBehind_WritesViaUndoServicePattern`
- [x] Live GUI test on `roms/FE8U.gba` — see GUI Test Report + screenshot

## GUI Test Report
| Test | Result |
|---|---|
| Hover Colors editor lists the 10 gradation colors with swatches | ✅ PASS — Color 0–9 (real FE8U Move Range colors) |
| Selecting a color loads its raw u16 + R/G/B breakdown | ✅ PASS — Color 1 `0x7183`, RGB888 24/96/224, addr `0x00A02F36` |
| New editor controls render (GBA Color NUD + read-only R/G/B + Preview swatch + Write) | ✅ PASS (screenshot) |
| Write button is enabled after selection (`CanWrite`) | ✅ PASS (verified via UIAutomation) |
| Edit → Write → undo round-trip persists/reverts the u16 | ✅ PASS (automated functional test) |

Method: app launched against `roms/FE8U.gba`; editor opened + row selected via UIAutomation `InvokePattern`; Write-button enablement confirmed programmatically; captured with `tools/WinCapture` PrintWindow (locked-session safe).

## Screenshots
**System Area (Hover) Color editor — now writable (GBA Color + R/G/B + swatch + Write; was read-only):**
![Hover Color editor](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1007-hover-color-editor.png)

---
Original request: *"set ralph loop to resolve all open GitHub issues in laqieer/FEBuilderGBA"* — 4th issue in the autonomous sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.168` · model `claude-opus-4-8[1m]`
