### PR TITLE
feat(avalonia): Graphics Tool TSA preview — image2-join + compressed paletteType (#1074)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GraphicsToolViewJumpTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GraphicsToolViewJumpTests.cs
@@ -350,6 +350,55 @@ namespace FEBuilderGBA.Avalonia.Tests
         }
 
         /// <summary>
+        /// #1074: Jump must set the image2-join + compressed-palette context.
+        /// <c>imageType == 2</c> -> <c>IsImage2Join</c> (NOT merely image2 != 0,
+        /// refinement #5); <c>paletteType == 1</c> -> <c>IsCompressedPalette</c>;
+        /// a nonzero <c>image2</c> -> <c>Image2AddressText</c> (hex), a 0 image2
+        /// -> "".
+        /// </summary>
+        [AvaloniaFact]
+        public void Jump_SetsImage2JoinAndCompressedPalette()
+        {
+            var view = new GraphicsToolView();
+            view.Jump(
+                width: 240, height: 160,
+                image: 0x08400000u, imageType: 2,   // join mode
+                tsa: 0x08500000u, tsaType: 1,
+                palette: 0x08600000u, paletteType: 1, // compressed palette
+                paletteCount: 8,
+                image2: 0x08700000u);
+
+            var vm = (FEBuilderGBA.Avalonia.ViewModels.GraphicsToolViewViewModel)view.DataContext!;
+            Assert.True(vm.IsImage2Join);
+            Assert.True(vm.IsCompressedPalette);
+            Assert.Contains("0x08700000", vm.Image2AddressText, System.StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// #1074 refinement #5: IsImage2Join is gated on imageType == 2, NOT on
+        /// image2 != 0. A non-join imageType that still carries a 2nd address must
+        /// NOT set the join flag. paletteType != 1 leaves IsCompressedPalette
+        /// false, and a 0 image2 leaves Image2AddressText empty.
+        /// </summary>
+        [AvaloniaFact]
+        public void Jump_NonJoinImageType_DoesNotSetImage2Join_AndZeroImage2IsEmpty()
+        {
+            var view = new GraphicsToolView();
+            view.Jump(
+                width: 240, height: 160,
+                image: 0x08400000u, imageType: 0,    // NOT join mode
+                tsa: 0x08500000u, tsaType: 1,
+                palette: 0x08600000u, paletteType: 0, // raw palette
+                paletteCount: 8,
+                image2: 0u);                          // null 2nd image
+
+            var vm = (FEBuilderGBA.Avalonia.ViewModels.GraphicsToolViewViewModel)view.DataContext!;
+            Assert.False(vm.IsImage2Join);
+            Assert.False(vm.IsCompressedPalette);
+            Assert.Equal("", vm.Image2AddressText);
+        }
+
+        /// <summary>
         /// Source parity: the AXAML binds Is4bppCheck + CompressedCheck
         /// IsEnabled to the inverse of TsaModeActive (so the TSA path is visibly
         /// fixed 4bpp + LZ77 image), and the VM DrawTiles references

--- a/FEBuilderGBA.Avalonia.Tests/GraphicsToolViewModelTsaTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GraphicsToolViewModelTsaTests.cs
@@ -19,9 +19,11 @@ namespace FEBuilderGBA.Avalonia.Tests
     public class GraphicsToolViewModelTsaTests
     {
         // Resolved ROM data offsets for the planted streams.
-        const uint IMAGE_OFFSET   = 0x1000;
-        const uint TSA_LZ_OFFSET  = 0x6000;
-        const uint PALETTE_OFFSET = 0x8000;
+        const uint IMAGE_OFFSET    = 0x1000;
+        const uint IMAGE2_OFFSET   = 0x2000;
+        const uint TSA_LZ_OFFSET   = 0x6000;
+        const uint PALETTE_OFFSET  = 0x8000;
+        const uint COMP_PAL_OFFSET = 0xA000;
 
         // GBA 5-5-5 colors used in the planted palette.
         const ushort RED   = 0x001F;
@@ -217,6 +219,116 @@ namespace FEBuilderGBA.Avalonia.Tests
                 Assert.Equal(160, image.Height);
                 Assert.Contains("32x20", vm.ImageInfo);
             });
+        }
+
+        // -----------------------------------------------------------------
+        // #1074 — image2-join + compressed paletteType behavioral tests.
+        // Setting Image2AddressText/IsImage2Join/IsCompressedPalette on the VM
+        // and calling DrawTiles must reflect the image2 tile / compressed-palette
+        // colors in the rendered CurrentImage.
+        // -----------------------------------------------------------------
+
+        /// <summary>image2 = a single tile that is entirely color index 2 (green
+        /// in bank 0). Joined after MarkerTiles()'s 2 tiles -> tile index 2.</summary>
+        static byte[] Image2GreenTile()
+        {
+            byte[] tiles = new byte[1 * 32];
+            FillTile(tiles, 0, 2);
+            return tiles;
+        }
+
+        [Fact]
+        public void DrawTiles_Image2Join_RendersSecondImageTile()
+        {
+            WithRomAndService(rom =>
+            {
+                PlantImage(rom, MarkerTiles());                  // tiles 0,1
+                PlantBytes(rom, IMAGE2_OFFSET, LZ77.compress(Image2GreenTile())); // tile 2
+                PlantPalette(rom, StandardPalette());
+                // TSA cell references tile index 2 -> only reachable via image2.
+                ushort[] cells = { Cell(2, false, false, 0) };
+                PlantBytes(rom, TSA_LZ_OFFSET, LZ77.compress(CellsToBytes(
+                    new ushort[] { cells[0], Cell(0, false, false, 0) }))); // pad to >=4 bytes
+
+                var vm = new GraphicsToolViewViewModel();
+                vm.ImageAddressText   = "0x" + U.toPointer(IMAGE_OFFSET).ToString("X8");
+                vm.PaletteAddressText = "0x" + U.toPointer(PALETTE_OFFSET).ToString("X8");
+                vm.TsaAddressText     = "0x" + U.toPointer(TSA_LZ_OFFSET).ToString("X8");
+                vm.Image2AddressText  = "0x" + U.toPointer(IMAGE2_OFFSET).ToString("X8");
+                vm.IsImage2Join = true;
+                vm.TileCountX = 2;   // 2 cells
+                vm.TileCountY = 1;
+                vm.TsaTypeIndex = 1; // Compressed (LZ77), non-header
+
+                var image = vm.DrawTiles();
+                Assert.NotNull(image);
+                // tile 2 (image2) is all green -> first cell (0,0) is green.
+                AssertPixel(image!, 0, 0, 0, 248, 0, 255);
+                Assert.Contains("+image2", vm.ImageInfo);
+
+                // WITHOUT the join, the SAME tile index 2 is out of range -> that
+                // cell is blank (transparent). Prove the renders differ.
+                var noJoin = new GraphicsToolViewViewModel();
+                noJoin.ImageAddressText   = vm.ImageAddressText;
+                noJoin.PaletteAddressText = vm.PaletteAddressText;
+                noJoin.TsaAddressText     = vm.TsaAddressText;
+                noJoin.IsImage2Join = false; // join disabled
+                noJoin.TileCountX = 2;
+                noJoin.TileCountY = 1;
+                noJoin.TsaTypeIndex = 1;
+                var noJoinImg = noJoin.DrawTiles();
+                Assert.NotNull(noJoinImg);
+                Assert.NotEqual(image!.GetPixelData(), noJoinImg!.GetPixelData());
+            });
+        }
+
+        [Fact]
+        public void DrawTiles_CompressedPalette_MatchesRawPaletteRender()
+        {
+            WithRomAndService(rom =>
+            {
+                PlantImage(rom, MarkerTiles());
+                ushort[] cells = { Cell(1, false, false, 0), Cell(0, false, false, 0) };
+                PlantBytes(rom, TSA_LZ_OFFSET, LZ77.compress(CellsToBytes(cells)));
+
+                byte[] rawPal = StandardPalette();
+                PlantPalette(rom, rawPal);                                  // raw
+                PlantBytes(rom, COMP_PAL_OFFSET, LZ77.compress(rawPal));    // compressed
+
+                // Raw-palette render.
+                var raw = new GraphicsToolViewViewModel();
+                raw.ImageAddressText   = "0x" + U.toPointer(IMAGE_OFFSET).ToString("X8");
+                raw.PaletteAddressText = "0x" + U.toPointer(PALETTE_OFFSET).ToString("X8");
+                raw.TsaAddressText     = "0x" + U.toPointer(TSA_LZ_OFFSET).ToString("X8");
+                raw.TileCountX = 2; raw.TileCountY = 1; raw.TsaTypeIndex = 1;
+                raw.IsCompressedPalette = false;
+                var rawImg = raw.DrawTiles();
+                Assert.NotNull(rawImg);
+
+                // Compressed-palette render of the SAME colors.
+                var comp = new GraphicsToolViewViewModel();
+                comp.ImageAddressText   = "0x" + U.toPointer(IMAGE_OFFSET).ToString("X8");
+                comp.PaletteAddressText = "0x" + U.toPointer(COMP_PAL_OFFSET).ToString("X8");
+                comp.TsaAddressText     = "0x" + U.toPointer(TSA_LZ_OFFSET).ToString("X8");
+                comp.TileCountX = 2; comp.TileCountY = 1; comp.TsaTypeIndex = 1;
+                comp.IsCompressedPalette = true;
+                var compImg = comp.DrawTiles();
+                Assert.NotNull(compImg);
+                Assert.Contains("LZ77 palette", comp.ImageInfo);
+
+                // Identical colors -> identical pixels.
+                Assert.Equal(rawImg!.GetPixelData(), compImg!.GetPixelData());
+            });
+        }
+
+        static void AssertPixel(IImage img, int x, int y, byte r, byte g, byte b, byte a)
+        {
+            byte[] px = img.GetPixelData();
+            int idx = (y * img.Width + x) * 4;
+            Assert.Equal(r, px[idx + 0]);
+            Assert.Equal(g, px[idx + 1]);
+            Assert.Equal(b, px[idx + 2]);
+            Assert.Equal(a, px[idx + 3]);
         }
 
         // -----------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia/ViewModels/GraphicsToolViewViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/GraphicsToolViewViewModel.cs
