### PR TITLE
chore(avalonia): TSA editor stale-comment cleanup — buttons wired + TSA write done (#1005)

### DIFF
--- a/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml.cs
@@ -8,9 +8,11 @@
 // open path stays harmless.
 //
 // All ROM-write handlers (Write / PaletteWrite) go through
-// _undoService.Begin/Commit/Rollback. The Clipboard / MainImageImport /
-// MainImageExport buttons are explicit IsEnabled=False stubs whose Click
-// handlers short-circuit — covered by KnownGap markers in the AXAML.
+// _undoService.Begin/Commit/Rollback. The Write button persists BOTH the edited
+// per-cell TSA (non-header; _vm.WriteTsa -> ImageTSAEditorCore.WriteTsaCells) and
+// the palette under ONE undo scope (#1005). The Clipboard / MainImageImport /
+// MainImageExport buttons are fully wired (#974/#901), gated on IsContextLoaded —
+// NOT IsEnabled=False stubs. Header-TSA per-cell editing is deferred to #1071.
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Input.Platform;

--- a/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml.cs
@@ -10,9 +10,11 @@
 // All ROM-write handlers (Write / PaletteWrite) go through
 // _undoService.Begin/Commit/Rollback. The Write button persists BOTH the edited
 // per-cell TSA (non-header; _vm.WriteTsa -> ImageTSAEditorCore.WriteTsaCells) and
-// the palette under ONE undo scope (#1005). The Clipboard / MainImageImport /
-// MainImageExport buttons are fully wired (#974/#901), gated on IsContextLoaded —
-// NOT IsEnabled=False stubs. Header-TSA per-cell editing is deferred to #1071.
+// the palette under ONE undo scope (#1005). The MainImageImport / MainImageExport
+// buttons are fully wired (#901/#974) and gated on IsContextLoaded; the Clipboard
+// button is wired and always enabled (read-only — copies the grid to the system
+// clipboard, no ROM context needed). None are IsEnabled=False stubs. Header-TSA
+// per-cell editing is deferred to #1071.
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Input.Platform;


### PR DESCRIPTION
## Summary
**chore / docs.** #1005's functional work is already merged — this PR corrects the last remaining acceptance item: a stale code-behind comment.

### #1005 acceptance criteria status
- ✅ **Per-cell TSA-edit grid + Write writes TSA + palette under an UndoService scope** — the "TSA Cell" tab has an X/Y editor (Tile ID + H/V flip + palette bank, `TsaCellApply_Click` → `_vm.SetCell`), and `Write_Click` persists BOTH the edited TSA (`_vm.WriteTsa` → `ImageTSAEditorCore.WriteTsaCells`, pointer-aware: raw in-place / LZ77-recompress-and-repoint) and the palette under one "Write TSA" undo scope with rollback. (Done in #1072 / earlier.)
- ✅ **Tests covering a TSA edit + write round-trip** — `ImageTSAEditorCellTests` (22 Core tests pass) + `ImageTSAEditorParityTests`.
- ✅ **Stale "IsEnabled=False stubs" comment removed** — **this PR.** The code-behind header comment still claimed Clipboard / MainImageImport / MainImageExport were "explicit IsEnabled=False stubs", but they are fully wired (#974/#901, gated on `IsContextLoaded`). Comment corrected to reflect the wired buttons + the TSA write.

Header-TSA per-cell editing stays deferred to **#1071** (bottom-to-top 32-wide stride + margin complexity); the cell panel is `CanEditCells`-gated off for `IsHeaderTSA`.

## Test plan
- [x] No test references the old comment text (the only match is an unrelated doc comment in `ImageTSAEditorParityTests`).
- [x] `dotnet build FEBuilderGBA.Avalonia` → Build succeeded (comment-only change).
- [x] `dotnet test FEBuilderGBA.Core.Tests --filter ImageTSAEditorCell` → 22 passed (the existing TSA edit/write round-trip coverage).

Comment-only change; no functional change, so no new screenshot (chore PR).

## Scope
**Closes #1005.** Header-TSA editing → #1071.

<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.168` · model `claude-opus-4-8[1m]`</sub>
