### PR TITLE
feat(core): ROM-rebuild producer — next form batch (#1261 slice 2b)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -157,6 +157,103 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void WalkAndAdd_U32LessThan_StopsWhenU32GreaterOrEqual()
+        {
+            // StatusUnitsMenuForm rule: continue while u32(addr+0) < 0xFF.
+            var rom = CreateTestRom();
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            uint block = 16;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u32(table + block * 0, 0x00); // < 0xFF -> exists
+            rom.write_u32(table + block * 1, 0x10); // < 0xFF -> exists
+            rom.write_u32(table + block * 2, 0xFF); // == 0xFF -> stop
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "UnitsMenu",
+                PointerField = _ => pointer,
+                BlockSize = block,
+                Rule = RebuildProducerCore.DataCountRule.U32LessThan,
+                RuleOffset = 0,
+                RuleStopValue = 0xFF,
+                PointerIndexes = new uint[] { },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            Assert.Single(list);
+            // dataCount = 2, length = 16 * (2 + 1) = 48
+            Assert.Equal(48u, list[0].Length);
+        }
+
+        [Fact]
+        public void WalkAndAdd_SoundBossBGMRule_StopsAtFFFFTerminator()
+        {
+            // SoundBossBGMForm rule: stop at the u16(addr)==0xFFFF terminator.
+            var rom = CreateTestRom();
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            uint block = 8;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u16(table + block * 0, 0x0001);
+            rom.write_u16(table + block * 1, 0x0002);
+            rom.write_u16(table + block * 2, 0xFFFF); // terminator
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "BossBGM",
+                PointerField = _ => pointer,
+                BlockSize = block,
+                Rule = RebuildProducerCore.DataCountRule.SoundBossBGMRule,
+                PointerIndexes = new uint[] { },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            Assert.Single(list);
+            // dataCount = 2, length = 8 * (2 + 1) = 24
+            Assert.Equal(24u, list[0].Length);
+        }
+
+        [Fact]
+        public void WalkAndAdd_SoundBossBGMRule_StopsAtTrailingEmptyRunAfter10Entries()
+        {
+            // The second guard: after the first 10 entries, stop once a run of 10 empty blocks
+            // (BlockSize*10 zero bytes) is hit. Fill 11 non-empty entries, then leave the rest 0;
+            // at i==11 the IsEmpty(addr, 80) guard fires (i > 10) -> count == 11.
+            var rom = CreateTestRom(0x8000);
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            uint block = 8;
+            rom.write_u32(pointer, Ptr(table));
+            for (uint i = 0; i < 11; i++)
+            {
+                // any non-zero, non-0xFFFF first u16 keeps the entry "present" and non-empty
+                rom.write_u16(table + block * i, 0x0100 + i);
+            }
+            // entries 11.. are all-zero -> IsEmpty(addr, 80) true at i==11 (> 10).
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "BossBGM",
+                PointerField = _ => pointer,
+                BlockSize = block,
+                Rule = RebuildProducerCore.DataCountRule.SoundBossBGMRule,
+                PointerIndexes = new uint[] { },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            Assert.Single(list);
+            // dataCount = 11, length = 8 * (11 + 1) = 96
+            Assert.Equal(96u, list[0].Length);
+        }
+
+        [Fact]
         public void WalkAndAdd_MultiPointer_EmitsOnePerNonZeroPointer()
         {
             var rom = CreateTestRom();
@@ -357,6 +454,29 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void GetNotYetPortedForms_DropsSlice2bCoveredForms_KeepsDeferredSiblings()
+        {
+            // Slice 2b ports these four single-table forms -> they must be removed from the
+            // not-yet-ported tracker (so IsComplete coverage stays accurate). This check is
+            // ROM-independent so it always runs (the FE8U batch test is env-gated).
+            string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
+            Assert.DoesNotContain("StatusUnitsMenuForm", notYet);
+            Assert.DoesNotContain("LinkArenaDenyUnitForm", notYet);
+            Assert.DoesNotContain("MonsterItemForm", notYet);
+            Assert.DoesNotContain("MonsterProbabilityForm", notYet);
+
+            // Their deferred siblings (embedded sub-walk / event-scan / dynamic count / patch
+            // pointer set) must STAY tracked — porting only some forms while leaving these
+            // un-tracked would dangle their pointers during a rebuild.
+            Assert.Contains("MonsterWMapProbabilityForm", notYet); // EventScriptForm.ScanScript
+            Assert.Contains("CCBranchForm", notYet);               // count == ClassForm.DataCount()
+            Assert.Contains("MapTileAnimation1Form", notYet);      // embedded IMG sub-block
+            Assert.Contains("MapTileAnimation2Form", notYet);      // embedded BIN sub-block
+            Assert.Contains("MapTerrainFloorLookupTableForm", notYet); // PatchUtil GetPointers()
+            Assert.Contains("MapTerrainBGLookupTableForm", notYet);    // PatchUtil GetPointers()
+        }
+
+        [Fact]
         public void GetNotYetPortedForms_HasNoDuplicates()
         {
             // Duplicates would inflate the count and make the IsComplete gate
@@ -460,6 +580,53 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.Contains(list, a => a.Addr == arFar && a.Info == "AreaClassForm far weapon");
                 uint arMagic = rom.p32(rom.RomInfo.arena_class_magic_weapon_pointer);
                 Assert.Contains(list, a => a.Addr == arMagic && a.Info == "AreaClassForm magic weapon");
+
+                // ---- slice 2b: the new batch tables must be present with the WF block sizes
+                //      and Info strings ----
+
+                // SoundBossBGMForm -> "BossBGM" (block 8, called unconditionally in WF).
+                uint bossBgmBase = rom.p32(rom.RomInfo.sound_boss_bgm_pointer);
+                Address bossBgm = list.FirstOrDefault(a => a.Addr == bossBgmBase && a.Info == "BossBGM");
+                Assert.NotNull(bossBgm);
+                Assert.Equal(8u, bossBgm.BlockSize);
+
+                // StatusUnitsMenuForm -> "UnitsMenu" (block 16, u32<0xFF, FE8-only).
+                uint unitsMenuBase = rom.p32(rom.RomInfo.status_units_menu_pointer);
+                Address unitsMenu = list.FirstOrDefault(a => a.Addr == unitsMenuBase && a.Info == "UnitsMenu");
+                Assert.NotNull(unitsMenu);
+                Assert.Equal(16u, unitsMenu.BlockSize);
+
+                // LinkArenaDenyUnitForm -> "LinkAreaDenyUnitForm" (WF typo, block 2, FE8-only).
+                uint linkDenyBase = rom.p32(rom.RomInfo.link_arena_deny_unit_pointer);
+                Address linkDeny = list.FirstOrDefault(a => a.Addr == linkDenyBase && a.Info == "LinkAreaDenyUnitForm");
+                Assert.NotNull(linkDeny);
+                Assert.Equal(2u, linkDeny.BlockSize);
+
+                // MonsterItemForm -> three distinct tables with WF Info strings and block sizes.
+                uint monItemBase = rom.p32(rom.RomInfo.monster_item_item_pointer);
+                Address monItem = list.FirstOrDefault(a => a.Addr == monItemBase && a.Info == "MonsterItemForm");
+                Assert.NotNull(monItem);
+                Assert.Equal(5u, monItem.BlockSize);
+                uint monItemProbBase = rom.p32(rom.RomInfo.monster_item_probability_pointer);
+                Assert.Contains(list, a => a.Addr == monItemProbBase && a.Info == "MonsterItemFormProbability" && a.BlockSize == 5);
+                uint monItemTableBase = rom.p32(rom.RomInfo.monster_item_table_pointer);
+                Assert.Contains(list, a => a.Addr == monItemTableBase && a.Info == "MonsterItemFormTable" && a.BlockSize == 32);
+
+                // MonsterProbabilityForm -> "MonsterProbabilityForm" (block 12).
+                uint monProbBase = rom.p32(rom.RomInfo.monster_probability_pointer);
+                Assert.Contains(list, a => a.Addr == monProbBase && a.Info == "MonsterProbabilityForm" && a.BlockSize == 12);
+
+                // The newly-covered forms must no longer be reported as NotYetPorted.
+                string[] notYet2b = RebuildProducerCore.GetNotYetPortedForms();
+                Assert.DoesNotContain("StatusUnitsMenuForm", notYet2b);
+                Assert.DoesNotContain("LinkArenaDenyUnitForm", notYet2b);
+                Assert.DoesNotContain("MonsterItemForm", notYet2b);
+                Assert.DoesNotContain("MonsterProbabilityForm", notYet2b);
+                // Deferred sibling forms MUST remain tracked (event-scan / dynamic count / patch).
+                Assert.Contains("MonsterWMapProbabilityForm", notYet2b);
+                Assert.Contains("CCBranchForm", notYet2b);
+                Assert.Contains("MapTileAnimation1Form", notYet2b);
+                Assert.Contains("MapTerrainFloorLookupTableForm", notYet2b);
 
                 // FAITHFULNESS / COMPLETENESS-SAFETY: Item and Class are NOT emitted by this
                 // slice (embedded sub-pointer blocks). They must be absent from the list AND

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -68,6 +68,14 @@ namespace FEBuilderGBA
             /// <summary>Item rule: <c>u32(addr+12)</c> pointer-or-null, plus <c>u32(addr+16)</c>
             /// pointer-or-null EXCEPT on FE8U (version 8 &amp;&amp; !multibyte). Capped at i&lt;=0xFF.</summary>
             ItemRule,
+            /// <summary>Continue while <c>u32(addr+Offset) &lt; <see cref="StructDescriptor.RuleStopValue"/></c>.
+            /// Matches StatusUnitsMenuForm (<c>u32(addr+0) &lt; 0xFF</c>).</summary>
+            U32LessThan,
+            /// <summary>SoundBossBGM rule: stop when <c>u16(addr) == 0xFFFF</c>, OR when
+            /// <c>i &gt; 10 &amp;&amp; rom.IsEmpty(addr, BlockSize*10)</c>. Reproduces
+            /// <c>SoundBossBGMForm.Init</c> verbatim (the trailing-empty guard prevents the
+            /// walk from running off the end of an un-terminated table).</summary>
+            SoundBossBGMRule,
         }
 
         /// <summary>A declarative description of one simple "table walk + emit IFR Address" form.</summary>
@@ -316,6 +324,22 @@ namespace FEBuilderGBA
                         return U.isPointerOrNULL(rom.u32(addr + 12))
                             && U.isPointerOrNULL(rom.u32(addr + 16));
                     };
+                case DataCountRule.U32LessThan:
+                    return (i, addr) =>
+                    {
+                        if (i >= d.MaxCount) return false;
+                        return rom.u32(addr + d.RuleOffset) < d.RuleStopValue;
+                    };
+                case DataCountRule.SoundBossBGMRule:
+                    return (i, addr) =>
+                    {
+                        if (i >= d.MaxCount) return false;
+                        // SoundBossBGMForm.Init: stop at the 0xFFFF terminator, and (after the
+                        // first 10 entries) stop once a run of 10 empty blocks is hit.
+                        if (rom.u16(addr) == 0xFFFF) return false;
+                        if (i > 10 && rom.IsEmpty(addr, d.BlockSize * 10)) return false;
+                        return true;
+                    };
                 default:
                     // An unhandled DataCountRule is a PROGRAMMING ERROR (a bad/new descriptor),
                     // not a 0-entry table. Returning always-false would silently emit a 1-block
@@ -475,6 +499,110 @@ namespace FEBuilderGBA
             // (ClassForm is NOT here — see the embedded-sub-pointer note above; it stays in
             //  GetNotYetPortedForms until its MoveCost sub-walk is ported.)
 
+            // SoundBossBGMForm.MakeAllDataLength — called UNCONDITIONALLY in WinForms
+            // (before the version branches). Info label "BossBGM". The Init IsDataExists is a
+            // 0xFFFF terminator PLUS a trailing-empty guard (see DataCountRule.SoundBossBGMRule).
+            l.Add(new StructDescriptor
+            {
+                Name = "BossBGM",
+                PointerField = r => r.RomInfo.sound_boss_bgm_pointer,
+                BlockSize = 8,
+                Rule = DataCountRule.SoundBossBGMRule,
+                PointerIndexes = new uint[] { },
+            });
+
+            // ---- version==8 (FE8) section ----
+            // These forms are called ONLY inside the WinForms `if (version == 8)` branch, in this
+            // order. Their data pointers are 0 on FE6/FE7 (EmitOne skips a 0/unsafe pointer), but
+            // we gate them to match the WF call structure exactly and avoid scanning junk on a
+            // non-FE8 ROM.
+            //
+            // MapTileAnimation1/2Form, MonsterWMapProbabilityForm, CCBranchForm, and the
+            // MapTerrain*LookupTable forms are deliberately NOT here:
+            //   * MapTileAnimation1/2 expand a per-entry embedded IMG/BIN sub-block (rule 3).
+            //   * MonsterWMapProbabilityForm also runs an EventScriptForm.ScanScript event-scan
+            //     in the same MakeAllDataLength (event-scan expansion, not a pure table walk).
+            //   * CCBranchForm's entry count is ClassForm.DataCount() (a dynamic class-table walk),
+            //     not a RomInfo field.
+            //   * MapTerrain{Floor,BG}LookupTableForm enumerate a PatchUtil-dependent GetPointers()
+            //     set (extends-battle-BG patch detection), not a fixed RomInfo table.
+            // They stay in GetNotYetPortedForms for a later slice.
+            if (rom.RomInfo.version == 8)
+            {
+                // StatusUnitsMenuForm.MakeAllDataLength — Info "UnitsMenu", block 16,
+                // IsDataExists = u32(addr+0) < 0xFF.
+                l.Add(new StructDescriptor
+                {
+                    Name = "UnitsMenu",
+                    PointerField = r => r.RomInfo.status_units_menu_pointer,
+                    BlockSize = 16,
+                    Rule = DataCountRule.U32LessThan,
+                    RuleOffset = 0,
+                    RuleStopValue = 0xFF,
+                    PointerIndexes = new uint[] { },
+                });
+
+                // LinkArenaDenyUnitForm.MakeAllDataLength — Info "LinkAreaDenyUnitForm" (WF typo
+                // preserved verbatim), block 2, IsDataExists = u8(addr) != 0x00.
+                l.Add(new StructDescriptor
+                {
+                    Name = "LinkAreaDenyUnitForm",
+                    PointerField = r => r.RomInfo.link_arena_deny_unit_pointer,
+                    BlockSize = 2,
+                    Rule = DataCountRule.U8NotEqual,
+                    RuleOffset = 0,
+                    RuleStopValue = 0x00,
+                    PointerIndexes = new uint[] { },
+                });
+
+                // MonsterItemForm.MakeAllDataLength — THREE tables (Init / N1_Init / N2_Init),
+                // each its own AddAddress with a distinct Info string, in this order. All
+                // IsDataExists = u8(addr) != 0xFF.
+                l.Add(new StructDescriptor
+                {
+                    Name = "MonsterItemForm",
+                    PointerField = r => r.RomInfo.monster_item_item_pointer,
+                    BlockSize = 5,
+                    Rule = DataCountRule.U8NotEqual,
+                    RuleOffset = 0,
+                    RuleStopValue = 0xFF,
+                    PointerIndexes = new uint[] { },
+                });
+                l.Add(new StructDescriptor
+                {
+                    Name = "MonsterItemFormProbability",
+                    PointerField = r => r.RomInfo.monster_item_probability_pointer,
+                    BlockSize = 5,
+                    Rule = DataCountRule.U8NotEqual,
+                    RuleOffset = 0,
+                    RuleStopValue = 0xFF,
+                    PointerIndexes = new uint[] { },
+                });
+                l.Add(new StructDescriptor
+                {
+                    Name = "MonsterItemFormTable",
+                    PointerField = r => r.RomInfo.monster_item_table_pointer,
+                    BlockSize = 32,
+                    Rule = DataCountRule.U8NotEqual,
+                    RuleOffset = 0,
+                    RuleStopValue = 0xFF,
+                    PointerIndexes = new uint[] { },
+                });
+
+                // MonsterProbabilityForm.MakeAllDataLength — Info "MonsterProbabilityForm",
+                // block 12, IsDataExists = u8(addr) != 0xFF.
+                l.Add(new StructDescriptor
+                {
+                    Name = "MonsterProbabilityForm",
+                    PointerField = r => r.RomInfo.monster_probability_pointer,
+                    BlockSize = 12,
+                    Rule = DataCountRule.U8NotEqual,
+                    RuleOffset = 0,
+                    RuleStopValue = 0xFF,
+                    PointerIndexes = new uint[] { },
+                });
+            }
+
             // ---- trailing is_multibyte branch: MapTerrainName(Eng) ----
             // WinForms: is_multibyte -> MapTerrainNameForm (embedded CString sub-walk, deferred);
             //           else        -> MapTerrainNameEngForm (clean u16!=0 table).
@@ -550,8 +678,9 @@ namespace FEBuilderGBA
                 "SkillConfigSkillSystemForm", "SkillConfigFE8NSkillForm",
                 "SkillConfigFE8NVer2SkillForm", "SkillConfigFE8NVer3SkillForm",
                 // status / menu definition / misc tables needing extra logic
-                "StatusOptionForm", "StatusOptionOrderForm", "StatusUnitsMenuForm",
-                "LinkArenaDenyUnitForm", "MantAnimationForm", "MapTileAnimation1Form",
+                // (StatusUnitsMenuForm + LinkArenaDenyUnitForm ported in slice 2b.)
+                "StatusOptionForm", "StatusOptionOrderForm",
+                "MantAnimationForm", "MapTileAnimation1Form",
                 "MapTileAnimation2Form", "MapTerrainFloorLookupTableForm",
                 "MapTerrainBGLookupTableForm",
                 // units / classes per-version with extra reads
@@ -559,7 +688,10 @@ namespace FEBuilderGBA
                 "ExtraUnitForm", "ExtraUnitFE8UForm", "SummonUnitForm", "SummonsDemonKingForm",
                 "EventUnitForm(RecycleReserveUnits)", "EventForceSortieForm",
                 // monster / world map / ED / support (FE8/FE7/FE6 variants)
-                "MonsterItemForm", "MonsterProbabilityForm", "MonsterWMapProbabilityForm",
+                // (MonsterItemForm + MonsterProbabilityForm ported in slice 2b.
+                //  MonsterWMapProbabilityForm stays — it runs an EventScriptForm.ScanScript
+                //  event-scan in the same MakeAllDataLength, not a pure table walk.)
+                "MonsterWMapProbabilityForm",
                 "EDForm", "EventBattleTalkForm", "CCBranchForm", "OPClassAlphaNameForm",
                 "WorldMapPathForm", "WorldMapEventPointerForm", "EDStaffRollForm",
                 "OPPrologueForm", "EventHaikuForm", "SupportTalkForm",


### PR DESCRIPTION
## Summary
**Slice 2b** of #1261 — extends the ROM-rebuild struct-pointer producer (`RebuildProducerCore`, merged in #1272) with the next batch of **simple single-table forms**, applying the same verbatim-WF faithfulness discipline.

## Forms added (7 forms / 7 descriptors — all cross-checked verbatim vs WF `Init`/`MakeAllDataLength`, all `pointerIndexes {}`)
- **SoundBossBGM** ("BossBGM", `sound_boss_bgm_pointer`, block 8, new `SoundBossBGMRule`)
- **StatusUnitsMenu** (FE8, `status_units_menu_pointer`, block 16, new `U32LessThan`)
- **LinkArenaDenyUnit** (FE8, `link_arena_deny_unit_pointer`, block 2, U8≠0x00; WF Info typo "LinkAreaDenyUnitForm" kept verbatim)
- **MonsterItem** ×3 distinct tables (item/probability/table — distinct WF Info each → 3 descriptors, per the ArenaClass rule)
- **MonsterProbability** (`monster_probability_pointer`, block 12, U8≠0xFF)
- 2 new `DataCountRule`s (`U32LessThan`, `SoundBossBGMRule`) with real `MakeIsDataExists` handlers (never hit the default-throws).

## Deferred (correctly kept in NotYetPorted — not a pure RomInfo-table walk)
MonsterWMapProbability (also runs an EventScript scan), CCBranch (dynamic count = ClassForm.DataCount), MapTileAnimation1/2 (per-entry embedded IMG/BIN sub-block), MapTerrainFloor/BGLookupTable (PatchUtil-dependent pointer set). These need their sub-walks extracted in later slices.

## Coverage
8 → **15 forms / 18 descriptors**. `GetNotYetPortedForms()` updated (4 covered forms removed, stays deduped): **130 → 126** remaining.

## Tests
- RebuildProducerCoreTests: **21 passed**, 0 failed (real-FE8U batch assertions run against a real ROM; all 7 new tables found with correct block sizes + Info strings; covered forms confirmed absent from NotYetPorted). FEBuilderGBA.Tests (windows): **1865 passed**.
- (~78 pre-existing `StructExportCoreTests`/etc. config-staging env failures — passes 67/67 in isolation, parallel shared-state ordering, not this change.)

Part of #1261.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
