### PR TITLE
feat(avalonia): implement Mini-Map Terrain image editor — port WinForms MapMiniMapTerrainImageForm (#1180)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/MapMiniMapTerrainImageViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/MapMiniMapTerrainImageViewModelTests.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+/// <summary>
+/// Headless ROM-backed tests for <see cref="MapMiniMapTerrainImageViewModel"/> (issue #1180 —
+/// port of WinForms <c>MapMiniMapTerrainImageForm</c>). The table at
+/// <c>p32(RomInfo.map_minimap_tile_array_pointer)</c> holds one 4-byte tile-array pointer per
+/// terrain type (count = <c>map_terrain_type_count</c>), with a named-preset combo from the
+/// <c>map_minimap_tile_array_</c> resource.
+/// </summary>
+[Collection("SharedState")]
+public class MapMiniMapTerrainImageViewModelTests : IClassFixture<RomFixture>
+{
+    private readonly RomFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public MapMiniMapTerrainImageViewModelTests(RomFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    bool Skip()
+    {
+        if (!_fixture.IsAvailable)
+        {
+            _output.WriteLine("RomFixture not available — skipping ROM-backed assertions.");
+            return true;
+        }
+        return false;
+    }
+
+    [Fact]
+    public void LoadList_ReturnsEntries_FourBytesApart_CountMatchesTerrainTypes()
+    {
+        if (Skip()) return;
+
+        var vm = new MapMiniMapTerrainImageViewModel();
+        List<AddrResult> list = vm.LoadList();
+
+        Assert.NotEmpty(list);
+        Assert.Equal((int)CoreState.ROM.RomInfo.map_terrain_type_count, list.Count);
+        Assert.Equal(vm.GetListCount(), list.Count);
+        for (int i = 1; i < list.Count; i++)
+        {
+            Assert.Equal(list[i - 1].addr + MapMiniMapTerrainImageViewModel.EntrySize, list[i].addr);
+        }
+    }
+
+    [Fact]
+    public void LoadEntry_ReadsPointer()
+    {
+        if (Skip()) return;
+
+        var vm = new MapMiniMapTerrainImageViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        uint addr = list[0].addr;
+        vm.LoadEntry(addr);
+
+        Assert.True(vm.IsLoaded);
+        Assert.Equal(addr, vm.CurrentAddr);
+        Assert.Equal(CoreState.ROM.u32(addr), vm.P0);
+    }
+
+    [Fact]
+    public void OptionCombo_LoadsNamedPresets_AndRoundTripsMapping()
+    {
+        if (Skip()) return;
+
+        var vm = new MapMiniMapTerrainImageViewModel();
+        var labels = vm.OptionLabels;
+
+        Assert.NotEmpty(labels);
+
+        // The value→index→value mapping must be consistent.
+        uint v0 = vm.GetOptionValue(0);
+        Assert.Equal(0, vm.GetOptionIndex(v0));
+
+        // Setting P0 to a known preset resolves its name; an unknown value resolves to empty.
+        vm.P0 = v0;
+        Assert.False(string.IsNullOrEmpty(vm.TileArrayName));
+        vm.P0 = 0xDEADBEEF;
+        Assert.Equal("", vm.TileArrayName);
+    }
+
+    [Fact]
+    public void Write_RoundTripsPointer()
+    {
+        if (Skip()) return;
+
+        var vm = new MapMiniMapTerrainImageViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        uint addr = list[0].addr;
+        vm.LoadEntry(addr);
+        uint orig = vm.P0;
+
+        try
+        {
+            vm.P0 = 0x08123456;
+            vm.Write();
+
+            var vm2 = new MapMiniMapTerrainImageViewModel();
+            vm2.LoadEntry(addr);
+            Assert.Equal(0x08123456u, vm2.P0);
+        }
+        finally
+        {
+            vm.P0 = orig;
+            vm.Write();
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/MapMiniMapTerrainImageViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapMiniMapTerrainImageViewModel.cs
@@ -24,8 +24,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         uint _p0;
         string _tileArrayName = string.Empty;
 
-        List<uint> _optionValues;
-        List<string> _optionLabels;
+        List<uint> _optionValues = new();
+        List<string> _optionLabels = new();
+        bool _optionsLoaded;
 
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
@@ -107,19 +108,26 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
         void EnsureOptions()
         {
-            if (_optionLabels != null) return;
-            _optionValues = new List<uint>();
-            _optionLabels = new List<string>();
+            if (_optionsLoaded) return;
+
+            // Without a ROM there is no version to resolve the resource file for — leave the
+            // presets empty (without marking them loaded, so a later call with a ROM retries)
+            // rather than caching a versionless fallback.
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return;
 
             Dictionary<uint, string> dic;
-            try { dic = U.LoadDicResource(U.ConfigDataFilename("map_minimap_tile_array_")); }
+            try { dic = U.LoadDicResource(U.ConfigDataFilename("map_minimap_tile_array_", rom)); }
             catch { dic = new Dictionary<uint, string>(); }
 
+            _optionValues.Clear();
+            _optionLabels.Clear();
             foreach (var kv in dic)
             {
                 _optionValues.Add(kv.Key);
                 _optionLabels.Add(U.ToHexString(kv.Key) + " " + CleanName(kv.Value));
             }
+            _optionsLoaded = true;
         }
 
         string ResolveName(uint value)

--- a/FEBuilderGBA.Avalonia/ViewModels/MapMiniMapTerrainImageViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MapMiniMapTerrainImageViewModel.cs
@@ -1,16 +1,45 @@
+using System;
 using System.Collections.Generic;
 using FEBuilderGBA.Avalonia.Services;
 
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
+    /// <summary>
+    /// Mini-Map Terrain image editor — port of WinForms <c>MapMiniMapTerrainImageForm</c>.
+    /// The table at <c>p32(RomInfo.map_minimap_tile_array_pointer)</c> holds one 4-byte pointer per
+    /// terrain type (count = <c>map_terrain_type_count</c>); each points at the minimap tile-array
+    /// graphic for that terrain. The pointer is editable directly, and a combo offers the known
+    /// named tile arrays from the version-specific <c>map_minimap_tile_array_</c> resource
+    /// (lines of <c>&lt;pointer&gt;=&lt;name&gt;</c>).
+    /// </summary>
     public class MapMiniMapTerrainImageViewModel : ViewModelBase, IDataVerifiable
     {
         static readonly List<EditorFormRef.FieldDef> _fields =
             EditorFormRef.DetectFields(new[] { "D0" });
 
+        public const uint EntrySize = 4;
+
+        uint _currentAddr;
+        bool _isLoaded;
+        uint _p0;
+        string _tileArrayName = string.Empty;
+
+        List<uint> _optionValues;
+        List<string> _optionLabels;
+
+        public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
+        public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
+        /// <summary>The 4-byte tile-array pointer (raw GBA pointer, matching the resource keys).</summary>
+        public uint P0 { get => _p0; set { if (SetField(ref _p0, value)) TileArrayName = ResolveName(value); } }
+        /// <summary>Resolved name of the current pointer from the tile-array resource (empty if custom).</summary>
+        public string TileArrayName { get => _tileArrayName; set => SetField(ref _tileArrayName, value); }
+
+        /// <summary>Combo labels ("0xPOINTER Name") for the known named tile arrays.</summary>
+        public List<string> OptionLabels { get { EnsureOptions(); return _optionLabels; } }
+
         /// <summary>
         /// Load the list of minimap terrain entries from map_minimap_tile_array_pointer.
-        /// Each entry is 4 bytes (a pointer/DWORD), total count = map_terrain_type_count.
+        /// Each entry is 4 bytes (a pointer), total count = map_terrain_type_count.
         /// </summary>
         public List<AddrResult> LoadList()
         {
@@ -24,30 +53,21 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (!U.isSafetyOffset(baseAddr, rom)) return new List<AddrResult>();
 
             int count = (int)rom.RomInfo.map_terrain_type_count;
-            const uint entrySize = 4;
             var result = new List<AddrResult>();
             for (int i = 0; i < count; i++)
             {
-                uint addr = (uint)(baseAddr + i * entrySize);
-                if (addr + entrySize > (uint)rom.Data.Length) break;
+                uint addr = (uint)(baseAddr + i * EntrySize);
+                if (addr + EntrySize > (uint)rom.Data.Length) break;
                 result.Add(new AddrResult(addr, $"0x{i:X02} Terrain {i}", (uint)i));
             }
             return result;
         }
 
-        uint _currentAddr;
-        bool _isLoaded;
-        uint _p0;
-
-        public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
-        public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
-        public uint P0 { get => _p0; set => SetField(ref _p0, value); }
-
         public void LoadEntry(uint addr)
         {
             ROM rom = CoreState.ROM;
             if (rom == null) return;
-            if (addr + 4 > (uint)rom.Data.Length) return;
+            if (addr + EntrySize > (uint)rom.Data.Length) return;
 
             CurrentAddr = addr;
             var values = EditorFormRef.ReadFields(rom, addr, _fields);
@@ -55,11 +75,69 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             IsLoaded = true;
         }
 
+        public void Write()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null || CurrentAddr == 0) return;
+            if (CurrentAddr + EntrySize > (uint)rom.Data.Length) return;
+            var values = new Dictionary<string, uint> { ["D0"] = P0 };
+            EditorFormRef.WriteFields(rom, CurrentAddr, values, _fields);
+        }
+
+        /// <summary>Combo index (-1 if none) whose pointer matches <paramref name="value"/>.</summary>
+        public int GetOptionIndex(uint value)
+        {
+            EnsureOptions();
+            return _optionValues.IndexOf(value);
+        }
+
+        /// <summary>Pointer for combo <paramref name="index"/>, or 0 when out of range.</summary>
+        public uint GetOptionValue(int index)
+        {
+            EnsureOptions();
+            return (index >= 0 && index < _optionValues.Count) ? _optionValues[index] : 0;
+        }
+
         public int GetListCount()
         {
             ROM rom = CoreState.ROM;
             if (rom?.RomInfo == null) return 0;
             return (int)rom.RomInfo.map_terrain_type_count;
+        }
+
+        void EnsureOptions()
+        {
+            if (_optionLabels != null) return;
+            _optionValues = new List<uint>();
+            _optionLabels = new List<string>();
+
+            Dictionary<uint, string> dic;
+            try { dic = U.LoadDicResource(U.ConfigDataFilename("map_minimap_tile_array_")); }
+            catch { dic = new Dictionary<uint, string>(); }
+
+            foreach (var kv in dic)
+            {
+                _optionValues.Add(kv.Key);
+                _optionLabels.Add(U.ToHexString(kv.Key) + " " + CleanName(kv.Value));
+            }
+        }
+
+        string ResolveName(uint value)
+        {
+            EnsureOptions();
+            int i = _optionValues.IndexOf(value);
+            if (i < 0) return "";
+            // OptionLabels[i] is "0xVALUE Name" — return the name portion.
+            int sp = _optionLabels[i].IndexOf(' ');
+            return sp >= 0 ? _optionLabels[i].Substring(sp + 1) : _optionLabels[i];
+        }
+
+        /// <summary>Trim the resource's trailing language/comment annotations (e.g. "Plain\t{J}").</summary>
+        static string CleanName(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return "";
+            var parts = s.Split(new[] { '\t', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            return parts.Length > 0 ? parts[0] : s.Trim();
         }
 
         public Dictionary<string, string> GetDataReport()

--- a/FEBuilderGBA.Avalonia/Views/MapMiniMapTerrainImageView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapMiniMapTerrainImageView.axaml
@@ -11,10 +11,20 @@
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Mini-Map Terrain" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="MapMiniMapTerrainImage_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+        <Grid ColumnDefinitions="160,300" RowDefinitions="Auto,Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="MapMiniMapTerrainImage_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" Margin="0,4" />
+
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="Tile Array:" VerticalAlignment="Center" Margin="0,4" />
+          <ComboBox AutomationProperties.AutomationId="MapMiniMapTerrainImage_TileArray_Combo" Grid.Row="1" Grid.Column="1" Name="TileArrayCombo" HorizontalAlignment="Stretch" Margin="0,4" />
+
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Image Pointer:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="MapMiniMapTerrainImage_Pointer_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="PointerBox" Minimum="0" Maximum="4294967295" Increment="1" Margin="0,4" />
         </Grid>
+
+        <TextBlock Text="Pointer to the minimap tile-array graphic used for this terrain type." TextWrapping="Wrap" Foreground="Gray" Margin="0,8" />
+
+        <Button AutomationProperties.AutomationId="MapMiniMapTerrainImage_Write_Button" Name="WriteButton" Content="Write" HorizontalAlignment="Left" Margin="0,8" />
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/MapMiniMapTerrainImageView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapMiniMapTerrainImageView.axaml.cs
@@ -9,6 +9,8 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class MapMiniMapTerrainImageView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly MapMiniMapTerrainImageViewModel _vm = new();
+        readonly UndoService _undoService = new();
+        bool _loading;
 
         public string ViewTitle => "Mini-Map Terrain";
         public bool IsLoaded => _vm.IsLoaded;
@@ -17,6 +19,9 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
+            WriteButton.Click += OnWrite;
+            TileArrayCombo.ItemsSource = _vm.OptionLabels;
+            TileArrayCombo.SelectionChanged += OnComboChanged;
             Opened += (_, _) => LoadList();
         }
 
@@ -24,12 +29,18 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                _vm.IsLoading = true;
                 var items = _vm.LoadList();
                 EntryList.SetItems(items);
             }
             catch (Exception ex)
             {
-                Log.Error("MapMiniMapTerrainImageView.LoadList failed: {0}", ex.Message);
+                Log.Error("MapMiniMapTerrainImageView.LoadList failed: " + ex.ToString());
+            }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
             }
         }
 
@@ -37,18 +48,64 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                _vm.IsLoading = true;
                 _vm.LoadEntry(addr);
                 UpdateUI();
             }
             catch (Exception ex)
             {
-                Log.Error("MapMiniMapTerrainImageView.OnSelected failed: {0}", ex.Message);
+                Log.Error("MapMiniMapTerrainImageView.OnSelected failed: " + ex.ToString());
+            }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
             }
         }
 
         void UpdateUI()
         {
-            AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            _loading = true;
+            try
+            {
+                AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+                PointerBox.Value = _vm.P0;
+                TileArrayCombo.SelectedIndex = _vm.GetOptionIndex(_vm.P0);
+            }
+            finally
+            {
+                _loading = false;
+            }
+        }
+
+        // Selecting a known tile array sets the pointer field to its value.
+        void OnComboChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_loading) return;
+            int idx = TileArrayCombo.SelectedIndex;
+            if (idx < 0) return;
+            PointerBox.Value = _vm.GetOptionValue(idx);
+        }
+
+        void OnWrite(object? sender, RoutedEventArgs e)
+        {
+            if (!_vm.IsLoaded) return;
+
+            _undoService.Begin(R._("Edit Mini-Map Terrain"));
+            try
+            {
+                _vm.P0 = (uint)(PointerBox.Value ?? 0);
+                _vm.Write();
+                _undoService.Commit();
+                _vm.MarkClean();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("MapMiniMapTerrainImageView.OnWrite failed: " + ex.ToString());
+            }
+
+            UpdateUI();
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/MapMiniMapTerrainImageView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapMiniMapTerrainImageView.axaml.cs
@@ -11,6 +11,7 @@ namespace FEBuilderGBA.Avalonia.Views
         readonly MapMiniMapTerrainImageViewModel _vm = new();
         readonly UndoService _undoService = new();
         bool _loading;
+        bool _syncing;
 
         public string ViewTitle => "Mini-Map Terrain";
         public bool IsLoaded => _vm.IsLoaded;
@@ -22,6 +23,7 @@ namespace FEBuilderGBA.Avalonia.Views
             WriteButton.Click += OnWrite;
             TileArrayCombo.ItemsSource = _vm.OptionLabels;
             TileArrayCombo.SelectionChanged += OnComboChanged;
+            PointerBox.ValueChanged += OnPointerChanged;
             Opened += (_, _) => LoadList();
         }
 
