### PR TITLE
feat(avalonia): implement Unit Action Pointer editor — port WinForms UnitActionPointerForm (#1173)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/UnitActionPointerViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/UnitActionPointerViewModelTests.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+/// <summary>
+/// Headless ROM-backed tests for <see cref="UnitActionPointerViewModel"/> (issue #1198 wave-2 #1173 —
+/// port of WinForms <c>UnitActionPointerForm</c>). The table is the per-unit action/behavior
+/// function-pointer table at <c>p32(RomInfo.unitaction_function_pointer)</c>, 4 bytes per entry
+/// (a single GBA pointer). The editor exposes that pointer (P0) for read/write plus a resolved
+/// action-name label.
+/// </summary>
+[Collection("SharedState")]
+public class UnitActionPointerViewModelTests : IClassFixture<RomFixture>
+{
+    private readonly RomFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public UnitActionPointerViewModelTests(RomFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    bool Skip()
+    {
+        if (!_fixture.IsAvailable)
+        {
+            _output.WriteLine("RomFixture not available — skipping ROM-backed assertions.");
+            return true;
+        }
+        return false;
+    }
+
+    [Fact]
+    public void LoadList_ReturnsEntries_FourBytesApart()
+    {
+        if (Skip()) return;
+
+        var vm = new UnitActionPointerViewModel();
+        List<AddrResult> list = vm.LoadList();
+
+        Assert.NotEmpty(list);
+        for (int i = 1; i < list.Count; i++)
+        {
+            Assert.Equal(list[i - 1].addr + 4, list[i].addr);
+        }
+        // Count helper agrees with the list it builds.
+        Assert.Equal(list.Count, vm.GetListCount());
+    }
+
+    [Fact]
+    public void LoadEntry_ReadsFunctionPointer_AndActionId()
+    {
+        if (Skip()) return;
+
+        var vm = new UnitActionPointerViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        uint addr = list[0].addr;
+        vm.LoadEntry(addr);
+
+        Assert.True(vm.IsLoaded);
+        Assert.Equal(addr, vm.CurrentAddr);
+        // P0 is the dereferenced function pointer (0x08 prefix stripped).
+        Assert.Equal(CoreState.ROM.p32(addr), vm.P0);
+        // First row is action id 1 (WinForms non-rework ids start at 1).
+        Assert.Equal(1u, vm.ActionId);
+    }
+
+    [Fact]
+    public void WriteEntry_RoundTripsFunctionPointer()
+    {
+        if (Skip()) return;
+
+        var vm = new UnitActionPointerViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        uint addr = list[0].addr;
+        vm.LoadEntry(addr);
+        uint orig = vm.P0;
+
+        try
+        {
+            vm.P0 = 0x1234;
+            vm.WriteEntry();
+
+            var vm2 = new UnitActionPointerViewModel();
+            vm2.LoadEntry(addr);
+            Assert.Equal(0x1234u, vm2.P0);
+        }
+        finally
+        {
+            vm.P0 = orig;
+            vm.WriteEntry();
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/UnitActionPointerViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/UnitActionPointerViewModelTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using FEBuilderGBA;
 using FEBuilderGBA.Avalonia.ViewModels;
 using Xunit;
 using Xunit.Abstractions;
@@ -6,7 +7,7 @@ using Xunit.Abstractions;
 namespace FEBuilderGBA.Avalonia.Tests;
 
 /// <summary>
-/// Headless ROM-backed tests for <see cref="UnitActionPointerViewModel"/> (issue #1198 wave-2 #1173 —
+/// Headless ROM-backed tests for <see cref="UnitActionPointerViewModel"/> (issue #1173 —
 /// port of WinForms <c>UnitActionPointerForm</c>). The table is the per-unit action/behavior
 /// function-pointer table at <c>p32(RomInfo.unitaction_function_pointer)</c>, 4 bytes per entry
 /// (a single GBA pointer). The editor exposes that pointer (P0) for read/write plus a resolved

--- a/FEBuilderGBA.Avalonia/ViewModels/UnitActionPointerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/UnitActionPointerViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using FEBuilderGBA.Avalonia.Services;
@@ -20,10 +21,18 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         uint _currentAddr;
         bool _isLoaded;
         uint _p0;
+        uint _actionId;
+        string _actionName = "";
 
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
         public uint P0 { get => _p0; set => SetField(ref _p0, value); }
+
+        /// <summary>1-based action id of the selected entry (WinForms: non-rework ids start at 1).</summary>
+        public uint ActionId { get => _actionId; set => SetField(ref _actionId, value); }
+
+        /// <summary>Human-readable action name from the <c>unitaction_</c> resource (empty if none).</summary>
+        public string ActionName { get => _actionName; set => SetField(ref _actionName, value); }
 
         /// <summary>
         /// Resolve the base address of the unit action pointer table.
@@ -46,6 +55,8 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             uint baseAddr = ResolveBaseAddress(rom);
             if (baseAddr == 0) return new List<AddrResult>();
 
+            var actionNames = LoadActionNames();
+
             return EditorFormRef.BuildListWithCount(rom, baseAddr, EntrySize,
                 (i, addr) =>
                 {
@@ -54,9 +65,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 },
                 (i, addr) =>
                 {
-                    // WinForms starts at id=1 for non-reworked; we use 0-based index here
+                    // WinForms starts at id=1 for non-reworked; we use 0-based index here.
                     uint id = (uint)(i + 1);
-                    return $"{U.ToHexString(id)} Action {id}";
+                    return MakeLabel(id, actionNames);
                 });
         }
 
@@ -68,7 +79,29 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             CurrentAddr = addr;
             var values = EditorFormRef.ReadFields(rom, addr, _fields);
             P0 = values["P0"];
+
+            // Recover the 1-based action id from the offset within the table and resolve its name.
+            uint baseAddr = ResolveBaseAddress(rom);
+            ActionId = (baseAddr != 0 && addr >= baseAddr) ? (addr - baseAddr) / EntrySize + 1 : 0;
+            ActionName = ActionId != 0 ? U.at(LoadActionNames(), ActionId) : "";
+
             IsLoaded = true;
+        }
+
+        /// <summary>Load the version-specific unit-action name dictionary (empty on any failure).</summary>
+        static Dictionary<uint, string> LoadActionNames()
+        {
+            try { return U.LoadDicResource(U.ConfigDataFilename("unitaction_")); }
+            catch { return new Dictionary<uint, string>(); }
+        }
+
+        /// <summary>List label mirroring WinForms: hex id + action name (falls back to "Action N").</summary>
+        static string MakeLabel(uint id, Dictionary<uint, string> actionNames)
+        {
+            string name = U.at(actionNames, id);
+            return string.IsNullOrEmpty(name)
+                ? U.ToHexString(id) + " Action " + id
+                : U.ToHexString(id) + " " + name;
         }
 
         public void WriteEntry()

--- a/FEBuilderGBA.Avalonia/ViewModels/UnitActionPointerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/UnitActionPointerViewModel.cs
@@ -83,7 +83,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             // Recover the 1-based action id from the offset within the table and resolve its name.
             uint baseAddr = ResolveBaseAddress(rom);
             ActionId = (baseAddr != 0 && addr >= baseAddr) ? (addr - baseAddr) / EntrySize + 1 : 0;
-            ActionName = ActionId != 0 ? U.at(LoadActionNames(), ActionId) : "";
+            ActionName = ActionId != 0 ? ResolveActionName(ActionId, LoadActionNames()) : "";
 
             IsLoaded = true;
         }
@@ -95,14 +95,17 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             catch { return new Dictionary<uint, string>(); }
         }
 
-        /// <summary>List label mirroring WinForms: hex id + action name (falls back to "Action N").</summary>
-        static string MakeLabel(uint id, Dictionary<uint, string> actionNames)
+        /// <summary>Action name from the resource, falling back to "Action N" when unnamed —
+        /// shared by the list label and the detail panel so both stay consistent.</summary>
+        static string ResolveActionName(uint id, Dictionary<uint, string> actionNames)
         {
             string name = U.at(actionNames, id);
-            return string.IsNullOrEmpty(name)
-                ? U.ToHexString(id) + " Action " + id
-                : U.ToHexString(id) + " " + name;
+            return string.IsNullOrEmpty(name) ? "Action " + id : name;
         }
+
+        /// <summary>List label mirroring WinForms: hex id + action name (falls back to "Action N").</summary>
+        static string MakeLabel(uint id, Dictionary<uint, string> actionNames)
+            => U.ToHexString(id) + " " + ResolveActionName(id, actionNames);
 
         public void WriteEntry()
         {

--- a/FEBuilderGBA.Avalonia/Views/UnitActionPointerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/UnitActionPointerView.axaml
@@ -11,10 +11,20 @@
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Unit Action Pointers" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="UnitActionPointer_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+        <Grid ColumnDefinitions="160,260" RowDefinitions="Auto,Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="UnitActionPointer_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" Margin="0,4" />
+
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="Action:" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="UnitActionPointer_Action_Label" Grid.Row="1" Grid.Column="1" Name="ActionLabel" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,4" />
+
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Function Pointer:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="UnitActionPointer_P0_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="P0Box" Minimum="0" Maximum="4294967295" Increment="1" Margin="0,4" />
         </Grid>
+
+        <TextBlock Text="The function routine that runs when a unit performs this action." TextWrapping="Wrap" Foreground="Gray" Margin="0,8" />
+
+        <Button AutomationProperties.AutomationId="UnitActionPointer_Write_Button" Name="WriteButton" Content="Write" HorizontalAlignment="Left" Margin="0,8" />
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/UnitActionPointerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/UnitActionPointerView.axaml.cs
@@ -9,6 +9,7 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class UnitActionPointerView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly UnitActionPointerViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         public string ViewTitle => "Unit Action Pointers";
         public bool IsLoaded => _vm.IsLoaded;
@@ -17,6 +18,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
+            WriteButton.Click += OnWrite;
             Opened += (_, _) => LoadList();
         }
 
@@ -24,12 +26,18 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                _vm.IsLoading = true;
                 var items = _vm.LoadList();
                 EntryList.SetItems(items);
             }
             catch (Exception ex)
             {
-                Log.Error("UnitActionPointerView.LoadList failed: {0}", ex.Message);
+                Log.Error("UnitActionPointerView.LoadList failed: " + ex.ToString());
+            }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
             }
         }
 
