### PR TITLE
feat(avalonia): port In-ROM Magic Animation multi-frame .txt + GIF export (#1230)

### DIFF
--- a/FEBuilderGBA.Avalonia/ViewModels/ImageRomAnimeViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageRomAnimeViewModel.cs
@@ -118,6 +118,44 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             return error;
         }
 
+        /// <summary>
+        /// Export the WHOLE animation as a <c>wait png</c> script + per-frame PNGs
+        /// (multi-frame, #1230). Returns "" on success or a user-facing error.
+        /// </summary>
+        public string ExportScript(string scriptPath)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null || _entry == null) return R._("No animation entry selected.");
+            return RomAnimeMultiFrameCore.ExportTxt(rom, _entry, scriptPath);
+        }
+
+        /// <summary>
+        /// Export the WHOLE animation as an animated GIF (multi-frame, #1230).
+        /// Returns "" on success or a user-facing error.
+        /// </summary>
+        public string ExportGif(string gifPath)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null || _entry == null) return R._("No animation entry selected.");
+            return RomAnimeMultiFrameCore.ExportGif(rom, _entry, gifPath);
+        }
+
+        /// <summary>
+        /// Import a multi-frame <c>wait png</c> script and rebuild the WHOLE animation
+        /// as one atomic transaction (#1230). The <paramref name="frameLoader"/> turns a
+        /// resolved PNG path into a quantized <c>(indexed, gbaPalette16, w, h)</c> tuple
+        /// (or null when missing). Returns "" on success or a user-facing error (ZERO
+        /// ROM mutation on failure).
+        /// </summary>
+        public string ImportScript(string scriptPath,
+            Func<string, (byte[] indexedPixels, byte[] gbaPalette16, int width, int height)?> frameLoader)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null || _entry == null) return R._("No animation entry selected.");
+            RomAnimeMultiFrameCore.ImportTxt(rom, _entry, scriptPath, frameLoader, out string error);
+            return error;
+        }
+
         // ---- IDataVerifiable ----
 
         public int GetListCount() => LoadList().Count;

--- a/FEBuilderGBA.Avalonia/Views/ImageRomAnimeView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageRomAnimeView.axaml
@@ -27,6 +27,12 @@
           <Button AutomationProperties.AutomationId="ImageRomAnime_ImportPng_Button" Content="Import PNG" Click="ImportPng_Click" />
         </StackPanel>
 
+        <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,4,0,0">
+          <Button AutomationProperties.AutomationId="ImageRomAnime_ExportScript_Button" Content="Export Script" Click="ExportScript_Click" />
+          <Button AutomationProperties.AutomationId="ImageRomAnime_ImportScript_Button" Content="Import Script" Click="ImportScript_Click" />
+          <Button AutomationProperties.AutomationId="ImageRomAnime_ExportGif_Button" Content="Export GIF" Click="ExportGif_Click" />
+        </StackPanel>
+
         <TextBlock AutomationProperties.AutomationId="ImageRomAnime_Info_Label" Name="InfoLabel" TextWrapping="Wrap" />
 
         <Border BorderThickness="1" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"

--- a/FEBuilderGBA.Avalonia/Views/ImageRomAnimeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageRomAnimeView.axaml.cs
@@ -167,6 +167,111 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
+        async void ExportScript_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (!_vm.IsLoaded || _vm.Entry == null)
+                {
+                    CoreState.Services?.ShowError(R._("No animation entry selected."));
+                    return;
+                }
+                string? path = await FileDialogHelper.SaveAnimationScriptFile(this,
+                    "romanime_" + U.ToHexString(_vm.CurrentId) + ".txt");
+                if (string.IsNullOrEmpty(path)) return;
+
+                string err = _vm.ExportScript(path);
+                if (!string.IsNullOrEmpty(err)) { CoreState.Services?.ShowError(err); return; }
+                CoreState.Services?.ShowInfo(R._("Animation script exported successfully."));
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImageRomAnimeView.ExportScript_Click failed: " + ex.ToString());
+                CoreState.Services?.ShowError(R._("Export failed: {0}", ex.Message));
+            }
+        }
+
+        async void ExportGif_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (!_vm.IsLoaded || _vm.Entry == null)
+                {
+                    CoreState.Services?.ShowError(R._("No animation entry selected."));
+                    return;
+                }
+                string? path = await FileDialogHelper.SaveFile(this,
+                    R._("Save Animation GIF"), R._("Animated GIF (.gif)"), "*.gif",
+                    "romanime_" + U.ToHexString(_vm.CurrentId) + ".gif");
+                if (string.IsNullOrEmpty(path)) return;
+
+                string err = _vm.ExportGif(path);
+                if (!string.IsNullOrEmpty(err)) { CoreState.Services?.ShowError(err); return; }
+                CoreState.Services?.ShowInfo(R._("Animation GIF exported successfully."));
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImageRomAnimeView.ExportGif_Click failed: " + ex.ToString());
+                CoreState.Services?.ShowError(R._("Export failed: {0}", ex.Message));
+            }
+        }
+
+        async void ImportScript_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (!_vm.IsLoaded || _vm.Entry == null)
+                {
+                    CoreState.Services?.ShowError(R._("No animation entry selected."));
+                    return;
+                }
+                string? path = await FileDialogHelper.OpenFile(this,
+                    R._("Open Animation Script"), "*.txt");
+                if (string.IsNullOrEmpty(path)) return;
+
+                int width = _vm.FrameWidthPx;
+                // Per-PNG loader: quantize each frame image to <=16 colors (the per-frame
+                // import path). strictSize:false — Core crops/pads to the canvas.
+                (byte[] indexedPixels, byte[] gbaPalette16, int width, int height)? Loader(string pngPath)
+                {
+                    var load = ImageImportService.LoadAndQuantizeFromFile(pngPath, width, 0, 16, strictSize: false);
+                    if (load == null || !load.Success) return null;
+                    return (load.IndexedPixels, load.GBAPalette, load.Width, load.Height);
+                }
+
+                _undoService.Begin("Import In-ROM Animation Script");
+                try
+                {
+                    string err = _vm.ImportScript(path, Loader);
+                    if (!string.IsNullOrEmpty(err))
+                    {
+                        _undoService.Rollback();
+                        CoreState.Services?.ShowError(err);
+                        return;
+                    }
+                    _undoService.Commit();
+                    // Re-resolve the entry (pointers changed) + refresh preview.
+                    _vm.IsLoading = true;
+                    try { _vm.LoadEntry(_vm.CurrentId); UpdateUI(); UpdateFrameRange(); }
+                    finally { _vm.IsLoading = false; }
+                    LoadImage();
+                    _vm.MarkClean();
+                    CoreState.Services?.ShowInfo(R._("Animation script imported successfully."));
+                }
+                catch (Exception ex)
+                {
+                    _undoService.Rollback();
+                    Log.Error("ImageRomAnimeView.ImportScript_Click write failed: " + ex.ToString());
+                    CoreState.Services?.ShowError(R._("Import failed: {0}", ex.Message));
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ImageRomAnimeView.ImportScript_Click failed: " + ex.ToString());
+                CoreState.Services?.ShowError(R._("Import failed: {0}", ex.Message));
+            }
+        }
+
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
     }

