### PR TITLE
feat(core): extract CustomBuild patch-install engine (#1248 slice 1)

### DIFF
--- a/FEBuilderGBA.Core.Tests/PatchInstallCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/PatchInstallCoreTests.cs
@@ -267,7 +267,7 @@ namespace FEBuilderGBA.Core.Tests
 
             PatchInstallCore.ApplyPatch(patch, rom, undo, vanillaRom: vanilla);
 
-            // The 0x150..0x160 window is restored to vanilla (0xFF).
+            // The 0x250..0x260 window is restored to vanilla (0xFF).
             Assert.Equal(vanilla, rom.Data);
         }
 

--- a/FEBuilderGBA.Core.Tests/PatchInstallCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/PatchInstallCoreTests.cs
@@ -1,0 +1,292 @@
+using System;
+using System.IO;
+using System.Linq;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// Synthetic round-trip tests for PatchInstallCore (issue #1248, slice 1).
+    /// No real ROM / SkillSystems environment: a vanilla byte[] is mutated, fed
+    /// through DiffToolCore.MakeDiff to produce a CustomBuild patch + .bin sidecars,
+    /// then PatchInstallCore loads + applies it and we assert the ROM equals the
+    /// mutated bytes. Mirrors the #1242 synthetic-round-trip idiom.
+    ///
+    /// Touches CoreState.ROM/Undo, so [Collection("SharedState")] serializes it.
+    /// </summary>
+    [Collection("SharedState")]
+    public class PatchInstallCoreTests : IDisposable
+    {
+        readonly string _tempDir;
+        readonly string _prevLanguage;
+
+        public PatchInstallCoreTests()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "PatchInstallCoreTests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDir);
+            _prevLanguage = CoreState.Language;
+            CoreState.Language = "en";
+        }
+
+        public void Dispose()
+        {
+            CoreState.Language = _prevLanguage;
+            CoreState.ROM = null;
+            CoreState.Undo = null;
+            try
+            {
+                if (Directory.Exists(_tempDir))
+                    Directory.Delete(_tempDir, recursive: true);
+            }
+            catch { /* best effort */ }
+        }
+
+        // ---------- helpers ----------
+
+        // Build a ROM around the given bytes and register it as CoreState.ROM so the
+        // Undo machinery (which snapshots from / rolls back into CoreState.ROM) works.
+        static ROM MakeRom(byte[] data)
+        {
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect((byte[])data.Clone());
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+            return rom;
+        }
+
+        static Undo.UndoData NewUndo(ROM rom)
+        {
+            return new Undo.UndoData
+            {
+                time = DateTime.Now,
+                name = "patch-install-test",
+                list = new System.Collections.Generic.List<Undo.UndoPostion>(),
+                filesize = (uint)rom.Data.Length,
+            };
+        }
+
+        // 0x200 of 0xFF, the spec's vanilla baseline.
+        static byte[] Vanilla(int size = 0x200)
+        {
+            var b = new byte[size];
+            for (int i = 0; i < b.Length; i++) b[i] = 0xFF;
+            return b;
+        }
+
+        // Produce a CustomBuild patch (PATCH_*.txt + *.bin sidecars) in _tempDir from
+        // a vanilla→modified diff, and load it back into a PatchSt.
+        PatchInstallCore.PatchSt MakeAndLoad(byte[] vanilla, byte[] modified, string name = "Synthetic")
+        {
+            string outFile = Path.Combine(_tempDir, "PATCH_" + name + ".txt");
+            DiffToolCore.MakeDiff(outFile, vanilla, modified, patchedIfMinSize: 10,
+                collectFreeSpace: false, version: 8, isMultibyte: false);
+            return PatchInstallCore.LoadPatch(outFile);
+        }
+
+        // ---------- core round-trip ----------
+
+        [Fact]
+        public void RoundTrip_MakeDiff_LoadPatch_ApplyPatch_RomEqualsModified()
+        {
+            byte[] vanilla = Vanilla();
+            byte[] modified = (byte[])vanilla.Clone();
+            // Mutate a few disjoint ranges (offsets > 0x100 so they clear the guard).
+            for (int i = 0x110; i < 0x118; i++) modified[i] = 0xAB;
+            for (int i = 0x180; i < 0x190; i++) modified[i] = (byte)(i & 0xFF);
+            modified[0x1F0] = 0x12;
+
+            var patch = MakeAndLoad(vanilla, modified);
+            Assert.NotNull(patch);
+            // CustomBuild emits at least one BINF line.
+            Assert.Contains(patch.Param.Keys, k => k.StartsWith("BINF:", StringComparison.Ordinal));
+
+            var rom = MakeRom(vanilla);
+            var undo = NewUndo(rom);
+            PatchInstallCore.ApplyPatch(patch, rom, undo);
+
+            Assert.Equal(modified, rom.Data);
+        }
+
+        [Fact]
+        public void RoundTrip_UndoRollback_RestoresVanillaBytes()
+        {
+            byte[] vanilla = Vanilla();
+            byte[] modified = (byte[])vanilla.Clone();
+            for (int i = 0x120; i < 0x140; i++) modified[i] = 0xCC;
+
+            var patch = MakeAndLoad(vanilla, modified, "UndoCase");
+            var rom = MakeRom(vanilla);
+            var undo = NewUndo(rom);
+
+            PatchInstallCore.ApplyPatch(patch, rom, undo);
+            Assert.Equal(modified, rom.Data);
+
+            // Commit the recorded undo then roll it back — ROM returns to vanilla.
+            CoreState.Undo.Push(undo);
+            CoreState.Undo.RunUndo();
+
+            Assert.Equal(vanilla, rom.Data);
+        }
+
+        [Fact]
+        public void RoundTrip_WriteBeyondEnd_ResizesRom()
+        {
+            // Modified is LONGER than vanilla: the diff range lands past the original
+            // 0x200 end, forcing write_resize_data inside ApplyPatch.
+            byte[] vanilla = Vanilla(0x200);
+            byte[] modified = new byte[0x240];
+            Array.Copy(vanilla, modified, vanilla.Length);
+            for (int i = 0x200; i < 0x240; i++) modified[i] = 0x77;
+
+            var patch = MakeAndLoad(vanilla, modified, "ResizeCase");
+            var rom = MakeRom(vanilla);
+            Assert.Equal(0x200, rom.Data.Length);
+
+            var undo = NewUndo(rom);
+            PatchInstallCore.ApplyPatch(patch, rom, undo);
+
+            Assert.True(rom.Data.Length >= 0x240, "ROM should have grown to fit the write");
+            // Every modified byte must now be present.
+            for (int i = 0x200; i < 0x240; i++)
+                Assert.Equal(0x77, rom.Data[i]);
+        }
+
+        // ---------- guard / reject cases ----------
+
+        [Fact]
+        public void ApplyPatch_ZeroAddressWrite_Rejected()
+        {
+            // Hand-craft a BINF that targets a low/protected address (<= 0x100).
+            string binName = "00000000.bin";
+            File.WriteAllBytes(Path.Combine(_tempDir, binName), new byte[] { 0x01, 0x02, 0x03, 0x04 });
+            string outFile = Path.Combine(_tempDir, "PATCH_ZeroAddr.txt");
+            File.WriteAllLines(outFile, new[]
+            {
+                "NAME=ZeroAddr",
+                "TYPE=BIN",
+                "BINF:0x0=" + binName,
+            });
+
+            var patch = PatchInstallCore.LoadPatch(outFile);
+            var rom = MakeRom(Vanilla());
+            var undo = NewUndo(rom);
+
+            Assert.Throws<PatchInstallException>(() => PatchInstallCore.ApplyPatch(patch, rom, undo));
+        }
+
+        [Fact]
+        public void ApplyPatch_UnsupportedKeyword_ThrowsLoudly()
+        {
+            // A COPY line is valid in the full PatchForm engine but outside the
+            // CustomBuild subset — the installer must reject it rather than ignore it.
+            string outFile = Path.Combine(_tempDir, "PATCH_Copy.txt");
+            File.WriteAllLines(outFile, new[]
+            {
+                "NAME=Copy",
+                "TYPE=BIN",
+                "COPY:0x800:0x10=dummy.bin",
+            });
+
+            var patch = PatchInstallCore.LoadPatch(outFile);
+            var rom = MakeRom(Vanilla());
+            var undo = NewUndo(rom);
+
+            Assert.Throws<PatchInstallException>(() => PatchInstallCore.ApplyPatch(patch, rom, undo));
+        }
+
+        [Fact]
+        public void ApplyPatch_MacroAddress_ThrowsLoudly()
+        {
+            // A '$' macro/pointer address is outside the literal-only CustomBuild subset.
+            string binName = "deadbeef.bin";
+            File.WriteAllBytes(Path.Combine(_tempDir, binName), new byte[] { 0xAA });
+            string outFile = Path.Combine(_tempDir, "PATCH_Macro.txt");
+            File.WriteAllLines(outFile, new[]
+            {
+                "NAME=Macro",
+                "TYPE=BIN",
+                "BINF:$FREEAREA=" + binName,
+            });
+
+            var patch = PatchInstallCore.LoadPatch(outFile);
+            var rom = MakeRom(Vanilla());
+            var undo = NewUndo(rom);
+
+            Assert.Throws<PatchInstallException>(() => PatchInstallCore.ApplyPatch(patch, rom, undo));
+        }
+
+        // ---------- LoadPatch parse ----------
+
+        [Fact]
+        public void LoadPatch_NoTypeLine_ReturnsNull()
+        {
+            string outFile = Path.Combine(_tempDir, "PATCH_NoType.txt");
+            File.WriteAllLines(outFile, new[] { "NAME=NoType", "INFO=nothing" });
+            Assert.Null(PatchInstallCore.LoadPatch(outFile));
+        }
+
+        [Fact]
+        public void LoadPatch_LanguageSuffixedKey_ResolvedToActiveLanguage()
+        {
+            CoreState.Language = "ja";
+            string[] lines =
+            {
+                "TYPE=BIN",
+                "NAME.ja=日本語",   // Japanese name
+                "NAME.en=English",
+            };
+            var patch = PatchInstallCore.LoadPatch(lines, Path.Combine(_tempDir, "PATCH_Lang.txt"));
+            Assert.NotNull(patch);
+            Assert.Equal("日本語", patch.Param["NAME"]);
+        }
+
+        // ---------- UNINSTALL extension ----------
+
+        [Fact]
+        public void ApplyPatch_Uninstall_CopiesVanillaBytesBack()
+        {
+            // Address must clear the 0x200 safety floor (WF isSafetyOffset), so use a
+            // larger ROM and target 0x250.
+            byte[] vanilla = Vanilla(0x400);     // all 0xFF
+            byte[] installed = (byte[])vanilla.Clone();
+            for (int i = 0x250; i < 0x260; i++) installed[i] = 0x00; // pretend a patch wrote zeros
+
+            // Patch: UNINSTALL the 0x10 bytes at 0x250 from the vanilla source.
+            string outFile = Path.Combine(_tempDir, "PATCH_Uninstall.txt");
+            File.WriteAllLines(outFile, new[]
+            {
+                "NAME=Uninstall",
+                "TYPE=BIN",
+                "UNINSTALL:0x250=0x10",
+            });
+
+            var patch = PatchInstallCore.LoadPatch(outFile);
+            var rom = MakeRom(installed);
+            var undo = NewUndo(rom);
+
+            PatchInstallCore.ApplyPatch(patch, rom, undo, vanillaRom: vanilla);
+
+            // The 0x150..0x160 window is restored to vanilla (0xFF).
+            Assert.Equal(vanilla, rom.Data);
+        }
+
+        [Fact]
+        public void ApplyPatch_Uninstall_NoVanillaRom_ThrowsLoudly()
+        {
+            string outFile = Path.Combine(_tempDir, "PATCH_UninstallNoRom.txt");
+            File.WriteAllLines(outFile, new[]
+            {
+                "NAME=UninstallNoRom",
+                "TYPE=BIN",
+                "UNINSTALL:0x150=0x10",
+            });
+
+            var patch = PatchInstallCore.LoadPatch(outFile);
+            var rom = MakeRom(Vanilla());
+            var undo = NewUndo(rom);
+
+            Assert.Throws<PatchInstallException>(() => PatchInstallCore.ApplyPatch(patch, rom, undo));
+        }
+    }
+}

