### PR TITLE
feat(avalonia): add GoldRoad assembler support to Add-via-ASM/C tool (#1244)

### DIFF
--- a/FEBuilderGBA.Avalonia/ViewModels/ToolASMInsertViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ToolASMInsertViewModel.cs
@@ -6,7 +6,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
     /// <summary>
     /// ViewModel for the Avalonia "Add-via-ASM/C" tool (WF
     /// <c>ToolASMInsertForm</c>). Compiles a C/C++/ASM source through the devkitARM
-    /// chain (gcc/g++/as → ELF → raw binary, or lyn → EA event) and inserts the
+    /// chain (gcc/g++/as → ELF → raw binary, or lyn → EA event) — or, for a legacy
+    /// <c>@thumb</c> <c>.ASM</c> source, the GoldRoad assembler (auto-selected from
+    /// the source content, mirroring WF <c>MainFormUtil.Compile</c>) — and inserts the
     /// result into the ROM via one of three methods (write-at-address, hook-inject,
     /// or compile-only).
     ///
@@ -15,9 +17,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
     /// to that helper. It reads no ROM bytes for display (it only WRITES via the
     /// helper) so it is a read-no-ROM tool VM (no data-verification contract).
     ///
-    /// Scope: the GoldRoad assembler path and the "Make Patch" text generator are
-    /// deferred to a follow-up (both WinForms-coupled); the devkitARM compile +
-    /// the three insert methods are the parity surface here.
+    /// Scope: the "Make Patch" text generator is deferred to a follow-up (WinForms-
+    /// coupled); the devkitARM compile, the GoldRoad <c>@thumb</c> path (auto-detected,
+    /// no extra UI), and the three insert methods are the parity surface here.
     /// </summary>
     public class ToolASMInsertViewModel : ViewModelBase
     {
@@ -88,8 +90,33 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// <summary>Localized "devkitpro_eabi not configured" message (for the UI).</summary>
         public string NotFoundMessage => AsmCompileCore.GetNotFoundMessage();
 
+        /// <summary>True when the legacy GoldRoad assembler path is configured and exists.</summary>
+        public bool IsGoldRoadAvailable => AsmCompileCore.IsGoldRoadAvailable();
+
+        /// <summary>Localized "goldroad not configured" message (for the UI).</summary>
+        public string GoldRoadNotFoundMessage => AsmCompileCore.GetGoldRoadNotFoundMessage();
+
         /// <summary>True when the selected source file exists on disk.</summary>
         public bool SourceExists => !string.IsNullOrEmpty(SourcePath) && File.Exists(SourcePath);
+
+        /// <summary>
+        /// True when the selected source is a legacy GoldRoad (<c>@thumb</c> <c>.ASM</c>)
+        /// source — the assembler is auto-selected from the source content (WF
+        /// <c>MainFormUtil.Compile</c>), so no compile-method UI is needed for it.
+        /// </summary>
+        public bool IsGoldRoadSource => SourceExists && AsmCompileCore.ShouldUseGoldRoad(SourcePath);
+
+        /// <summary>
+        /// The assembler the selected source will use is configured: GoldRoad for a
+        /// <c>@thumb</c> <c>.ASM</c>, otherwise devkitARM. Used by the View to surface
+        /// the right not-found message before running.
+        /// </summary>
+        public bool IsRequiredToolAvailable =>
+            IsGoldRoadSource ? IsGoldRoadAvailable : IsDevkitProAvailable;
+
+        /// <summary>The not-found message for whichever assembler the source requires.</summary>
+        public string RequiredToolNotFoundMessage =>
+            IsGoldRoadSource ? GoldRoadNotFoundMessage : NotFoundMessage;
 
         /// <summary>
         /// Parse a hex address field. Accepts "0x..." or bare hex; returns 0 on a

--- a/FEBuilderGBA.Avalonia/Views/ToolASMInsertView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolASMInsertView.axaml
@@ -13,8 +13,10 @@
        hook-register / debug-symbol combo items are populated in code-behind via R._()
        so they pick up ja/zh translations (ViewTranslationHelper does not translate
        ComboBoxItem content).
-       Deferred to a follow-up: the GoldRoad assembler path and the "Make Patch" text
-       generator (both WinForms-coupled); revert an applied insert via Undo for now. -->
+       The GoldRoad assembler path (@thumb .ASM, the legacy MASM-like assembler) is
+       supported via AsmCompileCore, auto-selected from the source content (#1244).
+       Deferred to a follow-up: the "Make Patch" text generator (#1243); revert an
+       applied insert via Undo for now. -->
   <ScrollViewer VerticalScrollBarVisibility="Auto">
     <StackPanel Margin="16" Spacing="10">
 

--- a/FEBuilderGBA.Avalonia/Views/ToolASMInsertView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolASMInsertView.axaml.cs
@@ -10,18 +10,19 @@ namespace FEBuilderGBA.Avalonia.Views
 {
     /// <summary>
     /// Add-via-ASM/C tool (WF <c>ToolASMInsertForm</c>). Compiles a C/C++/ASM source
-    /// through the devkitARM chain and inserts the result into the ROM via the
-    /// GUI-free Core helper <see cref="AsmCompileCore"/>, with a compile method
-    /// (dump binary / keep ELF / convert to lyn.event), an insert method
-    /// (compile-only / write-at-address / hook-inject), a hook register, a
-    /// debug-symbol store choice, a missing-label check and undo.
+    /// through the devkitARM chain — or, for a legacy <c>@thumb</c> <c>.ASM</c> source,
+    /// the GoldRoad assembler (auto-selected from the source content, no extra UI) —
+    /// and inserts the result into the ROM via the GUI-free Core helper
+    /// <see cref="AsmCompileCore"/>, with a compile method (dump binary / keep ELF /
+    /// convert to lyn.event), an insert method (compile-only / write-at-address /
+    /// hook-inject), a hook register, a debug-symbol store choice, a missing-label
+    /// check and undo.
     ///
     /// Combo items are added in code via R._() so they pick up ja/zh translations
     /// (ViewTranslationHelper does not translate ComboBoxItem content).
     ///
-    /// The GoldRoad assembler path and the "Make Patch" text generator are deferred
-    /// to a follow-up issue (both WinForms-coupled); an applied insert can be
-    /// reverted via Undo for now.
+    /// The "Make Patch" text generator is deferred to a follow-up issue
+    /// (WinForms-coupled); an applied insert can be reverted via Undo.
     /// </summary>
     public partial class ToolASMInsertView : TranslatedWindow, IEditorView
     {
@@ -153,9 +154,12 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (!await BrowseForSourceAsync() || !_vm.SourceExists)
                     return; // user cancelled / no usable file
             }
-            if (!_vm.IsDevkitProAvailable)
+            // The assembler is auto-selected from the source content (devkitARM, or
+            // GoldRoad for a @thumb .ASM) — surface the not-found message for whichever
+            // one this specific source requires (mirrors WF MainFormUtil.Compile).
+            if (!_vm.IsRequiredToolAvailable)
             {
-                _vm.StatusMessage = _vm.NotFoundMessage;
+                _vm.StatusMessage = _vm.RequiredToolNotFoundMessage;
                 return;
             }
 

--- a/FEBuilderGBA.Core.Tests/AsmCompileCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/AsmCompileCoreTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace FEBuilderGBA.Core.Tests
@@ -936,6 +937,89 @@ namespace FEBuilderGBA.Core.Tests
             Assert.False(string.IsNullOrEmpty(msg));
             Assert.Contains("goldroad", msg);
             Assert.DoesNotContain("devkitpro_eabi", msg);
+        }
+
+        // Fix #1 (Copilot, #1255): a STALE <toolDir>/<name>.gba from a previous run must
+        // NOT be mistaken for a fresh success when GoldRoad FAILS. We point goldroad_asm
+        // at a no-op stub that exits 0 without producing any .gba, pre-seed a stale
+        // <toolDir>/<name>.gba, and assert the compile FAILS (the pre-delete cleared the
+        // stale file) with ZERO mutation — rather than inserting the stale garbage.
+        [Fact]
+        public void CompileAndInsert_GoldRoadStaleGba_NotMistakenForSuccess_NoMutation()
+        {
+            var rom = CreateTestRom();
+            byte[] before = (byte[])rom.Data.Clone();
+
+            string toolDir = Path.Combine(Path.GetTempPath(), "fbg-gr-stale-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(toolDir);
+            string goldroadStub = WriteNoOpStub(toolDir, "goldroad");
+
+            string srcDir = Path.Combine(Path.GetTempPath(), "fbg-gr-src-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(srcDir);
+            string nameNoExt = "patch";
+            string src = Path.Combine(srcDir, nameNoExt + ".asm");
+            File.WriteAllText(src, "@thumb\r\nmov r0, r0\r\n");
+
+            // Pre-seed a STALE product the stub will NOT regenerate.
+            string staleGba = Path.Combine(toolDir, nameNoExt + ".gba");
+            File.WriteAllBytes(staleGba, new byte[] { 0xDE, 0xAD, 0xBE, 0xEF });
+
+            var savedConfig = CoreState.Config;
+            CoreState.Config = new Config { ["goldroad_asm"] = goldroadStub };
+            try
+            {
+                var undo = NewUndo(rom);
+                var result = AsmCompileCore.CompileAndInsert(
+                    rom, src, AsmCompileCore.CompileMethod.DumpBinary,
+                    AsmCompileCore.InsertMethod.WriteAtAddress, 0x100, U.NOT_FOUND, 3,
+                    SymbolUtil.DebugSymbol.None, checkMissingLabel: false, undo);
+
+                // The stub produced no fresh .gba and the stale one was pre-deleted, so the
+                // run must FAIL (not silently insert the 0xDEADBEEF stale bytes).
+                Assert.False(result.Success);
+                Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+                Assert.Equal(before, rom.Data);
+                Assert.Empty(undo.list);
+                // The stale .gba must have been cleared before the (failed) invocation.
+                Assert.False(File.Exists(staleGba));
+            }
+            finally
+            {
+                CoreState.Config = savedConfig;
+                try { Directory.Delete(toolDir, true); } catch { }
+                try { Directory.Delete(srcDir, true); } catch { }
+            }
+        }
+
+        /// <summary>
+        /// Write a no-op executable stub (exits 0, produces nothing) named
+        /// <paramref name="baseName"/> in <paramref name="dir"/>, platform-appropriate
+        /// (a .cmd on Windows, a chmod +x shell script elsewhere). Returns the path.
+        /// </summary>
+        static string WriteNoOpStub(string dir, string baseName)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                string cmd = Path.Combine(dir, baseName + ".cmd");
+                File.WriteAllText(cmd, "@echo off\r\nexit /b 0\r\n");
+                return cmd;
+            }
+            else
+            {
+                string sh = Path.Combine(dir, baseName);
+                File.WriteAllText(sh, "#!/bin/sh\nexit 0\n");
+                // chmod +x so it is executable.
+                try
+                {
+#if NET7_0_OR_GREATER
+                    File.SetUnixFileMode(sh, UnixFileMode.UserRead | UnixFileMode.UserWrite
+                        | UnixFileMode.UserExecute | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                        | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+#endif
+                }
+                catch { /* best-effort; the test still proves the pre-delete via the assert */ }
+                return sh;
+            }
         }
     }
 }

--- a/FEBuilderGBA.Core.Tests/AsmCompileCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/AsmCompileCoreTests.cs
@@ -679,5 +679,263 @@ namespace FEBuilderGBA.Core.Tests
                 CoreState.BaseDirectory = savedBaseDir;
             }
         }
+
+        // ---- GoldRoad (legacy @thumb assembler, #1244) ------------------------
+        //
+        // GoldRoad is a legacy Windows-era assembler that is NOT in CI (like devkitARM),
+        // so there is intentionally NO real-compile here. The deterministic paths ARE
+        // covered: the pure @thumb/.thumb auto-switch predicate, tool resolution
+        // (config path / directory / missing), goldroad-not-found → localized error +
+        // ZERO mutation, the pure argument builder, and that a @thumb source with no
+        // goldroad_asm fails cleanly without ever touching the ROM.
+
+        // ShouldUseGoldRoadFromText: the WF MainFormUtil.Compile auto-switch, pure.
+        [Theory]
+        [InlineData("@thumb\r\nmov r0, r0\r\n", true)]                  // bare @thumb → GoldRoad
+        [InlineData("@THUMB\r\n", true)]                               // case-insensitive
+        [InlineData(".thumb\r\nnop\r\n", false)]                       // .thumb → devkit (gnu as)
+        [InlineData(".thumb\r\n@thumb\r\n", false)]                    // .thumb WINS over @thumb
+        [InlineData("@thumb and .thumb on one line", false)]          // .thumb present anywhere → devkit
+        [InlineData("nop\r\nmov r0, r0\r\n", false)]                   // neither marker → devkit
+        [InlineData("", false)]                                        // empty → devkit
+        public void ShouldUseGoldRoadFromText_MatchesWfAutoSwitch(string text, bool expected)
+        {
+            Assert.Equal(expected, AsmCompileCore.ShouldUseGoldRoadFromText(text));
+        }
+
+        [Fact]
+        public void ShouldUseGoldRoadFromText_Null_ReturnsFalse()
+        {
+            Assert.False(AsmCompileCore.ShouldUseGoldRoadFromText(null));
+        }
+
+        // ShouldUseGoldRoad: ext gate (.ASM only) + the text predicate, with a real file.
+        [Theory]
+        [InlineData(".asm", "@thumb\r\nnop\r\n", true)]   // .ASM + @thumb → GoldRoad
+        [InlineData(".asm", ".thumb\r\nnop\r\n", false)]  // .ASM + .thumb → devkit
+        [InlineData(".s", "@thumb\r\nnop\r\n", false)]    // .S is ALWAYS devkit (WF gates on .ASM)
+        [InlineData(".c", "@thumb\r\n", false)]           // .C is ALWAYS devkit
+        public void ShouldUseGoldRoad_ExtGate_AndContent(string ext, string content, bool expected)
+        {
+            string src = Path.Combine(Path.GetTempPath(), "fbg-gr-" + Path.GetRandomFileName() + ext);
+            File.WriteAllText(src, content);
+            try
+            {
+                Assert.Equal(expected, AsmCompileCore.ShouldUseGoldRoad(src));
+            }
+            finally
+            {
+                try { File.Delete(src); } catch { }
+            }
+        }
+
+        [Fact]
+        public void ShouldUseGoldRoad_MissingOrEmptyPath_ReturnsFalse()
+        {
+            Assert.False(AsmCompileCore.ShouldUseGoldRoad(null));
+            Assert.False(AsmCompileCore.ShouldUseGoldRoad(""));
+            Assert.False(AsmCompileCore.ShouldUseGoldRoad(
+                Path.Combine(Path.GetTempPath(), "no-such-" + Guid.NewGuid() + ".asm")));
+        }
+
+        // BuildGoldRoadArgs: pure — <source> <output.gba> (bare names, escaped).
+        [Fact]
+        public void BuildGoldRoadArgs_BasicShape()
+        {
+            string args = AsmCompileCore.BuildGoldRoadArgs("foo.asm", "foo.gba");
+            Assert.Contains("foo.asm", args);
+            Assert.Contains("foo.gba", args);
+            // The source comes first, the .gba output second (WF order).
+            Assert.True(args.IndexOf("foo.asm", StringComparison.Ordinal)
+                < args.IndexOf("foo.gba", StringComparison.Ordinal));
+        }
+
+        // ResolveGoldRoad: config path / directory / missing.
+        [Fact]
+        public void ResolveGoldRoad_NotConfigured_ReturnsNull()
+        {
+            var savedConfig = CoreState.Config;
+            CoreState.Config = null;
+            try
+            {
+                Assert.Null(ToolPathResolver.ResolveGoldRoad());
+                Assert.Null(AsmCompileCore.ResolveGoldRoad());
+                Assert.False(AsmCompileCore.IsGoldRoadAvailable());
+            }
+            finally
+            {
+                CoreState.Config = savedConfig;
+            }
+        }
+
+        [Fact]
+        public void ResolveGoldRoad_DirectExePath_ResolvesAndIsAvailable()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "fbg-goldroad-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            string exe = Path.Combine(dir, "goldroad.exe");
+            File.WriteAllText(exe, "stub");
+
+            var savedConfig = CoreState.Config;
+            CoreState.Config = new Config { ["goldroad_asm"] = exe };
+            try
+            {
+                Assert.Equal(exe, ToolPathResolver.ResolveGoldRoad());
+                Assert.True(AsmCompileCore.IsGoldRoadAvailable());
+            }
+            finally
+            {
+                CoreState.Config = savedConfig;
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void ResolveGoldRoad_ConfigPointsAtDirectory_FindsPlatformBinary()
+        {
+            // When the config points at a directory, the platform-aware goldroad/
+            // goldroad.exe inside it is found (so a non-Windows layout works too).
+            string dir = Path.Combine(Path.GetTempPath(), "fbg-goldroad-dir-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            bool isWindows = System.Runtime.InteropServices.RuntimeInformation
+                .IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows);
+            string exeName = isWindows ? "goldroad.exe" : "goldroad";
+            string exe = Path.Combine(dir, exeName);
+            File.WriteAllText(exe, "stub");
+
+            var savedConfig = CoreState.Config;
+            CoreState.Config = new Config { ["goldroad_asm"] = dir };
+            try
+            {
+                Assert.Equal(exe, ToolPathResolver.ResolveGoldRoad());
+            }
+            finally
+            {
+                CoreState.Config = savedConfig;
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void ResolveGoldRoad_ConfiguredButMissing_ReturnsNull()
+        {
+            var savedConfig = CoreState.Config;
+            CoreState.Config = new Config
+            {
+                ["goldroad_asm"] = Path.Combine(Path.GetTempPath(), "no-goldroad-" + Guid.NewGuid() + ".exe")
+            };
+            try
+            {
+                Assert.Null(ToolPathResolver.ResolveGoldRoad());
+                Assert.False(AsmCompileCore.IsGoldRoadAvailable());
+            }
+            finally
+            {
+                CoreState.Config = savedConfig;
+            }
+        }
+
+        // GoldRoad not-found: a @thumb .ASM with no goldroad_asm → localized error,
+        // ZERO mutation. Note the source routes to GoldRoad (not devkit) PURELY from its
+        // content, so even with devkitARM unset the error names goldroad, not devkit.
+        [Fact]
+        public void Compile_GoldRoadSource_NotConfigured_ReturnsGoldRoadError()
+        {
+            var savedConfig = CoreState.Config;
+            CoreState.Config = new Config(); // no goldroad_asm, no devkitpro_eabi
+            string src = Path.Combine(Path.GetTempPath(), "gr-" + Path.GetRandomFileName() + ".asm");
+            File.WriteAllText(src, "@thumb\r\nmov r0, r0\r\n");
+            try
+            {
+                var result = AsmCompileCore.Compile(
+                    src, AsmCompileCore.CompileMethod.DumpBinary, checkMissingLabel: false);
+
+                Assert.False(result.Success);
+                Assert.Equal(AsmCompileCore.GetGoldRoadNotFoundMessage(), result.ErrorMessage);
+                // The error names goldroad (the auto-selected tool), NOT devkitpro_eabi.
+                Assert.Contains("goldroad", result.ErrorMessage);
+                Assert.DoesNotContain("devkitpro_eabi", result.ErrorMessage);
+            }
+            finally
+            {
+                CoreState.Config = savedConfig;
+                try { File.Delete(src); } catch { }
+            }
+        }
+
+        [Fact]
+        public void CompileAndInsert_GoldRoadSource_NotConfigured_NoMutation()
+        {
+            var rom = CreateTestRom();
+            byte[] before = (byte[])rom.Data.Clone();
+
+            var savedConfig = CoreState.Config;
+            CoreState.Config = new Config(); // no goldroad_asm
+            string src = Path.Combine(Path.GetTempPath(), "gr-" + Path.GetRandomFileName() + ".asm");
+            File.WriteAllText(src, "@thumb\r\nmov r0, r0\r\n");
+            try
+            {
+                var undo = NewUndo(rom);
+                var result = AsmCompileCore.CompileAndInsert(
+                    rom, src, AsmCompileCore.CompileMethod.DumpBinary,
+                    AsmCompileCore.InsertMethod.WriteAtAddress, 0x100, U.NOT_FOUND, 3,
+                    SymbolUtil.DebugSymbol.None, checkMissingLabel: false, undo);
+
+                Assert.False(result.Success);
+                Assert.Equal(AsmCompileCore.GetGoldRoadNotFoundMessage(), result.ErrorMessage);
+                Assert.Equal(before, rom.Data);
+                Assert.Empty(undo.list);
+            }
+            finally
+            {
+                CoreState.Config = savedConfig;
+                try { File.Delete(src); } catch { }
+            }
+        }
+
+        [Fact]
+        public void CompileAndInsert_GoldRoadSource_ConvertLynMethod_NotRejectedByLynGuard_FailsAtToolResolution()
+        {
+            // A GoldRoad source ALWAYS produces a raw .bin (WF ignores compileType for
+            // it), so pairing it with the ConvertLyn method must NOT trip the
+            // "lyn.event can't be written to the ROM" guard — it should instead fall
+            // through to the GoldRoad compile and fail cleanly at tool resolution
+            // (goldroad not configured), with NO mutation.
+            var rom = CreateTestRom();
+            byte[] before = (byte[])rom.Data.Clone();
+
+            var savedConfig = CoreState.Config;
+            CoreState.Config = new Config(); // no goldroad_asm
+            string src = Path.Combine(Path.GetTempPath(), "gr-" + Path.GetRandomFileName() + ".asm");
+            File.WriteAllText(src, "@thumb\r\nmov r0, r0\r\n");
+            try
+            {
+                var undo = NewUndo(rom);
+                var result = AsmCompileCore.CompileAndInsert(
+                    rom, src, AsmCompileCore.CompileMethod.ConvertLyn,
+                    AsmCompileCore.InsertMethod.WriteAtAddress, 0x100, U.NOT_FOUND, 3,
+                    SymbolUtil.DebugSymbol.None, checkMissingLabel: false, undo);
+
+                Assert.False(result.Success);
+                // The error is the GoldRoad not-found message, NOT the lyn-can't-write guard.
+                Assert.Equal(AsmCompileCore.GetGoldRoadNotFoundMessage(), result.ErrorMessage);
+                Assert.Equal(before, rom.Data);
+                Assert.Empty(undo.list);
+            }
+            finally
+            {
+                CoreState.Config = savedConfig;
+                try { File.Delete(src); } catch { }
+            }
+        }
+
+        [Fact]
+        public void GetGoldRoadNotFoundMessage_NamesGoldroad_NotDevkit()
+        {
+            string msg = AsmCompileCore.GetGoldRoadNotFoundMessage();
+            Assert.False(string.IsNullOrEmpty(msg));
+            Assert.Contains("goldroad", msg);
+            Assert.DoesNotContain("devkitpro_eabi", msg);
+        }
     }
 }

--- a/FEBuilderGBA.Core/AsmCompileCore.cs
+++ b/FEBuilderGBA.Core/AsmCompileCore.cs
@@ -574,6 +574,16 @@ namespace FEBuilderGBA
             // crashes.)
             string outGbaName = nameNoExt + ".gba";
             string args = BuildGoldRoadArgs(srcFull, outGbaName);
+            string producedGba = Path.Combine(toolDir, outGbaName);
+            string binPath = Path.Combine(srcDir, nameNoExt + ".bin");
+
+            // Delete any STALE product from a previous run BEFORE invoking GoldRoad: the
+            // success check below keys off the presence/size of <toolDir>/<name>.gba, so
+            // a leftover .gba would make a FAILED GoldRoad run look successful and feed
+            // garbage into the ROM. Clearing it (and the .bin target) means only a
+            // freshly-produced file can count as success.
+            TryDelete(producedGba);
+            TryDelete(binPath);
 
             onProgress?.Invoke(goldroad);
 
@@ -588,7 +598,6 @@ namespace FEBuilderGBA
                 return result;
             }
 
-            string producedGba = Path.Combine(toolDir, outGbaName);
             if (!File.Exists(producedGba) || U.GetFileSize(producedGba) <= 0)
             {
                 // Prefix the executed command so the user can repro (matches WF).
@@ -597,19 +606,16 @@ namespace FEBuilderGBA
                 return result;
             }
 
-            // Move the .gba product next to the source as <name>.bin (WF renames the
-            // scary .gba to .bin). Overwrite any stale product first.
-            string binPath = Path.Combine(srcDir, nameNoExt + ".bin");
-            try
-            {
-                TryDelete(binPath);
-                File.Move(producedGba, binPath);
-            }
-            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            // Move the freshly-produced .gba next to the source as <name>.bin (WF renames
+            // the scary .gba to .bin). File.Move throws across volumes (the toolchain on
+            // D: and the project on C: is common), so fall back to copy+delete in that
+            // case — keeping the never-throws contract (a failure → clean localized error,
+            // ZERO ROM mutation).
+            if (!TryMoveCrossVolume(producedGba, binPath, out string moveError))
             {
                 result.Output = output;
                 result.ErrorMessage = R._("Unable to write the temporary files needed for compilation.")
-                    + "\r\n" + ex.ToString();
+                    + "\r\n" + moveError;
                 return result;
             }
 
@@ -863,6 +869,46 @@ namespace FEBuilderGBA
         {
             try { if (!string.IsNullOrEmpty(path) && File.Exists(path)) File.Delete(path); }
             catch { /* best-effort cleanup */ }
+        }
+
+        /// <summary>
+        /// Move <paramref name="src"/> to <paramref name="dest"/>, overwriting any
+        /// existing destination, in a cross-volume-safe way. <see cref="File.Move(string,string)"/>
+        /// throws an <see cref="IOException"/> when source and destination are on
+        /// DIFFERENT volumes (e.g. the toolchain on D: and the project on C:), so we fall
+        /// back to a copy + delete in that case. Returns false (never throws) with the
+        /// failure detail in <paramref name="error"/> so the caller can surface a clean,
+        /// localized error with ZERO ROM mutation.
+        /// </summary>
+        static bool TryMoveCrossVolume(string src, string dest, out string error)
+        {
+            error = "";
+            try
+            {
+                TryDelete(dest); // File.Move won't overwrite — clear the target first
+                File.Move(src, dest);
+                return true;
+            }
+            catch (IOException)
+            {
+                // Most commonly a cross-volume move — retry as copy + delete.
+                try
+                {
+                    File.Copy(src, dest, overwrite: true);
+                    TryDelete(src);
+                    return true;
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                    error = ex.ToString();
+                    return false;
+                }
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                error = ex.ToString();
+                return false;
+            }
         }
 
         /// <summary>

--- a/FEBuilderGBA.Core/AsmCompileCore.cs
+++ b/FEBuilderGBA.Core/AsmCompileCore.cs
@@ -10,14 +10,19 @@ namespace FEBuilderGBA
     /// GUI-free compile+insert flow for the "Add-via-ASM/C" tool, shared by the
     /// Avalonia <c>ToolASMInsertView</c>. Ported from the WinForms path
     /// (<c>ToolASMInsertForm.RunButton_Click</c> → <c>MainFormUtil.Compile</c> /
-    /// <c>CompilerDevkitPro</c> / <c>ConvertLYN</c>), keeping the exact devkitARM
-    /// gcc/g++/as arguments, the ELF → text-section dump, the lyn ELF→EA-event
-    /// conversion, and the three insert methods (free-area data, write-at-address,
-    /// hook-inject).
+    /// <c>CompilerDevkitPro</c> / <c>CompilerGoldRoad</c> / <c>ConvertLYN</c>), keeping
+    /// the exact devkitARM gcc/g++/as arguments, the GoldRoad assemble-then-rename
+    /// flow, the ELF → text-section dump, the lyn ELF→EA-event conversion, and the
+    /// three insert methods (free-area data, write-at-address, hook-inject).
     ///
     /// Compile chain:
     ///   C/C++/ASM source
-    ///     → devkitARM gcc/g++/as (<c>CoreState.Config.at("devkitpro_eabi")</c>) → ELF
+    ///     → assembler auto-selected from the source (WF <c>MainFormUtil.Compile</c>):
+    ///       a <c>.ASM</c> whose text contains <c>@thumb</c> (and NOT <c>.thumb</c>)
+    ///       goes to the legacy GoldRoad assembler
+    ///       (<c>CoreState.Config.at("goldroad_asm")</c>) → raw <c>.bin</c>; everything
+    ///       else goes to devkitARM gcc/g++/as
+    ///       (<c>CoreState.Config.at("devkitpro_eabi")</c>) → ELF
     ///     → (a) raw text-section dump (.dmp) via <see cref="Elf.ProgramBIN"/>, OR
     ///       (b) <c>CONVERT_LYN</c>: as → .o → lyn.exe → .lyn.event (an EA event
     ///          script the caller assembles via <see cref="EventAssemblerCompileCore"/>).
@@ -25,11 +30,10 @@ namespace FEBuilderGBA
     ///
     /// Scope boundary (intentional — matches how <see cref="EventAssemblerCompileCore"/>
     /// deferred MakeEAAutoDef):
-    ///   PROVIDED: .c/.cpp/.s/.asm → ELF → .dmp / .lyn.event, the three insert
-    ///     methods, missing-label check, debug-symbol store, undo.
+    ///   PROVIDED: .c/.cpp/.s/.asm → ELF → .dmp / .lyn.event, the GoldRoad
+    ///     <c>@thumb</c> path, the three insert methods, missing-label check,
+    ///     debug-symbol store, undo.
     ///   INTENTIONALLY DEFERRED to a follow-up (WinForms-coupled):
-    ///     - the GoldRoad assembler path (<c>@thumb</c> ASM → CompilerGoldRoad) — a
-    ///       separate legacy assembler; the devkitARM path covers .asm/.s/.c/.cpp.
     ///     - the "Make Patch" text generator (GraphicsToolPatchMakerForm) — pure WF
     ///       patch-text UI, unrelated to the core compile/insert.
     /// </summary>
@@ -175,6 +179,59 @@ namespace FEBuilderGBA
             return ToolPathResolver.ResolveLynExe(ea);
         }
 
