### PR TITLE
fix(avalonia): render per-frame SkillConfig skill-animation preview via Core ExportSkillAnimation (#1010)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,8 +389,10 @@ Specialized utilities for different graphic types:
   into bank 0, banks 1–15 preserved; multi-bank quantizer is a documented follow-up). Bulk Redo deferred. #989.
 - `SkillSystemsAnimeExportCore.cs` (Core, READ-ONLY) — SkillSystems skill-anime EXPORT: `SkipCode`
   (FE8J direct; FE8U skips the `.dmp` program + flags defender), `ExportSkillAnimation` (walks frames
-  to the `0xFFFF` terminator, LZ77-decompresses OBJ+TSA), `BuildScriptLines`. Avalonia
-  `SkillConfigAnimeExportHelper` → `.txt`+PNG or GIF (FE8N Ver1 stub). #910/#912.
+  to the `0xFFFF` terminator, LZ77-decompresses OBJ+TSA), `BuildScriptLines`, `GetFrameImage`
+  (bounds-checked frame accessor, #1010). Avalonia `SkillConfigAnimeExportHelper` → `.txt`+PNG or GIF
+  (FE8N Ver1 stub); `SkillConfigAnimePreview` renders the per-frame preview on the 4 SkillConfig editors
+  (pointer-cached decode + IImage disposal, #1010). #910/#912.
 - `SkillSystemsAnimeImportCore.cs` (Core, ROM-MUTATING) — SkillSystems skill-anime IMPORT, FE8J #916
   + FE8U #917. `ParseScript` reads the `D`/`S{hex}`/`{wait} {png}` lines; `ImportSkillAnimation`
   validates EVERYTHING before mutating; palette kept **RAW 0x20

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigAnimePreviewParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SkillConfigAnimePreviewParityTests.cs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Parity regression tests for the SkillConfig per-frame animation preview
+// (#1010). Asserts the 4 SkillConfig views now render the per-frame preview
+// via the shared SkillConfigAnimePreview helper (instead of the old always-
+// blank SetPreviewBitmap(null)), and that the 4 VMs no longer claim the
+// preview is unavailable.
+//
+// Roslyn-static source-text checks only — no Avalonia head needed.
+using System.IO;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests.GapSweep;
+
+public class SkillConfigAnimePreviewParityTests
+{
+    /// <summary>
+    /// Each of the 4 views must reference the shared SkillConfigAnimePreview
+    /// helper (via the _animePreview field).
+    /// </summary>
+    [Theory]
+    [InlineData("SkillConfigSkillSystemView")]
+    [InlineData("SkillConfigFE8NVer2SkillView")]
+    [InlineData("SkillConfigFE8NVer3SkillView")]
+    [InlineData("SkillConfigFE8UCSkillSys09xView")]
+    public void View_ReferencesSkillConfigAnimePreview(string view)
+    {
+        string src = ReadViewSource(view);
+        Assert.Contains("SkillConfigAnimePreview", src);
+        Assert.Contains("_animePreview", src);
+    }
+
+    /// <summary>
+    /// Each view must render the selected frame via
+    /// SetPreviewBitmap(_animePreview.TryGetFrameBitmap( in BOTH UpdateUI and
+    /// ShowFrameUpDown_ValueChanged — i.e. the valid branch no longer ONLY
+    /// calls SetPreviewBitmap(null).
+    /// </summary>
+    [Theory]
+    [InlineData("SkillConfigSkillSystemView")]
+    [InlineData("SkillConfigFE8NVer2SkillView")]
+    [InlineData("SkillConfigFE8NVer3SkillView")]
+    [InlineData("SkillConfigFE8UCSkillSys09xView")]
+    public void View_RendersFrameBitmapInUpdateUIAndFrameChanged(string view)
+    {
+        string src = ReadViewSource(view);
+
+        // The actual render call, present at least twice (UpdateUI valid branch
+        // + ShowFrameUpDown_ValueChanged).
+        const string renderCall = "_animePreview.TryGetFrameBitmap(";
+        int idx1 = src.IndexOf(renderCall, System.StringComparison.Ordinal);
+        Assert.True(idx1 >= 0, $"{view} must call {renderCall}");
+        int idx2 = src.IndexOf(renderCall, idx1 + 1, System.StringComparison.Ordinal);
+        Assert.True(idx2 >= 0, $"{view} must call {renderCall} in BOTH UpdateUI and ShowFrameUpDown_ValueChanged");
+
+        // The ShowFrameUpDown_ValueChanged handler specifically routes the
+        // selected frame through SetPreviewBitmap(_animePreview.TryGetFrameBitmap(.
+        Assert.Contains("SetPreviewBitmap(_animePreview.TryGetFrameBitmap(", src);
+
+        // The cache must be invalidated + disposed on window close.
+        Assert.Contains("_animePreview.Clear()", src);
+    }
+
+    /// <summary>
+    /// The stale always-blank preview comments must be gone from the 4 views.
+    /// </summary>
+    [Theory]
+    [InlineData("SkillConfigSkillSystemView")]
+    [InlineData("SkillConfigFE8NVer2SkillView")]
+    [InlineData("SkillConfigFE8NVer3SkillView")]
+    [InlineData("SkillConfigFE8UCSkillSys09xView")]
+    public void View_NoStalePreviewBlankComment(string view)
+    {
+        string src = ReadViewSource(view);
+        Assert.DoesNotContain("leave the preview Image blank", src);
+        Assert.DoesNotContain("Real per-frame rendering pending #500", src);
+        Assert.DoesNotContain("Real frame rendering depends", src);
+    }
+
+    /// <summary>
+    /// The 4 VMs must no longer claim the preview is unavailable / tracked by
+    /// #500 (the BinInfoText wording fix).
+    /// </summary>
+    [Theory]
+    [InlineData("SkillConfigSkillSystemViewModel")]
+    [InlineData("SkillConfigFE8NVer2SkillViewModel")]
+    [InlineData("SkillConfigFE8NVer3SkillViewModel")]
+    [InlineData("SkillConfigFE8UCSkillSys09xViewModel")]
+    public void ViewModel_NoPreviewUnavailableOr500(string vm)
+    {
+        string src = ReadViewModelSource(vm);
+        Assert.DoesNotContain("preview unavailable", src);
+        Assert.DoesNotContain("#500", src);
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    static string ReadViewSource(string viewName)
+    {
+        string repoRoot = FindRepoRoot();
+        return File.ReadAllText(Path.Combine(repoRoot, "FEBuilderGBA.Avalonia",
+            "Views", viewName + ".axaml.cs"));
+    }
+
+    static string ReadViewModelSource(string vmName)
+    {
+        string repoRoot = FindRepoRoot();
+        return File.ReadAllText(Path.Combine(repoRoot, "FEBuilderGBA.Avalonia",
+            "ViewModels", vmName + ".cs"));
+    }
+
+    static string FindRepoRoot()
+    {
+        string? dir = System.AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+        if (dir == null)
+            throw new System.InvalidOperationException("Could not find FEBuilderGBA.sln from test base directory");
+        return dir;
+    }
+}

--- a/FEBuilderGBA.Avalonia/Services/SkillConfigAnimePreview.cs
+++ b/FEBuilderGBA.Avalonia/Services/SkillConfigAnimePreview.cs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System.Collections.Generic;
+using FEBuilderGBA.Avalonia.Controls;
+using Bitmap = global::Avalonia.Media.Imaging.Bitmap;
+
+namespace FEBuilderGBA.Avalonia.Services
+{
+    /// <summary>
+    /// Shared per-view helper that renders the SkillConfig "Display example"
+    /// per-frame preview via the cross-platform READ-ONLY
+    /// <see cref="FEBuilderGBA.SkillSystemsAnimeExportCore"/> seam (#1010).
+    ///
+    /// The decode is expensive (LZ77-decompresses OBJ+TSA per frame) so the
+    /// result is CACHED by anime pointer — re-selecting the same skill or
+    /// scrubbing frames re-uses the cached decode. The cache is invalidated
+    /// (disposed) by the host on a pointer change, a successful Write/import
+    /// that can mutate the slot, and on window close.
+    ///
+    /// Each cached <see cref="FEBuilderGBA.SkillAnimeFrame.Image"/> is an
+    /// <see cref="FEBuilderGBA.IImage"/> (which is <c>IDisposable</c>);
+    /// <see cref="Clear"/> disposes each UNIQUE frame image exactly once.
+    /// <see cref="TryGetFrameBitmap"/> copies pixels into a NEW Avalonia
+    /// WriteableBitmap, so a displayed bitmap survives disposal of its source
+    /// IImage (it is independent of the cache lifetime).
+    /// </summary>
+    public sealed class SkillConfigAnimePreview
+    {
+        uint _decodedPointer = U.NOT_FOUND;
+        SkillAnimeExportResult _cached;
+
+        /// <summary>Frame count of the currently-cached animation (0 when none).</summary>
+        public int FrameCount => _cached?.Frames?.Count ?? 0;
+
+        /// <summary>
+        /// Decode the animation at <paramref name="animePointer"/> once and cache
+        /// it; subsequent calls with the same pointer re-use the cache. Returns
+        /// true when at least one frame is available.
+        /// </summary>
+        public bool Load(ROM rom, uint animePointer)
+        {
+            if (rom == null || animePointer == 0) { Clear(); return false; }
+            if (_decodedPointer == animePointer && _cached != null) return _cached.Frames.Count > 0;
+            Clear();                                  // dispose any prior cache first
+            var r = SkillSystemsAnimeExportCore.ExportSkillAnimation(rom, animePointer);
+            _decodedPointer = animePointer;
+            _cached = (string.IsNullOrEmpty(r.Error) && r.Frames.Count > 0) ? r : null;
+            return _cached != null;
+        }
+
+        /// <summary>
+        /// Bounds-checked frame -> a NEW Avalonia Bitmap (null if OOB / no image).
+        /// The returned bitmap owns its own pixel buffer and is safe to keep after
+        /// the cache is cleared.
+        /// </summary>
+        public Bitmap TryGetFrameBitmap(int frameIndex)
+        {
+            var img = SkillSystemsAnimeExportCore.GetFrameImage(_cached, frameIndex);
+            return img == null ? null : IconBitmapBuilder.FromImage(img);
+        }
+
+        /// <summary>
+        /// Dispose each UNIQUE cached frame IImage (IImage : IDisposable) and
+        /// reset. Safe: <see cref="TryGetFrameBitmap"/> copies pixels into a NEW
+        /// WriteableBitmap, so a displayed bitmap survives disposal of its source
+        /// IImage. The Core export caches one IImage per OBJ id, so duplicate
+        /// frames share an instance — a HashSet de-dups them by reference (the
+        /// concrete IImage type uses default reference equality).
+        /// </summary>
+        public void Clear()
+        {
+            if (_cached?.Frames != null)
+            {
+                var seen = new HashSet<IImage>();        // ReferenceEqualityComparer not needed — distinct refs
+                foreach (var f in _cached.Frames)
+                    if (f.Image != null && seen.Add(f.Image))
+                        try { f.Image.Dispose(); } catch { /* swallow */ }
+            }
+            _cached = null;
+            _decodedPointer = U.NOT_FOUND;
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Services/SkillConfigAnimePreview.cs
+++ b/FEBuilderGBA.Avalonia/Services/SkillConfigAnimePreview.cs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+#nullable enable
 using System.Collections.Generic;
 using FEBuilderGBA.Avalonia.Controls;
 using Bitmap = global::Avalonia.Media.Imaging.Bitmap;
@@ -11,10 +12,12 @@ namespace FEBuilderGBA.Avalonia.Services
     /// <see cref="FEBuilderGBA.SkillSystemsAnimeExportCore"/> seam (#1010).
     ///
     /// The decode is expensive (LZ77-decompresses OBJ+TSA per frame) so the
-    /// result is CACHED by anime pointer — re-selecting the same skill or
-    /// scrubbing frames re-uses the cached decode. The cache is invalidated
-    /// (disposed) by the host on a pointer change, a successful Write/import
-    /// that can mutate the slot, and on window close.
+    /// result is CACHED by (ROM instance, anime pointer) — re-selecting the same
+    /// skill or scrubbing frames re-uses the cached decode. Keying on the ROM
+    /// reference too means a ROM swap that happens to reuse the same pointer
+    /// value can never render the previous ROM's stale frames. The cache is
+    /// invalidated (disposed) by the host on a pointer change, a successful
+    /// Write/import that can mutate the slot, and on window close.
     ///
     /// Each cached <see cref="FEBuilderGBA.SkillAnimeFrame.Image"/> is an
     /// <see cref="FEBuilderGBA.IImage"/> (which is <c>IDisposable</c>);
@@ -26,22 +29,26 @@ namespace FEBuilderGBA.Avalonia.Services
     public sealed class SkillConfigAnimePreview
     {
         uint _decodedPointer = U.NOT_FOUND;
-        SkillAnimeExportResult _cached;
+        ROM? _decodedRom;
+        SkillAnimeExportResult? _cached;
 
         /// <summary>Frame count of the currently-cached animation (0 when none).</summary>
         public int FrameCount => _cached?.Frames?.Count ?? 0;
 
         /// <summary>
         /// Decode the animation at <paramref name="animePointer"/> once and cache
-        /// it; subsequent calls with the same pointer re-use the cache. Returns
-        /// true when at least one frame is available.
+        /// it (keyed on the ROM instance + pointer); subsequent calls with the same
+        /// ROM and pointer re-use the cache. Returns true when at least one frame is
+        /// available.
         /// </summary>
         public bool Load(ROM rom, uint animePointer)
         {
             if (rom == null || animePointer == 0) { Clear(); return false; }
-            if (_decodedPointer == animePointer && _cached != null) return _cached.Frames.Count > 0;
+            if (ReferenceEquals(_decodedRom, rom) && _decodedPointer == animePointer && _cached != null)
+                return _cached.Frames.Count > 0;
             Clear();                                  // dispose any prior cache first
             var r = SkillSystemsAnimeExportCore.ExportSkillAnimation(rom, animePointer);
+            _decodedRom = rom;
             _decodedPointer = animePointer;
             _cached = (string.IsNullOrEmpty(r.Error) && r.Frames.Count > 0) ? r : null;
             return _cached != null;
@@ -52,9 +59,9 @@ namespace FEBuilderGBA.Avalonia.Services
         /// The returned bitmap owns its own pixel buffer and is safe to keep after
         /// the cache is cleared.
         /// </summary>
-        public Bitmap TryGetFrameBitmap(int frameIndex)
+        public Bitmap? TryGetFrameBitmap(int frameIndex)
         {
-            var img = SkillSystemsAnimeExportCore.GetFrameImage(_cached, frameIndex);
+            IImage? img = SkillSystemsAnimeExportCore.GetFrameImage(_cached, frameIndex);
             return img == null ? null : IconBitmapBuilder.FromImage(img);
         }
 
@@ -63,20 +70,22 @@ namespace FEBuilderGBA.Avalonia.Services
         /// reset. Safe: <see cref="TryGetFrameBitmap"/> copies pixels into a NEW
         /// WriteableBitmap, so a displayed bitmap survives disposal of its source
         /// IImage. The Core export caches one IImage per OBJ id, so duplicate
-        /// frames share an instance — a HashSet de-dups them by reference (the
-        /// concrete IImage type uses default reference equality).
+        /// frames share an instance — the HashSet de-dups by REFERENCE
+        /// (<see cref="ReferenceEqualityComparer"/>) so it can never mistake two
+        /// distinct images for one and skip a dispose (leak).
         /// </summary>
         public void Clear()
         {
             if (_cached?.Frames != null)
             {
-                var seen = new HashSet<IImage>();        // ReferenceEqualityComparer not needed — distinct refs
+                var seen = new HashSet<IImage>(ReferenceEqualityComparer.Instance);
                 foreach (var f in _cached.Frames)
                     if (f.Image != null && seen.Add(f.Image))
                         try { f.Image.Dispose(); } catch { /* swallow */ }
             }
             _cached = null;
             _decodedPointer = U.NOT_FOUND;
+            _decodedRom = null;
         }
     }
 }

--- a/FEBuilderGBA.Avalonia/ViewModels/SkillConfigFE8NVer2SkillViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SkillConfigFE8NVer2SkillViewModel.cs
@@ -327,11 +327,12 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             SelectedFrame = 0;
             // Runtime UI string runs through R._ so the ja/zh translation
             // entries pick it up (ViewTranslationHelper only translates AXAML
-            // literals, not VM-set TextBox values).
+            // literals, not VM-set TextBox values). The per-frame preview is
+            // rendered by the View via SkillConfigAnimePreview /
+            // SkillSystemsAnimeExportCore (#1010), so the BinInfoText is now
+            // just the factual address.
             BinInfoText = IsAnimationValid
-                ? string.Format(R._("Animation @ 0x{0:X08} ({1})"),
-                    animPtr,
-                    R._("preview unavailable - tracked by #500"))
+                ? string.Format(R._("Animation @ 0x{0:X08}"), animPtr)
                 : "";
 
             IsLoaded = true;

--- a/FEBuilderGBA.Avalonia/ViewModels/SkillConfigFE8NVer3SkillViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SkillConfigFE8NVer3SkillViewModel.cs
@@ -365,11 +365,12 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             SelectedFrame = 0;
             // Runtime UI string runs through R._ so the ja/zh translation
             // entries pick it up (ViewTranslationHelper only translates AXAML
-            // literals, not VM-set TextBox values).
+            // literals, not VM-set TextBox values). The per-frame preview is
+            // rendered by the View via SkillConfigAnimePreview /
+            // SkillSystemsAnimeExportCore (#1010), so the BinInfoText is now
+            // just the factual address.
             BinInfoText = IsAnimationValid
-                ? string.Format(R._("Animation @ 0x{0:X08} ({1})"),
-                    animPtr,
-                    R._("preview unavailable - tracked by #500"))
+                ? string.Format(R._("Animation @ 0x{0:X08}"), animPtr)
                 : "";
 
             IsLoaded = true;

--- a/FEBuilderGBA.Avalonia/ViewModels/SkillConfigFE8UCSkillSys09xViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SkillConfigFE8UCSkillSys09xViewModel.cs
@@ -233,11 +233,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             // Runtime UI string runs through R._ so the ja/zh translation
             // entries pick it up - ViewTranslationHelper only translates
             // AXAML literals, not VM-set TextBox values. Copilot bot review
-            // on PR #516 (round 4).
+            // on PR #516 (round 4). The per-frame preview is rendered by the
+            // View via SkillConfigAnimePreview / SkillSystemsAnimeExportCore
+            // (#1010), so the BinInfoText is now just the factual address.
             BinInfoText = IsAnimationValid
-                ? string.Format(R._("Animation @ 0x{0:X08} ({1})"),
-                    animPtr,
-                    R._("preview unavailable - tracked by #500"))
+                ? string.Format(R._("Animation @ 0x{0:X08}"), animPtr)
                 : "";
 
             IsLoaded = true;

--- a/FEBuilderGBA.Avalonia/ViewModels/SkillConfigSkillSystemViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SkillConfigSkillSystemViewModel.cs
@@ -22,11 +22,10 @@ namespace FEBuilderGBA.Avalonia.ViewModels
     /// LoadEntry populates both the u16 textId and the u32 animation pointer
     /// (read via <c>p32</c>, so the editor value is a ROM OFFSET not a raw
     /// GBA pointer). Write persists BOTH fields under a single undo scope
-    /// owned by the View code-behind (matches PR #516 pattern). Real image
-    /// import/export and animation creator/editor depend on Core extraction
-    /// of <c>ImageUtilSkillSystemsAnimeCreator</c> tracked by #500; the
-    /// corresponding buttons render with a tooltip but no-op until that
-    /// lands.
+    /// owned by the View code-behind (matches PR #516 pattern). The per-frame
+    /// animation preview is rendered by the View via the cross-platform
+    /// READ-ONLY <see cref="FEBuilderGBA.SkillSystemsAnimeExportCore"/> decode
+    /// (issue 1010).
     ///
     /// Declared <c>partial</c> so the Phase 4 navigation manifest can live in
     /// a sibling <c>.NavigationTargets.cs</c> file.
@@ -304,11 +303,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             // Runtime UI string runs through R._ so the ja/zh translation
             // entries pick it up - ViewTranslationHelper only translates
             // AXAML literals, not VM-set TextBox values (Copilot bot review
-            // on PR #516 round 4).
+            // on PR #516 round 4). The per-frame preview is rendered by the
+            // View via SkillConfigAnimePreview / SkillSystemsAnimeExportCore
+            // (#1010), so the BinInfoText is now just the factual address.
             BinInfoText = IsAnimationValid
-                ? string.Format(R._("Animation @ 0x{0:X08} ({1})"),
-                    animPtr,
-                    R._("preview unavailable - tracked by #500"))
+                ? string.Format(R._("Animation @ 0x{0:X08}"), animPtr)
                 : "";
 
             IsLoaded = true;

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer2SkillView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer2SkillView.axaml.cs
@@ -28,6 +28,7 @@ namespace FEBuilderGBA.Avalonia.Views
     {
         readonly SkillConfigFE8NVer2SkillViewModel _vm = new();
         readonly UndoService _undoService = new();
+        readonly SkillConfigAnimePreview _animePreview = new();
         bool _suppressZoomChange;
         bool _suppressFrameChange;
         Bitmap? _currentIconBitmap;
@@ -68,6 +69,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 DisposeBitmap(ref _currentIconBitmap);
                 DisposeBitmap(ref _currentPreviewBitmap);
+                _animePreview.Clear();
             };
         }
 
@@ -236,18 +238,27 @@ namespace FEBuilderGBA.Avalonia.Views
             AnimationPanel.IsVisible = _vm.IsAnimationValid;
             if (_vm.IsAnimationValid)
             {
+                // #1010 — render the per-frame preview via the cross-platform
+                // READ-ONLY SkillSystemsAnimeExportCore decode (cached by anime
+                // pointer in _animePreview).
+                bool hasFrames = _animePreview.Load(CoreState.ROM, _vm.AnimationPointer);
+                int frameCount = _animePreview.FrameCount;
+                // Clamp SelectedFrame into range BEFORE rendering (a shorter
+                // animation on a same-row pointer change).
+                if (frameCount > 0 && _vm.SelectedFrame >= (uint)frameCount) _vm.SelectedFrame = (uint)(frameCount - 1);
                 _suppressFrameChange = true;
-                try { ShowFrameUpDown.Value = _vm.SelectedFrame; }
+                try
+                {
+                    ShowFrameUpDown.Maximum = Math.Max(0, frameCount - 1);
+                    ShowFrameUpDown.Value = _vm.SelectedFrame;
+                }
                 finally { _suppressFrameChange = false; }
-
                 BinInfoBox.Text = _vm.BinInfoText;
-                // Real frame rendering depends on ImageUtilSkillSystemsAnimeCreator
-                // (#500). Until that moves to Core, leave the preview Image
-                // blank but show the animation address text.
-                SetPreviewBitmap(null);
+                SetPreviewBitmap(hasFrames ? _animePreview.TryGetFrameBitmap((int)_vm.SelectedFrame) : null);
             }
             else
             {
+                _animePreview.Clear();
                 SetPreviewBitmap(null);
                 BinInfoBox.Text = "";
             }
@@ -275,6 +286,10 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.Write();
                 _undoService.Commit();
                 _vm.MarkClean();
+                // #1010 — the animation pointer may have changed; drop the
+                // cached decode and re-render the preview for the new pointer.
+                _animePreview.Clear();
+                UpdateUI();
             }
             catch (Exception ex)
             {
@@ -374,6 +389,8 @@ namespace FEBuilderGBA.Avalonia.Views
                 this, _vm.AnimationPointer, _undoService);
             if (!ok) return;
 
+            // #1010 — the animation bytes changed; drop the cached decode.
+            _animePreview.Clear();
             OnSelected(_vm.CurrentAddr);
             LoadList();
             EntryList.SelectAddress(_vm.CurrentAddr);
@@ -407,7 +424,8 @@ namespace FEBuilderGBA.Avalonia.Views
             if (!_vm.IsAnimationValid) return;
             _vm.SelectedFrame = (uint)(ShowFrameUpDown.Value ?? 0);
             BinInfoBox.Text = _vm.BinInfoText;
-            // Real per-frame rendering pending #500.
+            // #1010 — render the selected frame from the cached decode.
+            SetPreviewBitmap(_animePreview.TryGetFrameBitmap((int)_vm.SelectedFrame));
         }
 
         void ShowZoomComboBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml.cs
@@ -28,6 +28,7 @@ namespace FEBuilderGBA.Avalonia.Views
     {
         readonly SkillConfigFE8NVer3SkillViewModel _vm = new();
         readonly UndoService _undoService = new();
+        readonly SkillConfigAnimePreview _animePreview = new();
         bool _suppressZoomChange;
         bool _suppressFrameChange;
         Bitmap? _currentIconBitmap;
@@ -72,6 +73,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 DisposeBitmap(ref _currentIconBitmap);
                 DisposeBitmap(ref _currentPreviewBitmap);
+                _animePreview.Clear();
             };
         }
 
@@ -240,18 +242,27 @@ namespace FEBuilderGBA.Avalonia.Views
             AnimationPanel.IsVisible = _vm.IsAnimationValid;
             if (_vm.IsAnimationValid)
             {
+                // #1010 — render the per-frame preview via the cross-platform
+                // READ-ONLY SkillSystemsAnimeExportCore decode (cached by anime
+                // pointer in _animePreview).
+                bool hasFrames = _animePreview.Load(CoreState.ROM, _vm.AnimationPointer);
+                int frameCount = _animePreview.FrameCount;
+                // Clamp SelectedFrame into range BEFORE rendering (a shorter
+                // animation on a same-row pointer change).
+                if (frameCount > 0 && _vm.SelectedFrame >= (uint)frameCount) _vm.SelectedFrame = (uint)(frameCount - 1);
                 _suppressFrameChange = true;
-                try { ShowFrameUpDown.Value = _vm.SelectedFrame; }
+                try
+                {
+                    ShowFrameUpDown.Maximum = Math.Max(0, frameCount - 1);
+                    ShowFrameUpDown.Value = _vm.SelectedFrame;
+                }
                 finally { _suppressFrameChange = false; }
-
                 BinInfoBox.Text = _vm.BinInfoText;
-                // Real frame rendering depends on ImageUtilSkillSystemsAnimeCreator
-                // (#500). Until that moves to Core, leave the preview Image
-                // blank but show the animation address text.
-                SetPreviewBitmap(null);
+                SetPreviewBitmap(hasFrames ? _animePreview.TryGetFrameBitmap((int)_vm.SelectedFrame) : null);
             }
             else
             {
+                _animePreview.Clear();
                 SetPreviewBitmap(null);
                 BinInfoBox.Text = "";
             }
@@ -277,6 +288,10 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.Write();
                 _undoService.Commit();
                 _vm.MarkClean();
+                // #1010 — the animation pointer may have changed; drop the
+                // cached decode and re-render the preview for the new pointer.
+                _animePreview.Clear();
+                UpdateUI();
             }
             catch (Exception ex)
             {
@@ -374,6 +389,8 @@ namespace FEBuilderGBA.Avalonia.Views
                 this, _vm.AnimationPointer, _undoService);
             if (!ok) return;
 
+            // #1010 — the animation bytes changed; drop the cached decode.
+            _animePreview.Clear();
             OnSelected(_vm.CurrentAddr);
             LoadList();
             EntryList.SelectAddress(_vm.CurrentAddr);
@@ -428,7 +445,8 @@ namespace FEBuilderGBA.Avalonia.Views
             if (!_vm.IsAnimationValid) return;
             _vm.SelectedFrame = (uint)(ShowFrameUpDown.Value ?? 0);
             BinInfoBox.Text = _vm.BinInfoText;
-            // Real per-frame rendering pending #500.
+            // #1010 — render the selected frame from the cached decode.
+            SetPreviewBitmap(_animePreview.TryGetFrameBitmap((int)_vm.SelectedFrame));
         }
 
         void ShowZoomComboBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml.cs
