### PR TITLE
feat(avalonia): add .ttf/.otf font auto-generation to Font editor (#1232)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/FontEditorViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/FontEditorViewModelTests.cs
@@ -9,6 +9,7 @@ using System;
 using System.IO;
 using FEBuilderGBA;
 using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
 using FEBuilderGBA.Core;
 using Xunit;
 
@@ -165,6 +166,52 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.Contains("_undoService.Begin", cs);
             Assert.Contains("_undoService.Commit", cs);
             Assert.Contains("_undoService.Rollback", cs);
+        }
+
+        // ---------------- #1232 auto-generate-from-font ----------------
+
+        [Fact]
+        public void Axaml_HasAutoGenAutomationIds()
+        {
+            string axaml = ReadView(".axaml");
+            Assert.Contains("FontEditor_LoadFont_Button", axaml);
+            Assert.Contains("FontEditor_ClearFont_Button", axaml);
+            Assert.Contains("FontEditor_FontFile_Label", axaml);
+            Assert.Contains("FontEditor_FontFamily_Input", axaml);
+            Assert.Contains("FontEditor_FontSize_Input", axaml);
+            Assert.Contains("FontEditor_VOffset_Input", axaml);
+            Assert.Contains("FontEditor_AutoGen_Button", axaml);
+        }
+
+        [Fact]
+        public void CodeBehind_WiresAutoGen_RasterizerCoreAndUndo()
+        {
+            string cs = ReadView(".axaml.cs");
+            // Auto-gen goes through the Core seam with a SkiaSharp rasterizer.
+            Assert.Contains("FontAutoGenCore.AutoGenerateGlyph", cs);
+            Assert.Contains("SkiaFontRasterizer", cs);
+            // FontFilePath is preferred over an installed-family name.
+            Assert.Contains("FontFilePath", cs);
+            // Undo scope around the mutation (begin/commit/rollback already
+            // asserted globally above; confirm the auto-gen label is present).
+            Assert.Contains("Auto-Generate Font Glyph", cs);
+        }
+
+        // The "@hex" undecodable fallback must be rejected, but a REAL '@'
+        // character (moji 0x40, whose decoded label is the lone "@") must
+        // rasterize normally — Copilot PR #1240 review #1.
+        [Theory]
+        [InlineData("@", false)]        // real at-sign glyph (moji 0x40)
+        [InlineData("@4140", true)]     // SJIS @hex fallback (4 hex digits)
+        [InlineData("@A0", true)]       // UTF-8 @hex fallback (2 hex digits)
+        [InlineData("@FF", true)]
+        [InlineData("A", false)]        // ordinary letter
+        [InlineData("@G", false)]       // '@' + non-hex => not the fallback marker
+        [InlineData("@@", false)]       // '@' + non-hex
+        [InlineData("", false)]
+        public void IsAtHexFallback_DistinguishesRealAtSignFromHexMarker(string input, bool expected)
+        {
+            Assert.Equal(expected, FontEditorView.IsAtHexFallback(input));
         }
     }
 }

--- a/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
+++ b/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
@@ -186,8 +186,15 @@ namespace FEBuilderGBA.Avalonia.Dialogs
 
         /// <summary>Open any file with custom filter.</summary>
         public static async Task<string?> OpenFile(Window owner, string title, string pattern)
