### PR TITLE
fix(avalonia): wire up World Map Image Decrease-Color + Open-Source buttons (#1013)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/WorldMapImageParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/WorldMapImageParityTests.cs
@@ -245,12 +245,11 @@ public class WorldMapImageParityTests
     // WorldMapImage_Main_Import_Button   — wired (#875, see View_ImportDarkButtons_AreWired)
     // WorldMapImage_Main_DarkImport_Button — wired (#875)
     // WorldMapImage_Main_DarkExport_Button — wired (#875)
+    // WorldMapImage_Main_DecreaseColor_Button — wired (#1013, see View_DecreaseColorButtons_AreWired)
+    // WorldMapImage_Main_OpenSource_Button / SelectSource_Button — wired (#1013, see View_SourceFileButtons_AreWired)
+    // WorldMapImage_Event_DecreaseColor_Button — wired (#1013)
     [InlineData("WorldMapImage_Main_Export_Button")]
-    [InlineData("WorldMapImage_Main_DecreaseColor_Button")]
-    [InlineData("WorldMapImage_Main_OpenSource_Button")]
-    [InlineData("WorldMapImage_Main_SelectSource_Button")]
     [InlineData("WorldMapImage_Event_Import_Button")]
-    [InlineData("WorldMapImage_Event_DecreaseColor_Button")]
     [InlineData("WorldMapImage_Mini_Import_Button")]
     [InlineData("WorldMapImage_PointIcon_Point1Import_Button")]
     [InlineData("WorldMapImage_PointIcon_Point2Import_Button")]
@@ -270,6 +269,97 @@ public class WorldMapImageParityTests
 
         Assert.Contains("IsEnabled=\"False\"", element);
         Assert.Contains("KnownGap", element);
+    }
+
+    /// <summary>
+    /// #1013: the Main + Event Decrease-Color Tool buttons are now wired
+    /// (previously KnownGap-disabled). Each must NOT be IsEnabled="False",
+    /// NOT reference KnownGap, and have a Click handler wired to the
+    /// corresponding code-behind handler (which opens DecreaseColorTSAToolView
+    /// + InitMethod 3/4).
+    /// </summary>
+    [Theory]
+    [InlineData("WorldMapImage_Main_DecreaseColor_Button", "MainDecreaseColor_Click", "InitMethod(3)")]
+    [InlineData("WorldMapImage_Event_DecreaseColor_Button", "EventDecreaseColor_Click", "InitMethod(4)")]
+    public void View_DecreaseColorButtons_AreWired(string automationId, string clickHandler, string initMethod)
+    {
+        string axaml = ReadAxaml();
+        int idx = axaml.IndexOf($"AutomationId=\"{automationId}\"", StringComparison.Ordinal);
+        Assert.True(idx >= 0, $"AutomationId {automationId} not found in AXAML");
+
+        int elementStart = axaml.LastIndexOf('<', idx);
+        Assert.True(elementStart >= 0);
+        int elementEnd = FindElementEnd(axaml, elementStart);
+        Assert.True(elementEnd > elementStart);
+        string element = axaml.Substring(elementStart, elementEnd - elementStart + 1);
+
+        Assert.Contains($"Click=\"{clickHandler}\"", element);
+        Assert.DoesNotContain("IsEnabled=\"False\"", element);
+        Assert.DoesNotContain("KnownGap", element);
+
+        // The click handler exists in the code-behind and routes through
+        // DecreaseColorTSAToolView with the correct InitMethod index.
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        Assert.Contains(clickHandler, source);
+        Assert.Contains("DecreaseColorTSAToolView", source);
+        Assert.Contains(initMethod, source);
+    }
+
+    /// <summary>
+    /// #1013: the Main Open Source File / Open Source Folder buttons are now
+    /// wired (previously KnownGap-disabled). Each must NOT be IsEnabled="False",
+    /// NOT reference KnownGap, be gated visible via
+    /// IsVisible="{Binding IsSourceFileAvailable}", and have a Click handler.
+    /// </summary>
+    [Theory]
+    [InlineData("WorldMapImage_Main_OpenSource_Button", "OpenSource_Click")]
+    [InlineData("WorldMapImage_Main_SelectSource_Button", "SelectSource_Click")]
+    public void View_SourceFileButtons_AreWired(string automationId, string clickHandler)
+    {
+        string axaml = ReadAxaml();
+        int idx = axaml.IndexOf($"AutomationId=\"{automationId}\"", StringComparison.Ordinal);
+        Assert.True(idx >= 0, $"AutomationId {automationId} not found in AXAML");
+
+        int elementStart = axaml.LastIndexOf('<', idx);
+        Assert.True(elementStart >= 0);
+        int elementEnd = FindElementEnd(axaml, elementStart);
+        Assert.True(elementEnd > elementStart);
+        string element = axaml.Substring(elementStart, elementEnd - elementStart + 1);
+
+        Assert.Contains($"Click=\"{clickHandler}\"", element);
+        Assert.Contains("IsVisible=\"{Binding IsSourceFileAvailable}\"", element);
+        Assert.DoesNotContain("IsEnabled=\"False\"", element);
+        Assert.DoesNotContain("KnownGap", element);
+
+        // The click handler exists in the code-behind.
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        Assert.Contains(clickHandler, source);
+    }
+
+    /// <summary>
+    /// #1013: the main-import driver records the imported source-file path so
+    /// the Open Source File / Folder buttons become available. The dark-import
+    /// driver must NOT record one (WF dark import never updates ResourceCache).
+    /// </summary>
+    [Fact]
+    public void View_MainImportRecordsSource_DarkImportDoesNot()
+    {
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        int mainIdx = source.IndexOf("DoMainImport", StringComparison.Ordinal);
+        Assert.True(mainIdx > 0);
+        int darkIdx = source.IndexOf("DoDarkImport", StringComparison.Ordinal);
+        Assert.True(darkIdx > 0);
+        // RecordSourceFile is called somewhere (main import path).
+        Assert.Contains("_vm.RecordSourceFile(imagePath)", source);
+        // The dark-import method body must NOT call RecordSourceFile. Find the
+        // public DoDarkImport task body and confirm it has no RecordSourceFile.
+        int darkBodyStart = source.IndexOf("public async System.Threading.Tasks.Task DoDarkImport", StringComparison.Ordinal);
+        Assert.True(darkBodyStart > 0);
+        // Scan to the next "public " method declaration after DoDarkImport.
+        int nextPublic = source.IndexOf("\n        public ", darkBodyStart + 10, StringComparison.Ordinal);
+        if (nextPublic < 0) nextPublic = source.Length;
+        string darkBody = source.Substring(darkBodyStart, nextPublic - darkBodyStart);
+        Assert.DoesNotContain("RecordSourceFile", darkBody);
     }
 
     /// <summary>
