### PR TITLE
feat(core): ROM-rebuild Make/Apply Core — make the .rebuild manifest applicable (#1261 slice 1)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildCoreTests.cs
@@ -547,6 +547,97 @@ namespace FEBuilderGBA.Core.Tests
             }
         }
 
+        [Theory]
+        [InlineData((byte)0xB2)]   // repointer: needs +4 payload
+        [InlineData((byte)0xBB)]   // single-byte-arg family
+        [InlineData((byte)0xB9)]   // MEMACC: needs +3
+        public void Make_TruncatedSongScore_EmitsGracefully_NoOverrun(byte truncCmd)
+        {
+            // Copilot finding 2-5: a SONGSCORE struct whose data is truncated mid-command must
+            // NOT throw IndexOutOfRange. The struct runs to the VERY END of the ROM array, and
+            // a multi-byte command sits as the LAST byte — so an unguarded read genuinely
+            // indexes past the array. The emitter must stop at the boundary instead.
+            const uint scoreOff = 0x1000;          // in the rebuild region
+            uint scoreLen = 0x20;
+            uint romLen = scoreOff + scoreLen;     // struct ends exactly at ROM end
+            byte[] mod = new byte[romLen];
+            mod[scoreOff + 0] = 0x90;              // a normal note byte
+            mod[scoreOff + 1] = 0x40;
+            // The truncating command is the LAST byte of the ROM: its payload would overrun.
+            mod[romLen - 1] = truncCmd;
+
+            var prevRom = CoreState.ROM;
+            try
+            {
+                var romObj = new ROM();
+                romObj.SwapNewROMDataDirect((byte[])mod.Clone());
+                CoreState.ROM = romObj;
+
+                // vanilla = small base so the struct (in the rebuild region) always differs.
+                var vanilla = new ROM();
+                vanilla.SwapNewROMDataDirect(new byte[0x1000]);
+
+                var structList = new List<Address>
+                {
+                    new Address(scoreOff, scoreLen, U.NOT_FOUND, "SCORE", Address.DataTypeEnum.SONGSCORE),
+                };
+
+                using (var tmp = new TempDir())
+                {
+                    string manifestPath = Path.Combine(tmp.Path, "score.rebuild");
+                    // Must NOT throw (pre-fix: IndexOutOfRangeException past the array end).
+                    var ex = Record.Exception(() =>
+                        RebuildMakeCore.Make(mod, vanilla, 0x1000, structList, manifestPath));
+                    Assert.Null(ex);
+                    Assert.True(File.Exists(manifestPath));
+                }
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+            }
+        }
+
+        [Fact]
+        public void Make_BareFilenameManifestPath_DoesNotThrow()
+        {
+            // Copilot finding 6: a manifest path with no directory component ("foo.rebuild")
+            // makes Path.GetDirectoryName return null; the guarded code must treat it as the
+            // current directory instead of throwing in Path.Combine. Run inside a temp cwd so
+            // the sidecar folders land somewhere disposable.
+            byte[] modified = BuildModified();
+            ROM vanilla = BuildVanilla();
+
+            var prevRom = CoreState.ROM;
+            string prevCwd = Directory.GetCurrentDirectory();
+            try
+            {
+                var modifiedRom = new ROM();
+                modifiedRom.SwapNewROMDataDirect((byte[])modified.Clone());
+                CoreState.ROM = modifiedRom;
+
+                using (var tmp = new TempDir())
+                {
+                    Directory.SetCurrentDirectory(tmp.Path);
+                    var structList = BuildStructList();
+
+                    var ex = Record.Exception(() =>
+                        RebuildMakeCore.Make(modified, vanilla, REBUILD_ADDR, structList, "bare.rebuild"));
+                    Assert.Null(ex);
+                    Assert.True(File.Exists(Path.Combine(tmp.Path, "bare.rebuild")));
+
+                    // The applier must equally tolerate a bare manifest filename.
+                    var result = RebuildApplyCore.Apply(vanilla, "bare.rebuild", 0x09000000);
+                    Assert.True(result.Success, "bare-filename Apply log:\n" + result.Log);
+                }
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(prevCwd);
+                CoreState.ROM = prevRom;
+            }
+        }
+
         static string ReadAllSidecars(string dir)
         {
             var sb = new System.Text.StringBuilder();

--- a/FEBuilderGBA.Core.Tests/RebuildCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildCoreTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Xunit;
 
@@ -195,6 +196,382 @@ namespace FEBuilderGBA.Core.Tests
         {
             var result = RebuildCore.WriteRebuildReport(new byte[64], new byte[64], 0, "");
             Assert.False(result.Success);
+        }
+    }
+
+    /// <summary>
+    /// #1261 slice 1 — full Make/Apply round-trip on a SYNTHETIC fragmented ROM with a
+    /// hand-built <see cref="Address"/> struct list (no real ROM, no WinForms keystone).
+    /// Proves: pointers stay intact through relocation, the free run is reclaimed, a second
+    /// Make on the rebuilt output is stable, and a forward (missing-then-resolved) pointer is
+    /// back-patched correctly.
+    /// </summary>
+    [Collection("SharedState")]
+    public class RebuildMakeApplyRoundTripTests
+    {
+        // Synthetic layout (all values little-endian):
+        //   0x000..0x0FF  header (arbitrary, identical vanilla vs modified)
+        //   0x200         pointer -> 0x08004000 (struct B)   [non-rebuild region]
+        //   0x204         pointer -> 0x08008000 (struct C)   [non-rebuild region]
+        //   0x1000        struct A  (0x20 bytes)  [rebuild region: addr == rebuildAddr, stays]
+        //   0x1800        0x2000-byte 0x00 FREE RUN
+        //   0x4000        struct B  (0x30 bytes)  [rebuild region, relocated/compacted]
+        //   0x8000        struct C  (0x40 bytes)  [rebuild region, relocated/compacted]
+        const uint HEADER_LEN = 0x100;
+        const uint PTR_B_OFF = 0x200;
+        const uint PTR_C_OFF = 0x204;
+        const uint STRUCT_A_OFF = 0x1000;
+        const uint STRUCT_A_LEN = 0x20;
+        const uint FREE_RUN_OFF = 0x1800;
+        const uint FREE_RUN_LEN = 0x2000;
+        const uint STRUCT_B_OFF = 0x4000;
+        const uint STRUCT_B_LEN = 0x30;
+        const uint STRUCT_C_OFF = 0x8000;
+        const uint STRUCT_C_LEN = 0x40;
+        const uint ROM_LEN = 0x10000;
+        const uint VANILLA_LEN = 0x1000;     // the non-rebuild base region
+        const uint REBUILD_ADDR = 0x1000;    // offset; everything strictly above this relocates
+
+        static void Fill(byte[] rom, uint off, uint len, byte seed)
+        {
+            for (uint i = 0; i < len; i++) rom[off + i] = (byte)(seed + i);
+        }
+        static void WriteU32(byte[] rom, uint off, uint val)
+        {
+            rom[off + 0] = (byte)(val & 0xFF);
+            rom[off + 1] = (byte)((val >> 8) & 0xFF);
+            rom[off + 2] = (byte)((val >> 16) & 0xFF);
+            rom[off + 3] = (byte)((val >> 24) & 0xFF);
+        }
+        static uint ReadU32(byte[] rom, uint off)
+        {
+            return (uint)(rom[off] | (rom[off + 1] << 8) | (rom[off + 2] << 16) | (rom[off + 3] << 24));
+        }
+
+        // The modified (fragmented) ROM.
+        static byte[] BuildModified()
+        {
+            byte[] rom = new byte[ROM_LEN];
+            Fill(rom, 0, HEADER_LEN, 0x11);
+            WriteU32(rom, PTR_B_OFF, 0x08000000 + STRUCT_B_OFF);
+            WriteU32(rom, PTR_C_OFF, 0x08000000 + STRUCT_C_OFF);
+            Fill(rom, STRUCT_A_OFF, STRUCT_A_LEN, 0xA0);
+            // FREE_RUN stays all-zero
+            Fill(rom, STRUCT_B_OFF, STRUCT_B_LEN, 0xB0);
+            Fill(rom, STRUCT_C_OFF, STRUCT_C_LEN, 0xC0);
+            return rom;
+        }
+
+        // The vanilla base: just the non-rebuild region (0..0x1000), zero elsewhere conceptually.
+        // It only needs to cover the non-rebuild region; Apply seeds the rebuilt ROM from it.
+        // The two pointer fields are LEFT NULL in vanilla — the mod is what points them at
+        // structs B/C. This makes the pointer fields DIFFER from vanilla, so the emitter
+        // records them as @-token MIX rows (not @DEF), which is what lets Apply back-patch
+        // them to the relocated targets. (Identical-to-vanilla pointer fields would emit @DEF
+        // and keep the stale literal address — the realistic case is always a repoint.)
+        static ROM BuildVanilla()
+        {
+            byte[] data = new byte[VANILLA_LEN];
+            Fill(data, 0, HEADER_LEN, 0x11);
+            // PTR_B_OFF / PTR_C_OFF stay 0x00000000 (null) in vanilla.
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(data);
+            return rom;
+        }
+
+        // Hand-built struct list marking the 3 structs + 2 pointer fields. No Forms — this IS
+        // the parameter boundary the slice exists to prove.
+        static List<Address> BuildStructList()
+        {
+            var list = new List<Address>();
+            // Pointer fields (in the non-rebuild region) — DataType POINTER, length 4.
+            list.Add(new Address(PTR_B_OFF, 4, U.NOT_FOUND, "PTR_B", Address.DataTypeEnum.POINTER));
+            list.Add(new Address(PTR_C_OFF, 4, U.NOT_FOUND, "PTR_C", Address.DataTypeEnum.POINTER));
+            // Struct A: stays at rebuildAddr (no pointer, fixed BIN).
+            list.Add(new Address(STRUCT_A_OFF, STRUCT_A_LEN, U.NOT_FOUND, "STRUCT_A", Address.DataTypeEnum.BIN));
+            // Structs B and C: reachable via the pointers; BIN data that must relocate.
+            list.Add(new Address(STRUCT_B_OFF, STRUCT_B_LEN, 0x08000000 + PTR_B_OFF, "STRUCT_B", Address.DataTypeEnum.BIN));
+            list.Add(new Address(STRUCT_C_OFF, STRUCT_C_LEN, 0x08000000 + PTR_C_OFF, "STRUCT_C", Address.DataTypeEnum.BIN));
+            return list;
+        }
+
+        sealed class TempDir : IDisposable
+        {
+            public string Path { get; }
+            public TempDir()
+            {
+                Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "feb_rebuild_rt_" + Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(Path);
+            }
+            public void Dispose() { try { Directory.Delete(Path, true); } catch { } }
+        }
+
+        [Fact]
+        public void RoundTrip_PointersIntact_FreeReclaimed_Idempotent()
+        {
+            byte[] modified = BuildModified();
+            ROM vanilla = BuildVanilla();
+
+            // The emitter's pointer-safety checks read CoreState.ROM (the modified ROM).
+            // The Address ctor itself validates against CoreState.ROM, so set it FIRST,
+            // then hand-build the struct list.
+            var prevRom = CoreState.ROM;
+            try
+            {
+                var modifiedRom = new ROM();
+                modifiedRom.SwapNewROMDataDirect((byte[])modified.Clone());
+                CoreState.ROM = modifiedRom;
+
+                var structList = BuildStructList();
+
+                using (var tmp = new TempDir())
+                {
+                    string manifestPath = Path.Combine(tmp.Path, "test.rebuild");
+
+                    // (3) Make -> manifest with the expected @-token columns.
+                    RebuildMakeCore.Make(modified, vanilla, REBUILD_ADDR, structList, manifestPath);
+                    Assert.True(File.Exists(manifestPath));
+                    string manifest = File.ReadAllText(manifestPath);
+
+                    Assert.Contains("@_CRC32 ", manifest);
+                    Assert.Contains("@_REBUILDADDRESS ", manifest);
+                    Assert.Contains("@BIN ", manifest);     // structs A/B/C emit as fixed BIN
+                    // The two pointer fields are MIX rows pointing at sidecar files; the
+                    // 4-byte pointer column lives in the sidecar as an @-token (the manifest
+                    // line only references the file). Verify both: the @MIX manifest line AND
+                    // the @-token inside the sidecar (proving pointer columns emit).
+                    Assert.Contains("@MIX ", manifest);
+                    string allSidecars = ReadAllSidecars(Path.Combine(tmp.Path, "rebuild_mix"));
+                    Assert.Contains("@" + U.ToHexString(0x08000000 + STRUCT_B_OFF), allSidecars);
+                    Assert.Contains("@" + U.ToHexString(0x08000000 + STRUCT_C_OFF), allSidecars);
+
+                    // (4) Apply -> rebuilt byte[].
+                    var result = RebuildApplyCore.Apply(vanilla, manifestPath, 0x09000000);
+                    Assert.True(result.Success, "Apply log:\n" + result.Log);
+                    Assert.NotNull(result.Rebuilt);
+                    byte[] rebuilt = result.Rebuilt;
+
+                    // (5a) DATA INTACT: every pointer still resolves to bytes equal to the
+                    // ORIGINAL struct content.
+                    uint newB = U.toOffset(ReadU32(rebuilt, PTR_B_OFF));
+                    uint newC = U.toOffset(ReadU32(rebuilt, PTR_C_OFF));
+                    AssertBytesEqual(modified, STRUCT_B_OFF, rebuilt, newB, STRUCT_B_LEN);
+                    AssertBytesEqual(modified, STRUCT_C_OFF, rebuilt, newC, STRUCT_C_LEN);
+                    // Struct A stays at its address (== rebuildAddr) and keeps its bytes.
+                    AssertBytesEqual(modified, STRUCT_A_OFF, rebuilt, STRUCT_A_OFF, STRUCT_A_LEN);
+
+                    // (5b) FREE RECLAIMED: the 0x2000-byte gap + the 0x4000/0x8000 holes are
+                    // gone — the rebuilt ROM is materially smaller than the fragmented one.
+                    Assert.True(rebuilt.Length < modified.Length,
+                        $"rebuilt {rebuilt.Length:X} should be < modified {modified.Length:X}");
+                    // The relocated structs are compacted right after the rebuild address,
+                    // so the old 0x8000 hole is no longer occupied by struct C.
+                    Assert.True(newB < STRUCT_C_OFF && newC < STRUCT_C_OFF + STRUCT_C_LEN,
+                        $"structs not compacted: B=0x{newB:X} C=0x{newC:X}");
+
+                    // (5c) IDEMPOTENCE: a second Make on the rebuilt output, with an updated
+                    // struct list, produces a stable manifest (same structural shape).
+                    var rebuiltRom = new ROM();
+                    rebuiltRom.SwapNewROMDataDirect((byte[])rebuilt.Clone());
+                    CoreState.ROM = rebuiltRom;
+
+                    var structList2 = new List<Address>
+                    {
+                        new Address(PTR_B_OFF, 4, U.NOT_FOUND, "PTR_B", Address.DataTypeEnum.POINTER),
+                        new Address(PTR_C_OFF, 4, U.NOT_FOUND, "PTR_C", Address.DataTypeEnum.POINTER),
+                        new Address(STRUCT_A_OFF, STRUCT_A_LEN, U.NOT_FOUND, "STRUCT_A", Address.DataTypeEnum.BIN),
+                        new Address(newB, STRUCT_B_LEN, 0x08000000 + PTR_B_OFF, "STRUCT_B", Address.DataTypeEnum.BIN),
+                        new Address(newC, STRUCT_C_LEN, 0x08000000 + PTR_C_OFF, "STRUCT_C", Address.DataTypeEnum.BIN),
+                    };
+                    string manifest2Path = Path.Combine(tmp.Path, "test2.rebuild");
+                    // vanilla compares against the rebuilt ROM here; structs already compacted,
+                    // so Apply of this manifest must reproduce a ROM of the same length.
+                    RebuildMakeCore.Make(rebuilt, vanilla, REBUILD_ADDR, structList2, manifest2Path);
+                    var result2 = RebuildApplyCore.Apply(vanilla, manifest2Path, 0x09000000);
+                    Assert.True(result2.Success, "2nd Apply log:\n" + result2.Log);
+                    Assert.Equal(rebuilt.Length, result2.Rebuilt.Length);
+                    uint newB2 = U.toOffset(ReadU32(result2.Rebuilt, PTR_B_OFF));
+                    uint newC2 = U.toOffset(ReadU32(result2.Rebuilt, PTR_C_OFF));
+                    AssertBytesEqual(modified, STRUCT_B_OFF, result2.Rebuilt, newB2, STRUCT_B_LEN);
+                    AssertBytesEqual(modified, STRUCT_C_OFF, result2.Rebuilt, newC2, STRUCT_C_LEN);
+                }
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+            }
+        }
+
+        [Fact]
+        public void Apply_ForwardPointer_BackPatchedCorrectly()
+        {
+            // A FORWARD (missing-then-resolved) pointer: struct P points at struct T, but the
+            // manifest emits P's MIX row BEFORE T is resolved (so P registers a MissingPointer
+            // that ResolvedPointer must back-patch when T lands). Hand-write the manifest so
+            // the ordering is guaranteed, exercising MissingPointerList / ResolvedPointer.
+            ROM vanilla = BuildVanilla();
+            byte[] modified = BuildModified();
+
+            var prevRom = CoreState.ROM;
+            try
+            {
+                var modifiedRom = new ROM();
+                modifiedRom.SwapNewROMDataDirect((byte[])modified.Clone());
+                CoreState.ROM = modifiedRom;
+
+                using (var tmp = new TempDir())
+                {
+                    // Sidecar: struct T (the target) as a BIN, struct P (a MIX whose 4-byte
+                    // column is an @-token to T's GBA pointer).
+                    Directory.CreateDirectory(Path.Combine(tmp.Path, "rebuild_bin"));
+                    Directory.CreateDirectory(Path.Combine(tmp.Path, "rebuild_mix"));
+
+                    byte[] targetBytes = new byte[STRUCT_C_LEN];
+                    for (int i = 0; i < targetBytes.Length; i++) targetBytes[i] = (byte)(0xC0 + i);
+                    File.WriteAllBytes(Path.Combine(tmp.Path, "rebuild_bin", "T.bin"), targetBytes);
+
+                    // P's MIX content: a single @-token pointing at T's *original* address.
+                    // Since T relocates, this @-token is unknown at the time P is applied
+                    // (P is emitted first) -> forward pointer.
+                    string pMix = "@" + U.ToHexString(0x08000000 + STRUCT_C_OFF);
+                    File.WriteAllText(Path.Combine(tmp.Path, "rebuild_mix", "P.txt"), pMix);
+
+                    // Manifest: P BEFORE T (forces the forward/back-patch path).
+                    string manifest =
+                        "@_CRC32 00000000 //x\r\n" +
+                        "@_REBUILDADDRESS " + U.ToHexString(REBUILD_ADDR) + " //x\r\n" +
+                        "@MIX " + U.ToHexString8(STRUCT_B_OFF) + " rebuild_mix/P.txt\r\n" +
+                        "@BIN " + U.ToHexString8(STRUCT_C_OFF) + " rebuild_bin/T.bin\r\n";
+                    string manifestPath = Path.Combine(tmp.Path, "fwd.rebuild");
+                    File.WriteAllText(manifestPath, manifest);
+
+                    var result = RebuildApplyCore.Apply(vanilla, manifestPath, 0x09000000);
+                    Assert.True(result.Success, "forward-pointer Apply left unresolved pointers:\n" + result.Log);
+
+                    // P relocated to newP; its first 4 bytes must now point at T's NEW location,
+                    // and T's bytes there must equal targetBytes.
+                    byte[] rebuilt = result.Rebuilt;
+                    // Find P's new home: it's the relocated copy of STRUCT_B_OFF. The pointer
+                    // P originally lived at STRUCT_B_OFF; after relocation read it back via the
+                    // AddressMap-driven resolution. We locate P by scanning for the back-patched
+                    // pointer value that resolves to T's content.
+                    bool found = false;
+                    for (uint off = REBUILD_ADDR; off + 4 <= rebuilt.Length; off += 4)
+                    {
+                        uint val = ReadU32(rebuilt, off);
+                        if (val >= 0x08000000 && val < 0x0A000000)
+                        {
+                            uint tgt = U.toOffset(val);
+                            if (tgt + STRUCT_C_LEN <= rebuilt.Length && BytesEqual(rebuilt, tgt, targetBytes))
+                            {
+                                found = true;
+                                break;
+                            }
+                        }
+                    }
+                    Assert.True(found, "forward pointer was not back-patched to the relocated target:\n" + result.Log);
+                }
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+            }
+        }
+
+        [Fact]
+        public void Apply_ForwardAsmPointer_PreservesThumbBit_OnBackPatch()
+        {
+            // The ASM ±1 thumb-bit path: an &-token references an ODD (thumb) pointer to a
+            // forward target. P is emitted before T, so at apply time AddressMap has neither
+            // the odd pointer nor its even base -> a MissingPointer{Type=ASM} is registered.
+            // When T resolves (even labelPointer), ResolvedPointer's ASM branch must rewrite
+            // the field to (relocatedTarget + 1), preserving the thumb bit. Without that
+            // logic the relocation would silently corrupt the ASM pointer.
+            ROM vanilla = BuildVanilla();
+            byte[] modified = BuildModified();
+
+            var prevRom = CoreState.ROM;
+            try
+            {
+                var modifiedRom = new ROM();
+                modifiedRom.SwapNewROMDataDirect((byte[])modified.Clone());
+                CoreState.ROM = modifiedRom;
+
+                using (var tmp = new TempDir())
+                {
+                    Directory.CreateDirectory(Path.Combine(tmp.Path, "rebuild_bin"));
+                    Directory.CreateDirectory(Path.Combine(tmp.Path, "rebuild_mix"));
+
+                    byte[] targetBytes = new byte[STRUCT_C_LEN];
+                    for (int i = 0; i < targetBytes.Length; i++) targetBytes[i] = (byte)(0xD0 + i);
+                    File.WriteAllBytes(Path.Combine(tmp.Path, "rebuild_bin", "T.bin"), targetBytes);
+
+                    // &-token to T's ORIGINAL address with the thumb bit set (odd).
+                    string pMix = "&" + U.ToHexString(0x08000000 + STRUCT_C_OFF + 1);
+                    File.WriteAllText(Path.Combine(tmp.Path, "rebuild_mix", "P.txt"), pMix);
+
+                    string manifest =
+                        "@_CRC32 00000000 //x\r\n" +
+                        "@_REBUILDADDRESS " + U.ToHexString(REBUILD_ADDR) + " //x\r\n" +
+                        "@MIX " + U.ToHexString8(STRUCT_B_OFF) + " rebuild_mix/P.txt\r\n" +
+                        "@BIN " + U.ToHexString8(STRUCT_C_OFF) + " rebuild_bin/T.bin\r\n";
+                    string manifestPath = Path.Combine(tmp.Path, "fwdasm.rebuild");
+                    File.WriteAllText(manifestPath, manifest);
+
+                    var result = RebuildApplyCore.Apply(vanilla, manifestPath, 0x09000000);
+                    Assert.True(result.Success, "forward ASM-pointer Apply left unresolved pointers:\n" + result.Log);
+
+                    // Scan for an ODD GBA pointer whose (value-1) target holds targetBytes —
+                    // i.e. the thumb bit survived the back-patch.
+                    byte[] rebuilt = result.Rebuilt;
+                    bool found = false;
+                    for (uint off = REBUILD_ADDR; off + 4 <= rebuilt.Length; off += 4)
+                    {
+                        uint val = ReadU32(rebuilt, off);
+                        if (val >= 0x08000001 && val < 0x0A000000 && U.IsValueOdd(val))
+                        {
+                            uint tgt = U.toOffset(val - 1);
+                            if (tgt + STRUCT_C_LEN <= rebuilt.Length && BytesEqual(rebuilt, tgt, targetBytes))
+                            {
+                                found = true;
+                                break;
+                            }
+                        }
+                    }
+                    Assert.True(found, "forward ASM pointer lost its thumb bit or was not back-patched:\n" + result.Log);
+                }
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+            }
+        }
+
+        static string ReadAllSidecars(string dir)
+        {
+            var sb = new System.Text.StringBuilder();
+            if (!Directory.Exists(dir)) return "";
+            foreach (string f in Directory.GetFiles(dir))
+            {
+                sb.AppendLine(File.ReadAllText(f));
+            }
+            return sb.ToString();
+        }
+        static bool BytesEqual(byte[] rom, uint off, byte[] expected)
+        {
+            for (uint i = 0; i < expected.Length; i++)
+            {
+                if (rom[off + i] != expected[i]) return false;
+            }
+            return true;
+        }
+        static void AssertBytesEqual(byte[] expectedRom, uint expectedOff, byte[] actualRom, uint actualOff, uint len)
+        {
+            for (uint i = 0; i < len; i++)
+            {
+                Assert.True(expectedRom[expectedOff + i] == actualRom[actualOff + i],
+                    $"byte mismatch at +0x{i:X}: expected 0x{expectedRom[expectedOff + i]:X2} got 0x{actualRom[actualOff + i]:X2} (actualOff=0x{actualOff:X})");
+            }
         }
     }
 }

