### PR TITLE
feat(avalonia): editable FE8 Event Unit after-coord move-path list via Core EventUnitCoordCore (#1017)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/EventUnitCoordListParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventUnitCoordListParityTests.cs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1017 parity tests for the FE8 Event Unit editor's editable after-coord
+// (move-path) list.
+//
+// The list is data-template-bound + the Write path goes through an OS-driven
+// editor, so this is a source-text parity test (same pattern as the other
+// *ParityTests in this project): it asserts the axaml exposes the editable
+// list + Add/Remove buttons by AutomationId, that the synthetic START-row
+// fields are disabled via IsAfterRow, and that the VM wires the Core
+// EventUnitCoordCore read/write seam (FE8-gated).
+using System;
+using System.IO;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    public class EventUnitCoordListParityTests
+    {
+        static string? FindRepoRoot()
+        {
+            string start = AppDomain.CurrentDomain.BaseDirectory;
+            for (DirectoryInfo? dir = new DirectoryInfo(start); dir != null; dir = dir.Parent)
+            {
+                if (File.Exists(Path.Combine(dir.FullName, "FEBuilderGBA.sln")))
+                    return dir.FullName;
+            }
+            return null;
+        }
+
+        static string ReadFile(params string[] parts)
+        {
+            string? repoRoot = FindRepoRoot();
+            Assert.NotNull(repoRoot);
+            string path = Path.Combine(repoRoot!, Path.Combine(parts));
+            Assert.True(File.Exists(path), $"Missing {path}");
+            return File.ReadAllText(path);
+        }
+
+        static string ReadView(string ext)
+            => ReadFile("FEBuilderGBA.Avalonia", "Views", "EventUnitView" + ext);
+
+        static string ReadViewModel()
+            => ReadFile("FEBuilderGBA.Avalonia", "ViewModels", "EventUnitViewModel.cs");
+
+        [Fact]
+        public void Axaml_Has_EditableAfterCoordList_AndButtons()
+        {
+            string axaml = ReadView(".axaml");
+            // The editable list + Add/Remove controls exist by AutomationId.
+            Assert.Contains("EventUnit_AfterCoords_List", axaml);
+            Assert.Contains("EventUnit_AddCoord_Button", axaml);
+            Assert.Contains("EventUnit_RemoveCoord_Button", axaml);
+            Assert.Contains("Click=\"AddCoord_Click\"", axaml);
+            Assert.Contains("Click=\"RemoveCoord_Click\"", axaml);
+            // Panel is FE8-gated (toggled from IsFE8 in the code-behind).
+            Assert.Contains("AfterCoordsPanel", axaml);
+        }
+
+        [Fact]
+        public void Axaml_StartRow_SyntheticFields_AreDisabled()
+        {
+            string axaml = ReadView(".axaml");
+            // Row-0 (START) synthetic fields (Speed/UnitId/Unk1/Unk2/Wait) are
+            // disabled via the per-row IsAfterRow binding; X/Y/Ext stay editable.
+            Assert.Contains("IsEnabled=\"{Binding IsAfterRow}\"", axaml);
+            // The eight per-row columns are bound two-way.
+            Assert.Contains("{Binding Speed}", axaml);
+            Assert.Contains("{Binding UnitId}", axaml);
+            Assert.Contains("{Binding Unk1}", axaml);
+            Assert.Contains("{Binding Unk2}", axaml);
+            Assert.Contains("{Binding Wait}", axaml);
+            Assert.Contains("{Binding X}", axaml);
+            Assert.Contains("{Binding Y}", axaml);
+            Assert.Contains("{Binding Ext}", axaml);
+        }
+
+        [Fact]
+        public void CodeBehind_Wires_AddRemove_UnderUndoScope()
+        {
+            string cs = ReadView(".axaml.cs");
+            Assert.Contains("AddCoord_Click", cs);
+            Assert.Contains("RemoveCoord_Click", cs);
+            Assert.Contains("_vm.AddCoord", cs);
+            Assert.Contains("_vm.RemoveCoord", cs);
+            // The whole block (incl. coords) writes under ONE undo scope.
+            Assert.Contains("_undoService.Begin", cs);
+            Assert.Contains("_undoService.Commit", cs);
+            Assert.Contains("_undoService.Rollback", cs);
+            // The list is bound to the VM collection.
+            Assert.Contains("AfterCoordsList.ItemsSource = _vm.AfterCoords", cs);
+        }
+
+        [Fact]
+        public void ViewModel_References_Core_EventUnitCoordCore_FE8Gated()
+        {
+            string vm = ReadViewModel();
+            // Read + write go through the Core seam.
+            Assert.Contains("EventUnitCoordCore.ReadAfterCoords", vm);
+            Assert.Contains("EventUnitCoordCore.WriteAfterCoords", vm);
+            // FE8-only (20-byte block).
+            Assert.Contains("dataSize == 20", vm);
+            Assert.Contains("public bool IsFE8", vm);
+            // The unified row VM with all 8 fields + the START-row flag.
+            Assert.Contains("class Fe8CoordRowViewModel", vm);
+            Assert.Contains("public bool IsStartRow", vm);
+            Assert.Contains("public bool IsAfterRow", vm);
+            // RemoveCoord refuses index 0 (the START row).
+            Assert.Contains("index <= 0", vm);
+            // The B7 u8 cap is honored when adding.
+            Assert.Contains("MaxAfterCoordRecords", vm);
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/EventUnitViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EventUnitViewModel.cs
@@ -602,6 +602,20 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 ["B12"] = Item1, ["B13"] = Item2, ["B14"] = Item3, ["B15"] = Item4,
                 ["B16"] = AI1Primary, ["B17"] = AI2Secondary, ["B18"] = AI3TargetRecovery, ["B19"] = AI4Retreat,
             };
+
+            // For FE8, WriteAfterCoords (below) is the SOLE authority for W4/B7/D8:
+            // it re-stamps W4 from list[0] and does the in-place-vs-append+repoint
+            // blob write AFTER capturing the OLD P8/B7 from the ROM. Letting
+            // WriteFields write B7/D8 here first would clobber the old pointer
+            // (and could leave D8 corrupted on a failed/restored write), so drop
+            // them from the field write — WriteFields skips keys not present.
+            // (Copilot bot review on PR #1073.)
+            if (IsFE8 && AfterCoords.Count > 0)
+            {
+                values.Remove("W4");
+                values.Remove("B7");
+                values.Remove("D8");
+            }
             EditorFormRef.WriteFields(rom, addr, values, Fields);
 
             // FE8 after-coord blob write (#1017). Field addresses are the unit

--- a/FEBuilderGBA.Avalonia/ViewModels/EventUnitViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EventUnitViewModel.cs
@@ -1,9 +1,70 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Core;
 
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
+    /// <summary>
+    /// One editable FE8 after-coord (move-path) row. Index 0 is the synthetic
+    /// START row (X/Y/Ext only — persisted to W4); indices 1+ are the 8-byte
+    /// blob records (Speed/UnitId/Unk1/Unk2/Wait become editable). The
+    /// <see cref="IsStartRow"/> flag drives the View's per-row enable logic so
+    /// the start row's synthetic fields stay disabled.
+    /// </summary>
+    public partial class Fe8CoordRowViewModel : ViewModelBase
+    {
+        uint _x, _y, _ext, _speed, _unitId, _unk1, _unk2, _wait;
+        bool _isStartRow;
+
+        public uint X { get => _x; set => SetField(ref _x, value); }
+        public uint Y { get => _y; set => SetField(ref _y, value); }
+        public uint Ext { get => _ext; set => SetField(ref _ext, value); }
+        public uint Speed { get => _speed; set => SetField(ref _speed, value); }
+        public uint UnitId { get => _unitId; set => SetField(ref _unitId, value); }
+        public uint Unk1 { get => _unk1; set => SetField(ref _unk1, value); }
+        public uint Unk2 { get => _unk2; set => SetField(ref _unk2, value); }
+        public uint Wait { get => _wait; set => SetField(ref _wait, value); }
+
+        /// <summary>True for index 0 (the START row). Bound (inverted) to the
+        /// View's Speed/UnitId/Unk1/Unk2/Wait NumericUpDown IsEnabled so the
+        /// synthetic fields are read-only; only X/Y/Ext are editable.</summary>
+        public bool IsStartRow
+        {
+            get => _isStartRow;
+            set
+            {
+                if (SetField(ref _isStartRow, value))
+                {
+                    OnPropertyChanged(nameof(IsAfterRow));
+                    OnPropertyChanged(nameof(StartRowMarker));
+                }
+            }
+        }
+
+        /// <summary>Inverse of <see cref="IsStartRow"/> — convenience binding
+        /// for the disabled synthetic-field NumericUpDowns.</summary>
+        public bool IsAfterRow => !_isStartRow;
+
+        /// <summary>Row marker shown in the list's "#" column — "S" for the
+        /// START row, blank otherwise (the ListBox supplies the ordinal).</summary>
+        public string StartRowMarker => _isStartRow ? "S" : "";
+
+        public Fe8Coord ToCoord() => new Fe8Coord
+        {
+            X = _x, Y = _y, Ext = _ext, Speed = _speed,
+            UnitId = _unitId, Unk1 = _unk1, Unk2 = _unk2, Wait = _wait,
+        };
+
+        public static Fe8CoordRowViewModel FromCoord(Fe8Coord c, bool isStartRow) => new Fe8CoordRowViewModel
+        {
+            X = c.X, Y = c.Y, Ext = c.Ext, Speed = c.Speed,
+            UnitId = c.UnitId, Unk1 = c.Unk1, Unk2 = c.Unk2, Wait = c.Wait,
+            IsStartRow = isStartRow,
+        };
+    }
+
     /// <summary>
     /// ViewModel for EventUnitForm (FE8 — 20-byte unit placement blocks).
     /// Provides 3-level navigation: Map -> Unit Group -> Unit.
@@ -112,6 +173,26 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public uint Reserved6 { get => _reserved6; set => SetField(ref _reserved6, value); }
         public uint CoordCount { get => _coordCount; set => SetField(ref _coordCount, value); }
         public uint CoordPointer { get => _coordPointer; set => SetField(ref _coordPointer, value); }
+
+        /// <summary>
+        /// Editable FE8 after-coord (move-path) list (#1017). Index 0 is the
+        /// synthetic START row (sourced from / persisted to W4); indices 1+ are
+        /// the 8-byte blob records at D8. Populated on <see cref="LoadEntry"/>
+        /// when <see cref="IsFE8"/>, written back through
+        /// <see cref="EventUnitCoordCore.WriteAfterCoords"/> on
+        /// <see cref="WriteEntry"/>.
+        /// </summary>
+        public ObservableCollection<Fe8CoordRowViewModel> AfterCoords { get; } = new();
+
+        /// <summary>True when the loaded ROM is FE8 (20-byte unit block). The
+        /// after-coord list editor is FE8-only — the View gates the whole panel
+        /// on this flag.</summary>
+        public bool IsFE8
+        {
+            get => _isFE8;
+            set => SetField(ref _isFE8, value);
+        }
+        bool _isFE8;
         public uint Item1 { get => _item1; set => SetField(ref _item1, value); }
         public uint Item2 { get => _item2; set => SetField(ref _item2, value); }
         public uint Item3 { get => _item3; set => SetField(ref _item3, value); }
@@ -437,7 +518,63 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 Comment = "";
             }
 
+            // FE8 detection — the after-coord list editor is FE8-only (20-byte
+            // unit block). FE7's 16-byte block has no after-coord list.
+            IsFE8 = dataSize == 20;
+            ReloadAfterCoords(rom);
+
             IsLoaded = true;
+        }
+
+        /// <summary>
+        /// Rebuild <see cref="AfterCoords"/> from the live W4/B7/D8 values via
+        /// <see cref="EventUnitCoordCore.ReadAfterCoords"/>. Non-FE8 ROMs leave
+        /// the list empty. Index 0 is flagged <c>IsStartRow</c>.
+        /// </summary>
+        void ReloadAfterCoords(ROM rom)
+        {
+            AfterCoords.Clear();
+            if (!IsFE8 || rom == null) return;
+
+            var coords = EventUnitCoordCore.ReadAfterCoords(rom, UnitGrowth, CoordCount, CoordPointer);
+            for (int i = 0; i < coords.Count; i++)
+                AfterCoords.Add(Fe8CoordRowViewModel.FromCoord(coords[i], isStartRow: i == 0));
+        }
+
+        /// <summary>
+        /// Append a new after-coord row with sane defaults (copies the last
+        /// row's X/Y, zero everything else). No-op for non-FE8. The new row is
+        /// never the START row.
+        /// </summary>
+        public void AddCoord()
+        {
+            if (!IsFE8) return;
+            // Cap at the START row + 255 after-coords (B7 is a u8).
+            if (AfterCoords.Count - 1 >= EventUnitCoordCore.MaxAfterCoordRecords) return;
+
+            uint x = 0, y = 0;
+            if (AfterCoords.Count > 0)
+            {
+                Fe8CoordRowViewModel last = AfterCoords[AfterCoords.Count - 1];
+                x = last.X;
+                y = last.Y;
+            }
+            AfterCoords.Add(new Fe8CoordRowViewModel
+            {
+                X = x, Y = y, Ext = 0, Speed = 0, UnitId = 0,
+                Unk1 = 0, Unk2 = 0, Wait = 0, IsStartRow = false,
+            });
+        }
+
+        /// <summary>
+        /// Remove the after-coord row at <paramref name="index"/>. Refuses index
+        /// 0 (the synthetic START row) and out-of-range indices.
+        /// </summary>
+        public void RemoveCoord(int index)
+        {
+            if (!IsFE8) return;
+            if (index <= 0 || index >= AfterCoords.Count) return; // never remove the START row
+            AfterCoords.RemoveAt(index);
         }
 
         public void WriteEntry()
