### PR TITLE
feat(avalonia): implement Final Serif (FE7) editor — port WinForms EventFinalSerifFE7Form (#1189)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/EventFinalSerifFE7ViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventFinalSerifFE7ViewModelTests.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+/// <summary>
+/// Headless ROM-backed tests for <see cref="EventFinalSerifFE7ViewModel"/> (issue #1189 —
+/// port of WinForms <c>EventFinalSerifFE7Form</c>). The final-chapter per-character dialogue table
+/// (<c>event_final_serif</c>, FE7-only) holds 8-byte records: Unit id at +0, Text id at +4. Loaded
+/// on a real FE7 ROM (the FE8U fixture has no such table).
+/// </summary>
+[Collection("SharedState")]
+public class EventFinalSerifFE7ViewModelTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public EventFinalSerifFE7ViewModelTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void LoadList_OnFe7_ReturnsEntries_EightBytesApart()
+    {
+        RomTestHelper.WithRom("FE7U", () =>
+        {
+            var vm = new EventFinalSerifFE7ViewModel();
+            List<AddrResult> list = vm.LoadList();
+
+            Assert.NotEmpty(list);
+            Assert.Equal(list.Count, vm.GetListCount());
+            for (int i = 1; i < list.Count; i++)
+            {
+                Assert.Equal(list[i - 1].addr + 8, list[i].addr);
+            }
+        });
+    }
+
+    [Fact]
+    public void LoadEntry_OnFe7_ReadsUnitAndText()
+    {
+        RomTestHelper.WithRom("FE7U", () =>
+        {
+            var vm = new EventFinalSerifFE7ViewModel();
+            var list = vm.LoadList();
+            Assert.NotEmpty(list);
+
+            uint addr = list[0].addr;
+            vm.LoadEntry(addr);
+
+            Assert.True(vm.IsLoaded);
+            Assert.Equal(addr, vm.CurrentAddr);
+            Assert.Equal(CoreState.ROM.u32(addr + 0), vm.Unit);
+            Assert.Equal(CoreState.ROM.u32(addr + 4), vm.TextID);
+        });
+    }
+
+    [Fact]
+    public void Write_OnFe7_RoundTripsUnitAndText()
+    {
+        RomTestHelper.WithRom("FE7U", () =>
+        {
+            var vm = new EventFinalSerifFE7ViewModel();
+            var list = vm.LoadList();
+            Assert.NotEmpty(list);
+
+            uint addr = list[0].addr;
+            vm.LoadEntry(addr);
+            uint origUnit = vm.Unit, origText = vm.TextID;
+
+            try
+            {
+                vm.Unit = 0x12;
+                vm.TextID = 0x0567;
+                vm.Write();
+
+                var vm2 = new EventFinalSerifFE7ViewModel();
+                vm2.LoadEntry(addr);
+                Assert.Equal(0x12u, vm2.Unit);
+                Assert.Equal(0x0567u, vm2.TextID);
+            }
+            finally
+            {
+                vm.Unit = origUnit;
+                vm.TextID = origText;
+                vm.Write();
+            }
+        });
+    }
+}

--- a/FEBuilderGBA.Avalonia/Views/EventFinalSerifFE7View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventFinalSerifFE7View.axaml
@@ -16,7 +16,7 @@
           <TextBlock AutomationProperties.AutomationId="EventFinalSerifFE7_Addr_Label" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Name="AddrLabel" VerticalAlignment="Center" Margin="0,4" />
 
           <TextBlock Grid.Row="1" Grid.Column="0" Text="Unit:" VerticalAlignment="Center" Margin="0,4" />
-          <NumericUpDown AutomationProperties.AutomationId="EventFinalSerifFE7_Unit_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="UnitBox" Minimum="0" Maximum="255" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventFinalSerifFE7_Unit_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="UnitBox" Minimum="1" Maximum="255" Margin="0,4" />
           <TextBlock AutomationProperties.AutomationId="EventFinalSerifFE7_UnitName_Label" Grid.Row="1" Grid.Column="2" Name="UnitNameLabel" VerticalAlignment="Center" TextWrapping="Wrap" Margin="8,4" />
 
           <TextBlock Grid.Row="2" Grid.Column="0" Text="Text:" VerticalAlignment="Center" Margin="0,4" />