--- a/FEBuilderGBA.Core/RebuildApplyCore.cs
+++ b/FEBuilderGBA.Core/RebuildApplyCore.cs
@@ -173,7 +173,9 @@ namespace FEBuilderGBA
                 // (and exercised when callers raise it) but the public API leaves it off.
                 this.UseShareSameData = 0;
 
-                string dir = Path.GetDirectoryName(filename);
+                //ディレクトリ成分が無いマニフェスト名 ("foo.rebuild") では GetDirectoryName が
+                //null を返すので、カレントディレクトリ ("") として扱う (Path.Combine が投げない).
+                string dir = Path.GetDirectoryName(filename) ?? "";
 
                 string[] lines;
                 try
@@ -479,9 +481,17 @@ namespace FEBuilderGBA
                     return U.NOT_FOUND;
                 }
 
-                if (this.IsReserved != null && this.IsReserved(foundAddr))
-                {//SkillSystemsのエリアがある場合は再検索.
-                    foundAddr = U.Grep(this.WriteROMData32MB, bin, foundAddr, this.WriteOffset, 4);
+                //SkillSystemsなどの予約領域にヒットした場合は、その先から再検索する.
+                //U.Grep の start は inclusive なので、必ず foundAddr+4 から再開しないと
+                //同じ予約済みヒットを永久に返してしまう (4 = ARMアライメント).
+                while (this.IsReserved != null && this.IsReserved(foundAddr))
+                {
+                    uint nextStart = foundAddr + 4;
+                    if (nextStart >= this.WriteOffset)
+                    {
+                        return U.NOT_FOUND;
+                    }
+                    foundAddr = U.Grep(this.WriteROMData32MB, bin, nextStart, this.WriteOffset, 4);
                     if (foundAddr == U.NOT_FOUND)
                     {
                         return U.NOT_FOUND;

--- a/FEBuilderGBA.Core/RebuildApplyCore.cs
+++ b/FEBuilderGBA.Core/RebuildApplyCore.cs
@@ -1,0 +1,830 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Cross-platform ROM-rebuild <c>Apply</c> (slice 1 of #1261): reads a <c>.rebuild</c>
+    /// manifest plus its sidecar files and reconstructs a defragmented ROM from a vanilla
+    /// base. Ported nearly verbatim from the WinForms <c>ToolROMRebuildApply</c>; the two
+    /// WinForms touches are replaced with injected parameters:
+    /// <list type="bullet">
+    ///   <item><c>Program.ROM.RomInfo.extends_address</c> -&gt; the <c>extendsAddress</c> parameter.</item>
+    ///   <item><c>MoveToFreeSapceForm.IsSkillReserve</c> -&gt; the optional <c>isReserved</c> callback.</item>
+    /// </list>
+    /// <para>
+    /// Slice 1 uses <b>append-only allocation</b>: relocated data always grows the ROM tail.
+    /// The free-area recycler (<c>ToolROMRebuildFreeArea</c>) is a later slice, so the
+    /// <c>useFreeArea</c> / free-area-min-size parameters of the WinForms shell are omitted
+    /// here. The flat 32MB reserve buffer + <c>ApplyVanillaROM</c> truncate are preserved so
+    /// the eventual Avalonia background-thread writer can keep the same fault-safe shape
+    /// (explicit undo + resize-before-write).
+    /// </para>
+    /// </summary>
+    public static class RebuildApplyCore
+    {
+        //LZ77のID部の位置.
+        const int LZ77UNIQ_SHIFT = 20;
+
+        enum PointerType
+        {
+            NONE
+            , ASM           //+0x1
+            , ANTI_HUFFMAN  //+0x80 00 00 00
+        }
+
+        //戦闘アニメのフレームはポインタがあるのに可変長のLZ77なのでそれを何とかして解決するために利用する.
+        //基本的に、無圧縮で格納して、最後にROM末尾に配置する.
+        sealed class LZ77Struct
+        {
+            public byte[] Bin;
+            public uint OrignalAddr;
+            public uint OrignalDataSize;
+            public string DebugInfo;
+
+            public LZ77Struct(byte[] bin, uint orignalAddr, uint orignalDataSize, string debugInfo)
+            {
+                this.Bin = bin;
+                this.OrignalAddr = orignalAddr;
+                this.OrignalDataSize = orignalDataSize;
+                this.DebugInfo = debugInfo;
+            }
+        }
+
+        //まだ発見していない不明なポインタ
+        sealed class MissingPointer
+        {
+            public uint FindPointer; //探しているポインタ
+            public uint WroteAddr;   //このデータがある位置
+            public PointerType Type;
+            public bool IsLZ77;      //LZ77の仮想アドレス
+            public string DebugTargetfilename;
+
+            public MissingPointer(uint findPointer, uint wroteAddr, PointerType type, bool isLZ77, string debugTargetfilename)
+            {
+                this.FindPointer = findPointer;
+                this.WroteAddr = wroteAddr;
+                this.Type = type;
+                this.IsLZ77 = isLZ77;
+                this.DebugTargetfilename = debugTargetfilename;
+            }
+        }
+
+        /// <summary>Result of an <see cref="Apply(ROM,string,uint,Func{uint,bool},IProgress{string})"/> run.</summary>
+        public sealed class ApplyResult
+        {
+            public bool Success { get; set; }
+            public string Message { get; set; }
+            /// <summary>The rebuilt ROM bytes (truncated to <c>WriteOffset</c>).</summary>
+            public byte[] Rebuilt { get; set; }
+            /// <summary>The self-check log (mirrors the WinForms <c>.log.txt</c> contents).</summary>
+            public string Log { get; set; }
+        }
+
+        /// <summary>
+        /// Apply a <c>.rebuild</c> manifest to a vanilla ROM and return the rebuilt bytes.
+        /// </summary>
+        /// <param name="vanilla">The unmodified base ROM (defines the non-rebuild region).</param>
+        /// <param name="manifestPath">Path to the <c>.rebuild</c> manifest; sidecar files are resolved relative to its directory.</param>
+        /// <param name="extendsAddress">GBA pointer of the extends ROM area (was <c>Program.ROM.RomInfo.extends_address</c>); reserved for later free-area slices.</param>
+        /// <param name="isReserved">Optional: returns true (and may advance the ref addr) when an offset falls in a reserved/SkillSystems region during share-search. Default = never reserved.</param>
+        /// <param name="progress">Optional progress reporter.</param>
+        public static ApplyResult Apply(ROM vanilla, string manifestPath, uint extendsAddress,
+            Func<uint, bool> isReserved = null, IProgress<string> progress = null)
+        {
+            if (vanilla == null || vanilla.Data == null)
+            {
+                return new ApplyResult { Success = false, Message = "Error: vanilla ROM is null." };
+            }
+            if (string.IsNullOrEmpty(manifestPath) || !File.Exists(manifestPath))
+            {
+                return new ApplyResult { Success = false, Message = "Error: manifest not found: " + manifestPath };
+            }
+
+            var session = new Session(vanilla, isReserved, progress);
+            return session.Run(manifestPath);
+        }
+
+        /// <summary>
+        /// Per-run mutable state. Kept as an instance class (mirroring the WinForms field
+        /// layout) so the ported method bodies stay byte-for-byte recognizable, while the
+        /// public surface stays a pure static <see cref="Apply"/>.
+        /// </summary>
+        sealed class Session
+        {
+            //書き込んでいるデータ. 当初は無改造ROMからスタートしデータをどんどん書き込んでいきます.
+            //ただし、リサイズによる無駄を避けるために、32MBを確保します.
+            readonly byte[] WriteROMData32MB;
+            //現在書き込んでいるROMサイズを指します.
+            uint WriteOffset;
+
+            //どのアドレスをどこに再マップしたかのテーブル
+            readonly Dictionary<uint, uint> AddressMap = new Dictionary<uint, uint>();
+            readonly List<MissingPointer> MissingPointerList = new List<MissingPointer>();
+            readonly List<LZ77Struct> LZ77StructList = new List<LZ77Struct>();
+            readonly StringBuilder ApplyLog = new StringBuilder();
+
+            uint RebuildAddress;
+            uint UseShareSameData = 0;
+
+            readonly ROM Vanilla;
+            readonly Func<uint, bool> IsReserved;
+            readonly IProgress<string> Progress;
+
+            public Session(ROM vanilla, Func<uint, bool> isReserved, IProgress<string> progress)
+            {
+                this.Vanilla = vanilla;
+                this.IsReserved = isReserved;
+                this.Progress = progress;
+                this.WriteROMData32MB = new byte[32 * 1024 * 1024]; //32MB memory reserve
+            }
+
+            //ROMリサイズ
+            void write_resize_data(uint addr)
+            {
+                this.WriteOffset = U.Padding4(addr);
+            }
+
+            bool isVanilaExtrendsROMArea(uint addr)
+            {
+                return addr > this.RebuildAddress;
+            }
+
+            //append-only allocation (slice 1 — no free-area recycler).
+            uint Alloc(uint size, uint current_addr)
+            {
+                uint writeaddr = this.WriteOffset;
+                writeaddr = U.Padding4(writeaddr);
+                write_resize_data(writeaddr + size);
+                return writeaddr;
+            }
+
+            public ApplyResult Run(string filename)
+            {
+                this.AddressMap.Clear();
+                this.MissingPointerList.Clear();
+                this.LZ77StructList.Clear();
+                U.write_range(this.WriteROMData32MB, 0, this.Vanilla.Data);
+                this.WriteOffset = (uint)this.Vanilla.Data.Length;
+                // UseShareSameData defaults to 0 (no share) for slice 1 — the WinForms
+                // useShareSameData option is a UI toggle; the share-search code is kept
+                // (and exercised when callers raise it) but the public API leaves it off.
+                this.UseShareSameData = 0;
+
+                string dir = Path.GetDirectoryName(filename);
+
+                string[] lines;
+                try
+                {
+                    lines = File.ReadAllLines(filename);
+                }
+                catch (Exception ex)
+                {
+                    return new ApplyResult { Success = false, Message = "Error: cannot read manifest. " + ex.Message };
+                }
+
+                this.RebuildAddress = GetRebuildAddress(lines);
+                if (this.RebuildAddress > this.WriteOffset)
+                {
+                    write_resize_data(this.RebuildAddress);
+                    this.RebuildAddress = this.WriteOffset;
+                }
+
+                int nextDoEvents = 0;
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    string line = lines[i];
+                    string srcline = line;
+                    line = U.ClipComment(line);
+                    string[] sp = line.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (sp.Length < 2)
+                    {
+                        continue;
+                    }
+                    if (sp[0] == "@_CRC32"
+                        || sp[0] == "@_REBUILDADDRESS"
+                        || sp[0] == "@_ASSERT")
+                    {
+                        continue;
+                    }
+
+                    uint vanilla_addr;
+                    uint blocksize;
+                    uint count;
+                    string targetfilename;
+                    uint addr = ParseLine(sp, out vanilla_addr, out targetfilename, out blocksize, out count);
+
+                    if (sp[0] == "@DEF")
+                    {
+                        DEF(addr, srcline);
+                        continue;
+                    }
+                    else if (sp[0] == "@BROKENDATA")
+                    {
+                        BrokenData(addr, srcline);
+                        continue;
+                    }
+                    else if (sp[0] == "@00")
+                    {
+                        Fixed00(addr, blocksize, srcline);
+                        continue;
+                    }
+
+                    if (i > nextDoEvents)
+                    {
+                        this.Progress?.Report(i + ":" + line);
+                        nextDoEvents = i + 0xff;
+                    }
+
+                    targetfilename = Path.Combine(dir, targetfilename);
+                    if (!File.Exists(targetfilename))
+                    {
+                        return new ApplyResult
+                        {
+                            Success = false,
+                            Message = "Error: missing sidecar file (" + targetfilename + ") at line " + (i + 1)
+                        };
+                    }
+
+                    if (sp[0] == "@IFR")
+                    {
+                        IFR(addr, vanilla_addr, targetfilename, blocksize, count, srcline);
+                    }
+                    else if (sp[0] == "@BIN")
+                    {
+                        Bin(addr, targetfilename, srcline);
+                    }
+                    else if (sp[0] == "@MIX")
+                    {
+                        Mix(addr, targetfilename, srcline);
+                    }
+                    else if (sp[0] == "@MIXLZ77")
+                    {
+                        MixLZ77(addr, targetfilename, blocksize, srcline);
+                    }
+                    else
+                    {
+                        continue;
+                    }
+                }
+
+                this.Progress?.Report("WriteBackMixLZ77");
+                //後回しにしていたLZ77の解決.
+                WriteBackMixLZ77();
+
+                this.Progress?.Report("CheckSelf");
+                string log;
+                bool ok = CheckSelf(out log);
+
+                this.Progress?.Report("ApplyVanillaROM");
+                byte[] rebuilt = BuildRebuilt();
+
+                return new ApplyResult
+                {
+                    Success = ok,
+                    Message = ok ? "Rebuild applied." : "Rebuild applied with unresolved pointers (see Log).",
+                    Rebuilt = rebuilt,
+                    Log = log,
+                };
+            }
+
+            //WinFormsの ApplyVanillaROM 相当. flat 32MB buffer を WriteOffset で切り詰める.
+            byte[] BuildRebuilt()
+            {
+                return U.getBinaryData(this.WriteROMData32MB, 0, this.WriteOffset);
+            }
+
+            bool CheckSelf(out string log)
+            {
+                StringBuilder sb = new StringBuilder();
+                ShowMissingPointers(sb);
+
+                bool isOK = true;
+                if (sb.Length > 0)
+                {
+                    sb.Insert(0, "== ERROR! ==\r\n");
+                    isOK = false;
+                }
+                sb.AppendLine("== MAPPING ==");
+                sb.Append(this.ApplyLog);
+
+                log = sb.ToString();
+                return isOK;
+            }
+
+            void ShowMissingPointers(StringBuilder sb)
+            {
+                for (int i = 0; i < this.MissingPointerList.Count; i++)
+                {
+                    MissingPointer m = this.MissingPointerList[i];
+                    if (m.WroteAddr < this.RebuildAddress)
+                    {
+                        continue;
+                    }
+                    sb.Append("Missing!");
+                    sb.Append(" P:");
+                    sb.Append(U.To0xHexString(m.FindPointer));
+                    sb.Append(" Pos:");
+                    sb.Append(U.To0xHexString(m.WroteAddr));
+                    sb.Append(" ");
+                    sb.Append(m.Type);
+                    sb.Append(m.IsLZ77 ? " (LZ77)" : "");
+                    sb.Append(" //");
+                    sb.Append(m.DebugTargetfilename);
+                    sb.AppendLine();
+                }
+            }
+
+            //ポインタが解決された
+            void ResolvedPointer(uint labelPointer, uint addrPointer, string debugInfo)
+            {
+                this.AddressMap[labelPointer] = addrPointer;
+                WriteApplyLog(labelPointer, addrPointer, debugInfo);
+
+                //不明なポインタが解決された場合、書き戻す.
+                for (int i = 0; i < this.MissingPointerList.Count; i++)
+                {
+                    MissingPointer m = this.MissingPointerList[i];
+
+                    if (m.FindPointer == labelPointer)
+                    {
+                        uint p = addrPointer;
+                        if (m.Type == PointerType.ANTI_HUFFMAN)
+                        {
+                            p += 0x80000000;
+                        }
+
+                        if (m.IsLZ77)
+                        {
+                            uint lz77uniq = (uint)(m.WroteAddr >> LZ77UNIQ_SHIFT);
+                            uint pos = (uint)(m.WroteAddr & ((1 << LZ77UNIQ_SHIFT) - 1));
+                            LZ77Struct lz77struct = this.LZ77StructList[(int)lz77uniq];
+                            U.write_u32(lz77struct.Bin, pos, p);
+                        }
+                        else
+                        {
+                            U.write_u32(this.WriteROMData32MB, m.WroteAddr, p);
+                        }
+                        //解決されたのでリストから消す.
+                        this.MissingPointerList.RemoveAt(i);
+                        i--;
+                    }
+                    else if (m.Type == PointerType.ASM)
+                    {
+                        uint l;
+                        uint p;
+                        if (U.IsValueOdd(m.FindPointer))
+                        {
+                            if (U.IsValueOdd(labelPointer))
+                            {
+                                continue;
+                            }
+                            l = labelPointer + 1;
+
+                            if (U.IsValueOdd(labelPointer))
+                            {
+                                p = addrPointer;
+                            }
+                            else
+                            {
+                                p = addrPointer + 1;
+                            }
+                        }
+                        else
+                        {
+                            if (!U.IsValueOdd(labelPointer))
+                            {
+                                continue;
+                            }
+                            l = labelPointer - 1;
+
+                            if (U.IsValueOdd(labelPointer))
+                            {
+                                p = addrPointer - 1;
+                            }
+                            else
+                            {
+                                p = addrPointer;
+                            }
+                        }
+
+                        if (m.FindPointer != l)
+                        {
+                            continue;
+                        }
+
+                        if (m.IsLZ77)
+                        {
+                            uint lz77uniq = (uint)(m.WroteAddr >> LZ77UNIQ_SHIFT);
+                            uint pos = (uint)(m.WroteAddr & ((1 << LZ77UNIQ_SHIFT) - 1));
+                            LZ77Struct lz77struct = this.LZ77StructList[(int)lz77uniq];
+                            U.write_u32(lz77struct.Bin, pos, p);
+                        }
+                        else
+                        {
+                            U.write_u32(this.WriteROMData32MB, m.WroteAddr, p);
+                        }
+                        //解決されたのでリストから消す.
+                        this.MissingPointerList.RemoveAt(i);
+                        i--;
+                    }
+                }
+            }
+
+            void DEF(uint addr, string debugInfo)
+            {
+                uint labelPointer = U.toPointer(addr);
+                ResolvedPointer(labelPointer, labelPointer, debugInfo);
+            }
+
+            void BrokenData(uint addr, string debugInfo)
+            {
+                if (!isVanilaExtrendsROMArea(addr))
+                {//非拡張データなので無視する.
+                    uint labelPointer = U.toPointer(addr);
+                    ResolvedPointer(labelPointer, labelPointer, debugInfo);
+                    return;
+                }
+
+                //壊れている魔法アニメなどの画像データ. とりあえず4バイト null を入れる.
+                Bin(addr, new byte[] { 0, 0, 0, 0 }, debugInfo);
+            }
+
+            void Fixed00(uint addr, uint length, string debugInfo)
+            {
+                U.write_fill(this.WriteROMData32MB, addr, length, 0);
+            }
+
+            void WriteApplyLog(uint labelPointer, uint addrPointer, string debugInfo)
+            {
+                if (labelPointer != addrPointer)
+                {
+                    ApplyLog.Append(U.ToHexString8(addrPointer));
+                    ApplyLog.Append(" <=re= ");
+                }
+                ApplyLog.Append(U.ToHexString8(labelPointer));
+                ApplyLog.Append(' ');
+                ApplyLog.Append(debugInfo);
+                ApplyLog.AppendLine();
+            }
+
+            uint SearchShareArea(byte[] bin)
+            {
+                //実はこのデータが既にROMにあったりしますか?
+                uint foundAddr = U.Grep(this.WriteROMData32MB, bin, 0x100, this.WriteOffset, 4);
+                if (foundAddr == U.NOT_FOUND)
+                {
+                    return U.NOT_FOUND;
+                }
+
+                if (this.IsReserved != null && this.IsReserved(foundAddr))
+                {//SkillSystemsのエリアがある場合は再検索.
+                    foundAddr = U.Grep(this.WriteROMData32MB, bin, foundAddr, this.WriteOffset, 4);
+                    if (foundAddr == U.NOT_FOUND)
+                    {
+                        return U.NOT_FOUND;
+                    }
+                }
+                //既にROMにあるので共有させましょう
+                return foundAddr;
+            }
+
+            void Bin(uint addr, string targetfilename, string debugInfo)
+            {
+                byte[] bin = File.ReadAllBytes(targetfilename);
+                Bin(addr, bin, debugInfo);
+            }
+            void Bin(uint addr, byte[] bin, string debugInfo)
+            {
+                uint writeaddr;
+                if (!isVanilaExtrendsROMArea(addr + (uint)bin.Length))
+                {//非拡張領域
+                    writeaddr = addr;
+                }
+                else
+                {
+                    if (IsShareData(bin.Length))
+                    {
+                        //実はこのデータが既にROMにあったりしますか?
+                        uint foundAddr = SearchShareArea(bin);
+                        if (foundAddr != U.NOT_FOUND)
+                        {//既にROMにあるので共有させましょう
+                            writeaddr = foundAddr;
+                            ResolvedPointer(U.toPointer(addr), U.toPointer(writeaddr), debugInfo + "//SHARE!");
+                            return;
+                        }
+                    }
+                    //リポイントが必須
+                    writeaddr = Alloc((uint)bin.Length, addr);
+                }
+
+                U.write_range(this.WriteROMData32MB, writeaddr, bin);
+                ResolvedPointer(U.toPointer(addr), U.toPointer(writeaddr), debugInfo);
+            }
+
+            bool IsShareData(int length)
+            {
+                if (this.UseShareSameData == 1)
+                {//32以下なら共有しない
+                    if (length <= 32)
+                    {
+                        return false;
+                    }
+                    return true;
+                }
+                if (this.UseShareSameData == 2)
+                {//8以下なら共有しない
+                    if (length <= 8)
+                    {
+                        return false;
+                    }
+                    return true;
+                }
+                //共有しない
+                return false;
+            }
+
+            List<byte> WriteBytes(int startIndex //spの中で書き込みを開始するデータ位置 1 or 0
+                , string[] sp                    //ファイルから読みこんでパースしたデータ
+                , uint writeTopBaseAddr          //トップデータの位置 (lz77の場合 0)
+                , uint currentBaseAddr           //書き込む予定の位置 (lz77の場合 ユニークな値)
+                , string debugInfo               //デバッグ用
+            )
+            {
+                bool isLZ77 = (writeTopBaseAddr == 0);
+
+                List<byte> bin = new List<byte>();
+                for (int i = startIndex; i < sp.Length; i++)
+                {
+                    string s = sp[i];
+                    if (s.Length <= 0)
+                    {
+                    }
+                    else if (s[0] == '@')
+                    {//ポインタ
+                        uint p = U.toPointer(U.atoh(s.Substring(1)));
+
+                        uint new_pointer;
+                        if (this.AddressMap.TryGetValue(p, out new_pointer))
+                        {
+                            U.append_u32(bin, new_pointer);
+                        }
+                        else
+                        {//アドレスのデータがないよ! 不明なポインタとしてリストに登録. 後で判明したら書き戻す
+                            this.MissingPointerList.Add(new MissingPointer(p
+                                , currentBaseAddr + (uint)bin.Count
+                                , PointerType.NONE, isLZ77, debugInfo));
+                            //とりあえずそのポインタの値で書き込む.
+                            U.append_u32(bin, p);
+                        }
+                    }
+                    else if (s[0] == '`')
+                    {//anti-huffmanのポインタ
+                        uint p = U.toPointer(U.atoh(s.Substring(1)));
+                        uint new_pointer;
+                        if (this.AddressMap.TryGetValue(p, out new_pointer))
+                        {
+                            U.append_u32(bin, new_pointer + 0x80000000);
+                        }
+                        else
+                        {//アドレスのデータがないよ! 不明なポインタとしてリストに登録. 後で判明したら書き戻す
+                            this.MissingPointerList.Add(new MissingPointer(p
+                                , currentBaseAddr + (uint)bin.Count
+                                , PointerType.ANTI_HUFFMAN, isLZ77, debugInfo));
+                            U.append_u32(bin, p + 0x80000000);
+                        }
+                    }
+                    else if (s[0] == '&')
+                    {//ASM
+                        uint p = U.toPointer(U.atoh(s.Substring(1)));
+
+                        uint new_pointer;
+                        if (this.AddressMap.TryGetValue(p, out new_pointer))
+                        {
+                            U.append_u32(bin, new_pointer);
+                        }
+                        else if (
+                            U.IsValueOdd(p)
+                            && this.AddressMap.TryGetValue(p - 1, out new_pointer))
+                        {
+                            U.append_u32(bin, new_pointer + 1);
+                        }
+                        else
+                        {//アドレスのデータがないよ! 不明なポインタとしてリストに登録. 後で判明したら書き戻す
+                            this.MissingPointerList.Add(new MissingPointer(p
+                                , currentBaseAddr + (uint)bin.Count
+                                , PointerType.ASM, isLZ77, debugInfo));
+                            U.append_u32(bin, p);
+                        }
+                    }
+                    else if (s[0] == '+')
+                    {//自己参照
+                        uint plus = U.atoh(s.Substring(1));
+                        uint new_pointer = U.toPointer(writeTopBaseAddr + plus);
+                        U.append_u32(bin, new_pointer);
+                    }
+                    else
+                    {
+                        U.append_u8(bin, U.atoh(s));
+                    }
+                }
+                return bin;
+            }
+
+            void Mix(uint addr, string targetfilename, string debugInfo)
+            {
+                string lines = File.ReadAllText(targetfilename);
+                string[] sp = lines.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+                //まずサイズを求めないといけない.
+                uint datasize = CalcWriteDataSize(sp);
+
+                //領域の確保
+                uint writeaddr;
+                if (!isVanilaExtrendsROMArea(addr + datasize))
+                {//非拡張領域. そのまま書き換えられる
+                    writeaddr = addr;
+                }
+                else
+                {//リポイントが必要
+                    writeaddr = Alloc(datasize, addr);
+                }
+                List<byte> bin = WriteBytes(0, sp, writeaddr, writeaddr, debugInfo);
+
+                //データの書き込み
+                U.write_range(this.WriteROMData32MB, writeaddr, bin.ToArray());
+                ResolvedPointer(U.toPointer(addr), U.toPointer(writeaddr), debugInfo);
+            }
+
+            uint CalcWriteDataSize(string[] sp)
+            {
+                uint datasize = 0;
+                for (int i = 0; i < sp.Length; i++)
+                {
+                    if (sp[i][0] == '@' //ポインタ
+                     || sp[i][0] == '&' //ASMコード ポインタ+1
+                     || sp[i][0] == '+' //自己参照
+                     || sp[i][0] == '`' //anti-huffman
+                        )
+                    {
+                        datasize += 4;
+                    }
+                    else
+                    {
+                        datasize++;
+                    }
+                }
+                return datasize;
+            }
+
+            void MixLZ77(uint addr, string targetfilename, uint datasize, string debugInfo)
+            {
+                string lines = File.ReadAllText(targetfilename);
+                string[] sp = lines.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+                int oldMissingSize = this.MissingPointerList.Count;
+                uint lz77uniq = (uint)(this.LZ77StructList.Count << LZ77UNIQ_SHIFT);
+                List<byte> bin = WriteBytes(0, sp, 0, lz77uniq, debugInfo);
+
+                int newMissingSize = this.MissingPointerList.Count;
+                if (oldMissingSize == newMissingSize)
+                {//不明なポインタは存在しない. よって、書き込めるはず
+                    WriteLZ77Bin(bin.ToArray(), addr, datasize, debugInfo);
+                }
+                else
+                {//不明なポインタがあるので、末尾に回す
+                    this.LZ77StructList.Add(new LZ77Struct(bin.ToArray(), addr, datasize, debugInfo));
+                }
+            }
+
+            void WriteLZ77Bin(byte[] bin, uint addr, uint datasize, string debugInfo)
+            {
+                byte[] newbin = LZ77.compress(bin);
+
+                //領域の確保
+                uint writeaddr;
+                if (!isVanilaExtrendsROMArea(addr + datasize)
+                    && datasize >= newbin.Length)
+                {//非拡張領域. そのまま書き換えられる
+                    writeaddr = addr;
+                }
+                else
+                {//リポイントが必要
+                    writeaddr = Alloc((uint)newbin.Length, addr);
+                }
+
+                //データの書き込み
+                U.write_range(this.WriteROMData32MB, writeaddr, newbin);
+                ResolvedPointer(U.toPointer(addr), U.toPointer(writeaddr), debugInfo);
+            }
+
+            void WriteBackMixLZ77()
+            {
+                for (int i = 0; i < this.LZ77StructList.Count; i++)
+                {
+                    LZ77Struct lz77Struct = this.LZ77StructList[i];
+                    WriteLZ77Bin(lz77Struct.Bin, lz77Struct.OrignalAddr, lz77Struct.OrignalDataSize, lz77Struct.DebugInfo);
+                }
+            }
+
+            void IFR(uint addr, uint vanilla_addr, string targetfilename, uint blocksize, uint count, string debugInfo)
+            {
+                uint writeaddr;
+                if (!isVanilaExtrendsROMArea(addr + blocksize * count))
+                {//非拡張領域. そのまま書き換えられる
+                    writeaddr = addr;
+                }
+                else
+                {//リポイントが必要
+                    writeaddr = Alloc(blocksize * count, addr);
+
+                    //データのコピー
+                    byte[] bin = U.getBinaryData(this.WriteROMData32MB, vanilla_addr, blocksize * count);
+                    U.write_range(this.WriteROMData32MB, writeaddr, bin);
+                }
+
+                string[] lines = File.ReadAllLines(targetfilename);
+                for (int n = 0; n < lines.Length; n++)
+                {
+                    string line = lines[n];
+                    string[] sp = line.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (sp.Length < 1 || sp[0].Length < 1 || sp[0][0] != '=')
+                    {
+                        continue;
+                    }
+                    uint dataIndex = U.atoh(sp[0].Substring(1));
+
+                    uint pos = writeaddr + (blocksize * dataIndex);
+                    List<byte> bin = WriteBytes(1, sp, writeaddr, pos, debugInfo);
+
+                    U.write_range(this.WriteROMData32MB, pos, bin.ToArray());
+                }
+                ResolvedPointer(U.toPointer(addr), U.toPointer(writeaddr), debugInfo);
+            }
+        }
+
+        static uint ParseLine(string[] sp
+           , out uint out_vanilla_addr
+           , out string out_filename
+           , out uint out_blocksize
+           , out uint out_count)
+        {
+            out_vanilla_addr = 0;
+            out_filename = "";
+            out_blocksize = 0;
+            out_count = 0;
+
+            for (int i = 2; i < sp.Length; i++)
+            {
+                if (sp[i][0] == '=')
+                {//無改造ROMのアドレス
+                    out_vanilla_addr = U.atoh(sp[i].Substring(1));
+                    out_vanilla_addr = U.toOffset(out_vanilla_addr);
+                }
+                else if (sp[i][0] == '*')
+                {//個数
+                    out_count = U.atoh(sp[i].Substring(1));
+                }
+                else if (sp[i][0] == ':')
+                {//ブロックサイズ
+                    out_blocksize = U.atoh(sp[i].Substring(1));
+                }
+                else
+                {//不明なので多分ファイルだと思う.
+                    out_filename = string.Join(" ", sp, i, sp.Length - i);
+                    break;
+                }
+            }
+
+            uint addr = U.atoh(sp[1]);
+            return U.toOffset(addr);
+        }
+
+        public static uint GetCRC32(string[] lines)
+        {
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string[] sp = lines[i].Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                if (sp.Length >= 1 && sp[0] == "@_CRC32" && sp.Length >= 2)
+                {
+                    return U.atoh(sp[1]);
+                }
+            }
+            return U.NOT_FOUND;
+        }
+        public static uint GetRebuildAddress(string[] lines)
+        {
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string[] sp = lines[i].Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                if (sp.Length >= 1 && sp[0] == "@_REBUILDADDRESS" && sp.Length >= 2)
+                {
+                    return U.atoh(sp[1]);
+                }
+            }
+            return U.NOT_FOUND;
+        }
+    }
+}