@@ -446,6 +583,18 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (rom == null || CurrentAddr == 0) return;
 
             uint addr = CurrentAddr;
+
+            // FE8 after-coord list (#1017): the START row (AfterCoords[0])
+            // owns W4, and B7/D8 are owned by the blob writer. Sync UnitGrowth
+            // from the START row BEFORE EditorFormRef.WriteFields so the field
+            // write and the coord write agree on W4, then let WriteAfterCoords
+            // own B7/D8 (and re-stamp W4 from list[0]).
+            if (IsFE8 && AfterCoords.Count > 0)
+            {
+                Fe8CoordRowViewModel startRow = AfterCoords[0];
+                UnitGrowth = U.MakeFe8UnitPos(startRow.X, startRow.Y, startRow.Ext);
+            }
+
             var values = new Dictionary<string, uint>
             {
                 ["B0"] = UnitID, ["B1"] = ClassID, ["B2"] = LeaderUnitID, ["B3"] = UnitInfo,
@@ -454,6 +603,36 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 ["B16"] = AI1Primary, ["B17"] = AI2Secondary, ["B18"] = AI3TargetRecovery, ["B19"] = AI4Retreat,
             };
             EditorFormRef.WriteFields(rom, addr, values, Fields);
+
+            // FE8 after-coord blob write (#1017). Field addresses are the unit
+            // base + fixed offsets: W4=+4, B7=+7, D8=+8. WriteAfterCoords does
+            // the in-place-vs-append+repoint blob write, the count-0 clear, and
+            // re-stamps W4 from list[0] — all under the caller's ambient undo
+            // scope with a byte-identical restore on any fault. It NEVER throws;
+            // a non-empty return is a localized error surfaced to the user.
+            if (IsFE8 && AfterCoords.Count > 0)
+            {
+                var list = new List<Fe8Coord>(AfterCoords.Count);
+                foreach (Fe8CoordRowViewModel row in AfterCoords)
+                    list.Add(row.ToCoord());
+
+                string err = EventUnitCoordCore.WriteAfterCoords(
+                    rom, addr + 4, addr + 7, addr + 8, list);
+                if (!string.IsNullOrEmpty(err))
+                {
+                    CoreState.Services?.ShowError(err);
+                }
+                else
+                {
+                    // Re-read the (possibly repointed) B7/D8/W4 so the VM + UI
+                    // reflect the new pointer/count, then rebuild the row list.
+                    var reread = EditorFormRef.ReadFields(rom, addr, Fields);
+                    UnitGrowth = reread["W4"];
+                    CoordCount = reread["B7"];
+                    CoordPointer = reread["D8"];
+                    ReloadAfterCoords(rom);
+                }
+            }
 
             // Persist the Comment to CoreState.CommentCache. The cache is a
             // separate annotation store and lives OUTSIDE the ROM undo

