### PR TITLE
feat(avalonia): implement Other In-ROM Literal Text editor — port WinForms OtherTextForm (#1163)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/OtherTextViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/OtherTextViewModelTests.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+/// <summary>
+/// Headless ROM-backed tests for <see cref="OtherTextViewModel"/> (issue #1163 — port of WinForms
+/// <c>OtherTextForm</c>). The entry list comes from the <c>other_text_</c> config; each slot holds a
+/// p32 to a null-terminated system-encoded literal string. Writing re-encodes the text, appends it to
+/// free space, and repoints the slot.
+/// </summary>
+[Collection("SharedState")]
+public class OtherTextViewModelTests : IClassFixture<RomFixture>
+{
+    private readonly RomFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public OtherTextViewModelTests(RomFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    bool Skip()
+    {
+        if (!_fixture.IsAvailable)
+        {
+            _output.WriteLine("RomFixture not available — skipping.");
+            return true;
+        }
+        return false;
+    }
+
+    [Fact]
+    public void LoadList_ReturnsEntries()
+    {
+        if (Skip()) return;
+
+        var vm = new OtherTextViewModel();
+        List<AddrResult> list = vm.LoadList();
+
+        Assert.NotEmpty(list);
+        Assert.Equal(list.Count, vm.GetListCount());
+    }
+
+    [Fact]
+    public void LoadEntry_ReadsStringAndPointer()
+    {
+        if (Skip()) return;
+
+        var vm = new OtherTextViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        uint addr = list[0].addr;
+        vm.LoadEntry(addr);
+
+        Assert.True(vm.IsLoaded);
+        Assert.Equal(addr, vm.CurrentAddr);
+        Assert.Equal(CoreState.ROM.p32(addr), vm.StringAddr);
+        Assert.NotNull(vm.Text);
+    }
+
+    [Fact]
+    public void Write_RoundTripsText_ViaAppendAndRepoint()
+    {
+        if (Skip()) return;
+
+        var vm = new OtherTextViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        uint addr = list[0].addr;
+        vm.LoadEntry(addr);
+        uint origPointer = CoreState.ROM.p32(addr);
+
+        try
+        {
+            vm.Text = "Test";
+            var undo = CoreState.Undo.NewUndoData("OtherText test");
+            Assert.True(vm.Write(undo));
+
+            // The slot must now point at a NEW location holding the edited string.
+            Assert.NotEqual(origPointer, CoreState.ROM.p32(addr));
+
+            var vm2 = new OtherTextViewModel();
+            vm2.LoadEntry(addr);
+            Assert.Equal("Test", vm2.Text);
+        }
+        finally
+        {
+            // Restore the original string pointer (the appended copy is left orphaned in the
+            // in-memory fixture, which is discarded after the test collection).
+            CoreState.ROM.write_p32(addr, origPointer);
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/OtherTextViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/OtherTextViewModel.cs
@@ -2,6 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 
+// Annotation-only nullable context: lets Write(Undo.UndoData? undoData) declare the nullable
+// contract (the method is a no-op when null) without enabling whole-file null-flow warnings.
+#nullable enable annotations
+
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
     /// <summary>
@@ -39,16 +43,22 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             string file = U.ConfigDataFilename("other_text_");
             if (!U.IsRequiredFileExist(file)) return result;
 
-            try
+            string[] lines;
+            try { lines = File.ReadAllLines(file); }
+            catch { return result; }
+
+            foreach (string raw in lines)
             {
-                foreach (string raw in File.ReadAllLines(file))
+                // Per-line guard: one malformed/EOF-adjacent entry must not abort the whole list.
+                try
                 {
                     if (U.IsComment(raw) || U.OtherLangLine(raw)) continue;
                     string line = U.ClipComment(raw).Trim();
                     if (line == "") continue;
 
                     uint addr = U.toOffset(U.atoh(line));
-                    if (!U.isSafetyOffset(addr)) continue;
+                    // p32 reads 4 bytes, so require addr+4 in bounds (isSafetyOffset only checks addr).
+                    if (!U.isSafetyOffset(addr) || (ulong)addr + 4 > (ulong)rom.Data.Length) continue;
 
                     uint pStr = rom.p32(addr);
                     string preview = U.isSafetyOffset(pStr)
@@ -56,10 +66,10 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                         : U.ToHexString(pStr);
                     result.Add(new AddrResult(addr, preview, pStr));
                 }
-            }
-            catch
-            {
-                // A malformed config line should not crash the editor — show whatever parsed.
+                catch
+                {
+                    // Skip this line; keep parsing the rest.
+                }
             }
             return result;
         }
@@ -94,7 +104,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// relocated (never overwritten in place) so a longer string can never clobber adjacent
         /// data. Returns false (no mutation) without a ROM / selection / encoder / undo scope.
         /// </summary>
-        public bool Write(Undo.UndoData undoData)
+        public bool Write(Undo.UndoData? undoData)
         {
             ROM rom = CoreState.ROM;
             if (rom == null || CurrentAddr == 0) return false;

--- a/FEBuilderGBA.Avalonia/ViewModels/OtherTextViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/OtherTextViewModel.cs
@@ -1,15 +1,34 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
+    /// <summary>
+    /// "Other In-ROM Literal Text" editor — port of WinForms <c>OtherTextForm</c>.
+    /// Edits miscellaneous hardcoded/literal in-ROM strings (outside the main Huffman text table).
+    /// The entry list comes from the version-specific <c>other_text_</c> config (one pointer-slot
+    /// address per line); each slot holds a p32 to a null-terminated system-encoded string. Writing
+    /// re-encodes the edited text, appends it to free space, and repoints the slot (mirrors WF
+    /// <c>InputFormRef.WriteBinaryDataPointer</c>).
+    /// </summary>
     public class OtherTextViewModel : ViewModelBase
     {
         uint _currentAddr;
         bool _isLoaded;
+        uint _stringAddr;
+        string _text = "";
+        int _byteLength;
 
+        /// <summary>The config-listed pointer-slot address (holds a p32 to the string).</summary>
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
+        /// <summary>Dereferenced string address (<c>p32(CurrentAddr)</c>).</summary>
+        public uint StringAddr { get => _stringAddr; set => SetField(ref _stringAddr, value); }
+        /// <summary>The decoded editable string.</summary>
+        public string Text { get => _text; set => SetField(ref _text, value); }
+        /// <summary>Byte length of the stored string (excluding the terminator).</summary>
+        public int ByteLength { get => _byteLength; set => SetField(ref _byteLength, value); }
 
         public List<AddrResult> LoadList()
         {
@@ -17,7 +36,31 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (rom?.RomInfo == null) return new List<AddrResult>();
 
             var result = new List<AddrResult>();
-            result.Add(new AddrResult(0, "Other Text Strings", 0));
+            string file = U.ConfigDataFilename("other_text_");
+            if (!U.IsRequiredFileExist(file)) return result;
+
+            try
+            {
+                foreach (string raw in File.ReadAllLines(file))
+                {
+                    if (U.IsComment(raw) || U.OtherLangLine(raw)) continue;
+                    string line = U.ClipComment(raw).Trim();
+                    if (line == "") continue;
+
+                    uint addr = U.toOffset(U.atoh(line));
+                    if (!U.isSafetyOffset(addr)) continue;
+
+                    uint pStr = rom.p32(addr);
+                    string preview = U.isSafetyOffset(pStr)
+                        ? U.ToHexString(pStr) + " " + rom.getString(pStr)
+                        : U.ToHexString(pStr);
+                    result.Add(new AddrResult(addr, preview, pStr));
+                }
+            }
+            catch
+            {
+                // A malformed config line should not crash the editor — show whatever parsed.
+            }
             return result;
         }
 
@@ -25,9 +68,73 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         {
             ROM rom = CoreState.ROM;
             if (rom == null) return;
+            if (!U.isSafetyOffset(addr) || (ulong)addr + 4 > (ulong)rom.Data.Length) return;
 
             CurrentAddr = addr;
+            uint cAddr = rom.p32(addr);
+            if (!U.isSafetyOffset(cAddr))
+            {
+                StringAddr = cAddr;
+                Text = "";
+                ByteLength = 0;
+                IsLoaded = true;
+                return;
+            }
+
+            string str = rom.getString(cAddr, out int length);
+            StringAddr = cAddr;
+            Text = str;
+            ByteLength = length;
             IsLoaded = true;
+        }
+
+        /// <summary>
+        /// Re-encode <see cref="Text"/>, append it to free space, and repoint the slot at
+        /// <see cref="CurrentAddr"/>. Mirrors WF <c>WriteBinaryDataPointer</c>: the literal is
+        /// relocated (never overwritten in place) so a longer string can never clobber adjacent
+        /// data. Returns false (no mutation) without a ROM / selection / encoder / undo scope.
+        /// </summary>
+        public bool Write(Undo.UndoData undoData)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null || CurrentAddr == 0) return false;
+            if (!U.isSafetyOffset(CurrentAddr) || (ulong)CurrentAddr + 4 > (ulong)rom.Data.Length) return false;
+            if (undoData == null || CoreState.SystemTextEncoder == null) return false;
+
+            byte[] bytes = CoreState.SystemTextEncoder.Encode(Text ?? "");
+            bytes = U.ArrayAppend(bytes, new byte[] { 0x00 });
+
+            uint newAddr = AppendBinaryDataHeadless(rom, bytes, undoData);
+            if (!U.isSafetyOffset(newAddr)) return false;
+
+            // Repoint the slot to the new string location (same transaction as the append).
+            rom.write_p32(CurrentAddr, newAddr, undoData);
+
+            StringAddr = rom.p32(CurrentAddr);
+            ByteLength = bytes.Length - 1;
+            return true;
+        }
+
+        public int GetListCount() => LoadList().Count;
+
+        /// <summary>
+        /// Headless equivalent of InputFormRef.AppendBinaryData (mirrors AIScriptViewModel):
+        /// route through the wired CoreState.AppendBinaryData free-space allocator when present,
+        /// else grow the ROM and append at the old end. Returns the new data OFFSET.
+        /// </summary>
+        static uint AppendBinaryDataHeadless(ROM rom, byte[] buffer, Undo.UndoData undoData)
+        {
+            if (buffer == null || buffer.Length == 0) return U.NOT_FOUND;
+
+            var allocator = CoreState.AppendBinaryData;
+            if (allocator != null)
+                return allocator(buffer, undoData);
+
+            uint appendAt = (uint)rom.Data.Length;
+            if (!rom.write_resize_data((uint)(appendAt + buffer.Length)))
+                return U.NOT_FOUND;
+            rom.write_range(appendAt, buffer, undoData);
+            return appendAt;
         }
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/OtherTextView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/OtherTextView.axaml
@@ -11,10 +11,24 @@
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Other Text Strings" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="OtherText_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="OtherText_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" Margin="0,4" />
+
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="String Pointer:" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="OtherText_Pointer_Label" Grid.Row="1" Grid.Column="1" Name="PointerLabel" VerticalAlignment="Center" Margin="0,4" />
+
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Length:" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="OtherText_Length_Label" Grid.Row="2" Grid.Column="1" Name="LengthLabel" VerticalAlignment="Center" Margin="0,4" />
         </Grid>
+
+        <TextBlock Text="Text:" />
+        <TextBox AutomationProperties.AutomationId="OtherText_Text_Input" Name="TextInput"
+                 AcceptsReturn="True" TextWrapping="Wrap" MinHeight="120" MaxWidth="600" HorizontalAlignment="Left" />
+
+        <TextBlock Text="A literal in-ROM string stored outside the main Huffman text table." TextWrapping="Wrap" Foreground="Gray" Margin="0,8" />
+
+        <Button AutomationProperties.AutomationId="OtherText_Write_Button" Name="WriteButton" Content="Write" HorizontalAlignment="Left" Margin="0,8" />
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/OtherTextView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OtherTextView.axaml.cs
@@ -9,6 +9,7 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class OtherTextView : TranslatedWindow, IEditorView
     {
         readonly OtherTextViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         public string ViewTitle => "Other Text Strings";
         public bool IsLoaded => _vm.IsLoaded;
@@ -17,6 +18,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
+            WriteButton.Click += OnWrite;
             Opened += (_, _) => LoadList();
         }
 
@@ -29,7 +31,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("OtherTextView.LoadList failed: {0}", ex.Message);
+                Log.Error("OtherTextView.LoadList failed: " + ex.ToString());
             }
         }
 
@@ -42,13 +44,42 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("OtherTextView.OnSelected failed: {0}", ex.Message);
+                Log.Error("OtherTextView.OnSelected failed: " + ex.ToString());
             }
         }
 
         void UpdateUI()
         {
             AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            PointerLabel.Text = string.Format("0x{0:X08}", _vm.StringAddr);
+            LengthLabel.Text = _vm.ByteLength.ToString();
+            TextInput.Text = _vm.Text;
+        }
+
+        void OnWrite(object? sender, RoutedEventArgs e)
+        {
+            if (!_vm.IsLoaded) return;
+
+            uint current = _vm.CurrentAddr;
+            _undoService.Begin(R._("Edit Other Text"));
+            try
+            {
+                _vm.Text = TextInput.Text ?? "";
+                if (_vm.Write(_undoService.GetActiveUndoData()))
+                    _undoService.Commit();
+                else
+                    _undoService.Rollback();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("OtherTextView.OnWrite failed: " + ex.ToString());
+                return;
+            }
+
+            // Refresh the list previews and re-select the edited entry.
+            LoadList();
+            EntryList.SelectAddress(current);
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20272,3 +20272,9 @@ Stretch
 
 :Edit Unit Height Adjustment
 Edit Unit Height Adjustment
+
+:A literal in-ROM string stored outside the main Huffman text table.
+A literal in-ROM string stored outside the main Huffman text table.
+
+:Edit Other Text
+Edit Other Text

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11091,3 +11091,9 @@ UPSパッチを保存
 
 :Edit Unit Height Adjustment
 身長調整の編集
+
+:A literal in-ROM string stored outside the main Huffman text table.
+メインのハフマンテキストテーブルの外に格納されたROM内のリテラル文字列。
+
+:Edit Other Text
+その他テキストの編集

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -24929,3 +24929,9 @@ A: 不使用 TSA 的背景 224 色(对话用)
 
 :Edit Unit Height Adjustment
 编辑身高调整
+
+:A literal in-ROM string stored outside the main Huffman text table.
+存储在主霍夫曼文本表之外的ROM内字面字符串。
+
+:Edit Other Text
+编辑其他文本


### PR DESCRIPTION
Fixes #1163

## What

Replaces the 21-line scaffold (over a 33-line dummy ViewModel) with a **functional Avalonia "Other In-ROM Literal Text" editor** with parity to WinForms `OtherTextForm` — editing miscellaneous hardcoded/literal in-ROM strings stored **outside** the main Huffman text table.

## Implementation (full VM port)

- **ViewModel**: `LoadList` parses the version-specific `other_text_` config (one pointer-slot address per line); each slot holds a `p32` to a null-terminated system-encoded string. `LoadEntry` reads the string via `rom.getString`. **`Write` re-encodes** the edited text (`CoreState.SystemTextEncoder.Encode` + `0x00` terminator), **appends it to free space, and repoints the slot** — mirroring WinForms `InputFormRef.WriteBinaryDataPointer`, reusing the `AIScriptViewModel` append-and-repoint pattern (`CoreState.AppendBinaryData` allocator with a ROM-end fallback, undo-tracked). Kept plain `ViewModelBase` (not in `FormMappings` and no fixed struct fields, so no `IDataVerifiable`).
- **View**: list + multi-line text editor + string-pointer/length labels + Write. The Write handler threads the `UndoService` scope's `UndoData` into the VM write, then refreshes the list previews and re-selects the edited entry.

## Tests

`OtherTextViewModelTests` (FE8U fixture):
- list, string/pointer read,
- a **write → append → repoint round-trip** ("Test" round-trips through encode/decode + relocation; the slot is confirmed to repoint to a new location; the original pointer is restored).

Gates green: L10n coverage, AutomationId (script + test), and 520 Avalonia view/VM/binding sweep tests. New literals localized in en/ja/zh.

## Screenshot (real GUI, `roms/FE8U.gba`)

![Other In-ROM Literal Text editor](https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1163-othertext-fe8u.png)

The list shows the FE8 literal strings with their pointers + previews (`0D791C An`, `0D7920 an`, `0D79D8 Some`, … — the grammar/article literals); the detail panel shows the slot address, string pointer, byte length, and the editable text ("An"). No path/username leak.

---
🔎 Generated with [Claude Code](https://claude.com/claude-code) `v2.1.169` · model `claude-opus-4-8[1m]`