### PR TITLE
feat(core): ROM-rebuild producer — flat LZ77-image + palette forms (#1261 slice 2e)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -2406,5 +2406,653 @@ namespace FEBuilderGBA.Core.Tests
                 CoreState.SystemTextEncoder = savedEnc;
             }
         }
+
+        // ====================================================================
+        // slice 2e: flat LZ77-image + palette forms
+        // ====================================================================
+
+        // ---- LZ77 helpers --------------------------------------------------
+
+        /// <summary>Hand-author a VALID all-literal LZ77 stream of <paramref name="uncompSize"/>
+        /// uncompressed bytes and write it at <paramref name="offset"/>. Returns the byte length the
+        /// stream occupies (== LZ77.getCompressedSize on it): header(4) + ceil(N/8) flag bytes + N
+        /// literal bytes. Each flag byte is 0x00 (all 8 following bytes are literal/uncompressed).</summary>
+        static uint WriteLz77AllLiteral(ROM rom, uint offset, int uncompSize)
+        {
+            var bytes = new List<byte>();
+            bytes.Add(0x10);
+            bytes.Add((byte)(uncompSize & 0xFF));
+            bytes.Add((byte)((uncompSize >> 8) & 0xFF));
+            bytes.Add((byte)((uncompSize >> 16) & 0xFF));
+            int written = 0;
+            while (written < uncompSize)
+            {
+                bytes.Add(0x00); // flag: next 8 bytes all literal
+                for (int b = 0; b < 8 && written < uncompSize; b++, written++)
+                {
+                    bytes.Add((byte)(0x40 + (written & 0x3F))); // arbitrary non-zero literal
+                }
+            }
+            for (int i = 0; i < bytes.Count; i++)
+            {
+                rom.write_u8(offset + (uint)i, bytes[i]);
+            }
+            uint clen = LZ77.getCompressedSize(rom.Data, offset);
+            Assert.True(clen > 0, "hand-authored LZ77 stream must be valid (getCompressedSize > 0)");
+            Assert.Equal((uint)bytes.Count, clen);
+            return clen;
+        }
+
+        // ---- SubKind.Lz77Pointer + FixedPointer machinery (via WalkAndAdd) --
+
+        [Fact]
+        public void SubWalk_Lz77Pointer_EmitsLZ77IMG_WithGetCompressedSizeLength()
+        {
+            var rom = CreateTestRom(0x8000);
+            // One-entry table: base at 0x1000, block 4, FixedCount 1. Entry +0 -> embedded LZ77 image.
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            uint imageData = 0x2000;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u32(table + 0, Ptr(imageData)); // embedded image pointer at offset 0
+            uint expectLen = WriteLz77AllLiteral(rom, imageData, 100);
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "Img",
+                PointerField = _ => pointer,
+                BlockSize = 4,
+                Rule = RebuildProducerCore.DataCountRule.FixedCount,
+                RuleFixedCount = 1,
+                PointerIndexes = new uint[] { 0 },
+                SubWalks = new List<RebuildProducerCore.SubWalk>
+                {
+                    new RebuildProducerCore.SubWalk
+                    {
+                        EmbeddedPointerOffset = 0,
+                        Kind = RebuildProducerCore.SubKind.Lz77Pointer,
+                        DataType = Address.DataTypeEnum.LZ77IMG,
+                        Name = (r, i) => "img" + i,
+                    },
+                },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            // main IFR Address (block*(1+1)=8) + one LZ77IMG sub-Address.
+            Address img = Assert.Single(list, a => a.DataType == Address.DataTypeEnum.LZ77IMG);
+            Assert.Equal(imageData, img.Addr);
+            Assert.Equal(expectLen, img.Length);
+            Assert.Equal(LZ77.getCompressedSize(rom.Data, imageData), img.Length);
+            Assert.Equal(table + 0, img.Pointer); // the embedded pointer field
+        }
+
+        [Fact]
+        public void SubWalk_Lz77Pointer_MalformedNearEofStream_EmitsLengthZero_NoThrow()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            uint imageData = 0x2000;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u32(table + 0, Ptr(imageData));
+            // Plant a malformed stream: 0x10 header claiming a huge size with no body -> getCompressedSize 0.
+            rom.write_u8(imageData + 0, 0x10);
+            rom.write_u8(imageData + 1, 0xFF);
+            rom.write_u8(imageData + 2, 0xFF);
+            rom.write_u8(imageData + 3, 0xFF);
+            Assert.Equal(0u, LZ77.getCompressedSize(rom.Data, imageData)); // confirm malformed
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "Img",
+                PointerField = _ => pointer,
+                BlockSize = 4,
+                Rule = RebuildProducerCore.DataCountRule.FixedCount,
+                RuleFixedCount = 1,
+                PointerIndexes = new uint[] { 0 },
+                SubWalks = new List<RebuildProducerCore.SubWalk>
+                {
+                    new RebuildProducerCore.SubWalk
+                    {
+                        EmbeddedPointerOffset = 0,
+                        Kind = RebuildProducerCore.SubKind.Lz77Pointer,
+                        DataType = Address.DataTypeEnum.LZ77IMG,
+                        Name = (r, i) => "img",
+                    },
+                },
+            };
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.WalkAndAdd(rom, list, d));
+            Assert.Null(ex); // never throws (matches WF AddLZ77Pointer)
+            Address img = Assert.Single(list, a => a.DataType == Address.DataTypeEnum.LZ77IMG);
+            Assert.Equal(0u, img.Length); // malformed -> length 0 (WF parity)
+        }
+
+        [Fact]
+        public void SubWalk_FixedPointer_EmitsFixedLengthBlock_WithConfiguredDataType()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            uint palData = 0x2000;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u32(table + 16, Ptr(palData)); // embedded palette pointer at offset 16
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "Pal",
+                PointerField = _ => pointer,
+                BlockSize = 24,
+                Rule = RebuildProducerCore.DataCountRule.FixedCount,
+                RuleFixedCount = 1,
+                PointerIndexes = new uint[] { 16 },
+                SubWalks = new List<RebuildProducerCore.SubWalk>
+                {
+                    new RebuildProducerCore.SubWalk
+                    {
+                        EmbeddedPointerOffset = 16,
+                        Kind = RebuildProducerCore.SubKind.FixedPointer,
+                        FixedLength = 0x20,
+                        DataType = Address.DataTypeEnum.PAL,
+                        Name = (r, i) => "pal",
+                    },
+                },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            Address pal = Assert.Single(list, a => a.DataType == Address.DataTypeEnum.PAL);
+            Assert.Equal(palData, pal.Addr);
+            Assert.Equal(0x20u, pal.Length);
+            Assert.Equal(table + 16, pal.Pointer);
+        }
+
+        [Fact]
+        public void EmitMainIfr_False_SuppressesMainAddress_ButStillWalksSubWalks()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            uint imgData = 0x2000;
+            uint palData = 0x3000;
+            rom.write_u32(pointer, Ptr(table));
+            // 2 entries, block 4, FixedCount 2; each entry: image @0, palette @16... but block is 4,
+            // so use a 20-byte block to fit both columns and a fixed count of 1 for simplicity.
+            rom.write_u32(table + 0, Ptr(imgData));
+            rom.write_u32(table + 16, Ptr(palData));
+            WriteLz77AllLiteral(rom, imgData, 40);
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "GEP",
+                PointerField = _ => pointer,
+                BlockSize = 4,
+                Rule = RebuildProducerCore.DataCountRule.FixedCount,
+                RuleFixedCount = 1,
+                PointerIndexes = new uint[] { },
+                EmitMainIfr = false,
+                SubWalks = new List<RebuildProducerCore.SubWalk>
+                {
+                    new RebuildProducerCore.SubWalk { EmbeddedPointerOffset = 0, Kind = RebuildProducerCore.SubKind.FixedPointer, FixedLength = 0x200, DataType = Address.DataTypeEnum.IMG, Name = (r, i) => "img" },
+                    new RebuildProducerCore.SubWalk { EmbeddedPointerOffset = 16, Kind = RebuildProducerCore.SubKind.FixedPointer, FixedLength = 0x20, DataType = Address.DataTypeEnum.PAL, Name = (r, i) => "pal" },
+                },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            // No main IFR Address (InputFormRef type) — only the per-entry IMG + PAL columns.
+            Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.InputFormRef);
+            Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.IMG && a.Addr == imgData);
+            Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.PAL && a.Addr == palData);
+        }
+
+        [Fact]
+        public void EmitMainIfr_DefaultsTrue_EmitsMainAddress()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            rom.write_u32(pointer, Ptr(table));
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "T",
+                PointerField = _ => pointer,
+                BlockSize = 4,
+                Rule = RebuildProducerCore.DataCountRule.FixedCount,
+                RuleFixedCount = 3,
+                PointerIndexes = new uint[] { },
+            };
+            Assert.True(d.EmitMainIfr); // default
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+            Assert.Single(list, a => a.DataType == Address.DataTypeEnum.InputFormRef);
+        }
+
+        // ---- new DataCountRules --------------------------------------------
+
+        [Fact]
+        public void Rule_TwoU32PointerAt04_ContinuesWhileBothPointers()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            uint block = 12;
+            rom.write_u32(pointer, Ptr(table));
+            // entry 0: +0 and +4 both pointers -> valid
+            rom.write_u32(table + 0 * block + 0, Ptr(0x4000));
+            rom.write_u32(table + 0 * block + 4, Ptr(0x4100));
+            // entry 1: +0 pointer, +4 NOT a pointer -> terminator
+            rom.write_u32(table + 1 * block + 0, Ptr(0x4200));
+            rom.write_u32(table + 1 * block + 4, 0x12345678); // not a ROM pointer
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "BBG",
+                PointerField = _ => pointer,
+                BlockSize = block,
+                Rule = RebuildProducerCore.DataCountRule.TwoU32PointerAt04,
+                PointerIndexes = new uint[] { },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+            // dataCount = 1, length = 12 * (1 + 1) = 24
+            Assert.Equal(24u, list[0].Length);
+        }
+
+        [Fact]
+        public void Rule_WaitIconRule_Entry0AlwaysAndTerminatesOnBothZero()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            uint block = 8;
+            rom.write_u32(pointer, Ptr(table));
+            // entry 0: both zero — but entry 0 always counts.
+            rom.write_u32(table + 0 * block + 0, 0);
+            rom.write_u32(table + 0 * block + 4, 0);
+            // entry 1: +4 pointer -> valid
+            rom.write_u32(table + 1 * block + 4, Ptr(0x4000));
+            // entry 2: +4 == 0, +0 != 0 -> valid (continue)
+            rom.write_u32(table + 2 * block + 0, 0x55);
+            rom.write_u32(table + 2 * block + 4, 0);
+            // entry 3: +4 == 0, +0 == 0 -> terminator
+            rom.write_u32(table + 3 * block + 0, 0);
+            rom.write_u32(table + 3 * block + 4, 0);
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "Wait",
+                PointerField = _ => pointer,
+                BlockSize = block,
+                Rule = RebuildProducerCore.DataCountRule.WaitIconRule,
+                PointerIndexes = new uint[] { },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+            // dataCount = 3 (entries 0,1,2), length = 8 * (3 + 1) = 32
+            Assert.Equal(32u, list[0].Length);
+        }
+
+        [Fact]
+        public void Rule_WaitIconRule_TerminatesOnNonZeroNonPointerAt4()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            uint block = 8;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u32(table + 0 * block + 4, Ptr(0x4000)); // entry 0 always
+            // entry 1: +4 = non-zero non-pointer -> terminator
+            rom.write_u32(table + 1 * block + 4, 0x000000AB);
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "Wait",
+                PointerField = _ => pointer,
+                BlockSize = block,
+                Rule = RebuildProducerCore.DataCountRule.WaitIconRule,
+                PointerIndexes = new uint[] { },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+            // dataCount = 1, length = 8 * 2 = 16
+            Assert.Equal(16u, list[0].Length);
+        }
+
+        [Fact]
+        public void Rule_UnitPaletteRule_TerminatesWhenPaletteAndNameBothNull()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            uint block = 16;
+            rom.write_u32(pointer, Ptr(table));
+            // entry 0: +12 pointer -> valid
+            rom.write_u32(table + 0 * block + 12, Ptr(0x4000));
+            // entry 1: +12 == 0 but +0 (name) != 0 -> valid (continue)
+            rom.write_u32(table + 1 * block + 0, 0x77);
+            rom.write_u32(table + 1 * block + 12, 0);
+            // entry 2: +12 == 0 and +0 == 0 -> terminator
+            rom.write_u32(table + 2 * block + 0, 0);
+            rom.write_u32(table + 2 * block + 12, 0);
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "UPal",
+                PointerField = _ => pointer,
+                BlockSize = block,
+                Rule = RebuildProducerCore.DataCountRule.UnitPaletteRule,
+                PointerIndexes = new uint[] { },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+            // dataCount = 2, length = 16 * 3 = 48
+            Assert.Equal(48u, list[0].Length);
+        }
+
+        // ---- BuildBatchDescriptors: version-agnostic image descriptors ------
+
+        [Fact]
+        public void BuildBatchDescriptors_HasVersionAgnosticImageForms()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                var descs = RebuildProducerCore.BuildBatchDescriptors(fe8);
+
+                var bbg = descs.Single(d => d.Name == "BattleBG");
+                Assert.Equal(12u, bbg.BlockSize);
+                Assert.Equal(RebuildProducerCore.DataCountRule.TwoU32PointerAt04, bbg.Rule);
+                Assert.Equal(new uint[] { 0, 4, 8 }, bbg.PointerIndexes);
+                Assert.Equal(3, bbg.SubWalks.Count);
+                Assert.All(bbg.SubWalks, s => Assert.Equal(RebuildProducerCore.SubKind.Lz77Pointer, s.Kind));
+                Assert.Equal(Address.DataTypeEnum.LZ77PAL, bbg.SubWalks[2].DataType);
+
+                var bt = descs.Single(d => d.Name == "BattleTerrain");
+                Assert.Equal(24u, bt.BlockSize);
+                Assert.Equal(RebuildProducerCore.DataCountRule.PointerAt, bt.Rule);
+                Assert.Equal(12u, bt.RuleOffset);
+                Assert.Equal(new uint[] { 12, 16 }, bt.PointerIndexes);
+                Assert.Equal(RebuildProducerCore.SubKind.Lz77Pointer, bt.SubWalks[0].Kind);
+                Assert.Equal(RebuildProducerCore.SubKind.FixedPointer, bt.SubWalks[1].Kind);
+                Assert.Equal(0x20u, bt.SubWalks[1].FixedLength);
+
+                var wait = descs.Single(d => d.Name == "WaitUnitIcon");
+                Assert.Equal(8u, wait.BlockSize);
+                Assert.Equal(RebuildProducerCore.DataCountRule.WaitIconRule, wait.Rule);
+                Assert.Equal(new uint[] { 4 }, wait.PointerIndexes);
+
+                var upal = descs.Single(d => d.Name == "UnitPalette" && d.BlockSize == 16);
+                Assert.Equal(RebuildProducerCore.DataCountRule.UnitPaletteRule, upal.Rule);
+                Assert.Equal(Address.DataTypeEnum.LZ77PAL, upal.SubWalks[0].DataType);
+
+                var gep = descs.Single(d => d.Name == "GenericEnemyPortait");
+                Assert.False(gep.EmitMainIfr);
+                Assert.NotNull(gep.ExtraFixedPointers);
+                Assert.Single(gep.ExtraFixedPointers);
+                Assert.Equal(Address.DataTypeEnum.POINTER, gep.ExtraFixedPointers[0].DataType);
+                Assert.Equal(8u * 2 * 4, gep.ExtraFixedPointers[0].FixedLength);
+                Assert.Equal(2, gep.SubWalks.Count);
+                Assert.Equal((4u * 8 / 2) * (4 * 8), gep.SubWalks[0].FixedLength);
+                Assert.Equal(Address.DataTypeEnum.IMG, gep.SubWalks[0].DataType);
+                Assert.Equal(Address.DataTypeEnum.PAL, gep.SubWalks[1].DataType);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+            }
+        }
+
+        [Fact]
+        public void BuildBatchDescriptors_FE8_HasChapterTitle_Block12_ThreeLz77Columns()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                var descs = RebuildProducerCore.BuildBatchDescriptors(fe8);
+                var ct = descs.Single(d => d.Name == "ChapterTitleImage");
+                Assert.Equal(12u, ct.BlockSize);
+                Assert.Equal(RebuildProducerCore.DataCountRule.PointerAt, ct.Rule);
+                Assert.Equal(new uint[] { 0, 4, 8 }, ct.PointerIndexes);
+                Assert.Equal(3, ct.SubWalks.Count);
+                Assert.All(ct.SubWalks, s => Assert.Equal(RebuildProducerCore.SubKind.Lz77Pointer, s.Kind));
+                Assert.All(ct.SubWalks, s => Assert.Equal(Address.DataTypeEnum.LZ77IMG, s.DataType));
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void BuildBatchDescriptors_FE6_HasChapterTitleFE7_Block4_OneLz77Column()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe6 = MakeVersionedRom("AFEJ01");
+                CoreState.ROM = fe6;
+                var descs = RebuildProducerCore.BuildBatchDescriptors(fe6);
+                var ct = descs.Single(d => d.Name == "ChapterTitleImage");
+                Assert.Equal(4u, ct.BlockSize); // FE7-form layout: block 4, ONE column
+                Assert.Equal(RebuildProducerCore.DataCountRule.PointerAt, ct.Rule);
+                Assert.Equal(new uint[] { 0 }, ct.PointerIndexes);
+                Assert.Single(ct.SubWalks);
+                Assert.Equal(Address.DataTypeEnum.LZ77IMG, ct.SubWalks[0].DataType);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        // ---- dedicated flat emitters: faithfulness on a version ROM ---------
+
+        [Fact]
+        public void EmitImageBattleScreen_EmitsConstTSA_Pal_AndLz77Images()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+
+                // Plant a data pointer at each RomInfo slot and the data at the target.
+                uint tsa1Slot = U.toOffset(fe8.RomInfo.battle_screen_TSA1_pointer);
+                uint palSlot = U.toOffset(fe8.RomInfo.battle_screen_palette_pointer);
+                uint img1Slot = U.toOffset(fe8.RomInfo.battle_screen_image1_pointer);
+                uint tsaData = 0x1000000;
+                uint palData = 0x1001000;
+                uint imgData = 0x1002000;
+                fe8.write_u32(tsa1Slot, Ptr(tsaData));
+                fe8.write_u32(palSlot, Ptr(palData));
+                fe8.write_u32(img1Slot, Ptr(imgData));
+                uint expectImgLen = WriteLz77AllLiteral(fe8, imgData, 60);
+
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitImageBattleScreen(fe8, list));
+                Assert.Null(ex);
+
+                // TSA1: constant length (5+1)*((15+1)-1)*2 = 180, type TSA, pointer = the slot.
+                Address tsa1 = Assert.Single(list, a => a.Info == "battle_screen_TSA1");
+                Assert.Equal(tsaData, tsa1.Addr);
+                Assert.Equal((uint)((5 + 1) * ((15 + 1) - 1) * 2), tsa1.Length);
+                Assert.Equal(Address.DataTypeEnum.TSA, tsa1.DataType);
+                Assert.Equal(tsa1Slot, tsa1.Pointer);
+
+                // Palette: 0x20*4 = 128, type PAL.
+                Address pal = Assert.Single(list, a => a.Info == "battle_screen_palette");
+                Assert.Equal(palData, pal.Addr);
+                Assert.Equal(0x20u * 4, pal.Length);
+                Assert.Equal(Address.DataTypeEnum.PAL, pal.DataType);
+
+                // image1: LZ77IMG with getCompressedSize length.
+                Address img1 = Assert.Single(list, a => a.DataType == Address.DataTypeEnum.LZ77IMG && a.Addr == imgData);
+                Assert.Equal(expectImgLen, img1.Length);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitWorldMapImageFE6_EmitsTenLz77Blocks_AtPlusEightOffsets()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe6 = MakeVersionedRom("AFEJ01");
+                CoreState.ROM = fe6;
+
+                uint imgP = U.toOffset(fe6.RomInfo.worldmap_big_image_pointer);
+                uint palP = U.toOffset(fe6.RomInfo.worldmap_big_palette_pointer);
+                // Plant LZ77 streams at the base image slot and base palette slot.
+                uint imgData = 0x700000;
+                uint palData = 0x701000;
+                fe6.write_u32(imgP + 0, Ptr(imgData));
+                fe6.write_u32(palP + 0, Ptr(palData));
+                uint imgLen = WriteLz77AllLiteral(fe6, imgData, 50);
+                uint palLen = WriteLz77AllLiteral(fe6, palData, 24);
+
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitWorldMapImageFE6(fe6, list));
+                Assert.Null(ex);
+
+                // 10 AddLZ77Pointer calls; the +0 image is LZ77IMG, +0 palette is LZ77PAL.
+                Address img0 = Assert.Single(list, a => a.Info == "worldmap_big_image");
+                Assert.Equal(imgData, img0.Addr);
+                Assert.Equal(imgLen, img0.Length);
+                Assert.Equal(Address.DataTypeEnum.LZ77IMG, img0.DataType);
+                Assert.Equal(imgP + 0, img0.Pointer);
+
+                Address pal0 = Assert.Single(list, a => a.Info == "worldmap_big_palette");
+                Assert.Equal(palData, pal0.Addr);
+                Assert.Equal(palLen, pal0.Length);
+                Assert.Equal(Address.DataTypeEnum.LZ77PAL, pal0.DataType);
+
+                // The +8/+16/+24/+32 slots point at 0 (no data planted) -> AddLZ77Pointer skips them
+                // gracefully (no throw), so the NW/NE/SW/SE labels are NOT in the list. Only the two
+                // base (+0) blocks were planted.
+                Assert.DoesNotContain(list, a => a.Info == "worldmap_big_imageNW");
+                Assert.Equal(2, list.Count); // exactly the +0 image + +0 palette
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitWorldMapImageFE7_EmitsPalette_TwelveFixedImages_AndEventBlocks()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe7 = MakeVersionedRom("AE7E01");
+                CoreState.ROM = fe7;
+
+                // worldmap_big_image_pointer -> imagemap table of 12 image pointers.
+                uint imgPtrSlot = U.toOffset(fe7.RomInfo.worldmap_big_image_pointer);
+                uint palPtrSlot = U.toOffset(fe7.RomInfo.worldmap_big_palette_pointer);
+                uint tsaPtrSlot = U.toOffset(fe7.RomInfo.worldmap_big_palettemap_pointer);
+                uint imagemap = 0x600000; // table of 12 u32 image pointers
+                uint palData = 0x601000;
+                uint tsamap = 0x602000;   // p32(tsaPtrSlot) -> tsamap; p32(tsamap) -> a tsa addr
+                uint tsaData = 0x603000;
+                uint img0Data = 0x610000;
+                fe7.write_u32(imgPtrSlot, Ptr(imagemap));
+                fe7.write_u32(palPtrSlot, Ptr(palData));
+                fe7.write_u32(tsaPtrSlot, Ptr(tsamap));
+                fe7.write_u32(tsamap, Ptr(tsaData)); // p32(tsamap) read inside the loop
+                // Plant all 12 image pointers in the imagemap table (each to a distinct target).
+                for (uint i = 0; i < 12; i++)
+                {
+                    fe7.write_u32(imagemap + i * 4, Ptr(img0Data + i * 0x1000));
+                }
+
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitWorldMapImageFE7(fe7, list));
+                Assert.Null(ex);
+
+                // Palette: 0x20*4, type PAL.
+                Address pal = Assert.Single(list, a => a.Info == "worldmap_big_palette");
+                Assert.Equal(palData, pal.Addr);
+                Assert.Equal(0x20u * 4, pal.Length);
+
+                // 12 image entries (worldmap_big_image0..11), each fixed 256/2*256.
+                Address img0 = Assert.Single(list, a => a.Info == "worldmap_big_image0");
+                Assert.Equal(img0Data, img0.Addr);
+                Assert.Equal((uint)(256 / 2 * 256), img0.Length);
+                Assert.Equal(Address.DataTypeEnum.IMG, img0.DataType);
+                Assert.Equal(12, list.Count(a => a.Info != null && a.Info.StartsWith("worldmap_big_image") && a.DataType == Address.DataTypeEnum.IMG));
+
+                // 12 tsa entries, all reading the SAME tsamap slot (WF quirk reproduced),
+                // each fixed 256/8*256/8, pointer = tsamap.
+                Address tsa0 = Assert.Single(list, a => a.Info == "worldmap_big_tsa0");
+                Assert.Equal(tsaData, tsa0.Addr);
+                Assert.Equal((uint)(256 / 8 * 256 / 8), tsa0.Length);
+                Assert.Equal(Address.DataTypeEnum.TSA, tsa0.DataType);
+                Assert.Equal(tsamap, tsa0.Pointer);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        // ---- whole-producer integration: version gating + no-throw ----------
+
+        [Fact]
+        public void MakeAllStructPointers_AllZeroSyntheticRom_DoesNotThrow_AndDefersImageForms()
+        {
+            // A synthetic CreateTestRom has RomInfo == null, so MakeAllStructPointers can't run
+            // (it reads rom.RomInfo). Instead verify the producer is robust on a real-version ROM
+            // whose image pointer slots are all-zero (no data) — every flat emitter / descriptor
+            // gracefully emits nothing for an unsafe/zero pointer.
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(fe8);
+
+                var ex = Record.Exception(() =>
+                {
+                    RebuildProducerCore.ProducerResult res = RebuildProducerCore.MakeAllStructPointers(fe8);
+                    Assert.NotNull(res);
+                    Assert.False(res.IsComplete); // image/anime/etc. forms still deferred
+                });
+                Assert.Null(ex);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = null;
+            }
+        }
+
+        [Fact]
+        public void GetNotYetPortedForms_NoLongerListsPortedImageForms_StillListsDeferred()
+        {
+            var ported = RebuildProducerCore.GetNotYetPortedForms();
+            // ported in slice 2e -> removed from the deferred list:
+            Assert.DoesNotContain("ImageBattleBGForm", ported);
+            Assert.DoesNotContain("ImageBattleTerrainForm", ported);
+            Assert.DoesNotContain("ImageBattleScreenForm", ported);
+            Assert.DoesNotContain("ImageUnitWaitIconFrom", ported);
+            Assert.DoesNotContain("ImageUnitPaletteForm", ported);
+            Assert.DoesNotContain("ImageGenericEnemyPortraitForm", ported);
+            Assert.DoesNotContain("ImageChapterTitleForm", ported);
+            // still deferred (need ImageUtil / config / runtime-inspection subsystems):
+            Assert.Contains("ImageBGForm", ported);
+            Assert.Contains("ImageCGForm", ported);
+            Assert.Contains("ImageSystemIconForm", ported);
+            Assert.Contains("ImageBattleAnimeForm", ported);
+            Assert.Contains("ImagePortraitForm", ported);
+            Assert.Contains("WorldMapImageForm", ported); // the FE8 form stays (AddHeaderTSAPointer)
+            Assert.Contains("ImageItemIconForm", ported);
+            Assert.Contains("ImageTSAAnimeForm", ported);
+        }
     }
 }

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -122,6 +122,21 @@ namespace FEBuilderGBA
             /// <summary>TextDic main rule: stop when <c>u16(addr+2) &lt;= 0 || u16(addr+4) &lt;= 0</c>.
             /// Reproduces <c>TextDicForm.Init</c> (the <c>dic_main</c> table) verbatim.</summary>
             DicMainRule,