@@ -10,6 +10,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         string _paletteAddressText = string.Empty;
         string _tsaAddressText = string.Empty;
         int _tsaTypeIndex;
+        string _image2AddressText = string.Empty;
+        bool _isImage2Join;
+        bool _isCompressedPalette;
         int _tileCountX = 8;
         int _tileCountY = 8;
         bool _is4bpp = true;
@@ -47,6 +50,26 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// the TSA path is fixed 4bpp + LZ77 image.
         /// </summary>
         public bool TsaModeActive => TsaTypeIndex > 0;
+        /// <summary>
+        /// ROM address of a SECOND image to join after the first (hex string)
+        /// — WF "Image 2" (#1074). Only consumed when <see cref="IsImage2Join"/>
+        /// is set AND a TSA type other than None is selected. Empty / 0 ⇒ no join
+        /// (single image).
+        /// </summary>
+        public string Image2AddressText { get => _image2AddressText; set => SetField(ref _image2AddressText, value); }
+        /// <summary>
+        /// True when the second image (<see cref="Image2AddressText"/>) is joined
+        /// after the first (WF <c>ImageOption == 2</c>, order image ++ image2,
+        /// #1074). Set by <c>Jump(...)</c> from <c>imageType == 2</c>.
+        /// </summary>
+        public bool IsImage2Join { get => _isImage2Join; set => SetField(ref _isImage2Join, value); }
+        /// <summary>
+        /// True when the palette block is an LZ77-compressed stream (WF
+        /// <c>PaletteOption == 1</c>, #1074). Set by <c>Jump(...)</c> from
+        /// <c>paletteType == 1</c>. Forwarded to
+        /// <see cref="ImageTSAEditorCore.TryRenderMainImage"/>.
+        /// </summary>
+        public bool IsCompressedPalette { get => _isCompressedPalette; set => SetField(ref _isCompressedPalette, value); }
         /// <summary>Number of tiles horizontally.</summary>
         public int TileCountX { get => _tileCountX; set => SetField(ref _tileCountX, value); }
         /// <summary>Number of tiles vertically.</summary>
@@ -108,15 +131,16 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 return null;
             }
 
