### PR TITLE
fix(avalonia): Class/Unit CSV emit + read the FE8U MagicSplit magic column (#1016)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ClassEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ClassEditorParityTests.cs
@@ -719,6 +719,223 @@ namespace FEBuilderGBA.Avalonia.Tests
                 Assert.Equal(u2Before[o - 11], rom.Data[baseAddr + 2 * dataSize + o]);
         }
 
+        // =================================================================
+        // ---- #1016: FE8U MagicSplit (FE8UMAGIC) MAG column tests ----
+        // =================================================================
+
+        /// <summary>
+        /// On a clean FE8U ROM with NO MagicSplit signature,
+        /// SearchMagicSplit()==NO, so the Class CSV header + column counts must
+        /// be byte-identical to the pre-#1016 baseline (regression guard).
+        /// </summary>
+        [Fact]
+        public void Class_VanillaFE8U_NoMagicColumn_HeaderUnchanged()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                // Clean FE8U ROM (no FE8UMAGIC / FE8UInit signatures).
+                byte[] data = new byte[0x1000000];
+                Array.Copy(System.Text.Encoding.ASCII.GetBytes("BE8E01"), 0, data, 0xAC, 6);
+                var rom = new ROM();
+                rom.LoadLow("test.gba", data, "BE8E01");
+                CoreState.ROM = rom;
+                MagicSplitUtil.ClearCache();
+                Assert.Equal(MagicSplitUtil.magic_split_enum.NO, MagicSplitUtil.SearchMagicSplit());
+
+                uint baseAddr = 0x500;
+                var mgr = new ClassCsvManager(
+                    useClipboard: false, includeUID: false, includeHeader: true,
+                    includeName: false, includeBaseStats: true, includeGrowths: true,
+                    includeWepLevel: true, growthsAsDecimal: false);
+                string csv = mgr.BuildExportCsv(rom, new[] { baseAddr });
+                string header = csv.Split('\n')[0];
+                // Exact baseline header (no MAG): base 7 + growth 7 + weplevel 8.
+                Assert.Equal(
+                    "HP, STR, SKL, SPD, DEF, RES, CON, HP, STR, SKL, SPD, DEF, RES, LUCK, " +
+                    "Sword, Lance, Axe, Bow, Staff, Anima, Light, Dark",
+                    header);
+                Assert.DoesNotContain("MAG", header);
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+                MagicSplitUtil.ClearCache();
+            }
+        }
+
+        /// <summary>
+        /// On an FE8UMAGIC ROM, the Class CSV header has exactly one "MAG"
+        /// immediately after the base block and one immediately after the
+        /// growth block (positions, not just Contains), with the weplevel
+        /// columns shifted by +1 per active block.
+        /// </summary>
+        [Fact]
+        public void Class_MagicSplitFE8U_HeaderHasMagAtBaseAndGrowthEnds()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                var rom = FE8UMagicSplitTestRom.Make();
+                CoreState.ROM = rom;
+                MagicSplitUtil.ClearCache();
+                Assert.Equal(MagicSplitUtil.magic_split_enum.FE8UMAGIC, MagicSplitUtil.SearchMagicSplit());
+
+                uint baseAddr = 0x500;
+                var mgr = new ClassCsvManager(
+                    useClipboard: false, includeUID: false, includeHeader: true,
+                    includeName: false, includeBaseStats: true, includeGrowths: true,
+                    includeWepLevel: true, growthsAsDecimal: false);
+                string csv = mgr.BuildExportCsv(rom, new[] { baseAddr });
+                string[] cols = csv.Split('\n')[0].Split(',');
+                for (int i = 0; i < cols.Length; i++) cols[i] = cols[i].Trim();
+
+                // Base block (0..6) then MAG at index 7.
+                Assert.Equal("CON", cols[6]);
+                Assert.Equal("MAG", cols[7]);
+                // Growth block (8..14) then MAG at index 15.
+                Assert.Equal("LUCK", cols[14]);
+                Assert.Equal("MAG", cols[15]);
+                // Weplevel shifted by +2 (one MAG per active block).
+                Assert.Equal("Sword", cols[16]);
+                Assert.Equal("Dark", cols[23]);
+                Assert.Equal(24, cols.Length); // 7+1 + 7+1 + 8
+                Assert.Equal(2, cols.Count(c => c == "MAG"));
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+                MagicSplitUtil.ClearCache();
+            }
+        }
+
+        /// <summary>
+        /// Full Class MagicSplit VALUE round-trip: write distinct base+growth
+        /// MAG values per class via the Core helpers, export, then import a CSV
+        /// with DIFFERENT MAG values, and assert the Get helpers now return the
+        /// imported values — for two distinct class ids (one &gt; 0). Proves
+        /// the id is read/written correctly (blockers 1+2).
+        /// </summary>
+        [Fact]
+        public void Class_MagicSplitFE8U_ValueRoundTrip_ImportsNewMagValues()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                var rom = FE8UMagicSplitTestRom.Make();
+                CoreState.ROM = rom;
+                MagicSplitUtil.ClearCache();
+                Assert.Equal(MagicSplitUtil.magic_split_enum.FE8UMAGIC, MagicSplitUtil.SearchMagicSplit());
+
+                // Four CONTIGUOUS class rows so multi-row UID routing maps
+                // rowAddresses[uid] == addr (the index whose address the UID
+                // selects). We exercise ids 0 and 3.
+                const uint dataSize = 84;
+                uint a0 = 0x500;
+                var addrs = new uint[4];
+                for (uint i = 0; i < 4; i++) addrs[i] = a0 + i * dataSize;
+                uint a3 = addrs[3];
+
+                var mgr = new ClassCsvManager(
+                    useClipboard: false, includeUID: true, includeHeader: false,
+                    includeName: false, includeBaseStats: true, includeGrowths: true,
+                    includeWepLevel: false, growthsAsDecimal: false);
+
+                // Seed original MAG values for ids 0 and 3.
+                using (FE8UMagicSplitTestRom.BeginUndoScope(rom))
+                {
+                    var u = ROM.GetAmbientUndoData()!;
+                    MagicSplitUtil.WriteClassBaseMagicExtends(0, a0, ToByte(5), u);
+                    MagicSplitUtil.WriteClassGrowMagicExtends(0, a0, ToByte(10), u);
+                    MagicSplitUtil.WriteClassBaseMagicExtends(3, a3, ToByte(6), u);
+                    MagicSplitUtil.WriteClassGrowMagicExtends(3, a3, ToByte(20), u);
+                }
+
+                // Sanity: export all 4 rows (UIDs 0..3); rows 0 and 3 carry the
+                // seeded MAG-base values (export reads MAG from the right id).
+                string exported = mgr.BuildExportCsv(rom, addrs);
+                string[] expLines = exported.Split('\n');
+                Assert.Equal(5, MagicBaseFromRow(expLines[0]));
+                Assert.Equal(6, MagicBaseFromRow(expLines[3]));
+
+                // Build a multi-row UID-routed import CSV with DIFFERENT MAG:
+                // id 0 -> base 9 / grow 33 ; id 3 -> base 14 / grow 41. Rows 1,2
+                // keep their seeded zeros.
+                string importCsv =
+                    BuildClassRow(0, baseMag: 9, growMag: 33) + "\n" +
+                    BuildClassRow(1, baseMag: 0, growMag: 0) + "\n" +
+                    BuildClassRow(2, baseMag: 0, growMag: 0) + "\n" +
+                    BuildClassRow(3, baseMag: 14, growMag: 41) + "\n";
+
+                using (FE8UMagicSplitTestRom.BeginUndoScope(rom))
+                {
+                    int n = mgr.ApplyImportCsv(rom, importCsv, addrs);
+                    Assert.Equal(4, n);
+                }
+
+                Assert.Equal((sbyte)9, (sbyte)MagicSplitUtil.GetClassBaseMagicExtends(0, a0));
+                Assert.Equal((sbyte)33, (sbyte)MagicSplitUtil.GetClassGrowMagicExtends(0, a0));
+                Assert.Equal((sbyte)14, (sbyte)MagicSplitUtil.GetClassBaseMagicExtends(3, a3));
+                Assert.Equal((sbyte)41, (sbyte)MagicSplitUtil.GetClassGrowMagicExtends(3, a3));
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+                MagicSplitUtil.ClearCache();
+            }
+        }
+
+        /// <summary>
+        /// MagicSplit import without an active ambient undo scope must FAIL FAST
+        /// (before any mutation) rather than silently dropping the MAG column.
+        /// </summary>
+        [Fact]
+        public void Class_MagicSplitFE8U_ImportWithoutUndoScope_Throws()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                var rom = FE8UMagicSplitTestRom.Make();
+                CoreState.ROM = rom;
+                MagicSplitUtil.ClearCache();
+                Assert.Equal(MagicSplitUtil.magic_split_enum.FE8UMAGIC, MagicSplitUtil.SearchMagicSplit());
+
+                var mgr = new ClassCsvManager(
+                    useClipboard: false, includeUID: false, includeHeader: false,
+                    includeName: false, includeBaseStats: true, includeGrowths: false,
+                    includeWepLevel: false, growthsAsDecimal: false);
+                // base(7) + MAG(1) cols, no undo scope open.
+                string csv = "1, 2, 3, 4, 5, 6, 7, 8\n";
+                Assert.Throws<InvalidOperationException>(
+                    () => mgr.ApplyImportCsv(rom, csv, new[] { 0x500u }));
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+                MagicSplitUtil.ClearCache();
+            }
+        }
+
+        // ---- #1016 Class MagicSplit test helpers ----
+
+        static uint ToByte(int v) => (uint)(byte)(sbyte)v;
+
+        // A class row: "uid, <7 base>, MAG, <7 growth>, MAG" with includeUID,
+        // includeBaseStats, includeGrowths (no weplevel).
+        static string BuildClassRow(uint uid, int baseMag, int growMag)
+        {
+            return $"{uid}, 1, 2, 3, 4, 5, 6, 7, {baseMag}, 10, 11, 12, 13, 14, 15, 16, {growMag}";
+        }
+
+        // Extract the MAG-base value from a single exported class row built with
+        // includeUID + includeBaseStats. The class base block is 7 cols, so
+        // MAG-base is at column index 1(uid)+7 = 8.
+        static int MagicBaseFromRow(string rowLine)
+        {
+            string[] cols = rowLine.Split(',');
+            return int.Parse(cols[8].Trim());
+        }
+
         static string? FindRepoRoot()
         {
             string start = AppDomain.CurrentDomain.BaseDirectory;

--- a/FEBuilderGBA.Avalonia.Tests/ClassEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ClassEditorParityTests.cs
@@ -916,6 +916,66 @@ namespace FEBuilderGBA.Avalonia.Tests
             }
         }
 
