### PR TITLE
feat(avalonia): wire Item Effectiveness (SkillSystems Rework) editor right pane (#1175)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ItemEffectivenessSkillSystemsReworkEditTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ItemEffectivenessSkillSystemsReworkEditTests.cs
@@ -50,6 +50,40 @@ public class ItemEffectivenessSkillSystemsReworkEditTests
         });
     }
 
+    [Fact]
+    public void SetCurrentItemById_PinsOwnerByItemId_OnFE8U()
+    {
+        // Regression for the shared-array disambiguation (PR #1259 review): when
+        // multiple items share one effectiveness array, picking a shared owner
+        // must pin CurrentItemAddr to THAT item's struct, not the first owner's
+        // (else Expand / Make-Independent rewrite the wrong item's +16 pointer).
+        RomTestHelper.WithRom("FE8U", () =>
+        {
+            ROM rom = CoreState.ROM;
+            uint itemBase = rom.p32(rom.RomInfo.item_pointer);
+            uint dataSize = rom.RomInfo.item_datasize;
+
+            var vm = new ItemEffectivenessSkillSystemsReworkViewModel();
+            var list = vm.LoadList();
+
+            foreach (var row in list)
+            {
+                vm.LoadEntry(row.addr);
+                var owners = vm.LoadSharedOwners();
+                if (owners.Count < 2) continue;
+
+                foreach (var owner in owners)
+                {
+                    vm.SetCurrentItemById(owner.tag);
+                    Assert.Equal(itemBase + owner.tag * dataSize, vm.CurrentItemAddr);
+                }
+                _output.WriteLine($"Disambiguation verified across {owners.Count} shared owners.");
+                return; // one genuinely-shared array exercises the path
+            }
+            _output.WriteLine("No shared effectiveness arrays in this ROM — path not exercised.");
+        });
+    }
+
     // -- Synthetic write/expand/independence round-trip ----------------------
 
     static ROM MakeRom(byte[] data)