-            // --- TSA-composited preview path (#1030) --------------------------
+            // --- TSA-composited preview path (#1030 / #1074) -----------------
             // When a TSA type other than None is selected AND a TSA address is
             // entered, route the preview through the EXISTING
             // ImageTSAEditorCore.TryRenderMainImage (no new render logic). The
             // TSA path is FIXED 4bpp + LZ77 image; the View disables
             // Is4bpp/IsCompressed in this mode. The TSA-type -> flags mapping is
             // the SAME one the TSA Editor button path uses (MapTsaType), so
-            // existing Jump callers render correctly. image2-join + compressed
-            // paletteType are deferred follow-ups.
+            // existing Jump callers render correctly. #1074 adds the optional
+            // image2-join (IsImage2Join + Image2AddressText) and compressed
+            // paletteType (IsCompressedPalette) carried in from Jump.
             uint tsaParsed = ParseHex(TsaAddressText);
             if (TsaTypeIndex > 0 && tsaParsed != 0)
             {
@@ -126,6 +150,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 uint palOff = U.toOffset(paletteAddr);   // normalize palette too
                 var (isLZ77TSA, isHeaderTSA) = MapTsaType(TsaTypeIndex);
 
+                // #1074: optional 2nd-image join. Only resolve image2 when the
+                // join flag is set (Jump maps imageType==2); a missing/empty
+                // address parses to 0 -> single image (Core treats 0 as no-op).
+                uint image2Off = IsImage2Join ? U.toOffset(ParseHex(Image2AddressText)) : 0u;
+
                 int w8 = TileCountX;
                 int h8 = TileCountY;
                 // Mirror ImageTSAEditorViewModel.Init's header-TSA min-dimension
@@ -133,7 +162,8 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 if (isHeaderTSA) { w8 = Math.Max(32, w8); h8 = Math.Max(20, h8); }
 
                 IImage? tsaImage = ImageTSAEditorCore.TryRenderMainImage(
-                    rom, (uint)w8, (uint)h8, imgOff, isHeaderTSA, isLZ77TSA, tsaOff, palOff);
+                    rom, (uint)w8, (uint)h8, imgOff, isHeaderTSA, isLZ77TSA, tsaOff, palOff,
+                    image2Off, IsCompressedPalette);
 
                 if (tsaImage == null)
                 {
@@ -144,7 +174,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 }
 
                 CurrentImage = tsaImage;
-                ImageInfo = $"TSA · 4bpp · LZ77 image ({w8}x{h8} tiles)";
+                string image2Tag = (IsImage2Join && image2Off != 0) ? " · +image2" : "";
+                string palTag = IsCompressedPalette ? " · LZ77 palette" : "";
+                ImageInfo = $"TSA · 4bpp · LZ77 image{image2Tag}{palTag} ({w8}x{h8} tiles)";
                 StatusMessage = $"Loaded TSA-composited {tsaImage.Width}x{tsaImage.Height} image.";
                 return tsaImage;
             }

--- a/FEBuilderGBA.Avalonia/Views/GraphicsToolView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/GraphicsToolView.axaml.cs
@@ -131,14 +131,13 @@ namespace FEBuilderGBA.Avalonia.Views
         /// directly, so we perform the same `/ 8` conversion here.
         ///
         /// <para>
-        /// Note (#1030): the Avalonia <c>GraphicsToolViewViewModel</c> now
-        /// consumes <paramref name="tsa"/> + <paramref name="tsaType"/> and
+        /// Note (#1030 / #1074): the Avalonia <c>GraphicsToolViewViewModel</c>
+        /// now consumes <paramref name="tsa"/> + <paramref name="tsaType"/> and
         /// routes the preview through <c>ImageTSAEditorCore.TryRenderMainImage</c>
-        /// (TSA-composited, fixed 4bpp + LZ77 image). The
-        /// <paramref name="paletteType"/> (compressed palette) and
-        /// <paramref name="image2"/> (2nd-image join) parameters are still
-        /// accepted for WinForms signature parity but are NOT yet consumed by
-        /// the Avalonia preview path — both are deferred follow-ups.
+        /// (TSA-composited, fixed 4bpp + LZ77 image). #1074 additionally wires
+        /// <paramref name="image2"/> (2nd-image join, gated on
+        /// <paramref name="imageType"/> == 2) and <paramref name="paletteType"/>
+        /// == 1 (LZ77-compressed palette) into that same preview path.
         /// </para>
         ///
         /// Parameter semantics mirror WF (see <c>GraphicsToolForm.Draw()</c>
@@ -149,8 +148,8 @@ namespace FEBuilderGBA.Avalonia.Views
         ///     (single, 2nd-joined, or other compressed modes);
         ///     1 = raw uncompressed. Battle BG callsites pass 0.</item>
         ///   <item><c>tsaType</c> / <c>paletteType</c>: 1 = LZ77-compressed
-        ///     in Battle BG callsites; 0 = raw. (Recorded on the WF VM;
-        ///     not yet consumed by the Avalonia decoder — see note above.)</item>
+        ///     in Battle BG callsites; 0 = raw. <c>paletteType == 1</c> now
+        ///     selects the LZ77-compressed palette decode (#1074).</item>
         ///   <item><c>paletteCount</c>: number of 16-color rows the WF form
         ///     would show.</item>
         /// </list>
@@ -163,9 +162,11 @@ namespace FEBuilderGBA.Avalonia.Views
         /// <param name="tsa">ROM offset or GBA pointer of the TSA data.</param>
         /// <param name="tsaType">WF `TSAOption.SelectedIndex` value (kept for parity).</param>
         /// <param name="palette">ROM offset or GBA pointer of the palette.</param>
-        /// <param name="paletteType">WF `PaletteOption.SelectedIndex` value (kept for parity).</param>
+        /// <param name="paletteType">WF `PaletteOption.SelectedIndex` value
+        ///   (1 = LZ77-compressed palette decode, #1074).</param>
         /// <param name="paletteCount">Number of 16-color rows the WF form would show.</param>
-        /// <param name="image2">Secondary image address (WF "Image 2" — unused in AV preview).</param>
+        /// <param name="image2">Secondary image address (WF "Image 2"); joined
+        ///   after the first when <paramref name="imageType"/> == 2 (#1074).</param>
         public void Jump(int width, int height, uint image, int imageType,
             uint tsa, int tsaType, uint palette, int paletteType,
             int paletteCount, uint image2)