+        /// <summary>
+        /// #1016 back-compat: importing a LEGACY pre-#1016 Avalonia CSV (base +
+        /// growth + weplevel, NO MAG columns) into a FE8UMAGIC ROM must NOT
+        /// consume a stat cell as MAG and shift the rest (see the Unit twin).
+        /// Class base block is 7 cols, so a legacy row is 23 columns while the
+        /// with-MAG layout is 25 — the fix gates MAG on that count.
+        /// </summary>
+        [Fact]
+        public void Class_MagicSplitFE8U_LegacyNoMagCsv_DoesNotShiftColumns()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                var rom = FE8UMagicSplitTestRom.Make();
+                CoreState.ROM = rom;
+                MagicSplitUtil.ClearCache();
+                Assert.Equal(MagicSplitUtil.magic_split_enum.FE8UMAGIC, MagicSplitUtil.SearchMagicSplit());
+
+                uint addr = 0x500;
+                var mgr = new ClassCsvManager(
+                    useClipboard: false, includeUID: true, includeHeader: false,
+                    includeName: false, includeBaseStats: true, includeGrowths: true,
+                    includeWepLevel: true, growthsAsDecimal: false);
+
+                // Seed sentinel MAG for class 0 so we can prove it survives.
+                using (FE8UMagicSplitTestRom.BeginUndoScope(rom))
+                {
+                    var u = ROM.GetAmbientUndoData()!;
+                    MagicSplitUtil.WriteClassBaseMagicExtends(0, addr, ToByte(77), u);
+                    MagicSplitUtil.WriteClassGrowMagicExtends(0, addr, ToByte(88), u);
+                }
+
+                // Legacy row: uid(1) + base(7) + growth(7) + weplevel(8) = 23
+                // columns, NO MAG. The with-MAG layout would be 25 columns.
+                string legacy =
+                    "0, 21, 22, 23, 24, 25, 26, 27, 40, 41, 42, 43, 44, 45, 46, 1, 2, 3, 4, 5, 6, 7, 8\n";
+                using (FE8UMagicSplitTestRom.BeginUndoScope(rom))
+                {
+                    int n = mgr.ApplyImportCsv(rom, legacy, new[] { addr }, singleRowId: 0);
+                    Assert.Equal(1, n);
+                }
+
+                // Normal stats land in the right offsets (no shift).
+                for (uint o = 11; o <= 17; o++) Assert.Equal((sbyte)(21 + (o - 11)), (sbyte)rom.u8(addr + o));
+                for (uint o = 27; o <= 33; o++) Assert.Equal((sbyte)(40 + (o - 27)), (sbyte)rom.u8(addr + o));
+                for (uint o = 44; o <= 51; o++) Assert.Equal((sbyte)(1 + (o - 44)), (sbyte)rom.u8(addr + o));
+                // The growth LUCK (offset 33) is 46, NOT 1 (the buggy shift would
+                // have read the first weplevel value here).
+                Assert.Equal((sbyte)46, (sbyte)rom.u8(addr + 33));
+                // The sentinel MAG values are UNTOUCHED.
+                Assert.Equal((sbyte)77, (sbyte)MagicSplitUtil.GetClassBaseMagicExtends(0, addr));
+                Assert.Equal((sbyte)88, (sbyte)MagicSplitUtil.GetClassGrowMagicExtends(0, addr));
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+                MagicSplitUtil.ClearCache();
+            }
+        }
+
         // ---- #1016 Class MagicSplit test helpers ----
 
         static uint ToByte(int v) => (uint)(byte)(sbyte)v;

--- a/FEBuilderGBA.Avalonia.Tests/FE8UMagicSplitTestRom.cs
+++ b/FEBuilderGBA.Avalonia.Tests/FE8UMagicSplitTestRom.cs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1016 — shared helper to build a fully-planted FE8U MagicSplit (FE8UMAGIC)
+// test ROM for the Class/Unit CSV MagicSplit round-trip tests.
+//
+// Plants BOTH:
+//   1. the FE8UMAGIC detection signature at 0x2BB44 (so
+//      MagicSplitUtil.SearchMagicSplit() returns FE8UMAGIC), AND
+//   2. the 88-byte FE8UInit code signature (copied verbatim from
+//      MagicSplitUtil.FE8UInit) past compress_image_borderline_address,
+//      followed by two valid in-ROM pointers so UnitTag / ClassTag resolve to
+//      scratch table regions inside rom.Data.
+//
+// Callers must set CoreState.ROM = rom and call MagicSplitUtil.ClearCache()
+// before use, and restore CoreState.ROM + ClearCache() in a finally block.
+using System;
+using FEBuilderGBA.Core;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    internal static class FE8UMagicSplitTestRom
+    {
+        // The 88-byte FE8UInit code signature (pre-2022 variant), verbatim from
+        // FEBuilderGBA.Core/MagicSplitUtil.cs FE8UInit().
+        static readonly byte[] FE8UInitSignature =
+        {
+            0x00, 0xB5, 0x13, 0x48, 0x86, 0x46, 0x38, 0x68, 0x00, 0x79, 0x40, 0x00, 0x12, 0x49, 0x40, 0x18,
+            0x40, 0x78, 0x50, 0x44, 0x00, 0xF8, 0x01, 0xB4, 0x0E, 0x48, 0x86, 0x46, 0xF8, 0x7A, 0x00, 0xF8,
+            0x41, 0x68, 0x3A, 0x30, 0x00, 0x78, 0x09, 0x79, 0x89, 0x00, 0x0C, 0x4A, 0x52, 0x18, 0x92, 0x78,
+            0x02, 0xBC, 0x76, 0x18, 0x43, 0x18, 0x93, 0x42, 0x00, 0xDD, 0x11, 0x1A, 0x38, 0x1C, 0x7A, 0x30,
+            0x01, 0x70, 0x01, 0xBC, 0x00, 0x99, 0x03, 0x91, 0x01, 0x9B, 0x02, 0x93, 0xC2, 0x46, 0x00, 0x47,
+            0xA0, 0xB9, 0x02, 0x08, 0x30, 0x94, 0x01, 0x08,
+        };
+
+        const uint SigOffset = 0x100000;    // FE8UInit signature (4-aligned, > 0xDB000).
+        public const uint UnitTagOffset = 0x200000;
+        public const uint ClassTagOffset = 0x300000;
+
+        /// <summary>Build a 16 MB FE8U ROM with both MagicSplit signatures planted.</summary>
+        public static ROM Make()
+        {
+            byte[] data = new byte[0x1000000]; // 16 MB
+            byte[] versionBytes = System.Text.Encoding.ASCII.GetBytes("BE8E01");
+            Array.Copy(versionBytes, 0, data, 0xAC, versionBytes.Length);
+
+            // FE8UMAGIC detection signature @ 0x2BB44.
+            byte[] det = { 0x01, 0x4B, 0xA5, 0xF0, 0xC1, 0xFE };
+            Array.Copy(det, 0, data, 0x2BB44, det.Length);
+
+            // FE8UInit code signature @ SigOffset, then the two tag pointers.
+            Array.Copy(FE8UInitSignature, 0, data, (int)SigOffset, FE8UInitSignature.Length);
+            uint p = SigOffset + (uint)FE8UInitSignature.Length;
+            WritePtr(data, p, UnitTagOffset);       // UnitTag = p32(p)
+            WritePtr(data, p + 4, ClassTagOffset);  // ClassTag = p32(p+4)
+
+            var rom = new ROM();
+            rom.LoadLow("test.gba", data, "BE8E01");
+            return rom;
+        }
+
+        static void WritePtr(byte[] data, uint at, uint offset)
+        {
+            uint ptr = offset + 0x08000000;
+            data[at + 0] = (byte)(ptr & 0xFF);
+            data[at + 1] = (byte)((ptr >> 8) & 0xFF);
+            data[at + 2] = (byte)((ptr >> 16) & 0xFF);
+            data[at + 3] = (byte)((ptr >> 24) & 0xFF);
+        }
+
+        /// <summary>
+        /// Open a public ambient-undo scope (matches what UndoService.Begin does
+        /// in the live UI). The CSV importer's MagicSplit write path requires a
+        /// non-null ambient undo.
+        /// </summary>
+        public static IDisposable BeginUndoScope(ROM rom) => ROM.BeginUndoScope(new Undo.UndoData
+        {
+            time = DateTime.Now,
+            name = "test",
+            list = new System.Collections.Generic.List<Undo.UndoPostion>(),
+            filesize = (uint)rom.Data.Length,
+        });
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/FE8UMagicSplitTestRom.cs
+++ b/FEBuilderGBA.Avalonia.Tests/FE8UMagicSplitTestRom.cs
@@ -60,10 +60,11 @@ namespace FEBuilderGBA.Avalonia.Tests
         static void WritePtr(byte[] data, uint at, uint offset)
         {
             uint ptr = offset + 0x08000000;
-            data[at + 0] = (byte)(ptr & 0xFF);
-            data[at + 1] = (byte)((ptr >> 8) & 0xFF);
-            data[at + 2] = (byte)((ptr >> 16) & 0xFF);
-            data[at + 3] = (byte)((ptr >> 24) & 0xFF);
+            int i = (int)at;
+            data[i + 0] = (byte)(ptr & 0xFF);
+            data[i + 1] = (byte)((ptr >> 8) & 0xFF);
+            data[i + 2] = (byte)((ptr >> 16) & 0xFF);
+            data[i + 3] = (byte)((ptr >> 24) & 0xFF);
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia.Tests/UnitEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/UnitEditorParityTests.cs
@@ -545,6 +545,226 @@ namespace FEBuilderGBA.Avalonia.Tests
                 Assert.Equal(u2Before[o - 12], rom.Data[baseAddr + 2 * dataSize + o]);
         }
 
+        // =================================================================
+        // ---- #1016: FE8U MagicSplit (FE8UMAGIC) MAG column tests ----
+        // =================================================================
+
+        /// <summary>
+        /// Clean FE8U ROM with NO MagicSplit signature: SearchMagicSplit()==NO,
+        /// so the Unit CSV header + column counts are byte-identical to the
+        /// pre-#1016 baseline (regression guard).
+        /// </summary>
+        [Fact]
+        public void Unit_VanillaFE8U_NoMagicColumn_HeaderUnchanged()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                byte[] data = new byte[0x1000000];
+                Array.Copy(System.Text.Encoding.ASCII.GetBytes("BE8E01"), 0, data, 0xAC, 6);
+                var rom = new ROM();
+                rom.LoadLow("test.gba", data, "BE8E01");
+                CoreState.ROM = rom;
+                MagicSplitUtil.ClearCache();
+                Assert.Equal(MagicSplitUtil.magic_split_enum.NO, MagicSplitUtil.SearchMagicSplit());
+
+                uint baseAddr = 0x500;
+                var mgr = new UnitCsvManager(
+                    useClipboard: false, includeUID: false, includeHeader: true,
+                    includeName: false, includeBaseStats: true, includeGrowths: true,
+                    includeWepLevel: true, growthsAsDecimal: false);
+                string csv = mgr.BuildExportCsv(rom, new[] { baseAddr });
+                string header = csv.Split('\n')[0];
+                // Exact baseline header (no MAG): base 8 + growth 7 + weplevel 8.
+                Assert.Equal(
+                    "HP, STR, SKL, SPD, DEF, RES, LUCK, CON, HP, STR, SKL, SPD, DEF, RES, LUCK, " +
+                    "Sword, Lance, Axe, Bow, Staff, Anima, Light, Dark",
+                    header);
+                Assert.DoesNotContain("MAG", header);
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+                MagicSplitUtil.ClearCache();
+            }
+        }
+
+        /// <summary>
+        /// FE6 ROM never matches FE8UMAGIC, so no MAG column is emitted.
+        /// </summary>
+        [Fact]
+        public void Unit_FE6_NoMagicColumn()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                byte[] data = new byte[0x800000];
+                Array.Copy(System.Text.Encoding.ASCII.GetBytes("AFEJ01"), 0, data, 0xAC, 6);
+                var rom = new ROM();
+                rom.LoadLow("test.gba", data, "AFEJ01");
+                CoreState.ROM = rom;
+                MagicSplitUtil.ClearCache();
+                Assert.NotEqual(MagicSplitUtil.magic_split_enum.FE8UMAGIC, MagicSplitUtil.SearchMagicSplit());
+
+                uint baseAddr = 0x500;
+                var mgr = new UnitCsvManager(
+                    useClipboard: false, includeUID: false, includeHeader: true,
+                    includeName: false, includeBaseStats: true, includeGrowths: true,
+                    includeWepLevel: false, growthsAsDecimal: false);
+                string header = mgr.BuildExportCsv(rom, new[] { baseAddr }).Split('\n')[0];
+                Assert.DoesNotContain("MAG", header);
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+                MagicSplitUtil.ClearCache();
+            }
+        }
+
+        /// <summary>
+        /// FE8UMAGIC ROM: the Unit CSV header has exactly one "MAG" immediately
+        /// after the base block and one immediately after the growth block
+        /// (positions, not just Contains), weplevel columns shifted by +1 per
+        /// active block.
+        /// </summary>
+        [Fact]
+        public void Unit_MagicSplitFE8U_HeaderHasMagAtBaseAndGrowthEnds()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                var rom = FE8UMagicSplitTestRom.Make();
+                CoreState.ROM = rom;
+                MagicSplitUtil.ClearCache();
+                Assert.Equal(MagicSplitUtil.magic_split_enum.FE8UMAGIC, MagicSplitUtil.SearchMagicSplit());
+
+                uint baseAddr = 0x500;
+                var mgr = new UnitCsvManager(
+                    useClipboard: false, includeUID: false, includeHeader: true,
+                    includeName: false, includeBaseStats: true, includeGrowths: true,
+                    includeWepLevel: true, growthsAsDecimal: false);
+                string[] cols = mgr.BuildExportCsv(rom, new[] { baseAddr }).Split('\n')[0].Split(',');
+                for (int i = 0; i < cols.Length; i++) cols[i] = cols[i].Trim();
+
+                // Base block (0..7) then MAG at index 8.
+                Assert.Equal("CON", cols[7]);
+                Assert.Equal("MAG", cols[8]);
+                // Growth block (9..15) then MAG at index 16.
+                Assert.Equal("LUCK", cols[15]);
+                Assert.Equal("MAG", cols[16]);
+                // Weplevel shifted by +2 (one MAG per active block).
+                Assert.Equal("Sword", cols[17]);
+                Assert.Equal("Dark", cols[24]);
+                Assert.Equal(25, cols.Length); // 8+1 + 7+1 + 8
+                Assert.Equal(2, cols.Count(c => c == "MAG"));
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+                MagicSplitUtil.ClearCache();
+            }
+        }
+
+        /// <summary>
+        /// Full Unit MagicSplit VALUE round-trip INCLUDING a SELECTED unit id
+        /// &gt; 0 (catches blockers 1+2: the right id is read/written). Seeds
+        /// distinct base+growth MAG per unit, exports anchored to the selected
+        /// id, then a SINGLE-ROW import (ExportSelected/ImportSelected shape)
+        /// with DIFFERENT MAG values must land on the SELECTED unit, not unit 0.
+        /// </summary>
+        [Fact]
+        public void Unit_MagicSplitFE8U_SelectedId_ValueRoundTrip()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                var rom = FE8UMagicSplitTestRom.Make();
+                CoreState.ROM = rom;
+                MagicSplitUtil.ClearCache();
+                Assert.Equal(MagicSplitUtil.magic_split_enum.FE8UMAGIC, MagicSplitUtil.SearchMagicSplit());
+
+                const uint dataSize = 52;
+                uint a0 = 0x500, a4 = 0x500 + 4 * dataSize;
+
+                var mgr = new UnitCsvManager(
+                    useClipboard: false, includeUID: true, includeHeader: false,
+                    includeName: false, includeBaseStats: true, includeGrowths: true,
+                    includeWepLevel: false, growthsAsDecimal: false);
+
+                // Seed: unit 0 -> base 1/grow 2 ; unit 4 -> base 7/grow 9.
+                using (FE8UMagicSplitTestRom.BeginUndoScope(rom))
+                {
+                    var u = ROM.GetAmbientUndoData()!;
+                    MagicSplitUtil.WriteUnitBaseMagicExtends(0, a0, ToByte(1), u);
+                    MagicSplitUtil.WriteUnitGrowMagicExtends(0, a0, ToByte(2), u);
+                    MagicSplitUtil.WriteUnitBaseMagicExtends(4, a4, ToByte(7), u);
+                    MagicSplitUtil.WriteUnitGrowMagicExtends(4, a4, ToByte(9), u);
+                }
+
+                // Export the SELECTED unit (id 4) — anchored to startingUid 4.
+                string selectedCsv = mgr.BuildExportCsv(rom, new[] { a4 }, startingUid: 4);
+                // The exported MAG-base (col 8 = uid + 8 base) must be 7 (unit 4),
+                // proving export reads MAG from the selected id, not unit 0.
+                string[] expCols = selectedCsv.Split('\n')[0].Split(',');
+                Assert.Equal("7", expCols[9].Trim()); // uid(0) + 8 base(1..8) -> MAG at 9
+
+                // Now SINGLE-ROW import a CSV with DIFFERENT MAG for the SELECTED
+                // unit id 4 (singleRowId=4): base 22 / grow 31. unit 0 must be
+                // untouched. Row shape: uid, <8 base>, MAG_base, <7 growth>, MAG_grow.
+                string importCsv =
+                    "4, 1, 2, 3, 4, 5, 6, 7, 8, 22, 10, 11, 12, 13, 14, 15, 16, 31\n";
+                using (FE8UMagicSplitTestRom.BeginUndoScope(rom))
+                {
+                    int n = mgr.ApplyImportCsv(rom, importCsv, new[] { a4 }, singleRowId: 4);
+                    Assert.Equal(1, n);
+                }
+
+                // Selected unit 4 got the imported MAG.
+                Assert.Equal((sbyte)22, (sbyte)MagicSplitUtil.GetUnitBaseMagicExtends(4, a4));
+                Assert.Equal((sbyte)31, (sbyte)MagicSplitUtil.GetUnitGrowMagicExtends(4, a4));
+                // Unit 0 unchanged (proves the write did NOT go to unit 0).
+                Assert.Equal((sbyte)1, (sbyte)MagicSplitUtil.GetUnitBaseMagicExtends(0, a0));
+                Assert.Equal((sbyte)2, (sbyte)MagicSplitUtil.GetUnitGrowMagicExtends(0, a0));
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+                MagicSplitUtil.ClearCache();
+            }
+        }
+
+        /// <summary>
+        /// MagicSplit import without an active ambient undo scope must FAIL FAST.
+        /// </summary>
+        [Fact]
+        public void Unit_MagicSplitFE8U_ImportWithoutUndoScope_Throws()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                var rom = FE8UMagicSplitTestRom.Make();
+                CoreState.ROM = rom;
+                MagicSplitUtil.ClearCache();
+                Assert.Equal(MagicSplitUtil.magic_split_enum.FE8UMAGIC, MagicSplitUtil.SearchMagicSplit());
+
+                var mgr = new UnitCsvManager(
+                    useClipboard: false, includeUID: false, includeHeader: false,
+                    includeName: false, includeBaseStats: true, includeGrowths: false,
+                    includeWepLevel: false, growthsAsDecimal: false);
+                // base(8) + MAG(1) cols, no undo scope open.
+                string csv = "1, 2, 3, 4, 5, 6, 7, 8, 9\n";
+                Assert.Throws<InvalidOperationException>(
+                    () => mgr.ApplyImportCsv(rom, csv, new[] { 0x500u }));
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+                MagicSplitUtil.ClearCache();
+            }
+        }
+
+        static uint ToByte(int v) => (uint)(byte)(sbyte)v;
+
         static string? FindRepoRoot()
         {
             string start = AppDomain.CurrentDomain.BaseDirectory;

--- a/FEBuilderGBA.Avalonia.Tests/UnitEditorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/UnitEditorParityTests.cs
@@ -763,6 +763,71 @@ namespace FEBuilderGBA.Avalonia.Tests
             }
         }
 
