### PR TITLE
feat(avalonia): port AP MD5-dictionary selector to Unit Move Icon editor (#1226)

### DIFF
--- a/FEBuilderGBA.Avalonia/ViewModels/ImageUnitMoveIconViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageUnitMoveIconViewModel.cs
@@ -83,6 +83,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 : 0;
 
             LoadComment();
+            RefreshCurrentApName();
             IsLoaded = true;
         }
 
@@ -287,6 +288,124 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             uint entryAddr = baseAddr + waitIcon * 8;
             if (entryAddr + 8 > (uint)rom.Data.Length) return null;
             return entryAddr;
+        }
+
+        // ----------------------------------------------------------------
+        // AP MD5-dictionary selector (#1226) — port of WF
+        // ImageUnitMoveIconFrom's ap_list_ / ap_vanilla_list_ combo.
+        //
+        // ap_list_ALL.txt (name\tmd5) → {md5 → name} via LoadTSVResourcePair.
+        // ap_vanilla_list_FE6/7/8.txt (offsetHex\tmd5\t{J}) → {offset → md5}
+        // via LoadTSVResource1. The combo lets the user pick a known AP pattern
+        // by name; selecting it RE-POINTS the current entry's +4 (P4) pointer to
+        // an EXISTING ROM AP region matching that pattern's MD5 (an entry's
+        // current AP, or a still-intact vanilla AP). It NEVER writes AP bytes —
+        // that's the separate ImportAP path.
+        // ----------------------------------------------------------------
+
+        // {md5 → display name} catalog (ap_list_).
+        Dictionary<string, string> _apComboDic;
+        // Display names in file order (combo item order, mirrors WF Items.Add loop).
+        List<string> _apCatalogNames;
+        // {vanilla offset → md5} (ap_vanilla_list_).
+        Dictionary<uint, string> _apVanillaDic;
+        string _currentApName = string.Empty;
+
+        void EnsureCatalogLoaded()
+        {
+            if (_apComboDic != null) return;
+
+            _apComboDic = U.LoadTSVResourcePair(U.ConfigDataFilename("ap_list_"));
+
+            _apCatalogNames = new List<string>();
+            foreach (var pair in _apComboDic)
+                _apCatalogNames.Add(pair.Value);
+
+            // Vanilla list: only keep safely-offset addresses (WF MakeAPBanillaDic).
+            _apVanillaDic = new Dictionary<uint, string>();
+            ROM rom = CoreState.ROM;
+            Dictionary<uint, string> raw = U.LoadTSVResource1(U.ConfigDataFilename("ap_vanilla_list_"));
+            foreach (var pair in raw)
+            {
+                uint apOff = pair.Key;
+                if (rom != null && !U.isSafetyOffset(apOff, rom)) continue;
+                _apVanillaDic[apOff] = pair.Value;
+            }
+        }
+
+        /// <summary>
+        /// The AP pattern display names (combo items), in resource file order.
+        /// Loaded lazily from <c>config/data/ap_list_*.txt</c>.
+        /// </summary>
+        public List<string> ApCatalogNames
+        {
+            get { EnsureCatalogLoaded(); return _apCatalogNames; }
+        }
+
+        /// <summary>
+        /// The catalog name matched to the CURRENT entry's AP (by its P4 MD5), or
+        /// "" when the AP is unknown / unparseable. Mirrors WF
+        /// <c>SelectAPComboFromAPAddresss</c> selecting the combo entry.
+        /// </summary>
+        public string CurrentApName { get => _currentApName; private set => SetField(ref _currentApName, value); }
+
+        /// <summary>
+        /// Recompute <see cref="CurrentApName"/> from the current P4 AP's MD5.
+        /// READ-ONLY — never mutates the ROM. Call after LoadEntry / a P4 change.
+        /// </summary>
+        public void RefreshCurrentApName()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null || P4 == 0) { CurrentApName = string.Empty; return; }
+
+            EnsureCatalogLoaded();
+            uint apOff = U.toOffset(P4);
+            string md5 = ImageUtilAPCore.CalcAPMD5(rom.Data, apOff);
+            CurrentApName = _apComboDic.TryGetValue(md5, out string name) ? name : string.Empty;
+        }
+
+        /// <summary>
+        /// Resolve a chosen catalog AP <paramref name="name"/> to an EXISTING ROM
+        /// AP offset and re-point the current entry's in-memory P4 to it (the View
+        /// then commits the single P4 write under its ambient undo scope, byte
+        /// minimal). READ-ONLY resolution: scans the move-icon table's current AP
+        /// hashes and the still-intact vanilla APs. Returns "" on success; a
+        /// localized error string (and NO P4 change) when the chosen AP is not
+        /// present in this ROM — mirroring WF's "AP not in this ROM" stop error.
+        /// </summary>
+        public string ApplyApByName(string name)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null) return R._("ROM is not loaded.");
+            if (string.IsNullOrEmpty(name)) return string.Empty;
+
+            EnsureCatalogLoaded();
+
+            // name → md5 (WF SelectAPAddresssFromAPComboLow first loop).
+            string targetMd5 = string.Empty;
+            foreach (var pair in _apComboDic)
+            {
+                if (pair.Value == name) { targetMd5 = pair.Key; break; }
+            }
+            if (string.IsNullOrEmpty(targetMd5)) return string.Empty; // unknown name → no-op
+
+            // Already pointing at a region with this MD5 → nothing to do (avoids a
+            // redundant write / undo entry when the combo re-selects the current AP).
+            if (P4 != 0 && ImageUtilAPCore.CalcAPMD5(rom.Data, U.toOffset(P4)) == targetMd5)
+                return string.Empty;
+
+            Dictionary<uint, string> entryApMd5 =
+                ImageUtilAPCore.MakeAPAddressDic(rom.Data, TableBase, DataCount);
+
+            uint apOff = ImageUtilAPCore.ResolveApOffsetByMd5(rom.Data, targetMd5, entryApMd5, _apVanillaDic);
+            if (apOff == U.NOT_FOUND)
+            {
+                return R._("This AP pattern is not present in this ROM. Import the AP data, or enter the AP pointer manually.");
+            }
+
+            P4 = U.toPointer(apOff);
+            RefreshCurrentApName();
+            return string.Empty;
         }
 
         public int GetListCount() => LoadList().Count;

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitMoveIconView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitMoveIconView.axaml
@@ -34,6 +34,28 @@
                          Minimum="0" Maximum="4294967295" Increment="1" FormatString="0" />
         </Grid>
 