@@ -192,6 +193,17 @@ namespace FEBuilderGBA.Avalonia.Views
                 // to the 5 populated items 0..4).
                 _vm.TsaAddressText = tsa == 0 ? "" : $"0x{NormalizeGbaPointer(tsa):X08}";
                 _vm.TsaTypeIndex = System.Math.Clamp(tsaType, 0, 4);
+
+                // #1074: feed the image2-join + compressed-palette context to the
+                // preview. A 0 image2 pointer maps to "" (empty box) like the TSA
+                // address above. IsImage2Join is gated on the WF imageType == 2
+                // (the join mode), NOT merely image2 != 0 (#1074 refinement #5),
+                // so a non-join mode that still carries a 2nd address does not
+                // accidentally join. IsCompressedPalette mirrors WF
+                // PaletteOption == 1 (paletteType == 1).
+                _vm.Image2AddressText = image2 == 0 ? "" : $"0x{NormalizeGbaPointer(image2):X08}";
+                _vm.IsImage2Join = (imageType == 2);
+                _vm.IsCompressedPalette = (paletteType == 1);
 
                 // WF passes pixels; AV stores tile counts. Convert.
                 _vm.TileCountX = System.Math.Max(1, width / 8);

--- a/FEBuilderGBA.Core.Tests/ImageTSAEditorCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ImageTSAEditorCoreTests.cs
@@ -982,6 +982,270 @@ namespace FEBuilderGBA.Core.Tests
             });
         }
 
