### PR TITLE
feat(core): ROM-rebuild producer — per-map PLIST forms (#1261 slice 2g)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -476,8 +476,8 @@ namespace FEBuilderGBA.Core.Tests
             // (CCBranchForm is now PORTED in the #1261 producer sweep via ClassDataCount — it is no
             //  longer a deferred sibling; EventBattleTalkForm stays deferred for its ScanScript.)
             Assert.Contains("EventBattleTalkForm", notYet);        // per-entry EventScriptForm.ScanScript
-            Assert.Contains("MapTileAnimation1Form", notYet);      // embedded IMG sub-block
-            Assert.Contains("MapTileAnimation2Form", notYet);      // embedded BIN sub-block
+            // (MapTileAnimation1Form/MapTileAnimation2Form are now PORTED in slice 2g — see
+            //  GetNotYetPortedForms_DropsSlice2gCoveredForms_KeepsDeferredSiblings.)
             Assert.Contains("MapTerrainFloorLookupTableForm", notYet); // PatchUtil GetPointers()
             Assert.Contains("MapTerrainBGLookupTableForm", notYet);    // PatchUtil GetPointers()
         }
@@ -638,7 +638,8 @@ namespace FEBuilderGBA.Core.Tests
                 //  per-entry EventScriptForm.ScanScript expansion.)
                 Assert.Contains("MonsterWMapProbabilityForm", notYet2b);
                 Assert.Contains("EventBattleTalkForm", notYet2b);
-                Assert.Contains("MapTileAnimation1Form", notYet2b);
+                // (MapTileAnimation1Form is now PORTED in slice 2g — its still-deferred map sibling
+                //  MapTerrainFloorLookupTableForm [PatchUtil GetPointers] stays tracked here instead.)
                 Assert.Contains("MapTerrainFloorLookupTableForm", notYet2b);
 
                 // FAITHFULNESS / COMPLETENESS-SAFETY: ItemForm is NOT emitted (its StatBooster
@@ -1703,8 +1704,9 @@ namespace FEBuilderGBA.Core.Tests
                 "MonsterWMapProbabilityForm", "SoundRoomForm",
                 // (StatusOptionForm + SoundFootStepsForm ported in slice 2d -> no longer kept here.
                 //  UnitFE6Form + ItemUsagePointerForm + AIPerform*/AIMapSetting/Mant/ArenaEnemyWeapon
