### PR TITLE
feat(avalonia): port World Map Event Pointer (FE6) editor (#1181)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/WorldMapEventPointerFE6ViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/WorldMapEventPointerFE6ViewModelTests.cs
@@ -88,6 +88,15 @@ public class WorldMapEventPointerFE6ViewModelTests : IClassFixture<RomFixture>
             return;
         }
 
+        // The fixture ROM must actually be non-FE6 for this to exercise the
+        // intended path; if the only available ROM is FE6, skip rather than
+        // mislabel an FE6 run as a non-FE6 assertion.
+        if (CoreState.ROM.RomInfo.version == 6)
+        {
+            _output.WriteLine("Fixture ROM is FE6 — non-FE6 path not exercised, skipping.");
+            return;
+        }
+
         var vm = new WorldMapEventPointerFE6ViewModel();
         var list = vm.LoadList();
         Assert.NotNull(list);

--- a/FEBuilderGBA.Avalonia.Tests/WorldMapEventPointerFE6ViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/WorldMapEventPointerFE6ViewModelTests.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+/// <summary>
+/// Headless ROM-backed tests for <see cref="WorldMapEventPointerFE6ViewModel"/> (issue #1181 —
+/// port of WinForms <c>WorldMapEventPointerFE6Form</c>). Unlike the FE7 sibling these tests need
+/// an FE6 ROM specifically: the FE6 list is built off the MAP SETTINGS table and resolves each
+/// row's address through the FE6-only world-map-event PLIST, so the data only exists when
+/// <c>RomInfo.version == 6</c>. <see cref="RomTestHelper.WithRom"/> loads FE6 (and no-ops when the
+/// ROM is unavailable, e.g. local runs without a roms/ dir), restoring CoreState afterwards.
+/// </summary>
+[Collection("SharedState")]
+public class WorldMapEventPointerFE6ViewModelTests : IClassFixture<RomFixture>
+{
+    private readonly RomFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public WorldMapEventPointerFE6ViewModelTests(RomFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    [Fact]
+    public void LoadList_OnFE6_ResolvesRowsIntoMapPointerTable()
+    {
+        RomTestHelper.WithRom("FE6", () =>
+        {
+            ROM rom = CoreState.ROM;
+            Assert.Equal(6, rom.RomInfo.version);
+
+            var vm = new WorldMapEventPointerFE6ViewModel();
+            List<AddrResult> list = vm.LoadList();
+
+            // GetListCount is the same code path — keep them in lockstep.
+            Assert.Equal(list.Count, vm.GetListCount());
+
+            uint mapBase = rom.p32(rom.RomInfo.map_map_pointer_pointer);
+            foreach (AddrResult r in list)
+            {
+                // Every row address must be the map-pointer-table slot the FE6
+                // world-map-event PLIST indexes: p32(map_map_pointer_pointer) +
+                // plist*4 — so it is >= base, 4-byte aligned from base, and safe.
+                Assert.True(r.addr >= mapBase);
+                Assert.Equal(0u, (r.addr - mapBase) % 4);
+                Assert.True(U.isSafetyOffset(r.addr, rom));
+                Assert.False(string.IsNullOrEmpty(r.name));
+            }
+            _output.WriteLine($"FE6 world-map-event rows: {list.Count}");
+        });
+    }
+
+    [Fact]
+    public void LoadEntry_SetsCurrentAddrAndIsLoaded()
+    {
+        RomTestHelper.WithRom("FE6", () =>
+        {
+            var vm = new WorldMapEventPointerFE6ViewModel();
+            var list = vm.LoadList();
+            if (list.Count == 0)
+            {
+                _output.WriteLine("FE6 ROM has no world-map-event maps — skipping entry check.");
+                return;
+            }
+
+            uint addr = list[0].addr;
+            vm.LoadEntry(addr);
+
+            Assert.True(vm.IsLoaded);
+            Assert.Equal(addr, vm.CurrentAddr);
+        });
+    }
+
+    [Fact]
+    public void LoadList_OnNonFE6Rom_DoesNotThrow()
+    {
+        // The VM must never throw on a non-FE6 ROM (the menu entry can be opened
+        // on any ROM). It should simply return a list (typically empty, since the
+        // FE6-only world-map-event PLIST is meaningful only on FE6).
+        if (!_fixture.IsAvailable || CoreState.ROM?.RomInfo == null)
+        {
+            _output.WriteLine("ROM not available — skipping.");
+            return;
+        }
+
+        var vm = new WorldMapEventPointerFE6ViewModel();
+        var list = vm.LoadList();
+        Assert.NotNull(list);
+        Assert.Equal(list.Count, vm.GetListCount());
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/WorldMapEventPointerFE6ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/WorldMapEventPointerFE6ViewModel.cs
@@ -48,8 +48,12 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             // map_map_pointer_pointer holds the base of the MAP-arrangement PLIST
             // table the FE6 world-map-event PLIST indexes into. Guard the slot +
             // the dereferenced base so a malformed/empty RomInfo never throws.
+            // isSafetyOffset only checks the START offset; p32 reads 4 bytes, so
+            // also require the full slot in-bounds (overflow-safe), exactly as
+            // MapSettingCore.GetMapIdFromAddr does before its p32.
             uint mapPtrPtr = rom.RomInfo.map_map_pointer_pointer;
             if (mapPtrPtr == 0 || !U.isSafetyOffset(mapPtrPtr, rom)) return new List<AddrResult>();
+            if ((ulong)mapPtrPtr + 4 > (ulong)rom.Data.Length) return new List<AddrResult>();
             uint mapBase = rom.p32(mapPtrPtr);
             if (!U.isSafetyOffset(mapBase, rom)) return new List<AddrResult>();
 

--- a/FEBuilderGBA.Avalonia/ViewModels/WorldMapEventPointerFE6ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/WorldMapEventPointerFE6ViewModel.cs
@@ -1,8 +1,29 @@
 using System;
 using System.Collections.Generic;
+using FEBuilderGBA.Avalonia.Services;
 
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
+    /// <summary>
+    /// World Map Event Pointer (FE6) editor — port of WinForms
+    /// <c>WorldMapEventPointerFE6Form</c>. FE6 is the most divergent of the three
+    /// world-map-event variants: unlike the FE8 base
+    /// (<see cref="WorldMapEventPointerViewModel"/>) and the FE7 sibling
+    /// (<see cref="WorldMapEventPointerFE7ViewModel"/>) — both of which read a
+    /// dedicated event-pointer table — FE6 has NO separate table. WF
+    /// <c>N_Init</c> drives the list straight off the MAP SETTINGS table
+    /// (<c>map_setting_pointer</c> / <c>map_setting_datasize</c>): every map whose
+    /// world-map-event PLIST byte is non-zero produces one navigate-only row.
+    ///
+    /// <para>For a qualifying map the row's resolved address is the entry in the
+    /// MAP-pointer table the PLIST indexes —
+    /// <c>p32(map_map_pointer_pointer) + worldmapEventPlist * 4</c> — exactly as
+    /// WF builds <c>AddrResult.addr</c>. Selecting a row jumps there; the FE6 form
+    /// (like its Designer) has NO editable ROM-data fields and NO Write button, so
+    /// this VM is strictly read-only — it writes no ROM bytes and so is not a
+    /// data-verifiable editor (matching the WF form and the field-completeness
+    /// contract).</para>
+    /// </summary>
     public class WorldMapEventPointerFE6ViewModel : ViewModelBase
     {
         uint _currentAddr;
@@ -11,13 +32,50 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
 
+        /// <summary>
+        /// Build the navigate-only list — port of WF <c>N_Init</c> + <c>MakeList</c>.
+        /// Walks the enumerated MAP SETTINGS table (same base / datasize /
+        /// terminator heuristic the editor's map list uses via
+        /// <see cref="MapSettingCore.MakeMapIDList(ROM)"/>), keeps each map whose
+        /// world-map-event PLIST byte is non-zero, and resolves its row address to
+        /// the MAP-pointer-table slot the PLIST indexes.
+        /// </summary>
         public List<AddrResult> LoadList()
         {
             ROM rom = CoreState.ROM;
             if (rom?.RomInfo == null) return new List<AddrResult>();
 
+            // map_map_pointer_pointer holds the base of the MAP-arrangement PLIST
+            // table the FE6 world-map-event PLIST indexes into. Guard the slot +
+            // the dereferenced base so a malformed/empty RomInfo never throws.
+            uint mapPtrPtr = rom.RomInfo.map_map_pointer_pointer;
+            if (mapPtrPtr == 0 || !U.isSafetyOffset(mapPtrPtr, rom)) return new List<AddrResult>();
+            uint mapBase = rom.p32(mapPtrPtr);
+            if (!U.isSafetyOffset(mapBase, rom)) return new List<AddrResult>();
+
             var result = new List<AddrResult>();
-            result.Add(new AddrResult(0, "Event Pointer (FE6)", 0));
+            foreach (AddrResult ms in MapSettingCore.MakeMapIDList(rom))
+            {
+                // WF predicate: a map entry counts only when its first dword is a
+                // pointer. MakeMapIDList already enforces the table terminator, so
+                // this just rejects in-range non-pointer rows (matches N_Init's
+                // isData check).
+                if (!U.isPointer(rom.u32(ms.addr + 0))) continue;
+
+                uint plist = MapPListResolverCore.GetWorldMapEventIDWhereAddr(rom, ms.addr);
+                if (plist == 0 || plist == U.NOT_FOUND) continue;
+
+                // WF row addr = p32(map_map_pointer_pointer) + plist * 4. Bounds-
+                // guard the resolved slot so an out-of-range PLIST is skipped
+                // rather than producing an unselectable / past-EOF row.
+                uint rowAddr = mapBase + plist * 4;
+                if (!U.isSafetyOffset(rowAddr, rom)) continue;
+
+                // WF label: ToHexString(i) + GetMapNameWhereAddr(addr) — directly
+                // concatenated (no separating space), preserved verbatim.
+                string name = U.ToHexString(ms.tag) + MapSettingCore.GetMapNameWhereAddr(rom, ms.addr);
+                result.Add(new AddrResult(rowAddr, name, ms.tag));
+            }
             return result;
         }
 
@@ -29,5 +87,8 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             CurrentAddr = addr;
             IsLoaded = true;
         }
+
+        /// <summary>Number of navigate-only rows (test hook, mirrors the FE7 VM).</summary>
+        public int GetListCount() => LoadList().Count;
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/WorldMapEventPointerFE6View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapEventPointerFE6View.axaml
@@ -15,6 +15,8 @@
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
           <TextBlock AutomationProperties.AutomationId="WorldMapEventPointerFE6_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
         </Grid>
+
+        <TextBlock Text="Each row is a map whose world-map event PLIST is set. The address points to the map-pointer table slot the PLIST indexes." TextWrapping="Wrap" Foreground="Gray" Margin="0,4" />
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/WorldMapEventPointerFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapEventPointerFE6View.axaml.cs
@@ -1,3 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// World Map Event Pointer (FE6) editor view — port of WinForms
+// WorldMapEventPointerFE6Form (#1181).
+//
+// FE6 is navigate-only: a single AddressListControl lists every map whose
+// world-map-event PLIST is set, and selecting a row resolves to the
+// MAP-pointer-table slot the PLIST indexes (see the VM). There are no
+// editable ROM-data fields and no Write button, so the view holds no
+// UndoService and the VM does not implement IDataVerifiable.
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -29,7 +38,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("WorldMapEventPointerFE6View.LoadList failed: {0}", ex.Message);
+                Log.Error("WorldMapEventPointerFE6View.LoadList failed: " + ex.ToString());
             }
         }
 
@@ -42,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("WorldMapEventPointerFE6View.OnSelected failed: {0}", ex.Message);
+                Log.Error("WorldMapEventPointerFE6View.OnSelected failed: " + ex.ToString());
             }
         }
 

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20592,3 +20592,6 @@ There is no compiled result, so a patch cannot be created.
 :A redistributable patch definition for the compiled result. Save it as a PATCH_(NAME).txt file to share the patch.
 A redistributable patch definition for the compiled result. Save it as a PATCH_(NAME).txt file to share the patch.
 
