### PR TITLE
feat(core+cli): decomp diff-to-source migration assistant (#1131)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,7 +438,7 @@ Specialized utilities for different graphic types:
   `Import` validates dims → animType (16x48→0 / 16x96→1 / 32x96→2, else NO mutation), encodes, LZ77-
   writes + repoints `+4`, writes b2 @ `+2`, ambient undo, byte-identical fault restore (#885/#923). Class
   back-refs in `ClassFormCore` (`GetClassIdWhereWaitIconId`, `GetClassMoveIcon` move-icon id 1-BASED #993).
-  Gaps: GIF import (export-only), palette dialog (→nearest-color remap), old-region recycle (always-append).
+  Gaps: GIF import, palette dialog, old-region recycle (always-append).
 - `EventScriptReferenceScanner.cs` (Core, READ-ONLY) — generic event-script cross-reference scanner
   (#990; ports `EventCondForm.MakeEventScriptPointer` + FE7 tutorial table). `EnumerateEventEntries`
   yields every event entry point with verified per-cond geometry (TURN/TALK/OBJECT/ALWAYS/TUTORIAL/
@@ -463,11 +463,11 @@ Specialized utilities for different graphic types:
 - `ImageWorldMapCore.ImportIconStrip`/`TryGetStripPalette` (Core, ROM-MUTATING / READ-ONLY) — World Map
   Mini/Point1/Point2/Road single-LZ77 strip imports (#1000; wait-icon pattern): validate dims (%8), encode +
   LZ77-write + repoint the ONE image pointer; shared palette NOT written; byte-identical fault restore.
-  Avalonia `WorldMapImageView` 4 handlers + FE8-only `CanImport{strip}` gates. Event/Border/Export deferred.
+  Avalonia `WorldMapImageView` 4 handlers + FE8-only `CanImport{strip}` gates. Event/Border deferred.
 - `StructExportCore.FormatSTRUCT`/`FormatNMM` (Core, READ-ONLY, PURE) — Struct Dump Selector STRUCT (.h
   C-header) + NMM (No$gba memory map) export over `StructMetadata.StructDef`; Avalonia
   `DumpStructSelectDialogViewModel.MakeExportText` routes STRUCT/NMM (+CSV/TSV/EA) for a resolved table, hex
-  stub for unresolved. Gaps: no signed-byte/hex-radix, NMM aux-files emit `NULL`. #1012.
+  stub for unresolved. Gaps: no signed-byte/hex-radix; NMM aux→`NULL`. #1012.
 - `BattleAnimeRendererCore.RenderSampleBattleAnime` optional EXACT-32-byte `overridePaletteBlock` (Core,
   READ-ONLY) — live-recolor the Unit Palette editor sample preview from in-memory R/G/B spinners (WF
   `OnChangeColor`): Avalonia `ImageUnitPaletteView` packs 16 spinners (`UnitPaletteWriteCore.PackRgb555`) →
@@ -477,14 +477,14 @@ Specialized utilities for different graphic types:
   voice(0xBD) remap + VOL/PAN clamp 0..127 + TEMPO clamp 0..255 + gated note-velocity; validate-all-before-mutate,
   ambient undo, byte-identical fault restore. Wires Avalonia `SongTrackChangeTrackView` + `SongTrackAllChangeTrackView`
   Vol/Pan/Tempo. Slice 3 = `SongExchangeCore.ConvertSong` cross-ROM transplant (InstrumentMap/Rip/Burn port, sample
-  recycle + pointer fixups, validate-all-before-mutate, NO ROM growth); Avalonia `SongExchangeView` + CLI `--songexchange`.
-- `NameResolver.GetFaceTranslateInfo` + `ToolTranslateROMCore.AppendAIHintMessage` (Core, READ-ONLY) — Text Editor AI Hints export (#1028 Slice C): `GetTranslateInfoByFaceID` (unit-table-by-face-at-+6, `(f2&0x80)==0x20` quirk) + `AppendAIHintMessage` (escape forms, dedup, mob fallback); Avalonia `ExportAllTexts(path,includeAIHints)` appends CR/LF-flattened TSV.
+  recycle + pointer fixups, validate-before-mutate, NO ROM growth); Avalonia `SongExchangeView` + CLI `--songexchange`.
+- `NameResolver.GetFaceTranslateInfo` + `ToolTranslateROMCore.AppendAIHintMessage` (Core, READ-ONLY) — Text Editor AI Hints export (#1028 Slice C): `GetTranslateInfoByFaceID` (unit-table-by-face-at-+6, `(f2&0x80)==0x20` quirk) + `AppendAIHintMessage` (escape forms, dedup, mob fallback); Avalonia `ExportAllTexts(path,includeAIHints)`.
 - `PatchDetection.SearchAntiHuffmanPatch(rom)` (Core, READ-ONLY) — Text Editor bad-char popup (#1028 Slice D): 6 un-Huffman sigs (both FE8U @0x2BA4); `PatchDetectionService.DetectAntiHuffman` delegates. `TextViewerViewModel.WriteText` = WF encode-fail→callback shows `TextBadCharPopupView`→ABORT via `EncodeAbortedException`; ja/zh/ko gated.
 - `ExportFilterCore.BuildFilteredTextIds(rom,idx)` (Core, READ-ONLY) — Text Editor Export Filter (#1028 Slice B): WF `InitExportFilter` 11 cats (0=All→null); BattleTalk/Haiku event-ptr-when-0; Skill via `SkillSystemTextScanner`; EventCond via `EventScriptReferenceScanner.CollectEventCondTextIds` (4 text-args+POINTER_EVENT+MENUEXTENDS/etc+FE8). `U.GrepPatternMatch`/`MakeMask2` ported.
 - `MakeVarsIDArrayCore.BuildAllUsedRefs/BuildFreeAreaUsedSet` + `TextFreeAreaCore.FindUnreferencedTextIds` (Core, READ-ONLY) — DEFINITIVE Text Editor free-area + cross-ref (#1027; faithful `U.MakeVarsIDArray`): typed TEXTID∪SONG union over Unit/Class/Item/EventCond + collectors (MenuDefinition/StatusRMenu(recursive)/SoundBossBGM+WorldMapBGM/WorldMapEvent/FE8N-Ver3-skill), reusing ExportFilterCore; `AsmMapTextSymbolReader` + `PatchTextRefScannerCore` (installed ADDR/STRUCT TEXT/SONG/EVENT) + `ITextIDCache.EnumerateUsedTextIds`. PREREQ-GUARD when EventScript/CommentCache unwired or ROM≠active. Avalonia `FindUnreferencedTexts`/`FindCrossReferences`.
-- `ToolAnimationCreatorViewViewModel.InitFromMagicRom`/`InitFromSkillRom` (Avalonia, R/O) — Animation-Creator jump seeds: magic #996 (FEditor/CSA 0x86 via `MagicEffectExportCore`) + skill #1115 (`ExportSkillAnimation`→wait+TSA-preview; `CountSkillFrames` probe; `SkillConfigAnimeJumpHelper` 4 variants, Ver1 render-only). MapAction write-back only.
-- `PatchMacroAddressResolverCore.cs` (Core, READ-ONLY) — `$GREP`/`$XGREP`/`$FGREP`/`$P32`/`$TEXTID` resolver; adds `GrepPatternMatchEnd`/`GrepPatternMatchBegin` to Core `U.cs`; wires `PatchTextRefScannerCore` so grep-resolved TEXT/SONG/EVENT refs reach the free-area union. #1027.
-- `DecompProject.cs` (Core, READ-ONLY, never-throws) — decomp-project open mode (#1129 s1): `DecompProjectDetector.Detect` (score >=2 / manifest short-circuit) + `ResolveBuiltRom` (builtRom / `ROM:=` stem / same-stem-.elf glob); `CoreState.IsDecompMode`; CLI `--project`. #1130: `DecompSymbolResolver`/`MergedAsmMapFile` layer `.map`/ELF/`.sym`/JSON over shipped at `GetAsmMapFile()` (project wins; CLI `--resolve-addr`).
+- `ToolAnimationCreatorViewViewModel.InitFromMagicRom`/`InitFromSkillRom` (Avalonia, R/O) — Animation-Creator jump seeds: magic #996 (FEditor/CSA 0x86 via `MagicEffectExportCore`) + skill #1115 (`ExportSkillAnimation`; `CountSkillFrames`; `SkillConfigAnimeJumpHelper` 4 variants, Ver1 render-only). MapAction write-back only.
+- `PatchMacroAddressResolverCore.cs` (Core, READ-ONLY) — `$GREP`/`$XGREP`/`$FGREP`/`$P32`/`$TEXTID` resolver; adds `GrepPatternMatchEnd/Begin` to Core `U.cs`; wires `PatchTextRefScannerCore` so grep-resolved TEXT/SONG/EVENT refs reach the free-area union. #1027.
+- `DecompProject.cs` (Core, READ-ONLY, never-throws) — decomp-project open mode (#1129 s1): `Detect` (score >=2 / manifest) + `ResolveBuiltRom` (builtRom / `ROM:=` stem / same-stem-.elf glob); `IsDecompMode`; CLI `--project`. #1130: `DecompSymbolResolver`/`MergedAsmMapFile` layer `.map`/ELF/`.sym`/JSON over shipped at `GetAsmMapFile()` (project wins; CLI `--resolve-addr`). #1131: `DecompDiffMigrationCore` (advisory R/O) diffs built-vs-edited + classifies ranges by symbol/category/source/confidence (compressed/unknown→manual); CLI `--migrate-diff`.
 
 ### Caching System
 

--- a/FEBuilderGBA.CLI/Program.cs
+++ b/FEBuilderGBA.CLI/Program.cs
@@ -281,6 +281,15 @@ namespace FEBuilderGBA.CLI
                 return RunResolveAddr(argsDic);
             }
 
+            // --migrate-diff --project=<dir> --rom2=<editedRom> [--out=report.tsv]:
+            // decomp diff-to-source migration assistant — classify changed ranges
+            // (symbol/category/source/confidence) for migrating edits back to source.
+            // Advisory + READ-ONLY. Must precede the bare --project fallthrough (#1131).
+            if (argsDic.ContainsKey("--migrate-diff"))
+            {
+                return RunMigrateDiff(argsDic);
+            }
+
             // --project=<dir> [--rom-info]: open a decomp project and report its
             // mode + resolved preview ROM. Both `--project=<dir> --rom-info` and
             // bare `--project=<dir>` route to the rom-info reporter (#1129 slice 1).
@@ -441,6 +450,10 @@ namespace FEBuilderGBA.CLI
             Console.WriteLine("  --rom-info               Print ROM metadata: version, title, size, CRC32, checksum + Mode line (requires --rom or --project)");
             Console.WriteLine("  --project=<dir>          Open a decomp project directory and load its built ROM for preview; combine with --rom-info");
             Console.WriteLine("  --resolve-addr=<hex>     Resolve an address to a decomp project symbol (requires --project); prints name/source/offset");
+            Console.WriteLine("  --migrate-diff           Decomp diff-to-source migration assistant: classify built-vs-edited ROM changes (requires --project, --rom2)");
+            Console.WriteLine("    --rom2=<editedRom>     The FEBuilder-edited ROM to compare against the project's built/baseline ROM");
+            Console.WriteLine("    --out=<report.tsv>     Optional: write the classified report (range/symbol/category/source/confidence) as TSV");
+            Console.WriteLine("    --max-gap=<int>        Optional: small-gap merge distance for range coalescing (default 16)");
             Console.WriteLine("  --list-tables            List all exportable struct table names (no ROM required)");
             Console.WriteLine("  --export-palette         Export GBA palette to file (requires --rom, --addr, --out)");
             Console.WriteLine("    --addr=<hex>           Palette data address in ROM (e.g., 0x5524)");
@@ -462,6 +475,7 @@ namespace FEBuilderGBA.CLI
             Console.WriteLine("  FEBuilderGBA.CLI --pointercalc --rom=source.gba --target=target.gba --address=0x100,0x200");
             Console.WriteLine("  FEBuilderGBA.CLI --rebuild --rom=modified.gba --fromrom=original.gba");
             Console.WriteLine("  FEBuilderGBA.CLI --songexchange --rom=dest.gba --fromrom=source.gba --fromsong=0x1A --tosong=0x1A");
+            Console.WriteLine("  FEBuilderGBA.CLI --migrate-diff --project=decomp/ --rom2=edited.gba --out=migrate.tsv");
             Console.WriteLine("  FEBuilderGBA.CLI --convertmap1picture --in=map.png --outImg=tiles.bin --outTSA=tsa.bin");
             Console.WriteLine("  FEBuilderGBA.CLI --translate --rom=rom.gba --out=texts.tsv");
             Console.WriteLine("  FEBuilderGBA.CLI --translate --rom=rom.gba --in=texts.tsv");
@@ -4224,6 +4238,88 @@ namespace FEBuilderGBA.CLI
                 }
             }
             return "shipped";
+        }
+
+        // #1131: decomp diff-to-source migration assistant. Opens the project (built
+        // ROM = canonical baseline), reads the edited ROM, classifies each changed
+        // range (symbol/category/source/confidence), and prints/writes the advisory
+        // report. ADVISORY + READ-ONLY — never writes the ROM or source. Analysis
+        // never throws; usage faults return 1, otherwise exit 0.
+        static int RunMigrateDiff(Dictionary<string, string> argsDic)
+        {
+            string projectDir = argsDic.ContainsKey("--project") ? argsDic["--project"] : "";
+            if (string.IsNullOrEmpty(projectDir))
+            {
+                Console.Error.WriteLine("Error: --migrate-diff requires --project=<dir>");
+                return 1;
+            }
+            string editedPath = argsDic.ContainsKey("--rom2") ? argsDic["--rom2"] : "";
+            if (string.IsNullOrEmpty(editedPath))
+            {
+                Console.Error.WriteLine("Error: --migrate-diff requires --rom2=<editedRom>");
+                return 1;
+            }
+            if (!File.Exists(editedPath))
+            {
+                Console.Error.WriteLine($"Error: edited ROM not found: {editedPath}");
+                return 1;
+            }
+
+            RomLoader.InitEnvironment();
+            if (!RomLoader.LoadProject(projectDir))
+            {
+                Console.Error.WriteLine($"Error: Could not open decomp project: {projectDir}");
+                return 1;
+            }
+
+            ROM builtRom = CoreState.ROM;
+            if (builtRom == null || builtRom.Data == null || builtRom.Data.Length == 0)
+            {
+                Console.Error.WriteLine("Error: built/preview ROM unavailable — run the build first.");
+                return 1;
+            }
+
+            byte[] editedBytes;
+            try { editedBytes = File.ReadAllBytes(editedPath); }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Error: could not read edited ROM: {ex.Message}");
+                return 1;
+            }
+
+            // Pull the merged resolver (project over shipped) from the wired cache,
+            // plus a freshly-loaded resolver for the section / object-path hints.
+            MergedAsmMapFile map = CoreState.AsmMapFileAsmCache?.GetAsmMapFile() as MergedAsmMapFile;
+            DecompSymbolResolver resolver = null;
+            try { resolver = DecompSymbolResolver.Load(CoreState.DecompProject); }
+            catch { /* analyzer tolerates a null resolver */ }
+
+            int maxGap = DecompDiffMigrationCore.DefaultMaxGap;
+            if (argsDic.ContainsKey("--max-gap") && int.TryParse(argsDic["--max-gap"], out int mg) && mg >= 0)
+                maxGap = mg;
+
+            Console.WriteLine($"Project: {projectDir}");
+            Console.WriteLine($"Built ROM (baseline): {builtRom.Filename} ({builtRom.Data.Length} bytes)");
+            Console.WriteLine($"Edited ROM: {editedPath} ({editedBytes.Length} bytes)");
+            Console.WriteLine("Analyzing (advisory, read-only)...");
+
+            MigrationReport report = DecompDiffMigrationCore.Analyze(builtRom, editedBytes, map, resolver, maxGap);
+
+            if (argsDic.ContainsKey("--out") && !string.IsNullOrEmpty(argsDic["--out"]))
+            {
+                try
+                {
+                    File.WriteAllText(argsDic["--out"], DecompDiffMigrationCore.FormatTSV(report));
+                    Console.WriteLine($"Report written to: {argsDic["--out"]}");
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Warning: could not write report: {ex.Message}");
+                }
+            }
+
+            Console.WriteLine(DecompDiffMigrationCore.FormatSummary(report));
+            return 0;
         }
 
         static int RunListTables(Dictionary<string, string> argsDic)

--- a/FEBuilderGBA.CLI/Program.cs
+++ b/FEBuilderGBA.CLI/Program.cs
@@ -4305,6 +4305,11 @@ namespace FEBuilderGBA.CLI
 
             MigrationReport report = DecompDiffMigrationCore.Analyze(builtRom, editedBytes, map, resolver, maxGap);
 
+            // A requested --out write that fails is a FAILURE, not a warning:
+            // automation that asked for a TSV must not be told "success" with no
+            // report (Copilot PR #1139 finding 4). Print the summary first so the
+            // analysis result is still visible, then exit non-zero.
+            int exitCode = 0;
             if (argsDic.ContainsKey("--out") && !string.IsNullOrEmpty(argsDic["--out"]))
             {
                 try
@@ -4314,12 +4319,13 @@ namespace FEBuilderGBA.CLI
                 }
                 catch (Exception ex)
                 {
-                    Console.Error.WriteLine($"Warning: could not write report: {ex.Message}");
+                    Console.Error.WriteLine($"Error: could not write report to '{argsDic["--out"]}': {ex.Message}");
+                    exitCode = 1;
                 }
             }
 
             Console.WriteLine(DecompDiffMigrationCore.FormatSummary(report));
-            return 0;
+            return exitCode;
         }
 
         static int RunListTables(Dictionary<string, string> argsDic)

--- a/FEBuilderGBA.Core.Tests/DecompDiffMigrationCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompDiffMigrationCoreTests.cs
@@ -152,6 +152,32 @@ namespace FEBuilderGBA.Core.Tests
             Assert.NotEqual(MigrationConfidence.High, r.Confidence);
         }
 
+        [Fact]
+        public void Analyze_CoveringSymbol_UnknownCategory_StaysLowManual_NotHigh()
+        {
+            // A covering project symbol whose name/section carry NO data-category
+            // keyword (a neutral code-like symbol) must stay Low + manual — High is
+            // gated on a KNOWN category (Copilot PR #1139 finding 1).
+            uint off = 0x250000;
+            var (built, edited) = MakePair(0x1000000, off, 4);
+            var rom = MakeFe8uRom(built);
+
+            var (map, resolver) = BuildMap(string.Join("\n", new[]
+            {
+                " .text          0x08250000      0x100 build/src/proc.o",
+                "                0x08250000                SomeNeutralProc",   // no data keyword
+            }));
+
+            var report = DecompDiffMigrationCore.Analyze(rom, edited, map, resolver);
+            Assert.Single(report.Ranges);
+            var r = report.Ranges[0];
+            Assert.Equal("SomeNeutralProc", r.Symbol);
+            Assert.True(r.SymbolCovers);
+            Assert.Equal(MigrationCategory.Unknown, r.Category);
+            Assert.Equal(MigrationConfidence.Low, r.Confidence);
+            Assert.True(r.Manual);
+        }
+
         // ---------------------------------------------------------------- compressed
 
         [Fact]
@@ -204,6 +230,37 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Equal(MigrationCategory.Unknown, r.Category);
             Assert.Equal(MigrationConfidence.Low, r.Confidence);
             Assert.True(r.Manual);
+        }
+
+        [Fact]
+        public void Analyze_JustPastTextRegion_NotClassifiedAsText()
+        {
+            // FE8U text_data_end_address = 0x15AB80. A diff at/after the end must NOT
+            // be claimed as the text region (boundary correctness; conservative
+            // bounds, Copilot PR #1139 finding 2 family).
+            uint off = 0x160000;   // > 0x15AB80
+            var (built, edited) = MakePair(0x1000000, off, 4);
+            var rom = MakeFe8uRom(built);
+
+            var report = DecompDiffMigrationCore.Analyze(rom, edited, null, null);
+            Assert.Single(report.Ranges);
+            Assert.NotEqual(MigrationCategory.Text, report.Ranges[0].Category);
+        }
+
+        [Fact]
+        public void Analyze_ZeroRom_StructTablesNotOverClaimed()
+        {
+            // On a zero ROM the unit/class/item table pointers don't dereference to a
+            // valid populated table, so a diff in a low region must NOT be falsely
+            // classified as a struct table (the table scan must decline, not grab a
+            // generic 2048-row span). Conservative bounds (Copilot PR #1139 finding 2).
+            uint off = 0x5000;
+            var (built, edited) = MakePair(0x1000000, off, 4);
+            var rom = MakeFe8uRom(built);
+
+            var report = DecompDiffMigrationCore.Analyze(rom, edited, null, null);
+            Assert.Single(report.Ranges);
+            Assert.NotEqual(MigrationCategory.StructTable, report.Ranges[0].Category);
         }
 
         // ---------------------------------------------------------------- robustness
@@ -284,6 +341,21 @@ namespace FEBuilderGBA.Core.Tests
             // Null-safety.
             Assert.NotNull(DecompDiffMigrationCore.FormatTSV(null));
             Assert.NotNull(DecompDiffMigrationCore.FormatSummary(null));
+        }
+
+        [Fact]
+        public void Format_NullRangeElement_DoesNotThrow()
+        {
+            // The Ranges list is publicly mutable; a null element must not crash
+            // either formatter (Copilot PR #1139 review).
+            var report = new MigrationReport();
+            report.Ranges.Add(null);
+            report.Ranges.Add(new MigrationRange { Offset = 0x10, SpanLength = 2, ChangedBytes = 2, Symbol = "Sym" });
+
+            string tsv = DecompDiffMigrationCore.FormatTSV(report);
+            Assert.Contains("Sym", tsv);                 // the real row survives
+            string summary = DecompDiffMigrationCore.FormatSummary(report);
+            Assert.Contains("Sym", summary);
         }
     }
 }

