### PR TITLE
feat(core): ROM-rebuild struct-pointer producer — data-driven descriptor batch (#1261 slice 2a)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -248,65 +248,41 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
-        public void WalkAndAdd_BoundsCheck_UsesPassedRom_NotCoreStateRom()
+        public void MakeAllStructPointers_RejectsRomThatIsNotCoreStateRom()
         {
-            // CoreState.ROM is a LARGE rom; the scanned `rom` is SMALL. A pointer/table that is
-            // valid in the small rom must still be walked, and a base whose reads would exceed the
-            // SMALL rom's length must NOT throw (the bug: U.isSafetyOffset(uint) used CoreState.ROM
-            // bounds, so the rom.u8/u16/u32 reads in getBlockDataCount could throw OOB).
-            var bigRom = new ROM();
-            bigRom.SwapNewROMDataDirect(new byte[0x40000]); // large ambient rom
-            CoreState.ROM = bigRom;
+            // The producer must scan the LOADED CoreState.ROM — Address length/offset validation
+            // is bound to CoreState.ROM, so a different instance cannot be scanned correctly.
+            var loaded = new ROM();
+            loaded.SwapNewROMDataDirect(new byte[0x2000]);
+            CoreState.ROM = loaded;
 
-            // The rom we actually scan is independent and much smaller.
-            var smallRom = new ROM();
-            smallRom.SwapNewROMDataDirect(new byte[0x2000]);
-            uint pointer = 0x0240;
-            uint table = 0x1000;
-            smallRom.write_u32(pointer, Ptr(table));
-            smallRom.write_u8(table + 0, 0x01);
-            smallRom.write_u8(table + 1, 0x00); // terminator (blockSize 1, u8!=0)
+            var other = new ROM();
+            other.SwapNewROMDataDirect(new byte[0x2000]);
 
-            var d = new RebuildProducerCore.StructDescriptor
-            {
-                Name = "CrossRom",
-                PointerField = _ => pointer,
-                BlockSize = 1,
-                Rule = RebuildProducerCore.DataCountRule.U8NotEqual,
-                RuleOffset = 0,
-                RuleStopValue = 0x00,
-                PointerIndexes = new uint[] { },
-            };
+            var ex = Assert.Throws<ArgumentException>(
+                () => RebuildProducerCore.MakeAllStructPointers(other));
+            Assert.Equal("rom", ex.ParamName);
 
-            var list = new List<Address>();
-            // Must not throw, and must emit the table found in the SMALL rom.
-            RebuildProducerCore.WalkAndAdd(smallRom, list, d);
-
-            Assert.Single(list);
-            Assert.Equal(table, list[0].Addr);
-            Assert.Equal(1u * (1 + 1), list[0].Length); // 1 entry -> block*(count+1)
+            // The list-returning overload guards the same way.
+            Assert.Throws<ArgumentException>(
+                () => RebuildProducerCore.MakeAllStructPointersList(other));
         }
 
         [Fact]
-        public void WalkAndAdd_PointerPastPassedRomEnd_DoesNotThrow_EmitsNothing()
+        public void WalkAndAdd_BlockSizeZero_EmitsNothing_AndDoesNotHang()
         {
-            // A pointer slot whose VALUE is valid in the big ambient rom but points PAST the
-            // small scanned rom must be rejected by the passed-rom bounds check (no OOB throw).
-            var bigRom = new ROM();
-            bigRom.SwapNewROMDataDirect(new byte[0x40000]);
-            CoreState.ROM = bigRom;
-
-            var smallRom = new ROM();
-            smallRom.SwapNewROMDataDirect(new byte[0x2000]);
+            // BlockSize 0 would make getBlockDataCount loop forever (addr += 0). EmitOne must
+            // skip it (a zero block is a descriptor bug, not a hang).
+            var rom = CreateTestRom();
             uint pointer = 0x0240;
-            // table offset 0x30000 is valid in bigRom but PAST smallRom's 0x2000 end.
-            smallRom.write_u32(pointer, Ptr(0x30000));
+            uint table = 0x1000;
+            rom.write_u32(pointer, Ptr(table));
 
             var d = new RebuildProducerCore.StructDescriptor
             {
-                Name = "OOB",
+                Name = "ZeroBlock",
                 PointerField = _ => pointer,
-                BlockSize = 4,
+                BlockSize = 0, // bug
                 Rule = RebuildProducerCore.DataCountRule.U8NotEqual,
                 RuleOffset = 0,
                 RuleStopValue = 0x00,
@@ -314,9 +290,33 @@ namespace FEBuilderGBA.Core.Tests
             };
 
             var list = new List<Address>();
-            var ex = Record.Exception(() => RebuildProducerCore.WalkAndAdd(smallRom, list, d));
-            Assert.Null(ex);     // no IndexOutOfRangeException
-            Assert.Empty(list);  // base past the scanned rom -> nothing emitted
+            RebuildProducerCore.WalkAndAdd(rom, list, d); // must return (not hang)
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void WalkAndAdd_UnhandledDataCountRule_ThrowsLoudly()
+        {
+            // An out-of-range DataCountRule is a programming error — MakeIsDataExists must throw,
+            // not silently treat the table as 0 entries.
+            var rom = CreateTestRom();
+            uint pointer = 0x0240;
+            uint table = 0x1000;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u8(table + 0, 0x01);
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "BadRule",
+                PointerField = _ => pointer,
+                BlockSize = 1,
+                Rule = (RebuildProducerCore.DataCountRule)999, // invalid
+                PointerIndexes = new uint[] { },
+            };
+
+            var list = new List<Address>();
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => RebuildProducerCore.WalkAndAdd(rom, list, d));
         }
 
         // ---- plumbing: cancellation returns partial list --------------------

