### PR TITLE
feat(avalonia): ROM Translation Override JP Font / WipeJP* flow — closes #1029

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ToolTranslateROMParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ToolTranslateROMParityTests.cs
@@ -586,6 +586,52 @@ public class ToolTranslateROMParityTests
         return rom;
     }
 
+    // -----------------------------------------------------------------
+    // #1029 — Override JP Font / WipeJP* wiring (source-text parity).
+    // The handler logic isn't unit-testable headlessly (modal dialogs +
+    // file I/O), so assert the wiring on the production source.
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void SimpleFire_NoLongerSurfacesWipeJPKnownGapMessage()
+    {
+        // The old "Use the WinForms tool for full JP-font wiping" KnownGap
+        // message must be gone now that the WipeJP* flow is cross-platform.
+        string src = File.ReadAllText(ViewCsPath());
+        Assert.DoesNotContain("Use the WinForms tool", src);
+        Assert.DoesNotContain("WipeJP* flow needs", src);
+    }
+
+    [Fact]
+    public void SimpleFire_PassesOverrideJpFontAndPrecondition_ToCore()
+    {
+        string src = File.ReadAllText(ViewCsPath());
+        // The Override flag is captured ONCE and forwarded to Core options.
+        Assert.Contains("bool overrideJpFont = _vm.SimpleOverrideJpFont", src);
+        Assert.Contains("OverrideJpFont = overrideJpFont", src);
+        // The ChapterNameText precondition is injected.
+        Assert.Contains("ChapterNameTextPrecondition", src);
+        Assert.Contains("SearchChapterNameToTextPatch", src);
+    }
+
+    [Fact]
+    public void ChapterNameTextRecommendation_InstallsPatch_OnApply()
+    {
+        string src = File.ReadAllText(ViewCsPath());
+        // Apply (UserApplied) must actually install the patch (WF parity);
+        // Skip leaves it absent.
+        Assert.Contains("if (!view.UserApplied) return", src);
+        Assert.Contains("InstallChapterNameToTextPatch", src);
+        Assert.Contains("PatchMetadataCore.ApplyPatch", src);
+    }
+
+    static string ViewCsPath()
+    {
+        string repoRoot = FindRepoRoot();
+        return Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "ToolTranslateROMView.axaml.cs");
+    }
+
     static string AxamlPath()
     {
         string repoRoot = FindRepoRoot();

--- a/FEBuilderGBA.Avalonia/ViewModels/PatchManagerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/PatchManagerViewModel.cs
@@ -308,7 +308,12 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             }
         }
 
-        static string ResolvePatchDirectory(string version)
+        /// <summary>
+        /// Resolve the config/patch2/{version} directory (exe dir, cwd, then repo
+        /// root in development). Public so other views (e.g. the ROM Translation
+        /// Tool's ChapterNameToText install) can reuse the single resolution path.
+        /// </summary>
+        public static string ResolvePatchDirectory(string version)
         {
             string exeDir = AppDomain.CurrentDomain.BaseDirectory;
 

--- a/FEBuilderGBA.Avalonia/Views/HowDoYouLikePatchView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/HowDoYouLikePatchView.axaml.cs
@@ -19,6 +19,18 @@ namespace FEBuilderGBA.Avalonia.Views
             _vm.Initialize();
         }
 
+        /// <summary>
+        /// Set the recommendation/explanation text shown in the dialog body
+        /// (the bound <see cref="HowDoYouLikePatchViewModel.PatchInfo"/>).
+        /// </summary>
+        public void SetPatchInfo(string info)
+        {
+            _vm.PatchInfo = info ?? string.Empty;
+        }
+
+        /// <summary>True when the user clicked Apply (vs. Skip).</summary>
+        public bool UserApplied => _vm.UserApplied;
+
         void Apply_Click(object? sender, RoutedEventArgs e)
         {
             _vm.UserApplied = true;

--- a/FEBuilderGBA.Avalonia/Views/ToolTranslateROMView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolTranslateROMView.axaml.cs
@@ -152,21 +152,30 @@ namespace FEBuilderGBA.Avalonia.Views
                 ToolTranslateROMViewModel.FromLanguageItemsRaw[
                     Math.Clamp(_vm.FromLanguageIndex, 0, ToolTranslateROMViewModel.FromLanguageItemsRaw.Length - 1)]);
 
+            // Capture the Override-JP-Font flag ONCE so the UI-thread precondition
+            // check, the worker-thread options, and the completion message all read
+            // the SAME value even if the checkbox changes mid-run. (A re-read race
+            // could otherwise let the worker wipe with OverrideJpFont=true while the
+            // precondition stayed at its not-checked default true — Copilot review #1101.)
+            bool overrideJpFont = _vm.SimpleOverrideJpFont;
+
             // Resolve the ChapterNameText precondition on the UI thread (BEFORE
             // the background Task.Run) — Avalonia modal dialogs must not be shown
             // from a worker thread. Mirrors WF
             // HowDoYouLikePatchForm.CheckAndShowPopupDialog(ChapterNameText): the
             // JP chapter-name wipe only proceeds when the ChapterNameToText patch
-            // is installed; if it isn't, surface the recommendation and re-check.
+            // is installed; if it isn't, surface the recommendation — and, when the
+            // user clicks Apply, install the patch — then re-check.
             bool chapterNameTextOk = true;
-            if (_vm.SimpleOverrideJpFont)
+            if (overrideJpFont)
             {
                 chapterNameTextOk = PatchDetection.SearchChapterNameToTextPatch(rom);
                 if (!chapterNameTextOk && rom.RomInfo.version == 8)
                 {
-                    await ShowChapterNameTextRecommendation();
-                    // Re-check: the user may have installed the patch via the
-                    // patch manager. The wipe proceeds only if it's now present.
+                    await ShowChapterNameTextRecommendation(rom);
+                    // Re-check: ShowChapterNameTextRecommendation installs the patch
+                    // when the user clicks Apply. The wipe proceeds only if it's now
+                    // present.
                     chapterNameTextOk = PatchDetection.SearchChapterNameToTextPatch(rom);
                 }
             }
@@ -188,7 +197,7 @@ namespace FEBuilderGBA.Avalonia.Views
                         TranslateDataFilename = _vm.TranslateDataPath,
                         FromLanguage = fromLang,
                         ToLanguage = toLang,
-                        OverrideJpFont = _vm.SimpleOverrideJpFont,
+                        OverrideJpFont = overrideJpFont,
                         // Precondition was resolved on the UI thread; pass the
                         // captured value (no dialog on the worker thread).
                         ChapterNameTextPrecondition = () => chapterNameTextOk,
@@ -200,10 +209,10 @@ namespace FEBuilderGBA.Avalonia.Views
 
                 _vm.UndoService.Commit();
                 string msg = $"Translation complete. {total} text entries written.";
-                if (_vm.SimpleOverrideJpFont)
+                if (overrideJpFont)
                 {
-                    msg += "\n\nOverride JP Font: the Japanese font tables were wiped " +
-                        "(class-reel font, chapter titles, and item/text fonts) to free space.";
+                    msg += "\n\n" + R._("Override JP Font: the Japanese font tables were wiped " +
+                        "(class-reel font, chapter titles, and item/text fonts) to free space.");
                 }
                 await ShowInfo(msg);
             }
@@ -465,24 +474,83 @@ namespace FEBuilderGBA.Avalonia.Views
         /// <summary>
         /// Surface the ChapterNameToText patch recommendation (the Avalonia
         /// counterpart of WF <c>HowDoYouLikePatchForm.CheckAndShowPopupDialog(ChapterNameText)</c>).
-        /// The dialog is informational — the JP chapter-name wipe only proceeds
-        /// when the patch is actually installed (re-checked by the caller), so
-        /// declining here simply skips the chapter-title portion of the wipe.
+        /// When the user clicks Apply, install the ChapterNameToText patch (the WF
+        /// dialog's Enable button calls <c>PatchForm.ApplyPatch</c>), so the
+        /// caller's re-check can then let the chapter-title wipe proceed. Clicking
+        /// Skip leaves the patch absent, and the wipe skips the chapter-title part.
         /// </summary>