-                //  ported in slice 2f -> no longer kept here.)
-                "ItemForm", "MapTileAnimation1Form", "MapTerrainFloorLookupTableForm",
+                //  ported in slice 2f -> no longer kept here. MapTileAnimation1Form/MapTileAnimation2Form +
+                //  ItemShopForm + MapChangeForm + MapExitPointForm ported in slice 2g -> no longer kept.)
+                "ItemForm", "MapTerrainFloorLookupTableForm",
             })
             {
                 Assert.Contains(kept, notYet);
@@ -3477,15 +3479,444 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Contains("AIScriptForm", ported);              // AI bytecode CalcLength + nested LZ77
             Assert.Contains("UnitActionPointerForm", ported);     // PatchUtil SearchUnitActionReworkPatch
             Assert.Contains("MonsterWMapProbabilityForm", ported);// EventScriptForm.ScanScript skirmish
-            Assert.Contains("MapChangeForm", ported);             // deferred for slice size (map-PLIST)
-            Assert.Contains("MapExitPointForm", ported);          // deferred for slice size (map-PLIST)
-            Assert.Contains("MapTileAnimation1Form", ported);     // deferred for slice size (map-PLIST)
-            Assert.Contains("MapTileAnimation2Form", ported);     // deferred for slice size (map-PLIST)
-            Assert.Contains("ItemShopForm", ported);              // deferred for slice size (map-PLIST)
+            // (the 5 map-PLIST forms that were deferred "for slice size" here are now PORTED in slice 2g
+            //  — see GetNotYetPortedForms_DropsSlice2gCoveredForms_KeepsDeferredSiblings.)
             Assert.Contains("EventCondForm", ported);             // EventScriptForm.ScanScript
             // and the no-duplicates invariant still holds after the edits.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
             Assert.Equal(raw.Length, raw.Distinct().Count());
+        }
+
+        // ====================================================================
+        // slice 2g — per-map PLIST forms (ItemShop / MapChange / MapExitPoint /
+        // MapTileAnimation1 / MapTileAnimation2). Each exercises the test-seam
+        // emitter with a synthetic per-map structure, then a near-EOF / corrupt
+        // case asserting no throw.
+        // ====================================================================
+
+        // ---- EmitItemShopList (BIN block per shop) --------------------------
+
+        [Fact]
+        public void EmitItemShopList_EmitsBinPerShop_LengthIsItemCountPlus1Times2()
+        {
+            // A shop with 3 non-zero 2-byte item entries then a 0x00 terminator -> DataCount = 3 ->
+            // length = (3+1)*2 = 8. The tag (pointer slot) is recorded on the emitted Address.
+            var rom = CreateTestRom();
+            uint shopAddr = 0x1000;
+            uint slot = 0x0800; // the inbound 4-byte pointer slot (AddrResult.tag)
+            // 3 items: each item-ID byte must be non-zero; the 4th byte is the 0x00 terminator.
+            rom.write_u8(shopAddr + 0, 0x11); rom.write_u8(shopAddr + 1, 0x05);
+            rom.write_u8(shopAddr + 2, 0x22); rom.write_u8(shopAddr + 3, 0x02);
+            rom.write_u8(shopAddr + 4, 0x33); rom.write_u8(shopAddr + 5, 0x01);
+            rom.write_u8(shopAddr + 6, 0x00); // terminator item-ID
+
+            var list = new List<Address>();
+            var shops = new List<AddrResult> { new AddrResult(shopAddr, "Shop", slot) };
+            RebuildProducerCore.EmitItemShopList(rom, list, shops);
+
+            Address a = Assert.Single(list);
+            Assert.Equal(shopAddr, a.Addr);
+            Assert.Equal(8u, a.Length); // (3+1)*2
+            Assert.Equal(slot, a.Pointer);
+            Assert.Equal(Address.DataTypeEnum.BIN, a.DataType);
+            Assert.Equal("Shop", a.Info);
+        }
+
+        [Fact]
+        public void EmitItemShopList_EmptyShop_LengthIsTwo()
+        {
+            // First item-ID byte is 0x00 -> DataCount = 0 -> length = (0+1)*2 = 2 (one terminator block).
+            var rom = CreateTestRom();
+            uint shopAddr = 0x1000;
+            uint slot = 0x0800;
+            rom.write_u8(shopAddr, 0x00);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitItemShopList(rom, list,
+                new List<AddrResult> { new AddrResult(shopAddr, "Shop", slot) });
+
+            Address a = Assert.Single(list);
+            Assert.Equal(2u, a.Length);
+        }
+
+        [Fact]
+        public void EmitItemShopList_UnsafeShopAddr_EmitsNothing()
+        {
+            // A shop whose item-list address is below 0x200 (unsafe) is skipped (WF ReInit -> AddAddress
+            // early-returns). Null/empty list also no-ops.
+            var rom = CreateTestRom();
+            var list = new List<Address>();
+            RebuildProducerCore.EmitItemShopList(rom, list,
+                new List<AddrResult> { new AddrResult(0x0100, "Shop", 0x0800) });
+            Assert.Empty(list);
+
+            RebuildProducerCore.EmitItemShopList(rom, list, null);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitItemShopList_UnterminatedShopNearEof_TruncatesWithoutThrowing()
+        {
+            // An unterminated all-non-zero run up to EOF must stop at addr+block > Data.Length
+            // (getBlockDataCount's EOF cutoff), NOT throw. length = (count+1)*2 is clamped to a safe value.
+            uint size = 0x2000;
+            var rom = CreateTestRom((int)size);
+            uint shopAddr = size - 6; // 0x1FFA — 3 two-byte entries fit before EOF, no terminator
+            for (uint i = shopAddr; i < size; i++) rom.write_u8(i, 0x11);
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.EmitItemShopList(rom, list,
+                new List<AddrResult> { new AddrResult(shopAddr, "Shop", 0x0800) }));
+            Assert.Null(ex);
+        }
+
+        // ---- EmitMapChangeAt (per-map 12-byte IFR + w*h*2 BIN per entry) ----
+
+        [Fact]
+        public void EmitMapChangeAt_MainIfrPlusPerEntryBinBlocks()
+        {
+            // Slot -> change-data base; the change table has 2 records (12 bytes each) then a 0xFF
+            // terminator record. Each record: +3 = w, +4 = h, +8 = p32(change-map). Record 0 points at
+            // a w*h*2 = 2*3*2 = 12-byte BIN; record 1 at a 1*1*2 = 2-byte BIN.
+            var rom = CreateTestRom(0x8000);
+            uint slot = 0x0800;        // PLIST slot (pointer)
+            uint changeBase = 0x1000;  // p32(slot)
+            rom.write_u32(slot, Ptr(changeBase));
+
+            uint mar0 = 0x2000, mar1 = 0x2100;
+            // record 0
+            rom.write_u8(changeBase + 0, 0x01);  // id (non-0xFF)
+            rom.write_u8(changeBase + 3, 2);     // w
+            rom.write_u8(changeBase + 4, 3);     // h
+            rom.write_u32(changeBase + 8, Ptr(mar0));
+            // record 1
+            rom.write_u8(changeBase + 12 + 0, 0x02);
+            rom.write_u8(changeBase + 12 + 3, 1);
+            rom.write_u8(changeBase + 12 + 4, 1);
+            rom.write_u32(changeBase + 12 + 8, Ptr(mar1));
+            // terminator record (id == 0xFF)
+            rom.write_u8(changeBase + 24, 0xFF);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitMapChangeAt(rom, list, mapid: 0x05, pointer: slot);
+
+            // Main IFR: base = changeBase, length = 12*(2+1) = 36, pointer = slot, block 12, {8}.
+            Address main = list.Single(a => a.DataType == Address.DataTypeEnum.InputFormRef);
+            Assert.Equal(changeBase, main.Addr);
+            Assert.Equal(36u, main.Length);
+            Assert.Equal(slot, main.Pointer);
+            Assert.Equal(12u, main.BlockSize);
+            Assert.Equal(new uint[] { 8 }, main.PointerIndexes);
+            Assert.Equal("MapChange map:0x05", main.Info); // U.To0xHexString(0x05) zero-pads to 2 digits
+
+            // Two BIN change-map blocks.
+            var bins = list.Where(a => a.DataType == Address.DataTypeEnum.BIN).ToList();
+            Assert.Equal(2, bins.Count);
+            Assert.Contains(bins, a => a.Addr == mar0 && a.Length == 12 && a.Pointer == changeBase + 8);
+            Assert.Contains(bins, a => a.Addr == mar1 && a.Length == 2 && a.Pointer == changeBase + 12 + 8);
+        }
+
+        [Fact]
+        public void EmitMapChangeAt_UnsafeBase_EmitsNothing()
+        {
+            // A slot whose p32 base is unsafe (0) -> WF ReInitPointer -> AddAddress early-returns.
+            var rom = CreateTestRom();
+            uint slot = 0x0800;
+            rom.write_u32(slot, 0); // base = 0 -> unsafe
+            var list = new List<Address>();
+            RebuildProducerCore.EmitMapChangeAt(rom, list, mapid: 0, pointer: slot);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitMapChangeAt_EntryPointerUnsafe_SkipsEntry_KeepsMainIfr()
+        {
+            // An entry whose +8 change pointer is unsafe is skipped (no BIN), but the main IFR is kept.
+            var rom = CreateTestRom(0x8000);
+            uint slot = 0x0800, changeBase = 0x1000;
+            rom.write_u32(slot, Ptr(changeBase));
+            rom.write_u8(changeBase + 0, 0x01);
+            rom.write_u8(changeBase + 3, 2);
+            rom.write_u8(changeBase + 4, 2);
+            rom.write_u32(changeBase + 8, 0); // unsafe change pointer (0)
+            rom.write_u8(changeBase + 12, 0xFF); // terminator
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitMapChangeAt(rom, list, mapid: 0, pointer: slot);
+            Assert.Single(list, a => a.DataType == Address.DataTypeEnum.InputFormRef);
+            Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.BIN);
+        }
+
+        [Fact]
+        public void EmitMapChangeAt_PointerSlotNearEof_SkipsWithoutThrowing()
+        {
+            // A PLIST slot whose 4 bytes straddle EOF must skip (pointer+3 guard), not throw.
+            uint size = 0x2000;
+            var rom = CreateTestRom((int)size);
+            uint slotNearEof = size - 2; // 0x1FFE: < Len but slot+3 = 0x2001 > Len
+            var list = new List<Address>();
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.EmitMapChangeAt(rom, list, mapid: 0, pointer: slotNearEof));
+            Assert.Null(ex);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitMapChangeAt_RecordRunsPastEof_TruncatesWithoutThrowing()
+        {
+            // A change table with no 0xFF terminator near EOF: getBlockDataCount stops at the EOF cutoff,
+            // and the per-entry p32(p+8) read (which reaches p+11) is guarded by the p+block <= Len check.
+            uint size = 0x2000;
+            var rom = CreateTestRom((int)size);
+            uint slot = 0x0800;
+            uint changeBase = size - 12; // exactly one 12-byte record fits; no terminator after it
+            rom.write_u32(slot, Ptr(changeBase));
+            rom.write_u8(changeBase + 0, 0x01); // non-0xFF id
+            rom.write_u8(changeBase + 3, 1);
+            rom.write_u8(changeBase + 4, 1);
+            // +8 left 0 (unsafe pointer) so no BIN; the point is the walk must not throw.
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.EmitMapChangeAt(rom, list, mapid: 0, pointer: slot));
+            Assert.Null(ex);
+        }
+
+        // ---- EmitMapExitPointAt (enemy + NPC slot tables + per-map N-tables) -
+
+        [Fact]
+        public void EmitMapExitPointAt_EmitsEnemyAndNpcMains_AndPerMapSubTables()
+        {
+            // Enemy base = p32(mainPointer). npc_blockadd = 2: enemy table caps at 2 slots, NPC base is
+            // enemyBase + 4*2. Two map slots each point at an N-table (4-byte rows, u8 != 0xFF).
+            var rom = CreateTestRom(0x8000);
+            uint mainPointer = 0x0800;
+            uint enemyBase = 0x1000;
+            rom.write_u32(mainPointer, Ptr(enemyBase));
+            uint npcBlockAdd = 2;
+            uint npcBase = enemyBase + 4 * npcBlockAdd; // 0x1008
+
+            // Enemy slots (2): slot 0 -> exitData0, slot 1 -> NULL (still pointer-or-null so counted).
+            uint exitData0 = 0x2000;
+            rom.write_u32(enemyBase + 0, Ptr(exitData0));
+            rom.write_u32(enemyBase + 4, 0); // NULL pointer (isPointerOrNULL true)
+            // exitData0 N-table: 2 rows then 0xFF terminator.
+            rom.write_u8(exitData0 + 0, 0x01);
+            rom.write_u8(exitData0 + 4, 0x02);
+            rom.write_u8(exitData0 + 8, 0xFF);
+
+            // NPC slots: slot 0 -> exitDataN.
+            uint exitDataN = 0x3000;
+            rom.write_u32(npcBase + 0, Ptr(exitDataN));
+            rom.write_u32(npcBase + 4, 0);
+            rom.write_u8(exitDataN + 0, 0x01);
+            rom.write_u8(exitDataN + 4, 0xFF);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitMapExitPointAt(rom, list, mainPointer, npcBlockAdd, mapCount: 4);
+
+            // Enemy main: addr = enemyBase, pointer = mainPointer, block 4, {0}.
+            Address enemyMain = list.Single(a => a.Info == "MapExit");
+            Assert.Equal(enemyBase, enemyMain.Addr);
+            Assert.Equal(mainPointer, enemyMain.Pointer);
+            Assert.Equal(4u, enemyMain.BlockSize);
+            Assert.Equal(new uint[] { 0 }, enemyMain.PointerIndexes);
+            // Enemy DataCount: 2 pointer-or-null slots before the i < npc_blockadd cap -> length 4*(2+1)=12.
+            Assert.Equal(12u, enemyMain.Length);
+
+            // NPC main: pointer FORCED to NOT_FOUND (AddAddressButIgnorePointer).
+            Address npcMain = list.Single(a => a.Info == "MapExit NPC");
+            Assert.Equal(npcBase, npcMain.Addr);
+            Assert.Equal(U.NOT_FOUND, npcMain.Pointer);
+
+            // Enemy per-map sub-table for map 0 (exitData0): length 4*(2+1)=12, pointer = enemyBase+0.
+            // (U.To0xHexString(0) zero-pads to 2 digits -> "0x00".)
+            Address enemySub = list.Single(a => a.Info == "MapExit map:0x00");
+            Assert.Equal(exitData0, enemySub.Addr);
+            Assert.Equal(enemyBase + 0, enemySub.Pointer);
+            Assert.Equal(12u, enemySub.Length);
+            Assert.Equal(new uint[] { }, enemySub.PointerIndexes);
+
+            // NPC per-map sub-table for map 0 (exitDataN): length 4*(1+1)=8, pointer = npcBase+0.
+            Address npcSub = list.Single(a => a.Info == "MapExit map:0x00 NPC");
+            Assert.Equal(exitDataN, npcSub.Addr);
+            Assert.Equal(npcBase + 0, npcSub.Pointer);
+            Assert.Equal(8u, npcSub.Length);
+        }
+
+        [Fact]
+        public void EmitMapExitPointAt_MainPointerNearEof_SkipsWithoutThrowing()
+        {
+            // The map_exit_point_pointer slot straddling EOF must skip (mainPointer+3 guard), not throw.
+            uint size = 0x2000;
+            var rom = CreateTestRom((int)size);
+            var list = new List<Address>();
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.EmitMapExitPointAt(rom, list, size - 2, npcBlockAdd: 2, mapCount: 4));
+            Assert.Null(ex);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitMapExitPointAt_SubTableNBaseUnsafe_SkipsThatSubTable()
+        {
+            // A map slot whose N base (p32) is unsafe (0) must be skipped (WF N_ReInitPointer ->
+            // AddAddress early-returns), but the enemy main is still emitted.
+            var rom = CreateTestRom(0x8000);
+            uint mainPointer = 0x0800, enemyBase = 0x1000;
+            rom.write_u32(mainPointer, Ptr(enemyBase));
+            rom.write_u32(enemyBase + 0, 0); // NULL -> p32 = 0 -> N base unsafe -> sub-table skipped
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitMapExitPointAt(rom, list, mainPointer, npcBlockAdd: 2, mapCount: 4);
+            Assert.Contains(list, a => a.Info == "MapExit");
+            Assert.DoesNotContain(list, a => a.Info == "MapExit map:0x00");
+        }
+
+        // ---- EmitMapTileAnimationFor (anime1 IMG / anime2 BIN) --------------
+
+        [Fact]
+        public void EmitMapTileAnimationFor_Anime1_MainIfrPlusImgPerEntry()
+        {
+            // anime1: image pointer at +4, IMG length = u16(p+2), main pointerIndexes {4}. Two entries
+            // (each +4 is a valid pointer) then a non-pointer +4 terminator.
+            var rom = CreateTestRom(0x8000);
+            uint baseAddr = 0x1000;
+            uint img0 = 0x2000, img1 = 0x2100;
+            // entry 0
+            rom.write_u16(baseAddr + 2, 0x40);          // length
+            rom.write_u32(baseAddr + 4, Ptr(img0));     // image pointer (+4)
+            // entry 1
+            rom.write_u16(baseAddr + 8 + 2, 0x20);
+            rom.write_u32(baseAddr + 8 + 4, Ptr(img1));
+            // entry 2 terminator: +4 not a pointer (0)
+            rom.write_u32(baseAddr + 16 + 4, 0);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitMapTileAnimationFor(rom, list, baseAddr, plist: 0x07, imgAtPlus4: true);
+
+            Address main = list.Single(a => a.DataType == Address.DataTypeEnum.InputFormRef);
+            Assert.Equal(baseAddr, main.Addr);
+            Assert.Equal(8u * (2 + 1), main.Length); // 24
+            Assert.Equal(U.NOT_FOUND, main.Pointer); // BasePointer 0 -> NOT_FOUND
+            Assert.Equal(8u, main.BlockSize);
+            Assert.Equal(new uint[] { 4 }, main.PointerIndexes);
+
+            var imgs = list.Where(a => a.DataType == Address.DataTypeEnum.IMG).ToList();
+            Assert.Equal(2, imgs.Count);
+            Assert.Contains(imgs, a => a.Addr == img0 && a.Length == 0x40 && a.Pointer == baseAddr + 4);
+            Assert.Contains(imgs, a => a.Addr == img1 && a.Length == 0x20 && a.Pointer == baseAddr + 8 + 4);
+        }
+
+        [Fact]
+        public void EmitMapTileAnimationFor_Anime2_MainIfrPlusBinPerEntry()
+        {
+            // anime2: image pointer at +0, BIN length = u8(p+5)*2, main pointerIndexes {0}.
+            var rom = CreateTestRom(0x8000);
+            uint baseAddr = 0x1000;
+            uint pal0 = 0x2000;
+            rom.write_u32(baseAddr + 0, Ptr(pal0)); // pointer at +0
+            rom.write_u8(baseAddr + 5, 4);          // count -> BIN length = 4*2 = 8
+            // entry 1 terminator: +0 not a pointer.
+            rom.write_u32(baseAddr + 8 + 0, 0);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitMapTileAnimationFor(rom, list, baseAddr, plist: 0x03, imgAtPlus4: false);
+
+            Address main = list.Single(a => a.DataType == Address.DataTypeEnum.InputFormRef);
+            Assert.Equal(baseAddr, main.Addr);
+            Assert.Equal(8u * (1 + 1), main.Length); // 16
+            Assert.Equal(new uint[] { 0 }, main.PointerIndexes);
+
+            Address bin = Assert.Single(list, a => a.DataType == Address.DataTypeEnum.BIN);
+            Assert.Equal(pal0, bin.Addr);
+            Assert.Equal(8u, bin.Length); // count*2
+            Assert.Equal(baseAddr + 0, bin.Pointer);
+        }
+
+        [Fact]
+        public void EmitMapTileAnimationFor_BrokenResolution_EmitsNothing()
+        {
+            // dataAddr == NOT_FOUND (broken "(破損)" PLIST) -> ReInit on an unsafe base -> emit nothing.
+            var rom = CreateTestRom();
+            var list = new List<Address>();
+            RebuildProducerCore.EmitMapTileAnimationFor(rom, list, U.NOT_FOUND, plist: 0x01, imgAtPlus4: true);
+            Assert.Empty(list);
+            // Also an unsafe (<0x200) base emits nothing.
+            RebuildProducerCore.EmitMapTileAnimationFor(rom, list, 0x0100, plist: 0x01, imgAtPlus4: true);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitMapTileAnimationFor_EntryRunsPastEof_TruncatesWithoutThrowing()
+        {
+            // An entry table with no terminator near EOF: the per-entry p32(p+4) read (reaching p+7) is
+            // guarded by p+block <= Len, so the walk truncates rather than throwing.
+            uint size = 0x2000;
+            var rom = CreateTestRom((int)size);
+            uint baseAddr = size - 8; // exactly one 8-byte entry fits
+            rom.write_u32(baseAddr + 4, Ptr(0x1000)); // valid pointer so the single entry is counted
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.EmitMapTileAnimationFor(rom, list, baseAddr, plist: 0x01, imgAtPlus4: true));
+            Assert.Null(ex);
+        }
+
+        // ---- NotYetPorted coverage delta for slice 2g ----------------------
+
+        [Fact]
+        public void GetNotYetPortedForms_DropsSlice2gCoveredForms_KeepsDeferredSiblings()
+        {
+            string[] ported = RebuildProducerCore.GetNotYetPortedForms();
+
+            // slice 2g ported these 5 map-PLIST forms — no longer in the deferred list:
+            Assert.DoesNotContain("ItemShopForm", ported);
+            Assert.DoesNotContain("MapChangeForm", ported);
+            Assert.DoesNotContain("MapExitPointForm", ported);
+            Assert.DoesNotContain("MapTileAnimation1Form", ported);
+            Assert.DoesNotContain("MapTileAnimation2Form", ported);
+
+            // deferred map siblings STAY (their blocking subsystem is not in Core):
+            Assert.Contains("MapPointerForm", ported);                 // palette2 via PatchUtil patch detect
+            Assert.Contains("MapTerrainFloorLookupTableForm", ported); // PatchUtil GetPointersExtendsPatch
+            Assert.Contains("MapTerrainBGLookupTableForm", ported);    // PatchUtil GetPointersExtendsPatch
+            Assert.Contains("MapSettingForm", ported);                 // IsMapSettingEnd + CString
+            Assert.Contains("ItemForm", ported);                       // StatBooster size via PatchUtil
+
+            // the no-duplicates invariant still holds after the edits.
+            string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
+            Assert.Equal(raw.Length, raw.Distinct().Count());
+        }
+
+        [Fact]
+        public void EmitMapPlistForms_RomInfoDriven_DoNotThrow_OnEmptyFakeRom()
+        {
+            // The public RomInfo-driven entry points must run cleanly on a versioned-but-empty 32MB
+            // fake ROM (real RomInfo, all-zero data -> every map/exit/shop/PLIST table base resolves
+            // unsafe). They emit nothing but must NOT throw (no NRE on RomInfo, no read past EOF).
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(fe8);
+
+                var list = new List<Address>();
+                var ex = Record.Exception(() =>
+                {
+                    RebuildProducerCore.EmitItemShop(fe8, list);
+                    RebuildProducerCore.EmitMapChange(fe8, list);
+                    RebuildProducerCore.EmitMapExitPoint(fe8, list);
+                    RebuildProducerCore.EmitMapTileAnimation1(fe8, list);
+                    RebuildProducerCore.EmitMapTileAnimation2(fe8, list);
+                });
+                Assert.Null(ex);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+            }
         }
     }
 }

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -1727,17 +1727,17 @@ namespace FEBuilderGBA
                 {
                     continue;
                 }
