### PR TITLE
feat(avalonia): FE8 Spell Menu Extensions editor (#1167)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/FE8SpellMenuExtendsParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/FE8SpellMenuExtendsParityTests.cs
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Parity / regression tests for FE8SpellMenuExtendsView (issue #1167).
+//
+// Mirrors the SkillAssignmentUnitSkillSystemParityTests pattern: plant the
+// SkillSystems202201 spell-menu signature into a synthetic FE8U ROM, then drive
+// the ViewModel through master/detail/expand round-trips. Marked
+// [Collection("SharedState")] because the ViewModel reads CoreState.ROM.
+using System;
+using System.IO;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests.GapSweep;
+
+[Collection("SharedState")]
+public class FE8SpellMenuExtendsParityTests
+{
+    static readonly byte[] SpellsGetter202201 = new byte[]
+    {
+        0x9E, 0x42, 0x04, 0xDA, 0x02, 0x34, 0xEF, 0xE7,
+        0x00, 0x9A, 0x9A, 0x42, 0xFA, 0xD1, 0x01, 0x9B,
+        0x01, 0x33, 0x03, 0xD1, 0x63, 0x78, 0x2B, 0x70,
+        0x01, 0x35, 0xF3, 0xE7, 0x60, 0x78, 0xFF, 0xF7,
+        0xBB, 0xFF, 0x01, 0x9B, 0x98, 0x42, 0xED, 0xD1,
+        0xF4, 0xE7, 0xC0, 0x46,
+    };
+
+    const uint SigPos = 0xB10000;
+    const uint UnitTableBase = 0xC00000;
+    const uint ListBase = 0xC10000;
+
+    static ROM MakeEmptyFE8URom()
+    {
+        var rom = new ROM();
+        byte[] data = new byte[0x1000000];
+        data[0x6E0] = 0xFF;
+        rom.LoadLow("synth-empty-fe8spell.gba", data, "BE8E01");
+        return rom;
+    }
+
+    static ROM MakeScratchRom()
+    {
+        var rom = new ROM();
+        byte[] data = new byte[0x1000000];
+        for (int i = 0; i < data.Length; i++) data[i] = 0xFF;
+        rom.LoadLow("synth-scratch-fe8spell.gba", data, "BE8E01");
+        return rom;
+    }
+
+    static void WriteBytes(ROM rom, uint addr, byte[] bytes)
+    {
+        for (int i = 0; i < bytes.Length; i++)
+            rom.write_u8(addr + (uint)i, bytes[i]);
+    }
+
+    static void WriteU32(ROM rom, uint addr, uint value)
+    {
+        rom.write_u8(addr + 0, (byte)(value & 0xFF));
+        rom.write_u8(addr + 1, (byte)((value >> 8) & 0xFF));
+        rom.write_u8(addr + 2, (byte)((value >> 16) & 0xFF));
+        rom.write_u8(addr + 3, (byte)((value >> 24) & 0xFF));
+    }
+
+    static uint PlantPatch(ROM rom)
+    {
+        WriteBytes(rom, SigPos, SpellsGetter202201);
+        uint slot = SigPos + (uint)SpellsGetter202201.Length;
+        WriteU32(rom, slot, UnitTableBase | 0x08000000u);
+        return slot;
+    }
+
+    static void PlantUnitList(ROM rom, uint unitId, uint listBase, (byte b0, byte b1)[] entries)
+    {
+        uint slot = UnitTableBase + unitId * 4;
+        WriteU32(rom, slot, listBase | 0x08000000u);
+        uint cursor = listBase;
+        foreach (var (b0, b1) in entries)
+        {
+            rom.write_u8(cursor + 0, b0);
+            rom.write_u8(cursor + 1, b1);
+            cursor += 2;
+        }
+        rom.write_u16(cursor, 0x0000);
+    }
+
+    // -----------------------------------------------------------------
+    // ViewModel — empty ROM yields empty list (proves stub placeholder gone)
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_LoadList_EmptyRom_ReturnsEmpty()
+    {
+        var prev = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = MakeEmptyFE8URom();
+            var vm = new FE8SpellMenuExtendsViewModel();
+            var items = vm.LoadList();
+            // No patch planted -> empty (NOT the single synthetic "Spell Menu
+            // Extensions" placeholder row the stub used to return).
+            Assert.Empty(items);
+            Assert.Equal(0u, vm.ReadStartAddress);
+            Assert.Equal(0u, vm.ReadCount);
+        }
+        finally { CoreState.ROM = prev; }
+    }
+
+    // -----------------------------------------------------------------
+    // ViewModel — planted ROM enumerates units
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_LoadList_PlantedRom_EnumeratesUnits()
+    {
+        var prev = CoreState.ROM;
+        try
+        {
+            ROM rom = MakeScratchRom();
+            PlantPatch(rom);
+            CoreState.ROM = rom;
+
+            var vm = new FE8SpellMenuExtendsViewModel();
+            var items = vm.LoadList();
+
+            Assert.True(items.Count > 0, "Expected at least one unit row");
+            Assert.Equal(UnitTableBase, vm.ReadStartAddress);
+            Assert.True(vm.ReadCount > 0);
+            // First row addr is the unit-0 slot (UnitTableBase + 0).
+            Assert.Equal(UnitTableBase, items[0].addr);
+            // Master block size is the per-unit u32 pointer slot (4 bytes).
+            Assert.Equal(4u, vm.MasterBlockSize);
+        }
+        finally { CoreState.ROM = prev; }
+    }
+
+    // -----------------------------------------------------------------
+    // ViewModel — LoadEntry reads the per-unit pointer + N1 list (B0/B1 split)
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_LoadEntry_ReadsN1ListAndSplitsB0()
+    {
+        var prev = CoreState.ROM;
+        try
+        {
+            ROM rom = MakeScratchRom();
+            PlantPatch(rom);
+            // Unit 5: promoted level 10 (0x8A) learns item 0x11; level 20 (0x14) item 0x12.
+            PlantUnitList(rom, 5, ListBase, new (byte, byte)[] { (0x8A, 0x11), (0x14, 0x12) });
+            CoreState.ROM = rom;
+
+            var vm = new FE8SpellMenuExtendsViewModel();
+            vm.LoadList();
+
+            uint addr = UnitTableBase + 5 * 4;
+            vm.LoadEntry(addr);
+            Assert.Equal(5u, vm.SelectedUnitId);
+            Assert.False(vm.IsZeroPointer);
+            Assert.Equal(2, vm.SpellEntries.Count);
+
+            // First entry: B0 0x8A -> level 10 + promoted, B1 0x11.
+            vm.LoadN1Entry(vm.SpellEntries[0].Addr);
+            Assert.Equal(10u, vm.N1Level);
+            Assert.True(vm.N1Promoted);
+            Assert.Equal(0x11u, vm.N1SpellId);
+
+            // Second entry: B0 0x14 -> level 20 + unpromoted, B1 0x12.
+            vm.LoadN1Entry(vm.SpellEntries[1].Addr);
+            Assert.Equal(20u, vm.N1Level);
+            Assert.False(vm.N1Promoted);
+            Assert.Equal(0x12u, vm.N1SpellId);
+        }
+        finally { CoreState.ROM = prev; }
+    }
+
+    // -----------------------------------------------------------------
+    // ViewModel — WriteN1 round-trips MakeB0 (level|promoted) + B1
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_WriteN1_RoundTripsMakeB0()
+    {
+        var prev = CoreState.ROM;
+        try
+        {
+            ROM rom = MakeScratchRom();
+            PlantPatch(rom);
+            PlantUnitList(rom, 1, ListBase, new (byte, byte)[] { (0x05, 0x10) });
+            CoreState.ROM = rom;
+
+            var vm = new FE8SpellMenuExtendsViewModel();
+            vm.LoadList();
+            vm.LoadEntry(UnitTableBase + 1 * 4);
+            vm.LoadN1Entry(vm.SpellEntries[0].Addr);
+
+            // Set promoted level 7 (-> 0x87), spell 0x22, write back.
+            vm.N1Level = 7;
+            vm.N1Promoted = true;
+            vm.N1SpellId = 0x22;
+            vm.WriteN1();
+
+            Assert.Equal((byte)0x87, rom.u8(ListBase + 0));
+            Assert.Equal((byte)0x22, rom.u8(ListBase + 1));
+        }
+        finally { CoreState.ROM = prev; }
+    }
+
+    // -----------------------------------------------------------------
+    // ViewModel — WriteMaster repoints the unit pointer slot
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_WriteMaster_RepointsUnitSlot()
+    {
+        var prev = CoreState.ROM;
+        try
+        {
+            ROM rom = MakeScratchRom();
+            PlantPatch(rom);
+            PlantUnitList(rom, 2, ListBase, new (byte, byte)[] { (0x05, 0x10) });
+            CoreState.ROM = rom;
+
+            var vm = new FE8SpellMenuExtendsViewModel();
+            vm.LoadList();
+            uint addr = UnitTableBase + 2 * 4;
+            vm.LoadEntry(addr);
+
+            uint newOffset = 0xC20000u;
+            vm.UnitListPointer = newOffset | 0x08000000u;
+            vm.WriteMaster();
+
+            Assert.Equal(newOffset, rom.p32(addr));
+        }
+        finally { CoreState.ROM = prev; }
+    }
+
+    // -----------------------------------------------------------------
+    // ViewModel — ExpandN1List re-terminates with 0x0000 and repoints
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_ExpandN1List_ReTerminatesWithZero()
+    {
+        var prev = CoreState.ROM;
+        try
+        {
+            ROM rom = MakeScratchRom();
+            PlantPatch(rom);
+            PlantUnitList(rom, 4, ListBase, new (byte, byte)[] { (0x05, 0x10), (0x0A, 0x11) });
+            CoreState.ROM = rom;
+
+            var vm = new FE8SpellMenuExtendsViewModel();
+            vm.LoadList();
+            uint addr = UnitTableBase + 4 * 4;
+            vm.LoadEntry(addr);
+            Assert.Equal(2, vm.SpellEntries.Count);
+
+            bool ok = vm.ExpandN1List(4);
+            Assert.True(ok);
+            // After expand: 4 entries + re-terminated list (the first two preserved).
+            Assert.Equal(4, vm.SpellEntries.Count);
+
+            uint newBase = U.toOffset(vm.UnitListPointer);
+            Assert.Equal((byte)0x05, rom.u8(newBase + 0));
+            Assert.Equal((byte)0x10, rom.u8(newBase + 1));
+            Assert.Equal(0x0000u, rom.u16(newBase + 8)); // terminator after 4 entries
+        }
+        finally { CoreState.ROM = prev; }
+    }
+
+    // -----------------------------------------------------------------
+    // ViewModel — IsZeroPointer true when the unit slot is null/unset
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void ViewModel_IsZeroPointer_WhenUnitSlotUnset()
+    {
+        var prev = CoreState.ROM;
+        try
+        {
+            ROM rom = MakeScratchRom();
+            PlantPatch(rom);
+            // Unit 7's slot left as 0xFFFFFFFF (unsafe pointer) -> IsZeroPointer.
+            CoreState.ROM = rom;
+
+            var vm = new FE8SpellMenuExtendsViewModel();
+            vm.LoadList();
+            vm.LoadEntry(UnitTableBase + 7 * 4);
+            Assert.True(vm.IsZeroPointer);
+            Assert.Empty(vm.SpellEntries);
+        }
+        finally { CoreState.ROM = prev; }
+    }
+
+    // -----------------------------------------------------------------
+    // View — static source assertions
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public void View_MasterWriteHandler_WrapsInUndoScope()
+    {
+        string src = File.ReadAllText(ViewCsPath());
+        Assert.Contains("_undoService.Begin(\"Edit Spell Menu Extensions Unit Pointer\")", src);
+        Assert.Contains("_undoService.Commit()", src);
+        Assert.Contains("_undoService.Rollback()", src);
+    }
+
+    [Fact]
+    public void View_N1WriteHandler_WrapsInUndoScope()
+    {
+        string src = File.ReadAllText(ViewCsPath());
+        Assert.Contains("_undoService.Begin(\"Edit Spell Menu Extensions Entry\")", src);
+    }
+
+    [Fact]
+    public void View_ExpandHandler_WrapsInUndoScope()
+    {
+        string src = File.ReadAllText(ViewCsPath());
+        Assert.Contains("_undoService.Begin(\"Expand Spell Menu Extensions List\")", src);
+    }
+
+    [Fact]
+    public void View_HasMasterAndN1WriteButtons_Wired()
+    {
+        string axaml = File.ReadAllText(AxamlPath());
+        Assert.Contains("AutomationId=\"FE8SpellMenuExtends_Write_Button\"", axaml);
+        Assert.Contains("Click=\"MasterWriteButton_Click\"", axaml);
+        Assert.Contains("AutomationId=\"FE8SpellMenuExtends_N1Write_Button\"", axaml);
+        Assert.Contains("Click=\"N1WriteButton_Click\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasN1EntryListAndExpand()
+    {
+        string axaml = File.ReadAllText(AxamlPath());
+        Assert.Contains("AutomationId=\"FE8SpellMenuExtends_N1Entry_List\"", axaml);
+        Assert.Contains("AutomationId=\"FE8SpellMenuExtends_N1ListExpand_Button\"", axaml);
+    }
+
+    [Fact]
+    public void View_SpellIdField_IsHexTextBox_NotHexNud()
+    {
+        // The spell-id field MUST be a TextBox (parsed via U.atoh), NOT a
+        // NumericUpDown with a hex FormatString — that combination throws a
+        // FormatException the AvaloniaEditorTests gate catches.
+        string axaml = File.ReadAllText(AxamlPath());
+        Assert.Contains("Name=\"N1SpellIdBox\"", axaml);
+        // No hex FormatString anywhere (X2/X02/X8 etc.) on this view.
+        Assert.DoesNotContain("FormatString=\"X", axaml);
+    }
+
+    [Fact]
+    public void View_PromotedCheckBox_Present()
+    {
+        string axaml = File.ReadAllText(AxamlPath());
+        Assert.Contains("AutomationId=\"FE8SpellMenuExtends_N1Promoted_Check\"", axaml);
+    }
+
+    [Fact]
+    public void ListParityHelper_ClassifiesAsContextDependent()
+    {
+        // The editor is patch-dependent (empty on vanilla FE8U), same shape as
+        // the SkillAssignment* skill editors. It must be context-dependent, NOT
+        // a no-list tool/dialog.
+        Assert.True(ListParityHelper.IsContextDependentEditor("FE8SpellMenuExtendsView"));
+        Assert.False(ListParityHelper.IsNoListEditor("FE8SpellMenuExtendsView"));
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    static string ViewCsPath() => Path.Combine(FindRepoRoot(), "FEBuilderGBA.Avalonia", "Views",
+        "FE8SpellMenuExtendsView.axaml.cs");
+
+    static string AxamlPath() => Path.Combine(FindRepoRoot(), "FEBuilderGBA.Avalonia", "Views",
+        "FE8SpellMenuExtendsView.axaml");
+
+    static string FindRepoRoot()
+    {
+        string dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+        if (dir == null)
+            throw new InvalidOperationException("Could not find FEBuilderGBA.sln from test base directory");
+        return dir;
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/FE8SpellMenuExtendsParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/FE8SpellMenuExtendsParityTests.cs
@@ -256,7 +256,14 @@ public class FE8SpellMenuExtendsParityTests
             vm.LoadEntry(addr);
             Assert.Equal(2, vm.SpellEntries.Count);
 
-            bool ok = vm.ExpandN1List(4);
+            var ud = new Undo.UndoData
+            {
+                time = System.DateTime.Now,
+                name = "expand",
+                list = new System.Collections.Generic.List<Undo.UndoPostion>(),
+                filesize = (uint)rom.Data.Length,
+            };
+            bool ok = vm.ExpandN1List(4, ud);
             Assert.True(ok);
             // After expand: 4 entries + re-terminated list (the first two preserved).
             Assert.Equal(4, vm.SpellEntries.Count);
@@ -355,6 +362,30 @@ public class FE8SpellMenuExtendsParityTests
     {
         string axaml = File.ReadAllText(AxamlPath());
         Assert.Contains("AutomationId=\"FE8SpellMenuExtends_N1Promoted_Check\"", axaml);
+    }
+
+    [Fact]
+    public void View_N1Label_IsSpell_NotSkill()
+    {
+        // Copilot #2: B1 is the item/spell id; WF labels it 魔法 (spell), so the
+        // Avalonia label must be "Spell" (not "Skill", which would conflate it
+        // with the SkillSystems skill editors).
+        string axaml = File.ReadAllText(AxamlPath());
+        Assert.Contains("AutomationId=\"FE8SpellMenuExtends_N1Spell_Label\"", axaml);
+        Assert.Matches(@"FE8SpellMenuExtends_N1Spell_Label[\s\S]{0,160}Content=""Spell""", axaml);
+        Assert.DoesNotContain("Content=\"Skill\"", axaml);
+    }
+
+    [Fact]
+    public void View_HasEditableListPointerField_AndMasterWriteReadsIt()
+    {
+        // Copilot #3: master Write must actually repoint the per-unit list base
+        // (WF N1_ReadStartAddress). The View needs an editable hex field, and
+        // MasterWriteButton_Click must read it before WriteMaster.
+        string axaml = File.ReadAllText(AxamlPath());
+        Assert.Contains("AutomationId=\"FE8SpellMenuExtends_ListPointer_Input\"", axaml);
+        string src = File.ReadAllText(ViewCsPath());
+        Assert.Contains("_vm.UnitListPointer = U.atoh(ListPointerBox.Text", src);
     }
 
     [Fact]

--- a/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
@@ -376,7 +376,6 @@ namespace FEBuilderGBA.Avalonia.Services
             "TextViewerView", "TextMainView", "OtherTextView",
             "TextEscapeEditorView", "TextCharCodeView",
             "OAMSPView",
-            "FE8SpellMenuExtendsView",
             "EDFE6View", "EDFE7View",
             "WorldMapPathEditorView",
             "WorldMapImageView", "WorldMapImageFE6View", "WorldMapImageFE7View",
@@ -425,6 +424,9 @@ namespace FEBuilderGBA.Avalonia.Services
             "SkillConfigFE8NSkillView", "SkillConfigFE8NVer2SkillView",
             "SkillConfigFE8NVer3SkillView", "SkillConfigFE8UCSkillSys09xView",
             "SkillSystemsEffectivenessReworkClassTypeView",
+            // FE8 SkillSystems spell-menu (Gaiden-style spell list) — patch-dependent;
+            // empty on vanilla FE8U until the FE8SpellMenu patch is installed (#1167).
+            "FE8SpellMenuExtendsView",
             // Image sub-editors (need parent context or specific address)
             "ImageBattleAnimePalletView",
             // Patch-dependent stat bonuses editors (need SkillSystem/Venno patch installed)

--- a/FEBuilderGBA.Avalonia/ViewModels/FE8SpellMenuExtendsViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/FE8SpellMenuExtendsViewModel.cs
@@ -1,23 +1,117 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Avalonia counterpart of WinForms FE8SpellMenuExtendsForm. Issue #1167 raises
+// the AXAML control surface from a single-placeholder stub to a functional
+// master/detail editor over the FE8 SkillSystems spell-menu (Gaiden-style
+// spell list) patch.
+//
+// Master row (unit) at unitTableBase + 4*unitId is a u32 GBA pointer to that
+// unit's spell-list block; the block is a 0x0000-terminated u16 array of
+// [B0|B1] entries (B0 = level|promoted, B1 = item/spell id).
+//
+// This VM READS ROM bytes, so it implements IDataVerifiable (NOT a tool
+// orphan). All scan/read logic lives in Core (FE8SpellMenuPatchScanner +
+// FE8SpellMenuExtendsCore); this VM is the thin CoreState.ROM-bound adapter.
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using FEBuilderGBA.Avalonia.Services;
 
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
-    public class FE8SpellMenuExtendsViewModel : ViewModelBase
+    public class FE8SpellMenuExtendsViewModel : ViewModelBase, IDataVerifiable
     {
-        uint _currentAddr;
+        public const uint MASTER_BLOCK_SIZE = FE8SpellMenuExtendsCore.MASTER_BLOCK_SIZE; // 4
+        public const uint N1_BLOCK_SIZE = FE8SpellMenuExtendsCore.N1_BLOCK_SIZE;          // 2
+        public const uint UNIT_MAX_ROWS = FE8SpellMenuExtendsCore.UNIT_MAX_ROWS;          // 0xFF
+
+        uint _assignLevelUpP = U.NOT_FOUND;
+        uint _unitTableBase;
+
+        public uint AssignLevelUpP { get => _assignLevelUpP; set => SetField(ref _assignLevelUpP, value); }
+        public uint UnitTableBase { get => _unitTableBase; set => SetField(ref _unitTableBase, value); }
+
+        uint _readStartAddress;
+        uint _readCount;
+        public uint ReadStartAddress { get => _readStartAddress; set => SetField(ref _readStartAddress, value); }
+        public uint ReadCount { get => _readCount; set => SetField(ref _readCount, value); }
+        public uint MasterBlockSize => MASTER_BLOCK_SIZE;
+        public uint N1BlockSize => N1_BLOCK_SIZE;
+
+        uint _currentAddr;        // selected unit's pointer-slot address
         bool _isLoaded;
+        uint _selectedUnitId;
+        uint _unitListPointer;    // the GBA pointer value in the slot
+        bool _isZeroPointer;
 
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
+        public uint SelectedUnitId { get => _selectedUnitId; set => SetField(ref _selectedUnitId, value); }
+        public uint UnitListPointer { get => _unitListPointer; set => SetField(ref _unitListPointer, value); }
+
+        /// <summary>True when the selected unit's pointer slot is 0 (no spell
+        /// list allocated). Drives the View's "no list" hint panel.</summary>
+        public bool IsZeroPointer { get => _isZeroPointer; set => SetField(ref _isZeroPointer, value); }
+
+        public sealed class SpellEntry
+        {
+            public uint Addr { get; init; }
+            public string Name { get; init; }
+            public uint Tag { get; init; }
+            public override string ToString() => Name;
+        }
+        public ObservableCollection<SpellEntry> SpellEntries { get; } = new();
+
+        uint _selectedN1Addr;
+        uint _selectedN1Id;
+        uint _n1Level;
+        bool _n1Promoted;
+        uint _n1SpellId;
+
+        public uint SelectedN1Addr { get => _selectedN1Addr; set => SetField(ref _selectedN1Addr, value); }
+        public uint SelectedN1Id { get => _selectedN1Id; set => SetField(ref _selectedN1Id, value); }
+        public uint N1Level { get => _n1Level; set => SetField(ref _n1Level, value); }
+        public bool N1Promoted { get => _n1Promoted; set => SetField(ref _n1Promoted, value); }
+        public uint N1SpellId { get => _n1SpellId; set => SetField(ref _n1SpellId, value); }
 
         public List<AddrResult> LoadList()
         {
             ROM rom = CoreState.ROM;
-            if (rom?.RomInfo == null) return new List<AddrResult>();
+            if (rom == null || rom.RomInfo == null)
+            {
+                ResetDerivedListState();
+                return new List<AddrResult>();
+            }
+
+            uint assignLevelUpP = FE8SpellMenuPatchScanner.FindFE8SpellPatchPointer(rom, CoreState.BaseDirectory);
+            AssignLevelUpP = assignLevelUpP;
+            if (assignLevelUpP == U.NOT_FOUND)
+            {
+                ResetDerivedListState();
+                return new List<AddrResult>();
+            }
+
+            uint unitTableBase = FE8SpellMenuExtendsCore.GetUnitTableBase(rom, assignLevelUpP);
+            if (unitTableBase == U.NOT_FOUND)
+            {
+                ResetDerivedListState();
+                return new List<AddrResult>();
+            }
+            UnitTableBase = unitTableBase;
+            ReadStartAddress = unitTableBase;
 
             var result = new List<AddrResult>();
-            result.Add(new AddrResult(0, "Spell Menu Extensions", 0));
+            for (uint i = 0; i < UNIT_MAX_ROWS; i++)
+            {
+                uint addr = FE8SpellMenuExtendsCore.GetUnitSlotAddr(unitTableBase, i);
+                if (!U.isSafetyOffset(addr + 3, rom)) break;
+                // The row index i IS the WF uid (UnitForm.GetUnitName((uint)i)).
+                string unitName = NameResolver.GetUnitNameByOneBasedId(i);
+                string label = string.IsNullOrEmpty(unitName)
+                    ? "0x" + i.ToString("X02")
+                    : "0x" + i.ToString("X02") + " " + unitName;
+                result.Add(new AddrResult(addr, label, i));
+            }
+            ReadCount = (uint)result.Count;
             return result;
         }
 
@@ -25,9 +119,183 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         {
             ROM rom = CoreState.ROM;
             if (rom == null) return;
+            if (!U.isSafetyOffset(addr + 3, rom)) return;
 
             CurrentAddr = addr;
+
+            if (_assignLevelUpP == U.NOT_FOUND)
+                AssignLevelUpP = FE8SpellMenuPatchScanner.FindFE8SpellPatchPointer(rom, CoreState.BaseDirectory);
+            if (_unitTableBase == 0 && _assignLevelUpP != U.NOT_FOUND)
+            {
+                uint baseAddr = FE8SpellMenuExtendsCore.GetUnitTableBase(rom, _assignLevelUpP);
+                if (baseAddr != U.NOT_FOUND) UnitTableBase = baseAddr;
+            }
+
+            SelectedUnitId = (_unitTableBase > 0 && addr >= _unitTableBase)
+                ? (addr - _unitTableBase) / MASTER_BLOCK_SIZE
+                : 0;
+
+            UnitListPointer = rom.u32(addr);
+            IsZeroPointer = !U.isSafetyPointer(UnitListPointer);
+
+            LoadSpellList(rom);
+
             IsLoaded = true;
         }
+
+        public void LoadSpellList(ROM rom)
+        {
+            SpellEntries.Clear();
+            SelectedN1Addr = 0;
+            SelectedN1Id = 0;
+            N1Level = 0;
+            N1Promoted = false;
+            N1SpellId = 0;
+            if (rom == null) return;
+            if (!U.isSafetyPointer(UnitListPointer)) return;
+
+            uint listBase = U.toOffset(UnitListPointer);
+            var entries = FE8SpellMenuExtendsCore.ReadSpellList(rom, listBase);
+            uint n = 0;
+            foreach (var (entryAddr, b0, b1) in entries)
+            {
+                string itemName = NameResolver.GetItemName(b1);
+                string label = string.IsNullOrEmpty(itemName)
+                    ? "0x" + b1.ToString("X02")
+                    : "0x" + b1.ToString("X02") + " " + itemName;
+                SpellEntries.Add(new SpellEntry { Addr = entryAddr, Name = label, Tag = n });
+                n++;
+            }
+        }
+
+        public void LoadN1Entry(uint entryAddr)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null) return;
+            if (!U.isSafetyOffset(entryAddr + 1, rom)) return;
+
+            SelectedN1Addr = entryAddr;
+            if (U.isSafetyPointer(UnitListPointer))
+            {
+                uint listBase = U.toOffset(UnitListPointer);
+                SelectedN1Id = entryAddr >= listBase
+                    ? (entryAddr - listBase) / N1_BLOCK_SIZE
+                    : 0;
+            }
+
+            uint b0 = rom.u8(entryAddr + 0);
+            FE8SpellMenuExtendsCore.SplitB0(b0, out uint level, out bool promoted);
+            N1Level = level;
+            N1Promoted = promoted;
+            N1SpellId = rom.u8(entryAddr + 1);
+        }
+
+        /// <summary>Compose the current B0 from N1Level + N1Promoted. Mirrors
+        /// WF FE8SpellMenuExtendsForm.MakeB0.</summary>
+        public uint MakeB0() => FE8SpellMenuExtendsCore.MakeB0(N1Level, N1Promoted);
+
+        /// <summary>Write the per-unit pointer slot (master Write). Mirrors WF
+        /// WriteButton_Click.</summary>
+        public void WriteMaster()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null || CurrentAddr == 0) return;
+            if (!U.isSafetyOffset(CurrentAddr + 3, rom)) return;
+            rom.write_p32(CurrentAddr, U.toOffset(UnitListPointer));
+        }
+
+        /// <summary>Write the selected N1 entry's B0/B1 in place. Mirrors WF
+        /// N1 list write.</summary>
+        public void WriteN1()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null || SelectedN1Addr == 0) return;
+            uint b0 = MakeB0();
+            FE8SpellMenuExtendsCore.WriteN1Entry(rom, SelectedN1Addr, b0, N1SpellId);
+        }
+
+        /// <summary>
+        /// Expand the selected unit's spell list to <paramref name="newCount"/>
+        /// entries, allocating a fresh 0x0000-terminated block and repointing the
+        /// unit slot. Mirrors WF N1_InputFormRef_AddressListExpandsEvent. The
+        /// caller MUST open an ambient UndoService scope first.
+        /// </summary>
+        /// <returns>True on success; false on failure (no expand performed).</returns>
+        public bool ExpandN1List(uint newCount)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null || _unitTableBase == 0) return false;
+            uint newAddr = FE8SpellMenuExtendsCore.ExpandSpellList(rom, _unitTableBase, SelectedUnitId, newCount);
+            if (newAddr == U.NOT_FOUND) return false;
+            // The unit slot was already repointed by ExpandSpellList; refresh the
+            // in-memory pointer + sub-list to match.
+            UnitListPointer = rom.u32(CurrentAddr);
+            IsZeroPointer = !U.isSafetyPointer(UnitListPointer);
+            LoadSpellList(rom);
+            return true;
+        }
+
+        void ResetDerivedListState()
+        {
+            ReadStartAddress = 0;
+            ReadCount = 0;
+            CurrentAddr = 0;
+            SelectedUnitId = 0;
+            IsLoaded = false;
+            UnitTableBase = 0;
+            UnitListPointer = 0;
+            IsZeroPointer = false;
+            SpellEntries.Clear();
+            SelectedN1Addr = 0;
+            SelectedN1Id = 0;
+            N1Level = 0;
+            N1Promoted = false;
+            N1SpellId = 0;
+        }
+
+        public int GetListCount()
+        {
+            if (ReadCount > 0) return (int)ReadCount;
+            return LoadList().Count;
+        }
+
+        // ----------------------------------------------------------------
+        // IDataVerifiable (this VM reads ROM bytes — it is NOT a tool orphan).
+        // ----------------------------------------------------------------
+
+        public Dictionary<string, string> GetDataReport()
+        {
+            return new Dictionary<string, string>
+            {
+                ["addr"] = $"0x{CurrentAddr:X08}",
+                ["SelectedUnitId"] = $"0x{SelectedUnitId:X02}",
+                ["UnitListPointer"] = $"0x{UnitListPointer:X08}",
+                ["N1Level"] = $"0x{N1Level:X02}",
+                ["N1Promoted"] = N1Promoted ? "1" : "0",
+                ["N1SpellId"] = $"0x{N1SpellId:X02}",
+            };
+        }
+
+        public Dictionary<string, string> GetRawRomReport()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null || CurrentAddr == 0) return new Dictionary<string, string>();
+            var dict = new Dictionary<string, string>
+            {
+                ["addr"] = $"0x{CurrentAddr:X08}",
+                ["u32@0x00_UnitListPointer"] = $"0x{rom.u32(CurrentAddr):X08}",
+            };
+            if (SelectedN1Addr != 0 && U.isSafetyOffset(SelectedN1Addr + 1, rom))
+            {
+                dict["u8@0x00_B0"] = $"0x{rom.u8(SelectedN1Addr + 0):X02}";
+                dict["u8@0x01_B1"] = $"0x{rom.u8(SelectedN1Addr + 1):X02}";
+            }
+            return dict;
+        }
+
+        public Dictionary<string, string> GetFieldOffsetMap() => new()
+        {
+            ["UnitListPointer"] = "u32@0x00",
+        };
     }
 }

