### PR TITLE
feat(core): add Haiku + BattleTalk flag scanners to Flags-Used tool (#1253)

### DIFF
--- a/FEBuilderGBA.Avalonia/ViewModels/ToolUseFlagViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ToolUseFlagViewModel.cs
@@ -9,17 +9,15 @@ namespace FEBuilderGBA.Avalonia.ViewModels
     /// every event-flag reference from the in-scope subsystems via the
     /// cross-platform <see cref="UseFlagScanCore"/> aggregator:
     ///   event-condition records (Turn/Talk/Object/Always), the event scripts
-    ///   those conditions reach (ArgType.FLAG), and map-change records.
+    ///   those conditions reach (ArgType.FLAG), map-change records, and — at full
+    ///   WinForms parity (#1253) — the per-version death-quote (Haiku) and
+    ///   battle-conversation (BattleTalk) records scoped to the chapter.
     ///
     /// This is a tool / aggregator that READS ROM bytes for the scan but NEVER
     /// writes — so it deliberately exposes no data-verify report contract (a
     /// no-write aggregator VM is orphan-safe by the FEBuilderGBA.Tests contract;
     /// implementing or even naming that verify interface would trip the
     /// NoOrphanVMs gate).
-    ///
-    /// DEFERRED (#1253): the Haiku x {FE6,FE7,FE8} + BattleTalk x {FE6,FE7,FE8}
-    /// scanners are not yet ported to Core; they are excluded here exactly as in
-    /// <see cref="UseFlagScanCore"/>.
     /// </summary>
     public class ToolUseFlagViewModel : ViewModelBase
     {

--- a/FEBuilderGBA.Core.Tests/UseFlagScanCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/UseFlagScanCoreTests.cs
@@ -468,6 +468,167 @@ namespace FEBuilderGBA.Core.Tests
             }
         }
 
