### PR TITLE
feat(avalonia): implement Battle Dialogue (FE6) editor — port WinForms EventBattleTalkFE6Form (#1188)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/EventBattleTalkFE6ViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventBattleTalkFE6ViewModelTests.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+/// <summary>
+/// Headless ROM-backed tests for <see cref="EventBattleTalkFE6ViewModel"/> (issue #1188 —
+/// port of WinForms <c>EventBattleTalkFE6Form</c>). FE6's battle-conversation struct is 12 bytes
+/// (u8 attacker/defender, text at +4) — different from FE8's 16-byte layout — so these tests load
+/// a genuine FE6 ROM via <see cref="RomTestHelper.WithRom"/>.
+/// </summary>
+[Collection("SharedState")]
+public class EventBattleTalkFE6ViewModelTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public EventBattleTalkFE6ViewModelTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void LoadList_OnFe6_ReturnsEntries_TwelveBytesApart()
+    {
+        RomTestHelper.WithRom("FE6", () =>
+        {
+            var vm = new EventBattleTalkFE6ViewModel();
+            List<AddrResult> list = vm.LoadList();
+
+            Assert.NotEmpty(list);
+            Assert.Equal(list.Count, vm.GetListCount());
+            for (int i = 1; i < list.Count; i++)
+            {
+                Assert.Equal(list[i - 1].addr + 12, list[i].addr);
+            }
+        });
+    }
+
+    [Fact]
+    public void LoadEntry_OnFe6_ReadsStructFields()
+    {
+        RomTestHelper.WithRom("FE6", () =>
+        {
+            var vm = new EventBattleTalkFE6ViewModel();
+            var list = vm.LoadList();
+            Assert.NotEmpty(list);
+
+            uint addr = list[0].addr;
+            vm.LoadEntry(addr);
+
+            Assert.True(vm.IsLoaded);
+            Assert.Equal(addr, vm.CurrentAddr);
+            Assert.Equal(CoreState.ROM.u8(addr + 0), vm.AttackerUnit);
+            Assert.Equal(CoreState.ROM.u8(addr + 1), vm.DefenderUnit);
+            Assert.Equal(CoreState.ROM.u16(addr + 4), vm.Text);
+            Assert.Equal(CoreState.ROM.u16(addr + 8), vm.AchievementFlag);
+        });
+    }
+
+    [Fact]
+    public void Write_OnFe6_RoundTripsAllFields()
+    {
+        RomTestHelper.WithRom("FE6", () =>
+        {
+            var vm = new EventBattleTalkFE6ViewModel();
+            var list = vm.LoadList();
+            Assert.NotEmpty(list);
+
+            uint addr = list[0].addr;
+            vm.LoadEntry(addr);
+
+            uint a0 = vm.AttackerUnit, d0 = vm.DefenderUnit, u2 = vm.Unknown02, u3 = vm.Unknown03,
+                 t0 = vm.Text, u6 = vm.Unknown06, u7 = vm.Unknown07, f0 = vm.AchievementFlag,
+                 ua = vm.Unknown0A, ub = vm.Unknown0B;
+
+            try
+            {
+                vm.AttackerUnit = 0x11; vm.DefenderUnit = 0x22; vm.Unknown02 = 0x33; vm.Unknown03 = 0x44;
+                vm.Text = 0x0567; vm.Unknown06 = 0x66; vm.Unknown07 = 0x77; vm.AchievementFlag = 0x0089;
+                vm.Unknown0A = 0xAA; vm.Unknown0B = 0xBB;
+                vm.Write();
+
+                var vm2 = new EventBattleTalkFE6ViewModel();
+                vm2.LoadEntry(addr);
+                Assert.Equal(0x11u, vm2.AttackerUnit);
+                Assert.Equal(0x22u, vm2.DefenderUnit);
+                Assert.Equal(0x33u, vm2.Unknown02);
+                Assert.Equal(0x44u, vm2.Unknown03);
+                Assert.Equal(0x0567u, vm2.Text);
+                Assert.Equal(0x66u, vm2.Unknown06);
+                Assert.Equal(0x77u, vm2.Unknown07);
+                Assert.Equal(0x0089u, vm2.AchievementFlag);
+                Assert.Equal(0xAAu, vm2.Unknown0A);
+                Assert.Equal(0xBBu, vm2.Unknown0B);
+            }
+            finally
+            {
+                vm.AttackerUnit = a0; vm.DefenderUnit = d0; vm.Unknown02 = u2; vm.Unknown03 = u3;
+                vm.Text = t0; vm.Unknown06 = u6; vm.Unknown07 = u7; vm.AchievementFlag = f0;
+                vm.Unknown0A = ua; vm.Unknown0B = ub;
+                vm.Write();
+            }
+        });
+    }
+}

