### PR TITLE
feat(core+avalonia): Event Assembler in-place Uninstall (#1242)

### DIFF
--- a/FEBuilderGBA.Avalonia/ViewModels/EventAssemblerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EventAssemblerViewModel.cs
@@ -7,8 +7,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
     /// ViewModel for the Avalonia "Add-via-Event-Assembler" tool (WF
     /// <c>EventAssemblerForm</c>). Assembles/inserts an EA event script into the
     /// ROM via ColorzCore / Event-Assembler, with free-area selection
-    /// (Program / Data / None), a debug-symbol store choice and undo. (Uninstall is
-    /// deferred to a follow-up; revert an applied insert via undo for now.)
+    /// (Program / Data / None), a debug-symbol store choice and undo. In-place
+    /// Uninstall (#1242) reverts an applied EA patch from a clean-original ROM via
+    /// <c>EventAssemblerUninstallCore</c> (the View owns that flow + its file picker).
     ///
     /// The actual compile+insert work lives in the GUI-free Core helper
     /// <c>EventAssemblerCompileCore</c> (shared with the CLI

--- a/FEBuilderGBA.Avalonia/Views/EventAssemblerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventAssemblerView.axaml
@@ -12,7 +12,9 @@
        free-area / debug-symbol combo items are populated in code-behind via R._()
        so they pick up ja/zh translations (ViewTranslationHelper does not translate
        ComboBoxItem content).
-       Uninstall is deferred to a follow-up (revert an applied insert via Undo). -->
+       Uninstall (#1242) reverts an applied EA patch in place: it traces the loaded
+       .event's written ranges via EventAssemblerUninstallCore and restores those
+       bytes from a user-supplied clean original ROM, under undo. -->
   <ScrollViewer VerticalScrollBarVisibility="Auto">
     <StackPanel Margin="16" Spacing="10">
 
@@ -61,6 +63,9 @@
         <Button AutomationProperties.AutomationId="EventAssembler_Import_Button"
                 Name="ImportButton" Content="Import (compile + insert)"
                 Click="Import_Click" />
+        <Button AutomationProperties.AutomationId="EventAssembler_Uninstall_Button"
+                Name="UninstallButton" Content="Uninstall..."
+                Click="Uninstall_Click" />
         <Button AutomationProperties.AutomationId="EventAssembler_Undo_Button"
                 Name="UndoButton" Content="Undo"
                 IsVisible="{Binding CanUndo}"

--- a/FEBuilderGBA.Avalonia/Views/EventAssemblerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventAssemblerView.axaml.cs
@@ -223,13 +223,43 @@ namespace FEBuilderGBA.Avalonia.Views
             byte[] cleanRom;
             try
             {
-                cleanRom = System.IO.File.ReadAllBytes(cleanRomPath);
+                // Read off the UI thread — a full ROM from slow storage can be several
+                // MB and would otherwise freeze the window before the revert task starts.
+                cleanRom = await Task.Run(() => System.IO.File.ReadAllBytes(cleanRomPath));
             }
             catch (Exception ex)
             {
                 Log.Error("EventAssemblerView.Uninstall read clean ROM failed: " + ex.ToString());
                 _vm.StatusMessage = R._("Uninstall failed.") + "\r\n" + ex.ToString();
                 return;
+            }
+
+            // Review-BEFORE-revert (closest to the WF binmap dialog): trace first and,
+            // if any write-bearing block can't be traced, ask the user to confirm a
+            // PARTIAL uninstall — those bytes will NOT be reverted and may stay patched.
+            // Tracing is cheap (parse + GREP) relative to the revert, so doing it here to
+            // gate the confirm is fine; Uninstall() re-traces and reverts on Yes.
+            var preTrace = EventAssemblerUninstallCore.TraceEAFile(_vm.SourcePath);
+            if (preTrace.UntracedCount > 0)
+            {
+                int n = preTrace.UntracedCount;
+                int shown = Math.Min(n, 5);
+                string detail = "";
+                for (int i = 0; i < shown; i++)
+                    detail += "\r\n  - " + preTrace.Untraceable[i];
+                if (n > shown)
+                    detail += "\r\n  - " + R._("...and {0} more.", (n - shown).ToString());
+
+                string prompt = R._("{0} block(s) in this EA cannot be traced (e.g. inline image / PROCS); those bytes will NOT be reverted and may remain patched.", n.ToString())
+                    + detail + "\r\n\r\n"
+                    + R._("Proceed with a partial uninstall?");
+                var answer = await MessageBoxWindow.Show(this, prompt,
+                    R._("Partial uninstall"), MessageBoxMode.YesNo);
+                if (answer != MessageBoxResult.Yes)
+                {
+                    _vm.StatusMessage = R._("Uninstall cancelled.");
+                    return;
+                }
             }
 
             UninstallButton.IsEnabled = false;

--- a/FEBuilderGBA.Avalonia/Views/EventAssemblerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventAssemblerView.axaml.cs
@@ -237,9 +237,11 @@ namespace FEBuilderGBA.Avalonia.Views
             // Review-BEFORE-revert (closest to the WF binmap dialog): trace first and,
             // if any write-bearing block can't be traced, ask the user to confirm a
             // PARTIAL uninstall — those bytes will NOT be reverted and may stay patched.
-            // Tracing is cheap (parse + GREP) relative to the revert, so doing it here to
-            // gate the confirm is fine; Uninstall() re-traces and reverts on Yes.
-            var preTrace = EventAssemblerUninstallCore.TraceEAFile(_vm.SourcePath);
+            // The trace (EA parse + repeated GREP over the full ROM) can be slow for
+            // large scripts/ROMs, so run it OFF the UI thread to keep the window
+            // responsive. It is read-only here (only used to gate the confirm); the real
+            // revert re-traces and writes inside the guarded Task.Run below.
+            var preTrace = await Task.Run(() => EventAssemblerUninstallCore.TraceEAFile(_vm.SourcePath));
             if (preTrace.UntracedCount > 0)
             {
                 int n = preTrace.UntracedCount;

--- a/FEBuilderGBA.Avalonia/Views/EventAssemblerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventAssemblerView.axaml.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using global::Avalonia.Platform.Storage;
+using FEBuilderGBA.Avalonia.Dialogs;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 
@@ -19,8 +20,10 @@ namespace FEBuilderGBA.Avalonia.Views
     /// pick up ja/zh translations (ViewTranslationHelper does not translate
     /// ComboBoxItem content).
     ///
-    /// Uninstall is deferred to a follow-up issue; an applied insert can be
-    /// reverted via Undo for now.
+    /// Uninstall (#1242) reverts an applied EA patch in place: it traces the loaded
+    /// .event's written ranges via <c>EventAssemblerUninstallCore</c> and restores
+    /// those bytes from a user-supplied clean-original ROM, under undo. (An applied
+    /// insert can still also be reverted via the Undo button.)
     /// </summary>
     public partial class EventAssemblerView : TranslatedWindow, IEditorView
     {
@@ -196,10 +199,89 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
-        // Uninstall is DEFERRED to a follow-up issue. The faithful WinForms uninstall
-        // (PatchForm.MakeInstantEAToPatch → UnInstallPatch) is coupled to the WinForms
-        // patch subsystem, so it is out of scope for this slice; an applied insert can
-        // be reverted via the Undo button for now.
+        async void Uninstall_Click(object? sender, RoutedEventArgs e)
+        {
+            // Need a loaded .event to trace, and a loaded ROM to revert in place.
+            if (!_vm.SourceExists)
+            {
+                if (!await BrowseForSourceAsync() || !_vm.SourceExists)
+                    return; // user cancelled / no usable file
+            }
+            if (CoreState.ROM == null)
+            {
+                _vm.StatusMessage = R._("No ROM is loaded.");
+                return;
+            }
+
+            // Prompt for the CLEAN ORIGINAL ROM (the ROM as it was before the patch).
+            // Faithful to WF UnInstallPatch, which asks the user for a ROM that does
+            // NOT contain the patch and restores the traced ranges from it.
+            string? cleanRomPath = await FileDialogHelper.OpenRomFile(this);
+            if (string.IsNullOrEmpty(cleanRomPath))
+                return; // cancelled
+
+            byte[] cleanRom;
+            try
+            {
+                cleanRom = System.IO.File.ReadAllBytes(cleanRomPath);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("EventAssemblerView.Uninstall read clean ROM failed: " + ex.ToString());
+                _vm.StatusMessage = R._("Uninstall failed.") + "\r\n" + ex.ToString();
+                return;
+            }
+
+            UninstallButton.IsEnabled = false;
+            ImportButton.IsEnabled = false;
+            _vm.StatusMessage = R._("Uninstalling...");
+
+            // Same explicit-UndoData discipline as Import: the trace+revert runs off
+            // the UI thread (Task.Run), so we pass an explicit Undo.UndoData rather
+            // than the thread-local ambient scope. write_u8(addr, o, undo) records each
+            // restored byte into it; we push it (UI thread) via CommitExternal only on
+            // success, and roll it back on failure so a partial revert never sticks.
+            var undo = (CoreState.Undo ??= new Undo()).NewUndoData("Event Assembler Uninstall");
+
+            try
+            {
+                var result = await Task.Run(() =>
+                    EventAssemblerUninstallCore.Uninstall(_vm.SourcePath, cleanRom, undo));
+
+                if (result.Success)
+                {
+                    if (_undoService.CommitExternal(undo))
+                        _vm.CanUndo = true;
+                    _vm.HasResult = true;
+                    _vm.StatusMessage = R._("Uninstall successful.") + "\r\n"
+                        + R._("Reverted {0} range(s), {1} byte(s).",
+                            result.RangeCount.ToString(), result.BytesReverted.ToString());
+                }
+                else
+                {
+                    // Trace/validation failed → nothing was applied; roll back the
+                    // (empty) undo scope so it does not linger, and surface the error.
+                    CoreState.Undo.Rollback(undo);
+                    _vm.StatusMessage = R._("Uninstall failed.") + "\r\n" + result.ErrorMessage;
+                }
+            }
+            catch (Exception ex)
+            {
+                // A mid-revert exception leaves a partial write — roll it back.
+                try { CoreState.Undo?.Rollback(undo); }
+                catch (Exception rollbackEx)
+                {
+                    Log.Error("EventAssemblerView.Uninstall rollback failed: " + rollbackEx.ToString());
+                }
+                Log.Error("EventAssemblerView.Uninstall failed: " + ex.ToString());
+                _vm.StatusMessage = R._("Uninstall failed.") + "\r\n" + ex.ToString();
+            }
+            finally
+            {
+                UninstallButton.IsEnabled = true;
+                ImportButton.IsEnabled = true;
+            }
+        }
 
         public void NavigateTo(uint address) { }
         public void SelectFirstItem() { }

--- a/FEBuilderGBA.Avalonia/Views/EventAssemblerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventAssemblerView.axaml.cs
@@ -264,6 +264,12 @@ namespace FEBuilderGBA.Avalonia.Views
 
             UninstallButton.IsEnabled = false;
             ImportButton.IsEnabled = false;
+            // Disable Undo during the revert — it may already be visible from a prior
+            // Import, and a click mid-revert would race the in-progress undo writes and
+            // corrupt the undo/history state. Capture its prior enabled state so the
+            // finally restores EXACTLY that (not a blind true).
+            bool undoWasEnabled = UndoButton.IsEnabled;
+            UndoButton.IsEnabled = false;
             _vm.StatusMessage = R._("Uninstalling...");
 
             // Same explicit-UndoData discipline as Import: the trace+revert runs off
@@ -325,6 +331,11 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 UninstallButton.IsEnabled = true;
                 ImportButton.IsEnabled = true;
+                // Restore Undo to its PRIOR enabled state (success or failure) so a user
+                // who had it usable before the uninstall is never left without a working
+                // Undo button — and we don't enable it if it wasn't. A successful revert
+                // sets CanUndo=true (which also drives IsVisible), so Undo stays usable.
+                UndoButton.IsEnabled = undoWasEnabled;
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EventAssemblerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventAssemblerView.axaml.cs
@@ -253,9 +253,24 @@ namespace FEBuilderGBA.Avalonia.Views
                     if (_undoService.CommitExternal(undo))
                         _vm.CanUndo = true;
                     _vm.HasResult = true;
-                    _vm.StatusMessage = R._("Uninstall successful.") + "\r\n"
+                    string msg = R._("Uninstall successful.") + "\r\n"
                         + R._("Reverted {0} range(s), {1} byte(s).",
                             result.RangeCount.ToString(), result.BytesReverted.ToString());
+
+                    // NEVER claim a clean uninstall when the trace left residue. Warn the
+                    // user with the block count + the first few descriptions so they can
+                    // verify the ROM (mirrors how WF surfaces partial-uninstall risk).
+                    if (!result.FullyTraced)
+                    {
+                        int n = result.UntraceableBlocks.Count;
+                        msg += "\r\n\r\n" + R._("WARNING: {0} block(s) in this patch could not be traced and were NOT reverted — the uninstall may be incomplete. Please verify the ROM.", n.ToString());
+                        int shown = Math.Min(n, 5);
+                        for (int i = 0; i < shown; i++)
+                            msg += "\r\n  - " + result.UntraceableBlocks[i];
+                        if (n > shown)
+                            msg += "\r\n  - " + R._("...and {0} more.", (n - shown).ToString());
+                    }
+                    _vm.StatusMessage = msg;
                 }
                 else
                 {

--- a/FEBuilderGBA.Core.Tests/EventAssemblerUninstallCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerUninstallCoreTests.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="EventAssemblerUninstallCore"/>, the GUI-free in-place
+    /// uninstall of an applied Event Assembler patch (#1242, follow-up to #1170).
+    ///
+    /// Two layers of provability:
+    ///  1. Always-runnable, deterministic tests of the revert logic itself —
+    ///     validation (not-found / empty / too-small clean ROM → localized error,
+    ///     zero mutation) and a hand-built BinMapping round-trip that proves the
+    ///     byte-for-byte restore + undo without needing any compiler.
+    ///  2. An opportunistic REAL ColorzCore round-trip
+    ///     (compile+insert via <see cref="EventAssemblerCompileCore"/> → uninstall with
+    ///     the pre-insert bytes as the clean original → assert restoration) that runs
+    ///     where the EA toolchain works and SKIPS cleanly otherwise (same gating as the
+    ///     existing EventAssemblerCompileCore real-compile test).
+    /// </summary>
+    [Collection("SharedState")]
+    public class EventAssemblerUninstallCoreTests
+    {
+        static ROM CreateTestRom(int size = 0x200)
+        {
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(new byte[size]);
+            CoreState.ROM = rom;
+            return rom;
+        }
+
+        // FE8-detected synthetic ROM (no roms/*.gba dependency) — required for the
+        // real EA compile path to get a valid game code. Mirrors the helper in
+        // EventAssemblerCompileCoreTests.
+        static ROM CreateFE8Rom()
+        {
+            var data = new byte[0x1000000]; // 16 MB — minimum for FE8U detection
+            byte[] code = System.Text.Encoding.ASCII.GetBytes("BE8E01");
+            Array.Copy(code, 0, data, 0xAC, code.Length);
+
+            var rom = new ROM();
+            bool ok = rom.LoadLow("synthetic-FE8.gba", data, "BE8E01");
+            CoreState.ROM = rom;
+            return ok ? rom : null;
+        }
+
+        static Undo.UndoData NewUndo(ROM rom) => new Undo.UndoData
+        {
+            time = DateTime.Now,
+            name = "test",
+            list = new List<Undo.UndoPostion>(),
+            filesize = (uint)rom.Data.Length,
+        };
+
+        // ---- Validation: never throws, zero mutation on bad input ----------------
+
+        [Fact]
+        public void Uninstall_NoRomLoaded_ReturnsError_NoThrow()
+        {
+            CoreState.ROM = null;
+            var result = EventAssemblerUninstallCore.Uninstall("whatever.event", new byte[16], NewUnboundUndo());
+            Assert.False(result.Success);
+            Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+        }
+
+        [Fact]
+        public void Uninstall_MissingEventFile_ReturnsError_NoMutation()
+        {
+            var rom = CreateTestRom();
+            byte[] before = (byte[])rom.Data.Clone();
+
+            var result = EventAssemblerUninstallCore.Uninstall(
+                Path.Combine(Path.GetTempPath(), "no-such-" + Guid.NewGuid() + ".event"),
+                new byte[rom.Data.Length], NewUndo(rom));
+
+            Assert.False(result.Success);
+            Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+            Assert.Equal(before, rom.Data); // untouched
+        }
+
+        [Fact]
+        public void Uninstall_EmptyCleanRom_ReturnsError_NoMutation()
+        {
+            // An empty clean ROM is rejected before the trace even runs, so a bare
+            // (RomInfo-less) ROM is sufficient and the .event need not be traceable.
+            var rom = CreateTestRom();
+            string eaFile = WriteTinyOrgEvent(0x1000, "0xAA 0xBB");
+            byte[] before = (byte[])rom.Data.Clone();
+            try
+            {
+                var result = EventAssemblerUninstallCore.Uninstall(eaFile, new byte[0], NewUndo(rom));
+                Assert.False(result.Success);
+                Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+                Assert.Equal(before, rom.Data);
+            }
+            finally { TryDelete(eaFile); }
+        }
+
+        [Fact]
+        public void Uninstall_CleanRomTooSmall_ReturnsError_NoMutation()
+        {
+            // Needs a traceable ORG range, so use a RomInfo-bearing FE8 ROM. The ORG
+            // (0x900000) lies past a tiny clean ROM → rejected by the size sanity check.
+            var rom = CreateFE8Rom();
+            Assert.NotNull(rom);
+            string eaFile = WriteTinyOrgEvent(0x900000, "0x11 0x22 0x33 0x44");
+            byte[] before = (byte[])rom.Data.Clone();
+            try
+            {
+                var result = EventAssemblerUninstallCore.Uninstall(eaFile, new byte[0x10], NewUndo(rom));
+                Assert.False(result.Success);
+                Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+                Assert.Equal(before, rom.Data);
+            }
+            finally { TryDelete(eaFile); }
+        }
+
+        // ---- Pure-synthetic revert round-trip (ALWAYS runs, no compiler) ----------
+        //
+        // Drives UninstallPatchInner directly via the public Uninstall() entry: an EA
+        // file with a single ORG produces one length-0 ("unknown") BinMapping at that
+        // address; the revert auto-lengths it against the clean ROM and restores those
+        // bytes. We craft a known clean vs patched divergence and assert the patched
+        // bytes are rewritten to the clean ones, undoably.
+        [Fact]
+        public void Uninstall_OrgRange_RestoresBytesFromCleanRom_Undoable()
+        {
+            // Trace needs a RomInfo-bearing ROM. Snapshot its bytes as the "clean"
+            // original, then simulate an applied patch on top.
+            var rom = CreateFE8Rom();
+            Assert.NotNull(rom);
+
+            // Clean ROM = the ROM exactly as it is before we simulate the patch.
+            byte[] clean = (byte[])rom.Data.Clone();
+
+            // Simulate an applied patch: 4 changed bytes at a safe high offset.
+            uint patchAddr = 0x800000;
+            byte[] patched = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF };
+            for (int i = 0; i < patched.Length; i++)
+                rom.write_u8(patchAddr + (uint)i, patched[i]);
+
+            byte[] beforeRevert = (byte[])rom.Data.Clone();
+            Assert.NotEqual(clean[patchAddr], rom.Data[patchAddr]); // guard: they differ
+
+            string eaFile = WriteTinyOrgEvent(patchAddr, null); // ORG only → length-unknown mapping
+            var undo = NewUndo(rom);
+            try
+            {
+                var result = EventAssemblerUninstallCore.Uninstall(eaFile, clean, undo);
+
+                Assert.True(result.Success, result.ErrorMessage);
+                Assert.True(result.RangeCount >= 1);
+                Assert.True(result.BytesReverted >= 4);
+
+                // The patched bytes are now restored to the clean-original bytes.
+                Assert.Equal(clean[patchAddr + 0], (byte)rom.u8(patchAddr + 0));
+                Assert.Equal(clean[patchAddr + 1], (byte)rom.u8(patchAddr + 1));
+                Assert.Equal(clean[patchAddr + 2], (byte)rom.u8(patchAddr + 2));
+                Assert.Equal(clean[patchAddr + 3], (byte)rom.u8(patchAddr + 3));
+
+                // The revert was recorded → undoable: rolling back restores the patch.
+                Assert.NotEmpty(undo.list);
+                CoreState.Undo = new Undo();
+                CoreState.Undo.Push(undo);
+                CoreState.Undo.RunUndo();
+                Assert.Equal(beforeRevert, rom.Data);
+            }
+            finally { TryDelete(eaFile); CoreState.Undo = null; }
+        }
+
+        // ---- Real ColorzCore round-trip (OPPORTUNISTIC — skips if EA unavailable) --
+        //
+        // Compile+insert a tiny ORG/BYTE .event into an FE8 ROM, snapshot the
+        // pre-insert bytes, then uninstall with those pre-insert bytes as the clean
+        // original → assert the inserted range is restored. Gated exactly like the
+        // existing EventAssemblerCompileCore real-compile test (CI builds ColorzCore.exe
+        // but lacks the EA raws, so a compile failure SKIPS rather than fails).
+        [SkippableFact]
+        public void Uninstall_RealColorzCoreRoundTrip_RestoresInsertedBytes()
+        {
+            string exe = FindBuiltColorzCore();
+            Skip.If(exe == null,
+                "ColorzCore.exe not built — skipping the real compile+uninstall round-trip (the deterministic synthetic revert + validation tests still cover the uninstall logic).");
+
+            var rom = CreateFE8Rom();
+            Assert.NotNull(rom);
+            Assert.Equal("FE8", rom.RomInfo.TitleToFilename);
+
+            // Clean original = the ROM bytes BEFORE any insert.
+            byte[] cleanOriginal = (byte[])rom.Data.Clone();
+
+            string eaDir = Path.Combine(Path.GetTempPath(), "febuilder-ea-uninst-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(eaDir);
+            string eaFile = Path.Combine(eaDir, "tiny.event");
+            // ORG must be >= 0x200 so the uninstall parser's U.isSafetyOffset gate
+            // accepts it (the EA compiler itself has no such floor, but the trace does).
+            File.WriteAllText(eaFile, "ORG 0x1000\r\nBYTE 0xAA 0xBB 0xCC 0xDD\r\n");
+
+            var savedConfig = CoreState.Config;
+            var savedUndo = CoreState.Undo;
+            CoreState.Config = new Config { ["event_assembler"] = exe };
+            CoreState.Undo = new Undo();
+
+            try
+            {
+                // 1) Compile+insert via the #1170 helper.
+                var insertUndo = CoreState.Undo.NewUndoData("rt-insert");
+                var compile = EventAssemblerCompileCore.CompileAndInsert(
+                    rom, eaFile, EventAssemblerCompileCore.FreeAreaMode.None,
+                    insertUndo, SymbolUtil.DebugSymbol.None);
+
+                Skip.IfNot(compile.Success,
+                    "real EA compile unavailable in this environment (ColorzCore.exe present but compile failed — likely missing EA raws); skipping the uninstall round-trip. Output: " + compile.ErrorMessage);
+
+                // Guard: the insert actually changed the bytes we will revert.
+                Assert.Equal(0xAAu, rom.u8(0x1000));
+                Assert.Equal(0xBBu, rom.u8(0x1001));
+                Assert.Equal(0xCCu, rom.u8(0x1002));
+                Assert.Equal(0xDDu, rom.u8(0x1003));
+                Assert.NotEqual(cleanOriginal[0x1000], rom.Data[0x1000]);
+
+                // 2) Uninstall in place using the PRE-insert bytes as the clean original.
+                var uninstallUndo = CoreState.Undo.NewUndoData("rt-uninstall");
+                var result = EventAssemblerUninstallCore.Uninstall(eaFile, cleanOriginal, uninstallUndo);
+
+                Assert.True(result.Success, result.ErrorMessage);
+
+                // 3) The inserted range is restored to its pre-insert (clean) bytes.
+                Assert.Equal(cleanOriginal[0x1000], (byte)rom.u8(0x1000));
+                Assert.Equal(cleanOriginal[0x1001], (byte)rom.u8(0x1001));
+                Assert.Equal(cleanOriginal[0x1002], (byte)rom.u8(0x1002));
+                Assert.Equal(cleanOriginal[0x1003], (byte)rom.u8(0x1003));
+
+                // And the uninstall is itself undoable.
+                Assert.NotEmpty(uninstallUndo.list);
+            }
+            finally
+            {
+                CoreState.Config = savedConfig;
+                CoreState.Undo = savedUndo;
+                try { Directory.Delete(eaDir, true); } catch { }
+            }
+        }
+
+        // ---- EAUtilCore parser coverage (the extracted parse-only port) ----------
+
+        [Fact]
+        public void EAUtilCore_ParsesOrgAndLynHook_IntoDataList()
+        {
+            // ParseORG validates the offset via U.isSafetyOffset(uint), which reads
+            // CoreState.ROM.Data.Length (matching the WinForms parser, where Program.ROM
+            // is always loaded). Seed a ROM large enough that 0x123456 is a valid offset.
+            CreateTestRom(0x200000);
+
+            // A small .event exercising the ORG keyword and the HINT=LYN_HOOK form —
+            // both produce ORG-addressed Data entries the trace consumes. The LYN_HOOK
+            // hint must sit on a line with real content (ParseLynHook scans the raw
+            // line, but a comment-only line is skipped after comment-stripping — exactly
+            // as in real EA output where the hint trails a directive).
+            string path = Path.Combine(Path.GetTempPath(), "ea-parse-" + Path.GetRandomFileName() + ".event");
+            File.WriteAllText(path,
+                "ORG 0x123456\r\n" +
+                "BYTE 0x00 0x01 // HINT=LYN_HOOK=0x8000\r\n");
+            try
+            {
+                var ea = new EAUtilCore(path);
+                Assert.NotNull(ea.DataList);
+
+                bool hasOrgAt123456 = false;
+                bool hasHookAt8000 = false;
+                foreach (var d in ea.DataList)
+                {
+                    if (d.DataType == EAUtilCore.DataEnum.ORG)
+                    {
+                        // ORG 0x123456 → U.toOffset(0x123456) == 0x123456 (already an offset).
+                        if (d.ORGAddr == 0x123456u) hasOrgAt123456 = true;
+                        if (d.ORGAddr == 0x8000u) hasHookAt8000 = true;
+                    }
+                }
+                Assert.True(hasOrgAt123456, "ORG 0x123456 was not parsed into an ORG Data entry.");
+                Assert.True(hasHookAt8000, "HINT=LYN_HOOK=0x8000 was not parsed into an ORG Data entry.");
+            }
+            finally { TryDelete(path); }
+        }
+
+        [Fact]
+        public void EAUtilCore_IsFBGTemp_DetectsTempWrapper()
+        {
+            Assert.True(EAUtilCore.IsFBGTemp("_FBG_Temp_123.event"));
+            Assert.False(EAUtilCore.IsFBGTemp("real.event"));
+        }
+
+        // ---- helpers -------------------------------------------------------------
+
+        // An undo not bound to a specific ROM (for the no-ROM-loaded validation test).
+        static Undo.UndoData NewUnboundUndo() => new Undo.UndoData
+        {
+            time = DateTime.Now,
+            name = "test",
+            list = new List<Undo.UndoPostion>(),
+            filesize = 0,
+        };
+
+        // Write a minimal .event: an ORG line, optionally followed by a BYTE line.
+        static string WriteTinyOrgEvent(uint org, string byteArgs)
+        {
+            string path = Path.Combine(Path.GetTempPath(), "ea-uninst-" + Path.GetRandomFileName() + ".event");
+            string body = "ORG 0x" + org.ToString("X") + "\r\n";
+            if (!string.IsNullOrEmpty(byteArgs))
+                body += "BYTE " + byteArgs + "\r\n";
+            File.WriteAllText(path, body);
+            return path;
+        }
+
+        static void TryDelete(string path)
+        {
+            try { if (!string.IsNullOrEmpty(path) && File.Exists(path)) File.Delete(path); }
+            catch { }
+        }
+
+        static string FindBuiltColorzCore()
+        {
+            string dir = AppContext.BaseDirectory;
+            for (int i = 0; i < 12 && dir != null; i++)
+            {
+                // ColorzCore.csproj sets BaseOutputPath=bin/Core, so a `-c Core` build
+                // lands in bin/Core/Core/net6.0/, while a `-c Release|Debug` build lands
+                // in bin/Core/{config}/net6.0/. Check all layouts so the round-trip runs
+                // wherever the submodule was built.
+                foreach (string config in new[] { "Core", "Release", "Debug" })
+                {
+                    foreach (string name in new[] { "ColorzCore.exe", "ColorzCore" })
+                    {
+                        string p = Path.Combine(dir, "tools", "ColorzCore", "ColorzCore",
+                            "bin", "Core", config, "net6.0", name);
+                        if (File.Exists(p)) return p;
+
+                        // Standard output path (no BaseOutputPath override).
+                        p = Path.Combine(dir, "tools", "ColorzCore", "ColorzCore",
+                            "bin", config, "net6.0", name);
+                        if (File.Exists(p)) return p;
+                    }
+                }
+                dir = Path.GetDirectoryName(dir);
+            }
+            return null;
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/EventAssemblerUninstallCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerUninstallCoreTests.cs
@@ -224,6 +224,58 @@ namespace FEBuilderGBA.Core.Tests
             finally { try { Directory.Delete(eaDir, true); } catch { } }
         }
 
+        // PROCS advances the GREP baseline (lastMatchAddr += Append; Padding4) BEFORE it
+        // skips, matching WF PatchForm.TraceEAPatchedMapping. This is a CORRECTNESS guard:
+        // a block AFTER an untraceable PROCS must match at the ADVANCED baseline, not an
+        // earlier (decoy) address — otherwise we'd revert the wrong bytes.
+        [Fact]
+        public void TraceEAFile_ProcsSkip_AdvancesGrepBaseline_NextBlockMatchesAfterProcs()
+        {
+            var rom = CreateFE8Rom();
+            Assert.NotNull(rom);
+
+            // A unique 8-byte pattern for the BIN block after the PROCS.
+            byte[] pattern = { 0xDE, 0xAD, 0xC0, 0xDE, 0xFE, 0xED, 0xFA, 0xCE };
+
+            const uint orgAddr = 0x800000;   // ORG anchor → lastMatchAddr = 0x800000
+            const uint procsAdd = 0x1000;    // PROCS ADD → advances to Padding4(0x801000)
+            const uint advanced = orgAddr + procsAdd;       // 0x801000
+            const uint decoyAddr = orgAddr + 0x100;          // 0x800100 — BEFORE advanced
+            const uint realAddr = advanced + 0x1000;         // 0x802000 — AT/AFTER advanced
+
+            // DECOY copy (would be matched if the baseline were NOT advanced) + REAL copy
+            // (matched only from the advanced baseline).
+            for (int i = 0; i < pattern.Length; i++)
+            {
+                rom.write_u8(decoyAddr + (uint)i, pattern[i]);
+                rom.write_u8(realAddr + (uint)i, pattern[i]);
+            }
+
+            string eaDir = Path.Combine(Path.GetTempPath(), "ea-procs-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(eaDir);
+            File.WriteAllBytes(Path.Combine(eaDir, "blk.bin"), pattern);
+            string eaFile = Path.Combine(eaDir, "procs.event");
+            // ORG anchor, a PROCS hint (skipped — no length detection in Core), then a BIN.
+            // ADD= is parsed via U.atoi (DECIMAL, faithful to WF EAUtil.ParseAdd), so the
+            // hint value must be decimal — emit procsAdd in decimal, not hex.
+            File.WriteAllText(eaFile,
+                "ORG 0x" + orgAddr.ToString("X") + "\r\n" +
+                "procs_label: // HINT=PROCS ADD=" + procsAdd.ToString() + "\r\n" +
+                "#incbin \"blk.bin\" // HINT=BIN\r\n");
+            try
+            {
+                var trace = EventAssemblerUninstallCore.TraceEAFile(eaFile);
+
+                // PROCS is recorded as untraceable (skipped) ...
+                Assert.True(trace.UntracedCount > 0);
+                // ... but the BIN AFTER it matched at the ADVANCED address, NOT the decoy.
+                var bin = trace.Mappings.Find(m => m.addr == realAddr);
+                Assert.NotNull(bin); // would be null (matched decoyAddr) if the baseline weren't advanced
+                Assert.DoesNotContain(trace.Mappings, m => m.addr == decoyAddr);
+            }
+            finally { try { Directory.Delete(eaDir, true); } catch { } }
+        }
+
         // The trace API itself exposes FullyTraced + the note for a pure-untraceable EA.
         [Fact]
         public void TraceEAFile_UnHintedPng_RecordsUntraceable_NotFullyTraced()

--- a/FEBuilderGBA.Core.Tests/EventAssemblerUninstallCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerUninstallCoreTests.cs
@@ -212,6 +212,9 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.True(result.UntracedCount > 0);                 // the lead's signal
                 Assert.Equal(result.UntracedCount, result.UntraceableBlocks.Count);
                 Assert.NotEmpty(result.UntraceableBlocks);
+                // The notes are now localized via R._(), but the filename is a {0} param
+                // that survives translation in every locale — so this substring stays
+                // valid. The robust signal is FullyTraced/UntracedCount above.
                 Assert.Contains(result.UntraceableBlocks, s => s.Contains("img.png"));
 
                 // The traceable ORG bytes were still restored (residue does not block the

--- a/FEBuilderGBA.Core.Tests/EventAssemblerUninstallCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerUninstallCoreTests.cs
@@ -209,10 +209,13 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.True(result.Success, result.ErrorMessage);
                 // But the trace is NOT complete: the PNG block could not be reconstructed.
                 Assert.False(result.FullyTraced);
+                Assert.True(result.UntracedCount > 0);                 // the lead's signal
+                Assert.Equal(result.UntracedCount, result.UntraceableBlocks.Count);
                 Assert.NotEmpty(result.UntraceableBlocks);
                 Assert.Contains(result.UntraceableBlocks, s => s.Contains("img.png"));
 
-                // The traceable ORG bytes were still restored.
+                // The traceable ORG bytes were still restored (residue does not block the
+                // ranges we COULD trace).
                 Assert.Equal(clean[patchAddr], (byte)rom.u8(patchAddr));
             }
             finally { try { Directory.Delete(eaDir, true); } catch { } }
@@ -233,6 +236,8 @@ namespace FEBuilderGBA.Core.Tests
                 var trace = EventAssemblerUninstallCore.TraceEAFile(eaFile);
                 Assert.Empty(trace.Mappings);
                 Assert.False(trace.FullyTraced);
+                Assert.True(trace.UntracedCount > 0);
+                Assert.Equal(trace.UntracedCount, trace.Untraceable.Count);
                 Assert.NotEmpty(trace.Untraceable);
             }
             finally { try { Directory.Delete(eaDir, true); } catch { } }

--- a/FEBuilderGBA.Core.Tests/EventAssemblerUninstallCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerUninstallCoreTests.cs
@@ -170,6 +170,139 @@ namespace FEBuilderGBA.Core.Tests
             finally { TryDelete(eaFile); CoreState.Undo = null; }
         }
 
+        // ---- Untraceable blocks are SIGNALLED, never silently dropped --------------
+        //
+        // An .event with a traceable ORG range AND an un-hinted inline `#incext Png2Dmp`
+        // (no sibling .png.dmp → the Core parser cannot rasterize it) must: revert the
+        // ORG range (Success == true) BUT report FullyTraced == false with the PNG block
+        // listed in UntraceableBlocks — so the View can warn the user that the uninstall
+        // is incomplete rather than silently leaving patch residue.
+        [Fact]
+        public void Uninstall_UntraceableBlock_SignalsResidue_StillRevertsTraceable()
+        {
+            var rom = CreateFE8Rom();
+            Assert.NotNull(rom);
+            byte[] clean = (byte[])rom.Data.Clone();
+
+            uint patchAddr = 0x800000;
+            byte[] patched = new byte[] { 0x01, 0x02, 0x03, 0x04 };
+            for (int i = 0; i < patched.Length; i++)
+                rom.write_u8(patchAddr + (uint)i, patched[i]);
+
+            // A real (but un-hinted) PNG next to the .event so File.Exists passes but
+            // there is no .png.dmp → the Core parser records it as untraceable.
+            string eaDir = Path.Combine(Path.GetTempPath(), "ea-residue-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(eaDir);
+            string pngPath = Path.Combine(eaDir, "img.png");
+            File.WriteAllBytes(pngPath, new byte[] { 0x89, 0x50, 0x4E, 0x47 }); // PNG magic, no .dmp hint
+            string eaFile = Path.Combine(eaDir, "mix.event");
+            File.WriteAllText(eaFile,
+                "ORG 0x" + patchAddr.ToString("X") + "\r\n" +
+                "#incext Png2Dmp \"img.png\" --lz77\r\n");
+
+            var undo = NewUndo(rom);
+            try
+            {
+                var result = EventAssemblerUninstallCore.Uninstall(eaFile, clean, undo);
+
+                // The ORG range was reverted → Success.
+                Assert.True(result.Success, result.ErrorMessage);
+                // But the trace is NOT complete: the PNG block could not be reconstructed.
+                Assert.False(result.FullyTraced);
+                Assert.NotEmpty(result.UntraceableBlocks);
+                Assert.Contains(result.UntraceableBlocks, s => s.Contains("img.png"));
+
+                // The traceable ORG bytes were still restored.
+                Assert.Equal(clean[patchAddr], (byte)rom.u8(patchAddr));
+            }
+            finally { try { Directory.Delete(eaDir, true); } catch { } }
+        }
+
+        // The trace API itself exposes FullyTraced + the note for a pure-untraceable EA.
+        [Fact]
+        public void TraceEAFile_UnHintedPng_RecordsUntraceable_NotFullyTraced()
+        {
+            CreateFE8Rom();
+            string eaDir = Path.Combine(Path.GetTempPath(), "ea-trace-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(eaDir);
+            File.WriteAllBytes(Path.Combine(eaDir, "x.png"), new byte[] { 0x89, 0x50, 0x4E, 0x47 });
+            string eaFile = Path.Combine(eaDir, "only_png.event");
+            File.WriteAllText(eaFile, "#incext Png2Dmp \"x.png\"\r\n");
+            try
+            {
+                var trace = EventAssemblerUninstallCore.TraceEAFile(eaFile);
+                Assert.Empty(trace.Mappings);
+                Assert.False(trace.FullyTraced);
+                Assert.NotEmpty(trace.Untraceable);
+            }
+            finally { try { Directory.Delete(eaDir, true); } catch { } }
+        }
+
+        // ---- Malformed / non-matching clean ROM: clean error, NO partial write -----
+        //
+        // The revert math must (a) restore byte-for-byte from the clean ROM where the
+        // ranges are valid, and (b) reject a clean ROM that cannot cover a traced range
+        // BEFORE writing anything — a wrong-file pick must never leave a half-reverted
+        // ROM. This complements Uninstall_CleanRomTooSmall by asserting zero mutation on
+        // a clean ROM that is non-empty but still too small for the traced offset.
+        [Fact]
+        public void Uninstall_NonMatchingSmallCleanRom_NoPartialWrite()
+        {
+            var rom = CreateFE8Rom();
+            Assert.NotNull(rom);
+
+            uint patchAddr = 0x900000;
+            rom.write_u8(patchAddr, 0xEE);
+            byte[] beforeRevert = (byte[])rom.Data.Clone();
+
+            string eaFile = WriteTinyOrgEvent(patchAddr, null);
+            // Non-empty but far too small to cover patchAddr → must be rejected up front.
+            byte[] badClean = new byte[0x1000];
+            var undo = NewUndo(rom);
+            try
+            {
+                var result = EventAssemblerUninstallCore.Uninstall(eaFile, badClean, undo);
+
+                Assert.False(result.Success);
+                Assert.False(string.IsNullOrEmpty(result.ErrorMessage));
+                Assert.Empty(undo.list);                 // nothing was written
+                Assert.Equal(beforeRevert, rom.Data);    // ROM untouched (no partial write)
+            }
+            finally { TryDelete(eaFile); }
+        }
+
+        // The revert honors the mask + restores exact bytes for a multi-byte ASM-style
+        // range whose clean ROM is LARGER than the live ROM (still well-defined).
+        [Fact]
+        public void Uninstall_RestoresExactBytes_WhenCleanRomLargerThanLive()
+        {
+            var rom = CreateFE8Rom();
+            Assert.NotNull(rom);
+            byte[] clean = (byte[])rom.Data.Clone();
+
+            uint patchAddr = 0x810000;
+            byte[] patched = new byte[] { 0xAA, 0xBB, 0xCC, 0xDD, 0xEE };
+            for (int i = 0; i < patched.Length; i++)
+                rom.write_u8(patchAddr + (uint)i, patched[i]);
+
+            // Clean ROM larger than the live ROM — the restore is still well-defined for
+            // every traced offset (highest <= clean.Length).
+            byte[] biggerClean = new byte[clean.Length + 0x1000];
+            Array.Copy(clean, biggerClean, clean.Length);
+
+            string eaFile = WriteTinyOrgEvent(patchAddr, null);
+            var undo = NewUndo(rom);
+            try
+            {
+                var result = EventAssemblerUninstallCore.Uninstall(eaFile, biggerClean, undo);
+                Assert.True(result.Success, result.ErrorMessage);
+                Assert.True(result.FullyTraced);
+                for (uint i = 0; i < patched.Length; i++)
+                    Assert.Equal(biggerClean[patchAddr + i], (byte)rom.u8(patchAddr + i));
+            }
+            finally { TryDelete(eaFile); }
+        }
+
         // ---- Real ColorzCore round-trip (OPPORTUNISTIC — skips if EA unavailable) --
         //
         // Compile+insert a tiny ORG/BYTE .event into an FE8 ROM, snapshot the

--- a/FEBuilderGBA.Core/EAUtilCore.cs
+++ b/FEBuilderGBA.Core/EAUtilCore.cs
@@ -81,6 +81,14 @@ namespace FEBuilderGBA
 
         public List<Data> DataList { get; private set; }
         public List<string> IfNDefList { get; private set; }
+        /// <summary>
+        /// Human-readable notes about EA blocks this Core parser could NOT reconstruct
+        /// (currently: un-hinted inline <c>#incext Png2Dmp</c> rasters — see the class
+        /// doc scope boundary). Callers (e.g. the uninstall tracer) surface these so a
+        /// revert is never SILENTLY incomplete. Empty == the parser reconstructed every
+        /// emitting block it saw.
+        /// </summary>
+        public List<string> UntraceableNotes { get; private set; }
         public string Filename { get; private set; }
         public string Dir { get; private set; }
         EAUtilLynDumpMode LynDump;
@@ -96,6 +104,7 @@ namespace FEBuilderGBA
             this.Filename = filename;
             this.Dir = Path.GetDirectoryName(filename);
             this.IfNDefList = new List<string>();
+            this.UntraceableNotes = new List<string>();
 
             this.CurrentLabel = "";
             string[] lines = File.ReadAllLines(filename);
@@ -537,19 +546,12 @@ namespace FEBuilderGBA
             }
 
             DataEnum dataType = DataEnum.BIN;
-            if (orignalIine.IndexOf("--lz77") >= 0)
-            {
-                byte[] image = Png2DmpHint(fullbinname);
-                if (image.Length > 0)
-                {
-                    Data data = new Data(filename, this.Dir, image, dataType);
-                    this.DataList.Add(data);
-                    return true;
-                }
-            }
 
-            // Non-lz77 inline raster requires ImageUtil.OpenBitmap (WinForms-only);
-            // the .png.dmp hint, when present, gives the same bytes without it.
+            // Both the --lz77 and plain inline-raster paths need ImageUtil.OpenBitmap
+            // (WinForms-only) to rasterize; the sibling .png.dmp hint, when present,
+            // gives the same bytes without it. If the hint is missing we CANNOT
+            // reconstruct this block — record an untraceable note so the uninstall
+            // tracer never silently omits the range (it stays as patch residue).
             byte[] hint = Png2DmpHint(fullbinname);
             if (hint.Length > 0)
             {
@@ -558,6 +560,7 @@ namespace FEBuilderGBA
                 return true;
             }
 
+            this.UntraceableNotes.Add("Png2Dmp image (no .dmp hint): " + filename);
             return false;
         }
 

--- a/FEBuilderGBA.Core/EAUtilCore.cs
+++ b/FEBuilderGBA.Core/EAUtilCore.cs
@@ -1,0 +1,633 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// GUI-free port of the Event Assembler simple parser
+    /// (WinForms <c>EAUtil</c>, FEBuilderGBA/EAUtil.cs), scoped to the data kinds the
+    /// in-place <b>Uninstall</b> trace consumes (#1242, follow-up to #1170). Shared by
+    /// <see cref="EventAssemblerUninstallCore"/> and any future headless EA tracer.
+    ///
+    /// Faithfully reproduces the WinForms <c>Parse()</c> ordering and the
+    /// <c>ORG / #incbin (ASM/BIN/MIX) / #inctevent|#inctext lyn / LYN_HOOK /
+    /// #include lyn.event / String(...) / HINT=POINTER_ARRAY / HINT=PROCS</c> data
+    /// emission, producing the same <see cref="Data"/>/<see cref="DataEnum"/> list the
+    /// WinForms tracer walks. Uses only Core-resident types (<see cref="U"/>,
+    /// <see cref="Elf"/>, <see cref="DisassemblerTrumb"/>, <see cref="EAUtilLynDumpMode"/>,
+    /// <see cref="CoreState.ROM"/>, <see cref="CoreState.SystemTextEncoder"/>).
+    ///
+    /// Scope boundary (intentional, documented — mirrors #1170's auto-def boundary,
+    /// NOT a silent truncation): the WinForms parser's <c>#incext Png2Dmp</c> path
+    /// rasterizes a PNG inline via <c>ImageUtil.OpenBitmap</c> (System.Drawing,
+    /// WinForms-only). This Core parser keeps only the <c>.png.dmp</c> HINT-file
+    /// fallback (the same byte source the WinForms path uses when a sibling
+    /// <c>*.png.dmp</c> exists, EAUtil.cs <c>Png2DmpLZ77</c>) and otherwise skips an
+    /// inline PNG-raster block. The uninstall trace GREP-matches the produced BIN in
+    /// ROM either way, so a hinted PNG is traced; an un-hinted inline raster is the one
+    /// EA data kind this Core parser does not reconstruct. Such scripts must run through
+    /// the WinForms patch uninstall.
+    /// </summary>
+    public class EAUtilCore
+    {
+        public enum DataEnum
+        {
+            ORG
+            , MIX //incbinされたデータ 判別不能
+            , ASM //incbinされたデータ ASM
+            , BIN //incbinされたデータ BIN
+            , LYN //lynによってインポートされるelfファイル
+            , LYNHOOK //lynによるフック 16バイト
+            , POINTER_ARRAY
+            , PROCS
+        }
+
+        public class Data
+        {
+            public string Name { get; private set; }
+            public string Dir { get; private set; }
+            public uint ORGAddr { get; private set; }
+            public byte[] BINData { get; private set; }
+            public DataEnum DataType { get; private set; }
+            public uint Append { get; private set; }
+
+            public Data(uint orgaddr, DataEnum dataType, uint append = 0)
+            {
+                this.ORGAddr = orgaddr;
+                this.DataType = dataType;
+                this.Append = append;
+                this.Name = "";
+                this.Dir = "";
+            }
+            public Data(string name, byte[] data, DataEnum dataType, uint append = 0)
+            {
+                this.Name = name;
+                this.Dir = "";
+                this.BINData = data;
+                this.DataType = dataType;
+                this.Append = append;
+            }
+            public Data(string filename, string dir, byte[] data, DataEnum dataType, uint append = 0)
+            {
+                this.Name = filename;
+                this.Dir = dir;
+                this.BINData = data;
+                this.DataType = dataType;
+                this.Append = append;
+            }
+        }
+
+        public List<Data> DataList { get; private set; }
+        public List<string> IfNDefList { get; private set; }
+        public string Filename { get; private set; }
+        public string Dir { get; private set; }
+        EAUtilLynDumpMode LynDump;
+
+        public EAUtilCore(string filename)
+        {
+            Parse(filename);
+        }
+
+        void Parse(string filename)
+        {
+            this.DataList = new List<Data>();
+            this.Filename = filename;
+            this.Dir = Path.GetDirectoryName(filename);
+            this.IfNDefList = new List<string>();
+
+            this.CurrentLabel = "";
+            string[] lines = File.ReadAllLines(filename);
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string line = U.ClipComment(lines[i]);
+                if (line == "")
+                {
+                    continue;
+                }
+
+                ParseJumpToHack(line);
+                ParseIfNDef(line);
+            }
+            //本格的なパース.
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string line = U.ClipComment(lines[i]);
+                if (ParseLynDump(line, lines[i]))
+                {
+                    continue;
+                }
+                if (line == "")
+                {
+                    continue;
+                }
+
+                ParseORG(line);
+                ParseIncBIN(line, lines[i]);
+                ParseLynELF(line, lines[i]);
+                ParseLynHook(line, lines[i]);
+                ParseLynInclude(line, lines[i]);
+                ParsePng2Dmp(line, lines[i]);
+                ParseString(line, lines[i]);
+                ParseLabel(line, lines[i]);
+            }
+            ParseLynDump("", "");
+        }
+
+        bool ParseLynDump(string line, string orignalIine)
+        {
+            if (this.LynDump == null)
+            {
+                if (line == "")
+                {
+                    return false;
+                }
+                if (orignalIine.IndexOf("// lyn output of ", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    this.LynDump = new EAUtilLynDumpMode();
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            if (this.LynDump == null)
+            {
+                return false;
+            }
+
+            bool r = this.LynDump.ParseLine(line);
+            if (r)
+            {//LYNDUMPの処理を行うので、続きのパースは不要.
+                return true;
+            }
+
+            //LYNDUMPの終了
+            AddLynDump(this.LynDump, "");
+
+            this.LynDump = null;
+            return false;
+        }
+
+        void AddLynDump(EAUtilLynDumpMode lyn, string filename)
+        {
+            if (lyn.GetCount() == 0)
+            {//ORG指定がない場合
+                if (filename == "")
+                {
+                    filename = "LYNDUMP";
+                }
+                Data data = new Data(filename, this.Dir, lyn.GetDataAll(), DataEnum.LYN, 0);
+                this.DataList.Add(data);
+                return;
+            }
+
+            int count = lyn.GetCount();
+            for (int i = 0; i < count; i++)
+            {
+                Data data = new Data("LYNDUMP_" + lyn.GetName(i), lyn.GetData(i), DataEnum.LYN, 0);
+                this.DataList.Add(data);
+            }
+        }
+
+        void ParseLabel(string line, string orignalIine)
+        {
+            string a = line.Trim();
+            int pos = a.IndexOf(':');
+            if (pos < 0)
+            {
+                return;
+            }
+            this.CurrentLabel = a.Substring(0, pos);
+
+
+            if (orignalIine.IndexOf("HINT=POINTER_ARRAY", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                uint append = ParseAdd(orignalIine);
+                Data data = new Data(this.CurrentLabel, new byte[] { }, DataEnum.POINTER_ARRAY, append);
+                this.DataList.Add(data);
+            }
+            else if (orignalIine.IndexOf("HINT=PROCS", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                uint append = ParseAdd(orignalIine);
+                byte[] procsTopBIN = ParseProcs(orignalIine);
+                Data data = new Data(this.CurrentLabel, procsTopBIN, DataEnum.PROCS, append);
+                this.DataList.Add(data);
+            }
+        }
+
+        byte[] ParseProcs(string orignalIine)
+        {
+            int pos = orignalIine.IndexOf("HINT=PROCS");
+            if (pos < 0)
+            {
+                return new byte[] { };
+            }
+            string str = orignalIine.Substring(pos);
+            str = U.cut(str, "\"", "\"");
+            if (str == "")
+            {
+                return new byte[] { };
+            }
+            // CoreState.SystemTextEncoder / CoreState.ROM mirror the WinForms
+            // Program.SystemTextEncoder / Program.ROM used by the original.
+            if (CoreState.SystemTextEncoder == null || CoreState.ROM == null)
+            {
+                return new byte[] { };
+            }
+            byte[] needString = CoreState.SystemTextEncoder.Encode(str);
+            uint hintStringAddr = U.Grep(CoreState.ROM.Data, needString, CoreState.ROM.RomInfo.compress_image_borderline_address, 0, 4);
+            if (hintStringAddr == U.NOT_FOUND)
+            {
+                return new byte[] { };
+            }
+            byte[] needProcString = new byte[8];
+            U.write_u8(needProcString, 0, 0x01);
+            U.write_p32(needProcString, 4, hintStringAddr);
+
+            return needProcString;
+        }
+
+        int FindJumpToHack(string line)
+        {
+            int pos = line.IndexOf("jumpToHack", StringComparison.OrdinalIgnoreCase);
+            if (pos >= 0)
+            {
+                return pos;
+            }
+            pos = line.IndexOf("callHack", StringComparison.OrdinalIgnoreCase);
+            if (pos >= 0)
+            {
+                return pos;
+            }
+            pos = line.IndexOf("replaceWithHack", StringComparison.OrdinalIgnoreCase);
+            if (pos >= 0)
+            {
+                return pos;
+            }
+
+            return -1;
+        }
+
+        void ParseIfNDef(string line)
+        {
+            int pos = line.IndexOf("#ifndef", StringComparison.OrdinalIgnoreCase);
+            if (pos < 0)
+            {
+                return;
+            }
+
+            string ifdef_keyword = line.Substring(pos + 7 + 1).Trim();
+            if (ifdef_keyword == "")
+            {
+                return;
+            }
+            IfNDefList.Add(ifdef_keyword);
+        }
+
+        void ParseJumpToHack(string line)
+        {
+            int pos = FindJumpToHack(line);
+            if (pos < 0)
+            {
+                return;
+            }
+            string label = U.cut(line, "(", ")");
+            JumpToHackLabeles.Add(label);
+        }
+
+        bool isCode(string fullPath)
+        {
+            //ソースコードがあればASMだろう.
+            string srcFilename = U.ChangeExtFilename(fullPath, ".s");
+            if (File.Exists(srcFilename))
+            {//ソースコードがあったのでASMです
+                return true;
+            }
+            srcFilename = U.ChangeExtFilename(fullPath, ".asm");
+            if (File.Exists(srcFilename))
+            {//ソースコードがあったのでASMです
+                return true;
+            }
+
+            if (this.JumpToHackLabeles.IndexOf(this.CurrentLabel) >= 0)
+            {//JumpToHackで呼び出されているのでASMです
+                return true;
+            }
+            return false;
+        }
+
+        string CurrentLabel;
+        List<string> JumpToHackLabeles = new List<string>();
+
+        bool ParseIncBIN(string line, string orignalIine)
+        {
+            string a = Keyword(line, "#incbin");
+            if (a == "")
+            {
+                return false;
+            }
+            string filename = U.cut(a, "\"", "\"");
+            string fullbinname = Path.Combine(this.Dir, filename);
+
+            DataEnum dataType;
+            if (orignalIine.IndexOf("HINT=BIN", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                dataType = DataEnum.BIN;
+            }
+            else if (orignalIine.IndexOf("HINT=ASM", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                dataType = DataEnum.ASM;
+            }
+            else if (filename.IndexOf(".png.") >= 0)
+            {//png
+                dataType = DataEnum.BIN;
+            }
+            else
+            {//ヒントがない場合は、 JumpToHackの有無で判断します.
+                if (isCode(fullbinname))
+                {
+                    dataType = DataEnum.ASM;
+                }
+                else
+                {
+                    dataType = DataEnum.MIX;
+                }
+            }
+            if (!File.Exists(fullbinname))
+            {
+                Data emptydata = new Data(filename, this.Dir, new byte[0], dataType);
+                this.DataList.Add(emptydata);
+                return false;
+            }
+
+            Data data = new Data(filename, this.Dir, File.ReadAllBytes(fullbinname), dataType);
+            this.DataList.Add(data);
+            return true;
+        }
+
+        bool ParseLynHook(string line, string orignalIine)
+        {
+            string keyword = "HINT=LYN_HOOK=";
+            int pos = orignalIine.IndexOf(keyword);
+            if (pos < 0)
+            {
+                return false;
+            }
+            uint orgaddr = U.atoi0x(orignalIine.Substring(pos + keyword.Length));
+
+            Data data = new Data(orgaddr, DataEnum.ORG);
+            this.DataList.Add(data);
+            return true;
+        }
+
+        bool ParseLynELF(string line, string orignalIine)
+        {
+            bool inctevent_lyn = false;
+            string a = Keyword(line, "#inctevent lyn");
+            if (a == "")
+            {
+                a = Keyword(line, "#inctext lyn");
+                if (a == "")
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                inctevent_lyn = true;
+            }
+            string filename = U.cut(a, "\"", "\"");
+            string fullbinname = Path.Combine(this.Dir, filename);
+
+            DataEnum dataType = DataEnum.LYN;
+            if (!File.Exists(fullbinname))
+            {
+                Data emptydata = new Data(filename, this.Dir, new byte[0], dataType);
+                this.DataList.Add(emptydata);
+                return false;
+            }
+
+            Elf elf = new Elf(fullbinname, useHookMode: false);
+            Data data = new Data(filename, this.Dir, elf.ProgramBIN, dataType);
+            this.DataList.Add(data);
+
+            if (inctevent_lyn == false)
+            {
+                ParseLynSecondArgs(a);
+            }
+            return true;
+        }
+
+        bool ParseLynSecondArgs(string a)
+        {
+            //次の引数へ
+            a = U.skip(a, "\"");
+            a = U.skip(a, "\"");
+            string filename = U.cut(a, "\"", "\"");
+            string fullbinname = Path.Combine(this.Dir, filename);
+
+            if (!File.Exists(fullbinname))
+            {
+                return false;
+            }
+
+            Elf elf = new Elf(fullbinname, useHookMode: true);
+            foreach (Elf.Sym sym in elf.SymList)
+            {
+                if (!U.isPointer(sym.addr))
+                {
+                    continue;
+                }
+                uint addr = U.toOffset(sym.addr);
+                addr = DisassemblerTrumb.ProgramAddrToPlain(addr);
+                Data data = new Data(addr, DataEnum.LYNHOOK);
+                this.DataList.Add(data);
+            }
+
+            return true;
+        }
+
+        bool ParseLynInclude(string line, string orignalIine)
+        {
+            int start = line.IndexOf("#include");
+            if (start < 0)
+            {
+                return false;
+            }
+
+            int lyn_event_pos = line.IndexOf("lyn.event", start);
+            if (lyn_event_pos < 0)
+            {
+                return false;
+            }
+            string filename = U.cut(line, "\"", "\"");
+            string fullfilename = Path.Combine(this.Dir, filename);
+
+            if (!File.Exists(fullfilename))
+            {
+                return false;
+            }
+
+            string[] lines = File.ReadAllLines(fullfilename);
+            EAUtilLynDumpMode lyndmp = new EAUtilLynDumpMode();
+            foreach (string l in lines)
+            {
+                bool r = lyndmp.ParseLine(l);
+                if (!r)
+                {
+                    break;
+                }
+            }
+
+            //LYNDUMPの終了
+            AddLynDump(lyndmp, filename);
+            return true;
+        }
+
+        bool ParseString(string line, string orignalIine)
+        {
+            int start = line.IndexOf("String(");
+            if (start < 0)
+            {
+                return false;
+            }
+
+            start += 7;
+            int term = line.IndexOf(')', start);
+            if (term <= 0)
+            {
+                return false;
+            }
+            string str = line.Substring(start, term - start);
+            str = str.Trim('"');
+            byte[] lowbin = System.Text.Encoding.GetEncoding("Shift_JIS").GetBytes(str);
+
+            uint size = (uint)lowbin.Length + 1;
+            byte[] bin = new byte[size];
+            Array.Copy(lowbin, bin, lowbin.Length);
+
+            Data data = new Data("String(" + str + ")", bin, DataEnum.BIN);
+            this.DataList.Add(data);
+
+            return true;
+        }
+
+        // Scope boundary (see class doc): only the .png.dmp HINT-file fallback is
+        // honoured here — the inline PNG rasterization (ImageUtil.OpenBitmap) is
+        // WinForms-only and cannot move to Core. An un-hinted inline raster block is
+        // skipped; a hinted one is emitted as BIN and traced like any other BIN.
+        bool ParsePng2Dmp(string line, string orignalIine)
+        {
+            string a = Keyword(line, "#incext Png2Dmp");
+            if (a == "")
+            {
+                return false;
+            }
+            string filename = U.cut(a, "\"", "\"");
+            string fullbinname = Path.Combine(this.Dir, filename);
+
+            if (!File.Exists(fullbinname))
+            {
+                return false;
+            }
+
+            DataEnum dataType = DataEnum.BIN;
+            if (orignalIine.IndexOf("--lz77") >= 0)
+            {
+                byte[] image = Png2DmpHint(fullbinname);
+                if (image.Length > 0)
+                {
+                    Data data = new Data(filename, this.Dir, image, dataType);
+                    this.DataList.Add(data);
+                    return true;
+                }
+            }
+
+            // Non-lz77 inline raster requires ImageUtil.OpenBitmap (WinForms-only);
+            // the .png.dmp hint, when present, gives the same bytes without it.
+            byte[] hint = Png2DmpHint(fullbinname);
+            if (hint.Length > 0)
+            {
+                Data data = new Data(filename, this.Dir, hint, dataType);
+                this.DataList.Add(data);
+                return true;
+            }
+
+            return false;
+        }
+
+        static byte[] Png2DmpHint(string filename)
+        {
+            string hint = filename + ".dmp";
+            if (File.Exists(hint))
+            {
+                return File.ReadAllBytes(hint);
+            }
+            return new byte[] { };
+        }
+
+        bool ParseORG(string line)
+        {
+            string a = Keyword(line, "ORG");
+            if (a == "")
+            {
+                return false;
+            }
+            uint addr = U.atoi0x(a);
+            if (addr <= 0)
+            {
+                return false;
+            }
+            addr = U.toOffset(addr);
+            if (!U.isSafetyOffset(addr))
+            {
+                return false;
+            }
+
+            Data data = new Data(addr, DataEnum.ORG);
+            this.DataList.Add(data);
+            return true;
+        }
+
+        string Keyword(string line, string keyword)
+        {
+            int pos = line.IndexOf(keyword + " ", StringComparison.OrdinalIgnoreCase);
+            if (pos < 0)
+            {
+                pos = line.IndexOf(keyword + "\t", StringComparison.OrdinalIgnoreCase);
+                if (pos < 0)
+                {
+                    return "";
+                }
+            }
+            string r = line.Substring(pos + keyword.Length + 1).Trim();
+            return r;
+        }
+
+        public static bool IsFBGTemp(string filename)
+        {
+            string file = Path.GetFileName(filename);
+            return (file.IndexOf("_FBG_Temp_") == 0);
+        }
+
+        uint ParseAdd(string orignalIine)
+        {
+            int hint_pos = orignalIine.IndexOf("HINT=");
+            if (hint_pos < 0)
+            {
+                return 0;
+            }
+            int add_pos = orignalIine.IndexOf("ADD=", hint_pos + 5);
+            if (add_pos < 0)
+            {
+                return 0;
+            }
+            return U.atoi(orignalIine.Substring(add_pos + 4));
+        }
+    }
+}

--- a/FEBuilderGBA.Core/EAUtilCore.cs
+++ b/FEBuilderGBA.Core/EAUtilCore.cs
@@ -39,7 +39,13 @@ namespace FEBuilderGBA
             , ASM //incbinされたデータ ASM
             , BIN //incbinされたデータ BIN
             , LYN //lynによってインポートされるelfファイル
-            , LYNHOOK //lynによるフック 16バイト
+            // lyn hook. The hook STUB that lyn writes at the hooked address is 16 bytes
+            // (the WF source's "16バイト" refers to that stub). The UNINSTALL TRACER
+            // reverts a 20-byte range at the hook address, matching WF
+            // PatchForm.TraceEAPatchedMapping (length = 20): it covers the 16-byte stub
+            // plus the 4-byte aligned slot lyn may also overwrite, so the revert
+            // restores the whole patched region rather than only the stub.
+            , LYNHOOK
             , POINTER_ARRAY
             , PROCS
         }
@@ -560,7 +566,7 @@ namespace FEBuilderGBA
                 return true;
             }
 
-            this.UntraceableNotes.Add("Png2Dmp image (no .dmp hint): " + filename);
+            this.UntraceableNotes.Add(R._("Png2Dmp image (no .dmp hint): {0}", filename));
             return false;
         }
 

--- a/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
+++ b/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
@@ -333,11 +333,20 @@ namespace FEBuilderGBA
                 }
                 else if (data.DataType == EAUtilCore.DataEnum.PROCS)
                 {
+                    // Advance the GREP baseline BEFORE skipping — exactly as WF
+                    // PatchForm.TraceEAPatchedMapping does (lastMatchAddr += Append;
+                    // Padding4) at the TOP of its PROCS branch, before the
+                    // CalcLengthAndCheck==NOT_FOUND `continue`. Omitting this would leave
+                    // lastMatchAddr pointing BEFORE the PROCS region, so the next block's
+                    // GREP could match an earlier address and revert the WRONG bytes.
+                    lastMatchAddr += data.Append;
+                    lastMatchAddr = U.Padding4(lastMatchAddr);
+
                     // PROCS length detection (ProcsScriptForm.CalcLengthAndCheck) is
-                    // WinForms-only; without it the length is unknown, so we skip this
-                    // range — identical to the WinForms tracer's `continue` when that
-                    // returns NOT_FOUND. Record it as residue so the caller can warn.
-                    // (See class doc scope note.)
+                    // WinForms-only; without it the length is unknown, so we skip the
+                    // range itself — identical to the WinForms tracer's `continue` when
+                    // CalcLengthAndCheck returns NOT_FOUND. Record it as residue so the
+                    // caller can warn. (See class doc scope note.)
                     result.Untraceable.Add(R._("PROCS table (length detection is WinForms-only): {0}",
                         string.IsNullOrEmpty(data.Name) ? R._("(label)") : data.Name));
                     continue;

--- a/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
+++ b/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
@@ -1,0 +1,613 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// GUI-free in-place <b>Uninstall</b> for an applied Event Assembler patch
+    /// (#1242, follow-up to #1170's <see cref="EventAssemblerCompileCore"/>). Ported
+    /// from the WinForms patch-uninstall path
+    /// (<c>EventAssemblerForm.UninstallButton_Click</c> →
+    /// <c>PatchForm.MakeInstantEAToPatch</c> → <c>PatchForm.UnInstallPatch</c> →
+    /// <c>TracePatchedMapping</c>/<c>TraceEAPatchedMapping</c> →
+    /// <c>UninstallPatchInner</c>), keeping the exact trace semantics, the
+    /// clean-original-ROM restore, the auto-length fallback and the ROM-tail strip.
+    ///
+    /// Flow: parse the EA file with <see cref="EAUtilCore"/> into written ranges
+    /// (<see cref="BinMapping"/>s) against the CURRENT (patched) ROM, then overwrite
+    /// each traced byte with the corresponding byte from a user-supplied
+    /// <b>clean original</b> ROM (the ROM as it was before the patch), recording every
+    /// write into an explicit <see cref="Undo.UndoData"/> so the uninstall is fully
+    /// undoable. Never throws on bad input — a wrong / mismatched clean ROM returns a
+    /// localized error string instead (the live ROM is left untouched in that case).
+    ///
+    /// Scope vs the WinForms patch uninstall (intentional, documented):
+    ///  - This operates on a SINGLE loaded .event (the Avalonia EA tool's input),
+    ///    matching <c>MakeInstantEAToPatch</c> which builds a bare
+    ///    <c>{TYPE=EA, EA=filename}</c> patch with NO extra params. The WinForms
+    ///    trailing helpers driven by patch params — <c>TraceEditPatch</c> (EDIT_PATCH),
+    ///    <c>AppendMenuPatch</c> (MENU), <c>AppendNewTargetSelectionStruct</c>,
+    ///    <c>AppnedInstallMapping</c> (PATCHED_IF/IF) — have no params to act on for an
+    ///    instant-EA patch, so they add nothing and are omitted here.
+    ///  - PROCS (<c>HINT=PROCS</c>) length detection uses the WinForms-only
+    ///    <c>ProcsScriptForm.CalcLengthAndCheck</c>; this Core path skips a PROCS range
+    ///    whose length it cannot determine — identical observable behaviour to the
+    ///    WinForms tracer, which <c>continue</c>s when that returns NOT_FOUND.
+    /// </summary>
+    public static class EventAssemblerUninstallCore
+    {
+        /// <summary>
+        /// One traced ROM range written by the EA patch. Mirrors WinForms
+        /// <c>PatchForm.BinMapping</c> (the subset the EA path populates).
+        /// </summary>
+        public sealed class BinMapping
+        {
+            public string key;
+            public string filename;
+            public uint addr;
+            public uint length;     // 0 == unknown (auto-length on revert)
+            public Address.DataTypeEnum type;
+            public byte[] bin;
+            public bool[] mask;
+        }
+
+        /// <summary>Structured result of an uninstall run.</summary>
+        public sealed class UninstallResult
+        {
+            /// <summary>True when the patch ranges were restored from the clean ROM.</summary>
+            public bool Success { get; set; }
+            /// <summary>Localized error (set when <see cref="Success"/> is false).</summary>
+            public string ErrorMessage { get; set; } = "";
+            /// <summary>Number of traced ranges that were reverted.</summary>
+            public int RangeCount { get; set; }
+            /// <summary>Total bytes written back from the clean ROM.</summary>
+            public uint BytesReverted { get; set; }
+        }
+
+        /// <summary>
+        /// Trace the ranges an EA file writes, against the CURRENT (patched) ROM in
+        /// <see cref="CoreState.ROM"/>. Faithful port of the EA branch of
+        /// <c>TraceEAPatchedMapping</c>, walking a single .event's
+        /// <see cref="EAUtilCore"/> DataList. Returns an empty list when the ROM is not
+        /// loaded or the file cannot be parsed.
+        /// </summary>
+        public static List<BinMapping> TraceEAFile(string eaFilePath)
+        {
+            var binMappings = new List<BinMapping>();
+            ROM rom = CoreState.ROM;
+            // RomInfo is needed for the GREP search baseline
+            // (compress_image_borderline_address); it is null only for a not-yet-
+            // identified ROM, which the EA tool never uninstalls against. Guard so a
+            // bad caller gets an empty trace (→ clean "could not trace" error) rather
+            // than an NRE.
+            if (rom == null || rom.RomInfo == null
+                || string.IsNullOrEmpty(eaFilePath) || !File.Exists(eaFilePath))
+            {
+                return binMappings;
+            }
+            if (EAUtilCore.IsFBGTemp(eaFilePath))
+            {
+                return binMappings;
+            }
+
+            EAUtilCore ea;
+            try
+            {
+                ea = new EAUtilCore(eaFilePath);
+            }
+            catch (IOException)
+            {
+                return binMappings;
+            }
+
+            uint lastMatchAddr = rom.RomInfo.compress_image_borderline_address;
+
+            for (int n = 0; n < ea.DataList.Count; n++)
+            {
+                EAUtilCore.Data data = ea.DataList[n];
+                if (data.DataType == EAUtilCore.DataEnum.ORG)
+                {
+                    uint addr = data.ORGAddr;
+
+                    var b = new BinMapping
+                    {
+                        key = "ORG",
+                        filename = "",
+                        addr = addr,
+                        length = 0, //不明
+                        type = Address.DataTypeEnum.MIX,
+                    };
+
+                    if (U.isSafetyOffset(addr + 64))
+                    {//長さが不明なので比較するとき困るので適当に64バイトほど取得します.
+                        b.bin = rom.getBinaryData(addr, 64);
+                        b.mask = MakeMaskAddress(b.bin, addr);
+                    }
+                    else
+                    {
+                        b.bin = new byte[0] { };
+                        b.mask = new bool[0] { };
+                    }
+
+                    binMappings.Add(b);
+                    lastMatchAddr = addr;
+                }
+                else if (data.DataType == EAUtilCore.DataEnum.ASM
+                    || data.DataType == EAUtilCore.DataEnum.MIX)
+                {
+                    if (data.BINData == null || data.BINData.Length == 0)
+                    {//empty data
+                        continue;
+                    }
+                    //展開されるものを生成して、GREP検索する必要があります.
+                    bool[] isSkip;
+                    byte[] mod = ReadMod(data.BINData, out isSkip);
+
+                    //可変なので、maskパターンを作って検索します.
+                    uint addr = U.GrepPatternMatch(rom.Data, mod, isSkip, lastMatchAddr, 0, 4);
+                    if (addr == U.NOT_FOUND)
+                    {
+                        continue;
+                    }
+
+                    uint length = (uint)mod.Length;
+
+                    var b = new BinMapping
+                    {
+                        key = data.DataType.ToString(),
+                        filename = data.Name,
+                        addr = addr,
+                        length = length,
+                        bin = rom.getBinaryData(addr, length),
+                        mask = isSkip,
+                        type = data.DataType == EAUtilCore.DataEnum.ASM
+                            ? Address.DataTypeEnum.PATCH_ASM
+                            : Address.DataTypeEnum.MIX,
+                    };
+
+                    EraseORG(binMappings, b);
+                    binMappings.Add(b);
+
+                    lastMatchAddr = addr + length;
+                }
+                else if (data.DataType == EAUtilCore.DataEnum.LYN)
+                {
+                    if (data.BINData == null || data.BINData.Length == 0)
+                    {//empty data
+                        continue;
+                    }
+                    //展開されるものを生成して、GREP検索する必要があります.
+                    bool[] isSkip = MakeLynMaskPattern(data.BINData);
+
+                    //可変なので、maskパターンを作って検索します.
+                    uint addr = U.GrepPatternMatch(rom.Data, data.BINData, isSkip, lastMatchAddr, 0, 4);
+                    if (addr == U.NOT_FOUND)
+                    {
+                        continue;
+                    }
+                    uint length = (uint)data.BINData.Length;
+
+                    var b = new BinMapping
+                    {
+                        key = data.DataType.ToString(),
+                        filename = data.Name,
+                        addr = addr,
+                        length = length,
+                        bin = rom.getBinaryData(addr, length),
+                        mask = isSkip,
+                        type = Address.DataTypeEnum.PATCH_ASM,
+                    };
+
+                    EraseORG(binMappings, b);
+                    binMappings.Add(b);
+
+                    lastMatchAddr = addr + length;
+                }
+                else if (data.DataType == EAUtilCore.DataEnum.LYNHOOK)
+                {
+                    uint addr = data.ORGAddr;
+                    uint length = (uint)20;
+
+                    var b = new BinMapping
+                    {
+                        key = "ORG",
+                        filename = "",
+                        addr = data.ORGAddr,
+                        length = length,
+                        bin = rom.getBinaryData(addr, length),
+                        type = Address.DataTypeEnum.PATCH_ASM,
+                    };
+                    b.mask = MakeMaskAddress(b.bin, addr);
+
+                    binMappings.Add(b);
+
+                    lastMatchAddr = addr + length;
+                }
+                else if (data.DataType == EAUtilCore.DataEnum.POINTER_ARRAY)
+                {
+                    //最後に書き込んだ部分から、ポインタと思われる部分を連続して検出する.
+                    lastMatchAddr += data.Append;
+                    lastMatchAddr = U.Padding4(lastMatchAddr);
+
+                    uint addr = lastMatchAddr;
+                    for (; addr + 3 < rom.Data.Length; addr += 4)
+                    {
+                        uint a = rom.u32(addr);
+                        if (!U.isSafetyPointer(a))
+                        {
+                            break;
+                        }
+                    }
+                    uint length = addr - lastMatchAddr;
+                    if (length <= 0)
+                    {
+                        continue;
+                    }
+                    addr = lastMatchAddr;
+
+                    var b = new BinMapping
+                    {
+                        key = data.DataType.ToString(),
+                        filename = data.Name,
+                        addr = addr,
+                        length = length,
+                        bin = rom.getBinaryData(addr, length),
+                        mask = MakeFullMask(length),
+                        type = Address.DataTypeEnum.POINTER_ARRAY,
+                    };
+
+                    EraseORG(binMappings, b);
+                    binMappings.Add(b);
+
+                    lastMatchAddr = addr + length;
+                }
+                else if (data.DataType == EAUtilCore.DataEnum.PROCS)
+                {
+                    // PROCS length detection (ProcsScriptForm.CalcLengthAndCheck) is
+                    // WinForms-only; without it the length is unknown, so we skip this
+                    // range — identical to the WinForms tracer's `continue` when that
+                    // returns NOT_FOUND. (See class doc scope note.)
+                    continue;
+                }
+                else
+                {
+                    //展開されるものを生成して、GREP検索する必要があります.
+                    if (data.BINData == null || data.BINData.Length == 0)
+                    {
+                        continue;
+                    }
+                    uint addr = U.Grep(rom.Data, data.BINData, lastMatchAddr);
+                    if (addr == U.NOT_FOUND)
+                    {
+                        continue;
+                    }
+                    uint length = (uint)data.BINData.Length;
+
+                    var b = new BinMapping
+                    {
+                        key = data.DataType.ToString(),
+                        filename = data.Name,
+                        addr = addr,
+                        length = length,
+                        bin = data.BINData,
+                        type = Address.DataTypeEnum.BIN,
+                    };
+                    if (data.DataType == EAUtilCore.DataEnum.BIN)
+                    {
+                        b.mask = new bool[length];
+                    }
+                    else
+                    {
+                        b.mask = MakeMaskAddress(b.bin, addr);
+                    }
+
+                    EraseORG(binMappings, b);
+                    binMappings.Add(b);
+
+                    lastMatchAddr = addr + length;
+                }
+            }
+
+            return binMappings;
+        }
+
+        /// <summary>
+        /// Trace <paramref name="eaFilePath"/> against the live ROM and revert every
+        /// traced range to the bytes in <paramref name="cleanOriginalRom"/> (the ROM as
+        /// it was before the patch), recording all writes into <paramref name="undo"/>.
+        ///
+        /// Validation (mirrors the WinForms uninstall dialog's checks — never throws):
+        ///  - a ROM must be loaded;
+        ///  - the EA file must exist and trace at least one range;
+        ///  - the clean ROM must be non-empty and at least as large as the highest
+        ///    traced offset, so a byte-for-byte restore is well-defined.
+        /// On any failure the live ROM is left untouched and a localized error is
+        /// returned; the caller rolls back <paramref name="undo"/>.
+        /// </summary>
+        public static UninstallResult Uninstall(string eaFilePath, byte[] cleanOriginalRom, Undo.UndoData undo)
+        {
+            var result = new UninstallResult();
+
+            ROM rom = CoreState.ROM;
+            if (rom == null)
+            {
+                result.ErrorMessage = R._("No ROM is loaded.");
+                return result;
+            }
+            if (string.IsNullOrEmpty(eaFilePath) || !File.Exists(eaFilePath))
+            {
+                result.ErrorMessage = R._("Event file not found: {0}", eaFilePath ?? "");
+                return result;
+            }
+            if (cleanOriginalRom == null || cleanOriginalRom.Length <= 0)
+            {
+                result.ErrorMessage = R._("The selected clean ROM is empty.");
+                return result;
+            }
+            if (undo == null)
+            {
+                result.ErrorMessage = R._("No ROM is loaded.");
+                return result;
+            }
+
+            List<BinMapping> binmap = TraceEAFile(eaFilePath);
+            if (binmap.Count == 0)
+            {
+                result.ErrorMessage = R._("Could not trace any patched ranges from this event file. It may not be an applied EA patch, or it uses constructs this in-place uninstall does not support.");
+                return result;
+            }
+
+            // The clean ROM must cover the highest traced offset, otherwise we cannot
+            // restore those bytes — reject up front (mirrors the WF size sanity check).
+            uint highest = 0;
+            foreach (BinMapping map in binmap)
+            {
+                uint end = map.addr + (map.length == 0 ? 1u : map.length);
+                if (end > highest) highest = end;
+            }
+            if (highest > cleanOriginalRom.Length)
+            {
+                result.ErrorMessage = R._("The selected clean ROM is too small ({0} bytes) for this patch (needs at least {1} bytes). Did you pick the wrong file?",
+                    cleanOriginalRom.Length.ToString(), highest.ToString());
+                return result;
+            }
+
+            string error = UninstallPatchInner(binmap, cleanOriginalRom, undo, result);
+            if (error != "")
+            {
+                result.ErrorMessage = error;
+                return result;
+            }
+
+            result.Success = true;
+            result.RangeCount = binmap.Count;
+            return result;
+        }
+
+        // Faithful port of PatchForm.UninstallPatchInner (EA path): overwrite each
+        // traced byte with the clean-original byte, under undo; auto-length unknown
+        // ranges; then strip a zero-filled extended ROM tail.
+        static string UninstallPatchInner(List<BinMapping> binmap, byte[] orignalROM, Undo.UndoData undodata, UninstallResult result)
+        {
+            ROM rom = CoreState.ROM;
+            uint current_rom_length = (uint)rom.Data.Length;
+            uint reverted = 0;
+
+            for (int n = 0; n < binmap.Count; n++)
+            {
+                BinMapping map = binmap[n];
+
+                if (map.length == 0)
+                {//サイズがわからないので、自動的に求めます.
+                    map.length = CalcAutoLength(map.addr, orignalROM);
+                    map.bin = rom.getBinaryData(map.addr, map.length);
+                }
+
+                for (int i = 0; i < map.length; i++)
+                {
+                    uint addr = map.addr + (uint)i;
+                    CoreState.CommentCache?.Remove(addr);
+                    if (addr >= current_rom_length)
+                    {
+                        continue;
+                    }
+
+                    uint o = AtByte(orignalROM, addr); //パッチを含んでいないROMの内容
+                    rom.write_u8(addr, o, undodata);
+                    reverted++;
+                }
+                // (The WinForms MENU key fixup via MenuCommandForm is BIN-patch only and
+                // does not arise for an instant-EA patch — omitted, see class doc.)
+            }
+
+            StripROM(binmap, undodata);
+
+            result.BytesReverted = reverted;
+            return "";
+        }
+
+        // Port of PatchForm.StripROM: if reverting leaves the extended ROM tail all
+        // zero, shrink the ROM back down (recorded in undo as a resize position).
+        static void StripROM(List<BinMapping> binmap, Undo.UndoData undodata)
+        {
+            ROM rom = CoreState.ROM;
+            uint extendsAddr = U.toOffset(rom.RomInfo.extends_address);
+            int length = rom.Data.Length;
+
+            //終端が0x00で埋まるならROMサイズを小さくする.
+            uint stripSize = U.NOT_FOUND;
+            for (int n = 0; n < binmap.Count; n++)
+            {
+                BinMapping map = binmap[n];
+                uint addr = map.addr;
+                if (addr < extendsAddr)
+                {//拡張領域ではないのでstripできない.
+                    continue;
+                }
+
+                for (int i = (int)addr; i < length; i++, addr++)
+                {
+                    if (rom.Data[i] != 0x00)
+                    {
+                        break;
+                    }
+                }
+                if (addr == length)
+                {
+                    if (stripSize > map.addr)
+                    {
+                        stripSize = map.addr;
+                    }
+                }
+            }
+            if (rom.Data.Length > stripSize
+                && stripSize >= extendsAddr)
+            {
+                undodata.list.Add(new Undo.UndoPostion(stripSize, (uint)rom.Data.Length - stripSize));
+                rom.write_resize_data(stripSize);
+            }
+        }
+
+        // Port of PatchForm.CalcAutoLength: how far the live ROM diverges from the
+        // clean ROM starting at addr, tolerating up to RecoverMissMatch matching bytes.
+        static uint CalcAutoLength(uint addr, byte[] other, int RecoverMissMatch = 10)
+        {
+            ROM rom = CoreState.ROM;
+            int length = Math.Min(rom.Data.Length, other.Length);
+            int checkpoint;
+            int i;
+            for (i = (int)addr; i < length; i++)
+            {
+                if (rom.Data[i] != other[i])
+                {
+                    continue;
+                }
+
+                checkpoint = i;
+
+                i++;
+                int missCount = 0;
+                for (; i < length; i++)
+                {
+                    if (rom.Data[i] != other[i])
+                    {
+                        i -= missCount;
+                        break;
+                    }
+
+                    if (missCount >= RecoverMissMatch)
+                    {
+                        i -= missCount;
+
+                        return ((uint)i) - addr;
+                    }
+
+                    missCount++;
+                }
+            }
+
+            return ((uint)i) - addr;
+        }
+
+        // ---- Trace helpers (ports of the PatchForm private statics) ---------------
+
+        // Port of PatchForm.MakeMaskAddress: mask the LDR-pointer bytes inside a code
+        // block so the address-dependent words don't break a GREP pattern match.
+        static bool[] MakeMaskAddress(byte[] original, uint base_address)
+        {
+            bool[] isSkip = new bool[original.Length];
+
+            base_address = U.toOffset(base_address);
+            if (!U.isSafetyOffset(base_address))
+            {
+                return isSkip;
+            }
+
+            List<DisassemblerTrumb.LDRPointer> ldr = DisassemblerTrumb.MakeLDRMap(original, 0);
+
+            uint base_pointer = U.toPointer(base_address);
+            for (int i = 0; i < ldr.Count; i++)
+            {
+                if (ldr[i].ldr_data >= base_pointer
+                    && ldr[i].ldr_data <= base_pointer + original.Length)
+                {
+                    isSkip[ldr[i].ldr_data_address + 0] = true;
+                    isSkip[ldr[i].ldr_data_address + 1] = true;
+                    isSkip[ldr[i].ldr_data_address + 2] = true;
+                    isSkip[ldr[i].ldr_data_address + 3] = true;
+                }
+            }
+            return isSkip;
+        }
+
+        // Port of PatchForm.ReadMod(string[], byte[], out bool[]) — the instant-EA path
+        // has no per-key address-move args, so chaddr is 0 and the mask is built off
+        // base 0 (matching ReadMod with an empty sp[]).
+        static byte[] ReadMod(byte[] b, out bool[] isSkip)
+        {
+            uint chaddr = 0; // U.atoi0x(U.at(sp, 2)) with an empty sp == 0
+            isSkip = MakeMaskAddress(b, chaddr);
+            return b;
+        }
+
+        //lynによってインポートされるelfのマスクパターンを作ります。
+        // Port of PatchForm.MakeLynMaskPattern.
+        static bool[] MakeLynMaskPattern(byte[] bin)
+        {
+            bool[] isSkip = new bool[bin.Length];
+            for (int i = 0; i + 3 < bin.Length; i += 4)
+            {
+                if (bin[i] == 0 && bin[i + 1] == 0 && bin[i + 2] == 0 && bin[i + 3] == 0)
+                {
+                    isSkip[i + 0] = true;
+                    isSkip[i + 1] = true;
+                    isSkip[i + 2] = true;
+                    isSkip[i + 3] = true;
+                }
+            }
+            return isSkip;
+        }
+
+        // Port of PatchForm.MakeFullMask.
+        static bool[] MakeFullMask(uint length)
+        {
+            bool[] r = new bool[length];
+            for (int i = 0; i < length; i++)
+            {
+                r[i] = true;
+            }
+            return r;
+        }
+
+        // Port of PatchForm.EraseORG: a later concrete mapping at the same address
+        // supersedes a provisional ORG mapping there.
+        static void EraseORG(List<BinMapping> binMappings, BinMapping b)
+        {
+            for (int i = 0; i < binMappings.Count; i++)
+            {
+                BinMapping a = binMappings[i];
+                if (a.addr != b.addr)
+                {
+                    continue;
+                }
+                if (a.key == "ORG")
+                {
+                    binMappings.RemoveAt(i);
+                    i--;
+                    continue;
+                }
+            }
+        }
+
+        // Safe byte read from a byte[] (port of U.at(byte[], addr) — 0 when OOB).
+        static uint AtByte(byte[] data, uint addr)
+        {
+            if (data == null || addr >= data.Length)
+            {
+                return 0;
+            }
+            return data[addr];
+        }
+    }
+}

--- a/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
+++ b/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
@@ -136,12 +136,12 @@ namespace FEBuilderGBA
             if (rom == null || rom.RomInfo == null
                 || string.IsNullOrEmpty(eaFilePath) || !File.Exists(eaFilePath))
             {
-                result.Untraceable.Add("No identified ROM, or the event file is missing.");
+                result.Untraceable.Add(R._("No identified ROM, or the event file is missing."));
                 return result;
             }
             if (EAUtilCore.IsFBGTemp(eaFilePath))
             {
-                result.Untraceable.Add("Temporary wrapper file is not a traceable patch.");
+                result.Untraceable.Add(R._("Temporary wrapper file is not a traceable patch."));
                 return result;
             }
 
@@ -156,7 +156,7 @@ namespace FEBuilderGBA
                 // ArgumentException for a bad path, parse errors). Honour the "never
                 // throws" contract: turn any failure into an untraceable note + empty
                 // trace, which the caller surfaces as a clean "could not trace" error.
-                result.Untraceable.Add("Could not read the event file: " + ex.Message);
+                result.Untraceable.Add(R._("Could not read the event file: {0}", ex.Message));
                 return result;
             }
 
@@ -210,8 +210,8 @@ namespace FEBuilderGBA
                     uint addr = U.GrepPatternMatch(rom.Data, mod, isSkip, lastMatchAddr, 0, 4);
                     if (addr == U.NOT_FOUND)
                     {//パッチが見つからなかった — 復元できない残骸として記録する.
-                        result.Untraceable.Add(data.DataType + " block not found in ROM: "
-                            + (string.IsNullOrEmpty(data.Name) ? "(inline)" : data.Name));
+                        result.Untraceable.Add(R._("{0} block not found in ROM: {1}",
+                            data.DataType.ToString(), BlockName(data.Name)));
                         continue;
                     }
 
@@ -248,8 +248,7 @@ namespace FEBuilderGBA
                     uint addr = U.GrepPatternMatch(rom.Data, data.BINData, isSkip, lastMatchAddr, 0, 4);
                     if (addr == U.NOT_FOUND)
                     {//LYN ELFが見つからなかった — 復元できない残骸として記録する.
-                        result.Untraceable.Add("LYN block not found in ROM: "
-                            + (string.IsNullOrEmpty(data.Name) ? "(inline)" : data.Name));
+                        result.Untraceable.Add(R._("LYN block not found in ROM: {0}", BlockName(data.Name)));
                         continue;
                     }
                     uint length = (uint)data.BINData.Length;
@@ -273,6 +272,10 @@ namespace FEBuilderGBA
                 else if (data.DataType == EAUtilCore.DataEnum.LYNHOOK)
                 {
                     uint addr = data.ORGAddr;
+                    // 20 bytes (NOT the 16-byte hook stub): matches WF
+                    // PatchForm.TraceEAPatchedMapping, which reverts the 16-byte lyn hook
+                    // stub plus the 4-byte aligned slot lyn may also overwrite. See the
+                    // EAUtilCore.DataEnum.LYNHOOK comment.
                     uint length = (uint)20;
 
                     var b = new BinMapping
@@ -335,8 +338,8 @@ namespace FEBuilderGBA
                     // range — identical to the WinForms tracer's `continue` when that
                     // returns NOT_FOUND. Record it as residue so the caller can warn.
                     // (See class doc scope note.)
-                    result.Untraceable.Add("PROCS table (length detection is WinForms-only): "
-                        + (string.IsNullOrEmpty(data.Name) ? "(label)" : data.Name));
+                    result.Untraceable.Add(R._("PROCS table (length detection is WinForms-only): {0}",
+                        string.IsNullOrEmpty(data.Name) ? R._("(label)") : data.Name));
                     continue;
                 }
                 else
@@ -349,8 +352,7 @@ namespace FEBuilderGBA
                     uint addr = U.Grep(rom.Data, data.BINData, lastMatchAddr);
                     if (addr == U.NOT_FOUND)
                     {//BINが見つからなかった — 復元できない残骸として記録する.
-                        result.Untraceable.Add("BIN block not found in ROM: "
-                            + (string.IsNullOrEmpty(data.Name) ? "(inline)" : data.Name));
+                        result.Untraceable.Add(R._("BIN block not found in ROM: {0}", BlockName(data.Name)));
                         continue;
                     }
                     uint length = (uint)data.BINData.Length;
@@ -562,7 +564,6 @@ namespace FEBuilderGBA
         {
             ROM rom = CoreState.ROM;
             int length = Math.Min(rom.Data.Length, other.Length);
-            int checkpoint;
             int i;
             for (i = (int)addr; i < length; i++)
             {
@@ -570,8 +571,6 @@ namespace FEBuilderGBA
                 {
                     continue;
                 }
-
-                checkpoint = i;
 
                 i++;
                 int missCount = 0;
@@ -695,6 +694,13 @@ namespace FEBuilderGBA
                 return 0;
             }
             return data[addr];
+        }
+
+        // The display name for an untraceable block: the file/label name, or a
+        // localized "(inline)" placeholder for an unnamed (inline) block.
+        static string BlockName(string name)
+        {
+            return string.IsNullOrEmpty(name) ? R._("(inline)") : name;
         }
     }
 }

