### PR TITLE
feat(avalonia): implement Ending (FE6) editor — port WinForms EDFE6Form (#1198)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/EDFE6ViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EDFE6ViewModelTests.cs
@@ -1,0 +1,120 @@
+using System.Collections.Generic;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+/// <summary>
+/// Headless ROM-backed tests for <see cref="EDFE6ViewModel"/> (issue #1198 —
+/// port of WinForms <c>EDFE6Form</c>, the FE6 "Ending / after story" text editor).
+/// The RomFixture loads an FE8U ROM; <c>ed_3a_pointer</c> is valid on FE8U too,
+/// so the list + read/write round-trip exercises real ROM data.
+/// </summary>
+[Collection("SharedState")]
+public class EDFE6ViewModelTests : IClassFixture<RomFixture>
+{
+    private readonly RomFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public EDFE6ViewModelTests(RomFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    bool Skip()
+    {
+        if (!_fixture.IsAvailable)
+        {
+            _output.WriteLine("RomFixture not available — skipping ROM-backed assertions.");
+            return true;
+        }
+        return false;
+    }
+
+    [Fact]
+    public void LoadList_ReturnsEntries_EightBytesApart()
+    {
+        if (Skip()) return;
+
+        var vm = new EDFE6ViewModel();
+        List<AddrResult> list = vm.LoadList();
+
+        Assert.NotEmpty(list);
+        Assert.True(list.Count <= (int)EDFE6ViewModel.MaxCount, "entry count must not exceed 0x42");
+
+        for (int i = 1; i < list.Count; i++)
+        {
+            Assert.Equal(list[i - 1].addr + EDFE6ViewModel.EntrySize, list[i].addr);
+        }
+    }
+
+    [Fact]
+    public void LoadEntry_PopulatesFourTextIdFields()
+    {
+        if (Skip()) return;
+
+        var vm = new EDFE6ViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        uint addr = list[0].addr;
+        vm.LoadEntry(addr);
+
+        Assert.True(vm.IsLoaded);
+        Assert.Equal(addr, vm.CurrentAddr);
+        Assert.Equal(CoreState.ROM.u16(addr + 0), vm.Text0Id);
+        Assert.Equal(CoreState.ROM.u16(addr + 2), vm.Text2Id);
+        Assert.Equal(CoreState.ROM.u16(addr + 4), vm.Text4Id);
+        Assert.Equal(CoreState.ROM.u16(addr + 6), vm.Text6Id);
+    }
+
+    [Fact]
+    public void WriteEntry_RoundTripsAllFourFields()
+    {
+        if (Skip()) return;
+
+        var vm = new EDFE6ViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        uint addr = list[0].addr;
+        vm.LoadEntry(addr);
+
+        uint orig0 = vm.Text0Id, orig2 = vm.Text2Id, orig4 = vm.Text4Id, orig6 = vm.Text6Id;
+        try
+        {
+            vm.Text0Id = 0x0123;
+            vm.Text2Id = 0x0045;
+            vm.Text4Id = 0x0067;
+            vm.Text6Id = 0x0089;
+            Assert.True(vm.WriteEntry());
+
+            // Re-read with a fresh VM to prove the bytes actually landed in ROM.
+            var vm2 = new EDFE6ViewModel();
+            vm2.LoadEntry(addr);
+            Assert.Equal(0x0123u, vm2.Text0Id);
+            Assert.Equal(0x0045u, vm2.Text2Id);
+            Assert.Equal(0x0067u, vm2.Text4Id);
+            Assert.Equal(0x0089u, vm2.Text6Id);
+        }
+        finally
+        {
+            // Restore the shared fixture ROM byte-for-byte.
+            vm.Text0Id = orig0;
+            vm.Text2Id = orig2;
+            vm.Text4Id = orig4;
+            vm.Text6Id = orig6;
+            vm.WriteEntry();
+        }
+    }
+
+    [Fact]
+    public void WriteEntry_WithoutSelection_DoesNotMutate()
+    {
+        // No ROM dependency: a VM that never loaded an entry has CurrentAddr == 0.
+        var vm = new EDFE6ViewModel();
+        Assert.False(vm.WriteEntry());
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/EDFE6ViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EDFE6ViewModelTests.cs
@@ -8,113 +8,140 @@ namespace FEBuilderGBA.Avalonia.Tests;
 /// <summary>
 /// Headless ROM-backed tests for <see cref="EDFE6ViewModel"/> (issue #1198 —
 /// port of WinForms <c>EDFE6Form</c>, the FE6 "Ending / after story" text editor).
-/// The RomFixture loads an FE8U ROM; <c>ed_3a_pointer</c> is valid on FE8U too,
-/// so the list + read/write round-trip exercises real ROM data.
+///
+/// The editor is FE6-ONLY: ed_3a is a 4×u16 text-ID table on FE6 but an ED/epilogue
+/// table with a different schema on FE7/FE8. These tests therefore load a genuine FE6
+/// ROM via <see cref="RomTestHelper.WithRom"/> (skipped gracefully when FE6 is absent)
+/// and a separate test loads FE8U to prove the FE6 gate refuses to touch non-FE6 data.
 /// </summary>
 [Collection("SharedState")]
-public class EDFE6ViewModelTests : IClassFixture<RomFixture>
+public class EDFE6ViewModelTests
 {
-    private readonly RomFixture _fixture;
     private readonly ITestOutputHelper _output;
 
-    public EDFE6ViewModelTests(RomFixture fixture, ITestOutputHelper output)
+    public EDFE6ViewModelTests(ITestOutputHelper output)
     {
-        _fixture = fixture;
         _output = output;
     }
 
-    bool Skip()
+    [Fact]
+    public void LoadList_OnFe6_ReturnsEntries_EightBytesApart()
     {
-        if (!_fixture.IsAvailable)
+        RomTestHelper.WithRom("FE6", () =>
         {
-            _output.WriteLine("RomFixture not available — skipping ROM-backed assertions.");
-            return true;
-        }
-        return false;
+            var vm = new EDFE6ViewModel();
+            List<AddrResult> list = vm.LoadList();
+
+            Assert.NotEmpty(list);
+            Assert.True(list.Count <= (int)EDFE6ViewModel.MaxCount, "entry count must not exceed 0x42");
+
+            for (int i = 1; i < list.Count; i++)
+            {
+                Assert.Equal(list[i - 1].addr + EDFE6ViewModel.EntrySize, list[i].addr);
+            }
+        });
     }
 
     [Fact]
-    public void LoadList_ReturnsEntries_EightBytesApart()
+    public void LoadEntry_OnFe6_PopulatesFourTextIdFields()
     {
-        if (Skip()) return;
-
-        var vm = new EDFE6ViewModel();
-        List<AddrResult> list = vm.LoadList();
-
-        Assert.NotEmpty(list);
-        Assert.True(list.Count <= (int)EDFE6ViewModel.MaxCount, "entry count must not exceed 0x42");
-
-        for (int i = 1; i < list.Count; i++)
+        RomTestHelper.WithRom("FE6", () =>
         {
-            Assert.Equal(list[i - 1].addr + EDFE6ViewModel.EntrySize, list[i].addr);
-        }
+            var vm = new EDFE6ViewModel();
+            var list = vm.LoadList();
+            Assert.NotEmpty(list);
+
+            uint addr = list[0].addr;
+            vm.LoadEntry(addr);
+
+            Assert.True(vm.IsLoaded);
+            Assert.Equal(addr, vm.CurrentAddr);
+            Assert.Equal(CoreState.ROM.u16(addr + 0), vm.Text0Id);
+            Assert.Equal(CoreState.ROM.u16(addr + 2), vm.Text2Id);
+            Assert.Equal(CoreState.ROM.u16(addr + 4), vm.Text4Id);
+            Assert.Equal(CoreState.ROM.u16(addr + 6), vm.Text6Id);
+        });
     }
 
     [Fact]
-    public void LoadEntry_PopulatesFourTextIdFields()
+    public void WriteEntry_OnFe6_RoundTripsAllFourFields()
     {
-        if (Skip()) return;
+        RomTestHelper.WithRom("FE6", () =>
+        {
+            var vm = new EDFE6ViewModel();
+            var list = vm.LoadList();
+            Assert.NotEmpty(list);
 
-        var vm = new EDFE6ViewModel();
-        var list = vm.LoadList();
-        Assert.NotEmpty(list);
+            // Use entry 1 (Roy) — entry 0 is an empty placeholder.
+            uint addr = list.Count > 1 ? list[1].addr : list[0].addr;
+            vm.LoadEntry(addr);
 
-        uint addr = list[0].addr;
-        vm.LoadEntry(addr);
+            uint orig0 = vm.Text0Id, orig2 = vm.Text2Id, orig4 = vm.Text4Id, orig6 = vm.Text6Id;
+            try
+            {
+                vm.Text0Id = 0x0123;
+                vm.Text2Id = 0x0045;
+                vm.Text4Id = 0x0067;
+                vm.Text6Id = 0x0089;
+                Assert.True(vm.WriteEntry());
 
-        Assert.True(vm.IsLoaded);
-        Assert.Equal(addr, vm.CurrentAddr);
-        Assert.Equal(CoreState.ROM.u16(addr + 0), vm.Text0Id);
-        Assert.Equal(CoreState.ROM.u16(addr + 2), vm.Text2Id);
-        Assert.Equal(CoreState.ROM.u16(addr + 4), vm.Text4Id);
-        Assert.Equal(CoreState.ROM.u16(addr + 6), vm.Text6Id);
+                // Re-read with a fresh VM to prove the bytes actually landed in ROM.
+                var vm2 = new EDFE6ViewModel();
+                vm2.LoadEntry(addr);
+                Assert.Equal(0x0123u, vm2.Text0Id);
+                Assert.Equal(0x0045u, vm2.Text2Id);
+                Assert.Equal(0x0067u, vm2.Text4Id);
+                Assert.Equal(0x0089u, vm2.Text6Id);
+            }
+            finally
+            {
+                // Restore the in-memory ROM (the on-disk file is never written).
+                vm.Text0Id = orig0;
+                vm.Text2Id = orig2;
+                vm.Text4Id = orig4;
+                vm.Text6Id = orig6;
+                vm.WriteEntry();
+            }
+        });
     }
 
     [Fact]
-    public void WriteEntry_RoundTripsAllFourFields()
+    public void LoadEntry_InvalidSelection_ClearsFieldsAndStaysUnloaded()
     {
-        if (Skip()) return;
-
-        var vm = new EDFE6ViewModel();
-        var list = vm.LoadList();
-        Assert.NotEmpty(list);
-
-        uint addr = list[0].addr;
-        vm.LoadEntry(addr);
-
-        uint orig0 = vm.Text0Id, orig2 = vm.Text2Id, orig4 = vm.Text4Id, orig6 = vm.Text6Id;
-        try
+        RomTestHelper.WithRom("FE6", () =>
         {
-            vm.Text0Id = 0x0123;
-            vm.Text2Id = 0x0045;
-            vm.Text4Id = 0x0067;
-            vm.Text6Id = 0x0089;
-            Assert.True(vm.WriteEntry());
+            var vm = new EDFE6ViewModel();
+            var list = vm.LoadList();
+            Assert.NotEmpty(list);
 
-            // Re-read with a fresh VM to prove the bytes actually landed in ROM.
-            var vm2 = new EDFE6ViewModel();
-            vm2.LoadEntry(addr);
-            Assert.Equal(0x0123u, vm2.Text0Id);
-            Assert.Equal(0x0045u, vm2.Text2Id);
-            Assert.Equal(0x0067u, vm2.Text4Id);
-            Assert.Equal(0x0089u, vm2.Text6Id);
-        }
-        finally
-        {
-            // Restore the shared fixture ROM byte-for-byte.
-            vm.Text0Id = orig0;
-            vm.Text2Id = orig2;
-            vm.Text4Id = orig4;
-            vm.Text6Id = orig6;
-            vm.WriteEntry();
-        }
+            // First load a real entry so the fields are non-zero / loaded...
+            vm.LoadEntry(list[0].addr);
+            // ...then select an invalid (zero) address.
+            vm.LoadEntry(0);
+
+            Assert.False(vm.IsLoaded);
+            Assert.Equal(0u, vm.Text0Id);
+            Assert.Equal(0u, vm.Text2Id);
+            Assert.Equal(0u, vm.Text4Id);
+            Assert.Equal(0u, vm.Text6Id);
+        });
     }
 
     [Fact]
-    public void WriteEntry_WithoutSelection_DoesNotMutate()
+    public void NonFe6Rom_ListEmpty_AndWriteRefused()
     {
-        // No ROM dependency: a VM that never loaded an entry has CurrentAddr == 0.
-        var vm = new EDFE6ViewModel();
-        Assert.False(vm.WriteEntry());
+        // The FE6 gate must prevent any list/read/write on a non-FE6 ROM, where
+        // ed_3a holds a differently-structured ED/epilogue table.
+        RomTestHelper.WithRom("FE8U", () =>
+        {
+            var vm = new EDFE6ViewModel();
+
+            Assert.Empty(vm.LoadList());
+
+            uint epilogueBase = CoreState.ROM.p32(CoreState.ROM.RomInfo.ed_3a_pointer);
+            vm.LoadEntry(epilogueBase);
+            Assert.False(vm.IsLoaded);          // invalid selection on non-FE6
+            Assert.False(vm.WriteEntry());      // gate refuses mutation
+        });
     }
 }

--- a/FEBuilderGBA.Avalonia/ViewModels/EDFE6ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EDFE6ViewModel.cs
@@ -8,11 +8,18 @@ namespace FEBuilderGBA.Avalonia.ViewModels
     /// The table lives at <c>p32(RomInfo.ed_3a_pointer)</c>, 8 bytes per entry,
     /// at most 0x42 entries. Each entry holds four u16 text-IDs at offsets +0/+2/+4/+6
     /// (the post-game "after story" ending text slots).
+    ///
+    /// FE6-ONLY: on FE7/FE8 the same <c>ed_3a_pointer</c> addresses an ED/epilogue table
+    /// with a DIFFERENT schema (flag/uid/uid/flag + u32 text-id — see the sibling
+    /// <c>EDFE7ViewModel</c> Epilogue tab and Core's <c>{4}</c> ED text-id scan). Reading,
+    /// and especially writing, this table as 4×u16 on a non-FE6 ROM would corrupt unrelated
+    /// data, so every list/read/write path is gated to <c>RomInfo.version == 6</c>.
     /// </summary>
     public class EDFE6ViewModel : ViewModelBase
     {
         public const uint EntrySize = 8;
         public const uint MaxCount = 0x42;
+        const int FE6Version = 6;
 
         uint _currentAddr;
         bool _isLoaded;
@@ -38,56 +45,72 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             catch { return "???"; }
         }
 
+        /// <summary>True only for an FE6 ROM — the only version whose ed_3a uses the 4×u16 schema.</summary>
+        static bool IsFe6(ROM rom) => rom?.RomInfo != null && rom.RomInfo.version == FE6Version;
+
         /// <summary>List every ending entry. Label mirrors WinForms: hex index + unit name.</summary>
         public List<AddrResult> LoadList()
         {
             var result = new List<AddrResult>();
             ROM rom = CoreState.ROM;
-            if (rom?.RomInfo == null) return result;
+            if (!IsFe6(rom)) return result;
 
             uint ptr = rom.RomInfo.ed_3a_pointer;
             if (ptr == 0) return result;
 
             uint baseAddr = rom.p32(ptr);
-            if (!U.isSafetyOffset(baseAddr)) return result;
+            if (!U.isSafetyOffset(baseAddr, rom)) return result;
 
             for (uint i = 0; i < MaxCount; i++)
             {
                 uint addr = baseAddr + i * EntrySize;
-                if (!U.isSafetyOffset(addr + EntrySize - 1)) break;
+                if (!U.isSafetyOffset(addr + EntrySize - 1, rom)) break;
                 string label = U.ToHexString(i) + " " + NameResolver.GetUnitName(i);
                 result.Add(new AddrResult(addr, label, i));
             }
             return result;
         }
 
-        /// <summary>Read the four u16 text-IDs for the selected entry into the editable fields.</summary>
+        /// <summary>
+        /// Read the four u16 text-IDs for the selected entry into the editable fields.
+        /// On an invalid selection (no ROM / non-FE6 / addr 0 / unsafe) the fields are
+        /// cleared and <see cref="IsLoaded"/> stays false so the Write button is disabled
+        /// and no stale IDs/previews linger.
+        /// </summary>
         public void LoadEntry(uint addr)
         {
             ROM rom = CoreState.ROM;
             if (rom == null) return;
 
             CurrentAddr = addr;
-            if (addr != 0 && U.isSafetyOffset(addr + EntrySize - 1))
+            if (addr != 0 && IsFe6(rom) && U.isSafetyOffset(addr + EntrySize - 1, rom))
             {
                 Text0Id = rom.u16(addr + 0);
                 Text2Id = rom.u16(addr + 2);
                 Text4Id = rom.u16(addr + 4);
                 Text6Id = rom.u16(addr + 6);
+                IsLoaded = true;
             }
-            IsLoaded = true;
+            else
+            {
+                Text0Id = 0;
+                Text2Id = 0;
+                Text4Id = 0;
+                Text6Id = 0;
+                IsLoaded = false;
+            }
         }
 
         /// <summary>
         /// Write the four u16 text-IDs back to ROM via the direct <c>write_u16</c> overload —
         /// the caller wraps this in <c>UndoService.Begin/Commit</c> for undo support.
-        /// Returns false (no mutation) when there is no ROM or the address is unsafe.
+        /// Returns false (no mutation) when there is no FE6 ROM or the address is unsafe.
         /// </summary>
         public bool WriteEntry()
         {
             ROM rom = CoreState.ROM;
-            if (rom == null || CurrentAddr == 0) return false;
-            if (!U.isSafetyOffset(CurrentAddr + EntrySize - 1)) return false;
+            if (!IsFe6(rom) || CurrentAddr == 0) return false;
+            if (!U.isSafetyOffset(CurrentAddr + EntrySize - 1, rom)) return false;
 
             rom.write_u16(CurrentAddr + 0, Text0Id);
             rom.write_u16(CurrentAddr + 2, Text2Id);

--- a/FEBuilderGBA.Avalonia/ViewModels/EDFE6ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EDFE6ViewModel.cs
@@ -3,31 +3,97 @@ using System.Collections.Generic;
 
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
+    /// <summary>
+    /// View-model for the "Ending (FE6)" editor — port of WinForms <c>EDFE6Form</c>.
+    /// The table lives at <c>p32(RomInfo.ed_3a_pointer)</c>, 8 bytes per entry,
+    /// at most 0x42 entries. Each entry holds four u16 text-IDs at offsets +0/+2/+4/+6
+    /// (the post-game "after story" ending text slots).
+    /// </summary>
     public class EDFE6ViewModel : ViewModelBase
     {
+        public const uint EntrySize = 8;
+        public const uint MaxCount = 0x42;
+
         uint _currentAddr;
         bool _isLoaded;
+        uint _text0Id, _text2Id, _text4Id, _text6Id;
 
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
 
+        public uint Text0Id { get => _text0Id; set { if (SetField(ref _text0Id, value)) OnPropertyChanged(nameof(Text0Preview)); } }
+        public uint Text2Id { get => _text2Id; set { if (SetField(ref _text2Id, value)) OnPropertyChanged(nameof(Text2Preview)); } }
+        public uint Text4Id { get => _text4Id; set { if (SetField(ref _text4Id, value)) OnPropertyChanged(nameof(Text4Preview)); } }
+        public uint Text6Id { get => _text6Id; set { if (SetField(ref _text6Id, value)) OnPropertyChanged(nameof(Text6Preview)); } }
+
+        public string Text0Preview => ResolveText(_text0Id);
+        public string Text2Preview => ResolveText(_text2Id);
+        public string Text4Preview => ResolveText(_text4Id);
+        public string Text6Preview => ResolveText(_text6Id);
+
+        static string ResolveText(uint id)
+        {
+            if (id == 0) return "(none)";
+            try { return NameResolver.GetTextById(id); }
+            catch { return "???"; }
+        }
+
+        /// <summary>List every ending entry. Label mirrors WinForms: hex index + unit name.</summary>
         public List<AddrResult> LoadList()
         {
-            ROM rom = CoreState.ROM;
-            if (rom?.RomInfo == null) return new List<AddrResult>();
-
             var result = new List<AddrResult>();
-            result.Add(new AddrResult(0, "ED (FE6)", 0));
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return result;
+
+            uint ptr = rom.RomInfo.ed_3a_pointer;
+            if (ptr == 0) return result;
+
+            uint baseAddr = rom.p32(ptr);
+            if (!U.isSafetyOffset(baseAddr)) return result;
+
+            for (uint i = 0; i < MaxCount; i++)
+            {
+                uint addr = baseAddr + i * EntrySize;
+                if (!U.isSafetyOffset(addr + EntrySize - 1)) break;
+                string label = U.ToHexString(i) + " " + NameResolver.GetUnitName(i);
+                result.Add(new AddrResult(addr, label, i));
+            }
             return result;
         }
 
+        /// <summary>Read the four u16 text-IDs for the selected entry into the editable fields.</summary>
         public void LoadEntry(uint addr)
         {
             ROM rom = CoreState.ROM;
             if (rom == null) return;
 
             CurrentAddr = addr;
+            if (addr != 0 && U.isSafetyOffset(addr + EntrySize - 1))
+            {
+                Text0Id = rom.u16(addr + 0);
+                Text2Id = rom.u16(addr + 2);
+                Text4Id = rom.u16(addr + 4);
+                Text6Id = rom.u16(addr + 6);
+            }
             IsLoaded = true;
+        }
+
+        /// <summary>
+        /// Write the four u16 text-IDs back to ROM via the direct <c>write_u16</c> overload —
+        /// the caller wraps this in <c>UndoService.Begin/Commit</c> for undo support.
+        /// Returns false (no mutation) when there is no ROM or the address is unsafe.
+        /// </summary>
+        public bool WriteEntry()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null || CurrentAddr == 0) return false;
+            if (!U.isSafetyOffset(CurrentAddr + EntrySize - 1)) return false;
+
+            rom.write_u16(CurrentAddr + 0, Text0Id);
+            rom.write_u16(CurrentAddr + 2, Text2Id);
+            rom.write_u16(CurrentAddr + 4, Text4Id);
+            rom.write_u16(CurrentAddr + 6, Text6Id);
+            return true;
         }
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/EDFE6View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EDFE6View.axaml
@@ -2,19 +2,47 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
         x:Class="FEBuilderGBA.Avalonia.Views.EDFE6View"
-        Title="ED (FE6)" Width="1204" Height="885"
+        Title="Ending (FE6)" Width="1204" Height="885"
         SizeToContent="WidthAndHeight">
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="EDFE6_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
 
     <ScrollViewer Grid.Column="1" Margin="4">
       <StackPanel Spacing="8" Margin="8">
-        <TextBlock Text="ED (FE6)" FontSize="18" FontWeight="Bold" />
+        <TextBlock Text="Ending (FE6)" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="EDFE6_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+        <Grid ColumnDefinitions="120,140,*"
+              RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EDFE6_Addr_Label" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Name="AddrLabel" VerticalAlignment="Center" Margin="0,4" />
+
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="Text 1:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EDFE6_Text0Id_Input" Grid.Row="1" Grid.Column="1" Name="Text0IdBox"
+                         Minimum="0" Maximum="65535" Increment="1" FormatString="0" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EDFE6_Text0_Preview_Label" Grid.Row="1" Grid.Column="2" Name="Text0Preview"
+                     VerticalAlignment="Center" TextWrapping="Wrap" Margin="8,4" />
+
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Text 2:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EDFE6_Text2Id_Input" Grid.Row="2" Grid.Column="1" Name="Text2IdBox"
+                         Minimum="0" Maximum="65535" Increment="1" FormatString="0" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EDFE6_Text2_Preview_Label" Grid.Row="2" Grid.Column="2" Name="Text2Preview"
+                     VerticalAlignment="Center" TextWrapping="Wrap" Margin="8,4" />
+
+          <TextBlock Grid.Row="3" Grid.Column="0" Text="Text 3:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EDFE6_Text4Id_Input" Grid.Row="3" Grid.Column="1" Name="Text4IdBox"
+                         Minimum="0" Maximum="65535" Increment="1" FormatString="0" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EDFE6_Text4_Preview_Label" Grid.Row="3" Grid.Column="2" Name="Text4Preview"
+                     VerticalAlignment="Center" TextWrapping="Wrap" Margin="8,4" />
+
+          <TextBlock Grid.Row="4" Grid.Column="0" Text="Text 4:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EDFE6_Text6Id_Input" Grid.Row="4" Grid.Column="1" Name="Text6IdBox"
+                         Minimum="0" Maximum="65535" Increment="1" FormatString="0" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EDFE6_Text6_Preview_Label" Grid.Row="4" Grid.Column="2" Name="Text6Preview"
+                     VerticalAlignment="Center" TextWrapping="Wrap" Margin="8,4" />
         </Grid>
+
+        <Button AutomationProperties.AutomationId="EDFE6_Write_Button" Name="WriteButton"
+                Content="Write" Click="Write_Click" HorizontalAlignment="Left" Margin="0,8" />
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/EDFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EDFE6View.axaml.cs
@@ -38,7 +38,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EDFE6View.LoadList failed: " + ex.Message);
+                Log.Error("EDFE6View.LoadList failed: " + ex.ToString());
             }
         }
 
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EDFE6View.OnSelected failed: " + ex.Message);
+                Log.Error("EDFE6View.OnSelected failed: " + ex.ToString());
             }
         }
 
