### PR TITLE
fix(avalonia): FE8N Ver3 Move-to-COMBAT_ART jump filters the Patch Manager (#1009)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigFE8NVer3SkillParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigFE8NVer3SkillParityTests.cs
@@ -715,8 +715,12 @@ public class SkillConfigFE8NVer3SkillParityTests
     /// <summary>
     /// Read the JumpToCombatArt_Click handler body from the View code-behind so
     /// the #1009 static assertions are scoped to that handler (not the whole
-    /// file). Returns text from the method signature up to the next
-    /// `void`-prefixed method declaration.
+    /// file). Returns text from the handler's method signature up to the NEXT
+    /// method declaration — found generically by the next occurrence of the
+    /// standard 8-space-indented `void ` signature (the indentation every
+    /// handler in this file uses), so renaming/reordering the following handler
+    /// cannot silently break the extraction. If no following `void ` method is
+    /// found, the slice extends to the end of the source.
     /// </summary>
     static string ExtractJumpToCombatArtHandlerBody()
     {
@@ -729,9 +733,15 @@ public class SkillConfigFE8NVer3SkillParityTests
         int start = source.IndexOf(marker, StringComparison.Ordinal);
         Assert.True(start >= 0, "JumpToCombatArt_Click handler not found in the View code-behind");
 
-        // End at the next handler/method declaration after the marker.
+        // End at the next method declaration after the marker — located
+        // generically via the standard 8-space method-signature indentation
+        // ("\n        void "), not a hard-coded handler name. Normalize CRLF so
+        // the search works regardless of the file's line endings.
         int searchFrom = start + marker.Length;
-        int next = source.IndexOf("void ListExpand_Click(", searchFrom, StringComparison.Ordinal);
+        const string nextMethodSignature = "\n        void ";
+        int crlf = source.IndexOf("\r\n        void ", searchFrom, StringComparison.Ordinal);
+        int lf = source.IndexOf(nextMethodSignature, searchFrom, StringComparison.Ordinal);
+        int next = (crlf >= 0 && (lf < 0 || crlf < lf)) ? crlf : lf;
         if (next < 0) next = source.Length;
         return source.Substring(start, next - start);
     }

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigFE8NVer3SkillParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigFE8NVer3SkillParityTests.cs
@@ -616,6 +616,126 @@ public class SkillConfigFE8NVer3SkillParityTests
         Assert.Contains("AutomationId=\"SkillConfigFE8NVer3Skill_JumpToCombatArt_Button\"", axaml);
     }
 
