### PR TITLE
feat(avalonia): implement Command-0x85 Pointer Table editor — port WinForms Command85PointerForm (#1186)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/Command85PointerViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/Command85PointerViewModelTests.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+/// <summary>
+/// Headless ROM-backed tests for <see cref="Command85PointerViewModel"/> (issue #1186 —
+/// port of WinForms <c>Command85PointerForm</c>). The table at
+/// <c>p32(RomInfo.command_85_pointer_table_pointer)</c> holds 4-byte function pointers, one per
+/// battle-animation command code starting at <c>0x19</c>.
+/// </summary>
+[Collection("SharedState")]
+public class Command85PointerViewModelTests : IClassFixture<RomFixture>
+{
+    private readonly RomFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public Command85PointerViewModelTests(RomFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    bool Skip()
+    {
+        if (!_fixture.IsAvailable)
+        {
+            _output.WriteLine("RomFixture not available — skipping ROM-backed assertions.");
+            return true;
+        }
+        return false;
+    }
+
+    [Fact]
+    public void LoadList_ReturnsEntries_FourBytesApart_FirstIdIs0x19()
+    {
+        if (Skip()) return;
+
+        var vm = new Command85PointerViewModel();
+        List<AddrResult> list = vm.LoadList();
+
+        Assert.NotEmpty(list);
+        Assert.Equal(Command85PointerViewModel.FirstCommandId, list[0].tag);
+        for (int i = 1; i < list.Count; i++)
+        {
+            Assert.Equal(list[i - 1].addr + Command85PointerViewModel.EntrySize, list[i].addr);
+        }
+        Assert.Equal(list.Count, vm.GetListCount());
+    }
+
+    [Fact]
+    public void LoadEntry_ReadsPointer_AndCommandId()
+    {
+        if (Skip()) return;
+
+        var vm = new Command85PointerViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        uint addr = list[0].addr;
+        vm.LoadEntry(addr);
+
+        Assert.True(vm.IsLoaded);
+        Assert.Equal(addr, vm.CurrentAddr);
+        Assert.Equal(CoreState.ROM.u32(addr), vm.PointerValue);
+        Assert.Equal(Command85PointerViewModel.FirstCommandId, vm.CommandId);
+    }
+
+    [Fact]
+    public void Write_RoundTripsPointer()
+    {
+        if (Skip()) return;
+
+        var vm = new Command85PointerViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        uint addr = list[0].addr;
+        vm.LoadEntry(addr);
+        uint orig = vm.PointerValue;
+
+        try
+        {
+            vm.PointerValue = 0x08123456;
+            vm.Write();
+
+            var vm2 = new Command85PointerViewModel();
+            vm2.LoadEntry(addr);
+            Assert.Equal(0x08123456u, vm2.PointerValue);
+        }
+        finally
+        {
+            vm.PointerValue = orig;
+            vm.Write();
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/Command85PointerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/Command85PointerViewModel.cs
@@ -1,25 +1,39 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using FEBuilderGBA.Avalonia.Services;
 
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
+    /// <summary>
+    /// Command-0x85 Pointer Table editor — port of WinForms <c>Command85PointerForm</c>.
+    /// The table at <c>p32(RomInfo.command_85_pointer_table_pointer)</c> holds 4-byte function
+    /// pointers, one per battle-animation command code starting at <c>0x19</c> (so list row
+    /// <c>i</c> = command id <c>i + 0x19</c>). Each pointer (D0) is editable; the command name
+    /// comes from the version-specific <c>battleanime_85command_</c> resource.
+    /// </summary>
     public class Command85PointerViewModel : ViewModelBase, IDataVerifiable
     {
         static readonly List<EditorFormRef.FieldDef> _fields =
             EditorFormRef.DetectFields(new[] { "D0" });
 
+        public const uint FirstCommandId = 0x19;
+        public const uint EntrySize = 4;
+
         uint _currentAddr;
         bool _isLoaded;
         uint _pointerValue;
-        string _asmLabel = string.Empty;
+        uint _commandId;
+        string _commandName = string.Empty;
 
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
         /// <summary>Pointer value at the command 0x85 address.</summary>
         public uint PointerValue { get => _pointerValue; set => SetField(ref _pointerValue, value); }
-        /// <summary>ASM label name if the pointer resolves to a known function.</summary>
-        public string AsmLabel { get => _asmLabel; set => SetField(ref _asmLabel, value); }
+        /// <summary>Command id of the selected entry (0x19-based, WinForms convention).</summary>
+        public uint CommandId { get => _commandId; set => SetField(ref _commandId, value); }
+        /// <summary>Human-readable command name from the battleanime_85command_ resource (empty if none).</summary>
+        public string CommandName { get => _commandName; set => SetField(ref _commandName, value); }
 
         public List<AddrResult> LoadList()
         {
@@ -31,17 +45,20 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             uint baseAddr = rom.p32(pointer);
             if (!U.isSafetyOffset(baseAddr, rom)) return new List<AddrResult>();
 
-            const uint blockSize = 4;
+            var commandNames = LoadCommandNames();
+
             var result = new List<AddrResult>();
             for (int i = 0; i < 256; i++)
             {
-                uint addr = baseAddr + (uint)(i * blockSize);
-                if (addr + blockSize > (uint)rom.Data.Length) break;
+                uint addr = baseAddr + (uint)i * EntrySize;
+                if (addr + EntrySize > (uint)rom.Data.Length) break;
                 uint ptr = rom.u32(addr);
+                // Mirror WinForms cond: pointer-or-NULL, NULL allowed, reject sub-0x08000100.
                 if (!U.isPointerOrNULL(ptr)) break;
+                if (ptr != 0 && ptr <= 0x08000100) break;
 
-                string ptrStr = ptr == 0 ? "NULL" : $"0x{ptr:X08}";
-                result.Add(new AddrResult(addr, $"0x{i:X2} {ptrStr}", (uint)i));
+                uint id = (uint)i + FirstCommandId;
+                result.Add(new AddrResult(addr, MakeLabel(id, commandNames), id));
             }
             return result;
         }
@@ -50,10 +67,17 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         {
             ROM rom = CoreState.ROM;
             if (rom == null) return;
-            if (addr + 4 > (uint)rom.Data.Length) return;
+            if (addr + EntrySize > (uint)rom.Data.Length) return;
             CurrentAddr = addr;
             var values = EditorFormRef.ReadFields(rom, addr, _fields);
             PointerValue = values["D0"];
+
+            // Recover the 0x19-based command id from the table offset and resolve its name.
+            uint pointer = rom.RomInfo.command_85_pointer_table_pointer;
+            uint baseAddr = pointer != 0 ? rom.p32(pointer) : 0;
+            CommandId = (baseAddr != 0 && addr >= baseAddr) ? (addr - baseAddr) / EntrySize + FirstCommandId : 0;
+            CommandName = CommandId != 0 ? U.at(LoadCommandNames(), CommandId) : "";
+
             IsLoaded = true;
         }
 
@@ -61,16 +85,31 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         {
             ROM rom = CoreState.ROM;
             if (rom == null || CurrentAddr == 0) return;
-            if (CurrentAddr + 4 > (uint)rom.Data.Length) return;
+            if (CurrentAddr + EntrySize > (uint)rom.Data.Length) return;
             var values = new Dictionary<string, uint> { ["D0"] = PointerValue };
             EditorFormRef.WriteFields(rom, CurrentAddr, values, _fields);
         }
 
         public int GetListCount() => LoadList().Count;
 
+        /// <summary>Load the version-specific command-name dictionary (empty on any failure).</summary>
+        static Dictionary<uint, string> LoadCommandNames()
+        {
+            try { return U.LoadDicResource(U.ConfigDataFilename("battleanime_85command_")); }
+            catch { return new Dictionary<uint, string>(); }
+        }
+
+        /// <summary>List label mirroring WinForms: hex id + "C{id:X02}", plus the command name when known.</summary>
+        static string MakeLabel(uint id, Dictionary<uint, string> commandNames)
+        {
+            string label = U.ToHexString(id) + " C" + id.ToString("X02");
+            string name = U.at(commandNames, id);
+            return string.IsNullOrEmpty(name) ? label : label + " " + name;
+        }
+
         public Dictionary<string, string> GetDataReport()
         {
-            // Note: AsmLabel is a display-only field (not ROM-backed), so it is
+            // Note: CommandName is a display-only field (not ROM-backed), so it is
             // excluded from the report.  Including it as "" would cause the
             // data-verify cross-check to skip the entire record.
             return new Dictionary<string, string>

--- a/FEBuilderGBA.Avalonia/Views/Command85PointerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/Command85PointerView.axaml
@@ -11,10 +11,20 @@
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Command 0x85 Pointer" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="Command85Pointer_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+        <Grid ColumnDefinitions="160,260" RowDefinitions="Auto,Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="Command85Pointer_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" Margin="0,4" />
+
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="Command:" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="Command85Pointer_Command_Label" Grid.Row="1" Grid.Column="1" Name="CommandLabel" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,4" />
+
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Function Pointer:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="Command85Pointer_Pointer_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="PointerBox" Minimum="0" Maximum="4294967295" Increment="1" Margin="0,4" />
         </Grid>
+
+        <TextBlock Text="The function routine called by event command 0x85 for this command code." TextWrapping="Wrap" Foreground="Gray" Margin="0,8" />
+
+        <Button AutomationProperties.AutomationId="Command85Pointer_Write_Button" Name="WriteButton" Content="Write" HorizontalAlignment="Left" Margin="0,8" />
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/Command85PointerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/Command85PointerView.axaml.cs
@@ -9,6 +9,7 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class Command85PointerView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly Command85PointerViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         public string ViewTitle => "Command 0x85 Pointer";
         public bool IsLoaded => _vm.IsLoaded;
@@ -17,6 +18,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
+            WriteButton.Click += OnWrite;
             Opened += (_, _) => LoadList();
         }
 
@@ -24,12 +26,18 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                _vm.IsLoading = true;
                 var items = _vm.LoadList();
                 EntryList.SetItems(items);
             }
             catch (Exception ex)
             {
-                Log.Error("Command85PointerView.LoadList failed: {0}", ex.Message);
+                Log.Error("Command85PointerView.LoadList failed: " + ex.ToString());
+            }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
             }
         }
 
@@ -37,18 +45,45 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                _vm.IsLoading = true;
                 _vm.LoadEntry(addr);
                 UpdateUI();
             }
             catch (Exception ex)
             {
-                Log.Error("Command85PointerView.OnSelected failed: {0}", ex.Message);
+                Log.Error("Command85PointerView.OnSelected failed: " + ex.ToString());
+            }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
             }
         }
 
         void UpdateUI()
         {
             AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            CommandLabel.Text = _vm.CommandName;
+            PointerBox.Value = _vm.PointerValue;
+        }
+
+        void OnWrite(object? sender, RoutedEventArgs e)
+        {
+            if (!_vm.IsLoaded) return;
+
+            _undoService.Begin(R._("Edit Command 0x85 Pointer"));
+            try
+            {
+                _vm.PointerValue = (uint)(PointerBox.Value ?? 0);
+                _vm.Write();
+                _undoService.Commit();
+                _vm.MarkClean();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("Command85PointerView.OnWrite failed: " + ex.ToString());
+            }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20191,3 +20191,9 @@ The function routine that runs when a unit performs this action.
 
 :Edit Unit Action Pointer
 Edit Unit Action Pointer
+
+:The function routine called by event command 0x85 for this command code.
+The function routine called by event command 0x85 for this command code.
+
+:Edit Command 0x85 Pointer
+Edit Command 0x85 Pointer

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11010,3 +11010,9 @@ UPSパッチを保存
 
 :Edit Unit Action Pointer
 ユニットアクションポインタの編集
+
+:The function routine called by event command 0x85 for this command code.
+このコマンドコードに対してイベントコマンド0x85が呼び出す関数ルーチン。
+
+:Edit Command 0x85 Pointer
+コマンド0x85ポインタの編集

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -24848,3 +24848,9 @@ A: 不使用 TSA 的背景 224 色(对话用)
 
 :Edit Unit Action Pointer
 编辑单位动作指针
+
+:The function routine called by event command 0x85 for this command code.
+事件命令0x85针对此命令码调用的函数例程。
+
+:Edit Command 0x85 Pointer
+编辑命令0x85指针


### PR DESCRIPTION
Fixes #1186

## What

Replaces the 21-line address-list scaffold with a **functional Avalonia Command-0x85 Pointer Table editor** with parity to WinForms `Command85PointerForm` — the event-command `0x85` (ASMC / special-call) function-pointer table (`p32(RomInfo.command_85_pointer_table_pointer)`, 4 bytes/entry).

## Implementation

- **View** — added the function-pointer (`D0`) edit control + a resolved **command-name** label + a **Write** button. Write-back wraps `Write` in `UndoService.Begin/Commit` with `Rollback` on exception and `ex.ToString()` logging. Kept the window at 1185×658.
- **ViewModel** — the list label now matches WinForms: row `i` = command id `i + 0x19`, label `C{id:X02}`, plus the command name resolved from the version-specific `battleanime_85command_` resource. The previous stub used the wrong id and showed the raw pointer instead. `LoadEntry` recovers `CommandId`/`CommandName`; the `D0` pointer read/write is retained. Also enforces the WinForms list condition (reject pointers ≤ `0x08000100`).

## Tests

`Command85PointerViewModelTests` (all pass, no skips — real fixture ROM):
- list geometry (4-byte stride + first id `0x19` + `GetListCount` parity),
- pointer + `CommandId` read,
- pointer write → read round-trip (restores the fixture).

Gates green: L10n coverage, AutomationId (script + test), **field-completeness** (net9.0-windows), and 1722 Avalonia view/VM/binding sweep tests. New literals localized in en/ja/zh.

## Screenshot (real GUI, `roms/FE8U.gba`)

![Command 0x85 Pointer editor](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1186-cmd85-fe8u.png)

The list shows the `0x19`-based ids with `C{id:X02}` codes and resolved command names (`19 C19 Play bow pulling SFE`, `1A C1A Normal hit`, `22 C22 Play short sword swing`, …); the detail panel shows `Command: Play bow pulling SFE` and the editable `Function Pointer`. No path/username leak.

---
🔎 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.169` · model `claude-opus-4-8[1m]`