### PR TITLE
feat(avalonia): Portrait → Status Height ID-based jump pre-selects the portrait's height row (#1019)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/PortraitStatusHeightJumpTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/PortraitStatusHeightJumpTests.cs
@@ -1,0 +1,341 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using FEBuilderGBA.Avalonia.Controls;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// Tests for the Portrait editor's FE8 "Status Height" ID-based jump (#1019):
+    ///   - UnitIncreaseHeightViewModel.IdToAddress (dense FE8 table, guard-before-
+    ///     subtract, RESOLVED count = raw switch byte + 1)
+    ///   - ImagePortraitViewModel.GetSelectedPortraitId (aligned-only + named sentinel)
+    ///   - UnitIncreaseHeightView.NavigateToId + pending-navigate timing pattern
+    ///
+    /// Uses a synthetic FE8U ROM (rom.LoadLow(.., "BE8E01")) so the run is
+    /// deterministic and ROM-independent. The FE8U RomInfo fixes:
+    ///   portrait_pointer                     = 0x5524
+    ///   unit_increase_height_pointer         = 0x5C38
+    ///   unit_increase_height_switch2_address = 0x5C26
+    /// We write the switch2 instruction pattern, the two table base pointers, and
+    /// the table data into the 16 MB buffer at those offsets.
+    /// </summary>
+    [Collection("SharedState")]
+    public class PortraitStatusHeightJumpTests
+    {
+        // FE8U RomInfo fixed addresses (see ROMFE8U.cs).
+        const uint Switch2Addr = 0x5C26;
+        const uint HeightPtrSlot = 0x5C38;
+        const uint PortraitPtrSlot = 0x5524;
+
+        const uint DefaultHeightBase = 0x00100000; // well inside the 16 MB buffer
+        const uint DefaultPortraitBase = 0x00120000;
+        const uint HeightEntrySize = 4;
+        const uint PortraitEntrySize = 28;
+
+        /// <summary>
+        /// Build a synthetic FE8U ROM. <paramref name="startId"/> is the first
+        /// managed portrait id; <paramref name="rawCount"/> is the raw switch2
+        /// byte (resolved row count = rawCount + 1). Set <paramref name="enable"/>
+        /// false to write a non-SUB op1 so IsSwitch2Enable() fails.
+        /// </summary>
+        static ROM BuildRom(
+            byte startId = 0x10,
+            byte rawCount = 0x04,
+            uint heightBase = DefaultHeightBase,
+            uint portraitBase = DefaultPortraitBase,
+            bool enable = true,
+            bool zeroHeightPtr = false,
+            bool zeroPortraitPtr = false)
+        {
+            var rom = new ROM();
+            rom.LoadLow("synth-fe8u.gba", new byte[0x1000000], "BE8E01");
+
+            // switch2 instruction pattern at 0x5C26:
+            //   +0 startId  +1 op1(SUB)  +2 rawCount  +3 op2(CMP)
+            rom.write_u8(Switch2Addr + 0, startId);
+            rom.write_u8(Switch2Addr + 1, enable ? 0x38u : 0x00u); // SUB op (0x38..0x3D) / invalid
+            rom.write_u8(Switch2Addr + 2, rawCount);
+            rom.write_u8(Switch2Addr + 3, 0x28u); // CMP op (0x28..0x2D)
+
+            // Height table base pointer at 0x5C38, portrait base at 0x5524.
+            rom.write_p32(HeightPtrSlot, zeroHeightPtr ? 0u : (heightBase + 0x08000000));
+            rom.write_p32(PortraitPtrSlot, zeroPortraitPtr ? 0u : (portraitBase + 0x08000000));
+
+            return rom;
+        }
+
+        static IDisposable UseRom(ROM rom)
+        {
+            ROM prev = CoreState.ROM;
+            CoreState.ROM = rom;
+            return new Restore(prev);
+        }
+
+        sealed class Restore : IDisposable
+        {
+            readonly ROM _prev;
+            public Restore(ROM prev) => _prev = prev;
+            public void Dispose() => CoreState.ROM = _prev;
+        }
+
+        // ===================================================================
+        // IdToAddress
+        // ===================================================================
+
+        [Fact]
+        public void IdToAddress_FirstId_ReturnsBaseAddr()
+        {
+            var rom = BuildRom(startId: 0x10, rawCount: 0x04, heightBase: DefaultHeightBase);
+            using (UseRom(rom))
+            {
+                uint addr = UnitIncreaseHeightViewModel.IdToAddress(rom, 0x10);
+                Assert.Equal(DefaultHeightBase, addr);
+            }
+        }
+
+        [Fact]
+        public void IdToAddress_LastResolvedRow_ReturnsLastRowAddr()
+        {
+            // raw count 0x04 -> resolved count 5 -> rows 0x10..0x14 (5 rows).
+            var rom = BuildRom(startId: 0x10, rawCount: 0x04, heightBase: DefaultHeightBase);
+            using (UseRom(rom))
+            {
+                // Off-by-one assertion: with raw switch byte N, the table has N+1
+                // rows, so id == startId + N (the LAST) must be a valid addr.
+                uint addr = UnitIncreaseHeightViewModel.IdToAddress(rom, 0x10 + 0x04);
+                Assert.Equal(DefaultHeightBase + 0x04 * HeightEntrySize, addr);
+            }
+        }
+
+        [Fact]
+        public void IdToAddress_OnePastEnd_ReturnsZero()
+        {
+            var rom = BuildRom(startId: 0x10, rawCount: 0x04, heightBase: DefaultHeightBase);
+            using (UseRom(rom))
+            {
+                // startId + count == startId + 5 == 0x15 is one past the last row.
+                uint addr = UnitIncreaseHeightViewModel.IdToAddress(rom, 0x10 + 0x05);
+                Assert.Equal(0u, addr);
+            }
+        }
+
+        [Fact]
+        public void IdToAddress_BelowStartId_ReturnsZero()
+        {
+            var rom = BuildRom(startId: 0x10, rawCount: 0x04);
+            using (UseRom(rom))
+            {
+                Assert.Equal(0u, UnitIncreaseHeightViewModel.IdToAddress(rom, 0x0F));
+                Assert.Equal(0u, UnitIncreaseHeightViewModel.IdToAddress(rom, 0x00));
+            }
+        }
+
+        [Fact]
+        public void IdToAddress_SentinelId_ReturnsZeroNoThrow()
+        {
+            var rom = BuildRom(startId: 0x10, rawCount: 0x04);
+            using (UseRom(rom))
+            {
+                // 0xFFFFFFFF is the "no portrait selected" sentinel — must be
+                // rejected by the >= startId+count guard with no unsigned underflow.
+                uint addr = UnitIncreaseHeightViewModel.IdToAddress(rom, 0xFFFFFFFF);
+                Assert.Equal(0u, addr);
+            }
+        }
+
+        [Fact]
+        public void IdToAddress_ResolvedCountOffByOne_RawByteRowsAreNPlusOne()
+        {
+            // Raw switch byte 0 still yields ONE valid row (resolved count = 1).
+            var rom = BuildRom(startId: 0x10, rawCount: 0x00, heightBase: DefaultHeightBase);
+            using (UseRom(rom))
+            {
+                Assert.Equal(DefaultHeightBase, UnitIncreaseHeightViewModel.IdToAddress(rom, 0x10));
+                Assert.Equal(0u, UnitIncreaseHeightViewModel.IdToAddress(rom, 0x11));
+            }
+        }
+
+        [Fact]
+        public void IdToAddress_ZeroPointer_ReturnsZero()
+        {
+            var rom = BuildRom(startId: 0x10, rawCount: 0x04, zeroHeightPtr: true);
+            using (UseRom(rom))
+            {
+                Assert.Equal(0u, UnitIncreaseHeightViewModel.IdToAddress(rom, 0x10));
+            }
+        }
+
+        [Fact]
+        public void IdToAddress_DisabledSwitch2_ReturnsZero()
+        {
+            // enable:false writes a non-SUB op1 so IsSwitch2Enable() fails.
+            var rom = BuildRom(startId: 0x10, rawCount: 0x04, enable: false);
+            using (UseRom(rom))
+            {
+                Assert.Equal(0u, UnitIncreaseHeightViewModel.IdToAddress(rom, 0x10));
+            }
+        }
+
+        [Fact]
+        public void IdToAddress_NullRom_ReturnsZero()
+        {
+            Assert.Equal(0u, UnitIncreaseHeightViewModel.IdToAddress(null, 0x10));
+        }
+
+        [Fact]
+        public void IdToAddress_FinalRowNearEof_ReturnsZero()
+        {
+            var rom = BuildRom(startId: 0x10, rawCount: 0x04);
+            uint romLen = (uint)rom.Data.Length;
+            // Place the base so the last row (id startId+4 -> base + 16) overflows.
+            // base = len - 6 -> last addr = len + 10 -> addr + EntrySize > len.
+            uint nearEofBase = romLen - 6;
+            var eofRom = BuildRom(startId: 0x10, rawCount: 0x04, heightBase: nearEofBase);
+            using (UseRom(eofRom))
+            {
+                // First row is still in bounds...
+                Assert.Equal(nearEofBase, UnitIncreaseHeightViewModel.IdToAddress(eofRom, 0x10));
+                // ...the last row overflows the ROM and must return 0.
+                Assert.Equal(0u, UnitIncreaseHeightViewModel.IdToAddress(eofRom, 0x14));
+            }
+        }
+
+        // ===================================================================
+        // GetSelectedPortraitId
+        // ===================================================================
+
+        [Fact]
+        public void GetSelectedPortraitId_AlignedEntry_ReturnsId()
+        {
+            var rom = BuildRom(portraitBase: DefaultPortraitBase);
+            using (UseRom(rom))
+            {
+                var vm = new ImagePortraitViewModel();
+                const uint k = 7;
+                vm.CurrentAddr = DefaultPortraitBase + k * PortraitEntrySize;
+                Assert.Equal(k, vm.GetSelectedPortraitId());
+            }
+        }
+
+        [Fact]
+        public void GetSelectedPortraitId_CurrentAddrZero_ReturnsSentinel()
+        {
+            var rom = BuildRom();
+            using (UseRom(rom))
+            {
+                var vm = new ImagePortraitViewModel();
+                vm.CurrentAddr = 0;
+                Assert.Equal(ImagePortraitViewModel.NoPortraitSelection, vm.GetSelectedPortraitId());
+            }
+        }
+
+        [Fact]
+        public void GetSelectedPortraitId_AddrBelowBase_ReturnsSentinel()
+        {
+            var rom = BuildRom(portraitBase: DefaultPortraitBase);
+            using (UseRom(rom))
+            {
+                var vm = new ImagePortraitViewModel();
+                vm.CurrentAddr = DefaultPortraitBase - PortraitEntrySize; // below base
+                Assert.Equal(ImagePortraitViewModel.NoPortraitSelection, vm.GetSelectedPortraitId());
+            }
+        }
+
+        [Fact]
+        public void GetSelectedPortraitId_NonAligned_ReturnsSentinel()
+        {
+            var rom = BuildRom(portraitBase: DefaultPortraitBase);
+            using (UseRom(rom))
+            {
+                var vm = new ImagePortraitViewModel();
+                // base + 28*K + 1 — one byte past an aligned entry.
+                vm.CurrentAddr = DefaultPortraitBase + 3 * PortraitEntrySize + 1;
+                Assert.Equal(ImagePortraitViewModel.NoPortraitSelection, vm.GetSelectedPortraitId());
+            }
+        }
+
+        [Fact]
+        public void GetSelectedPortraitId_ZeroPortraitPointer_ReturnsSentinel()
+        {
+            var rom = BuildRom(zeroPortraitPtr: true);
+            using (UseRom(rom))
+            {
+                var vm = new ImagePortraitViewModel();
+                vm.CurrentAddr = DefaultPortraitBase; // any non-zero addr
+                Assert.Equal(ImagePortraitViewModel.NoPortraitSelection, vm.GetSelectedPortraitId());
+            }
+        }
+
+        // ===================================================================
+        // NavigateToId (view, headless)
+        // ===================================================================
+
+        [AvaloniaFact]
+        public void NavigateToId_OutOfRange_ReturnsFalseNoThrow()
+        {
+            var rom = BuildRom(startId: 0x10, rawCount: 0x04);
+            using (UseRom(rom))
+            {
+                var view = new UnitIncreaseHeightView();
+                // id below the first managed id -> no height row.
+                bool ok = view.NavigateToId(0x00);
+                Assert.False(ok);
+                // Sentinel id (what GetSelectedPortraitId returns with no selection).
+                Assert.False(view.NavigateToId(0xFFFFFFFF));
+            }
+        }
+
+        [AvaloniaFact]
+        public void NavigateToId_BeforeListLoads_StashesPendingAndReplaysAfterLoad()
+        {
+            var rom = BuildRom(startId: 0x10, rawCount: 0x04, heightBase: DefaultHeightBase);
+            using (UseRom(rom))
+            {
+                var view = new UnitIncreaseHeightView();
+                var list = view.FindControl<AddressListControl>("EntryList");
+                Assert.NotNull(list);
+
+                // List not yet loaded (Opened/LoadList fires on Show()).
+                Assert.Equal(0, list!.ItemCount);
+
+                // NavigateToId of a valid id BEFORE the list loads -> returns true
+                // (id resolved to an address) and stashes the pending navigation.
+                uint expectedAddr = UnitIncreaseHeightViewModel.IdToAddress(rom, 0x12); // 3rd row
+                Assert.NotEqual(0u, expectedAddr);
+                Assert.True(view.NavigateToId(0x12));
+
+                // Trigger Opened -> LoadList(), which replays the pending selection.
+                view.Show();
+
+                Assert.True(list.ItemCount > 0);
+                Assert.NotNull(list.SelectedItem);
+                Assert.Equal(expectedAddr, list.SelectedItem!.addr);
+            }
+        }
+
+        [AvaloniaFact]
+        public void NavigateToId_AfterListLoads_SelectsImmediately()
+        {
+            var rom = BuildRom(startId: 0x10, rawCount: 0x04, heightBase: DefaultHeightBase);
+            using (UseRom(rom))
+            {
+                var view = new UnitIncreaseHeightView();
+                var list = view.FindControl<AddressListControl>("EntryList");
+                Assert.NotNull(list);
+
+                view.Show(); // list loads now
+                Assert.True(list!.ItemCount > 0);
+
+                uint expectedAddr = UnitIncreaseHeightViewModel.IdToAddress(rom, 0x13); // 4th row
+                Assert.True(view.NavigateToId(0x13));
+
+                Assert.NotNull(list.SelectedItem);
+                Assert.Equal(expectedAddr, list.SelectedItem!.addr);
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/ImagePortraitViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImagePortraitViewModel.cs
@@ -26,6 +26,37 @@ namespace FEBuilderGBA.Avalonia.ViewModels
     {
         const uint SIZE = 28;
 
+        /// <summary>
+        /// Sentinel returned by <see cref="GetSelectedPortraitId"/> when no valid,
+        /// aligned portrait entry is selected. Distinct from any real portrait id.
+        /// </summary>
+        public const uint NoPortraitSelection = 0xFFFFFFFF;
+
+        /// <summary>
+        /// Resolve the portrait id (0-based row index) of the currently selected
+        /// entry from <see cref="CurrentAddr"/> and the portrait table base.
+        /// Returns <see cref="NoPortraitSelection"/> when nothing is selected, the
+        /// portrait pointer is missing/unsafe, the address is below the table base,
+        /// or the address is NOT entry-aligned (a non-aligned address yields no
+        /// selection rather than a floored wrong id). Never throws.
+        /// </summary>
+        public uint GetSelectedPortraitId()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null || CurrentAddr == 0) return NoPortraitSelection;
+
+            uint pointer = rom.RomInfo.portrait_pointer;
+            if (pointer == 0) return NoPortraitSelection;
+
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr) || CurrentAddr < baseAddr) return NoPortraitSelection;
+
+            uint delta = CurrentAddr - baseAddr;
+            if (delta % SIZE != 0) return NoPortraitSelection;
+
+            return delta / SIZE;
+        }
+
         uint _currentAddr;
         bool _isLoaded;
         uint _portraitImagePtr, _miniPortraitPtr, _palettePtr, _mouthFramesPtr, _classCardPtr;