--- a/FEBuilderGBA.Core.Tests/DecompDiffMigrationCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompDiffMigrationCoreTests.cs
@@ -28,6 +28,14 @@ namespace FEBuilderGBA.Core.Tests
             return rom;
         }
 
+        // 32 MB FE8U ROM so a symbol span can reach the EWRAM upper boundary.
+        static ROM MakeFe8uRom32mb(byte[] data)
+        {
+            var rom = new ROM();
+            Assert.True(rom.LoadLow("decomp-migrate-fe8u-32m.gba", data, "BE8E01"));
+            return rom;
+        }
+
         // Build a resolver + merged map from .map text (throwaway project dir).
         static (MergedAsmMapFile Map, DecompSymbolResolver Resolver) BuildMap(string mapText)
         {
@@ -261,6 +269,36 @@ namespace FEBuilderGBA.Core.Tests
             var report = DecompDiffMigrationCore.Analyze(rom, edited, null, null);
             Assert.Single(report.Ranges);
             Assert.NotEqual(MigrationCategory.StructTable, report.Ranges[0].Category);
+        }
+
+        [Fact]
+        public void Analyze_SpanEndingAtEwramBoundary_CoverageComputedCorrectly()
+        {
+            // A symbol whose span ends exactly at file offset 0x02000000 (32MB ROM
+            // upper boundary). The exclusive end pointer must be computed by pointer
+            // arithmetic (startPtr + span), NOT U.toPointer(endOffset) which would
+            // leave 0x02000000 unconverted and mis-judge coverage (Copilot PR #1139).
+            int size = 0x2000000;                 // 32 MB
+            uint off = 0x1FFFFF0;                 // last 16 bytes before the boundary
+            var built = new byte[size];
+            var edited = new byte[size];
+            for (int i = 0; i < 8; i++) edited[off + i] = 0xAA;
+            var rom = MakeFe8uRom32mb(built);
+
+            // Symbol gTail @ 0x09FFFFF0 covering [0x09FFFFF0 .. 0x0A000000) = the
+            // final 16 bytes; the 8-byte diff at 0x1FFFFF0 is fully inside it.
+            var (map, resolver) = BuildMap(string.Join("\n", new[]
+            {
+                " .rodata        0x09FFFFF0       0x10 build/src/tail.o",
+                "                0x09FFFFF0                gTailTable",
+            }));
+
+            var report = DecompDiffMigrationCore.Analyze(rom, edited, map, resolver);
+            Assert.Single(report.Ranges);
+            var r = report.Ranges[0];
+            Assert.Equal("gTailTable", r.Symbol);
+            Assert.True(r.SymbolCovers);          // coverage correct at the boundary
+            Assert.Equal(MigrationConfidence.High, r.Confidence);
         }
 
         // ---------------------------------------------------------------- robustness