--- a/FEBuilderGBA.Core.Tests/RomAnimeMultiFrameCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RomAnimeMultiFrameCoreTests.cs
@@ -1,0 +1,570 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for RomAnimeMultiFrameCore (#1230) — the In-ROM Magic Animation editor's
+// DEFERRED multi-frame `.txt` script export/import + animated-GIF export, on top of
+// the single-frame slice (RomAnimeCore, #1176).
+//
+// Each test plants a synthetic `romanime_` entry of one of the four WF storage
+// shapes, then drives ExportTxt -> ImportTxt round-trips, the fault-restore path,
+// and ExportGif. The four shapes:
+//   FIXEDCOUNT  + multi-palette  : per-frame image/tsa/pal lists; FramePointer == N.
+//   FIXEDCOUNT  + palette-anime  : ONE image+tsa, a per-frame PAL list (TSAList==1 &&
+//                                  PaletteList>=2).
+//   frame-table + COMMONPALETTE  : per-frame image/tsa lists, ONE shared palette
+//                                  (TSAList>=2 && PaletteList==1) + the {id,wait} table.
+//   frame-table + multi-palette  : per-frame image/tsa/pal lists + the {id,wait} table.
+//
+// Reuses the synthetic-ROM harness shape from RomAnimeCoreTests (rom.LoadLow + a
+// StubImageService). [Collection("SharedState")] because the render reads
+// CoreState.ImageService and the import reads CoreState.ROM.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class RomAnimeMultiFrameCoreTests
+    {
+        const int WIDTH_TILES = 8;        // 64 px wide
+        const int FRAME_HEIGHT = 8 * 16;  // 128 px tall canvas
+
+        // Pointer SLOTS (addresses that themselves hold pointer-lists / values).
+        const uint FRAME_PTR_SLOT = 0x000800;
+        const uint TSA_PTR_SLOT   = 0x001000;
+        const uint IMAGE_PTR_SLOT = 0x002000;
+        const uint PAL_PTR_SLOT   = 0x003000;
+        // The pointer LISTS.
+        const uint FRAME_TABLE    = 0x008000;
+        const uint TSA_LIST       = 0x010000;
+        const uint IMAGE_LIST     = 0x011000;
+        const uint PAL_LIST       = 0x012000;
+        // Per-frame data (two frames worth, distinct).
+        const uint TSA_DATA_0     = 0x020000;
+        const uint TSA_DATA_1     = 0x020800;
+        const uint IMAGE_DATA_0   = 0x021000;
+        const uint IMAGE_DATA_1   = 0x021800;
+        const uint PAL_DATA_0     = 0x022000;
+        const uint PAL_DATA_1     = 0x022800;
+
+        const ushort RED   = 0x001F;
+        const ushort GREEN = 0x03E0;
+        const ushort BLUE  = 0x7C00;
+
+        // =================================================================
+        // Round-trip: FIXEDCOUNT multi-palette (2 frames).
+        // =================================================================
+
+        [Fact]
+        public void RoundTrip_FixedCountMultiPalette_ReproducesFrames()
+        {
+            WithRom((rom, dir) =>
+            {
+                PlantFixedCount(rom, 2, paletteAnime: false);
+                RomAnimeCore.RomAnimeEntry e = ResolveFixed(rom, 2, "FIXEDCOUNT");
+                Assert.False(e.IsFrameTable);
+
+                string script = Path.Combine(dir, "rt.txt");
+                Assert.Equal("", RomAnimeMultiFrameCore.ExportTxt(rom, e, script));
+                AssertScriptHasFrames(script, 2);
+
+                // Materialize the script's referenced PNG placeholders (the stub codec
+                // writes nothing on Save), then import the just-exported script.
+                MaterializeScriptPngs(dir, script);
+                bool ok = RomAnimeMultiFrameCore.ImportTxt(rom, e, script, Loader, out string err);
+                Assert.True(ok, err);
+
+                // Re-resolve + re-export: still 2 renderable frames.
+                RomAnimeCore.RomAnimeEntry e2 = ResolveFixed(rom, 2, "FIXEDCOUNT");
+                string script2 = Path.Combine(dir, "rt2.txt");
+                Assert.Equal("", RomAnimeMultiFrameCore.ExportTxt(rom, e2, script2));
+                AssertScriptHasFrames(script2, 2);
+            });
+        }
+
+        // =================================================================
+        // FIXEDCOUNT palette-animation (TSAList==1, PaletteList>=2).
+        // =================================================================
+
+        [Fact]
+        public void Import_FixedCountPaletteAnime_WritesOneImagePerFramePalette()
+        {
+            WithRom((rom, dir) =>
+            {
+                PlantFixedCount(rom, 2, paletteAnime: true);
+                RomAnimeCore.RomAnimeEntry e = ResolveFixed(rom, 2, "");
+                Assert.False(e.IsFrameTable);
+                Assert.Single(e.TSAList);
+                Assert.Equal(2, e.PaletteList.Count);
+
+                string script = WriteScript(dir, "pa.txt", new (uint, string)[]
+                {
+                    (1, "f0.png"), (1, "f1.png"),
+                });
+                MakePngFiles(dir, "f0.png", "f1.png");
+
+                bool ok = RomAnimeMultiFrameCore.ImportTxt(rom, e, script, Loader, out string err);
+                Assert.True(ok, err);
+
+                // The PALETTE pointer now resolves to a 2-entry list (one per frame).
+                RomAnimeCore.RomAnimeEntry e2 = ResolveFixed(rom, 2, "");
+                Assert.Equal(2, e2.PaletteList.Count);
+                // The IMAGE list still resolves (frame 0's image written + repointed).
+                uint img = U.toOffset(rom.u32(IMAGE_PTR_SLOT));
+                Assert.True(U.isSafetyOffset(img, rom));
+            });
+        }
+
+        // =================================================================
+        // frame-table COMMONPALETTE (TSAList>=2, PaletteList==1).
+        // =================================================================
+
+        [Fact]
+        public void RoundTrip_FrameTableCommonPalette_ReproducesTable()
+        {
+            WithRom((rom, dir) =>
+            {
+                PlantFrameTable(rom, commonPalette: true);
+                RomAnimeCore.RomAnimeEntry e = ResolveFrameTable(rom, "COMMONPALETTE");
+                Assert.True(e.IsFrameTable);
+                Assert.True(e.TSAList.Count >= 2);
+                Assert.Single(e.PaletteList);
+
+                string script = Path.Combine(dir, "ct.txt");
+                Assert.Equal("", RomAnimeMultiFrameCore.ExportTxt(rom, e, script));
+
+                MaterializeScriptPngs(dir, script);
+                bool ok = RomAnimeMultiFrameCore.ImportTxt(rom, e, script, Loader, out string err);
+                Assert.True(ok, err);
+
+                // A fresh frame table is in place + walks to a 0xFFFF terminator.
+                uint tableAddr = rom.p32(FRAME_PTR_SLOT);
+                Assert.True(U.isSafetyOffset(tableAddr, rom));
+                Assert.True(WalkFrameTableCount(rom, tableAddr) >= 2);
+
+                // PALETTE pointer resolves to a single shared 32-byte block (count 1).
+                RomAnimeCore.RomAnimeEntry e2 = ResolveFrameTable(rom, "COMMONPALETTE");
+                Assert.Single(e2.PaletteList);
+            });
+        }
+
+        // =================================================================
+        // frame-table multi-palette.
+        // =================================================================
+
+        [Fact]
+        public void RoundTrip_FrameTableMultiPalette_ReproducesTable()
+        {
+            WithRom((rom, dir) =>
+            {
+                PlantFrameTable(rom, commonPalette: false);
+                RomAnimeCore.RomAnimeEntry e = ResolveFrameTable(rom, "");
+                Assert.True(e.IsFrameTable);
+                Assert.True(e.PaletteList.Count >= 2);
+
+                string script = Path.Combine(dir, "mt.txt");
+                Assert.Equal("", RomAnimeMultiFrameCore.ExportTxt(rom, e, script));
+
+                MaterializeScriptPngs(dir, script);
+                bool ok = RomAnimeMultiFrameCore.ImportTxt(rom, e, script, Loader, out string err);
+                Assert.True(ok, err);
+
+                uint tableAddr = rom.p32(FRAME_PTR_SLOT);
+                Assert.True(U.isSafetyOffset(tableAddr, rom));
+                Assert.True(WalkFrameTableCount(rom, tableAddr) >= 2);
+
+                RomAnimeCore.RomAnimeEntry e2 = ResolveFrameTable(rom, "");
+                Assert.True(e2.PaletteList.Count >= 2);
+            });
+        }
+
+        // =================================================================
+        // Atomic fault-restore: a failing import mutates ZERO bytes.
+        // =================================================================
+
+        [Fact]
+        public void Import_WrongFixedCount_MutatesZeroBytes()
+        {
+            WithRom((rom, dir) =>
+            {
+                PlantFixedCount(rom, 2, paletteAnime: false);
+                RomAnimeCore.RomAnimeEntry e = ResolveFixed(rom, 2, "FIXEDCOUNT");
+                byte[] before = (byte[])rom.Data.Clone();
+
+                // Script defines only ONE frame but the entry requires exactly 2.
+                string script = WriteScript(dir, "bad.txt", new (uint, string)[] { (1, "only.png") });
+                MakePngFiles(dir, "only.png");
+
+                bool ok = RomAnimeMultiFrameCore.ImportTxt(rom, e, script, Loader, out string err);
+                Assert.False(ok);
+                Assert.False(string.IsNullOrEmpty(err));
+                Assert.Equal(before, rom.Data); // byte-identical
+            });
+        }
+
+        [Fact]
+        public void Import_ForcedNoFreeSpace_MutatesZeroBytes()
+        {
+            var savedRom = CoreState.ROM;
+            var savedSvc = CoreState.ImageService;
+            string dir = Directory.CreateDirectory(
+                Path.Combine(Path.GetTempPath(), "romanime_mf_" + Guid.NewGuid().ToString("N"))).FullName;
+            try
+            {
+                // A ROM at the 32 MB max filled with 0x01 (no free runs) -> every write
+                // fails -> the import must restore byte-identical.
+                const uint MAX = 0x02000000;
+                var rom = new ROM();
+                byte[] data = new byte[MAX];
+                Array.Fill(data, (byte)0x01);
+                rom.LoadLow("synth.gba", data, "BE8E01");
+                CoreState.ROM = rom;
+                CoreState.ImageService = new StubImageService();
+
+                PlantFixedCount(rom, 2, paletteAnime: false);
+                RomAnimeCore.RomAnimeEntry e = ResolveFixed(rom, 2, "FIXEDCOUNT");
+                byte[] before = (byte[])rom.Data.Clone();
+
+                string script = WriteScript(dir, "nofree.txt", new (uint, string)[] { (1, "f0.png"), (1, "f1.png") });
+                MakePngFiles(dir, "f0.png", "f1.png");
+
+                bool ok = RomAnimeMultiFrameCore.ImportTxt(rom, e, script, Loader, out string err);
+                Assert.False(ok);
+                Assert.False(string.IsNullOrEmpty(err));
+                Assert.Equal(before.Length, rom.Data.Length);
+                Assert.Equal(before, rom.Data);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom; CoreState.ImageService = savedSvc;
+                TryDeleteDir(dir);
+            }
+        }
+
+        [Fact]
+        public void Import_MissingPng_MutatesZeroBytes()
+        {
+            WithRom((rom, dir) =>
+            {
+                PlantFixedCount(rom, 2, paletteAnime: false);
+                RomAnimeCore.RomAnimeEntry e = ResolveFixed(rom, 2, "FIXEDCOUNT");
+                byte[] before = (byte[])rom.Data.Clone();
+
+                // Script references a PNG that does not exist on disk.
+                string script = WriteScript(dir, "miss.txt", new (uint, string)[] { (1, "ghost.png"), (1, "ghost2.png") });
+
+                bool ok = RomAnimeMultiFrameCore.ImportTxt(rom, e, script, Loader, out string err);
+                Assert.False(ok);
+                Assert.False(string.IsNullOrEmpty(err));
+                Assert.Equal(before, rom.Data);
+            });
+        }
+
+        // =================================================================
+        // ExportGif: produces a valid GIF89a file.
+        // =================================================================
+
+        [Fact]
+        public void ExportGif_FrameTable_WritesValidGif89a()
+        {
+            WithRom((rom, dir) =>
+            {
+                PlantFrameTable(rom, commonPalette: false);
+                RomAnimeCore.RomAnimeEntry e = ResolveFrameTable(rom, "");
+
+                string gif = Path.Combine(dir, "anim.gif");
+                Assert.Equal("", RomAnimeMultiFrameCore.ExportGif(rom, e, gif));
+
+                Assert.True(File.Exists(gif));
+                byte[] bytes = File.ReadAllBytes(gif);
+                Assert.True(bytes.Length > 6);
+                // GIF89a header.
+                Assert.Equal((byte)'G', bytes[0]);
+                Assert.Equal((byte)'I', bytes[1]);
+                Assert.Equal((byte)'F', bytes[2]);
+                Assert.Equal((byte)'8', bytes[3]);
+                Assert.Equal((byte)'9', bytes[4]);
+                Assert.Equal((byte)'a', bytes[5]);
+                // GIF trailer.
+                Assert.Equal((byte)0x3B, bytes[bytes.Length - 1]);
+            });
+        }
+
+        [Fact]
+        public void ExportGif_FixedCount_WritesValidGif89a()
+        {
+            WithRom((rom, dir) =>
+            {
+                PlantFixedCount(rom, 2, paletteAnime: false);
+                RomAnimeCore.RomAnimeEntry e = ResolveFixed(rom, 2, "FIXEDCOUNT");
+
+                string gif = Path.Combine(dir, "fixed.gif");
+                Assert.Equal("", RomAnimeMultiFrameCore.ExportGif(rom, e, gif));
+                byte[] bytes = File.ReadAllBytes(gif);
+                Assert.Equal((byte)'G', bytes[0]);
+                Assert.Equal((byte)'a', bytes[5]);
+            });
+        }
+
+        // =================================================================
+        // Guards: null inputs never throw, return errors.
+        // =================================================================
+
+        [Fact]
+        public void ExportTxt_NullEntry_ReturnsError()
+            => Assert.False(string.IsNullOrEmpty(RomAnimeMultiFrameCore.ExportTxt(null, null, "x.txt")));
+
+        [Fact]
+        public void ImportTxt_MissingScript_ReturnsErrorNoThrow()
+        {
+            WithRom((rom, dir) =>
+            {
+                PlantFixedCount(rom, 2, paletteAnime: false);
+                RomAnimeCore.RomAnimeEntry e = ResolveFixed(rom, 2, "FIXEDCOUNT");
+                bool ok = RomAnimeMultiFrameCore.ImportTxt(rom, e,
+                    Path.Combine(dir, "no-such.txt"), Loader, out string err);
+                Assert.False(ok);
+                Assert.False(string.IsNullOrEmpty(err));
+            });
+        }
+
+        // =================================================================
+        // The loader. The Core.Tests StubImageService does NOT do real PNG I/O
+        // (LoadImage returns null, Save is a no-op), so the loader is SYNTHETIC:
+        // it returns deterministic indexed pixels + a 16-color GBA palette for any
+        // path that exists on disk, and null for a missing file (so the missing-PNG
+        // fault test can exercise the validate-before-mutate path). This mirrors what
+        // the View's real ImageImportService.LoadAndQuantizeFromFile yields — quantized
+        // indexed bytes + a 32-byte palette — without depending on a real image codec.
+        // =================================================================
+
+        static (byte[] indexedPixels, byte[] gbaPalette16, int width, int height)? Loader(string pngPath)
+        {
+            if (!File.Exists(pngPath)) return null;
+            int w = WIDTH_TILES * 8, h = FRAME_HEIGHT;
+            byte[] indexed = new byte[w * h];
+            // Seed the indices off the filename so distinct PNGs encode to distinct tiles.
+            int seed = Math.Abs((Path.GetFileNameWithoutExtension(pngPath) ?? "").GetHashCode()) % 13 + 1;
+            for (int i = 0; i < indexed.Length; i++) indexed[i] = (byte)(((i + seed) % 15) + 1);
+            return (indexed, MakePalette(RED, GREEN), w, h);
+        }
+
+        // =================================================================
+        // Harness
+        // =================================================================
+
+        static void WithRom(Action<ROM, string> body)
+        {
+            var savedRom = CoreState.ROM;
+            var savedSvc = CoreState.ImageService;
+            string dir = Directory.CreateDirectory(
+                Path.Combine(Path.GetTempPath(), "romanime_mf_" + Guid.NewGuid().ToString("N"))).FullName;
+            try
+            {
+                var rom = new ROM();
+                byte[] data = new byte[0x1000000]; // 16 MB
+                rom.LoadLow("synth.gba", data, "BE8E01");
+                CoreState.ROM = rom;
+                CoreState.ImageService = new StubImageService();
+                body(rom, dir);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom; CoreState.ImageService = savedSvc;
+                TryDeleteDir(dir);
+            }
+        }
+
+        // ---- entry resolvers ----
+
+        static RomAnimeCore.RomAnimeEntry ResolveFixed(ROM rom, int count, string option)
+        {
+            string[] fields =
+            {
+                WIDTH_TILES.ToString(), option, U.ToHexString((uint)count),
+                U.ToHexString(TSA_PTR_SLOT), U.ToHexString(IMAGE_PTR_SLOT), U.ToHexString(PAL_PTR_SLOT),
+                "efxFixed",
+            };
+            return RomAnimeCore.Resolve(rom, 0x1000, fields);
+        }
+
+        static RomAnimeCore.RomAnimeEntry ResolveFrameTable(ROM rom, string option)
+        {
+            string[] fields =
+            {
+                WIDTH_TILES.ToString(), option, U.ToHexString(FRAME_PTR_SLOT),
+                U.ToHexString(TSA_PTR_SLOT), U.ToHexString(IMAGE_PTR_SLOT), U.ToHexString(PAL_PTR_SLOT),
+                "efxTable",
+            };
+            return RomAnimeCore.Resolve(rom, 0x2000, fields);
+        }
+
+        // ---- planters ----
+
+        // FIXEDCOUNT: FramePointer == count (< 0x100). When paletteAnime, TSA/IMAGE lists
+        // are single-entry (one shared image) and the PALETTE list has `count` entries.
+        static void PlantFixedCount(ROM rom, int count, bool paletteAnime)
+        {
+            PlantFrameData(rom);
+
+            int tsaImgCount = paletteAnime ? 1 : count;
+            // TSA + IMAGE pointer lists.
+            WriteList(rom, TSA_LIST, Pick(TSA_DATA_0, TSA_DATA_1, tsaImgCount));
+            WriteList(rom, IMAGE_LIST, Pick(IMAGE_DATA_0, IMAGE_DATA_1, tsaImgCount));
+            WriteList(rom, PAL_LIST, Pick(PAL_DATA_0, PAL_DATA_1, count));
+
+            rom.write_p32(TSA_PTR_SLOT, TSA_LIST);
+            rom.write_p32(IMAGE_PTR_SLOT, IMAGE_LIST);
+            rom.write_p32(PAL_PTR_SLOT, PAL_LIST);
+            // FRAME pointer slot is NOT used for FIXEDCOUNT (FramePointer is the count).
+        }
+
+        // frame-table: a {u16 id,u16 wait} table {0,1},{1,1},0xFFFF. When commonPalette,
+        // PALETTE pointer slot dereferences to a single 32-byte block (count 1) and the
+        // TSA/IMAGE lists have 2 entries.
+        static void PlantFrameTable(ROM rom, bool commonPalette)
+        {
+            PlantFrameData(rom);
+
+            // The frame table: ids 0 and 1, each wait 1, then terminator.
+            rom.write_u16(FRAME_TABLE + 0, 0); rom.write_u16(FRAME_TABLE + 2, 1);
+            rom.write_u16(FRAME_TABLE + 4, 1); rom.write_u16(FRAME_TABLE + 6, 1);
+            rom.write_u16(FRAME_TABLE + 8, 0xFFFF); rom.write_u16(FRAME_TABLE + 10, 0);
+            rom.write_p32(FRAME_PTR_SLOT, FRAME_TABLE);
+
+            WriteList(rom, TSA_LIST, new[] { TSA_DATA_0, TSA_DATA_1 });
+            WriteList(rom, IMAGE_LIST, new[] { IMAGE_DATA_0, IMAGE_DATA_1 });
+            rom.write_p32(TSA_PTR_SLOT, TSA_LIST);
+            rom.write_p32(IMAGE_PTR_SLOT, IMAGE_LIST);
+
+            if (commonPalette)
+            {
+                // PAL pointer slot -> directly the 32-byte block (no intermediate list).
+                rom.write_p32(PAL_PTR_SLOT, PAL_DATA_0);
+            }
+            else
+            {
+                WriteList(rom, PAL_LIST, new[] { PAL_DATA_0, PAL_DATA_1 });
+                rom.write_p32(PAL_PTR_SLOT, PAL_LIST);
+            }
+        }
+
+        // Two frames of distinct TSA/IMAGE (LZ77) + RAW palettes.
+        static void PlantFrameData(ROM rom)
+        {
+            PlantBytes(rom, TSA_DATA_0, LZ77.compress(MakeTsa(0)));
+            PlantBytes(rom, TSA_DATA_1, LZ77.compress(MakeTsa(1)));
+            PlantBytes(rom, IMAGE_DATA_0, LZ77.compress(MakeImage(1)));
+            PlantBytes(rom, IMAGE_DATA_1, LZ77.compress(MakeImage(2)));
+            PlantBytes(rom, PAL_DATA_0, MakePalette(RED, GREEN));
+            PlantBytes(rom, PAL_DATA_1, MakePalette(BLUE, RED));
+        }
+
+        static uint[] Pick(uint a, uint b, int n)
+        {
+            var arr = new uint[n];
+            for (int i = 0; i < n; i++) arr[i] = (i % 2 == 0) ? a : b;
+            return arr;
+        }
+
+        // Write a per-frame pointer LIST at `listAddr` then a 0 terminator.
+        static void WriteList(ROM rom, uint listAddr, uint[] dataAddrs)
+        {
+            for (int i = 0; i < dataAddrs.Length; i++)
+                rom.write_p32(listAddr + (uint)(i * 4), dataAddrs[i]);
+            rom.write_u32(listAddr + (uint)(dataAddrs.Length * 4), 0);
+        }
+
+        // ---- script/PNG helpers ----
+
+        static string WriteScript(string dir, string name, (uint wait, string png)[] frames)
+        {
+            string path = Path.Combine(dir, name);
+            var lines = new List<string>();
+            foreach (var (wait, png) in frames) lines.Add(wait + " " + png);
+            File.WriteAllLines(path, lines);
+            return path;
+        }
+
+        // Write placeholder PNG files (one per name) so the synthetic Loader's
+        // File.Exists check passes. The stub codec does no real PNG I/O; the Loader
+        // ignores the bytes and returns deterministic synthetic frame data.
+        static void MakePngFiles(string dir, params string[] names)
+        {
+            foreach (string n in names)
+                File.WriteAllBytes(Path.Combine(dir, n), new byte[] { 0x89, (byte)'P', (byte)'N', (byte)'G' });
+        }
+
+        // Read a `wait png` script and write a placeholder for every referenced PNG so
+        // the synthetic Loader's File.Exists check passes on a round-trip import.
+        static void MaterializeScriptPngs(string dir, string scriptPath)
+        {
+            foreach (string line in File.ReadAllLines(scriptPath))
+            {
+                string t = line.Trim();
+                if (t.Length == 0 || t.StartsWith("//")) continue;
+                string[] sp = t.Replace("\t", " ").Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                if (sp.Length < 2) continue;
+                string png = sp[1];
+                string full = Path.Combine(dir, png);
+                if (!File.Exists(full))
+                    File.WriteAllBytes(full, new byte[] { 0x89, (byte)'P', (byte)'N', (byte)'G' });
+            }
+        }
+
+        static void AssertScriptHasFrames(string scriptPath, int min)
+        {
+            Assert.True(File.Exists(scriptPath));
+            int data = 0;
+            foreach (string line in File.ReadAllLines(scriptPath))
+            {
+                string t = line.Trim();
+                if (t.Length == 0 || t.StartsWith("//")) continue;
+                data++;
+            }
+            Assert.True(data >= min, $"expected >= {min} data lines, got {data}");
+        }
+
+        static int WalkFrameTableCount(ROM rom, uint addr)
+        {
+            int n = 0;
+            for (; addr + 4 <= rom.Data.Length && n < 1024; n++, addr += 4)
+            {
+                if (rom.u16(addr) == 0xFFFF) break;
+            }
+            return n;
+        }
+
+        static byte[] MakeTsa(int seed)
+        {
+            byte[] tsa = new byte[WIDTH_TILES * 2];
+            for (int i = 0; i < WIDTH_TILES; i++)
+                tsa[i * 2] = (byte)((i + seed) & 0x07);
+            return tsa;
+        }
+
+        static byte[] MakeImage(int seed)
+        {
+            byte[] image = new byte[WIDTH_TILES * 32];
+            for (int i = 0; i < image.Length; i++) image[i] = (byte)(((i + seed) % 15) + 1);
+            return image;
+        }
+
+        static byte[] MakePalette(ushort c1, ushort c2)
+        {
+            byte[] pal = new byte[16 * 2];
+            pal[1 * 2] = (byte)(c1 & 0xFF); pal[1 * 2 + 1] = (byte)(c1 >> 8);
+            pal[2 * 2] = (byte)(c2 & 0xFF); pal[2 * 2 + 1] = (byte)(c2 >> 8);
+            return pal;
+        }
+
+        static void PlantBytes(ROM rom, uint addr, byte[] bytes)
+            => Array.Copy(bytes, 0, rom.Data, addr, bytes.Length);
+
+        static void TryDeleteDir(string dir)
+        {
+            try { if (Directory.Exists(dir)) Directory.Delete(dir, true); } catch { }
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/RomAnimeMultiFrameCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RomAnimeMultiFrameCoreTests.cs
@@ -234,6 +234,10 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.False(string.IsNullOrEmpty(err));
                 Assert.Equal(before.Length, rom.Data.Length);
                 Assert.Equal(before, rom.Data);
+                // The fault-restore must operate on the SAME object the ambient writes
+                // mutate (CoreState.ROM) — review #1. Here rom IS CoreState.ROM.
+                Assert.Same(rom, CoreState.ROM);
+                Assert.Equal(before, CoreState.ROM.Data);
             }
             finally
             {
@@ -258,6 +262,40 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.False(ok);
                 Assert.False(string.IsNullOrEmpty(err));
                 Assert.Equal(before, rom.Data);
+            });
+        }
+
+        [Fact]
+        public void Import_RomNotAmbientCoreStateRom_RefusesAndLeavesCoreStateRomUntouched()
+        {
+            // review #1: the ambient writes mutate CoreState.ROM, so a `rom` that is NOT
+            // CoreState.ROM must be refused up front (else snapshot/restore would operate
+            // on the wrong object and could leave CoreState.ROM corrupted on a fault).
+            WithRom((ambient, dir) =>
+            {
+                PlantFixedCount(ambient, 2, paletteAnime: false);
+                byte[] ambientBefore = (byte[])ambient.Data.Clone();
+
+                // A DIFFERENT ROM object, resolved against itself, passed as `rom`.
+                var other = new ROM();
+                byte[] data = new byte[0x1000000];
+                Array.Copy(ambient.Data, data, ambient.Data.Length);
+                other.LoadLow("other.gba", data, "BE8E01");
+                RomAnimeCore.RomAnimeEntry e = RomAnimeCore.Resolve(other, 0x1000, new[]
+                {
+                    WIDTH_TILES.ToString(), "FIXEDCOUNT", U.ToHexString(2u),
+                    U.ToHexString(TSA_PTR_SLOT), U.ToHexString(IMAGE_PTR_SLOT), U.ToHexString(PAL_PTR_SLOT),
+                    "efxOther",
+                });
+
+                string script = WriteScript(dir, "mismatch.txt", new (uint, string)[] { (1, "f0.png"), (1, "f1.png") });
+                MakePngFiles(dir, "f0.png", "f1.png");
+
+                bool ok = RomAnimeMultiFrameCore.ImportTxt(other, e, script, Loader, out string err);
+                Assert.False(ok);
+                Assert.False(string.IsNullOrEmpty(err));
+                // CoreState.ROM (the ambient write target) is completely untouched.
+                Assert.Equal(ambientBefore, CoreState.ROM.Data);
             });
         }
 

