### PR TITLE
fix(avalonia): add Class OP Demo N1 font-glyph preview via Core renderer (#1032)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -460,12 +460,10 @@ Specialized utilities for different graphic types:
   non-affine, non-bug (`bank<4`) 16-color bank → `max+1` (≥2 ⇒ banner). Animation-wide CONSERVATIVE
   (over-warns, never under-warns); affine excluded (WF draws them at shift 0); safe default 1 on guard fail.
 - `ClassOPDemoFontRenderCore.cs` (Core, READ-ONLY) — Class OP Demo N1 JP-name font-glyph preview (#1032;
-  ports WF `OPClassFontForm.DrawFontByID`/`DrawFont`). `RenderGlyphById(rom,id)` does a bounded DataCount
-  scan of the 4-byte-pointer table at `op_class_font_pointer` (rejects ids ≥ the contiguous run / overflow,
-  no `base+id*4` multiply before the bound) then `RenderGlyphImage` LZ77-decompresses the 4bpp glyph and
-  renders 32×32 via `ImageUtilCore.ByteToImage16Tile` with the `op_class_font_palette`. Avalonia
-  `ClassOPDemoView` GbaImageControl preview live-updates on the N1 glyph spinner / selection; null on any
-  guard fail (caller clears). Never throws.
+  ports WF `OPClassFontForm.DrawFontByID`/`DrawFont`). `RenderGlyphById(rom,id)` bounded-DataCount-scans the
+  4-byte-pointer table at `op_class_font_pointer` (reject id ≥ contiguous run; overflow-safe) → `RenderGlyphImage`
+  LZ77-decompresses the 4bpp glyph → 32×32 `ImageUtilCore.ByteToImage16Tile` with `op_class_font_palette`.
+  Drives the Avalonia `ClassOPDemoView` GbaImageControl preview (live on N1 spinner/selection); null on guard fail.
 
 ### Caching System
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -459,6 +459,13 @@ Specialized utilities for different graphic types:
   banner detector (#1033) replacing WF `GetPalette16Count`: scans all sections/frames' OAM for the max
   non-affine, non-bug (`bank<4`) 16-color bank → `max+1` (≥2 ⇒ banner). Animation-wide CONSERVATIVE
   (over-warns, never under-warns); affine excluded (WF draws them at shift 0); safe default 1 on guard fail.
+- `ClassOPDemoFontRenderCore.cs` (Core, READ-ONLY) — Class OP Demo N1 JP-name font-glyph preview (#1032;
+  ports WF `OPClassFontForm.DrawFontByID`/`DrawFont`). `RenderGlyphById(rom,id)` does a bounded DataCount
+  scan of the 4-byte-pointer table at `op_class_font_pointer` (rejects ids ≥ the contiguous run / overflow,
+  no `base+id*4` multiply before the bound) then `RenderGlyphImage` LZ77-decompresses the 4bpp glyph and
+  renders 32×32 via `ImageUtilCore.ByteToImage16Tile` with the `op_class_font_palette`. Avalonia
+  `ClassOPDemoView` GbaImageControl preview live-updates on the N1 glyph spinner / selection; null on any
+  guard fail (caller clears). Never throws.
 
 ### Caching System
 

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ClassOPDemoParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ClassOPDemoParityTests.cs
@@ -191,7 +191,7 @@ public class ClassOPDemoParityTests
     {
         string axaml = ReadAxaml();
         // The real GbaImageControl preview is now present...
-        Assert.Contains("AutomationId=\"ClassOPDemo_N1_GlyphPreview\"", axaml);
+        Assert.Contains("AutomationId=\"ClassOPDemo_N1_GlyphPreview_Image\"", axaml);
         Assert.Contains("<controls:GbaImageControl", axaml);
         // ...and the former N1FontGlyphPreview KnownGap is removed.
         Assert.DoesNotContain("KnownGap: N1FontGlyphPreview", axaml);

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ClassOPDemoParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ClassOPDemoParityTests.cs
@@ -181,6 +181,62 @@ public class ClassOPDemoParityTests
         Assert.Contains("AutomationId=\"ClassOPDemo_AnimeShared_List\"", axaml);
     }
 
+    // -----------------------------------------------------------------
+    // #1032 — N1 JP-name font-glyph image preview (port of WF
+    // OPClassFontForm.DrawFontByID/DrawFont via ClassOPDemoFontRenderCore).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_HasN1GlyphPreview_AndNoFontGlyphKnownGap()
+    {
+        string axaml = ReadAxaml();
+        // The real GbaImageControl preview is now present...
+        Assert.Contains("AutomationId=\"ClassOPDemo_N1_GlyphPreview\"", axaml);
+        Assert.Contains("<controls:GbaImageControl", axaml);
+        // ...and the former N1FontGlyphPreview KnownGap is removed.
+        Assert.DoesNotContain("KnownGap: N1FontGlyphPreview", axaml);
+    }
+
+    [Fact]
+    public void View_RefreshN1GlyphPreview_CallsCoreRenderer()
+    {
+        string source = ReadCodeBehind();
+        // The refresh method renders via the Core port and clears on null.
+        Assert.Matches(new Regex(
+            @"void\s+RefreshN1GlyphPreview[\s\S]*?ClassOPDemoFontRenderCore\.RenderGlyphById",
+            RegexOptions.Compiled), source);
+    }
+
+    [Fact]
+    public void View_SubscribesToN1B0BoxValueChanged_AndRefreshes()
+    {
+        string source = ReadCodeBehind();
+        Assert.Matches(new Regex(@"N1B0Box\.ValueChanged\s*\+=", RegexOptions.Compiled), source);
+        // The value-change path calls the refresh.
+        Assert.Matches(new Regex(
+            @"void\s+OnN1B0Changed[\s\S]*?RefreshN1GlyphPreview\(\)",
+            RegexOptions.Compiled), source);
+    }
+
+    [Fact]
+    public void View_OnN1Selected_RefreshesGlyphPreview()
+    {
+        string source = ReadCodeBehind();
+        Assert.Matches(new Regex(
+            @"void\s+OnN1Selected[\s\S]*?RefreshN1GlyphPreview\(\)",
+            RegexOptions.Compiled), source);
+    }
+
+    [Fact]
+    public void View_ApplyN1Rows_ClearsGlyphPreview()
+    {
+        string source = ReadCodeBehind();
+        // ApplyN1Rows (incl. the empty-list/reset path) clears the stale preview.
+        Assert.Matches(new Regex(
+            @"void\s+ApplyN1Rows[\s\S]*?N1GlyphPreview\??\.SetImage\(null\)",
+            RegexOptions.Compiled), source);
+    }
+
     [Fact]
     public void View_HasInlinePreviewLabels()
     {
@@ -497,9 +553,12 @@ public class ClassOPDemoParityTests
         var rx = new Regex(@"KnownGap:\s*(\S+(?:\s+\S+)*?)\s+reason=(.+?)\s*-->",
             RegexOptions.Compiled);
         var matches = rx.Matches(axaml);
+        // #1032: the N1FontGlyphPreview KnownGap was removed (implemented via
+        // ClassOPDemoFontRenderCore). The remaining markers are the
+        // battle-anime PNG preview + the patch-aware UI deferral.
         Assert.True(matches.Count >= 2,
             $"AXAML must contain at least 2 KnownGap markers (battle-anime PNG preview, " +
-            $"font glyph PNG preview); found {matches.Count}.");
+            $"patch-aware UI); found {matches.Count}.");
         foreach (Match m in matches)
         {
             Assert.False(string.IsNullOrWhiteSpace(m.Groups[1].Value),

--- a/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml
@@ -18,7 +18,10 @@
        N2 (anime spec tuple): single 6-byte tuple (orphan validator `i < 1`).
 
        KnownGap: BattleAnimePreview reason=Live ImageBattleAnimeForm.DrawBattleAnime PNG rendering is a large WinForms-only dep; deferred consistent with PRs #544/#549/#537. -->
-  <!-- KnownGap: N1FontGlyphPreview reason=N1_L_0_OPCLASSDEMOFONT PictureBox preview is a WinForms-only graphics pipeline; deferred consistent with PRs #544/#549/#537. -->
+  <!-- #1032: the former N1FontGlyphPreview KnownGap is REMOVED — the N1 JP-name
+       font-glyph image preview is now implemented via the cross-platform
+       ClassOPDemoFontRenderCore (port of WF OPClassFontForm.DrawFontByID/DrawFont)
+       and the GbaImageControl in the N1 sub-bar below. -->
   <!-- KnownGap: PatchAwareUI reason=Orphan ClassOPDemoForm constructor has zero PatchUtil calls; OPClassReelSort/Over255 affordances live in canonical OPClassDemoViewerView (PR #544). -->
   <Grid RowDefinitions="Auto,Auto,*" ColumnDefinitions="270,*">
 
@@ -212,8 +215,8 @@
           <DockPanel>
             <Label DockPanel.Dock="Top" Content="Japanese Name Pointer Target"
                    FontWeight="Bold" />
-            <!-- N1 sub-bar: Write Pointer / Address / Size / Selected / Glyph spinner / Write / List Expand -->
-            <Grid DockPanel.Dock="Bottom" ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="0,4,0,0">
+            <!-- N1 sub-bar: Write Pointer / Address / Size / Selected / Glyph spinner / Write / List Expand / Glyph image preview (#1032) -->
+            <Grid DockPanel.Dock="Bottom" ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="0,4,0,0">
               <Button Grid.Column="0"
                       AutomationProperties.AutomationId="ClassOPDemo_N1_WritePtr_Button"
                       Name="N1WritePtrButton" Content="Write JP Name Pointer"
@@ -247,6 +250,17 @@
                       AutomationProperties.AutomationId="ClassOPDemo_N1_ListExpand_Button"
                       Name="N1ListExpandButton" Content="List Expand"
                       Click="N1_ListExpand_Click" Margin="8,0,0,0" />
+              <!-- #1032: N1 JP-name font-glyph image preview. Renders the 32x32
+                   4bpp glyph for the current Glyph: id via
+                   ClassOPDemoFontRenderCore (port of WF
+                   OPClassFontForm.DrawFontByID/DrawFont). -->
+              <Label Grid.Column="11" Content="Glyph:" Margin="12,0,2,0" VerticalAlignment="Center" />
+              <Border Grid.Column="12" BorderBrush="Gray" BorderThickness="1"
+                      Width="48" Height="48" VerticalAlignment="Center">
+                <controls:GbaImageControl
+                    AutomationProperties.AutomationId="ClassOPDemo_N1_GlyphPreview"
+                    Name="N1GlyphPreview" Width="48" Height="48" />
+              </Border>
             </Grid>
             <controls:AddressListControl
                 AutomationProperties.AutomationId="ClassOPDemo_N1_List"

--- a/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml
@@ -258,7 +258,7 @@
               <Border Grid.Column="12" BorderBrush="Gray" BorderThickness="1"
                       Width="48" Height="48" VerticalAlignment="Center">
                 <controls:GbaImageControl
-                    AutomationProperties.AutomationId="ClassOPDemo_N1_GlyphPreview"
+                    AutomationProperties.AutomationId="ClassOPDemo_N1_GlyphPreview_Image"
                     Name="N1GlyphPreview" Width="48" Height="48" />
               </Border>
             </Grid>

--- a/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml.cs
@@ -66,6 +66,12 @@ namespace FEBuilderGBA.Avalonia.Views
             // — NOT N2B0 which is the fixed 0x05 marker (per the orphan
             // WF designer + Copilot CLI plan-review v2 finding #2 nit).
             N2B2Box.ValueChanged += OnN2B2Changed;
+            // #1032: editing the N1 glyph id live-updates the font-glyph image
+            // preview (mirrors WF OPCLASSDEMOFONT ValueChanged re-render). Gated
+            // by `_vm.IsLoading` so the load-time spinner writes don't render
+            // mid-load (the explicit post-selection RefreshN1GlyphPreview() in
+            // OnN1Selected handles the selection case).
+            N1B0Box.ValueChanged += OnN1B0Changed;
 
             // ComboBox.Items strings are NOT scanned by ViewTranslationHelper
             // (Copilot bot review thread `PRRT_kwDOH0Mc1M6ETSJC` on PR #544),
@@ -382,6 +388,12 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 finally { _vm.IsLoading = false; }
 
+                // #1032: clear any stale glyph preview when switching to a class
+                // with no N1 entries or an invalid JP-name pointer. SetItems on
+                // an empty list does NOT fire a selection callback, so this
+                // explicit clear is required.
+                N1GlyphPreview?.SetImage(null);
+
                 _n1Rows = rows;
                 var items = new List<AddrResult>();
                 for (int i = 0; i < _n1Rows.Count; i++)
@@ -417,6 +429,38 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 Log.Error("ClassOPDemoView.OnN1Selected failed: {0}", ex.Message);
+            }
+            // #1032: refresh the font-glyph image preview from the just-loaded
+            // glyph id. Run OUTSIDE the `_vm.IsLoading` gate above so it isn't
+            // skipped (the ValueChanged handler is gated by IsLoading).
+            RefreshN1GlyphPreview();
+        }
+
+        // #1032: editing the N1 glyph id live-updates the preview, mirroring the
+        // WF OPCLASSDEMOFONT ValueChanged re-render. Gated by `_vm.IsLoading`.
+        void OnN1B0Changed(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            if (_vm.IsLoading) return;
+            RefreshN1GlyphPreview();
+        }
+
+        /// <summary>
+        /// Render the N1 JP-name font glyph for the current Glyph: id into the
+        /// preview control. Port of WF OPClassFontForm.DrawFontByID/DrawFont via
+        /// the cross-platform ClassOPDemoFontRenderCore. A null/invalid id
+        /// clears the preview (GbaImageControl.SetImage(null)).
+        /// </summary>
+        void RefreshN1GlyphPreview()
+        {
+            try
+            {
+                N1GlyphPreview?.SetImage(
+                    ClassOPDemoFontRenderCore.RenderGlyphById(CoreState.ROM, (uint)(N1B0Box.Value ?? 0)));
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ClassOPDemoView.RefreshN1GlyphPreview failed: {0}", ex.Message);
+                N1GlyphPreview?.SetImage(null);
             }
         }
 

--- a/FEBuilderGBA.Core.Tests/ClassOPDemoFontRenderCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ClassOPDemoFontRenderCoreTests.cs
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1032 Core tests for ClassOPDemoFontRenderCore — the cross-platform Class OP
+// Demo N1 JP-name font-glyph render seam ported from WF
+// OPClassFontForm.DrawFontByID + DrawFont.
+//
+// The synthetic ROM plants:
+//   * op_class_font_pointer slot -> a table base
+//   * at the base, N glyph-image POINTERS, each -> an LZ77-compressed 4x4-tile
+//     (16 tiles x 32 bytes = 512-byte 4bpp glyph), then a 0 (non-pointer
+//     terminator) at slot N
+//   * op_class_font_palette_pointer slot -> a 16-color palette
+//
+// Core.Tests has a shared StubImageService (BattleAnimeDetailTests.cs) whose
+// CreateImage + GBAColorToRGBA are real enough to validate that
+// RenderGlyphById produces a non-null 32x32 IImage, plus all the null/blank
+// guard paths.
+using System;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class ClassOPDemoFontRenderCoreTests
+    {
+        // High offsets (>= 0x200, < ROM length) so isSafetyOffset passes.
+        const uint TableBase = 0x00500000u;
+        const uint Glyph0Off = 0x00510000u;
+        const uint Glyph1Off = 0x00520000u;
+        const uint PaletteOff = 0x00530000u;
+
+        sealed class ImageServiceScope : IDisposable
+        {
+            readonly IImageService _prev;
+            public ImageServiceScope()
+            {
+                _prev = CoreState.ImageService;
+                CoreState.ImageService = new StubImageService();
+            }
+            public void Dispose() { CoreState.ImageService = _prev; }
+        }
+
+        // Build a synthetic FE8U ROM with a 2-glyph OP-class-font table.
+        static ROM MakeRom()
+        {
+            var rom = new ROM();
+            byte[] data = new byte[0x1000000];
+            rom.LoadLow("x.gba", data, "BE8E01");
+
+            // A 4x4-tile (32x32) 4bpp glyph = 16 tiles x 32 bytes = 512 bytes.
+            byte[] rawGlyph = new byte[16 * 32];
+            for (int i = 0; i < rawGlyph.Length; i++)
+                rawGlyph[i] = (byte)0x11; // nibble 1 left+right => visible color index 1
+            byte[] comp = LZ77.compress(rawGlyph);
+            Array.Copy(comp, 0, rom.Data, Glyph0Off, comp.Length);
+            Array.Copy(comp, 0, rom.Data, Glyph1Off, comp.Length);
+
+            // Table base: slot0 -> Glyph0, slot1 -> Glyph1, slot2 -> 0 terminator.
+            U.write_u32(rom.Data, TableBase + 0, U.toPointer(Glyph0Off));
+            U.write_u32(rom.Data, TableBase + 4, U.toPointer(Glyph1Off));
+            U.write_u32(rom.Data, TableBase + 8, 0); // non-pointer terminator
+
+            // op_class_font_pointer slot -> table base.
+            U.write_u32(rom.Data, rom.RomInfo.op_class_font_pointer, U.toPointer(TableBase));
+
+            // 16-color palette (32 bytes). index 0 transparent, index 1 = green.
+            for (uint i = 0; i < 32; i++) rom.Data[PaletteOff + i] = 0;
+            U.write_u16(rom.Data, PaletteOff + 1 * 2, 0x03E0); // index 1 = green
+            U.write_u32(rom.Data, rom.RomInfo.op_class_font_palette_pointer, U.toPointer(PaletteOff));
+
+            return rom;
+        }
+
+        [Fact]
+        public void RenderGlyphById_Index0_Returns32x32NonNull()
+        {
+            var prevRom = CoreState.ROM;
+            using var svc = new ImageServiceScope();
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                using IImage img = ClassOPDemoFontRenderCore.RenderGlyphById(rom, 0);
+                Assert.NotNull(img);
+                Assert.Equal(32, img!.Width);
+                Assert.Equal(32, img.Height);
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void RenderGlyphById_Index1_Returns32x32NonNull()
+        {
+            var prevRom = CoreState.ROM;
+            using var svc = new ImageServiceScope();
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                using IImage img = ClassOPDemoFontRenderCore.RenderGlyphById(rom, 1);
+                Assert.NotNull(img);
+                Assert.Equal(32, img!.Width);
+                Assert.Equal(32, img.Height);
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void RenderGlyphById_TerminatorIndex_ReturnsNull()
+        {
+            var prevRom = CoreState.ROM;
+            using var svc = new ImageServiceScope();
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                // Index 2 == the 0 terminator slot — past the contiguous run.
+                using IImage img = ClassOPDemoFontRenderCore.RenderGlyphById(rom, 2);
+                Assert.Null(img);
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void RenderGlyphById_MaxUint_NoWraparound_ReturnsNull()
+        {
+            var prevRom = CoreState.ROM;
+            using var svc = new ImageServiceScope();
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                // A huge id whose base + id*4 would wrap in uint must NOT alias
+                // back into the table — the bounded DataCount scan rejects it.
+                using IImage img = ClassOPDemoFontRenderCore.RenderGlyphById(rom, uint.MaxValue);
+                Assert.Null(img);
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void RenderGlyphById_NonPointerSlot0_ReturnsNull()
+        {
+            var prevRom = CoreState.ROM;
+            using var svc = new ImageServiceScope();
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                // Wipe slot0 to a non-pointer (0) so the contiguous run is empty
+                // (glyphCount == 0), and id 0 is therefore out of range.
+                U.write_u32(rom.Data, TableBase + 0, 0);
+                using IImage img = ClassOPDemoFontRenderCore.RenderGlyphById(rom, 0);
+                Assert.Null(img);
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void RenderGlyphById_NullRom_ReturnsNull()
+        {
+            using var svc = new ImageServiceScope();
+            Assert.Null(ClassOPDemoFontRenderCore.RenderGlyphById(null, 0));
+        }
+
+        [Fact]
+        public void RenderGlyphById_NullImageService_ReturnsNull()
+        {
+            var prevRom = CoreState.ROM;
+            var prevSvc = CoreState.ImageService;
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                CoreState.ImageService = null;
+                Assert.Null(ClassOPDemoFontRenderCore.RenderGlyphById(rom, 0));
+            }
+            finally { CoreState.ROM = prevRom; CoreState.ImageService = prevSvc; }
+        }
+
+        [Fact]
+        public void RenderGlyphById_UnsafeTablePointer_ReturnsNull()
+        {
+            var prevRom = CoreState.ROM;
+            using var svc = new ImageServiceScope();
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                // Point op_class_font_pointer at 0 (unsafe table base).
+                U.write_u32(rom.Data, rom.RomInfo.op_class_font_pointer, 0);
+                using IImage img = ClassOPDemoFontRenderCore.RenderGlyphById(rom, 0);
+                Assert.Null(img);
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void RenderGlyphImage_NonPointer_ReturnsNull()
+        {
+            var prevRom = CoreState.ROM;
+            using var svc = new ImageServiceScope();
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                // 0 is not a pointer -> WF BlankDummy -> null preview.
+                using IImage img = ClassOPDemoFontRenderCore.RenderGlyphImage(rom, 0);
+                Assert.Null(img);
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void RenderGlyphImage_ValidPointer_Returns32x32NonNull()
+        {
+            var prevRom = CoreState.ROM;
+            using var svc = new ImageServiceScope();
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                using IImage img = ClassOPDemoFontRenderCore.RenderGlyphImage(rom, U.toPointer(Glyph0Off));
+                Assert.NotNull(img);
+                Assert.Equal(32, img!.Width);
+                Assert.Equal(32, img.Height);
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/ClassOPDemoFontRenderCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ClassOPDemoFontRenderCoreTests.cs
@@ -157,6 +157,25 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void RenderGlyphById_ZeroPalettePointer_ReturnsNull_NoThrow()
+        {
+            // #1059 review: a 0 palette-pointer slot (non-FE8 ROMs) must return null,
+            // NOT silently read palette bytes from offset 0. Also proves the guard
+            // doesn't throw when the resolved palette offset is unsafe.
+            var prevRom = CoreState.ROM;
+            using var svc = new ImageServiceScope();
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                U.write_u32(rom.Data, rom.RomInfo.op_class_font_palette_pointer, 0);
+                using IImage img = ClassOPDemoFontRenderCore.RenderGlyphById(rom, 0);
+                Assert.Null(img);
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
         public void RenderGlyphById_NullRom_ReturnsNull()
         {
             using var svc = new ImageServiceScope();

--- a/FEBuilderGBA.Core.Tests/ClassOPDemoFontRenderCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ClassOPDemoFontRenderCoreTests.cs
@@ -157,6 +157,30 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void RenderGlyphById_OversizedLz77Header_ReturnsNull_NoOom()
+        {
+            // #1059 review: a corrupt glyph pointer whose LZ77 header encodes a size
+            // beyond MAX_UNCOMP_DATA_LIMIT must return null (getUncompressSize == 0),
+            // NOT allocate a huge buffer in LZ77.decompress (OutOfMemoryException).
+            var prevRom = CoreState.ROM;
+            using var svc = new ImageServiceScope();
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                // Overwrite glyph 0's LZ77 header with a valid 0x10 type but an
+                // enormous (0xFFFFFF) uncompressed size — over the cap.
+                rom.Data[Glyph0Off + 0] = 0x10;
+                rom.Data[Glyph0Off + 1] = 0xFF;
+                rom.Data[Glyph0Off + 2] = 0xFF;
+                rom.Data[Glyph0Off + 3] = 0xFF;
+                using IImage img = ClassOPDemoFontRenderCore.RenderGlyphById(rom, 0);
+                Assert.Null(img);
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
         public void RenderGlyphById_ZeroPalettePointer_ReturnsNull_NoThrow()
         {
             // #1059 review: a 0 palette-pointer slot (non-FE8 ROMs) must return null,

--- a/FEBuilderGBA.Core/ClassOPDemoFontRenderCore.cs
+++ b/FEBuilderGBA.Core/ClassOPDemoFontRenderCore.cs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1032 — Cross-platform Core renderer for the Class OP Demo editor's N1
+// JP-name font-glyph image preview. Port of WinForms
+// OPClassFontForm.DrawFontByID + DrawFont (READ-ONLY, never mutates the ROM).
+//
+// The OP-class-font table at p32(op_class_font_pointer) is an array of 4-byte
+// glyph-image pointers (WF InputFormRef BlockSize 4); each glyph image is
+// LZ77-compressed 4bpp tile data rendered 32x32 (4x4 tiles) with the 16-color
+// op_class_font_palette.
+using System;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// READ-ONLY cross-platform renderer for the OP-class JP-name font glyphs
+    /// (port of WinForms <c>OPClassFontForm.DrawFontByID</c> + <c>DrawFont</c>).
+    /// </summary>
+    public static class ClassOPDemoFontRenderCore
+    {
+        /// <summary>Generous upper bound on the OP-class-font table size (the DataCount scan).</summary>
+        const uint ScanCap = 0x4000;
+
+        /// <summary>
+        /// Render the OP-class JP-name font glyph for table index <paramref name="id"/>.
+        /// Cross-platform port of WF OPClassFontForm.DrawFontByID + DrawFont: the table
+        /// at p32(op_class_font_pointer) is an array of 4-byte glyph-image pointers
+        /// (WF InputFormRef BlockSize 4); IDToAddr(id) = base + id*4; the glyph image is
+        /// LZ77-compressed 4bpp tile data rendered 32x32 (4x4 tiles) with the
+        /// op_class_font_palette. Returns null (caller clears the preview) for an id past
+        /// the contiguous pointer run / a non-pointer (blank) slot / unsafe addresses /
+        /// failed decompress. Never throws.
+        /// </summary>
+        public static IImage RenderGlyphById(ROM rom, uint id)
+        {
+            if (rom?.RomInfo == null || CoreState.ImageService == null) return null;
+            uint tablePtr = rom.RomInfo.op_class_font_pointer;
+            if (!U.isSafetyOffset(tablePtr, rom)) return null;
+            uint tableBase = rom.p32(tablePtr);
+            if (!U.isSafetyOffset(tableBase, rom)) return null;
+
+            // WF IDToAddr returns NOT_FOUND for id >= DataCount, where DataCount is the
+            // contiguous run of pointer entries from the base. Scan (bounded) and reject
+            // an id at/after the first non-pointer terminator. No base+id*4 multiply
+            // before this bound, so a huge uint id can't wrap.
+            uint glyphCount = 0;
+            for (uint i = 0; i < ScanCap; i++)
+            {
+                uint slot = tableBase + i * 4;
+                if (slot + 4 > (uint)rom.Data.Length) break;     // EOF / overflow-safe
+                if (!U.isPointer(rom.u32(slot))) break;          // terminator
+                glyphCount = i + 1;
+            }
+            if (id >= glyphCount) return null;
+
+            uint image = rom.u32(tableBase + id * 4);
+            return RenderGlyphImage(rom, image);
+        }
+
+        /// <summary>
+        /// Render a single OP-class font glyph from its image pointer (WF DrawFont):
+        /// LZ77-decompress the 4bpp tile data and render 32x32 (4x4 tiles) with the
+        /// 16-color op_class_font_palette read straight from rom.Data. Returns null for a
+        /// non-pointer/unsafe image or a failed decompress. Exposed for reuse by the OP
+        /// Class Font viewer (parity follow-up). Never throws.
+        /// </summary>
+        public static IImage RenderGlyphImage(ROM rom, uint image)
+        {
+            if (rom?.RomInfo == null || CoreState.ImageService == null) return null;
+            if (!U.isPointer(image)) return null;                // WF BlankDummy → null preview
+            uint imageOff = U.toOffset(image);
+            if (!U.isSafetyOffset(imageOff, rom)) return null;
+            byte[] tileData = LZ77.decompress(rom.Data, imageOff);
+            if (tileData == null || tileData.Length == 0) return null;
+            uint palette = rom.p32(rom.RomInfo.op_class_font_palette_pointer);
+            // 4x4 tiles = 32x32, single 16-color palette read straight from rom.Data
+            // (mirrors WF DrawFont's ByteToImage16Tile(32,32, imageUZ,0, rom.Data, palOff)).
+            return ImageUtilCore.ByteToImage16Tile(tileData, 0, rom.Data, (int)U.toOffset(palette), 32, 32);
+        }
+    }
+}

--- a/FEBuilderGBA.Core/ClassOPDemoFontRenderCore.cs
+++ b/FEBuilderGBA.Core/ClassOPDemoFontRenderCore.cs
@@ -71,6 +71,10 @@ namespace FEBuilderGBA
             if (!U.isPointer(image)) return null;                // WF BlankDummy → null preview
             uint imageOff = U.toOffset(image);
             if (!U.isSafetyOffset(imageOff, rom)) return null;
+            // getUncompressSize enforces MAX_UNCOMP_DATA_LIMIT (LZ77.decompress does NOT),
+            // so a corrupt/garbage pointer with a huge size header can't force an oversized
+            // allocation / OutOfMemoryException — return null for an invalid header. #1059 review.
+            if (LZ77.getUncompressSize(rom.Data, imageOff) == 0) return null;
             byte[] tileData = LZ77.decompress(rom.Data, imageOff);
             if (tileData == null || tileData.Length == 0) return null;
             // Guard the palette POINTER slot: a 0 slot (non-FE8 ROMs) or a near-EOF

--- a/FEBuilderGBA.Core/ClassOPDemoFontRenderCore.cs
+++ b/FEBuilderGBA.Core/ClassOPDemoFontRenderCore.cs
@@ -34,7 +34,9 @@ namespace FEBuilderGBA
         {
             if (rom?.RomInfo == null || CoreState.ImageService == null) return null;
             uint tablePtr = rom.RomInfo.op_class_font_pointer;
-            if (!U.isSafetyOffset(tablePtr, rom)) return null;
+            // isSafetyOffset only checks tablePtr < Data.Length, not that the 4-byte
+            // p32 read is in-bounds; guard tablePtr+4 so rom.p32 can't throw. #1059 review.
+            if (!U.isSafetyOffset(tablePtr, rom) || tablePtr + 4 > (uint)rom.Data.Length) return null;
             uint tableBase = rom.p32(tablePtr);
             if (!U.isSafetyOffset(tableBase, rom)) return null;
 
@@ -71,10 +73,16 @@ namespace FEBuilderGBA
             if (!U.isSafetyOffset(imageOff, rom)) return null;
             byte[] tileData = LZ77.decompress(rom.Data, imageOff);
             if (tileData == null || tileData.Length == 0) return null;
-            uint palette = rom.p32(rom.RomInfo.op_class_font_palette_pointer);
+            // Guard the palette POINTER slot: a 0 slot (non-FE8 ROMs) or a near-EOF
+            // address would otherwise read garbage / throw in p32. Then validate the
+            // RESOLVED palette offset before rendering. #1059 review.
+            uint palPtr = rom.RomInfo.op_class_font_palette_pointer;
+            if (!U.isSafetyOffset(palPtr, rom) || palPtr + 4 > (uint)rom.Data.Length) return null;
+            uint palOff = U.toOffset(rom.p32(palPtr));
+            if (!U.isSafetyOffset(palOff, rom)) return null;
             // 4x4 tiles = 32x32, single 16-color palette read straight from rom.Data
             // (mirrors WF DrawFont's ByteToImage16Tile(32,32, imageUZ,0, rom.Data, palOff)).
-            return ImageUtilCore.ByteToImage16Tile(tileData, 0, rom.Data, (int)U.toOffset(palette), 32, 32);
+            return ImageUtilCore.ByteToImage16Tile(tileData, 0, rom.Data, (int)palOff, 32, 32);
         }
     }
 }


### PR DESCRIPTION
## Summary
Adds the missing **N1 JP-name font-glyph image preview** to the Class OP Demo editor (the N1 list previously showed the glyph id as hex text only). Ports WF `OPClassFontForm.DrawFontByID`/`DrawFont` to a cross-platform Core renderer + a `GbaImageControl` preview that live-updates on the N1 glyph spinner / selection.

Plan reviewed + accepted by Copilot CLI (issue #1032 thread, with 7 hardening adjustments applied).

Closes #1032.

## Changes
- **`FEBuilderGBA.Core/ClassOPDemoFontRenderCore.cs`** (new, READ-ONLY):
  - `RenderGlyphById(rom, id)` — does a **bounded DataCount scan** of the 4-byte-pointer table at `op_class_font_pointer` (rejects `id` at/after the first non-pointer terminator, exactly like WF `InputFormRef.IDToAddr` returning `NOT_FOUND` for `id >= DataCount`; no `base + id*4` multiply before the bound, so a huge `uint` id can't wrap), then `RenderGlyphImage`.
  - `RenderGlyphImage(rom, imagePtr)` — LZ77-decompresses the 4bpp glyph and renders 32×32 (4×4 tiles) via `ImageUtilCore.ByteToImage16Tile` with the `op_class_font_palette` read straight from `rom.Data` (faithful to WF `DrawFont`). Exposed for the OP Class Font viewer parity follow-up.
  - Every address guarded; returns `null` (caller clears the preview) on out-of-range id / non-pointer (blank) slot / unsafe address / failed decompress. Never throws.
- **`ClassOPDemoView`** — replaced the `KnownGap: N1FontGlyphPreview` comment with a real `GbaImageControl` (`ClassOPDemo_N1_GlyphPreview`). `RefreshN1GlyphPreview()` renders the current N1 glyph id and is called from the `N1B0Box.ValueChanged` subscription (live edit) **and** from `OnN1Selected` (after the `IsLoading` gate, so it isn't suppressed); `ApplyN1Rows` explicitly clears the preview (`SetImage(null)`) when the N1 list resets/empties (since `SetItems(empty)` fires no selection callback).

## Screenshot (FE8J.gba, live Avalonia)
Class OP Demo editor, class **アーチャー (Archer)** selected → N1 row `00: 0x0B` selected (Glyph spinner = 11) → the preview box (far right of the N1 sub-bar) renders the corresponding JP font glyph:

![N1 font-glyph preview](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1032-n1-glyph-preview.png)

## Test plan
- [x] `dotnet build` Core + Avalonia (Debug) — 0 errors
- [x] **Core** `ClassOPDemoFontRenderCoreTests` — **10/10**: synthetic ROM renders a non-null 32×32 glyph; the first-non-pointer terminator blocks later ids; `uint.MaxValue` id → null (no wraparound); non-pointer slot / unsafe table / null rom → null
- [x] **Avalonia** `ClassOPDemo`-filtered — **47/47** (parity: `ClassOPDemo_N1_GlyphPreview` present, `KnownGap: N1FontGlyphPreview` gone, code-behind wires `RenderGlyphById` + `N1B0Box.ValueChanged` + post-selection refresh + the `ApplyN1Rows` clear)
- [x] Full `FEBuilderGBA.Avalonia.Tests` — **7676/7679** (3 pre-existing skips, **0 failures**)
- [x] Live GUI: glyph renders in the preview box on a real FE8J class (screenshot)

> The full `FEBuilderGBA.Core.Tests` run shows 10 unrelated pre-existing `SkillSystems*` failures from the `config/patch2` submodule not being checked out in the throwaway worktree (verified: `git submodule status config/patch2` shows the uninitialized `-` prefix; CI checks out submodules, so they pass there). My 10 new Core tests all pass.

## GUI Test Report
| Test | Result |
|---|---|
| Open Class OP Demo editor (FE8J) | ✅ PASS |
| Select a JP-named class + N1 glyph row → preview renders the font glyph | ✅ PASS (screenshot) |
| Glyph render correctness (DataCount terminator, blank/unsafe → null) | ✅ PASS (10 Core tests) |

## Out of scope (noted follow-up)
Routing `OPClassFontViewerViewModel.TryLoadImage` through the shared `RenderGlyphImage` to parity-lock the two renderers (it currently height-adjusts for short data — a behavior change); `RenderGlyphImage` is now exposed so that's a one-liner later.

---
Original request: *"set ralph loop to resolve all open GitHub issues in laqieer/FEBuilderGBA"* — 18th issue in the autonomous sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.168` · model `claude-opus-4-8[1m]`
