### PR TITLE
feat(core): ROM-rebuild producer — AI/Arena/Mant/ItemUsage/UnitFE6 forms (#1261 slice 2f)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -1697,11 +1697,13 @@ namespace FEBuilderGBA.Core.Tests
             // Still deferred (un-ported subsystem) -> must REMAIN:
             foreach (var kept in new[]
             {
-                "UnitFE6Form", "EventBattleTalkForm", "EventHaikuForm", "SupportUnitForm",
+                "EventBattleTalkForm", "EventHaikuForm", "SupportUnitForm",
                 "WorldMapPathForm", "WorldMapEventPointerForm", "EDStaffRollForm", "OPPrologueForm",
                 "MapSettingForm", "OPClassFontForm", "OPClassDemoForm", "FE8SpellMenuExtendsForm",
                 "MonsterWMapProbabilityForm", "SoundRoomForm",
-                // (StatusOptionForm + SoundFootStepsForm ported in slice 2d -> no longer kept here.)
+                // (StatusOptionForm + SoundFootStepsForm ported in slice 2d -> no longer kept here.
+                //  UnitFE6Form + ItemUsagePointerForm + AIPerform*/AIMapSetting/Mant/ArenaEnemyWeapon
+                //  ported in slice 2f -> no longer kept here.)
                 "ItemForm", "MapTileAnimation1Form", "MapTerrainFloorLookupTableForm",
             })
             {
@@ -3053,6 +3055,418 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Contains("WorldMapImageForm", ported); // the FE8 form stays (AddHeaderTSAPointer)
             Assert.Contains("ImageItemIconForm", ported);
             Assert.Contains("ImageTSAAnimeForm", ported);
+        }
+
+        // ===================================================================
+        // slice 2f: AI / Arena / Mant flat descriptors + ItemUsage / UnitFE6
+        // dedicated emitters.
+        // ===================================================================
+
+        // ---- AIMapSetting / AIPerformStaff / AIPerformItem / Mant / Arena descriptors ----
+
+        [Fact]
+        public void BuildBatchDescriptors_HasAIMapSetting_FlatU8NotEqualFF()
+        {
+            // AIMapSettingForm: base ai_map_setting_pointer, block 4, u8!=0xFF, pointerIndexes {},
+            // no sub-walk. Version-agnostic (called unconditionally in WF).
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                var descs = RebuildProducerCore.BuildBatchDescriptors(fe8);
+                var d = descs.Single(x => x.Name == "AIMapSetting");
+                Assert.Equal(4u, d.BlockSize);
+                Assert.Equal(RebuildProducerCore.DataCountRule.U8NotEqual, d.Rule);
+                Assert.Equal(0u, d.RuleOffset);
+                Assert.Equal(0xFFu, d.RuleStopValue);
+                Assert.Equal(new uint[] { }, d.PointerIndexes);
+                Assert.Null(d.SubWalks);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void BuildBatchDescriptors_HasAIPerformStaffAndItem_WithAsmFunctionSubWalkAt4()
+        {
+            // AIPerformStaff/AIPerformItem: block 8, u16!=0, pointerIndexes {4}, + AsmFunction sub-walk
+            // @4 (WF AddFunctions(MakeList(), 4, ...)). Version-agnostic.
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                var descs = RebuildProducerCore.BuildBatchDescriptors(fe8);
+
+                foreach (string name in new[] { "AIPerformStaff", "AIPerformItem" })
+                {
+                    var d = descs.Single(x => x.Name == name);
+                    Assert.Equal(8u, d.BlockSize);
+                    Assert.Equal(RebuildProducerCore.DataCountRule.U16NotZero, d.Rule);
+                    Assert.Equal(new uint[] { 4 }, d.PointerIndexes);
+                    Assert.NotNull(d.SubWalks);
+                    var sw = d.SubWalks.Single();
+                    Assert.Equal(4u, sw.EmbeddedPointerOffset);
+                    Assert.Equal(RebuildProducerCore.SubKind.AsmFunction, sw.Kind);
+                }
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void BuildBatchDescriptors_HasMant_PointerAt0_WithFixedPointer0x10SubWalk()
+        {
+            // MantAnimationForm: block 4, PointerAt @0, pointerIndexes {0}, + FixedPointer sub-walk @0
+            // (0x10-byte POINTER block). Version-agnostic.
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                var descs = RebuildProducerCore.BuildBatchDescriptors(fe8);
+                var d = descs.Single(x => x.Name == "Mant");
+                Assert.Equal(4u, d.BlockSize);
+                Assert.Equal(RebuildProducerCore.DataCountRule.PointerAt, d.Rule);
+                Assert.Equal(0u, d.RuleOffset);
+                Assert.Equal(new uint[] { 0 }, d.PointerIndexes);
+                var sw = d.SubWalks.Single();
+                Assert.Equal(0u, sw.EmbeddedPointerOffset);
+                Assert.Equal(RebuildProducerCore.SubKind.FixedPointer, sw.Kind);
+                Assert.Equal(0x10u, sw.FixedLength);
+                Assert.Equal(Address.DataTypeEnum.POINTER, sw.DataType);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void BuildBatchDescriptors_HasArenaEnemyWeapon_EmittedTwice_BothBasic()
+        {
+            // VERBATIM QUIRK: WF ArenaEnemyWeaponForm.MakeAllDataLength emits the descriptor TWICE,
+            // and BOTH read the BASIC table (Init(null), i<8) — the second is a copy/paste of the
+            // basic, NOT the rankup table. So there must be EXACTLY 2 identical "ArenaEnemyWeapon"
+            // descriptors, both FixedCount=8 on arena_enemy_weapon_basic_pointer.
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                var descs = RebuildProducerCore.BuildBatchDescriptors(fe8);
+                var arena = descs.Where(x => x.Name == "ArenaEnemyWeapon").ToList();
+                Assert.Equal(2, arena.Count);
+                Assert.All(arena, d =>
+                {
+                    Assert.Equal(1u, d.BlockSize);
+                    Assert.Equal(RebuildProducerCore.DataCountRule.FixedCount, d.Rule);
+                    Assert.Equal(8u, d.RuleFixedCount);
+                    Assert.Equal(new uint[] { }, d.PointerIndexes);
+                });
+                // both resolve to the SAME basic pointer field (not the rankup pointer).
+                Assert.Equal(arena[0].PointerField(fe8), arena[1].PointerField(fe8));
+                Assert.Equal(fe8.RomInfo.arena_enemy_weapon_basic_pointer, arena[0].PointerField(fe8));
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void WalkAndAdd_AIPerformStaffShape_EmitsMainPlusAsmFunctionPerEntry()
+        {
+            // Synthetic: base block 8, u16!=0 terminator, AsmFunction @4. 2 valid entries -> main IFR
+            // (length 8*(2+1)=24) + 2 ASM blocks at ProgramAddrToPlain(u32(p+4)).
+            var rom = CreateTestRom();
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            const uint block = 8;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u16(table + block * 0, 0x0001); // entry 0 valid (u16!=0)
+            rom.write_u16(table + block * 1, 0x0002); // entry 1 valid
+            rom.write_u16(table + block * 2, 0x0000); // entry 2 -> stop
+            uint asm0 = 0x2000, asm1 = 0x2100;
+            rom.write_u32(table + block * 0 + 4, Ptr(asm0) | 1); // thumb bit
+            rom.write_u32(table + block * 1 + 4, Ptr(asm1) | 1);
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "AIPerformStaff",
+                PointerField = _ => pointer,
+                BlockSize = block,
+                Rule = RebuildProducerCore.DataCountRule.U16NotZero,
+                RuleOffset = 0,
+                PointerIndexes = new uint[] { 4 },
+                SubWalks = new List<RebuildProducerCore.SubWalk>
+                {
+                    new RebuildProducerCore.SubWalk { EmbeddedPointerOffset = 4, Kind = RebuildProducerCore.SubKind.AsmFunction, Name = (r, i) => "AIPerformStaff_ASM_" },
+                },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            Address main = list.Single(a => a.DataType == Address.DataTypeEnum.InputFormRef);
+            Assert.Equal(table, main.Addr);
+            Assert.Equal(24u, main.Length); // 8*(2+1)
+            Assert.Equal(new uint[] { 4 }, main.PointerIndexes);
+
+            var asms = list.Where(a => a.DataType == Address.DataTypeEnum.ASM).ToList();
+            Assert.Equal(2, asms.Count);
+            Assert.Contains(asms, a => a.Addr == asm0); // thumb bit cleared by ProgramAddrToPlain
+            Assert.Contains(asms, a => a.Addr == asm1);
+            Assert.All(asms, a => Assert.Equal(0u, a.Length));
+        }
+
+        [Fact]
+        public void WalkAndAdd_MantShape_EmitsFixedPointer0x10BehindEachEntry()
+        {
+            // Synthetic: base block 4, PointerAt @0, FixedPointer @0 (0x10 POINTER). 2 valid entries.
+            var rom = CreateTestRom();
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            const uint block = 4;
+            rom.write_u32(pointer, Ptr(table));
+            uint t0 = 0x2000, t1 = 0x2100;
+            rom.write_u32(table + block * 0, Ptr(t0)); // entry 0: valid pointer
+            rom.write_u32(table + block * 1, Ptr(t1)); // entry 1: valid pointer
+            rom.write_u32(table + block * 2, 0);       // entry 2: NULL -> PointerAt stops
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "Mant",
+                PointerField = _ => pointer,
+                BlockSize = block,
+                Rule = RebuildProducerCore.DataCountRule.PointerAt,
+                RuleOffset = 0,
+                PointerIndexes = new uint[] { 0 },
+                SubWalks = new List<RebuildProducerCore.SubWalk>
+                {
+                    new RebuildProducerCore.SubWalk { EmbeddedPointerOffset = 0, Kind = RebuildProducerCore.SubKind.FixedPointer, FixedLength = 0x10, DataType = Address.DataTypeEnum.POINTER, Name = (r, i) => "MANT_P:" + U.To0xHexString((int)i) },
+                },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            // main IFR + 2 POINTER sub-blocks of 0x10 bytes each.
+            var ptrs = list.Where(a => a.DataType == Address.DataTypeEnum.POINTER).ToList();
+            Assert.Equal(2, ptrs.Count);
+            Address p0 = ptrs.Single(a => a.Addr == t0);
+            Assert.Equal(0x10u, p0.Length);
+            Assert.Equal(table + block * 0, p0.Pointer);
+            Address p1 = ptrs.Single(a => a.Addr == t1);
+            Assert.Equal(0x10u, p1.Length);
+            Assert.Equal(table + block * 1, p1.Pointer);
+        }
+
+        // ---- EmitItemUsagePointerTables (Switch2-gated dedicated walker) ----
+
+        // Build a single-usage table array with an explicit pointer + switch2 address.
+        static RebuildProducerCore.ItemUsageTable[] OneUsageTable(uint pointer, uint switch2Addr, string name)
+        {
+            return new[]
+            {
+                new RebuildProducerCore.ItemUsageTable
+                {
+                    Pointer = _ => pointer,
+                    Switch2Address = _ => switch2Addr,
+                    Name = name,
+                },
+            };
+        }
+
+        [Fact]
+        public void EmitItemUsagePointer_Switch2Enabled_EmitsMainAsmIfrPlusAsmPerEntry()
+        {
+            // Switch2 enabled, count byte = 2 -> DataCount = 3. Main InputFormRef_ASM Address
+            // (length 4*(3+1)=16, pointer = the RomInfo slot, pointerIndexes {0}) + 3 ASM AddFunctions
+            // at offset 0 (the entry block address itself).
+            var rom = CreateTestRom(0x8000);
+            uint switch2Addr = 0x0300;
+            uint pointer = 0x0400; // the usage data-pointer slot
+            uint table = 0x1000;   // base = p32(pointer)
+            PlantSwitch2(rom, switch2Addr, count: 2); // DataCount = count + 1 = 3
+            rom.write_u32(pointer, Ptr(table));
+            uint a0 = 0x2000, a1 = 0x2100, a2 = 0x2200;
+            rom.write_u32(table + 0, Ptr(a0) | 1);
+            rom.write_u32(table + 4, Ptr(a1) | 1);
+            rom.write_u32(table + 8, Ptr(a2) | 1);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitItemUsagePointerTables(rom, list, OneUsageTable(pointer, switch2Addr, "ItemUsageP0"));
+
+            Address main = list.Single(a => a.DataType == Address.DataTypeEnum.InputFormRef_ASM);
+            Assert.Equal(table, main.Addr);
+            // BasePointer IS the RomInfo slot here (safe offset), unlike SoundFootSteps (NOT_FOUND).
+            Assert.Equal(pointer, main.Pointer);
+            Assert.Equal(4u, main.BlockSize);
+            Assert.Equal(16u, main.Length); // 4*(3+1)
+            Assert.Equal(new uint[] { 0 }, main.PointerIndexes);
+
+            var asms = list.Where(a => a.DataType == Address.DataTypeEnum.ASM).ToList();
+            Assert.Equal(3, asms.Count);
+            Assert.Contains(asms, a => a.Addr == a0);
+            Assert.Contains(asms, a => a.Addr == a1);
+            Assert.Contains(asms, a => a.Addr == a2);
+        }
+
+        [Fact]
+        public void EmitItemUsagePointer_Switch2Disabled_EmitsNothingForThatUsage()
+        {
+            // WF ReInit returns NOT_FOUND (continue) when IsSwitch2Enable is false. An all-zero
+            // switch2 region (subOp/cmpOp out of range) is disabled.
+            var rom = CreateTestRom();
+            uint switch2Addr = 0x0300;
+            uint pointer = 0x0400;
+            uint table = 0x1000;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u32(table + 0, Ptr(0x2000) | 1);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitItemUsagePointerTables(rom, list, OneUsageTable(pointer, switch2Addr, "ItemUsageP0"));
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitItemUsagePointer_CountRunsPastEof_TruncatesWithoutThrowing()
+        {
+            // A corrupted/too-large count near EOF must TRUNCATE (like WF MakeList breaking on
+            // addr + BlockSize > Data.Length), NOT throw (AddFunction's u32 read would throw past EOF).
+            uint size = 0x2000;
+            var rom = CreateTestRom((int)size);
+            uint switch2Addr = 0x0300;
+            uint pointer = 0x0400;
+            uint table = size - 8; // 0x1FF8 — exactly 2 of the 4-byte entries fit before EOF.
+            PlantSwitch2(rom, switch2Addr, count: 5); // claims 6 entries; only 2 fit
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u32(table + 0, Ptr(0x1000) | 1);
+            rom.write_u32(table + 4, Ptr(0x1100) | 1);
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.EmitItemUsagePointerTables(rom, list, OneUsageTable(pointer, switch2Addr, "ItemUsageP0")));
+            Assert.Null(ex);
+
+            // main IFR still emitted; only the 2 in-bounds entries become ASM (the rest truncated).
+            Assert.Single(list, a => a.DataType == Address.DataTypeEnum.InputFormRef_ASM);
+            var asms = list.Where(a => a.DataType == Address.DataTypeEnum.ASM).ToList();
+            Assert.Equal(2, asms.Count);
+        }
+
+        [Fact]
+        public void EmitItemUsagePointer_AllTenUsages_PresentInRomInfoDrivenPath()
+        {
+            // The public RomInfo-driven EmitItemUsagePointer must not throw on a real RomInfo (FE8U).
+            // It is gated per-usage on IsSwitch2Enable; on an all-zero 32MB fake ROM none are enabled,
+            // so it emits nothing — but it must run cleanly (no NRE / no throw).
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitItemUsagePointer(fe8, list));
+                Assert.Null(ex);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        // ---- EmitUnitFE6At (FE6-only dynamic-base dedicated walker) ----
+
+        [Fact]
+        public void EmitUnitFE6At_BaseIsOneBlockPastTableStart_PointerIsNotFound()
+        {
+            // WF UnitFE6Form: base = p32(unit_pointer) + unit_datasize (skip unit 0), BasePointer 0 ->
+            // NOT_FOUND, i < unit_maxcount, pointerIndexes {44}.
+            var rom = CreateTestRom(0x8000);
+            uint unitPointerSlot = 0x0400;
+            uint tableStart = 0x1000;
+            const uint block = 0x34; // unit_datasize (> 44 so offset 44 fits)
+            const uint maxcount = 3;
+            rom.write_u32(unitPointerSlot, Ptr(tableStart));
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitUnitFE6At(rom, list, unitPointerSlot, block, maxcount);
+
+            Address main = list.Single();
+            // base = tableStart + block (one block past), pointer = NOT_FOUND.
+            Assert.Equal(tableStart + block, main.Addr);
+            Assert.Equal(U.NOT_FOUND, main.Pointer);
+            Assert.Equal(block, main.BlockSize);
+            // length = block * (DataCount + 1); DataCount = maxcount (i < maxcount).
+            Assert.Equal(block * (maxcount + 1), main.Length);
+            Assert.Equal(new uint[] { 44 }, main.PointerIndexes);
+            Assert.Equal(Address.DataTypeEnum.InputFormRef, main.DataType);
+        }
+
+        [Fact]
+        public void EmitUnitFE6At_ZeroBlock_EmitsNothing_AndDoesNotHang()
+        {
+            var rom = CreateTestRom();
+            uint unitPointerSlot = 0x0400;
+            rom.write_u32(unitPointerSlot, Ptr(0x1000));
+            var list = new List<Address>();
+            RebuildProducerCore.EmitUnitFE6At(rom, list, unitPointerSlot, block: 0, maxcount: 5);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitUnitFE6At_UnsafeBase_EmitsNothing_NoThrow()
+        {
+            // If p32(unit_pointer)+block is not a safe offset, WF's ReInit -> AddAddress early-returns.
+            var rom = CreateTestRom(0x2000);
+            uint unitPointerSlot = 0x0400;
+            // table start points past EOF -> base unsafe.
+            rom.write_u32(unitPointerSlot, Ptr(0x1FFF0));
+            var list = new List<Address>();
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.EmitUnitFE6At(rom, list, unitPointerSlot, block: 0x34, maxcount: 3));
+            Assert.Null(ex);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitUnitFE6_FE6_RunsCleanly_FE8UDoesNotEmitUnitViaThisPath()
+        {
+            // The public RomInfo-driven EmitUnitFE6 reads unit_pointer/unit_datasize/unit_maxcount.
+            // On a fake all-zero FE6 ROM it must run without throwing (base resolves to a zero region).
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe6 = MakeVersionedRom("AFEJ01");
+                CoreState.ROM = fe6;
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitUnitFE6(fe6, list));
+                Assert.Null(ex);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        // ---- NotYetPorted coverage delta for slice 2f ----
+
+        [Fact]
+        public void GetNotYetPortedForms_DropsSlice2fCoveredForms_KeepsDeferredSiblings()
+        {
+            string[] ported = RebuildProducerCore.GetNotYetPortedForms();
+
+            // slice 2f ported these 7 — no longer in the deferred list:
+            Assert.DoesNotContain("AIMapSettingForm", ported);
+            Assert.DoesNotContain("AIPerformStaffForm", ported);
+            Assert.DoesNotContain("AIPerformItemForm", ported);
+            Assert.DoesNotContain("MantAnimationForm", ported);
+            Assert.DoesNotContain("ArenaEnemyWeaponForm", ported);
+            Assert.DoesNotContain("ItemUsagePointerForm", ported);
+            Assert.DoesNotContain("UnitFE6Form", ported);
+
+            // deferred siblings STAY (their blocking subsystem is not in Core):
+            Assert.Contains("AIScriptForm", ported);              // AI bytecode CalcLength + nested LZ77
+            Assert.Contains("UnitActionPointerForm", ported);     // PatchUtil SearchUnitActionReworkPatch
+            Assert.Contains("MonsterWMapProbabilityForm", ported);// EventScriptForm.ScanScript skirmish
+            Assert.Contains("MapChangeForm", ported);             // deferred for slice size (map-PLIST)
+            Assert.Contains("MapExitPointForm", ported);          // deferred for slice size (map-PLIST)
+            Assert.Contains("MapTileAnimation1Form", ported);     // deferred for slice size (map-PLIST)
+            Assert.Contains("MapTileAnimation2Form", ported);     // deferred for slice size (map-PLIST)
+            Assert.Contains("ItemShopForm", ported);              // deferred for slice size (map-PLIST)
+            Assert.Contains("EventCondForm", ported);             // EventScriptForm.ScanScript
+            // and the no-duplicates invariant still holds after the edits.
+            string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
+            Assert.Equal(raw.Length, raw.Distinct().Count());
         }
     }
 }

--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -3350,6 +3350,25 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void EmitItemUsagePointer_PointerSlotNearEof_SkipsWithoutThrowing()
+        {
+            // Regression (PR #1278 review): a usage data-pointer SLOT whose 4 bytes straddle EOF must
+            // skip, not throw. isSafetyOffset(pointer) alone passes (pointer < Len) but p32(pointer)
+            // reads pointer..pointer+3 -> u32 -> check_safety throws. The pointer+3 guard skips it.
+            uint size = 0x2000;
+            var rom = CreateTestRom((int)size);
+            uint switch2Addr = 0x0300;
+            uint pointerNearEof = size - 2; // 0x1FFE: < Len (old guard passes) but pointer+3 = 0x2001 > Len
+            PlantSwitch2(rom, switch2Addr, count: 2); // Switch2 enabled so we reach the pointer guard
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.EmitItemUsagePointerTables(rom, list, OneUsageTable(pointerNearEof, switch2Addr, "ItemUsageP0")));
+            Assert.Null(ex);
+            Assert.Empty(list); // pointer slot straddles EOF -> usage skipped
+        }
+
+        [Fact]
         public void EmitItemUsagePointer_AllTenUsages_PresentInRomInfoDrivenPath()
         {
             // The public RomInfo-driven EmitItemUsagePointer must not throw on a real RomInfo (FE8U).

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -450,6 +450,20 @@ namespace FEBuilderGBA
             progress?.Report("ImageBattleScreen");
             EmitImageBattleScreen(rom, list);
 
+            // ---- slice 2f: ItemUsagePointerForm (version-agnostic) ----
+            // ItemUsagePointerForm.MakeAllDataLength is NOT a flat descriptor walk: it loops the 10
+            // usage tables, each Switch2-gated with its base/count read from a RomInfo *address* (the
+            // count is u8(switch2_address+2), the base is p32(usage_pointer)), then emits a main
+            // InputFormRef_ASM Address + one ASM AddFunction per entry. A dedicated walker reproduces it
+            // verbatim (its own cancel-check mirrors the WF DoEvents posture).
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("ItemUsagePointer");
+            EmitItemUsagePointer(rom, list);
+
             if (rom.RomInfo.version == 7)
             {
                 if (ct.IsCancellationRequested)
@@ -469,6 +483,19 @@ namespace FEBuilderGBA
                 }
                 progress?.Report("WorldMapImageFE6");
                 EmitWorldMapImageFE6(rom, list);
+
+                // ---- slice 2f: UnitFE6Form (FE6-only) ----
+                // UnitFE6Form.MakeAllDataLength is FE6-only (the WF version==6 branch). Its IFR base is
+                // p32(unit_pointer)+unit_datasize (one block past the table start — class 0 is skipped via
+                // a direct ReInit), and its BasePointer is 0 (-> NOT_FOUND). The pointer-slot descriptor
+                // model assumes baseAddr = p32(PointerField), so this needs a dedicated emitter.
+                if (ct.IsCancellationRequested)
+                {
+                    progress?.Report("MakeAllStructPointersList cancelled");
+                    return new ProducerResult(list, notYet, cancelled: true);
+                }
+                progress?.Report("UnitFE6");
+                EmitUnitFE6(rom, list);
             }
 
             // Surface — never silently drop — the statics this slice does not yet cover.
@@ -1187,6 +1214,176 @@ namespace FEBuilderGBA
             Address.AddPointer(list, rom.RomInfo.worldmap_event_palette_pointer, 0x20 * 4, "worldmap_event_palette", Address.DataTypeEnum.PAL);
         }
 
+        /// <summary>One ItemUsage usage-table descriptor (the 10 Switch2-gated usage arrays). Captures
+        /// the WF <c>ReInit(n, ...)</c> case verbatim: the RomInfo data pointer, the Switch2 enable/count
+        /// address, and the WF Info name "ItemUsageP&lt;n&gt;". Public so a synthetic-ROM test can supply
+        /// explicit addresses (the RomInfo fields are not settable in tests).</summary>
+        public sealed class ItemUsageTable
+        {
+            public Func<ROM, uint> Pointer;
+            public Func<ROM, uint> Switch2Address;
+            public string Name;
+        }
+
+        /// <summary>
+        /// <c>ItemUsagePointerForm.MakeAllDataLength</c> (slice 2f). NOT a flat RomInfo pointer-slot
+        /// table: the WF <c>MakeAllDataLength</c> loops the 10 usage tables, each re-initialized by
+        /// <c>ReInit(n, ifr)</c> which derives its base + count from a Switch2-gated RomInfo *address*.
+        /// Reproduced VERBATIM per usage <c>n</c>:
+        /// <list type="bullet">
+        ///   <item>pointer = <c>usage_pointer</c>; addr = <c>p32(pointer)</c>; count = <c>u8(switch2_address+2)</c>;</item>
+        ///   <item>GATE: only if <c>IsSwitch2Enable(switch2_address)</c> AND <c>isSafetyOffset(addr)</c>
+        ///   (else WF's <c>ReInit</c> returns <c>NOT_FOUND</c> and <c>MakeAllDataLength</c> <c>continue</c>s
+        ///   — emits nothing for that usage);</item>
+        ///   <item><c>ReInitPointer(pointer, count + 1)</c> sets BasePointer = pointer, BaseAddress =
+        ///   p32(pointer), DataCount = <c>count + 1</c> (the count is set EXPLICITLY here, NOT via a
+        ///   getBlockDataCount walk — the IFR's IsDataExists returns false);</item>
+        ///   <item>main IFR Address: <c>AddAddress(ifr, "ItemUsageP"+n, {0}, InputFormRef_ASM)</c> -&gt;
+        ///   length = block(4) × (DataCount + 1) = 4 × (count + 2), pointer = BasePointer;</item>
+        ///   <item>then <c>AddFunctions(MakeList(), 0, " ItemUsageP"+n)</c>: one ASM AddFunction per entry
+        ///   at offset 0 (block address itself), bounded by <c>MakeList()</c>'s EOF cutoff.</item>
+        /// </list>
+        /// The Switch2 enable byte-pattern + the count read are pure ROM reads
+        /// (<see cref="ItemUsagePointerCore.IsSwitch2Enable"/>), so this is faithfully headless. The WF
+        /// per-entry ASM label is the IFR display name + " ItemUsageP&lt;n&gt;"; a static label is used
+        /// here (non-load-bearing for relocation, same convention as the other AsmFunction sub-walks).
+        /// </summary>
+        public static void EmitItemUsagePointer(ROM rom, List<Address> list)
+        {
+            // The 10 usage tables in WF ReInit case order (0..9). Each is a RomInfo data pointer + a
+            // RomInfo Switch2 address; the WF "config file" reads in ReInit are GUI-only (the combo box)
+            // and do NOT affect the produced Address list, so they are intentionally omitted here.
+            ItemUsageTable[] tables = new ItemUsageTable[]
+            {
+                new ItemUsageTable { Pointer = r => r.RomInfo.item_usability_array_pointer,    Switch2Address = r => r.RomInfo.item_usability_array_switch2_address,    Name = "ItemUsageP0" },
+                new ItemUsageTable { Pointer = r => r.RomInfo.item_effect_array_pointer,       Switch2Address = r => r.RomInfo.item_effect_array_switch2_address,       Name = "ItemUsageP1" },
+                new ItemUsageTable { Pointer = r => r.RomInfo.item_promotion1_array_pointer,   Switch2Address = r => r.RomInfo.item_promotion1_array_switch2_address,   Name = "ItemUsageP2" },
+                new ItemUsageTable { Pointer = r => r.RomInfo.item_promotion2_array_pointer,   Switch2Address = r => r.RomInfo.item_promotion2_array_switch2_address,   Name = "ItemUsageP3" },
+                new ItemUsageTable { Pointer = r => r.RomInfo.item_staff1_array_pointer,       Switch2Address = r => r.RomInfo.item_staff1_array_switch2_address,       Name = "ItemUsageP4" },
+                new ItemUsageTable { Pointer = r => r.RomInfo.item_staff2_array_pointer,       Switch2Address = r => r.RomInfo.item_staff2_array_switch2_address,       Name = "ItemUsageP5" },
+                new ItemUsageTable { Pointer = r => r.RomInfo.item_statbooster1_array_pointer, Switch2Address = r => r.RomInfo.item_statbooster1_array_switch2_address, Name = "ItemUsageP6" },
+                new ItemUsageTable { Pointer = r => r.RomInfo.item_statbooster2_array_pointer, Switch2Address = r => r.RomInfo.item_statbooster2_array_switch2_address, Name = "ItemUsageP7" },
+                new ItemUsageTable { Pointer = r => r.RomInfo.item_errormessage_array_pointer, Switch2Address = r => r.RomInfo.item_errormessage_array_switch2_address, Name = "ItemUsageP8" },
+                new ItemUsageTable { Pointer = r => r.RomInfo.item_name_article_pointer,       Switch2Address = r => r.RomInfo.item_name_article_switch2_address,       Name = "ItemUsageP9" },
+            };
+            EmitItemUsagePointerTables(rom, list, tables);
+        }
+
+        /// <summary>ItemUsagePointer walk from an explicit set of usage tables (test seam — lets a
+        /// synthetic ROM supply the pointer/switch2 addresses without populating RomInfo, which has no
+        /// public setters). See <see cref="EmitItemUsagePointer"/> for the verbatim WF reproduction.</summary>
+        public static void EmitItemUsagePointerTables(ROM rom, List<Address> list, ItemUsageTable[] tables)
+        {
+            const uint block = 4;
+            foreach (ItemUsageTable t in tables)
+            {
+                uint switch2Addr = t.Switch2Address(rom);
+                // WF ReInit: enable-gate, then base-safety. Either failing => NOT_FOUND => continue.
+                if (!ItemUsagePointerCore.IsSwitch2Enable(rom, switch2Addr))
+                {
+                    continue;
+                }
+                uint pointer = U.toOffset(t.Pointer(rom));
+                if (!U.isSafetyOffset(pointer, rom))
+                {
+                    continue; // p32(pointer) below would read junk; WF's ReInitPointer->p32 needs a safe slot.
+                }
+                uint baseAddr = rom.p32(pointer);
+                // WF ReInit: !isSafetyOffset(addr) -> NOT_FOUND -> continue (no emit for this usage).
+                if (!U.isSafetyOffset(baseAddr, rom))
+                {
+                    continue;
+                }
+
+                // WF: count = u8(switch2_address + 2); ReInitPointer(pointer, count + 1) -> DataCount =
+                // count + 1 (set EXPLICITLY, not via getBlockDataCount). The +2 read is in-bounds because
+                // IsSwitch2Enable already validated the full switch2 opcode region at switch2Addr.
+                uint count = rom.u8(switch2Addr + 2);
+                uint dataCount = count + 1;
+
+                // Main IFR Address: AddAddress(ifr, name, {0}, InputFormRef_ASM) ->
+                // length = block * (DataCount + 1). BasePointer = the RomInfo pointer slot (safe here).
+                uint length = block * (dataCount + 1);
+                list.Add(new Address(baseAddr, length, pointer, t.Name,
+                    Address.DataTypeEnum.InputFormRef_ASM, block, new uint[] { 0 }));
+
+                // AddFunctions(MakeList(), 0, " " + name): one ASM AddFunction per entry at offset 0
+                // (the entry block address itself). MakeList() yields DataCount entries from baseAddr,
+                // stepping by block, with an EOF cutoff (addr + block > Data.Length -> stop). Mirror that
+                // bound exactly so a corrupted/too-large count near EOF truncates instead of throwing
+                // (AddFunction's u32 read check_safety would throw past EOF).
+                for (uint i = 0; i < dataCount; i++)
+                {
+                    uint entryAddr = baseAddr + i * block;
+                    if (entryAddr + block > (uint)rom.Data.Length)
+                    {
+                        break;
+                    }
+                    Address.AddFunction(list, entryAddr, " " + t.Name);
+                }
+            }
+        }
+
+        /// <summary>
+        /// <c>UnitFE6Form.MakeAllDataLength</c> (slice 2f, FE6 only). NOT a flat pointer-slot table: the
+        /// WF <c>Init</c> builds an IFR with BasePointer 0 and then <c>ReInit(p32(unit_pointer) +
+        /// unit_datasize)</c> sets BaseAddress DIRECTLY (one block past the table start — FE6 skips unit
+        /// 0). Reproduced VERBATIM:
+        /// <list type="bullet">
+        ///   <item>base = <c>p32(unit_pointer) + unit_datasize</c>; block = <c>unit_datasize</c>;
+        ///   IsDataExists = <c>i &lt; unit_maxcount</c> (FixedCount);</item>
+        ///   <item>BasePointer = 0 -&gt; <c>isSafetyOffset(0)</c> false -&gt; pointer slot = NOT_FOUND
+        ///   (the table is reached via the +unit_datasize computed base, NOT a plain RomInfo pointer
+        ///   slot, so its pointer FIELD is intentionally untracked — matching WF's AddAddress on a
+        ///   BasePointer-0 IFR);</item>
+        ///   <item>main IFR Address: <c>AddAddress(ifr, "Unit", {44})</c> -&gt; length =
+        ///   block × (DataCount + 1), type InputFormRef, pointerIndexes {44}.</item>
+        /// </list>
+        /// FLAT — no per-entry sub-walk (unlike the FE8 UnitForm's +44 support BinFixed). The per-entry
+        /// embedded pointer at offset 44 is tracked via pointerIndexes {44} on the main Address (its
+        /// target is relocated by the rebuild's pointer-index pass), exactly as the FE7 UnitFE7Form
+        /// descriptor does.
+        /// </summary>
+        public static void EmitUnitFE6(ROM rom, List<Address> list)
+        {
+            EmitUnitFE6At(rom, list, rom.RomInfo.unit_pointer, rom.RomInfo.unit_datasize,
+                rom.RomInfo.unit_maxcount);
+        }
+
+        /// <summary>UnitFE6 walk from explicit unit-pointer slot / block / maxcount (test seam — lets a
+        /// synthetic ROM supply them without populating RomInfo, which has no public setters). See
+        /// <see cref="EmitUnitFE6"/> for the verbatim WF reproduction.</summary>
+        public static void EmitUnitFE6At(ROM rom, List<Address> list, uint rawUnitPointer, uint block, uint maxcount)
+        {
+            if (block == 0)
+            {
+                return; // a zero block would make getBlockDataCount spin; not real data.
+            }
+
+            // WF Init: ifr.ReInit(p32(unit_pointer) + unit_datasize). Guard the full pointer slot
+            // before p32 (root+3) so a near-EOF unit_pointer slot skips instead of throwing.
+            uint unitPointerSlot = U.toOffset(rawUnitPointer);
+            if (!U.isSafetyOffset(unitPointerSlot + 3, rom))
+            {
+                return;
+            }
+            uint tableStart = rom.p32(unitPointerSlot);
+            // baseAddr = tableStart + one block (FE6 skips unit 0 via the +unit_datasize ReInit).
+            uint baseAddr = U.toOffset(tableStart + block);
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                return; // WF ReInit on an unsafe addr -> AddAddress early-returns (isSafetyOffset(addr) false).
+            }
+
+            uint dataCount = rom.getBlockDataCount(baseAddr, block, (i, addr) => i < maxcount);
+
+            // AddAddress(ifr, "Unit", {44}): length = block * (DataCount + 1); pointer = BasePointer = 0
+            // -> NOT_FOUND (the FE6 unit table's pointer slot is intentionally untracked).
+            uint length = block * (dataCount + 1);
+            list.Add(new Address(baseAddr, length, U.NOT_FOUND, "Unit",
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { 44 }));
+        }
+
         /// <summary>Turn a descriptor's <see cref="DataCountRule"/> into the
         /// <c>is_data_exists_callback</c> that <see cref="ROM.getBlockDataCount(uint,uint,Func{int,uint,bool})"/> expects.</summary>
         static Func<int, uint, bool> MakeIsDataExists(ROM rom, StructDescriptor d)
@@ -1545,6 +1742,102 @@ namespace FEBuilderGBA
                 RuleStopValue = 0xFF,
                 PointerIndexes = new uint[] { },
             });
