### PR TITLE
fix(avalonia): Item editor shows the MagicSplit magic stat-bonus row (#1036)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ItemEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ItemEditorParityTests.cs
@@ -372,6 +372,193 @@ public class ItemEditorParityTests
     }
 
     // -----------------------------------------------------------------
+    // #1036 — MagicSplit magic stat-bonus preview row (WF MagicExtUnitBase).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void RecalcStatBonuses_ReadsSignedMagByteAtOffset9_AndCoreStats()
+    {
+        // Plant a 10-byte stat-bonus block where the 10th value (offset +9 =
+        // Magic) is the SIGNED byte 0xFB == -5, and the 9 core stats hold
+        // distinct signed values. The item's P12 points at the block.
+        var rom = MakeRomWithStatBonusBlock(
+            out uint itemAddr,
+            block: new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xFB });
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            // No MagicSplit signature planted → detector defaults to None, but
+            // the +9 byte is still read regardless of the gate.
+            PatchDetectionService.Instance.Refresh();
+
+            var vm = new ItemEditorViewModel();
+            vm.LoadItem(itemAddr);
+
+            Assert.True(vm.HasBonusPreview, "Stat bonus preview should be active.");
+            // 9 core stats read correctly.
+            Assert.Equal(1, vm.BonusHP);
+            Assert.Equal(2, vm.BonusStr);
+            Assert.Equal(3, vm.BonusSkl);
+            Assert.Equal(4, vm.BonusSpd);
+            Assert.Equal(5, vm.BonusDef);
+            Assert.Equal(6, vm.BonusRes);
+            Assert.Equal(7, vm.BonusLck);
+            Assert.Equal(8, vm.BonusMove);
+            Assert.Equal(9, vm.BonusCon);
+            // The signed +9 magic byte: 0xFB == -5.
+            Assert.Equal(-5, vm.BonusMag);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            PatchDetectionService.Instance.Refresh();
+        }
+    }
+
+    [Fact]
+    public void RecalcStatBonuses_NineByteBlock_StillPreviews_MagDefaultsZero()
+    {
+        // A block where only 9 bytes are readable (the block ends exactly at the
+        // end of the ROM, so offset +9 is past EOF). The +9 guard returns Mag=0
+        // and must NOT break the HP..Con preview.
+        var rom = MakeRomWithStatBonusBlockAtEof(
+            out uint itemAddr,
+            coreNine: new byte[] { 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12 });
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            PatchDetectionService.Instance.Refresh();
+
+            var vm = new ItemEditorViewModel();
+            vm.LoadItem(itemAddr);
+
+            Assert.True(vm.HasBonusPreview, "9-byte block must still set HasBonusPreview.");
+            Assert.Equal(0x0A, vm.BonusHP);
+            Assert.Equal(0x12, vm.BonusCon);
+            // +9 byte is past EOF → bounds-guarded read yields 0, no crash.
+            Assert.Equal(0, vm.BonusMag);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            PatchDetectionService.Instance.Refresh();
+        }
+    }
+
+    [Fact]
+    public void HasMagicBonus_TrueOnFE8UMagicSplit_FalseOnVanilla()
+    {
+        // FE8U magic split signature at 0x2BB44: { 0x01, 0x4B, 0xA5, 0xF0, 0xC1, 0xFE }.
+        var rom = MakeRomWithStatBonusBlock(
+            out uint itemAddr,
+            block: new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0x07 });
+        var prevRom = CoreState.ROM;
+        try
+        {
+            // --- Vanilla (no signature): gate must be false. ---
+            CoreState.ROM = rom;
+            PatchDetectionService.Instance.Refresh();
+            Assert.Equal(PatchDetectionService.MagicSplitType.None,
+                PatchDetectionService.Instance.MagicSplit);
+
+            var vmVanilla = new ItemEditorViewModel();
+            vmVanilla.LoadItem(itemAddr);
+            Assert.True(vmVanilla.HasBonusPreview);
+            Assert.False(vmVanilla.HasMagicBonus);
+
+            // --- FE8U MagicSplit: plant signature, Refresh, gate must be true. ---
+            rom.Data[0x2BB44] = 0x01;
+            rom.Data[0x2BB45] = 0x4B;
+            rom.Data[0x2BB46] = 0xA5;
+            rom.Data[0x2BB47] = 0xF0;
+            rom.Data[0x2BB48] = 0xC1;
+            rom.Data[0x2BB49] = 0xFE;
+            // MagicSplitUtil.ClearCache alone is NOT enough — the VM reads the
+            // singleton's cached MagicSplit, so the service must be Refresh()ed.
+            PatchDetectionService.Instance.Refresh();
+            Assert.Equal(PatchDetectionService.MagicSplitType.FE8U,
+                PatchDetectionService.Instance.MagicSplit);
+
+            var vmSplit = new ItemEditorViewModel();
+            vmSplit.LoadItem(itemAddr);
+            Assert.True(vmSplit.HasBonusPreview);
+            Assert.True(vmSplit.HasMagicBonus);
+            Assert.Equal(7, vmSplit.BonusMag);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            // Restore detection state so it does not leak to other tests.
+            PatchDetectionService.Instance.Refresh();
+        }
+    }
+
+    [Fact]
+    public void HasMagicBonus_FalseOnFE8NMagicSplit_WfParityGate()
+    {
+        // WF parity: only FE7U/FE8U show the Magic row, NOT FE8N. Build an FE8J
+        // ROM and plant the FE8N magic-split signature at 0x2a542 = { 0x30, 0x1C }.
+        var rom = MakeFE8JRomWithStatBonusBlock(
+            out uint itemAddr,
+            block: new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0x07 });
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            rom.Data[0x2A542] = 0x30;
+            rom.Data[0x2A543] = 0x1C;
+            PatchDetectionService.Instance.Refresh();
+            // Confirm we really detected FE8N (so this is a real gate test, not
+            // a vacuous None==None pass).
+            Assert.Equal(PatchDetectionService.MagicSplitType.FE8N,
+                PatchDetectionService.Instance.MagicSplit);
+
+            var vm = new ItemEditorViewModel();
+            vm.LoadItem(itemAddr);
+            Assert.True(vm.HasBonusPreview);
+            // FE8N must NOT show the Magic row.
+            Assert.False(vm.HasMagicBonus);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            PatchDetectionService.Instance.Refresh();
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // #1036 — View source/static assertions.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_PopulatesBonusMagLabel_FromViewModel()
+    {
+        // The code-behind must set BonusMagLabel.Text from _vm.BonusMag and
+        // its visibility from _vm.HasMagicBonus.
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        Assert.True(source.Contains("BonusMagLabel.Text"),
+            "Code-behind must set BonusMagLabel.Text.");
+        Assert.True(source.Contains("_vm.BonusMag"),
+            "Code-behind must read _vm.BonusMag.");
+        Assert.True(source.Contains("BonusMagLabel.IsVisible = _vm.HasMagicBonus"),
+            "Code-behind must gate BonusMagLabel.IsVisible on _vm.HasMagicBonus.");
+    }
+
+    [Fact]
+    public void View_BonusMagLabel_StaleDeferredWordingRemoved()
+    {
+        // The old KnownGap comment that called MagicExtUnitBase "deferred" must
+        // be gone now that the row is implemented (#1036).
+        string axaml = ReadAxaml();
+        Assert.False(axaml.Contains("MagicExtUnitBase: requires HasMagicSplit + per-unit"),
+            "Stale 'deferred' MagicExtUnitBase KnownGap wording must be removed.");
+        Assert.True(axaml.Contains("AutomationId=\"ItemEditor_BonusMag_Label\""),
+            "BonusMag label must still exist in the AXAML.");
+    }
+
+    // -----------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------
 