+        // ---- GoldRoad (legacy @thumb assembler) -------------------------------
+
+        /// <summary>Resolve the legacy GoldRoad assembler from <c>goldroad_asm</c>, or
+        /// null. Delegates to <see cref="ToolPathResolver.ResolveGoldRoad"/>.</summary>
+        public static string ResolveGoldRoad() => ToolPathResolver.ResolveGoldRoad();
+
+        /// <summary>
+        /// True when the GoldRoad assembler path is configured and exists. Callers
+        /// should surface <see cref="GetGoldRoadNotFoundMessage"/> when this is false
+        /// and the source is a GoldRoad (<c>@thumb</c>) source.
+        /// </summary>
+        public static bool IsGoldRoadAvailable() => !string.IsNullOrEmpty(ResolveGoldRoad());
+
+        /// <summary>Localized "goldroad not configured" message (no throw). Reuses the
+        /// same parameterized key as the devkit message, with the tool name "goldroad"
+        /// (mirrors WF <c>CompilerGoldRoad</c>).</summary>
+        public static string GetGoldRoadNotFoundMessage() =>
+            R._("{0}の設定がありません。 設定->オプションから、{0}を設定してください。", "goldroad");
+
+        /// <summary>
+        /// Decide whether a source must be assembled with GoldRoad instead of devkitARM
+        /// — the pure source-content auto-switch from WF <c>MainFormUtil.Compile</c>: a
+        /// <c>.ASM</c> source whose (case-insensitive) text contains <c>@thumb</c> and
+        /// does NOT contain <c>.thumb</c> routes to GoldRoad; everything else
+        /// (.thumb ASM, .s/.c/.cpp, or any non-.ASM ext) routes to devkitARM. Pure: it
+        /// only inspects the extension and the file text, mutating nothing.
+        /// </summary>
+        public static bool ShouldUseGoldRoad(string sourcePath)
+        {
+            if (string.IsNullOrEmpty(sourcePath)) return false;
+            // WF keys the auto-switch on the .ASM extension only (a .S is always devkit).
+            if (U.GetFilenameExt(sourcePath) != ".ASM") return false;
+
+            string text;
+            try { text = File.ReadAllText(sourcePath); }
+            catch { return false; } // unreadable → let the devkit path report the error
+            return ShouldUseGoldRoadFromText(text);
+        }
+
+        /// <summary>
+        /// The pure text predicate behind <see cref="ShouldUseGoldRoad"/> (exposed for
+        /// unit-testing without a file): mirrors WF <c>MainFormUtil.Compile</c> — a
+        /// <c>.thumb</c> marker forces devkitARM (gnu-as) even when <c>@thumb</c> is
+        /// also present; only a bare <c>@thumb</c> (no <c>.thumb</c>) selects GoldRoad.
+        /// </summary>
+        public static bool ShouldUseGoldRoadFromText(string sourceText)
+        {
+            if (string.IsNullOrEmpty(sourceText)) return false;
+            string lower = sourceText.ToLowerInvariant();
+            if (lower.IndexOf(".thumb", StringComparison.Ordinal) >= 0) return false;
+            return lower.IndexOf("@thumb", StringComparison.Ordinal) >= 0;
+        }
+
         // ---- Argument building (pure — unit-tested without running anything) ---
 
         /// <summary>