--- a/FEBuilderGBA.Core/RomAnimeCore.cs
+++ b/FEBuilderGBA.Core/RomAnimeCore.cs
@@ -329,6 +329,20 @@ namespace FEBuilderGBA
             return true;
         }
 
+        /// <summary>
+        /// Render one frame straight from its resolved TSA / IMAGE / PALETTE ROM offsets
+        /// (the WF <c>DrawImageLow</c> body), bypassing the UI-frame -&gt; stored-id
+        /// resolution. Used by the multi-frame export/GIF walk (#1230) where the stored
+        /// frame id differs from the UI frame index. Returns <c>null</c> (never throws)
+        /// on any null / out-of-bounds / corrupt input.
+        /// </summary>
+        public static IImage RenderFromOffsets(ROM rom, int imageWidthTiles, uint tsa, uint image, uint palette)
+        {
+            if (rom == null || rom.Data == null) return null;
+            if (CoreState.ImageService == null) return null;
+            return RenderImageLow(rom, imageWidthTiles, tsa, image, palette);
+        }
+
         // WF DrawImageLow: LZ77-decompress TSA + IMAGE, read the RAW palette, decode.
         static IImage RenderImageLow(ROM rom, int imageWidthTiles, uint tsa, uint image, uint palette)
         {

--- a/FEBuilderGBA.Core/RomAnimeMultiFrameCore.cs
+++ b/FEBuilderGBA.Core/RomAnimeMultiFrameCore.cs
@@ -1,0 +1,705 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Cross-platform multi-frame animation-script (.txt) + animated-GIF subsystem for
+// the In-ROM Magic Animation editor (#1230 — follow-up to #1176). Ports the
+// DEFERRED multi-frame workflow of WinForms ImageRomAnimeForm.cs:
+//   * Export (L879)    -> ExportTxt   : a `wait png` script that dumps every frame
+//   * ExportGif (L805) -> ExportGif   : the same frame walk emitted as an animated GIF
+//   * Import (L989)    -> ImportTxt   : parse the `wait png` script and rebuild the
+//                                        WHOLE animation (frame table + ALL pointer
+//                                        arrays) as ONE atomic transaction
+//   * MakeRecycleList (L457)          : a Core port that pools the OLD regions for reuse
+//
+// The single-frame slice (RomAnimeCore: list / preview / per-frame PNG import &
+// export) is unchanged; this file adds the whole-animation rewrite on top of it.
+//
+// === Storage shapes (ported from RomAnimeCore.Resolve) ===
+//   * FRAME-ptr is a real ROM offset (IsFrameTable) -> a {u16 id, u16 wait} frame
+//     table terminated by 0xFFFF; TSA/IMAGE/PAL each point to a per-id pointer-LIST.
+//   * FRAME-ptr < 0x100 (FIXEDCOUNT)               -> a fixed frame count; no frame
+//     table; TSA/IMAGE/PAL are per-frame pointer-lists (or a single COMMONPALETTE).
+//
+// === The four WF import modes (faithfully reproduced) ===
+//   FIXEDCOUNT  + multi-palette  : per-frame image/tsa/pal lists; frame count must match.
+//   FIXEDCOUNT  + palette-anime  : ONE image+tsa, a per-frame PALETTE list (TSAList==1
+//                                  && PaletteList>=2). Only frame 0's image is written.
+//   frame-table + COMMONPALETTE  : per-frame image/tsa lists, a SINGLE shared palette
+//                                  (TSAList>=2 && PaletteList==1). Frame 0's palette wins.
+//   frame-table + multi-palette  : per-frame image/tsa/pal lists + the {id,wait} table.
+//
+// === Atomicity (the #1230 correctness bar) ===
+// ImportTxt validates EVERYTHING first (parse every line, load+quantize+encode+LZ77
+// every unique image, verify the FIXEDCOUNT count) with ZERO ROM mutation. It then
+// takes a `byte[] snap = (byte[])rom.Data.Clone()` immediately before the first write,
+// pools the OLD regions via MakeRecycleList, and performs ALL writes through the
+// RecycleAddress AMBIENT overloads so they land in the View's `ROM.BeginUndoScope`
+// ambient undo (the same mechanism RomAnimeCore.ImportFrame and the sibling cores use).
+// On ANY failure (a write returns U.NOT_FOUND, or an exception) it RestoreSnapshot()s
+// the ROM byte-identical and returns an error — a FAILED import mutates ZERO bytes.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Cross-platform multi-frame export/import + animated-GIF export for the
+    /// In-ROM Magic Animation editor (#1230). GUI-free; every ROM read is bounds-
+    /// guarded, the export methods are read-only, and <see cref="ImportTxt"/> is an
+    /// atomic transaction with a byte-identical fault restore.
+    /// </summary>
+    public static class RomAnimeMultiFrameCore
+    {
+        // WF renders/encodes every frame at a fixed 16-tile (128 px) tall canvas.
+        const int FRAME_HEIGHT = 8 * 16;
+        // RAW 16-color GBA palette = 16 * 2 bytes.
+        const int PALETTE_BYTES = 16 * 2;
+        // WF limiter for the uncompressed frame table (1 MB search ceiling).
+        const uint FRAME_TABLE_LIMIT = 1024 * 1024;
+
+        // ----------------------------------------------------------------
+        // ExportTxt — dump every frame as PNGs + a `wait png` script.
+        // ----------------------------------------------------------------
+
+        /// <summary>
+        /// Export the whole animation as a <c>wait png</c> script plus per-unique-frame
+        /// PNGs alongside it (WF <c>Export</c>, L879). For a frame-table entry each
+        /// line is <c>&lt;wait&gt; &lt;png&gt;</c> walking the <c>{id,wait}</c> table
+        /// (a repeated id reuses its PNG); for a FIXEDCOUNT entry each of the
+        /// <c>FramePointer</c> frames is dumped with <c>wait == 1</c>. Read-only.
+        /// </summary>
+        /// <param name="rom">Loaded ROM.</param>
+        /// <param name="e">The resolved entry (from <see cref="RomAnimeCore.Resolve"/>).</param>
+        /// <param name="scriptPath">Output .txt path (PNGs land in the same directory).</param>
+        /// <returns>Empty string on success; a user-facing error otherwise. Never throws.</returns>
+        public static string ExportTxt(ROM rom, RomAnimeCore.RomAnimeEntry e, string scriptPath)
+        {
+            if (rom == null || rom.Data == null) return R.Error("ROM not loaded.");
+            if (e == null) return R.Error("No animation entry selected.");
+            if (string.IsNullOrEmpty(scriptPath)) return R.Error("Output path is empty.");
+            if (CoreState.ImageService == null) return R.Error("Image service is not configured.");
+
+            string baseName = Path.GetFileNameWithoutExtension(scriptPath) + "_";
+            string baseDir = Path.GetDirectoryName(Path.GetFullPath(scriptPath)) ?? "";
+            try
+            {
+                if (baseDir.Length > 0 && !Directory.Exists(baseDir)) Directory.CreateDirectory(baseDir);
+            }
+            catch (Exception ex) { return R.Error("Failed to create output directory: {0}", ex.Message); }
+
+            var lines = new List<string>();
+
+            // WF advisory comments (L886/L892): warn when the storage shape forces a
+            // shared palette / palette-animation interpretation on re-import.
+            if (e.TSAList.Count >= 2 && e.PaletteList.Count == 1)
+                lines.Add("//" + R._("A common palette is required. Only the first image's palette is used; later frames reuse it."));
+
+            try
+            {
+                if (!e.IsFrameTable)
+                {
+                    if (e.TSAList.Count == 1 && e.PaletteList.Count >= 2)
+                        lines.Add("//" + R._("This is a palette animation. Only the first image is used; later frames change only the palette."));
+                    lines.Add("//" + R._("This animation has a fixed frame count. The frame count must be {0} ({1}).",
+                        U.To0xHexString(e.FramePointer), e.FramePointer));
+
+                    int count = (int)e.FramePointer;
+                    for (int i = 0; i < count; i++)
+                    {
+                        string png = baseName.Replace(" ", "_") + "g" + i.ToString("000", CultureInfo.InvariantCulture) + ".png";
+                        string werr = RenderAndSave(rom, e, i, Path.Combine(baseDir, png));
+                        if (werr.Length > 0) return werr;
+                        lines.Add("1 " + png);
+                    }
+                }
+                else
+                {
+                    // Frame-table walk: dedup PNG output per frame id (WF animeHash).
+                    var saved = new HashSet<uint>();
+                    uint addr = rom.p32(e.FramePointer);
+                    if (!U.isSafetyOffset(addr, rom)) return R.Error("The animation frame table pointer is invalid.");
+
+                    uint limit = (uint)Math.Min((ulong)addr + FRAME_TABLE_LIMIT, (ulong)rom.Data.Length);
+                    for (; addr + 4 <= rom.Data.Length && addr < limit; addr += 4)
+                    {
+                        uint id = rom.u16(addr);
+                        uint wait = rom.u16(addr + 2);
+                        if (id == 0xFFFF) break;
+
+                        string png = baseName.Replace(" ", "_") + "g" + id.ToString("000", CultureInfo.InvariantCulture) + ".png";
+                        if (saved.Add(id))
+                        {
+                            string werr = RenderAndSaveById(rom, e, (int)id, Path.Combine(baseDir, png));
+                            if (werr.Length > 0) return werr;
+                        }
+                        lines.Add(wait.ToString(CultureInfo.InvariantCulture) + " " + png);
+                    }
+                }
+
+                File.WriteAllLines(scriptPath, lines);
+            }
+            catch (Exception ex)
+            {
+                return R.Error("Failed to export animation script: {0}", ex.Message);
+            }
+            return "";
+        }
+
+        // ----------------------------------------------------------------
+        // ExportGif — walk the frame table and emit an animated GIF.
+        // ----------------------------------------------------------------
+
+        /// <summary>
+        /// Export the whole animation as an animated GIF (WF <c>ExportGif</c>, L805):
+        /// walk the frame table (or the fixed count), render each frame, and encode via
+        /// <see cref="GifEncoderCore"/>. The per-frame GIF delay uses
+        /// <see cref="U.GameFrameSecToGifFrameSec"/> so the rounding matches WF. Read-only.
+        /// </summary>
+        public static string ExportGif(ROM rom, RomAnimeCore.RomAnimeEntry e, string gifPath)
+        {
+            if (rom == null || rom.Data == null) return R.Error("ROM not loaded.");
+            if (e == null) return R.Error("No animation entry selected.");
+            if (string.IsNullOrEmpty(gifPath)) return R.Error("Output path is empty.");
+            if (CoreState.ImageService == null) return R.Error("Image service is not configured.");
+
+            var frames = new List<GifEncoderCore.GifFrame>();
+            try
+            {
+                if (!e.IsFrameTable)
+                {
+                    int count = (int)e.FramePointer;
+                    for (int i = 0; i < count; i++)
+                    {
+                        GifEncoderCore.GifFrame f = RenderGifFrame(rom, e, i, 1);
+                        if (f != null) frames.Add(f);
+                    }
+                }
+                else
+                {
+                    var cache = new Dictionary<uint, GifEncoderCore.GifFrame>();
+                    uint addr = rom.p32(e.FramePointer);
+                    if (!U.isSafetyOffset(addr, rom)) return R.Error("The animation frame table pointer is invalid.");
+
+                    uint limit = (uint)Math.Min((ulong)addr + FRAME_TABLE_LIMIT, (ulong)rom.Data.Length);
+                    for (; addr + 4 <= rom.Data.Length && addr < limit; addr += 4)
+                    {
+                        uint id = rom.u16(addr);
+                        uint wait = rom.u16(addr + 2);
+                        if (id == 0xFFFF) break;
+
+                        if (!cache.TryGetValue(id, out GifEncoderCore.GifFrame f))
+                        {
+                            f = RenderGifFrameById(rom, e, (int)id, wait);
+                            cache[id] = f;
+                        }
+                        if (f != null)
+                        {
+                            // Re-emit with THIS frame's wait (cache holds the rendered pixels).
+                            frames.Add(new GifEncoderCore.GifFrame
+                            {
+                                Width = f.Width,
+                                Height = f.Height,
+                                RgbaPixels = f.RgbaPixels,
+                                DelayCs = U.GameFrameSecToGifFrameSec(wait),
+                            });
+                        }
+                    }
+                }
+
+                if (frames.Count == 0) return R.Error("No renderable frames in animation.");
+
+                string outDir = Path.GetDirectoryName(Path.GetFullPath(gifPath)) ?? "";
+                if (outDir.Length > 0 && !Directory.Exists(outDir)) Directory.CreateDirectory(outDir);
+                GifEncoderCore.Encode(frames, gifPath);
+            }
+            catch (Exception ex)
+            {
+                return R.Error("Failed to export animation GIF: {0}", ex.Message);
+            }
+            return "";
+        }
+
+        // ----------------------------------------------------------------
+        // ImportTxt — parse the script and rebuild the WHOLE animation atomically.
+        // ----------------------------------------------------------------
+
+        /// <summary>One parsed unique frame image (the WF <c>anime</c> record).</summary>
+        public sealed class FrameImage
+        {
+            /// <summary>LZ77-compressed 4bpp tile data.</summary>
+            public byte[] Image;
+            /// <summary>LZ77-compressed TSA map.</summary>
+            public byte[] TSA;
+            /// <summary>RAW 16-color GBA palette (32 bytes).</summary>
+            public byte[] Palette;
+            /// <summary>The source PNG filename (dedup key, mirrors WF <c>filename</c>).</summary>
+            public string Name;
+        }
+
+        /// <summary>
+        /// Import a multi-frame <c>wait png</c> script and rebuild the WHOLE animation
+        /// (WF <c>Import</c>, L989) as ONE atomic transaction. Parses every line, loads
+        /// + quantizes + encodes + LZ77-compresses every UNIQUE image (ZERO ROM mutation),
+        /// builds the <c>{id,wait}</c> frame table, then — only after every region is
+        /// ready — pools the old regions (<see cref="MakeRecycleList"/>) and rewrites the
+        /// frame table + ALL pointer arrays through the RecycleAddress AMBIENT overloads
+        /// (so the active <see cref="ROM.BeginUndoScope"/> captures each write once). On
+        /// ANY failure the ROM is restored byte-identical (snapshot + length-aware copy)
+        /// and an error is returned — a FAILED import mutates ZERO bytes.
+        ///
+        /// <para>The <paramref name="frameLoader"/> turns a resolved PNG path into a
+        /// quantized <c>(indexedPixels, gbaPalette16, width, height)</c> tuple (the View
+        /// wires it to <c>ImageImportService.LoadAndQuantizeFromFile</c>, exactly like the
+        /// per-frame import) or returns null when the file is missing / unreadable. Core
+        /// crops/pads the indexed pixels to <c>(ImageWidthTiles*8, 128)</c> — the WF
+        /// <c>ImageUtil.Copy(bitmap, 0, 0, imageWidth, imageHeight)</c> step.</para>
+        /// </summary>
+        /// <param name="rom">Target ROM.</param>
+        /// <param name="e">The resolved entry (from <see cref="RomAnimeCore.Resolve"/>).</param>
+        /// <param name="scriptPath">Input <c>wait png</c> script.</param>
+        /// <param name="frameLoader">PNG path -&gt; <c>(indexed, gbaPalette16, w, h)</c> or null.</param>
+        /// <param name="error">Empty on success; a user-facing message on failure.</param>
+        /// <returns>true on success; false (with <paramref name="error"/> set and ZERO ROM
+        /// mutation) on any validation or write failure. Never throws.</returns>
+        public static bool ImportTxt(ROM rom, RomAnimeCore.RomAnimeEntry e, string scriptPath,
+            Func<string, (byte[] indexedPixels, byte[] gbaPalette16, int width, int height)?> frameLoader,
+            out string error)
+        {
+            error = "";
+            if (rom == null || rom.RomInfo == null || rom.Data == null)
+            { error = R.Error("ROM not loaded."); return false; }
+            if (e == null)
+            { error = R.Error("No animation entry selected."); return false; }
+            if (frameLoader == null)
+            { error = R.Error("Invalid image data."); return false; }
+            if (string.IsNullOrEmpty(scriptPath) || !File.Exists(scriptPath))
+            { error = R.Error("Script file not found: {0}", scriptPath ?? ""); return false; }
+
+            int imageWidth = e.ImageWidthTiles * 8;
+            if (imageWidth <= 0) { error = R.Error("The animation frame width is invalid."); return false; }
+
+            string baseDir = Path.GetDirectoryName(Path.GetFullPath(scriptPath)) ?? "";
+            string[] lines;
+            try { lines = File.ReadAllLines(scriptPath); }
+            catch (Exception ex) { error = R.Error("Failed to read script file: {0}", ex.Message); return false; }
+
+            // ---- PHASE 1: parse + encode EVERY unique image. ZERO ROM mutation. ----
+            var animeList = new List<FrameImage>();
+            var frames = new List<byte>(); // {u16 id, u16 wait} table being built
+            for (int li = 0; li < lines.Length; li++)
+            {
+                string line = lines[li];
+                if (line == null) continue;
+                if (U.IsComment(line) || (rom.RomInfo != null && U.OtherLangLine(line, rom))) continue;
+                line = U.ClipComment(line);
+                if (line.Length <= 0) continue;
+
+                line = line.Replace("\t", " ");
+                string[] sp = line.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                if (sp.Length < 2) continue;
+                string command = sp[0];
+                if (command.Length <= 0 || !U.isNumString(command)) continue;
+
+                uint wait = U.atoi(command);
+                string imageName = sp[1];
+
+                uint id = FindImage(animeList, imageName);
+                if (id == U.NOT_FOUND)
+                {
+                    id = (uint)animeList.Count;
+                    string werr = EncodeFrame(baseDir, imageName, imageWidth, frameLoader, li + 1, out FrameImage a);
+                    if (werr.Length > 0) { error = werr; return false; }
+                    animeList.Add(a);
+                }
+
+                U.append_u16(frames, (ushort)id);
+                U.append_u16(frames, (ushort)wait);
+            }
+            // Terminator (WF L1065): {0xFFFF, 0x0000}.
+            U.append_u16(frames, 0xFFFF);
+            U.append_u16(frames, 0x0000);
+
+            if (animeList.Count <= 0)
+            { error = R.Error("There is no animation to write."); return false; }
+
+            // FIXEDCOUNT shape: the parsed frame count MUST equal the fixed count.
+            if (!e.IsFrameTable && e.FramePointer != animeList.Count)
+            {
+                error = R.Error(
+                    "This is a fixed-count animation requiring {0} frames, but the script defines {1}.",
+                    e.FramePointer, animeList.Count);
+                return false;
+            }
+
+            // ---- PHASE 2: snapshot, pool old regions, rewrite atomically. ----
+            byte[] snap = (byte[])rom.Data.Clone();
+            try
+            {
+                var recycle = new List<Address>();
+                MakeRecycleList(rom, e, recycle);
+                var ra = new RecycleAddress(recycle);
+
+                bool ok;
+                if (!e.IsFrameTable)
+                {
+                    if (e.TSAList.Count == 1 && e.PaletteList.Count >= 2)
+                        ok = WriteFixedPaletteAnime(rom, e, ra, animeList);
+                    else
+                        ok = WriteFixedMultiPalette(rom, e, ra, animeList);
+                }
+                else
+                {
+                    if (e.TSAList.Count >= 2 && e.PaletteList.Count == 1)
+                        ok = WriteFrameTableCommonPalette(rom, e, ra, animeList, frames.ToArray());
+                    else
+                        ok = WriteFrameTableMultiPalette(rom, e, ra, animeList, frames.ToArray());
+                }
+
+                if (!ok)
+                {
+                    RestoreSnapshot(rom, snap);
+                    error = R._("Failed to write animation. Check ROM free space.");
+                    return false;
+                }
+
+                // Free-list any leftover recycle ranges (WF ra.BlackOut).
+                ra.BlackOutAmbient();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                RestoreSnapshot(rom, snap);
+                error = R.Error("Animation import failed: {0}", ex.Message);
+                return false;
+            }
+        }
+
+        // -- The four WF write modes (each returns false on the first NOT_FOUND). --
+
+        // FIXEDCOUNT, palette-animation: ONE image+tsa (frame 0), a per-frame PAL list.
+        static bool WriteFixedPaletteAnime(ROM rom, RomAnimeCore.RomAnimeEntry e,
+            RecycleAddress ra, List<FrameImage> list)
+        {
+            var palList = new List<byte>();
+            foreach (FrameImage a in list)
+            {
+                uint p = ra.WriteAmbient(a.Palette);
+                if (p == U.NOT_FOUND) return false;
+                U.append_u32(palList, U.toPointer(p));
+            }
+            if (ra.WriteAndWritePointerAmbient(e.TSAPointer, list[0].TSA) == U.NOT_FOUND) return false;
+            if (ra.WriteAndWritePointerAmbient(e.ImagePointer, list[0].Image) == U.NOT_FOUND) return false;
+            if (ra.WriteAndWritePointerAmbient(e.PalettePointer, palList.ToArray()) == U.NOT_FOUND) return false;
+            return true;
+        }
+
+        // FIXEDCOUNT, multi-palette: per-frame image/tsa/pal lists.
+        static bool WriteFixedMultiPalette(ROM rom, RomAnimeCore.RomAnimeEntry e,
+            RecycleAddress ra, List<FrameImage> list)
+        {
+            var imageList = new List<byte>();
+            var tsaList = new List<byte>();
+            var palList = new List<byte>();
+            foreach (FrameImage a in list)
+            {
+                uint pi = ra.WriteAmbient(a.Image);
+                if (pi == U.NOT_FOUND) return false;
+                U.append_u32(imageList, U.toPointer(pi));
+
+                uint pt = ra.WriteAmbient(a.TSA);
+                if (pt == U.NOT_FOUND) return false;
+                U.append_u32(tsaList, U.toPointer(pt));
+
+                uint pp = ra.WriteAmbient(a.Palette);
+                if (pp == U.NOT_FOUND) return false;
+                U.append_u32(palList, U.toPointer(pp));
+            }
+            if (ra.WriteAndWritePointerAmbient(e.TSAPointer, tsaList.ToArray()) == U.NOT_FOUND) return false;
+            if (ra.WriteAndWritePointerAmbient(e.ImagePointer, imageList.ToArray()) == U.NOT_FOUND) return false;
+            if (ra.WriteAndWritePointerAmbient(e.PalettePointer, palList.ToArray()) == U.NOT_FOUND) return false;
+            return true;
+        }
+
+        // frame-table, COMMONPALETTE: per-frame image/tsa lists, ONE shared palette.
+        static bool WriteFrameTableCommonPalette(ROM rom, RomAnimeCore.RomAnimeEntry e,
+            RecycleAddress ra, List<FrameImage> list, byte[] frameTable)
+        {
+            var imageList = new List<byte>();
+            var tsaList = new List<byte>();
+            foreach (FrameImage a in list)
+            {
+                uint pi = ra.WriteAmbient(a.Image);
+                if (pi == U.NOT_FOUND) return false;
+                U.append_u32(imageList, U.toPointer(pi));
+
+                uint pt = ra.WriteAmbient(a.TSA);
+                if (pt == U.NOT_FOUND) return false;
+                U.append_u32(tsaList, U.toPointer(pt));
+            }
+            if (ra.WriteAndWritePointerAmbient(e.FramePointer, frameTable) == U.NOT_FOUND) return false;
+            if (ra.WriteAndWritePointerAmbient(e.TSAPointer, tsaList.ToArray()) == U.NOT_FOUND) return false;
+            if (ra.WriteAndWritePointerAmbient(e.ImagePointer, imageList.ToArray()) == U.NOT_FOUND) return false;
+            if (ra.WriteAndWritePointerAmbient(e.PalettePointer, list[0].Palette) == U.NOT_FOUND) return false;
+            return true;
+        }
+
+        // frame-table, multi-palette: per-frame image/tsa/pal lists + the {id,wait} table.
+        static bool WriteFrameTableMultiPalette(ROM rom, RomAnimeCore.RomAnimeEntry e,
+            RecycleAddress ra, List<FrameImage> list, byte[] frameTable)
+        {
+            var imageList = new List<byte>();
+            var tsaList = new List<byte>();
+            var palList = new List<byte>();
+            foreach (FrameImage a in list)
+            {
+                uint pi = ra.WriteAmbient(a.Image);
+                if (pi == U.NOT_FOUND) return false;
+                U.append_u32(imageList, U.toPointer(pi));
+
+                uint pt = ra.WriteAmbient(a.TSA);
+                if (pt == U.NOT_FOUND) return false;
+                U.append_u32(tsaList, U.toPointer(pt));
+
+                uint pp = ra.WriteAmbient(a.Palette);
+                if (pp == U.NOT_FOUND) return false;
+                U.append_u32(palList, U.toPointer(pp));
+            }
+            if (ra.WriteAndWritePointerAmbient(e.FramePointer, frameTable) == U.NOT_FOUND) return false;
+            if (ra.WriteAndWritePointerAmbient(e.TSAPointer, tsaList.ToArray()) == U.NOT_FOUND) return false;
+            if (ra.WriteAndWritePointerAmbient(e.ImagePointer, imageList.ToArray()) == U.NOT_FOUND) return false;
+            if (ra.WriteAndWritePointerAmbient(e.PalettePointer, palList.ToArray()) == U.NOT_FOUND) return false;
+            return true;
+        }
+
+        // ----------------------------------------------------------------
+        // MakeRecycleList — pool the OLD regions for reuse (WF L457).
+        // ----------------------------------------------------------------
+
+        /// <summary>
+        /// Pool the entry's CURRENT IMAGE / TSA / PALETTE (and the frame table, for a
+        /// frame-table entry) regions into <paramref name="recycle"/> so the rewrite can
+        /// reuse the freed bytes (WF <c>MakeRecycleList(ref recycle, "", false)</c>, L457).
+        /// FIXEDCOUNT walks 0..FramePointer; a frame-table entry walks the <c>{id,wait}</c>
+        /// table (clamping list indexes like WF) and finally pools the table pointer itself.
+        /// </summary>
+        public static void MakeRecycleList(ROM rom, RomAnimeCore.RomAnimeEntry e, List<Address> recycle)
+        {
+            if (rom == null || e == null || recycle == null) return;
+
+            if (!e.IsFrameTable)
+            {
+                int count = (int)e.FramePointer;
+                for (int i = 0; i < count; i++)
+                    AddFrameRegions(rom, e, i, recycle);
+                return;
+            }
+
+            uint addr = rom.p32(e.FramePointer);
+            if (!U.isSafetyOffset(addr, rom)) return;
+            uint startAddr = addr;
+            uint limit = (uint)Math.Min((ulong)addr + FRAME_TABLE_LIMIT, (ulong)rom.Data.Length);
+            for (; addr + 4 <= rom.Data.Length && addr < limit; addr += 4)
+            {
+                uint id = rom.u16(addr);
+                if (id == 0xFFFF) break;
+                AddFrameRegions(rom, e, (int)id, recycle);
+            }
+            // Pool the frame table itself (WF AddPointer ROMANIMEFRAME).
+            Address.AddPointer(recycle, e.FramePointer, addr - startAddr,
+                "FRAME", Address.DataTypeEnum.ROMANIMEFRAME);
+        }
+
+        // Pool the IMAGE+TSA (LZ77) + PALETTE (32-byte) regions for one frame index.
+        static void AddFrameRegions(ROM rom, RomAnimeCore.RomAnimeEntry e, int i, List<Address> recycle)
+        {
+            if (e.TSAList.Count > 0)
+            {
+                uint tsa = ClampPick(e.TSAList, i);
+                Address.AddAddress(recycle, tsa, LZ77.getCompressedSize(rom.Data, tsa),
+                    U.NOT_FOUND, "TSA", Address.DataTypeEnum.LZ77TSA);
+            }
+            if (e.ImageList.Count > 0)
+            {
+                uint image = ClampPick(e.ImageList, i);
+                Address.AddAddress(recycle, image, LZ77.getCompressedSize(rom.Data, image),
+                    U.NOT_FOUND, "IMAGE", Address.DataTypeEnum.LZ77IMG);
+            }
+            if (e.PaletteList.Count > 0)
+            {
+                uint pal = ClampPick(e.PaletteList, i);
+                Address.AddAddress(recycle, pal, PALETTE_BYTES,
+                    U.NOT_FOUND, "PAL", Address.DataTypeEnum.PAL);
+            }
+        }
+
+        static uint ClampPick(List<uint> list, int i)
+            => (i >= list.Count) ? list[list.Count - 1] : list[i];
+
+        // ----------------------------------------------------------------
+        // Per-frame encode / render helpers.
+        // ----------------------------------------------------------------
+
+        // Load + quantize a PNG (via the caller's loader), crop/pad the indexed pixels
+        // to (imageWidth, 128), EncodeTSA, then LZ77-compress image + tsa. ZERO ROM
+        // mutation — every byte produced here is buffered until PHASE 2.
+        static string EncodeFrame(string baseDir, string imageName, int imageWidth,
+            Func<string, (byte[] indexedPixels, byte[] gbaPalette16, int width, int height)?> loader,
+            int lineNo, out FrameImage a)
+        {
+            a = null;
+            string fullPath = Path.Combine(baseDir, imageName);
+            (byte[] indexedPixels, byte[] gbaPalette16, int width, int height)? loaded;
+            try { loaded = loader(fullPath); }
+            catch (Exception ex) { return R.Error("Failed to load image: {0}\r\nFile: {1} line:{2}", ex.Message, imageName, lineNo); }
+            if (loaded == null)
+                return R.Error("The file was not found.\r\nFile: {0} line:{1}", imageName, lineNo);
+
+            var (indexed, gbaPal, srcW, srcH) = loaded.Value;
+            if (indexed == null || gbaPal == null)
+                return R.Error("Could not import the image.\r\nFile: {0} line:{1}", imageName, lineNo);
+
+            // Crop/pad the indexed pixels to the canvas (WF ImageUtil.Copy).
+            byte[] canvas = CropOrPadIndexed(indexed, srcW, srcH, imageWidth, FRAME_HEIGHT);
+
+            ImageImportCore.TSAEncodeResult enc;
+            try { enc = ImageImportCore.EncodeTSA(canvas, imageWidth, FRAME_HEIGHT); }
+            catch (Exception ex) { return R.Error("Could not import the image.\r\nFile: {0} line:{1}\r\n\r\n{2}", imageName, lineNo, ex.Message); }
+            if (enc == null || enc.TileData == null || enc.TSAData == null)
+                return R.Error("Could not import the image.\r\nFile: {0} line:{1}", imageName, lineNo);
+
+            a = new FrameImage
+            {
+                Image = LZ77.compress(enc.TileData),
+                TSA = LZ77.compress(enc.TSAData),
+                Palette = NormalizePalette(gbaPal),
+                Name = imageName,
+            };
+            return "";
+        }
+
+        // Render UI frame `frameIndex` and persist as a PNG (FIXEDCOUNT export path).
+        static string RenderAndSave(ROM rom, RomAnimeCore.RomAnimeEntry e, int frameIndex, string pngPath)
+        {
+            using IImage img = RomAnimeCore.TryRenderFrame(rom, e, frameIndex);
+            return SaveOrBlank(img, e, pngPath);
+        }
+
+        // Render stored-id `id` (frame-table export path) and persist as a PNG.
+        static string RenderAndSaveById(ROM rom, RomAnimeCore.RomAnimeEntry e, int id, string pngPath)
+        {
+            using IImage img = RenderById(rom, e, id);
+            return SaveOrBlank(img, e, pngPath);
+        }
+
+        static string SaveOrBlank(IImage img, RomAnimeCore.RomAnimeEntry e, string pngPath)
+        {
+            try
+            {
+                IImage save = img ?? CoreState.ImageService.CreateImage(e.ImageWidthTiles * 8, FRAME_HEIGHT);
+                using (save == img ? null : save) { save.Save(pngPath); }
+                return "";
+            }
+            catch (Exception ex) { return R.Error("Failed to write PNG: {0}", ex.Message); }
+        }
+
+        // Render a GIF frame from a UI frame index (FIXEDCOUNT path).
+        static GifEncoderCore.GifFrame RenderGifFrame(ROM rom, RomAnimeCore.RomAnimeEntry e, int frameIndex, uint wait)
+        {
+            using IImage img = RomAnimeCore.TryRenderFrame(rom, e, frameIndex);
+            return ToGifFrame(img, e, wait);
+        }
+
+        // Render a GIF frame from a stored frame id (frame-table path).
+        static GifEncoderCore.GifFrame RenderGifFrameById(ROM rom, RomAnimeCore.RomAnimeEntry e, int id, uint wait)
+        {
+            using IImage img = RenderById(rom, e, id);
+            return ToGifFrame(img, e, wait);
+        }
+
+        static GifEncoderCore.GifFrame ToGifFrame(IImage img, RomAnimeCore.RomAnimeEntry e, uint wait)
+        {
+            int w = e.ImageWidthTiles * 8, h = FRAME_HEIGHT;
+            byte[] rgba;
+            if (img != null)
+            {
+                w = img.Width; h = img.Height;
+                rgba = GifEncoderCore.IndexedToRgba(img.GetPixelData(), img.GetPaletteRGBA(), w, h);
+            }
+            else
+            {
+                rgba = new byte[w * h * 4]; // a fully transparent blank frame
+            }
+            return new GifEncoderCore.GifFrame
+            {
+                Width = w,
+                Height = h,
+                RgbaPixels = rgba,
+                DelayCs = U.GameFrameSecToGifFrameSec(wait),
+            };
+        }
+
+        // Render a specific STORED frame id (the WF DrawDirect((int)id) path) — used by
+        // both the frame-table export and GIF walks where id != UI frame index.
+        static IImage RenderById(ROM rom, RomAnimeCore.RomAnimeEntry e, int id)
+        {
+            if (rom == null || e == null || id < 0) return null;
+            if (CoreState.ImageService == null) return null;
+            if (!TryPick(e.TSAList, id, out uint tsa)) return null;
+            if (!TryPick(e.ImageList, id, out uint image)) return null;
+            if (!TryPick(e.PaletteList, id, out uint palette)) return null;
+            return RomAnimeCore.RenderFromOffsets(rom, e.ImageWidthTiles, tsa, image, palette);
+        }
+
+        static bool TryPick(List<uint> list, int index, out uint offset)
+        {
+            offset = 0;
+            if (list == null || list.Count <= 0) return false;
+            offset = (index >= list.Count) ? list[list.Count - 1] : list[index];
+            return true;
+        }
+
+        static uint FindImage(List<FrameImage> list, string name)
+        {
+            for (int i = 0; i < list.Count; i++)
+                if (list[i].Name == name) return (uint)i;
+            return U.NOT_FOUND;
+        }
+
+        // Crop/pad indexed pixels top-left to (dstW, dstH) (WF ImageUtil.Copy(_,0,0,w,h)).
+        static byte[] CropOrPadIndexed(byte[] src, int srcW, int srcH, int dstW, int dstH)
+        {
+            byte[] dst = new byte[dstW * dstH];
+            if (src == null || srcW <= 0 || srcH <= 0) return dst;
+            int copyW = Math.Min(srcW, dstW);
+            int copyH = Math.Min(srcH, dstH);
+            for (int y = 0; y < copyH; y++)
+            {
+                int srcOff = y * srcW;
+                int dstOff = y * dstW;
+                int n = Math.Min(copyW, Math.Min(src.Length - srcOff, dst.Length - dstOff));
+                if (n > 0) Array.Copy(src, srcOff, dst, dstOff, n);
+            }
+            return dst;
+        }
+
+        // Normalize any quantize palette to exactly 32 bytes (16 colors x 2).
+        static byte[] NormalizePalette(byte[] input)
+        {
+            byte[] result = new byte[PALETTE_BYTES];
+            if (input == null) return result;
+            Array.Copy(input, result, Math.Min(input.Length, PALETTE_BYTES));
+            return result;
+        }
+
+        // Length-aware byte-identical restore for the fault path (#885/#923), identical
+        // to RomAnimeCore.RestoreSnapshot.
+        static void RestoreSnapshot(ROM rom, byte[] snap)
+        {
+            if (rom == null || snap == null) return;
+            if (rom.Data.Length != snap.Length)
+                rom.write_resize_data((uint)snap.Length);
+            Array.Copy(snap, rom.Data, snap.Length);
+        }
+    }
+}