+        /// <summary>
+        /// #1016 back-compat: importing a LEGACY pre-#1016 Avalonia CSV (base +
+        /// growth + weplevel, NO MAG columns) into a FE8UMAGIC ROM must NOT
+        /// consume a stat cell as MAG and shift the rest. With the old
+        /// <c>colIdx &lt; cols.Length</c> guard, the first growth value would be
+        /// written as base MAG, every growth column would shift by one, and
+        /// weplevel parsing would shift too — corrupting both the normal stat
+        /// bytes and the MagicSplit table. The fix gates MAG consumption on the
+        /// row's column count matching the with-MAG layout. Distinct per-column
+        /// values make the shift observable.
+        /// </summary>
+        [Fact]
+        public void Unit_MagicSplitFE8U_LegacyNoMagCsv_DoesNotShiftColumns()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                var rom = FE8UMagicSplitTestRom.Make();
+                CoreState.ROM = rom;
+                MagicSplitUtil.ClearCache();
+                Assert.Equal(MagicSplitUtil.magic_split_enum.FE8UMAGIC, MagicSplitUtil.SearchMagicSplit());
+
+                uint addr = 0x500;
+                var mgr = new UnitCsvManager(
+                    useClipboard: false, includeUID: true, includeHeader: false,
+                    includeName: false, includeBaseStats: true, includeGrowths: true,
+                    includeWepLevel: true, growthsAsDecimal: false);
+
+                // Seed sentinel MAG for unit 0 so we can prove it survives.
+                using (FE8UMagicSplitTestRom.BeginUndoScope(rom))
+                {
+                    var u = ROM.GetAmbientUndoData()!;
+                    MagicSplitUtil.WriteUnitBaseMagicExtends(0, addr, ToByte(77), u);
+                    MagicSplitUtil.WriteUnitGrowMagicExtends(0, addr, ToByte(88), u);
+                }
+
+                // Legacy row: uid(1) + base(8) + growth(7) + weplevel(8) = 24
+                // columns, NO MAG. The with-MAG layout would be 26 columns.
+                string legacy =
+                    "0, 30, 31, 32, 33, 34, 35, 36, 37, 40, 41, 42, 43, 44, 45, 46, 1, 2, 3, 4, 5, 6, 7, 8\n";
+                using (FE8UMagicSplitTestRom.BeginUndoScope(rom))
+                {
+                    int n = mgr.ApplyImportCsv(rom, legacy, new[] { addr }, singleRowId: 0);
+                    Assert.Equal(1, n);
+                }
+
+                // Normal stats land in the right offsets (no shift).
+                for (uint o = 12; o <= 19; o++) Assert.Equal((sbyte)(30 + (o - 12)), (sbyte)rom.u8(addr + o));
+                for (uint o = 28; o <= 34; o++) Assert.Equal((sbyte)(40 + (o - 28)), (sbyte)rom.u8(addr + o));
+                for (uint o = 20; o <= 27; o++) Assert.Equal((sbyte)(1 + (o - 20)), (sbyte)rom.u8(addr + o));
+                // The growth LUCK (offset 34) is 46, NOT 1 (the buggy shift would
+                // have read the first weplevel value here).
+                Assert.Equal((sbyte)46, (sbyte)rom.u8(addr + 34));
+                // The sentinel MAG values are UNTOUCHED (not overwritten by a
+                // shifted stat cell).
+                Assert.Equal((sbyte)77, (sbyte)MagicSplitUtil.GetUnitBaseMagicExtends(0, addr));
+                Assert.Equal((sbyte)88, (sbyte)MagicSplitUtil.GetUnitGrowMagicExtends(0, addr));
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+                MagicSplitUtil.ClearCache();
+            }
+        }
+
         static uint ToByte(int v) => (uint)(byte)(sbyte)v;
 
         static string? FindRepoRoot()

--- a/FEBuilderGBA.Avalonia/Services/ClassCsvManager.cs
+++ b/FEBuilderGBA.Avalonia/Services/ClassCsvManager.cs
@@ -17,9 +17,16 @@
 // the file/clipboard dialogs live in ExportAllAsync / ExportSelectedAsync /
 // ImportAllAsync / ImportSelectedAsync (Avalonia-only).
 //
-// FE8UMAGIC magic-split bytes are out of scope (same as UnitCsvManager — the
-// MagicSplit columns require WinForms-only patch detection; default returns
-// false). The HardCoding-warning hook on the editor host is a separate path.
+// FE8UMAGIC magic-split bytes (#1016): when the active ROM has the FE8U
+// MagicSplit (FE8UMAGIC) patch installed, an extra "MAG" column is appended at
+// the END of the base-stat block and the END of the growth block (mirrors WF
+// CsvManager). The Core MagicSplitUtil.Get/Write{Class}{Base,Grow}MagicExtends
+// helpers index by the numeric CLASS id (NOT the addr), so export threads
+// `uid = startingUid + i` and import derives `rowId` in the same branch as
+// `addr`. Every MAG addition is gated on `isUsingMagicSplit`, so vanilla /
+// FE6 / FE8J / FE7J output stays byte-identical. The MAG path is only enabled
+// when the passed ROM IS the active CoreState.ROM (the MagicExtends helpers
+// read/write through CoreState.ROM).
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -97,12 +104,30 @@ namespace FEBuilderGBA.Avalonia.Services
             if (rom == null) throw new ArgumentNullException(nameof(rom));
             if (rowAddresses == null) throw new ArgumentNullException(nameof(rowAddresses));
 
