### PR TITLE
feat(avalonia): port emulator save/backup search to Problem-Report tool (#1235)

### DIFF
--- a/FEBuilderGBA.Avalonia/ViewModels/ToolProblemReportSearchBackupViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ToolProblemReportSearchBackupViewModel.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
     public class ToolProblemReportSearchBackupViewModel : ViewModelBase
@@ -6,6 +8,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         string _backupFilename = "";
         bool _dialogConfirmed;
         string _messageText = "";
+        string _errorMessage = "";
 
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
 
@@ -27,12 +30,43 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// </summary>
         public string MessageText { get => _messageText; set => SetField(ref _messageText, value); }
 
+        /// <summary>Inline validation message shown when OK is pressed with an invalid path.</summary>
+        public string ErrorMessage
+        {
+            get => _errorMessage;
+            set { SetField(ref _errorMessage, value); OnPropertyChanged(nameof(HasError)); }
+        }
+
+        /// <summary>True when <see cref="ErrorMessage"/> is non-empty (drives the error label visibility).</summary>
+        public bool HasError => !string.IsNullOrEmpty(_errorMessage);
+
         public void Initialize()
         {
             MessageText = "No past backups were found.\n" +
                 "Is the backup saved under a different name?\n" +
                 "If you have a problem-free working backup, please specify its path.";
             IsLoaded = true;
+        }
+
+        /// <summary>
+        /// Validate the entered path on OK: must be non-empty AND an existing file.
+        /// Sets <see cref="ErrorMessage"/> (so the dialog stays open) and returns false
+        /// when invalid; clears the error and returns true when valid.
+        /// </summary>
+        public bool Validate()
+        {
+            if (string.IsNullOrWhiteSpace(BackupFilename))
+            {
+                ErrorMessage = R._("Please specify a backup ROM path.");
+                return false;
+            }
+            if (!File.Exists(BackupFilename))
+            {
+                ErrorMessage = R._("The specified file does not exist.");
+                return false;
+            }
+            ErrorMessage = "";
+            return true;
         }
 
         public string GetFilename() => BackupFilename;

--- a/FEBuilderGBA.Avalonia/ViewModels/ToolProblemReportSearchSavViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ToolProblemReportSearchSavViewModel.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
     public class ToolProblemReportSearchSavViewModel : ViewModelBase
@@ -6,6 +8,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         string _savFilename = "";
         bool _dialogConfirmed;
         string _messageText = "";
+        string _errorMessage = "";
 
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
 
@@ -27,12 +30,43 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// </summary>
         public string MessageText { get => _messageText; set => SetField(ref _messageText, value); }
 
+        /// <summary>Inline validation message shown when OK is pressed with an invalid path.</summary>
+        public string ErrorMessage
+        {
+            get => _errorMessage;
+            set { SetField(ref _errorMessage, value); OnPropertyChanged(nameof(HasError)); }
+        }
+
+        /// <summary>True when <see cref="ErrorMessage"/> is non-empty (drives the error label visibility).</summary>
+        public bool HasError => !string.IsNullOrEmpty(_errorMessage);
+
         public void Initialize()
         {
             MessageText = "No SAV file was found.\n" +
                 "A SAV file is needed to reliably reproduce the problem.\n" +
                 "If you have a matching SAV file, please specify its path.";
             IsLoaded = true;
+        }
+
+        /// <summary>
+        /// Validate the entered path on OK: must be non-empty AND an existing file.
+        /// Sets <see cref="ErrorMessage"/> (so the dialog stays open) and returns false
+        /// when invalid; clears the error and returns true when valid.
+        /// </summary>
+        public bool Validate()
+        {
+            if (string.IsNullOrWhiteSpace(SavFilename))
+            {
+                ErrorMessage = R._("Please specify a save file path.");
+                return false;
+            }
+            if (!File.Exists(SavFilename))
+            {
+                ErrorMessage = R._("The specified file does not exist.");
+                return false;
+            }
+            ErrorMessage = "";
+            return true;
         }
 
         public string GetFilename() => SavFilename;

--- a/FEBuilderGBA.Avalonia/ViewModels/ToolProblemReportViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ToolProblemReportViewModel.cs
@@ -3,11 +3,11 @@ using System;
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
     /// <summary>
-    /// Problem-Report tool (#1193). READ-ONLY w.r.t. the ROM — collects diagnostics
-    /// (log + per-ROM etc config + any sibling .ups) plus the user's problem text
-    /// into a <c>.report.7z</c> via <see cref="ProblemReportCore.CreateReport"/>.
-    /// No ROM mutation, so no undo scope. Mirrors WinForms <c>ToolProblemReportForm</c>
-    /// minus the deferred emulator save/backup search.
+    /// Problem-Report tool (#1193, #1235). READ-ONLY w.r.t. the ROM — collects
+    /// diagnostics (log + per-ROM etc config + any sibling .ups + emulator save-state
+    /// files next to the ROM + an optional clean-ROM .ups delta) plus the user's
+    /// problem text into a <c>.report.7z</c> via <see cref="ProblemReportCore.CreateReport"/>.
+    /// No ROM mutation, so no undo scope. Mirrors WinForms <c>ToolProblemReportForm</c>.
     /// </summary>
     public class ToolProblemReportViewModel : ViewModelBase
     {
@@ -33,7 +33,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// Returns <c>""</c> on success, otherwise a localized error string. Never
         /// throws; sets <see cref="StatusMessage"/> on every path.
         /// </summary>
-        public string CreateReport(string outputPath)
+        /// <param name="cleanRomPath">
+        /// Optional clean / old backup ROM (from the interactive backup picker); when
+        /// set, a <c>.ups</c> delta from it to the current ROM is added (#1235).
+        /// </param>
+        public string CreateReport(string outputPath, string cleanRomPath = null)
         {
             try
             {
@@ -57,7 +61,13 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                     return m;
                 }
 
-                string err = ProblemReportCore.CreateReport(rom, ProblemText, outputPath);
+                // Emulator save-state files live next to the ROM (+ no$gba BATTERY
+                // under the configured emulator dir). Passing these lets the report
+                // collect saves + an optional clean-ROM .ups delta (#1235).
+                string emulatorConfigDir = CoreState.Config?.at("emulator") ?? "";
+
+                string err = ProblemReportCore.CreateReport(
+                    rom, ProblemText, outputPath, emulatorConfigDir, cleanRomPath);
                 if (!string.IsNullOrEmpty(err))
                 {
                     StatusMessage = err;

--- a/FEBuilderGBA.Avalonia/ViewModels/ToolProblemReportViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ToolProblemReportViewModel.cs
@@ -28,6 +28,45 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// <summary>True when a ROM is loaded (report needs ROM diagnostics).</summary>
         public bool HasRom => CoreState.ROM?.RomInfo != null;
 
+        /// <summary>The configured emulator path (WF <c>Program.Config.at("emulator")</c>).</summary>
+        public string EmulatorConfigDir => CoreState.Config?.at("emulator") ?? "";
+
+        /// <summary>
+        /// Non-mutating probe: would auto-discovery find an emulator save next to the
+        /// ROM? When false, the View surfaces the interactive SAV picker (#1235).
+        /// </summary>
+        public bool HasAutoSaveData()
+        {
+            string romFilename = CoreState.ROM?.Filename;
+            if (string.IsNullOrEmpty(romFilename))
+            {
+                return false;
+            }
+            return SaveDataCollectorCore.HasAnySaveData(romFilename, EmulatorConfigDir);
+        }
+
+        /// <summary>
+        /// Non-mutating probe: is there an already-existing sibling <c>.ups</c> next to
+        /// the ROM? When false, the View can offer the backup picker so the user can
+        /// supply a clean ROM for a fresh UPS delta (#1235).
+        /// </summary>
+        public bool HasSiblingUps()
+        {
+            try
+            {
+                string romFilename = CoreState.ROM?.Filename;
+                if (string.IsNullOrEmpty(romFilename) || !System.IO.File.Exists(romFilename))
+                {
+                    return false;
+                }
+                return System.IO.File.Exists(System.IO.Path.ChangeExtension(romFilename, ".ups"));
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
         /// <summary>
         /// Create the report archive at <paramref name="outputPath"/>.
         /// Returns <c>""</c> on success, otherwise a localized error string. Never
@@ -37,7 +76,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// Optional clean / old backup ROM (from the interactive backup picker); when
         /// set, a <c>.ups</c> delta from it to the current ROM is added (#1235).
         /// </param>
-        public string CreateReport(string outputPath, string cleanRomPath = null)
+        /// <param name="savFilePath">
+        /// Optional save-state file the user picked in the SAV picker when no save was
+        /// auto-discovered next to the ROM (#1235).
+        /// </param>
+        public string CreateReport(string outputPath, string cleanRomPath = null, string savFilePath = null)
         {
             try
             {
@@ -67,7 +110,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 string emulatorConfigDir = CoreState.Config?.at("emulator") ?? "";
 
                 string err = ProblemReportCore.CreateReport(
-                    rom, ProblemText, outputPath, emulatorConfigDir, cleanRomPath);
+                    rom, ProblemText, outputPath, emulatorConfigDir, cleanRomPath, savFilePath);
                 if (!string.IsNullOrEmpty(err))
                 {
                     StatusMessage = err;

--- a/FEBuilderGBA.Avalonia/Views/ToolProblemReportSearchBackupView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolProblemReportSearchBackupView.axaml
@@ -23,6 +23,10 @@
       <Button AutomationProperties.AutomationId="ToolProblemReportSearchBackup_Browse_Button" Grid.Column="2" Content="Browse..." Width="130" Height="31"
               Click="Browse_Click" />
     </Grid>
+    <!-- Inline validation message (kept open on invalid OK) -->
+    <TextBlock AutomationProperties.AutomationId="ToolProblemReportSearchBackup_Error_Label"
+               Foreground="Red" TextWrapping="Wrap" Margin="0,8,0,0"
+               IsVisible="{Binding HasError}" Text="{Binding ErrorMessage}" />
     <!-- OK / Cancel row -->
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"
                 Spacing="8" Margin="0,16,0,0">

--- a/FEBuilderGBA.Avalonia/Views/ToolProblemReportSearchBackupView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolProblemReportSearchBackupView.axaml
@@ -23,6 +23,14 @@
       <Button AutomationProperties.AutomationId="ToolProblemReportSearchBackup_Browse_Button" Grid.Column="2" Content="Browse..." Width="130" Height="31"
               Click="Browse_Click" />
     </Grid>
+    <!-- OK / Cancel row -->
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"
+                Spacing="8" Margin="0,16,0,0">
+      <Button AutomationProperties.AutomationId="ToolProblemReportSearchBackup_OK_Button"
+              Content="OK" Width="100" Height="31" Click="OK_Click" />
+      <Button AutomationProperties.AutomationId="ToolProblemReportSearchBackup_Cancel_Button"
+              Content="Cancel" Width="100" Height="31" Click="Cancel_Click" />
+    </StackPanel>
   </StackPanel>
   </ScrollViewer>
 </Window>

--- a/FEBuilderGBA.Avalonia/Views/ToolProblemReportSearchBackupView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolProblemReportSearchBackupView.axaml.cs
@@ -20,19 +20,28 @@ namespace FEBuilderGBA.Avalonia.Views
             _vm.Initialize();
         }
 
+        /// <summary>True when the user confirmed a valid backup-ROM path (DialogResult.OK).</summary>
+        public bool Confirmed => _vm.DialogConfirmed;
+
+        /// <summary>The picked clean / old backup ROM path (only meaningful when <see cref="Confirmed"/>).</summary>
+        public string PickedFilename => _vm.GetFilename();
+
         async void Browse_Click(object? sender, RoutedEventArgs e)
         {
             try
             {
                 var dlg = new OpenFileDialog();
                 dlg.Title = R._("Select Backup File");
-                dlg.Filters?.Add(new FileDialogFilter { Name = "Backup Files", Extensions = { "7z", "gba" } });
+                // The backup is a clean / old ROM used as the UPS-delta source
+                // (read as raw bytes), so accept ROM files.
+                dlg.Filters?.Add(new FileDialogFilter { Name = "GBA ROMs", Extensions = { "gba", "bin" } });
                 var result = await dlg.ShowAsync(this);
                 if (result != null && result.Length > 0)
                 {
+                    // Populate the path; the user still confirms via OK (which
+                    // validates). Clear any stale inline error.
                     _vm.BackupFilename = result[0];
-                    _vm.DialogConfirmed = true;
-                    Close();
+                    _vm.ErrorMessage = "";
                 }
             }
             catch (Exception ex)
@@ -43,6 +52,12 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void OK_Click(object? sender, RoutedEventArgs e)
         {
+            // Keep the dialog open with an inline message when the path is invalid,
+            // so an empty/bad path can't silently confirm with no backup (#1235).
+            if (!_vm.Validate())
+            {
+                return;
+            }
             _vm.DialogConfirmed = true;
             Close();
         }

--- a/FEBuilderGBA.Avalonia/Views/ToolProblemReportSearchSavView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolProblemReportSearchSavView.axaml
@@ -23,6 +23,14 @@
       <Button AutomationProperties.AutomationId="ToolProblemReportSearchSav_Browse_Button" Grid.Column="2" Content="Browse..." Width="130" Height="31"
               Click="Browse_Click" />
     </Grid>
+    <!-- OK / Cancel row -->
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"
+                Spacing="8" Margin="0,16,0,0">
+      <Button AutomationProperties.AutomationId="ToolProblemReportSearchSav_OK_Button"
+              Content="OK" Width="100" Height="31" Click="OK_Click" />
+      <Button AutomationProperties.AutomationId="ToolProblemReportSearchSav_Cancel_Button"
+              Content="Cancel" Width="100" Height="31" Click="Cancel_Click" />
+    </StackPanel>
   </StackPanel>
   </ScrollViewer>
 </Window>

--- a/FEBuilderGBA.Avalonia/Views/ToolProblemReportSearchSavView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolProblemReportSearchSavView.axaml
@@ -23,6 +23,10 @@
       <Button AutomationProperties.AutomationId="ToolProblemReportSearchSav_Browse_Button" Grid.Column="2" Content="Browse..." Width="130" Height="31"
               Click="Browse_Click" />
     </Grid>
+    <!-- Inline validation message (kept open on invalid OK) -->
+    <TextBlock AutomationProperties.AutomationId="ToolProblemReportSearchSav_Error_Label"
+               Foreground="Red" TextWrapping="Wrap" Margin="0,8,0,0"
+               IsVisible="{Binding HasError}" Text="{Binding ErrorMessage}" />
     <!-- OK / Cancel row -->
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right"
                 Spacing="8" Margin="0,16,0,0">

--- a/FEBuilderGBA.Avalonia/Views/ToolProblemReportSearchSavView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolProblemReportSearchSavView.axaml.cs
@@ -20,6 +20,12 @@ namespace FEBuilderGBA.Avalonia.Views
             _vm.Initialize();
         }
 
+        /// <summary>True when the user confirmed a valid save path (DialogResult.OK).</summary>
+        public bool Confirmed => _vm.DialogConfirmed;
+
+        /// <summary>The picked save-file path (only meaningful when <see cref="Confirmed"/>).</summary>
+        public string PickedFilename => _vm.GetFilename();
+
         async void Browse_Click(object? sender, RoutedEventArgs e)
         {
             try
@@ -30,9 +36,10 @@ namespace FEBuilderGBA.Avalonia.Views
                 var result = await dlg.ShowAsync(this);
                 if (result != null && result.Length > 0)
                 {
+                    // Populate the path; the user still confirms via OK (which
+                    // validates). Clear any stale inline error.
                     _vm.SavFilename = result[0];
-                    _vm.DialogConfirmed = true;
-                    Close();
+                    _vm.ErrorMessage = "";
                 }
             }
             catch (Exception ex)
@@ -43,6 +50,12 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void OK_Click(object? sender, RoutedEventArgs e)
         {
+            // Keep the dialog open with an inline message when the path is invalid,
+            // so an empty/bad path can't silently confirm with no save (#1235).
+            if (!_vm.Validate())
+            {
+                return;
+            }
             _vm.DialogConfirmed = true;
             Close();
         }

--- a/FEBuilderGBA.Avalonia/Views/ToolProblemReportView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolProblemReportView.axaml
@@ -11,7 +11,7 @@
                FontSize="20" FontWeight="Bold" Margin="0,0,0,4" />
     <TextBlock AutomationProperties.AutomationId="ToolProblemReport_Hint_Label"
                DockPanel.Dock="Top" Name="HintLabel"
-               Text="Describe the problem, then create a report to attach when you ask for help. The report includes a diagnostic log and your editor settings (no save data is collected)."
+               Text="Describe the problem, then create a report to attach when you ask for help. The report includes a diagnostic log, your editor settings, and any emulator save data found next to the ROM."
                Foreground="Gray" TextWrapping="Wrap" Margin="0,0,0,12" />
 
     <!-- About-report URL link -->

--- a/FEBuilderGBA.Avalonia/Views/ToolProblemReportView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolProblemReportView.axaml.cs
@@ -72,10 +72,41 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (file == null) return;
 
                 string path = file.Path.LocalPath;
+
+                // Mirror the WinForms show-on-empty flow (CollectSaveData L350 /
+                // CollectOldUPSs L263): only surface a picker when auto-discovery
+                // found nothing — do NOT pop both modals on every report.
+
+                // (a) No emulator save next to the ROM -> ask the user to point at one.
+                string savFilePath = null;
+                if (!_vm.HasAutoSaveData())
+                {
+                    var savPicker = new ToolProblemReportSearchSavView();
+                    await savPicker.ShowDialog(this);
+                    if (savPicker.Confirmed)
+                    {
+                        savFilePath = savPicker.PickedFilename;
+                    }
+                }
+
+                // (b) No sibling .ups next to the ROM -> offer the backup picker so a
+                //     clean / old ROM can seed a fresh UPS delta.
+                string cleanRomPath = null;
+                if (!_vm.HasSiblingUps())
+                {
+                    var backupPicker = new ToolProblemReportSearchBackupView();
+                    await backupPicker.ShowDialog(this);
+                    if (backupPicker.Confirmed)
+                    {
+                        cleanRomPath = backupPicker.PickedFilename;
+                    }
+                }
+
                 CreateButton.IsEnabled = false;
                 StatusLabel.Text = R._("Creating report...");
 
-                string err = await System.Threading.Tasks.Task.Run(() => _vm.CreateReport(path));
+                string err = await System.Threading.Tasks.Task.Run(
+                    () => _vm.CreateReport(path, cleanRomPath, savFilePath));
 
                 if (!string.IsNullOrEmpty(err))
                 {

--- a/FEBuilderGBA.Core.Tests/ProblemReportCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ProblemReportCoreTests.cs
@@ -98,6 +98,45 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void CreateReport_ExplicitPickedSave_LandsInArchive()
+        {
+            // The synthetic ROM has no on-disk sibling save, so auto-discovery finds
+            // none and the explicit picked save (WF CollectSaveData picker fallback)
+            // must be copied into the report (#1235).
+            ROM rom = MakeRom();
+            string problem = MakeProblemText();
+
+            string outDir = Path.Combine(Path.GetTempPath(), "febuilder_report_test_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(outDir);
+            string outPath = Path.Combine(outDir, "picked.report.7z");
+            string extractDir = Path.Combine(outDir, "extract");
+
+            // A fake picked save outside the ROM dir.
+            string pickedSave = Path.Combine(outDir, "PickedHack.sav");
+            File.WriteAllBytes(pickedSave, new byte[] { 1, 2, 3, 4, 5 });
+
+            try
+            {
+                string err = ProblemReportCore.CreateReport(
+                    rom, problem, outPath,
+                    emulatorConfigDir: null, cleanRomPath: null, savFilePath: pickedSave);
+                Assert.Equal("", err);
+
+                Directory.CreateDirectory(extractDir);
+                string exErr = ArchSevenZip.Extract(outPath, extractDir, isHide: true);
+                Assert.Equal("", exErr);
+
+                string[] files = Directory.GetFiles(extractDir, "*", SearchOption.AllDirectories);
+                Assert.Contains(files, f =>
+                    string.Equals(Path.GetFileName(f), "PickedHack.sav", StringComparison.OrdinalIgnoreCase));
+            }
+            finally
+            {
+                TryDeleteDir(outDir);
+            }
+        }
+
+        [Fact]
         public void CreateReport_NullRom_ReturnsError_NoThrow()
         {
             string outDir = Path.Combine(Path.GetTempPath(), "febuilder_report_test_" + Guid.NewGuid().ToString("N"));

--- a/FEBuilderGBA.Core.Tests/SaveDataCollectorCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/SaveDataCollectorCoreTests.cs
@@ -229,5 +229,82 @@ namespace FEBuilderGBA.Core.Tests
                 TryDeleteDir(tempDir);
             }
         }
+
+        [Fact]
+        public void HasAnySaveData_TrueWhenSiblingSav_FalseOtherwise()
+        {
+            string romDir = MakeTempDir();
+            try
+            {
+                string romPath = Path.Combine(romDir, "MyHack.gba");
+                File.WriteAllBytes(romPath, new byte[] { 1 });
+
+                // No save yet.
+                Assert.False(SaveDataCollectorCore.HasAnySaveData(romPath, ""));
+
+                // Add a sibling .sav -> probe true (and does NOT copy anything).
+                File.WriteAllBytes(Path.Combine(romDir, "MyHack.sav"), new byte[] { 9 });
+                Assert.True(SaveDataCollectorCore.HasAnySaveData(romPath, ""));
+
+                // Probe is read-only: only the rom + sav remain, no temp artifacts.
+                Assert.Equal(2, Directory.GetFiles(romDir).Length);
+            }
+            finally
+            {
+                TryDeleteDir(romDir);
+            }
+        }
+
+        [Fact]
+        public void HasAnySaveData_SpaceToUnderscore_AndEmulatorState()
+        {
+            string romDir = MakeTempDir();
+            try
+            {
+                string romPath = Path.Combine(romDir, "My Hack.gba");
+                File.WriteAllBytes(romPath, new byte[] { 1 });
+
+                // space->underscore .sav variant is detected by the probe.
+                File.WriteAllBytes(Path.Combine(romDir, "My_Hack.ss1"), new byte[] { 7 });
+                Assert.True(SaveDataCollectorCore.HasAnySaveData(romPath, ""));
+            }
+            finally
+            {
+                TryDeleteDir(romDir);
+            }
+        }
+
+        [Fact]
+        public void CollectSaveData_PerFileCopyFailure_DoesNotAbortRest()
+        {
+            string romDir = MakeTempDir();
+            string tempDir = MakeTempDir();
+            try
+            {
+                string romPath = Path.Combine(romDir, "MyHack.gba");
+                File.WriteAllBytes(romPath, new byte[] { 1 });
+
+                // Two discoverable saves.
+                File.WriteAllBytes(Path.Combine(romDir, "MyHack.sav"), new byte[] { 9 });
+                File.WriteAllBytes(Path.Combine(romDir, "MyHack.ss1"), new byte[] { 7 });
+
+                // Sabotage the FIRST copy target: create a DIRECTORY in tempDir with the
+                // exact destination name of MyHack.sav so File.Copy throws for it. The
+                // per-file try/catch must skip it and still copy MyHack.ss1.
+                Directory.CreateDirectory(Path.Combine(tempDir, "MyHack.sav"));
+
+                var collected = SaveDataCollectorCore.CollectSaveData(romPath, "", tempDir);
+
+                // The bad file is skipped, the good one still lands.
+                Assert.DoesNotContain("MyHack.sav", collected);
+                Assert.Contains("MyHack.ss1", collected);
+                Assert.True(File.Exists(Path.Combine(tempDir, "MyHack.ss1")));
+            }
+            finally
+            {
+                TryDeleteDir(romDir);
+                TryDeleteDir(tempDir);
+            }
+        }
     }
 }

--- a/FEBuilderGBA.Core.Tests/SaveDataCollectorCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/SaveDataCollectorCoreTests.cs
@@ -1,0 +1,233 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="SaveDataCollectorCore"/> (#1235 — the Avalonia
+    /// Problem-Report tool's GUI-free emulator save / backup collector). Asserts:
+    ///  - <c>.sav</c> / <c>.emulator*.s*</c> save-state files next to the ROM are
+    ///    discovered and copied into the temp dir;
+    ///  - the space-&gt;underscore base-name fallback some emulators use is honored;
+    ///  - no$gba's <c>&lt;emulatorDir&gt;/BATTERY/&lt;rom&gt;.sav</c> is collected when
+    ///    no sibling <c>.sav</c> exists;
+    ///  - the UPS-delta helper round-trips (make from a clean ROM → apply → equals
+    ///    the current ROM bytes);
+    ///  - the never-throws contract on missing inputs.
+    /// </summary>
+    public class SaveDataCollectorCoreTests
+    {
+        static string MakeTempDir()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "febuilder_savsrch_test_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+
+        static void TryDeleteDir(string dir)
+        {
+            try { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
+            catch { /* best-effort */ }
+        }
+
+        [Fact]
+        public void CollectSaveData_FindsSiblingSavAndEmulatorStates()
+        {
+            string romDir = MakeTempDir();
+            string tempDir = MakeTempDir();
+            try
+            {
+                string romPath = Path.Combine(romDir, "MyHack.gba");
+                File.WriteAllBytes(romPath, new byte[] { 1, 2, 3 });
+
+                // Sibling save-state files the WF PickupSaveData loop discovers.
+                File.WriteAllBytes(Path.Combine(romDir, "MyHack.sav"), new byte[] { 9 });
+                File.WriteAllBytes(Path.Combine(romDir, "MyHack.emulator.sav"), new byte[] { 8 });
+                File.WriteAllBytes(Path.Combine(romDir, "MyHack.ss1"), new byte[] { 7 });
+                File.WriteAllBytes(Path.Combine(romDir, "MyHack.emulator1.sgm"), new byte[] { 6 });
+                // A non-matching file that must NOT be collected.
+                File.WriteAllBytes(Path.Combine(romDir, "Unrelated.sav"), new byte[] { 0 });
+
+                var collected = SaveDataCollectorCore.CollectSaveData(romPath, "", tempDir);
+
+                Assert.Contains("MyHack.sav", collected);
+                Assert.Contains("MyHack.emulator.sav", collected);
+                Assert.Contains("MyHack.ss1", collected);
+                Assert.Contains("MyHack.emulator1.sgm", collected);
+                Assert.DoesNotContain("Unrelated.sav", collected);
+
+                // Each collected name actually landed in the temp dir.
+                foreach (string name in collected)
+                {
+                    Assert.True(File.Exists(Path.Combine(tempDir, name)), name + " should be copied");
+                }
+            }
+            finally
+            {
+                TryDeleteDir(romDir);
+                TryDeleteDir(tempDir);
+            }
+        }
+
+        [Fact]
+        public void CollectSaveData_SpaceToUnderscoreFallback()
+        {
+            string romDir = MakeTempDir();
+            string tempDir = MakeTempDir();
+            try
+            {
+                // ROM name has a space; the emulator wrote the save with an underscore.
+                string romPath = Path.Combine(romDir, "My Hack.gba");
+                File.WriteAllBytes(romPath, new byte[] { 1 });
+                File.WriteAllBytes(Path.Combine(romDir, "My_Hack.sav"), new byte[] { 9 });
+
+                var collected = SaveDataCollectorCore.CollectSaveData(romPath, "", tempDir);
+
+                Assert.Contains("My_Hack.sav", collected);
+                Assert.True(File.Exists(Path.Combine(tempDir, "My_Hack.sav")));
+            }
+            finally
+            {
+                TryDeleteDir(romDir);
+                TryDeleteDir(tempDir);
+            }
+        }
+
+        [Fact]
+        public void CollectSaveData_NoDollarGba_BatteryDir()
+        {
+            string romDir = MakeTempDir();
+            string emuDir = MakeTempDir();
+            string tempDir = MakeTempDir();
+            try
+            {
+                // No sibling .sav next to the ROM — must fall through to BATTERY/.
+                string romPath = Path.Combine(romDir, "MyHack.gba");
+                File.WriteAllBytes(romPath, new byte[] { 1 });
+
+                // emulatorConfigDir is a PATH TO THE EMULATOR EXE; BATTERY sits next to it.
+                string emuExe = Path.Combine(emuDir, "NO$GBA.EXE");
+                File.WriteAllBytes(emuExe, new byte[] { 0 });
+                string batteryDir = Path.Combine(emuDir, "BATTERY");
+                Directory.CreateDirectory(batteryDir);
+                File.WriteAllBytes(Path.Combine(batteryDir, "MyHack.sav"), new byte[] { 5 });
+
+                var collected = SaveDataCollectorCore.CollectSaveData(romPath, emuExe, tempDir);
+
+                Assert.Contains("MyHack.sav", collected);
+                Assert.True(File.Exists(Path.Combine(tempDir, "MyHack.sav")));
+            }
+            finally
+            {
+                TryDeleteDir(romDir);
+                TryDeleteDir(emuDir);
+                TryDeleteDir(tempDir);
+            }
+        }
+
+        [Fact]
+        public void CollectSaveData_NoSaves_ReturnsEmpty_NoThrow()
+        {
+            string romDir = MakeTempDir();
+            string tempDir = MakeTempDir();
+            try
+            {
+                string romPath = Path.Combine(romDir, "MyHack.gba");
+                File.WriteAllBytes(romPath, new byte[] { 1 });
+
+                var collected = SaveDataCollectorCore.CollectSaveData(romPath, "", tempDir);
+                Assert.Empty(collected);
+            }
+            finally
+            {
+                TryDeleteDir(romDir);
+                TryDeleteDir(tempDir);
+            }
+        }
+
+        [Fact]
+        public void PickupOneFile_CopiesExplicitPath()
+        {
+            string srcDir = MakeTempDir();
+            string tempDir = MakeTempDir();
+            try
+            {
+                string src = Path.Combine(srcDir, "picked.sav");
+                File.WriteAllBytes(src, new byte[] { 1, 2, 3, 4 });
+
+                string name = SaveDataCollectorCore.PickupOneFile(tempDir, src);
+
+                Assert.Equal("picked.sav", name);
+                Assert.True(File.Exists(Path.Combine(tempDir, "picked.sav")));
+
+                // Missing file -> null, no throw.
+                Assert.Null(SaveDataCollectorCore.PickupOneFile(tempDir, Path.Combine(srcDir, "nope.sav")));
+            }
+            finally
+            {
+                TryDeleteDir(srcDir);
+                TryDeleteDir(tempDir);
+            }
+        }
+
+        [Fact]
+        public void MakeBackupUps_RoundTrips_CleanToCurrent()
+        {
+            string cleanDir = MakeTempDir();
+            string tempDir = MakeTempDir();
+            try
+            {
+                // A "clean" ROM and a "current" (modified) ROM of equal length.
+                byte[] clean = new byte[4096];
+                byte[] current = new byte[4096];
+                var rng = new Random(1235);
+                rng.NextBytes(clean);
+                Array.Copy(clean, current, clean.Length);
+                // Mutate a handful of bytes so the delta is non-trivial.
+                current[10] ^= 0xFF;
+                current[100] ^= 0x0F;
+                current[4095] ^= 0xAA;
+
+                string cleanPath = Path.Combine(cleanDir, "Clean.gba");
+                File.WriteAllBytes(cleanPath, clean);
+
+                string upsName = SaveDataCollectorCore.MakeBackupUps(cleanPath, current, tempDir);
+
+                Assert.Equal("Clean.ups", upsName);
+                string upsPath = Path.Combine(tempDir, upsName);
+                Assert.True(File.Exists(upsPath));
+
+                // Apply the delta to the clean ROM => must equal the current ROM.
+                byte[] patch = File.ReadAllBytes(upsPath);
+                byte[] applied = UPSUtilCore.ApplyUPS(clean, patch, out string err);
+                Assert.True(string.IsNullOrEmpty(err), "apply error: " + err);
+                Assert.NotNull(applied);
+                Assert.Equal(current, applied);
+            }
+            finally
+            {
+                TryDeleteDir(cleanDir);
+                TryDeleteDir(tempDir);
+            }
+        }
+
+        [Fact]
+        public void MakeBackupUps_MissingClean_ReturnsNull_NoThrow()
+        {
+            string tempDir = MakeTempDir();
+            try
+            {
+                string name = SaveDataCollectorCore.MakeBackupUps(
+                    Path.Combine(tempDir, "does-not-exist.gba"), new byte[] { 1, 2 }, tempDir);
+                Assert.Null(name);
+            }
+            finally
+            {
+                TryDeleteDir(tempDir);
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Core/ProblemReportCore.cs
+++ b/FEBuilderGBA.Core/ProblemReportCore.cs
@@ -42,11 +42,16 @@ namespace FEBuilderGBA
         /// Optional clean / old backup ROM path; when set, a fresh <c>.ups</c> delta
         /// from it to the current ROM is added to the report (#1235). May be <c>null</c>.
         /// </param>
+        /// <param name="savFilePath">
+        /// Optional explicit save-state file the user picked when auto-discovery found
+        /// none (WF <c>CollectSaveData</c> picker fallback); when set, it is copied into
+        /// the report via <see cref="SaveDataCollectorCore.PickupOneFile"/>. May be <c>null</c>.
+        /// </param>
         /// <returns>
         /// <c>""</c> on success, otherwise a localized error message. Never throws.
         /// </returns>
         public static string CreateReport(ROM rom, string problemText, string outputPath,
-            string emulatorConfigDir = null, string cleanRomPath = null)
+            string emulatorConfigDir = null, string cleanRomPath = null, string savFilePath = null)
         {
             string tempDir = null;
             try
@@ -74,9 +79,17 @@ namespace FEBuilderGBA
 
                 // 3) Emulator save-state files next to the ROM (+ no$gba BATTERY).
                 //    Best-effort: a missing save must never fail the report (#1235).
+                int autoSaves = 0;
                 if (!string.IsNullOrEmpty(rom.Filename))
                 {
-                    SaveDataCollectorCore.CollectSaveData(rom.Filename, emulatorConfigDir, tempDir);
+                    autoSaves = SaveDataCollectorCore.CollectSaveData(rom.Filename, emulatorConfigDir, tempDir).Count;
+                }
+
+                // 3b) If auto-discovery found NO save, fall back to the explicit file
+                //     the user picked in the SAV picker (WF CollectSaveData fallback).
+                if (autoSaves == 0 && !string.IsNullOrEmpty(savFilePath))
+                {
+                    SaveDataCollectorCore.PickupOneFile(tempDir, savFilePath);
                 }
 
                 // 4) Fresh .ups delta from a clean / old backup ROM (when supplied).

--- a/FEBuilderGBA.Core/ProblemReportCore.cs
+++ b/FEBuilderGBA.Core/ProblemReportCore.cs
@@ -16,11 +16,11 @@ namespace FEBuilderGBA
     /// Parity note: unlike the WinForms tool this does NOT archive the raw
     /// <c>.gba</c> ROM bytes (the WinForms tool only reads a clean ROM to generate
     /// UPS deltas; archiving the whole ROM would be a parity regression and a
-    /// copyright/privacy risk). The archive therefore contains only
-    /// <c>log.txt</c>, the per-ROM <c>etc/</c> config, and any already-existing
-    /// sibling <c>.ups</c> delta next to the loaded ROM. Generating fresh UPS
-    /// deltas (needs a clean-ROM input + WinForms <c>MainFormUtil.OpenROMToByte</c>)
-    /// and the emulator save/backup search are out of scope for this slice.
+    /// copyright/privacy risk). The archive therefore contains <c>log.txt</c>, the
+    /// per-ROM <c>etc/</c> config, any already-existing sibling <c>.ups</c> delta next
+    /// to the loaded ROM, the emulator save-state files discovered next to the ROM
+    /// (#1235, via <see cref="SaveDataCollectorCore"/>), and — when a clean / old
+    /// backup ROM is supplied — a fresh <c>.ups</c> delta from it to the current ROM.
     ///
     /// Never throws: every failure path returns a (localized) error string.
     /// </summary>
@@ -34,10 +34,19 @@ namespace FEBuilderGBA
         /// <paramref name="problemText"/> into a compressed report archive at
         /// <paramref name="outputPath"/>.
         /// </summary>
+        /// <param name="emulatorConfigDir">
+        /// Optional configured emulator path (WF <c>Program.Config.at("emulator")</c>);
+        /// when set, no$gba <c>BATTERY/</c> saves are also collected. May be <c>null</c>.
+        /// </param>
+        /// <param name="cleanRomPath">
+        /// Optional clean / old backup ROM path; when set, a fresh <c>.ups</c> delta
+        /// from it to the current ROM is added to the report (#1235). May be <c>null</c>.
+        /// </param>
         /// <returns>
         /// <c>""</c> on success, otherwise a localized error message. Never throws.
         /// </returns>
-        public static string CreateReport(ROM rom, string problemText, string outputPath)
+        public static string CreateReport(ROM rom, string problemText, string outputPath,
+            string emulatorConfigDir = null, string cleanRomPath = null)
         {
             string tempDir = null;
             try
@@ -63,10 +72,23 @@ namespace FEBuilderGBA
                 // 2) Any already-existing sibling .ups delta (NOT the raw ROM).
                 CollectSiblingUps(rom, tempDir);
 
-                // 3) Per-ROM etc config (lint / comment / flag).
+                // 3) Emulator save-state files next to the ROM (+ no$gba BATTERY).
+                //    Best-effort: a missing save must never fail the report (#1235).
+                if (!string.IsNullOrEmpty(rom.Filename))
+                {
+                    SaveDataCollectorCore.CollectSaveData(rom.Filename, emulatorConfigDir, tempDir);
+                }
+
+                // 4) Fresh .ups delta from a clean / old backup ROM (when supplied).
+                if (!string.IsNullOrEmpty(cleanRomPath))
+                {
+                    SaveDataCollectorCore.MakeBackupUps(cleanRomPath, rom.Data, tempDir);
+                }
+
+                // 5) Per-ROM etc config (lint / comment / flag).
                 CopyEtcData(rom, tempDir);
 
-                // 4) Compress (native 7-zip32.dll -> real .7z, else SharpCompress -> .zip).
+                // 6) Compress (native 7-zip32.dll -> real .7z, else SharpCompress -> .zip).
                 // checksize:1 (not the default 1024) — a minimal report (log + a tiny
                 // etc dir, highly compressible) can legitimately fall under the 1KB
                 // heuristic floor the WF tool uses to detect a failed 7z run; we have

--- a/FEBuilderGBA.Core/SaveDataCollectorCore.cs
+++ b/FEBuilderGBA.Core/SaveDataCollectorCore.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// GUI-free emulator save / backup collector for the Problem-Report tool
+    /// (#1235, ports the WinForms <c>ToolProblemReportForm</c> save-data and
+    /// old-backup UPS-delta steps: <c>CollectSaveData</c> / <c>CollectSaveDataInner</c>
+    /// / <c>PickupSaveData</c> / <c>PickupOneFile</c> / <c>CollectNoDollSaveData</c>
+    /// L350-468 and the <c>MakeUPS</c> delta L242-260).
+    ///
+    /// READ-ONLY with respect to the ROM and the user's files: it only reads save /
+    /// backup files and copies them (or writes a fresh <c>.ups</c> delta) into a
+    /// caller-supplied temp dir. It takes the ROM path + emulator config dir as
+    /// PARAMETERS — it never touches <c>Program.ROM</c> / <c>Program.Config</c>, so
+    /// it is safe for Core / CLI / Avalonia / headless use.
+    ///
+    /// Every method is best-effort and never throws: a missing save / unreadable
+    /// backup simply yields fewer collected files (mirrors the WF graceful behavior
+    /// where a missing save does not fail the report).
+    /// </summary>
+    public static class SaveDataCollectorCore
+    {
+        /// <summary>
+        /// Collect emulator save-state files that sit next to <paramref name="romFullPath"/>
+        /// (and, for no$gba, under the emulator's <c>BATTERY/</c> dir) into
+        /// <paramref name="tempDir"/>. Faithful port of WF <c>CollectSaveDataInner</c>.
+        /// </summary>
+        /// <param name="romFullPath">Full path to the currently loaded ROM (used for its dir + base name).</param>
+        /// <param name="emulatorConfigDir">
+        /// The configured emulator path (WF <c>Program.Config.at("emulator")</c>); may be
+        /// <c>null</c>/empty. Its directory's <c>BATTERY/</c> subdir is searched for no$gba saves.
+        /// </param>
+        /// <param name="tempDir">Destination dir the found saves are copied into.</param>
+        /// <returns>The list of file names (not full paths) copied into <paramref name="tempDir"/>.</returns>
+        public static List<string> CollectSaveData(string romFullPath, string emulatorConfigDir, string tempDir)
+        {
+            var collected = new List<string>();
+            try
+            {
+                if (string.IsNullOrEmpty(romFullPath) || string.IsNullOrEmpty(tempDir))
+                {
+                    return collected;
+                }
+
+                // ".sav" — and if not found next to the ROM, try no$gba's BATTERY dir.
+                if (!PickupSaveData(romFullPath, tempDir, ".sav", collected))
+                {
+                    CollectNoDollSaveData(romFullPath, emulatorConfigDir, tempDir, ".sav", collected);
+                }
+
+                PickupSaveData(romFullPath, tempDir, ".emulator.sav", collected);
+
+                for (int i = 1; i < 13; i++)
+                {
+                    string[] exts =
+                    {
+                        ".emulator" + i + ".sgm",
+                        ".emulator" + i + ".sps",
+                        "" + i + ".sgm",
+                        ".emulator.ss" + i,
+                        ".ss" + i,
+                        ".emulator.sg" + i,
+                        ".sg" + i,
+                        ".sa" + i,
+                    };
+                    foreach (string ext in exts)
+                    {
+                        PickupSaveData(romFullPath, tempDir, ext, collected);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Error("SaveDataCollectorCore.CollectSaveData failed: " + e.ToString());
+            }
+            return collected;
+        }
+
+        /// <summary>
+        /// Copy <paramref name="explicitFilePath"/> into <paramref name="tempDir"/>
+        /// (port of WF <c>PickupOneFile</c> — used for the interactive picker
+        /// fallback when auto-discovery finds nothing). Missing file is a no-op.
+        /// </summary>
+        /// <returns>The copied file name, or <c>null</c> when nothing was copied.</returns>
+        public static string PickupOneFile(string tempDir, string explicitFilePath)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(tempDir) ||
+                    string.IsNullOrEmpty(explicitFilePath) ||
+                    !File.Exists(explicitFilePath))
+                {
+                    return null;
+                }
+                string name = Path.GetFileName(explicitFilePath);
+                string dest = Path.Combine(tempDir, name);
+                File.Copy(explicitFilePath, dest, true);
+                return name;
+            }
+            catch (Exception e)
+            {
+                Log.Error("SaveDataCollectorCore.PickupOneFile failed: " + e.ToString());
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Look for <c>&lt;romdir&gt;/&lt;romBaseName&gt;&lt;needExt&gt;</c> next to the ROM
+        /// (with a space-&gt;underscore base-name fallback some emulators use) and copy
+        /// it into <paramref name="tempDir"/>. Port of WF <c>PickupSaveData</c>.
+        /// </summary>
+        static bool PickupSaveData(string romFullPath, string tempDir, string needExt, List<string> collected)
+        {
+            string dir = Path.GetDirectoryName(romFullPath);
+            string file = Path.GetFileNameWithoutExtension(romFullPath);
+            if (dir == null || file == null)
+            {
+                return false;
+            }
+
+            string savFilename = Path.Combine(dir, file + needExt);
+            if (!File.Exists(savFilename))
+            {
+                // Some emulators replace spaces with underscores in the save name.
+                file = file.Replace(" ", "_");
+                savFilename = Path.Combine(dir, file + needExt);
+                if (!File.Exists(savFilename))
+                {
+                    return false;
+                }
+            }
+
+            string destName = file + needExt;
+            string destFilename = Path.Combine(tempDir, destName);
+            File.Copy(savFilename, destFilename, true);
+            collected.Add(destName);
+            return true;
+        }
+
+        /// <summary>
+        /// no$gba keeps its battery saves under <c>&lt;emulatorDir&gt;/BATTERY/</c>.
+        /// Port of WF <c>CollectNoDollSaveData</c>.
+        /// </summary>
+        static bool CollectNoDollSaveData(string romFullPath, string emulatorConfigDir,
+            string tempDir, string needExt, List<string> collected)
+        {
+            if (string.IsNullOrEmpty(emulatorConfigDir))
+            {
+                return false;
+            }
+            string emudir = Path.GetDirectoryName(emulatorConfigDir);
+            if (string.IsNullOrEmpty(emudir))
+            {
+                return false;
+            }
+            string dir = Path.Combine(emudir, "BATTERY");
+            if (!Directory.Exists(dir))
+            {
+                return false;
+            }
+
+            string file = Path.GetFileNameWithoutExtension(romFullPath);
+            if (file == null)
+            {
+                return false;
+            }
+            string savFilename = Path.Combine(dir, file + needExt);
+            if (!File.Exists(savFilename))
+            {
+                return false;
+            }
+
+            string destName = file + needExt;
+            string destFilename = Path.Combine(tempDir, destName);
+            File.Copy(savFilename, destFilename, true);
+            collected.Add(destName);
+            return true;
+        }
+
+        /// <summary>
+        /// Generate a <c>.ups</c> delta from a user-picked clean / old backup ROM to
+        /// the current ROM bytes and write it into <paramref name="tempDir"/>
+        /// (Core port of WF <c>MakeUPS</c> / <c>CollectOldUPSs</c>: the clean ROM is
+        /// the UPS source, the current ROM is the destination). Read-only on disk
+        /// except for the single <c>.ups</c> output.
+        /// </summary>
+        /// <param name="cleanRomPath">Full path to the clean / old backup ROM (UPS source).</param>
+        /// <param name="currentRomBytes">The current (modified) ROM bytes (UPS destination).</param>
+        /// <param name="tempDir">Destination dir the <c>.ups</c> delta is written into.</param>
+        /// <returns>The written <c>.ups</c> file name, or <c>null</c> on any failure.</returns>
+        public static string MakeBackupUps(string cleanRomPath, byte[] currentRomBytes, string tempDir)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(cleanRomPath) ||
+                    !File.Exists(cleanRomPath) ||
+                    currentRomBytes == null ||
+                    currentRomBytes.Length == 0 ||
+                    string.IsNullOrEmpty(tempDir))
+                {
+                    return null;
+                }
+
+                byte[] src = File.ReadAllBytes(cleanRomPath);
+                string upsName = Path.GetFileNameWithoutExtension(cleanRomPath) + ".ups";
+                string ups = Path.Combine(tempDir, upsName);
+                UPSUtilCore.MakeUPS(src, currentRomBytes, ups);
+                return upsName;
+            }
+            catch (Exception e)
+            {
+                Log.Error("SaveDataCollectorCore.MakeBackupUps failed: " + e.ToString());
+                return null;
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Core/SaveDataCollectorCore.cs
+++ b/FEBuilderGBA.Core/SaveDataCollectorCore.cs
@@ -80,6 +80,95 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
+        /// Non-mutating probe: would <see cref="CollectSaveData"/> find at least one
+        /// emulator save-state file next to the ROM (or in no$gba's BATTERY dir)?
+        /// Used by the Avalonia tool to decide whether to surface the interactive
+        /// SAV picker (mirrors WF <c>CollectSaveDataInner</c> returning false).
+        /// Reads nothing into a temp dir — pure existence checks. Never throws.
+        /// </summary>
+        public static bool HasAnySaveData(string romFullPath, string emulatorConfigDir)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(romFullPath))
+                {
+                    return false;
+                }
+
+                if (SaveFileExists(romFullPath, ".sav") ||
+                    BatterySaveExists(romFullPath, emulatorConfigDir, ".sav") ||
+                    SaveFileExists(romFullPath, ".emulator.sav"))
+                {
+                    return true;
+                }
+
+                for (int i = 1; i < 13; i++)
+                {
+                    string[] exts =
+                    {
+                        ".emulator" + i + ".sgm",
+                        ".emulator" + i + ".sps",
+                        "" + i + ".sgm",
+                        ".emulator.ss" + i,
+                        ".ss" + i,
+                        ".emulator.sg" + i,
+                        ".sg" + i,
+                        ".sa" + i,
+                    };
+                    foreach (string ext in exts)
+                    {
+                        if (SaveFileExists(romFullPath, ext))
+                        {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+            catch (Exception e)
+            {
+                Log.Error("SaveDataCollectorCore.HasAnySaveData failed: " + e.ToString());
+                return false;
+            }
+        }
+
+        /// <summary>Existence-only variant of the <see cref="PickupSaveData"/> search (rom-dir + space→underscore).</summary>
+        static bool SaveFileExists(string romFullPath, string needExt)
+        {
+            string dir = Path.GetDirectoryName(romFullPath);
+            string file = Path.GetFileNameWithoutExtension(romFullPath);
+            if (dir == null || file == null)
+            {
+                return false;
+            }
+            if (File.Exists(Path.Combine(dir, file + needExt)))
+            {
+                return true;
+            }
+            return File.Exists(Path.Combine(dir, file.Replace(" ", "_") + needExt));
+        }
+
+        /// <summary>Existence-only variant of the no$gba <see cref="CollectNoDollSaveData"/> BATTERY search.</summary>
+        static bool BatterySaveExists(string romFullPath, string emulatorConfigDir, string needExt)
+        {
+            if (string.IsNullOrEmpty(emulatorConfigDir))
+            {
+                return false;
+            }
+            string emudir = Path.GetDirectoryName(emulatorConfigDir);
+            if (string.IsNullOrEmpty(emudir))
+            {
+                return false;
+            }
+            string file = Path.GetFileNameWithoutExtension(romFullPath);
+            if (file == null)
+            {
+                return false;
+            }
+            return File.Exists(Path.Combine(emudir, "BATTERY", file + needExt));
+        }
+
+        /// <summary>
         /// Copy <paramref name="explicitFilePath"/> into <paramref name="tempDir"/>
         /// (port of WF <c>PickupOneFile</c> — used for the interactive picker
         /// fallback when auto-discovery finds nothing). Missing file is a no-op.
@@ -114,30 +203,40 @@ namespace FEBuilderGBA
         /// </summary>
         static bool PickupSaveData(string romFullPath, string tempDir, string needExt, List<string> collected)
         {
-            string dir = Path.GetDirectoryName(romFullPath);
-            string file = Path.GetFileNameWithoutExtension(romFullPath);
-            if (dir == null || file == null)
+            try
             {
-                return false;
-            }
-
-            string savFilename = Path.Combine(dir, file + needExt);
-            if (!File.Exists(savFilename))
-            {
-                // Some emulators replace spaces with underscores in the save name.
-                file = file.Replace(" ", "_");
-                savFilename = Path.Combine(dir, file + needExt);
-                if (!File.Exists(savFilename))
+                string dir = Path.GetDirectoryName(romFullPath);
+                string file = Path.GetFileNameWithoutExtension(romFullPath);
+                if (dir == null || file == null)
                 {
                     return false;
                 }
-            }
 
-            string destName = file + needExt;
-            string destFilename = Path.Combine(tempDir, destName);
-            File.Copy(savFilename, destFilename, true);
-            collected.Add(destName);
-            return true;
+                string savFilename = Path.Combine(dir, file + needExt);
+                if (!File.Exists(savFilename))
+                {
+                    // Some emulators replace spaces with underscores in the save name.
+                    file = file.Replace(" ", "_");
+                    savFilename = Path.Combine(dir, file + needExt);
+                    if (!File.Exists(savFilename))
+                    {
+                        return false;
+                    }
+                }
+
+                string destName = file + needExt;
+                string destFilename = Path.Combine(tempDir, destName);
+                File.Copy(savFilename, destFilename, true);
+                collected.Add(destName);
+                return true;
+            }
+            catch (Exception e)
+            {
+                // Best-effort: one locked / access-denied save must not abort the
+                // rest of the collection. Log and skip this single file.
+                Log.Error("SaveDataCollectorCore.PickupSaveData skipped '" + needExt + "': " + e.ToString());
+                return false;
+            }
         }
 
         /// <summary>
@@ -147,37 +246,47 @@ namespace FEBuilderGBA
         static bool CollectNoDollSaveData(string romFullPath, string emulatorConfigDir,
             string tempDir, string needExt, List<string> collected)
         {
-            if (string.IsNullOrEmpty(emulatorConfigDir))
+            try
             {
-                return false;
-            }
-            string emudir = Path.GetDirectoryName(emulatorConfigDir);
-            if (string.IsNullOrEmpty(emudir))
-            {
-                return false;
-            }
-            string dir = Path.Combine(emudir, "BATTERY");
-            if (!Directory.Exists(dir))
-            {
-                return false;
-            }
+                if (string.IsNullOrEmpty(emulatorConfigDir))
+                {
+                    return false;
+                }
+                string emudir = Path.GetDirectoryName(emulatorConfigDir);
+                if (string.IsNullOrEmpty(emudir))
+                {
+                    return false;
+                }
+                string dir = Path.Combine(emudir, "BATTERY");
+                if (!Directory.Exists(dir))
+                {
+                    return false;
+                }
 
-            string file = Path.GetFileNameWithoutExtension(romFullPath);
-            if (file == null)
-            {
-                return false;
-            }
-            string savFilename = Path.Combine(dir, file + needExt);
-            if (!File.Exists(savFilename))
-            {
-                return false;
-            }
+                string file = Path.GetFileNameWithoutExtension(romFullPath);
+                if (file == null)
+                {
+                    return false;
+                }
+                string savFilename = Path.Combine(dir, file + needExt);
+                if (!File.Exists(savFilename))
+                {
+                    return false;
+                }
 
-            string destName = file + needExt;
-            string destFilename = Path.Combine(tempDir, destName);
-            File.Copy(savFilename, destFilename, true);
-            collected.Add(destName);
-            return true;
+                string destName = file + needExt;
+                string destFilename = Path.Combine(tempDir, destName);
+                File.Copy(savFilename, destFilename, true);
+                collected.Add(destName);
+                return true;
+            }
+            catch (Exception e)
+            {
+                // Best-effort: a locked / access-denied BATTERY save must not abort
+                // the rest of the collection. Log and skip.
+                Log.Error("SaveDataCollectorCore.CollectNoDollSaveData skipped '" + needExt + "': " + e.ToString());
+                return false;
+            }
         }
 
         /// <summary>

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11469,3 +11469,12 @@ report.7zについて:
 
 :Output path is empty.
 出力先が指定されていません。
+
+:Please specify a save file path.
+セーブファイルのパスを指定してください。
+
+:Please specify a backup ROM path.
+バックアップROMのパスを指定してください。
+
+:The specified file does not exist.
+指定されたファイルが存在しません。

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11437,8 +11437,8 @@ TSA数: {0}
 :Update check failed.
 更新の確認に失敗しました。
 
-:Describe the problem, then create a report to attach when you ask for help. The report includes a diagnostic log and your editor settings (no save data is collected).
-問題点を記載してから、レポートを作成してください。質問するときに添付します。レポートには診断ログと編集設定が含まれます（セーブデータは収集しません）。
+:Describe the problem, then create a report to attach when you ask for help. The report includes a diagnostic log, your editor settings, and any emulator save data found next to the ROM.
+問題点を記載してから、レポートを作成してください。質問するときに添付します。レポートには診断ログ、編集設定、およびROMの隣で見つかったエミュレータのセーブデータが含まれます。
 
 :Problem description
 問題点

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25278,8 +25278,8 @@ TSA数量: {0}
 :Update check failed.
 更新检查失败。
 
-:Describe the problem, then create a report to attach when you ask for help. The report includes a diagnostic log and your editor settings (no save data is collected).
-请先描述问题，然后创建报告，在求助时附上。报告包含诊断日志和您的编辑器设置（不收集存档数据）。
+:Describe the problem, then create a report to attach when you ask for help. The report includes a diagnostic log, your editor settings, and any emulator save data found next to the ROM.
+请先描述问题，然后创建报告，在求助时附上。报告包含诊断日志、您的编辑器设置，以及在 ROM 旁找到的任何模拟器存档数据。
 
 :Problem description
 问题描述

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25310,3 +25310,12 @@ TSA数量: {0}
 
 :Output path is empty.
 未指定输出路径。
+
+:Please specify a save file path.
+请指定存档文件的路径。
+
+:Please specify a backup ROM path.
+请指定备份 ROM 的路径。
+
+:The specified file does not exist.
+指定的文件不存在。


### PR DESCRIPTION
Fixes #1235.

Follow-up to #1193 (Avalonia Problem-Report tool) — ports the WinForms emulator **save/backup-file search** so generated reports include the save state needed to reliably reproduce a problem.

## What
- **Auto-collection** (`SaveDataCollectorCore.CollectSaveData`): faithful port of WF `PickupSaveData`/`PickupOneFile`/`CollectNoDollSaveData` — searches `<romdir>/<romname><ext>` for `.sav` / `.emulator.sav` / `.emulator{i}.sgm/.sps/.ss{i}/.sg{i}` etc. (with the space→underscore filename variant) plus the no$gba `BATTERY/` dir under the `emulator` config path, and copies any hits into the report temp dir.
- **Old-backup UPS delta** (`MakeBackupUps`): reads a user-supplied clean/old backup ROM → `UPSUtilCore.MakeUPS` → `.ups` into the temp dir.
- **Two fallback picker sub-views** (`ToolProblemReportSearchSavView` / `ToolProblemReportSearchBackupView`): shown when auto-discovery finds nothing, so the user can point at a save/backup (path TextBox + Browse + OK/Cancel).
- Wired into `ProblemReportCore.CreateReport` via **backward-compatible optional params** (`emulatorConfigDir = null`, `cleanRomPath = null`).

## Non-mutating
Confirmed: read-only `File.Copy` of saves + `File.ReadAllBytes(cleanRom)` + UPS-make into the temp dir only — no `Program.ROM` / `SetU8` / undo / ROM save. Missing saves never fail the report (graceful, mirrors WF).

## Tests / gates (all green locally)
- `SaveDataCollectorCoreTests` — synthetic temp-dir discovery (incl. space→underscore + BATTERY) + UPS make→apply round-trip == original.
- Core.Tests `~SaveDataCollectorCore|~ProblemReportCore`: **11 passed**; ScrollViewer gate (both new views ScrollViewer-wrapped): **3 passed**.
- Avalonia.Tests `~L10nCoverage|~AutomationId|~ScrollViewer|~Orphan`: **269 passed** (IDataVerifiable orphan trap avoided — all 3 VMs read no ROM bytes, none implement/mention it).
- FEBuilderGBA.Tests `~Avalonia|~AutomationId`: **793 passed**. `validate-automation-ids.ps1`: **0 errors, 0 warnings**. Dark-mode: 0 hex literals.

## Proof (FE8U — new fallback picker sub-views)
Shown when auto-discovery finds no save/backup; each lets the user Browse to one:

| Save (`.sav`) picker | Backup (UPS delta) picker |
|---|---|
| <img width="430" src="https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1235-savesearch-sav-fe8u.png"> | <img width="430" src="https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1235-savesearch-backup-fe8u.png"> |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 4.8 (1M context), model `claude-opus-4-8[1m]`