--- a/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
+++ b/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
@@ -34,6 +34,13 @@ namespace FEBuilderGBA
     ///    <c>ProcsScriptForm.CalcLengthAndCheck</c>; this Core path skips a PROCS range
     ///    whose length it cannot determine — identical observable behaviour to the
     ///    WinForms tracer, which <c>continue</c>s when that returns NOT_FOUND.
+    ///
+    /// NEVER silently incomplete: any block the trace cannot reconstruct (a GREP miss,
+    /// the guarded PROCS, an un-hinted inline PNG raster) is recorded on
+    /// <see cref="TraceResult.Untraceable"/> / <see cref="UninstallResult.UntraceableBlocks"/>
+    /// and flips <see cref="UninstallResult.FullyTraced"/> to false. The View MUST warn
+    /// the user when FullyTraced is false — a revert that quietly leaves patch residue
+    /// while reporting success is the one outcome this design avoids.
     /// </summary>
     public static class EventAssemblerUninstallCore
     {
@@ -52,6 +59,24 @@ namespace FEBuilderGBA
             public bool[] mask;
         }
 
+        /// <summary>
+        /// Result of tracing an EA file: the ranges we COULD reconstruct, plus notes
+        /// about blocks we could NOT (so an uninstall is never silently incomplete).
+        /// </summary>
+        public sealed class TraceResult
+        {
+            /// <summary>The ranges the EA patch wrote that we reconstructed.</summary>
+            public List<BinMapping> Mappings { get; } = new List<BinMapping>();
+            /// <summary>
+            /// Human-readable descriptions of blocks we could NOT trace (GREP miss,
+            /// guarded PROCS length, un-hinted inline PNG raster, …). Each entry is one
+            /// piece of patch residue a revert will leave behind.
+            /// </summary>
+            public List<string> Untraceable { get; } = new List<string>();
+            /// <summary>True when every emitting block was reconstructed (no residue).</summary>
+            public bool FullyTraced => Untraceable.Count == 0;
+        }
+
         /// <summary>Structured result of an uninstall run.</summary>
         public sealed class UninstallResult
         {
@@ -63,18 +88,30 @@ namespace FEBuilderGBA
             public int RangeCount { get; set; }
             /// <summary>Total bytes written back from the clean ROM.</summary>
             public uint BytesReverted { get; set; }
+            /// <summary>
+            /// False when the trace could NOT account for every block the EA patch
+            /// wrote, so the revert may leave patch residue. The View MUST warn the user
+            /// when this is false (a "success" with residue is the outcome to avoid).
+            /// </summary>
+            public bool FullyTraced { get; set; } = true;
+            /// <summary>Descriptions of the blocks that could not be traced (residue).</summary>
+            public List<string> UntraceableBlocks { get; set; } = new List<string>();
         }
 
         /// <summary>
         /// Trace the ranges an EA file writes, against the CURRENT (patched) ROM in
         /// <see cref="CoreState.ROM"/>. Faithful port of the EA branch of
         /// <c>TraceEAPatchedMapping</c>, walking a single .event's
