### PR TITLE
feat(avalonia): CSA Magic Creator live frame preview + MoreData link via MagicEffectExportCore.RenderCsaFramePreview (#1021)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageMagicCSACreatorParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageMagicCSACreatorParityTests.cs
@@ -468,6 +468,98 @@ public class ImageMagicCSACreatorParityTests
     }
 
     // -----------------------------------------------------------------
+    // #1021 — live CSA frame preview + working MoreData link.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// #1021: the dead static &lt;Image PreviewImage&gt; placeholder is replaced
+    /// by a GbaImageControl named MagicFramePreview (mirrors the FEditor preview),
+    /// and the "#500" placeholder tooltip is gone.
+    /// </summary>
+    [Fact]
+    public void View_PreviewIsGbaImageControl_NoStubTooltip()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("controls:GbaImageControl", axaml);
+        Assert.Contains("Name=\"MagicFramePreview\"", axaml);
+        // The dead Image placeholder named PreviewImage must be gone.
+        Assert.DoesNotContain("Name=\"PreviewImage\"", axaml);
+        // The "#500" pending-extraction tooltips on the preview + link must be gone.
+        Assert.DoesNotContain("Pending Core extraction - tracked by #500.", axaml);
+    }
+
+    /// <summary>
+    /// #1021: the code-behind has a RenderPreview() that calls the VM's
+    /// RenderCsaFramePreview, and a FrameBox.ValueChanged handler that re-renders.
+    /// </summary>
+    [Fact]
+    public void View_HasRenderPreview_AndFrameValueChangedHandler()
+    {
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        Assert.Contains("void RenderPreview()", source);
+        Assert.Contains("RenderCsaFramePreview(out", source);
+        Assert.Contains("void FrameBox_ValueChanged(", source);
+        // The FrameBox ValueChanged handler must be wired in the AXAML.
+        string axaml = ReadAxaml();
+        Assert.Contains("ValueChanged=\"FrameBox_ValueChanged\"", axaml);
+    }
+
+    /// <summary>
+    /// #1021: the zoom combo maps to the GbaImageControl zoom (no ROM re-render).
+    /// </summary>
+    [Fact]
+    public void View_ZoomCombo_MapsToImageControlZoom()
+    {
+        string axaml = ReadAxaml();
+        Assert.Contains("SelectionChanged=\"ZoomComboBox_SelectionChanged\"", axaml);
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        Assert.Contains("void ZoomComboBox_SelectionChanged(", source);
+        Assert.Contains("MagicFramePreview.Zoom", source);
+    }
+
+    /// <summary>
+    /// #1021 Part A: the "Find new resources online" label is now a working
+    /// link — a TextBlock with PointerPressed="LinkInternet_Click" + a handler
+    /// mirroring the FEditor's MoreData wiki opener.
+    /// </summary>
+    [Fact]
+    public void View_FindMoreDataLink_IsWired_ToMoreData()
+    {
+        string axaml = ReadAxaml();
+        int idx = axaml.IndexOf("AutomationId=\"ImageMagicCSACreator_FindMoreData_Label\"",
+            StringComparison.Ordinal);
+        Assert.True(idx >= 0, "FindMoreData label AutomationId not found in AXAML");
+        int elementStart = axaml.LastIndexOf('<', idx);
+        int elementEnd = axaml.IndexOf("/>", idx, StringComparison.Ordinal);
+        Assert.True(elementEnd > elementStart);
+        string element = axaml.Substring(elementStart, elementEnd - elementStart + 2);
+
+        // Must be a clickable link (blue / underline) wired to LinkInternet_Click.
+        Assert.Contains("PointerPressed=\"LinkInternet_Click\"", element);
+        Assert.Contains("TextDecorations=\"Underline\"", element);
+        Assert.DoesNotContain("#500", element);
+
+        string source = File.ReadAllText(ViewCodeBehindPath());
+        Assert.Contains("void LinkInternet_Click(", source);
+        Assert.Contains("wiki/MoreData", source);
+    }
+
+    /// <summary>
+    /// #1021: the ViewModel exposes the read-only RenderCsaFramePreview + the
+    /// CanRenderPreview gate (CsaCreator + IsLoaded) the view wires.
+    /// </summary>
+    [Fact]
+    public void ViewModel_CanRenderPreview_GatedOnCsaAndLoaded()
+    {
+        var vm = new ImageMagicCSACreatorViewModel();
+        // Not loaded + no system → cannot render; preview returns null.
+        Assert.False(vm.CanRenderPreview);
+        var img = vm.RenderCsaFramePreview(out string log);
+        Assert.Null(img);
+        Assert.False(string.IsNullOrEmpty(log));
+    }
+
+    // -----------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------
 

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageMagicCSACreatorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageMagicCSACreatorViewModel.cs
@@ -296,6 +296,75 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             return "";
         }
 
+        // ---- #1021 — live CSA frame preview (READ-ONLY) ----
+
+        /// <summary>
+        /// True when <see cref="RenderCsaFramePreview"/> can produce a non-null
+        /// image (the CSA Creator magic system is detected and an entry is
+        /// loaded). Gates the live preview re-render in the view, mirroring the
+        /// FEditor <c>CanExportMagicFrame</c> gate.
+        /// </summary>
+        public bool CanRenderPreview =>
+            _magicKind == MagicSystemKind.CsaCreator && IsLoaded;
+
+        /// <summary>
+        /// Render the currently-selected CSA frame as a 240×128 live preview using
+        /// the live P0/Frame/P4/P12 values (READ-ONLY). Mirrors the FEditor
+        /// <c>RenderMagicFramePreview</c>: gated on <c>rom != null</c> +
+        /// <c>MagicKind == CsaCreator</c> + <c>IsLoaded</c>, then delegates to
+        /// <see cref="MagicEffectExportCore.RenderCsaFramePreview"/>.
+        ///
+        /// <para>Pointer mapping (CSA): P0 = frame-data; P4 = OBJRightToLeft OAM;
+        /// P12 = OBJBGRightToLeft OAM.</para>
+        /// </summary>
+        /// <param name="log">Diagnostic text (empty on success, reason on null).</param>
+        /// <returns>A 240×128 <see cref="IImage"/>, or <c>null</c>.</returns>
+        public IImage RenderCsaFramePreview(out string log)
+        {
+            log = string.Empty;
+            var rom = CoreState.ROM;
+            if (rom == null)
+            {
+                log = "ROM not loaded.";
+                return null;
+            }
+            if (_magicKind != MagicSystemKind.CsaCreator)
+            {
+                log = "CSA Creator magic system not detected.";
+                return null;
+            }
+            if (!IsLoaded)
+            {
+                log = "No CSA entry loaded.";
+                return null;
+            }
+            // P0=frameData, P4=OBJRightToLeftOAM, P12=OBJBGRightToLeftOAM.
+            var img = MagicEffectExportCore.RenderCsaFramePreview(rom, P0, Frame, P4, P12);
+            if (img == null) log = "Frame render produced no image.";
+            return img;
+        }
+
+        /// <summary>
+        /// Count of 0x86 frames in the currently-loaded CSA animation (P0
+        /// frame-data stream). Used by the view to bound <c>FrameBox.Maximum</c>.
+        /// Returns 0 when no system / entry is loaded. READ-ONLY.
+        /// </summary>
+        public int GetFrameCount()
+        {
+            var rom = CoreState.ROM;
+            if (rom == null) return 0;
+            if (_magicKind != MagicSystemKind.CsaCreator) return 0;
+            if (!IsLoaded) return 0;
+
+            List<int> sharedObjSlots, sharedBgSlots;
+            List<MagicFrameMeta> frames;
+            MagicEffectExportCore.ExportMagicScriptLines(
+                rom, P0, string.Empty, false,
+                out sharedObjSlots, out sharedBgSlots, out frames,
+                isCsa: true);
+            return frames.Count;
+        }
+
         // ---- IDataVerifiable ----
 
         public int GetListCount() => LoadList().Count;