@@ -21,6 +21,7 @@ namespace FEBuilderGBA.Avalonia.Views
     {
         readonly SkillConfigFE8UCSkillSys09xViewModel _vm = new();
         readonly UndoService _undoService = new();
+        readonly SkillConfigAnimePreview _animePreview = new();
         bool _suppressZoomChange;
         bool _suppressFrameChange;
         Bitmap? _currentIconBitmap;
@@ -39,6 +40,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 DisposeBitmap(ref _currentIconBitmap);
                 DisposeBitmap(ref _currentPreviewBitmap);
+                _animePreview.Clear();
             };
         }
 
@@ -132,20 +134,27 @@ namespace FEBuilderGBA.Avalonia.Views
 
             if (_vm.IsAnimationValid)
             {
+                // #1010 — render the per-frame preview via the cross-platform
+                // READ-ONLY SkillSystemsAnimeExportCore decode (cached by anime
+                // pointer in _animePreview).
+                bool hasFrames = _animePreview.Load(CoreState.ROM, _vm.AnimationPointer);
+                int frameCount = _animePreview.FrameCount;
+                // Clamp SelectedFrame into range BEFORE rendering (a shorter
+                // animation on a same-row pointer change).
+                if (frameCount > 0 && _vm.SelectedFrame >= (uint)frameCount) _vm.SelectedFrame = (uint)(frameCount - 1);
                 _suppressFrameChange = true;
-                try { ShowFrameUpDown.Value = _vm.SelectedFrame; }
+                try
+                {
+                    ShowFrameUpDown.Maximum = Math.Max(0, frameCount - 1);
+                    ShowFrameUpDown.Value = _vm.SelectedFrame;
+                }
                 finally { _suppressFrameChange = false; }
-
                 BinInfoBox.Text = _vm.BinInfoText;
-                // Real frame rendering depends on the WinForms-only
-                // ImageUtilSkillSystemsAnimeCreator (#500). Until that
-                // moves to Core, leave the preview Image blank but show the
-                // animation address text so the user knows the pointer is
-                // valid.
-                SetPreviewBitmap(null);
+                SetPreviewBitmap(hasFrames ? _animePreview.TryGetFrameBitmap((int)_vm.SelectedFrame) : null);
             }
             else
             {
+                _animePreview.Clear();
                 SetPreviewBitmap(null);
                 BinInfoBox.Text = "";
             }
