### PR TITLE
feat(avalonia): implement World Map Event (FE7) editor — port WinForms WorldMapEventPointerFE7Form (#1182)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/WorldMapEventPointerFE7ViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/WorldMapEventPointerFE7ViewModelTests.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+/// <summary>
+/// Headless ROM-backed tests for <see cref="WorldMapEventPointerFE7ViewModel"/> (issue #1182 —
+/// port of WinForms <c>WorldMapEventPointerFE7Form</c>). The stage-select event table
+/// (<c>p32(worldmap_event_on_stageselect_pointer)</c>, 4-byte event pointers) and the two global
+/// ending-event pointers share the same schema on FE7 and FE8, so the FE8U fixture exercises the
+/// read/write mechanics; the GUI screenshot uses FE7U.
+/// </summary>
+[Collection("SharedState")]
+public class WorldMapEventPointerFE7ViewModelTests : IClassFixture<RomFixture>
+{
+    private readonly RomFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public WorldMapEventPointerFE7ViewModelTests(RomFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    bool Skip()
+    {
+        if (!_fixture.IsAvailable || CoreState.ROM?.RomInfo == null
+            || CoreState.ROM.RomInfo.worldmap_event_on_stageselect_pointer == 0)
+        {
+            _output.WriteLine("ROM/world-map-event pointer not available — skipping.");
+            return true;
+        }
+        return false;
+    }
+
+    [Fact]
+    public void LoadList_ReturnsEntries_FourBytesApart()
+    {
+        if (Skip()) return;
+
+        var vm = new WorldMapEventPointerFE7ViewModel();
+        List<AddrResult> list = vm.LoadList();
+
+        Assert.NotEmpty(list);
+        Assert.Equal(list.Count, vm.GetListCount());
+        for (int i = 1; i < list.Count; i++)
+        {
+            Assert.Equal(list[i - 1].addr + WorldMapEventPointerFE7ViewModel.EntrySize, list[i].addr);
+        }
+    }
+
+    [Fact]
+    public void LoadEntry_ReadsEventPointer()
+    {
+        if (Skip()) return;
+
+        var vm = new WorldMapEventPointerFE7ViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        uint addr = list[0].addr;
+        vm.LoadEntry(addr);
+
+        Assert.True(vm.IsLoaded);
+        Assert.Equal(addr, vm.CurrentAddr);
+        Assert.Equal(CoreState.ROM.p32(addr), vm.EventPointer);
+    }
+
+    [Fact]
+    public void LoadGlobalEvents_ReadsEndingPointers()
+    {
+        if (Skip()) return;
+
+        var vm = new WorldMapEventPointerFE7ViewModel();
+        vm.LoadGlobalEvents();
+
+        Assert.Equal(CoreState.ROM.p32(CoreState.ROM.RomInfo.ending1_event_pointer), vm.Ending1Event);
+        Assert.Equal(CoreState.ROM.p32(CoreState.ROM.RomInfo.ending2_event_pointer), vm.Ending2Event);
+    }
+
+    [Fact]
+    public void WriteEntry_RoundTripsEventPointer()
+    {
+        if (Skip()) return;
+
+        var vm = new WorldMapEventPointerFE7ViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        // Use a non-row-0 entry (row 0 is the always-included header slot).
+        uint addr = list.Count > 1 ? list[1].addr : list[0].addr;
+        vm.LoadEntry(addr);
+        uint orig = vm.EventPointer;
+
+        try
+        {
+            vm.EventPointer = 0x123456;
+            Assert.True(vm.WriteEntry());
+
+            var vm2 = new WorldMapEventPointerFE7ViewModel();
+            vm2.LoadEntry(addr);
+            Assert.Equal(0x123456u, vm2.EventPointer);
+        }
+        finally
+        {
+            vm.EventPointer = orig;
+            vm.WriteEntry();
+        }
+    }
+
+    [Fact]
+    public void WriteGlobalEvents_RoundTripsEndings()
+    {
+        if (Skip()) return;
+
+        var vm = new WorldMapEventPointerFE7ViewModel();
+        vm.LoadGlobalEvents();
+        uint orig1 = vm.Ending1Event, orig2 = vm.Ending2Event;
+
+        try
+        {
+            vm.Ending1Event = 0x111111;
+            vm.Ending2Event = 0x222222;
+            Assert.True(vm.WriteGlobalEvents());
+
+            var vm2 = new WorldMapEventPointerFE7ViewModel();
+            vm2.LoadGlobalEvents();
+            Assert.Equal(0x111111u, vm2.Ending1Event);
+            Assert.Equal(0x222222u, vm2.Ending2Event);
+        }
+        finally
+        {
+            vm.Ending1Event = orig1;
+            vm.Ending2Event = orig2;
+            vm.WriteGlobalEvents();
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/WorldMapEventPointerFE7ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/WorldMapEventPointerFE7ViewModel.cs
@@ -1,23 +1,75 @@
 using System;
 using System.Collections.Generic;
+using FEBuilderGBA.Avalonia.Services;
 
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
-    public class WorldMapEventPointerFE7ViewModel : ViewModelBase
+    /// <summary>
+    /// World Map Event (FE7) editor — port of WinForms <c>WorldMapEventPointerFE7Form</c>.
+    /// FE7's world-map-event editor is the simpler sibling of the FE8 base
+    /// (<see cref="WorldMapEventPointerViewModel"/>): a single list of stage-select event
+    /// pointers (4 bytes each, at <c>p32(worldmap_event_on_stageselect_pointer)</c>) plus the two
+    /// global ending-event pointers. Per-entry event pointers and the two endings are read in
+    /// offset form (<c>p32</c>) and written back via <c>write_p32</c> (mask re-applied).
+    /// </summary>
+    public class WorldMapEventPointerFE7ViewModel : ViewModelBase, IDataVerifiable
     {
+        public const uint EntrySize = 4;
+
         uint _currentAddr;
         bool _isLoaded;
+        bool _canWrite;
+        uint _eventPointer;
+        uint _ending1Event;
+        uint _ending2Event;
 
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
+        public bool CanWrite { get => _canWrite; set => SetField(ref _canWrite, value); }
+        /// <summary>Event pointer for the selected stage-select row (offset form).</summary>
+        public uint EventPointer { get => _eventPointer; set => SetField(ref _eventPointer, value); }
+        /// <summary>Global ending-1 (Eliwood) event pointer (offset form).</summary>
+        public uint Ending1Event { get => _ending1Event; set => SetField(ref _ending1Event, value); }
+        /// <summary>Global ending-2 (Hector) event pointer (offset form).</summary>
+        public uint Ending2Event { get => _ending2Event; set => SetField(ref _ending2Event, value); }
+
+        public void LoadGlobalEvents()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null)
+            {
+                Ending1Event = Ending2Event = 0;
+                return;
+            }
+            Ending1Event = rom.p32(rom.RomInfo.ending1_event_pointer);
+            Ending2Event = rom.p32(rom.RomInfo.ending2_event_pointer);
+        }
 
         public List<AddrResult> LoadList()
         {
             ROM rom = CoreState.ROM;
             if (rom?.RomInfo == null) return new List<AddrResult>();
 
+            uint ptr = rom.RomInfo.worldmap_event_on_stageselect_pointer;
+            if (ptr == 0) return new List<AddrResult>();
+
+            uint baseAddr = rom.p32(ptr);
+            if (!U.isSafetyOffset(baseAddr, rom)) return new List<AddrResult>();
+
+            // Mirror WF Init(): row 0 always passes; later rows require U.isPointer; stop at the
+            // first non-pointer entry past row 0.
             var result = new List<AddrResult>();
-            result.Add(new AddrResult(0, "Event Pointer (FE7)", 0));
+            for (uint i = 0; i < 0x200; i++)
+            {
+                uint addr = baseAddr + i * EntrySize;
+                if (addr + EntrySize > (uint)rom.Data.Length) break;
+
+                uint eventPtr = rom.u32(addr);
+                bool include = i == 0 || U.isPointer(eventPtr);
+                if (!include) break;
+
+                result.Add(new AddrResult(addr, $"{U.ToHexString(i)} 0x{eventPtr:X08}", i));
+            }
             return result;
         }
 
@@ -25,9 +77,60 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         {
             ROM rom = CoreState.ROM;
             if (rom == null) return;
+            if (addr + EntrySize > (uint)rom.Data.Length) return;
 
             CurrentAddr = addr;
+            EventPointer = rom.p32(addr);
             IsLoaded = true;
+            CanWrite = true;
         }
+
+        /// <summary>Write the selected row's event pointer. Returns false when no row is selected.</summary>
+        public bool WriteEntry()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null || CurrentAddr == 0) return false;
+            if (CurrentAddr + EntrySize > (uint)rom.Data.Length) return false;
+            rom.write_p32(CurrentAddr, EventPointer);
+            return true;
+        }
+
+        /// <summary>Write both global ending-event pointers (the WF "Event Write" button).</summary>
+        public bool WriteGlobalEvents()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return false;
+            rom.write_p32(rom.RomInfo.ending1_event_pointer, Ending1Event);
+            rom.write_p32(rom.RomInfo.ending2_event_pointer, Ending2Event);
+            return true;
+        }
+
+        public int GetListCount() => LoadList().Count;
+
+        public Dictionary<string, string> GetDataReport()
+        {
+            return new Dictionary<string, string>
+            {
+                ["addr"] = $"0x{CurrentAddr:X08}",
+                ["EventPointer"] = $"0x{EventPointer:X08}",
+            };
+        }
+
+        public Dictionary<string, string> GetRawRomReport()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null || CurrentAddr == 0) return new Dictionary<string, string>();
+            uint a = CurrentAddr;
+            return new Dictionary<string, string>
+            {
+                ["addr"] = $"0x{a:X08}",
+                ["p32@0x00"] = $"0x{rom.p32(a):X08}",
+            };
+        }
+
+        public Dictionary<string, string> GetFieldOffsetMap() => new()
+        {
+            ["EventPointer"] = "p32@0x00",
+        };
     }
 }