@@ -420,6 +607,68 @@ public class ItemEditorParityTests
         data[offset + 1] = (byte)((value >> 8) & 0xFF);
         data[offset + 2] = (byte)((value >> 16) & 0xFF);
         data[offset + 3] = (byte)((value >> 24) & 0xFF);
+    }
+
+    /// <summary>
+    /// Build a synthetic FE8U ROM with a single item record at a known address
+    /// whose P12 (stat-bonus pointer) targets a planted stat-bonus
+    /// <paramref name="block"/>. Returns the item record address so the caller
+    /// can drive <c>ItemEditorViewModel.LoadItem(itemAddr)</c>.
+    /// </summary>
+    static ROM MakeRomWithStatBonusBlock(out uint itemAddr, byte[] block)
+    {
+        var rom = new ROM();
+        rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+
+        itemAddr = 0x200000;          // FE8U item record is 36 bytes.
+        uint blockAddr = 0x210000;    // stat-bonus block, distinct region.
+
+        // Plant the stat-bonus block.
+        for (int i = 0; i < block.Length; i++)
+            rom.Data[blockAddr + i] = block[i];
+
+        // P12 (offset +12 in the item record) → GBA pointer to the block.
+        WriteU32(rom.Data, (int)(itemAddr + 12), 0x08000000u | blockAddr);
+        return rom;
+    }
+
+    /// <summary>
+    /// Like <see cref="MakeRomWithStatBonusBlock"/> but places the 9 core-stat
+    /// bytes at the very END of the ROM so offset +9 (Magic) is past EOF. The
+    /// bounds guard must keep the HP..Con preview but return Mag = 0.
+    /// </summary>
+    static ROM MakeRomWithStatBonusBlockAtEof(out uint itemAddr, byte[] coreNine)
+    {
+        Assert.Equal(9, coreNine.Length);
+        var rom = new ROM();
+        rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+
+        itemAddr = 0x200000;
+        // Place the 9 bytes so the block ends exactly at EOF: addr = len - 9.
+        uint blockAddr = (uint)rom.Data.Length - 9;
+        for (int i = 0; i < 9; i++)
+            rom.Data[blockAddr + i] = coreNine[i];
+
+        WriteU32(rom.Data, (int)(itemAddr + 12), 0x08000000u | blockAddr);
+        return rom;
+    }
+
+    /// <summary>
+    /// FE8J variant of <see cref="MakeRomWithStatBonusBlock"/> — registers as
+    /// BE8J01 so the FE8N magic-split signature (FE8J-only) can be planted.
+    /// </summary>
+    static ROM MakeFE8JRomWithStatBonusBlock(out uint itemAddr, byte[] block)
+    {
+        var rom = new ROM();
+        rom.LoadLow("synth.gba", new byte[0x1000000], "BE8J01");
+
+        itemAddr = 0x200000;
+        uint blockAddr = 0x210000;
+        for (int i = 0; i < block.Length; i++)
+            rom.Data[blockAddr + i] = block[i];
+
+        WriteU32(rom.Data, (int)(itemAddr + 12), 0x08000000u | blockAddr);
+        return rom;
     }
 
     static string AxamlPath()