--- a/FEBuilderGBA.Core/RomAnimeMultiFrameCore.cs
+++ b/FEBuilderGBA.Core/RomAnimeMultiFrameCore.cs
@@ -80,10 +80,13 @@ namespace FEBuilderGBA
             if (string.IsNullOrEmpty(scriptPath)) return R.Error("Output path is empty.");
             if (CoreState.ImageService == null) return R.Error("Image service is not configured.");
 
-            string baseName = Path.GetFileNameWithoutExtension(scriptPath) + "_";
-            string baseDir = Path.GetDirectoryName(Path.GetFullPath(scriptPath)) ?? "";
+            // Path.GetFullPath / GetDirectoryName can throw on invalid path chars; keep
+            // them inside try/catch so the method honors its "never throws" contract.
+            string baseName, baseDir;
             try
             {
+                baseName = Path.GetFileNameWithoutExtension(scriptPath) + "_";
+                baseDir = Path.GetDirectoryName(Path.GetFullPath(scriptPath)) ?? "";
                 if (baseDir.Length > 0 && !Directory.Exists(baseDir)) Directory.CreateDirectory(baseDir);
             }
             catch (Exception ex) { return R.Error("Failed to create output directory: {0}", ex.Message); }
@@ -254,8 +257,14 @@ namespace FEBuilderGBA
         /// per-frame import) or returns null when the file is missing / unreadable. Core
         /// crops/pads the indexed pixels to <c>(ImageWidthTiles*8, 128)</c> — the WF
         /// <c>ImageUtil.Copy(bitmap, 0, 0, imageWidth, imageHeight)</c> step.</para>
