### PR TITLE
feat(avalonia): implement Add-via-ASM/C tool (#1169)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ToolASMInsertViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ToolASMInsertViewModelTests.cs
@@ -1,0 +1,93 @@
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// Unit tests for <see cref="ToolASMInsertViewModel"/>, the form-field holder for
+    /// the Avalonia "Add-via-ASM/C" tool. The compile/insert work itself lives in the
+    /// GUI-free Core helper <c>AsmCompileCore</c> (covered by AsmCompileCoreTests and
+    /// NOT re-run here — devkitARM is not built in CI). These tests cover the VM's
+    /// pure field-mapping logic: the index→enum projection, the WF-default indices,
+    /// and the hex address parser.
+    /// </summary>
+    public class ToolASMInsertViewModelTests
+    {
+        [Fact]
+        public void Defaults_MirrorWinFormsCtorIndices()
+        {
+            var vm = new ToolASMInsertViewModel();
+
+            Assert.Equal(0, vm.CompileMethodIndex);              // dump binary
+            Assert.Equal(0, vm.InsertMethodIndex);               // compile-only
+            Assert.Equal(3, vm.HookRegisterIndex);               // r3 (WF default)
+            Assert.Equal(3, vm.DebugSymbolIndex);                // Save both (WF default)
+            Assert.True(vm.CheckMissingLabel);                   // on (WF default)
+            Assert.False(vm.CanUndo);
+            Assert.Equal("", vm.SourcePath);
+        }
+
+        [Theory]
+        [InlineData(0, AsmCompileCore.CompileMethod.DumpBinary)]
+        [InlineData(1, AsmCompileCore.CompileMethod.KeepElf)]
+        [InlineData(2, AsmCompileCore.CompileMethod.ConvertLyn)]
+        public void CompileMethod_MapsFromIndex(int idx, AsmCompileCore.CompileMethod expected)
+        {
+            var vm = new ToolASMInsertViewModel { CompileMethodIndex = idx };
+            Assert.Equal(expected, vm.CompileMethod);
+        }
+
+        [Theory]
+        [InlineData(0, AsmCompileCore.InsertMethod.CompileOnly)]
+        [InlineData(1, AsmCompileCore.InsertMethod.WriteAtAddress)]
+        [InlineData(2, AsmCompileCore.InsertMethod.HookInject)]
+        public void InsertMethod_MapsFromIndex(int idx, AsmCompileCore.InsertMethod expected)
+        {
+            var vm = new ToolASMInsertViewModel { InsertMethodIndex = idx };
+            Assert.Equal(expected, vm.InsertMethod);
+        }
+
+        [Theory]
+        [InlineData(0, SymbolUtil.DebugSymbol.None)]
+        [InlineData(1, SymbolUtil.DebugSymbol.SaveSymTxt)]
+        public void StoreSymbol_MapsFromIndex(int idx, SymbolUtil.DebugSymbol expected)
+        {
+            var vm = new ToolASMInsertViewModel { DebugSymbolIndex = idx };
+            Assert.Equal(expected, vm.StoreSymbol);
+        }
+
+        [Theory]
+        [InlineData("0x08000000", 0x08000000u)]
+        [InlineData("08000000", 0x08000000u)]
+        [InlineData("0X100", 0x100u)]
+        [InlineData("  0x1F ", 0x1Fu)]
+        [InlineData("", 0u)]
+        [InlineData("   ", 0u)]
+        [InlineData("not-hex", 0u)]
+        public void ParseHex_ReadsHexAddresses(string text, uint expected)
+        {
+            Assert.Equal(expected, ToolASMInsertViewModel.ParseHex(text));
+        }
+
+        [Theory]
+        [InlineData(0, 0u)]
+        [InlineData(3, 3u)]
+        [InlineData(8, 8u)]
+        public void HookRegister_ClampedFromIndex(int idx, uint expected)
+        {
+            var vm = new ToolASMInsertViewModel { HookRegisterIndex = idx };
+            Assert.Equal(expected, vm.HookRegister);
+        }
+
+        [Fact]
+        public void SourceExists_FalseForBlankOrMissingPath()
+        {
+            var vm = new ToolASMInsertViewModel();
+            Assert.False(vm.SourceExists);
+
+            vm.SourcePath = "Z:\\does\\not\\exist\\foo.s";
+            Assert.False(vm.SourceExists);
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/ToolASMInsertViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ToolASMInsertViewModelTests.cs
@@ -57,6 +57,35 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.Equal(expected, vm.StoreSymbol);
         }
 
+        // Copilot #2: a ComboBox reports -1 (no selection) and could be out of range;
+        // the index→enum casts must clamp to a defined enum, not produce garbage.
+        [Theory]
+        [InlineData(-1)]   // no selection
+        [InlineData(99)]   // out of range
+        public void EnumProjections_ClampOutOfRangeIndices_ToDefinedEnums(int badIdx)
+        {
+            var vm = new ToolASMInsertViewModel
+            {
+                CompileMethodIndex = badIdx,
+                InsertMethodIndex = badIdx,
+                DebugSymbolIndex = badIdx,
+                HookRegisterIndex = badIdx,
+            };
+
+            Assert.True(System.Enum.IsDefined(typeof(AsmCompileCore.CompileMethod), vm.CompileMethod));
+            Assert.True(System.Enum.IsDefined(typeof(AsmCompileCore.InsertMethod), vm.InsertMethod));
+            Assert.True(System.Enum.IsDefined(typeof(SymbolUtil.DebugSymbol), vm.StoreSymbol));
+            Assert.InRange(vm.HookRegister, 0u, 8u);
+
+            // -1 must default to the first (safe) item; 99 clamps to the max.
+            if (badIdx < 0)
+            {
+                Assert.Equal(AsmCompileCore.CompileMethod.DumpBinary, vm.CompileMethod);
+                Assert.Equal(AsmCompileCore.InsertMethod.CompileOnly, vm.InsertMethod);
+                Assert.Equal(SymbolUtil.DebugSymbol.None, vm.StoreSymbol);
+            }
+        }
+
         [Theory]
         [InlineData("0x08000000", 0x08000000u)]
         [InlineData("08000000", 0x08000000u)]

--- a/FEBuilderGBA.Avalonia/ViewModels/ToolASMInsertViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ToolASMInsertViewModel.cs
@@ -1,33 +1,117 @@
 using System;
-using System.Collections.Generic;
+using System.IO;
 
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
+    /// <summary>
+    /// ViewModel for the Avalonia "Add-via-ASM/C" tool (WF
+    /// <c>ToolASMInsertForm</c>). Compiles a C/C++/ASM source through the devkitARM
+    /// chain (gcc/g++/as → ELF → raw binary, or lyn → EA event) and inserts the
+    /// result into the ROM via one of three methods (write-at-address, hook-inject,
+    /// or compile-only).
+    ///
+    /// The actual compile+insert work lives in the GUI-free Core helper
+    /// <see cref="AsmCompileCore"/>. This VM only holds the form fields and forwards
+    /// to that helper. It reads no ROM bytes for display (it only WRITES via the
+    /// helper) so it is a read-no-ROM tool VM (no data-verification contract).
+    ///
+    /// Scope: the GoldRoad assembler path and the "Make Patch" text generator are
+    /// deferred to a follow-up (both WinForms-coupled); the devkitARM compile +
+    /// the three insert methods are the parity surface here.
+    /// </summary>
     public class ToolASMInsertViewModel : ViewModelBase
     {
-        uint _currentAddr;
-        bool _isLoaded;
+        string _sourcePath = "";
+        int _compileMethodIndex;            // 0 DumpBinary, 1 KeepElf, 2 ConvertLyn
+        int _insertMethodIndex;             // 0 CompileOnly, 1 WriteAtAddress, 2 HookInject
+        string _addressHex = "0x00000000";
+        string _freeAreaHex = "0x00000000";
+        int _hookRegisterIndex = 3;         // WF ctor: HookRegister.SelectedIndex = 3 (r3)
+        int _debugSymbolIndex = 3;          // WF ctor: DebugSymbolComboBox.SelectedIndex = 3 (SaveBoth)
+        bool _checkMissingLabel = true;     // WF ctor: CheckMissingLabelComboBox.SelectedIndex = 1 (on)
+        bool _canUndo;
+        string _statusMessage = "";
 
-        public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
-        public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
+        /// <summary>Selected C/C++/ASM source file to compile and insert.</summary>
+        public string SourcePath { get => _sourcePath; set => SetField(ref _sourcePath, value); }
 
-        public List<AddrResult> LoadList()
+        /// <summary>Compile method index: 0 = dump binary, 1 = keep ELF, 2 = convert to lyn.event.</summary>
+        public int CompileMethodIndex { get => _compileMethodIndex; set => SetField(ref _compileMethodIndex, value); }
+
+        /// <summary>Insert method index: 0 = compile-only, 1 = write at address, 2 = hook-inject.</summary>
+        public int InsertMethodIndex { get => _insertMethodIndex; set => SetField(ref _insertMethodIndex, value); }
+
+        /// <summary>Target address (hex), used by write-at-address and hook-inject.</summary>
+        public string AddressHex { get => _addressHex; set => SetField(ref _addressHex, value); }
+
+        /// <summary>Free-area address (hex), used by hook-inject for the routine body.</summary>
+        public string FreeAreaHex { get => _freeAreaHex; set => SetField(ref _freeAreaHex, value); }
+
+        /// <summary>Hook register index (r0..r8) for the injected thumb jump.</summary>
+        public int HookRegisterIndex { get => _hookRegisterIndex; set => SetField(ref _hookRegisterIndex, value); }
+
+        /// <summary>Debug-symbol store index (maps to <c>SymbolUtil.DebugSymbol</c>).</summary>
+        public int DebugSymbolIndex { get => _debugSymbolIndex; set => SetField(ref _debugSymbolIndex, value); }
+
+        /// <summary>When true, a reference to a missing label aborts the compile (WF check).</summary>
+        public bool CheckMissingLabel { get => _checkMissingLabel; set => SetField(ref _checkMissingLabel, value); }
+
+        /// <summary>True when an applied insert can be undone.</summary>
+        public bool CanUndo { get => _canUndo; set => SetField(ref _canUndo, value); }
+
+        /// <summary>Result / error text shown in the status area.</summary>
+        public string StatusMessage { get => _statusMessage; set => SetField(ref _statusMessage, value); }
+
+        /// <summary>The selected compile method for the Core helper.</summary>
+        public AsmCompileCore.CompileMethod CompileMethod =>
+            (AsmCompileCore.CompileMethod)_compileMethodIndex;
+
+        /// <summary>The selected insert method for the Core helper.</summary>
+        public AsmCompileCore.InsertMethod InsertMethod =>
+            (AsmCompileCore.InsertMethod)_insertMethodIndex;
+
+        /// <summary>The selected debug-symbol store for the Core helper.</summary>
+        public SymbolUtil.DebugSymbol StoreSymbol =>
+            (SymbolUtil.DebugSymbol)_debugSymbolIndex;
+
+        /// <summary>True when the devkitARM EABI tool path is configured and exists.</summary>
+        public bool IsDevkitProAvailable => AsmCompileCore.IsDevkitProAvailable();
+
+        /// <summary>Localized "devkitpro_eabi not configured" message (for the UI).</summary>
+        public string NotFoundMessage => AsmCompileCore.GetNotFoundMessage();
+
+        /// <summary>True when the selected source file exists on disk.</summary>
+        public bool SourceExists => !string.IsNullOrEmpty(SourcePath) && File.Exists(SourcePath);
+
+        /// <summary>
+        /// Parse a hex address field. Accepts "0x..." or bare hex; returns 0 on a
+        /// blank/invalid value (the WF NumericUpDown defaults to 0).
+        /// </summary>
+        public static uint ParseHex(string text)
         {
-            ROM rom = CoreState.ROM;
-            if (rom?.RomInfo == null) return new List<AddrResult>();
-
-            var result = new List<AddrResult>();
-            result.Add(new AddrResult(0, "ASM Insertion Tool", 0));
-            return result;
+            if (string.IsNullOrWhiteSpace(text)) return 0;
+            string s = text.Trim();
+            if (s.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                s = s.Substring(2);
+            return uint.TryParse(s, System.Globalization.NumberStyles.HexNumber,
+                System.Globalization.CultureInfo.InvariantCulture, out uint v) ? v : 0u;
         }
 
-        public void LoadEntry(uint addr)
+        /// <summary>The hook register value (r0..r8) from the selected index.</summary>
+        public uint HookRegister => AsmCompileCore.ClampHookRegister((uint)Math.Max(0, _hookRegisterIndex));
+
+        /// <summary>
+        /// Compile and insert <see cref="SourcePath"/> using the shared Core helper.
+        /// The caller owns the undo scope and passes its active <c>Undo.UndoData</c>.
+        /// </summary>
+        public AsmCompileCore.CompileResult Run(Undo.UndoData undo)
         {
             ROM rom = CoreState.ROM;
-            if (rom == null) return;
-
-            CurrentAddr = addr;
-            IsLoaded = true;
+            uint addr = U.toOffset(ParseHex(AddressHex));
+            uint freeArea = U.toOffset(ParseHex(FreeAreaHex));
+            return AsmCompileCore.CompileAndInsert(
+                rom, SourcePath, CompileMethod, InsertMethod,
+                addr, freeArea, HookRegister, StoreSymbol, CheckMissingLabel, undo);
         }
     }
 }

--- a/FEBuilderGBA.Avalonia/ViewModels/ToolASMInsertViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ToolASMInsertViewModel.cs
@@ -62,17 +62,25 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// <summary>Result / error text shown in the status area.</summary>
         public string StatusMessage { get => _statusMessage; set => SetField(ref _statusMessage, value); }
 
+        /// <summary>
+        /// Clamp a ComboBox SelectedIndex into [0, max] before casting to an enum: a
+        /// ComboBox reports -1 when nothing is selected (e.g. mid-rebind), and a stray
+        /// out-of-range value would cast to an undefined enum. Defaults to 0 (the first,
+        /// safe item) in those cases.
+        /// </summary>
+        static int ClampIndex(int index, int max) => index < 0 ? 0 : (index > max ? max : index);
+
         /// <summary>The selected compile method for the Core helper.</summary>
         public AsmCompileCore.CompileMethod CompileMethod =>
-            (AsmCompileCore.CompileMethod)_compileMethodIndex;
+            (AsmCompileCore.CompileMethod)ClampIndex(_compileMethodIndex, 2);
 
         /// <summary>The selected insert method for the Core helper.</summary>
         public AsmCompileCore.InsertMethod InsertMethod =>
-            (AsmCompileCore.InsertMethod)_insertMethodIndex;
+            (AsmCompileCore.InsertMethod)ClampIndex(_insertMethodIndex, 2);
 
         /// <summary>The selected debug-symbol store for the Core helper.</summary>
         public SymbolUtil.DebugSymbol StoreSymbol =>
-            (SymbolUtil.DebugSymbol)_debugSymbolIndex;
+            (SymbolUtil.DebugSymbol)ClampIndex(_debugSymbolIndex, 3);
 
         /// <summary>True when the devkitARM EABI tool path is configured and exists.</summary>
         public bool IsDevkitProAvailable => AsmCompileCore.IsDevkitProAvailable();

--- a/FEBuilderGBA.Avalonia/Views/ToolASMInsertView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolASMInsertView.axaml
@@ -1,21 +1,123 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
         x:Class="FEBuilderGBA.Avalonia.Views.ToolASMInsertView"
-        Title="ASM Insertion Tool" Width="825" Height="497"
+        Title="Add via ASM/C" Width="640" Height="600"
+        WindowStartupLocation="CenterOwner"
         SizeToContent="WidthAndHeight">
-  <Grid ColumnDefinitions="250,*">
-    <controls:AddressListControl AutomationProperties.AutomationId="ToolASMInsert_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
+  <!-- Add-via-ASM/C tool (WF ToolASMInsertForm). Compiles a C/C++/ASM source via
+       the devkitARM chain (gcc/g++/as -> ELF -> raw binary, or lyn -> EA event) and
+       inserts the result into the ROM. Three insert methods: compile-only (make file
+       only), write-at-address, and hook-inject (write the routine to a free area and
+       patch a thumb jump at a hook address). The compile+insert work runs in the
+       GUI-free Core helper AsmCompileCore. The compile-method / insert-method /
+       hook-register / debug-symbol combo items are populated in code-behind via R._()
+       so they pick up ja/zh translations (ViewTranslationHelper does not translate
+       ComboBoxItem content).
+       Deferred to a follow-up: the GoldRoad assembler path and the "Make Patch" text
+       generator (both WinForms-coupled); revert an applied insert via Undo for now. -->
+  <ScrollViewer VerticalScrollBarVisibility="Auto">
+    <StackPanel Margin="16" Spacing="10">
 
-    <ScrollViewer Grid.Column="1" Margin="4">
-      <StackPanel Spacing="8" Margin="8">
-        <TextBlock Text="ASM Insertion Tool" FontSize="18" FontWeight="Bold" />
+      <TextBlock Text="Add via ASM/C" FontSize="18" FontWeight="Bold" />
+      <TextBlock Text="Compile a C/C++/ASM source and insert the result into the ROM."
+                 TextWrapping="Wrap" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="ToolASMInsert_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
-        </Grid>
+      <!-- Source .c/.cpp/.s/.asm file -->
+      <TextBlock Text="Source file:" FontWeight="SemiBold" Margin="0,6,0,0" />
+      <Grid ColumnDefinitions="*,Auto">
+        <TextBox AutomationProperties.AutomationId="ToolASMInsert_Source_Input"
+                 Grid.Column="0" Name="SourceBox"
+                 Text="{Binding SourcePath}"
+                 Watermark="Select a .c / .cpp / .s / .asm file" />
+        <Button AutomationProperties.AutomationId="ToolASMInsert_Browse_Button"
+                Grid.Column="1" Content="Browse..." Margin="6,0,0,0"
+                Click="Browse_Click" />
+      </Grid>
+
+      <!-- Compile method (ELF dump / keep ELF / convert to lyn.event) -->
+      <Grid ColumnDefinitions="180,*" Margin="0,6,0,0">
+        <TextBlock Grid.Column="0" Text="Compile method:" VerticalAlignment="Center" />
+        <ComboBox AutomationProperties.AutomationId="ToolASMInsert_CompileMethod_Combo"
+                  Grid.Column="1" Name="CompileMethodCombo"
+                  HorizontalAlignment="Stretch"
+                  SelectedIndex="{Binding CompileMethodIndex}" />
+      </Grid>
+
+      <!-- Insert method (compile-only / write-at-address / hook-inject) -->
+      <Grid ColumnDefinitions="180,*">
+        <TextBlock Grid.Column="0" Text="Insert method:" VerticalAlignment="Center" />
+        <ComboBox AutomationProperties.AutomationId="ToolASMInsert_InsertMethod_Combo"
+                  Grid.Column="1" Name="InsertMethodCombo"
+                  HorizontalAlignment="Stretch"
+                  SelectedIndex="{Binding InsertMethodIndex}"
+                  SelectionChanged="InsertMethod_SelectionChanged" />
+      </Grid>
+
+      <!-- Target address (write-at-address: destination; hook-inject: hook site) -->
+      <Grid ColumnDefinitions="180,*" Name="AddressRow">
+        <TextBlock AutomationProperties.AutomationId="ToolASMInsert_Address_Label"
+                   Grid.Column="0" Name="AddressLabel" Text="Address:" VerticalAlignment="Center" />
+        <TextBox AutomationProperties.AutomationId="ToolASMInsert_Address_Input"
+                 Grid.Column="1" Name="AddressBox"
+                 Text="{Binding AddressHex}"
+                 Watermark="0x08000000" />
+      </Grid>
+
+      <!-- Free area (hook-inject only: where the routine body is written) -->
+      <Grid ColumnDefinitions="180,*" Name="FreeAreaRow">
+        <TextBlock Grid.Column="0" Text="Free area:" VerticalAlignment="Center" />
+        <TextBox AutomationProperties.AutomationId="ToolASMInsert_FreeArea_Input"
+                 Grid.Column="1" Name="FreeAreaBox"
+                 Text="{Binding FreeAreaHex}"
+                 Watermark="0x08F00000" />
+      </Grid>
+
+      <!-- Hook register (hook-inject only) -->
+      <Grid ColumnDefinitions="180,*" Name="HookRegisterRow">
+        <TextBlock Grid.Column="0" Text="Hook register:" VerticalAlignment="Center" />
+        <ComboBox AutomationProperties.AutomationId="ToolASMInsert_HookRegister_Combo"
+                  Grid.Column="1" Name="HookRegisterCombo"
+                  HorizontalAlignment="Stretch"
+                  SelectedIndex="{Binding HookRegisterIndex}" />
+      </Grid>
+
+      <!-- Debug-symbol store -->
+      <Grid ColumnDefinitions="180,*">
+        <TextBlock Grid.Column="0" Text="Store debug symbols:" VerticalAlignment="Center" />
+        <ComboBox AutomationProperties.AutomationId="ToolASMInsert_DebugSymbol_Combo"
+                  Grid.Column="1" Name="DebugSymbolCombo"
+                  HorizontalAlignment="Stretch"
+                  SelectedIndex="{Binding DebugSymbolIndex}" />
+      </Grid>
+
+      <!-- Missing-label check -->
+      <CheckBox AutomationProperties.AutomationId="ToolASMInsert_CheckMissingLabel_Check"
+                Name="CheckMissingLabelCheck"
+                Content="Stop on a reference to a missing label"
+                IsChecked="{Binding CheckMissingLabel}" Margin="0,6,0,0" />
+
+      <!-- Actions -->
+      <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
+        <Button AutomationProperties.AutomationId="ToolASMInsert_Run_Button"
+                Name="RunButton" Content="Run (compile + insert)"
+                Click="Run_Click" />
+        <Button AutomationProperties.AutomationId="ToolASMInsert_Undo_Button"
+                Name="UndoButton" Content="Undo"
+                IsVisible="{Binding CanUndo}"
+                Click="Undo_Click" />
       </StackPanel>
-    </ScrollViewer>
-  </Grid>
+
+      <!-- Status / result -->
+      <Border BorderBrush="Gray" BorderThickness="1" CornerRadius="4"
+              Padding="8" Margin="0,8,0,0" MinHeight="120">
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+          <SelectableTextBlock AutomationProperties.AutomationId="ToolASMInsert_Status_Label"
+                               Name="StatusText"
+                               Text="{Binding StatusMessage}"
+                               TextWrapping="Wrap" FontFamily="Consolas,monospace" />
+        </ScrollViewer>
+      </Border>
+
+    </StackPanel>
+  </ScrollViewer>
 </Window>

--- a/FEBuilderGBA.Avalonia/Views/ToolASMInsertView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolASMInsertView.axaml.cs
@@ -1,57 +1,234 @@
 using System;
+using System.Threading.Tasks;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
+using global::Avalonia.Platform.Storage;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
+    /// <summary>
+    /// Add-via-ASM/C tool (WF <c>ToolASMInsertForm</c>). Compiles a C/C++/ASM source
+    /// through the devkitARM chain and inserts the result into the ROM via the
+    /// GUI-free Core helper <see cref="AsmCompileCore"/>, with a compile method
+    /// (dump binary / keep ELF / convert to lyn.event), an insert method
+    /// (compile-only / write-at-address / hook-inject), a hook register, a
+    /// debug-symbol store choice, a missing-label check and undo.
+    ///
+    /// Combo items are added in code via R._() so they pick up ja/zh translations
+    /// (ViewTranslationHelper does not translate ComboBoxItem content).
+    ///
+    /// The GoldRoad assembler path and the "Make Patch" text generator are deferred
+    /// to a follow-up issue (both WinForms-coupled); an applied insert can be
+    /// reverted via Undo for now.
+    /// </summary>
     public partial class ToolASMInsertView : TranslatedWindow, IEditorView
     {
         readonly ToolASMInsertViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
-        public string ViewTitle => "ASM Insertion Tool";
-        public bool IsLoaded => _vm.IsLoaded;
+        public string ViewTitle => "Add via ASM/C";
+        public bool IsLoaded => true;
 
         public ToolASMInsertView()
         {
             InitializeComponent();
-            EntryList.SelectedAddressChanged += OnSelected;
-            Opened += (_, _) => LoadList();
+            DataContext = _vm;
+
+            // Compile methods (mirror WF ELFComboBox; default index 0 = dump binary).
+            CompileMethodCombo.Items.Add(R._("ELF -> raw binary (delete ELF)"));
+            CompileMethodCombo.Items.Add(R._("ELF -> raw binary (keep ELF)"));
+            CompileMethodCombo.Items.Add(R._("Convert to lyn.event (compile-only)"));
+
+            // Insert methods (mirror WF Method combo; default index 0 = compile-only).
+            InsertMethodCombo.Items.Add(R._("Make file only (do not write to the ROM)"));
+            InsertMethodCombo.Items.Add(R._("Write at the address"));
+            InsertMethodCombo.Items.Add(R._("Hook the address (jump to a free area)"));
+
+            // Hook registers r0..r8 (mirror WF HookRegister; default index 3 = r3).
+            for (int i = 0; i <= 8; i++)
+                HookRegisterCombo.Items.Add("r" + i);
+
+            // Debug-symbol store (mirror WF DebugSymbolComboBox; default index 3).
+            DebugSymbolCombo.Items.Add(R._("None"));
+            DebugSymbolCombo.Items.Add(R._("Save sym.txt"));
+            DebugSymbolCombo.Items.Add(R._("Save as comment"));
+            DebugSymbolCombo.Items.Add(R._("Save both"));
+
+            CompileMethodCombo.SelectedIndex = _vm.CompileMethodIndex;
+            InsertMethodCombo.SelectedIndex = _vm.InsertMethodIndex;
+            HookRegisterCombo.SelectedIndex = _vm.HookRegisterIndex;
+            DebugSymbolCombo.SelectedIndex = _vm.DebugSymbolIndex;
+
+            UpdateInsertMethodVisibility();
+
+            Opened += (_, _) =>
+            {
+                // Surface a clear message up front if devkitARM is not configured.
+                if (!_vm.IsDevkitProAvailable)
+                    _vm.StatusMessage = _vm.NotFoundMessage;
+            };
         }
 
-        void LoadList()
+        /// <summary>
+        /// Show/hide the address / free-area / hook-register rows per the insert
+        /// method (mirrors WF <c>Method_SelectedIndexChanged</c>):
+        ///   0 compile-only → none; 1 write-at-address → address only;
+        ///   2 hook-inject → address (hook site) + free area + hook register.
+        /// </summary>
+        void UpdateInsertMethodVisibility()
         {
+            int idx = InsertMethodCombo.SelectedIndex;
+            bool isWrite = idx == 1;
+            bool isHook = idx == 2;
+
+            AddressRow.IsVisible = isWrite || isHook;
+            FreeAreaRow.IsVisible = isHook;
+            HookRegisterRow.IsVisible = isHook;
+
+            AddressLabel.Text = isHook ? R._("Hook address:") : R._("Write to:");
+        }
+
+        void InsertMethod_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            UpdateInsertMethodVisibility();
+        }
+
+        async void Browse_Click(object? sender, RoutedEventArgs e)
+        {
+            await BrowseForSourceAsync();
+        }
+
+        /// <summary>
+        /// Show the source picker and store the chosen path on the VM. Returns true
+        /// if the user picked a usable file. Awaitable so Run can pick-then-continue
+        /// in the same invocation (mirrors WF RunButton/AllowDropFilename).
+        /// </summary>
+        async Task<bool> BrowseForSourceAsync()
+        {
+            var storage = GetTopLevel(this)?.StorageProvider;
+            if (storage == null) return false;
+
             try
             {
-                var items = _vm.LoadList();
-                EntryList.SetItems(items);
+                var files = await storage.OpenFilePickerAsync(new FilePickerOpenOptions
+                {
+                    Title = R._("Please select a source file to import."),
+                    AllowMultiple = false,
+                    FileTypeFilter = new[]
+                    {
+                        new FilePickerFileType(R._("source file"))
+                            { Patterns = new[] { "*.c", "*.cpp", "*.s", "*.asm" } },
+                        new FilePickerFileType("asm") { Patterns = new[] { "*.s", "*.asm" } },
+                        new FilePickerFileType("c") { Patterns = new[] { "*.c", "*.cpp" } },
+                        new FilePickerFileType(R._("All Files")) { Patterns = new[] { "*" } },
+                    }
+                });
+
+                if (files.Count > 0)
+                {
+                    string? path = files[0].TryGetLocalPath();
+                    if (!string.IsNullOrEmpty(path))
+                    {
+                        _vm.SourcePath = path;
+                        return true;
+                    }
+                }
             }
             catch (Exception ex)
             {
-                Log.Error("ToolASMInsertView.LoadList failed: {0}", ex.Message);
+                Log.Error("ToolASMInsertView.Browse failed: " + ex.ToString());
+                _vm.StatusMessage = ex.Message;
             }
+            return false;
         }
 
-        void OnSelected(uint addr)
+        async void Run_Click(object? sender, RoutedEventArgs e)
         {
+            // Prompt for a file if none chosen yet, then CONTINUE the run in the same
+            // action once a file is picked (mirrors WF AllowDropFilename auto-run).
+            if (!_vm.SourceExists)
+            {
+                if (!await BrowseForSourceAsync() || !_vm.SourceExists)
+                    return; // user cancelled / no usable file
+            }
+            if (!_vm.IsDevkitProAvailable)
+            {
+                _vm.StatusMessage = _vm.NotFoundMessage;
+                return;
+            }
+
+            RunButton.IsEnabled = false;
+            _vm.StatusMessage = R._("Compiling...");
+
+            // Use an EXPLICIT UndoData passed through to the Core helper rather than
+            // the thread-local ambient ROM.BeginUndoScope: the compile+insert runs on
+            // a background thread (Task.Run), and the ambient scope is thread-local to
+            // the UI thread. The Core helper records diffs directly into this passed
+            // UndoData, so undo capture stays correct and thread-consistent. We push it
+            // (UI thread) only after a successful insert, via UndoService.CommitExternal
+            // which also refreshes the dirty bit.
+            var undo = (CoreState.Undo ??= new Undo()).NewUndoData("Add via ASM/C");
+
             try
             {
-                _vm.LoadEntry(addr);
-                UpdateUI();
+                // The devkitARM compile can take several seconds — run off the UI thread.
+                var result = await Task.Run(() => _vm.Run(undo));
+
+                if (result.Success)
+                {
+                    // Only a real ROM mutation is undoable; compile-only / lyn produces
+                    // a file but writes nothing, so there is nothing to commit/undo.
+                    bool mutated = undo.list.Count > 0;
+                    if (mutated && _undoService.CommitExternal(undo))
+                        _vm.CanUndo = true;
+
+                    string msg = R._("Compilation successful.");
+                    if (!string.IsNullOrEmpty(result.ProductPath))
+                        msg += "\r\n" + R._("Product: {0}", result.ProductPath);
+                    if (result.InsertedAddr != U.NOT_FOUND)
+                        msg += "\r\n" + R._("Inserted at: {0}", U.To0xHexString(result.InsertedAddr));
+                    if (!string.IsNullOrEmpty(result.Output.Trim()))
+                        msg += "\r\n" + result.Output.Trim();
+                    _vm.StatusMessage = msg;
+                }
+                else
+                {
+                    // Compile/insert failed → nothing was applied (fault-safe helper),
+                    // so there is nothing to undo; just surface the error.
+                    _vm.StatusMessage = R._("Compilation failed.") + "\r\n" + result.ErrorMessage;
+                }
             }
             catch (Exception ex)
             {
-                Log.Error("ToolASMInsertView.OnSelected failed: {0}", ex.Message);
+                Log.Error("ToolASMInsertView.Run failed: " + ex.ToString());
+                _vm.StatusMessage = R._("Compilation failed.") + "\r\n" + ex.ToString();
+            }
+            finally
+            {
+                RunButton.IsEnabled = true;
             }
         }
 
-        void UpdateUI()
+        void Undo_Click(object? sender, RoutedEventArgs e)
         {
-            AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            try
+            {
+                if (CoreState.Undo == null) return;
+                CoreState.Undo.RunUndo();
+                _vm.CanUndo = false;
+                _vm.StatusMessage = R._("The last operation has been undone.");
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ToolASMInsertView.Undo failed: " + ex.ToString());
+                _vm.StatusMessage = ex.Message;
+            }
         }
 
-        public void NavigateTo(uint address) => EntryList.SelectAddress(address);
-        public void SelectFirstItem() => EntryList.SelectFirst();
+        // This tool has no entry list (it is a compile form like EventAssemblerView).
+        public void NavigateTo(uint address) { }
+        public void SelectFirstItem() { }
     }
 }

