### PR TITLE
fix(avalonia): Chinese Font Import-PNG 16x13 + perf/doc (post-merge #1166 review)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/FontZHViewImportParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/FontZHViewImportParityTests.cs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1166 follow-up — the Chinese (ZH) Font editor's PNG-import path. The merged
+// editor wired the per-glyph import through ImageImportService
+// .LoadAndRemapToExistingPalette, whose remap helper (LoadAndRemapFromFile)
+// hard-rejected any image whose width/height weren't multiples of 8. ZH glyphs are
+// 16x13 — height 13 is NOT a multiple of 8 — so a correctly-sized 16x13 PNG ALWAYS
+// failed with "Image dimensions must be multiples of 8". The fix threads a
+// requireTileMultiple flag (default true, like the #871 LoadAndQuantizeFromFile
+// path) and the View opts out with requireTileMultiple: false.
+//
+// Two layers, mirroring FontEditorViewModelTests:
+//   * Source-text parity — the service guards the %8 check + the View opts out.
+//   * Functional — a real 16x13 PNG loads + remaps to the 4-color ZH palette
+//     (no %8 rejection) and the indexed pixels import into a synthetic ZH ROM.
+using System;
+using System.IO;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Core;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class FontZHViewImportParityTests
+    {
+        static string? FindRepoRoot()
+        {
+            string start = AppDomain.CurrentDomain.BaseDirectory;
+            for (DirectoryInfo? dir = new DirectoryInfo(start); dir != null; dir = dir.Parent)
+            {
+                if (File.Exists(Path.Combine(dir.FullName, "FEBuilderGBA.sln")))
+                    return dir.FullName;
+            }
+            return null;
+        }
+
+        static string ReadRepoFile(params string[] parts)
+        {
+            string? root = FindRepoRoot();
+            Assert.NotNull(root);
+            string path = Path.Combine(root!, Path.Combine(parts));
+            Assert.True(File.Exists(path), $"Missing {path}");
+            return File.ReadAllText(path);
+        }
+
+        // ---------------- Source-text parity ----------------
+
+        [Fact]
+        public void Service_GuardsTileMultipleCheck_OnRemapPath()
+        {
+            string svc = ReadRepoFile("FEBuilderGBA.Avalonia", "Services", "ImageImportService.cs");
+            // Both remap overloads expose the opt-out flag (default keeps old behavior).
+            Assert.Contains("bool requireTileMultiple = true", svc);
+            // The remap %8 check is now GUARDED by the flag (was unconditional).
+            Assert.Contains("requireTileMultiple && (image.Width % 8 != 0 || image.Height % 8 != 0)", svc);
+        }
+
+        [Fact]
+        public void ZHView_ImportPng_OptsOutOfTileMultiple()
+        {
+            string cs = ReadRepoFile("FEBuilderGBA.Avalonia", "Views", "FontZHView.axaml.cs");
+            // The ZH import remaps onto the 4-color ZH palette AND opts out of the
+            // tile-size guard so a 16x13 (height 13) PNG is accepted.
+            Assert.Contains("LoadAndRemapToExistingPalette", cs);
+            Assert.Contains("GetFontPaletteGBA", cs);
+            Assert.Contains("requireTileMultiple: false", cs);
+        }
+
+        // ---------------- Functional: 16x13 round-trips the load+remap path ----------------
+
+        static IImageService EnsureImageService()
+        {
+            if (CoreState.ImageService == null)
+                CoreState.ImageService = new FEBuilderGBA.SkiaSharp.SkiaImageService();
+            return CoreState.ImageService;
+        }
+
+        // Build a 16x13 RGBA image painted with the 4 ZH serif-font colors (so the
+        // closest-color remap maps each pixel to a distinct 0..3 index) and save it.
+        static string Write16x13Png(IImageService svc, bool isItemFont)
+        {
+            // Mirror FontGlyphZHCore's fixed ZH palette ordering: bg / white / gray / black.
+            (byte R, byte G, byte B)[] rgb = isItemFont
+                ? new[] { ((byte)0x68, (byte)0x88, (byte)0xA8), ((byte)0xF8, (byte)0xF8, (byte)0xF8), ((byte)0xA8, (byte)0xA8, (byte)0xA7), ((byte)0x28, (byte)0x28, (byte)0x28) }
+                : new[] { ((byte)0xE0, (byte)0xE0, (byte)0xE0), ((byte)0xF8, (byte)0xF8, (byte)0xF8), ((byte)0xA8, (byte)0xA8, (byte)0xA7), ((byte)0x28, (byte)0x28, (byte)0x28) };
+
+            const int W = 16, H = 13;
+            using IImage img = svc.CreateImage(W, H);
+            byte[] rgba = new byte[W * H * 4];
+            for (int y = 0; y < H; y++)
+                for (int x = 0; x < W; x++)
+                {
+                    int idx = (x + y) & 0x03; // all 4 colors appear
+                    int po = (y * W + x) * 4;
+                    rgba[po + 0] = rgb[idx].R;
+                    rgba[po + 1] = rgb[idx].G;
+                    rgba[po + 2] = rgb[idx].B;
+                    rgba[po + 3] = 255;
+                }
+            img.SetPixelData(rgba);
+
+            string path = Path.Combine(Path.GetTempPath(), "fontzh_16x13_" + Guid.NewGuid().ToString("N") + ".png");
+            img.Save(path);
+            return path;
+        }
+
+        [Fact]
+        public void LoadAndRemap_16x13_Accepted_NoTileMultipleError()
+        {
+            var svc = EnsureImageService();
+            string png = Write16x13Png(svc, isItemFont: false);
+            try
+            {
+                byte[] pal = FontGlyphZHCore.GetFontPaletteGBA(isItemFont: false);
+                // requireTileMultiple:false — the 16x13 (height 13) image MUST load.
+                var lr = ImageImportService.LoadAndRemapFromFile(png,
+                    FontGlyphZHCore.GLYPH_W, FontGlyphZHCore.GLYPH_H, pal, 4,
+                    strictSize: true, requireTileMultiple: false);
+
+                Assert.True(lr.Success, lr.Error);
+                Assert.Equal(FontGlyphZHCore.GLYPH_W, lr.Width);
+                Assert.Equal(FontGlyphZHCore.GLYPH_H, lr.Height);
+                Assert.Equal(FontGlyphZHCore.GLYPH_W * FontGlyphZHCore.GLYPH_H, lr.IndexedPixels.Length);
+                foreach (byte b in lr.IndexedPixels)
+                    Assert.InRange(b, (byte)0, (byte)3); // stays in the 4-color range
+            }
+            finally { try { File.Delete(png); } catch { } }
+        }
+
+        [Fact]
+        public void LoadAndRemap_16x13_DefaultStillRejects()
+        {
+            // Regression guard: the DEFAULT (requireTileMultiple omitted) must still
+            // reject 16x13 so existing tile-based callers are unaffected.
+            var svc = EnsureImageService();
+            string png = Write16x13Png(svc, isItemFont: false);
+            try
+            {
+                byte[] pal = FontGlyphZHCore.GetFontPaletteGBA(isItemFont: false);
+                var lr = ImageImportService.LoadAndRemapFromFile(png,
+                    FontGlyphZHCore.GLYPH_W, FontGlyphZHCore.GLYPH_H, pal, 4, strictSize: true);
+                Assert.False(lr.Success);
+                Assert.Contains("multiples of 8", lr.Error);
+            }
+            finally { try { File.Delete(png); } catch { } }
+        }
+
+        // Full end-to-end: load a 16x13 PNG (requireTileMultiple:false) then feed the
+        // remapped indices into the Core import on a synthetic ZH ROM — proving the
+        // editor's import path now works for a correctly-sized ZH glyph PNG.
+        [Fact]
+        public void LoadAndRemap_Then_ImportGlyphZH_RoundTrips()
+        {
+            const uint ROM_LEN = 0x01000000;
+            const uint MOJI_TEN = 0x8181; // '、', codeB 0x54
+            var svc = EnsureImageService();
+
+            var prevRom = CoreState.ROM;
+            string png = Write16x13Png(svc, isItemFont: false);
+            try
+            {
+                var rom = new ROM();
+                byte[] data = new byte[ROM_LEN];
+                Array.Fill(data, (byte)0xFF);
+                for (uint i = 0; i < 0x600000; i++) data[i] = 0x00;
+                rom.LoadLow("synth.gba", data, "BE8J01"); // multibyte FE8J (ZH)
+                // Plant the serif glyph slot so the in-place import has a target.
+                uint top = FontGlyphZHCore.GetFontPointerZH(8, isItemFont: false);
+                uint addr = top + FontGlyphZHCore.CalcCodeB(MOJI_TEN);
+                U.write_u8(rom.Data, addr + 0, 0xD);
+                U.write_u8(rom.Data, addr + 1, 16);
+                U.write_u8(rom.Data, addr + 2, 0xD);
+                CoreState.ROM = rom;
+
+                byte[] pal = FontGlyphZHCore.GetFontPaletteGBA(isItemFont: false);
+                var lr = ImageImportService.LoadAndRemapFromFile(png,
+                    FontGlyphZHCore.GLYPH_W, FontGlyphZHCore.GLYPH_H, pal, 4,
+                    strictSize: true, requireTileMultiple: false);
+                Assert.True(lr.Success, lr.Error);
+
+                string err = FontGlyphZHCore.ImportGlyphZH(rom, isItemFont: false, MOJI_TEN,
+                    lr.IndexedPixels, lr.Width, lr.Height);
+                Assert.Equal("", err); // import succeeds — no "%8" / size rejection
+                // Header stays a valid ZH glyph struct.
+                Assert.Equal(0xDu, rom.u8(addr + 0));
+                Assert.Equal(0xDu, rom.u8(addr + 2));
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                try { File.Delete(png); } catch { }
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Services/ImageImportService.cs
+++ b/FEBuilderGBA.Avalonia/Services/ImageImportService.cs
@@ -153,24 +153,38 @@ namespace FEBuilderGBA.Avalonia.Services
         /// Used for editors that share a global palette (e.g. item icons, system icons).
         /// Returns null if user cancels.
         /// </summary>
+        /// <param name="requireTileMultiple">
+        /// When <c>true</c> (default), the image width and height must both be
+        /// multiples of 8 - required for tile-based sprite/graphic import. Pass
+        /// <c>false</c> for editors whose glyph is NOT a whole number of 8x8 tiles
+        /// (e.g. the 16x13 Chinese font glyph, #1166) - the closest-color remap in
+        /// <c>ImageImportCore.RemapToExistingPalette</c> handles arbitrary dims.
+        /// Does NOT override <paramref name="strictSize"/> - both flags apply
+        /// independently.
+        /// </param>
         public static async Task<LoadResult> LoadAndRemapToExistingPalette(Window owner,
             int expectedWidth, int expectedHeight, byte[] existingGBAPalette, int colorCount,
-            bool strictSize = false)
+            bool strictSize = false, bool requireTileMultiple = true)
         {
             string filePath = await FileDialogHelper.OpenImageFile(owner);
             if (string.IsNullOrEmpty(filePath))
                 return null;
 
             return LoadAndRemapFromFile(filePath, expectedWidth, expectedHeight,
-                existingGBAPalette, colorCount, strictSize);
+                existingGBAPalette, colorCount, strictSize, requireTileMultiple);
         }
 
         /// <summary>
         /// Load image from file, validate, remap pixels to existing palette by closest color match.
         /// </summary>
+        /// <param name="requireTileMultiple">
+        /// When <c>true</c> (default), the image width and height must both be
+        /// multiples of 8. Pass <c>false</c> for non-tile glyphs (e.g. the 16x13
+        /// Chinese font glyph, #1166). See the overload above.
+        /// </param>
         public static LoadResult LoadAndRemapFromFile(string filePath,
             int expectedWidth, int expectedHeight, byte[] existingGBAPalette, int colorCount,
-            bool strictSize = false)
+            bool strictSize = false, bool requireTileMultiple = true)
         {
             var result = new LoadResult();
             var imgService = CoreState.ImageService;
@@ -199,7 +213,9 @@ namespace FEBuilderGBA.Avalonia.Services
                     return result;
                 }
 
-                if (image.Width % 8 != 0 || image.Height % 8 != 0)
+                // Skip the tile-size check for non-tile glyphs (e.g. the 16x13 ZH font
+                // glyph, #1166). RemapToExistingPalette handles arbitrary dims.
+                if (requireTileMultiple && (image.Width % 8 != 0 || image.Height % 8 != 0))
                 {
                     result.Error = $"Image dimensions must be multiples of 8 (got {image.Width}x{image.Height})";
                     return result;

--- a/FEBuilderGBA.Avalonia/Views/FontZHView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/FontZHView.axaml.cs
@@ -146,10 +146,13 @@ namespace FEBuilderGBA.Avalonia.Views
                 uint importedMoji = _vm.CurrentMoji;
 
                 // Remap the PNG onto the 4-color ZH font palette (colorCount=4 so the
-                // quantized indices stay 0..3). ZH glyphs are 16x13.
+                // quantized indices stay 0..3). ZH glyphs are 16x13 — height 13 is NOT a
+                // multiple of 8, so requireTileMultiple MUST be false or strictSize-correct
+                // 16x13 PNGs would be rejected by the tile-size guard (#1166 import bug).
                 byte[] fontPal = FontGlyphZHCore.GetFontPaletteGBA(_vm.IsItemFont);
                 var result = await ImageImportService.LoadAndRemapToExistingPalette(this,
-                    FontGlyphZHCore.GLYPH_W, FontGlyphZHCore.GLYPH_H, fontPal, 4, strictSize: true);
+                    FontGlyphZHCore.GLYPH_W, FontGlyphZHCore.GLYPH_H, fontPal, 4,
+                    strictSize: true, requireTileMultiple: false);
                 if (result == null) return;                                  // cancelled
                 if (!result.Success) { CoreState.Services?.ShowError(result.Error); return; } // BEFORE the undo scope
 

--- a/FEBuilderGBA.Core.Tests/FontGlyphZHCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/FontGlyphZHCoreTests.cs
@@ -483,6 +483,40 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.NotNull(hit);
                 Assert.Equal(9, hit!.Width);
                 Assert.Equal(CHAR_TEN, hit.Name); // '、' decoded from the ZH TBL
+                Assert.Equal(MOJI_TEN, hit.Moji); // moji carried straight from the TBL map
+
+                // The TBL-carried Moji must equal the per-char re-encode it replaced
+                // (EncodeMoji == the old MojiFromChar path) — the #1166 perf fix builds
+                // the encoder ONCE per enumeration instead of once per glyph, with
+                // identical results.
+                Assert.Equal(FontGlyphZHCore.EncodeMoji(rom, hit.Name), hit.Moji);
+            }
+            finally { CoreState.BaseDirectory = prevBase; }
+        }
+
+        [Fact]
+        public void EnumerateGlyphsZH_MojiRoundTripsToCorrectCodeB()
+        {
+            // The Moji carried in each entry MUST re-derive the SAME slot address it was
+            // enumerated at — proving the once-built-encoder optimization keeps the moji
+            // usable for re-import (ImportGlyphZH(moji) -> CalcCodeB(moji) -> same slot).
+            string? repoRoot = FindRepoRoot();
+            if (repoRoot == null) return; // skip
+            string tbl = System.IO.Path.Combine(repoRoot, "config", "translate", "zh_tbl", "FE8.tbl");
+            if (!System.IO.File.Exists(tbl)) return; // skip when the TBL is absent
+
+            using var _ = NewStub();
+            var prevBase = CoreState.BaseDirectory;
+            try
+            {
+                CoreState.BaseDirectory = repoRoot;
+                ROM rom = MakeRom();
+                CoreState.ROM = rom;
+
+                var list = FontGlyphZHCore.EnumerateGlyphsZH(rom, isItemFont: false);
+                Assert.NotEmpty(list);
+                foreach (var g in list)
+                    Assert.Equal(g.Addr, FontGlyphZHCore.FindGlyphZH(rom, isItemFont: false, g.Moji));
             }
             finally { CoreState.BaseDirectory = prevBase; }
         }