+:Each row is a map whose world-map event PLIST is set. The address points to the map-pointer table slot the PLIST indexes.
+Each row is a map whose world-map event PLIST is set. The address points to the map-pointer table slot the PLIST indexes.
+

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11852,3 +11852,6 @@ config/translate/<lang>.txt
 :A redistributable patch definition for the compiled result. Save it as a PATCH_(NAME).txt file to share the patch.
 コンパイル結果の再配布可能なパッチ定義です。PATCH_(NAME).txt ファイルとして保存すると、パッチを共有できます。
 
+:Each row is a map whose world-map event PLIST is set. The address points to the map-pointer table slot the PLIST indexes.
+各行はワールドマップイベントPLISTが設定されたマップです。アドレスはPLISTが指すマップポインタテーブルのスロットを指します。
+

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25693,3 +25693,6 @@ config/translate/<lang>.txt
 :A redistributable patch definition for the compiled result. Save it as a PATCH_(NAME).txt file to share the patch.
 编译结果的可再分发补丁定义。将其保存为 PATCH_(NAME).txt 文件即可分享该补丁。
 
+:Each row is a map whose world-map event PLIST is set. The address points to the map-pointer table slot the PLIST indexes.
+每行是设置了世界地图事件PLIST的地图。地址指向PLIST索引的地图指针表槽位。
+