--- a/FEBuilderGBA.Avalonia/ViewModels/WorldMapEventPointerFE7ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/WorldMapEventPointerFE7ViewModel.cs
@@ -12,7 +12,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
     /// global ending-event pointers. Per-entry event pointers and the two endings are read in
     /// offset form (<c>p32</c>) and written back via <c>write_p32</c> (mask re-applied).
     /// </summary>
-    public class WorldMapEventPointerFE7ViewModel : ViewModelBase, IDataVerifiable
+    public class WorldMapEventPointerFE7ViewModel : ViewModelBase
     {
         public const uint EntrySize = 4;
 
@@ -106,31 +106,5 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         }
 
         public int GetListCount() => LoadList().Count;
-
-        public Dictionary<string, string> GetDataReport()
-        {
-            return new Dictionary<string, string>
-            {
-                ["addr"] = $"0x{CurrentAddr:X08}",
-                ["EventPointer"] = $"0x{EventPointer:X08}",
-            };
-        }
-
-        public Dictionary<string, string> GetRawRomReport()
-        {
-            ROM rom = CoreState.ROM;
-            if (rom == null || CurrentAddr == 0) return new Dictionary<string, string>();
-            uint a = CurrentAddr;
-            return new Dictionary<string, string>
-            {
-                ["addr"] = $"0x{a:X08}",
-                ["p32@0x00"] = $"0x{rom.p32(a):X08}",
-            };
-        }
-
-        public Dictionary<string, string> GetFieldOffsetMap() => new()
-        {
-            ["EventPointer"] = "p32@0x00",
-        };
     }
 }