--- a/FEBuilderGBA.Avalonia.Tests/ItemEffectivenessSkillSystemsReworkEditTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ItemEffectivenessSkillSystemsReworkEditTests.cs
@@ -1,0 +1,191 @@
+using System.Collections.Generic;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+/// <summary>
+/// Issue #1175 — tests for the SkillSystems "特効リワーク" effectiveness editor's
+/// right-pane behaviour (effective-against class-type list, shared-items list,
+/// per-entry write round-trip). The Rework on-ROM format is 4-byte entries with
+/// a u16 class-type, distinct from the classic single-byte ItemEffectivenessForm,
+/// so it is backed by the ItemClassListCore.*Rework* helpers.
+///
+/// The Rework patch is absent from a vanilla FE8U.gba, so the ROM-backed tests
+/// only assert the VM stays safe (no crash, empty/valid output) against real
+/// item metadata. The write/expand round-trip is exercised against a synthetic
+/// in-memory ROM seeded with a valid rework array, driven through the VM exactly
+/// as the view does.
+/// </summary>
+[Collection("SharedState")]
+public class ItemEffectivenessSkillSystemsReworkEditTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public ItemEffectivenessSkillSystemsReworkEditTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    // -- ROM-backed safety (FE8U) --------------------------------------------
+
+    [Fact]
+    public void LoadInnerEntries_AndSharedOwners_DoNotThrow_OnFE8U()
+    {
+        RomTestHelper.WithRom("FE8U", () =>
+        {
+            var vm = new ItemEffectivenessSkillSystemsReworkViewModel();
+            var list = vm.LoadList();
+            _output.WriteLine($"LoadList returned {list.Count} entries");
+            foreach (var row in list)
+            {
+                vm.LoadEntry(row.addr);
+                var inner = vm.LoadInnerEntries();   // must not throw
+                var shared = vm.LoadSharedOwners();  // must not throw
+                Assert.NotNull(inner);
+                Assert.NotNull(shared);
+            }
+        });
+    }
+
+    // -- Synthetic write/expand/independence round-trip ----------------------
+
+    static ROM MakeRom(byte[] data)
+    {
+        var rom = new ROM();
+        typeof(ROM).GetProperty("Data")!.SetValue(rom, data);
+        return rom;
+    }
+
+    static void WriteReworkEntryBytes(byte[] data, int off, byte coeff, ushort classType)
+    {
+        data[off + 0] = 0;
+        data[off + 1] = coeff;
+        data[off + 2] = (byte)(classType & 0xFF);
+        data[off + 3] = (byte)((classType >> 8) & 0xFF);
+    }
+
+    [Fact]
+    public void Vm_LoadInnerEntries_ReadsReworkArray_Synthetic()
+    {
+        // Synthetic ROM: a rework array of [armor, cavalry] + u32 terminator at
+        // offset 256, with the outer-list "address" pointing straight at it.
+        byte[] data = new byte[1024];
+        for (int i = 0; i < data.Length; i++) data[i] = 0xFF;
+        WriteReworkEntryBytes(data, 256, 6, 0x01); // armor
+        WriteReworkEntryBytes(data, 260, 6, 0x02); // cavalry
+        data[264] = data[265] = data[266] = data[267] = 0; // terminator
+
+        var rom = MakeRom(data);
+        var prevRom = CoreState.ROM;
+        CoreState.ROM = rom;
+        try
+        {
+            var vm = new ItemEffectivenessSkillSystemsReworkViewModel();
+            vm.LoadEntry(256);
+            var inner = vm.LoadInnerEntries();
+            Assert.Equal(2, inner.Count);
+            // Each row's value (AddrResult.x) is the class-type bitmask.
+            Assert.Equal(0x01u, inner[0].tag);
+            Assert.Equal(0x02u, inner[1].tag);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+        }
+    }
+
+    [Fact]
+    public void Vm_WriteCurrentEntry_RoundTrips_Synthetic()
+    {
+        byte[] data = new byte[1024];
+        for (int i = 0; i < data.Length; i++) data[i] = 0xFF;
+        WriteReworkEntryBytes(data, 256, 6, 0x01); // armor
+        data[260] = data[261] = data[262] = data[263] = 0; // terminator
+
+        var rom = MakeRom(data);
+        var prevRom = CoreState.ROM;
+        var prevUndo = CoreState.Undo;
+        CoreState.ROM = rom;
+        CoreState.Undo = new Undo();
+        try
+        {
+            var vm = new ItemEffectivenessSkillSystemsReworkViewModel();
+            vm.LoadEntry(256);
+            var inner = vm.LoadInnerEntries();
+            Assert.Single(inner);
+
+            // Select the entry, change coefficient + class-type, write.
+            vm.LoadEntryFields(inner[0].addr);
+            vm.Coefficient = 4;
+            vm.ClassType = 0x24; // flying + sword
+
+            var undo = CoreState.Undo!.NewUndoData(this, "test write");
+            vm.WriteCurrentEntry(undo);
+
+            // Re-read straight off the ROM.
+            Assert.Equal(0x00, rom.Data[256]); // leading byte preserved as 0
+            Assert.Equal(0x04, rom.Data[257]); // coefficient
+            Assert.Equal(0x24u, rom.u16(258)); // class-type
+
+            // And via a fresh scan through the VM.
+            var reread = vm.LoadInnerEntries();
+            Assert.Single(reread);
+            Assert.Equal(0x24u, reread[0].tag);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.Undo = prevUndo;
+        }
+    }
+
+    [Fact]
+    public void Vm_ExpandCurrentList_AddsEntry_Synthetic()
+    {
+        byte[] data = new byte[2048];
+        for (int i = 0; i < data.Length; i++) data[i] = 0xFF;
+        // Item record at offset 512 whose +16 effectiveness pointer → 256.
+        // Build a minimal item table so FindItemsSharingPointer resolves the
+        // owning item (needed for the pointer rewrite during expand).
+        // We point item_pointer (via RomInfo) — but RomInfo is null on a
+        // synthetic ROM, so instead drive expand by setting CurrentItemAddr
+        // directly through LoadEntry's resolution is not possible. Use the
+        // ItemClassListCore directly is covered in Core.Tests; here we verify
+        // the VM forwards a known owner pointer.
+        WriteReworkEntryBytes(data, 256, 6, 0x01); // armor
+        data[260] = data[261] = data[262] = data[263] = 0; // terminator
+        // Owner pointer slot at offset 16 of a fake item at 512 → 256.
+        uint ptr = 256u | 0x08000000u;
+        for (int i = 0; i < 4; i++) data[512 + 16 + i] = (byte)((ptr >> (i * 8)) & 0xFF);
+
+        var rom = MakeRom(data);
+        var prevRom = CoreState.ROM;
+        var prevUndo = CoreState.Undo;
+        CoreState.ROM = rom;
+        CoreState.Undo = new Undo();
+        try
+        {
+            var vm = new ItemEffectivenessSkillSystemsReworkViewModel();
+            vm.CurrentAddr = 256;
+            vm.CurrentItemAddr = 512; // owner item (its +16 holds the pointer)
+
+            var undo = CoreState.Undo!.NewUndoData(this, "test expand");
+            uint newBase = vm.ExpandCurrentList(undo);
+
+            Assert.NotEqual(256u, newBase);
+            // Pointer at the item's +16 was repointed to the new array.
+            Assert.Equal(newBase | 0x08000000u, rom.u32(512 + 16));
+
+            var inner = vm.LoadInnerEntries();
+            Assert.Equal(2, inner.Count); // armor + appended placeholder
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            CoreState.Undo = prevUndo;
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Controls/AddressListControl.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Controls/AddressListControl.axaml.cs
@@ -155,6 +155,28 @@ namespace FEBuilderGBA.Avalonia.Controls
         }
 
         /// <summary>
+        /// Select the item whose <see cref="AddrResult.tag"/> equals
+        /// <paramref name="tag"/>. Unlike <see cref="SelectByIndex"/> (original
+        /// index) this matches the per-row tag — e.g. an item ID — so callers can
+        /// disambiguate multiple rows that share the same <c>addr</c>.
+        /// </summary>
+        /// <returns>True if a row with that tag was found and selected.</returns>
+        public bool SelectByTag(uint tag)
+        {
+            for (int displayIdx = 0; displayIdx < _filteredIndices.Count; displayIdx++)
+            {
+                int itemIdx = _filteredIndices[displayIdx];
+                if (itemIdx >= 0 && itemIdx < _items.Count && _items[itemIdx].tag == tag)
+                {
+                    AddressList.SelectedIndex = displayIdx;
+                    AddressList.ScrollIntoView(displayIdx);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
         /// Clear the current selection. After this call <see cref="SelectedItem"/>
         /// returns null and the inner ListBox shows nothing highlighted.
         /// Mirrors WinForms `ListBox.SelectedIndex = -1` and is used by

--- a/FEBuilderGBA.Avalonia/ViewModels/ItemEffectivenessSkillSystemsReworkViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ItemEffectivenessSkillSystemsReworkViewModel.cs
@@ -1,14 +1,27 @@
 using System;
 using System.Collections.Generic;
+using FEBuilderGBA.Avalonia.Services;
 
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
     public class ItemEffectivenessSkillSystemsReworkViewModel : ViewModelBase
     {
-        uint _currentAddr;
+        uint _currentAddr;          // effectiveness-array offset (the outer-list key)
+        uint _currentItemAddr;      // item struct that owns the selected array (for expand / independence)
+        uint _currentEntryAddr;     // 4-byte entry currently selected in the inner list
+        uint _coefficient;          // entry +1 (coefficient_times*2)
+        uint _classType;            // entry +2 (u16 class-type bitmask)
+        string _classTypeNames = "";
+        bool _hasSharedOwners;
         bool _isLoaded;
 
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
+        public uint CurrentItemAddr { get => _currentItemAddr; set => SetField(ref _currentItemAddr, value); }
+        public uint CurrentEntryAddr { get => _currentEntryAddr; set => SetField(ref _currentEntryAddr, value); }
+        public uint Coefficient { get => _coefficient; set => SetField(ref _coefficient, value); }
+        public uint ClassType { get => _classType; set => SetField(ref _classType, value); }
+        public string ClassTypeNames { get => _classTypeNames; set => SetField(ref _classTypeNames, value); }
+        public bool HasSharedOwners { get => _hasSharedOwners; set => SetField(ref _hasSharedOwners, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
 
         /// <summary>
@@ -73,13 +86,162 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             return result;
         }
 
+        /// <summary>
+        /// Select an outer-list row by its effectiveness-array offset. Resolves
+        /// the owning item via <see cref="ItemClassListCore.FindItemsSharingPointer"/>
+        /// (used for the Expand / Make-Independent pointer writes) and records
+        /// the array offset as the editor's current address.
+        /// </summary>
         public void LoadEntry(uint addr)
         {
             ROM rom = CoreState.ROM;
             if (rom == null) return;
 
             CurrentAddr = addr;
+            CurrentItemAddr = ResolveOwningItemAddr(rom, addr);
+            CurrentEntryAddr = 0;
+            Coefficient = 0;
+            ClassType = 0;
+            ClassTypeNames = "";
             IsLoaded = true;
+        }
+
+        /// <summary>
+        /// The "effective against" list — the 4-byte Rework entries at the
+        /// current effectiveness array. Each <see cref="AddrResult.addr"/> is
+        /// the entry's ROM offset; the name is the class-type bitmask decoded
+        /// to its set bit names (localized) prefixed by the raw hex value, so
+        /// it mirrors the WinForms <c>N_AddressList</c> rows.
+        /// </summary>
+        public List<AddrResult> LoadInnerEntries()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null || CurrentAddr == 0) return new List<AddrResult>();
+
+            var entries = ItemClassListCore.ScanReworkEntries(rom, CurrentAddr);
+            var result = new List<AddrResult>();
+            foreach (var e in entries)
+            {
+                string names = ClassTypeDisplay(e.ClassType);
+                string label = string.IsNullOrEmpty(names)
+                    ? U.ToHexString(e.ClassType)
+                    : $"{U.ToHexString(e.ClassType)} {names}";
+                result.Add(new AddrResult(e.Addr, label, e.ClassType));
+            }
+            return result;
+        }
+
+        /// <summary>Items that point at the current effectiveness array (WF ItemListBox).</summary>
+        public List<AddrResult> LoadSharedOwners()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null || CurrentAddr == 0) return new List<AddrResult>();
+
+            var owners = ItemClassListCore.FindItemsSharingPointer(rom, CurrentAddr);
+            var result = new List<AddrResult>();
+            uint itemBase = rom.p32(rom.RomInfo.item_pointer);
+            uint dataSize = rom.RomInfo.item_datasize;
+            if (!U.isSafetyOffset(itemBase) || dataSize == 0)
+            {
+                HasSharedOwners = false;
+                return result;
+            }
+            foreach (uint id in owners)
+            {
+                uint itemAddr = itemBase + id * dataSize;
+                string name = $"{U.ToHexString(id)} {NameResolver.GetItemName(id)}";
+                result.Add(new AddrResult(itemAddr, name, id));
+            }
+            HasSharedOwners = result.Count > 1;
+            return result;
+        }
+
+        /// <summary>Read the selected 4-byte entry (inner-list selection changed).</summary>
+        public void LoadEntryFields(uint entryAddr)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null) return;
+            if (entryAddr + ItemClassListCore.ReworkEntrySize > (uint)rom.Data.Length) return;
+            CurrentEntryAddr = entryAddr;
+            Coefficient = rom.u8(entryAddr + 1);
+            ClassType = rom.u16(entryAddr + 2);
+            ClassTypeNames = ClassTypeDisplay(ClassType);
+        }
+
+        /// <summary>
+        /// Write the coefficient + class-type of the currently-selected entry.
+        /// The caller owns the undo group (an explicit <see cref="Undo.UndoData"/>)
+        /// so the ROM writes stay inside the editor's undo scope rather than the
+        /// thread-local ambient one.
+        /// </summary>
+        public void WriteCurrentEntry(Undo.UndoData undo)
+        {
+            ROM rom = CoreState.ROM
+                ?? throw new InvalidOperationException("No ROM loaded.");
+            if (undo == null) throw new ArgumentNullException(nameof(undo));
+            if (CurrentEntryAddr == 0)
+                throw new InvalidOperationException("No effectiveness entry selected.");
+            ItemClassListCore.WriteReworkEntry(rom, CurrentEntryAddr, Coefficient, ClassType, undo);
+            ClassTypeNames = ClassTypeDisplay(ClassType);
+        }
+
+        /// <summary>Append a new editable Rework entry to the current array.</summary>
+        public uint ExpandCurrentList(Undo.UndoData undo)
+        {
+            ROM rom = CoreState.ROM
+                ?? throw new InvalidOperationException("No ROM loaded.");
+            if (undo == null) throw new ArgumentNullException(nameof(undo));
+            if (CurrentItemAddr == 0)
+                throw new InvalidOperationException("No item owns this effectiveness list.");
+            uint ptrAddr = CurrentItemAddr + 16;
+            uint newAddr = ItemClassListCore.ExpandReworkList(rom, ptrAddr, undo);
+            CurrentAddr = newAddr;
+            return newAddr;
+        }
+
+        /// <summary>Fork the shared effectiveness array into an independent copy.</summary>
+        public uint MakeCurrentItemIndependent(Undo.UndoData undo)
+        {
+            ROM rom = CoreState.ROM
+                ?? throw new InvalidOperationException("No ROM loaded.");
+            if (undo == null) throw new ArgumentNullException(nameof(undo));
+            if (CurrentItemAddr == 0 || CurrentAddr == 0)
+                throw new InvalidOperationException("No item owns this effectiveness list.");
+            uint ptrAddr = CurrentItemAddr + 16;
+            uint newAddr = ItemClassListCore.MakeIndependentReworkCopy(rom, CurrentAddr, ptrAddr, undo);
+            CurrentAddr = newAddr;
+            return newAddr;
+        }
+
+        /// <summary>
+        /// Decode a class-type bitmask to its display text. The Core helper
+        /// returns canonical English keys (Armor/Cavalry/...); run each through
+        /// <c>R._()</c> so the row text is localized.
+        /// </summary>
+        static string ClassTypeDisplay(uint classType)
+        {
+            string raw = ItemClassListCore.GetClassTypeNames(classType);
+            if (string.IsNullOrEmpty(raw)) return "";
+            string[] keys = raw.Split(',');
+            for (int i = 0; i < keys.Length; i++)
+                keys[i] = R._(keys[i]);
+            return string.Join(",", keys);
+        }
+
+        /// <summary>
+        /// Find the item struct that owns <paramref name="effAddr"/> so the
+        /// pointer-write operations (Expand / Make-Independent) know which +16
+        /// slot to repoint. Returns 0 when no item owns the array.
+        /// </summary>
+        static uint ResolveOwningItemAddr(ROM rom, uint effAddr)
+        {
+            if (rom?.RomInfo == null || effAddr == 0) return 0;
+            var owners = ItemClassListCore.FindItemsSharingPointer(rom, effAddr);
+            if (owners.Count == 0) return 0;
+            uint itemBase = rom.p32(rom.RomInfo.item_pointer);
+            uint dataSize = rom.RomInfo.item_datasize;
+            if (!U.isSafetyOffset(itemBase) || dataSize == 0) return 0;
+            return itemBase + owners[0] * dataSize;
         }
     }
 }

