### PR TITLE
feat(core): ROM-rebuild producer — per-entry sub-walks + ClassForm (#1261 slice 2c)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -23,6 +23,9 @@ namespace FEBuilderGBA.Core.Tests
             var rom = new ROM();
             rom.SwapNewROMDataDirect(new byte[size]);
             CoreState.ROM = rom;
+            // The CString/BinString sub-walks decode strings via ROM.getString, which needs a
+            // SystemTextEncoder. A headless ASCII encoder is enough for the synthetic-ROM tests.
+            CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
             return rom;
         }
 
@@ -447,10 +450,11 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Contains("TextForm", notYet);
             Assert.Contains("EventCondForm", notYet);
             Assert.Contains("SongTableForm", notYet);
-            // Item/Class have embedded per-entry sub-pointer blocks (StatBooster/effectiveness,
-            // MoveCost) the descriptor walker cannot emit yet -> must be DEFERRED, not in the batch.
+            // ItemForm stays DEFERRED: its StatBooster sub-block size depends on un-ported PatchUtil
+            // patch detection. (ClassForm WAS deferred for its MoveCost sub-blocks but is ported in
+            // slice 2c — see GetNotYetPortedForms_DropsSlice2cCoveredForms_KeepsDeferredSiblings.)
             Assert.Contains("ItemForm", notYet);
-            Assert.Contains("ClassForm", notYet);
+            Assert.DoesNotContain("ClassForm", notYet);
         }
 
         [Fact]
