### PR TITLE
fix(e2e): WriteSource all-skipped test must use bulk (two macro fields)

### DIFF
--- a/FEBuilderGBA.E2ETests/Tests/WriteSourceE2ETests.cs
+++ b/FEBuilderGBA.E2ETests/Tests/WriteSourceE2ETests.cs
@@ -585,10 +585,10 @@ namespace FEBuilderGBA.E2ETests.Tests
                 string srcDir = Path.Combine(projectDir, "src");
                 Directory.CreateDirectory(srcDir);
                 string srcAbs = Path.Combine(srcDir, "support.c");
-                // b0 slot is a MACRO token (unwritable).
+                // b0 AND b1 slots are MACRO tokens (unwritable) — a genuine BULK all-skipped scenario.
                 string content =
                     "const SupportData gSupportData[] = {\n" +
-                    "    {SOME_MACRO, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},\n" +
+                    "    {SOME_MACRO, OTHER_MACRO, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},\n" +
                     "};\n";
                 File.WriteAllText(srcAbs, content);
 
@@ -605,8 +605,11 @@ namespace FEBuilderGBA.E2ETests.Tests
                 File.WriteAllText(Path.Combine(projectDir, "febuilder.project.json"), manifest);
                 File.Copy(FirstRom!, Path.Combine(projectDir, "synth.gba"), overwrite: true);
 
-                // Edit ONLY the macro field → all requested fields skipped.
-                string args = $"--write-source --project=\"{projectDir}\" --table=support_units --id=0 --field=b0 --value=0x09";
+                // Edit BOTH macro fields → every requested field maps to a macro → all skipped (bulk).
+                // (A single-field macro edit is a HARD UnsupportedField fail by #1159 design; only a
+                //  bulk/multi-field edit routes macro fields to the soft "skipped" no-op path, which is
+                //  what this test's stderr "skipped" + "NeedsRebuild=false" + byte-identical contract asserts.)
+                string args = $"--write-source --project=\"{projectDir}\" --table=support_units --id=0 --field=b0 --value=0x09 --field=b1 --value=0x0A";
                 var (code, stdout, stderr) = RunWithRetry(args);
 
                 Assert.Equal(2, code);


### PR DESCRIPTION
## Problem
All 5 scheduled ROM E2E runs were RED (#1200 FE6, #1201 FE7J, #1202 FE7U, #1203 FE8J, #1204 FE8U). Each failed on **exactly one** test: `WriteSourceE2ETests.WriteSource_SupportUnits_AllSkipped_ExitsTwo`.

```
Assert.Contains() Failure: "skipped" not found
Actual stderr: "ROM-only / manual / not owned: Value 'SOME_MACRO'..."
```
(`Assert.Equal(2, code)` already passed — exit code was correct; only the stderr-wording / `NeedsRebuild` assertions were wrong.)

## Root cause — test bug, not a product regression
The test's name + comment describe the **bulk** contract ("ALL requested fields map to a macro → exit 2 + stderr `skipped` + `NeedsRebuild=false` + source byte-identical"), but it edited a **single** field. By deliberate **#1159** design (`bool singleFieldIntent = changedFields.Count == 1` in `DecompSourceWriterCore.cs`), a single-field macro edit is a **hard `UnsupportedField` failure** (`res.Ok==false` → CLI `Program.cs:5035` "ROM-only / manual / not owned", exit 2). Only a **bulk/multi-field** edit routes macro fields to the soft `SkippedMacro` no-op path that emits "skipped" + "NeedsRebuild=false" (`Program.cs:4970-4974`). The product behaviour is correct and intentional.

It slipped through because E2E only runs on **schedule with ROMs**, never in PR CI — so this assertion never executed before merge.

## Fix (test-only)
Make the test a genuine **bulk all-skipped** scenario: two macro fields (`b0` + `b1`), edit both. This matches the asserted contract and mirrors the sibling test `WriteSource_SupportUnits_Partial_ExitsTwo_WritesNumericField` (same manifest `fields: [b0, b1]`, edits both). All four assertions kept verbatim. No product code changed.

## Validation
- `dotnet build FEBuilderGBA.E2ETests` → **0 errors**.
- The test `Skip`s locally (no ROMs), so the authoritative check is a dispatched `e2e-fe6.yml` run on master (CI has ROM secrets) — will confirm green before closing the 5 issues.

Fixes #1200
Fixes #1201
Fixes #1202
Fixes #1203
Fixes #1204

— Claude Code (Opus 4.8 1M context, ultracode effort)