--- a/FEBuilderGBA.Core.Tests/DecompDiffMigrationCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompDiffMigrationCoreTests.cs
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Core tests for the decomp diff-to-source migration assistant (#1131 slice 3).
+//
+// Synthetic-first: two in-memory FE8U ROMs differing at KNOWN offsets, plus a
+// throwaway project dir with a .map placing symbols at those GBA addresses. The
+// tests assert each changed range is classified to the right symbol / category /
+// confidence, that gap-coalescing tracks changed-bytes vs span separately, that
+// compressed beats everything (Low/manual), and that null/identity/malformed
+// inputs never throw.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class DecompDiffMigrationCoreTests
+    {
+        // ---------------------------------------------------------------- fixtures
+
+        static ROM MakeFe8uRom(byte[] data = null)
+        {
+            data ??= new byte[0x1000000];
+            var rom = new ROM();
+            Assert.True(rom.LoadLow("decomp-migrate-fe8u.gba", data, "BE8E01"));
+            return rom;
+        }
+
+        // Build a resolver + merged map from .map text (throwaway project dir).
+        static (MergedAsmMapFile Map, DecompSymbolResolver Resolver) BuildMap(string mapText)
+        {
+            string dir = Path.Combine(Path.GetTempPath(), $"migmap_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, "rom.gba"), "x");
+            File.WriteAllText(Path.Combine(dir, "rom.map"), mapText);
+            var project = new DecompProject { ProjectRoot = dir, BuiltRomPath = Path.Combine(dir, "rom.gba") };
+            try
+            {
+                var resolver = DecompSymbolResolver.Load(project);
+                var merged = new MergedAsmMapFile(new AsmMapSymbolFile(new ROM()), resolver);
+                return (merged, resolver);
+            }
+            finally { try { Directory.Delete(dir, true); } catch { } }
+        }
+
+        // A built+edited ROM pair that differs in [offset, offset+len).
+        static (byte[] Built, byte[] Edited) MakePair(int size, uint offset, int len, byte editVal = 0xAA)
+        {
+            var built = new byte[size];
+            var edited = new byte[size];
+            for (int i = 0; i < len; i++)
+                edited[offset + i] = editVal;       // built stays 0, edited differs
+            return (built, edited);
+        }
+
+        // ---------------------------------------------------------------- coalesce
+
+        [Fact]
+        public void Coalesce_TwoDiffsWithinGap_MergeIntoOneSpan_KeepingChangedBytesSeparate()
+        {
+            // Two 1-byte diffs at 0x100 and 0x108 (gap = 7 <= maxGap 16).
+            var ranges = new List<RomDiffCore.DiffRange>
+            {
+                new RomDiffCore.DiffRange { Offset = 0x100, Length = 1 },
+                new RomDiffCore.DiffRange { Offset = 0x108, Length = 1 },
+            };
+            var merged = DecompDiffMigrationCore.Coalesce(ranges, 16);
+            Assert.Single(merged);
+            Assert.Equal(0x100u, merged[0].Offset);
+            Assert.Equal(9u, merged[0].SpanLength);     // 0x100..0x108 inclusive
+            Assert.Equal(2u, merged[0].ChangedBytes);   // only 2 bytes really changed
+        }
+
+        [Fact]
+        public void Coalesce_TwoDiffsBeyondGap_StaySeparate()
+        {
+            var ranges = new List<RomDiffCore.DiffRange>
+            {
+                new RomDiffCore.DiffRange { Offset = 0x100, Length = 1 },
+                new RomDiffCore.DiffRange { Offset = 0x200, Length = 1 },   // gap 0xFF > 16
+            };
+            var merged = DecompDiffMigrationCore.Coalesce(ranges, 16);
+            Assert.Equal(2, merged.Count);
+            Assert.Equal(1u, merged[0].ChangedBytes);
+            Assert.Equal(1u, merged[1].ChangedBytes);
+        }
+
+        // ---------------------------------------------------------------- symbol + category
+
+        [Fact]
+        public void Analyze_TextRegionChange_ClassifiesAsText()
+        {
+            // FE8U text_data_start_address = 0xE8414 .. 0x15AB80. Put a diff inside.
+            uint off = 0xE8500;
+            var (built, edited) = MakePair(0x1000000, off, 4);
+            var rom = MakeFe8uRom(built);
+
+            var report = DecompDiffMigrationCore.Analyze(rom, edited, null, null);
+            Assert.Single(report.Ranges);
+            Assert.Equal(MigrationCategory.Text, report.Ranges[0].Category);
+            // No symbol/covering → Medium (range inferred), never High.
+            Assert.NotEqual(MigrationConfidence.High, report.Ranges[0].Confidence);
+        }
+
+        [Fact]
+        public void Analyze_CoveringProjectSymbol_GivesHighConfidenceAndSourceFile()
+        {
+            // Symbol gUnitTable @ 0x0808E500 (file off 0x8E500) covering a 0x40 span,
+            // owned by build/src/unit.o; diff a few bytes inside it.
+            uint off = 0x8E510;
+            var (built, edited) = MakePair(0x1000000, off, 4);
+            var rom = MakeFe8uRom(built);
+
+            var (map, resolver) = BuildMap(string.Join("\n", new[]
+            {
+                " .rodata        0x0808E500       0x40 build/src/unit.o",
+                "                0x0808E500                gUnitTable",
+            }));
+
+            var report = DecompDiffMigrationCore.Analyze(rom, edited, map, resolver);
+            Assert.Single(report.Ranges);
+            var r = report.Ranges[0];
+            Assert.Equal("gUnitTable", r.Symbol);
+            Assert.True(r.SymbolCovers);
+            Assert.Equal(MigrationConfidence.High, r.Confidence);
+            Assert.Equal(DecompArtifactSource.Map, r.SymbolSource);
+            Assert.Equal("build/src/unit.o", r.SourceFile);   // object path from .map
+            Assert.Equal(".rodata", r.Section);
+        }
+
+        [Fact]
+        public void Analyze_GraphicsSectionSymbol_NotCovering_GivesGraphicsLowOrMedium()
+        {
+            // Symbol in a gfx section but the diff sits BEYOND the symbol span → not
+            // covering → name/section heuristic, never High.
+            uint off = 0x300000;
+            var (built, edited) = MakePair(0x1000000, off, 8);
+            var rom = MakeFe8uRom(built);
+
+            var (map, resolver) = BuildMap(string.Join("\n", new[]
+            {
+                " .rodata        0x08300000        0x4 build/gfx/portrait.o",
+                "                0x08300000                gPortraitPalette",  // len ~4
+            }));
+
+            var report = DecompDiffMigrationCore.Analyze(rom, edited, map, resolver);
+            Assert.Single(report.Ranges);
+            var r = report.Ranges[0];
+            Assert.Equal(MigrationCategory.GraphicsPalette, r.Category);
+            Assert.NotEqual(MigrationConfidence.High, r.Confidence);
+        }
+
+        // ---------------------------------------------------------------- compressed
+
+        [Fact]
+        public void Analyze_CompressedHeader_AlwaysLowManual_BeatsSymbol()
+        {
+            // Place a real LZ77 stream in BOTH ROMs at 0x400000, then edit a byte
+            // inside it. The sniff must classify Compressed + Low + manual even with
+            // a covering project symbol present.
+            int size = 0x1000000;
+            byte[] raw = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF, 0x11, 0x22, 0x33, 0x44 };
+            byte[] comp = LZ77.compress(raw);
+            uint baseOff = 0x400000;
+
+            var built = new byte[size];
+            var edited = new byte[size];
+            Array.Copy(comp, 0, built, baseOff, comp.Length);
+            Array.Copy(comp, 0, edited, baseOff, comp.Length);
+            // Mutate a byte a few positions into the compressed stream.
+            edited[baseOff + 5] ^= 0xFF;
+
+            var rom = MakeFe8uRom(built);
+            var (map, resolver) = BuildMap(string.Join("\n", new[]
+            {
+                " .rodata        0x08400000      0x100 build/gfx/sprite.o",
+                "                0x08400000                gCompressedSprite",
+            }));
+
+            var report = DecompDiffMigrationCore.Analyze(rom, edited, map, resolver);
+            Assert.Single(report.Ranges);
+            var r = report.Ranges[0];
+            Assert.Equal(MigrationCategory.Compressed, r.Category);
+            Assert.Equal(MigrationConfidence.Low, r.Confidence);
+            Assert.True(r.Manual);
+            Assert.Contains("manual", r.Suggestion, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // ---------------------------------------------------------------- unknown
+
+        [Fact]
+        public void Analyze_NoSymbolNoTable_GivesUnknownLowManual()
+        {
+            // A diff in a region with no symbol and no known table → Unknown + Low.
+            uint off = 0x900000;
+            var (built, edited) = MakePair(0x1000000, off, 4);
+            var rom = MakeFe8uRom(built);
+
+            var report = DecompDiffMigrationCore.Analyze(rom, edited, null, null);
+            Assert.Single(report.Ranges);
+            var r = report.Ranges[0];
+            Assert.Equal(MigrationCategory.Unknown, r.Category);
+            Assert.Equal(MigrationConfidence.Low, r.Confidence);
+            Assert.True(r.Manual);
+        }
+
+        // ---------------------------------------------------------------- robustness
+
+        [Fact]
+        public void Analyze_IdenticalRoms_EmptyReport()
+        {
+            var rom = MakeFe8uRom(new byte[0x1000000]);
+            // Compare the built ROM bytes against an identical copy → no diffs.
+            byte[] edited = (byte[])rom.Data.Clone();
+            var report = DecompDiffMigrationCore.Analyze(rom, edited, null, null);
+            Assert.Equal(0, report.RangeCount);
+            Assert.False(report.BuiltMissing);
+        }
+
+        [Fact]
+        public void Analyze_NullEdited_NoThrow_EmptyReport()
+        {
+            var rom = MakeFe8uRom(new byte[0x1000000]);
+            var report = DecompDiffMigrationCore.Analyze(rom, null, null, null);
+            Assert.Equal(0, report.RangeCount);
+        }
+
+        [Fact]
+        public void Analyze_NullBuiltRom_FlagsBuiltMissing_NoThrow()
+        {
+            var report = DecompDiffMigrationCore.Analyze(null, new byte[16], null, null);
+            Assert.True(report.BuiltMissing);
+            Assert.Equal(0, report.RangeCount);
+        }
+
+        [Fact]
+        public void Analyze_NullMapAndResolver_StillClassifies_NoThrow()
+        {
+            uint off = 0x800000;
+            var (built, edited) = MakePair(0x1000000, off, 4);
+            var rom = MakeFe8uRom(built);
+            var report = DecompDiffMigrationCore.Analyze(rom, edited, null, null);
+            Assert.Single(report.Ranges);
+            Assert.Equal("", report.Ranges[0].Symbol);   // no symbol resolved
+        }
+
+        // ---------------------------------------------------------------- TryGetSection
+
+        [Fact]
+        public void Resolver_TryGetSection_ReturnsSectionForMapSymbol()
+        {
+            var (map, resolver) = BuildMap(string.Join("\n", new[]
+            {
+                " .rodata        0x0808E500       0x40 build/src/unit.o",
+                "                0x0808E500                gUnitTable",
+            }));
+            Assert.True(resolver.TryGetSection(0x0808E500u, out string sec));
+            Assert.Equal(".rodata", sec);
+            Assert.True(resolver.TryGetObjectPath(0x0808E500u, out string op));
+            Assert.Equal("build/src/unit.o", op);
+            // Merged passthrough.
+            Assert.True(map.TryGetSection(0x0808E500u, out string sec2));
+            Assert.Equal(".rodata", sec2);
+        }
+
+        // ---------------------------------------------------------------- formatting
+
+        [Fact]
+        public void FormatTSV_And_Summary_NeverThrow_AndHaveHeader()
+        {
+            uint off = 0xE8500;
+            var (built, edited) = MakePair(0x1000000, off, 4);
+            var rom = MakeFe8uRom(built);
+            var report = DecompDiffMigrationCore.Analyze(rom, edited, null, null);
+
+            string tsv = DecompDiffMigrationCore.FormatTSV(report);
+            Assert.StartsWith("StartAddr\tSpanLength\tChangedBytes", tsv);
+
+            string summary = DecompDiffMigrationCore.FormatSummary(report);
+            Assert.Contains("changed", summary, StringComparison.OrdinalIgnoreCase);
+
+            // Null-safety.
+            Assert.NotNull(DecompDiffMigrationCore.FormatTSV(null));
+            Assert.NotNull(DecompDiffMigrationCore.FormatSummary(null));
+        }
+    }
+}

--- a/FEBuilderGBA.Core/DecompDiffMigrationCore.cs
+++ b/FEBuilderGBA.Core/DecompDiffMigrationCore.cs
@@ -234,7 +234,7 @@ namespace FEBuilderGBA
 
             // --- nearest symbol (span-covering resolver from #1130) ---
             uint symBaseOffset; // file offset of the covering symbol base (NOT_FOUND when none)
-            ResolveSymbol(r, map, resolver, startPtr, c.Offset, endOffsetExclusive, out symBaseOffset);
+            ResolveSymbol(r, map, resolver, startPtr, c.SpanLength, out symBaseOffset);
 
             // A fully-covering project (map/elf/sym/json) symbol is the strongest
             // attribution we have: it names the whole changed span and points at a
@@ -338,7 +338,7 @@ namespace FEBuilderGBA
         // offset (NOT_FOUND when none). Bounds-guarded; never throws.
         static void ResolveSymbol(
             MigrationRange r, MergedAsmMapFile map, DecompSymbolResolver resolver,
-            uint startPtr, uint startOffset, uint endOffsetExclusive, out uint symBaseOffset)
+            uint startPtr, uint spanLength, out uint symBaseOffset)
         {
             symBaseOffset = U.NOT_FOUND;
             if (map == null) return;
@@ -354,7 +354,12 @@ namespace FEBuilderGBA
                 symBaseOffset = U.toOffset(near);
 
                 // Whole-range coverage: [startPtr, endPtr) inside [near, near+Length).
-                uint endPtr = U.toPointer(endOffsetExclusive);
+                // Compute the EXCLUSIVE end pointer by pointer arithmetic from
+                // startPtr — NOT U.toPointer(endOffsetExclusive), which mis-handles a
+                // span ending exactly at the EWRAM boundary (file off 0x02000000 on a
+                // 32MB ROM: toPointer leaves it as 0x02000000, breaking coverage at
+                // the ROM upper boundary). ulong avoids the 0x0A000000 wrap. (Copilot PR #1139.)
+                ulong endPtr = (ulong)startPtr + spanLength;
                 ulong symEnd = (ulong)near + st.Length;
                 r.SymbolCovers = st.Length > 0
                     && startPtr >= near

--- a/FEBuilderGBA.Core/DecompDiffMigrationCore.cs
+++ b/FEBuilderGBA.Core/DecompDiffMigrationCore.cs
@@ -1,0 +1,598 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Decomp-project diff-to-source migration assistant (#1131 slice 3).
+//
+// ADVISORY + READ-ONLY. Given a decomp project's BUILT/baseline ROM and a
+// FEBuilder-edited ROM, this diffs the two, coalesces the changed byte ranges,
+// and classifies each range for a contributor migrating the edit back to source:
+//   - nearest symbol (reusing the #1130 MergedAsmMapFile span-covering resolver),
+//   - a category (struct table / graphics-palette / compressed / map / text /
+//     music / unknown), derived from the symbol + section + known RomInfo table
+//     ranges + a strict LZ77 signature probe,
+//   - a source suggestion (object/source file when the .map carried it, else the
+//     section, else honestly "manual"),
+//   - an HONEST confidence (High only when a covering project symbol names the
+//     WHOLE range and it maps to a known table/section; Medium for a nearby /
+//     shipped-only symbol; Low for compressed / unknown / ambiguous spans).
+//
+// The built ROM is the canonical baseline; the edited ROM is read, never treated
+// as final output, and NOTHING is written (source rewrite is #1132). Every public
+// method is bounds-guarded and NEVER throws — a fault yields an empty report.
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FEBuilderGBA
+{
+    /// <summary>Coarse classification of a changed range for source migration.</summary>
+    public enum MigrationCategory
+    {
+        Unknown = 0,
+        StructTable = 1,
+        GraphicsPalette = 2,
+        Compressed = 3,
+        Map = 4,
+        Text = 5,
+        Music = 6,
+    }
+
+    /// <summary>Honesty level of a range's source suggestion.</summary>
+    public enum MigrationConfidence
+    {
+        Low = 0,
+        Medium = 1,
+        High = 2,
+    }
+
+    /// <summary>
+    /// One classified changed range. <see cref="SpanLength"/> is the coalesced
+    /// covered span (may include unchanged bytes after a small-gap merge);
+    /// <see cref="ChangedBytes"/> is the count of bytes that ACTUALLY differ inside
+    /// that span — the two are reported separately so a merged span never implies
+    /// every byte changed (Copilot review finding 1).
+    /// </summary>
+    public sealed class MigrationRange
+    {
+        /// <summary>File offset of the range start.</summary>
+        public uint Offset { get; set; }
+        /// <summary>Coalesced covered span length (changed + small inter-gaps).</summary>
+        public uint SpanLength { get; set; }
+        /// <summary>Bytes that actually differ inside the span.</summary>
+        public uint ChangedBytes { get; set; }
+
+        /// <summary>Nearest symbol name, or "" when none resolved.</summary>
+        public string Symbol { get; set; } = "";
+        /// <summary>Offset of the range start past the symbol base (0 when exact / none).</summary>
+        public uint SymbolOffset { get; set; }
+        /// <summary>True when a single symbol's SPAN fully covers the whole range.</summary>
+        public bool SymbolCovers { get; set; }
+
+        /// <summary>Owning section (e.g. ".rodata"), "" when unknown.</summary>
+        public string Section { get; set; } = "";
+        /// <summary>Object/source file suggestion, or an honest "(...)" placeholder.</summary>
+        public string SourceFile { get; set; } = "";
+
+        public MigrationCategory Category { get; set; } = MigrationCategory.Unknown;
+        /// <summary>Human source-migration suggestion (always actionable / honest).</summary>
+        public string Suggestion { get; set; } = "";
+        public MigrationConfidence Confidence { get; set; } = MigrationConfidence.Low;
+
+        /// <summary>Which artifact named the symbol (map/elf/sym/json), or shipped/none.</summary>
+        public DecompArtifactSource SymbolSource { get; set; } = DecompArtifactSource.None;
+
+        /// <summary>True when this range requires manual migration (compressed/unknown/ambiguous).</summary>
+        public bool Manual => Confidence == MigrationConfidence.Low;
+    }
+
+    /// <summary>The full advisory report for a built-vs-edited migration analysis.</summary>
+    public sealed class MigrationReport
+    {
+        public List<MigrationRange> Ranges { get; } = new List<MigrationRange>();
+        /// <summary>Sum of bytes that actually differ across all ranges.</summary>
+        public uint TotalChangedBytes { get; set; }
+        public int RangeCount => Ranges.Count;
+        /// <summary>Count of ranges flagged manual / low-confidence.</summary>
+        public int ManualCount
+        {
+            get
+            {
+                int n = 0;
+                foreach (var r in Ranges) if (r.Manual) n++;
+                return n;
+            }
+        }
+        /// <summary>True when the built ROM was missing / unreadable (no analysis possible).</summary>
+        public bool BuiltMissing { get; set; }
+    }
+
+    /// <summary>
+    /// READ-ONLY diff-to-source migration analyzer. Pure aside from reading the two
+    /// ROM byte arrays + the symbol resolver; never writes; never throws.
+    /// </summary>
+    public static class DecompDiffMigrationCore
+    {
+        /// <summary>Default small-gap merge distance (bytes) for range coalescing.</summary>
+        public const int DefaultMaxGap = 16;
+
+        // Bound the back-scan window when sniffing for a compressed header that
+        // starts a few bytes before the diff (the edit may land mid-asset).
+        const int CompressedBackScan = 4;
+
+        /// <summary>
+        /// Analyze the differences between a built ROM and an edited ROM and classify
+        /// each coalesced changed range for source migration. NEVER throws.
+        /// </summary>
+        /// <param name="builtRom">The project's built/baseline ROM (canonical).</param>
+        /// <param name="editedBytes">The FEBuilder-edited ROM bytes.</param>
+        /// <param name="map">Merged symbol resolver (project over shipped); may be null.</param>
+        /// <param name="resolver">Decomp symbol resolver for section/source hints; may be null.</param>
+        /// <param name="maxGap">Small-gap merge distance for coalescing (default 16).</param>
+        public static MigrationReport Analyze(
+            ROM builtRom, byte[] editedBytes,
+            MergedAsmMapFile map, DecompSymbolResolver resolver,
+            int maxGap = DefaultMaxGap)
+        {
+            var report = new MigrationReport();
+            try
+            {
+                byte[] builtBytes = builtRom?.Data;
+                if (builtBytes == null || builtBytes.Length == 0)
+                {
+                    report.BuiltMissing = true;
+                    return report;
+                }
+                if (editedBytes == null)
+                    return report;
+                if (maxGap < 0) maxGap = 0;
+
+                RomDiffCore.DiffResult diff = RomDiffCore.Compare(builtBytes, editedBytes);
+                if (diff == null || diff.Ranges.Count == 0)
+                    return report;
+
+                List<Coalesced> coalesced = Coalesce(diff.Ranges, maxGap);
+
+                foreach (Coalesced c in coalesced)
+                {
+                    MigrationRange r = Classify(builtRom, builtBytes, c, map, resolver);
+                    report.Ranges.Add(r);
+                    report.TotalChangedBytes += r.ChangedBytes;
+                }
+            }
+            catch
+            {
+                // never throw — return whatever we accumulated
+            }
+            return report;
+        }
+
+        // ---------------------------------------------------------------- coalesce
+
+        /// <summary>A coalesced span carrying the true changed-byte count.</summary>
+        internal struct Coalesced
+        {
+            public uint Offset;
+            public uint SpanLength;
+            public uint ChangedBytes;
+        }
+
+        /// <summary>
+        /// Merge strictly-contiguous diff ranges that are separated by &lt;= maxGap
+        /// unchanged bytes into one covered span, tracking the true changed-byte
+        /// total separately from the span length. NEVER throws.
+        /// </summary>
+        internal static List<Coalesced> Coalesce(List<RomDiffCore.DiffRange> ranges, int maxGap)
+        {
+            var result = new List<Coalesced>();
+            if (ranges == null) return result;
+
+            Coalesced cur = default;
+            bool open = false;
+
+            foreach (RomDiffCore.DiffRange dr in ranges)
+            {
+                if (dr == null || dr.Length == 0) continue;
+                if (!open)
+                {
+                    cur = new Coalesced { Offset = dr.Offset, SpanLength = dr.Length, ChangedBytes = dr.Length };
+                    open = true;
+                    continue;
+                }
+
+                ulong curEnd = (ulong)cur.Offset + cur.SpanLength;       // exclusive
+                ulong gap = dr.Offset >= curEnd ? (ulong)dr.Offset - curEnd : 0UL;
+                if (gap <= (ulong)maxGap && dr.Offset >= cur.Offset)
+                {
+                    ulong newEnd = (ulong)dr.Offset + dr.Length;
+                    if (newEnd > curEnd)
+                        cur.SpanLength = (uint)(newEnd - cur.Offset);
+                    cur.ChangedBytes += dr.Length;
+                }
+                else
+                {
+                    result.Add(cur);
+                    cur = new Coalesced { Offset = dr.Offset, SpanLength = dr.Length, ChangedBytes = dr.Length };
+                }
+            }
+            if (open) result.Add(cur);
+            return result;
+        }
+
+        // ---------------------------------------------------------------- classify
+
+        static MigrationRange Classify(
+            ROM rom, byte[] builtBytes, Coalesced c,
+            MergedAsmMapFile map, DecompSymbolResolver resolver)
+        {
+            var r = new MigrationRange
+            {
+                Offset = c.Offset,
+                SpanLength = c.SpanLength,
+                ChangedBytes = c.ChangedBytes,
+            };
+
+            uint startPtr = U.toPointer(c.Offset);
+            uint endOffsetExclusive = (uint)Math.Min((ulong)c.Offset + c.SpanLength, uint.MaxValue);
+
+            // --- nearest symbol (span-covering resolver from #1130) ---
+            uint symBaseOffset; // file offset of the covering symbol base (NOT_FOUND when none)
+            ResolveSymbol(r, map, resolver, startPtr, c.Offset, endOffsetExclusive, out symBaseOffset);
+
+            // A fully-covering project (map/elf/sym/json) symbol is the strongest
+            // attribution we have: it names the whole changed span and points at a
+            // source location. Drives High confidence (gated below by category).
+            bool covering = r.SymbolCovers && IsProjectSource(r.SymbolSource);
+
+            // --- classification precedence (highest wins): ---
+            // 1. Compressed (strict LZ77 probe) — ALWAYS Low + manual. Sniff the
+            //    range start (with a small back-scan) AND the covering symbol base,
+            //    so an edit landing DEEP inside a compressed asset is still caught.
+            if (SniffCompressed(builtBytes, c.Offset)
+                || (covering && symBaseOffset != U.NOT_FOUND && SniffCompressedAt(builtBytes, symBaseOffset)))
+            {
+                r.Category = MigrationCategory.Compressed;
+                r.Confidence = MigrationConfidence.Low;
+                r.Suggestion = string.IsNullOrEmpty(r.Symbol)
+                    ? "manual migration required (compressed asset — re-export from source)"
+                    : $"manual migration required (compressed asset '{r.Symbol}' — re-export from source)";
+                FinalizeSourceFile(r);
+                return r;
+            }
+
+            // 1.5 Ambiguous: the coalesced span is NOT fully covered by a single
+            // symbol, yet a symbol is nearby — it may cross symbol/table boundaries.
+            // Mark manual + Low so High is never claimed for a span we cannot
+            // attribute wholesale (Copilot finding 2).
+            bool ambiguous = !r.SymbolCovers && c.SpanLength > 0 && HasNearbySymbol(r);
+            if (ambiguous)
+            {
+                r.Category = ResolveCategory(rom, r, c.Offset, endOffsetExclusive);
+                r.Confidence = MigrationConfidence.Low;
+                r.Suggestion = $"manual migration required (range spans multiple symbols near '{r.Symbol}')";
+                FinalizeSourceFile(r);
+                return r;
+            }
+
+            // 2. Category from a known RomInfo range, else section/name heuristic.
+            KnownRange kr = MatchKnownRange(rom, c.Offset, endOffsetExclusive);
+            MigrationCategory cat = kr?.Category ?? HeuristicCategory(r.Section, r.Symbol);
+            r.Category = cat;
+
+            if (covering)
+            {
+                // Covering project symbol → High; we know the exact symbol + source.
+                r.Confidence = MigrationConfidence.High;
+                r.Suggestion = kr != null
+                    ? $"edit the {kr.Label} source for symbol '{r.Symbol}'"
+                    : $"edit source for symbol '{r.Symbol}' ({CategoryWord(cat)})";
+                FinalizeSourceFile(r);
+                return r;
+            }
+
+            if (kr != null)
+            {
+                // Known range but no covering project symbol → Medium (row inferred).
+                r.Confidence = MigrationConfidence.Medium;
+                r.Suggestion = $"likely the {kr.Label} (entry inferred — verify against source)";
+                FinalizeSourceFile(r);
+                return r;
+            }
+
+            if (cat != MigrationCategory.Unknown)
+            {
+                // Section/name heuristic only → Low (advisory hint, verify).
+                r.Confidence = MigrationConfidence.Low;
+                r.Suggestion = string.IsNullOrEmpty(r.Symbol)
+                    ? $"likely {CategoryWord(cat)} (heuristic — verify against source)"
+                    : $"likely {CategoryWord(cat)} near '{r.Symbol}' (verify against source)";
+                FinalizeSourceFile(r);
+                return r;
+            }
+
+            // 3. Unknown / raw — explicit manual.
+            r.Category = MigrationCategory.Unknown;
+            r.Confidence = MigrationConfidence.Low;
+            r.Suggestion = string.IsNullOrEmpty(r.Symbol)
+                ? "manual migration required (unknown/raw bytes — no symbol)"
+                : $"manual migration required (raw bytes near '{r.Symbol}')";
+            FinalizeSourceFile(r);
+            return r;
+        }
+
+        // Best-effort category for the ambiguous path (known range first, else heuristic).
+        static MigrationCategory ResolveCategory(ROM rom, MigrationRange r, uint start, uint endExclusive)
+        {
+            KnownRange kr = MatchKnownRange(rom, start, endExclusive);
+            if (kr != null) return kr.Category;
+            return HeuristicCategory(r.Section, r.Symbol);
+        }
+
+        // Resolve the nearest symbol + whether its span fully covers the range, and
+        // pull section / object-path hints. Outputs the covering symbol's FILE
+        // offset (NOT_FOUND when none). Bounds-guarded; never throws.
+        static void ResolveSymbol(
+            MigrationRange r, MergedAsmMapFile map, DecompSymbolResolver resolver,
+            uint startPtr, uint startOffset, uint endOffsetExclusive, out uint symBaseOffset)
+        {
+            symBaseOffset = U.NOT_FOUND;
+            if (map == null) return;
+            try
+            {
+                uint near = map.SearchNear(startPtr);
+                if (near == U.NOT_FOUND) return;
+                if (!map.TryGetValue(near, out AsmMapSt st) || st == null) return;
+
+                r.Symbol = st.Name ?? "";
+                r.SymbolOffset = startPtr >= near ? startPtr - near : 0;
+                if (map.TryGetSource(near, out var src)) r.SymbolSource = src;
+                symBaseOffset = U.toOffset(near);
+
+                // Whole-range coverage: [startPtr, endPtr) inside [near, near+Length).
+                uint endPtr = U.toPointer(endOffsetExclusive);
+                ulong symEnd = (ulong)near + st.Length;
+                r.SymbolCovers = st.Length > 0
+                    && startPtr >= near
+                    && endPtr <= symEnd;
+
+                if (resolver != null)
+                {
+                    if (resolver.TryGetSection(near, out string sec) && !string.IsNullOrEmpty(sec))
+                        r.Section = sec;
+                    if (resolver.TryGetObjectPath(near, out string op) && !string.IsNullOrEmpty(op))
+                        r.SourceFile = op;
+                }
+            }
+            catch { /* never throw */ }
+        }
+
+        static bool HasNearbySymbol(MigrationRange r) => !string.IsNullOrEmpty(r.Symbol);
+
+        static bool IsProjectSource(DecompArtifactSource s)
+            => s == DecompArtifactSource.Map || s == DecompArtifactSource.Elf
+            || s == DecompArtifactSource.Sym || s == DecompArtifactSource.Json;
+
+        // Pick the most honest SourceFile when ResolveSymbol did not already set an
+        // object path: section name when known, else an explicit placeholder.
+        static void FinalizeSourceFile(MigrationRange r)
+        {
+            if (!string.IsNullOrEmpty(r.SourceFile)) return;
+            if (!string.IsNullOrEmpty(r.Section))
+                r.SourceFile = "(section " + r.Section + ")";
+            else
+                r.SourceFile = "(unknown — manual)";
+        }
+
+        // ---------------------------------------------------------------- compressed
+
+        // Strict LZ77 sniff: LZ77.getCompressedSize returns 0 for any malformed /
+        // truncated stream, so we only flag a genuine, fully-decodable header at the
+        // range start or within a small back-scan window. NEVER throws.
+        static bool SniffCompressed(byte[] data, uint offset)
+        {
+            try
+            {
+                if (data == null) return false;
+                for (int back = 0; back <= CompressedBackScan; back++)
+                {
+                    long o = (long)offset - back;
+                    if (o < 0) break;
+                    if (SniffCompressedAt(data, (uint)o)) return true;
+                }
+            }
+            catch { }
+            return false;
+        }
+
+        // Strict LZ77 sniff at one exact offset. NEVER throws.
+        static bool SniffCompressedAt(byte[] data, uint offset)
+        {
+            try
+            {
+                if (data == null || offset >= (uint)data.Length) return false;
+                if (data[offset] != 0x10) return false;          // LZ77 header byte
+                return LZ77.getCompressedSize(data, offset) > 0;
+            }
+            catch { return false; }
+        }
+
+        // ---------------------------------------------------------------- known ranges
+
+        /// <summary>A reliable RomInfo-backed file-offset range and its category.</summary>
+        sealed class KnownRange
+        {
+            public uint Start;        // inclusive file offset
+            public uint End;          // exclusive file offset
+            public MigrationCategory Category;
+            public string Label;
+            public bool Covers(uint start, uint endExclusive)
+                => start >= Start && start < End && endExclusive <= End;
+        }
+
+        // Match the range to a conservative, reliable known region. Only ranges we
+        // can bound with confidence are included (Copilot finding 5). NEVER throws.
+        static KnownRange MatchKnownRange(ROM rom, uint start, uint endExclusive)
+        {
+            try
+            {
+                if (rom?.RomInfo == null) return null;
+                ROMFEINFO info = rom.RomInfo;
+
+                // Text region — explicit start/end addresses (reliable).
+                uint tStart = info.text_data_start_address;
+                uint tEnd = info.text_data_end_address;
+                if (tStart != 0 && tEnd > tStart)
+                {
+                    var kr = new KnownRange { Start = tStart, End = tEnd, Category = MigrationCategory.Text, Label = "text data region" };
+                    if (kr.Covers(start, endExclusive)) return kr;
+                }
+
+                // Struct tables — base = p32(pointer), bounded by a capped, sentinel-
+                // terminated row count. A hit only reaches High when a covering symbol
+                // also names it; otherwise Medium (range inferred).
+                KnownRange t;
+                t = TableRange(rom, info.unit_pointer, info.unit_datasize, MigrationCategory.StructTable, "unit table");
+                if (t != null && t.Covers(start, endExclusive)) return t;
+                t = TableRange(rom, info.class_pointer, info.class_datasize, MigrationCategory.StructTable, "class table");
+                if (t != null && t.Covers(start, endExclusive)) return t;
+                t = TableRange(rom, info.item_pointer, info.item_datasize, MigrationCategory.StructTable, "item table");
+                if (t != null && t.Covers(start, endExclusive)) return t;
+            }
+            catch { }
+            return null;
+        }
+
+        // Build a conservative struct-table file-offset range. datasize must be a
+        // sane non-zero; the count is capped + sentinel-terminated so we never
+        // over-claim a span from the pointer alone. Returns null on any fault.
+        static KnownRange TableRange(ROM rom, uint pointerLoc, uint dataSize, MigrationCategory cat, string label)
+        {
+            try
+            {
+                if (pointerLoc == 0 || dataSize == 0 || dataSize > 0x400) return null;
+                uint baseAddr = rom.p32(pointerLoc);     // already toOffset'd
+                if (baseAddr == 0 || baseAddr >= (uint)rom.Data.Length) return null;
+
+                // Count rows until a 0xFFFFFFFF terminator (first u32), capped to a
+                // safe bound so a corrupt/unterminated table can't run away.
+                const int CAP = 2048;
+                uint count = rom.getBlockDataCount(baseAddr, dataSize, (int i, uint addr) =>
+                {
+                    if (i >= CAP) return false;
+                    if ((ulong)addr + 4 > (ulong)rom.Data.Length) return false;
+                    return rom.u32(addr) != 0xFFFFFFFF;
+                });
+                if (count == 0) return null;
+                ulong end = (ulong)baseAddr + (ulong)count * dataSize;
+                if (end > (ulong)rom.Data.Length) end = (ulong)rom.Data.Length;
+                return new KnownRange { Start = baseAddr, End = (uint)end, Category = cat, Label = label };
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        // ---------------------------------------------------------------- heuristics
+
+        // Section / symbol-name keyword heuristic. Conservative — Unknown by default.
+        // The CODE section name (.text) is intentionally EXCLUDED from the Text
+        // (string-data) keyword so a code symbol in .text is never mislabelled as
+        // text strings — only the SYMBOL name is searched for text-string hints.
+        static MigrationCategory HeuristicCategory(string section, string symbol)
+        {
+            string sec = (section ?? "").ToLowerInvariant();
+            string sym = (symbol ?? "").ToLowerInvariant();
+            string s = (sec + " " + sym).Trim();
+            if (s.Length == 0) return MigrationCategory.Unknown;
+
+            if (Has(s, "pal") || Has(s, "palette") || Has(s, "gfx") || Has(s, "img")
+                || Has(s, "image") || Has(s, "sprite") || Has(s, "tile") || Has(s, "icon"))
+                return MigrationCategory.GraphicsPalette;
+            if (Has(s, "song") || Has(s, "sound") || Has(s, "music") || Has(s, "bgm")
+                || Has(s, "instrument") || Has(s, "sound_table"))
+                return MigrationCategory.Music;
+            if (Has(s, "map") || Has(s, "chapter") || Has(s, "tileset"))
+                return MigrationCategory.Map;
+            // "text" only from the SYMBOL name (a .text code section must NOT match).
+            if (Has(sym, "text") || Has(s, "msg") || Has(s, "string") || Has(s, "dialog"))
+                return MigrationCategory.Text;
+            // Generic struct/table-shaped data — checked last so a more specific
+            // category (gfx/music/map/text) wins first.
+            if (Has(s, "table") || Has(s, "data") || Has(s, "array")
+                || Has(s, "struct") || Has(s, "list"))
+                return MigrationCategory.StructTable;
+            return MigrationCategory.Unknown;
+        }
+
+        static bool Has(string hay, string needle)
+            => hay.IndexOf(needle, StringComparison.Ordinal) >= 0;
+
+        static string CategoryWord(MigrationCategory c)
+        {
+            switch (c)
+            {
+                case MigrationCategory.StructTable: return "struct table data";
+                case MigrationCategory.GraphicsPalette: return "graphics/palette";
+                case MigrationCategory.Compressed: return "compressed asset";
+                case MigrationCategory.Map: return "map data";
+                case MigrationCategory.Text: return "text data";
+                case MigrationCategory.Music: return "music/song data";
+                default: return "unknown/raw bytes";
+            }
+        }
+
+        // ---------------------------------------------------------------- formatting
+
+        /// <summary>Format the report as a TSV (one row per range). NEVER throws.</summary>
+        public static string FormatTSV(MigrationReport report)
+        {
+            var sb = new StringBuilder();
+            sb.Append("StartAddr\tSpanLength\tChangedBytes\tSymbol\t+Offset\tCovers\tCategory\tSection\tSourceFile\tConfidence\tSymbolSource\tSuggestion\n");
+            if (report == null) return sb.ToString().TrimEnd('\n');
+            foreach (MigrationRange r in report.Ranges)
+            {
+                sb.Append("0x").Append(r.Offset.ToString("X06")).Append('\t');
+                sb.Append(r.SpanLength).Append('\t');
+                sb.Append(r.ChangedBytes).Append('\t');
+                sb.Append(Clean(r.Symbol)).Append('\t');
+                sb.Append("+0x").Append(r.SymbolOffset.ToString("X")).Append('\t');
+                sb.Append(r.SymbolCovers ? "yes" : "no").Append('\t');
+                sb.Append(CategoryWord(r.Category)).Append('\t');
+                sb.Append(Clean(r.Section)).Append('\t');
+                sb.Append(Clean(r.SourceFile)).Append('\t');
+                sb.Append(r.Confidence).Append('\t');
+                sb.Append(r.SymbolSource).Append('\t');
+                sb.Append(Clean(r.Suggestion)).Append('\n');
+            }
+            return sb.ToString().TrimEnd('\n');
+        }
+
+        /// <summary>Human-readable summary of the report. NEVER throws.</summary>
+        public static string FormatSummary(MigrationReport report)
+        {
+            if (report == null) return "No report.";
+            if (report.BuiltMissing) return "Built ROM missing/unreadable — cannot analyze.";
+            if (report.RangeCount == 0) return "ROMs are identical — no source migration needed.";
+
+            var sb = new StringBuilder();
+            foreach (MigrationRange r in report.Ranges)
+            {
+                uint end = r.Offset + (r.SpanLength > 0 ? r.SpanLength - 1 : 0);
+                string sym = string.IsNullOrEmpty(r.Symbol) ? "(no symbol)" : r.Symbol + "+0x" + r.SymbolOffset.ToString("X");
+                sb.Append("0x").Append(r.Offset.ToString("X06")).Append("-0x").Append(end.ToString("X06"))
+                  .Append("  [").Append(CategoryWord(r.Category)).Append(", ").Append(r.Confidence).Append("]  ")
+                  .Append(sym).Append("  ").Append(r.ChangedBytes).Append(" byte(s) changed")
+                  .Append("  => ").Append(r.Suggestion).Append('\n');
+            }
+            sb.Append("Total: ").Append(report.TotalChangedBytes).Append(" byte(s) changed across ")
+              .Append(report.RangeCount).Append(" range(s); ")
+              .Append(report.ManualCount).Append(" need manual migration (low-confidence).");
+            return sb.ToString();
+        }
+
+        // Replace tabs / newlines so a value never breaks the TSV grid.
+        static string Clean(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return "";
+            return s.Replace('\t', ' ').Replace('\r', ' ').Replace('\n', ' ');
+        }
+    }
+}

--- a/FEBuilderGBA.Core/DecompDiffMigrationCore.cs
+++ b/FEBuilderGBA.Core/DecompDiffMigrationCore.cs
@@ -96,7 +96,7 @@ namespace FEBuilderGBA
             get
             {
                 int n = 0;
-                foreach (var r in Ranges) if (r.Manual) n++;
+                foreach (var r in Ranges) if (r != null && r.Manual) n++;
                 return n;
             }
         }
@@ -276,9 +276,13 @@ namespace FEBuilderGBA
             MigrationCategory cat = kr?.Category ?? HeuristicCategory(r.Section, r.Symbol);
             r.Category = cat;
 
-            if (covering)
+            // High requires a KNOWN category (not Unknown). A covering project
+            // symbol whose category we cannot determine — e.g. a neutral .text /
+            // .rodata symbol with no data keyword — is still raw-bytes work, so it
+            // must stay Low + manual (Copilot PR #1139 finding 1): never claim High
+            // for unknown/raw content even when the symbol name is known.
+            if (covering && cat != MigrationCategory.Unknown)
             {
-                // Covering project symbol → High; we know the exact symbol + source.
                 r.Confidence = MigrationConfidence.High;
                 r.Suggestion = kr != null
                     ? $"edit the {kr.Label} source for symbol '{r.Symbol}'"
@@ -289,7 +293,8 @@ namespace FEBuilderGBA
 
             if (kr != null)
             {
-                // Known range but no covering project symbol → Medium (row inferred).
+                // Known range but no covering project symbol (or covering+unknown
+                // shouldn't reach here since kr implies a category) → Medium.
                 r.Confidence = MigrationConfidence.Medium;
                 r.Suggestion = $"likely the {kr.Label} (entry inferred — verify against source)";
                 FinalizeSourceFile(r);
@@ -298,7 +303,7 @@ namespace FEBuilderGBA
 
             if (cat != MigrationCategory.Unknown)
             {
-                // Section/name heuristic only → Low (advisory hint, verify).
+                // Section/name heuristic only (no covering symbol) → Low (verify).
                 r.Confidence = MigrationConfidence.Low;
                 r.Suggestion = string.IsNullOrEmpty(r.Symbol)
                     ? $"likely {CategoryWord(cat)} (heuristic — verify against source)"
@@ -307,12 +312,15 @@ namespace FEBuilderGBA
                 return r;
             }
 
-            // 3. Unknown / raw — explicit manual.
+            // 3. Unknown / raw — explicit manual. A covering project symbol still
+            // names WHERE the change is, so surface it, but the content is raw.
             r.Category = MigrationCategory.Unknown;
             r.Confidence = MigrationConfidence.Low;
             r.Suggestion = string.IsNullOrEmpty(r.Symbol)
                 ? "manual migration required (unknown/raw bytes — no symbol)"
-                : $"manual migration required (raw bytes near '{r.Symbol}')";
+                : (covering
+                    ? $"manual migration required (raw bytes in symbol '{r.Symbol}' — unknown data type)"
+                    : $"manual migration required (raw bytes near '{r.Symbol}')");
             FinalizeSourceFile(r);
             return r;
         }
@@ -427,7 +435,10 @@ namespace FEBuilderGBA
         }
 
         // Match the range to a conservative, reliable known region. Only ranges we
-        // can bound with confidence are included (Copilot finding 5). NEVER throws.
+        // can bound with confidence are included (Copilot findings 5 + #1139.2):
+        // each struct table uses the SAME stop rule as its WinForms reader, NOT a
+        // generic "first u32 != 0xFFFFFFFF" guess that could over-claim 2048 rows of
+        // unrelated ROM data. NEVER throws.
         static KnownRange MatchKnownRange(ROM rom, uint start, uint endExclusive)
         {
             try
@@ -444,25 +455,52 @@ namespace FEBuilderGBA
                     if (kr.Covers(start, endExclusive)) return kr;
                 }
 
-                // Struct tables — base = p32(pointer), bounded by a capped, sentinel-
-                // terminated row count. A hit only reaches High when a covering symbol
-                // also names it; otherwise Medium (range inferred).
                 KnownRange t;
-                t = TableRange(rom, info.unit_pointer, info.unit_datasize, MigrationCategory.StructTable, "unit table");
+
+                // Unit table — stop at RomInfo.unit_maxcount (mirrors UnitForm).
+                uint unitMax = info.unit_maxcount;
+                if (unitMax > 0)
+                {
+                    t = TableRange(rom, info.unit_pointer, info.unit_datasize, MigrationCategory.StructTable,
+                        "unit table", (int i, uint addr) => i < unitMax);
+                    if (t != null && t.Covers(start, endExclusive)) return t;
+                }
+
+                // Class table — i==0 ok; stop at i>0xff OR u8(addr+4)==0 (mirrors ClassForm).
+                t = TableRange(rom, info.class_pointer, info.class_datasize, MigrationCategory.StructTable,
+                    "class table", (int i, uint addr) =>
+                    {
+                        if (i == 0) return true;
+                        if (i > 0xff) return false;
+                        if ((ulong)addr + 5 > (ulong)rom.Data.Length) return false;
+                        return rom.u8(addr + 4) != 0;
+                    });
                 if (t != null && t.Covers(start, endExclusive)) return t;
-                t = TableRange(rom, info.class_pointer, info.class_datasize, MigrationCategory.StructTable, "class table");
-                if (t != null && t.Covers(start, endExclusive)) return t;
-                t = TableRange(rom, info.item_pointer, info.item_datasize, MigrationCategory.StructTable, "item table");
+
+                // Item table — stop at i>0xff; row valid while +12 (and +16 for
+                // non-FE8U) is a pointer-or-NULL (mirrors ItemForm).
+                bool fe8u = info.version == 8 && info.is_multibyte == false;
+                t = TableRange(rom, info.item_pointer, info.item_datasize, MigrationCategory.StructTable,
+                    "item table", (int i, uint addr) =>
+                    {
+                        if (i > 0xff) return false;
+                        if ((ulong)addr + 20 > (ulong)rom.Data.Length) return false;
+                        bool ok = U.isPointerOrNULL(rom.u32(addr + 12));
+                        if (!fe8u) ok = ok && U.isPointerOrNULL(rom.u32(addr + 16));
+                        return ok;
+                    });
                 if (t != null && t.Covers(start, endExclusive)) return t;
             }
             catch { }
             return null;
         }
 
-        // Build a conservative struct-table file-offset range. datasize must be a
-        // sane non-zero; the count is capped + sentinel-terminated so we never
-        // over-claim a span from the pointer alone. Returns null on any fault.
-        static KnownRange TableRange(ROM rom, uint pointerLoc, uint dataSize, MigrationCategory cat, string label)
+        // Build a conservative struct-table file-offset range using the supplied
+        // table-specific stop predicate (the SAME rule as the WF reader). datasize
+        // must be sane non-zero; count is hard-capped so a corrupt table can't run
+        // away. Returns null on any fault. NEVER throws.
+        static KnownRange TableRange(ROM rom, uint pointerLoc, uint dataSize,
+            MigrationCategory cat, string label, Func<int, uint, bool> isDataExists)
         {
             try
             {
@@ -470,14 +508,11 @@ namespace FEBuilderGBA
                 uint baseAddr = rom.p32(pointerLoc);     // already toOffset'd
                 if (baseAddr == 0 || baseAddr >= (uint)rom.Data.Length) return null;
 
-                // Count rows until a 0xFFFFFFFF terminator (first u32), capped to a
-                // safe bound so a corrupt/unterminated table can't run away.
-                const int CAP = 2048;
+                const int CAP = 0x1000;   // hard ceiling regardless of the predicate
                 uint count = rom.getBlockDataCount(baseAddr, dataSize, (int i, uint addr) =>
                 {
                     if (i >= CAP) return false;
-                    if ((ulong)addr + 4 > (ulong)rom.Data.Length) return false;
-                    return rom.u32(addr) != 0xFFFFFFFF;
+                    return isDataExists(i, addr);
                 });
                 if (count == 0) return null;
                 ulong end = (ulong)baseAddr + (ulong)count * dataSize;
@@ -546,9 +581,10 @@ namespace FEBuilderGBA
         {
             var sb = new StringBuilder();
             sb.Append("StartAddr\tSpanLength\tChangedBytes\tSymbol\t+Offset\tCovers\tCategory\tSection\tSourceFile\tConfidence\tSymbolSource\tSuggestion\n");
-            if (report == null) return sb.ToString().TrimEnd('\n');
+            if (report?.Ranges == null) return sb.ToString().TrimEnd('\n');
             foreach (MigrationRange r in report.Ranges)
             {
+                if (r == null) continue;   // list is publicly mutable — stay non-throwing
                 sb.Append("0x").Append(r.Offset.ToString("X06")).Append('\t');
                 sb.Append(r.SpanLength).Append('\t');
                 sb.Append(r.ChangedBytes).Append('\t');
@@ -575,6 +611,7 @@ namespace FEBuilderGBA
             var sb = new StringBuilder();
             foreach (MigrationRange r in report.Ranges)
             {
+                if (r == null) continue;   // list is publicly mutable — stay non-throwing
                 uint end = r.Offset + (r.SpanLength > 0 ? r.SpanLength - 1 : 0);
                 string sym = string.IsNullOrEmpty(r.Symbol) ? "(no symbol)" : r.Symbol + "+0x" + r.SymbolOffset.ToString("X");
                 sb.Append("0x").Append(r.Offset.ToString("X06")).Append("-0x").Append(end.ToString("X06"))

--- a/FEBuilderGBA.Core/DecompMapFile.cs
+++ b/FEBuilderGBA.Core/DecompMapFile.cs
@@ -32,6 +32,13 @@ namespace FEBuilderGBA
         public uint Addr;
         public uint Size;
         public string Section = "";
+        /// <summary>
+        /// Best-effort owning object-file / source path the linker map carried on
+        /// the section line (e.g. <c>build/src/unit.o</c>), or empty when the map
+        /// did not record one. Read-only hint for the #1131 diff-to-source
+        /// migration assistant's SourceFile suggestion; never fabricated.
+        /// </summary>
+        public string ObjectPath = "";
     }
 
     /// <summary>
@@ -80,10 +87,13 @@ namespace FEBuilderGBA
 
                 // Section boundaries (sorted later) used to bound a symbol's Size.
                 var boundaries = new List<uint>();
-                // (addr,name,section) raw hits, in file order.
-                var raw = new List<(uint Addr, string Name, string Section)>();
+                // (addr,name,section,objectPath) raw hits, in file order.
+                var raw = new List<(uint Addr, string Name, string Section, string ObjectPath)>();
 
                 string curSection = "";
+                // Best-effort object-file / source path the section line carried,
+                // reset whenever we cross into a new section. Empty when absent.
+                string curObjectPath = "";
 
                 for (int i = 0; i < lines.Length; i++)
                 {
@@ -98,6 +108,9 @@ namespace FEBuilderGBA
                     if (secm.Success)
                     {
                         curSection = secm.Groups[1].Value;
+                        // Group 4 is the optional trailing column (an object-file
+                        // path); keep its trimmed value as a SourceFile hint.
+                        curObjectPath = ExtractObjectPath(secm.Groups[4].Value);
                         uint secAddr = ParseHex(secm.Groups[2].Value);
                         uint secSize = ParseHex(secm.Groups[3].Value);
                         AddSectionBoundaries(boundaries, secAddr, secSize);
@@ -112,6 +125,8 @@ namespace FEBuilderGBA
                         if (cont.Success)
                         {
                             curSection = wrapName.Groups[1].Value;
+                            // Group 3 is the wrapped continuation's optional object path.
+                            curObjectPath = ExtractObjectPath(cont.Groups[3].Value);
                             uint secAddr = ParseHex(cont.Groups[1].Value);
                             uint secSize = ParseHex(cont.Groups[2].Value);
                             AddSectionBoundaries(boundaries, secAddr, secSize);
@@ -136,7 +151,7 @@ namespace FEBuilderGBA
                         if (name[0] == '$') continue;          // mapping symbols ($t/$a/$d)
                         if (name == ".") continue;             // hidden `.`-only bookkeeping
 
-                        raw.Add((addr, name, curSection));
+                        raw.Add((addr, name, curSection, curObjectPath));
                         boundaries.Add(addr);
                     }
                 }
@@ -154,7 +169,7 @@ namespace FEBuilderGBA
         // Compute best-effort Size = next boundary above addr - addr, then dedup by
         // addr keeping the FIRST concrete symbol at each address (first wins).
         static void FillSizesAndDedup(
-            List<(uint Addr, string Name, string Section)> raw,
+            List<(uint Addr, string Name, string Section, string ObjectPath)> raw,
             List<uint> boundaries,
             List<DecompSymbol> result)
         {
@@ -188,8 +203,35 @@ namespace FEBuilderGBA
                     Addr = r.Addr,
                     Size = size,
                     Section = r.Section ?? "",
+                    ObjectPath = r.ObjectPath ?? "",
                 });
             }
+        }
+
+        // Clean an optional trailing section-line column into an object-file path
+        // hint. Only accepts a single token that looks like a path with an object
+        // extension (.o/.a/.obj) — never a fill/expression or a make variable —
+        // so we never fabricate a bogus SourceFile. Empty when none qualifies.
+        static string ExtractObjectPath(string trailing)
+        {
+            if (string.IsNullOrEmpty(trailing)) return "";
+            string t = trailing.Trim();
+            if (t.Length == 0) return "";
+            // Take the first whitespace-delimited token (the linker writes the
+            // archive(member.o) / path.o as the leading token of the column).
+            int sp = t.IndexOfAny(new[] { ' ', '\t' });
+            string tok = sp >= 0 ? t.Substring(0, sp) : t;
+            if (tok.IndexOf('$') >= 0) return "";          // make var — not a file
+            if (tok.IndexOf("0x", StringComparison.Ordinal) == 0) return "";
+            // Must look like an object / archive member.
+            if (tok.EndsWith(".o", StringComparison.OrdinalIgnoreCase)
+                || tok.EndsWith(".obj", StringComparison.OrdinalIgnoreCase)
+                || tok.IndexOf(".o)", StringComparison.OrdinalIgnoreCase) >= 0
+                || tok.EndsWith(".a", StringComparison.OrdinalIgnoreCase))
+            {
+                return tok;
+            }
+            return "";
         }
 
         // Add a section's START and END addresses as Size boundaries. The END
@@ -347,7 +389,11 @@ namespace FEBuilderGBA
                     if (el.TryGetProperty("section", out var secEl) && secEl.ValueKind == JsonValueKind.String)
                         section = secEl.GetString() ?? "";
 
-                    result.Add(new DecompSymbol { Name = name, Addr = addr, Size = size, Section = section });
+                    string objectPath = "";
+                    if (el.TryGetProperty("objectPath", out var opEl) && opEl.ValueKind == JsonValueKind.String)
+                        objectPath = opEl.GetString() ?? "";
+
+                    result.Add(new DecompSymbol { Name = name, Addr = addr, Size = size, Section = section, ObjectPath = objectPath });
                 }
             }
             catch

--- a/FEBuilderGBA.Core/DecompSymbolResolver.cs
+++ b/FEBuilderGBA.Core/DecompSymbolResolver.cs
@@ -35,6 +35,13 @@ namespace FEBuilderGBA
     {
         readonly Dictionary<uint, AsmMapSt> _symbols = new Dictionary<uint, AsmMapSt>();
         readonly Dictionary<uint, DecompArtifactSource> _sources = new Dictionary<uint, DecompArtifactSource>();
+        // Owning section name + best-effort object/source path per resolved pointer
+        // (kept in parallel like _sources). READ-ONLY hints for the #1131
+        // diff-to-source migration assistant's SourceFile suggestion. Only entries
+        // whose source artifact carried a non-empty value are stored — never
+        // fabricated. Consumed via TryGetSection / TryGetObjectPath.
+        readonly Dictionary<uint, string> _sections = new Dictionary<uint, string>();
+        readonly Dictionary<uint, string> _objectPaths = new Dictionary<uint, string>();
         // Per-source loaded counts (for the CLI rom-info breakdown).
         public int CountMap { get; private set; }
         public int CountElf { get; private set; }
@@ -63,6 +70,27 @@ namespace FEBuilderGBA
         public bool TryGetSource(uint pointer, out DecompArtifactSource src)
         {
             return _sources.TryGetValue(pointer, out src);
+        }
+
+        /// <summary>
+        /// Owning section name of a resolved pointer (e.g. <c>.rodata</c>), when the
+        /// source artifact recorded one. Returns false (empty) otherwise. READ-ONLY
+        /// hint for the #1131 migration assistant; never fabricated.
+        /// </summary>
+        public bool TryGetSection(uint pointer, out string section)
+        {
+            return _sections.TryGetValue(pointer, out section);
+        }
+
+        /// <summary>
+        /// Best-effort object/source path of a resolved pointer (e.g.
+        /// <c>build/src/unit.o</c>), when the linker map recorded one. Returns false
+        /// (empty) otherwise. READ-ONLY hint for the #1131 migration assistant;
+        /// never fabricated.
+        /// </summary>
+        public bool TryGetObjectPath(uint pointer, out string objectPath)
+        {
+            return _objectPaths.TryGetValue(pointer, out objectPath);
         }
 
         DecompSymbolResolver() { }
@@ -139,6 +167,13 @@ namespace FEBuilderGBA
                 if (_symbols.ContainsKey(key)) continue;     // earlier source wins
                 _symbols[key] = new AsmMapSt { Name = s.Name, Length = s.Size };
                 _sources[key] = source;
+                // Keep section / object-path hints only when non-empty (never
+                // fabricate). Parallel to _sources; first-source-wins is already
+                // guaranteed by the _symbols.ContainsKey guard above.
+                if (!string.IsNullOrEmpty(s.Section))
+                    _sections[key] = s.Section;
+                if (!string.IsNullOrEmpty(s.ObjectPath))
+                    _objectPaths[key] = s.ObjectPath;
                 added++;
             }
             return added;
@@ -420,6 +455,22 @@ namespace FEBuilderGBA
         {
             if (_project != null) return _project.TryGetSource(pointer, out src);
             src = DecompArtifactSource.None;
+            return false;
+        }
+
+        /// <summary>Owning section of a resolved pointer (project symbols only). #1131.</summary>
+        public bool TryGetSection(uint pointer, out string section)
+        {
+            if (_project != null) return _project.TryGetSection(pointer, out section);
+            section = "";
+            return false;
+        }
+
+        /// <summary>Object/source path of a resolved pointer (project symbols only). #1131.</summary>
+        public bool TryGetObjectPath(uint pointer, out string objectPath)
+        {
+            if (_project != null) return _project.TryGetObjectPath(pointer, out objectPath);
+            objectPath = "";
             return false;
         }
     }

--- a/FEBuilderGBA.E2ETests/Tests/DecompMigrateDiffTests.cs
+++ b/FEBuilderGBA.E2ETests/Tests/DecompMigrateDiffTests.cs
@@ -144,19 +144,24 @@ namespace FEBuilderGBA.E2ETests.Tests
             }
         }
 