--- a/FEBuilderGBA.Core/PatchInstallCore.cs
+++ b/FEBuilderGBA.Core/PatchInstallCore.cs
@@ -247,7 +247,10 @@ namespace FEBuilderGBA
             // sp[1] is the destination address; a CustomBuild BINF emits exactly two
             // tokens ("BINF" and "0x...."). A third token (sp[2]) would request a
             // ChangeAddress relocation, which is out of the CustomBuild subset.
-            if (sp.Length > 2 && U.atoi0x(U.at(sp, 2)) > 0)
+            // Reject ANY third token unconditionally (loud fail) — a numeric check
+            // would let a non-hex relocation token like "$TEXTID" parse to 0 and slip
+            // through, silently ignoring the relocation it requested.
+            if (sp.Length > 2)
             {
                 throw new PatchInstallException(R.Error(
                     "Address relocation is not supported by the CustomBuild patch installer: {0}",

--- a/FEBuilderGBA.Core/PatchInstallCore.cs
+++ b/FEBuilderGBA.Core/PatchInstallCore.cs
@@ -1,0 +1,345 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Thrown when a patch cannot be loaded or applied: malformed text, an
+    /// unsupported keyword/macro-address, an unsafe write target, or a ROM that
+    /// cannot be grown to fit the patch.
+    /// Carries a localized message (via <see cref="R.Error"/>) and never raises a
+    /// dialog — callers decide how to surface it.
+    /// </summary>
+    public class PatchInstallException : Exception
+    {
+        public PatchInstallException(string message) : base(message) { }
+    }
+
+    /// <summary>
+    /// Cross-platform patch load + apply engine extracted from WinForms PatchForm.
+    /// SLICE 1 of issue #1248: handles the CustomBuild auto-install path only.
+    ///
+    /// A CustomBuild patch (produced by <see cref="DiffToolCore.MakeDiff"/>) contains
+    /// ONLY literal-offset BIN/BINF byte-diffs — no macros ($), GREP, FREEAREA,
+    /// pointer kinds, COPY/SLIDE/JUMP/TEXT/etc. This engine therefore implements just
+    /// that literal-offset load+apply path so it is fully provable headless with no
+    /// ROM/SkillSystems environment.
+    ///
+    /// Any keyword or address form outside the CustomBuild subset is rejected LOUDLY
+    /// (<see cref="PatchInstallException"/>) so a non-CustomBuild patch fails fast
+    /// rather than silently mis-applying. The full UpdatePatch merge engine and the
+    /// MargeAndUpdate orchestration are separate later slices.
+    ///
+    /// Mirrors PatchForm.LoadPatch / CleanupKey (text parse) and
+    /// writeBIN/BinWriteFile/makeBinModInnerReadFile/WriteBB (the BIN/BINF write path).
+    /// </summary>
+    public static class PatchInstallCore
+    {
+        /// <summary>
+        /// Parsed patch: file path, display name, plus the raw key/value Param map.
+        /// Mirrors PatchForm.PatchSt.
+        /// </summary>
+        public class PatchSt
+        {
+            public string PatchFileName;
+            public string Name;
+            public string SearchData; // search index text
+            public DateTime Date;
+
+            public Dictionary<string, string> Param;
+        }
+
+        /// <summary>
+        /// Read a PATCH_*.txt file and parse it into a <see cref="PatchSt"/>.
+        /// Mirrors PatchForm.LoadPatch(string,bool) with isScanOnly=false.
+        /// Returns null when the text has no TYPE= line (not a patch).
+        /// </summary>
+        public static PatchSt LoadPatch(string fullfilename)
+        {
+            string[] lines = File.ReadAllLines(fullfilename);
+            return LoadPatch(lines, fullfilename);
+        }
+
+        /// <summary>
+        /// Parse already-read patch text into a <see cref="PatchSt"/>.
+        /// Mirrors PatchForm.LoadPatch(string[],string,bool) with isScanOnly=false.
+        /// Language-suffixed keys (NAME.ja / NAME.en) are resolved against
+        /// <see cref="CoreState.Language"/>, exactly like the WinForms path.
+        /// </summary>
+        public static PatchSt LoadPatch(string[] lines, string fullfilename)
+        {
+            string lang = CoreState.Language;
+            bool canSecondLanguageEnglish = U.CanSecondLanguageEnglish(lang);
+
+            PatchSt p = new PatchSt();
+            p.PatchFileName = fullfilename;
+            p.Param = new Dictionary<string, string>();
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string line = lines[i];
+                if (U.IsComment(line) || U.OtherLangLine(line))
+                {
+                    continue;
+                }
+                line = U.ClipComment(line);
+                line = line.Trim();
+
+                int sep = line.IndexOf('=');
+                if (sep < 0)
+                {
+                    continue;
+                }
+                string key = line.Substring(0, sep);
+                string value = line.Substring(sep + 1);
+
+                key = CleanupKey(key, lang, canSecondLanguageEnglish, p);
+                if (key == "")
+                {
+                    continue;
+                }
+
+                p.Param[key] = value;
+            }
+
+            string type = U.at(p.Param, "TYPE");
+            if (type == "")
+            {
+                return null;
+            }
+
+            // PATCH_ prefix is 6 chars; mirror PatchForm's Substring(6).
+            string stem = Path.GetFileNameWithoutExtension(fullfilename) ?? "";
+            string search_filename = stem.Length >= 6 ? stem.Substring(6) : stem;
+
+            string name = U.at(p.Param, "NAME");
+            if (name == "")
+            {
+                name = search_filename;
+            }
+            p.Name = name;
+
+            p.SearchData = name + "\t" + search_filename + "\t"
+                + U.at(p.Param, "INFO") + "\t" + U.at(p.Param, "AUTHOR") + "\t"
+                + U.at(p.Param, "TAG") + "\t" + U.at(p.Param, "HINT");
+            // WF uses U.GetFileDateLastWriteTime (a WinForms-only helper); inline its
+            // body here. File.Exists guards parse-from-text callers with no real file.
+            p.Date = File.Exists(fullfilename) ? File.GetLastWriteTime(fullfilename) : DateTime.MinValue;
+
+            return p;
+        }
+
+        /// <summary>
+        /// Resolve a language-suffixed key (e.g. "NAME.ja") against the active
+        /// language. Returns the bare key when it matches the language (or the
+        /// English fallback when permitted and the first language did not already
+        /// set it), "" when it is for a different language, and the key unchanged
+        /// when it carries no ".xx" suffix. Mirrors PatchForm.CleanupKey.
+        /// </summary>
+        static string CleanupKey(string key, string lang, bool canSecondLanguageEnglish, PatchSt patch)
+        {
+            if (key.Length < 3)
+            {
+                return key;
+            }
+            if (key[key.Length - 3] != '.')
+            {
+                return key;
+            }
+            string k = key.Substring(key.Length - 2);
+            if (k == lang)
+            {
+                return key.Substring(0, key.Length - 3);
+            }
+
+            if (canSecondLanguageEnglish)
+            {
+                if (k == "en")
+                {
+                    string ret_key = key.Substring(0, key.Length - 3);
+                    if (!patch.Param.ContainsKey(ret_key))
+                    {
+                        return ret_key;
+                    }
+                }
+            }
+
+            return "";
+        }
+
+        /// <summary>
+        /// Apply a CustomBuild patch to <paramref name="rom"/>, recording the
+        /// pre-write bytes into <paramref name="undo"/> so the install can be rolled
+        /// back. Iterates the Param map and, for each BIN/BINF key, reads the sidecar
+        /// from the patch directory, resolves the LITERAL offset, runs the
+        /// zero-address guard, grows the ROM if the write extends past its end, then
+        /// writes the bytes.
+        ///
+        /// IMPORTANT: BIN/BINF here means a LITERAL-offset write only. Any other
+        /// keyword, or a macro address ($...), throws <see cref="PatchInstallException"/>
+        /// so a non-CustomBuild patch fails loudly rather than silently mis-applying.
+        ///
+        /// For undo to be meaningful the supplied ROM must be the one Undo snapshots
+        /// from — i.e. CoreState.ROM — because the WinForms Undo machinery reads the
+        /// pre-write bytes from CoreState.ROM at write time and rolls back into it.
+        ///
+        /// <paramref name="vanillaRom"/> is the unmodified ROM bytes used by the
+        /// optional UNINSTALL keyword to copy the original bytes back; it is null for
+        /// a plain install and only needed when the patch carries UNINSTALL lines.
+        /// </summary>
+        public static void ApplyPatch(PatchSt patch, ROM rom, Undo.UndoData undo, byte[] vanillaRom = null)
+        {
+            if (patch == null) throw new ArgumentNullException(nameof(patch));
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (undo == null) throw new ArgumentNullException(nameof(undo));
+
+            string basedir = Path.GetDirectoryName(patch.PatchFileName) ?? "";
+
+            foreach (var pair in patch.Param)
+            {
+                string[] sp = pair.Key.Split(':');
+                string keyword = sp[0];
+                string value = pair.Value;
+
+                switch (keyword)
+                {
+                    // Non-write metadata keys — skip (mirrors WF, which only acts on
+                    // keyword-matched lines and ignores the rest).
+                    case "TYPE":
+                    case "NAME":
+                    case "INFO":
+                    case "AUTHOR":
+                    case "TAG":
+                    case "HINT":
+                    case "DATE":
+                    case "URL":
+                    case "PATCHED_IF":
+                        continue;
+
+                    case "BIN":
+                    case "BINF":
+                        ApplyBinFile(sp, Path.Combine(basedir, value), rom, undo);
+                        break;
+
+                    case "UNINSTALL":
+                        // Optional clean extension: copy bytes back from a supplied
+                        // vanilla ROM. The "value" is a hex length (matching WF, which
+                        // takes the length from Path.GetFileName of the sidecar arg).
+                        ApplyUninstall(sp, value, rom, undo, vanillaRom);
+                        break;
+
+                    default:
+                        throw new PatchInstallException(R.Error(
+                            "This keyword is not supported by the CustomBuild patch installer: {0}",
+                            keyword));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Apply a single BIN/BINF literal-offset write: read the sidecar, resolve
+        /// the literal offset, and write. Mirrors PatchForm.BinWriteFile +
+        /// makeBinModInnerReadFile (literal branch only).
+        /// </summary>
+        static void ApplyBinFile(string[] sp, string filename, ROM rom, Undo.UndoData undo)
+        {
+            // sp[1] is the destination address; a CustomBuild BINF emits exactly two
+            // tokens ("BINF" and "0x...."). A third token (sp[2]) would request a
+            // ChangeAddress relocation, which is out of the CustomBuild subset.
+            if (sp.Length > 2 && U.atoi0x(U.at(sp, 2)) > 0)
+            {
+                throw new PatchInstallException(R.Error(
+                    "Address relocation is not supported by the CustomBuild patch installer: {0}",
+                    sp[0] + ":" + U.at(sp, 1)));
+            }
+
+            string addrstring = U.at(sp, 1);
+            uint addr = ResolveLiteralOffset(addrstring);
+
+            byte[] b = File.ReadAllBytes(filename);
+            WriteBB(addr, b, rom, undo);
+        }
+
+        /// <summary>
+        /// Optional UNINSTALL keyword: copy <c>length</c> bytes from the supplied
+        /// vanilla ROM back into the working ROM at the literal destination address,
+        /// undoing a prior install. Mirrors PatchForm.BinUninstall, but the vanilla
+        /// ROM is supplied explicitly (no FindOrignalROM lookup / no caching).
+        /// The length is taken from <paramref name="lengthHex"/> (the patch value),
+        /// matching WF which reads it from the sidecar file name.
+        /// </summary>
+        static void ApplyUninstall(string[] sp, string lengthHex, ROM rom, Undo.UndoData undo, byte[] vanilla)
+        {
+            if (vanilla == null)
+            {
+                throw new PatchInstallException(R.Error(
+                    "An unmodified ROM is required to uninstall, but none was supplied."));
+            }
+
+            // Bound-check directly against the vanilla ROM (U.isSafetyOffset reads
+            // CoreState.ROM, whose length may differ from the vanilla source).
+            uint addr = U.atoi0x(U.at(sp, 1));
+            if (addr < 0x00000200 || addr >= 0x02000000 || addr >= vanilla.Length)
+            {
+                throw new PatchInstallException(R.Error(
+                    "The uninstall destination address is invalid dest:{0}", U.at(sp, 1)));
+            }
+
+            uint length = U.atoi0x(lengthHex);
+            byte[] s = U.getBinaryData(vanilla, addr, length);
+            WriteBB(addr, s, rom, undo);
+        }
+
+        /// <summary>
+        /// Resolve a CustomBuild address string to a ROM offset. Only the literal form
+        /// is accepted (mirrors PatchForm.convertBinAddressString's first branch:
+        /// U.toOffset(U.atoi0x(...))). A leading '$' (macro/pointer) is rejected as
+        /// outside the CustomBuild subset.
+        /// </summary>
+        static uint ResolveLiteralOffset(string addrstring)
+        {
+            if (addrstring == "")
+            {
+                throw new PatchInstallException(R.Error("The patch is missing a destination address."));
+            }
+            if (addrstring[0] == '$')
+            {
+                throw new PatchInstallException(R.Error(
+                    "Macro/pointer addresses are not supported by the CustomBuild patch installer: {0}",
+                    addrstring));
+            }
+            return U.toOffset(U.atoi0x(addrstring));
+        }
+
+        /// <summary>
+        /// Write <paramref name="b"/> at <paramref name="addr"/> into the ROM with
+        /// the zero-address guard and auto-resize. Mirrors PatchForm.WriteBB.
+        /// The resize happens BEFORE the write so the undo snapshot (taken inside
+        /// write_range) captures the freshly-grown, zero-filled region as the
+        /// pre-write state — matching the WinForms ordering exactly.
+        /// </summary>
+        static void WriteBB(uint addr, byte[] b, ROM rom, Undo.UndoData undo)
+        {
+            // WF U.CheckZeroAddressWrite: reject NOT_FOUND or addr <= 0x100.
+            if (addr == U.NOT_FOUND || addr <= 0x100)
+            {
+                throw new PatchInstallException(R.Error(
+                    "This address is dangerous to write to: {0}", U.To0xHexString(addr)));
+            }
+
+            if (addr + b.Length > rom.Data.Length)
+            {
+                bool isResizeSuccess = rom.write_resize_data((uint)(addr + b.Length));
+                if (isResizeSuccess == false)
+                {
+                    throw new PatchInstallException(R.Error(
+                        "Cannot allocate a region larger than 32MB(0x02000000). requested size:{0}",
+                        U.To0xHexString((uint)(addr + b.Length))));
+                }
+            }
+
+            rom.write_range(addr, b, undo);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
**Slice 1** of #1248 (Custom Build MargeAndUpdate auto-install): extracts the **CustomBuild patch-install engine** to Core as a standalone, fully-tested foundation. A CustomBuild patch (from the already-in-Core `DiffToolCore.MakeDiff`) contains *only* literal-offset `BINF` byte-diffs — no macros/GREP/FREEAREA/pointer kinds — so the load+apply path is a clean, GUI-free extraction provable by a synthetic round-trip, with no SkillSystems environment needed.

This unblocks the keystone patch-install path the campaign had flagged as the WinForms-coupled remainder. (Slice 2 = the `MargeAndUpdate` file-orchestration + `ToolCustomBuildView` VM wiring that closes #1248; slice 3 = the full `PatchForm.UpdatePatch` merge engine. Both are separate follow-ups.)

## Changes (additive only — no existing file modified)
- **`FEBuilderGBA.Core/PatchInstallCore.cs`** (+345): `PatchSt` DTO + `LoadPatch(path)`/`LoadPatch(lines, path)` + `CleanupKey` (text→PatchSt parse, ported from `PatchForm.LoadPatch`; lang-suffixed keys resolve against `CoreState.Language`) + `ApplyPatch(patch, rom, undo, vanillaRom=null)` for **BIN/BINF** (sidecar read → literal offset `U.toOffset(U.atoi0x)` → zero-address guard → `write_resize_data` when extending past end → `write_range(addr, bytes, undo)`, ported from `writeBIN`/`BinWriteFile`/`makeBinModInnerReadFile`/`WriteBB`). Any other keyword or a `$` macro address throws `PatchInstallException` (loud fail for non-CustomBuild patches). Optional `UNINSTALL` keyword restores bytes from a supplied vanilla ROM (no new CoreState field).
- **`FEBuilderGBA.Core.Tests/PatchInstallCoreTests.cs`** (+292, 10 tests).

## Tests
- Core.Tests: **4391 passed**, 0 failed — the synthetic round-trip `MakeDiff(v8) → LoadPatch → ApplyPatch` asserts `rom.Data == modified`, plus undo-rollback (restores vanilla), resize (write past end grows ROM), and reject cases (zero-address / unsupported keyword / `$` macro / UNINSTALL-without-vanilla all throw).
- FEBuilderGBA.Tests (net9.0-windows): **1864 passed**, 0 failed (no CliProjectTests / source-text regression).

Part of #1248

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
