### PR TITLE
feat(avalonia): implement Battle Dialogue (FE8) editor — port WinForms EventBattleTalkForm (#1187)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/EventBattleTalkViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventBattleTalkViewModelTests.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+/// <summary>
+/// Headless ROM-backed tests for <see cref="EventBattleTalkViewModel"/> (issue #1187 —
+/// port of WinForms <c>EventBattleTalkForm</c>, the FE8 battle-conversation editor). The table at
+/// <c>p32(event_ballte_talk_pointer)</c> holds 16-byte records (attacker/defender units, map,
+/// achievement flag, text id, event pointer).
+/// </summary>
+[Collection("SharedState")]
+public class EventBattleTalkViewModelTests : IClassFixture<RomFixture>
+{
+    private readonly RomFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public EventBattleTalkViewModelTests(RomFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    bool Skip()
+    {
+        if (!_fixture.IsAvailable || CoreState.ROM?.RomInfo == null
+            || CoreState.ROM.RomInfo.event_ballte_talk_pointer == 0)
+        {
+            _output.WriteLine("ROM/battle-talk pointer not available — skipping.");
+            return true;
+        }
+        return false;
+    }
+
+    [Fact]
+    public void LoadList_ReturnsEntries_SixteenBytesApart()
+    {
+        if (Skip()) return;
+
+        var vm = new EventBattleTalkViewModel();
+        List<AddrResult> list = vm.LoadList();
+
+        Assert.NotEmpty(list);
+        Assert.Equal(list.Count, vm.GetListCount());
+        for (int i = 1; i < list.Count; i++)
+        {
+            Assert.Equal(list[i - 1].addr + 16, list[i].addr);
+        }
+    }
+
+    [Fact]
+    public void LoadEntry_ReadsStructFields()
+    {
+        if (Skip()) return;
+
+        var vm = new EventBattleTalkViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        uint addr = list[0].addr;
+        vm.LoadEntry(addr);
+
+        Assert.True(vm.IsLoaded);
+        Assert.Equal(addr, vm.CurrentAddr);
+        Assert.Equal(CoreState.ROM.u16(addr + 0), vm.AttackerUnit);
+        Assert.Equal(CoreState.ROM.u16(addr + 2), vm.DefenderUnit);
+        Assert.Equal(CoreState.ROM.u8(addr + 4), vm.Map);
+        Assert.Equal(CoreState.ROM.u16(addr + 8), vm.Text);
+        Assert.Equal(CoreState.ROM.u32(addr + 12), vm.EventPointer);
+    }
+
+    [Fact]
+    public void Write_RoundTripsAllFields()
+    {
+        if (Skip()) return;
+
+        var vm = new EventBattleTalkViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        uint addr = list[0].addr;
+        vm.LoadEntry(addr);
+
+        uint a0 = vm.AttackerUnit, d0 = vm.DefenderUnit, m0 = vm.Map, u5 = vm.Unknown05,
+             f0 = vm.AchievementFlag, t0 = vm.Text, ua = vm.Unknown0A, ub = vm.Unknown0B, ep = vm.EventPointer;
+
+        try
+        {
+            vm.AttackerUnit = 0x11; vm.DefenderUnit = 0x22; vm.Map = 0x33; vm.Unknown05 = 0x44;
+            vm.AchievementFlag = 0x55; vm.Text = 0x66; vm.Unknown0A = 0x77; vm.Unknown0B = 0x88;
+            vm.EventPointer = 0x08123456;
+            vm.Write();
+
+            var vm2 = new EventBattleTalkViewModel();
+            vm2.LoadEntry(addr);
+            Assert.Equal(0x11u, vm2.AttackerUnit);
+            Assert.Equal(0x22u, vm2.DefenderUnit);
+            Assert.Equal(0x33u, vm2.Map);
+            Assert.Equal(0x44u, vm2.Unknown05);
+            Assert.Equal(0x55u, vm2.AchievementFlag);
+            Assert.Equal(0x66u, vm2.Text);
+            Assert.Equal(0x77u, vm2.Unknown0A);
+            Assert.Equal(0x88u, vm2.Unknown0B);
+            Assert.Equal(0x08123456u, vm2.EventPointer);
+        }
+        finally
+        {
+            vm.AttackerUnit = a0; vm.DefenderUnit = d0; vm.Map = m0; vm.Unknown05 = u5;
+            vm.AchievementFlag = f0; vm.Text = t0; vm.Unknown0A = ua; vm.Unknown0B = ub; vm.EventPointer = ep;
+            vm.Write();
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Views/EventBattleTalkView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventBattleTalkView.axaml
@@ -11,10 +11,45 @@
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Battle Dialogue Editor" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="EventBattleTalk_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+        <Grid ColumnDefinitions="180,140,*"
+              RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalk_Addr_Label" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Name="AddrLabel" VerticalAlignment="Center" Margin="0,4" />
+
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="Attacker Unit:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalk_AttackerUnit_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="AttackerUnitBox" Minimum="0" Maximum="65535" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalk_AttackerName_Label" Grid.Row="1" Grid.Column="2" Name="AttackerNameLabel" VerticalAlignment="Center" TextWrapping="Wrap" Margin="8,4" />
+
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Defender Unit:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalk_DefenderUnit_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="DefenderUnitBox" Minimum="0" Maximum="65535" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalk_DefenderName_Label" Grid.Row="2" Grid.Column="2" Name="DefenderNameLabel" VerticalAlignment="Center" TextWrapping="Wrap" Margin="8,4" />
+
+          <TextBlock Grid.Row="3" Grid.Column="0" Text="Map:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalk_Map_Input" FormatString="0" Grid.Row="3" Grid.Column="1" Name="MapBox" Minimum="0" Maximum="255" Margin="0,4" />
+
+          <TextBlock Grid.Row="4" Grid.Column="0" Text="Unknown (0x05):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalk_Unknown05_Input" FormatString="0" Grid.Row="4" Grid.Column="1" Name="Unknown05Box" Minimum="0" Maximum="255" Margin="0,4" />
+
+          <TextBlock Grid.Row="5" Grid.Column="0" Text="Achievement Flag:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalk_AchievementFlag_Input" FormatString="0" Grid.Row="5" Grid.Column="1" Name="AchievementFlagBox" Minimum="0" Maximum="65535" Margin="0,4" />
+
+          <TextBlock Grid.Row="6" Grid.Column="0" Text="Text:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalk_Text_Input" FormatString="0" Grid.Row="6" Grid.Column="1" Name="TextIdBox" Minimum="0" Maximum="65535" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalk_TextPreview_Label" Grid.Row="6" Grid.Column="2" Name="TextPreviewLabel" VerticalAlignment="Center" TextWrapping="Wrap" Margin="8,4" />
+
+          <TextBlock Grid.Row="7" Grid.Column="0" Text="Unknown (0x0A):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalk_Unknown0A_Input" FormatString="0" Grid.Row="7" Grid.Column="1" Name="Unknown0ABox" Minimum="0" Maximum="255" Margin="0,4" />
+
+          <TextBlock Grid.Row="8" Grid.Column="0" Text="Unknown (0x0B):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalk_Unknown0B_Input" FormatString="0" Grid.Row="8" Grid.Column="1" Name="Unknown0BBox" Minimum="0" Maximum="255" Margin="0,4" />
+
+          <TextBlock Grid.Row="9" Grid.Column="0" Text="Event Pointer:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalk_EventPointer_Input" FormatString="0" Grid.Row="9" Grid.Column="1" Name="EventPointerBox" Minimum="0" Maximum="4294967295" Margin="0,4" />
         </Grid>
+
+        <TextBlock Text="A mid-battle conversation triggered when the attacker and defender units fight." TextWrapping="Wrap" Foreground="Gray" Margin="0,8" />
+
+        <Button AutomationProperties.AutomationId="EventBattleTalk_Write_Button" Name="WriteButton" Content="Write" HorizontalAlignment="Left" Margin="0,8" />
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/EventBattleTalkView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventBattleTalkView.axaml.cs
@@ -9,6 +9,7 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class EventBattleTalkView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventBattleTalkViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         public string ViewTitle => "Battle Dialogue Editor";
         public bool IsLoaded => _vm.IsLoaded;
@@ -17,6 +18,13 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
+            WriteButton.Click += OnWrite;
+
+            // Live name/text previews while editing.
+            AttackerUnitBox.ValueChanged += (_, _) => AttackerNameLabel.Text = UnitName(AttackerUnitBox);
+            DefenderUnitBox.ValueChanged += (_, _) => DefenderNameLabel.Text = UnitName(DefenderUnitBox);
+            TextIdBox.ValueChanged += (_, _) => TextPreviewLabel.Text = TextPreview(TextIdBox);
+
             Opened += (_, _) => LoadList();
         }
 
@@ -24,12 +32,18 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                _vm.IsLoading = true;
                 var items = _vm.LoadList();
                 EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitFromAddrU16Loader(items, i));
             }
             catch (Exception ex)
             {
-                Log.Error("EventBattleTalkView.LoadList failed: {0}", ex.Message);
+                Log.Error("EventBattleTalkView.LoadList failed: " + ex.ToString());
+            }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
             }
         }
 