### PR DESCRIPTION
## Summary
Ports the **World Map Event Pointer (FE6)** editor to functional parity with WinForms `WorldMapEventPointerFE6Form` (#1181). The Avalonia `WorldMapEventPointerFE6ViewModel` was a 33-line stub returning a single dummy row; it now resolves the real FE6 list.

FE6 is the most divergent of the three variants — it has **no dedicated event-pointer table**. The list is driven straight off the **map settings** table (`MapSettingCore.MakeMapIDList`): every map whose world-map-event PLIST byte (`MapPListResolverCore.GetWorldMapEventIDWhereAddr`) is non-zero becomes one row, and the row address is resolved via `p32(map_map_pointer_pointer) + worldmapEventPlist * 4` — because FE6 stores a PLIST *index*, not a direct pointer. The WinForms form (and its Designer) have **no editable field controls and no Write button**, so the port is read-only / navigate-only, matching base/FE7's read-only contract (VM does not implement `IDataVerifiable`, not in `AvaloniaFieldCompletenessTests` FormMappings).

## Changes
- `WorldMapEventPointerFE6ViewModel.cs` — real list resolution (was a dummy-row stub)
- `WorldMapEventPointerFE6View.axaml(.cs)` — descriptive label (`Foreground="Gray"`, no hex), `Log.Error` string-concat
- `WorldMapEventPointerFE6ViewModelTests.cs` — 3 new tests (ROM-backed, run in CI)
- `config/translate/{en,ja,zh}.txt` — ja+zh for the new literal

## Tests (all run locally, all green)
- Core.Tests: **4350 passed**, 0 failed (incl. AvaloniaScrollViewerTests)
- Avalonia.Tests: **8327 passed**, 0 failed (incl. L10nCoverageTest + NoOrphanVMs_ImplementIDataVerifiable)
- FEBuilderGBA.Tests (net9.0-windows): **1864 passed**, 0 failed (incl. AvaloniaDarkModeTests + AvaloniaFieldCompletenessTests)
- validate-automation-ids.ps1: **0 errors / 0 warnings** (5918 IDs across 370 files)

Screenshot (FE6 ROM) added below.

Fixes #1181

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