--- a/FEBuilderGBA.Avalonia/ViewModels/UnitIncreaseHeightViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/UnitIncreaseHeightViewModel.cs
@@ -74,6 +74,44 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             return (baseAddr, count);
         }
 
+        /// <summary>
+        /// Resolve the ROM address of the height row for a given portrait id.
+        ///
+        /// The Unit Increase Height table is a DENSE FE8 table: row 0 belongs to
+        /// the first managed portrait id (<c>u8(switch2_address)</c>) and the rows
+        /// are contiguous from there. The id therefore maps to a row only when it
+        /// falls inside <c>[startId, startId + count)</c>, where <c>count</c> is the
+        /// RESOLVED row count from <see cref="ResolveTable"/> (raw switch byte + 1).
+        ///
+        /// Returns 0 ("no height row for this id") when the table is disabled, the
+        /// id is below the first managed id, the id is at/above the end of the
+        /// table (this also rejects the <c>0xFFFFFFFF</c> "no selection" sentinel
+        /// without unsigned underflow), or the resolved row would fall outside the
+        /// ROM. Never throws.
+        /// </summary>
+        public static uint IdToAddress(ROM rom, uint portraitId)
+        {
+            if (rom?.RomInfo == null) return 0;
+
+            var (baseAddr, count) = ResolveTable(rom);
+            if (baseAddr == 0 || count == 0) return 0;
+
+            uint startId = rom.u8(rom.RomInfo.unit_increase_height_switch2_address);
+
+            // Guard BEFORE subtracting so an id below the first managed id — or
+            // the 0xFFFFFFFF sentinel — can never underflow the unsigned math.
+            if (portraitId < startId) return 0;
+            if (portraitId >= startId + count) return 0;
+
+            uint addr = baseAddr + (portraitId - startId) * EntrySize;
+
+            // Full-row + safety bounds.
+            if ((long)addr + EntrySize > rom.Data.Length) return 0;
+            if (!U.isSafetyOffset(addr, rom)) return 0;
+
+            return addr;
+        }
+
         public List<AddrResult> LoadList()
         {
             ROM rom = CoreState.ROM;

--- a/FEBuilderGBA.Avalonia/Views/ImagePortraitView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImagePortraitView.axaml.cs
@@ -712,7 +712,14 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void JumpToStatusHeight_Click(object? sender, RoutedEventArgs e)
         {
-            try { WindowManager.Instance.Open<UnitIncreaseHeightView>(); }
+            try
+            {
+                var view = WindowManager.Instance.Open<UnitIncreaseHeightView>();
+                // Best-effort pre-selection of the selected portrait's height row.
+                // An out-of-range id (no height row, or NoPortraitSelection) just
+                // leaves the default first row selected — no error (#1019).
+                view.NavigateToId(_vm.GetSelectedPortraitId());
+            }
             catch (Exception ex) { Log.Error("JumpToStatusHeight failed: {0}", ex.Message); }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/UnitIncreaseHeightView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/UnitIncreaseHeightView.axaml.cs
@@ -10,6 +10,15 @@ namespace FEBuilderGBA.Avalonia.Views
     {
         readonly UnitIncreaseHeightViewModel _vm = new();
 
+        // True once Opened -> LoadList() has populated EntryList. A NavigateTo
+        // request that arrives BEFORE the list loads (WindowManager.Open then an
+        // immediate NavigateToId, but Avalonia raises Opened asynchronously after
+        // layout) is stashed in _pendingNavigateAddr and replayed once LoadList
+        // completes — otherwise EntryList.SelectAddress no-ops against the
+        // still-empty list. Mirrors MonsterProbabilityViewerView (#1018/#1019).
+        bool _listLoaded;
+        uint? _pendingNavigateAddr;
+
         public string ViewTitle => "Unit Height Adjustment";
         public bool IsLoaded => _vm.IsLoaded;
 
@@ -26,10 +35,18 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 var items = _vm.LoadList();
                 EntryList.SetItemsWithIcons(items, i => ListIconLoaders.PortraitLoader(items, i));
+                _listLoaded = true;
             }
             catch (Exception ex)
             {
                 Log.Error("UnitIncreaseHeightView.LoadList failed: {0}", ex.Message);
+            }
+
+            // Replay a navigation requested before the list was ready.
+            if (_pendingNavigateAddr is uint pending)
+            {
+                _pendingNavigateAddr = null;
+                EntryList.SelectAddress(pending);
             }
         }
 
@@ -51,7 +68,34 @@ namespace FEBuilderGBA.Avalonia.Views
             AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
         }
 