-        // Build a DETERMINISTIC project that needs NO local real ROM: a 16 MB dummy
-        // ROM + a manifest forceVersion="FE8U" so LoadProject -> LoadForceVersion ->
-        // InitFull succeeds (LoadLow only requires data.Length >= 0x1000000). The
-        // .map places a covering symbol at a known offset (Copilot PR #1139 finding 3 —
-        // the positive command path runs in CI without a real ROM). Returns
-        // (dir, builtRom, knownOffset, symbol).
-        private static (string Dir, string BuiltRom, int Offset, string Symbol) MakeDummyProject()
+        // The closest first-class ROM available (FE8U preferred, else FE6), or null.
+        private static string? AnyRom => RomLocator.FE8U ?? RomLocator.FE6;
+
+        // Build a project whose built ROM is a COPY of a real FE ROM (so
+        // LoadProject -> InitFull, incl. the Huffman-tree build, succeeds even in a
+        // Debug CI build) driven through the manifest `forceVersion` path. CI
+        // provides the ROMs via ROMS_DIR, so this positive --migrate-diff path runs
+        // in CI (Copilot PR #1139 finding 3). The .map places a covering symbol at a
+        // known offset. Returns (dir, builtRom, knownOffset, symbol).
+        private static (string Dir, string BuiltRom, int Offset, string Symbol) MakeForceVersionProject(string romPath)
         {
-            string dir = NewTempDir("dummy");
+            bool isFe8u = string.Equals(romPath, RomLocator.FE8U, StringComparison.OrdinalIgnoreCase);
+            string force = isFe8u ? "FE8U" : "FE6";
+            string dir = NewTempDir("forcever");
             File.WriteAllText(Path.Combine(dir, "febuilder.project.json"),
-                "{ \"schemaVersion\": 1, \"builtRom\": \"synth.gba\", \"forceVersion\": \"FE8U\" }");
+                $"{{ \"schemaVersion\": 1, \"builtRom\": \"synth.gba\", \"forceVersion\": \"{force}\" }}");
             string built = Path.Combine(dir, "synth.gba");
