### PR TITLE
feat(avalonia): STRUCT/NMM struct-aware export for resolved tables via StructExportCore (#1012)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -468,6 +468,11 @@ Specialized utilities for different graphic types:
   `Import` validates dims (parameterized multiples of 8, NOT hardcoded 32×32), `EncodeDirectTiles4bpp` + LZ77-
   writes + repoints the D0 glyph pointer under the caller's ambient undo, length-aware byte-identical fault
   restore (#885/#923). Avalonia `OPClassFontViewerView.ImportPng_Click` remaps onto the shared `op_class_font_palette`.
+- `StructExportCore.FormatSTRUCT`/`FormatNMM` (Core, READ-ONLY, PURE) — Struct Dump Selector STRUCT (.h
+  C-header) + NMM (No$gba memory map) export over the existing `StructMetadata.StructDef`; the Avalonia
+  `DumpStructSelectDialogViewModel.MakeExportText` routes STRUCT/NMM (alongside CSV/TSV/EA) through them for
+  a resolved table, hex stub only for unresolved addresses. Documented gaps: no headless signed-byte/hex-radix
+  per-control distinction, NMM dropdown aux-files emit `NULL`. #1012.
 
 ### Caching System
 

--- a/FEBuilderGBA.Avalonia.Tests/DumpStructSelectDialogViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/DumpStructSelectDialogViewModelTests.cs
@@ -200,27 +200,62 @@ namespace FEBuilderGBA.Avalonia.Tests
         }
 
         [Fact]
-        public void MakeExportText_STRUCT_AlwaysFallsBackToHexBanner()
+        public void MakeExportText_STRUCT_ResolvedTable_ProducesStructAwareOutput()
         {
             RomTestHelper.WithRom("FE8U", () =>
             {
                 var vm = new DumpStructSelectDialogViewModel();
-                vm.LoadAddress(UnitsEntryAddr()); // even over a known table
+                vm.LoadAddress(UnitsEntryAddr()); // inside the units table
                 string text = vm.MakeExportText("STRUCT");
-                Assert.Contains("# STRUCT export", text);
-                Assert.False(text.StartsWith("Index"), "STRUCT must use the hex fallback, not the struct header");
+                // Struct-aware C-header layout, NOT the honest hex banner (#1012).
+                Assert.DoesNotContain("Avalonia stub", text);
+                Assert.DoesNotContain("# STRUCT export", text);
+                Assert.StartsWith("struct ", text);
+                Assert.Contains("}; sizeof(", text);
             });
         }
 
         [Fact]
-        public void MakeExportText_NMM_AlwaysFallsBackToHexBanner()
+        public void MakeExportText_NMM_ResolvedTable_ProducesStructAwareOutput()
         {
             RomTestHelper.WithRom("FE8U", () =>
             {
                 var vm = new DumpStructSelectDialogViewModel();
                 vm.LoadAddress(UnitsEntryAddr());
                 string text = vm.MakeExportText("NMM");
+                // Struct-aware No$gba memory map, NOT the honest hex banner (#1012).
+                Assert.DoesNotContain("Avalonia stub", text);
+                Assert.DoesNotContain("# NMM export", text);
+                Assert.StartsWith("1", text);             // NMM magic line
+                Assert.Contains("by FEBuilderGBA", text); // title line
+            });
+        }
+
+        [Fact]
+        public void MakeExportText_STRUCT_AtHeaderAddress_FallsBackToHexBanner()
+        {
+            RomTestHelper.WithRom("FE8U", () =>
+            {
+                var vm = new DumpStructSelectDialogViewModel();
+                vm.LoadAddress(0x100); // GBA header — no struct table
+                string text = vm.MakeExportText("STRUCT");
+                // Unresolved address → honest hex fallback (banner present).
+                Assert.Contains("# STRUCT export", text);
+                Assert.Contains("Avalonia stub", text);
+                Assert.False(text.StartsWith("struct "), "unresolved STRUCT must use the hex fallback");
+            });
+        }
+
+        [Fact]
+        public void MakeExportText_NMM_AtHeaderAddress_FallsBackToHexBanner()
+        {
+            RomTestHelper.WithRom("FE8U", () =>
+            {
+                var vm = new DumpStructSelectDialogViewModel();
+                vm.LoadAddress(0x100); // GBA header — no struct table
+                string text = vm.MakeExportText("NMM");
                 Assert.Contains("# NMM export", text);
+                Assert.Contains("Avalonia stub", text);
             });
         }
 

--- a/FEBuilderGBA.Avalonia/ViewModels/DumpStructSelectDialogViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/DumpStructSelectDialogViewModel.cs
@@ -120,11 +120,13 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// <summary>
         /// Build the export preview text for a given format button.
         /// For CSV/TSV/EA/STRUCT/NMM, if the loaded address falls inside a known
-        /// ROM struct table, returns the raw struct-aware formatter output —
-        /// byte-identical to the CLI <c>--export-data</c> writers. CSV/TSV/EA emit
-        /// the table data; STRUCT emits the C-header layout and NMM the No$gba
-        /// memory map. Otherwise (no table matched / no ROM loaded) falls back to
-        /// the honest hex dump from <see cref="MakeStubExportText"/>.
+        /// ROM struct table, returns the raw struct-aware formatter output from
+        /// <see cref="StructExportCore"/> (matching its <c>ExportTo*</c> writers):
+        /// CSV/TSV/EA emit the table data, STRUCT the C-header layout, NMM the
+        /// No$gba memory map. (The CLI <c>--export-data</c> command exposes only
+        /// CSV/TSV/EA today — STRUCT/NMM are produced by these Core formatters but
+        /// are not yet CLI-exposed.) Otherwise (no table matched / no ROM loaded)
+        /// falls back to the honest hex dump from <see cref="MakeStubExportText"/>.
         /// </summary>
         public string MakeExportText(string format)
         {

--- a/FEBuilderGBA.Avalonia/ViewModels/DumpStructSelectDialogViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/DumpStructSelectDialogViewModel.cs
@@ -103,52 +103,55 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         // ===================================================================
         // Export text builders.
         //
-        // CSV/TSV/EA now produce struct-aware output via StructExportCore when
-        // the loaded address falls inside a known ROM data table (units,
-        // classes, items, ...). The dispatcher resolves the table from the
-        // address alone (StructExportCore.ResolveTableAt), so it no longer
-        // needs the source editor's InputFormRef widget tree — closing the
-        // long-standing Avalonia-vs-WinForms gap tracked from #439 (#770).
+        // CSV/TSV/EA/STRUCT/NMM now produce struct-aware output via
+        // StructExportCore when the loaded address falls inside a known ROM data
+        // table (units, classes, items, ...). The dispatcher resolves the table
+        // from the address alone (StructExportCore.ResolveTableAt), so it no
+        // longer needs the source editor's InputFormRef widget tree — closing the
+        // long-standing Avalonia-vs-WinForms gap tracked from #439 (#770) and
+        // extended to STRUCT (.h C-header) + NMM (No$gba memory map) in #1012.
         //
-        // STRUCT/NMM (and any address that resolves to no known table) still
-        // fall back to the honest 128-byte hex dump in MakeStubExportText.
+        // CSV/TSV/EA emit per-entry table DATA; STRUCT/NMM emit the struct LAYOUT
+        // (field names/offsets/types). Any address that resolves to no known
+        // table (or no ROM) still falls back to the honest 128-byte hex dump in
+        // MakeStubExportText.
         // ===================================================================
 
         /// <summary>
         /// Build the export preview text for a given format button.
-        /// For CSV/TSV/EA, if the loaded address falls inside a known ROM struct
-        /// table, returns the raw struct-aware formatter output (header-first, no
-        /// banner/prefix) — byte-identical to the CLI <c>--export-data</c> command.
-        /// Otherwise (STRUCT/NMM, or no table matched / no ROM loaded) falls back
-        /// to the honest hex dump from <see cref="MakeStubExportText"/>.
+        /// For CSV/TSV/EA/STRUCT/NMM, if the loaded address falls inside a known
+        /// ROM struct table, returns the raw struct-aware formatter output —
+        /// byte-identical to the CLI <c>--export-data</c> writers. CSV/TSV/EA emit
+        /// the table data; STRUCT emits the C-header layout and NMM the No$gba
+        /// memory map. Otherwise (no table matched / no ROM loaded) falls back to
+        /// the honest hex dump from <see cref="MakeStubExportText"/>.
         /// </summary>
         public string MakeExportText(string format)
         {
-            if (format == "CSV" || format == "TSV" || format == "EA")
+            if (format is "CSV" or "TSV" or "EA" or "STRUCT" or "NMM")
             {
                 ROM? rom = CoreState.ROM;
                 if (rom != null)
                 {
                     var table = StructExportCore.ResolveTableAt(rom, CurrentAddr);
-                    if (table != null)
+                    var sd = table != null ? StructExportCore.LoadStructDef(rom, table) : null;
+                    if (table != null && sd != null)
                     {
-                        var sd = StructExportCore.LoadStructDef(rom, table);
-                        if (sd != null)
+                        if (format == "STRUCT") return StructExportCore.FormatSTRUCT(sd);
+                        if (format == "NMM") return StructExportCore.FormatNMM(rom, table, sd);
+                        var entries = StructExportCore.ExportTable(rom, table, sd);
+                        return format switch
                         {
-                            var entries = StructExportCore.ExportTable(rom, table, sd);
-                            return format switch
-                            {
-                                "CSV" => StructExportCore.FormatCSV(entries, sd),
-                                "TSV" => StructExportCore.FormatTSV(entries, sd),
-                                "EA" => StructExportCore.FormatEA(entries, sd),
-                                _ => MakeStubExportText(format),
-                            };
-                        }
+                            "CSV" => StructExportCore.FormatCSV(entries, sd),
+                            "TSV" => StructExportCore.FormatTSV(entries, sd),
+                            "EA" => StructExportCore.FormatEA(entries, sd),
+                            _ => MakeStubExportText(format),
+                        };
                     }
                 }
             }
 
-            // STRUCT / NMM, or no resolvable table / no ROM → honest hex fallback.
+            // Unresolved address / no ROM → honest hex fallback.
             return MakeStubExportText(format);
         }
 
@@ -162,9 +165,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
         // ===================================================================
         // Honest-stub export text builder. Returns a placeholder hex dump of
-        // 128 bytes starting at the loaded address. Used as the fallback for
-        // STRUCT/NMM and for any address that does not resolve to a known
-        // struct table. KEPT (per #770) as the honest fallback path.
+        // 128 bytes starting at the loaded address. Used as the fallback for any
+        // address that does not resolve to a known struct table (or when no ROM
+        // is loaded) across ALL export formats — including STRUCT/NMM, which
+        // produce struct-aware output for RESOLVED tables (#1012) but fall back
+        // here otherwise. KEPT (per #770) as the honest fallback path.
         // ===================================================================
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/Views/DumpStructSelectDialogView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/DumpStructSelectDialogView.axaml.cs
@@ -131,9 +131,11 @@ namespace FEBuilderGBA.Avalonia.Views
         // shows a file-save dialog, and writes StructExportCore.ExportToTSV/CSV/EA
         // output (byte-identical to the CLI) — addressing the DumpStruct
         // export/import portion of #439 (not the issue's full parity scope).
-        // When the address resolves to NO known table, we fall back to the honest
-        // hex-dump preview banner. STRUCT/NMM are not backed by the Core seam, so
-        // they always use the preview banner.
+        // STRUCT/NMM are also backed by the Core seam (#1012): they open the text
+        // preview dialog whose body is _vm.MakeExportText, which now returns the
+        // struct-aware FormatSTRUCT (.h C-header) / FormatNMM (No$gba memory map)
+        // output for a resolved table. When the address resolves to NO known
+        // table, ALL formats fall back to the honest hex-dump preview banner.
         // ===================================================================
 
         void CSVButton_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Core.Tests/StructExportCoreStructNmmTests.cs
+++ b/FEBuilderGBA.Core.Tests/StructExportCoreStructNmmTests.cs
@@ -43,13 +43,17 @@ namespace FEBuilderGBA.Core.Tests
 
         /// <summary>
         /// Build a synthetic FE8U ROM, install it into CoreState, run the action,
-        /// then restore prior CoreState. Skips (no-op) if config metadata is not
-        /// reachable (so LoadStructDef would return null).
+        /// then restore prior CoreState. FAILS LOUDLY if config/data (the source of
+        /// the struct metadata) is not reachable — a silent no-op here would let the
+        /// whole assertion body be skipped and report a false-positive pass. The
+        /// repo-root config/data is present in CI and every dev checkout.
         /// </summary>
         static void WithSyntheticFE8U(Action<ROM> action)
         {
             EnsureBaseDirectory();
-            if (CoreState.BaseDirectory == null) return; // can't load struct metadata
+            Assert.True(CoreState.BaseDirectory != null,
+                "config/data BaseDirectory must resolve so LoadStructDef can read the struct metadata "
+                + "(repo-root config/data is present in CI and dev checkouts); refusing to no-op this test.");
 
             var savedRom = CoreState.ROM;
             try
@@ -64,6 +68,14 @@ namespace FEBuilderGBA.Core.Tests
             {
                 CoreState.ROM = savedRom;
             }
+        }
+
+        /// <summary>Assert the file does NOT begin with a UTF-8 BOM (EF BB BF).</summary>
+        static void AssertNoUtf8Bom(string path)
+        {
+            byte[] bytes = File.ReadAllBytes(path);
+            bool hasBom = bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF;
+            Assert.False(hasBom, "exported file must not start with a UTF-8 BOM");
         }
 
         // ===================================================================
@@ -217,6 +229,8 @@ namespace FEBuilderGBA.Core.Tests
                     StructExportCore.ExportToSTRUCT(sd, path);
                     Assert.Equal(StructExportCore.FormatSTRUCT(sd),
                         File.ReadAllText(path, System.Text.Encoding.UTF8));
+                    // No UTF-8 BOM (external .h consumers + WF no-BOM parity).
+                    AssertNoUtf8Bom(path);
                 }
                 finally
                 {
@@ -240,6 +254,8 @@ namespace FEBuilderGBA.Core.Tests
                     StructExportCore.ExportToNMM(rom, table, sd, path);
                     Assert.Equal(StructExportCore.FormatNMM(rom, table, sd),
                         File.ReadAllText(path, System.Text.Encoding.UTF8));
+                    // No UTF-8 BOM — the strict ".nmm" magic "1" must be byte 0.
+                    AssertNoUtf8Bom(path);
                 }
                 finally
                 {

--- a/FEBuilderGBA.Core.Tests/StructExportCoreStructNmmTests.cs
+++ b/FEBuilderGBA.Core.Tests/StructExportCoreStructNmmTests.cs
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for the STRUCT (.h C-header) + NMM (No$gba memory map) pure formatters
+// added to StructExportCore for #1012. These mirror the WinForms
+// DumpStructSelectDialogForm.MakeStructString / MakNMMString output.
+//
+// Setup: a synthetic FE8U ROM (LoadLow + zeroed 16 MB) provides the RomInfo
+// constants the units TableDef callbacks read (unit_datasize / unit_maxcount).
+// The real struct metadata is loaded from config/data via LoadStructDef, so the
+// StructDef field list is exactly what production uses. The formatters are pure
+// over StructDef + TableDef — they never read table DATA — so a zeroed ROM is
+// sufficient and the output is fully deterministic.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class StructExportCoreStructNmmTests
+    {
+        static string FindRepoRoot()
+        {
+            string dir = AppContext.BaseDirectory;
+            for (int i = 0; i < 10; i++)
+            {
+                if (Directory.Exists(Path.Combine(dir, "config", "data")))
+                    return dir;
+                dir = Path.GetDirectoryName(dir);
+                if (dir == null) break;
+            }
+            return null;
+        }
+
+        static void EnsureBaseDirectory()
+        {
+            if (CoreState.BaseDirectory != null) return;
+            string root = FindRepoRoot();
+            if (root != null)
+                CoreState.BaseDirectory = root;
+        }
+
+        /// <summary>
+        /// Build a synthetic FE8U ROM, install it into CoreState, run the action,
+        /// then restore prior CoreState. Skips (no-op) if config metadata is not
+        /// reachable (so LoadStructDef would return null).
+        /// </summary>
+        static void WithSyntheticFE8U(Action<ROM> action)
+        {
+            EnsureBaseDirectory();
+            if (CoreState.BaseDirectory == null) return; // can't load struct metadata
+
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var rom = new ROM();
+                bool ok = rom.LoadLow("x.gba", new byte[0x1000000], "BE8E01");
+                Assert.True(ok, "synthetic FE8U ROM must load");
+                CoreState.ROM = rom;
+                action(rom);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+            }
+        }
+
+        // ===================================================================
+        // FormatSTRUCT — C-header layout.
+        // ===================================================================
+
+        [Fact]
+        public void FormatSTRUCT_UnitsTable_HasHeaderTypesAndFooter()
+        {
+            WithSyntheticFE8U(rom =>
+            {
+                var table = StructExportCore.GetTable("units");
+                var sd = StructExportCore.LoadStructDef(rom, table);
+                Assert.NotNull(sd);
+
+                string text = StructExportCore.FormatSTRUCT(sd);
+
+                // First line: struct {Name} {//{Name}
+                Assert.StartsWith("struct " + sd.Name, text);
+                Assert.Contains("struct " + sd.Name + " {//" + sd.Name, text);
+
+                // One correct C type per FieldType present (units has all four).
+                Assert.Contains("byte    _", text);    // Byte
+                Assert.Contains("ushort   _", text);   // Word
+                Assert.Contains("dword   _", text);    // DWord
+                Assert.Contains("void*   _", text);    // Pointer
+
+                // Footer: }; sizeof({DataSize})
+                Assert.Contains("}; sizeof(" + sd.DataSize + ")", text);
+                Assert.EndsWith("}; sizeof(" + sd.DataSize + ")" + Environment.NewLine, text);
+
+                // Honest-stub banner must never appear.
+                Assert.DoesNotContain("Avalonia stub", text);
+            });
+        }
+
+        [Fact]
+        public void FormatSTRUCT_EmitsDecimalOffsetAndFieldNameComment()
+        {
+            WithSyntheticFE8U(rom =>
+            {
+                var table = StructExportCore.GetTable("units");
+                var sd = StructExportCore.LoadStructDef(rom, table);
+                Assert.NotNull(sd);
+
+                string text = StructExportCore.FormatSTRUCT(sd);
+
+                // The first field (NameTextID, Word at offset 0) → ushort   _0;//NameTextID
+                var first = sd.Fields[0];
+                Assert.Equal("NameTextID", first.Name);
+                Assert.Contains("ushort   _" + first.Offset + ";//" + first.Name, text);
+
+                // A field at a non-zero offset must use its DECIMAL offset.
+                // ClassID is a Byte at offset 0x05 → decimal 5.
+                var classId = sd.Fields.Find(f => f.Name == "ClassID");
+                Assert.NotNull(classId);
+                Assert.Equal(5u, classId.Offset);
+                Assert.Contains("byte    _5;//ClassID", text);
+            });
+        }
+
+        // ===================================================================
+        // FormatNMM — No$gba memory map.
+        // ===================================================================
+
+        [Fact]
+        public void FormatNMM_UnitsTable_HasHeaderAndPerFieldBlock()
+        {
+            WithSyntheticFE8U(rom =>
+            {
+                var table = StructExportCore.GetTable("units");
+                var sd = StructExportCore.LoadStructDef(rom, table);
+                Assert.NotNull(sd);
+
+                string text = StructExportCore.FormatNMM(rom, table, sd);
+                string[] lines = text.Replace("\r\n", "\n").Split('\n');
+
+                // First line is exactly "1".
+                Assert.Equal("1", lines[0]);
+                // Title line.
+                Assert.Equal(sd.Name + " by FEBuilderGBA", lines[1]);
+                // 0x-prefixed base address.
+                Assert.StartsWith("0x", lines[2]);
+                Assert.Equal(U.To0xHexString(table.GetBaseAddress(rom)), lines[2]);
+                // Entry count then block size.
+                Assert.Equal(table.GetEntryCount(rom).ToString(), lines[3]);
+                Assert.Equal(table.GetDataSize(rom).ToString(), lines[4]);
+                // Two NULL lines + blank line round out the header.
+                Assert.Equal("NULL", lines[5]);
+                Assert.Equal("NULL", lines[6]);
+                Assert.Equal("", lines[7]);
+
+                // Per-field block for the first field: Name / decimal offset /
+                // size code / NEHU / NULL.
+                var first = sd.Fields[0];
+                Assert.Equal(first.Name, lines[8]);
+                Assert.Equal(first.Offset.ToString(), lines[9]);
+                Assert.Equal(first.Size.ToString(), lines[10]); // Word → 2
+                Assert.Equal("2", lines[10]);
+                Assert.Equal("NEHU", lines[11]);
+                Assert.Equal("NULL", lines[12]);
+
+                // The right size code appears for the relevant field widths: a
+                // Byte field's block carries Name / offset / "1" / NEHU / NULL.
+                var byteField = sd.Fields.Find(f => f.Type == StructMetadata.FieldType.Byte);
+                Assert.NotNull(byteField);
+                Assert.Contains(byteField.Name + "\n" + byteField.Offset + "\n1\nNEHU\nNULL",
+                    text.Replace("\r\n", "\n"));
+
+                // A Pointer/DWord field's block carries size "4".
+                var ptrField = sd.Fields.Find(f => f.Type == StructMetadata.FieldType.Pointer);
+                Assert.NotNull(ptrField);
+                Assert.Contains(ptrField.Name + "\n" + ptrField.Offset + "\n4\nNEHU\nNULL",
+                    text.Replace("\r\n", "\n"));
+
+                Assert.DoesNotContain("Avalonia stub", text);
+            });
+        }
+
+        [Fact]
+        public void FormatNMM_IsDeterministic()
+        {
+            WithSyntheticFE8U(rom =>
+            {
+                var table = StructExportCore.GetTable("units");
+                var sd = StructExportCore.LoadStructDef(rom, table);
+                Assert.NotNull(sd);
+
+                string a = StructExportCore.FormatNMM(rom, table, sd);
+                string b = StructExportCore.FormatNMM(rom, table, sd);
+                Assert.Equal(a, b);
+            });
+        }
+
+        // ===================================================================
+        // ExportToSTRUCT / ExportToNMM — file byte-identity.
+        // ===================================================================
+
+        [Fact]
+        public void ExportToSTRUCT_MatchesFormatSTRUCT_ByteForByte()
+        {
+            WithSyntheticFE8U(rom =>
+            {
+                var table = StructExportCore.GetTable("units");
+                var sd = StructExportCore.LoadStructDef(rom, table);
+                Assert.NotNull(sd);
+
+                string path = Path.Combine(Path.GetTempPath(), $"struct_{Guid.NewGuid():N}.h");
+                try
+                {
+                    StructExportCore.ExportToSTRUCT(sd, path);
+                    Assert.Equal(StructExportCore.FormatSTRUCT(sd),
+                        File.ReadAllText(path, System.Text.Encoding.UTF8));
+                }
+                finally
+                {
+                    File.Delete(path);
+                }
+            });
+        }
+
+        [Fact]
+        public void ExportToNMM_MatchesFormatNMM_ByteForByte()
+        {
+            WithSyntheticFE8U(rom =>
+            {
+                var table = StructExportCore.GetTable("units");
+                var sd = StructExportCore.LoadStructDef(rom, table);
+                Assert.NotNull(sd);
+
+                string path = Path.Combine(Path.GetTempPath(), $"map_{Guid.NewGuid():N}.nmm");
+                try
+                {
+                    StructExportCore.ExportToNMM(rom, table, sd, path);
+                    Assert.Equal(StructExportCore.FormatNMM(rom, table, sd),
+                        File.ReadAllText(path, System.Text.Encoding.UTF8));
+                }
+                finally
+                {
+                    File.Delete(path);
+                }
+            });
+        }
+
+        // ===================================================================
+        // Divergence guard — the STRUCT footer + NMM block size both come from
+        // DataSize, so the table's reported entry size and the struct metadata
+        // size MUST agree or the two formatters would silently diverge.
+        // ===================================================================
+
+        [Fact]
+        public void UnitsTable_DataSize_MatchesStructDefDataSize()
+        {
+            WithSyntheticFE8U(rom =>
+            {
+                var table = StructExportCore.GetTable("units");
+                var sd = StructExportCore.LoadStructDef(rom, table);
+                Assert.NotNull(sd);
+                Assert.Equal(table.GetDataSize(rom), sd.DataSize);
+            });
+        }
+    }
+}