--- a/FEBuilderGBA.Avalonia/ViewModels/ItemEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ItemEditorViewModel.cs
@@ -110,8 +110,8 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public uint ShopForgePrice { get => _shopForgePrice; private set => SetField(ref _shopForgePrice, value); }
 
         // --- Computed: Stat bonus preview ---
-        int _bonusHP, _bonusStr, _bonusSkl, _bonusSpd, _bonusDef, _bonusRes, _bonusLck, _bonusMove, _bonusCon;
-        bool _hasBonusPreview;
+        int _bonusHP, _bonusStr, _bonusSkl, _bonusSpd, _bonusDef, _bonusRes, _bonusLck, _bonusMove, _bonusCon, _bonusMag;
+        bool _hasBonusPreview, _hasMagicBonus;
         public int BonusHP { get => _bonusHP; private set => SetField(ref _bonusHP, value); }
         public int BonusStr { get => _bonusStr; private set => SetField(ref _bonusStr, value); }
         public int BonusSkl { get => _bonusSkl; private set => SetField(ref _bonusSkl, value); }
@@ -122,6 +122,19 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public int BonusMove { get => _bonusMove; private set => SetField(ref _bonusMove, value); }
         public int BonusCon { get => _bonusCon; private set => SetField(ref _bonusCon, value); }
         public bool HasBonusPreview { get => _hasBonusPreview; private set => SetField(ref _hasBonusPreview, value); }
+        /// <summary>
+        /// MagicSplit magic stat-bonus value (offset +9 in the stat-bonus block).
+        /// Mirrors WF <c>MagicExtUnitBase</c>. Read bounds-guarded; 0 when the
+        /// 10th byte is unavailable. Only meaningful when <see cref="HasMagicBonus"/>.
+        /// </summary>
+        public int BonusMag { get => _bonusMag; private set => SetField(ref _bonusMag, value); }
+        /// <summary>
+        /// True only on FE7U/FE8U MagicSplit ROMs, where the stat-bonus block
+        /// carries a 10th Magic value (mirrors WF <c>MagicExtUnitBase</c>
+        /// visibility). FE8N/vanilla/FE6 keep this false so the Magic row stays
+        /// hidden.
+        /// </summary>
+        public bool HasMagicBonus { get => _hasMagicBonus; private set => SetField(ref _hasMagicBonus, value); }
 
         // --- Computed: Effective class list ---
         List<string> _effectiveClassList = new();
@@ -166,6 +179,8 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             {
                 HasBonusPreview = false;
                 BonusHP = BonusStr = BonusSkl = BonusSpd = BonusDef = BonusRes = BonusLck = BonusMove = BonusCon = 0;
+                BonusMag = 0;
+                HasMagicBonus = false;
                 return;
             }
 