--- a/FEBuilderGBA.Avalonia/ViewModels/FE8SpellMenuExtendsViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/FE8SpellMenuExtendsViewModel.cs
@@ -218,14 +218,15 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// Expand the selected unit's spell list to <paramref name="newCount"/>
         /// entries, allocating a fresh 0x0000-terminated block and repointing the
         /// unit slot. Mirrors WF N1_InputFormRef_AddressListExpandsEvent. The
-        /// caller MUST open an ambient UndoService scope first.
+        /// caller opens the UndoService scope and passes its active UndoData so
+        /// every write (to CoreState.ROM here) is recorded into that scope.
         /// </summary>
         /// <returns>True on success; false on failure (no expand performed).</returns>
-        public bool ExpandN1List(uint newCount)
+        public bool ExpandN1List(uint newCount, Undo.UndoData undodata)
         {
             ROM rom = CoreState.ROM;
             if (rom == null || _unitTableBase == 0) return false;
-            uint newAddr = FE8SpellMenuExtendsCore.ExpandSpellList(rom, _unitTableBase, SelectedUnitId, newCount);
+            uint newAddr = FE8SpellMenuExtendsCore.ExpandSpellList(rom, _unitTableBase, SelectedUnitId, newCount, undodata);
             if (newAddr == U.NOT_FOUND) return false;
             // The unit slot was already repointed by ExpandSpellList; refresh the
             // in-memory pointer + sub-list to match.

--- a/FEBuilderGBA.Avalonia/Views/FE8SpellMenuExtendsView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/FE8SpellMenuExtendsView.axaml
@@ -3,18 +3,130 @@
         xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
         x:Class="FEBuilderGBA.Avalonia.Views.FE8SpellMenuExtendsView"
         Title="Spell Menu Extensions" Width="1189" Height="849"
-        SizeToContent="WidthAndHeight">
-  <Grid ColumnDefinitions="250,*">
-    <controls:AddressListControl AutomationProperties.AutomationId="FE8SpellMenuExtends_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
+        SizeToContent="Manual">
+  <Grid ColumnDefinitions="250,250,*" RowDefinitions="Auto,*">
 
-    <ScrollViewer Grid.Column="1" Margin="4">
+    <!-- Row 0: master-write bar (spans all columns) -->
+    <Border Grid.Row="0" Grid.ColumnSpan="3" BorderBrush="Gray" BorderThickness="1" Margin="4,4,4,0">
+      <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
+        <Label Content="Address:" VerticalAlignment="Center" />
+        <Label AutomationProperties.AutomationId="FE8SpellMenuExtends_Addr_Label"
+               Name="AddrLabel" Width="100" VerticalAlignment="Center"
+               FontFamily="Consolas" />
+        <Label Content="Selected Address:" VerticalAlignment="Center" />
+        <Label AutomationProperties.AutomationId="FE8SpellMenuExtends_SelectedAddress_Label"
+               Name="SelectedAddressLabel" Width="100" VerticalAlignment="Center"
+               FontFamily="Consolas" />
+        <Button AutomationProperties.AutomationId="FE8SpellMenuExtends_Write_Button"
+                Name="MasterWriteButton" Content="Write" Click="MasterWriteButton_Click" />
+        <Button AutomationProperties.AutomationId="FE8SpellMenuExtends_ReloadList_Button"
+                Name="ReloadListButton" Content="Reload" Click="ReloadList_Click" />
+      </StackPanel>
+    </Border>
+
+    <!-- Row 1 col 0: Unit master list -->
+    <Border Grid.Row="1" Grid.Column="0" BorderBrush="Gray" BorderThickness="1" Margin="4">
+      <DockPanel>
+        <Label DockPanel.Dock="Top"
+               AutomationProperties.AutomationId="FE8SpellMenuExtends_FilterName_Label"
+               Content="Filter Name" HorizontalAlignment="Stretch" />
+        <controls:AddressListControl
+            AutomationProperties.AutomationId="FE8SpellMenuExtends_Entry_List"
+            Name="EntryList" />
+      </DockPanel>
+    </Border>
+
+    <!-- Row 1 col 1: N1 spell sub-list -->
+    <Border Grid.Row="1" Grid.Column="1" BorderBrush="Gray" BorderThickness="1" Margin="0,4,4,4">
+      <DockPanel>
+        <Label DockPanel.Dock="Top"
+               AutomationProperties.AutomationId="FE8SpellMenuExtends_N1FilterName_Label"
+               Content="Filter Name" HorizontalAlignment="Stretch" />
+        <Button DockPanel.Dock="Bottom"
+                AutomationProperties.AutomationId="FE8SpellMenuExtends_N1ListExpand_Button"
+                Name="N1ListExpandButton" Content="Expand List"
+                Margin="2" Click="N1ListExpand_Click" />
+        <ListBox AutomationProperties.AutomationId="FE8SpellMenuExtends_N1Entry_List"
+                 Name="N1EntryList" ItemsSource="{Binding SpellEntries}"
+                 SelectionChanged="N1EntryList_SelectionChanged">
+          <ListBox.ItemTemplate>
+            <DataTemplate>
+              <TextBlock Text="{Binding Name}"
+                         ToolTip.Tip="{Binding Name}" />
+            </DataTemplate>
+          </ListBox.ItemTemplate>
+        </ListBox>
+      </DockPanel>
+    </Border>
+
+    <!-- Row 1 col 2: N1 detail panel -->
+    <ScrollViewer Grid.Row="1" Grid.Column="2" Margin="0,4,4,4">
       <StackPanel Spacing="8" Margin="8">
-        <TextBlock Text="Spell Menu Extensions" FontSize="18" FontWeight="Bold" />
+        <Label Content="Spell Menu Extensions" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="FE8SpellMenuExtends_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+        <Border Background="{DynamicResource WarningBackgroundBrush}"
+                BorderBrush="{DynamicResource WarningBorderBrush}"
+                BorderThickness="1" CornerRadius="4" Padding="12">
+          <TextBlock AutomationProperties.AutomationId="FE8SpellMenuExtends_Status_Label"
+                     TextWrapping="Wrap" Name="StatusText"
+                     Text="This editor requires the FE8 SkillSystems Gaiden-style spell menu patch to be installed." />
+        </Border>
+
+        <!-- N1 address bar -->
+        <Border BorderBrush="Gray" BorderThickness="1" Padding="6">
+          <StackPanel Orientation="Horizontal" Spacing="6">
+            <Label Content="Address:" VerticalAlignment="Center" />
+            <Label AutomationProperties.AutomationId="FE8SpellMenuExtends_N1SelectedAddress_Label"
+                   Name="N1SelectedAddressLabel" Width="100" VerticalAlignment="Center"
+                   FontFamily="Consolas" />
+            <Label Content="Size:" VerticalAlignment="Center" />
+            <Label AutomationProperties.AutomationId="FE8SpellMenuExtends_N1BlockSize_Label"
+                   Name="N1BlockSizeLabel" Width="40" VerticalAlignment="Center"
+                   FontFamily="Consolas" />
+            <Button AutomationProperties.AutomationId="FE8SpellMenuExtends_N1Write_Button"
+                    Name="N1WriteButton" Content="Write" Click="N1WriteButton_Click" />
+          </StackPanel>
+        </Border>
+
+        <!-- Acquisition level + promoted -->
+        <Grid ColumnDefinitions="160,80,160,*" RowDefinitions="Auto">
+          <Label Grid.Column="0"
+                 AutomationProperties.AutomationId="FE8SpellMenuExtends_N1Level_Label"
+                 Content="Acquisition Level" VerticalAlignment="Center" />
+          <NumericUpDown Grid.Column="1"
+                         AutomationProperties.AutomationId="FE8SpellMenuExtends_N1Level_Input"
+                         FormatString="0" Name="N1LevelBox" Minimum="0" Maximum="127" />
+          <CheckBox Grid.Column="2"
+                    AutomationProperties.AutomationId="FE8SpellMenuExtends_N1Promoted_Check"
+                    Name="N1PromotedCheck" Content="Promoted" Margin="6,0,0,0" />
         </Grid>
+
+        <!-- Spell id (hex TextBox) + item icon + name -->
+        <Grid ColumnDefinitions="160,80,Auto,*" RowDefinitions="Auto">
+          <Label Grid.Column="0"
+                 AutomationProperties.AutomationId="FE8SpellMenuExtends_N1Spell_Label"
+                 Content="Skill" VerticalAlignment="Center" />
+          <TextBox Grid.Column="1"
+                   AutomationProperties.AutomationId="FE8SpellMenuExtends_N1SpellId_Input"
+                   Name="N1SpellIdBox" FontFamily="Consolas" VerticalAlignment="Center" />
+          <Border Grid.Column="2" BorderBrush="DarkGray" BorderThickness="1"
+                  Padding="2" Width="48" Height="48" Margin="6,0,0,0">
+            <Image AutomationProperties.AutomationId="FE8SpellMenuExtends_N1SpellIcon_Image"
+                   Name="N1SpellIconImage" Width="40" Height="40" Stretch="Uniform" />
+          </Border>
+          <TextBox Grid.Column="3"
+                   AutomationProperties.AutomationId="FE8SpellMenuExtends_N1SpellName_Input"
+                   Name="N1SpellNameBox" IsReadOnly="True" Margin="8,0,0,0"
+                   VerticalAlignment="Center" />
+        </Grid>
+
+        <Border AutomationProperties.AutomationId="FE8SpellMenuExtends_ZeroPointerPanel"
+                Name="ZeroPointerPanel" BorderBrush="Gray" BorderThickness="1" Padding="6"
+                IsVisible="False">
+          <TextBlock AutomationProperties.AutomationId="FE8SpellMenuExtends_ZeroPointerText_Label"
+                     TextWrapping="Wrap" Name="ZeroPointerText" />
+        </Border>
+
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/FE8SpellMenuExtendsView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/FE8SpellMenuExtendsView.axaml
@@ -17,6 +17,10 @@
         <Label AutomationProperties.AutomationId="FE8SpellMenuExtends_SelectedAddress_Label"
                Name="SelectedAddressLabel" Width="100" VerticalAlignment="Center"
                FontFamily="Consolas" />
+        <Label Content="Top Address" VerticalAlignment="Center" />
+        <TextBox AutomationProperties.AutomationId="FE8SpellMenuExtends_ListPointer_Input"
+                 Name="ListPointerBox" Width="120" FontFamily="Consolas"
+                 VerticalAlignment="Center" />
         <Button AutomationProperties.AutomationId="FE8SpellMenuExtends_Write_Button"
                 Name="MasterWriteButton" Content="Write" Click="MasterWriteButton_Click" />
         <Button AutomationProperties.AutomationId="FE8SpellMenuExtends_ReloadList_Button"
@@ -105,7 +109,7 @@
         <Grid ColumnDefinitions="160,80,Auto,*" RowDefinitions="Auto">
           <Label Grid.Column="0"
                  AutomationProperties.AutomationId="FE8SpellMenuExtends_N1Spell_Label"
-                 Content="Skill" VerticalAlignment="Center" />
+                 Content="Spell" VerticalAlignment="Center" />
           <TextBox Grid.Column="1"
                    AutomationProperties.AutomationId="FE8SpellMenuExtends_N1SpellId_Input"
                    Name="N1SpellIdBox" FontFamily="Consolas" VerticalAlignment="Center" />

--- a/FEBuilderGBA.Avalonia/Views/FE8SpellMenuExtendsView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/FE8SpellMenuExtendsView.axaml.cs
@@ -1,57 +1,275 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Avalonia counterpart of WinForms FE8SpellMenuExtendsForm. Issue #1167 raises
+// the AXAML control surface from a single-placeholder stub to a functional
+// master/detail editor over the FE8 SkillSystems spell-menu patch.
+//
+// Master row (unit) -> the unit's spell-list pointer slot. The N1 sub-list is
+// the unit's 0x0000-terminated u16 [B0|B1] spell array (B0 = level|promoted,
+// B1 = item/spell id). Master + N1 ROM writes and the N1 list-expand are
+// wrapped in View-owned UndoService scopes.
+//
+// The N1 spell-id field is a HEX TextBox (parsed via U.atoh), NOT a hex
+// FormatString NumericUpDown — that combination throws a FormatException the
+// AvaloniaEditorTests gate catches. The B1 item icon is loaded via
+// PreviewIconHelper.LoadItemIconByItemId (a detail-panel preview, NOT a per-row
+// list-icon loader), so the master-list rows stay icon-free per the #939
+// Category-B contract.
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
+using global::Avalonia.Media.Imaging;
+using FEBuilderGBA.Avalonia.Dialogs;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class FE8SpellMenuExtendsView : TranslatedWindow, IEditorView
+    public partial class FE8SpellMenuExtendsView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly FE8SpellMenuExtendsViewModel _vm = new();
+        readonly UndoService _undoService = new();
+        Bitmap _n1IconBitmap;
 
         public string ViewTitle => "Spell Menu Extensions";
         public bool IsLoaded => _vm.IsLoaded;
+        public ViewModelBase DataViewModel => _vm;
 
         public FE8SpellMenuExtendsView()
         {
             InitializeComponent();
+            // Bind DataContext so AXAML {Binding SpellEntries} resolves.
+            DataContext = _vm;
             EntryList.SelectedAddressChanged += OnSelected;
             Opened += (_, _) => LoadList();
+            Closed += (_, _) => DisposeBitmap(ref _n1IconBitmap);
+        }
+
+        static void DisposeBitmap(ref Bitmap bmp)
+        {
+            if (bmp == null) return;
+            try { bmp.Dispose(); } catch (System.Exception ex) { Log.Debug("FE8SpellMenuExtendsView dispose bmp: " + ex.ToString()); }
+            bmp = null;
         }
 
         void LoadList()
         {
+            _vm.IsLoading = true;
             try
             {
                 var items = _vm.LoadList();
-                // #939: the single row is a synthetic section label, NOT an
-                // item — the prefix is not an item id, so the old item-icon
-                // loader showed a spurious icon. Drop the icon column entirely.
+                // #939 Category-B: master rows are units, NOT an item table —
+                // no per-row icon loader (the B1 item icon lives in the detail
+                // panel, loaded via PreviewIconHelper, not a per-row loader).
                 EntryList.SetItems(items);
             }
             catch (Exception ex)
             {
-                Log.Error("FE8SpellMenuExtendsView.LoadList failed: {0}", ex.Message);
+                Log.Error("FE8SpellMenuExtendsView.LoadList failed: " + ex.ToString());
             }
+            finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
 
         void OnSelected(uint addr)
         {
+            _vm.IsLoading = true;
             try
             {
                 _vm.LoadEntry(addr);
                 UpdateUI();
+                if (_vm.SpellEntries.Count > 0)
+                {
+                    N1EntryList.SelectedIndex = 0;
+                }
             }
             catch (Exception ex)
             {
-                Log.Error("FE8SpellMenuExtendsView.OnSelected failed: {0}", ex.Message);
+                Log.Error("FE8SpellMenuExtendsView.OnSelected failed: " + ex.ToString());
             }
+            finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
 
         void UpdateUI()
         {
-            AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            AddrLabel.Content = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            SelectedAddressLabel.Content = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            UpdateZeroPointerPanel();
+        }
+
+        void UpdateZeroPointerPanel()
+        {
+            ZeroPointerPanel.IsVisible = _vm.IsZeroPointer;
+            if (string.IsNullOrEmpty(ZeroPointerText.Text))
+            {
+                ZeroPointerText.Text = R._("No spell list is allocated for this unit.\nUse Expand List to allocate one.");
+            }
+        }
+
+        void N1EntryList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (N1EntryList.SelectedItem is not FE8SpellMenuExtendsViewModel.SpellEntry entry) return;
+            try
+            {
+                _vm.IsLoading = true;
+                _vm.LoadN1Entry(entry.Addr);
+                UpdateN1UI();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("FE8SpellMenuExtendsView.N1EntryList_SelectionChanged failed: " + ex.ToString());
+            }
+            finally { _vm.IsLoading = false; }
+        }
+
+        void UpdateN1UI()
+        {
+            N1SelectedAddressLabel.Content = string.Format("0x{0:X08}", _vm.SelectedN1Addr);
+            N1BlockSizeLabel.Content = _vm.N1BlockSize.ToString();
+            N1LevelBox.Value = _vm.N1Level;
+            N1PromotedCheck.IsChecked = _vm.N1Promoted;
+            N1SpellIdBox.Text = "0x" + _vm.N1SpellId.ToString("X02");
+            N1SpellNameBox.Text = NameResolver.GetItemName(_vm.N1SpellId);
+            RefreshN1Icon();
+        }
+
+        void RefreshN1Icon()
+        {
+            try
+            {
+                ROM rom = CoreState.ROM;
+                if (rom != null && _vm.N1SpellId > 0)
+                {
+                    using var img = PreviewIconHelper.LoadItemIconByItemId(_vm.N1SpellId);
+                    Bitmap bmp = img != null ? ImageConversionHelper.ToAvaloniaBitmap(img) : null;
+                    SetN1Icon(bmp);
+                }
+                else
+                {
+                    SetN1Icon(null);
+                }
+            }
+            catch { SetN1Icon(null); }
+        }
+
+        void SetN1Icon(Bitmap bmp)
+        {
+            if (_n1IconBitmap != null && !ReferenceEquals(_n1IconBitmap, bmp))
+            {
+                try { _n1IconBitmap.Dispose(); } catch (System.Exception ex) { Log.Debug("FE8SpellMenuExtendsView dispose n1 icon: " + ex.ToString()); }
+            }
+            _n1IconBitmap = bmp;
+            N1SpellIconImage.Source = bmp;
+        }
+
+        void MasterWriteButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (!_vm.IsLoaded || _vm.CurrentAddr == 0) return;
+            _undoService.Begin("Edit Spell Menu Extensions Unit Pointer");
+            try
+            {
+                _vm.WriteMaster();
+                _undoService.Commit();
+                _vm.MarkClean();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("FE8SpellMenuExtendsView.MasterWrite failed: " + ex.ToString());
+            }
+        }
+
+        void N1WriteButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (!_vm.IsLoaded || _vm.SelectedN1Addr == 0) return;
+            _undoService.Begin("Edit Spell Menu Extensions Entry");
+            try
+            {
+                _vm.N1Level = (uint)(N1LevelBox.Value ?? 0);
+                _vm.N1Promoted = N1PromotedCheck.IsChecked == true;
+                _vm.N1SpellId = U.atoh(N1SpellIdBox.Text ?? "0");
+                _vm.WriteN1();
+                _undoService.Commit();
+                _vm.MarkClean();
+                // Reload the N1 list label so the row reflects the new B1, then
+                // re-select the same entry.
+                uint keepAddr = _vm.SelectedN1Addr;
+                ROM rom = CoreState.ROM;
+                if (rom != null) _vm.LoadSpellList(rom);
+                SelectN1ByAddr(keepAddr);
+                RefreshN1Icon();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("FE8SpellMenuExtendsView.N1Write failed: " + ex.ToString());
+            }
+        }
+
+        async void N1ListExpand_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (!_vm.IsLoaded || _vm.CurrentAddr == 0)
+                {
+                    CoreState.Services?.ShowInfo(R._("Select a unit first."));
+                    return;
+                }
+                uint currentCount = (uint)_vm.SpellEntries.Count;
+                uint maxCount = System.Math.Max(64u, currentCount + 1);
+                uint defaultCount = currentCount + 1;
+                if (defaultCount > maxCount) defaultCount = maxCount;
+                uint? chosen = await NumberInputDialog.Show(
+                    this,
+                    R._("Enter the new spell-list entry count for this unit (current: {0}, max: {1}).",
+                        currentCount, maxCount),
+                    R._("List Expansion"),
+                    defaultCount,
+                    1,
+                    maxCount);
+                if (chosen == null) return; // user cancelled
+                uint newCount = chosen.Value;
+
+                _undoService.Begin("Expand Spell Menu Extensions List");
+                try
+                {
+                    bool ok = _vm.ExpandN1List(newCount);
+                    if (!ok)
+                    {
+                        _undoService.Rollback();
+                        CoreState.Services?.ShowError(R._("List expansion failed (out of free space?)."));
+                        return;
+                    }
+                    _undoService.Commit();
+                    _vm.MarkClean();
+                    UpdateUI();
+                    if (_vm.SpellEntries.Count > 0) N1EntryList.SelectedIndex = 0;
+                    CoreState.Services?.ShowInfo(
+                        R._("Expanded the spell list to {0} entries.", newCount));
+                }
+                catch (Exception inner)
+                {
+                    _undoService.Rollback();
+                    Log.Error("FE8SpellMenuExtendsView.N1ListExpand inner failed: " + inner.ToString());
+                    CoreState.Services?.ShowError(R._("List expansion failed: {0}", inner.Message));
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("FE8SpellMenuExtendsView.N1ListExpand failed: " + ex.ToString());
+            }
+        }
+
+        void ReloadList_Click(object sender, RoutedEventArgs e) => LoadList();
+
+        void SelectN1ByAddr(uint addr)
+        {
+            for (int i = 0; i < _vm.SpellEntries.Count; i++)
+            {
+                if (_vm.SpellEntries[i].Addr == addr)
+                {
+                    N1EntryList.SelectedIndex = i;
+                    return;
+                }
+            }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/FE8SpellMenuExtendsView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/FE8SpellMenuExtendsView.axaml.cs
@@ -92,6 +92,9 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             AddrLabel.Content = string.Format("0x{0:X08}", _vm.CurrentAddr);
             SelectedAddressLabel.Content = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            // Editable per-unit list-base OFFSET (mirrors WF N1_ReadStartAddress).
+            // master Write repoints the unit slot at whatever the user types here.
+            ListPointerBox.Text = "0x" + U.toOffset(_vm.UnitListPointer).ToString("X08");
             UpdateZeroPointerPanel();
         }
 