+            /// <summary>Continue while <c>U.isPointer(u32(addr+0)) &amp;&amp; U.isPointer(u32(addr+4))</c>
+            /// (BOTH non-NULL ROM pointers). Matches <c>ImageBattleBGForm.Init</c> (its IsDataExists is
+            /// "0 と 4 がポインタであればデータがある"). The offsets are fixed at 0 and 4.</summary>
+            TwoU32PointerAt04,
+            /// <summary><c>ImageUnitWaitIconFrom.Init</c> rule: entry 0 always exists; otherwise the
+            /// <c>+4</c> field decides — a <c>U.isPointer(u32(addr+4))</c> continues; a <c>u32(addr+4)==0</c>
+            /// continues ONLY while <c>u32(addr+0) != 0</c> (both zero = terminator); any other (non-zero,
+            /// non-pointer) <c>+4</c> value terminates. Reproduced VERBATIM.</summary>
+            WaitIconRule,
+            /// <summary><c>ImageUnitPaletteForm.Init</c> rule: a <c>U.isPointer(u32(addr+12))</c> continues;
+            /// a <c>u32(addr+12)==0</c> terminates ONLY when <c>u32(addr+0)==0</c> too (name also NULL);
+            /// any other value continues. Reproduced VERBATIM (the +12 palette-pointer field, with the
+            /// +0 name-NULL tie-break, distinct from <see cref="PointerAt"/> which terminates on any
+            /// non-pointer).</summary>
+            UnitPaletteRule,
         }
 
         /// <summary>How a <see cref="SubWalk"/> reproduces the per-entry embedded-data
