### PR TITLE
feat(avalonia): implement Unit Height Adjustment editor — port WinForms UnitIncreaseHeightForm (#1174)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/UnitIncreaseHeightViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/UnitIncreaseHeightViewModelTests.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+/// <summary>
+/// Headless ROM-backed tests for <see cref="UnitIncreaseHeightViewModel"/> (issue #1174 —
+/// port of WinForms <c>UnitIncreaseHeightForm</c>). The "tall portrait" status-screen height table
+/// is native to FE8 (the switch2 SUB/CMP pattern matches in vanilla), so the FE8U fixture has data.
+/// Each 4-byte row holds the height marker (unit_increase_height_no / _yes).
+/// </summary>
+[Collection("SharedState")]
+public class UnitIncreaseHeightViewModelTests : IClassFixture<RomFixture>
+{
+    private readonly RomFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public UnitIncreaseHeightViewModelTests(RomFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    bool Skip()
+    {
+        if (!_fixture.IsAvailable)
+        {
+            _output.WriteLine("RomFixture not available — skipping.");
+            return true;
+        }
+        return false;
+    }
+
+    [Fact]
+    public void LoadList_ReturnsEntries_FourBytesApart()
+    {
+        if (Skip()) return;
+
+        var vm = new UnitIncreaseHeightViewModel();
+        List<AddrResult> list = vm.LoadList();
+
+        Assert.NotEmpty(list);
+        Assert.Equal(list.Count, vm.GetListCount());
+        for (int i = 1; i < list.Count; i++)
+        {
+            Assert.Equal(list[i - 1].addr + 4, list[i].addr);
+        }
+    }
+
+    [Fact]
+    public void LoadEntry_ReadsHeightValue()
+    {
+        if (Skip()) return;
+
+        var vm = new UnitIncreaseHeightViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        uint addr = list[0].addr;
+        vm.LoadEntry(addr);
+
+        Assert.True(vm.IsLoaded);
+        Assert.Equal(addr, vm.CurrentAddr);
+        Assert.Equal(CoreState.ROM.u32(addr), vm.HeightValue);
+    }
+
+    [Fact]
+    public void WriteEntry_RoundTripsHeightValue()
+    {
+        if (Skip()) return;
+
+        var vm = new UnitIncreaseHeightViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        uint addr = list[0].addr;
+        vm.LoadEntry(addr);
+        uint orig = vm.HeightValue;
+
+        // Toggle between the two valid marker values.
+        uint yes = CoreState.ROM.RomInfo.unit_increase_height_yes;
+        uint no = CoreState.ROM.RomInfo.unit_increase_height_no;
+        uint target = orig == yes ? no : yes;
+
+        try
+        {
+            vm.HeightValue = target;
+            vm.WriteEntry();
+
+            var vm2 = new UnitIncreaseHeightViewModel();
+            vm2.LoadEntry(addr);
+            Assert.Equal(target, vm2.HeightValue);
+        }
+        finally
+        {
+            vm.HeightValue = orig;
+            vm.WriteEntry();
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Views/UnitIncreaseHeightView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/UnitIncreaseHeightView.axaml
@@ -11,10 +11,20 @@
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Unit Height Adjustment" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="UnitIncreaseHeight_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+        <Grid ColumnDefinitions="160,300" RowDefinitions="Auto,Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="UnitIncreaseHeight_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" Margin="0,4" />
+
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="Height:" VerticalAlignment="Center" Margin="0,4" />
+          <ComboBox AutomationProperties.AutomationId="UnitIncreaseHeight_Height_Combo" Grid.Row="1" Grid.Column="1" Name="HeightCombo" HorizontalAlignment="Stretch" Margin="0,4" />
+
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Height Value:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="UnitIncreaseHeight_HeightValue_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="HeightValueBox" Minimum="0" Maximum="4294967295" Increment="1" Margin="0,4" />
         </Grid>
+
+        <TextBlock Text="Whether this portrait is stretched taller on the status screen." TextWrapping="Wrap" Foreground="Gray" Margin="0,8" />
+
+        <Button AutomationProperties.AutomationId="UnitIncreaseHeight_Write_Button" Name="WriteButton" Content="Write" HorizontalAlignment="Left" Margin="0,8" />
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/UnitIncreaseHeightView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/UnitIncreaseHeightView.axaml.cs
@@ -9,6 +9,7 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class UnitIncreaseHeightView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly UnitIncreaseHeightViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         // True once Opened -> LoadList() has populated EntryList. A NavigateTo
         // request that arrives BEFORE the list loads (WindowManager.Open then an
@@ -18,6 +19,7 @@ namespace FEBuilderGBA.Avalonia.Views
         // still-empty list. Mirrors MonsterProbabilityViewerView (#1018/#1019).
         bool _listLoaded;
         uint? _pendingNavigateAddr;
+        bool _syncing;
 
         public string ViewTitle => "Unit Height Adjustment";
         public bool IsLoaded => _vm.IsLoaded;
@@ -26,6 +28,13 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
+            WriteButton.Click += OnWrite;
+
+            // "Stretch" / "Don't Stretch" map to the unit_increase_height_yes / _no marker values.
+            HeightCombo.ItemsSource = new[] { R._("Don't Stretch"), R._("Stretch") };
+            HeightCombo.SelectionChanged += OnComboChanged;
+            HeightValueBox.ValueChanged += OnHeightValueChanged;
+
             Opened += (_, _) => LoadList();
         }
 
@@ -33,13 +42,19 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                _vm.IsLoading = true;
                 var items = _vm.LoadList();
                 EntryList.SetItemsWithIcons(items, i => ListIconLoaders.PortraitLoader(items, i));
                 _listLoaded = true;
             }
             catch (Exception ex)
             {
-                Log.Error("UnitIncreaseHeightView.LoadList failed: {0}", ex.Message);
+                Log.Error("UnitIncreaseHeightView.LoadList failed: " + ex.ToString());
+            }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
             }
 
             // Replay a navigation requested before the list was ready.
@@ -54,18 +69,83 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                _vm.IsLoading = true;
                 _vm.LoadEntry(addr);
                 UpdateUI();
             }
             catch (Exception ex)
             {
-                Log.Error("UnitIncreaseHeightView.OnSelected failed: {0}", ex.Message);
+                Log.Error("UnitIncreaseHeightView.OnSelected failed: " + ex.ToString());
+            }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
             }
         }
 
         void UpdateUI()
         {
-            AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            _syncing = true;
+            try
+            {
+                AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+                HeightValueBox.Value = _vm.HeightValue;
+                HeightCombo.SelectedIndex = ComboIndexFor(_vm.HeightValue);
+            }
+            finally
+            {
+                _syncing = false;
+            }
+        }
+
+        static uint NoValue() => CoreState.ROM?.RomInfo?.unit_increase_height_no ?? 0;
+        static uint YesValue() => CoreState.ROM?.RomInfo?.unit_increase_height_yes ?? 0;
+
+        static int ComboIndexFor(uint value)
+        {
+            if (value == YesValue()) return 1;
+            if (value == NoValue()) return 0;
+            return -1;
+        }
+
+        // Picking Stretch/Don't Stretch sets the raw marker value.
+        void OnComboChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_syncing) return;
+            int idx = HeightCombo.SelectedIndex;
+            if (idx < 0) return;
+            _syncing = true;
+            try { HeightValueBox.Value = idx == 1 ? YesValue() : NoValue(); }
+            finally { _syncing = false; }
+        }
+
+        // Editing the raw value re-selects the matching combo entry (or clears it).
+        void OnHeightValueChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            if (_syncing) return;
+            _syncing = true;
+            try { HeightCombo.SelectedIndex = ComboIndexFor((uint)(HeightValueBox.Value ?? 0)); }
+            finally { _syncing = false; }
+        }
+
+        void OnWrite(object? sender, RoutedEventArgs e)
+        {
+            if (!_vm.IsLoaded) return;
+
+            _undoService.Begin(R._("Edit Unit Height Adjustment"));
+            try
+            {
+                _vm.HeightValue = (uint)(HeightValueBox.Value ?? 0);
+                _vm.WriteEntry();
+                _undoService.Commit();
+                _vm.MarkClean();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("UnitIncreaseHeightView.OnWrite failed: " + ex.ToString());
+            }
         }
 
         public void NavigateTo(uint address)