@@ -166,9 +169,24 @@ namespace FEBuilderGBA.Avalonia.Views
             _undoService.Begin("Edit Spell Menu Extensions Unit Pointer");
             try
             {
+                // Repoint the unit's spell-list base at the user-edited offset
+                // (mirrors WF WriteButton_Click reading N1_ReadStartAddress.Value).
+                _vm.UnitListPointer = U.atoh(ListPointerBox.Text ?? "0");
                 _vm.WriteMaster();
                 _undoService.Commit();
                 _vm.MarkClean();
+                // Re-read the slot so UnitListPointer holds the canonical GBA
+                // pointer write_p32 stored (a bare offset fails U.isSafetyPointer
+                // in LoadSpellList), then refresh the N1 list + zero-pointer panel.
+                ROM rom = CoreState.ROM;
+                if (rom != null && U.isSafetyOffset(_vm.CurrentAddr + 3, rom))
+                {
+                    _vm.UnitListPointer = rom.u32(_vm.CurrentAddr);
+                    _vm.IsZeroPointer = !U.isSafetyPointer(_vm.UnitListPointer);
+                    _vm.LoadSpellList(rom);
+                }
+                UpdateUI();
+                if (_vm.SpellEntries.Count > 0) N1EntryList.SelectedIndex = 0;
             }
             catch (Exception ex)
             {
@@ -231,7 +249,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _undoService.Begin("Expand Spell Menu Extensions List");
                 try
                 {
-                    bool ok = _vm.ExpandN1List(newCount);
+                    bool ok = _vm.ExpandN1List(newCount, _undoService.GetActiveUndoData());
                     if (!ok)
                     {
                         _undoService.Rollback();

--- a/FEBuilderGBA.Core.Tests/FE8SpellMenuExtendsTests.cs
+++ b/FEBuilderGBA.Core.Tests/FE8SpellMenuExtendsTests.cs
@@ -230,11 +230,12 @@ namespace FEBuilderGBA.Core.Tests
                 ROM rom = MakeFE8URom();
                 PlantPatch(rom);
                 PlantUnitList(rom, 2, ListBase, new (byte, byte)[] { (0x05, 0x10), (0x0A, 0x11) });
-                // ExpandSpellList writes via RecycleAddress -> CoreState.ROM.
-                CoreState.ROM = rom;
 
-                // Drive it inside an ambient undo scope (the editor opens one via
-                // UndoService.Begin); the writes route through it exactly once.
+                // Copilot #1: ExpandSpellList must allocate/write into the PASSED
+                // rom (NOT CoreState.ROM). Point CoreState.ROM at a DIFFERENT ROM
+                // and assert the passed rom is the one that changes.
+                CoreState.ROM = MakeFE8URom();
+
                 var ud = new Undo.UndoData
                 {
                     time = System.DateTime.Now,
@@ -242,15 +243,13 @@ namespace FEBuilderGBA.Core.Tests
                     list = new System.Collections.Generic.List<Undo.UndoPostion>(),
                     filesize = (uint)rom.Data.Length,
                 };
-                uint newBase;
-                using (ROM.BeginUndoScope(ud))
-                {
-                    newBase = FE8SpellMenuExtendsCore.ExpandSpellList(rom, UnitTableBase, 2, 4);
-                }
+                uint newBase = FE8SpellMenuExtendsCore.ExpandSpellList(rom, UnitTableBase, 2, 4, ud);
 
                 Assert.NotEqual(U.NOT_FOUND, newBase);
+                // Writes recorded into the EXPLICIT undodata (2: block + pointer).
+                Assert.Equal(2, ud.list.Count);
 
-                // The unit slot must now point at the new block.
+                // The PASSED rom's unit slot must now point at the new block.
                 uint slot = UnitTableBase + 2 * 4;
                 Assert.Equal(newBase, rom.p32(slot));
 
@@ -265,6 +264,34 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.Equal((byte)0x01, rom.u8(newBase + 6));
                 // Terminator after 4 entries (8 bytes).
                 Assert.Equal(0x0000u, rom.u16(newBase + 8));
+            }
+            finally { CoreState.ROM = prev; }
+        }
+
+        [Fact]
+        public void ExpandSpellList_DoesNotTouchCoreStateRom_WhenDifferentRomPassed()
+        {
+            // Copilot #1 regression: the passed rom and CoreState.ROM are distinct
+            // instances; only the PASSED rom may be mutated.
+            var prev = CoreState.ROM;
+            try
+            {
+                ROM passed = MakeFE8URom();
+                PlantPatch(passed);
+                PlantUnitList(passed, 1, ListBase, new (byte, byte)[] { (0x05, 0x10) });
+
+                ROM other = MakeFE8URom();   // CoreState.ROM — must stay untouched
+                PlantPatch(other);
+                PlantUnitList(other, 1, ListBase, new (byte, byte)[] { (0x05, 0x10) });
+                CoreState.ROM = other;
+                uint otherSlotBefore = other.u32(UnitTableBase + 1 * 4);
+
+                uint newBase = FE8SpellMenuExtendsCore.ExpandSpellList(passed, UnitTableBase, 1, 3, null);
+                Assert.NotEqual(U.NOT_FOUND, newBase);
+
+                // Passed rom changed; CoreState.ROM's same slot is byte-identical.
+                Assert.Equal(newBase, passed.p32(UnitTableBase + 1 * 4));
+                Assert.Equal(otherSlotBefore, other.u32(UnitTableBase + 1 * 4));
             }
             finally { CoreState.ROM = prev; }
         }

--- a/FEBuilderGBA.Core.Tests/FE8SpellMenuExtendsTests.cs
+++ b/FEBuilderGBA.Core.Tests/FE8SpellMenuExtendsTests.cs
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Core tests for the FE8 SkillSystems spell-menu patch (issue #1167):
+//   - FE8SpellMenuPatchScanner.FindFE8SpellPatchPointer (SkillSystems202201
+//     hard-coded-signature path — no external .dmp needed).
+//   - FE8SpellMenuExtendsCore read/write/expand + MakeB0/SplitB0 + Export/Import.
+//
+// Each test plants the WF byte signature into a synthetic FE8U ROM and asserts
+// the scanner + Core helpers resolve/round-trip the planted data. No patched
+// ROM file is required.
+using System;
+using System.IO;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class FE8SpellMenuExtendsTests
+    {
+        // SkillSystems202201 SpellsGetter signature (the 44-byte run GrepEnd
+        // lands AFTER). Must match FE8SpellMenuPatchScanner.s_SpellsGetter202201.
+        static readonly byte[] SpellsGetter202201 = new byte[]
+        {
+            0x9E, 0x42, 0x04, 0xDA, 0x02, 0x34, 0xEF, 0xE7,
+            0x00, 0x9A, 0x9A, 0x42, 0xFA, 0xD1, 0x01, 0x9B,
+            0x01, 0x33, 0x03, 0xD1, 0x63, 0x78, 0x2B, 0x70,
+            0x01, 0x35, 0xF3, 0xE7, 0x60, 0x78, 0xFF, 0xF7,
+            0xBB, 0xFF, 0x01, 0x9B, 0x98, 0x42, 0xED, 0xD1,
+            0xF4, 0xE7, 0xC0, 0x46,
+        };
+
+        // Plant the signature well past FE8U compress_image_borderline_address
+        // (0xDB000) and 4-byte aligned (GrepEnd uses blocksize 4).
+        const uint SigPos = 0xB10000;
+        const uint UnitTableBase = 0xC00000;
+        const uint ListBase = 0xC10000;
+
+        static ROM MakeFE8URom(int size = 0x1000000)
+        {
+            var rom = new ROM();
+            byte[] data = new byte[size];
+            for (int i = 0; i < data.Length; i++) data[i] = 0xFF;
+            rom.LoadLow("synth-fe8spellmenu.gba", data, "BE8E01");
+            return rom;
+        }
+
+        static void WriteBytes(ROM rom, uint addr, byte[] bytes)
+        {
+            for (int i = 0; i < bytes.Length; i++)
+                rom.write_u8(addr + (uint)i, bytes[i]);
+        }
+
+        static void WriteU32(ROM rom, uint addr, uint value)
+        {
+            rom.write_u8(addr + 0, (byte)(value & 0xFF));
+            rom.write_u8(addr + 1, (byte)((value >> 8) & 0xFF));
+            rom.write_u8(addr + 2, (byte)((value >> 16) & 0xFF));
+            rom.write_u8(addr + 3, (byte)((value >> 24) & 0xFF));
+        }
+
+        /// <summary>
+        /// Plant the SpellsGetter signature + the assignLevelUpP slot (which
+        /// GrepEnd lands on, right after the 44-byte run) pointing at the
+        /// per-unit pointer-table base. Returns the assignLevelUpP slot address.
+        /// </summary>
+        static uint PlantPatch(ROM rom)
+        {
+            WriteBytes(rom, SigPos, SpellsGetter202201);
+            uint assignLevelUpP = SigPos + (uint)SpellsGetter202201.Length; // GrepEnd plus=0
+            WriteU32(rom, assignLevelUpP, UnitTableBase | 0x08000000u);
+            return assignLevelUpP;
+        }
+
+        /// <summary>Plant a per-unit pointer at unitTableBase + 4*unitId -> listBase,
+        /// and a 0x0000-terminated [B0|B1] array at listBase.</summary>
+        static void PlantUnitList(ROM rom, uint unitId, uint listBase, (byte b0, byte b1)[] entries)
+        {
+            uint slot = UnitTableBase + unitId * 4;
+            WriteU32(rom, slot, listBase | 0x08000000u);
+            uint cursor = listBase;
+            foreach (var (b0, b1) in entries)
+            {
+                rom.write_u8(cursor + 0, b0);
+                rom.write_u8(cursor + 1, b1);
+                cursor += 2;
+            }
+            rom.write_u16(cursor, 0x0000); // terminator
+        }
+
+        // -----------------------------------------------------------------
+        // Scanner — resolves the planted assignLevelUpP slot
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void FindFE8SpellPatchPointer_ResolvesPlantedSignature()
+        {
+            ROM rom = MakeFE8URom();
+            uint expectedSlot = PlantPatch(rom);
+
+            uint resolved = FE8SpellMenuPatchScanner.FindFE8SpellPatchPointer(rom, null);
+            Assert.Equal(expectedSlot, resolved);
+            Assert.Equal(UnitTableBase, U.toOffset(rom.u32(resolved)));
+        }
+
+        [Fact]
+        public void FindFE8SpellPatchPointer_NotFoundOnVanillaRom()
+        {
+            ROM rom = MakeFE8URom();
+            Assert.Equal(U.NOT_FOUND, FE8SpellMenuPatchScanner.FindFE8SpellPatchPointer(rom, null));
+        }
+
+        [Fact]
+        public void FindFE8SpellPatchPointer_NullRom_ReturnsNotFound()
+        {
+            Assert.Equal(U.NOT_FOUND, FE8SpellMenuPatchScanner.FindFE8SpellPatchPointer(null, null));
+        }
+
+        // -----------------------------------------------------------------
+        // Guards — version != 8 and is_multibyte both yield NOT_FOUND
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void FindFE8SpellPatchPointer_NonFE8Rom_ReturnsNotFound()
+        {
+            // FE7U: version != 8. Plant the signature anyway — the version guard
+            // must short-circuit before the grep.
+            var rom = new ROM();
+            byte[] data = new byte[0x1000000];
+            for (int i = 0; i < data.Length; i++) data[i] = 0xFF;
+            rom.LoadLow("synth-fe7u.gba", data, "AE7E01");
+            WriteBytes(rom, SigPos, SpellsGetter202201);
+
+            Assert.NotEqual(8, (int)rom.RomInfo.version);
+            Assert.Equal(U.NOT_FOUND, FE8SpellMenuPatchScanner.FindFE8SpellPatchPointer(rom, null));
+        }
+
+        [Fact]
+        public void FindFE8SpellPatchPointer_MultibyteRom_ReturnsNotFound()
+        {
+            // FE8J is multibyte. The is_multibyte guard must short-circuit.
+            var rom = new ROM();
+            byte[] data = new byte[0x1000000];
+            for (int i = 0; i < data.Length; i++) data[i] = 0xFF;
+            rom.LoadLow("synth-fe8j.gba", data, "BE8J01");
+            WriteBytes(rom, SigPos, SpellsGetter202201);
+
+            if (rom.RomInfo.is_multibyte)
+            {
+                Assert.Equal(U.NOT_FOUND, FE8SpellMenuPatchScanner.FindFE8SpellPatchPointer(rom, null));
+            }
+        }
+
+        // -----------------------------------------------------------------
+        // Core — unit table base + slot resolution + N1 read
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void GetUnitTableBase_ResolvesDereferencedBase()
+        {
+            ROM rom = MakeFE8URom();
+            uint slot = PlantPatch(rom);
+            Assert.Equal(UnitTableBase, FE8SpellMenuExtendsCore.GetUnitTableBase(rom, slot));
+        }
+
+        [Fact]
+        public void ReadSpellList_ReadsB0B1UntilTerminator()
+        {
+            ROM rom = MakeFE8URom();
+            PlantPatch(rom);
+            PlantUnitList(rom, 3, ListBase, new (byte, byte)[]
+            {
+                (0x05, 0x10), (0x8A, 0x11), (0x14, 0x12),
+            });
+
+            var list = FE8SpellMenuExtendsCore.ReadSpellList(rom, ListBase);
+            Assert.Equal(3, list.Count);
+            Assert.Equal((0x05u, 0x10u), (list[0].b0, list[0].b1));
+            Assert.Equal((0x8Au, 0x11u), (list[1].b0, list[1].b1));
+            Assert.Equal((0x14u, 0x12u), (list[2].b0, list[2].b1));
+        }
+
+        // -----------------------------------------------------------------
+        // MakeB0 / SplitB0 — level | promoted round-trip
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void MakeB0_SplitB0_RoundTrip()
+        {
+            // Promoted level 10 -> 0x8A.
+            byte b0 = FE8SpellMenuExtendsCore.MakeB0(10, true);
+            Assert.Equal((byte)0x8A, b0);
+            FE8SpellMenuExtendsCore.SplitB0(b0, out uint level, out bool promoted);
+            Assert.Equal(10u, level);
+            Assert.True(promoted);
+
+            // Unpromoted level 20 -> 0x14.
+            byte b0b = FE8SpellMenuExtendsCore.MakeB0(20, false);
+            Assert.Equal((byte)0x14, b0b);
+            FE8SpellMenuExtendsCore.SplitB0(b0b, out uint level2, out bool promoted2);
+            Assert.Equal(20u, level2);
+            Assert.False(promoted2);
+        }
+
+        // -----------------------------------------------------------------
+        // WriteN1Entry — round-trips a (B0,B1) pair in place
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void WriteN1Entry_RoundTrips()
+        {
+            ROM rom = MakeFE8URom();
+            PlantPatch(rom);
+            PlantUnitList(rom, 1, ListBase, new (byte, byte)[] { (0x05, 0x10) });
+
+            uint b0 = FE8SpellMenuExtendsCore.MakeB0(7, true); // 0x87
+            Assert.True(FE8SpellMenuExtendsCore.WriteN1Entry(rom, ListBase, b0, 0x22));
+            Assert.Equal((byte)0x87, rom.u8(ListBase + 0));
+            Assert.Equal((byte)0x22, rom.u8(ListBase + 1));
+        }
+
+        // -----------------------------------------------------------------
+        // ExpandSpellList — re-terminates with 0x0000 and repoints the slot
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void ExpandSpellList_AllocatesTerminatedBlockAndRepoints()
+        {
+            var prev = CoreState.ROM;
+            try
+            {
+                ROM rom = MakeFE8URom();
+                PlantPatch(rom);
+                PlantUnitList(rom, 2, ListBase, new (byte, byte)[] { (0x05, 0x10), (0x0A, 0x11) });
+                // ExpandSpellList writes via RecycleAddress -> CoreState.ROM.
+                CoreState.ROM = rom;
+
+                // Drive it inside an ambient undo scope (the editor opens one via
+                // UndoService.Begin); the writes route through it exactly once.
+                var ud = new Undo.UndoData
+                {
+                    time = System.DateTime.Now,
+                    name = "expand",
+                    list = new System.Collections.Generic.List<Undo.UndoPostion>(),
+                    filesize = (uint)rom.Data.Length,
+                };
+                uint newBase;
+                using (ROM.BeginUndoScope(ud))
+                {
+                    newBase = FE8SpellMenuExtendsCore.ExpandSpellList(rom, UnitTableBase, 2, 4);
+                }
+
+                Assert.NotEqual(U.NOT_FOUND, newBase);
+
+                // The unit slot must now point at the new block.
+                uint slot = UnitTableBase + 2 * 4;
+                Assert.Equal(newBase, rom.p32(slot));
+
+                // First two entries preserved; the block is 0x0000-terminated
+                // after `newCount` (4) entries.
+                Assert.Equal((byte)0x05, rom.u8(newBase + 0));
+                Assert.Equal((byte)0x10, rom.u8(newBase + 1));
+                Assert.Equal((byte)0x0A, rom.u8(newBase + 2));
+                Assert.Equal((byte)0x11, rom.u8(newBase + 3));
+                // Entries 3 and 4 are new defaults (level 1, skill 0).
+                Assert.Equal((byte)0x01, rom.u8(newBase + 4));
+                Assert.Equal((byte)0x01, rom.u8(newBase + 6));
+                // Terminator after 4 entries (8 bytes).
+                Assert.Equal(0x0000u, rom.u16(newBase + 8));
+            }
+            finally { CoreState.ROM = prev; }
+        }
+
+        // -----------------------------------------------------------------
+        // Export / Import round-trip
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void ExportImport_RoundTripsPerUnitEntries()
+        {
+            ROM rom = MakeFE8URom();
+            uint slot = PlantPatch(rom);
+            PlantUnitList(rom, 1, ListBase, new (byte, byte)[] { (0x05, 0x10), (0x0A, 0x11) });
+
+            string path = Path.GetTempFileName();
+            try
+            {
+                bool exportOk = FE8SpellMenuExtendsCore.ExportAllData(rom, slot, 4, path);
+                Assert.True(exportOk);
+
+                string[] lines = File.ReadAllLines(path);
+                Assert.Equal(4, lines.Length);
+                // Unit 1's line: offset \t 05 \t 10 \t 0A \t 11
+                string[] sp1 = lines[1].Split('\t');
+                Assert.True(sp1.Length >= 5);
+                Assert.Equal("05", sp1[1]);
+                Assert.Equal("10", sp1[2]);
+                Assert.Equal("0A", sp1[3]);
+                Assert.Equal("11", sp1[4]);
+
+                // Mutate the ROM, then re-import to restore the exported values.
+                rom.write_u8(ListBase + 0, 0x77);
+                rom.write_u8(ListBase + 1, 0x88);
+
+                bool importOk = FE8SpellMenuExtendsCore.ImportAllData(rom, slot, 4, path);
+                Assert.True(importOk);
+                Assert.Equal((byte)0x05, rom.u8(ListBase + 0));
+                Assert.Equal((byte)0x10, rom.u8(ListBase + 1));
+            }
+            finally
+            {
+                if (File.Exists(path)) File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void Export_NotFoundPatch_ReturnsFalse()
+        {
+            ROM rom = MakeFE8URom(); // no signature planted
+            Assert.False(FE8SpellMenuExtendsCore.ExportAllData(rom, U.NOT_FOUND, 4, "ignored.tsv"));
+        }
+
+        [Fact]
+        public void Import_MissingFile_ReturnsFalse()
+        {
+            ROM rom = MakeFE8URom();
+            uint slot = PlantPatch(rom);
+            string path = Path.Combine(Path.GetTempPath(), "fe8spell-missing-" + Guid.NewGuid() + ".tsv");
+            Assert.False(File.Exists(path));
+            Assert.False(FE8SpellMenuExtendsCore.ImportAllData(rom, slot, 4, path));
+        }
+    }
+}

--- a/FEBuilderGBA.Core/FE8SpellMenuExtendsCore.cs
+++ b/FEBuilderGBA.Core/FE8SpellMenuExtendsCore.cs
@@ -125,20 +125,24 @@ namespace FEBuilderGBA
         /// <summary>
         /// Expand a unit's spell list to <paramref name="newCount"/> entries
         /// (each B0|B1). A fresh block of (newCount * 2) + 2 bytes is allocated
-        /// in free space (the +2 is the 0x0000 terminator), the existing entries
-        /// are copied, and the unit's pointer slot is repointed at the new block.
-        /// Mirrors WF N1_InputFormRef_AddressListExpandsEvent (allocate a new
+        /// in free space of the PASSED <paramref name="rom"/> (the +2 is the
+        /// 0x0000 terminator), the existing entries are copied, and the unit's
+        /// pointer slot is repointed at the new block. Mirrors WF
+        /// N1_InputFormRef_AddressListExpandsEvent (allocate a new
         /// 0x0000-terminated block + repoint the unit slot).
         ///
-        /// The caller MUST open an ambient UndoService scope first; every write
-        /// here routes through the ambient RecycleAddress overload so the active
-        /// undo scope records each write exactly once.
+        /// All allocation and writes go to the EXPLICIT <paramref name="rom"/>
+        /// (NOT CoreState.ROM) and are recorded into the EXPLICIT
+        /// <paramref name="undodata"/> — honouring this class's "no CoreState"
+        /// contract. The View opens the UndoService scope and hands its active
+        /// UndoData here; pass null to write without undo capture.
         /// </summary>
         /// <returns>The new block OFFSET on success, or NOT_FOUND on failure
         /// (no ROM, unsafe slot, zero/oversized count, or free-space exhaustion).</returns>
-        public static uint ExpandSpellList(ROM rom, uint unitTableBase, uint unitId, uint newCount)
+        public static uint ExpandSpellList(ROM rom, uint unitTableBase, uint unitId, uint newCount,
+            Undo.UndoData undodata)
         {
-            if (rom == null) return U.NOT_FOUND;
+            if (rom == null || rom.Data == null) return U.NOT_FOUND;
             uint slot = GetUnitSlotAddr(unitTableBase, unitId);
             if (!U.isSafetyOffset(slot + 3, rom)) return U.NOT_FOUND;
             if (newCount == 0 || newCount > N1_MAX_ROWS) return U.NOT_FOUND;
@@ -171,9 +175,34 @@ namespace FEBuilderGBA
             }
             // Trailing two bytes already 0x00 0x00 → the terminator.
 
-            var ra = new RecycleAddress();
-            uint newAddr = ra.WriteAndWritePointerAmbient(slot, buffer);
-            if (newAddr == U.NOT_FOUND) return U.NOT_FOUND;
+            // Allocate against the PASSED rom (upper half, then lower half,
+            // then resize the tail) — a CoreState-free re-implementation of the
+            // RecycleAddress freespace fallback.
+            uint searchStart = (uint)(rom.Data.Length / 2);
+            uint newAddr = rom.FindFreeSpace(searchStart, (uint)buffer.Length);
+            if (newAddr == U.NOT_FOUND)
+            {
+                newAddr = rom.FindFreeSpace(0x100u, (uint)buffer.Length);
+            }
+            if (newAddr == U.NOT_FOUND)
+            {
+                uint newSize = U.Padding4((uint)rom.Data.Length + (uint)buffer.Length);
+                if (newSize > 0x02000000u) return U.NOT_FOUND;
+                uint tail = (uint)rom.Data.Length;
+                if (!rom.write_resize_data(newSize)) return U.NOT_FOUND;
+                newAddr = tail;
+            }
+
+            if (undodata != null)
+            {
+                rom.write_range(newAddr, buffer, undodata);
+                rom.write_p32(slot, newAddr, undodata);
+            }
+            else
+            {
+                rom.write_range(newAddr, buffer);
+                rom.write_p32(slot, newAddr);
+            }
             return newAddr;
         }
 

--- a/FEBuilderGBA.Core/FE8SpellMenuExtendsCore.cs
+++ b/FEBuilderGBA.Core/FE8SpellMenuExtendsCore.cs
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Core-side read/write logic for the FE8 SkillSystems spell-menu (Gaiden-style
+// spell list) patch. Mirrors WinForms FE8SpellMenuExtendsForm's master/detail
+// model so the Avalonia editor and CLI share one implementation (issue #1167).
+//
+// Data model (mirrors WF):
+//   - assignLevelUpP  : a u32 pointer slot resolved by FE8SpellMenuPatchScanner.
+//   - *assignLevelUpP : the PER-UNIT pointer-table base. Slot at base + 4*unit
+//                       is a u32 GBA pointer to unit `unit`'s spell-list block.
+//   - spell-list block: a 0x0000-terminated u16 array. Each u16 entry:
+//                         B0 (u8 @+0) = level | promoted-flag (0x80)
+//                         B1 (u8 @+1) = item / spell id
+//
+// MakeB0 / SplitB0 mirror WF FE8SpellMenuExtendsForm.MakeB0 and the
+// N1_B0_ValueChanged split exactly (Level = B0 & 0x7F, Promoted = B0 & 0x80).
+//
+// No CoreState reads. All entry points take an explicit ROM parameter.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace FEBuilderGBA
+{
+    public static class FE8SpellMenuExtendsCore
+    {
+        public const uint MASTER_BLOCK_SIZE = 4;   // per-unit u32 pointer slot
+        public const uint N1_BLOCK_SIZE = 2;       // u16 [B0|B1] entry
+        public const uint UNIT_MAX_ROWS = 0xFF;    // WF read-max predicate (i < 0xFF)
+        public const uint N1_MAX_ROWS = 1024;       // safety cap for sub-list walk
+        public const byte PROMOTED_BIT = 0x80;
+        public const byte LEVEL_MASK = 0x7F;
+
+        /// <summary>Compose a B0 byte from a level (0..0x7F) + promoted flag.
+        /// Faithful to WF FE8SpellMenuExtendsForm.MakeB0.</summary>
+        public static byte MakeB0(uint level, bool promoted)
+        {
+            byte b0 = (byte)(level & LEVEL_MASK);
+            if (promoted)
+            {
+                b0 |= PROMOTED_BIT;
+            }
+            return b0;
+        }
+
+        /// <summary>Split a B0 byte into level (B0 &amp; 0x7F) and promoted
+        /// (B0 &amp; 0x80). Faithful to WF N1_B0_ValueChanged.</summary>
+        public static void SplitB0(uint b0, out uint level, out bool promoted)
+        {
+            level = b0 & LEVEL_MASK;
+            promoted = (b0 & PROMOTED_BIT) == PROMOTED_BIT;
+        }
+
+        /// <summary>
+        /// Resolve the per-unit pointer-table base (= *assignLevelUpP). Returns
+        /// NOT_FOUND when the slot or its dereference is unsafe.
+        /// </summary>
+        public static uint GetUnitTableBase(ROM rom, uint assignLevelUpP)
+        {
+            if (rom == null || assignLevelUpP == U.NOT_FOUND) return U.NOT_FOUND;
+            if (!U.isSafetyOffset(assignLevelUpP + 3, rom)) return U.NOT_FOUND;
+            uint baseAddr = rom.p32(assignLevelUpP);
+            if (!U.isSafetyOffset(baseAddr, rom)) return U.NOT_FOUND;
+            return baseAddr;
+        }
+
+        /// <summary>Address of unit <paramref name="unitId"/>'s u32 pointer slot
+        /// (unitTableBase + 4*unitId).</summary>
+        public static uint GetUnitSlotAddr(uint unitTableBase, uint unitId)
+        {
+            return unitTableBase + unitId * MASTER_BLOCK_SIZE;
+        }
+
+        /// <summary>
+        /// Read the spell-list block for one unit. Returns the list of (b0, b1)
+        /// pairs walking the 0x0000-terminated u16 array starting at
+        /// <paramref name="listBase"/>. Stops on a 0x0000 / 0xFFFF u16, an unsafe
+        /// offset, or N1_MAX_ROWS — never throws.
+        /// </summary>
+        public static List<(uint addr, uint b0, uint b1)> ReadSpellList(ROM rom, uint listBase)
+        {
+            var result = new List<(uint, uint, uint)>();
+            if (rom == null) return result;
+            if (!U.isSafetyOffset(listBase, rom)) return result;
+
+            uint cursor = listBase;
+            for (uint n = 0; n < N1_MAX_ROWS; n++, cursor += N1_BLOCK_SIZE)
+            {
+                if (!U.isSafetyOffset(cursor + 1, rom)) break;
+                uint pair = rom.u16(cursor);
+                if (pair == 0x0000 || pair == 0xFFFF) break;
+                uint b0 = rom.u8(cursor + 0);
+                uint b1 = rom.u8(cursor + 1);
+                result.Add((cursor, b0, b1));
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Write a single N1 (B0,B1) entry in place. Returns false (no write)
+        /// when the address is unsafe.
+        /// </summary>
+        public static bool WriteN1Entry(ROM rom, uint entryAddr, uint b0, uint b1)
+        {
+            if (rom == null) return false;
+            if (!U.isSafetyOffset(entryAddr + 1, rom)) return false;
+            rom.write_u8(entryAddr + 0, b0);
+            rom.write_u8(entryAddr + 1, b1);
+            return true;
+        }
+
+        /// <summary>
+        /// Write the per-unit pointer slot to point at <paramref name="listOffset"/>.
+        /// Mirrors WF WriteButton_Click (write_p32). Returns false on unsafe slot.
+        /// </summary>
+        public static bool WriteUnitPointer(ROM rom, uint unitTableBase, uint unitId, uint listOffset)
+        {
+            if (rom == null) return false;
+            uint slot = GetUnitSlotAddr(unitTableBase, unitId);
+            if (!U.isSafetyOffset(slot + 3, rom)) return false;
+            rom.write_p32(slot, U.toOffset(listOffset));
+            return true;
+        }
+
+        /// <summary>
+        /// Expand a unit's spell list to <paramref name="newCount"/> entries
+        /// (each B0|B1). A fresh block of (newCount * 2) + 2 bytes is allocated
+        /// in free space (the +2 is the 0x0000 terminator), the existing entries
+        /// are copied, and the unit's pointer slot is repointed at the new block.
+        /// Mirrors WF N1_InputFormRef_AddressListExpandsEvent (allocate a new
+        /// 0x0000-terminated block + repoint the unit slot).
+        ///
+        /// The caller MUST open an ambient UndoService scope first; every write
+        /// here routes through the ambient RecycleAddress overload so the active
+        /// undo scope records each write exactly once.
+        /// </summary>
+        /// <returns>The new block OFFSET on success, or NOT_FOUND on failure
+        /// (no ROM, unsafe slot, zero/oversized count, or free-space exhaustion).</returns>
+        public static uint ExpandSpellList(ROM rom, uint unitTableBase, uint unitId, uint newCount)
+        {
+            if (rom == null) return U.NOT_FOUND;
+            uint slot = GetUnitSlotAddr(unitTableBase, unitId);
+            if (!U.isSafetyOffset(slot + 3, rom)) return U.NOT_FOUND;
+            if (newCount == 0 || newCount > N1_MAX_ROWS) return U.NOT_FOUND;
+
+            // Read the existing entries so the expand preserves them.
+            uint oldListBase = rom.p32(slot);
+            var existing = U.isSafetyOffset(oldListBase, rom)
+                ? ReadSpellList(rom, oldListBase)
+                : new List<(uint addr, uint b0, uint b1)>();
+
+            // Build the new block: newCount entries (copied where available,
+            // 0x0001/0x00 default otherwise) + a 0x0000 u16 terminator.
+            int blockBytes = (int)(newCount * N1_BLOCK_SIZE + N1_BLOCK_SIZE);
+            byte[] buffer = new byte[blockBytes];
+            for (uint n = 0; n < newCount; n++)
+            {
+                int off = (int)(n * N1_BLOCK_SIZE);
+                if (n < existing.Count)
+                {
+                    buffer[off + 0] = (byte)existing[(int)n].b0;
+                    buffer[off + 1] = (byte)existing[(int)n].b1;
+                }
+                else
+                {
+                    // New rows default to level 1, skill 0 (non-zero B0 so the
+                    // row is not mistaken for the terminator at read time).
+                    buffer[off + 0] = 0x01;
+                    buffer[off + 1] = 0x00;
+                }
+            }
+            // Trailing two bytes already 0x00 0x00 → the terminator.
+
+            var ra = new RecycleAddress();
+            uint newAddr = ra.WriteAndWritePointerAmbient(slot, buffer);
+            if (newAddr == U.NOT_FOUND) return U.NOT_FOUND;
+            return newAddr;
+        }
+
+        /// <summary>
+        /// Export the entire spell-menu table to a TSV file: one line per unit,
+        /// tab-separated, the per-unit list OFFSET followed by [b0 b1] pairs.
+        ///   unit_list_offset_hex   [b0_hex b1_hex]*
+        /// Mirrors the WF MakeAllDataLength enumeration shape (per-unit blocks).
+        /// </summary>
+        public static bool ExportAllData(ROM rom, uint assignLevelUpP, uint unitCount, string filename)
+        {
+            if (rom == null || rom.Data == null) return false;
+            if (string.IsNullOrEmpty(filename)) return false;
+            uint unitTableBase = GetUnitTableBase(rom, assignLevelUpP);
+            if (unitTableBase == U.NOT_FOUND) return false;
+
+            try
+            {
+                var lines = new List<string>();
+                for (uint i = 0; i < unitCount; i++)
+                {
+                    uint slot = GetUnitSlotAddr(unitTableBase, i);
+                    if (!U.isSafetyOffset(slot + 3, rom)) break;
+
+                    var sb = new StringBuilder();
+                    uint listOffset = rom.p32(slot);
+                    sb.Append(U.ToHexString(listOffset));
+
+                    if (U.isSafetyOffset(listOffset, rom))
+                    {
+                        foreach (var (addr, b0, b1) in ReadSpellList(rom, listOffset))
+                        {
+                            sb.Append('\t');
+                            sb.Append(U.ToHexString(b0));
+                            sb.Append('\t');
+                            sb.Append(U.ToHexString(b1));
+                        }
+                    }
+                    lines.Add(sb.ToString());
+                }
+                File.WriteAllLines(filename, lines);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Import the spell-menu table from a TSV file produced by
+        /// <see cref="ExportAllData"/>. Walks each unit's EXISTING referenced
+        /// spell-list block and writes the [b0 b1] pairs in place (shared-table
+        /// mutation; the per-unit pointer is left untouched). Stops a unit early
+        /// if the existing block terminates before the TSV pairs are exhausted.
+        /// </summary>
+        public static bool ImportAllData(ROM rom, uint assignLevelUpP, uint unitCount, string filename)
+        {
+            if (rom == null || rom.Data == null) return false;
+            if (string.IsNullOrEmpty(filename) || !File.Exists(filename)) return false;
+            uint unitTableBase = GetUnitTableBase(rom, assignLevelUpP);
+            if (unitTableBase == U.NOT_FOUND) return false;
+
+            try
+            {
+                string[] lines = File.ReadAllLines(filename);
+                if (lines == null) return false;
+
+                for (uint i = 0; i < unitCount; i++)
+                {
+                    if (i >= lines.Length) break;
+                    uint slot = GetUnitSlotAddr(unitTableBase, i);
+                    if (!U.isSafetyOffset(slot + 3, rom)) break;
+
+                    string[] sp = lines[i].Split('\t');
+                    if (sp.Length < 1) continue;
+
+                    uint listOffset = rom.p32(slot);
+                    if (!U.isSafetyOffset(listOffset, rom)) continue;
+
+                    uint cursor = listOffset;
+                    int pairCount = (sp.Length - 1) / 2;
+                    for (int n = 0; n < pairCount && n < (int)N1_MAX_ROWS; n++, cursor += N1_BLOCK_SIZE)
+                    {
+                        if (!U.isSafetyOffset(cursor + 1, rom)) break;
+                        // Mirror the read terminator: never write past the
+                        // existing 0x0000-terminated block.
+                        uint pair = rom.u16(cursor);
+                        if (pair == 0x0000 || pair == 0xFFFF) break;
+                        uint b0 = U.atoh(sp[1 + n * 2 + 0]);
+                        uint b1 = U.atoh(sp[1 + n * 2 + 1]);
+                        rom.write_u8(cursor + 0, b0);
+                        rom.write_u8(cursor + 1, b1);
+                    }
+                }
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Core/FE8SpellMenuPatchScanner.cs
+++ b/FEBuilderGBA.Core/FE8SpellMenuPatchScanner.cs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Core-side ROM byte-pattern scanner for the FE8 SkillSystems spell-menu
+// (Gaiden-style spell list) patch. Mirrors the WinForms
+// FE8SpellMenuExtendsForm.FindFE8SpellPatchPointerLow helpers so the byte
+// tables live in one place and the resolution is reusable from the CLI and
+// Avalonia projects (issue #1167).
+//
+// No CoreState reads. All entry points take an explicit ROM + base directory
+// so the scanner is headless-testable. The OldSystem path needs an external
+// .dmp from config/patch2; it degrades to NOT_FOUND when the file is missing.
+// The SkillSystems202201 path uses a hard-coded 44-byte signature (no external
+// file) — it is the path provable on a synthetic ROM.
+using System;
+using System.IO;
+
+namespace FEBuilderGBA
+{
+    public static class FE8SpellMenuPatchScanner
+    {
+        public const uint NOT_FOUND = U.NOT_FOUND;
+
+        // SkillSystems202201 signature: the bytes that immediately precede the
+        // assignLevelUpP pointer slot in the SpellsGetter routine. GrepEnd lands
+        // on the 4-byte pointer slot right after this 44-byte run. This path
+        // needs no external file, so it is the synthetic-test path. (Faithful
+        // copy of WF FindFE8SpellPatchPointerLow_SkillSystems202201.)
+        static readonly byte[] s_SpellsGetter202201 = new byte[]
+        {
+            0x9E, 0x42, 0x04, 0xDA, 0x02, 0x34, 0xEF, 0xE7,
+            0x00, 0x9A, 0x9A, 0x42, 0xFA, 0xD1, 0x01, 0x9B,
+            0x01, 0x33, 0x03, 0xD1, 0x63, 0x78, 0x2B, 0x70,
+            0x01, 0x35, 0xF3, 0xE7, 0x60, 0x78, 0xFF, 0xF7,
+            0xBB, 0xFF, 0x01, 0x9B, 0x98, 0x42, 0xED, 0xD1,
+            0xF4, 0xE7, 0xC0, 0x46,
+        };
+
+        /// <summary>
+        /// Resolve the address of the assignLevelUpP pointer slot for the FE8
+        /// SkillSystems spell-menu patch. Returns <see cref="NOT_FOUND"/> when:
+        /// the ROM is null, the ROM is not FE8 (RomInfo.version != 8), the ROM
+        /// is multibyte (is_multibyte), or neither the OldSystem .dmp grep nor
+        /// the hard-coded SkillSystems202201 signature matches.
+        ///
+        /// The returned value is the address of the u32 slot itself
+        /// (assignLevelUpP); *assignLevelUpP is the per-unit pointer-table base.
+        /// </summary>
+        /// <param name="rom">Target ROM (explicit; no CoreState read).</param>
+        /// <param name="baseDir">Base directory whose config/patch2 holds the
+        /// OldSystem SpellsGetter.dmp. May be null/empty — the OldSystem path is
+        /// then skipped and only the hard-coded signature path is tried.</param>
+        public static uint FindFE8SpellPatchPointer(ROM rom, string baseDir)
+        {
+            if (rom == null || rom.Data == null || rom.RomInfo == null)
+            {
+                return NOT_FOUND;
+            }
+            if (rom.RomInfo.version != 8)
+            {
+                return NOT_FOUND;
+            }
+            if (rom.RomInfo.is_multibyte)
+            {
+                return NOT_FOUND;
+            }
+
+            uint pointer = FindFE8SpellPatchPointer_OldSystem(rom, baseDir);
+            if (pointer != NOT_FOUND)
+            {
+                return pointer;
+            }
+            pointer = FindFE8SpellPatchPointer_SkillSystems202201(rom);
+            if (pointer != NOT_FOUND)
+            {
+                return pointer;
+            }
+            return NOT_FOUND;
+        }
+
+        static uint FindFE8SpellPatchPointer_OldSystem(ROM rom, string baseDir)
+        {
+            if (string.IsNullOrEmpty(baseDir))
+            {
+                return NOT_FOUND;
+            }
+            string spellsGetterDmp = Path.Combine(baseDir, "config", "patch2",
+                "FE8U", "FE8SpellMenu", "GaidenMagic", "SpellsGetter.dmp");
+            if (!File.Exists(spellsGetterDmp))
+            {
+                return NOT_FOUND;
+            }
+            byte[] sig;
+            try
+            {
+                sig = File.ReadAllBytes(spellsGetterDmp);
+            }
+            catch
+            {
+                return NOT_FOUND;
+            }
+            if (sig == null || sig.Length == 0)
+            {
+                return NOT_FOUND;
+            }
+            return U.GrepEnd(rom.Data, sig, rom.RomInfo.compress_image_borderline_address, 0, 4);
+        }
+
+        static uint FindFE8SpellPatchPointer_SkillSystems202201(ROM rom)
+        {
+            return U.GrepEnd(rom.Data, s_SpellsGetter202201,
+                rom.RomInfo.compress_image_borderline_address, 0, 4);
+        }
+    }
+}

--- a/FEBuilderGBA.Tests/Unit/AvaloniaFieldCompletenessTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AvaloniaFieldCompletenessTests.cs
@@ -242,6 +242,7 @@ namespace FEBuilderGBA.Tests.Unit
             ("SkillAssignmentUnitSkillSystemView", "SkillAssignmentUnitSkillSystemForm", "SkillAssignmentUnitSkillSystemViewModel"),
             ("SkillAssignmentClassSkillSystemView", "SkillAssignmentClassSkillSystemForm", "SkillAssignmentClassSkillSystemViewModel"),
             ("SkillConfigSkillSystemView", "SkillConfigSkillSystemForm", "SkillConfigSkillSystemViewModel"),
+            ("FE8SpellMenuExtendsView", "FE8SpellMenuExtendsForm", "FE8SpellMenuExtendsViewModel"),
             ("Command85PointerView", "Command85PointerForm", "Command85PointerViewModel"),
             ("MantAnimationView", "MantAnimationForm", "MantAnimationViewModel"),
 

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -12047,3 +12047,6 @@ Png2Dmp画像(.dmpヒントなし): {0}
 
 :This editor requires the FE8 SkillSystems Gaiden-style spell menu patch to be installed.
 このエディタを使用するには、FE8 SkillSystemsのガイデン式呪文メニューパッチがインストールされている必要があります。
+
+:Spell
+魔法

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -12041,3 +12041,9 @@ PROCSテーブル(長さ検出はWinForms専用): {0}
 :Png2Dmp image (no .dmp hint): {0}
 Png2Dmp画像(.dmpヒントなし): {0}
 
+
+:Promoted
+上級職
+
+:This editor requires the FE8 SkillSystems Gaiden-style spell menu patch to be installed.
+このエディタを使用するには、FE8 SkillSystemsのガイデン式呪文メニューパッチがインストールされている必要があります。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25882,3 +25882,9 @@ PROCS 表（长度检测仅限 WinForms）：{0}
 :Png2Dmp image (no .dmp hint): {0}
 Png2Dmp 图像（无 .dmp 提示）：{0}
 
+
+:Promoted
+高级职业
+
+:This editor requires the FE8 SkillSystems Gaiden-style spell menu patch to be installed.
+此编辑器需要安装 FE8 SkillSystems 外传式魔法菜单补丁才能使用。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25888,3 +25888,6 @@ Png2Dmp 图像（无 .dmp 提示）：{0}
 
 :This editor requires the FE8 SkillSystems Gaiden-style spell menu patch to be installed.
 此编辑器需要安装 FE8 SkillSystems 外传式魔法菜单补丁才能使用。
+
+:Spell
+魔法

--- a/docs/field-completeness-report.txt
+++ b/docs/field-completeness-report.txt
@@ -2,5 +2,5 @@
 Total WinForms fields: 1563
 Total Avalonia fields: 1812
 Total missing: 0
-Forms with gaps: 0 / 178
+Forms with gaps: 0 / 179
 


### PR DESCRIPTION
## Summary
Ports the **Spell Menu Extensions** editor (FE8 SkillSystems spell-menu) to functional parity (#1167) — a near-twin of the merged SkillAssignmentClassSkillSystem editor. The 57-line scaffold + 33-line dummy VM become a working master/detail editor over the FE8 spell-menu patch's per-unit level-up spell tables.

## Changes
- **`FE8SpellMenuPatchScanner.cs`** (NEW): `FindFE8SpellPatchPointer(rom, baseDir)` — version!=8 / is_multibyte → NOT_FOUND; the OldSystem `.dmp` path takes an explicit baseDir (degrades to NOT_FOUND if absent); the SkillSystems202201 44-byte hard-coded signature is the testable path (no external file).
- **`FE8SpellMenuExtendsCore.cs`** (NEW): per-unit u32 pointer table read/expand, N1 `0x0000`-terminated u16 `[B0|B1]` read/write, `MakeB0/SplitB0` (level | promoted 0x80), `ExpandSpellList`, Export/Import.
- `FE8SpellMenuExtendsViewModel` (stub → full master/detail, `IDataVerifiable`) + View (Grid(250,250,*) master `AddressListControl` + N1 list + detail: Level NUD, Promoted CheckBox, spell-id **hex TextBox** + item icon, master/N1 Write + expand, all writes under UndoService).
- `FE8SpellMenuExtendsTests.cs` (13 Core) + `FE8SpellMenuExtendsParityTests.cs` (12) + FormMappings/ListParity registration + ja/zh.

## Tests
- Core.Tests: **4394 passed**, 0 failed (synthetic: plant SkillSystems202201 signature → resolve assignLevelUpP slot → enumerate units → read B0/B1 + Level/Promoted split → WriteN1 round-trips MakeB0 → ExpandN1List re-terminates → Export/Import round-trip; guards return NOT_FOUND).
- Avalonia.Tests: **8367 passed**, 0 failed. FEBuilderGBA.Tests (windows): **1864 passed**, 0 failed. validate-automation-ids: **0/0/0**.

The editor is correctly empty on a vanilla FE8U (no patch); the synthetic Core + parity tests are the functional proof. Headless render screenshot + the new [Skill Systems wiki page](https://github.com/laqieer/FEBuilderGBA/wiki/Skill-Systems) (sources to populate it) below.

Fixes #1167

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