@@ -150,6 +165,24 @@ namespace FEBuilderGBA
             /// relocation, so a static name is used (the WinForms <c>isPointerOnly</c> flag only swaps
             /// the label between <c>""</c> and a Huffman-decoded string — neither affects addr/length).</summary>
             AsmFunction,
+            /// <summary>An embedded LZ77-compressed block (image / TSA / palette) behind a pointer.
+            /// Emits via <see cref="Address.AddLZ77Pointer"/> VERBATIM (reads <c>u32(p +
+            /// EmbeddedPointerOffset)</c>, <c>isSafetyPointer</c>-checks, then adds a block whose length
+            /// is <c>LZ77.getCompressedSize(rom.Data, addr)</c> — the producer always scans with
+            /// <c>isPointerOnly = false</c>, so a real length is computed, NOT 0). The block's
+            /// <see cref="Address.DataTypeEnum"/> is taken from <see cref="SubWalk.DataType"/>
+            /// (LZ77IMG / LZ77TSA / LZ77PAL). Matches the per-entry <c>AddLZ77Pointer</c> in
+            /// <c>ImageBattleBGForm</c>/<c>ImageBattleTerrainForm</c>/<c>ImageUnitWaitIconFrom</c>/
+            /// <c>ImageUnitPaletteForm</c>/<c>ImageChapterTitleForm</c> etc. EOF-safe: a near-EOF /
+            /// malformed stream yields <c>getCompressedSize == 0</c> (length 0), never throws.</summary>
+            Lz77Pointer,
+            /// <summary>An embedded FIXED-size block (palette / uncompressed image) behind a pointer.
+            /// Emits via <see cref="Address.AddPointer"/> VERBATIM (<c>u32(p + EmbeddedPointerOffset)</c>
+            /// -&gt; addr, <c>isSafetyPointer</c>-check, add a <see cref="SubWalk.FixedLength"/>-byte block
+            /// of <see cref="SubWalk.DataType"/>). Distinct from <see cref="BinFixed"/> only in that the
+            /// data type is configurable (PAL / IMG / LZ77PAL), not hard-wired to BIN. Matches the
+            /// per-entry <c>AddPointer(p + N, 0x20*K, name, PAL)</c> palette/image columns.</summary>
+            FixedPointer,
         }
 
         /// <summary>One per-entry embedded-data sub-walk applied to every entry of a
