### PR TITLE
feat(avalonia): wire instrument-set picker into MIDI song import (#1002 Slice 2)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/SongTrackMidiImportTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/SongTrackMidiImportTests.cs
@@ -71,6 +71,15 @@ namespace FEBuilderGBA.Avalonia.Tests
             songHeaderAddr = 0x100000;
             entrySlot = tableBase; // entry 0
 
+            // Mark the region below 0x400 as "used" (non-zero, non-0xFF) so the
+            // ImportMidiFile free-space search (FindFreeSpace from 0x100) cannot
+            // return an offset < 0x200 — an all-zero synthetic ROM otherwise hands
+            // back 0x100, which fails U.isSafetyOffset's >= 0x200 lower bound. Real
+            // ROMs never have a multi-KB zero run at 0x100, so this only restores
+            // realistic free-space layout for the synthetic image.
+            for (int i = 0; i < 0x400; i++)
+                rom.Data[i] = 0x55;
+
             // Song table entry 0 -> header0 pointer + dummy player type.
             WriteU32(rom.Data, (int)tableBase + 0, 0x08000000u | songHeaderAddr);
             WriteU32(rom.Data, (int)tableBase + 4, 0x00000000u);
@@ -535,6 +544,39 @@ namespace FEBuilderGBA.Avalonia.Tests
             File.WriteAllBytes(path, bytes.ToArray());
         }
 
+        /// <summary>Write a Format-0, 1-track MIDI whose MTrk body contains a
+        /// real NoteOn/NoteOff pair on channel 0 so SongMidiCore.ConvertMidiToGBA
+        /// yields a NON-null song (it returns null when there are zero music
+        /// channels with notes). Used by the #1002 Slice 2 pointer tests so the
+        /// import actually succeeds and the header+4 assertion is reached.</summary>
+        static void WriteMidiWithNote(string path)
+        {
+            var track = new System.Collections.Generic.List<byte>
+            {
+                0x00, 0x90, 0x3C, 0x64,   // delta 0, NoteOn  ch0 key=60 vel=100
+                0x60, 0x80, 0x3C, 0x40,   // delta 96, NoteOff ch0 key=60 vel=64
+                0x00, 0xFF, 0x2F, 0x00,   // delta 0, End-of-Track
+            };
+
+            var bytes = new System.Collections.Generic.List<byte>();
+            // MThd: format 0, 1 track, 480 TPQN (same header as WriteMinimalMidi).
+            bytes.AddRange(System.Text.Encoding.ASCII.GetBytes("MThd"));
+            bytes.AddRange(new byte[] { 0, 0, 0, 6 });   // header length
+            bytes.AddRange(new byte[] { 0, 0 });          // format 0
+            bytes.AddRange(new byte[] { 0, 1 });          // 1 track
+            bytes.AddRange(new byte[] { 0x01, 0xE0 });    // 480 TPQN
+            // MTrk: the NoteOn/NoteOff body. Length is big-endian 4 bytes.
+            bytes.AddRange(System.Text.Encoding.ASCII.GetBytes("MTrk"));
+            int len = track.Count;
+            bytes.AddRange(new byte[]
+            {
+                (byte)((len >> 24) & 0xFF), (byte)((len >> 16) & 0xFF),
+                (byte)((len >> 8) & 0xFF), (byte)(len & 0xFF),
+            });
+            bytes.AddRange(track);
+            File.WriteAllBytes(path, bytes.ToArray());
+        }
+
         // -----------------------------------------------------------------
         // #1002 Slice 2: instrument-pointer correctness — end-to-end assertion
         // that the MIDI writer stores the chosen GBA POINTER verbatim in header +4.