--- a/FEBuilderGBA.Avalonia/Views/ImageMagicCSACreatorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageMagicCSACreatorView.axaml
@@ -51,11 +51,14 @@
                 ToolTip.Tip="Expand the magic-effect + CSA spell tables to 254 entries."
                 HorizontalAlignment="Stretch" Margin="2"
                 Click="ListExpand_Click" />
-        <Label DockPanel.Dock="Bottom"
-               AutomationProperties.AutomationId="ImageMagicCSACreator_FindMoreData_Label"
-               Name="FindMoreDataLabel" Content="Find new resources online"
-               ToolTip.Tip="Pending Core extraction - tracked by #500."
-               HorizontalAlignment="Stretch" Margin="2" />
+        <!-- #1021 — working "Find new resources online" link (mirrors the
+             FEditor LinkInternet TextBlock: blue / underline / hand cursor). -->
+        <TextBlock DockPanel.Dock="Bottom"
+                   AutomationProperties.AutomationId="ImageMagicCSACreator_FindMoreData_Label"
+                   Name="FindMoreDataLabel" Text="Find new resources online"
+                   Foreground="Blue" TextDecorations="Underline" Cursor="Hand"
+                   HorizontalAlignment="Stretch" Margin="2"
+                   PointerPressed="LinkInternet_Click" />
         <controls:AddressListControl AutomationProperties.AutomationId="ImageMagicCSACreator_Entry_List"
                                      Name="EntryList" />
       </DockPanel>
@@ -117,14 +120,17 @@
             <Label Grid.Row="8" Grid.Column="0" Content="Frame" VerticalAlignment="Center" Margin="0,4,0,0" />
             <NumericUpDown AutomationProperties.AutomationId="ImageMagicCSACreator_Frame_Input"
                            FormatString="0" Grid.Row="8" Grid.Column="1" Name="FrameBox" Width="80"
-                           Minimum="0" Maximum="255" Margin="0,4,0,0" />
+                           Minimum="0" Maximum="255" Margin="0,4,0,0"
+                           ValueChanged="FrameBox_ValueChanged" />
 
             <Label Grid.Row="9" Grid.Column="0" Content="Zoom" VerticalAlignment="Center" Margin="0,4,0,0" />
             <ComboBox AutomationProperties.AutomationId="ImageMagicCSACreator_Zoom_Combo"
-                      Grid.Row="9" Grid.Column="1" Name="ZoomComboBox" Width="160" Margin="0,4,0,0">
+                      Grid.Row="9" Grid.Column="1" Name="ZoomComboBox" Width="160" Margin="0,4,0,0"
+                      SelectionChanged="ZoomComboBox_SelectionChanged">
               <!-- TextBlock-inside-ComboBoxItem so ViewTranslationHelper
                    picks them up for ja/zh localization (Copilot CLI inline
-                   review #7 on PR #547). -->
+                   review #7 on PR #547). #1021 maps the selection to the
+                   GbaImageControl zoom (no ROM re-render). -->
               <ComboBoxItem><TextBlock Text="Zoom in" /></ComboBoxItem>
               <ComboBoxItem><TextBlock Text="Original size" /></ComboBoxItem>
             </ComboBox>
@@ -136,14 +142,18 @@
           </Grid>
         </Border>
 
-        <!-- Preview area (placeholder - live ImageUtilMagicCSACreator.Draw is WF-coupled) -->
+        <!-- #1021 — live 240×128 CSA frame preview via
+             MagicEffectExportCore.RenderCsaFramePreview (READ-ONLY). Mirrors the
+             FEditor MagicFramePreview GbaImageControl. -->
         <Border BorderBrush="Gray" BorderThickness="1" Padding="8">
           <StackPanel Spacing="4">
             <Label AutomationProperties.AutomationId="ImageMagicCSACreator_Preview_Label"
                    Content="Preview" FontWeight="SemiBold" />
-            <Image AutomationProperties.AutomationId="ImageMagicCSACreator_Preview_Image"
-                   Name="PreviewImage" Width="400" Height="160"
-                   Stretch="Uniform" ToolTip.Tip="Pending Core extraction - tracked by #500." />
+            <controls:GbaImageControl
+                AutomationProperties.AutomationId="ImageMagicCSACreator_Preview_Image"
+                Name="MagicFramePreview"
+                Width="240" Height="160"
+                HorizontalAlignment="Left" />
           </StackPanel>
         </Border>
 

--- a/FEBuilderGBA.Avalonia/Views/ImageMagicCSACreatorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageMagicCSACreatorView.axaml.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using global::Avalonia.Controls;
+using global::Avalonia.Input;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Dialogs;
 using FEBuilderGBA.Avalonia.Services;
@@ -152,12 +153,82 @@ namespace FEBuilderGBA.Avalonia.Views
             P16Box.Text = string.Format("0x{0:X08}", _vm.P16);
             DimComboBox.SelectedIndex = (int)_vm.DimMode;
             CommentBox.Text = _vm.Comment;
+            // #1021 — bound the frame spinner to the actual 0x86 frame count so
+            // the user can't scrub past the end (mirrors the FEditor preview).
+            int frameCount = _vm.GetFrameCount();
+            FrameBox.Maximum = frameCount > 0 ? frameCount - 1 : 0;
             FrameBox.Value = _vm.Frame;
             ZoomComboBox.SelectedIndex = (int)_vm.Zoom;
             BinInfoBox.Text = _vm.BinInfo;
             // #886
             UpdateIoButtonsEnabled();
             UpdateSourceButtonVisibility();
+            // #1021 — live CSA frame preview re-render on entry select.
+            RenderPreview();
+        }
+
+        /// <summary>
+        /// Render the current CSA frame and update the live preview control
+        /// (READ-ONLY). Clears the surface when the preview can't be produced.
+        /// Mirrors the FEditor <c>RenderPreview</c> (#1021).
+        /// </summary>
+        void RenderPreview()
+        {
+            try
+            {
+                if (!_vm.CanRenderPreview)
+                {
+                    MagicFramePreview.SetImage(null);
+                    return;
+                }
+                using IImage? img = _vm.RenderCsaFramePreview(out _);
+                MagicFramePreview.SetImage(img);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImageMagicCSACreatorView.RenderPreview: {0}", ex.Message);
+                MagicFramePreview.SetImage(null);
+            }
+        }
+
+        // #1021 — frame spinner drives live preview re-render (CSA had none).
+        void FrameBox_ValueChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            if (_vm == null) return;
+            _vm.Frame = (uint)(FrameBox.Value ?? 0);
+            RenderPreview();
+        }
+
+        // #1021 — zoom combo maps to the GbaImageControl zoom; NO ROM re-render.
+        void ZoomComboBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_vm == null) return;
+            if (sender is not ComboBox combo) return;
+            int idx = combo.SelectedIndex;
+            if (idx < 0) return;
+            _vm.Zoom = (uint)idx;
+            // Index 0 = "Zoom in" (2x), index 1 = "Original size" (1x).
+            // GbaImageControl owns the zoom; clamps to [1..8] internally.
+            MagicFramePreview.Zoom = idx == 0 ? 2 : 1;
+        }
+
+        // #1021 — working "Find new resources online" link → MoreData wiki
+        // (mirrors ImageMagicFEditorView.LinkInternet_Click / WF GotoMoreData).
+        void LinkInternet_Click(object? sender, PointerPressedEventArgs e)
+        {
+            try
+            {
+                const string url = "https://github.com/laqieer/FEBuilderGBA/wiki/MoreData";
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = url,
+                    UseShellExecute = true,
+                });
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImageMagicCSACreatorView.LinkInternet: {0}", ex.Message);
+            }
         }
 
         // #886 — Export button enabled when CSA system is detected + entry selected.

--- a/FEBuilderGBA.Core.Tests/MagicEffectExportCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/MagicEffectExportCoreTests.cs
@@ -1378,5 +1378,220 @@ namespace FEBuilderGBA.Core.Tests
             finally { CoreState.ROM = prevRom; CoreState.ImageService = prevSvc; }
         }
 