@@ -542,12 +546,16 @@ namespace FEBuilderGBA.Core.Tests
             if (romPath == null) return; // skip when no ROM available (env-only)
 
             var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
             try
             {
                 var rom = new ROM();
                 if (!rom.Load(romPath, out string _)) return; // skip
                 CoreState.ROM = rom;
                 if (rom.RomInfo.version != 8) return; // this assertion is FE8U-specific
+                // The full producer walk now decodes strings (slice 2c StatusParam/MapTerrainName
+                // sub-walks) via ROM.getString, which needs a SystemTextEncoder.
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
 
                 // Pass a progress collector through and assert reporting happens (does not throw).
                 var progressLines = new List<string>();
@@ -628,13 +636,13 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.Contains("MapTileAnimation1Form", notYet2b);
                 Assert.Contains("MapTerrainFloorLookupTableForm", notYet2b);
 
-                // FAITHFULNESS / COMPLETENESS-SAFETY: Item and Class are NOT emitted by this
-                // slice (embedded sub-pointer blocks). They must be absent from the list AND
-                // tracked in NotYetPorted so a rebuild does not silently drop their sub-blocks.
+                // FAITHFULNESS / COMPLETENESS-SAFETY: ItemForm is NOT emitted (its StatBooster
+                // sub-block size needs un-ported PatchUtil detection) — it must be absent from the
+                // list AND tracked in NotYetPorted so a rebuild does not silently drop its
+                // sub-blocks. ClassForm IS emitted as of slice 2c (covered by the dedicated
+                // MakeAllStructPointersList_FE8U_FindsClassMoveCostSubBlocks_AndDefersItem test).
                 uint itemBase = rom.p32(rom.RomInfo.item_pointer);
                 Assert.DoesNotContain(list, a => a.Addr == itemBase && a.Info == "Item");
-                uint classBase = rom.p32(rom.RomInfo.class_pointer);
-                Assert.DoesNotContain(list, a => a.Addr == classBase && a.Info == "Class");
 
                 // The progress collector must have received reports (per-descriptor + summary).
                 lock (progressLines)
@@ -646,6 +654,365 @@ namespace FEBuilderGBA.Core.Tests
             finally
             {
                 CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
+        }
+
+        // ---- slice 2c: per-entry embedded sub-walks ------------------------
+
+        [Fact]
+        public void SubWalk_BinFixed_EmitsFixedLengthBinBehindEachEntryPointer()
+        {
+            // ClassForm MoveCost: a 66-byte BIN block behind the embedded pointer at offset 56.
+            var rom = CreateTestRom(0x4000);
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            uint block = 0x54; // > 56 so the embedded pointer fits in the block
+            rom.write_u32(pointer, Ptr(table));
+            // entry 0 exists (index-0 always), entry 1 u8(+4)=1 exists, entry 2 u8(+4)=0 stops.
+            rom.write_u8(table + block * 1 + 4, 0x01);
+            // entry 0's MoveCost pointer @ +56 -> 0x2000 ; entry 1's -> 0x2100
+            uint mc0 = 0x2000, mc1 = 0x2100;
+            rom.write_u32(table + block * 0 + 56, Ptr(mc0));
+            rom.write_u32(table + block * 1 + 56, Ptr(mc1));
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "Class",
+                PointerField = _ => pointer,
+                BlockSize = block,
+                Rule = RebuildProducerCore.DataCountRule.U8NotZeroIndex0Always,
+                RuleOffset = 4,
+                MaxCount = 0x100,
+                PointerIndexes = new uint[] { 56 },
+                SubWalks = new List<RebuildProducerCore.SubWalk>
+                {
+                    new RebuildProducerCore.SubWalk
+                    {
+                        EmbeddedPointerOffset = 56,
+                        Kind = RebuildProducerCore.SubKind.BinFixed,
+                        FixedLength = 66,
+                        Name = (r, i) => "MoveCost Clear",
+                    },
+                },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            // main IFR + 2 MoveCost sub-blocks
+            Assert.Equal(3, list.Count);
+            // main is first
+            Assert.Equal(table, list[0].Addr);
+            // both MoveCost blocks present at the right addr/length/pointer-slot/type
+            Address b0 = list.First(a => a.Addr == mc0);
+            Assert.Equal(66u, b0.Length);
+            Assert.Equal(table + block * 0 + 56, b0.Pointer);
+            Assert.Equal(Address.DataTypeEnum.BIN, b0.DataType);
+            Address b1 = list.First(a => a.Addr == mc1);
+            Assert.Equal(66u, b1.Length);
+            Assert.Equal(table + block * 1 + 56, b1.Pointer);
+        }
+
+        [Fact]
+        public void SubWalk_BinFixed_SkipsEntryWhenEmbeddedPointerUnsafe()
+        {
+            // If an entry's embedded pointer is not a safe offset, no sub-block is emitted
+            // (WF: `if (U.isSafetyOffset(pointer))`).
+            var rom = CreateTestRom(0x4000);
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            uint block = 0x54;
+            rom.write_u32(pointer, Ptr(table));
+            // single entry (index 0); embedded pointer @ +56 left 0 (unsafe) -> no sub-block.
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "Class",
+                PointerField = _ => pointer,
+                BlockSize = block,
+                Rule = RebuildProducerCore.DataCountRule.U8NotZeroIndex0Always,
+                RuleOffset = 4,
+                MaxCount = 0x100,
+                PointerIndexes = new uint[] { 56 },
+                SubWalks = new List<RebuildProducerCore.SubWalk>
+                {
+                    new RebuildProducerCore.SubWalk
+                    {
+                        EmbeddedPointerOffset = 56,
+                        Kind = RebuildProducerCore.SubKind.BinFixed,
+                        FixedLength = 66,
+                        Name = (r, i) => "MoveCost Clear",
+                    },
+                },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            // only the main IFR Address — the 0 (unsafe) embedded pointer is skipped.
+            Assert.Single(list);
+            Assert.Equal(table, list[0].Addr);
+        }
+
+        [Fact]
+        public void ExtraFixedPointers_EmittedOncePerDescriptor()
+        {
+            // ClassForm's three 全クラス共通 terrain pointers are emitted ONCE (not per entry).
+            var rom = CreateTestRom(0x4000);
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            uint block = 0x10;
+            rom.write_u32(pointer, Ptr(table));
+            // 2 entries (index 0 + u8(+4)=1 at entry 1)
+            rom.write_u8(table + block * 1 + 4, 0x01);
+
+            uint tr0 = 0x0250, tr1 = 0x0254;
+            uint tBlock0 = 0x2200, tBlock1 = 0x2300;
+            rom.write_u32(tr0, Ptr(tBlock0));
+            rom.write_u32(tr1, Ptr(tBlock1));
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "Class",
+                PointerField = _ => pointer,
+                BlockSize = block,
+                Rule = RebuildProducerCore.DataCountRule.U8NotZeroIndex0Always,
+                RuleOffset = 4,
+                MaxCount = 0x100,
+                PointerIndexes = new uint[] { },
+                ExtraFixedPointers = new[]
+                {
+                    new RebuildProducerCore.ExtraFixedPointer { PointerField = _ => tr0, FixedLength = 66, Name = "MoveCost ref" },
+                    new RebuildProducerCore.ExtraFixedPointer { PointerField = _ => tr1, FixedLength = 66, Name = "MoveCost recovery bad status" },
+                },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            // main IFR + exactly 2 extra pointers (once, regardless of the 2 entries).
+            Assert.Equal(3, list.Count);
+            Assert.Single(list, a => a.Addr == tBlock0 && a.Length == 66 && a.DataType == Address.DataTypeEnum.BIN);
+            Assert.Single(list, a => a.Addr == tBlock1 && a.Length == 66 && a.DataType == Address.DataTypeEnum.BIN);
+        }
+
+        [Fact]
+        public void SubWalk_CString_EmitsNulTerminatedStringBehindEmbeddedPointer()
+        {
+            // StatusParamForm: a CString (len+1, CSTRING) behind the embedded pointer at offset 12.
+            var rom = CreateTestRom(0x4000);
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            uint block = 16;
+            rom.write_u32(pointer, Ptr(table));
+            // entry 0: embedded pointer @ +12 must be a real pointer (PointerAt rule) -> 0x2000
+            // entry 1: embedded pointer @ +12 == 0 (NULL) -> PointerAt stops (count == 1)
+            uint str0 = 0x2000;
+            rom.write_u32(table + block * 0 + 12, Ptr(str0));
+            // plant the C string "AB\0" at str0
+            rom.write_u8(str0 + 0, (byte)'A');
+            rom.write_u8(str0 + 1, (byte)'B');
+            rom.write_u8(str0 + 2, 0x00);
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "StatusParam0",
+                PointerField = _ => pointer,
+                BlockSize = block,
+                Rule = RebuildProducerCore.DataCountRule.PointerAt,
+                RuleOffset = 12,
+                MaxCount = 0x10000,
+                PointerIndexes = new uint[] { 0, 4, 12 },
+                SubWalks = new List<RebuildProducerCore.SubWalk>
+                {
+                    new RebuildProducerCore.SubWalk
+                    {
+                        EmbeddedPointerOffset = 12,
+                        Kind = RebuildProducerCore.SubKind.CString,
+                    },
+                },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            // main IFR (dataCount == 1) + 1 CString sub-block
+            Assert.Equal(2, list.Count);
+            Address main = list[0];
+            Assert.Equal(table, main.Addr);
+            Assert.Equal(16u * (1 + 1), main.Length); // count 1 -> length block*(1+1)
+            Address cstr = list.First(a => a.DataType == Address.DataTypeEnum.CSTRING);
+            Assert.Equal(str0, cstr.Addr);
+            Assert.Equal(3u, cstr.Length); // "AB" + NUL == strlen(2) + 1
+            Assert.Equal(table + 0 * block + 12, cstr.Pointer);
+        }
+
+        [Fact]
+        public void SubWalk_BinString_EmitsStringLengthBinNoPlusOne()
+        {
+            // MapTerrainNameForm: a string-derived BIN block of length == strlen (NO +1) behind the
+            // embedded pointer at offset 0.
+            var rom = CreateTestRom(0x4000);
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            uint block = 4;
+            rom.write_u32(pointer, Ptr(table));
+            // entry 0: embedded pointer @ +0 -> 0x2000 (a real pointer, PointerOrNullAt continues)
+            // entry 1: embedded pointer @ +0 == not-a-pointer -> stop.
+            uint str0 = 0x2000;
+            rom.write_u32(table + block * 0 + 0, Ptr(str0));
+            rom.write_u32(table + block * 1 + 0, 0x12345678); // not a pointer-or-null -> stop
+            rom.write_u8(str0 + 0, (byte)'X');
+            rom.write_u8(str0 + 1, (byte)'Y');
+            rom.write_u8(str0 + 2, (byte)'Z');
+            rom.write_u8(str0 + 3, 0x00);
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "Terrain",
+                PointerField = _ => pointer,
+                BlockSize = block,
+                Rule = RebuildProducerCore.DataCountRule.PointerOrNullAt,
+                RuleOffset = 0,
+                PointerIndexes = new uint[] { 0 },
+                SubWalks = new List<RebuildProducerCore.SubWalk>
+                {
+                    new RebuildProducerCore.SubWalk
+                    {
+                        EmbeddedPointerOffset = 0,
+                        Kind = RebuildProducerCore.SubKind.BinString,
+                    },
+                },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            // main IFR (dataCount == 1) + 1 string-BIN sub-block
+            Assert.Equal(2, list.Count);
+            Address bin = list.First(a => a.DataType == Address.DataTypeEnum.BIN);
+            Assert.Equal(str0, bin.Addr);
+            Assert.Equal(3u, bin.Length); // "XYZ" == strlen 3, NO +1 (distinct from CString)
+            Assert.Equal(table + 0 * block + 0, bin.Pointer);
+        }
+
+        [Fact]
+        public void DataCountRule_PointerAt_NullSlotTerminates_OrNullDoesNot()
+        {
+            // PointerAt stops at a NULL slot; PointerOrNullAt continues through it. Two synthetic
+            // tables prove the difference (StatusParam vs MapTerrain semantics).
+            var rom = CreateTestRom(0x4000);
+            uint pointer = 0x0240;
+            uint table = 0x1000;
+            uint block = 16;
+            rom.write_u32(pointer, Ptr(table));
+            // entry 0 slot @ +12 = real ptr ; entry 1 slot @ +12 = NULL(0) ; entry 2 = real ptr ;
+            // entry 3 slot @ +12 = garbage (neither pointer nor NULL) -> the hard stop for BOTH rules.
+            rom.write_u32(table + block * 0 + 12, Ptr(0x2000));
+            rom.write_u32(table + block * 1 + 12, 0x00000000);   // NULL
+            rom.write_u32(table + block * 2 + 12, Ptr(0x2100));
+            rom.write_u32(table + block * 3 + 12, 0x12345678);   // garbage (not pointer-or-null)
+
+            var pAt = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "PAt", PointerField = _ => pointer, BlockSize = block,
+                Rule = RebuildProducerCore.DataCountRule.PointerAt, RuleOffset = 12,
+                MaxCount = 0x100, PointerIndexes = new uint[] { },
+            };
+            var listAt = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, listAt, pAt);
+            // PointerAt stops at entry 1 (NULL terminates) -> dataCount 1 -> length block*(1+1)
+            Assert.Equal(block * (1 + 1), listAt[0].Length);
+
+            var pOrNull = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "POrNull", PointerField = _ => pointer, BlockSize = block,
+                Rule = RebuildProducerCore.DataCountRule.PointerOrNullAt, RuleOffset = 12,
+                MaxCount = 0x100, PointerIndexes = new uint[] { },
+            };
+            var listOrNull = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, listOrNull, pOrNull);
+            // PointerOrNullAt passes THROUGH the NULL at entry 1; it stops only at the entry-3
+            // garbage -> dataCount 3 -> length block*(3+1).
+            Assert.Equal(block * (3 + 1), listOrNull[0].Length);
+        }
+
+        [Fact]
+        public void GetNotYetPortedForms_DropsSlice2cCoveredForms_KeepsDeferredSiblings()
+        {
+            // Slice 2c ports ClassForm + StatusParamForm + MapTerrainNameForm -> they must be
+            // removed from the not-yet-ported tracker. ROM-independent so it always runs.
+            string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
+            Assert.DoesNotContain("ClassForm", notYet);
+            Assert.DoesNotContain("StatusParamForm", notYet);
+            Assert.DoesNotContain("MapTerrainNameForm", notYet);
+
+            // The deferred siblings (un-ported patch detection / PROCS disasm / recursive ASM tree /
+            // config-file driven) MUST stay tracked — porting only some embedded forms while leaving
+            // these un-tracked would dangle their sub-block pointers during a rebuild.
+            Assert.Contains("ItemForm", notYet);          // StatBooster size needs PatchUtil detection
+            Assert.Contains("ItemWeaponEffectForm", notYet); // PROCS length needs ProcsScript disasm
+            Assert.Contains("MenuDefinitionForm", notYet);   // recursive MenuCommand + ASM ptrs
+            Assert.Contains("StatusRMenuForm", notYet);      // recursive 28-byte tree + ASM funcs
+            Assert.Contains("OtherTextForm", notYet);        // config-file (U.ConfigDataFilename) driven
+        }
+
+        [Fact]
+        public void MakeAllStructPointersList_FE8U_FindsClassMoveCostSubBlocks_AndDefersItem()
+        {
+            string romPath = FindTestRom();
+            if (romPath == null) return; // skip when no ROM available (env-only)
+
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var rom = new ROM();
+                if (!rom.Load(romPath, out string _)) return; // skip
+                CoreState.ROM = rom;
+                if (rom.RomInfo.version != 8) return; // FE8U-specific
+                // Slice 2c forms decode strings (StatusParam CString, MapTerrainName string-BIN) via
+                // ROM.getString, which needs a SystemTextEncoder. A headless encoder is sufficient.
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+
+                List<Address> list = RebuildProducerCore.MakeAllStructPointersList(rom);
+                Assert.NotEmpty(list);
+
+                // ClassForm main IFR must now be present (it was DEFERRED before slice 2c).
+                uint classBase = rom.p32(rom.RomInfo.class_pointer);
+                Address main = list.FirstOrDefault(a => a.Addr == classBase && a.Info == "Class");
+                Assert.NotNull(main);
+                Assert.Equal(rom.RomInfo.class_datasize, main.BlockSize);
+                Assert.Equal(new uint[] { 52, 56, 60, 64, 68, 72, 76 }, main.PointerIndexes);
+
+                // At least one MoveCost sub-block (66-byte BIN) must be emitted behind an embedded
+                // class pointer @ off 56..76. (Vanilla FE8U classes share MoveCost tables.)
+                int moveCostBlocks = list.Count(a => a.DataType == Address.DataTypeEnum.BIN
+                    && a.Length == 66
+                    && a.Info != null && a.Info.StartsWith("MoveCost"));
+                Assert.True(moveCostBlocks > 0, "expected at least one 66-byte MoveCost BIN sub-block");
+
+                // The three 全クラス共通 terrain pointers must be present (once each).
+                uint trBase = rom.p32(rom.RomInfo.terrain_recovery_pointer);
+                if (U.isSafetyOffset(trBase))
+                {
+                    Assert.Contains(list, a => a.Addr == trBase && a.Length == 66
+                        && a.Info == "MoveCost ref" && a.DataType == Address.DataTypeEnum.BIN);
+                }
+
+                // ClassForm must no longer be tracked as not-yet-ported; ItemForm STAYS deferred
+                // and its main IFR must be ABSENT from the list (StatBooster size unportable).
+                string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
+                Assert.DoesNotContain("ClassForm", notYet);
+                Assert.Contains("ItemForm", notYet);
+                uint itemBase = rom.p32(rom.RomInfo.item_pointer);
+                Assert.DoesNotContain(list, a => a.Addr == itemBase && a.Info == "Item");
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
             }
         }
 