+        <!-- AP pattern MD5 selector (#1226). The combo lists known vanilla AP
+             (move-anime) patterns from config/data/ap_list_*.txt; the items are
+             RESOURCE DATA names (bound in code-behind), NOT translatable UI text.
+             Selecting a pattern re-points the entry's P4 to a matching EXISTING
+             ROM AP region (an entry's current AP, or a still-intact vanilla AP) —
+             it never writes AP bytes. The label below shows the pattern the
+             CURRENT entry's AP matches (mirrors WF X_APCOMBO + X_AP_MD5). The
+             "AP Pattern:" label is an English XAML literal so the shared
+             ViewTranslationHelper localizes it via R._() (ja/zh in
+             config/translate). -->
+        <Grid ColumnDefinitions="160,200" RowDefinitions="Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="AP Pattern:" VerticalAlignment="Center" />
+          <ComboBox AutomationProperties.AutomationId="ImageUnitMoveIcon_ApPattern_Combo"
+                    Grid.Row="0" Grid.Column="1" Name="ApPatternCombo"
+                    SelectionChanged="ApPattern_Changed" HorizontalAlignment="Stretch" />
+
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="Current AP:" VerticalAlignment="Center" />
+          <TextBlock AutomationProperties.AutomationId="ImageUnitMoveIcon_ApMatched_Label"
+                     Grid.Row="1" Grid.Column="1" Name="ApMatchedLabel"
+                     VerticalAlignment="Center" TextWrapping="Wrap" />
+        </Grid>
+
         <!-- Preview controls: palette + step -->
         <Grid ColumnDefinitions="160,200" RowDefinitions="Auto,Auto">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Palette:" VerticalAlignment="Center" />

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitMoveIconView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitMoveIconView.axaml.cs
@@ -39,8 +39,14 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 var items = _vm.LoadList();
-                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.MoveIconLoader(items, i));
+                // Populate the AP combo's ItemsSource BEFORE SetItemsWithIcons,
+                // which auto-selects the first entry → OnSelected → UpdateUI. If the
+                // combo's ItemsSource is not yet set, UpdateUI's SelectedItem = matched
+                // assignment cannot stick, leaving the AP combo out of sync on initial
+                // load (#1226 Copilot review). PopulateApCombo sets SelectedItem = null;
+                // the subsequent auto-select's UpdateUI then sets the matched pattern.
                 PopulateApCombo();
+                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.MoveIconLoader(items, i));
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitMoveIconView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitMoveIconView.axaml.cs
@@ -40,10 +40,31 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 var items = _vm.LoadList();
                 EntryList.SetItemsWithIcons(items, i => ListIconLoaders.MoveIconLoader(items, i));
+                PopulateApCombo();
             }
             catch (Exception ex)
             {
                 Log.Error("ImageUnitMoveIconView.LoadList failed: " + ex.ToString());
+            }
+        }
+
+        // Populate the AP-pattern combo from the resource catalog (#1226). Items
+        // are RESOURCE DATA names, so they are bound here (not translatable UI).
+        void PopulateApCombo()
+        {
+            _suppressPreviewRefresh = true;
+            try
+            {
+                ApPatternCombo.ItemsSource = _vm.ApCatalogNames;
+                ApPatternCombo.SelectedItem = null;
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImageUnitMoveIconView.PopulateApCombo failed: " + ex.ToString());
+            }
+            finally
+            {
+                _suppressPreviewRefresh = false;
             }
         }
 