@@ -167,9 +200,15 @@ namespace FEBuilderGBA
             public uint EmbeddedPointerOffset;
             /// <summary>What kind of data the embedded pointer targets.</summary>
             public SubKind Kind;
-            /// <summary>For <see cref="SubKind.BinFixed"/>: the fixed block length
-            /// (e.g. MoveCost = 66). Ignored for the string kinds.</summary>
+            /// <summary>For <see cref="SubKind.BinFixed"/> / <see cref="SubKind.FixedPointer"/>: the
+            /// fixed block length (e.g. MoveCost = 66, a 16-color palette = 0x20). Ignored for the
+            /// string / LZ77 kinds (LZ77 length comes from <c>getCompressedSize</c>).</summary>
             public uint FixedLength;
+            /// <summary>For <see cref="SubKind.Lz77Pointer"/> / <see cref="SubKind.FixedPointer"/>: the
+            /// <see cref="Address.DataTypeEnum"/> the emitted block is tagged with (LZ77IMG / LZ77TSA /
+            /// LZ77PAL / PAL / IMG). Reproduces the WinForms per-entry call's last argument VERBATIM.
+            /// Ignored for the other kinds (which have a fixed type: CSTRING / BIN / ASM).</summary>
+            public Address.DataTypeEnum DataType;
             /// <summary>Builds the <see cref="Address.Info"/> label for entry <c>i</c>
             /// (was the WinForms per-entry name string). For <see cref="SubKind.CString"/> the
             /// label is taken from the decoded string itself (matching
@@ -239,19 +278,33 @@ namespace FEBuilderGBA
             /// (terrain_recovery / terrain_bad_status_recovery / terrain_show_infomation), each a
             /// 66-byte BIN via <c>Address.AddPointer(..., 66, name, BIN)</c>.</summary>
             public ExtraFixedPointer[] ExtraFixedPointers;
+            /// <summary>Whether to emit the main IFR <see cref="Address"/> (block × (DataCount+1)).
+            /// Default <c>true</c> (every flat / sub-walk descriptor so far). A few WinForms image
+            /// forms (e.g. <c>ImageGenericEnemyPortraitForm</c>) run the per-entry loop but emit NO
+            /// <c>AddressWinForms.AddAddress(list, IFR, ...)</c> — only the standalone header pointer +
+            /// the per-entry columns. Setting this <c>false</c> suppresses the main IFR Address while
+            /// still walking <see cref="SubWalks"/> over the same <c>getBlockDataCount</c>.</summary>
+            public bool EmitMainIfr = true;
         }
 
-        /// <summary>A standalone fixed-size BIN pointer emitted once per descriptor (see
-        /// <see cref="StructDescriptor.ExtraFixedPointers"/>).</summary>
+        /// <summary>A standalone fixed-size pointer emitted once per descriptor (see
+        /// <see cref="StructDescriptor.ExtraFixedPointers"/>). Default type is BIN (the ClassForm
+        /// terrain pointers); <see cref="DataType"/> overrides it (e.g. the GenericEnemyPortrait
+        /// header is a POINTER block).</summary>
         public sealed class ExtraFixedPointer
         {
             /// <summary>Resolves the <c>RomInfo</c> pointer field (e.g.
             /// <c>r =&gt; r.RomInfo.terrain_recovery_pointer</c>).</summary>
             public Func<ROM, uint> PointerField;
-            /// <summary>Fixed BIN block length (e.g. 66).</summary>
+            /// <summary>Fixed block length (e.g. 66 for MoveCost BIN, 8*2*4 for the GenericEnemyPortrait
+            /// POINTER header).</summary>
             public uint FixedLength;
             /// <summary>The <see cref="Address.Info"/> label.</summary>
             public string Name;
+            /// <summary>The emitted block's <see cref="Address.DataTypeEnum"/>. Defaults to
+            /// <see cref="Address.DataTypeEnum.BIN"/> (the ClassForm terrain pointers); set to e.g.
+            /// <see cref="Address.DataTypeEnum.POINTER"/> for the GenericEnemyPortrait header.</summary>
+            public Address.DataTypeEnum DataType = Address.DataTypeEnum.BIN;
         }
 
         /// <summary>
@@ -384,6 +437,40 @@ namespace FEBuilderGBA
             progress?.Report("RMENU");
             EmitStatusRMenuTree(rom, list);
 
+            // ---- slice 2e: flat LZ77-image + palette forms that are NOT a descriptor walk ----
+            // ImageBattleScreenForm is version-agnostic (called in the WF unconditional section);
+            // WorldMapImageFE6Form / WorldMapImageFE7Form are version-gated (the FE8 WorldMapImageForm
+            // is DEFERRED — it uses AddHeaderTSAPointer / AddROMTCSPointer, both ImageUtil-backed and
+            // not yet in Core). Each gets its own cancel-check, mirroring the WF DoEvents checkpoints.
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("ImageBattleScreen");
+            EmitImageBattleScreen(rom, list);
+
+            if (rom.RomInfo.version == 7)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    progress?.Report("MakeAllStructPointersList cancelled");
+                    return new ProducerResult(list, notYet, cancelled: true);
+                }
+                progress?.Report("WorldMapImageFE7");
+                EmitWorldMapImageFE7(rom, list);
+            }
+            else if (rom.RomInfo.version == 6)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    progress?.Report("MakeAllStructPointersList cancelled");
+                    return new ProducerResult(list, notYet, cancelled: true);
+                }
+                progress?.Report("WorldMapImageFE6");
+                EmitWorldMapImageFE6(rom, list);
+            }
+
             // Surface — never silently drop — the statics this slice does not yet cover.
             progress?.Report("MakeAllStructPointersList: ported batch=" + batch.Count
                 + " descriptors; not-yet-ported=" + notYet.Length + " forms (deferred to later slices)");
