### PR TITLE
fix(avalonia): Map Settings FE6 — wire Refetch + Jump-to-MapEditor + Jump-to-ExitPoint (#1003)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/MapSettingFE6JumpWiringTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/MapSettingFE6JumpWiringTests.cs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1003 — wiring tests for the FE6 Map Settings editor's three inert
+// placeholder buttons that are now functional: Refetch (再取得),
+// Jump-to-MapEditor (マップエディタへJump), Jump-to-ExitPoint (離脱ポイントへJump).
+//
+// Two layers of proof:
+//   1. Headless Avalonia (AvaloniaFact): construct the view and assert the
+//      three wired buttons exist + are ENABLED, and the two deferred
+//      placeholders (Expand list, Map style change) remain DISABLED.
+//   2. Source-text scan (Fact): the three .Click += handler wirings are
+//      present in the code-behind, and the three placeholder names lost their
+//      IsEnabled="False" in the .axaml (while the two deferred ones keep it).
+//      This guards CI even if the headless runtime regresses.
+using System;
+using System.IO;
+using global::Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    public class MapSettingFE6JumpWiringTests
+    {
+        // ---- Layer 1: headless construction + button enabled-state ----
+
+        [AvaloniaFact]
+        public void MapSettingFE6View_WiredButtons_Exist_And_Enabled()
+        {
+            var view = new MapSettingFE6View();
+
+            var refetch = view.FindControl<Button>("RefetchButton");
+            var jumpMap = view.FindControl<Button>("JumpMapEditorButton");
+            var jumpExit = view.FindControl<Button>("JumpExitPointButton");
+
+            Assert.NotNull(refetch);
+            Assert.NotNull(jumpMap);
+            Assert.NotNull(jumpExit);
+
+            Assert.True(refetch!.IsEnabled, "RefetchButton must be enabled (wired).");
+            Assert.True(jumpMap!.IsEnabled, "JumpMapEditorButton must be enabled (wired).");
+            Assert.True(jumpExit!.IsEnabled, "JumpExitPointButton must be enabled (wired).");
+        }
+
+        [AvaloniaFact]
+        public void MapSettingFE6View_DeferredPlaceholders_Remain_Disabled()
+        {
+            var view = new MapSettingFE6View();
+
+            var expand = view.FindControl<Button>("ExpandListPlaceholder");
+            var mapStyle = view.FindControl<Button>("MapStyleChangePlaceholder");
+
+            Assert.NotNull(expand);
+            Assert.NotNull(mapStyle);
+
+            Assert.False(expand!.IsEnabled, "ExpandListPlaceholder must stay disabled (deferred).");
+            Assert.False(mapStyle!.IsEnabled, "MapStyleChangePlaceholder must stay disabled (deferred).");
+        }
+
+        // ---- Layer 2: source-text wiring scan (CI-safe, no runtime) ----
+
+        private static string FindProjectRoot()
+        {
+            string dir = AppDomain.CurrentDomain.BaseDirectory;
+            for (int i = 0; i < 12; i++)
+            {
+                if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                    return dir;
+                string? parent = Path.GetDirectoryName(dir);
+                if (parent == null || parent == dir) break;
+                dir = parent;
+            }
+            throw new InvalidOperationException("Could not find project root (FEBuilderGBA.sln)");
+        }
+
+        private static string ViewsDir()
+            => Path.Combine(FindProjectRoot(), "FEBuilderGBA.Avalonia", "Views");
+
+        [Fact]
+        public void CodeBehind_Wires_Three_Click_Handlers()
+        {
+            string src = File.ReadAllText(Path.Combine(ViewsDir(), "MapSettingFE6View.axaml.cs"));
+            Assert.Contains("RefetchButton.Click += OnRefetchClick", src);
+            Assert.Contains("JumpMapEditorButton.Click += OnJumpMapEditorClick", src);
+            Assert.Contains("JumpExitPointButton.Click += OnJumpExitPointClick", src);
+            // Handlers themselves exist.
+            Assert.Contains("void OnRefetchClick(", src);
+            Assert.Contains("void OnJumpMapEditorClick(", src);
+            Assert.Contains("void OnJumpExitPointClick(", src);
+            // Refetch must RESELECT the kept address, not row 0.
+            Assert.Contains("EntryList.SelectAddress(keep)", src);
+        }
+
+        [Fact]
+        public void Axaml_Wired_Buttons_Lost_IsEnabledFalse_DeferredKeepIt()
+        {
+            string xaml = File.ReadAllText(Path.Combine(ViewsDir(), "MapSettingFE6View.axaml"));
+
+            // The three wired buttons are renamed (no longer *Placeholder) and
+            // do not carry IsEnabled="False".
+            Assert.Contains("Name=\"RefetchButton\"", xaml);
+            Assert.Contains("Name=\"JumpMapEditorButton\"", xaml);
+            Assert.Contains("Name=\"JumpExitPointButton\"", xaml);
+            Assert.DoesNotContain("Name=\"RefetchPlaceholder\"", xaml);
+            Assert.DoesNotContain("Name=\"JumpMapEditorPlaceholder\"", xaml);
+            Assert.DoesNotContain("Name=\"JumpExitPointPlaceholder\"", xaml);
+
+            // The two deferred placeholders keep their disabled state — assert
+            // IsEnabled="False" still sits on each of their specific lines.
+            foreach (var line in xaml.Split('\n'))
+            {
+                if (line.Contains("Name=\"ExpandListPlaceholder\"") ||
+                    line.Contains("Name=\"MapStyleChangePlaceholder\""))
+                {
+                    Assert.Contains("IsEnabled=\"False\"", line);
+                }
+                // The three wired buttons must NOT carry IsEnabled="False".
+                if (line.Contains("Name=\"RefetchButton\"") ||
+                    line.Contains("Name=\"JumpMapEditorButton\"") ||
+                    line.Contains("Name=\"JumpExitPointButton\""))
+                {
+                    Assert.DoesNotContain("IsEnabled=\"False\"", line);
+                }
+            }
+
+            // AutomationIds preserved for all five buttons.
+            Assert.Contains("MapSettingFE6_Refetch_Button", xaml);
+            Assert.Contains("MapSettingFE6_JumpMapEditor_Button", xaml);
+            Assert.Contains("MapSettingFE6_JumpExitPoint_Button", xaml);
+            Assert.Contains("MapSettingFE6_ExpandList_Button", xaml);
+            Assert.Contains("MapSettingFE6_MapStyleChange_Button", xaml);
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/MapSettingFE6JumpWiringTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/MapSettingFE6JumpWiringTests.cs
@@ -111,23 +111,27 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.DoesNotContain("Name=\"JumpMapEditorPlaceholder\"", xaml);
             Assert.DoesNotContain("Name=\"JumpExitPointPlaceholder\"", xaml);
 
-            // The two deferred placeholders keep their disabled state — assert
-            // IsEnabled="False" still sits on each of their specific lines.
-            foreach (var line in xaml.Split('\n'))
+            // Scope the disabled-state assertions to each <Button> ELEMENT (not
+            // a single source line) so a harmless attribute-wrapping reformat
+            // can't spuriously fail the test (Copilot bot review on #1086).
+            // [^>]* matches across newlines, so this captures the full opening
+            // tag even when attributes wrap.
+            var buttonTags = System.Text.RegularExpressions.Regex.Matches(xaml, @"<Button\b[^>]*?/?>");
+            bool sawExpand = false, sawMapStyle = false, sawRefetch = false, sawJumpMap = false, sawJumpExit = false;
+            foreach (System.Text.RegularExpressions.Match m in buttonTags)
             {
-                if (line.Contains("Name=\"ExpandListPlaceholder\"") ||
-                    line.Contains("Name=\"MapStyleChangePlaceholder\""))
-                {
-                    Assert.Contains("IsEnabled=\"False\"", line);
-                }
-                // The three wired buttons must NOT carry IsEnabled="False".
-                if (line.Contains("Name=\"RefetchButton\"") ||
-                    line.Contains("Name=\"JumpMapEditorButton\"") ||
-                    line.Contains("Name=\"JumpExitPointButton\""))
-                {
-                    Assert.DoesNotContain("IsEnabled=\"False\"", line);
-                }
+                string el = m.Value;
+                // Deferred placeholders MUST keep IsEnabled="False".
+                if (el.Contains("Name=\"ExpandListPlaceholder\"")) { sawExpand = true; Assert.Contains("IsEnabled=\"False\"", el); }
+                if (el.Contains("Name=\"MapStyleChangePlaceholder\"")) { sawMapStyle = true; Assert.Contains("IsEnabled=\"False\"", el); }
+                // Wired buttons MUST NOT carry IsEnabled="False".
+                if (el.Contains("Name=\"RefetchButton\"")) { sawRefetch = true; Assert.DoesNotContain("IsEnabled=\"False\"", el); }
+                if (el.Contains("Name=\"JumpMapEditorButton\"")) { sawJumpMap = true; Assert.DoesNotContain("IsEnabled=\"False\"", el); }
+                if (el.Contains("Name=\"JumpExitPointButton\"")) { sawJumpExit = true; Assert.DoesNotContain("IsEnabled=\"False\"", el); }
             }
+            // Guard against the regex silently matching nothing.
+            Assert.True(sawExpand && sawMapStyle && sawRefetch && sawJumpMap && sawJumpExit,
+                "All five Button elements must be found by the element scan.");
 
             // AutomationIds preserved for all five buttons.
             Assert.Contains("MapSettingFE6_Refetch_Button", xaml);

--- a/FEBuilderGBA.Avalonia.Tests/MapSettingFE6JumpWiringTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/MapSettingFE6JumpWiringTests.cs
@@ -61,14 +61,20 @@ namespace FEBuilderGBA.Avalonia.Tests
 
         private static string FindProjectRoot()
         {
-            string dir = AppDomain.CurrentDomain.BaseDirectory;
-            for (int i = 0; i < 12; i++)
+            // Try the build-output dir first, then the current working dir —
+            // some CI runners/layouts launch the test host from a different CWD,
+            // so a single starting point is brittle (matches sibling tests).
+            foreach (var start in new[] { AppDomain.CurrentDomain.BaseDirectory, Directory.GetCurrentDirectory() })
             {
-                if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
-                    return dir;
-                string? parent = Path.GetDirectoryName(dir);
-                if (parent == null || parent == dir) break;
-                dir = parent;
+                string dir = start;
+                for (int i = 0; i < 12; i++)
+                {
+                    if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                        return dir;
+                    string? parent = Path.GetDirectoryName(dir);
+                    if (parent == null || parent == dir) break;
+                    dir = parent;
+                }
             }
             throw new InvalidOperationException("Could not find project root (FEBuilderGBA.sln)");
         }

--- a/FEBuilderGBA.Avalonia/ViewModels/MapSettingFE6ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapSettingFE6ViewModel.cs
@@ -335,5 +335,13 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public List<AddrResult> LoadList() => LoadMapSettingList();
         public uint TilesetPLIST => ObjectTypePLIST;
         public uint MapPLIST => MapPointerPLIST;
+
+        /// <summary>
+        /// Current map id (list index) derived from <see cref="CurrentAddr"/>,
+        /// or <see cref="U.NOT_FOUND"/> when the address does not resolve to an
+        /// enumerated map-setting entry. Read on demand by the jump handlers, so
+        /// it does not raise PropertyChanged.
+        /// </summary>
+        public uint CurrentMapId => MapSettingCore.GetMapIdFromAddr(CoreState.ROM, CurrentAddr);
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/MapSettingFE6View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapSettingFE6View.axaml
@@ -10,7 +10,7 @@
       <TextBlock DockPanel.Dock="Top" Text="先頭アドレス" Margin="2,0,2,2" FontWeight="Bold" />
       <TextBlock DockPanel.Dock="Top" Text="読込数" Margin="2,0,2,2" Foreground="Gray" FontSize="11" />
       <Button AutomationProperties.AutomationId="MapSettingFE6_ExpandList_Button" DockPanel.Dock="Top" Name="ExpandListPlaceholder" Content="リストの拡張" IsEnabled="False" Margin="2" />
-      <Button AutomationProperties.AutomationId="MapSettingFE6_Refetch_Button" DockPanel.Dock="Top" Name="RefetchPlaceholder" Content="再取得" IsEnabled="False" Margin="2" />
+      <Button AutomationProperties.AutomationId="MapSettingFE6_Refetch_Button" DockPanel.Dock="Top" Name="RefetchButton" Content="再取得" Margin="2" />
       <controls:AddressListControl AutomationProperties.AutomationId="MapSettingFE6_Entry_List" Name="EntryList" />
     </DockPanel>
 
@@ -262,10 +262,12 @@
               <TextBlock Grid.Row="3" Grid.Column="3" Text="ワールドマップポイントY" VerticalAlignment="Center" />
               <NumericUpDown AutomationProperties.AutomationId="MapSettingFE6_B66_Input" FormatString="0" Grid.Row="3" Grid.Column="4" Name="NB66" Minimum="0" Maximum="255" />
 
-              <!-- KnownGap placeholders for WF jump-to-editor links. Surface
-                   as non-functional Buttons so labels-sweep sees them. -->
-              <Button AutomationProperties.AutomationId="MapSettingFE6_JumpMapEditor_Button" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Name="JumpMapEditorPlaceholder" Content="マップエディタへJump" IsEnabled="False" Margin="0,4,0,0" />
-              <Button AutomationProperties.AutomationId="MapSettingFE6_JumpExitPoint_Button" Grid.Row="4" Grid.Column="3" Grid.ColumnSpan="2" Name="JumpExitPointPlaceholder" Content="離脱ポイントへJump" IsEnabled="False" Margin="0,4,0,0" />
+              <!-- WF jump-to-editor links (#1003). MapEditorView keys its list by
+                   the same MakeMapIDList addresses, so the editor jump passes
+                   CurrentAddr; the exit-point jump resolves the map id to its
+                   pointer-table slot via MapExitPointCore. -->
+              <Button AutomationProperties.AutomationId="MapSettingFE6_JumpMapEditor_Button" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Name="JumpMapEditorButton" Content="マップエディタへJump" Margin="0,4,0,0" />
+              <Button AutomationProperties.AutomationId="MapSettingFE6_JumpExitPoint_Button" Grid.Row="4" Grid.Column="3" Grid.ColumnSpan="2" Name="JumpExitPointButton" Content="離脱ポイントへJump" Margin="0,4,0,0" />
             </Grid>
           </StackPanel>
         </Border>

--- a/FEBuilderGBA.Avalonia/Views/MapSettingFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapSettingFE6View.axaml.cs
@@ -20,7 +20,49 @@ namespace FEBuilderGBA.Avalonia.Views
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
             WriteButton.Click += OnWriteClick;
+            RefetchButton.Click += OnRefetchClick;
+            JumpMapEditorButton.Click += OnJumpMapEditorClick;
+            JumpExitPointButton.Click += OnJumpExitPointClick;
             Opened += (_, _) => LoadList();
+        }
+
+        // 再取得 — reload the entry list and reselect the current entry. Zero mutation.
+        void OnRefetchClick(object? sender, RoutedEventArgs e)
+        {
+            uint keep = _vm.CurrentAddr;
+            LoadList();
+            if (keep != 0) EntryList.SelectAddress(keep);
+        }
+
+        // マップエディタへJump — Avalonia ADDRESS-keyed bridge. WF J_ID_MAPEDITOR
+        // passes the selected map id to MapEditorForm.JumpTo(mapid); here we pass
+        // CurrentAddr because MapEditorView keys its list by the same
+        // MakeMapIDList addresses (verified identical address space). Not a literal
+        // WF link-value match, but equivalent.
+        void OnJumpMapEditorClick(object? sender, RoutedEventArgs e)
+        {
+            if (_vm.CurrentAddr == 0) return;
+            try { WindowManager.Instance.Navigate<MapEditorView>(_vm.CurrentAddr); }
+            catch (Exception ex) { Log.Error("MapSettingFE6View.JumpMapEditor failed: {0}", ex.ToString()); }
+        }
+
+        // 離脱ポイントへJump — map id -> exit-point table slot -> navigate.
+        void OnJumpExitPointClick(object? sender, RoutedEventArgs e)
+        {
+            if (_vm.CurrentAddr == 0) return;
+            try
+            {
+                uint mapId = _vm.CurrentMapId;
+                if (mapId == U.NOT_FOUND) return;
+                uint slot = MapExitPointCore.GetMapEntrySlotAddr(CoreState.ROM, mapId);
+                if (slot == U.NOT_FOUND)
+                {
+                    CoreState.Services?.ShowInfo("No exit-point entry exists for this map.");
+                    return;
+                }
+                WindowManager.Instance.Navigate<MapExitPointView>(slot);
+            }
+            catch (Exception ex) { Log.Error("MapSettingFE6View.JumpExitPoint failed: {0}", ex.ToString()); }
         }
 
         void LoadList()

--- a/FEBuilderGBA.Core.Tests/MapExitPointCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/MapExitPointCoreTests.cs
@@ -402,6 +402,50 @@ public class MapExitPointCoreTests
         Assert.Equal(0u, count);
     }
 
+    // -----------------------------------------------------------------
+    // GetMapEntrySlotAddr — map id -> filter-0 pointer-table slot (#1003)
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void GetMapEntrySlotAddr_NullRom_ReturnsNotFound()
+    {
+        Assert.Equal(U.NOT_FOUND, MapExitPointCore.GetMapEntrySlotAddr(null!, 0));
+    }
+
+    [Fact]
+    public void GetMapEntrySlotAddr_ValidMapId_ReturnsBasePlusMapIdTimesFour()
+    {
+        // tableAddr is the filter-0 base; map 0 -> base, map 2 -> base + 2*4.
+        ROM rom = MakeFe8uWithExitTable(enemyCount: 4, npcCount: 2);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            uint baseAddr = MapExitPointCore.ResolveBaseAddress(rom, filterIndex: 0);
+            Assert.Equal(baseAddr, MapExitPointCore.GetMapEntrySlotAddr(rom, 0));
+            Assert.Equal(baseAddr + 2u * 4u, MapExitPointCore.GetMapEntrySlotAddr(rom, 2));
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
+    [Fact]
+    public void GetMapEntrySlotAddr_MapIdBeyondPopulatedRange_ReturnsNotFound()
+    {
+        // The synthetic ROM plants 4 enemy entries then a zero (NULL) slot.
+        // A map id well beyond the populated/cap range has no entry in
+        // ListMapEntries(rom, 0), so the slot lookup must report NOT_FOUND.
+        ROM rom = MakeFe8uWithExitTable(enemyCount: 4, npcCount: 2);
+        var prevRom = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            uint npcBlockAdd = rom.RomInfo.map_exit_point_npc_blockadd; // FE8U = 65 (the cap)
+            Assert.Equal(U.NOT_FOUND, MapExitPointCore.GetMapEntrySlotAddr(rom, npcBlockAdd));
+            Assert.Equal(U.NOT_FOUND, MapExitPointCore.GetMapEntrySlotAddr(rom, 0xFFFFu));
+        }
+        finally { CoreState.ROM = prevRom; }
+    }
+
     [Fact]
     public void NewAlloc_RolledBackByUndoScope_RestoresOriginalPointer()
     {

--- a/FEBuilderGBA.Core.Tests/MapSettingCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/MapSettingCoreTests.cs
@@ -424,6 +424,108 @@ namespace FEBuilderGBA.Core.Tests
             }
         }
 
+        // ---- GetMapIdFromAddr (#1003 — FE6 Map Settings Jump-to-MapEditor) ----
+
+        /// <summary>
+        /// Build a synthetic FE6 ROM whose map-setting table at
+        /// <paramref name="baseAddr"/> holds <paramref name="mapCount"/> valid
+        /// pointer-backed rows (each <c>map_setting_datasize</c> bytes) followed
+        /// by an all-zero terminator row (fails IsMapSettingValid). Returns the
+        /// loaded ROM and reports the base offset + per-row size via out params.
+        /// </summary>
+        static ROM MakeFe6WithMapTable(out uint baseAddr, out uint dataSize, int mapCount = 4)
+        {
+            var rom = new ROM();
+            rom.LoadLow("synthetic-fe6.gba", new byte[0x1000000], "AFEJ01");
+            baseAddr = 0x200u;
+            dataSize = rom.RomInfo.map_setting_datasize; // FE6 = 68 or 72
+
+            WriteU32(rom.Data, (int)rom.RomInfo.map_setting_pointer, 0x08000000 + baseAddr);
+            // Each valid row's first dword is a pointer → IsMapSettingValid true.
+            for (int i = 0; i < mapCount; i++)
+            {
+                uint rowAddr = baseAddr + (uint)i * dataSize;
+                WriteU32(rom.Data, (int)rowAddr, 0x08000300); // pointer-backed → valid
+            }
+            // Terminator row (all-zero) at index mapCount → IsMapSettingValid false.
+            // The buffer is already zero there; nothing to write.
+            return rom;
+        }
+
+        [Fact]
+        public void GetMapIdFromAddr_NullRom_ReturnsNotFound()
+        {
+            Assert.Equal(U.NOT_FOUND, MapSettingCore.GetMapIdFromAddr(null!, 0x200u));
+        }
+
+        [Fact]
+        public void GetMapIdFromAddr_ValidAddresses_ReturnsCorrectId()
+        {
+            ROM rom = MakeFe6WithMapTable(out uint baseAddr, out uint dataSize, mapCount: 4);
+            Assert.Equal(0u, MapSettingCore.GetMapIdFromAddr(rom, baseAddr));
+            Assert.Equal(1u, MapSettingCore.GetMapIdFromAddr(rom, baseAddr + dataSize));
+            Assert.Equal(3u, MapSettingCore.GetMapIdFromAddr(rom, baseAddr + 3u * dataSize));
+        }
+
+        [Fact]
+        public void GetMapIdFromAddr_PointerFormAndOffsetForm_ResolveSame()
+        {
+            ROM rom = MakeFe6WithMapTable(out uint baseAddr, out uint dataSize, mapCount: 4);
+            uint offsetAddr = baseAddr + 2u * dataSize;
+            uint pointerAddr = offsetAddr + 0x08000000u;
+            Assert.Equal(2u, MapSettingCore.GetMapIdFromAddr(rom, offsetAddr));
+            Assert.Equal(MapSettingCore.GetMapIdFromAddr(rom, offsetAddr),
+                         MapSettingCore.GetMapIdFromAddr(rom, pointerAddr));
+        }
+
+        [Fact]
+        public void GetMapIdFromAddr_BelowBase_ReturnsNotFound()
+        {
+            ROM rom = MakeFe6WithMapTable(out uint baseAddr, out _, mapCount: 4);
+            Assert.Equal(U.NOT_FOUND, MapSettingCore.GetMapIdFromAddr(rom, baseAddr - 4u));
+        }
+
+        [Fact]
+        public void GetMapIdFromAddr_MisalignedAddr_ReturnsNotFound()
+        {
+            ROM rom = MakeFe6WithMapTable(out uint baseAddr, out _, mapCount: 4);
+            Assert.Equal(U.NOT_FOUND, MapSettingCore.GetMapIdFromAddr(rom, baseAddr + 1u));
+        }
+
+        [Fact]
+        public void GetMapIdFromAddr_TerminatorRow_ReturnsNotFound()
+        {
+            // base + mapCount*dataSize is the all-zero terminator row → must be
+            // rejected by the IsMapSettingValid gate (not reported as a map id).
+            ROM rom = MakeFe6WithMapTable(out uint baseAddr, out uint dataSize, mapCount: 4);
+            Assert.Equal(U.NOT_FOUND, MapSettingCore.GetMapIdFromAddr(rom, baseAddr + 4u * dataSize));
+            // One row past the terminator (also aligned, also invalid).
+            Assert.Equal(U.NOT_FOUND, MapSettingCore.GetMapIdFromAddr(rom, baseAddr + 5u * dataSize));
+        }
+
+        [Fact]
+        public void GetMapIdFromAddr_RecordPastEof_ReturnsNotFound()
+        {
+            // The record START is in-bounds but start+datasize runs past EOF.
+            var rom = new ROM();
+            rom.LoadLow("synthetic-fe6.gba", new byte[0x1000000], "AFEJ01");
+            // Place the table base 4 bytes before EOF so an aligned row (delta 0)
+            // is in-bounds at the start but baseAddr + dataSize overruns the buffer.
+            uint baseAddr = (uint)rom.Data.Length - 4u;
+            WriteU32(rom.Data, (int)rom.RomInfo.map_setting_pointer, 0x08000000 + baseAddr);
+            Assert.Equal(U.NOT_FOUND, MapSettingCore.GetMapIdFromAddr(rom, baseAddr));
+        }
+
+        [Fact]
+        public void GetMapIdFromAddr_ZeroBasePointer_ReturnsNotFound()
+        {
+            // map_setting_pointer slot reads 0 (zero-filled) → unsafe base.
+            var rom = new ROM();
+            rom.LoadLow("synthetic-fe6.gba", new byte[0x1000000], "AFEJ01");
+            // Do NOT plant a base pointer — p32(slot) == 0 → isSafetyOffset false.
+            Assert.Equal(U.NOT_FOUND, MapSettingCore.GetMapIdFromAddr(rom, 0x200u));
+        }
+
         static void WriteU32(byte[] data, int offset, uint value)
         {
             data[offset + 0] = (byte)(value & 0xFF);

--- a/FEBuilderGBA.Core.Tests/MapSettingCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/MapSettingCoreTests.cs
@@ -504,6 +504,30 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void GetMapIdFromAddr_ValidLookingRowAfterTerminator_ReturnsNotFound()
+        {
+            // Rows 0,1 valid; row 2 all-zero terminator; row 3 valid-looking
+            // (pointer-backed). MakeMapIDList stops at row 2 (count == 2), so the
+            // post-terminator row 3 is NOT an enumerated entry even though it
+            // passes IsMapSettingValid in isolation — must resolve to NOT_FOUND.
+            // (Regression for Copilot CLI review #1086 blocking finding #2.)
+            var rom = new ROM();
+            rom.LoadLow("synthetic-fe6.gba", new byte[0x1000000], "AFEJ01");
+            uint baseAddr = 0x200u;
+            uint dataSize = rom.RomInfo.map_setting_datasize;
+            WriteU32(rom.Data, (int)rom.RomInfo.map_setting_pointer, 0x08000000 + baseAddr);
+            WriteU32(rom.Data, (int)(baseAddr + 0u * dataSize), 0x08000300); // row 0 valid
+            WriteU32(rom.Data, (int)(baseAddr + 1u * dataSize), 0x08000300); // row 1 valid
+            // row 2 left all-zero → terminator (IsMapSettingValid false)
+            WriteU32(rom.Data, (int)(baseAddr + 3u * dataSize), 0x08000300); // row 3 valid-looking
+
+            Assert.Equal(2, MapSettingCore.MakeMapIDList(rom).Count);
+            Assert.Equal(0u, MapSettingCore.GetMapIdFromAddr(rom, baseAddr));
+            Assert.Equal(1u, MapSettingCore.GetMapIdFromAddr(rom, baseAddr + 1u * dataSize));
+            Assert.Equal(U.NOT_FOUND, MapSettingCore.GetMapIdFromAddr(rom, baseAddr + 3u * dataSize));
+        }
+
+        [Fact]
         public void GetMapIdFromAddr_RecordPastEof_ReturnsNotFound()
         {
             // The record START is in-bounds but start+datasize runs past EOF.

--- a/FEBuilderGBA.Core/MapExitPointCore.cs
+++ b/FEBuilderGBA.Core/MapExitPointCore.cs
@@ -124,6 +124,26 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
+        /// The exit-point pointer-table SLOT address for a given map id, taken
+        /// from the main (filter 0) table via <see cref="ListMapEntries(ROM, uint)"/>
+        /// (so it respects the <c>npc_blockadd</c> cap). Returns
+        /// <see cref="U.NOT_FOUND"/> when no entry exists for that map id.
+        /// PURE / read-only — used by the FE6 Map Settings "Jump to ExitPoint".
+        /// </summary>
+        public static uint GetMapEntrySlotAddr(ROM rom, uint mapId)
+        {
+            if (rom == null) return U.NOT_FOUND;
+
+            // filterIndex 0 is the DEFAULT / enemy exit-point table. NPC exit
+            // entries live in the npc_blockadd-shifted table (filter 1) and are
+            // intentionally NOT selected by this Map Settings jump.
+            var entries = ListMapEntries(rom, 0);
+            foreach (var e in entries)
+                if (e.tag == mapId) return e.addr;
+            return U.NOT_FOUND;
+        }
+
+        /// <summary>
         /// Walk the per-map exit-point block starting at
         /// <paramref name="exitPointAddr"/> (the dereferenced pointer value
         /// — NOT a slot). Each row is 4 bytes; the walk stops on the first

--- a/FEBuilderGBA.Core/MapSettingCore.cs
+++ b/FEBuilderGBA.Core/MapSettingCore.cs
@@ -109,12 +109,17 @@ namespace FEBuilderGBA
             // Overflow-safe full-row EOF bound — the entire record must be in ROM.
             if ((ulong)addr + dataSize > (ulong)rom.Data.Length) return U.NOT_FOUND;
 
-            // Validity gate: an aligned address PAST the table terminator (or on
-            // trailing garbage) must NOT produce a plausible map id. Reject any
-            // address that fails the same heuristic MakeMapIDList stops on.
-            if (!IsMapSettingValid(rom, addr)) return U.NOT_FOUND;
-
-            return delta / dataSize;
+            // Gate against the ENUMERATED list, not just IsMapSettingValid on the
+            // candidate row in isolation: MakeMapIDList stops at the first invalid
+            // (terminator) row, so a valid-looking row AFTER an earlier terminator
+            // is NOT a real map entry and must resolve to NOT_FOUND. Require the
+            // candidate id to be in the list AND map back to the exact same
+            // address (Copilot CLI review on #1086).
+            uint id = delta / dataSize;
+            var list = MakeMapIDList(rom);
+            if (id >= (uint)list.Count) return U.NOT_FOUND;
+            if (list[(int)id].addr != addr) return U.NOT_FOUND;
+            return id;
         }
 
         /// <summary>

--- a/FEBuilderGBA.Core/MapSettingCore.cs
+++ b/FEBuilderGBA.Core/MapSettingCore.cs
@@ -93,7 +93,11 @@ namespace FEBuilderGBA
             if (basePointer == 0 || dataSize == 0) return U.NOT_FOUND;
 
             // Guard the pointer SLOT before dereferencing it via p32.
+            // isSafetyOffset only checks basePointer < Data.Length; p32 reads 4
+            // bytes, so also require the full 4-byte slot to be in ROM (overflow
+            // -safe) to keep this method truly non-throwing as documented.
             if (!U.isSafetyOffset(basePointer, rom)) return U.NOT_FOUND;
+            if ((ulong)basePointer + 4 > (ulong)rom.Data.Length) return U.NOT_FOUND;
 
             uint baseAddr = rom.p32(basePointer);
             if (!U.isSafetyOffset(baseAddr, rom)) return U.NOT_FOUND;

--- a/FEBuilderGBA.Core/MapSettingCore.cs
+++ b/FEBuilderGBA.Core/MapSettingCore.cs
@@ -66,6 +66,54 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
+        /// Map a map-setting DATA address back to its map id (list index).
+        /// Inverse of <see cref="MakeMapIDList(ROM)"/>'s
+        /// <c>baseAddr + i*dataSize</c>. PURE / read-only.
+        ///
+        /// Returns <see cref="U.NOT_FOUND"/> when the rom/RomInfo is null, the
+        /// map-setting pointer slot or datasize is unusable, the table base is
+        /// unsafe, <paramref name="addr"/> is below the table base, not aligned
+        /// to a row boundary, has a row that runs past EOF, or is an aligned
+        /// address that does NOT correspond to an enumerated map entry (i.e. it
+        /// fails the same terminator/validity heuristic the list builder uses —
+        /// this rejects a plausible-but-bogus id for an aligned address past the
+        /// table terminator). Pointer-form input (0x080xxxxx) is normalized to a
+        /// ROM offset before the lookup.
+        /// </summary>
+        public static uint GetMapIdFromAddr(ROM rom, uint addr)
+        {
+            if (rom == null || rom.RomInfo == null) return U.NOT_FOUND;
+            if (addr == U.NOT_FOUND) return U.NOT_FOUND;
+
+            // Accept a GBA pointer (0x080xxxxx) as well as a raw ROM offset.
+            if (U.isPointer(addr)) addr = U.toOffset(addr);
+
+            uint basePointer = rom.RomInfo.map_setting_pointer;
+            uint dataSize = rom.RomInfo.map_setting_datasize;
+            if (basePointer == 0 || dataSize == 0) return U.NOT_FOUND;
+
+            // Guard the pointer SLOT before dereferencing it via p32.
+            if (!U.isSafetyOffset(basePointer, rom)) return U.NOT_FOUND;
+
+            uint baseAddr = rom.p32(basePointer);
+            if (!U.isSafetyOffset(baseAddr, rom)) return U.NOT_FOUND;
+
+            if (addr < baseAddr) return U.NOT_FOUND;
+            uint delta = addr - baseAddr;
+            if (delta % dataSize != 0) return U.NOT_FOUND;
+
+            // Overflow-safe full-row EOF bound — the entire record must be in ROM.
+            if ((ulong)addr + dataSize > (ulong)rom.Data.Length) return U.NOT_FOUND;
+
+            // Validity gate: an aligned address PAST the table terminator (or on
+            // trailing garbage) must NOT produce a plausible map id. Reject any
+            // address that fails the same heuristic MakeMapIDList stops on.
+            if (!IsMapSettingValid(rom, addr)) return U.NOT_FOUND;
+
+            return delta / dataSize;
+        }
+
+        /// <summary>
         /// Get the number of valid maps in <c>CoreState.ROM</c>.
         /// </summary>
         public static int GetMapCount()


### PR DESCRIPTION
## Summary
Wires three inert placeholder buttons in the **FE6 Map Settings** editor (zero ROM mutation):
- **再取得 (Refetch)** — reload the entry list + reselect the current entry.
- **マップエディタへJump** — `Navigate<MapEditorView>(CurrentAddr)`. `MapEditorViewModel.LoadList()` returns the same `MapSettingCore.MakeMapIDList()`, so the two editors share an address space (an address-keyed bridge to WF `MapEditorForm.JumpTo(mapid)`).
- **離脱ポイントへJump** — derive map id → `MapExitPointCore.GetMapEntrySlotAddr` (default/enemy filter 0) → `Navigate<MapExitPointView>(slot)`.

## Scope
**Refs #1003** — completes Refetch + Jump-to-MapEditor + Jump-to-ExitPoint. Deferrals (per the issue's acceptance criteria):
- **List Expand** → follow-up **#1085** (needs `ExpandsFillOption.FIRST` + complete reference repointing — the FE6 list is validity-gated so a zero-fill row never enumerates, and the engine-referenced table base needs more than a single-slot repoint).
- **Map Style Change popup** (needs the missing `MapStyleEditorAppendPopup`) and **BGM ♪ play** (needs a GBA audio engine) remain documented deferrals.

Plan posted on #1003 and **accepted by Copilot CLI plan review** (GPT-5.5); all its guardrails folded in.

## What changed
**Core (PURE, read-only):**
- `MapSettingCore.GetMapIdFromAddr(rom, addr)` — addr → map id, fully guarded: null, `NOT_FOUND`, pointer-form normalize (`U.toOffset`), pointer-slot bounds before `p32`, zero base/datasize, below-base, misalignment, overflow-safe EOF, and an **`IsMapSettingValid` validity gate** so an aligned address *past* the table terminator returns `NOT_FOUND` instead of a bogus id.
- `MapExitPointCore.GetMapEntrySlotAddr(rom, mapId)` — reuses `ListMapEntries(rom, 0)` and returns `NOT_FOUND` when the map id is absent (no manufactured `base + id*4`).

**Avalonia:** `MapSettingFE6ViewModel.CurrentMapId`; three `Click` handlers + three enabled/renamed buttons in `MapSettingFE6View`.

## Test plan
- [x] `MapSettingCore.GetMapIdFromAddr` — synthetic-ROM round-trip (ids 0/1/3) + negatives: below-base, misaligned, **post-terminator aligned**, past-EOF, pointer-vs-offset input, null rom → `NOT_FOUND`.
- [x] `MapExitPointCore.GetMapEntrySlotAddr` — correct slot for a valid id, `NOT_FOUND` for null rom / id past the table cap.
- [x] `MapSettingFE6JumpWiringTests` — headless `[AvaloniaFact]`: the three buttons exist + are **enabled**, the two deferred placeholders stay **disabled**; source-text `[Fact]`: the three `Click +=` wirings present, the three `IsEnabled="False"` removed (deferred two kept).
- [x] `dotnet test FEBuilderGBA.Core.Tests` (MapSetting+MapExitPoint filter) → **84 passed, 0 failed**.
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` (MapSettingFE6JumpWiring) → **4 passed, 0 failed**.
- [x] `FEBuilderGBA.Tests` (net9.0-windows) builds clean; no cross-project source-text assertion references the renamed buttons.
- [x] Live GUI: launched the Release build against `roms/FE6.gba`, opened the editor, invoked Jump-to-MapEditor (see GUI Test Report + screenshots).

## GUI Test Report
| Case | Result | Evidence |
|------|--------|----------|
| Editor opens populated (FE6 row 0, addr 0x006637AA) with 再取得 enabled, リストの拡張 disabled | ✅ PASS | screenshot 1 |
| Jump-to-MapEditor opens the Visual Map Editor at the **matching** Map ID 0x00 / addr 0x006637AA with that row selected (load-race resolved — deep-link lands despite `Opened`→`LoadList` timing) | ✅ PASS | screenshot 2 |
| Wired buttons enabled / deferred buttons disabled | ✅ PASS | headless `[AvaloniaFact]` |

## Screenshots
**Map Settings (FE6) — populated, Refetch enabled:**
![Map Settings FE6](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1003-mapsetting-fe6.png)

**Jump-to-MapEditor → Visual Map Editor at the matching map (load-race resolved):**
![Jump to Map Editor](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1003-mapeditor-jump.png)

<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.168` · model `claude-opus-4-8[1m]`</sub>
