### PR TITLE
docs: document FE8 Skill System sources (wiki + README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,15 @@ We would like to thank our hacking predecessors who have publicly shared any ana
 Details (There is a commentary at the bottom of the page, and the wiki provides other instructions)
 https://dw.ngmansion.xyz/doku.php?id=en:guide:febuildergba:index
 
+### FE8 Skill Systems
+
+Several FE8 editors — **FE8 Spell Menu Extends**, the **Skill** editors, and **Item Effectiveness (SkillSystems Rework)** — only show data once a community **Skill System** is installed on the ROM. Recommended sources:
+
+- **FE8U** (US/International): [FireEmblemUniverse/SkillSystem_FE8](https://github.com/FireEmblemUniverse/SkillSystem_FE8) (the canonical Event Assembler buildfile) or [MokhaLeee/fe8u-cskillsys-kernel](https://github.com/MokhaLeee/fe8u-cskillsys-kernel) (a modern C kernel).
+- **FE8J** (Japan): [ngmansion/FE8N](https://github.com/ngmansion/FE8N) (the de-facto-standard FE8J hacking base).
+
+These projects distribute **patches / source**, not the game — apply them to a clean FE8 ROM you dumped yourself. See the [Skill Systems (FE8) wiki page](https://github.com/laqieer/FEBuilderGBA/wiki/Skill-Systems) for installation details.
+
 Some poorly designed anti-virus software may misidentify FEBuilderGBA as a virus.
 This is because FEBuilderGBA uses the WindowsDebugAPI to communicate with the emulator.
 Please configure your anti-virus to exclude the FEBuilderGBA directory.

--- a/README.md
+++ b/README.md
@@ -716,10 +716,10 @@ https://dw.ngmansion.xyz/doku.php?id=en:guide:febuildergba:index
 
 ### FE8 Skill Systems
 
-Several FE8 editors — **FE8 Spell Menu Extends**, the **Skill** editors, and **Item Effectiveness (SkillSystems Rework)** — only show data once a community **Skill System** is installed on the ROM. Recommended sources:
+Several FE8 editors — **Spell Menu Extensions**, the **Skill** editors, and **Effectiveness (Skill Systems Rework)** — only show data once a community **Skill System** is installed on the ROM. Recommended sources:
 
 - **FE8U** (US/International): [FireEmblemUniverse/SkillSystem_FE8](https://github.com/FireEmblemUniverse/SkillSystem_FE8) (the canonical Event Assembler buildfile) or [MokhaLeee/fe8u-cskillsys-kernel](https://github.com/MokhaLeee/fe8u-cskillsys-kernel) (a modern C kernel).
-- **FE8J** (Japan): [ngmansion/FE8N](https://github.com/ngmansion/FE8N) (the de-facto-standard FE8J hacking base).
+- **FE8J** (Japan): [ngmansion/FE8N](https://github.com/ngmansion/FE8N) (the de facto standard FE8J hacking base).
 
 These projects distribute **patches / source**, not the game — apply them to a clean FE8 ROM you dumped yourself. See the [Skill Systems (FE8) wiki page](https://github.com/laqieer/FEBuilderGBA/wiki/Skill-Systems) for installation details.
 


### PR DESCRIPTION
## Summary
Documents the community **FE8 Skill System** sources for users, so the Skill-System-gated FE8 editors aren't mistaken for broken when empty on a vanilla ROM.

- **Wiki** (already pushed): new **[Skill Systems (FE8)](https://github.com/laqieer/FEBuilderGBA/wiki/Skill-Systems)** page + links from Home and Editors Reference.
- **README**: new "FE8 Skill Systems" section under the user guide.

### Sources documented
- **FE8U**: [FireEmblemUniverse/SkillSystem_FE8](https://github.com/FireEmblemUniverse/SkillSystem_FE8) (canonical EA buildfile, v1.2.2) · [MokhaLeee/fe8u-cskillsys-kernel](https://github.com/MokhaLeee/fe8u-cskillsys-kernel) (modern C kernel, v3.3.0-LTS)
- **FE8J**: [ngmansion/FE8N](https://github.com/ngmansion/FE8N) (de-facto FE8J base, 20240225)

Context: these unlock the editors covered by #1167 (FE8 Spell Menu Extends), the Skill editors, and the merged #1175 (Item Effectiveness SkillSystems Rework). Docs-only — no code change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