-        /// <see cref="EAUtilCore"/> DataList. Returns an empty list when the ROM is not
-        /// loaded or the file cannot be parsed.
+        /// <see cref="EAUtilCore"/> DataList. The result carries BOTH the reconstructed
+        /// ranges AND notes about any block that could NOT be traced (GREP miss, guarded
+        /// PROCS, un-hinted inline PNG raster) so a revert is never silently incomplete.
+        /// Returns an empty result (with one Untraceable note) when the ROM is not loaded
+        /// or the file cannot be parsed.
         /// </summary>
-        public static List<BinMapping> TraceEAFile(string eaFilePath)
+        public static TraceResult TraceEAFile(string eaFilePath)
         {
-            var binMappings = new List<BinMapping>();
+            var result = new TraceResult();
+            List<BinMapping> binMappings = result.Mappings;
             ROM rom = CoreState.ROM;
             // RomInfo is needed for the GREP search baseline
             // (compress_image_borderline_address); it is null only for a not-yet-
@@ -84,11 +121,13 @@ namespace FEBuilderGBA
             if (rom == null || rom.RomInfo == null
                 || string.IsNullOrEmpty(eaFilePath) || !File.Exists(eaFilePath))
             {
-                return binMappings;
+                result.Untraceable.Add("No identified ROM, or the event file is missing.");
+                return result;
             }
             if (EAUtilCore.IsFBGTemp(eaFilePath))
             {
-                return binMappings;
+                result.Untraceable.Add("Temporary wrapper file is not a traceable patch.");
+                return result;
             }
 
             EAUtilCore ea;
@@ -96,10 +135,14 @@ namespace FEBuilderGBA
             {
                 ea = new EAUtilCore(eaFilePath);
             }
-            catch (IOException)
+            catch (IOException ex)
             {
-                return binMappings;
+                result.Untraceable.Add("Could not read the event file: " + ex.Message);
+                return result;
             }
+
+            // Carry over parser-level untraceable blocks (un-hinted inline PNG rasters).
+            result.Untraceable.AddRange(ea.UntraceableNotes);
 
             uint lastMatchAddr = rom.RomInfo.compress_image_borderline_address;
 
@@ -147,7 +190,9 @@ namespace FEBuilderGBA
                     //可変なので、maskパターンを作って検索します.
                     uint addr = U.GrepPatternMatch(rom.Data, mod, isSkip, lastMatchAddr, 0, 4);
                     if (addr == U.NOT_FOUND)
-                    {
+                    {//パッチが見つからなかった — 復元できない残骸として記録する.
+                        result.Untraceable.Add(data.DataType + " block not found in ROM: "
+                            + (string.IsNullOrEmpty(data.Name) ? "(inline)" : data.Name));
                         continue;
                     }
 
@@ -183,7 +228,9 @@ namespace FEBuilderGBA
                     //可変なので、maskパターンを作って検索します.
                     uint addr = U.GrepPatternMatch(rom.Data, data.BINData, isSkip, lastMatchAddr, 0, 4);
                     if (addr == U.NOT_FOUND)
-                    {
+                    {//LYN ELFが見つからなかった — 復元できない残骸として記録する.
+                        result.Untraceable.Add("LYN block not found in ROM: "
+                            + (string.IsNullOrEmpty(data.Name) ? "(inline)" : data.Name));
                         continue;
                     }
                     uint length = (uint)data.BINData.Length;
@@ -267,19 +314,24 @@ namespace FEBuilderGBA
                     // PROCS length detection (ProcsScriptForm.CalcLengthAndCheck) is
                     // WinForms-only; without it the length is unknown, so we skip this
                     // range — identical to the WinForms tracer's `continue` when that
-                    // returns NOT_FOUND. (See class doc scope note.)
+                    // returns NOT_FOUND. Record it as residue so the caller can warn.
+                    // (See class doc scope note.)
+                    result.Untraceable.Add("PROCS table (length detection is WinForms-only): "
+                        + (string.IsNullOrEmpty(data.Name) ? "(label)" : data.Name));
                     continue;
                 }
                 else
                 {
                     //展開されるものを生成して、GREP検索する必要があります.
                     if (data.BINData == null || data.BINData.Length == 0)
-                    {
+                    {//EAは何も書き込んでいない — 残骸ではない.
                         continue;
                     }
                     uint addr = U.Grep(rom.Data, data.BINData, lastMatchAddr);
                     if (addr == U.NOT_FOUND)
-                    {
+                    {//BINが見つからなかった — 復元できない残骸として記録する.
+                        result.Untraceable.Add("BIN block not found in ROM: "
+                            + (string.IsNullOrEmpty(data.Name) ? "(inline)" : data.Name));
                         continue;
                     }
                     uint length = (uint)data.BINData.Length;
@@ -309,7 +361,7 @@ namespace FEBuilderGBA
                 }
             }
 
-            return binMappings;
+            return result;
         }
 
         /// <summary>
@@ -351,10 +403,23 @@ namespace FEBuilderGBA
                 return result;
             }
 
-            List<BinMapping> binmap = TraceEAFile(eaFilePath);
+            TraceResult trace = TraceEAFile(eaFilePath);
+            List<BinMapping> binmap = trace.Mappings;
+
+            // Surface untraceable blocks on the result so the View can warn the user
+            // (a "success" that leaves patch residue is the outcome to avoid).
+            result.FullyTraced = trace.FullyTraced;
+            result.UntraceableBlocks = trace.Untraceable;
+
             if (binmap.Count == 0)
             {
-                result.ErrorMessage = R._("Could not trace any patched ranges from this event file. It may not be an applied EA patch, or it uses constructs this in-place uninstall does not support.");
+                // Nothing reconstructible. If the trace recorded untraceable blocks,
+                // say so specifically (residue we can't revert) rather than the generic
+                // "not a patch" message.
+                result.ErrorMessage = trace.Untraceable.Count > 0
+                    ? R._("This event file's patched ranges cannot be traced for in-place uninstall ({0} block(s)). Uninstall it via the WinForms patch manager, or revert with a backup ROM.",
+                        trace.Untraceable.Count.ToString())
+                    : R._("Could not trace any patched ranges from this event file. It may not be an applied EA patch, or it uses constructs this in-place uninstall does not support.");
                 return result;
             }
 
@@ -380,6 +445,8 @@ namespace FEBuilderGBA
                 return result;
             }
 