+        // ---------------------------------------------------------------
+        // #1076 FIX 1 — slot-namespace mismatch regression
+        // ---------------------------------------------------------------
+
+        /// <summary>
+        /// Plant a 3-frame CSA stream where frames 0 and 1 SHARE the same BG image
+        /// pointer (0x600) but have DIFFERENT +28 BG TSA pointers (0x2000 vs 0x4000),
+        /// and frame 2 is fully distinct. This makes the CSA hash namespace (BG hash
+        /// = BgPtr+TsaPtr) DIVERGE from the renderer namespace
+        /// (<see cref="MagicEffectExportCore.RenderObjFrameSlot"/> uses the NON-CSA BG
+        /// hash = BgPtr only, so frames 0 and 1 collide to ONE BG slot):
+        ///
+        ///   CSA namespace:      F0 OBJ→0 BG(0x600+0x2000)→1 | F1 OBJ→2 BG(0x600+0x4000)→3 | F2 OBJ→4 BG→5
+        ///   Renderer namespace: F0 OBJ→0 BG(0x600)→1        | F1 OBJ→2 BG(0x600)=slot1   | F2 OBJ→3 BG→4
+        ///
+        /// So the CSA <c>sharedObjSlots[2] = 4</c> points PAST the renderer's OBJ slots
+        /// {0,2,3} — the OLD code (indexing sharedObjSlots) would render OBJ slot 4,
+        /// find no frame, and silently drop the OBJ layer.
+        /// </summary>
+        static uint PlantSharedBgDifferentTsaStream(ROM rom, uint baseOff)
+        {
+            byte[] d = rom.Data;
+
+            // Frame 0: OBJ 0x500, BG 0x600, TSA 0x2000.
+            uint f0 = baseOff;
+            d[f0 + 3] = 0x86;
+            WriteU32Le(d, f0 + 4,  0x08000500u);
+            WriteU32Le(d, f0 + 8,  0u);
+            WriteU32Le(d, f0 + 12, 0u);
+            WriteU32Le(d, f0 + 16, 0x08000600u); // BG (SHARED)
+            WriteU32Le(d, f0 + 20, 0x08000700u);
+            WriteU32Le(d, f0 + 24, 0x08000800u);
+            WriteU32Le(d, f0 + 28, 0x08002000u); // TSA A
+
+            // Frame 1: OBJ 0x900 (distinct), BG 0x600 (SAME as F0), TSA 0x4000 (different).
+            uint f1 = baseOff + 32;
+            d[f1 + 3] = 0x86;
+            WriteU32Le(d, f1 + 4,  0x08000900u);
+            WriteU32Le(d, f1 + 8,  0u);
+            WriteU32Le(d, f1 + 12, 0u);
+            WriteU32Le(d, f1 + 16, 0x08000600u); // BG (SHARED with F0)
+            WriteU32Le(d, f1 + 20, 0x08000700u);
+            WriteU32Le(d, f1 + 24, 0x08000800u);
+            WriteU32Le(d, f1 + 28, 0x08004000u); // TSA B (different → CSA inserts an extra BG slot)
+
+            // Frame 2: fully distinct OBJ 0xD00, BG 0xE00, TSA 0x6000.
+            uint f2 = baseOff + 64;
+            d[f2 + 3] = 0x86;
+            WriteU32Le(d, f2 + 4,  0x08000D00u);
+            WriteU32Le(d, f2 + 8,  0u);
+            WriteU32Le(d, f2 + 12, 0u);
+            WriteU32Le(d, f2 + 16, 0x08000E00u);
+            WriteU32Le(d, f2 + 20, 0x08000700u);
+            WriteU32Le(d, f2 + 24, 0x08000800u);
+            WriteU32Le(d, f2 + 28, 0x08006000u);
+
+            // Terminator after the 3rd 32-byte frame.
+            d[f2 + 32 + 3] = 0x80;
+
+            // Plant LZ77 + palettes so each frame's OBJ/BG/TSA render succeeds.
+            PlantSmallLZ77(d, 0x500u, 8192);    // OBJ F0
+            PlantSmallLZ77(d, 0x600u, 19200);   // BG (shared F0+F1)
+            PlantSmallLZ77(d, 0x2000u, 1200);   // TSA A
+            PlantSmallLZ77(d, 0x900u, 8192);    // OBJ F1
+            PlantSmallLZ77(d, 0x4000u, 1200);   // TSA B
+            PlantSmallLZ77(d, 0xD00u, 8192);    // OBJ F2
+            PlantSmallLZ77(d, 0xE00u, 19200);   // BG F2
+            PlantSmallLZ77(d, 0x6000u, 1200);   // TSA F2
+            PlantRawPalette(d, 0x700u);         // OBJ pal (shared)
+            PlantRawPalette(d, 0x800u);         // BG pal (shared)
+
+            return baseOff;
+        }
+
+        [Fact]
+        public void RenderCsaFramePreview_SharedBgDifferentTsa_LaterFrame_KeepsObjLayer()
+        {
+            // #1076 FIX 1 regression: when earlier CSA frames share a BG image but
+            // differ in the +28 TSA pointer, the CSA hash namespace diverges from the
+            // renderer namespace. The OLD code (indexing sharedObjSlots[frameIndex] and
+            // passing it to RenderObjFrameSlot over the FULL frame list) would render a
+            // slot that does NOT exist in the renderer namespace → OBJ layer dropped.
+            // The fix renders the SELECTED frame via a single-frame list (OBJ slot 0).
+            var prevRom = CoreState.ROM;
+            var prevSvc = CoreState.ImageService;
+            try
+            {
+                var rom = MakeMinimalRomSize(0x1100000);
+                CoreState.ROM = rom;
+                CoreState.ImageService = new StubImageService();
+
+                uint baseOff = 0x20000u;
+                PlantSharedBgDifferentTsaStream(rom, baseOff);
+
+                System.Collections.Generic.List<int> objSlots, bgSlots;
+                System.Collections.Generic.List<MagicFrameMeta> frames;
+                MagicEffectExportCore.ExportMagicScriptLines(
+                    rom, baseOff, "t_", false,
+                    out objSlots, out bgSlots, out frames, isCsa: true);
+
+                // Prove the divergence the CLI flagged: the CSA scan gives frame 2's
+                // OBJ shared slot = 4 (because F1's distinct-TSA BG took an extra slot).
+                Assert.Equal(3, frames.Count);
+                Assert.Equal(4, objSlots[2]);
+
+                // OLD-code path: passing the CSA slot index (4) to RenderObjFrameSlot
+                // over the FULL list renders NOTHING — slot 4 is past the renderer's
+                // OBJ slots {0,2,3} (F0,F1 share a BG slot in the non-CSA namespace).
+                var objViaCsaSlot = MagicEffectExportCore.RenderObjFrameSlot(
+                    rom, frames, objSlots[2], 0u, 0u);
+                Assert.Null(objViaCsaSlot); // OBJ layer would be SILENTLY DROPPED
+
+                // FIX path: render frame 2's OBJ via a single-frame list at slot 0.
+                var single = new System.Collections.Generic.List<MagicFrameMeta> { frames[2] };
+                var objViaSingle = MagicEffectExportCore.RenderObjFrameSlot(
+                    rom, single, 0, 0u, 0u);
+                Assert.NotNull(objViaSingle); // OBJ layer rendered correctly
+
+                // End-to-end: RenderCsaFramePreview for the later frame returns a
+                // non-null composite (no longer drops the OBJ layer).
+                var img = MagicEffectExportCore.RenderCsaFramePreview(
+                    rom, baseOff, 2u, 0u, 0u);
+                Assert.NotNull(img);
+            }
+            finally { CoreState.ROM = prevRom; CoreState.ImageService = prevSvc; }
+        }
+
+        // ---------------------------------------------------------------
+        // #1076 FIX 2 — bgPalette[0] OPAQUE canvas fill (WF parity)
+        // ---------------------------------------------------------------
+
+        /// <summary>Plant a 16-color BG palette whose color 0 is a distinctive
+        /// (non-black) GBA color, so the canvas fill is detectable. The
+        /// StubImageService maps each 5-bit channel via <c>&lt;&lt;3</c>.</summary>
+        static void PlantBgPaletteWithColor0(byte[] data, uint offset, ushort gbaColor0)
+        {
+            if (offset + 0x20 > data.Length) return;
+            data[offset + 0] = (byte)(gbaColor0 & 0xFF);
+            data[offset + 1] = (byte)((gbaColor0 >> 8) & 0xFF);
+            for (int i = 1; i < 16; i++)
+            {
+                // Remaining colors: opaque red so any BG-covered pixel differs from fill.
+                ushort c = 0x001F;
+                data[offset + i * 2 + 0] = (byte)(c & 0xFF);
+                data[offset + i * 2 + 1] = (byte)((c >> 8) & 0xFF);
+            }
+        }
+
+        [Fact]
+        public void RenderCsaFramePreview_CanvasBackground_IsBgPalette0_NotTransparentBlack()
+        {
+            // #1076 FIX 2: WF fills the 240×128 canvas with bgPalette[0] (OPAQUE)
+            // BEFORE drawing the BG. With a 64px-tall BG (small TSA), the bottom rows
+            // (64..127) are NOT covered by the BG blit, so they must carry the
+            // palette[0] fill — NOT transparent black (all-zero RGBA).
+            var prevRom = CoreState.ROM;
+            var prevSvc = CoreState.ImageService;
+            try
+            {
+                var rom = MakeMinimalRomSize(0x1100000);
+                CoreState.ROM = rom;
+                CoreState.ImageService = new StubImageService();
+
+                uint baseOff = 0x30000u;
+                byte[] d = rom.Data;
+
+                // One CSA frame with a SMALL TSA (480 bytes → 64px BG height).
+                d[baseOff + 3] = 0x86;
+                WriteU32Le(d, baseOff + 4,  0x08000500u); // OBJ img
+                WriteU32Le(d, baseOff + 8,  0u);
+                WriteU32Le(d, baseOff + 12, 0u);
+                WriteU32Le(d, baseOff + 16, 0x08000600u); // BG img
+                WriteU32Le(d, baseOff + 20, 0x08000700u); // OBJ pal
+                WriteU32Le(d, baseOff + 24, 0x08000800u); // BG pal
+                WriteU32Le(d, baseOff + 28, 0x08003000u); // TSA (small → 64px)
+                d[baseOff + 32 + 3] = 0x80;               // terminator
+
+                PlantSmallLZ77(d, 0x500u, 8192);   // OBJ tilesheet
+                PlantSmallLZ77(d, 0x600u, 8192);   // BG tilesheet
+                PlantSmallLZ77(d, 0x3000u, 480);   // small TSA → 64px BG height
+                PlantRawPalette(d, 0x700u);        // OBJ palette
+                // Distinctive BG palette color 0 = GBA 0x03E0 (green=31) → RGBA (0,248,0,255).
+                ushort gbaGreen = 0x03E0;
+                PlantBgPaletteWithColor0(d, 0x800u, gbaGreen);
+
+                var img = MagicEffectExportCore.RenderCsaFramePreview(
+                    rom, baseOff, 0u, 0u, 0u);
+                Assert.NotNull(img);
+
+                byte[] px = img.GetPixelData();
+                Assert.NotNull(px);
+
+                // Expected fill RGBA from the stub's GBAColorToRGBA(<<3):
+                //   r = (0x03E0 & 0x1F) << 3 = 0
+                //   g = ((0x03E0 >> 5) & 0x1F) << 3 = 31 << 3 = 248
+                //   b = ((0x03E0 >> 10) & 0x1F) << 3 = 0
+                byte expR = 0, expG = 248, expB = 0, expA = 255;
+
+                // Sample a pixel in the UNCOVERED region (row 100, col 120) — below the
+                // 64px BG. It must be the OPAQUE palette[0] fill, not transparent black.
+                int row = 100, col = 120;
+                int idx = (row * MagicEffectExportCore.CSA_PREVIEW_WIDTH + col) * 4;
+                Assert.Equal(expR, px[idx + 0]);
+                Assert.Equal(expG, px[idx + 1]);
+                Assert.Equal(expB, px[idx + 2]);
+                Assert.Equal(expA, px[idx + 3]);
+
+                // And it is explicitly NOT transparent black (the old all-zero canvas).
+                bool isTransparentBlack = px[idx + 0] == 0 && px[idx + 1] == 0
+                    && px[idx + 2] == 0 && px[idx + 3] == 0;
+                Assert.False(isTransparentBlack);
+            }
+            finally { CoreState.ROM = prevRom; CoreState.ImageService = prevSvc; }
+        }
+
     }
 }