@@ -100,7 +100,8 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EDFE6View.Write_Click failed: " + ex.Message);
+                _undoService.Rollback();
+                Log.Error("EDFE6View.Write_Click failed: " + ex.ToString());
             }
 
             UpdateUI();

--- a/FEBuilderGBA.Avalonia/Views/EDFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EDFE6View.axaml.cs
@@ -9,14 +9,23 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class EDFE6View : TranslatedWindow, IEditorView
     {
         readonly EDFE6ViewModel _vm = new();
+        readonly UndoService _undoService = new();
+        bool _loading;
 
-        public string ViewTitle => "ED (FE6)";
+        public string ViewTitle => "Ending (FE6)";
         public bool IsLoaded => _vm.IsLoaded;
 
         public EDFE6View()
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
+
+            // Live text preview as the user edits each text-ID (no ROM write until "Write").
+            Text0IdBox.ValueChanged += (_, _) => OnIdEdited(Text0IdBox, id => _vm.Text0Id = id, Text0Preview, () => _vm.Text0Preview);
+            Text2IdBox.ValueChanged += (_, _) => OnIdEdited(Text2IdBox, id => _vm.Text2Id = id, Text2Preview, () => _vm.Text2Preview);
+            Text4IdBox.ValueChanged += (_, _) => OnIdEdited(Text4IdBox, id => _vm.Text4Id = id, Text4Preview, () => _vm.Text4Preview);
+            Text6IdBox.ValueChanged += (_, _) => OnIdEdited(Text6IdBox, id => _vm.Text6Id = id, Text6Preview, () => _vm.Text6Preview);
+
             Opened += (_, _) => LoadList();
         }
 