--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -1,0 +1,352 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="RebuildProducerCore"/> (#1261 slice 2a).
+    /// Synthetic ROMs prove the descriptor-driven walker reproduces the WinForms
+    /// <c>MakeAllDataLength</c> "table walk + IFR Address" behaviour for each
+    /// <see cref="RebuildProducerCore.DataCountRule"/>; a real-FE8U test proves the
+    /// batch finds the known item/class tables at the expected counts.
+    /// </summary>
+    [Collection("SharedState")]
+    public class RebuildProducerCoreTests
+    {
+        // ---- helpers -------------------------------------------------------
+
+        static ROM CreateTestRom(int size = 0x4000)
+        {
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(new byte[size]);
+            CoreState.ROM = rom;
+            return rom;
+        }
+
+        // GBA pointer = offset | 0x08000000
+        static uint Ptr(uint offset) => offset | 0x08000000;
+
+        // ---- WalkAndAdd: each DataCountRule reproduces InputFormRef walk -----
+
+        [Fact]
+        public void WalkAndAdd_U8NotEqual_StopsAtTerminator_AndEmitsLengthPlusOne()
+        {
+            var rom = CreateTestRom();
+            // table at 0x1000, blockSize 2, terminator u8(addr+0)==0xFF; 3 valid entries
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u8(table + 0, 0x01);
+            rom.write_u8(table + 2, 0x02);
+            rom.write_u8(table + 4, 0x03);
+            rom.write_u8(table + 6, 0xFF); // terminator
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "T",
+                PointerField = _ => pointer,
+                BlockSize = 2,
+                Rule = RebuildProducerCore.DataCountRule.U8NotEqual,
+                RuleOffset = 0,
+                RuleStopValue = 0xFF,
+                PointerIndexes = new uint[] { },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            Assert.Single(list);
+            Address a = list[0];
+            Assert.Equal(table, a.Addr);
+            Assert.Equal(pointer, a.Pointer);
+            Assert.Equal(2u, a.BlockSize);
+            // dataCount = 3, length = blockSize * (count + 1) = 2 * 4 = 8
+            Assert.Equal(8u, a.Length);
+            Assert.Equal(Address.DataTypeEnum.InputFormRef, a.DataType);
+        }
+
+        [Fact]
+        public void WalkAndAdd_FixedCount_EmitsExactCount()
+        {
+            var rom = CreateTestRom();
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            rom.write_u32(pointer, Ptr(table));
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "Fixed8",
+                PointerField = _ => pointer,
+                BlockSize = 20,
+                Rule = RebuildProducerCore.DataCountRule.FixedCount,
+                RuleFixedCount = 8,
+                PointerIndexes = new uint[] { },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            Assert.Single(list);
+            // length = 20 * (8 + 1) = 180
+            Assert.Equal(180u, list[0].Length);
+        }
+
+        [Fact]
+        public void WalkAndAdd_U8NotZeroIndex0Always_CountsEntryZeroEvenIfZero()
+        {
+            var rom = CreateTestRom();
+            // ClassForm rule: i==0 always exists; else u8(addr+4)!=0.
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            uint block = 16;
+            rom.write_u32(pointer, Ptr(table));
+            // entry 0: u8(+4)==0 but still counts
+            // entry 1: u8(+4)=5 -> exists
+            rom.write_u8(table + block + 4, 0x05);
+            // entry 2: u8(+4)==0 -> stop
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "Class",
+                PointerField = _ => pointer,
+                BlockSize = block,
+                Rule = RebuildProducerCore.DataCountRule.U8NotZeroIndex0Always,
+                RuleOffset = 4,
+                MaxCount = 0x100,
+                PointerIndexes = new uint[] { },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            Assert.Single(list);
+            // dataCount = 2 (entries 0 and 1), length = 16 * (2 + 1) = 48
+            Assert.Equal(48u, list[0].Length);
+        }
+
+        [Fact]
+        public void WalkAndAdd_U16NotZero_StopsAtZeroU16()
+        {
+            var rom = CreateTestRom();
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u16(table + 0, 0x0011);
+            rom.write_u16(table + 2, 0x0022);
+            rom.write_u16(table + 4, 0x0000); // stop
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "TerrainEng",
+                PointerField = _ => pointer,
+                BlockSize = 2,
+                Rule = RebuildProducerCore.DataCountRule.U16NotZero,
+                RuleOffset = 0,
+                PointerIndexes = new uint[] { },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            Assert.Single(list);
+            // dataCount = 2, length = 2 * 3 = 6
+            Assert.Equal(6u, list[0].Length);
+        }
+
+        [Fact]
+        public void WalkAndAdd_MultiPointer_EmitsOnePerNonZeroPointer()
+        {
+            var rom = CreateTestRom();
+            uint p0 = 0x0240, p1 = 0x0244, p2 = 0x0248;
+            uint t0 = 0x1000, t2 = 0x1100;
+            rom.write_u32(p0, Ptr(t0));
+            rom.write_u8(t0 + 0, 0x01);
+            rom.write_u8(t0 + 1, 0x00); // terminator (blockSize 1, u8!=0)
+            // p1 left zero -> skipped
+            rom.write_u32(p2, Ptr(t2));
+            rom.write_u8(t2 + 0, 0x05);
+            rom.write_u8(t2 + 1, 0x06);
+            rom.write_u8(t2 + 2, 0x00); // terminator
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "Multi",
+                PointerFields = _ => new uint[] { p0, p1, p2 },
+                BlockSize = 1,
+                Rule = RebuildProducerCore.DataCountRule.U8NotEqual,
+                RuleOffset = 0,
+                RuleStopValue = 0x00,
+                PointerIndexes = new uint[] { },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            // p1 is zero -> only 2 Addresses
+            Assert.Equal(2, list.Count);
+            Assert.Equal(t0, list[0].Addr);
+            Assert.Equal(t2, list[1].Addr);
+            // t0: dataCount 1 -> length 1*(1+1)=2 ; t2: dataCount 2 -> length 1*3=3
+            Assert.Equal(2u, list[0].Length);
+            Assert.Equal(3u, list[1].Length);
+        }
+
+        [Fact]
+        public void WalkAndAdd_PointerIndexes_ArePreservedOnAddress()
+        {
+            var rom = CreateTestRom();
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            rom.write_u32(pointer, Ptr(table));
+            // 1 entry exists, then a zero terminator at +0x24.
+            rom.write_u16(table + 0, 0x0001);
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "Item",
+                PointerField = _ => pointer,
+                BlockSize = 0x24,
+                Rule = RebuildProducerCore.DataCountRule.U16NotZero,
+                RuleOffset = 0,
+                MaxCount = 0x100,
+                PointerIndexes = new uint[] { 12, 16 },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            Assert.Single(list);
+            Assert.Equal(new uint[] { 12, 16 }, list[0].PointerIndexes);
+        }
+
+        [Fact]
+        public void WalkAndAdd_UnsafePointer_EmitsNothing()
+        {
+            var rom = CreateTestRom();
+            uint pointer = 0x0240;
+            // pointer slot holds a bogus value (not a safe ROM pointer)
+            rom.write_u32(pointer, 0xFFFFFFFF);
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "Bad",
+                PointerField = _ => pointer,
+                BlockSize = 4,
+                Rule = RebuildProducerCore.DataCountRule.U8NotEqual,
+                RuleOffset = 0,
+                RuleStopValue = 0x00,
+                PointerIndexes = new uint[] { },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            Assert.Empty(list);
+        }
+
+        // ---- plumbing: cancellation returns partial list --------------------
+
+        [Fact]
+        public void MakeAllStructPointersList_Cancelled_ReturnsImmediately()
+        {
+            var rom = CreateTestRom();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var list = RebuildProducerCore.MakeAllStructPointersList(rom, null, cts.Token);
+
+            // Cancelled before processing any descriptor -> empty list (no throw).
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void MakeAllStructPointersList_NullRom_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => RebuildProducerCore.MakeAllStructPointersList(null));
+        }
+
+        [Fact]
+        public void GetNotYetPortedForms_IsNonEmpty_AndTracksDeferredCoverage()
+        {
+            string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
+            Assert.NotEmpty(notYet);
+            // The heavy editors that need extraction first must be tracked, not dropped.
+            Assert.Contains("TextForm", notYet);
+            Assert.Contains("EventCondForm", notYet);
+            Assert.Contains("SongTableForm", notYet);
+        }
+
+        // ---- real-FE8U parity: the batch finds the known tables -------------
+
+        [Fact]
+        public void MakeAllStructPointersList_FE8U_FindsKnownItemAndClassTables()
+        {
+            string romPath = FindTestRom();
+            if (romPath == null) return; // skip when no ROM available (env-only)
+
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var rom = new ROM();
+                if (!rom.Load(romPath, out string _)) return; // skip
+                CoreState.ROM = rom;
+                if (rom.RomInfo.version != 8) return; // this assertion is FE8U-specific
+
+                var progressLines = new List<string>();
+                var progress = new Progress<string>(s => progressLines.Add(s));
+                List<Address> list = RebuildProducerCore.MakeAllStructPointersList(rom);
+
+                Assert.NotEmpty(list);
+
+                // The item table must be present at the RomInfo.item_pointer target,
+                // with the {12,16} pointer columns and a sane FE8U item count (~0x9F).
+                uint itemBase = rom.p32(rom.RomInfo.item_pointer);
+                Address item = list.FirstOrDefault(a => a.Addr == itemBase && a.Info == "Item");
+                Assert.NotNull(item);
+                Assert.Equal(rom.RomInfo.item_datasize, item.BlockSize);
+                Assert.Equal(new uint[] { 12, 16 }, item.PointerIndexes);
+                uint itemCount = item.Length / item.BlockSize - 1; // length = block*(count+1)
+                Assert.True(itemCount >= 0x80 && itemCount <= 0x100,
+                    "FE8U item count out of expected range: 0x" + itemCount.ToString("X"));
+
+                // The class table must be present too.
+                uint classBase = rom.p32(rom.RomInfo.class_pointer);
+                Address cls = list.FirstOrDefault(a => a.Addr == classBase && a.Info == "Class");
+                Assert.NotNull(cls);
+                Assert.Equal(rom.RomInfo.class_datasize, cls.BlockSize);
+                uint classCount = cls.Length / cls.BlockSize - 1;
+                Assert.True(classCount >= 0x40 && classCount <= 0x100,
+                    "FE8U class count out of expected range: 0x" + classCount.ToString("X"));
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+            }
+        }
+
+        static string FindTestRom()
+        {
+            string thisAssembly = System.Reflection.Assembly.GetExecutingAssembly().Location;
+            string dir = System.IO.Path.GetDirectoryName(thisAssembly);
+            for (int i = 0; i < 10 && dir != null; i++)
+            {
+                if (System.IO.File.Exists(System.IO.Path.Combine(dir, "FEBuilderGBA.sln")))
+                {
+                    string romsDir = System.IO.Path.Combine(dir, "roms");
+                    if (System.IO.Directory.Exists(romsDir))
+                    {
+                        string path = System.IO.Path.Combine(romsDir, "FE8U.gba");
+                        if (System.IO.File.Exists(path)) return path;
+                    }
+                    break;
+                }
+                dir = System.IO.Path.GetDirectoryName(dir);
+            }
+            return null;
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -247,6 +247,78 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Empty(list);
         }
 
+        [Fact]
+        public void WalkAndAdd_BoundsCheck_UsesPassedRom_NotCoreStateRom()
+        {
+            // CoreState.ROM is a LARGE rom; the scanned `rom` is SMALL. A pointer/table that is
+            // valid in the small rom must still be walked, and a base whose reads would exceed the
+            // SMALL rom's length must NOT throw (the bug: U.isSafetyOffset(uint) used CoreState.ROM
+            // bounds, so the rom.u8/u16/u32 reads in getBlockDataCount could throw OOB).
+            var bigRom = new ROM();
+            bigRom.SwapNewROMDataDirect(new byte[0x40000]); // large ambient rom
+            CoreState.ROM = bigRom;
+
+            // The rom we actually scan is independent and much smaller.
+            var smallRom = new ROM();
+            smallRom.SwapNewROMDataDirect(new byte[0x2000]);
+            uint pointer = 0x0240;
+            uint table = 0x1000;
+            smallRom.write_u32(pointer, Ptr(table));
+            smallRom.write_u8(table + 0, 0x01);
+            smallRom.write_u8(table + 1, 0x00); // terminator (blockSize 1, u8!=0)
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "CrossRom",
+                PointerField = _ => pointer,
+                BlockSize = 1,
+                Rule = RebuildProducerCore.DataCountRule.U8NotEqual,
+                RuleOffset = 0,
+                RuleStopValue = 0x00,
+                PointerIndexes = new uint[] { },
+            };
+
+            var list = new List<Address>();
+            // Must not throw, and must emit the table found in the SMALL rom.
+            RebuildProducerCore.WalkAndAdd(smallRom, list, d);
+
+            Assert.Single(list);
+            Assert.Equal(table, list[0].Addr);
+            Assert.Equal(1u * (1 + 1), list[0].Length); // 1 entry -> block*(count+1)
+        }
+
+        [Fact]
+        public void WalkAndAdd_PointerPastPassedRomEnd_DoesNotThrow_EmitsNothing()
+        {
+            // A pointer slot whose VALUE is valid in the big ambient rom but points PAST the
+            // small scanned rom must be rejected by the passed-rom bounds check (no OOB throw).
+            var bigRom = new ROM();
+            bigRom.SwapNewROMDataDirect(new byte[0x40000]);
+            CoreState.ROM = bigRom;
+
+            var smallRom = new ROM();
+            smallRom.SwapNewROMDataDirect(new byte[0x2000]);
+            uint pointer = 0x0240;
+            // table offset 0x30000 is valid in bigRom but PAST smallRom's 0x2000 end.
+            smallRom.write_u32(pointer, Ptr(0x30000));
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "OOB",
+                PointerField = _ => pointer,
+                BlockSize = 4,
+                Rule = RebuildProducerCore.DataCountRule.U8NotEqual,
+                RuleOffset = 0,
+                RuleStopValue = 0x00,
+                PointerIndexes = new uint[] { },
+            };
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.WalkAndAdd(smallRom, list, d));
+            Assert.Null(ex);     // no IndexOutOfRangeException
+            Assert.Empty(list);  // base past the scanned rom -> nothing emitted
+        }
+
         // ---- plumbing: cancellation returns partial list --------------------
 
         [Fact]
