### PR TITLE
feat(avalonia): Unit Palette New Palette Allocation — fresh block alloc + P12 repoint (#1067)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteParityTests.cs
@@ -169,10 +169,58 @@ namespace FEBuilderGBA.Avalonia.Tests
         {
             var view = new ImageUnitPaletteView();
             // #1006: Clipboard / Zoom / UNDO / REDO are now wired — they are no
-            // longer disabled KnownGap stubs (see WiredControls_AreEnabled). Only
-            // the two ROM-mutating allocation surfaces remain deferred stubs.
-            Assert.False(FindByAutomationId<Button>(view, "ImageUnitPalette_NewAlloc_Button")!.IsEnabled);
+            // longer disabled KnownGap stubs (see WiredControls_AreEnabled).
+            // #1067: New Palette Allocation is now wired too (NewAlloc_AreEnabled).
+            // Only the Expand List surface remains a deferred stub (split to a
+            // follow-up).
             Assert.False(FindByAutomationId<Button>(view, "ImageUnitPalette_Expand_Button")!.IsEnabled);
+        }
+
+        // ===== #1067: New Palette Allocation wiring =====
+
+        [AvaloniaFact]
+        public void NewAlloc_Button_IsEnabled()
+        {
+            var view = new ImageUnitPaletteView();
+            // #1067: the New Palette Allocation button is now wired + enabled.
+            Assert.True(FindByAutomationId<Button>(view, "ImageUnitPalette_NewAlloc_Button")!.IsEnabled);
+        }
+
+        [Fact]
+        public void Axaml_NewAlloc_HasHandler_AndNoStubTooltip_NorDisabled()
+        {
+            string axaml = ReadViewAxaml();
+            // The button has a Click handler.
+            Assert.Contains("Click=\"NewAlloc_Click\"", axaml);
+
+            string element = ExtractElement(axaml, "ImageUnitPalette_NewAlloc_Button");
+            // No longer disabled.
+            Assert.DoesNotContain("IsEnabled=\"False\"", element);
+            // The old "tracked separately" stub tooltip is gone; a meaningful
+            // tooltip is present.
+            Assert.DoesNotContain("tracked separately", element);
+            Assert.DoesNotContain("KnownGap", element);
+            Assert.Contains("repoint this slot's P12", element);
+        }
+
+        [Fact]
+        public void View_NewAllocClick_WrapsInUndoScope_AndCallsAllocNewPalette()
+        {
+            string src = ReadViewSource();
+            // NewAlloc_Click opens an undo scope, calls the Core seam, and
+            // commits / rolls back like PerformPaletteWrite.
+            Assert.Matches(new System.Text.RegularExpressions.Regex(
+                @"void\s+NewAlloc_Click\([^)]*\)\s*\{[\s\S]*?_undoService\.Begin\(",
+                System.Text.RegularExpressions.RegexOptions.Singleline), src);
+            Assert.Matches(new System.Text.RegularExpressions.Regex(
+                @"void\s+NewAlloc_Click\([^)]*\)\s*\{[\s\S]*?UnitPaletteWriteCore\.AllocNewPalette\(",
+                System.Text.RegularExpressions.RegexOptions.Singleline), src);
+            Assert.Matches(new System.Text.RegularExpressions.Regex(
+                @"void\s+NewAlloc_Click\([^)]*\)\s*\{[\s\S]*?U\.NOT_FOUND[\s\S]*?_undoService\.Rollback\(\)",
+                System.Text.RegularExpressions.RegexOptions.Singleline), src);
+            Assert.Matches(new System.Text.RegularExpressions.Regex(
+                @"void\s+NewAlloc_Click\([^)]*\)\s*\{[\s\S]*?_undoService\.Commit\(\)",
+                System.Text.RegularExpressions.RegexOptions.Singleline), src);
         }
 
         // ===== #1006: Clipboard / Zoom / UNDO / REDO wiring =====
@@ -237,9 +285,10 @@ namespace FEBuilderGBA.Avalonia.Tests
         public void Axaml_DeferredControls_RemainDisabled_WithNonKnownGapTooltip()
         {
             string axaml = ReadViewAxaml();
+            // #1067: NewAlloc is now wired; only Expand List remains a deferred
+            // stub (split to a follow-up).
             foreach (var aid in new[]
             {
-                "ImageUnitPalette_NewAlloc_Button",
                 "ImageUnitPalette_Expand_Button",
             })
             {

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml
@@ -94,8 +94,8 @@
                          Name="PalettePointerBox" Width="160" HorizontalAlignment="Left" />
 
                 <Button AutomationProperties.AutomationId="ImageUnitPalette_NewAlloc_Button"
-                        Content="New Palette Allocation" Margin="0,4,0,0" IsEnabled="False"
-                        ToolTip.Tip="Pending Core alloc+repoint / DataExpansionCore wiring — tracked separately" />
+                        Content="New Palette Allocation" Margin="0,4,0,0" Click="NewAlloc_Click"
+                        ToolTip.Tip="Allocate a fresh palette block in free space and repoint this slot's P12" />
 
                 <Button AutomationProperties.AutomationId="ImageUnitPalette_Write_Button"
                         Content="Write" Name="WriteButton" Click="Write_Click" Margin="0,8,0,0" />

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
@@ -433,6 +433,66 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         /// <summary>
+        /// #1067: "New Palette Allocation" — allocate a FRESH free-space palette
+        /// block for the selected row and repoint its P12 pointer, giving the
+        /// slot its OWN independent palette (no longer sharing the previous
+        /// block). Mirrors <see cref="PerformPaletteWrite"/> exactly: same
+        /// spinner read, same paletteIndex/override-all read, same single undo
+        /// scope (Begin / Commit / Rollback) + reload + MarkClean. The only
+        /// difference is the Core seam — <see cref="UnitPaletteWriteCore.AllocNewPalette"/>
+        /// always appends + repoints (never in-place), and leaves the OLD block
+        /// untouched for shared-palette safety.
+        /// </summary>
+        void NewAlloc_Click(object? sender, RoutedEventArgs e)
+        {
+            if (_vm.CurrentAddr == 0)
+            {
+                Log.Error("ImageUnitPaletteView.NewAlloc: no selected entry.");
+                return;
+            }
+            var r = new uint[16];
+            var g = new uint[16];
+            var b = new uint[16];
+            for (int i = 0; i < 16; i++)
+            {
+                r[i] = (uint)(_rBoxes[i]?.Value ?? 0);
+                g[i] = (uint)(_gBoxes[i]?.Value ?? 0);
+                b[i] = (uint)(_bBoxes[i]?.Value ?? 0);
+            }
+            int paletteIndex = PaletteTypeCombo.SelectedIndex;
+            if (paletteIndex < 0) paletteIndex = 0;
+            bool isOverrideAll = PaletteOverrideAllCheck.IsChecked ?? false;
+            _undoService.Begin("New Unit Palette Allocation");
+            try
+            {
+                uint newP12 = UnitPaletteWriteCore.AllocNewPalette(
+                    CoreState.ROM,
+                    _vm.CurrentAddr + 12,
+                    r, g, b,
+                    paletteIndex,
+                    isOverrideAll);
+                if (newP12 == U.NOT_FOUND)
+                {
+                    _undoService.Rollback();
+                    Log.Error("ImageUnitPaletteView.NewAlloc: AllocNewPalette returned NOT_FOUND (no free space or write fault).");
+                    CoreState.Services?.ShowError(R._("Failed to allocate a new palette block. Check ROM free space."));
+                    return;
+                }
+                _vm.PalettePointer = newP12;
+                PalettePointerBox.Text = $"0x{newP12:X08}";
+                PaletteAddressBox.Text = $"0x{newP12:X08}";
+                _undoService.Commit();
+                _vm.MarkClean();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("ImageUnitPaletteView.NewAlloc: {0}", ex.Message);
+                CoreState.Services?.ShowError(R._("Failed to allocate a new palette block. Check ROM free space."));
+            }
+        }
+
+        /// <summary>
         /// #904: Export the rendered class battle-anime SAMPLE GRID preview as a
         /// PNG. Delegates to <see cref="Controls.GbaImageControl.ExportPng"/> on
         /// the SamplePreview control — that helper owns the Skia IImage backing

--- a/FEBuilderGBA.Core.Tests/UnitPaletteWriteCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/UnitPaletteWriteCoreTests.cs
@@ -122,9 +122,9 @@ namespace FEBuilderGBA.Core.Tests
         {
             var compressed = LZ77.compress(PackRgb555(MakeUniquePalette().r, MakeUniquePalette().g, MakeUniquePalette().b));
             var (rom, _, p12Slot) = BuildRomWithPaletteAt(compressed);
-            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, p12Slot, null!, new uint[16], new uint[16], 0, false, null));
-            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, p12Slot, new uint[16], null!, new uint[16], 0, false, null));
-            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, p12Slot, new uint[16], new uint[16], null!, 0, false, null));
+            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, p12Slot, null!, new uint[16], new uint[16], 0, false, undo: null));
+            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, p12Slot, new uint[16], null!, new uint[16], 0, false, undo: null));
+            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, p12Slot, new uint[16], new uint[16], null!, 0, false, undo: null));
         }
 
         [Fact]