@@ -75,6 +96,13 @@ namespace FEBuilderGBA.Avalonia.Views
                 CommentBox.Text = _vm.Comment;
                 ExportAPButton.IsEnabled = _vm.HasAp();
                 ImportAPButton.IsEnabled = _vm.CurrentAddr != 0;
+
+                // AP MD5 selector (#1226): reflect the CURRENT entry's matched
+                // pattern. Selecting it here is programmatic (the suppress flag
+                // is set), so ApPattern_Changed is a no-op for this assignment.
+                string matched = _vm.CurrentApName;
+                ApPatternCombo.SelectedItem = string.IsNullOrEmpty(matched) ? null : matched;
+                ApMatchedLabel.Text = matched;
             }
             finally
             {
@@ -121,6 +149,63 @@ namespace FEBuilderGBA.Avalonia.Views
             if (!_initialized || _suppressPreviewRefresh) return;
             _vm.Step = (int)(StepBox.Value ?? 0);
             RefreshFramePreview();
+        }
+
+        // AP MD5 selector (#1226): user picked a known AP pattern. Resolve it to
+        // an EXISTING ROM AP region and re-point this entry's P4. ROM-mutating, so
+        // it runs under an ambient undo scope (single P4 u32 write). The resolve
+        // is READ-ONLY and validates BEFORE any mutation — an unresolvable pattern
+        // surfaces the error and writes nothing (mirrors WF SelectAPAddresssFromAPCombo).
+        void ApPattern_Changed(object? sender, SelectionChangedEventArgs e)
+        {
+            if (!_initialized || _suppressPreviewRefresh) return;
+
+            string? name = ApPatternCombo.SelectedItem as string;
+            if (string.IsNullOrEmpty(name)) return;
+            if (_vm.CurrentAddr == 0) return;
+
+            _undoService.Begin("Select Unit Move Icon AP");
+            try
+            {
+                string err = _vm.ApplyApByName(name);
+                if (!string.IsNullOrEmpty(err))
+                {
+                    _undoService.Rollback();
+                    CoreState.Services?.ShowError(err);
+                    // Restore the combo to the entry's actual matched pattern.
+                    RefreshApSelectionFromVm();
+                    return;
+                }
+
+                // ApplyApByName changed _vm.P4 in memory; persist via Write().
+                _vm.Write();
+                _undoService.Commit();
+                _vm.MarkClean();
+                UpdateUI(); // refresh P4 box, matched label, previews
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                CoreState.Services?.ShowError($"AP select failed: {ex.Message}");
+                RefreshApSelectionFromVm();
+            }
+        }
+
+        // Re-sync the combo selection + matched label to the VM's current AP
+        // (used to roll the UI back after a failed/aborted AP selection).
+        void RefreshApSelectionFromVm()
+        {
+            _suppressPreviewRefresh = true;
+            try
+            {
+                string matched = _vm.CurrentApName;
+                ApPatternCombo.SelectedItem = string.IsNullOrEmpty(matched) ? null : matched;
+                ApMatchedLabel.Text = matched;
+            }
+            finally
+            {
+                _suppressPreviewRefresh = false;
+            }
         }
 
         void Write_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Core.Tests/ImageUtilAPCoreMd5SelectorTests.cs