-                // WF: a = p32(exit_addr); if (a == U.NOT_FOUND) continue. p32 strips 0x08000000 so it is
-                // never literally NOT_FOUND; reproduced for structural fidelity (the real gate is the
-                // N base-safety below, exactly as WF's N_ReInitPointer -> AddAddress early-return).
-                uint a = rom.p32(exitAddr);
-                if (a == U.NOT_FOUND)
+                // WF: a = p32(exit_addr); if (a == U.NOT_FOUND) continue; then N_ReInitPointer(exit_addr)
+                // (N BasePointer = exit_addr, N BaseAddress = p32(exit_addr)). Read p32 ONCE into nBase
+                // and use it for both. ROM.p32 DOES return U.NOT_FOUND (0xFFFFFFFF) when the dword is
+                // 0xFFFFFFFF — toOffset leaves it as-is (0xFFFFFFFF is not a valid 0x08-pointer) — i.e.
+                // an unset/empty exit slot, so this check meaningfully skips those maps (matching WF —
+                // it is NOT merely structural).
+                uint nBase = rom.p32(exitAddr);
+                if (nBase == U.NOT_FOUND)
                 {
                     continue;
                 }
-
-                // N_ReInitPointer(exit_addr): N BasePointer = exit_addr, N BaseAddress = p32(exit_addr).
-                uint nBase = rom.p32(exitAddr);
                 // N_Init IsDataExists = u8(addr) != 0xFF. AddAddress early-returns on an unsafe N base.
                 if (!U.isSafetyOffset(nBase, rom))
                 {

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -464,6 +464,52 @@ namespace FEBuilderGBA
             progress?.Report("ItemUsagePointer");
             EmitItemUsagePointer(rom, list);
 
+            // ---- slice 2g: per-map PLIST forms (version-agnostic) ----
+            // ItemShop / MapChange / MapExitPoint / MapTileAnimation1 / MapTileAnimation2 are all
+            // version-agnostic in WF MakeAllStructPointersList. None is a flat StructDescriptor walk:
+            // each is a per-map enumeration (MakeMapIDList / event-cond shop scan / PLIST resolve) with
+            // verbatim per-entry length reproduction. Each gets a dedicated walker with its own
+            // cancel-check, mirroring the WF DoEvents posture.
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("ItemShop");
+            EmitItemShop(rom, list);
+
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("MapChange");
+            EmitMapChange(rom, list);
+
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("MapExitPoint");
+            EmitMapExitPoint(rom, list);
+
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("MapTileAnimation1");
+            EmitMapTileAnimation1(rom, list);
+
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("MapTileAnimation2");
+            EmitMapTileAnimation2(rom, list);
+
             if (rom.RomInfo.version == 7)
             {
                 if (ct.IsCancellationRequested)
@@ -1387,6 +1433,473 @@ namespace FEBuilderGBA
             uint length = block * (dataCount + 1);
             list.Add(new Address(baseAddr, length, U.NOT_FOUND, "Unit",
                 Address.DataTypeEnum.InputFormRef, block, new uint[] { 44 }));
+        }
+
+        // ===================================================================
+        // slice 2g — per-map PLIST forms (version-agnostic section of WF
+        // MakeAllStructPointersList). Each is a per-map walk that a flat
+        // StructDescriptor cannot express, so each gets a dedicated emitter +
+        // a test seam that supplies the resolved work items without RomInfo.
+        // ===================================================================
+
+        /// <summary>
+        /// <c>ItemShopForm.MakeAllDataLength</c> (slice 2g, version-agnostic). For each shop
+        /// enumerated by <see cref="ItemShopCore.MakeShopList"/> (hensei preparation shop, FE8
+        /// worldmap shops, per-map event-cond shops — verbatim WF <c>MakeShopListLow</c> scan
+        /// order), WF re-inits an IFR at the shop item-list address and emits one BIN
+        /// <see cref="Address"/> whose length is <c>(DataCount + 1) * BlockSize</c> with
+        /// BlockSize = 2 and DataCount = the count of non-zero 2-byte item entries
+        /// (<c>ItemShopForm.Init</c> IsDataExists = <c>u8(addr) != 0x00</c>). Reproduced VERBATIM:
+        /// <list type="bullet">
+        ///   <item>shop_addr = <c>AddrResult.addr</c>; tag (pointer slot) = <c>AddrResult.tag</c>;</item>
+        ///   <item>DataCount = <c>getBlockDataCount(shop_addr, 2, u8(addr)!=0)</c> (the WF IFR walk;
+        ///   NOT <see cref="ItemShopCore.CountShopItems"/>, whose 0x200 cap WF's IFR lacks);</item>
+        ///   <item><c>AddAddress(list, shop_addr, (DataCount+1)*2, tag, "Shop", BIN)</c>.</item>
+        /// </list>
+        /// The shop enumeration depends on the event-script OBJECT-condition scan
+        /// (<see cref="ItemShopCore.MakeShopList"/> via <c>MapEventUnitCore.GetCondSlots</c> /
+        /// <c>GetEventAddrForMap</c>), which are pure ROM reads — so this is faithfully headless.
+        /// </summary>
+        public static void EmitItemShop(ROM rom, List<Address> list)
+        {
+            EmitItemShopList(rom, list, ItemShopCore.MakeShopList(rom));
+        }
+
+        /// <summary>ItemShop emission from an explicit shop list (test seam — lets a synthetic ROM
+        /// supply the shop addr/tag without driving the full event-cond scan). See
+        /// <see cref="EmitItemShop"/> for the verbatim WF reproduction. Each
+        /// <see cref="AddrResult.addr"/> is the shop's item-list address and
+        /// <see cref="AddrResult.tag"/> is the inbound 4-byte pointer slot.</summary>
+        public static void EmitItemShopList(ROM rom, List<Address> list, List<AddrResult> shopList)
+        {
+            if (shopList == null)
+            {
+                return;
+            }
+            const uint block = 2; // ItemShopForm.Init BlockSize.
+            foreach (AddrResult shop in shopList)
+            {
+                uint shopAddr = U.toOffset(shop.addr);
+                // WF ReInit(shop_addr) -> AddAddress early-returns on an unsafe base. getBlockDataCount
+                // itself returns 0 on an unsafe/zero addr, but guard explicitly so the AddAddress below
+                // (which would otherwise emit a 1-block length on a NOT_FOUND base) mirrors WF.
+                if (!U.isSafetyOffset(shopAddr, rom))
+                {
+                    continue;
+                }
+
+                // WF IFR DataCount: getBlockDataCount(shop_addr, 2, u8(addr) != 0). The 2-arg overload
+                // stops at the 0x00 terminator OR at addr+block > Data.Length (EOF) — no extra guard is
+                // needed (the callback only reads u8(addr), fully covered by the loop's addr+block<=Len).
+                uint dataCount = rom.getBlockDataCount(shopAddr, block, (i, addr) => rom.u8(addr) != 0x00);
+                uint length = block * (dataCount + 1);
+                // AddAddress(list, shop_addr, length, tag, "Shop", BIN). The tag (pointer slot) is the
+                // address of the 4-byte pointer that references the shop — relocated by the rebuild.
+                Address.AddAddress(list, shopAddr, length, shop.tag, "Shop", Address.DataTypeEnum.BIN);
+            }
+        }
+
+        /// <summary>
+        /// <c>MapChangeForm.MakeAllDataLength</c> (slice 2g, version-agnostic). Iterates every map
+        /// (<c>mapid &lt; MapSettingForm.GetDataCount()</c>), resolves the per-map mapchange PLIST via
+        /// <see cref="MapChangeCore.GetMapChangeAddrWhereMapID"/> (= WF
+        /// <c>MapSettingForm.GetMapChangeAddrWhereMapID(mapid, out pointer)</c> +
+        /// <c>MapPointerForm.PlistToOffsetAddrFast(CHANGE, ...)</c>), and for each resolved map emits:
+        /// <list type="bullet">
+        ///   <item>the main IFR <see cref="Address"/> (<c>N_Init</c>: BlockSize 12, IsDataExists
+        ///   <c>u8(addr) != 0xFF</c>): <c>AddAddress(N_IFR, "MapChange map:0x&lt;id&gt;", {8})</c>
+        ///   via <c>ReInitPointer(pointer)</c> — base = <c>p32(pointer)</c>, length =
+        ///   12 × (DataCount + 1), pointer = the PLIST slot, pointerIndexes {8};</item>
+        ///   <item>per entry (<c>p = base + i*12</c>): <c>w = u8(p+3)</c>, <c>h = u8(p+4)</c>,
+        ///   <c>change_mar = p32(p+8)</c>; if <c>isSafetyOffset(change_mar)</c> a BIN
+        ///   <see cref="Address"/> of length <c>w*h*2</c> at <c>change_mar</c>, pointer slot
+        ///   <c>p+8</c>.</item>
+        /// </list>
+        /// The map iteration uses <see cref="MapSettingCore.MakeMapIDList"/> (= WF
+        /// <c>Init().MakeList()</c>) whose entries carry the sequential mapid in <c>tag</c>; the loop
+        /// is bounded by its <c>.Count</c> (= WF <c>GetDataCount()</c>). All reads are pure ROM reads
+        /// — faithfully headless.
+        /// </summary>
+        public static void EmitMapChange(ROM rom, List<Address> list)
+        {
+            // WF: for (mapid = 0; mapid < GetDataCount(); mapid++). MakeMapIDList(rom) yields one entry
+            // per map with tag == mapid (sequential), Count == the WF IFR DataCount.
+            foreach (AddrResult map in MapSettingCore.MakeMapIDList(rom))
+            {
+                uint mapid = map.tag;
+                uint change_addr = MapChangeCore.GetMapChangeAddrWhereMapID(rom, mapid, out uint pointer);
+                if (change_addr == U.NOT_FOUND)
+                {
+                    continue; // WF: change_addr == NOT_FOUND -> continue.
+                }
+                EmitMapChangeAt(rom, list, mapid, pointer);
+            }
+        }
+
+        /// <summary>MapChange emission for one map from its resolved CHANGE PLIST slot
+        /// <paramref name="pointer"/> (test seam — lets a synthetic ROM supply the slot directly
+        /// without populating the map-setting / PLIST tables). See <see cref="EmitMapChange"/> for the
+        /// verbatim WF reproduction. <paramref name="pointer"/> is the 4-byte PLIST-table slot whose
+        /// <c>p32</c> is the change-data base (WF <c>N_InputFormRef.ReInitPointer(pointer)</c>).</summary>
+        public static void EmitMapChangeAt(ROM rom, List<Address> list, uint mapid, uint pointer)
+        {
+            const uint block = 12; // MapChangeForm.N_Init BlockSize.
+
+            // WF N_InputFormRef.ReInitPointer(pointer): BasePointer = pointer, BaseAddress = p32(pointer).
+            // Guard the full 4-byte slot before p32 (pointer+3) so a near-EOF slot skips, not throws
+            // (matches the EmitUnitFE6At / ItemUsage root+3 convention).
+            uint pointerSlot = U.toOffset(pointer);
+            if (!U.isSafetyOffset(pointerSlot + 3, rom))
+            {
+                return;
+            }
+            uint baseAddr = rom.p32(pointerSlot);
+            // WF AddAddress early-returns when !isSafetyOffset(BaseAddress) (the pointer slot then
+            // becomes NOT_FOUND); without a safe base there is also nothing to walk.
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                return;
+            }
+
+            // N_Init IsDataExists = u8(addr) != 0xFF. The 2-arg getBlockDataCount stops at the 0xFF
+            // terminator OR at addr+12 > Data.Length (EOF) — the callback reads only u8(addr).
+            uint dataCount = rom.getBlockDataCount(baseAddr, block, (i, addr) => rom.u8(addr) != 0xFF);
+
+            // Main IFR: AddAddress(N_IFR, "MapChange map:0x<id>", {8}) -> length = 12 * (DataCount + 1),
+            // pointer = BasePointer = the PLIST slot (safe here), pointerIndexes {8}.
+            uint length = block * (dataCount + 1);
+            string name = "MapChange map:" + U.To0xHexString(mapid);
+            list.Add(new Address(baseAddr, length, pointerSlot, name,
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { 8 }));
+
+            // Per-entry change-map BIN blocks (WF inner loop): for each entry p = base + i*12 read the
+            // w/h size bytes and the +8 change pointer, then add a w*h*2 BIN block behind it.
+            for (uint i = 0; i < dataCount; i++)
+            {
+                uint p = baseAddr + i * block;
+                // Guard the full 12-byte record (the deepest read is p32(p+8) -> p+11) before any read,
+                // so a corrupted/too-large DataCount near EOF skips instead of throwing. On valid ROMs
+                // every record is fully in-bounds (getBlockDataCount already bounded by addr+12<=Len),
+                // so this only hardens synthetic/corrupted ROMs — but the p32(p+8) read below reaches
+                // p+11, one byte past getBlockDataCount's addr+block-1, so the explicit guard is needed.
+                if (p + block > (uint)rom.Data.Length)
+                {
+                    break;
+                }
+                uint w = rom.u8(p + 3); // size w
+                uint h = rom.u8(p + 4); // size h
+                uint change_mar = rom.p32(p + 8); // change-map pointer
+                if (!U.isSafetyOffset(change_mar, rom))
+                {
+                    continue; // WF: !isSafetyOffset(change_mar) -> continue (no emit for this entry).
+                }
+                string entryName = "MapChange map:" + U.To0xHexString(mapid) + " n:" + U.To0xHexString(i);
+                Address.AddAddress(list, change_mar, w * h * 2, p + 8, entryName,
+                    Address.DataTypeEnum.BIN);
+            }
+        }
+
+        /// <summary>
+        /// <c>MapExitPointForm.MakeAllDataLength</c> (slice 2g, version-agnostic). Emits TWO main IFR
+        /// tables (enemy + NPC escape-point slot tables) plus a per-map sub-table for each:
+        /// <list type="bullet">
+        ///   <item><b>enemy main</b> (<c>Init</c>: BasePointer = <c>map_exit_point_pointer</c>, BlockSize
+        ///   4, IsDataExists <c>isPointerOrNULL(u32(addr)) &amp;&amp; i &lt; npc_blockadd</c>):
+        ///   <c>AddAddress(IFR, "MapExit", {0})</c> — length 4 × (DataCount + 1), pointer =
+        ///   <c>map_exit_point_pointer</c>, pointerIndexes {0};</item>
+        ///   <item><b>enemy per-map</b> (<c>mapid &lt; GetDataCount()</c>): <c>exit_addr =
+        ///   IDToAddr(mapid)</c> (= enemy base + mapid*4, bounded by the enemy IFR DataCount); skip when
+        ///   out of range or <c>p32(exit_addr) == NOT_FOUND</c>; else <c>N_ReInitPointer(exit_addr)</c>
+        ///   (<c>N_Init</c>: BlockSize 4, <c>u8(addr) != 0xFF</c>) and
+        ///   <c>AddAddress(N_IFR, "MapExit map:0x&lt;id&gt;", {})</c> — length 4 × (N_DataCount + 1),
+        ///   pointer = <c>exit_addr</c>, empty pointerIndexes;</item>
+        ///   <item><b>NPC main</b>: <c>ReInit(p32(map_exit_point_pointer) + 4*npc_blockadd)</c> then
+        ///   <c>AddAddressButIgnorePointer(IFR, "MapExit NPC", {0})</c> — pointer FORCED to NOT_FOUND
+        ///   (the NPC base is reached by a computed offset, not a RomInfo slot), type InputFormRef;</item>
+        ///   <item><b>NPC per-map</b>: identical to enemy per-map but rooted at the NPC base, name
+        ///   "MapExit map:0x&lt;id&gt; NPC".</item>
+        /// </list>
+        /// Reproduced VERBATIM (the enemy/NPC bases, the <c>i &lt; npc_blockadd</c> enemy cap, the
+        /// <c>ButIgnorePointer</c> NPC main). All reads are pure ROM reads — faithfully headless.
+        /// </summary>
+        public static void EmitMapExitPoint(ROM rom, List<Address> list)
+        {
+            uint mapCount = (uint)MapSettingCore.MakeMapIDList(rom).Count; // WF GetDataCount().
+            EmitMapExitPointAt(rom, list, rom.RomInfo.map_exit_point_pointer,
+                rom.RomInfo.map_exit_point_npc_blockadd, mapCount);
+        }
+
+        /// <summary>MapExitPoint emission from explicit RomInfo addresses (test seam — lets a synthetic
+        /// ROM supply the pointer slot / npc_blockadd / map count without populating RomInfo). See
+        /// <see cref="EmitMapExitPoint"/> for the verbatim WF reproduction.</summary>
+        public static void EmitMapExitPointAt(ROM rom, List<Address> list, uint rawMainPointer,
+            uint npcBlockAdd, uint mapCount)
+        {
+            const uint block = 4; // Init / N_Init BlockSize.
+
+            // --- enemy table ---
+            // WF Init: BasePointer = map_exit_point_pointer, BaseAddress = p32(map_exit_point_pointer).
+            uint mainPointer = U.toOffset(rawMainPointer);
+            if (!U.isSafetyOffset(mainPointer + 3, rom))
+            {
+                return; // p32(mainPointer) would read junk past EOF.
+            }
+            uint enemyBase = rom.p32(mainPointer);
+
+            // Enemy IsDataExists = isPointerOrNULL(u32(addr)) && i < npc_blockadd.
+            Func<int, uint, bool> enemyRule = (i, addr) =>
+                U.isPointerOrNULL(rom.u32(addr)) && i < npcBlockAdd;
+
+            // Enemy main: AddAddress(IFR, "MapExit", {0}) — pointer = BasePointer (map_exit_point_pointer).
+            EmitMapExitMain(rom, list, enemyBase, block, enemyRule, mainPointer, "MapExit",
+                new uint[] { 0 }, ignorePointer: false);
+
+            // Enemy per-map sub-tables: exit_addr = enemyBase + mapid*4 (IDToAddr bounded by the enemy
+            // IFR DataCount). The DataCount is the getBlockDataCount over the enemy rule.
+            EmitMapExitSubTables(rom, list, enemyBase, block, enemyRule, mapCount, "");
+
+            // --- NPC table ---
+            // WF: InputFormRef.ReInit(p32(map_exit_point_pointer) + 4 * npc_blockadd). BasePointer is
+            // UNCHANGED by ReInit (still map_exit_point_pointer), but AddAddressButIgnorePointer forces
+            // the emitted pointer to NOT_FOUND, so the NPC main's pointer slot is intentionally untracked.
+            uint npcBase = enemyBase + block * npcBlockAdd;
+
+            // NPC main: AddAddressButIgnorePointer(IFR, "MapExit NPC", {0}) — pointer forced NOT_FOUND.
+            EmitMapExitMain(rom, list, npcBase, block, enemyRule, mainPointer, "MapExit NPC",
+                new uint[] { 0 }, ignorePointer: true);
+
+            // NPC per-map sub-tables: exit_addr = npcBase + mapid*4 (IDToAddr bounded by the NPC IFR
+            // DataCount, computed from the same enemy rule over the NPC base). Name suffix " NPC".
+            EmitMapExitSubTables(rom, list, npcBase, block, enemyRule, mapCount, " NPC");
+        }
+
+        /// <summary>The MapExitPoint main-IFR emit (enemy or NPC). Reproduces
+        /// <c>AddressWinForms.AddAddress</c> (or <c>AddAddressButIgnorePointer</c> when
+        /// <paramref name="ignorePointer"/>): addr = BaseAddress, length = block × (DataCount + 1),
+        /// type InputFormRef. The pointer is <paramref name="basePointer"/> for the enemy table and
+        /// forced NOT_FOUND for the NPC table.</summary>
+        static void EmitMapExitMain(ROM rom, List<Address> list, uint baseAddr, uint block,
+            Func<int, uint, bool> rule, uint basePointer, string name, uint[] pointerIndexes,
+            bool ignorePointer)
+        {
+            // WF AddAddress: early-return when !isSafetyOffset(BaseAddress).
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                return;
+            }
+            uint dataCount = rom.getBlockDataCount(baseAddr, block, rule);
+            uint length = block * (dataCount + 1);
+            // AddAddress: pointer = BasePointer (-> NOT_FOUND if unsafe). ButIgnorePointer: pointer
+            // ALWAYS NOT_FOUND. basePointer (the RomInfo slot) is already verified safe by the caller.
+            uint pointer = ignorePointer ? U.NOT_FOUND : basePointer;
+            list.Add(new Address(baseAddr, length, pointer, name,
+                Address.DataTypeEnum.InputFormRef, block, pointerIndexes));
+        }
+
+        /// <summary>The MapExitPoint per-map sub-table loop (enemy or NPC). For each
+        /// <c>mapid &lt; mapCount</c>, WF computes <c>exit_addr = IDToAddr(mapid)</c> (= base + mapid*4,
+        /// NOT_FOUND once <c>mapid &gt;= mainDataCount</c>), checks <c>p32(exit_addr) != NOT_FOUND</c>,
+        /// then <c>N_ReInitPointer(exit_addr)</c> + <c>AddAddress(N_IFR, "MapExit map:0x&lt;id&gt;" +
+        /// suffix, {})</c> — block × (N_DataCount + 1), pointer = exit_addr, empty pointerIndexes, type
+        /// InputFormRef.</summary>
+        static void EmitMapExitSubTables(ROM rom, List<Address> list, uint base_, uint block,
+            Func<int, uint, bool> mainRule, uint mapCount, string nameSuffix)
+        {
+            if (!U.isSafetyOffset(base_, rom))
+            {
+                return; // base unsafe -> IDToAddr's IFR DataCount is 0 -> no sub-tables.
+            }
+            // The main IFR DataCount bounds IDToAddr (WF: id >= DataCount -> NOT_FOUND). Compute it once.
+            uint mainDataCount = rom.getBlockDataCount(base_, block, mainRule);
+
+            for (uint mapid = 0; mapid < mapCount; mapid++)
+            {
+                // WF IDToAddr(mapid): NOT_FOUND when mapid >= mainDataCount.
+                if (mapid >= mainDataCount)
+                {
+                    continue;
+                }
+                uint exitAddr = base_ + mapid * block;
+                // Guard the full 4-byte slot before p32(exitAddr) (exitAddr+3). On valid ROMs the slot is
+                // in-bounds (mapid < mainDataCount, which getBlockDataCount bounded by addr+block<=Len);
+                // this only hardens corrupted ROMs (p32 reads exitAddr..exitAddr+3).
+                if (!U.isSafetyOffset(exitAddr + 3, rom))
+                {
+                    continue;
+                }
+                // WF: a = p32(exit_addr); if (a == U.NOT_FOUND) continue. p32 strips 0x08000000 so it is
+                // never literally NOT_FOUND; reproduced for structural fidelity (the real gate is the
+                // N base-safety below, exactly as WF's N_ReInitPointer -> AddAddress early-return).
+                uint a = rom.p32(exitAddr);
+                if (a == U.NOT_FOUND)
+                {
+                    continue;
+                }
+
+                // N_ReInitPointer(exit_addr): N BasePointer = exit_addr, N BaseAddress = p32(exit_addr).
+                uint nBase = rom.p32(exitAddr);
+                // N_Init IsDataExists = u8(addr) != 0xFF. AddAddress early-returns on an unsafe N base.
+                if (!U.isSafetyOffset(nBase, rom))
+                {
+                    continue;
+                }
+                uint nDataCount = rom.getBlockDataCount(nBase, block, (i, addr) => rom.u8(addr) != 0xFF);
+                uint length = block * (nDataCount + 1);
+                string name = "MapExit map:" + U.To0xHexString(mapid) + nameSuffix;
+                // AddAddress(N_IFR, name, {}) -> pointer = N BasePointer = exit_addr, empty pointerIndexes.
+                list.Add(new Address(nBase, length, exitAddr, name,
+                    Address.DataTypeEnum.InputFormRef, block, new uint[] { }));
+            }
+        }
+
+        /// <summary>
+        /// <c>MapTileAnimation1Form.MakeAllDataLength</c> (slice 2g, version-agnostic). Builds the
+        /// dedup'd anime1-PLIST list (WF <c>MakeTileAnimation1</c>: every map's <c>anime1_plist</c> at
+        /// map-setting +9, skip 0 / already-seen, resolved via
+        /// <c>MapPointerForm.PlistToOffsetAddr(ANIMATION, plist)</c> =
+        /// <see cref="MapChangeCore.PlistToOffsetAddr"/> with
+        /// <see cref="MapChangeCore.PlistType.ANIMATION"/>), then for each resolved PLIST emits:
+        /// <list type="bullet">
+        ///   <item>the main IFR <see cref="Address"/> (<c>Init</c>: BlockSize 8, IsDataExists
+        ///   <c>isPointer(u32(addr+4))</c>): <c>AddAddress(IFR, name, {4})</c> via
+        ///   <c>ReInit(addr)</c> — base = addr, BasePointer = 0 -&gt; NOT_FOUND, length =
+        ///   8 × (DataCount + 1), pointerIndexes {4};</item>
+        ///   <item>per entry (<c>p = base + i*8</c>): <c>img = p32(p+4)</c>, <c>len = u16(p+2)</c>;
+        ///   if <c>isSafetyOffset(img)</c> an IMG <see cref="Address"/> of length <c>len</c> at
+        ///   <c>img</c>, pointer slot <c>p+4</c>.</item>
+        /// </list>
+        /// Reproduced VERBATIM. Uses <see cref="MapChangeCore.PlistToOffsetAddr"/> (NOT the
+        /// <c>MapTileAnimation1Core.BuildPlistList</c> resolution, which omits the version PLIST-limit
+        /// gate) so the resolved data set is byte-identical to WF; a resolution that returns 0/NOT_FOUND
+        /// emits no <see cref="Address"/> (WF <c>ReInit</c> on an unsafe base early-returns).
+        /// </summary>
+        public static void EmitMapTileAnimation1(ROM rom, List<Address> list)
+        {
+            EmitMapTileAnimationN(rom, list, atOffset: 9, MapChangeCore.PlistType.ANIMATION,
+                imgAtPlus4: true);
+        }
+
+        /// <summary>
+        /// <c>MapTileAnimation2Form.MakeAllDataLength</c> (slice 2g, version-agnostic). Same shape as
+        /// <see cref="EmitMapTileAnimation1"/> but: the per-map PLIST is <c>anime2_plist</c> at
+        /// map-setting +10, the PLIST type is <see cref="MapChangeCore.PlistType.ANIMATION2"/>, the
+        /// main IFR IsDataExists is <c>isPointer(u32(addr+0))</c> (image pointer at +0, NOT +4), the
+        /// main IFR pointerIndexes is {0}, and each per-entry block is a BIN of length <c>u8(p+5) * 2</c>
+        /// behind the +0 pointer (<c>count = u8(p+5)</c>; palette rows are 2 bytes each). Reproduced
+        /// VERBATIM.
+        /// </summary>
+        public static void EmitMapTileAnimation2(ROM rom, List<Address> list)
+        {
+            EmitMapTileAnimationN(rom, list, atOffset: 10, MapChangeCore.PlistType.ANIMATION2,
+                imgAtPlus4: false);
+        }
+
+        /// <summary>Shared MapTileAnimation1/2 emitter. <paramref name="atOffset"/> is the map-setting
+        /// byte holding the per-map PLIST (9 = anime1, 10 = anime2); <paramref name="plistType"/> is the
+        /// PLIST table; <paramref name="imgAtPlus4"/> selects the anime1 schema (image pointer at +4,
+        /// IMG length = <c>u16(p+2)</c>, pointerIndexes {4}) vs the anime2 schema (image pointer at +0,
+        /// BIN length = <c>u8(p+5) * 2</c>, pointerIndexes {0}). Reproduces WF <c>MakeTileAnimationN</c>
+        /// (dedup by PLIST) + the per-entry inner loop VERBATIM.</summary>
+        static void EmitMapTileAnimationN(ROM rom, List<Address> list, uint atOffset,
+            MapChangeCore.PlistType plistType, bool imgAtPlus4)
+        {
+            var seen = new HashSet<uint>();
+            foreach (AddrResult map in MapSettingCore.MakeMapIDList(rom))
+            {
+                // anime1_plist = u8(mapAddr+9) / anime2_plist = u8(mapAddr+10).
+                uint mapAddr = map.addr;
+                if (mapAddr + atOffset + 1 > (uint)rom.Data.Length)
+                {
+                    continue;
+                }
+                uint plist = rom.u8(mapAddr + atOffset);
+                if (plist == 0)
+                {
+                    continue; // WF: plist == 0 -> continue.
+                }
+                if (!seen.Add(plist))
+                {
+                    continue; // WF: already-found dedup.
+                }
+
+                // WF: addr = PlistToOffsetAddr(ANIMATION/ANIMATION2, plist). Returns the resolved data
+                // offset (or 0/NOT_FOUND when broken). MapChangeCore.PlistToOffsetAddr applies the same
+                // version PLIST-limit + safety gate as the WF MapPointerForm path. A broken resolution
+                // (NOT_FOUND) means WF marks the row "(破損)" and ReInit on it emits nothing — so skip.
+                uint dataAddr = MapChangeCore.PlistToOffsetAddr(rom, plistType, plist, out uint _);
+                EmitMapTileAnimationFor(rom, list, dataAddr, plist, imgAtPlus4);
+            }
+        }
+
+        /// <summary>MapTileAnimation emission for one resolved PLIST data address (test seam — lets a
+        /// synthetic ROM supply the entry-table base + plist directly without populating the
+        /// map-setting / PLIST tables). <paramref name="dataAddr"/> is the WF <c>urList[n].addr</c>
+        /// (the PLIST-resolved entry-table base); <paramref name="imgAtPlus4"/> selects the anime1 vs
+        /// anime2 schema. See <see cref="EmitMapTileAnimation1"/> / <see cref="EmitMapTileAnimation2"/>
+        /// for the verbatim WF reproduction.</summary>
+        public static void EmitMapTileAnimationFor(ROM rom, List<Address> list, uint dataAddr,
+            uint plist, bool imgAtPlus4)
+        {
+            const uint block = 8; // Init BlockSize (both anime1 and anime2).
+
+            // WF: InputFormRef.ReInit(urList[n].addr). On an unsafe/NOT_FOUND base the IFR DataCount is 0
+            // and AddAddress early-returns — emit nothing (the "(破損)"/0-resolution case).
+            uint baseAddr = U.toOffset(dataAddr);
+            if (dataAddr == U.NOT_FOUND || !U.isSafetyOffset(baseAddr, rom))
+            {
+                return;
+            }
+
+            // Main IFR IsDataExists: anime1 = isPointer(u32(addr+4)); anime2 = isPointer(u32(addr+0)).
+            uint imgOffset = imgAtPlus4 ? 4u : 0u;
+            uint dataCount = rom.getBlockDataCount(baseAddr, block,
+                (i, addr) => U.isPointer(rom.u32(addr + imgOffset)));
+
+            // Main IFR Address: AddAddress(IFR, name, {imgOffset}). BasePointer = 0 -> NOT_FOUND (the
+            // entry table is reached via the PLIST resolution, not a plain RomInfo pointer slot). The WF
+            // name is the localized "タイルアニメーション1/2:0x<plist>" string; the label is non-load-
+            // bearing for relocation (same convention as SoundFootSteps), so a stable ASCII label is
+            // used here ("MapTileAnime1/2:0x<plist>") — headless and locale-independent.
+            uint length = block * (dataCount + 1);
+            string animeKind = imgAtPlus4 ? "1" : "2";
+            string name = "MapTileAnime" + animeKind + ":" + U.To0xHexString(plist);
+            list.Add(new Address(baseAddr, length, U.NOT_FOUND, name,
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { imgOffset }));
+
+            // Per-entry image/palette blocks (WF inner loop).
+            for (uint i = 0; i < dataCount; i++)
+            {
+                uint p = baseAddr + i * block;
+                // Guard the full 8-byte record before any read. The deepest read is p32(p+4) -> p+7
+                // (anime1) or u8(p+5) (anime2); getBlockDataCount already bounded addr+block<=Len, but
+                // guard explicitly so a corrupted DataCount near EOF skips instead of throwing.
+                if (p + block > (uint)rom.Data.Length)
+                {
+                    break;
+                }
+                if (imgAtPlus4)
+                {
+                    // anime1: addr = p32(p+4); len = u16(p+2); IMG block of length len at addr, slot p+4.
+                    uint addr = rom.p32(p + 4);
+                    uint imgLen = rom.u16(p + 2);
+                    if (U.isSafetyOffset(addr, rom))
+                    {
+                        Address.AddAddress(list, addr, imgLen, p + 4,
+                            name + "_" + U.ToHexString(i), Address.DataTypeEnum.IMG);
+                    }
+                }
+                else
+                {
+                    // anime2: addr = p32(p+0); count = u8(p+5); BIN block of length count*2 at addr, slot p+0.
+                    uint addr = rom.p32(p + 0);
+                    uint count = rom.u8(p + 5);
+                    if (U.isSafetyOffset(addr, rom))
+                    {
+                        Address.AddAddress(list, addr, count * 2, p + 0,
+                            name + "_" + U.To0xHexString(i), Address.DataTypeEnum.BIN);
+                    }
+                }
+            }
         }
 
         /// <summary>Turn a descriptor's <see cref="DataCountRule"/> into the