--- a/FEBuilderGBA.Avalonia/Views/EventUnitView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventUnitView.axaml
@@ -95,7 +95,7 @@
             <CheckBox AutomationProperties.AutomationId="EventUnit_ItemDropFlag_Check" Content="Drop Item" Name="ItemDropCheck" Margin="10,0,0,0" />
           </StackPanel>
 
-          <!-- After-coords read-only (B7 count + D8 pointer) -->
+          <!-- After-coords (B7 count + D8 pointer) read-only summary -->
           <TextBlock Grid.Row="6" Grid.Column="0" Text="After Coordinates:" VerticalAlignment="Center" Margin="0,2" />
           <StackPanel Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="6" Margin="0,2">
             <TextBlock Text="Count:" VerticalAlignment="Center" />
@@ -146,6 +146,47 @@
           <TextBlock Grid.Row="16" Grid.Column="0" Text="Comment:" VerticalAlignment="Center" Margin="0,2" />
           <TextBox AutomationProperties.AutomationId="EventUnit_Comment_Input" Grid.Row="16" Grid.Column="1" Grid.ColumnSpan="2" Name="CommentBox" Margin="0,2" />
         </Grid>
+
+        <!-- Editable FE8 after-coord (move-path) list (#1017). FE8-only -->
+        <Border Name="AfterCoordsPanel" BorderBrush="Gray" BorderThickness="1" Padding="6" IsVisible="False">
+          <StackPanel Spacing="6">
+            <StackPanel Orientation="Horizontal" Spacing="8">
+              <TextBlock Text="After Coordinate Move Path (FE8)" FontWeight="Bold" VerticalAlignment="Center" />
+              <Button AutomationProperties.AutomationId="EventUnit_AddCoord_Button" Content="Add Coord" Name="AddCoordBtn" Click="AddCoord_Click" />
+              <Button AutomationProperties.AutomationId="EventUnit_RemoveCoord_Button" Content="Remove Coord" Name="RemoveCoordBtn" Click="RemoveCoord_Click" IsEnabled="False" />
+            </StackPanel>
+            <TextBlock Text="Row 0 is the start position (X/Y/Ext persist to W4). Rows 1+ are the move-path steps." Foreground="Gray" TextWrapping="Wrap" />
+            <Grid ColumnDefinitions="40,70,70,70,80,90,70,70,80">
+              <TextBlock Grid.Column="0" Text="#" FontWeight="Bold" />
+              <TextBlock Grid.Column="1" Text="X" FontWeight="Bold" />
+              <TextBlock Grid.Column="2" Text="Y" FontWeight="Bold" />
+              <TextBlock Grid.Column="3" Text="Ext" FontWeight="Bold" />
+              <TextBlock Grid.Column="4" Text="Speed" FontWeight="Bold" />
+              <TextBlock Grid.Column="5" Text="UnitId" FontWeight="Bold" />
+              <TextBlock Grid.Column="6" Text="Unk1" FontWeight="Bold" />
+              <TextBlock Grid.Column="7" Text="Unk2" FontWeight="Bold" />
+              <TextBlock Grid.Column="8" Text="Wait" FontWeight="Bold" />
+            </Grid>
+            <ListBox AutomationProperties.AutomationId="EventUnit_AfterCoords_List" Name="AfterCoordsList"
+                     SelectionChanged="AfterCoordsList_SelectionChanged" MaxHeight="280">
+              <ListBox.ItemTemplate>
+                <DataTemplate>
+                  <Grid ColumnDefinitions="40,70,70,70,80,90,70,70,80">
+                    <TextBlock Grid.Column="0" Text="{Binding StartRowMarker}" VerticalAlignment="Center" />
+                    <NumericUpDown Grid.Column="1" FormatString="0" Minimum="0" Maximum="63" Width="64" Value="{Binding X}" />
+                    <NumericUpDown Grid.Column="2" FormatString="0" Minimum="0" Maximum="63" Width="64" Value="{Binding Y}" />
+                    <NumericUpDown Grid.Column="3" FormatString="0" Minimum="0" Maximum="7" Width="64" Value="{Binding Ext}" />
+                    <NumericUpDown Grid.Column="4" FormatString="0" Minimum="0" Maximum="255" Width="74" Value="{Binding Speed}" IsEnabled="{Binding IsAfterRow}" />
+                    <NumericUpDown Grid.Column="5" FormatString="0" Minimum="0" Maximum="255" Width="84" Value="{Binding UnitId}" IsEnabled="{Binding IsAfterRow}" />
+                    <NumericUpDown Grid.Column="6" FormatString="0" Minimum="0" Maximum="255" Width="64" Value="{Binding Unk1}" IsEnabled="{Binding IsAfterRow}" />
+                    <NumericUpDown Grid.Column="7" FormatString="0" Minimum="0" Maximum="255" Width="64" Value="{Binding Unk2}" IsEnabled="{Binding IsAfterRow}" />
+                    <NumericUpDown Grid.Column="8" FormatString="0" Minimum="0" Maximum="65535" Width="74" Value="{Binding Wait}" IsEnabled="{Binding IsAfterRow}" />
+                  </Grid>
+                </DataTemplate>
+              </ListBox.ItemTemplate>
+            </ListBox>
+          </StackPanel>
+        </Border>
 
         <!-- Address bar (Size / Selected Address / Write) -->
         <Border BorderBrush="Gray" BorderThickness="1" Padding="6">

--- a/FEBuilderGBA.Avalonia/Views/EventUnitView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventUnitView.axaml.cs
@@ -76,6 +76,10 @@ namespace FEBuilderGBA.Avalonia.Views
             ItemDropCheck.IsCheckedChanged += ItemDropCheck_IsCheckedChanged;
             UnitGrowthBox.ValueChanged += UnitGrowthBox_ValueChanged;
 
+            // FE8 after-coord (move-path) list (#1017). Bound to the VM's
+            // ObservableCollection so Add/Remove + per-row edits flow through.
+            AfterCoordsList.ItemsSource = _vm.AfterCoords;
+
             Opened += (_, _) => LoadMapList();
         }
 
@@ -237,6 +241,10 @@ namespace FEBuilderGBA.Avalonia.Views
             AI4DescLabel.Text = "";
             ItemDropLabel.Text = "";
             CommentBox.Text = "";
+            // Hide + clear the FE8 after-coord panel when no unit is loaded
+            // (#1017). The VM clears _vm.AfterCoords on the next LoadEntry.
+            AfterCoordsPanel.IsVisible = false;
+            UpdateRemoveCoordEnabled();
             // Reset VM loaded state so Write_Click cannot commit changes
             // against a stale CurrentAddr after the user moves to an empty
             // group (Copilot bot review round 3 on PR #540: WriteEntry
@@ -287,6 +295,12 @@ namespace FEBuilderGBA.Avalonia.Views
                 AI3DescLabel.Text = _vm.AI3Desc;
                 AI4DescLabel.Text = _vm.AI4Desc;
                 ItemDropLabel.Text = _vm.ItemDropDisplay;
+
+                // FE8 after-coord (move-path) list (#1017). The VM has already
+                // rebuilt _vm.AfterCoords in LoadEntry; only the panel
+                // visibility + Remove-button enable state are view concerns.
+                AfterCoordsPanel.IsVisible = _vm.IsFE8;
+                UpdateRemoveCoordEnabled();
             }
             finally { _suppressUiSync = false; }
         }
@@ -327,6 +341,56 @@ namespace FEBuilderGBA.Avalonia.Views
                 _undoService.Rollback();
                 Log.Error("EventUnitView.Write failed: {0}", ex.Message);
             }
