### PR TITLE
feat(avalonia): implement Flags-Used-in-Chapter tool (#1192)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ToolUseFlagViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ToolUseFlagViewModelTests.cs
@@ -73,6 +73,42 @@ public class ToolUseFlagViewModelTests
     }
 
     [Fact]
+    public void EventScriptRow_DetailAddress_UsesTagNotTreeRoot()
+    {
+        // For EVENTSCRIPT, Addr is the event-tree ROOT and Tag is the actual
+        // referencing COMMAND. The detail "Address" must show the command (Tag),
+        // not the tree root (Addr) — mirrors WF GotoEvent → EventScriptForm.JumpTo
+        // positioning at tag.
+        var vm = new ToolUseFlagViewModel();
+        // Addr = tree root 0x00009000, Tag = referencing command 0x00009040.
+        var usages = new List<UseFlagIDCore>
+        {
+            new(FELintCore.Type.EVENTSCRIPT, 0x00009000, "", 0x0022, 0, 0x00009040),
+        };
+        vm.LoadFromUsages(usages);
+
+        vm.LoadEntryByIndex(0);
+        Assert.Equal("0x00009040", vm.SelectedAddrText); // Tag (command), not Addr (root)
+    }
+
+    [Fact]
+    public void EventCondRow_DetailAddress_UsesAddr()
+    {
+        // For EVENT_COND_*/MAPCHANGE, Addr IS the record address and Tag is the
+        // slot index (not an address), so the detail must show Addr.
+        var vm = new ToolUseFlagViewModel();
+        var usages = new List<UseFlagIDCore>
+        {
+            // Tag = 2 (slot index) must NOT be shown as the address.
+            new(FELintCore.Type.EVENT_COND_ALWAYS, 0x0000B000, "Always", 0x0055, 0, 2),
+        };
+        vm.LoadFromUsages(usages);
+
+        vm.LoadEntryByIndex(0);
+        Assert.Equal("0x0000B000", vm.SelectedAddrText); // Addr (record), not Tag (slot idx)
+    }
+
+    [Fact]
     public void DuplicateAddressRows_ResolveByIndex_NotFirstMatch()
     {
         // Index 2 and index 3 share addr 0x0000A000 but carry different flag ids.

--- a/FEBuilderGBA.Avalonia.Tests/ToolUseFlagViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ToolUseFlagViewModelTests.cs
@@ -1,0 +1,160 @@
+using System.Collections.Generic;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+/// <summary>
+/// Headless tests for <see cref="ToolUseFlagViewModel"/> (issue #1192 — port of
+/// WinForms <c>ToolUseFlagForm</c>). The ViewModel reuses the cross-platform
+/// <see cref="UseFlagScanCore"/> aggregator and is strictly READ-ONLY: it never
+/// mutates the ROM, so it deliberately does NOT implement IDataVerifiable.
+///
+/// Row-building and INDEX-keyed detail are covered DETERMINISTICALLY via the
+/// <c>LoadFromUsages</c> test seam (injecting synthetic usages), independent of a
+/// real ROM/chapter. The end-to-end scan is covered by the Core
+/// <c>UseFlagScanCoreTests</c> synthetic-ROM suite.
+/// </summary>
+[Collection("SharedState")]
+public class ToolUseFlagViewModelTests
+{
+    static UseFlagIDCore Usage(FELintCore.Type type, uint addr, string info, uint id, uint mapid = 0)
+        => new(type, addr, info, id, mapid, addr);
+
+    static List<UseFlagIDCore> SampleUsages() => new()
+    {
+        Usage(FELintCore.Type.EVENT_COND_TURN, 0x00008000, "Turn Conditions", 0x0011),
+        Usage(FELintCore.Type.EVENTSCRIPT,     0x00009000, "",               0x0022),
+        // Two rows sharing an address but different flag ids — duplicate-address case.
+        Usage(FELintCore.Type.MAPCHANGE,       0x0000A000, "00",             0x0033),
+        Usage(FELintCore.Type.MAPCHANGE,       0x0000A000, "01",             0x0044),
+    };
+
+    [Fact]
+    public void LoadFromUsages_BuildsOneRowPerUsage()
+    {
+        var vm = new ToolUseFlagViewModel();
+        List<AddrResult> list = vm.LoadFromUsages(SampleUsages());
+
+        Assert.Equal(4, list.Count);
+        Assert.Equal(4, vm.UsageListCount);
+        Assert.Equal(4, vm.FlagUsageCount);
+        // Summary renders the count.
+        Assert.Contains("4", vm.SummaryText);
+    }
+
+    [Fact]
+    public void RowLabel_ContainsFlagHexAndType()
+    {
+        var vm = new ToolUseFlagViewModel();
+        List<AddrResult> list = vm.LoadFromUsages(SampleUsages());
+
+        // First row: flag 0x11 (magnitude-padded hex, X02 for <= 0xff — WF parity),
+        // type EVENT_COND_TURN, info "Turn Conditions".
+        Assert.Contains("0x11", list[0].name);
+        Assert.Contains("EVENT_COND_TURN", list[0].name);
+        Assert.Contains("Turn Conditions", list[0].name);
+    }
+
+    [Fact]
+    public void LoadEntryByIndex_PopulatesDetail()
+    {
+        var vm = new ToolUseFlagViewModel();
+        vm.LoadFromUsages(SampleUsages());
+
+        vm.LoadEntryByIndex(0);
+
+        Assert.True(vm.IsLoaded);
+        Assert.Equal("0x11", vm.SelectedFlagText);
+        Assert.Equal("EVENT_COND_TURN", vm.SelectedTypeText);
+        Assert.Equal("Turn Conditions", vm.SelectedInfoText);
+        Assert.Equal("0x00008000", vm.SelectedAddrText);
+    }
+
+    [Fact]
+    public void DuplicateAddressRows_ResolveByIndex_NotFirstMatch()
+    {
+        // Index 2 and index 3 share addr 0x0000A000 but carry different flag ids.
+        // Index-keyed LoadEntryByIndex must show EACH row's own flag; address-keyed
+        // LoadEntry collapses to the first match.
+        var vm = new ToolUseFlagViewModel();
+        vm.LoadFromUsages(SampleUsages());
+
+        vm.LoadEntryByIndex(3);
+        Assert.Equal("0x44", vm.SelectedFlagText);
+
+        vm.LoadEntryByIndex(2);
+        Assert.Equal("0x33", vm.SelectedFlagText);
+
+        vm.LoadEntry(0x0000A000);
+        Assert.Equal("0x33", vm.SelectedFlagText); // first match
+    }
+
+    [Fact]
+    public void LoadEntryByIndex_OutOfRange_ClearsDetail()
+    {
+        var vm = new ToolUseFlagViewModel();
+        vm.LoadFromUsages(SampleUsages());
+        vm.LoadEntryByIndex(0);
+        Assert.True(vm.IsLoaded);
+
+        vm.LoadEntryByIndex(99);
+        Assert.False(vm.IsLoaded);
+        Assert.Equal("", vm.SelectedFlagText);
+        Assert.Equal("", vm.SelectedTypeText);
+        Assert.Equal("", vm.SelectedAddrText);
+    }
+
+    [Fact]
+    public void Rescan_ClearsStaleDetail()
+    {
+        var vm = new ToolUseFlagViewModel();
+        vm.LoadFromUsages(SampleUsages());
+        vm.LoadEntryByIndex(0);
+        Assert.True(vm.IsLoaded);
+
+        vm.LoadFromUsages(new List<UseFlagIDCore>()); // rescan → empty chapter
+        Assert.False(vm.IsLoaded);
+        Assert.Equal("", vm.SelectedFlagText);
+        Assert.Equal(0, vm.FlagUsageCount);
+    }
+
+    [Fact]
+    public void LoadForChapter_NoRom_ReturnsEmptyAndDoesNotThrow()
+    {
+        ROM? prev = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = null;
+
+            var vm = new ToolUseFlagViewModel();
+            List<AddrResult> list = vm.LoadForChapter(0u);
+
+            Assert.NotNull(list);
+            Assert.Empty(list);
+            Assert.Equal(0, vm.FlagUsageCount);
+            Assert.False(string.IsNullOrEmpty(vm.SummaryText)); // still renders "Flags used: 0"
+        }
+        finally
+        {
+            CoreState.ROM = prev;
+        }
+    }
+
+    [Fact]
+    public void LoadMapList_NoRom_ReturnsEmpty()
+    {
+        ROM? prev = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = null;
+            var vm = new ToolUseFlagViewModel();
+            Assert.Empty(vm.LoadMapList());
+        }
+        finally
+        {
+            CoreState.ROM = prev;
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/ToolUseFlagViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ToolUseFlagViewModel.cs
@@ -3,31 +3,210 @@ using System.Collections.Generic;
 
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
+    /// <summary>
+    /// Read-only "Flags-Used-in-Chapter" tool ViewModel (issue #1192 — port of
+    /// WinForms <c>ToolUseFlagForm</c>). For the selected chapter (map) it lists
+    /// every event-flag reference from the in-scope subsystems via the
+    /// cross-platform <see cref="UseFlagScanCore"/> aggregator:
+    ///   event-condition records (Turn/Talk/Object/Always), the event scripts
+    ///   those conditions reach (ArgType.FLAG), and map-change records.
+    ///
+    /// This is a tool / aggregator that READS ROM bytes for the scan but NEVER
+    /// writes — so it deliberately exposes no data-verify report contract (a
+    /// no-write aggregator VM is orphan-safe by the FEBuilderGBA.Tests contract;
+    /// implementing or even naming that verify interface would trip the
+    /// NoOrphanVMs gate).
+    ///
+    /// DEFERRED (#1253): the Haiku x {FE6,FE7,FE8} + BattleTalk x {FE6,FE7,FE8}
+    /// scanners are not yet ported to Core; they are excluded here exactly as in
+    /// <see cref="UseFlagScanCore"/>.
+    /// </summary>
     public class ToolUseFlagViewModel : ViewModelBase
     {
         uint _currentAddr;
         bool _isLoaded;
+        int _flagUsageCount;
+        string _summaryText = "";
+        string _selectedFlagText = "";
+        string _selectedFlagName = "";
+        string _selectedTypeText = "";
+        string _selectedInfoText = "";
+        string _selectedAddrText = "";
+
+        // The flag-usage records backing the entry list, in row order (one row
+        // per record). Index-keyed so duplicate flag ids each resolve their own
+        // detail (matching the ToolFELint pattern).
+        List<UseFlagIDCore> _usages = new();
 
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
 
-        public List<AddrResult> LoadList()
+        /// <summary>Number of flag-usage rows from the last scan.</summary>
+        public int FlagUsageCount { get => _flagUsageCount; set => SetField(ref _flagUsageCount, value); }
+
+        /// <summary>Localized one-line summary built IN THE VM (Avalonia XAML
+        /// StringFormat is not translated).</summary>
+        public string SummaryText { get => _summaryText; set => SetField(ref _summaryText, value); }
+
+        public string SelectedFlagText { get => _selectedFlagText; set => SetField(ref _selectedFlagText, value); }
+        public string SelectedFlagName { get => _selectedFlagName; set => SetField(ref _selectedFlagName, value); }
+        public string SelectedTypeText { get => _selectedTypeText; set => SetField(ref _selectedTypeText, value); }
+        public string SelectedInfoText { get => _selectedInfoText; set => SetField(ref _selectedInfoText, value); }
+        public string SelectedAddrText { get => _selectedAddrText; set => SetField(ref _selectedAddrText, value); }
+
+        /// <summary>Number of stored flag-usage rows.</summary>
+        public int UsageListCount => _usages.Count;
+
+        /// <summary>
+        /// The chapter (map) list for the left-panel selector. Empty when no ROM
+        /// is loaded.
+        /// </summary>
+        public List<AddrResult> LoadMapList()
         {
             ROM rom = CoreState.ROM;
             if (rom?.RomInfo == null) return new List<AddrResult>();
+            return MapSettingCore.MakeMapIDList(rom);
+        }
+
+        /// <summary>
+        /// Scan the selected chapter and build the flag-usage entry list. Each row
+        /// is one <see cref="UseFlagIDCore"/>. Detail/summary are reset first so a
+        /// fresh scan never leaves stale detail. Guards a missing ROM (empty list).
+        /// </summary>
+        public List<AddrResult> LoadForChapter(uint mapId)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null)
+                return BuildList(new List<UseFlagIDCore>());
+
+            return BuildList(UseFlagScanCore.Scan(rom, mapId) ?? new List<UseFlagIDCore>());
+        }
+
+        /// <summary>
+        /// Test seam (InternalsVisibleTo): build the entry list from an injected
+        /// usage set instead of scanning, so the row/detail behaviour is covered
+        /// deterministically without a real chapter.
+        /// </summary>
+        internal List<AddrResult> LoadFromUsages(List<UseFlagIDCore> usages)
+            => BuildList(usages ?? new List<UseFlagIDCore>());
+
+        List<AddrResult> BuildList(List<UseFlagIDCore> usages)
+        {
+            _usages = usages;
+            ClearDetail();
 
             var result = new List<AddrResult>();
-            result.Add(new AddrResult(0, "Flag Usage Viewer", 0));
+            foreach (UseFlagIDCore u in _usages)
+            {
+                // Row label: "0x<flag> <name>  [<type>] <info>" — built here so the
+                // localized type label is correct (no XAML StringFormat).
+                string flagName = FlagNameOf(u.ID);
+                string label = ToHexString(u.ID)
+                    + (flagName.Length > 0 ? " " + flagName : "")
+                    + "  [" + TypeText(u.DataType) + "]"
+                    + (string.IsNullOrEmpty(u.Info) ? "" : " " + u.Info);
+                result.Add(new AddrResult(u.Addr, label, u.Tag));
+            }
+
+            FlagUsageCount = _usages.Count;
+            IsLoaded = false;
+            RefreshSummary();
             return result;
         }
 
+        /// <summary>
+        /// INDEX-keyed detail load. <paramref name="index"/> is the row's original
+        /// index, which equals the usage's index in the stored list. Out-of-range
+        /// clears the detail panel.
+        /// </summary>
+        public void LoadEntryByIndex(int index)
+        {
+            if (index < 0 || index >= _usages.Count)
+            {
+                ClearDetail();
+                return;
+            }
+
+            UseFlagIDCore u = _usages[index];
+            CurrentAddr = u.Addr;
+            IsLoaded = true;
+            SelectedFlagText = ToHexString(u.ID);
+            SelectedFlagName = FlagNameOf(u.ID);
+            SelectedTypeText = TypeText(u.DataType);
+            SelectedInfoText = u.Info ?? "";
+            SelectedAddrText = string.Format("0x{0:X08}", u.Addr);
+        }
+
+        /// <summary>
+        /// Address-keyed detail load (FIRST stored usage whose <c>.Addr</c>
+        /// matches). Used by <c>IEditorView.NavigateTo</c>. Duplicate addresses
+        /// resolve to the first match — the interactive UI uses
+        /// <see cref="LoadEntryByIndex"/>, which is row-exact.
+        /// </summary>
         public void LoadEntry(uint addr)
         {
-            ROM rom = CoreState.ROM;
-            if (rom == null) return;
-
-            CurrentAddr = addr;
-            IsLoaded = true;
+            for (int i = 0; i < _usages.Count; i++)
+            {
+                if (_usages[i].Addr == addr)
+                {
+                    LoadEntryByIndex(i);
+                    return;
+                }
+            }
+            ClearDetail();
         }
+
+        /// <summary>
+        /// True only when the row at <paramref name="index"/> has a real in-ROM
+        /// byte offset (drives the double-click/Enter jump-to-HexEditor path).
+        /// </summary>
+        public bool TryGetJumpOffset(int index, out uint offset)
+        {
+            offset = 0;
+            if (index < 0 || index >= _usages.Count) return false;
+
+            ROM rom = CoreState.ROM;
+            if (rom == null) return false;
+
+            uint addr = _usages[index].Addr;
+            if (!U.isSafetyOffset(addr, rom)) return false;
+
+            offset = addr;
+            return true;
+        }
+
+        void ClearDetail()
+        {
+            IsLoaded = false;
+            SelectedFlagText = "";
+            SelectedFlagName = "";
+            SelectedTypeText = "";
+            SelectedInfoText = "";
+            SelectedAddrText = "";
+        }
+
+        void RefreshSummary()
+        {
+            SummaryText = R._("Flags used") + ": " + FlagUsageCount;
+        }
+
+        // Magnitude-padded hex with a "0x" prefix (mirrors WF U.ToHexString
+        // usage in the flag list — short flags shown compactly).
+        static string ToHexString(uint a) =>
+            a <= 0xff ? "0x" + a.ToString("X02")
+            : a <= 0xffff ? "0x" + a.ToString("X04")
+            : a <= 0xffffff ? "0x" + a.ToString("X06")
+            : "0x" + a.ToString("X08");
+
+        // Resolve a flag's custom/base name via the shared flag-name cache
+        // (same source as the Flag-Name editor). "" when no name / no cache.
+        static string FlagNameOf(uint flag)
+        {
+            EtcCacheFLag cache = CoreState.FlagCache;
+            if (cache == null) return "";
+            return cache.TryGetValue(flag, out string name) ? (name ?? "") : "";
+        }
+
+        static string TypeText(FELintCore.Type type) => type.ToString();
     }
 }

