### PR TITLE
fix(avalonia): disable FE8N Ver1 SkillConfig no-op Animation/Image I/O buttons (#1008)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigFE8NSkillParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigFE8NSkillParityTests.cs
@@ -1454,4 +1454,97 @@ public class SkillConfigFE8NSkillParityTests
             throw new InvalidOperationException("Could not find FEBuilderGBA.sln from test base directory");
         return dir;
     }
+
+    // -----------------------------------------------------------------
+    // #1008 - FE8N Ver1 Animation/Image I/O buttons disabled by design.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// The four Image/Animation Import/Export buttons must carry IsEnabled="False"
+    /// in the Ver1 AXAML (no-op buttons disabled by design, #1008), and must
+    /// carry honest tooltips that say "Disabled by design" / "render-only"
+    /// rather than the stale "#500"/"Pending Core extraction" text.
+    /// </summary>
+    [Fact]
+    public void View_Fe8nVer1_AnimationAndImageIoButtons_AreDisabled()
+    {
+        string axaml = ReadAxaml();
+        string[] buttonIds = new[]
+        {
+            "SkillConfigFE8NSkill_ImageImport_Button",
+            "SkillConfigFE8NSkill_ImageExport_Button",
+            "SkillConfigFE8NSkill_AnimationImport_Button",
+            "SkillConfigFE8NSkill_AnimationExport_Button",
+        };
+
+        foreach (string buttonId in buttonIds)
+        {
+            // Scope to the exact <Button .../> element containing this AutomationId.
+            int idIdx = axaml.IndexOf(buttonId, StringComparison.Ordinal);
+            Assert.True(idIdx >= 0, $"AutomationId '{buttonId}' not found in AXAML");
+
+            int btnStart = axaml.LastIndexOf("<Button", idIdx, StringComparison.Ordinal);
+            Assert.True(btnStart >= 0, $"Opening <Button tag not found before '{buttonId}'");
+
+            int btnEnd = axaml.IndexOf("/>", idIdx, StringComparison.Ordinal);
+            Assert.True(btnEnd >= 0, $"Closing /> not found after '{buttonId}'");
+
+            string btnElement = axaml.Substring(btnStart, btnEnd - btnStart + 2);
+
+            // Must be disabled.
+            Assert.Contains("IsEnabled="False"", btnElement,
+                $"Button '{buttonId}' must carry IsEnabled="False" (#1008)");
+
+            // Must NOT contain the stale #500 / "Pending Core extraction" tooltip.
+            Assert.DoesNotContain("#500", btnElement,
+                $"Button '{buttonId}' must not reference the stale #500 tooltip");
+            Assert.DoesNotContain("Pending Core extraction", btnElement,
+                $"Button '{buttonId}' must not carry the stale 'Pending Core extraction' tooltip");
+
+            // Must contain an honest disabled-by-design explanation.
+            bool hasDisabledByDesign = btnElement.Contains("Disabled by design")
+                || btnElement.Contains("render-only");
+            Assert.True(hasDisabledByDesign,
+                $"Button '{buttonId}' tooltip must mention 'Disabled by design' or 'render-only' (#1008)");
+        }
+    }
+
+    /// <summary>
+    /// Negative guard: the four equivalent I/O buttons in the Ver2 view must NOT
+    /// carry IsEnabled="False" — proves the disable did not leak from Ver1 to Ver2
+    /// (Ver2 has real wiring through SkillConfigIconIoHelper / SkillAnimeHelper).
+    /// </summary>
+    [Fact]
+    public void View_Fe8nVer2_IoButtons_StayEnabled()
+    {
+        string repoRoot = FindRepoRoot();
+        string ver2Axaml = File.ReadAllText(Path.Combine(repoRoot, "FEBuilderGBA.Avalonia",
+            "Views", "SkillConfigFE8NVer2SkillView.axaml"));
+
+        string[] buttonIds = new[]
+        {
+            "SkillConfigFE8NVer2Skill_ImageImport_Button",
+            "SkillConfigFE8NVer2Skill_ImageExport_Button",
+            "SkillConfigFE8NVer2Skill_AnimationImport_Button",
+            "SkillConfigFE8NVer2Skill_AnimationExport_Button",
+        };
+
+        foreach (string buttonId in buttonIds)
+        {
+            int idIdx = ver2Axaml.IndexOf(buttonId, StringComparison.Ordinal);
+            Assert.True(idIdx >= 0, $"AutomationId '{buttonId}' not found in Ver2 AXAML");
+
+            int btnStart = ver2Axaml.LastIndexOf("<Button", idIdx, StringComparison.Ordinal);
+            Assert.True(btnStart >= 0, $"Opening <Button tag not found before '{buttonId}'");
+
+            int btnEnd = ver2Axaml.IndexOf("/>", idIdx, StringComparison.Ordinal);
+            Assert.True(btnEnd >= 0, $"Closing /> not found after '{buttonId}'");
+
+            string btnElement = ver2Axaml.Substring(btnStart, btnEnd - btnStart + 2);
+
+            // Ver2 buttons must NOT be disabled.
+            Assert.DoesNotContain("IsEnabled="False"", btnElement,
+                $"Ver2 button '{buttonId}' must NOT carry IsEnabled="False" — disable must not leak from Ver1 to Ver2");
+        }
+    }
 }

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigFE8NSkillParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigFE8NSkillParityTests.cs
@@ -1492,13 +1492,13 @@ public class SkillConfigFE8NSkillParityTests
             string btnElement = axaml.Substring(btnStart, btnEnd - btnStart + 2);
 
             // Must be disabled.