@@ -425,7 +512,7 @@ namespace FEBuilderGBA
                 foreach (ExtraFixedPointer ep in d.ExtraFixedPointers)
                 {
                     Address.AddPointer(list, ep.PointerField(rom), ep.FixedLength, ep.Name,
-                        Address.DataTypeEnum.BIN);
+                        ep.DataType);
                 }
             }
         }
@@ -458,7 +545,14 @@ namespace FEBuilderGBA
             // WinForms AddressWinForms.AddAddress: length = BlockSize * (DataCount + 1).
             uint length = d.BlockSize * (dataCount + 1);
 
-            list.Add(new Address(baseAddr, length, pointer, d.Name, d.DataType, d.BlockSize, d.PointerIndexes));
+            // Most descriptors emit a main IFR Address (AddressWinForms.AddAddress(list, IFR, ...)).
+            // A few image forms (ImageGenericEnemyPortraitForm) run the per-entry loop but emit NO main
+            // IFR Address — EmitMainIfr==false suppresses it while still walking the SubWalks over the
+            // SAME getBlockDataCount (so the dataCount that drives the sub-walk loop is identical).
+            if (d.EmitMainIfr)
+            {
+                list.Add(new Address(baseAddr, length, pointer, d.Name, d.DataType, d.BlockSize, d.PointerIndexes));
+            }
 
             // Per-entry embedded-data sub-walks (slice 2c). The WinForms MakeAllDataLength runs
             // these inside the `for (i < DataCount)` loop right after the main AddAddress, over the
@@ -553,6 +647,31 @@ namespace FEBuilderGBA
                             // rebuild). No encoder needed — the label is static (see SubKind.AsmFunction).
                             Address.AddFunction(list, pfield,
                                 sw.Name != null ? sw.Name(rom, i) : d.Name);
+                            break;
+
+                        case SubKind.Lz77Pointer:
+                            // ImageBattleBGForm/ImageBattleTerrainForm/ImageUnitWaitIconFrom/
+                            // ImageUnitPaletteForm/ImageChapterTitle(FE7)Form per-entry:
+                            // Address.AddLZ77Pointer(list, p + N, name, isPointerOnly, type).
+                            // AddLZ77Pointer reads u32(pfield), isSafetyPointer-checks, then
+                            // AddLZ77Address computes length = LZ77.getCompressedSize(rom.Data, addr).
+                            // The producer scans real lengths, so isPointerOnly: false (WF passes the
+                            // caller's isPointerOnly; a defragment scan is always !isPointerOnly).
+                            // No encoder needed (no string decode). EOF-safe (getCompressedSize == 0
+                            // on a malformed/near-EOF stream — never throws).
+                            Address.AddLZ77Pointer(list, pfield,
+                                sw.Name != null ? sw.Name(rom, i) : d.Name,
+                                false, sw.DataType);
+                            break;
+
+                        case SubKind.FixedPointer:
+                            // The fixed-size palette/image columns: Address.AddPointer(list, p + N,
+                            // <constant>, name, <PAL/IMG/LZ77PAL>). AddPointer reads u32(pfield),
+                            // isSafetyPointer-checks, and adds a FixedLength block of DataType. Same
+                            // shape as BinFixed but with a configurable (non-BIN) data type.
+                            Address.AddPointer(list, pfield, sw.FixedLength,
+                                sw.Name != null ? sw.Name(rom, i) : d.Name,
+                                sw.DataType);
                             break;
 
                         default:
@@ -965,6 +1084,109 @@ namespace FEBuilderGBA
             }
         }
 
+        /// <summary>
+        /// <c>ImageBattleScreenForm.MakeAllDataLength</c> (slice 2e) — a FLAT sequence of fixed-size
+        /// TSA + palette blocks and LZ77 images, all from RomInfo pointer slots (no per-entry table
+        /// walk). Reproduced VERBATIM: five <c>battle_screen_TSA{1..5}</c> blocks of the WF constant
+        /// lengths (type TSA), one <c>battle_screen_palette</c> (0x20*4, PAL), five
+        /// <c>battle_screen_image{1..5}</c> LZ77 images via <see cref="Address.AddLZ77Pointer"/>. The WF
+        /// image labels are all "battle_screen_image1" (a copy/paste in the original) — preserved
+        /// verbatim (the label is non-load-bearing).
+        /// </summary>
+        public static void EmitImageBattleScreen(ROM rom, List<Address> list)
+        {
+            // Each TSA: tsa = p32(ptr); AddAddress(list, tsa, <const>, ptr, name, TSA). AddAddress
+            // re-checks addr/pointer safety and computes nothing — the length is a pure constant.
+            uint tsa;
+            tsa = rom.p32(rom.RomInfo.battle_screen_TSA1_pointer);
+            Address.AddAddress(list, tsa, (5 + 1) * ((15 + 1) - 1) * 2,
+                rom.RomInfo.battle_screen_TSA1_pointer, "battle_screen_TSA1", Address.DataTypeEnum.TSA);
+            tsa = rom.p32(rom.RomInfo.battle_screen_TSA2_pointer);
+            Address.AddAddress(list, tsa, (5 + 1) * ((30 + 16) - 1) * 2,
+                rom.RomInfo.battle_screen_TSA2_pointer, "battle_screen_TSA2", Address.DataTypeEnum.TSA);
+            tsa = rom.p32(rom.RomInfo.battle_screen_TSA3_pointer);
+            Address.AddAddress(list, tsa, ((19 + 1) - 13) * ((15 + 1) - 1) * 2,
+                rom.RomInfo.battle_screen_TSA3_pointer, "battle_screen_TSA3", Address.DataTypeEnum.TSA);
+            tsa = rom.p32(rom.RomInfo.battle_screen_TSA4_pointer);
+            Address.AddAddress(list, tsa, ((19 + 1) - 13) * ((31 + 1) - 16) * 2,
+                rom.RomInfo.battle_screen_TSA4_pointer, "battle_screen_TSA4", Address.DataTypeEnum.TSA);
+            tsa = rom.p32(rom.RomInfo.battle_screen_TSA5_pointer);
+            Address.AddAddress(list, tsa, ((19 + 1) - 0) * ((32 + 1) - 31) * 2,
+                rom.RomInfo.battle_screen_TSA5_pointer, "battle_screen_TSA5", Address.DataTypeEnum.TSA);
+
+            uint pal = rom.p32(rom.RomInfo.battle_screen_palette_pointer);
+            Address.AddAddress(list, pal, 0x20 * 4,
+                rom.RomInfo.battle_screen_palette_pointer, "battle_screen_palette", Address.DataTypeEnum.PAL);
+
+            // Five LZ77 images via AddLZ77Pointer (length = getCompressedSize, isPointerOnly: false —
+            // the producer always computes real lengths for a defragment). WF labels are all
+            // "battle_screen_image1" verbatim.
+            Address.AddLZ77Pointer(list, rom.RomInfo.battle_screen_image1_pointer, "battle_screen_image1", false, Address.DataTypeEnum.LZ77IMG);
+            Address.AddLZ77Pointer(list, rom.RomInfo.battle_screen_image2_pointer, "battle_screen_image1", false, Address.DataTypeEnum.LZ77IMG);
+            Address.AddLZ77Pointer(list, rom.RomInfo.battle_screen_image3_pointer, "battle_screen_image1", false, Address.DataTypeEnum.LZ77IMG);
+            Address.AddLZ77Pointer(list, rom.RomInfo.battle_screen_image4_pointer, "battle_screen_image1", false, Address.DataTypeEnum.LZ77IMG);
+            Address.AddLZ77Pointer(list, rom.RomInfo.battle_screen_image5_pointer, "battle_screen_image1", false, Address.DataTypeEnum.LZ77IMG);
+        }
+
+        /// <summary>
+        /// <c>WorldMapImageFE6Form.MakeAllDataLength</c> (slice 2e, FE6 only) — a FLAT sequence of
+        /// <see cref="Address.AddLZ77Pointer"/> calls: five (image, palette) pairs at offsets 0/8/16/
+        /// 24/32 off the two RomInfo pointers <c>worldmap_big_image_pointer</c> /
+        /// <c>worldmap_big_palette_pointer</c> (image = LZ77IMG, palette = LZ77PAL). Reproduced
+        /// VERBATIM (same pointer-slot offsets, labels, types, order).
+        /// </summary>
+        public static void EmitWorldMapImageFE6(ROM rom, List<Address> list)
+        {
+            uint imgP = rom.RomInfo.worldmap_big_image_pointer;
+            uint palP = rom.RomInfo.worldmap_big_palette_pointer;
+            Address.AddLZ77Pointer(list, imgP + 0, "worldmap_big_image", false, Address.DataTypeEnum.LZ77IMG);
+            Address.AddLZ77Pointer(list, palP + 0, "worldmap_big_palette", false, Address.DataTypeEnum.LZ77PAL);
+            Address.AddLZ77Pointer(list, imgP + 8, "worldmap_big_imageNW", false, Address.DataTypeEnum.LZ77IMG);
+            Address.AddLZ77Pointer(list, palP + 8, "worldmap_big_paletteNW", false, Address.DataTypeEnum.LZ77PAL);
+            Address.AddLZ77Pointer(list, imgP + 16, "worldmap_big_imageNE", false, Address.DataTypeEnum.LZ77IMG);
+            Address.AddLZ77Pointer(list, palP + 16, "worldmap_big_paletteNE", false, Address.DataTypeEnum.LZ77PAL);
+            Address.AddLZ77Pointer(list, imgP + 24, "worldmap_big_imageSW", false, Address.DataTypeEnum.LZ77IMG);
+            Address.AddLZ77Pointer(list, palP + 24, "worldmap_big_paletteSW", false, Address.DataTypeEnum.LZ77PAL);
+            Address.AddLZ77Pointer(list, imgP + 32, "worldmap_big_imageSE", false, Address.DataTypeEnum.LZ77IMG);
+            Address.AddLZ77Pointer(list, palP + 32, "worldmap_big_paletteSE", false, Address.DataTypeEnum.LZ77PAL);
+        }
+
+        /// <summary>
+        /// <c>WorldMapImageFE7Form.MakeAllDataLength</c> (slice 2e, FE7 only) — the big-map block: a
+        /// PAL (0x20*4), then a FIXED 12-entry loop reading <c>imagemap = p32(worldmap_big_image_pointer)</c>
+        /// (advancing 4 bytes per entry) for a constant-size IMG (256/2*256), and a TSA (256/8*256/8)
+        /// read from <c>tsamap = p32(worldmap_big_palettemap_pointer)</c>. NOTE: the WF loop reads
+        /// <c>tsa = p32(tsamap)</c> WITHOUT advancing <c>tsamap</c> — every TSA entry points at the
+        /// SAME slot; this (likely-WF-quirk) is reproduced VERBATIM to keep the produced Address list
+        /// byte-identical. Then the three flat <c>worldmap_event_*</c> blocks (LZ77 image, LZ77 TSA,
+        /// fixed PAL 0x20*4).
+        /// </summary>
+        public static void EmitWorldMapImageFE7(ROM rom, List<Address> list)
+        {
+            uint imagemap = rom.p32(rom.RomInfo.worldmap_big_image_pointer);
+            uint palette = rom.p32(rom.RomInfo.worldmap_big_palette_pointer);
+            uint tsamap = rom.p32(rom.RomInfo.worldmap_big_palettemap_pointer);
+
+            Address.AddAddress(list, palette, 0x20 * 4,
+                rom.RomInfo.worldmap_big_palette_pointer, "worldmap_big_palette", Address.DataTypeEnum.PAL);
+
+            uint pointer = imagemap;
+            for (int i = 0; i < 12; i++, pointer += 4)
+            {
+                uint image = rom.p32(pointer);
+                uint imagelength = 256 / 2 * 256;
+                Address.AddAddress(list, image, imagelength, pointer, "worldmap_big_image" + i, Address.DataTypeEnum.IMG);
+
+                uint tsa = rom.p32(tsamap); // WF does NOT advance tsamap — verbatim.
+                uint tsalength = 256 / 8 * 256 / 8;
+                Address.AddAddress(list, tsa, tsalength, tsamap, "worldmap_big_tsa" + i, Address.DataTypeEnum.TSA);
+            }
+
+            Address.AddLZ77Pointer(list, rom.RomInfo.worldmap_event_image_pointer, "worldmap_event_image", false, Address.DataTypeEnum.LZ77IMG);
+            Address.AddLZ77Pointer(list, rom.RomInfo.worldmap_event_tsa_pointer, "worldmap_event_tsa", false, Address.DataTypeEnum.LZ77TSA);
+            Address.AddPointer(list, rom.RomInfo.worldmap_event_palette_pointer, 0x20 * 4, "worldmap_event_palette", Address.DataTypeEnum.PAL);
+        }
+
         /// <summary>Turn a descriptor's <see cref="DataCountRule"/> into the
         /// <c>is_data_exists_callback</c> that <see cref="ROM.getBlockDataCount(uint,uint,Func{int,uint,bool})"/> expects.</summary>
         static Func<int, uint, bool> MakeIsDataExists(ROM rom, StructDescriptor d)