--- a/FEBuilderGBA.Avalonia/ViewModels/ToolUseFlagViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ToolUseFlagViewModel.cs
@@ -98,8 +98,12 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             var result = new List<AddrResult>();
             foreach (UseFlagIDCore u in _usages)
             {
-                // Row label: "0x<flag> <name>  [<type>] <info>" — built here so the
-                // localized type label is correct (no XAML StringFormat).
+                // Row label: "0x<flag> <name>  [<type>] <info>" — assembled here in
+                // the VM (not via XAML StringFormat, which Avalonia does not
+                // translate). The <type> is the raw FELint enum tag (e.g.
+                // EVENT_COND_ALWAYS / MAPCHANGE), shown untranslated to match the
+                // sibling ToolFELintViewModel.CategoryText — these tags read fine in
+                // any locale and there is no Core type→localized-name map to use.
                 string flagName = FlagNameOf(u.ID);
                 string label = ToHexString(u.ID)
                     + (flagName.Length > 0 ? " " + flagName : "")
@@ -207,6 +211,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             return cache.TryGetValue(flag, out string name) ? (name ?? "") : "";
         }
 
+        // Raw FELint enum tag (e.g. "EVENT_COND_ALWAYS", "MAPCHANGE"), NOT
+        // localized — matches ToolFELintViewModel.CategoryText. The tags are
+        // locale-neutral identifiers and there is no Core type→display-name map.
         static string TypeText(FELintCore.Type type) => type.ToString();
     }
 }

--- a/FEBuilderGBA.Avalonia/ViewModels/ToolUseFlagViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ToolUseFlagViewModel.cs
@@ -132,14 +132,30 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             }
 
             UseFlagIDCore u = _usages[index];
-            CurrentAddr = u.Addr;
+            uint addr = EffectiveAddr(u);
+            CurrentAddr = addr;
             IsLoaded = true;
             SelectedFlagText = ToHexString(u.ID);
             SelectedFlagName = FlagNameOf(u.ID);
             SelectedTypeText = TypeText(u.DataType);
             SelectedInfoText = u.Info ?? "";
-            SelectedAddrText = string.Format("0x{0:X08}", u.Addr);
+            SelectedAddrText = string.Format("0x{0:X08}", addr);
         }
+
+        /// <summary>
+        /// The byte offset the detail panel shows and the jump targets, by source
+        /// type. For EVENTSCRIPT the row's <see cref="UseFlagIDCore.Addr"/> is the
+        /// event-script TREE ROOT and <see cref="UseFlagIDCore.Tag"/> is the actual
+        /// referencing COMMAND (mirroring WF GotoEvent → EventScriptForm.JumpTo,
+        /// which positions the cursor at <c>tag</c>), so we surface Tag — that's
+        /// the byte where the flag is referenced. For EVENT_COND_* / MAPCHANGE the
+        /// Addr IS the record address (Tag is the slot index, not an address), so
+        /// Addr is correct. Falls back to Addr if an EVENTSCRIPT Tag is unset.
+        /// </summary>
+        static uint EffectiveAddr(UseFlagIDCore u)
+            => u.DataType == FELintCore.Type.EVENTSCRIPT && u.Tag != U.NOT_FOUND
+                ? u.Tag
+                : u.Addr;
 
         /// <summary>
         /// Address-keyed detail load (FIRST stored usage whose <c>.Addr</c>