+        ///
+        /// <para><b>Mutates the ambient <see cref="CoreState.ROM"/>.</b> The atomic rewrite
+        /// goes through the RecycleAddress AMBIENT overloads, which write to
+        /// <see cref="CoreState.ROM"/>; <paramref name="rom"/> MUST be that same instance
+        /// (the method refuses a mismatch). The snapshot and byte-identical fault-restore
+        /// operate on <see cref="CoreState.ROM"/> accordingly (Copilot PR #1239 review #1).</para>
         /// </summary>
-        /// <param name="rom">Target ROM.</param>
+        /// <param name="rom">Target ROM — MUST be the ambient <see cref="CoreState.ROM"/>.</param>
         /// <param name="e">The resolved entry (from <see cref="RomAnimeCore.Resolve"/>).</param>
         /// <param name="scriptPath">Input <c>wait png</c> script.</param>
         /// <param name="frameLoader">PNG path -&gt; <c>(indexed, gbaPalette16, w, h)</c> or null.</param>
@@ -279,9 +288,25 @@ namespace FEBuilderGBA
             int imageWidth = e.ImageWidthTiles * 8;
             if (imageWidth <= 0) { error = R.Error("The animation frame width is invalid."); return false; }
 
-            string baseDir = Path.GetDirectoryName(Path.GetFullPath(scriptPath)) ?? "";
+            // The atomic rewrite goes through the RecycleAddress AMBIENT overloads, which
+            // are hardcoded to mutate CoreState.ROM. The snapshot + fault-restore MUST
+            // therefore operate on that SAME object — not the passed `rom` — or a caller
+            // whose `rom` differs from CoreState.ROM would leave CoreState.ROM corrupted
+            // on a fault (Copilot PR #1239 review #1). Refuse a mismatch loudly rather
+            // than silently writing to the wrong ROM.
+            if (!ReferenceEquals(rom, CoreState.ROM))
+            { error = R.Error("ROM not loaded."); return false; }
+
+            // Path.GetFullPath / GetDirectoryName can throw on invalid path chars; keep
+            // them inside try/catch so the method returns its error out-param instead of
+            // throwing (Copilot PR #1239 review #3).
+            string baseDir;
             string[] lines;