--- a/FEBuilderGBA.Avalonia/ViewModels/ItemEffectivenessSkillSystemsReworkViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ItemEffectivenessSkillSystemsReworkViewModel.cs
@@ -107,6 +107,27 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         }
 
         /// <summary>
+        /// Pin the current owning item explicitly by item ID. When several items
+        /// share one effectiveness array, <see cref="LoadEntry"/>'s address-based
+        /// resolution can only return the first owner, so Expand / Make-Independent
+        /// would act on the wrong item when the user picked a different shared row.
+        /// The view calls this with the actually-selected row's
+        /// <see cref="AddrResult.tag"/> to correct <see cref="CurrentItemAddr"/>.
+        /// No-op (leaves the address-resolved fallback) if the ID is out of range.
+        /// </summary>
+        public void SetCurrentItemById(uint itemId)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return;
+            uint itemBase = rom.p32(rom.RomInfo.item_pointer);
+            uint dataSize = rom.RomInfo.item_datasize;
+            if (!U.isSafetyOffset(itemBase) || dataSize == 0) return;
+            uint itemAddr = itemBase + itemId * dataSize;
+            if (itemAddr + dataSize > (uint)rom.Data.Length) return;
+            CurrentItemAddr = itemAddr;
+        }
+
+        /// <summary>
         /// The "effective against" list — the 4-byte Rework entries at the
         /// current effectiveness array. Each <see cref="AddrResult.addr"/> is
         /// the entry's ROM offset; the name is the class-type bitmask decoded

--- a/FEBuilderGBA.Avalonia/Views/ItemEffectivenessSkillSystemsReworkView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ItemEffectivenessSkillSystemsReworkView.axaml
@@ -3,19 +3,123 @@
         xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
         x:Class="FEBuilderGBA.Avalonia.Views.ItemEffectivenessSkillSystemsReworkView"
         Title="Effectiveness (Skill Systems Rework)" Width="1297" Height="918"
-        SizeToContent="WidthAndHeight">
-  <Grid ColumnDefinitions="250,*">
-    <controls:AddressListControl AutomationProperties.AutomationId="ItemEffectivenessSkillSystemsRework_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
+        SizeToContent="Manual">
+  <!--
+    Issue #1175: item-driven master/detail layout mirroring the WinForms
+    ItemEffectivenessSkillSystemsReworkForm. Outer EntryList = items whose +16
+    effectiveness pointer is set; InnerList = the 4-byte SkillSystems-Rework
+    entries (coefficient + class-type bitmask) that item targets; the right
+    pane edits one entry at a time and surfaces shared-pointer detection via
+    the IndependencePanel. The Rework on-ROM format differs from the classic
+    single-byte ItemEffectivenessForm (4-byte stride, u16 class-type), so it is
+    backed by the ItemClassListCore.*Rework* helpers.
+  -->
+  <Grid ColumnDefinitions="320,*">
+    <controls:AddressListControl AutomationProperties.AutomationId="ItemEffectivenessSkillSystemsRework_Entry_List"
+                                 Grid.Column="0" Name="EntryList" Margin="4" />
 
-    <ScrollViewer Grid.Column="1" Margin="4">
-      <StackPanel Spacing="8" Margin="8">
+    <Grid Grid.Column="1" Margin="8" RowDefinitions="Auto,Auto,*">
+      <!-- Header -->
+      <StackPanel Grid.Row="0" Spacing="4">
         <TextBlock Text="Effectiveness (Skill Systems Rework)" FontSize="18" FontWeight="Bold" />
-
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="ItemEffectivenessSkillSystemsRework_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
-        </Grid>
+        <TextBlock Text="Weapon effectiveness class-type list (per item)" FontSize="12" Foreground="Gray" />
       </StackPanel>
-    </ScrollViewer>
+
+      <!-- Address + selection metadata -->
+      <Grid Grid.Row="1" Margin="0,8,0,8" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto">
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
+        <TextBlock AutomationProperties.AutomationId="ItemEffectivenessSkillSystemsRework_Addr_Label"
+                   Grid.Row="0" Grid.Column="1" Name="AddrLabel"
+                   VerticalAlignment="Center" FontFamily="Consolas,Courier New" />
+        <TextBlock Grid.Row="1" Grid.Column="0" Text="Selected:" VerticalAlignment="Center" />
+        <TextBlock AutomationProperties.AutomationId="ItemEffectivenessSkillSystemsRework_SelectAddress_Label"
+                   Grid.Row="1" Grid.Column="1" Name="SelectAddressLabel"
+                   VerticalAlignment="Center" FontFamily="Consolas,Courier New" />
+      </Grid>
+
+      <!-- Two-pane content: inner class-type list + right edit panel -->
+      <Grid Grid.Row="2" ColumnDefinitions="320,*">
+        <!-- Inner list of class-type entries for the selected item -->
+        <Grid Grid.Column="0" Margin="0,0,8,0" RowDefinitions="Auto,*,Auto">
+          <TextBlock Grid.Row="0" Text="Effective against (classes)" FontWeight="Bold" />
+          <ListBox Grid.Row="1" Name="InnerList"
+                   AutomationProperties.AutomationId="ItemEffectivenessSkillSystemsRework_Inner_List"
+                   SelectionChanged="InnerList_SelectionChanged">
+            <ListBox.ItemTemplate>
+              <DataTemplate>
+                <TextBlock Text="{Binding Text}" VerticalAlignment="Center" />
+              </DataTemplate>
+            </ListBox.ItemTemplate>
+          </ListBox>
+          <Button Grid.Row="2" Name="ListExpandsButton"
+                  AutomationProperties.AutomationId="ItemEffectivenessSkillSystemsRework_ListExpands_Button"
+                  Content="Expand List (+1 slot)" Click="ListExpands_Click"
+                  HorizontalAlignment="Stretch" Margin="0,4,0,0" />
+        </Grid>
+
+        <!-- Right edit panel (per-entry fields + shared-pointer panel) -->
+        <ScrollViewer Grid.Column="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+          <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+            <!-- Per-entry edit fields (mirror WF N_ panel: coefficient + class-type) -->
+            <Grid Grid.Row="0" Margin="0,0,0,8" ColumnDefinitions="160,200" RowDefinitions="Auto,Auto,Auto">
+              <TextBlock Grid.Row="0" Grid.Column="0" Text="Entry Address:" VerticalAlignment="Center" />
+              <TextBlock AutomationProperties.AutomationId="ItemEffectivenessSkillSystemsRework_EntryAddr_Label"
+                         Grid.Row="0" Grid.Column="1" Name="EntryAddrLabel"
+                         VerticalAlignment="Center" FontFamily="Consolas,Courier New" />
+
+              <TextBlock Grid.Row="1" Grid.Column="0" Text="Coefficient (x2):" VerticalAlignment="Center" Margin="0,4" />
+              <NumericUpDown AutomationProperties.AutomationId="ItemEffectivenessSkillSystemsRework_Coefficient_Input"
+                             FormatString="0" Grid.Row="1" Grid.Column="1" Name="CoefficientBox"
+                             Minimum="0" Maximum="255" Margin="0,4" />
+
+              <TextBlock Grid.Row="2" Grid.Column="0" Text="Class Type:" VerticalAlignment="Center" Margin="0,4" />
+              <TextBox AutomationProperties.AutomationId="ItemEffectivenessSkillSystemsRework_ClassType_Input"
+                       Grid.Row="2" Grid.Column="1" Name="ClassTypeBox"
+                       TextChanged="ClassType_TextChanged" Margin="0,4" />
+            </Grid>
+
+            <!-- Decoded class-type names + write button -->
+            <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8" Margin="0,0,0,8">
+              <TextBlock AutomationProperties.AutomationId="ItemEffectivenessSkillSystemsRework_ClassTypeNames_Label"
+                         Name="ClassTypeNamesLabel" VerticalAlignment="Center" Foreground="Gray" />
+            </StackPanel>
+
+            <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="8" Margin="0,0,0,8">
+              <Button Name="WriteButton"
+                      AutomationProperties.AutomationId="ItemEffectivenessSkillSystemsRework_Write_Button"
+                      Content="Write" Click="Write_Click" />
+            </StackPanel>
+
+            <!-- Shared-pointer list (mirrors WinForms ItemListBox) -->
+            <Grid Grid.Row="3" Margin="0,8,0,8" RowDefinitions="Auto,*">
+              <TextBlock Grid.Row="0" Text="Items sharing this effectiveness list" FontWeight="Bold" />
+              <ListBox Grid.Row="1" Name="ItemListBox" Height="120"
+                       AutomationProperties.AutomationId="ItemEffectivenessSkillSystemsRework_SharedOwners_List"
+                       SelectionChanged="ItemListBox_SelectionChanged">
+                <ListBox.ItemTemplate>
+                  <DataTemplate>
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                      <Image Source="{Binding Icon}" Width="32" Height="32" Stretch="Fill" />
+                      <TextBlock Text="{Binding Text}" VerticalAlignment="Center" />
+                    </StackPanel>
+                  </DataTemplate>
+                </ListBox.ItemTemplate>
+              </ListBox>
+            </Grid>
+
+            <!-- IndependencePanel (visible when >1 item shares the list) -->
+            <Grid Grid.Row="4" Name="IndependencePanel" IsVisible="False"
+                  RowDefinitions="Auto,Auto" Margin="0,8,0,0">
+              <TextBlock Grid.Row="0" Foreground="DarkOrange"
+                         Text="This data is shared with other items. Forking will isolate the current item's edits." />
+              <Button Grid.Row="1" Name="IndependenceButton"
+                      AutomationProperties.AutomationId="ItemEffectivenessSkillSystemsRework_Independence_Button"
+                      Content="Make Independent Copy" Click="Independence_Click"
+                      HorizontalAlignment="Left" Margin="0,4,0,0" />
+            </Grid>
+          </Grid>
+        </ScrollViewer>
+      </Grid>
+    </Grid>
   </Grid>
 </Window>