@@ -166,6 +175,10 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.Write();
                 _undoService.Commit();
                 _vm.MarkClean();
+                // #1010 — the animation pointer may have changed; drop the
+                // cached decode and re-render the preview for the new pointer.
+                _animePreview.Clear();
+                UpdateUI();
             }
             catch (Exception ex)
             {
@@ -261,6 +274,8 @@ namespace FEBuilderGBA.Avalonia.Views
                 this, _vm.AnimationPointer, _undoService);
             if (!ok) return;
 
+            // #1010 — the animation bytes changed; drop the cached decode.
+            _animePreview.Clear();
             OnSelected(_vm.CurrentAddr);
             LoadList();
             EntryList.SelectAddress(_vm.CurrentAddr);
@@ -294,7 +309,8 @@ namespace FEBuilderGBA.Avalonia.Views
             if (!_vm.IsAnimationValid) return;
             _vm.SelectedFrame = (uint)(ShowFrameUpDown.Value ?? 0);
             BinInfoBox.Text = _vm.BinInfoText;
-            // Real per-frame rendering pending #500.
+            // #1010 — render the selected frame from the cached decode.
+            SetPreviewBitmap(_animePreview.TryGetFrameBitmap((int)_vm.SelectedFrame));
         }
 
         void ShowZoomComboBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml.cs
