### PR TITLE
feat(avalonia): Custom Build MargeAndUpdate auto-install (#1248 slice 2 — closes #1248)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ToolCustomBuildViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ToolCustomBuildViewModelTests.cs
@@ -69,5 +69,34 @@ namespace FEBuilderGBA.Avalonia.Tests
             vm.OriginalRomPath = "Z:\\does\\not\\exist\\base.gba";
             Assert.False(vm.OriginalRomExists);
         }
+
+        // ---- TakeoverSkillAssignment (Marge and Update, #1248 slice 2) ----------
+
+        [Fact]
+        public void TakeoverSkillAssignment_DefaultsToCarryOver()
+        {
+            // Matches the WF form (TakeoverSkillAssignmentComboBox.SelectedIndex = 1).
+            var vm = new ToolCustomBuildViewModel();
+            Assert.Equal(1, vm.TakeoverSkillAssignmentIndex);
+            Assert.Equal(1u, vm.TakeoverSkillAssignment);
+        }
+
+        [Theory]
+        [InlineData(0, 0u)]   // do not carry over
+        [InlineData(1, 1u)]   // carry over
+        public void TakeoverSkillAssignment_MapsFromIndex(int idx, uint expected)
+        {
+            var vm = new ToolCustomBuildViewModel { TakeoverSkillAssignmentIndex = idx };
+            Assert.Equal(expected, vm.TakeoverSkillAssignment);
+        }
+
+        [Theory]
+        [InlineData(-1, 0u)]  // no selection → 0 (do not carry over)
+        [InlineData(99, 1u)]  // out of range → clamps to 1 (carry over)
+        public void TakeoverSkillAssignment_ClampsOutOfRangeIndices(int badIdx, uint expected)
+        {
+            var vm = new ToolCustomBuildViewModel { TakeoverSkillAssignmentIndex = badIdx };
+            Assert.Equal(expected, vm.TakeoverSkillAssignment);
+        }
     }
 }

--- a/FEBuilderGBA.Avalonia/ViewModels/ToolCustomBuildViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ToolCustomBuildViewModel.cs
@@ -15,15 +15,20 @@ namespace FEBuilderGBA.Avalonia.ViewModels
     /// It reads no ROM bytes for display (it only WRITES via the helper) so it is a
     /// read-no-ROM tool VM (no data-verification contract).
     ///
-    /// Scope: the WinForms <c>MargeAndUpdate</c> patch-merge + auto-install phase is
-    /// deferred to a follow-up (WinForms-coupled: PatchForm/ToolDiffForm/PatchUtil); the
-    /// build + ROM load is the parity surface here.
+    /// "Marge and Update" (issue #1248 slice 2) runs the build, then
+    /// <see cref="CustomBuildCore.MargeAndUpdate"/>: it diffs the built ROM against the
+    /// vanilla ROM, assembles a CustomBuild patch under
+    /// <c>config/patch2/FE8U/skill_CustomBuild</c>, and auto-installs it via
+    /// <see cref="PatchInstallCore"/> (a CustomBuild patch is literal-offset BIN-diffs,
+    /// so the slice-1 install — not the full PatchForm dependency-resolution engine — is
+    /// what it needs).
     /// </summary>
     public class ToolCustomBuildViewModel : ViewModelBase
     {
         string _targetPath = "";
         string _originalRomPath = "";
         int _buildMethodIndex;              // 0 Auto, 1 CMD, 2 EA (CustomBuildCore.BuildMethod)
+        int _takeoverSkillAssignmentIndex = 1; // 0 = don't carry over, 1 = carry over (WF default)
         bool _canUndo;
         string _statusMessage = "";
 
@@ -35,6 +40,20 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
         /// <summary>Build-method index: 0 = auto (by extension), 1 = CMD, 2 = Event Assembler.</summary>
         public int BuildMethodIndex { get => _buildMethodIndex; set => SetField(ref _buildMethodIndex, value); }
+
+        /// <summary>
+        /// Take-over-skill-assignment index (WF TakeoverSkillAssignmentComboBox):
+        /// 0 = do not carry over the parent patch's skill assignment, 1 = carry it over.
+        /// Defaults to 1 to match the WinForms form (SelectedIndex = 1).
+        /// </summary>
+        public int TakeoverSkillAssignmentIndex
+        {
+            get => _takeoverSkillAssignmentIndex;
+            set => SetField(ref _takeoverSkillAssignmentIndex, value);
+        }
+
+        /// <summary>The take-over flag passed to <see cref="CustomBuildCore.MargeAndUpdate"/> (0 or 1).</summary>
+        public uint TakeoverSkillAssignment => (uint)ClampIndex(_takeoverSkillAssignmentIndex, 1);
 
         /// <summary>True when an applied build can be undone.</summary>
         public bool CanUndo { get => _canUndo; set => SetField(ref _canUndo, value); }
@@ -123,6 +142,39 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         {
             ROM rom = CoreState.ROM;
             return CustomBuildCore.Build(rom, TargetPath, OriginalRomPath, BuildMethod, undo);
+        }
+
+        /// <summary>
+        /// The full WF <c>ToolCustomBuildForm.Run</c> flow (issue #1248): build the
+        /// target, then — on success and when the build produced a ROM file — diff it
+        /// against the vanilla ROM and auto-install the merged CustomBuild patch via
+        /// <see cref="CustomBuildCore.MargeAndUpdate"/>. Both phases record their ROM
+        /// writes into the caller-owned <paramref name="undo"/> (no thread-local ambient
+        /// undo), so the caller commits/rolls back the whole operation as one unit.
+        ///
+        /// Returns the build result plus the marge result (null when the build failed or
+        /// produced no on-disk ROM to diff — e.g. the EA in-place path, which has nothing
+        /// to MargeAndUpdate from).
+        /// </summary>
+        public (CustomBuildCore.BuildResult build, CustomBuildCore.MargeResult marge) RunAndMarge(
+            Undo.UndoData undo, Action<string> onProgress = null)
+        {
+            ROM rom = CoreState.ROM;
+            var build = CustomBuildCore.Build(rom, TargetPath, OriginalRomPath, BuildMethod, undo, onProgress);
+            if (!build.Success)
+                return (build, null);
+
+            // MargeAndUpdate needs an on-disk built ROM to diff against vanilla; the
+            // CMD path produces SkillsTest.gba (BuiltRomPath). The EA in-place path has
+            // no separate ROM file, so there is nothing to marge (the build already
+            // wrote into the ROM directly).
+            if (string.IsNullOrEmpty(build.BuiltRomPath))
+                return (build, null);
+
+            var marge = CustomBuildCore.MargeAndUpdate(
+                rom, OriginalRomPath, build.BuiltRomPath, TargetPath,
+                TakeoverSkillAssignment, undo, onProgress);
+            return (build, marge);
         }
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ToolCustomBuildView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolCustomBuildView.axaml
@@ -8,11 +8,12 @@
        project: either a user CUSTOM_BUILD.cmd batch script (CMD method, Windows-only) or
        an Event Assembler target (EA method), then loads the freshly-built ROM. The
        build+load work runs in the GUI-free Core helper CustomBuildCore (which reuses
-       EventAssemblerCompileCore for the EA path). The build-method combo items are
-       populated in code-behind via R._() so they pick up ja/zh translations
+       EventAssemblerCompileCore for the EA path). The build-method + take-over combo
+       items are populated in code-behind via R._() so they pick up ja/zh translations
        (ViewTranslationHelper does not translate ComboBoxItem content).