@@ -237,6 +294,15 @@ namespace FEBuilderGBA
                 result.ErrorMessage = R._("ファイルがありません。\r\nファイル名:{0}", sourcePath ?? "");
                 return result;
             }
+
+            // Source-content auto-switch (WF MainFormUtil.Compile): a .ASM with @thumb
+            // (and no .thumb) is assembled by the legacy GoldRoad assembler, not the
+            // devkitARM chain. GoldRoad always produces a raw .bin (there is no ELF, so
+            // the ConvertLyn/KeepElf methods do not apply — it always behaves like
+            // DumpBinary, matching WF which ignores compileType for the GoldRoad path).
+            if (ShouldUseGoldRoad(sourcePath))
+                return CompileGoldRoad(sourcePath, onProgress);
+
             if (!IsDevkitProAvailable())
             {
                 result.ErrorMessage = GetNotFoundMessage();
@@ -436,6 +502,124 @@ namespace FEBuilderGBA
             return list[0];
         }
 
+        // ---- GoldRoad assemble (@thumb legacy path) ---------------------------
+
+        /// <summary>
+        /// Build the GoldRoad command-line arguments (WF <c>CompilerGoldRoad</c>):
+        /// <c>&lt;source&gt; &lt;output.gba&gt;</c>. The OUTPUT is passed as a BARE filename
+        /// (no directory) because GoldRoad is buggy and crashes on a complex output
+        /// path — WF works around this by running with the working directory set to the
+        /// GoldRoad tool dir so the bare-named product lands there. The source may be a
+        /// full path (GoldRoad tolerates that for the input). Pure: takes its inputs
+        /// explicitly so it is unit-testable without running anything.
+        /// </summary>
+        public static string BuildGoldRoadArgs(string sourceFileName, string outputGbaFileName)
+        {
+            return U.escape_shell_args(sourceFileName)
+                + " " + U.escape_shell_args(outputGbaFileName);
+        }
+
+        /// <summary>
+        /// Assemble a <c>@thumb</c> <c>.ASM</c> source with the legacy GoldRoad
+        /// assembler (WF <c>MainFormUtil.CompilerGoldRoad</c>). GoldRoad has no ELF
+        /// stage: it emits a raw <c>.gba</c> binary, which we rename to
+        /// <c>&lt;source&gt;.bin</c> (the WF product) and feed into the SAME insert
+        /// methods as the devkit path. Never throws — a missing tool / process / file
+        /// failure returns a structured, localized error with ZERO ROM mutation.
+        ///
+        /// Faithful WF quirks: GoldRoad is invoked with bare filenames and its working
+        /// directory set to the tool dir (it crashes on complex output paths), so the
+        /// product first lands as <c>&lt;tooldir&gt;/&lt;name&gt;.gba</c> and is then moved
+        /// next to the source as <c>&lt;name&gt;.bin</c> (a <c>.gba</c> extension is
+        /// avoided as "scary"). There are no EA symbols (no ELF), so
+        /// <see cref="CompileResult.SymbolText"/> stays empty.
+        /// </summary>
+        static CompileResult CompileGoldRoad(string sourcePath, Action<string> onProgress)
+        {
+            var result = new CompileResult();
+
+            string goldroad = ResolveGoldRoad();
+            if (string.IsNullOrEmpty(goldroad))
+            {
+                result.ErrorMessage = GetGoldRoadNotFoundMessage();
+                return result;
+            }
+
+            string srcFull;
+            string toolDir;
+            try
+            {
+                srcFull = Path.GetFullPath(sourcePath);
+                toolDir = Path.GetDirectoryName(Path.GetFullPath(goldroad));
+            }
+            catch (Exception ex) when (ex is ArgumentException || ex is PathTooLongException
+                || ex is NotSupportedException || ex is System.Security.SecurityException)
+            {
+                result.ErrorMessage = R._("プロセスを実行できません。\r\nfilename:{0}\r\n{1}", goldroad, ex.ToString());
+                return result;
+            }
+            if (string.IsNullOrEmpty(toolDir) || !Directory.Exists(toolDir))
+            {
+                result.ErrorMessage = GetGoldRoadNotFoundMessage();
+                return result;
+            }
+
+            string srcDir = Path.GetDirectoryName(srcFull);
+            string nameNoExt = Path.GetFileNameWithoutExtension(srcFull);
+
+            // GoldRoad bug workaround: pass the OUTPUT as a bare ".gba" filename with the
+            // working directory set to the tool dir, so GoldRoad writes the product into
+            // its own directory. (WF passes the full source path as the first arg;
+            // GoldRoad tolerates that, but the OUTPUT must be a bare filename or it
+            // crashes.)
+            string outGbaName = nameNoExt + ".gba";
+            string args = BuildGoldRoadArgs(srcFull, outGbaName);
+
+            onProgress?.Invoke(goldroad);
+
+            string output;
+            try
+            {
+                output = RunProcess(goldroad, args, toolDir);
+            }
+            catch (Exception ex)
+            {
+                result.ErrorMessage = R._("プロセスを実行できません。\r\nfilename:{0}\r\n{1}", goldroad, ex.ToString());
+                return result;
+            }
+
+            string producedGba = Path.Combine(toolDir, outGbaName);
+            if (!File.Exists(producedGba) || U.GetFileSize(producedGba) <= 0)
+            {
+                // Prefix the executed command so the user can repro (matches WF).
+                result.Output = output;
+                result.ErrorMessage = goldroad + " " + args + " \r\noutput:\r\n" + output;
+                return result;
+            }
+
+            // Move the .gba product next to the source as <name>.bin (WF renames the
+            // scary .gba to .bin). Overwrite any stale product first.
+            string binPath = Path.Combine(srcDir, nameNoExt + ".bin");
+            try
+            {
+                TryDelete(binPath);
+                File.Move(producedGba, binPath);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                result.Output = output;
+                result.ErrorMessage = R._("Unable to write the temporary files needed for compilation.")
+                    + "\r\n" + ex.ToString();
+                return result;
+            }
+
+            result.Output = output;
+            result.ProductPath = binPath;
+            result.SymbolText = ""; // no ELF → no EA symbols
+            result.Success = true;
+            return result;
+        }
+
         // ---- Compile + insert (the full Run flow) -----------------------------
 
         /// <summary>
