### PR TITLE
feat(avalonia): functional ROM Rebuild (analysis) tool (#1171)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ToolROMRebuildViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ToolROMRebuildViewModelTests.cs
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1171 — ROM Rebuild analysis tool (Avalonia port of WinForms ToolROMRebuildForm).
+// Tests the VM's address validation + validate-then-make report over Core RebuildCore.
+using System;
+using System.IO;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class ToolROMRebuildViewModelTests
+    {
+        [Fact]
+        public void ValidateRebuildAddress_NotAligned_ReturnsNotAligned()
+        {
+            var prevRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = null;   // no RomInfo -> only alignment/safety apply
+                var vm = new ToolROMRebuildViewModel();
+                Assert.Equal(ToolROMRebuildViewModel.AddressCheck.NotAligned, vm.ValidateRebuildAddress(0x09000001));
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void ValidateRebuildAddress_NullRom_ReturnsUnsafe()
+        {
+            var prevRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = null;   // no loaded ROM -> cannot judge safety
+                var vm = new ToolROMRebuildViewModel();
+                Assert.Equal(ToolROMRebuildViewModel.AddressCheck.Unsafe, vm.ValidateRebuildAddress(0x00000400));
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void ValidateRebuildAddress_Aligned_ReturnsOk_WhenNoRomInfo()
+        {
+            var prevRom = CoreState.ROM;
+            try
+            {
+                // In-memory ROM (no RomInfo). isSafetyOffset judges against ITS length, so
+                // pick an aligned offset that is >= 0x200 and < the ROM size.
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(new byte[0x4000]);
+                CoreState.ROM = rom;
+                var vm = new ToolROMRebuildViewModel();
+                Assert.Equal(ToolROMRebuildViewModel.AddressCheck.Ok, vm.ValidateRebuildAddress(0x00001000));
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void MakeRebuild_NoRom_ReturnsNoRom()
+        {
+            var prevRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = null;
+                var vm = new ToolROMRebuildViewModel();
+                Assert.Equal(ToolROMRebuildViewModel.MakeResult.NoRom, vm.MakeRebuild("x", 0x09000000, "y"));
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void MakeRebuild_MissingOriginal_ReturnsOriginalMissing()
+        {
+            var prevRom = CoreState.ROM;
+            try
+            {
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(new byte[0x100]);
+                CoreState.ROM = rom;
+                var vm = new ToolROMRebuildViewModel();
+                string missing = Path.Combine(Path.GetTempPath(), "feb_rb_missing_" + Guid.NewGuid().ToString("N") + ".gba");
+                Assert.Equal(ToolROMRebuildViewModel.MakeResult.OriginalMissing, vm.MakeRebuild(missing, 0x00000000, "out.rebuild"));
+            }
+            finally { CoreState.ROM = prevRom; }
+        }
+
+        [Fact]
+        public void MakeRebuild_BadAddress_ReturnsBadAddress()
+        {
+            var prevRom = CoreState.ROM;
+            string origPath = Path.Combine(Path.GetTempPath(), "feb_rb_orig_" + Guid.NewGuid().ToString("N") + ".gba");
+            try
+            {
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(new byte[0x400]);
+                CoreState.ROM = rom;
+                File.WriteAllBytes(origPath, new byte[0x400]);
+
+                var vm = new ToolROMRebuildViewModel();
+                // Misaligned address is a hard failure, checked before reading the original ROM.
+                Assert.Equal(ToolROMRebuildViewModel.MakeResult.BadAddress, vm.MakeRebuild(origPath, 0x09000001, "out.rebuild"));
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                try { File.Delete(origPath); } catch { }
+            }
+        }
+
+        [Fact]
+        public void MakeRebuild_WritesReport_WhenOriginalCrcSkipped()
+        {
+            // No RomInfo -> orignal_crc32 == 0 -> CRC check skipped (headless path).
+            var prevRom = CoreState.ROM;
+            string origPath = Path.Combine(Path.GetTempPath(), "feb_rb_orig2_" + Guid.NewGuid().ToString("N") + ".gba");
+            string outPath = Path.Combine(Path.GetTempPath(), "feb_rb_out_" + Guid.NewGuid().ToString("N") + ".rebuild");
+            try
+            {
+                byte[] cur = new byte[0x4000];
+                for (int i = 0; i < cur.Length; i++) cur[i] = (byte)(i & 0xFF);
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(cur);
+                CoreState.ROM = rom;
+
+                byte[] orig = (byte[])cur.Clone();
+                orig[0x40] ^= 0xFF;
+                File.WriteAllBytes(origPath, orig);
+
+                var vm = new ToolROMRebuildViewModel();
+                // Aligned, >= 0x200, < ROM length -> a safe offset for this in-memory ROM.
+                var r = vm.MakeRebuild(origPath, 0x00001000, outPath);
+                Assert.Equal(ToolROMRebuildViewModel.MakeResult.Ok, r);
+                Assert.True(File.Exists(outPath));
+                Assert.Contains("@_CRC32 ", File.ReadAllText(outPath));
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                try { File.Delete(origPath); } catch { }
+                try { File.Delete(outPath); } catch { }
+            }
+        }
+
+        [Fact]
+        public void SuggestedName_MirrorsWinFormsPrefix()
+        {
+            Assert.Equal("R.20260616123000.rebuild", ToolROMRebuildViewModel.SuggestedName("20260616123000"));
+        }
+    }
+
+    // Needs a real ROM so RomInfo.extends_address / orignal_crc32 are set; skips without ROMs.
+    [Collection("SharedState")]
+    public class ToolROMRebuildRomTests : IClassFixture<RomFixture>
+    {
+        readonly RomFixture _fixture;
+        readonly ITestOutputHelper _output;
+        public ToolROMRebuildRomTests(RomFixture fixture, ITestOutputHelper output)
+        { _fixture = fixture; _output = output; }
+
+        [Fact]
+        public void Load_DefaultsAddressToExtends_ForRealRom()
+        {
+            if (!_fixture.IsAvailable) { _output.WriteLine("SKIP: no ROM available"); return; }
+            var vm = new ToolROMRebuildViewModel();
+            bool ok = vm.Load();
+            Assert.True(ok);
+            uint expected = U.toOffset(CoreState.ROM.RomInfo.extends_address);
+            Assert.Equal(expected, vm.RebuildAddress);
+            Assert.Equal(expected, vm.DefaultRebuildAddress());
+        }
+
+        [Fact]
+        public void MakeRebuild_WrongOriginal_ReturnsOriginalNotMatching()
+        {
+            if (!_fixture.IsAvailable) { _output.WriteLine("SKIP: no ROM available"); return; }
+            string wrong = Path.Combine(Path.GetTempPath(), "feb_rb_wrong_" + Guid.NewGuid().ToString("N") + ".gba");
+            try
+            {
+                // Zeros -> CRC32 won't match the loaded game's known-original CRC32.
+                File.WriteAllBytes(wrong, new byte[0x1000]);
+                var vm = new ToolROMRebuildViewModel();
+                uint addr = U.toOffset(CoreState.ROM.RomInfo.extends_address);
+                Assert.Equal(ToolROMRebuildViewModel.MakeResult.OriginalNotMatching, vm.MakeRebuild(wrong, addr, "out.rebuild"));
+            }
+            finally { try { File.Delete(wrong); } catch { } }
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/ToolROMRebuildViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ToolROMRebuildViewModel.cs
@@ -1,33 +1,150 @@
 using System;
-using System.Collections.Generic;
+using System.IO;
 
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
+    /// <summary>
+    /// ROM Rebuild (defragment) analysis tool — input-surface parity with WinForms
+    /// <c>ToolROMRebuildForm</c> (#1171). Picks the clean original ROM, validates the
+    /// rebuild address (WF <c>CheckRebuildAddress</c>), and writes a <c>.rebuild</c>
+    /// analysis report via Core <see cref="RebuildCore.WriteRebuildReport"/> — the same
+    /// Core path the CLI <c>--rebuild</c> command uses.
+    ///
+    /// NOTE: the full WinForms defragment (per-struct Make + auto-reopen Apply) lives in
+    /// <c>ToolROMRebuildMake</c>/<c>ToolROMRebuildApply</c>, which are deeply coupled to
+    /// WinForms (<c>InputFormRef</c>, <c>Program.AsmMapFileAsmCache</c>, etc.) and not yet
+    /// ported to Core. This tool produces the analysis report and clearly messages that the
+    /// compacting Make/Apply phase remains a WinForms-only follow-up; it never fabricates a
+    /// compacted ROM. As a file producer (no in-place ROM writes) the VM does not implement
+    /// the verifiable-data contract.
+    /// </summary>
     public class ToolROMRebuildViewModel : ViewModelBase
     {
-        uint _currentAddr;
         bool _isLoaded;
+        string _originalRom = "";
+        uint _rebuildAddress;
+        string _status = "";
 
-        public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
+        /// <summary>Path to the clean/unmodified original ROM the modified ROM is diffed against.</summary>
+        public string OriginalRom { get => _originalRom; set => SetField(ref _originalRom, value); }
+        /// <summary>Rebuild start address (offset). Defaults to the loaded ROM's extends_address.</summary>
+        public uint RebuildAddress { get => _rebuildAddress; set => SetField(ref _rebuildAddress, value); }
+        public string Status { get => _status; set => SetField(ref _status, value); }
 
-        public List<AddrResult> LoadList()
+        public enum MakeResult { Ok, NoRom, OriginalMissing, OriginalUnreadable, OriginalNotMatching, BadAddress, Error }
+
+        /// <summary>Outcome of <see cref="ValidateRebuildAddress"/> (mirrors WF CheckRebuildAddress).</summary>
+        public enum AddressCheck { Ok, NotAligned, Unsafe, BelowExtends }
+
+        /// <summary>The default rebuild address for the loaded ROM = offset of extends_address.</summary>
+        public uint DefaultRebuildAddress()
         {
             ROM rom = CoreState.ROM;
-            if (rom?.RomInfo == null) return new List<AddrResult>();
-
-            var result = new List<AddrResult>();
-            result.Add(new AddrResult(0, "ROM Rebuild Tool", 0));
-            return result;
+            if (rom?.RomInfo == null) return 0;
+            return U.toOffset(rom.RomInfo.extends_address);
         }
 
-        public void LoadEntry(uint addr)
+        /// <summary>
+        /// Initialize the address default (called when the view opens). Returns false if no
+        /// ROM is loaded or the ROM does not use an extended region (nothing to rebuild).
+        /// </summary>
+        public bool Load()
         {
             ROM rom = CoreState.ROM;
-            if (rom == null) return;
-
-            CurrentAddr = addr;
+            if (rom?.RomInfo == null || rom.Data == null) return false;
+            uint extends = U.toOffset(rom.RomInfo.extends_address);
+            // WF ROMRebuildForm_Load: a ROM not using the extended region can't be rebuilt.
+            if (rom.Data.Length <= extends) return false;
+            RebuildAddress = extends;
             IsLoaded = true;
+            return true;
         }
+
+        /// <summary>
+        /// Validate the rebuild address — mirrors WF <c>CheckRebuildAddress</c>: must be
+        /// 4-byte aligned, within a safe offset range, and (warning) not below extends_address.
+        /// </summary>
+        public AddressCheck ValidateRebuildAddress(uint addr)
+        {
+            if (!U.isPadding4(addr)) return AddressCheck.NotAligned;
+            ROM rom = CoreState.ROM;
+            // U.isSafetyOffset(uint) dereferences CoreState.ROM.Data — guard the null case
+            // (headless tests) and pass the ROM explicitly so a small in-memory ROM is judged
+            // against its own length, exactly like the WF check against the loaded ROM.
+            if (rom?.Data == null) return AddressCheck.Unsafe;
+            if (!U.isSafetyOffset(addr, rom)) return AddressCheck.Unsafe;
+            if (rom.RomInfo != null && addr < U.toOffset(rom.RomInfo.extends_address))
+                return AddressCheck.BelowExtends;
+            return AddressCheck.Ok;
+        }
+
+        /// <summary>
+        /// Best-effort auto-find of a clean original ROM near the loaded ROM (mirrors WF
+        /// ToolROMRebuildForm.Load -> MainFormUtil.FindOrignalROM). Returns "" on any error.
+        /// </summary>
+        public string FindOriginal()
+        {
+            try
+            {
+                ROM rom = CoreState.ROM;
+                if (rom?.RomInfo == null || string.IsNullOrEmpty(rom.Filename)) return "";
+                uint targetCrc = rom.RomInfo.orignal_crc32;
+                if (targetCrc == 0) return "";
+                string dir = Path.GetDirectoryName(rom.Filename) ?? "";
+                // Find by the loaded ROM's known-original CRC32 — locale-independent and only
+                // ever returns the CORRECT clean original (same approach as the UPS tool).
+                string found = ToolTranslateROMCore.FindOrignalROMByCRC32(dir, targetCrc, "", rom.Filename, "") ?? "";
+                if (!string.IsNullOrEmpty(found) && SamePath(found, rom.Filename)) return "";
+                return found;
+            }
+            catch { return ""; }
+        }
+
+        static bool SamePath(string a, string b)
+        {
+            try { return string.Equals(Path.GetFullPath(a), Path.GetFullPath(b), StringComparison.OrdinalIgnoreCase); }
+            catch { return string.Equals(a, b, StringComparison.OrdinalIgnoreCase); }
+        }
+
+        /// <summary>
+        /// Run the rebuild analysis against <paramref name="originalPath"/> (the clean ROM)
+        /// and write the <c>.rebuild</c> report to <paramref name="outputPath"/>. Validate-
+        /// then-make; never throws. The work itself is Core/headless so the caller may run it
+        /// on a background thread.
+        /// </summary>
+        public MakeResult MakeRebuild(string originalPath, uint rebuildAddress, string outputPath, IProgress<string> progress = null)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom?.Data == null) return MakeResult.NoRom;
+            if (string.IsNullOrEmpty(originalPath) || !File.Exists(originalPath)) return MakeResult.OriginalMissing;
+
+            AddressCheck check = ValidateRebuildAddress(rebuildAddress);
+            // BelowExtends is only a warning in WF (Yes/No prompt); the caller decides whether
+            // to proceed, so accept it here. NotAligned/Unsafe are hard failures.
+            if (check == AddressCheck.NotAligned || check == AddressCheck.Unsafe) return MakeResult.BadAddress;
+
+            byte[] vanilla;
+            try { vanilla = File.ReadAllBytes(originalPath); }
+            catch { return MakeResult.OriginalUnreadable; }
+            if (vanilla.Length == 0) return MakeResult.OriginalUnreadable;
+
+            // Verify the selected file IS the unmodified original for the loaded game (mirrors
+            // WF CheckOrignalROM). Rebuilding against the wrong/already-modified ROM is invalid.
+            // (RomInfo can be null in headless tests — skip the check then.)
+            uint targetCrc = rom.RomInfo?.orignal_crc32 ?? 0;
+            if (targetCrc != 0 && new U.CRC32().Calc(vanilla) != targetCrc)
+                return MakeResult.OriginalNotMatching;
+
+            RebuildCore.RebuildResult result = RebuildCore.WriteRebuildReport(vanilla, rom.Data, rebuildAddress, outputPath, progress);
+            LastMessage = result.Message ?? "";
+            return result.Success ? MakeResult.Ok : MakeResult.Error;
+        }
+
+        /// <summary>The last Core analysis message (region/free-space stats), for display.</summary>
+        public string LastMessage { get; private set; } = "";
+
+        /// <summary>Suggested default report name (mirrors WF "R.{timestamp}.rebuild").</summary>
+        public static string SuggestedName(string timestamp) => "R." + timestamp + ".rebuild";
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ToolROMRebuildView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolROMRebuildView.axaml
@@ -1,21 +1,33 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
         x:Class="FEBuilderGBA.Avalonia.Views.ToolROMRebuildView"
-        Title="ROM Rebuild Tool" Width="1193" Height="582"
-        SizeToContent="WidthAndHeight">
-  <Grid ColumnDefinitions="250,*">
-    <controls:AddressListControl AutomationProperties.AutomationId="ToolROMRebuild_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
+        Title="ROM Rebuild Tool" Width="760" Height="480"
+        SizeToContent="Manual">
+  <ScrollViewer Margin="8">
+    <StackPanel Spacing="12" Margin="8">
+      <TextBlock Text="ROM Rebuild Tool" FontSize="18" FontWeight="Bold" />
+      <TextBlock AutomationProperties.AutomationId="ToolROMRebuild_Intro_Label" Name="IntroText"
+                 TextWrapping="Wrap" Opacity="0.8" />
 
-    <ScrollViewer Grid.Column="1" Margin="4">
-      <StackPanel Spacing="8" Margin="8">
-        <TextBlock Text="ROM Rebuild Tool" FontSize="18" FontWeight="Bold" />
+      <TextBlock Text="Original (unmodified) ROM:" />
+      <Grid ColumnDefinitions="*,Auto">
+        <TextBox Grid.Column="0" AutomationProperties.AutomationId="ToolROMRebuild_Original_Input"
+                 Name="OriginalRomTextBox" Watermark="Path to the clean ROM" />
+        <Button Grid.Column="1" AutomationProperties.AutomationId="ToolROMRebuild_Select_Button"
+                Name="SelectButton" Content="Select…" Click="Select_Click" Margin="6,0,0,0" />
+      </Grid>
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="ToolROMRebuild_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
-        </Grid>
-      </StackPanel>
-    </ScrollViewer>
-  </Grid>
+      <TextBlock Text="Rebuild address (hex):" />
+      <TextBox AutomationProperties.AutomationId="ToolROMRebuild_Address_Input"
+               Name="RebuildAddressTextBox" Watermark="08800000" Width="200" HorizontalAlignment="Left" />
+      <TextBlock AutomationProperties.AutomationId="ToolROMRebuild_AddressHelp_Label" Name="AddressHelpText"
+                 TextWrapping="Wrap" Opacity="0.8" />
+
+      <Button AutomationProperties.AutomationId="ToolROMRebuild_Make_Button" Name="MakeButton"
+              Content="Make ROMRebuild report…" Click="Make_Click" />
+
+      <TextBlock AutomationProperties.AutomationId="ToolROMRebuild_Status_Label" Name="StatusText"
+                 TextWrapping="Wrap" />
+    </StackPanel>
+  </ScrollViewer>
 </Window>

--- a/FEBuilderGBA.Avalonia/Views/ToolROMRebuildView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolROMRebuildView.axaml.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Threading.Tasks;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
-using global::Avalonia.Threading;
 using FEBuilderGBA.Avalonia.Dialogs;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
@@ -119,8 +118,12 @@ namespace FEBuilderGBA.Avalonia.Views
                 MakeButton.IsEnabled = false;
                 StatusText.Text = R._("Analyzing…");
 
-                var progress = new Progress<string>(msg =>
-                    Dispatcher.UIThread.Post(() => StatusText.Text = msg));
+                // Progress<T> is constructed here on the UI thread, so it captures the UI
+                // SynchronizationContext and already marshals Report() callbacks back onto
+                // it — set the text directly. Wrapping in an extra Dispatcher.UIThread.Post
+                // would add a second async hop that could land a late progress update AFTER
+                // the final result status set synchronously below, overwriting it.
+                var progress = new Progress<string>(msg => StatusText.Text = msg);
 
                 // The analysis + report write are Core/headless; run them off the UI thread so
                 // a large ROM does not freeze the window (the operation can take a while).

--- a/FEBuilderGBA.Avalonia/Views/ToolROMRebuildView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolROMRebuildView.axaml.cs
@@ -1,6 +1,11 @@
 using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
+using global::Avalonia.Threading;
+using FEBuilderGBA.Avalonia.Dialogs;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 
@@ -16,42 +21,161 @@ namespace FEBuilderGBA.Avalonia.Views
         public ToolROMRebuildView()
         {
             InitializeComponent();
-            EntryList.SelectedAddressChanged += OnSelected;
-            Opened += (_, _) => LoadList();
+            IntroText.Text = R._("Analyze the modified ROM against the clean original and write a .rebuild report listing the modified regions and reusable free space. The full defragment (compacting Make/Apply with auto-reopen) is not yet available in this build.");
+            Opened += (_, _) =>
+            {
+                try
+                {
+                    bool ok = _vm.Load();
+                    AddressHelpText.Text = BuildAddressHelp();
+                    if (!ok)
+                    {
+                        StatusText.Text = R._("This ROM does not use an extended region, so it cannot be rebuilt.");
+                        MakeButton.IsEnabled = false;
+                        return;
+                    }
+                    RebuildAddressTextBox.Text = string.Format("{0:X8}", _vm.RebuildAddress);
+                    string found = _vm.FindOriginal();
+                    if (!string.IsNullOrEmpty(found))
+                        OriginalRomTextBox.Text = found;
+                }
+                catch (Exception ex)
+                {
+                    Log.Error("ToolROMRebuildView.Opened failed: " + ex);
+                }
+            };
         }
 
-        void LoadList()
+        string BuildAddressHelp()
+        {
+            uint def = _vm.DefaultRebuildAddress();
+            // Mirrors the gist of WF GetExplainRebuildAddress without the WinForms-only details.
+            return R._("Data from this address onward is rebuilt. The default is {0}. Normally leave it unchanged; raise it if the rebuild fails because of custom-installed ASM.", "0x" + string.Format("{0:X8}", def));
+        }
+
+        async void Select_Click(object? sender, RoutedEventArgs e)
         {
             try
             {
-                var items = _vm.LoadList();
-                EntryList.SetItems(items);
+                string? path = await FileDialogHelper.OpenRomFile(this);
+                if (!string.IsNullOrEmpty(path))
+                    OriginalRomTextBox.Text = path;
             }
             catch (Exception ex)
             {
-                Log.Error("ToolROMRebuildView.LoadList failed: {0}", ex.Message);
+                Log.Error("ToolROMRebuildView.Select_Click failed: " + ex);
             }
         }
 
-        void OnSelected(uint addr)
+        async void Make_Click(object? sender, RoutedEventArgs e)
         {
             try
             {
-                _vm.LoadEntry(addr);
-                UpdateUI();
+                string original = OriginalRomTextBox.Text ?? "";
+                if (string.IsNullOrWhiteSpace(original) || !File.Exists(original))
+                {
+                    StatusText.Text = R._("Please select a valid original (unmodified) ROM.");
+                    return;
+                }
+
+                if (!TryParseHex(RebuildAddressTextBox.Text, out uint rebuildAddress))
+                {
+                    StatusText.Text = R._("The rebuild address is not a valid hexadecimal number.");
+                    return;
+                }
+
+                // WF CheckRebuildAddress: hard-fail on misaligned/unsafe, warn (Yes/No) when below extends.
+                var check = _vm.ValidateRebuildAddress(rebuildAddress);
+                if (check == ToolROMRebuildViewModel.AddressCheck.NotAligned)
+                {
+                    StatusText.Text = R._("This address ({0}) cannot be used: it is not a multiple of 4.", "0x" + string.Format("{0:X8}", rebuildAddress));
+                    return;
+                }
+                if (check == ToolROMRebuildViewModel.AddressCheck.Unsafe)
+                {
+                    StatusText.Text = R._("This address ({0}) cannot be used: the address range is dangerous.", "0x" + string.Format("{0:X8}", rebuildAddress));
+                    return;
+                }
+                if (check == ToolROMRebuildViewModel.AddressCheck.BelowExtends)
+                {
+                    var dr = await MessageBoxWindow.Show(this,
+                        R._("Rebuilding an address ({0}) below the extended region is dangerous. Continue anyway?", "0x" + string.Format("{0:X8}", rebuildAddress)),
+                        ViewTitle, MessageBoxMode.YesNo);
+                    if (dr != MessageBoxResult.Yes)
+                        return;
+                }
+
+                string suggested = ToolROMRebuildViewModel.SuggestedName(DateTime.Now.ToString("yyyyMMddHHmmss"));
+                string? output = await FileDialogHelper.SaveFile(this,
+                    R._("Save ROMRebuild report"), R._("ROMRebuild report"), "*.rebuild", suggested);
+                if (string.IsNullOrEmpty(output))
+                    return;   // user cancelled
+
+                MakeButton.IsEnabled = false;
+                StatusText.Text = R._("Analyzing…");
+
+                var progress = new Progress<string>(msg =>
+                    Dispatcher.UIThread.Post(() => StatusText.Text = msg));
+
+                // The analysis + report write are Core/headless; run them off the UI thread so
+                // a large ROM does not freeze the window (the operation can take a while).
+                var result = await Task.Run(() => _vm.MakeRebuild(original, rebuildAddress, output, progress));
+
+                StatusText.Text = result switch
+                {
+                    ToolROMRebuildViewModel.MakeResult.Ok => R._("ROMRebuild report created. {0}", _vm.LastMessage),
+                    ToolROMRebuildViewModel.MakeResult.NoRom => R._("No ROM is loaded."),
+                    ToolROMRebuildViewModel.MakeResult.OriginalMissing => R._("Please select a valid original (unmodified) ROM."),
+                    ToolROMRebuildViewModel.MakeResult.OriginalUnreadable => R._("The original ROM could not be read."),
+                    ToolROMRebuildViewModel.MakeResult.OriginalNotMatching => R._("The selected ROM is not the unmodified original for this game (CRC32 mismatch). Select the official clean ROM."),
+                    ToolROMRebuildViewModel.MakeResult.BadAddress => R._("The rebuild address is invalid."),
+                    _ => R._("Failed to create the ROMRebuild report. {0}", _vm.LastMessage),
+                };
+
+                if (result == ToolROMRebuildViewModel.MakeResult.Ok)
+                    RevealInExplorer(output);
             }
             catch (Exception ex)
             {
-                Log.Error("ToolROMRebuildView.OnSelected failed: {0}", ex.Message);
+                Log.Error("ToolROMRebuildView.Make_Click failed: " + ex);
+                StatusText.Text = R._("Failed to create the ROMRebuild report.");
+            }
+            finally
+            {
+                MakeButton.IsEnabled = true;
             }
         }
 
-        void UpdateUI()
+        static bool TryParseHex(string? text, out uint value)
         {
-            AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            value = 0;
+            if (string.IsNullOrWhiteSpace(text)) return false;
+            text = text.Trim();
+            if (text.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                text = text.Substring(2);
+            return uint.TryParse(text, System.Globalization.NumberStyles.HexNumber,
+                System.Globalization.CultureInfo.InvariantCulture, out value);
         }
 
-        public void NavigateTo(uint address) => EntryList.SelectAddress(address);
-        public void SelectFirstItem() => EntryList.SelectFirst();
+        static void RevealInExplorer(string path)
+        {
+            try
+            {
+                if (OperatingSystem.IsWindows())
+                {
+                    Process.Start(new ProcessStartInfo("explorer.exe", "/select,\"" + path + "\"") { UseShellExecute = true });
+                }
+                else
+                {
+                    string dir = Path.GetDirectoryName(path) ?? "";
+                    if (!string.IsNullOrEmpty(dir))
+                        Process.Start(new ProcessStartInfo(dir) { UseShellExecute = true });
+                }
+            }
+            catch { /* reveal is best-effort */ }
+        }
+
+        public void NavigateTo(uint address) { }
+        public void SelectFirstItem() { }
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ToolROMRebuildView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolROMRebuildView.axaml.cs
@@ -28,13 +28,18 @@ namespace FEBuilderGBA.Avalonia.Views
                 {
                     bool ok = _vm.Load();
                     AddressHelpText.Text = BuildAddressHelp();
+                    // Always populate the address field with the real default so it
+                    // matches the help text — even when the ROM can't be rebuilt, where
+                    // Load() leaves RebuildAddress unset and the field would otherwise
+                    // fall back to the misleading watermark example.
+                    RebuildAddressTextBox.Text = string.Format("{0:X8}",
+                        ok ? _vm.RebuildAddress : _vm.DefaultRebuildAddress());
                     if (!ok)
                     {
                         StatusText.Text = R._("This ROM does not use an extended region, so it cannot be rebuilt.");
                         MakeButton.IsEnabled = false;
                         return;
                     }
-                    RebuildAddressTextBox.Text = string.Format("{0:X8}", _vm.RebuildAddress);
                     string found = _vm.FindOriginal();
                     if (!string.IsNullOrEmpty(found))
                         OriginalRomTextBox.Text = found;

--- a/FEBuilderGBA.Core.Tests/RebuildCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildCoreTests.cs
@@ -153,6 +153,35 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void WriteRebuildReport_OverwritesExistingReport_AtomicReplace()
+        {
+            // Writing over an existing report must succeed (atomic File.Move overwrite)
+            // and leave the file holding the NEW content — not lose it to a
+            // delete-then-failed-move window.
+            byte[] vanilla = new byte[256];
+            byte[] modified1 = new byte[256]; modified1[20] = 0xFF;
+            byte[] modified2 = new byte[256]; modified2[20] = 0xFF; modified2[21] = 0xFF; modified2[100] = 0xAB;
+
+            string outPath = Path.Combine(Path.GetTempPath(), "feb_rebuild_ovr_" + Guid.NewGuid().ToString("N") + ".rebuild");
+            try
+            {
+                var r1 = RebuildCore.WriteRebuildReport(vanilla, modified1, 0x09000000, outPath);
+                Assert.True(r1.Success);
+                Assert.True(File.Exists(outPath));
+
+                // Second write replaces the first; file still present + parseable, no temp left.
+                var r2 = RebuildCore.WriteRebuildReport(vanilla, modified2, 0x09100000, outPath);
+                Assert.True(r2.Success);
+                Assert.True(File.Exists(outPath));
+                Assert.False(File.Exists(outPath + ".tmp"));
+                string text = File.ReadAllText(outPath);
+                Assert.Contains("@_CRC32 ", text);
+                Assert.Contains("@_REBUILDADDRESS ", text);
+            }
+            finally { try { File.Delete(outPath); } catch { } }
+        }
+
+        [Fact]
         public void WriteRebuildReport_NullData_ReturnsFailure_NoFile()
         {
             string outPath = Path.Combine(Path.GetTempPath(), "feb_rebuild_null_" + Guid.NewGuid().ToString("N") + ".rebuild");

--- a/FEBuilderGBA.Core.Tests/RebuildCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildCoreTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using Xunit;
 
 namespace FEBuilderGBA.Core.Tests
@@ -110,6 +112,59 @@ namespace FEBuilderGBA.Core.Tests
         public void Rebuild_NullReturnsFailure()
         {
             var result = RebuildCore.Rebuild(null, new byte[64]);
+            Assert.False(result.Success);
+        }
+
+        [Fact]
+        public void BuildRebuildReport_ContainsHeaderAndRegions()
+        {
+            byte[] vanilla = new byte[128];
+            byte[] modified = new byte[128];
+            for (int i = 10; i < 15; i++) modified[i] = 0xAA;   // a modified region
+
+            string report = RebuildCore.BuildRebuildReport(vanilla, modified, 0x09000000);
+            Assert.Contains("@_CRC32 ", report);
+            Assert.Contains("@_REBUILDADDRESS 09000000", report);   // ToHexString(uint) pads to X08
+            Assert.Contains("@MOD ", report);
+            Assert.Contains("MODIFIED REGIONS:", report);
+            Assert.Contains("FREE SPACE:", report);
+        }
+
+        [Fact]
+        public void WriteRebuildReport_WritesFile_AndReportsSuccess()
+        {
+            byte[] vanilla = new byte[256];
+            byte[] modified = new byte[256];
+            modified[20] = 0xFF; modified[21] = 0xFF;
+
+            string outPath = Path.Combine(Path.GetTempPath(), "feb_rebuild_" + Guid.NewGuid().ToString("N") + ".rebuild");
+            try
+            {
+                var result = RebuildCore.WriteRebuildReport(vanilla, modified, 0x09000000, outPath);
+                Assert.True(result.Success);
+                Assert.True(File.Exists(outPath));
+                string text = File.ReadAllText(outPath);
+                Assert.Contains("@_CRC32 ", text);
+                Assert.Contains(outPath, result.Message);   // message reports the output path
+                // No leftover temp artifact.
+                Assert.False(File.Exists(outPath + ".tmp"));
+            }
+            finally { try { File.Delete(outPath); } catch { } }
+        }
+
+        [Fact]
+        public void WriteRebuildReport_NullData_ReturnsFailure_NoFile()
+        {
+            string outPath = Path.Combine(Path.GetTempPath(), "feb_rebuild_null_" + Guid.NewGuid().ToString("N") + ".rebuild");
+            var result = RebuildCore.WriteRebuildReport(null, new byte[64], 0, outPath);
+            Assert.False(result.Success);
+            Assert.False(File.Exists(outPath));
+        }
+
+        [Fact]
+        public void WriteRebuildReport_EmptyOutputPath_ReturnsFailure()
+        {
+            var result = RebuildCore.WriteRebuildReport(new byte[64], new byte[64], 0, "");
             Assert.False(result.Success);
         }
     }

--- a/FEBuilderGBA.Core/RebuildCore.cs
+++ b/FEBuilderGBA.Core/RebuildCore.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 
 namespace FEBuilderGBA
 {
@@ -160,6 +161,103 @@ namespace FEBuilderGBA
                 BlocksMoved = modifiedRegions.Count,
                 BytesSaved = (int)totalFree,
             };
+        }
+
+        /// <summary>
+        /// Build the text of a <c>.rebuild</c> analysis report: a CRC32 of the vanilla
+        /// ROM, the requested rebuild address, and the lists of modified regions and free
+        /// space found in the modified ROM. The header lines (<c>@_CRC32</c> /
+        /// <c>@_REBUILDADDRESS</c>) mirror the WinForms <c>ToolROMRebuildMake</c> output so
+        /// the report is recognizable, but this is an analysis/report only — it does NOT
+        /// contain the full per-struct rebuild commands the WinForms defragment writes
+        /// (that path is WinForms-coupled; see the class summary).
+        /// </summary>
+        public static string BuildRebuildReport(byte[] vanillaData, byte[] modifiedData, uint rebuildAddress)
+        {
+            var sb = new StringBuilder();
+
+            uint vanillaCrc = vanillaData == null ? 0u : new U.CRC32().Calc(vanillaData);
+            sb.Append("@_CRC32 ").Append(U.ToHexString(vanillaCrc))
+              .AppendLine(" //vanilla ROM CRC32");
+            sb.Append("@_REBUILDADDRESS ").Append(U.ToHexString(rebuildAddress))
+              .AppendLine(" //rebuild start address");
+
+            var modifiedRegions = FindModifiedRegions(vanillaData, modifiedData);
+            var freeSpace = FindFreeSpace(modifiedData);
+
+            uint totalModified = 0;
+            foreach (var (_, length) in modifiedRegions) totalModified += length;
+            uint totalFree = 0;
+            foreach (var (_, length) in freeSpace) totalFree += length;
+
+            sb.Append("//MODIFIED REGIONS: ").Append(modifiedRegions.Count)
+              .Append(" (").Append(totalModified).AppendLine(" bytes)");
+            foreach (var (offset, length) in modifiedRegions)
+            {
+                sb.Append("@MOD ").Append(U.ToHexString8(offset))
+                  .Append(" :").Append(U.ToHexString(length)).AppendLine();
+            }
+
+            sb.Append("//FREE SPACE: ").Append(freeSpace.Count)
+              .Append(" (").Append(totalFree).AppendLine(" bytes)");
+            foreach (var (offset, length) in freeSpace)
+            {
+                sb.Append("@FREE ").Append(U.ToHexString8(offset))
+                  .Append(" :").Append(U.ToHexString(length)).AppendLine();
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Run the analysis and write the report to <paramref name="outputPath"/> fault-safely:
+        /// the text is written to a sibling temp file first, then atomically moved into place,
+        /// so a failure partway never leaves a corrupt half-written <c>.rebuild</c>. Never
+        /// throws — returns a <see cref="RebuildResult"/> whose <see cref="RebuildResult.Success"/>
+        /// reports the outcome.
+        /// </summary>
+        public static RebuildResult WriteRebuildReport(byte[] vanillaData, byte[] modifiedData,
+            uint rebuildAddress, string outputPath, IProgress<string> progress = null)
+        {
+            if (vanillaData == null || modifiedData == null)
+            {
+                return new RebuildResult { Success = false, Message = "Error: ROM data is null." };
+            }
+            if (string.IsNullOrEmpty(outputPath))
+            {
+                return new RebuildResult { Success = false, Message = "Error: output path is empty." };
+            }
+
+            RebuildResult analysis = Rebuild(vanillaData, modifiedData, progress);
+            if (!analysis.Success)
+            {
+                return analysis;
+            }
+
+            progress?.Report("Writing report...");
+
+            string tempPath = outputPath + ".tmp";
+            try
+            {
+                string report = BuildRebuildReport(vanillaData, modifiedData, rebuildAddress);
+                File.WriteAllText(tempPath, report);
+                // Atomic-ish replace: remove any stale target, then move the fully-written temp.
+                if (File.Exists(outputPath))
+                {
+                    File.Delete(outputPath);
+                }
+                File.Move(tempPath, outputPath);
+            }
+            catch (Exception ex)
+            {
+                // Clean up the half-written temp so no corrupt artifact is left behind.
+                try { if (File.Exists(tempPath)) File.Delete(tempPath); } catch { }
+                return new RebuildResult { Success = false, Message = "Error: could not write report. " + ex.Message };
+            }
+
+            progress?.Report("Report written.");
+            analysis.Message = analysis.Message + " -> " + outputPath;
+            return analysis;
         }
     }
 }

--- a/FEBuilderGBA.Core/RebuildCore.cs
+++ b/FEBuilderGBA.Core/RebuildCore.cs
@@ -241,12 +241,14 @@ namespace FEBuilderGBA
             {
                 string report = BuildRebuildReport(vanillaData, modifiedData, rebuildAddress);
                 File.WriteAllText(tempPath, report);
-                // Atomic-ish replace: remove any stale target, then move the fully-written temp.
-                if (File.Exists(outputPath))
-                {
-                    File.Delete(outputPath);
-                }
-                File.Move(tempPath, outputPath);
+                // Atomic replace: move the fully-written temp over the target in one
+                // operation. Unlike delete-then-move, File.Move(overwrite:true) leaves
+                // the existing report intact if the move fails (permissions / AV lock /
+                // crash), so the fault-safe guarantee holds — there is never a window
+                // where the old report is gone but the new one isn't yet in place. The
+                // temp is a sibling (.tmp in the same directory), so this stays on one
+                // volume.
+                File.Move(tempPath, outputPath, overwrite: true);
             }
             catch (Exception ex)
             {

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20595,3 +20595,51 @@ A redistributable patch definition for the compiled result. Save it as a PATCH_(
 :Each row is a map whose world-map event PLIST is set. The address points to the map-pointer table slot the PLIST indexes.
 Each row is a map whose world-map event PLIST is set. The address points to the map-pointer table slot the PLIST indexes.
 
+:Rebuild address (hex):
+Rebuild address (hex):
+
+:Make ROMRebuild report…
+Make ROMRebuild report…
+
+:Analyze the modified ROM against the clean original and write a .rebuild report listing the modified regions and reusable free space. The full defragment (compacting Make/Apply with auto-reopen) is not yet available in this build.
+Analyze the modified ROM against the clean original and write a .rebuild report listing the modified regions and reusable free space. The full defragment (compacting Make/Apply with auto-reopen) is not yet available in this build.
+
+:This ROM does not use an extended region, so it cannot be rebuilt.
+This ROM does not use an extended region, so it cannot be rebuilt.
+
+:Data from this address onward is rebuilt. The default is {0}. Normally leave it unchanged; raise it if the rebuild fails because of custom-installed ASM.
+Data from this address onward is rebuilt. The default is {0}. Normally leave it unchanged; raise it if the rebuild fails because of custom-installed ASM.
+
+:The rebuild address is not a valid hexadecimal number.
+The rebuild address is not a valid hexadecimal number.
+
+:This address ({0}) cannot be used: it is not a multiple of 4.
+This address ({0}) cannot be used: it is not a multiple of 4.
+
+:This address ({0}) cannot be used: the address range is dangerous.
+This address ({0}) cannot be used: the address range is dangerous.
+
+:Rebuilding an address ({0}) below the extended region is dangerous. Continue anyway?
+Rebuilding an address ({0}) below the extended region is dangerous. Continue anyway?
+
+:Save ROMRebuild report
+Save ROMRebuild report
+
+:ROMRebuild report
+ROMRebuild report
+
+:Analyzing…
+Analyzing…
+
+:ROMRebuild report created. {0}
+ROMRebuild report created. {0}
+
+:The rebuild address is invalid.
+The rebuild address is invalid.
+
+:Failed to create the ROMRebuild report. {0}
+Failed to create the ROMRebuild report. {0}
+
+:Failed to create the ROMRebuild report.
+Failed to create the ROMRebuild report.
+

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11918,3 +11918,51 @@ config/translate/<lang>.txt
 :Independence failed: 
 分離独立に失敗しました: 
 
+:Rebuild address (hex):
+リビルドアドレス(16進数):
+
+:Make ROMRebuild report…
+ROMRebuildレポートを作成…
+
+:Analyze the modified ROM against the clean original and write a .rebuild report listing the modified regions and reusable free space. The full defragment (compacting Make/Apply with auto-reopen) is not yet available in this build.
+改造ROMを無改造ROMと比較し、変更された領域と再利用可能な空き領域を一覧にした .rebuild レポートを書き出します。完全なデフラグ(Make/Apply による圧縮と自動再オープン)はこのビルドではまだ利用できません。
+
+:This ROM does not use an extended region, so it cannot be rebuilt.
+このROMは拡張領域を利用していないので、リビルドできません。
+
+:Data from this address onward is rebuilt. The default is {0}. Normally leave it unchanged; raise it if the rebuild fails because of custom-installed ASM.
+このアドレス以降のデータを再構築します。ディフォルトは{0}です。通常は変更しないでください。独自に追加したASMが原因でリビルドに失敗する場合は、この値を大きくしてください。
+
+:The rebuild address is not a valid hexadecimal number.
+リビルドアドレスが有効な16進数ではありません。
+
+:This address ({0}) cannot be used: it is not a multiple of 4.
+このアドレス({0})はリビルドに利用できません。アドレスが4で割り切れません。
+
+:This address ({0}) cannot be used: the address range is dangerous.
+このアドレス({0})はリビルドに利用できません。アドレスの範囲が危険です。
+
+:Rebuilding an address ({0}) below the extended region is dangerous. Continue anyway?
+拡張領域より下のアドレス({0})をリビルドするのは危険です。続行してもよろしいですか?
+
+:Save ROMRebuild report
+ROMRebuildレポートを保存
+
+:ROMRebuild report
+ROMRebuildレポート
+
+:Analyzing…
+解析中…
+
+:ROMRebuild report created. {0}
+ROMRebuildレポートを作成しました。{0}
+
+:The rebuild address is invalid.
+リビルドアドレスが無効です。
+
+:Failed to create the ROMRebuild report. {0}
+ROMRebuildレポートの作成に失敗しました。{0}
+
+:Failed to create the ROMRebuild report.
+ROMRebuildレポートの作成に失敗しました。
+

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25759,3 +25759,51 @@ config/translate/<lang>.txt
 :Independence failed: 
 独立化失败: 
 
+:Rebuild address (hex):
+重建地址(十六进制):
+
+:Make ROMRebuild report…
+生成 ROMRebuild 报告…
+
+:Analyze the modified ROM against the clean original and write a .rebuild report listing the modified regions and reusable free space. The full defragment (compacting Make/Apply with auto-reopen) is not yet available in this build.
+将改造 ROM 与无改造原版对比，写出一份 .rebuild 报告，列出已修改的区域和可重用的空闲空间。完整的碎片整理(Make/Apply 压缩并自动重新打开)在此版本中尚不可用。
+
+:This ROM does not use an extended region, so it cannot be rebuilt.
+此 ROM 未使用扩展区域，因此无法重建。
+
+:Data from this address onward is rebuilt. The default is {0}. Normally leave it unchanged; raise it if the rebuild fails because of custom-installed ASM.
+从此地址开始的数据将被重建。默认值为 {0}。通常请勿更改；如果因自定义安装的 ASM 导致重建失败，请调大此值。
+
+:The rebuild address is not a valid hexadecimal number.
+重建地址不是有效的十六进制数。
+
+:This address ({0}) cannot be used: it is not a multiple of 4.
+无法使用此地址({0}):它不是 4 的倍数。
+
+:This address ({0}) cannot be used: the address range is dangerous.
+无法使用此地址({0}):地址范围有危险。
+
+:Rebuilding an address ({0}) below the extended region is dangerous. Continue anyway?
+重建扩展区域以下的地址({0})有危险。仍要继续吗?
+
+:Save ROMRebuild report
+保存 ROMRebuild 报告
+
+:ROMRebuild report
+ROMRebuild 报告
+
+:Analyzing…
+正在分析…
+
+:ROMRebuild report created. {0}
+已生成 ROMRebuild 报告。{0}
+
+:The rebuild address is invalid.
+重建地址无效。
+
+:Failed to create the ROMRebuild report. {0}
+生成 ROMRebuild 报告失败。{0}
+
+:Failed to create the ROMRebuild report.
+生成 ROMRebuild 报告失败。
+


### PR DESCRIPTION
## Summary
De-stubs the Avalonia **ROM Rebuild** tool (#1171). `ToolROMRebuildView` was a 57-line scaffold over a 33-line stub VM (dummy row, no flow); it's now a functional tool with input-surface parity to WinForms `ToolROMRebuildForm`, wiring the **existing reusable rebuild path** into a GUI.

**Scope (verified):** the reusable rebuild path that exists in Core/CLI — `RebuildCore.Rebuild`, used by `CLI --rebuild` — is an **analysis** path (it finds modified regions / free space / pointers and reports them; the CLI prints "Rebuild analysis complete"). The full per-struct compacting defragment (`ToolROMRebuildMake` / `ToolROMRebuildApply`) is **deeply coupled to WinForms** and is not in Core. So this PR wires the analysis path and writes a `.rebuild` analysis report; the full compacting Make/Apply phase is left as a WinForms-coupled follow-up (filed separately) — the tool never fabricates a fake full rebuild.

## Changes
- `RebuildCore.cs` (+98): `BuildRebuildReport(vanilla, modified, rebuildAddress)` (CRC32 + rebuild address + modified-regions + free-space, with `@_CRC32`/`@_REBUILDADDRESS` headers mirroring the WF output) and `WriteRebuildReport(...)` — **fault-safe**: writes to a sibling temp file then atomically moves into place, never leaves a corrupt half-written `.rebuild`, never throws (returns a `RebuildResult`).
- ViewModel (+141): pick the clean original ROM, default the rebuild address to `extends_address`, validate it (WF `CheckRebuildAddress` parity → `AddressCheck`), run the report off the UI thread. Produces files only → **does not** implement `IDataVerifiable`.
- View AXAML (+42) + code-behind (+152): original-ROM picker, rebuild-address **hex TextBox**, Make button, status/progress.
- Core.Tests (+55) + Avalonia.Tests (+189): report round-trip, fault-safe write, address default/validation.
- `config/translate/{en,ja,zh}.txt` (+48 each): new literals (ja+zh).

## Tests (local)
- Core.Tests (Rebuild filter): **24 passed**, 0 failed
- Avalonia.Tests (ToolROMRebuild filter): **10 passed**, 0 failed
- validate-automation-ids: **0 errors / 0 warnings**
- Build: succeeded. (Full 3-project sweep runs in CI.)

Screenshot below.

Fixes #1171

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