+        // =================================================================
+        // image2-join + compressed paletteType (#1074) — the 10-arg
+        // TryRenderMainImage overload.
+        //   * image2 join: a 2nd LZ77 tile image is concatenated AFTER the
+        //     first (order image ++ image2), so a TSA cell with a tile index
+        //     >= image1's tile count reaches the joined image2 tiles.
+        //   * compressed palette: the palette address is an LZ77 stream
+        //     (paletteType == 1) clamped to <=512 bytes.
+        //   * backward-compat: the 8-arg wrapper == the 10-arg with
+        //     image2Addr:0, isCompressedPalette:false.
+        //   * no-throw: corrupt/near-EOF compressed palette -> null (NOT a raw
+        //     fallback); invalid/zero image2 -> single image; near-EOF LZ77-TSA
+        //     pointer -> null.
+        // Reuses the MarkerTiles + StandardPalette synthetic harness.
+        // =================================================================
+
+        // Image2 lives at a separate offset from IMAGE_OFFSET (0x1000) and the
+        // TSA (0x4000) / palette (0x8000) so the planted streams never overlap.
+        const uint IMAGE2_OFFSET = 0x2000;
+
+        /// <summary>image2 = a single tile that is entirely color index 2
+        /// (green in bank 0). Joined after MarkerTiles()'s 2 tiles, this becomes
+        /// tile index 2.</summary>
+        static byte[] Image2GreenTile()
+        {
+            byte[] tiles = new byte[1 * 32];
+            FillTile(tiles, 0, 2); // all index 2
+            return tiles;
+        }
+
+        [Fact]
+        public void Image2Join_TsaCellReachesSecondImageTile()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());                  // 2 tiles (idx 0,1)
+                PlantBytes(rom, IMAGE2_OFFSET, LZ77.compress(Image2GreenTile())); // tile idx 2
+                PlantPalette(rom, StandardPalette());
+                // TSA cell references tile index 2 -> ONLY reachable via image2.
+                PlantRawCells(rom, TSA_OFFSET, new ushort[] { Cell(2, false, false, 0) });
+
+                using IImage joined = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET,
+                    image2Addr: IMAGE2_OFFSET, isCompressedPalette: false);
+
+                Assert.NotNull(joined);
+                // image2 tile 2 is all green -> pixel (0,0) is green.
+                AssertPixel(joined, 0, 0, 0, 248, 0, 255);
+
+                // WITHOUT image2 the same tile index 2 is out of range -> that
+                // cell renders blank (alpha 0). Prove the two renders differ.
+                using IImage single = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET,
+                    image2Addr: 0u, isCompressedPalette: false);
+
+                Assert.NotNull(single);
+                byte[] singlePx = single.GetPixelData();
+                Assert.Equal(0, singlePx[(0 * single.Width + 0) * 4 + 3]); // (0,0) transparent
+                Assert.NotEqual(joined.GetPixelData(), single.GetPixelData());
+            });
+        }
+
+        [Fact]
+        public void Image2Join_ZeroOrInvalid_RendersSingleImage()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+                PlantRawCells(rom, TSA_OFFSET, new ushort[] { Cell(1, false, false, 0) });
+
+                // image2Addr 0 -> no-op (single image), no throw.
+                using IImage zero = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET,
+                    image2Addr: 0u, isCompressedPalette: false);
+                Assert.NotNull(zero);
+                AssertPixel(zero, 0, 0, 0, 248, 0, 255); // tile 1 marker
+
+                // image2Addr pointing at a zero-filled (non-LZ77) region -> no-op
+                // (single image), no throw, byte-identical to the zero case.
+                using IImage invalid = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET,
+                    image2Addr: 0xC000u, isCompressedPalette: false);
+                Assert.NotNull(invalid);
+                Assert.Equal(zero.GetPixelData(), invalid.GetPixelData());
+            });
+        }
+
+        [Fact]
+        public void CompressedPalette_Bank0_EqualsRawPaletteRender()
+        {
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantRawCells(rom, TSA_OFFSET, new ushort[] { Cell(1, false, false, 0) });
+
+                byte[] rawPal = StandardPalette();           // 512-byte raw palette
+
+                // Render A: RAW palette at PALETTE_OFFSET (isCompressedPalette:false).
+                PlantPalette(rom, rawPal);
+                using IImage rawRender = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET,
+                    image2Addr: 0u, isCompressedPalette: false);
+                Assert.NotNull(rawRender);
+
+                // Render B: the SAME colors, LZ77-compressed, decoded with
+                // isCompressedPalette:true at a separate offset.
+                const uint COMP_PAL_OFFSET = 0xA000;
+                PlantBytes(rom, COMP_PAL_OFFSET, LZ77.compress(rawPal));
+                using IImage compRender = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, COMP_PAL_OFFSET,
+                    image2Addr: 0u, isCompressedPalette: true);
+                Assert.NotNull(compRender);
+
+                // Identical colors -> identical PNG.
+                Assert.Equal(rawRender.EncodePng(), compRender.EncodePng());
+            });
+        }
+
+        [Fact]
+        public void CompressedPalette_NonzeroBank512Bytes_EqualsRawPaletteRender()
+        {
+            // Refinement #3: exercise a FULL 512-byte palette with a NONZERO bank
+            // (bank 3), not only bank 0, so the compressed decode covers the
+            // whole 16-bank block.
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                // Cell uses palette bank 3.
+                PlantRawCells(rom, TSA_OFFSET, new ushort[] { Cell(1, false, false, 3) });
+
+                // 512-byte palette: bank 3 idx1 = blue, idx2 = white (so the
+                // bank-3 colors are nonzero and distinct from bank 0).
+                byte[] rawPal = new byte[512];
+                SetColor(rawPal, 3, 1, BLUE);
+                SetColor(rawPal, 3, 2, WHITE);
+                Assert.Equal(512, rawPal.Length);
+
+                PlantPalette(rom, rawPal);
+                using IImage rawRender = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET,
+                    image2Addr: 0u, isCompressedPalette: false);
+                Assert.NotNull(rawRender);
+                // bank 3 idx2 (marker) = white; idx1 = blue.
+                AssertPixel(rawRender, 0, 0, 248, 248, 248, 255);
+                AssertPixel(rawRender, 1, 0, 0, 0, 248, 255);
+
+                const uint COMP_PAL_OFFSET = 0xA000;
+                PlantBytes(rom, COMP_PAL_OFFSET, LZ77.compress(rawPal));
+                using IImage compRender = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, COMP_PAL_OFFSET,
+                    image2Addr: 0u, isCompressedPalette: true);
+                Assert.NotNull(compRender);
+
+                Assert.Equal(rawRender.EncodePng(), compRender.EncodePng());
+            });
+        }
+
+        [Fact]
+        public void EightArgWrapper_EqualsTenArgWithDefaults()
+        {
+            // Refinement #4: the 8-arg back-compat wrapper must be byte-identical
+            // to the 10-arg with image2Addr:0, isCompressedPalette:false.
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+                PlantRawCells(rom, TSA_OFFSET, new ushort[]
+                {
+                    Cell(1, false, false, 0), Cell(0, false, false, 0),
+                    Cell(1, true, false, 0),  Cell(1, false, true, 0),
+                });
+
+                using IImage eight = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 2, 2, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET);
+                using IImage ten = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 2, 2, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET,
+                    image2Addr: 0u, isCompressedPalette: false);
+
+                Assert.NotNull(eight);
+                Assert.NotNull(ten);
+                Assert.Equal(eight.EncodePng(), ten.EncodePng());
+            });
+        }
+
+        [Fact]
+        public void CompressedPalette_CorruptStream_ReturnsNull_NoRawFallback()
+        {
+            // Refinement #2: a bad compressed-palette stream returns null (NOT a
+            // silent raw read), so a paletteType==1 failure is visible.
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantRawCells(rom, TSA_OFFSET, new ushort[] { Cell(1, false, false, 0) });
+                // PALETTE_OFFSET holds a valid RAW palette, but we ask for a
+                // compressed decode -> the (non-LZ77) bytes there are not a valid
+                // stream -> getCompressedSize == 0 -> null (no raw fallback).
+                PlantPalette(rom, StandardPalette());
+
+                using IImage img = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, PALETTE_OFFSET,
+                    image2Addr: 0u, isCompressedPalette: true);
+                Assert.Null(img);
+            });
+        }
+
+        [Fact]
+        public void CompressedPalette_NearRomEnd_ReturnsNull_NoThrow()
+        {
+            // Refinement #2: a truncated LZ77 palette near the ROM end must return
+            // null (no throw, no raw fallback).
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantRawCells(rom, TSA_OFFSET, new ushort[] { Cell(1, false, false, 0) });
+                // Valid 0x10 header claiming 0x100 bytes, planted 4 bytes from the
+                // ROM end -> getCompressedSize == 0.
+                uint addr = (uint)rom.Data.Length - 4;
+                rom.Data[addr + 0] = 0x10;
+                rom.Data[addr + 1] = 0x00;
+                rom.Data[addr + 2] = 0x01;
+                rom.Data[addr + 3] = 0x00;
+
+                using IImage img = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, false, TSA_OFFSET, addr,
+                    image2Addr: 0u, isCompressedPalette: true);
+                Assert.Null(img);
+            });
+        }
+
+        [Fact]
+        public void Lz77Tsa_PointerNearRomEnd_ReturnsNull_NoThrow()
+        {
+            // Refinement #1: an LZ77-TSA pointer in the last 1-3 ROM bytes passes
+            // isSafetyOffset but would throw inside getCompressedSize without the
+            // 4-byte-header guard. With the guard it returns null (no throw — there
+            // is no try/catch here).
+            WithImageService(() =>
+            {
+                var rom = MakeRom();
+                PlantImage(rom, MarkerTiles());
+                PlantPalette(rom, StandardPalette());
+
+                int addr = rom.Data.Length - 3;       // only 3 header bytes in-bounds
+                rom.Data[addr + 0] = 0x10;            // LZ77 magic
+                rom.Data[addr + 1] = 0x00;
+                rom.Data[addr + 2] = 0x01;
+                // addr+3 is out of range -- the guard must reject BEFORE
+                // getCompressedSize touches input[addr+3].
+
+                using IImage img = ImageTSAEditorCore.TryRenderMainImage(
+                    rom, 1, 1, IMAGE_OFFSET, false, true /*isLZ77TSA*/, (uint)addr, PALETTE_OFFSET,
+                    image2Addr: 0u, isCompressedPalette: false);
+                Assert.Null(img);
+            });
+        }
+
         // -----------------------------------------------------------------
         // Helpers
         // -----------------------------------------------------------------

--- a/FEBuilderGBA.Core/ImageTSAEditorCore.cs
+++ b/FEBuilderGBA.Core/ImageTSAEditorCore.cs
@@ -52,6 +52,11 @@ namespace FEBuilderGBA
         /// addresses. Returns the composed <see cref="IImage"/> sized
         /// <paramref name="width8"/>*8 x <paramref name="height8"/>*8 pixels, or
         /// <c>null</c> on any null/out-of-bounds/corrupt input (never throws).