+
+            // ---- slice 2f: version-agnostic AI / Arena-weapon / Mant flat forms ----
+            // These are called UNCONDITIONALLY in the WF MakeAllStructPointersList (between
+            // DoEvents checkpoints 3 and 4). Each is a pure RomInfo table walk whose count + every
+            // length is a pure ROM read (no Huffman/LZ77/disasm/PatchUtil/config-file), expressible
+            // with the existing descriptor + AsmFunction/FixedPointer SubWalk machinery.
+
+            // AIMapSettingForm.MakeAllDataLength — Info "AIMapSetting", block 4, base
+            // ai_map_setting_pointer, IsDataExists = u8(addr)!=0xFF (U8NotEqual @0), pointerIndexes {}.
+            // Flat — no per-entry sub-walk.
+            l.Add(new StructDescriptor
+            {
+                Name = "AIMapSetting",
+                PointerField = r => r.RomInfo.ai_map_setting_pointer,
+                BlockSize = 4,
+                Rule = DataCountRule.U8NotEqual,
+                RuleOffset = 0,
+                RuleStopValue = 0xFF,
+                PointerIndexes = new uint[] { },
+            });
+
+            // AIPerformStaffForm.MakeAllDataLength — Info "AIPerformStaff", block 8, base
+            // ai_preform_staff_pointer, IsDataExists = u16(addr)!=0 (U16NotZero @0), pointerIndexes {4}.
+            // PLUS Address.AddFunctions(MakeList(), 4, "AIPerformStaff_ASM_"): one ASM AddFunction per
+            // entry at offset 4. Reproduced as a SubKind.AsmFunction sub-walk @4 (reads u32(p+4),
+            // ProgramAddrToPlain, length-0 ASM block — extent at rebuild). The WF per-entry label is the
+            // IFR display name + "_ASM_"; the producer uses a static label (non-load-bearing for
+            // relocation, same convention as StatusOption/SoundFootSteps AsmFunction sub-walks).
+            // EOF-safe: getBlockDataCount guarantees p+8<=Length, so u32(p+4) (deepest p+7) is in bounds.
+            l.Add(new StructDescriptor
+            {
+                Name = "AIPerformStaff",
+                PointerField = r => r.RomInfo.ai_preform_staff_pointer,
+                BlockSize = 8,
+                Rule = DataCountRule.U16NotZero,
+                RuleOffset = 0,
+                PointerIndexes = new uint[] { 4 },
+                SubWalks = new List<SubWalk>
+                {
+                    new SubWalk { EmbeddedPointerOffset = 4, Kind = SubKind.AsmFunction, Name = (r, i) => "AIPerformStaff_ASM_" },
+                },
+            });
+
+            // AIPerformItemForm.MakeAllDataLength — identical shape to AIPerformStaff but base
+            // ai_preform_item_pointer, Info "AIPerformItem", per-entry ASM label "AIPerformItem_ASM_".
+            l.Add(new StructDescriptor
+            {
+                Name = "AIPerformItem",
+                PointerField = r => r.RomInfo.ai_preform_item_pointer,
+                BlockSize = 8,
+                Rule = DataCountRule.U16NotZero,
+                RuleOffset = 0,
+                PointerIndexes = new uint[] { 4 },
+                SubWalks = new List<SubWalk>
+                {
+                    new SubWalk { EmbeddedPointerOffset = 4, Kind = SubKind.AsmFunction, Name = (r, i) => "AIPerformItem_ASM_" },
+                },
+            });
+
+            // MantAnimationForm.MakeAllDataLength — Info "Mant", block 4, base mant_command_pointer,
+            // IsDataExists = U.isPointer(u32(addr+0)) (PointerAt @0 — a NULL slot terminates),
+            // pointerIndexes {0}. PLUS per entry: Address.AddPointer(p+0, 0x10, "MANT_P:0x<i>", POINTER)
+            // — a fixed 0x10-byte POINTER block behind the +0 pointer (SubKind.FixedPointer @0). The
+            // per-entry label "MANT_P:0x<i>" is reproduced verbatim via the sub-walk Name callback.
+            l.Add(new StructDescriptor
+            {
+                Name = "Mant",
+                PointerField = r => r.RomInfo.mant_command_pointer,
+                BlockSize = 4,
+                Rule = DataCountRule.PointerAt,
+                RuleOffset = 0,
+                PointerIndexes = new uint[] { 0 },
+                SubWalks = new List<SubWalk>
+                {
+                    new SubWalk { EmbeddedPointerOffset = 0, Kind = SubKind.FixedPointer, FixedLength = 0x10, DataType = Address.DataTypeEnum.POINTER, Name = (r, i) => "MANT_P:" + U.To0xHexString((int)i) },
+                },
+            });
+
+            // ArenaEnemyWeaponForm.MakeAllDataLength — Info "ArenaEnemyWeapon", block 1, base
+            // arena_enemy_weapon_basic_pointer, IsDataExists = i<8 (FixedCount 8), pointerIndexes {}.
+            // VERBATIM QUIRK: WF emits this descriptor TWICE — the second block reads `Init(null)`
+            // (the BASIC table again), NOT `N_Init` (the rankup table), so the rankup_pointer / i<0x1A
+            // table is never emitted. The duplicate-basic emit is a WF copy/paste, reproduced exactly
+            // (two identical descriptors) to keep the produced Address list byte-identical.
+            for (int dup = 0; dup < 2; dup++)
+            {
+                l.Add(new StructDescriptor
+                {
+                    Name = "ArenaEnemyWeapon",
+                    PointerField = r => r.RomInfo.arena_enemy_weapon_basic_pointer,
+                    BlockSize = 1,
+                    Rule = DataCountRule.FixedCount,
+                    RuleFixedCount = 8,
+                    PointerIndexes = new uint[] { },
+                });
+            }
 
             // ---- slice 2e: flat LZ77-image + palette IFR-loop forms (version-agnostic) ----
             // Each is the Core port of an ImageXxxForm.MakeAllDataLength that emits a main IFR Address