+            bool isUsingMagicSplit = IsUsingMagicSplit(rom);
+
             var sb = new StringBuilder();
             if (_includeHeader)
-                sb.Append(BuildHeader());
+                sb.Append(BuildHeader(isUsingMagicSplit));
             for (int i = 0; i < rowAddresses.Count; i++)
-                sb.Append(BuildDataRow(rom, startingUid + (uint)i, rowAddresses[i]));
+                sb.Append(BuildDataRow(rom, startingUid + (uint)i, rowAddresses[i], isUsingMagicSplit));
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// #1016 — true when the active ROM has the FE8U MagicSplit (FE8UMAGIC)
+        /// patch installed. Only enabled when the passed <paramref name="rom"/>
+        /// IS the active <see cref="CoreState.ROM"/> with a non-null
+        /// <c>RomInfo</c> (the <c>MagicSplitUtil</c> Get/Write helpers read and
+        /// write through <c>CoreState.ROM</c>, so a stale/global-ROM mismatch
+        /// would corrupt the wrong ROM). Vanilla / FE6 / FE8J / FE7J return
+        /// false, keeping CSV output byte-identical to the pre-#1016 behavior.
+        /// </summary>
+        static bool IsUsingMagicSplit(ROM rom)
+        {
+            return ReferenceEquals(rom, CoreState.ROM)
+                && rom?.RomInfo != null
+                && MagicSplitUtil.SearchMagicSplit() == MagicSplitUtil.magic_split_enum.FE8UMAGIC;
         }
 
         /// <summary>
@@ -124,10 +149,42 @@ namespace FEBuilderGBA.Avalonia.Services
         /// </summary>
         /// <returns>Number of rows written.</returns>
         public int ApplyImportCsv(ROM rom, string csv, IReadOnlyList<uint> rowAddresses)
+            => ApplyImportCsv(rom, csv, rowAddresses, singleRowId: null);
+
+        /// <summary>
+        /// #1016 overload — same as <see cref="ApplyImportCsv(ROM,string,IReadOnlyList{uint})"/>
+        /// but lets a single-row import carry the SELECTED class id so the
+        /// FE8U MagicSplit MAG column is written to the correct record. The
+        /// <c>MagicSplitUtil.WriteClass*MagicExtends</c> helpers index by the
+        /// numeric class id (cid*4), NOT by addr, so single-row import must
+        /// know the id (the live UI threads
+        /// <c>ClassList.SelectedOriginalIndex</c>). When
+        /// <paramref name="singleRowId"/> is null the legacy positional id is
+        /// used (back-compat with existing call sites/tests).
+        /// </summary>
+        public int ApplyImportCsv(ROM rom, string csv, IReadOnlyList<uint> rowAddresses, uint? singleRowId)
         {
             if (rom == null) throw new ArgumentNullException(nameof(rom));
             if (csv == null) throw new ArgumentNullException(nameof(csv));
             if (rowAddresses == null) throw new ArgumentNullException(nameof(rowAddresses));
+
+            // #1016: MagicSplit gating + ambient-undo capture. The
+            // MagicSplitUtil.Write* helpers require a non-null Undo.UndoData
+            // (their write_u8(a, v, undodata) would NPE on null). The live UI
+            // import always opens an UndoService.Begin scope (which calls
+            // ROM.BeginUndoScope), and the round-trip tests open
+            // ROM.BeginUndoScope, so the ambient undo is non-null there. If MAG
+            // is active but there is NO ambient undo, FAIL FAST before any
+            // mutation rather than silently skipping MAG after writing the
+            // normal columns (would lose the magic stat on a partial import).
+            bool isUsingMagicSplit = IsUsingMagicSplit(rom);
+            Undo.UndoData? undo = ROM.GetAmbientUndoData();
+            if (isUsingMagicSplit && undo == null)
+            {
+                throw new InvalidOperationException(
+                    "ClassCsvManager: FE8U MagicSplit import requires an active undo scope " +
+                    "(ROM.BeginUndoScope / UndoService.Begin). Aborting before mutation.");
+            }
 
             // Parse via TextFieldParser to match WF CsvManager's tolerant
             // ", " delimiter handling (quoted fields, embedded commas, trim).
@@ -183,9 +240,16 @@ namespace FEBuilderGBA.Avalonia.Services
                 // rather than risk writing to the wrong row. Copilot bot
                 // inline review on PR #570.
                 uint addr;
+                // #1016: derive the numeric class id (rowId) in the SAME branch
+                // as `addr` so the MagicSplit table writes the id that owns the
+                // record we just wrote normal columns to (never a mismatch).
+                uint rowId;
                 if (isSingleRow)
                 {
                     addr = rowAddresses[0];
+                    // Single-row: prefer the explicit threaded selected id; else
+                    // fall back to the positional 0.
+                    rowId = singleRowId ?? 0u;
                     if (_includeName || _includeUID) colIdx++;
                 }
                 else
@@ -209,6 +273,7 @@ namespace FEBuilderGBA.Avalonia.Services
                     if (parsedUid.HasValue && parsedUid.Value < rowAddresses.Count)
                     {
                         addr = rowAddresses[(int)parsedUid.Value];
+                        rowId = parsedUid.Value; // UID-routed: id == the accepted UID.
                     }
                     else if ((_includeUID || _includeName) && !parsedUid.HasValue)
                     {
@@ -221,6 +286,7 @@ namespace FEBuilderGBA.Avalonia.Services
                     else if (i < rowAddresses.Count)
                     {
                         addr = rowAddresses[i]; // positional fallback only when neither UID nor Name was requested.
+                        rowId = (uint)i;        // positional id == the row index.
                     }
                     else
                     {
@@ -239,6 +305,16 @@ namespace FEBuilderGBA.Avalonia.Services
                         rom.write_u8(addr + o, (uint)(byte)ParseStrictSbyte(cols[colIdx].Trim(), csvLine, "base stat"));
                         colIdx++;
                     }
+                    // #1016: MAG base column (after the base block). Guarded on
+                    // colIdx < cols.Length so a non-MagicSplit CSV read against a
+                    // MagicSplit ROM does not over-read. `undo` is non-null here
+                    // (fail-fast above guarantees it when isUsingMagicSplit).
+                    if (isUsingMagicSplit && colIdx < cols.Length)
+                    {
+                        sbyte mv = ParseStrictSbyte(cols[colIdx].Trim(), csvLine, "magic base");
+                        MagicSplitUtil.WriteClassBaseMagicExtends(rowId, addr, (uint)(byte)mv, undo!);
+                        colIdx++;
+                    }
                 }
 
                 if (_includeGrowths)
@@ -251,6 +327,14 @@ namespace FEBuilderGBA.Avalonia.Services
                         float fv = ParseStrictFloat(cols[colIdx].Trim(), csvLine, "growth");
                         sbyte sv = (sbyte)Math.Round(fv * divisor);
                         rom.write_u8(addr + o, (uint)(byte)sv);
+                        colIdx++;
+                    }
+                    // #1016: MAG growth column (after the growth block).
+                    if (isUsingMagicSplit && colIdx < cols.Length)
+                    {
+                        float fv = ParseStrictFloat(cols[colIdx].Trim(), csvLine, "magic growth");
+                        sbyte mv = (sbyte)Math.Round(fv * divisor);
+                        MagicSplitUtil.WriteClassGrowMagicExtends(rowId, addr, (uint)(byte)mv, undo!);
                         colIdx++;
                     }
                 }
@@ -316,7 +400,7 @@ namespace FEBuilderGBA.Avalonia.Services
                 $"ClassCsvManager: invalid {fieldKind} value '{s}' at CSV line {csvLine}. Aborting import.");
         }
 
-        string BuildHeader()
+        string BuildHeader(bool isUsingMagicSplit)
         {
             // Matches WF CsvManager.SetupHeader: emits "Name" only when
             // includeName is set; UID alone does NOT introduce a header column
@@ -328,10 +412,14 @@ namespace FEBuilderGBA.Avalonia.Services
             if (_includeBaseStats)
             {
                 parts.AddRange(new[] { "HP", "STR", "SKL", "SPD", "DEF", "RES", "CON" });
+                // #1016: MAG column appended at the END of the base block.
+                if (isUsingMagicSplit) parts.Add("MAG");
             }
             if (_includeGrowths)
             {
                 parts.AddRange(new[] { "HP", "STR", "SKL", "SPD", "DEF", "RES", "LUCK" });
+                // #1016: MAG column appended at the END of the growth block.
+                if (isUsingMagicSplit) parts.Add("MAG");
             }
             if (_includeWepLevel)
             {
@@ -340,7 +428,7 @@ namespace FEBuilderGBA.Avalonia.Services
             return string.Join(", ", parts) + "\n";
         }
 
-        string BuildDataRow(ROM rom, uint uid, uint addr)
+        string BuildDataRow(ROM rom, uint uid, uint addr, bool isUsingMagicSplit)
         {
             var parts = new List<string>();
 
@@ -360,6 +448,10 @@ namespace FEBuilderGBA.Avalonia.Services
                 // Class-shape offsets 11..17 (no LUCK).
                 for (uint o = 11; o <= 17; o++)
                     parts.Add(((sbyte)rom.u8(addr + o)).ToString(CultureInfo.InvariantCulture));
+                // #1016: MAG base appended after the base block (id-indexed via
+                // the Core helper — NOT a fixed offset).
+                if (isUsingMagicSplit)
+                    parts.Add(((int)(sbyte)MagicSplitUtil.GetClassBaseMagicExtends(uid, addr)).ToString(CultureInfo.InvariantCulture));
             }
 
             if (_includeGrowths)
@@ -369,6 +461,12 @@ namespace FEBuilderGBA.Avalonia.Services
                 {
                     float val = (float)(sbyte)rom.u8(addr + o) / divisor;
                     parts.Add(val.ToString(_growthsAsDecimal ? "0.##" : "0", CultureInfo.InvariantCulture));
+                }
+                // #1016: MAG growth appended after the growth block.
+                if (isUsingMagicSplit)
+                {
+                    float m = (float)(sbyte)MagicSplitUtil.GetClassGrowMagicExtends(uid, addr) / divisor;
+                    parts.Add(m.ToString(_growthsAsDecimal ? "0.##" : "0", CultureInfo.InvariantCulture));
                 }
             }
 
@@ -446,11 +544,20 @@ namespace FEBuilderGBA.Avalonia.Services
         }
 
         /// <summary>Import a single row from a clipboard or file source.</summary>
-        public async Task<int> ImportSelectedAsync(Window owner, ROM rom, uint addr)
+        public Task<int> ImportSelectedAsync(Window owner, ROM rom, uint addr)
+            => ImportSelectedAsync(owner, rom, addr, uid: null);
+
+        /// <summary>
+        /// #1016 — import a single row carrying the SELECTED class id so the
+        /// FE8U MagicSplit MAG column is read into the correct record (the
+        /// <c>WriteClass*MagicExtends</c> helpers index by cid, not addr). The
+        /// live UI threads <c>ClassList.SelectedOriginalIndex</c>.
+        /// </summary>
+        public async Task<int> ImportSelectedAsync(Window owner, ROM rom, uint addr, uint? uid)
         {
             string? csv = await ReadCsvAsync(owner);
             if (csv == null) return 0;
-            return ApplyImportCsv(rom, csv, new[] { addr });
+            return ApplyImportCsv(rom, csv, new[] { addr }, uid);
         }
 
         async Task WriteCsvAsync(Window owner, string csv)