--- a/FEBuilderGBA.Core.Tests/AsmCompileCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/AsmCompileCoreTests.cs
@@ -35,17 +35,49 @@ namespace FEBuilderGBA.Core.Tests
             filesize = (uint)rom.Data.Length,
         };
 
-        // ---- CompilerGlobForExt -----------------------------------------------
+        // ---- Compiler base-name + glob (cross-platform) ------------------------
 
         [Theory]
-        [InlineData(".C", "*gcc.exe")]
-        [InlineData(".CPP", "*g++.exe")]
-        [InlineData(".S", "*as.exe")]
-        [InlineData(".ASM", "*as.exe")]
-        [InlineData(".TXT", "*as.exe")]
-        public void CompilerGlobForExt_PicksTool(string ext, string expected)
+        [InlineData(".C", "gcc")]
+        [InlineData(".CPP", "g++")]
+        [InlineData(".S", "as")]
+        [InlineData(".ASM", "as")]
+        [InlineData(".TXT", "as")]
+        public void CompilerBaseNameForExt_PicksTool(string ext, string expected)
         {
-            Assert.Equal(expected, AsmCompileCore.CompilerGlobForExt(ext));
+            Assert.Equal(expected, AsmCompileCore.CompilerBaseNameForExt(ext));
+        }
+
+        [Theory]
+        [InlineData(".C", "gcc")]
+        [InlineData(".CPP", "g++")]
+        [InlineData(".S", "as")]
+        public void CompilerGlobForExt_IsPlatformAware(string ext, string baseName)
+        {
+            // On Windows the glob carries .exe; on Linux/macOS it does not (else
+            // devkitARM resolution silently fails there — Copilot #1/#8).
+            string glob = AsmCompileCore.CompilerGlobForExt(ext);
+            bool isWindows = System.Runtime.InteropServices.RuntimeInformation
+                .IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows);
+            Assert.Equal(isWindows ? "*" + baseName + ".exe" : "*" + baseName, glob);
+        }
+
+        [Fact]
+        public void DevkitArmGlobs_PlatformAware_IncludesExtensionlessFormOffWindows()
+        {
+            // The non-.exe form MUST be among the globs so Linux/macOS resolution works.
+            string[] globs = ToolPathResolver.DevkitArmGlobs("gcc");
+            bool isWindows = System.Runtime.InteropServices.RuntimeInformation
+                .IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows);
+            if (isWindows)
+            {
+                Assert.Equal(new[] { "*gcc.exe" }, globs);
+            }
+            else
+            {
+                Assert.Contains("*gcc", globs);     // extension-less (Linux/macOS) form
+                Assert.Contains("*gcc.exe", globs); // cross-build fallback
+            }
         }
 
         // ---- BuildAssembleArgs (pure) -----------------------------------------