-        async Task ShowChapterNameTextRecommendation()
+        async Task ShowChapterNameTextRecommendation(ROM rom)
         {
             try
             {
                 var view = new HowDoYouLikePatchView();
-                view.SetPatchInfo(
+                view.SetPatchInfo(R._(
                     "To display chapter titles as text (required before wiping the Japanese " +
-                    "chapter-title images), install the ChapterNameToText patch via the Patch " +
-                    "manager, then run the translation again.");
+                    "chapter-title images), the ChapterNameToText patch must be installed. " +
+                    "Apply it now?"));
                 await view.ShowDialog(this);
+                if (!view.UserApplied) return; // Skip — leave the patch absent.
+
+                // Apply the ChapterNameToText patch (mirrors WF Enable button ->
+                // PatchForm.ApplyPatch). On success the caller's re-check of
+                // SearchChapterNameToTextPatch passes and the wipe proceeds.
+                string result = InstallChapterNameToTextPatch(rom);
+                if (!PatchDetection.SearchChapterNameToTextPatch(rom))
+                {
+                    await ShowInfo(R._("Could not install the ChapterNameToText patch.") +
+                        "\n" + result);
+                }
             }
             catch (Exception ex)
             {
                 Log.Error("ToolTranslateROMView.ShowChapterNameTextRecommendation: {0}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Find and apply the "Convert Chapter Titles to Text" patch for the
+        /// current ROM version (the WF ChapterNameToText patch). Returns a status
+        /// message. Mirrors <see cref="PatchManagerViewModel.InstallPatch"/>'s
+        /// enumerate -&gt; ApplyPatch path. The mutation is recorded in the active
+        /// translate undo scope.
+        /// </summary>
+        string InstallChapterNameToTextPatch(ROM rom)
+        {
+            try
+            {
+                string version = rom.RomInfo.VersionToFilename;
+                string patchDir = PatchManagerViewModel.ResolvePatchDirectory(version);
+                string lang = PatchMetadataCore.GetLanguageSuffix();
+                var infos = PatchMetadataCore.EnumeratePatches(patchDir, rom, lang);
+
+                // Match the WF ChapterNameToText installer patch by name.
+                var target = infos.FirstOrDefault(p =>
+                    p.Name.IndexOf("Convert Chapter Titles to Text",
+                        StringComparison.OrdinalIgnoreCase) >= 0);
+                if (target == null || string.IsNullOrEmpty(target.PatchFilePath))
+                    return "ChapterNameToText patch not found in " + patchDir;
+
+                // The patch install is a distinct user action (the Apply button),
+                // so it gets its OWN undo scope — separate from the translate undo
+                // begun later in SimpleFire_Click.
+                _vm.UndoService.Begin("Install ChapterNameToText");
+                try
+                {
+                    var res = PatchMetadataCore.ApplyPatch(rom, target.PatchFilePath,
+                        _vm.UndoService.GetActiveUndoData());
+                    _vm.UndoService.Commit();
+                    return res.Message ?? string.Empty;
+                }
+                catch
+                {
+                    _vm.UndoService.Rollback();
+                    throw;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ToolTranslateROMView.InstallChapterNameToTextPatch: {0}", ex.Message);
+                return ex.Message;
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ToolTranslateROMView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolTranslateROMView.axaml.cs
@@ -128,9 +128,10 @@ namespace FEBuilderGBA.Avalonia.Views
         //    SkiaFontRasterizer (#796) — the ImportFont handler rasterizes
         //    missing glyphs through the IFontRasterizer seam, no longer
         //    WinForms-only.
-        //  - The full WipeJP* flow still needs WF HowDoYouLikePatchForm popup
-        //    orchestration; Avalonia SimpleFire skips the OverrideJpFont
-        //    branch and notes this in the user-facing message (KnownGap).
+        //  - The full WipeJP* flow (#1029) is now cross-platform via
+        //    ToolTranslateROMCore.SimpleFireTranslate (OverrideJpFont); the WF
+        //    HowDoYouLikePatchForm ChapterNameText popup is replaced by an
+        //    injected precondition delegate evaluated on the UI thread below.
 
         async void SimpleFire_Click(object? sender, RoutedEventArgs e)
         {
@@ -151,6 +152,25 @@ namespace FEBuilderGBA.Avalonia.Views
                 ToolTranslateROMViewModel.FromLanguageItemsRaw[
                     Math.Clamp(_vm.FromLanguageIndex, 0, ToolTranslateROMViewModel.FromLanguageItemsRaw.Length - 1)]);
 
+            // Resolve the ChapterNameText precondition on the UI thread (BEFORE
+            // the background Task.Run) — Avalonia modal dialogs must not be shown
+            // from a worker thread. Mirrors WF
+            // HowDoYouLikePatchForm.CheckAndShowPopupDialog(ChapterNameText): the
+            // JP chapter-name wipe only proceeds when the ChapterNameToText patch
+            // is installed; if it isn't, surface the recommendation and re-check.
+            bool chapterNameTextOk = true;
+            if (_vm.SimpleOverrideJpFont)
+            {
+                chapterNameTextOk = PatchDetection.SearchChapterNameToTextPatch(rom);
+                if (!chapterNameTextOk && rom.RomInfo.version == 8)
+                {
+                    await ShowChapterNameTextRecommendation();
+                    // Re-check: the user may have installed the patch via the
+                    // patch manager. The wipe proceeds only if it's now present.
+                    chapterNameTextOk = PatchDetection.SearchChapterNameToTextPatch(rom);
+                }
+            }
+
             _vm.UndoService.Begin("Translate ROM");
             try
             {
@@ -169,6 +189,9 @@ namespace FEBuilderGBA.Avalonia.Views
                         FromLanguage = fromLang,
                         ToLanguage = toLang,
                         OverrideJpFont = _vm.SimpleOverrideJpFont,
+                        // Precondition was resolved on the UI thread; pass the
+                        // captured value (no dialog on the worker thread).
+                        ChapterNameTextPrecondition = () => chapterNameTextOk,
                     };
                     var recycle = new RecycleAddress();
                     total = ToolTranslateROMCore.SimpleFireTranslate(rom, opts, recycle,
@@ -179,9 +202,8 @@ namespace FEBuilderGBA.Avalonia.Views
                 string msg = $"Translation complete. {total} text entries written.";
                 if (_vm.SimpleOverrideJpFont)
                 {
-                    msg += "\n\nNote: Override JP Font is checked, but the WipeJP* flow needs " +
-                        "WinForms HowDoYouLikePatchForm popups and stays WinForms-only (#536 " +
-                        "KnownGap). Use the WinForms tool for full JP-font wiping.";
+                    msg += "\n\nOverride JP Font: the Japanese font tables were wiped " +
+                        "(class-reel font, chapter titles, and item/text fonts) to free space.";
                 }
                 await ShowInfo(msg);
             }
@@ -439,6 +461,30 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         Task ShowError(string message) => ShowInfo(message);
+
+        /// <summary>
+        /// Surface the ChapterNameToText patch recommendation (the Avalonia
+        /// counterpart of WF <c>HowDoYouLikePatchForm.CheckAndShowPopupDialog(ChapterNameText)</c>).
+        /// The dialog is informational — the JP chapter-name wipe only proceeds
+        /// when the patch is actually installed (re-checked by the caller), so
+        /// declining here simply skips the chapter-title portion of the wipe.
+        /// </summary>
+        async Task ShowChapterNameTextRecommendation()
+        {
+            try
+            {
+                var view = new HowDoYouLikePatchView();
+                view.SetPatchInfo(
+                    "To display chapter titles as text (required before wiping the Japanese " +
+                    "chapter-title images), install the ChapterNameToText patch via the Patch " +
+                    "manager, then run the translation again.");
+                await view.ShowDialog(this);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ToolTranslateROMView.ShowChapterNameTextRecommendation: {0}", ex.Message);
+            }
+        }
 
         public void NavigateTo(uint address) { /* tool dialog - nothing to navigate to */ }
         public void SelectFirstItem() { /* tool dialog - no list to seed */ }

--- a/FEBuilderGBA.Core.Tests/ChapterTitleCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ChapterTitleCoreTests.cs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1029 Core tests for ChapterTitleCore.MakeList — the cross-platform port of WF
+// ImageChapterTitleForm.MakeList() (the 12-byte chapter-title struct table walk).
+//
+// The synthetic FE8J ROM plants a contiguous run of N chapter-title rows at the
+// table base, terminated by a non-pointer +0 entry, and points
+// image_chapter_title_pointer at that base.
+using System;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class ChapterTitleCoreTests
+    {
+        const uint TableBase = 0x00500000u;
+        const uint Img0 = 0x00510000u;
+        const uint Img1 = 0x00520000u;
+        const uint Img2 = 0x00530000u;
+
+        // Build a synthetic FE8J ROM with a 3-row chapter-title table.
+        static ROM MakeRom(int rows = 3)
+        {
+            var rom = new ROM();
+            byte[] data = new byte[0x1000000];
+            rom.LoadLow("x.gba", data, "BE8J01");
+
+            for (uint i = 0; i < (uint)rows; i++)
+            {
+                uint row = TableBase + i * ChapterTitleCore.EntrySize;
+                // +0 Save image pointer (must be a valid pointer for the run).
+                U.write_u32(rom.Data, row + 0, U.toPointer(Img0 + i * 0x1000));
+                U.write_u32(rom.Data, row + 4, U.toPointer(Img1 + i * 0x1000));
+                U.write_u32(rom.Data, row + 8, U.toPointer(Img2 + i * 0x1000));
+            }
+            // Terminator row: +0 is a non-pointer (0).
+            U.write_u32(rom.Data, TableBase + (uint)rows * ChapterTitleCore.EntrySize, 0);
+
+            U.write_u32(rom.Data, rom.RomInfo.image_chapter_title_pointer, U.toPointer(TableBase));
+            return rom;
+        }
+
+        [Fact]
+        public void MakeList_ReturnsContiguousRun()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom(3);
+                CoreState.ROM = rom;
+                var list = ChapterTitleCore.MakeList(rom);
+                Assert.Equal(3, list.Count);
+                Assert.Equal(U.toOffset(TableBase + 0), list[0].addr);
+                Assert.Equal(U.toOffset(TableBase + 1 * ChapterTitleCore.EntrySize), list[1].addr);
+                Assert.Equal(U.toOffset(TableBase + 2 * ChapterTitleCore.EntrySize), list[2].addr);
+            }
+            finally { CoreState.ROM = prev; }
+        }
+
+        [Fact]
+        public void MakeList_StopsAtNonPointerTerminator()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom(3);
+                CoreState.ROM = rom;
+                // Wipe row 1's +0 pointer -> run truncates at 1.
+                U.write_u32(rom.Data, TableBase + 1 * ChapterTitleCore.EntrySize, 0);
+                var list = ChapterTitleCore.MakeList(rom);
+                Assert.Single(list);
+            }
+            finally { CoreState.ROM = prev; }
+        }
+
+        [Fact]
+        public void MakeList_NullRom_ReturnsEmpty_NoThrow()
+        {
+            Assert.Empty(ChapterTitleCore.MakeList(null));
+        }
+
+        [Fact]
+        public void MakeList_UnsafeTablePointer_ReturnsEmpty()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom(3);
+                CoreState.ROM = rom;
+                U.write_u32(rom.Data, rom.RomInfo.image_chapter_title_pointer, 0);
+                Assert.Empty(ChapterTitleCore.MakeList(rom));
+            }
+            finally { CoreState.ROM = prev; }
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/OPClassFontListCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/OPClassFontListCoreTests.cs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1029 Core tests for OPClassFontListCore.MakeList — the cross-platform port of WF
+// OPClassFontForm.MakeList() / OPClassFontFE8UForm.MakeList() (the 4-byte glyph-
+// pointer slot table walk). JP = contiguous pointer run; FE8U = fixed i <= 0x7a.
+using System;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class OPClassFontListCoreTests
+    {
+        const uint TableBase = 0x00500000u;
+        const uint Glyph = 0x00510000u;
+
+        static ROM MakeRom(string gameCode, int contiguousPointers)
+        {
+            var rom = new ROM();
+            byte[] data = new byte[0x1000000];
+            rom.LoadLow("x.gba", data, gameCode);
+
+            for (uint i = 0; i < (uint)contiguousPointers; i++)
+            {
+                U.write_u32(rom.Data, TableBase + i * OPClassFontListCore.EntrySize,
+                    U.toPointer(Glyph + i * 0x100));
+            }
+            // Terminator: a 0 (non-pointer) just past the run.
+            U.write_u32(rom.Data, TableBase + (uint)contiguousPointers * OPClassFontListCore.EntrySize, 0);
+
+            U.write_u32(rom.Data, rom.RomInfo.op_class_font_pointer, U.toPointer(TableBase));
+            return rom;
+        }
+
+        [Fact]
+        public void MakeList_JP_ReturnsContiguousPointerRun()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom("BE8J01", 5);
+                CoreState.ROM = rom;
+                var list = OPClassFontListCore.MakeList(rom);
+                Assert.Equal(5, list.Count);
+                Assert.Equal(U.toOffset(TableBase + 0), list[0].addr);
+                Assert.Equal(U.toOffset(TableBase + 4 * OPClassFontListCore.EntrySize), list[4].addr);
+            }
+            finally { CoreState.ROM = prev; }
+        }
+
+        [Fact]
+        public void MakeList_FE8U_ReturnsFixed0x7bSlots()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                // FE8U uses the fixed i <= 0x7a run (0..0x7a inclusive = 0x7b slots)
+                // regardless of the pointer contents.
+                ROM rom = MakeRom("BE8E01", 3);
+                CoreState.ROM = rom;
+                var list = OPClassFontListCore.MakeList(rom);
+                Assert.Equal(0x7b, list.Count);
+            }
+            finally { CoreState.ROM = prev; }
+        }
+
+        [Fact]
+        public void MakeList_JP_StopsAtNonPointer()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom("BE8J01", 5);
+                CoreState.ROM = rom;
+                // Break the run at slot 2.
+                U.write_u32(rom.Data, TableBase + 2 * OPClassFontListCore.EntrySize, 0);
+                var list = OPClassFontListCore.MakeList(rom);
+                Assert.Equal(2, list.Count);
+            }
+            finally { CoreState.ROM = prev; }
+        }
+
+        [Fact]
+        public void MakeList_NullRom_ReturnsEmpty_NoThrow()
+        {
+            Assert.Empty(OPClassFontListCore.MakeList(null));
+        }
+
+        [Fact]
+        public void MakeList_UnsafeTablePointer_ReturnsEmpty()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom("BE8J01", 5);
+                CoreState.ROM = rom;
+                U.write_u32(rom.Data, rom.RomInfo.op_class_font_pointer, 0);
+                Assert.Empty(OPClassFontListCore.MakeList(rom));
+            }
+            finally { CoreState.ROM = prev; }
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/SimpleFireWipeJPOrderTests.cs
+++ b/FEBuilderGBA.Core.Tests/SimpleFireWipeJPOrderTests.cs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1029 Core tests for SimpleFireTranslate's consumption of opts.OverrideJpFont:
+//   * OverrideJpFont=true runs the 3 wipes in the WF order
+//     (ClassReel -> Title -> Font) BEFORE the import, then the final BlackOut.
+//   * OverrideJpFont=false skips them.
+//   * a fault after a partial wipe rolls the ROM back byte-identically (the
+//     finding-5 safety proof: covers the direct write_fill clears, the pointer
+//     rewrites, WriteBackFont, and BlackOut).
+using System;
+using System.Collections.Generic;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class SimpleFireWipeJPOrderTests
+    {
+        const uint ChTableBase = 0x00700000u;
+        const uint OpTableBase = 0x00740000u;
+
+        sealed class Harness : IDisposable
+        {
+            readonly ROM _prevRom;
+            readonly Func<byte[], Undo.UndoData, uint> _prevAppend;
+            readonly ISystemTextEncoder _prevEnc;
+            readonly TextEncodingEnum _prevTextEnc;
+            public ROM Rom { get; }
+            public Undo Undo { get; }
+
+            public Harness()
+            {
+                _prevRom = CoreState.ROM;
+                _prevAppend = CoreState.AppendBinaryData;
+                _prevEnc = CoreState.SystemTextEncoder;
+                _prevTextEnc = CoreState.TextEncoding;
+
+                Rom = MakeRom();
+                CoreState.ROM = Rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(Rom);
+                CoreState.TextEncoding = TextEncodingEnum.Auto;
+                CoreState.AppendBinaryData = (data, undo) =>
+                {
+                    uint at = (uint)Rom.Data.Length;
+                    Rom.write_resize_data(at + (uint)data.Length);
+                    if (undo != null) Rom.write_range(at, data, undo);
+                    else Rom.write_range(at, data);
+                    return at;
+                };
+                Undo = new Undo();
+            }
+
+            public void Dispose()
+            {
+                CoreState.ROM = _prevRom;
+                CoreState.AppendBinaryData = _prevAppend;
+                CoreState.SystemTextEncoder = _prevEnc;
+                CoreState.TextEncoding = _prevTextEnc;
+            }
+        }
+
+        static ROM MakeRom()
+        {
+            // Reuse the synthetic FE8J layout from the wipe tests.
+            var rom = new ROM();
+            byte[] data = new byte[0x1000000];
+            rom.LoadLow("x.gba", data, "BE8J01");
+
+            // Text-font keep glyph "０" (moji 0x4F82).
+            const uint TextFontTop = 0x593F74;
+            uint listHead = TextFontTop + ((0x4Fu) << 2) - 0x100;
+            const uint KeepNodeOff = 0x00C00000u;
+            U.write_u32(rom.Data, listHead, U.toPointer(KeepNodeOff));
+            U.write_u32(rom.Data, KeepNodeOff + 0, 0);
+            rom.Data[KeepNodeOff + 4] = 0x82;
+            rom.Data[KeepNodeOff + 5] = 8;
+            for (int i = 0; i < 64; i++) rom.Data[KeepNodeOff + 8 + i] = (byte)(i + 1);
+
+            // Chapter-title table (3 rows).
+            const uint ChImgLast = 0x00710000u, ChImgA = 0x00720000u, ChImgB = 0x00730000u;
+            void Row(uint r, uint img)
+            {
+                U.write_u32(rom.Data, ChTableBase + r * 12 + 0, U.toPointer(img));
+                U.write_u32(rom.Data, ChTableBase + r * 12 + 4, U.toPointer(img + 0x100));
+                U.write_u32(rom.Data, ChTableBase + r * 12 + 8, U.toPointer(img + 0x200));
+            }
+            Row(0, ChImgA); Row(1, ChImgB); Row(2, ChImgLast);
+            U.write_u32(rom.Data, ChTableBase + 3 * 12 + 0, 0);
+            U.write_u32(rom.Data, rom.RomInfo.image_chapter_title_pointer, U.toPointer(ChTableBase));
+            foreach (uint b in new uint[] { ChImgA, ChImgB, ChImgLast })
+                for (uint o = 0; o <= 0x200; o += 0x100) Lz77Stub(rom, b + o);
+
+            // OP-class-font table (2 slots).
+            const uint OpGlyph0 = 0x00750000u, OpGlyph1 = 0x00760000u;
+            U.write_u32(rom.Data, OpTableBase + 0, U.toPointer(OpGlyph0));
+            U.write_u32(rom.Data, OpTableBase + 4, U.toPointer(OpGlyph1));
+            U.write_u32(rom.Data, OpTableBase + 8, 0);
+            U.write_u32(rom.Data, rom.RomInfo.op_class_font_pointer, U.toPointer(OpTableBase));
+            Lz77Stub(rom, OpGlyph0); Lz77Stub(rom, OpGlyph1);
+            U.write_u16(rom.Data, 0xB7890, 0x4B00);
+
+            // ChapterNameToText FE8J patch signature (so default precondition wipes).
+            rom.Data[0x8B894] = 0x00; rom.Data[0x8B895] = 0x4B;
+            rom.Data[0x8B896] = 0x18; rom.Data[0x8B897] = 0x47;
+
+            return rom;
+        }
+
+        static void Lz77Stub(ROM rom, uint off)
+        {
+            rom.Data[off + 0] = 0x10; rom.Data[off + 1] = 0x08;
+            rom.Data[off + 4] = 0x00;
+            for (uint i = 5; i < 14; i++) rom.Data[off + i] = (byte)i;
+        }
+
+        // ============================================================
+        // Order
+        // ============================================================
+
+        [Fact]
+        public void SimpleFire_OverrideJpFontTrue_RunsThreeWipes_InWFOrder()
+        {
+            using var h = new Harness();
+            var undo = h.Undo.NewUndoData("test");
+            var progress = new List<string>();
+
+            var opts = new ToolTranslateROMCore.SimpleFireOptions
+            {
+                FromLanguage = "en",
+                ToLanguage = "ja",       // different -> not short-circuited
+                OverrideJpFont = true,
+            };
+            var recycle = new RecycleAddress();
+            ToolTranslateROMCore.SimpleFireTranslate(h.Rom, opts, recycle, undo, progress.Add);
+
+            // The 3 wipe progress markers appear in the WF order, before any
+            // import work.
+            int iClassReel = progress.FindIndex(s => s.Contains("WipeJP ClassReel"));
+            int iTitle = progress.FindIndex(s => s.Contains("WipeJP Title"));
+            int iFont = progress.FindIndex(s => s.Contains("WipeJP Font"));
+            Assert.True(iClassReel >= 0 && iTitle >= 0 && iFont >= 0,
+                "all three wipe progress markers must appear");
+            Assert.True(iClassReel < iTitle, "ClassReel must precede Title");
+            Assert.True(iTitle < iFont, "Title must precede Font");
+
+            // Observable effect of each wipe (not just final state):
+            uint firstOp = h.Rom.u32(OpTableBase + 0);
+            Assert.Equal(firstOp, h.Rom.u32(OpTableBase + 4));         // ClassReel ran
+            uint lastCh = h.Rom.u32(ChTableBase + 2 * 12 + 0);
+            Assert.Equal(lastCh, h.Rom.u32(ChTableBase + 0 * 12 + 0)); // Title ran
+            // Font table cleared (item-font hash table zeroed).
+            for (uint a = 0x57994C; a < 0x57994C + 896; a++)
+                Assert.Equal(0, h.Rom.Data[a]);                       // Font ran
+        }
+
+        [Fact]
+        public void SimpleFire_OverrideJpFontFalse_SkipsAllWipes()
+        {
+            using var h = new Harness();
+            var undo = h.Undo.NewUndoData("test");
+            var progress = new List<string>();
+
+            uint opSlot1 = h.Rom.u32(OpTableBase + 4);
+            uint chRow0Num = h.Rom.u32(ChTableBase + 0 * 12 + 4);
+            byte itemFontByte = h.Rom.Data[0x57994C];
+
+            var opts = new ToolTranslateROMCore.SimpleFireOptions
+            {
+                FromLanguage = "en",
+                ToLanguage = "ja",
+                OverrideJpFont = false,
+            };
+            var recycle = new RecycleAddress();
+            ToolTranslateROMCore.SimpleFireTranslate(h.Rom, opts, recycle, undo, progress.Add);
+
+            Assert.DoesNotContain(progress, s => s.Contains("WipeJP"));
+            Assert.Equal(opSlot1, h.Rom.u32(OpTableBase + 4));        // unchanged
+            Assert.Equal(chRow0Num, h.Rom.u32(ChTableBase + 0 * 12 + 4)); // unchanged
+            Assert.Equal(itemFontByte, h.Rom.Data[0x57994C]);        // unchanged
+        }
+
+        // ============================================================
+        // Rollback (finding-5 safety proof)
+        // ============================================================
+
+        [Fact]
+        public void WipeJP_AllThree_Rollback_RestoresByteIdentical()
+        {
+            using var h = new Harness();
+
+            // Snapshot the entire ROM before any wipe.
+            byte[] before = (byte[])h.Rom.Data.Clone();
+            int beforeLen = h.Rom.Data.Length;
+
+            var undo = h.Undo.NewUndoData("wipe");
+            var recycle = new RecycleAddress();
+
+            // Run all three wipes + the final BlackOut, exactly as SimpleFire does.
+            ToolTranslateROMCore.WipeJPClassReelFont(h.Rom, recycle, undo);
+            ToolTranslateROMCore.WipeJPTitle(h.Rom, recycle, undo);
+            ToolTranslateROMCore.WipeJPFont(h.Rom, recycle, undo);
+            recycle.BlackOut(undo);
+
+            // Something actually changed (chapter row 0 +0 was repointed to the
+            // last image by WipeJPTitle).
+            Assert.NotEqual(
+                U.u32(before, ChTableBase + 0 * 12 + 0),
+                h.Rom.u32(ChTableBase + 0 * 12 + 0));
+
+            // Roll back via the captured undo.
+            h.Undo.Push(undo);
+            h.Undo.RunUndo();
+
+            // Byte-identical restore (length first).
+            Assert.Equal(beforeLen, h.Rom.Data.Length);
+            for (int i = 0; i < before.Length; i++)
+                Assert.True(before[i] == h.Rom.Data[i],
+                    $"byte mismatch at 0x{i:X} after rollback: {before[i]:X2} != {h.Rom.Data[i]:X2}");
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/ToolTranslateROMWipeJPCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ToolTranslateROMWipeJPCoreTests.cs
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1029 Core tests for the JP-font-wipe flow ported from the WF ROM Translation
+// Tool (ToolTranslateROMWipeJPFont / ToolTranslateROMWipeJPChapterName /
+// ToolTranslateROMWipeJPClassReelFont), driven through the Form-free
+// ToolTranslateROMCore.WipeJPFont / WipeJPTitle / WipeJPClassReelFont and
+// SimpleFireTranslate orchestration.
+//
+// The synthetic FE8J ROM plants:
+//   * a text-font hash table at font_serif_address (0x593F74) with one keep-glyph
+//     node ("０", SJIS 0x4F82) reachable through the hash chain;
+//   * a custom-font node inside the wipeable text-font region (0x5942F4..0x5B8CDC);
+//   * a 3-row chapter-title table + image_chapter_title_pointer;
+//   * a contiguous OP-class-font slot table + op_class_font_pointer + the
+//     0xB7890 == 0x4B00 signature;
+//   * the ChapterNameToText patch signature (so the default precondition wipes).
+using System;
+using System.Collections.Generic;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class ToolTranslateROMWipeJPCoreTests
+    {
+        // --- Font hash table layout (FE8J) ---
+        const uint TextFontTop = 0x593F74;     // font_serif_address
+        const uint ItemFontTop = 0x57994C;     // font_item_address
+        // "０" (U+FF10) Shift-JIS = 0x82 0x4F -> little-endian uint 0x4F82.
+        const uint Moji0 = 0x4F82;
+        const uint KeepNodeOff = 0x00C00000u;  // keep-glyph node (outside wipe regions)
+        const uint CustomNodeOff = 0x005A0000u; // custom font inside the text-font wipe region
+
+        // --- Chapter-title table ---
+        const uint ChTableBase = 0x00700000u;
+        const uint ChImgLast = 0x00710000u;
+        const uint ChImgA = 0x00720000u;
+        const uint ChImgB = 0x00730000u;
+
+        // --- OP-class-font table ---
+        const uint OpTableBase = 0x00740000u;
+        const uint OpGlyph0 = 0x00750000u;
+        const uint OpGlyph1 = 0x00760000u;
+
+        // ChapterNameToText FE8J patch signature site.
+        const uint ChapterNameTextPatchAddr = 0x8B894;
+
+        sealed class Harness : IDisposable
+        {
+            readonly ROM _prevRom;
+            readonly Func<byte[], Undo.UndoData, uint> _prevAppend;
+            readonly ISystemTextEncoder _prevEnc;
+            readonly TextEncodingEnum _prevTextEnc;
+            public ROM Rom { get; }
+            public Undo Undo { get; }
+
+            public Harness(bool installChapterNameTextPatch = true,
+                bool installClassReelSignature = true)
+            {
+                _prevRom = CoreState.ROM;
+                _prevAppend = CoreState.AppendBinaryData;
+                _prevEnc = CoreState.SystemTextEncoder;
+                _prevTextEnc = CoreState.TextEncoding;
+
+                Rom = MakeRom(installChapterNameTextPatch, installClassReelSignature);
+                CoreState.ROM = Rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(Rom);
+                CoreState.TextEncoding = TextEncodingEnum.Auto;
+                CoreState.AppendBinaryData = (data, undo) =>
+                {
+                    uint at = (uint)Rom.Data.Length;
+                    Rom.write_resize_data(at + (uint)data.Length);
+                    if (undo != null) Rom.write_range(at, data, undo);
+                    else Rom.write_range(at, data);
+                    return at;
+                };
+                Undo = new Undo();
+            }
+
+            public void Dispose()
+            {
+                CoreState.ROM = _prevRom;
+                CoreState.AppendBinaryData = _prevAppend;
+                CoreState.SystemTextEncoder = _prevEnc;
+                CoreState.TextEncoding = _prevTextEnc;
+            }
+        }
+
+        static ROM MakeRom(bool installChapterNameTextPatch, bool installClassReelSignature)
+        {
+            var rom = new ROM();
+            byte[] data = new byte[0x1000000];
+            rom.LoadLow("x.gba", data, "BE8J01");
+
+            // ---- Text-font hash chain for "０" (moji 0x4F82) ----
+            // FindFontDataSJIS: moji1=0x4F, list = top + (0x4F<<2) - 0x100.
+            uint listHead = TextFontTop + (((Moji0 >> 8) & 0xff) << 2) - 0x100;
+            // head -> keep node
+            U.write_u32(rom.Data, listHead, U.toPointer(KeepNodeOff));
+            // keep node: next=0, moji2=0x82, width=8, then 64-byte bitmap.
+            U.write_u32(rom.Data, KeepNodeOff + 0, 0);
+            rom.Data[KeepNodeOff + 4] = 0x82;   // moji2
+            rom.Data[KeepNodeOff + 5] = 8;      // width
+            for (int i = 0; i < 64; i++) rom.Data[KeepNodeOff + 8 + i] = (byte)(i + 1);
+
+            // ---- A custom-font node INSIDE the text-font wipe region ----
+            // (a separate hash bucket head also inside the cleared hash table)
+            const uint customMoji1 = 0x50;
+            uint customListHead = TextFontTop + (customMoji1 << 2) - 0x100;
+            U.write_u32(rom.Data, customListHead, U.toPointer(CustomNodeOff));
+            U.write_u32(rom.Data, CustomNodeOff + 0, 0); // next=0
+            rom.Data[CustomNodeOff + 4] = 0x99;          // moji2 (arbitrary)
+            rom.Data[CustomNodeOff + 5] = 8;
+            for (int i = 0; i < 64; i++) rom.Data[CustomNodeOff + 8 + i] = 0x55;
+
+            // ---- Chapter-title table (3 rows; last is the keep entry) ----
+            U.write_u32(rom.Data, ChTableBase + 0 * 12 + 0, U.toPointer(ChImgA));
+            U.write_u32(rom.Data, ChTableBase + 0 * 12 + 4, U.toPointer(ChImgA + 0x100));
+            U.write_u32(rom.Data, ChTableBase + 0 * 12 + 8, U.toPointer(ChImgA + 0x200));
+            U.write_u32(rom.Data, ChTableBase + 1 * 12 + 0, U.toPointer(ChImgB));
+            U.write_u32(rom.Data, ChTableBase + 1 * 12 + 4, U.toPointer(ChImgB + 0x100));
+            U.write_u32(rom.Data, ChTableBase + 1 * 12 + 8, U.toPointer(ChImgB + 0x200));
+            U.write_u32(rom.Data, ChTableBase + 2 * 12 + 0, U.toPointer(ChImgLast));
+            U.write_u32(rom.Data, ChTableBase + 2 * 12 + 4, U.toPointer(ChImgLast + 0x100));
+            U.write_u32(rom.Data, ChTableBase + 2 * 12 + 8, U.toPointer(ChImgLast + 0x200));
+            U.write_u32(rom.Data, ChTableBase + 3 * 12 + 0, 0); // terminator
+            U.write_u32(rom.Data, rom.RomInfo.image_chapter_title_pointer, U.toPointer(ChTableBase));
+            // LZ77-stub the chapter images so AddLZ77Pointer can size them.
+            WriteLz77Stub(rom, ChImgA); WriteLz77Stub(rom, ChImgA + 0x100); WriteLz77Stub(rom, ChImgA + 0x200);
+            WriteLz77Stub(rom, ChImgB); WriteLz77Stub(rom, ChImgB + 0x100); WriteLz77Stub(rom, ChImgB + 0x200);
+            WriteLz77Stub(rom, ChImgLast); WriteLz77Stub(rom, ChImgLast + 0x100); WriteLz77Stub(rom, ChImgLast + 0x200);
+
+            // ---- OP-class-font table (2 slots, slot0 is the keep entry) ----
+            U.write_u32(rom.Data, OpTableBase + 0 * 4, U.toPointer(OpGlyph0));
+            U.write_u32(rom.Data, OpTableBase + 1 * 4, U.toPointer(OpGlyph1));
+            U.write_u32(rom.Data, OpTableBase + 2 * 4, 0); // terminator
+            U.write_u32(rom.Data, rom.RomInfo.op_class_font_pointer, U.toPointer(OpTableBase));
+            WriteLz77Stub(rom, OpGlyph0); WriteLz77Stub(rom, OpGlyph1);
+            if (installClassReelSignature) U.write_u16(rom.Data, 0xB7890, 0x4B00);
+
+            // ChapterNameToText FE8J patch signature: 00 4B 18 47 at 0x8B894.
+            if (installChapterNameTextPatch)
+            {
+                rom.Data[ChapterNameTextPatchAddr + 0] = 0x00;
+                rom.Data[ChapterNameTextPatchAddr + 1] = 0x4B;
+                rom.Data[ChapterNameTextPatchAddr + 2] = 0x18;
+                rom.Data[ChapterNameTextPatchAddr + 3] = 0x47;
+            }
+
+            return rom;
+        }
+
+        // A minimal valid LZ77 stream (type 0x10, size 0, no blocks) so
+        // LZ77.getCompressedSize returns a small value.
+        static void WriteLz77Stub(ROM rom, uint off)
+        {
+            rom.Data[off + 0] = 0x10; // LZ77 type
+            rom.Data[off + 1] = 0x08; // size low (8 bytes uncompressed)
+            rom.Data[off + 2] = 0x00;
+            rom.Data[off + 3] = 0x00;
+            rom.Data[off + 4] = 0x00; // flag byte: 0 literals
+            rom.Data[off + 5] = 0x41;
+            rom.Data[off + 6] = 0x42;
+            rom.Data[off + 7] = 0x43;
+            rom.Data[off + 8] = 0x44;
+            rom.Data[off + 9] = 0x00;
+            rom.Data[off + 10] = 0x45;
+            rom.Data[off + 11] = 0x46;
+            rom.Data[off + 12] = 0x47;
+            rom.Data[off + 13] = 0x48;
+        }
+
+        // ============================================================
+        // WipeJPFont — keep-glyph restoration + table clears
+        // ============================================================
+
+        [Fact]
+        public void WipeJPFont_ClearsFontHashTables_AndRestoresKeepGlyph()
+        {
+            using var h = new Harness();
+            var undo = h.Undo.NewUndoData("test");
+
+            // Sanity: the keep glyph "０" IS found before the wipe.
+            uint before = FontCore.FindFontData(FontCore.GetFontPointer(false, h.Rom),
+                Moji0, out _, h.Rom, PriorityCodeUtil.SearchPriorityCode(h.Rom));
+            Assert.NotEqual(U.NOT_FOUND, before);
+
+            var recycle = new RecycleAddress();
+            ToolTranslateROMCore.WipeJPFont(h.Rom, recycle, undo);
+
+            // The item-font hash-pointer table (896 bytes @ 0x57994C) is zeroed.
+            for (uint a = 0x57994C; a < 0x57994C + 896; a++)
+                Assert.Equal(0, h.Rom.Data[a]);
+            // The text-font hash-pointer table (896 bytes @ 0x593F74) is zeroed
+            // EXCEPT the keep-glyph head which WriteBackFont re-pointed.
+            uint listHead = TextFontTop + (((Moji0 >> 8) & 0xff) << 2) - 0x100;
+            uint reHead = h.Rom.u32(listHead);
+            Assert.True(U.isPointer(reHead),
+                "WriteBackFont should re-point the keep-glyph hash head to a new node");
+
+            // The re-appended node carries the preserved bitmap + width.
+            uint newNode = U.toOffset(reHead);
+            Assert.Equal(8u, h.Rom.u8(newNode + 5)); // width preserved
+            for (int i = 0; i < 64; i++)
+                Assert.Equal((byte)(i + 1), h.Rom.Data[newNode + 8 + i]); // bitmap preserved
+        }
+
+        // ============================================================
+        // WipeJPTitle — chapter-name pointer rewrites + precondition
+        // ============================================================
+
+        [Fact]
+        public void WipeJPTitle_RepointsAllButLast_ToLastImage()
+        {
+            using var h = new Harness(installChapterNameTextPatch: true);
+            var undo = h.Undo.NewUndoData("test");
+
+            uint lastImg = h.Rom.u32(ChTableBase + 2 * 12 + 0);
+
+            var recycle = new RecycleAddress();
+            ToolTranslateROMCore.WipeJPTitle(h.Rom, recycle, undo);
+
+            // Rows 0 and 1 +0 now point at the last image; +4/+8 are zeroed.
+            Assert.Equal(lastImg, h.Rom.u32(ChTableBase + 0 * 12 + 0));
+            Assert.Equal(lastImg, h.Rom.u32(ChTableBase + 1 * 12 + 0));
+            Assert.Equal(0u, h.Rom.u32(ChTableBase + 0 * 12 + 4));
+            Assert.Equal(0u, h.Rom.u32(ChTableBase + 0 * 12 + 8));
+            Assert.Equal(0u, h.Rom.u32(ChTableBase + 1 * 12 + 4));
+            Assert.Equal(0u, h.Rom.u32(ChTableBase + 1 * 12 + 8));
+            // The last row is preserved.
+            Assert.Equal(lastImg, h.Rom.u32(ChTableBase + 2 * 12 + 0));
+        }
+
+        [Fact]
+        public void WipeJPTitle_PatchAbsent_DefaultPrecondition_SkipsWipe()
+        {
+            using var h = new Harness(installChapterNameTextPatch: false);
+            var undo = h.Undo.NewUndoData("test");
+
+            uint row0Before = h.Rom.u32(ChTableBase + 0 * 12 + 0);
+            uint row0Num = h.Rom.u32(ChTableBase + 0 * 12 + 4);
+
+            var recycle = new RecycleAddress();
+            // Default precondition = SearchChapterNameToTextPatch (absent) -> skip.
+            ToolTranslateROMCore.WipeJPTitle(h.Rom, recycle, undo);
+
+            Assert.Equal(row0Before, h.Rom.u32(ChTableBase + 0 * 12 + 0)); // unchanged
+            Assert.Equal(row0Num, h.Rom.u32(ChTableBase + 0 * 12 + 4));    // unchanged
+        }
+
+        [Fact]
+        public void WipeJPTitle_InjectedPreconditionFalse_SkipsWipe_EvenIfPatchPresent()
+        {
+            using var h = new Harness(installChapterNameTextPatch: true);
+            var undo = h.Undo.NewUndoData("test");
+
+            uint row0Num = h.Rom.u32(ChTableBase + 0 * 12 + 4);
+            bool invoked = false;
+
+            var recycle = new RecycleAddress();
+            ToolTranslateROMCore.WipeJPTitle(h.Rom, recycle, undo,
+                () => { invoked = true; return false; });
+
+            Assert.True(invoked, "the injected precondition must be invoked");
+            Assert.Equal(row0Num, h.Rom.u32(ChTableBase + 0 * 12 + 4)); // unchanged
+        }
+
+        [Fact]
+        public void WipeJPTitle_InjectedPreconditionTrue_Wipes()
+        {
+            using var h = new Harness(installChapterNameTextPatch: false);
+            var undo = h.Undo.NewUndoData("test");
+
+            var recycle = new RecycleAddress();
+            ToolTranslateROMCore.WipeJPTitle(h.Rom, recycle, undo, () => true);
+
+            // Even with the patch absent, an explicit-true precondition wipes.
+            Assert.Equal(0u, h.Rom.u32(ChTableBase + 0 * 12 + 4));
+        }
+
+        // ============================================================
+        // WipeJPClassReelFont — OP-class-font pointer rewrites
+        // ============================================================
+
+        [Fact]
+        public void WipeJPClassReelFont_RepointsAllButFirst_ToFirstImage()
+        {
+            using var h = new Harness();
+            var undo = h.Undo.NewUndoData("test");
+
+            uint firstImg = h.Rom.u32(OpTableBase + 0 * 4);
+
+            var recycle = new RecycleAddress();
+            ToolTranslateROMCore.WipeJPClassReelFont(h.Rom, recycle, undo);
+
+            Assert.Equal(firstImg, h.Rom.u32(OpTableBase + 0 * 4)); // first preserved
+            Assert.Equal(firstImg, h.Rom.u32(OpTableBase + 1 * 4)); // second repointed
+        }
+
+        [Fact]
+        public void WipeJPClassReelFont_NoSignature_SkipsWipe()
+        {
+            using var h = new Harness(installClassReelSignature: false);
+            var undo = h.Undo.NewUndoData("test");
+
+            uint slot1Before = h.Rom.u32(OpTableBase + 1 * 4);
+
+            var recycle = new RecycleAddress();
+            ToolTranslateROMCore.WipeJPClassReelFont(h.Rom, recycle, undo);
+
+            Assert.Equal(slot1Before, h.Rom.u32(OpTableBase + 1 * 4)); // unchanged
+        }
+
+        // ============================================================
+        // Guards — wrong version / null don't crash
+        // ============================================================
+
+        [Fact]
+        public void WipeJPFont_NonFE8_NoOp_NoThrow()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                var rom = new ROM();
+                byte[] data = new byte[0x1000000];
+                rom.LoadLow("x.gba", data, "AE7E01"); // FE7U
+                CoreState.ROM = rom;
+                var undo = new Undo().NewUndoData("test");
+                var recycle = new RecycleAddress();
+                ToolTranslateROMCore.WipeJPFont(rom, recycle, undo); // no throw
+            }
+            finally { CoreState.ROM = prev; }
+        }
+
+        [Fact]
+        public void WipeJP_NullRom_NoOp_NoThrow()
+        {
+            var recycle = new RecycleAddress();
+            ToolTranslateROMCore.WipeJPFont(null, recycle, null);
+            ToolTranslateROMCore.WipeJPTitle(null, recycle, null);
+            ToolTranslateROMCore.WipeJPClassReelFont(null, recycle, null);
+        }
+
+        // ============================================================
+        // ChapterNameText precondition default (blocker-1 parity)
+        // ============================================================
+
+        [Fact]
+        public void WipeJPTitle_PatchPresent_DefaultPrecondition_Wipes()
+        {
+            // Default (null) precondition = SearchChapterNameToTextPatch; patch
+            // present -> wipe proceeds.
+            using var h = new Harness(installChapterNameTextPatch: true);
+            var undo = h.Undo.NewUndoData("test");
+            var recycle = new RecycleAddress();
+            ToolTranslateROMCore.WipeJPTitle(h.Rom, recycle, undo);
+            Assert.Equal(0u, h.Rom.u32(ChTableBase + 0 * 12 + 4)); // wiped
+        }
+
+        [Fact]
+        public void SearchChapterNameToTextPatch_DetectsSignature()
+        {
+            using var present = new Harness(installChapterNameTextPatch: true);
+            Assert.True(PatchDetection.SearchChapterNameToTextPatch(present.Rom));
+            using var absent = new Harness(installChapterNameTextPatch: false);
+            Assert.False(PatchDetection.SearchChapterNameToTextPatch(absent.Rom));
+        }
+
+        // ============================================================
+        // ZH_TBL guard (blocker-2 parity)
+        // ============================================================
+
+        [Fact]
+        public void WipeJPFont_ZhTbl_NoOp()
+        {
+            using var h = new Harness();
+            var prevTextEnc = CoreState.TextEncoding;
+            try
+            {
+                CoreState.TextEncoding = TextEncodingEnum.ZH_TBL;
+                byte itemFontByte = h.Rom.Data[0x57994C];
+
+                var undo = h.Undo.NewUndoData("test");
+                var recycle = new RecycleAddress();
+                ToolTranslateROMCore.WipeJPFont(h.Rom, recycle, undo);
+
+                // ZH font system guard -> AddJPFonts is a no-op, the item-font
+                // hash table is NOT cleared.
+                Assert.Equal(itemFontByte, h.Rom.Data[0x57994C]);
+            }
+            finally { CoreState.TextEncoding = prevTextEnc; }
+        }
+
+        [Fact]
+        public void WipeJPFont_AutoEncoding_Proceeds()
+        {
+            using var h = new Harness(); // TextEncoding = Auto
+            var undo = h.Undo.NewUndoData("test");
+            var recycle = new RecycleAddress();
+            ToolTranslateROMCore.WipeJPFont(h.Rom, recycle, undo);
+            // Auto != ZH_TBL -> the item-font hash table IS cleared.
+            for (uint a = 0x57994C; a < 0x57994C + 896; a++)
+                Assert.Equal(0, h.Rom.Data[a]);
+        }
+    }
+}