--- a/FEBuilderGBA.Avalonia/Views/EventBattleTalkFE6View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventBattleTalkFE6View.axaml
@@ -11,10 +11,48 @@
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Battle Dialogue (FE6)" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE6_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+        <Grid ColumnDefinitions="180,140,*"
+              RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE6_Addr_Label" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Name="AddrLabel" VerticalAlignment="Center" Margin="0,4" />
+
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="Attacker Unit:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_AttackerUnit_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="AttackerUnitBox" Minimum="0" Maximum="255" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE6_AttackerName_Label" Grid.Row="1" Grid.Column="2" Name="AttackerNameLabel" VerticalAlignment="Center" TextWrapping="Wrap" Margin="8,4" />
+
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Defender Unit:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_DefenderUnit_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="DefenderUnitBox" Minimum="0" Maximum="255" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE6_DefenderName_Label" Grid.Row="2" Grid.Column="2" Name="DefenderNameLabel" VerticalAlignment="Center" TextWrapping="Wrap" Margin="8,4" />
+
+          <TextBlock Grid.Row="3" Grid.Column="0" Text="Unknown (0x02):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_Unknown02_Input" FormatString="0" Grid.Row="3" Grid.Column="1" Name="Unknown02Box" Minimum="0" Maximum="255" Margin="0,4" />
+
+          <TextBlock Grid.Row="4" Grid.Column="0" Text="Unknown (0x03):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_Unknown03_Input" FormatString="0" Grid.Row="4" Grid.Column="1" Name="Unknown03Box" Minimum="0" Maximum="255" Margin="0,4" />
+
+          <TextBlock Grid.Row="5" Grid.Column="0" Text="Text:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_Text_Input" FormatString="0" Grid.Row="5" Grid.Column="1" Name="TextIdBox" Minimum="0" Maximum="65535" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE6_TextPreview_Label" Grid.Row="5" Grid.Column="2" Name="TextPreviewLabel" VerticalAlignment="Center" TextWrapping="Wrap" Margin="8,4" />
+
+          <TextBlock Grid.Row="6" Grid.Column="0" Text="Unknown (0x06):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_Unknown06_Input" FormatString="0" Grid.Row="6" Grid.Column="1" Name="Unknown06Box" Minimum="0" Maximum="255" Margin="0,4" />
+
+          <TextBlock Grid.Row="7" Grid.Column="0" Text="Unknown (0x07):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_Unknown07_Input" FormatString="0" Grid.Row="7" Grid.Column="1" Name="Unknown07Box" Minimum="0" Maximum="255" Margin="0,4" />
+
+          <TextBlock Grid.Row="8" Grid.Column="0" Text="Achievement Flag:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_AchievementFlag_Input" FormatString="0" Grid.Row="8" Grid.Column="1" Name="AchievementFlagBox" Minimum="0" Maximum="65535" Margin="0,4" />
+
+          <TextBlock Grid.Row="9" Grid.Column="0" Text="Unknown (0x0A):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_Unknown0A_Input" FormatString="0" Grid.Row="9" Grid.Column="1" Name="Unknown0ABox" Minimum="0" Maximum="255" Margin="0,4" />
+
+          <TextBlock Grid.Row="10" Grid.Column="0" Text="Unknown (0x0B):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_Unknown0B_Input" FormatString="0" Grid.Row="10" Grid.Column="1" Name="Unknown0BBox" Minimum="0" Maximum="255" Margin="0,4" />
         </Grid>