--- a/FEBuilderGBA.Avalonia/ViewModels/WorldMapEventPointerFE7ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/WorldMapEventPointerFE7ViewModel.cs
@@ -56,6 +56,10 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             uint baseAddr = rom.p32(ptr);
             if (!U.isSafetyOffset(baseAddr, rom)) return new List<AddrResult>();
 
+            // WF label is "<index> <map name>" (resolved via the map-settings table). Build the
+            // world-map-event-id -> map-name lookup once.
+            var mapNames = BuildMapNameByWorldMapEventId(rom);
+
             // Mirror WF Init(): row 0 always passes; later rows require U.isPointer; stop at the
             // first non-pointer entry past row 0.
             var result = new List<AddrResult>();
@@ -68,9 +72,29 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 bool include = i == 0 || U.isPointer(eventPtr);
                 if (!include) break;
 
-                result.Add(new AddrResult(addr, $"{U.ToHexString(i)} 0x{eventPtr:X08}", i));
+                // Prefer the map name (WF parity); fall back to the event pointer when no map
+                // references this world-map-event id (e.g. row 0 / unused slots).
+                string name = mapNames.TryGetValue(i, out string m) && m != "" ? m : $"0x{eventPtr:X08}";
+                result.Add(new AddrResult(addr, $"{U.ToHexString(i)} {name}", i));
             }
             return result;