@@ -2264,9 +2557,11 @@ namespace FEBuilderGBA
             else if (rom.RomInfo.version == 6)
             {
                 // ---- version==6 (FE6) section ----
-                // Forms called ONLY inside the WF `else if (version == 6)` branch. UnitFE6Form,
-                // WorldMapEventPointerFE6Form (PLIST event-scan), MapSettingFE6Form (IsMapSettingEnd +
-                // CString), SupportUnitFE6Form (GetUnitIDWhereSupportAddr) stay deferred.
+                // Forms called ONLY inside the WF `else if (version == 6)` branch. UnitFE6Form is ported
+                // in slice 2f via the dedicated EmitUnitFE6 walker (its base is p32(unit_pointer)+
+                // unit_datasize with a NOT_FOUND pointer slot, which the pointer-slot descriptor model
+                // cannot express). WorldMapEventPointerFE6Form (PLIST event-scan), MapSettingFE6Form
+                // (IsMapSettingEnd + CString), SupportUnitFE6Form (GetUnitIDWhereSupportAddr) stay deferred.
                 // ImagePortraitFE6Form STAYS too — its Init has a stateful nullContinuousCount
                 // terminator + GetFEditorLengthHint, not faithfully reproducible by the stateless
                 // descriptor rule model. The clean tables below are ported; ImageChapterTitleFE7Form
@@ -2536,11 +2831,25 @@ namespace FEBuilderGBA
                 //  CString + 6 ASM ptrs — + its own 6 ASM ptrs] ported in slice 2d via dedicated recursive
                 //  walkers; MenuCommandForm.MakeAllDataLengthP is reproduced by EmitMenuCommandSubTable.)
                 "ItemShopForm",
-                "ItemWeaponEffectForm", "ItemUsagePointerForm", "UnitActionPointerForm",
+                "ItemWeaponEffectForm",
+                // UnitActionPointerForm STAYS — its base = SearchActionPointer(), gated on
+                //   PatchUtil.SearchUnitActionReworkPatch() (PatchUtil patch detection not in Core).
+                // (ItemUsagePointerForm ported in slice 2f — dedicated EmitItemUsagePointer walker over
+                //  the 10 Switch2-gated usage tables, base/count from each xxx_array_switch2_address via
+                //  the Core ItemUsagePointerCore.IsSwitch2Enable + per-entry ASM AddFunction @0.)
+                "UnitActionPointerForm",
+                // MapChangeForm/MapExitPointForm — tractable via the Core map helpers
+                //   (MapChangeCore.GetMapChangeAddrWhereMapID / MapExitPointCore.ListMapEntries +
+                //    ListExitPointsForMap) but each needs a dedicated per-map walker with verbatim
+                //    per-entry length reproduction; DEFERRED for slice size (a coherent map-PLIST batch).
                 "MapChangeForm", "MapExitPointForm", "MapPointerForm", "FontForm",
                 // AI scripts (disasm)
-                "AIScriptForm", "AIMapSettingForm", "AIPerformStaffForm", "AIPerformItemForm",
-                "ArenaEnemyWeaponForm",
+                // (AIMapSettingForm [flat u8!=0xFF table], AIPerformStaffForm + AIPerformItemForm
+                //  [flat u16!=0 table + per-entry ASM AddFunction @4 via SubKind.AsmFunction] ported in
+                //  slice 2f. AIScriptForm STAYS — its per-entry length is AIScriptForm.CalcLength (AI
+                //  16-byte-opcode bytecode walk) + AIUnitsForm.CalcLength + nested LZ77 sub-pointers, none
+                //  of which is in Core.)
+                "AIScriptForm",
                 // skills (version/patch dependent)
                 "SkillAssignmentClassSkillSystemForm", "SkillAssignmentUnitSkillSystemForm",
                 "SkillConfigSkillSystemForm", "SkillConfigFE8NSkillForm",
@@ -2551,17 +2860,26 @@ namespace FEBuilderGBA
                 //  StatusOptionForm ported in slice 2d [v7+v8, PointerAt@40 main IFR + per-entry
                 //  SubKind.AsmFunction @40]. NOTE: "MapMiniMapTerrainForm" does NOT exist as a distinct
                 //  ASM form — the only file is MapMiniMapTerrainImageForm (an LZ77 image form, already
-                //  listed above), so there is nothing extra to port for it.)
-                "MantAnimationForm", "MapTileAnimation1Form",
+                //  listed above), so there is nothing extra to port for it.
+                //  MantAnimationForm ported in slice 2f — PointerAt@0 main IFR ("Mant") + per-entry
+                //  SubKind.FixedPointer @0 (0x10-byte POINTER block "MANT_P:0x<i>").
+                //  MapTileAnimation1Form/MapTileAnimation2Form — tractable via the Core helpers
+                //  (MapTileAnimation1Core/2Core.BuildPlistList + ScanEntries) but need a dedicated
+                //  per-PLIST walker with verbatim per-entry IMG/BIN length reproduction; DEFERRED for
+                //  slice size (the coherent map-PLIST batch).
+                //  MapTerrainFloorLookupTableForm/MapTerrainBGLookupTableForm — their pointer set comes
+                //  from GetPointersExtendsPatch (PatchUtil.SearchExtendsBattleBG + hardcoded FE8 offsets),
+                //  not in Core.)
+                "MapTileAnimation1Form",
                 "MapTileAnimation2Form", "MapTerrainFloorLookupTableForm",
                 "MapTerrainBGLookupTableForm",
                 // units / classes per-version with extra reads
                 // (UnitForm [FE8, flat + 24-byte support BinFixed sub-walk @44] and UnitFE7Form
                 //  [FE7, flat, no sub-walk] ported in this sweep; SummonUnitForm + SummonsDemonKingForm
-                //  + EventForceSortieForm [FE8 clean tables] ported too. UnitFE6Form STAYS — its base is
-                //  p32(unit_pointer)+unit_datasize via a direct ReInit, which the pointer-slot descriptor
-                //  model cannot express faithfully.)
-                "UnitFE6Form", "UnitCustomBattleAnimeForm",
+                //  + EventForceSortieForm [FE8 clean tables] ported too. UnitFE6Form ported in slice 2f
+                //  via the dedicated EmitUnitFE6 walker — base p32(unit_pointer)+unit_datasize, BasePointer
+                //  0 -> NOT_FOUND, i < unit_maxcount, pointerIndexes {44}.)
+                "UnitCustomBattleAnimeForm",
                 "ExtraUnitForm", "ExtraUnitFE8UForm",
                 "EventUnitForm(RecycleReserveUnits)",
                 // monster / world map / ED / support (FE8/FE7/FE6 variants)
@@ -2572,7 +2890,11 @@ namespace FEBuilderGBA
                 //  WorldMapPointForm [FE8], SupportTalkForm/FE6/FE7, EventBattleTalkFE6Form [FE6 ×2],
                 //  EventHaikuFE6Form [FE6], TacticianAffinityFE7, EventFinalSerifFE7Form.
                 //  STILL deferred (event-scan / LZ77 / recursive / GetUnitIDWhereSupportAddr / dynamic
-                //  base): MonsterWMapProbabilityForm + WorldMapEventPointerForm [ScanScript],
+                //  base): MonsterWMapProbabilityForm STAYS — although its 5 IFR probability/stage tables
+                //    are flat ROM reads, its MakeAllDataLength ALSO emits EventScriptForm.ScanScript over
+                //    the two skirmish start/end event pointers (no Core ScanScript primitive yet);
+                //    porting only the flat tables would drop those skirmish-event regions = corruption.
+                //  WorldMapEventPointerForm [ScanScript],
                 //  EventBattleTalkForm + EventHaikuForm [FE8, ScanScript per-entry], SupportUnitForm
                 //  [GetUnitIDWhereSupportAddr], WorldMapPathForm [CalcPathDataLength], EDStaffRollForm +
                 //  OPPrologueForm + OPClassFontForm + OPClassDemoForm/FE7Form [LZ77], MapSettingForm

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -1284,7 +1284,12 @@ namespace FEBuilderGBA
                     continue;
                 }
                 uint pointer = U.toOffset(t.Pointer(rom));