@@ -81,10 +83,21 @@ namespace FEBuilderGBA.Avalonia.Views
         // Selecting a known tile array sets the pointer field to its value.
         void OnComboChanged(object? sender, SelectionChangedEventArgs e)
         {
-            if (_loading) return;
+            if (_loading || _syncing) return;
             int idx = TileArrayCombo.SelectedIndex;
             if (idx < 0) return;
-            PointerBox.Value = _vm.GetOptionValue(idx);
+            _syncing = true;
+            try { PointerBox.Value = _vm.GetOptionValue(idx); }
+            finally { _syncing = false; }
+        }
+
+        // Editing the pointer manually re-selects the matching preset (or clears it).
+        void OnPointerChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            if (_loading || _syncing) return;
+            _syncing = true;
+            try { TileArrayCombo.SelectedIndex = _vm.GetOptionIndex((uint)(PointerBox.Value ?? 0)); }
+            finally { _syncing = false; }
         }
 
         void OnWrite(object? sender, RoutedEventArgs e)

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20197,3 +20197,12 @@ The function routine called by event command 0x85 for this command code.
 
 :Edit Command 0x85 Pointer
 Edit Command 0x85 Pointer
+
+:Tile Array:
+Tile Array:
+
+:Pointer to the minimap tile-array graphic used for this terrain type.
+Pointer to the minimap tile-array graphic used for this terrain type.
+
+:Edit Mini-Map Terrain
+Edit Mini-Map Terrain

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11016,3 +11016,12 @@ UPSパッチを保存
 
 :Edit Command 0x85 Pointer
 コマンド0x85ポインタの編集