--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -540,7 +540,7 @@ namespace FEBuilderGBA.Core.Tests
         // ---- real-FE8U parity: the batch finds the known tables -------------
 
         [Fact]
-        public void MakeAllStructPointersList_FE8U_FindsBatchTables_AndDefersItemClass()
+        public void MakeAllStructPointersList_FE8U_FindsBatchTables_AndDefersItem()
         {
             string romPath = FindTestRom();
             if (romPath == null) return; // skip when no ROM available (env-only)
@@ -659,6 +659,187 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         // ---- slice 2c: per-entry embedded sub-walks ------------------------
+
+        // Synthetic versioned ROMs: LoadLow matches the GBA game-code substring to select the
+        // ROMFE* subclass, which populates RomInfo (version / class_datasize). The version string
+        // MUST be one LoadLow actually recognizes (FE6="AFEJ01", FE8U="BE8E01"), else RomInfo stays
+        // null. (Distinct from ClassFE6LayoutTests, which constructs ROMFE6JP directly.)
+        static ROM MakeVersionedRom(string versionString)
+        {
+            var rom = new ROM();
+            var data = new byte[0x200_0000]; // 32MB — survives ROMFE ctor patch probing
+            bool ok = rom.LoadLow("fake.gba", data, versionString);
+            Assert.True(ok, "LoadLow did not recognize version string: " + versionString);
+            return rom;
+        }
+
+        [Fact]
+        public void BuildBatchDescriptors_FE6_UsesFE6ClassLayout_NotFE78()
+        {
+            // CORRECTNESS (FE6 version bug): on a FE6 ROM the producer MUST use the ClassFE6Form
+            // layout (pointerIndexes {48,52,56,60,64}, 4x MoveCost @ {48,52,56,60} length 52, skip
+            // class 0, terrain pointers length 52) — NOT the FE7/8 layout ({52..76}, 6x len 66).
+            // Running the FE7/8 descriptor on FE6 would relocate the wrong bytes (corruption).
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe6 = MakeVersionedRom("AFEJ01"); // FE6 (ROMFE6JP) version code LoadLow matches
+                CoreState.ROM = fe6;
+                Assert.NotNull(fe6.RomInfo);
+                Assert.Equal(6, fe6.RomInfo.version);
+
+                var descs = RebuildProducerCore.BuildBatchDescriptors(fe6);
+                var cls = descs.Single(d => d.Name == "Class");
+
+                Assert.Equal(new uint[] { 48, 52, 56, 60, 64 }, cls.PointerIndexes);
+                Assert.Equal(1u, cls.SubWalkStartIndex); // FE6 skips class 0
+                Assert.NotNull(cls.SubWalks);
+                Assert.Equal(4, cls.SubWalks.Count);
+                Assert.Equal(new uint[] { 48, 52, 56, 60 },
+                    cls.SubWalks.Select(s => s.EmbeddedPointerOffset).ToArray());
+                Assert.All(cls.SubWalks, s => Assert.Equal(52u, s.FixedLength));
+                Assert.All(cls.SubWalks, s => Assert.Equal(RebuildProducerCore.SubKind.BinFixed, s.Kind));
+                Assert.NotNull(cls.ExtraFixedPointers);
+                Assert.Equal(3, cls.ExtraFixedPointers.Length);
+                Assert.All(cls.ExtraFixedPointers, e => Assert.Equal(52u, e.FixedLength));
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+            }
+        }
+
+        [Fact]
+        public void BuildBatchDescriptors_FE8_UsesFE78ClassLayout()
+        {
+            // Conversely, a FE8 ROM must get the FE7/8 Class layout ({52..76}, 6x len 66, start 0).
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01"); // FE8U (ROMFE8U) version code LoadLow matches
+                CoreState.ROM = fe8;
+                Assert.NotNull(fe8.RomInfo);
+                Assert.Equal(8, fe8.RomInfo.version);
+
+                var descs = RebuildProducerCore.BuildBatchDescriptors(fe8);
+                var cls = descs.Single(d => d.Name == "Class");
+
+                Assert.Equal(new uint[] { 52, 56, 60, 64, 68, 72, 76 }, cls.PointerIndexes);
+                Assert.Equal(0u, cls.SubWalkStartIndex);
+                Assert.Equal(6, cls.SubWalks.Count);
+                Assert.Equal(new uint[] { 56, 60, 64, 68, 72, 76 },
+                    cls.SubWalks.Select(s => s.EmbeddedPointerOffset).ToArray());
+                Assert.All(cls.SubWalks, s => Assert.Equal(66u, s.FixedLength));
+                Assert.All(cls.ExtraFixedPointers, e => Assert.Equal(66u, e.FixedLength));
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+            }
+        }
+
+        [Fact]
+        public void SubWalkStartIndex_SkipsLeadingEntries()
+        {
+            // FE6 Class skips class 0: with SubWalkStartIndex=1 the entry-0 embedded pointer is NOT
+            // sub-walked even though it's a valid pointer; entry 1+ are.
+            var rom = CreateTestRom(0x4000);
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            uint block = 0x48; // > 60 not needed; FE6 offsets go up to 60, use a block that fits
+            block = 0x40;
+            rom.write_u32(pointer, Ptr(table));
+            // 2 entries: index 0 (always) + index 1 (u8(+4)=1); index 2 stops.
+            rom.write_u8(table + block * 1 + 4, 0x01);
+            // both entries have a valid MoveCost pointer @ +48
+            uint mc0 = 0x2000, mc1 = 0x2100;
+            rom.write_u32(table + block * 0 + 48, Ptr(mc0));
+            rom.write_u32(table + block * 1 + 48, Ptr(mc1));
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "Class",
+                PointerField = _ => pointer,
+                BlockSize = block,
+                Rule = RebuildProducerCore.DataCountRule.U8NotZeroIndex0Always,
+                RuleOffset = 4,
+                MaxCount = 0x100,
+                PointerIndexes = new uint[] { 48 },
+                SubWalkStartIndex = 1, // skip class 0
+                SubWalks = new List<RebuildProducerCore.SubWalk>
+                {
+                    new RebuildProducerCore.SubWalk
+                    {
+                        EmbeddedPointerOffset = 48,
+                        Kind = RebuildProducerCore.SubKind.BinFixed,
+                        FixedLength = 52,
+                        Name = (r, i) => "MoveCost Clear",
+                    },
+                },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            // main IFR + exactly 1 MoveCost block (entry 1 only — entry 0 skipped).
+            Assert.Equal(2, list.Count);
+            Assert.Single(list, a => a.Addr == mc1 && a.Length == 52);
+            Assert.DoesNotContain(list, a => a.Addr == mc0); // entry 0 NOT sub-walked
+        }
+
+        [Fact]
+        public void EmitSubWalks_NoEncoder_SkipsStringKindsGracefully_NoNRE()
+        {
+            // REGRESSION: the string-decoding sub-walks (CString/BinString) read ROM.getString,
+            // which needs CoreState.SystemTextEncoder. With no encoder the producer must SKIP them
+            // (never NRE). BinFixed does not decode strings, so it still runs.
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(new byte[0x4000]);
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = null; // the critical condition
+
+                uint table = 0x1000, pointer = 0x0240, block = 16;
+                rom.write_u32(pointer, Ptr(table));
+                // entry 0 has a CString pointer @ +12 and a BinFixed pointer @ +0
+                rom.write_u32(table + 12, Ptr(0x2000)); // PointerAt keeps entry 0
+                rom.write_u8(0x2000, (byte)'A');
+                rom.write_u8(0x2001, 0x00);
+                rom.write_u32(table + 0, Ptr(0x2200)); // BinFixed target
+
+                var d = new RebuildProducerCore.StructDescriptor
+                {
+                    Name = "Mixed",
+                    PointerField = _ => pointer,
+                    BlockSize = block,
+                    Rule = RebuildProducerCore.DataCountRule.PointerAt,
+                    RuleOffset = 12,
+                    MaxCount = 0x100,
+                    PointerIndexes = new uint[] { 0, 12 },
+                    SubWalks = new List<RebuildProducerCore.SubWalk>
+                    {
+                        new RebuildProducerCore.SubWalk { EmbeddedPointerOffset = 12, Kind = RebuildProducerCore.SubKind.CString },
+                        new RebuildProducerCore.SubWalk { EmbeddedPointerOffset = 0, Kind = RebuildProducerCore.SubKind.BinFixed, FixedLength = 40, Name = (r, i) => "Fixed" },
+                    },
+                };
+
+                var list = new List<Address>();
+                // must NOT throw NRE
+                RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+                // main IFR + the BinFixed sub-block; the CString is skipped (no encoder).
+                Assert.Contains(list, a => a.Addr == 0x2200 && a.Length == 40);
+                Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.CSTRING);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
+        }
 
         [Fact]
         public void SubWalk_BinFixed_EmitsFixedLengthBinBehindEachEntryPointer()