-       Deferred to a follow-up: the WinForms MargeAndUpdate patch-merge + auto-install
-       phase (PatchForm/ToolDiffForm/PatchUtil-coupled); revert an applied build via Undo. -->
+       "Marge and Update" (issue #1248) runs the build, diffs the built ROM against the
+       vanilla ROM, assembles a CustomBuild patch under config/patch2/FE8U/skill_CustomBuild,
+       and auto-installs it via PatchInstallCore. Any applied operation reverts via Undo. -->
   <ScrollViewer VerticalScrollBarVisibility="Auto">
     <StackPanel Margin="16" Spacing="10">
 
@@ -53,11 +54,23 @@
                   SelectedIndex="{Binding BuildMethodIndex}" />
       </Grid>
 
+      <!-- Take over the parent patch's skill assignment when merging (Marge and Update) -->
+      <Grid ColumnDefinitions="180,*" Margin="0,6,0,0">
+        <TextBlock Grid.Column="0" Text="Skill assignment:" VerticalAlignment="Center" />
+        <ComboBox AutomationProperties.AutomationId="ToolCustomBuild_TakeoverSkill_Combo"
+                  Grid.Column="1" Name="TakeoverSkillCombo"
+                  HorizontalAlignment="Stretch"
+                  SelectedIndex="{Binding TakeoverSkillAssignmentIndex}" />
+      </Grid>
+
       <!-- Actions -->
       <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
         <Button AutomationProperties.AutomationId="ToolCustomBuild_Run_Button"
                 Name="RunButton" Content="Run build"
                 Click="Run_Click" />
+        <Button AutomationProperties.AutomationId="ToolCustomBuild_MargeUpdate_Button"
+                Name="MargeUpdateButton" Content="Marge and Update"
+                Click="MargeUpdate_Click" />
         <Button AutomationProperties.AutomationId="ToolCustomBuild_Undo_Button"
                 Name="UndoButton" Content="Undo"
                 IsVisible="{Binding CanUndo}"

--- a/FEBuilderGBA.Avalonia/Views/ToolCustomBuildView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolCustomBuildView.axaml.cs
@@ -222,6 +222,11 @@ namespace FEBuilderGBA.Avalonia.Views
 
             RunButton.IsEnabled = false;
             MargeUpdateButton.IsEnabled = false;
+            // Disable Undo during the background build+install — a click mid-mutation
+            // would race the bg-thread CoreState.Undo/ROM writes and corrupt state.
+            // Restored to its prior state in the finally below.
+            bool undoWasEnabled = UndoButton.IsEnabled;
+            UndoButton.IsEnabled = false;
             _vm.StatusMessage = R._("Building...");
 
             // Same EXPLICIT-UndoData posture as Run_Click: the build AND the patch
@@ -280,6 +285,9 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 RunButton.IsEnabled = true;
                 MargeUpdateButton.IsEnabled = true;
+                // Restore Undo (success or failure); a successful commit above set
+                // CanUndo=true which drives IsVisible.
+                UndoButton.IsEnabled = undoWasEnabled;
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ToolCustomBuildView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolCustomBuildView.axaml.cs
@@ -18,9 +18,11 @@ namespace FEBuilderGBA.Avalonia.Views
     /// Combo items are added in code via R._() so they pick up ja/zh translations
     /// (ViewTranslationHelper does not translate ComboBoxItem content).
     ///
-    /// The WinForms <c>MargeAndUpdate</c> patch-merge + auto-install phase is deferred
-    /// to a follow-up issue (PatchForm/ToolDiffForm/PatchUtil-coupled); an applied
-    /// build can be reverted via Undo for now.
+    /// "Marge and Update" (issue #1248) runs the build, diffs the built ROM against the
+    /// vanilla ROM, assembles a CustomBuild patch under
+    /// <c>config/patch2/FE8U/skill_CustomBuild</c>, and auto-installs it via
+    /// <see cref="PatchInstallCore"/> (the <see cref="ToolCustomBuildViewModel.RunAndMarge"/>
+    /// orchestration). Any applied operation can be reverted via Undo.
     /// </summary>
     public partial class ToolCustomBuildView : TranslatedWindow, IEditorView
     {
@@ -40,6 +42,12 @@ namespace FEBuilderGBA.Avalonia.Views
             BuildMethodCombo.Items.Add(R._("CUSTOM_BUILD.cmd (Windows batch)"));
             BuildMethodCombo.Items.Add(R._("Event Assembler target"));
             BuildMethodCombo.SelectedIndex = _vm.BuildMethodIndex;
+
+            // Take-over-skill-assignment (WF TakeoverSkillAssignmentComboBox; default
+            // index 1 = carry over the parent patch's skill assignment).
+            TakeoverSkillCombo.Items.Add(R._("Do not carry over the skill assignment"));
+            TakeoverSkillCombo.Items.Add(R._("Carry over the skill assignment"));
+            TakeoverSkillCombo.SelectedIndex = _vm.TakeoverSkillAssignmentIndex;
 
             Opened += (_, _) =>
             {
@@ -195,6 +203,83 @@ namespace FEBuilderGBA.Avalonia.Views
             finally
             {
                 RunButton.IsEnabled = true;
+            }
+        }
+
+        async void MargeUpdate_Click(object? sender, RoutedEventArgs e)
+        {
+            // Prompt for a target if none chosen yet, then CONTINUE in the same action.
+            if (!_vm.TargetExists)
+            {
+                if (!await BrowseForTargetAsync() || !_vm.TargetExists)
+                    return; // user cancelled / no usable file
+            }
+            if (!_vm.OriginalRomExists)
+            {
+                _vm.StatusMessage = R._("無改造ROM({0})が見つかりませんでした", _vm.OriginalRomPath);
+                return;
+            }
+
+            RunButton.IsEnabled = false;
+            MargeUpdateButton.IsEnabled = false;
+            _vm.StatusMessage = R._("Building...");
+
+            // Same EXPLICIT-UndoData posture as Run_Click: the build AND the patch
+            // install run on a background thread (Task.Run), where the thread-local
+            // ambient undo scope is null. Both phases record into this passed UndoData,
+            // which we commit (UI thread) via UndoService.CommitExternal only on success.
+            var undo = (CoreState.Undo ??= new Undo()).NewUndoData("Custom Build (Marge and Update)");
+
+            try
+            {
+                // No onProgress callback: it would fire on the background thread and a
+                // bound StatusMessage mutation must stay on the UI thread (Run_Click uses
+                // the same no-progress posture). The final status is set below on the UI
+                // thread once the awaited Task completes.
+                var (build, marge) = await Task.Run(() => _vm.RunAndMarge(undo));
+
+                if (!build.Success)
+                {
+                    // Build failed → nothing applied (fault-safe helper); surface the error.
+                    _vm.StatusMessage = R._("Build failed.") + "\r\n" + build.ErrorMessage;
+                    return;
+                }
+
+                if (marge != null && !marge.Success)
+                {
+                    // The build wrote into the ROM before the marge step failed, so there
+                    // ARE recorded writes — commit them so the user can Undo, then report.
+                    bool builtMutated = undo.list.Count > 0;
+                    if (builtMutated && _undoService.CommitExternal(undo))
+                        _vm.CanUndo = true;
+                    _vm.StatusMessage = R._("Marge and Update failed.") + "\r\n" + marge.ErrorMessage;
+                    return;
+                }
+
+                bool mutated = undo.list.Count > 0;
+                if (mutated && _undoService.CommitExternal(undo))
+                    _vm.CanUndo = true;
+
+                string msg = (marge != null)
+                    ? R._("Marge and Update successful.")
+                    : R._("Build successful.");
+                if (marge != null && !string.IsNullOrEmpty(marge.PatchPath))
+                    msg += "\r\n" + R._("Patch: {0}", marge.PatchPath);
+                else if (!string.IsNullOrEmpty(build.BuiltRomPath))
+                    msg += "\r\n" + R._("Built ROM: {0}", build.BuiltRomPath);
+                if (!string.IsNullOrEmpty(build.Output.Trim()))
+                    msg += "\r\n" + build.Output.Trim();
+                _vm.StatusMessage = msg;
+            }
+            catch (Exception ex)
+            {
+                Log.Error("ToolCustomBuildView.MargeUpdate failed: " + ex.ToString());
+                _vm.StatusMessage = R._("Marge and Update failed.") + "\r\n" + ex.ToString();
+            }
+            finally
+            {
+                RunButton.IsEnabled = true;
+                MargeUpdateButton.IsEnabled = true;
             }
         }
 

--- a/FEBuilderGBA.Core.Tests/CustomBuildCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/CustomBuildCoreTests.cs
@@ -489,6 +489,89 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void MargeAndUpdate_BuiltEqualsVanilla_NoBinEntries_SkipsInstall_StillWritesArtifact()
+        {
+            // Built ROM identical to vanilla → MakeDiff emits a TYPE=BIN header but NO
+            // BIN/BINF lines, so the install is skipped (ROM untouched) yet the merged
+            // patch artifact is still written and the result is success.
+            string prevBase = CoreState.BaseDirectory;
+            string prevLang = CoreState.Language;
+            string baseDir = Path.Combine(Path.GetTempPath(), "cb-mau-eq-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(baseDir);
+            CoreState.BaseDirectory = baseDir;
+            CoreState.Language = "en";
+            try
+            {
+                StageParentPatch(baseDir);
+
+                byte[] vanilla = new byte[0x400];
+                for (int i = 0; i < vanilla.Length; i++) vanilla[i] = 0xFF;
+                byte[] built = (byte[])vanilla.Clone();   // IDENTICAL → no diff
+
+                string origRomPath = Path.Combine(baseDir, "vanilla.gba");
+                string builtRomPath = Path.Combine(baseDir, "SkillsTest.gba");
+                File.WriteAllBytes(origRomPath, vanilla);
+                File.WriteAllBytes(builtRomPath, built);
+                string targetPath = Path.Combine(baseDir, "CUSTOM_BUILD.cmd");
+                File.WriteAllText(targetPath, "echo hi\r\n");
+
+                var rom = MakeCoreRom(vanilla);
+                byte[] before = (byte[])rom.Data.Clone();
+                var undo = NewUndo(rom);
+
+                var r = CustomBuildCore.MargeAndUpdate(
+                    rom, origRomPath, builtRomPath, targetPath,
+                    takeoverSkillAssignment: 1, undo: undo);
+
+                Assert.True(r.Success, "MargeAndUpdate failed: " + r.ErrorMessage);
+                // No BIN entries → nothing installed → ROM untouched, undo empty.
+                Assert.Equal(before, rom.Data);
+                Assert.Empty(undo.list);
+                // The merged artifact is still written (valid on-disk patch).
+                Assert.True(File.Exists(r.PatchPath));
+                string patchText = File.ReadAllText(r.PatchPath);
+                Assert.Contains("UPDATE_UNINSTALL:0=", patchText);
+                Assert.DoesNotContain("BINF:", patchText);
+            }
+            finally
+            {
+                CoreState.BaseDirectory = prevBase;
+                CoreState.Language = prevLang;
+                CoreState.ROM = null;
+                CoreState.Undo = null;
+                try { Directory.Delete(baseDir, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void MargeAndUpdate_NullUndo_ReturnsUndoRequiredError()
+        {
+            string prevBase = CoreState.BaseDirectory;
+            string baseDir = Path.Combine(Path.GetTempPath(), "cb-mau-nu-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(baseDir);
+            CoreState.BaseDirectory = baseDir;
+            try
+            {
+                var rom = MakeCoreRom(new byte[0x200]);
+                var r = CustomBuildCore.MargeAndUpdate(
+                    rom, "ignored.gba", "ignored-built.gba", "ignored.cmd",
+                    takeoverSkillAssignment: 1, undo: null);
+
+                Assert.False(r.Success);
+                // The null-undo message must NOT be the rom==null "No ROM is loaded." string.
+                Assert.Equal(R._("Undo data is required for MargeAndUpdate."), r.ErrorMessage);
+                Assert.NotEqual(R._("No ROM is loaded."), r.ErrorMessage);
+            }
+            finally
+            {
+                CoreState.BaseDirectory = prevBase;
+                CoreState.ROM = null;
+                CoreState.Undo = null;
+                try { Directory.Delete(baseDir, true); } catch { }
+            }
+        }
+
+        [Fact]
         public void MargeAndUpdate_MissingBuiltRom_ReturnsError_NoMutation()
         {
             string prevBase = CoreState.BaseDirectory;

--- a/FEBuilderGBA.Core.Tests/CustomBuildCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/CustomBuildCoreTests.cs
@@ -302,5 +302,269 @@ namespace FEBuilderGBA.Core.Tests
             }
             return null;
         }
+
+        // ====================================================================
+        //  MargeAndUpdate (#1248 slice 2) — synthetic end-to-end glue + filter
+        // ====================================================================
+
+        // Build a CoreState ROM around bytes (so the Undo machinery snapshots/rolls
+        // back into CoreState.ROM, like PatchInstallCoreTests).
+        static ROM MakeCoreRom(byte[] data)
+        {
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect((byte[])data.Clone());
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+            return rom;
+        }
+
+        // Stage a minimal parent SkillSystem patch dir under <baseDir>/config/patch2/
+        // FE8U/skill20220703/ so GetParentPatchPath resolves to a real file. The text
+        // carries one line of each kind MargePatch filters, so a test can assert the
+        // filter dropped them and kept the rest.
+        static void StageParentPatch(string baseDir)
+        {
+            string dir = Path.Combine(baseDir, "config", "patch2", "FE8U", "skill20220703");
+            Directory.CreateDirectory(dir);
+            File.WriteAllLines(Path.Combine(dir, "PATCH_Skill20220703.txt"), new[]
+            {
+                "TYPE=SKILL",
+                "NAME=SkillSystem",
+                "INFO=parent",
+                "PATCHED_IF:0x100=0x1 0x2",
+                "BINF:0x800=00000800.bin",
+                "BIN:0x900=00000900.bin",
+                "AFTER_TRY_EXECUTE:0=x.event",
+                "TEXTADV:0=y",
+                "EXTENDS:0=z",
+                "UPDATE_METHOD=SKILLSYSTEM",
+                "EDIT_PATCH:0=p",
+                "KEEPME=1",                  // a non-filtered line — must survive
+            });
+            // A sidecar the CopyDirectoryShallow would copy (and DeleteFile 0*.bin nukes).
+            File.WriteAllBytes(Path.Combine(dir, "00000800.bin"), new byte[] { 0xAA });
+        }
+
+        // ---- MargePatch (pure string filter) -------------------------------
+
+        [Fact]
+        public void MargePatch_FiltersParentMetadata_KeepsOthers_TakeoverOn()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "cb-marge-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            try
+            {
+                string parent = Path.Combine(dir, "PATCH_Parent.txt");
+                File.WriteAllLines(parent, new[]
+                {
+                    "TYPE=SKILL", "NAME=Sys", "INFO=x",
+                    "PATCHED_IF:0x100=0x1", "BINF:0x800=a.bin", "BIN:0x900=b.bin",
+                    "AFTER_TRY_EXECUTE:0=e", "TEXTADV:0=t", "EXTENDS:0=z",
+                    "UPDATE_METHOD=SKILLSYSTEM", "EDIT_PATCH:0=p", "KEEPME=1",
+                });
+                string custombuild = Path.Combine(dir, CustomBuildCore.CustomBuildPatchLeafName);
+                File.WriteAllText(custombuild, "BINF:0xABCD=00ABCD00.bin\r\n");
+
+                CustomBuildCore.MargePatch(custombuild, parent, takeoverSkillAssignment: 1);
+                string merged = File.ReadAllText(custombuild);
+
+                // Header: UPDATE_UNINSTALL of the parent.
+                Assert.Contains("UPDATE_UNINSTALL:0=" + parent, merged);
+                // Filtered-out parent lines are gone.
+                Assert.DoesNotContain("PATCHED_IF:", merged);
+                Assert.DoesNotContain("BIN:0x900", merged);
+                Assert.DoesNotContain("AFTER_TRY_EXECUTE:", merged);
+                Assert.DoesNotContain("TEXTADV:", merged);
+                Assert.DoesNotContain("EXTENDS:", merged);
+                Assert.DoesNotContain("\nNAME", merged.Replace("\r", ""));
+                Assert.DoesNotContain("\nINFO", merged.Replace("\r", ""));
+                // With takeover ON, the skill-assignment lines are KEPT.
+                Assert.Contains("UPDATE_METHOD=SKILLSYSTEM", merged);
+                Assert.Contains("EDIT_PATCH:0=p", merged);
+                // A non-filtered parent line survives.
+                Assert.Contains("KEEPME=1", merged);
+                // The freshly-generated CustomBuild diff text is appended.
+                Assert.Contains("BINF:0xABCD=00ABCD00.bin", merged);
+            }
+            finally { try { Directory.Delete(dir, true); } catch { } }
+        }
+
+        [Fact]
+        public void MargePatch_TakeoverOff_DropsSkillAssignmentLines()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "cb-marge-off-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            try
+            {
+                string parent = Path.Combine(dir, "PATCH_Parent.txt");
+                File.WriteAllLines(parent, new[]
+                {
+                    "TYPE=SKILL", "KEEPME=1",
+                    "UPDATE_METHOD=SKILLSYSTEM", "EDIT_PATCH:0=p",
+                });
+                string custombuild = Path.Combine(dir, CustomBuildCore.CustomBuildPatchLeafName);
+                File.WriteAllText(custombuild, "BINF:0x1=x.bin\r\n");
+
+                CustomBuildCore.MargePatch(custombuild, parent, takeoverSkillAssignment: 0);
+                string merged = File.ReadAllText(custombuild);
+
+                Assert.DoesNotContain("UPDATE_METHOD=SKILLSYSTEM", merged);
+                Assert.DoesNotContain("EDIT_PATCH:0=p", merged);
+                Assert.Contains("KEEPME=1", merged);
+            }
+            finally { try { Directory.Delete(dir, true); } catch { } }
+        }
+
+        // ---- MargeAndUpdate end-to-end (synthetic) -------------------------
+
+        [Fact]
+        public void MargeAndUpdate_SyntheticRoundTrip_InstallsBinDiff_RomEqualsBuilt()
+        {
+            string prevBase = CoreState.BaseDirectory;
+            string prevLang = CoreState.Language;
+            string baseDir = Path.Combine(Path.GetTempPath(), "cb-mau-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(baseDir);
+            CoreState.BaseDirectory = baseDir;
+            CoreState.Language = "en";
+            try
+            {
+                StageParentPatch(baseDir);
+
+                // Vanilla (the diff baseline) and the "built" ROM (= vanilla + edits).
+                // The working ROM starts as a CLONE of vanilla, so installing the
+                // vanilla→built diff must drive it to equal the built bytes.
+                byte[] vanilla = new byte[0x400];
+                for (int i = 0; i < vanilla.Length; i++) vanilla[i] = 0xFF;
+                byte[] built = (byte[])vanilla.Clone();
+                for (int i = 0x110; i < 0x118; i++) built[i] = 0xAB;
+                for (int i = 0x250; i < 0x270; i++) built[i] = (byte)(i & 0xFF);
+
+                string origRomPath = Path.Combine(baseDir, "vanilla.gba");
+                string builtRomPath = Path.Combine(baseDir, "SkillsTest.gba");
+                File.WriteAllBytes(origRomPath, vanilla);
+                File.WriteAllBytes(builtRomPath, built);
+                // A build target whose directory holds the (absent) .sym/.dmp sidecars.
+                string targetPath = Path.Combine(baseDir, "CUSTOM_BUILD.cmd");
+                File.WriteAllText(targetPath, "echo hi\r\n");
+
+                var rom = MakeCoreRom(vanilla);  // working ROM = vanilla clone
+                var undo = NewUndo(rom);
+
+                var r = CustomBuildCore.MargeAndUpdate(
+                    rom, origRomPath, builtRomPath, targetPath,
+                    takeoverSkillAssignment: 1, undo: undo);
+
+                Assert.True(r.Success, "MargeAndUpdate failed: " + r.ErrorMessage);
+                Assert.True(File.Exists(r.PatchPath), "the CustomBuild patch should exist on disk");
+                // The install drove the working ROM to the built bytes.
+                Assert.Equal(built, rom.Data);
+                Assert.NotEmpty(undo.list);
+
+                // The generated patch merged the parent text (UPDATE_UNINSTALL header)
+                // and kept a non-filtered parent line, then appended the BIN diff.
+                string patchText = File.ReadAllText(r.PatchPath);
+                Assert.Contains("UPDATE_UNINSTALL:0=", patchText);
+                Assert.Contains("KEEPME=1", patchText);
+                Assert.Contains("BINF:", patchText);
+
+                // The cache dir was rebuilt and the parent's own 0*.bin / PATCH_*.txt
+                // were dropped (only our generated patch + symbol-less copy remain).
+                string cacheDir = CustomBuildCore.GetCustomBuildCacheDir();
+                Assert.True(Directory.Exists(cacheDir));
+                Assert.Empty(Directory.GetFiles(cacheDir, "00000800.bin"));
+
+                // Undo restores the working ROM to vanilla.
+                CoreState.Undo.Push(undo);
+                CoreState.Undo.RunUndo();
+                Assert.Equal(vanilla, rom.Data);
+            }
+            finally
+            {
+                CoreState.BaseDirectory = prevBase;
+                CoreState.Language = prevLang;
+                CoreState.ROM = null;
+                CoreState.Undo = null;
+                try { Directory.Delete(baseDir, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void MargeAndUpdate_MissingBuiltRom_ReturnsError_NoMutation()
+        {
+            string prevBase = CoreState.BaseDirectory;
+            string baseDir = Path.Combine(Path.GetTempPath(), "cb-mau-nb-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(baseDir);
+            CoreState.BaseDirectory = baseDir;
+            try
+            {
+                StageParentPatch(baseDir);
+                byte[] vanilla = new byte[0x200];
+                string origRomPath = Path.Combine(baseDir, "vanilla.gba");
+                File.WriteAllBytes(origRomPath, vanilla);
+
+                var rom = MakeCoreRom(vanilla);
+                byte[] before = (byte[])rom.Data.Clone();
+                var undo = NewUndo(rom);
+
+                var r = CustomBuildCore.MargeAndUpdate(
+                    rom, origRomPath,
+                    builtRomPath: Path.Combine(baseDir, "no-such-built.gba"),
+                    targetPath: Path.Combine(baseDir, "CUSTOM_BUILD.cmd"),
+                    takeoverSkillAssignment: 1, undo: undo);
+
+                Assert.False(r.Success);
+                Assert.False(string.IsNullOrEmpty(r.ErrorMessage));
+                Assert.Equal(before, rom.Data);
+                Assert.Empty(undo.list);
+            }
+            finally
+            {
+                CoreState.BaseDirectory = prevBase;
+                CoreState.ROM = null;
+                CoreState.Undo = null;
+                try { Directory.Delete(baseDir, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void MargeAndUpdate_MissingParentPatch_ReturnsError_NoMutation()
+        {
+            string prevBase = CoreState.BaseDirectory;
+            // A base dir WITHOUT the parent patch staged → GetParentPatchPath misses.
+            string baseDir = Path.Combine(Path.GetTempPath(), "cb-mau-np-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(baseDir);
+            CoreState.BaseDirectory = baseDir;
+            try
+            {
+                byte[] vanilla = new byte[0x200];
+                byte[] built = (byte[])vanilla.Clone();
+                built[0x110] = 0x11;
+                string origRomPath = Path.Combine(baseDir, "vanilla.gba");
+                string builtRomPath = Path.Combine(baseDir, "built.gba");
+                File.WriteAllBytes(origRomPath, vanilla);
+                File.WriteAllBytes(builtRomPath, built);
+
+                var rom = MakeCoreRom(vanilla);
+                byte[] before = (byte[])rom.Data.Clone();
+                var undo = NewUndo(rom);
+
+                var r = CustomBuildCore.MargeAndUpdate(
+                    rom, origRomPath, builtRomPath,
+                    Path.Combine(baseDir, "CUSTOM_BUILD.cmd"),
+                    takeoverSkillAssignment: 1, undo: undo);
+
+                Assert.False(r.Success);
+                Assert.False(string.IsNullOrEmpty(r.ErrorMessage));
+                Assert.Equal(before, rom.Data);
+                Assert.Empty(undo.list);
+            }
+            finally
+            {
+                CoreState.BaseDirectory = prevBase;
+                CoreState.ROM = null;
+                CoreState.Undo = null;
+                try { Directory.Delete(baseDir, true); } catch { }
+            }
+        }
     }
 }

--- a/FEBuilderGBA.Core/CustomBuildCore.cs
+++ b/FEBuilderGBA.Core/CustomBuildCore.cs
@@ -245,6 +245,17 @@ namespace FEBuilderGBA
                 result.ErrorMessage = R._("No ROM is loaded.");
                 return result;
             }
+            // The install writes through PatchInstallCore.ApplyPatch, whose undo
+            // machinery (write_resize_data / UndoPostion) snapshots pre-write bytes
+            // from — and rolls back into — CoreState.ROM. So rom MUST be exactly
+            // CoreState.ROM, or the snapshot would be taken from a different buffer and
+            // rollback would corrupt state. Fail loudly rather than apply with a broken
+            // undo.
+            if (!ReferenceEquals(rom, CoreState.ROM))
+            {
+                result.ErrorMessage = R._("MargeAndUpdate must install into the currently loaded ROM.");
+                return result;
+            }
             if (undo == null)
             {
                 result.ErrorMessage = R._("Undo data is required for MargeAndUpdate.");

--- a/FEBuilderGBA.Core/CustomBuildCore.cs
+++ b/FEBuilderGBA.Core/CustomBuildCore.cs
@@ -24,19 +24,17 @@ namespace FEBuilderGBA
     ///            more complete than the WinForms form).
     ///     → replace the current ROM with the built bytes (undoable, fault-safe).
     ///
-    /// Scope boundary (intentional — matches how <see cref="EventAssemblerCompileCore"/>
-    /// deferred MakeEAAutoDef and <see cref="AsmCompileCore"/> deferred GoldRoad/MakePatch):
+    /// Scope (issue #1248 slice 2 wired the MargeAndUpdate auto-install):
     ///   PROVIDED: CMD build (run CUSTOM_BUILD.cmd → SkillsTest.gba), EA build (via
     ///     EventAssemblerCompileCore), the EA-error detection, the vanilla FE8_clean copy,
-    ///     loading the built ROM (undoable), reading SkillsTest.sym.
-    ///   INTENTIONALLY DEFERRED to a follow-up (WinForms-coupled): the WinForms
-    ///     <c>MargeAndUpdate</c> phase — diffing vanilla vs built ROM, copying the
-    ///     symbol/dump files into <c>config/patch2/FE8U/skill_CustomBuild</c>, generating
-    ///     a <c>PATCH_SkillSystem_CustomBuild.txt</c>, and AUTO-INSTALLING it via
-    ///     <c>PatchForm.UpdatePatch</c>. That pipeline depends on WinForms-only types
-    ///     (<c>PatchForm</c>, <c>ToolDiffForm</c>, <c>PatchUtil.SearchSkillSystem</c>)
-    ///     that cannot move to Core without a separate extraction. The user re-installs
-    ///     the built ROM's custom patch via the existing patch tooling for now.
+    ///     loading the built ROM (undoable), reading SkillsTest.sym, AND the
+    ///     <see cref="MargeAndUpdate"/> phase — diffing vanilla vs the built ROM,
+    ///     copying the symbol/dump files into <c>config/patch2/FE8U/skill_CustomBuild</c>,
+    ///     generating a <c>PATCH_SkillSystem_CustomBuild.txt</c>, merging the parent
+    ///     SkillSystem patch text, and AUTO-INSTALLING it via <see cref="PatchInstallCore"/>
+    ///     (a CustomBuild patch is literal-offset BIN-diffs, so the slice-1
+    ///     <c>PatchInstallCore.ApplyPatch</c> install — not the full
+    ///     <c>PatchForm.UpdatePatch</c> dependency-resolution engine — is what it needs).
     ///
     /// Platform boundary (the #1169 lesson): <c>CUSTOM_BUILD.cmd</c> is a Windows batch
     /// script. On Linux/macOS the CMD build path surfaces a clear localized
@@ -157,6 +155,310 @@ namespace FEBuilderGBA
             if (effective == BuildMethod.Cmd)
                 return BuildCmd(rom, targetPath, originalRomPath, undo, onProgress);
             return BuildEA(rom, targetPath, undo, onProgress);
+        }
+
+        // ===================================================================
+        //  MargeAndUpdate — the patch-merge + auto-install phase (#1248 slice 2)
+        // ===================================================================
+
+        /// <summary>The relative path of the parent SkillSystem patch under BaseDirectory.</summary>
+        public static readonly string[] ParentPatchRelativeParts =
+            { "config", "patch2", "FE8U", "skill20220703", "PATCH_Skill20220703.txt" };
+
+        /// <summary>The relative path of the CustomBuild cache directory under BaseDirectory.</summary>
+        public static readonly string[] CustomBuildCacheRelativeParts =
+            { "config", "patch2", "FE8U", "skill_CustomBuild" };
+
+        /// <summary>The generated CustomBuild patch leaf name.</summary>
+        public const string CustomBuildPatchLeafName = "PATCH_SkillSystem_CustomBuild.txt";
+
+        /// <summary>Structured result of a <see cref="MargeAndUpdate"/> run.</summary>
+        public sealed class MargeResult
+        {
+            /// <summary>True when the merged patch was generated and installed.</summary>
+            public bool Success { get; set; }
+            /// <summary>Path of the generated CustomBuild patch on disk, when one was produced.</summary>
+            public string PatchPath { get; set; } = "";
+            /// <summary>Localized human-readable error (set when <see cref="Success"/> is false).</summary>
+            public string ErrorMessage { get; set; } = "";
+        }
+
+        /// <summary>
+        /// Resolve <see cref="ParentPatchRelativeParts"/> against
+        /// <see cref="CoreState.BaseDirectory"/> (empty BaseDirectory → relative path).
+        /// </summary>
+        public static string GetParentPatchPath() =>
+            CombineUnderBase(ParentPatchRelativeParts);
+
+        /// <summary>
+        /// Resolve <see cref="CustomBuildCacheRelativeParts"/> against
+        /// <see cref="CoreState.BaseDirectory"/>.
+        /// </summary>
+        public static string GetCustomBuildCacheDir() =>
+            CombineUnderBase(CustomBuildCacheRelativeParts);
+
+        static string CombineUnderBase(string[] parts)
+        {
+            string baseDir = CoreState.BaseDirectory ?? "";
+            string[] all = new string[parts.Length + 1];
+            all[0] = baseDir;
+            Array.Copy(parts, 0, all, 1, parts.Length);
+            return Path.Combine(all);
+        }
+
+        /// <summary>
+        /// Port of the WinForms <c>ToolCustomBuildForm.MargeAndUpdate</c>, MINUS the
+        /// WinForms UI and the <c>PatchForm.UpdatePatch</c> dependency-resolution engine.
+        ///
+        /// Diff the built ROM against the vanilla ROM, assemble a self-contained
+        /// CustomBuild patch in <c>config/patch2/FE8U/skill_CustomBuild</c> (the parent
+        /// SkillSystem patch's text minus its own BIN/BINF/metadata lines + the fresh
+        /// vanilla→built BIN-diff), then auto-install it via
+        /// <see cref="PatchInstallCore"/>. A CustomBuild patch is literal-offset
+        /// BIN-diffs only, so the slice-1 install (not the full PatchForm engine) is
+        /// what it needs; <c>UPDATE_UNINSTALL</c> of a prior patch is a no-op here (the
+        /// fresh-install case), so the install applies the BIN diffs directly.
+        ///
+        /// Fault-safety: validates inputs up front (no throw, no ROM mutation on a bad
+        /// path); the install writes go through <see cref="PatchInstallCore.ApplyPatch"/>
+        /// into <paramref name="undo"/> (so the caller commits/rolls back on the UI
+        /// thread). A mid-install failure leaves whatever ApplyPatch already wrote
+        /// recorded in <paramref name="undo"/> for the caller to roll back.
+        /// </summary>
+        /// <param name="rom">The working ROM to install the CustomBuild patch into (CoreState.ROM).</param>
+        /// <param name="originalRomPath">The un-modded (vanilla) ROM path — the diff baseline.</param>
+        /// <param name="builtRomPath">The freshly-built ROM path (SkillsTest.gba).</param>
+        /// <param name="targetPath">The build target path (its directory holds the .sym/.dmp sidecars).</param>
+        /// <param name="takeoverSkillAssignment">
+        /// 0 = do not carry over the parent patch's skill assignment (drops
+        /// UPDATE_METHOD=SKILLSYSTEM / EDIT_PATCH lines); non-zero = carry it over.
+        /// </param>
+        /// <param name="undo">Explicit undo scope the install writes into (NOT thread-local).</param>
+        public static MargeResult MargeAndUpdate(ROM rom, string originalRomPath,
+            string builtRomPath, string targetPath, uint takeoverSkillAssignment,
+            Undo.UndoData undo, Action<string> onProgress = null)
+        {
+            var result = new MargeResult();
+
+            if (rom == null)
+            {
+                result.ErrorMessage = R._("No ROM is loaded.");
+                return result;
+            }
+            if (undo == null)
+            {
+                result.ErrorMessage = R._("No ROM is loaded.");
+                return result;
+            }
+            if (string.IsNullOrEmpty(originalRomPath) || !File.Exists(originalRomPath))
+            {
+                result.ErrorMessage = R._("無改造ROM({0})が見つかりませんでした", originalRomPath ?? "");
+                return result;
+            }
+            if (string.IsNullOrEmpty(builtRomPath) || !File.Exists(builtRomPath))
+            {
+                result.ErrorMessage = R._("ターゲット({0})が見つかりませんでした。", builtRomPath ?? "");
+                return result;
+            }
+
+            string parentPatch = GetParentPatchPath();
+            if (!File.Exists(parentPatch))
+            {
+                result.ErrorMessage = R._("ベースとなるシステム({0})が見つかりませんでした", parentPatch);
+                return result;
+            }
+
+            byte[] originalBin, builtBin;
+            try
+            {
+                originalBin = File.ReadAllBytes(originalRomPath);
+                builtBin = File.ReadAllBytes(builtRomPath);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                result.ErrorMessage = R._("Unable to read the compiled file.\r\nfilename:{0}", builtRomPath)
+                    + "\r\n" + ex.ToString();
+                return result;
+            }
+
+            string cacheDir = GetCustomBuildCacheDir();
+            try
+            {
+                // Rebuild the CustomBuild cache directory from the parent patch dir,
+                // dropping the parent's own diffs + patch text (we regenerate them).
+                onProgress?.Invoke(R._("Preparing the CustomBuild patch..."));
+                if (!DelTree(cacheDir))
+                {
+                    result.ErrorMessage = R._(
+                        "カスタムビルドのキャッシュを削除できませんでした。\r\n以下のディレクトリを手動で消去してください。\r\n{0}",
+                        cacheDir);
+                    return result;
+                }
+                Directory.CreateDirectory(cacheDir);
+
+                string parentDir = Path.GetDirectoryName(parentPatch) ?? "";
+                CopyDirectoryShallow(parentDir, cacheDir);
+                DeleteFilesByPattern(cacheDir, "0*.bin");
+                DeleteFilesByPattern(cacheDir, "PATCH_*.txt");
+
+                // Copy the symbol + dump sidecars produced beside the build target.
+                string targetDir = string.IsNullOrEmpty(targetPath)
+                    ? "" : (Path.GetDirectoryName(Path.GetFullPath(targetPath)) ?? "");
+                CopySYM(targetDir, cacheDir);
+                CopySomeDumpFiles(targetDir, cacheDir);
+            }
+            catch (Exception ex)
+            {
+                result.ErrorMessage = R._(
+                    "Unable to write the temporary files needed for compilation.")
+                    + "\r\n" + ex.ToString();
+                return result;
+            }
+
+            // The CustomBuild tool targets FE8 (the view gates on version==8), so default
+            // to FE8U when RomInfo is unavailable; otherwise honour the loaded ROM's
+            // version/multibyte so the free-area span in MakeDiff matches FE8U vs FE8J.
+            int diffVersion = rom.RomInfo?.version ?? 8;
+            bool diffMultibyte = rom.RomInfo?.is_multibyte ?? false;
+
+            string custombuild = Path.Combine(cacheDir, CustomBuildPatchLeafName);
+            PatchInstallCore.PatchSt diffPatch;
+            try
+            {
+                // Diff the built ROM against vanilla → the CustomBuild BIN-diff patch.
+                // MakeDiff writes ONLY the pure literal-offset BIN subset (TYPE=BIN +
+                // BINF: lines + .bin sidecars), which is exactly what PatchInstallCore
+                // installs. We load THIS pre-merge diff for the fresh install (below),
+                // then overwrite the file with the parent-merged text as the on-disk
+                // artifact the full PatchForm engine consumes on a later re-install.
+                onProgress?.Invoke(R._("Generating the patch diff..."));
+                DiffToolCore.MakeDiff(custombuild, originalBin, builtBin,
+                    patchedIfMinSize: 10, collectFreeSpace: true,
+                    version: diffVersion, isMultibyte: diffMultibyte);
+                diffPatch = PatchInstallCore.LoadPatch(custombuild);
+            }
+            catch (Exception ex)
+            {
+                result.ErrorMessage = R._("Unable to write the compiled file: {0}", custombuild)
+                    + "\r\n" + ex.ToString();
+                return result;
+            }
+
+            // Auto-install the fresh CustomBuild diff (slice-1 BIN install). This is a
+            // FRESH install: a CustomBuild patch is BIN-diffs, and the parent's
+            // UPDATE_UNINSTALL is a no-op on first run, so applying the diff's BIN lines
+            // is all the install needs (no full PatchForm dependency-resolution engine).
+            if (diffPatch == null)
+            {
+                // MakeDiff produced no diff (built ROM == vanilla) → nothing to install.
+                // Still write the merged artifact below so the on-disk patch is valid.
+            }
+            else
+            {
+                try
+                {
+                    onProgress?.Invoke(R._("Installing the patch..."));
+                    PatchInstallCore.ApplyPatch(diffPatch, rom, undo);
+                }
+                catch (PatchInstallException pex)
+                {
+                    result.ErrorMessage = pex.Message;
+                    return result;
+                }
+                catch (Exception ex)
+                {
+                    result.ErrorMessage = R._("Failed to apply the compiled ROM (size/resize limit exceeded?).")
+                        + "\r\n" + ex.ToString();
+                    return result;
+                }
+            }
+
+            // Write the parent-merged patch text as the on-disk CustomBuild artifact
+            // (UPDATE_UNINSTALL of the parent + the carried-over parent lines + the diff).
+            // This overwrites the pure-diff file we just installed from.
+            try
+            {
+                MargePatch(custombuild, parentPatch, takeoverSkillAssignment);
+            }
+            catch (Exception ex)
+            {
+                result.ErrorMessage = R._("Unable to write the compiled file: {0}", custombuild)
+                    + "\r\n" + ex.ToString();
+                return result;
+            }
+            result.PatchPath = custombuild;
+
+            result.Success = true;
+            return result;
+        }
+
+        /// <summary>
+        /// Port of the WinForms <c>ToolCustomBuildForm.MargePatch</c>: build the merged
+        /// CustomBuild patch text by emitting an <c>UPDATE_UNINSTALL</c> of the parent
+        /// patch, then every parent line EXCEPT the parent's own diffs/metadata
+        /// (PATCHED_IF/BINF/BIN/AFTER_TRY_EXECUTE/NAME/INFO/TEXTADV/EXTENDS), and finally
+        /// the freshly-generated CustomBuild diff text. When
+        /// <paramref name="takeoverSkillAssignment"/> is 0 the skill-assignment lines
+        /// (UPDATE_METHOD=SKILLSYSTEM / EDIT_PATCH) are dropped too. Pure string filter —
+        /// no ROM, no UI.
+        /// </summary>
+        public static void MargePatch(string custombuild, string currentPatchFileName,
+            uint takeoverSkillAssignment)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("UPDATE_UNINSTALL:0=" + currentPatchFileName);
+            string[] lines = File.ReadAllLines(currentPatchFileName);
+            foreach (string line in lines)
+            {
+                if (line.IndexOf("PATCHED_IF") == 0) continue;
+                if (line.IndexOf("BINF:") == 0) continue;
+                if (line.IndexOf("BIN:") == 0) continue;
+                if (line.IndexOf("AFTER_TRY_EXECUTE:") == 0) continue;
+                if (line.IndexOf("NAME") == 0) continue;
+                if (line.IndexOf("INFO") == 0) continue;
+                if (line.IndexOf("TEXTADV:") == 0) continue;
+                if (line.IndexOf("EXTENDS:") == 0) continue;
+                if (takeoverSkillAssignment == 0)
+                {
+                    // Do not carry the parent's skill assignment over.
+                    if (line.IndexOf("UPDATE_METHOD=SKILLSYSTEM") == 0) continue;
+                    if (line.IndexOf("EDIT_PATCH:") == 0) continue;
+                }
+
+                sb.AppendLine(line);
+            }
+
+            sb.AppendLine(File.ReadAllText(custombuild));
+            File.WriteAllText(custombuild, sb.ToString());
+        }
+
+        /// <summary>Copy <c>SkillsTest.sym</c> from the build dir → <c>symbol.sym</c> in the cache.</summary>
+        static void CopySYM(string buildDir, string cacheDir)
+        {
+            if (string.IsNullOrEmpty(buildDir)) return;
+            string src = Path.Combine(buildDir, BuiltSymLeafName);
+            string dest = Path.Combine(cacheDir, "symbol.sym");
+            CopyFileIfExists(src, dest);
+        }
+
+        /// <summary>Copy the optional ASMC/skill dump sidecars from the build dir into the cache.</summary>
+        static void CopySomeDumpFiles(string buildDir, string cacheDir)
+        {
+            if (string.IsNullOrEmpty(buildDir)) return;
+            CopySomeDumpFile(buildDir, cacheDir, "ASMC_ForgetSkill.dmp", "ASMC_ForgetSkill.bin");
+            CopySomeDumpFile(buildDir, cacheDir, "ASMC_HasSkill.dmp", "ASMC_HasSkill.bin");
+            CopySomeDumpFile(buildDir, cacheDir, "ASMC_LearnSkill.dmp", "ASMC_LearnSkill.bin");
+            CopySomeDumpFile(buildDir, cacheDir, "GetSkills.dmp", "GetSkills.dmp");
+            CopySomeDumpFile(buildDir, cacheDir, "nihilTester.dmp", "nihilTester.dmp");
+            CopySomeDumpFile(buildDir, cacheDir, "rtextloop.dmp", "rtextloop.dmp");
+            CopySomeDumpFile(buildDir, cacheDir, "skillDescGetter.dmp", "skillDescGetter.dmp");
+        }
+
+        static void CopySomeDumpFile(string srcdir, string destdir, string srcfilename, string destfilename)
+        {
+            string src = FindFileOne(srcdir, srcfilename);
+            if (src == "") return;
+            CopyFileIfExists(src, Path.Combine(destdir, destfilename));
         }
 
         /// <summary>
@@ -372,6 +674,101 @@ namespace FEBuilderGBA
                 }
             }
             return sb.ToString();
+        }
+
+        // ===================================================================
+        //  File helpers — Core-local ports of the WinForms U.* directory ops
+        //  (U.DelTree / U.CopyDirectory / U.DeleteFile / U.CopyFile /
+        //  U.FindFileOne live in FEBuilderGBA/U.cs, which is WinForms-only;
+        //  these are the headless, no-Log.localization equivalents this tool
+        //  needs, mirroring AsmCompileCore's local FindFileOne precedent).
+        // ===================================================================
+
+        /// <summary>
+        /// Recursively delete <paramref name="dir"/> with a bounded retry (a build tool
+        /// may still hold a handle briefly). Returns true when the directory is gone (or
+        /// never existed). Mirrors WinForms <c>U.DelTree</c>.
+        /// </summary>
+        static bool DelTree(string dir, int retry = 10)
+        {
+            if (!Directory.Exists(dir))
+                return true;
+
+            for (int i = 0; i < retry; i++)
+            {
+                try
+                {
+                    Directory.Delete(dir, recursive: true);
+                    return true;
+                }
+                catch (Exception e)
+                {
+                    Log.Error("CustomBuildCore.DelTree: " + e.ToString());
+                }
+                System.Threading.Thread.Sleep(500);
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Recursively copy <paramref name="sourceDir"/> into <paramref name="destDir"/>
+        /// (files overwrite, empty sub-dirs are skipped). Headless port of WinForms
+        /// <c>U.CopyDirectory</c> minus the timestamp/attribute copy + localized Log calls.
+        /// </summary>
+        static void CopyDirectoryShallow(string sourceDir, string destDir)
+        {
+            if (!Directory.Exists(sourceDir))
+                return;
+
+            Directory.CreateDirectory(destDir);
+
+            foreach (string file in Directory.GetFiles(sourceDir))
+            {
+                string destFile = Path.Combine(destDir, Path.GetFileName(file));
+                File.Copy(file, destFile, overwrite: true);
+            }
+
+            foreach (string sub in Directory.GetDirectories(sourceDir))
+            {
+                // Skip empty sub-dirs (matches WF, which short-circuits IsEmptyDirectory).
+                if (Directory.GetFiles(sub).Length == 0 &&
+                    Directory.GetDirectories(sub).Length == 0)
+                    continue;
+                CopyDirectoryShallow(sub, Path.Combine(destDir, Path.GetFileName(sub)));
+            }
+        }
+
+        /// <summary>
+        /// Delete every top-level file in <paramref name="dir"/> matching
+        /// <paramref name="pattern"/>. Mirrors WinForms <c>U.DeleteFile</c> (top-dir only).
+        /// </summary>
+        static void DeleteFilesByPattern(string dir, string pattern)
+        {
+            if (!Directory.Exists(dir))
+                return;
+            foreach (string file in Directory.GetFiles(dir, pattern, SearchOption.TopDirectoryOnly))
+                File.Delete(file);
+        }
+
+        /// <summary>Copy <paramref name="src"/>→<paramref name="dest"/> only when the source exists (WF <c>U.CopyFile</c>).</summary>
+        static void CopyFileIfExists(string src, string dest)
+        {
+            if (!File.Exists(src))
+                return;
+            File.Copy(src, dest, overwrite: true);
+        }
+
+        /// <summary>
+        /// First file under <paramref name="path"/> (recursive) matching
+        /// <paramref name="name"/>, or "" when none. Mirrors WinForms <c>U.FindFileOne</c>
+        /// (same shape as <c>AsmCompileCore</c>'s local helper).
+        /// </summary>
+        static string FindFileOne(string path, string name)
+        {
+            if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
+                return "";
+            string[] files = U.Directory_GetFiles_Safe(path, name, SearchOption.AllDirectories);
+            return files.Length > 0 ? files[0] : "";
         }
     }
 }

--- a/FEBuilderGBA.Core/CustomBuildCore.cs
+++ b/FEBuilderGBA.Core/CustomBuildCore.cs
@@ -247,7 +247,7 @@ namespace FEBuilderGBA
             }
             if (undo == null)
             {
-                result.ErrorMessage = R._("No ROM is loaded.");
+                result.ErrorMessage = R._("Undo data is required for MargeAndUpdate.");
                 return result;
             }
             if (string.IsNullOrEmpty(originalRomPath) || !File.Exists(originalRomPath))
@@ -348,12 +348,12 @@ namespace FEBuilderGBA
             // FRESH install: a CustomBuild patch is BIN-diffs, and the parent's
             // UPDATE_UNINSTALL is a no-op on first run, so applying the diff's BIN lines
             // is all the install needs (no full PatchForm dependency-resolution engine).
-            if (diffPatch == null)
-            {
-                // MakeDiff produced no diff (built ROM == vanilla) → nothing to install.
-                // Still write the merged artifact below so the on-disk patch is valid.
-            }
-            else
+            //
+            // MakeDiff always writes a TYPE=BIN header, so LoadPatch never returns null;
+            // the meaningful "no actual changes" case is when the built ROM equals the
+            // vanilla ROM, which emits NO BIN/BINF entries. Skip the install in that case
+            // (nothing to apply) but still write the merged artifact below.
+            if (PatchHasBinEntries(diffPatch))
             {
                 try
                 {
@@ -430,6 +430,28 @@ namespace FEBuilderGBA
 
             sb.AppendLine(File.ReadAllText(custombuild));
             File.WriteAllText(custombuild, sb.ToString());
+        }
+
+        /// <summary>
+        /// True when <paramref name="patch"/> carries at least one BIN/BINF write entry.
+        /// A vanilla→built diff with NO actual byte changes produces a TYPE=BIN header
+        /// but no BIN/BINF lines, so this distinguishes a real diff from an empty one.
+        /// </summary>
+        static bool PatchHasBinEntries(PatchInstallCore.PatchSt patch)
+        {
+            if (patch?.Param == null)
+            {
+                return false;
+            }
+            foreach (string key in patch.Param.Keys)
+            {
+                if (key.StartsWith("BINF:", StringComparison.Ordinal)
+                    || key.StartsWith("BIN:", StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         /// <summary>Copy <c>SkillsTest.sym</c> from the build dir → <c>symbol.sym</c> in the cache.</summary>

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20754,3 +20754,6 @@ Patch: {0}
 :Unable to write the compiled file: {0}
 Unable to write the compiled file: {0}
 
+:Undo data is required for MargeAndUpdate.
+Undo data is required for MargeAndUpdate.
+

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20748,6 +20748,9 @@ Marge and Update successful.
 :Marge and Update failed.
 Marge and Update failed.
 
+:MargeAndUpdate must install into the currently loaded ROM.
+MargeAndUpdate must install into the currently loaded ROM.
+
 :Patch: {0}
 Patch: {0}
 

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20721,3 +20721,36 @@ Could not read the event file: {0}
 :Png2Dmp image (no .dmp hint): {0}
 Png2Dmp image (no .dmp hint): {0}
 
+:Marge and Update
+Marge and Update
+
+:Skill assignment:
+Skill assignment:
+
+:Do not carry over the skill assignment
+Do not carry over the skill assignment
+
+:Carry over the skill assignment
+Carry over the skill assignment
+
+:Preparing the CustomBuild patch...
+Preparing the CustomBuild patch...
+
+:Generating the patch diff...
+Generating the patch diff...
+
+:Installing the patch...
+Installing the patch...
+
+:Marge and Update successful.
+Marge and Update successful.
+
+:Marge and Update failed.
+Marge and Update failed.
+
+:Patch: {0}
+Patch: {0}
+
+:Unable to write the compiled file: {0}
+Unable to write the compiled file: {0}
+

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -12059,3 +12059,36 @@ Png2Dmp画像(.dmpヒントなし): {0}
 :No font glyphs were exported.
 エクスポートするフォントがありませんでした。
 
+:Marge and Update
+マージして更新
+
+:Skill assignment:
+スキル割り当て:
+
+:Do not carry over the skill assignment
+スキル割り当てを引き継がない
+
+:Carry over the skill assignment
+スキル割り当てを引き継ぐ
+
+:Preparing the CustomBuild patch...
+カスタムビルドパッチを準備しています...
+
+:Generating the patch diff...
+パッチの差分を生成しています...
+
+:Installing the patch...
+パッチをインストールしています...
+
+:Marge and Update successful.
+マージと更新に成功しました。
+
+:Marge and Update failed.
+マージと更新に失敗しました。
+
+:Patch: {0}
+パッチ: {0}
+
+:Unable to write the compiled file: {0}
+コンパイル済みファイルを書き込めません: {0}
+

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -12086,6 +12086,9 @@ Png2Dmp画像(.dmpヒントなし): {0}
 :Marge and Update failed.
 マージと更新に失敗しました。
 
+:MargeAndUpdate must install into the currently loaded ROM.
+マージと更新は、現在読み込まれているROMにインストールする必要があります。
+
 :Patch: {0}
 パッチ: {0}
 

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -12092,3 +12092,6 @@ Png2Dmp画像(.dmpヒントなし): {0}
 :Unable to write the compiled file: {0}
 コンパイル済みファイルを書き込めません: {0}
 
+:Undo data is required for MargeAndUpdate.
+MargeAndUpdate には Undo データが必要です。
+

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25927,6 +25927,9 @@ Png2Dmp 图像（无 .dmp 提示）：{0}
 :Marge and Update failed.
 合并并更新失败。
 
+:MargeAndUpdate must install into the currently loaded ROM.
+合并并更新必须安装到当前加载的ROM中。
+
 :Patch: {0}
 补丁: {0}
 

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25900,3 +25900,36 @@ Png2Dmp 图像（无 .dmp 提示）：{0}
 :No font glyphs were exported.
 没有可导出的字体字形。
 
+:Marge and Update
+合并并更新
+
+:Skill assignment:
+技能分配:
+
+:Do not carry over the skill assignment
+不继承技能分配
+
+:Carry over the skill assignment
+继承技能分配
+
+:Preparing the CustomBuild patch...
+正在准备自定义构建补丁...
+
+:Generating the patch diff...
+正在生成补丁差异...
+
+:Installing the patch...
+正在安装补丁...
+
+:Marge and Update successful.
+合并并更新成功。
+
+:Marge and Update failed.
+合并并更新失败。
+
+:Patch: {0}
+补丁: {0}
+
+:Unable to write the compiled file: {0}
+无法写入已编译的文件: {0}
+

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -25933,3 +25933,6 @@ Png2Dmp 图像（无 .dmp 提示）：{0}
 :Unable to write the compiled file: {0}
 无法写入已编译的文件: {0}
 
+:Undo data is required for MargeAndUpdate.
+MargeAndUpdate 需要撤销数据。
+


### PR DESCRIPTION
## Summary
**Slice 2** of #1248 — wires the Custom Build **MargeAndUpdate auto-install** into the Avalonia tool, **closing #1248**. Builds on the merged Slice-1 `PatchInstallCore`.

**Confirmed:** a CustomBuild patch is pure literal-offset BIN-diffs (`DiffToolCore.MakeDiff` → `TYPE=BIN` + `BINF:` + `.bin` sidecars) — exactly `PatchInstallCore.ApplyPatch`'s subset — so MargeAndUpdate is wireable **without** the deep `PatchForm.UpdatePatch` dependency-resolution engine (fresh install → the parent's `UPDATE_UNINSTALL` is a no-op).

## Changes
- **`CustomBuildCore.MargeAndUpdate(...)`** + `MargePatch` (Core static) + `CopySYM`/`CopySomeDumpFiles` + cache-dir mgmt + 5 file-helper ports (U.DelTree/CopyDirectory/… are WinForms-only, so ported Core-local like AsmCompileCore's `FindFileOne`). Removed the deferred claim.
- **`ToolCustomBuildViewModel`** — `RunAndMarge(undo)` + TakeoverSkillAssignment; still **not** `IDataVerifiable` (read-no-ROM aggregator). **`ToolCustomBuildView`** — "Marge and Update" button + skill-assignment combo, bg `Task.Run` + **explicit `Undo.UndoData` + `CommitExternal`** (no ambient undo on the bg thread). Deferred claims removed from all files.
- Tests: +5 Core (CustomBuildCoreTests), +3 VM. 11 ja/zh/en keys.

End-to-end: Build → rebuild skill_CustomBuild cache → `MakeDiff(vanilla, built)` → `LoadPatch`+`ApplyPatch` the BIN diff (into the explicit UndoData) → `MargePatch` writes the parent-merged artifact.

## Tests
- Core.Tests **4445** / 0; Avalonia.Tests **8383** / 0; FEBuilderGBA.Tests (windows) **1865** / 0; automation-ids **0/0/0**. The synthetic round-trip drives `rom.Data == built bytes` + merged-artifact write + cache cleanup + undo-restores-vanilla, plus takeover filter + missing-ROM/parent guards.

The live full-pipeline GUI hits the skill-editor ROM-detection wall (no Avalonia editor detects a SkillSystems ROM headlessly — same posture as #1172), so the functional proof is the synthetic Core round-trip; headless view render below shows the new action.

Fixes #1248

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