@@ -24,6 +24,7 @@ namespace FEBuilderGBA.Avalonia.Views
     {
         readonly SkillConfigSkillSystemViewModel _vm = new();
         readonly UndoService _undoService = new();
+        readonly SkillConfigAnimePreview _animePreview = new();
         bool _suppressZoomChange;
         bool _suppressFrameChange;
         Bitmap? _currentIconBitmap;
@@ -42,6 +43,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 DisposeBitmap(ref _currentIconBitmap);
                 DisposeBitmap(ref _currentPreviewBitmap);
+                _animePreview.Clear();
             };
         }
 
@@ -154,20 +156,27 @@ namespace FEBuilderGBA.Avalonia.Views
 
             if (_vm.IsAnimationValid)
             {
+                // #1010 — render the per-frame preview via the cross-platform
+                // READ-ONLY SkillSystemsAnimeExportCore decode (cached by anime
+                // pointer in _animePreview).
+                bool hasFrames = _animePreview.Load(CoreState.ROM, _vm.AnimationPointer);
+                int frameCount = _animePreview.FrameCount;
+                // Clamp SelectedFrame into range BEFORE rendering (a shorter
+                // animation on a same-row pointer change).
+                if (frameCount > 0 && _vm.SelectedFrame >= (uint)frameCount) _vm.SelectedFrame = (uint)(frameCount - 1);
                 _suppressFrameChange = true;
-                try { ShowFrameUpDown.Value = _vm.SelectedFrame; }
+                try
+                {
+                    ShowFrameUpDown.Maximum = Math.Max(0, frameCount - 1);
+                    ShowFrameUpDown.Value = _vm.SelectedFrame;
+                }
                 finally { _suppressFrameChange = false; }
-
                 BinInfoBox.Text = _vm.BinInfoText;
-                // Real frame rendering depends on the WinForms-only
-                // ImageUtilSkillSystemsAnimeCreator (#500). Until that
-                // moves to Core, leave the preview Image blank but show the
-                // animation address text so the user knows the pointer is
-                // valid.
-                SetPreviewBitmap(null);
+                SetPreviewBitmap(hasFrames ? _animePreview.TryGetFrameBitmap((int)_vm.SelectedFrame) : null);
             }
             else
             {
+                _animePreview.Clear();
                 SetPreviewBitmap(null);
                 BinInfoBox.Text = "";
             }