+        ///
+        /// 8-arg back-compat wrapper (#1074 refinement #4): delegates to the
+        /// 10-arg overload with <c>image2Addr: 0</c> + <c>isCompressedPalette:
+        /// false</c>, so this call is BYTE-IDENTICAL to the pre-#1074 behaviour
+        /// (#1030 entrypoints, the #810 tests).
         /// </summary>
         /// <param name="rom">Loaded ROM.</param>
         /// <param name="width8">Canvas width in 8-pixel tiles.</param>
@@ -63,18 +68,74 @@ namespace FEBuilderGBA
         /// <param name="paletteAddr">Resolved ROM offset of the palette block.</param>
         public static IImage TryRenderMainImage(ROM rom, uint width8, uint height8,
             uint imageAddr, bool isHeaderTSA, bool isLZ77TSA, uint tsaAddr, uint paletteAddr)
+            => TryRenderMainImage(rom, width8, height8, imageAddr, isHeaderTSA,
+                isLZ77TSA, tsaAddr, paletteAddr, 0u, false);
+
+        /// <summary>
+        /// Render the TSA-composited main image with optional <b>image2-join</b>
+        /// and <b>compressed-palette</b> support (#1074). Returns the composed
+        /// <see cref="IImage"/> sized <paramref name="width8"/>*8 x
+        /// <paramref name="height8"/>*8 pixels, or <c>null</c> on any
+        /// null/out-of-bounds/corrupt input (never throws).
+        ///
+        /// With the defaults (<paramref name="image2Addr"/> = 0,
+        /// <paramref name="isCompressedPalette"/> = false) this is BYTE-IDENTICAL
+        /// to the pre-#1074 8-arg render path (#1030 byte-identical).
+        /// </summary>
+        /// <param name="rom">Loaded ROM.</param>
+        /// <param name="width8">Canvas width in 8-pixel tiles.</param>
+        /// <param name="height8">Canvas height in 8-pixel tiles.</param>
+        /// <param name="imageAddr">Resolved ROM offset of the LZ77 tile image.</param>
+        /// <param name="isHeaderTSA">True if the TSA stream carries a {w,h} header.</param>
+        /// <param name="isLZ77TSA">True if the TSA stream is LZ77-compressed.</param>
+        /// <param name="tsaAddr">Resolved ROM offset of the TSA stream.</param>
+        /// <param name="paletteAddr">Resolved ROM offset of the palette block.</param>
+        /// <param name="image2Addr">Resolved ROM offset of a SECOND LZ77 tile
+        ///   image to join after the first (WF <c>ImageOption == 2</c>, order
+        ///   <c>image ++ image2</c>). 0 or invalid ⇒ single image (no join).</param>
+        /// <param name="isCompressedPalette">True if the palette block is an LZ77
+        ///   stream (WF <c>PaletteOption == 1</c>); false ⇒ RAW palette read.</param>
+        public static IImage TryRenderMainImage(ROM rom, uint width8, uint height8,
+            uint imageAddr, bool isHeaderTSA, bool isLZ77TSA, uint tsaAddr, uint paletteAddr,
+            uint image2Addr = 0, bool isCompressedPalette = false)
         {
             if (rom == null || rom.RomInfo == null || rom.Data == null) return null;
             if (CoreState.ImageService == null) return null;
             if (width8 == 0 || height8 == 0) return null;
 
-            // Shared LZ77-image-decode + raw-palette read (with the truncation
-            // guards). Behaviour-preserving extraction -- see
-            // TryLoadTSATileAndPalette. RenderChipList reuses the SAME loader.
+            // Shared LZ77-image-decode + palette read (raw OR compressed, with the
+            // truncation guards). See TryLoadTSATileAndPalette. RenderChipList /
+            // RenderRawTilesheet reuse the SAME loader (raw palette only).
             if (!TryLoadTSATileAndPalette(rom, imageAddr, paletteAddr,
-                                          out byte[] tileData, out byte[] palette))
+                                          out byte[] tileData, out byte[] palette,
+                                          isCompressedPalette))
             {
                 return null;
+            }
+
+            // --- image2 join (#1074, mirrors WF ImageOption == 2; order
+            // image ++ image2) ---
+            // If image2Addr is a valid non-zero LZ77 pointer, decompress it and
+            // concatenate AFTER the first image's tiles so a TSA cell with a tile
+            // index >= image1's tile count reaches the joined image2 tiles. An
+            // invalid / zero image2 is a no-op (single image). Never throws.
+            if (image2Addr != 0
+                && U.isSafetyOffset(image2Addr, rom)
+                && IsLZ77HeaderSafe(rom, image2Addr))
+            {
+                uint img2Compressed = LZ77.getCompressedSize(rom.Data, image2Addr);
+                if (img2Compressed != 0
+                    && (ulong)image2Addr + img2Compressed <= (ulong)rom.Data.Length)
+                {
+                    byte[] tile2 = LZ77.decompress(rom.Data, image2Addr);
+                    if (tile2 != null && tile2.Length != 0)
+                    {
+                        byte[] joined = new byte[tileData.Length + tile2.Length];
+                        Array.Copy(tileData, 0, joined, 0, tileData.Length);
+                        Array.Copy(tile2, 0, joined, tileData.Length, tile2.Length);
+                        tileData = joined;
+                    }
+                }
             }
 
             int wTiles = (int)width8;
@@ -85,6 +146,11 @@ namespace FEBuilderGBA
             // --- TSA data ---
             if (isLZ77TSA)
             {
+                // #1074 refinement #1: a TSA pointer in the last 1-3 ROM bytes
+                // passes isSafetyOffset yet would throw inside getCompressedSize
+                // (it reads input[tsaAddr+3]). Guard the full 4-byte LZ77 header
+                // BEFORE getCompressedSize (mirrors the image path).
+                if (!IsLZ77HeaderSafe(rom, tsaAddr)) return null;
                 uint tsaCompressed = LZ77.getCompressedSize(rom.Data, tsaAddr);
                 if (tsaCompressed == 0) return null;
                 if ((ulong)tsaAddr + tsaCompressed > (ulong)rom.Data.Length) return null;
@@ -149,9 +215,11 @@ namespace FEBuilderGBA
 
             // Same LZ77-image-decode + raw-palette read as TryRenderMainImage
             // (inherits the isSafetyOffset / getCompressedSize / end-of-ROM
-            // truncation guards). The chip list never reads the TSA stream.
+            // truncation guards). The chip list never reads the TSA stream and
+            // always uses a RAW palette (isCompressedPalette: false).
             if (!TryLoadTSATileAndPalette(rom, imageAddr, paletteAddr,
-                                          out byte[] tileData, out byte[] palette))
+                                          out byte[] tileData, out byte[] palette,
+                                          isCompressedPalette: false))
             {
                 return null;
             }