+        // =================================================================
+        // #1256 — FE6 / FE7-specific synthetic-ROM coverage.
+        //
+        // The FE8-only fixture above never exercises the FE6/FE7 BattleTalk
+        // u16==0||0xFFFF terminator nor the FE7 tutorial-Haiku tables, which is
+        // how the wrong (0xFFFF-only) terminator slipped through. These build a
+        // minimal versioned ROM with ONLY the relevant table wired — the
+        // EventCond / EventScript / MapChange sub-scans bail safely on the
+        // un-wired ROM (proven by Scan_EmptyChapter_*), so the returned list
+        // isolates the haiku/battletalk rows.
+        // =================================================================
+
+        // Minimal versioned ROM (same sizing as EventCondCoreTests.MakeMinimalRom).
+        static ROM MakeVersionedRom(int version)
+        {
+            (string vs, int ms) = version switch
+            {
+                6 => ("AFEJ01", 0x800000),
+                7 => ("AE7E01", 0x1000000),
+                _ => ("BE8E01", 0x1000000),
+            };
+            var rom = new ROM();
+            rom.LoadLow("useflag-synth.gba", new byte[ms], vs);
+            return rom;
+        }
+
+        // Run body with CoreState.ROM set to a freshly built versioned ROM, then
+        // restore. EventScript/CommentCache stay null so AppendEventScriptFlags
+        // bails (it requires CoreState.EventScript) — the scan reduces to the
+        // table-driven HAIKU/BATTTLE_TALK rows under test.
+        static void WithVersionedRom(int version, System.Action<ROM> body)
+        {
+            var prevRom = CoreState.ROM;
+            var prevEs = CoreState.EventScript;
+            var prevComment = CoreState.CommentCache;
+            try
+            {
+                var rom = MakeVersionedRom(version);
+                Assert.Equal(version, rom.RomInfo.version); // guard: the right layout loaded
+                CoreState.ROM = rom;
+                CoreState.EventScript = null;
+                CoreState.CommentCache = null;
+                body(rom);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.EventScript = prevEs;
+                CoreState.CommentCache = prevComment;
+            }
+        }
+
+        // Helper: point a RomInfo pointer field at baseOffset (as a GBA 0x08-pointer).
+        static void WirePointer(ROM rom, uint pointerField, uint baseOffset)
+            => WriteU32(rom, pointerField, baseOffset | 0x08000000u);
+
+        [Theory]
+        [InlineData(7)] // EventBattleTalkFE7Form.Init main: bs16, flag@+12, ch@+2, unit u16@+0
+        [InlineData(6)] // EventBattleTalkFE6Form.Init main: bs12, flag@+8,  ch@+2, unit u16@+0
+        public void Scan_BattleTalk_StopsOnU16ZeroTerminator(int version)
+        {
+            // #1256: the FE6/FE7 BattleTalk table terminates on unit u16 == 0
+            // (NOT only 0xFFFF). A record placed AFTER a u16==0 terminator must
+            // NOT be collected — with the old 0xFFFF-only terminator the walk
+            // over-read past the zero and harvested its garbage flag.
+            uint blockSize = (uint)(version == 7 ? 16 : 12);
+            uint flagOffset = (uint)(version == 7 ? 12 : 8);
+            const uint BaseOffset = 0x00300000u;
+            const uint BeforeFlag = 0x0071; // live record's flag (must be collected)
+            const uint AfterFlag  = 0x0072; // post-terminator flag (must NOT be collected)
+
+            WithVersionedRom(version, rom =>
+            {
+                WirePointer(rom, rom.RomInfo.event_ballte_talk_pointer, BaseOffset);
+
+                // Record 0 (live): unit u16 != 0, chapter byte @ +2 = 0, flag set.
+                rom.write_u16(BaseOffset + 0, 0x0101);
+                rom.Data[BaseOffset + 2] = 0x00; // chapter = 0 (this chapter)
+                rom.write_u16(BaseOffset + flagOffset, (ushort)BeforeFlag);
+
+                // Record 1: unit u16 == 0 → TERMINATES the table.
+                rom.write_u16(BaseOffset + blockSize + 0, 0x0000);
+
+                // Record 2 (AFTER terminator): a fully-formed record whose flag must
+                // never be reached.
+                uint rec2 = BaseOffset + 2 * blockSize;
+                rom.write_u16(rec2 + 0, 0x0202);
+                rom.Data[rec2 + 2] = 0x00;
+                rom.write_u16(rec2 + flagOffset, (ushort)AfterFlag);
+
+                var list = UseFlagScanCore.Scan(rom, 0u);
+
+                Assert.Contains(list, u =>
+                    u.ID == BeforeFlag && u.DataType == FELintCore.Type.BATTTLE_TALK);
+                Assert.DoesNotContain(list, u => u.ID == AfterFlag);
+            });
+        }
+
+        [Fact]
+        public void Scan_FE6BattleTalk_SecondaryTable_StopsOnU16ZeroTerminator()
+        {
+            // FE6 EventBattleTalkFE6Form.N_Init secondary table: bs16, flag@+8,
+            // ch@+1, unit u16@+0 — also terminates on u16==0||0xFFFF (#1256).
+            const uint Base2 = 0x00320000u;
+            const uint BeforeFlag = 0x0081;
+            const uint AfterFlag  = 0x0082;
+
+            WithVersionedRom(6, rom =>
+            {
+                WirePointer(rom, rom.RomInfo.event_ballte_talk2_pointer, Base2);
+
+                // Record 0 (live): chapter @ +1 = 0, flag @ +8.
+                rom.write_u16(Base2 + 0, 0x0303);
+                rom.Data[Base2 + 1] = 0x00;
+                rom.write_u16(Base2 + 8, (ushort)BeforeFlag);
+                // Record 1: u16 == 0 terminates.
+                rom.write_u16(Base2 + 16, 0x0000);
+                // Record 2 (after terminator): must not be collected.
+                rom.write_u16(Base2 + 32, 0x0404);
+                rom.Data[Base2 + 32 + 1] = 0x00;
+                rom.write_u16(Base2 + 32 + 8, (ushort)AfterFlag);
+
+                var list = UseFlagScanCore.Scan(rom, 0u);
+                Assert.Contains(list, u =>
+                    u.ID == BeforeFlag && u.DataType == FELintCore.Type.BATTTLE_TALK);
+                Assert.DoesNotContain(list, u => u.ID == AfterFlag);
+            });
+        }
+
+        [Fact]
+        public void Scan_FE7TutorialHaiku_FlagIsCollectedAndStopsOnU8Zero()
+        {
+            // FE7 EventHaikuFE7Form.N1_Init tutorial table (event_haiku_tutorial_1):
+            // bs12, flag@+8, ch@+1, unit u8@+0 — terminates on u8==0. Proves the
+            // FE7-only tutorial-Haiku path (never reached by the FE8 fixture).
+            const uint TutBase = 0x00340000u;
+            const uint TutFlag   = 0x0091; // live tutorial-haiku flag
+            const uint AfterFlag = 0x0092; // post-terminator flag
+
+            WithVersionedRom(7, rom =>
+            {
+                WirePointer(rom, rom.RomInfo.event_haiku_tutorial_1_pointer, TutBase);
+
+                // Record 0 (live): unit u8 != 0, chapter @ +1 = 0, flag @ +8.
+                rom.Data[TutBase + 0] = 0x01;
+                rom.Data[TutBase + 1] = 0x00; // chapter = 0
+                rom.write_u16(TutBase + 8, (ushort)TutFlag);
+                // Record 1: unit u8 == 0 → terminates.
+                rom.Data[TutBase + 12] = 0x00;
+                // Record 2 (after terminator): must not be collected.
+                rom.Data[TutBase + 24 + 0] = 0x02;
+                rom.Data[TutBase + 24 + 1] = 0x00;
+                rom.write_u16(TutBase + 24 + 8, (ushort)AfterFlag);
+
+                var list = UseFlagScanCore.Scan(rom, 0u);
+                Assert.Contains(list, u =>
+                    u.ID == TutFlag && u.DataType == FELintCore.Type.HAIKU);
+                Assert.DoesNotContain(list, u => u.ID == AfterFlag);
+            });
+        }
+
         static string FindRom(string romName)
         {
             string thisAssembly = System.Reflection.Assembly.GetExecutingAssembly().Location;

--- a/FEBuilderGBA.Core.Tests/UseFlagScanCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/UseFlagScanCoreTests.cs
@@ -7,11 +7,12 @@
 //   (1) EVENT_COND_*  — the flag field (u16 @ +2) of a Turn condition record,
 //   (2) EVENTSCRIPT   — an ArgType.FLAG arg in the event script that the Turn
 //                       record's event pointer reaches, and
-//   (3) MAPCHANGE     — the flag field (u16 @ +5) of a map-change record.
+//   (3) MAPCHANGE     — the flag field (u16 @ +5) of a map-change record,
+//   (4) HAIKU         — the flag field (u16 @ +4) of a death-quote record, and
+//   (5) BATTTLE_TALK  — the flag field (u16 @ +6) of a battle-conversation record.
 // Plus guard tests: id 0 is dropped, a foreign/empty ROM yields an empty list,
-// and the result is sorted by flag id.
-//
-// DEFERRED (#1253): the Haiku/BattleTalk scanners are NOT part of this slice.
+// the result is sorted by flag id, the dedup invariant holds, and the
+// haiku/battletalk rows are scoped to the record's own chapter (#1253).
 
 using System.Collections.Generic;
 using System.Linq;
@@ -39,10 +40,18 @@ namespace FEBuilderGBA.Core.Tests
         // the SAME ScriptFlag, to prove cross-TREE dedup (one EVENTSCRIPT row).
         const uint TalkRecord      = 0x00770000u;
         const uint EventScriptAddr2= 0x00780000u;
+        // FE8 Haiku table (event_haiku_pointer → 12-byte records, flag@+4,
+        // chapter@+3) and BattleTalk table (event_ballte_talk_pointer → 16-byte
+        // records, flag@+6, chapter@+4).
+        const uint HaikuTable      = 0x00790000u;
+        const uint BattleTalkTable = 0x007A0000u;
 
-        const uint CondFlag   = 0x0011; // Turn record flag (u16 @ +2)
-        const uint ScriptFlag = 0x0022; // event-script FLAG arg
-        const uint ChangeFlag = 0x0033; // map-change record flag (u16 @ +5)
+        const uint CondFlag      = 0x0011; // Turn record flag (u16 @ +2)
+        const uint ScriptFlag    = 0x0022; // event-script FLAG arg
+        const uint ChangeFlag    = 0x0033; // map-change record flag (u16 @ +5)
+        const uint HaikuFlag     = 0x0044; // FE8 Haiku record flag (u16 @ +4)
+        const uint BattleTalkFlag= 0x0055; // FE8 BattleTalk record flag (u16 @ +6)
+        const uint HaikuOtherChapterFlag = 0x0066; // Haiku flag in a DIFFERENT chapter
 
         // A command "0100 XXXX" — opcode 0x0001 then a 2-byte FLAG arg at byte 2.
         static EventScript.Script FlagCommand()
@@ -140,6 +149,29 @@ namespace FEBuilderGBA.Core.Tests
                 rom.write_u16(ChangeData + 5, (ushort)ChangeFlag);
                 rom.Data[ChangeData + 12] = 0xFF;
 
+                // 7) FE8 Haiku table (event_haiku_pointer): 12-byte records,
+                //    flag@+4, chapter@+3. Record 0 belongs to chapter 0 (this
+                //    chapter); record 1 to chapter 5 (a DIFFERENT chapter, to prove
+                //    the chapter-scope filter excludes it); record 2 = 0xFFFF
+                //    sentinel terminates. First byte non-0xFFFF so the table starts.
+                WriteU32(rom, rom.RomInfo.event_haiku_pointer, HaikuTable | 0x08000000u);
+                rom.Data[HaikuTable + 0] = 0x01;                 // unit id (non-zero, not 0xFFFF)
+                rom.Data[HaikuTable + 3] = 0x00;                 // chapter = 0 (this chapter)
+                rom.write_u16(HaikuTable + 4, (ushort)HaikuFlag);
+                rom.Data[HaikuTable + 12 + 0] = 0x02;            // record 1 unit id
+                rom.Data[HaikuTable + 12 + 3] = 0x05;            // chapter = 5 (other chapter)
+                rom.write_u16(HaikuTable + 12 + 4, (ushort)HaikuOtherChapterFlag);
+                rom.write_u16(HaikuTable + 24 + 0, 0xFFFF);      // record 2 sentinel → terminates
+
+                // 8) FE8 BattleTalk table (event_ballte_talk_pointer): 16-byte
+                //    records, flag@+6, chapter@+4. Record 0 = chapter 0; record 1 =
+                //    0xFFFF sentinel terminates.
+                WriteU32(rom, rom.RomInfo.event_ballte_talk_pointer, BattleTalkTable | 0x08000000u);
+                rom.write_u16(BattleTalkTable + 0, 0x0101);      // unit ids (non-zero, not 0xFFFF)
+                rom.Data[BattleTalkTable + 4] = 0x00;            // chapter = 0 (this chapter)
+                rom.write_u16(BattleTalkTable + 6, (ushort)BattleTalkFlag);
+                rom.write_u16(BattleTalkTable + 16 + 0, 0xFFFF); // record 1 sentinel → terminates
+
                 CoreState.ROM = rom;
                 CoreState.EventScript = BuildEventScript(FlagCommand(), TermCommand());
                 CoreState.CommentCache = new HeadlessEtcCache();
@@ -220,6 +252,74 @@ namespace FEBuilderGBA.Core.Tests
                 var list = UseFlagScanCore.Scan(rom, 0u);
                 Assert.Contains(list, u =>
                     u.ID == ChangeFlag && u.DataType == FELintCore.Type.MAPCHANGE);
+            });
+        }
+
+        [Fact]
+        public void Scan_FindsHaikuFlag()
+        {
+            // #1253: the FE8 Haiku record for THIS chapter (chapter byte = 0)
+            // contributes a HAIKU-typed row for its flag.
+            WithChapter(rom =>
+            {
+                var list = UseFlagScanCore.Scan(rom, 0u);
+                Assert.Contains(list, u =>
+                    u.ID == HaikuFlag && u.DataType == FELintCore.Type.HAIKU);
+            });
+        }
+
+        [Fact]
+        public void Scan_FindsBattleTalkFlag()
+        {
+            // #1253: the FE8 BattleTalk record for THIS chapter (chapter byte = 0)
+            // contributes a BATTTLE_TALK-typed row for its flag.
+            WithChapter(rom =>
+            {
+                var list = UseFlagScanCore.Scan(rom, 0u);
+                Assert.Contains(list, u =>
+                    u.ID == BattleTalkFlag && u.DataType == FELintCore.Type.BATTTLE_TALK);
+            });
+        }
+
+        [Fact]
+        public void Scan_Haiku_OtherChapterFlag_IsExcluded()
+        {
+            // The Haiku table's record 1 belongs to chapter 5; scanning chapter 0
+            // must NOT surface its flag (WF ToolUseFlagForm scopes haiku/battletalk
+            // rows to the selected chapter).
+            WithChapter(rom =>
+            {
+                var list = UseFlagScanCore.Scan(rom, 0u);
+                Assert.DoesNotContain(list, u => u.ID == HaikuOtherChapterFlag);
+            });
+        }
+
+        [Fact]
+        public void Scan_Haiku_OtherChapterFlag_AppearsForItsOwnChapter()
+        {
+            // Conversely, scanning chapter 5 surfaces record 1's flag (with the
+            // HAIKU type) — proving the scope filter keys on the record's chapter
+            // field, not a blanket include/exclude.
+            WithChapter(rom =>
+            {
+                var list = UseFlagScanCore.Scan(rom, 5u);
+                Assert.Contains(list, u =>
+                    u.ID == HaikuOtherChapterFlag && u.DataType == FELintCore.Type.HAIKU);
+            });
+        }
+
+        [Fact]
+        public void Scan_HaikuAndBattleTalk_RespectDedupInvariant()
+        {
+            // The #1192 dedup invariant must still hold with the new sources wired:
+            // no (flag id, source type) pair repeats across the whole list.
+            WithChapter(rom =>
+            {
+                var list = UseFlagScanCore.Scan(rom, 0u);
+                var seen = new HashSet<(uint, int)>();
+                foreach (var u in list)
+                    Assert.True(seen.Add((u.ID, (int)u.DataType)),
+                        $"duplicate row for flag 0x{u.ID:X} type {u.DataType}");
             });
         }
 