+        }
+
+        /// <summary>
+        /// Build a world-map-event-id -> map-name lookup by scanning the map-settings table
+        /// (ports WF <c>MapSettingForm.GetMapNameFromWorldMapEventID</c> as a one-pass dictionary).
+        /// </summary>
+        static Dictionary<uint, string> BuildMapNameByWorldMapEventId(ROM rom)
+        {
+            var dict = new Dictionary<uint, string>();
+            foreach (AddrResult ms in MapSettingCore.MakeMapIDList(rom))
+            {
+                uint wmId = MapPListResolverCore.GetWorldMapEventIDWhereAddr(rom, ms.addr);
+                if (wmId == U.NOT_FOUND || wmId == 0) continue;
+                if (!dict.ContainsKey(wmId))
+                    dict[wmId] = MapSettingCore.GetMapNameWhereAddr(rom, ms.addr);
+            }
+            return dict;
         }
 
         public void LoadEntry(uint addr)

--- a/FEBuilderGBA.Avalonia/ViewModels/WorldMapEventPointerFE7ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/WorldMapEventPointerFE7ViewModel.cs
@@ -12,7 +12,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
     /// global ending-event pointers. Per-entry event pointers and the two endings are read in
     /// offset form (<c>p32</c>) and written back via <c>write_p32</c> (mask re-applied).
     /// </summary>
-    public class WorldMapEventPointerFE7ViewModel : ViewModelBase
+    public class WorldMapEventPointerFE7ViewModel : ViewModelBase, IDataVerifiable
     {
         public const uint EntrySize = 4;
 
@@ -130,5 +130,34 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         }
 
         public int GetListCount() => LoadList().Count;
+
+        public Dictionary<string, string> GetDataReport()
+        {
+            return new Dictionary<string, string>
+            {
+                ["addr"] = $"0x{CurrentAddr:X08}",
+                ["EventPointer"] = $"0x{EventPointer:X08}",
+            };
+        }
+
+        public Dictionary<string, string> GetRawRomReport()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null || CurrentAddr == 0) return new Dictionary<string, string>();
+            uint a = CurrentAddr;
+            return new Dictionary<string, string>
+            {
+                ["addr"] = $"0x{a:X08}",
+                // Same offset-0 event pointer surfaced both raw (u32, as LoadList reads it) and
+                // dereferenced (p32, as LoadEntry reads it) for --data-verify-full cross-checking.
+                ["u32@0x00"] = $"0x{rom.u32(a):X08}",
+                ["p32@0x00"] = $"0x{rom.p32(a):X08}",
+            };
+        }
+
+        public Dictionary<string, string> GetFieldOffsetMap() => new()
+        {
+            ["EventPointer"] = "p32@0x00",
+        };
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/WorldMapEventPointerFE7View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapEventPointerFE7View.axaml
@@ -9,12 +9,30 @@
 
     <ScrollViewer Grid.Column="1" Margin="4">
       <StackPanel Spacing="8" Margin="8">