@@ -282,6 +354,21 @@ namespace FEBuilderGBA.Core.Tests
             // MoveCost) the descriptor walker cannot emit yet -> must be DEFERRED, not in the batch.
             Assert.Contains("ItemForm", notYet);
             Assert.Contains("ClassForm", notYet);
+        }
+
+        [Fact]
+        public void GetNotYetPortedForms_HasNoDuplicates()
+        {
+            // Duplicates would inflate the count and make the IsComplete gate
+            // ("empty == safe to wire into a real defragment") unreliable. Assert BOTH the public
+            // (dedup'd) view AND the raw literal are duplicate-free.
+            string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
+            Assert.Equal(notYet.Length, notYet.Distinct().Count());
+
+            string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
+            var dups = raw.GroupBy(s => s).Where(g => g.Count() > 1).Select(g => g.Key).ToArray();
+            Assert.True(dups.Length == 0,
+                "NotYetPorted raw list has duplicate entries: " + string.Join(", ", dups));
         }
 
         [Fact]
@@ -342,7 +429,10 @@ namespace FEBuilderGBA.Core.Tests
                 CoreState.ROM = rom;
                 if (rom.RomInfo.version != 8) return; // this assertion is FE8U-specific
 
-                List<Address> list = RebuildProducerCore.MakeAllStructPointersList(rom);
+                // Pass a progress collector through and assert reporting happens (does not throw).
+                var progressLines = new List<string>();
+                var progress = new Progress<string>(s => { lock (progressLines) progressLines.Add(s); });
+                List<Address> list = RebuildProducerCore.MakeAllStructPointersList(rom, progress);
                 Assert.NotEmpty(list);
 
                 // SupportAttribute table (a clean single-walk batch form) must be present
@@ -361,6 +451,16 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.Equal(20u, ai3.BlockSize);
                 Assert.Equal(20u * (8 + 1), ai3.Length); // fixed 8 -> length = 20*(8+1)
 
+                // ArenaClass emits THREE separate tables with DISTINCT WF Info strings (faithfulness
+                // fix — not one collapsed multi-pointer entry). Each base must be present by its
+                // own RomInfo pointer with the matching Info label.
+                uint arNear = rom.p32(rom.RomInfo.arena_class_near_weapon_pointer);
+                Assert.Contains(list, a => a.Addr == arNear && a.Info == "AreaClassForm near weapon");
+                uint arFar = rom.p32(rom.RomInfo.arena_class_far_weapon_pointer);
+                Assert.Contains(list, a => a.Addr == arFar && a.Info == "AreaClassForm far weapon");
+                uint arMagic = rom.p32(rom.RomInfo.arena_class_magic_weapon_pointer);
+                Assert.Contains(list, a => a.Addr == arMagic && a.Info == "AreaClassForm magic weapon");
+
                 // FAITHFULNESS / COMPLETENESS-SAFETY: Item and Class are NOT emitted by this
                 // slice (embedded sub-pointer blocks). They must be absent from the list AND
                 // tracked in NotYetPorted so a rebuild does not silently drop their sub-blocks.
@@ -368,6 +468,13 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.DoesNotContain(list, a => a.Addr == itemBase && a.Info == "Item");
                 uint classBase = rom.p32(rom.RomInfo.class_pointer);
                 Assert.DoesNotContain(list, a => a.Addr == classBase && a.Info == "Class");
+
+                // The progress collector must have received reports (per-descriptor + summary).
+                lock (progressLines)
+                {
+                    Assert.NotEmpty(progressLines);
+                    Assert.Contains(progressLines, s => s.Contains("not-yet-ported"));
+                }
             }
             finally
             {

--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -278,12 +278,58 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Contains("TextForm", notYet);
             Assert.Contains("EventCondForm", notYet);
             Assert.Contains("SongTableForm", notYet);
+            // Item/Class have embedded per-entry sub-pointer blocks (StatBooster/effectiveness,
+            // MoveCost) the descriptor walker cannot emit yet -> must be DEFERRED, not in the batch.
+            Assert.Contains("ItemForm", notYet);
+            Assert.Contains("ClassForm", notYet);
+        }
+
+        [Fact]
+        public void MakeAllStructPointers_Cancelled_ReportsIncompleteAndCancelled()
+        {
+            var rom = CreateTestRom();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            RebuildProducerCore.ProducerResult result = RebuildProducerCore.MakeAllStructPointers(rom, null, cts.Token);
+            // Pre-cancel returns before the descriptor walk (no RomInfo needed) and still
+            // surfaces the coverage state.
+            Assert.True(result.Cancelled);
+            Assert.False(result.IsComplete);   // NotYetPorted is non-empty regardless of cancel
+            Assert.NotEmpty(result.NotYetPorted);
+            Assert.Empty(result.List);
+        }
+
+        [Fact]
+        public void MakeAllStructPointers_FE8U_ReportsIncomplete_WhileFormsRemain()
+        {
+            string romPath = FindTestRom();
+            if (romPath == null) return; // skip when no ROM available (env-only)
+
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var rom = new ROM();
+                if (!rom.Load(romPath, out string _)) return; // skip
+                CoreState.ROM = rom;
+
+                RebuildProducerCore.ProducerResult result = RebuildProducerCore.MakeAllStructPointers(rom);
+                // COMPLETENESS-SAFETY: while any form is un-ported the result must report incomplete
+                // so a future wiring slice refuses to feed a partial list to a real defragment.
+                Assert.False(result.IsComplete);
+                Assert.NotEmpty(result.NotYetPorted);
+                Assert.False(result.Cancelled);
+                Assert.NotEmpty(result.List);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+            }
         }
 
         // ---- real-FE8U parity: the batch finds the known tables -------------
 
         [Fact]
-        public void MakeAllStructPointersList_FE8U_FindsKnownItemAndClassTables()
+        public void MakeAllStructPointersList_FE8U_FindsBatchTables_AndDefersItemClass()
         {
             string romPath = FindTestRom();
             if (romPath == null) return; // skip when no ROM available (env-only)
@@ -296,31 +342,32 @@ namespace FEBuilderGBA.Core.Tests
                 CoreState.ROM = rom;
                 if (rom.RomInfo.version != 8) return; // this assertion is FE8U-specific
 
-                var progressLines = new List<string>();
-                var progress = new Progress<string>(s => progressLines.Add(s));
                 List<Address> list = RebuildProducerCore.MakeAllStructPointersList(rom);
-
                 Assert.NotEmpty(list);
 
-                // The item table must be present at the RomInfo.item_pointer target,
-                // with the {12,16} pointer columns and a sane FE8U item count (~0x9F).
-                uint itemBase = rom.p32(rom.RomInfo.item_pointer);
-                Address item = list.FirstOrDefault(a => a.Addr == itemBase && a.Info == "Item");
-                Assert.NotNull(item);
-                Assert.Equal(rom.RomInfo.item_datasize, item.BlockSize);
-                Assert.Equal(new uint[] { 12, 16 }, item.PointerIndexes);
-                uint itemCount = item.Length / item.BlockSize - 1; // length = block*(count+1)
-                Assert.True(itemCount >= 0x80 && itemCount <= 0x100,
-                    "FE8U item count out of expected range: 0x" + itemCount.ToString("X"));
+                // SupportAttribute table (a clean single-walk batch form) must be present
+                // with the correct block size and a terminator-bounded count.
+                uint saBase = rom.p32(rom.RomInfo.support_attribute_pointer);
+                Address sa = list.FirstOrDefault(a => a.Addr == saBase && a.Info == "SupportAttribute");
+                Assert.NotNull(sa);
+                Assert.Equal(8u, sa.BlockSize);
+                uint saCount = sa.Length / sa.BlockSize - 1; // length = block*(count+1)
+                Assert.True(saCount >= 1, "SupportAttribute count should be positive");
 
-                // The class table must be present too.
+                // AI3 (fixed-8) table must be present with the expected 9-block length.
+                uint ai3Base = rom.p32(rom.RomInfo.ai3_pointer);
+                Address ai3 = list.FirstOrDefault(a => a.Addr == ai3Base && a.Info == "AI3");
+                Assert.NotNull(ai3);
+                Assert.Equal(20u, ai3.BlockSize);
+                Assert.Equal(20u * (8 + 1), ai3.Length); // fixed 8 -> length = 20*(8+1)
+
+                // FAITHFULNESS / COMPLETENESS-SAFETY: Item and Class are NOT emitted by this
+                // slice (embedded sub-pointer blocks). They must be absent from the list AND
+                // tracked in NotYetPorted so a rebuild does not silently drop their sub-blocks.
+                uint itemBase = rom.p32(rom.RomInfo.item_pointer);
+                Assert.DoesNotContain(list, a => a.Addr == itemBase && a.Info == "Item");
                 uint classBase = rom.p32(rom.RomInfo.class_pointer);
-                Address cls = list.FirstOrDefault(a => a.Addr == classBase && a.Info == "Class");
-                Assert.NotNull(cls);
-                Assert.Equal(rom.RomInfo.class_datasize, cls.BlockSize);
-                uint classCount = cls.Length / cls.BlockSize - 1;
-                Assert.True(classCount >= 0x40 && classCount <= 0x100,
-                    "FE8U class count out of expected range: 0x" + classCount.ToString("X"));
+                Assert.DoesNotContain(list, a => a.Addr == classBase && a.Info == "Class");
             }
             finally
             {

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -214,13 +214,17 @@ namespace FEBuilderGBA
 
         static void EmitOne(ROM rom, List<Address> list, StructDescriptor d, uint pointer)
         {
+            // Bounds-check against the PASSED rom, not CoreState.ROM — this is a Core API that
+            // may scan a rom != CoreState.ROM. The plain U.isSafetyOffset(uint) overload is bound
+            // to CoreState.ROM.Data.Length, so on a differently-sized rom it would mis-judge the
+            // pointer and the rom.u8/u16/u32 reads in getBlockDataCount could throw OOB.
             pointer = U.toOffset(pointer);
-            if (!U.isSafetyOffset(pointer))
+            if (!U.isSafetyOffset(pointer, rom))
             {
                 return;
             }
             uint baseAddr = rom.p32(pointer);
-            if (!U.isSafetyOffset(baseAddr))
+            if (!U.isSafetyOffset(baseAddr, rom))
             {
                 return;
             }
@@ -391,16 +395,35 @@ namespace FEBuilderGBA
                 PointerIndexes = new uint[] { },
             });
 