@@ -1016,7 +1197,9 @@ namespace FEBuilderGBA.Core.Tests
             }
         }
 
-        static string FindTestRom()
+        static string FindTestRom() => FindTestRomNamed("FE8U.gba");
+
+        static string FindTestRomNamed(string romFile)
         {
             string thisAssembly = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string dir = System.IO.Path.GetDirectoryName(thisAssembly);
@@ -1027,7 +1210,7 @@ namespace FEBuilderGBA.Core.Tests
                     string romsDir = System.IO.Path.Combine(dir, "roms");
                     if (System.IO.Directory.Exists(romsDir))
                     {
-                        string path = System.IO.Path.Combine(romsDir, "FE8U.gba");
+                        string path = System.IO.Path.Combine(romsDir, romFile);
                         if (System.IO.File.Exists(path)) return path;
                     }
                     break;
@@ -1035,6 +1218,48 @@ namespace FEBuilderGBA.Core.Tests
                 dir = System.IO.Path.GetDirectoryName(dir);
             }
             return null;
+        }
+
+        [Fact]
+        public void MakeAllStructPointersList_FE6_UsesFE6ClassLayout_Len52SubBlocks()
+        {
+            // CORRECTNESS (FE6 version bug) end-to-end on a real FE6 ROM: the Class descriptor must
+            // emit 52-byte MoveCost BIN sub-blocks (NOT 66) and the FE6 pointerIndexes, proving the
+            // version gate picks ClassFE6Form's layout. Env-gated on roms/FE6.gba.
+            string romPath = FindTestRomNamed("FE6.gba");
+            if (romPath == null) return; // skip when no FE6 ROM available (env-only)
+
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var rom = new ROM();
+                if (!rom.Load(romPath, out string _)) return; // skip
+                CoreState.ROM = rom;
+                if (rom.RomInfo.version != 6) return; // FE6-specific
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+
+                List<Address> list = RebuildProducerCore.MakeAllStructPointersList(rom);
+                Assert.NotEmpty(list);
+
+                // Class main IFR present with FE6 pointerIndexes {48,52,56,60,64}.
+                uint classBase = rom.p32(rom.RomInfo.class_pointer);
+                Address main = list.FirstOrDefault(a => a.Addr == classBase && a.Info == "Class");
+                Assert.NotNull(main);
+                Assert.Equal(new uint[] { 48, 52, 56, 60, 64 }, main.PointerIndexes);
+
+                // MoveCost sub-blocks must be 52-byte (the FE6 length) — NEVER 66 (the FE7/8 length).
+                int len52 = list.Count(a => a.DataType == Address.DataTypeEnum.BIN
+                    && a.Length == 52 && a.Info != null && a.Info.StartsWith("MoveCost"));
+                Assert.True(len52 > 0, "expected at least one 52-byte FE6 MoveCost BIN sub-block");
+                Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.BIN
+                    && a.Length == 66 && a.Info != null && a.Info.StartsWith("MoveCost"));
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
         }
     }
 }

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -76,6 +76,59 @@ namespace FEBuilderGBA
             /// <c>SoundBossBGMForm.Init</c> verbatim (the trailing-empty guard prevents the
             /// walk from running off the end of an un-terminated table).</summary>
             SoundBossBGMRule,
+            /// <summary>Continue while <c>U.isPointer(u32(addr+Offset))</c> (a non-NULL ROM
+            /// pointer). Matches <c>StatusParamForm.Init</c> (<c>U.isPointer(u32(addr+12))</c>).
+            /// Distinct from <see cref="U32IsPointerOrNull"/>: a NULL slot terminates here.</summary>
+            PointerAt,
+            /// <summary>Continue while <c>U.isPointerOrNULL(u32(addr+Offset))</c>. Matches
+            /// <c>MapTerrainNameForm.Init</c> (<c>U.isPointerOrNULL(u32(addr+0))</c>). NULL is
+            /// accepted (unlike <see cref="PointerAt"/>).</summary>
+            PointerOrNullAt,
+        }
+
+        /// <summary>How a <see cref="SubWalk"/> reproduces the per-entry embedded-data
+        /// <see cref="Address"/> that the WinForms <c>MakeAllDataLength</c> emits behind an
+        /// embedded pointer field (<c>p32(p + EmbeddedPointerOffset)</c>).</summary>
+        public enum SubKind
+        {
+            /// <summary>A NUL-terminated C string. Emits via <see cref="Address.AddCString"/>
+            /// verbatim (length = <c>strlen + 1</c>, type <see cref="Address.DataTypeEnum.CSTRING"/>).
+            /// Matches <c>StatusParamForm</c> (<c>Address.AddCString(list, p + 12)</c>).</summary>
+            CString,
+            /// <summary>A string-derived BIN block whose length is the decoded string length with
+            /// <b>NO</b> trailing-NUL +1 (type <see cref="Address.DataTypeEnum.BIN"/>). Matches
+            /// <c>MapTerrainNameForm</c>/<c>OtherTextForm</c>
+            /// (<c>AddAddress(nameAddr, (uint)length, p + 0, name, BIN)</c>) — deliberately
+            /// distinct from <see cref="CString"/>, which adds the +1.</summary>
+            BinString,
+            /// <summary>A fixed-size BIN block (type <see cref="Address.DataTypeEnum.BIN"/>).
+            /// Matches <c>ClassForm</c> MoveCost (<c>AddPointer(p + 56, 66, "MoveCost ...", BIN)</c>).</summary>
+            BinFixed,
+        }
+
+        /// <summary>One per-entry embedded-data sub-walk applied to every entry of a
+        /// <see cref="StructDescriptor"/>'s table (after the main IFR <see cref="Address"/> is
+        /// emitted). Reproduces the embedded-pointer expansion in the WinForms
+        /// <c>MakeAllDataLength</c>: for entry base <c>p</c> the embedded pointer at
+        /// <c>p + EmbeddedPointerOffset</c> targets a CString / string-BIN / fixed-BIN block, and
+        /// <b>both</b> the pointer FIELD (tracked via the descriptor's <see cref="StructDescriptor.PointerIndexes"/>)
+        /// AND the pointed-at DATA (this sub-walk) must be relocated during a rebuild — missing
+        /// either dangles the pointer (silent corruption).</summary>
+        public sealed class SubWalk
+        {
+            /// <summary>Byte offset inside the entry block holding the embedded pointer
+            /// (the WinForms <c>p + N</c>).</summary>
+            public uint EmbeddedPointerOffset;
+            /// <summary>What kind of data the embedded pointer targets.</summary>
+            public SubKind Kind;
+            /// <summary>For <see cref="SubKind.BinFixed"/>: the fixed block length
+            /// (e.g. MoveCost = 66). Ignored for the string kinds.</summary>
+            public uint FixedLength;
+            /// <summary>Builds the <see cref="Address.Info"/> label for entry <c>i</c>
+            /// (was the WinForms per-entry name string). For <see cref="SubKind.CString"/> the
+            /// label is taken from the decoded string itself (matching
+            /// <see cref="Address.AddCString"/>), so this is only used by the BIN kinds.</summary>
+            public Func<ROM, uint, string> Name;
         }
 
         /// <summary>A declarative description of one simple "table walk + emit IFR Address" form.</summary>
