### PR TITLE
feat(core): ROM-rebuild producer — ASM-function + recursive forms (#1261 slice 2d)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -1979,6 +1979,37 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Empty(list);
         }
 
+        [Fact]
+        public void EmitSoundFootStepsAt_CountRunsPastEof_TruncatesWithoutThrowing()
+        {
+            // Regression (PR #1276 review): a corrupted/too-large count near EOF must TRUNCATE like
+            // WF InputFormRef.MakeList() (breaks on `addr + BlockSize > Data.Length`), NOT throw.
+            // AddFunction reads u32(entryAddr) whose check_safety throws past EOF.
+            uint size = 0x2000;
+            var rom = CreateTestRom((int)size);
+            uint switch2Addr = 0x0300;
+            uint pointer = 0x0400;
+            // Place the table so that exactly 2 of its 4-byte entries fit before EOF.
+            //   i=0 -> 0x1FF8 (+4=0x1FFC <= 0x2000) fits; i=1 -> 0x1FFC (+4=0x2000) fits;
+            //   i=2 -> 0x2000 (+4=0x2004 > 0x2000) -> WF MakeList breaks here.
+            uint table = size - 8; // 0x1FF8
+            PlantSwitch2(rom, switch2Addr, count: 5); // claims 6 entries; only 2 fit
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u32(table + 0, Ptr(0x1000) | 1);
+            rom.write_u32(table + 4, Ptr(0x1100) | 1);
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.EmitSoundFootStepsAt(rom, list, switch2Addr, pointer));
+            Assert.Null(ex); // must not throw on the past-EOF entries
+
+            // Only the 2 entries that fit before EOF are emitted as ASM (the other 4 are truncated).
+            var asms = list.Where(a => a.DataType == Address.DataTypeEnum.ASM).ToList();
+            Assert.Equal(2, asms.Count);
+            Assert.Contains(asms, a => a.Addr == 0x1000);
+            Assert.Contains(asms, a => a.Addr == 0x1100);
+        }
+
         // ---- EmitStatusRMenuRoots / EmitStatusRMenuSub (recursive MIX tree) -
 
         // Plant a 28-byte RMENU node at addr with child sub-pointers at 0/4/8/12 and ASM ptrs at

--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -1134,13 +1134,13 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("StatusParamForm", notYet);
             Assert.DoesNotContain("MapTerrainNameForm", notYet);
 
-            // The deferred siblings (un-ported patch detection / PROCS disasm / recursive ASM tree /
-            // config-file driven) MUST stay tracked — porting only some embedded forms while leaving
-            // these un-tracked would dangle their sub-block pointers during a rebuild.
+            // The deferred siblings (un-ported patch detection / PROCS disasm / config-file driven)
+            // MUST stay tracked — porting only some embedded forms while leaving these un-tracked
+            // would dangle their sub-block pointers during a rebuild. (MenuDefinitionForm and
+            // StatusRMenuForm were the recursive-tree siblings here; slice 2d ports them via dedicated
+            // recursive walkers, so they are now covered — see GetNotYetPortedForms_DropsSlice2dCoveredForms.)
             Assert.Contains("ItemForm", notYet);          // StatBooster size needs PatchUtil detection
             Assert.Contains("ItemWeaponEffectForm", notYet); // PROCS length needs ProcsScript disasm
-            Assert.Contains("MenuDefinitionForm", notYet);   // recursive MenuCommand + ASM ptrs
-            Assert.Contains("StatusRMenuForm", notYet);      // recursive 28-byte tree + ASM funcs
             Assert.Contains("OtherTextForm", notYet);        // config-file (U.ConfigDataFilename) driven
         }
 
@@ -1700,7 +1700,8 @@ namespace FEBuilderGBA.Core.Tests
                 "UnitFE6Form", "EventBattleTalkForm", "EventHaikuForm", "SupportUnitForm",
                 "WorldMapPathForm", "WorldMapEventPointerForm", "EDStaffRollForm", "OPPrologueForm",
                 "MapSettingForm", "OPClassFontForm", "OPClassDemoForm", "FE8SpellMenuExtendsForm",