-                if (!U.isSafetyOffset(pointer, rom))
+                // Guard the FULL 4-byte slot before p32: isSafetyOffset(pointer) alone leaves
+                // pointer+1..pointer+3 unchecked, and ROM.p32 only short-circuits when pointer >=
+                // Data.Length (a pointer in [Len-3, Len-1] still reaches u32 -> check_safety throws).
+                // Mirrors EmitUnitFE6At / the StatusRMenu root+3 guard. On valid ROMs the RomInfo slot
+                // is never near EOF, so this only hardens synthetic/corrupted ROMs.
+                if (!U.isSafetyOffset(pointer + 3, rom))
                 {
                     continue; // p32(pointer) below would read junk; WF's ReInitPointer->p32 needs a safe slot.
                 }


### PR DESCRIPTION
## Summary
**Slice 2f** of #1261 — a **re-sweep** of the remaining `NotYetPortedRaw` forms now that 2c/2d/2e added the sub-walk / ASM / LZ77 machinery. Ports the newly-tractable **AI / Arena / Mant / ItemUsage / UnitFE6** batch; refines the deferral reasons for the rest with the precise missing Core primitive.

## Ported (7 forms — VERBATIM vs WF `MakeAllDataLength`, version-gated per the WF call structure)
- **AIMapSettingForm** — `U8NotEqual @0 = 0xFF`, block 4, pIdx `{}`.
- **AIPerformStaffForm** — `U16NotZero @0`, block 8, pIdx `{4}` + `SubKind.AsmFunction @4`.
- **AIPerformItemForm** — same shape, base `ai_preform_item_pointer`.
- **MantAnimationForm** — `PointerAt @0`, block 4, pIdx `{0}` + `SubKind.FixedPointer @0` (0x10 POINTER).
- **ArenaEnemyWeaponForm** — `FixedCount 8`, block 1, pIdx `{}`, **emitted TWICE** — WF reproduces the same BASIC table twice (`InputFormRef` + `N_InputFormRef`, both `Init(null)`); the rankup table is never emitted. Reproduced exactly (a WF quirk — verbatim is required for rebuild parity).
- **ItemUsagePointerForm** — dedicated `EmitItemUsagePointer`: 10 Switch2-gated usage tables, base `p32(usage_pointer)`, count `u8(switch2+2)`, gated by `ItemUsagePointerCore.IsSwitch2Enable`, main `InputFormRef_ASM` + per-entry ASM `AddFunction @0`.
- **UnitFE6Form** [FE6-only, `version==6`] — dedicated `EmitUnitFE6`: base `p32(unit_pointer)+unit_datasize`, `BasePointer 0 → NOT_FOUND`, `i < unit_maxcount`, pIdx `{44}`.