@@ -174,6 +189,8 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             {
                 HasBonusPreview = false;
                 BonusHP = BonusStr = BonusSkl = BonusSpd = BonusDef = BonusRes = BonusLck = BonusMove = BonusCon = 0;
+                BonusMag = 0;
+                HasMagicBonus = false;
                 return;
             }
 
@@ -187,6 +204,15 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             BonusLck  = (sbyte)rom.u8(addr + 6);
             BonusMove = (sbyte)rom.u8(addr + 7);
             BonusCon  = (sbyte)rom.u8(addr + 8);
+
+            // MagicSplit magic stat-bonus (offset +9) — mirrors WF MagicExtUnitBase.
+            // Bounds-guard the 10th byte so the existing 9-byte vanilla preview
+            // stays intact (a vanilla block has no +9 byte → Mag = 0).
+            BonusMag = (addr + 10 <= (uint)rom.Data.Length) ? (sbyte)rom.u8(addr + 9) : 0;
+            // Visibility gate: FE7U/FE8U MagicSplit only (NOT FE8N) for WF parity.
+            var ms = PatchDetectionService.Instance.MagicSplit;
+            HasMagicBonus = (ms == PatchDetectionService.MagicSplitType.FE7U
+                          || ms == PatchDetectionService.MagicSplitType.FE8U);
         }
 
         void UpdateEffectiveClassList()

--- a/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml
@@ -208,14 +208,15 @@
         </Border>
         </Expander>
 
