### PR TITLE
feat(avalonia): Animation Creator live frame preview for Map-Action kind (#1024)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ToolAnimationCreatorPreviewScreenshotTest.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ToolAnimationCreatorPreviewScreenshotTest.cs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1024 — screenshot proof for the Animation Creator live frame preview
+// (Map-Action kind). Mirrors the repo's existing *ScreenshotTest pattern
+// (e.g. ImageUnitPaletteSamplePreviewScreenshotTest): render through the REAL
+// production pipeline and write a PNG via IImage.EncodePng so real pixels are
+// produced even when the headless drawing backend is a no-op.
+//
+// Why a synthetic ROM instead of RomFixture: the Map Action Animation list is
+// discovered by a hard-coded byte-signature search (ImageMapActionAnimation
+// VM.FindAnimationPointer). The bundled stock ROMs under roms/ do not match
+// that signature (the table is not where the signature expects), so the source
+// editor reports 0 animations and the Creator cannot be populated end-to-end
+// from them. This test therefore builds a self-contained, CI-portable ROM with
+// one VALID map-action frame (LZ77-compressed 64x64 4bpp OBJ + a 16-colour
+// palette) and drives the EXACT production seam
+// (ImageUtilMapActionAnimationCore.RenderFrameImage) plus the real
+// ToolAnimationCreatorView — the same code path the live editor runs.
+using System;
+using System.IO;
+using global::Avalonia;
+using global::Avalonia.Controls;
+using global::Avalonia.Headless.XUnit;
+using global::Avalonia.Media.Imaging;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Controls;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using FEBuilderGBA.SkiaSharp;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class ToolAnimationCreatorPreviewScreenshotTest
+    {
+        readonly ITestOutputHelper _output;
+        public ToolAnimationCreatorPreviewScreenshotTest(ITestOutputHelper output) => _output = output;
+
+        const int FRAME_BASE = 0x210;   // 12-byte map-action frame row (>= 0x200)
+        const int OBJ_OFFSET = 0x400;   // LZ77-compressed 64x64 4bpp OBJ tiles
+        const int PAL_OFFSET = 0x900;   // 0x20-byte (16-colour) palette
+        const int ROM_SIZE   = 0x4000;
+        const int W = 1024, H = 720;
+
+        [AvaloniaFact]
+        public void AnimationCreatorPreview_MapActionFrame_RendersAndSavesScreenshot()
+        {
+            var prevRom = CoreState.ROM;
+            var prevSvc = CoreState.ImageService;
+            try
+            {
+                if (CoreState.ImageService == null)
+                    CoreState.ImageService = new SkiaImageService();
+
+                var rom = BuildRomWithOneColourfulFrame();
+                CoreState.ROM = rom;
+
+                string outDir = ResolveScreenshotOutputDir();
+                Directory.CreateDirectory(outDir);
+
+                // --- Primary artifact: the ACTUAL preview pixels --------------
+                // RenderFrameImage is the seam the view's RenderPreview() calls.
+                // EncodePng goes through the real SkiaImageService and yields real
+                // pixels independent of the headless RenderTargetBitmap backend.
+                IImage preview = ImageUtilMapActionAnimationCore.RenderFrameImage(
+                    rom, (uint)OBJ_OFFSET, (uint)PAL_OFFSET);
+                Assert.NotNull(preview);
+                Assert.Equal(64, preview!.Width);
+                Assert.Equal(64, preview.Height);
+
+                byte[] png = preview.EncodePng();
+                Assert.NotNull(png);
+                Assert.True(png!.Length > 0, "preview PNG must have bytes");
+                string previewPath = Path.Combine(outDir, "pr1024-animation-creator-preview.png");
+                File.WriteAllBytes(previewPath, png);
+                _output.WriteLine($"Saved preview ({preview.Width}x{preview.Height}) to: {previewPath} ({png.Length} bytes)");
+                preview.Dispose();
+
+                // --- Drive the REAL view (populated + frame selected) ---------
+                var view = new ToolAnimationCreatorView();
+                view.InitFromRom(AnimationTypeEnum.MapActionAnimation, 0,
+                    "Map Action Animation #00 (demo frame)", U.toPointer((uint)FRAME_BASE));
+
+                var framesList = view.FindControl<ListBox>("FramesList");
+                Assert.NotNull(framesList);
+                Assert.True(framesList!.ItemCount >= 1, "view should have at least one frame");
+                framesList.SelectedIndex = 0;   // fires SelectionChanged -> RenderPreview
+
+                var previewControl = view.FindControl<GbaImageControl>("MapActionPreview");
+                Assert.NotNull(previewControl);
+
+                // --- Secondary artifact: full editor view (best-effort) -------
+                // The headless no-op drawing backend may not support
+                // RenderTargetBitmap; that is an environment limitation, not a
+                // #1024 failure, so it is caught and reported (the preview PNG
+                // above is the authoritative pixel proof).
+                try
+                {
+                    view.Measure(new Size(W, H));
+                    view.Arrange(new Rect(0, 0, W, H));
+                    using var bmp = new RenderTargetBitmap(new PixelSize(W, H));
+                    bmp.Render(view);
+                    string viewPath = Path.Combine(outDir, "pr1024-animation-creator-view.png");
+                    bmp.Save(viewPath);
+                    _output.WriteLine($"Saved editor view to: {viewPath} ({new FileInfo(viewPath).Length} bytes)");
+                }
+                catch (Exception ex)
+                {
+                    _output.WriteLine($"Headless full-view render skipped (environment, not #1024): {ex.Message}");
+                }
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.ImageService = prevSvc;
+            }
+        }
+
+        static string ResolveScreenshotOutputDir()
+        {
+            string? overrideDir = Environment.GetEnvironmentVariable("FEBUILDERGBA_SCREENSHOT_DIR");
+            if (!string.IsNullOrEmpty(overrideDir))
+                return overrideDir;
+            return Path.Combine(Path.GetTempPath(), "FEBuilderGBA-screenshots");
+        }
+
+        /// <summary>
+        /// Synthetic ROM: one valid map-action frame whose OBJ decodes to a
+        /// colourful radial-ring 64x64 image (clearly a rendered preview, not a
+        /// blank box) under a 16-colour rainbow palette.
+        /// </summary>
+        static ROM BuildRomWithOneColourfulFrame()
+        {
+            byte[] data = new byte[ROM_SIZE];
+
+            // 16-colour rainbow palette (RGB555, little-endian) at PAL_OFFSET.
+            // Index 0 kept dark so ring boundaries read clearly.
+            for (int i = 0; i < 16; i++)
+            {
+                int r, g, b;
+                if (i == 0) { r = g = b = 2; }
+                else
+                {
+                    double h = (i - 1) / 15.0 * 6.0;
+                    int seg = (int)h; double f = h - seg;
+                    int v = 31, p = 4, q = (int)(31 * (1 - f)), t = (int)(31 * f);
+                    switch (seg % 6)
+                    {
+                        case 0: r = v; g = t; b = p; break;
+                        case 1: r = q; g = v; b = p; break;
+                        case 2: r = p; g = v; b = t; break;
+                        case 3: r = p; g = q; b = v; break;
+                        case 4: r = t; g = p; b = v; break;
+                        default: r = v; g = p; b = q; break;
+                    }
+                }
+                ushort c = (ushort)((b << 10) | (g << 5) | r);
+                data[PAL_OFFSET + i * 2 + 0] = (byte)(c & 0xFF);
+                data[PAL_OFFSET + i * 2 + 1] = (byte)((c >> 8) & 0xFF);
+            }
+
+            // 64x64 4bpp OBJ tiles, radial colour rings, packed in GBA tile order.
+            byte[] raw = BuildRadialTiles(64, 64);
+            byte[] compressed = LZ77.compress(raw);
+            Array.Copy(compressed, 0, data, OBJ_OFFSET, compressed.Length);
+
+            // Frame row: wait=4, sound=0, img -> OBJ_OFFSET, pal -> PAL_OFFSET.
+            data[FRAME_BASE + 0] = 4;
+            WriteU32(data, FRAME_BASE + 4, U.toPointer((uint)OBJ_OFFSET));
+            WriteU32(data, FRAME_BASE + 8, U.toPointer((uint)PAL_OFFSET));
+            // Zero terminator row already present at FRAME_BASE + 12.
+
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(data);
+            return rom;
+        }
+
+        static byte[] BuildRadialTiles(int w, int h)
+        {
+            byte[] tiles = new byte[w * h / 2];
+            int tilesW = w / 8;
+            int cx = w / 2, cy = h / 2;
+            int p = 0;
+            for (int ty = 0; ty < h / 8; ty++)
+                for (int tx = 0; tx < tilesW; tx++)
+                    for (int py = 0; py < 8; py++)
+                        for (int px = 0; px < 8; px += 2)
+                        {
+                            int x0 = tx * 8 + px, y0 = ty * 8 + py;
+                            int lo = RingIndex(x0, y0, cx, cy);
+                            int hi = RingIndex(x0 + 1, y0, cx, cy);
+                            tiles[p++] = (byte)((lo & 0x0F) | ((hi & 0x0F) << 4));
+                        }
+            return tiles;
+        }
+
+        static int RingIndex(int x, int y, int cx, int cy)
+        {
+            double d = Math.Sqrt((x - cx) * (x - cx) + (y - cy) * (y - cy));
+            return ((int)(d / 3.0) % 15) + 1; // 1..15 (skip 0/dark)
+        }
+
+        static void WriteU32(byte[] data, int addr, uint v)
+        {
+            data[addr + 0] = (byte)(v & 0xFF);
+            data[addr + 1] = (byte)((v >> 8) & 0xFF);
+            data[addr + 2] = (byte)((v >> 16) & 0xFF);
+            data[addr + 3] = (byte)((v >> 24) & 0xFF);
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/ToolAnimationCreatorPreviewTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ToolAnimationCreatorPreviewTests.cs
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1024 headless Avalonia tests for the Animation Creator live frame preview
+// (Map-Action kind). Covers:
+//   - the preview GbaImageControl is present + carries the expected AutomationId,
+//   - the old "Animation preview (deferred ..." placeholder TextBlock is gone,
+//   - selecting a frame whose Image/Palette pointers reference a valid compressed
+//     OBJ + palette renders a non-empty image into the preview control,
+//   - selecting no frame (or clearing) leaves the preview empty.
+//
+// The render assertions use the real SkiaSharp decoder (the Core stub only
+// produces synthetic blank images); they are guarded so they no-op cleanly when
+// the native decoder is unavailable, matching the codebase pattern.
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Controls;
+using FEBuilderGBA.Avalonia.Views;
+using FEBuilderGBA.SkiaSharp;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+[Collection("SharedState")]
+public class ToolAnimationCreatorPreviewTests
+{
+    const int OBJ_OFFSET = 0x400;
+    const int PAL_OFFSET = 0x900;
+    const int ROM_SIZE = 0x2000;
+    const int OBJ_UNCOMPRESSED_LEN = (64 * 64) / 2; // 2048 bytes for 64x64 @4bpp
+
+    static List<string> CollectAutomationIds(Control root)
+        => root.GetLogicalDescendants()
+               .OfType<Control>()
+               .Select(c => AutomationProperties.GetAutomationId(c))
+               .Where(id => !string.IsNullOrEmpty(id))
+               .ToList()!;
+
+    /// <summary>
+    /// Build a synthetic ROM with one map-action frame row at 0x210 whose img/pal
+    /// pointers reference a valid LZ77-compressed 64x64 4bpp OBJ + 0x20 palette.
+    /// </summary>
+    static ROM BuildRomWithOneFrame(uint baseAddr)
+    {
+        byte[] data = new byte[ROM_SIZE];
+
+        byte[] raw = new byte[OBJ_UNCOMPRESSED_LEN];
+        for (int i = 0; i < raw.Length; i++) raw[i] = (byte)(i & 0xFF);
+        byte[] compressed = LZ77.compress(raw);
+        System.Array.Copy(compressed, 0, data, OBJ_OFFSET, compressed.Length);
+
+        // Frame row: wait=1, img -> OBJ_OFFSET, pal -> PAL_OFFSET (GBA pointers).
+        data[baseAddr] = 1;
+        WriteU32(data, baseAddr + 4u, U.toPointer((uint)OBJ_OFFSET));
+        WriteU32(data, baseAddr + 8u, U.toPointer((uint)PAL_OFFSET));
+        // Terminator at baseAddr+12 (already zero).
+
+        var rom = new ROM();
+        rom.SwapNewROMDataDirect(data);
+        return rom;
+    }
+
+    static void WriteU32(byte[] data, uint addr, uint v)
+    {
+        data[addr + 0] = (byte)(v & 0xFF);
+        data[addr + 1] = (byte)((v >> 8) & 0xFF);
+        data[addr + 2] = (byte)((v >> 16) & 0xFF);
+        data[addr + 3] = (byte)((v >> 24) & 0xFF);
+    }
+
+    // ====================================================================
+    // Structure: preview control present, correct AutomationId, no placeholder
+    // ====================================================================
+    [AvaloniaFact]
+    public void PreviewControl_Present_WithAutomationId()
+    {
+        var view = new ToolAnimationCreatorView();
+
+        var preview = view.FindControl<GbaImageControl>("MapActionPreview");
+        Assert.NotNull(preview);
+
+        var ids = CollectAutomationIds(view);
+        Assert.Contains("ToolAnimationCreator_Preview_Image", ids);
+    }
+
+    [AvaloniaFact]
+    public void Preview_NoDeferredPlaceholderTextBlock()
+    {
+        var view = new ToolAnimationCreatorView();
+
+        // The old deferred-preview placeholder must be gone — no TextBlock in the
+        // view should carry that text.
+        bool hasPlaceholder = view.GetLogicalDescendants()
+            .OfType<TextBlock>()
+            .Any(tb => tb.Text != null && tb.Text.Contains("Animation preview (deferred"));
+        Assert.False(hasPlaceholder);
+    }
+
+    // ====================================================================
+    // Functional: selecting a frame renders into the preview (real decoder)
+    // ====================================================================
+    [AvaloniaFact]
+    public void SelectingFrame_RendersPreviewImage()
+    {
+        var origRom = CoreState.ROM;
+        var origService = CoreState.ImageService;
+        try
+        {
+            CoreState.ImageService = new SkiaImageService();
+            uint baseAddr = 0x210;
+            CoreState.ROM = BuildRomWithOneFrame(baseAddr);
+
+            var view = new ToolAnimationCreatorView();
+            view.InitFromRom(AnimationTypeEnum.MapActionAnimation, 0, "hint", baseAddr);
+
+            var list = view.FindControl<ListBox>("FramesList");
+            var preview = view.FindControl<GbaImageControl>("MapActionPreview");
+            Assert.NotNull(list);
+            Assert.NotNull(preview);
+            Assert.Equal(1, list!.ItemCount);
+
+            // Nothing selected yet -> preview empty.
+            Assert.False(preview!.HasImage);
+
+            // Select the single frame -> SelectionChanged drives RenderPreview.
+            list.SelectedIndex = 0;
+
+            Assert.True(preview.HasImage);
+        }
+        finally
+        {
+            CoreState.ROM = origRom;
+            CoreState.ImageService = origService;
+        }
+    }
+
+    [AvaloniaFact]
+    public void ChangingSelectedFramePointer_ReRendersPreview()
+    {
+        var origRom = CoreState.ROM;
+        var origService = CoreState.ImageService;
+        try
+        {
+            CoreState.ImageService = new SkiaImageService();
+            uint baseAddr = 0x210;
+            CoreState.ROM = BuildRomWithOneFrame(baseAddr);
+
+            var view = new ToolAnimationCreatorView();
+            view.InitFromRom(AnimationTypeEnum.MapActionAnimation, 0, "hint", baseAddr);
+
+            var list = view.FindControl<ListBox>("FramesList");
+            var preview = view.FindControl<GbaImageControl>("MapActionPreview");
+            list!.SelectedIndex = 0;
+            Assert.True(preview!.HasImage);
+
+            // Point the image pointer at an invalid (zero) offset -> preview clears
+            // via the tracked-frame PropertyChanged subscription.
+            var frame = list.SelectedItem as FEBuilderGBA.Avalonia.ViewModels.EditableMapActionFrame;
+            Assert.NotNull(frame);
+            frame!.ImagePointer = 0;
+
+            Assert.False(preview.HasImage);
+        }
+        finally
+        {
+            CoreState.ROM = origRom;
+            CoreState.ImageService = origService;
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/ToolAnimationCreatorPreviewTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ToolAnimationCreatorPreviewTests.cs
@@ -53,9 +53,10 @@ public class ToolAnimationCreatorPreviewTests
         System.Array.Copy(compressed, 0, data, OBJ_OFFSET, compressed.Length);
 
         // Frame row: wait=1, img -> OBJ_OFFSET, pal -> PAL_OFFSET (GBA pointers).
-        data[baseAddr] = 1;
-        WriteU32(data, baseAddr + 4u, U.toPointer((uint)OBJ_OFFSET));
-        WriteU32(data, baseAddr + 8u, U.toPointer((uint)PAL_OFFSET));
+        int b = (int)baseAddr;
+        data[b] = 1;
+        WriteU32(data, b + 4, U.toPointer((uint)OBJ_OFFSET));
+        WriteU32(data, b + 8, U.toPointer((uint)PAL_OFFSET));
         // Terminator at baseAddr+12 (already zero).
 
         var rom = new ROM();
@@ -63,7 +64,7 @@ public class ToolAnimationCreatorPreviewTests
         return rom;
     }
 
-    static void WriteU32(byte[] data, uint addr, uint v)
+    static void WriteU32(byte[] data, int addr, uint v)
     {
         data[addr + 0] = (byte)(v & 0xFF);
         data[addr + 1] = (byte)((v >> 8) & 0xFF);

--- a/FEBuilderGBA.Avalonia/Views/ToolAnimationCreatorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolAnimationCreatorView.axaml
@@ -1,5 +1,6 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
         x:Class="FEBuilderGBA.Avalonia.Views.ToolAnimationCreatorView"
         Title="Animation Creator" Width="1024" Height="720"
         WindowStartupLocation="CenterOwner"
@@ -112,9 +113,8 @@
           </StackPanel>
 
           <Border BorderBrush="Gray" BorderThickness="1" Height="120" Padding="4">
-            <TextBlock Text="Animation preview (deferred — see #500 follow-up)"
-                       HorizontalAlignment="Center" VerticalAlignment="Center"
-                       Foreground="Gray" TextWrapping="Wrap" />
+            <controls:GbaImageControl AutomationProperties.AutomationId="ToolAnimationCreator_Preview_Image"
+                                      Name="MapActionPreview" Zoom="2" />
           </Border>
         </StackPanel>
       </Border>

--- a/FEBuilderGBA.Avalonia/Views/ToolAnimationCreatorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolAnimationCreatorView.axaml.cs
@@ -124,7 +124,12 @@ namespace FEBuilderGBA.Avalonia.Views
                 return;
             }
 
-            IImage? img = ImageUtilMapActionAnimationCore.RenderFrameImage(
+            // GbaImageControl.SetImage synchronously copies the pixels into a
+            // WriteableBitmap and does NOT take ownership of the source IImage, so
+            // dispose the freshly-decoded image here — otherwise frequent
+            // re-renders (selection / pointer-edit changes) leak native Skia
+            // memory. Copilot review on PR #1077.
+            using IImage? img = ImageUtilMapActionAnimationCore.RenderFrameImage(
                 CoreState.ROM, f.ImagePointer, f.PalettePointer);
             MapActionPreview.SetImage(img);
         }

--- a/FEBuilderGBA.Avalonia/Views/ToolAnimationCreatorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolAnimationCreatorView.axaml.cs
@@ -10,9 +10,11 @@
 // Create_Click branches on context (ROM vs file). BrowseImage_Click is wired
 // through the StorageProvider file picker.
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
+using FEBuilderGBA; // Core: ImageUtilMapActionAnimationCore, CoreState, IImage
 using FEBuilderGBA.Avalonia.Dialogs;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
@@ -23,6 +25,11 @@ namespace FEBuilderGBA.Avalonia.Views
     {
         readonly ToolAnimationCreatorViewViewModel _vm = new();
         readonly UndoService _undoService = new();
+
+        // The frame whose PropertyChanged we are currently subscribed to so the
+        // live preview re-renders when its Image/Palette pointer changes. We must
+        // unsubscribe before re-subscribing (and on close) to avoid leaks.
+        EditableMapActionFrame? _previewTrackedFrame;
 
         public string ViewTitle => "Animation Creator";
         public bool IsLoaded => _vm.IsLoaded;
@@ -71,7 +78,65 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             // Mirror the list selection into _vm.SelectedFrame so the right-
             // pane edit controls follow the active row.
-            _vm.SelectedFrame = FramesList.SelectedItem as EditableMapActionFrame;
+            var frame = FramesList.SelectedItem as EditableMapActionFrame;
+            _vm.SelectedFrame = frame;
+
+            // Track the newly-selected frame so the live preview re-renders when
+            // its Image/Palette pointer changes. Unsubscribe from the previously
+            // tracked frame first to avoid handler leaks.
+            if (!ReferenceEquals(_previewTrackedFrame, frame))
+            {
+                if (_previewTrackedFrame != null)
+                    _previewTrackedFrame.PropertyChanged -= OnTrackedFramePropertyChanged;
+                _previewTrackedFrame = frame;
+                if (_previewTrackedFrame != null)
+                    _previewTrackedFrame.PropertyChanged += OnTrackedFramePropertyChanged;
+            }
+
+            RenderPreview();
+        }
+
+        void OnTrackedFramePropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            // Re-render whenever the image or palette pointer changes (null name =
+            // bulk reset → re-render to be safe).
+            if (e.PropertyName == null
+                || e.PropertyName == nameof(EditableMapActionFrame.ImagePointer)
+                || e.PropertyName == nameof(EditableMapActionFrame.PalettePointer))
+            {
+                RenderPreview();
+            }
+        }
+
+        /// <summary>
+        /// Read-only live preview of the selected Map-Action frame. Decodes the
+        /// frame's OBJ + palette through the Core RenderFrameImage seam and pushes
+        /// the result into the GbaImageControl. No ROM mutation, no undo.
+        /// </summary>
+        void RenderPreview()
+        {
+            if (MapActionPreview == null) return;
+
+            var f = _vm.SelectedFrame;
+            if (f == null || CoreState.ROM == null)
+            {
+                MapActionPreview.SetImage(null);
+                return;
+            }
+
+            IImage? img = ImageUtilMapActionAnimationCore.RenderFrameImage(
+                CoreState.ROM, f.ImagePointer, f.PalettePointer);
+            MapActionPreview.SetImage(img);
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            if (_previewTrackedFrame != null)
+            {
+                _previewTrackedFrame.PropertyChanged -= OnTrackedFramePropertyChanged;
+                _previewTrackedFrame = null;
+            }
+            base.OnClosed(e);
         }
 
         async void BrowseImage_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Core.Tests/ImageUtilMapActionAnimationCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ImageUtilMapActionAnimationCoreTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Xunit;
 using FEBuilderGBA;
 
@@ -9,6 +10,48 @@ namespace FEBuilderGBA.Core.Tests
         // isSafetyOffset requires address >= 0x200, so test data must be at >= 0x200
         const int FRAME_BASE = 0x1000;
         const int ROM_SIZE = 0x2000;
+
+        // ---- Helpers for the RenderFrameImage seam (#1024) ----------------
+
+        // Offsets inside the synthetic ROM for the compressed OBJ + raw palette.
+        const int OBJ_OFFSET = 0x400;   // LZ77-compressed 64x64 4bpp tiles
+        const int PAL_OFFSET = 0x900;   // raw 0x20-byte (16-color) palette
+
+        // 64x64 px @ 4bpp = (64*64)/2 = 2048 uncompressed bytes.
+        const int OBJ_UNCOMPRESSED_LEN = (64 * 64) / 2;
+
+        /// <summary>
+        /// Build a synthetic ROM holding an LZ77-compressed 64x64 4bpp OBJ payload
+        /// at <see cref="OBJ_OFFSET"/> and a 0x20-byte palette at
+        /// <see cref="PAL_OFFSET"/>. Returns the ROM; out-params expose the
+        /// GBA pointers (0x08000000-based) so callers can pass either form.
+        /// </summary>
+        static ROM BuildRomWithObjAndPalette(out uint objPointer, out uint palPointer)
+        {
+            byte[] data = new byte[ROM_SIZE];
+
+            // Uncompressed OBJ tile bytes (any deterministic pattern is fine).
+            byte[] raw = new byte[OBJ_UNCOMPRESSED_LEN];
+            for (int i = 0; i < raw.Length; i++)
+                raw[i] = (byte)(i & 0xFF);
+
+            byte[] compressed = LZ77.compress(raw);
+            Assert.NotNull(compressed);
+            Assert.True(OBJ_OFFSET + compressed.Length <= PAL_OFFSET,
+                "compressed OBJ must fit before the palette region");
+            Array.Copy(compressed, 0, data, OBJ_OFFSET, compressed.Length);
+
+            // Raw 16-color palette (0x20 bytes); leave as zeros (valid palette).
+            // PAL_OFFSET + 0x20 must be in range.
+            Assert.True(PAL_OFFSET + 0x20 <= ROM_SIZE);
+
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(data);
+
+            objPointer = U.toPointer((uint)OBJ_OFFSET);
+            palPointer = U.toPointer((uint)PAL_OFFSET);
+            return rom;
+        }
 
         [Fact]
         public void DrawFrame_WithNoRom_ReturnsNull()
@@ -205,6 +248,231 @@ namespace FEBuilderGBA.Core.Tests
             finally
             {
                 CoreState.ROM = origRom;
+            }
+        }
+
+        // ---- RenderFrameImage seam tests (#1024) --------------------------
+
+        [Fact]
+        public void RenderFrameImage_ValidObjAndPalette_Returns64x64()
+        {
+            var origRom = CoreState.ROM;
+            var origService = CoreState.ImageService;
+            try
+            {
+                CoreState.ImageService = new StubImageService();
+                var rom = BuildRomWithObjAndPalette(out uint objPtr, out uint palPtr);
+                CoreState.ROM = rom; // RenderFrameImage is rom-aware, but set anyway.
+
+                using (var img = ImageUtilMapActionAnimationCore.RenderFrameImage(rom, objPtr, palPtr))
+                {
+                    Assert.NotNull(img);
+                    Assert.Equal(64, img.Width);
+                    Assert.Equal(64, img.Height);
+                }
+            }
+            finally
+            {
+                CoreState.ROM = origRom;
+                CoreState.ImageService = origService;
+            }
+        }
+
+        [Fact]
+        public void RenderFrameImage_AcceptsRawOffsets()
+        {
+            // U.toOffset is idempotent for already-converted offsets, so passing
+            // the raw ROM offset (not the GBA pointer) must also work — this is
+            // exactly how the refactored DrawFrameImage forwards rom.p32 results.
+            var origRom = CoreState.ROM;
+            var origService = CoreState.ImageService;
+            try
+            {
+                CoreState.ImageService = new StubImageService();
+                var rom = BuildRomWithObjAndPalette(out _, out _);
+                CoreState.ROM = rom;
+
+                using (var img = ImageUtilMapActionAnimationCore.RenderFrameImage(
+                    rom, (uint)OBJ_OFFSET, (uint)PAL_OFFSET))
+                {
+                    Assert.NotNull(img);
+                    Assert.Equal(64, img.Width);
+                    Assert.Equal(64, img.Height);
+                }
+            }
+            finally
+            {
+                CoreState.ROM = origRom;
+                CoreState.ImageService = origService;
+            }
+        }
+
+        [Fact]
+        public void RenderFrameImage_NullRom_ReturnsNull()
+        {
+            var origService = CoreState.ImageService;
+            try
+            {
+                CoreState.ImageService = new StubImageService();
+                var result = ImageUtilMapActionAnimationCore.RenderFrameImage(null, 0x400, 0x900);
+                Assert.Null(result);
+            }
+            finally
+            {
+                CoreState.ImageService = origService;
+            }
+        }
+
+        [Fact]
+        public void RenderFrameImage_NullImageService_ReturnsNull()
+        {
+            var origRom = CoreState.ROM;
+            var origService = CoreState.ImageService;
+            try
+            {
+                CoreState.ImageService = null;
+                var rom = BuildRomWithObjAndPalette(out uint objPtr, out uint palPtr);
+                CoreState.ROM = rom;
+
+                var result = ImageUtilMapActionAnimationCore.RenderFrameImage(rom, objPtr, palPtr);
+                Assert.Null(result);
+            }
+            finally
+            {
+                CoreState.ROM = origRom;
+                CoreState.ImageService = origService;
+            }
+        }
+
+        [Fact]
+        public void RenderFrameImage_ZeroImagePointer_ReturnsNull()
+        {
+            var origRom = CoreState.ROM;
+            var origService = CoreState.ImageService;
+            try
+            {
+                CoreState.ImageService = new StubImageService();
+                var rom = BuildRomWithObjAndPalette(out _, out uint palPtr);
+                CoreState.ROM = rom;
+
+                // Zero image pointer fails the safety-offset guard (< 0x200).
+                var result = ImageUtilMapActionAnimationCore.RenderFrameImage(rom, 0, palPtr);
+                Assert.Null(result);
+            }
+            finally
+            {
+                CoreState.ROM = origRom;
+                CoreState.ImageService = origService;
+            }
+        }
+
+        [Fact]
+        public void RenderFrameImage_OutOfRangePointer_ReturnsNull()
+        {
+            var origRom = CoreState.ROM;
+            var origService = CoreState.ImageService;
+            try
+            {
+                CoreState.ImageService = new StubImageService();
+                var rom = BuildRomWithObjAndPalette(out uint objPtr, out _);
+                CoreState.ROM = rom;
+
+                // Out-of-range pointer must be rejected without throwing.
+                var result = ImageUtilMapActionAnimationCore.RenderFrameImage(rom, objPtr, 0xFFFFFFFF);
+                Assert.Null(result);
+            }
+            finally
+            {
+                CoreState.ROM = origRom;
+                CoreState.ImageService = origService;
+            }
+        }
+
+        [Fact]
+        public void DrawFrame_ParityThroughRenderFrameImage_Returns64x64()
+        {
+            // Build a 12-byte frame row whose img/pal pointers reference the same
+            // compressed OBJ + palette, then assert DrawFrame (ambient CoreState.ROM)
+            // renders through the shared RenderFrameImage helper.
+            var origRom = CoreState.ROM;
+            var origService = CoreState.ImageService;
+            try
+            {
+                CoreState.ImageService = new StubImageService();
+
+                byte[] data = new byte[ROM_SIZE];
+
+                // OBJ payload (LZ77-compressed 64x64 4bpp).
+                byte[] raw = new byte[OBJ_UNCOMPRESSED_LEN];
+                for (int i = 0; i < raw.Length; i++)
+                    raw[i] = (byte)(i & 0xFF);
+                byte[] compressed = LZ77.compress(raw);
+                Array.Copy(compressed, 0, data, OBJ_OFFSET, compressed.Length);
+
+                // Frame row at FRAME_BASE: wait=5, img -> OBJ_OFFSET, pal -> PAL_OFFSET.
+                int b = FRAME_BASE;
+                data[b + 0] = 5;
+                uint imgPtr = U.toPointer((uint)OBJ_OFFSET);
+                uint palPtr = U.toPointer((uint)PAL_OFFSET);
+                U.write_u32(data, (uint)(b + 4), imgPtr);
+                U.write_u32(data, (uint)(b + 8), palPtr);
+                // Terminator at b+12 = all zeros (default).
+
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(data);
+                CoreState.ROM = rom;
+
+                using (var img = ImageUtilMapActionAnimationCore.DrawFrame((uint)FRAME_BASE, 0))
+                {
+                    Assert.NotNull(img);
+                    Assert.Equal(64, img.Width);
+                    Assert.Equal(64, img.Height);
+                }
+            }
+            finally
+            {
+                CoreState.ROM = origRom;
+                CoreState.ImageService = origService;
+            }
+        }
+
+        [Fact]
+        public void DrawFrame_NearEofFrameRow_ReturnsNullNoThrow()
+        {
+            // Place a frame row so that frame + 12 > rom.Data.Length: the explicit
+            // 12-byte bounds guard must return null WITHOUT throwing.
+            var origRom = CoreState.ROM;
+            var origService = CoreState.ImageService;
+            try
+            {
+                CoreState.ImageService = new StubImageService();
+
+                byte[] data = new byte[ROM_SIZE];
+                // Non-zero leading bytes near EOF so the frame isn't an immediate
+                // terminator; FindFrame returns this row, DrawFrameImage rejects it.
+                data[ROM_SIZE - 4] = 5;
+                data[ROM_SIZE - 3] = 1;
+
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(data);
+                CoreState.ROM = rom;
+
+                // animeAddress = ROM_SIZE - 4 → frame at ROM_SIZE-4, +12 overflows EOF.
+                IImage img = null;
+                var ex = Record.Exception(() =>
+                {
+                    img = ImageUtilMapActionAnimationCore.DrawFrame((uint)(ROM_SIZE - 4), 0);
+                });
+                Assert.Null(ex);
+                using (img)
+                {
+                    Assert.Null(img);
+                }
+            }
+            finally
+            {
+                CoreState.ROM = origRom;
+                CoreState.ImageService = origService;
             }
         }
     }

--- a/FEBuilderGBA.Core/ImageUtilMapActionAnimationCore.cs
+++ b/FEBuilderGBA.Core/ImageUtilMapActionAnimationCore.cs
@@ -57,9 +57,10 @@ namespace FEBuilderGBA
 
             int count = 0;
             uint limiter = animeAddress + 1024 * 1024;
-            limiter = (uint)Math.Min(limiter, rom.Data.Length);
+            // Cap so a full 12-byte row (read up to n+8..n+11) never overruns EOF.
+            limiter = (uint)Math.Min(limiter, Math.Max(0, rom.Data.Length - 12 + 1));
 
-            for (uint n = animeAddress; n < limiter; n += 12)
+            for (uint n = animeAddress; n + 12 <= (uint)rom.Data.Length && n < limiter; n += 12)
             {
                 uint term1 = U.u32(rom.Data, n);
                 uint term2 = U.u32(rom.Data, n + 4);
@@ -78,7 +79,8 @@ namespace FEBuilderGBA
             uint limiter = animeAddress + 1024 * 1024;
             limiter = (uint)Math.Min(limiter, data.Length);
 
-            for (uint n = animeAddress; n < limiter; n += 12)
+            // Stop before a partial 12-byte row would overrun EOF (n+4..n+11 read).
+            for (uint n = animeAddress; n + 12 <= (uint)data.Length && n < limiter; n += 12)
             {
                 uint term1 = U.u32(data, n);
                 uint term2 = U.u32(data, n + 4);
@@ -107,25 +109,72 @@ namespace FEBuilderGBA
             //   void*  pal;   // offset +8
             // } // sizeof() == 12
 
+            // Explicit 12-byte frame-row bounds guard so the no-throw contract is
+            // self-evident and does not merely rely on rom.p32's EOF tolerance.
+            if ((long)frame + 12 > rom.Data.Length)
+                return null;
+
             uint objOffset = rom.p32(frame + 4);
             uint palOffset = rom.p32(frame + 8);
 
-            if (!U.isSafetyOffset(objOffset))
+            // rom.p32 already returns a ROM offset (post-toOffset, 0 if OOR);
+            // RenderFrameImage re-applies U.toOffset which is a no-op for an
+            // already-converted offset (< 0x08000000), so passing the offset is safe.
+            return RenderFrameImage(rom, objOffset, palOffset);
+        }
+
+        /// <summary>
+        /// ROM-aware renderer for a single map-action animation frame's image.
+        /// Decodes the LZ77-compressed 4bpp OBJ tiles pointed to by
+        /// <paramref name="imagePointer"/> using the 16-color palette pointed to by
+        /// <paramref name="palettePointer"/>, producing a 64x64 (8x8 tiles) IImage.
+        ///
+        /// Does NOT use the ambient <see cref="CoreState.ROM"/> — reads exclusively
+        /// from the supplied <paramref name="rom"/>. Both pointers may be GBA
+        /// pointers or already-converted ROM offsets (<see cref="U.toOffset"/> is
+        /// idempotent for offsets). READ-ONLY: never mutates the ROM.
+        ///
+        /// Never throws — any bad pointer, short/corrupt LZ77 stream, missing
+        /// palette, or unexpected exception returns null (blank-dummy contract,
+        /// mirroring WaitIconRenderCore / SkillSystemsAnimeExportCore).
+        /// </summary>
+        /// <param name="rom">ROM to read from (not the ambient CoreState.ROM).</param>
+        /// <param name="imagePointer">GBA pointer / offset to LZ77-compressed 4bpp OBJ tiles.</param>
+        /// <param name="palettePointer">GBA pointer / offset to the raw 0x20-byte palette.</param>
+        /// <returns>Rendered 64x64 IImage, or null on any failure.</returns>
+        public static IImage RenderFrameImage(ROM rom, uint imagePointer, uint palettePointer)
+        {
+            if (rom == null || rom.Data == null)
                 return null;
-            if (!U.isSafetyOffset(palOffset))
+            if (CoreState.ImageService == null)
                 return null;
 
-            // OBJ data is LZ77-compressed
-            byte[] obj = LZ77.decompress(rom.Data, objOffset);
-            if (obj == null || obj.Length == 0)
+            uint objOffset = U.toOffset(imagePointer);
+            uint palOffset = U.toOffset(palettePointer);
+
+            if (!U.isSafetyOffset(objOffset, rom))
+                return null;
+            if (!U.isSafetyOffset(palOffset, rom))
                 return null;
 
-            // PAL is 0x20 bytes (16 colors, 2 bytes each) uncompressed
-            byte[] palette = ImageUtilCore.GetPalette(palOffset, 16);
-            if (palette == null)
-                return null;
+            try
+            {
+                // OBJ data is LZ77-compressed.
+                byte[] obj = LZ77.decompress(rom.Data, objOffset);
+                if (obj == null || obj.Length == 0)
+                    return null;
 
-            return CoreState.ImageService.Decode4bppTiles(obj, 0, SCREEN_WIDTH, SCREEN_HEIGHT, palette);
+                // PAL is 0x20 bytes (16 colors, 2 bytes each) uncompressed.
+                byte[] palette = ImageUtilCore.GetPalette(rom, palOffset, 16);
+                if (palette == null)
+                    return null;
+
+                return CoreState.ImageService.Decode4bppTiles(obj, 0, SCREEN_WIDTH, SCREEN_HEIGHT, palette);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
         }
     }
 }

--- a/FEBuilderGBA.Core/ImageUtilMapActionAnimationCore.cs
+++ b/FEBuilderGBA.Core/ImageUtilMapActionAnimationCore.cs
@@ -159,6 +159,14 @@ namespace FEBuilderGBA
 
             try
             {
+                // Guard a corrupt LZ77 header that advertises a huge uncompressed
+                // size: getUncompressSize enforces MAX_UNCOMP_DATA_LIMIT (raw
+                // LZ77.decompress does NOT), so a garbage/corrupt OBJ pointer can't
+                // force an oversized allocation that stalls the UI preview. Mirrors
+                // ClassOPDemoFontRenderCore. Copilot review on PR #1077.
+                if (LZ77.getUncompressSize(rom.Data, objOffset) == 0)
+                    return null;
+
                 // OBJ data is LZ77-compressed.
                 byte[] obj = LZ77.decompress(rom.Data, objOffset);
                 if (obj == null || obj.Length == 0)


### PR DESCRIPTION
## Summary
Wires a **live frame preview** into the Avalonia **Animation Creator** for the **Map-Action kind** — the only kind the editor currently parses/writes. The placeholder `TextBlock` ("Animation preview (deferred — see #500 follow-up)") is replaced by a real `GbaImageControl` that renders the currently-selected frame by reusing the existing Core decode path.

Plan: https://github.com/laqieer/FEBuilderGBA/issues/1024#issuecomment-4659386049 (Copilot CLI plan review: **approved**).

## Scope
- **Closes #1024** (live preview for the Map-Action kind).
- **Ref #996** — Battle/Magic/Skill **kind routing** in `InitFromRom`/`InitFromFile` is intentionally deferred (the issue flags it as a separate concern that ties into the magic/skill jump work, #996), keeping this PR a single reviewable slice.

## Changes
**Core — `ImageUtilMapActionAnimationCore.cs`**
- New `RenderFrameImage(ROM rom, uint imagePointer, uint palettePointer)` — rom-aware, reuses `LZ77.decompress` + `ImageUtilCore.GetPalette(rom, …)` + `Decode4bppTiles` (64×64). Guards `rom`/`Data`/`ImageService`/both pointers; **never throws**. A corrupt-LZ77-header guard (`LZ77.getUncompressSize == 0`) prevents an oversized allocation from a garbage OBJ pointer (Copilot review).
- Private `DrawFrameImage` delegates to it (single source of truth) with an explicit 12-byte frame-row bounds guard; `FindFrame`/`CountFrames` hardened against near-EOF partial rows. Ambient behaviour for existing callers unchanged.

**Avalonia — `Views/ToolAnimationCreatorView.axaml(.cs)`**
- Placeholder `TextBlock` → `controls:GbaImageControl` (`MapActionPreview`, `AutomationId=ToolAnimationCreator_Preview_Image`).
- Read-only `RenderPreview()` re-renders on `SelectedFrame` change + the selected frame's pointer changes (subscribe/unsubscribe lifecycle, unsubscribed on close). The decoded `IImage` is disposed after `SetImage` (which copies pixels) to avoid leaking native Skia memory (Copilot review).

## Test plan
- [x] **Core** (`ImageUtilMapActionAnimationCoreTests`, 17/17): `RenderFrameImage` positive (real LZ77 64×64 4bpp + palette → non-null 64×64 IImage); null rom / zero ptr / out-of-range ptr / no ImageService → null, never throws; **parity** (`DrawFrame` renders through the shared helper); **near-EOF frame row** → null + no throw.
- [x] **Avalonia** (`ToolAnimationCreatorPreviewTests`, 4/4): preview control present + correct AutomationId; placeholder gone; selecting a frame renders a non-empty preview (real SkiaSharp decoder); no-frame → empty.
- [x] **Avalonia screenshot** (`ToolAnimationCreatorPreviewScreenshotTest`, 1/1): drives the real `ToolAnimationCreatorView` (InitFromRom populates Frames, frame 0 selected) and writes the rendered preview pixels via `IImage.EncodePng`.
- [x] All Animation Creator suites green locally (Core 17/17, Avalonia 16/16). Pre-existing Core `config/patch2`-submodule env skips are unrelated (CI inits the submodule).

## Screenshots
**Populated, real running Animation Creator** — opened from the Map Action Animation editor on a real entry; **Frame Count 1**, the frame selected in the Frames list (`Wait: 6`), and the **decoded frame rendered live inside the `GbaImageControl`** (zoom toolbar `- 2x + 1:1`). This is the exact behaviour #1024 adds:

![Populated Animation Creator with live preview](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1024-populated.png)

Standalone rendered preview (the production seam `ImageUtilMapActionAnimationCore.RenderFrameImage` → `SkiaImageService.EncodePng`, the same code the control calls):

![Rendered map-action frame](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1024-animation-creator-preview.png)

> **How the populated capture was produced (transparency):** the bundled stock ROMs under `roms/` don't match the Map Action Animation **list signature search** (`ImageMapActionAnimationViewModel.FindAnimationPointer`), so the source editor reports **0 animations** on them (a limitation of the #501 editor, unrelated to this change). For this capture I injected one valid map-action animation (signature + list table + 12-byte frame row + LZ77 OBJ + palette) into free space of a throwaway copy of `FE8U.gba`; the editor then discovered it (Read Count 3, with per-entry thumbnails) and the **entire flow runs through unmodified production code** — list → "Open in Animation Creator" → `InitFromRom` → frame select → `RenderFrameImage` → `GbaImageControl`. No app code is altered for the screenshot; the throwaway ROM is not committed.

## GUI Test Report
| Case | Result |
| --- | --- |
| Map Action editor discovers the animation, opens it in the Creator | ✅ live |
| Animation Creator populated (name, Frame Count 1, frame in list) | ✅ `pr1024-populated.png` |
| Selected frame renders live in the `GbaImageControl` (zoom toolbar visible) | ✅ `pr1024-populated.png` |
| Production seam decodes a map-action frame (real Skia) | ✅ `pr1024-animation-creator-preview.png` |
| Preview re-renders on frame selection / pointer change | ✅ Avalonia preview tests |
| No-frame → preview cleared | ✅ Avalonia preview test |
| Decoded IImage disposed after SetImage (no Skia leak) | ✅ `using` in RenderPreview |

🤖 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.168` · model `claude-opus-4-8[1m]`