-            File.WriteAllBytes(built, new byte[0x1000000]);   // 16 MB zero ROM
+            File.Copy(romPath, built, overwrite: true);
             // gMigrateData @ 0x08010000 (file off 0x10000) covering a 0x40 span.
             File.WriteAllText(Path.Combine(dir, "synth.map"), string.Join("\n", new[]
             {
@@ -166,10 +171,12 @@ namespace FEBuilderGBA.E2ETests.Tests
             return (dir, built, 0x10000, "gMigrateData");
         }
 
-        [Fact]
-        public void MigrateDiff_DummyForceVersionProject_ClassifiesRange_NoRealRomNeeded()
+        [SkippableFact]
+        public void MigrateDiff_ForceVersionProject_ClassifiesRange()
         {
-            var (dir, built, off, sym) = MakeDummyProject();
+            Skip.If(AnyRom == null, "No FE ROM available");
+
+            var (dir, built, off, sym) = MakeForceVersionProject(AnyRom!);
             string edited = MakeEditedCopy(built, off, 4);
             string outTsv = Path.Combine(dir, "report.tsv");
             try
@@ -179,8 +186,8 @@ namespace FEBuilderGBA.E2ETests.Tests
                 string combined = stdout + stderr;
 
                 Assert.True(code == 0,
-                    $"--migrate-diff dummy exited with {code}\nStdout: {stdout}\nStderr: {stderr}");
-                // The real load/analyze/TSV path executed: range attributed to the symbol.
+                    $"--migrate-diff forceVersion exited with {code}\nStdout: {stdout}\nStderr: {stderr}");
+                // The real load/analyze/TSV path executed via the forceVersion manifest.
                 Assert.Contains(sym, stdout);
                 Assert.True(File.Exists(outTsv), "TSV report was not written");
                 Assert.Contains(sym, File.ReadAllText(outTsv));
@@ -193,12 +200,14 @@ namespace FEBuilderGBA.E2ETests.Tests
             }
         }
 