@@ -163,6 +179,8 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// <summary>
         /// True only when the row at <paramref name="index"/> has a real in-ROM
         /// byte offset (drives the double-click/Enter jump-to-HexEditor path).
+        /// Uses <see cref="EffectiveAddr"/> so an EVENTSCRIPT row jumps to its
+        /// referencing command (Tag), not the event-tree root.
         /// </summary>
         public bool TryGetJumpOffset(int index, out uint offset)
         {
@@ -172,7 +190,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             ROM rom = CoreState.ROM;
             if (rom == null) return false;
 
-            uint addr = _usages[index].Addr;
+            uint addr = EffectiveAddr(_usages[index]);
             if (!U.isSafetyOffset(addr, rom)) return false;
 
             offset = addr;

--- a/FEBuilderGBA.Avalonia/Views/ToolUseFlagView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolUseFlagView.axaml
@@ -2,18 +2,60 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
         x:Class="FEBuilderGBA.Avalonia.Views.ToolUseFlagView"
-        Title="Flag Usage Viewer" Width="1113" Height="854"
-        SizeToContent="WidthAndHeight">
-  <Grid ColumnDefinitions="250,*">
-    <controls:AddressListControl AutomationProperties.AutomationId="ToolUseFlag_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
+        Title="Flags Used in Chapter" Width="1113" Height="720"
+        SizeToContent="Manual">
+  <Grid ColumnDefinitions="260,*,320">
+    <!-- Chapter (map) selector -->
+    <DockPanel Grid.Column="0" Margin="4">
+      <TextBlock DockPanel.Dock="Top" Text="Chapter" FontWeight="Bold" Margin="0,0,0,4" />
+      <controls:AddressListControl
+          AutomationProperties.AutomationId="ToolUseFlag_Map_List"
+          Name="MapList" />
+    </DockPanel>
 
-    <ScrollViewer Grid.Column="1" Margin="4">
+    <!-- Flag-usage list for the selected chapter -->
+    <DockPanel Grid.Column="1" Margin="4">
+      <TextBlock DockPanel.Dock="Top"
+                 AutomationProperties.AutomationId="ToolUseFlag_Summary_Label"
+                 Name="SummaryLabel" FontWeight="Bold" Margin="0,0,0,4"
+                 Text="{Binding SummaryText}" />
+      <controls:AddressListControl
+          AutomationProperties.AutomationId="ToolUseFlag_Entry_List"
+          Name="EntryList" />
+    </DockPanel>
+
+    <!-- Detail panel for the selected flag usage -->
+    <ScrollViewer Grid.Column="2" Margin="4">
       <StackPanel Spacing="8" Margin="8">
-        <TextBlock Text="Flag Usage Viewer" FontSize="18" FontWeight="Bold" />
+        <TextBlock Text="Flags Used in Chapter" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="ToolUseFlag_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+        <Grid ColumnDefinitions="120,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Flag:" VerticalAlignment="Center" />
+          <TextBlock AutomationProperties.AutomationId="ToolUseFlag_Flag_Label"
+                     Grid.Row="0" Grid.Column="1" Name="FlagLabel"
+                     VerticalAlignment="Center" Text="{Binding SelectedFlagText}" />
+
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="Name:" VerticalAlignment="Center" />
+          <TextBlock AutomationProperties.AutomationId="ToolUseFlag_Name_Label"
+                     Grid.Row="1" Grid.Column="1" Name="NameLabel"
+                     VerticalAlignment="Center" TextWrapping="Wrap"
+                     Text="{Binding SelectedFlagName}" />
+
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Type:" VerticalAlignment="Center" />
+          <TextBlock AutomationProperties.AutomationId="ToolUseFlag_Type_Label"
+                     Grid.Row="2" Grid.Column="1" Name="TypeLabel"
+                     VerticalAlignment="Center" Text="{Binding SelectedTypeText}" />
+
+          <TextBlock Grid.Row="3" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
+          <TextBlock AutomationProperties.AutomationId="ToolUseFlag_Addr_Label"
+                     Grid.Row="3" Grid.Column="1" Name="AddrLabel"
+                     VerticalAlignment="Center" Text="{Binding SelectedAddrText}" />
+
+          <TextBlock Grid.Row="4" Grid.Column="0" Text="Info:" VerticalAlignment="Top" />
+          <TextBlock AutomationProperties.AutomationId="ToolUseFlag_Info_Label"
+                     Grid.Row="4" Grid.Column="1" Name="InfoLabel"
+                     VerticalAlignment="Top" TextWrapping="Wrap"
+                     Text="{Binding SelectedInfoText}" />
         </Grid>
       </StackPanel>
     </ScrollViewer>

--- a/FEBuilderGBA.Avalonia/Views/ToolUseFlagView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolUseFlagView.axaml.cs
@@ -33,14 +33,15 @@ namespace FEBuilderGBA.Avalonia.Views
             Opened += (_, _) => LoadMapList();
         }
 