-            try { lines = File.ReadAllLines(scriptPath); }
+            try
+            {
+                baseDir = Path.GetDirectoryName(Path.GetFullPath(scriptPath)) ?? "";
+                lines = File.ReadAllLines(scriptPath);
+            }
             catch (Exception ex) { error = R.Error("Failed to read script file: {0}", ex.Message); return false; }
 
             // ---- PHASE 1: parse + encode EVERY unique image. ZERO ROM mutation. ----
@@ -333,32 +358,38 @@ namespace FEBuilderGBA
             }
 
             // ---- PHASE 2: snapshot, pool old regions, rewrite atomically. ----
-            byte[] snap = (byte[])rom.Data.Clone();
+            // Snapshot + restore the SAME object the RecycleAddress ambient writes
+            // mutate (CoreState.ROM), so the fault-restore actually undoes the writes
+            // (Copilot PR #1239 review #1). The early ReferenceEquals guard means
+            // `target` == `rom` here, but binding it explicitly keeps the snapshot,
+            // every write, and the restore provably consistent.
+            ROM target = CoreState.ROM;
+            byte[] snap = (byte[])target.Data.Clone();
             try
             {
                 var recycle = new List<Address>();
-                MakeRecycleList(rom, e, recycle);
+                MakeRecycleList(target, e, recycle);
                 var ra = new RecycleAddress(recycle);
 
                 bool ok;
                 if (!e.IsFrameTable)
                 {
                     if (e.TSAList.Count == 1 && e.PaletteList.Count >= 2)
-                        ok = WriteFixedPaletteAnime(rom, e, ra, animeList);
+                        ok = WriteFixedPaletteAnime(target, e, ra, animeList);
                     else
-                        ok = WriteFixedMultiPalette(rom, e, ra, animeList);
+                        ok = WriteFixedMultiPalette(target, e, ra, animeList);
                 }
                 else
                 {
                     if (e.TSAList.Count >= 2 && e.PaletteList.Count == 1)
-                        ok = WriteFrameTableCommonPalette(rom, e, ra, animeList, frames.ToArray());
+                        ok = WriteFrameTableCommonPalette(target, e, ra, animeList, frames.ToArray());
                     else
-                        ok = WriteFrameTableMultiPalette(rom, e, ra, animeList, frames.ToArray());
+                        ok = WriteFrameTableMultiPalette(target, e, ra, animeList, frames.ToArray());
                 }
 
                 if (!ok)
                 {
-                    RestoreSnapshot(rom, snap);
+                    RestoreSnapshot(target, snap);
                     error = R._("Failed to write animation. Check ROM free space.");
                     return false;
                 }
@@ -369,7 +400,7 @@ namespace FEBuilderGBA
             }
             catch (Exception ex)
             {
-                RestoreSnapshot(rom, snap);
+                RestoreSnapshot(target, snap);
                 error = R.Error("Animation import failed: {0}", ex.Message);
                 return false;
             }

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11478,3 +11478,30 @@ report.7zについて:
 
 :The specified file does not exist.
 指定されたファイルが存在しません。