-                "MonsterWMapProbabilityForm", "StatusOptionForm", "SoundRoomForm",
+                "MonsterWMapProbabilityForm", "SoundRoomForm",
+                // (StatusOptionForm + SoundFootStepsForm ported in slice 2d -> no longer kept here.)
                 "ItemForm", "MapTileAnimation1Form", "MapTerrainFloorLookupTableForm",
             })
             {
@@ -1804,6 +1805,493 @@ namespace FEBuilderGBA.Core.Tests
                 // FE8/FE7-only tables must NOT have been emitted on FE6.
                 Assert.DoesNotContain(list, a => a.Info == "CCBranch");
                 Assert.DoesNotContain(list, a => a.Info == "SupportTalk"); // FE8 variant
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
+        }
+
+        // ==================================================================
+        // slice 2d: ASM-function SubKind + recursive walkers
+        // ==================================================================
+
+        // ---- SubKind.AsmFunction (StatusOptionForm per-entry ASM) -----------
+
+        [Fact]
+        public void WalkAndAdd_AsmFunctionSubWalk_EmitsAsmAddressAtResolvedTarget()
+        {
+            // A descriptor with a SubKind.AsmFunction sub-walk must, for each table entry, emit an
+            // ASM Address whose Addr is ProgramAddrToPlain(u32(p + off)) — the thumb LSB cleared, the
+            // GBA prefix stripped by the Address ctor. This is the StatusOptionForm @40 shape.
+            var rom = CreateTestRom();
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            const uint block = 44;
+            rom.write_u32(pointer, Ptr(table));
+
+            // 2 entries: PointerAt @40 (U.isPointer terminates on NULL). Entry 0/1 have a valid ASM
+            // pointer @40 (thumb bit set); entry 2's @40 is NULL -> stop.
+            uint asm0 = 0x2000, asm1 = 0x2100;
+            rom.write_u32(table + block * 0 + 40, Ptr(asm0) | 1); // thumb bit
+            rom.write_u32(table + block * 1 + 40, Ptr(asm1) | 1);
+            rom.write_u32(table + block * 2 + 40, 0); // NULL -> PointerAt stops
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "GameOption",
+                PointerField = _ => pointer,
+                BlockSize = block,
+                Rule = RebuildProducerCore.DataCountRule.PointerAt,
+                RuleOffset = 40,
+                PointerIndexes = new uint[] { 40 },
+                SubWalks = new List<RebuildProducerCore.SubWalk>
+                {
+                    new RebuildProducerCore.SubWalk
+                    {
+                        EmbeddedPointerOffset = 40,
+                        Kind = RebuildProducerCore.SubKind.AsmFunction,
+                        Name = (r, i) => "GameOption",
+                    },
+                },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            // main IFR Address + 2 ASM functions.
+            Address main = list.Single(a => a.Info == "GameOption" && a.BlockSize == block);
+            Assert.Equal(table, main.Addr);
+            Assert.Equal(2u * block, main.Length - block); // length = block*(count+1), count=2
+
+            var asms = list.Where(a => a.DataType == Address.DataTypeEnum.ASM).ToList();
+            Assert.Equal(2, asms.Count);
+            Assert.Contains(asms, a => a.Addr == asm0); // thumb bit cleared by ProgramAddrToPlain
+            Assert.Contains(asms, a => a.Addr == asm1);
+            Assert.All(asms, a => Assert.Equal(0u, a.Length)); // ASM length 0 (disasm at rebuild)
+        }
+
+        [Fact]
+        public void BuildBatchDescriptors_FE8_EmitsStatusOptionWithAsmFunctionSubWalk()
+        {
+            // StatusOptionForm must be in the v8 batch with a PointerAt@40 main rule + an AsmFunction
+            // sub-walk @40 (the WF per-entry Address.AddFunction(p+40)).
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                var descs = RebuildProducerCore.BuildBatchDescriptors(fe8);
+
+                var go = descs.Single(d => d.Name == "GameOption" && d.BlockSize == 44);
+                Assert.Equal(RebuildProducerCore.DataCountRule.PointerAt, go.Rule);
+                Assert.Equal(40u, go.RuleOffset);
+                Assert.Equal(new uint[] { 40 }, go.PointerIndexes);
+                Assert.NotNull(go.SubWalks);
+                var sw = go.SubWalks.Single();
+                Assert.Equal(40u, sw.EmbeddedPointerOffset);
+                Assert.Equal(RebuildProducerCore.SubKind.AsmFunction, sw.Kind);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void BuildBatchDescriptors_FE6_OmitsStatusOption()
+        {
+            // StatusOptionForm is called ONLY in the WF v8 + v7 branches, never v6. The descriptor
+            // must be gated accordingly (its data pointer is junk on FE6).
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe6 = MakeVersionedRom("AFEJ01");
+                CoreState.ROM = fe6;
+                var descs = RebuildProducerCore.BuildBatchDescriptors(fe6);
+                Assert.DoesNotContain(descs, d => d.Name == "GameOption" && d.BlockSize == 44);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        // ---- EmitSoundFootStepsAt (Switch2-gated dedicated walker) ----------
+
+        // Plant a valid Switch2 byte pattern at switch2Addr so IsSwitch2Enable returns true:
+        //   u8(+1) (subOp) in [0x38,0x3D]; u8(+3) (cmpOp) in [0x28,0x2D]; u16(+2) != 0x9A00.
+        // The count is read from u8(switch2Addr+2). entries = count + 1.
+        static void PlantSwitch2(ROM rom, uint switch2Addr, byte count)
+        {
+            rom.write_u8(switch2Addr + 0, 0x00);
+            rom.write_u8(switch2Addr + 1, 0x3A); // subOp in range
+            rom.write_u8(switch2Addr + 2, count); // also the count byte
+            rom.write_u8(switch2Addr + 3, 0x2A); // cmpOp in range (u16(+2)=0x2A?? != 0x9A00)
+        }
+
+        [Fact]
+        public void EmitSoundFootStepsAt_Switch2Enabled_EmitsAsmFunctionPerEntry()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint switch2Addr = 0x0300;
+            uint pointer = 0x0400;       // RomInfo sound_foot_steps_pointer slot
+            uint table = 0x1000;         // base = p32(pointer)
+            PlantSwitch2(rom, switch2Addr, count: 2); // entries = 3
+            rom.write_u32(pointer, Ptr(table));
+
+            // 3 entries, block 4; each 4-byte slot is an ASM-routine pointer (thumb bit set).
+            uint a0 = 0x2000, a1 = 0x2100, a2 = 0x2200;
+            rom.write_u32(table + 0, Ptr(a0) | 1);
+            rom.write_u32(table + 4, Ptr(a1) | 1);
+            rom.write_u32(table + 8, Ptr(a2) | 1);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitSoundFootStepsAt(rom, list, switch2Addr, pointer);
+
+            // main IFR Address: type InputFormRef_ASM, length = 4*(3+1)=16, pointerIndexes {0}.
+            Address main = list.Single(a => a.DataType == Address.DataTypeEnum.InputFormRef_ASM);
+            Assert.Equal(table, main.Addr);
+            // BasePointer is NOT_FOUND: WF's IFR BasePointer is 0 (Init's 3rd arg), so AddAddress
+            // sets pointer = NOT_FOUND. The base is reached via the Switch2 LDR, not a RomInfo slot.
+            Assert.Equal(U.NOT_FOUND, main.Pointer);
+            Assert.Equal(4u, main.BlockSize);
+            Assert.Equal(16u, main.Length);
+            Assert.Equal(new uint[] { 0 }, main.PointerIndexes);
+
+            // one ASM function per entry at the entry block address itself.
+            var asms = list.Where(a => a.DataType == Address.DataTypeEnum.ASM).ToList();
+            Assert.Equal(3, asms.Count);
+            Assert.Contains(asms, a => a.Addr == a0);
+            Assert.Contains(asms, a => a.Addr == a1);
+            Assert.Contains(asms, a => a.Addr == a2);
+        }
+
+        [Fact]
+        public void EmitSoundFootStepsAt_Switch2Disabled_EmitsNothing()
+        {
+            // The WF ReInit returns NOT_FOUND (no emit) when IsSwitch2Enable is false. An all-zero
+            // switch2 region (subOp/cmpOp out of range) is disabled.
+            var rom = CreateTestRom();
+            uint switch2Addr = 0x0300;
+            uint pointer = 0x0400;
+            uint table = 0x1000;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u32(table + 0, Ptr(0x2000) | 1);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitSoundFootStepsAt(rom, list, switch2Addr, pointer);
+            Assert.Empty(list);
+        }
+
+        // ---- EmitStatusRMenuRoots / EmitStatusRMenuSub (recursive MIX tree) -
+
+        // Plant a 28-byte RMENU node at addr with child sub-pointers at 0/4/8/12 and ASM ptrs at
+        // 20/24 (thumb-bit set). u16(+18) is the node's preview id (drives the name).
+        static void PlantRMenuNode(ROM rom, uint addr, uint child0, uint child4, uint child8, uint child12,
+            uint asm20, uint asm24, ushort previewId)
+        {
+            rom.write_u32(addr + 0, child0 == 0 ? 0u : Ptr(child0));
+            rom.write_u32(addr + 4, child4 == 0 ? 0u : Ptr(child4));
+            rom.write_u32(addr + 8, child8 == 0 ? 0u : Ptr(child8));
+            rom.write_u32(addr + 12, child12 == 0 ? 0u : Ptr(child12));
+            rom.write_u16(addr + 18, previewId);
+            rom.write_u32(addr + 20, asm20 == 0 ? 0u : Ptr(asm20) | 1);
+            rom.write_u32(addr + 24, asm24 == 0 ? 0u : Ptr(asm24) | 1);
+        }
+
+        [Fact]
+        public void EmitStatusRMenuRoots_WalksTree_VisitsEachNodeOnce_EmitsAsmAt2024()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint rootPtr = 0x0300;   // RomInfo rmenu pointer slot
+            uint nodeA = 0x1000;     // root node = p32(rootPtr)
+            uint nodeB = 0x1100;     // child @ +0 of A
+            uint nodeC = 0x1200;     // child @ +4 of A
+            rom.write_u32(rootPtr, Ptr(nodeA));
+
+            // A -> B (off0), C (off4); B and C are leaves. ASM ptrs at 20/24 on each.
+            PlantRMenuNode(rom, nodeA, child0: nodeB, child4: nodeC, child8: 0, child12: 0,
+                asm20: 0x3000, asm24: 0x3100, previewId: 0x00AA);
+            PlantRMenuNode(rom, nodeB, 0, 0, 0, 0, asm20: 0x3200, asm24: 0x3300, previewId: 0x00BB);
+            PlantRMenuNode(rom, nodeC, 0, 0, 0, 0, asm20: 0x3400, asm24: 0x3500, previewId: 0x00CC);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitStatusRMenuRoots(rom, list, new uint[] { rootPtr });
+
+            // 3 MIX nodes, each emitted exactly once at its address, block 28, pointerIndexes {0,4,8,12,20,24}.
+            var mix = list.Where(a => a.DataType == Address.DataTypeEnum.MIX).ToList();
+            Assert.Equal(3, mix.Count);
+            foreach (uint n in new[] { nodeA, nodeB, nodeC })
+            {
+                Address node = mix.Single(a => a.Addr == n);
+                Assert.Equal(28u, node.Length);
+                Assert.Equal(28u, node.BlockSize);
+                Assert.Equal(new uint[] { 0, 4, 8, 12, 20, 24 }, node.PointerIndexes);
+            }
+
+            // 2 ASM functions per node = 6 total.
+            var asms = list.Where(a => a.DataType == Address.DataTypeEnum.ASM).ToList();
+            Assert.Equal(6, asms.Count);
+            foreach (uint t in new[] { 0x3000u, 0x3100u, 0x3200u, 0x3300u, 0x3400u, 0x3500u })
+            {
+                Assert.Contains(asms, a => a.Addr == t);
+            }
+        }
+
+        [Fact]
+        public void EmitStatusRMenuRoots_CycleGuard_StopsSelfReferentialNode()
+        {
+            // A node whose +0 sub-pointer points back to ITSELF must be emitted once and NOT recursed
+            // into again (the foundDic visited-set is the cycle-guard). Without it this infinite-loops.
+            var rom = CreateTestRom(0x8000);
+            uint rootPtr = 0x0300;
+            uint node = 0x1000;
+            rom.write_u32(rootPtr, Ptr(node));
+            // +0 points to itself; +4/+8/+12 NULL.
+            PlantRMenuNode(rom, node, child0: node, child4: 0, child8: 0, child12: 0,
+                asm20: 0x3000, asm24: 0x3100, previewId: 0x0001);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitStatusRMenuRoots(rom, list, new uint[] { rootPtr });
+
+            // exactly one MIX node (self-cycle did not re-emit / infinite-loop).
+            Assert.Single(list, a => a.DataType == Address.DataTypeEnum.MIX);
+            Assert.Equal(2, list.Count(a => a.DataType == Address.DataTypeEnum.ASM));
+        }
+
+        [Fact]
+        public void EmitStatusRMenuRoots_SharedVisitedSet_DedupsNodeReachableFromTwoRoots()
+        {
+            // A node reachable from two distinct roots must be emitted ONCE (the foundDic is shared
+            // across all roots — verbatim WF). Two roots both point at the same node.
+            var rom = CreateTestRom(0x8000);
+            uint root1 = 0x0300, root2 = 0x0304;
+            uint shared = 0x1000;
+            rom.write_u32(root1, Ptr(shared));
+            rom.write_u32(root2, Ptr(shared));
+            PlantRMenuNode(rom, shared, 0, 0, 0, 0, asm20: 0x3000, asm24: 0x3100, previewId: 0x0002);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitStatusRMenuRoots(rom, list, new uint[] { root1, root2 });
+
+            Assert.Single(list, a => a.DataType == Address.DataTypeEnum.MIX && a.Addr == shared);
+        }
+
+        // ---- EmitMenuDefinitionPointers + EmitMenuCommandSubTable -----------
+
+        [Fact]
+        public void EmitMenuDefinitionPointers_WalksTable_RecursesIntoMenuCommandSubTable()
+        {
+            var rom = CreateTestRom(0x1_0000);
+            uint defPtr = 0x0300;     // RomInfo menu_definiton pointer slot
+            uint defTable = 0x1000;   // base = p32(defPtr), block 36
+            rom.write_u32(defPtr, Ptr(defTable));
+
+            // 1 MenuDef entry: IsDataExists = isPointer(u32(addr+8)); entry 0 has a valid +8 menu ptr,
+            // entry 1's +8 is NULL -> table stops at count 1.
+            uint menuTable = 0x2000;  // the MenuCommand sub-table behind +8
+            rom.write_u32(defTable + 0 * 36 + 8, Ptr(menuTable));
+            rom.write_u32(defTable + 1 * 36 + 8, 0); // stop
+
+            // 6 ASM ptrs on the MenuDef entry @ {12,16,20,24,28,32}.
+            uint dbase = 0x4000;
+            for (uint k = 0; k < 6; k++)
+            {
+                rom.write_u32(defTable + 0 * 36 + 12 + k * 4, Ptr(dbase + k * 0x100) | 1);
+            }
+
+            // MenuCommand sub-table: block 36, IsDataExists = isPointer(u32(addr+0xc)); 1 entry.
+            rom.write_u32(menuTable + 0 * 36 + 0xc, Ptr(0x5000) | 1); // entry 0 valid
+            rom.write_u32(menuTable + 1 * 36 + 0xc, 0);               // stop
+            // entry 0: a CString @ +0 + 6 ASM @ {12,16,20,24,28,32}.
+            uint cstr = 0x6000;
+            rom.write_u32(menuTable + 0, Ptr(cstr));
+            rom.write_u8(cstr + 0, (byte)'A');
+            rom.write_u8(cstr + 1, (byte)'B');
+            rom.write_u8(cstr + 2, 0x00); // NUL
+            uint mbase = 0x7000;
+            for (uint k = 0; k < 6; k++)
+            {
+                rom.write_u32(menuTable + 0 * 36 + 12 + k * 4, Ptr(mbase + k * 0x100) | 1);
+            }
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitMenuDefinitionPointers(rom, list, new uint[] { defPtr });
+
+            // MenuDefinition main table: type InputFormRef_1, length = 36*1 (NO +1), pointerIndexes 7-wide.
+            Address defMain = list.Single(a => a.Info == "MenuDefinition");
+            Assert.Equal(defTable, defMain.Addr);
+            Assert.Equal(Address.DataTypeEnum.InputFormRef_1, defMain.DataType);
+            Assert.Equal(36u, defMain.Length); // block * DataCount (no +1)
+            Assert.Equal(new uint[] { 8, 12, 16, 20, 24, 28, 32 }, defMain.PointerIndexes);
+
+            // MenuCommand sub-table main: type InputFormRef_MIX, length = 36*(1+1) (the +1 form).
+            Address menuMain = list.Single(a => a.Info == "MENU");
+            Assert.Equal(menuTable, menuMain.Addr);
+            Assert.Equal(Address.DataTypeEnum.InputFormRef_MIX, menuMain.DataType);
+            Assert.Equal(72u, menuMain.Length);
+            Assert.Equal(new uint[] { 0, 12, 16, 20, 24, 28, 32 }, menuMain.PointerIndexes);
+
+            // 6 (MenuDef entry) + 6 (MenuCommand entry) = 12 ASM blocks.
+            var asms = list.Where(a => a.DataType == Address.DataTypeEnum.ASM).ToList();
+            Assert.Equal(12, asms.Count);
+            for (uint k = 0; k < 6; k++)
+            {
+                Assert.Contains(asms, a => a.Addr == dbase + k * 0x100);
+                Assert.Contains(asms, a => a.Addr == mbase + k * 0x100);
+            }
+
+            // the menu-name CString behind +0 (length strlen+1 = 3, type CSTRING).
+            Assert.Contains(list, a => a.Addr == cstr && a.DataType == Address.DataTypeEnum.CSTRING);
+        }
+
+        [Fact]
+        public void EmitMenuCommandSubTable_NoEncoder_SkipsCStringButStillEmitsAsm()
+        {
+            // The +0 CString needs a SystemTextEncoder; without one it is gracefully skipped (no NRE)
+            // while the 6 ASM blocks still emit (the wiring slice gates on IsComplete anyway).
+            var savedEnc = CoreState.SystemTextEncoder;
+            var rom = CreateTestRom(0x1_0000);
+            CoreState.SystemTextEncoder = null; // force the no-encoder path
+            try
+            {
+                uint pointer = 0x0300;
+                uint menuTable = 0x2000;
+                rom.write_u32(pointer, Ptr(menuTable));
+                rom.write_u32(menuTable + 0xc, Ptr(0x5000) | 1); // 1 entry
+                rom.write_u32(menuTable + 36 + 0xc, 0);          // stop
+                rom.write_u32(menuTable + 0, Ptr(0x6000));       // a +0 pointer (CString target)
+                uint mbase = 0x7000;
+                for (uint k = 0; k < 6; k++)
+                {
+                    rom.write_u32(menuTable + 12 + k * 4, Ptr(mbase + k * 0x100) | 1);
+                }
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitMenuCommandSubTable(rom, list, pointer, "MenuDef0_");
+
+                Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.CSTRING);
+                Assert.Equal(6, list.Count(a => a.DataType == Address.DataTypeEnum.ASM));
+                Assert.Contains(list, a => a.Info == "MENU"); // main table still emitted
+            }
+            finally { CoreState.SystemTextEncoder = savedEnc; }
+        }
+
+        // ---- GetNotYetPortedForms coverage update --------------------------
+
+        [Fact]
+        public void GetNotYetPortedForms_DropsSlice2dCoveredForms()
+        {
+            var ported = RebuildProducerCore.GetNotYetPortedForms();
+            Assert.DoesNotContain("StatusOptionForm", ported);
+            Assert.DoesNotContain("SoundFootStepsForm", ported);
+            Assert.DoesNotContain("StatusRMenuForm", ported);
+            Assert.DoesNotContain("MenuDefinitionForm", ported);
+            // sibling forms that genuinely still need un-ported subsystems STAY.
+            Assert.Contains("ItemForm", ported);
+            Assert.Contains("SoundRoomForm", ported);
+            Assert.Contains("ItemWeaponEffectForm", ported);
+        }
+
+        // ---- real ROM: the new tables are found --------------------------
+
+        [Fact]
+        public void MakeAllStructPointersList_FE8U_FindsStatusRMenuMenuDefAndStatusOption()
+        {
+            string romPath = FindTestRomNamed("FE8U.gba");
+            if (romPath == null) return; // env-only
+
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var rom = new ROM();
+                if (!rom.Load(romPath, out string _)) return;
+                CoreState.ROM = rom;
+                if (rom.RomInfo.version != 8) return;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+
+                List<Address> list = RebuildProducerCore.MakeAllStructPointersList(rom);
+                Assert.NotEmpty(list);
+
+                // StatusOptionForm (v8): main IFR at p32(status_game_option_pointer), block 44.
+                uint goBase = rom.p32(rom.RomInfo.status_game_option_pointer);
+                Assert.Contains(list, a => a.Addr == goBase && a.Info == "GameOption" && a.BlockSize == 44);
+
+                // StatusRMenu: at least one 28-byte MIX node from a non-0 root.
+                Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.MIX && a.BlockSize == 28
+                    && a.Info.StartsWith("RMENU"));
+
+                // MenuDefinition main table (InputFormRef_1) + a MenuCommand sub-table (InputFormRef_MIX).
+                Assert.Contains(list, a => a.Info == "MenuDefinition"
+                    && a.DataType == Address.DataTypeEnum.InputFormRef_1);
+                Assert.Contains(list, a => a.Info == "MENU"
+                    && a.DataType == Address.DataTypeEnum.InputFormRef_MIX);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
+        }
+
+        [Fact]
+        public void MakeAllStructPointersList_FE7_FindsStatusOptionAndMenuDef()
+        {
+            string romPath = FindTestRomNamed("FE7U.gba");
+            if (romPath == null) return; // env-only
+
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var rom = new ROM();
+                if (!rom.Load(romPath, out string _)) return;
+                CoreState.ROM = rom;
+                if (rom.RomInfo.version != 7) return;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+
+                List<Address> list = RebuildProducerCore.MakeAllStructPointersList(rom);
+                Assert.NotEmpty(list);
+
+                // StatusOptionForm is called in the WF v7 branch too.
+                uint goBase = rom.p32(rom.RomInfo.status_game_option_pointer);
+                Assert.Contains(list, a => a.Addr == goBase && a.Info == "GameOption" && a.BlockSize == 44);
+
+                // MenuDefinition is unconditional.
+                Assert.Contains(list, a => a.Info == "MenuDefinition"
+                    && a.DataType == Address.DataTypeEnum.InputFormRef_1);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
+        }
+
+        [Fact]
+        public void MakeAllStructPointersList_FE6_FindsMenuDefAndStatusRMenu_ButNoStatusOption()
+        {
+            string romPath = FindTestRomNamed("FE6.gba");
+            if (romPath == null) return; // env-only
+
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var rom = new ROM();
+                if (!rom.Load(romPath, out string _)) return;
+                CoreState.ROM = rom;
+                if (rom.RomInfo.version != 6) return;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+
+                List<Address> list = RebuildProducerCore.MakeAllStructPointersList(rom);
+                Assert.NotEmpty(list);
+
+                // MenuDefinition + StatusRMenu are unconditional (version-agnostic).
+                Assert.Contains(list, a => a.Info == "MenuDefinition"
+                    && a.DataType == Address.DataTypeEnum.InputFormRef_1);
+                Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.MIX && a.BlockSize == 28
+                    && a.Info.StartsWith("RMENU"));
+
+                // StatusOptionForm is NOT called on FE6 -> no "GameOption" block-44 IFR.
+                Assert.DoesNotContain(list, a => a.Info == "GameOption" && a.BlockSize == 44);
             }
             finally
             {

--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -2173,6 +2173,46 @@ namespace FEBuilderGBA.Core.Tests
             finally { CoreState.SystemTextEncoder = savedEnc; }
         }
 