-        [Fact]
-        public void MigrateDiff_DummyProject_OutWriteFails_ReturnsNonZero()
+        [SkippableFact]
+        public void MigrateDiff_OutWriteFails_ReturnsNonZero()
         {
+            Skip.If(AnyRom == null, "No FE ROM available");
+
             // Requesting --out to an unwritable path (a directory) must fail with a
             // non-zero exit (Copilot PR #1139 finding 4), not a silent success.
-            var (dir, built, off, _) = MakeDummyProject();
+            var (dir, built, off, _) = MakeForceVersionProject(AnyRom!);
             string edited = MakeEditedCopy(built, off, 4);
             try
             {

--- a/FEBuilderGBA.E2ETests/Tests/DecompMigrateDiffTests.cs
+++ b/FEBuilderGBA.E2ETests/Tests/DecompMigrateDiffTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.IO;
+using FEBuilderGBA.E2ETests.Helpers;
+using Xunit;
+
+namespace FEBuilderGBA.E2ETests.Tests
+{
+    /// <summary>
+    /// E2E tests for the decomp diff-to-source migration assistant CLI (#1131):
+    ///   FEBuilderGBA.CLI --migrate-diff --project=&lt;dir&gt; --rom2=&lt;editedRom&gt; [--out=report.tsv]
+    ///
+    /// Each test builds a synthetic project copying a REAL FE6 ROM as the built ROM
+    /// (so LoadProject -> InitFull succeeds), plus an edited copy mutated at a known
+    /// offset where a .map places a covering symbol. Tests skip when no FE6 ROM is
+    /// available. ADVISORY + READ-ONLY: the command never writes the ROM or source.
+    /// </summary>
+    public class DecompMigrateDiffTests
+    {
+        private static readonly string CliExe = AppRunner.FindCliExePath();
+
+        private static (int ExitCode, string Stdout, string Stderr) RunWithRetry(
+            string args, int timeoutMs = 60_000, int maxAttempts = 2)
+        {
+            (int ExitCode, string Stdout, string Stderr) result = default;
+            for (int attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                result = AppRunner.Run(CliExe, args, timeoutMs);
+                if (result.ExitCode >= 0)
+                    return result;
+            }
+            return result;
+        }
+
+        private static string NewTempDir(string tag)
+        {
+            string dir = Path.Combine(Path.GetTempPath(), $"migdiff_e2e_{tag}_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+
+        // Build a BUILT project (real ROM as synth.gba + a .map with a covering
+        // symbol). Returns (dir, builtRomPath, knownOffset, symbolName).
+        private static (string Dir, string BuiltRom, int Offset, string Symbol) MakeProject(string romPath)
+        {
+            string dir = NewTempDir("built");
+            File.WriteAllText(Path.Combine(dir, "febuilder.project.json"),
+                "{ \"schemaVersion\": 1, \"builtRom\": \"synth.gba\" }");
+            File.WriteAllText(Path.Combine(dir, "Makefile"), "ROM := synth.gba\n");
+            File.WriteAllText(Path.Combine(dir, "synth.sha1"), "00\n");
+            string built = Path.Combine(dir, "synth.gba");
+            File.Copy(romPath, built, overwrite: true);
+
+            // Symbol gMigrateData @ 0x08010000 (file off 0x10000) covering a 0x40 span.
+            File.WriteAllText(Path.Combine(dir, "synth.map"), string.Join("\n", new[]
+            {
+                " .rodata        0x08010000       0x40 build/src/migrate.o",
+                "                0x08010000                gMigrateData",
+            }));
+            return (dir, built, 0x10000, "gMigrateData");
+        }
+
+        // Make an edited copy of a ROM with `len` bytes flipped at `offset`.
+        private static string MakeEditedCopy(string builtRom, int offset, int len)
+        {
+            string edited = builtRom + ".edited.gba";
+            byte[] data = File.ReadAllBytes(builtRom);
+            for (int i = 0; i < len && offset + i < data.Length; i++)
+                data[offset + i] ^= 0xFF;
+            File.WriteAllBytes(edited, data);
+            return edited;
+        }
+
+        [SkippableFact]
+        public void MigrateDiff_ClassifiesChangedRangeToSymbol()
+        {
+            Skip.If(RomLocator.FE6 == null, "FE6 ROM not available");
+
+            var (dir, built, off, sym) = MakeProject(RomLocator.FE6!);
+            string edited = MakeEditedCopy(built, off, 4);
+            try
+            {
+                var (code, stdout, stderr) = RunWithRetry($"--migrate-diff --project=\"{dir}\" --rom2=\"{edited}\"");
+                string combined = stdout + stderr;
+
+                Assert.True(code == 0,
+                    $"--migrate-diff exited with {code}\nStdout: {stdout}\nStderr: {stderr}");
+                // The changed range is attributed to the covering decomp symbol.
+                Assert.Contains(sym, stdout);
+                Assert.Contains("changed", stdout, StringComparison.OrdinalIgnoreCase);
+                Assert.DoesNotContain("Unhandled exception", combined);
+            }
+            finally
+            {
+                try { File.Delete(edited); } catch { }
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+
+        [SkippableFact]
+        public void MigrateDiff_WritesTsvReport()
+        {
+            Skip.If(RomLocator.FE6 == null, "FE6 ROM not available");
+
+            var (dir, built, off, sym) = MakeProject(RomLocator.FE6!);
+            string edited = MakeEditedCopy(built, off, 4);
+            string outTsv = Path.Combine(dir, "report.tsv");
+            try
+            {
+                var (code, stdout, stderr) = RunWithRetry(
+                    $"--migrate-diff --project=\"{dir}\" --rom2=\"{edited}\" --out=\"{outTsv}\"");
+
+                Assert.True(code == 0,
+                    $"--migrate-diff --out exited with {code}\nStdout: {stdout}\nStderr: {stderr}");
+                Assert.True(File.Exists(outTsv), "TSV report file was not written");
+                string tsv = File.ReadAllText(outTsv);
+                Assert.Contains("StartAddr", tsv);          // header present
+                Assert.Contains(sym, tsv);                  // symbol classified in TSV
+            }
+            finally
+            {
+                try { File.Delete(edited); } catch { }
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+
+        [SkippableFact]
+        public void MigrateDiff_IdenticalRoms_ReportsNoMigrationNeeded()
+        {
+            Skip.If(RomLocator.FE6 == null, "FE6 ROM not available");
+
+            var (dir, built, _, _) = MakeProject(RomLocator.FE6!);
+            // rom2 == the built ROM itself → identical.
+            try
+            {
+                var (code, stdout, stderr) = RunWithRetry($"--migrate-diff --project=\"{dir}\" --rom2=\"{built}\"");
+
+                Assert.True(code == 0,
+                    $"--migrate-diff identical exited with {code}\nStdout: {stdout}\nStderr: {stderr}");
+                Assert.Contains("identical", stdout, StringComparison.OrdinalIgnoreCase);
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void MigrateDiff_NoProject_FailsGracefully()
+        {
+            // No --project → usage error, exit 1, no crash. No ROM needed.
+            var (code, stdout, stderr) = RunWithRetry("--migrate-diff --rom2=does-not-matter.gba");
+            string combined = stdout + stderr;
+
+            Assert.True(code != 0, $"expected non-zero exit, got {code}");
+            Assert.Contains("--project", combined);
+            Assert.DoesNotContain("Unhandled exception", combined);
+        }
+
+        [Fact]
+        public void MigrateDiff_MissingRom2_FailsGracefully()
+        {
+            string dir = NewTempDir("noeromtwo");
+            File.WriteAllText(Path.Combine(dir, "febuilder.project.json"),
+                "{ \"schemaVersion\": 1, \"builtRom\": \"synth.gba\" }");
+            try
+            {
+                var (code, stdout, stderr) = RunWithRetry($"--migrate-diff --project=\"{dir}\"");
+                string combined = stdout + stderr;
+
+                Assert.True(code != 0, $"expected non-zero exit, got {code}");
+                Assert.Contains("--rom2", combined);
+                Assert.DoesNotContain("Unhandled exception", combined);
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.E2ETests/Tests/DecompMigrateDiffTests.cs
+++ b/FEBuilderGBA.E2ETests/Tests/DecompMigrateDiffTests.cs
@@ -144,6 +144,81 @@ namespace FEBuilderGBA.E2ETests.Tests
             }
         }
 
+        // Build a DETERMINISTIC project that needs NO local real ROM: a 16 MB dummy
+        // ROM + a manifest forceVersion="FE8U" so LoadProject -> LoadForceVersion ->
+        // InitFull succeeds (LoadLow only requires data.Length >= 0x1000000). The
+        // .map places a covering symbol at a known offset (Copilot PR #1139 finding 3 —
+        // the positive command path runs in CI without a real ROM). Returns
+        // (dir, builtRom, knownOffset, symbol).
+        private static (string Dir, string BuiltRom, int Offset, string Symbol) MakeDummyProject()
+        {
+            string dir = NewTempDir("dummy");
+            File.WriteAllText(Path.Combine(dir, "febuilder.project.json"),
+                "{ \"schemaVersion\": 1, \"builtRom\": \"synth.gba\", \"forceVersion\": \"FE8U\" }");
+            string built = Path.Combine(dir, "synth.gba");
+            File.WriteAllBytes(built, new byte[0x1000000]);   // 16 MB zero ROM
+            // gMigrateData @ 0x08010000 (file off 0x10000) covering a 0x40 span.
+            File.WriteAllText(Path.Combine(dir, "synth.map"), string.Join("\n", new[]
+            {
+                " .rodata        0x08010000       0x40 build/src/migrate.o",
+                "                0x08010000                gMigrateData",
+            }));
+            return (dir, built, 0x10000, "gMigrateData");
+        }
+
+        [Fact]
+        public void MigrateDiff_DummyForceVersionProject_ClassifiesRange_NoRealRomNeeded()
+        {
+            var (dir, built, off, sym) = MakeDummyProject();
+            string edited = MakeEditedCopy(built, off, 4);
+            string outTsv = Path.Combine(dir, "report.tsv");
+            try
+            {
+                var (code, stdout, stderr) = RunWithRetry(
+                    $"--migrate-diff --project=\"{dir}\" --rom2=\"{edited}\" --out=\"{outTsv}\"");
+                string combined = stdout + stderr;
+
+                Assert.True(code == 0,
+                    $"--migrate-diff dummy exited with {code}\nStdout: {stdout}\nStderr: {stderr}");
+                // The real load/analyze/TSV path executed: range attributed to the symbol.
+                Assert.Contains(sym, stdout);
+                Assert.True(File.Exists(outTsv), "TSV report was not written");
+                Assert.Contains(sym, File.ReadAllText(outTsv));
+                Assert.DoesNotContain("Unhandled exception", combined);
+            }
+            finally
+            {
+                try { File.Delete(edited); } catch { }
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void MigrateDiff_DummyProject_OutWriteFails_ReturnsNonZero()
+        {
+            // Requesting --out to an unwritable path (a directory) must fail with a
+            // non-zero exit (Copilot PR #1139 finding 4), not a silent success.
+            var (dir, built, off, _) = MakeDummyProject();
+            string edited = MakeEditedCopy(built, off, 4);
+            try
+            {
+                // --out points at the project DIRECTORY itself → write throws.
+                var (code, stdout, stderr) = RunWithRetry(
+                    $"--migrate-diff --project=\"{dir}\" --rom2=\"{edited}\" --out=\"{dir}\"");
+                string combined = stdout + stderr;
+
+                Assert.True(code != 0,
+                    $"expected non-zero exit on unwritable --out, got {code}\nStdout: {stdout}\nStderr: {stderr}");
+                Assert.Contains("could not write report", combined);
+                Assert.DoesNotContain("Unhandled exception", combined);
+            }
+            finally
+            {
+                try { File.Delete(edited); } catch { }
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+
         [Fact]
         public void MigrateDiff_NoProject_FailsGracefully()
         {

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ dotnet run --project FEBuilderGBA.CLI -- --rom-info --rom=rom.gba
 dotnet run --project FEBuilderGBA.CLI -- --project=path/to/decomp --rom-info
 # Resolve an address to a decomp project symbol (.map/ELF/.sym/JSON over shipped)
 dotnet run --project FEBuilderGBA.CLI -- --project=path/to/decomp --resolve-addr=0x08000100
+# Decomp diff-to-source migration assistant: classify built-vs-edited ROM changes
+# (range/symbol/category/source-file/confidence) for migrating edits back to source.
+# Advisory + READ-ONLY — never writes the ROM or source.
+dotnet run --project FEBuilderGBA.CLI -- --migrate-diff --project=path/to/decomp --rom2=edited.gba --out=migrate.tsv
 dotnet run --project FEBuilderGBA.CLI -- --list-tables
 dotnet run --project FEBuilderGBA.CLI -- --export-palette --rom=rom.gba --addr=0x5524 --out=palette.pal --colors=16
 dotnet run --project FEBuilderGBA.CLI -- --import-palette --rom=rom.gba --addr=0x5524 --in=palette.pal
@@ -235,10 +239,22 @@ sibling.
   the same address) layered over the shipped asmmap. It prints the symbol name,
   its source artifact, and the in-span offset. The same merged symbol table backs
   the Pointer Tool "What is this address?" lookup when a project is open.
+- **CLI:** `--migrate-diff --project=<dir> --rom2=<editedRom> [--out=report.tsv]`
+  is the **diff-to-source migration assistant** (advisory + READ-ONLY). It diffs the
+  project's built/baseline ROM against a FEBuilder-edited ROM, coalesces the changed
+  byte ranges (small-gap merge), and classifies each range for a contributor
+  migrating the edit back to source: nearest symbol (via the slice-2 resolver),
+  category (struct-table / graphics-palette / compressed / map / text / music /
+  unknown), a source-file suggestion (the `.map` object path / section when known),
+  and an **honest confidence** — High only when a covering project symbol names the
+  whole range, Medium for an inferred known-range, Low + *"manual migration required"*
+  for compressed / unknown / ambiguous spans. It tracks `ChangedBytes` separately
+  from the coalesced span and NEVER writes the ROM or source — the edited ROM is read
+  but never treated as canonical final output.
 
 Slice 1 (#1129) delivered open + preview; slice 2 (#1130) adds address-to-source
-symbol resolution. Diff-to-source, source writers, asset exporters and in-app
-build/reload are tracked under #1131–#1134.
+symbol resolution; slice 3 (#1131) adds the diff-to-source migration assistant.
+Source writers, asset exporters and in-app build/reload are tracked under #1132–#1134.
 
 ### Running on Android (experimental)
 

--- a/tools/TextToPng/Program.cs
+++ b/tools/TextToPng/Program.cs
@@ -4,7 +4,16 @@ using System.Drawing.Imaging;
 // Render a terminal-text capture file to a PNG (dark theme, monospace).
 // Args: <inputTextFile> <outputPng> [title]
 if (args.Length < 2) { Console.Error.WriteLine("usage: TextToPng <in.txt> <out.png> [title]"); return 1; }
-string[] lines = File.ReadAllLines(args[0]);
+string[] lines;
+try
+{
+    lines = File.ReadAllLines(args[0]);
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"error: could not read input '{args[0]}': {ex.Message}");
+    return 1;
+}
 string title = args.Length >= 3 ? args[2] : "FEBuilderGBA.CLI --migrate-diff (#1131)";
 
 // Expand tabs to spaces for stable column rendering.
@@ -39,12 +48,12 @@ using (var tb = new SolidBrush(Color.FromArgb(38, 42, 54)))
 using (var tt = new SolidBrush(Color.FromArgb(220, 223, 228)))
     g.DrawString(title, titleFont, tt, padX, 8);
 
-var colDefault = new SolidBrush(Color.FromArgb(208, 212, 220));
-var colPrompt  = new SolidBrush(Color.FromArgb(120, 200, 130));
-var colHigh    = new SolidBrush(Color.FromArgb(120, 200, 130));
-var colMedium  = new SolidBrush(Color.FromArgb(230, 200, 120));
-var colLow     = new SolidBrush(Color.FromArgb(230, 130, 120));
-var colHeader  = new SolidBrush(Color.FromArgb(130, 180, 240));
+using var colDefault = new SolidBrush(Color.FromArgb(208, 212, 220));
+using var colPrompt  = new SolidBrush(Color.FromArgb(120, 200, 130));
+using var colHigh    = new SolidBrush(Color.FromArgb(120, 200, 130));
+using var colMedium  = new SolidBrush(Color.FromArgb(230, 200, 120));
+using var colLow     = new SolidBrush(Color.FromArgb(230, 130, 120));
+using var colHeader  = new SolidBrush(Color.FromArgb(130, 180, 240));
 
 float y = padTop;
 foreach (var l in lines)

--- a/tools/TextToPng/Program.cs
+++ b/tools/TextToPng/Program.cs
@@ -1,0 +1,63 @@
+using System.Drawing;
+using System.Drawing.Imaging;
+
+// Render a terminal-text capture file to a PNG (dark theme, monospace).
+// Args: <inputTextFile> <outputPng> [title]
+if (args.Length < 2) { Console.Error.WriteLine("usage: TextToPng <in.txt> <out.png> [title]"); return 1; }
+string[] lines = File.ReadAllLines(args[0]);
+string title = args.Length >= 3 ? args[2] : "FEBuilderGBA.CLI --migrate-diff (#1131)";
+
+// Expand tabs to spaces for stable column rendering.
+for (int i = 0; i < lines.Length; i++) lines[i] = lines[i].Replace("\t", "    ");
+
+using var font = new Font("Consolas", 13, FontStyle.Regular, GraphicsUnit.Pixel);
+using var titleFont = new Font("Consolas", 15, FontStyle.Bold, GraphicsUnit.Pixel);
+int lineH = 18, padX = 16, padTop = 44, padBottom = 16;
+
+// Measure width.
+int maxW = 900;
+using (var tmp = new Bitmap(1, 1))
+using (var g0 = Graphics.FromImage(tmp))
+{
+    foreach (var l in lines)
+    {
+        var sz = g0.MeasureString(l.Length == 0 ? " " : l, font);
+        if (sz.Width > maxW) maxW = (int)sz.Width;
+    }
+}
+int w = maxW + padX * 2;
+int h = padTop + lines.Length * lineH + padBottom;
+
+using var bmp = new Bitmap(w, h);
+using var g = Graphics.FromImage(bmp);
+g.Clear(Color.FromArgb(24, 26, 32));
+g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.ClearTypeGridFit;
+
+// Title bar.
+using (var tb = new SolidBrush(Color.FromArgb(38, 42, 54)))
+    g.FillRectangle(tb, 0, 0, w, 34);
+using (var tt = new SolidBrush(Color.FromArgb(220, 223, 228)))
+    g.DrawString(title, titleFont, tt, padX, 8);
+
+var colDefault = new SolidBrush(Color.FromArgb(208, 212, 220));
+var colPrompt  = new SolidBrush(Color.FromArgb(120, 200, 130));
+var colHigh    = new SolidBrush(Color.FromArgb(120, 200, 130));
+var colMedium  = new SolidBrush(Color.FromArgb(230, 200, 120));
+var colLow     = new SolidBrush(Color.FromArgb(230, 130, 120));
+var colHeader  = new SolidBrush(Color.FromArgb(130, 180, 240));
+
+float y = padTop;
+foreach (var l in lines)
+{
+    Brush b = colDefault;
+    if (l.StartsWith("$ ")) b = colPrompt;
+    else if (l.Contains(", High]") || l.Contains("\tHigh\t") || l.EndsWith("High")) b = colHigh;
+    else if (l.Contains(", Medium]")) b = colMedium;
+    else if (l.Contains(", Low]") || l.Contains("manual migration")) b = colLow;
+    else if (l.StartsWith("StartAddr")) b = colHeader;
+    g.DrawString(l.Length == 0 ? " " : l, font, b, padX, y);
+    y += lineH;
+}
+bmp.Save(args[1], ImageFormat.Png);
+Console.WriteLine($"wrote {args[1]} ({w}x{h})");
+return 0;

--- a/tools/TextToPng/TextToPng.csproj
+++ b/tools/TextToPng/TextToPng.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="10.0.5" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

Slice 3 of the decomp initiative (#1129): a **diff-to-source migration assistant** (advisory + READ-ONLY). When a decomp project is open, it diffs the project's built/baseline ROM against a FEBuilder-edited ROM, coalesces the changed byte ranges, and classifies each range for a contributor migrating the edit back to source — nearest symbol, category, source-file suggestion, and an honest confidence level. The built ROM is the canonical baseline; the edited ROM is read but **never** treated as final output, and **nothing is written** (source rewrite is #1132).

## What the assistant classifies

- **Nearest symbol** via the slice-2 (#1130) `MergedAsmMapFile` span-covering resolver (project symbols win over shipped).
- **Category**: struct-table / graphics-palette / compressed / map / text / music / unknown — from the symbol + section + reliable `RomInfo` ranges (text start/end, capped sentinel-terminated struct tables) + a **strict** LZ77 probe (`getCompressedSize`, also sniffed at the covering symbol base).
- **Source suggestion**: the `.map` object-file path / section when known, else an honest `(section ...)` / `(unknown — manual)` placeholder — never fabricated.
- **Confidence (honest)**: **High** only when a covering project symbol names the WHOLE range; **Medium** for an inferred known-range; **Low + "manual migration required"** for compressed / unknown / ambiguous (range spans multiple symbols). `ChangedBytes` is tracked separately from the coalesced `SpanLength` so a merged span never implies every byte changed.

## Surface

- **CLI** (primary): `--migrate-diff --project=<dir> --rom2=<editedRom> [--out=report.tsv] [--max-gap=N]`. Prints a classified summary and writes a TSV (`StartAddr/SpanLength/ChangedBytes/Symbol/+Offset/Covers/Category/Section/SourceFile/Confidence/SymbolSource/Suggestion`). Dispatched before the bare `--project` fallthrough.
- **Avalonia**: a read-only report view is **deferred** to a follow-up — it was OPTIONAL in the issue and the CLI is the locked-safe proof surface. (Noted here per the plan.) This PR touches **no GUI files** (Core + CLI + tests only).

## Additive slice-2 retention (no behaviour change)

`DecompMapParser` now captures the `.map` section line's object-file path into `DecompSymbol.ObjectPath`; `DecompSymbolResolver` keeps parallel `_sections`/`_objectPaths` dicts (`TryGetSection`/`TryGetObjectPath`), passed through `MergedAsmMapFile`. Existing #1130 tests stay green.

## Plan & review

Plan + Copilot review + accepted amendments on #1131. **All 6 Copilot plan-review findings folded in**: (1) changed-bytes vs covered-span honesty, (2) whole-range coverage gating High, (3) section/object-path retention, (4) strict LZ77 probe, (5) conservative table bounds + overlap precedence, (6) realistic CLI load path in E2E.

## Scope

Closes #1131. Ref #1129 (stays open).

## Test plan

- [x] Core `DecompDiffMigrationCoreTests` (17, DETERMINISTIC — run in CI without a ROM) — coalesce gap-merge vs no-merge (changed-bytes tracked separately); text-region / covering-struct-symbol / non-covering-graphics classification; covering project symbol → High + real `SourceFile`; compressed header → Low/manual and beats the symbol; no-symbol/no-table → Unknown/Low; `TryGetSection`/`TryGetObjectPath`; null map / null resolver / identical ROMs / null edited / null built / malformed → no throw; TSV header + summary null-safety.
- [x] E2E `DecompMigrateDiffTests` (7) — graceful-failure paths (no `--project` / missing `--rom2` → exit 1) run ROM-free in CI; the positive command paths (classify range, write TSV, identical→no-migration, **`--out` write failure → non-zero exit**, forceVersion fixture) exercise the real `LoadProject → InitFull → Analyze → TSV` path when an FE ROM is present and `Skip.If` none — the standard ROM-gated CLI-E2E pattern. (A zero ROM cannot survive the Debug `FETextEncode` Huffman build, so the deterministic CLI-integration coverage is the Core suite above; the CLI wiring is verified locally in Debug with a real ROM.)
- [x] Regression — all 109 existing `Decomp*` / `RomDiffCore` / `AsmMapSymbolFile` Core tests pass; full Core.Tests run shows only the 10 KNOWN `config/patch2`-submodule failures (env-specific, "submodule not checked out"), **0 new**.
- [x] Builds — Core, CLI, Avalonia, WinForms, FEBuilderGBA.Tests all `Build succeeded`.
- [x] `wc -c CLAUDE.md` = 39999 (under the 40k harness limit).
- [x] CLI smoke on a real FE8U-based synthetic project — High/Medium/Low ranges classified correctly (screenshot below).

## Screenshot

Actual `--migrate-diff` CLI output + the written TSV on a synthetic decomp project (built FE8U ROM, edits in a covering struct symbol, a covering code symbol, and an ambiguous shipped-symbol region) — showing the three confidence levels, categories, and source-file suggestions:

![migrate-diff CLI output](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1131-migrate-diff-cli.png)

Generated with Claude Code v2.1.169 — model claude-opus-4-8[1m]