--- a/FEBuilderGBA.Core/FontGlyphZHCore.cs
+++ b/FEBuilderGBA.Core/FontGlyphZHCore.cs
@@ -24,9 +24,10 @@
 //   * PackGlyphZHBytes(indexedPixels,width) — port of ImageUtil.Image4ToByteZH
 //     (16-wide 2bpp pack capped at 40 bytes).
 //   * ImportGlyphZH(...) — ROM-MUTATING port of FontZHForm.WriteButton_Click:
-//     validate-all-before-mutate, in-place update if the slot exists, else append a
-//     44-byte struct + repoint. Byte-identical fault restore (#885/#923) + ambient
-//     undo threading, mirroring FontGlyphRenderCore.ImportGlyph.
+//     validate-all-before-mutate, then update the directly-referenced slot at
+//     topaddress+codeB IN PLACE (the ZH table is pre-sized; an out-of-range slot is
+//     an error, never an append — every glyph has a fixed slot). Byte-identical fault
+//     restore (#885/#923) + ambient undo threading, mirroring FontGlyphRenderCore.ImportGlyph.
 //
 // The ZH glyph struct is 44 bytes:
 //   byte0 unk1 (0xD) | byte1 width | byte2 height (0xD) | byte3 0x00 | 40-byte bitmap