+        [Fact]
+        public void EmitMenuCommandSubTable_OutOfRangeAsmPointer_SkipsBlock_NoThrow()
+        {
+            // RELEASE-SAFETY (the #1261 no-divergence audit, team-lead point 2): the 6 ASM blocks call
+            // Address.AddAddress(ProgramAddrToPlain(p32(off+p)), ...) with NO pre-check (verbatim WF).
+            // A junk/out-of-range p32 must SILENTLY SKIP that block via AddAddress's early-return — no
+            // throw (in Debug OR Release), matching WF. (The producer requires rom==CoreState.ROM, so
+            // AddAddress's isSafetyOffset early-return and the Address ctor's Debug.Assert test the same
+            // Data.Length; the ctor is never reached with an unsafe addr.)
+            var rom = CreateTestRom(0x1_0000);
+            uint pointer = 0x0300;
+            uint menuTable = 0x2000;
+            rom.write_u32(pointer, Ptr(menuTable));
+            rom.write_u32(menuTable + 0xc, Ptr(0x5000) | 1); // 1 entry
+            rom.write_u32(menuTable + 36 + 0xc, 0);          // stop
+            rom.write_u32(menuTable + 0, Ptr(0x6000));       // CString target (valid)
+            rom.write_u8(0x6000, 0x00);                      // empty string
+
+            // 3 valid ASM ptrs (@12/16/20), 3 out-of-range (@24/28/32): junk that ProgramAddrToPlain
+            // cannot rescue (0x00000000, 0xFFFFFFFF, and a > ROM-length offset).
+            rom.write_u32(menuTable + 12, Ptr(0x7000) | 1);
+            rom.write_u32(menuTable + 16, Ptr(0x7100) | 1);
+            rom.write_u32(menuTable + 20, Ptr(0x7200) | 1);
+            rom.write_u32(menuTable + 24, 0x00000000);       // NULL  -> skipped
+            rom.write_u32(menuTable + 28, 0xFFFFFFFF);       // wild  -> skipped
+            rom.write_u32(menuTable + 32, 0x00FF_FFFE);      // offset > 0x1_0000 ROM -> skipped
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.EmitMenuCommandSubTable(rom, list, pointer, "MenuDef0_"));
+            Assert.Null(ex); // no throw
+
+            // Exactly the 3 in-range ASM blocks emit; the 3 out-of-range ones are skipped.
+            var asms = list.Where(a => a.DataType == Address.DataTypeEnum.ASM).ToList();
+            Assert.Equal(3, asms.Count);
+            Assert.Contains(asms, a => a.Addr == 0x7000);
+            Assert.Contains(asms, a => a.Addr == 0x7100);
+            Assert.Contains(asms, a => a.Addr == 0x7200);
+        }
+
         // ---- GetNotYetPortedForms coverage update --------------------------
 
         [Fact]