@@ -1130,6 +1352,44 @@ namespace FEBuilderGBA
                         if (text1 <= 0 || text2 <= 0) return false;
                         return true;
                     };
+                case DataCountRule.TwoU32PointerAt04:
+                    return (i, addr) =>
+                    {
+                        if (i >= d.MaxCount) return false;
+                        // ImageBattleBGForm.Init: 0 と 4 がポインタであればデータがある.
+                        return U.isPointer(rom.u32(addr + 0))
+                            && U.isPointer(rom.u32(addr + 4));
+                    };
+                case DataCountRule.WaitIconRule:
+                    return (i, addr) =>
+                    {
+                        if (i >= d.MaxCount) return false;
+                        // ImageUnitWaitIconFrom.Init verbatim: entry 0 always; then the +4 field.
+                        if (i == 0) return true;
+                        uint a = rom.u32(addr + 4);
+                        if (U.isPointer(a)) return true;
+                        if (a == 0)
+                        {
+                            uint flags = rom.u32(addr + 0);
+                            if (flags == 0) return false; // both 0 -> terminator
+                            return true;
+                        }
+                        return false; // non-zero non-pointer -> terminator
+                    };
+                case DataCountRule.UnitPaletteRule:
+                    return (i, addr) =>
+                    {
+                        if (i >= d.MaxCount) return false;
+                        // ImageUnitPaletteForm.Init verbatim: +12 palette pointer, +0 name tie-break.
+                        uint p = rom.u32(addr + 12);
+                        if (U.isPointer(p)) return true;
+                        if (p == 0)
+                        {
+                            uint name = rom.u32(addr + 0);
+                            if (name == 0) return false; // name also NULL -> terminator
+                        }
+                        return true; // any other value -> valid
+                    };
                 default:
                     // An unhandled DataCountRule is a PROGRAMMING ERROR (a bad/new descriptor),
                     // not a 0-entry table. Returning always-false would silently emit a 1-block
@@ -1284,6 +1544,111 @@ namespace FEBuilderGBA
                 RuleOffset = 0,
                 RuleStopValue = 0xFF,
                 PointerIndexes = new uint[] { },