@@ -2835,7 +3348,9 @@ namespace FEBuilderGBA
                 //  and MenuDefinitionForm [recursive MenuCommandForm sub-table — InputFormRef_MIX + per-entry
                 //  CString + 6 ASM ptrs — + its own 6 ASM ptrs] ported in slice 2d via dedicated recursive
                 //  walkers; MenuCommandForm.MakeAllDataLengthP is reproduced by EmitMenuCommandSubTable.)
-                "ItemShopForm",
+                // (ItemShopForm ported in slice 2g — EmitItemShop walks ItemShopCore.MakeShopList [hensei +
+                //  FE8 worldmap + per-map event-cond OBJECT-slot shops] and emits one BIN Address per shop,
+                //  length = (count of non-zero 2-byte item entries + 1) * 2.)
                 "ItemWeaponEffectForm",
                 // UnitActionPointerForm STAYS — its base = SearchActionPointer(), gated on
                 //   PatchUtil.SearchUnitActionReworkPatch() (PatchUtil patch detection not in Core).
@@ -2843,11 +3358,16 @@ namespace FEBuilderGBA
                 //  the 10 Switch2-gated usage tables, base/count from each xxx_array_switch2_address via
                 //  the Core ItemUsagePointerCore.IsSwitch2Enable + per-entry ASM AddFunction @0.)
                 "UnitActionPointerForm",