+
+        <TextBlock Text="A mid-battle conversation triggered when the attacker and defender units fight." TextWrapping="Wrap" Foreground="Gray" Margin="0,8" />
+
+        <Button AutomationProperties.AutomationId="EventBattleTalkFE6_Write_Button" Name="WriteButton" Content="Write" HorizontalAlignment="Left" Margin="0,8" />
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/EventBattleTalkFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventBattleTalkFE6View.axaml.cs
@@ -9,6 +9,7 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class EventBattleTalkFE6View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventBattleTalkFE6ViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         public string ViewTitle => "Battle Dialogue (FE6)";
         public bool IsLoaded => _vm.IsLoaded;
@@ -17,6 +18,13 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
+            WriteButton.Click += OnWrite;
+
+            // Live name/text previews while editing.
+            AttackerUnitBox.ValueChanged += (_, _) => AttackerNameLabel.Text = UnitName(AttackerUnitBox);
+            DefenderUnitBox.ValueChanged += (_, _) => DefenderNameLabel.Text = UnitName(DefenderUnitBox);
+            TextIdBox.ValueChanged += (_, _) => TextPreviewLabel.Text = TextPreview(TextIdBox);
+
             Opened += (_, _) => LoadList();
         }
 
@@ -24,12 +32,18 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                _vm.IsLoading = true;
                 var items = _vm.LoadList();
                 EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitFromAddrU8Loader(items, i));
             }
             catch (Exception ex)
             {
-                Log.Error("EventBattleTalkFE6View.LoadList failed: {0}", ex.Message);
+                Log.Error("EventBattleTalkFE6View.LoadList failed: " + ex.ToString());
+            }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
             }
         }
 