@@ -946,9 +1036,89 @@ public class WorldMapImageParityTests
         finally { CoreState.ROM = prev; }
     }
 
+    /// <summary>
+    /// #1013: RecordSourceFile writes the path under the fixed WF "WorldMap_"
+    /// ResourceCache key and sets IsSourceFileAvailable based on File.Exists;
+    /// RefreshSourceFile reads the same value back. A non-existent path leaves
+    /// IsSourceFileAvailable false (but SourceFilePath is still set).
+    /// </summary>
+    [Fact]
+    public void ViewModel_RecordAndRefreshSourceFile_RoundTripsViaResourceCache()
+    {
+        EnsureCoreStateBaseDirectory();
+        var prevRes = CoreState.ResourceCache;
+        string tempFile = Path.GetTempFileName();
+        try
+        {
+            var cache = new FEBuilderGBA.EtcCacheResource();
+            CoreState.ResourceCache = cache;
+
+            var vm = new WorldMapImageViewModel();
+
+            // Record a REAL temp file → available + path set.
+            vm.RecordSourceFile(tempFile);
+            Assert.Equal(tempFile, vm.SourceFilePath);
+            Assert.True(vm.IsSourceFileAvailable);
+
+            // Refresh reads the SAME value back from the "WorldMap_" key.
+            vm.SourceFilePath = string.Empty;
+            vm.IsSourceFileAvailable = false;
+            vm.RefreshSourceFile();
+            Assert.Equal(tempFile, vm.SourceFilePath);
+            Assert.True(vm.IsSourceFileAvailable);
+
+            // The fixed WF key is used (not per-index).
+            Assert.Equal(tempFile, cache.At("WorldMap_", string.Empty));
+
+            // A non-existent path → SourceFilePath set, but not available.
+            string missing = Path.Combine(Path.GetTempPath(), "nope_worldmap_xyz.png");
+            vm.RecordSourceFile(missing);
+            Assert.Equal(missing, vm.SourceFilePath);
+            Assert.False(vm.IsSourceFileAvailable);
+        }
+        finally
+        {
+            CoreState.ResourceCache = prevRes;
+            try { if (File.Exists(tempFile)) File.Delete(tempFile); } catch { /* best-effort cleanup */ }
+        }
+    }
+
+    /// <summary>
+    /// #1013: with no ResourceCache wired, RefreshSourceFile must clear the
+    /// affordance (false + empty path), never throw.
+    /// </summary>
+    [Fact]
+    public void ViewModel_RefreshSourceFile_NullCache_ClearsAffordance()
+    {
+        var prevRes = CoreState.ResourceCache;
+        try
+        {
+            CoreState.ResourceCache = null;
+            var vm = new WorldMapImageViewModel
+            {
+                SourceFilePath = "stale",
+                IsSourceFileAvailable = true,
+            };
+            vm.RefreshSourceFile();
+            Assert.False(vm.IsSourceFileAvailable);
+            Assert.Equal(string.Empty, vm.SourceFilePath);
+        }
+        finally { CoreState.ResourceCache = prevRes; }
+    }
+
     // ===================================================================
     // Helpers
     // ===================================================================