--- a/FEBuilderGBA.Avalonia/Views/UnitIncreaseHeightView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/UnitIncreaseHeightView.axaml.cs
@@ -31,11 +31,31 @@ namespace FEBuilderGBA.Avalonia.Views
             WriteButton.Click += OnWrite;
 
             // "Stretch" / "Don't Stretch" map to the unit_increase_height_yes / _no marker values.
-            HeightCombo.ItemsSource = new[] { R._("Don't Stretch"), R._("Stretch") };
             HeightCombo.SelectionChanged += OnComboChanged;
             HeightValueBox.ValueChanged += OnHeightValueChanged;
+            RebuildHeightCombo();
+
+            // TranslatedWindow auto-translates Text/Content, but NOT ComboBox items — rebuild the
+            // combo labels ourselves on a runtime language change (preserving the selection).
+            CoreState.LanguageChanged += RebuildHeightCombo;
+            Closed += (_, _) => CoreState.LanguageChanged -= RebuildHeightCombo;
 
             Opened += (_, _) => LoadList();
+        }
+
+        void RebuildHeightCombo()
+        {
+            int sel = HeightCombo.SelectedIndex;
+            _syncing = true;
+            try
+            {
+                HeightCombo.ItemsSource = new[] { R._("Don't Stretch"), R._("Stretch") };
+                HeightCombo.SelectedIndex = sel;
+            }
+            finally
+            {
+                _syncing = false;
+            }
         }
 
         void LoadList()

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20257,3 +20257,18 @@ The per-character dialogue line shown in the final chapter.
 
 :Edit Final Serif (FE7)
 Edit Final Serif (FE7)