--- a/FEBuilderGBA.Avalonia/Views/EventFinalSerifFE7View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventFinalSerifFE7View.axaml
@@ -11,10 +11,22 @@
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Final Serif (FE7)" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="EventFinalSerifFE7_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+        <Grid ColumnDefinitions="160,140,*" RowDefinitions="Auto,Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventFinalSerifFE7_Addr_Label" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Name="AddrLabel" VerticalAlignment="Center" Margin="0,4" />
+
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="Unit:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventFinalSerifFE7_Unit_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="UnitBox" Minimum="0" Maximum="255" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventFinalSerifFE7_UnitName_Label" Grid.Row="1" Grid.Column="2" Name="UnitNameLabel" VerticalAlignment="Center" TextWrapping="Wrap" Margin="8,4" />
+
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Text:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventFinalSerifFE7_Text_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="TextIdBox" Minimum="0" Maximum="65535" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventFinalSerifFE7_TextPreview_Label" Grid.Row="2" Grid.Column="2" Name="TextPreviewLabel" VerticalAlignment="Center" TextWrapping="Wrap" Margin="8,4" />
         </Grid>
+
+        <TextBlock Text="The per-character dialogue line shown in the final chapter." TextWrapping="Wrap" Foreground="Gray" Margin="0,8" />
+
+        <Button AutomationProperties.AutomationId="EventFinalSerifFE7_Write_Button" Name="WriteButton" Content="Write" HorizontalAlignment="Left" Margin="0,8" />
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/EventFinalSerifFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventFinalSerifFE7View.axaml.cs
@@ -9,6 +9,7 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class EventFinalSerifFE7View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventFinalSerifFE7ViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         public string ViewTitle => "Final Serif (FE7)";
         public bool IsLoaded => _vm.IsLoaded;
@@ -17,6 +18,12 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
+            WriteButton.Click += OnWrite;
+
+            // Live name/text previews while editing.
+            UnitBox.ValueChanged += (_, _) => UnitNameLabel.Text = UnitName(UnitBox);
+            TextIdBox.ValueChanged += (_, _) => TextPreviewLabel.Text = TextPreview(TextIdBox);
+
             Opened += (_, _) => LoadList();
         }
 
@@ -24,12 +31,18 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                _vm.IsLoading = true;
                 var items = _vm.LoadList();
                 EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitByIdLoader(items, i));
             }
             catch (Exception ex)
             {
-                Log.Error("EventFinalSerifFE7View.LoadList failed: {0}", ex.Message);
+                Log.Error("EventFinalSerifFE7View.LoadList failed: " + ex.ToString());
+            }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
             }
         }
 