--- a/FEBuilderGBA.Core/ChapterTitleCore.cs
+++ b/FEBuilderGBA.Core/ChapterTitleCore.cs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// #1029 — Cross-platform Core port of the WinForms ImageChapterTitleForm.MakeList()
+// table walk (READ-ONLY, never mutates the ROM). The chapter-title editor and the
+// JP-chapter-name wipe flow (ToolTranslateROMWipeJPChapterName) need the list of
+// chapter-title struct addresses; the WF version is built through InputFormRef
+// (Form-bound), so this provides the same enumeration WinForms-free.
+//
+// The table at p32(image_chapter_title_pointer) is an array of 12-byte structs:
+//   +0 : LZ77 image pointer (the "Save" picture)
+//   +4 : LZ77 image pointer (the chapter Number)
+//   +8 : LZ77 image pointer (the chapter Title)
+// DataCount = the contiguous run of rows whose +0 entry is a valid pointer (mirrors
+// the WF InputFormRef "is data exists" callback: U.isPointer(u32(addr+0))).
+using System;
+using System.Collections.Generic;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// READ-ONLY cross-platform enumerator for the chapter-title struct table
+    /// (port of WinForms <c>ImageChapterTitleForm.MakeList</c> minus the
+    /// <c>InputFormRef</c> / <c>Form</c> dependency).
+    /// </summary>
+    public static class ChapterTitleCore
+    {
+        /// <summary>12-byte struct (Save/Number/Title LZ77 image pointers).</summary>
+        public const uint EntrySize = 12;
+
+        /// <summary>Generous upper bound on the chapter-title table size (the DataCount scan).</summary>
+        const uint ScanCap = 0x4000;
+
+        /// <summary>
+        /// Enumerate the chapter-title struct rows on the given ROM. Returns one
+        /// <see cref="AddrResult"/> per row (addr = the row base, name = the map
+        /// index hex). The list stops at the first row whose +0 image pointer is
+        /// not a valid pointer (mirrors the WF InputFormRef contiguous-run
+        /// DataCount). Returns an empty list (never null, never throws) when the
+        /// table pointer is missing / unsafe.
+        /// </summary>
+        public static List<AddrResult> MakeList(ROM rom)
+        {
+            var result = new List<AddrResult>();
+            if (rom?.RomInfo == null) return result;
+
+            uint tablePtr = rom.RomInfo.image_chapter_title_pointer;
+            // isSafetyOffset only checks tablePtr < Data.Length, not that the 4-byte
+            // p32 read is in-bounds; guard tablePtr+4 so rom.p32 can't throw.
+            if (!U.isSafetyOffset(tablePtr, rom) || tablePtr + 4 > (uint)rom.Data.Length)
+                return result;
+            uint tableBase = rom.p32(tablePtr);
+            if (!U.isSafetyOffset(tableBase, rom)) return result;
+
+            for (uint i = 0; i < ScanCap; i++)
+            {
+                uint row = tableBase + i * EntrySize;
+                // Need the +0 pointer slot in-bounds before reading it.
+                if (row + 4 > (uint)rom.Data.Length) break;
+                if (!U.isPointer(rom.u32(row))) break; // contiguous-run terminator
+
+                result.Add(new AddrResult(row, U.ToHexString(i)));
+            }
+
+            return result;
+        }
+    }
+}

