### PR TITLE
fix(avalonia): disable the no-op C-SkillSys Bulk Export/Import buttons (#1011)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillAssignmentClassCSkillSysParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillAssignmentClassCSkillSysParityTests.cs
@@ -139,6 +139,27 @@ public class SkillAssignmentClassCSkillSysParityTests
         Assert.Contains("AutomationId=\"SkillAssignmentClassCSkillSys_ImportAll_Button\"", axaml);
     }
 
+    // #1011: WF SkillAssignmentClassCSkillSysForm.ExportAllData/ImportAllData are
+    // empty stubs, so the Avalonia bulk buttons must be DISABLED (not silent
+    // no-ops) with the explanation on the enabled wrapping panel (a disabled
+    // Avalonia control isn't hit-testable and wouldn't surface its own tooltip).
+    [Fact] public void View_BulkButtons_AreDisabled_WithTooltip() {
+        string axaml = ReadAxaml();
+        var importBtn = Regex.Match(axaml, @"<Button[^>]*ImportAll_Button[^>]*?/>");
+        var exportBtn = Regex.Match(axaml, @"<Button[^>]*ExportAll_Button[^>]*?/>");
+        Assert.True(importBtn.Success, "ImportAll button element not found");
+        Assert.True(exportBtn.Success, "ExportAll button element not found");
+        // Both disabled.
+        Assert.Contains("IsEnabled=\"False\"", importBtn.Value);
+        Assert.Contains("IsEnabled=\"False\"", exportBtn.Value);
+        // No-op Click handlers removed (the buttons no longer advertise an action).
+        Assert.DoesNotContain("Click=", importBtn.Value);
+        Assert.DoesNotContain("Click=", exportBtn.Value);
+        // Explanatory tooltip present (on the enabled wrapping StackPanel).
+        Assert.Contains("ToolTip.Tip=", axaml);
+        Assert.Matches(new Regex("not available for the C-SkillSys", RegexOptions.IgnoreCase), axaml);
+    }
+
     [Fact] public void View_StatusBanner_NamesCSkillSys300() {
         string axaml = ReadAxaml();
         Assert.Contains("CSkillSys", axaml);

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml
@@ -231,11 +231,17 @@
                           Name="LearnInfoLink" Content="Click here for acquired level and skill details"
                           Click="OnLearnInfo" Classes="Hyperlink" HorizontalAlignment="Left" />
 
-                  <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,4,0,0">
+                  <!-- #1011: Bulk Import/Export are DISABLED for the C-SkillSys variant — WinForms
+                       SkillAssignmentClassCSkillSysForm.ExportAllData/ImportAllData are empty stubs
+                       (the bulk serializer exists only on the non-C SkillSystem sibling). The tooltip
+                       lives on this ENABLED StackPanel because a disabled Avalonia control is not
+                       hit-testable and would not surface its own ToolTip on hover. -->
+                  <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,4,0,0"
+                              ToolTip.Tip="Bulk Import/Export is not available for the C-SkillSys variant (unimplemented in WinForms too).">
                     <Button AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_ImportAll_Button"
-                            Name="ImportAllButton" Content="Bulk Import" Click="OnImportAll" MinWidth="140" />
+                            Name="ImportAllButton" Content="Bulk Import" IsEnabled="False" MinWidth="140" />
                     <Button AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_ExportAll_Button"
-                            Name="ExportAllButton" Content="Bulk Export" Click="OnExportAll" MinWidth="140" />
+                            Name="ExportAllButton" Content="Bulk Export" IsEnabled="False" MinWidth="140" />
                   </StackPanel>
 
                 </StackPanel>

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml.cs
@@ -488,18 +488,11 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         // -----------------------------------------------------------------
-        // No-op stubs (mirror WF — ExportAll/ImportAll are empty in WF).
+        // #1011: Bulk Export/Import are DISABLED in the view (WF stubs them —
+        // ExportAllData/ImportAllData are empty). The buttons carry no Click
+        // handler now; they are greyed out with an explanatory tooltip on the
+        // wrapping StackPanel rather than advertising a silent no-op.
         // -----------------------------------------------------------------
-
-        void OnExportAll(object? sender, RoutedEventArgs e)
-        {
-            Log.Notify("SkillAssignmentClassCSkillSysView.OnExportAll: not implemented (mirrors WF stub).");
-        }
-
-        void OnImportAll(object? sender, RoutedEventArgs e)
-        {
-            Log.Notify("SkillAssignmentClassCSkillSysView.OnImportAll: not implemented (mirrors WF stub).");
-        }
 
         void OnLearnInfo(object? sender, RoutedEventArgs e)
         {

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -10259,3 +10259,6 @@ FE8N Ver1 にはアイコンのインポート/エクスポートがありませ
 
 :FE8N Ver1 has no animation pointer or animation I/O in WinForms (render-only). Disabled by design (#1008).
 FE8N Ver1 には WinForms でアニメーションポインタやアニメーションI/Oがありません（表示専用）。設計上無効 (#1008)。
+
+:Bulk Import/Export is not available for the C-SkillSys variant (unimplemented in WinForms too).
+一括インポート/エクスポートはC-SkillSys版では使用できません（WinForms版でも未実装）。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -24091,3 +24091,6 @@ FE8N Ver1 没有图标导入/导出功能 — WinForms 的 SkillConfigFE8NSkillF
 
 :FE8N Ver1 has no animation pointer or animation I/O in WinForms (render-only). Disabled by design (#1008).
 FE8N Ver1 在 WinForms 中没有动画指针或动画 I/O（仅供显示）。设计上已禁用 (#1008)。
+
+:Bulk Import/Export is not available for the C-SkillSys variant (unimplemented in WinForms too).
+C-SkillSys 版本不支持批量导入/导出（WinForms 版本同样未实现）。


### PR DESCRIPTION
## Summary
The C-SkillSys class skill-assignment editor exposed **enabled** "Bulk Import"/"Bulk Export" buttons whose handlers only logged a no-op. WinForms itself stubs these (`SkillAssignmentClassCSkillSysForm.ExportAllData` = `{ return; }`, `ImportAllData` = `{ return false; }`) — the real bulk serializer exists only on the non-C SkillSystem sibling. This makes the buttons **disabled** with an explanatory tooltip so the UI no longer advertises a silent no-op (the honest, WF-faithful fix per the issue's acceptance criteria).

Plan reviewed + accepted by Copilot CLI (issue #1011 thread).

Closes #1011.

## Changes
- `SkillAssignmentClassCSkillSysView.axaml` — both bulk buttons set `IsEnabled="False"`; the `Click` bindings removed. The explanatory `ToolTip.Tip` lives on the **enabled** wrapping `StackPanel` (a disabled Avalonia control isn't hit-testable and wouldn't surface its own tooltip — Copilot plan-review nuance).
- `SkillAssignmentClassCSkillSysView.axaml.cs` — removed the two no-op `OnExportAll`/`OnImportAll` handlers; updated the section comment.
- `config/translate/ja.txt` + `zh.txt` — ja/zh translations for the new tooltip (L10n coverage).
- `SkillAssignmentClassCSkillSysParityTests.cs` — new `View_BulkButtons_AreDisabled_WithTooltip` (both buttons `IsEnabled="False"`, no `Click=`, tooltip present); existing `View_HasExportImportButtons` still green.

## Screenshot (FE8J_skill.gba, live Avalonia editor)
The C-SkillSys editor with **Bulk Import / Bulk Export greyed-out/disabled** (vs. the dark enabled Write/Reload buttons):

![Bulk buttons disabled](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1011-cskillsys-bulk-disabled.png)

## Test plan
- [x] `dotnet build FEBuilderGBA.Avalonia` (Debug) — 0 errors (proves the removed handlers were unreferenced)
- [x] `SkillAssignmentClassCSkillSysParityTests` — **35/35** (incl. the new disabled-buttons test)
- [x] `L10nCoverageTest.AvaloniaViews_HaveJaAndZhTranslations` — green (tooltip now has ja+zh entries)
- [x] Full `FEBuilderGBA.Avalonia.Tests` — **7644/7647** (3 skipped, **0 failures**)
- [x] Live GUI: opened the C-SkillSys editor on FE8J_skill.gba; both Bulk buttons render disabled (screenshot above)

## GUI Test Report
Captured live from the running Avalonia app (UIAutomation navigation + PrintWindow capture).

| Test | Result |
|---|---|
| Open Class CSkillSys editor | ✅ PASS |
| Bulk Import button disabled (greyed) | ✅ PASS (screenshot) |
| Bulk Export button disabled (greyed) | ✅ PASS (screenshot) |
| Enabled controls (Write/Reload) unaffected | ✅ PASS (screenshot) |

## Out of scope
Implementing real C-SkillSys bulk TSV export/import — WinForms itself doesn't (its handlers are empty); that would be a new feature, not a parity fix.

---
Original request: *"set ralph loop to resolve all open GitHub issues in laqieer/FEBuilderGBA"* — 13th issue in the autonomous sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.168` · model `claude-opus-4-8[1m]`