-        <TextBlock Text="Event Pointer (FE7)" FontSize="18" FontWeight="Bold" />
+        <TextBlock Text="World Map Event (FE7)" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="WorldMapEventPointerFE7_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+        <Grid ColumnDefinitions="180,300" RowDefinitions="Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="WorldMapEventPointerFE7_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" Margin="0,4" />
+
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="Event Pointer:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="WorldMapEventPointerFE7_EventPointer_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="EventPointerBox" Minimum="0" Maximum="4294967295" Increment="1" Margin="0,4" />
         </Grid>
+
+        <TextBlock Text="Pointer to the event run when this chapter is selected on the world map." TextWrapping="Wrap" Foreground="Gray" Margin="0,4" />
+        <Button AutomationProperties.AutomationId="WorldMapEventPointerFE7_Write_Button" Name="WriteButton" Content="Write" HorizontalAlignment="Left" Margin="0,4" />
+
+        <Border BorderBrush="Gray" BorderThickness="0,1,0,0" Margin="0,12,0,4" />
+
+        <TextBlock Text="Ending Events" FontSize="14" FontWeight="Bold" />
+        <Grid ColumnDefinitions="180,300" RowDefinitions="Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Ending 1 (Eliwood):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="WorldMapEventPointerFE7_Ending1_Input" FormatString="0" Grid.Row="0" Grid.Column="1" Name="Ending1Box" Minimum="0" Maximum="4294967295" Increment="1" Margin="0,4" />
+
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="Ending 2 (Hector):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="WorldMapEventPointerFE7_Ending2_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="Ending2Box" Minimum="0" Maximum="4294967295" Increment="1" Margin="0,4" />
+        </Grid>
+        <Button AutomationProperties.AutomationId="WorldMapEventPointerFE7_EventWrite_Button" Name="EventWriteButton" Content="Event Write" HorizontalAlignment="Left" Margin="0,4" />
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/WorldMapEventPointerFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapEventPointerFE7View.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class WorldMapEventPointerFE7View : TranslatedWindow, IEditorView
+    public partial class WorldMapEventPointerFE7View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly WorldMapEventPointerFE7ViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -118,5 +118,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/WorldMapEventPointerFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapEventPointerFE7View.axaml.cs
@@ -6,7 +6,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class WorldMapEventPointerFE7View : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class WorldMapEventPointerFE7View : TranslatedWindow, IEditorView
     {
         readonly WorldMapEventPointerFE7ViewModel _vm = new();
         readonly UndoService _undoService = new();
@@ -118,6 +118,5 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
-        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/WorldMapEventPointerFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapEventPointerFE7View.axaml.cs
@@ -6,17 +6,20 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class WorldMapEventPointerFE7View : TranslatedWindow, IEditorView
+    public partial class WorldMapEventPointerFE7View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly WorldMapEventPointerFE7ViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
-        public string ViewTitle => "Event Pointer (FE7)";
+        public string ViewTitle => "World Map Event (FE7)";
         public bool IsLoaded => _vm.IsLoaded;
 
         public WorldMapEventPointerFE7View()
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
+            WriteButton.Click += OnWriteEntry;
+            EventWriteButton.Click += OnWriteGlobalEvents;
             Opened += (_, _) => LoadList();
         }
 
@@ -24,12 +27,20 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                _vm.IsLoading = true;
+                _vm.LoadGlobalEvents();
                 var items = _vm.LoadList();
                 EntryList.SetItems(items);