@@ -234,9 +302,11 @@ namespace FEBuilderGBA
             if (CoreState.ImageService == null) return null;
 
             // Same LZ77-image-decode + raw-palette read as TryRenderMainImage /
-            // RenderChipList. The raw tilesheet never reads the TSA stream.
+            // RenderChipList. The raw tilesheet never reads the TSA stream and
+            // always uses a RAW palette (isCompressedPalette: false).
             if (!TryLoadTSATileAndPalette(rom, imageAddr, paletteAddr,
-                                          out byte[] tileData, out byte[] palette))
+                                          out byte[] tileData, out byte[] palette,
+                                          isCompressedPalette: false))
             {
                 return null;
             }
@@ -271,8 +341,8 @@ namespace FEBuilderGBA
 
         /// <summary>
         /// Shared loader extracted from <see cref="TryRenderMainImage"/> (#819):
-        /// LZ77-decode the tile image and read the raw (≤512-byte) palette block
-        /// from already-resolved ROM addresses. Behaviour-preserving -- returns
+        /// LZ77-decode the tile image and read the palette block from
+        /// already-resolved ROM addresses. Behaviour-preserving -- returns
         /// <c>false</c> exactly where the inline block previously returned
         /// <c>null</c> (the #810 <see cref="TryRenderMainImage"/> tests pin this).
         ///
@@ -280,12 +350,30 @@ namespace FEBuilderGBA
         /// <c>LZ77.decompress</c> silently returns a zero-filled buffer on a
         /// truncated stream, so <c>getCompressedSize == 0</c> + an end-of-ROM
         /// bound check is the truncation guard (mirrors ImageBattleScreenCore's
-        /// TryLoadChipsetAndPalette). The palette read is RAW (no LZ77), clamped
-        /// to ROM end; <c>DecodeTileToPixels</c> bounds-checks short palettes so
-        /// a clamped read is safe.
+        /// TryLoadChipsetAndPalette).
+        ///
+        /// Palette read (#1074):
+        /// <list type="bullet">
+        ///   <item><paramref name="isCompressedPalette"/> <c>false</c> — RAW read
+        ///     (no LZ77), clamped to ROM end (≤512 bytes / 16 banks). UNCHANGED:
+        ///     byte-for-byte identical to the pre-#1074 loader for every existing
+        ///     caller. <c>DecodeTileToPixels</c> bounds-checks short palettes so a
+        ///     clamped read is safe.</item>
+        ///   <item><paramref name="isCompressedPalette"/> <c>true</c> — the palette
+        ///     address is an LZ77 stream (WF <c>PaletteOption == 1</c>): guard the
+        ///     full 4-byte header (<see cref="IsLZ77HeaderSafe"/>) +
+        ///     <c>getCompressedSize != 0</c> + an end-of-ROM bound, decompress,
+        ///     then clamp to <see cref="PALETTE_BYTES"/> (512) like WF
+        ///     <c>U.subrange(decompressed, 0, 0x20*16)</c> — take up to 512 bytes
+        ///     (fewer if the decompressed buffer is shorter; NOT required to be
+        ///     exactly 512). A decode FAILURE (bad header / null / empty) returns
+        ///     <c>false</c> — NO silent fall back to a raw read (so the
+        ///     paletteType==1 failure surfaces as a null render, #1074
+        ///     refinement #2).</item>
+        /// </list>
         /// </summary>
         static bool TryLoadTSATileAndPalette(ROM rom, uint imageAddr, uint paletteAddr,
-            out byte[] tiles, out byte[] palette)
+            out byte[] tiles, out byte[] palette, bool isCompressedPalette)
         {
             tiles = null;
             palette = null;
@@ -309,17 +397,40 @@ namespace FEBuilderGBA
             byte[] tileData = LZ77.decompress(rom.Data, imageAddr);
             if (tileData == null || tileData.Length == 0) return false;
 
-            // --- Palette: RAW up to 512 bytes (16 banks), clamped to ROM end
-            // (no LZ77). ---
+            // --- Palette ---
             if (!U.isSafetyOffset(paletteAddr, rom)) return false;
-            int palBytes = PALETTE_BYTES;
-            if ((ulong)paletteAddr + (ulong)palBytes > (ulong)rom.Data.Length)
+
+            byte[] palBuf;
+            if (isCompressedPalette)
             {
-                palBytes = (int)((ulong)rom.Data.Length - paletteAddr);
+                // LZ77-compressed palette (WF PaletteOption == 1). Guard the full
+                // 4-byte header + truncation BEFORE decompress, then clamp to 512
+                // bytes (WF U.subrange(decompressed, 0, 0x20*16)). A decode
+                // failure returns false -- NO raw fallback (#1074 refinement #2).
+                if (!IsLZ77HeaderSafe(rom, paletteAddr)) return false;
+                uint palCompressed = LZ77.getCompressedSize(rom.Data, paletteAddr);
+                if (palCompressed == 0) return false;
+                if ((ulong)paletteAddr + palCompressed > (ulong)rom.Data.Length) return false;
+                byte[] decompressed = LZ77.decompress(rom.Data, paletteAddr);
+                if (decompressed == null || decompressed.Length == 0) return false;
+
+                // Clamp to PALETTE_BYTES (take fewer if the buffer is shorter).
+                int palLen = Math.Min(decompressed.Length, PALETTE_BYTES);
+                palBuf = new byte[palLen];
+                Array.Copy(decompressed, palBuf, palLen);
             }
-            if (palBytes <= 0) return false;
-            byte[] palBuf = new byte[palBytes];
-            Array.Copy(rom.Data, paletteAddr, palBuf, 0, palBytes);
+            else
+            {
+                // RAW up to 512 bytes (16 banks), clamped to ROM end (no LZ77).
+                int palBytes = PALETTE_BYTES;
+                if ((ulong)paletteAddr + (ulong)palBytes > (ulong)rom.Data.Length)
+                {
+                    palBytes = (int)((ulong)rom.Data.Length - paletteAddr);
+                }
+                if (palBytes <= 0) return false;
+                palBuf = new byte[palBytes];
+                Array.Copy(rom.Data, paletteAddr, palBuf, 0, palBytes);
+            }
 
             tiles = tileData;
             palette = palBuf;
@@ -463,8 +574,10 @@ namespace FEBuilderGBA
             if (width8 == 0 || height8 == 0) return null;
             if (cells == null) return null;
 
+            // In-memory cell editing always renders against a RAW palette.
             if (!TryLoadTSATileAndPalette(rom, imageAddr, paletteAddr,
-                                          out byte[] tileData, out byte[] palette))
+                                          out byte[] tileData, out byte[] palette,
+                                          isCompressedPalette: false))
             {
                 return null;
             }