-        // Populate the chapter selector and auto-select the first chapter so the
-        // flag list is non-empty on open.
+        // Populate the chapter selector. SetItems auto-selects the first row
+        // (AddressListControl.SetItems calls SelectFirst internally), which fires
+        // OnMapSelected → the flag list is non-empty on open. No explicit
+        // SelectFirst needed.
         void LoadMapList()
         {
             try
             {
                 MapList.SetItems(_vm.LoadMapList());
-                MapList.SelectFirst();
             }
             catch (Exception ex)
             {
@@ -49,12 +50,16 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         // A chapter was picked — re-scan and repopulate the flag-usage list. The
-        // AddressListControl tag carries the map id (MakeMapIDList sets tag=mapid).
+        // map id is the selected row's AddrResult.tag (MapSettingCore.MakeMapIDList
+        // encodes the map id in tag), matching how the other map-selector views
+        // resolve it.
         void OnMapSelected(uint mapAddr)
         {
             try
             {
-                uint mapId = (uint)MapList.SelectedOriginalIndex;
+                AddrResult? selected = MapList.SelectedItem;
+                if (selected == null) return;
+                uint mapId = selected.tag;
                 EntryList.SetItems(_vm.LoadForChapter(mapId));
             }
             catch (Exception ex)

--- a/FEBuilderGBA.Avalonia/Views/ToolUseFlagView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolUseFlagView.axaml.cs
@@ -1,57 +1,97 @@
 using System;
 using global::Avalonia.Controls;
-using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
+    /// <summary>
+    /// Read-only "Flags-Used-in-Chapter" tool (issue #1192 — port of WinForms
+    /// <c>ToolUseFlagForm</c>). Pick a chapter on the left; the middle list shows
+    /// every event-flag referenced by that chapter's event conditions, the event
+    /// scripts they reach, and its map changes (via the cross-platform
+    /// <see cref="UseFlagScanCore"/>). Selecting a usage shows its detail; a
+    /// double-click / Enter jumps to the referencing bytes in the Hex Editor.
+    /// Strictly read-only — no ROM mutation, no undo.
+    /// </summary>
     public partial class ToolUseFlagView : TranslatedWindow, IEditorView
     {
         readonly ToolUseFlagViewModel _vm = new();
 
-        public string ViewTitle => "Flag Usage Viewer";
+        public string ViewTitle => "Flags Used in Chapter";
         public bool IsLoaded => _vm.IsLoaded;
 
         public ToolUseFlagView()
         {
             InitializeComponent();
-            EntryList.SelectedAddressChanged += OnSelected;
-            Opened += (_, _) => LoadList();
+            DataContext = _vm;
+
+            MapList.SelectedAddressChanged += OnMapSelected;
+            EntryList.SelectedAddressChanged += OnUsageSelected;
+            EntryList.SelectionConfirmed += OnUsageConfirmed;
+
+            Opened += (_, _) => LoadMapList();
         }
 
-        void LoadList()
+        // Populate the chapter selector and auto-select the first chapter so the
+        // flag list is non-empty on open.
+        void LoadMapList()
         {
             try
             {
-                var items = _vm.LoadList();
-                EntryList.SetItems(items);
+                MapList.SetItems(_vm.LoadMapList());
+                MapList.SelectFirst();
             }
             catch (Exception ex)
             {
-                Log.Error("ToolUseFlagView.LoadList failed: {0}", ex.Message);
+                Log.Error("ToolUseFlagView.LoadMapList failed: " + ex.ToString());
             }
         }
 
-        void OnSelected(uint addr)
+        // A chapter was picked — re-scan and repopulate the flag-usage list. The
+        // AddressListControl tag carries the map id (MakeMapIDList sets tag=mapid).
+        void OnMapSelected(uint mapAddr)
         {
             try
             {
-                _vm.LoadEntry(addr);
-                UpdateUI();
+                uint mapId = (uint)MapList.SelectedOriginalIndex;
+                EntryList.SetItems(_vm.LoadForChapter(mapId));
             }
             catch (Exception ex)
             {
-                Log.Error("ToolUseFlagView.OnSelected failed: {0}", ex.Message);
+                Log.Error("ToolUseFlagView.OnMapSelected failed: " + ex.ToString());
             }
         }
 
-        void UpdateUI()
+        // Index-keyed detail load so duplicate flag-id rows each resolve their own
+        // detail.
+        void OnUsageSelected(uint addr)
         {
-            AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            try
+            {
+                _vm.LoadEntryByIndex(EntryList.SelectedOriginalIndex);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ToolUseFlagView.OnUsageSelected failed: " + ex.ToString());
+            }
+        }
+
+        // Double-click / Enter: jump to the referencing bytes in the Hex Editor.
+        void OnUsageConfirmed(PickResult pick)
+        {
+            try
+            {
+                if (_vm.TryGetJumpOffset(pick.Index, out uint offset))
+                    WindowManager.Instance.Navigate<HexEditorView>(offset);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ToolUseFlagView.OnUsageConfirmed failed: " + ex.ToString());
+            }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
-        public void SelectFirstItem() => EntryList.SelectFirst();
+        public void SelectFirstItem() => MapList.SelectFirst();
     }
 }

--- a/FEBuilderGBA.Core.Tests/UseFlagScanCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/UseFlagScanCoreTests.cs
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for UseFlagScanCore (#1192) — the strictly READ-ONLY per-chapter
+// flag-usage aggregator that backs the Avalonia "Flags-Used-in-Chapter" tool.
+//
+// SYNTHETIC scratch-ROM tests build a minimal FE8 chapter and assert the three
+// in-scope flag sources are each found:
+//   (1) EVENT_COND_*  — the flag field (u16 @ +2) of a Turn condition record,
+//   (2) EVENTSCRIPT   — an ArgType.FLAG arg in the event script that the Turn
+//                       record's event pointer reaches, and
+//   (3) MAPCHANGE     — the flag field (u16 @ +5) of a map-change record.
+// Plus guard tests: id 0 is dropped, a foreign/empty ROM yields an empty list,
+// and the result is sorted by flag id.
+//
+// DEFERRED (#1253): the Haiku/BattleTalk scanners are NOT part of this slice.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class UseFlagScanCoreTests
+    {
+        const int RomSize = 0x1000000; // 16MB — FE8 LoadLow minimum.
+
+        // Layout (FE8U): map_setting_datasize=148, event_plist_pos=116,
+        // eventcond_tern_size=12, cond slot 0 = Turn.
+        const uint MapTableBase   = 0x00700000u;
+        const uint EventTableBase = 0x00710000u;
+        const uint CondBlock      = 0x00720000u;
+        const uint TurnRecord     = 0x00730000u;
+        const uint EventScriptAddr= 0x00740000u;
+        const uint ChangeTable    = 0x00750000u;
+        const uint ChangeData     = 0x00760000u;
+
+        const uint CondFlag   = 0x0011; // Turn record flag (u16 @ +2)
+        const uint ScriptFlag = 0x0022; // event-script FLAG arg
+        const uint ChangeFlag = 0x0033; // map-change record flag (u16 @ +5)
+
+        // A command "0100 XXXX" — opcode 0x0001 then a 2-byte FLAG arg at byte 2.
+        static EventScript.Script FlagCommand()
+            => EventScript.ParseScriptLine("0100XXXX\tSETFLAG [XXXX:FLAG:Flag]");
+
+        // Terminator "0A 00 00 00".
+        static EventScript.Script TermCommand()
+            => EventScript.ParseScriptLine("0A000000\tENDA [TERM]");
+
+        static EventScript BuildEventScript(params EventScript.Script[] scripts)
+        {
+            var es = new EventScript();
+            typeof(EventScript).GetProperty("Scripts")!.SetValue(es, scripts);
+            return es;
+        }
+
+        static void WriteU32(ROM rom, uint offset, uint value)
+        {
+            rom.Data[offset + 0] = (byte)(value & 0xFF);
+            rom.Data[offset + 1] = (byte)((value >> 8) & 0xFF);
+            rom.Data[offset + 2] = (byte)((value >> 16) & 0xFF);
+            rom.Data[offset + 3] = (byte)((value >> 24) & 0xFF);
+        }
+
+        /// <summary>
+        /// Build a synthetic FE8 chapter (map id 0) wiring all three flag
+        /// sources, run <paramref name="body"/> with CoreState fully wired (the
+        /// disasm path needs ROM + EventScript + CommentCache), then restore.
+        /// </summary>
+        static void WithChapter(System.Action<ROM> body)
+        {
+            var prevRom = CoreState.ROM;
+            var prevEs = CoreState.EventScript;
+            var prevComment = CoreState.CommentCache;
+            try
+            {
+                var rom = new ROM();
+                rom.LoadLow("flagscan-fe8u.gba", new byte[RomSize], "BE8E01");
+
+                uint dataSize = rom.RomInfo.map_setting_datasize;
+                uint eventPlistPos = rom.RomInfo.map_setting_event_plist_pos;
+
+                // 1) Map setting table: one map (id 0), event_plist = 1,
+                //    mapchange_plist (offset 11) = 3.
+                WriteU32(rom, rom.RomInfo.map_setting_pointer, MapTableBase | 0x08000000u);
+                WriteU32(rom, MapTableBase + 0, 0x08123456u); // first dword = pointer → valid
+                rom.Data[MapTableBase + eventPlistPos] = 1;
+                rom.Data[MapTableBase + 11] = 3;              // mapchange plist
+                WriteU32(rom, MapTableBase + dataSize, 0x00000000u); // terminator row
+
+                // 2) Event pointer table: entry[1] → cond block.
+                WriteU32(rom, rom.RomInfo.map_event_pointer, EventTableBase | 0x08000000u);
+                WriteU32(rom, EventTableBase + 1 * 4, CondBlock | 0x08000000u);
+
+                // 3) Cond block slot 0 (Turn) → a 12-byte turn record:
+                //    header non-zero, type=0, flag @ +2, event ptr @ +4.
+                WriteU32(rom, CondBlock + 0, TurnRecord | 0x08000000u);
+                rom.Data[TurnRecord + 0] = 0x02; // non-zero header / type != 1
+                rom.write_u16(TurnRecord + 2, (ushort)CondFlag);
+                WriteU32(rom, TurnRecord + 4, EventScriptAddr | 0x08000000u);
+                // Next turn record header = 0 → terminates the slot walk.
+                WriteU32(rom, TurnRecord + 12, 0x00000000u);
+
+                // 4) Event script: SETFLAG ScriptFlag ; ENDA.
+                rom.write_u16(EventScriptAddr + 0, 0x0001);
+                rom.write_u16(EventScriptAddr + 2, (ushort)ScriptFlag);
+                WriteU32(rom, EventScriptAddr + 4, 0x0000000A);
+
+                // 5) Map-change PLIST table: entry[3] → change data block.
+                WriteU32(rom, rom.RomInfo.map_mapchange_pointer, ChangeTable | 0x08000000u);
+                WriteU32(rom, ChangeTable + 3 * 4, ChangeData | 0x08000000u);
+                // 6) Change data: one 12-byte record (first byte != 0xFF),
+                //    flag @ +5; next record's first byte = 0xFF → terminates.
+                rom.Data[ChangeData + 0] = 0x01;
+                rom.write_u16(ChangeData + 5, (ushort)ChangeFlag);
+                rom.Data[ChangeData + 12] = 0xFF;
+
+                CoreState.ROM = rom;
+                CoreState.EventScript = BuildEventScript(FlagCommand(), TermCommand());
+                CoreState.CommentCache = new HeadlessEtcCache();
+
+                body(rom);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.EventScript = prevEs;
+                CoreState.CommentCache = prevComment;
+            }
+        }
+
+        [Fact]
+        public void Scan_FindsEventCondFlag()
+        {
+            WithChapter(rom =>
+            {
+                var list = UseFlagScanCore.Scan(rom, 0u);
+                Assert.Contains(list, u =>
+                    u.ID == CondFlag && u.DataType == FELintCore.Type.EVENT_COND_TURN);
+            });
+        }
+
+        [Fact]
+        public void Scan_FindsEventScriptFlag()
+        {
+            WithChapter(rom =>
+            {
+                var list = UseFlagScanCore.Scan(rom, 0u);
+                Assert.Contains(list, u =>
+                    u.ID == ScriptFlag && u.DataType == FELintCore.Type.EVENTSCRIPT);
+            });
+        }
+
+        [Fact]
+        public void Scan_FindsMapChangeFlag()
+        {
+            WithChapter(rom =>
+            {
+                var list = UseFlagScanCore.Scan(rom, 0u);
+                Assert.Contains(list, u =>
+                    u.ID == ChangeFlag && u.DataType == FELintCore.Type.MAPCHANGE);
+            });
+        }
+
+        [Fact]
+        public void Scan_ResultIsSortedByFlagId()
+        {
+            WithChapter(rom =>
+            {
+                var list = UseFlagScanCore.Scan(rom, 0u);
+                Assert.NotEmpty(list);
+                for (int i = 1; i < list.Count; i++)
+                    Assert.True(list[i - 1].ID <= list[i].ID,
+                        "results must be sorted ascending by flag id");
+            });
+        }
+
+        [Fact]
+        public void Scan_NeverYieldsFlagZero()
+        {
+            WithChapter(rom =>
+            {
+                var list = UseFlagScanCore.Scan(rom, 0u);
+                Assert.DoesNotContain(list, u => u.ID == 0);
+            });
+        }
+
+        [Fact]
+        public void Scan_NullRom_ReturnsEmpty()
+        {
+            var list = UseFlagScanCore.Scan(null, 0u);
+            Assert.NotNull(list);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void Scan_EmptyChapter_ReturnsEmptyWithoutThrowing()
+        {
+            // A bare FE8 ROM with no map/event data: every sub-scan must bail
+            // safely and the merged list is empty (not a throw).
+            var prevRom = CoreState.ROM;
+            var prevEs = CoreState.EventScript;
+            var prevComment = CoreState.CommentCache;
+            try
+            {
+                var rom = new ROM();
+                rom.LoadLow("empty-fe8u.gba", new byte[RomSize], "BE8E01");
+                CoreState.ROM = rom;
+                CoreState.EventScript = BuildEventScript(FlagCommand(), TermCommand());
+                CoreState.CommentCache = new HeadlessEtcCache();
+
+                var ex = Record.Exception(() =>
+                {
+                    var list = UseFlagScanCore.Scan(rom, 0u);
+                    Assert.Empty(list);
+                });
+                Assert.Null(ex);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.EventScript = prevEs;
+                CoreState.CommentCache = prevComment;
+            }
+        }
+
+        [Fact]
+        public void MakeFlagIDArray_MapChange_FindsRecordFlag()
+        {
+            // Direct unit test of the MapChangeCore.MakeFlagIDArray seam in
+            // isolation (no event-script env needed).
+            WithChapter(rom =>
+            {
+                var list = new List<UseFlagIDCore>();
+                MapChangeCore.MakeFlagIDArray(rom, 0u, list);
+                Assert.Contains(list, u =>
+                    u.ID == ChangeFlag && u.DataType == FELintCore.Type.MAPCHANGE);
+            });
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/UseFlagScanCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/UseFlagScanCoreTests.cs
@@ -26,7 +26,8 @@ namespace FEBuilderGBA.Core.Tests
         const int RomSize = 0x1000000; // 16MB — FE8 LoadLow minimum.
 
         // Layout (FE8U): map_setting_datasize=148, event_plist_pos=116,
-        // eventcond_tern_size=12, cond slot 0 = Turn.
+        // eventcond_tern_size=12, eventcond_talk_size=16,
+        // cond slot 0 = Turn, slot 1 = Talk.
         const uint MapTableBase   = 0x00700000u;
         const uint EventTableBase = 0x00710000u;
         const uint CondBlock      = 0x00720000u;
@@ -34,6 +35,10 @@ namespace FEBuilderGBA.Core.Tests
         const uint EventScriptAddr= 0x00740000u;
         const uint ChangeTable    = 0x00750000u;
         const uint ChangeData     = 0x00760000u;
+        // Second event-script tree, reached from the Talk cond slot — references
+        // the SAME ScriptFlag, to prove cross-TREE dedup (one EVENTSCRIPT row).
+        const uint TalkRecord      = 0x00770000u;
+        const uint EventScriptAddr2= 0x00780000u;
 
         const uint CondFlag   = 0x0011; // Turn record flag (u16 @ +2)
         const uint ScriptFlag = 0x0022; // event-script FLAG arg
@@ -101,15 +106,30 @@ namespace FEBuilderGBA.Core.Tests
                 // Next turn record header = 0 → terminates the slot walk.
                 WriteU32(rom, TurnRecord + 12, 0x00000000u);
 
-                // 4) Event script: SETFLAG ScriptFlag ; SETFLAG ScriptFlag ; ENDA.
-                //    The SAME flag is referenced TWICE (two distinct commands) so the
-                //    test can prove the WF per-tree flag-id dedup collapses it to ONE
-                //    EVENTSCRIPT row.
+                // 3b) Cond block slot 1 (Talk, stride eventcond_talk_size=16) → a
+                //     Talk record whose event ptr reaches a SECOND tree. This makes
+                //     ScriptFlag referenced from TWO DIFFERENT trees (Turn + Talk) so
+                //     the test proves CROSS-TREE dedup → still ONE EVENTSCRIPT row.
+                WriteU32(rom, CondBlock + 4, TalkRecord | 0x08000000u);
+                rom.Data[TalkRecord + 0] = 0x05; // non-zero header
+                rom.write_u16(TalkRecord + 2, 0x00); // talk record's own flag = 0 (none)
+                WriteU32(rom, TalkRecord + 4, EventScriptAddr2 | 0x08000000u);
+                // Next Talk record header word = 0 → terminates the slot walk.
+                WriteU32(rom, TalkRecord + 16, 0x00000000u);
+
+                // 4) Tree 1 (from Turn): SETFLAG ScriptFlag ; SETFLAG ScriptFlag ; ENDA.
+                //    The SAME flag is referenced TWICE within this one tree.
                 rom.write_u16(EventScriptAddr + 0, 0x0001);
                 rom.write_u16(EventScriptAddr + 2, (ushort)ScriptFlag);
                 rom.write_u16(EventScriptAddr + 4, 0x0001);
                 rom.write_u16(EventScriptAddr + 6, (ushort)ScriptFlag);
                 WriteU32(rom, EventScriptAddr + 8, 0x0000000A);
+
+                // 4b) Tree 2 (from Talk): SETFLAG ScriptFlag ; ENDA — the same flag
+                //     from a DIFFERENT tree.
+                rom.write_u16(EventScriptAddr2 + 0, 0x0001);
+                rom.write_u16(EventScriptAddr2 + 2, (ushort)ScriptFlag);
+                WriteU32(rom, EventScriptAddr2 + 4, 0x0000000A);
 
                 // 5) Map-change PLIST table: entry[3] → change data block.
                 WriteU32(rom, rom.RomInfo.map_mapchange_pointer, ChangeTable | 0x08000000u);
@@ -157,22 +177,38 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
-        public void Scan_EventScriptFlag_DedupedPerTree()
+        public void Scan_EventScriptFlag_DedupedPerChapterAndType()
         {
-            // The synthetic event script references ScriptFlag from TWO distinct
-            // SETFLAG commands within one tree. WF MakeFlagIDEventScan dedups per
-            // flag id within a tree (U.FindList), so the chapter list must contain
-            // EXACTLY ONE EVENTSCRIPT row for ScriptFlag — not one per command.
+            // ScriptFlag is referenced from TWO different commands in tree 1 (Turn)
+            // AND from tree 2 (Talk). Without chapter-level dedup that would be 3
+            // EVENTSCRIPT rows (and a real chapter, with the flag across ~8 trees,
+            // showed it 8x — PR #1254). The scan collapses to ONE row per
+            // (flag id, source type), so ScriptFlag yields EXACTLY ONE EVENTSCRIPT
+            // row regardless of how many trees/commands reference it.
             WithChapter(rom =>
             {
                 var list = UseFlagScanCore.Scan(rom, 0u);
                 var scriptRows = list.FindAll(u =>
                     u.ID == ScriptFlag && u.DataType == FELintCore.Type.EVENTSCRIPT);
                 Assert.Single(scriptRows);
-                // Addr is the event-tree root (WF UseFlagID.Addr = event_addr), and
-                // Tag is the FIRST referencing command (the earlier SETFLAG).
+                // First occurrence wins (tree 1, the Turn slot's event script).
                 Assert.Equal(EventScriptAddr, scriptRows[0].Addr);
-                Assert.Equal(EventScriptAddr, scriptRows[0].Tag);
+            });
+        }
+
+        [Fact]
+        public void Scan_NoFlagRepeatsWithinASourceType()
+        {
+            // Count-sanity / dedup invariant: across the whole returned list, no
+            // (flag id, DataType) pair appears more than once — the property that
+            // keeps the flat list readable (PR #1254 regression: 0x07 x8).
+            WithChapter(rom =>
+            {
+                var list = UseFlagScanCore.Scan(rom, 0u);
+                var seen = new System.Collections.Generic.HashSet<(uint, int)>();
+                foreach (var u in list)
+                    Assert.True(seen.Add((u.ID, (int)u.DataType)),
+                        $"duplicate row for flag 0x{u.ID:X} type {u.DataType}");
             });
         }
 
@@ -261,6 +297,92 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.Contains(list, u =>
                     u.ID == ChangeFlag && u.DataType == FELintCore.Type.MAPCHANGE);
             });
+        }
+
+        // =================================================================
+        // Real-ROM regression test for the PR #1254 duplicate-row bug
+        // (skipped when the ROM is absent — e.g. CI without roms/).
+        // =================================================================
+
+        /// <summary>
+        /// PR #1254 regression guard on the REAL FE8U chapter 0: the per-tree dedup
+        /// (d23ab511e) listed flag 0x07 ~8 times (one per cond-slot event tree).
+        /// With chapter-level (flag id, source type) dedup, NO flag may repeat
+        /// within a source type, and the row count is well below the per-tree
+        /// inflated total. Asserts the invariant + that the list is non-trivial.
+        /// </summary>
+        [Fact]
+        public void RealRom_FE8U_Chapter0_NoDuplicateFlagPerType()
+        {
+            string romPath = FindRom("FE8U.gba");
+            if (romPath == null) return; // skip when ROM absent
+
+            WithRealRomEnv(romPath, rom =>
+            {
+                var list = UseFlagScanCore.Scan(rom, 0u);
+                Assert.NotEmpty(list); // chapter 0 uses flags — non-stub proof
+
+                // The core invariant: one row per (flag id, source type).
+                var seen = new HashSet<(uint, int)>();
+                foreach (var u in list)
+                    Assert.True(seen.Add((u.ID, (int)u.DataType)),
+                        $"duplicate row for flag 0x{u.ID:X} type {u.DataType} " +
+                        "(PR #1254 regression)");
+            });
+        }
+
+        static void WithRealRomEnv(string romPath, System.Action<ROM> body)
+        {
+            var savedRom = CoreState.ROM;
+            var savedEs = CoreState.EventScript;
+            var savedEnc = CoreState.SystemTextEncoder;
+            var savedComment = CoreState.CommentCache;
+            var savedBaseDir = CoreState.BaseDirectory;
+            try
+            {
+                string asmDir = System.IO.Path.GetDirectoryName(
+                    System.Reflection.Assembly.GetExecutingAssembly().Location);
+                CoreState.BaseDirectory = asmDir;
+
+                var rom = new ROM();
+                if (!rom.Load(romPath, out string _)) return;
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+                if (CoreState.CommentCache == null)
+                    CoreState.CommentCache = new HeadlessEtcCache();
+
+                var es = new EventScript();
+                es.Load(EventScript.EventScriptType.Event);
+                CoreState.EventScript = es;
+
+                body(rom);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.EventScript = savedEs;
+                CoreState.SystemTextEncoder = savedEnc;
+                CoreState.CommentCache = savedComment;
+                if (savedBaseDir != null)
+                    CoreState.BaseDirectory = savedBaseDir;
+            }
+        }
+
+        static string FindRom(string romName)
+        {
+            string thisAssembly = System.Reflection.Assembly.GetExecutingAssembly().Location;
+            string dir = System.IO.Path.GetDirectoryName(thisAssembly);
+            for (int i = 0; i < 10 && dir != null; i++)
+            {
+                if (System.IO.File.Exists(System.IO.Path.Combine(dir, "FEBuilderGBA.sln")))
+                {
+                    string path = System.IO.Path.Combine(dir, "roms", romName);
+                    if (System.IO.File.Exists(path)) return path;
+                    break;
+                }
+                dir = System.IO.Path.GetDirectoryName(dir);
+            }
+            return null;
         }
     }
 }

--- a/FEBuilderGBA.Core.Tests/UseFlagScanCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/UseFlagScanCoreTests.cs
@@ -101,10 +101,15 @@ namespace FEBuilderGBA.Core.Tests
                 // Next turn record header = 0 → terminates the slot walk.
                 WriteU32(rom, TurnRecord + 12, 0x00000000u);
 
-                // 4) Event script: SETFLAG ScriptFlag ; ENDA.
+                // 4) Event script: SETFLAG ScriptFlag ; SETFLAG ScriptFlag ; ENDA.
+                //    The SAME flag is referenced TWICE (two distinct commands) so the
+                //    test can prove the WF per-tree flag-id dedup collapses it to ONE
+                //    EVENTSCRIPT row.
                 rom.write_u16(EventScriptAddr + 0, 0x0001);
                 rom.write_u16(EventScriptAddr + 2, (ushort)ScriptFlag);
-                WriteU32(rom, EventScriptAddr + 4, 0x0000000A);
+                rom.write_u16(EventScriptAddr + 4, 0x0001);
+                rom.write_u16(EventScriptAddr + 6, (ushort)ScriptFlag);
+                WriteU32(rom, EventScriptAddr + 8, 0x0000000A);
 
                 // 5) Map-change PLIST table: entry[3] → change data block.
                 WriteU32(rom, rom.RomInfo.map_mapchange_pointer, ChangeTable | 0x08000000u);
@@ -148,6 +153,26 @@ namespace FEBuilderGBA.Core.Tests
                 var list = UseFlagScanCore.Scan(rom, 0u);
                 Assert.Contains(list, u =>
                     u.ID == ScriptFlag && u.DataType == FELintCore.Type.EVENTSCRIPT);
+            });
+        }
+
+        [Fact]
+        public void Scan_EventScriptFlag_DedupedPerTree()
+        {
+            // The synthetic event script references ScriptFlag from TWO distinct
+            // SETFLAG commands within one tree. WF MakeFlagIDEventScan dedups per
+            // flag id within a tree (U.FindList), so the chapter list must contain
+            // EXACTLY ONE EVENTSCRIPT row for ScriptFlag — not one per command.
+            WithChapter(rom =>
+            {
+                var list = UseFlagScanCore.Scan(rom, 0u);
+                var scriptRows = list.FindAll(u =>
+                    u.ID == ScriptFlag && u.DataType == FELintCore.Type.EVENTSCRIPT);
+                Assert.Single(scriptRows);
+                // Addr is the event-tree root (WF UseFlagID.Addr = event_addr), and
+                // Tag is the FIRST referencing command (the earlier SETFLAG).
+                Assert.Equal(EventScriptAddr, scriptRows[0].Addr);
+                Assert.Equal(EventScriptAddr, scriptRows[0].Tag);
             });
         }
 