--- a/FEBuilderGBA.Avalonia/Services/ClassCsvManager.cs
+++ b/FEBuilderGBA.Avalonia/Services/ClassCsvManager.cs
@@ -223,12 +223,22 @@ namespace FEBuilderGBA.Avalonia.Services
             // rowAddresses[0]; multi-row imports honor the embedded UID when
             // present so a reordered CSV writes to the correct classes.
             bool isSingleRow = rowAddresses.Count == 1;
+            // #1016: the number of columns a row must have to carry the new
+            // FE8U MagicSplit MAG columns. A legacy pre-#1016 CSV (no MAG) has
+            // ExpectedColumnCount(false) columns; only consume MAG cells when a
+            // row's actual count matches ExpectedColumnCount(true). Without this
+            // a legacy CSV's first growth value would be read as base MAG and
+            // shift every following column.
+            int expectedWithMag = ExpectedColumnCount(withMag: true);
             for (int i = 0; i + startRow < rows.Count; i++)
             {
                 string[] cols = rows[i + startRow];
                 if (cols.Length == 0 || (cols.Length == 1 && string.IsNullOrWhiteSpace(cols[0]))) continue;
                 int colIdx = 0;
                 int csvLine = i + startRow + 1; // 1-based for error messages.
+                // #1016: this row carries MAG only when its column count matches
+                // the with-MAG layout (not merely "there are more columns").
+                bool rowHasMag = isUsingMagicSplit && cols.Length == expectedWithMag;
 
                 // Determine the destination address. Default = positional
                 // mapping (matches WF behavior when neither UID nor Name is
@@ -305,11 +315,12 @@ namespace FEBuilderGBA.Avalonia.Services
                         rom.write_u8(addr + o, (uint)(byte)ParseStrictSbyte(cols[colIdx].Trim(), csvLine, "base stat"));
                         colIdx++;
                     }
-                    // #1016: MAG base column (after the base block). Guarded on
-                    // colIdx < cols.Length so a non-MagicSplit CSV read against a
-                    // MagicSplit ROM does not over-read. `undo` is non-null here
-                    // (fail-fast above guarantees it when isUsingMagicSplit).
-                    if (isUsingMagicSplit && colIdx < cols.Length)
+                    // #1016: MAG base column (after the base block). Gated on
+                    // rowHasMag (row column count matches the with-MAG layout) so
+                    // a legacy no-MAG CSV imported into a MagicSplit ROM does NOT
+                    // consume a growth cell as MAG and shift the rest. `undo` is
+                    // non-null here (fail-fast above guarantees it).
+                    if (rowHasMag && colIdx < cols.Length)
                     {
                         sbyte mv = ParseStrictSbyte(cols[colIdx].Trim(), csvLine, "magic base");
                         MagicSplitUtil.WriteClassBaseMagicExtends(rowId, addr, (uint)(byte)mv, undo!);
@@ -329,8 +340,9 @@ namespace FEBuilderGBA.Avalonia.Services
                         rom.write_u8(addr + o, (uint)(byte)sv);
                         colIdx++;
                     }
-                    // #1016: MAG growth column (after the growth block).
-                    if (isUsingMagicSplit && colIdx < cols.Length)
+                    // #1016: MAG growth column (after the growth block). Gated on
+                    // rowHasMag (see the base-MAG read) for legacy-CSV safety.
+                    if (rowHasMag && colIdx < cols.Length)
                     {
                         float fv = ParseStrictFloat(cols[colIdx].Trim(), csvLine, "magic growth");
                         sbyte mv = (sbyte)Math.Round(fv * divisor);
@@ -356,6 +368,28 @@ namespace FEBuilderGBA.Avalonia.Services
         }
 
         // ------ private helpers ------
+
+        /// <summary>
+        /// #1016 — number of CSV columns a data row is expected to have for the
+        /// current export option flags. <paramref name="withMag"/> adds the FE8U
+        /// MagicSplit "MAG" column at the end of the base block (offsets 11..17)
+        /// and the end of the growth block (offsets 27..33). Import compares a
+        /// row's actual column count to <c>ExpectedColumnCount(true)</c> to
+        /// decide whether the row really carries the new MAG columns or is a
+        /// legacy pre-#1016 CSV — so a legacy CSV imported into a FE8UMAGIC ROM
+        /// is NOT mis-parsed by consuming a stat cell as MAG. Mirrors the
+        /// column layout emitted by <c>BuildHeader</c>/<c>BuildDataRow</c>:
+        /// Name/UID prefix (1), base (7), growth (7), weplevel (8).
+        /// </summary>
+        int ExpectedColumnCount(bool withMag)
+        {
+            int n = 0;
+            if (_includeName || _includeUID) n += 1;
+            if (_includeBaseStats) n += 7 + (withMag ? 1 : 0);
+            if (_includeGrowths) n += 7 + (withMag ? 1 : 0);
+            if (_includeWepLevel) n += 8;
+            return n;
+        }
 
         /// <summary>
         /// Try to parse a float string using BOTH invariant culture (the

--- a/FEBuilderGBA.Avalonia/Services/UnitCsvManager.cs
+++ b/FEBuilderGBA.Avalonia/Services/UnitCsvManager.cs
@@ -17,10 +17,18 @@
 // ImportAllAsync / ImportSelectedAsync (Avalonia-only).
 //
 // Note: this is a Unit-shape port. The original WF CsvManager also handles
-// Class records via an exportAsClass flag, plus FE8UMAGIC magic-split bytes;
-// neither is in scope for #413. The UnitCsvManager.IsMagicSplitInstalled
-// hook returns false unconditionally (matches the no-patch-installed default
-// observed in the gap-sweep test ROMs and the Avalonia headless test runs).
+// Class records via an exportAsClass flag (that lives in ClassCsvManager here).
+//
+// FE8UMAGIC magic-split (#1016): when the active ROM has the FE8U MagicSplit
+// (FE8UMAGIC) patch installed, an extra "MAG" column is appended at the END of
+// the base-stat block and the END of the growth block (mirrors WF CsvManager).
+// The Core MagicSplitUtil.Get/Write{Unit}{Base,Grow}MagicExtends helpers index
+// by the numeric UNIT id (uid*2), NOT the addr, so export threads
+// `uid = startingUid + i` and import derives `rowId` in the same branch as
+// `addr`. Every MAG addition is gated on `isUsingMagicSplit`, so vanilla /
+// FE6 / FE8J / FE7J output stays byte-identical. The MAG path is only enabled
+// when the passed ROM IS the active CoreState.ROM (the MagicExtends helpers
+// read/write through CoreState.ROM).
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -77,16 +85,47 @@ namespace FEBuilderGBA.Avalonia.Services
         /// in '\n' per data row (matches WF CsvManager output shape).
         /// </summary>
         public string BuildExportCsv(ROM rom, IReadOnlyList<uint> rowAddresses)
+            => BuildExportCsv(rom, rowAddresses, startingUid: 0);
+
+        /// <summary>
+        /// #1016 — build the CSV anchoring the UID column to
+        /// <paramref name="startingUid"/> rather than 0. Mirrors the
+        /// <see cref="ClassCsvManager"/> overload. Used by
+        /// <see cref="ExportSelectedAsync(Window,ROM,uint,uint)"/> so a single
+        /// exported unit row carries the SELECTED unit's id. This also makes
+        /// the FE8U MagicSplit MAG column read from the correct unit record —
+        /// the <c>MagicSplitUtil.GetUnit*MagicExtends</c> helpers index by
+        /// uid*2, NOT by addr, so selected export of any unit other than row 0
+        /// would otherwise read MAG from unit 0.
+        /// </summary>
+        public string BuildExportCsv(ROM rom, IReadOnlyList<uint> rowAddresses, uint startingUid)
         {
             if (rom == null) throw new ArgumentNullException(nameof(rom));
             if (rowAddresses == null) throw new ArgumentNullException(nameof(rowAddresses));
 
+            bool isUsingMagicSplit = IsUsingMagicSplit(rom);
+
             var sb = new StringBuilder();
             if (_includeHeader)
-                sb.Append(BuildHeader());
+                sb.Append(BuildHeader(isUsingMagicSplit));
             for (int i = 0; i < rowAddresses.Count; i++)
-                sb.Append(BuildDataRow(rom, (uint)i, rowAddresses[i]));
+                sb.Append(BuildDataRow(rom, startingUid + (uint)i, rowAddresses[i], isUsingMagicSplit));
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// #1016 — true when the active ROM has the FE8U MagicSplit (FE8UMAGIC)
+        /// patch installed. Only enabled when the passed <paramref name="rom"/>
+        /// IS the active <see cref="CoreState.ROM"/> with a non-null
+        /// <c>RomInfo</c> (the <c>MagicSplitUtil</c> Get/Write helpers read and
+        /// write through <c>CoreState.ROM</c>). Vanilla / FE6 / FE8J / FE7J
+        /// return false, keeping CSV output byte-identical to pre-#1016.
+        /// </summary>
+        static bool IsUsingMagicSplit(ROM rom)
+        {
+            return ReferenceEquals(rom, CoreState.ROM)
+                && rom?.RomInfo != null
+                && MagicSplitUtil.SearchMagicSplit() == MagicSplitUtil.magic_split_enum.FE8UMAGIC;
         }
 
         /// <summary>
@@ -108,10 +147,40 @@ namespace FEBuilderGBA.Avalonia.Services
         /// </summary>
         /// <returns>Number of rows written.</returns>
         public int ApplyImportCsv(ROM rom, string csv, IReadOnlyList<uint> rowAddresses)
+            => ApplyImportCsv(rom, csv, rowAddresses, singleRowId: null);
+
+        /// <summary>
+        /// #1016 overload — same as <see cref="ApplyImportCsv(ROM,string,IReadOnlyList{uint})"/>
+        /// but lets a single-row import carry the SELECTED unit id so the FE8U
+        /// MagicSplit MAG column is written to the correct record. The
+        /// <c>MagicSplitUtil.WriteUnit*MagicExtends</c> helpers index by the
+        /// numeric unit id (uid*2), NOT by addr, so single-row import must know
+        /// the id (the live UI threads <c>UnitList.SelectedOriginalIndex</c>).
+        /// When <paramref name="singleRowId"/> is null the legacy positional id
+        /// is used (back-compat with existing call sites/tests).
+        /// </summary>
+        public int ApplyImportCsv(ROM rom, string csv, IReadOnlyList<uint> rowAddresses, uint? singleRowId)
         {
             if (rom == null) throw new ArgumentNullException(nameof(rom));
             if (csv == null) throw new ArgumentNullException(nameof(csv));
             if (rowAddresses == null) throw new ArgumentNullException(nameof(rowAddresses));
+
+            // #1016: MagicSplit gating + ambient-undo capture. The
+            // MagicSplitUtil.Write* helpers require a non-null Undo.UndoData.
+            // The live UI import always opens an UndoService.Begin scope (which
+            // calls ROM.BeginUndoScope), and the round-trip tests open
+            // ROM.BeginUndoScope, so the ambient undo is non-null there. If MAG
+            // is active but there is NO ambient undo, FAIL FAST before any
+            // mutation rather than silently skipping MAG after writing the
+            // normal columns.
+            bool isUsingMagicSplit = IsUsingMagicSplit(rom);
+            Undo.UndoData? undo = ROM.GetAmbientUndoData();
+            if (isUsingMagicSplit && undo == null)
+            {
+                throw new InvalidOperationException(
+                    "UnitCsvManager: FE8U MagicSplit import requires an active undo scope " +
+                    "(ROM.BeginUndoScope / UndoService.Begin). Aborting before mutation.");
+            }
 
             // Parse via TextFieldParser to match WF CsvManager's tolerant
             // ", " delimiter handling (quoted fields, embedded commas, trim).
@@ -151,9 +220,14 @@ namespace FEBuilderGBA.Avalonia.Services
                 // a "Name(UID)" tail, parse the embedded UID and look it up
                 // in rowAddresses by index.
                 uint addr;
+                // #1016: derive the numeric unit id (rowId) in the SAME branch
+                // as `addr` so the MagicSplit table writes the id that owns the
+                // record we just wrote normal columns to (never a mismatch).
+                uint rowId;
                 if (isSingleRow)
                 {
                     addr = rowAddresses[0];
+                    rowId = singleRowId ?? 0u;
                     if (_includeName || _includeUID) colIdx++;
                 }
                 else
@@ -175,9 +249,15 @@ namespace FEBuilderGBA.Avalonia.Services
                     }
 
                     if (parsedUid.HasValue && parsedUid.Value < rowAddresses.Count)
+                    {
                         addr = rowAddresses[(int)parsedUid.Value];
+                        rowId = parsedUid.Value; // UID-routed: id == the accepted UID.
+                    }
                     else if (i < rowAddresses.Count)
+                    {
                         addr = rowAddresses[i]; // fall back to positional
+                        rowId = (uint)i;        // positional id == the row index.
+                    }
                     else
                         continue; // ran out of target rows
                 }