+
+:Tile Array:
+タイル配列:
+
+:Pointer to the minimap tile-array graphic used for this terrain type.
+この地形タイプに使用されるミニマップのタイル配列グラフィックへのポインタ。
+
+:Edit Mini-Map Terrain
+ミニマップ地形の編集

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -24854,3 +24854,12 @@ A: 不使用 TSA 的背景 224 色(对话用)
 
 :Edit Command 0x85 Pointer
 编辑命令0x85指针
+
+:Tile Array:
+图块数组:
+
+:Pointer to the minimap tile-array graphic used for this terrain type.
+指向此地形类型所用小地图图块数组图形的指针。
+
+:Edit Mini-Map Terrain
+编辑小地图地形


### PR DESCRIPTION
Fixes #1180

## What

Replaces the 21-line address-list scaffold with a **functional Avalonia Mini-Map Terrain image editor** with parity to WinForms `MapMiniMapTerrainImageForm` — one 4-byte tile-array pointer per terrain type (`p32(RomInfo.map_minimap_tile_array_pointer)`, count = `map_terrain_type_count`).

## Implementation

- **View** — added a **tile-array ComboBox** (named presets) + the image-pointer (`D0`) edit control + a **Write** button. The combo and pointer field stay in sync: selecting a preset sets the pointer; loading an entry selects the matching preset. Write-back wraps `Write` in `UndoService.Begin/Commit` with `Rollback` on exception and `ex.ToString()` logging. Kept the window at 1253×790.
- **ViewModel** — added named-value combo support parsed from the version-specific `map_minimap_tile_array_` resource (`<pointer>=<name>` lines via `U.LoadDicResource`): `OptionLabels` + value↔index mapping + `TileArrayName` resolution, with trailing language/comment annotations (`Plain\t{J}`) trimmed. The `D0` pointer read/write was already present; the list keeps the `Terrain N` label convention used by the sibling terrain editors.

## Tests

`MapMiniMapTerrainImageViewModelTests` (all pass, no skips — real fixture ROM):
- list geometry (4-byte stride + count = `map_terrain_type_count` + `GetListCount` parity),
- pointer read,
- **combo preset round-trip + name resolution** (known pointer → name; unknown → empty),
- pointer write → read round-trip (restores the fixture).

Gates green: L10n coverage, AutomationId (script + test), **field-completeness** (net9.0-windows), and 1720 Avalonia view/VM/binding sweep tests. New literals localized in en/ja/zh.

## Screenshot (real GUI, `roms/FE8U.gba`)

![Mini-Map Terrain editor](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1180-minimap-fe8u.png)

The detail panel shows the **Tile Array combo correctly resolved and selected** (`080A7BF2 Blank` for terrain 0's pointer `134904818` = `0x080A7BF2`) alongside the editable image pointer. No path/username leak.

---
🔎 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.169` · model `claude-opus-4-8[1m]`