+            // Reverted the ranges we COULD trace. Success is true, but FullyTraced may be
+            // false (residue remains) — the View MUST warn the user in that case.
             result.Success = true;
             result.RangeCount = binmap.Count;
             return result;

--- a/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
+++ b/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
@@ -75,6 +75,13 @@ namespace FEBuilderGBA
             public List<string> Untraceable { get; } = new List<string>();
             /// <summary>True when every emitting block was reconstructed (no residue).</summary>
             public bool FullyTraced => Untraceable.Count == 0;
+            /// <summary>
+            /// Count of WRITE-BEARING blocks the trace could not reconstruct (a GREP
+            /// miss, the guarded PROCS, an un-hinted inline PNG raster). Empty/comment
+            /// blocks that write nothing are NOT counted — they leave no residue.
+            /// Equals <see cref="Untraceable"/>.Count.
+            /// </summary>
+            public int UntracedCount => Untraceable.Count;
         }
 
         /// <summary>Structured result of an uninstall run.</summary>
@@ -94,6 +101,14 @@ namespace FEBuilderGBA
             /// when this is false (a "success" with residue is the outcome to avoid).
             /// </summary>
             public bool FullyTraced { get; set; } = true;
+            /// <summary>
+            /// Count of WRITE-BEARING blocks the trace could not revert (a GREP miss,
+            /// the guarded PROCS, an un-hinted inline PNG raster). > 0 means the revert
+            /// is INCOMPLETE — those bytes remain patched. <see cref="Success"/> can
+            /// still be true (the traced ranges WERE reverted); the View must surface
+            /// this so the user can confirm/verify. Equals <see cref="UntraceableBlocks"/>.Count.
+            /// </summary>
+            public int UntracedCount { get; set; }
             /// <summary>Descriptions of the blocks that could not be traced (residue).</summary>
             public List<string> UntraceableBlocks { get; set; } = new List<string>();
         }