--- a/FEBuilderGBA.Avalonia/Views/ItemEffectivenessSkillSystemsReworkView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemEffectivenessSkillSystemsReworkView.axaml.cs
@@ -169,11 +169,18 @@ namespace FEBuilderGBA.Avalonia.Views
         void ClassType_TextChanged(object? sender, TextChangedEventArgs e)
         {
             if (_suppressFieldEvents) return;
-            if (TryParseHex(ClassTypeBox.Text, out uint v))
+            if (TryParseClassType(ClassTypeBox.Text, out uint v))
             {
                 _vm.ClassType = v;
                 // Live-decode the bitmask names so the user sees the effect.
                 ClassTypeNamesLabel.Text = ClassTypeDisplay(v);
+            }
+            else
+            {
+                // Out-of-range (> u16) or unparseable: don't decode names for a
+                // value the u16 write path would truncate — Write_Click surfaces
+                // the "valid hex value" error instead.
+                ClassTypeNamesLabel.Text = "";
             }
         }
 
@@ -186,7 +193,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     CoreState.Services?.ShowError(R._("No effectiveness entry selected."));
                     return;
                 }
-                if (!TryParseHex(ClassTypeBox.Text, out uint classType))
+                if (!TryParseClassType(ClassTypeBox.Text, out uint classType))
                 {
                     CoreState.Services?.ShowError(R._("Class Type must be a valid hex value."));
                     return;
@@ -282,6 +289,15 @@ namespace FEBuilderGBA.Avalonia.Views
                 keys[i] = R._(keys[i]);
             return string.Join(",", keys);
         }
+
+        /// <summary>
+        /// Parse the class-type field as a hex value that fits the on-ROM u16 at
+        /// entry +2. Rejects values &gt; 0xFFFF up front so the UI never decodes /
+        /// displays names for a value that <c>WriteReworkEntry</c> would silently
+        /// truncate to 16 bits.
+        /// </summary>
+        static bool TryParseClassType(string? text, out uint value)
+            => TryParseHex(text, out value) && value <= 0xFFFF;
 
         static bool TryParseHex(string? text, out uint value)
         {

--- a/FEBuilderGBA.Avalonia/Views/ItemEffectivenessSkillSystemsReworkView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemEffectivenessSkillSystemsReworkView.axaml.cs
@@ -1,14 +1,41 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
+using FEBuilderGBA.Avalonia.Controls;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
+    /// <summary>
+    /// Issue #1175 — item-driven Avalonia Item Effectiveness editor for the FE8U
+    /// SkillSystems "特効リワーク" variant. Mirrors the WinForms
+    /// <c>ItemEffectivenessSkillSystemsReworkForm</c> right pane: outer EntryList
+    /// of items, an InnerList of the 4-byte Rework class-type entries the item
+    /// targets, a per-entry editor (coefficient + class-type bitmask), an
+    /// ItemListBox of items sharing the same effectiveness array, plus the
+    /// IndependencePanel for forking shared arrays. The Rework on-ROM format
+    /// (4-byte stride, u16 class-type) differs from the classic single-byte
+    /// <c>ItemEffectivenessForm</c>, so writes go through the
+    /// <c>ItemClassListCore.*Rework*</c> helpers with an explicit
+    /// <see cref="Undo.UndoData"/> committed via
+    /// <see cref="UndoService.CommitExternal"/>.
+    /// </summary>
     public partial class ItemEffectivenessSkillSystemsReworkView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly ItemEffectivenessSkillSystemsReworkViewModel _vm = new();
+        readonly UndoService _undoService = new();
+
+        readonly ObservableCollection<AddressListItem> _innerDisplay = new();
+        List<AddrResult> _innerData = new();
+
+        readonly ObservableCollection<AddressListItem> _sharedDisplay = new();
+        List<AddrResult> _sharedData = new();
+
+        bool _suppressFieldEvents;
 
         public string ViewTitle => "Effectiveness (Skill Systems Rework)";
         public bool IsLoaded => _vm.IsLoaded;
@@ -25,6 +52,8 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
+            InnerList.ItemsSource = _innerDisplay;
+            ItemListBox.ItemsSource = _sharedDisplay;
             Opened += (_, _) => LoadList();
         }
 
@@ -40,7 +69,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemEffectivenessSkillSystemsReworkView.LoadList failed: {0}", ex.Message);
+                Log.Error("ItemEffectivenessSkillSystemsReworkView.LoadList failed: " + ex.ToString());
             }
         }
 
@@ -49,17 +78,211 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 _vm.LoadEntry(addr);
+                ReloadInnerAndShared();
                 UpdateUI();
             }
             catch (Exception ex)
             {
-                Log.Error("ItemEffectivenessSkillSystemsReworkView.OnSelected failed: {0}", ex.Message);
+                Log.Error("ItemEffectivenessSkillSystemsReworkView.OnSelected failed: " + ex.ToString());
             }
+        }
+
+        void ReloadInnerAndShared()
+        {
+            // Effective-against class-type list.
+            _innerData = _vm.LoadInnerEntries();
+            _innerDisplay.Clear();
+            foreach (var e in _innerData)
+                _innerDisplay.Add(new AddressListItem { Text = e.name });
+
+            // Items sharing this effectiveness array.
+            _sharedData = _vm.LoadSharedOwners();
+            _sharedDisplay.Clear();
+            for (int i = 0; i < _sharedData.Count; i++)
+            {
+                var bmp = ListIconLoaders.ItemIconLoader(_sharedData, i);
+                _sharedDisplay.Add(new AddressListItem { Text = _sharedData[i].name, Icon = bmp });
+            }
+            IndependencePanel.IsVisible = _vm.HasSharedOwners;
+
+            if (_innerDisplay.Count > 0)
+            {
+                InnerList.SelectedIndex = 0;
+            }
+            else
+            {
+                _vm.CurrentEntryAddr = 0;
+                _vm.Coefficient = 0;
+                _vm.ClassType = 0;
+                _vm.ClassTypeNames = "";
+                UpdateRightPanel();
+            }
+        }
+
+        void InnerList_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            int idx = InnerList.SelectedIndex;
+            if (idx < 0 || idx >= _innerData.Count) return;
+            _vm.LoadEntryFields(_innerData[idx].addr);
+            UpdateRightPanel();
+        }
+
+        void ItemListBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            int idx = ItemListBox.SelectedIndex;
+            if (idx < 0 || idx >= _sharedData.Count) return;
+            // Jump the outer list to the picked owner's effectiveness array.
+            EntryList.SelectAddress(_vm.CurrentAddr);
         }
 
         void UpdateUI()
         {
             AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            SelectAddressLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+        }