@@ -132,9 +132,9 @@ namespace FEBuilderGBA.Core.Tests
         {
             var compressed = LZ77.compress(PackRgb555(MakeUniquePalette().r, MakeUniquePalette().g, MakeUniquePalette().b));
             var (rom, _, p12Slot) = BuildRomWithPaletteAt(compressed);
-            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, p12Slot, new uint[15], new uint[16], new uint[16], 0, false, null));
-            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, p12Slot, new uint[16], new uint[17], new uint[16], 0, false, null));
-            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, p12Slot, new uint[16], new uint[16], new uint[8], 0, false, null));
+            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, p12Slot, new uint[15], new uint[16], new uint[16], 0, false, undo: null));
+            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, p12Slot, new uint[16], new uint[17], new uint[16], 0, false, undo: null));
+            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, p12Slot, new uint[16], new uint[16], new uint[8], 0, false, undo: null));
         }
 
         [Fact]
@@ -144,10 +144,10 @@ namespace FEBuilderGBA.Core.Tests
             var (rom, _, p12Slot) = BuildRomWithPaletteAt(compressed);
             var r = new uint[16];
             r[5] = 32; // OUT OF 0-31 range
-            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, p12Slot, r, new uint[16], new uint[16], 0, false, null));
+            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, p12Slot, r, new uint[16], new uint[16], 0, false, undo: null));
             var g = new uint[16];
             g[7] = 0xFFFFFFFF;
-            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, p12Slot, new uint[16], g, new uint[16], 0, false, null));
+            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, p12Slot, new uint[16], g, new uint[16], 0, false, undo: null));
         }
 
         [Fact]
@@ -156,7 +156,7 @@ namespace FEBuilderGBA.Core.Tests
             var compressed = LZ77.compress(PackRgb555(MakeUniquePalette().r, MakeUniquePalette().g, MakeUniquePalette().b));
             var (rom, _, p12Slot) = BuildRomWithPaletteAt(compressed);
             var (r, g, b) = MakeUniformPalette();
-            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, p12Slot, r, g, b, -1, false, null));
+            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, p12Slot, r, g, b, -1, false, undo: null));
         }
 
         [Fact]
@@ -167,7 +167,7 @@ namespace FEBuilderGBA.Core.Tests
             rom.SwapNewROMDataDirect(data);
             CoreState.ROM = rom;
             var (r, g, b) = MakeUniquePalette();
-            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, 0x4Cu, r, g, b, 0, false, null));
+            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, 0x4Cu, r, g, b, 0, false, undo: null));
         }
 
         [Fact]
@@ -184,7 +184,7 @@ namespace FEBuilderGBA.Core.Tests
             rom.SwapNewROMDataDirect(data);
             CoreState.ROM = rom;
             var (r, g, b) = MakeUniquePalette();
-            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, 0x4Cu, r, g, b, 0, false, null));
+            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, 0x4Cu, r, g, b, 0, false, undo: null));
         }
 
         // ===== Single-slot in-place writes (no other slots present) =====
@@ -198,7 +198,7 @@ namespace FEBuilderGBA.Core.Tests
             uint origP12 = rom.u32(p12Slot);
             int origLen = rom.Data.Length;
 
-            uint result = UnitPaletteWriteCore.WritePalette(rom, p12Slot, rInit, gInit, bInit, 0, false, null);
+            uint result = UnitPaletteWriteCore.WritePalette(rom, p12Slot, rInit, gInit, bInit, 0, false, undo: null);
 
             Assert.Equal(origP12, result);
             Assert.Equal(origP12, rom.u32(p12Slot));
@@ -223,7 +223,7 @@ namespace FEBuilderGBA.Core.Tests
                 "Test invariant: uniform palette must compress smaller than unique palette.");
             int origRomLen = rom.Data.Length;
 
-            uint result = UnitPaletteWriteCore.WritePalette(rom, p12Slot, rNew, gNew, bNew, 0, false, null);
+            uint result = UnitPaletteWriteCore.WritePalette(rom, p12Slot, rNew, gNew, bNew, 0, false, undo: null);
 
             Assert.Equal(origP12, result);
             Assert.Equal(origP12, rom.u32(p12Slot));
@@ -258,7 +258,7 @@ namespace FEBuilderGBA.Core.Tests
             Assert.True(newCompressedExpected.Length > oldCompressedLen,
                 "Test invariant: unique palette must compress larger than the uniform initial.");
 
-            uint result = UnitPaletteWriteCore.WritePalette(rom, p12Slot, rNew, gNew, bNew, 0, false, null);
+            uint result = UnitPaletteWriteCore.WritePalette(rom, p12Slot, rNew, gNew, bNew, 0, false, undo: null);
 
             Assert.NotEqual(origP12, result);
             // Round-2 explicit ask: P12 slot updated to the new pointer.
@@ -282,7 +282,7 @@ namespace FEBuilderGBA.Core.Tests
             var (rom, _, p12Slot) = BuildRomWithPaletteAt(initialCompressed);
 
             var (rNew, gNew, bNew) = MakeUniquePalette();
-            uint newP12 = UnitPaletteWriteCore.WritePalette(rom, p12Slot, rNew, gNew, bNew, 0, false, null);
+            uint newP12 = UnitPaletteWriteCore.WritePalette(rom, p12Slot, rNew, gNew, bNew, 0, false, undo: null);
             Assert.NotEqual(U.NOT_FOUND, newP12);
             byte[] decompressed = LZ77.decompress(rom.Data, U.toOffset(newP12));
             Assert.Equal(32, decompressed.Length);
@@ -311,7 +311,7 @@ namespace FEBuilderGBA.Core.Tests
             uint[] r = new uint[16], g = new uint[16], b = new uint[16];
             for (int i = 0; i < 16; i++) { r[i] = 31; g[i] = 31; b[i] = 31; }
 
-            uint result = UnitPaletteWriteCore.WritePalette(rom, p12Slot, r, g, b, 0, false, null);
+            uint result = UnitPaletteWriteCore.WritePalette(rom, p12Slot, r, g, b, 0, false, undo: null);
             Assert.NotEqual(U.NOT_FOUND, result);
 
             byte[] decompressed = LZ77.decompress(rom.Data, U.toOffset(rom.u32(p12Slot)));
@@ -345,7 +345,7 @@ namespace FEBuilderGBA.Core.Tests
             // New Gray palette = pure red
             uint[] r = new uint[16], g = new uint[16], b = new uint[16];
             for (int i = 0; i < 16; i++) { r[i] = 31; g[i] = 0; b[i] = 0; }