@@ -187,6 +196,10 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.Write();
                 _undoService.Commit();
                 _vm.MarkClean();
+                // #1010 — the animation pointer may have changed; drop the
+                // cached decode and re-render the preview for the new pointer.
+                _animePreview.Clear();
+                UpdateUI();
             }
             catch (Exception ex)
             {
@@ -278,7 +291,9 @@ namespace FEBuilderGBA.Avalonia.Views
                 this, _vm.AnimationPointer, _undoService);
             if (!ok) return;
 
-            // Success: refresh the animation preview + the list thumbnails.
+            // Success: the animation bytes changed — drop the cached decode,
+            // then refresh the animation preview + the list thumbnails.
+            _animePreview.Clear();
             OnSelected(_vm.CurrentAddr);
             LoadList();
             EntryList.SelectAddress(_vm.CurrentAddr);
@@ -384,7 +399,9 @@ namespace FEBuilderGBA.Avalonia.Views
 
                 CoreState.Services?.ShowInfo(R._("Bulk imported from: {0}", path));
 
-                // Success: refresh the VM + reload the list/preview.
+                // Success: the animation bytes / pointer slots changed — drop the
+                // cached decode, then refresh the VM + reload the list/preview.
+                _animePreview.Clear();
                 OnSelected(_vm.CurrentAddr);
                 LoadList();
                 EntryList.SelectAddress(_vm.CurrentAddr);