@@ -105,6 +158,29 @@ namespace FEBuilderGBA
             public Address.DataTypeEnum DataType = Address.DataTypeEnum.InputFormRef;
             /// <summary>Optional safety cap on entry count (the WinForms <c>i &gt; 0xff</c> guards).</summary>
             public uint MaxCount = 0x10000;
+            /// <summary>Optional per-entry embedded-data sub-walks (null = none, back-compat with
+            /// the slice-2a/2b flat descriptors). Applied to every table entry AFTER the main IFR
+            /// <see cref="Address"/> is emitted.</summary>
+            public List<SubWalk> SubWalks;
+            /// <summary>Optional standalone fixed-size BIN pointers emitted ONCE per descriptor
+            /// (not per entry). Each is a <c>RomInfo</c> pointer whose target is a fixed-length
+            /// BIN block — reproduces <c>ClassForm</c>'s three全クラス共通 terrain pointers
+            /// (terrain_recovery / terrain_bad_status_recovery / terrain_show_infomation), each a
+            /// 66-byte BIN via <c>Address.AddPointer(..., 66, name, BIN)</c>.</summary>
+            public ExtraFixedPointer[] ExtraFixedPointers;
+        }
+
+        /// <summary>A standalone fixed-size BIN pointer emitted once per descriptor (see
+        /// <see cref="StructDescriptor.ExtraFixedPointers"/>).</summary>
+        public sealed class ExtraFixedPointer
+        {
+            /// <summary>Resolves the <c>RomInfo</c> pointer field (e.g.
+            /// <c>r =&gt; r.RomInfo.terrain_recovery_pointer</c>).</summary>
+            public Func<ROM, uint> PointerField;
+            /// <summary>Fixed BIN block length (e.g. 66).</summary>
+            public uint FixedLength;
+            /// <summary>The <see cref="Address.Info"/> label.</summary>
+            public string Name;
         }
 
         /// <summary>
@@ -236,6 +312,20 @@ namespace FEBuilderGBA
                 uint pointer = d.PointerField(rom);
                 EmitOne(rom, list, d, pointer);
             }
+
+            // Standalone fixed-size BIN pointers emitted ONCE per descriptor (not per entry).
+            // ClassForm: after the per-entry MoveCost loop, three 全クラス共通 terrain pointers
+            // (terrain_recovery / terrain_bad_status_recovery / terrain_show_infomation), each a
+            // 66-byte BIN via Address.AddPointer. Their pointer FIELDS live in RomInfo (relocated
+            // by the rebuild's RomInfo-pointer pass), and their DATA is tracked here.
+            if (d.ExtraFixedPointers != null)
+            {
+                foreach (ExtraFixedPointer ep in d.ExtraFixedPointers)
+                {
+                    Address.AddPointer(list, ep.PointerField(rom), ep.FixedLength, ep.Name,
+                        Address.DataTypeEnum.BIN);
+                }
+            }
         }
 
         static void EmitOne(ROM rom, List<Address> list, StructDescriptor d, uint pointer)
@@ -267,6 +357,80 @@ namespace FEBuilderGBA
             uint length = d.BlockSize * (dataCount + 1);
 
             list.Add(new Address(baseAddr, length, pointer, d.Name, d.DataType, d.BlockSize, d.PointerIndexes));
+
+            // Per-entry embedded-data sub-walks (slice 2c). The WinForms MakeAllDataLength runs
+            // these inside the `for (i < DataCount)` loop right after the main AddAddress, over the
+            // SAME dataCount getBlockDataCount just returned — so the un-tracked embedded blocks
+            // (MoveCost / CString / string-BIN) behind the entry pointer fields get relocated too.
+            if (d.SubWalks != null)
+            {
+                EmitSubWalks(rom, list, d, baseAddr, dataCount);
+            }
+        }
+
+        /// <summary>
+        /// For each table entry (<c>p = baseAddr + i*BlockSize</c>, <c>i &lt; dataCount</c>) and each
+        /// <see cref="SubWalk"/>, emit the embedded-data <see cref="Address"/> behind the entry's
+        /// embedded pointer (<c>p32(p + EmbeddedPointerOffset)</c>). Reproduces the WinForms
+        /// per-entry expansion VERBATIM per <see cref="SubKind"/> (CString = strlen+1 CSTRING;
+        /// BinString = strlen BIN, no +1; BinFixed = FixedLength BIN).
+        /// </summary>
+        static void EmitSubWalks(ROM rom, List<Address> list, StructDescriptor d, uint baseAddr, uint dataCount)
+        {
+            for (uint i = 0; i < dataCount; i++)
+            {
+                uint p = baseAddr + i * d.BlockSize;
+                foreach (SubWalk sw in d.SubWalks)
+                {
+                    uint pfield = p + sw.EmbeddedPointerOffset;
+                    switch (sw.Kind)
+                    {
+                        case SubKind.CString:
+                            // StatusParamForm: Address.AddCString(list, p + 12). AddCString does its
+                            // own pointer-safety + getString and adds (len + 1, CSTRING) verbatim.
+                            Address.AddCString(list, pfield);
+                            break;
+
+                        case SubKind.BinString:
+                        {
+                            // MapTerrainNameForm/OtherTextForm: read the embedded pointer, decode the
+                            // string, and add a BIN block of length == strlen (NO trailing-NUL +1).
+                            uint nameAddr = rom.p32(pfield);
+                            if (!U.isSafetyOffset(nameAddr))
+                            {
+                                continue;
+                            }
+                            int len;
+                            string name = rom.getString(nameAddr, out len);
+                            Address.AddAddress(list, nameAddr, (uint)len, pfield, name,
+                                Address.DataTypeEnum.BIN);
+                            break;
+                        }
+
+                        case SubKind.BinFixed:
+                        {
+                            // ClassForm MoveCost: if the embedded pointer is a safe offset, add a
+                            // fixed-length BIN block. WF uses Address.AddPointer (pointer-slot form),
+                            // which resolves p32 itself and length-checks — mirror it exactly.
+                            uint target = rom.p32(pfield);
+                            if (!U.isSafetyOffset(target))
+                            {
+                                continue;
+                            }
+                            Address.AddPointer(list, pfield, sw.FixedLength,
+                                sw.Name != null ? sw.Name(rom, i) : d.Name,
+                                Address.DataTypeEnum.BIN);
+                            break;
+                        }
+
+                        default:
+                            // A new/bad SubKind is a programming error — fail loudly rather than
+                            // silently skip an embedded block (which would dangle on rebuild).
+                            throw new ArgumentOutOfRangeException(nameof(sw),
+                                "Unhandled SubKind: " + sw.Kind);
+                    }
+                }
+            }
         }
 
         /// <summary>Turn a descriptor's <see cref="DataCountRule"/> into the
@@ -339,6 +503,21 @@ namespace FEBuilderGBA
                         if (rom.u16(addr) == 0xFFFF) return false;
                         if (i > 10 && rom.IsEmpty(addr, d.BlockSize * 10)) return false;
                         return true;
+                    };
+                case DataCountRule.PointerAt:
+                    return (i, addr) =>
+                    {
+                        if (i >= d.MaxCount) return false;
+                        // StatusParamForm.Init: U.isPointer(u32(addr+12)) — a NULL slot terminates
+                        // (isPointer, NOT isPointerOrNULL).
+                        return U.isPointer(rom.u32(addr + d.RuleOffset));
+                    };
+                case DataCountRule.PointerOrNullAt:
+                    return (i, addr) =>
+                    {
+                        if (i >= d.MaxCount) return false;
+                        // MapTerrainNameForm.Init: U.isPointerOrNULL(u32(addr+0)) — NULL is accepted.
+                        return U.isPointerOrNULL(rom.u32(addr + d.RuleOffset));
                     };
                 default:
                     // An unhandled DataCountRule is a PROGRAMMING ERROR (a bad/new descriptor),
@@ -496,8 +675,72 @@ namespace FEBuilderGBA
                 PointerIndexes = new uint[] { },
             });
 