@@ -190,6 +270,17 @@ namespace FEBuilderGBA.Avalonia.Services
                         if (colIdx >= cols.Length) break;
                         if (sbyte.TryParse(cols[colIdx].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out sbyte sv))
                             rom.write_u8(addr + o, (uint)(byte)sv);
+                        colIdx++;
+                    }
+                    // #1016: MAG base column (after the base block). Guarded on
+                    // colIdx < cols.Length so a non-MagicSplit CSV read against a
+                    // MagicSplit ROM does not over-read. `undo` is non-null here
+                    // (fail-fast above guarantees it when isUsingMagicSplit).
+                    // Lenient TryParse to match the Unit importer's style.
+                    if (isUsingMagicSplit && colIdx < cols.Length)
+                    {
+                        if (sbyte.TryParse(cols[colIdx].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out sbyte mv))
+                            MagicSplitUtil.WriteUnitBaseMagicExtends(rowId, addr, (uint)(byte)mv, undo!);
                         colIdx++;
                     }
                 }
@@ -205,6 +296,16 @@ namespace FEBuilderGBA.Avalonia.Services
                         {
                             sbyte sv = (sbyte)Math.Round(fv * divisor);
                             rom.write_u8(addr + o, (uint)(byte)sv);
+                        }
+                        colIdx++;
+                    }
+                    // #1016: MAG growth column (after the growth block).
+                    if (isUsingMagicSplit && colIdx < cols.Length)
+                    {
+                        if (float.TryParse(cols[colIdx].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float fmv))
+                        {
+                            sbyte mv = (sbyte)Math.Round(fmv * divisor);
+                            MagicSplitUtil.WriteUnitGrowMagicExtends(rowId, addr, (uint)(byte)mv, undo!);
                         }
                         colIdx++;
                     }
@@ -229,7 +330,7 @@ namespace FEBuilderGBA.Avalonia.Services
 
         // ------ private helpers ------
 
-        string BuildHeader()
+        string BuildHeader(bool isUsingMagicSplit)
         {
             // Matches WF CsvManager.SetupHeader: emits "Name, " only when
             // includeName is set; UID alone does NOT introduce a header column
@@ -241,10 +342,14 @@ namespace FEBuilderGBA.Avalonia.Services
             if (_includeBaseStats)
             {
                 parts.AddRange(new[] { "HP", "STR", "SKL", "SPD", "DEF", "RES", "LUCK", "CON" });
+                // #1016: MAG column appended at the END of the base block.
+                if (isUsingMagicSplit) parts.Add("MAG");
             }
             if (_includeGrowths)
             {
                 parts.AddRange(new[] { "HP", "STR", "SKL", "SPD", "DEF", "RES", "LUCK" });
+                // #1016: MAG column appended at the END of the growth block.
+                if (isUsingMagicSplit) parts.Add("MAG");
             }
             if (_includeWepLevel)
             {
@@ -253,7 +358,7 @@ namespace FEBuilderGBA.Avalonia.Services
             return string.Join(", ", parts) + "\n";
         }
 
-        string BuildDataRow(ROM rom, uint uid, uint addr)
+        string BuildDataRow(ROM rom, uint uid, uint addr, bool isUsingMagicSplit)
         {
             var parts = new List<string>();
 
@@ -272,6 +377,10 @@ namespace FEBuilderGBA.Avalonia.Services
             {
                 for (uint o = 12; o <= 19; o++)
                     parts.Add(((sbyte)rom.u8(addr + o)).ToString(CultureInfo.InvariantCulture));
+                // #1016: MAG base appended after the base block (id-indexed via
+                // the Core helper — NOT a fixed offset).
+                if (isUsingMagicSplit)
+                    parts.Add(((int)(sbyte)MagicSplitUtil.GetUnitBaseMagicExtends(uid, addr)).ToString(CultureInfo.InvariantCulture));
             }
 
             if (_includeGrowths)
@@ -281,6 +390,12 @@ namespace FEBuilderGBA.Avalonia.Services
                 {
                     float val = (float)(sbyte)rom.u8(addr + o) / divisor;
                     parts.Add(val.ToString(_growthsAsDecimal ? "0.##" : "0", CultureInfo.InvariantCulture));
+                }
+                // #1016: MAG growth appended after the growth block.
+                if (isUsingMagicSplit)
+                {
+                    float m = (float)(sbyte)MagicSplitUtil.GetUnitGrowMagicExtends(uid, addr) / divisor;
+                    parts.Add(m.ToString(_growthsAsDecimal ? "0.##" : "0", CultureInfo.InvariantCulture));
                 }
             }
 
@@ -328,10 +443,24 @@ namespace FEBuilderGBA.Avalonia.Services
             await WriteCsvAsync(owner, csv);
         }
 
-        /// <summary>Export a single row. Routes to clipboard or file dialog.</summary>
-        public async Task ExportSelectedAsync(Window owner, ROM rom, uint addr)
+        /// <summary>
+        /// Export a single row. Routes to clipboard or file dialog. The
+        /// backwards-compatible overload exports with UID=0; prefer the
+        /// uid-aware overload in new code so a single exported unit row carries
+        /// the SELECTED unit's id (and reads the FE8U MagicSplit MAG column
+        /// from the correct record). #1016.
+        /// </summary>
+        public Task ExportSelectedAsync(Window owner, ROM rom, uint addr)
+            => ExportSelectedAsync(owner, rom, addr, uid: 0);
+
+        /// <summary>
+        /// #1016 — export a single row anchoring the UID column (and the FE8U
+        /// MagicSplit MAG column) to the SELECTED unit's id. The live UI passes
+        /// <c>UnitList.SelectedOriginalIndex</c>.
+        /// </summary>
+        public async Task ExportSelectedAsync(Window owner, ROM rom, uint addr, uint uid)
         {
-            string csv = BuildExportCsv(rom, new[] { addr });
+            string csv = BuildExportCsv(rom, new[] { addr }, startingUid: uid);
             await WriteCsvAsync(owner, csv);
         }
 
@@ -344,11 +473,20 @@ namespace FEBuilderGBA.Avalonia.Services
         }
 
         /// <summary>Import a single row from a clipboard or file source.</summary>
-        public async Task<int> ImportSelectedAsync(Window owner, ROM rom, uint addr)
+        public Task<int> ImportSelectedAsync(Window owner, ROM rom, uint addr)
+            => ImportSelectedAsync(owner, rom, addr, uid: null);
+
+        /// <summary>
+        /// #1016 — import a single row carrying the SELECTED unit id so the
+        /// FE8U MagicSplit MAG column is read into the correct record (the
+        /// <c>WriteUnit*MagicExtends</c> helpers index by uid, not addr). The
+        /// live UI threads <c>UnitList.SelectedOriginalIndex</c>.
+        /// </summary>
+        public async Task<int> ImportSelectedAsync(Window owner, ROM rom, uint addr, uint? uid)
         {
             string? csv = await ReadCsvAsync(owner);
             if (csv == null) return 0;
-            return ApplyImportCsv(rom, csv, new[] { addr });
+            return ApplyImportCsv(rom, csv, new[] { addr }, uid);
         }
 
         async Task WriteCsvAsync(Window owner, string csv)

--- a/FEBuilderGBA.Avalonia/Services/UnitCsvManager.cs
+++ b/FEBuilderGBA.Avalonia/Services/UnitCsvManager.cs
@@ -208,11 +208,21 @@ namespace FEBuilderGBA.Avalonia.Services
             // rowAddresses[0]; multi-row imports honor the embedded UID when
             // present so a reordered CSV writes to the correct units.
             bool isSingleRow = rowAddresses.Count == 1;
+            // #1016: the number of columns a row must have to carry the new
+            // FE8U MagicSplit MAG columns. A legacy pre-#1016 CSV (no MAG) has
+            // ExpectedColumnCount(false) columns; only consume MAG cells when a
+            // row's actual count matches ExpectedColumnCount(true). Without this
+            // a legacy CSV's first growth value would be read as base MAG and
+            // shift every following column.
+            int expectedWithMag = ExpectedColumnCount(withMag: true);
             for (int i = 0; i + startRow < rows.Count; i++)
             {
                 string[] cols = rows[i + startRow];
                 if (cols.Length == 0 || (cols.Length == 1 && string.IsNullOrWhiteSpace(cols[0]))) continue;
                 int colIdx = 0;
+                // #1016: this row carries MAG only when its column count matches
+                // the with-MAG layout (not merely "there are more columns").
+                bool rowHasMag = isUsingMagicSplit && cols.Length == expectedWithMag;
 
                 // Determine the destination address. Default = positional
                 // mapping (matches WF behavior when neither UID nor Name is
@@ -272,12 +282,13 @@ namespace FEBuilderGBA.Avalonia.Services
                             rom.write_u8(addr + o, (uint)(byte)sv);
                         colIdx++;
                     }
-                    // #1016: MAG base column (after the base block). Guarded on
-                    // colIdx < cols.Length so a non-MagicSplit CSV read against a
-                    // MagicSplit ROM does not over-read. `undo` is non-null here
-                    // (fail-fast above guarantees it when isUsingMagicSplit).
-                    // Lenient TryParse to match the Unit importer's style.
-                    if (isUsingMagicSplit && colIdx < cols.Length)
+                    // #1016: MAG base column (after the base block). Gated on
+                    // rowHasMag (row column count matches the with-MAG layout) so
+                    // a legacy no-MAG CSV imported into a MagicSplit ROM does NOT
+                    // consume a growth cell as MAG and shift the rest. `undo` is
+                    // non-null here (fail-fast above guarantees it). Lenient
+                    // TryParse to match the Unit importer's style.
+                    if (rowHasMag && colIdx < cols.Length)
                     {
                         if (sbyte.TryParse(cols[colIdx].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out sbyte mv))
                             MagicSplitUtil.WriteUnitBaseMagicExtends(rowId, addr, (uint)(byte)mv, undo!);
@@ -299,8 +310,9 @@ namespace FEBuilderGBA.Avalonia.Services
                         }
                         colIdx++;
                     }