--- a/FEBuilderGBA.Core/ChapterTitleCore.cs
+++ b/FEBuilderGBA.Core/ChapterTitleCore.cs
@@ -54,8 +54,11 @@ namespace FEBuilderGBA
             for (uint i = 0; i < ScanCap; i++)
             {
                 uint row = tableBase + i * EntrySize;
-                // Need the +0 pointer slot in-bounds before reading it.
-                if (row + 4 > (uint)rom.Data.Length) break;
+                // Require the FULL 12-byte entry in-bounds before treating the row
+                // as valid — callers (WipeJPChapterNameHelper) read/write at
+                // row+0/+4/+8, so a truncated last row must be excluded. Mirrors
+                // the WF InputFormRef block-walk safety. (Copilot review #1101.)
+                if (row + EntrySize > (uint)rom.Data.Length) break; // EOF / overflow-safe
                 if (!U.isPointer(rom.u32(row))) break; // contiguous-run terminator
 
                 result.Add(new AddrResult(row, U.ToHexString(i)));

--- a/FEBuilderGBA.Core/OPClassFontListCore.cs
+++ b/FEBuilderGBA.Core/OPClassFontListCore.cs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// #1029 — Cross-platform Core port of the WinForms OPClassFontForm.MakeList() /
+// OPClassFontFE8UForm.MakeList() table walks (READ-ONLY, never mutates the ROM).
+// The JP-class-reel-font wipe flow (ToolTranslateROMWipeJPClassReelFont) needs the
+// list of OP-class-font slot addresses; the WF version is built through
+// InputFormRef (Form-bound), so this provides the same enumeration WinForms-free.
+//
+// The table at p32(op_class_font_pointer) is an array of 4-byte glyph-image
+// pointers (WF InputFormRef BlockSize 4):
+//   * JP (multibyte) ROMs: DataCount = the contiguous run of pointer slots
+//     (mirrors WF OPClassFontForm.Init's U.isPointer(u32(addr)) callback).
+//   * FE8U (English) ROMs: DataCount = the fixed run i <= 0x7a (mirrors WF
+//     OPClassFontFE8UForm.Init's i <= 0x7a callback).
+// The WipeJPClassReelFont path only fires on FE8J (version 8 + multibyte), so the
+// wipe consumes the JP contiguous run; the FE8U branch is included for parity /
+// future reuse.
+using System;
+using System.Collections.Generic;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// READ-ONLY cross-platform enumerator for the OP-class JP-name font slot
+    /// table (port of WinForms <c>OPClassFontForm.MakeList</c> /
+    /// <c>OPClassFontFE8UForm.MakeList</c> minus the <c>InputFormRef</c> /
+    /// <c>Form</c> dependency).
+    /// </summary>
+    public static class OPClassFontListCore
+    {
+        /// <summary>4-byte glyph-image pointer slot.</summary>
+        public const uint EntrySize = 4;
+
+        /// <summary>FE8U fixed DataCount upper index (slots 0..0x7a inclusive).</summary>
+        const uint FE8UMaxIndex = 0x7a;
+
+        /// <summary>Generous upper bound on the JP table size (the DataCount scan).</summary>
+        const uint ScanCap = 0x4000;
+
+        /// <summary>
+        /// Enumerate the OP-class-font glyph slots on the given ROM. Returns one
+        /// <see cref="AddrResult"/> per slot (addr = the slot address, name = the
+        /// slot index hex), mirroring the WF MakeList routing: FE8U uses the fixed
+        /// i &lt;= 0x7a run, every other (JP) layout uses the contiguous pointer
+        /// run. Returns an empty list (never null, never throws) when the table
+        /// pointer is missing / unsafe.
+        /// </summary>
+        public static List<AddrResult> MakeList(ROM rom)
+        {
+            var result = new List<AddrResult>();
+            if (rom?.RomInfo == null) return result;
+
+            uint tablePtr = rom.RomInfo.op_class_font_pointer;
+            // Guard the 4-byte p32 read.
+            if (!U.isSafetyOffset(tablePtr, rom) || tablePtr + 4 > (uint)rom.Data.Length)
+                return result;
+            uint tableBase = rom.p32(tablePtr);
+            if (!U.isSafetyOffset(tableBase, rom)) return result;
+
+            bool isFE8U = rom.RomInfo.version == 8 && !rom.RomInfo.is_multibyte;
+
+            if (isFE8U)
+            {
+                // FE8U: fixed i <= 0x7a run (WF OPClassFontFE8UForm.Init).
+                for (uint i = 0; i <= FE8UMaxIndex; i++)
+                {
+                    uint slot = tableBase + i * EntrySize;
+                    if (slot + 4 > (uint)rom.Data.Length) break; // EOF / overflow-safe
+                    result.Add(new AddrResult(slot, U.ToHexString(i)));
+                }
+                return result;
+            }
+
+            // JP / other: contiguous run where u32(slot) is a valid pointer
+            // (WF OPClassFontForm.Init).
+            for (uint i = 0; i < ScanCap; i++)
+            {
+                uint slot = tableBase + i * EntrySize;
+                if (slot + 4 > (uint)rom.Data.Length) break;
+                if (!U.isPointer(rom.u32(slot))) break; // contiguous-run terminator
+
+                result.Add(new AddrResult(slot, U.ToHexString(i)));
+            }
+
+            return result;
+        }
+    }
+}