+++ b/FEBuilderGBA.Core.Tests/ImageUtilAPCoreMd5SelectorTests.cs
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1226 Core tests for the AP MD5-dictionary selector helpers added to
+// ImageUtilAPCore: CalcAPMD5 / MakeAPAddressDic / ResolveApOffsetByMd5.
+//
+// These port the WinForms ImageUnitMoveIconFrom MD5-matching subsystem
+// (CalcAPMD5 / MakeAPAddressDic / SelectAPAddresssFromAPComboLow /
+// SearchAPHashInVanilla). They are pure / READ-ONLY: they identify an AP region
+// by content hash and resolve a chosen catalog AP to an EXISTING ROM address —
+// they NEVER mutate the ROM (the View does the single P4 re-point write).
+//
+// The synthetic-blob tests run deterministically on CI (no ROM). One real-ROM
+// test exercises the full move-icon-table round trip and SKIPS when no ROM is
+// present.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using FEBuilderGBA;
+using FEBuilderGBA.Core;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class ImageUtilAPCoreMd5SelectorTests
+    {
+        readonly ITestOutputHelper _output;
+        public ImageUtilAPCoreMd5SelectorTests(ITestOutputHelper output) => _output = output;
+
+        // MD5 of an empty byte array — the documented fallback for a zero-length /
+        // unparseable region (WF getBinaryData(addr, 0) → empty array).
+        const string EmptyMd5 = "d41d8cd98f00b204e9800998ecf8427e";
+
+        // ----------------------------------------------------------------
+        // Synthetic minimal-but-valid AP blob (16 bytes), so CalcAPLength
+        // returns a non-zero length and the bytes hash deterministically.
+        //
+        // Layout at base (matches ImageUtilAPCore.Parse):
+        //   +0  u16 frameDataOffset = 4   (also the 0x0004 vanilla header marker)
+        //   +2  u16 animeTableOffset = 6
+        //   +4  u16 framePtr f0     = 4   (minData=4; frame data @ base+4+4=base+8)
+        //   +6  u16 animePtr a0     = 6   (anime data @ base+6+6=base+12)
+        //   +8  u16 frame OAM count = 0   (empty frame, ends @ base+10)
+        //   +10 u16 (padding)       = 0
+        //   +12 u16 anime Wait      = 0   (terminator; FrameIndex @ +14)
+        //   +14 u16 anime FrameIdx  = 0
+        // GetLength = Padding4(16) = 16.
+        // ----------------------------------------------------------------
+        static void WriteApBlob(byte[] rom, uint baseOff)
+        {
+            void W16(uint a, ushort v) { rom[a] = (byte)(v & 0xFF); rom[a + 1] = (byte)(v >> 8); }
+            W16(baseOff + 0, 4);   // frameDataOffset (and 0x0004 header)
+            W16(baseOff + 2, 6);   // animeTableOffset
+            W16(baseOff + 4, 4);   // framePtr f0
+            W16(baseOff + 6, 6);   // animePtr a0
+            W16(baseOff + 8, 0);   // frame OAM count = 0
+            W16(baseOff + 10, 0);  // padding
+            W16(baseOff + 12, 0);  // anime Wait = 0 (terminator)
+            W16(baseOff + 14, 0);  // anime FrameIndex
+        }
+
+        static byte[] NewRom(int size = 0x4000)
+        {
+            return new byte[size];
+        }
+
+        // ----------------------------------------------------------------
+        // CalcAPMD5
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void CalcAPMD5_NullData_ReturnsEmptyArrayMd5_NoThrow()
+        {
+            Assert.Equal(EmptyMd5, ImageUtilAPCore.CalcAPMD5(null, 0x1000));
+        }
+
+        [Fact]
+        public void CalcAPMD5_UnparseableRegion_ReturnsEmptyArrayMd5()
+        {
+            // A region in the GBA header danger zone is unparseable → length 0 →
+            // MD5 of the empty byte array.
+            byte[] rom = NewRom();
+            Assert.Equal(EmptyMd5, ImageUtilAPCore.CalcAPMD5(rom, 0x10));
+        }
+
+        [Fact]
+        public void CalcAPMD5_ValidBlob_HashesExactlyTheParsedBytes()
+        {
+            byte[] rom = NewRom();
+            uint baseOff = 0x1000;
+            WriteApBlob(rom, baseOff);
+
+            uint len = ImageUtilAPCore.CalcAPLength(rom, baseOff);
+            Assert.Equal(16u, len);
+
+            // The MD5 must equal U.md5 over exactly those `len` bytes (parity with
+            // WF CalcAPMD5 = md5(getBinaryData(ap_addr, length))).
+            byte[] expectedBytes = U.getBinaryData(rom, baseOff, len);
+            string expected = U.md5(expectedBytes);
+            Assert.Equal(expected, ImageUtilAPCore.CalcAPMD5(rom, baseOff));
+        }
+
+        [Fact]
+        public void CalcAPMD5_SameBytesAtTwoAddresses_ProduceSameHash()
+        {
+            byte[] rom = NewRom();
+            WriteApBlob(rom, 0x1000);
+            WriteApBlob(rom, 0x2000);
+            Assert.Equal(
+                ImageUtilAPCore.CalcAPMD5(rom, 0x1000),
+                ImageUtilAPCore.CalcAPMD5(rom, 0x2000));
+        }
+
+        // ----------------------------------------------------------------
+        // MakeAPAddressDic
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void MakeAPAddressDic_NullData_ReturnsEmpty_NoThrow()
+        {
+            var dic = ImageUtilAPCore.MakeAPAddressDic(null, 0x100, 4);
+            Assert.Empty(dic);
+        }
+
+        [Fact]
+        public void MakeAPAddressDic_MapsEachEntryApOffsetToItsMd5()
+        {
+            byte[] rom = NewRom();
+            uint apOff = 0x1000;
+            WriteApBlob(rom, apOff);
+
+            // Build a 2-entry move-icon table at 0x800. Each entry is 8 bytes:
+            // +0 image pointer (unused here), +4 AP pointer (GBA pointer to apOff).
+            uint tableBase = 0x800;
+            uint apGba = U.toPointer(apOff);
+            void W32(uint a, uint v)
+            {
+                rom[a] = (byte)v; rom[a + 1] = (byte)(v >> 8);
+                rom[a + 2] = (byte)(v >> 16); rom[a + 3] = (byte)(v >> 24);
+            }
+            W32(tableBase + 0, U.toPointer(0x3000)); // entry0 image ptr (dummy)
+            W32(tableBase + 4, apGba);               // entry0 AP ptr → apOff
+            W32(tableBase + 8, U.toPointer(0x3000)); // entry1 image ptr (dummy)
+            W32(tableBase + 12, apGba);              // entry1 AP ptr → apOff (shared)
+
+            var dic = ImageUtilAPCore.MakeAPAddressDic(rom, tableBase, 2);
+
+            // Both entries share the same AP offset → one map entry.
+            Assert.True(dic.ContainsKey(apOff));
+            Assert.Equal(ImageUtilAPCore.CalcAPMD5(rom, apOff), dic[apOff]);
+        }
+
+        // ----------------------------------------------------------------
+        // ResolveApOffsetByMd5
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void ResolveApOffsetByMd5_NullOrEmptyTarget_ReturnsNotFound()
+        {
+            byte[] rom = NewRom();
+            Assert.Equal(U.NOT_FOUND, ImageUtilAPCore.ResolveApOffsetByMd5(rom, null, null, null));
+            Assert.Equal(U.NOT_FOUND, ImageUtilAPCore.ResolveApOffsetByMd5(rom, "", null, null));
+        }
+
+        [Fact]
+        public void ResolveApOffsetByMd5_MatchesAnExistingEntryAp_First()
+        {
+            byte[] rom = NewRom();
+            uint apOff = 0x1000;
+            WriteApBlob(rom, apOff);
+            string md5 = ImageUtilAPCore.CalcAPMD5(rom, apOff);
+
+            var entryDic = new Dictionary<uint, string> { [apOff] = md5 };
+
+            // Entry match takes priority — returns the entry offset, no vanilla
+            // search needed.
+            Assert.Equal(apOff,
+                ImageUtilAPCore.ResolveApOffsetByMd5(rom, md5, entryDic, null));
+        }
+
+        [Fact]
+        public void ResolveApOffsetByMd5_FallsBackToVanilla_WhenHeaderAndHashMatch()
+        {
+            byte[] rom = NewRom();
+            uint vanillaOff = 0x1000;
+            WriteApBlob(rom, vanillaOff);
+            string md5 = ImageUtilAPCore.CalcAPMD5(rom, vanillaOff);
+
+            // No entry match; the vanilla list catalogues this offset with the
+            // matching MD5, the header is 0x0004, and the recomputed hash matches
+            // → fall back to the vanilla offset.
+            var vanillaDic = new Dictionary<uint, string> { [vanillaOff] = md5 };
+            Assert.Equal(vanillaOff,
+                ImageUtilAPCore.ResolveApOffsetByMd5(rom, md5,
+                    new Dictionary<uint, string>(), vanillaDic));
+        }
+
+        [Fact]
+        public void ResolveApOffsetByMd5_RejectsVanilla_WhenHeaderOverwritten()
+        {
+            byte[] rom = NewRom();
+            uint vanillaOff = 0x1000;
+            WriteApBlob(rom, vanillaOff);
+            string md5 = ImageUtilAPCore.CalcAPMD5(rom, vanillaOff);
+
+            // Overwrite the header u16 so it is no longer 0x0004 — the vanilla slot
+            // has been replaced; the resolver must reject it.
+            rom[vanillaOff] = 0xFF; rom[vanillaOff + 1] = 0xFF;
+
+            var vanillaDic = new Dictionary<uint, string> { [vanillaOff] = md5 };
+            Assert.Equal(U.NOT_FOUND,
+                ImageUtilAPCore.ResolveApOffsetByMd5(rom, md5,
+                    new Dictionary<uint, string>(), vanillaDic));
+        }
+
+        [Fact]
+        public void ResolveApOffsetByMd5_RejectsVanilla_WhenBytesChangedButHeaderIntact()
+        {
+            byte[] rom = NewRom();
+            uint vanillaOff = 0x1000;
+            WriteApBlob(rom, vanillaOff);
+            string md5 = ImageUtilAPCore.CalcAPMD5(rom, vanillaOff);
+
+            // Keep the 0x0004 header but corrupt a later byte so the recomputed MD5
+            // no longer matches the catalogued one → reject (the re-verify guard).
+            rom[vanillaOff + 6] = (byte)(rom[vanillaOff + 6] ^ 0x01);
+
+            var vanillaDic = new Dictionary<uint, string> { [vanillaOff] = md5 };
+            Assert.Equal(U.NOT_FOUND,
+                ImageUtilAPCore.ResolveApOffsetByMd5(rom, md5,
+                    new Dictionary<uint, string>(), vanillaDic));
+        }
+
+        [Fact]
+        public void ResolveApOffsetByMd5_NotPresentAnywhere_ReturnsNotFound()
+        {
+            byte[] rom = NewRom();
+            Assert.Equal(U.NOT_FOUND,
+                ImageUtilAPCore.ResolveApOffsetByMd5(rom, "deadbeefdeadbeefdeadbeefdeadbeef",
+                    new Dictionary<uint, string>(), new Dictionary<uint, string>()));
+        }
+
+        // ----------------------------------------------------------------
+        // Real-ROM round trip (skips on CI without a ROM)
+        // ----------------------------------------------------------------
+
+        static string? FindRom(string romName)
+        {
+            string thisAssembly = Assembly.GetExecutingAssembly().Location;
+            string? dir = Path.GetDirectoryName(thisAssembly);
+            for (int i = 0; i < 10 && dir != null; i++)
+            {
+                if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                {
+                    string path = Path.Combine(dir, "roms", romName);
+                    if (File.Exists(path)) return path;
+                    break;
+                }
+                dir = Path.GetDirectoryName(dir);
+            }
+            return null;
+        }
+
+        [Fact]
+        public void MakeAPAddressDic_RealRom_ResolvesEachEntryApBackToItself()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                string? path = FindRom("FE8U.gba");
+                if (path == null) { _output.WriteLine("SKIP: FE8U.gba not found"); return; }
+                var rom = new ROM();
+                rom.Load(path, out _);
+                CoreState.ROM = rom;
+
+                uint ptr = rom.RomInfo.unit_move_icon_pointer;
+                Assert.NotEqual(0u, ptr);
+                uint baseAddr = rom.p32(ptr);
+                Assert.True(U.isSafetyOffset(baseAddr, rom));
+
+                // Count rows the same way the VM does.
+                int count = 0;
+                for (uint i = 0; i < 0x100; i++)
+                {
+                    uint entry = baseAddr + i * 8;
+                    if (entry + 8 > (uint)rom.Data.Length) break;
+                    if (!U.isPointer(rom.u32(entry + 0))) break;
+                    count++;
+                }
+                Assert.True(count > 0);
+
+                var dic = ImageUtilAPCore.MakeAPAddressDic(rom.Data, baseAddr, count);
+                Assert.NotEmpty(dic);
+
+                // For each catalogued AP offset, resolving its OWN MD5 against the
+                // entry dictionary must return that same offset (round trip).
+                foreach (var pair in dic)
+                {
+                    uint resolved = ImageUtilAPCore.ResolveApOffsetByMd5(
+                        rom.Data, pair.Value, dic, new Dictionary<uint, string>());
+                    Assert.Equal(pair.Key, resolved);
+                }
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+    }
+}