-            uint result = UnitPaletteWriteCore.WritePalette(rom, p12Slot, r, g, b, 3, false, null);
+            uint result = UnitPaletteWriteCore.WritePalette(rom, p12Slot, r, g, b, 3, false, undo: null);
             Assert.NotEqual(U.NOT_FOUND, result);
 
             byte[] decompressed = LZ77.decompress(rom.Data, U.toOffset(rom.u32(p12Slot)));
@@ -375,7 +375,7 @@ namespace FEBuilderGBA.Core.Tests
             // Pure blue for all slots.
             uint[] r = new uint[16], g = new uint[16], b = new uint[16];
             for (int i = 0; i < 16; i++) { r[i] = 0; g[i] = 0; b[i] = 31; }
-            uint result = UnitPaletteWriteCore.WritePalette(rom, p12Slot, r, g, b, 0, true, null);
+            uint result = UnitPaletteWriteCore.WritePalette(rom, p12Slot, r, g, b, 0, true, undo: null);
             Assert.NotEqual(U.NOT_FOUND, result);
 
             byte[] decompressed = LZ77.decompress(rom.Data, U.toOffset(rom.u32(p12Slot)));
@@ -404,7 +404,7 @@ namespace FEBuilderGBA.Core.Tests
 
             uint[] r = new uint[16], g = new uint[16], b = new uint[16];
             for (int i = 0; i < 16; i++) { r[i] = 1; g[i] = 2; b[i] = 3; }
-            uint result = UnitPaletteWriteCore.WritePalette(rom, p12Slot, r, g, b, 2, false, null);
+            uint result = UnitPaletteWriteCore.WritePalette(rom, p12Slot, r, g, b, 2, false, undo: null);
             Assert.NotEqual(U.NOT_FOUND, result);
 
             byte[] decompressed = LZ77.decompress(rom.Data, U.toOffset(rom.u32(p12Slot)));
@@ -447,7 +447,7 @@ namespace FEBuilderGBA.Core.Tests
             using (ROM.BeginUndoScope(undo))
             {
                 var (rNew, gNew, bNew) = MakeUniformPalette();
-                uint result = UnitPaletteWriteCore.WritePalette(rom, p12Slot, rNew, gNew, bNew, 0, false, undo);
+                uint result = UnitPaletteWriteCore.WritePalette(rom, p12Slot, rNew, gNew, bNew, 0, false, undo: undo);
                 Assert.NotEqual(U.NOT_FOUND, result);
             }
             // Ambient scope recorded at least one entry per write_*: write_range
@@ -477,7 +477,7 @@ namespace FEBuilderGBA.Core.Tests
             using (ROM.BeginUndoScope(undo))
             {
                 var (rNew, gNew, bNew) = MakeUniquePalette();
-                uint result = UnitPaletteWriteCore.WritePalette(rom, p12Slot, rNew, gNew, bNew, 0, false, undo);
+                uint result = UnitPaletteWriteCore.WritePalette(rom, p12Slot, rNew, gNew, bNew, 0, false, undo: undo);
                 Assert.NotEqual(U.NOT_FOUND, result);
                 Assert.NotEqual(origP12, result);
             }
@@ -519,7 +519,7 @@ namespace FEBuilderGBA.Core.Tests
             using (ROM.BeginUndoScope(undo))
             {
                 var (rNew, gNew, bNew) = MakeUniformPalette();
-                UnitPaletteWriteCore.WritePalette(rom, p12Slot, rNew, gNew, bNew, 0, false, undo);
+                UnitPaletteWriteCore.WritePalette(rom, p12Slot, rNew, gNew, bNew, 0, false, undo: undo);
             }
 
             // Each address should appear AT MOST ONCE in the undo list
@@ -562,6 +562,313 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Equal(0x03E0, c1);
             ushort c2 = (ushort)(raw[4] | (raw[5] << 8));
             Assert.Equal(0x7C00, c2);