@@ -221,7 +253,7 @@ namespace FEBuilderGBA.Core.Tests
             var undo = NewUndo(rom);
 
             byte[] bin = { 0xAA, 0xBB, 0xCC, 0xDD };
-            AsmCompileCore.InsertAtAddress(rom, 0x100, bin, undo);
+            Assert.True(AsmCompileCore.InsertAtAddress(rom, 0x100, bin, undo));
 
             Assert.Equal(0xAAu, rom.u8(0x100));
             Assert.Equal(0xBBu, rom.u8(0x101));
@@ -246,7 +278,7 @@ namespace FEBuilderGBA.Core.Tests
             for (int i = 0; i < bin.Length; i++) bin[i] = (byte)(i + 1);
             var undo = NewUndo(rom);
 
-            AsmCompileCore.InsertAtAddress(rom, addr, bin, undo);
+            Assert.True(AsmCompileCore.InsertAtAddress(rom, addr, bin, undo));
 
             Assert.True(rom.Data.Length >= addr + bin.Length);
             Assert.Equal(1u, rom.u8(addr));
@@ -266,7 +298,7 @@ namespace FEBuilderGBA.Core.Tests
             uint reg = 4;
             byte[] routine = { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66 };
 
-            AsmCompileCore.InsertHookInject(rom, hookAddr, freeArea, reg, routine, undo);
+            Assert.True(AsmCompileCore.InsertHookInject(rom, hookAddr, freeArea, reg, routine, undo));
 
             // Routine body landed verbatim in the free area.
             for (uint i = 0; i < routine.Length; i++)
@@ -327,11 +359,165 @@ namespace FEBuilderGBA.Core.Tests
             byte[] routine = new byte[0x20];
             for (int i = 0; i < routine.Length; i++) routine[i] = (byte)(0x80 + i);
 
-            AsmCompileCore.InsertHookInject(rom, hookAddr, freeArea, 3, routine, undo);
+            Assert.True(AsmCompileCore.InsertHookInject(rom, hookAddr, freeArea, 3, routine, undo));
 
             Assert.True(rom.Data.Length >= freeArea + routine.Length);
             Assert.Equal(0x80u, rom.u8(freeArea));
             Assert.Equal((uint)(0x80 + 0x1F), rom.u8(freeArea + 0x1F));
+        }
+
+        [Fact]
+        public void InsertHookInject_HookNearRomEnd_ResizesForJumpCodeToo()
+        {
+            // Copilot #6: the HOOK site can be near the ROM end (its jump-code is the
+            // furthest write). A body-only resize would let the jump-code write run
+            // out of bounds. Hook at the current end with a free area earlier.
+            var rom = CreateTestRom(0x400);
+            var undo = NewUndo(rom);
+
+            uint freeArea = 0x100;       // body fits inside the existing ROM
+            uint hookAddr = 0x3FC;       // 4-aligned, near the 0x400 end; jump-code = 8B → 0x404 > 0x400
+            byte[] routine = { 0x10, 0x20, 0x30, 0x40 };
+
+            Assert.True(AsmCompileCore.InsertHookInject(rom, hookAddr, freeArea, 4, routine, undo));
+
+            byte[] expectedJump = DisassemblerTrumb.MakeInjectJump(hookAddr, freeArea, 4);
+            Assert.True(rom.Data.Length >= hookAddr + expectedJump.Length); // resized for the jump-code
+            for (uint i = 0; i < expectedJump.Length; i++)
+                Assert.Equal((uint)expectedJump[i], rom.u8(hookAddr + i));
+        }
+
+        // ---- Fault-safety: a mid-insert failure leaves the ROM byte-identical ---
+        //
+        // Copilot #3/#7: a resize rejection (e.g. > 32 MB) must NOT partially mutate
+        // the ROM. The insert primitives return false (no throw) and CompileAndInsert
+        // restores a snapshot, so the ROM is byte-identical and undo stays clean.
+
+        [Fact]
+        public void InsertAtAddress_ResizeRejected_ReturnsFalse_NoMutation()
+        {
+            // A write that would push the ROM past 32 MB → write_resize_data returns
+            // false → InsertAtAddress returns false with NO write.
+            var savedServices = CoreState.Services;
+            CoreState.Services = new HeadlessAppServices();
+            try
+            {
+                var rom = CreateTestRom(0x400);
+                byte[] before = (byte[])rom.Data.Clone();
+                var undo = NewUndo(rom);
+
+                uint addr = 0x01FFFFFC;          // a write here ends past 0x02000000
+                byte[] bin = new byte[0x40];
+                for (int i = 0; i < bin.Length; i++) bin[i] = 0xEE;
+
+                bool ok = AsmCompileCore.InsertAtAddress(rom, addr, bin, undo);
+
+                Assert.False(ok);
+                Assert.Equal(before, rom.Data);  // byte-identical — no partial write
+                Assert.Empty(undo.list);
+            }
+            finally
+            {
+                CoreState.Services = savedServices;
+            }
+        }
+
+        [Fact]
+        public void InsertHookInject_ResizeRejected_ReturnsFalse_NoMutation()
+        {
+            var savedServices = CoreState.Services;
+            CoreState.Services = new HeadlessAppServices();
+            try
+            {
+                var rom = CreateTestRom(0x400);
+                byte[] before = (byte[])rom.Data.Clone();
+                var undo = NewUndo(rom);
+
+                uint hookAddr = 0x100;
+                uint freeArea = 0x01FFFFF0;      // body ends past 0x02000000 → resize rejected
+                byte[] routine = new byte[0x40];
+
+                bool ok = AsmCompileCore.InsertHookInject(rom, hookAddr, freeArea, 3, routine, undo);
+
+                Assert.False(ok);
+                Assert.Equal(before, rom.Data);  // no partial write (body or jump)
+                Assert.Empty(undo.list);
+            }
+            finally
+            {
+                CoreState.Services = savedServices;
+            }
+        }
+
+        // ---- Address validation (Copilot #4) -----------------------------------
+
+        [Fact]
+        public void ValidateInsertAddresses_ZeroTarget_Rejected()
+        {
+            var rom = CreateTestRom(0x1000);
+            string err = AsmCompileCore.ValidateInsertAddresses(
+                rom, AsmCompileCore.InsertMethod.WriteAtAddress, 0u, U.NOT_FOUND, 16);
+            Assert.NotNull(err);
+        }
+
+        [Fact]
+        public void ValidateInsertAddresses_InRangeTarget_Ok()
+        {
+            var rom = CreateTestRom(0x1000);
+            string err = AsmCompileCore.ValidateInsertAddresses(
+                rom, AsmCompileCore.InsertMethod.WriteAtAddress, 0x200u, U.NOT_FOUND, 16);
+            Assert.Null(err);
+        }
+
+        [Fact]
+        public void ValidateInsertAddresses_AppendAtRomEnd_Ok()
+        {
+            var rom = CreateTestRom(0x1000);
+            string err = AsmCompileCore.ValidateInsertAddresses(
+                rom, AsmCompileCore.InsertMethod.WriteAtAddress, (uint)rom.Data.Length, U.NOT_FOUND, 16);
+            Assert.Null(err);
+        }
+
+        [Fact]
+        public void ValidateInsertAddresses_HookInject_ZeroFreeArea_Rejected()
+        {
+            var rom = CreateTestRom(0x1000);
+            string err = AsmCompileCore.ValidateInsertAddresses(
+                rom, AsmCompileCore.InsertMethod.HookInject, 0x200u, 0u, 16);
+            Assert.NotNull(err);
+        }
+
+        [Fact]
+        public void CompileAndInsert_ZeroTargetAddress_NoMutation()
+        {
+            // Full-path guard: a zero target address must be rejected before any write.
+            // (devkitARM is absent in CI, so the compile fails first — but with a
+            // configured-but-broken devkit we still never mutate. We assert via the
+            // pure validator above; here we assert CompileAndInsert never throws and
+            // never mutates with a zero address even when the compile can't run.)
+            var rom = CreateTestRom(0x400);
+            byte[] before = (byte[])rom.Data.Clone();
+            var savedConfig = CoreState.Config;
+            CoreState.Config = null; // devkit not configured → compile fails cleanly first
+            string src = Path.Combine(Path.GetTempPath(), "asm-" + Path.GetRandomFileName() + ".s");
+            File.WriteAllText(src, ".thumb\r\nnop\r\n");
+            try
+            {
+                var undo = NewUndo(rom);
+                var result = AsmCompileCore.CompileAndInsert(
+                    rom, src, AsmCompileCore.CompileMethod.DumpBinary,
+                    AsmCompileCore.InsertMethod.WriteAtAddress, 0u, U.NOT_FOUND, 3,
+                    SymbolUtil.DebugSymbol.None, checkMissingLabel: false, undo);
+
+                Assert.False(result.Success);
+                Assert.Equal(before, rom.Data);
+                Assert.Empty(undo.list);
+            }
+            finally
+            {
+                CoreState.Config = savedConfig;
+                try { File.Delete(src); } catch { }
+            }
         }
 
         // ---- GetCFlags default -------------------------------------------------

--- a/FEBuilderGBA.Core.Tests/AsmCompileCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/AsmCompileCoreTests.cs
@@ -645,6 +645,12 @@ namespace FEBuilderGBA.Core.Tests
 
                 Assert.False(result.Success);
                 Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+                // The error must name the platform-neutral base tool (gcc for a .c),