-                // MapChangeForm/MapExitPointForm — tractable via the Core map helpers
-                //   (MapChangeCore.GetMapChangeAddrWhereMapID / MapExitPointCore.ListMapEntries +
-                //    ListExitPointsForMap) but each needs a dedicated per-map walker with verbatim
-                //    per-entry length reproduction; DEFERRED for slice size (a coherent map-PLIST batch).
-                "MapChangeForm", "MapExitPointForm", "MapPointerForm", "FontForm",
+                // (MapChangeForm + MapExitPointForm ported in slice 2g via dedicated per-map walkers:
+                //  EmitMapChange [per map: MapChangeCore.GetMapChangeAddrWhereMapID -> main 12-byte IFR
+                //  {8} + per-entry w*h*2 BIN behind +8] and EmitMapExitPoint [enemy + NPC 4-byte slot
+                //  tables, each with a per-map N-table; NPC main via ButIgnorePointer].
+                //  MapPointerForm STAYS — out of the slice-2g per-map-PLIST scope: its MakeAllDataLength
+                //  emits 6+ MAPPOINTERS IFR tables AND a per-map sweep that reads palette2_plist via
+                //  MapSettingForm.GetMapPListsWhereAddr, gated on PatchUtil.SearchFlag0x28ToMapSecond-
+                //  PalettePatch (PatchUtil patch detection not in Core), so its column set can't be
+                //  reproduced verbatim yet.)
+                "MapPointerForm", "FontForm",
                 // AI scripts (disasm)
                 // (AIMapSettingForm [flat u8!=0xFF table], AIPerformStaffForm + AIPerformItemForm
                 //  [flat u16!=0 table + per-entry ASM AddFunction @4 via SubKind.AsmFunction] ported in