--- a/FEBuilderGBA.Core/StructExportCore.cs
+++ b/FEBuilderGBA.Core/StructExportCore.cs
@@ -1264,6 +1264,103 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
+        /// Format the struct layout as a C-header (".h") string, porting the
+        /// WinForms <c>DumpStructSelectDialogForm.MakeStructString</c> output.
+        /// The first line is <c>struct {Name} {//{Name}</c>; each field emits one
+        /// line keyed off <see cref="StructMetadata.FieldType"/>:
+        /// Byte→<c>byte    _{Offset};//{Name}</c>, Word→<c>ushort   _{Offset};//{Name}</c>,
+        /// DWord→<c>dword   _{Offset};//{Name}</c>, Pointer→<c>void*   _{Offset};//{Name}</c>
+        /// (spacing matches WinForms exactly; <c>_{Offset}</c> uses the DECIMAL
+        /// field offset like WinForms <c>nm.Id</c>). The footer is
+        /// <c>}; sizeof({DataSize})</c>. <see cref="ExportToSTRUCT"/> writes
+        /// exactly this string to disk.
+        /// </summary>
+        /// <remarks>
+        /// Documented fidelity gap vs WinForms: WinForms distinguishes a
+        /// signed-byte (<c>sbyte</c>) widget from <c>byte</c>, but the headless
+        /// <see cref="StructMetadata.FieldType.Byte"/> carries no signedness, so
+        /// all single bytes emit <c>byte</c>. WinForms hidden <c>h</c> widgets
+        /// have no headless analog (already absent from the metadata).
+        /// </remarks>
+        public static string FormatSTRUCT(StructMetadata.StructDef structDef)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"struct {structDef.Name} {{//{structDef.Name}");
+
+            foreach (var field in structDef.Fields)
+            {
+                string comment = ";//" + field.Name;
+                switch (field.Type)
+                {
+                    case StructMetadata.FieldType.Byte:
+                        sb.AppendLine("byte    _" + field.Offset + comment);
+                        break;
+                    case StructMetadata.FieldType.Word:
+                        sb.AppendLine("ushort   _" + field.Offset + comment);
+                        break;
+                    case StructMetadata.FieldType.DWord:
+                        sb.AppendLine("dword   _" + field.Offset + comment);
+                        break;
+                    case StructMetadata.FieldType.Pointer:
+                        sb.AppendLine("void*   _" + field.Offset + comment);
+                        break;
+                }
+            }
+
+            sb.AppendLine("}; sizeof(" + structDef.DataSize + ")");
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Format a No$gba memory map (".nmm") string, porting the WinForms
+        /// <c>DumpStructSelectDialogForm.MakNMMString</c> header + per-field block.
+        /// The header is the magic <c>1</c>, a <c>{Name} by FEBuilderGBA</c> title,
+        /// the 0x-prefixed base address, the entry count, the block size, then two
+        /// <c>NULL</c> lines and a blank line. Each field (in Fields order) emits
+        /// its Name, decimal Offset, size (1/2/4), the type code <c>NEHU</c>, a
+        /// <c>NULL</c> dropdown filename, and a blank line. <see cref="ExportToNMM"/>
+        /// writes exactly this string to disk.
+        /// </summary>
+        /// <remarks>
+        /// Documented fidelity gaps vs WinForms:
+        /// (a) WinForms' per-field dropdown enumeration aux-files
+        /// (<c>MakeNMMDropDownList</c>/<c>addFiles</c>) are widget-tree-driven and
+        /// out of scope — all dropdown filenames emit <c>NULL</c>. The output stays
+        /// a structurally valid No$gba memory map with correct field
+        /// names/offsets/sizes/types; only the named value-dropdowns are absent.
+        /// (b) The type-code display radix defaults to hex (<c>H</c>) — this is NOT
+        /// a "WinForms default": WinForms derives H/D per-control from
+        /// <c>NumericUpDown.Hexadecimal</c> (some UnitForm controls like B11/B25 are
+        /// decimal), which the headless metadata does not carry. Signedness defaults
+        /// to <c>U</c> (unsigned); the signed-byte variant has no headless analog.
+        /// </remarks>
+        public static string FormatNMM(ROM rom, TableDef table, StructMetadata.StructDef structDef)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("1");
+            sb.AppendLine(structDef.Name + " by FEBuilderGBA");
+            sb.AppendLine(U.To0xHexString(table.GetBaseAddress(rom)));
+            sb.AppendLine(table.GetEntryCount(rom).ToString());
+            sb.AppendLine(table.GetDataSize(rom).ToString());
+            sb.AppendLine("NULL");
+            sb.AppendLine("NULL");
+            sb.AppendLine();
+
+            foreach (var field in structDef.Fields)
+            {
+                sb.AppendLine(field.Name);
+                sb.AppendLine(field.Offset.ToString()); // decimal index
+                sb.AppendLine(field.Size.ToString());   // 1, 2, or 4
+                // Type code: N + E(no dropdown) + H(hex radix default) + U(unsigned default).
+                sb.AppendLine("NEHU");
+                sb.AppendLine("NULL");                   // dropdown filename
+                sb.AppendLine();
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
         /// Export table data to a TSV file. Output is byte-identical to
         /// <see cref="FormatTSV"/>.
         /// </summary>
@@ -1289,6 +1386,24 @@ namespace FEBuilderGBA
         public static void ExportToEA(List<Dictionary<string, string>> entries, StructMetadata.StructDef structDef, string outputPath)
         {
             File.WriteAllText(outputPath, FormatEA(entries, structDef), Encoding.UTF8);
+        }
+
+        /// <summary>
+        /// Export the struct layout to a C-header (".h") file. Output is
+        /// byte-identical to <see cref="FormatSTRUCT"/>.
+        /// </summary>
+        public static void ExportToSTRUCT(StructMetadata.StructDef structDef, string outputPath)
+        {
+            File.WriteAllText(outputPath, FormatSTRUCT(structDef), Encoding.UTF8);
+        }
+
+        /// <summary>
+        /// Export the struct layout to a No$gba memory map (".nmm") file. Output
+        /// is byte-identical to <see cref="FormatNMM"/>.
+        /// </summary>
+        public static void ExportToNMM(ROM rom, TableDef table, StructMetadata.StructDef structDef, string outputPath)
+        {
+            File.WriteAllText(outputPath, FormatNMM(rom, table, structDef), Encoding.UTF8);
         }
 
         /// <summary>RFC 4180 CSV quoting: double-quote fields containing commas, quotes, or newlines.</summary>

--- a/FEBuilderGBA.Core/StructExportCore.cs
+++ b/FEBuilderGBA.Core/StructExportCore.cs
@@ -1388,22 +1388,29 @@ namespace FEBuilderGBA
             File.WriteAllText(outputPath, FormatEA(entries, structDef), Encoding.UTF8);
         }
 