@@ -244,23 +245,27 @@ namespace FEBuilderGBA.Core
                 list.Add(new FontGlyphZHEntry
                 {
                     Addr = addr,
-                    Moji = MojiFromChar(rom, p.Value),
+                    // Moji comes straight from the TBL map (it is the engine code
+                    // CalcCodeB already consumed) — no per-glyph re-encode.
+                    Moji = p.Value.Moji,
                     Width = (int)rom.u8(addr + OFF_WIDTH),
-                    Name = p.Value,
+                    Name = p.Value.Name,
                 });
             }
             return list;
         }
 
         /// <summary>
-        /// Build the { codeB -> char } map from the ZH TBL encoder, mirroring
-        /// FontZHForm.MakeCodeBMap. Builds its OWN ZH_TBL encoder on demand so the
-        /// list is populated even when the app's CoreState encoder is Auto. Returns
-        /// an empty map when the ZH TBL can't be loaded.
+        /// Build the { codeB -> (char, moji) } map from the ZH TBL encoder, mirroring
+        /// FontZHForm.MakeCodeBMap. Builds the ZH_TBL encoder ONCE (the TBL is parsed a
+        /// single time per enumeration — on a CN ROM the map has thousands of entries,
+        /// so re-parsing per glyph was the #1166 hot path). The moji is carried in the
+        /// value so the enumeration never re-encodes. Returns an empty map when the ZH
+        /// TBL can't be loaded.
         /// </summary>