-        public void NavigateTo(uint address) => EntryList.SelectAddress(address);
+        public void NavigateTo(uint address)
+        {
+            // When the list has not yet loaded (WindowManager.Open calls
+            // NavigateToId synchronously right after Show(), before Avalonia
+            // raises Opened), stash the address so LoadList() can replay the
+            // selection — a direct SelectAddress would no-op (#1018/#1019).
+            if (!_listLoaded)
+            {
+                _pendingNavigateAddr = address;
+                return;
+            }
+            EntryList.SelectAddress(address);
+        }
+
+        /// <summary>
+        /// Pre-select the height row for the given portrait id (FE8 Status Height
+        /// jump from the Portrait editor, #1019). Returns false without selecting
+        /// or throwing when the id has no height row (out of range / disabled
+        /// table); the default first row is left selected in that case.
+        /// </summary>
+        public bool NavigateToId(uint portraitId)
+        {
+            uint addr = UnitIncreaseHeightViewModel.IdToAddress(CoreState.ROM, portraitId);
+            if (addr == 0) return false;
+            NavigateTo(addr);
+            return true;
+        }
+
         public void SelectFirstItem() => EntryList.SelectFirst();
         public ViewModelBase? DataViewModel => _vm;
     }


### PR DESCRIPTION
## Summary
Wires the Portrait editor's FE8 **Status Height** jump so it **pre-selects the selected portrait's height row** in `UnitIncreaseHeightView`, instead of opening at the default first row.

