### PR TITLE
docs(cross-platform): document experimental Winlator/Gamenative Android path (#1069)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,13 @@ dotnet run --project FEBuilderGBA.Avalonia -- --gap-sweep-density --dry-run --ou
 dotnet test FEBuilderGBA.Core.Tests/FEBuilderGBA.Core.Tests.csproj
 ```
 
+### Running on Android (experimental)
+
+Two distinct paths exist, both covered in detail in [docs/CROSS_PLATFORM.md → Running on Android](docs/CROSS_PLATFORM.md#running-on-android):
+
+- **Emulation (Gamenative/Winlator)** — run the Windows *desktop* build under Wine + Box86/Box64. User-side, **experimental / unsupported / community-tested**; try the Avalonia `win-x64` build first.
+- **Native Android app** — a separate port of the Avalonia GUI, tracked as exploration epic [#1070](https://github.com/laqieer/FEBuilderGBA/issues/1070). Not shipped.
+
 ### Architecture Diagram
 
 ```

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -186,14 +186,14 @@ msbuild /m /p:Configuration=Release /p:Platform=x86 /t:build /restore FEBuilderG
 
 ### Option A — Emulation via Gamenative / Winlator (experimental, unsupported)
 
-**Gamenative** (a Pluvia/Winlator fork) runs Windows x86/x64 binaries on Android via **Wine + Box86/Box64** (x86→ARM dynamic translation). This runs the **Windows *desktop* build** of FEBuilderGBA under emulation — a **user-side compatibility layer**, **not** a native Android app.
+**Gamenative** (a Winlator fork) runs Windows x86/x64 binaries on Android via **Wine + Box86/Box64** (x86/x64 → ARM dynamic translation). This runs the **Windows *desktop* build** of FEBuilderGBA under emulation — a **user-side compatibility layer**, **not** a native Android app.
 
 - **Which build to try:** as a best-effort suggestion, the **Avalonia desktop `win-x64`** self-contained build (`./scripts/publish-all.sh win-x64`) is more likely to behave under Wine than the classic WinForms build — modern cross-platform .NET generally fares better under Wine than WinForms. This is *not* a guarantee of compatibility or a support commitment.
 - **Known caveats — set expectations accordingly:**
   - Desktop mouse/keyboard UX on a touchscreen (the UI is not touch-designed).
   - Wine + .NET-under-Wine reliability is **unverified** for this app.
   - No native Android file picker / scoped-storage (SAF) integration.
-  - External-tool features will not work: GBA emulator test-play, devkitARM assembler, and EA/ColorzCore event compilation.
+  - External-tool integrations are not expected to work (and are unsupported in this path): GBA emulator test-play, devkitARM assembler, and EA/ColorzCore event compilation.
 
 ### Option B — Native Android app
 

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -179,3 +179,22 @@ msbuild /m /p:Configuration=Release /p:Platform=x86 /t:build /restore FEBuilderG
 | Event Assembler | `Tools/Event Assembler/` | Wine or native port | Wine or native port |
 | 7-Zip | `7-zip32.dll` (bundled) | SharpCompress fallback | SharpCompress fallback |
 | Git | `PortableGit/` or system | System package | System or Homebrew |
+
+## Running on Android
+
+> **Status: experimental / unsupported / community-tested.** Nothing in this section is something this project builds, ships, or can support. It is documented for users who ask about it (see source [discussion #1062](https://github.com/laqieer/FEBuilderGBA/discussions/1062)).
+
+### Option A — Emulation via Gamenative / Winlator (experimental, unsupported)
+
+**Gamenative** (a Pluvia/Winlator fork) runs Windows x86/x64 binaries on Android via **Wine + Box86/Box64** (x86→ARM dynamic translation). This runs the **Windows *desktop* build** of FEBuilderGBA under emulation — a **user-side compatibility layer**, **not** a native Android app.
+
+- **Which build to try:** as a best-effort suggestion, the **Avalonia desktop `win-x64`** self-contained build (`./scripts/publish-all.sh win-x64`) is more likely to behave under Wine than the classic WinForms build — modern cross-platform .NET generally fares better under Wine than WinForms. This is *not* a guarantee of compatibility or a support commitment.
+- **Known caveats — set expectations accordingly:**
+  - Desktop mouse/keyboard UX on a touchscreen (the UI is not touch-designed).
+  - Wine + .NET-under-Wine reliability is **unverified** for this app.
+  - No native Android file picker / scoped-storage (SAF) integration.
+  - External-tool features will not work: GBA emulator test-play, devkitARM assembler, and EA/ColorzCore event compilation.
+
+### Option B — Native Android app
+
+Running the Windows binary under emulation gives you the *desktop* program on an Android device; it does **not** give you a touch-native app. An actual native Android build of the Avalonia GUI is a substantial, separate port tracked as the exploration epic [#1070](https://github.com/laqieer/FEBuilderGBA/issues/1070) — there is no commitment to ship it yet.


### PR DESCRIPTION
## Summary
Adds an honest **experimental / unsupported** note documenting the Gamenative/Winlator path for running FEBuilderGBA on Android, clearly separated from the native-Android epic (#1070). Docs-only — no code changes.

- `docs/CROSS_PLATFORM.md` — new `## Running on Android` section:
  - **Option A** — emulation via Gamenative/Winlator = **Wine + Box86/Box64** (x86→ARM) running the **Windows *desktop* build** (user-side compatibility layer, not an Android app). Recommends trying the Avalonia `win-x64` build as best-effort; lists caveats (touchscreen UX, Wine+.NET reliability unverified, no SAF file picker, external tools won't work).
  - **Option B** — pointer to the native-Android epic #1070.
  - Source [discussion #1062](https://github.com/laqieer/FEBuilderGBA/discussions/1062) linked explicitly.
- `README.md` — short `### Running on Android (experimental)` pointer to the detailed section.

## Plan reference
Implementation plan posted on the issue and **accepted by Copilot CLI** (GPT-5.5) with two refinements folded in: explicit Markdown link for Discussion #1062 (not an issue/PR autolink) and best-effort (non-promissory) phrasing for the Avalonia `win-x64` recommendation.

## Scope
Closes #1069

## Test plan
- [x] Docs-only — no `.cs` files touched (`git diff --stat`: `README.md`, `docs/CROSS_PLATFORM.md` only, 26 insertions)
- [x] All four issue acceptance-criteria bullets covered (Wine+Box86/64 emulation clarified; Avalonia `win-x64` recommended; caveats listed; marked experimental/unsupported)
- [x] README anchor `docs/CROSS_PLATFORM.md#running-on-android` matches the actual heading (GitHub lowercase+hyphenate rule)
- [x] No fabricated URLs — Gamenative written in bold without a guessed repo URL; #1062/#1070 use real GitHub links
- [x] Build unaffected (no code paths change)

## Screenshots
`docs` PR — screenshots are optional/exempt per DEVELOPMENT-WORKFLOW.md (no GUI or behavior change).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) v2.1.169 — model `claude-opus-4-8[1m]`
