### PR TITLE
feat(avalonia): implement Dev Translate tool (#1164)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/DevTranslateViewParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/DevTranslateViewParityTests.cs
@@ -73,6 +73,45 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.Contains("\"DevTranslateView\"", mainWindow);
         }
 
+        // --- SanitizeProgress: the status-label sanitizer (#1252 review fix) -----
+
+        [Theory]
+        [InlineData("a\r\nb", "a b")]                 // CRLF -> single space
+        [InlineData("a\nb\nc", "a b c")]              // LF -> spaces
+        [InlineData("a\tb", "a b")]                   // tab -> space
+        [InlineData("a\r\n\r\n\r\nb", "a b")]         // runs of newlines collapse to one space
+        [InlineData("  a   b  ", "a b")]              // leading/trailing + inner runs collapse
+        [InlineData("plain", "plain")]               // unchanged
+        [InlineData("", "")]                          // empty
+        public void SanitizeProgress_CollapsesWhitespaceToSingleLine(string input, string expected)
+        {
+            Assert.Equal(expected, FEBuilderGBA.Avalonia.Views.DevTranslateView.SanitizeProgress(input));
+        }
+
+        [Fact]
+        public void SanitizeProgress_TruncatesOverlongValues()
+        {
+            string input = new string('x', 500);
+            string result = FEBuilderGBA.Avalonia.Views.DevTranslateView.SanitizeProgress(input);
+            // 120 chars + the single-char ellipsis.
+            Assert.Equal(121, result.Length);
+            Assert.EndsWith("…", result);
+            Assert.StartsWith("xxxx", result);
+        }
+
+        [Fact]
+        public void SanitizeProgress_MultilineLongValue_IsSingleLineAndTruncated()
+        {
+            // A realistic worst case: a multiline untranslated target longer than
+            // the cap. Result must be one line (no newlines) and truncated.
+            string input = "line one of a very long target\r\n" + new string('y', 300) + "\r\nlast line";
+            string result = FEBuilderGBA.Avalonia.Views.DevTranslateView.SanitizeProgress(input);
+            Assert.DoesNotContain('\n', result);
+            Assert.DoesNotContain('\r', result);
+            Assert.True(result.Length <= 121, $"expected <=121 chars, got {result.Length}");
+            Assert.EndsWith("…", result);
+        }
+
         /// <summary>
         /// Parse a translate file and return the set of source keys (`:Key` lines)
         /// that have a non-empty following translation line.