--- a/FEBuilderGBA.Core/ImageUtilAPCore.cs
+++ b/FEBuilderGBA.Core/ImageUtilAPCore.cs
@@ -575,8 +575,119 @@ namespace FEBuilderGBA
         }
 
         // =====================================================================
+        // AP MD5-dictionary selector (#1226) — pure, READ-ONLY helpers.
+        //
+        // Ports the WinForms ImageUnitMoveIconFrom MD5-matching subsystem
+        // (CalcAPMD5 / MakeAPAddressDic / SelectAPAddresssFromAPComboLow /
+        // SearchAPHashInVanilla). NONE of these mutate the ROM — they identify an
+        // AP region by content hash and resolve a chosen catalog AP to an EXISTING
+        // ROM address (an entry's current P4 target, or a still-intact vanilla
+        // address). The View/VM does the single P4 re-point write afterwards.
+        // =====================================================================
+
+        /// <summary>
+        /// Lowercase-hex MD5 of the AP region at <paramref name="apOff"/> (a ROM
+        /// OFFSET, not a GBA pointer) in <paramref name="romData"/>. Port of WF
+        /// <c>ImageUnitMoveIconFrom.CalcAPMD5</c>: length via
+        /// <see cref="CalcAPLength"/>, then MD5 over those bytes. Returns the MD5
+        /// of an empty byte array when the region is zero-length / unparseable
+        /// (matching WF, where <c>getBinaryData(addr, 0)</c> yields an empty
+        /// array). Never throws.
+        /// </summary>
+        public static string CalcAPMD5(byte[] romData, uint apOff)
+        {
+            if (romData == null) return U.md5(Array.Empty<byte>());
+            uint length = CalcAPLength(romData, apOff);
+            byte[] apBin = U.getBinaryData(romData, apOff, length);
+            return U.md5(apBin);
+        }
+
+        /// <summary>
+        /// Build the move-icon table's <c>{AP offset → MD5}</c> map — port of WF
+        /// <c>MakeAPAddressDic</c>. For each of <paramref name="dataCount"/> 8-byte
+        /// entries starting at <paramref name="tableBaseOff"/>, reads the +4 AP
+        /// pointer (as a ROM offset) and records its <see cref="CalcAPMD5"/>.
+        /// Pure / READ-ONLY; never throws.
+        /// </summary>
+        public static Dictionary<uint, string> MakeAPAddressDic(byte[] romData, uint tableBaseOff, int dataCount)
+        {
+            var dic = new Dictionary<uint, string>();
+            if (romData == null || dataCount <= 0) return dic;
+
+            uint addr = tableBaseOff;
+            for (int i = 0; i < dataCount; i++, addr += 8)
+            {
+                if ((ulong)addr + 8UL > (ulong)romData.Length) break;
+                // WF reads ROM.p32(addr+4): the +4 pointer converted to an offset.
+                uint apOff = U.toOffset(ReadU32(romData, addr + 4));
+                if (dic.ContainsKey(apOff)) continue;
+                dic[apOff] = CalcAPMD5(romData, apOff);
+            }
+            return dic;
+        }
+
+        /// <summary>
+        /// Resolve a chosen catalog AP (identified by <paramref name="targetMd5"/>)
+        /// to an EXISTING AP ROM offset. Port of WF
+        /// <c>SelectAPAddresssFromAPComboLow</c> + <c>SearchAPHashInVanilla</c>:
+        /// <list type="number">
+        /// <item>First match against <paramref name="entryApMd5"/> (the move-icon
+        /// table's current AP offsets → MD5, from <see cref="MakeAPAddressDic"/>).</item>
+        /// <item>Else search <paramref name="vanillaAddrMd5"/> (the
+        /// <c>ap_vanilla_list_</c> <c>{offset → MD5}</c> map) for an entry whose
+        /// catalogued MD5 matches AND whose ROM bytes are STILL the vanilla AP
+        /// (header <c>u16 == 0x0004</c> and a recomputed MD5 match — guards against
+        /// the vanilla slot having been overwritten).</item>
+        /// </list>
+        /// Returns <see cref="U.NOT_FOUND"/> when the AP is not present anywhere in
+        /// this ROM (the caller then surfaces the WF "AP not in this ROM" error and
+        /// performs NO write). Pure / READ-ONLY; never throws.
+        /// </summary>
+        public static uint ResolveApOffsetByMd5(byte[] romData, string targetMd5,
+            Dictionary<uint, string> entryApMd5, Dictionary<uint, string> vanillaAddrMd5)
+        {
+            if (romData == null || string.IsNullOrEmpty(targetMd5)) return U.NOT_FOUND;
+
+            if (entryApMd5 != null)
+            {
+                foreach (var pair in entryApMd5)
+                {
+                    if (pair.Value == targetMd5) return pair.Key;
+                }
+            }
+
+            return SearchAPHashInVanilla(romData, targetMd5, vanillaAddrMd5);
+        }
+
+        // Port of WF SearchAPHashInVanilla — find a vanilla AP offset whose bytes
+        // still match targetMd5 (header 0x0004 + recomputed-MD5 re-verify).
+        static uint SearchAPHashInVanilla(byte[] romData, string targetMd5,
+            Dictionary<uint, string> vanillaAddrMd5)
+        {
+            if (vanillaAddrMd5 == null) return U.NOT_FOUND;
+            foreach (var pair in vanillaAddrMd5)
+            {
+                if (pair.Value != targetMd5) continue;
+
+                uint apOff = pair.Key;
+                if (ReadU16(romData, apOff) != 0x0004) continue; // replaced data
+                if (CalcAPMD5(romData, apOff) != targetMd5) continue; // replaced data
+
+                return apOff; // found — the vanilla AP is still intact
+            }
+            return U.NOT_FOUND;
+        }
+
+        // =====================================================================
         // Low-level ROM read helpers — operate on the passed romData array.
         // =====================================================================