--- a/FEBuilderGBA.Core/UseFlagScanCore.cs
+++ b/FEBuilderGBA.Core/UseFlagScanCore.cs
@@ -9,14 +9,18 @@ namespace FEBuilderGBA
     /// <c>ToolUseFlagForm.UpdateList</c> flag-usage roll-up).
     ///
     /// Given a chapter (map id) it collects every event-flag reference from the
-    /// PRIMARY flag-usage subsystems and returns the merged + WF-sorted list:
+    /// flag-usage subsystems and returns the merged + WF-sorted list:
     ///   (1) event-condition records   — the flag field of each Turn / Talk /
     ///       Object / Always condition record  (FELint EVENT_COND_*),
     ///   (2) event scripts              — every <see cref="EventScript.ArgType.FLAG"/>
     ///       referenced by the scripts reachable from the chapter's condition
-    ///       slots  (FELint EVENTSCRIPT), and
+    ///       slots  (FELint EVENTSCRIPT),
     ///   (3) map changes                — the flag field of each map-change record
-    ///       (FELint MAPCHANGE).
+    ///       (FELint MAPCHANGE),
+    ///   (4) death quotes (Haiku)       — the flag field of each per-version Haiku
+    ///       record scoped to this chapter  (FELint HAIKU), and
+    ///   (5) battle conversations       — the flag field of each per-version
+    ///       BattleTalk record scoped to this chapter  (FELint BATTTLE_TALK).
     ///
     /// Reuses the existing Core seams rather than re-deriving them:
     ///   <see cref="MapEventUnitCore.GetCondSlots"/>      (the per-version slot→type table),