--- a/FEBuilderGBA.Core/MapChangeCore.cs
+++ b/FEBuilderGBA.Core/MapChangeCore.cs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 using System;
+using System.Collections.Generic;
 
 namespace FEBuilderGBA
 {
@@ -337,5 +338,57 @@ namespace FEBuilderGBA
         /// </summary>
         public static uint GetMapChangeAddrWhereMapID(ROM rom, uint mapId)
             => GetMapChangeAddrWhereMapID(rom, mapId, out _);
+
+        // ============================================================
+        // #1192 — per-chapter map-change flag scan.
+        //
+        // InputFormRef-free port of WinForms MapChangeForm.MakeFlagIDArray
+        // (which used N_Init's InputFormRef: a 12-byte block whose record
+        // count walks until u8(addr)==0xFF, with the flag id as the u16 at
+        // record offset +5). The WinForms path delegated to
+        // UseFlagID.AppendFlagIDFixedMapID — "FixedMapID" because every
+        // change record of the selected chapter belongs to THAT chapter, so
+        // we attribute the selected mapid directly (matching the tool's
+        // intent of listing the chapter's own map-change flags).
+        // ============================================================
+
+        /// <summary>Block stride of one map-change record (WF N_Init blocksize).</summary>
+        const uint MapChangeRecordSize = 12;
+        /// <summary>u16 flag id offset inside a map-change record (WF flagIDPlus).</summary>
+        const uint MapChangeFlagOffset = 5;
+        /// <summary>Defensive bound so a corrupt 0xFF-less table can never loop forever.</summary>
+        const int MapChangeMaxRecords = 4096;
+
+        /// <summary>
+        /// Append every map-change flag used by <paramref name="mapId"/> to
+        /// <paramref name="list"/> (lint category <see cref="FELintCore.Type.MAPCHANGE"/>).
+        /// Strictly READ-ONLY: every read is bounds-guarded, malformed data
+        /// terminates the walk and yields a (possibly empty) partial list
+        /// instead of throwing. Mirrors WF MapChangeForm.MakeFlagIDArray.
+        /// </summary>
+        public static void MakeFlagIDArray(ROM rom, uint mapId, List<UseFlagIDCore> list)
+        {
+            if (rom?.RomInfo == null || list == null) return;
+
+            uint changeAddr = GetMapChangeAddrWhereMapID(rom, mapId);
+            if (changeAddr == U.NOT_FOUND || !U.isSafetyOffset(changeAddr, rom)) return;
+
+            uint addr = changeAddr;
+            for (int i = 0; i < MapChangeMaxRecords; i++, addr += MapChangeRecordSize)
+            {
+                // Bounds-check the full record (incl. the +5 flag u16) before
+                // any read so a near-EOF table can't throw.
+                if (!U.isSafetyOffset(addr, rom)) break;
+                if (addr + MapChangeRecordSize > (uint)rom.Data.Length) break;
+
+                // WF N_Init DataCount predicate: a record whose first byte is
+                // 0xFF terminates the change table.
+                if (rom.u8(addr) == 0xFF) break;
+
+                uint flag = rom.u16(addr + MapChangeFlagOffset);
+                UseFlagIDCore.AppendUseFlagID(
+                    list, FELintCore.Type.MAPCHANGE, addr, U.ToHexString((uint)i), flag, mapId, (uint)i);
+            }
+        }
     }
 }