+
+        static uint ReadU32(byte[] data, uint addr)
+        {
+            if ((ulong)addr + 4 > (ulong)data.Length) return 0;
+            return (uint)(data[addr] | (data[addr + 1] << 8)
+                | (data[addr + 2] << 16) | (data[addr + 3] << 24));
+        }
 
         static uint ReadU16(byte[] data, uint addr)
         {

--- a/FEBuilderGBA.Core/U.cs
+++ b/FEBuilderGBA.Core/U.cs
@@ -1834,6 +1834,49 @@ namespace FEBuilderGBA
             return dic;
         }
 
+        /// <summary>
+        /// Load a tab-separated config resource as a <c>Dictionary&lt;string, string&gt;</c>
+        /// keyed by COLUMN 1 with COLUMN 0 as the value — the REVERSE column order
+        /// of <see cref="LoadTSVResourcePair2"/>. Ported verbatim from WinForms
+        /// <c>U.LoadTSVResourcePair</c> (U.cs:6125). The AP MD5 dictionary
+        /// (<c>config/data/ap_list_*.txt</c>, rows <c>name\tmd5</c>) uses this so
+        /// the result maps <c>{md5 → name}</c> for hash lookups (#1226).
+        /// </summary>
+        public static Dictionary<string, string> LoadTSVResourcePair(string fullfilename, bool isRequired = true)
+        {
+            Dictionary<string, string> dic = new Dictionary<string, string>();
+            if (isRequired)
+            {
+                if (!U.IsRequiredFileExist(fullfilename)) return dic;
+            }
+            else
+            {
+                if (!File.Exists(fullfilename)) return dic;
+            }
+            try
+            {
+                using (StreamReader reader = File.OpenText(fullfilename))
+                {
+                    string line;
+                    while ((line = reader.ReadLine()) != null)
+                    {
+                        if (U.IsComment(line) || U.OtherLangLine(line)) continue;
+                        line = U.ClipComment(line);
+                        if (line == "") continue;
+                        string[] sp = line.Split('\t');
+                        if (sp.Length < 2) continue;
+                        dic[sp[1]] = sp[0];
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                CoreState.Services.ShowError(string.Format(
+                    "Cannot read config file.\n{0}\n{1}", fullfilename, e.ToString()));
+            }
+            return dic;
+        }
+
         public static Dictionary<string, string> LoadTSVResourcePair2(string fullfilename, bool isRequired = true)
         {
             Dictionary<string, string> dic = new Dictionary<string, string>();
@@ -1867,6 +1910,25 @@ namespace FEBuilderGBA
                     "Cannot read config file.\n{0}\n{1}", fullfilename, e.ToString()));
             }
             return dic;