--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -2104,6 +2104,42 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Single(list, a => a.DataType == Address.DataTypeEnum.MIX && a.Addr == shared);
         }
 
+        [Fact]
+        public void EmitStatusRMenuRoots_RootSlotNearEof_SkipsWithoutThrowing()
+        {
+            // Regression (PR #1276 review): a root whose 4-byte pointer slot straddles EOF must skip,
+            // not throw. ROM.p32 only short-circuits when root >= Data.Length; a root in [Len-3, Len-1]
+            // reaches u32 -> check_safety -> throw. The root+3 guard (matching MakeVarsIDArrayCore) skips.
+            uint size = 0x2000;
+            var rom = CreateTestRom((int)size);
+            uint rootNearEof = size - 2; // 0x1FFE: < Len but root+3 = 0x2001 > Len
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.EmitStatusRMenuRoots(rom, list, new uint[] { rootNearEof }));
+            Assert.Null(ex);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitStatusRMenuSub_NodeNearEof_SkipsWithoutThrowing()
+        {
+            // Regression (PR #1276 review): a node whose 28-byte record straddles EOF must skip, not
+            // throw. The node is readable at p+18 (old guard) but its u32 reads at p+20/p+24 (-> p+27)
+            // run past EOF; the widened p+27 guard skips the whole node gracefully.
+            uint size = 0x2000;
+            var rom = CreateTestRom((int)size);
+            uint rootPtr = 0x0300;
+            uint node = size - 20; // 0x1FEC: p+18=0x1FFE < Len (old guard passes) but p+27=0x2007 > Len
+            rom.write_u32(rootPtr, Ptr(node));
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.EmitStatusRMenuRoots(rom, list, new uint[] { rootPtr }));
+            Assert.Null(ex);
+            Assert.Empty(list); // node straddles EOF -> not emitted
+        }
+
         // ---- EmitMenuDefinitionPointers + EmitMenuCommandSubTable -----------
 
         [Fact]

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -855,12 +855,22 @@ namespace FEBuilderGBA
             }
         }
 
-        /// <summary>One MenuDefinition per-entry ASM block: WF
+        /// <summary>One MenuDefinition/MenuCommand per-entry ASM block: WF
         /// <c>Address.AddAddress(list, DisassemblerTrumb.ProgramAddrToPlain(p32(off+p)), 0, p+off,
-        /// name, ASM)</c>. Note <c>ProgramAddrToPlain</c> is applied to the RAW <c>p32</c> result with
-        /// no prior pointer-safety check (WF behaviour); the length is 0 (the disassembler determines
-        /// the routine extent at rebuild). <see cref="Address.AddAddress"/> applies its own offset
-        /// safety guard, returning early on an unsafe resolved address.</summary>
+        /// name, ASM)</c>. Note <c>ProgramAddrToPlain</c> (= <c>U.Padding2Before</c>, clears the thumb
+        /// LSB only) is applied to the RAW <c>p32</c> result with NO prior pointer-safety check — this
+        /// is the WF behaviour, deliberately preserved (distinct from <see cref="Address.AddFunction"/>,
+        /// which DOES pre-check). The length is 0 (the disassembler determines the routine extent at
+        /// rebuild).
+        /// <para>RELEASE-SAFETY (the #1261 no-divergence audit): an out-of-range
+        /// <c>ProgramAddrToPlain</c> result does NOT throw in Release (nor Debug). Core
+        /// <see cref="Address.AddAddress"/> early-returns (<c>if (!isSafetyOffset(addr)) return;</c>)
+        /// BEFORE the <see cref="Address"/> ctor — byte-identical to WF's AddAddress. Because the
+        /// producer requires <c>rom == CoreState.ROM</c>, that early-return and the ctor's
+        /// <c>Debug.Assert(isSafetyOffset)</c> test the SAME <c>CoreState.ROM.Data.Length</c>, so the
+        /// ctor is never reached with an unsafe addr in either build. A junk/NULL <c>p32</c> therefore
+        /// silently skips that ASM block in Core exactly as it does in WF — no throw, no divergence.</para>
+        /// </summary>
         static void EmitMenuDefAsm(ROM rom, List<Address> list, uint p, uint off, string name)
         {
             uint paddr = rom.p32(off + p);

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -142,6 +142,14 @@ namespace FEBuilderGBA
             /// <summary>A fixed-size BIN block (type <see cref="Address.DataTypeEnum.BIN"/>).
             /// Matches <c>ClassForm</c> MoveCost (<c>AddPointer(p + 56, 66, "MoveCost ...", BIN)</c>).</summary>
             BinFixed,
+            /// <summary>An embedded ASM-routine pointer. Emits via <see cref="Address.AddFunction"/>
+            /// verbatim (reads <c>u32(p + EmbeddedPointerOffset)</c>, <c>ProgramAddrToPlain</c>s it, and
+            /// adds a length-0 <see cref="Address.DataTypeEnum.ASM"/> block whose extent the
+            /// disassembler determines at rebuild time). Matches <c>StatusOptionForm</c>
+            /// (<c>Address.AddFunction(list, p + 40, name)</c>). The label is non-load-bearing for
+            /// relocation, so a static name is used (the WinForms <c>isPointerOnly</c> flag only swaps
+            /// the label between <c>""</c> and a Huffman-decoded string — neither affects addr/length).</summary>
+            AsmFunction,
         }
 
         /// <summary>One per-entry embedded-data sub-walk applied to every entry of a