--- a/FEBuilderGBA.Core/PatchDetection.cs
+++ b/FEBuilderGBA.Core/PatchDetection.cs
@@ -397,6 +397,30 @@ namespace FEBuilderGBA
             return SearchPatchBool(rom, OPClassReelSortPatchTable);
         }
 
+        // ---- ChapterNameToText patch detector (#1029) ----
+        // Cross-platform port of WinForms PatchUtil.SearchChapterNameToTextPatch.
+        // Used as the headless default precondition for the JP chapter-name wipe
+        // (ToolTranslateROMCore.WipeJPTitle): the wipe rewrites chapter-title
+        // pointers to text only when this patch is installed, mirroring WF
+        // HowDoYouLikePatchForm.CheckAndShowPopupDialog(ChapterNameText) which
+        // returns true only when the patch is present / freshly installed.
+
+        static readonly PatchTableSt[] ChapterNameToTextPatchTable = new PatchTableSt[] {
+            new PatchTableSt{ name="ChapterNameToText", ver = "FE8J", addr = 0x8B894, data = new byte[]{0x00, 0x4B, 0x18, 0x47}},
+            new PatchTableSt{ name="ChapterNameToText", ver = "FE8U", addr = 0x89624, data = new byte[]{0x00, 0x4B, 0x18, 0x47}},
+        };
+
+        /// <summary>
+        /// True when the "ChapterNameToText" patch (FE8J or FE8U) is installed in
+        /// <paramref name="rom"/>. Cross-platform port of WinForms
+        /// <c>PatchUtil.SearchChapterNameToTextPatch</c>. Returns false on null
+        /// ROM and on any non-FE8 version (signature table only contains FE8J/U).
+        /// </summary>
+        public static bool SearchChapterNameToTextPatch(ROM rom)
+        {
+            return SearchPatchBool(rom, ChapterNameToTextPatchTable);
+        }
+
         // ---- Class skill extends (SkillSystem) ----
         // The CSkillSys "class skill extends" patch detector now lives in
         // FEBuilderGBA.Core/SkillSystemPatchScanner.cs as