-            // ArenaClassForm.MakeAllDataLength (3 weapon-class pointers, blockSize 1, u8!=0)
+            // ArenaClassForm.MakeAllDataLength emits THREE SEPARATE base tables (near/far/magic),
+            // each via its own ReInitPointer + AddAddress with a DISTINCT Info string — NOT one
+            // table with 3 pointer columns. So they are 3 single-pointer descriptors with the
+            // verbatim WF Info strings, in WF order (near, far, magic). Collapsing them into one
+            // multi-pointer descriptor would give all three the same Info (faithfulness break).
             l.Add(new StructDescriptor
             {
-                Name = "AreaClassForm weapon",
-                PointerFields = r => new uint[]
-                {
-                    r.RomInfo.arena_class_near_weapon_pointer,
-                    r.RomInfo.arena_class_far_weapon_pointer,
-                    r.RomInfo.arena_class_magic_weapon_pointer,
-                },
+                Name = "AreaClassForm near weapon",
+                PointerField = r => r.RomInfo.arena_class_near_weapon_pointer,
+                BlockSize = 1,
+                Rule = DataCountRule.U8NotEqual,
+                RuleOffset = 0,
+                RuleStopValue = 0x00,
+                PointerIndexes = new uint[] { },
+            });
+            l.Add(new StructDescriptor
+            {
+                Name = "AreaClassForm far weapon",
+                PointerField = r => r.RomInfo.arena_class_far_weapon_pointer,
+                BlockSize = 1,
+                Rule = DataCountRule.U8NotEqual,
+                RuleOffset = 0,
+                RuleStopValue = 0x00,
+                PointerIndexes = new uint[] { },
+            });
+            l.Add(new StructDescriptor
+            {
+                Name = "AreaClassForm magic weapon",
+                PointerField = r => r.RomInfo.arena_class_magic_weapon_pointer,
                 BlockSize = 1,
                 Rule = DataCountRule.U8NotEqual,
                 RuleOffset = 0,
@@ -452,7 +475,19 @@ namespace FEBuilderGBA
         /// </summary>
         public static string[] GetNotYetPortedForms()
         {
-            return new[]
+            // Defensively de-dup: duplicates would inflate the count and make the IsComplete
+            // gate ("empty == safe to wire into a real defragment") unreliable. The
+            // RebuildProducerCoreTests.GetNotYetPortedForms_HasNoDuplicates test also asserts
+            // the raw literal itself stays duplicate-free.
+            return System.Linq.Enumerable.ToArray(
+                   System.Linq.Enumerable.Distinct(NotYetPortedRaw));
+        }
+
+        /// <summary>The un-deduplicated source list (exposed so a test can assert it has no
+        /// duplicates — keeping the literal clean, not just the public dedup'd view).</summary>
+        public static string[] GetNotYetPortedFormsRaw() => (string[])NotYetPortedRaw.Clone();
+
+        static readonly string[] NotYetPortedRaw = new[]
             {
                 // event conditions / scripts
                 "EventCondForm", "EventScript(MakeEventASMMAPList)", "EventFunctionPointerForm",
@@ -498,14 +533,13 @@ namespace FEBuilderGBA
                 "MonsterItemForm", "MonsterProbabilityForm", "MonsterWMapProbabilityForm",
                 "EDForm", "EventBattleTalkForm", "CCBranchForm", "OPClassAlphaNameForm",
                 "WorldMapPathForm", "WorldMapEventPointerForm", "EDStaffRollForm",
-                "OPPrologueForm", "EventHaikuForm", "SoundRoomForm", "SupportTalkForm",
+                "OPPrologueForm", "EventHaikuForm", "SupportTalkForm",
                 "SupportUnitForm", "WorldMapPointForm", "MapSettingForm",
                 "OPClassFontForm", "OPClassDemoForm", "FE8SpellMenuExtendsForm",
-                "WorldMapPointForm", "TacticianAffinityFE7", "EventFinalSerifFE7Form",
+                "TacticianAffinityFE7", "EventFinalSerifFE7Form",
                 "EDSensekiCommentForm", "OPClassDemoFE7Form", "ImageCGFE7UForm",
                 // patch / procs / ASM (AppendAllASMStructPointersList)
                 "PatchForm(MakePatchStructDataList)", "ProcsScriptForm",
             };
-        }
     }
 }

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -23,9 +23,11 @@ namespace FEBuilderGBA
     ///   <item>A first batch of the <b>simplest</b> <c>MakeAllDataLength</c> statics
     ///   — the ones that are a pure "walk a <c>RomInfo</c> pointer table of
     ///   N entries × blockSize, emit one IFR <see cref="Address"/>" with a
-    ///   small data-driven <c>IsDataExists</c> rule and no Form/Drawing/event-scan
-    ///   dependency. They are expressed as a declarative <see cref="StructDescriptor"/>
-    ///   table walked by <see cref="WalkAndAdd"/> — one table replaces ~16 hand-ports.</item>
+    ///   small data-driven <c>IsDataExists</c> rule, no Form/Drawing/event-scan
+    ///   dependency AND <b>no embedded per-entry sub-pointer expansion</b>
+    ///   (ItemForm/ClassForm are excluded for exactly that reason — see
+    ///   <see cref="BuildBatchDescriptors"/>). They are expressed as a declarative
+    ///   <see cref="StructDescriptor"/> table walked by <see cref="WalkAndAdd"/>.</item>
     /// </list>
     /// <para><b>What is intentionally deferred</b></para>
     /// <para>
@@ -98,6 +100,38 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
+        /// Result of <see cref="MakeAllStructPointers"/>: the produced <see cref="Address"/> list
+        /// plus the explicit coverage state so a future wiring slice can gate on it.
+        /// </summary>
+        /// <remarks>
+        /// COMPLETENESS-SAFETY: a producer that omits forms (<see cref="IsComplete"/> false) must NOT
+        /// be fed to <see cref="RebuildMakeCore.Make"/> for a real defragment — relocating only SOME
+        /// structs while leaving others un-tracked would leave the un-tracked pointers dangling
+        /// (silent ROM corruption). The wiring slice MUST refuse (or loudly warn on) a rebuild while
+        /// <see cref="IsComplete"/> is false / <see cref="NotYetPorted"/> is non-empty.
+        /// </remarks>
+        public sealed class ProducerResult
+        {
+            /// <summary>The accumulated known-struct list (may be partial if <see cref="Cancelled"/>).</summary>
+            public List<Address> List { get; }
+            /// <summary>The <c>MakeAllDataLength</c> statics NOT yet ported (see <see cref="GetNotYetPortedForms"/>).</summary>
+            public IReadOnlyList<string> NotYetPorted { get; }
+            /// <summary>True only when every WinForms producer static has a Core equivalent
+            /// (<see cref="NotYetPorted"/> empty). While false the result is UNSAFE to feed to a
+            /// real <see cref="RebuildMakeCore.Make"/> defragment.</summary>
+            public bool IsComplete => NotYetPorted.Count == 0;
+            /// <summary>True if cancellation was observed mid-run (the list is partial).</summary>
+            public bool Cancelled { get; }
+
+            public ProducerResult(List<Address> list, IReadOnlyList<string> notYetPorted, bool cancelled)
+            {
+                List = list;
+                NotYetPorted = notYetPorted;
+                Cancelled = cancelled;
+            }
+        }
+
+        /// <summary>
         /// Build the known-struct <see cref="Address"/> list for <paramref name="rom"/>.
         /// Port of <c>U.MakeAllStructPointersList</c> (the batch ported so far; see class remarks).
         /// </summary>