@@ -345,6 +353,37 @@ namespace FEBuilderGBA
                 WalkAndAdd(rom, list, d);
             }
 
+            // ---- slice 2d: forms that are NOT a flat descriptor walk ----
+            // SoundFootStepsForm, StatusRMenuForm, MenuDefinitionForm are called UNCONDITIONALLY in
+            // the WinForms producer (version-agnostic section), but none fit the StructDescriptor
+            // pointer-slot model: SoundFootSteps is Switch2-gated with a count read from a RomInfo
+            // *address*; StatusRMenu is a recursive 28-byte MIX tree with a visited-set; MenuDefinition
+            // recurses into a MenuCommand sub-table. They get dedicated walkers, each with its own
+            // cancel-check (mirroring the WF DoEvents checkpoints) so a cancel returns the partial list.
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("SoundFootStepsPointer");
+            EmitSoundFootSteps(rom, list);
+
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("MenuDefinition");
+            EmitMenuDefinition(rom, list);
+
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("RMENU");
+            EmitStatusRMenuTree(rom, list);
+
             // Surface — never silently drop — the statics this slice does not yet cover.
             progress?.Report("MakeAllStructPointersList: ported batch=" + batch.Count
                 + " descriptors; not-yet-ported=" + notYet.Length + " forms (deferred to later slices)");
@@ -507,6 +546,15 @@ namespace FEBuilderGBA
                             break;
                         }
 
+                        case SubKind.AsmFunction:
+                            // StatusOptionForm: Address.AddFunction(list, p + 40, name). AddFunction
+                            // reads u32(pfield), isSafetyPointer-checks, ProgramAddrToPlain-resolves,
+                            // and adds a length-0 ASM block (extent determined by the disassembler at
+                            // rebuild). No encoder needed — the label is static (see SubKind.AsmFunction).
+                            Address.AddFunction(list, pfield,
+                                sw.Name != null ? sw.Name(rom, i) : d.Name);
+                            break;
+
                         default:
                             // A new/bad SubKind is a programming error — fail loudly rather than
                             // silently skip an embedded block (which would dangle on rebuild).
@@ -539,6 +587,349 @@ namespace FEBuilderGBA
                 if (i > 0xff) return false;
                 return rom.u8(addr + 4) != 0;
             });