+    // -----------------------------------------------------------------
+    // #1009 — Move-to-COMBAT_ART now FILTERS + selects the patch.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// #1009: the JumpToCombatArt_Click handler must Navigate to the Patch
+    /// Manager and call PatchManagerView.JumpTo("FE8N SKILL COMBAT ART", 0)
+    /// (the #428 filter seam) so it filters + selects the combat-art patch,
+    /// instead of opening unfiltered with nothing selected. Roslyn-static
+    /// read scoped to the handler BODY (so unrelated handlers in the same file
+    /// can't satisfy these assertions).
+    /// </summary>
+    [Fact]
+    public void View_JumpToCombatArt_FiltersPatchManager()
+    {
+        string handler = ExtractJumpToCombatArtHandlerBody();
+
+        Assert.True(handler.Contains("Navigate<PatchManagerView>"),
+            "JumpToCombatArt_Click must Navigate<PatchManagerView> (mirrors ItemEditorView.OnWeaponDebuffsLink_Click)");
+        Assert.True(handler.Contains("FindOpen<PatchManagerView>"),
+            "JumpToCombatArt_Click must FindOpen<PatchManagerView> to grab the opened view instance");
+        Assert.True(handler.Contains("JumpTo(\"FE8N SKILL COMBAT ART\", 0)"),
+            "JumpToCombatArt_Click must call JumpTo(\"FE8N SKILL COMBAT ART\", 0) (the #428 filter seam)");
+    }
+
+    /// <summary>
+    /// #1009: the handler must no longer rely solely on a bare
+    /// `Open<PatchManagerView>()` (unfiltered, nothing selected), and the stale
+    /// "does not yet expose JumpToSelectStruct" wording must be gone from the
+    /// handler body.
+    /// </summary>
+    [Fact]
+    public void View_JumpToCombatArt_NoLongerBareOpenOrStaleWording()
+    {
+        string handler = ExtractJumpToCombatArtHandlerBody();
+
+        // ".Open<PatchManagerView>()" (with the leading dot) is the bare
+        // navigate-only call; the leading dot distinguishes it from the
+        // legitimate "FindOpen<PatchManagerView>()" call which ends in the
+        // same "Open<PatchManagerView>()" text.
+        Assert.False(handler.Contains(".Open<PatchManagerView>()"),
+            "JumpToCombatArt_Click must not use the bare .Open<PatchManagerView>() (unfiltered, nothing selected)");
+        Assert.False(handler.Contains("does not yet expose JumpToSelectStruct"),
+            "The stale 'does not yet expose JumpToSelectStruct' wording must be removed from the handler");
+    }
+
+    /// <summary>
+    /// Config guard (Copilot refinement): the filter substring
+    /// "FE8N SKILL COMBAT ART" must resolve UNAMBIGUOUSLY to exactly one shipped
+    /// patch. Scan every PATCH_*.txt under config/patch2/, PARSE each patch's
+    /// NAME= metadata line (mirroring PatchMetadataCore.ParsePatchFile —
+    /// Trim() + StartsWith("NAME=", OrdinalIgnoreCase) + Substring(5).Trim()),
+    /// and assert EXACTLY ONE patch NAME contains the filter substring. If the
+    /// submodule is not checked out (no patch files found), the test is skipped
+    /// (Assert.True(true)) rather than failing on a missing dependency.
+    /// </summary>
+    [Fact]
+    public void Config_ExactlyOnePatch_NamedFE8NSkillCombatArt()
+    {
+        string repoRoot = FindRepoRoot();
+        string patch2Dir = Path.Combine(repoRoot, "config", "patch2");
+        if (!Directory.Exists(patch2Dir))
+        {
+            // config/patch2 is a git submodule; if it's not checked out there
+            // are no patch files to scan. Skip rather than fail.
+            Assert.True(true, "config/patch2 submodule not checked out — skipping config guard");
+            return;
+        }
+
+        var patchFiles = Directory.GetFiles(patch2Dir, "PATCH_*.txt", SearchOption.AllDirectories);
+        if (patchFiles.Length == 0)
+        {
+            Assert.True(true, "no PATCH_*.txt files found (submodule not populated) — skipping config guard");
+            return;
+        }
+
+        const string filter = "FE8N SKILL COMBAT ART";
+        int matches = 0;
+        foreach (string file in patchFiles)
+        {
+            foreach (string rawLine in File.ReadAllLines(file))
+            {
+                string line = rawLine.Trim();
+                if (line.StartsWith("//")) continue;
+                if (!line.StartsWith("NAME=", StringComparison.OrdinalIgnoreCase)) continue;
+                string name = line.Substring(5).Trim();
+                if (name.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0)
+                    matches++;
+                break; // one NAME= per patch file
+            }
+        }
+
+        Assert.True(matches == 1,
+            $"Exactly one shipped patch NAME must contain \"{filter}\" so the JumpTo filter resolves unambiguously — found {matches}");
+    }
+
+    /// <summary>
+    /// Read the JumpToCombatArt_Click handler body from the View code-behind so
+    /// the #1009 static assertions are scoped to that handler (not the whole
+    /// file). Returns text from the method signature up to the next
+    /// `void`-prefixed method declaration.
+    /// </summary>
+    static string ExtractJumpToCombatArtHandlerBody()
+    {
+        string repoRoot = FindRepoRoot();
+        string sourcePath = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "SkillConfigFE8NVer3SkillView.axaml.cs");
+        string source = File.ReadAllText(sourcePath);
+
+        const string marker = "void JumpToCombatArt_Click(";
+        int start = source.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(start >= 0, "JumpToCombatArt_Click handler not found in the View code-behind");
+
+        // End at the next handler/method declaration after the marker.
+        int searchFrom = start + marker.Length;
+        int next = source.IndexOf("void ListExpand_Click(", searchFrom, StringComparison.Ordinal);
+        if (next < 0) next = source.Length;
+        return source.Substring(start, next - start);
+    }
+
     [Fact]
     public void View_HasListExpandButton_Wired()
     {

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigJumpWiringParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigJumpWiringParityTests.cs
@@ -58,8 +58,11 @@ public class SkillConfigJumpWiringParityTests
             ReadViewSource("SkillConfigFE8NVer3SkillView.axaml.cs"),
             "JumpToCombatArt_Click");
 
-        Assert.Matches(@"WindowManager\.Instance\.Open<", body);
-        Assert.Contains("WindowManager.Instance.Open<PatchManagerView>", body);
+        // #1009: the handler now FILTERS + selects the combat-art patch via the
+        // PatchManagerView.JumpTo (#428) seam, instead of a bare unfiltered open.
+        Assert.Matches(@"WindowManager\.Instance\.Navigate<PatchManagerView>", body);
+        Assert.Contains("WindowManager.Instance.FindOpen<PatchManagerView>", body);
+        Assert.Contains("JumpTo(\"FE8N SKILL COMBAT ART\", 0)", body);
         Assert.DoesNotContain("Log.Debug", body);
     }
 