@@ -108,16 +142,27 @@ namespace FEBuilderGBA
         /// <returns>The accumulated <see cref="Address"/> list.</returns>
         public static List<Address> MakeAllStructPointersList(ROM rom, IProgress<string> progress = null, CancellationToken ct = default)
         {
+            return MakeAllStructPointers(rom, progress, ct).List;
+        }
+
+        /// <summary>
+        /// Like <see cref="MakeAllStructPointersList"/> but returns a <see cref="ProducerResult"/> that
+        /// also surfaces the coverage state (<see cref="ProducerResult.NotYetPorted"/> /
+        /// <see cref="ProducerResult.IsComplete"/>) so a future wiring slice can gate the rebuild.
+        /// </summary>
+        public static ProducerResult MakeAllStructPointers(ROM rom, IProgress<string> progress = null, CancellationToken ct = default)
+        {
             if (rom == null) throw new ArgumentNullException(nameof(rom));
 
             var list = new List<Address>(50000);
+            string[] notYet = GetNotYetPortedForms();
 
             // A pre-cancelled token short-circuits before any work (mirrors the WinForms
             // first DoEvents returning the empty list).
             if (ct.IsCancellationRequested)
             {
                 progress?.Report("MakeAllStructPointersList cancelled");
-                return list;
+                return new ProducerResult(list, notYet, cancelled: true);
             }
 
             // The WinForms producer interleaves DoEvents checkpoints between groups of
@@ -129,18 +174,17 @@ namespace FEBuilderGBA
                 if (ct.IsCancellationRequested)
                 {
                     progress?.Report("MakeAllStructPointersList cancelled");
-                    return list;
+                    return new ProducerResult(list, notYet, cancelled: true);
                 }
                 progress?.Report(d.Name);
                 WalkAndAdd(rom, list, d);
             }
 
             // Surface — never silently drop — the statics this slice does not yet cover.
-            string[] notYet = GetNotYetPortedForms();
             progress?.Report("MakeAllStructPointersList: ported batch=" + batch.Count
                 + " descriptors; not-yet-ported=" + notYet.Length + " forms (deferred to later slices)");
 
-            return list;
+            return new ProducerResult(list, notYet, cancelled: false);
         }
 
         /// <summary>
@@ -259,17 +303,14 @@ namespace FEBuilderGBA
             var l = new List<StructDescriptor>();
 
             // ---- version-agnostic section (called unconditionally in WinForms) ----
-
-            // ItemForm.MakeAllDataLength
-            l.Add(new StructDescriptor
-            {
-                Name = "Item",
-                PointerField = r => r.RomInfo.item_pointer,
-                BlockSize = rom.RomInfo.item_datasize,
-                Rule = DataCountRule.ItemRule,
-                MaxCount = 0x100,
-                PointerIndexes = new uint[] { 12, 16 },
-            });
+            //
+            // NOTE: ItemForm and ClassForm are deliberately NOT here. Their MakeAllDataLength
+            // does the main IFR AddAddress AND an embedded per-entry sub-pointer expansion
+            // (Item: StatBooster + ItemEffectiveness BIN blocks; Class: 7 MoveCost BIN blocks
+            // behind offsets 56/60/64/68/72/76). A descriptor only emits the main table — porting
+            // the main walk alone would leave those embedded blocks un-tracked, dangling their
+            // pointers during a rebuild (silent ROM corruption). They stay in GetNotYetPortedForms
+            // until the sub-walk is extracted to Core (a later slice).
 
             // ItemPromotionForm.MakeAllDataLength (10 cc_* pointers, blockSize 1, u8!=0)
             l.Add(new StructDescriptor
@@ -327,10 +368,10 @@ namespace FEBuilderGBA
                 PointerIndexes = new uint[] { },
             });
 
-            // AITargetForm.MakeAllDataLength (fixed 8)
+            // AITargetForm.MakeAllDataLength (fixed 8) — WinForms Info label is "AI3"
             l.Add(new StructDescriptor
             {
-                Name = "AITarget",
+                Name = "AI3",
                 PointerField = r => r.RomInfo.ai3_pointer,
                 BlockSize = 20,
                 Rule = DataCountRule.FixedCount,
@@ -379,18 +420,8 @@ namespace FEBuilderGBA
                 PointerIndexes = new uint[] { },
             });
 
-            // ---- per-version Class table (same descriptor for v6/7/8) ----
-            // ClassForm.MakeAllDataLength: i==0 -> true, else u8(addr+4)!=0, cap 0xFF.
-            l.Add(new StructDescriptor
-            {
-                Name = "Class",
-                PointerField = r => r.RomInfo.class_pointer,
-                BlockSize = rom.RomInfo.class_datasize,
-                Rule = DataCountRule.U8NotZeroIndex0Always,
-                RuleOffset = 4,
-                MaxCount = 0x100,
-                PointerIndexes = new uint[] { },
-            });
+            // (ClassForm is NOT here — see the embedded-sub-pointer note above; it stays in
+            //  GetNotYetPortedForms until its MoveCost sub-walk is ported.)
 
             // ---- trailing is_multibyte branch: MapTerrainName(Eng) ----
             // WinForms: is_multibyte -> MapTerrainNameForm (embedded CString sub-walk, deferred);
@@ -440,6 +471,10 @@ namespace FEBuilderGBA
                 "SongTableForm", "SoundFootStepsForm", "SoundRoomForm", "SoundRoomCGForm",
                 "WorldMapBGMForm",
                 // embedded sub-pointer / event-scan / CString expansion
+                // (ItemForm = main IFR + per-entry StatBooster/ItemEffectiveness BIN sub-blocks;
+                //  ClassForm = main IFR + per-entry 7x MoveCost BIN sub-blocks @ off 56..76 —
+                //  the main walk is trivial but the sub-blocks need porting before either is safe.)
+                "ItemForm", "ClassForm",
                 "ItemShopForm", "StatusParamForm", "StatusRMenuForm", "MenuDefinitionForm",
                 "ItemWeaponEffectForm", "ItemUsagePointerForm", "UnitActionPointerForm",
                 "MapChangeForm", "MapExitPointForm", "MapPointerForm", "FontForm",

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -132,10 +132,11 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
-        /// Build the known-struct <see cref="Address"/> list for <paramref name="rom"/>.
+        /// Build the known-struct <see cref="Address"/> list for the loaded <paramref name="rom"/>.
         /// Port of <c>U.MakeAllStructPointersList</c> (the batch ported so far; see class remarks).
         /// </summary>
-        /// <param name="rom">The ROM to scan (was <c>Program.ROM</c>).</param>
+        /// <param name="rom">The ROM to scan. MUST be the loaded <see cref="CoreState.ROM"/>
+        /// (see <see cref="MakeAllStructPointers"/> for why).</param>
         /// <param name="progress">Optional progress reporter (was the <c>DoEvents</c> messages).</param>
         /// <param name="ct">Cancellation token; on cancel the partial list is returned (was the
         /// <c>DoEvents</c> early-<c>return list</c>).</param>
@@ -150,9 +151,26 @@ namespace FEBuilderGBA
         /// also surfaces the coverage state (<see cref="ProducerResult.NotYetPorted"/> /
         /// <see cref="ProducerResult.IsComplete"/>) so a future wiring slice can gate the rebuild.
         /// </summary>