@@ -2868,15 +3388,16 @@ namespace FEBuilderGBA
                 //  listed above), so there is nothing extra to port for it.
                 //  MantAnimationForm ported in slice 2f — PointerAt@0 main IFR ("Mant") + per-entry
                 //  SubKind.FixedPointer @0 (0x10-byte POINTER block "MANT_P:0x<i>").
-                //  MapTileAnimation1Form/MapTileAnimation2Form — tractable via the Core helpers
-                //  (MapTileAnimation1Core/2Core.BuildPlistList + ScanEntries) but need a dedicated
-                //  per-PLIST walker with verbatim per-entry IMG/BIN length reproduction; DEFERRED for
-                //  slice size (the coherent map-PLIST batch).
-                //  MapTerrainFloorLookupTableForm/MapTerrainBGLookupTableForm — their pointer set comes
+                //  (MapTileAnimation1Form + MapTileAnimation2Form ported in slice 2g — EmitMapTileAnimation1
+                //   / EmitMapTileAnimation2 build the dedup'd per-map PLIST list [anime1_plist@+9 /
+                //   anime2_plist@+10, resolved via MapChangeCore.PlistToOffsetAddr ANIMATION/ANIMATION2 with
+                //   the version PLIST-limit gate], emit the main 8-byte IFR [isPointer(u32+4)/{4} for anime1,
+                //   isPointer(u32+0)/{0} for anime2], then per-entry IMG [u16(p+2) @ p32(p+4)] / BIN
+                //   [u8(p+5)*2 @ p32(p+0)] columns.)
+                //  MapTerrainFloorLookupTableForm/MapTerrainBGLookupTableForm STAY — their pointer set comes
                 //  from GetPointersExtendsPatch (PatchUtil.SearchExtendsBattleBG + hardcoded FE8 offsets),
                 //  not in Core.)
