### PR TITLE
fix(avalonia): restore Battle Animation Palette 32-color-mode warning banner (#1033)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,12 +455,10 @@ Specialized utilities for different graphic types:
   Background Image editor's References list). `MakeListByUseBG(rom, bgId)` builds the `bgId→refs` map
   once per loaded ROM. **Cache-poisoning guard (#992):** pre-checks scanner prerequisites and returns
   empty WITHOUT caching when unsatisfied, so an early/headless call can't pin a permanently-empty cache.
-- `BattleAnimeRendererCore.CountAnimationPaletteBanks` (Core, READ-ONLY) — 32-color-mode detector
-  (#1033) replacing WF `ImageUtil.GetPalette16Count(DrawBitmap)`: `MaxOamPaletteBank` scans an OAM list
-  (same loop/terminators as `DrawOAMSprites`) for the max non-affine, non-bug (`bank<4`) 16-color bank;
-  `CountAnimationPaletteBanks` walks ALL sections/frames → `max(bank)+1`. Animation-wide CONSERVATIVE
-  (over-warns, never under-warns); affine sprites excluded (WF draws them at palette shift 0); safe
-  default 1 (no banner) on any guard failure. Drives the Avalonia Battle Animation Palette warning banner.
+- `BattleAnimeRendererCore.CountAnimationPaletteBanks`/`MaxOamPaletteBank` (Core, READ-ONLY) — 32-color
+  banner detector (#1033) replacing WF `GetPalette16Count`: scans all sections/frames' OAM for the max
+  non-affine, non-bug (`bank<4`) 16-color bank → `max+1` (≥2 ⇒ banner). Animation-wide CONSERVATIVE
+  (over-warns, never under-warns); affine excluded (WF draws them at shift 0); safe default 1 on guard fail.
 
 ### Caching System
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,6 +455,12 @@ Specialized utilities for different graphic types:
   Background Image editor's References list). `MakeListByUseBG(rom, bgId)` builds the `bgId→refs` map
   once per loaded ROM. **Cache-poisoning guard (#992):** pre-checks scanner prerequisites and returns
   empty WITHOUT caching when unsatisfied, so an early/headless call can't pin a permanently-empty cache.
+- `BattleAnimeRendererCore.CountAnimationPaletteBanks` (Core, READ-ONLY) — 32-color-mode detector
+  (#1033) replacing WF `ImageUtil.GetPalette16Count(DrawBitmap)`: `MaxOamPaletteBank` scans an OAM list
+  (same loop/terminators as `DrawOAMSprites`) for the max non-affine, non-bug (`bank<4`) 16-color bank;
+  `CountAnimationPaletteBanks` walks ALL sections/frames → `max(bank)+1`. Animation-wide CONSERVATIVE
+  (over-warns, never under-warns); affine sprites excluded (WF draws them at palette shift 0); safe
+  default 1 (no banner) on any guard failure. Drives the Avalonia Battle Animation Palette warning banner.
 
 ### Caching System
 

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
@@ -349,13 +349,14 @@ public class ImageBattleAnimePalletParityTests
     }
 
     [Fact]
-    public void ViewModel_Is32ColorMode_HonestlyDeferred()
+    public void ViewModel_Is32ColorMode_PaletteOnlyRecord_NoBanner()
     {
-        // Per Plan v3 Finding #2: even after loading a multi-slot palette
-        // (which WF would detect as 32-color), the VM keeps
-        // WarningVisible/Is32ColorMode false because the WF
-        // ImageUtil.GetPalette16Count(Bitmap) data source has not been
-        // ported to Core.
+        // #1033: the 32-color-mode banner is now driven by an OAM palette-bank
+        // scan (BattleAnimeRendererCore.CountAnimationPaletteBanks). A record
+        // that has a multi-slot PALETTE but NO section/frame/OAM pointers is
+        // unresolvable for the scan => it safely defaults to single-bank
+        // (palette_count == 1) => no banner. (Having 4 palette SLOTS does not
+        // by itself mean the SPRITES reference more than one bank.)
         var (rom, paletteOffset, sourceSlot) = MakeRomWithMultiSlotPalette();
         var prevRom = CoreState.ROM;
         try
@@ -364,8 +365,103 @@ public class ImageBattleAnimePalletParityTests
             var vm = new ImageBattleAnimePalletViewModel();
             vm.LoadEntry(paletteOffset, sourceSlot, paletteIndex: 0);
             Assert.False(vm.WarningVisible,
-                "32-color-mode detection is honestly deferred per Plan Finding #2");
+                "an unresolvable (palette-only) record must default to no banner (#1033)");
             Assert.False(vm.Is32ColorMode);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    // -----------------------------------------------------------------
+    // #1033 — 32-color-mode warning banner driven by the OAM palette-bank
+    // scan (BattleAnimeRendererCore.CountAnimationPaletteBanks).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_LoadEntry_NoBankedSprites_NoBanner()
+    {
+        // A full record whose only sprite is bank 0 => single bank => no banner.
+        EnsureImageService();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            var (rom, paletteOffset, sourceSlot) = MakeRomWithFullAnimeRecord(spritePaletteBank: 0);
+            CoreState.ROM = rom;
+            var vm = new ImageBattleAnimePalletViewModel();
+            vm.LoadEntry(paletteOffset, sourceSlot, paletteIndex: 0);
+            Assert.False(vm.WarningVisible);
+            Assert.False(vm.Is32ColorMode);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_LoadEntry_BankedSprite_ShowsBanner()
+    {
+        // A full record whose sprite uses 16-color palette bank 1 => 2 banks =>
+        // 32-color mode => banner visible (#1033, mirrors WF
+        // Is32ColorMode = (palette_count >= 2)).
+        EnsureImageService();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            var (rom, paletteOffset, sourceSlot) = MakeRomWithFullAnimeRecord(spritePaletteBank: 1);
+            CoreState.ROM = rom;
+            var vm = new ImageBattleAnimePalletViewModel();
+            vm.LoadEntry(paletteOffset, sourceSlot, paletteIndex: 0);
+            Assert.True(vm.WarningVisible);
+            Assert.True(vm.Is32ColorMode);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_LoadEntry_SourceSlotBelowRecordOffset_DoesNotThrow_NoBanner()
+    {
+        // Guard: a source pointer slot < 0x1C cannot derive a valid record
+        // offset; LoadEntry must not throw and must leave the banner hidden.
+        // We construct a synthetic entry with a tiny source slot directly.
+        EnsureImageService();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            var rom = new ROM();
+            rom.LoadLow("synth.gba", new byte[0x2000000], "BE8E01");
+            // Plant a small valid LZ77 palette near the start so LoadEntry's
+            // palette read succeeds; the bank scan is what we guard here.
+            const uint paletteOffset = 0x150000;
+            PlantLZ77(rom, paletteOffset, new byte[32]);
+            CoreState.ROM = rom;
+
+            var vm = new ImageBattleAnimePalletViewModel();
+            // sourcePointerSlot = 4 (< PalettePointerOffsetInRecord 0x1C).
+            vm.LoadEntry(paletteOffset, sourcePointerSlot: 4, paletteIndex: 0);
+            Assert.False(vm.WarningVisible);
+            Assert.False(vm.Is32ColorMode);
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void ViewModel_LoadEntry_RaisesPropertyChanged_WhenBannerFlipsOn()
+    {
+        // Subscribing to PropertyChanged must see WarningVisible AND
+        // Is32ColorMode raised after a LoadEntry that turns the banner on.
+        EnsureImageService();
+        var prevRom = CoreState.ROM;
+        try
+        {
+            var (rom, paletteOffset, sourceSlot) = MakeRomWithFullAnimeRecord(spritePaletteBank: 1);
+            CoreState.ROM = rom;
+            var vm = new ImageBattleAnimePalletViewModel();
+
+            var raised = new HashSet<string>();
+            vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+            vm.LoadEntry(paletteOffset, sourceSlot, paletteIndex: 0);
+
+            Assert.True(vm.WarningVisible, "banner should be on for a banked sprite");
+            Assert.Contains(nameof(ImageBattleAnimePalletViewModel.WarningVisible), raised);
+            Assert.Contains(nameof(ImageBattleAnimePalletViewModel.Is32ColorMode), raised);
         }
         finally { CoreState.ROM = prevRom; }
     }
@@ -1184,6 +1280,15 @@ public class ImageBattleAnimePalletParityTests
     /// and the source pointer slot (record + 0x1C) the VM loads.
     /// </summary>
     static (ROM rom, uint paletteOffset, uint sourceSlot) MakeRomWithFullAnimeRecord()
+        => MakeRomWithFullAnimeRecord(spritePaletteBank: 0);
+
+    /// <summary>
+    /// Overload that stamps the sprite's 16-color palette bank into OAM byte[5]
+    /// (high nibble), so the #1033 OAM palette-bank scan
+    /// (<c>BattleAnimeRendererCore.CountAnimationPaletteBanks</c>) sees a
+    /// banked (32-color) animation when <paramref name="spritePaletteBank"/> >= 1.
+    /// </summary>
+    static (ROM rom, uint paletteOffset, uint sourceSlot) MakeRomWithFullAnimeRecord(int spritePaletteBank)
     {
         var rom = new ROM();
         rom.LoadLow("synth.gba", new byte[0x2000000], "BE8E01");
@@ -1223,7 +1328,9 @@ public class ImageBattleAnimePalletParityTests
         // imgX = vramX + 0x94 = 100 => vramX = -48; imgY = vramY + 0x58 = 30 => vramY = -58.
         byte[] oam = new byte[24];
         oam[0] = 0x00; oam[1] = 0x00; oam[2] = 0x00; oam[3] = 0x00;
-        oam[4] = 0x00; oam[5] = 0x00;
+        oam[4] = 0x00;
+        // byte[5] high nibble = 16-color palette bank selector (#1033 scan).
+        oam[5] = (byte)((spritePaletteBank & 0x0F) << 4);
         oam[6] = unchecked((byte)(-48 & 0xFF)); oam[7] = unchecked((byte)((-48 >> 8) & 0xFF));
         oam[8] = unchecked((byte)(-58 & 0xFF)); oam[9] = unchecked((byte)((-58 >> 8) & 0xFF));
         oam[12] = 0x01; // terminator

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageBattleAnimePalletViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageBattleAnimePalletViewModel.cs
@@ -10,10 +10,14 @@
 //   - Offsets-throughout contract: `_paletteOffset`, `_sourcePointerSlot` are
 //     ROM offsets internally. The public PaletteAddress property converts
 //     offset->pointer for display (user-facing).
-//   - 32-color mode (Is32ColorMode / WarningVisible) is honestly deferred:
-//     defaults to false; flipping it on requires the WF
-//     ImageUtil.GetPalette16Count(Bitmap) Core extraction which depends on
-//     sample rendering. Marked as KnownGap (no follow-up issue per task scope).
+//   - 32-color mode (Is32ColorMode / WarningVisible) is now driven by the Core
+//     port BattleAnimeRendererCore.CountAnimationPaletteBanks (#1033) — an
+//     animation-wide CONSERVATIVE OAM palette-bank scan replacing WF
+//     ImageUtil.GetPalette16Count(DrawBitmap). The banner turns on when the scan
+//     finds a non-affine sprite using a 16-color bank >= 1 (palette_count >= 2),
+//     mirroring WF Is32ColorMode = (palette_count >= 2). This restores the
+//     banner only; the WF JumpTo palette-index-0 redraw coupling remains out of
+//     scope.
 using System;
 using System.Collections.Generic;
 using FEBuilderGBA.Avalonia.Services;
@@ -98,9 +102,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         }
 
         /// <summary>
-        /// Whether the 32-color-mode warning is visible.
-        /// Honestly deferred per Finding #2 — always false until WF
-        /// ImageUtil.GetPalette16Count is ported to Core.
+        /// Whether the 32-color-mode warning banner is visible. Set by
+        /// <see cref="LoadEntry"/> to <see cref="Is32ColorMode"/> — true when the
+        /// loaded animation's OAM sprites use more than one 16-color palette bank
+        /// (#1033), detected via
+        /// <c>BattleAnimeRendererCore.CountAnimationPaletteBanks</c>.
         /// </summary>
         public bool WarningVisible
         {
@@ -109,8 +115,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         }
 
         /// <summary>
-        /// Whether the current animation uses 32-color mode. Honestly
-        /// deferred (always false). See WarningVisible comment.
+        /// Whether the currently-loaded animation uses 32-color (multi-bank)
+        /// mode. Set by <see cref="LoadEntry"/> from
+        /// <c>BattleAnimeRendererCore.CountAnimationPaletteBanks(recordOffset) &gt;= 2</c>
+        /// (#1033), mirroring WF <c>Is32ColorMode = (palette_count &gt;= 2)</c>.
+        /// Drives <see cref="WarningVisible"/>.
         /// </summary>
         public bool Is32ColorMode
         {
@@ -251,9 +260,19 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 }
             }
 
-            // 32-color mode detection is honestly deferred — see class doc.
-            _is32ColorMode = false;
-            _warningVisible = false;
+            // #1033: 32-color mode detection — port of WF
+            // ImageUtil.GetPalette16Count(DrawBitmap) via an OAM palette-bank scan.
+            // The animation record begins at _sourcePointerSlot - 0x1C (the palette
+            // pointer lives at record+0x1C), the same derivation
+            // RenderSampleBattleAnime uses.
+            int bankCount = 1;
+            if (_sourcePointerSlot >= PalettePointerOffsetInRecord)
+            {
+                uint recordOffset = _sourcePointerSlot - PalettePointerOffsetInRecord;
+                bankCount = BattleAnimeRendererCore.CountAnimationPaletteBanks(recordOffset);
+            }
+            _is32ColorMode = bankCount >= 2;   // mirrors WF: Is32ColorMode = (palette_count >= 2)
+            _warningVisible = _is32ColorMode;
 
             IsLoaded = true;
             OnPropertyChanged(nameof(PaletteAddress));

--- a/FEBuilderGBA.Core.Tests/BattleAnimePaletteBankCountTests.cs
+++ b/FEBuilderGBA.Core.Tests/BattleAnimePaletteBankCountTests.cs
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for the #1033 32-color-mode detector in BattleAnimeRendererCore:
+//   - MaxOamPaletteBank: the OAM palette-bank scan (non-affine, non-bug, with
+//     the same parse loop + terminators as DrawOAMSprites).
+//   - CountAnimationPaletteBanks: the animation-wide max(bank)+1 detector that
+//     replaces WF ImageUtil.GetPalette16Count(DrawBitmap).
+//
+// Reuses the synthetic-battle-anime-ROM scaffold pattern from
+// BattleAnimeSamplePreviewTests (rom.LoadLow + U.write_u32 + LZ77.compress).
+using System;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class BattleAnimePaletteBankCountTests : IDisposable
+    {
+        readonly ROM _prevRom;
+
+        public BattleAnimePaletteBankCountTests()
+        {
+            _prevRom = CoreState.ROM;
+        }
+
+        public void Dispose()
+        {
+            CoreState.ROM = _prevRom;
+        }
+
+        // ================================================================
+        // MaxOamPaletteBank — direct byte[] unit tests (no ROM needed).
+        // MaxOamPaletteBank is internal; the Core.Tests assembly has
+        // InternalsVisibleTo, so it is reachable from here.
+        // ================================================================
+
+        [Fact]
+        public void MaxOamPaletteBank_AllSpritesBank0_ReturnsZero()
+        {
+            byte[] oam = new byte[36];
+            WriteSprite(oam, 0, bank: 0);
+            WriteSprite(oam, 12, bank: 0);
+            oam[24] = 0x01; // terminator
+            Assert.Equal(0, BattleAnimeRendererCore.MaxOamPaletteBank(oam, 0));
+        }
+
+        [Fact]
+        public void MaxOamPaletteBank_NonAffineBank1_ReturnsOne()
+        {
+            byte[] oam = new byte[24];
+            WriteSprite(oam, 0, bank: 1);
+            oam[12] = 0x01; // terminator
+            Assert.Equal(1, BattleAnimeRendererCore.MaxOamPaletteBank(oam, 0));
+        }
+
+        [Fact]
+        public void MaxOamPaletteBank_NonAffineBank3_ReturnsThree()
+        {
+            byte[] oam = new byte[24];
+            WriteSprite(oam, 0, bank: 3);
+            oam[12] = 0x01; // terminator
+            Assert.Equal(3, BattleAnimeRendererCore.MaxOamPaletteBank(oam, 0));
+        }
+
+        [Fact]
+        public void MaxOamPaletteBank_BankAtOrAbove4_IsSkipped_ReturnsZero()
+        {
+            // A lone bank-5 sprite is a bug frame (>= 4) and is skipped, so the
+            // result is 0 (no qualifying entry).
+            byte[] oam = new byte[24];
+            WriteSprite(oam, 0, bank: 5);
+            oam[12] = 0x01; // terminator
+            Assert.Equal(0, BattleAnimeRendererCore.MaxOamPaletteBank(oam, 0));
+        }
+
+        [Fact]
+        public void MaxOamPaletteBank_AffineSprite_IsExcluded_ReturnsZero()
+        {
+            // An AFFINE sprite (align bit0 set) with bank 2 must NOT count;
+            // all other sprites are bank 0 => result 0.
+            byte[] oam = new byte[36];
+            WriteSprite(oam, 0, bank: 2, affine: true); // excluded
+            WriteSprite(oam, 12, bank: 0);                    // bank 0
+            oam[24] = 0x01; // terminator
+            Assert.Equal(0, BattleAnimeRendererCore.MaxOamPaletteBank(oam, 0));
+        }
+
+        [Fact]
+        public void MaxOamPaletteBank_NormalTerminator_EndsWalk()
+        {
+            // A 0x01 terminator BEFORE the bank-2 sprite stops the walk, so the
+            // bank-2 entry past it is never seen => 0.
+            byte[] oam = new byte[36];
+            oam[0] = 0x01; // immediate terminator
+            WriteSprite(oam, 12, bank: 2);
+            Assert.Equal(0, BattleAnimeRendererCore.MaxOamPaletteBank(oam, 0));
+        }
+
+        [Fact]
+        public void MaxOamPaletteBank_FEditorAltTerminator_EndsWalk()
+        {
+            // 00 FF FF FF alternate terminator ends the walk before the bank-2
+            // sprite that follows.
+            byte[] oam = new byte[36];
+            oam[0] = 0x00; oam[1] = 0xFF; oam[2] = 0xFF; oam[3] = 0xFF; // alt terminator
+            WriteSprite(oam, 12, bank: 2);
+            Assert.Equal(0, BattleAnimeRendererCore.MaxOamPaletteBank(oam, 0));
+        }
+
+        [Fact]
+        public void MaxOamPaletteBank_AffineMatrixEntry_IsSkipped_WalkContinues()
+        {
+            // An affine-MATRIX entry ([2..3]==FFFF, first byte != 0) is NOT a
+            // terminator: the walk must continue past it and still find the
+            // bank-2 sprite after it.
+            byte[] oam = new byte[36];
+            // matrix entry: byte0 non-zero so the alt-terminator (00 FF FF FF)
+            // branch does NOT fire; bytes [2..3] == FFFF marks it a matrix.
+            oam[0] = 0x10; oam[2] = 0xFF; oam[3] = 0xFF;
+            WriteSprite(oam, 12, bank: 2);
+            oam[24] = 0x01; // terminator
+            Assert.Equal(2, BattleAnimeRendererCore.MaxOamPaletteBank(oam, 0));
+        }
+
+        [Fact]
+        public void MaxOamPaletteBank_NullOrOutOfRange_ReturnsZero()
+        {
+            Assert.Equal(0, BattleAnimeRendererCore.MaxOamPaletteBank(null, 0));
+            Assert.Equal(0, BattleAnimeRendererCore.MaxOamPaletteBank(new byte[12], 100));
+        }
+
+        // ================================================================
+        // CountAnimationPaletteBanks — integration tests (synthetic ROM).
+        // ================================================================
+
+        [Fact]
+        public void CountAnimationPaletteBanks_AllBanks0_ReturnsOne()
+        {
+            ROM rom = MakeAnimeRom(sec0Bank: 0, sec1Bank: 0);
+            CoreState.ROM = rom;
+            Assert.Equal(1, BattleAnimeRendererCore.CountAnimationPaletteBanks(RECORD_OFFSET));
+        }
+
+        [Fact]
+        public void CountAnimationPaletteBanks_Bank1InSection0_ReturnsTwo()
+        {
+            ROM rom = MakeAnimeRom(sec0Bank: 1, sec1Bank: 0);
+            CoreState.ROM = rom;
+            Assert.Equal(2, BattleAnimeRendererCore.CountAnimationPaletteBanks(RECORD_OFFSET));
+        }
+
+        [Fact]
+        public void CountAnimationPaletteBanks_Bank1OnlyInLaterSection_ReturnsTwo()
+        {
+            // The banked sprite is reachable ONLY via section 1 (section 0 is
+            // bank 0). The animation-wide scan must still find it => 2. This
+            // proves the detector is animation-wide, not sample-only.
+            ROM rom = MakeAnimeRom(sec0Bank: 0, sec1Bank: 1);
+            CoreState.ROM = rom;
+            Assert.Equal(2, BattleAnimeRendererCore.CountAnimationPaletteBanks(RECORD_OFFSET));
+        }
+
+        [Fact]
+        public void CountAnimationPaletteBanks_OnlyAffineBank1Sprite_ReturnsOne()
+        {
+            // Both sprites are AFFINE with bank 1; affine sprites are excluded
+            // (WF renders them with palette shift 0) => single bank => 1.
+            ROM rom = MakeAnimeRom(sec0Bank: 1, sec1Bank: 1, affine: true);
+            CoreState.ROM = rom;
+            Assert.Equal(1, BattleAnimeRendererCore.CountAnimationPaletteBanks(RECORD_OFFSET));
+        }
+
+        [Fact]
+        public void CountAnimationPaletteBanks_ZeroPointers_ReturnsOne()
+        {
+            ROM rom = MakeAnimeRom(sec0Bank: 1, sec1Bank: 1);
+            // Wipe section/frame/OAM pointers => unresolvable => safe default 1.
+            U.write_u32(rom.Data, RECORD_OFFSET + 12, 0);
+            U.write_u32(rom.Data, RECORD_OFFSET + 16, 0);
+            U.write_u32(rom.Data, RECORD_OFFSET + 20, 0);
+            CoreState.ROM = rom;
+            Assert.Equal(1, BattleAnimeRendererCore.CountAnimationPaletteBanks(RECORD_OFFSET));
+        }
+
+        [Fact]
+        public void CountAnimationPaletteBanks_NullRom_ReturnsOne()
+        {
+            CoreState.ROM = null;
+            Assert.Equal(1, BattleAnimeRendererCore.CountAnimationPaletteBanks(RECORD_OFFSET));
+        }
+
+        [Fact]
+        public void CountAnimationPaletteBanks_RecordPastEndOfRom_ReturnsOne()
+        {
+            ROM rom = MakeAnimeRom(sec0Bank: 1, sec1Bank: 0);
+            CoreState.ROM = rom;
+            uint badOffset = (uint)rom.Data.Length - 4; // record would overrun
+            Assert.Equal(1, BattleAnimeRendererCore.CountAnimationPaletteBanks(badOffset));
+        }
+
+        // ================================================================
+        // Synthetic anime ROM construction (mirrors BattleAnimeSamplePreview).
+        // ================================================================
+
+        const uint RECORD_OFFSET   = 0x200000;
+        const uint SECTION_OFFSET  = 0x201000;
+        const uint FRAME_OFFSET    = 0x202000;
+        const uint OAM_OFFSET      = 0x203000;
+        const uint PALETTE_OFFSET  = 0x204000;
+        const uint GFX_OFFSET      = 0x210000;
+
+        // OAM byte offsets inside the (uncompressed) OAM data we author.
+        const uint OAM_SEC0_FRAME0 = 0;
+        const uint OAM_SEC1_FRAME0 = 24;
+
+        static ROM MakeAnimeRom(int sec0Bank, int sec1Bank, bool affine = false)
+        {
+            var rom = new ROM();
+            byte[] data = new byte[0x2000000];
+            Array.Fill(data, (byte)0x00); // zero free space (0xFF looks like pointers)
+            rom.LoadLow("synth.gba", data, "BE8E01");
+
+            // ---- 32-byte animation record ----
+            U.write_u32(rom.Data, RECORD_OFFSET + 12, U.toPointer(SECTION_OFFSET));
+            U.write_u32(rom.Data, RECORD_OFFSET + 16, U.toPointer(FRAME_OFFSET));
+            U.write_u32(rom.Data, RECORD_OFFSET + 20, U.toPointer(OAM_OFFSET));
+            U.write_u32(rom.Data, RECORD_OFFSET + 24, U.toPointer(OAM_OFFSET));
+            U.write_u32(rom.Data, RECORD_OFFSET + 28, U.toPointer(PALETTE_OFFSET));
+
+            // ---- Frame stream: section 0 + section 1, one frame each ----
+            byte[] frameStream = new byte[24];
+            frameStream[3] = 0x86;
+            U.write_u32(frameStream, 4, U.toPointer(GFX_OFFSET));
+            U.write_u32(frameStream, 8, OAM_SEC0_FRAME0);
+            frameStream[15] = 0x86;
+            U.write_u32(frameStream, 16, U.toPointer(GFX_OFFSET));
+            U.write_u32(frameStream, 20, OAM_SEC1_FRAME0);
+            PlantCompressed(rom, FRAME_OFFSET, frameStream);
+
+            // ---- Section array: section 0 = [0,12), section 1 = [12,24) ----
+            for (int s = 0; s < 12; s++)
+            {
+                uint start = s == 0 ? 0u : (s == 1 ? 12u : 24u);
+                U.write_u32(rom.Data, SECTION_OFFSET + (uint)(s * 4), start);
+            }
+
+            // ---- OAM data: one sprite per section, each at its bank ----
+            byte[] oam = new byte[48];
+            WriteSprite(oam, (int)OAM_SEC0_FRAME0, sec0Bank, affine);
+            oam[12] = 0x01; // terminator for section 0's list
+            WriteSprite(oam, (int)OAM_SEC1_FRAME0, sec1Bank, affine);
+            oam[36] = 0x01; // terminator for section 1's list
+            PlantCompressed(rom, OAM_OFFSET, oam);
+
+            // ---- Graphics: one 4bpp tile (content irrelevant to the scan) ----
+            byte[] tile = new byte[32];
+            for (int i = 0; i < 32; i++) tile[i] = 0x55;
+            PlantCompressed(rom, GFX_OFFSET, tile);
+
+            // ---- Palette: 2 blocks x 16 colors ----
+            byte[] pal = new byte[64];
+            PlantCompressed(rom, PALETTE_OFFSET, pal);
+
+            return rom;
+        }
+
+        // Write a "square 1x1 tile" OAM sprite entry at byte offset `at`, with
+        // the given 16-color palette bank in byte[5] high nibble. When `affine`
+        // is true, align bit0 is set (affine sprite => excluded by the scan).
+        static void WriteSprite(byte[] oam, int at, int bank, bool affine = false)
+        {
+            oam[at + 0] = 0x00;                                  // normal entry
+            oam[at + 1] = (byte)(affine ? 0x01 : 0x00);          // align: bit0 = affine
+            oam[at + 2] = 0x00;                                  // not a matrix entry
+            oam[at + 3] = 0x00;                                  // area
+            oam[at + 4] = 0x00;                                  // sheet tile x/y
+            oam[at + 5] = (byte)((bank & 0x0F) << 4);            // palette bank selector
+            oam[at + 6] = 0x00; oam[at + 7] = 0x00;
+            oam[at + 8] = 0x00; oam[at + 9] = 0x00;
+            oam[at + 10] = 0x00; oam[at + 11] = 0x00;
+        }
+
+        static void PlantCompressed(ROM rom, uint offset, byte[] raw)
+        {
+            byte[] comp = LZ77.compress(raw);
+            Array.Copy(comp, 0, rom.Data, offset, comp.Length);
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/BattleAnimePaletteBankCountTests.cs
+++ b/FEBuilderGBA.Core.Tests/BattleAnimePaletteBankCountTests.cs
@@ -198,6 +198,21 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Equal(1, BattleAnimeRendererCore.CountAnimationPaletteBanks(badOffset));
         }
 
+        [Fact]
+        public void CountAnimationPaletteBanks_SectionTableNearEof_ReturnsOne_NoThrow()
+        {
+            // #1051 review: a section pointer 2 bytes before EOF passes
+            // U.isSafetyOffset (base only) but GetSectionRange's rom.u32 would read
+            // past EOF and THROW IndexOutOfRangeException without the 48-byte
+            // section-table bounds guard. Must honor the contract: return 1, no throw.
+            ROM rom = MakeAnimeRom(sec0Bank: 1, sec1Bank: 1);
+            uint nearEof = (uint)rom.Data.Length - 2;
+            U.write_u32(rom.Data, RECORD_OFFSET + 12, U.toPointer(nearEof));
+            CoreState.ROM = rom;
+            int result = BattleAnimeRendererCore.CountAnimationPaletteBanks(RECORD_OFFSET);
+            Assert.Equal(1, result);
+        }
+
         // ================================================================
         // Synthetic anime ROM construction (mirrors BattleAnimeSamplePreview).
         // ================================================================

--- a/FEBuilderGBA.Core/BattleAnimeRendererCore.cs
+++ b/FEBuilderGBA.Core/BattleAnimeRendererCore.cs
@@ -978,6 +978,13 @@ namespace FEBuilderGBA
             if (!U.isPointer(sectionRaw)) return 1;
             uint sectionOffset = U.toOffset(sectionRaw);
             if (!U.isSafetyOffset(sectionOffset, rom)) return 1;
+            // #1051 review: U.isSafetyOffset only validates the base offset, but
+            // GetSectionRange reads the full SECTION_COUNT-entry (48-byte) section
+            // table via rom.u32, which THROWS within 4 bytes of EOF. Guard the whole
+            // table is in-bounds so the documented "return 1 on guard failure"
+            // contract holds for a record whose section pointer sits near the ROM
+            // end. (sectionOffset < 0x02000000 from isSafetyOffset, so no overflow.)
+            if (sectionOffset + (uint)(SECTION_COUNT * 4) > (uint)rom.Data.Length) return 1;
 
             byte[] frameData = DecompressFrameData(rom, frameRaw);
             if (frameData == null || frameData.Length == 0) return 1;

--- a/FEBuilderGBA.Core/BattleAnimeRendererCore.cs
+++ b/FEBuilderGBA.Core/BattleAnimeRendererCore.cs
@@ -893,6 +893,121 @@ namespace FEBuilderGBA
             return crop ?? BlankSampleCell();
         }
 
+        /// <summary>
+        /// Walk the OAM entry list at <paramref name="oamStart"/> using the SAME
+        /// parse loop + terminators as <see cref="DrawOAMSprites"/> and return the
+        /// maximum 16-color palette-bank selector (<c>(oam[pos+5]&gt;&gt;4)&amp;0xF</c>)
+        /// among the NON-affine sprite entries, skipping bug-frame banks &gt;= 4.
+        /// Affine sprites are excluded because the WinForms affine draw path
+        /// (<c>ImageUtilOAM.Draw</c>, the affine <c>BitBlt</c>) renders them with
+        /// palette shift 0, so they never contribute a bank to WF's
+        /// <c>GetPalette16Count(DrawBitmap)</c>. Returns 0 when no qualifying entry
+        /// has a usable bank.
+        /// </summary>
+        internal static int MaxOamPaletteBank(byte[] oamData, uint oamStart)
+        {
+            if (oamData == null || oamStart >= (uint)oamData.Length) return 0;
+            int maxBank = 0;
+            for (uint pos = oamStart; ; pos += 12)
+            {
+                if (pos + 12 > (uint)oamData.Length) break;
+
+                byte firstByte = oamData[pos];
+
+                // FEditor serialized alternate terminator (00 FF FF FF).
+                if (firstByte == 0 && oamData[pos + 1] == 0xFF
+                    && oamData[pos + 2] == 0xFF && oamData[pos + 3] == 0xFF)
+                    break;
+
+                // Affine MATRIX entry ([2..3]==FFFF): not a sprite — keep walking.
+                if (oamData[pos + 2] == 0xFF && oamData[pos + 3] == 0xFF)
+                    continue;
+
+                // Normal terminator.
+                if (firstByte == 0x01) break;
+
+                // First byte must be 0x00 for a normal OAM sprite entry.
+                if (firstByte != 0x00) break;
+
+                // Affine SPRITE (align bit0 set): WF renders with palette shift 0
+                // (excluded from the bank count). align is byte[pos+1].
+                bool isAffineSprite = (oamData[pos + 1] & 0x01) != 0;
+                if (isAffineSprite) continue;
+
+                int paletteShift = (oamData[pos + 5] >> 4) & 0xF;
+                if (paletteShift >= 4) continue; // bug frame — skip (matches DrawOAMSprites)
+                if (paletteShift > maxBank) maxBank = paletteShift;
+            }
+            return maxBank;
+        }
+
+        /// <summary>
+        /// Count the 16-color palette banks a battle animation's sprites use — the
+        /// cross-platform replacement for WinForms
+        /// <c>ImageUtil.GetPalette16Count(DrawBitmap)</c> used by
+        /// <c>ImageBattleAnimePalletForm.JumpTo</c>. Returns <c>max(bank)+1</c> (>= 1);
+        /// the caller treats &gt;= 2 as 32-color mode (mirrors WF
+        /// <c>Is32ColorMode = (palette_count &gt;= 2)</c>).
+        ///
+        /// <para>This is an INTENTIONAL animation-wide CONSERVATIVE detector, NOT a
+        /// pixel-exact reproduction of WF: WF counts banks only in the rendered
+        /// 12-cell 90x90 sample bitmap (so it applies frame selection, crop,
+        /// transparency and draw-order overdraw); this scans every non-affine,
+        /// non-bug OAM entry across ALL sections/frames. It is strictly more
+        /// conservative — it can warn for a banked sprite WF happens not to sample,
+        /// but it NEVER misses a real multi-bank animation. The banner is a safety
+        /// hint (the palette editor edits only one 16-color sub-palette), so
+        /// over-warning is safe and under-warning is the damaging case #1033 fixes.</para>
+        ///
+        /// <para>Returns <c>1</c> (single bank → no banner) on any guard failure
+        /// (null ROM / out-of-range record / non-pointer or unsafe section/frame/OAM
+        /// pointer / failed decompress). This is a deliberate safe default — a
+        /// malformed record shows no banner rather than a spurious one.</para>
+        /// </summary>
+        /// <param name="animeRecordAddr">ROM OFFSET of the 32-byte animation record.</param>
+        public static int CountAnimationPaletteBanks(uint animeRecordAddr)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null) return 1;
+            if (animeRecordAddr + 32 > (uint)rom.Data.Length) return 1;
+
+            uint sectionRaw = rom.u32(animeRecordAddr + 12);
+            uint frameRaw   = rom.u32(animeRecordAddr + 16);
+            uint oamRtLRaw  = rom.u32(animeRecordAddr + 20);
+
+            if (!U.isPointer(sectionRaw)) return 1;
+            uint sectionOffset = U.toOffset(sectionRaw);
+            if (!U.isSafetyOffset(sectionOffset, rom)) return 1;
+
+            byte[] frameData = DecompressFrameData(rom, frameRaw);
+            if (frameData == null || frameData.Length == 0) return 1;
+
+            byte[] oamData = null;
+            if (U.isPointer(oamRtLRaw))
+            {
+                uint oamOff = U.toOffset(oamRtLRaw);
+                if (U.isSafetyOffset(oamOff, rom))
+                    oamData = LZ77.decompress(rom.Data, oamOff);
+            }
+            if (oamData == null) return 1;
+
+            int maxBank = 0;
+            for (int section = 0; section < SECTION_COUNT; section++)
+            {
+                GetSectionRange(section, sectionOffset, (uint)frameData.Length, rom,
+                    out uint start, out uint end);
+                System.Collections.Generic.List<FrameInfo> frames =
+                    ParseFramesInRange(frameData, start, end);
+                if (frames == null) continue;
+                foreach (var f in frames)
+                {
+                    int b = MaxOamPaletteBank(oamData, f.OamOffset);
+                    if (b > maxBank) maxBank = b;
+                }
+            }
+            return maxBank + 1;
+        }
+
         /// <summary>A fresh transparent 90x90 cell (for missing/failed frames).</summary>
         static IImage BlankSampleCell()
         {


### PR DESCRIPTION
## Summary
Restores the Battle Animation Palette editor's **"32 Color Mode"** warning banner, which was wired in XAML but driven by flags hardcoded `false` (the WF detector `ImageUtil.GetPalette16Count(Bitmap)` was never ported to Core). The banner now appears for 32-color (2+ palette-bank) animations, mirroring WF `ImageBattleAnimePalletForm.JumpTo`.

Plan reviewed + accepted by Copilot CLI over 2 rounds (issue #1033 thread).

Closes #1033.

## Root cause
`ImageBattleAnimePalletViewModel.LoadEntry` hardcoded `_is32ColorMode = false; _warningVisible = false;`. The Avalonia renderer decodes tiles with a single 16-color palette into RGBA (bank info lost in pixels), so WF's "scan the rendered indexed bitmap, `pixel/16` = bank" cannot be reproduced from the image. The source of truth for the bank is the per-OAM palette selector `oam[+5]>>4` — the exact field `DrawOAMSprites` already reads.

## Changes
- **`FEBuilderGBA.Core/BattleAnimeRendererCore.cs`** (READ-ONLY, no rendering, headless):
  - `MaxOamPaletteBank(oamData, oamStart)` — walks the OAM list with the **same parse loop + terminators** as `DrawOAMSprites` and returns the max `(oam[+5]>>4)&0xF` among **non-affine** sprites, skipping bug-frame banks `>=4`.
  - `CountAnimationPaletteBanks(animeRecordAddr)` — resolves the record (section/frame/OAM at +12/+16/+20, guarded), decompresses, and scans **all** sections/frames → `max(bank)+1`. The VM treats `>=2` as 32-color mode.
- **`ImageBattleAnimePalletViewModel.LoadEntry`** — drives `_is32ColorMode`/`_warningVisible` from `CountAnimationPaletteBanks(_sourcePointerSlot - 0x1C)`; rewrote the 3 stale "honestly deferred / always false" XML doc blocks.
- No view change — `ImageBattleAnimePalletView.axaml.cs` already binds `Warning32ColorBorder.IsVisible = _vm.WarningVisible`, refreshed after `LoadEntry`.

## Design decisions (both accepted in plan review)
- **Affine sprites excluded** from the bank count — verified at `ImageUtilOAM.cs:497-507` the WF affine `BitBlt` passes palette shift **0** (vs `:542-552` non-affine passing `t.paletteShift`), so affine sprites never contribute a bank to WF's `GetPalette16Count`.
- **Intentional animation-wide CONSERVATIVE detector**, not pixel-exact WF parity (no clip/crop/transparency/overdraw — those need rendering, out of scope). It scans every non-affine, non-bug OAM across all sections vs WF's rendered 12-cell sample: strictly more conservative (can warn for a banked sprite WF happens not to sample, never misses a real multi-bank animation). The banner is a safety hint, so over-warning is safe; under-warning is the harmful case #1033 targets. Unresolved/guard failures return `1` (no banner) — a documented safe default.
- Out of scope (noted as follow-up): WF `JumpTo` also forces later palette redraws to sub-palette index 0 once 32-color; bank-aware sample rendering.

## Validation on real ROMs
A scan with the new `CountAnimationPaletteBanks` found real 32-color animations in **every** commercial ROM (FE8U indices 0x43/0x48 → 3 banks; 0x9E/0xBD/0xBF/0xC4/0xC5 → 2 banks; FE7U/FE7J 0x8B; FE6 0x67/0x6B/0x6C) — proving the detector works against real data, not just synthetic fixtures.

## Screenshots (FE8U.gba, live Avalonia editor)
**32-color animation `0x43` → banner shown** (orange "32 Color Mode" by Palette Write):

![32 Color Mode banner](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1033-32color-banner.png)

**16-color animation `0x00` → no banner** (same editor, no warning):

![No banner on 16-color](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1033-16color-nobanner.png)

## Test plan
- [x] `dotnet build` Core + Avalonia (Release) — 0 errors
- [x] **Core** `BattleAnimePaletteBankCountTests` — **16/16**: `MaxOamPaletteBank` (all-bank-0, bank 1, bank 3, `>=4` skipped, affine excluded, all 3 terminators + affine-matrix skip) + `CountAnimationPaletteBanks` (all-0→1, bank-1 section 0→2, **bank-1 only in a later section→2** (animation-wide), affine-only→1, unresolved pointers→1)
- [x] **Avalonia** `ImageBattleAnimePalletParityTests` — **52/52**: `LoadEntry` 16-color→`WarningVisible==false`; 32-color→`WarningVisible==Is32ColorMode==true`; `_sourcePointerSlot<0x1C` guard (no throw, no banner); `PropertyChanged` raised for `WarningVisible`/`Is32ColorMode` after `LoadEntry`
- [x] Full **Core.Tests** 2932/2932 · full **Avalonia.Tests** 7659/7662 (3 skipped, 0 failures)
- [x] Negative-control confirmed via real-ROM scan (16-color animations return 1/no banner; 32-color return ≥2/banner) and the live before/after screenshots above

## GUI Test Report
Captured live from the running Avalonia app on `roms/FE8U.gba` (UIAutomation navigation + PrintWindow capture).

| Test | Result |
|---|---|
| Open Battle Animation Palette editor (FE8U) | ✅ PASS |
| Select 32-color animation `0x43` → "32 Color Mode" banner visible | ✅ PASS (screenshot 1) |
| Select 16-color animation `0x00` → banner hidden | ✅ PASS (screenshot 2) |
| Palette swatches + sample preview populate per selection | ✅ PASS (both screenshots) |

---
Original request: *"set ralph loop to resolve all open GitHub issues in laqieer/FEBuilderGBA"* — 11th issue in the autonomous sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.168` · model `claude-opus-4-8[1m]`