Plan: https://github.com/laqieer/FEBuilderGBA/issues/1019#issuecomment-4661481329 (Copilot CLI plan review: acceptable → **all 5 tightenings folded in**, https://github.com/laqieer/FEBuilderGBA/issues/1019#issuecomment-4661526366).

## Scope
- **Ref #1019** — implements the **Status Height ID-based jump** half. The **Import** jump's `SetOriginalImage` (source bitmap + eye/mouth calibration) stays deferred (the importer's source is file-based via `LoadAndQuantizeFromFile`, so seeding it from the in-memory portrait needs temp-PNG + coord-NUD lifecycle work). **#1019 stays open** for that follow-up.

## Changes
- **`UnitIncreaseHeightViewModel.IdToAddress(rom, portraitId)`** — dense FE8 table (`id = startId + i`, `EntrySize = 4`). Reuses `ResolveTable`'s **resolved** count (`u8(switch2+2)+1`, no last-row drop); **guards the range before subtracting** (`startId <= id < startId+count`) so `id<startId` / the `0xFFFFFFFF` sentinel can't underflow; full-row + `isSafetyOffset` bounds; returns `0` = "no height row".
- **`ImagePortraitViewModel.GetSelectedPortraitId()`** — derives the id from `CurrentAddr` (`SIZE=28`, `base=p32(portrait_pointer)`); guards `CurrentAddr==0`, zero/unsafe base, `CurrentAddr<base`, and **non-aligned** `(CurrentAddr-base)%28 != 0` → returns the named `NoPortraitSelection` sentinel (not a floored wrong id).
- **`UnitIncreaseHeightView`** — `NavigateToId(portraitId)` + the **pending-navigate** pattern (mirrors `MonsterProbabilityViewerView`): the list loads on `Opened`, so a navigate before load stashes `_pendingNavigateAddr` and replays after `LoadList`.
- **`ImagePortraitView.JumpToStatusHeight_Click`** — `Open<UnitIncreaseHeightView>()` then `view.NavigateToId(_vm.GetSelectedPortraitId())` (best-effort; an out-of-range id leaves the default row, no error — WF parity).