+        }
+
+        // ===== #1067: New Palette Allocation (AllocNewPalette) =====
+
+        /// <summary>Decode a 16-color RGB555 bank from the decompressed buffer at
+        /// the given slot index into per-channel arrays.</summary>
+        static (uint[] r, uint[] g, uint[] b) DecodeBank(byte[] decompressed, int slot)
+        {
+            var r = new uint[16];
+            var g = new uint[16];
+            var b = new uint[16];
+            for (int i = 0; i < 16; i++)
+            {
+                ushort c = (ushort)(decompressed[slot * 32 + i * 2] | (decompressed[slot * 32 + i * 2 + 1] << 8));
+                r[i] = (uint)(c & 0x1F);
+                g[i] = (uint)((c >> 5) & 0x1F);
+                b[i] = (uint)((c >> 10) & 0x1F);
+            }
+            return (r, g, b);
+        }
+
+        // (1) AllocNewPalette repoints P12 to a NEW offset even when the
+        // recompressed bytes would have fit in-place (forced append).
+        [Fact]
+        public void AllocNewPalette_ForcesAppend_RepointsP12_EvenWhenFitsInPlace()
+        {
+            // Two-bank initial stream so multi-bank is exercised.
+            byte[] rawInit = BuildMultiSlotRaw(2);
+            byte[] initialCompressed = LZ77.compress(rawInit);
+            var (rom, _, p12Slot) = BuildRomWithPaletteAt(initialCompressed);
+            uint origP12 = rom.u32(p12Slot);
+            int origRomLen = rom.Data.Length;
+
+            // Edit bank 0 to a UNIFORM palette so the recompressed bytes would
+            // compress SMALLER than (or equal to) the original — i.e. the
+            // default WritePalette path would have taken the in-place branch.
+            var (rNew, gNew, bNew) = MakeUniformPalette();
+
+            uint result = UnitPaletteWriteCore.AllocNewPalette(rom, p12Slot, rNew, gNew, bNew, 0, false);
+
+            Assert.NotEqual(U.NOT_FOUND, result);
+            // P12 was repointed to a brand-new offset (NOT the original).
+            Assert.NotEqual(origP12, result);
+            Assert.Equal(result, rom.u32(p12Slot));
+            Assert.NotEqual(origP12, rom.u32(p12Slot));
+            // ROM grew (appended at the end).
+            Assert.True(rom.Data.Length > origRomLen, $"ROM should grow: was {origRomLen}, now {rom.Data.Length}");
+            Assert.True(U.toOffset(result) >= (uint)origRomLen, "new block should live in the appended region");
+        }
+
+        // (2) The new stream decodes back to the edited colors for the selected bank.
+        [Fact]
+        public void AllocNewPalette_NewStream_DecodesEditedBank()
+        {
+            byte[] rawInit = BuildMultiSlotRaw(2);
+            byte[] initialCompressed = LZ77.compress(rawInit);
+            var (rom, _, p12Slot) = BuildRomWithPaletteAt(initialCompressed);
+
+            // Distinctive edited palette for bank 1.
+            var (rNew, gNew, bNew) = MakeUniquePalette();
+            uint result = UnitPaletteWriteCore.AllocNewPalette(rom, p12Slot, rNew, gNew, bNew, 1, false);
+            Assert.NotEqual(U.NOT_FOUND, result);
+
+            byte[] decompressed = LZ77.decompress(rom.Data, U.toOffset(rom.u32(p12Slot)));
+            Assert.Equal(2 * 32, decompressed.Length);
+            var (rGot, gGot, bGot) = DecodeBank(decompressed, 1);
+            Assert.Equal(rNew, rGot);
+            Assert.Equal(gNew, gGot);
+            Assert.Equal(bNew, bGot);
+        }
+
+        // (3) The untouched bank(s) are preserved verbatim in the new stream.
+        [Fact]
+        public void AllocNewPalette_PreservesUntouchedBanks()
+        {
+            byte[] rawInit = BuildMultiSlotRaw(2);
+            byte[] initialCompressed = LZ77.compress(rawInit);
+            var (rom, _, p12Slot) = BuildRomWithPaletteAt(initialCompressed);
+
+            // Edit bank 0 only -> bank 1 must survive byte-identical to rawInit.
+            uint[] r = new uint[16], g = new uint[16], b = new uint[16];
+            for (int i = 0; i < 16; i++) { r[i] = 31; g[i] = 31; b[i] = 31; } // pure white
+            uint result = UnitPaletteWriteCore.AllocNewPalette(rom, p12Slot, r, g, b, 0, false);
+            Assert.NotEqual(U.NOT_FOUND, result);
+
+            byte[] decompressed = LZ77.decompress(rom.Data, U.toOffset(rom.u32(p12Slot)));
+            Assert.Equal(2 * 32, decompressed.Length);
+            // Bank 0 = pure white.
+            for (int i = 0; i < 16; i++)
+            {
+                ushort c = (ushort)(decompressed[i * 2] | (decompressed[i * 2 + 1] << 8));
+                Assert.Equal(0x7FFF, c);
+            }
+            // Bank 1 = untouched (verbatim from rawInit).
+            for (int i = 0; i < 32; i++)
+            {
+                Assert.Equal(rawInit[32 + i], decompressed[32 + i]);
+            }
+        }
+
+        // (4) The OLD compressed block bytes are unchanged after alloc (no recycle).
+        [Fact]
+        public void AllocNewPalette_LeavesOldBlockUntouched()
+        {
+            byte[] rawInit = BuildMultiSlotRaw(2);
+            byte[] initialCompressed = LZ77.compress(rawInit);
+            uint initialPaletteOffset = 0x200;
+            var (rom, _, p12Slot) = BuildRomWithPaletteAt(initialCompressed, initialPaletteOffset);
+            uint origP12 = rom.u32(p12Slot);
+            uint oldOffset = U.toOffset(origP12);
+            uint oldLen = LZ77.getCompressedSize(rom.Data, oldOffset);
+
+            // Snapshot the old compressed block.
+            byte[] oldBlock = new byte[oldLen];
+            System.Array.Copy(rom.Data, oldOffset, oldBlock, 0, (int)oldLen);
+
+            var (rNew, gNew, bNew) = MakeUniquePalette();
+            uint result = UnitPaletteWriteCore.AllocNewPalette(rom, p12Slot, rNew, gNew, bNew, 0, false);
+            Assert.NotEqual(U.NOT_FOUND, result);
+            // The new block lives elsewhere.
+            Assert.NotEqual(oldOffset, U.toOffset(result));
+
+            // The OLD block bytes are byte-identical (shared-palette safety).
+            for (uint i = 0; i < oldLen; i++)
+            {
+                Assert.Equal(oldBlock[i], rom.Data[oldOffset + i]);
+            }
+        }
+
+        // (5) Invalid/zero P12 -> deterministic fresh SINGLE 32-byte bank.
+        [Fact]
+        public void AllocNewPalette_ZeroP12_BuildsFreshSingleBank()
+        {
+            // Build a ROM whose row P12 slot is ZERO (no pointer at all).
+            byte[] data = new byte[0x10000];
+            uint rowAddr = 0x40;
+            data[rowAddr + 0] = (byte)'P';
+            data[rowAddr + 1] = (byte)'a';
+            data[rowAddr + 2] = (byte)'l';
+            // P12 (offset +12) left as 0.
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(data);
+            CoreState.ROM = rom;
+            uint p12Slot = rowAddr + 12;
+            int origRomLen = rom.Data.Length;
+
+            var (rNew, gNew, bNew) = MakeUniquePalette();
+            uint result = UnitPaletteWriteCore.AllocNewPalette(rom, p12Slot, rNew, gNew, bNew, 0, false);
+
+            Assert.NotEqual(U.NOT_FOUND, result);
+            Assert.Equal(result, rom.u32(p12Slot));
+            Assert.True(rom.Data.Length > origRomLen);
+
+            byte[] decompressed = LZ77.decompress(rom.Data, U.toOffset(result));
+            // Exactly ONE 32-byte bank (deterministic single slot).
+            Assert.Equal(32, decompressed.Length);
+            var (rGot, gGot, bGot) = DecodeBank(decompressed, 0);
+            Assert.Equal(rNew, rGot);
+            Assert.Equal(gNew, gGot);
+            Assert.Equal(bNew, bGot);
+        }
+
+        [Fact]
+        public void AllocNewPalette_NonLZ77P12_BuildsFreshSingleBank()
+        {
+            // P12 points at junk (non-LZ77). The fresh-single-bank path applies.
+            byte[] data = new byte[0x10000];
+            for (int i = 0; i < 32; i++) data[0x200 + i] = 0xAB; // junk
+            uint rowAddr = 0x40;
+            uint gbaPtr = U.toPointer(0x200);
+            data[rowAddr + 12] = (byte)(gbaPtr & 0xFF);
+            data[rowAddr + 13] = (byte)((gbaPtr >> 8) & 0xFF);
+            data[rowAddr + 14] = (byte)((gbaPtr >> 16) & 0xFF);
+            data[rowAddr + 15] = (byte)((gbaPtr >> 24) & 0xFF);
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(data);
+            CoreState.ROM = rom;
+            uint p12Slot = rowAddr + 12;
+
+            var (rNew, gNew, bNew) = MakeUniformPalette();
+            uint result = UnitPaletteWriteCore.AllocNewPalette(rom, p12Slot, rNew, gNew, bNew, 0, false);
+            Assert.NotEqual(U.NOT_FOUND, result);
+
+            byte[] decompressed = LZ77.decompress(rom.Data, U.toOffset(rom.u32(p12Slot)));
+            Assert.Equal(32, decompressed.Length);
+            var (rGot, gGot, bGot) = DecodeBank(decompressed, 0);
+            Assert.Equal(rNew, rGot);
+            Assert.Equal(gNew, gGot);
+            Assert.Equal(bNew, bGot);
+            // The junk source bytes are left untouched.
+            for (int i = 0; i < 32; i++) Assert.Equal(0xAB, rom.Data[0x200 + i]);
+        }
+
+        // (6) Outer Undo.Rollback restores byte-identical (length + P12 + bytes).
+        [Fact]
+        public void AllocNewPalette_OuterUndo_RestoresByteIdentical()
+        {
+            byte[] rawInit = BuildMultiSlotRaw(2);
+            byte[] initialCompressed = LZ77.compress(rawInit);
+            var (rom, _, p12Slot) = BuildRomWithPaletteAt(initialCompressed);
+
+            var prevUndo = CoreState.Undo;
+            try
+            {
+                CoreState.Undo = new Undo();
+                uint origP12 = rom.u32(p12Slot);
+                byte[] before = (byte[])rom.Data.Clone();
+
+                var (rNew, gNew, bNew) = MakeUniquePalette();
+                Undo.UndoData ud = CoreState.Undo.NewUndoData("AllocNewPalette outer-undo");
+                using (ROM.BeginUndoScope(ud))
+                {
+                    uint result = UnitPaletteWriteCore.AllocNewPalette(rom, p12Slot, rNew, gNew, bNew, 0, false);
+                    Assert.NotEqual(U.NOT_FOUND, result);
+                }
+                if (ud.list.Count > 0)
+                {
+                    CoreState.Undo.Push(ud);
+                    CoreState.Undo.RunUndo();
+                }
+
+                // Byte-identical: length, P12, and every byte.
+                Assert.Equal(before.Length, rom.Data.Length);
+                Assert.Equal(origP12, rom.u32(p12Slot));
+                for (int i = 0; i < before.Length; i++)
+                {
+                    if (before[i] != rom.Data[i])
+                        Assert.Fail($"Byte mismatch at 0x{i:X06}: before=0x{before[i]:X02}, after-undo=0x{rom.Data[i]:X02}");
+                }
+            }
+            finally { CoreState.Undo = prevUndo; }
+        }
+
+        // (7) Regression: WritePalette(forceNewAlloc:false) keeps in-place behavior
+        // byte-identical to the pre-change path (P12 unchanged, in-place write).
+        [Fact]
+        public void WritePalette_ForceNewAllocFalse_StillInPlace_WhenFits()
+        {
+            var (rInit, gInit, bInit) = MakeUniquePalette();
+            byte[] initialCompressed = LZ77.compress(PackRgb555(rInit, gInit, bInit));
+            var (rom, _, p12Slot) = BuildRomWithPaletteAt(initialCompressed);
+            uint origP12 = rom.u32(p12Slot);
+            int origLen = rom.Data.Length;
+
+            // Same-size rewrite -> in-place when forceNewAlloc is false (default).
+            uint result = UnitPaletteWriteCore.WritePalette(
+                rom, p12Slot, rInit, gInit, bInit, 0, false, forceNewAlloc: false, undo: null);
+
+            Assert.Equal(origP12, result);
+            Assert.Equal(origP12, rom.u32(p12Slot)); // P12 unchanged
+            Assert.Equal(origLen, rom.Data.Length);   // no growth (in-place)
+            byte[] decompressed = LZ77.decompress(rom.Data, U.toOffset(origP12));
+            Assert.Equal(PackRgb555(rInit, gInit, bInit), decompressed);
+        }
+
+        [Fact]
+        public void WritePalette_ForceNewAllocTrue_AppendsEvenWhenFits()
+        {
+            // Direct WritePalette force-append (the seam AllocNewPalette uses).
+            var (rInit, gInit, bInit) = MakeUniquePalette();
+            byte[] initialCompressed = LZ77.compress(PackRgb555(rInit, gInit, bInit));
+            var (rom, _, p12Slot) = BuildRomWithPaletteAt(initialCompressed);
+            uint origP12 = rom.u32(p12Slot);
+            int origLen = rom.Data.Length;
+
+            uint result = UnitPaletteWriteCore.WritePalette(
+                rom, p12Slot, rInit, gInit, bInit, 0, false, forceNewAlloc: true, undo: null);
+
+            Assert.NotEqual(origP12, result);
+            Assert.Equal(result, rom.u32(p12Slot));
+            Assert.True(rom.Data.Length > origLen);
+        }
+
+        // (8) Fault restore: a bad input that passes the rom-null guard but fails
+        // validation inside the write must return NOT_FOUND with the ROM
+        // byte-identical (no partial mutation). We inject an out-of-range channel,
+        // which AppendFreshSingleBank / WritePalette both reject AFTER the
+        // snapshot is taken — proving the no-mutation-on-fault contract.
+        [Fact]
+        public void AllocNewPalette_BadInput_ReturnsNotFound_NoMutation()
+        {
+            byte[] rawInit = BuildMultiSlotRaw(2);
+            byte[] initialCompressed = LZ77.compress(rawInit);
+            var (rom, _, p12Slot) = BuildRomWithPaletteAt(initialCompressed);
+            uint origP12 = rom.u32(p12Slot);
+            byte[] before = (byte[])rom.Data.Clone();
+
+            var (r, g, b) = MakeUniquePalette();
+            r[3] = 0xFFFFFFFF; // out of 0-31 range -> rejected before any write
+
+            uint result = UnitPaletteWriteCore.AllocNewPalette(rom, p12Slot, r, g, b, 0, false);
+
+            Assert.Equal(U.NOT_FOUND, result);
+            // ROM byte-identical: length, P12, and every byte.
+            Assert.Equal(before.Length, rom.Data.Length);
+            Assert.Equal(origP12, rom.u32(p12Slot));
+            for (int i = 0; i < before.Length; i++)
+            {
+                Assert.Equal(before[i], rom.Data[i]);
+            }
+        }
+
+        [Fact]
+        public void AllocNewPalette_NullRom_ReturnsNotFound()
+        {
+            var (r, g, b) = MakeUniquePalette();
+            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.AllocNewPalette(null!, 0x4Cu, r, g, b, 0, false));
         }
     }
 }