+            => await OpenFile(owner, title, new[] { pattern });
+
+        /// <summary>
+        /// Open any file with a custom multi-pattern filter (e.g. ".ttf" + ".otf"
+        /// for the Font editor's auto-generate font picker, #1232).
+        /// </summary>
+        public static async Task<string?> OpenFile(Window owner, string title, string[] patterns)
         {
-            var fileType = new FilePickerFileType(title) { Patterns = new[] { pattern } };
+            var fileType = new FilePickerFileType(title) { Patterns = patterns };
             var files = await owner.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
             {
                 Title = title,

--- a/FEBuilderGBA.Avalonia/Views/FontEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/FontEditorView.axaml
@@ -46,6 +46,33 @@
             </StackPanel>
           </StackPanel>
         </Border>
+
+        <!-- Auto-generate the selected glyph from a desktop .ttf/.otf font (#1232). -->
+        <Border BorderBrush="Gray" BorderThickness="1" Padding="6" Margin="0,12,0,0">
+          <StackPanel Spacing="6">
+            <TextBlock Text="Auto-Generate from Font" FontWeight="Bold" />
+
+            <StackPanel Orientation="Horizontal" Spacing="8">
+              <Button AutomationProperties.AutomationId="FontEditor_LoadFont_Button" Name="LoadFontButton" Content="Load .ttf/.otf" Click="LoadFont_Click" />
+              <Button AutomationProperties.AutomationId="FontEditor_ClearFont_Button" Name="ClearFontButton" Content="Clear" Click="ClearFont_Click" />
+            </StackPanel>
+            <TextBlock AutomationProperties.AutomationId="FontEditor_FontFile_Label" Name="FontFileLabel" TextWrapping="Wrap" Foreground="Gray" />
+
+            <Grid ColumnDefinitions="120,*" RowDefinitions="Auto,Auto,Auto">
+              <TextBlock Grid.Row="0" Grid.Column="0" Text="Family:" VerticalAlignment="Center" />
+              <TextBox AutomationProperties.AutomationId="FontEditor_FontFamily_Input" Grid.Row="0" Grid.Column="1" Name="FontFamilyInput" Text="Arial" Margin="0,2"
+                       ToolTip.Tip="Used only when no .ttf/.otf file is loaded." />
+              <TextBlock Grid.Row="1" Grid.Column="0" Text="Size:" VerticalAlignment="Center" />
+              <NumericUpDown AutomationProperties.AutomationId="FontEditor_FontSize_Input" Grid.Row="1" Grid.Column="1" Name="FontSizeInput" Margin="0,2"
+                             Minimum="6" Maximum="32" Increment="1" Value="12" />
+              <TextBlock Grid.Row="2" Grid.Column="0" Text="Vertical Offset:" VerticalAlignment="Center" />
+              <NumericUpDown AutomationProperties.AutomationId="FontEditor_VOffset_Input" Grid.Row="2" Grid.Column="1" Name="VOffsetInput" Margin="0,2"
+                             Minimum="-8" Maximum="8" Increment="1" Value="0" />
+            </Grid>
+
+            <Button AutomationProperties.AutomationId="FontEditor_AutoGen_Button" Name="AutoGenButton" Content="Auto-Generate" Click="AutoGen_Click" HorizontalAlignment="Left" />
+          </StackPanel>
+        </Border>
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/FontEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/FontEditorView.axaml
@@ -60,7 +60,7 @@
 
             <Grid ColumnDefinitions="120,*" RowDefinitions="Auto,Auto,Auto">
               <TextBlock Grid.Row="0" Grid.Column="0" Text="Family:" VerticalAlignment="Center" />
-              <TextBox AutomationProperties.AutomationId="FontEditor_FontFamily_Input" Grid.Row="0" Grid.Column="1" Name="FontFamilyInput" Text="Arial" Margin="0,2"
+              <TextBox AutomationProperties.AutomationId="FontEditor_FontFamily_Input" Grid.Row="0" Grid.Column="1" Name="FontFamilyInput" Margin="0,2"
                        ToolTip.Tip="Used only when no .ttf/.otf file is loaded." />
               <TextBlock Grid.Row="1" Grid.Column="0" Text="Size:" VerticalAlignment="Center" />
               <NumericUpDown AutomationProperties.AutomationId="FontEditor_FontSize_Input" Grid.Row="1" Grid.Column="1" Name="FontSizeInput" Margin="0,2"

--- a/FEBuilderGBA.Avalonia/Views/FontEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/FontEditorView.axaml.cs
@@ -34,6 +34,11 @@ namespace FEBuilderGBA.Avalonia.Views
 
             EntryList.SelectedAddressChanged += OnSelected;
             Opened += (_, _) => LoadList();
+
+            // Default font family (a data value, not a UI label — set here so it
+            // isn't a scanned AXAML literal the L10n gate would flag as
+            // untranslated). AutoGen_Click also falls back to "Arial" when empty.
+            FontFamilyInput.Text = "Arial";
         }
 
         void LoadList()
@@ -336,9 +341,30 @@ namespace FEBuilderGBA.Avalonia.Views
             string label = EntryList.SelectedItem?.name ?? "";
             int sp = label.IndexOf(' ');
             string ch = sp >= 0 ? label.Substring(sp + 1) : "";
-            // "@XXXX" is the FontGlyphRenderCore fallback for an undecodable code.
-            if (string.IsNullOrEmpty(ch) || ch.StartsWith("@")) return "";
+            if (string.IsNullOrEmpty(ch)) return "";
+            // Reject ONLY the FontGlyphRenderCore "@hex" fallback for an
+            // undecodable code: '@' followed by one or more hex digits (e.g.
+            // "@4140", "@A0"). A real '@' character (moji 0x40) decodes to the
+            // lone "@" and MUST rasterize normally — so don't blanket-reject
+            // everything starting with '@'.
+            if (IsAtHexFallback(ch)) return "";
             return ch;
+        }
+
+        /// <summary>
+        /// True when <paramref name="s"/> is the "@hex" fallback marker emitted by
+        /// FontGlyphRenderCore.FontChar / FontCharUTF8 for an undecodable code:
+        /// a literal '@' followed by one or more hex digits and nothing else. A
+        /// bare "@" (the real at-sign glyph, moji 0x40) is NOT a fallback.
+        /// </summary>
+        internal static bool IsAtHexFallback(string s)
+        {
+            if (string.IsNullOrEmpty(s) || s.Length < 2 || s[0] != '@') return false;
+            for (int i = 1; i < s.Length; i++)
+            {
+                if (!Uri.IsHexDigit(s[i])) return false;
+            }
+            return true;
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/FontEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/FontEditorView.axaml.cs
@@ -14,6 +14,10 @@ namespace FEBuilderGBA.Avalonia.Views
         readonly FontEditorViewModel _vm = new();
         readonly UndoService _undoService = new();
 
+        // Path of the desktop .ttf/.otf loaded for Auto-Generate (#1232). Empty
+        // => fall back to the typed font family. Set by LoadFont_Click.
+        string _fontFilePath = "";
+
         public string ViewTitle => "Font Editor";
         public bool IsLoaded => _vm.IsLoaded;
         public ViewModelBase? DataViewModel => _vm;
@@ -246,6 +250,95 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 CoreState.Services?.ShowError(R._("Import failed: {0}", ex.Message));
             }
+        }
+
+        // ---- Auto-generate from a desktop .ttf/.otf font (#1232) ----
+
+        async void LoadFont_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                string? path = await FileDialogHelper.OpenFile(this,
+                    R._("Load Font File"), new[] { "*.ttf", "*.otf" });
+                if (string.IsNullOrEmpty(path)) return;
+                _fontFilePath = path;
+                FontFileLabel.Text = Path.GetFileName(path);
+            }
+            catch (Exception ex)
+            {
+                CoreState.Services?.ShowError(R._("Load failed: {0}", ex.Message));
+            }
+        }
+
+        void ClearFont_Click(object? sender, RoutedEventArgs e)
+        {
+            _fontFilePath = "";
+            FontFileLabel.Text = "";
+        }
+
+        void AutoGen_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                ROM rom = CoreState.ROM;
+                if (rom == null) return;
+                if (_vm.CurrentAddr == 0) { CoreState.Services?.ShowError(R._("No glyph selected.")); return; }
+
+                // The character to rasterize is the selected row's decoded glyph
+                // (the label is "0xXX <char>"); the moji is the target slot.
+                string character = GlyphCharacterOfSelected();
+                if (string.IsNullOrEmpty(character)) { CoreState.Services?.ShowError(R._("This glyph has no renderable character.")); return; }
+
+                // Build the cross-platform font selector: a loaded .ttf/.otf file
+                // wins; otherwise the typed family (resolved by SKTypeface).
+                var font = new FontSpec
+                {
+                    FamilyName = string.IsNullOrWhiteSpace(FontFamilyInput.Text) ? "Arial" : FontFamilyInput.Text,
+                    Size = (float)(FontSizeInput.Value is { } sz && sz > 0 ? sz : 12m),
+                    FontFilePath = string.IsNullOrEmpty(_fontFilePath) ? null : _fontFilePath,
+                };
+                int vOffset = (int)(VOffsetInput.Value ?? 0m);
+
+                // Capture the target char code BEFORE reload (LoadList re-selects
+                // the first row), so we can re-select the just-edited glyph.
+                uint targetMoji = _vm.CurrentMoji;
+
+                var rasterizer = new FEBuilderGBA.SkiaSharp.SkiaFontRasterizer();
+
+                _undoService.Begin("Auto-Generate Font Glyph");
+                try
+                {
+                    string err = FontAutoGenCore.AutoGenerateGlyph(rom, rasterizer, font,
+                        character, targetMoji, _vm.IsItemFont, vOffset);
+                    if (!string.IsNullOrEmpty(err)) { _undoService.Rollback(); CoreState.Services?.ShowError(err); return; }
+                    _undoService.Commit();
+                }
+                catch { _undoService.Rollback(); throw; }
+
+                LoadList();
+                SelectByMoji(targetMoji);
+                _vm.MarkClean();
+                CoreState.Services?.ShowInfo(R._("Glyph generated successfully."));
+            }
+            catch (Exception ex)
+            {
+                CoreState.Services?.ShowError(R._("Auto-generate failed: {0}", ex.Message));
+            }
+        }
+
+        /// <summary>
+        /// The renderable character of the selected glyph row. The list label is
+        /// "0xXX &lt;char&gt;" (hex code + decoded char); take the part after the
+        /// first space. An "@hex" fallback name (an undecodable code) yields "".
+        /// </summary>
+        string GlyphCharacterOfSelected()
+        {
+            string label = EntryList.SelectedItem?.name ?? "";
+            int sp = label.IndexOf(' ');
+            string ch = sp >= 0 ? label.Substring(sp + 1) : "";
+            // "@XXXX" is the FontGlyphRenderCore fallback for an undecodable code.
+            if (string.IsNullOrEmpty(ch) || ch.StartsWith("@")) return "";
+            return ch;
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Core.Tests/FontAutoGenCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/FontAutoGenCoreTests.cs
@@ -24,6 +24,19 @@ namespace FEBuilderGBA.Core.Tests
         const uint GLYPH_OFF = 0x00700000; // free space for the planted glyph struct
         const uint MOJI_A = 0x41;          // 'A'
 
+        // Installs the shared StubImageService so RenderGlyphBytes can decode a
+        // glyph back to RGBA for the pixel-for-pixel round-trip assertion.
+        sealed class ImageServiceScope : IDisposable
+        {
+            readonly IImageService _prev;
+            public ImageServiceScope()
+            {
+                _prev = CoreState.ImageService;
+                CoreState.ImageService = new StubImageService();
+            }
+            public void Dispose() { CoreState.ImageService = _prev; }
+        }
+
         // A stub rasterizer that returns a caller-supplied packed 64-byte tile and
         // a caller-supplied advance width. Records the last call's arguments so the
         // tests can assert the character / font / offset were threaded through.
@@ -347,6 +360,69 @@ namespace FEBuilderGBA.Core.Tests
             byte[] packed = FontGlyphRenderCore.PackGlyphBytes(idx);
             byte[] unpacked = FontAutoGenCore.UnpackGlyphBytes(packed);
             Assert.Equal(idx, unpacked);
+        }
+
+        // The real proof the 2bpp bit-order / nibble convention is right: feed the
+        // stub rasterizer a packed tile built from a DISTINCT, ASYMMETRIC index
+        // pattern (so a transposed/row-reversed/bit-swapped unpack would change the
+        // result), run AutoGenerateGlyph, then RENDER the resulting ROM glyph and
+        // map each pixel back to its palette index — it must reproduce the original
+        // pattern pixel-for-pixel. (rasterize -> unpack -> ImportGlyph -> render.)
+        [Fact]
+        public void AutoGenerateGlyph_AsymmetricPattern_RoundTripsPixelForPixel()
+        {
+            var prevRom = CoreState.ROM;
+            using var svc = new ImageServiceScope();
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+
+                // Asymmetric, all-4-colors pattern: index varies with BOTH x and y
+                // and is NOT symmetric under transpose or row/column reversal.
+                byte[] original = new byte[16 * 16];
+                for (int y = 0; y < 16; y++)
+                    for (int x = 0; x < 16; x++)
+                        original[y * 16 + x] = (byte)((x + 2 * y) & 0x03);
+                // Plant a couple of unique single-pixel marks so a flip is unmissable.
+                original[0 * 16 + 1] = 3;   // top row, x=1
+                original[15 * 16 + 0] = 2;  // bottom-left corner
+                original[1 * 16 + 15] = 1;  // near top-right
+
+                byte[] packed = FontGlyphRenderCore.PackGlyphBytes(original);
+                Assert.NotNull(packed);
+
+                var stub = new StubRasterizer(packed, width: 16);
+                string err = FontAutoGenCore.AutoGenerateGlyph(rom, stub, FileFontSpec(),
+                    "A", MOJI_A, isItemFont: false, verticalOffset: 0);
+                Assert.Equal("", err);
+
+                // Render the ROM glyph and map each RGBA pixel back to its index.
+                using IImage img = FontGlyphRenderCore.RenderGlyph(rom, GLYPH_OFF, isItemFont: false);
+                Assert.NotNull(img);
+                byte[] rgba = img!.GetPixelData();
+
+                byte[] roundTripped = new byte[16 * 16];
+                for (int p = 0; p < 16 * 16; p++)
+                {
+                    byte r = rgba[p * 4 + 0];
+                    byte a = rgba[p * 4 + 3];
+                    roundTripped[p] = RgbaToFontIndex(r, a);
+                }
+                Assert.Equal(original, roundTripped);
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        // Inverse of FontGlyphRenderCore's render palette (serif/text font):
+        // index 0 = transparent; 1 = Gray (R 0xA8); 2 = White (R 0xF8); 3 = Black
+        // (R 0x28). Identify by alpha first, then by the red channel.
+        static byte RgbaToFontIndex(byte r, byte a)
+        {
+            if (a == 0) return 0;
+            if (r == 0xF8) return 2;
+            if (r == 0x28) return 3;
+            return 1; // 0xA8 (Gray)
         }
     }
 }