-        <!-- KnownGap (out-of-scope for #409, parent #374):
+        <!-- Parity notes (parent #374):
              - WF X_SIM_* labels (HP/Str/Skl/Spd/Def/Res/Lck/Move/Con preview):
                rendered as the Stat Bonuses Preview WrapPanel above.
              - WF X_VALUE_SHOP / X_VALUE_SEL / X_VALUE_SHINGEKI_SHOP:
                surfaced as the Buy Price / Sell Price / Forge Price labels.
-             - WF MagicExtUnitBase: requires HasMagicSplit + per-unit
-               base-magic detection — deferred.
-             None of these spawn new follow-up issues per #409 scope rule. -->
+             - WF MagicExtUnitBase: implemented (#1036) as the BonusMag row in
+               the Stat Bonuses Preview below — the stat-bonus block's 10th
+               value (offset +9) is read into BonusMag and the row is shown only
+               on FE7U/FE8U MagicSplit ROMs (HasMagicBonus). -->
 
 
         <!-- Null pointer warnings + new-alloc buttons.
@@ -256,9 +257,10 @@
               <TextBlock AutomationProperties.AutomationId="ItemEditor_BonusLck_Label" Name="BonusLckLabel" Margin="0,0,12,0" />
               <TextBlock AutomationProperties.AutomationId="ItemEditor_BonusMove_Label" Name="BonusMoveLabel" Margin="0,0,12,0" />
               <TextBlock AutomationProperties.AutomationId="ItemEditor_BonusCon_Label" Name="BonusConLabel" Margin="0,0,12,0" />
-              <!-- Magic split base — visible only when HasMagicSplit is detected
-                   (mirrors WF MagicExtUnitBase). Stays hidden by default so we
-                   do not mislead users on vanilla ROMs. -->
+              <!-- Magic split base (#1036) — the stat-bonus block's 10th value
+                   (offset +9). Visible only on FE7U/FE8U MagicSplit ROMs
+                   (HasMagicBonus; mirrors WF MagicExtUnitBase). Stays hidden by
+                   default so we do not mislead users on vanilla/FE8N/FE6 ROMs. -->
               <TextBlock AutomationProperties.AutomationId="ItemEditor_BonusMag_Label"
                          Name="BonusMagLabel"
                          Margin="0,0,12,0"

--- a/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml.cs
@@ -383,6 +383,10 @@ namespace FEBuilderGBA.Avalonia.Views
                 BonusLckLabel.Text = $"Lck: {_vm.BonusLck:+#;-#;0}";
                 BonusMoveLabel.Text = $"Move: {_vm.BonusMove:+#;-#;0}";
                 BonusConLabel.Text = $"Con: {_vm.BonusCon:+#;-#;0}";
+                // MagicSplit magic bonus (WF MagicExtUnitBase) — shown only on
+                // FE7U/FE8U MagicSplit ROMs; hidden on vanilla/FE8N/FE6.
+                BonusMagLabel.Text = $"Mag: {_vm.BonusMag:+#;-#;0}";
+                BonusMagLabel.IsVisible = _vm.HasMagicBonus;
             }
         }
 

--- a/docs/field-completeness-report.txt
+++ b/docs/field-completeness-report.txt
@@ -1,6 +1,6 @@
 === Field Completeness Report ===
 Total WinForms fields: 1563
-Total Avalonia fields: 1811
+Total Avalonia fields: 1812
 Total missing: 0
 Forms with gaps: 0 / 175
 


### PR DESCRIPTION
## Summary
Surfaces the Item editor's MagicSplit magic stat-bonus row (WF `MagicExtUnitBase`). On FE7U/FE8U with the MagicSplit (魔力分離) patch, the item stat-bonus block carries a 10th value at **offset +9** (the 魔力/Magic bonus). `ItemEditorViewModel` now reads it into `BonusMag` and exposes `HasMagicBonus`, and the Item editor populates `BonusMagLabel` + shows it **only when MagicSplit is FE7U/FE8U**. Hidden on vanilla, FE8N, and FE6 (mirrors WF). No Core changes.

Plan + Copilot CLI review: issue #1036 comment thread (no blocking findings; the FE7U/FE8U-not-FE8N gate + detector cache-hygiene guidance folded in).

## Scope
Closes #1036.

- `BonusMag = (sbyte)rom.u8(addr + 9)` — **bounds-guarded** (`addr+10<=len`) so vanilla 9-byte stat-bonus blocks still preview HP..Con.
- `HasMagicBonus = MagicSplit is FE7U or FE8U` (the specific enum members — **not** the generic `HasMagicSplit`, which would wrongly include FE8N).

## Test plan
- [x] `dotnet build FEBuilderGBA.Avalonia` — Release, 0 errors
- [x] `FEBuilderGBA.Avalonia.Tests` — **7644/7647** pass (3 skipped, **0 failures**); filtered `~ItemEditor` **98/99**
- [x] `FEBuilderGBA.Tests` (net9.0-windows) — **1851/1851** pass
- [x] `RecalcStatBonuses_ReadsSignedMagByteAtOffset9_AndCoreStats` — `+9 = 0xFB` → `BonusMag == -5` (signed), all 9 core stats correct
- [x] `RecalcStatBonuses_NineByteBlock_StillPreviews_MagDefaultsZero` — 9-byte-readable block still previews HP..Con (the +9 guard returns 0)
- [x] `HasMagicBonus_TrueOnFE8UMagicSplit_FalseOnVanilla` — planted FE8U sig `{0x01,0x4B,0xA5,0xF0,0xC1,0xFE}` @ `0x2BB44` + `PatchDetectionService.Instance.Refresh()` → true; vanilla → false (with cache hygiene in `finally`)
- [x] `HasMagicBonus_FalseOnFE8NMagicSplit_WfParityGate` — real FE8J ROM + FE8N sig → detector returns FE8N, `HasMagicBonus == false` (WF parity)
- [x] `View_PopulatesBonusMagLabel_FromViewModel` + `View_BonusMagLabel_StaleDeferredWordingRemoved`
- [x] Live GUI test on a MagicSplit-signature-planted FE8U ROM — see GUI Test Report + screenshot

## GUI Test Report
| Test | Result |
|---|---|
| Item editor opens on a MagicSplit ROM | ✅ PASS |
| An item with stat bonuses shows the Stat Bonuses Preview **including the Mag column** | ✅ PASS — item `3E Excalibur` (Spd +5) → preview `HP:0 Str:0 Skl:0 Spd:+5 … Con:0 **Mag:0**` (verified via UIAutomation: `ItemEditor_BonusMag_Label` present + visible) |
| Mag row stays hidden on vanilla / FE8N | ✅ PASS (unit tests — detector gates on FE7U/FE8U only) |

Method: app launched against an `FE8U.gba` copy with the FE8U MagicSplit signature planted at `0x2BB44` (so `HasMagicSplit` detects FE8U, mirroring the unit test); Item editor opened + navigated to a stat-bonus item via UIAutomation; the `BonusMag` label's presence/visibility confirmed programmatically; captured with `tools/WinCapture` PrintWindow (locked-session safe).

## Screenshots
**Item editor on a MagicSplit ROM — the Stat Bonuses Preview now surfaces the `Mag:` column (was hidden); item Excalibur (Spd +5):**
![Item magic stat-bonus](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1036-item-magic-bonus.png)

---
Original request: *"set ralph loop to resolve all open GitHub issues in laqieer/FEBuilderGBA"* — 9th issue in the autonomous sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.168` · model `claude-opus-4-8[1m]`