--- a/FEBuilderGBA.Core.Tests/UnitPaletteWriteCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/UnitPaletteWriteCoreTests.cs
@@ -755,6 +755,68 @@ namespace FEBuilderGBA.Core.Tests
             for (int i = 0; i < 32; i++) Assert.Equal(0xAB, rom.Data[0x200 + i]);
         }
 
+        // (5a) Copilot review: zero P12 + paletteIndex=2 (non-override) -> fresh
+        // buffer is >=3 banks, ONLY bank 2 carries the edited colors, banks 0/1
+        // are all-zero/black.
+        [Fact]
+        public void AllocNewPalette_ZeroP12_HonorsPaletteIndex_NonOverride()
+        {
+            byte[] data = new byte[0x10000];
+            uint rowAddr = 0x40;
+            data[rowAddr + 0] = (byte)'P';
+            // P12 (offset +12) left as 0.
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(data);
+            CoreState.ROM = rom;
+            uint p12Slot = rowAddr + 12;
+
+            var (rNew, gNew, bNew) = MakeUniquePalette();
+            uint result = UnitPaletteWriteCore.AllocNewPalette(rom, p12Slot, rNew, gNew, bNew, 2, false);
+            Assert.NotEqual(U.NOT_FOUND, result);
+            Assert.Equal(result, rom.u32(p12Slot));
+
+            byte[] decompressed = LZ77.decompress(rom.Data, U.toOffset(result));
+            // (paletteIndex + 1) = 3 banks.
+            Assert.Equal(3 * 32, decompressed.Length);
+            // Banks 0 and 1 are all-zero/black (untouched).
+            for (int i = 0; i < 2 * 32; i++) Assert.Equal((byte)0, decompressed[i]);
+            // Bank 2 = the edited colors.
+            var (rGot, gGot, bGot) = DecodeBank(decompressed, 2);
+            Assert.Equal(rNew, rGot);
+            Assert.Equal(gNew, gGot);
+            Assert.Equal(bNew, bGot);
+        }
+
+        // (5b) Copilot review: zero P12 + paletteIndex=2 + isOverrideAll=true ->
+        // ALL 3 banks decode to the edited colors.
+        [Fact]
+        public void AllocNewPalette_ZeroP12_OverrideAll_FillsEveryBank()
+        {
+            byte[] data = new byte[0x10000];
+            uint rowAddr = 0x40;
+            data[rowAddr + 0] = (byte)'P';
+            // P12 (offset +12) left as 0.
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(data);
+            CoreState.ROM = rom;
+            uint p12Slot = rowAddr + 12;
+
+            var (rNew, gNew, bNew) = MakeUniquePalette();
+            uint result = UnitPaletteWriteCore.AllocNewPalette(rom, p12Slot, rNew, gNew, bNew, 2, true);
+            Assert.NotEqual(U.NOT_FOUND, result);
+
+            byte[] decompressed = LZ77.decompress(rom.Data, U.toOffset(rom.u32(p12Slot)));
+            Assert.Equal(3 * 32, decompressed.Length);
+            // EVERY bank decodes to the edited colors.
+            for (int s = 0; s < 3; s++)
+            {
+                var (rGot, gGot, bGot) = DecodeBank(decompressed, s);
+                Assert.Equal(rNew, rGot);
+                Assert.Equal(gNew, gGot);
+                Assert.Equal(bNew, bGot);
+            }
+        }
+
         // (6) Outer Undo.Rollback restores byte-identical (length + P12 + bytes).
         [Fact]
         public void AllocNewPalette_OuterUndo_RestoresByteIdentical()
@@ -838,7 +900,7 @@ namespace FEBuilderGBA.Core.Tests
         // (8) Fault restore: a bad input that passes the rom-null guard but fails
         // validation inside the write must return NOT_FOUND with the ROM
         // byte-identical (no partial mutation). We inject an out-of-range channel,
-        // which AppendFreshSingleBank / WritePalette both reject AFTER the
+        // which AppendFreshBanks / WritePalette both reject AFTER the
         // snapshot is taken — proving the no-mutation-on-fault contract.
         [Fact]
         public void AllocNewPalette_BadInput_ReturnsNotFound_NoMutation()