-            // (ClassForm is NOT here — see the embedded-sub-pointer note above; it stays in
-            //  GetNotYetPortedForms until its MoveCost sub-walk is ported.)
+            // ClassForm.MakeAllDataLength (slice 2c) — main IFR (block class_datasize,
+            // U8NotZeroIndex0Always @+4, max 0x100, pointerIndexes {52,56,60,64,68,72,76}) PLUS a
+            // per-entry MoveCost sub-walk: six 66-byte BIN blocks behind the embedded pointers at
+            // offsets 56/60/64/68/72/76. Offset 52 is IN pointerIndexes (the battle-animation
+            // pointer FIELD is relocated) but is NOT a MoveCost sub-walk — its TARGET is tracked by
+            // the battle-anime form, so adding a 52 sub-walk here would double-track it. After the
+            // per-entry loop, three 全クラス共通 terrain pointers (66-byte BIN each) are emitted once.
+            l.Add(new StructDescriptor
+            {
+                Name = "Class",
+                PointerField = r => r.RomInfo.class_pointer,
+                FixedCountField = null,
+                BlockSize = rom.RomInfo.class_datasize,
+                Rule = DataCountRule.U8NotZeroIndex0Always,
+                RuleOffset = 4,
+                MaxCount = 0x100,
+                PointerIndexes = new uint[] { 52, 56, 60, 64, 68, 72, 76 },
+                SubWalks = new List<SubWalk>
+                {
+                    new SubWalk { EmbeddedPointerOffset = 56, Kind = SubKind.BinFixed, FixedLength = 66, Name = (r, i) => "MoveCost Clear" },
+                    new SubWalk { EmbeddedPointerOffset = 60, Kind = SubKind.BinFixed, FixedLength = 66, Name = (r, i) => "MoveCost Rain" },
+                    new SubWalk { EmbeddedPointerOffset = 64, Kind = SubKind.BinFixed, FixedLength = 66, Name = (r, i) => "MoveCost Snow" },
+                    new SubWalk { EmbeddedPointerOffset = 68, Kind = SubKind.BinFixed, FixedLength = 66, Name = (r, i) => "MoveCost avoid" },
+                    new SubWalk { EmbeddedPointerOffset = 72, Kind = SubKind.BinFixed, FixedLength = 66, Name = (r, i) => "MoveCost def" },
+                    new SubWalk { EmbeddedPointerOffset = 76, Kind = SubKind.BinFixed, FixedLength = 66, Name = (r, i) => "MoveCost ref" },
+                },
+                ExtraFixedPointers = new[]
+                {
+                    new ExtraFixedPointer { PointerField = r => r.RomInfo.terrain_recovery_pointer, FixedLength = 66, Name = "MoveCost ref" },
+                    new ExtraFixedPointer { PointerField = r => r.RomInfo.terrain_bad_status_recovery_pointer, FixedLength = 66, Name = "MoveCost recovery bad status" },
+                    new ExtraFixedPointer { PointerField = r => r.RomInfo.terrain_show_infomation_pointer, FixedLength = 66, Name = "MoveCost show infomation" },
+                },
+            });
+
+            // StatusParamForm.MakeAllDataLength (slice 2c) — FOUR pointers (param1/2/3w/3m), block
+            // 16, IsDataExists = U.isPointer(u32(addr+12)) (NULL terminates -> DataCountRule.PointerAt
+            // @ off 12), main pointerIndexes {0,4,12}. Per entry: a CString behind the embedded
+            // pointer at offset 12 (Address.AddCString(p+12)). The WF Info per pointer is
+            // "StatusParam0".."StatusParam3"; faithfully one descriptor per pointer with that label.
+            for (uint sp = 0; sp < 4; sp++)
+            {
+                uint spIndex = sp; // capture
+                l.Add(new StructDescriptor
+                {
+                    Name = "StatusParam" + spIndex,
+                    PointerField = r =>
+                    {
+                        switch (spIndex)
+                        {
+                            case 0: return r.RomInfo.status_param1_pointer;
+                            case 1: return r.RomInfo.status_param2_pointer;
+                            case 2: return r.RomInfo.status_param3w_pointer;
+                            default: return r.RomInfo.status_param3m_pointer;
+                        }
+                    },
+                    BlockSize = 16,
+                    Rule = DataCountRule.PointerAt,
+                    RuleOffset = 12,
+                    MaxCount = 0x10000,
+                    PointerIndexes = new uint[] { 0, 4, 12 },
+                    SubWalks = new List<SubWalk>
+                    {
+                        new SubWalk { EmbeddedPointerOffset = 12, Kind = SubKind.CString },
+                    },
+                });
+            }
 
             // SoundBossBGMForm.MakeAllDataLength — called UNCONDITIONALLY in WinForms
             // (before the version branches). Info label "BossBGM". The Init IsDataExists is a
@@ -604,7 +847,8 @@ namespace FEBuilderGBA
             }
 
             // ---- trailing is_multibyte branch: MapTerrainName(Eng) ----
-            // WinForms: is_multibyte -> MapTerrainNameForm (embedded CString sub-walk, deferred);
+            // WinForms: is_multibyte -> MapTerrainNameForm (per-entry embedded string-BIN sub-walk,
+            //                           slice 2c);
             //           else        -> MapTerrainNameEngForm (clean u16!=0 table).
             if (rom.RomInfo.is_multibyte == false)
             {
@@ -616,6 +860,27 @@ namespace FEBuilderGBA
                     Rule = DataCountRule.U16NotZero,
                     RuleOffset = 0,
                     PointerIndexes = new uint[] { },
+                });
+            }
+            else
+            {
+                // MapTerrainNameForm.MakeAllDataLength (slice 2c) — main IFR (block 4, base
+                // map_terrain_name_pointer, IsDataExists = U.isPointerOrNULL(u32(addr+0)) ->
+                // DataCountRule.PointerOrNullAt @ off 0, pointerIndexes {0}). Per entry: a string-BIN
+                // block (length == strlen, NO +1) behind the embedded pointer at offset 0. Info
+                // label "Terrain" (the per-entry sub-block names come from the decoded string).
+                l.Add(new StructDescriptor
+                {
+                    Name = "Terrain",
+                    PointerField = r => r.RomInfo.map_terrain_name_pointer,
+                    BlockSize = 4,
+                    Rule = DataCountRule.PointerOrNullAt,
+                    RuleOffset = 0,
+                    PointerIndexes = new uint[] { 0 },
+                    SubWalks = new List<SubWalk>
+                    {
+                        new SubWalk { EmbeddedPointerOffset = 0, Kind = SubKind.BinString },
+                    },
                 });
             }
 
@@ -650,7 +915,10 @@ namespace FEBuilderGBA
                 "EventCondForm", "EventScript(MakeEventASMMAPList)", "EventFunctionPointerForm",
                 "Command85PointerForm",
                 // text (Huffman)
-                "TextForm", "TextCharCodeForm", "TextDicForm", "OtherTextForm", "MapTerrainNameForm",
+                // (MapTerrainNameForm ported in slice 2c — per-entry string-BIN sub-walk; OtherTextForm
+                //  STAYS: it iterates a config file `other_text_*` (U.ConfigDataFilename), not a
+                //  RomInfo table, so it has a headless config-file dependency, not ROM-derived data.)
+                "TextForm", "TextCharCodeForm", "TextDicForm", "OtherTextForm",
                 // images (LZ77/TSA length calc)
                 "ImageBattleAnimeForm", "ImageBattleBGForm", "ImageBattleTerrainForm", "ImageBGForm",
                 "ImageMagicFEditorForm", "ImageMagicCSACreatorForm", "ImageBattleScreenForm",
@@ -663,11 +931,13 @@ namespace FEBuilderGBA
                 "SongTableForm", "SoundFootStepsForm", "SoundRoomForm", "SoundRoomCGForm",
                 "WorldMapBGMForm",
                 // embedded sub-pointer / event-scan / CString expansion
-                // (ItemForm = main IFR + per-entry StatBooster/ItemEffectiveness BIN sub-blocks;
-                //  ClassForm = main IFR + per-entry 7x MoveCost BIN sub-blocks @ off 56..76 —
-                //  the main walk is trivial but the sub-blocks need porting before either is safe.)
-                "ItemForm", "ClassForm",
-                "ItemShopForm", "StatusParamForm", "StatusRMenuForm", "MenuDefinitionForm",
+                // (ClassForm + StatusParamForm ported in slice 2c — per-entry MoveCost / CString
+                //  sub-walks. ItemForm STAYS: its StatBooster sub-block SIZE depends on un-ported
+                //  PatchUtil patch detection (SearchGrowsMod / ItemUsingExtendsPatch -> 12/16/20)
+                //  and the ItemEffectiveness rework variant on SearchClassType — a wrong size would
+                //  relocate the wrong bytes, so it must wait until those detectors reach Core.)
+                "ItemForm",
+                "ItemShopForm", "StatusRMenuForm", "MenuDefinitionForm",
                 "ItemWeaponEffectForm", "ItemUsagePointerForm", "UnitActionPointerForm",
                 "MapChangeForm", "MapExitPointForm", "MapPointerForm", "FontForm",
                 // AI scripts (disasm)

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -162,6 +162,11 @@ namespace FEBuilderGBA
             /// the slice-2a/2b flat descriptors). Applied to every table entry AFTER the main IFR
             /// <see cref="Address"/> is emitted.</summary>
             public List<SubWalk> SubWalks;
