### PR TITLE
feat(android): stream-based ROM I/O + IStorageFile picks + app-private side-writes (#1124)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/AutoSaveSidecarPathTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/AutoSaveSidecarPathTests.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1124 — AutoSaveService sidecar path redirect. Desktop keeps the sidecar next
+// to the ROM; Android (content:// ROM, no writable parent) redirects into
+// app-private {CoreState.BaseDirectory}/autosave. The internal overload injects
+// the platform flag + base dir so the Android branch is exercised on a desktop
+// test host (reached via the existing InternalsVisibleTo seam in the csproj).
+using System.IO;
+using FEBuilderGBA.Avalonia.Services;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+public class AutoSaveSidecarPathTests
+{
+    [Fact]
+    public void Desktop_KeepsSidecarBesideRom()
+    {
+        string rom = Path.Combine("roms", "FE8U.gba");
+        string result = AutoSaveService.ComputeSidecarPath(rom, isAndroid: false, baseDir: "/ignored");
+
+        string expectedDir = Path.GetDirectoryName(rom)!;
+        string expected = Path.Combine(expectedDir, "FE8U.autosave.gba");
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Android_RedirectsIntoBaseDirectoryAutosave()
+    {
+        string baseDir = Path.Combine(Path.GetTempPath(), "febuilder_autosave_test");
+        // SAF content:// URIs have no meaningful local parent dir; only the file
+        // name matters for the redirected sidecar.
+        string rom = "content://com.android.providers/document/FE8U.gba";
+        string result = AutoSaveService.ComputeSidecarPath(rom, isAndroid: true, baseDir: baseDir);
+
+        string expected = Path.Combine(baseDir, "autosave", "FE8U.autosave.gba");
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void NullOrEmptyRomFilename_ReturnsNull(bool isAndroid)
+    {
+        Assert.Null(AutoSaveService.ComputeSidecarPath(null, isAndroid, "/base"));
+        Assert.Null(AutoSaveService.ComputeSidecarPath("", isAndroid, "/base"));
+    }
+
+    [Fact]
+    public void PublicOverload_OnDesktopHost_MatchesDesktopBranch()
+    {
+        // The desktop test host has OperatingSystem.IsAndroid() == false, so the
+        // public single-arg overload must equal the explicit desktop branch.
+        string rom = Path.Combine("roms", "FE8U.gba");
+        string viaPublic = AutoSaveService.ComputeSidecarPath(rom);
+        string viaDesktopBranch = AutoSaveService.ComputeSidecarPath(rom, isAndroid: false, baseDir: CoreState.BaseDirectory);
+        Assert.Equal(viaDesktopBranch, viaPublic);
+    }
+}

--- a/FEBuilderGBA.Avalonia/App.axaml.cs
+++ b/FEBuilderGBA.Avalonia/App.axaml.cs
@@ -182,6 +182,7 @@ namespace FEBuilderGBA.Avalonia
             CoreState.WireHeadlessAppendBinaryData();
 
             // Load config
+            // #1124: baseDir is the exe dir on desktop and Context.FilesDir (app-private) on Android (#1123), so config.xml is already redirected to app-private storage on Android.
             string configPath = Path.Combine(baseDir, "config", "config.xml");
             if (File.Exists(configPath))
             {

--- a/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
+++ b/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
@@ -66,6 +66,34 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         }
 
         /// <summary>
+        /// Open a GBA ROM and return the picked <see cref="IStorageFile"/> itself
+        /// (not collapsed to a local path). On Android the SAF result usually has NO
+        /// local path, so callers must read it via the stream API (#1124). Desktop
+        /// callers can still call TryGetLocalPath() on the returned handle.
+        /// </summary>
+        public static async Task<IStorageFile?> OpenRomFilePick(Window owner)
+        {
+            var files = await owner.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            {
+                Title = R._("Open ROM"),
+                AllowMultiple = false,
+                FileTypeFilter = new[] { MakeGbaFileType(), MakeAllFileType() },
+            });
+            return files.Count > 0 ? files[0] : null;
+        }
+
+        /// <summary>Save a GBA ROM and return the picked IStorageFile (#1124).</summary>
+        public static async Task<IStorageFile?> SaveRomFilePick(Window owner, string? suggestedName = null)
+        {
+            return await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            {
+                Title = R._("Save ROM"),
+                SuggestedFileName = suggestedName ?? "rom.gba",
+                FileTypeChoices = new[] { MakeGbaFileType(), MakeAllFileType() },
+            });
+        }
+
+        /// <summary>
         /// Open a decomp project folder (#1129 slice 1). Returns the chosen
         /// directory's local path, or null when cancelled / unavailable.
         /// </summary>

--- a/FEBuilderGBA.Avalonia/Services/AutoSaveService.cs
+++ b/FEBuilderGBA.Avalonia/Services/AutoSaveService.cs
@@ -28,13 +28,26 @@ namespace FEBuilderGBA.Avalonia.Services
 
         /// <summary>
         /// Compute the auto-save sidecar file path from the primary ROM filename.
-        /// Returns {dir}/{base}.autosave.gba.
+        /// Desktop: {romDir}/{base}.autosave.gba. On Android the ROM is a content://
+        /// URI with no writable parent dir, so redirect into app-private storage
+        /// {CoreState.BaseDirectory}/autosave/{base}.autosave.gba (#1124).
         /// </summary>
         public static string ComputeSidecarPath(string romFilename)
+            => ComputeSidecarPath(romFilename, OperatingSystem.IsAndroid(), CoreState.BaseDirectory);
+
+        /// <summary>Testable core of <see cref="ComputeSidecarPath(string)"/> — the
+        /// platform flag + base dir are injected so desktop unit tests can exercise the
+        /// Android branch (#1124).</summary>
+        internal static string ComputeSidecarPath(string romFilename, bool isAndroid, string baseDir)
         {
             if (string.IsNullOrEmpty(romFilename)) return null;
-            string dir = Path.GetDirectoryName(romFilename) ?? ".";
             string baseName = Path.GetFileNameWithoutExtension(romFilename);
+            if (isAndroid)
+            {
+                string root = string.IsNullOrEmpty(baseDir) ? "." : baseDir;
+                return Path.Combine(root, "autosave", baseName + ".autosave.gba");
+            }
+            string dir = Path.GetDirectoryName(romFilename) ?? ".";
             return Path.Combine(dir, baseName + ".autosave.gba");
         }
 
@@ -108,6 +121,12 @@ namespace FEBuilderGBA.Avalonia.Services
             {
                 try
                 {
+                    // Ensure the sidecar directory exists. On Android the redirect
+                    // target {BaseDirectory}/autosave may not exist yet (#1124); on
+                    // desktop the ROM's own dir already does, so this is a no-op.
+                    string sidecarDir = Path.GetDirectoryName(sidecar);
+                    if (!string.IsNullOrEmpty(sidecarDir)) Directory.CreateDirectory(sidecarDir);
+
                     // Write to temp file first, then move for atomicity
                     string tempPath = sidecar + ".tmp";
                     File.WriteAllBytes(tempPath, data);

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
@@ -24,6 +24,14 @@ namespace FEBuilderGBA.Avalonia.Views
     {
         readonly MainWindowViewModel _vm = new();
 
+        /// <summary>
+        /// Retains the picked SAF/content:// <see cref="global::Avalonia.Platform.Storage.IStorageFile"/>
+        /// handle when a ROM was opened from a source that has NO local filesystem
+        /// path (Android), so a later Save can write back via OpenWriteAsync (#1124).
+        /// Null on desktop and whenever the current ROM has a real local path.
+        /// </summary>
+        private global::Avalonia.Platform.Storage.IStorageFile? _currentRomStorageFile;
+
         public MainWindow()
         {
             InitializeComponent();
@@ -731,6 +739,24 @@ namespace FEBuilderGBA.Avalonia.Views
                 ok = rom.Load(path, out string version);
             }
             if (!ok) return false;
+
+            // This is a real local-path load (desktop / OpenLastRom / decomp /
+            // build-reload), so clear any retained SAF handle from a prior Android
+            // content:// open before converging on the shared init (#1124).
+            _currentRomStorageFile = null;
+            return FinishLoadedRom(rom, path);
+        }
+
+        /// <summary>
+        /// Shared post-load initialization for both the local-path and the Android
+        /// SAF/stream load paths (#1124). Wires CoreState, caches, encoders, event
+        /// scripts, UI state and auto-save. <paramref name="displayName"/> is the
+        /// path on desktop or the SAF file name on Android (used for recent-files
+        /// and the last-ROM config key).
+        /// </summary>
+        private bool FinishLoadedRom(ROM rom, string displayName)
+        {
+            string path = displayName;
 
             CoreState.ROM = rom;
 
@@ -2482,20 +2508,53 @@ namespace FEBuilderGBA.Avalonia.Views
 
         private async void OpenRom_Click(object? sender, RoutedEventArgs e)
         {
-            var path = await FileDialogHelper.OpenRomFile(this);
-            if (string.IsNullOrEmpty(path)) return;
+            var file = await FileDialogHelper.OpenRomFilePick(this);
+            if (file == null) return;
 
             // Opening a plain ROM clears any active decomp project (#1129). Cleared
-            // only AFTER the picker returns a real path, so cancelling the dialog
+            // only AFTER the picker returns a real file, so cancelling the dialog
             // leaves a currently-open decomp preview (and its save guard) intact.
             CoreState.DecompProject = null;
 
-            bool ok = LoadRomFile(path);
+            string? localPath = file.TryGetLocalPath();
+            bool ok;
+            if (!string.IsNullOrEmpty(localPath))
+            {
+                // Desktop / any provider with a real filesystem path — unchanged behavior.
+                _currentRomStorageFile = null;
+                ok = LoadRomFile(localPath);
+            }
+            else
+            {
+                // Android SAF content:// — no local path. Read via the stream API and
+                // retain the handle so a later Save can OpenWriteAsync() it (#1124).
+                ok = await LoadRomFromStorageFile(file);
+            }
             if (!ok)
             {
                 await MessageBoxWindow.Show(this, R._("Failed to load ROM."), R._("Error"), MessageBoxMode.Ok);
             }
             UpdateDecompBadge();
+        }
+
+        /// <summary>
+        /// Load a ROM from a SAF/content:// IStorageFile that has no local filesystem
+        /// path (Android). Reads bytes via the stream API, retains the handle for a
+        /// later stream Save, and converges on the shared post-load init (#1124).
+        /// </summary>
+        private async System.Threading.Tasks.Task<bool> LoadRomFromStorageFile(global::Avalonia.Platform.Storage.IStorageFile file)
+        {
+            ROM rom = new ROM();
+            bool ok;
+            string displayName = file.Name ?? "rom.gba";
+            await using (var stream = await file.OpenReadAsync())
+            {
+                var result = await rom.LoadFromStreamAsync(stream, displayName);
+                ok = result.ok;
+            }
+            if (!ok) { _currentRomStorageFile = null; return false; }
+            _currentRomStorageFile = file;
+            return FinishLoadedRom(rom, displayName);
         }
 
         /// <summary>
@@ -2622,17 +2681,25 @@ namespace FEBuilderGBA.Avalonia.Views
             UpdateDecompBadge();
         }
 
-        private void SaveRom_Click(object? sender, RoutedEventArgs e)
+        private async void SaveRom_Click(object? sender, RoutedEventArgs e)
         {
             if (CoreState.ROM == null) return;
-            // Amendment 5: decomp preview ROMs are read-only — block save with an
-            // explanatory dialog (non-awaited pattern to keep the sync signature).
+            // Amendment 5: decomp preview ROMs are read-only — block save.
             if (CoreState.IsDecompMode)
             {
-                _ = MessageBoxWindow.Show(this, R._("This is a source-backed decomp project. The built ROM is a preview and cannot be saved over. Edit the source and rebuild instead."), R._("Decomp Project"), MessageBoxMode.Ok);
+                await MessageBoxWindow.Show(this, R._("This is a source-backed decomp project. The built ROM is a preview and cannot be saved over. Edit the source and rebuild instead."), R._("Decomp Project"), MessageBoxMode.Ok);
                 return;
             }
-            CoreState.ROM.Save(CoreState.ROM.Filename, false);
+            if (_currentRomStorageFile != null && string.IsNullOrEmpty(_currentRomStorageFile.TryGetLocalPath()))
+            {
+                // Android SAF-backed ROM — write back through the retained handle.
+                await using var stream = await _currentRomStorageFile.OpenWriteAsync();
+                await CoreState.ROM.SaveToStreamAsync(stream);
+            }
+            else
+            {
+                CoreState.ROM.Save(CoreState.ROM.Filename, false);
+            }
             _vm.HasUnsavedChanges = false;
             AutoSaveService.Instance.MarkSaved();
             CoreState.Services.ShowInfo(R._("ROM saved."));
@@ -2649,16 +2716,34 @@ namespace FEBuilderGBA.Avalonia.Views
             }
 
             string suggestedName = Path.GetFileName(CoreState.ROM.Filename ?? "rom.gba");
-            var path = await FileDialogHelper.SaveRomFile(this, suggestedName);
-            if (string.IsNullOrEmpty(path)) return;
+            var file = await FileDialogHelper.SaveRomFilePick(this, suggestedName);
+            if (file == null) return;
 
-            CoreState.ROM.Save(path, false);
-            CoreState.ROM.Filename = path;  // Keep ROM.Filename in sync after Save As
-            _vm.RomFilename = Path.GetFileName(path);
+            string? localPath = file.TryGetLocalPath();
+            string displayName;
+            if (!string.IsNullOrEmpty(localPath))
+            {
+                _currentRomStorageFile = null;
+                CoreState.ROM.Save(localPath, false);
+                CoreState.ROM.Filename = localPath;  // Keep ROM.Filename in sync after Save As
+                displayName = localPath;
+            }
+            else
+            {
+                // Android SAF — write via stream + retain the new handle (#1124).
+                await using (var stream = await file.OpenWriteAsync())
+                {
+                    await CoreState.ROM.SaveToStreamAsync(stream);
+                }
+                _currentRomStorageFile = file;
+                displayName = file.Name ?? "rom.gba";
+                CoreState.ROM.Filename = displayName;
+            }
+            _vm.RomFilename = Path.GetFileName(displayName);
             _vm.HasUnsavedChanges = false;
-            AutoSaveService.Instance.UpdateRomFilename(path);
+            AutoSaveService.Instance.UpdateRomFilename(displayName);
             AutoSaveService.Instance.MarkSaved();
-            CoreState.Services.ShowInfo(R._("ROM saved as:") + $" {Path.GetFileName(path)}");
+            CoreState.Services.ShowInfo(R._("ROM saved as:") + $" {Path.GetFileName(displayName)}");
         }
 
         private void OpenLastRom_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Core.Tests/LogConfigBaseDirTests.cs
+++ b/FEBuilderGBA.Core.Tests/LogConfigBaseDirTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// #1124 — guard that the log file resolves under CoreState.BaseDirectory
+    /// (which is the exe dir on desktop and Context.FilesDir / app-private on
+    /// Android via #1123). No behaviour change is introduced — this pins the
+    /// existing redirect so a regression on Android storage would be caught here.
+    /// </summary>
+    [Collection("SharedState")]
+    public class LogConfigBaseDirTests
+    {
+        [Fact]
+        public void Log_WritesUnderBaseDirectory_ConfigLog()
+        {
+            string original = CoreState.BaseDirectory;
+            string tempDir = Path.Combine(Path.GetTempPath(), "febuilder_log_" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                Directory.CreateDirectory(tempDir);
+                CoreState.BaseDirectory = tempDir;
+
+                Log.Notify("#1124 base-dir guard log line");
+                Log.SyncLog();
+
+                string expected = Path.Combine(tempDir, "config", "log", "log.txt");
+                Assert.True(File.Exists(expected),
+                    $"Expected log file under BaseDirectory at {expected}");
+            }
+            finally
+            {
+                CoreState.BaseDirectory = original;
+                try { if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/RomStreamIoTests.cs
+++ b/FEBuilderGBA.Core.Tests/RomStreamIoTests.cs
@@ -163,5 +163,106 @@ namespace FEBuilderGBA.Core.Tests
             Assert.True(syncBytes.SequenceEqual(asyncBytes));
             Assert.True(asyncBytes.SequenceEqual(rom.Data));
         }
+
+        // #1124 Copilot review — SaveToStream into a pre-filled LARGER seekable
+        // stream (the real SAF OpenWriteAsync write-back case) must truncate to
+        // exactly Data.Length so no stale trailing bytes remain (corrupt ROM).
+        [Fact]
+        public void SaveToStream_IntoPrefilledLargerStream_TruncatesToExactLength()
+        {
+            byte[] buffer = MakeFe8uBuffer();
+            var rom = new ROM();
+            Assert.True(rom.LoadFromStream(new MemoryStream(buffer), "BE8E01.gba", out _));
+
+            using var ms = new MemoryStream();
+            // Pre-fill so Length = Data.Length + 123 and position is at the end.
+            byte[] filler = new byte[rom.Data.Length + 123];
+            for (int i = 0; i < filler.Length; i++) filler[i] = 0xCC;
+            ms.Write(filler, 0, filler.Length);
+            Assert.Equal(rom.Data.Length + 123, ms.Length);
+
+            rom.SaveToStream(ms);
+
+            Assert.Equal(rom.Data.Length, ms.Length);
+            Assert.True(ms.ToArray().SequenceEqual(rom.Data));
+        }
+
+        [Fact]
+        public async Task SaveToStreamAsync_IntoPrefilledLargerStream_TruncatesToExactLength()
+        {
+            byte[] buffer = MakeFe8uBuffer();
+            var rom = new ROM();
+            Assert.True(rom.LoadFromStream(new MemoryStream(buffer), "BE8E01.gba", out _));
+
+            using var ms = new MemoryStream();
+            byte[] filler = new byte[rom.Data.Length + 123];
+            for (int i = 0; i < filler.Length; i++) filler[i] = 0xCC;
+            await ms.WriteAsync(filler, 0, filler.Length);
+            Assert.Equal(rom.Data.Length + 123, ms.Length);
+
+            await rom.SaveToStreamAsync(ms);
+
+            Assert.Equal(rom.Data.Length, ms.Length);
+            Assert.True(ms.ToArray().SequenceEqual(rom.Data));
+        }
+
+        // #1124 Copilot review — LoadFromStream must rewind a seekable input that
+        // is not at position 0 (path Load always reads from the start), otherwise
+        // it would load a truncated ROM.
+        [Fact]
+        public void LoadFromStream_NonZeroPosition_RewindsAndLoadsFull()
+        {
+            byte[] buffer = MakeFe8uBuffer();
+            string tempFile = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllBytes(tempFile, buffer);
+                var romPath = new ROM();
+                Assert.True(romPath.Load(tempFile, out string versionPath));
+
+                using var ms = new MemoryStream();
+                ms.Write(buffer, 0, buffer.Length);
+                ms.Position = 100; // non-zero — must be rewound by the loader
+
+                var romStream = new ROM();
+                bool ok = romStream.LoadFromStream(ms, "BE8E01.gba", out string versionStream);
+
+                Assert.True(ok);
+                Assert.Equal(versionPath, versionStream);
+                Assert.True(romPath.Data.SequenceEqual(romStream.Data));
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        }
+
+        [Fact]
+        public async Task LoadFromStreamAsync_NonZeroPosition_RewindsAndLoadsFull()
+        {
+            byte[] buffer = MakeFe8uBuffer();
+            string tempFile = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllBytes(tempFile, buffer);
+                var romPath = new ROM();
+                Assert.True(romPath.Load(tempFile, out string versionPath));
+
+                using var ms = new MemoryStream();
+                ms.Write(buffer, 0, buffer.Length);
+                ms.Position = 100;
+
+                var romStream = new ROM();
+                var result = await romStream.LoadFromStreamAsync(ms, "BE8E01.gba");
+
+                Assert.True(result.ok);
+                Assert.Equal(versionPath, result.version);
+                Assert.True(romPath.Data.SequenceEqual(romStream.Data));
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        }
     }
 }

--- a/FEBuilderGBA.Core.Tests/RomStreamIoTests.cs
+++ b/FEBuilderGBA.Core.Tests/RomStreamIoTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// #1124 — stream-based ROM load/save (LoadFromStream/SaveToStream + async).
+    /// These guard that the new stream seam is byte-for-byte identical to the
+    /// existing path Load/Save (used on Android where a SAF content:// pick has
+    /// no local filesystem path so the bytes must be read/written via streams).
+    /// </summary>
+    public class RomStreamIoTests
+    {
+        // Build the smallest buffer LoadLow accepts as a real ROM: FE8U needs
+        // >= 0x1000000 bytes with the 6-byte game code "BE8E01" at 0x080000AC
+        // (offset 0xAC). Mirrors the AsmMapSymbolFileTests fixture.
+        static byte[] MakeFe8uBuffer()
+        {
+            byte[] data = new byte[0x1000000];
+            byte[] code = System.Text.Encoding.ASCII.GetBytes("BE8E01");
+            uint off = U.toOffset(0x080000AC); // 0xAC
+            Array.Copy(code, 0, data, (int)off, code.Length);
+            // Sprinkle a few non-zero bytes so byte-identity assertions are
+            // meaningful (not all zeros).
+            for (int i = 0; i < 256; i++) data[0x200 + i] = (byte)(i & 0xFF);
+            return data;
+        }
+
+        [Fact]
+        public void LoadFromStream_MatchesPathLoad_ByteIdentical()
+        {
+            byte[] buffer = MakeFe8uBuffer();
+            string tempFile = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllBytes(tempFile, buffer);
+
+                var rom1 = new ROM();
+                bool ok1 = rom1.Load(tempFile, out string version1);
+
+                var rom2 = new ROM();
+                bool ok2;
+                using (var ms = new MemoryStream(buffer))
+                {
+                    ok2 = rom2.LoadFromStream(ms, "BE8E01.gba", out string version2);
+                    Assert.Equal(version1, version2);
+                }
+
+                Assert.True(ok1);
+                Assert.True(ok2);
+                Assert.Equal("BE8E01", version1);
+                Assert.True(rom1.Data.SequenceEqual(rom2.Data));
+                Assert.Equal(rom1.RomInfo.GetType(), rom2.RomInfo.GetType());
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        }
+
+        [Fact]
+        public async Task LoadFromStreamAsync_MatchesSync()
+        {
+            byte[] buffer = MakeFe8uBuffer();
+
+            var romSync = new ROM();
+            bool okSync = romSync.LoadFromStream(new MemoryStream(buffer), "BE8E01.gba", out string versionSync);
+
+            var romAsync = new ROM();
+            (bool ok, string version) result;
+            using (var ms = new MemoryStream(buffer))
+            {
+                result = await romAsync.LoadFromStreamAsync(ms, "BE8E01.gba");
+            }
+
+            Assert.True(okSync);
+            Assert.True(result.ok);
+            Assert.Equal(versionSync, result.version);
+            Assert.True(romSync.Data.SequenceEqual(romAsync.Data));
+        }
+
+        [Fact]
+        public void SaveToStream_MatchesPathSave_ByteIdentical()
+        {
+            byte[] buffer = MakeFe8uBuffer();
+            var rom = new ROM();
+            Assert.True(rom.LoadFromStream(new MemoryStream(buffer), "BE8E01.gba", out _));
+
+            string tempFile = Path.GetTempFileName();
+            try
+            {
+                rom.Save(tempFile, false);
+                byte[] pathBytes = File.ReadAllBytes(tempFile);
+
+                byte[] streamBytes;
+                using (var ms = new MemoryStream())
+                {
+                    rom.SaveToStream(ms);
+                    streamBytes = ms.ToArray();
+                }
+
+                Assert.True(pathBytes.SequenceEqual(streamBytes));
+                Assert.True(streamBytes.SequenceEqual(rom.Data));
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        }
+
+        [Fact]
+        public void SaveToStream_Silent_PreservesModifiedSemantics()
+        {
+            byte[] buffer = MakeFe8uBuffer();
+
+            // silent=true must NOT clear Modified.
+            var romSilent = new ROM();
+            Assert.True(romSilent.LoadFromStream(new MemoryStream(buffer), "BE8E01.gba", out _));
+            romSilent.write_u8(0x200, 0x99); // dirties Modified=true
+            Assert.True(romSilent.Modified);
+            using (var ms = new MemoryStream())
+            {
+                romSilent.SaveToStream(ms, true);
+            }
+            Assert.True(romSilent.Modified);
+
+            // silent=false (default) clears Modified — mirrors Save(name, false).
+            var romNotSilent = new ROM();
+            Assert.True(romNotSilent.LoadFromStream(new MemoryStream(buffer), "BE8E01.gba", out _));
+            romNotSilent.write_u8(0x200, 0x99);
+            Assert.True(romNotSilent.Modified);
+            using (var ms = new MemoryStream())
+            {
+                romNotSilent.SaveToStream(ms);
+            }
+            Assert.False(romNotSilent.Modified);
+        }
+
+        [Fact]
+        public async Task SaveToStreamAsync_MatchesSync()
+        {
+            byte[] buffer = MakeFe8uBuffer();
+            var rom = new ROM();
+            Assert.True(rom.LoadFromStream(new MemoryStream(buffer), "BE8E01.gba", out _));
+
+            byte[] syncBytes;
+            using (var ms = new MemoryStream())
+            {
+                rom.SaveToStream(ms);
+                syncBytes = ms.ToArray();
+            }
+
+            byte[] asyncBytes;
+            using (var ms = new MemoryStream())
+            {
+                await rom.SaveToStreamAsync(ms);
+                asyncBytes = ms.ToArray();
+            }
+
+            Assert.True(syncBytes.SequenceEqual(asyncBytes));
+            Assert.True(asyncBytes.SequenceEqual(rom.Data));
+        }
+    }
+}

--- a/FEBuilderGBA.Core/Log.cs
+++ b/FEBuilderGBA.Core/Log.cs
@@ -50,6 +50,7 @@ namespace FEBuilderGBA
 
         static string GetLogFilename()
         {
+            // #1124: CoreState.BaseDirectory is the exe dir on desktop and Context.FilesDir (app-private) on Android (#1123), so the log is already redirected to app-private storage on Android.
             return Path.Combine(CoreState.BaseDirectory ?? ".", "config", "log", "log.txt");
         }
 

--- a/FEBuilderGBA.Core/Rom.cs
+++ b/FEBuilderGBA.Core/Rom.cs
@@ -623,6 +623,9 @@ namespace FEBuilderGBA
         // LoadBytes seam as the path Load so detection stays identical.
         public bool LoadFromStream(System.IO.Stream stream, string name, out string version)
         {
+            // Path Load always reads from the start; rewind a seekable input so a
+            // stream left at a non-zero position doesn't load truncated (#1124 review).
+            if (stream.CanSeek) { stream.Seek(0, System.IO.SeekOrigin.Begin); }
             using (var ms = new System.IO.MemoryStream())
             {
                 stream.CopyTo(ms);
@@ -631,6 +634,7 @@ namespace FEBuilderGBA
         }
         public async System.Threading.Tasks.Task<(bool ok, string version)> LoadFromStreamAsync(System.IO.Stream stream, string name)
         {
+            if (stream.CanSeek) { stream.Seek(0, System.IO.SeekOrigin.Begin); }
             using (var ms = new System.IO.MemoryStream())
             {
                 await stream.CopyToAsync(ms).ConfigureAwait(false);
@@ -697,6 +701,15 @@ namespace FEBuilderGBA
         public void SaveToStream(System.IO.Stream stream) => SaveToStream(stream, false);
         public void SaveToStream(System.IO.Stream stream, bool silent)
         {
+            // Mirror Save(name,...) which truncates/replaces the file: for a seekable
+            // target, rewind + SetLength so a pre-existing LARGER stream (the real SAF
+            // OpenWriteAsync write-back case) doesn't keep stale trailing bytes (#1124
+            // Copilot review).
+            if (stream.CanSeek)
+            {
+                stream.Seek(0, System.IO.SeekOrigin.Begin);
+                stream.SetLength(this.Data.Length);
+            }
             stream.Write(this.Data, 0, this.Data.Length);
             if (!silent)
             {
@@ -705,6 +718,11 @@ namespace FEBuilderGBA
         }
         public async System.Threading.Tasks.Task SaveToStreamAsync(System.IO.Stream stream, bool silent = false)
         {
+            if (stream.CanSeek)
+            {
+                stream.Seek(0, System.IO.SeekOrigin.Begin);
+                stream.SetLength(this.Data.Length);
+            }
             await stream.WriteAsync(this.Data, 0, this.Data.Length).ConfigureAwait(false);
             if (!silent)
             {

--- a/FEBuilderGBA.Core/Rom.cs
+++ b/FEBuilderGBA.Core/Rom.cs
@@ -595,6 +595,15 @@ namespace FEBuilderGBA
             }
             return false;
         }
+        // Shared byte-level load seam: extract the GBA game code at 0x080000AC and
+        // dispatch to LoadLow. Used by Load, LoadFromStream and the async wrappers so
+        // the stream==path round-trip is a real drift guard (#1124).
+        bool LoadBytes(string name, byte[] data, out string version)
+        {
+            version = U.getASCIIString(data, U.toOffset(0x080000AC), 6);
+            return LoadLow(name, data, version);
+        }
+
         public bool Load(string name,out string version)
         {
             if (!File.Exists(name))
@@ -604,9 +613,30 @@ namespace FEBuilderGBA
             }
 
             byte[] data = File.ReadAllBytes(name);
-            version = U.getASCIIString(data,U.toOffset(0x080000AC),6);
 
-            return LoadLow(name, data, version);
+            return LoadBytes(name, data, out version);
+        }
+
+        // Stream-based ROM load (#1124). On Android a SAF content:// pick has no
+        // local filesystem path, so the Avalonia head reads the bytes via the
+        // IStorageFile stream API and feeds them here. Converges on the same
+        // LoadBytes seam as the path Load so detection stays identical.
+        public bool LoadFromStream(System.IO.Stream stream, string name, out string version)
+        {
+            using (var ms = new System.IO.MemoryStream())
+            {
+                stream.CopyTo(ms);
+                return LoadBytes(name, ms.ToArray(), out version);
+            }
+        }
+        public async System.Threading.Tasks.Task<(bool ok, string version)> LoadFromStreamAsync(System.IO.Stream stream, string name)
+        {
+            using (var ms = new System.IO.MemoryStream())
+            {
+                await stream.CopyToAsync(ms).ConfigureAwait(false);
+                bool ok = LoadBytes(name, ms.ToArray(), out string version);
+                return (ok, version);
+            }
         }
 
         public bool LoadForceVersion(string name,string forceversion)
@@ -655,6 +685,27 @@ namespace FEBuilderGBA
         {
             U.WriteAllBytes(name, this.Data);
 
+            if (!silent)
+            {
+                this.Modified = false;
+            }
+        }
+
+        // Stream-based ROM save (#1124). Mirrors Save(name, silent) Modified
+        // semantics so the Android SAF write-back path (no local path → write via
+        // IStorageFile.OpenWriteAsync) clears Modified exactly like the path Save.
+        public void SaveToStream(System.IO.Stream stream) => SaveToStream(stream, false);
+        public void SaveToStream(System.IO.Stream stream, bool silent)
+        {
+            stream.Write(this.Data, 0, this.Data.Length);
+            if (!silent)
+            {
+                this.Modified = false;
+            }
+        }
+        public async System.Threading.Tasks.Task SaveToStreamAsync(System.IO.Stream stream, bool silent = false)
+        {
+            await stream.WriteAsync(this.Data, 0, this.Data.Length).ConfigureAwait(false);
             if (!silent)
             {
                 this.Modified = false;

--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ Two distinct paths exist, both covered in detail in [docs/CROSS_PLATFORM.md → 
 
 - **Emulation (Gamenative/Winlator)** — run the Windows *desktop* build under Wine + Box86/Box64. User-side, **experimental / unsupported / community-tested**; try the Avalonia `win-x64` build first.
 - **Native Android app** — a separate port of the Avalonia GUI, tracked as exploration epic [#1070](https://github.com/laqieer/FEBuilderGBA/issues/1070). Not shipped. See the evidence-backed feasibility assessment in [docs/ANDROID.md](docs/ANDROID.md) (Avalonia.Android lifetime, SkiaSharp native pin, SAF ROM access, `config/` bundling, the multi-window→single-activity gap) and the authored head skeleton in [`FEBuilderGBA.Android/`](FEBuilderGBA.Android/README.md).
+  - **Stream-based ROM I/O for SAF (#1124)** — `ROM.LoadFromStream`/`SaveToStream` (+ async) share the byte-level seam with the existing path `Load`/`Save`, so the Avalonia head can open/save a ROM picked via `IStorageProvider` even when the SAF `content://` handle has no local filesystem path (it retains the `IStorageFile` and reads/writes through `OpenReadAsync`/`OpenWriteAsync`). Desktop path I/O is unchanged. The auto-save sidecar is redirected into app-private `{BaseDirectory}/autosave/` on Android (where the ROM's parent dir is not writable); the log and `config.xml` already resolve under `BaseDirectory` (`Context.FilesDir` on Android via #1123).
 
 ### Architecture Diagram
 


### PR DESCRIPTION
## Summary
Implements **stream-based ROM I/O** so a ROM can be opened and saved through an Android SAF `content://` `IStorageFile` (which usually has no local filesystem path), while leaving the desktop path-based flow byte-for-byte unchanged. Part of the native-Android epic #1070 (foundation #1121 + config #1123).

Three seams, exactly per the [accepted plan](https://github.com/laqieer/FEBuilderGBA/issues/1124#issuecomment-4703053383):

1. **Stream ROM load/save on `Rom` (Core)** — new `LoadFromStream`/`LoadFromStreamAsync` and `SaveToStream`/`SaveToStreamAsync`, all converging on a private `LoadBytes(name, data, out version)` seam (the `0x080000AC` game-code read + the existing `LoadLow`), so the stream path **shares the byte logic** with `Load`/`Save` (zero duplication). `SaveToStream(stream, silent)` mirrors `Save(name, silent)` `Modified` semantics. Path `Load`/`Save` signatures + behavior untouched.
2. **`FileDialogHelper` retains the `IStorageFile`** — new `OpenRomFilePick`/`SaveRomFilePick` return the picked `IStorageFile` instead of collapsing it to `TryGetLocalPath()` (which returns null for SAF). `MainWindow` threads the handle through Open / Save / Save As: when a local path exists (desktop) it takes the **unchanged** path branch; when there's no local path (Android) it reads/writes via `OpenReadAsync`/`OpenWriteAsync` and **retains the handle** (`_currentRomStorageFile`) so a later Save can write back to the same SAF file. Both branches converge on a shared `FinishLoadedRom` so Android can't leave stale state.
3. **App-private side-writes on Android** — `AutoSaveService.ComputeSidecarPath` redirects the sidecar into `{CoreState.BaseDirectory}/autosave/…` on Android (the ROM's `content://` parent dir isn't writable), via a testable `(romFilename, isAndroid, baseDir)` overload; `OnTick` ensures the dir exists. `Log` and `Config` already resolve under `CoreState.BaseDirectory` → `Context.FilesDir` on Android (#1123), confirmed with comments + a guard test.

## Plan
- Plan comment: https://github.com/laqieer/FEBuilderGBA/issues/1124#issuecomment-4703042588
- Copilot plan review (5 findings, all folded in): https://github.com/laqieer/FEBuilderGBA/issues/1124#issuecomment-4703053383

## Scope
**Closes #1124** — all three checklist items implemented and desktop-validated.
Out of scope (tracked under #1070): SAF `content://` runtime/content-resolver behavior, the multi-window → single-view Android navigation port, `config/patch2` on Android.

## Validation — desktop / build-only (honest disclosure)
**No Android device or emulator is available in this environment, so this PR is NOT device-validated.** The SAF `content://` runtime path cannot be exercised here and is tracked under epic #1070. No device screenshot is fabricated. What IS proven (terminal output below):
- the stream ROM load/save seam round-trips **byte-identically** to the path API (Core unit tests),
- the desktop `FileDialogHelper`/Open/Save flow is unchanged (regression),
- the Android autosave redirect is android-gated (desktop output unchanged),
- the Android head **still builds** (`dotnet build … -p:EnableAndroidTarget=true` → 0 errors), proving the SAF `OpenReadAsync`/`OpenWriteAsync` + `OperatingSystem.IsAndroid()` code compiles on `net9.0-android`.

![#1124 desktop/build-only proof](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1124-rom-saf.png)

## GUI Test Report
**Not device-validated — stream seam + desktop regression unit-tested, Android head builds; SAF `content://` runtime tracked under #1070.** The GUI change (`MainWindow` Open/Save/Save As) is exercised on desktop indirectly via the unchanged local-path branch (existing `OpenRomFile`/`SaveRomFile` semantics preserved) and the new `IStorageFile` handle plumbing is covered by the build + unit tests; the Android-only SAF branch has no desktop GUI surface to screenshot. Manual desktop Open/Save was not changed (same code path).

| # | Test | Result |
|---|------|--------|
| 1 | `LoadFromStream` == path `Load` (byte-identical `Data`, same version, same `RomInfo`) | PASS |
| 2 | `LoadFromStreamAsync` matches sync | PASS |
| 3 | `SaveToStream` == path `Save` (byte-identical) | PASS |
| 4 | `SaveToStream(silent)` preserves `Modified` semantics | PASS |
| 5 | `SaveToStreamAsync` matches sync | PASS |
| 6 | `Log` resolves under `CoreState.BaseDirectory` (app-private on Android) | PASS |
| 7 | `ComputeSidecarPath` desktop branch unchanged | PASS |
| 8 | `ComputeSidecarPath` Android branch → `{baseDir}/autosave/*.autosave.gba` | PASS |
| 9 | `ComputeSidecarPath` null/empty → null (both branches) | PASS |
| 10 | public `ComputeSidecarPath` (desktop host) == desktop-branch result | PASS |
| 11 | Android head builds (`-p:EnableAndroidTarget=true`) — 0 errors | PASS |
| 12 | `SaveToStream` into a prefilled LARGER stream truncates to exact length (Copilot repro) | PASS |
| 13 | `LoadFromStream` from a non-zero stream position rewinds + loads full | PASS |

## Test plan
- [x] `dotnet test FEBuilderGBA.Core.Tests --filter RomStreamIo|LogConfigBaseDir` → 9 passed, 0 failed (incl. 4 seekable-stream truncate/rewind regressions from Copilot review)
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests --filter AutoSaveSidecarPath` → 5 passed, 0 failed
- [x] Full `FEBuilderGBA.Core.Tests` → 3880 passed; the only 10 failures are the **pre-existing** `config/patch2`-submodule SkillSystems tests (0 NEW failures)
- [x] Full `FEBuilderGBA.Avalonia.Tests` → 7988 passed, 0 failed, 3 pre-existing skips
- [x] Full `FEBuilderGBA.Tests` (net9.0-windows) → 1859 passed, 0 failed (incl. 4 seekable-stream truncate/rewind regressions from Copilot review)
- [x] Desktop Avalonia head builds (`FEBuilderGBA.Avalonia.csproj` net9.0) — 0 errors
- [x] Android head builds (`FEBuilderGBA.Android.csproj -p:EnableAndroidTarget=true`) — 0 errors
- [x] README updated; CLAUDE.md unchanged (39999 chars, < 40000)

🤖 Generated with Claude Code v2.1.169 — model claude-opus-4-8[1m]