-                    // #1016: MAG growth column (after the growth block).
-                    if (isUsingMagicSplit && colIdx < cols.Length)
+                    // #1016: MAG growth column (after the growth block). Gated on
+                    // rowHasMag (see the base-MAG read) for legacy-CSV safety.
+                    if (rowHasMag && colIdx < cols.Length)
                     {
                         if (float.TryParse(cols[colIdx].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float fmv))
                         {
@@ -329,6 +341,28 @@ namespace FEBuilderGBA.Avalonia.Services
         }
 
         // ------ private helpers ------
+
+        /// <summary>
+        /// #1016 — number of CSV columns a data row is expected to have for the
+        /// current export option flags. <paramref name="withMag"/> adds the FE8U
+        /// MagicSplit "MAG" column at the end of the base block (offsets 12..19)
+        /// and the end of the growth block (offsets 28..34). Import compares a
+        /// row's actual column count to <c>ExpectedColumnCount(true)</c> to
+        /// decide whether the row really carries the new MAG columns or is a
+        /// legacy pre-#1016 CSV — so a legacy CSV imported into a FE8UMAGIC ROM
+        /// is NOT mis-parsed by consuming a stat cell as MAG. Mirrors the
+        /// column layout emitted by <see cref="BuildHeader"/>/<c>BuildDataRow</c>:
+        /// Name/UID prefix (1), base (8), growth (7), weplevel (8).
+        /// </summary>
+        int ExpectedColumnCount(bool withMag)
+        {
+            int n = 0;
+            if (_includeName || _includeUID) n += 1;
+            if (_includeBaseStats) n += 8 + (withMag ? 1 : 0);
+            if (_includeGrowths) n += 7 + (withMag ? 1 : 0);
+            if (_includeWepLevel) n += 8;
+            return n;
+        }
 
         string BuildHeader(bool isUsingMagicSplit)
         {

--- a/FEBuilderGBA.Avalonia/Views/ClassEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ClassEditorView.axaml.cs
@@ -966,11 +966,16 @@ namespace FEBuilderGBA.Avalonia.Views
                 var mgr = MakeCsvManager();
                 string? csv = await mgr.ReadCsvForUiAsync(this);
                 if (csv == null) return;
+                // #1016: thread the SELECTED class id (0-based AddressList
+                // index) so the FE8U MagicSplit MAG column is read into the
+                // correct record (WriteClass*MagicExtends index by cid).
+                int selIdx = ClassList.SelectedOriginalIndex;
+                uint? selUid = selIdx >= 0 ? (uint)selIdx : (uint?)null;
                 _undoService.Begin(R._("Import Class CSV"));
                 int written;
                 try
                 {
-                    written = mgr.ApplyImportCsv(rom, csv, new[] { _vm.CurrentAddr });
+                    written = mgr.ApplyImportCsv(rom, csv, new[] { _vm.CurrentAddr }, selUid);
                     _undoService.Commit();
                 }
                 catch { _undoService.Rollback(); throw; }

--- a/FEBuilderGBA.Avalonia/Views/ClassEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ClassEditorView.axaml.cs
@@ -970,12 +970,12 @@ namespace FEBuilderGBA.Avalonia.Views
                 // index) so the FE8U MagicSplit MAG column is read into the
                 // correct record (WriteClass*MagicExtends index by cid).
                 int selIdx = ClassList.SelectedOriginalIndex;
-                uint? selUid = selIdx >= 0 ? (uint)selIdx : (uint?)null;
+                uint? selCid = selIdx >= 0 ? (uint)selIdx : (uint?)null;
                 _undoService.Begin(R._("Import Class CSV"));
                 int written;
                 try
                 {
-                    written = mgr.ApplyImportCsv(rom, csv, new[] { _vm.CurrentAddr }, selUid);
+                    written = mgr.ApplyImportCsv(rom, csv, new[] { _vm.CurrentAddr }, selCid);
                     _undoService.Commit();
                 }
                 catch { _undoService.Rollback(); throw; }

--- a/FEBuilderGBA.Avalonia/Views/UnitEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/UnitEditorView.axaml.cs
@@ -749,7 +749,13 @@ namespace FEBuilderGBA.Avalonia.Views
                 var rom = CoreState.ROM;
                 if (rom == null) return;
                 if (_vm.CurrentAddr == 0) return;
-                await MakeCsvManager().ExportSelectedAsync(this, rom, _vm.CurrentAddr);
+                // #1016: pass the SELECTED unit id (0-based AddressList index)
+                // so the exported single-row CSV carries the correct UID and
+                // the FE8U MagicSplit MAG column reads from the right unit
+                // record. Falls back to 0 when no selection is resolvable.
+                int idx = UnitList.SelectedOriginalIndex;
+                uint uid = idx >= 0 ? (uint)idx : 0u;
+                await MakeCsvManager().ExportSelectedAsync(this, rom, _vm.CurrentAddr, uid);
             }
             catch (Exception ex) { Log.Error("ExportSelected_Click failed: {0}", ex.Message); }
         }
@@ -797,11 +803,16 @@ namespace FEBuilderGBA.Avalonia.Views
                 // Read CSV first (no undo scope across the picker await).
                 string? csv = await mgr.ReadCsvForUiAsync(this);
                 if (csv == null) return;
+                // #1016: thread the SELECTED unit id (0-based AddressList index)
+                // so the FE8U MagicSplit MAG column is read into the correct
+                // record (WriteUnit*MagicExtends index by uid).
+                int selIdx = UnitList.SelectedOriginalIndex;
+                uint? selUid = selIdx >= 0 ? (uint)selIdx : (uint?)null;
                 _undoService.Begin(R._("Import Unit CSV"));
                 int written;
                 try
                 {
-                    written = mgr.ApplyImportCsv(rom, csv, new[] { _vm.CurrentAddr });
+                    written = mgr.ApplyImportCsv(rom, csv, new[] { _vm.CurrentAddr }, selUid);
                     _undoService.Commit();
                 }
                 catch { _undoService.Rollback(); throw; }