@@ -25,11 +29,13 @@ namespace FEBuilderGBA
     ///   the <see cref="EventScript.ArgType.FLAG"/> walk, and
     ///   <see cref="MapChangeCore.MakeFlagIDArray"/>.
     ///
-    /// DEFERRED (#1253): the Haiku × {FE6,FE7,FE8} and BattleTalk × {FE6,FE7,FE8}
-    /// scanners (WinForms EventHaiku*Form.MakeFlagIDArray / EventBattleTalk*Form.MakeFlagIDArray)
-    /// are NOT included here. Each needs its subsystem's per-version data-table
-    /// layout (InputFormRef Init base-pointer / block-size / count) ported to
-    /// Core first — out of scope for this slice, tracked by follow-up issue #1253.
+    /// The Haiku/BattleTalk scanners (#1253) port the WinForms
+    /// EventHaiku*Form.MakeFlagIDArray / EventBattleTalk*Form.MakeFlagIDArray data
+    /// tables into Core — the same per-version (base-pointer / block-size /
+    /// flag-offset / chapter-offset) layouts ExportFilterCore already walks. Like
+    /// WF ToolUseFlagForm.UpdateList, the records are read table-wide then scoped to
+    /// the selected chapter (a record's chapter field at <c>chapter-offset</c>, or
+    /// every chapter when that field is the 0xF0+ "any" marker).
     ///
     /// NO ROM mutation, NO undo. Every read is bounds-guarded; malformed data
     /// truncates a sub-scan and yields a partial list rather than throwing.