+
+        void UpdateRightPanel()
+        {
+            _suppressFieldEvents = true;
+            try
+            {
+                EntryAddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentEntryAddr);
+                CoefficientBox.Value = _vm.Coefficient;
+                ClassTypeBox.Text = string.Format("0x{0:X04}", _vm.ClassType);
+                ClassTypeNamesLabel.Text = _vm.ClassTypeNames;
+            }
+            finally
+            {
+                _suppressFieldEvents = false;
+            }
+        }
+
+        void ClassType_TextChanged(object? sender, TextChangedEventArgs e)
+        {
+            if (_suppressFieldEvents) return;
+            if (TryParseHex(ClassTypeBox.Text, out uint v))
+            {
+                _vm.ClassType = v;
+                // Live-decode the bitmask names so the user sees the effect.
+                ClassTypeNamesLabel.Text = ClassTypeDisplay(v);
+            }
+        }
+
+        void Write_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (_vm.CurrentEntryAddr == 0)
+                {
+                    CoreState.Services?.ShowError(R._("No effectiveness entry selected."));
+                    return;
+                }
+                if (!TryParseHex(ClassTypeBox.Text, out uint classType))
+                {
+                    CoreState.Services?.ShowError(R._("Class Type must be a valid hex value."));
+                    return;
+                }
+                _vm.Coefficient = (uint)(CoefficientBox.Value ?? 0);
+                _vm.ClassType = classType;
+
+                var undo = CoreState.Undo?.NewUndoData(this, "Edit Item Effectiveness Rework");
+                if (undo == null)
+                {
+                    CoreState.Services?.ShowError(R._("Undo manager unavailable."));
+                    return;
+                }
+                _vm.WriteCurrentEntry(undo);
+                _undoService.CommitExternal(undo);
+
+                _vm.MarkClean();
+                ReloadInnerAndShared();
+                CoreState.Services?.ShowInfo(R._("Item Effectiveness data written."));
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ItemEffectivenessSkillSystemsReworkView.Write_Click failed: " + ex.ToString());
+                CoreState.Services?.ShowError(R._("Write failed: ") + ex.Message);
+            }
+        }
+
+        void ListExpands_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (_vm.CurrentItemAddr == 0)
+                {
+                    CoreState.Services?.ShowError(R._("No item owns this effectiveness list."));
+                    return;
+                }
+                var undo = CoreState.Undo?.NewUndoData(this, "Expand Item Effectiveness Rework");
+                if (undo == null)
+                {
+                    CoreState.Services?.ShowError(R._("Undo manager unavailable."));
+                    return;
+                }
+                _vm.ExpandCurrentList(undo);
+                _undoService.CommitExternal(undo);
+                CoreState.Services?.ShowInfo(R._("Added a new class slot."));
+                // The pointer moved; re-resolve and reload from the new array.
+                _vm.LoadEntry(_vm.CurrentAddr);
+                ReloadInnerAndShared();
+                UpdateUI();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ItemEffectivenessSkillSystemsReworkView.ListExpands_Click failed: " + ex.ToString());
+                CoreState.Services?.ShowError(R._("Expand failed: ") + ex.Message);
+            }
+        }
+
+        void Independence_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (_vm.CurrentItemAddr == 0)
+                {
+                    CoreState.Services?.ShowError(R._("No item owns this effectiveness list."));
+                    return;
+                }
+                var undo = CoreState.Undo?.NewUndoData(this, "Independence Item Effectiveness Rework");
+                if (undo == null)
+                {
+                    CoreState.Services?.ShowError(R._("Undo manager unavailable."));
+                    return;
+                }
+                _vm.MakeCurrentItemIndependent(undo);
+                _undoService.CommitExternal(undo);
+                CoreState.Services?.ShowInfo(R._("Item effectiveness array forked."));
+                _vm.LoadEntry(_vm.CurrentAddr);
+                ReloadInnerAndShared();
+                UpdateUI();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ItemEffectivenessSkillSystemsReworkView.Independence_Click failed: " + ex.ToString());
+                CoreState.Services?.ShowError(R._("Independence failed: ") + ex.Message);
+            }
+        }
+
+        static string ClassTypeDisplay(uint classType)
+        {
+            string raw = global::FEBuilderGBA.ItemClassListCore.GetClassTypeNames(classType);
+            if (string.IsNullOrEmpty(raw)) return "";
+            string[] keys = raw.Split(',');
+            for (int i = 0; i < keys.Length; i++)
+                keys[i] = R._(keys[i]);
+            return string.Join(",", keys);
+        }
+
+        static bool TryParseHex(string? text, out uint value)
+        {
+            value = 0;
+            if (string.IsNullOrWhiteSpace(text)) return false;
+            string s = text.Trim();
+            if (s.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ||
+                s.StartsWith("0X", StringComparison.Ordinal))
+                s = s.Substring(2);
+            return uint.TryParse(s, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out value);
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/ItemEffectivenessSkillSystemsReworkView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemEffectivenessSkillSystemsReworkView.axaml.cs
@@ -78,6 +78,12 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 _vm.LoadEntry(addr);
+                // The outer list can hold multiple rows that share one
+                // effectiveness array (same addr, different item). Pin the
+                // current item to the actually-selected row's ID so Expand /
+                // Make-Independent act on it, not on the first owner.
+                var sel = EntryList.SelectedItem;
+                if (sel != null) _vm.SetCurrentItemById(sel.tag);
                 ReloadInnerAndShared();
                 UpdateUI();
             }
@@ -131,8 +137,11 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             int idx = ItemListBox.SelectedIndex;
             if (idx < 0 || idx >= _sharedData.Count) return;
-            // Jump the outer list to the picked owner's effectiveness array.
-            EntryList.SelectAddress(_vm.CurrentAddr);
+            // Jump the outer list to the picked owner BY ITEM ID. Rows sharing
+            // this effectiveness array have the same addr, so SelectAddress would
+            // just re-pick the first owner; SelectByTag highlights the actual
+            // owner and re-fires OnSelected, which pins CurrentItemAddr to it.
+            EntryList.SelectByTag(_sharedData[idx].tag);
         }
 
         void UpdateUI()

--- a/FEBuilderGBA.Core.Tests/ItemClassListCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ItemClassListCoreTests.cs
@@ -430,6 +430,188 @@ namespace FEBuilderGBA.Core.Tests
             }
         }
 
+        // =====================================================================
+        // SkillSystems "Effectiveness Rework" (4-byte entries) — issue #1175
+        // =====================================================================
+
+        // Build a 4-byte rework entry [0, coeff, classtype_lo, classtype_hi].
+        static void WriteReworkEntryBytes(byte[] data, int off, byte coeff, ushort classType)
+        {
+            data[off + 0] = 0;
+            data[off + 1] = coeff;
+            data[off + 2] = (byte)(classType & 0xFF);
+            data[off + 3] = (byte)((classType >> 8) & 0xFF);
+        }
+
+        [Fact]
+        public void ScanReworkEntries_EmptyOnZeroAddress()
+        {
+            byte[] data = new byte[64];
+            WriteReworkEntryBytes(data, 0, 6, 0x01);
+            var rom = MakeRom(data);
+            var list = ItemClassListCore.ScanReworkEntries(rom, baseAddr: 0);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void ScanReworkEntries_TerminatesOnU32Zero()
+        {
+            // Two valid 4-byte entries at offset 8, terminated by a u32==0.
+            byte[] data = new byte[64];
+            WriteReworkEntryBytes(data, 8, 6, 0x01);   // armor, coeff 6
+            WriteReworkEntryBytes(data, 12, 4, 0x02);  // cavalry, coeff 4
+            // data[16..19] stay 0 → terminator.
+            WriteReworkEntryBytes(data, 20, 8, 0x04);  // beyond terminator — must NOT appear
+
+            var rom = MakeRom(data);
+            var list = ItemClassListCore.ScanReworkEntries(rom, baseAddr: 8);
+            Assert.Equal(2, list.Count);
+            Assert.Equal(8u, list[0].Addr);
+            Assert.Equal(6u, list[0].Coefficient);
+            Assert.Equal(0x01u, list[0].ClassType);
+            Assert.Equal(12u, list[1].Addr);
+            Assert.Equal(4u, list[1].Coefficient);
+            Assert.Equal(0x02u, list[1].ClassType);
+        }
+
+        [Fact]
+        public void WriteReworkEntry_UpdatesCoeffAndClassType_KeepsLeadingZero()
+        {
+            byte[] data = new byte[32];
+            // Pre-seed a non-zero leading byte to prove WriteReworkEntry clears it.
+            data[4] = 0x99;
+            var rom = MakeRom(data);
+            var prev = CoreState.ROM;
+            CoreState.ROM = rom;
+            try
+            {
+                var undo = new Undo.UndoData
+                {
+                    name = "test",
+                    list = new List<Undo.UndoPostion>(),
+                    filesize = (uint)rom.Data.Length,
+                };
+                ItemClassListCore.WriteReworkEntry(rom, addr: 4, coefficient: 6, classType: 0x21, undo: undo);
+
+                Assert.Equal(0x00, rom.Data[4]);             // leading byte forced to 0
+                Assert.Equal(0x06, rom.Data[5]);             // coefficient
+                Assert.Equal(0x21u, rom.u16(6));             // class-type u16
+                Assert.True(undo.list.Count >= 1);           // writes recorded
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+            }
+        }
+
+        [Fact]
+        public void ExpandReworkList_AppendsEntryBeforeTerminator_PreservesOldBytes()
+        {
+            byte[] data = new byte[1024];
+            for (int i = 0; i < data.Length; i++) data[i] = 0xFF; // free
+            // One rework entry at offset 64 (armor coeff 6) + u32==0 terminator.
+            WriteReworkEntryBytes(data, 64, 6, 0x01);
+            data[68] = data[69] = data[70] = data[71] = 0; // terminator
+            uint origPtr = 64u | 0x08000000u;
+            for (int i = 0; i < 4; i++) data[i] = (byte)((origPtr >> (i * 8)) & 0xFF);
+
+            var rom = MakeRom(data);
+            var prev = CoreState.ROM;
+            CoreState.ROM = rom;
+            try
+            {
+                var undo = new Undo.UndoData
+                {
+                    name = "test",
+                    list = new List<Undo.UndoPostion>(),
+                    filesize = (uint)rom.Data.Length,
+                };
+
+                uint newBase = ItemClassListCore.ExpandReworkList(rom, pointerAddr: 0, undo: undo);
+                Assert.NotEqual(U.NOT_FOUND, newBase);
+                Assert.NotEqual(64u, newBase); // relocated
+
+                // Pointer updated.
+                Assert.Equal(newBase | 0x08000000u, rom.u32(0));
+
+                // New array has 2 entries: the original armor + the appended one.
+                var scanned = ItemClassListCore.ScanReworkEntries(rom, newBase);
+                Assert.Equal(2, scanned.Count);
+                Assert.Equal(0x01u, scanned[0].ClassType);
+                Assert.Equal(ItemClassListCore.ReworkNewSlotClassType, scanned[1].ClassType);
+                Assert.Equal(ItemClassListCore.ReworkNewSlotCoefficient, scanned[1].Coefficient);
+
+                // Old bytes intact (shared-array safety).
+                Assert.Equal(0x00, rom.Data[64]);
+                Assert.Equal(0x06, rom.Data[65]);
+                Assert.Equal(0x01, rom.Data[66]);
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+            }
+        }
+
+        [Fact]
+        public void MakeIndependentReworkCopy_DuplicatesAndRepointsOwnerOnly()
+        {
+            byte[] data = new byte[1024];
+            for (int i = 0; i < data.Length; i++) data[i] = 0xFF;
+            // Shared rework array at offset 96: armor + cavalry + terminator.
+            WriteReworkEntryBytes(data, 96, 6, 0x01);
+            WriteReworkEntryBytes(data, 100, 6, 0x02);
+            data[104] = data[105] = data[106] = data[107] = 0; // terminator
+            uint sharedPtr = 96u | 0x08000000u;
+            for (int i = 0; i < 4; i++)
+            {
+                data[0 + i] = (byte)((sharedPtr >> (i * 8)) & 0xFF); // owner A
+                data[8 + i] = (byte)((sharedPtr >> (i * 8)) & 0xFF); // owner B
+            }
+
+            var rom = MakeRom(data);
+            var prev = CoreState.ROM;
+            CoreState.ROM = rom;
+            try
+            {
+                var undo = new Undo.UndoData
+                {
+                    name = "test",
+                    list = new List<Undo.UndoPostion>(),
+                    filesize = (uint)rom.Data.Length,
+                };
+
+                uint newBase = ItemClassListCore.MakeIndependentReworkCopy(rom, sourceAddr: 96, ownerPointerAddr: 0, undo: undo);
+                Assert.NotEqual(U.NOT_FOUND, newBase);
+                Assert.NotEqual(96u, newBase);
+
+                // Owner A repointed; owner B still shares the original.
+                Assert.Equal(newBase | 0x08000000u, rom.u32(0));
+                Assert.Equal(sharedPtr, rom.u32(8));
+
+                // New copy has the same two entries.
+                var copy = ItemClassListCore.ScanReworkEntries(rom, newBase);
+                Assert.Equal(2, copy.Count);
+                Assert.Equal(0x01u, copy[0].ClassType);
+                Assert.Equal(0x02u, copy[1].ClassType);
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+            }
+        }
+
+        [Theory]
+        [InlineData(0x00u, "")]
+        [InlineData(0x01u, "Armor")]
+        [InlineData(0x02u, "Cavalry")]
+        [InlineData(0x03u, "Armor,Cavalry")]
+        [InlineData(0x24u, "Flying,Sword")] // 0x04 flying + 0x20 sword
+        [InlineData(0xC0u, "Unknown1,Unknown2")]
+        public void GetClassTypeNames_DecodesBitmask(uint classType, string expected)
+        {
+            Assert.Equal(expected, ItemClassListCore.GetClassTypeNames(classType));
+        }
+
         // ---------------------------------------------------------------------
         // Helpers
         // ---------------------------------------------------------------------

--- a/FEBuilderGBA.Core.Tests/ItemClassListCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ItemClassListCoreTests.cs
@@ -593,11 +593,139 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.Equal(2, copy.Count);
                 Assert.Equal(0x01u, copy[0].ClassType);
                 Assert.Equal(0x02u, copy[1].ClassType);
+
+                // Copy-on-write: owner B's scan of the ORIGINAL array is byte-for-
+                // byte untouched (not relocated, not corrupted).
+                var ownerB = ItemClassListCore.ScanReworkEntries(rom, 96);
+                Assert.Equal(2, ownerB.Count);
+                Assert.Equal(0x01u, ownerB[0].ClassType);
+                Assert.Equal(6u, ownerB[0].Coefficient);
+                Assert.Equal(0x02u, ownerB[1].ClassType);
+                Assert.Equal(6u, ownerB[1].Coefficient);
             }
             finally
             {
                 CoreState.ROM = prev;
             }