+
+:Height Value:
+Height Value:
+
+:Whether this portrait is stretched taller on the status screen.
+Whether this portrait is stretched taller on the status screen.
+
+:Don't Stretch
+Don't Stretch
+
+:Stretch
+Stretch
+
+:Edit Unit Height Adjustment
+Edit Unit Height Adjustment

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11076,3 +11076,18 @@ UPSパッチを保存
 
 :Edit Final Serif (FE7)
 終章セリフの編集 (FE7)
+
+:Height Value:
+身長値:
+
+:Whether this portrait is stretched taller on the status screen.
+このポートレートをステータス画面で背を高く伸ばすかどうか。
+
+:Don't Stretch
+伸ばさない
+
+:Stretch
+伸ばす
+
+:Edit Unit Height Adjustment
+身長調整の編集

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -24914,3 +24914,18 @@ A: 不使用 TSA 的背景 224 色(对话用)
 
 :Edit Final Serif (FE7)
 编辑终章台词 (FE7)
+
+:Height Value:
+身高值:
+
+:Whether this portrait is stretched taller on the status screen.
+此立绘是否在状态画面中被拉高。
+
+:Don't Stretch
+不拉伸
+
+:Stretch
+拉伸
+
+:Edit Unit Height Adjustment
+编辑身高调整


### PR DESCRIPTION
Fixes #1174

## What

Replaces the address-list scaffold with a **functional Avalonia Unit Height Adjustment editor** with parity to WinForms `UnitIncreaseHeightForm` — the per-portrait "tall portrait" status-screen height table.

**Not patch-gated:** the height feature is **native to vanilla FE8** (the switch2 `SUB`/`CMP` instruction pattern matches at `unit_increase_height_switch2_address`), so the editor shows real data on a clean FE8U ROM.

## Implementation

The `UnitIncreaseHeightViewModel` (height-marker read/write + `IDataVerifiable` + `IdToAddress`, already registered in `FormMappings`) was already implemented — the gap was the **editing controls** in the View:

- A **Height combo** ("Don't Stretch" / "Stretch") mapped to the `unit_increase_height_no` / `_yes` marker values, plus a raw **Height Value** field. The combo and field stay in sync bidirectionally (a `_syncing` reentrancy guard).
- Write-back wraps `WriteEntry()` in `UndoService.Begin/Commit` with `Rollback` on exception and `ex.ToString()` logging. Kept the window at 1185×658.
- **Preserved** the existing `NavigateToId`/pending-navigate logic (the Portrait→Height jump, #1019).

## Tests

`UnitIncreaseHeightViewModelTests` (FE8U fixture):
- list geometry (4-byte stride + `GetListCount` parity),
- height read,
- no↔yes marker write → read round-trip.

Gates green: L10n coverage, AutomationId (script + test), the net9.0-windows **field-completeness suite**, and the Avalonia sweep tests. New literals localized in en/ja/zh.

## Screenshot (real GUI, `roms/FE8U.gba`)

![Unit Height Adjustment editor](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1174-unitheight-fe8u.png)

The list shows the FE8 portraits with height rows (`10 Lute`, `11 Natasha`, `13 Cormag`, `14 Ephraim`, …); the detail panel shows Lute resolved to **Height: "Stretch"** with its raw marker value. No path/username leak.

---
🔎 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.169` · model `claude-opus-4-8[1m]`