@@ -64,11 +70,14 @@ namespace FEBuilderGBA
             var raw = new List<UseFlagIDCore>();
             if (rom?.RomInfo == null) return raw;
 
-            // Collect in WF append order (cond → event-script → map-change) so the
+            // Collect in WF append order (cond → event-script → map-change →
+            // haiku → battle-talk, matching ToolUseFlagForm.UpdateList) so the
             // first-occurrence kept per (id, type) is deterministic.
             AppendEventCondFlags(rom, mapId, raw);
             AppendEventScriptFlags(rom, mapId, raw);
             MapChangeCore.MakeFlagIDArray(rom, mapId, raw);
+            AppendHaikuFlags(rom, mapId, raw);
+            AppendBattleTalkFlags(rom, mapId, raw);
 
             var list = DedupByFlagAndType(raw);
             SortLikeWinForms(list);
@@ -295,6 +304,164 @@ namespace FEBuilderGBA
             for (int i = 0; i < found.Count; i++)
                 if (found[i].flag == flag) return true;
             return false;
+        }
+
+        // ------------------------------------------------------------
+        // (4) Death-quote (Haiku) record flags  +  (5) Battle-conversation
+        //     (BattleTalk) record flags.
+        //
+        // Port of the WF EventHaiku*Form.MakeFlagIDArray / EventBattleTalk*Form
+        // .MakeFlagIDArray data tables (the per-version base-pointer / block-size
+        // / flag-offset / chapter-offset that UseFlagID.AppendFlagID consumes) —
+        // the SAME tables ExportFilterCore.CollectHaiku / CollectBattleTalk walk.
+        //
+        // WF AppendFlagID reads a u16 flag at flagOffset and a u8 chapter at
+        // chapterOffset; a chapter >= 0xF0 becomes the "any chapter" marker
+        // (mapid = U.NOT_FOUND). ToolUseFlagForm.UpdateList then keeps a row when
+        // its chapter equals the selected map OR is the "any" marker. We replicate
+        // that scoping HERE (so only the selected chapter's rows are appended),
+        // because UseFlagScanCore.Scan is chapter-scoped by contract.
+        // ------------------------------------------------------------
+
+        // Defensive per-table record-walk bound (mirrors ExportFilterCore's 0x400
+        // cap — a corrupt table with no terminating record can never loop forever).
+        const int MaxHaikuBattleTalkRecords = 0x400;
+
+        static void AppendHaikuFlags(ROM rom, uint mapId, List<UseFlagIDCore> list)
+        {
+            int version = rom.RomInfo.version;
+            uint haikuPtr = rom.RomInfo.event_haiku_pointer;
+
+            if (version == 8)
+            {
+                // EventHaikuForm: blocksize 12, flag@+4, chapter@+3.
+                AppendFlagTable(rom, mapId, list, FELintCore.Type.HAIKU,
+                    haikuPtr, 12, 4, 3, TableTerm.U16Sentinel);
+            }
+            else if (version == 7)
+            {
+                // EventHaikuFE7Form main: blocksize 16, flag@+12, chapter@+1.
+                AppendFlagTable(rom, mapId, list, FELintCore.Type.HAIKU,
+                    haikuPtr, 16, 12, 1, TableTerm.U8Zero);
+                // + the two Lyn/Eliwood tutorial tables: blocksize 12, flag@+8,
+                //   chapter@+1 (WF N1_Init reused per ReInitPointer).
+                AppendFlagTable(rom, mapId, list, FELintCore.Type.HAIKU,
+                    rom.RomInfo.event_haiku_tutorial_1_pointer, 12, 8, 1, TableTerm.U8Zero);
+                AppendFlagTable(rom, mapId, list, FELintCore.Type.HAIKU,
+                    rom.RomInfo.event_haiku_tutorial_2_pointer, 12, 8, 1, TableTerm.U8Zero);
+            }
+            else
+            {
+                // EventHaikuFE6Form: blocksize 16, flag@+8, chapter@+1.
+                AppendFlagTable(rom, mapId, list, FELintCore.Type.HAIKU,
+                    haikuPtr, 16, 8, 1, TableTerm.U8Zero);
+            }
+        }
+
+        static void AppendBattleTalkFlags(ROM rom, uint mapId, List<UseFlagIDCore> list)
+        {
+            int version = rom.RomInfo.version;
+            uint talkPtr = rom.RomInfo.event_ballte_talk_pointer;
+            uint talk2Ptr = rom.RomInfo.event_ballte_talk2_pointer;
+
+            if (version == 8)
+            {
+                // EventBattleTalkForm: blocksize 16, flag@+6, chapter@+4.
+                AppendFlagTable(rom, mapId, list, FELintCore.Type.BATTTLE_TALK,
+                    talkPtr, 16, 6, 4, TableTerm.U16Sentinel);
+            }
+            else if (version == 7)
+            {
+                // EventBattleTalkFE7Form main: blocksize 16, flag@+12, chapter@+2.
+                AppendFlagTable(rom, mapId, list, FELintCore.Type.BATTTLE_TALK,
+                    talkPtr, 16, 12, 2, TableTerm.U16Sentinel);
+                // + N1 (BattleTalk2): blocksize 12, flag@+8, chapter@+1.
+                AppendFlagTable(rom, mapId, list, FELintCore.Type.BATTTLE_TALK,
+                    talk2Ptr, 12, 8, 1, TableTerm.U8Sentinel);
+            }
+            else
+            {
+                // EventBattleTalkFE6Form main: blocksize 12, flag@+8, chapter@+2.
+                AppendFlagTable(rom, mapId, list, FELintCore.Type.BATTTLE_TALK,
+                    talkPtr, 12, 8, 2, TableTerm.U16Sentinel);
+                // + N (BattleTalk2): blocksize 16, flag@+8, chapter@+1.
+                AppendFlagTable(rom, mapId, list, FELintCore.Type.BATTTLE_TALK,
+                    talk2Ptr, 16, 8, 1, TableTerm.U16Sentinel);
+            }
+        }
+
+        // Per-version record terminator (mirrors the WF InputFormRef Init
+        // DataCount predicate — when to stop counting records). All variants ALSO
+        // honor the WF "i>10 && IsEmpty(addr, blocksize*10)" empty-run guard.
+        enum TableTerm
+        {
+            /// <summary>Stop when the record's first u16 is 0xFFFF (FE8 Haiku/BattleTalk, FE7/FE6 BattleTalk).</summary>
+            U16Sentinel,
+            /// <summary>Stop when the record's first u8 is 0 (FE7 main Haiku, FE6 Haiku, FE7 tutorials).</summary>
+            U8Zero,
+            /// <summary>Stop when the record's first u8 is 0 or 0xFF (FE7 BattleTalk2).</summary>
+            U8Sentinel,
+        }
+
+        // Walk one InputFormRef-style flag table: deref the base pointer, then for
+        // each fixed-size record read a u16 flag (flagOffset) + u8 chapter
+        // (chapterOffset), terminate per the version predicate, and append a
+        // chapter-scoped HAIKU/BATTTLE_TALK row. Strictly READ-ONLY: every read is
+        // bounds-guarded; malformed data terminates the walk with a partial list.
+        static void AppendFlagTable(
+            ROM rom, uint mapId, List<UseFlagIDCore> list, FELintCore.Type type,
+            uint pointerField, uint blockSize, uint flagOffset, uint chapterOffset,
+            TableTerm term)
+        {
+            if (list == null) return;
+            // A 0 pointer field means this table does not exist for the version.
+            if (pointerField == 0) return;
+            if (!U.isSafetyOffset(pointerField + 3, rom)) return;
+
+            uint baseAddr = rom.p32(pointerField);
+            if (!U.isSafetyOffset(baseAddr, rom)) return;
+
+            uint romLen = (uint)rom.Data.Length;
+            uint emptyRunLen = blockSize * 10;
+            uint addr = baseAddr;
+
+            for (int i = 0; i < MaxHaikuBattleTalkRecords; i++, addr += blockSize)
+            {
+                // Bounds-check the FULL record (incl. the read offsets) before any
+                // read so a near-EOF table can never throw.
+                if (!U.isSafetyOffset(addr, rom)) break;
+                if (addr + blockSize > romLen) break;
+
+                if (IsTableTerminator(rom, addr, term)) break;
+                // WF empty-run guard: after the first 10 records, an all-0x00 /
+                // all-0xFF block of blocksize*10 ends the table.
+                if (i > 10 && addr + emptyRunLen <= romLen && rom.IsEmpty(addr, emptyRunLen)) break;
+
+                uint flag = rom.u16(addr + flagOffset);
+                if (flag == 0) continue; // WF AppendFlagID skips id == 0.
+
+                uint chapter = rom.u8(addr + chapterOffset);
+                // WF AppendFlagID: chapter >= 0xF0 → "any chapter" (U.NOT_FOUND).
+                bool anyChapter = chapter >= 0xF0;
+                if (!anyChapter && chapter != mapId) continue; // chapter scope filter
+
+                uint mapid = anyChapter ? U.NOT_FOUND : mapId;
+                UseFlagIDCore.AppendUseFlagID(
+                    list, type, addr, U.ToHexString((uint)i), flag, mapid, (uint)i);
+            }
+        }
+
+        static bool IsTableTerminator(ROM rom, uint addr, TableTerm term)
+        {
+            switch (term)
+            {
+                case TableTerm.U16Sentinel: return rom.u16(addr) == 0xFFFF;
+                case TableTerm.U8Zero:      return rom.u8(addr) == 0;
+                case TableTerm.U8Sentinel:
+                    uint v = rom.u8(addr);
+                    return v == 0 || v == 0xFF;
+                default: return false;
+            }
         }
 
         // ------------------------------------------------------------