@@ -479,7 +496,8 @@ namespace FEBuilderGBA.Avalonia.Views
             if (!_vm.IsAnimationValid) return;
             _vm.SelectedFrame = (uint)(ShowFrameUpDown.Value ?? 0);
             BinInfoBox.Text = _vm.BinInfoText;
-            // Real per-frame rendering pending #500.
+            // #1010 — render the selected frame from the cached decode.
+            SetPreviewBitmap(_animePreview.TryGetFrameBitmap((int)_vm.SelectedFrame));
         }
 
         void ShowZoomComboBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)

--- a/FEBuilderGBA.Core.Tests/SkillSystemsAnimeExportCoreGetFrameTests.cs
+++ b/FEBuilderGBA.Core.Tests/SkillSystemsAnimeExportCoreGetFrameTests.cs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// Hermetic tests for the bounds-checked frame accessor
+    /// <see cref="SkillSystemsAnimeExportCore.GetFrameImage"/> (#1010).
+    ///
+    /// No ROM and no CoreState mutation — every test builds a synthetic
+    /// <see cref="SkillAnimeExportResult"/> directly and asserts the routing.
+    /// The in-range identity check uses the shared <c>StubImage</c> sentinel so
+    /// we can assert the EXACT stored reference is returned (no clone).
+    /// </summary>
+    public class SkillSystemsAnimeExportCoreGetFrameTests
+    {
+        [Fact]
+        public void GetFrameImage_NullResult_ReturnsNull()
+        {
+            Assert.Null(SkillSystemsAnimeExportCore.GetFrameImage(null, 0));
+        }
+
+        [Fact]
+        public void GetFrameImage_ResultWithError_ReturnsNull()
+        {
+            var r = new SkillAnimeExportResult { Error = "BAD ANIME ADDRESS" };
+            r.Frames.Add(new SkillAnimeFrame { Id = 1, Wait = 3, Image = new StubImage(8, 8) });
+            Assert.Null(SkillSystemsAnimeExportCore.GetFrameImage(r, 0));
+        }
+
+        [Fact]
+        public void GetFrameImage_FramesNullResult_ReturnsNull()
+        {
+            var r = new SkillAnimeExportResult { Frames = null };
+            Assert.Null(SkillSystemsAnimeExportCore.GetFrameImage(r, 0));
+        }
+
+        [Fact]
+        public void GetFrameImage_NegativeIndex_ReturnsNull()
+        {
+            var r = new SkillAnimeExportResult();
+            r.Frames.Add(new SkillAnimeFrame { Id = 1, Wait = 3, Image = new StubImage(8, 8) });
+            Assert.Null(SkillSystemsAnimeExportCore.GetFrameImage(r, -1));
+        }
+
+        [Fact]
+        public void GetFrameImage_IndexAtCount_ReturnsNull()
+        {
+            var r = new SkillAnimeExportResult();
+            r.Frames.Add(new SkillAnimeFrame { Id = 1, Wait = 3, Image = new StubImage(8, 8) });
+            // index == Count (one past the last valid index) is out of range.
+            Assert.Null(SkillSystemsAnimeExportCore.GetFrameImage(r, 1));
+        }
+
+        [Fact]
+        public void GetFrameImage_IndexBeyondCount_ReturnsNull()
+        {
+            var r = new SkillAnimeExportResult();
+            r.Frames.Add(new SkillAnimeFrame { Id = 1, Wait = 3, Image = new StubImage(8, 8) });
+            Assert.Null(SkillSystemsAnimeExportCore.GetFrameImage(r, 99));
+        }
+
+        [Fact]
+        public void GetFrameImage_InRange_ReturnsExactStoredReference()
+        {
+            var img0 = new StubImage(8, 8);
+            var img1 = new StubImage(16, 16);
+            var r = new SkillAnimeExportResult();
+            r.Frames.Add(new SkillAnimeFrame { Id = 1, Wait = 3, Image = img0 });
+            r.Frames.Add(new SkillAnimeFrame { Id = 2, Wait = 5, Image = img1 });
+
+            // Must return the SAME reference stored at each index (no clone).
+            Assert.Same(img0, SkillSystemsAnimeExportCore.GetFrameImage(r, 0));
+            Assert.Same(img1, SkillSystemsAnimeExportCore.GetFrameImage(r, 1));
+        }
+
+        [Fact]
+        public void GetFrameImage_InRange_NullStoredImage_ReturnsNull()
+        {
+            // A frame whose Image is explicitly null routes through (index in
+            // range) and returns that null reference — the routing, not a
+            // bounds rejection.
+            var r = new SkillAnimeExportResult();
+            r.Frames.Add(new SkillAnimeFrame { Id = 1, Wait = 3, Image = null });
+            Assert.Null(SkillSystemsAnimeExportCore.GetFrameImage(r, 0));
+        }
+    }
+}