-                "MapTileAnimation1Form",
-                "MapTileAnimation2Form", "MapTerrainFloorLookupTableForm",
+                "MapTerrainFloorLookupTableForm",
                 "MapTerrainBGLookupTableForm",
                 // units / classes per-version with extra reads
                 // (UnitForm [FE8, flat + 24-byte support BinFixed sub-walk @44] and UnitFE7Form


### PR DESCRIPTION
## Summary
**Slice 2g** of #1261 — the **per-map PLIST** producer forms. Each is a dedicated `Emit…` walker (a flat `StructDescriptor` can't express per-map PLIST tables), reproducing the WF `MakeAllDataLength` Address list verbatim. All 5 target Core helpers existed and were sufficient — no deferrals.

## Ported (5 forms — all version-agnostic, confirmed in the WF unconditional section `U.cs` 2425/2426/2430/2472/2473)
1. **ItemShopForm** → `EmitItemShop`/`EmitItemShopList` — walks `ItemShopCore.MakeShopList` (hensei + FE8 worldmap + per-map event-cond OBJECT shops); one BIN Address per shop, length `(DataCount+1)*BlockSize` via `getBlockDataCount(shop, 2, u8!=0)`. **Deliberately NOT `CountShopItems`** — its 0x200 cap would diverge from WF's `InputFormRef.DataCount` (verified WF uses `(InputFormRef.DataCount+1) * InputFormRef.BlockSize`).
2. **MapChangeForm** → `EmitMapChange`/`EmitMapChangeAt` — per map: `MapChangeCore.GetMapChangeAddrWhereMapID(out pointer)` → main 12-byte IFR pIdx `{8}` (u8!=0xFF) + per-entry `w*h*2` BIN behind +8.
3. **MapExitPointForm** → `EmitMapExitPoint`/`EmitMapExitPointAt` — enemy + NPC 4-byte slot tables (enemy `isPointerOrNULL(u32) && i<npc_blockadd`; NPC main via `AddAddressButIgnorePointer` → NOT_FOUND pointer — verbatim) each with a per-map N-table; map count from `MapSettingCore.MakeMapIDList`.
4/5. **MapTileAnimation1/2Form** → `EmitMapTileAnimation1/2`/`…N`/`…For` — dedup'd per-map PLIST (anime1@+9 / anime2@+10) resolved via `MapChangeCore.PlistToOffsetAddr` ANIMATION/ANIMATION2 **WITH the version PLIST-limit gate** (deliberately NOT the cores' `BuildPlistList` addr, which skips that limit) → 8-byte main IFR (anime1 `isPointer(u32+4)`/{4}; anime2 `isPointer(u32+0)`/{0}) + per-entry IMG[`u16(p+2)`@`p32(p+4)`] / BIN[`u8(p+5)*2`@`p32(p+0)`].