--- a/FEBuilderGBA.Core.Tests/MagicEffectExportCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/MagicEffectExportCoreTests.cs
@@ -1144,5 +1144,239 @@ namespace FEBuilderGBA.Core.Tests
             finally { CoreState.ROM = prevRom; CoreState.ImageService = prevSvc; }
         }
 
+        // ---------------------------------------------------------------
+        // #1021 — RenderCsaFramePreview (live 240×128 CSA composite)
+        // ---------------------------------------------------------------
+
+        /// <summary>
+        /// Plant a complete 2-frame CSA frame-data stream where frame 1's shared
+        /// BG slot index is &gt; 1 (proving slotIndex ≠ frameIndex). Both frames
+        /// have planted LZ77 OBJ/BG/TSA + raw palettes so the render succeeds.
+        ///   Frame 0: OBJ 0x500, BG 0x600, TSA 0x2000  → OBJ slot 0, BG slot 1.
+        ///   Frame 1: OBJ 0x900 (distinct), BG 0xA00, TSA 0x4000 → OBJ slot 2, BG slot 3.
+        /// </summary>
+        static uint PlantTwoFrameCsaStream(ROM rom, uint baseOff)
+        {
+            byte[] d = rom.Data;
+
+            // Frame 0 (32-byte CSA record).
+            d[baseOff + 3] = 0x86;
+            WriteU32Le(d, baseOff + 4,  0x08000500u); // OBJ img
+            WriteU32Le(d, baseOff + 8,  0u);          // OAMAbsoStart (front)
+            WriteU32Le(d, baseOff + 12, 0u);          // OAMBGAbsoStart (back)
+            WriteU32Le(d, baseOff + 16, 0x08000600u); // BG img
+            WriteU32Le(d, baseOff + 20, 0x08000700u); // OBJ pal
+            WriteU32Le(d, baseOff + 24, 0x08000800u); // BG pal
+            WriteU32Le(d, baseOff + 28, 0x08002000u); // TSA (+28)
+
+            // Frame 1 (distinct OBJ/BG/TSA → its shared BG slot is 3, NOT 1).
+            uint off1 = baseOff + 32;
+            d[off1 + 3] = 0x86;
+            WriteU32Le(d, off1 + 4,  0x08000900u);
+            WriteU32Le(d, off1 + 8,  0u);
+            WriteU32Le(d, off1 + 12, 0u);
+            WriteU32Le(d, off1 + 16, 0x08000A00u);
+            WriteU32Le(d, off1 + 20, 0x08000700u);
+            WriteU32Le(d, off1 + 24, 0x08000800u);
+            WriteU32Le(d, off1 + 28, 0x08004000u);
+
+            // Terminator after the 2nd 32-byte frame.
+            d[off1 + 32 + 3] = 0x80;
+
+            // Plant LZ77 + palettes for BOTH frames.
+            // BG tilesheet (19200 bytes), TSA for 240x160 (1200 bytes) → height 160.
+            PlantSmallLZ77(d, 0x500u, 8192);    // OBJ frame 0
+            PlantSmallLZ77(d, 0x600u, 19200);   // BG frame 0
+            PlantSmallLZ77(d, 0x2000u, 1200);   // TSA frame 0
+            PlantSmallLZ77(d, 0x900u, 8192);    // OBJ frame 1
+            PlantSmallLZ77(d, 0xA00u, 19200);   // BG frame 1
+            PlantSmallLZ77(d, 0x4000u, 1200);   // TSA frame 1
+            PlantRawPalette(d, 0x700u);         // OBJ pal
+            PlantRawPalette(d, 0x800u);         // BG pal
+
+            return baseOff;
+        }
+
+        [Fact]
+        public void RenderCsaFramePreview_Frame1SlotGreaterThan1_UsesSharedSlotMapping()
+        {
+            // slot-vs-frame regression: frame 1's shared BG slot is 3 (> 1), so
+            // passing frameIndex 1 directly as a slot index would render the WRONG
+            // slot. RenderCsaFramePreview must map frame 1 → its shared slots via
+            // ExportMagicScriptLines (isCsa:true) and still produce a non-null image.
+            var prevRom = CoreState.ROM;
+            var prevSvc = CoreState.ImageService;
+            try
+            {
+                var rom = MakeMinimalRomSize(0x1100000);
+                CoreState.ROM = rom;
+                CoreState.ImageService = new StubImageService();
+
+                uint baseOff = 0x10000u;
+                PlantTwoFrameCsaStream(rom, baseOff);
+
+                // Cross-check the shared-slot mapping the renderer relies on:
+                // frame 1 maps to OBJ slot 2 + BG slot 3 (NOT slot 1).
+                System.Collections.Generic.List<int> objSlots, bgSlots;
+                System.Collections.Generic.List<MagicFrameMeta> frames;
+                MagicEffectExportCore.ExportMagicScriptLines(
+                    rom, baseOff, "t_", false,
+                    out objSlots, out bgSlots, out frames, isCsa: true);
+                Assert.Equal(2, frames.Count);
+                Assert.Equal(2, objSlots[1]); // frame 1 OBJ shared slot
+                Assert.Equal(3, bgSlots[1]);  // frame 1 BG shared slot (> 1)
+
+                // Render frame 1 → non-null (proves the mapping, not frameIndex-as-slot).
+                var img = MagicEffectExportCore.RenderCsaFramePreview(
+                    rom, baseOff, 1u, 0u, 0u);
+                Assert.NotNull(img);
+            }
+            finally { CoreState.ROM = prevRom; CoreState.ImageService = prevSvc; }
+        }
+
+        [Fact]
+        public void RenderCsaFramePreview_CsaAwareScan_PopulatesBgTsaForFrame1()
+        {
+            // CSA-aware scan: ExportMagicScriptLines(isCsa:true) reads the +28 BG TSA
+            // field for frame 1 (proving the 32-byte CSA stride, not 28-byte FEditor).
+            var prevRom = CoreState.ROM;
+            var prevSvc = CoreState.ImageService;
+            try
+            {
+                var rom = MakeMinimalRomSize(0x1100000);
+                CoreState.ROM = rom;
+                CoreState.ImageService = new StubImageService();
+
+                uint baseOff = 0x11000u;
+                PlantTwoFrameCsaStream(rom, baseOff);
+
+                System.Collections.Generic.List<int> objSlots, bgSlots;
+                System.Collections.Generic.List<MagicFrameMeta> frames;
+                MagicEffectExportCore.ExportMagicScriptLines(
+                    rom, baseOff, "t_", false,
+                    out objSlots, out bgSlots, out frames, isCsa: true);
+
+                Assert.Equal(2, frames.Count);
+                // Frame 1's +28 TSA pointer must be populated (CSA stride proof).
+                Assert.Equal(0x08004000u, frames[1].RawBgTsaPtr);
+                Assert.Equal(0x4000u, frames[1].BgTsaOffset);
+            }
+            finally { CoreState.ROM = prevRom; CoreState.ImageService = prevSvc; }
+        }
+
+        [Fact]
+        public void RenderCsaFramePreview_CompositeIs240x128()
+        {
+            // composite dims: the live preview is a 240×128 image regardless of the
+            // BG/OBJ source dims.
+            var prevRom = CoreState.ROM;
+            var prevSvc = CoreState.ImageService;
+            try
+            {
+                var rom = MakeMinimalRomSize(0x1100000);
+                CoreState.ROM = rom;
+                CoreState.ImageService = new StubImageService();
+
+                uint baseOff = 0x12000u;
+                PlantTwoFrameCsaStream(rom, baseOff);
+
+                var img = MagicEffectExportCore.RenderCsaFramePreview(
+                    rom, baseOff, 0u, 0u, 0u);
+
+                Assert.NotNull(img);
+                Assert.Equal(MagicEffectExportCore.CSA_PREVIEW_WIDTH,  img.Width);
+                Assert.Equal(MagicEffectExportCore.CSA_PREVIEW_HEIGHT, img.Height);
+                Assert.Equal(240, img.Width);
+                Assert.Equal(128, img.Height);
+            }
+            finally { CoreState.ROM = prevRom; CoreState.ImageService = prevSvc; }
+        }
+
+        [Fact]
+        public void RenderCsaFramePreview_OutOfRangeFrame_ReturnsNull()
+        {
+            // guards: out-of-range frameIndex → null.
+            var prevRom = CoreState.ROM;
+            var prevSvc = CoreState.ImageService;
+            try
+            {
+                var rom = MakeMinimalRomSize(0x1100000);
+                CoreState.ROM = rom;
+                CoreState.ImageService = new StubImageService();
+
+                uint baseOff = 0x13000u;
+                PlantTwoFrameCsaStream(rom, baseOff); // only 2 frames (0,1)
+
+                var img = MagicEffectExportCore.RenderCsaFramePreview(
+                    rom, baseOff, 5u, 0u, 0u); // frame 5 doesn't exist
+                Assert.Null(img);
+            }
+            finally { CoreState.ROM = prevRom; CoreState.ImageService = prevSvc; }
+        }
+
+        [Fact]
+        public void RenderCsaFramePreview_NullRom_ReturnsNull()
+        {
+            // guards: null ROM → null (no throw).
+            var prevSvc = CoreState.ImageService;
+            try
+            {
+                CoreState.ImageService = new StubImageService();
+                var img = MagicEffectExportCore.RenderCsaFramePreview(
+                    null, 0x10000u, 0u, 0u, 0u);
+                Assert.Null(img);
+            }
+            finally { CoreState.ImageService = prevSvc; }
+        }
+
+        [Fact]
+        public void RenderCsaFramePreview_NoImageService_ReturnsNull()
+        {
+            // guards: no ImageService → null (no throw).
+            var prevRom = CoreState.ROM;
+            var prevSvc = CoreState.ImageService;
+            try
+            {
+                var rom = MakeMinimalRomSize(0x1100000);
+                CoreState.ROM = rom;
+                CoreState.ImageService = null;
+
+                uint baseOff = 0x14000u;
+                PlantTwoFrameCsaStream(rom, baseOff);
+
+                var img = MagicEffectExportCore.RenderCsaFramePreview(
+                    rom, baseOff, 0u, 0u, 0u);
+                Assert.Null(img);
+            }
+            finally { CoreState.ROM = prevRom; CoreState.ImageService = prevSvc; }
+        }
+
+        [Fact]
+        public void RenderCsaFramePreview_NoMutation_RomByteIdentical()
+        {
+            // no-mutation: RenderCsaFramePreview is strictly read-only.
+            var prevRom = CoreState.ROM;
+            var prevSvc = CoreState.ImageService;
+            try
+            {
+                var rom = MakeMinimalRomSize(0x1100000);
+                CoreState.ROM = rom;
+                CoreState.ImageService = new StubImageService();
+
+                uint baseOff = 0x15000u;
+                PlantTwoFrameCsaStream(rom, baseOff);
+
+                byte[] before = (byte[])rom.Data.Clone();
+
+                // Render both frames (and an out-of-range one) — none may mutate.
+                MagicEffectExportCore.RenderCsaFramePreview(rom, baseOff, 0u, 0u, 0u);
+                MagicEffectExportCore.RenderCsaFramePreview(rom, baseOff, 1u, 0u, 0u);
+                MagicEffectExportCore.RenderCsaFramePreview(rom, baseOff, 9u, 0u, 0u);
+
+                Assert.Equal(before, rom.Data);
+            }
+            finally { CoreState.ROM = prevRom; CoreState.ImageService = prevSvc; }
+        }
+
     }
 }