--- a/FEBuilderGBA.Core/SkillSystemsAnimeExportCore.cs
+++ b/FEBuilderGBA.Core/SkillSystemsAnimeExportCore.cs
@@ -245,6 +245,17 @@ namespace FEBuilderGBA
             return result;
         }
 
+        /// <summary>Bounds-checked frame image accessor. Returns the EXACT stored
+        /// IImage reference for the given frame, or null if the result is null/errored
+        /// or the index is out of range. Does NOT clone or dispose.</summary>
+        public static IImage GetFrameImage(SkillAnimeExportResult result, int index)
+        {
+            if (result == null || result.Frames == null) return null;
+            if (!string.IsNullOrEmpty(result.Error)) return null;
+            if (index < 0 || index >= result.Frames.Count) return null;
+            return result.Frames[index].Image;
+        }
+
         /// <summary>
         /// Render a single frame image (mirrors WF <c>DrawFrameImage</c>):
         /// deref obj/tsa/pal via id, LZ77-decompress obj+tsa, render via

--- a/FEBuilderGBA.Core/SkillSystemsAnimeExportCore.cs
+++ b/FEBuilderGBA.Core/SkillSystemsAnimeExportCore.cs
@@ -233,6 +233,18 @@ namespace FEBuilderGBA
                     if (img == null)
                     {
                         result.Error = err;
+                        // Dispose every unique IImage rendered so far. On error the
+                        // Frames list is cleared and the caller never receives (and so
+                        // can't dispose) these native bitmaps — interactive callers
+                        // (the SkillConfig preview) re-decode malformed animations
+                        // repeatedly, so a leak here accumulates. `cache` holds exactly
+                        // the unique rendered images; `result.Frames` only references
+                        // them. (Successful results transfer ownership to the caller.)
+                        foreach (var rendered in cache.Values)
+                        {
+                            try { rendered?.Dispose(); } catch { /* best-effort cleanup */ }
+                        }
+                        cache.Clear();
                         result.Frames.Clear();
                         return result;
                     }

--- a/docs/avalonia-forms.md
+++ b/docs/avalonia-forms.md
@@ -464,14 +464,14 @@ Editors for various skill system implementations.
 |---|------|-----------|-------------|
 | 266 | SkillAssignmentUnitSkillSystemView | SkillAssignmentUnitSkillSystemViewModel | Unit skill assignment (SkillSystem) |
 | 267 | SkillAssignmentClassSkillSystemView | SkillAssignmentClassSkillSystemViewModel | Class skill assignment (SkillSystem) |