+            /// <summary>First entry index the <see cref="SubWalks"/> apply to (default 0 = every
+            /// entry). <c>ClassFE6Form.MakeAllDataLength</c> SKIPS class 0 (its MoveCost loop starts
+            /// at <c>cid=1, addr=BaseAddress+BlockSize</c>), so its descriptor sets this to 1. Does
+            /// NOT affect the main IFR <see cref="Address"/> length (still block×(count+1)).</summary>
+            public uint SubWalkStartIndex = 0;
             /// <summary>Optional standalone fixed-size BIN pointers emitted ONCE per descriptor
             /// (not per entry). Each is a <c>RomInfo</c> pointer whose target is a fixed-length
             /// BIN block — reproduces <c>ClassForm</c>'s three全クラス共通 terrain pointers
@@ -377,7 +382,18 @@ namespace FEBuilderGBA
         /// </summary>
         static void EmitSubWalks(ROM rom, List<Address> list, StructDescriptor d, uint baseAddr, uint dataCount)
         {
-            for (uint i = 0; i < dataCount; i++)
+            // The string-decoding sub-walks (CString/BinString) read ROM.getString, which needs a
+            // CoreState.SystemTextEncoder. In the real app + CLI InitFull it is always set, but the
+            // producer must NOT NewReferenceException if a caller scans without one. Skip those
+            // sub-walks gracefully (the BinFixed/fixed-length kinds do not decode strings, so they
+            // still run). NOTE: skipping leaves those embedded string blocks un-tracked — the
+            // ProducerResult is already IsComplete==false in any partial scan, so the wiring slice
+            // must not feed such a list to a real defragment.
+            bool hasEncoder = CoreState.SystemTextEncoder != null;
+
+            // Most forms walk every entry from 0. ClassFE6Form skips class 0 (its MoveCost loop
+            // starts at cid=1, addr=BaseAddress+BlockSize) — SubWalkStartIndex models that verbatim.
+            for (uint i = d.SubWalkStartIndex; i < dataCount; i++)
             {
                 uint p = baseAddr + i * d.BlockSize;
                 foreach (SubWalk sw in d.SubWalks)
@@ -388,6 +404,11 @@ namespace FEBuilderGBA
                         case SubKind.CString:
                             // StatusParamForm: Address.AddCString(list, p + 12). AddCString does its
                             // own pointer-safety + getString and adds (len + 1, CSTRING) verbatim.
+                            // Needs an encoder; skip (don't NRE) if none is loaded.
+                            if (!hasEncoder)
+                            {
+                                continue;
+                            }
                             Address.AddCString(list, pfield);
                             break;
 
@@ -395,6 +416,11 @@ namespace FEBuilderGBA
                         {
                             // MapTerrainNameForm/OtherTextForm: read the embedded pointer, decode the
                             // string, and add a BIN block of length == strlen (NO trailing-NUL +1).
+                            // Needs an encoder; skip (don't NRE) if none is loaded.
+                            if (!hasEncoder)
+                            {
+                                continue;
+                            }
                             uint nameAddr = rom.p32(pfield);
                             if (!U.isSafetyOffset(nameAddr))
                             {
@@ -675,39 +701,86 @@ namespace FEBuilderGBA
                 PointerIndexes = new uint[] { },
             });
 
-            // ClassForm.MakeAllDataLength (slice 2c) — main IFR (block class_datasize,
-            // U8NotZeroIndex0Always @+4, max 0x100, pointerIndexes {52,56,60,64,68,72,76}) PLUS a
-            // per-entry MoveCost sub-walk: six 66-byte BIN blocks behind the embedded pointers at
-            // offsets 56/60/64/68/72/76. Offset 52 is IN pointerIndexes (the battle-animation
-            // pointer FIELD is relocated) but is NOT a MoveCost sub-walk — its TARGET is tracked by
-            // the battle-anime form, so adding a 52 sub-walk here would double-track it. After the
-            // per-entry loop, three 全クラス共通 terrain pointers (66-byte BIN each) are emitted once.
-            l.Add(new StructDescriptor
+            // ClassForm vs ClassFE6Form (slice 2c) — VERSION-SPECIFIC. The WinForms
+            // MakeAllStructPointersList calls ClassForm.MakeAllDataLength ONLY inside the version==8
+            // and version==7 branches, and ClassFE6Form.MakeAllDataLength inside version==6. The two
+            // forms have DIFFERENT MoveCost offsets/lengths and pointerIndexes, so running the FE7/8
+            // descriptor on a FE6 ROM would relocate the wrong bytes (silent corruption). We mirror
+            // the WF version branch exactly.
+            if (rom.RomInfo.version != 6)
             {
-                Name = "Class",
-                PointerField = r => r.RomInfo.class_pointer,
-                FixedCountField = null,
-                BlockSize = rom.RomInfo.class_datasize,
-                Rule = DataCountRule.U8NotZeroIndex0Always,
-                RuleOffset = 4,
-                MaxCount = 0x100,
-                PointerIndexes = new uint[] { 52, 56, 60, 64, 68, 72, 76 },
-                SubWalks = new List<SubWalk>
+                // ClassForm (FE7/FE8).MakeAllDataLength — main IFR (block class_datasize,
+                // U8NotZeroIndex0Always @+4, max 0x100, pointerIndexes {52,56,60,64,68,72,76}) PLUS a
+                // per-entry MoveCost sub-walk: six 66-byte BIN blocks behind the embedded pointers at
+                // offsets 56/60/64/68/72/76. Offset 52 is IN pointerIndexes (the battle-animation
+                // pointer FIELD is relocated) but is NOT a MoveCost sub-walk — its TARGET is tracked
+                // by the battle-anime form, so adding a 52 sub-walk here would double-track it. After
+                // the per-entry loop, three 全クラス共通 terrain pointers (66-byte BIN each) are emitted once.
+                l.Add(new StructDescriptor
                 {
-                    new SubWalk { EmbeddedPointerOffset = 56, Kind = SubKind.BinFixed, FixedLength = 66, Name = (r, i) => "MoveCost Clear" },
-                    new SubWalk { EmbeddedPointerOffset = 60, Kind = SubKind.BinFixed, FixedLength = 66, Name = (r, i) => "MoveCost Rain" },
-                    new SubWalk { EmbeddedPointerOffset = 64, Kind = SubKind.BinFixed, FixedLength = 66, Name = (r, i) => "MoveCost Snow" },
-                    new SubWalk { EmbeddedPointerOffset = 68, Kind = SubKind.BinFixed, FixedLength = 66, Name = (r, i) => "MoveCost avoid" },
-                    new SubWalk { EmbeddedPointerOffset = 72, Kind = SubKind.BinFixed, FixedLength = 66, Name = (r, i) => "MoveCost def" },
-                    new SubWalk { EmbeddedPointerOffset = 76, Kind = SubKind.BinFixed, FixedLength = 66, Name = (r, i) => "MoveCost ref" },
-                },
-                ExtraFixedPointers = new[]
+                    Name = "Class",
+                    PointerField = r => r.RomInfo.class_pointer,
+                    FixedCountField = null,
+                    BlockSize = rom.RomInfo.class_datasize,
+                    Rule = DataCountRule.U8NotZeroIndex0Always,
+                    RuleOffset = 4,
+                    MaxCount = 0x100,
+                    PointerIndexes = new uint[] { 52, 56, 60, 64, 68, 72, 76 },
+                    SubWalks = new List<SubWalk>
+                    {
+                        new SubWalk { EmbeddedPointerOffset = 56, Kind = SubKind.BinFixed, FixedLength = 66, Name = (r, i) => "MoveCost Clear" },
+                        new SubWalk { EmbeddedPointerOffset = 60, Kind = SubKind.BinFixed, FixedLength = 66, Name = (r, i) => "MoveCost Rain" },
+                        new SubWalk { EmbeddedPointerOffset = 64, Kind = SubKind.BinFixed, FixedLength = 66, Name = (r, i) => "MoveCost Snow" },
+                        new SubWalk { EmbeddedPointerOffset = 68, Kind = SubKind.BinFixed, FixedLength = 66, Name = (r, i) => "MoveCost avoid" },
+                        new SubWalk { EmbeddedPointerOffset = 72, Kind = SubKind.BinFixed, FixedLength = 66, Name = (r, i) => "MoveCost def" },
+                        new SubWalk { EmbeddedPointerOffset = 76, Kind = SubKind.BinFixed, FixedLength = 66, Name = (r, i) => "MoveCost ref" },
+                    },
+                    ExtraFixedPointers = new[]
+                    {
+                        new ExtraFixedPointer { PointerField = r => r.RomInfo.terrain_recovery_pointer, FixedLength = 66, Name = "MoveCost ref" },
+                        new ExtraFixedPointer { PointerField = r => r.RomInfo.terrain_bad_status_recovery_pointer, FixedLength = 66, Name = "MoveCost recovery bad status" },
+                        new ExtraFixedPointer { PointerField = r => r.RomInfo.terrain_show_infomation_pointer, FixedLength = 66, Name = "MoveCost show infomation" },
+                    },
+                });
+            }
+            else
+            {
+                // ClassFE6Form.MakeAllDataLength — SAME main IFR Init (block class_datasize, base
+                // class_pointer, U8NotZeroIndex0Always @+4, max 0x100) but FE6-specific:
+                //   * pointerIndexes {48,52,56,60,64} (NOT {52..76}).
+                //   * MoveCost sub-walk: FOUR 52-byte BIN blocks @ off {48,52,56,60}, names
+                //     "MoveCost Clear/avoid/def/ref" (FE7/8 are SIX 66-byte @ {56..76}).
+                //   * The MoveCost loop SKIPS class 0 (cid starts at 1) -> SubWalkStartIndex = 1.
+                //   * Off 64 is in pointerIndexes (pointer FIELD relocated) but is NOT a MoveCost
+                //     sub-walk (target owned by another form) — same don't-double-track posture as
+                //     the FE7/8 off-52.
+                //   * Three 全クラス共通 terrain pointers are 52-byte BIN (NOT 66), same names.
+                l.Add(new StructDescriptor
                 {
-                    new ExtraFixedPointer { PointerField = r => r.RomInfo.terrain_recovery_pointer, FixedLength = 66, Name = "MoveCost ref" },
-                    new ExtraFixedPointer { PointerField = r => r.RomInfo.terrain_bad_status_recovery_pointer, FixedLength = 66, Name = "MoveCost recovery bad status" },
-                    new ExtraFixedPointer { PointerField = r => r.RomInfo.terrain_show_infomation_pointer, FixedLength = 66, Name = "MoveCost show infomation" },
-                },
-            });
+                    Name = "Class",
+                    PointerField = r => r.RomInfo.class_pointer,
+                    FixedCountField = null,
+                    BlockSize = rom.RomInfo.class_datasize,
+                    Rule = DataCountRule.U8NotZeroIndex0Always,
+                    RuleOffset = 4,
+                    MaxCount = 0x100,
+                    PointerIndexes = new uint[] { 48, 52, 56, 60, 64 },
+                    SubWalkStartIndex = 1, // FE6 skips class 0
+                    SubWalks = new List<SubWalk>
+                    {
+                        new SubWalk { EmbeddedPointerOffset = 48, Kind = SubKind.BinFixed, FixedLength = 52, Name = (r, i) => "MoveCost Clear" },
+                        new SubWalk { EmbeddedPointerOffset = 52, Kind = SubKind.BinFixed, FixedLength = 52, Name = (r, i) => "MoveCost avoid" },
+                        new SubWalk { EmbeddedPointerOffset = 56, Kind = SubKind.BinFixed, FixedLength = 52, Name = (r, i) => "MoveCost def" },
+                        new SubWalk { EmbeddedPointerOffset = 60, Kind = SubKind.BinFixed, FixedLength = 52, Name = (r, i) => "MoveCost ref" },
+                    },
+                    ExtraFixedPointers = new[]
+                    {
+                        new ExtraFixedPointer { PointerField = r => r.RomInfo.terrain_recovery_pointer, FixedLength = 52, Name = "MoveCost ref" },
+                        new ExtraFixedPointer { PointerField = r => r.RomInfo.terrain_bad_status_recovery_pointer, FixedLength = 52, Name = "MoveCost recovery bad status" },
+                        new ExtraFixedPointer { PointerField = r => r.RomInfo.terrain_show_infomation_pointer, FixedLength = 52, Name = "MoveCost show infomation" },
+                    },
+                });
+            }
 
             // StatusParamForm.MakeAllDataLength (slice 2c) — FOUR pointers (param1/2/3w/3m), block
             // 16, IsDataExists = U.isPointer(u32(addr+12)) (NULL terminates -> DataCountRule.PointerAt

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -937,6 +937,11 @@ namespace FEBuilderGBA
                 //  and the ItemEffectiveness rework variant on SearchClassType — a wrong size would
                 //  relocate the wrong bytes, so it must wait until those detectors reach Core.)
                 "ItemForm",