+        }
+
+        /// <summary>
+        /// <c>SoundFootStepsForm.MakeAllDataLength</c> (slice 2d). This is NOT a flat RomInfo
+        /// pointer-slot table: the WinForms <c>ReInit</c> derives the base + count from a Switch2
+        /// jump-table, gated by a patch detector. Reproduced VERBATIM:
+        /// <list type="bullet">
+        ///   <item>base = <c>p32(sound_foot_steps_pointer)</c>; block = 4;</item>
+        ///   <item>count = <c>u8(sound_foot_steps_switch2_address + 2)</c>; entries = count + 1;</item>
+        ///   <item>GATE: only if <c>IsSwitch2Enable(sound_foot_steps_switch2_address)</c> AND the base
+        ///   is a safe offset (else WF's <c>ReInit</c> returns <c>NOT_FOUND</c> and emits nothing).</item>
+        /// </list>
+        /// Then: the main IFR <see cref="Address"/> (block × (entries + 1), type
+        /// <see cref="Address.DataTypeEnum.InputFormRef_ASM"/>, pointerIndexes {0}) + one
+        /// <see cref="Address.AddFunction"/> per entry at the entry block address itself (offset 0 —
+        /// each 4-byte slot is an ASM-routine pointer; the WF <c>AddFunctions(list, MakeList(), 0,
+        /// name)</c>). The per-entry label is the class name (Huffman) in WF; a static
+        /// "SoundFootStepsPointer" label is used here (non-load-bearing for relocation; headless-safe).
+        /// <para>The Switch2-enable byte pattern + the count read are pure ROM reads
+        /// (<see cref="ItemUsagePointerCore.IsSwitch2Enable"/>), so this is faithfully headless.</para>
+        /// </summary>
+        public static void EmitSoundFootSteps(ROM rom, List<Address> list)
+        {
+            EmitSoundFootStepsAt(rom, list,
+                rom.RomInfo.sound_foot_steps_switch2_address,
+                rom.RomInfo.sound_foot_steps_pointer);
+        }
+
+        /// <summary>SoundFootSteps walk from explicit switch2 + base-pointer addresses (test seam —
+        /// lets a synthetic ROM supply the addresses without populating RomInfo). See
+        /// <see cref="EmitSoundFootSteps"/> for the verbatim WF reproduction.</summary>
+        public static void EmitSoundFootStepsAt(ROM rom, List<Address> list, uint switch2Addr, uint rawPointer)
+        {
+            // WF ReInit: enable-gate FIRST, then base-safety. Either failing => NOT_FOUND => no emit.
+            if (!ItemUsagePointerCore.IsSwitch2Enable(rom, switch2Addr))
+            {
+                return;
+            }
+            uint pointer = U.toOffset(rawPointer);
+            if (!U.isSafetyOffset(pointer, rom))
+            {
+                return;
+            }
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                return; // WF ReInit: !isSafetyOffset(addr) -> NOT_FOUND.
+            }
+
+            const uint block = 4;
+            uint count = rom.u8(switch2Addr + 2);
+            uint dataCount = count + 1; // WF: ifr.ReInit(addr, count + 1) -> DataCount = count + 1.
+
+            // Main IFR Address: AddressWinForms.AddAddress(ifr, name, {0}, InputFormRef_ASM) ->
+            // length = BlockSize * (DataCount + 1). CRITICAL: the IFR's BasePointer is the Init's 3rd
+            // arg = 0 (SoundFootStepsForm.Init passes basepointer 0; ReInit(addr,count) sets only
+            // BaseAddress, NOT BasePointer). So in AddAddress, `pointer = BasePointer = 0` is not a
+            // safe offset -> it becomes U.NOT_FOUND. The base is reached via the Switch2 LDR, NOT a
+            // plain RomInfo pointer slot, so the table's pointer FIELD is intentionally untracked
+            // (NOT_FOUND); only the per-entry +0 ASM columns (pointerIndexes {0}) are relocated.
+            uint length = block * (dataCount + 1);
+            list.Add(new Address(baseAddr, length, U.NOT_FOUND, "SoundFootStepsPointer",
+                Address.DataTypeEnum.InputFormRef_ASM, block, new uint[] { 0 }));
+
+            // AddFunctions(list, ifr.MakeList(), 0, name): one ASM function per entry at the entry
+            // block address itself (offset 0). ifr.MakeList() yields one AddrResult per entry at
+            // baseAddr + i*block. AddFunction reads u32(entryAddr), isSafetyPointer-checks, and
+            // ProgramAddrToPlain-resolves — identical to the BinFixed/AsmFunction sub-walks.
+            for (uint i = 0; i < dataCount; i++)
+            {
+                uint entryAddr = baseAddr + i * block;
+                Address.AddFunction(list, entryAddr, "SoundFootStepsPointer");
+            }
+        }
+
+        /// <summary>
+        /// <c>StatusRMenuForm.MakeAllDataLength</c> (slice 2d) — a recursive 28-byte MIX-tree walk
+        /// with a shared visited-set. Reproduced VERBATIM from the WinForms
+        /// <c>MakeAllDataLength</c> + <c>MakeAllDataLengthSub</c>:
+        /// <list type="bullet">
+        ///   <item>6 roots (<c>status_rmenu_unit/game/3/4/5/6_pointer</c>); for each non-0 root
+        ///   <c>pointer</c>, walk from <c>p = p32(pointer)</c> with the root <c>pointer</c> as the
+        ///   incoming pointer slot.</item>
+        ///   <item>The <c>foundDic</c> visited-set is SHARED across all 6 roots (a node reachable from
+        ///   two roots is emitted once), and is the cycle-guard: a node already in the set is neither
+        ///   re-emitted nor re-descended (stops self-referential / cyclic trees).</item>
+        ///   <item>Per node <c>p</c>: if <c>!isSafetyOffset(p + 18)</c> bail; name = "RMENU " +
+        ///   <c>u16(p+18)</c>; emit a 28-byte MIX <see cref="Address"/> (pointer = NOT_FOUND, block 28,
+        ///   pointerIndexes {0,4,8,12,20,24}) only if not yet visited; mark visited; then recurse into
+        ///   the 4 sub-pointers at offsets 0/4/8/12 (each guarded by isSafetyOffset + not-visited);
+        ///   then 2 ASM functions at offsets 20/24.</item>
+        /// </list>
+        /// The visited-check is keyed on the NODE ADDRESS <c>p</c> (matching WF's
+        /// <c>foundDic.ContainsKey(p)</c>), so the emit-once + cycle-guard are byte-faithful.
+        /// </summary>
+        public static void EmitStatusRMenuTree(ROM rom, List<Address> list)
+        {
+            uint[] roots = new uint[]
+            {
+                rom.RomInfo.status_rmenu_unit_pointer,
+                rom.RomInfo.status_rmenu_game_pointer,
+                rom.RomInfo.status_rmenu3_pointer,
+                rom.RomInfo.status_rmenu4_pointer,
+                rom.RomInfo.status_rmenu5_pointer,
+                rom.RomInfo.status_rmenu6_pointer,
+            };
+            EmitStatusRMenuRoots(rom, list, roots);
+        }
+
+        /// <summary>Walk the StatusRMenu MIX tree from an explicit set of root RomInfo pointers
+        /// (test seam — lets a synthetic ROM supply roots without populating RomInfo). The
+        /// <c>foundDic</c> visited-set is SHARED across all roots (dedup + cycle-guard, verbatim WF);
+        /// each non-0 root <c>pointer</c> starts the walk at <c>p = p32(pointer)</c>.</summary>
+        public static void EmitStatusRMenuRoots(ROM rom, List<Address> list, uint[] roots)
+        {
+            uint[] pointerIndexes = new uint[] { 0, 4, 8, 12, 20, 24 };
+            var foundDic = new Dictionary<uint, bool>();
+            foreach (uint root in roots)
+            {
+                if (root == 0)
+                {
+                    continue;
+                }
+                uint p = rom.p32(root + 0);
+                EmitStatusRMenuSub(rom, list, p, root, foundDic, pointerIndexes);
+            }
+        }
+
+        /// <summary>One recursive node of <see cref="EmitStatusRMenuTree"/> — the Core port of
+        /// <c>StatusRMenuForm.MakeAllDataLengthSub</c>. <paramref name="pointer"/> is the incoming
+        /// pointer slot (the +0/4/8/12 field of the parent, or the root RomInfo pointer).</summary>
+        public static void EmitStatusRMenuSub(ROM rom, List<Address> list, uint p, uint pointer,
+            Dictionary<uint, bool> foundDic, uint[] pointerIndexes)
+        {
+            if (!U.isSafetyOffset(p + 18, rom))
+            {
+                return;
+            }
+
+            string name = "RMENU " + U.To0xHexString(rom.u16(p + 18));
+            if (!foundDic.ContainsKey(p))
+            {
+                // WF: new Address(p, 28, NOT_FOUND, name, MIX, 28, pointerIndexes). Note the incoming
+                // `pointer` slot is NOT recorded on the node itself (WF passes NOT_FOUND); the parent's
+                // pointer FIELD is relocated via the parent node's pointerIndexes {0,4,8,12}.
+                list.Add(new Address(p, 28, U.NOT_FOUND, name,
+                    Address.DataTypeEnum.MIX, 28, pointerIndexes));
+            }
+            foundDic[p] = true;
+
+            // Recurse the 4 child sub-pointers at offsets 0/4/8/12 (verbatim guard order).
+            uint pp;
+            pp = rom.p32(p + 0);
+            if (U.isSafetyOffset(pp, rom) && !foundDic.ContainsKey(pp))
+            {
+                EmitStatusRMenuSub(rom, list, pp, p + 0, foundDic, pointerIndexes);
+            }
+            pp = rom.p32(p + 4);
+            if (U.isSafetyOffset(pp, rom) && !foundDic.ContainsKey(pp))
+            {
+                EmitStatusRMenuSub(rom, list, pp, p + 4, foundDic, pointerIndexes);
+            }
+            pp = rom.p32(p + 8);
+            if (U.isSafetyOffset(pp, rom) && !foundDic.ContainsKey(pp))
+            {
+                EmitStatusRMenuSub(rom, list, pp, p + 8, foundDic, pointerIndexes);
+            }
+            pp = rom.p32(p + 12);
+            if (U.isSafetyOffset(pp, rom) && !foundDic.ContainsKey(pp))
+            {
+                EmitStatusRMenuSub(rom, list, pp, p + 12, foundDic, pointerIndexes);
+            }
+
+            // 2 ASM functions at offsets 20/24 (extent determined by the disassembler at rebuild).
+            Address.AddFunction(list, p + 20, name + "+P20");
+            Address.AddFunction(list, p + 24, name + "+P24");
+        }
+
+        /// <summary>
+        /// <c>MenuDefinitionForm.MakeAllDataLength</c> (slice 2d). Reproduced VERBATIM:
+        /// <list type="bullet">
+        ///   <item>6 pointers (<c>menu_definiton</c>, <c>menu_promotion</c>,
+        ///   <c>menu_promotion_branch</c>, <c>menu_definiton_split</c>,
+        ///   <c>menu_definiton_worldmap</c>, <c>menu_definiton_worldmap_shop</c>); skip 0.</item>
+        ///   <item>Per pointer: <c>ReInitPointer</c> the main IFR (block 36, base = <c>p32(pointer)</c>,
+        ///   IsDataExists = <c>isPointer(u32(addr+8))</c>), emit it with length <b>NOT +1</b>
+        ///   (<c>AddAddressButDoNotLengthPuls1</c> = block × DataCount), type
+        ///   <see cref="Address.DataTypeEnum.InputFormRef_1"/>, pointerIndexes {8,12,16,20,24,28,32}.</item>
+        ///   <item>Per entry (<c>p = base + i*36</c>): if <c>!isSafetyOffset(p32(8+p))</c> skip; else
+        ///   recurse into a MenuCommand sub-table at <c>8+p</c> (<see cref="EmitMenuCommandSubTable"/>),
+        ///   then 6 ASM <see cref="Address"/>es at offsets 12/16/20/24/28/32 (each
+        ///   <c>AddAddress(ProgramAddrToPlain(p32(off+p)), 0, p+off, name, ASM)</c>).</item>
+        /// </list>
+        /// </summary>
+        public static void EmitMenuDefinition(ROM rom, List<Address> list)
+        {
+            uint[] pointers = new uint[]
+            {
+                rom.RomInfo.menu_definiton_pointer,
+                rom.RomInfo.menu_promotion_pointer,
+                rom.RomInfo.menu_promotion_branch_pointer,
+                rom.RomInfo.menu_definiton_split_pointer,
+                rom.RomInfo.menu_definiton_worldmap_pointer,
+                rom.RomInfo.menu_definiton_worldmap_shop_pointer,
+            };
+            EmitMenuDefinitionPointers(rom, list, pointers);
+        }
+
+        /// <summary>MenuDefinition walk from an explicit set of RomInfo table pointers (test seam —
+        /// lets a synthetic ROM supply pointers without populating RomInfo). See
+        /// <see cref="EmitMenuDefinition"/> for the verbatim WF reproduction.</summary>
+        public static void EmitMenuDefinitionPointers(ROM rom, List<Address> list, uint[] pointers)
+        {
+            const uint block = 36;
+            foreach (uint rawPointer in pointers)
+            {
+                if (rawPointer == 0)
+                {
+                    continue;
+                }
+                uint pointer = U.toOffset(rawPointer);
+                if (!U.isSafetyOffset(pointer, rom))
+                {
+                    continue;
+                }
+                uint baseAddr = rom.p32(pointer);
+                if (!U.isSafetyOffset(baseAddr, rom))
+                {
+                    continue;
+                }
+
+                // Main IFR IsDataExists = U.isPointer(u32(addr+8)) -> a NULL slot terminates.
+                uint dataCount = rom.getBlockDataCount(baseAddr, block, (i, addr) =>
+                    U.isPointer(rom.u32(addr + 8)));
+
+                // AddAddressButDoNotLengthPuls1: length = block * DataCount (NO +1), type
+                // InputFormRef_1, pointerIndexes {8,12,16,20,24,28,32}.
+                uint length = block * dataCount;
+                list.Add(new Address(baseAddr, length, pointer, "MenuDefinition",
+                    Address.DataTypeEnum.InputFormRef_1, block,
+                    new uint[] { 8, 12, 16, 20, 24, 28, 32 }));
+
+                for (uint i = 0; i < dataCount; i++)
+                {
+                    uint p = baseAddr + i * block;
+                    string name = "MenuDef" + i + "_";
+
+                    uint paddr = rom.p32(8 + p);
+                    if (!U.isSafetyOffset(paddr, rom))
+                    {
+                        continue;
+                    }
+                    // Recurse into the MenuCommand sub-table behind the +8 pointer.
+                    EmitMenuCommandSubTable(rom, list, 8 + p, name);
+
+                    // 6 ASM blocks at offsets 12/16/20/24/28/32. WF does NOT pre-check isSafetyPointer
+                    // before ProgramAddrToPlain here (unlike AddFunction); Address.AddAddress applies
+                    // the safety guard AFTER (return-early on an unsafe resolved addr) — byte-faithful.
+                    EmitMenuDefAsm(rom, list, p, 12, name + "_HandleBPress");
+                    EmitMenuDefAsm(rom, list, p, 16, name + "_HandleRPress");
+                    EmitMenuDefAsm(rom, list, p, 20, name + "_Construction");
+                    EmitMenuDefAsm(rom, list, p, 24, name + "_Destruction");
+                    EmitMenuDefAsm(rom, list, p, 28, name + "_UnkP28");
+                    EmitMenuDefAsm(rom, list, p, 32, name + "_Unk32");
+                }
+            }
+        }
+
+        /// <summary>One MenuDefinition per-entry ASM block: WF
+        /// <c>Address.AddAddress(list, DisassemblerTrumb.ProgramAddrToPlain(p32(off+p)), 0, p+off,
+        /// name, ASM)</c>. Note <c>ProgramAddrToPlain</c> is applied to the RAW <c>p32</c> result with
+        /// no prior pointer-safety check (WF behaviour); the length is 0 (the disassembler determines
+        /// the routine extent at rebuild). <see cref="Address.AddAddress"/> applies its own offset
+        /// safety guard, returning early on an unsafe resolved address.</summary>
+        static void EmitMenuDefAsm(ROM rom, List<Address> list, uint p, uint off, string name)
+        {
+            uint paddr = rom.p32(off + p);
+            Address.AddAddress(list, DisassemblerTrumb.ProgramAddrToPlain(paddr), 0,
+                p + off, name, Address.DataTypeEnum.ASM);
+        }
+
+        /// <summary>
+        /// <c>MenuCommandForm.MakeAllDataLengthP</c> (slice 2d) — the MenuDefinition sub-table.
+        /// Reproduced VERBATIM:
+        /// <list type="bullet">
+        ///   <item>base = <c>p32(pointer)</c>; block = <c>MENU_SIZE</c> = 36; IsDataExists =
+        ///   <c>isPointer(u32(addr+0xc))</c>.</item>
+        ///   <item>Main IFR <see cref="Address"/>: length +1 (block × (DataCount+1)), type
+        ///   <see cref="Address.DataTypeEnum.InputFormRef_MIX"/>, pointerIndexes
+        ///   {0,12,16,20,24,28,32}, Info "MENU".</item>
+        ///   <item>Per entry: a CString behind the embedded pointer at offset 0
+        ///   (<c>AddCString(0+p)</c>; needs an encoder — gracefully skipped if none, like the other
+        ///   string sub-walks), then 6 ASM blocks at offsets 12/16/20/24/28/32 (same
+        ///   <c>AddAddress(ProgramAddrToPlain(...), 0, ...)</c> shape as MenuDefinition).</item>
+        /// </list>
+        /// This is the only nesting under MenuDefinition and it bottoms out cleanly (no further
+        /// un-ported recursion). The WF per-entry ASM labels are localized strings; static labels are
+        /// used here (non-load-bearing for relocation).
+        /// </summary>
+        public static void EmitMenuCommandSubTable(ROM rom, List<Address> list, uint pointer, string name)
+        {
+            pointer = U.toOffset(pointer);
+            if (!U.isSafetyOffset(pointer, rom))
+            {
+                return;
+            }
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                return;
+            }
+
+            const uint block = 36; // MenuCommandForm.MENU_SIZE
+            uint dataCount = rom.getBlockDataCount(baseAddr, block, (i, addr) =>
+                U.isPointer(rom.u32(addr + 0xc)));
+
+            // Main IFR: AddAddress(ifr, "MENU", {0,12,16,20,24,28,32}, InputFormRef_MIX) ->
+            // length = block * (DataCount + 1) (the +1 form).
+            uint length = block * (dataCount + 1);
+            list.Add(new Address(baseAddr, length, pointer, "MENU",
+                Address.DataTypeEnum.InputFormRef_MIX, block,
+                new uint[] { 0, 12, 16, 20, 24, 28, 32 }));
+
+            bool hasEncoder = CoreState.SystemTextEncoder != null;
+            for (uint i = 0; i < dataCount; i++)
+            {
+                uint p = baseAddr + i * block;
+
+                // AddCString(0+p): the menu-name C string behind the +0 pointer. Needs an encoder;
+                // skip (don't NRE) if none is loaded (the wiring slice gates on IsComplete anyway).
+                if (hasEncoder)
+                {
+                    Address.AddCString(list, 0 + p);
+                }
+
+                // 6 ASM blocks at offsets 12/16/20/24/28/32 (verbatim WF, raw ProgramAddrToPlain).
+                EmitMenuDefAsm(rom, list, p, 12, name + "_p12");
+                EmitMenuDefAsm(rom, list, p, 16, name + "_p16");
+                EmitMenuDefAsm(rom, list, p, 20, name + "_p20");
+                EmitMenuDefAsm(rom, list, p, 24, name + "_p24");
+                EmitMenuDefAsm(rom, list, p, 28, name + "_p28");
+                EmitMenuDefAsm(rom, list, p, 32, name + "_p32");
+            }
         }
 
         /// <summary>Turn a descriptor's <see cref="DataCountRule"/> into the