--- a/FEBuilderGBA.Core/ToolTranslateROMCore.cs
+++ b/FEBuilderGBA.Core/ToolTranslateROMCore.cs
@@ -23,15 +23,15 @@
 //  - ImportTextsFromFile - reads `[XXXX]\ntext\n\n` and writes back via
 //    Huffman/UnHuffman/CString depending on the entry kind.
 //
+//  - WipeJPFont / WipeJPTitle / WipeJPClassReelFont orchestration (#1029) — now
+//    fully cross-platform via ToolTranslateROMWipeJPCore.cs + ChapterTitleCore +
+//    OPClassFontListCore; the HowDoYouLikePatchForm ChapterNameText popup is
+//    replaced by an injected precondition delegate (Core stays UI-free). Consumed
+//    by SimpleFireTranslate when opts.OverrideJpFont is set.
+//
 // What's intentionally NOT here (KnownGap, documented in PR Known Limitations):
 //  - Bitmap font auto-generation (`ImageUtil.AutoGenerateFont` is
 //    System.Drawing-bound; lives in WinForms).
-//  - WipeJPFont / WipeJPTitle / WipeJPClassReelFont orchestration (depend on
-//    WF `HowDoYouLikePatchForm` dialog popups + WF `FontForm` static methods
-//    that haven't been migrated yet). The Core PriorityCode + FontCore helpers
-//    *are* now in Core (see PriorityCode.cs / FontCore.cs), so a follow-up PR
-//    can wire WipeJP via delegate hooks once `HowDoYouLikePatchForm` is
-//    abstracted.
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -964,11 +964,25 @@ namespace FEBuilderGBA
             public string FromLanguage { get; set; } = string.Empty;
             public string ToLanguage { get; set; } = string.Empty;
             public bool OverrideJpFont { get; set; }
+
+            /// <summary>
+            /// Gate for the JP chapter-name wipe (<see cref="WipeJPTitle"/>),
+            /// mirroring WF <c>HowDoYouLikePatchForm.CheckAndShowPopupDialog(ChapterNameText)</c>:
+            /// return true to wipe the chapter-title images, false to skip. When
+            /// null (the default), the wipe falls back to a headless
+            /// <see cref="PatchDetection.SearchChapterNameToTextPatch"/> check —
+            /// it skips when the ChapterNameToText patch is absent. The Avalonia
+            /// host injects a delegate that surfaces the patch recommendation.
+            /// Only consulted when <see cref="OverrideJpFont"/> is set.
+            /// </summary>
+            public Func<bool> ChapterNameTextPrecondition { get; set; }
         }
 
         /// <summary>
         /// Orchestrates the full WF SimpleFireButton_Click flow against the
         /// Core helpers:
+        ///   0. (When opts.OverrideJpFont) WipeJPClassReelFont -> WipeJPTitle ->
+        ///      WipeJPFont — the WF wipe order, BEFORE the translate import.
         ///   1. ApplyTranslatePatch (main menu width + status-screen skill)
         ///   2. If TranslateDataFilename is supplied, ImportTextsFromFile from
         ///      that file
@@ -977,9 +991,9 @@ namespace FEBuilderGBA
         ///      file back into the ROM (auto-translates static texts)
         ///   4. ImportFont from TO ROM (font-copy path; auto-gen stays
         ///      WinForms-only)
-        ///   5. BlackOut + Push undo are caller's responsibility
-        /// Skips OverrideJpFont (WipeJP*) which depend on WF popups - see
-        /// #536 Known Limitations.
+        ///   5. BlackOut — clears any leftover recycle ranges with 0x00 (WF
+        ///      parity: trans.BlackOut(undodata)). Push undo is the caller's
+        ///      responsibility.
         /// Returns the number of text entries imported in the auto-translate
         /// pass; 0 on failure.
         /// </summary>
@@ -989,6 +1003,18 @@ namespace FEBuilderGBA
             if (rom?.RomInfo == null || opts == null) return 0;
             if (opts.FromLanguage == opts.ToLanguage) return 0;
             if (recycle == null) return 0;
+
+            // Step 0: JP-font wipe (Override JP Font). WF order is
+            // WipeJPClassReelFont -> WipeJPTitle -> WipeJPFont, BEFORE the import.
+            if (opts.OverrideJpFont)
+            {
+                progressCallback?.Invoke("WipeJP ClassReel Font...");
+                WipeJPClassReelFont(rom, recycle, undo);
+                progressCallback?.Invoke("WipeJP Title...");
+                WipeJPTitle(rom, recycle, undo, opts.ChapterNameTextPrecondition);
+                progressCallback?.Invoke("WipeJP Font...");
+                WipeJPFont(rom, recycle, undo);
+            }
 
             // Step 1: Apply translate patch.
             ApplyTranslatePatch(rom, opts.ToLanguage, undo);
@@ -1040,7 +1066,82 @@ namespace FEBuilderGBA
                     recycle, undo, progressCallback);
             }
 
+            // Step 5: BlackOut — clear any leftover recycle ranges with 0x00 so
+            // the freed JP-font / text regions don't leave stale bytes behind
+            // (WF parity: trans.BlackOut(undodata) at the end of
+            // SimpleFireButton_Click). Threads undo so it rolls back.
+            recycle.BlackOut(undo);
+
             return total;
+        }
+
+        // ============================================================
+        // WipeJP* orchestration (#1029) — Form-free ports of WF
+        // ToolTranslateROM.WipeJPFont / WipeJPTitle / WipeJPClassReelFont.
+        // Each mirrors the WF body: helper -> recycle.AddRecycle -> RecycleOptimize
+        // (WipeJPFont additionally re-appends the preserved glyphs from the
+        // OPTIMIZED recycle pool via WriteBackFont, so order matters).
+        // ============================================================
+
+        /// <summary>
+        /// Wipe the FE8J Japanese font hash tables, preserving the always-keep
+        /// glyphs. Builds the recycle list, optimizes it, then re-appends the
+        /// preserved glyphs from the optimized pool. Form-free port of WF
+        /// <c>ToolTranslateROM.WipeJPFont</c>. No-op on non-FE8J ROMs.
+        /// </summary>
+        public static void WipeJPFont(ROM rom, RecycleAddress recycle, Undo.UndoData undo)
+        {
+            if (rom?.RomInfo == null || recycle == null) return;
+
+            var list = new List<Address>();
+            var jpfont = new WipeJPFontHelper(rom, undo);
+            jpfont.AddJPFonts(list);
+
+            recycle.AddRecycle(list);
+            recycle.RecycleOptimize();
+
+            // WriteBackFont allocates preserved glyphs from the OPTIMIZED pool,
+            // so this MUST run after RecycleOptimize.
+            jpfont.WriteBackFont(recycle);
+        }
+
+        /// <summary>
+        /// Wipe the JP chapter-name images (repoint to the last entry, zero the
+        /// number/title pointers). Form-free port of WF
+        /// <c>ToolTranslateROM.WipeJPTitle</c>. The
+        /// <paramref name="chapterNameTextPrecondition"/> gates the wipe (WF
+        /// HowDoYouLikePatchForm(ChapterNameText) parity); null = headless patch
+        /// check. No-op on non-FE8 ROMs / when the precondition is false.
+        /// </summary>
+        public static void WipeJPTitle(ROM rom, RecycleAddress recycle, Undo.UndoData undo,
+            Func<bool> chapterNameTextPrecondition = null)
+        {
+            if (rom?.RomInfo == null || recycle == null) return;
+
+            var list = new List<Address>();
+            var jpChapter = new WipeJPChapterNameHelper(rom, undo);
+            jpChapter.Wipe(list, chapterNameTextPrecondition);
+
+            recycle.AddRecycle(list);
+            recycle.RecycleOptimize();
+        }
+
+        /// <summary>
+        /// Wipe the OP-class JP-name font slots (repoint all-but-first to the
+        /// first). Form-free port of WF
+        /// <c>ToolTranslateROM.WipeJPClassReelFont</c>. No-op unless the ROM is
+        /// FE8J with the OP-class-reel font code signature present.
+        /// </summary>
+        public static void WipeJPClassReelFont(ROM rom, RecycleAddress recycle, Undo.UndoData undo)
+        {
+            if (rom?.RomInfo == null || recycle == null) return;
+
+            var list = new List<Address>();
+            var jpClassReel = new WipeJPClassReelFontHelper(rom, undo);
+            jpClassReel.Wipe(list);
+
+            recycle.AddRecycle(list);
+            recycle.RecycleOptimize();
         }
 
         // ============================================================

--- a/FEBuilderGBA.Core/ToolTranslateROMWipeJPCore.cs
+++ b/FEBuilderGBA.Core/ToolTranslateROMWipeJPCore.cs
@@ -167,12 +167,18 @@ namespace FEBuilderGBA
             Address.AddAddress(list, itemFontStart, itemFontEnd - itemFontStart,
                 U.NOT_FOUND, "ItemFont Wipe", Address.DataTypeEnum.BIN);
 
-            // Clear the item-font hash-pointer table (896 bytes) — WITH undo.
-            Rom.write_fill(0x57994C, 896, 0, UndoData);
-            ClearedRanges.Add((U.toOffset(0x57994C), U.toOffset(0x57994C) + 896));
-            // Clear the text-font hash-pointer table (896 bytes) — WITH undo.
-            Rom.write_fill(0x593F74, 896, 0, UndoData);
-            ClearedRanges.Add((U.toOffset(0x593F74), U.toOffset(0x593F74) + 896));
+            // Clear the two font hash-pointer tables (896 bytes each) — WITH undo.
+            // Resolve the table heads from RomInfo (via FontCore.GetFontPointer)
+            // rather than hard-coding the FE8J offsets, so the version-specific
+            // addresses stay centralized. For FE8J these are font_item_address
+            // (0x57994C) and font_serif_address (0x593F74). (Copilot review #1101.)
+            uint itemTable = U.toOffset(FontCore.GetFontPointer(true, Rom));
+            uint textTable = U.toOffset(FontCore.GetFontPointer(false, Rom));
+            const uint TableBytes = 896;
+            Rom.write_fill(itemTable, TableBytes, 0, UndoData);
+            ClearedRanges.Add((itemTable, itemTable + TableBytes));
+            Rom.write_fill(textTable, TableBytes, 0, UndoData);
+            ClearedRanges.Add((textTable, textTable + TableBytes));
         }
 
         void SearchCustomFonts(bool isItemFont, uint ignoreEnd, List<Address> list)
@@ -397,8 +403,10 @@ namespace FEBuilderGBA
             if (!Rom.RomInfo.is_multibyte) return;
 
             // The OP-class-reel font code must match the FE8J signature; otherwise
-            // the table layout is unknown and wiping it is unsafe.
-            if (!U.isSafetyOffset(0xB7890, Rom)) return;
+            // the table layout is unknown and wiping it is unsafe. isSafetyOffset
+            // only checks addr < Data.Length, not addr+2, so guard the 16-bit read
+            // explicitly to keep this truly no-throw. (Copilot review #1101.)
+            if (!U.isSafetyOffset(0xB7890, Rom) || 0xB7890 + 2 > (uint)Rom.Data.Length) return;
             if (Rom.u16(0xB7890) != 0x4B00) return;
 
             // Keep the first entry; wipe everything else.