-            Assert.Contains("IsEnabled="False"", btnElement,
-                $"Button '{buttonId}' must carry IsEnabled="False" (#1008)");
+            Assert.True(btnElement.Contains("IsEnabled=\"False\""),
+                $"Button '{buttonId}' must carry IsEnabled=\"False\" (#1008)");
 
             // Must NOT contain the stale #500 / "Pending Core extraction" tooltip.
-            Assert.DoesNotContain("#500", btnElement,
+            Assert.False(btnElement.Contains("#500"),
                 $"Button '{buttonId}' must not reference the stale #500 tooltip");
-            Assert.DoesNotContain("Pending Core extraction", btnElement,
+            Assert.False(btnElement.Contains("Pending Core extraction"),
                 $"Button '{buttonId}' must not carry the stale 'Pending Core extraction' tooltip");
 
             // Must contain an honest disabled-by-design explanation.
@@ -1543,8 +1543,8 @@ public class SkillConfigFE8NSkillParityTests
             string btnElement = ver2Axaml.Substring(btnStart, btnEnd - btnStart + 2);
 
             // Ver2 buttons must NOT be disabled.
-            Assert.DoesNotContain("IsEnabled="False"", btnElement,
-                $"Ver2 button '{buttonId}' must NOT carry IsEnabled="False" — disable must not leak from Ver1 to Ver2");
+            Assert.False(btnElement.Contains("IsEnabled=\"False\""),
+                $"Ver2 button '{buttonId}' must NOT carry IsEnabled=\"False\" — disable must not leak from Ver1 to Ver2");
         }
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NSkillView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NSkillView.axaml
@@ -113,13 +113,15 @@
               <Button Grid.Column="2"
                       AutomationProperties.AutomationId="SkillConfigFE8NSkill_ImageImport_Button"
                       Name="ImageImportButton" Content="Image Import" Margin="8,0,0,0"
+                      IsEnabled="False"
                       Click="ImageImport_Click"
-                      ToolTip.Tip="Pending Core extraction - tracked by #500." />
+                      ToolTip.Tip="FE8N Ver1 has no icon import/export — WinForms SkillConfigFE8NSkillForm is render-only, and this variant's icon address lacks the 0x100 page offset v2/v3 use. Disabled by design (#1008)." />
               <Button Grid.Column="3"
                       AutomationProperties.AutomationId="SkillConfigFE8NSkill_ImageExport_Button"
                       Name="ImageExportButton" Content="Image Export" Margin="8,0,0,0"
+                      IsEnabled="False"
                       Click="ImageExport_Click"
-                      ToolTip.Tip="Pending Core extraction - tracked by #500." />
+                      ToolTip.Tip="FE8N Ver1 has no icon import/export — WinForms SkillConfigFE8NSkillForm is render-only, and this variant's icon address lacks the 0x100 page offset v2/v3 use. Disabled by design (#1008)." />
               <Label Grid.Column="4"
                      AutomationProperties.AutomationId="SkillConfigFE8NSkill_IconAddr_Label"
                      Name="IconAddrLabel" VerticalAlignment="Center" Margin="12,0,0,0"
@@ -265,13 +267,15 @@
               <Button Grid.Column="2"
                       AutomationProperties.AutomationId="SkillConfigFE8NSkill_AnimationImport_Button"
                       Name="AnimationImportButton" Content="Animation Import" Margin="8,0,0,0"
+                      IsEnabled="False"
                       Click="AnimationImport_Click"
-                      ToolTip.Tip="Pending Core extraction - tracked by #500." />
+                      ToolTip.Tip="FE8N Ver1 has no animation pointer or animation I/O in WinForms (render-only). Disabled by design (#1008)." />
               <Button Grid.Column="3"
                       AutomationProperties.AutomationId="SkillConfigFE8NSkill_AnimationExport_Button"
                       Name="AnimationExportButton" Content="Animation Export" Margin="8,0,0,0"
+                      IsEnabled="False"
                       Click="AnimationExport_Click"
-                      ToolTip.Tip="Pending Core extraction - tracked by #500." />
+                      ToolTip.Tip="FE8N Ver1 has no animation pointer or animation I/O in WinForms (render-only). Disabled by design (#1008)." />
               <Button Grid.Column="4"
                       AutomationProperties.AutomationId="SkillConfigFE8NSkill_JumpToEditor_Button"
                       Name="JumpToEditorButton" Content="Editor" Margin="8,0,0,0"

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NSkillView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NSkillView.axaml.cs
@@ -14,10 +14,11 @@ namespace FEBuilderGBA.Avalonia.Views
     /// AXAML control surface from 33 to MEDIUM-verdict density (>= 85) and
     /// wires W0 + W2 + B4..B15 write under a single UndoService scope.
     ///
-    /// Image/Animation Import/Export, JumpToEditor, and List Expand still
-    /// depend on Core extraction work tracked by #500 - those buttons render
-    /// so the density verdict moves, but their click handlers are intentional
-    /// no-ops with a tooltip until the Core seam lands (mirrors PR #598).
+    /// Image/Animation Import/Export buttons are disabled by design (#1008) —
+    /// WF SkillConfigFE8NSkillForm is render-only (no animation pointer, no
+    /// icon I/O), and this variant's icon address lacks the 0x100 page offset
+    /// v2/v3 use. Their click handlers are kept as no-ops (disabled buttons
+    /// never fire them; keeping them satisfies the wired-or-inert audit).
     ///
     /// The Unit sub-list tab is an editable B16..B31 ext-byte editor (#790) —
     /// FE8N v1's N00..N03 sub-tabs all union onto the SAME 16 row bytes, so the
@@ -486,36 +487,49 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         // -----------------------------------------------------------
-        // No-op handlers - wired so the AutomationIds are enumerable
-        // from headless tests, and so the density verdict moves. The
-        // real implementations depend on Core extraction tracked by
-        // #500. Mirrors the exact pattern used by PR #598 / #525 / #516.
+        // Disabled-by-design handlers — kept wired so the AutomationIds are
+        // enumerable from headless tests and the wired-or-inert audit passes.
+        // The buttons are IsEnabled="False" in AXAML so these handlers never
+        // fire at runtime. FE8N Ver1 has no animation pointer or icon I/O in
+        // WinForms (render-only); disabled by design (#1008).
         // -----------------------------------------------------------
 
-        // #898 — FE8N v1 is intentionally read-only for skill icons. The WF
-        // SkillConfigFE8NSkillForm has NO icon import/export (render-only),
-        // and this variant's icon address derivation lacks the 0x100 page
-        // offset that v2/v3 use, so wiring it to the shared
-        // SkillConfigIconIoHelper would write to the wrong slot. Left as a
-        // no-op on purpose — do NOT wire it to the helper.
+        // #898 / #1008 — FE8N v1 is intentionally read-only for skill icons.
+        // The WF SkillConfigFE8NSkillForm has NO icon import/export (render-only),
+        // and this variant's icon address derivation lacks the 0x100 page offset
+        // that v2/v3 use, so wiring it to the shared SkillConfigIconIoHelper would
+        // write to the wrong slot. Button is disabled by design (#1008) —
+        // this handler is kept only to satisfy the wired-or-inert audit.
         void ImageImport_Click(object? sender, RoutedEventArgs e)
         {
-            Log.Debug("SkillConfigFE8NSkillView.ImageImport_Click invoked - read-only: this skill variant has no icon import/export in WinForms");
+            // Disabled by design (#1008): FE8N Ver1 is read-only for icon I/O.
+            // Icon address lacks the 0x100 page offset v2/v3 use; WF form is render-only.
+            // Button is IsEnabled="False"; handler kept only to satisfy the wired-or-inert audit.
+            Log.Debug("SkillConfigFE8NSkillView.ImageImport_Click: button disabled by design (#1008), read-only variant");
         }
 
         void ImageExport_Click(object? sender, RoutedEventArgs e)
         {
-            Log.Debug("SkillConfigFE8NSkillView.ImageExport_Click invoked - read-only: this skill variant has no icon import/export in WinForms");
+            // Disabled by design (#1008): FE8N Ver1 is read-only for icon I/O.
+            // Icon address lacks the 0x100 page offset v2/v3 use; WF form is render-only.
+            // Button is IsEnabled="False"; handler kept only to satisfy the wired-or-inert audit.
+            Log.Debug("SkillConfigFE8NSkillView.ImageExport_Click: button disabled by design (#1008), read-only variant");
         }
 
         void AnimationImport_Click(object? sender, RoutedEventArgs e)
         {
-            Log.Debug("SkillConfigFE8NSkillView.AnimationImport_Click invoked - disabled until Core extraction lands (#500)");
+            // Disabled by design (#1008): FE8N Ver1 has no animation pointer or
+            // animation I/O in WinForms (render-only). Button is IsEnabled="False";
+            // this handler is kept only to satisfy the wired-or-inert audit.
+            Log.Debug("SkillConfigFE8NSkillView.AnimationImport_Click: button disabled by design (#1008)");
         }
 
         void AnimationExport_Click(object? sender, RoutedEventArgs e)
         {
-            Log.Debug("SkillConfigFE8NSkillView.AnimationExport_Click invoked - disabled until Core extraction lands (#500)");
+            // Disabled by design (#1008): FE8N Ver1 has no animation pointer or
+            // animation I/O in WinForms (render-only). Button is IsEnabled="False";
+            // this handler is kept only to satisfy the wired-or-inert audit.
+            Log.Debug("SkillConfigFE8NSkillView.AnimationExport_Click: button disabled by design (#1008)");
         }
 
         void JumpToEditor_Click(object? sender, RoutedEventArgs e)

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -10253,3 +10253,9 @@ ROMに取り込む
 グレー
 :Four Army
 4軍
+
+:FE8N Ver1 has no icon import/export — WinForms SkillConfigFE8NSkillForm is render-only, and this variant's icon address lacks the 0x100 page offset v2/v3 use. Disabled by design (#1008).
+FE8N Ver1 にはアイコンのインポート/エクスポートがありません — WinForms の SkillConfigFE8NSkillForm は表示専用であり、このバリアントのアイコンアドレスには v2/v3 が使用する 0x100 ページオフセットがありません。設計上無効 (#1008)。
+
+:FE8N Ver1 has no animation pointer or animation I/O in WinForms (render-only). Disabled by design (#1008).
+FE8N Ver1 には WinForms でアニメーションポインタやアニメーションI/Oがありません（表示専用）。設計上無効 (#1008)。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -24085,3 +24085,9 @@ AI脚本已导出到:
 灰色
 :Four Army
 第四军
+
+:FE8N Ver1 has no icon import/export — WinForms SkillConfigFE8NSkillForm is render-only, and this variant's icon address lacks the 0x100 page offset v2/v3 use. Disabled by design (#1008).
+FE8N Ver1 没有图标导入/导出功能 — WinForms 的 SkillConfigFE8NSkillForm 仅供显示，此变体的图标地址缺少 v2/v3 使用的 0x100 页面偏移。设计上已禁用 (#1008)。
+
+:FE8N Ver1 has no animation pointer or animation I/O in WinForms (render-only). Disabled by design (#1008).
+FE8N Ver1 在 WinForms 中没有动画指针或动画 I/O（仅供显示）。设计上已禁用 (#1008)。

--- a/docs/field-completeness-report.txt
+++ b/docs/field-completeness-report.txt
@@ -1,6 +1,6 @@
 === Field Completeness Report ===
 Total WinForms fields: 1563
-Total Avalonia fields: 1809
+Total Avalonia fields: 1811
 Total missing: 0
 Forms with gaps: 0 / 175
 


### PR DESCRIPTION
## Summary
Stops the FE8N **Ver1** SkillConfig editor from advertising non-existent capabilities. Its four Animation/Image **Import/Export** buttons were **enabled but pure no-ops** (`Log.Debug` only). WF `SkillConfigFE8NSkillForm` is render-only — no animation pointer, no icon I/O — and FE8N Ver1's icon address derivation lacks the `0x100` page offset v2/v3 use, so wiring the image buttons would write the **wrong icon slot**. This disables the four buttons with honest tooltips. **UI-honesty only — no Core changes, no ROM writes.**

Ver1-scoped: `SkillConfigFE8NSkillView` is a distinct view from `SkillConfigFE8NVer2/Ver3SkillView` (which keep their real, wired animation/icon I/O).

Plan + Copilot CLI review: issue #1008 comment thread (no blocking findings).

## Scope
Closes #1008.

## Test plan
- [x] `dotnet build FEBuilderGBA.Avalonia` — Release, 0 errors
- [x] `View_Fe8nVer1_AnimationAndImageIoButtons_AreDisabled` — all 4 buttons carry `IsEnabled="False"` + honest tooltips; the stale `#500`/"Pending Core extraction" tooltip is gone
- [x] `View_Fe8nVer2_IoButtons_StayEnabled` — negative guard: the v2 I/O buttons are NOT disabled (proves the change is Ver1-scoped)
- [x] Existing `FE8NVer1_Import_StaysReadOnly_DoesNotCallHelper` still passes (handlers kept, "read-only" preserved)
- [x] ja/zh translations added for the two new tooltip strings
- [x] Live GUI test on `roms/FE8J_skill.gba` — see GUI Test Report + screenshot
- [x] CI (clean environment) is the test-suite arbiter — local main-checkout test counts were environmentally skewed; CI validates the real status

## GUI Test Report
| Test | Result |
|---|---|
| FE8N Ver1 SkillConfig editor opens with full layout | ✅ PASS (Skill Detail + Unit/Class/Item/Other lists, Icon, conditions, Animation row) |
| Image Import / Image Export buttons render disabled (greyed) | ✅ PASS — `enabled=False` (verified via UIAutomation) |
| Animation Import / Animation Export buttons render disabled (greyed) | ✅ PASS — `enabled=False` (verified via UIAutomation) |
| "Editor" + "Write" buttons stay enabled (out of scope) | ✅ PASS |
| Honest tooltips replace the stale "Pending Core extraction #500" text | ✅ PASS |

Method: app launched against `roms/FE8J_skill.gba`; editor opened via UIAutomation; all four buttons' `IsEnabled=False` confirmed programmatically; captured with `tools/WinCapture` PrintWindow (locked-session safe).

## Screenshots
**FE8N Ver1 SkillConfig — the four no-op Animation/Image I/O buttons now disabled (greyed); "Editor"/"Write" stay enabled:**
![FE8N Ver1 disabled buttons](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1008-fe8n-ver1-disabled-buttons.png)

---
Original request: *"set ralph loop to resolve all open GitHub issues in laqieer/FEBuilderGBA"* — 5th issue in the autonomous sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.168` · model `claude-opus-4-8[1m]`