## Test plan
- [x] **Avalonia** (`PortraitStatusHeightJumpTests`, **18/18**): `IdToAddress` boundaries (`id==startId`, `id==startId+count-1` **valid** [resolved-count off-by-one], `id==startId+count`→0, `id<startId`→0, `0xFFFFFFFF` sentinel→0 no-underflow, zero/invalid pointer→0, disabled switch2→0, final-row-near-EOF→0); `GetSelectedPortraitId` (id K round-trip, `CurrentAddr==0`/`<base`/non-aligned/zero-pointer → sentinel); `NavigateToId` out-of-range → false, no throw; **headless pending-navigate timing** (navigate before `Opened`/`LoadList`, then assert the row is selected after load).
- [x] Filtered set 197/0; full **Avalonia.Tests 7778/0** (+3 pre-existing skips) — no regression.

## Screenshots
Real FE8U flow: portrait **0x14 (Ephraim, id 20)** selected in the Portrait editor → **Jump to Status Height** → the Status Height editor opens **pre-selected at "14 Ephraim"** (address `0x5C4C` = `baseAddr + (20-16)*4`, exactly `IdToAddress(20)`), not the default "10 Lute":

![Status Height jump pre-selects the portrait's row](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1019-statusheight-jump.png)

## GUI Test Report
| Case | Result |
| --- | --- |
| Portrait editor → Jump to Status Height opens the editor | ✅ live |
| Editor pre-selects the selected portrait's row (non-default) | ✅ "14 Ephraim" @ `0x5C4C`, screenshot |
| Address = `baseAddr + (id-startId)*4` (IdToAddress) | ✅ `0x5C4C` matches | 
| Pending-navigate replays on a freshly-opened window | ✅ live + headless timing test |
| Out-of-range / non-aligned id → no jump, no error | ✅ tests |

<sub>Note: #1019 stays open for the Import `SetOriginalImage` half.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.168` · model `claude-opus-4-8[1m]`