--- a/FEBuilderGBA.Avalonia/ViewModels/SkillConfigFE8NVer3SkillViewModel.NavigationTargets.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SkillConfigFE8NVer3SkillViewModel.NavigationTargets.cs
@@ -5,9 +5,12 @@
 // JumpParityScanner needs to cross-reference (Copilot plan-review #2):
 //   1. X_JUMP_TO_COMBAT_ART_Click -> PatchForm.JumpToSelectStruct(...)
 //      Avalonia counterpart: PatchManagerView (paired via the
-//      KnownExtraCrossViewMappings entry below). The AV view lacks a
-//      programmatic JumpToSelectStruct seam (tracked by #374) so the
-//      jump is declared as a KnownGap until that lands.
+//      KnownExtraCrossViewMappings entry below). #1009 implemented the
+//      filter-level jump: the handler now Navigates to PatchManagerView and
+//      calls JumpTo("FE8N SKILL COMBAT ART", 0) (the #428 filter seam) to
+//      filter + select the patch. Only the struct-level row selection
+//      (PatchManagerView has no inner struct list) remains gated on #374, so
+//      the IssueRef stays #374 to flag that residual gap.
 //   2. ImportButton_Click -> ErrorPaletteShowForm.JumpFormLow(...)
 //      Avalonia counterpart: ErrorPaletteShowView. The Import flow itself
 //      is no-op until ImageUtilSkillSystemsAnimeCreator extracts to Core