--- a/FEBuilderGBA.Core/UseFlagScanCore.cs
+++ b/FEBuilderGBA.Core/UseFlagScanCore.cs
@@ -373,8 +373,9 @@ namespace FEBuilderGBA
             else if (version == 7)
             {
                 // EventBattleTalkFE7Form main: blocksize 16, flag@+12, chapter@+2.
+                // WF Init stops on u16==0 || 0xFFFF (NOT 0xFFFF only) — #1256.
                 AppendFlagTable(rom, mapId, list, FELintCore.Type.BATTTLE_TALK,
-                    talkPtr, 16, 12, 2, TableTerm.U16Sentinel);
+                    talkPtr, 16, 12, 2, TableTerm.U16ZeroOrSentinel);
                 // + N1 (BattleTalk2): blocksize 12, flag@+8, chapter@+1.
                 AppendFlagTable(rom, mapId, list, FELintCore.Type.BATTTLE_TALK,
                     talk2Ptr, 12, 8, 1, TableTerm.U8Sentinel);
@@ -382,11 +383,13 @@ namespace FEBuilderGBA
             else
             {
                 // EventBattleTalkFE6Form main: blocksize 12, flag@+8, chapter@+2.
+                // WF Init stops on u16==0 || 0xFFFF (NOT 0xFFFF only) — #1256.
                 AppendFlagTable(rom, mapId, list, FELintCore.Type.BATTTLE_TALK,
-                    talkPtr, 12, 8, 2, TableTerm.U16Sentinel);
+                    talkPtr, 12, 8, 2, TableTerm.U16ZeroOrSentinel);
                 // + N (BattleTalk2): blocksize 16, flag@+8, chapter@+1.