+        }
+
+        // ---------------------------------------------------------------
+        // FE8 after-coord (move-path) list editing (#1017). The grid binds
+        // each row two-way, so per-cell edits flow into the VM rows directly;
+        // Add/Remove mutate the VM ObservableCollection (bound to the ListBox).
+        // The Write button persists the whole list with the rest of the block
+        // under ONE _undoService scope (see Write_Click -> WriteEntry).
+        // ---------------------------------------------------------------
+
+        void AddCoord_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (!_vm.IsFE8) return;
+                _vm.AddCoord();
+                UpdateRemoveCoordEnabled();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("EventUnitView.AddCoord_Click failed: {0}", ex.Message);
+            }
+        }
+
+        void RemoveCoord_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (!_vm.IsFE8) return;
+                int idx = AfterCoordsList.SelectedIndex;
+                if (idx <= 0) return; // never remove the START row (index 0)
+                _vm.RemoveCoord(idx);
+                UpdateRemoveCoordEnabled();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("EventUnitView.RemoveCoord_Click failed: {0}", ex.Message);
+            }
+        }
+
+        void AfterCoordsList_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            UpdateRemoveCoordEnabled();
+        }
+
+        /// <summary>Remove is enabled only when an after-row (index >= 1) is
+        /// selected — the synthetic START row (index 0) can never be removed.</summary>
+        void UpdateRemoveCoordEnabled()
+        {
+            RemoveCoordBtn.IsEnabled = _vm.IsFE8 && AfterCoordsList.SelectedIndex >= 1;
         }
 
         // ---------------------------------------------------------------