--- a/FEBuilderGBA.Core/UseFlagIDCore.cs
+++ b/FEBuilderGBA.Core/UseFlagIDCore.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Cross-platform, strictly READ-ONLY record describing one event-flag
+    /// usage found in a chapter (Avalonia "Flags-Used-in-Chapter" tool, issue
+    /// #1192 — port of the WinForms <c>UseFlagID</c> class consumed by
+    /// <c>ToolUseFlagForm</c>).
+    ///
+    /// This is a PARALLEL Core type, NOT a move of the WinForms
+    /// <c>FEBuilderGBA.UseFlagID</c> — the WinForms class stays in place (it is
+    /// referenced by EventCondForm / MapChangeForm / EventHaiku* / EventBattleTalk*
+    /// and its <c>AppendFlagID</c> overloads take a WinForms <c>InputFormRef</c>).
+    /// This Core copy carries only the InputFormRef-free essence so the headless
+    /// scanner (<see cref="UseFlagScanCore"/>) and the Avalonia tool can build the
+    /// same per-chapter flag-usage list without any WinForms dependency.
+    /// </summary>
+    public sealed class UseFlagIDCore
+    {
+        /// <summary>The lint category that classifies WHERE the flag was found
+        /// (event condition / event script / map change).</summary>
+        public FELintCore.Type DataType { get; }
+
+        /// <summary>The event-flag id that is referenced.</summary>
+        public uint ID { get; }
+
+        /// <summary>A short human-readable label for the usage site (slot name
+        /// or "").</summary>
+        public string Info { get; }
+
+        /// <summary>The ROM byte offset of the referencing record / command.</summary>
+        public uint Addr { get; }
+
+        /// <summary>The chapter (map) id the usage belongs to, or
+        /// <see cref="U.NOT_FOUND"/> when it is chapter-independent.</summary>
+        public uint MapID { get; }
+
+        /// <summary>Opaque navigation tag (slot index / event-script command
+        /// address), mirroring the WinForms record's <c>Tag</c>.</summary>
+        public uint Tag { get; }
+
+        public UseFlagIDCore(FELintCore.Type dataType, uint addr, string info, uint id, uint mapid, uint tag = U.NOT_FOUND)
+        {
+            this.DataType = dataType;
+            this.Addr = addr;
+            this.Info = info ?? "";
+            this.ID = id;
+            this.MapID = mapid;
+            this.Tag = tag;
+        }
+
+        /// <summary>
+        /// Append a usage record unless the flag id is 0 (the "no flag" sentinel,
+        /// matching the WinForms <c>UseFlagID.AppendUseFlagID</c> guard). Strictly
+        /// additive — never mutates the ROM.
+        /// </summary>
+        public static void AppendUseFlagID(List<UseFlagIDCore> list, FELintCore.Type dataType, uint addr, string info, uint id, uint mapid, uint tag = U.NOT_FOUND)
+        {
+            if (list == null) return;
+            if (id == 0) return;
+            list.Add(new UseFlagIDCore(dataType, addr, info, id, mapid, tag));
+        }
+    }
+}