--- a/FEBuilderGBA.Avalonia.Tests/DevTranslateViewParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/DevTranslateViewParityTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// Static build-gate assertions for the Developer Translation Tool view
+    /// (#1164 — Avalonia port of WF DevTranslateForm / Core MyTranslateBuild).
+    ///
+    /// Guards:
+    ///   * The code-only runtime R._ status/error literals (which the AXAML
+    ///     L10nCoverageTest cannot see) have ja AND zh translations.
+    ///   * The tool is a read-no-ROM-bytes orphan: its VM must NOT take part in
+    ///     the data-verification contract (no IDataVerifiable).
+    ///   * The view is wired into the MainWindow editor registry.
+    /// </summary>
+    public class DevTranslateViewParityTests
+    {
+        static string RepoRoot()
+        {
+            string dir = AppContext.BaseDirectory;
+            while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                dir = Path.GetDirectoryName(dir)!;
+            return dir ?? throw new InvalidOperationException("Cannot find solution root");
+        }
+
+        [Theory]
+        // Status / progress messages built at runtime via R._() (code-only).
+        [InlineData("Translating... This may take a while.")]
+        [InlineData("Translation complete. Please restart the tool.")]
+        [InlineData("Translation failed. See the log for details.")]
+        [InlineData("Converting designer strings...")]
+        [InlineData("Designer string conversion complete.")]
+        [InlineData("Reversing designer strings...")]
+        [InlineData("Designer string reverse complete.")]
+        [InlineData("Scanning: ")]
+        [InlineData("Could not open the folder picker.")]
+        [InlineData("Please select a target language (ja and auto cannot be selected).")]
+        [InlineData("Please select a valid source code folder.")]
+        public void CodeOnlyLiteral_HasJaAndZhTranslation(string literal)
+        {
+            string repo = RepoRoot();
+            var ja = LoadForwardKeys(Path.Combine(repo, "config", "translate", "ja.txt"));
+            var zh = LoadForwardKeys(Path.Combine(repo, "config", "translate", "zh.txt"));
+
+            Assert.True(ja.Contains(literal), $"ja.txt is missing a translation for: {literal}");
+            Assert.True(zh.Contains(literal), $"zh.txt is missing a translation for: {literal}");
+        }
+
+        [Fact]
+        public void ViewModel_DoesNotImplementDataVerifiable()
+        {
+            // This is a read-no-ROM-bytes tool; the VM is an orphan by the
+            // FEBuilderGBA.Tests data-verification contract. Even MENTIONING the
+            // interface name in the VM source would trip NoOrphanVMs, so assert
+            // the source never references it.
+            string repo = RepoRoot();
+            string vm = Path.Combine(repo, "FEBuilderGBA.Avalonia", "ViewModels", "DevTranslateViewModel.cs");
+            string src = File.ReadAllText(vm);
+            Assert.DoesNotContain("IDataVerifiable", src);
+        }
+
+        [Fact]
+        public void View_IsRegisteredInMainWindow()
+        {
+            string repo = RepoRoot();
+            string mainWindow = File.ReadAllText(
+                Path.Combine(repo, "FEBuilderGBA.Avalonia", "Views", "MainWindow.axaml.cs"));
+            // The editor factory entry + the menu button handler must both exist.
+            Assert.Contains("Open<DevTranslateView>()", mainWindow);
+            Assert.Contains("\"DevTranslateView\"", mainWindow);
+        }
+
+        /// <summary>
+        /// Parse a translate file and return the set of source keys (`:Key` lines)
+        /// that have a non-empty following translation line.
+        /// </summary>
+        static HashSet<string> LoadForwardKeys(string path)
+        {
+            var keys = new HashSet<string>(StringComparer.Ordinal);
+            if (!File.Exists(path)) return keys;
+
+            string? src = null;
+            foreach (string raw in File.ReadLines(path))
+            {
+                if (raw.Length == 0) { src = null; continue; }
+                if (src == null)
+                {
+                    if (raw[0] != ':') continue;
+                    src = raw.Substring(1).Replace("\\r\\n", "\r\n");
+                }
+                else
+                {
+                    if (!string.IsNullOrWhiteSpace(raw))
+                        keys.Add(src);
+                    src = null;
+                }
+            }
+            return keys;
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/DevTranslateViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/DevTranslateViewModel.cs
@@ -1,33 +1,239 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
 
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
+    /// <summary>
+    /// Developer Translation tool (WF <c>DevTranslateForm</c> / Core
+    /// <c>MyTranslateBuild</c>). Builds the app's own translation resources from
+    /// source: scans C# source, patches, MODs and config data and seeds
+    /// <c>config/translate/&lt;lang&gt;.txt</c> (Translate), plus the Designer.cs
+    /// convert/reverse helpers. This is a DEVELOPER workflow — it reads source
+    /// files and writes translation .txt files, it does NOT touch any ROM bytes,
+    /// so it is a read-no-ROM-bytes orphan and does not participate in the
+    /// data-verification contract.
+    /// </summary>
     public class DevTranslateViewModel : ViewModelBase
     {
-        uint _currentAddr;
-        bool _isLoaded;
+        // ---- Language combos (func_lang_ resource) ----
+        // Each entry is (code, label) e.g. ("en", "English"). "auto" and "ja"
+        // are filtered out for the build/convert targets — you cannot build the
+        // Japanese source from itself, and "auto" is not a concrete language.
+        public ObservableCollection<LangItem> BuildLanguages { get; } = new();
+        public ObservableCollection<LangItem> DesignLanguages { get; } = new();
 
-        public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
-        public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
-
-        public List<AddrResult> LoadList()
+        LangItem _selectedBuildLanguage;
+        public LangItem SelectedBuildLanguage
         {
-            ROM rom = CoreState.ROM;
-            if (rom?.RomInfo == null) return new List<AddrResult>();
+            get => _selectedBuildLanguage;
+            set => SetField(ref _selectedBuildLanguage, value);
+        }
 
-            var result = new List<AddrResult>();
-            result.Add(new AddrResult(0, "Developer Translation Tool", 0));
+        LangItem _selectedDesignLanguage;
+        public LangItem SelectedDesignLanguage
+        {
+            get => _selectedDesignLanguage;
+            set => SetField(ref _selectedDesignLanguage, value);
+        }
+
+        // ---- Source directory + options ----
+        string _buildSourcePath = "";
+        public string BuildSourcePath
+        {
+            get => _buildSourcePath;
+            set => SetField(ref _buildSourcePath, value);
+        }
+
+        string _designSourcePath = "";
+        public string DesignSourcePath
+        {
+            get => _designSourcePath;
+            set => SetField(ref _designSourcePath, value);
+        }
+
+        bool _englishBase;
+        public bool EnglishBase
+        {
+            get => _englishBase;
+            set => SetField(ref _englishBase, value);
+        }
+
+        // ---- Status / progress ----
+        string _statusMessage = "";
+        public string StatusMessage
+        {
+            get => _statusMessage;
+            set => SetField(ref _statusMessage, value);
+        }
+
+        public DevTranslateViewModel()
+        {
+            LoadLanguages();
+        }
+
+        /// <summary>
+        /// Populate both language combos from the <c>func_lang_</c> resource,
+        /// excluding "auto" and "ja" (parity with WF DevTranslateForm's guard).
+        /// Falls back to the built-in en/zh set when the resource file is absent
+        /// (e.g. headless/test context with no config tree).
+        /// </summary>
+        void LoadLanguages()
+        {
+            BuildLanguages.Clear();
+            DesignLanguages.Clear();
+
+            foreach (var item in LoadFuncLangResource())
+            {
+                BuildLanguages.Add(item);
+                DesignLanguages.Add(item);
+            }
+
+            if (BuildLanguages.Count > 0)
+                SelectedBuildLanguage = BuildLanguages[0];
+            if (DesignLanguages.Count > 0)
+                SelectedDesignLanguage = DesignLanguages[0];
+        }
+
+        static List<LangItem> LoadFuncLangResource()
+        {
+            var result = new List<LangItem>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            string fullfilename = null;
+            try
+            {
+                if (!string.IsNullOrEmpty(CoreState.BaseDirectory))
+                    fullfilename = U.ConfigDataFilename("func_lang_");
+            }
+            catch
+            {
+                // BaseDirectory or ROM may be null in test/headless contexts.
+            }
+
+            if (!string.IsNullOrEmpty(fullfilename) && File.Exists(fullfilename))
+            {
+                foreach (string raw in File.ReadAllLines(fullfilename))
+                {
+                    string line = raw;
+                    try
+                    {
+                        if (U.IsComment(line) || U.OtherLangLine(line))
+                            continue;
+                    }
+                    catch
+                    {
+                        // OtherLangLine may throw when CoreState.ROM is null.
+                    }
+                    line = U.ClipComment(line).Trim();
+                    if (string.IsNullOrEmpty(line))
+                        continue;
+
+                    string[] sp = line.Split('\t');
+                    if (sp.Length < 2)
+                        continue;
+                    string code = sp[0].Trim();
+                    string label = sp[1].Trim();
+                    if (!IsSelectableTarget(code))
+                        continue;
+                    if (seen.Add(code))
+                        result.Add(new LangItem(code, label));
+                }
+            }
+
+            if (result.Count == 0)
+            {
+                // Minimal fallback so the tool is usable even without the config
+                // tree. These are the languages the project actually ships.
+                if (seen.Add("en")) result.Add(new LangItem("en", "English"));
+                if (seen.Add("zh")) result.Add(new LangItem("zh", "中文"));
+            }
+
             return result;
         }
 
-        public void LoadEntry(uint addr)
+        // "auto", "ja" and the empty value are not valid build/convert targets
+        // (WF DevTranslateForm shows a stop-error for them).
+        static bool IsSelectableTarget(string code)
         {
-            ROM rom = CoreState.ROM;
-            if (rom == null) return;
-
-            CurrentAddr = addr;
-            IsLoaded = true;
+            if (string.IsNullOrEmpty(code)) return false;
+            if (code == "auto") return false;
+            if (code == "ja") return false;
+            return true;
         }
+
+        /// <summary>
+        /// Run the full build scan (ScanPatch + ScanMOD + ScanData + ScanCS) for
+        /// the selected build language. Returns true on success. Designed to run
+        /// on a background thread; <paramref name="onProgress"/> reports the file
+        /// currently being scanned. Throws on I/O / translate failures so the
+        /// caller can surface a localized status.
+        /// </summary>
+        public bool RunBuild(string lang, string sourcePath, bool englishBase, Action<string> onProgress)
+        {
+            if (string.IsNullOrEmpty(lang) || !IsSelectableTarget(lang))
+                return false;
+            if (string.IsNullOrEmpty(sourcePath) || !Directory.Exists(sourcePath))
+                return false;
+
+            var t = new MyTranslateBuild(lang, englishBase, onProgress);
+            t.ScanPatch();
+            t.ScanMOD();
+            t.ScanData();
+            t.ScanCS(sourcePath);
+            return true;
+        }
+
+        /// <summary>
+        /// Run DesignStringConvert: replace Japanese string literals in
+        /// *.Designer.cs files with translations from the selected language
+        /// (writes a .tlink.txt sidecar so the change is reversible).
+        /// </summary>
+        public bool RunDesignConvert(string lang, string sourcePath, Action<string> onProgress)
+        {
+            if (string.IsNullOrEmpty(lang) || !IsSelectableTarget(lang))
+                return false;
+            if (string.IsNullOrEmpty(sourcePath) || !Directory.Exists(sourcePath))
+                return false;
+
+            var t = new MyTranslateBuild(lang, false, onProgress);
+            t.DesignStringConvert(sourcePath);
+            return true;
+        }
+
+        /// <summary>
+        /// Run DesignStringReverse: restore the Japanese literals in
+        /// *.Designer.cs files from the .tlink.txt sidecar and back-fill the
+        /// translate resource with the current (translated) strings.
+        /// </summary>
+        public bool RunDesignReverse(string lang, string sourcePath, Action<string> onProgress)
+        {
+            if (string.IsNullOrEmpty(lang) || !IsSelectableTarget(lang))
+                return false;
+            if (string.IsNullOrEmpty(sourcePath) || !Directory.Exists(sourcePath))
+                return false;
+
+            var t = new MyTranslateBuild(lang, false, onProgress);
+            t.DesignStringReverse(sourcePath);
+            return true;
+        }
+    }
+
+    /// <summary>A target language entry: code (e.g. "en") + display label.</summary>
+    public sealed class LangItem
+    {
+        public string Code { get; }
+        public string Label { get; }
+
+        public LangItem(string code, string label)
+        {
+            Code = code;
+            Label = label;
+        }
+
+        // Shown in the ComboBox. Prefer "label (code)" so the dev sees both.
+        public override string ToString()
+            => string.IsNullOrEmpty(Label) || Label == Code ? Code : $"{Label} ({Code})";
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/DevTranslateView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/DevTranslateView.axaml
@@ -1,21 +1,113 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
         x:Class="FEBuilderGBA.Avalonia.Views.DevTranslateView"
-        Title="Developer Translation Tool" Width="768" Height="380"
-        SizeToContent="WidthAndHeight">
-  <Grid ColumnDefinitions="250,*">
-    <controls:AddressListControl AutomationProperties.AutomationId="DevTranslate_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
+        Title="Developer Translation Tool" Width="620" Height="560"
+        WindowStartupLocation="CenterOwner"
+        SizeToContent="Height">
+  <!-- Developer translation builder (WF DevTranslateForm / Core MyTranslateBuild).
+       Scans C# source + patches + MODs + config data and seeds the app's own
+       config/translate/<lang>.txt resource (Translate), plus the *.Designer.cs
+       convert/reverse helpers. READS source files, WRITES translation .txt files.
+       NO ROM mutation, NO Undo, NO address list — so the VM does NOT implement
+       IDataVerifiable. Language combos are bound to func_lang_ resource items. -->
+  <ScrollViewer VerticalScrollBarVisibility="Auto">
+    <StackPanel Margin="16" Spacing="10">
 
-    <ScrollViewer Grid.Column="1" Margin="4">
-      <StackPanel Spacing="8" Margin="8">
-        <TextBlock Text="Developer Translation Tool" FontSize="18" FontWeight="Bold" />
+      <TextBlock Text="Developer Translation Tool" FontSize="18" FontWeight="Bold" />
+      <TextBlock Text="Build the app's own translation files from source. Developer-only."
+                 TextWrapping="Wrap" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="DevTranslate_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
-        </Grid>
-      </StackPanel>
-    </ScrollViewer>
-  </Grid>
+      <!-- ============ Build (Translate) section ============ -->
+      <Border BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1"
+              Padding="10" Margin="0,4,0,0">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Build translation resource" FontWeight="Bold" />
+          <TextBlock Text="Scans patches, MODs, data and C# source, then writes config/translate/&lt;lang&gt;.txt."
+                     TextWrapping="Wrap" />
+
+          <!-- Target language -->
+          <Grid ColumnDefinitions="140,*">
+            <TextBlock Grid.Column="0" Text="To language:" VerticalAlignment="Center" />
+            <ComboBox AutomationProperties.AutomationId="DevTranslate_BuildLang_Combo"
+                      Grid.Column="1" Name="BuildLangCombo"
+                      HorizontalAlignment="Stretch"
+                      ItemsSource="{Binding BuildLanguages}"
+                      SelectedItem="{Binding SelectedBuildLanguage}" />
+          </Grid>
+
+          <!-- Source directory -->
+          <Grid ColumnDefinitions="140,*,Auto">
+            <TextBlock Grid.Column="0" Text="Source folder:" VerticalAlignment="Center" />
+            <TextBox AutomationProperties.AutomationId="DevTranslate_BuildSource_Input"
+                     Grid.Column="1" Name="BuildSourceBox"
+                     Text="{Binding BuildSourcePath}"
+                     Watermark="Select the C# source code folder" />
+            <Button AutomationProperties.AutomationId="DevTranslate_BuildSourceBrowse_Button"
+                    Grid.Column="2" Content="Browse..." Margin="6,0,0,0"
+                    Click="BuildSourceBrowse_Click" />
+          </Grid>
+
+          <CheckBox AutomationProperties.AutomationId="DevTranslate_EnglishBase_Check"
+                    Name="EnglishBaseCheck"
+                    Content="Translate from English base (en.txt) when available"
+                    IsChecked="{Binding EnglishBase}" />
+
+          <Button AutomationProperties.AutomationId="DevTranslate_Build_Button"
+                  Name="BuildButton" Content="Translate (build)"
+                  HorizontalAlignment="Left"
+                  Click="Build_Click" />
+        </StackPanel>
+      </Border>
+
+      <!-- ============ Designer string convert/reverse section ============ -->
+      <Border BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1"
+              Padding="10" Margin="0,4,0,0">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Designer string convert / reverse" FontWeight="Bold" />
+          <TextBlock Text="Replace Japanese literals in *.Designer.cs with translations, or restore them."
+                     TextWrapping="Wrap" />
+
+          <!-- Target language -->
+          <Grid ColumnDefinitions="140,*">
+            <TextBlock Grid.Column="0" Text="To language:" VerticalAlignment="Center" />
+            <ComboBox AutomationProperties.AutomationId="DevTranslate_DesignLang_Combo"
+                      Grid.Column="1" Name="DesignLangCombo"
+                      HorizontalAlignment="Stretch"
+                      ItemsSource="{Binding DesignLanguages}"
+                      SelectedItem="{Binding SelectedDesignLanguage}" />
+          </Grid>
+
+          <!-- Source directory -->
+          <Grid ColumnDefinitions="140,*,Auto">
+            <TextBlock Grid.Column="0" Text="Source folder:" VerticalAlignment="Center" />
+            <TextBox AutomationProperties.AutomationId="DevTranslate_DesignSource_Input"
+                     Grid.Column="1" Name="DesignSourceBox"
+                     Text="{Binding DesignSourcePath}"
+                     Watermark="Select the C# source code folder" />
+            <Button AutomationProperties.AutomationId="DevTranslate_DesignSourceBrowse_Button"
+                    Grid.Column="2" Content="Browse..." Margin="6,0,0,0"
+                    Click="DesignSourceBrowse_Click" />
+          </Grid>
+
+          <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button AutomationProperties.AutomationId="DevTranslate_DesignConvert_Button"
+                    Name="DesignConvertButton" Content="Convert (JP to lang)"
+                    Click="DesignConvert_Click" />
+            <Button AutomationProperties.AutomationId="DevTranslate_DesignReverse_Button"
+                    Name="DesignReverseButton" Content="Reverse (lang to JP)"
+                    Click="DesignReverse_Click" />
+          </StackPanel>
+        </StackPanel>
+      </Border>
+
+      <!-- Status -->
+      <Border BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1"
+              Padding="8" Margin="0,4,0,0">
+        <TextBlock AutomationProperties.AutomationId="DevTranslate_Status_Label"
+                   Name="StatusText" Text="{Binding StatusMessage}"
+                   TextWrapping="Wrap" MinHeight="20" />
+      </Border>
+
+    </StackPanel>
+  </ScrollViewer>
 </Window>

--- a/FEBuilderGBA.Avalonia/Views/DevTranslateView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/DevTranslateView.axaml.cs
@@ -69,6 +69,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (!ValidateSource(source)) return;
 
             SetButtonsEnabled(false);
+            ResetProgress();
             _vm.StatusMessage = R._("Translating... This may take a while.");
             try
             {
@@ -97,6 +98,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (!ValidateSource(source)) return;
 
             SetButtonsEnabled(false);
+            ResetProgress();
             _vm.StatusMessage = R._("Converting designer strings...");
             try
             {
@@ -125,6 +127,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (!ValidateSource(source)) return;
 
             SetButtonsEnabled(false);
+            ResetProgress();
             _vm.StatusMessage = R._("Reversing designer strings...");
             try
             {
@@ -144,14 +147,61 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
-        // Called from the background scan thread; marshal the status update onto
-        // the UI thread (mirrors the WF InputFormRef.DoEvents progress pump).
-        void ReportProgress(string filename)
+        // Min interval between status-label UI posts during a scan. MyTranslateBuild
+        // fires onProgress per file AND per untranslated string target, which can be
+        // many thousands of events for a large scan — posting every one would
+        // saturate the UI thread. We coalesce to at most one post per interval.
+        const long ProgressThrottleMs = 150;
+        // Max status-label length; progress targets can be very long multiline text.
+        const int ProgressMaxLength = 120;
+
+        long _lastProgressPostTicks;
+
+        // Reset the throttle gate so the first progress event of a fresh scan always
+        // shows (otherwise a quick second scan could swallow its first update).
+        void ResetProgress() => _lastProgressPostTicks = 0;
+
+        // Called from the background scan thread; marshal a sanitized + throttled
+        // status update onto the UI thread (mirrors the WF InputFormRef.DoEvents
+        // progress pump). The trailing completion message set after the awaited scan
+        // always overwrites the last in-flight progress, so the final state is exact.
+        void ReportProgress(string target)
         {
-            Dispatcher.UIThread.Post(() =>
+            long now = Environment.TickCount64;
+            // Best-effort throttle: a stale read here only means one extra/skipped
+            // post, which is harmless for a progress indicator (no lock needed).
+            if (now - _lastProgressPostTicks < ProgressThrottleMs)
+                return;
+            _lastProgressPostTicks = now;
+
+            string text = R._("Scanning: ") + SanitizeProgress(target);
+            Dispatcher.UIThread.Post(() => _vm.StatusMessage = text);
+        }
+
+        // Collapse a progress target to a single readable line: turn any newline /
+        // tab / carriage-return into a space, collapse runs of whitespace, trim, and
+        // truncate over-long values so the status label stays one short line.
+        internal static string SanitizeProgress(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return "";
+
+            var sb = new System.Text.StringBuilder(value.Length);
+            bool prevSpace = false;
+            foreach (char c in value)
             {
-                _vm.StatusMessage = R._("Scanning: ") + filename;
-            });
+                char ch = (c == '\r' || c == '\n' || c == '\t') ? ' ' : c;
+                bool isSpace = ch == ' ';
+                if (isSpace && prevSpace)
+                    continue;
+                sb.Append(ch);
+                prevSpace = isSpace;
+            }
+
+            string collapsed = sb.ToString().Trim();
+            if (collapsed.Length > ProgressMaxLength)
+                collapsed = collapsed.Substring(0, ProgressMaxLength) + "…";
+            return collapsed;
         }
 
         bool ValidateLanguage(string lang)

--- a/FEBuilderGBA.Avalonia/Views/DevTranslateView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/DevTranslateView.axaml.cs
@@ -1,57 +1,188 @@
 using System;
+using System.IO;
+using System.Threading.Tasks;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
+using global::Avalonia.Threading;
+using FEBuilderGBA.Avalonia.Dialogs;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
+    /// <summary>
+    /// Developer Translation Tool — builds the app's own translation resources
+    /// from source (WF <c>DevTranslateForm</c> / Core <c>MyTranslateBuild</c>).
+    /// Three operations: Translate (full build scan → config/translate/&lt;lang&gt;.txt),
+    /// DesignStringConvert and DesignStringReverse (*.Designer.cs). READS source
+    /// files, WRITES translation .txt files. NO ROM mutation, NO Undo, NO address
+    /// list — a read-no-ROM-bytes tool (orphan by the data-verification contract).
+    /// </summary>
     public partial class DevTranslateView : TranslatedWindow, IEditorView
     {
         readonly DevTranslateViewModel _vm = new();
 
         public string ViewTitle => "Developer Translation Tool";
-        public bool IsLoaded => _vm.IsLoaded;
+        public bool IsLoaded => true;
 
         public DevTranslateView()
         {
             InitializeComponent();
-            EntryList.SelectedAddressChanged += OnSelected;
-            Opened += (_, _) => LoadList();
+            DataContext = _vm;
         }
 
-        void LoadList()
+        async void BuildSourceBrowse_Click(object? sender, RoutedEventArgs e)
+        {
+            string? path = await PickSourceFolder();
+            if (!string.IsNullOrEmpty(path))
+                _vm.BuildSourcePath = path;
+        }
+
+        async void DesignSourceBrowse_Click(object? sender, RoutedEventArgs e)
+        {
+            string? path = await PickSourceFolder();
+            if (!string.IsNullOrEmpty(path))
+                _vm.DesignSourcePath = path;
+        }
+
+        async Task<string?> PickSourceFolder()
         {
             try
             {
-                var items = _vm.LoadList();
-                EntryList.SetItems(items);
+                return await FileDialogHelper.OpenProjectFolder(this);
             }
             catch (Exception ex)
             {
-                Log.Error("DevTranslateView.LoadList failed: {0}", ex.Message);
+                Log.Error("DevTranslateView.PickSourceFolder failed: " + ex.ToString());
+                _vm.StatusMessage = R._("Could not open the folder picker.");
+                return null;
             }
         }
 
-        void OnSelected(uint addr)
+        async void Build_Click(object? sender, RoutedEventArgs e)
         {
+            string lang = _vm.SelectedBuildLanguage?.Code ?? "";
+            string source = _vm.BuildSourcePath;
+            bool englishBase = _vm.EnglishBase;
+
+            if (!ValidateLanguage(lang)) return;
+            if (!ValidateSource(source)) return;
+
+            SetButtonsEnabled(false);
+            _vm.StatusMessage = R._("Translating... This may take a while.");
             try
             {
-                _vm.LoadEntry(addr);
-                UpdateUI();
+                bool ok = await Task.Run(() => _vm.RunBuild(lang, source, englishBase, ReportProgress));
+                _vm.StatusMessage = ok
+                    ? R._("Translation complete. Please restart the tool.")
+                    : R._("Translation failed. See the log for details.");
             }
             catch (Exception ex)
             {
-                Log.Error("DevTranslateView.OnSelected failed: {0}", ex.Message);
+                Log.Error("DevTranslateView.Build failed: " + ex.ToString());
+                _vm.StatusMessage = R._("Translation failed. See the log for details.");
+            }
+            finally
+            {
+                SetButtonsEnabled(true);
             }
         }
 
-        void UpdateUI()
+        async void DesignConvert_Click(object? sender, RoutedEventArgs e)
         {
-            AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            string lang = _vm.SelectedDesignLanguage?.Code ?? "";
+            string source = _vm.DesignSourcePath;
+
+            if (!ValidateLanguage(lang)) return;
+            if (!ValidateSource(source)) return;
+
+            SetButtonsEnabled(false);
+            _vm.StatusMessage = R._("Converting designer strings...");
+            try
+            {
+                bool ok = await Task.Run(() => _vm.RunDesignConvert(lang, source, ReportProgress));
+                _vm.StatusMessage = ok
+                    ? R._("Designer string conversion complete.")
+                    : R._("Translation failed. See the log for details.");
+            }
+            catch (Exception ex)
+            {
+                Log.Error("DevTranslateView.DesignConvert failed: " + ex.ToString());
+                _vm.StatusMessage = R._("Translation failed. See the log for details.");
+            }
+            finally
+            {
+                SetButtonsEnabled(true);
+            }
         }
 
-        public void NavigateTo(uint address) => EntryList.SelectAddress(address);
-        public void SelectFirstItem() => EntryList.SelectFirst();
+        async void DesignReverse_Click(object? sender, RoutedEventArgs e)
+        {
+            string lang = _vm.SelectedDesignLanguage?.Code ?? "";
+            string source = _vm.DesignSourcePath;
+
+            if (!ValidateLanguage(lang)) return;
+            if (!ValidateSource(source)) return;
+
+            SetButtonsEnabled(false);
+            _vm.StatusMessage = R._("Reversing designer strings...");
+            try
+            {
+                bool ok = await Task.Run(() => _vm.RunDesignReverse(lang, source, ReportProgress));
+                _vm.StatusMessage = ok
+                    ? R._("Designer string reverse complete.")
+                    : R._("Translation failed. See the log for details.");
+            }
+            catch (Exception ex)
+            {
+                Log.Error("DevTranslateView.DesignReverse failed: " + ex.ToString());
+                _vm.StatusMessage = R._("Translation failed. See the log for details.");
+            }
+            finally
+            {
+                SetButtonsEnabled(true);
+            }
+        }
+
+        // Called from the background scan thread; marshal the status update onto
+        // the UI thread (mirrors the WF InputFormRef.DoEvents progress pump).
+        void ReportProgress(string filename)
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                _vm.StatusMessage = R._("Scanning: ") + filename;
+            });
+        }
+
+        bool ValidateLanguage(string lang)
+        {
+            if (string.IsNullOrEmpty(lang) || lang == "auto" || lang == "ja")
+            {
+                _vm.StatusMessage = R._("Please select a target language (ja and auto cannot be selected).");
+                return false;
+            }
+            return true;
+        }
+
+        bool ValidateSource(string source)
+        {
+            if (string.IsNullOrEmpty(source) || !Directory.Exists(source))
+            {
+                _vm.StatusMessage = R._("Please select a valid source code folder.");
+                return false;
+            }
+            return true;
+        }
+
+        void SetButtonsEnabled(bool enabled)
+        {
+            BuildButton.IsEnabled = enabled;
+            DesignConvertButton.IsEnabled = enabled;
+            DesignReverseButton.IsEnabled = enabled;
+        }
+
+        // IEditorView — this tool has no navigable address list; these are no-ops.
+        public void NavigateTo(uint address) { }
+        public void SelectFirstItem() { }
     }
 }

--- a/FEBuilderGBA.Core.Tests/MyTranslateBuildTests.cs
+++ b/FEBuilderGBA.Core.Tests/MyTranslateBuildTests.cs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Core tests for MyTranslateBuild (#1164) — the developer translation builder
+// moved from WinForms so the Avalonia Dev Translate tool can reuse it.
+//
+// Fully offline: the test pre-seeds the <lang>.txt resource with a translation
+// for the synthetic non-ASCII literal, so MakeTranslate resolves it locally and
+// NEVER calls the Google translate engine (no network). It asserts that ScanCS
+// extracts the non-ASCII C# string literal and writes it into the output
+// config/translate/<lang>.txt resource. The onProgress callback is exercised too.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class MyTranslateBuildTests
+    {
+        // A non-ASCII Japanese literal that ScanCS must extract from C# source.
+        const string NonAsciiLiteral = "テスト文字列";
+        const string SeededTranslation = "TestString";
+
+        [Fact]
+        public void ScanCS_ExtractsNonAsciiLiteral_AndWritesToLangResource()
+        {
+            string baseDir = Path.Combine(Path.GetTempPath(), "fe_devtranslate_" + Guid.NewGuid().ToString("N"));
+            string savedBaseDir = CoreState.BaseDirectory;
+            try
+            {
+                // --- Arrange a minimal config tree ---------------------------
+                string translateDir = Path.Combine(baseDir, "config", "translate");
+                Directory.CreateDirectory(translateDir);
+                // Empty data + patch2 dirs so ScanData/ScanPatch/ScanMOD no-op
+                // cleanly (the build VM runs them; here we only call ScanCS).
+                Directory.CreateDirectory(Path.Combine(baseDir, "config", "data"));
+                Directory.CreateDirectory(Path.Combine(baseDir, "config", "patch2"));
+
+                // Seed en.txt resource so MyTranslateBuild's ctor LoadResource
+                // finds a file, and pre-translate the non-ASCII literal so
+                // MakeTranslate returns locally (no network call).
+                string langFile = Path.Combine(translateDir, "en.txt");
+                File.WriteAllText(langFile,
+                    ":" + NonAsciiLiteral + "\r\n" + SeededTranslation + "\r\n\r\n");
+
+                CoreState.BaseDirectory = baseDir;
+
+                // A synthetic C# source file containing the non-ASCII literal.
+                string sourceDir = Path.Combine(baseDir, "src");
+                Directory.CreateDirectory(sourceDir);
+                File.WriteAllText(Path.Combine(sourceDir, "Sample.cs"),
+                    "public class Sample { string F() { return R._(\"" + NonAsciiLiteral + "\"); } }\r\n");
+
+                // Capture progress callbacks (replaces InputFormRef.DoEvents).
+                var progressed = new List<string>();
+                Action<string> onProgress = f => progressed.Add(f);
+
+                // --- Act -----------------------------------------------------
+                var t = new MyTranslateBuild("en", false, onProgress);
+                t.ScanCS(sourceDir);
+
+                // --- Assert --------------------------------------------------
+                // ScanCS rewrites config/translate/en.txt with the extracted
+                // literals. The output must contain the extracted non-ASCII key
+                // line ":<literal>" and its seeded translation.
+                Assert.True(File.Exists(langFile), "expected en.txt output to exist");
+                string output = File.ReadAllText(langFile);
+                Assert.Contains(":" + NonAsciiLiteral, output);
+                Assert.Contains(SeededTranslation, output);
+
+                // The progress callback must have fired for the scanned .cs file.
+                Assert.Contains(progressed, p => p.EndsWith("Sample.cs", StringComparison.Ordinal));
+            }
+            finally
+            {
+                CoreState.BaseDirectory = savedBaseDir;
+                try { if (Directory.Exists(baseDir)) Directory.Delete(baseDir, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void ScanCS_IgnoresPureAsciiLiterals()
+        {
+            string baseDir = Path.Combine(Path.GetTempPath(), "fe_devtranslate_" + Guid.NewGuid().ToString("N"));
+            string savedBaseDir = CoreState.BaseDirectory;
+            try
+            {
+                string translateDir = Path.Combine(baseDir, "config", "translate");
+                Directory.CreateDirectory(translateDir);
+                string langFile = Path.Combine(translateDir, "en.txt");
+                File.WriteAllText(langFile, "");
+
+                CoreState.BaseDirectory = baseDir;
+
+                string sourceDir = Path.Combine(baseDir, "src");
+                Directory.CreateDirectory(sourceDir);
+                // Only ASCII literals — none should be extracted.
+                File.WriteAllText(Path.Combine(sourceDir, "AsciiOnly.cs"),
+                    "public class AsciiOnly { string F() { return \"plain ascii\"; } }\r\n");
+
+                var t = new MyTranslateBuild("en", false, null);
+                t.ScanCS(sourceDir);
+
+                string output = File.ReadAllText(langFile);
+                Assert.DoesNotContain(":plain ascii", output);
+            }
+            finally
+            {
+                CoreState.BaseDirectory = savedBaseDir;
+                try { if (Directory.Exists(baseDir)) Directory.Delete(baseDir, true); } catch { }
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Core/MyTranslateBuild.cs
+++ b/FEBuilderGBA.Core/MyTranslateBuild.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Diagnostics;
@@ -6,14 +6,24 @@ using System.Text;
 
 namespace FEBuilderGBA
 {
-    class MyTranslateBuild
+    // Developer translation builder: scans C# source, patches, MODs and data files
+    // and seeds the config/translate/<lang>.txt resource (plus the Designer.cs
+    // convert/reverse helpers). Moved to Core so the Avalonia Dev Translate tool can
+    // reuse it; the only WinForms coupling was InputFormRef.DoEvents progress pumps,
+    // replaced here with an optional onProgress callback. (#1164)
+    public class MyTranslateBuild
     {
-        public MyTranslateBuild(string lang,bool isEnglishBase = false)
+        // Optional progress callback invoked per-file/per-string as the scan walks.
+        // Mirrors the WinForms InputFormRef.DoEvents(null, filename) progress pump.
+        readonly Action<string> _onProgress;
+
+        public MyTranslateBuild(string lang, bool isEnglishBase = false, Action<string> onProgress = null)
         {
+            this._onProgress = onProgress;
             this.Lang = lang;
             this.GoogleTranslateLang = lang_to_googlelang(lang);
 
-            string resoucefilename = System.IO.Path.Combine(Program.BaseDirectory, "config", "translate", lang + ".txt");
+            string resoucefilename = System.IO.Path.Combine(CoreState.BaseDirectory, "config", "translate", lang + ".txt");
             this.TranslateResource = new MyTranslateResourceLow();
             this.TranslateResource.LoadResource(resoucefilename);
 
@@ -21,7 +31,7 @@ namespace FEBuilderGBA
             if (isEnglishBase && lang != "en")
             {
                 //英語から翻訳する 日本語->多言語 より、 英語->多言語の方が効率が良い場合がある.
-                string resoucefilenameEN = System.IO.Path.Combine(Program.BaseDirectory, "config", "translate", "en.txt");
+                string resoucefilenameEN = System.IO.Path.Combine(CoreState.BaseDirectory, "config", "translate", "en.txt");
                 if (File.Exists(resoucefilenameEN))
                 {
                     this.TranslateResourceEN = new MyTranslateResourceLow();
@@ -32,8 +42,12 @@ namespace FEBuilderGBA
             //一行ずつ翻訳したものをキャッシュにいれる.
             this.TranslateCache = this.TranslateResource.ConvertOnelineSplitWord();
             //固定文の翻訳辞書
-            this.TransDic = new Dictionary<string, string>();
-            TranslateTextUtil.AppendFixedDic(this.TransDic, "ja", lang);
+            this.TransDic = TranslateTextUtilCore.LoadFixedDic("ja", lang);
+        }
+
+        void Progress(string filename)
+        {
+            this._onProgress?.Invoke(filename);
         }
 
         MyTranslateResourceLow TranslateResource;
@@ -52,7 +66,7 @@ namespace FEBuilderGBA
                 string[] files = U.Directory_GetFiles_Safe(source_path, "*.cs", SearchOption.TopDirectoryOnly);
                 foreach (string fullfilename in files)
                 {
-                    InputFormRef.DoEvents(null, fullfilename);
+                    Progress(fullfilename);
                     ScanStringForSourceCode(fullfilename);
                 }
             }
@@ -70,7 +84,7 @@ namespace FEBuilderGBA
 
             for (int next = index + 1; next < lines.Length; next++)
             {
-                //行末が " +\r\nかどうかを見る 
+                //行末が " +\r\nかどうかを見る
                 string l = U.substr(line, -3);
                 if (l != "\" +")
                 {
@@ -285,7 +299,7 @@ namespace FEBuilderGBA
 
             int eq = t.IndexOf("=");
             if (eq >= 1 && eq <= 10)
-            {//01=xxx みたいなものがあったとき 
+            {//01=xxx みたいなものがあったとき
                 t = t.Substring(eq + 1);
                 if (this.TranslateCache.ContainsKey(t))
                 {
@@ -311,7 +325,7 @@ namespace FEBuilderGBA
             return t;
         }
 
-        
+
         string OneLineTranslate(string src,string from)
         {
             if (src.Length <= 0)
@@ -346,7 +360,7 @@ namespace FEBuilderGBA
         public void TransFileWriter()
         {
             bool goolge_translate_failed = false;
-            
+
             List<string> lines = new List<string>();
 
             //ファイルに書き出す.
@@ -374,7 +388,7 @@ namespace FEBuilderGBA
                 line = "";
                 lines.Add(line);
             }
-            string resoucefilename = System.IO.Path.Combine(Program.BaseDirectory, "config", "translate", this.Lang + ".txt");
+            string resoucefilename = System.IO.Path.Combine(CoreState.BaseDirectory, "config", "translate", this.Lang + ".txt");
             if (!U.CanWriteFileRetry(resoucefilename))
             {
                 return;
@@ -448,7 +462,7 @@ namespace FEBuilderGBA
             }
 
             //翻訳がない
-            InputFormRef.DoEvents(null, target);
+            Progress(target);
             if (this.IsEnglishBase())
             {
                 string tempT = this.TranslateResourceEN.str(target);
@@ -598,7 +612,7 @@ namespace FEBuilderGBA
 
         public void DesignStringConvert(string source_path)
         {
-            string resoucefilename = System.IO.Path.Combine(Program.BaseDirectory, "config", "translate", this.Lang + ".txt");
+            string resoucefilename = System.IO.Path.Combine(CoreState.BaseDirectory, "config", "translate", this.Lang + ".txt");
             this.TranslateResource.LoadResource(resoucefilename);
 
             //デザインのソースコードスキャンして日本語文字列を置き換え.
@@ -606,7 +620,7 @@ namespace FEBuilderGBA
                 string[] files = U.Directory_GetFiles_Safe(source_path, "*.Designer.cs", SearchOption.TopDirectoryOnly);
                 foreach (string fullfilename in files)
                 {
-                    InputFormRef.DoEvents(null, fullfilename);
+                    Progress(fullfilename);
                     ScanStringForSourceCodeAndReplace(fullfilename);
                 }
             }
@@ -726,7 +740,7 @@ namespace FEBuilderGBA
         }
         public void DesignStringReverse(string source_path)
         {
-            string resoucefilename = System.IO.Path.Combine(Program.BaseDirectory, "config", "translate", this.Lang + ".txt");
+            string resoucefilename = System.IO.Path.Combine(CoreState.BaseDirectory, "config", "translate", this.Lang + ".txt");
             this.TranslateResource.LoadResource(resoucefilename);
 
             //デザインのソースコードスキャンして英語等の言語を日本語文字列に置き換え.
@@ -734,7 +748,7 @@ namespace FEBuilderGBA
                 string[] files = U.Directory_GetFiles_Safe(source_path, "*.Designer.cs", SearchOption.TopDirectoryOnly);
                 foreach (string fullfilename in files)
                 {
-                    InputFormRef.DoEvents(null, fullfilename);
+                    Progress(fullfilename);
                     ScanStringForReverseSourceCode(fullfilename);
                 }
             }
@@ -745,7 +759,7 @@ namespace FEBuilderGBA
         //パッチの翻訳
         public void ScanPatch()
         {
-            string path = System.IO.Path.Combine(Program.BaseDirectory, "config", "patch2");
+            string path = System.IO.Path.Combine(CoreState.BaseDirectory, "config", "patch2");
             string[] patchs = U.Directory_GetFiles_Safe(path, "PATCH_*.txt", SearchOption.AllDirectories);
             for (int i = 0; i < patchs.Length ; i++)
             {
@@ -770,7 +784,7 @@ namespace FEBuilderGBA
         //MODの翻訳
         public void ScanMOD()
         {
-            string path = System.IO.Path.Combine(Program.BaseDirectory, "config", "patch2");
+            string path = System.IO.Path.Combine(CoreState.BaseDirectory, "config", "patch2");
             string[] mods = U.Directory_GetFiles_Safe(path, "MOD_*.txt", SearchOption.AllDirectories);
             for (int i = 0; i < mods.Length; i++)
             {
@@ -947,7 +961,7 @@ namespace FEBuilderGBA
         //データの翻訳
         public void ScanData()
         {
-            string path = System.IO.Path.Combine(Program.BaseDirectory, "config", "data");
+            string path = System.IO.Path.Combine(CoreState.BaseDirectory, "config", "data");
             string[] data = U.Directory_GetFiles_Safe(path, "*.txt", SearchOption.TopDirectoryOnly);
             for (int i = 0; i < data.Length; i++)
             {
@@ -989,7 +1003,7 @@ namespace FEBuilderGBA
                 string line = lines[i];
                 if (U.IsComment(line))
                 {
-                    continue;   
+                    continue;
                 }
                 line = line.Trim();
 

--- a/FEBuilderGBA/FEBuilderGBA.csproj
+++ b/FEBuilderGBA/FEBuilderGBA.csproj
@@ -206,6 +206,7 @@
     <Compile Remove="SystemTextEncoderTBLEncode.cs" />
     <Compile Remove="SystemTextEncoderArabianTBLEncode.cs" />
     <Compile Remove="MultiByteJPUtil.cs" />
+    <Compile Remove="MyTranslateBuild.cs" />
     <Compile Remove="MyTranslateResource.cs" />
     <Compile Remove="MyTranslateResourceLow.cs" />
     <Compile Remove="EtcCacheResource.cs" />

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20488,3 +20488,75 @@ Binary file
 
 :CUSTOM_BUILD.cmd is a Windows batch script and can only be run on Windows.
 CUSTOM_BUILD.cmd is a Windows batch script and can only be run on Windows.
+
+:Build the app's own translation files from source. Developer-only.
+Build the app's own translation files from source. Developer-only.
+
+:Build translation resource
+Build translation resource
+
+:To language:
+To language:
+
+:Source folder:
+Source folder:
+
+:Translate from English base (en.txt) when available
+Translate from English base (en.txt) when available
+
+:Translate (build)
+Translate (build)
+
+:Select the C# source code folder
+Select the C# source code folder
+
+:Designer string convert / reverse
+Designer string convert / reverse
+
+:Replace Japanese literals in *.Designer.cs with translations, or restore them.
+Replace Japanese literals in *.Designer.cs with translations, or restore them.
+
+:Convert (JP to lang)
+Convert (JP to lang)
+
+:Reverse (lang to JP)
+Reverse (lang to JP)
+
+:config/translate/<lang>.txt
+config/translate/<lang>.txt
+
+:Scans patches, MODs, data and C# source, then writes config/translate/<lang>.txt.
+Scans patches, MODs, data and C# source, then writes config/translate/<lang>.txt.
+
+:Could not open the folder picker.
+Could not open the folder picker.
+
+:Translating... This may take a while.
+Translating... This may take a while.
+
+:Translation complete. Please restart the tool.
+Translation complete. Please restart the tool.
+
+:Translation failed. See the log for details.
+Translation failed. See the log for details.
+
+:Converting designer strings...
+Converting designer strings...
+
+:Designer string conversion complete.
+Designer string conversion complete.
+
+:Reversing designer strings...
+Reversing designer strings...
+
+:Designer string reverse complete.
+Designer string reverse complete.
+
+:Scanning: 
+Scanning: 
+
+:Please select a target language (ja and auto cannot be selected).
+Please select a target language (ja and auto cannot be selected).
+
+:Please select a valid source code folder.
+Please select a valid source code folder.

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11748,3 +11748,75 @@ GBA ROM
 
 :CUSTOM_BUILD.cmd is a Windows batch script and can only be run on Windows.
 CUSTOM_BUILD.cmd は Windows のバッチスクリプトで、Windows でのみ実行できます。
+
+:Build the app's own translation files from source. Developer-only.
+ソースからアプリ自身の翻訳ファイルをビルドします。開発者用です。
+
+:Build translation resource
+翻訳リソースをビルド
+
+:To language:
+翻訳先の言語:
+
+:Source folder:
+ソースフォルダ:
+
+:Translate from English base (en.txt) when available
+可能な場合は英語ベース (en.txt) から翻訳する
+
+:Translate (build)
+翻訳 (ビルド)
+
+:Select the C# source code folder
+C# ソースコードのフォルダを選択してください
+
+:Designer string convert / reverse
+デザイナー文字列の変換 / 復元
+
+:Replace Japanese literals in *.Designer.cs with translations, or restore them.
+*.Designer.cs 内の日本語文字列を翻訳に置き換える、または元に戻します。
+
+:Convert (JP to lang)
+変換 (日本語→言語)
+
+:Reverse (lang to JP)
+復元 (言語→日本語)
+
+:config/translate/<lang>.txt
+config/translate/<lang>.txt
+
+:Scans patches, MODs, data and C# source, then writes config/translate/<lang>.txt.
+パッチ・MOD・データ・C# ソースをスキャンし、config/translate/<lang>.txt に書き込みます。
+
+:Could not open the folder picker.
+フォルダ選択ダイアログを開けませんでした。
+
+:Translating... This may take a while.
+翻訳中... しばらくお待ちください。
+
+:Translation complete. Please restart the tool.
+翻訳が完了しました。ツールを再起動してください。
+
+:Translation failed. See the log for details.
+翻訳に失敗しました。詳細はログを確認してください。
+
+:Converting designer strings...
+デザイナー文字列を変換しています...
+
+:Designer string conversion complete.
+デザイナー文字列の変換が完了しました。
+
+:Reversing designer strings...
+デザイナー文字列を復元しています...
+
+:Designer string reverse complete.
+デザイナー文字列の復元が完了しました。
+
+:Scanning: 
+スキャン中: 
+
+:Please select a target language (ja and auto cannot be selected).
+翻訳先の言語を選択してください (ja と auto は選択できません)。
+
+:Please select a valid source code folder.
+有効なソースコードフォルダを選択してください。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25589,3 +25589,75 @@ GBA ROM
 
 :CUSTOM_BUILD.cmd is a Windows batch script and can only be run on Windows.
 CUSTOM_BUILD.cmd 是 Windows 批处理脚本，只能在 Windows 上运行。
+
+:Build the app's own translation files from source. Developer-only.
+从源代码构建应用自身的翻译文件。仅供开发者使用。
+
+:Build translation resource
+构建翻译资源
+
+:To language:
+目标语言:
+
+:Source folder:
+源代码文件夹:
+
+:Translate from English base (en.txt) when available
+可用时从英文基准 (en.txt) 翻译
+
+:Translate (build)
+翻译 (构建)
+
+:Select the C# source code folder
+请选择 C# 源代码文件夹
+
+:Designer string convert / reverse
+设计器字符串转换 / 还原
+
+:Replace Japanese literals in *.Designer.cs with translations, or restore them.
+将 *.Designer.cs 中的日文字符串替换为译文，或将其还原。
+
+:Convert (JP to lang)
+转换 (日文→语言)
+
+:Reverse (lang to JP)
+还原 (语言→日文)
+
+:config/translate/<lang>.txt
+config/translate/<lang>.txt
+
+:Scans patches, MODs, data and C# source, then writes config/translate/<lang>.txt.
+扫描补丁、MOD、数据和 C# 源代码，然后写入 config/translate/<lang>.txt。
+
+:Could not open the folder picker.
+无法打开文件夹选择器。
+
+:Translating... This may take a while.
+正在翻译... 这可能需要一些时间。
+
+:Translation complete. Please restart the tool.
+翻译完成。请重启工具。
+
+:Translation failed. See the log for details.
+翻译失败。详情请查看日志。
+
+:Converting designer strings...
+正在转换设计器字符串...
+
+:Designer string conversion complete.
+设计器字符串转换完成。
+
+:Reversing designer strings...
+正在还原设计器字符串...
+
+:Designer string reverse complete.
+设计器字符串还原完成。
+
+:Scanning: 
+正在扫描: 
+
+:Please select a target language (ja and auto cannot be selected).
+请选择目标语言 (ja 和 auto 不可选择)。
+
+:Please select a valid source code folder.
+请选择有效的源代码文件夹。


### PR DESCRIPTION
Fixes #1164.

Implements the Avalonia **Dev Translate** (Developer Translation) tool (was a bare scaffold over a dummy `AddrResult`), with parity to WinForms `DevTranslateForm`: builds the app's own translation files from source — a developer workflow.

## What
- **Build translation resource**: scans patches, MODs, data, and C# source, then writes `config/translate/<lang>.txt` — To-language combo, source-folder picker, "translate from English base" checkbox, Translate (build) button.
- **Designer string convert / reverse**: replaces Japanese literals in `*.Designer.cs` with translations (Convert), or restores them (Reverse) — its own To-language combo + source-folder picker.

## How (architecture)
- **Moved `MyTranslateBuild` (1138-line source scanner) into `FEBuilderGBA.Core`** (git-rename, namespace `FEBuilderGBA`, `public`), decoupling its **only** WinForms dependency — the 4 `InputFormRef.DoEvents(null, f)` progress pumps → an `Action<string> onProgress` callback. `Program.BaseDirectory` → `CoreState.BaseDirectory`; the dead `TransDic` init → `TranslateTextUtilCore.LoadFixedDic`. The WinForms `DevTranslateForm.CommandLineTranslateOnly` (`#if DEBUG`) keeps compiling against the Core type via the existing ProjectReference (same as prior Core-migration batches); `<Compile Remove>` prevents double-compile.
- VM runs scans on a background `Task` with the `onProgress` callback → status text. Reads no ROM bytes (not `IDataVerifiable` — orphan-safe). File I/O guarded → localized status.

## Tests / gates (all green — FULL projects)
- `MyTranslateBuildTests` (Core) — scans a synthetic temp source dir containing a literal → asserts the `<lang>.txt` output contains the extracted string. `DevTranslateViewParityTests` (Avalonia, 13).
- Core build / Avalonia build / **WinForms `FEBuilderGBA` (net9.0-windows) build** all 0 errors (the move keeps WinForms compiling). Core.Tests **4299/5skip**; Avalonia.Tests `~L10nCoverage|~DevTranslate` **21/0** (HaveJaAndZhTranslations PASS); Avalonia.Tests WHOLE **8298/3skip**; FEBuilderGBA.Tests WHOLE **1864/0** (NoOrphanVMs PASS). `validate-automation-ids` 0/0; dark-mode 0 hex; en+ja+zh added.

## Proof (Developer Translation Tool)
Both sections — Build translation resource + Designer string convert/reverse:

<img width="640" src="https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1164-dev-translate-fe8u.png">

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 4.8 (1M context), model `claude-opus-4-8[1m]`