### PR TITLE
fix(core): harden EventAssemblerCompileCore.RunProcess (null-start + kill tree) (#1250)

### DIFF
--- a/FEBuilderGBA.Core.Tests/EventAssemblerCompileCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerCompileCoreTests.cs
@@ -68,6 +68,19 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("-symOutput:", args);
         }
 
+        // #1250: the RunProcess error sentinels (process-could-not-start, timeout) must be
+        // treated as build FAILURES by IsEASuccess (no success marker) so a null Process.Start
+        // or a killed-process-tree never emits a patched ROM. Real success markers stay true.
+        [Theory]
+        [InlineData("Error: the Event Assembler process could not be started. filename:ea.exe", false)]
+        [InlineData("Error: Event Assembler timed out after 120 seconds.", false)]
+        [InlineData("Assembling...\r\nNo errors or warnings.\r\n", true)]
+        [InlineData("No errors. Please continue being awesome.", true)]
+        public void IsEASuccess_TreatsRunProcessErrorSentinelsAsFailure(string output, bool expected)
+        {
+            Assert.Equal(expected, EventAssemblerCompileCore.IsEASuccess(output));
+        }
+
         [Fact]
         public void BuildArgs_ClassicEA_UsesSymOutput()
         {

--- a/FEBuilderGBA.Core/EventAssemblerCompileCore.cs
+++ b/FEBuilderGBA.Core/EventAssemblerCompileCore.cs
@@ -337,6 +337,13 @@ namespace FEBuilderGBA
             var sb = new StringBuilder();
             using (var proc = Process.Start(psi))
             {
+                // Process.Start can return null (documented) — guard against an NRE and
+                // return a clean error. The string carries no EA success marker, so the
+                // caller's IsEASuccess treats it as a failure and emits nothing (#1250).
+                if (proc == null)
+                {
+                    return "Error: the Event Assembler process could not be started. filename:" + exePath;
+                }
                 proc.OutputDataReceived += (_, e) => { if (e.Data != null) sb.AppendLine(e.Data); };
                 proc.ErrorDataReceived += (_, e) => { if (e.Data != null) sb.AppendLine(e.Data); };
                 proc.BeginOutputReadLine();
@@ -344,7 +351,9 @@ namespace FEBuilderGBA
 
                 if (!proc.WaitForExit(120_000))
                 {
-                    try { proc.Kill(); } catch { }
+                    // Kill the WHOLE tree — an EA/build invocation may spawn child processes
+                    // that killing only the parent would orphan.
+                    try { proc.Kill(entireProcessTree: true); } catch { }
                     return "Error: Event Assembler timed out after 120 seconds.";
                 }
             }


### PR DESCRIPTION
Fixes #1250.

Follow-up surfaced during #1172 review: the merged `EventAssemblerCompileCore.RunProcess` (shared by the #1170 Event-Assembler and #1169 ASM/C chains) had the same two robustness gaps Copilot flagged on `CustomBuildCore.RunProcess`:
1. **`Process.Start(psi)` assumed non-null** — it can return null (documented), which would NRE on the next `proc.*`.
2. **Timeout killed only the parent** (`proc.Kill()`) — an EA/build invocation may spawn child processes that get orphaned.

## Fix
- Null-check `Process.Start` → return a clean error string (`"...could not be started. filename:..."`). It carries **no EA success marker**, so the caller's `IsEASuccess` treats it as a build failure → emits nothing, **zero ROM mutation**.
- `proc.Kill(entireProcessTree: true)` on timeout.

## Tests / gates
- New `IsEASuccess_TreatsRunProcessErrorSentinelsAsFailure` theory — the not-started + timeout sentinels → `false` (failure), real success markers → `true`.
- EventAssembler Core tests **21/2skip**; Core build 0 errors.

> Core-only change (no GUI surface) → screenshot-exempt; the failure-handling contract is proven by the unit test.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 4.8 (1M context), model `claude-opus-4-8[1m]`