--- a/FEBuilderGBA.Core.Tests/FontAutoGenCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/FontAutoGenCoreTests.cs
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1232 Core tests for FontAutoGenCore — the Avalonia Font editor's
+// ".ttf/.otf Auto-Generate" seam (rasterize one character into a ROM glyph via
+// the platform-neutral IFontRasterizer + write-back through
+// FontGlyphRenderCore.ImportGlyph).
+//
+// Core.Tests stays SkiaSharp-free: these tests inject a STUB IFontRasterizer
+// that returns a deterministic packed 64-byte tile, so the rasterize -> unpack
+// -> ImportGlyph wiring is exercised without any real font rendering. The real
+// FEBuilderGBA.SkiaSharp.SkiaFontRasterizer is covered via the Avalonia layer.
+//
+// Same synthetic FE8U (LAT1) ROM as FontGlyphRenderCoreTests: a single 'A'
+// (0x41) serif glyph planted in free space.
+using System;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class FontAutoGenCoreTests
+    {
+        const uint ROM_LEN = 0x01000000;   // 16 MiB (font_serif_address in-bounds)
+        const uint GLYPH_OFF = 0x00700000; // free space for the planted glyph struct
+        const uint MOJI_A = 0x41;          // 'A'
+
+        // A stub rasterizer that returns a caller-supplied packed 64-byte tile and
+        // a caller-supplied advance width. Records the last call's arguments so the
+        // tests can assert the character / font / offset were threaded through.
+        sealed class StubRasterizer : IFontRasterizer
+        {
+            readonly byte[] _packed;
+            readonly int _width;
+            public FontSpec LastFont;
+            public string LastCharacter = "";
+            public bool LastIsItemFont;
+            public int LastVerticalOffset;
+            public int CallCount;
+
+            public StubRasterizer(byte[] packed, int width) { _packed = packed; _width = width; }
+
+            public byte[] RasterizeGlyph(FontSpec font, string character, bool isItemFont,
+                int verticalOffset, out int glyphWidth)
+            {
+                CallCount++;
+                LastFont = font;
+                LastCharacter = character;
+                LastIsItemFont = isItemFont;
+                LastVerticalOffset = verticalOffset;
+                glyphWidth = _width;
+                return _packed;
+            }
+        }
+
+        // A rasterizer that always throws, to prove faults become localized errors.
+        sealed class ThrowingRasterizer : IFontRasterizer
+        {
+            public byte[] RasterizeGlyph(FontSpec font, string character, bool isItemFont,
+                int verticalOffset, out int glyphWidth)
+                => throw new InvalidOperationException("boom");
+        }
+
+        static ROM MakeRom()
+        {
+            var rom = new ROM();
+            byte[] data = new byte[ROM_LEN];
+            Array.Fill(data, (byte)0xFF); // 0xFF = free-space marker for the append path
+            for (uint i = 0; i < 0x600000; i++) data[i] = 0x00;
+            rom.LoadLow("synth.gba", data, "BE8E01");
+
+            PlantGlyph(rom, MOJI_A, GLYPH_OFF, width: 9, fillByte: 0x00);
+            return rom;
+        }
+
+        static void PlantGlyph(ROM rom, uint moji, uint glyphOff, uint width, byte fillByte)
+        {
+            uint topaddress = rom.RomInfo.font_serif_address;
+            uint bucket = topaddress + (moji << 2); // LAT1: hash by moji2
+            U.write_u32(rom.Data, glyphOff + 0, 0);
+            U.write_u8(rom.Data, glyphOff + 4, moji);
+            U.write_u8(rom.Data, glyphOff + 5, width);
+            U.write_u8(rom.Data, glyphOff + 6, 0);
+            U.write_u8(rom.Data, glyphOff + 7, 0);
+            for (uint i = 0; i < 64; i++) rom.Data[glyphOff + 8 + i] = fillByte;
+            U.write_u32(rom.Data, bucket, U.toPointer(glyphOff));
+        }
+
+        // A deterministic packed 64-byte tile: pixel index = (x % 4), packed
+        // 4 px/byte low-bits-first => every byte = 0b11_10_01_00 = 0xE4. Its
+        // rightmost non-zero pixel is x=15 (index 3), so the derived width is 16 —
+        // but we pass an explicit width that must win.
+        static byte[] MakePackedTile()
+        {
+            byte[] idx = new byte[16 * 16];
+            for (int y = 0; y < 16; y++)
+                for (int x = 0; x < 16; x++)
+                    idx[y * 16 + x] = (byte)(x & 0x03);
+            return FontGlyphRenderCore.PackGlyphBytes(idx);
+        }
+
+        static FontSpec FileFontSpec() => new FontSpec
+        {
+            FamilyName = "TestFamily",
+            Size = 14f,
+            FontFilePath = "/some/font.ttf",
+        };
+
+        // ---- undo replay helpers (mirrors FontGlyphRenderCoreTests) ----
+
+        static Undo.UndoData NewUd(ROM rom) => new Undo.UndoData
+        {
+            time = DateTime.Now,
+            name = "font-autogen-test",
+            list = new System.Collections.Generic.List<Undo.UndoPostion>(),
+            filesize = (uint)rom.Data.Length,
+        };
+
+        static void RollbackReplay(ROM rom, Undo.UndoData ud)
+        {
+            for (int i = ud.list.Count - 1; i >= 0; i--)
+            {
+                var up = ud.list[i];
+                Array.Copy(up.data, 0, rom.Data, up.addr, up.data.Length);
+            }
+        }
+
+        // ===================== Tests =====================
+
+        [Fact]
+        public void AutoGenerateGlyph_ExistingGlyph_WritesRasterizedBytes()
+        {
+            var prevRom = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+
+                byte[] packed = MakePackedTile();
+                var stub = new StubRasterizer(packed, width: 7);
+
+                string err = FontAutoGenCore.AutoGenerateGlyph(rom, stub, FileFontSpec(),
+                    "A", MOJI_A, isItemFont: false, verticalOffset: 0);
+                Assert.Equal("", err);
+
+                // The rasterized 64 bytes landed in the existing glyph slot at +8.
+                Assert.Equal(packed, rom.getBinaryData(GLYPH_OFF + 8, 64));
+                // The rasterizer's advance width was written verbatim.
+                Assert.Equal(7u, rom.u8(GLYPH_OFF + 5));
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void AutoGenerateGlyph_ThreadsCharFontOffsetToRasterizer()
+        {
+            var prevRom = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+
+                var stub = new StubRasterizer(MakePackedTile(), width: 5);
+                FontSpec spec = FileFontSpec();
+
+                string err = FontAutoGenCore.AutoGenerateGlyph(rom, stub, spec,
+                    "A", MOJI_A, isItemFont: true, verticalOffset: 3);
+                Assert.Equal("", err);
+
+                Assert.Equal(1, stub.CallCount);
+                Assert.Equal("A", stub.LastCharacter);
+                Assert.True(stub.LastIsItemFont);
+                Assert.Equal(3, stub.LastVerticalOffset);
+                Assert.Equal("/some/font.ttf", stub.LastFont.FontFilePath);
+                Assert.Equal(14f, stub.LastFont.Size);
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void AutoGenerateGlyph_NewGlyph_AppendsAndChainLinks()
+        {
+            var prevRom = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+
+                const uint MOJI_B = 0x42; // 'B' — no glyph yet (empty bucket)
+                uint bucket = rom.RomInfo.font_serif_address + (MOJI_B << 2);
+                Assert.Equal(0u, rom.u32(bucket));
+
+                var stub = new StubRasterizer(MakePackedTile(), width: 8);
+                string err = FontAutoGenCore.AutoGenerateGlyph(rom, stub, FileFontSpec(),
+                    "B", MOJI_B, isItemFont: false, verticalOffset: 0);
+                Assert.Equal("", err);
+
+                uint ptr = rom.u32(bucket);
+                Assert.True(U.isPointer(ptr));
+                var list = FontGlyphRenderCore.EnumerateGlyphs(rom, isItemFont: false);
+                Assert.Contains(list, g => g.Moji == MOJI_B);
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void AutoGenerateGlyph_ExistingGlyph_UndoRestoresByteIdentical()
+        {
+            var prevRom = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                byte[] before = (byte[])rom.Data.Clone();
+
+                var stub = new StubRasterizer(MakePackedTile(), width: 7);
+                var ud = NewUd(rom);
+                using (ROM.BeginUndoScope(ud))
+                {
+                    Assert.Equal("", FontAutoGenCore.AutoGenerateGlyph(rom, stub, FileFontSpec(),
+                        "A", MOJI_A, isItemFont: false, verticalOffset: 0));
+                }
+                Assert.NotEqual(before, rom.Data); // generation mutated the ROM
+                Assert.NotEmpty(ud.list);          // and recorded undo positions
+
+                RollbackReplay(rom, ud);
+                Assert.Equal(before, rom.Data);    // undo restored it byte-identical
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void AutoGenerateGlyph_NewGlyph_AppendUndoRestoresByteIdentical()
+        {
+            var prevRom = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                byte[] before = (byte[])rom.Data.Clone();
+
+                const uint MOJI_B = 0x42;
+                var stub = new StubRasterizer(MakePackedTile(), width: 8);
+                var ud = NewUd(rom);
+                using (ROM.BeginUndoScope(ud))
+                {
+                    Assert.Equal("", FontAutoGenCore.AutoGenerateGlyph(rom, stub, FileFontSpec(),
+                        "B", MOJI_B, isItemFont: false, verticalOffset: 0));
+                }
+                Assert.NotEqual(before, rom.Data);
+                Assert.NotEmpty(ud.list);
+
+                RollbackReplay(rom, ud);
+                Assert.Equal(before, rom.Data); // append + bucket repoint both undone
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void AutoGenerateGlyph_RasterizerThrows_ReturnsError_NoMutation()
+        {
+            var prevRom = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                byte[] snap = (byte[])rom.Data.Clone();
+
+                string err = FontAutoGenCore.AutoGenerateGlyph(rom, new ThrowingRasterizer(),
+                    FileFontSpec(), "A", MOJI_A, isItemFont: false, verticalOffset: 0);
+                Assert.NotEqual("", err);          // localized error, no throw
+                Assert.Equal(snap, rom.Data);      // ZERO mutation
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void AutoGenerateGlyph_NullRasterizer_ReturnsError()
+        {
+            var prevRom = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                string err = FontAutoGenCore.AutoGenerateGlyph(rom, null, FileFontSpec(),
+                    "A", MOJI_A, isItemFont: false, verticalOffset: 0);
+                Assert.NotEqual("", err);
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void AutoGenerateGlyph_NullRom_ReturnsError_NoThrow()
+        {
+            var stub = new StubRasterizer(MakePackedTile(), width: 7);
+            var ex = Record.Exception(() =>
+                FontAutoGenCore.AutoGenerateGlyph(null, stub, FileFontSpec(),
+                    "A", MOJI_A, isItemFont: false, verticalOffset: 0));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void AutoGenerateGlyph_EmptyCharacter_ReturnsError()
+        {
+            var prevRom = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                var stub = new StubRasterizer(MakePackedTile(), width: 7);
+                string err = FontAutoGenCore.AutoGenerateGlyph(rom, stub, FileFontSpec(),
+                    "", MOJI_A, isItemFont: false, verticalOffset: 0);
+                Assert.NotEqual("", err);
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void AutoGenerateGlyph_ShortRasterOutput_ReturnsError_NoMutation()
+        {
+            var prevRom = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+                byte[] snap = (byte[])rom.Data.Clone();
+
+                // A rasterizer that returns a too-short buffer (< 64 bytes).
+                var stub = new StubRasterizer(new byte[10], width: 7);
+                string err = FontAutoGenCore.AutoGenerateGlyph(rom, stub, FileFontSpec(),
+                    "A", MOJI_A, isItemFont: false, verticalOffset: 0);
+                Assert.NotEqual("", err);
+                Assert.Equal(snap, rom.Data);
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        // ---- unpack round-trip ----
+
+        [Fact]
+        public void UnpackGlyphBytes_RoundTripsPackGlyphBytes()
+        {
+            byte[] idx = new byte[16 * 16];
+            for (int y = 0; y < 16; y++)
+                for (int x = 0; x < 16; x++)
+                    idx[y * 16 + x] = (byte)((x + y) & 0x03);
+
+            byte[] packed = FontGlyphRenderCore.PackGlyphBytes(idx);
+            byte[] unpacked = FontAutoGenCore.UnpackGlyphBytes(packed);
+            Assert.Equal(idx, unpacked);
+        }
+    }
+}

--- a/FEBuilderGBA.Core/FontAutoGenCore.cs
+++ b/FEBuilderGBA.Core/FontAutoGenCore.cs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Cross-platform desktop-font auto-generation seam (#1232) — the Avalonia Font
+// editor's "Load .ttf/.otf" + Auto-Generate flow, ported GUI-free from WinForms
+// FontForm (L1105 LoadFontFromFile / L1150 AutoGenerateFont).
+//
+// WinForms FontForm rasterizes a desktop TrueType / OpenType font into a ROM
+// glyph bitmap via System.Drawing GDI (ImageUtil.AutoGenerateFont +
+// ImageUtil.Image4ToByte). This seam drives that purely through the
+// platform-neutral IFontRasterizer (#796), so the same auto-gen works on
+// Windows / Linux / macOS via FEBuilderGBA.SkiaSharp.SkiaFontRasterizer.
+//
+// The write-back reuses FontGlyphRenderCore.ImportGlyph (#1165): in-place update
+// for an existing glyph, MakeNewFontData + append + chain-link for a new one,
+// ambient undo, and byte-identical fault restore. RasterizeGlyph returns a
+// PACKED 64-byte 2bpp tile, but ImportGlyph wants a 16x16 one-index-per-pixel
+// buffer (it re-packs internally), so this helper UNPACKS the rasterizer output
+// back to 256 indices before handing it off.
+using System;
+
+namespace FEBuilderGBA.Core
+{
+    /// <summary>
+    /// GUI-free desktop-font glyph auto-generator (#1232). Rasterizes one
+    /// character from a .ttf/.otf file (or installed family) into a ROM font
+    /// glyph via the platform-neutral <see cref="IFontRasterizer"/> seam, then
+    /// writes it back through <see cref="FontGlyphRenderCore.ImportGlyph"/>
+    /// (ambient undo + byte-identical fault restore). Never throws.
+    /// </summary>
+    public static class FontAutoGenCore
+    {
+        /// <summary>
+        /// Rasterize <paramref name="character"/> with <paramref name="rasterizer"/>
+        /// /<paramref name="font"/> and write the resulting 16x16 glyph into the
+        /// item (true) or serif (false) font for the engine character code
+        /// <paramref name="moji"/>.
+        ///
+        /// Runs under the caller's ambient undo scope: an existing glyph is
+        /// updated in place; a new one is appended + chain-linked. On any fault
+        /// the ROM is restored byte-identical (delegated to
+        /// <see cref="FontGlyphRenderCore.ImportGlyph"/>). The rasterizer's
+        /// reported advance width is preserved (passed as the explicit width so
+        /// it is not re-derived from the pixels).
+        /// </summary>
+        /// <param name="rom">Target ROM (mutated on success).</param>
+        /// <param name="rasterizer">The desktop-font rasterizer (the Avalonia
+        /// layer supplies a SkiaSharp implementation; tests inject a stub).</param>
+        /// <param name="font">Typeface / size selector (see <see cref="FontSpec"/>;
+        /// a <c>FontFilePath</c> loads a .ttf/.otf file).</param>
+        /// <param name="character">The single character to rasterize (a 1-length
+        /// string; surrogate pairs pass whole).</param>
+        /// <param name="moji">The engine character code of the target glyph slot
+        /// (from the editor's selected list row).</param>
+        /// <param name="isItemFont">Item-font (true) vs serif/text-font (false).</param>
+        /// <param name="verticalOffset">Extra vertical pixel shift forwarded to
+        /// the rasterizer (WF <c>V.Offset</c>).</param>
+        /// <returns><c>""</c> on success, or a localized error string. Never
+        /// throws and never leaves a partial mutation.</returns>
+        public static string AutoGenerateGlyph(ROM rom, IFontRasterizer rasterizer,
+            FontSpec font, string character, uint moji, bool isItemFont, int verticalOffset)
+        {
+            if (rom?.RomInfo == null) return R._("ROM is not loaded.");
+            if (rasterizer == null) return R._("No font rasterizer is available.");
+            if (string.IsNullOrEmpty(character)) return R._("No character to generate.");
+
+            // Rasterize the glyph into a packed 64-byte 2bpp tile. A rasterizer
+            // fault must never throw out of here — convert to a localized error so
+            // the never-throws contract holds (nothing has been written yet).
+            byte[] packed;
+            int glyphWidth;
+            try
+            {
+                packed = rasterizer.RasterizeGlyph(font, character, isItemFont,
+                    verticalOffset, out glyphWidth);
+            }
+            catch (Exception ex)
+            {
+                return R._("Font auto-generation failed: {0}", ex.Message);
+            }
+
+            if (packed == null || packed.Length < FontGlyphRenderCore.GLYPH_BITMAP_BYTES)
+                return R._("Font auto-generation produced no glyph data.");
+
+            // Unpack the 64-byte 2bpp tile (4 px/byte, low 2 bits = leftmost) to a
+            // 16x16 one-index-per-pixel buffer, which ImportGlyph re-packs.
+            byte[] indexedPixels = UnpackGlyphBytes(packed);
+
+            // ImportGlyph owns the snapshot/restore + ambient undo. Pass the
+            // rasterizer's advance width explicitly so the auto-gen width wins
+            // (>= 0 => the supplied value is used, not re-derived from pixels).
+            return FontGlyphRenderCore.ImportGlyph(rom, isItemFont, moji, indexedPixels,
+                FontGlyphRenderCore.GLYPH_W, FontGlyphRenderCore.GLYPH_H,
+                explicitWidth: glyphWidth, manageSnapshot: true);
+        }
+
+        /// <summary>
+        /// Unpack a 64-byte 2bpp font tile into a 16x16 one-index-per-pixel buffer
+        /// (row-major, 1 byte/pixel, values 0..3). Inverse of
+        /// <see cref="FontGlyphRenderCore.PackGlyphBytes"/> / WF Image4ToByte:
+        /// 4 horizontal pixels per byte, low 2 bits = leftmost.
+        /// </summary>
+        public static byte[] UnpackGlyphBytes(byte[] packed)
+        {
+            int w = FontGlyphRenderCore.GLYPH_W;
+            int h = FontGlyphRenderCore.GLYPH_H;
+            byte[] idx = new byte[w * h];
+            if (packed == null) return idx;
+
+            int x = 0, y = 0;
+            for (int i = 0; i < FontGlyphRenderCore.GLYPH_BITMAP_BYTES && i < packed.Length; i++)
+            {
+                byte a = packed[i];
+                for (int sub = 0; sub < 4; sub++)
+                {
+                    int px = x + sub;
+                    if (px < w && y < h)
+                        idx[y * w + px] = (byte)((a >> (sub * 2)) & 0x03);
+                }
+                x += 4;
+                if (x >= w) { x = 0; y++; }
+            }
+            return idx;
+        }
+    }
+}

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11532,3 +11532,21 @@ GIF出力
 
 :Auto-generate failed: {0}
 自動生成に失敗しました: {0}
+
+:Auto-Generate from Font
+フォントから自動生成
+
+:Load .ttf/.otf
+.ttf/.otfを読み込む
+
+:Family:
+フォント名:
+
+:Vertical Offset:
+垂直オフセット:
+
+:Auto-Generate
+自動生成
+
+:Used only when no .ttf/.otf file is loaded.
+.ttf/.otfファイルを読み込んでいない場合のみ使用されます。

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11505,3 +11505,30 @@ GIF出力
 
 :Animation script imported successfully.
 アニメスクリプトを読み込みました。
+
+:No font rasterizer is available.
+フォントラスタライザーが利用できません。
+
+:No character to generate.
+生成する文字がありません。
+
+:Font auto-generation failed: {0}
+フォントの自動生成に失敗しました: {0}
+
+:Font auto-generation produced no glyph data.
+フォントの自動生成でグリフデータが生成されませんでした。
+
+:Load Font File
+フォントファイルを読み込む
+
+:Load failed: {0}
+読み込みに失敗しました: {0}
+
+:This glyph has no renderable character.
+このグリフには描画可能な文字がありません。
+
+:Glyph generated successfully.
+グリフを生成しました。
+
+:Auto-generate failed: {0}
+自動生成に失敗しました: {0}

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25346,3 +25346,30 @@ TSA数量: {0}
 
 :Animation script imported successfully.
 动画脚本导入成功。
+
+:No font rasterizer is available.
+字体光栅化器不可用。
+
+:No character to generate.
+没有要生成的字符。
+
+:Font auto-generation failed: {0}
+字体自动生成失败：{0}
+
+:Font auto-generation produced no glyph data.
+字体自动生成未产生字形数据。
+
+:Load Font File
+加载字体文件
+
+:Load failed: {0}
+加载失败：{0}
+
+:This glyph has no renderable character.
+此字形没有可渲染的字符。
+
+:Glyph generated successfully.
+字形生成成功。
+
+:Auto-generate failed: {0}
+自动生成失败：{0}

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25373,3 +25373,21 @@ TSA数量: {0}
 
 :Auto-generate failed: {0}
 自动生成失败：{0}
+
+:Auto-Generate from Font
+从字体自动生成
+
+:Load .ttf/.otf
+加载 .ttf/.otf
+
+:Family:
+字体名称:
+
+:Vertical Offset:
+垂直偏移:
+
+:Auto-Generate
+自动生成
+
+:Used only when no .ttf/.otf file is loaded.
+仅在未加载 .ttf/.otf 文件时使用。


### PR DESCRIPTION
Fixes #1232.

Follow-up to #1165 (Avalonia Font editor) — ports the deferred **`.ttf`/`.otf` auto-generation** subsystem (WinForms `ImageUtil.AutoGenerateFont` / `LoadFontFromFile`): rasterize a desktop font's glyphs INTO the ROM font bitmaps.

## What
- New **"Auto-Generate from Font"** section in the Font editor: **Load .ttf/.otf** (file picker) + **Clear**, a **Family** field (installed-font name), **Size**, a **Vertical Offset** field (WF `V.Offset`), and an **Auto-Generate** button that rasterizes the selected glyph's character into the ROM slot and re-renders the preview.

## How (architecture — mostly wiring; the seams already existed)
- New **`FEBuilderGBA.Core/FontAutoGenCore.AutoGenerateGlyph`** (GUI-free): `RasterizeGlyph` (existing `IFontRasterizer` seam) → **unpack the packed 64-byte 2bpp tile to a 256-index buffer** → `FontGlyphRenderCore.ImportGlyph(explicitWidth = rasterizer width, manageSnapshot = true)`. Never throws (rasterizer faults → localized error, zero mutation).
- Reuses the cross-platform `SkiaFontRasterizer` (already wired for `ToolTranslateROMCore.ImportFonts`) + `FontSpec` (`FontFilePath`/`FamilyName`/`Size`) + the #1165 `ImportGlyph` write-back (ambient undo + byte-identical fault restore).
- The character is derived from the selected row's decoded label; an undecodable `@hex` glyph yields a clear "no renderable character" error rather than rasterizing garbage.

## Tests / gates (all green locally)
- `FontAutoGenCoreTests` — **13** Core tests with a STUB `IFontRasterizer` (asymmetric known pixels → proves the 64→256 unpack convention; in-place + new-glyph **undo-restores-byte-identical** round-trips). Core.Tests stays SkiaSharp-free.
- Core.Tests `~Font|~AvaloniaScrollViewer`: **93 passed**. FEBuilderGBA.Tests `~Avalonia|~AutomationId`: **793 passed**. `validate-automation-ids.ps1`: **0 errors, 0 warnings**. Dark-mode: 0 hex literals (named `Gray`).

## Proof (FE8U — Font editor, Item Font)
New **Auto-Generate from Font** section (Load .ttf/.otf · Clear · Family · Size · Vertical Offset · Auto-Generate):

<img width="640" src="https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1232-font-autogen-fe8u.png">

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 4.8 (1M context), model `claude-opus-4-8[1m]`