+                UpdateGlobalUI();
             }
             catch (Exception ex)
             {
-                Log.Error("WorldMapEventPointerFE7View.LoadList failed: {0}", ex.Message);
+                Log.Error("WorldMapEventPointerFE7View.LoadList failed: " + ex.ToString());
+            }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
             }
         }
 
@@ -37,21 +48,76 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                _vm.IsLoading = true;
                 _vm.LoadEntry(addr);
                 UpdateUI();
             }
             catch (Exception ex)
             {
-                Log.Error("WorldMapEventPointerFE7View.OnSelected failed: {0}", ex.Message);
+                Log.Error("WorldMapEventPointerFE7View.OnSelected failed: " + ex.ToString());
+            }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
             }
         }
 
         void UpdateUI()
         {
             AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            EventPointerBox.Value = _vm.EventPointer;
+        }
+
+        void UpdateGlobalUI()
+        {
+            Ending1Box.Value = _vm.Ending1Event;
+            Ending2Box.Value = _vm.Ending2Event;
+        }
+
+        void OnWriteEntry(object? sender, RoutedEventArgs e)
+        {
+            if (!_vm.IsLoaded) return;
+
+            _undoService.Begin(R._("Edit World Map Event (FE7)"));
+            try
+            {
+                _vm.EventPointer = (uint)(EventPointerBox.Value ?? 0);
+                if (_vm.WriteEntry())
+                    _undoService.Commit();
+                else
+                    _undoService.Rollback();
+                _vm.MarkClean();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("WorldMapEventPointerFE7View.OnWriteEntry failed: " + ex.ToString());
+            }
+        }
+
+        void OnWriteGlobalEvents(object? sender, RoutedEventArgs e)
+        {
+            _undoService.Begin(R._("Edit World Map Ending Events (FE7)"));
+            try
+            {
+                _vm.Ending1Event = (uint)(Ending1Box.Value ?? 0);
+                _vm.Ending2Event = (uint)(Ending2Box.Value ?? 0);
+                if (_vm.WriteGlobalEvents())
+                    _undoService.Commit();
+                else
+                    _undoService.Rollback();
+                _vm.MarkClean();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("WorldMapEventPointerFE7View.OnWriteGlobalEvents failed: " + ex.ToString());
+            }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
+        public ViewModelBase? DataViewModel => _vm;
     }
 }

--- a/FEBuilderGBA.Tests/Unit/AvaloniaFieldCompletenessTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AvaloniaFieldCompletenessTests.cs
@@ -92,6 +92,7 @@ namespace FEBuilderGBA.Tests.Unit
             ("WorldMapPointView", "WorldMapPointForm", "WorldMapPointViewModel"),
             ("WorldMapBGMView", "WorldMapBGMForm", "WorldMapBGMViewModel"),
             ("WorldMapEventPointerView", "WorldMapEventPointerForm", "WorldMapEventPointerViewModel"),
+            ("WorldMapEventPointerFE7View", "WorldMapEventPointerFE7Form", "WorldMapEventPointerFE7ViewModel"),
 
             // Audio
             ("SongTableView", "SongTableForm", "SongTableViewModel"),

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20206,3 +20206,24 @@ Pointer to the minimap tile-array graphic used for this terrain type.
 
 :Edit Mini-Map Terrain
 Edit Mini-Map Terrain
+
+:Ending 1 (Eliwood):
+Ending 1 (Eliwood):
+
+:Ending 2 (Hector):
+Ending 2 (Hector):
+
+:Event Write
+Event Write
+
+:World Map Event (FE7)
+World Map Event (FE7)
+
+:Pointer to the event run when this chapter is selected on the world map.
+Pointer to the event run when this chapter is selected on the world map.
+
+:Edit World Map Event (FE7)
+Edit World Map Event (FE7)
+
+:Edit World Map Ending Events (FE7)
+Edit World Map Ending Events (FE7)

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11025,3 +11025,24 @@ UPSパッチを保存
 
 :Edit Mini-Map Terrain
 ミニマップ地形の編集