+                // WF N_Init stops on u16==0 || 0xFFFF (NOT 0xFFFF only) — #1256.
                 AppendFlagTable(rom, mapId, list, FELintCore.Type.BATTTLE_TALK,
-                    talk2Ptr, 16, 8, 1, TableTerm.U16Sentinel);
+                    talk2Ptr, 16, 8, 1, TableTerm.U16ZeroOrSentinel);
             }
         }
 
@@ -395,11 +398,20 @@ namespace FEBuilderGBA
         // honor the WF "i>10 && IsEmpty(addr, blocksize*10)" empty-run guard.
         enum TableTerm
         {
-            /// <summary>Stop when the record's first u16 is 0xFFFF (FE8 Haiku/BattleTalk, FE7/FE6 BattleTalk).</summary>
+            /// <summary>Stop when the record's first u16 is 0xFFFF ONLY — FE8 Haiku
+            /// + FE8 BattleTalk (WF EventHaikuForm.Init / EventBattleTalkForm.Init
+            /// stop on <c>u16==0xFFFF</c>; a u16==0 record is a LIVE record there).</summary>
             U16Sentinel,
+            /// <summary>Stop when the record's first u16 is 0 OR 0xFFFF — FE6
+            /// BattleTalk (main + N) and FE7 BattleTalk main (WF
+            /// EventBattleTalkFE{6,7}Form.Init/N(_)Init stop on
+            /// <c>unit==0 || unit==0xFFFF</c>; matches Core
+            /// TextRefTableRegistry.StopOnU16FFFFOrZero). Without the u16==0 stop the
+            /// walk OVER-READS past a zero terminator into garbage records (#1256).</summary>
+            U16ZeroOrSentinel,
             /// <summary>Stop when the record's first u8 is 0 (FE7 main Haiku, FE6 Haiku, FE7 tutorials).</summary>
             U8Zero,
-            /// <summary>Stop when the record's first u8 is 0 or 0xFF (FE7 BattleTalk2).</summary>
+            /// <summary>Stop when the record's first u8 is 0 or 0xFF (FE7 BattleTalk2 N1).</summary>
             U8Sentinel,
         }
 