+
+:Export Script
+スクリプト出力
+
+:Import Script
+スクリプト読込
+
+:Export GIF
+GIF出力
+
+:Save Animation GIF
+アニメGIFを保存
+
+:Animated GIF (.gif)
+アニメGIF (.gif)
+
+:Open Animation Script
+アニメスクリプトを開く
+
+:Animation script exported successfully.
+アニメスクリプトを出力しました。
+
+:Animation GIF exported successfully.
+アニメGIFを出力しました。
+
+:Animation script imported successfully.
+アニメスクリプトを読み込みました。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25319,3 +25319,30 @@ TSA数量: {0}
 
 :The specified file does not exist.
 指定的文件不存在。
+
+:Export Script
+导出脚本
+
+:Import Script
+导入脚本
+
+:Export GIF
+导出GIF
+
+:Save Animation GIF
+保存动画GIF
+
+:Animated GIF (.gif)
+动画GIF (.gif)
+
+:Open Animation Script
+打开动画脚本
+
+:Animation script exported successfully.
+动画脚本导出成功。
+
+:Animation GIF exported successfully.
+动画GIF导出成功。
+
+:Animation script imported successfully.
+动画脚本导入成功。


### PR DESCRIPTION
Fixes #1230.

Follow-up to #1176 (In-ROM Magic Animation editor) — ports the deferred **multi-frame animation-script subsystem**.