+
+    static void EnsureCoreStateBaseDirectory()
+    {
+        if (!string.IsNullOrEmpty(CoreState.BaseDirectory))
+            return;
+        string? assemblyDir = Path.GetDirectoryName(
+            System.Reflection.Assembly.GetExecutingAssembly().Location);
+        if (assemblyDir != null)
+            CoreState.BaseDirectory = assemblyDir;
+    }
 
     static int FindElementEnd(string axaml, int elementStart)
     {

--- a/FEBuilderGBA.Avalonia/ViewModels/WorldMapImageViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/WorldMapImageViewModel.cs
@@ -105,6 +105,37 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         bool _isLoaded;
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
 
+        // ---- #1013: Source-file affordance (mirrors ImageBGViewModel). WF
+        // WorldMapImageForm records the imported source-image path under the
+        // FIXED ResourceCache key "WorldMap_" (NOT per-index). Open Source
+        // File / Folder become available only when the recorded file exists. ----
+        const string SourceFileResourceKey = "WorldMap_";   // matches WF WorldMapImageForm
+        string _sourceFilePath = string.Empty;
+        bool _isSourceFileAvailable;
+        public string SourceFilePath { get => _sourceFilePath; set => SetField(ref _sourceFilePath, value); }
+        public bool IsSourceFileAvailable { get => _isSourceFileAvailable; set => SetField(ref _isSourceFileAvailable, value); }
+
+        /// <summary>Re-read the recorded World Map source-image path from ResourceCache (WF "WorldMap_" key).</summary>
+        public void RefreshSourceFile()
+        {
+            var cache = CoreState.ResourceCache as FEBuilderGBA.EtcCacheResource;
+            if (cache == null) { IsSourceFileAvailable = false; SourceFilePath = string.Empty; return; }
+            string path = cache.At(SourceFileResourceKey, string.Empty);
+            SourceFilePath = path ?? string.Empty;
+            IsSourceFileAvailable = !string.IsNullOrEmpty(SourceFilePath) && System.IO.File.Exists(SourceFilePath);
+        }
+
+        /// <summary>Record a new World Map source-image path after a successful MAIN import (WF ImportButton_Click).</summary>
+        public void RecordSourceFile(string path)
+        {
+            if (string.IsNullOrEmpty(path)) return;
+            var cache = CoreState.ResourceCache as FEBuilderGBA.EtcCacheResource;
+            if (cache == null) return;
+            cache.Update(SourceFileResourceKey, path);
+            SourceFilePath = path;
+            IsSourceFileAvailable = System.IO.File.Exists(path);
+        }
+
         // ---- Reuse-based preview export gates (#843 NV5a) + main field map
         // (#846 NV5b) + county border (#849 NV5c). Each is set true only after a
         // successful render so the per-preview "Export PNG" button stays disabled
@@ -145,6 +176,10 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             Point2ImagePtr = rom.u32(rom.RomInfo.worldmap_icon2_pointer);
             RoadImagePtr = rom.u32(rom.RomInfo.worldmap_road_tile_pointer);
             IconPalettePtr = rom.u32(rom.RomInfo.worldmap_icon_palette_pointer);
+            // #1013: re-populate the source-file affordance from ResourceCache
+            // (WF "WorldMap_" key) so Open Source File / Folder light up if a
+            // path was recorded by a previous import.
+            RefreshSourceFile();
             IsLoaded = true;
         }
 