+        }
+
+        [Fact]
+        public void ScanWriteScan_RoundTrips()
+        {
+            // scan → write → scan round-trip on the Core methods directly.
+            byte[] data = new byte[256];
+            WriteReworkEntryBytes(data, 32, 6, 0x01); // armor, coeff 6
+            WriteReworkEntryBytes(data, 36, 4, 0x08); // dragon, coeff 4
+            data[40] = data[41] = data[42] = data[43] = 0; // terminator
+
+            var rom = MakeRom(data);
+            var prev = CoreState.ROM;
+            CoreState.ROM = rom;
+            try
+            {
+                var before = ItemClassListCore.ScanReworkEntries(rom, 32);
+                Assert.Equal(2, before.Count);
+                Assert.Equal(0x01u, before[0].ClassType);
+                Assert.Equal(0x08u, before[1].ClassType);
+
+                var undo = new Undo.UndoData
+                {
+                    name = "test",
+                    list = new List<Undo.UndoPostion>(),
+                    filesize = (uint)rom.Data.Length,
+                };
+                // Rewrite the second entry: dragon coeff4 → flying+sword coeff 8.
+                ItemClassListCore.WriteReworkEntry(rom, before[1].Addr, coefficient: 8, classType: 0x24, undo: undo);
+
+                var after = ItemClassListCore.ScanReworkEntries(rom, 32);
+                Assert.Equal(2, after.Count);                 // count unchanged
+                Assert.Equal(0x01u, after[0].ClassType);      // first entry intact
+                Assert.Equal(6u, after[0].Coefficient);
+                Assert.Equal(0x24u, after[1].ClassType);      // second entry updated
+                Assert.Equal(8u, after[1].Coefficient);
+                Assert.Equal(0x00, rom.Data[36]);             // leading byte still 0
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+            }
+        }
+
+        [Fact]
+        public void ExpandReworkList_OnSharedArray_OtherOwnerUnchanged()
+        {
+            // Copy-on-write for Expand: owner A grows its shared array; owner B's
+            // scan still shows the ORIGINAL list (relocated array is A-only).
+            byte[] data = new byte[1024];
+            for (int i = 0; i < data.Length; i++) data[i] = 0xFF;
+            WriteReworkEntryBytes(data, 128, 6, 0x01); // armor
+            data[132] = data[133] = data[134] = data[135] = 0; // terminator
+            uint sharedPtr = 128u | 0x08000000u;
+            for (int i = 0; i < 4; i++)
+            {
+                data[0 + i] = (byte)((sharedPtr >> (i * 8)) & 0xFF); // owner A
+                data[8 + i] = (byte)((sharedPtr >> (i * 8)) & 0xFF); // owner B
+            }
+
+            var rom = MakeRom(data);
+            var prev = CoreState.ROM;
+            CoreState.ROM = rom;
+            try
+            {
+                var undo = new Undo.UndoData
+                {
+                    name = "test",
+                    list = new List<Undo.UndoPostion>(),
+                    filesize = (uint)rom.Data.Length,
+                };
+
+                uint newBaseA = ItemClassListCore.ExpandReworkList(rom, pointerAddr: 0, undo: undo);
+
+                // Owner A grew to 2 entries (armor + placeholder).
+                var scanA = ItemClassListCore.ScanReworkEntries(rom, newBaseA);
+                Assert.Equal(2, scanA.Count);
+                Assert.Equal(0x01u, scanA[0].ClassType);
+
+                // Owner B's pointer is unchanged and its scan still shows ONLY
+                // the original single armor entry.
+                Assert.Equal(sharedPtr, rom.u32(8));
+                var scanB = ItemClassListCore.ScanReworkEntries(rom, 128);
+                Assert.Single(scanB);
+                Assert.Equal(0x01u, scanB[0].ClassType);
+                Assert.Equal(6u, scanB[0].Coefficient);
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+            }
+        }
+
+        [Fact]
+        public void ScanReworkEntries_ReadsBuildEffectivenessTemplateLayout()
+        {
+            // Seed the array exactly the way ItemAllocCore.BuildEffectivenessTemplate
+            // (skillSystemsRework: true) does — zero-filled 12 bytes with
+            // [1]=6,[2]=1 (armor coeff6) and [5]=6,[6]=2 (cavalry coeff6) — so the
+            // test data matches the real on-ROM layout. The 12-byte template is
+            // three 4-byte slots: [armor][cavalry][terminator].
+            byte[] template = ItemAllocCore.BuildEffectivenessTemplate(skillSystemsRework: true);
+            Assert.Equal(12, template.Length);
+
+            byte[] data = new byte[64];
+            // Place the template at a non-zero offset so the null-pointer guard
+            // does not short-circuit.
+            const int baseOff = 16;
+            for (int i = 0; i < template.Length; i++) data[baseOff + i] = template[i];
+
+            var rom = MakeRom(data);
+            var list = ItemClassListCore.ScanReworkEntries(rom, baseOff);
+            Assert.Equal(2, list.Count);
+            Assert.Equal(0x01u, list[0].ClassType); // armor
+            Assert.Equal(6u, list[0].Coefficient);
+            Assert.Equal(0x02u, list[1].ClassType); // cavalry
+            Assert.Equal(6u, list[1].Coefficient);
+            Assert.Equal("Armor", ItemClassListCore.GetClassTypeNames(list[0].ClassType));
+            Assert.Equal("Cavalry", ItemClassListCore.GetClassTypeNames(list[1].ClassType));
         }
 
         [Theory]