--- a/FEBuilderGBA.Core/UnitPaletteWriteCore.cs
+++ b/FEBuilderGBA.Core/UnitPaletteWriteCore.cs
@@ -232,12 +232,17 @@ namespace FEBuilderGBA
         /// decompressed stream, and preserves the untouched banks.
         ///
         /// Invalid / zero / non-LZ77 P12: there is no existing stream to splice
-        /// into, so a DETERMINISTIC fresh SINGLE 32-byte bank is built from the
-        /// supplied R/G/B (16 colors), LZ77-compressed, appended at ROM end, and
-        /// the P12 slot repointed to it. (<see cref="WritePalette"/> itself
-        /// early-outs to <see cref="U.NOT_FOUND"/> for a bad pointer because it
-        /// must not invent a stream during an in-place write; the New-Alloc flow
-        /// always allocates, so a fresh slot is the well-defined result.)
+        /// into, so a DETERMINISTIC fresh buffer is built that still HONORS the
+        /// requested bank — <c>(paletteIndex + 1)</c> 32-byte banks, zero-filled,
+        /// with the supplied colors written into bank
+        /// <paramref name="paletteIndex"/> (or EVERY bank when
+        /// <paramref name="isOverrideAll"/>), LZ77-compressed, appended at ROM
+        /// end, and the P12 slot repointed to it. For <c>paletteIndex == 0</c>
+        /// non-override this is a single 32-byte bank.
+        /// (<see cref="WritePalette"/> itself early-outs to
+        /// <see cref="U.NOT_FOUND"/> for a bad pointer because it must not invent
+        /// a stream during an in-place write; the New-Alloc flow always
+        /// allocates, so a fresh slot is the well-defined result.)
         ///
         /// The OLD compressed block is left UNTOUCHED (no recycle) — this is the
         /// shared-palette safety guarantee: another slot may still reference it.