+            });
+
+            // ---- slice 2e: flat LZ77-image + palette IFR-loop forms (version-agnostic) ----
+            // Each is the Core port of an ImageXxxForm.MakeAllDataLength that emits a main IFR Address
+            // (AddressWinForms.AddAddress(list, IFR, name, pointerIndexes) -> length = block ×
+            // (DataCount+1)) PLUS a per-entry loop of AddLZ77Pointer / AddPointer columns. The
+            // per-entry columns are the SubWalks (Lz77Pointer / FixedPointer). EVERY length is either
+            // LZ77.getCompressedSize (EOF-safe, 0 on malformed) or a CONSTANT palette/image size — no
+            // ImageUtil/TSA-header/frame-walk dependency. The forms that DO need such a subsystem
+            // (AddHeaderTSAPointer, ImageUtil*.RecycleOldAnime, config-file g_TSAAnime/g_ROMAnime,
+            // ImageUtilOAM, IsHalfBodyFlag, AddAPPointer) stay in GetNotYetPortedForms.
+
+            // ImageBattleBGForm.MakeAllDataLength — Info "BattleBG", block 12, base battle_bg_pointer,
+            // IsDataExists = isPointer(u32+0) && isPointer(u32+4) (TwoU32PointerAt04), pointerIndexes
+            // {0,4,8}. Per entry: LZ77IMG @0, LZ77IMG @4 (the WF "_tsa" column is tagged LZ77IMG, NOT
+            // LZ77TSA — reproduced verbatim), LZ77PAL @8.
+            l.Add(new StructDescriptor
+            {
+                Name = "BattleBG",
+                PointerField = r => r.RomInfo.battle_bg_pointer,
+                BlockSize = 12,
+                Rule = DataCountRule.TwoU32PointerAt04,
+                PointerIndexes = new uint[] { 0, 4, 8 },
+                SubWalks = new List<SubWalk>
+                {
+                    new SubWalk { EmbeddedPointerOffset = 0, Kind = SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77IMG, Name = (r, i) => "BattleBG " + U.To0xHexString((uint)i) + "_img" },
+                    new SubWalk { EmbeddedPointerOffset = 4, Kind = SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77IMG, Name = (r, i) => "BattleBG " + U.To0xHexString((uint)i) + "_tsa" },
+                    new SubWalk { EmbeddedPointerOffset = 8, Kind = SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77PAL, Name = (r, i) => "BattleBG " + U.To0xHexString((uint)i) + "_lz77pal" },
+                },
+            });
+
+            // ImageBattleTerrainForm.MakeAllDataLength — Info "BattleTerrain", block 24, base
+            // battle_terrain_pointer, IsDataExists = isPointer(u32+12) (PointerAt @12), pointerIndexes
+            // {12,16}. Per entry: LZ77IMG @12, fixed PAL (0x20) @16.
+            l.Add(new StructDescriptor
+            {
+                Name = "BattleTerrain",
+                PointerField = r => r.RomInfo.battle_terrain_pointer,
+                BlockSize = 24,
+                Rule = DataCountRule.PointerAt,
+                RuleOffset = 12,
+                PointerIndexes = new uint[] { 12, 16 },
+                SubWalks = new List<SubWalk>
+                {
+                    new SubWalk { EmbeddedPointerOffset = 12, Kind = SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77IMG, Name = (r, i) => "BattleTerrain 0x" + U.ToHexString((int)i) },
+                    new SubWalk { EmbeddedPointerOffset = 16, Kind = SubKind.FixedPointer, FixedLength = 0x20 * 1, DataType = Address.DataTypeEnum.PAL, Name = (r, i) => "BattleTerrain 0x" + U.ToHexString((int)i) },
+                },
+            });
+
+            // ImageUnitWaitIconFrom.MakeAllDataLength — Info "WaitUnitIcon", block 8, base
+            // unit_wait_icon_pointer, IsDataExists = WaitIconRule, pointerIndexes {4}. Per entry:
+            // LZ77IMG @4.
+            l.Add(new StructDescriptor
+            {
+                Name = "WaitUnitIcon",
+                PointerField = r => r.RomInfo.unit_wait_icon_pointer,
+                BlockSize = 8,
+                Rule = DataCountRule.WaitIconRule,
+                PointerIndexes = new uint[] { 4 },
+                SubWalks = new List<SubWalk>
+                {
+                    new SubWalk { EmbeddedPointerOffset = 4, Kind = SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77IMG, Name = (r, i) => "WaitUnitIcon " + U.To0xHexString((uint)i) },
+                },
+            });
+
+            // ImageUnitPaletteForm.MakeAllDataLength — Info "UnitPalette", block 16, base
+            // image_unit_palette_pointer, IsDataExists = UnitPaletteRule, pointerIndexes {12}. Per
+            // entry: LZ77PAL @12. (NOTE: the WF per-entry label uses i+1, faithfully reproduced.)
+            l.Add(new StructDescriptor
+            {
+                Name = "UnitPalette",
+                PointerField = r => r.RomInfo.image_unit_palette_pointer,
+                BlockSize = 16,
+                Rule = DataCountRule.UnitPaletteRule,
+                PointerIndexes = new uint[] { 12 },
+                SubWalks = new List<SubWalk>
+                {
+                    new SubWalk { EmbeddedPointerOffset = 12, Kind = SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77PAL, Name = (r, i) => "UnitPalette " + U.To0xHexString((uint)i + 1) },
+                },
+            });
+
+            // ImageGenericEnemyPortraitForm.MakeAllDataLength — Info "GenericEnemyPortait" (WF
+            // spelling preserved). This form is SPECIAL: it emits NO main IFR Address — instead a
+            // standalone POINTER (8*2*4 = 64-byte) at generic_enemy_portrait_pointer ONCE, then a
+            // per-entry loop (count = generic_enemy_portrait_count, block 4): a fixed IMG
+            // (4*8/2)*(4*8)=512 @0 and a fixed PAL (0x20) @16. Modeled as a FixedCount descriptor with
+            // EmitMainIfr=false + an ExtraFixedPointer for the standalone header + per-entry SubWalks.
+            l.Add(new StructDescriptor
+            {
+                Name = "GenericEnemyPortait",
+                PointerField = r => r.RomInfo.generic_enemy_portrait_pointer,
+                BlockSize = 4,
+                Rule = DataCountRule.FixedCount,
+                FixedCountField = r => r.RomInfo.generic_enemy_portrait_count,
+                PointerIndexes = new uint[] { },
+                EmitMainIfr = false, // WF emits no main IFR AddAddress for this form
+                ExtraFixedPointers = new[]
+                {
+                    new ExtraFixedPointer { PointerField = r => r.RomInfo.generic_enemy_portrait_pointer, FixedLength = 8 * 2 * 4, Name = "GenericEnemyPortait", DataType = Address.DataTypeEnum.POINTER },
+                },
+                SubWalks = new List<SubWalk>
+                {
+                    new SubWalk { EmbeddedPointerOffset = 0, Kind = SubKind.FixedPointer, FixedLength = (4 * 8 / 2) * (4 * 8), DataType = Address.DataTypeEnum.IMG, Name = (r, i) => "GenericEnemyPortait 0x" + U.ToHexString((int)i) },
+                    new SubWalk { EmbeddedPointerOffset = 16, Kind = SubKind.FixedPointer, FixedLength = 0x20 * 1, DataType = Address.DataTypeEnum.PAL, Name = (r, i) => "GenericEnemyPortait 0x" + U.ToHexString((int)i) },
+                },
             });
 
             // ClassForm vs ClassFE6Form (slice 2c) — VERSION-SPECIFIC. The WinForms
@@ -1736,6 +2101,27 @@ namespace FEBuilderGBA
                     RuleWidth = 2, RuleOffset = 0, RuleStopValue = 0xFFFF, HasEmptyGuard = true,
                     PointerIndexes = new uint[] { },
                 });
+
+                // ImageChapterTitleForm.MakeAllDataLength (FE8, slice 2e) — Info "ChapterTitleImage",
+                // block 12, base image_chapter_title_pointer, IsDataExists = isPointer(u32+0)
+                // (PointerAt @0), pointerIndexes {0,4,8}. Per entry: THREE LZ77IMG columns at 0/4/8
+                // ("_Save"/"_Number"/"_Title"). (The FE7/FE6 path uses ImageChapterTitleFE7Form below —
+                // block 4, ONE column.)
+                l.Add(new StructDescriptor
+                {
+                    Name = "ChapterTitleImage",
+                    PointerField = r => r.RomInfo.image_chapter_title_pointer,
+                    BlockSize = 12,
+                    Rule = DataCountRule.PointerAt,
+                    RuleOffset = 0,
+                    PointerIndexes = new uint[] { 0, 4, 8 },
+                    SubWalks = new List<SubWalk>
+                    {
+                        new SubWalk { EmbeddedPointerOffset = 0, Kind = SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77IMG, Name = (r, i) => "ChapterTitleImage_Save" },
+                        new SubWalk { EmbeddedPointerOffset = 4, Kind = SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77IMG, Name = (r, i) => "ChapterTitleImage_Number" },
+                        new SubWalk { EmbeddedPointerOffset = 8, Kind = SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77IMG, Name = (r, i) => "ChapterTitleImage_Title" },
+                    },
+                });
             }
             else if (rom.RomInfo.version == 7)
             {
@@ -1864,15 +2250,28 @@ namespace FEBuilderGBA
                     RuleRangeHi = 0xff,
                     PointerIndexes = new uint[] { },
                 });
+
+                // ImageChapterTitleFE7Form.MakeAllDataLength (FE7, slice 2e) — called in the WF FE7
+                // branch ONLY inside `if (is_multibyte)` (the FE7U non-multibyte path uses a different
+                // CG/title set). Gated identically here. Block 4, base image_chapter_title_pointer,
+                // IsDataExists = isPointer(u32+0) (PointerAt @0), pointerIndexes {0}. Per entry: ONE
+                // LZ77IMG column at 0.
+                if (rom.RomInfo.is_multibyte)
+                {
+                    l.Add(MakeImageChapterTitleFE7Descriptor());
+                }
             }
             else if (rom.RomInfo.version == 6)
             {
                 // ---- version==6 (FE6) section ----
                 // Forms called ONLY inside the WF `else if (version == 6)` branch. UnitFE6Form,
-                // WorldMapEventPointerFE6Form (PLIST event-scan), ImagePortraitFE6Form (LZ77),
-                // ImageChapterTitleFE7Form (LZ77), WorldMapImageFE6Form (LZ77), MapSettingFE6Form
-                // (IsMapSettingEnd + CString), SupportUnitFE6Form (GetUnitIDWhereSupportAddr) stay
-                // deferred. The clean tables below are ported.
+                // WorldMapEventPointerFE6Form (PLIST event-scan), MapSettingFE6Form (IsMapSettingEnd +
+                // CString), SupportUnitFE6Form (GetUnitIDWhereSupportAddr) stay deferred.
+                // ImagePortraitFE6Form STAYS too — its Init has a stateful nullContinuousCount
+                // terminator + GetFEditorLengthHint, not faithfully reproducible by the stateless
+                // descriptor rule model. The clean tables below are ported; ImageChapterTitleFE7Form
+                // (flat LZ77) and WorldMapImageFE6Form (flat LZ77) are ported in slice 2e (see the
+                // ImageChapterTitleFE7Form descriptor at the end of this branch + EmitWorldMapImageFE6).
 
                 // EDFE6Form.MakeAllDataLength — Info "EDFE6Form", single table N2 (ed_3a, block 8),
                 // IsDataExists = i < 0x42 (fixed cap).
@@ -1963,6 +2362,12 @@ namespace FEBuilderGBA
                         new SubWalk { EmbeddedPointerOffset = 0, Kind = SubKind.BinString },
                     },
                 });
+
+                // ImageChapterTitleFE7Form.MakeAllDataLength (FE6, slice 2e) — the WF FE6 branch calls
+                // it UNCONDITIONALLY (no is_multibyte gate, unlike FE7). Same descriptor as the FE7
+                // multibyte path: block 4, base image_chapter_title_pointer, PointerAt @0, one LZ77IMG
+                // column at 0.
+                l.Add(MakeImageChapterTitleFE7Descriptor());
             }
 
             // EDSensekiCommentForm.MakeAllDataLength — called in the WF version==7 AND version==6
@@ -2022,6 +2427,28 @@ namespace FEBuilderGBA
             return l;
         }
 