--- a/docs/avalonia-forms.md
+++ b/docs/avalonia-forms.md
@@ -294,7 +294,7 @@ Editors for portraits, sprites, battle animations, tilesets, and other graphics.
 | 172 | BattleTerrainViewerView | BattleTerrainViewerViewModel | Battle terrain viewer |
 | 173 | ChapterTitleViewerView | ChapterTitleViewerViewModel | Chapter title image viewer |
 | 174 | BigCGViewerView | BigCGViewerViewModel | Large CG image viewer |
-| 175 | GraphicsToolView | GraphicsToolViewViewModel | Graphics tool main view (TSA-composited preview via ImageTSAEditorCore.TryRenderMainImage, #1030; image2-join + compressed paletteType deferred) |
+| 175 | GraphicsToolView | GraphicsToolViewViewModel | Graphics tool main view (TSA-composited preview via ImageTSAEditorCore.TryRenderMainImage, #1030; image2-join + LZ77-compressed paletteType wired in via the 10-arg overload, #1074) |
 | 176 | GraphicsToolPatchMakerView | GraphicsToolPatchMakerViewViewModel | Graphics patch creation tool |
 | 177 | MantAnimationView | MantAnimationViewModel | Map/mant animation viewer |
 | 178 | OAMSPView | OAMSPViewModel | OAM sprite editor |


### PR DESCRIPTION
## Summary
Completes the #1030 Graphics Tool TSA preview with the two deferred pieces: **image2-join** (WF `ImageOption==2`) and **compressed paletteType** (WF `PaletteOption==1`, e.g. Battle BG). Both are bounded **read-only rendering** extensions of `ImageTSAEditorCore.TryRenderMainImage` — no ROM mutation.

Plan: https://github.com/laqieer/FEBuilderGBA/issues/1074#issuecomment-4662980088 (Copilot CLI plan review: direction correct → **all 6 refinements folded in**, https://github.com/laqieer/FEBuilderGBA/issues/1074#issuecomment-4663027242).

## Scope
- **Closes #1074** · **Ref #1030**.

## Changes
**Core — `ImageTSAEditorCore`** (defaults ⇒ #1030 callers **byte-identical**):
- The existing 8-arg `TryRenderMainImage` is now a **delegating wrapper** to a new 10-arg overload adding `uint image2Addr = 0, bool isCompressedPalette = false`.
- **image2 join** (`image ++ image2`, mirrors WF `ImageOption==2`): when `image2Addr` is a valid in-bounds LZ77 pointer, decompress Image2 and concatenate to the primary tile data before TSA decode; invalid/zero ⇒ single image.
- **compressed palette**: `TryLoadTSATileAndPalette` gains `isCompressedPalette` — LZ77-decompress the palette stream (clamped like WF `U.subrange(decompressed, 0, 0x20*16)` to ≤512 bytes). A corrupt/near-EOF compressed palette returns **null** (NOT a silent raw fallback that would keep wrong colors).
- **TSA guard hardening**: the existing `isLZ77TSA` branch now runs the full-4-byte `IsLZ77HeaderSafe` guard before `getCompressedSize`, so a near-EOF TSA pointer returns null instead of throwing.

**Avalonia — `GraphicsToolView` Jump + `GraphicsToolViewViewModel`**: capture `IsImage2Join = (imageType == 2)`, `IsCompressedPalette = (paletteType == 1)`, `Image2AddressText`; `DrawTiles` forwards `image2Off` + `IsCompressedPalette` to the 10-arg seam.

## Test plan
- [x] **Core** (`ImageTSAEditorCoreTests`, **+9**): image2-join reachability (a TSA tile index only present in the concatenated Image2 region renders, differing from the no-join render); compressed-palette `EncodePng`-equals the raw-palette render of the same colors (incl. a **nonzero-bank 512-byte** case); 8-arg wrapper == 10-arg defaults (byte-identical); corrupt/near-EOF compressed palette ⇒ null no-throw (no raw fallback); invalid image2 ⇒ single image; **near-EOF LZ77-TSA ⇒ null, no throw**.
- [x] **Avalonia** (`GraphicsToolViewModelTsaTests` behavioral + `GraphicsToolViewJumpTests` parity): `DrawTiles` with `IsImage2Join`/`IsCompressedPalette` renders the joined image2 tile / the compressed-palette colors; `Jump(imageType=2,paletteType=1)` sets the props.
- [x] Core ImageTSAEditor 55/0, Avalonia GraphicsTool 33/0, full **Avalonia.Tests 7792/0** (+3 skips), full **Core.Tests 3064 pass** (10 pre-existing `config/patch2` env skips) — no regression.

## Screenshots
Real FE8U: **Battle BG editor → Graphics Tool** (jumps with `paletteType=1` compressed palette). The TSA-composited preview now renders with **correct colors** — note the info line **"LZ77 palette"** (the compressed-palette decode path), vs the prior wrong-color raw read:

![Graphics Tool TSA preview with decompressed (correct) palette](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1074-graphics-tool-compressed-palette.png)

The image2-join path is proven by the Core behavioral test (no stock-FE8U jump passes image2).

## GUI Test Report
| Case | Result |
| --- | --- |
| Battle BG → Graphics Tool renders the TSA preview | ✅ live |
| Compressed palette (paletteType=1) → **correct colors** | ✅ "LZ77 palette", screenshot |
| image2-join renders the second image's tiles | ✅ Core + Avalonia behavioral test |
| Corrupt compressed palette → null (no wrong-color fallback) | ✅ Core test |
| Near-EOF LZ77 image/TSA/palette → null, no throw | ✅ Core test |
| #1030 callers byte-identical (default params) | ✅ wrapper regression test |

🤖 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.168` · model `claude-opus-4-8[1m]`