--- a/FEBuilderGBA.Core/MagicEffectExportCore.cs
+++ b/FEBuilderGBA.Core/MagicEffectExportCore.cs
@@ -737,7 +737,18 @@ namespace FEBuilderGBA
             IImageService svc = CoreState.ImageService;
             if (svc == null) return null;
 
-            // 1. CSA-aware scan + per-frame shared-slot mapping (slotIndex ≠ frameIndex).
+            // 1. CSA-aware scan to get the per-frame `frames` list (correct +28 TSA).
+            //    NOTE (#1076 FIX 1): we deliberately do NOT index sharedObjSlots /
+            //    sharedBgSlots here. Those slot indices live in the CSA hash namespace
+            //    (BG hash = RawBgImagePtr + RawBgTsaPtr), but RenderObjFrameSlot /
+            //    RenderCsaBgFrameSlot rebuild the shared namespace differently
+            //    (RenderObjFrameSlot uses the NON-CSA BG hash = RawBgImagePtr). When
+            //    earlier CSA frames share a BG image but differ in the +28 TSA pointer,
+            //    the CSA scan inserts extra BG slots the renderer does NOT — so a CSA
+            //    slot index can point past the renderer's namespace and silently drop
+            //    the OBJ layer. Instead we render the SELECTED frame via a SINGLE-frame
+            //    list, which sidesteps the divergence: the lone frame is OBJ slot 0 and
+            //    (since the OBJ hash is registered first) BG slot 1.
             List<int> sharedObjSlots, sharedBgSlots;
             List<MagicFrameMeta> frames;
             ExportMagicScriptLines(
@@ -748,15 +759,17 @@ namespace FEBuilderGBA
             if (frames.Count == 0) return null;
             if (frameIndex >= (uint)frames.Count) return null;
 
-            int objSlot = sharedObjSlots[(int)frameIndex];
-            int bgSlot  = sharedBgSlots[(int)frameIndex];
+            // 2. Render the selected frame from a single-frame list (FIX 1).
+            //    OBJ → slot 0; CSA BG → slot 1 (OBJ hash occupies slot 0 first, so the
+            //    BG hash lands at slot 1 in BOTH the renderer namespace and the export).
+            var selectedFrame = frames[(int)frameIndex];
+            var single = new List<MagicFrameMeta> { selectedFrame };
 
-            // 2. Render the per-frame slots.
             //    BG: 240×(160|64) TSA-composited (CSA +28).
             //    OBJ: 480×160, front in the LEFT 240px, back in the RIGHT 240px.
-            IImage bg  = RenderCsaBgFrameSlot(rom, frames, bgSlot);
+            IImage bg  = RenderCsaBgFrameSlot(rom, single, 1);
             IImage obj = RenderObjFrameSlot(
-                rom, frames, objSlot, objRightToLeftOAM, objBGRightToLeftOAM);
+                rom, single, 0, objRightToLeftOAM, objBGRightToLeftOAM);
 
             byte[] bgPx  = bg?.GetPixelData();
             byte[] objPx = obj?.GetPixelData();