-| 268 | SkillConfigSkillSystemView | SkillConfigSkillSystemViewModel | Skill config (SkillSystem) |
+| 268 | SkillConfigSkillSystemView | SkillConfigSkillSystemViewModel | Skill config (SkillSystem) — renders the per-frame animation preview via Core `SkillSystemsAnimeExportCore` (#1010) |
 | 269 | SkillAssignmentUnitCSkillSysView | SkillAssignmentUnitCSkillSysViewModel | Unit skill assignment (CSkillSys) |
 | 270 | SkillAssignmentClassCSkillSysView | SkillAssignmentClassCSkillSysViewModel | Class skill assignment (CSkillSys) |
 | 271 | SkillAssignmentUnitFE8NView | SkillAssignmentUnitFE8NViewModel | Unit skill assignment (FE8N) |
 | 272 | SkillConfigFE8NSkillView | SkillConfigFE8NSkillViewModel | Skill config (FE8N) |
-| 273 | SkillConfigFE8NVer2SkillView | SkillConfigFE8NVer2SkillViewModel | Skill config (FE8N v2) |
-| 274 | SkillConfigFE8NVer3SkillView | SkillConfigFE8NVer3SkillViewModel | Skill config (FE8N v3) |
-| 275 | SkillConfigFE8UCSkillSys09xView | SkillConfigFE8UCSkillSys09xViewModel | Skill config (FE8U CSkillSys 0.9.x) |
+| 273 | SkillConfigFE8NVer2SkillView | SkillConfigFE8NVer2SkillViewModel | Skill config (FE8N v2) — renders the per-frame animation preview via Core `SkillSystemsAnimeExportCore` (#1010) |
+| 274 | SkillConfigFE8NVer3SkillView | SkillConfigFE8NVer3SkillViewModel | Skill config (FE8N v3) — renders the per-frame animation preview via Core `SkillSystemsAnimeExportCore` (#1010) |
+| 275 | SkillConfigFE8UCSkillSys09xView | SkillConfigFE8UCSkillSys09xViewModel | Skill config (FE8U CSkillSys 0.9.x) — renders the per-frame animation preview via Core `SkillSystemsAnimeExportCore` (#1010) |
 | 276 | SkillSystemsEffectivenessReworkClassTypeView | SkillSystemsEffectivenessReworkClassTypeViewModel | Effectiveness rework class type |
 | 277 | SkillSystemsCSkillRechainView | SkillSystemsCSkillRechainViewModel | CSkill rechain editor |
 


### PR DESCRIPTION
## Summary
Renders the per-frame skill-animation preview in the four SkillConfig editors. Every preview path previously called `SetPreviewBitmap(null)` with a stale "WinForms-only `ImageUtilSkillSystemsAnimeCreator` (#500)" comment — but the frame decode is **already in Core**: `SkillSystemsAnimeExportCore.ExportSkillAnimation` returns one rendered `IImage` per frame (and is already used by the animation **export** path). This wires that decode into the preview.

Closes #1010. Part of the `avalonia-stub` backlog (#1038). **Read-only** (no ROM mutation).

## Plan
Reviewed + accepted by Copilot CLI (GPT-5.5): https://github.com/laqieer/FEBuilderGBA/issues/1010#issuecomment-4655686479 (refinements at #issuecomment-4655720293).

## What changed
- **`FEBuilderGBA.Core/SkillSystemsAnimeExportCore.cs`** — `GetFrameImage(result, index)`: pure, bounds-checked accessor returning the exact stored frame `IImage` (null on null/errored result or OOB index).
- **`FEBuilderGBA.Avalonia/Services/SkillConfigAnimePreview.cs`** (new) — instance helper: caches the decoded `SkillAnimeExportResult` **by anime pointer** (decode once, not per spinner tick); `TryGetFrameBitmap(i)` → a NEW Avalonia `Bitmap` via `IconBitmapBuilder.FromImage`; `Clear()` disposes each **unique** cached frame `IImage` (`IImage : IDisposable`).
- **4 views** (`SkillConfigSkillSystemView`, `SkillConfigFE8NVer2SkillView`, `SkillConfigFE8NVer3SkillView`, `SkillConfigFE8UCSkillSys09xView`) — render `TryGetFrameBitmap(SelectedFrame)` in both `UpdateUI` and `ShowFrameUpDown_ValueChanged`; `ShowFrameUpDown.Maximum = FrameCount-1` set inside the `_suppressFrameChange` block; `SelectedFrame` clamped to range; **cache invalidated** (`Clear()` + re-render) after a successful Write / AnimationImport / Bulk Import; `Clear()` on window close. FE8N **Ver1** stays unwired (no animation pointer).
- **4 VMs** — stale `BinInfoText` "preview unavailable - tracked by #500" removed.

## Test plan
- [x] `dotnet build` Core + Avalonia — 0 errors
- [x] `scripts/validate-automation-ids.ps1` — VALIDATION PASSED
- [x] Core `GetFrame` tests — **8/8** (null/errored/OOB → null; in-range → reference-equal stored `IImage`)
- [x] Avalonia `SkillConfig` tests — **209/209** (parity: all 4 views now render `TryGetFrameBitmap(...)` in UpdateUI + ShowFrame, no longer only `SetPreviewBitmap(null)`; VMs no longer say "preview unavailable")
- [x] Full `FEBuilderGBA.Avalonia.Tests` — **7696 passed, 0 failed**, 3 skipped

## GUI Test Report
| Test | Result |
|------|--------|
| SkillConfig (SkillSystem) editor launches (FE8J_skill.gba) with the Animation panel | PASS (screenshot below) |
| Core decode produces real rendered frames — `ExportSkillAnimation_FE8J_TwoFrames_ReturnsFramesWithStructure` asserts 2 frames, each `Image` non-null at **240×(≥160)** | PASS (these are the exact `IImage`s the preview now displays) |
| Bounds-checked frame selection `GetFrameImage` | PASS (8 unit tests) |
| All 4 views route `TryGetFrameBitmap` → `SetPreviewBitmap` (no longer null) | PASS (209 parity tests) |

**Screenshot honesty note:** the per-frame preview (`AnimationPanel`) only becomes visible when a skill with a *resolvable animation pointer* is selected, which requires a skill-patched ROM whose patch the Avalonia detection recognizes. The Avalonia skill-patch finders are **FE8U-pattern byte-greps** (`PreviewIconHelper.FindSkillSystem*` / FE8N markers); the only skill-patched ROM available — `roms/FE8J_skill.gba` — matches **none** of the five skill-editor variants (all report "patch not installed"), so a live rendered-frame capture isn't possible in this environment. The render path is therefore proven by the Core decode test (real 240×160 frames) + the 8 `GetFrame` + 209 parity tests above, not a fabricated image. The screenshot shows the actual running affected editor.

## Screenshots
![SkillConfig (SkillSystem) editor — Animation panel](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1010-skillconfig-preview.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