@@ -37,18 +45,45 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                _vm.IsLoading = true;
                 _vm.LoadEntry(addr);
                 UpdateUI();
             }
             catch (Exception ex)
             {
-                Log.Error("UnitActionPointerView.OnSelected failed: {0}", ex.Message);
+                Log.Error("UnitActionPointerView.OnSelected failed: " + ex.ToString());
+            }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
             }
         }
 
         void UpdateUI()
         {
             AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            ActionLabel.Text = _vm.ActionName;
+            P0Box.Value = _vm.P0;
+        }
+
+        void OnWrite(object? sender, RoutedEventArgs e)
+        {
+            if (!_vm.IsLoaded) return;
+
+            _undoService.Begin(R._("Edit Unit Action Pointer"));
+            try
+            {
+                _vm.P0 = (uint)(P0Box.Value ?? 0);
+                _vm.WriteEntry();
+                _undoService.Commit();
+                _vm.MarkClean();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("UnitActionPointerView.OnWrite failed: " + ex.ToString());
+            }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20182,3 +20182,12 @@ Text 4:
 
 :Edit Ending Text
 Edit Ending Text
+
+:Action:
+Action:
+
+:The function routine that runs when a unit performs this action.
+The function routine that runs when a unit performs this action.
+
+:Edit Unit Action Pointer
+Edit Unit Action Pointer

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11001,3 +11001,12 @@ UPSパッチを保存
 
 :Edit Ending Text
 エンディングテキストの編集
+
+:Action:
+アクション:
+
+:The function routine that runs when a unit performs this action.
+ユニットがこのアクションを実行するときに動作する関数ルーチン。
+
+:Edit Unit Action Pointer
+ユニットアクションポインタの編集

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -24839,3 +24839,12 @@ A: 不使用 TSA 的背景 224 色(对话用)
 
 :Edit Ending Text
 编辑结局文本
+
+:Action:
+动作:
+
+:The function routine that runs when a unit performs this action.
+单位执行此动作时运行的函数例程。
+
+:Edit Unit Action Pointer
+编辑单位动作指针


### PR DESCRIPTION
Fixes #1173

## What

Replaces the 21-line address-list scaffold with a **functional Avalonia Unit Action Pointer editor** with parity to WinForms `UnitActionPointerForm` — the per-unit action/behavior function-pointer table (`p32(RomInfo.unitaction_function_pointer)`, 4 bytes/entry).

## Implementation

- **View** — added the function-pointer (`P0`) edit control + a resolved **action-name** label + a **Write** button. Write-back wraps `WriteEntry` in `UndoService.Begin/Commit` with `Rollback` on exception and `ex.ToString()` logging. Kept the window at **1293×863** (asserted by `AvaloniaDialogViewTests`).
- **ViewModel** — the list label now resolves the **real action name** from the version-specific `unitaction_` resource (`U.LoadDicResource(U.ConfigDataFilename("unitaction_"))`), mirroring WinForms (hex id + name, falling back to `Action N`). `LoadEntry` recovers the 1-based `ActionId` from the table offset and exposes `ActionName` for the detail label. The `P0` function-pointer read/write was already present and is retained.

## Tests

`UnitActionPointerViewModelTests` (all pass, no skips — real fixture ROM):
- list geometry (4-byte stride + `GetListCount` parity),
- `P0` (dereferenced function pointer) + `ActionId` read,
- `P0` write → read round-trip (restores the fixture ROM).

Gates green: L10n coverage, AutomationId validation, **field-completeness** + **dialog-dimension** (net9.0-windows), and 1722 Avalonia view/VM/binding sweep tests. New literals localized in en/ja/zh.

## Screenshot (real GUI, `roms/FE8U.gba`)

Headless `RenderTargetBitmap` capture of the actual editor:

![Unit Action Pointer editor](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1173-unitactionptr-fe8u.png)

The list shows real action names resolved from the `unitaction_` resource (`01 Wait`, `02 Combat`, `03 Staff`, `04 Dance`, `06 Steal`, `07 Summon`, `09 Rescue`, `0E Talk`, …); the detail panel shows `Address: 0x00032060`, `Action: Wait`, and the editable `Function Pointer` (`205016`). No path/username leak.

---
🔎 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.169` · model `claude-opus-4-8[1m]`