@@ -767,10 +780,23 @@ namespace FEBuilderGBA
                 // 3. Composite into a 240×128 canvas (mirror WF DrawFrameImage).
                 byte[] canvas = new byte[CSA_PREVIEW_WIDTH * CSA_PREVIEW_HEIGHT * 4];
 
-                // 3a. BG first. WF fills with bgPalette[0] then draws BG; honour
+                // 3-pre (#1076 FIX 2): WF Blank()-fills the whole canvas with the BG
+                // palette's color 0 (OPAQUE) BEFORE drawing the BG, so palette-index-0
+                // BG pixels (alpha 0) and rows not covered by a 64px-tall BG show the WF
+                // background fill instead of transparent-black holes. Read the selected
+                // frame's RAW 16-color BG palette (offset +24) and fill with entry 0.
+                if (selectedFrame.BgPaletteOffset + 0x20 <= (uint)rom.Data.Length)
+                {
+                    byte[] bgPalette = rom.getBinaryData(selectedFrame.BgPaletteOffset, 0x20);
+                    byte[] fillColor = GBAPaletteColor0(bgPalette, svc); // RGBA, alpha 255
+                    FillBackground(canvas, CSA_PREVIEW_WIDTH, CSA_PREVIEW_HEIGHT, fillColor);
+                }
+
+                // 3a. BG. WF then draws the BG over the palette[0] fill; honour
                 //     IsExpandsBG (the preceding 0x85/0x53 command scales the top
                 //     64px of the BG into the full 240×128). When not expanding,
-                //     the BG is blitted 1:1.
+                //     the BG is blitted 1:1. The BG's own transparent (index-0)
+                //     pixels then show the palette[0] fill underneath.
                 if (bgPx != null && bgW == CSA_PREVIEW_WIDTH && bgH > 0)
                 {
                     bool bgExpands = IsCsaExpandsBG(rom, frameDataAddr, frameIndex);

--- a/FEBuilderGBA.Core/MagicEffectExportCore.cs
+++ b/FEBuilderGBA.Core/MagicEffectExportCore.cs
@@ -685,6 +685,261 @@ namespace FEBuilderGBA
         }
 
         // -----------------------------------------------------------------------