@@ -1008,6 +1399,29 @@ namespace FEBuilderGBA
             // pointer is 0 elsewhere). Emit it for both; EmitOne skips a 0/unsafe pointer.
             if (rom.RomInfo.version == 8 || rom.RomInfo.version == 7)
             {
+                // StatusOptionForm.MakeAllDataLength (slice 2d) — called in the WF version==8 AND
+                // version==7 branches (right before StatusOptionOrderForm), so it is gated to v7||8
+                // here in the same order. Main IFR: base status_game_option_pointer, block 44,
+                // IsDataExists = U.isPointer(u32(addr+40)) -> DataCountRule.PointerAt @ off 40,
+                // pointerIndexes {40}, DataType InputFormRef (default). Per entry: an ASM-function
+                // sub-walk behind the embedded pointer at offset 40 (Address.AddFunction(p+40, name)).
+                // The WF per-entry label is "GameOption " + GetNameFast(p) when !isPointerOnly (Huffman
+                // text) or "" when isPointerOnly — neither affects addr/length, so a static
+                // "GameOption" label is used (headless-safe, relocation-identical).
+                l.Add(new StructDescriptor
+                {
+                    Name = "GameOption",
+                    PointerField = r => r.RomInfo.status_game_option_pointer,
+                    BlockSize = 44,
+                    Rule = DataCountRule.PointerAt,
+                    RuleOffset = 40,
+                    PointerIndexes = new uint[] { 40 },
+                    SubWalks = new List<SubWalk>
+                    {
+                        new SubWalk { EmbeddedPointerOffset = 40, Kind = SubKind.AsmFunction, Name = (r, i) => "GameOption" },
+                    },
+                });
+
                 // StatusOptionOrderForm.MakeAllDataLength — Info "GameOptionOrder", block 1,
                 // IsDataExists = i < u8(status_game_option_order_count_address).
                 l.Add(new StructDescriptor
@@ -1618,9 +2032,11 @@ namespace FEBuilderGBA
                 "MapMiniMapTerrainImageForm", "WorldMapImageForm",
                 // songs / sound (recycle, embedded inst)
                 // (SoundRoomCGForm [FE7, clean u32-FFFFFFFF table], SoundRoomFE6Form [FE6, clean],
-                //  and WorldMapBGMForm [FE8, clean] ported in this sweep. SoundRoomForm STAYS — its FE7
+                //  and WorldMapBGMForm [FE8, clean] ported in this sweep. SoundFootStepsForm ported in
+                //  slice 2d — Switch2-gated dedicated walker (base/count from sound_foot_steps_switch2_address,
+                //  IsSwitch2Enable gate) + per-entry ASM AddFunction. SoundRoomForm STAYS — its FE7
                 //  path adds a per-entry getString C-string sub-walk + InputFormRef_MIX type.)
-                "SongTableForm", "SoundFootStepsForm", "SoundRoomForm",
+                "SongTableForm", "SoundRoomForm",
                 // embedded sub-pointer / event-scan / CString expansion
                 // (ClassForm + StatusParamForm ported in slice 2c — per-entry MoveCost / CString
                 //  sub-walks. ItemForm STAYS: its StatBooster sub-block SIZE depends on un-ported
@@ -1630,10 +2046,12 @@ namespace FEBuilderGBA
                 "ItemForm",
                 // The other slice-2c embedded forms also stay — their sub-block LENGTH needs a
                 // subsystem not yet in Core (a wrong length relocates the wrong bytes = corruption):
-                //   StatusRMenuForm     — recursive 28-byte MIX tree (visited-set) + ASM AddFunction (disasm).
-                //   MenuDefinitionForm  — recursive MenuCommandForm sub-table + 6 ASM ptrs (disasm).
                 //   ItemWeaponEffectForm— PROCS sub-block length = ProcsScriptForm.CalcLengthAndCheck (disasm).
-                "ItemShopForm", "StatusRMenuForm", "MenuDefinitionForm",
+                // (StatusRMenuForm [recursive 28-byte MIX tree, shared visited-set + 2 ASM AddFunction]
+                //  and MenuDefinitionForm [recursive MenuCommandForm sub-table — InputFormRef_MIX + per-entry
+                //  CString + 6 ASM ptrs — + its own 6 ASM ptrs] ported in slice 2d via dedicated recursive
+                //  walkers; MenuCommandForm.MakeAllDataLengthP is reproduced by EmitMenuCommandSubTable.)
+                "ItemShopForm",
                 "ItemWeaponEffectForm", "ItemUsagePointerForm", "UnitActionPointerForm",
                 "MapChangeForm", "MapExitPointForm", "MapPointerForm", "FontForm",
                 // AI scripts (disasm)
@@ -1646,8 +2064,10 @@ namespace FEBuilderGBA
                 // status / menu definition / misc tables needing extra logic
                 // (StatusUnitsMenuForm + LinkArenaDenyUnitForm ported in slice 2b.
                 //  StatusOptionOrderForm [v7+v8, count-address fixed table] ported in this sweep.
-                //  StatusOptionForm STAYS — its per-entry AddFunction is an ASM disasm sub-walk.)
-                "StatusOptionForm",
+                //  StatusOptionForm ported in slice 2d [v7+v8, PointerAt@40 main IFR + per-entry
+                //  SubKind.AsmFunction @40]. NOTE: "MapMiniMapTerrainForm" does NOT exist as a distinct
+                //  ASM form — the only file is MapMiniMapTerrainImageForm (an LZ77 image form, already
+                //  listed above), so there is nothing extra to port for it.)
                 "MantAnimationForm", "MapTileAnimation1Form",
                 "MapTileAnimation2Form", "MapTerrainFloorLookupTableForm",
                 "MapTerrainBGLookupTableForm",

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -658,6 +658,15 @@ namespace FEBuilderGBA
             for (uint i = 0; i < dataCount; i++)
             {
                 uint entryAddr = baseAddr + i * block;
+                // Faithful to WF InputFormRef.MakeList(): it stops yielding the moment a block would
+                // run past EOF (`addr + BlockSize > Data.Length` -> break), so AddFunctions never
+                // reads past EOF. AddFunction reads u32(entryAddr) whose check_safety THROWS past EOF,
+                // so without this same bound a corrupted/too-large count near EOF would throw instead
+                // of truncating gracefully. block is the BlockSize and equals the u32 read width.
+                if (entryAddr + block > (uint)rom.Data.Length)
+                {
+                    break;
+                }
                 Address.AddFunction(list, entryAddr, "SoundFootStepsPointer");
             }
         }

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -682,7 +682,10 @@ namespace FEBuilderGBA
         ///   <item>The <c>foundDic</c> visited-set is SHARED across all 6 roots (a node reachable from
         ///   two roots is emitted once), and is the cycle-guard: a node already in the set is neither
         ///   re-emitted nor re-descended (stops self-referential / cyclic trees).</item>
-        ///   <item>Per node <c>p</c>: if <c>!isSafetyOffset(p + 18)</c> bail; name = "RMENU " +
+        ///   <item>Per node <c>p</c>: if <c>!isSafetyOffset(p + 27)</c> bail (full 28-byte node — WF's
+        ///   verbatim guard is <c>p + 18</c>, widened to <c>p + 27</c> to cover the u16(p+18) + the two
+        ///   AddFunction u32 reads at p+20/p+24 so malformed near-EOF nodes skip instead of throwing);
+        ///   name = "RMENU " +
         ///   <c>u16(p+18)</c>; emit a 28-byte MIX <see cref="Address"/> (pointer = NOT_FOUND, block 28,
         ///   pointerIndexes {0,4,8,12,20,24}) only if not yet visited; mark visited; then recurse into
         ///   the 4 sub-pointers at offsets 0/4/8/12 (each guarded by isSafetyOffset + not-visited);
@@ -715,7 +718,12 @@ namespace FEBuilderGBA
             var foundDic = new Dictionary<uint, bool>();
             foreach (uint root in roots)
             {
-                if (root == 0)
+                // Guard the FULL 4-byte pointer slot before p32: U.isSafetyOffset(root) alone leaves
+                // root+1..root+3 unchecked, and ROM.p32 only short-circuits when root >= Data.Length
+                // (a root in [Len-3, Len-1] still reaches u32 -> check_safety throws). Matches the
+                // Core-wide convention (MakeVarsIDArrayCore.CollectStatusRMenu). On valid ROMs roots
+                // are never near EOF, so this only hardens synthetic/corrupted ROMs (WF throws here too).
+                if (root == 0 || !U.isSafetyOffset(root + 3, rom))
                 {
                     continue;
                 }
@@ -730,7 +738,13 @@ namespace FEBuilderGBA
         public static void EmitStatusRMenuSub(ROM rom, List<Address> list, uint p, uint pointer,
             Dictionary<uint, bool> foundDic, uint[] pointerIndexes)
         {
-            if (!U.isSafetyOffset(p + 18, rom))
+            // Guard the FULL 28-byte node, not just p+18: this method reads u16(p+18) (-> p+19) and two
+            // AddFunction u32 reads at p+20/p+24 (the latter -> p+27, the deepest read). isSafetyOffset(
+            // p+18) alone leaves p+19..p+27 unchecked, so a node near EOF would throw in u16 / AddFunction
+            // -> u32 -> check_safety. On valid ROMs every 28-byte node is fully in-bounds, so this changes
+            // nothing there (WF's verbatim p+18 guard crashes on such malformed near-EOF nodes); it only
+            // hardens synthetic/corrupted ROMs to skip gracefully. p+27 covers the recursion p32 reads too.
+            if (!U.isSafetyOffset(p + 27, rom))
             {
                 return;
             }


### PR DESCRIPTION
## Summary
**Slice 2d** of #1261 — the **ASM-function + recursive sub-table** producer forms (deferred in the sweep because they need disassembler-emit / recursive walks). 4 forms, 57→ more descriptors.

## New machinery
- **`SubKind.AsmFunction`** — at an embedded pointer offset, emits `Address.AddFunction(p+off, name)` (byte-identical to WF; the disassembler determines extent at rebuild time, so no length to get wrong).
- **Dedicated recursive walkers** (a flat SubKind can't express a tree): `EmitStatusRMenuTree`/`Roots`/`Sub`, `EmitMenuDefinition`/`EmitMenuCommandSubTable`, with WF-verbatim cycle-guards.

## Forms added (4 — main + ASM/recursive + version cross-check, all verbatim vs WF)
1. **StatusOptionForm** (gated **v7||8**, absent on FE6) — IFR block 44, `PointerAt@40`, pointerIndexes {40}, per-entry `AsmFunction@40`.
2. **SoundFootStepsForm** — dedicated walker, base=`p32(sound_foot_steps_pointer)`, count=`u8(switch2_address+2)+1`, **gated by `IsSwitch2Enable`** (verified pure-ROM in Core via `ItemUsagePointerCore`). Faithfulness subtlety: WF's IFR base-pointer arg is 0 → the main Address pointer is `NOT_FOUND` (base reached via the Switch2 LDR, not a RomInfo slot), then one ASM `AddFunction` per 4-byte entry.
3. **StatusRMenuForm** — 6 roots, 28-byte MIX tree, **SHARED `foundDic`** across all roots (dedup + cycle-guard, verbatim); per node: emit-once `Address(p,28,…,MIX)`, recurse @0/4/8/12, 2 ASM funcs @20/24.
4. **MenuDefinitionForm** — 6 pointers, IFR block 36 (length **no +1**, `InputFormRef_1`), recurses into **MenuCommand** sub-table (block 36, CString@0 [encoder-graceful-skip] + 6 ASM @12..32); bottoms out cleanly.

Version audit: StatusOption is the only version-split (v7||8); the other 3 are version-agnostic in WF (verified).

## Coverage
**73/151 forms covered, 78 remain** (removed StatusOption/SoundFootSteps/StatusRMenu/MenuDefinition from NotYetPorted; deduped, reason-tagged).

## Tests
- RebuildProducer: **65 passed**, 0 failed — +15 (synthetic AsmFunction; Switch2 on/off; recursive RMENU **once / self-cycle / shared-set diamond**; MenuDef→MenuCommand nesting + no-encoder skip; per-version StatusOption gating; **real FE8U/FE7U/FE6** executed). FEBuilderGBA.Tests (windows): **1865 passed**.
- (Pre-existing config-staging env failures — not this change; fail in isolation too.)

Part of #1261.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