--- a/FEBuilderGBA.Core/ItemClassListCore.cs
+++ b/FEBuilderGBA.Core/ItemClassListCore.cs
@@ -238,5 +238,251 @@ namespace FEBuilderGBA
 
             return newBase;
         }
+
+        // =====================================================================
+        // SkillSystems "Effectiveness Rework" format (issue #1175)
+        //
+        // The classic single-byte methods above back the non-rework
+        // ItemEffectivenessForm / ItemPromotionForm (issue #368). The FE8U
+        // SkillSystems 特効リワーク variant
+        // (ItemEffectivenessSkillSystemsReworkForm) stores a DIFFERENT layout:
+        // a null-(u32)-terminated array of 4-byte entries
+        //   [0]=00, [1]=coefficient*2, [2..3]=class-type (u16 bitmask).
+        // Termination follows WinForms N_Init: an entry counts while its
+        // leading u8 is 0 AND its u32 is non-zero; the first u32==0 ends the
+        // list. Confirmed by ItemAllocCore.BuildEffectivenessTemplate(true)
+        // (zero-filled 4-byte stride seeded [1]=6,[2]=1 armor / [5]=6,[6]=2
+        // cavalry).
+        //
+        // The class-type field is the same bitmask the WinForms
+        // SkillSystemsEffectivenessReworkClassTypeForm edits
+        // (armor/cavalry/flying/dragon/monster/sword/unknown1/unknown2).
+        // =====================================================================
+
+        /// <summary>Stride, in bytes, of one Rework effectiveness entry.</summary>
+        public const uint ReworkEntrySize = 4;
+
+        /// <summary>
+        /// One decoded SkillSystems-Rework effectiveness entry. <see cref="Addr"/>
+        /// is the ROM offset of the 4-byte record; <see cref="Coefficient"/> is
+        /// the raw +1 byte (the WinForms label is "coefficient_times*2"); and
+        /// <see cref="ClassType"/> is the u16 class-type bitmask at +2.
+        /// </summary>
+        public readonly struct ReworkEntry
+        {
+            public ReworkEntry(uint addr, uint coefficient, uint classType)
+            {
+                Addr = addr;
+                Coefficient = coefficient;
+                ClassType = classType;
+            }
+            public uint Addr { get; }
+            public uint Coefficient { get; }
+            public uint ClassType { get; }
+        }
+
+        /// <summary>
+        /// Scan the null-(u32)-terminated array of 4-byte Rework entries
+        /// starting at <paramref name="baseAddr"/>. Mirrors WinForms
+        /// <c>ItemEffectivenessSkillSystemsReworkForm.N_Init</c>: an entry is
+        /// valid while its leading u8 is 0 AND its u32 is non-zero; the first
+        /// u32==0 ends the list. Returns an empty list if
+        /// <paramref name="baseAddr"/> is zero, beyond the ROM, or not even
+        /// room for one entry.
+        /// </summary>
+        public static List<ReworkEntry> ScanReworkEntries(ROM rom, uint baseAddr)
+        {
+            var result = new List<ReworkEntry>();
+            if (rom == null || rom.Data == null) return result;
+            // Address 0 is a null pointer (same convention as ScanClassList).
+            if (baseAddr == 0) return result;
+            if (baseAddr >= (uint)rom.Data.Length) return result;
+
+            for (uint i = 0; i < 0x200; i++)
+            {
+                uint a = baseAddr + i * ReworkEntrySize;
+                // Need a full 4-byte record to read the entry + its terminator.
+                if (a + ReworkEntrySize > (uint)rom.Data.Length) break;
+                // WinForms N_Init termination: leading byte must be 0 and the
+                // u32 must be non-zero. The first u32==0 (the terminator) ends
+                // the scan; a non-zero leading byte is also treated as the end
+                // (defensive — the data should never have one).
+                if (rom.u8(a) != 0) break;
+                if (rom.u32(a) == 0) break;
+                result.Add(new ReworkEntry(a, rom.u8(a + 1), rom.u16(a + 2)));
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Write one Rework entry (the +1 coefficient byte and the +2 u16
+        /// class-type) at <paramref name="addr"/>, leaving the leading 0 byte
+        /// intact. Records the writes on <paramref name="undo"/>.
+        /// </summary>
+        public static void WriteReworkEntry(ROM rom, uint addr, uint coefficient, uint classType, Undo.UndoData undo)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (undo == null) throw new ArgumentNullException(nameof(undo));
+            if (addr + ReworkEntrySize > (uint)rom.Data.Length)
+                throw new ArgumentOutOfRangeException(nameof(addr), "Address is out of ROM bounds.");
+            // Keep the leading byte at 0 (the format's record marker) so the
+            // entry survives the ScanReworkEntries termination check.
+            rom.write_u8(addr, 0u, undo);
+            rom.write_u8(addr + 1, coefficient & 0xFFu, undo);
+            rom.write_u16(addr + 2, classType & 0xFFFFu, undo);
+        }
+
+        /// <summary>
+        /// Expand the null-(u32)-terminated Rework array referenced by
+        /// <paramref name="pointerAddr"/> by one entry. Relocates the existing
+        /// entries to free space, appends a new editable entry (leading 0,
+        /// coefficient = <see cref="ReworkNewSlotCoefficient"/>, class-type =
+        /// <see cref="ReworkNewSlotClassType"/> so the new entry survives the
+        /// terminator scan and is visible to the UI), writes a u32==0
+        /// terminator, and repoints only the owning pointer. The original bytes
+        /// are intentionally LEFT INTACT so other owners that still point at the
+        /// old array keep working (copy-on-write, mirroring
+        /// <see cref="ExpandClassList"/>).
+        /// </summary>
+        /// <returns>The new array base offset.</returns>
+        public static uint ExpandReworkList(ROM rom, uint pointerAddr, Undo.UndoData undo)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (undo == null) throw new ArgumentNullException(nameof(undo));
+            if (pointerAddr + 4 > (uint)rom.Data.Length)
+                throw new ArgumentOutOfRangeException(nameof(pointerAddr));
+
+            uint oldPtr = rom.u32(pointerAddr);
+            if (!U.isPointer(oldPtr))
+                throw new InvalidOperationException("Owner pointer does not reference a ROM address.");
+
+            uint oldBase = U.toOffset(oldPtr);
+            if (oldBase >= (uint)rom.Data.Length)
+                throw new InvalidOperationException("Owner pointer references an out-of-range address.");
+
+            var oldList = ScanReworkEntries(rom, oldBase);
+            uint oldCount = (uint)oldList.Count;
+
+            // New layout: oldCount entries + 1 new entry + 1 terminator (u32 0).
+            uint newSize = (oldCount + 1) * ReworkEntrySize + ReworkEntrySize;
+            uint newBase = rom.FindFreeSpace(oldBase, newSize);
+            if (newBase == U.NOT_FOUND)
+                newBase = rom.FindFreeSpace(0x100, newSize);
+            if (newBase == U.NOT_FOUND)
+                throw new InvalidOperationException("No free space large enough to expand rework list.");
+
+            // Copy the relocated entries.
+            for (uint i = 0; i < oldCount; i++)
+            {
+                uint dst = newBase + i * ReworkEntrySize;
+                rom.write_u8(dst, 0u, undo);
+                rom.write_u8(dst + 1, oldList[(int)i].Coefficient & 0xFFu, undo);
+                rom.write_u16(dst + 2, oldList[(int)i].ClassType & 0xFFFFu, undo);
+            }
+            // Append the new editable entry (non-zero so it is visible).
+            uint newEntry = newBase + oldCount * ReworkEntrySize;
+            rom.write_u8(newEntry, 0u, undo);
+            rom.write_u8(newEntry + 1, ReworkNewSlotCoefficient, undo);
+            rom.write_u16(newEntry + 2, ReworkNewSlotClassType, undo);
+            // Write the trailing u32==0 terminator.
+            uint term = newEntry + ReworkEntrySize;
+            rom.write_u32(term, 0u, undo);
+
+            // Repoint only the requested owner.
+            rom.write_p32(pointerAddr, newBase, undo);
+
+            // INTENTIONAL: leave the old bytes intact (shared-array safety).
+            return newBase;
+        }
+
+        /// <summary>
+        /// Fork the null-(u32)-terminated Rework array at
+        /// <paramref name="sourceAddr"/> into an independent copy and repoint
+        /// only <paramref name="ownerPointerAddr"/>. Leaves the original bytes
+        /// untouched so other owners keep working. Mirrors
+        /// <see cref="MakeIndependentCopy"/> for the 4-byte Rework format.
+        /// </summary>
+        /// <returns>The new array base offset.</returns>
+        public static uint MakeIndependentReworkCopy(ROM rom, uint sourceAddr, uint ownerPointerAddr, Undo.UndoData undo)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (undo == null) throw new ArgumentNullException(nameof(undo));
+            if (ownerPointerAddr + 4 > (uint)rom.Data.Length)
+                throw new ArgumentOutOfRangeException(nameof(ownerPointerAddr));
+            if (sourceAddr >= (uint)rom.Data.Length)
+                throw new ArgumentOutOfRangeException(nameof(sourceAddr));
+
+            var list = ScanReworkEntries(rom, sourceAddr);
+            uint count = (uint)list.Count;
+
+            // New copy: count entries + 1 terminator (u32 0).
+            uint newSize = count * ReworkEntrySize + ReworkEntrySize;
+            uint newBase = rom.FindFreeSpace(sourceAddr, newSize);
+            if (newBase == U.NOT_FOUND)
+                newBase = rom.FindFreeSpace(0x100, newSize);
+            if (newBase == U.NOT_FOUND)
+                throw new InvalidOperationException("No free space large enough to fork rework list.");
+
+            for (uint i = 0; i < count; i++)
+            {
+                uint dst = newBase + i * ReworkEntrySize;
+                rom.write_u8(dst, 0u, undo);
+                rom.write_u8(dst + 1, list[(int)i].Coefficient & 0xFFu, undo);
+                rom.write_u16(dst + 2, list[(int)i].ClassType & 0xFFFFu, undo);
+            }
+            rom.write_u32(newBase + count * ReworkEntrySize, 0u, undo); // terminator
+
+            rom.write_p32(ownerPointerAddr, newBase, undo);
+            return newBase;
+        }
+
+        /// <summary>
+        /// Coefficient byte written into a new entry by
+        /// <see cref="ExpandReworkList"/>. 6 == "x3" effectiveness in the
+        /// SkillSystems rework (coefficient_times*2), matching the armor/cavalry
+        /// seed in <c>ItemAllocCore.BuildEffectivenessTemplate(true)</c>.
+        /// </summary>
+        public const uint ReworkNewSlotCoefficient = 6;
+
+        /// <summary>
+        /// Class-type bitmask written into a new entry by
+        /// <see cref="ExpandReworkList"/>. 0x01 == armor — a recognizable,
+        /// non-zero default so the new entry survives the terminator scan and
+        /// is immediately visible/editable.
+        /// </summary>
+        public const uint ReworkNewSlotClassType = 0x01;
+
+        // Class-type bit → name table (matches WinForms
+        // SkillSystemsEffectivenessReworkClassTypeForm.GetText). The display
+        // strings are localized at the Avalonia layer; Core returns the
+        // canonical English keys so the UI can run them through R._().
+        static readonly (uint Bit, string Key)[] ReworkClassTypeBits =
+        {
+            (0x01, "Armor"),
+            (0x02, "Cavalry"),
+            (0x04, "Flying"),
+            (0x08, "Dragon"),
+            (0x10, "Monster"),
+            (0x20, "Sword"),
+            (0x40, "Unknown1"),
+            (0x80, "Unknown2"),
+        };
+
+        /// <summary>
+        /// Decode a Rework class-type bitmask into its set bit names (English
+        /// keys, comma-joined), mirroring WinForms
+        /// <c>SkillSystemsEffectivenessReworkClassTypeForm.GetText</c>. Returns
+        /// an empty string when no known bit is set. The Avalonia layer runs
+        /// each key through <c>R._()</c> for localization.
+        /// </summary>
+        public static string GetClassTypeNames(uint classType)
+        {
+            var parts = new List<string>();
+            foreach (var (bit, key) in ReworkClassTypeBits)
+            {
+                if ((classType & bit) == bit) parts.Add(key);
+            }
+            return string.Join(",", parts);
+        }
     }
 }

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11855,3 +11855,66 @@ config/translate/<lang>.txt
 :Each row is a map whose world-map event PLIST is set. The address points to the map-pointer table slot the PLIST indexes.
 各行はワールドマップイベントPLISTが設定されたマップです。アドレスはPLISTが指すマップポインタテーブルのスロットを指します。
 