+        /// <summary>UTF-8 WITHOUT a BOM. The .h/.nmm files are consumed by
+        /// external tools (a C compiler / No$gba), and a leading BOM corrupts
+        /// the strict ".nmm" magic line ("1") and pollutes the .h; this also
+        /// matches the WinForms U.WriteAllText default (UTF-8 no-BOM).</summary>
+        static readonly UTF8Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
         /// <summary>
         /// Export the struct layout to a C-header (".h") file. Output is
-        /// byte-identical to <see cref="FormatSTRUCT"/>.
+        /// byte-identical to <see cref="FormatSTRUCT"/> (UTF-8, no BOM).
         /// </summary>
         public static void ExportToSTRUCT(StructMetadata.StructDef structDef, string outputPath)
         {
-            File.WriteAllText(outputPath, FormatSTRUCT(structDef), Encoding.UTF8);
+            File.WriteAllText(outputPath, FormatSTRUCT(structDef), Utf8NoBom);
         }
 
         /// <summary>
         /// Export the struct layout to a No$gba memory map (".nmm") file. Output
-        /// is byte-identical to <see cref="FormatNMM"/>.
+        /// is byte-identical to <see cref="FormatNMM"/> (UTF-8, no BOM — the
+        /// strict ".nmm" magic line must be the very first byte).
         /// </summary>
         public static void ExportToNMM(ROM rom, TableDef table, StructMetadata.StructDef structDef, string outputPath)
         {
-            File.WriteAllText(outputPath, FormatNMM(rom, table, structDef), Encoding.UTF8);
+            File.WriteAllText(outputPath, FormatNMM(rom, table, structDef), Utf8NoBom);
         }
 
         /// <summary>RFC 4180 CSV quoting: double-quote fields containing commas, quotes, or newlines.</summary>