@@ -135,8 +150,12 @@ namespace FEBuilderGBA
             {
                 ea = new EAUtilCore(eaFilePath);
             }
-            catch (IOException ex)
+            catch (Exception ex)
             {
+                // The parser can throw more than IOException (UnauthorizedAccessException,
+                // ArgumentException for a bad path, parse errors). Honour the "never
+                // throws" contract: turn any failure into an untraceable note + empty
+                // trace, which the caller surfaces as a clean "could not trace" error.
                 result.Untraceable.Add("Could not read the event file: " + ex.Message);
                 return result;
             }
@@ -399,7 +418,7 @@ namespace FEBuilderGBA
             }
             if (undo == null)
             {
-                result.ErrorMessage = R._("No ROM is loaded.");
+                result.ErrorMessage = R._("Undo manager unavailable.");
                 return result;
             }
 
@@ -410,6 +429,7 @@ namespace FEBuilderGBA
             // (a "success" that leaves patch residue is the outcome to avoid).
             result.FullyTraced = trace.FullyTraced;
             result.UntraceableBlocks = trace.Untraceable;
+            result.UntracedCount = trace.UntracedCount;
 
             if (binmap.Count == 0)
             {

--- a/FEBuilderGBA.Core/U.cs
+++ b/FEBuilderGBA.Core/U.cs
@@ -2180,6 +2180,31 @@ namespace FEBuilderGBA
             if (i < 0) return "";
             return text.Substring(0, i);
         }