+:Weapon effectiveness class-type list (per item)
+武器の特効クラス分類リスト（アイテムごと）
+
+:Entry Address:
+エントリアドレス:
+
+:Coefficient (x2):
+係数（x2）:
+
+:Armor
+アーマー系
+
+:Cavalry
+騎兵系
+
+:Flying
+飛行系
+
+:Dragon
+ドラゴン系
+
+:Monster
+モンスター系
+
+:Sword
+ソード系
+
+:Unknown1
+不明1
+
+:Unknown2
+不明2
+
+:No effectiveness entry selected.
+特効エントリが選択されていません。
+
+:Class Type must be a valid hex value.
+クラス分類は有効な16進数値である必要があります。
+
+:Undo manager unavailable.
+アンドゥマネージャが利用できません。
+
+:Item Effectiveness data written.
+アイテムの特効データを書き込みました。
+
+:Write failed: 
+書き込みに失敗しました: 
+
+:No item owns this effectiveness list.
+この特効リストを所有するアイテムがありません。
+
+:Added a new class slot.
+新しいクラススロットを追加しました。
+
+:Expand failed: 
+拡張に失敗しました: 
+
+:Item effectiveness array forked.
+アイテムの特効配列を分離しました。
+
+:Independence failed: 
+分離独立に失敗しました: 
+

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25696,3 +25696,66 @@ config/translate/<lang>.txt
 :Each row is a map whose world-map event PLIST is set. The address points to the map-pointer table slot the PLIST indexes.
 每行是设置了世界地图事件PLIST的地图。地址指向PLIST索引的地图指针表槽位。
 
+:Weapon effectiveness class-type list (per item)
+武器特效职业分类列表（每个物品）
+
+:Entry Address:
+条目地址:
+
+:Coefficient (x2):
+系数（x2）:
+
+:Armor
+装甲系
+
+:Cavalry
+骑兵系
+
+:Flying
+飞行系
+
+:Dragon
+龙系
+
+:Monster
+怪物系
+
+:Sword
+剑系
+
+:Unknown1
+未知1
+
+:Unknown2
+未知2
+
+:No effectiveness entry selected.
+未选择特效条目。
+
+:Class Type must be a valid hex value.
+职业分类必须是有效的十六进制值。
+
+:Undo manager unavailable.
+撤销管理器不可用。
+
+:Item Effectiveness data written.
+已写入物品特效数据。
+
+:Write failed: 
+写入失败: 
+
+:No item owns this effectiveness list.
+没有物品拥有此特效列表。
+
+:Added a new class slot.
+已添加新的职业槽位。
+
+:Expand failed: 
+扩展失败: 
+
+:Item effectiveness array forked.
+已分离物品特效数组。
+
+:Independence failed: 
+独立化失败: 
+


### PR DESCRIPTION
## Summary
Completes the **Item Effectiveness (SkillSystems Rework)** editor (#1175) to parity with WinForms `ItemEffectivenessSkillSystemsReworkForm`. The outer item list + navigation already worked; this wires the right pane, which previously showed only the address.

**Data-format correction:** the brief initially suggested reusing the classic single-byte `ScanClassList`/`WriteClassByte` (the `ItemEffectivenessForm`/`ItemPromotionForm` format, #368). But the SkillSystems-Rework table is a **different on-ROM layout** — 4-byte stride, `u32==0` terminator (leading `u8==0` guard), with a **u16 class-type bitmask at +2** and a coefficient at +1 — verified against both `ItemEffectivenessSkillSystemsReworkForm.N_Init` and `ItemAllocCore.BuildEffectivenessTemplate(skillSystemsRework: true)`. Reusing the single-byte methods would terminate immediately on rework data and clobber the wrong byte. So this adds **rework-format** Core helpers alongside the untouched single-byte ones.

## Changes
- `ItemClassListCore.cs` (+246): `ScanReworkEntries` / `WriteReworkEntry` / `ExpandReworkList` / `MakeIndependentReworkCopy` (4-byte stride, u16 class-type, u32-zero terminator, copy-on-write) + `GetClassTypeNames` bitmask decoder. `FindItemsSharingPointer` reused unchanged. Existing single-byte methods untouched.
- ViewModel (+164): inner-entries / shared-owners / per-entry field load + write/expand/make-independent. Existing `LoadList`/`LoadEntry` (#362 jump path) untouched.
- View AXAML (+124) + code-behind (+227): right pane now shows the effective-against class-type list, the shared-items list (icons), a per-entry editor (coefficient NUD + class-type **hex TextBox**), and Write / Expand / Make-Independent buttons.
- Core.Tests (+182): 5 rework round-trip / terminator / expand / copy-on-write tests. Avalonia.Tests (new, +191): FE8U no-crash + 3 synthetic VM round-trips.
- `config/translate/{ja,zh}.txt` (+63 each): 21 new keys (literals + class-type names + messages).

All writes go through explicit `Undo.UndoData` + `UndoService.CommitExternal`.

## Tests (all run locally, all green)
- Core.Tests: **4361 passed**, 0 failed
- Avalonia.Tests: **8332 passed**, 0 failed (incl. L10nCoverageTest + NoOrphanVMs + the Jump tests + new edit tests)
- FEBuilderGBA.Tests (net9.0-windows): **1864 passed**, 0 failed (AvaloniaDarkModeTests + AvaloniaFieldCompletenessTests)
- validate-automation-ids.ps1: **0 errors / 0 warnings**

## Note on validation
The SkillSystems-Rework patch is absent from vanilla FE8U, so the **read/write round-trip is proven on synthetic ROMs** (Core.Tests + VM tests); the FE8U test asserts no-crash. Editor screenshot below.

Fixes #1175

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