+        // RenderCsaFramePreview — live 240×128 CSA frame composite (#1021)
+        // -----------------------------------------------------------------------
+
+        /// <summary>Live-preview canvas width — mirrors WF
+        /// <c>ImageUtilMagicCSACreator.SCREEN_TILE_WIDTH*8 = 240</c>.</summary>
+        public const int CSA_PREVIEW_WIDTH  = 240; // 240/8 tiles * 8
+        /// <summary>Live-preview canvas height — mirrors WF
+        /// <c>ImageUtilMagicCSACreator.SCREEN_TILE_HEIGHT*8 = 128</c>.</summary>
+        public const int CSA_PREVIEW_HEIGHT = 128; // 64*2/8 tiles * 8
+
+        /// <summary>
+        /// Render a single CSA-Creator frame as a 240×128 live-preview image
+        /// (READ-ONLY: zero ROM mutation). Mirrors WF
+        /// <c>ImageUtilMagicCSACreator.Draw</c> →
+        /// <c>DrawFrameImage</c> composite order:
+        /// <list type="number">
+        ///   <item>BG (honoring the <c>IsExpandsBG</c> top-64 vertical scale driven by
+        ///     the preceding 0x85 <c>0x53</c> command);</item>
+        ///   <item>OBJ <b>back</b> layer (the RIGHT 240px of the 480×160
+        ///     <see cref="RenderObjFrameSlot"/> output);</item>
+        ///   <item>OBJ <b>front</b> layer (the LEFT 240px), each alpha-over.</item>
+        /// </list>
+        ///
+        /// <para><b>slotIndex ≠ frameIndex.</b> The per-frame OBJ/BG <em>shared</em>
+        /// slot indices are obtained from
+        /// <see cref="ExportMagicScriptLines"/> with <c>isCsa:true</c> (one entry per
+        /// frame in <c>sharedObjSlots</c>/<c>sharedBgSlots</c>). One CSA frame can map
+        /// to OBJ slot 0 + BG slot 1, so <paramref name="frameIndex"/> is NEVER passed
+        /// directly as a slot index.</para>
+        ///
+        /// <para>Returns <c>null</c> (never throws) on any guard failure: null ROM,
+        /// no ImageService, a failed/empty CSA scan, an out-of-range
+        /// <paramref name="frameIndex"/>, or a failed slot render.</para>
+        /// </summary>
+        /// <param name="rom">Loaded ROM.</param>
+        /// <param name="frameDataAddr">P0 — GBA pointer (or raw offset) to the CSA
+        ///   frame-data script.</param>
+        /// <param name="frameIndex">0-based index of the 0x86 frame to render.</param>
+        /// <param name="objRightToLeftOAM">P4 — front OAM table base.</param>
+        /// <param name="objBGRightToLeftOAM">P12 — back (BG) OAM table base.</param>
+        /// <returns>A 240×128 <see cref="IImage"/>, or <c>null</c>.</returns>
+        public static IImage RenderCsaFramePreview(
+            ROM rom,
+            uint frameDataAddr,
+            uint frameIndex,
+            uint objRightToLeftOAM,
+            uint objBGRightToLeftOAM)
+        {
+            if (rom == null || rom.Data == null) return null;
+            IImageService svc = CoreState.ImageService;
+            if (svc == null) return null;
+
+            // 1. CSA-aware scan + per-frame shared-slot mapping (slotIndex ≠ frameIndex).
+            List<int> sharedObjSlots, sharedBgSlots;
+            List<MagicFrameMeta> frames;
+            ExportMagicScriptLines(
+                rom, frameDataAddr, string.Empty, false,
+                out sharedObjSlots, out sharedBgSlots, out frames,
+                isCsa: true);
+
+            if (frames.Count == 0) return null;
+            if (frameIndex >= (uint)frames.Count) return null;
+
+            int objSlot = sharedObjSlots[(int)frameIndex];
+            int bgSlot  = sharedBgSlots[(int)frameIndex];
+
+            // 2. Render the per-frame slots.
+            //    BG: 240×(160|64) TSA-composited (CSA +28).
+            //    OBJ: 480×160, front in the LEFT 240px, back in the RIGHT 240px.
+            IImage bg  = RenderCsaBgFrameSlot(rom, frames, bgSlot);
+            IImage obj = RenderObjFrameSlot(
+                rom, frames, objSlot, objRightToLeftOAM, objBGRightToLeftOAM);
+
+            byte[] bgPx  = bg?.GetPixelData();
+            byte[] objPx = obj?.GetPixelData();
+            int bgW = bg?.Width ?? 0, bgH = bg?.Height ?? 0;
+
+            try
+            {
+                // 3. Composite into a 240×128 canvas (mirror WF DrawFrameImage).
+                byte[] canvas = new byte[CSA_PREVIEW_WIDTH * CSA_PREVIEW_HEIGHT * 4];
+
+                // 3a. BG first. WF fills with bgPalette[0] then draws BG; honour
+                //     IsExpandsBG (the preceding 0x85/0x53 command scales the top
+                //     64px of the BG into the full 240×128). When not expanding,
+                //     the BG is blitted 1:1.
+                if (bgPx != null && bgW == CSA_PREVIEW_WIDTH && bgH > 0)
+                {
+                    bool bgExpands = IsCsaExpandsBG(rom, frameDataAddr, frameIndex);
+                    if (bgExpands)
+                    {
+                        // Scale the BG's top 64px up to fill the 240×128 canvas
+                        // (mirrors WF ImageUtil.Scale(retImage,0,0,W,H, bg,0,0,W,64)).
+                        int srcScaleH = Math.Min(64, bgH);
+                        ScaleBgIntoCanvas(bgPx, bgW, bgH, srcScaleH,
+                            canvas, CSA_PREVIEW_WIDTH, CSA_PREVIEW_HEIGHT);
+                    }
+                    else
+                    {
+                        // 1:1 blit of the top 128px (mirrors WF BitBlt opaque copy).
+                        BlitOpaque(bgPx, bgW, bgH, canvas,
+                            CSA_PREVIEW_WIDTH, CSA_PREVIEW_HEIGHT);
+                    }
+                }
+
+                // 3b. OBJ back layer = the RIGHT 240px of the 480×160 OBJ image.
+                // 3c. OBJ front layer = the LEFT 240px. Both alpha-over.
+                if (objPx != null
+                    && obj.Width == OBJ_EXPORT_WIDTH && obj.Height == OBJ_EXPORT_HEIGHT)
+                {
+                    AlphaOverObjHalf(objPx, OBJ_EXPORT_WIDTH, OBJ_EXPORT_HEIGHT,
+                        srcX0: 240, canvas, CSA_PREVIEW_WIDTH, CSA_PREVIEW_HEIGHT); // back
+                    AlphaOverObjHalf(objPx, OBJ_EXPORT_WIDTH, OBJ_EXPORT_HEIGHT,
+                        srcX0: 0,   canvas, CSA_PREVIEW_WIDTH, CSA_PREVIEW_HEIGHT); // front
+                }
+
+                var image = svc.CreateImage(CSA_PREVIEW_WIDTH, CSA_PREVIEW_HEIGHT);
+                image.SetPixelData(canvas);
+                return image;
+            }
+            finally
+            {
+                bg?.Dispose();
+                obj?.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Determine whether the BG of the <paramref name="frameIndex"/>-th 0x86 frame
+        /// should be vertically expanded (mirrors WF
+        /// <c>ImageUtilMagicCSACreator.IsExpandsBG</c>): a preceding 0x85 command
+        /// whose first byte is <c>0x53</c> with <c>byte[1] &gt;= 0x01</c> sets the
+        /// expand flag, which persists until overridden. EOF-safe; read-only.
+        /// </summary>
+        static bool IsCsaExpandsBG(ROM rom, uint frameDataAddr, uint frameIndex)
+        {
+            if (rom == null || rom.Data == null) return false;
+            uint frameDataOffset = U.isSafetyPointer(frameDataAddr)
+                ? U.toOffset(frameDataAddr) : frameDataAddr;
+            if (!U.isSafetyOffset(frameDataOffset, rom)) return false;
+
+            byte[] data = rom.Data;
+            uint dataLen = (uint)data.Length;
+            uint limiter = frameDataOffset + SCAN_LIMITER;
+            if (limiter > dataLen) limiter = dataLen;
+
+            uint frameI = 0;
+            bool bgExpands = false;
+            for (uint n = frameDataOffset; n < limiter; n += 4)
+            {
+                if (n + 4 > dataLen) break;
+                byte cmd = data[n + 3];
+
+                if (cmd == 0x80) // terminator (with 0x01 continuation tolerance)
+                {
+                    if (n + 2 <= dataLen && data[n + 1] == 0x01) continue;
+                    break;
+                }
+                if (cmd != 0x86)
+                {
+                    if (cmd == 0x85)
+                    {
+                        // WF: a 0x53 command sets/clears the expand flag.
+                        if (data[n + 0] == 0x53)
+                            bgExpands = (data[n + 1] >= 0x01);
+                        continue;
+                    }
+                    break; // unknown command
+                }
+
+                if (frameI == frameIndex) return bgExpands;
+                if (n + 32 > dataLen) break; // CSA stride = 32
+                frameI++;
+                n += 24 + 4; // 28 (inside) + 4 (outer) = 32
+            }
+            return bgExpands;
+        }
+
+        /// <summary>Scale the top <paramref name="srcScaleH"/> rows of a 240-wide BG
+        /// into the full <paramref name="dstW"/>×<paramref name="dstH"/> canvas
+        /// (nearest-neighbour, opaque). Mirrors WF
+        /// <c>ImageUtil.Scale(retImage,0,0,W,H, bg,0,0,W,64)</c>.</summary>
+        static void ScaleBgIntoCanvas(
+            byte[] src, int srcW, int srcTotalH, int srcScaleH,
+            byte[] dst, int dstW, int dstH)
+        {
+            if (src == null || dst == null || srcScaleH <= 0) return;
+            for (int dy = 0; dy < dstH; dy++)
+            {
+                int sy = dy * srcScaleH / dstH;
+                if (sy >= srcTotalH) sy = srcTotalH - 1;
+                if (sy < 0) continue;
+                for (int dx = 0; dx < dstW; dx++)
+                {
+                    int sx = dx; // 1:1 horizontally (both 240 wide)
+                    if (sx >= srcW) sx = srcW - 1;
+                    int si = (sy * srcW + sx) * 4;
+                    int di = (dy * dstW + dx) * 4;
+                    if (si + 3 >= src.Length || di + 3 >= dst.Length) continue;
+                    dst[di]     = src[si];
+                    dst[di + 1] = src[si + 1];
+                    dst[di + 2] = src[si + 2];
+                    dst[di + 3] = src[si + 3];
+                }
+            }
+        }
+
+        /// <summary>Opaque 1:1 blit of the top-left <paramref name="dstW"/>×<paramref name="dstH"/>
+        /// of a BG image into the canvas (mirrors WF non-expand BitBlt).</summary>
+        static void BlitOpaque(
+            byte[] src, int srcW, int srcH,
+            byte[] dst, int dstW, int dstH)
+        {
+            if (src == null || dst == null) return;
+            int h = Math.Min(srcH, dstH);
+            int w = Math.Min(srcW, dstW);
+            for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+            {
+                int si = (y * srcW + x) * 4;
+                int di = (y * dstW + x) * 4;
+                if (si + 3 >= src.Length || di + 3 >= dst.Length) continue;
+                dst[di]     = src[si];
+                dst[di + 1] = src[si + 1];
+                dst[di + 2] = src[si + 2];
+                dst[di + 3] = src[si + 3];
+            }
+        }
+
+        /// <summary>Alpha-over (source-over) the 240-wide half of the 480×160 OBJ image
+        /// starting at <paramref name="srcX0"/> onto the canvas. A source pixel with
+        /// alpha==0 is skipped (mirrors WF BitBlt transparency flag 1).</summary>
+        static void AlphaOverObjHalf(
+            byte[] src, int srcW, int srcH, int srcX0,
+            byte[] dst, int dstW, int dstH)
+        {
+            if (src == null || dst == null) return;
+            int h = Math.Min(srcH, dstH);
+            for (int y = 0; y < h; y++)
+            for (int x = 0; x < dstW; x++)
+            {
+                int sx = srcX0 + x;
+                if (sx >= srcW) break;
+                int si = (y * srcW + sx) * 4;
+                int di = (y * dstW + x) * 4;
+                if (si + 3 >= src.Length || di + 3 >= dst.Length) continue;
+                if (src[si + 3] == 0) continue; // transparent → keep BG
+                dst[di]     = src[si];
+                dst[di + 1] = src[si + 1];
+                dst[di + 2] = src[si + 2];
+                dst[di + 3] = src[si + 3];
+            }
+        }
+
+        // -----------------------------------------------------------------------
         // Convenience slot counters (shared-hash aware — FIX 1)
         // -----------------------------------------------------------------------
 

--- a/docs/avalonia-forms.md
+++ b/docs/avalonia-forms.md
@@ -283,7 +283,7 @@ Editors for portraits, sprites, battle animations, tilesets, and other graphics.
 | 161 | ImageTSAAnime2View | ImageTSAAnime2ViewModel | TSA animation editor (type 2) |
 | 162 | ImagePalletView | ImagePalletViewModel | Palette viewer/editor |
 | 163 | ImageMagicFEditorView | ImageMagicFEditorViewModel | Magic effect frame editor |
-| 164 | ImageMagicCSACreatorView | ImageMagicCSACreatorViewModel | Magic CSA (compressed sprite) creator |
+| 164 | ImageMagicCSACreatorView | ImageMagicCSACreatorViewModel | Magic CSA (compressed sprite) creator — live 240×128 frame preview (`MagicEffectExportCore.RenderCsaFramePreview`, READ-ONLY; BG→OBJ-back→OBJ-front composite, honors `IsExpandsBG`) on entry-select / Frame spinner / Zoom; working "Find new resources online" → MoreData wiki link (#1021) |
 | 165 | ImageMapActionAnimationView | ImageMapActionAnimationViewModel | Map action animation editor |
 | 166 | ImageFormRefViewerView | ImageFormRefViewerViewModel | Image form reference viewer |
 | 167 | InterpolatedPictureBoxViewerView | InterpolatedPictureBoxViewerViewModel | Interpolated image viewer |


### PR DESCRIPTION
## Summary
Adds the two affordances the CSA Magic Creator was missing (the FEditor sibling already has both):
1. A **live CSA-frame preview** — the previously dead `PreviewImage` placeholder is replaced by a real `GbaImageControl` driven by a new Core render.
2. The **"Find new resources online"** link — the inert `Label` is now a working blue-underlined link.

Closes #1021. **Read-only** (no ROM mutation).

## Plan
Reviewed + accepted by Copilot CLI (GPT-5.5) with 2 blocker fixes + a precise composite spec: https://github.com/laqieer/FEBuilderGBA/issues/1021#issuecomment-4658920851 (corrections at #issuecomment-4658969914).

## What changed
- **`FEBuilderGBA.Core/MagicEffectExportCore.cs`** — `RenderCsaFramePreview(rom, frameDataAddr, frameIndex, objRtL, objBgRtL)` (READ-ONLY). Uses **`ExportMagicScriptLines(isCsa:true)`** (the CSA-aware scan: 32-byte stride + the +28 BG TSA) which outputs the per-frame `sharedObjSlots`/`sharedBgSlots` mapping — so frame N renders the right deduped slots (`slotIndex != frameIndex`, the key review correction). Composites **240×128** mirroring WF `DrawFrameImage`: BG → OBJ **back** (right 240 of the 480×160 OBJ render) → OBJ **front** (left 240), alpha-over; **`IsExpandsBG`** ported (a preceding `0x85`/`0x53` command scales the BG top-64 into the canvas). Null on any guard fail; zero `rom.write_*`.
- **`ImageMagicCSACreatorViewModel`** — `RenderCsaFramePreview(out log)` gated on `MagicSystemKind.CsaCreator && IsLoaded`; exposes the frame count for `FrameBox.Maximum`.
- **`ImageMagicCSACreatorView`** — dead `PreviewImage` → `GbaImageControl MagicFramePreview` + `RenderPreview()` (on entry-select + the new `FrameBox.ValueChanged`); `ZoomComboBox` → `MagicFramePreview.Zoom`; `FindMoreDataLabel` → a styled `TextBlock` link (`PointerPressed="LinkInternet_Click"` mirroring the FEditor's MoreData handler). The "#500" placeholders are gone.

## Test plan
- [x] `dotnet build` Core + Avalonia — 0 errors
- [x] `scripts/validate-automation-ids.ps1` — VALIDATION PASSED
- [x] Core `MagicEffectExport`/`CsaFrame` — **43/43** (incl. 7 new: CSA-aware 2-frame scan populates the +28 BG TSA; **slot-vs-frame regression** where frame 1's shared slot > 1; 240×128 composite dims; out-of-range/null guards; **no-mutation** ROM byte-identical before/after)
- [x] Avalonia `MagicCSA` — **30/30** (parity: `MagicFramePreview` + `RenderPreview` + `FrameBox.ValueChanged` ref `RenderCsaFramePreview`; the link has `PointerPressed="LinkInternet_Click"`; "#500" gone)
- [x] Full `FEBuilderGBA.Avalonia.Tests` — **7745 passed, 0 failed**, 3 skipped

## GUI Test Report
| Test | Result |
|------|--------|
| CSA Magic Creator (FE8U.gba): new **Preview** panel (GbaImageControl + zoom) + **"Find new resources online"** working blue-underlined link | PASS (screenshot below) |
| CSA frame composite (shared-slot mapping, BG→OBJ-back→OBJ-front, 240×128, IsExpandsBG) | PASS (43 Core tests on a synthetic CSA stream) |

Stock FE8U.gba has **0 CSA entries** (the CSA_Creator magic system is a patch, not present), so the preview gate is closed (no entry to render) — same environmental limitation as the skill editors. The screenshot shows both new affordances in the actual running editor; the render is proven by the 43 Core tests (synthetic CSA frame stream incl. the slot-vs-frame regression + 240×128 composite).

## Screenshots
![CSA Magic Creator — new Preview panel + working MoreData link](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1021-csa.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
