### PR TITLE
fix(core): resolve lyn cross-platform (no .exe on Linux/macOS) (#1246)

### DIFF
--- a/FEBuilderGBA.Core.Tests/ToolPathResolverTests.cs
+++ b/FEBuilderGBA.Core.Tests/ToolPathResolverTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace FEBuilderGBA.Core.Tests
@@ -141,6 +142,33 @@ namespace FEBuilderGBA.Core.Tests
             finally
             {
                 CoreState.BaseDirectory = savedBaseDir;
+                Directory.Delete(tempDir, true);
+            }
+        }
+
+        // #1246: on Linux/macOS the lyn binary has no .exe extension; the resolver must
+        // find the platform-appropriate name. With the old "lyn.exe"-only search this
+        // would fail on the Linux/macOS CI runners (extensionless "lyn" never matched).
+        [Fact]
+        public void ResolveLynExe_FindsPlatformAwareLynName()
+        {
+            string lynName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "lyn.exe" : "lyn";
+            string tempDir = Path.Combine(Path.GetTempPath(), "febuilder-test-" + Path.GetRandomFileName());
+            string eaExe = Path.Combine(tempDir, "ea", "ColorzCore.exe");
+            string lynPath = Path.Combine(tempDir, "ea", "Tools", lynName);
+            Directory.CreateDirectory(Path.GetDirectoryName(eaExe));
+            Directory.CreateDirectory(Path.GetDirectoryName(lynPath));
+            File.WriteAllText(eaExe, "mock");
+            File.WriteAllText(lynPath, "mock");
+
+            try
+            {
+                string result = ToolPathResolver.ResolveLynExe(eaExe);
+                Assert.NotNull(result);
+                Assert.Equal(lynPath, result);
+            }
+            finally
+            {
                 Directory.Delete(tempDir, true);
             }
         }

--- a/FEBuilderGBA.Core/ToolPathResolver.cs
+++ b/FEBuilderGBA.Core/ToolPathResolver.cs
@@ -118,9 +118,11 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
-        /// Resolve lyn.exe path from the Event Assembler directory.
-        /// Checks Tools/lyn.exe relative to the EA executable, then searches
-        /// the EA submodule's Event Assembler directory.
+        /// Resolve the lyn executable path from the Event Assembler directory.
+        /// Checks the <c>Tools/</c> dir relative to the EA executable (and its parents),
+        /// then the EA submodule's Event Assembler directory. The binary name is
+        /// platform-aware: <c>lyn.exe</c> on Windows, <c>lyn</c> (or <c>lyn.exe</c>) on
+        /// Linux/macOS — see <see cref="GetExeNames"/>.
         /// </summary>
         public static string ResolveLynExe(string eaExePath)
         {
@@ -160,7 +162,7 @@ namespace FEBuilderGBA
             return null;
         }
 
-        // Returns the first existing lyn binary (platform-aware names) in <paramref name="dir"/>, or null.
+        // Returns the first existing lyn binary (one of lynNames, platform-aware) in dir, or null.
         static string FindLynInDir(string dir, string[] lynNames)
         {
             foreach (string name in lynNames)

--- a/FEBuilderGBA.Core/ToolPathResolver.cs
+++ b/FEBuilderGBA.Core/ToolPathResolver.cs
@@ -126,12 +126,18 @@ namespace FEBuilderGBA
         {
             if (string.IsNullOrEmpty(eaExePath)) return null;
 
-            // Standard location: same dir as EA, under Tools/lyn.exe
+            // lyn carries .exe on Windows; on Linux/macOS the binary is "lyn" with no
+            // extension, so a "lyn.exe"-only search silently fails there. Try both names
+            // at every candidate location (#1246), mirroring GetExeNames for the EA/ColorzCore
+            // resolver. Benefits both the ASM/C (#1169) and Event-Assembler (#1170) chains.
+            string[] lynNames = GetExeNames("lyn");
+
+            // Standard location: same dir as EA, under Tools/
             string eaDir = Path.GetDirectoryName(eaExePath);
             if (!string.IsNullOrEmpty(eaDir))
             {
-                string standard = Path.Combine(eaDir, "Tools", "lyn.exe");
-                if (File.Exists(standard)) return standard;
+                string hit = FindLynInDir(Path.Combine(eaDir, "Tools"), lynNames);
+                if (hit != null) return hit;
 
                 // Also check parent directories (bundled layout may have deeper nesting)
                 string parent = eaDir;
@@ -139,18 +145,29 @@ namespace FEBuilderGBA
                 {
                     parent = Path.GetDirectoryName(parent);
                     if (string.IsNullOrEmpty(parent)) break;
-                    string candidate = Path.Combine(parent, "Tools", "lyn.exe");
-                    if (File.Exists(candidate)) return candidate;
+                    hit = FindLynInDir(Path.Combine(parent, "Tools"), lynNames);
+                    if (hit != null) return hit;
                 }
             }
 
             // Search from repo root
             foreach (string root in GetSearchRoots())
             {
-                string sub = Path.Combine(root, "tools", "Event-Assembler", "Event Assembler", "Tools", "lyn.exe");
-                if (File.Exists(sub)) return sub;
+                string hit = FindLynInDir(Path.Combine(root, "tools", "Event-Assembler", "Event Assembler", "Tools"), lynNames);
+                if (hit != null) return hit;
             }
 
+            return null;
+        }
+
+        // Returns the first existing lyn binary (platform-aware names) in <paramref name="dir"/>, or null.
+        static string FindLynInDir(string dir, string[] lynNames)
+        {
+            foreach (string name in lynNames)
+            {
+                string candidate = Path.Combine(dir, name);
+                if (File.Exists(candidate)) return candidate;
+            }
             return null;
         }
 


### PR DESCRIPTION
Fixes #1246.

`ToolPathResolver.ResolveLynExe` hard-coded the `lyn.exe` name at all 3 candidate locations (the EA-sibling `Tools/` dir, its parent walk, and the EA submodule path), so on **Linux/macOS** — where the binary is `lyn` with no extension — the ELF→EA conversion step silently failed to resolve the tool.

## Fix
`ResolveLynExe` now tries both names via the existing `GetExeNames("lyn")` helper (`lyn.exe` on Windows; `lyn` **and** `lyn.exe` on Linux/macOS) at every candidate location, via a small `FindLynInDir` helper. This is the same platform-aware pattern already used for the EA/ColorzCore (`GetExeNames`) and devkitARM (`DevkitArmGlobs`) resolvers.

Benefits **both** the ASM/C (#1169) and Event-Assembler (#1170) compile chains, which both depend on `ResolveLynExe`.

## Tests / gates
- New `ResolveLynExe_FindsPlatformAwareLynName` — creates the platform-appropriate `lyn`/`lyn.exe` and asserts it resolves. On the Linux/macOS CI runners this creates an **extensionless** `lyn` (which the old code never matched), so it genuinely guards the cross-platform fix; the existing `lyn.exe` + not-found tests still pass.
- `ToolPathResolver` tests: **7/0**. Core build: 0 errors.

> Core-only change (no Avalonia view / GUI surface touched), so no editor screenshot applies — the cross-platform behavior is proven by the unit test, which exercises the extensionless path on the Linux/macOS CI legs.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 4.8 (1M context), model `claude-opus-4-8[1m]`