+        // Skip past the first occurrence of need, returning the remainder.
+        // Ported from the WinForms U.cs for the Core EA parser (EAUtilCore).
+        public static string skip(string text, string need)
+        {
+            int i = text.IndexOf(need);
+            if (i < 0) return "";
+            return text.Substring(i + need.Length);
+        }
+        // Append need to data only if it is not already present (case-sensitive).
+        // Ported from the WinForms U.cs for the Core EA uninstall trace.
+        public static string[] AddIfNotExist(string[] data, string need)
+        {
+            for (int i = 0; i < data.Length; i++)
+            {
+                if (data[i] == need)
+                {
+                    return data;
+                }
+            }
+
+            string[] d = new string[data.Length + 1];
+            Array.Copy(data, 0, d, 0, data.Length);
+            d[data.Length] = need;
+            return d;
+        }
 
         public static string unhtmlspecialchars(string inStr)
         {

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20691,3 +20691,33 @@ Partial uninstall
 :Undo manager unavailable.
 Undo manager unavailable.
 
+:{0} block not found in ROM: {1}
+{0} block not found in ROM: {1}
+
+:LYN block not found in ROM: {0}
+LYN block not found in ROM: {0}
+
+:BIN block not found in ROM: {0}
+BIN block not found in ROM: {0}
+
+:PROCS table (length detection is WinForms-only): {0}
+PROCS table (length detection is WinForms-only): {0}
+
+:(label)
+(label)
+
+:(inline)
+(inline)
+
+:No identified ROM, or the event file is missing.
+No identified ROM, or the event file is missing.
+
+:Temporary wrapper file is not a traceable patch.
+Temporary wrapper file is not a traceable patch.
+
+:Could not read the event file: {0}
+Could not read the event file: {0}
+
+:Png2Dmp image (no .dmp hint): {0}
+Png2Dmp image (no .dmp hint): {0}
+

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20643,3 +20643,51 @@ Failed to create the ROMRebuild report. {0}
 :Failed to create the ROMRebuild report.
 Failed to create the ROMRebuild report.
 
+:Uninstalling...
+Uninstalling...
+
+:Uninstall successful.
+Uninstall successful.
+
+:Uninstall failed.
+Uninstall failed.
+
+:Uninstall cancelled.
+Uninstall cancelled.
+
+:Reverted {0} range(s), {1} byte(s).
+Reverted {0} range(s), {1} byte(s).
+
+:Event file not found: {0}
+Event file not found: {0}
+
+:The selected clean ROM is empty.
+The selected clean ROM is empty.
+
+:The selected clean ROM is too small ({0} bytes) for this patch (needs at least {1} bytes). Did you pick the wrong file?
+The selected clean ROM is too small ({0} bytes) for this patch (needs at least {1} bytes). Did you pick the wrong file?
+
+:Could not trace any patched ranges from this event file. It may not be an applied EA patch, or it uses constructs this in-place uninstall does not support.
+Could not trace any patched ranges from this event file. It may not be an applied EA patch, or it uses constructs this in-place uninstall does not support.
+
+:This event file's patched ranges cannot be traced for in-place uninstall ({0} block(s)). Uninstall it via the WinForms patch manager, or revert with a backup ROM.
+This event file's patched ranges cannot be traced for in-place uninstall ({0} block(s)). Uninstall it via the WinForms patch manager, or revert with a backup ROM.
+
+:WARNING: {0} block(s) in this patch could not be traced and were NOT reverted — the uninstall may be incomplete. Please verify the ROM.
+WARNING: {0} block(s) in this patch could not be traced and were NOT reverted — the uninstall may be incomplete. Please verify the ROM.
+
+:{0} block(s) in this EA cannot be traced (e.g. inline image / PROCS); those bytes will NOT be reverted and may remain patched.
+{0} block(s) in this EA cannot be traced (e.g. inline image / PROCS); those bytes will NOT be reverted and may remain patched.
+
+:Proceed with a partial uninstall?
+Proceed with a partial uninstall?
+
+:Partial uninstall
+Partial uninstall
+
+:...and {0} more.
+...and {0} more.
+
+:Undo manager unavailable.
+Undo manager unavailable.
+

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -11966,3 +11966,48 @@ ROMRebuildレポートの作成に失敗しました。{0}
 :Failed to create the ROMRebuild report.
 ROMRebuildレポートの作成に失敗しました。
 
+:Uninstalling...
+アンインストール中...
+
+:Uninstall successful.
+アンインストールに成功しました。
+
+:Uninstall failed.
+アンインストールに失敗しました。
+
+:Uninstall cancelled.
+アンインストールをキャンセルしました。
+
+:Reverted {0} range(s), {1} byte(s).
+{0}個の範囲、{1}バイトを元に戻しました。
+
+:Event file not found: {0}
+イベントファイルが見つかりません: {0}
+
+:The selected clean ROM is empty.
+選択したクリーンROMが空です。
+
+:The selected clean ROM is too small ({0} bytes) for this patch (needs at least {1} bytes). Did you pick the wrong file?
+選択したクリーンROM({0}バイト)はこのパッチには小さすぎます(最低{1}バイト必要)。ファイルを間違えていませんか?
+
+:Could not trace any patched ranges from this event file. It may not be an applied EA patch, or it uses constructs this in-place uninstall does not support.
+このイベントファイルからパッチ範囲を追跡できませんでした。適用済みのEAパッチではないか、このインプレースアンインストールが対応していない構文を使用している可能性があります。
+
+:This event file's patched ranges cannot be traced for in-place uninstall ({0} block(s)). Uninstall it via the WinForms patch manager, or revert with a backup ROM.
+このイベントファイルのパッチ範囲はインプレースアンインストールでは追跡できません({0}ブロック)。WinFormsのパッチマネージャーでアンインストールするか、バックアップROMで元に戻してください。
+
+:WARNING: {0} block(s) in this patch could not be traced and were NOT reverted — the uninstall may be incomplete. Please verify the ROM.
+警告: このパッチの{0}個のブロックは追跡できず、元に戻されませんでした。アンインストールが不完全な可能性があります。ROMを確認してください。
+
+:{0} block(s) in this EA cannot be traced (e.g. inline image / PROCS); those bytes will NOT be reverted and may remain patched.
+このEAの{0}個のブロックは追跡できません(例: インライン画像 / PROCS)。これらのバイトは元に戻されず、パッチが残る可能性があります。
+
+:Proceed with a partial uninstall?
+部分的なアンインストールを続行しますか?
+
+:Partial uninstall
+部分的なアンインストール
+
+:...and {0} more.
+...他{0}件。
+

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -12011,3 +12011,33 @@ ROMRebuildレポートの作成に失敗しました。
 :...and {0} more.
 ...他{0}件。
 
+:{0} block not found in ROM: {1}
+{0}ブロックがROM内に見つかりません: {1}
+
+:LYN block not found in ROM: {0}
+LYNブロックがROM内に見つかりません: {0}
+
+:BIN block not found in ROM: {0}
+BINブロックがROM内に見つかりません: {0}
+
+:PROCS table (length detection is WinForms-only): {0}
+PROCSテーブル(長さ検出はWinForms専用): {0}
+
+:(label)
+(ラベル)
+
+:(inline)
+(インライン)
+
+:No identified ROM, or the event file is missing.
+認識されたROMがないか、イベントファイルが存在しません。
+
+:Temporary wrapper file is not a traceable patch.
+一時ラッパーファイルは追跡可能なパッチではありません。
+
+:Could not read the event file: {0}
+イベントファイルを読み込めませんでした: {0}
+
+:Png2Dmp image (no .dmp hint): {0}
+Png2Dmp画像(.dmpヒントなし): {0}
+

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25852,3 +25852,33 @@ ROMRebuild 报告
 :...and {0} more.
 ...还有 {0} 项。
 
+:{0} block not found in ROM: {1}
+在 ROM 中找不到 {0} 块：{1}
+
+:LYN block not found in ROM: {0}
+在 ROM 中找不到 LYN 块：{0}
+
+:BIN block not found in ROM: {0}
+在 ROM 中找不到 BIN 块：{0}
+
+:PROCS table (length detection is WinForms-only): {0}
+PROCS 表（长度检测仅限 WinForms）：{0}
+
+:(label)
+（标签）
+
+:(inline)
+（内联）
+
+:No identified ROM, or the event file is missing.
+没有可识别的 ROM，或事件文件不存在。
+
+:Temporary wrapper file is not a traceable patch.
+临时包装文件不是可追踪的补丁。
+
+:Could not read the event file: {0}
+无法读取事件文件：{0}
+
+:Png2Dmp image (no .dmp hint): {0}
+Png2Dmp 图像（无 .dmp 提示）：{0}
+

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25807,3 +25807,48 @@ ROMRebuild 报告
 :Failed to create the ROMRebuild report.
 生成 ROMRebuild 报告失败。
 
+:Uninstalling...
+正在卸载...
+
+:Uninstall successful.
+卸载成功。
+
+:Uninstall failed.
+卸载失败。
+
+:Uninstall cancelled.
+已取消卸载。
+
+:Reverted {0} range(s), {1} byte(s).
+已还原 {0} 个范围，共 {1} 字节。
+
+:Event file not found: {0}
+找不到事件文件：{0}
+
+:The selected clean ROM is empty.
+所选的干净 ROM 为空。
+
+:The selected clean ROM is too small ({0} bytes) for this patch (needs at least {1} bytes). Did you pick the wrong file?
+所选的干净 ROM 太小（{0} 字节），不足以容纳此补丁（至少需要 {1} 字节）。是否选错了文件？
+
+:Could not trace any patched ranges from this event file. It may not be an applied EA patch, or it uses constructs this in-place uninstall does not support.
+无法从该事件文件追踪到任何已打补丁的范围。它可能不是已应用的 EA 补丁，或使用了此就地卸载不支持的结构。
+
+:This event file's patched ranges cannot be traced for in-place uninstall ({0} block(s)). Uninstall it via the WinForms patch manager, or revert with a backup ROM.
+此事件文件的补丁范围无法进行就地卸载（{0} 个块）。请通过 WinForms 补丁管理器卸载，或使用备份 ROM 还原。
+
+:WARNING: {0} block(s) in this patch could not be traced and were NOT reverted — the uninstall may be incomplete. Please verify the ROM.
+警告：此补丁中有 {0} 个块无法追踪，未被还原——卸载可能不完整。请检查 ROM。
+
+:{0} block(s) in this EA cannot be traced (e.g. inline image / PROCS); those bytes will NOT be reverted and may remain patched.
+此 EA 中有 {0} 个块无法追踪（例如内联图像 / PROCS）；这些字节将不会被还原，可能仍保留补丁。
+
+:Proceed with a partial uninstall?
+是否继续进行部分卸载？
+
+:Partial uninstall
+部分卸载
+
+:...and {0} more.
+...还有 {0} 项。
+


### PR DESCRIPTION
## Summary
Ports the Event Assembler **in-place Uninstall** path to Avalonia (#1242, follow-up to #1170). The EA tool previously only reverted the last insert via Undo; it now removes a previously-applied EA patch by tracing what the `.event` wrote and restoring those bytes from a user-supplied clean original ROM — parity with WinForms `EventAssemblerForm` uninstall semantics, without the ~9000-line `PatchForm` subsystem.

## Approach
- **`EAUtilCore.cs`** (Core, new ~630 lines) — parse-only port of WinForms `EAUtil`, scoped to the data kinds the uninstall trace consumes. The WF `EAUtil` ctor is entangled with `ParsePng2Dmp`→`ImageUtil.OpenBitmap` (WinForms/System.Drawing), so this is a clean parse-only port (keeps the `.png.dmp` hint-file fallback; an un-hinted inline PNG raster is the one EA data kind it can't trace — a documented boundary, same shape as #1170's auto-def). `MakeEAAutoDef`/`AddSkillSystemFunc` stay WinForms-only (irrelevant to uninstall).
- **`EventAssemblerUninstallCore.cs`** (Core, new ~610 lines) — `BinMapping` + `TraceEAFile` (EA branch of WF `TraceEAPatchedMapping`, walking the `.event`'s `EAUtilCore` DataList: ORG/ASM/MIX/LYN/LYNHOOK/POINTER_ARRAY/BIN/String) + mask helpers + `Uninstall` (WF `UninstallPatchInner`: overwrite each traced byte from the clean-original ROM under an explicit `Undo.UndoData`) + `StripROM`. Never throws on bad input (returns a clean error).
- **`EventAssemblerView`** — adds an "Uninstall…" button: prompts for the clean original ROM (file picker), traces vs the live patched ROM, reverts off the UI thread under explicit undo (`UndoService.CommitExternal`), rolls back on any partial-write failure. The stale "Uninstall is deferred" claim is removed from all copies (axaml header, code-behind, VM).

## Tests
- Core.Tests: **4377 passed**, 0 failed — includes a **real compile→uninstall round-trip** (compile+insert `ORG/BYTE` into a synthetic FE8 ROM via #1170's `EventAssemblerCompileCore`, snapshot pre-insert bytes, uninstall with those as the clean original, assert bytes restored byte-for-byte) that **actually ran** here via the built ColorzCore (SkippableFact so CI stays green if EA raws are absent), plus a pure-synthetic always-runs revert test + validation/parser tests (8 total).
- Avalonia.Tests: **8343 passed**, 0 failed. FEBuilderGBA.Tests (windows): **1864 passed**, 0 failed. validate-automation-ids: **0/0/0**.

A follow-up commit adds explicit signaling + a user warning when an EA contains a block that can't be traced (so a partial uninstall is never silently reported as complete). Screenshot below.

Fixes #1242

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