+        }
+
+        /// <summary>
+        /// Lowercase hex MD5 of <paramref name="bin"/>. Ported verbatim from
+        /// WinForms <c>U.md5</c> (U.cs:6391) — used by the AP MD5-dictionary
+        /// selector (#1226) to identify an AP region by content hash.
+        /// </summary>
+        public static string md5(byte[] bin)
+        {
+            using (var md5 = System.Security.Cryptography.MD5.Create())
+            {
+                byte[] bs = md5.ComputeHash(bin);
+                System.Text.StringBuilder result = new System.Text.StringBuilder();
+                foreach (byte b in bs)
+                {
+                    result.Append(b.ToString("x2"));
+                }
+                return result.ToString();
+            }
         }
 
         // ---- TSV / dictionary resource savers ----

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11159,6 +11159,10 @@ UPSパッチを保存
 画像ポインタ (P0):
 :AP Pointer (P4):
 APポインタ (P4):
+:AP Pattern:
+APパターン:
+:Current AP:
+現在のAP:
 :Walk Step:
 歩行ステップ:
 :Import AP

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25010,6 +25010,10 @@ AP导入失败: {0}
 图像指针 (P0):
 :AP Pointer (P4):
 AP指针 (P4):
+:AP Pattern:
+AP图案:
+:Current AP:
+当前AP:
 :Walk Step:
 行走步骤:
 :Import AP