+        /// <param name="rom">
+        /// The ROM to scan. MUST be the same instance as <see cref="CoreState.ROM"/>. The emitted
+        /// <see cref="Address"/> objects validate their length via <c>U.isSafetyLength</c>, which is
+        /// bound to <c>CoreState.ROM.Data.Length</c> (as is the <see cref="Address"/> ctor's
+        /// <c>Debug.Assert</c>), so a <paramref name="rom"/> that is not <see cref="CoreState.ROM"/>
+        /// cannot be scanned correctly. The producer's job is to enumerate the LOADED ROM being
+        /// rebuilt — which is always <see cref="CoreState.ROM"/> (same posture as the
+        /// patch/custom-build cores that require the loaded ROM for their undo). Passing any other
+        /// instance throws <see cref="ArgumentException"/>.
+        /// </param>
         public static ProducerResult MakeAllStructPointers(ROM rom, IProgress<string> progress = null, CancellationToken ct = default)
         {
             if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (!ReferenceEquals(rom, CoreState.ROM))
+            {
+                throw new ArgumentException(
+                    "RebuildProducerCore must scan the loaded CoreState.ROM (Address length/offset "
+                    + "validation is bound to CoreState.ROM, so a different ROM cannot be scanned "
+                    + "safely).", nameof(rom));
+            }
 
             var list = new List<Address>(50000);
             string[] notYet = GetNotYetPortedForms();
@@ -214,10 +232,17 @@ namespace FEBuilderGBA
 
         static void EmitOne(ROM rom, List<Address> list, StructDescriptor d, uint pointer)
         {
-            // Bounds-check against the PASSED rom, not CoreState.ROM — this is a Core API that
-            // may scan a rom != CoreState.ROM. The plain U.isSafetyOffset(uint) overload is bound
-            // to CoreState.ROM.Data.Length, so on a differently-sized rom it would mis-judge the
-            // pointer and the rom.u8/u16/u32 reads in getBlockDataCount could throw OOB.
+            // BlockSize 0 (e.g. an uninitialized descriptor) would make getBlockDataCount loop
+            // forever (addr += 0 never advances). A zero block is a descriptor bug, not data —
+            // skip it rather than hang. (DataCountRule.FixedCount is fine with block 0 in theory,
+            // but every real table has a positive block, so reject defensively.)
+            if (d.BlockSize == 0)
+            {
+                return;
+            }
+
+            // rom is guaranteed == CoreState.ROM by the MakeAllStructPointers guard, so the
+            // (addr, rom) safety overloads agree with the Address ctor's CoreState.ROM-bound checks.
             pointer = U.toOffset(pointer);
             if (!U.isSafetyOffset(pointer, rom))
             {
@@ -292,7 +317,11 @@ namespace FEBuilderGBA
                             && U.isPointerOrNULL(rom.u32(addr + 16));
                     };
                 default:
-                    return (i, addr) => false;
+                    // An unhandled DataCountRule is a PROGRAMMING ERROR (a bad/new descriptor),
+                    // not a 0-entry table. Returning always-false would silently emit a 1-block
+                    // Address and hide the bug — fail loudly instead.
+                    throw new ArgumentOutOfRangeException(nameof(d),
+                        "Unhandled DataCountRule: " + d.Rule);
             }
         }
 

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -1,0 +1,476 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Cross-platform ROM-rebuild struct-pointer <b>PRODUCER</b> (slice 2a of #1261).
+    /// <para>
+    /// This is the Core port of <c>U.MakeAllStructPointersList</c>
+    /// (<c>FEBuilderGBA/U.cs</c>). The WinForms original walks ~150
+    /// <c>XxxForm.MakeAllDataLength(list)</c> statics to enumerate every known
+    /// data/pointer struct location in the ROM, producing the <see cref="Address"/>
+    /// list that <see cref="RebuildMakeCore.Make"/> consumes.
+    /// </para>
+    /// <para><b>What this slice ports</b></para>
+    /// <list type="bullet">
+    ///   <item>The list-assembly plumbing and the 5 progress/cancel checkpoints
+    ///   (the WinForms <c>21× InputFormRef.DoEvents(null,...)</c> calls become
+    ///   <see cref="IProgress{T}"/> reports + a <see cref="CancellationToken"/>;
+    ///   on cancel the partial list is returned, matching the WinForms
+    ///   <c>return list;</c> behaviour).</item>
+    ///   <item>A first batch of the <b>simplest</b> <c>MakeAllDataLength</c> statics
+    ///   — the ones that are a pure "walk a <c>RomInfo</c> pointer table of
+    ///   N entries × blockSize, emit one IFR <see cref="Address"/>" with a
+    ///   small data-driven <c>IsDataExists</c> rule and no Form/Drawing/event-scan
+    ///   dependency. They are expressed as a declarative <see cref="StructDescriptor"/>
+    ///   table walked by <see cref="WalkAndAdd"/> — one table replaces ~16 hand-ports.</item>
+    /// </list>
+    /// <para><b>What is intentionally deferred</b></para>
+    /// <para>
+    /// The remaining ~130 statics need their editor's data-read logic (Huffman text,
+    /// LZ77/TSA image length, event/AI/procs disassembly, song recycle, battle-anime
+    /// frame walkers, patch/ASM LDR maps, embedded sub-pointer expansion). They are
+    /// <b>not silently omitted</b>: <see cref="GetNotYetPortedForms"/> enumerates them
+    /// and the producer reports the count through <paramref name="progress"/> so a later
+    /// slice can diff coverage. <see cref="RebuildMakeCore.Make"/>'s signature is
+    /// unchanged — this producer is made available for a later slice to wire in.
+    /// </para>
+    /// <para>
+    /// WinForms touches replaced: <c>Program.ROM</c> -&gt; the <c>rom</c> parameter;
+    /// each <c>XxxForm.Init(null)</c>'s <c>{BasePointer, BlockSize, IsDataExists}</c>
+    /// is captured in the descriptor; <c>InputFormRef.DoEvents</c> -&gt;
+    /// <c>progress</c>/<c>ct</c>.
+    /// </para>
+    /// </summary>
+    public static class RebuildProducerCore
+    {
+        /// <summary>How a descriptor reproduces the per-form <c>IsDataExists</c> callback
+        /// that drives <see cref="ROM.getBlockDataCount(uint,uint,Func{int,uint,bool})"/>.</summary>
+        public enum DataCountRule
+        {
+            /// <summary>Fixed entry count (e.g. <c>i &lt; unit_maxcount</c>, <c>i &lt; 8</c>).</summary>
+            FixedCount,
+            /// <summary>Stop when <c>u8(addr+Offset)</c> equals <see cref="StructDescriptor.RuleStopValue"/>.</summary>
+            U8NotEqual,
+            /// <summary>Stop when <c>u16(addr+Offset)</c> equals <see cref="StructDescriptor.RuleStopValue"/>.</summary>
+            U16NotEqual,
+            /// <summary>Continue while <c>u8(addr+Offset) != 0</c> — but entry 0 always exists.
+            /// Matches ClassForm (<c>i==0 -&gt; true</c>, else <c>u8(addr+4)!=0</c>).</summary>
+            U8NotZeroIndex0Always,
+            /// <summary>Continue while <c>u32(addr+Offset)</c> is a pointer-or-NULL.</summary>
+            U32IsPointerOrNull,
+            /// <summary>Continue while <c>u16(addr+Offset) != 0</c>.</summary>
+            U16NotZero,
+            /// <summary>Item rule: <c>u32(addr+12)</c> pointer-or-null, plus <c>u32(addr+16)</c>
+            /// pointer-or-null EXCEPT on FE8U (version 8 &amp;&amp; !multibyte). Capped at i&lt;=0xFF.</summary>
+            ItemRule,
+        }
+
+        /// <summary>A declarative description of one simple "table walk + emit IFR Address" form.</summary>
+        public sealed class StructDescriptor
+        {
+            /// <summary>Label emitted into the <see cref="Address.Info"/> (was the form's name string).</summary>
+            public string Name;
+            /// <summary>Resolves the <c>RomInfo</c> base pointer (e.g. <c>r =&gt; r.RomInfo.item_pointer</c>).
+            /// For multi-pointer forms (ItemPromotion, ArenaClass) use <see cref="PointerFields"/>.</summary>
+            public Func<ROM, uint> PointerField;
+            /// <summary>Multi-pointer variant: emit one Address per non-zero pointer.
+            /// When set, <see cref="PointerField"/> is ignored.</summary>
+            public Func<ROM, uint[]> PointerFields;
+            public uint BlockSize;
+            public DataCountRule Rule;
+            /// <summary>Byte offset inside the block the rule inspects.</summary>
+            public uint RuleOffset;
+            /// <summary>For <see cref="DataCountRule.FixedCount"/>: the count (or use <see cref="FixedCountField"/>).</summary>
+            public uint RuleFixedCount;
+            /// <summary>For <see cref="DataCountRule.FixedCount"/> when the count comes from RomInfo
+            /// (e.g. <c>unit_maxcount</c>); takes precedence over <see cref="RuleFixedCount"/>.</summary>
+            public Func<ROM, uint> FixedCountField;
+            /// <summary>For the <c>*NotEqual</c> rules: the terminator value.</summary>
+            public uint RuleStopValue;
+            /// <summary>Byte offsets inside the block that hold pointers (the WinForms <c>pointerIndexes</c>).</summary>
+            public uint[] PointerIndexes;
+            public Address.DataTypeEnum DataType = Address.DataTypeEnum.InputFormRef;
+            /// <summary>Optional safety cap on entry count (the WinForms <c>i &gt; 0xff</c> guards).</summary>
+            public uint MaxCount = 0x10000;
+        }
+
+        /// <summary>
+        /// Build the known-struct <see cref="Address"/> list for <paramref name="rom"/>.
+        /// Port of <c>U.MakeAllStructPointersList</c> (the batch ported so far; see class remarks).
+        /// </summary>
+        /// <param name="rom">The ROM to scan (was <c>Program.ROM</c>).</param>
+        /// <param name="progress">Optional progress reporter (was the <c>DoEvents</c> messages).</param>
+        /// <param name="ct">Cancellation token; on cancel the partial list is returned (was the
+        /// <c>DoEvents</c> early-<c>return list</c>).</param>
+        /// <returns>The accumulated <see cref="Address"/> list.</returns>
+        public static List<Address> MakeAllStructPointersList(ROM rom, IProgress<string> progress = null, CancellationToken ct = default)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+
+            var list = new List<Address>(50000);
+
+            // A pre-cancelled token short-circuits before any work (mirrors the WinForms
+            // first DoEvents returning the empty list).
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return list;
+            }
+
+            // The WinForms producer interleaves DoEvents checkpoints between groups of
+            // statics. We keep the SAME checkpoint boundaries so a later parity slice can
+            // line them up. ct.IsCancellationRequested mirrors a DoEvents cancel.
+            List<StructDescriptor> batch = BuildBatchDescriptors(rom);
+            foreach (StructDescriptor d in batch)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    progress?.Report("MakeAllStructPointersList cancelled");
+                    return list;
+                }
+                progress?.Report(d.Name);
+                WalkAndAdd(rom, list, d);
+            }
+
+            // Surface — never silently drop — the statics this slice does not yet cover.
+            string[] notYet = GetNotYetPortedForms();
+            progress?.Report("MakeAllStructPointersList: ported batch=" + batch.Count
+                + " descriptors; not-yet-ported=" + notYet.Length + " forms (deferred to later slices)");
+
+            return list;
+        }
+
+        /// <summary>
+        /// Walk one descriptor's table(s) and emit the IFR <see cref="Address"/>(es),
+        /// reproducing <c>InputFormRef.Init</c> + <c>AddressWinForms.AddAddress</c>
+        /// (length = blockSize × (dataCount + 1)) entirely from the passed <paramref name="rom"/>.
+        /// </summary>
+        public static void WalkAndAdd(ROM rom, List<Address> list, StructDescriptor d)
+        {
+            if (d.PointerFields != null)
+            {
+                foreach (uint pointer in d.PointerFields(rom))
+                {
+                    if (pointer == 0)
+                    {
+                        continue;
+                    }
+                    EmitOne(rom, list, d, pointer);
+                }
+            }
+            else
+            {
+                uint pointer = d.PointerField(rom);
+                EmitOne(rom, list, d, pointer);
+            }
+        }
+
+        static void EmitOne(ROM rom, List<Address> list, StructDescriptor d, uint pointer)
+        {
+            pointer = U.toOffset(pointer);
+            if (!U.isSafetyOffset(pointer))
+            {
+                return;
+            }
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr))
+            {
+                return;
+            }
+
+            uint dataCount = rom.getBlockDataCount(baseAddr, d.BlockSize, MakeIsDataExists(rom, d));
+            // WinForms AddressWinForms.AddAddress: length = BlockSize * (DataCount + 1).
+            uint length = d.BlockSize * (dataCount + 1);
+
+            list.Add(new Address(baseAddr, length, pointer, d.Name, d.DataType, d.BlockSize, d.PointerIndexes));
+        }
+
+        /// <summary>Turn a descriptor's <see cref="DataCountRule"/> into the
+        /// <c>is_data_exists_callback</c> that <see cref="ROM.getBlockDataCount(uint,uint,Func{int,uint,bool})"/> expects.</summary>
+        static Func<int, uint, bool> MakeIsDataExists(ROM rom, StructDescriptor d)
+        {
+            switch (d.Rule)
+            {
+                case DataCountRule.FixedCount:
+                {
+                    uint count = d.FixedCountField != null ? d.FixedCountField(rom) : d.RuleFixedCount;
+                    return (i, addr) => i < count;
+                }
+                case DataCountRule.U8NotEqual:
+                    return (i, addr) =>
+                    {
+                        if (i >= d.MaxCount) return false;
+                        return rom.u8(addr + d.RuleOffset) != d.RuleStopValue;
+                    };
+                case DataCountRule.U16NotEqual:
+                    return (i, addr) =>
+                    {
+                        if (i >= d.MaxCount) return false;
+                        return rom.u16(addr + d.RuleOffset) != d.RuleStopValue;
+                    };
+                case DataCountRule.U8NotZeroIndex0Always:
+                    return (i, addr) =>
+                    {
+                        if (i == 0) return true;
+                        if (i >= d.MaxCount) return false;
+                        return rom.u8(addr + d.RuleOffset) != 0;
+                    };
+                case DataCountRule.U32IsPointerOrNull:
+                    return (i, addr) =>
+                    {
+                        if (i >= d.MaxCount) return false;
+                        return U.isPointerOrNULL(rom.u32(addr + d.RuleOffset));
+                    };
+                case DataCountRule.U16NotZero:
+                    return (i, addr) =>
+                    {
+                        if (i >= d.MaxCount) return false;
+                        return rom.u16(addr + d.RuleOffset) != 0;
+                    };
+                case DataCountRule.ItemRule:
+                    return (i, addr) =>
+                    {
+                        if (i > 0xff) return false;
+                        if (rom.RomInfo.version == 8 && rom.RomInfo.is_multibyte == false)
+                        {
+                            // FE8U: only the +12 stat-booster pointer is checked (the +16
+                            // effectiveness pointer is left to SkillSystems, per ItemForm.Init).
+                            return U.isPointerOrNULL(rom.u32(addr + 12));
+                        }
+                        return U.isPointerOrNULL(rom.u32(addr + 12))
+                            && U.isPointerOrNULL(rom.u32(addr + 16));
+                    };
+                default:
+                    return (i, addr) => false;
+            }
+        }
+
+        /// <summary>
+        /// The first-batch descriptor table. These are the <c>MakeAllDataLength</c> statics that
+        /// are a pure table-walk with a simple <c>IsDataExists</c> and no editor-specific
+        /// (Huffman/LZ77/disasm/event-scan/embedded-sub-pointer) logic. Order follows the
+        /// WinForms <c>U.MakeAllStructPointersList</c> call order where these forms appear.
+        /// </summary>
+        public static List<StructDescriptor> BuildBatchDescriptors(ROM rom)
+        {
+            var l = new List<StructDescriptor>();
+
+            // ---- version-agnostic section (called unconditionally in WinForms) ----
+
+            // ItemForm.MakeAllDataLength
+            l.Add(new StructDescriptor
+            {
+                Name = "Item",
+                PointerField = r => r.RomInfo.item_pointer,
+                BlockSize = rom.RomInfo.item_datasize,
+                Rule = DataCountRule.ItemRule,
+                MaxCount = 0x100,
+                PointerIndexes = new uint[] { 12, 16 },
+            });
+
+            // ItemPromotionForm.MakeAllDataLength (10 cc_* pointers, blockSize 1, u8!=0)
+            l.Add(new StructDescriptor
+            {
+                Name = "CCItem",
+                PointerFields = r => new uint[]
+                {
+                    r.RomInfo.cc_item_hero_crest_pointer,
+                    r.RomInfo.cc_item_knight_crest_pointer,
+                    r.RomInfo.cc_item_orion_bolt_pointer,
+                    r.RomInfo.cc_elysian_whip_pointer,
+                    r.RomInfo.cc_guiding_ring_pointer,
+                    r.RomInfo.cc_fallen_contract_pointer,
+                    r.RomInfo.cc_master_seal_pointer,
+                    r.RomInfo.cc_ocean_seal_pointer,
+                    r.RomInfo.cc_moon_bracelet_pointer,
+                    r.RomInfo.cc_sun_bracelet_pointer,
+                },
+                BlockSize = 1,
+                Rule = DataCountRule.U8NotEqual,
+                RuleOffset = 0,
+                RuleStopValue = 0x00,
+                PointerIndexes = new uint[] { },
+            });
+
+            // SupportAttributeForm.MakeAllDataLength
+            l.Add(new StructDescriptor
+            {
+                Name = "SupportAttribute",
+                PointerField = r => r.RomInfo.support_attribute_pointer,
+                BlockSize = 8,
+                Rule = DataCountRule.U8NotEqual,
+                RuleOffset = 0,
+                RuleStopValue = 0x00,
+                PointerIndexes = new uint[] { },
+            });
+
+            // UnitPaletteForm.MakeAllDataLength (color + class palette tables; fixed unit_maxcount)
+            l.Add(new StructDescriptor
+            {
+                Name = "UnitPalette",
+                PointerField = r => r.RomInfo.unit_palette_color_pointer,
+                BlockSize = 7,
+                Rule = DataCountRule.FixedCount,
+                FixedCountField = r => r.RomInfo.unit_maxcount,
+                PointerIndexes = new uint[] { },
+            });
+            l.Add(new StructDescriptor
+            {
+                Name = "UnitPalette",
+                PointerField = r => r.RomInfo.unit_palette_class_pointer,
+                BlockSize = 7,
+                Rule = DataCountRule.FixedCount,
+                FixedCountField = r => r.RomInfo.unit_maxcount,
+                PointerIndexes = new uint[] { },
+            });
+
+            // AITargetForm.MakeAllDataLength (fixed 8)
+            l.Add(new StructDescriptor
+            {
+                Name = "AITarget",
+                PointerField = r => r.RomInfo.ai3_pointer,
+                BlockSize = 20,
+                Rule = DataCountRule.FixedCount,
+                RuleFixedCount = 8,
+                PointerIndexes = new uint[] { },
+            });
+
+            // AIStealItemForm.MakeAllDataLength (u8 != 0xFF)
+            l.Add(new StructDescriptor
+            {
+                Name = "AIStealItem",
+                PointerField = r => r.RomInfo.ai_steal_item_pointer,
+                BlockSize = 2,
+                Rule = DataCountRule.U8NotEqual,
+                RuleOffset = 0,
+                RuleStopValue = 0xFF,
+                PointerIndexes = new uint[] { },
+            });
+
+            // ArenaClassForm.MakeAllDataLength (3 weapon-class pointers, blockSize 1, u8!=0)
+            l.Add(new StructDescriptor
+            {
+                Name = "AreaClassForm weapon",
+                PointerFields = r => new uint[]
+                {
+                    r.RomInfo.arena_class_near_weapon_pointer,
+                    r.RomInfo.arena_class_far_weapon_pointer,
+                    r.RomInfo.arena_class_magic_weapon_pointer,
+                },
+                BlockSize = 1,
+                Rule = DataCountRule.U8NotEqual,
+                RuleOffset = 0,
+                RuleStopValue = 0x00,
+                PointerIndexes = new uint[] { },
+            });
+
+            // ItemWeaponTriangleForm.MakeAllDataLength (u8 != 255)
+            l.Add(new StructDescriptor
+            {
+                Name = "ItemWeaponTriangle",
+                PointerField = r => r.RomInfo.item_cornered_pointer,
+                BlockSize = 4,
+                Rule = DataCountRule.U8NotEqual,
+                RuleOffset = 0,
+                RuleStopValue = 0xFF,
+                PointerIndexes = new uint[] { },
+            });
+
+            // ---- per-version Class table (same descriptor for v6/7/8) ----
+            // ClassForm.MakeAllDataLength: i==0 -> true, else u8(addr+4)!=0, cap 0xFF.
+            l.Add(new StructDescriptor
+            {
+                Name = "Class",
+                PointerField = r => r.RomInfo.class_pointer,
+                BlockSize = rom.RomInfo.class_datasize,
+                Rule = DataCountRule.U8NotZeroIndex0Always,
+                RuleOffset = 4,
+                MaxCount = 0x100,
+                PointerIndexes = new uint[] { },
+            });
+
+            // ---- trailing is_multibyte branch: MapTerrainName(Eng) ----
+            // WinForms: is_multibyte -> MapTerrainNameForm (embedded CString sub-walk, deferred);
+            //           else        -> MapTerrainNameEngForm (clean u16!=0 table).
+            if (rom.RomInfo.is_multibyte == false)
+            {
+                l.Add(new StructDescriptor
+                {
+                    Name = "TerrainEng",
+                    PointerField = r => r.RomInfo.map_terrain_name_pointer,
+                    BlockSize = 2,
+                    Rule = DataCountRule.U16NotZero,
+                    RuleOffset = 0,
+                    PointerIndexes = new uint[] { },
+                });
+            }
+
+            return l;
+        }
+
+        /// <summary>
+        /// The <c>MakeAllDataLength</c> statics from <c>U.MakeAllStructPointersList</c> /
+        /// <c>U.AppendAllASMStructPointersList</c> that this slice does <b>not</b> yet port.
+        /// Tracked explicitly so coverage is auditable and nothing is silently dropped.
+        /// Each needs editor-specific logic (Huffman text, LZ77/TSA image length, event/AI/procs
+        /// disasm, song/instrument recycle, battle-anime frame walk, patch/ASM LDR map, or
+        /// embedded sub-pointer / event-scan expansion) to be extracted into Core first.
+        /// </summary>
+        public static string[] GetNotYetPortedForms()
+        {
+            return new[]
+            {
+                // event conditions / scripts
+                "EventCondForm", "EventScript(MakeEventASMMAPList)", "EventFunctionPointerForm",
+                "Command85PointerForm",
+                // text (Huffman)
+                "TextForm", "TextCharCodeForm", "TextDicForm", "OtherTextForm", "MapTerrainNameForm",
+                // images (LZ77/TSA length calc)
+                "ImageBattleAnimeForm", "ImageBattleBGForm", "ImageBattleTerrainForm", "ImageBGForm",
+                "ImageMagicFEditorForm", "ImageMagicCSACreatorForm", "ImageBattleScreenForm",
+                "ImageItemIconForm", "ImageUnitMoveIconFrom", "ImageUnitWaitIconFrom",
+                "ImageUnitPaletteForm", "ImageSystemIconForm", "ImageRomAnimeForm",
+                "ImageGenericEnemyPortraitForm", "ImageMapActionAnimationForm", "ImageTSAAnimeForm",
+                "ImageTSAAnime2Form", "ImageChapterTitleForm", "ImagePortraitForm", "ImageCGForm",
+                "MapMiniMapTerrainImageForm", "WorldMapImageForm",
+                // songs / sound (recycle, embedded inst)
+                "SongTableForm", "SoundFootStepsForm", "SoundRoomForm", "SoundRoomCGForm",
+                "WorldMapBGMForm",
+                // embedded sub-pointer / event-scan / CString expansion
+                "ItemShopForm", "StatusParamForm", "StatusRMenuForm", "MenuDefinitionForm",
+                "ItemWeaponEffectForm", "ItemUsagePointerForm", "UnitActionPointerForm",
+                "MapChangeForm", "MapExitPointForm", "MapPointerForm", "FontForm",
+                // AI scripts (disasm)
+                "AIScriptForm", "AIMapSettingForm", "AIPerformStaffForm", "AIPerformItemForm",
+                "ArenaEnemyWeaponForm",
+                // skills (version/patch dependent)
+                "SkillAssignmentClassSkillSystemForm", "SkillAssignmentUnitSkillSystemForm",
+                "SkillConfigSkillSystemForm", "SkillConfigFE8NSkillForm",
+                "SkillConfigFE8NVer2SkillForm", "SkillConfigFE8NVer3SkillForm",
+                // status / menu definition / misc tables needing extra logic
+                "StatusOptionForm", "StatusOptionOrderForm", "StatusUnitsMenuForm",
+                "LinkArenaDenyUnitForm", "MantAnimationForm", "MapTileAnimation1Form",
+                "MapTileAnimation2Form", "MapTerrainFloorLookupTableForm",
+                "MapTerrainBGLookupTableForm",
+                // units / classes per-version with extra reads
+                "UnitForm", "UnitFE7Form", "UnitFE6Form", "UnitCustomBattleAnimeForm",
+                "ExtraUnitForm", "ExtraUnitFE8UForm", "SummonUnitForm", "SummonsDemonKingForm",
+                "EventUnitForm(RecycleReserveUnits)", "EventForceSortieForm",
+                // monster / world map / ED / support (FE8/FE7/FE6 variants)
+                "MonsterItemForm", "MonsterProbabilityForm", "MonsterWMapProbabilityForm",
+                "EDForm", "EventBattleTalkForm", "CCBranchForm", "OPClassAlphaNameForm",
+                "WorldMapPathForm", "WorldMapEventPointerForm", "EDStaffRollForm",
+                "OPPrologueForm", "EventHaikuForm", "SoundRoomForm", "SupportTalkForm",
+                "SupportUnitForm", "WorldMapPointForm", "MapSettingForm",
+                "OPClassFontForm", "OPClassDemoForm", "FE8SpellMenuExtendsForm",
+                "WorldMapPointForm", "TacticianAffinityFE7", "EventFinalSerifFE7Form",
+                "EDSensekiCommentForm", "OPClassDemoFE7Form", "ImageCGFE7UForm",
+                // patch / procs / ASM (AppendAllASMStructPointersList)
+                "PatchForm(MakePatchStructDataList)", "ProcsScriptForm",
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
**Slice 2a** of #1261 — begins porting the ROM-rebuild **struct-pointer producer** (`U.MakeAllStructPointersList`, **151** `XxxForm.MakeAllDataLength` callers) to Core via a **data-driven descriptor table** instead of 151 hand-ports.

The dominant idiom is `AddAddress(list, Init(null), name, pointerIndexes)` = package an `InputFormRef` into an `Address`. Core already has the hard parts (`ROM.getBlockDataCount`, RomInfo pointers/datasizes, `Address` ctor, `Address.AddAddressInstantIFR`); the only non-Core piece — each form's `IsDataExists` — collapses to a 7-value `DataCountRule` enum. So a simple form = one `StructDescriptor` row, walked by a generic `WalkAndAdd`.

## Safety (this slice's two guardrails)
- **Faithfulness** — every descriptor was cross-checked **verbatim** against the WF `XxxForm.Init`/`MakeAllDataLength`. This caught a real would-be corruption bug: **ClassForm** needs `pointerIndexes {52,56,60,64,68,72,76}` + a per-entry MoveCost sub-walk, and **ItemForm** has an embedded StatBooster/Effectiveness sub-walk — both were therefore **deferred to NotYetPorted** (they re-enter in slice 2c once the per-entry BIN sub-block emit is ported). The surviving **8 forms / 9 descriptors** (SupportAttribute, UnitPalette ×2, AI3, AIStealItem, ItemWeaponTriangle, MapTerrainNameEng, CCItem, ArenaClass weapon) are clean single/multi `AddAddress` with no embedded sub-pointers, so empty `pointerIndexes` is correct.
- **Completeness** — `MakeAllStructPointers(...) → ProducerResult { List, NotYetPorted, IsComplete, Cancelled }`; `IsComplete` is true only when `NotYetPorted` is empty. A later slice wiring producer→`RebuildMakeCore.Make` MUST refuse/warn on a real defragment while `IsComplete` is false (relocating only some structs dangles the rest). The `List<Address>` overload is retained.

## Changes (additive — Core only)
- `RebuildProducerCore.cs` (NEW): `MakeAllStructPointers`/`MakeAllStructPointersList` (21× `DoEvents` → `IProgress` + `CancellationToken`, cancel→partial) + `StructDescriptor`/`DataCountRule`/`ProducerResult` + `WalkAndAdd`/`EmitOne` + `GetNotYetPortedForms()`.
- `RebuildProducerCoreTests.cs` (NEW, **13 tests**).

## Tests
- RebuildProducerCore: **13 passed**, 0 failed — descriptor walker per rule + **4 real-FE8U tests run** (SupportAttribute/AI3 found with correct block sizes; Item/Class asserted ABSENT and tracked in NotYetPorted; real-FE8U → `IsComplete == false`); cancel → incomplete+partial.
- FEBuilderGBA.Tests (net9.0-windows): **1865 passed**, 0 failed.
- (~78 local `StructExportCoreTests.MetadataFile_LoadsSuccessfully(struct_*.txt)` failures are a pre-existing worktree config-staging gap — unrelated, absent in CI.)

Part of #1261. `RebuildMakeCore.Make` signature unchanged. Remaining producer slices 2b–2g outlined; 2c owns the deferred Item/Class sub-walks.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