@@ -461,8 +645,16 @@ namespace FEBuilderGBA
             if (rom == null)
                 return new CompileResult { ErrorMessage = R._("No ROM is loaded.") };
 
+            // A GoldRoad (@thumb .ASM) source ALWAYS produces a raw writable .bin — there
+            // is no ELF/lyn stage, so the selected CompileMethod (DumpBinary/KeepElf/
+            // ConvertLyn) does not apply to it (WF MainFormUtil.Compile routes to
+            // CompilerGoldRoad ignoring compileType). Detect it up front so the lyn-guard
+            // below does NOT reject a GoldRoad source paired with the ConvertLyn method.
+            bool isGoldRoad = ShouldUseGoldRoad(sourcePath);
+
             // A lyn.event is a script, not bytes — it cannot be written to the ROM here.
-            if (method == CompileMethod.ConvertLyn && insert != InsertMethod.CompileOnly)
+            // (GoldRoad never makes a lyn.event, so the guard skips it.)
+            if (!isGoldRoad && method == CompileMethod.ConvertLyn && insert != InsertMethod.CompileOnly)
                 return new CompileResult
                 {
                     ErrorMessage = R._("lyn.eventを作成する時は、ROMに書き込むことはできません。")
@@ -472,8 +664,10 @@ namespace FEBuilderGBA
             if (!result.Success)
                 return result;
 
-            // Store debug symbols for the compile-only / lyn product (addr 0).
-            if (insert == InsertMethod.CompileOnly || method == CompileMethod.ConvertLyn)
+            // Store debug symbols for the compile-only / lyn product (addr 0). A GoldRoad
+            // source produces a raw .bin even under the ConvertLyn method, so it is NOT
+            // treated as a non-writable lyn product here.
+            if (insert == InsertMethod.CompileOnly || (!isGoldRoad && method == CompileMethod.ConvertLyn))
             {
                 SymbolUtil.ProcessSymbolByComment(Path.GetFullPath(sourcePath), result.SymbolText, storeSymbol, 0);
                 return result;

--- a/FEBuilderGBA.Core/ToolPathResolver.cs
+++ b/FEBuilderGBA.Core/ToolPathResolver.cs
@@ -231,6 +231,45 @@ namespace FEBuilderGBA
         public static string ResolveDevkitArmAs() => ResolveDevkitArmTool("as");
 
         /// <summary>
+        /// Resolve the legacy GoldRoad assembler (<c>goldroad.exe</c>) from the
+        /// <c>goldroad_asm</c> config path. GoldRoad is the older MASM-like ARM
+        /// assembler used for <c>@thumb</c> sources (vs the modern devkitARM gnu-as
+        /// path). Symmetric with <see cref="ResolveDevkitArmDir"/> /
+        /// <see cref="ResolveEventAssembler"/> / <see cref="ResolveLynExe"/>.
+        ///
+        /// The config value normally points directly at the executable. To be
+        /// platform-aware (GoldRoad is Windows-era, but the resolver should not bake in
+        /// <c>.exe</c>), when the configured value is a directory we look for the
+        /// platform-appropriate <c>goldroad</c>/<c>goldroad.exe</c> inside it
+        /// (mirroring <see cref="GetExeNames"/>). Returns null when unset or missing.
+        /// </summary>
+        public static string ResolveGoldRoad()
+        {
+            string configured = CoreState.Config?.at("goldroad_asm", "");
+            if (string.IsNullOrEmpty(configured))
+                return null;
+
+            // Direct path to the executable (the normal case — OptionForm stores the
+            // full goldroad.exe path).
+            if (File.Exists(configured))
+                return configured;
+
+            // The config points at a directory → try the platform-aware binary names
+            // inside it, so a Linux/macOS layout (extension-less "goldroad") resolves
+            // too, not just "goldroad.exe".
+            if (Directory.Exists(configured))
+            {
+                foreach (string name in GetExeNames("goldroad"))
+                {
+                    string candidate = Path.Combine(configured, name);
+                    if (File.Exists(candidate)) return candidate;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Check if the resolved EA path points to ColorzCore (vs classic EA Core.exe).
         /// </summary>
         public static bool IsColorzCore(string eaPath)


### PR DESCRIPTION
Fixes #1244.

Follow-up to #1169 — adds the legacy **GoldRoad** assembler path to the Add-via-ASM/C tool (the path #1169's `AsmCompileCore` explicitly documented as deferred). GoldRoad is the older MASM-like ARM assembler; devkitARM (gnu-as) is the modern path already supported.

## What
- New GoldRoad compile path in `AsmCompileCore`, **auto-selected from the source content** (mirrors WinForms `MainFormUtil.Compile`): a `.ASM` source containing `@thumb` → GoldRoad; `.thumb`/`.c`/`.cpp`/`.s` → devkitARM. The GoldRoad binary feeds the SAME insert methods (free-area / write-at-address / hook-inject) + fault-safe snapshot-rollback + explicit-UndoData as the devkit path.
- `ToolPathResolver.ResolveGoldRoad()` (reads `CoreState.Config.at("goldroad_asm")`, platform-aware names, symmetric with `ResolveDevkitArmGcc`/`ResolveLynExe`).
- VM exposes `IsGoldRoadSource`/`IsGoldRoadAvailable` + a localized "goldroad not configured (Settings → Options)" status, so building a `@thumb` source without `goldroad_asm` set surfaces a clear message (mirrors the devkit not-found path) with zero ROM mutation.

## Pre-empt checklist (build-tool, from #1169/#1172/#1250)
NO real-compile test (goldroad.exe isn't CI-buildable); platform-aware resolution; `Process.Start` null-check + `Kill(entireProcessTree:true)`; guarded file I/O → localized error; platform-correct tool name in errors. The stale "GoldRoad deferred" comment in `AsmCompileCore`/the View is removed (it's now implemented).

## Tests / gates (all green — verified independently)
- `AsmCompileCoreTests` — GoldRoad not-found → localized error (zero mutation), the `@thumb` vs `.thumb` auto-switch detection (`ShouldUseGoldRoad`), arg/command building.
- Core.Tests `~AsmCompile|~GoldRoad|~AvaloniaScrollViewer` **69/0**; Avalonia.Tests `~L10nCoverage|~ASMInsert` **30/0** (HaveJaAndZhTranslations PASS); FEBuilderGBA.Tests `~Avalonia|~AutomationId|~CliProject` **867/0**. Core+Avalonia+CLI builds 0 err; `validate-automation-ids` 0/0.

## Scope note
The "Make Patch" text generator remains deferred → **#1243** (the View comment is updated to reflect GoldRoad is now done, only Make-Patch deferred).

## Proof (FE8U — Add via ASM/C tool)
GoldRoad is source-content auto-detected (a `@thumb` `.ASM` routes to GoldRoad; the form is unchanged in the empty state). Functional path is unit-tested (auto-switch + resolution + insert):

<img width="700" src="https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1244-goldroad-fe8u.png">

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 4.8 (1M context), model `claude-opus-4-8[1m]`