--- a/FEBuilderGBA.Core.Tests/MagicSplitUtilFE8UValueTests.cs
+++ b/FEBuilderGBA.Core.Tests/MagicSplitUtilFE8UValueTests.cs
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1016 — FE8U MagicSplit (FE8UMAGIC) value-fidelity tests for the Core
+// MagicSplitUtil Get/Write{Unit,Class}{Base,Grow}MagicExtends helpers.
+//
+// These prove the id-indexed magic-extends helpers round-trip a non-zero
+// signed value for at least two distinct ids. They plant BOTH:
+//   1. the FE8UMAGIC *detection* signature at 0x2BB44 (so SearchMagicSplit
+//      returns FE8UMAGIC), AND
+//   2. the FE8UInit *code* signature (88-byte `bin`, copied verbatim from
+//      MagicSplitUtil.FE8UInit) at a scratch offset past
+//      compress_image_borderline_address, followed by two valid in-ROM
+//      pointers so UnitTag / ClassTag resolve to scratch table regions inside
+//      rom.Data.
+//
+// The CSV-layer value round-trip lives in the Avalonia tests; these Core tests
+// prove the helpers + the id indexing in isolation.
+using System;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class MagicSplitUtilFE8UValueTests
+    {
+        // The 88-byte FE8UInit code signature — copied verbatim from
+        // FEBuilderGBA.Core/MagicSplitUtil.cs FE8UInit() (the pre-2022 variant).
+        static readonly byte[] FE8UInitSignature =
+        {
+            0x00, 0xB5, 0x13, 0x48, 0x86, 0x46, 0x38, 0x68, 0x00, 0x79, 0x40, 0x00, 0x12, 0x49, 0x40, 0x18,
+            0x40, 0x78, 0x50, 0x44, 0x00, 0xF8, 0x01, 0xB4, 0x0E, 0x48, 0x86, 0x46, 0xF8, 0x7A, 0x00, 0xF8,
+            0x41, 0x68, 0x3A, 0x30, 0x00, 0x78, 0x09, 0x79, 0x89, 0x00, 0x0C, 0x4A, 0x52, 0x18, 0x92, 0x78,
+            0x02, 0xBC, 0x76, 0x18, 0x43, 0x18, 0x93, 0x42, 0x00, 0xDD, 0x11, 0x1A, 0x38, 0x1C, 0x7A, 0x30,
+            0x01, 0x70, 0x01, 0xBC, 0x00, 0x99, 0x03, 0x91, 0x01, 0x9B, 0x02, 0x93, 0xC2, 0x46, 0x00, 0x47,
+            0xA0, 0xB9, 0x02, 0x08, 0x30, 0x94, 0x01, 0x08,
+        };
+
+        // Scratch offsets (all 4-aligned, all past FE8U
+        // compress_image_borderline_address = 0xDB000, all < 16 MB ROM size).
+        const uint SigOffset = 0x100000;   // 88-byte FE8UInit signature.
+        const uint UnitTagOffset = 0x200000;
+        const uint ClassTagOffset = 0x300000;
+
+        static ROM MakeFullyPlantedFE8URom()
+        {
+            byte[] data = new byte[0x1000000]; // 16 MB
+            // GBA header game code "BE8E01" → FE8U.
+            byte[] versionBytes = System.Text.Encoding.ASCII.GetBytes("BE8E01");
+            Array.Copy(versionBytes, 0, data, 0xAC, versionBytes.Length);
+
+            // (1) FE8UMAGIC detection signature @ 0x2BB44.
+            byte[] det = { 0x01, 0x4B, 0xA5, 0xF0, 0xC1, 0xFE };
+            Array.Copy(det, 0, data, 0x2BB44, det.Length);
+
+            // (2) FE8UInit code signature @ SigOffset, followed by the two tag
+            //     pointers at SigOffset+88 and SigOffset+92.
+            Array.Copy(FE8UInitSignature, 0, data, (int)SigOffset, FE8UInitSignature.Length);
+            uint p = SigOffset + (uint)FE8UInitSignature.Length;
+            WritePtr(data, p, UnitTagOffset);       // UnitTag = p32(p)
+            WritePtr(data, p + 4, ClassTagOffset);  // ClassTag = p32(p+4)
+
+            var rom = new ROM();
+            rom.LoadLow("test.gba", data, "BE8E01");
+            return rom;
+        }
+
+        static Undo.UndoData MakeUndo(ROM rom) => new Undo.UndoData
+        {
+            time = DateTime.Now,
+            name = "test",
+            list = new System.Collections.Generic.List<Undo.UndoPostion>(),
+            filesize = (uint)rom.Data.Length,
+        };
+
+        // Encode a signed magic value into the (uint)(byte) form the Write
+        // helpers expect (matches the CSV manager's `(uint)(byte)mv`). A method
+        // (not a constant cast) so negative values don't trip the C# checked
+        // constant-conversion rule.
+        static uint SByteToWriteValue(int v) => (uint)(byte)(sbyte)v;
+
+        static void WritePtr(byte[] data, uint at, uint offset)
+        {
+            uint ptr = offset + 0x08000000;
+            data[at + 0] = (byte)(ptr & 0xFF);
+            data[at + 1] = (byte)((ptr >> 8) & 0xFF);
+            data[at + 2] = (byte)((ptr >> 16) & 0xFF);
+            data[at + 3] = (byte)((ptr >> 24) & 0xFF);
+        }
+
+        [Fact]
+        public void FE8UInit_ResolvesTags_DetectionIsFE8UMAGIC()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                var rom = MakeFullyPlantedFE8URom();
+                CoreState.ROM = rom;
+                MagicSplitUtil.ClearCache();
+
+                Assert.Equal(MagicSplitUtil.magic_split_enum.FE8UMAGIC, MagicSplitUtil.SearchMagicSplit());
+                // GetUnitTag() should equal the planted UnitTag offset (proves
+                // FE8UInit walked the signature and read the pointer).
+                Assert.Equal(UnitTagOffset, MagicSplitUtil.GetUnitTag());
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+                MagicSplitUtil.ClearCache();
+            }
+        }
+
+        [Fact]
+        public void WriteThenGet_UnitBaseMagic_RoundTrips_TwoDistinctIds()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                var rom = MakeFullyPlantedFE8URom();
+                CoreState.ROM = rom;
+                MagicSplitUtil.ClearCache();
+                Assert.Equal(MagicSplitUtil.magic_split_enum.FE8UMAGIC, MagicSplitUtil.SearchMagicSplit());
+
+                var undo = MakeUndo(rom);
+                // Two distinct ids with distinct signed values, to prove the
+                // uid*2 indexing addresses different bytes per id.
+                MagicSplitUtil.WriteUnitBaseMagicExtends(1, 0, SByteToWriteValue(7), undo);
+                MagicSplitUtil.WriteUnitBaseMagicExtends(5, 0, SByteToWriteValue(-3), undo);
+
+                Assert.Equal((sbyte)7, (sbyte)MagicSplitUtil.GetUnitBaseMagicExtends(1, 0));
+                Assert.Equal((sbyte)(-3), (sbyte)MagicSplitUtil.GetUnitBaseMagicExtends(5, 0));
+                // Distinct ids don't alias.
+                Assert.NotEqual(
+                    (sbyte)MagicSplitUtil.GetUnitBaseMagicExtends(1, 0),
+                    (sbyte)MagicSplitUtil.GetUnitBaseMagicExtends(5, 0));
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+                MagicSplitUtil.ClearCache();
+            }
+        }
+
+        [Fact]
+        public void WriteThenGet_UnitGrowMagic_RoundTrips()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                var rom = MakeFullyPlantedFE8URom();
+                CoreState.ROM = rom;
+                MagicSplitUtil.ClearCache();
+                Assert.Equal(MagicSplitUtil.magic_split_enum.FE8UMAGIC, MagicSplitUtil.SearchMagicSplit());
+
+                var undo = MakeUndo(rom);
+                MagicSplitUtil.WriteUnitGrowMagicExtends(2, 0, SByteToWriteValue(40), undo);
+                MagicSplitUtil.WriteUnitGrowMagicExtends(9, 0, SByteToWriteValue(25), undo);
+
+                Assert.Equal((sbyte)40, (sbyte)MagicSplitUtil.GetUnitGrowMagicExtends(2, 0));
+                Assert.Equal((sbyte)25, (sbyte)MagicSplitUtil.GetUnitGrowMagicExtends(9, 0));
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+                MagicSplitUtil.ClearCache();
+            }
+        }
+
+        [Fact]
+        public void WriteThenGet_ClassBaseMagic_RoundTrips_TwoDistinctIds()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                var rom = MakeFullyPlantedFE8URom();
+                CoreState.ROM = rom;
+                MagicSplitUtil.ClearCache();
+                Assert.Equal(MagicSplitUtil.magic_split_enum.FE8UMAGIC, MagicSplitUtil.SearchMagicSplit());
+
+                var undo = MakeUndo(rom);
+                // Class indexing is cid*4 (4 magic bytes per class).
+                MagicSplitUtil.WriteClassBaseMagicExtends(1, 0, SByteToWriteValue(6), undo);
+                MagicSplitUtil.WriteClassBaseMagicExtends(4, 0, SByteToWriteValue(-2), undo);
+
+                Assert.Equal((sbyte)6, (sbyte)MagicSplitUtil.GetClassBaseMagicExtends(1, 0));
+                Assert.Equal((sbyte)(-2), (sbyte)MagicSplitUtil.GetClassBaseMagicExtends(4, 0));
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+                MagicSplitUtil.ClearCache();
+            }
+        }
+
+        [Fact]
+        public void WriteThenGet_ClassGrowMagic_RoundTrips()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                var rom = MakeFullyPlantedFE8URom();
+                CoreState.ROM = rom;
+                MagicSplitUtil.ClearCache();
+                Assert.Equal(MagicSplitUtil.magic_split_enum.FE8UMAGIC, MagicSplitUtil.SearchMagicSplit());
+
+                var undo = MakeUndo(rom);
+                MagicSplitUtil.WriteClassGrowMagicExtends(3, 0, SByteToWriteValue(35), undo);
+                MagicSplitUtil.WriteClassGrowMagicExtends(7, 0, SByteToWriteValue(20), undo);
+
+                Assert.Equal((sbyte)35, (sbyte)MagicSplitUtil.GetClassGrowMagicExtends(3, 0));
+                Assert.Equal((sbyte)20, (sbyte)MagicSplitUtil.GetClassGrowMagicExtends(7, 0));
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+                MagicSplitUtil.ClearCache();
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/MagicSplitUtilFE8UValueTests.cs
+++ b/FEBuilderGBA.Core.Tests/MagicSplitUtilFE8UValueTests.cs
@@ -81,10 +81,11 @@ namespace FEBuilderGBA.Core.Tests
         static void WritePtr(byte[] data, uint at, uint offset)
         {
             uint ptr = offset + 0x08000000;
-            data[at + 0] = (byte)(ptr & 0xFF);
-            data[at + 1] = (byte)((ptr >> 8) & 0xFF);
-            data[at + 2] = (byte)((ptr >> 16) & 0xFF);
-            data[at + 3] = (byte)((ptr >> 24) & 0xFF);
+            int i = (int)at;
+            data[i + 0] = (byte)(ptr & 0xFF);
+            data[i + 1] = (byte)((ptr >> 8) & 0xFF);
+            data[i + 2] = (byte)((ptr >> 16) & 0xFF);
+            data[i + 3] = (byte)((ptr >> 24) & 0xFF);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
Adds the FE8U MagicSplit (FE8UMAGIC) magic column to the Avalonia Class/Unit **CSV export + import**. When `MagicSplitUtil.SearchMagicSplit()==FE8UMAGIC` is detected, `ClassCsvManager`/`UnitCsvManager` now append the magic **base** + **growth** columns (via the existing Core `Get/Write*MagicExtends` helpers) at the end of the base block and the end of the growth block, and read them back on import — so a CSV round-trip on a magic-split FE8U ROM preserves the magic stat. **No Core changes.**

Plan + Copilot CLI review (+ a revision resolving 3 blocking points): issue #1016 comment thread (plan accepted, no blocking concerns).

## Scope
Closes #1016.

Three correctness items the review required (all addressed):
- **Numeric id threaded through selected EXPORT + import** (not the addr): `UnitCsvManager` gains the `startingUid`/selected-uid path `ClassCsvManager` had; `UnitEditorView`/`ClassEditorView` pass `…List.SelectedOriginalIndex`. The `MagicExtends` helpers index by `uid*2`/`cid*4`, so this prevents selected unit/class IDs > 0 reading/writing MAG through id 0.
- **`rowId` derived in the same branch as `addr`** (positional=`i`; UID-routed=`parsedUid` only when accepted & `addr==rowAddresses[uid]`; single-row=the explicit selected id).
- **Null-ambient-undo fail-fast**: `ApplyImportCsv` captures `ROM.GetAmbientUndoData()`; if `isUsingMagicSplit && undo==null` it throws **before** any mutation.
- Gated on `ReferenceEquals(rom, CoreState.ROM) && rom.RomInfo != null && …==FE8UMAGIC`, so vanilla FE8U / FE6 / FE7J / FE8J output stays **byte-identical**.

## Proof — exported CSV now carries the MAG column (the feature is file-content, not a visible GUI change)
Generated from a fully-planted FE8U MagicSplit ROM (FE8UMAGIC detection signature **+** the `FE8UInit` code signature so `UnitTag`/`ClassTag` resolve), with distinct MAG values seeded per record:

**Unit export** (`MAG` after the 8-col base block, and after the 7-col growth block):
```
HP, STR, SKL, SPD, DEF, RES, LUCK, CON, MAG, HP, STR, SKL, SPD, DEF, RES, LUCK, MAG
0, 30, 11, 12, 13, 14, 15, 16, 17, 3, 45, 45, 45, 45, 45, 45, 45, 40
1, 31, 12, 13, 14, 15, 16, 17, 18, 5, 50, 50, 50, 50, 50, 50, 50, 55
2, 32, 13, 14, 15, 16, 17, 18, 19, 7, 55, 55, 55, 55, 55, 55, 55, 70
```
**Class export** (`MAG` after the 7-col base block, and after the growth block):
```
HP, STR, SKL, SPD, DEF, RES, CON, MAG, HP, STR, SKL, SPD, DEF, RES, LUCK, MAG
0, 35, 21, 22, 23, 24, 25, 26, 4, 50, 50, 50, 50, 50, 50, 50, 35
1, 36, 22, 23, 24, 25, 26, 27, 6, 55, 55, 55, 55, 55, 55, 55, 50
2, 37, 23, 24, 25, 26, 27, 28, 8, 60, 60, 60, 60, 60, 60, 60, 65
```
Base MAG values 3/5/7 (unit), 4/6/8 (class) and growth MAG 40/55/70, 35/50/65 are the seeded values — they survive export and re-import.

## Test plan
- [x] `dotnet build FEBuilderGBA.Avalonia` — Release, 0 errors
- [x] `FEBuilderGBA.Core.Tests` (MagicSplit filtered) — **7/7** (5 new value tests: FE8UInit tags resolve; `Write→Get` round-trips a non-zero signed value for ≥2 distinct ids, Unit/Class × base/growth)
- [x] `FEBuilderGBA.Avalonia.Tests` (CSV filtered) — **77/77**; full suite **7653/7656** (3 skipped, **0 failures**)
- [x] `FEBuilderGBA.Tests` (net9.0-windows) — **1851/1851**
- [x] Class + Unit **value round-trip** on the fully-planted ROM — incl. a **selected Unit id > 0** (single-row import lands on unit 4, unit 0 untouched) — catches the id-threading bugs
- [x] **Column-position** tests — exactly one `MAG` after the base block + one after the growth block (positions, not just presence), weplevel columns shifted consistently — Class AND Unit
- [x] **Vanilla unchanged** (exact-string header regression) + **FE6 unaffected** (never yields FE8UMAGIC) — with `ClearCache()` + `CoreState.ROM` restored in `finally`

## GUI Test Report
This PR's behavior change is the **content of the exported CSV** (a magic column), not a visible control change — the editor's CSV Export/Import affordances are unchanged. The end-to-end proof is the exported CSV above (driven through the real `UnitCsvManager`/`ClassCsvManager.BuildExportCsv` export path on a MagicSplit ROM) plus the 14 unit tests' real non-zero value round-trip. No commercial ROM ships the MagicSplit mag-tables, so the values come from a fully-planted ROM (as in the unit tests).

| Test | Result |
|---|---|
| Export on FE8UMAGIC ROM emits `MAG` base + growth columns (Class & Unit) | ✅ PASS (CSV above) |
| Import reads `MAG` back; values round-trip, correct per-id | ✅ PASS (value round-trip tests, incl. selected id > 0) |
| Vanilla / FE6 output unchanged (no MAG column) | ✅ PASS (exact-string regression tests) |

---
Original request: *"set ralph loop to resolve all open GitHub issues in laqieer/FEBuilderGBA"* — 10th issue in the autonomous sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.168` · model `claude-opus-4-8[1m]`
---

### Update — backward-compat fix (commit `7fea25141`, addressing Copilot CLI review)

Copilot CLI flagged a real backward-compatibility hole: import consumed the MAG cell whenever `isUsingMagicSplit && colIdx < cols.Length`, which only proves *later columns exist*, not that the row carries the new MAG layout. A **legacy pre-#1016 CSV** (base+growth+weplevel, no MAG) imported into a FE8UMAGIC ROM would read the first growth value as base MAG, shift every growth column, shift weplevel parsing, and corrupt both normal stat bytes and the MagicSplit table.

**Fix:** added `ExpectedColumnCount(withMag)` (Name/UID prefix + base + growth + weplevel, +1 per block for MAG) and gate MAG consumption on the row's **actual column count == with-MAG layout** (`rowHasMag`). A legacy row has the old count → parsed exactly as before, no MAG consumed, no shift. Vanilla/FE6/FE8J/FE7J still byte-identical.

**New regression tests (Unit + Class):** import a legacy no-MAG CSV with DISTINCT per-column values into a FE8UMAGIC ROM with sentinel MAG seeded; assert normal stats land in the right offsets (growth LUCK == its real value, not the first weplevel) and the sentinel MAG is untouched. **Verified both FAIL with the old gate and PASS with the fix** (negative-control confirmed). 10 MagicSplit + 79 CSV/parity tests green.

Added to the test plan:
- [x] `Unit_MagicSplitFE8U_LegacyNoMagCsv_DoesNotShiftColumns` — legacy 24-col CSV → no shift, MAG sentinel intact
- [x] `Class_MagicSplitFE8U_LegacyNoMagCsv_DoesNotShiftColumns` — legacy 23-col CSV → no shift, MAG sentinel intact
- [x] Negative control: both regression tests FAIL when the gate is reverted to the old `colIdx < cols.Length` check