@@ -455,8 +467,11 @@ namespace FEBuilderGBA
         {
             switch (term)
             {
-                case TableTerm.U16Sentinel: return rom.u16(addr) == 0xFFFF;
-                case TableTerm.U8Zero:      return rom.u8(addr) == 0;
+                case TableTerm.U16Sentinel:      return rom.u16(addr) == 0xFFFF;
+                case TableTerm.U16ZeroOrSentinel:
+                    uint w = rom.u16(addr);
+                    return w == 0 || w == 0xFFFF;
+                case TableTerm.U8Zero:           return rom.u8(addr) == 0;
                 case TableTerm.U8Sentinel:
                     uint v = rom.u8(addr);
                     return v == 0 || v == 0xFF;


### PR DESCRIPTION
Fixes #1253.

Completes the #1192 Flags-Used-in-Chapter tool by adding the deferred **Haiku** + **BattleTalk** flag scanners — the two remaining flag-usage sources (death-quotes / battle conversations).

## What
- 6 per-game scanners wired into `UseFlagScanCore.Scan(rom, mapId)` after the existing 3 sources (EVENT_COND_* / EVENTSCRIPT / MAPCHANGE): HAIKU × {FE6,FE7,FE8} and BATTTLE_TALK × {FE6,FE7,FE8} (incl. FE7's tutorial-Haiku tables + the FE6/FE7 secondary BattleTalk tables). Rows get `FELintCore.Type.HAIKU` / `BATTTLE_TALK` (types already in Core) and flow through the established #1192 dedup (one row per (flag id, DataType) per chapter) + sort.

## How (architecture)
- A shared, bounds-guarded, **self-contained** `AppendFlagTable(rom, mapId, list, type, pointerField, blockSize, flagOffset, chapterOffset, term)` walk — mirroring the established `ExportFilterCore` Haiku/BattleTalk table idiom (RomInfo pointer field + blocksize + per-record flag/chapter offsets + the WF termination predicates: u16==0xFFFF / u8==0 / `i>10 && IsEmpty(addr, bs*10)`). `chapter>=0xF0 → MapID=NOT_FOUND` (WF "any-chapter" rule). **No WinForms coupling, no InputFormRef** — all 5 pointer fields are RomInfo fields Core already reads. Read-only (no ROM mutation).

## Tests / gates (all green — FULL projects)
- `UseFlagScanCoreTests` — synthetic FE8 ROM extended with Haiku + BattleTalk records → both land with the right type; the dedup invariant still holds (no regression to the existing 3 sources). **16/16** (11 existing + 5 new).
- Core.Tests WHOLE **4338/5skip**; Avalonia.Tests `~L10nCoverage|~UseFlag` **18/0**; FEBuilderGBA.Tests WHOLE **1864/0**. Builds 0 err; `validate-automation-ids` 0/0. No type/translation changes.

## Proof (FE8U — Flags Used in Chapter, "00 The Fall of Renais" → 28 flags, was 21)
The new scanners resolve live: `0x01 Battle Quotes flag [BATTTLE_TALK]` (selected; detail address shown), `0x02 Defeat Boss flag [HAIKU]` (deduped alongside its `[EVENT_COND_ALWAYS]` row), `0x65 GameOver [HAIKU]` — existing EVENT_COND/EVENTSCRIPT rows unchanged:

<img width="900" src="https://github.com/laqieer/FEBuilderGBA/releases/download/bugsweep-screenshots/pr1253-haiku-battletalk-fe8u.png">

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 4.8 (1M context), model `claude-opus-4-8[1m]`