--- a/FEBuilderGBA.Core.Tests/EventUnitCoordCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventUnitCoordCoreTests.cs
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1017 Core tests for EventUnitCoordCore — the FE8 Event-Unit after-coord
+// (move-path) list read/write seam.
+//
+// Uses a synthetic ROM (RomInfo not needed — the seam only touches the unit
+// block's W4/B7/D8 fields + the 8-byte blob in free space). Validates:
+//   * ReadAfterCoords: START row from W4 (Unk1=Unk2=0xFF, others 0) + blob rows
+//   * Read with P8=0 / B7=0 -> only the START row, no throw
+//   * Add a coord -> WriteAfterCoords -> re-read: B7++, blob round-trips, W4=list[0]
+//   * In-place (same size) keeps P8; grow repoints P8 (both round-trip)
+//   * count-0 clear -> P8=0, B7=0, old region 0xFF-filled
+//   * index-0 -> W4 coupling
+//   * Guards (ZERO mutation): null list, empty list, >255 after-rows, free-space
+//     exhaustion -> byte-identical restore
+using System;
+using System.Collections.Generic;
+using FEBuilderGBA;
+using FEBuilderGBA.Core;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class EventUnitCoordCoreTests
+    {
+        // A 20-byte unit block near the ROM START. Free 0xFF space follows the
+        // midpoint so the append path lands there; the blob is planted in the
+        // low region (also 0xFF after the planted bytes).
+        const uint UNIT_ADDR = 0x400;       // unit block base
+        const uint BLOB_ADDR = 0x800;       // planted after-coord blob base
+        const uint ROM_LEN = 0x20000;       // 128 KiB
+
+        static uint W4Addr => UNIT_ADDR + 4;
+        static uint B7Addr => UNIT_ADDR + 7;
+        static uint P8Addr => UNIT_ADDR + 8;
+
+        static ROM MakeRom()
+        {
+            var rom = new ROM();
+            byte[] data = new byte[ROM_LEN];
+            Array.Fill(data, (byte)0xFF); // free-space marker for FindFreeSpace
+            // Zero the low region so reads are deterministic (covers the unit
+            // block + the planted blob area).
+            for (uint i = 0; i < 0x1000; i++) data[i] = 0x00;
+            rom.LoadLow("synth.gba", data, "BE8E01"); // FE8U header sig
+            return rom;
+        }
+
+        /// <summary>Plant a FE8 unit block: W4 packed pos + B7 records + D8->blob.</summary>
+        static void PlantBlock(ROM rom, uint x, uint y, uint ext, Fe8Coord[] afterRecords)
+        {
+            rom.write_u16(W4Addr, (ushort)U.MakeFe8UnitPos(x, y, ext));
+            if (afterRecords == null || afterRecords.Length == 0)
+            {
+                rom.write_u8(B7Addr, 0);
+                rom.write_p32(P8Addr, 0);
+                return;
+            }
+            rom.write_u8(B7Addr, (uint)afterRecords.Length);
+            rom.write_p32(P8Addr, U.toPointer(BLOB_ADDR));
+            uint a = BLOB_ADDR;
+            foreach (Fe8Coord r in afterRecords)
+            {
+                rom.write_u16(a + 0, (ushort)U.MakeFe8UnitPos(r.X, r.Y, r.Ext));
+                rom.write_u8(a + 2, r.Speed);
+                rom.write_u8(a + 3, r.UnitId);
+                rom.write_u8(a + 4, r.Unk1);
+                rom.write_u8(a + 5, r.Unk2);
+                rom.write_u16(a + 6, (ushort)r.Wait);
+                a += 8;
+            }
+        }
+
+        static Fe8Coord Rec(uint x, uint y, uint ext, uint speed, uint unitId, uint unk1, uint unk2, uint wait)
+            => new Fe8Coord { X = x, Y = y, Ext = ext, Speed = speed, UnitId = unitId, Unk1 = unk1, Unk2 = unk2, Wait = wait };
+
+        // ---------------------------------------------------------------
+        // READ
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public void ReadAfterCoords_StartRowFromW4_PlusBlobRows()
+        {
+            ROM rom = MakeRom();
+            var records = new[]
+            {
+                Rec(5, 6, 1, 0x11, 0x22, 0x33, 0x44, 0x1234),
+                Rec(7, 8, 2, 0x55, 0x66, 0x77, 0x88, 0x4321),
+            };
+            PlantBlock(rom, x: 3, y: 4, ext: 2, afterRecords: records);
+
+            var list = EventUnitCoordCore.ReadAfterCoords(rom, rom.u16(W4Addr), rom.u8(B7Addr), rom.u32(P8Addr));
+
+            Assert.Equal(3, list.Count); // START + 2 records
+
+            // START row — from W4: X/Y/Ext, Unk1=Unk2=0xFF, others 0.
+            Fe8Coord start = list[0];
+            Assert.Equal(3u, start.X);
+            Assert.Equal(4u, start.Y);
+            Assert.Equal(2u, start.Ext);
+            Assert.Equal(0u, start.Speed);
+            Assert.Equal(0u, start.UnitId);
+            Assert.Equal(0xFFu, start.Unk1);
+            Assert.Equal(0xFFu, start.Unk2);
+            Assert.Equal(0u, start.Wait);
+
+            // Record 1 — all 8 fields.
+            Fe8Coord r1 = list[1];
+            Assert.Equal(5u, r1.X); Assert.Equal(6u, r1.Y); Assert.Equal(1u, r1.Ext);
+            Assert.Equal(0x11u, r1.Speed); Assert.Equal(0x22u, r1.UnitId);
+            Assert.Equal(0x33u, r1.Unk1); Assert.Equal(0x44u, r1.Unk2);
+            Assert.Equal(0x1234u, r1.Wait);
+
+            // Record 2.
+            Fe8Coord r2 = list[2];
+            Assert.Equal(7u, r2.X); Assert.Equal(8u, r2.Y); Assert.Equal(2u, r2.Ext);
+            Assert.Equal(0x55u, r2.Speed); Assert.Equal(0x66u, r2.UnitId);
+            Assert.Equal(0x77u, r2.Unk1); Assert.Equal(0x88u, r2.Unk2);
+            Assert.Equal(0x4321u, r2.Wait);
+        }
+
+        [Fact]
+        public void ReadAfterCoords_NoBlob_ReturnsOnlyStartRow()
+        {
+            ROM rom = MakeRom();
+            PlantBlock(rom, x: 9, y: 10, ext: 0, afterRecords: null); // P8=0, B7=0
+
+            var list = EventUnitCoordCore.ReadAfterCoords(rom, rom.u16(W4Addr), rom.u8(B7Addr), rom.u32(P8Addr));
+
+            Assert.Single(list);
+            Assert.Equal(9u, list[0].X);
+            Assert.Equal(10u, list[0].Y);
+            Assert.Equal(0xFFu, list[0].Unk1);
+        }
+
+        // ---------------------------------------------------------------
+        // WRITE — add a coord (append path, grows beyond old size)
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public void WriteAfterCoords_AddCoord_RoundTrips()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                // Start: one after-coord planted.
+                PlantBlock(rom, x: 1, y: 2, ext: 0, afterRecords: new[]
+                {
+                    Rec(5, 5, 0, 1, 2, 3, 4, 100),
+                });
+
+                // Build list = START + 2 after-coords (one new -> grow).
+                var list = new List<Fe8Coord>
+                {
+                    Rec(1, 2, 0, 0, 0, 0xFF, 0xFF, 0),          // START
+                    Rec(5, 5, 0, 1, 2, 3, 4, 100),              // existing
+                    Rec(9, 9, 1, 9, 8, 7, 6, 0xBEEF),           // new
+                };
+
+                string err = EventUnitCoordCore.WriteAfterCoords(rom, W4Addr, B7Addr, P8Addr, list);
+                Assert.Equal("", err);
+
+                // B7 incremented to 2.
+                Assert.Equal(2u, rom.u8(B7Addr));
+                // W4 = list[0].
+                Assert.Equal(U.MakeFe8UnitPos(1, 2, 0), rom.u16(W4Addr));
+
+                // Re-read and compare all 8 fields per record.
+                var reread = EventUnitCoordCore.ReadAfterCoords(rom, rom.u16(W4Addr), rom.u8(B7Addr), rom.u32(P8Addr));
+                Assert.Equal(3, reread.Count);
+                AssertRecordEqual(list[1], reread[1]);
+                AssertRecordEqual(list[2], reread[2]);
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        // ---------------------------------------------------------------
+        // WRITE — in-place vs append
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public void WriteAfterCoords_SameSize_InPlace_PointerUnchanged()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                PlantBlock(rom, x: 1, y: 1, ext: 0, afterRecords: new[]
+                {
+                    Rec(2, 2, 0, 1, 1, 1, 1, 10),
+                    Rec(3, 3, 0, 2, 2, 2, 2, 20),
+                });
+                uint p8Before = rom.u32(P8Addr);
+
+                // Same count (2 after-coords) -> in-place, P8 must NOT change.
+                var list = new List<Fe8Coord>
+                {
+                    Rec(1, 1, 0, 0, 0, 0xFF, 0xFF, 0),
+                    Rec(4, 4, 1, 9, 9, 9, 9, 99),  // edited
+                    Rec(5, 5, 2, 8, 8, 8, 8, 88),  // edited
+                };
+                string err = EventUnitCoordCore.WriteAfterCoords(rom, W4Addr, B7Addr, P8Addr, list);
+                Assert.Equal("", err);
+
+                Assert.Equal(p8Before, rom.u32(P8Addr)); // in-place: unchanged
+                Assert.Equal(2u, rom.u8(B7Addr));
+
+                var reread = EventUnitCoordCore.ReadAfterCoords(rom, rom.u16(W4Addr), rom.u8(B7Addr), rom.u32(P8Addr));
+                AssertRecordEqual(list[1], reread[1]);
+                AssertRecordEqual(list[2], reread[2]);
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void WriteAfterCoords_Grow_Repoints_AndRoundTrips()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                PlantBlock(rom, x: 1, y: 1, ext: 0, afterRecords: new[]
+                {
+                    Rec(2, 2, 0, 1, 1, 1, 1, 10),
+                });
+                uint p8Before = rom.u32(P8Addr);
+
+                // Grow from 1 -> 3 after-coords (beyond old size) -> append + repoint.
+                var list = new List<Fe8Coord>
+                {
+                    Rec(1, 1, 0, 0, 0, 0xFF, 0xFF, 0),
+                    Rec(2, 2, 0, 1, 1, 1, 1, 10),
+                    Rec(3, 3, 0, 2, 2, 2, 2, 20),
+                    Rec(4, 4, 1, 3, 3, 3, 3, 30),
+                };
+                string err = EventUnitCoordCore.WriteAfterCoords(rom, W4Addr, B7Addr, P8Addr, list);
+                Assert.Equal("", err);
+
+                Assert.NotEqual(p8Before, rom.u32(P8Addr)); // repointed
+                Assert.True(U.isPointer(rom.u32(P8Addr)));
+                Assert.Equal(3u, rom.u8(B7Addr));
+
+                var reread = EventUnitCoordCore.ReadAfterCoords(rom, rom.u16(W4Addr), rom.u8(B7Addr), rom.u32(P8Addr));
+                Assert.Equal(4, reread.Count);
+                for (int i = 1; i < 4; i++) AssertRecordEqual(list[i], reread[i]);
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        // ---------------------------------------------------------------
+        // WRITE — count-0 clear
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public void WriteAfterCoords_RemoveAll_ClearsPointerCountAndFillsOldRegion()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                PlantBlock(rom, x: 1, y: 1, ext: 0, afterRecords: new[]
+                {
+                    Rec(2, 2, 0, 1, 1, 1, 1, 10),
+                    Rec(3, 3, 0, 2, 2, 2, 2, 20),
+                });
+
+                // Only the START row -> count 0 -> clear.
+                var list = new List<Fe8Coord> { Rec(1, 1, 0, 0, 0, 0xFF, 0xFF, 0) };
+                string err = EventUnitCoordCore.WriteAfterCoords(rom, W4Addr, B7Addr, P8Addr, list);
+                Assert.Equal("", err);
+
+                Assert.Equal(0u, rom.u32(P8Addr));
+                Assert.Equal(0u, rom.u8(B7Addr));
+                // Old region (2 records = 16 bytes at BLOB_ADDR) filled with 0xFF.
+                for (uint i = 0; i < 16; i++)
+                    Assert.Equal((byte)0xFF, rom.u8(BLOB_ADDR + i));
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        // ---------------------------------------------------------------
+        // index-0 -> W4 coupling
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public void WriteAfterCoords_EditStartRow_UpdatesW4()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                PlantBlock(rom, x: 1, y: 1, ext: 0, afterRecords: null);
+
+                var list = new List<Fe8Coord> { Rec(12, 13, 3, 0, 0, 0xFF, 0xFF, 0) };
+                string err = EventUnitCoordCore.WriteAfterCoords(rom, W4Addr, B7Addr, P8Addr, list);
+                Assert.Equal("", err);
+
+                Assert.Equal(U.MakeFe8UnitPos(12, 13, 3), rom.u16(W4Addr));
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        // ---------------------------------------------------------------
+        // Guards — ZERO mutation
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public void WriteAfterCoords_NullList_NoMutation()
+        {
+            ROM rom = MakeRom();
+            PlantBlock(rom, x: 1, y: 1, ext: 0, afterRecords: new[] { Rec(2, 2, 0, 1, 1, 1, 1, 10) });
+            byte[] before = (byte[])rom.Data.Clone();
+
+            string err = EventUnitCoordCore.WriteAfterCoords(rom, W4Addr, B7Addr, P8Addr, null);
+
+            Assert.NotEqual("", err);
+            Assert.Equal(before, rom.Data);
+        }
+
+        [Fact]
+        public void WriteAfterCoords_EmptyList_NoMutation()
+        {
+            ROM rom = MakeRom();
+            PlantBlock(rom, x: 1, y: 1, ext: 0, afterRecords: new[] { Rec(2, 2, 0, 1, 1, 1, 1, 10) });
+            byte[] before = (byte[])rom.Data.Clone();
+
+            string err = EventUnitCoordCore.WriteAfterCoords(rom, W4Addr, B7Addr, P8Addr, new List<Fe8Coord>());
+
+            Assert.NotEqual("", err);
+            Assert.Equal(before, rom.Data);
+        }
+
+        [Fact]
+        public void WriteAfterCoords_TooManyAfterRows_NoMutation()
+        {
+            ROM rom = MakeRom();
+            PlantBlock(rom, x: 1, y: 1, ext: 0, afterRecords: null);
+            byte[] before = (byte[])rom.Data.Clone();
+
+            // START + 256 after-coords (count-1 = 256 > 255).
+            var list = new List<Fe8Coord> { Rec(1, 1, 0, 0, 0, 0xFF, 0xFF, 0) };
+            for (int i = 0; i < 256; i++) list.Add(Rec(2, 2, 0, 0, 0, 0, 0, 0));
+
+            string err = EventUnitCoordCore.WriteAfterCoords(rom, W4Addr, B7Addr, P8Addr, list);
+
+            Assert.NotEqual("", err);
+            Assert.Equal(before, rom.Data);
+        }
+
+        [Fact]
+        public void WriteAfterCoords_FreeSpaceExhausted_RestoresByteIdentical()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                // ROM with NO free space: FindFreeSpace treats BOTH 0x00 and
+                // 0xFF runs as free, so fill with 0x55 (neither marker) — no
+                // contiguous 16-byte free run exists, forcing NOT_FOUND on the
+                // append path. (The unit-block field writes touch < a 16-byte
+                // contiguous run of one value, so they don't create free space.)
+                var rom = new ROM();
+                byte[] data = new byte[0x1000];
+                Array.Fill(data, (byte)0x55);
+                rom.LoadLow("tiny.gba", data, "BE8E01");
+                CoreState.ROM = rom;
+
+                // Plant with NO existing blob so the write must take the append
+                // path (in-place needs a safe old blob; there is none).
+                rom.write_u16(W4Addr, (ushort)U.MakeFe8UnitPos(1, 1, 0));
+                rom.write_u8(B7Addr, 0);
+                rom.write_p32(P8Addr, 0);
+                byte[] before = (byte[])rom.Data.Clone();
+
+                var list = new List<Fe8Coord>
+                {
+                    Rec(1, 1, 0, 0, 0, 0xFF, 0xFF, 0),
+                    Rec(2, 2, 0, 1, 1, 1, 1, 10),
+                };
+                string err = EventUnitCoordCore.WriteAfterCoords(rom, W4Addr, B7Addr, P8Addr, list);
+
+                Assert.NotEqual("", err);
+                // Byte-identical restore: even the W4 write (which DID happen
+                // before the append fault) is rolled back by the snapshot.
+                Assert.Equal(before, rom.Data);
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        static void AssertRecordEqual(Fe8Coord expected, Fe8Coord actual)
+        {
+            Assert.Equal(expected.X, actual.X);
+            Assert.Equal(expected.Y, actual.Y);
+            Assert.Equal(expected.Ext, actual.Ext);
+            Assert.Equal(expected.Speed, actual.Speed);
+            Assert.Equal(expected.UnitId, actual.UnitId);
+            Assert.Equal(expected.Unk1, actual.Unk1);
+            Assert.Equal(expected.Unk2, actual.Unk2);
+            Assert.Equal(expected.Wait, actual.Wait);
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/EventUnitCoordCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventUnitCoordCoreTests.cs
@@ -133,6 +133,22 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Equal(0xFFu, list[0].Unk1);
         }
 
+        [Fact]
+        public void ReadAfterCoords_NullRom_StillReturnsStartRowFromW4()
+        {
+            // The START row is a pure parse of W4 (no ROM read), so the
+            // "always >=1 row" contract holds even with a null ROM — only the
+            // blob records need the ROM (Copilot bot review on PR #1073).
+            uint w4 = U.MakeFe8UnitPos(7, 12, 0);
+            var list = EventUnitCoordCore.ReadAfterCoords(null, w4, b7: 5, p8: 0x08001000);
+
+            Assert.Single(list);
+            Assert.Equal(7u, list[0].X);
+            Assert.Equal(12u, list[0].Y);
+            Assert.Equal(0xFFu, list[0].Unk1);
+            Assert.Equal(0xFFu, list[0].Unk2);
+        }
+
         // ---------------------------------------------------------------
         // WRITE — add a coord (append path, grows beyond old size)
         // ---------------------------------------------------------------

--- a/FEBuilderGBA.Core/EventUnitCoordCore.cs
+++ b/FEBuilderGBA.Core/EventUnitCoordCore.cs
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Cross-platform FE8 Event-Unit after-coord (move-path) list seam (#1017).
+//
+// Ports the read/write halves of WinForms EventUnitForm.MakeUnitCoordList +
+// PreWriteHandler so the Avalonia Event Unit editor can edit the FE8
+// after-coord move-path list (the WF FE8CoordListBox).
+//
+// FE8 20-byte unit block field map used here:
+//   W4 = +4 (u16)  — the packed START (before) UnitPos (X/Y/Ext)
+//   B7 = +7 (u8)   — after-coord record COUNT (u8 cap)
+//   D8 = +8 (u32)  — after-coord blob GBA pointer
+//
+// List shape (the unified Fe8Coord list this seam reads/writes):
+//   index 0   = the synthetic START row sourced from W4 (X/Y/Ext only;
+//               Unk1=Unk2=0xFF, Speed=UnitId=Wait=0). Persisted back to W4.
+//   indices 1+ = the after-coord records, each an 8-byte blob entry at D8:
+//                 u16 unitpos @+0 (X/Y/Ext), u8 Speed @+2, u8 UnitId @+3,
+//                 u8 Unk1 @+4, u8 Unk2 @+5, u16 Wait @+6.
+//
+// WRITE atomicity: runs under the CALLER's ambient undo scope. A defensive
+// length-aware rom.Data snapshot is restored byte-identical on ANY fault
+// (exception OR a free-space NOT_FOUND), mirroring the #885/#923 pattern.
+using System;
+using System.Collections.Generic;
+using FEBuilderGBA; // ROM, U, R live here.
+
+namespace FEBuilderGBA.Core
+{
+    /// <summary>
+    /// One unified FE8 after-coord row. Index 0 is the synthetic START row
+    /// (sourced from / persisted to W4); indices 1+ are the 8-byte blob records.
+    /// </summary>
+    public sealed class Fe8Coord
+    {
+        public uint X, Y, Ext, Speed, UnitId, Unk1, Unk2, Wait;
+    }
+
+    /// <summary>
+    /// Cross-platform read/write seam for the FE8 Event-Unit after-coord
+    /// (move-path) list (#1017). FE8-only — callers gate on
+    /// <c>eventunit_data_size == 20</c>.
+    /// </summary>
+    public static class EventUnitCoordCore
+    {
+        // B7 is a u8, so the after-coord record count cannot exceed 255.
+        public const int MaxAfterCoordRecords = 255;
+
+        /// <summary>
+        /// READ-ONLY. Build the unified after-coord list for a FE8 unit block.
+        /// Always returns at least one row (the START row from <paramref name="w4"/>);
+        /// indices 1+ come from the <paramref name="b7"/> records of 8 bytes at
+        /// <c>toOffset(<paramref name="p8"/>)</c>. A record is dropped (and the
+        /// scan stops) when its <c>addr+7</c> would read out of range.
+        /// </summary>
+        public static List<Fe8Coord> ReadAfterCoords(ROM rom, uint w4, uint b7, uint p8)
+        {
+            var list = new List<Fe8Coord>();
+            if (rom == null) return list;
+
+            // index 0 — synthetic START row from W4.
+            var start = new Fe8Coord
+            {
+                X = U.ParseFe8UnitPosX(w4),
+                Y = U.ParseFe8UnitPosY(w4),
+                Ext = U.ParseFe8UnitPosExt(w4),
+                Speed = 0,
+                UnitId = 0,
+                Unk1 = 0xFF,
+                Unk2 = 0xFF,
+                Wait = 0,
+            };
+            list.Add(start);
+
+            // indices 1+ — the after-coord blob records (8 bytes each).
+            uint count = b7;
+            uint addr = U.toOffset(p8);
+            for (uint i = 0; i < count; i++, addr += 8)
+            {
+                // Guard the full 8-byte record (the WF code guards addr+7).
+                if (!U.isSafetyOffset(addr + 7, rom))
+                    break;
+
+                uint unitpos = rom.u16(addr + 0);
+                var rec = new Fe8Coord
+                {
+                    X = U.ParseFe8UnitPosX(unitpos),
+                    Y = U.ParseFe8UnitPosY(unitpos),
+                    Ext = U.ParseFe8UnitPosExt(unitpos),
+                    Speed = rom.u8(addr + 2),
+                    UnitId = rom.u8(addr + 3),
+                    Unk1 = rom.u8(addr + 4),
+                    Unk2 = rom.u8(addr + 5),
+                    Wait = rom.u16(addr + 6),
+                };
+                list.Add(rec);
+            }
+
+            return list;
+        }
+
+        /// <summary>
+        /// ROM-MUTATING. Persist the unified after-coord list back to the FE8
+        /// unit block: <c>list[0]</c> -> W4 (via <see cref="U.MakeFe8UnitPos"/>),
+        /// indices 1+ -> the 8-byte blob (in-place when it fits the old blob and
+        /// the old pointer is safe, otherwise append to free space + repoint +
+        /// recycle the old region). count==0 (only the START row) clears the blob
+        /// (P8=0, B7=0, old region 0xFF-filled).
+        ///
+        /// Runs under the CALLER's ambient undo scope (all writes go through the
+        /// rom write methods). Never throws; returns "" on success or a localized
+        /// error string. On ANY fault (exception OR a free-space NOT_FOUND) the
+        /// ROM is restored byte-identical (length-aware snapshot) so the failure
+        /// mutates ZERO bytes.
+        /// </summary>
+        public static string WriteAfterCoords(ROM rom, uint w4FieldAddr, uint b7FieldAddr, uint p8FieldAddr,
+            List<Fe8Coord> list)
+        {
+            if (rom == null) return R._("ROM is not loaded.");
+            if (list == null || list.Count == 0)
+                return R._("The after-coord list must contain at least the start row.");
+
+            int count = list.Count - 1; // after-coord records (excludes the START row)
+            if (count > MaxAfterCoordRecords)
+                return R._("Too many after-coords: {0} (max {1}).", count, MaxAfterCoordRecords);
+
+            // Field-slot bounds — these must be in range for the W4/B7/P8 writes.
+            if (w4FieldAddr + 2 > (uint)rom.Data.Length
+                || b7FieldAddr + 1 > (uint)rom.Data.Length
+                || p8FieldAddr + 4 > (uint)rom.Data.Length)
+            {
+                return R._("The event-unit block address is out of range.");
+            }
+
+            // Capture the OLD blob pointer + count BEFORE any write so the
+            // in-place / recycle decisions use the pre-write state.
+            uint oldP8 = rom.p32(p8FieldAddr);
+            uint oldB7 = rom.u8(b7FieldAddr);
+            uint oldBlobOffset = U.toOffset(oldP8);
+            uint oldBlobLen = 8 * oldB7;
+
+            // Defensive snapshot for the byte-identical restore on fault. The
+            // caller's ambient undo scope captures the writes for UNDO; this
+            // snapshot guarantees a FAILED write mutates ZERO bytes.
+            byte[] snap = (byte[])rom.Data.Clone();
+            try
+            {
+                // 1. list[0] -> W4 (the synthetic START row).
+                Fe8Coord startRow = list[0];
+                rom.write_u16(w4FieldAddr, (ushort)U.MakeFe8UnitPos(startRow.X, startRow.Y, startRow.Ext));
+
+                // 2a. count==0 — no after-coords. Clear the old blob and zero P8/B7.
+                if (count == 0)
+                {
+                    if (oldB7 > 0 && U.isSafetyOffset(oldBlobOffset, rom)
+                        && oldBlobOffset + oldBlobLen <= (uint)rom.Data.Length)
+                    {
+                        rom.write_fill(oldBlobOffset, oldBlobLen, 0xFF);
+                    }
+                    rom.write_p32(p8FieldAddr, 0);
+                    rom.write_u8(b7FieldAddr, 0);
+                    return "";
+                }
+
+                // 2b. Serialize indices 1+ into the 8-byte blob layout.
+                byte[] bin = new byte[8 * count];
+                uint binOff = 0;
+                for (int i = 1; i < list.Count; i++, binOff += 8)
+                {
+                    Fe8Coord rec = list[i];
+                    uint unitpos = U.MakeFe8UnitPos(rec.X, rec.Y, rec.Ext);
+                    U.write_u16(bin, binOff + 0, unitpos);
+                    U.write_u8(bin, binOff + 2, rec.Speed);
+                    U.write_u8(bin, binOff + 3, rec.UnitId);
+                    U.write_u8(bin, binOff + 4, rec.Unk1);
+                    U.write_u8(bin, binOff + 5, rec.Unk2);
+                    U.write_u16(bin, binOff + 6, rec.Wait);
+                }
+
+                bool oldBlobSafe = oldB7 > 0 && U.isSafetyOffset(oldBlobOffset, rom)
+                    && oldBlobOffset + oldBlobLen <= (uint)rom.Data.Length;
+
+                if ((uint)bin.Length <= oldBlobLen && oldBlobSafe)
+                {
+                    // IN-PLACE: the new blob fits the old region. Overwrite + zero
+                    // the unused tail; the pointer stays put (no repoint).
+                    rom.write_range(oldBlobOffset, bin);
+                    uint tail = oldBlobLen - (uint)bin.Length;
+                    if (tail > 0)
+                        rom.write_fill(oldBlobOffset + (uint)bin.Length, tail, 0xFF);
+
+                    rom.write_u8(b7FieldAddr, (uint)count);
+                    // P8 unchanged on the in-place path.
+                    return "";
+                }
+
+                // APPEND: find free space, write the new blob, repoint P8, then
+                // recycle the old region (only when it was a real, safe blob).
+                uint searchStart = (uint)(rom.Data.Length / 2);
+                uint newAddr = rom.FindFreeSpace(searchStart, (uint)bin.Length);
+                if (newAddr == U.NOT_FOUND)
+                    newAddr = rom.FindFreeSpace(0x100, (uint)bin.Length);
+                if (newAddr == U.NOT_FOUND)
+                {
+                    RestoreSnapshot(rom, snap);
+                    return R._("Failed to write after-coords. Check ROM free space.");
+                }
+
+                rom.write_range(newAddr, bin);
+                rom.write_p32(p8FieldAddr, U.toPointer(newAddr));
+                rom.write_u8(b7FieldAddr, (uint)count);
+
+                // Recycle the OLD region (0xFF) — but never if it overlaps the
+                // freshly-written new blob (defensive; FindFreeSpace returns a
+                // non-overlapping region so this only guards a degenerate case).
+                if (oldBlobSafe && !RegionsOverlap(oldBlobOffset, oldBlobLen, newAddr, (uint)bin.Length))
+                {
+                    rom.write_fill(oldBlobOffset, oldBlobLen, 0xFF);
+                }
+
+                return "";
+            }
+            catch (Exception ex)
+            {
+                RestoreSnapshot(rom, snap);
+                return R._("After-coord write failed: {0}", ex.Message);
+            }
+        }
+
+        static bool RegionsOverlap(uint aStart, uint aLen, uint bStart, uint bLen)
+        {
+            if (aLen == 0 || bLen == 0) return false;
+            uint aEnd = aStart + aLen;
+            uint bEnd = bStart + bLen;
+            return aStart < bEnd && bStart < aEnd;
+        }
+
+        /// <summary>
+        /// Length-aware byte-identical restore: a free-space resize-append can
+        /// GROW rom.Data, so down-resize back to the snapshot length BEFORE the
+        /// in-place copy (a naive Array.Copy would leave the grown tail alive).
+        /// </summary>
+        static void RestoreSnapshot(ROM rom, byte[] snap)
+        {
+            if (rom.Data.Length != snap.Length)
+                rom.write_resize_data((uint)snap.Length);
+            Array.Copy(snap, rom.Data, snap.Length);
+        }
+    }
+}

--- a/FEBuilderGBA.Core/EventUnitCoordCore.cs
+++ b/FEBuilderGBA.Core/EventUnitCoordCore.cs
@@ -55,9 +55,11 @@ namespace FEBuilderGBA.Core
         public static List<Fe8Coord> ReadAfterCoords(ROM rom, uint w4, uint b7, uint p8)
         {
             var list = new List<Fe8Coord>();
-            if (rom == null) return list;
 
-            // index 0 — synthetic START row from W4.
+            // index 0 — synthetic START row from W4. This is a PURE parse of w4
+            // (no ROM read), so the start row is present even with a null ROM —
+            // honoring the "always returns >=1 row" contract (Copilot bot review
+            // on PR #1073). Only the blob records below need the ROM.
             var start = new Fe8Coord
             {
                 X = U.ParseFe8UnitPosX(w4),
@@ -70,6 +72,8 @@ namespace FEBuilderGBA.Core
                 Wait = 0,
             };
             list.Add(start);
+
+            if (rom == null) return list;
 
             // indices 1+ — the after-coord blob records (8 bytes each).
             uint count = b7;

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -10304,3 +10304,42 @@ TSA セル
 
 :Per-cell editing supports non-header TSA only — header-TSA editing tracked separately.
 セル単位の編集は非ヘッダ TSA のみ対応 — ヘッダ TSA の編集は別途対応予定です。
+
+:After Coordinate Move Path (FE8)
+配置後の移動座標 (FE8)
+
+:Add Coord
+座標を追加
+
+:Remove Coord
+座標を削除
+
+:Row 0 is the start position (X/Y/Ext persist to W4). Rows 1+ are the move-path steps.
+行0は開始位置（X/Y/ExtはW4に保存）。行1以降は移動経路のステップです。
+
+:The after-coord list must contain at least the start row.
+移動座標リストには少なくとも開始行が必要です。
+
+:Too many after-coords: {0} (max {1}).
+移動座標が多すぎます: {0} (最大 {1})。
+
+:The event-unit block address is out of range.
+イベントユニットブロックのアドレスが範囲外です。
+
+:Failed to write after-coords. Check ROM free space.
+移動座標の書き込みに失敗しました。ROMの空き容量を確認してください。
+
+:After-coord write failed: {0}
+移動座標の書き込みに失敗しました: {0}
+
+:UnitId
+ユニットID
+
+:Unk1
+不明1
+
+:Unk2
+不明2
+
+:Wait
+待機

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -24136,3 +24136,42 @@ TSA 单元格
 
 :Per-cell editing supports non-header TSA only — header-TSA editing tracked separately.
 逐单元格编辑仅支持非头部 TSA — 头部 TSA 的编辑另行跟踪处理。
+
+:After Coordinate Move Path (FE8)
+到达坐标移动路径 (FE8)
+
+:Add Coord
+添加坐标
+
+:Remove Coord
+删除坐标
+
+:Row 0 is the start position (X/Y/Ext persist to W4). Rows 1+ are the move-path steps.
+第0行是起始位置（X/Y/Ext保存到W4）。第1行及以后是移动路径步骤。
+
+:The after-coord list must contain at least the start row.
+到达坐标列表必须至少包含起始行。
+
+:Too many after-coords: {0} (max {1}).
+到达坐标过多: {0} (最大 {1})。
+
+:The event-unit block address is out of range.
+事件单位数据块地址超出范围。
+
+:Failed to write after-coords. Check ROM free space.
+写入到达坐标失败。请检查ROM空闲空间。
+
+:After-coord write failed: {0}
+写入到达坐标失败: {0}
+
+:UnitId
+单位ID
+
+:Unk1
+未知1
+
+:Unk2
+未知2
+
+:Wait
+等待

--- a/docs/avalonia-forms.md
+++ b/docs/avalonia-forms.md
@@ -191,7 +191,7 @@ Editors for event scripts, conditions, units, templates, and related data.
 | 90 | EventScriptPopupView | EventScriptPopupViewModel | Event script popup editor |
 | 91 | EventCondView | EventCondViewModel | Event condition editor |
 | 92 | EventCondMainView | EventCondMainViewModel | Nested sub-view for conditions |
-| 93 | EventUnitView | EventUnitViewModel | Event unit placement editor |
+| 93 | EventUnitView | EventUnitViewModel | Event unit placement editor — FE8 editable after-coord (move-path) list (#1017): row 0 is the synthetic START pos (X/Y/Ext persist to W4, synthetic fields disabled), rows 1+ are the 8-byte blob records (X/Y/Ext/Speed/UnitId/Unk1/Unk2/Wait); Add/Remove + in-place-vs-append+repoint write via Core `EventUnitCoordCore`; FE8-gated |
 | 94 | EventUnitFE6View | EventUnitFE6ViewModel | Event unit placement (FE6) |
 | 95 | EventUnitFE7View | EventUnitFE7ViewModel | Event unit placement (FE7) |
 | 96 | EventUnitSimView | EventUnitSimViewModel | Simplified event unit editor |


### PR DESCRIPTION
## Summary
Makes the **FE8 Event Unit after-coord move-path list editable**. It was read-only (B7 count + D8 pointer shown but the coordinate list couldn't be edited). Ports WF `FE8CoordListBox`.

Closes #1017.

## Plan
Reviewed + accepted by Copilot CLI (GPT-5.5) with 8 refinements: https://github.com/laqieer/FEBuilderGBA/issues/1017#issuecomment-4657854002 (folded in at #issuecomment-4657923032).

## What changed
- **`FEBuilderGBA.Core/EventUnitCoordCore.cs`** (new, FE8-only):
  - `ReadAfterCoords(rom, w4, b7, p8)` (READ-ONLY) — list **index 0 = the unit START position from W4** (X/Y/Ext via `U.ParseFe8UnitPos*`, Unk1=Unk2=0xFF, Speed/UnitId/Wait synthetic 0); indices **1+** = `B7` records of **8 bytes** at `toOffset(P8)` (`u16 unitpos`, `u8 speed/unitid/unk1/unk2`, `u16 wait`). Always returns ≥1 row even when P8/B7 are 0/unsafe.
  - `WriteAfterCoords(rom, w4Addr, b7Addr, p8Addr, list)` (ROM-MUTATING) — list[0] → **W4** (`U.MakeFe8UnitPos`); `count = list.Count-1`; **count-0** → clear old region + P8=0/B7=0; else serialize 1+ → **in-place overwrite + zero-tail when it fits** (no repoint) / **else append to free space + repoint P8 + recycle old**; B7=count. Guards: null/empty list and `count > 255` (B7 is u8) → error with **ZERO** mutation; length-aware byte-identical snapshot restore on any exception or free-space `NOT_FOUND`; never throws.
- **`EventUnitViewModel`** — `ObservableCollection<Fe8CoordRowViewModel> AfterCoords` (8 editable fields + `IsStartRow`/`IsAfterRow`), `AddCoord`/`RemoveCoord` (row 0 not removable), FE8 gate, Write → `WriteAfterCoords(CurrentAddr+4/+7/+8, list)` + reload.
- **`EventUnitView`** — a FE8-gated "After Coordinate Move Path" panel: an editable row list (X/Y/Ext/Speed/UnitId/Unk1/Unk2/Wait) with **row 0's synthetic Speed/UnitId/Unk/Wait disabled** (only X/Y/Ext persist, to W4), **Add Coord** / **Remove Coord** buttons. Persists with the rest of the unit block under one undo scope.

## Test plan
- [x] `dotnet build` Core + Avalonia — 0 errors
- [x] `scripts/validate-automation-ids.ps1` — VALIDATION PASSED
- [x] Core `EventUnitCoord` — **11/11** (read index-0-from-W4 + blob rows; P8=0/B7=0 → start row only; add→write→re-read round-trip; **in-place same-size keeps P8** vs **grow repoints P8**; count-0 clear; index-0→W4 coupling; null/empty/`>255`/no-free-space → byte-identical restore)
- [x] Avalonia `EventUnit` — **93/93** (parity: coord list + Add/Remove reference `EventUnitCoordCore`; row-0 synthetic fields disabled; FE8-gated)
- [x] Full `FEBuilderGBA.Avalonia.Tests` — **7726 passed, 0 failed**, 3 skipped

## GUI Test Report
| Test | Result |
|------|--------|
| Event Unit (FE8) editor (FE8U.gba): the "After Coordinate Move Path" panel renders the unit's coord list — Add/Remove Coord, row **S** (start, X/Y/Ext only — Speed/UnitId/Unk/Wait disabled), editable move-path rows | PASS (screenshot below) |
| Read/write round-trip: index-0↔W4, 8-byte blob, in-place vs append+repoint, count-0 clear, B7 cap, fault restore | PASS (11 Core tests) |

The coord-list edit + Write persists through the global undo stack (the file-write isn't headlessly assertable on a locked session); the round-trips are proven authoritatively by the 11 Core tests, and the screenshot shows the populated editable list in the actual running editor.

## Screenshots
![FE8 Event Unit — editable After Coordinate Move Path list](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1017-eventunit.png)

## Out of scope (noted)
WF owner-drawn map-overlay coord pick + copy/paste of rows (per-field edit + add/remove covers the core editing); FE6/FE7 (no FE8 after-coord list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