+        /// <summary>The <c>ImageChapterTitleFE7Form.MakeAllDataLength</c> descriptor (slice 2e), shared
+        /// by the FE7 (multibyte-gated) and FE6 (unconditional) branches: block 4, base
+        /// <c>image_chapter_title_pointer</c>, IsDataExists = <c>isPointer(u32+0)</c>
+        /// (<see cref="DataCountRule.PointerAt"/> @0), pointerIndexes {0}, one LZ77IMG column at 0.
+        /// (Distinct from the FE8 <c>ImageChapterTitleForm</c>: block 12, THREE columns.)</summary>
+        static StructDescriptor MakeImageChapterTitleFE7Descriptor()
+        {
+            return new StructDescriptor
+            {
+                Name = "ChapterTitleImage",
+                PointerField = r => r.RomInfo.image_chapter_title_pointer,
+                BlockSize = 4,
+                Rule = DataCountRule.PointerAt,
+                RuleOffset = 0,
+                PointerIndexes = new uint[] { 0 },
+                SubWalks = new List<SubWalk>
+                {
+                    new SubWalk { EmbeddedPointerOffset = 0, Kind = SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77IMG, Name = (r, i) => "ChapterTitleImage" + U.To0xHexString((uint)i) },
+                },
+            };
+        }
+
         /// <summary>
         /// The <c>MakeAllDataLength</c> statics from <c>U.MakeAllStructPointersList</c> /
         /// <c>U.AppendAllASMStructPointersList</c> that this slice does <b>not</b> yet port.
@@ -2056,12 +2483,36 @@ namespace FEBuilderGBA
                 //  so it has a headless config-file dependency, not ROM-derived data.)
                 "TextForm", "TextCharCodeForm", "OtherTextForm",
                 // images (LZ77/TSA length calc)
-                "ImageBattleAnimeForm", "ImageBattleBGForm", "ImageBattleTerrainForm", "ImageBGForm",
-                "ImageMagicFEditorForm", "ImageMagicCSACreatorForm", "ImageBattleScreenForm",
-                "ImageItemIconForm", "ImageUnitMoveIconFrom", "ImageUnitWaitIconFrom",
-                "ImageUnitPaletteForm", "ImageSystemIconForm", "ImageRomAnimeForm",
-                "ImageGenericEnemyPortraitForm", "ImageMapActionAnimationForm", "ImageTSAAnimeForm",
-                "ImageTSAAnime2Form", "ImageChapterTitleForm", "ImagePortraitForm", "ImageCGForm",
+                // (slice 2e ported the FLAT LZ77-image + palette forms whose every length is
+                //  LZ77.getCompressedSize (EOF-safe) or a CONSTANT palette/image size:
+                //    ImageBattleBGForm, ImageBattleTerrainForm, ImageUnitWaitIconFrom,
+                //    ImageUnitPaletteForm, ImageGenericEnemyPortraitForm, ImageChapterTitleForm [FE8]
+                //    + ImageChapterTitleFE7Form [FE7-multibyte/FE6] (StructDescriptor + Lz77Pointer/
+                //    FixedPointer SubWalks); ImageBattleScreenForm, WorldMapImageFE6Form [FE6],
+                //    WorldMapImageFE7Form [FE7] (dedicated flat emitters). The FE8 WorldMapImageForm
+                //    STAYS (AddHeaderTSAPointer + AddROMTCSPointer — both ImageUtil-backed, not in Core).
+                //  The rest STAY, each blocked on a subsystem not yet in Core (a wrong length relocates
+                //  the wrong bytes = silent corruption):
+                //    ImageBGForm/ImageCGForm/ImageSystemIconForm/ImageTSAAnime2Form/WorldMapImageForm —
+                //      AddHeaderTSAPointer (ImageUtil.CalcByteLengthForHeaderTSAData).
+                //    ImageMagicFEditorForm/ImageMagicCSACreatorForm/ImageMapActionAnimationForm —
+                //      ImageUtil*.RecycleOldAnime (ImageUtil anime length helpers).
+                //    ImageBattleAnimeForm — ImageUtilOAM.MakeAllDataLength (LZ77-embedded OAM pointers).
+                //    ImageUnitMoveIconFrom — AddAPPointer (ImageUtilAP.CalcAPLength).
+                //    ImageRomAnimeForm/ImageTSAAnimeForm — config-file tables (U.ConfigDataFilename
+                //      "romanime_"/"tsaanime_") + dynamic pointer-list frame walks, not RomInfo slots.
+                //    ImagePortraitForm — IsHalfBodyFlag runtime header inspection (+ ImagePortraitFE6Form
+                //      has a stateful nullContinuousCount terminator + GetFEditorLengthHint).
+                //    ImageItemIconForm — out of slice scope: a flat 128-byte icon-SHEET IFR (no LZ77
+                //      image / palette to relocate) whose count rule reads a hardcoded FE7U magic addr.
+                //    MapMiniMapTerrainImageForm — InputFormRef_ASM + AddFunctions, called from the
+                //      AppendAllASMStructPointersList ASM path, not this producer's data path.)
+                "ImageBattleAnimeForm", "ImageBGForm",
+                "ImageMagicFEditorForm", "ImageMagicCSACreatorForm",
+                "ImageItemIconForm", "ImageUnitMoveIconFrom",
+                "ImageSystemIconForm", "ImageRomAnimeForm",
+                "ImageMapActionAnimationForm", "ImageTSAAnimeForm",
+                "ImageTSAAnime2Form", "ImagePortraitForm", "ImageCGForm",
                 "MapMiniMapTerrainImageForm", "WorldMapImageForm",
                 // songs / sound (recycle, embedded inst)
                 // (SoundRoomCGForm [FE7, clean u32-FFFFFFFF table], SoundRoomFE6Form [FE6, clean],


### PR DESCRIPTION
## Summary
**Slice 2e** of #1261 — the **flat LZ77-image + palette** producer forms. These emit `AddLZ77Pointer`/`AddAddress` for an LZ77-compressed image (length = `LZ77.getCompressedSize`) + fixed-size palettes. `getCompressedSize`/`getUncompressSize` are already fully EOF-safe in Core (return 0 on any malformed/near-EOF/wrong-header stream, never throw), so the image-length path is robust by construction.

## New machinery
- **`SubKind.Lz77Pointer`** — at an embedded pointer offset, emits an LZ77IMG/LZ77 `Address` whose length is `LZ77.getCompressedSize(rom.Data, p32(off))`.
- **`SubKind.FixedPointer`** — embedded pointer → fixed-size `Address` (palettes, const-size images).
- **`EmitMainIfr=false`** descriptor flag + 3 new `DataCountRule`s (`TwoU32PointerAt04`, `WaitIconRule`, `UnitPaletteRule`) for the forms whose count/header shape isn't a plain IFR block.
- Dedicated flat emitters (no IFR loop) for `ImageBattleScreenForm`, `WorldMapImageFE6Form`, `WorldMapImageFE7Form`.

## Ported (10 WF forms — VERBATIM slot/length/DataType/name/order, FE6/FE7/FE8 gated to match `U.MakeAllStructPointersList`)
`ImageBattleBGForm`, `ImageBattleTerrainForm`, `ImageUnitWaitIconFrom`, `ImageUnitPaletteForm`, `ImageGenericEnemyPortraitForm`, `ImageBattleScreenForm`, `ImageChapterTitleForm` [FE8], `ImageChapterTitleFE7Form` [FE7-**multibyte** + FE6], `WorldMapImageFE6Form` [FE6], `WorldMapImageFE7Form` [FE7].

**Version-gating audit (corruption-critical):** ChapterTitle is FE8→`ImageChapterTitleForm`; FE7→`ImageChapterTitleFE7Form` **only inside `if (is_multibyte)`** (FE7U emits none); FE6→unconditional. Reproduced exactly (FE7 gated on `is_multibyte`, FE6 unconditional, documented).

## Deferred (reason-tagged in `NotYetPortedRaw` — each needs an un-ported subsystem; a wrong length = corruption)
- **`ImageUtil.CalcByteLengthForHeaderTSAData`** (TSA, not in Core): ImageBG/CG/CGFE7U/SystemIcon/TSAAnime2, WorldMapImage[FE8].
- **`ImageUtil*.RecycleOldAnime`**: ImageMagicFEditor/MagicCSACreator/MapActionAnimation. **`ImageUtilOAM`**: ImageBattleAnime. **`ImageUtilAP.CalcAPLength`**: ImageUnitMoveIcon.
- **config-file tables** (`U.ConfigDataFilename`): ImageTSAAnime (g_TSAAnime is config-populated — *looks* flat, caught it), ImageRomAnime.
- **runtime header / stateful Init**: ImagePortrait (IsHalfBodyFlag), ImagePortraitFE6 (stateful nullContinuousCount). **ASM path**: MapMiniMapTerrainImage. **out of slice scope**: ImageItemIcon (icon-sheet IFR + FE7U magic-addr count).

## Tests
- RebuildProducer filter: **86 passed / 0 failed** (+17): the new SubKind/rule machinery; version-gated descriptor presence FE6/FE7/FE8; dedicated-emitter faithfulness with planted LZ77 streams (hand-authored all-literal stream asserts `getCompressedSize` == authored length); **near-EOF malformed stream → length 0, no throw** (`Record.Exception` null); NotYetPorted coverage.
- FEBuilderGBA.Tests (net9.0-windows): **1865 passed / 0 failed**.
- (Full Core.Tests: the only failures are the known env-only `Skill*`/`SkillSystemsAnime*` tests — `config/patch2` submodule not checked out in the worktree; they pass in CI. Zero RebuildProducer failures.)

Part of #1261.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