--- a/FEBuilderGBA.Avalonia/Views/DecreaseColorTSAToolView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/DecreaseColorTSAToolView.axaml.cs
@@ -65,7 +65,7 @@ namespace FEBuilderGBA.Avalonia.Views
         /// honest so a future full port can pick the mode without
         /// breaking existing callers.
         /// </summary>
-        /// <param name="methodIndex">WF method index — 2 = Battle BG.</param>
+        /// <param name="methodIndex">WF method index — 2 = Battle BG, 3 = world map main, 4 = world map event.</param>
         public void InitMethod(int methodIndex)
         {
             _vm.Method = methodIndex;

--- a/FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml
@@ -112,16 +112,15 @@
 
             <Button AutomationProperties.AutomationId="WorldMapImage_Main_DecreaseColor_Button"
                     Content="Decrease Color Tool"
-                    IsEnabled="False"
-                    ToolTip.Tip="KnownGap: DecreaseColorTSAToolForm not yet ported." />
+                    Click="MainDecreaseColor_Click" />
             <Button AutomationProperties.AutomationId="WorldMapImage_Main_OpenSource_Button"
                     Content="Open Source File"
-                    IsEnabled="False"
-                    ToolTip.Tip="KnownGap: ResourceCache source-file feature not yet wired in Avalonia." />
+                    IsVisible="{Binding IsSourceFileAvailable}"
+                    Click="OpenSource_Click" />
             <Button AutomationProperties.AutomationId="WorldMapImage_Main_SelectSource_Button"
                     Content="Open Source Folder"
-                    IsEnabled="False"
-                    ToolTip.Tip="KnownGap: ResourceCache source-file feature not yet wired in Avalonia." />
+                    IsVisible="{Binding IsSourceFileAvailable}"
+                    Click="SelectSource_Click" />
           </StackPanel>
 
           <!-- Col 1: live main field-map preview (#846 NV5b — FE8-only, 480x320)
@@ -179,8 +178,7 @@
                     Click="EventExport_Click" />
             <Button AutomationProperties.AutomationId="WorldMapImage_Event_DecreaseColor_Button"
                     Content="Decrease Color Tool"
-                    IsEnabled="False"
-                    ToolTip.Tip="KnownGap: DecreaseColorTSAToolForm not yet ported." />
+                    Click="EventDecreaseColor_Click" />
           </StackPanel>
 
           <!-- #843: live event preview (32x20 tiles = 256x160) via

--- a/FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml.cs
@@ -13,6 +13,8 @@
 // A single top-level Undo button is present (Copilot CLI plan review C3 —
 // WinForms has no per-tab Undo; we don't introduce them either).
 using System;
+using System.Diagnostics;
+using System.IO;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Controls;
@@ -687,6 +689,11 @@ namespace FEBuilderGBA.Avalonia.Views
                     }
                     _undoService.Commit();
                     _vm.MarkClean();
+                    // #1013: record the imported source-file path under the WF
+                    // "WorldMap_" ResourceCache key so Open Source File / Folder
+                    // become available. WF ImportButton_Click records ONLY on the
+                    // MAIN import (not the dark import).
+                    _vm.RecordSourceFile(imagePath);
                 }
                 catch (Exception ex)
                 {
@@ -919,6 +926,82 @@ namespace FEBuilderGBA.Avalonia.Views
                 // Single interpolated string + full exception (Core Log.Error does
                 // not apply {0}/{1} substitution — see RenderInto).
                 Log.Error($"WorldMapImageView.ExportPreview({suggestedName}) failed: {ex}");
+            }
+        }
+
+        // ===================================================================
+        // #1013: Decrease Color Tool launchers (Main + Event tabs)
+        // ===================================================================
+
+        void MainDecreaseColor_Click(object? sender, RoutedEventArgs e)
+        {
+            // WF WorldMapImageForm.DecreaseColorTSAToolButton_Click → InitMethod(3) (world map main).
+            WindowManager.Instance.Open<DecreaseColorTSAToolView>().InitMethod(3);
+        }
+
+        void EventDecreaseColor_Click(object? sender, RoutedEventArgs e)
+        {
+            // WF DecreaseColorTSAToolForWorldmapEventButton_Click → InitMethod(4) (world map event).
+            WindowManager.Instance.Open<DecreaseColorTSAToolView>().InitMethod(4);
+        }
+
+        // ===================================================================
+        // #1013: Open Source File / Open Source Folder (Main tab)
+        // Mirrors ImageBGView.OpenSource_Click / SelectSource_Click. The
+        // recorded path lives in CoreState.ResourceCache under the FIXED WF
+        // "WorldMap_" key (see WorldMapImageViewModel). Buttons are gated
+        // visible only when IsSourceFileAvailable.
+        // ===================================================================
+
+        void OpenSource_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(_vm.SourceFilePath) || !File.Exists(_vm.SourceFilePath))
+                {
+                    CoreState.Services?.ShowError("Source file is not recorded.");
+                    return;
+                }
+                var psi = new ProcessStartInfo(_vm.SourceFilePath) { UseShellExecute = true };
+                Process.Start(psi);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("WorldMapImageView.OpenSource_Click: {0}", ex.Message);
+                CoreState.Services?.ShowError($"Failed to open source file: {ex.Message}");
+            }
+        }
+
+        void SelectSource_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(_vm.SourceFilePath) || !File.Exists(_vm.SourceFilePath))
+                {
+                    CoreState.Services?.ShowError("Source file is not recorded.");
+                    return;
+                }
+                if (OperatingSystem.IsWindows())
+                {
+                    var psi = new ProcessStartInfo("explorer.exe",
+                        $"/select,\"{_vm.SourceFilePath}\"")
+                        { UseShellExecute = true };
+                    Process.Start(psi);
+                }
+                else
+                {
+                    string? folder = Path.GetDirectoryName(_vm.SourceFilePath);
+                    if (!string.IsNullOrEmpty(folder))
+                    {
+                        var psi = new ProcessStartInfo(folder) { UseShellExecute = true };
+                        Process.Start(psi);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("WorldMapImageView.SelectSource_Click: {0}", ex.Message);
+                CoreState.Services?.ShowError($"Failed to open source folder: {ex.Message}");
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml.cs
@@ -957,9 +957,17 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                if (string.IsNullOrEmpty(_vm.SourceFilePath) || !File.Exists(_vm.SourceFilePath))
+                if (string.IsNullOrEmpty(_vm.SourceFilePath))
                 {
                     CoreState.Services?.ShowError("Source file is not recorded.");
+                    return;
+                }
+                if (!File.Exists(_vm.SourceFilePath))
+                {
+                    // The recorded path no longer exists — clear availability so the
+                    // buttons hide (IsVisible binding) and report the real cause.
+                    _vm.IsSourceFileAvailable = false;
+                    CoreState.Services?.ShowError($"Source file not found: {_vm.SourceFilePath}");
                     return;
                 }
                 var psi = new ProcessStartInfo(_vm.SourceFilePath) { UseShellExecute = true };
@@ -976,9 +984,15 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                if (string.IsNullOrEmpty(_vm.SourceFilePath) || !File.Exists(_vm.SourceFilePath))
+                if (string.IsNullOrEmpty(_vm.SourceFilePath))
                 {
                     CoreState.Services?.ShowError("Source file is not recorded.");
+                    return;
+                }
+                if (!File.Exists(_vm.SourceFilePath))
+                {
+                    _vm.IsSourceFileAvailable = false;
+                    CoreState.Services?.ShowError($"Source file not found: {_vm.SourceFilePath}");
                     return;
                 }
                 if (OperatingSystem.IsWindows())


### PR DESCRIPTION
## Summary
The World Map Image editor's "Decrease Color Tool" buttons (Main + Event tabs) and the "Open Source File"/"Open Source Folder" buttons were permanently `IsEnabled="False"` inert controls with stale `KnownGap` tooltips. The capabilities they reference are **already ported elsewhere** — this view just never wired them. This wires both, mirroring the existing `ImageBGView` pattern.

Plan reviewed + accepted by Copilot CLI (issue #1013 thread, incl. one parity correction — see below).

Closes #1013.

## Changes
**Part A — Decrease Color Tool launchers**
- Both `Decrease Color Tool` buttons re-enabled with `Click` handlers opening the already-ported `DecreaseColorTSAToolView`: WF parity uses `InitMethod(3)` for the Main tab and `InitMethod(4)` for the world-map-event tab (`WorldMapImageForm.cs:466-477`). Updated the `InitMethod` XML doc to note `3/4 = world map`.

**Part B — Open Source File / Folder (Main tab)**
- Added `SourceFilePath`/`IsSourceFileAvailable`/`RefreshSourceFile`/`RecordSourceFile` to `WorldMapImageViewModel`, using WF's **fixed** ResourceCache key `"WorldMap_"` (`WorldMapImageForm.cs:51-60,192-194,574-600`). `LoadAll()` calls `RefreshSourceFile()` so a recorded path re-populates on open.
- The source path is recorded **only** in `DoMainImport` after a successful commit — **not** `DoDarkImport` (Copilot review caught that WF's dark-map import never touches `"WorldMap_"`; only the main `ImportButton_Click` does).
- The two buttons gate visibility via `IsVisible="{Binding IsSourceFileAvailable}"` (matches WF Show/Hide) and shell-open the file / containing folder (`explorer /select` on Windows), mirroring `ImageBGView`.

No change to the Event/Mini/Point/Road/Border import buttons (#1000) or the Color-Reduction tool's actual operation (#998) — out of scope.

## Screenshots (FE8U.gba, live Avalonia)
World Map Image editor with the now-**enabled** "Decrease Color Tool" button (`IsEnabled=True` verified via UIAutomation):

![World Map editor, Decrease Color enabled](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1013-worldmap-decreasecolor-enabled.png)

Clicking it opens the Color Reduction Tool (proving the launcher wire-up; the tool's full UI is the separate #998 gap):

![Color Reduction Tool opens](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1013-tool-opened.png)

## Test plan
- [x] `dotnet build FEBuilderGBA.Avalonia` (Debug) — 0 errors
- [x] `WorldMapImage`-filtered tests — **62/62** (new: DecreaseColor buttons wired; source buttons wired w/ IsVisible binding; main-import records source & dark-import does NOT; VM `Record`/`Refresh` round-trips via ResourceCache with a real temp file; null-cache guard)
- [x] Full `FEBuilderGBA.Avalonia.Tests` — **7647/7650** (3 pre-existing skips, **0 failures**); `L10nCoverageTest` green (tooltips removed, no new English strings)
- [x] Live GUI: World Map editor "Decrease Color Tool" button `IsEnabled=True`; clicking opens the Color Reduction Tool (screenshots above)

## GUI Test Report
Captured live (UIAutomation navigation + PrintWindow).

| Test | Result |
|---|---|
| Open World Map Image editor (FE8U) | ✅ PASS |
| "Decrease Color Tool" button enabled (was disabled) | ✅ PASS (`IsEnabled=True`) |
| Clicking it opens the Color Reduction Tool | ✅ PASS (screenshot) |
| Open Source buttons hidden until a main import records a source path | ✅ PASS (IsVisible binding; round-trip covered by VM test) |

---
Original request: *"set ralph loop to resolve all open GitHub issues in laqieer/FEBuilderGBA"* — 14th issue in the autonomous sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.168` · model `claude-opus-4-8[1m]`