--- a/FEBuilderGBA.Core/RebuildMakeCore.cs
+++ b/FEBuilderGBA.Core/RebuildMakeCore.cs
@@ -1,0 +1,1412 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Cross-platform ROM-rebuild <c>Make</c> EMITTER (slice 1 of #1261): given the
+    /// modified ROM bytes, a vanilla base ROM, a rebuild start address and a
+    /// <b>caller-supplied</b> <see cref="Address"/> struct list, it writes a
+    /// <c>.rebuild</c> manifest plus the per-struct sidecar files
+    /// (<c>rebuild_ifr/</c>, <c>rebuild_mix/</c>, <c>rebuild_bin/</c>) that
+    /// <see cref="RebuildApplyCore"/> consumes.
+    /// <para>
+    /// The keystone producer (<c>U.MakeAllStructPointersList</c> + ~120 WinForms Form
+    /// statics) is NOT ported here — the struct list is a <b>parameter</b>, so the WinForms
+    /// shell keeps producing it for now (a later slice ports the producer). Consequently the
+    /// producer-only steps of the WinForms <c>ToolROMRebuildMake.Make</c> (LDR/BL re-scan,
+    /// hardcoded-pointer search, OptimizeList, ProcssPointer) are intentionally omitted: the
+    /// supplied list is taken as authoritative and emitted as-is.
+    /// </para>
+    /// <para>WinForms touches replaced by injected parameters/callbacks:</para>
+    /// <list type="bullet">
+    ///   <item><c>Program.ROM.Data</c> -&gt; the <c>modified</c> parameter.</item>
+    ///   <item><c>this.Vanilla</c> -&gt; the <c>vanilla</c> parameter.</item>
+    ///   <item><c>Program.AsmMapFileAsmCache.GetName</c> -&gt; the optional <c>nameResolver</c> callback (default returns "").</item>
+    ///   <item><c>Program.ROM.RomInfo.version</c> -&gt; the <c>romVersion</c> parameter (default 8 = FE8U).</item>
+    ///   <item><c>Program.AIScript</c>/<c>Program.ProcsScript</c>/<c>EventScriptWithPatchDic</c> -&gt; optional script dictionaries; when a struct needs one that was not supplied the generic <c>WildCard</c> emitter is used instead of crashing.</item>
+    /// </list>
+    /// </summary>
+    public static class RebuildMakeCore
+    {
+        enum PointerType
+        {
+            NONE
+            , POINTER
+            , ASM
+            , DATA
+        }
+
+        enum ASMC_Delect
+        {
+            NONE
+            , AUTO
+            , TEXTPOINTERS
+            , ASM
+        }
+
+        sealed class RefCmd
+        {
+            //コマンドのデータ
+            public string Cmd = "";
+            //このコマンドが定義するポインタ値
+            public Address UseAddress;
+        }
+
+        /// <summary>
+        /// Emit a <c>.rebuild</c> manifest (and its sidecar files) for <paramref name="modified"/>.
+        /// </summary>
+        /// <param name="modified">The modified ROM bytes to defragment.</param>
+        /// <param name="vanilla">The unmodified base ROM.</param>
+        /// <param name="rebuildAddress">Offset at/after which data is rebuilt (everything below is left in place).</param>
+        /// <param name="structList">The caller-supplied list of known data/pointer locations (the parameter boundary — was <c>U.MakeAllStructPointersList</c>).</param>
+        /// <param name="manifestPath">Output path of the <c>.rebuild</c> file; sidecar folders are created beside it.</param>
+        /// <param name="nameResolver">Optional symbol-name resolver (was <c>Program.AsmMapFileAsmCache.GetName</c>); default returns "".</param>
+        /// <param name="romVersion">FE game version for EventCond layout (6/7/8); default 8.</param>
+        /// <param name="eventScriptWithPatch">Optional EVENTSCRIPT dictionary (with patch). Null -&gt; generic emit.</param>
+        /// <param name="eventScriptWithoutPatch">Optional EVENTSCRIPT dictionary (without patch). Null -&gt; generic emit.</param>
+        /// <param name="aiScript">Optional AISCRIPT dictionary. Null -&gt; generic emit.</param>
+        /// <param name="procsScript">Optional PROCS dictionary. Null -&gt; generic emit.</param>
+        /// <param name="progress">Optional progress reporter.</param>
+        public static void Make(byte[] modified, ROM vanilla, uint rebuildAddress, List<Address> structList,
+            string manifestPath,
+            Func<uint, string> nameResolver = null,
+            int romVersion = 8,
+            EventScript eventScriptWithPatch = null,
+            EventScript eventScriptWithoutPatch = null,
+            EventScript aiScript = null,
+            EventScript procsScript = null,
+            IProgress<string> progress = null)
+        {
+            if (modified == null) throw new ArgumentNullException(nameof(modified));
+            if (vanilla == null) throw new ArgumentNullException(nameof(vanilla));
+            if (structList == null) throw new ArgumentNullException(nameof(structList));
+            if (string.IsNullOrEmpty(manifestPath)) throw new ArgumentNullException(nameof(manifestPath));
+
+            var emitter = new Emitter(modified, vanilla, rebuildAddress, structList,
+                nameResolver ?? (_ => ""), romVersion,
+                eventScriptWithPatch, eventScriptWithoutPatch, aiScript, procsScript, progress);
+            emitter.Run(manifestPath);
+        }
+
+        /// <summary>
+        /// Per-run emitter state. Instance class so the ported WinForms method bodies stay
+        /// recognizable while the public surface stays a pure static <see cref="Make"/>.
+        /// </summary>
+        sealed class Emitter
+        {
+            readonly byte[] Modified;
+            readonly ROM Vanilla;
+            readonly uint RebuildAddress;
+            readonly List<Address> StructList;
+            readonly Func<uint, string> NameResolver;
+            readonly int RomVersion;
+            readonly EventScript EventScriptWithPatchDic;
+            readonly EventScript EventScriptWithoutPatchDic;
+            readonly EventScript AIScript;
+            readonly EventScript ProcsScript;
+            readonly IProgress<string> Progress;
+
+            string BaseDir;
+            Dictionary<uint, PointerType> PointerMark;
+
+            public Emitter(byte[] modified, ROM vanilla, uint rebuildAddress, List<Address> structList,
+                Func<uint, string> nameResolver, int romVersion,
+                EventScript eswp, EventScript eswop, EventScript ai, EventScript procs, IProgress<string> progress)
+            {
+                this.Modified = modified;
+                this.Vanilla = vanilla;
+                this.RebuildAddress = rebuildAddress;
+                this.StructList = structList;
+                this.NameResolver = nameResolver;
+                this.RomVersion = romVersion;
+                this.EventScriptWithPatchDic = eswp;
+                this.EventScriptWithoutPatchDic = eswop;
+                this.AIScript = ai;
+                this.ProcsScript = procs;
+                this.Progress = progress;
+            }
+
+            bool isRebuildAddress(uint addr)
+            {
+                return addr >= this.RebuildAddress;
+            }
+
+            // ---- ROM compare helpers (read from Modified / Vanilla, not Program.ROM) ----
+            bool romcmp(uint addr, uint vanilla_addr, uint blockSize)
+            {
+                if (isRebuildAddress(addr))
+                {
+                    return false;
+                }
+                byte[] s = U.getBinaryData(this.Modified, addr, blockSize);
+                byte[] v = this.Vanilla.getBinaryData(vanilla_addr, blockSize);
+                return (U.memcmp(s, v) == 0);
+            }
+            bool romcmpPointer(uint addr, uint vanilla_addr, uint blockSize)
+            {
+                if (isRebuildAddress(addr))
+                {
+                    return false;
+                }
+                if (!U.isSafetyOffset(addr) || !U.isSafetyOffset(vanilla_addr, this.Vanilla))
+                {
+                    return false;
+                }
+
+                uint sp = U.u32(this.Modified, addr);
+                uint vp = this.Vanilla.p32(vanilla_addr);
+
+                if (isRebuildAddress(U.toOffset(sp)))
+                {
+                    return false;
+                }
+                if (!U.isSafetyOffset(U.toOffset(sp)) || !U.isSafetyOffset(vp, this.Vanilla))
+                {
+                    return false;
+                }
+
+                byte[] s = U.getBinaryData(this.Modified, U.toOffset(sp), blockSize);
+                byte[] v = this.Vanilla.getBinaryData(vp, blockSize);
+                return (U.memcmp(s, v) == 0);
+            }
+
+            public void Run(string manifestPath)
+            {
+                this.BaseDir = Path.GetDirectoryName(manifestPath);
+                Directory.CreateDirectory(Path.Combine(this.BaseDir, "rebuild_ifr"));
+                Directory.CreateDirectory(Path.Combine(this.BaseDir, "rebuild_mix"));
+                Directory.CreateDirectory(Path.Combine(this.BaseDir, "rebuild_bin"));
+
+                this.Progress?.Report("データを準備中...");
+                //ポインタを高速に探索するためにルックアップテーブルを作成する.
+                MakePointerMark();
+
+                //処理済みアドレスマーク
+                bool[] processedAddress = new bool[32 * 1024 * 1024];
+                List<RefCmd> refCmdList = new List<RefCmd>(65535);
+
+                int nextDoEvents = 0;
+                for (int i = 0; i < StructList.Count; i++)
+                {
+                    Address a = StructList[i];
+
+                    if (a.Addr >= processedAddress.Length || processedAddress[a.Addr])
+                    {
+                        continue;
+                    }
+                    processedAddress[a.Addr] = true;
+
+                    if (i > nextDoEvents)
+                    {
+                        this.Progress?.Report(a.Info);
+                        nextDoEvents = i + 0xff;
+                    }
+
+                    RefCmd refCmd;
+                    if (a.BlockSize > 0)
+                    {//ifrデータ
+                        if (a.DataType == Address.DataTypeEnum.TEXTPOINTERS)
+                        {//TEXT POINTERSは、Anti-Huffmanの可能性を考慮しないといけない.
+                            refCmd = IFR(a, ASMC_Delect.TEXTPOINTERS);
+                        }
+                        else if (a.DataType == Address.DataTypeEnum.InputFormRef)
+                        {//データポインタ
+                            refCmd = IFR(a, ASMC_Delect.NONE);
+                        }
+                        else if (a.DataType == Address.DataTypeEnum.InputFormRef_ASM)
+                        {//ASMポインタ
+                            refCmd = IFR(a, ASMC_Delect.AUTO);
+                        }
+                        else
+                        {//データとASMポインタの混在
+                            refCmd = IFR(a, ASMC_Delect.AUTO);
+                        }
+                    }
+                    else if (Address.IsPointerableType(a.DataType))
+                    {//ポインタが存在するデータ
+                        refCmd = Mix(a);
+                    }
+                    else
+                    {//固定データ ポインタはこの中には発生しない
+                        refCmd = BIN(a);
+                    }
+
+                    if (refCmd.Cmd == "")
+                    {
+                        Def(refCmd, a);
+                    }
+
+                    refCmd.UseAddress = a;
+                    refCmdList.Add(refCmd);
+                }
+
+                this.Progress?.Report("未知のハックを探索中...");
+                FindUnknownHack2(refCmdList, processedAddress);
+
+                StringBuilder rebuildData = new StringBuilder();
+                rebuildData.Append(RefSortSimple(refCmdList));
+
+                U.WriteAllText(manifestPath, rebuildData.ToString());
+            }
+
+            void MakePointerMark()
+            {
+                this.PointerMark = new Dictionary<uint, PointerType>(65535);
+                for (int i = 0; i < StructList.Count; i++)
+                {
+                    Address address = StructList[i];
+                    if (address.Pointer == U.NOT_FOUND || address.Pointer == 0)
+                    {
+                    }
+                    else
+                    {
+                        this.PointerMark[U.toPointer(address.Pointer)] = PointerType.POINTER;
+                    }
+
+                    if (Address.IsASMOnly(address.DataType))
+                    {
+                        this.PointerMark[U.toPointer(address.Addr)] = PointerType.ASM;
+                    }
+                    else
+                    {
+                        this.PointerMark[U.toPointer(address.Addr)] = PointerType.DATA;
+                    }
+                }
+            }
+
+            void Def(RefCmd refCmd, Address a)
+            {
+                refCmd.Cmd = "@DEF " + U.ToHexString8(a.Addr) + "\t//" + a.Info;
+            }
+
+            static int CompareRefCmd(RefCmd a, RefCmd b)
+            {
+                return (int)((int)a.UseAddress.Addr - (int)b.UseAddress.Addr);
+            }
+
+            string RefSortSimple(List<RefCmd> refCmdList)
+            {
+                this.Progress?.Report("Make List....");
+                StringBuilder sb = new StringBuilder();
+                U.CRC32 crc32 = new U.CRC32();
+                sb.Append("@_CRC32 ");
+                sb.Append(U.ToHexString(crc32.Calc(this.Vanilla.Data)));
+                sb.AppendLine(" //vanilla ROM CRC32");
+
+                sb.Append("@_REBUILDADDRESS ");
+                sb.Append(U.ToHexString(this.RebuildAddress));
+                sb.AppendLine(" //rebuild start address");
+
+                refCmdList.Sort(CompareRefCmd);
+                for (int i = 0; i < refCmdList.Count; i++)
+                {
+                    RefCmd refCmd = refCmdList[i];
+                    sb.AppendLine(refCmd.Cmd);
+                }
+
+                this.Progress?.Report("Save File!");
+                return sb.ToString();
+            }
+
+            // ---- IFR -----------------------------------------------------------
+            RefCmd IFR(Address address, ASMC_Delect asmdelect)
+            {
+                StringBuilder sb = new StringBuilder();
+
+                uint vanila_addr;
+                if (address.Pointer == 0 || address.Pointer == U.NOT_FOUND)
+                {//ポインタがないので代わりに現在のアドレスで比較してみる.
+                    vanila_addr = address.Addr;
+                }
+                else if (U.isSafetyOffset(address.Pointer, this.Vanilla))
+                {
+                    vanila_addr = this.Vanilla.p32(address.Pointer);
+                    if (!U.isSafetyOffset(vanila_addr, this.Vanilla))
+                    {//ポインタ先が不明なのでアドレスで補う
+                        vanila_addr = address.Addr;
+                    }
+                }
+                else
+                {//ポインタがないので、現在のアドレスで比較するしかない.
+                    vanila_addr = address.Addr;
+                }
+
+                string basename = MakeName(address);
+                string filename = Path.Combine("rebuild_ifr", basename + ".txt");
+                StringBuilder infsb = new StringBuilder();
+
+                RefCmd refCmd = new RefCmd();
+
+                uint addr = address.Addr;
+                uint startaddr = addr;
+                uint end = addr + address.Length;                   //終端データまで含めたデータ末尾の位置
+                uint endMinusOneBlock = end - address.BlockSize;    //終端データを含めないデータ末尾の位置
+
+                byte[] bin = this.Modified;
+                for (uint no = 0; addr < end; addr += address.BlockSize, no++)
+                {
+                    infsb.Append("=");
+                    infsb.Append(U.ToHexString8(no));
+
+                    bool isTermData = (endMinusOneBlock == addr); //終端データ
+                    //1件だけのデータなので、終端データの保護はありません
+                    if (address.DataType == Address.DataTypeEnum.InputFormRef_1)
+                    {
+                        isTermData = false;
+                    }
+
+                    uint inner_end = Math.Min(addr + address.BlockSize, (uint)bin.Length);
+                    for (uint a = addr; a < inner_end; a++)
+                    {
+                        infsb.Append(' ');
+                        if (a % 4 == 0 //ARMなので4バイトアライメント
+                            && isTermData == false //終端データのポインタは無効のデータがあるので無視していい
+                            && U.GetIndexOf(address.PointerIndexes, a - addr) >= 0 //ポインタがあるカラムかどうか
+                            )
+                        {
+                            bool r = IsRegistAddr(refCmd, infsb, bin, startaddr, endMinusOneBlock, a, asmdelect);
+                            if (r)
+                            {
+                                a += 3;
+                                continue;
+                            }
+                        }
+                        infsb.Append(U.ToHexString(bin[a]));
+                    }
+                    infsb.AppendLine();
+                }
+
+                if (infsb.Length == 0)
+                {//記録するデータがない
+                    return refCmd;
+                }
+
+                string fullfilename = Path.Combine(this.BaseDir, filename);
+                U.WriteAllText(fullfilename, infsb.ToString());
+
+                sb.Append("@IFR ");
+                sb.Append(U.ToHexString8(address.Addr)); //addr
+                sb.Append(" :");
+                sb.Append(U.ToHexString(address.BlockSize)); //blocksize
+                sb.Append(" *");
+                sb.Append(U.ToHexString(address.Length / address.BlockSize)); //count
+                if (vanila_addr == address.Addr)
+                {//ポインタがないか、アドレスを変更していない.
+                }
+                else
+                {
+                    sb.Append(" =");
+                    sb.Append(U.ToHexString8(vanila_addr)); //無改造ROMのアドレス
+                }
+                sb.Append(" ");
+                sb.Append(filename);
+
+                refCmd.Cmd = sb.ToString();
+                return refCmd;
+            }
+
+            void Apeend4Bytes(StringBuilder sb, byte[] romdata, uint addr)
+            {
+                sb.Append(U.ToHexString(romdata[addr + 0]));
+                sb.Append(' ');
+                sb.Append(U.ToHexString(romdata[addr + 1]));
+                sb.Append(' ');
+                sb.Append(U.ToHexString(romdata[addr + 2]));
+                sb.Append(' ');
+                sb.Append(U.ToHexString(romdata[addr + 3]));
+            }
+
+            // ---- IsRegistAddr (the @ / ` / & / + token decision) ---------------
+            bool IsRegistAddrTextPointers(RefCmd refCmd, StringBuilder sb, byte[] romdata, uint startaddr, uint endaddr, uint addr)
+            {
+                uint srcp = U.u32(romdata, addr);
+                bool isAntiHuffman;
+
+                if (srcp >= 0x80000000 && srcp < 0x8A000000)
+                {//Anti-Huffman
+                    isAntiHuffman = true;
+                    srcp -= 0x80000000;
+                }
+                else
+                {//通常のポインタ
+                    isAntiHuffman = false;
+                }
+
+                if (!U.isSafetyPointer(srcp))
+                {//正しいポインタではない.
+                    return false;
+                }
+
+                if (PointerMark.ContainsKey(srcp))
+                {
+                    if (isAntiHuffman)
+                    {
+                        sb.Append('`');
+                    }
+                    else
+                    {
+                        sb.Append('@');
+                    }
+                    sb.Append(U.ToHexString(srcp));
+                    return true;
+                }
+
+                return false;
+            }
+
+            bool IsRegistAddr(RefCmd refCmd, StringBuilder sb, byte[] romdata, uint startaddr, uint endaddr, uint addr, ASMC_Delect asmcdelect)
+            {
+                if (asmcdelect == ASMC_Delect.TEXTPOINTERS)
+                {
+                    return IsRegistAddrTextPointers(refCmd, sb, romdata, startaddr, endaddr, addr);
+                }
+
+                uint srcp = U.u32(romdata, addr);
+                if (!U.isSafetyPointer(srcp))
+                {
+                    return false;
+                }
+                uint srcoffset = U.toOffset(srcp);
+
+                if (PointerMark.ContainsKey(srcp))
+                {
+                    if (srcoffset == startaddr
+                     && IsEnableSelfPointer(asmcdelect)
+                        )
+                    {//自己参照
+                        sb.Append('+');
+                        sb.Append(U.ToHexString(srcoffset - startaddr));
+                    }
+                    else if (asmcdelect == ASMC_Delect.ASM
+                        && U.IsValueOdd(srcp)
+                        && PointerMark[srcp] == PointerType.ASM)
+                    {//ASMポインタ
+                        sb.Append('&');
+                        sb.Append(U.ToHexString(srcp - 1));
+                    }
+                    else
+                    {//ポインタ
+                        sb.Append('@');
+                        sb.Append(U.ToHexString(srcp));
+                    }
+
+                    return true;
+                }
+                else if (srcoffset >= startaddr && srcoffset < endaddr
+                     && IsEnableSelfPointer(asmcdelect)
+                    )
+                {//自己参照
+                    sb.Append('+');
+                    sb.Append(U.ToHexString(srcoffset - startaddr));
+                    return true;
+                }
+                else if (U.IsValueOdd(srcp)
+                            && PointerMark.ContainsKey(srcp - 1)
+                            && PointerMark[srcp - 1] == PointerType.ASM
+                            && IsEnableASMPointer(asmcdelect)
+                    )
+                {//ASM参照
+                    sb.Append('&');
+                    sb.Append(U.ToHexString(srcp));
+                    return true;
+                }
+                else
+                {//謎のアドレス
+                    return false;
+                }
+            }
+            bool IsEnableASMPointer(ASMC_Delect asmcdelect)
+            {
+                return asmcdelect == ASMC_Delect.AUTO || asmcdelect == ASMC_Delect.ASM;
+            }
+            bool IsEnableSelfPointer(ASMC_Delect asmcdelect)
+            {
+                return asmcdelect != ASMC_Delect.ASM;
+            }
+
+            // ---- generic / specialised MIX inner emitters ----------------------
+            bool WildCard(RefCmd refCmd, StringBuilder infsb, byte[] romdata, uint addr, uint length, ASMC_Delect asmc_delect)
+            {
+                uint startaddr = addr;
+                uint end = Math.Min(addr + length, (uint)romdata.Length);
+                bool isPointer = false;
+
+                for (; addr < end; addr++)
+                {
+                    infsb.Append(' ');
+                    if (addr % 4 == 0)
+                    {
+                        bool r = IsRegistAddr(refCmd, infsb, romdata, startaddr, end, addr, asmc_delect);
+                        if (r)
+                        {
+                            addr += 3;
+                            isPointer = true;
+                            continue;
+                        }
+                    }
+                    infsb.Append(U.ToHexString(romdata[addr]));
+                }
+
+                return isPointer;
+            }
+            void MixRec(RefCmd refCmd, StringBuilder infsb, byte[] romdata, uint addr, uint length, uint[] pointerIndexes)
+            {
+                uint startaddr = addr;
+                uint end = Math.Min(addr + length, (uint)romdata.Length);
+
+                for (; addr < end; addr++)
+                {
+                    infsb.Append(' ');
+                    if (addr % 4 == 0
+                        && U.GetIndexOf(pointerIndexes, addr - startaddr) >= 0)
+                    {
+                        bool r = IsRegistAddr(refCmd, infsb, romdata, startaddr, end, addr, ASMC_Delect.AUTO);
+                        if (r)
+                        {
+                            addr += 3;
+                            continue;
+                        }
+                    }
+                    infsb.Append(U.ToHexString(romdata[addr]));
+                }
+            }
+
+            //楽譜専用
+            void SongScore(RefCmd refCmd, StringBuilder infsb, byte[] romdata, uint addr, uint length)
+            {
+                uint startaddr = addr;
+                uint end = Math.Min(addr + length, (uint)romdata.Length);
+
+                uint position = addr;
+                uint percussion = 0;
+                while (true)
+                {
+                    if (position >= end)
+                    {
+                        break;
+                    }
+                    uint b = romdata[position];
+                    position++;
+
+                    infsb.Append(' ');
+                    infsb.Append(U.ToHexString(b));
+
+                    if (b == 0xB1)
+                    {
+                        break;
+                    }
+                    else if (b == 0xB2 || b == 0xB3)
+                    {
+                        infsb.Append(' ');
+                        //repointer
+                        bool r = IsRegistAddr(refCmd, infsb, romdata, startaddr, end, position, ASMC_Delect.NONE);
+                        if (!r)
+                        {
+                            Apeend4Bytes(infsb, romdata, position);
+                        }
+                        position += 4;
+                    }
+                    else if (b == 0xBD || b == 0xBB || b == 0xBC || b == 0xBE || b == 0xBF || b == 0xC0 || b == 0xC1)
+                    {
+                        // These commands take a data byte that must not be processed.
+                        infsb.Append(' ');
+                        infsb.Append(U.ToHexString(romdata[position]));
+                        position++;
+                    }
+                    else if (b == 0xb9)
+                    {//MEMACC 4バイト命令. 最初の1バイトはコピー済みなので、残りの3バイトコピーする.
+                        infsb.Append(' ');
+                        infsb.Append(U.ToHexString(romdata[position]));
+                        position++;
+                        infsb.Append(' ');
+                        infsb.Append(U.ToHexString(romdata[position]));
+                        position++;
+                        infsb.Append(' ');
+                        infsb.Append(U.ToHexString(romdata[position]));
+                        position++;
+                    }
+                    else if (percussion != 0 && b < 0x80)
+                    {
+                        while (romdata[position] < 0x80)
+                        {// Volume marker
+                            infsb.Append(' ');
+                            infsb.Append(U.ToHexString(romdata[position]));
+                            position++;
+                        }
+                    }
+                }
+            }
+
+            //Font
+            void Font(RefCmd refCmd, StringBuilder infsb, byte[] romdata, uint addr, uint length)
+            {
+                uint startaddr = addr;
+                uint end = Math.Min(addr + length, (uint)romdata.Length);
+
+                //先頭だけポインタ
+                {
+                    infsb.Append(' ');
+                    bool r = IsRegistAddr(refCmd, infsb, romdata, startaddr, end, addr, ASMC_Delect.NONE);
+                    if (!r)
+                    {
+                        Apeend4Bytes(infsb, romdata, addr);
+                    }
+                    addr += 4;
+                }
+
+                //以下データ
+                for (; addr < end; addr++)
+                {
+                    infsb.Append(' ');
+                    infsb.Append(U.ToHexString(romdata[addr]));
+                }
+            }
+
+            //ASM
+            void ASM(RefCmd refCmd, StringBuilder infsb, byte[] romdata, uint addr, uint length)
+            {
+                List<DisassemblerTrumb.LDRPointer> ldrmap = DisassemblerTrumb.MakeLDRMap(romdata, addr, addr + length, true);
+                Dictionary<uint, bool> ldrmapFast = new Dictionary<uint, bool>();
+                for (int i = 0; i < ldrmap.Count; i++)
+                {
+                    DisassemblerTrumb.LDRPointer ldr = ldrmap[i];
+                    ldrmapFast[ldr.ldr_data_address] = true;
+                }
+
+                uint startaddr = addr;
+                uint end = Math.Min(addr + length, (uint)romdata.Length);
+
+                for (; addr < end; addr++)
+                {
+                    infsb.Append(' ');
+                    if (addr % 4 == 0
+                        && ldrmapFast.ContainsKey(addr))
+                    {
+                        bool r = IsRegistAddr(refCmd, infsb, romdata, startaddr, end, addr, ASMC_Delect.ASM);
+                        if (r)
+                        {
+                            addr += 3;
+                            continue;
+                        }
+                    }
+                    infsb.Append(U.ToHexString(romdata[addr]));
+                }
+            }
+
+            void NoPointer(RefCmd refCmd, StringBuilder infsb, byte[] romdata, uint addr, uint length)
+            {
+                uint end = Math.Min(addr + length, (uint)romdata.Length);
+                for (; addr < end; addr++)
+                {
+                    infsb.Append(' ');
+                    infsb.Append(U.ToHexString(romdata[addr]));
+                }
+            }
+
+            bool IsEventCondASM(uint type)
+            {
+                if (this.RomVersion == 6)
+                {
+                    return type == 0xD;
+                }
+                return type == 0xE || type == 0x4;
+            }
+
+            void EventCond12_16(RefCmd refCmd, StringBuilder infsb, byte[] romdata, uint addr, uint length)
+            {
+                uint startaddr = addr;
+                uint end = Math.Min(addr + length, (uint)romdata.Length);
+
+                bool isFE7 = this.RomVersion == 7;
+
+                while (addr < end)
+                {
+                    if (addr + 12 > end)
+                    {
+                        break;
+                    }
+
+                    uint type = romdata[addr];
+                    if (type == 0)
+                    {//終端
+                        break;
+                    }
+
+                    infsb.Append(' ');
+                    Apeend4Bytes(infsb, romdata, addr + 0);
+
+                    infsb.Append(' ');
+                    bool r = IsRegistAddr(refCmd, infsb, romdata, startaddr, end, addr + 4, ASMC_Delect.NONE);
+                    if (!r)
+                    {
+                        Apeend4Bytes(infsb, romdata, addr + 4);
+                    }
+
+                    infsb.Append(' ');
+                    bool r2;
+                    if (IsEventCondASM(type))
+                    {
+                        r2 = IsRegistAddr(refCmd, infsb, romdata, startaddr, end, addr + 8, ASMC_Delect.ASM);
+                    }
+                    else
+                    {
+                        r2 = false;
+                    }
+                    if (!r2)
+                    {
+                        Apeend4Bytes(infsb, romdata, addr + 8);
+                    }
+
+                    if (isFE7 && type == 0x02)
+                    {
+                        infsb.Append(' ');
+                        Apeend4Bytes(infsb, romdata, addr + 12);
+                        addr += 16;
+                    }
+                    else
+                    {
+                        addr += 12;
+                    }
+                }
+                //端数データがあれば記録する
+                NoPointer(refCmd, infsb, romdata, addr, end - addr);
+            }
+
+            void EventCond12(RefCmd refCmd, StringBuilder infsb, byte[] romdata, uint addr, uint length)
+            {
+                uint startaddr = addr;
+                uint end = Math.Min(addr + length, (uint)romdata.Length);
+
+                while (addr < end)
+                {
+                    if (addr + 12 > end)
+                    {//端数を何とか格納する
+                        break;
+                    }
+
+                    uint type = romdata[addr];
+                    if (type == 0)
+                    {//終端
+                        break;
+                    }
+                    infsb.Append(' ');
+                    Apeend4Bytes(infsb, romdata, addr + 0);
+
+                    infsb.Append(' ');
+                    bool r = IsRegistAddr(refCmd, infsb, romdata, startaddr, end, addr + 4, ASMC_Delect.NONE);
+                    if (!r)
+                    {
+                        Apeend4Bytes(infsb, romdata, addr + 4);
+                    }
+
+                    infsb.Append(' ');
+                    bool r2;
+                    if (IsEventCondASM(type))
+                    {
+                        r2 = IsRegistAddr(refCmd, infsb, romdata, startaddr, end, addr + 8, ASMC_Delect.ASM);
+                    }
+                    else
+                    {
+                        r2 = false;
+                    }
+                    if (!r2)
+                    {
+                        Apeend4Bytes(infsb, romdata, addr + 8);
+                    }
+
+                    addr += 12;
+                }
+                //端数データがあれば記録する
+                NoPointer(refCmd, infsb, romdata, addr, end - addr);
+            }
+
+            void EventCond16(RefCmd refCmd, StringBuilder infsb, byte[] romdata, uint addr, uint length)
+            {
+                uint startaddr = addr;
+                uint end = Math.Min(addr + length, (uint)romdata.Length);
+
+                while (addr < end)
+                {
+                    if (addr + 12 > end)
+                    {//端数を何とか格納する
+                        break;
+                    }
+
+                    uint type = romdata[addr];
+                    if (type == 0)
+                    {//終端
+                        break;
+                    }
+
+                    infsb.Append(' ');
+                    Apeend4Bytes(infsb, romdata, addr + 0);
+
+                    infsb.Append(' ');
+                    bool r = IsRegistAddr(refCmd, infsb, romdata, startaddr, end, addr + 4, ASMC_Delect.NONE);
+                    if (!r)
+                    {
+                        Apeend4Bytes(infsb, romdata, addr + 4);
+                    }
+
+                    infsb.Append(' ');
+                    Apeend4Bytes(infsb, romdata, addr + 8);
+
+                    infsb.Append(' ');
+                    bool r3;
+                    if (IsEventCondASM(type))
+                    {
+                        r3 = IsRegistAddr(refCmd, infsb, romdata, startaddr, end, addr + 12, ASMC_Delect.ASM);
+                    }
+                    else
+                    {
+                        r3 = false;
+                    }
+                    if (!r3)
+                    {
+                        Apeend4Bytes(infsb, romdata, addr + 12);
+                    }
+
+                    addr += 16;
+                }
+                //端数データがあれば記録する
+                NoPointer(refCmd, infsb, romdata, addr, end - addr);
+            }
+
+            void EventScript1(RefCmd refCmd, StringBuilder infsb, byte[] romdata, uint addr, uint length)
+            {
+                uint end = Math.Min(addr + length, (uint)romdata.Length);
+                while (addr < end)
+                {
+                    List<uint> pointerIndexes = new List<uint>();
+                    EventScript.OneCode code = this.EventScriptWithPatchDic.DisAseemble(romdata, addr);
+                    for (int i = 0; i < code.Script.Args.Length; i++)
+                    {
+                        EventScript.Arg arg = code.Script.Args[i];
+                        EventScript.ArgType type = arg.Type;
+                        if (FEBuilderGBA.EventScript.IsPointerArgs(type))
+                        {
+                            pointerIndexes.Add((uint)arg.Position);
+                        }
+                    }
+
+                    uint inneraddr = addr;
+                    uint innerend = addr + (uint)code.Script.Size;
+                    uint inneroffset = 0;
+                    while (inneraddr < innerend)
+                    {
+                        EventScript.OneCode innercode = this.EventScriptWithoutPatchDic.DisAseemble(romdata, inneraddr);
+                        for (int i = 0; i < innercode.Script.Args.Length; i++)
+                        {
+                            EventScript.Arg arg = innercode.Script.Args[i];
+                            EventScript.ArgType type = arg.Type;
+                            if (FEBuilderGBA.EventScript.IsPointerArgs(type))
+                            {
+                                pointerIndexes.Add((uint)arg.Position + inneroffset);
+                            }
+                        }
+                        inneroffset += (uint)innercode.Script.Size;
+                        inneraddr += (uint)innercode.Script.Size;
+                    }
+
+                    MixRec(refCmd, infsb, romdata, addr, (uint)code.Script.Size, pointerIndexes.ToArray());
+
+                    addr += (uint)code.Script.Size;
+                }
+            }
+
+            void EventScript2(RefCmd refCmd, StringBuilder infsb, byte[] romdata, uint addr, uint length, EventScript scriptDic)
+            {
+                uint end = Math.Min(addr + length, (uint)romdata.Length);
+                while (addr < end)
+                {
+                    List<uint> pointerIndexes = new List<uint>();
+                    EventScript.OneCode code = scriptDic.DisAseemble(romdata, addr);
+                    for (int i = 0; i < code.Script.Args.Length; i++)
+                    {
+                        EventScript.Arg arg = code.Script.Args[i];
+                        EventScript.ArgType type = arg.Type;
+                        if (FEBuilderGBA.EventScript.IsPointerArgs(type))
+                        {
+                            pointerIndexes.Add((uint)arg.Position);
+                        }
+                    }
+
+                    MixRec(refCmd, infsb, romdata, addr, (uint)code.Script.Size, pointerIndexes.ToArray());
+
+                    addr += (uint)code.Script.Size;
+                }
+            }
+
+            //戦闘アニメ or 魔法アニメなどの 0x85フレームがあるもの専用
+            void BattleAnimation(RefCmd refCmd, StringBuilder infsb, byte[] romdata, uint addr, uint length, uint pointerCount)
+            {
+                uint startaddr = addr;
+                uint end = Math.Min(addr + length, (uint)romdata.Length);
+
+                for (; addr < end; addr += 4)
+                {
+                    if (!U.isSafetyZArray(addr + 4 + (4 * pointerCount), romdata))
+                    {
+                        break;
+                    }
+
+                    infsb.Append(' ');
+                    Apeend4Bytes(infsb, romdata, addr + 0);
+
+                    if (romdata[addr + 3] != 0x86)
+                    {
+                        continue;
+                    }
+                    for (int n = 0; n < pointerCount; n++)
+                    {
+                        addr += 4;
+
+                        infsb.Append(' ');
+                        bool r = IsRegistAddr(refCmd, infsb, romdata, startaddr, end, addr, ASMC_Delect.NONE);
+                        if (!r)
+                        {
+                            Apeend4Bytes(infsb, romdata, addr);
+                        }
+                    }
+                }
+
+                //端数データがあれば記録する.
+                NoPointer(refCmd, infsb, romdata, addr, end - addr);
+            }
+
+            // ---- MIX dispatcher ------------------------------------------------
+            RefCmd Mix(Address address)
+            {
+                RefCmd refCmd = new RefCmd();
+
+                if (address.Length <= 0)
+                {//サイズが0の場合、推測します.
+                    if (address.DataType == Address.DataTypeEnum.MAGICFRAME_CSA
+                        || address.DataType == Address.DataTypeEnum.MAGICFRAME_FEITORADV)
+                    {//間違ったフレームデータ
+                        return BrokenData(address);
+                    }
+                    else
+                    {
+                        return refCmd;
+                    }
+                }
+
+                uint vanila_addr;
+                if (address.Pointer == 0 || address.Pointer == U.NOT_FOUND)
+                {//ポインタがないので代わりに現在のアドレスで比較してみる.
+                    if (romcmp(address.Addr, address.Addr, address.Length))
+                    {//無改造ROMと同一なので記録する必要なし.
+                        return refCmd;
+                    }
+                    vanila_addr = address.Addr;
+                }
+                else if (U.isSafetyOffset(address.Pointer, this.Vanilla))
+                {
+                    if (romcmpPointer(address.Pointer, address.Pointer, address.Length))
+                    {//ポインタ上では、記録する必要なし
+                        if (romcmp(address.Addr, address.Addr, address.Length))
+                        {//無改造ROMと同一なので記録する必要なし.
+                            return refCmd;
+                        }
+                    }
+
+                    vanila_addr = this.Vanilla.p32(address.Pointer);
+                    if (!U.isSafetyOffset(vanila_addr, this.Vanilla))
+                    {//バニラのアドレスが不明
+                        vanila_addr = address.Addr;
+                    }
+                }
+                else
+                {//ポインタはあるがバニラにはないということは拡張領域にあるデータだと思われる.
+                    if (romcmp(address.Addr, address.Addr, address.Length))
+                    {//無改造ROMと同一なので記録する必要なし.
+                        return refCmd;
+                    }
+                    vanila_addr = address.Addr;
+                }
+
+                string basename = MakeName(address);
+                string filename = Path.Combine("rebuild_mix", basename + ".txt");
+                StringBuilder infsb = new StringBuilder();
+
+                StringBuilder sb = new StringBuilder();
+
+                if (address.DataType == Address.DataTypeEnum.BATTLEFRAME)
+                {//LZ77で圧縮が必要
+                    byte[] bin = LZ77.decompress(this.Modified, address.Addr);
+                    BattleAnimation(refCmd, infsb, bin, 0, (uint)bin.Length, 2);
+                    sb.Append("@MIXLZ77 ");
+                }
+                else if (address.DataType == Address.DataTypeEnum.MAGICFRAME_FEITORADV)
+                {//魔法フレーム1
+                    BattleAnimation(refCmd, infsb, this.Modified, address.Addr, address.Length, 6);
+                    sb.Append("@MIX ");
+                }
+                else if (address.DataType == Address.DataTypeEnum.MAGICFRAME_CSA)
+                {//魔法フレーム2
+                    BattleAnimation(refCmd, infsb, this.Modified, address.Addr, address.Length, 7);
+                    sb.Append("@MIX ");
+                }
+                else if (address.DataType == Address.DataTypeEnum.EVENTCOND_ALWAYS)
+                {//常時条件
+                    EventCond12(refCmd, infsb, this.Modified, address.Addr, address.Length);
+                    sb.Append("@MIX ");
+                }
+                else if (address.DataType == Address.DataTypeEnum.EVENTCOND_OBJECT)
+                {//オブジェクト
+                    EventCond12(refCmd, infsb, this.Modified, address.Addr, address.Length);
+                    sb.Append("@MIX ");
+                }
+                else if (address.DataType == Address.DataTypeEnum.EVENTCOND_TALK)
+                {//会話
+                    if (this.RomVersion == 6)
+                    {
+                        EventCond12(refCmd, infsb, this.Modified, address.Addr, address.Length);
+                    }
+                    else
+                    {
+                        EventCond16(refCmd, infsb, this.Modified, address.Addr, address.Length);
+                    }
+                    sb.Append("@MIX ");
+                }
+                else if (address.DataType == Address.DataTypeEnum.EVENTCOND_TURN)
+                {//ターン
+                    if (this.RomVersion == 7)
+                    {
+                        EventCond12_16(refCmd, infsb, this.Modified, address.Addr, address.Length);
+                    }
+                    else
+                    {
+                        EventCond12(refCmd, infsb, this.Modified, address.Addr, address.Length);
+                    }
+                    sb.Append("@MIX ");
+                }
+                else if (address.DataType == Address.DataTypeEnum.SONGSCORE)
+                {//音楽データ
+                    SongScore(refCmd, infsb, this.Modified, address.Addr, address.Length);
+                    sb.Append("@MIX ");
+                }
+                else if (address.DataType == Address.DataTypeEnum.EVENTSCRIPT
+                         && this.EventScriptWithPatchDic != null && this.EventScriptWithoutPatchDic != null)
+                {
+                    EventScript1(refCmd, infsb, this.Modified, address.Addr, address.Length);
+                    sb.Append("@MIX ");
+                }
+                else if (address.DataType == Address.DataTypeEnum.AISCRIPT && this.AIScript != null)
+                {
+                    EventScript2(refCmd, infsb, this.Modified, address.Addr, address.Length, this.AIScript);
+                    sb.Append("@MIX ");
+                }
+                else if (address.DataType == Address.DataTypeEnum.PROCS && this.ProcsScript != null)
+                {
+                    EventScript2(refCmd, infsb, this.Modified, address.Addr, address.Length, this.ProcsScript);
+                    sb.Append("@MIX ");
+                }
+                else if (address.DataType == Address.DataTypeEnum.SONGTRACK)
+                {
+                    WildCard(refCmd, infsb, this.Modified, address.Addr, address.Length, ASMC_Delect.NONE);
+                    sb.Append("@MIX ");
+                }
+                else if (address.DataType == Address.DataTypeEnum.ASM
+                    || address.DataType == Address.DataTypeEnum.PATCH_ASM
+                    || address.DataType == Address.DataTypeEnum.BL_ASM
+                    )
+                {
+                    ASM(refCmd, infsb, this.Modified, address.Addr, address.Length);
+                    sb.Append("@MIX ");
+                }
+                else if (address.DataType == Address.DataTypeEnum.FONT)
+                {//フォント
+                    Font(refCmd, infsb, this.Modified, address.Addr, address.Length);
+                    sb.Append("@MIX ");
+                }
+                else if (address.DataType == Address.DataTypeEnum.POINTER)
+                {//ポインタ
+                    WildCard(refCmd, infsb, this.Modified, address.Addr, address.Length, ASMC_Delect.NONE);
+                    sb.Append("@MIX ");
+                }
+                else if (address.DataType == Address.DataTypeEnum.POINTER_ASM)
+                {//ポインタ
+                    WildCard(refCmd, infsb, this.Modified, address.Addr, address.Length, ASMC_Delect.ASM);
+                    sb.Append("@MIX ");
+                }
+                else if (address.DataType == Address.DataTypeEnum.NEW_TARGET_SELECTION_STRUCT)
+                {//ポインタ
+                    WildCard(refCmd, infsb, this.Modified, address.Addr, address.Length, ASMC_Delect.ASM);
+                    sb.Append("@MIX ");
+                }
+                else if (address.DataType == Address.DataTypeEnum.POINTER_ARRAY)
+                {//ポインタ
+                    WildCard(refCmd, infsb, this.Modified, address.Addr, address.Length, ASMC_Delect.NONE);
+                    sb.Append("@MIX ");
+                }
+                else if (address.DataType == Address.DataTypeEnum.SplitMenu5)
+                {//分岐メニュー5
+                    WildCard(refCmd, infsb, this.Modified, address.Addr, address.Length, ASMC_Delect.AUTO);
+                    sb.Append("@MIX ");
+                }
+                else if (address.DataType == Address.DataTypeEnum.SplitMenu9)
+                {//分岐メニュー9
+                    WildCard(refCmd, infsb, this.Modified, address.Addr, address.Length, ASMC_Delect.AUTO);
+                    sb.Append("@MIX ");
+                }
+                else
+                {
+                    WildCard(refCmd, infsb, this.Modified, address.Addr, address.Length, ASMC_Delect.AUTO);
+                    sb.Append("@MIX ");
+                }
+
+                if (infsb.Length <= 0)
+                {
+                    return refCmd;
+                }
+
+                //MIXデータを書き込む.
+                infsb.Remove(0, 1);
+                string fullfilename = Path.Combine(this.BaseDir, filename);
+                U.WriteAllText(fullfilename, infsb.ToString());
+
+                sb.Append(U.ToHexString8(address.Addr)); //addr
+
+                if (address.DataType == Address.DataTypeEnum.BATTLEFRAME)
+                {//LZ77で圧縮する場合、データのサイズが可変なので、上書きできるか調べるにはサイズデータが必要です.
+                    sb.Append(" :");
+                    sb.Append(U.ToHexString(address.Length)); //blocksize
+                }
+
+                sb.Append(" ");
+                sb.Append(filename);
+
+                refCmd.Cmd = sb.ToString();
+                return refCmd;
+            }
+
+            RefCmd BIN(Address address)
+            {
+                RefCmd refCmd = new RefCmd();
+                if (address.Length <= 0)
+                {
+                    return BrokenData(address);
+                }
+
+                uint vanila_addr;
+                if (address.Pointer == 0 || address.Pointer == U.NOT_FOUND)
+                {//ポインタがないので代わりに現在のアドレスで比較してみる.
+                    if (romcmp(address.Addr, address.Addr, address.Length))
+                    {//無改造ROMと同一なので記録する必要なし.
+                        return refCmd;
+                    }
+                    vanila_addr = address.Addr;
+                }
+                else if (U.isSafetyOffset(address.Pointer, this.Vanilla))
+                {
+                    if (romcmpPointer(address.Pointer, address.Pointer, address.Length))
+                    {//無改造ROMと同一なので記録する必要なし.
+                        if (romcmp(address.Addr, address.Addr, address.Length))
+                        {//無改造ROMと同一なので記録する必要なし.
+                            return refCmd;
+                        }
+                    }
+                    vanila_addr = this.Vanilla.p32(address.Pointer);
+                    if (!U.isSafetyOffset(vanila_addr, this.Vanilla))
+                    {//バニラのアドレスが不明
+                        vanila_addr = address.Addr;
+                    }
+                }
+                else
+                {//ポインタはあるがバニラにはないということは拡張領域にあるデータだと思われる.
+                    if (romcmp(address.Addr, address.Addr, address.Length))
+                    {//無改造ROMと同一なので記録する必要なし.
+                        return refCmd;
+                    }
+                    vanila_addr = address.Addr;
+                }
+                StringBuilder sb = new StringBuilder();
+
+                string basename = MakeName(address);
+                string filename = Path.Combine("rebuild_bin", basename + ".bin");
+
+                sb.Append("@BIN ");
+                sb.Append(U.ToHexString8(address.Addr));
+                sb.Append(" ");
+                sb.Append(filename);
+
+                string fullfilename = Path.Combine(this.BaseDir, filename);
+                byte[] bin = U.getBinaryData(this.Modified, address.Addr, address.Length);
+                U.WriteAllBytes(fullfilename, bin);
+
+                refCmd.Cmd = sb.ToString();
+                return refCmd;
+            }
+
+            //壊れたデータ
+            RefCmd BrokenData(Address address)
+            {
+                RefCmd refCmd = new RefCmd();
+                StringBuilder sb = new StringBuilder();
+
+                sb.Append("@BROKENDATA ");
+                sb.Append(U.ToHexString8(address.Addr));
+                sb.Append("//");
+                sb.Append(address.Info);
+
+                refCmd.Cmd = sb.ToString();
+                return refCmd;
+            }
+
+            // ---- FindUnknownHack2 (byte-diff fallback for unmarked regions) ----
+            bool IsNULLData(byte[] bin)
+            {
+                for (int i = 0; i < bin.Length; i++)
+                {
+                    if (bin[i] != 0)
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            RefCmd UnkBin(uint addr, uint length)
+            {
+                Address address = new Address(addr, length, U.NOT_FOUND, "UnkHack", Address.DataTypeEnum.BIN);
+
+                byte[] bin = U.getBinaryData(this.Modified, address.Addr, length);
+
+                StringBuilder sb = new StringBuilder();
+                RefCmd refCmd = new RefCmd();
+                if (IsNULLData(bin))
+                {
+                    sb.Append("@00 ");
+                    sb.Append(U.ToHexString8(address.Addr));
+                    sb.Append(" :");
+                    sb.Append(U.ToHexString(address.Length)); //blocksize
+                }
+                else
+                {
+                    string basename = MakeName(address);
+                    string filename = Path.Combine("rebuild_bin", basename + ".bin");
+
+                    sb.Append("@BIN ");
+                    sb.Append(U.ToHexString8(address.Addr));
+                    sb.Append(" ");
+                    sb.Append(filename);
+
+                    string fullfilename = Path.Combine(this.BaseDir, filename);
+                    U.WriteAllBytes(fullfilename, bin);
+                }
+
+                refCmd.Cmd = sb.ToString();
+                refCmd.UseAddress = address;
+                return refCmd;
+            }
+
+            void FindUnknownHack2(List<RefCmd> refCmdList, bool[] processedAddress)
+            {
+                for (int i = 0; i < refCmdList.Count; i++)
+                {
+                    RefCmd rc = refCmdList[i];
+                    Address a = rc.UseAddress;
+
+                    uint addr = a.Addr;
+                    uint end = addr + a.Length;
+                    end = Math.Min(end, (uint)processedAddress.Length);
+
+                    if (rc.Cmd.IndexOf("@DEF") == 0)
+                    {
+                        for (; addr < end; addr++)
+                        {
+                            processedAddress[addr] = false;
+                        }
+                        continue;
+                    }
+
+                    for (; addr < end; addr++)
+                    {
+                        processedAddress[addr] = true;
+                    }
+                }
+
+                uint vallinaLength = (uint)this.Vanilla.Data.Length;
+                uint length = Math.Min(vallinaLength, this.RebuildAddress);
+                uint start = U.NOT_FOUND;
+                for (uint i = 0x0; i < length; i++)
+                {
+                    if (processedAddress[i])
+                    {
+                        if (start != U.NOT_FOUND)
+                        {
+                            RefCmd refCmd = UnkBin(start, i - start);
+                            refCmdList.Add(refCmd);
+                            start = U.NOT_FOUND;
+                        }
+
+                        continue;
+                    }
+
+                    uint c = i < (uint)this.Modified.Length ? this.Modified[i] : (uint)0;
+                    uint v = this.Vanilla.u8(i);
+                    if (c != v)
+                    {
+                        if (start == U.NOT_FOUND)
+                        {
+                            start = i;
+                        }
+                    }
+                    else
+                    {
+                        if (start != U.NOT_FOUND)
+                        {
+                            RefCmd refCmd = UnkBin(start, i - start);
+                            refCmdList.Add(refCmd);
+                            start = U.NOT_FOUND;
+                        }
+                    }
+                }
+
+                if (this.RebuildAddress > vallinaLength)
+                {//無改造ROMより大きい領域で、コピーできる領域.
+                    length = this.RebuildAddress - vallinaLength;
+                    RefCmd refCmd = UnkBin(vallinaLength, length);
+                    refCmdList.Add(refCmd);
+                }
+            }
+
+            string MakeName(Address address)
+            {
+                string basename;
+                if (address.Info != "")
+                {
+                    basename = U.escape_filename(address.Info) + "_";
+                    basename = basename.Replace(' ', '_');
+                    basename = basename.Replace("_____", "_");
+                    basename = basename.Replace("____", "_");
+                    basename = basename.Replace("___", "_");
+                    basename = basename.Replace("__", "_");
+                }
+                else
+                {
+                    basename = "";
+                }
+
+                if (basename.Length >= 25)
+                {
+                    basename = basename.Substring(0, 25);
+                }
+
+                if (address.Pointer == 0 || address.Pointer == U.NOT_FOUND)
+                {
+                    return basename + "." + U.ToHexString8(address.Addr);
+                }
+                else
+                {
+                    return basename + ".P" + U.ToHexString8(address.Pointer);
+                }
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Core/RebuildMakeCore.cs
+++ b/FEBuilderGBA.Core/RebuildMakeCore.cs
@@ -175,7 +175,10 @@ namespace FEBuilderGBA
 
             public void Run(string manifestPath)
             {
-                this.BaseDir = Path.GetDirectoryName(manifestPath);
+                //GetDirectoryName は manifestPath にディレクトリ成分が無い (例 "foo.rebuild")
+                //場合 null を返し、続く Path.Combine が ArgumentNullException を投げる.
+                //ディレクトリ無し = カレントディレクトリ ("") として扱う.
+                this.BaseDir = Path.GetDirectoryName(manifestPath) ?? "";
                 Directory.CreateDirectory(Path.Combine(this.BaseDir, "rebuild_ifr"));
                 Directory.CreateDirectory(Path.Combine(this.BaseDir, "rebuild_mix"));
                 Directory.CreateDirectory(Path.Combine(this.BaseDir, "rebuild_bin"));
@@ -600,8 +603,12 @@ namespace FEBuilderGBA
                     }
                     else if (b == 0xB2 || b == 0xB3)
                     {
+                        //repointer (4-byte payload). 切り詰められたデータで end を跨がないよう確認.
+                        if (position + 4 > end)
+                        {
+                            break;
+                        }
                         infsb.Append(' ');
-                        //repointer
                         bool r = IsRegistAddr(refCmd, infsb, romdata, startaddr, end, position, ASMC_Delect.NONE);
                         if (!r)
                         {
@@ -612,12 +619,20 @@ namespace FEBuilderGBA
                     else if (b == 0xBD || b == 0xBB || b == 0xBC || b == 0xBE || b == 0xBF || b == 0xC0 || b == 0xC1)
                     {
                         // These commands take a data byte that must not be processed.
+                        if (position >= end)
+                        {
+                            break;
+                        }
                         infsb.Append(' ');
                         infsb.Append(U.ToHexString(romdata[position]));
                         position++;
                     }
                     else if (b == 0xb9)
                     {//MEMACC 4バイト命令. 最初の1バイトはコピー済みなので、残りの3バイトコピーする.
+                        if (position + 3 > end)
+                        {
+                            break;
+                        }
                         infsb.Append(' ');
                         infsb.Append(U.ToHexString(romdata[position]));
                         position++;
@@ -630,7 +645,7 @@ namespace FEBuilderGBA
                     }
                     else if (percussion != 0 && b < 0x80)
                     {
-                        while (romdata[position] < 0x80)
+                        while (position < end && romdata[position] < 0x80)
                         {// Volume marker
                             infsb.Append(' ');
                             infsb.Append(U.ToHexString(romdata[position]));

--- a/FEBuilderGBA.Core/U.cs
+++ b/FEBuilderGBA.Core/U.cs
@@ -970,6 +970,16 @@ namespace FEBuilderGBA
             string name = Path.GetFileNameWithoutExtension(filename);
             return Path.Combine(dir, name + appendname + ext);
         }
+
+        //https://stackoverflow.com/questions/146134/how-to-remove-illegal-characters-from-path-and-filenames
+        readonly static string s_regexSearch = "[" + System.Text.RegularExpressions.Regex.Escape(
+            new string(Path.GetInvalidFileNameChars()) + new string(Path.GetInvalidPathChars()))
+            + "]";
+        public static string escape_filename(string str)
+        {
+            str = RegexCache.Replace(str, s_regexSearch, "_");
+            return str;
+        }
         public static void WriteAllBytes(string path, byte[] bytes)
         {
             try
@@ -1025,6 +1035,18 @@ namespace FEBuilderGBA
                 if (a[i] != b[i]) return a[i] < b[i] ? -1 : 1;
             }
             return 0;
+        }
+        public static int GetIndexOf(uint[] list, uint need)
+        {
+            if (list == null) return -1;
+            for (int i = 0; i < list.Length; i++)
+            {
+                if (list[i] == need)
+                {
+                    return i;
+                }
+            }
+            return -1;
         }
 
         // ---- Checksum ---------------------------------------------------------


### PR DESCRIPTION
## Summary
**Slice 1** of #1261 (full ROM-rebuild compaction): makes the `.rebuild` manifest **actually applicable for the first time** by extracting the Make **emitter** and the Apply **writer** to Core. #1171 shipped analysis-only; this is the round-trip core.

The keystone `U.MakeAllStructPointersList` (~120 WinForms Form statics) is NOT portable wholesale, so `RebuildMakeCore.Make` takes the **struct list as a parameter** — the WinForms shell keeps producing it while Core does the emitting/applying. This is fully provable via a synthetic fragmented-ROM round-trip with a hand-built `List<Address>` — no real ROM, no keystone. (Later slices: port the producer editor-by-editor, the free-area recycler, and the Avalonia VM wiring.)

## Changes (additive only — Core)
- **`RebuildApplyCore.cs`** (+830): ports `ToolROMRebuildApply.cs` ~verbatim → `Apply(ROM vanilla, string manifestPath, uint extendsAddress, Func<uint,bool> isReserved=null, IProgress<string>=null) → ApplyResult{Rebuilt, Log, Success}`. The 2 WinForms touches replaced by params (extends_address → param; `IsSkillReserve` → `isReserved` callback, default false). Append-only allocation for slice 1.
- **`RebuildMakeCore.cs`** (+1412): the manifest **emitter only**, struct list passed in. Ports IFR/Mix/BIN/BrokenData/Def/IsRegistAddr/WildCard/MixRec/SongScore/Font/ASM/EventCond12/16/12_16/EventScript1/2/BattleAnimation/NoPointer/MakePointerMark/RefSortSimple/FindUnknownHack2/MakeName. `AsmMapFileAsmCache.GetName` → injected `nameResolver`; `SearchPointer` → `U.GrepPointerAllOnLDR`. **No `Program.*` singleton required** — EVENTSCRIPT/AISCRIPT/PROCS dicts are optional params; an unsupplied one falls back to generic `WildCard(AUTO)`.
- **`U.cs`** (+22): `escape_filename` + `GetIndexOf` (additive).
- **`RebuildCoreTests.cs`** (+377): 3 synthetic round-trip tests.

## Tests
- Core.Tests: **4383 passed**, 0 failed (incl. 28 Rebuild tests). The round-trip asserts (a) every pointer resolves to bytes == the original struct (**data intact**), (b) `rebuilt.Length < modified.Length` + structs compacted (**free reclaimed**), (c) a 2nd Make/Apply is stable (**idempotence**), plus a forward missing→resolved pointer back-patch and the **ASM thumb-bit (+1) preservation** negative test.
- FEBuilderGBA.Tests (net9.0-windows): **1864 passed**, 0 failed.

Part of #1261

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