@@ -37,18 +51,78 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                _vm.IsLoading = true;
                 _vm.LoadEntry(addr);
                 UpdateUI();
             }
             catch (Exception ex)
             {
-                Log.Error("EventBattleTalkView.OnSelected failed: {0}", ex.Message);
+                Log.Error("EventBattleTalkView.OnSelected failed: " + ex.ToString());
+            }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
             }
         }
 
         void UpdateUI()
         {
             AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            AttackerUnitBox.Value = _vm.AttackerUnit;
+            DefenderUnitBox.Value = _vm.DefenderUnit;
+            MapBox.Value = _vm.Map;
+            Unknown05Box.Value = _vm.Unknown05;
+            AchievementFlagBox.Value = _vm.AchievementFlag;
+            TextIdBox.Value = _vm.Text;
+            Unknown0ABox.Value = _vm.Unknown0A;
+            Unknown0BBox.Value = _vm.Unknown0B;
+            EventPointerBox.Value = _vm.EventPointer;
+
+            AttackerNameLabel.Text = UnitName(AttackerUnitBox);
+            DefenderNameLabel.Text = UnitName(DefenderUnitBox);
+            TextPreviewLabel.Text = TextPreview(TextIdBox);
+        }
+
+        static string UnitName(NumericUpDown box)
+        {
+            try { return NameResolver.GetUnitNameAndANYByOneBasedId((uint)(box.Value ?? 0)); }
+            catch { return ""; }
+        }
+
+        static string TextPreview(NumericUpDown box)
+        {
+            uint id = (uint)(box.Value ?? 0);
+            if (id == 0) return "";
+            try { return NameResolver.GetTextById(id); }
+            catch { return ""; }
+        }
+
+        void OnWrite(object? sender, RoutedEventArgs e)
+        {
+            if (!_vm.IsLoaded) return;
+
+            _undoService.Begin(R._("Edit Battle Dialogue"));
+            try
+            {
+                _vm.AttackerUnit = (uint)(AttackerUnitBox.Value ?? 0);
+                _vm.DefenderUnit = (uint)(DefenderUnitBox.Value ?? 0);
+                _vm.Map = (uint)(MapBox.Value ?? 0);
+                _vm.Unknown05 = (uint)(Unknown05Box.Value ?? 0);
+                _vm.AchievementFlag = (uint)(AchievementFlagBox.Value ?? 0);
+                _vm.Text = (uint)(TextIdBox.Value ?? 0);
+                _vm.Unknown0A = (uint)(Unknown0ABox.Value ?? 0);
+                _vm.Unknown0B = (uint)(Unknown0BBox.Value ?? 0);
+                _vm.EventPointer = (uint)(EventPointerBox.Value ?? 0);
+                _vm.Write();
+                _undoService.Commit();
+                _vm.MarkClean();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("EventBattleTalkView.OnWrite failed: " + ex.ToString());
+            }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20227,3 +20227,24 @@ Edit World Map Event (FE7)
 
 :Edit World Map Ending Events (FE7)
 Edit World Map Ending Events (FE7)
+
+:Attacker Unit:
+Attacker Unit:
+
+:Defender Unit:
+Defender Unit:
+
+:Map:
+Map:
+
+:Unknown (0x05):
+Unknown (0x05):
+
+:Text:
+Text:
+
+:A mid-battle conversation triggered when the attacker and defender units fight.
+A mid-battle conversation triggered when the attacker and defender units fight.
+
+:Edit Battle Dialogue
+Edit Battle Dialogue

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11046,3 +11046,24 @@ UPSパッチを保存
 
 :Edit World Map Ending Events (FE7)
 ワールドマップエンディングイベントの編集 (FE7)
+
+:Attacker Unit:
+攻撃ユニット:
+
+:Defender Unit:
+防御ユニット:
+
+:Map:
+マップ:
+
+:Unknown (0x05):
+不明 (0x05):
+
+:Text:
+テキスト:
+
+:A mid-battle conversation triggered when the attacker and defender units fight.
+攻撃ユニットと防御ユニットが戦うときに発生する戦闘中の会話。
+
+:Edit Battle Dialogue
+戦闘会話の編集

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -24884,3 +24884,24 @@ A: 不使用 TSA 的背景 224 色(对话用)
 
 :Edit World Map Ending Events (FE7)
 编辑世界地图结局事件 (FE7)
+
+:Attacker Unit:
+攻击单位:
+
+:Defender Unit:
+防御单位:
+
+:Map:
+地图:
+
+:Unknown (0x05):
+未知 (0x05):
+
+:Text:
+文本:
+
+:A mid-battle conversation triggered when the attacker and defender units fight.
+当攻击单位与防御单位交战时触发的战斗中对话。
+
+:Edit Battle Dialogue
+编辑战斗对话


### PR DESCRIPTION
Fixes #1187

## What

Replaces the 21-line scaffold with a **functional Avalonia Battle Dialogue (FE8) editor** with parity to WinForms `EventBattleTalkForm` — the FE8 mid-battle conversation table (`p32(event_ballte_talk_pointer)`, 16-byte records pairing two units with a triggered talk text/event).

## Implementation

The `EventBattleTalkViewModel` (16-byte struct read/write + `IDataVerifiable`, already registered in `FormMappings`) was already implemented — the gap was purely the **View**:

- 9 struct fields: Attacker/Defender units, Map, Unknown 0x05, Achievement Flag, Text, Unknown 0x0A/0x0B, Event Pointer.
- **Live previews** — attacker/defender unit names via `NameResolver.GetUnitNameAndANYByOneBasedId` (id 0 → "ANY") and the conversation text via `NameResolver.GetTextById`.
- Write-back wraps the VM's `Write()` in `UndoService.Begin/Commit` with `Rollback` on exception and `ex.ToString()` logging. Kept the window at 1445×815.

## Tests

`EventBattleTalkViewModelTests` (all pass, no skips — real fixture ROM):
- list geometry (16-byte stride + `GetListCount` parity),
- struct-field read,
- full 9-field write → read round-trip (restores the fixture).

Gates green: L10n coverage, AutomationId (script + test), the net9.0-windows **field-completeness suite** (orphan + 80% coverage + raw-report), and 1576 Avalonia sweep tests. New literals localized in en/ja/zh.

## Screenshot (real GUI, `roms/FE8U.gba`)

![Battle Dialogue (FE8) editor](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1187-battletalk-fe8u.png)

The list shows real FE8 battle conversations with portraits + the `ANY` semantics (`0x00 Valter vs Seth`, `0x01 ANY vs O'Neill`, …); the detail panel resolves Attacker `69 → Valter`, Defender `2 → Seth`, and Text `2314 →` the actual dialogue ("I am Valter, the Moonstone, Grado's finest general!…"). No path/username leak.

---
🔎 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.169` · model `claude-opus-4-8[1m]`