## What
- **Multi-frame `.txt` (`wait png`) export/import** — rebuilds the WHOLE animation: a `{u16 id, u16 wait}` frame table, the per-frame image/TSA/palette pointer LISTS, the **COMMONPALETTE / palette-animation / FIXEDCOUNT** modes, and `RecycleAddress` reuse of the old regions (`MakeRecycleList`). Faithful port of WinForms `ImageRomAnimeForm.Export`/`Import`.
- **Animated GIF export** — walks the frame table, renders each frame, encodes via the existing `GifEncoderCore`.

## How (architecture)
- New **`FEBuilderGBA.Core/RomAnimeMultiFrameCore.cs`** (GUI-free): `ExportTxt`, `ExportGif`, `ImportTxt`, `MakeRecycleList`. Reuses `RomAnimeCore` (per-frame 4bpp+TSA decode/encode + repoint) and `GifEncoderCore`.
- **`ImportTxt` is ONE atomic transaction:** validate everything first (parse all lines, load+encode+LZ77 every unique image, FIXEDCOUNT count check) with **zero ROM mutation**; take a `rom.Data.Clone()` snapshot immediately before the first write; rewrite the frame table + all pointer arrays via `RecycleAddress` ambient overloads (under the View's `UndoService.Begin/Commit`); on **any** failure, `RestoreSnapshot` → ROM **byte-identical**. Same fault model as the single-frame `ImportFrame` + sibling export cores.
- View: 3 new buttons (Export Script / Import Script / Export GIF) with file pickers; import runs under ambient undo. English XAML literals + ja/zh.

## Tests / gates (all green locally)
- `RomAnimeMultiFrameCoreTests` — round-trip (export→import→export reproduces the frame table + ids) across **all 4 palette-mode shapes** (FIXEDCOUNT multi-palette / FIXEDCOUNT palette-animation / frame-table COMMONPALETTE / frame-table multi-palette), a **forced-fault byte-identical restore** test, and a GIF89a-header test.
- Core.Tests `~RomAnime|~AvaloniaScrollViewer`: **32 passed**. FEBuilderGBA.Tests `~Avalonia|~AutomationId`: **793 passed** (incl. ja/zh translation gate). `validate-automation-ids.ps1`: **0 errors, 0 warnings**. Dark-mode: 0 hex literals.

## Proof (FE8U — In-ROM Magic Animation editor, entry 00 efxLvupBG)
New **Export Script / Import Script / Export GIF** buttons; multi-frame metadata (Frames 11 / TSA 22 / Image 11 / Palette 1) the subsystem reads:

<img width="620" src="https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1230-romanime-multiframe-fe8u.png">

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 4.8 (1M context), model `claude-opus-4-8[1m]`