--- a/FEBuilderGBA.Core/UseFlagScanCore.cs
+++ b/FEBuilderGBA.Core/UseFlagScanCore.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Cross-platform, strictly READ-ONLY aggregator for the Avalonia
+    /// "Flags-Used-in-Chapter" tool (issue #1192 — port of the WinForms
+    /// <c>ToolUseFlagForm.UpdateList</c> flag-usage roll-up).
+    ///
+    /// Given a chapter (map id) it collects every event-flag reference from the
+    /// PRIMARY flag-usage subsystems and returns the merged + WF-sorted list:
+    ///   (1) event-condition records   — the flag field of each Turn / Talk /
+    ///       Object / Always condition record  (FELint EVENT_COND_*),
+    ///   (2) event scripts              — every <see cref="EventScript.ArgType.FLAG"/>
+    ///       referenced by the scripts reachable from the chapter's condition
+    ///       slots  (FELint EVENTSCRIPT), and
+    ///   (3) map changes                — the flag field of each map-change record
+    ///       (FELint MAPCHANGE).
+    ///
+    /// Reuses the existing Core seams rather than re-deriving them:
+    ///   <see cref="MapEventUnitCore.GetCondSlots"/>      (the per-version slot→type table),
+    ///   <see cref="MapEventUnitCore.GetEventAddrForMap"/> (map id → cond block),
+    ///   <see cref="EventScriptReferenceScanner.EnumerateEventEntries"/> +
+    ///   the <see cref="EventScript.ArgType.FLAG"/> walk, and
+    ///   <see cref="MapChangeCore.MakeFlagIDArray"/>.
+    ///
+    /// DEFERRED (#1253): the Haiku × {FE6,FE7,FE8} and BattleTalk × {FE6,FE7,FE8}
+    /// scanners (WinForms EventHaiku*Form.MakeFlagIDArray / EventBattleTalk*Form.MakeFlagIDArray)
+    /// are NOT included here. Each needs its subsystem's per-version data-table
+    /// layout (InputFormRef Init base-pointer / block-size / count) ported to
+    /// Core first — out of scope for this slice, tracked by follow-up issue #1253.
+    ///
+    /// NO ROM mutation, NO undo. Every read is bounds-guarded; malformed data
+    /// truncates a sub-scan and yields a partial list rather than throwing.
+    /// </summary>
+    public static class UseFlagScanCore
+    {
+        // Defensive per-slot record-walk bound (a corrupt table with no
+        // terminating zero word can never loop forever).
+        const int MaxRecordsPerSlot = 4096;
+
+        /// <summary>
+        /// Scan chapter <paramref name="mapId"/> and return its merged, WF-sorted
+        /// flag-usage list. Returns an empty (never null) list when the ROM is
+        /// missing/foreign or the chapter has no resolvable event data.
+        /// </summary>
+        public static List<UseFlagIDCore> Scan(ROM rom, uint mapId)
+        {
+            var list = new List<UseFlagIDCore>();
+            if (rom?.RomInfo == null) return list;
+
+            AppendEventCondFlags(rom, mapId, list);
+            AppendEventScriptFlags(rom, mapId, list);
+            MapChangeCore.MakeFlagIDArray(rom, mapId, list);
+
+            SortLikeWinForms(list);
+            return list;
+        }
+
+        // ------------------------------------------------------------
+        // (1) Event-condition record flags.
+        //
+        // Mirrors the per-slot reads in WF EventCondForm.MakeFlagIDArray: for
+        // each Object / Talk / Turn / Always slot, walk the record array
+        // (stop at a zero header word) and append the u16 flag at record +2.
+        // ALWAYS records whose type word (u16 @ +0) is 1 also expose a second
+        // "use flag" (u16 @ +8) — preserved for parity.
+        // ------------------------------------------------------------
+        static void AppendEventCondFlags(ROM rom, uint mapId, List<UseFlagIDCore> list)
+        {
+            uint condBlock = MapEventUnitCore.GetEventAddrForMap(rom, mapId);
+            if (condBlock == U.NOT_FOUND || !U.isSafetyOffset(condBlock, rom)) return;
+
+            var slots = MapEventUnitCore.GetCondSlots(rom);
+            if (slots.Count == 0) return;
+
+            bool isFE7 = rom.RomInfo.version == 7;
+            uint romLen = (uint)rom.Data.Length;
+
+            for (int i = 0; i < slots.Count; i++)
+            {
+                uint slotAddr = (uint)(condBlock + 4 * i);
+                if (slotAddr + 4 > romLen) break;
+
+                var slot = slots[i];
+                FELintCore.Type type;
+                switch (slot.Type)
+                {
+                    case MapEventUnitCore.CondType.Object: type = FELintCore.Type.EVENT_COND_OBJECT; break;
+                    case MapEventUnitCore.CondType.Talk:   type = FELintCore.Type.EVENT_COND_TALK;   break;
+                    case MapEventUnitCore.CondType.Turn:   type = FELintCore.Type.EVENT_COND_TURN;   break;
+                    case MapEventUnitCore.CondType.Always: type = FELintCore.Type.EVENT_COND_ALWAYS; break;
+                    default:
+                        // Trap / unit-placement / tutorial / start / end slots are
+                        // NOT flag-bearing condition records in WF MakeFlagIDArray.
+                        continue;
+                }
+
+                uint recAddr = rom.p32(slotAddr);
+                if (!U.isSafetyOffset(recAddr, rom)) continue;
+
+                uint stride = SlotRecordStride(rom, slot.Type);
+                if (stride == 0) continue;
+
+                uint addr = recAddr;
+                for (int n = 0; n < MaxRecordsPerSlot; n++)
+                {
+                    if (!U.isSafetyOffset(addr, rom)) break;
+                    if (addr + stride > romLen) break;
+                    if (rom.u32(addr) == 0) break; // zero header word terminates
+
+                    uint flag = rom.u16(addr + 2);
+                    UseFlagIDCore.AppendUseFlagID(list, type, addr, slot.Name, flag, mapId, (uint)n);
+
+                    if (slot.Type == MapEventUnitCore.CondType.Always && rom.u16(addr + 0) == 1)
+                    {
+                        uint useFlag = rom.u16(addr + 8);
+                        UseFlagIDCore.AppendUseFlagID(list, type, addr, slot.Name, useFlag, mapId, (uint)n);
+                    }
+
+                    // FE7 short Turn record (type==1) is 12 bytes vs the slot stride.
+                    if (slot.Type == MapEventUnitCore.CondType.Turn && isFE7 && rom.u8(addr) == 1)
+                        addr += 12;
+                    else
+                        addr += stride;
+                }
+            }
+        }
+
+        static uint SlotRecordStride(ROM rom, MapEventUnitCore.CondType type)
+        {
+            switch (type)
+            {
+                case MapEventUnitCore.CondType.Turn: return rom.RomInfo.eventcond_tern_size;
+                case MapEventUnitCore.CondType.Talk: return rom.RomInfo.eventcond_talk_size;
+                case MapEventUnitCore.CondType.Object:
+                case MapEventUnitCore.CondType.Always: return 12;
+                default: return 0;
+            }
+        }
+
+        // ------------------------------------------------------------
+        // (2) Event-script FLAG references.
+        //
+        // EnumerateEventEntries yields the SAME per-map event-script entry
+        // points WF MakeFlagIDArrayOne recurses from (tagged by mapid). For the
+        // selected chapter we disassemble each entry, collecting every
+        // ArgType.FLAG (recursing through POINTER_EVENT with a cycle guard) —
+        // identical to WF MakeFlagIDEventScan. The Tag carries the referencing
+        // command address so the UI can jump to it.
+        // ------------------------------------------------------------
+        static void AppendEventScriptFlags(ROM rom, uint mapId, List<UseFlagIDCore> list)
+        {
+            // The disasm path dereferences CoreState.ROM / CoreState.EventScript /
+            // CoreState.CommentCache; only scan when this ROM IS the active one
+            // and those are wired (matches EventScriptReferenceScanner gating).
+            var es = CoreState.EventScript;
+            if (es == null) return;
+            if (CoreState.ROM == null || !ReferenceEquals(CoreState.ROM, rom)) return;
+            if (CoreState.CommentCache == null) return;
+
+            var entries = EventScriptReferenceScanner.EnumerateEventEntries(rom);
+            var tracelist = new List<uint>();
+            var seen = new HashSet<ulong>(); // (flag,cmdAddr) dedup across slots
+
+            foreach (var entry in entries)
+            {
+                if (entry.tag != mapId) continue; // .tag == mapid of the entry
+                ScanScriptForFlags(rom, es, entry.addr, mapId, tracelist, seen, list);
+            }
+        }
+
+        // Port of WF EventCondForm.MakeFlagIDEventScan (FLAG path): disassemble
+        // an event script, collect ArgType.FLAG, recurse through POINTER_EVENT.
+        static void ScanScriptForFlags(
+            ROM rom, EventScript es, uint eventAddr, uint mapId,
+            List<uint> tracelist, HashSet<ulong> seen, List<UseFlagIDCore> list)
+        {
+            uint addr = eventAddr;
+            uint lastBranchAddr = 0;
+            int unknownCount = 0;
+            uint romLen = (uint)rom.Data.Length;
+
+            for (int guard = 0; guard < 4096; guard++)
+            {
+                if (U.toOffset(addr) + 4 > romLen) break;
+
+                EventScript.OneCode code = es.DisAseemble(rom.Data, addr);
+                if (code?.Script == null) break;
+                if (EventScript.IsExitCode(code, addr, lastBranchAddr)) break;
+
+                if (code.Script.Has == EventScript.ScriptHas.UNKNOWN)
+                {
+                    unknownCount++;
+                    if (unknownCount > 10) break;
+                }
+                else
+                {
+                    unknownCount = 0;
+
+                    if (code.Script.Has == EventScript.ScriptHas.IF_CONDITIONAL)
+                        lastBranchAddr = addr;
+                    else if (code.Script.Has == EventScript.ScriptHas.LABEL_CONDITIONAL)
+                        lastBranchAddr = 0;
+
+                    if (code.Script.Args != null)
+                    {
+                        for (int a = 0; a < code.Script.Args.Length; a++)
+                        {
+                            EventScript.Arg arg = code.Script.Args[a];
+
+                            if (arg.Type == EventScript.ArgType.POINTER_EVENT)
+                            {
+                                uint v = U.toOffset(EventScript.GetArgValue(code, arg));
+                                if (U.isSafetyOffset(v, rom) && tracelist.IndexOf(v) < 0)
+                                {
+                                    tracelist.Add(v);
+                                    ScanScriptForFlags(rom, es, v, mapId, tracelist, seen, list);
+                                }
+                            }
+                            else if (arg.Type == EventScript.ArgType.FLAG)
+                            {
+                                uint v = EventScript.GetArgValue(code, arg);
+                                if (v == 0) continue;
+                                // Dedup identical (flag id, referencing command) pairs so a
+                                // script reached from multiple slots is not double-listed.
+                                ulong key = ((ulong)v << 32) | addr;
+                                if (!seen.Add(key)) continue;
+                                UseFlagIDCore.AppendUseFlagID(
+                                    list, FELintCore.Type.EVENTSCRIPT, addr, "", v, mapId, addr);
+                            }
+                        }
+                    }
+                }
+
+                int step = code.Script.Size;
+                if (step <= 0) break;
+                addr += (uint)step;
+            }
+        }
+
+        // ------------------------------------------------------------
+        // WF ToolUseFlagForm.UpdateList sort: by flag ID, then MapID, then
+        // DataType — so the UI groups all sites of one flag together.
+        // ------------------------------------------------------------
+        static void SortLikeWinForms(List<UseFlagIDCore> list)
+        {
+            list.Sort((a, b) =>
+            {
+                if (a.ID != b.ID) return a.ID.CompareTo(b.ID);
+                if (a.MapID != b.MapID) return a.MapID.CompareTo(b.MapID);
+                return ((int)a.DataType).CompareTo((int)b.DataType);
+            });
+        }
+    }
+}

--- a/FEBuilderGBA.Core/UseFlagScanCore.cs
+++ b/FEBuilderGBA.Core/UseFlagScanCore.cs
@@ -161,21 +161,39 @@ namespace FEBuilderGBA
             if (CoreState.CommentCache == null) return;
 
             var entries = EventScriptReferenceScanner.EnumerateEventEntries(rom);
-            var tracelist = new List<uint>();
-            var seen = new HashSet<ulong>(); // (flag,cmdAddr) dedup across slots
 
             foreach (var entry in entries)
             {
                 if (entry.tag != mapId) continue; // .tag == mapid of the entry
-                ScanScriptForFlags(rom, es, entry.addr, mapId, tracelist, seen, list);
+
+                // WF MakeFlagIDArrayOne builds a FRESH (flag-id-keyed) result list
+                // PER event-script entry tree, then appends one UseFlagID per
+                // distinct flag id found in that tree. So the dedup scope is the
+                // single tree, NOT the whole chapter: a flag referenced 3x inside
+                // one tree -> ONE EVENTSCRIPT row (recording the FIRST command),
+                // while the same flag appearing in two different cond-slot trees
+                // legitimately yields one row each.
+                var found = new List<(uint flag, uint cmdAddr)>();
+                var tracelist = new List<uint>();
+                ScanScriptForFlags(rom, es, entry.addr, tracelist, found);
+
+                foreach (var (flag, cmdAddr) in found)
+                {
+                    // Mirror WF UseFlagID: Addr = the event-tree root (entry.addr),
+                    // Tag = the referencing command address (cmdAddr).
+                    UseFlagIDCore.AppendUseFlagID(
+                        list, FELintCore.Type.EVENTSCRIPT, entry.addr, "", flag, mapId, cmdAddr);
+                }
             }
         }
 