@@ -25,7 +28,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
     {
         public IReadOnlyList<NavigationTarget> GetNavigationTargets() => new[]
         {
-            // (1) WF X_JUMP_TO_COMBAT_ART_Click -> PatchForm.
+            // (1) WF X_JUMP_TO_COMBAT_ART_Click -> PatchForm. Filter-level jump
+            //     implemented (#1009: JumpTo("FE8N SKILL COMBAT ART", 0)); only
+            //     struct-level row selection remains gated on #374.
             new NavigationTarget(
                 CommandName: "JumpToCombatArt",
                 TargetViewType: typeof(PatchManagerView),

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml
@@ -220,7 +220,7 @@
               <Button AutomationProperties.AutomationId="SkillConfigFE8NVer3Skill_JumpToCombatArt_Button"
                       Name="JumpToCombatArtButton" Content="Move to COMBAT_ART"
                       Click="JumpToCombatArt_Click"
-                      ToolTip.Tip="PatchManagerView does not yet expose JumpToSelectStruct (tracked by #374)." />
+                      ToolTip.Tip="Opens the Patch Manager and filters/selects the FE8N SKILL COMBAT ART patch. Struct-level row selection is a #374 follow-up." />
             </StackPanel>
 
             <!-- Animation row: label + animation pointer + import/export buttons -->

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml.cs
@@ -403,12 +403,18 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void JumpToCombatArt_Click(object? sender, RoutedEventArgs e)
         {
-            // Navigate-only open; full Init/struct-jump context is the
-            // symmetric #500/#374 follow-up. Mirrors the merged
-            // ImageMagicFEditorView.JumpEditor_Click (#894) pattern.
+            // #1009: filter + select the FE8N SKILL COMBAT ART(Editor) patch via
+            // the PatchManagerView.JumpTo (#428) filter seam, instead of opening
+            // unfiltered with nothing selected. Mirrors WF
+            // PatchForm.JumpToSelectStruct's filter+select step; struct-level row
+            // selection stays a #374 follow-up (PatchManagerView has no inner
+            // struct list). Mirrors the ItemEditorView.OnWeaponDebuffsLink_Click
+            // Navigate -> FindOpen -> JumpTo pattern.
             try
             {
-                WindowManager.Instance.Open<PatchManagerView>();
+                WindowManager.Instance.Navigate<PatchManagerView>(0);
+                var pmView = WindowManager.Instance.FindOpen<PatchManagerView>();
+                pmView?.JumpTo("FE8N SKILL COMBAT ART", 0);  // filter + select the combat-art patch (struct-level row select = #374 follow-up)
             }
             catch (Exception ex)
             {

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -8883,8 +8883,8 @@ WF の N03 サブタブには固定の意味を持たない汎用 16 バイト (
 :Adds the effect of another skill (KnownGap: tracked by #374)
 他のスキルの効果を追加します (KnownGap: #374 で追跡中)
 
-:PatchManagerView does not yet expose JumpToSelectStruct (tracked by #374).
-PatchManagerView は JumpToSelectStruct をまだ公開していません (#374 で追跡中)。
+:Opens the Patch Manager and filters/selects the FE8N SKILL COMBAT ART patch. Struct-level row selection is a #374 follow-up.
+パッチマネージャーを開き、FE8N SKILL COMBAT ART パッチを絞り込んで選択します。構造体レベルの行選択は #374 のフォローアップです。
 
 :Move to COMBAT_ART
 COMBAT_ARTへ移動

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -22718,8 +22718,8 @@ WF 中的 N03 子标签包含 16 个无固定语义的通用字节 (B16..B31)。
 :Adds the effect of another skill (KnownGap: tracked by #374)
 添加其他技能的效果 (KnownGap: #374 跟踪中)
 
-:PatchManagerView does not yet expose JumpToSelectStruct (tracked by #374).
-PatchManagerView 尚未暴露 JumpToSelectStruct (#374 跟踪中)。
+:Opens the Patch Manager and filters/selects the FE8N SKILL COMBAT ART patch. Struct-level row selection is a #374 follow-up.
+打开补丁管理器并筛选/选中 FE8N SKILL COMBAT ART 补丁。结构体级别的行选择是 #374 的后续工作。
 
 :Move to COMBAT_ART
 跳转到 COMBAT_ART


### PR DESCRIPTION
## Summary
Fixes the FE8N Ver3 SkillConfig **"Move to COMBAT_ART"** jump. It opened the Patch Manager **unfiltered with nothing selected**; it now uses the existing `PatchManagerView.JumpTo(filter, subIndex)` seam (#428) to filter the patch list to **`FE8N SKILL COMBAT ART`** and select that patch — mirroring WF `JumpToSelectStruct`'s filter+select step. No Core/ROM changes.

Struct-level row selection (landing on the inner combat-art struct matching the selected skill row, WF's 3rd `JumpToSelectStruct` arg) stays a documented **#374** follow-up — the Avalonia `PatchManagerView` renders no inner struct `AddressList`. This delivers the issue's explicit "at minimum" acceptance target.

Plan + Copilot CLI review: issue #1009 comment thread (no blocking findings).

## Scope
Closes #1009.

`JumpToCombatArt_Click` now mirrors the proven `ItemEditorView` deep-link pattern: `Navigate<PatchManagerView>(0)` → `FindOpen<PatchManagerView>()` → `JumpTo("FE8N SKILL COMBAT ART", 0)`. The shipped patch `NAME=FE8N SKILL COMBAT ART(Editor)` matches the filter substring (Contains, OrdinalIgnoreCase).

## Test plan
- [x] `dotnet build FEBuilderGBA.Avalonia` — Release, 0 errors
- [x] `FEBuilderGBA.Avalonia.Tests` — **7635/7638** pass (3 skipped, **0 failures**); filtered `~SkillConfigFE8NVer3` **43/43**
- [x] `FEBuilderGBA.Tests` (net9.0-windows; parity/L10n assertions) — **1851/1851** pass
- [x] `View_JumpToCombatArt_FiltersPatchManager` — handler calls `Navigate<PatchManagerView>` + `FindOpen<PatchManagerView>` + `JumpTo("FE8N SKILL COMBAT ART", 0)`
- [x] `View_JumpToCombatArt_NoLongerBareOpenOrStaleWording` — no bare `.Open<PatchManagerView>()`; stale "does not yet expose JumpToSelectStruct" wording gone
- [x] `Config_ExactlyOnePatch_NamedFE8NSkillCombatArt` — parses `NAME=` metadata; exactly one shipped patch matches (unambiguous filter)
- [x] Updated `SkillConfigJumpWiringParityTests` (was asserting the old bare-`Open`) + ja/zh tooltip translations
- [x] Live GUI test on `roms/FE8J_skill.gba` — see GUI Test Report + screenshot

## GUI Test Report
| Test | Result |
|---|---|
| SkillConfig FE8N v3 opens; "Move to COMBAT_ART" button enabled | ✅ PASS |
| Click it → Patch Manager opens **filtered** to the combat-art patch | ✅ PASS — search box seeded `FE8N SKILL COMBAT ART`, list `filtered: 1` |
| The `FE8N SKILL COMBAT ART(Editor)` patch is **selected** with details shown | ✅ PASS — Type STRUCT, #ENGINE, description rendered (verified via UIAutomation: `SEARCH=FE8N SKILL COMBAT ART`, 1 item selected) |
| Previously: opened unfiltered (274 patches) with nothing selected | ✅ fixed |

Method: app launched against `roms/FE8J_skill.gba`; FE8N v3 opened + Move-to-COMBAT_ART invoked via UIAutomation `InvokePattern`; search-box value + selected patch read via `ValuePattern`/`SelectionItemPattern`; captured with `tools/WinCapture` PrintWindow (locked-session safe).

## Screenshots
**Move to COMBAT_ART → Patch Manager filtered to & selecting the `FE8N SKILL COMBAT ART(Editor)` patch (was: unfiltered, nothing selected):**
![Combat-art jump](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1009-combat-art-jump.png)

---
Original request: *"set ralph loop to resolve all open GitHub issues in laqieer/FEBuilderGBA"* — 7th issue in the autonomous sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.168` · model `claude-opus-4-8[1m]`