@@ -552,7 +594,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         [Fact]
         public void ImportMidi_HonorsChosenInstrumentPointer()
         {
-            var rom = MakeRomWithSongTable(out uint tableBase, out _, out uint entrySlot);
+            var rom = MakeRomWithSongTable(out uint tableBase, out _, out _);
             var prevRom = CoreState.ROM;
             // A fresh Undo so ambient writes are captured.
             var prevUndo = CoreState.Undo;
@@ -569,6 +611,12 @@ namespace FEBuilderGBA.Avalonia.Tests
                 vm.SelectedSongIndex = (int)list[1].tag;
                 Assert.True(vm.IsLoaded);
 
+                // Resolve the song-table ENTRY slot for the SELECTED song (song 1
+                // lives at tableBase+8, NOT entry 0) so the read-back below targets
+                // the slot the import actually repoints.
+                uint entrySlot = vm.GetSelectedSongTableEntryAddr();
+                Assert.NotEqual(U.NOT_FOUND, entrySlot);
+
                 // Choose a distinct instrument set address (as a POINTER).
                 // Pick an offset inside U.isSafetyOffset range (>= 0x200).
                 uint chosenOffset = 0x100400u;            // inside our 16MB synthetic ROM
@@ -577,10 +625,12 @@ namespace FEBuilderGBA.Avalonia.Tests
                 // Simulate what the View does after the instrument picker confirms:
                 vm.InstrumentAddr = chosenPointer;
 
-                // Write a minimal MIDI, then import under an undo scope.
+                // Write a MIDI WITH A NOTE so ConvertMidiToGBA yields a non-null
+                // song (a note-less MIDI returns "no valid music tracks", which
+                // would short-circuit the import and skip the assertion below).
                 string midiPath = System.IO.Path.Combine(
                     System.IO.Path.GetTempPath(), $"slice2_{Guid.NewGuid():N}.mid");
-                WriteMinimalMidi(midiPath);
+                WriteMidiWithNote(midiPath);
                 try
                 {
                     var undoSvc = new UndoService();
@@ -590,9 +640,9 @@ namespace FEBuilderGBA.Avalonia.Tests
                     if (error != null)
                     {
                         undoSvc.Rollback();
-                        // If the import fails for an unrelated reason (e.g. too
-                        // few notes in the minimal MIDI), skip gracefully but do
-                        // NOT hide a pointer-correctness failure.
+                        // A MIDI with a real note MUST import — anything else is a
+                        // hard failure (do NOT silently skip the header+4 assertion).
+                        Assert.True(false, "ImportMidi must succeed for a MIDI with a note: " + error);
                         return;
                     }
 
@@ -631,7 +681,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         [Fact]
         public void ImportMidiVm_StandaloneHonorsChosenInstrument()
         {
-            var rom = MakeRomWithSongTable(out uint tableBase, out _, out uint entrySlot);
+            var rom = MakeRomWithSongTable(out uint tableBase, out _, out _);
             var prevRom = CoreState.ROM;
             var prevUndo = CoreState.Undo;
             CoreState.Undo = new Undo();
@@ -647,15 +697,24 @@ namespace FEBuilderGBA.Avalonia.Tests
                 Assert.True(vm.IsLoaded);
                 Assert.Equal(1, vm.SelectedSongId);
 
+                // Capture the song-table ENTRY slot for the selected song BEFORE
+                // the import — the VM's post-import LoadEntry re-resolves
+                // SongTableEntryAddr from the freshly-written header, so we must
+                // read the slot the import actually repointed, not the reloaded one.
+                uint entrySlot = vm.SongTableEntryAddr;
+                Assert.NotEqual(0u, entrySlot);
+
                 // Override with our chosen instrument pointer (GBA pointer slot).
                 uint chosenOffset = 0x100400u;
                 uint chosenPointer = U.toPointer(chosenOffset); // 0x08100400
                 vm.InstrumentAddr = chosenPointer;
 
-                // Parse a minimal MIDI so HasMidiInfo is set.
+                // Parse a MIDI WITH A NOTE so HasMidiInfo is set AND the import
+                // yields a non-null song (a note-less MIDI returns "no valid music
+                // tracks", which would short-circuit the import).
                 string midiPath = System.IO.Path.Combine(
                     System.IO.Path.GetTempPath(), $"slice2vm_{Guid.NewGuid():N}.mid");
-                WriteMinimalMidi(midiPath);
+                WriteMidiWithNote(midiPath);
                 try
                 {
                     string? parseErr = vm.ParseMidiInfo(midiPath);
@@ -669,15 +728,17 @@ namespace FEBuilderGBA.Avalonia.Tests
                     if (error != null)
                     {
                         undoSvc.Rollback();
-                        // Minimal MIDI may produce no tracks; skip but don't hide
-                        // pointer-correctness failures.
+                        // A MIDI with a real note MUST import — anything else is a
+                        // hard failure (do NOT silently skip the header+4 assertion).
+                        Assert.True(false, "ImportMidi must succeed for a MIDI with a note: " + error);
                         return;
                     }
 
                     undoSvc.Commit();
 
-                    // Re-read the freshly-written song header from the table entry.
-                    uint newHeaderPtr = rom.u32(vm.SongTableEntryAddr);
+                    // Re-read the freshly-written song header from the captured
+                    // table entry slot (the slot the import repointed).
+                    uint newHeaderPtr = rom.u32(entrySlot);
                     Assert.True(U.isPointer(newHeaderPtr),
                         "Table entry must point to a valid GBA header.");
                     uint newHeaderOffset = U.toOffset(newHeaderPtr);

--- a/FEBuilderGBA.Avalonia.Tests/SongTrackMidiImportTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/SongTrackMidiImportTests.cs
@@ -535,6 +535,171 @@ namespace FEBuilderGBA.Avalonia.Tests
             File.WriteAllBytes(path, bytes.ToArray());
         }
 
+        // -----------------------------------------------------------------
+        // #1002 Slice 2: instrument-pointer correctness — end-to-end assertion
+        // that the MIDI writer stores the chosen GBA POINTER verbatim in header +4.
+        // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Regression test for the #1002 Slice 2 pointer-vs-offset correctness
+        /// contract: after setting <c>vm.InstrumentAddr</c> to a chosen GBA
+        /// POINTER and calling <c>vm.ImportMidi</c>, the freshly-written song
+        /// header's +4 slot (read back from ROM) must equal that same POINTER
+        /// verbatim. This proves the View's "store as POINTER" step correctly feeds
+        /// <see cref="SongMidiCore.ImportMidiFile"/> (which writes verbatim) and
+        /// that the offset/pointer conversion is NOT applied a second time.
+        /// </summary>
+        [Fact]
+        public void ImportMidi_HonorsChosenInstrumentPointer()
+        {
+            var rom = MakeRomWithSongTable(out uint tableBase, out _, out uint entrySlot);
+            var prevRom = CoreState.ROM;
+            // A fresh Undo so ambient writes are captured.
+            var prevUndo = CoreState.Undo;
+            CoreState.Undo = new Undo();
+            try
+            {
+                CoreState.ROM = rom;
+
+                var vm = new SongTrackViewModel();
+                var list = vm.LoadFullList();
+                // Select song 1 (writable, non-silence).
+                Assert.True(list.Count >= 2);
+                vm.LoadEntry(list[1].addr);
+                vm.SelectedSongIndex = (int)list[1].tag;
+                Assert.True(vm.IsLoaded);
+
+                // Choose a distinct instrument set address (as a POINTER).
+                // Pick an offset inside U.isSafetyOffset range (>= 0x200).
+                uint chosenOffset = 0x100400u;            // inside our 16MB synthetic ROM
+                uint chosenPointer = U.toPointer(chosenOffset); // 0x08100400
+
+                // Simulate what the View does after the instrument picker confirms:
+                vm.InstrumentAddr = chosenPointer;
+
+                // Write a minimal MIDI, then import under an undo scope.
+                string midiPath = System.IO.Path.Combine(
+                    System.IO.Path.GetTempPath(), $"slice2_{Guid.NewGuid():N}.mid");
+                WriteMinimalMidi(midiPath);
+                try
+                {
+                    var undoSvc = new UndoService();
+                    undoSvc.Begin("Import MIDI");
+                    string? error = vm.ImportMidi(midiPath, out string summary);
+
+                    if (error != null)
+                    {
+                        undoSvc.Rollback();
+                        // If the import fails for an unrelated reason (e.g. too
+                        // few notes in the minimal MIDI), skip gracefully but do
+                        // NOT hide a pointer-correctness failure.
+                        return;
+                    }
+
+                    undoSvc.Commit();
+
+                    // Read back the freshly-written song-table entry -> new header.
+                    uint newHeaderPtr = rom.u32(entrySlot);
+                    Assert.True(U.isPointer(newHeaderPtr),
+                        "Song-table entry must point to a valid GBA header.");
+                    uint newHeaderOffset = U.toOffset(newHeaderPtr);
+                    Assert.True(U.isSafetyOffset(newHeaderOffset, rom),
+                        "New header offset must be in ROM range.");
+
+                    // Header +4 must equal the chosen POINTER (verbatim write).
+                    uint storedInstrPtr = rom.u32(newHeaderOffset + 4);
+                    Assert.Equal(chosenPointer, storedInstrPtr);
+                }
+                finally
+                {
+                    try { System.IO.File.Delete(midiPath); } catch { /* best effort */ }
+                }
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.Undo = prevUndo;
+            }
+        }
+
+        /// <summary>
+        /// Same assertion via <see cref="SongTrackImportMidiViewModel"/> (the
+        /// standalone import window's VM): LoadList → LoadEntry a real song →
+        /// override InstrumentAddr with a chosen pointer → ParseMidiInfo →
+        /// ImportMidi → assert header+4 == chosen pointer end-to-end.
+        /// </summary>
+        [Fact]
+        public void ImportMidiVm_StandaloneHonorsChosenInstrument()
+        {
+            var rom = MakeRomWithSongTable(out uint tableBase, out _, out uint entrySlot);
+            var prevRom = CoreState.ROM;
+            var prevUndo = CoreState.Undo;
+            CoreState.Undo = new Undo();
+            try
+            {
+                CoreState.ROM = rom;
+
+                var vm = new SongTrackImportMidiViewModel();
+                var list = vm.LoadList();
+                Assert.True(list.Count >= 2);
+                // Select song 1 (writable, non-silence).
+                vm.LoadEntry(list[1].addr, list[1].tag);
+                Assert.True(vm.IsLoaded);
+                Assert.Equal(1, vm.SelectedSongId);
+
+                // Override with our chosen instrument pointer (GBA pointer slot).
+                uint chosenOffset = 0x100400u;
+                uint chosenPointer = U.toPointer(chosenOffset); // 0x08100400
+                vm.InstrumentAddr = chosenPointer;
+
+                // Parse a minimal MIDI so HasMidiInfo is set.
+                string midiPath = System.IO.Path.Combine(
+                    System.IO.Path.GetTempPath(), $"slice2vm_{Guid.NewGuid():N}.mid");
+                WriteMinimalMidi(midiPath);
+                try
+                {
+                    string? parseErr = vm.ParseMidiInfo(midiPath);
+                    Assert.Null(parseErr); // parse must succeed
+                    Assert.True(vm.HasMidiInfo);
+
+                    var undoSvc = new UndoService();
+                    undoSvc.Begin("Import MIDI");
+                    string? error = vm.ImportMidi(out string summary);
+
+                    if (error != null)
+                    {
+                        undoSvc.Rollback();
+                        // Minimal MIDI may produce no tracks; skip but don't hide
+                        // pointer-correctness failures.
+                        return;
+                    }
+
+                    undoSvc.Commit();
+
+                    // Re-read the freshly-written song header from the table entry.
+                    uint newHeaderPtr = rom.u32(vm.SongTableEntryAddr);
+                    Assert.True(U.isPointer(newHeaderPtr),
+                        "Table entry must point to a valid GBA header.");
+                    uint newHeaderOffset = U.toOffset(newHeaderPtr);
+                    Assert.True(U.isSafetyOffset(newHeaderOffset, rom),
+                        "New header offset must be in ROM range.");
+
+                    // Header +4 must equal the chosen POINTER verbatim.
+                    uint storedInstrPtr = rom.u32(newHeaderOffset + 4);
+                    Assert.Equal(chosenPointer, storedInstrPtr);
+                }
+                finally
+                {
+                    try { System.IO.File.Delete(midiPath); } catch { /* best effort */ }
+                }
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.Undo = prevUndo;
+            }
+        }
+
         static void WriteU32(byte[] data, int offset, uint value)
         {
             data[offset + 0] = (byte)(value & 0xFF);

--- a/FEBuilderGBA.Avalonia/ViewModels/SongTrackImportSelectInstrumentViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SongTrackImportSelectInstrumentViewModel.cs
@@ -4,16 +4,14 @@ using System.Text;
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
     /// <summary>
-    /// View model for the standalone (non-modal) SongTrack instrument-set
-    /// (voicegroup) browser. Populates its list from the cross-platform
-    /// <see cref="InstrumentSetCore"/> — the same discovery routine WinForms
-    /// <c>SongTrackImportSelectInstrumentForm.PickupInstrument()</c> uses.
-    /// (#787)
-    ///
-    /// The WinForms MODAL pick-and-return flow (SongTrackForm → JumpFormLow →
-    /// GetInstrumentAddr → SongUtil.ImportS) is intentionally NOT mirrored here
-    /// — this Avalonia window is a read-only browser of the available
-    /// instrument sets, not a picker wired into a MIDI/.s import.
+    /// View model for the SongTrack instrument-set (voicegroup) browser and
+    /// pick-and-return picker. Populates its list from <see cref="InstrumentSetCore"/>
+    /// — the same discovery routine WinForms <c>PickupInstrument()</c> uses (#787).
+    /// The view (<c>SongTrackImportSelectInstrumentView</c>) implements
+    /// <c>IPickableEditor</c> and is now wired as a pick-and-return into BOTH
+    /// the <c>.s</c> import (<c>SongTrackSImportCore.ImportS</c>) and the MIDI
+    /// import (<c>SongMidiCore.ImportMidiFile</c>) via
+    /// <c>WindowManager.PickFromEditor</c> (#1002).
     /// </summary>
     public class SongTrackImportSelectInstrumentViewModel : ViewModelBase
     {

--- a/FEBuilderGBA.Avalonia/Views/SongTrackImportMidiView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SongTrackImportMidiView.axaml
@@ -16,6 +16,12 @@
           <TextBlock AutomationProperties.AutomationId="SongTrackImportMidi_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
         </Grid>
 
+        <!-- Instrument Set selection (#1002 Slice 2) -->
+        <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
+          <Button AutomationProperties.AutomationId="SongTrackImportMidi_SelectInstrument_Button" Content="Select Instrument Set..." Click="SelectInstrument_Click" />
+          <TextBlock AutomationProperties.AutomationId="SongTrackImportMidi_Instrument_Label" Name="InstrumentLabel" VerticalAlignment="Center" Foreground="Gray" />
+        </StackPanel>
+
         <!-- MIDI file selection -->
         <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
           <Button AutomationProperties.AutomationId="SongTrackImportMidi_BrowseMidi_Button" Content="Browse MIDI File..." Click="BrowseMidi_Click" />

--- a/FEBuilderGBA.Avalonia/Views/SongTrackImportMidiView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongTrackImportMidiView.axaml.cs
@@ -4,6 +4,7 @@ using global::Avalonia.Interactivity;
 using global::Avalonia.Platform.Storage;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Core;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
@@ -64,6 +65,13 @@ namespace FEBuilderGBA.Avalonia.Views
                     _vm.CurrentAddr, _vm.SongTableEntryAddr);
             else
                 AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+
+            // #1002 Slice 2: show the current instrument set pointer (seeded from
+            // the destination header +4 on LoadEntry, or updated by the picker).
+            if (InstrumentLabel != null)
+                InstrumentLabel.Text = _vm.InstrumentAddr != 0
+                    ? string.Format("0x{0:X08}", _vm.InstrumentAddr)
+                    : "(use destination's current voicegroup)";
         }
 
         /// <summary>Enable Import only when BOTH a destination song and a
@@ -157,6 +165,58 @@ namespace FEBuilderGBA.Avalonia.Views
                 Log.Error($"SongTrackImportMidiView.ImportMidi_Click failed: {ex.Message}");
                 CoreState.Services.ShowError($"MIDI import failed: {ex.Message}");
             }
+        }
+
+        // #1002 Slice 2: instrument-set picker for the standalone MIDI import window.
+        // Opens the SongTrackImportSelectInstrumentView in pick mode, seeds it with
+        // the destination's current voicegroup, and stores the chosen address as a GBA
+        // POINTER — SongMidiCore.AssembleGBASong writes instrumentAddr VERBATIM into
+        // the new song header +4 (a GBA pointer slot), unlike the .s path where
+        // ImportS applies toPointer internally and receives an OFFSET.
+        async void SelectInstrument_Click(object? sender, RoutedEventArgs e)
+        {
+            if (!_vm.IsLoaded)
+            {
+                CoreState.Services.ShowError(R._("Pick a destination song from the list first."));
+                return;
+            }
+
+            ROM rom = CoreState.ROM;
+            if (rom == null) return;
+
+            // Seed the picker with the destination's current voicegroup (already
+            // stored in InstrumentAddr as a raw GBA pointer from LoadEntry).
+            uint seed = _vm.InstrumentAddr;
+
+            PickResult? pick;
+            try
+            {
+                pick = await WindowManager.Instance.PickFromEditor<SongTrackImportSelectInstrumentView>(
+                    seed, this);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("SongTrackImportMidiView.SelectInstrument_Click pick failed: {0}", ex.Message);
+                CoreState.Services.ShowError(R._("Instrument selection failed: {0}", ex.Message));
+                return;
+            }
+            if (pick == null) return; // user cancelled.
+
+            // Normalize to offset + validate — the instrument list mixes an
+            // OFFSET-valued "Current" seed with toPointer'd discovered rows.
+            uint instrumentOffset = U.toOffset(pick.Address);
+            if (!U.isSafetyOffset(instrumentOffset, rom))
+            {
+                CoreState.Services.ShowError(R._("The selected instrument set address is invalid."));
+                return;
+            }
+
+            // Store as POINTER: the MIDI writer writes it verbatim into header +4.
+            _vm.InstrumentAddr = U.toPointer(instrumentOffset);
+
+            // Reflect the new choice in the label immediately.
+            if (InstrumentLabel != null)
+                InstrumentLabel.Text = string.Format("0x{0:X08}", _vm.InstrumentAddr);
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/SongTrackImportMidiView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongTrackImportMidiView.axaml.cs
@@ -71,7 +71,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (InstrumentLabel != null)
                 InstrumentLabel.Text = _vm.InstrumentAddr != 0
                     ? string.Format("0x{0:X08}", _vm.InstrumentAddr)
-                    : "(use destination's current voicegroup)";
+                    : R._("(use destination's current voicegroup)");
         }
 
         /// <summary>Enable Import only when BOTH a destination song and a

--- a/FEBuilderGBA.Avalonia/Views/SongTrackView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongTrackView.axaml.cs
@@ -432,6 +432,61 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 // Default: MIDI import (.mid/.midi or any other extension).
 
+                // #1002 Slice 2: pick the instrument set BEFORE importing so the user
+                // can choose which voicegroup the converted song uses — mirrors the .s
+                // pick-and-return path (ImportSondFontSource). The MIDI writer writes
+                // instrumentAddr VERBATIM into the new song header +4 (a GBA POINTER
+                // slot), so we must store a POINTER (unlike the .s path where ImportS
+                // applies toPointer internally and therefore receives an OFFSET).
+                ROM rom = CoreState.ROM;
+                if (rom == null) return;
+
+                // 1. Resolve + validate the song-table slot up front.
+                uint slot = _vm.GetSelectedSongTableEntryAddr();
+                if (slot == U.NOT_FOUND || !U.isSafetyOffset(slot, rom))
+                {
+                    CoreState.Services.ShowError(R._(
+                        "Cannot resolve the song-table entry for the selected song."));
+                    return;
+                }
+                // 2. Dereference + validate the header (+4 = instrument-pointer slot).
+                uint songHeaderOffset = rom.p32(slot);
+                if (!U.isSafetyOffset(songHeaderOffset, rom)
+                    || !U.isSafetyOffset(songHeaderOffset + 4, rom))
+                {
+                    CoreState.Services.ShowError(R._("The song table has no song header."));
+                    return;
+                }
+                // 3. Seed the picker with the current voicegroup (WF f.Init(P4) parity).
+                uint currentVoicegroup = rom.p32(songHeaderOffset + 4);
+
+                // 4. Open the instrument picker as a modal pick-and-return.
+                PickResult? pick;
+                try
+                {
+                    pick = await WindowManager.Instance.PickFromEditor<SongTrackImportSelectInstrumentView>(
+                        currentVoicegroup, this);
+                }
+                catch (Exception exPick)
+                {
+                    Log.Error("SongTrackView.ImportMidi_Click pick failed: {0}", exPick.Message);
+                    CoreState.Services.ShowError(R._("MIDI import failed: {0}", exPick.Message));
+                    return;
+                }
+                if (pick == null) return; // user cancelled the picker.
+
+                // 5. Normalize to offset and validate — the instrument list mixes an
+                //    OFFSET-valued "Current" seed with toPointer'd discovered rows.
+                uint instrumentOffset = U.toOffset(pick.Address);
+                if (!U.isSafetyOffset(instrumentOffset, rom))
+                {
+                    CoreState.Services.ShowError(R._("The selected instrument set address is invalid."));
+                    return;
+                }
+                // 6. Store as POINTER: SongMidiCore.AssembleGBASong writes this value
+                //    VERBATIM into the new song header +4 (a GBA pointer slot).
+                _vm.InstrumentAddr = U.toPointer(instrumentOffset);
+
                 // Parse and show MIDI metadata preview first so the user can
                 // confirm the file before it overwrites the song.
                 string preview = _vm.PreviewMidi(path);

--- a/FEBuilderGBA.Core.Tests/SongMidiCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/SongMidiCoreTests.cs
@@ -912,6 +912,46 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Equal(0x0800100Cu, ptr);
         }
 
+        /// <summary>
+        /// Regression test for the #1002 Slice 2 pointer-vs-offset correctness
+        /// contract: <see cref="SongMidiCore.ConvertMidiToGBA"/> writes the
+        /// <c>instrumentAddr</c> parameter VERBATIM into the returned song binary
+        /// at bytes [4..7] (the song header +4 GBA pointer slot). This locks the
+        /// invariant that the MIDI path must supply a POINTER, not an offset.
+        /// </summary>
+        [Fact]
+        public void ConvertMidiToGBA_WritesInstrumentPointerVerbatimAtHeaderPlus4()
+        {
+            // Build a minimal MIDI with one note so ConvertMidiToGBA does NOT
+            // return null (requires at least one channel with notes).
+            byte[] trackData = new byte[]
+            {
+                0x00, 0x90, 60, 100,   // NoteOn C4 vel=100
+                0x60,                   // delta=96 ticks
+                0x80, 60, 0,           // NoteOff
+                0x00, 0xFF, 0x2F, 0x00 // End of track
+            };
+
+            byte[] midiBytes = BuildTestMidi(0, 1, 96, trackData);
+            var midi = SongMidiCore.ParseMidiBytes(midiBytes);
+            Assert.NotNull(midi);
+
+            // Use a recognisable GBA pointer value to prove the verbatim-write
+            // contract — this is a POINTER (0x08xxxxxx), not an offset.
+            uint instrumentPointer = 0x08123456u;
+            byte[] gba = SongMidiCore.ConvertMidiToGBA(midi, midiBytes, instrumentPointer);
+
+            Assert.NotNull(gba);
+            Assert.True(gba.Length >= 8, "GBA song binary must include the 8-byte header");
+
+            // Bytes [4..7] of the header must equal the supplied pointer verbatim.
+            uint storedPointer = (uint)(gba[4]
+                | (gba[5] << 8)
+                | (gba[6] << 16)
+                | (gba[7] << 24));
+            Assert.Equal(instrumentPointer, storedPointer);
+        }
+
         [Fact]
         public void ConvertMidiToGBA_TickScaling_CorrectlyScales()
         {

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -769,6 +769,9 @@ MIDIインポート
 :Select Instrument
 楽器選択
 
+:Select Instrument Set...
+楽器セット選択...
+
 :Import Wave
 波形インポート
 

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -772,6 +772,9 @@ MIDIインポート
 :Select Instrument Set...
 楽器セット選択...
 
+:(use destination's current voicegroup)
+（インポート先の現在の音色セットを使用）
+
 :Import Wave
 波形インポート
 

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -14686,6 +14686,9 @@ MIDI导入
 :Select Instrument
 选择乐器
 
+:Select Instrument Set...
+选择乐器组...
+
 :Import Wave
 导入波形
 

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -14689,6 +14689,9 @@ MIDI导入
 :Select Instrument Set...
 选择乐器组...
 
+:(use destination's current voicegroup)
+（使用目标曲目的当前乐器组）
+
 :Import Wave
 导入波形
 


### PR DESCRIPTION
## Summary
Wires the existing Avalonia `SongTrackImportSelectInstrumentView` (a functional read-only instrument-set browser, already an `IPickableEditor`) into the **MIDI song import** as a modal pick-and-return that supplies the chosen instrument-set (voicegroup) address to the converted song.

The `.s` (SondFont) import path already did this pick-and-return (merged in #1095). This PR closes the remaining WinForms-parity gap: the MIDI import never offered the picker — it silently reused the destination header's existing `+4` voicegroup. Now both MIDI surfaces let the user choose the voicegroup at import time, mirroring WF `SongTrackForm` (MIDI branch → `SongTrackImportMidiForm` seeded with `P4` → `GetInstrumentAddr()` → `SongUtil.ImportMidiFile`).

## Plan
Implementation plan + Copilot review + acceptance: https://github.com/laqieer/FEBuilderGBA/issues/1002#issuecomment-4685468084 (plan), https://github.com/laqieer/FEBuilderGBA/issues/1002#issuecomment-4685500205 (acceptance of Copilot's two amendments).

### Correctness contract (Copilot blocker, addressed)
`SongMidiCore.AssembleGBASong` writes `instrumentAddr` **verbatim** into the new song header `+4` (a GBA POINTER slot). The picker's list mixes an OFFSET-valued "Current" seed with `toPointer`'d discovered rows. So the picked address is validated as an offset (`U.toOffset` + `U.isSafetyOffset`) and then stored as a **POINTER** (`U.toPointer(offset)`). This is the OPPOSITE of the `.s` path, where `SongTrackSImportCore.ImportS` applies `toPointer` internally and therefore receives an offset.

## Scope
- **Ref #1002** (issue stays open for Slice 3 — Song Exchange cross-ROM transplant).
- **In scope:** MIDI-import pick-and-return wiring on BOTH surfaces — the main `SongTrackView.ImportMidi_Click` (picker before import) and the standalone `SongTrackImportMidiView` (new "Select Instrument Set..." button) — plus the corrected picker VM doc comment.
- **Carved out (Ref #1002):** the full `SongTrackImportMidiForm` option panel (mid2agb method toggle + ignoreMOD/BEND/LFOS/HEAD/BACK + midfix4agb) and the Slice-3 Song Exchange transplant (`InstrumentMap`/`Rip`/`Burn`). Not ported here.

## Changes
- `FEBuilderGBA.Avalonia/Views/SongTrackView.axaml.cs` — `ImportMidi_Click` MIDI branch: resolve+validate slot/header, seed picker with `rom.p32(header+4)`, `PickFromEditor<SongTrackImportSelectInstrumentView>`, validate offset, store `U.toPointer(offset)` into `_vm.InstrumentAddr` before the existing preview→confirm→undo import.
- `FEBuilderGBA.Avalonia/Views/SongTrackImportMidiView.axaml` + `.axaml.cs` — new "Select Instrument Set..." button + instrument-pointer label; `SelectInstrument_Click` opens the picker (seeded with the destination's current voicegroup) and stores the chosen pointer.
- `FEBuilderGBA.Avalonia/ViewModels/SongTrackImportSelectInstrumentViewModel.cs` — corrected the stale doc comment (it claimed the pick-and-return was "NOT mirrored").
- `config/translate/{ja,zh}.txt` — localized the new button string (L10n CI gate).
- Tests: `FEBuilderGBA.Avalonia.Tests/SongTrackMidiImportTests.cs` (+2), `FEBuilderGBA.Core.Tests/SongMidiCoreTests.cs` (+1).

## Test plan
- [x] Core: `ConvertMidiToGBA_WritesInstrumentPointerVerbatimAtHeaderPlus4` — asserts `ConvertMidiToGBA(midi, bytes, 0x08123456)` writes 0x08123456 little-endian into the returned header `+4` (locks the verbatim-write contract the pointer fix depends on).
- [x] Avalonia: `ImportMidi_HonorsChosenInstrumentPointer` — main-editor VM imports a MIDI with a chosen `U.toPointer(offset)` and the newly-repointed song header `+4` equals that exact GBA pointer (end-to-end regression for the Copilot blocker).
- [x] Avalonia: `ImportMidiVm_StandaloneHonorsChosenInstrument` — same assertion via the standalone `SongTrackImportMidiViewModel`.
- [x] `dotnet build FEBuilderGBA.Core` + `FEBuilderGBA.Avalonia` (Debug + Release): 0 errors.
- [x] `dotnet test FEBuilderGBA.Core.Tests`: 3510 passed, 10 failed (all pre-existing SkillSystems FE8U-ROM-dependent failures, none in touched files), 0 new failures.
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests`: 7924 passed, 0 failed, 3 skipped (+2 new tests pass; L10n gate satisfied).
- [x] `FEBuilderGBA.Tests` (net9.0-windows) builds: 0 errors.

## GUI Test Report
Captured via the headless `--screenshot-all` off-screen renderer on `roms/FE8U.gba` (works on a locked desktop). 325 editors captured, 0 failed.

| # | Test | Surface | Result |
|---|------|---------|--------|
| 1 | Standalone MIDI Import shows the new "Select Instrument Set..." button + chosen-pointer label | `SongTrackImportMidiView` | PASS — button + `0x40000000` pointer label render alongside Browse MIDI / Import to ROM |
| 2 | Instrument picker renders as a selectable pick-and-return browser | `SongTrackImportSelectInstrumentView` | PASS — "Instrument Selection" window with the About note ("selecting the instrument set used when importing MIDI or .s files") + Selected Instrument Set panel |
| 3 | Main Song Track editor MIDI import path compiles + wires the picker before import | `SongTrackView` | PASS — renders; picker invoked in `ImportMidi_Click` before the preview/confirm/undo step |

### Standalone MIDI Import (new "Select Instrument Set..." button)
![MIDI import with instrument pick](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1002s2-midi-import-instrument-pick.png)

### Instrument-set picker (pick-and-return browser)
![Instrument picker](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1002s2-instrument-picker.png)

Ref #1002

🤖 Generated with Claude Code v2.1.169 — model claude-opus-4-8[1m]