+
+:Ending 1 (Eliwood):
+エンディング1 (エリウッド):
+
+:Ending 2 (Hector):
+エンディング2 (ヘクトル):
+
+:Event Write
+イベント書き込み
+
+:World Map Event (FE7)
+ワールドマップイベント (FE7)
+
+:Pointer to the event run when this chapter is selected on the world map.
+ワールドマップでこの章が選択されたときに実行されるイベントへのポインタ。
+
+:Edit World Map Event (FE7)
+ワールドマップイベントの編集 (FE7)
+
+:Edit World Map Ending Events (FE7)
+ワールドマップエンディングイベントの編集 (FE7)

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -24863,3 +24863,24 @@ A: 不使用 TSA 的背景 224 色(对话用)
 
 :Edit Mini-Map Terrain
 编辑小地图地形
+
+:Ending 1 (Eliwood):
+结局1 (埃利乌德):
+
+:Ending 2 (Hector):
+结局2 (赫克托尔):
+
+:Event Write
+写入事件
+
+:World Map Event (FE7)
+世界地图事件 (FE7)
+
+:Pointer to the event run when this chapter is selected on the world map.
+在世界地图上选择此章节时运行的事件的指针。
+
+:Edit World Map Event (FE7)
+编辑世界地图事件 (FE7)
+
+:Edit World Map Ending Events (FE7)
+编辑世界地图结局事件 (FE7)


### PR DESCRIPTION
Fixes #1182

## What

Replaces the 21-line scaffold (over a 33-line dummy ViewModel) with a **functional Avalonia World Map Event (FE7) editor** with parity to WinForms `WorldMapEventPointerFE7Form` — the FE7 stage-select world-map event table plus the two global ending-event pointers.

## Implementation

- **ViewModel** — ports the FE7-specific subset of the FE8 base (`WorldMapEventPointerViewModel`). A single list of stage-select event pointers at `p32(worldmap_event_on_stageselect_pointer)` (4-byte entries; **row 0 always included**, later rows require `U.isPointer`, stop at the first non-pointer). Per-entry `EventPointer` is read in offset form (`p32`) and written via `write_p32`; `LoadGlobalEvents`/`WriteGlobalEvents` handle the two ending-event pointers. Implements `IDataVerifiable` for parity with the base.
- **No version gate** — FE7 and FE8 share this exact schema (tables of event pointers), so unlike #1198's `ed_3a` there is no per-version reinterpretation / corruption risk.
- **View** — per-entry event-pointer field + Write, then a separated **Ending Events** section (Ending 1 Eliwood / Ending 2 Hector + an "Event Write" button). Both write paths are undo-wrapped with bool-gated Commit/Rollback and `ex.ToString()` logging.

## Tests

`WorldMapEventPointerFE7ViewModelTests` (all pass, no skips — real fixture ROM):
- list geometry (4-byte stride + `GetListCount` parity),
- event-pointer read, ending-pointer read,
- per-entry write round-trip, and global-endings write round-trip.

The FE8U fixture exercises the shared schema; the GUI screenshot uses FE7U. Gates green: L10n coverage, AutomationId (script + test), and 1727 Avalonia view/VM/binding/data-verify sweep tests. New literals localized in en/ja/zh.

## Screenshot (real GUI, `roms/FE7U.gba`)

![World Map Event (FE7) editor](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1182-wmevent-fe7.png)

The list shows real FE7 stage-select event pointers (`01 0x08CE791C`, `02 0x08CE7920`, …; row 0 is the always-included null header), with the per-entry Event Pointer field and the **Ending Events** section populated with the real FE7 ending pointers (`13376284`, `13376496`). No path/username leak.

---
🔎 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.169` · model `claude-opus-4-8[1m]`