+                // The other slice-2c embedded forms also stay — their sub-block LENGTH needs a
+                // subsystem not yet in Core (a wrong length relocates the wrong bytes = corruption):
+                //   StatusRMenuForm     — recursive 28-byte MIX tree (visited-set) + ASM AddFunction (disasm).
+                //   MenuDefinitionForm  — recursive MenuCommandForm sub-table + 6 ASM ptrs (disasm).
+                //   ItemWeaponEffectForm— PROCS sub-block length = ProcsScriptForm.CalcLengthAndCheck (disasm).
                 "ItemShopForm", "StatusRMenuForm", "MenuDefinitionForm",
                 "ItemWeaponEffectForm", "ItemUsagePointerForm", "UnitActionPointerForm",
                 "MapChangeForm", "MapExitPointForm", "MapPointerForm", "FontForm",

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -384,7 +384,7 @@ namespace FEBuilderGBA
         {
             // The string-decoding sub-walks (CString/BinString) read ROM.getString, which needs a
             // CoreState.SystemTextEncoder. In the real app + CLI InitFull it is always set, but the
-            // producer must NOT NewReferenceException if a caller scans without one. Skip those
+            // producer must NOT NullReferenceException if a caller scans without one. Skip those
             // sub-walks gracefully (the BinFixed/fixed-length kinds do not decode strings, so they
             // still run). NOTE: skipping leaves those embedded string blocks un-tracked — the
             // ProducerResult is already IsComplete==false in any partial scan, so the wiring slice
@@ -452,8 +452,8 @@ namespace FEBuilderGBA
                         default:
                             // A new/bad SubKind is a programming error — fail loudly rather than
                             // silently skip an embedded block (which would dangle on rebuild).
-                            throw new ArgumentOutOfRangeException(nameof(sw),
-                                "Unhandled SubKind: " + sw.Kind);
+                            throw new ArgumentOutOfRangeException(nameof(sw) + "." + nameof(sw.Kind),
+                                sw.Kind, "Unhandled SubKind.");
                     }
                 }
             }


### PR DESCRIPTION
## Summary
**Slice 2c** of #1261 — extends the ROM-rebuild producer (`RebuildProducerCore`) with **per-entry sub-walk** support (embedded CStrings / sub-pointers / BIN blocks), and adds the first 3 forms that need it — including ClassForm, deferred since slice 2a.

## New capability
`StructDescriptor` gains `List<SubWalk> SubWalks` (applied per entry after the main IFR Address) + `ExtraFixedPointer[]` (once per descriptor). `SubKind`: `CString` (`AddCString`, strlen+1), `BinString` (`AddAddress`, strlen — **no +1**, a sharp WF distinction), `BinFixed` (`AddPointer`, fixed length). 2 new `DataCountRule`s: `PointerAt` (isPointer@off) + `PointerOrNullAt` (isPointerOrNULL@off). All reuse `Address.AddCString`/`AddPointer`/`AddAddress`.

## Forms added (3 — each cross-checked verbatim vs WF Init + MakeAllDataLength)
- **ClassForm** — main IFR (`class_pointer`/`class_datasize`, U8NotZeroIndex0Always@4, pointerIndexes `{52,56,60,64,68,72,76}`) + **6× BinFixed(66) MoveCost** sub-blocks @ {56…76} + 3 ExtraFixedPointers (terrain_recovery/bad_status_recovery/show_information). Off 52 is relocated as a pointer field but its target (battle-anime data) is owned by the battle-anime form, so it's intentionally NOT sub-walked (commented).
- **StatusParamForm** — 4 ptrs, `PointerAt@12`, pointerIndexes `{0,4,12}`, 1× CString@12.
- **MapTerrainNameForm** — `PointerOrNullAt@0`, pointerIndexes `{0}`, 1× BinString@0 (len, no +1); gated `is_multibyte` (the Eng/false path is the existing TerrainEng form).

## Forms deferred (5 — kept in NotYetPorted; sub-length not faithfully reproducible in Core ⇒ defer rather than corrupt)
- **ItemForm** (StatBooster size needs `PatchUtil.SearchGrowsMod`/`ItemUsingExtendsPatch` + SearchClassType — not in Core)
- **ItemWeaponEffectForm** (PROCS length = `ProcsScriptForm.CalcLengthAndCheck` disasm)
- **MenuDefinitionForm** (recursive `MenuCommandForm` + ASM ptrs)
- **StatusRMenuForm** (recursive 28-byte MIX tree + ASM)
- **OtherTextForm** (config-file `other_text_*`, not a RomInfo table)

## Coverage
15 → **18 forms / 151**; 133 remain. ClassForm removed from NotYetPorted; the 5 above stay.

## Tests
- RebuildProducerCoreTests: **29 passed**, 0 failed — per-SubKind emit + skip-unsafe, ExtraFixedPointers-once, PointerAt-vs-OrNull NULL semantics, and real-FE8U proving the Class MoveCost(66) sub-blocks + terrain pointers (Item confirmed deferred/absent). FEBuilderGBA.Tests (windows): **1865 passed**.
- (~78 pre-existing config-staging env failures — not this change; pass in isolation.)

Part of #1261. rom==CoreState.ROM guard + default-throws retained (now also in EmitSubWalks).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