@@ -37,18 +50,62 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                _vm.IsLoading = true;
                 _vm.LoadEntry(addr);
                 UpdateUI();
             }
             catch (Exception ex)
             {
-                Log.Error("EventFinalSerifFE7View.OnSelected failed: {0}", ex.Message);
+                Log.Error("EventFinalSerifFE7View.OnSelected failed: " + ex.ToString());
+            }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
             }
         }
 
         void UpdateUI()
         {
             AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            UnitBox.Value = _vm.Unit;
+            TextIdBox.Value = _vm.TextID;
+            UnitNameLabel.Text = UnitName(UnitBox);
+            TextPreviewLabel.Text = TextPreview(TextIdBox);
+        }
+
+        static string UnitName(NumericUpDown box)
+        {
+            try { return NameResolver.GetUnitNameByOneBasedId((uint)(box.Value ?? 0)); }
+            catch { return ""; }
+        }
+
+        static string TextPreview(NumericUpDown box)
+        {
+            uint id = (uint)(box.Value ?? 0);
+            if (id == 0) return "";
+            try { return NameResolver.GetTextById(id); }
+            catch { return ""; }
+        }
+
+        void OnWrite(object? sender, RoutedEventArgs e)
+        {
+            if (!_vm.IsLoaded) return;
+
+            _undoService.Begin(R._("Edit Final Serif (FE7)"));
+            try
+            {
+                _vm.Unit = (uint)(UnitBox.Value ?? 0);
+                _vm.TextID = (uint)(TextIdBox.Value ?? 0);
+                _vm.Write();
+                _undoService.Commit();
+                _vm.MarkClean();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("EventFinalSerifFE7View.OnWrite failed: " + ex.ToString());
+            }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/EventFinalSerifFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventFinalSerifFE7View.axaml.cs
@@ -33,7 +33,9 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 _vm.IsLoading = true;
                 var items = _vm.LoadList();
-                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitByIdLoader(items, i));
+                // The list label prefix is the row index, not the unit id — load the portrait from
+                // the entry's unit id (stored at +0, value <= 0xFF) instead of the label prefix.
+                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitFromAddrU8Loader(items, i));
             }
             catch (Exception ex)
             {

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20251,3 +20251,9 @@ Edit Battle Dialogue
 
 :Edit Battle Dialogue (FE6)
 Edit Battle Dialogue (FE6)
+
+:The per-character dialogue line shown in the final chapter.
+The per-character dialogue line shown in the final chapter.
+
+:Edit Final Serif (FE7)
+Edit Final Serif (FE7)

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11070,3 +11070,9 @@ UPSパッチを保存
 
 :Edit Battle Dialogue (FE6)
 戦闘会話の編集 (FE6)
+
+:The per-character dialogue line shown in the final chapter.
+最終章で表示されるキャラクターごとのセリフ。
+
+:Edit Final Serif (FE7)
+終章セリフの編集 (FE7)

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -24908,3 +24908,9 @@ A: 不使用 TSA 的背景 224 色(对话用)
 
 :Edit Battle Dialogue (FE6)
 编辑战斗对话 (FE6)
+
+:The per-character dialogue line shown in the final chapter.
+在最终章中显示的每个角色的台词。
+
+:Edit Final Serif (FE7)
+编辑终章台词 (FE7)


### PR DESCRIPTION
Fixes #1189

## What

Replaces the bare scaffold with a **functional Avalonia Final Serif (FE7) editor** with parity to WinForms `EventFinalSerifFE7Form` — the final-chapter per-character dialogue table (`event_final_serif`, FE7-only; 8-byte records: Unit id at +0, Text id at +4).

## Implementation

The `EventFinalSerifFE7ViewModel` (8-byte struct read/write + `IDataVerifiable`, already registered in `FormMappings`) was already implemented — the gap was purely the **View**:

- The two struct fields — **Unit** (id at +0) with a live unit-name preview (`NameResolver.GetUnitNameByOneBasedId`) and **Text** (id at +4) with a live text preview (`NameResolver.GetTextById`).
- Write-back wraps the VM's `Write()` in `UndoService.Begin/Commit` with `Rollback` on exception and `ex.ToString()` logging. Kept the window at 1238×806.

## Tests

`EventFinalSerifFE7ViewModelTests` — run on a real **FE7 ROM** via `RomTestHelper.WithRom("FE7U")` (`event_final_serif` is FE7-only; the FE8U fixture has no such table):
- list geometry (8-byte stride + `GetListCount` parity),
- Unit/Text read,
- write → read round-trip (restores the ROM).

Gates green: L10n coverage, AutomationId (script + test), the net9.0-windows **field-completeness suite**, and the Avalonia sweep tests. Two new literals localized in en/ja/zh.

## Screenshot (real GUI, `roms/FE7U.gba`)

![Final Serif (FE7) editor](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1189-finalserif-fe7.png)

The list shows the FE7 cast with their final-chapter lines (`0x00 Marcus`, `0x01 Lowen`, …); the detail panel resolves Unit `26 → Marcus` and Text `3785 →` his line ("I'll show you the strength of a knight of Pherae."). No path/username leak.

---
🔎 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.169` · model `claude-opus-4-8[1m]`