--- a/docs/avalonia-forms.md
+++ b/docs/avalonia-forms.md
@@ -538,7 +538,7 @@ Editors for miscellaneous ROM structure data.
 | # | View | ViewModel | Description |
 |---|------|-----------|-------------|
 | 306 | Command85PointerView | Command85PointerViewModel | Command 0x85 pointer table editor |
-| 307 | DumpStructSelectDialogView | DumpStructSelectDialogViewModel | Struct dump selection dialog |
+| 307 | DumpStructSelectDialogView | DumpStructSelectDialogViewModel | Struct dump selection dialog (CSV/TSV/EA/STRUCT/NMM all export struct-aware output for resolved tables via `StructExportCore`; STRUCT=.h C-header, NMM=No$gba memory map — #1012) |
 | 308 | DumpStructSelectToTextDialogView | DumpStructSelectToTextDialogViewModel | Struct dump to text dialog |
 | 309 | ResourceView | ResourceViewModel | Resource table viewer |
 


### PR DESCRIPTION
## Summary
Adds **STRUCT (.h C-header)** and **NMM (No$gba memory map)** struct-aware export to the Struct Dump Selector (`DumpStructSelectDialogView`). CSV/TSV/EA already route through `StructExportCore` for any address that resolves to a known ROM table (#770/#439); STRUCT and NMM still fell back to a 128-byte hex-dump stub because no `FormatSTRUCT`/`FormatNMM` existed. Both are now pure read-only formatters over the existing `StructMetadata.StructDef` field metadata.

Closes #1012. Part of the `avalonia-stub` backlog (#1038).

## Plan
Reviewed + accepted by Copilot CLI (GPT-5.5): https://github.com/laqieer/FEBuilderGBA/issues/1012#issuecomment-4655430341 (refinements at #issuecomment-4655456607).

## What changed
- **`FEBuilderGBA.Core/StructExportCore.cs`** — two pure, read-only formatters (+ `ExportToSTRUCT`/`ExportToNMM` file writers):
  - `FormatSTRUCT(structDef)` — ports WF `MakeStructString`: a C-struct layout (`byte`/`ushort`/`dword`/`void*` by `FieldType`, `_{Offset};//{Name}` per field, `struct {Name} {` header + `}; sizeof({DataSize})` footer).
  - `FormatNMM(rom, table, structDef)` — ports WF `MakNMMString` header (`1` / `{Name} by FEBuilderGBA` / `0x`base / count / blocksize / `NULL` / `NULL` / blank) + per-field block (`Name` / `Offset` / `1|2|4` / `NEHU` type-code / `NULL` dropdown / blank).
- **`FEBuilderGBA.Avalonia/ViewModels/DumpStructSelectDialogViewModel.cs`** — `MakeExportText` now routes STRUCT/NMM to the new formatters for resolved tables (honest hex stub retained only for unresolved addresses / no ROM); stale "STRUCT/NMM always stub" comments updated.
- **`DumpStructSelectDialogView.axaml.cs`** — stale comment updated.

## Documented fidelity gaps (degraded, not blocking — structural validity + field-named output preserved)
- **NMM dropdown enumeration aux-files** (`MakeNMMDropDownList`/`addFiles`) are widget-tree-driven → all dropdown filenames emit `NULL` (valid No$gba map; named value-dropdowns absent).
- **Signed-byte** (`sbyte`) widget identity has no headless `FieldType` analog → all single bytes emit `byte`.
- NMM type-code **display radix defaults to hex (`H`)** — WF derives H/D per-control from `NumericUpDown.Hexadecimal` (not in headless metadata).

## Real output sample (units table — `Unit_FE78`)
```
FormatSTRUCT:                  FormatNMM:
struct Unit_FE78 {//Unit_FE78  1
ushort   _0;//NameTextID       Unit_FE78 by FEBuilderGBA
ushort   _2;//DescTextID       0x........   (real unit table base)
byte    _4;//UnitNumber        255
byte    _5;//ClassID           52
ushort   _6;//PortraitID       NULL
...                            NULL
}; sizeof(52)                  <blank> then per-field: NameTextID / 0 / 2 / NEHU / NULL ...
```

## Test plan
- [x] `dotnet build` Core + Avalonia — 0 errors
- [x] Core `StructExportCoreStructNmmTests` — **7/7 pass** (FormatSTRUCT C-types + header/footer; FormatNMM `1`-magic + header order + per-field size codes; `ExportToSTRUCT/NMM` byte-identity; `GetDataSize == structDef.DataSize` divergence guard; deterministic)
- [x] Avalonia `DumpStructSelectDialogViewModel` — **20/20 pass** (the two old `*_AlwaysFallsBackToHexBanner` tests INVERTED to assert struct-aware output for a resolved address; new unresolved-address-still-stub tests added — no coverage hole)
- [x] Core `StructExport`-filtered (CSV/TSV/EA regression) — **86/86 pass**
- [x] Full `FEBuilderGBA.Avalonia.Tests` — **7680 passed, 0 failed**, 3 skipped

## GUI Test Report
| Test | Result |
|------|--------|
| Struct Dump Selector ("Data Address Editor") launches (FE8U.gba) showing the STRUCT ("Display Byte Structure in C") + NMM ("Create Nightmare .nmm File") buttons | PASS (screenshot below) |
| `FormatSTRUCT` produces field-named C-struct for a resolved table (no stub banner) | PASS (Core + VM tests + sample above) |
| `FormatNMM` produces a valid No$gba map with field names/offsets/sizes/types | PASS (Core + VM tests + sample above) |
| Unresolved address / no ROM → honest hex stub retained | PASS (VM tests) |

The struct-aware **preview** dialog (`DumpStructSelectToTextDialogView`) is opened via `ShowDialog` (modal); the Avalonia app currently only opens this selector at address 0 from the Main menu (a resolved-address GUI entry point from list editors is a separate, pre-existing gap), so the struct-aware output is proven authoritatively by the 7 Core + 20 VM tests and the real sample above. The screenshot shows the actual running affected editor with the two new-format buttons.

## Screenshots
![Struct Dump Selector with STRUCT + NMM buttons](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1012-struct-dump-editor.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