@@ -29,7 +38,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EDFE6View.LoadList failed: {0}", ex.Message);
+                Log.Error("EDFE6View.LoadList failed: " + ex.Message);
             }
         }
 
@@ -42,13 +51,59 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EDFE6View.OnSelected failed: {0}", ex.Message);
+                Log.Error("EDFE6View.OnSelected failed: " + ex.Message);
             }
+        }
+
+        void OnIdEdited(NumericUpDown box, Action<uint> setId, TextBlock preview, Func<string> getPreview)
+        {
+            if (_loading) return;
+            setId((uint)(box.Value ?? 0));
+            preview.Text = getPreview();
         }
 
         void UpdateUI()
         {
-            AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            _loading = true;
+            try
+            {
+                AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+                Text0IdBox.Value = _vm.Text0Id;
+                Text2IdBox.Value = _vm.Text2Id;
+                Text4IdBox.Value = _vm.Text4Id;
+                Text6IdBox.Value = _vm.Text6Id;
+                Text0Preview.Text = _vm.Text0Preview;
+                Text2Preview.Text = _vm.Text2Preview;
+                Text4Preview.Text = _vm.Text4Preview;
+                Text6Preview.Text = _vm.Text6Preview;
+            }
+            finally
+            {
+                _loading = false;
+            }
+        }
+
+        void Write_Click(object? sender, RoutedEventArgs e)
+        {
+            if (!_vm.IsLoaded) return;
+
+            _vm.Text0Id = (uint)(Text0IdBox.Value ?? 0);
+            _vm.Text2Id = (uint)(Text2IdBox.Value ?? 0);
+            _vm.Text4Id = (uint)(Text4IdBox.Value ?? 0);
+            _vm.Text6Id = (uint)(Text6IdBox.Value ?? 0);
+
+            _undoService.Begin(R._("Edit Ending Text"));
+            try
+            {
+                _vm.WriteEntry();
+                _undoService.Commit();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("EDFE6View.Write_Click failed: " + ex.Message);
+            }
+
+            UpdateUI();
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20164,3 +20164,21 @@ Talk groups are available on FE7 / FE8 only.
 
 :Talk Group
 Talk Group
+
+:Ending (FE6)
+Ending (FE6)
+
+:Text 1:
+Text 1:
+
+:Text 2:
+Text 2:
+
+:Text 3:
+Text 3:
+
+:Text 4:
+Text 4:
+
+:Edit Ending Text
+Edit Ending Text

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -10983,3 +10983,21 @@ UPSパッチを保存
 
 :Talk Group
 会話グループ
+
+:Ending (FE6)
+エンディング (FE6)
+
+:Text 1:
+テキスト1:
+
+:Text 2:
+テキスト2:
+
+:Text 3:
+テキスト3:
+
+:Text 4:
+テキスト4:
+
+:Edit Ending Text
+エンディングテキストの編集

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -24821,3 +24821,21 @@ A: 不使用 TSA 的背景 224 色(对话用)
 
 :Talk Group
 会话组
+
+:Ending (FE6)
+结局 (FE6)
+
+:Text 1:
+文本1:
+
+:Text 2:
+文本2:
+
+:Text 3:
+文本3:
+
+:Text 4:
+文本4:
+
+:Edit Ending Text
+编辑结局文本


### PR DESCRIPTION
Fixes #1198

## What

Replaces the `EDFE6View` scaffold/stub with a **functional Avalonia "Ending (FE6)" editor** with parity to WinForms `EDFE6Form` — the FE6 post-game "after story" ending-text editor.

## Implementation

- **`EDFE6ViewModel`** — lists every ending entry over `p32(RomInfo.ed_3a_pointer)`, 8-byte records, capped at `0x42` (mirrors the WinForms `InputFormRef` `i >= 0x42` cond). List label = `U.ToHexString(i) + " " + unit name` (WF parity). `LoadEntry` reads the four `u16` text-IDs at `+0/+2/+4/+6`; `WriteEntry` writes them back via `write_u16`.
- **`EDFE6View`** — address list (with unit portraits) + four editable text-ID fields, each with a **live `NameResolver.GetTextById` preview**, plus a **Write** button. The code-behind wraps `WriteEntry` in `UndoService.Begin/Commit` so edits are undoable. Already wired into the editor registry.

## Correctness note (base address)

The table base is `p32(ed_3a_pointer)` (**not** the raw pointer `0x91834`). Verified against:
- WinForms `InputFormRef.Init` → `BaseAddress = ROM.p32(BasePointer)`, and
- the sibling `EDFE7View` Epilogue tab, whose `LoadListInternal` also `p32`s `ed_3a_pointer`.

FE6's record schema is **4× u16 text-IDs**, which legitimately differs from FE7's epilogue schema (flag/uid/uid/flag + u32 text-id) — the same pointer slot holds differently-structured data per game, which is exactly why WinForms ships separate `EDFE6Form` / `EDFE7Form`.

## Tests

`EDFE6ViewModelTests` (all pass, no skips — ran on the real fixture ROM):
- list geometry (8-byte stride, `count <= 0x42`),
- per-field read,
- full 4-field **write → read round-trip** (restores the shared fixture ROM byte-for-byte),
- no-selection no-mutation guard.

Gates: global L10n coverage (`AvaloniaViews_HaveJaAndZhTranslations`) ✓, AutomationId validation ✓, 522-test view sweep ✓. New UI literals localized in en/ja/zh.

## Screenshot (real GUI, `roms/FE6.gba`)

Headless `RenderTargetBitmap` capture of the actual editor loaded with FE6:

![Ending (FE6) editor](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1198-edfe6-fe6.png)

The list shows real FE6 ending entries with portraits + names (`01 ロイ`/Roy, `02 クラリーネ`/Clarine, …); `Address: 0x0068BFCC` confirms the `p32` dereference (the raw pointer is `0x91834`). The selected row is entry `00`, whose four text-IDs are genuinely all-zero in the ROM (`0x68BFCC = 00 00 00 00 00 00 00 00` — an empty placeholder); selecting any unit row (e.g. Roy at `0x68BFD4 = C9 09 00 00 04 0A 39 0A`) populates the four text-ID fields with that ending's text, previewed live.

---
🔎 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.169` · model `claude-opus-4-8[1m]`