-        // Port of WF EventCondForm.MakeFlagIDEventScan (FLAG path): disassemble
-        // an event script, collect ArgType.FLAG, recurse through POINTER_EVENT.
+        // Port of WF EventCondForm.MakeFlagIDEventScan (FLAG path): disassemble an
+        // event script, collect each ArgType.FLAG ONCE per distinct flag id (WF
+        // U.FindList(list, flag) dedup — keeps the FIRST referencing command),
+        // recursing through POINTER_EVENT with a cycle guard. Strictly read-only.
         static void ScanScriptForFlags(
-            ROM rom, EventScript es, uint eventAddr, uint mapId,
-            List<uint> tracelist, HashSet<ulong> seen, List<UseFlagIDCore> list)
+            ROM rom, EventScript es, uint eventAddr,
+            List<uint> tracelist, List<(uint flag, uint cmdAddr)> found)
         {
             uint addr = eventAddr;
             uint lastBranchAddr = 0;
@@ -216,19 +234,17 @@ namespace FEBuilderGBA
                                 if (U.isSafetyOffset(v, rom) && tracelist.IndexOf(v) < 0)
                                 {
                                     tracelist.Add(v);
-                                    ScanScriptForFlags(rom, es, v, mapId, tracelist, seen, list);
+                                    ScanScriptForFlags(rom, es, v, tracelist, found);
                                 }
                             }
                             else if (arg.Type == EventScript.ArgType.FLAG)
                             {
                                 uint v = EventScript.GetArgValue(code, arg);
                                 if (v == 0) continue;
-                                // Dedup identical (flag id, referencing command) pairs so a
-                                // script reached from multiple slots is not double-listed.
-                                ulong key = ((ulong)v << 32) | addr;
-                                if (!seen.Add(key)) continue;
-                                UseFlagIDCore.AppendUseFlagID(
-                                    list, FELintCore.Type.EVENTSCRIPT, addr, "", v, mapId, addr);
+                                // WF U.FindList(list, v): one entry per distinct flag id
+                                // within this tree, keeping the first command seen.
+                                if (ContainsFlag(found, v)) continue;
+                                found.Add((v, addr));
                             }
                         }
                     }
@@ -238,6 +254,13 @@ namespace FEBuilderGBA
                 if (step <= 0) break;
                 addr += (uint)step;
             }
+        }
+
+        static bool ContainsFlag(List<(uint flag, uint cmdAddr)> found, uint flag)
+        {
+            for (int i = 0; i < found.Count; i++)
+                if (found[i].flag == flag) return true;
+            return false;
         }
 
         // ------------------------------------------------------------

--- a/FEBuilderGBA.Core/UseFlagScanCore.cs
+++ b/FEBuilderGBA.Core/UseFlagScanCore.cs
@@ -42,20 +42,54 @@ namespace FEBuilderGBA
 
         /// <summary>
         /// Scan chapter <paramref name="mapId"/> and return its merged, WF-sorted
-        /// flag-usage list. Returns an empty (never null) list when the ROM is
-        /// missing/foreign or the chapter has no resolvable event data.
+        /// flag-usage list — ONE row per distinct (flag id, source type). Returns
+        /// an empty (never null) list when the ROM is missing/foreign or the
+        /// chapter has no resolvable event data.
+        ///
+        /// DEDUP RATIONALE (PR #1254 review): WinForms ToolUseFlagForm does NOT
+        /// dedup its underlying FlagList (a flag referenced from N cond-slot event
+        /// trees yields N EVENTSCRIPT entries), but its owner-draw list COLLAPSES
+        /// them visually — the flag header/name is drawn only when the id changes
+        /// (ToolUseFlagForm.Draw: <c>current.ID != FlagList[index-1].ID</c>), so the
+        /// user sees each flag's source-types grouped under one header, not the same
+        /// flag repeated. The Avalonia AddressListControl is a FLAT list with no
+        /// owner-draw grouping, so to reproduce that readable "one flag, its source
+        /// types once each" UX we collapse to one row per (flag id, DataType) here,
+        /// keeping the FIRST occurrence (its Addr/Tag). This is the right flat-list
+        /// UX AND matches what WF actually displays (a single 0x07 [EVENTSCRIPT]
+        /// line, not the same flag 8x).
         /// </summary>
         public static List<UseFlagIDCore> Scan(ROM rom, uint mapId)
         {
-            var list = new List<UseFlagIDCore>();
-            if (rom?.RomInfo == null) return list;
+            var raw = new List<UseFlagIDCore>();
+            if (rom?.RomInfo == null) return raw;
 
-            AppendEventCondFlags(rom, mapId, list);
-            AppendEventScriptFlags(rom, mapId, list);
-            MapChangeCore.MakeFlagIDArray(rom, mapId, list);
+            // Collect in WF append order (cond → event-script → map-change) so the
+            // first-occurrence kept per (id, type) is deterministic.
+            AppendEventCondFlags(rom, mapId, raw);
+            AppendEventScriptFlags(rom, mapId, raw);
+            MapChangeCore.MakeFlagIDArray(rom, mapId, raw);
 
+            var list = DedupByFlagAndType(raw);
             SortLikeWinForms(list);
             return list;
+        }
+
+        // One row per (flag id, DataType), keeping the first occurrence in scan
+        // order (its Addr/Tag — the first referencing site). A flag used by both
+        // an EVENT_COND_* record and an event script still shows BOTH rows (one
+        // per source type), so the user can tell where a flag is used; it just
+        // never repeats the SAME source type for the SAME flag.
+        static List<UseFlagIDCore> DedupByFlagAndType(List<UseFlagIDCore> raw)
+        {
+            var result = new List<UseFlagIDCore>(raw.Count);
+            var seen = new HashSet<(uint, int)>();
+            foreach (UseFlagIDCore u in raw)
+            {
+                if (seen.Add((u.ID, (int)u.DataType)))
+                    result.Add(u);
+            }
+            return result;
         }
 
         // ------------------------------------------------------------

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20560,3 +20560,11 @@ Please select a target language (ja and auto cannot be selected).
 
 :Please select a valid source code folder.
 Please select a valid source code folder.
+:Flags Used in Chapter
+Flags Used in Chapter
+
+:Chapter
+Chapter
+
+:Flags used
+Flags used

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11820,3 +11820,11 @@ config/translate/<lang>.txt
 
 :Please select a valid source code folder.
 有効なソースコードフォルダを選択してください。
+:Flags Used in Chapter
+章で使用しているフラグ
+
+:Chapter
+章
+
+:Flags used
+使用フラグ数

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25661,3 +25661,11 @@ config/translate/<lang>.txt
 
 :Please select a valid source code folder.
 请选择有效的源代码文件夹。
+:Flags Used in Chapter
+章节中使用的旗标
+
+:Chapter
+章节
+
+:Flags used
+使用的旗标数


### PR DESCRIPTION
Fixes #1192.

Implements the Avalonia **Flags-Used-in-Chapter** tool (was a bare scaffold over a dummy `AddrResult`), with parity to WinForms `ToolUseFlagForm`: scans + lists which event flags are referenced per chapter. **Read-only** (no ROM mutation).

## What
- Chapter/map selector + a per-chapter flag-usage list (flag ID + name + type tag + where-used Info) + a detail pane (flag, name, type, address, info).

## How (architecture)
- New GUI-free **`FEBuilderGBA.Core/UseFlagScanCore.Scan(rom, mapId)`** aggregating flag usage from **three** sources (sorted by ID → MapID → DataType, matching WF):
  1. **Event-condition** flag fields (`EVENT_COND_TURN/TALK/OBJECT/ALWAYS`) — via the existing `MapEventUnitCore.GetCondSlots`/`GetEventAddrForMap`.
  2. **Event-script** `ArgType.FLAG` refs (`EVENTSCRIPT`) — via the existing `EventScriptReferenceScanner.EnumerateEventEntries` (already yields per-map event roots tagged by mapid).
  3. **Map-change** flags (`MAPCHANGE`) — new `MapChangeCore.MakeFlagIDArray` (12-byte stride, flag u16 @ +5, bounds-guarded).
- New parallel Core record **`UseFlagIDCore`** (the WinForms `UseFlagID` is left untouched — a parallel type avoids churning the 6 WF callers). Read-only aggregator VM → **not** `IDataVerifiable` (orphan-safe).
- **Key reuse:** `GetEventAddrForMap` + Core `MapCond` + the event-script walk already existed, so this is **2 new Core files + 1 method** — no new event-subsystem ports.

### Scope boundary (intentional, documented → #1253)
The WinForms tool also scans **EventHaiku** + **EventBattleTalk** (× FE6/FE7/FE8 = 6 scanners). Each needs its per-version data-table layout ported to Core first — **deferred to #1253** (documented in `UseFlagScanCore.cs` + the VM). The shipped slice covers the primary flag-usage sources (event conditions + event scripts + map changes).

## Tests / gates (all green — FULL projects)
- `UseFlagScanCoreTests` (8) — synthetic-ROM scans asserting each in-scope source type lands; `ToolUseFlagViewModelTests` (8).
- Core.Tests WHOLE **4307/5skip**; Avalonia.Tests WHOLE **8316/3skip** (L10n HaveJaAndZhTranslations + NoOrphanVMs PASS); FEBuilderGBA.Tests WHOLE **1864/0**. Builds 0 err; `validate-automation-ids` 0/0; AvaloniaDarkMode PASS (0 hex); en+ja+zh added.

## Proof (FE8U — Flags Used in Chapter, "00 The Fall of Renais" → 35 flags)
All 3 source types resolve live (`EVENT_COND_ALWAYS`/`EVENT_COND_TURN`/`EVENTSCRIPT`), with names + a detail pane:

<img width="900" src="https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1192-flags-used-fe8u.png">

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 4.8 (1M context), model `claude-opus-4-8[1m]`