--- a/FEBuilderGBA.Core/ToolTranslateROMWipeJPCore.cs
+++ b/FEBuilderGBA.Core/ToolTranslateROMWipeJPCore.cs
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// #1029 — Cross-platform Core port of the three WinForms JP-font-wipe helpers
+// used by the ROM Translation Tool's "Override JP Font" flow:
+//   * ToolTranslateROMWipeJPFont.cs        -> WipeJPFontHelper
+//   * ToolTranslateROMWipeJPChapterName.cs -> WipeJPChapterNameHelper
+//   * ToolTranslateROMWipeJPClassReelFont.cs -> WipeJPClassReelFontHelper
+//
+// These are ROM-MUTATING when run, so every write threads the caller's
+// Undo.UndoData (the WF AddJPFonts cleared the item/text font tables WITHOUT undo;
+// this port routes those write_fill clears through the undo-aware overload so they
+// roll back). The pointer rewrites and the recycle-pool WriteBackFont allocations
+// also go through undo / RecycleAddress. Nothing mutates the ROM outside undo.
+//
+// WinForms-free swaps:
+//   FontForm.GetFontPointer/FindFontData/MakeNewFontData -> FontCore.*
+//   OptionForm.textencoding()                            -> CoreState.TextEncoding
+//   PatchUtil.SearchPriorityCode()                       -> PriorityCodeUtil.SearchPriorityCode(rom)
+//   U.ConvertMojiCharToUnit                              -> ToolTranslateROMCore.ConvertMojiCharToUnit
+//   ImageChapterTitleForm.MakeList()                     -> ChapterTitleCore.MakeList(rom)
+//   OPClassFontForm/FE8UForm.MakeList()                  -> OPClassFontListCore.MakeList(rom)
+//   HowDoYouLikePatchForm.CheckAndShowPopupDialog(ChapterNameText)
+//                                                        -> injected Func<bool> precondition
+//   Program.ROM                                          -> passed ROM rom
+using System;
+using System.Collections.Generic;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Cross-platform Core port of WinForms <c>ToolTranslateROMWipeJPFont</c>.
+    /// Wipes the FE8J Japanese font hash tables (freeing ~100 KB), preserving a
+    /// small set of always-keep glyphs (digits, item-name symbols, etc.) which
+    /// are re-allocated from the optimized recycle pool by
+    /// <see cref="WriteBackFont"/>.
+    /// </summary>
+    public sealed class WipeJPFontHelper
+    {
+        /// <summary>A glyph that must survive the wipe and be re-appended afterward.</summary>
+        sealed class KeepFont
+        {
+            public bool IsItemFont;
+            public string Moji;
+            public uint MojiCode;
+            public uint Width;
+            public byte[] Data;
+            public uint RewritePointer;
+        }
+
+        readonly List<KeepFont> KeepFontList = new List<KeepFont>();
+        readonly ROM Rom;
+        readonly PRIORITY_CODE PriorityCode;
+        readonly Undo.UndoData UndoData;
+
+        // The two font hash-pointer table regions cleared by write_fill (in OFFSET
+        // form). WriteBackFont's hash-head splice lands inside these regions; the
+        // fill already snapshotted the ORIGINAL bytes there, so re-recording the
+        // splice would double-cover the address and (because the undo system
+        // applies records forward / last-wins) clobber the original on rollback.
+        // We therefore write splices that fall inside a filled region WITHOUT undo
+        // — the fill's record is the single source of truth for those bytes,
+        // keeping rollback byte-identical (#1029 finding-5 safety).
+        readonly List<(uint start, uint end)> ClearedRanges = new List<(uint, uint)>();
+
+        public WipeJPFontHelper(ROM rom, Undo.UndoData undoData)
+        {
+            this.Rom = rom;
+            this.UndoData = undoData;
+            this.PriorityCode = PriorityCodeUtil.SearchPriorityCode(rom);
+        }
+
+        bool InClearedRange(uint addr)
+        {
+            foreach (var (start, end) in ClearedRanges)
+                if (addr >= start && addr < end) return true;
+            return false;
+        }
+
+        // Write a 4-byte pointer; thread undo only when the address is NOT already
+        // covered by a fill snapshot (see ClearedRanges note above).
+        void WritePointer(uint addr, uint pointer)
+        {
+            if (InClearedRange(addr))
+                Rom.write_u32(addr, pointer);           // fill snapshot covers it
+            else
+                Rom.write_u32(addr, pointer, UndoData); // record the original
+        }
+
+        void AddKeepFont(bool isItemFont, uint moji, uint rewritePointer = U.NOT_FOUND)
+        {
+            uint topaddress = FontCore.GetFontPointer(isItemFont, Rom);
+            uint fontaddress = FontCore.FindFontData(topaddress, moji, out _, Rom, PriorityCode);
+            if (fontaddress == U.NOT_FOUND) return;
+
+            var kf = new KeepFont
+            {
+                IsItemFont = isItemFont,
+                Moji = "Code" + U.To0xHexString(moji),
+                MojiCode = moji,
+                Width = Rom.u8(fontaddress + 5),
+                Data = Rom.getBinaryData(fontaddress + 8, 64),
+                RewritePointer = rewritePointer,
+            };
+            KeepFontList.Add(kf);
+        }
+
+        void AddKeepFont(bool isItemFont, string one, uint rewritePointer = U.NOT_FOUND)
+        {
+            uint moji = ToolTranslateROMCore.ConvertMojiCharToUnit(one, PriorityCode);
+            uint topaddress = FontCore.GetFontPointer(isItemFont, Rom);
+            uint fontaddress = FontCore.FindFontData(topaddress, moji, out _, Rom, PriorityCode);
+            if (fontaddress == U.NOT_FOUND) return;
+
+            var kf = new KeepFont
+            {
+                IsItemFont = isItemFont,
+                Moji = one,
+                MojiCode = moji,
+                Width = Rom.u8(fontaddress + 5),
+                Data = Rom.getBinaryData(fontaddress + 8, 64),
+                RewritePointer = rewritePointer,
+            };
+            KeepFontList.Add(kf);
+        }
+
+        /// <summary>
+        /// Build the recycle list of wipeable JP-font regions and clear the two
+        /// font hash-pointer tables. FE8J-only (multibyte, version 8, not ZH_TBL);
+        /// no-op otherwise. The two <c>write_fill</c> font-table clears thread the
+        /// caller's undo so they roll back (the WF original did NOT — #1029 fix).
+        /// </summary>
+        public void AddJPFonts(List<Address> list)
+        {
+            if (Rom?.RomInfo == null) return;
+            if (!Rom.RomInfo.is_multibyte)
+            {
+                // English ROM — irrelevant.
+                return;
+            }
+            if (CoreState.TextEncoding == TextEncodingEnum.ZH_TBL)
+            {
+                // The ZH font system is different — can't wipe it this way.
+                // (Avalonia/CLI leave TextEncoding at Auto, so this guard only
+                // fires when the WinForms user explicitly chose the ZH TBL.)
+                return;
+            }
+            if (Rom.RomInfo.version != 8)
+            {
+                // FE8 only.
+                return;
+            }
+
+            // Register the glyphs we must NOT lose.
+            MakeKeepFontFE8J();
+
+            // Existing text-font table region.
+            const uint textFontStart = 0x5942F4;
+            const uint textFontEnd = 0x5B8CDC;
+            SearchCustomFonts(false, textFontEnd, list);
+            Address.AddAddress(list, textFontStart, textFontEnd - textFontStart,
+                U.NOT_FOUND, "TextFont Wipe", Address.DataTypeEnum.BIN);
+
+            // Existing item-font table region.
+            const uint itemFontStart = 0x579CCC;
+            const uint itemFontEnd = 0x593ECC;
+            SearchCustomFonts(true, itemFontEnd, list);
+            Address.AddAddress(list, itemFontStart, itemFontEnd - itemFontStart,
+                U.NOT_FOUND, "ItemFont Wipe", Address.DataTypeEnum.BIN);
+
+            // Clear the item-font hash-pointer table (896 bytes) — WITH undo.
+            Rom.write_fill(0x57994C, 896, 0, UndoData);
+            ClearedRanges.Add((U.toOffset(0x57994C), U.toOffset(0x57994C) + 896));
+            // Clear the text-font hash-pointer table (896 bytes) — WITH undo.
+            Rom.write_fill(0x593F74, 896, 0, UndoData);
+            ClearedRanges.Add((U.toOffset(0x593F74), U.toOffset(0x593F74) + 896));
+        }
+
+        void SearchCustomFonts(bool isItemFont, uint ignoreEnd, List<Address> list)
+        {
+            uint topaddress = FontCore.GetFontPointer(isItemFont, Rom);
+
+            for (uint moji1 = 0x1f; moji1 <= 0xff; moji1++)
+            {
+                // Move to the hash-list head pointer.
+                uint fontlist = topaddress + (moji1 << 2) - 0x100;
+                if (!U.isSafetyOffset(fontlist, Rom)) continue;
+
+                uint p = Rom.p32(fontlist);
+                if (!U.isSafetyOffset(p, Rom)) continue;
+                uint before_pointer = fontlist;
+
+                // struct{ void* next; byte moji2; byte width; byte nazo1; byte nazo2; } // 8
+                //   + 64-byte 4bpp bitmap
+                while (p > 0)
+                {
+                    if (p >= ignoreEnd)
+                    {
+                        Address.AddAddress(list, p, 8 + 64, before_pointer,
+                            "WipeJP Font", Address.DataTypeEnum.BIN);
+                    }
+
+                    uint next = Rom.u32(p);
+                    if (next == 0) break;                       // list terminator
+                    if (!U.isSafetyPointer(next, Rom)) break;   // corrupt list
+
+                    before_pointer = p;
+                    p = U.toOffset(next);                       // next node
+                }
+            }
+        }
+
+        void MakeKeepFontFE8J()
+        {
+            AddKeepFont(false, "０");
+            AddKeepFont(false, "１");
+            AddKeepFont(false, "２");
+            AddKeepFont(false, "３");
+            AddKeepFont(false, "４");
+            AddKeepFont(false, "５");
+            AddKeepFont(false, "６");
+            AddKeepFont(false, "７");
+            AddKeepFont(false, "８");
+            AddKeepFont(false, "９");
+            AddKeepFont(false, 0x7a81); // heart
+            AddKeepFont(true, 0x7a81);  // heart
+            AddKeepFont(true, "０", 0x593ECC);
+            AddKeepFont(true, "１", 0x593ED0);
+            AddKeepFont(true, "２", 0x593ED4);
+            AddKeepFont(true, "３", 0x593ED8);
+            AddKeepFont(true, "４", 0x593EDC);
+            AddKeepFont(true, "５", 0x593EE0);
+            AddKeepFont(true, "６", 0x593EE4);
+            AddKeepFont(true, "７", 0x593EE8);
+            AddKeepFont(true, "８", 0x593EEC);
+            AddKeepFont(true, "９", 0x593EF0);
+            AddKeepFont(true, "ⅹ", 0x593EF4);
+            AddKeepFont(true, "ⅰ", 0x593EF8);
+            AddKeepFont(true, "ⅱ", 0x593EFC);
+            AddKeepFont(true, "ⅲ", 0x593F00);
+            AddKeepFont(true, "ⅳ", 0x593F04);
+            AddKeepFont(true, "ⅴ", 0x593F08);
+            AddKeepFont(true, "ⅵ", 0x593F0C);
+            AddKeepFont(true, "ⅶ", 0x593F10);
+            AddKeepFont(true, "ⅷ", 0x593F14);
+            AddKeepFont(true, "ⅸ", 0x593F18);
+            AddKeepFont(true, "ー", 0x593F1C);
+            AddKeepFont(true, "＋", 0x593F20);
+            AddKeepFont(true, "／", 0x593F24);
+            AddKeepFont(true, "～", 0x593F28);
+            AddKeepFont(true, "Ｓ", 0x593F2C);
+            AddKeepFont(true, "Ａ", 0x593F30);
+            AddKeepFont(true, "Ｂ", 0x593F34);
+            AddKeepFont(true, "Ｃ", 0x593F38);
+            AddKeepFont(true, "Ｄ", 0x593F3C);
+            AddKeepFont(true, "Ｅ", 0x593F40);
+            AddKeepFont(true, "Ｇ", 0x593F44);
+            AddKeepFont(true, "ε", 0x593F48);
+            AddKeepFont(true, "：", 0x593F4C);
+            AddKeepFont(true, "．", 0x593F50);
+            AddKeepFont(true, "Ｈ", 0x593F54);
+            AddKeepFont(true, "Ｐ", 0x593F58);
+            AddKeepFont(true, "＃", 0x593F5C);
+            AddKeepFont(true, "＊", 0x593F60);
+            AddKeepFont(true, "→", 0x593F64);
+            AddKeepFont(true, "⊆", 0x593F68);
+            AddKeepFont(true, "⊇", 0x593F6C);
+            AddKeepFont(true, "％", 0x593F70);
+        }
+
+        void WriteBackFontKF(KeepFont kf, RecycleAddress ra)
+        {
+            uint topaddress = FontCore.GetFontPointer(kf.IsItemFont, Rom);
+
+            uint fontaddr = FontCore.FindFontData(topaddress, kf.MojiCode, out uint prevaddr, Rom, PriorityCode);
+            if (fontaddr != U.NOT_FOUND) return; // already present
+            if (prevaddr == U.NOT_FOUND) return; // can't append
+
+            byte[] newFontData = FontCore.MakeNewFontData(kf.MojiCode, kf.Width, kf.Data, Rom, PriorityCode);
+            U.write_u32(newFontData, 0, 0); // NULL — appending to the list tail
+
+            uint newaddr = ra.Write(newFontData, UndoData);
+            if (newaddr == U.NOT_FOUND) return; // allocation error
+
+            // Splice into the hash chain: point the previous node at the new tail.
+            // WritePointer threads undo only when the target wasn't already
+            // captured by a fill snapshot (keeps rollback byte-identical).
+            WritePointer(prevaddr + 0, U.toPointer(newaddr));
+
+            if (kf.RewritePointer != U.NOT_FOUND)
+            {
+                WritePointer(kf.RewritePointer, U.toPointer(newaddr));
+            }
+        }
+
+        /// <summary>
+        /// Re-append every preserved glyph, allocating each from the OPTIMIZED
+        /// recycle pool. MUST be called after <c>recycle.RecycleOptimize()</c>.
+        /// </summary>
+        public void WriteBackFont(RecycleAddress ra)
+        {
+            foreach (KeepFont kf in KeepFontList)
+            {
+                WriteBackFontKF(kf, ra);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Cross-platform Core port of WinForms <c>ToolTranslateROMWipeJPChapterName</c>.
+    /// Repoints every chapter-title image pointer (except the last) at the last
+    /// entry's image and zeros the chapter Number / Title pointers, freeing those
+    /// LZ77 images for recycling. FE8-only; gated by an injected precondition that
+    /// mirrors WF <c>CheckAndShowPopupDialog(ChapterNameText)</c> (skip when the
+    /// ChapterNameToText patch is absent / the user declines).
+    /// </summary>
+    public sealed class WipeJPChapterNameHelper
+    {
+        readonly ROM Rom;
+        readonly Undo.UndoData UndoData;
+
+        public WipeJPChapterNameHelper(ROM rom, Undo.UndoData undoData)
+        {
+            this.Rom = rom;
+            this.UndoData = undoData;
+        }
+
+        /// <summary>
+        /// Wipe the JP chapter-name images. <paramref name="chapterNameTextPrecondition"/>
+        /// gates the wipe (true ⇒ proceed, false ⇒ skip) — pass a delegate that
+        /// surfaces the ChapterNameToText patch recommendation; null defaults to a
+        /// headless <see cref="PatchDetection.SearchChapterNameToTextPatch"/> check
+        /// (skip when the patch is absent, matching WF).
+        /// </summary>
+        public void Wipe(List<Address> list, Func<bool> chapterNameTextPrecondition = null)
+        {
+            if (Rom?.RomInfo == null) return;
+            if (Rom.RomInfo.version != 8) return;
+
+            // Mirror WF CheckAndShowPopupDialog(ChapterNameText): only wipe when the
+            // patch is present / freshly installed. Default = headless patch check.
+            bool ok = chapterNameTextPrecondition != null
+                ? chapterNameTextPrecondition()
+                : PatchDetection.SearchChapterNameToTextPatch(Rom);
+            if (!ok) return;
+
+            // Keep the last entry; wipe everything else.
+            List<AddrResult> alist = ChapterTitleCore.MakeList(Rom);
+            if (alist.Count <= 1) return;
+
+            uint addr = alist[alist.Count - 1].addr;
+            if (!U.isSafetyOffset(addr, Rom)) return;
+            uint lastChapterNameImageAddr = Rom.u32(addr + 0);
+
+            for (int i = 0; i < alist.Count; i++)
+            {
+                addr = alist[i].addr;
+                uint a = Rom.u32(addr + 0);
+
+                if (a != lastChapterNameImageAddr)
+                {
+                    Address.AddLZ77Pointer(list, addr + 0, "Chapter_Save",
+                        false, Address.DataTypeEnum.LZ77IMG);
+                    Rom.write_u32(addr + 0, lastChapterNameImageAddr, UndoData);
+                }
+                Address.AddLZ77Pointer(list, addr + 4, "Chapter_Number",
+                    false, Address.DataTypeEnum.LZ77IMG);
+                Address.AddLZ77Pointer(list, addr + 8, "Chapter_Title",
+                    false, Address.DataTypeEnum.LZ77IMG);
+
+                Rom.write_u32(addr + 4, 0, UndoData);
+                Rom.write_u32(addr + 8, 0, UndoData);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Cross-platform Core port of WinForms <c>ToolTranslateROMWipeJPClassReelFont</c>.
+    /// Repoints every OP-class JP-name font slot (except the first) at the first
+    /// slot's image, freeing those LZ77 images for recycling. FE8J-only (version 8,
+    /// multibyte, and the OP-class-reel font code signature present).
+    /// </summary>
+    public sealed class WipeJPClassReelFontHelper
+    {
+        readonly ROM Rom;
+        readonly Undo.UndoData UndoData;
+
+        public WipeJPClassReelFontHelper(ROM rom, Undo.UndoData undoData)
+        {
+            this.Rom = rom;
+            this.UndoData = undoData;
+        }
+
+        public void Wipe(List<Address> list)
+        {
+            if (Rom?.RomInfo == null) return;
+            if (Rom.RomInfo.version != 8) return;
+            if (!Rom.RomInfo.is_multibyte) return;
+
+            // The OP-class-reel font code must match the FE8J signature; otherwise
+            // the table layout is unknown and wiping it is unsafe.
+            if (!U.isSafetyOffset(0xB7890, Rom)) return;
+            if (Rom.u16(0xB7890) != 0x4B00) return;
+
+            // Keep the first entry; wipe everything else.
+            List<AddrResult> alist = OPClassFontListCore.MakeList(Rom);
+            if (alist.Count <= 1) return;
+
+            uint addr = alist[0].addr;
+            if (!U.isSafetyOffset(addr, Rom)) return;
+            uint firstJpFontImageAddr = Rom.u32(addr + 0);
+
+            for (int i = 0; i < alist.Count; i++)
+            {
+                addr = alist[i].addr;
+                uint a = Rom.u32(addr + 0);
+
+                if (a != firstJpFontImageAddr)
+                {
+                    Address.AddLZ77Pointer(list, addr + 0,
+                        "OPClassFont " + U.To0xHexString(i),
+                        false, Address.DataTypeEnum.LZ77IMG);
+                    Rom.write_u32(addr + 0, firstJpFontImageAddr, UndoData);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ports the WinForms ROM Translation Tool's **"Override JP Font" / WipeJP\*** flow cross-platform so the Avalonia Simple-translate path actually wipes the Japanese fonts when the checkbox is checked. Previously this was a KnownGap that told users to "use the WinForms tool."

**Closes #1029**

### What changed

**Core (new, WinForms-free):**
- `ChapterTitleCore.MakeList` — port of `ImageChapterTitleForm.MakeList` (12-byte chapter-title struct table walk).
- `OPClassFontListCore.MakeList` — port of `OPClassFontForm`/`OPClassFontFE8UForm.MakeList` (4-byte OP-class-font slot table; JP contiguous-pointer run / FE8U `i<=0x7a`).
- `ToolTranslateROMWipeJPCore` — `WipeJPFontHelper` / `WipeJPChapterNameHelper` / `WipeJPClassReelFontHelper`. Swaps `FontForm.*`→`FontCore.*`, `OptionForm.textencoding()`→`CoreState.TextEncoding`, `PatchUtil.SearchPriorityCode()`→`PriorityCodeUtil.SearchPriorityCode(rom)`, `U.ConvertMojiCharToUnit`→`ToolTranslateROMCore.ConvertMojiCharToUnit`, `Program.ROM`→passed `rom`.
- `PatchDetection.SearchChapterNameToTextPatch` — port of the WF byte-signature check (FE8J `0x8B894` / FE8U `0x89624` == `00 4B 18 47`); the headless default precondition for `WipeJPTitle`.

**Core (`ToolTranslateROMCore`):**
- `WipeJPFont` / `WipeJPTitle` / `WipeJPClassReelFont` orchestration (helper → `AddRecycle` → `RecycleOptimize`; `WipeJPFont` then `WriteBackFont` from the **optimized** recycle pool — order matters).
- `SimpleFireTranslate` consumes `opts.OverrideJpFont` in **WF order (ClassReel → Title → Font) BEFORE the import**, then the **final `recycle.BlackOut(undo)`** (WF parity).
- The `ChapterNameText` `HowDoYouLikePatchForm` popup is replaced by an injected `Func<bool>` precondition (Core stays UI-free; `null` defaults to the patch check — skip when absent).
- Removed the stale #536 KnownGap docs.

**Avalonia (`ToolTranslateROMView`):**
- `SimpleFire_Click` passes `OverrideJpFont` through (no more KnownGap message); resolves the `ChapterNameText` precondition on the **UI thread** (surfacing the ported `HowDoYouLikePatchView` recommendation when the patch is absent, then re-checking) and forwards the captured value into the worker thread.

### Undo / rollback safety (finding 5)
The two `AddJPFonts` font-table `write_fill` clears now **thread the caller's undo** (the WF original did NOT) and roll back. The `WriteBackFont` hash-head splice writes inside an already-snapshotted fill range **without re-recording undo**, so the overlapping ranges restore the ROM **byte-identically** on rollback (proven by a test).

### Plan-review blocker fixes
1. `ChapterNameText` default = **patch-present wipes / patch-absent skips** (NOT a no-op-that-wipes).
2. `CoreState.TextEncoding` parity: only WinForms `Program.cs` sets it; Avalonia/CLI leave it `Auto` (`!= ZH_TBL`) so the `AddJPFonts` ZH guard is WF-equivalent. Documented + tested.

## Test plan

All automated (Core.Tests), all passing:

- [x] `ChapterTitleCoreTests` — list-builder returns the contiguous run / stops at the non-pointer terminator / guards null+unsafe.
- [x] `OPClassFontListCoreTests` — JP contiguous run + FE8U fixed `i<=0x7a` (0x7b slots) + guards.
- [x] `ToolTranslateROMWipeJPCoreTests.WipeJPFont_ClearsFontHashTables_AndRestoresKeepGlyph` — item/text font-table clears happen AND `WriteBackFont` restores the preserved glyph (width + 64-byte bitmap) re-pointing the hash head.
- [x] `WipeJPTitle_RepointsAllButLast_ToLastImage` — chapter-title `+0` repointed, `+4`/`+8` zeroed, last row preserved.
- [x] `WipeJPClassReelFont_RepointsAllButFirst_ToFirstImage` + `_NoSignature_SkipsWipe`.
- [x] `WipeJPTitle_PatchPresent_DefaultPrecondition_Wipes` / `_PatchAbsent_DefaultPrecondition_SkipsWipe` / `_InjectedPreconditionFalse_SkipsWipe_EvenIfPatchPresent` / `_InjectedPreconditionTrue_Wipes` (ChapterNameText precondition, both directions).
- [x] `SearchChapterNameToTextPatch_DetectsSignature` (present + absent).
- [x] `WipeJPFont_ZhTbl_NoOp` + `WipeJPFont_AutoEncoding_Proceeds` (blocker-2 ZH_TBL guard).
- [x] `SimpleFireWipeJPOrderTests.SimpleFire_OverrideJpFontTrue_RunsThreeWipes_InWFOrder` — asserts the **observable order** ClassReel → Title → Font (progress markers + per-wipe ROM effects), not just final state.
- [x] `SimpleFire_OverrideJpFontFalse_SkipsAllWipes`.
- [x] `WipeJP_AllThree_Rollback_RestoresByteIdentical` — all 3 wipes + `BlackOut` then `undo.RunUndo()` restores the ROM **byte-identically** (covers `write_fill` clears, pointer rewrites, `WriteBackFont`, and `BlackOut`).
- [x] Guards — `WipeJPFont_NonFE8_NoOp_NoThrow`, `WipeJP_NullRom_NoOp_NoThrow`.
- [x] Full suites: **Core.Tests 3298 pass** (10 pre-existing FE8U `.dmp` `SkillSystemsAnime*`/`SkillConfigSkillSystemBulkImport*` failures, identical on clean master — not touched here), **Avalonia.Tests 7884 pass** (incl. L10n / dark-mode / ViewModel-sweep gates), **FEBuilderGBA.Tests 1851 pass**.

## GUI Test Report

| Test case | Steps | Result |
|---|---|---|
| Override JP Font checkbox visible + functional (FE8J) | Launch Avalonia with FE8J.gba → open ROM Translate → Simple tab | PASS — checkbox shown (`ShowJpFontOverride`), no KnownGap message |
| Checkbox toggles | Toggle `ToolTranslateROM_SimpleOverrideJpFont_Check` via UIAutomation | PASS — toggled to checked |
| Editor renders | Capture the ROM Translation Tool window | PASS — see screenshot below |

The checkbox is hidden on FE8U (WF rule `!(!is_multibyte && version>=7)`), so the GUI proof uses **FE8J** where the WipeJP flow is meaningful and the checkbox is exposed.

## Screenshot

ROM Translation Tool (FE8J), Simple tab, **Override JP Font checked** — no KnownGap message:

![ROM Translation Tool — Override JP Font checked](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr-1029-wipe-jp-font.png)

---

Original user request: resolve all open GitHub issues in laqieer/FEBuilderGBA.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-4-8[1m])