## Disciplines
- **Verbatim** vs each WF `MakeAllDataLength` (AddAddress vs `AddAddressButIgnorePointer` reproduced exactly for the NPC main).
- **Version audit:** all 5 in the WF unconditional section — no FE6/FE7/FE8 variant, no `is_multibyte` branch.
- **EOF self-audit:** every raw `p32`/`u32`/`u16`/`u8` in the new walkers guarded before the read — `pointer+3` slot guards + per-entry `p + block > Data.Length → break` (block 12 MapChange, 8 TileAnime — covers the deepest p32 at +8/+4) + `getBlockDataCount`'s own `addr+block≤Len`.

## Tests
- RebuildProducer filter: **120 passed / 0 failed** (+18): synthetic per-map structures via `*At`/`*List`/`*For` test seams; a near-EOF `Record.Exception`-null case per hand-written walker; coverage delta; a RomInfo-driven no-throw test on a versioned-empty FE8 ROM. Updated 4 stale NotYetPorted coverage assertions.
- FEBuilderGBA.Tests (net9.0-windows): **1865 passed / 0 failed**.
- (Full Core.Tests: only the known env-only `SkillConfigSkillSystem*`/`SkillSystemsAnime*` failures — `config/patch2` submodule absent in the worktree. Zero RebuildProducer failures.)

Part of #1261.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