@@ -37,18 +51,80 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                _vm.IsLoading = true;
                 _vm.LoadEntry(addr);
                 UpdateUI();
             }
             catch (Exception ex)
             {
-                Log.Error("EventBattleTalkFE6View.OnSelected failed: {0}", ex.Message);
+                Log.Error("EventBattleTalkFE6View.OnSelected failed: " + ex.ToString());
+            }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
             }
         }
 
         void UpdateUI()
         {
             AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            AttackerUnitBox.Value = _vm.AttackerUnit;
+            DefenderUnitBox.Value = _vm.DefenderUnit;
+            Unknown02Box.Value = _vm.Unknown02;
+            Unknown03Box.Value = _vm.Unknown03;
+            TextIdBox.Value = _vm.Text;
+            Unknown06Box.Value = _vm.Unknown06;
+            Unknown07Box.Value = _vm.Unknown07;
+            AchievementFlagBox.Value = _vm.AchievementFlag;
+            Unknown0ABox.Value = _vm.Unknown0A;
+            Unknown0BBox.Value = _vm.Unknown0B;
+
+            AttackerNameLabel.Text = UnitName(AttackerUnitBox);
+            DefenderNameLabel.Text = UnitName(DefenderUnitBox);
+            TextPreviewLabel.Text = TextPreview(TextIdBox);
+        }
+
+        static string UnitName(NumericUpDown box)
+        {
+            try { return NameResolver.GetUnitNameByOneBasedId((uint)(box.Value ?? 0)); }
+            catch { return ""; }
+        }
+
+        static string TextPreview(NumericUpDown box)
+        {
+            uint id = (uint)(box.Value ?? 0);
+            if (id == 0) return "";
+            try { return NameResolver.GetTextById(id); }
+            catch { return ""; }
+        }
+
+        void OnWrite(object? sender, RoutedEventArgs e)
+        {
+            if (!_vm.IsLoaded) return;
+
+            _undoService.Begin(R._("Edit Battle Dialogue (FE6)"));
+            try
+            {
+                _vm.AttackerUnit = (uint)(AttackerUnitBox.Value ?? 0);
+                _vm.DefenderUnit = (uint)(DefenderUnitBox.Value ?? 0);
+                _vm.Unknown02 = (uint)(Unknown02Box.Value ?? 0);
+                _vm.Unknown03 = (uint)(Unknown03Box.Value ?? 0);
+                _vm.Text = (uint)(TextIdBox.Value ?? 0);
+                _vm.Unknown06 = (uint)(Unknown06Box.Value ?? 0);
+                _vm.Unknown07 = (uint)(Unknown07Box.Value ?? 0);
+                _vm.AchievementFlag = (uint)(AchievementFlagBox.Value ?? 0);
+                _vm.Unknown0A = (uint)(Unknown0ABox.Value ?? 0);
+                _vm.Unknown0B = (uint)(Unknown0BBox.Value ?? 0);
+                _vm.Write();
+                _undoService.Commit();
+                _vm.MarkClean();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("EventBattleTalkFE6View.OnWrite failed: " + ex.ToString());
+            }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20248,3 +20248,6 @@ A mid-battle conversation triggered when the attacker and defender units fight.
 
 :Edit Battle Dialogue
 Edit Battle Dialogue
+
+:Edit Battle Dialogue (FE6)
+Edit Battle Dialogue (FE6)

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11067,3 +11067,6 @@ UPSパッチを保存
 
 :Edit Battle Dialogue
 戦闘会話の編集
+
+:Edit Battle Dialogue (FE6)
+戦闘会話の編集 (FE6)

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -24905,3 +24905,6 @@ A: 不使用 TSA 的背景 224 色(对话用)
 
 :Edit Battle Dialogue
 编辑战斗对话
+
+:Edit Battle Dialogue (FE6)
+编辑战斗对话 (FE6)


### PR DESCRIPTION
Fixes #1188

## What

Replaces the 21-line scaffold with a **functional Avalonia Battle Dialogue (FE6) editor** with parity to WinForms `EventBattleTalkFE6Form` — the FE6 mid-battle conversation table. Sibling of #1187 (FE8) but with the **FE6 layout**: a 12-byte struct with `u8` attacker/defender unit ids and the text id at `+4` (vs FE8's 16-byte / `u16` units).

## Implementation

The `EventBattleTalkFE6ViewModel` (12-byte struct read/write + `IDataVerifiable`, already registered in `FormMappings`) was already implemented — the gap was purely the **View**:

- 10 FE6 struct fields: Attacker/Defender units, Unknown 0x02/0x03, Text, Unknown 0x06/0x07, Achievement Flag, Unknown 0x0A/0x0B.
- **Live previews** — attacker/defender unit names via `NameResolver.GetUnitNameByOneBasedId` and the conversation text via `NameResolver.GetTextById`.
- Write-back wraps the VM's `Write()` in `UndoService.Begin/Commit` with `Rollback` on exception and `ex.ToString()` logging. Kept the window at 1585×940.

## Tests

`EventBattleTalkFE6ViewModelTests` — run on a real **FE6 ROM** via `RomTestHelper.WithRom("FE6")` (the FE8U fixture would misread the 12-byte struct):
- list geometry (12-byte stride + `GetListCount` parity),
- struct read,
- full 10-field write → read round-trip (restores the ROM).

Gates green: L10n coverage, AutomationId (script + test), the net9.0-windows **field-completeness suite**, and 1576 Avalonia sweep tests. Field labels reused from #1187; only one new R._ literal localized in en/ja/zh.

## Screenshot (real GUI, `roms/FE6.gba`)

![Battle Dialogue (FE6) editor](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1188-battletalk-fe6.png)

The list shows real FE6 boss conversations with portraits (`0x00 ナーシェン vs クラリーネ`, `0x05 マードック vs ツァイス`, …); the detail panel resolves Attacker `89 → ナーシェン`, Defender `2 → クラリーネ`, and Text `677 →` the actual FE6 dialogue. No path/username leak.

---
🔎 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.169` · model `claude-opus-4-8[1m]`