-        static Dictionary<uint, string> BuildCodeBMap(ROM rom)
+        static Dictionary<uint, (string Name, uint Moji)> BuildCodeBMap(ROM rom)
         {
-            var codeBMap = new Dictionary<uint, string>();
+            var codeBMap = new Dictionary<uint, (string, uint)>();
             ISystemTextEncoder encoder = GetZHEncoder(rom);
             if (encoder == null) return codeBMap;
 
@@ -271,24 +276,29 @@ namespace FEBuilderGBA.Core
             {
                 uint codeB = CalcCodeB(p.Value);
                 if (codeB == U.NOT_FOUND) continue;
-                codeBMap[codeB] = p.Key; // last char for a colliding codeB wins (as WF)
+                // last char for a colliding codeB wins (as WF); p.Value is the moji.
+                codeBMap[codeB] = (p.Key, p.Value);
             }
             return codeBMap;
         }
 
         /// <summary>
-        /// A ZH_TBL encoder for this ROM. Reuses CoreState.SystemTextEncoder when it
-        /// is already a ZH encoder (CLI path); otherwise builds a fresh one from
-        /// config/translate/zh_tbl/{FE6,FE7,FE8}.tbl (Avalonia path, encoding=Auto).
-        /// Returns null when the TBL can't be loaded.
+        /// A fresh ZH_TBL encoder for this ROM, built from
+        /// config/translate/zh_tbl/{FE6,FE7,FE8}.tbl. Always constructs a NEW
+        /// SystemTextEncoder (independent of CoreState.SystemTextEncoder, since the
+        /// Avalonia app keeps encoding=Auto). SystemTextEncoder.LoadTBL FALLS BACK
+        /// rather than throwing when the TBL is missing, so this normally does NOT
+        /// return null — a missing TBL yields an encoder whose GetTBLEncodeDicLow() is
+        /// empty (the enumeration then produces an empty list, no crash). Returns null
+        /// only if the constructor itself throws.
         /// </summary>
         static ISystemTextEncoder GetZHEncoder(ROM rom)
         {
             try
             {
                 var enc = new SystemTextEncoder(TextEncodingEnum.ZH_TBL, rom);
-                // GetTBLEncodeDicLow returns empty for a non-TBL encoder; an empty
-                // map just yields an empty list (no crash), so this is safe.
+                // A missing/unparseable TBL yields an empty GetTBLEncodeDicLow(); an
+                // empty map just yields an empty list (no crash), so this is safe.
                 return enc;
             }
             catch
@@ -472,11 +482,13 @@ namespace FEBuilderGBA.Core
         /// <summary>
         /// Import one glyph for <paramref name="moji"/> into the item/serif ZH font.
         /// Validate-all-before-mutate: dims must be 16x13 and every consumed index
-        /// 0..3 (else localized error + ZERO mutation). Existing glyph → in-place
-        /// width + bitmap update; new glyph → build a 44-byte struct + append to free
-        /// space + repoint the directly-referenced slot. This call clones the ROM and
-        /// restores it byte-identical on any fault (#885/#923). Returns "" on success
-        /// or a localized error string; never throws.
+        /// 0..3 (else localized error + ZERO mutation). The ZH table is a DIRECT-reference
+        /// array (every glyph has a fixed slot at topaddress+codeB), so this always
+        /// updates that slot IN PLACE — width + bitmap; there is no append/repoint path.
+        /// A slot that does not fit in-bounds returns an out-of-range error (the table is
+        /// too small for this char). This call clones the ROM and restores it
+        /// byte-identical on any fault (#885/#923). Returns "" on success or a localized
+        /// error string; never throws.
         /// </summary>
         /// <param name="explicitWidth">Advance width to write. When &lt; 0 it is
         /// derived from the glyph pixels; when &gt;= 0 the supplied value wins.</param>


### PR DESCRIPTION
## Summary
Fixes the 4 Copilot findings raised on the merged Chinese Font editor (#1166 / PR #1266) — one a **real functional bug**, plus a perf improvement and two doc corrections.

## Fixes
1. **Import PNG was broken for ZH glyphs (functional).** `ImageImportService.LoadAndRemapToExistingPalette` had an unconditional `Width%8==0 && Height%8==0` reject, so a correctly-sized **16×13** ZH glyph PNG always failed with "must be multiples of 8". Added a `requireTileMultiple` flag (mirroring the #871 pattern) to both remap overloads, guarded the %8 check with it, and `FontZHView.ImportPng_Click` now passes `requireTileMultiple: false`. The Core path was already correct (`RemapToExistingPalette` + `ImportGlyphZH` handle 16×13). **Default stays `true`** so every tile-based caller is unaffected (regression-guarded by a test).
2. **Perf:** `EnumerateGlyphsZH` no longer builds a `SystemTextEncoder(ZH_TBL)` per glyph (2676× on a CN ROM). `BuildCodeBMap` now carries the moji it consumed, so the encoder is built **once** per enumeration. Behavior-identical (asserted).
3. **Doc:** corrected the `ImportGlyphZH` XML doc + file-header comment (removed the false "append a 44-byte struct + repoint" claim — the ZH format is direct-reference / always in-place).
4. **Doc:** corrected the `GetZHEncoder` docstring (always builds a new encoder; won't return null since `LoadTBL` falls back to an empty map).

## Tests
- **`FontZHViewImportParityTests.cs`** (NEW, 5 tests): `LoadAndRemap_Then_ImportGlyphZH_RoundTrips` writes a real 16×13 PNG → loads with `requireTileMultiple:false` → remaps to the 4-color ZH palette → `ImportGlyphZH` on a synthetic ZH ROM asserts `err==""` (the bug, end-to-end). `LoadAndRemap_16x13_DefaultStillRejects` guards the default.
- Core.Tests **4419 passed** / 0 failed; Avalonia.Tests **8352** / 0; FEBuilderGBA.Tests (windows) **1865** / 0; validate-automation-ids **0/0/0**.

The affected editor (`FontZHView`, with the now-working **Import PNG** button) is shown on PR #1266 (2676 real CN glyphs). This fix is behavioral (import path), proven by the round-trip test above.

Follow-up to #1166 (post-merge Copilot review).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