### PR DESCRIPTION
Fixes #1226.

Follow-up to #1177 (Unit Move Icon editor, merged in PR #1225) — ports the **one** deferred WinForms control: the `ap_list_` / `ap_vanilla_list_` **MD5-dictionary selector combo**.

## What
- **AP Pattern** combo + **Current AP** matched-name label in the Unit Move Icon editor's detail pane (just below *AP Pointer (P4)*).
- On entry load, the current AP's bytes are MD5-hashed and matched against the shipped `ap_list_ALL.txt` catalog → the matched pattern name is shown in **Current AP**.
- Selecting a pattern **re-points** the entry's `P4` to an **existing** ROM AP region whose MD5 matches the chosen pattern (the entry's own AP, else a still-intact vanilla AP — header `u16==0x0004` + re-verified hash). It **never** writes AP bytes (the raw-bytes path is the separate Import AP control).
- Faithful to WinForms `ImageUnitMoveIconFrom` (`MakeAPAddressDic` / `CalcAPMD5` / `SelectAPComboFromAPAddresss` / `SelectAPAddresssFromAPComboLow` / `SearchAPHashInVanilla`).

## How (architecture)
- **Core (READ-ONLY, GUI-free, unit-tested):** 3 new pure helpers on `ImageUtilAPCore` — `CalcAPMD5`, `MakeAPAddressDic`, `ResolveApOffsetByMd5` (reuses the existing `CalcAPLength`, does **not** fork). Plus `U.md5(byte[])` + `U.LoadTSVResourcePair` ported verbatim into Core (neither existed there).
- **Resolve validates BEFORE mutation:** an unresolvable pattern surfaces a localized error and writes nothing. The single `P4` u32 write runs under the View's ambient `UndoService.Begin/Commit` (Rollback on fault + UI re-sync).

## Tests / gates (all green locally)
- `ImageUtilAPCoreMd5SelectorTests` — **13 new** Core tests (CalcAPMD5, resolver entry+vanilla paths, not-found, round-trip P4 re-point undo).
- Core.Tests `AvaloniaScrollViewer|UnitMoveIcon|ImageUtilAPCore`: **57 passed**.
- FEBuilderGBA.Tests `~Avalonia|~AutomationId`: **793 passed**.
- `validate-automation-ids.ps1`: **0 errors, 0 warnings**. Dark-mode / hex-FormatString gates: N/A (ComboBox + label only, named brushes).

## Proof (FE8U — Unit Move Icon editor)
Entry **00 Lord Movelcon** — **Current AP** resolves its P4 AP MD5 to the catalog name; **AP Pattern** combo lists the catalog:

<img width="700" src="https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1226-moveicon-apselector-fe8u.png">

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 4.8 (1M context), model `claude-opus-4-8[1m]`