+                // NOT the Windows-only "*gcc.exe" glob — else it misnames the searched
+                // tool on Linux/macOS (Copilot #1245 follow-up).
+                Assert.Contains("gcc", result.ErrorMessage);
+                Assert.DoesNotContain("*gcc.exe", result.ErrorMessage);
+                Assert.DoesNotContain("*gcc", result.ErrorMessage);
             }
             finally
             {

--- a/FEBuilderGBA.Core.Tests/AsmCompileCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/AsmCompileCoreTests.cs
@@ -1,0 +1,491 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="AsmCompileCore"/>, the GUI-free C/ASM → ELF → lyn → insert
+    /// flow behind the Avalonia "Add-via-ASM/C" tool.
+    ///
+    /// devkitARM is a large external SDK that is NOT built in CI (unlike ColorzCore),
+    /// so there is intentionally NO real-compile round-trip here. The deterministic,
+    /// always-runnable paths ARE covered: tool-not-found → localized error + zero
+    /// mutation, the (pure) argument/glob builders, the hook-register clamp, the
+    /// lyn-can't-write-to-ROM guard, and the insert math (write-at-address +
+    /// hook-inject) exercised directly with a pre-made binary product.
+    /// </summary>
+    [Collection("SharedState")]
+    public class AsmCompileCoreTests
+    {
+        static ROM CreateTestRom(int size = 0x400)
+        {
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(new byte[size]);
+            CoreState.ROM = rom;
+            return rom;
+        }
+
+        static Undo.UndoData NewUndo(ROM rom) => new Undo.UndoData
+        {
+            time = DateTime.Now,
+            name = "test",
+            list = new List<Undo.UndoPostion>(),
+            filesize = (uint)rom.Data.Length,
+        };
+
+        // ---- CompilerGlobForExt -----------------------------------------------
+
+        [Theory]
+        [InlineData(".C", "*gcc.exe")]
+        [InlineData(".CPP", "*g++.exe")]
+        [InlineData(".S", "*as.exe")]
+        [InlineData(".ASM", "*as.exe")]
+        [InlineData(".TXT", "*as.exe")]
+        public void CompilerGlobForExt_PicksTool(string ext, string expected)
+        {
+            Assert.Equal(expected, AsmCompileCore.CompilerGlobForExt(ext));
+        }
+
+        // ---- BuildAssembleArgs (pure) -----------------------------------------
+
+        [Fact]
+        public void BuildAssembleArgs_Asm_NoCflags()
+        {
+            string args = AsmCompileCore.BuildAssembleArgs(
+                "src.s", "out.elf", ".S", "-c -mthumb -O2", "");
+
+            Assert.Contains("-mthumb-interwork", args);
+            Assert.Contains("-o ", args);
+            Assert.Contains("src.s", args);
+            Assert.Contains("out.elf", args);
+            // CFLAGS only apply to .C/.CPP — an .S build must NOT include them.
+            Assert.DoesNotContain("-O2", args);
+        }
+
+        [Fact]
+        public void BuildAssembleArgs_C_AppendsCflags()
+        {
+            string args = AsmCompileCore.BuildAssembleArgs(
+                "src.c", "out.elf", ".C", "-c -mthumb -O2", "");
+
+            Assert.Contains("-c -mthumb -O2", args);
+        }
+
+        [Fact]
+        public void BuildAssembleArgs_NonexistentFeclib_OmitsIncludeFlag()
+        {
+            // FEClib include is only added when the file exists on disk.
+            string args = AsmCompileCore.BuildAssembleArgs(
+                "src.c", "out.elf", ".C", "", Path.Combine(Path.GetTempPath(), "no-such-feclib-" + Guid.NewGuid() + ".s"));
+
+            Assert.DoesNotContain(" -I ", args);
+        }
+
+        [Fact]
+        public void BuildLynObjectArgs_BasicShape()
+        {
+            string args = AsmCompileCore.BuildLynObjectArgs("src.s", "out.o", "");
+            Assert.Contains("-mthumb-interwork", args);
+            Assert.Contains("src.s", args);
+            Assert.Contains("-o ", args);
+            Assert.Contains("out.o", args);
+        }
+
+        // ---- ClampHookRegister -------------------------------------------------
+
+        [Theory]
+        [InlineData(0u, 0u)]
+        [InlineData(3u, 3u)]
+        [InlineData(8u, 8u)]
+        [InlineData(9u, 8u)]
+        [InlineData(100u, 8u)]
+        public void ClampHookRegister_ClampsToR0R8(uint input, uint expected)
+        {
+            Assert.Equal(expected, AsmCompileCore.ClampHookRegister(input));
+        }
+
+        // ---- Tool-not-found: localized error, ZERO mutation -------------------
+
+        [Fact]
+        public void Compile_DevkitNotConfigured_ReturnsLocalizedError()
+        {
+            var savedConfig = CoreState.Config;
+            CoreState.Config = null; // no devkitpro_eabi
+            string src = Path.Combine(Path.GetTempPath(), "asm-" + Path.GetRandomFileName() + ".s");
+            File.WriteAllText(src, ".thumb\r\nnop\r\n");
+            try
+            {
+                var result = AsmCompileCore.Compile(src, AsmCompileCore.CompileMethod.DumpBinary, checkMissingLabel: false);
+
+                Assert.False(result.Success);
+                Assert.Equal(AsmCompileCore.GetNotFoundMessage(), result.ErrorMessage);
+            }
+            finally
+            {
+                CoreState.Config = savedConfig;
+                try { File.Delete(src); } catch { }
+            }
+        }
+
+        [Fact]
+        public void Compile_MissingSourceFile_ReturnsError()
+        {
+            var result = AsmCompileCore.Compile(
+                Path.Combine(Path.GetTempPath(), "does-not-exist-" + Guid.NewGuid() + ".s"),
+                AsmCompileCore.CompileMethod.DumpBinary, checkMissingLabel: false);
+
+            Assert.False(result.Success);
+            Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+        }
+
+        [Fact]
+        public void CompileAndInsert_DevkitNotConfigured_NoMutation()
+        {
+            var rom = CreateTestRom();
+            byte[] before = (byte[])rom.Data.Clone();
+
+            var savedConfig = CoreState.Config;
+            CoreState.Config = null;
+            string src = Path.Combine(Path.GetTempPath(), "asm-" + Path.GetRandomFileName() + ".s");
+            File.WriteAllText(src, ".thumb\r\nnop\r\n");
+            try
+            {
+                var undo = NewUndo(rom);
+                var result = AsmCompileCore.CompileAndInsert(
+                    rom, src, AsmCompileCore.CompileMethod.DumpBinary,
+                    AsmCompileCore.InsertMethod.WriteAtAddress, 0x100, U.NOT_FOUND, 3,
+                    SymbolUtil.DebugSymbol.None, checkMissingLabel: false, undo);
+
+                Assert.False(result.Success);
+                Assert.Equal(AsmCompileCore.GetNotFoundMessage(), result.ErrorMessage);
+                Assert.Equal(before, rom.Data);
+                Assert.Empty(undo.list);
+            }
+            finally
+            {
+                CoreState.Config = savedConfig;
+                try { File.Delete(src); } catch { }
+            }
+        }
+
+        [Fact]
+        public void CompileAndInsert_NullRom_ReturnsError()
+        {
+            var undo = new Undo.UndoData { list = new List<Undo.UndoPostion>() };
+            var result = AsmCompileCore.CompileAndInsert(
+                null, "x.s", AsmCompileCore.CompileMethod.DumpBinary,
+                AsmCompileCore.InsertMethod.WriteAtAddress, 0x100, U.NOT_FOUND, 3,
+                SymbolUtil.DebugSymbol.None, checkMissingLabel: false, undo);
+
+            Assert.False(result.Success);
+            Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+        }
+
+        // ---- lyn.event can't be written to the ROM (WF guard) -----------------
+
+        [Fact]
+        public void CompileAndInsert_ConvertLynWithWriteMethod_RejectedBeforeCompiling()
+        {
+            var rom = CreateTestRom();
+            byte[] before = (byte[])rom.Data.Clone();
+            var undo = NewUndo(rom);
+
+            // ConvertLyn + a write method must short-circuit with a localized error
+            // BEFORE any compile/mutation (mirrors WF IsMakeLynEventMode guard).
+            var result = AsmCompileCore.CompileAndInsert(
+                rom, "any.s", AsmCompileCore.CompileMethod.ConvertLyn,
+                AsmCompileCore.InsertMethod.WriteAtAddress, 0x100, U.NOT_FOUND, 3,
+                SymbolUtil.DebugSymbol.None, checkMissingLabel: false, undo);
+
+            Assert.False(result.Success);
+            Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+            Assert.Equal(before, rom.Data);
+            Assert.Empty(undo.list);
+        }
+
+        // ---- Insert math: the trickiest correctness surface (no compiler needed) --
+        //
+        // These exercise the PUBLIC insert primitives (InsertAtAddress /
+        // InsertHookInject) directly with a synthetic binary, asserting the byte
+        // placement, the resize/append math, the exact hook jump-code (a wrong jump
+        // offset is the kind of bug that ships silently), and full undo round-trips.
+
+        [Fact]
+        public void InsertAtAddress_WithinRom_WritesBytes_RecordsUndo_NoResize_Undoable()
+        {
+            var rom = CreateTestRom(0x400);
+            int lenBefore = rom.Data.Length;
+            byte[] before = (byte[])rom.Data.Clone();
+            var undo = NewUndo(rom);
+
+            byte[] bin = { 0xAA, 0xBB, 0xCC, 0xDD };
+            AsmCompileCore.InsertAtAddress(rom, 0x100, bin, undo);
+
+            Assert.Equal(0xAAu, rom.u8(0x100));
+            Assert.Equal(0xBBu, rom.u8(0x101));
+            Assert.Equal(0xCCu, rom.u8(0x102));
+            Assert.Equal(0xDDu, rom.u8(0x103));
+            Assert.Equal(lenBefore, rom.Data.Length); // fit inside → no resize
+            Assert.NotEmpty(undo.list);
+
+            // Undo must revert byte-identical.
+            CoreState.Undo = new Undo();
+            CoreState.Undo.Push(undo);
+            CoreState.Undo.RunUndo();
+            Assert.Equal(before, rom.Data);
+        }
+
+        [Fact]
+        public void InsertAtAddress_BeyondRomEnd_ResizesThenWrites()
+        {
+            var rom = CreateTestRom(0x100);
+            uint addr = 0xF0;
+            byte[] bin = new byte[0x40]; // ends at 0x130 > 0x100 → must resize
+            for (int i = 0; i < bin.Length; i++) bin[i] = (byte)(i + 1);
+            var undo = NewUndo(rom);
+
+            AsmCompileCore.InsertAtAddress(rom, addr, bin, undo);
+
+            Assert.True(rom.Data.Length >= addr + bin.Length);
+            Assert.Equal(1u, rom.u8(addr));
+            Assert.Equal(0x40u, rom.u8(addr + 0x3F)); // last byte landed
+        }
+
+        [Fact]
+        public void InsertHookInject_WritesRoutine_AndCorrectJumpCode_Undoable()
+        {
+            // 0x2000 ROM; hook at a 4-aligned address, routine into a free area.
+            var rom = CreateTestRom(0x2000);
+            byte[] before = (byte[])rom.Data.Clone();
+            var undo = NewUndo(rom);
+
+            uint hookAddr = 0x400;     // 4-aligned → no NOP padding
+            uint freeArea = 0x1000;
+            uint reg = 4;
+            byte[] routine = { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66 };
+
+            AsmCompileCore.InsertHookInject(rom, hookAddr, freeArea, reg, routine, undo);
+
+            // Routine body landed verbatim in the free area.
+            for (uint i = 0; i < routine.Length; i++)
+                Assert.Equal((uint)routine[i], rom.u8(freeArea + i));
+
+            // The hook site holds the EXACT thumb jump-code that MakeInjectJump emits
+            // for (hookAddr, freeArea, reg) — this is the load-bearing correctness check.
+            byte[] expectedJump = DisassemblerTrumb.MakeInjectJump(hookAddr, freeArea, reg);
+            for (uint i = 0; i < expectedJump.Length; i++)
+                Assert.Equal((uint)expectedJump[i], rom.u8(hookAddr + i));
+
+            // The embedded routine pointer in the jump-code must be toPointer(freeArea)
+            // (0x08-based GBA pointer), little-endian at offset +4 of the jump-code.
+            uint embeddedPtr = (uint)expectedJump[4]
+                | (uint)expectedJump[5] << 8
+                | (uint)expectedJump[6] << 16
+                | (uint)expectedJump[7] << 24;
+            Assert.Equal(U.toPointer(freeArea), embeddedPtr);
+
+            // Both the hook site and the routine body are recorded → fully undoable.
+            Assert.NotEmpty(undo.list);
+            CoreState.Undo = new Undo();
+            CoreState.Undo.Push(undo);
+            CoreState.Undo.RunUndo();
+            Assert.Equal(before, rom.Data);
+        }
+
+        [Fact]
+        public void InsertHookInject_UnalignedHook_AddsNopPadding()
+        {
+            // An unaligned hook address forces a 2-byte NOP prefix (MakeInjectJump),
+            // making the jump-code 10 bytes instead of 8. Verify the leading NOP.
+            var rom = CreateTestRom(0x2000);
+            var undo = NewUndo(rom);
+
+            uint hookAddr = 0x402;     // NOT 4-aligned → NOP padding
+            uint freeArea = 0x1000;
+            byte[] routine = { 0xDE, 0xAD };
+
+            AsmCompileCore.InsertHookInject(rom, hookAddr, freeArea, 3, routine, undo);
+
+            byte[] expectedJump = DisassemblerTrumb.MakeInjectJump(hookAddr, freeArea, 3);
+            Assert.Equal(10, expectedJump.Length);      // 2 NOP + 4 instr + 4 ptr
+            Assert.Equal(0x00, expectedJump[0]);        // NOP
+            Assert.Equal(0x00, expectedJump[1]);
+            for (uint i = 0; i < expectedJump.Length; i++)
+                Assert.Equal((uint)expectedJump[i], rom.u8(hookAddr + i));
+        }
+
+        [Fact]
+        public void InsertHookInject_FreeAreaBeyondRomEnd_Resizes()
+        {
+            var rom = CreateTestRom(0x400);
+            var undo = NewUndo(rom);
+
+            uint hookAddr = 0x100;
+            uint freeArea = 0x3F0;     // routine ends at 0x3F0+0x20 = 0x410 > 0x400
+            byte[] routine = new byte[0x20];
+            for (int i = 0; i < routine.Length; i++) routine[i] = (byte)(0x80 + i);
+
+            AsmCompileCore.InsertHookInject(rom, hookAddr, freeArea, 3, routine, undo);
+
+            Assert.True(rom.Data.Length >= freeArea + routine.Length);
+            Assert.Equal(0x80u, rom.u8(freeArea));
+            Assert.Equal((uint)(0x80 + 0x1F), rom.u8(freeArea + 0x1F));
+        }
+
+        // ---- GetCFlags default -------------------------------------------------
+
+        [Fact]
+        public void GetCFlags_DefaultsWhenUnset()
+        {
+            var savedConfig = CoreState.Config;
+            CoreState.Config = new Config(); // empty → default
+            try
+            {
+                Assert.Equal("-c -mthumb -O2", AsmCompileCore.GetCFlags());
+            }
+            finally
+            {
+                CoreState.Config = savedConfig;
+            }
+        }
+
+        [Fact]
+        public void GetCFlags_HonorsConfiguredValue()
+        {
+            var savedConfig = CoreState.Config;
+            CoreState.Config = new Config { ["CFLAGS"] = "-c -O3" };
+            try
+            {
+                Assert.Equal("-c -O3", AsmCompileCore.GetCFlags());
+            }
+            finally
+            {
+                CoreState.Config = savedConfig;
+            }
+        }
+
+        // ---- FindFileOne: null (not "") when nothing matches ------------------
+
+        [Fact]
+        public void FindFileOne_NoMatch_ReturnsNull()
+        {
+            string emptyDir = Path.Combine(Path.GetTempPath(), "fbg-asm-empty-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(emptyDir);
+            try
+            {
+                Assert.Null(AsmCompileCore.FindFileOne(emptyDir, "*nonexistent-tool.exe"));
+            }
+            finally
+            {
+                try { Directory.Delete(emptyDir, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void ResolveCompiler_NonexistentToolDir_ReturnsNull()
+        {
+            Assert.Null(AsmCompileCore.ResolveCompiler(
+                Path.Combine(Path.GetTempPath(), "no-such-dir-" + Guid.NewGuid()), ".C"));
+        }
+
+        // ---- Per-tool resolution: each external tool not-found → null/error -----
+        //
+        // devkitARM (gcc/as), lyn, and EA are three SEPARATE external tools; each must
+        // fail cleanly with a localized error and ZERO mutation when missing.
+
+        [Fact]
+        public void ResolveDevkitArmTools_NotConfigured_ReturnNull()
+        {
+            var savedConfig = CoreState.Config;
+            CoreState.Config = null; // no devkitpro_eabi
+            try
+            {
+                Assert.Null(ToolPathResolver.ResolveDevkitArmDir());
+                Assert.Null(ToolPathResolver.ResolveDevkitArmGcc());
+                Assert.Null(ToolPathResolver.ResolveDevkitArmGpp());
+                Assert.Null(ToolPathResolver.ResolveDevkitArmAs());
+            }
+            finally
+            {
+                CoreState.Config = savedConfig;
+            }
+        }
+
+        [Fact]
+        public void ResolveDevkitArmDir_PointsAtMarkerDirectory_WhenConfigured()
+        {
+            // Create a fake devkitpro_eabi marker file; ResolveDevkitArmDir must return
+            // its directory (the tool tree root), matching the WF tooldir derivation.
+            string dir = Path.Combine(Path.GetTempPath(), "fbg-devkit-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            string marker = Path.Combine(dir, "arm-none-eabi-objcopy.exe");
+            File.WriteAllText(marker, "stub");
+
+            var savedConfig = CoreState.Config;
+            CoreState.Config = new Config { ["devkitpro_eabi"] = marker };
+            try
+            {
+                Assert.Equal(dir, ToolPathResolver.ResolveDevkitArmDir());
+                // No *gcc.exe in the tree → still null (tool-specific miss).
+                Assert.Null(ToolPathResolver.ResolveDevkitArmGcc());
+            }
+            finally
+            {
+                CoreState.Config = savedConfig;
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void Compile_DevkitConfiguredButNoGcc_ReturnsToolMissingError_NoThrow()
+        {
+            // devkitpro_eabi marker exists but the tree has NO *gcc.exe → the compile
+            // must return a clean tool-missing error, never throw.
+            string dir = Path.Combine(Path.GetTempPath(), "fbg-devkit2-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            string marker = Path.Combine(dir, "arm-none-eabi-objcopy.exe");
+            File.WriteAllText(marker, "stub");
+            string src = Path.Combine(dir, "x.c");
+            File.WriteAllText(src, "int main(){return 0;}");
+
+            var savedConfig = CoreState.Config;
+            CoreState.Config = new Config { ["devkitpro_eabi"] = marker };
+            try
+            {
+                var result = AsmCompileCore.Compile(
+                    src, AsmCompileCore.CompileMethod.DumpBinary, checkMissingLabel: false);
+
+                Assert.False(result.Success);
+                Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+            }
+            finally
+            {
+                CoreState.Config = savedConfig;
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void ResolveLyn_NoEventAssembler_ReturnsNull()
+        {
+            // With no EA exe resolvable (null config + empty base dir), lyn resolution
+            // (which keys off the EA tree) returns null.
+            var savedConfig = CoreState.Config;
+            var savedBaseDir = CoreState.BaseDirectory;
+            CoreState.Config = null;
+            CoreState.BaseDirectory = Path.Combine(Path.GetTempPath(),
+                "fbg-no-ea-" + Path.GetRandomFileName());
+            try
+            {
+                Assert.Null(AsmCompileCore.ResolveLyn());
+            }
+            finally
+            {
+                CoreState.Config = savedConfig;
+                CoreState.BaseDirectory = savedBaseDir;
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Core/AsmCompileCore.cs
+++ b/FEBuilderGBA.Core/AsmCompileCore.cs
@@ -121,25 +121,41 @@ namespace FEBuilderGBA
 
         /// <summary>
         /// Resolve the compiler executable in the devkitARM tree for the given source
-        /// extension. <c>.C</c> → *gcc, <c>.CPP</c> → *g++, otherwise the assembler
-        /// (*as). Mirrors WinForms <c>CompilerDevkitPro</c> + <c>U.FindFileOne</c>.
-        /// Returns null when the tool tree or the specific compiler is missing.
+        /// extension. <c>.C</c> → gcc, <c>.CPP</c> → g++, otherwise the assembler (as).
+        /// Mirrors WinForms <c>CompilerDevkitPro</c> + <c>U.FindFileOne</c>, but is
+        /// cross-platform: on Linux/macOS the binaries have NO <c>.exe</c>, so it tries
+        /// the platform-appropriate globs. Returns null when the tree or the specific
+        /// compiler is missing.
         /// </summary>
         public static string ResolveCompiler(string toolDir, string sourceExtUpper)
         {
             if (string.IsNullOrEmpty(toolDir) || !Directory.Exists(toolDir))
                 return null;
-            string pattern = CompilerGlobForExt(sourceExtUpper);
-            return FindFileOne(toolDir, pattern);
+            string baseName = CompilerBaseNameForExt(sourceExtUpper);
+            foreach (string glob in ToolPathResolver.DevkitArmGlobs(baseName))
+            {
+                string hit = FindFileOne(toolDir, glob);
+                if (hit != null) return hit;
+            }
+            return null;
         }
 
-        /// <summary>The *gcc/*g++/*as glob WinForms picks for a (dotted, upper-case) ext.</summary>
-        public static string CompilerGlobForExt(string sourceExtUpper)
+        /// <summary>The gcc/g++/as base tool name WinForms picks for a (dotted,
+        /// upper-case) ext.</summary>
+        public static string CompilerBaseNameForExt(string sourceExtUpper)
         {
-            if (sourceExtUpper == ".C") return "*gcc.exe";
-            if (sourceExtUpper == ".CPP") return "*g++.exe";
-            return "*as.exe";
+            if (sourceExtUpper == ".C") return "gcc";
+            if (sourceExtUpper == ".CPP") return "g++";
+            return "as";
         }
+
+        /// <summary>
+        /// The compiler glob WinForms picks for a (dotted, upper-case) ext, on THIS
+        /// platform (Windows → <c>*gcc.exe</c>; Linux/macOS → <c>*gcc</c>). The first
+        /// of <see cref="ToolPathResolver.DevkitArmGlobs"/> for the mapped base name.
+        /// </summary>
+        public static string CompilerGlobForExt(string sourceExtUpper) =>
+            ToolPathResolver.DevkitArmGlobs(CompilerBaseNameForExt(sourceExtUpper))[0];
 
         /// <summary>
         /// Find the first file under <paramref name="dir"/> matching the glob,
@@ -463,10 +479,20 @@ namespace FEBuilderGBA
             {
                 bin = File.ReadAllBytes(result.ProductPath);
             }
-            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            catch (Exception ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
             {
+                // The compiled product vanished (deleted/moved between compile and read).
                 result.Success = false;
                 result.ErrorMessage = R._("ファイルがありません。\r\nファイル名:{0}", result.ProductPath);
+                return result;
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                // A permission/lock/IO problem reading the product (it exists but can't
+                // be read) — a DISTINCT failure from "file missing".
+                result.Success = false;
+                result.ErrorMessage = R._("Unable to read the compiled file.\r\nfilename:{0}", result.ProductPath)
+                    + "\r\n" + ex.ToString();
                 return result;
             }
             if (bin.Length <= 0)
@@ -476,18 +502,43 @@ namespace FEBuilderGBA
                 return result;
             }
 
+            // Validate the destination address(es) BEFORE mutating (the addresses come
+            // from free-form UI fields). targetAddr is the write/hook site; freeArea is
+            // the routine body for hook-inject.
+            string addrError = ValidateInsertAddresses(rom, insert, targetAddr, freeArea, (uint)bin.Length);
+            if (addrError != null)
+            {
+                result.Success = false;
+                result.ErrorMessage = addrError;
+                return result;
+            }
+
+            // Fault-safe insert: snapshot the ROM, attempt the write, and on ANY failure
+            // (resize limit, out-of-bounds, unexpected throw) restore the snapshot so the
+            // ROM is left byte-identical with NO partial mutation. The insert helpers
+            // return false (no throw) for the expected resize/bounds failures.
+            byte[] snapshot = (byte[])rom.Data.Clone();
+            int undoCountBefore = undo.list.Count;
+            bool inserted;
             try
             {
-                if (insert == InsertMethod.WriteAtAddress)
-                    InsertAtAddress(rom, targetAddr, bin, undo);
-                else // HookInject
-                    InsertHookInject(rom, targetAddr, freeArea, hookRegister, bin, undo);
+                inserted = insert == InsertMethod.WriteAtAddress
+                    ? InsertAtAddress(rom, targetAddr, bin, undo)
+                    : InsertHookInject(rom, targetAddr, freeArea, hookRegister, bin, undo);
             }
             catch (Exception ex)
             {
+                RollbackPartialInsert(rom, snapshot, undo, undoCountBefore);
                 result.Success = false;
                 result.ErrorMessage = R._("Failed to apply the compiled ROM (size/resize limit exceeded?).")
                     + "\r\n" + ex.ToString();
+                return result;
+            }
+            if (!inserted)
+            {
+                RollbackPartialInsert(rom, snapshot, undo, undoCountBefore);
+                result.Success = false;
+                result.ErrorMessage = R._("Failed to apply the compiled ROM (size/resize limit exceeded?).");
                 return result;
             }
 
@@ -504,45 +555,100 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
+        /// Validate the destination address(es) for an insert. The write/hook site and
+        /// (for hook-inject) the free area must be non-zero and either a safe ROM offset
+        /// or exactly the ROM end (append). Mirrors the WF
+        /// <c>CheckZeroAddressWrite</c> + <c>isSafetyOffset</c>/append guard. Returns a
+        /// localized error string when invalid, or null when OK.
+        /// </summary>
+        public static string ValidateInsertAddresses(ROM rom, InsertMethod insert,
+            uint targetAddr, uint freeArea, uint binLength)
+        {
+            if (!IsValidWriteAddress(rom, targetAddr))
+                return R._("無効なポインタです。\r\nこの設定は危険です。") + "\r\n" + U.To0xHexString(targetAddr);
+
+            if (insert == InsertMethod.HookInject)
+            {
+                if (!IsValidWriteAddress(rom, freeArea))
+                    return R._("無効なポインタです。\r\nこの設定は危険です。") + "\r\n" + U.To0xHexString(freeArea);
+            }
+            return null;
+        }
+
+        /// <summary>True when <paramref name="addr"/> is a safe write target: non-zero
+        /// and either a safe ROM offset or exactly the ROM end (append).</summary>
+        static bool IsValidWriteAddress(ROM rom, uint addr)
+        {
+            if (addr == 0) return false;                      // CheckZeroAddressWrite
+            if (U.isSafetyOffset(addr, rom)) return true;     // inside the ROM
+            if (addr == (uint)rom.Data.Length) return true;   // append at the very end
+            return false;
+        }
+
+        /// <summary>
+        /// Restore the ROM to <paramref name="snapshot"/> and trim any undo entries the
+        /// failed insert appended, so a mid-insert failure leaves NO partial mutation.
+        /// </summary>
+        static void RollbackPartialInsert(ROM rom, byte[] snapshot, Undo.UndoData undo, int undoCountBefore)
+        {
+            rom.SwapNewROMDataDirect(snapshot);
+            if (undo.list.Count > undoCountBefore)
+                undo.list.RemoveRange(undoCountBefore, undo.list.Count - undoCountBefore);
+        }
+
+        /// <summary>
         /// Write the binary verbatim at <paramref name="addr"/> (WF Method 1),
         /// resizing the ROM if it runs past the end. The write is recorded into
-        /// <paramref name="undo"/> so it is fully undoable. Exposed for unit-testing
-        /// the insert math with a synthetic binary (no compiler needed).
+        /// <paramref name="undo"/> so it is fully undoable. Returns false (no write)
+        /// when the required resize is rejected (e.g. &gt; 32 MB) — never throws for
+        /// that expected case. Exposed for unit-testing with a synthetic binary.
         /// </summary>
-        public static void InsertAtAddress(ROM rom, uint addr, byte[] bin, Undo.UndoData undo)
+        public static bool InsertAtAddress(ROM rom, uint addr, byte[] bin, Undo.UndoData undo)
         {
             uint newLength = addr + (uint)bin.Length;
             if (newLength > (uint)rom.Data.Length)
-                rom.write_resize_data(newLength);
+            {
+                // CHECK the resize result — write_resize_data returns false at the 32 MB
+                // limit; writing afterwards would otherwise throw out of range.
+                if (!rom.write_resize_data(newLength))
+                    return false;
+            }
             rom.write_range(addr, bin, undo);
+            return true;
         }
 
         /// <summary>
         /// Write the binary into the free area and patch a thumb jump at the hook
-        /// address (WF Method 2). The hook (8 bytes) and the routine body are both
-        /// recorded into <paramref name="undo"/>. Exposed for unit-testing the
-        /// jump-code + resize math with a synthetic binary (no compiler needed).
+        /// address (WF Method 2). The hook and the routine body are both recorded into
+        /// <paramref name="undo"/>. Returns false (no partial write) when a required
+        /// resize is rejected. Exposed for unit-testing with a synthetic binary.
         /// </summary>
-        public static void InsertHookInject(ROM rom, uint hookAddr, uint freeArea, uint hookRegister,
+        public static bool InsertHookInject(ROM rom, uint hookAddr, uint freeArea, uint hookRegister,
             byte[] bin, Undo.UndoData undo)
         {
-            // Resize FIRST so the free area is within bounds before any undo snapshot
-            // is taken — UndoPostion(addr,size) reads the bytes AT CONSTRUCTION and
-            // CLAMPS to the current ROM end, so snapshotting a past-the-end free area
-            // before resizing would record a truncated/empty original and break undo.
-            uint endAddr = freeArea + (uint)bin.Length;
-            if (endAddr > (uint)rom.Data.Length)
-                rom.write_resize_data(endAddr);
-
-            // Write the routine body, then patch the thumb jump at the hook site. Both
-            // go through the EXPLICIT-undodata overload (write_range(addr,data,undo)) —
-            // never the no-undodata overload, whose [ThreadStatic] ambient scope is
-            // null on this background Task.Run thread (so it would record nothing) and
-            // could otherwise absorb an unrelated UI-thread write.
-            rom.write_range(freeArea, bin, undo);
             uint useReg = ClampHookRegister(hookRegister);
             byte[] jumpCode = DisassemblerTrumb.MakeInjectJump(hookAddr, freeArea, useReg);
+
+            // Resize ONCE to cover BOTH the routine body AND the hook-site jump-code —
+            // the hook can be near the ROM end too (#6: a body-only resize would let the
+            // jump-code write run out of bounds). Resize FIRST so the free area is in
+            // bounds before any undo snapshot (UndoPostion clamps at construction).
+            uint bodyEnd = freeArea + (uint)bin.Length;
+            uint hookEnd = hookAddr + (uint)jumpCode.Length;
+            uint needLength = Math.Max(bodyEnd, hookEnd);
+            if (needLength > (uint)rom.Data.Length)
+            {
+                if (!rom.write_resize_data(needLength))
+                    return false; // resize rejected (e.g. > 32 MB) — no partial write
+            }
+
+            // Both writes go through the EXPLICIT-undodata overload — never the
+            // no-undodata overload, whose [ThreadStatic] ambient scope is null on this
+            // background Task.Run thread (so it would record nothing) and could absorb
+            // an unrelated UI-thread write.
+            rom.write_range(freeArea, bin, undo);
             rom.write_range(hookAddr, jumpCode, undo);
+            return true;
         }
 
         /// <summary>Clamp the hook register to the valid r0..r8 range (WF GetSaftyRegister).</summary>

--- a/FEBuilderGBA.Core/AsmCompileCore.cs
+++ b/FEBuilderGBA.Core/AsmCompileCore.cs
@@ -1,0 +1,595 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// GUI-free compile+insert flow for the "Add-via-ASM/C" tool, shared by the
+    /// Avalonia <c>ToolASMInsertView</c>. Ported from the WinForms path
+    /// (<c>ToolASMInsertForm.RunButton_Click</c> → <c>MainFormUtil.Compile</c> /
+    /// <c>CompilerDevkitPro</c> / <c>ConvertLYN</c>), keeping the exact devkitARM
+    /// gcc/g++/as arguments, the ELF → text-section dump, the lyn ELF→EA-event
+    /// conversion, and the three insert methods (free-area data, write-at-address,
+    /// hook-inject).
+    ///
+    /// Compile chain:
+    ///   C/C++/ASM source
+    ///     → devkitARM gcc/g++/as (<c>CoreState.Config.at("devkitpro_eabi")</c>) → ELF
+    ///     → (a) raw text-section dump (.dmp) via <see cref="Elf.ProgramBIN"/>, OR
+    ///       (b) <c>CONVERT_LYN</c>: as → .o → lyn.exe → .lyn.event (an EA event
+    ///          script the caller assembles via <see cref="EventAssemblerCompileCore"/>).
+    ///     → insert the raw binary into the ROM (free-area / address / hook-inject).
+    ///
+    /// Scope boundary (intentional — matches how <see cref="EventAssemblerCompileCore"/>
+    /// deferred MakeEAAutoDef):
+    ///   PROVIDED: .c/.cpp/.s/.asm → ELF → .dmp / .lyn.event, the three insert
+    ///     methods, missing-label check, debug-symbol store, undo.
+    ///   INTENTIONALLY DEFERRED to a follow-up (WinForms-coupled):
+    ///     - the GoldRoad assembler path (<c>@thumb</c> ASM → CompilerGoldRoad) — a
+    ///       separate legacy assembler; the devkitARM path covers .asm/.s/.c/.cpp.
+    ///     - the "Make Patch" text generator (GraphicsToolPatchMakerForm) — pure WF
+    ///       patch-text UI, unrelated to the core compile/insert.
+    /// </summary>
+    public static class AsmCompileCore
+    {
+        /// <summary>
+        /// What to do with the compiled ELF (mirrors WinForms
+        /// <c>MainFormUtil.CompileType</c> + the ELF combo choices).
+        /// </summary>
+        public enum CompileMethod
+        {
+            /// <summary>Assemble to ELF, dump the raw text section to a .dmp binary,
+            /// then delete the intermediate ELF (WF <c>CompileType.NONE</c>).</summary>
+            DumpBinary = 0,
+            /// <summary>As <see cref="DumpBinary"/> but keep the .elf on disk
+            /// (WF <c>CompileType.KEEP_ELF</c>).</summary>
+            KeepElf = 1,
+            /// <summary>Convert the ELF to an EA event script via lyn.exe
+            /// (WF <c>CompileType.CONVERT_LYN</c>) — produces a .lyn.event, not a
+            /// raw binary, so it cannot be written directly to the ROM here.</summary>
+            ConvertLyn = 2,
+        }
+
+        /// <summary>
+        /// Where the compiled binary lands in the ROM (mirrors WinForms
+        /// <c>ToolASMInsertForm.Method</c> combo).
+        /// </summary>
+        public enum InsertMethod
+        {
+            /// <summary>Do not write to the ROM; just compile and report the product
+            /// (WF Method index 0 — "make file only").</summary>
+            CompileOnly = 0,
+            /// <summary>Write the binary verbatim at the chosen address
+            /// (WF Method index 1).</summary>
+            WriteAtAddress = 1,
+            /// <summary>Write the binary into the free area and patch a thumb jump at
+            /// the chosen hook address (WF Method index 2).</summary>
+            HookInject = 2,
+        }
+
+        /// <summary>Structured result of a compile (+ optional insert) run.</summary>
+        public sealed class CompileResult
+        {
+            /// <summary>True when the source compiled and (if requested) was inserted.</summary>
+            public bool Success { get; set; }
+            /// <summary>Raw tool stdout/stderr (for display / logging).</summary>
+            public string Output { get; set; } = "";
+            /// <summary>The compiled product path (.dmp binary, or .lyn.event for ConvertLyn).</summary>
+            public string ProductPath { get; set; } = "";
+            /// <summary>The ROM offset the binary was written to, or <see cref="U.NOT_FOUND"/>
+            /// when nothing was inserted (CompileOnly / ConvertLyn).</summary>
+            public uint InsertedAddr { get; set; } = U.NOT_FOUND;
+            /// <summary>Number of bytes written to the ROM (0 when nothing was inserted).</summary>
+            public int InsertedSize { get; set; }
+            /// <summary>EA symbol text produced from the ELF (may be empty).</summary>
+            public string SymbolText { get; set; } = "";
+            /// <summary>Localized human-readable error (set when <see cref="Success"/> is false).</summary>
+            public string ErrorMessage { get; set; } = "";
+        }
+
+        // ---- Tool resolution --------------------------------------------------
+
+        /// <summary>The devkitARM EABI marker path from config (the as/gcc tree root
+        /// is its directory). Empty when unset.</summary>
+        public static string GetDevkitProEabi() => CoreState.Config?.at("devkitpro_eabi", "") ?? "";
+
+        /// <summary>The C/C++ compile flags (WF <c>OptionForm.GetCFLAGS</c> default).</summary>
+        public static string GetCFlags() => CoreState.Config?.at("CFLAGS", "-c -mthumb -O2") ?? "-c -mthumb -O2";
+
+        /// <summary>The FEClib path (WF <c>OptionForm.GetFECLIB</c>). Empty when unset.</summary>
+        public static string GetFEClib() => CoreState.Config?.at("FECLIB", "") ?? "";
+
+        /// <summary>
+        /// True when the devkitARM EABI tool path is configured and exists. Callers
+        /// should surface <see cref="GetNotFoundMessage"/> when this is false.
+        /// </summary>
+        public static bool IsDevkitProAvailable()
+        {
+            string eabi = GetDevkitProEabi();
+            return !string.IsNullOrEmpty(eabi) && File.Exists(eabi);
+        }
+
+        /// <summary>Localized "devkitpro_eabi not configured" message (no throw).</summary>
+        public static string GetNotFoundMessage()
+        {
+            // Mirror the WinForms CompilerDevkitPro message.
+            return R._("{0}の設定がありません。 設定->オプションから、{0}を設定してください。", "devkitpro_eabi");
+        }
+
+        /// <summary>
+        /// Resolve the compiler executable in the devkitARM tree for the given source
+        /// extension. <c>.C</c> → *gcc, <c>.CPP</c> → *g++, otherwise the assembler
+        /// (*as). Mirrors WinForms <c>CompilerDevkitPro</c> + <c>U.FindFileOne</c>.
+        /// Returns null when the tool tree or the specific compiler is missing.
+        /// </summary>
+        public static string ResolveCompiler(string toolDir, string sourceExtUpper)
+        {
+            if (string.IsNullOrEmpty(toolDir) || !Directory.Exists(toolDir))
+                return null;
+            string pattern = CompilerGlobForExt(sourceExtUpper);
+            return FindFileOne(toolDir, pattern);
+        }
+
+        /// <summary>The *gcc/*g++/*as glob WinForms picks for a (dotted, upper-case) ext.</summary>
+        public static string CompilerGlobForExt(string sourceExtUpper)
+        {
+            if (sourceExtUpper == ".C") return "*gcc.exe";
+            if (sourceExtUpper == ".CPP") return "*g++.exe";
+            return "*as.exe";
+        }
+
+        /// <summary>
+        /// Find the first file under <paramref name="dir"/> matching the glob,
+        /// recursively. Mirrors WinForms <c>U.FindFileOne</c>. Returns null (not "")
+        /// when nothing matches, so callers can null-check.
+        /// </summary>
+        public static string FindFileOne(string dir, string pattern)
+        {
+            string[] files = U.Directory_GetFiles_Safe(dir, pattern, SearchOption.AllDirectories);
+            return files.Length > 0 ? files[0] : null;
+        }
+
+        /// <summary>Resolve lyn.exe via the Event Assembler tree (shared resolver).</summary>
+        public static string ResolveLyn()
+        {
+            string ea = ToolPathResolver.ResolveEventAssembler() ?? "";
+            return ToolPathResolver.ResolveLynExe(ea);
+        }
+
+        // ---- Argument building (pure — unit-tested without running anything) ---
+
+        /// <summary>
+        /// Build the gcc/g++/as arguments for the ELF assemble step (WF
+        /// <c>CompilerDevkitPro</c>). Appends CFLAGS for .C/.CPP and a <c>-I</c> for
+        /// the FEClib directory when one exists. Pure: takes its inputs explicitly.
+        /// </summary>
+        public static string BuildAssembleArgs(string sourcePath, string elfOutPath,
+            string sourceExtUpper, string cflags, string feclibPath)
+        {
+            var sb = new StringBuilder();
+            sb.Append("-g -mcpu=arm7tdmi -mthumb-interwork ");
+            sb.Append(' ').Append(U.escape_shell_args(sourcePath));
+            sb.Append(" -o ").Append(U.escape_shell_args(elfOutPath));
+
+            if (sourceExtUpper == ".C" || sourceExtUpper == ".CPP")
+            {
+                if (!string.IsNullOrEmpty(cflags))
+                    sb.Append(' ').Append(cflags);
+            }
+            if (!string.IsNullOrEmpty(feclibPath) && File.Exists(feclibPath))
+            {
+                string feclibDir = Path.GetDirectoryName(feclibPath);
+                sb.Append(" -I ").Append(U.escape_shell_args(feclibDir));
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Build the <c>as</c> arguments for the lyn .o step (WF
+        /// <c>ConvertLYN_S_to_O</c>). Appends the FEClib reference .s when present.
+        /// </summary>
+        public static string BuildLynObjectArgs(string sourcePath, string objOutPath, string feclibReference)
+        {
+            var sb = new StringBuilder();
+            sb.Append("-g -mcpu=arm7tdmi -mthumb-interwork ");
+            sb.Append(' ').Append(U.escape_shell_args(sourcePath));
+            if (!string.IsNullOrEmpty(feclibReference) && File.Exists(feclibReference))
+                sb.Append(' ').Append(U.escape_shell_args(feclibReference));
+            sb.Append(" -o ").Append(U.escape_shell_args(objOutPath));
+            return sb.ToString();
+        }
+
+        // ---- Compile-only (no ROM mutation) -----------------------------------
+
+        /// <summary>
+        /// Compile <paramref name="sourcePath"/> to a product (a .dmp raw binary, or a
+        /// .lyn.event for <see cref="CompileMethod.ConvertLyn"/>) WITHOUT touching the
+        /// ROM. Never throws — file/process failures return a structured error.
+        /// On success, <see cref="CompileResult.ProductPath"/> is the product file and
+        /// <see cref="CompileResult.SymbolText"/> the EA symbols extracted from the ELF.
+        /// </summary>
+        public static CompileResult Compile(string sourcePath, CompileMethod method,
+            bool checkMissingLabel, Action<string> onProgress = null)
+        {
+            var result = new CompileResult();
+
+            if (string.IsNullOrEmpty(sourcePath) || !File.Exists(sourcePath))
+            {
+                result.ErrorMessage = R._("ファイルがありません。\r\nファイル名:{0}", sourcePath ?? "");
+                return result;
+            }
+            if (!IsDevkitProAvailable())
+            {
+                result.ErrorMessage = GetNotFoundMessage();
+                return result;
+            }
+
+            string eabi = GetDevkitProEabi();
+            string toolDir = Path.GetDirectoryName(eabi);
+            string ext = U.GetFilenameExt(sourcePath); // dotted, upper-case (e.g. ".C")
+            string srcFull = Path.GetFullPath(sourcePath);
+            string srcDir = Path.GetDirectoryName(srcFull);
+            string baseNoExt = Path.Combine(srcDir, Path.GetFileNameWithoutExtension(srcFull));
+
+            try
+            {
+                if (method == CompileMethod.ConvertLyn)
+                    return ConvertLyn(srcFull, toolDir, baseNoExt, onProgress);
+
+                string compilerExe = ResolveCompiler(toolDir, ext);
+                if (string.IsNullOrEmpty(compilerExe))
+                {
+                    result.ErrorMessage = R._("{0}の設定がありません。 設定->オプションから、{0}を設定してください。",
+                        "devkitpro_eabi " + CompilerGlobForExt(ext));
+                    return result;
+                }
+
+                string elfPath = baseNoExt + ".elf";
+                string args = BuildAssembleArgs(srcFull, elfPath, ext, GetCFlags(), GetFEClib());
+
+                string output;
+                try
+                {
+                    output = RunProcess(compilerExe, args, srcDir);
+                }
+                catch (Exception ex)
+                {
+                    result.ErrorMessage = R._("プロセスを実行できません。\r\nfilename:{0}\r\n{1}", compilerExe, ex.ToString());
+                    return result;
+                }
+
+                if (!File.Exists(elfPath) || U.GetFileSize(elfPath) <= 0)
+                {
+                    // Prefix the executed command so the user can repro (matches WF).
+                    result.Output = output;
+                    result.ErrorMessage = compilerExe + " " + args + " \r\noutput:\r\n" + output;
+                    return result;
+                }
+
+                var elf = new Elf(elfPath, useHookMode: false);
+                if (checkMissingLabel)
+                {
+                    string lost = elf.CheckLostLabel();
+                    if (!string.IsNullOrEmpty(lost))
+                    {
+                        result.ErrorMessage = lost;
+                        TryDelete(elfPath);
+                        return result;
+                    }
+                }
+                result.SymbolText = elf.ToEASymbol();
+
+                // Dump the raw text-section binary.
+                string dmpPath = baseNoExt + ".dmp";
+                U.WriteAllBytes(dmpPath, elf.ProgramBIN);
+
+                if (method != CompileMethod.KeepElf)
+                    TryDelete(elfPath);
+
+                result.Output = output;
+                result.ProductPath = dmpPath;
+                result.Success = true;
+                return result;
+            }
+            catch (Exception ioex) when (ioex is IOException || ioex is UnauthorizedAccessException)
+            {
+                result.Success = false;
+                result.ErrorMessage = R._("Unable to write the temporary files needed for compilation.")
+                    + "\r\n" + ioex.ToString();
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// CONVERT_LYN path: as → .o → lyn.exe → .lyn.event (WF
+        /// <c>ConvertLYN</c>). The product is an EA event script (not a raw binary),
+        /// so it cannot be written directly to the ROM by this helper.
+        /// </summary>
+        static CompileResult ConvertLyn(string srcFull, string toolDir, string baseNoExt, Action<string> onProgress)
+        {
+            var result = new CompileResult();
+
+            string asExe = ResolveCompiler(toolDir, ".S"); // *as.exe
+            if (string.IsNullOrEmpty(asExe))
+            {
+                result.ErrorMessage = R._("{0}の設定がありません。 設定->オプションから、{0}を設定してください。",
+                    "devkitpro_eabi *as.exe");
+                return result;
+            }
+
+            string lynExe = ResolveLyn();
+            if (string.IsNullOrEmpty(lynExe) || !File.Exists(lynExe))
+            {
+                result.ErrorMessage = R._("lyn.exeが見つかりません。\r\n{0}", lynExe ?? "");
+                return result;
+            }
+
+            string objPath = baseNoExt + ".o";
+            string srcDir = Path.GetDirectoryName(srcFull);
+            string feclibRef = GetFEClibReference();
+            string asArgs = BuildLynObjectArgs(srcFull, objPath, feclibRef);
+
+            string asOut;
+            try
+            {
+                asOut = RunProcess(asExe, asArgs, srcDir);
+            }
+            catch (Exception ex)
+            {
+                result.ErrorMessage = R._("プロセスを実行できません。\r\nfilename:{0}\r\n{1}", asExe, ex.ToString());
+                return result;
+            }
+            if (!File.Exists(objPath) || U.GetFileSize(objPath) <= 0)
+            {
+                result.Output = asOut;
+                result.ErrorMessage = asExe + " " + asArgs + " \r\noutput:\r\n" + asOut;
+                return result;
+            }
+
+            // Extract EA symbols from the object before lyn consumes it.
+            try { result.SymbolText = new Elf(objPath, useHookMode: false).ToEASymbol(); }
+            catch { /* symbol extraction is best-effort */ }
+
+            string lynArgs = U.escape_shell_args(objPath);
+            string lynOut;
+            try
+            {
+                lynOut = RunProcess(lynExe, lynArgs, srcDir);
+            }
+            catch (Exception ex)
+            {
+                TryDelete(objPath);
+                result.ErrorMessage = R._("プロセスを実行できません。\r\nfilename:{0}\r\n{1}", lynExe, ex.ToString());
+                return result;
+            }
+            TryDelete(objPath);
+
+            // lyn emits an EA event script; "ALIGN 4" is WF's success marker.
+            if (lynOut.IndexOf("ALIGN 4", StringComparison.Ordinal) < 0)
+            {
+                result.Output = lynOut;
+                result.ErrorMessage = lynExe + " " + lynArgs + " \r\noutput:\r\n" + lynOut;
+                return result;
+            }
+
+            string eventPath = U.ChangeExtFilename(srcFull, ".lyn.event");
+            File.WriteAllText(eventPath, lynOut);
+
+            result.Output = lynOut;
+            result.ProductPath = eventPath;
+            result.Success = true;
+            return result;
+        }
+
+        /// <summary>
+        /// Find the FEClib reference .s for the current ROM version (WF
+        /// <c>MainFormUtil.GetFEClibReference</c>): <c>&lt;feclib&gt;/../reference/&lt;version&gt;*.s</c>,
+        /// newest first. Empty when no FEClib / no match.
+        /// </summary>
+        public static string GetFEClibReference()
+        {
+            string feclib = GetFEClib();
+            if (string.IsNullOrEmpty(feclib)) return "";
+
+            string dir;
+            try
+            {
+                dir = Path.GetDirectoryName(feclib);
+                dir = Path.Combine(dir, "../reference/");
+            }
+            catch (Exception) { return ""; }
+
+            if (!Directory.Exists(dir)) return "";
+
+            string version = CoreState.ROM?.RomInfo?.VersionToFilename;
+            if (string.IsNullOrEmpty(version)) return "";
+
+            string[] list = U.Directory_GetFiles_Safe(dir, version + "*.s", SearchOption.TopDirectoryOnly);
+            if (list.Length <= 0) return "";
+
+            Array.Sort(list);
+            Array.Reverse(list);
+            return list[0];
+        }
+
+        // ---- Compile + insert (the full Run flow) -----------------------------
+
+        /// <summary>
+        /// Compile <paramref name="sourcePath"/> and insert the result into
+        /// <paramref name="rom"/> per <paramref name="insert"/>, fault-safe in one step.
+        ///
+        /// Behaviour:
+        ///  - devkitARM not configured → localized <see cref="GetNotFoundMessage"/>,
+        ///    NO throw, NO ROM mutation.
+        ///  - The ROM is mutated ONLY after a clean compile (no partial insert on
+        ///    failure). All writes go into <paramref name="undo"/> so they are undoable.
+        ///  - <see cref="CompileMethod.ConvertLyn"/> produces an EA event (not a raw
+        ///    binary), so it is only valid with <see cref="InsertMethod.CompileOnly"/>;
+        ///    any other insert method returns a localized error (matches the WinForms
+        ///    "can't write a lyn.event to the ROM" guard).
+        ///  - Debug symbols are stored via <see cref="SymbolUtil.ProcessSymbolByComment"/>.
+        /// </summary>
+        public static CompileResult CompileAndInsert(ROM rom, string sourcePath,
+            CompileMethod method, InsertMethod insert, uint targetAddr, uint freeArea,
+            uint hookRegister, SymbolUtil.DebugSymbol storeSymbol, bool checkMissingLabel,
+            Undo.UndoData undo, Action<string> onProgress = null)
+        {
+            if (rom == null)
+                return new CompileResult { ErrorMessage = R._("No ROM is loaded.") };
+
+            // A lyn.event is a script, not bytes — it cannot be written to the ROM here.
+            if (method == CompileMethod.ConvertLyn && insert != InsertMethod.CompileOnly)
+                return new CompileResult
+                {
+                    ErrorMessage = R._("lyn.eventを作成する時は、ROMに書き込むことはできません。")
+                };
+
+            CompileResult result = Compile(sourcePath, method, checkMissingLabel, onProgress);
+            if (!result.Success)
+                return result;
+
+            // Store debug symbols for the compile-only / lyn product (addr 0).
+            if (insert == InsertMethod.CompileOnly || method == CompileMethod.ConvertLyn)
+            {
+                SymbolUtil.ProcessSymbolByComment(Path.GetFullPath(sourcePath), result.SymbolText, storeSymbol, 0);
+                return result;
+            }
+
+            byte[] bin;
+            try
+            {
+                bin = File.ReadAllBytes(result.ProductPath);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                result.Success = false;
+                result.ErrorMessage = R._("ファイルがありません。\r\nファイル名:{0}", result.ProductPath);
+                return result;
+            }
+            if (bin.Length <= 0)
+            {
+                result.Success = false;
+                result.ErrorMessage = R._("ファイルがゼロバイトです。\r\nファイル名:{0}", result.ProductPath);
+                return result;
+            }
+
+            try
+            {
+                if (insert == InsertMethod.WriteAtAddress)
+                    InsertAtAddress(rom, targetAddr, bin, undo);
+                else // HookInject
+                    InsertHookInject(rom, targetAddr, freeArea, hookRegister, bin, undo);
+            }
+            catch (Exception ex)
+            {
+                result.Success = false;
+                result.ErrorMessage = R._("Failed to apply the compiled ROM (size/resize limit exceeded?).")
+                    + "\r\n" + ex.ToString();
+                return result;
+            }
+
+            // For write-at-address the bytes land AT the target; for hook-inject the
+            // routine body lands in the free area (the hook site only gets the jump).
+            uint symbolAddr = insert == InsertMethod.WriteAtAddress ? targetAddr : freeArea;
+            CoreState.CommentCache?.RemoveRange(symbolAddr, symbolAddr + (uint)bin.Length);
+            SymbolUtil.ProcessSymbolByComment(Path.GetFullPath(sourcePath), result.SymbolText, storeSymbol, symbolAddr);
+
+            result.InsertedAddr = symbolAddr;
+            result.InsertedSize = bin.Length;
+            result.Success = true;
+            return result;
+        }
+
+        /// <summary>
+        /// Write the binary verbatim at <paramref name="addr"/> (WF Method 1),
+        /// resizing the ROM if it runs past the end. The write is recorded into
+        /// <paramref name="undo"/> so it is fully undoable. Exposed for unit-testing
+        /// the insert math with a synthetic binary (no compiler needed).
+        /// </summary>
+        public static void InsertAtAddress(ROM rom, uint addr, byte[] bin, Undo.UndoData undo)
+        {
+            uint newLength = addr + (uint)bin.Length;
+            if (newLength > (uint)rom.Data.Length)
+                rom.write_resize_data(newLength);
+            rom.write_range(addr, bin, undo);
+        }
+
+        /// <summary>
+        /// Write the binary into the free area and patch a thumb jump at the hook
+        /// address (WF Method 2). The hook (8 bytes) and the routine body are both
+        /// recorded into <paramref name="undo"/>. Exposed for unit-testing the
+        /// jump-code + resize math with a synthetic binary (no compiler needed).
+        /// </summary>
+        public static void InsertHookInject(ROM rom, uint hookAddr, uint freeArea, uint hookRegister,
+            byte[] bin, Undo.UndoData undo)
+        {
+            // Resize FIRST so the free area is within bounds before any undo snapshot
+            // is taken — UndoPostion(addr,size) reads the bytes AT CONSTRUCTION and
+            // CLAMPS to the current ROM end, so snapshotting a past-the-end free area
+            // before resizing would record a truncated/empty original and break undo.
+            uint endAddr = freeArea + (uint)bin.Length;
+            if (endAddr > (uint)rom.Data.Length)
+                rom.write_resize_data(endAddr);
+
+            // Write the routine body, then patch the thumb jump at the hook site. Both
+            // go through the EXPLICIT-undodata overload (write_range(addr,data,undo)) —
+            // never the no-undodata overload, whose [ThreadStatic] ambient scope is
+            // null on this background Task.Run thread (so it would record nothing) and
+            // could otherwise absorb an unrelated UI-thread write.
+            rom.write_range(freeArea, bin, undo);
+            uint useReg = ClampHookRegister(hookRegister);
+            byte[] jumpCode = DisassemblerTrumb.MakeInjectJump(hookAddr, freeArea, useReg);
+            rom.write_range(hookAddr, jumpCode, undo);
+        }
+
+        /// <summary>Clamp the hook register to the valid r0..r8 range (WF GetSaftyRegister).</summary>
+        public static uint ClampHookRegister(uint reg)
+        {
+            if (reg > 8) return 8;
+            return reg;
+        }
+
+        // ---- Process runner (mirrors EventAssemblerCompileCore.RunProcess) ----
+
+        static void TryDelete(string path)
+        {
+            try { if (!string.IsNullOrEmpty(path) && File.Exists(path)) File.Delete(path); }
+            catch { /* best-effort cleanup */ }
+        }
+
+        /// <summary>
+        /// Run a tool and capture combined stdout+stderr (120s timeout). Shared shape
+        /// with <see cref="EventAssemblerCompileCore"/>'s runner.
+        /// </summary>
+        static string RunProcess(string exePath, string args, string workDir)
+        {
+            var psi = new ProcessStartInfo(exePath, args)
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+                WorkingDirectory = workDir,
+            };
+
+            var sb = new StringBuilder();
+            using (var proc = Process.Start(psi))
+            {
+                proc.OutputDataReceived += (_, e) => { if (e.Data != null) sb.AppendLine(e.Data); };
+                proc.ErrorDataReceived += (_, e) => { if (e.Data != null) sb.AppendLine(e.Data); };
+                proc.BeginOutputReadLine();
+                proc.BeginErrorReadLine();
+
+                if (!proc.WaitForExit(120_000))
+                {
+                    try { proc.Kill(); } catch { }
+                    return "Error: the compiler timed out after 120 seconds.";
+                }
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/FEBuilderGBA.Core/AsmCompileCore.cs
+++ b/FEBuilderGBA.Core/AsmCompileCore.cs
@@ -258,8 +258,11 @@ namespace FEBuilderGBA
                 string compilerExe = ResolveCompiler(toolDir, ext);
                 if (string.IsNullOrEmpty(compilerExe))
                 {
+                    // Name the platform-neutral base tool (gcc/g++/as) — the actual
+                    // binary carries .exe only on Windows, so a hard-coded "*as.exe"
+                    // would misname the searched-for tool on Linux/macOS.
                     result.ErrorMessage = R._("{0}の設定がありません。 設定->オプションから、{0}を設定してください。",
-                        "devkitpro_eabi " + CompilerGlobForExt(ext));
+                        "devkitpro_eabi " + CompilerBaseNameForExt(ext));
                     return result;
                 }
 
@@ -328,11 +331,13 @@ namespace FEBuilderGBA
         {
             var result = new CompileResult();
 
-            string asExe = ResolveCompiler(toolDir, ".S"); // *as.exe
+            string asExe = ResolveCompiler(toolDir, ".S"); // *as / *as.exe (platform-aware)
             if (string.IsNullOrEmpty(asExe))
             {
+                // Name the platform-neutral base tool ("as") — not "*as.exe", which
+                // would misname the searched-for binary on Linux/macOS.
                 result.ErrorMessage = R._("{0}の設定がありません。 設定->オプションから、{0}を設定してください。",
-                    "devkitpro_eabi *as.exe");
+                    "devkitpro_eabi " + CompilerBaseNameForExt(".S"));
                 return result;
             }
 

--- a/FEBuilderGBA.Core/ToolPathResolver.cs
+++ b/FEBuilderGBA.Core/ToolPathResolver.cs
@@ -169,27 +169,47 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
-        /// Resolve a devkitARM tool (e.g. <c>*gcc.exe</c>, <c>*g++.exe</c>,
-        /// <c>*as.exe</c>) by globbing the configured devkitARM tree recursively.
+        /// The recursive globs to try for a devkitARM tool with the given base name
+        /// (<c>gcc</c>/<c>g++</c>/<c>as</c>), platform-aware: on Windows the binaries
+        /// carry <c>.exe</c>; on Linux/macOS they do NOT (e.g. <c>arm-none-eabi-gcc</c>),
+        /// so a <c>*gcc.exe</c>-only search would silently fail there. Mirrors the
+        /// <see cref="GetExeNames"/> philosophy used for the Event Assembler resolver.
+        /// </summary>
+        public static string[] DevkitArmGlobs(string baseName)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return new[] { "*" + baseName + ".exe" };
+            // Linux/macOS: prefer the extension-less binary, fall back to .exe in case
+            // the tree was populated by a Windows cross-build.
+            return new[] { "*" + baseName, "*" + baseName + ".exe" };
+        }
+
+        /// <summary>
+        /// Resolve a devkitARM tool by its base name (<c>gcc</c>/<c>g++</c>/<c>as</c>),
+        /// trying the platform-appropriate globs recursively under the configured tree.
         /// Returns null when the tree or the tool is missing.
         /// </summary>
-        public static string ResolveDevkitArmTool(string glob)
+        public static string ResolveDevkitArmTool(string baseName)
         {
             string dir = ResolveDevkitArmDir();
             if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir))
                 return null;
-            string[] files = U.Directory_GetFiles_Safe(dir, glob, SearchOption.AllDirectories);
-            return files.Length > 0 ? files[0] : null;
+            foreach (string glob in DevkitArmGlobs(baseName))
+            {
+                string[] files = U.Directory_GetFiles_Safe(dir, glob, SearchOption.AllDirectories);
+                if (files.Length > 0) return files[0];
+            }
+            return null;
         }
 
-        /// <summary>Resolve the devkitARM C compiler (<c>*gcc.exe</c>), or null.</summary>
-        public static string ResolveDevkitArmGcc() => ResolveDevkitArmTool("*gcc.exe");
+        /// <summary>Resolve the devkitARM C compiler (gcc), or null.</summary>
+        public static string ResolveDevkitArmGcc() => ResolveDevkitArmTool("gcc");
 
-        /// <summary>Resolve the devkitARM C++ compiler (<c>*g++.exe</c>), or null.</summary>
-        public static string ResolveDevkitArmGpp() => ResolveDevkitArmTool("*g++.exe");
+        /// <summary>Resolve the devkitARM C++ compiler (g++), or null.</summary>
+        public static string ResolveDevkitArmGpp() => ResolveDevkitArmTool("g++");
 
-        /// <summary>Resolve the devkitARM assembler (<c>*as.exe</c>), or null.</summary>
-        public static string ResolveDevkitArmAs() => ResolveDevkitArmTool("*as.exe");
+        /// <summary>Resolve the devkitARM assembler (as), or null.</summary>
+        public static string ResolveDevkitArmAs() => ResolveDevkitArmTool("as");
 
         /// <summary>
         /// Check if the resolved EA path points to ColorzCore (vs classic EA Core.exe).

--- a/FEBuilderGBA.Core/ToolPathResolver.cs
+++ b/FEBuilderGBA.Core/ToolPathResolver.cs
@@ -155,6 +155,43 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
+        /// Resolve the devkitARM tool directory from the <c>devkitpro_eabi</c> config
+        /// marker (the as/gcc tree root is the marker's directory). Returns null when
+        /// the marker is unset or missing. Symmetric with
+        /// <see cref="ResolveEventAssembler"/> / <see cref="ResolveLynExe"/>.
+        /// </summary>
+        public static string ResolveDevkitArmDir()
+        {
+            string eabi = CoreState.Config?.at("devkitpro_eabi", "");
+            if (string.IsNullOrEmpty(eabi) || !File.Exists(eabi))
+                return null;
+            return Path.GetDirectoryName(eabi);
+        }
+
+        /// <summary>
+        /// Resolve a devkitARM tool (e.g. <c>*gcc.exe</c>, <c>*g++.exe</c>,
+        /// <c>*as.exe</c>) by globbing the configured devkitARM tree recursively.
+        /// Returns null when the tree or the tool is missing.
+        /// </summary>
+        public static string ResolveDevkitArmTool(string glob)
+        {
+            string dir = ResolveDevkitArmDir();
+            if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir))
+                return null;
+            string[] files = U.Directory_GetFiles_Safe(dir, glob, SearchOption.AllDirectories);
+            return files.Length > 0 ? files[0] : null;
+        }
+
+        /// <summary>Resolve the devkitARM C compiler (<c>*gcc.exe</c>), or null.</summary>
+        public static string ResolveDevkitArmGcc() => ResolveDevkitArmTool("*gcc.exe");
+
+        /// <summary>Resolve the devkitARM C++ compiler (<c>*g++.exe</c>), or null.</summary>
+        public static string ResolveDevkitArmGpp() => ResolveDevkitArmTool("*g++.exe");
+
+        /// <summary>Resolve the devkitARM assembler (<c>*as.exe</c>), or null.</summary>
+        public static string ResolveDevkitArmAs() => ResolveDevkitArmTool("*as.exe");
+
+        /// <summary>
         /// Check if the resolved EA path points to ColorzCore (vs classic EA Core.exe).
         /// </summary>
         public static bool IsColorzCore(string eaPath)

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20365,3 +20365,63 @@ Failed to apply the compiled ROM (size/resize limit exceeded?).
 
 :Unable to write the temporary files needed for compilation.
 Unable to write the temporary files needed for compilation.
+
+:Add via ASM/C
+Add via ASM/C
+
+:Compile a C/C++/ASM source and insert the result into the ROM.
+Compile a C/C++/ASM source and insert the result into the ROM.
+
+:Source file:
+Source file:
+
+:Select a .c / .cpp / .s / .asm file
+Select a .c / .cpp / .s / .asm file
+
+:Compile method:
+Compile method:
+
+:Insert method:
+Insert method:
+
+:Hook register:
+Hook register:
+
+:Stop on a reference to a missing label
+Stop on a reference to a missing label
+
+:Run (compile + insert)
+Run (compile + insert)
+
+:ELF -> raw binary (delete ELF)
+ELF -> raw binary (delete ELF)
+
+:ELF -> raw binary (keep ELF)
+ELF -> raw binary (keep ELF)
+
+:Convert to lyn.event (compile-only)
+Convert to lyn.event (compile-only)
+
+:Make file only (do not write to the ROM)
+Make file only (do not write to the ROM)
+
+:Write at the address
+Write at the address
+
+:Hook the address (jump to a free area)
+Hook the address (jump to a free area)
+
+:Hook address:
+Hook address:
+
+:Write to:
+Write to:
+
+:Please select a source file to import.
+Please select a source file to import.
+
+:source file
+source file
+
+:Product: {0}
+Product: {0}

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20425,3 +20425,6 @@ source file
 
 :Product: {0}
 Product: {0}
+
+:Unable to read the compiled file.\r\nfilename:{0}
+Unable to read the compiled file.\r\nfilename:{0}

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11685,3 +11685,6 @@ lyn.eventに変換(コンパイルのみ)
 
 :Product: {0}
 成果物: {0}
+
+:Unable to read the compiled file.\r\nfilename:{0}
+コンパイルしたファイルを読み込めません。\r\nfilename:{0}

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11625,3 +11625,63 @@ sym.txt を保存
 
 :Unable to write the temporary files needed for compilation.
 コンパイルに必要な一時ファイルを書き込めませんでした。
+
+:Add via ASM/C
+ASM/Cで追加
+
+:Compile a C/C++/ASM source and insert the result into the ROM.
+C/C++/ASMソースをコンパイルして、結果をROMに挿入します。
+
+:Source file:
+ソースファイル:
+
+:Select a .c / .cpp / .s / .asm file
+.c / .cpp / .s / .asm ファイルを選択
+
+:Compile method:
+コンパイル方法:
+
+:Insert method:
+挿入方法:
+
+:Hook register:
+フックレジスタ:
+
+:Stop on a reference to a missing label
+存在しないラベルを参照したら停止する
+
+:Run (compile + insert)
+実行(コンパイル + 挿入)
+
+:ELF -> raw binary (delete ELF)
+ELF -> バイナリ(ELFを削除)
+
+:ELF -> raw binary (keep ELF)
+ELF -> バイナリ(ELFを保持)
+
+:Convert to lyn.event (compile-only)
+lyn.eventに変換(コンパイルのみ)
+
+:Make file only (do not write to the ROM)
+ファイルを作成するだけ(ROMに書き込まない)
+
+:Write at the address
+アドレスに書き込む
+
+:Hook the address (jump to a free area)
+アドレスをフックする(フリーエリアにジャンプ)
+
+:Hook address:
+フックするアドレス:
+
+:Write to:
+書き込む:
+
+:Please select a source file to import.
+インポートするソースファイルを選択してください。
+
+:source file
+ソースファイル
+
+:Product: {0}
+成果物: {0}

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25526,3 +25526,6 @@ ELF -> 二进制(保留ELF)
 
 :Product: {0}
 成果物: {0}
+
+:Unable to read the compiled file.\r\nfilename:{0}
+无法读取编译后的文件。\r\nfilename:{0}

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25466,3 +25466,63 @@ TSA数量: {0}
 
 :Unable to write the temporary files needed for compilation.
 无法写入编译所需的临时文件。
+
+:Add via ASM/C
+通过ASM/C添加
+
+:Compile a C/C++/ASM source and insert the result into the ROM.
+编译C/C++/ASM源代码并将结果插入ROM。
+
+:Source file:
+源文件:
+
+:Select a .c / .cpp / .s / .asm file
+选择 .c / .cpp / .s / .asm 文件
+
+:Compile method:
+编译方法:
+
+:Insert method:
+插入方法:
+
+:Hook register:
+钩子寄存器:
+
+:Stop on a reference to a missing label
+引用不存在的标签时停止
+
+:Run (compile + insert)
+运行(编译 + 插入)
+
+:ELF -> raw binary (delete ELF)
+ELF -> 二进制(删除ELF)
+
+:ELF -> raw binary (keep ELF)
+ELF -> 二进制(保留ELF)
+
+:Convert to lyn.event (compile-only)
+转换为lyn.event(仅编译)
+
+:Make file only (do not write to the ROM)
+仅生成文件(不写入ROM)
+
+:Write at the address
+写入到地址
+
+:Hook the address (jump to a free area)
+钩住地址(跳转到空闲区域)
+
+:Hook address:
+钩子地址:
+
+:Write to:
+写入到:
+
+:Please select a source file to import.
+请选择要导入的源文件。
+
+:source file
+源文件
+
+:Product: {0}
+成果物: {0}


### PR DESCRIPTION
Fixes #1169.

Implements the Avalonia **Add-via-ASM/C** tool (was a bare scaffold over a dummy `AddrResult`), with parity to WinForms `ToolASMInsertForm`: compile a C/C++/ASM source and insert the result into the ROM. Sibling of #1170 (Add-via-Event-Assembler).

## What
- Filled `ToolASMInsertView`/`ToolASMInsertViewModel`: source picker (`.c`/`.cpp`/`.s`/`.asm`), **Compile method** (ELF→raw / KEEP_ELF / CONVERT_LYN), **Insert method** (free-area-as-data / write-at-address / hook-inject), **Store debug symbols**, **Stop on missing-label reference**, **Run (compile + insert)**, Undo, status. When `devkitpro_eabi` isn't configured the view shows the localized "set it in Settings → Options" guidance (matches WF).

## How (architecture)
- New GUI-free **`FEBuilderGBA.Core/AsmCompileCore.CompileAndInsert(...)`** porting the C/ASM→devkitARM(gcc)→ELF→`lyn`(ELF→EA)→**EA assemble** (reuses the merged `EventAssemblerCompileCore`)→insert chain. Reuses `CoreState.Config` (devkitpro_eabi), `ToolPathResolver` (added `ResolveDevkitArmGcc()` alongside `ResolveEventAssembler`/`ResolveLynExe`), the `Elf`/`MakeInjectJump`/`write_range`/`write_resize_data` Core helpers, and the EA helper's process-running pattern.
- **Insert is undoable**: writes go through explicit `Undo.UndoData` (passed to each `write_*`, not the thread-local ambient scope — correct across the background `Task.Run`), pushed via `UndoService.CommitExternal` on the UI thread. All temp file I/O guarded → localized error, never throws. Tool-not-found (gcc/lyn/EA) → localized error, zero mutation.

### Scope boundaries (intentional, documented + tracked)
- **"Make Patch"** (WF `GraphicsToolPatchMakerForm` — a separate patch-text export UI) deferred → **#1243**.
- **GoldRoad** (legacy `@thumb` assembler) deferred → **#1244** (devkitARM covers .c/.cpp/.s/.asm).

## Tests / gates (all green)
- `AsmCompileCoreTests` — insert-math (hook-inject jump-code / write-at-address / free-area resize on synthetic ROMs), per-tool not-found→localized-error (zero mutation), arg/command building, undo round-trip. (NO real-compile test — devkitARM isn't CI-buildable.)
- Core.Tests `~AsmCompile|~AvaloniaScrollViewer` **35/0**; Avalonia.Tests `~L10nCoverage|~ASMInsert` **28/0** (HaveJaAndZhTranslations PASS); FEBuilderGBA.Tests `~Avalonia|~AutomationId` **793/0**. Builds Core+Avalonia 0 err; `validate-automation-ids` 0/0; dark-mode 0 hex.

## Proof (FE8U — Add via ASM/C tool)
Fully-implemented form (source picker · compile-method · insert-method · debug-symbols · missing-label · Run); functional compile path is unit-tested (insert math + tool resolution):

<img width="700" src="https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1169-asm-insert-fe8u.png">

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 4.8 (1M context), model `claude-opus-4-8[1m]`