@@ -293,9 +298,10 @@ namespace FEBuilderGBA
                 else
                 {
                     // No existing stream to splice into (zero / non-pointer /
-                    // non-LZ77 P12): build a deterministic fresh single bank,
+                    // non-LZ77 P12): build a deterministic fresh buffer that
+                    // honors the requested bank (paletteIndex) + override-all,
                     // append + repoint.
-                    result = AppendFreshSingleBank(rom, rowP12SlotOffset, r, g, b);
+                    result = AppendFreshBanks(rom, rowP12SlotOffset, r, g, b, paletteIndex, isOverrideAll);
                 }
                 if (result == U.NOT_FOUND)
                 {
@@ -340,16 +346,29 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
-        /// Build a DETERMINISTIC fresh SINGLE 32-byte palette bank from the
-        /// supplied R/G/B (16 colors), LZ77-compress it, append at ROM end, and
-        /// repoint the P12 slot to it. Used by <see cref="AllocNewPalette"/> when
-        /// the slot has no existing LZ77 stream to splice into. Validates the
-        /// R/G/B inputs exactly like <see cref="WritePalette"/> and returns
-        /// <see cref="U.NOT_FOUND"/> on bad input or a resize failure (the caller
-        /// restores the snapshot). Writes record into the caller's ambient undo
-        /// scope.
+        /// Build a DETERMINISTIC fresh palette buffer that HONORS the requested
+        /// bank, LZ77-compress it, append at ROM end, and repoint the P12 slot to
+        /// it. Used by <see cref="AllocNewPalette"/> when the slot has no existing
+        /// LZ77 stream to splice into. Mirrors <see cref="WritePalette"/>'s
+        /// resize/splice semantics applied to a fresh zero-filled buffer:
+        /// <list type="bullet">
+        /// <item>The buffer is <c>(paletteIndex + 1)</c> 32-byte banks long, so
+        /// the requested bank index is in range and any lower banks stay
+        /// black/zero.</item>
+        /// <item>When <paramref name="isOverrideAll"/> is true, the packed colors
+        /// fill EVERY 32-byte bank; otherwise only bank
+        /// <paramref name="paletteIndex"/> is written and lower banks stay zero.</item>
+        /// </list>
+        /// So <c>paletteIndex == 0</c> (non-override) is a single 32-byte bank
+        /// (backward compatible). Validates the R/G/B inputs and
+        /// <paramref name="paletteIndex"/> exactly like <see cref="WritePalette"/>
+        /// and returns <see cref="U.NOT_FOUND"/> on bad input or a resize failure
+        /// (the caller restores the snapshot). Writes record into the caller's
+        /// ambient undo scope.
         /// </summary>
-        static uint AppendFreshSingleBank(ROM rom, uint rowP12SlotOffset, uint[] r, uint[] g, uint[] b)
+        static uint AppendFreshBanks(
+            ROM rom, uint rowP12SlotOffset, uint[] r, uint[] g, uint[] b,
+            int paletteIndex, bool isOverrideAll)
         {
             if (r == null || g == null || b == null) return U.NOT_FOUND;
             if (r.Length != PALETTE_COUNT || g.Length != PALETTE_COUNT || b.Length != PALETTE_COUNT)
@@ -358,9 +377,27 @@ namespace FEBuilderGBA
             {
                 if (r[i] > 0x1F || g[i] > 0x1F || b[i] > 0x1F) return U.NOT_FOUND;
             }
+            if (paletteIndex < 0) return U.NOT_FOUND;
             if (rowP12SlotOffset + 4 > (uint)rom.Data.Length) return U.NOT_FOUND;
 
-            byte[] raw = PackRgb555(r, g, b);
+            byte[] newSlot = PackRgb555(r, g, b);
+
+            // Zero-filled buffer large enough to hold the requested bank index;
+            // lower banks remain black until the user edits them.
+            int bankCount = paletteIndex + 1;
+            byte[] raw = new byte[bankCount * RAW_PALETTE_BYTES];
+            if (isOverrideAll)
+            {
+                for (int s = 0; s < bankCount; s++)
+                {
+                    System.Buffer.BlockCopy(newSlot, 0, raw, s * RAW_PALETTE_BYTES, RAW_PALETTE_BYTES);
+                }
+            }
+            else
+            {
+                System.Buffer.BlockCopy(newSlot, 0, raw, paletteIndex * RAW_PALETTE_BYTES, RAW_PALETTE_BYTES);
+            }
+
             byte[] compressed = LZ77.compress(raw);
 
             uint appendOffset = (uint)rom.Data.Length;

--- a/FEBuilderGBA.Core/UnitPaletteWriteCore.cs
+++ b/FEBuilderGBA.Core/UnitPaletteWriteCore.cs
@@ -20,6 +20,8 @@
 // Cross-platform: depends only on Core LZ77 + ROM + U helpers. No WinForms,
 // no Avalonia, no System.Drawing dependencies.
 
+using System;
+
 namespace FEBuilderGBA
 {
     public static class UnitPaletteWriteCore
@@ -90,6 +92,15 @@ namespace FEBuilderGBA
         /// When true, every 32-byte slot in the decompressed stream is replaced
         /// with the new colors (matches WF `PaletteFormRef.OVERRAIDE_ALL_PALETTE`).
         /// </param>
+        /// <param name="forceNewAlloc">
+        /// When true, the in-place branch is skipped entirely and the helper
+        /// ALWAYS takes the reallocate (append at ROM end + repoint P12) path,
+        /// even when the new compressed bytes would fit within the original
+        /// buffer. This gives the slot its OWN independent palette block in free
+        /// space (the "New Palette Allocation" flow, #1067). The default
+        /// <c>false</c> preserves the original in-place-or-reallocate behavior
+        /// byte-identically — existing callers are unaffected.
+        /// </param>
         /// <param name="undo">
         /// Accepted for API parity but UNUSED. The helper relies on the
         /// caller having opened an ambient undo scope via
@@ -112,7 +123,8 @@ namespace FEBuilderGBA
             uint[] b,
             int paletteIndex,
             bool isOverrideAll,
-            Undo.UndoData? undo)
+            bool forceNewAlloc = false,
+            Undo.UndoData? undo = null)
         {
             // `undo` is intentionally ignored — see XML doc.
             _ = undo;
@@ -174,7 +186,10 @@ namespace FEBuilderGBA
             uint newCompressedLen = (uint)compressed.Length;
 
             // ----- In-place vs reallocate (writes go through the ambient undo scope) -----
-            if (newCompressedLen <= oldCompressedLen)
+            // forceNewAlloc skips the in-place branch entirely and always
+            // appends + repoints, giving the slot its own independent palette
+            // block (the "New Palette Allocation" flow, #1067).
+            if (!forceNewAlloc && newCompressedLen <= oldCompressedLen)
             {
                 rom.write_range(srcOffset, compressed);
                 uint trailing = oldCompressedLen - newCompressedLen;
@@ -199,6 +214,176 @@ namespace FEBuilderGBA
                 rom.write_p32(rowP12SlotOffset, appendOffset);
                 return newPointer;
             }
+        }
+
+        /// <summary>
+        /// Allocate a FRESH free-space palette block for the row's P12 slot and
+        /// repoint the slot to it (the "New Palette Allocation" flow, #1067).
+        /// Unlike <see cref="WritePalette"/> with the default in-place branch,
+        /// this ALWAYS appends a brand-new LZ77-compressed block at ROM end and
+        /// repoints P12 — even when the recompressed bytes would have fit in the
+        /// original buffer — so the slot gets its OWN independent palette and no
+        /// longer shares the previous block with any other slot.
+        ///
+        /// Multi-bank correctness: when the P12 slot points at a valid LZ77
+        /// stream this reuses <see cref="WritePalette"/>'s splice logic, so it
+        /// overwrites ONLY the <paramref name="paletteIndex"/> 32-byte bank
+        /// (unless <paramref name="isOverrideAll"/>), recompresses the FULL
+        /// decompressed stream, and preserves the untouched banks.
+        ///
+        /// Invalid / zero / non-LZ77 P12: there is no existing stream to splice
+        /// into, so a DETERMINISTIC fresh SINGLE 32-byte bank is built from the
+        /// supplied R/G/B (16 colors), LZ77-compressed, appended at ROM end, and
+        /// the P12 slot repointed to it. (<see cref="WritePalette"/> itself
+        /// early-outs to <see cref="U.NOT_FOUND"/> for a bad pointer because it
+        /// must not invent a stream during an in-place write; the New-Alloc flow
+        /// always allocates, so a fresh slot is the well-defined result.)
+        ///
+        /// The OLD compressed block is left UNTOUCHED (no recycle) — this is the
+        /// shared-palette safety guarantee: another slot may still reference it.
+        ///
+        /// Fault restore: a defensive byte-for-byte snapshot is taken before any
+        /// mutation. If the underlying write throws OR returns
+        /// <see cref="U.NOT_FOUND"/> (no free space / resize failure), the ROM is
+        /// restored byte-identical (length-aware, since a free-space append can
+        /// GROW <c>rom.Data</c>) and <see cref="U.NOT_FOUND"/> is returned. This
+        /// method NEVER throws.
+        ///
+        /// Undo handling matches <see cref="WritePalette"/>: writes record into
+        /// the caller's ambient <see cref="ROM.BeginUndoScope"/> automatically.
+        /// </summary>
+        /// <param name="rom">ROM to mutate. Must be non-null.</param>
+        /// <param name="rowP12SlotOffset">ROM offset of the row's P12 pointer slot.</param>
+        /// <param name="r">16 R channel values in 0-31 range.</param>
+        /// <param name="g">16 G channel values in 0-31 range.</param>
+        /// <param name="b">16 B channel values in 0-31 range.</param>
+        /// <param name="paletteIndex">Zero-based slot index to overwrite (ignored when override-all).</param>
+        /// <param name="isOverrideAll">When true, every 32-byte slot is replaced.</param>
+        /// <returns>
+        /// The freshly-allocated GBA pointer (0x08xxxxxx) the P12 slot now holds,
+        /// or <see cref="U.NOT_FOUND"/> on any invalid input or write fault (with
+        /// the ROM restored byte-identical).
+        /// </returns>
+        public static uint AllocNewPalette(
+            ROM rom,
+            uint rowP12SlotOffset,
+            uint[] r,
+            uint[] g,
+            uint[] b,
+            int paletteIndex,
+            bool isOverrideAll)
+        {
+            if (rom == null) return U.NOT_FOUND;
+
+            // Defensive snapshot — restored byte-identical on ANY fault so a
+            // failed alloc never leaves the ROM half-mutated (the #885/#923
+            // WaitIconImportCore / SkillSystemsAnimeImportCore pattern).
+            byte[] snapshot = (byte[])rom.Data.Clone();
+            try
+            {
+                uint result;
+                if (HasValidLz77Source(rom, rowP12SlotOffset))
+                {
+                    // Existing multi-bank stream: splice + force-append (preserves
+                    // untouched banks).
+                    result = WritePalette(
+                        rom, rowP12SlotOffset, r, g, b, paletteIndex, isOverrideAll,
+                        forceNewAlloc: true, undo: null);
+                }
+                else
+                {
+                    // No existing stream to splice into (zero / non-pointer /
+                    // non-LZ77 P12): build a deterministic fresh single bank,
+                    // append + repoint.
+                    result = AppendFreshSingleBank(rom, rowP12SlotOffset, r, g, b);
+                }
+                if (result == U.NOT_FOUND)
+                {
+                    RestoreSnapshot(rom, snapshot);
+                    return U.NOT_FOUND;
+                }
+                return result;
+            }
+            catch (Exception)
+            {
+                RestoreSnapshot(rom, snapshot);
+                return U.NOT_FOUND;
+            }
+        }
+
+        /// <summary>
+        /// True when the P12 slot at <paramref name="rowP12SlotOffset"/> holds a
+        /// valid in-bounds pointer to a decodable LZ77 stream of at least one
+        /// 32-byte palette bank — i.e. the same preconditions
+        /// <see cref="WritePalette"/> requires before it splices. Mirrors that
+        /// validation exactly so the splice-vs-fresh decision in
+        /// <see cref="AllocNewPalette"/> never feeds <see cref="WritePalette"/> a
+        /// pointer it would reject. Guarded against every fault; never throws.
+        /// </summary>
+        static bool HasValidLz77Source(ROM rom, uint rowP12SlotOffset)
+        {
+            try
+            {
+                if (rowP12SlotOffset + 4 > (uint)rom.Data.Length) return false;
+                uint rawP12 = rom.u32(rowP12SlotOffset);
+                if (!U.isPointer(rawP12)) return false;
+                uint srcOffset = U.toOffset(rawP12);
+                if (!U.isSafetyOffset(srcOffset, rom)) return false;
+                if (LZ77.getCompressedSize(rom.Data, srcOffset) == 0) return false;
+                byte[] decompressed = LZ77.decompress(rom.Data, srcOffset);
+                return decompressed != null && decompressed.Length >= RAW_PALETTE_BYTES;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Build a DETERMINISTIC fresh SINGLE 32-byte palette bank from the
+        /// supplied R/G/B (16 colors), LZ77-compress it, append at ROM end, and
+        /// repoint the P12 slot to it. Used by <see cref="AllocNewPalette"/> when
+        /// the slot has no existing LZ77 stream to splice into. Validates the
+        /// R/G/B inputs exactly like <see cref="WritePalette"/> and returns
+        /// <see cref="U.NOT_FOUND"/> on bad input or a resize failure (the caller
+        /// restores the snapshot). Writes record into the caller's ambient undo
+        /// scope.
+        /// </summary>
+        static uint AppendFreshSingleBank(ROM rom, uint rowP12SlotOffset, uint[] r, uint[] g, uint[] b)
+        {
+            if (r == null || g == null || b == null) return U.NOT_FOUND;
+            if (r.Length != PALETTE_COUNT || g.Length != PALETTE_COUNT || b.Length != PALETTE_COUNT)
+                return U.NOT_FOUND;
+            for (int i = 0; i < PALETTE_COUNT; i++)
+            {
+                if (r[i] > 0x1F || g[i] > 0x1F || b[i] > 0x1F) return U.NOT_FOUND;
+            }
+            if (rowP12SlotOffset + 4 > (uint)rom.Data.Length) return U.NOT_FOUND;
+
+            byte[] raw = PackRgb555(r, g, b);
+            byte[] compressed = LZ77.compress(raw);
+
+            uint appendOffset = (uint)rom.Data.Length;
+            uint newRomSize = appendOffset + (uint)compressed.Length;
+            if (!rom.write_resize_data(newRomSize)) return U.NOT_FOUND;
+
+            rom.write_range(appendOffset, compressed);
+            rom.write_p32(rowP12SlotOffset, appendOffset);
+            return U.toPointer(appendOffset);
+        }
+
+        /// <summary>
+        /// Length-aware byte-identical restore: a free-space append can GROW
+        /// <c>rom.Data</c> via <see cref="ROM.write_resize_data"/>, so down-resize
+        /// back to the snapshot length BEFORE the in-place copy (a naive
+        /// Array.Copy would leave the grown tail alive). Mirrors
+        /// <c>WaitIconImportCore.RestoreSnapshot</c> (#885/#923).
+        /// </summary>
+        static void RestoreSnapshot(ROM rom, byte[] snapshot)
+        {
+            if (rom.Data.Length != snapshot.Length)
+                rom.write_resize_data((uint)snapshot.Length);
+            Array.Copy(snapshot, rom.Data, snapshot.Length);
         }
     }
 }

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -6771,6 +6771,9 @@ TSA
 :Failed to allocate new event-unit block.
 新規ユニット配置領域の確保に失敗しました。
 
+:Failed to allocate a new palette block. Check ROM free space.
+新規パレット領域の確保に失敗しました。ROMの空き容量を確認してください。
+
 :Allocated new event-unit block ({0} units) at 0x{1:X08}.
 新規ユニット配置領域({0}体)を 0x{1:X08} に確保しました。
 
@@ -10274,6 +10277,9 @@ Sappy エミュレータ再生は Windows 専用です（user32 P/Invoke）。Wi
 
 :Pending Core alloc+repoint / DataExpansionCore wiring — tracked separately
 Core の alloc+repoint / DataExpansionCore の配線待ち — 別途追跡します
+
+:Allocate a fresh palette block in free space and repoint this slot's P12
+空き容量に新しいパレット領域を確保し、このスロットの P12 を貼り直します
 
 :Actual size
 等倍

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -20706,6 +20706,9 @@ ID=00 Empty 已预留为空数据。\r\n请勿设置 0x0 之外的值。
 :Failed to allocate new event-unit block.
 分配新的事件单位区块失败。
 
+:Failed to allocate a new palette block. Check ROM free space.
+分配新的调色板区块失败。请检查ROM的剩余空间。
+
 :Allocated new event-unit block ({0} units) at 0x{1:X08}.
 已在 0x{1:X08} 分配新的事件单位区块（{0} 个单位）。
 
@@ -24106,6 +24109,9 @@ Sappy 模拟器播放为 Windows 专用（user32 P/Invoke），请使用 WinForm
 
 :Pending Core alloc+repoint / DataExpansionCore wiring — tracked separately
 等待 Core 的 alloc+repoint / DataExpansionCore 接线 — 单独跟踪
+
+:Allocate a fresh palette block in free space and repoint this slot's P12
+在空闲空间分配一个新的调色板区块，并重新指向此槽位的 P12
 
 :Actual size
 实际大小


### PR DESCRIPTION
## Summary
Wires the Unit Palette editor's disabled **New Palette Allocation** button to a new Core seam that allocates a **fresh free-space palette block** and repoints the selected row's **P12** pointer, giving the slot its **own independent palette** (no longer sharing the previous block).

Plan: https://github.com/laqieer/FEBuilderGBA/issues/1067#issuecomment-4660259679 (Copilot CLI plan review v2: **ready to implement**).

## Scope
- **Ref #1067** — implements the **New Palette Allocation** half. The **Expand List** half is split to **#1078** (it needs a predicate-aware table expansion — real-count, full-zero terminator row, FIRST-fill + clear-P12, all-ref repoint — which a generic `ExpandTableTo` doesn't provide). `ImageUnitPalette_Expand_Button` stays disabled until #1078.

## Changes
**Core — `UnitPaletteWriteCore.cs`**
- `WritePalette` gains a `bool forceNewAlloc = false` parameter (default ⇒ existing callers **byte-identical**; `true` ⇒ always take the append-at-ROM-end + `write_p32` repoint branch, even when the recompressed bytes would fit in-place).
- New `AllocNewPalette(rom, rowP12SlotOffset, r,g,b, paletteIndex, isOverrideAll)`:
  - **Multi-bank correct:** for a valid LZ77 P12, reuses `WritePalette`'s splice (overwrites only the `paletteIndex` 32-byte bank unless `isOverrideAll`, recompresses the **full** stream, preserves untouched banks), then force-appends a fresh block + repoints.
  - **Invalid/zero P12:** builds a **deterministic fresh single 32-byte bank** (`AppendFreshSingleBank`) — append + repoint.
  - **Old block untouched** (shared-palette safety; intentional orphan, no recycle).
  - **Never throws:** defensive `(byte[])rom.Data.Clone()` snapshot, **length-aware** byte-identical restore on any fault/`NOT_FOUND` (#885/#923). Writes via the caller's ambient undo scope.

**Avalonia — `ImageUnitPaletteView.axaml(.cs)`**
- `NewAlloc_Click` mirrors `PerformPaletteWrite` exactly (spinner read, `paletteIndex`/`isOverrideAll` from `PaletteTypeCombo`/`PaletteOverrideAllCheck`, single `UndoService` Begin/Commit/Rollback, reload + `MarkClean`, `ShowError` on `NOT_FOUND`/exception). Button enabled + `Click` + meaningful tooltip.

## Test plan
- [x] **Core** (`UnitPaletteWriteCoreTests`, **29/29**, +11 new): P12 repoints to a **new** offset even when bytes fit in-place; new stream decodes back to the edited bank; **untouched banks preserved**; **old block bytes unchanged**; invalid/zero P12 ⇒ deterministic fresh single bank; outer `Undo.Rollback` byte-identical (length + P12 + bytes); `WritePalette` `forceNewAlloc:false` **regression** byte-identical; no-mutation on bad input.
- [x] **Avalonia** (`ImageUnitPaletteParityTests`, **41/41**): NewAlloc button enabled, AutomationId present, stub tooltip gone.
- [x] Full **Avalonia.Tests 7753/0** (+3 skipped), full **Core.Tests 3039 pass** (10 pre-existing `config/patch2`-submodule env skips, unrelated), cross-project **FEBuilderGBA.Tests UnitPalette 24/24** — no regressions from the `WritePalette` signature change.

## Screenshots
Real running **Unit Palette Editor** (FE8U, entry `0x00 mer`, Class 26 Archer) — the **New Palette Allocation** button is now **enabled** (next to Write), previously greyed out with a "tracked separately" tooltip:

![Unit Palette Editor — New Palette Allocation enabled](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1067-unitpalette-newalloc.png)

The actual allocation (ROM-mutating) is proven by the Core round-trip tests above (repoint to a fresh block, multi-bank preservation, byte-identical undo rollback).

## GUI Test Report
| Case | Result |
| --- | --- |
| Unit Palette editor opens populated (FE8U) | ✅ live |
| New Palette Allocation button **enabled** (was disabled stub) | ✅ `IsEnabled=True`, screenshot |
| Alloc repoints P12 to a fresh free-space block | ✅ Core test |
| Multi-bank: edited bank written, untouched banks preserved | ✅ Core test |
| Old block left untouched (shared-palette safety) | ✅ Core test |
| Byte-identical fault restore + outer undo rollback | ✅ Core test |
| `WritePalette` existing callers byte-identical (`forceNewAlloc:false`) | ✅ Core regression test |

🤖 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.168` · model `claude-opus-4-8[1m]`