## Deferred (reason comments refined to the exact missing Core primitive)
- **AIScriptForm** — `AIScriptForm.CalcLength` + `AIUnitsForm.CalcLength` AI-bytecode walkers + nested LZ77 sub-pointers, not in Core.
- **UnitActionPointerForm** — base `SearchActionPointer()` + `PatchUtil.SearchUnitActionReworkPatch`, not in Core.
- **MonsterWMapProbabilityForm** — flat tables are fine, but `MakeAllDataLength` also `EventScriptForm.ScanScript`s 2 skirmish event pointers (no Core ScanScript); a partial port would drop those regions = corruption.
- **EventFunctionPointerForm / Command85PointerForm** — these live in `AppendAllASMStructPointersList` (the ASM path), NOT `MakeAllStructPointersList` (this producer's data path) — correctly out of scope.

Next-slice candidates (map-PLIST forms whose Core helpers were verified to exist): `MapChangeForm`, `MapExitPointForm`, `MapTileAnimation1/2Form`, `ItemShopForm`.

## Tests
- RebuildProducer filter: **101 passed / 0 failed** (+17): version-gated presence (FE6 vs FE8U), EOF/malformed `Record.Exception`-null for both hand-written walkers (ItemUsage past-EOF truncate; UnitFE6 unsafe-base), the ArenaEnemyWeapon double-emit, the AsmFunction/FixedPointer sub-walks. Fixed the stale "UnitFE6Form still deferred" assertion.
- FEBuilderGBA.Tests (net9.0-windows): **1865 passed / 0 failed**.
- (Full Core.Tests: only the known env-only `SkillSystemsAnime*`/`SkillConfig FE8U` failures — `config/patch2` submodule absent in the worktree; they pass in CI. Zero RebuildProducer failures.)

Part of #1261.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
