### PR TITLE
feat(core): ROM-rebuild producer — OP/ED LZ77 + SupportUnit/WorldMapPath forms (#1261 slice 2h)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -1698,14 +1698,16 @@ namespace FEBuilderGBA.Core.Tests
             // Still deferred (un-ported subsystem) -> must REMAIN:
             foreach (var kept in new[]
             {
-                "EventBattleTalkForm", "EventHaikuForm", "SupportUnitForm",
-                "WorldMapPathForm", "WorldMapEventPointerForm", "EDStaffRollForm", "OPPrologueForm",
-                "MapSettingForm", "OPClassFontForm", "OPClassDemoForm", "FE8SpellMenuExtendsForm",
+                "EventBattleTalkForm", "EventHaikuForm",
+                "WorldMapEventPointerForm",
+                "MapSettingForm", "OPClassDemoForm", "FE8SpellMenuExtendsForm",
                 "MonsterWMapProbabilityForm", "SoundRoomForm",
                 // (StatusOptionForm + SoundFootStepsForm ported in slice 2d -> no longer kept here.
                 //  UnitFE6Form + ItemUsagePointerForm + AIPerform*/AIMapSetting/Mant/ArenaEnemyWeapon
                 //  ported in slice 2f -> no longer kept here. MapTileAnimation1Form/MapTileAnimation2Form +
-                //  ItemShopForm + MapChangeForm + MapExitPointForm ported in slice 2g -> no longer kept.)
+                //  ItemShopForm + MapChangeForm + MapExitPointForm ported in slice 2g -> no longer kept.
+                //  SupportUnitForm + WorldMapPathForm + EDStaffRollForm + OPPrologueForm + OPClassFontForm
+                //  ported in slice 2h -> no longer kept here.)
                 "ItemForm", "MapTerrainFloorLookupTableForm",
             })
             {
@@ -3917,6 +3919,447 @@ namespace FEBuilderGBA.Core.Tests
             {
                 CoreState.ROM = savedRom;
             }
+        }
+
+        // ====================================================================
+        // slice 2h — OP/ED LZ77 stragglers (OPPrologue / EDStaffRoll / OPClassFont
+        // descriptors) + SupportUnit (owner-lookahead flat IFR) + WorldMapPath
+        // (per-entry computed-length sub-blocks). Descriptor-shape + version-gate
+        // tests, LZ77 emit tests, dedicated-emitter tests with a near-EOF no-throw
+        // case, and the NotYetPorted coverage delta.
+        // ====================================================================
+
+        // ---- OPPrologue / EDStaffRoll descriptors (FE8, version==8) ----------
+
+        [Fact]
+        public void BuildBatchDescriptors_FE8_HasOPPrologue_Block12_TwoLz77Cols_AndPalExtra()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                var descs = RebuildProducerCore.BuildBatchDescriptors(fe8);
+                var d = descs.Single(x => x.Name == "OPPrologue");
+                Assert.Equal(12u, d.BlockSize);
+                Assert.Equal(RebuildProducerCore.DataCountRule.PointerAt, d.Rule);
+                Assert.Equal(0u, d.RuleOffset);
+                Assert.Equal(new uint[] { 0, 4 }, d.PointerIndexes);
+                // Two LZ77 columns: IMG @0, TSA @4.
+                Assert.Equal(2, d.SubWalks.Count);
+                Assert.All(d.SubWalks, s => Assert.Equal(RebuildProducerCore.SubKind.Lz77Pointer, s.Kind));
+                Assert.Equal(Address.DataTypeEnum.LZ77IMG, d.SubWalks[0].DataType);
+                Assert.Equal(0u, d.SubWalks[0].EmbeddedPointerOffset);
+                Assert.Equal(Address.DataTypeEnum.LZ77TSA, d.SubWalks[1].DataType);
+                Assert.Equal(4u, d.SubWalks[1].EmbeddedPointerOffset);
+                // Standalone palette ExtraFixedPointer (emitted once, type PAL, length 0x20).
+                var ep = Assert.Single(d.ExtraFixedPointers);
+                Assert.Equal(2u * 16u, ep.FixedLength);
+                Assert.Equal(Address.DataTypeEnum.PAL, ep.DataType);
+                Assert.Equal("OPPrologue Palette", ep.Name);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void BuildBatchDescriptors_FE8_HasEDStaffRoll_Block8_PointerAtCappedAt12()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                var descs = RebuildProducerCore.BuildBatchDescriptors(fe8);
+                var d = descs.Single(x => x.Name == "EDStaffRoll");
+                Assert.Equal(8u, d.BlockSize);
+                Assert.Equal(RebuildProducerCore.DataCountRule.PointerAt, d.Rule);
+                // WF rule: isPointer(u32+0) && i < 12 -> PointerAt with MaxCount 12.
+                Assert.Equal(12u, d.MaxCount);
+                Assert.Equal(new uint[] { 0, 4 }, d.PointerIndexes);
+                Assert.Equal(2, d.SubWalks.Count);
+                Assert.Equal(Address.DataTypeEnum.LZ77IMG, d.SubWalks[0].DataType);
+                Assert.Equal(Address.DataTypeEnum.LZ77TSA, d.SubWalks[1].DataType);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        // ---- OPClassFont: FE8-multibyte gate ---------------------------------
+
+        [Fact]
+        public void BuildBatchDescriptors_FE8Multibyte_HasOPClassFont_Block4_OneLz77Col()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8j = MakeVersionedRom("BE8J01"); // FE8J: version 8, is_multibyte == true
+                CoreState.ROM = fe8j;
+                Assert.True(fe8j.RomInfo.is_multibyte);
+                var descs = RebuildProducerCore.BuildBatchDescriptors(fe8j);
+                var d = descs.Single(x => x.Name == "OPClassFont");
+                Assert.Equal(4u, d.BlockSize);
+                Assert.Equal(RebuildProducerCore.DataCountRule.PointerAt, d.Rule);
+                Assert.Equal(new uint[] { 0 }, d.PointerIndexes);
+                var sw = Assert.Single(d.SubWalks);
+                Assert.Equal(RebuildProducerCore.SubKind.Lz77Pointer, sw.Kind);
+                Assert.Equal(Address.DataTypeEnum.LZ77IMG, sw.DataType);
+                Assert.Equal(0u, sw.EmbeddedPointerOffset);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void BuildBatchDescriptors_FE8U_NonMultibyte_OmitsOPClassFont()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8u = MakeVersionedRom("BE8E01"); // FE8U: version 8, is_multibyte == false
+                CoreState.ROM = fe8u;
+                Assert.False(fe8u.RomInfo.is_multibyte);
+                var descs = RebuildProducerCore.BuildBatchDescriptors(fe8u);
+                // OPClassFontForm is FE8-multibyte ONLY (the FE8U path uses OPClassFontFE8UForm, deferred).
+                Assert.DoesNotContain(descs, x => x.Name == "OPClassFont");
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        // ---- LZ77 emit through WalkAndAdd: OPPrologue shape ------------------
+
+        [Fact]
+        public void OPPrologueShape_EmitsMainIfr_TwoLz77Cols_AndPalExtra()
+        {
+            // Reproduce the OPPrologue descriptor with an explicit pointer (RomInfo has no setters),
+            // plant one entry whose +0 image and +4 tsa are valid LZ77 streams, and assert the emitted
+            // Addresses: main IFR (block*(1+1)=24), LZ77IMG @ image, LZ77TSA @ tsa, plus the PAL extra.
+            var rom = CreateTestRom(0x8000);
+            uint table = 0x1000;
+            uint pointer = 0x0400;
+            uint palettePtr = 0x0500;
+            uint paletteData = 0x2000;
+            uint imageData = 0x3000;
+            uint tsaData = 0x3800;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u32(palettePtr, Ptr(paletteData));
+            // entry 0: +0 -> image pointer, +4 -> tsa pointer. Entry 1 +0 NULL terminates (PointerAt).
+            rom.write_u32(table + 0, Ptr(imageData));
+            rom.write_u32(table + 4, Ptr(tsaData));
+            uint imgLen = WriteLz77AllLiteral(rom, imageData, 80);
+            uint tsaLen = WriteLz77AllLiteral(rom, tsaData, 40);
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "OPPrologue",
+                PointerField = _ => pointer,
+                BlockSize = 12,
+                Rule = RebuildProducerCore.DataCountRule.PointerAt,
+                RuleOffset = 0,
+                PointerIndexes = new uint[] { 0, 4 },
+                ExtraFixedPointers = new[]
+                {
+                    new RebuildProducerCore.ExtraFixedPointer { PointerField = _ => palettePtr, FixedLength = 2 * 16, Name = "OPPrologue Palette", DataType = Address.DataTypeEnum.PAL },
+                },
+                SubWalks = new System.Collections.Generic.List<RebuildProducerCore.SubWalk>
+                {
+                    new RebuildProducerCore.SubWalk { EmbeddedPointerOffset = 0, Kind = RebuildProducerCore.SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77IMG, Name = (r, i) => "OPPrologue image" },
+                    new RebuildProducerCore.SubWalk { EmbeddedPointerOffset = 4, Kind = RebuildProducerCore.SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77TSA, Name = (r, i) => "OPPrologue tsa" },
+                },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            // main IFR: DataCount = 1 (entry 0 valid, entry 1 +0 NULL terminates) -> length 12*(1+1)=24.
+            Address main = list.Single(a => a.DataType == Address.DataTypeEnum.InputFormRef && a.Info == "OPPrologue");
+            Assert.Equal(table, main.Addr);
+            Assert.Equal(pointer, main.Pointer);
+            Assert.Equal(24u, main.Length);
+            Assert.Equal(new uint[] { 0, 4 }, main.PointerIndexes);
+            // LZ77 columns with getCompressedSize length.
+            Address img = Assert.Single(list, a => a.DataType == Address.DataTypeEnum.LZ77IMG);
+            Assert.Equal(imageData, img.Addr);
+            Assert.Equal(imgLen, img.Length);
+            Address tsa = Assert.Single(list, a => a.DataType == Address.DataTypeEnum.LZ77TSA);
+            Assert.Equal(tsaData, tsa.Addr);
+            Assert.Equal(tsaLen, tsa.Length);
+            // PAL extra (emitted once).
+            Address pal = Assert.Single(list, a => a.DataType == Address.DataTypeEnum.PAL);
+            Assert.Equal(paletteData, pal.Addr);
+            Assert.Equal(2u * 16u, pal.Length);
+            Assert.Equal("OPPrologue Palette", pal.Info);
+        }
+
+        // ---- EmitSupportUnitAt (owner-lookahead flat IFR) -------------------
+
+        [Fact]
+        public void EmitSupportUnitAt_FirstFieldNonZero_CountsEntries_EmitsFlatIfr()
+        {
+            // FE7/8: block 24, first-field u16. 3 entries with non-zero first u16, then a 0/unowned row
+            // terminates. No unit table planted -> the lookahead never finds an owner, so termination is
+            // purely first-field-driven. DataCount = 3 -> length = 24*(3+1) = 96; pointerIndexes {}.
+            var rom = CreateTestRom(0x8000);
+            uint table = 0x1000;
+            uint pointer = 0x0400;
+            const uint block = 24;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u16(table + 0 * block, 0x0011);
+            rom.write_u16(table + 1 * block, 0x0022);
+            rom.write_u16(table + 2 * block, 0x0033);
+            // entry 3: first u16 = 0 and no owner in the next 4 blocks -> terminates here.
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitSupportUnitAt(rom, list, pointer, block, firstFieldWidth: 2, name: "SupportUnit");
+
+            Address main = list.Single();
+            Assert.Equal(table, main.Addr);
+            Assert.Equal(pointer, main.Pointer);
+            Assert.Equal(block, main.BlockSize);
+            Assert.Equal(block * (3 + 1), main.Length);
+            Assert.Equal(new uint[] { }, main.PointerIndexes);
+            Assert.Equal(Address.DataTypeEnum.InputFormRef, main.DataType);
+            Assert.Equal("SupportUnit", main.Info);
+        }
+
+        [Fact]
+        public void EmitSupportUnitAt_ZeroFirstField_ButOwnedByUnit_ContinuesViaLookahead()
+        {
+            // A zero-first-field row is KEPT when a unit's +44 support pointer points at it (the WF
+            // "飛び地" lookahead). Plant a unit table where unit 0's +44 points at support entry 1.
+            var rom = CreateTestRom(0x8000);
+            uint supTable = 0x1000;
+            uint supPtr = 0x0400;
+            const uint block = 24;
+            rom.write_u32(supPtr, Ptr(supTable));
+            // support entries: 0 has a non-zero first field; 1 has ZERO first field but is OWNED;
+            // 2 is zero + unowned -> terminator.
+            rom.write_u16(supTable + 0 * block, 0x0011);
+            rom.write_u16(supTable + 1 * block, 0x0000); // zero, but owned below
+            rom.write_u16(supTable + 2 * block, 0x0000); // zero + unowned -> stop
+
+            // Unit table: GetUnitIdAtSupportAddr reads unit_pointer/unit_datasize/unit_maxcount from
+            // RomInfo. On a synthetic CreateTestRom RomInfo is null, so the lookahead returns null and
+            // the row would NOT be kept. Confirm: without a unit table, entry 1 terminates the walk.
+            var listNoUnit = new List<Address>();
+            RebuildProducerCore.EmitSupportUnitAt(rom, listNoUnit, supPtr, block, firstFieldWidth: 2, name: "SupportUnit");
+            Address mainNoUnit = listNoUnit.Single();
+            // entry 0 valid, entry 1 zero+unowned -> DataCount = 1 -> length 24*2 = 48.
+            Assert.Equal(block * (1 + 1), mainNoUnit.Length);
+        }
+
+        [Fact]
+        public void EmitSupportUnitAt_NearEof_NoThrow()
+        {
+            // Pointer slot resolves to a base near EOF: getBlockDataCount stops at the EOF bound, the
+            // first-field reads stay in bounds, and the owner lookahead is internally guarded.
+            var rom = CreateTestRom(0x2000);
+            uint pointer = 0x0400;
+            // base near EOF (only a couple of 24-byte blocks fit before 0x2000).
+            rom.write_u32(pointer, Ptr(0x1FE0));
+            var list = new List<Address>();
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.EmitSupportUnitAt(rom, list, pointer, block: 24, firstFieldWidth: 2, name: "SupportUnit"));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void EmitSupportUnitAt_ZeroBlock_EmitsNothing_AndDoesNotHang()
+        {
+            var rom = CreateTestRom();
+            uint pointer = 0x0400;
+            rom.write_u32(pointer, Ptr(0x1000));
+            var list = new List<Address>();
+            RebuildProducerCore.EmitSupportUnitAt(rom, list, pointer, block: 0, firstFieldWidth: 2, name: "SupportUnit");
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitSupportUnit_FE6_UsesBlock32AndFE6Name()
+        {
+            // The RomInfo-driven EmitSupportUnit picks block 32 / first-field u8 / "SupportUnitFE6" for
+            // a version-6 ROM. On a fake all-zero FE6 ROM the base resolves unsafe -> emits nothing, but
+            // must run without throwing and must NOT crash on the version branch.
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe6 = MakeVersionedRom("AFEJ01");
+                CoreState.ROM = fe6;
+                Assert.Equal(6, fe6.RomInfo.version);
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitSupportUnit(fe6, list));
+                Assert.Null(ex);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        // ---- EmitWorldMapPathAt (per-entry computed-length sub-blocks) -------
+
+        [Fact]
+        public void EmitWorldMapPathAt_EmitsMainIfr_AndPerEntryBinAndPointerSubBlocks()
+        {
+            // One entry: +0 path-data pointer, +8 path-move pointer. Plant a path-data stream
+            // (terminated by an x8==0xFF header) and a path-move stream (terminated by 0xFFFFFFFF).
+            var rom = CreateTestRom(0x8000);
+            uint table = 0x1000;
+            uint pointer = 0x0400;
+            uint pathData = 0x2000;
+            uint moveData = 0x3000;
+            rom.write_u32(pointer, Ptr(table));
+            // entry 0 valid (+0 is a pointer -> PointerAt continues); entry 1 +0 NULL -> terminate.
+            rom.write_u32(table + 0, Ptr(pathData));
+            rom.write_u32(table + 8, Ptr(moveData));
+
+            // path-data: one chip header (x8=1,y8=2,count=2) + 2*2 chip bytes, then a terminator header
+            // (x8=0xFF). Length = 4 + 4 + 4 = 12.
+            rom.write_u8(pathData + 0, 0x01); rom.write_u8(pathData + 1, 0x02); rom.write_u8(pathData + 2, 0x02); rom.write_u8(pathData + 3, 0x00);
+            rom.write_u8(pathData + 4, 0xAA); rom.write_u8(pathData + 5, 0xBB); rom.write_u8(pathData + 6, 0xCC); rom.write_u8(pathData + 7, 0xDD);
+            rom.write_u8(pathData + 8, 0xFF); // terminator header (x8==0xFF), consumes 4 -> total 12
+            uint expectPathLen = 12;
+
+            // path-move: two u32 then 0xFFFFFFFF terminator. Length = 4 + 4 + 4 = 12.
+            rom.write_u32(moveData + 0, 0x11111111);
+            rom.write_u32(moveData + 4, 0x22222222);
+            rom.write_u32(moveData + 8, 0xFFFFFFFF);
+            uint expectMoveLen = 12;
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitWorldMapPathAt(rom, list, pointer);
+
+            // main IFR: DataCount = 1 -> length 12*(1+1)=24, pointerIndexes {0,8}.
+            Address main = list.Single(a => a.DataType == Address.DataTypeEnum.InputFormRef && a.Info == "WorldMapPath");
+            Assert.Equal(table, main.Addr);
+            Assert.Equal(pointer, main.Pointer);
+            Assert.Equal(24u, main.Length);
+            Assert.Equal(new uint[] { 0, 8 }, main.PointerIndexes);
+            // path-data BIN sub-block.
+            Address bin = list.Single(a => a.DataType == Address.DataTypeEnum.BIN && a.Addr == pathData);
+            Assert.Equal(expectPathLen, bin.Length);
+            Assert.Equal(table + 0, bin.Pointer);
+            Assert.Equal("WorldMapPath:" + U.To0xHexString(0u), bin.Info);
+            // path-move POINTER sub-block.
+            Address ptrBlock = list.Single(a => a.DataType == Address.DataTypeEnum.POINTER && a.Addr == moveData);
+            Assert.Equal(expectMoveLen, ptrBlock.Length);
+            Assert.Equal(table + 8, ptrBlock.Pointer);
+            Assert.Equal("WorldMapPathMove:" + U.To0xHexString(0u), ptrBlock.Info);
+        }
+
+        [Fact]
+        public void EmitWorldMapPathAt_NullSubPointers_EmitOnlyMainIfr()
+        {
+            // entry 0: +0 is a pointer (so PointerAt continues) but +8 is 0 -> no move sub-block; and the
+            // +0 path-data pointer is planted but points at a 0-length (immediate-terminator) stream.
+            var rom = CreateTestRom(0x8000);
+            uint table = 0x1000;
+            uint pointer = 0x0400;
+            uint pathData = 0x2000;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u32(table + 0, Ptr(pathData));
+            rom.write_u32(table + 8, 0); // a8 == 0 -> no POINTER sub-block
+            rom.write_u8(pathData + 0, 0xFF); // immediate terminator header -> CalcPathDataLength = 4
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitWorldMapPathAt(rom, list, pointer);
+
+            Assert.Single(list, a => a.DataType == Address.DataTypeEnum.InputFormRef);
+            Assert.Single(list, a => a.DataType == Address.DataTypeEnum.BIN); // path-data emitted
+            Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.POINTER); // a8==0 skipped
+        }
+
+        [Fact]
+        public void EmitWorldMapPathAt_NearEof_NoThrow()
+        {
+            var rom = CreateTestRom(0x2000);
+            uint pointer = 0x0400;
+            rom.write_u32(pointer, Ptr(0x1FF0)); // base near EOF
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.EmitWorldMapPathAt(rom, list, pointer));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void EmitWorldMapPath_FE8_RunsCleanly_OnEmptyFakeRom()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitWorldMapPath(fe8, list));
+                Assert.Null(ex);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        // ---- CalcPath{,Move}DataLength terminator walks (verbatim) ----------
+
+        [Fact]
+        public void CalcPathDataLength_StopsAtFFHeader_CountsHeadersAndChips()
+        {
+            var rom = CreateTestRom();
+            uint addr = 0x1000;
+            // header (x8=3,y8=0,count=1) + 1*2 chips -> 4+2 ; then terminator header x8=0xFF (+4). 10 total.
+            rom.write_u8(addr + 0, 0x03); rom.write_u8(addr + 2, 0x01);
+            rom.write_u8(addr + 4, 0x12); rom.write_u8(addr + 5, 0x34);
+            rom.write_u8(addr + 6, 0xFF); // terminator header
+            Assert.Equal(10u, RebuildProducerCore.CalcPathDataLength(rom, addr));
+        }
+
+        [Fact]
+        public void CalcPathMoveDataLength_StopsAtFFFFFFFFTerminator()
+        {
+            var rom = CreateTestRom();
+            uint addr = 0x1000;
+            rom.write_u32(addr + 0, 0x12345678);
+            rom.write_u32(addr + 4, 0xFFFFFFFF); // terminator
+            Assert.Equal(8u, RebuildProducerCore.CalcPathMoveDataLength(rom, addr));
+        }
+
+        [Fact]
+        public void CalcPathMoveDataLength_UnterminatedNearEof_NoThrow_ReturnsConsumed()
+        {
+            // An unterminated u32 stream that runs to EOF: the root+3 guard returns the consumed length
+            // instead of throwing (WF's isSafetyOffset(p)-only guard would throw on the final u32).
+            var rom = CreateTestRom(0x2000);
+            uint addr = 0x1FF0; // (0x2000 - 0x1FF0) = 0x10 bytes = 4 u32 slots, all non-terminator
+            for (uint i = 0; i < 4; i++) rom.write_u32(addr + i * 4, 0x11111111);
+            uint len = 0;
+            var ex = Record.Exception(() => { len = RebuildProducerCore.CalcPathMoveDataLength(rom, addr); });
+            Assert.Null(ex);
+            // 4 in-bounds u32 reads consumed before p+3 would exceed EOF.
+            Assert.Equal(0x10u, len);
+        }
+
+        [Fact]
+        public void CalcPath_UnsafeStart_ReturnsZero()
+        {
+            var rom = CreateTestRom(0x2000);
+            Assert.Equal(0u, RebuildProducerCore.CalcPathDataLength(rom, 0x30000));     // past EOF
+            Assert.Equal(0u, RebuildProducerCore.CalcPathMoveDataLength(rom, 0x30000)); // past EOF
+        }
+
+        // ---- NotYetPorted coverage delta for slice 2h -----------------------
+
+        [Fact]
+        public void GetNotYetPortedForms_DropsSlice2hCoveredForms_KeepsDeferredSiblings()
+        {
+            string[] ported = RebuildProducerCore.GetNotYetPortedForms();
+
+            // slice 2h ported these 5 — no longer in the deferred list:
+            Assert.DoesNotContain("EDStaffRollForm", ported);
+            Assert.DoesNotContain("OPPrologueForm", ported);
+            Assert.DoesNotContain("OPClassFontForm", ported);
+            Assert.DoesNotContain("SupportUnitForm", ported);
+            Assert.DoesNotContain("WorldMapPathForm", ported);
+
+            // deferred siblings STAY (their blocking subsystem is not in Core):
+            Assert.Contains("OPClassDemoForm", ported);     // nested-IFR N1/N2 sub-table
+            Assert.Contains("OPClassDemoFE7Form", ported);  // nested-IFR N2 sub-table
+            Assert.Contains("MapSettingForm", ported);      // IsMapSettingEnd needs WF text-count cache
+            Assert.Contains("WorldMapEventPointerForm", ported); // ScanScript
+            Assert.Contains("ImageCGFE7UForm", ported);     // LZ77 CG (FE7U)
+
+            // the no-duplicates invariant still holds after the edits.
+            string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
+            Assert.Equal(raw.Length, raw.Distinct().Count());
         }
     }
 }

--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -4120,28 +4120,29 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
-        public void EmitSupportUnitAt_ZeroFirstField_ButOwnedByUnit_ContinuesViaLookahead()
+        public void EmitSupportUnitAt_ZeroFirstField_NullRomInfo_TerminatesWithoutLookahead()
         {
-            // A zero-first-field row is KEPT when a unit's +44 support pointer points at it (the WF
-            // "飛び地" lookahead). Plant a unit table where unit 0's +44 points at support entry 1.
+            // With a null RomInfo (synthetic CreateTestRom), the WF "飛び地" owner-lookahead cannot fire
+            // — SupportUnitNavigation.GetUnitIdAtSupportAddr returns null when RomInfo == null — so a
+            // zero-first-field row terminates the count walk. This verifies the count rule degrades
+            // gracefully in headless/synthetic contexts (no unit table to consult). The POSITIVE
+            // lookahead path (a zero-first-field row KEPT because a unit's +44 support pointer owns it)
+            // is covered by SupportUnitNavigationTests.GetUnitIdAtSupportAddr_FindsOwnerFE8U.
             var rom = CreateTestRom(0x8000);
             uint supTable = 0x1000;
             uint supPtr = 0x0400;
             const uint block = 24;
             rom.write_u32(supPtr, Ptr(supTable));
-            // support entries: 0 has a non-zero first field; 1 has ZERO first field but is OWNED;
-            // 2 is zero + unowned -> terminator.
+            // support entries: 0 has a non-zero first field; 1 has ZERO first field — with no RomInfo
+            // it is unowned -> terminator at entry 1.
             rom.write_u16(supTable + 0 * block, 0x0011);
-            rom.write_u16(supTable + 1 * block, 0x0000); // zero, but owned below
-            rom.write_u16(supTable + 2 * block, 0x0000); // zero + unowned -> stop
+            rom.write_u16(supTable + 1 * block, 0x0000); // zero + (no RomInfo -> ) unowned -> stop
+            rom.write_u16(supTable + 2 * block, 0x0000);
 
-            // Unit table: GetUnitIdAtSupportAddr reads unit_pointer/unit_datasize/unit_maxcount from
-            // RomInfo. On a synthetic CreateTestRom RomInfo is null, so the lookahead returns null and
-            // the row would NOT be kept. Confirm: without a unit table, entry 1 terminates the walk.
             var listNoUnit = new List<Address>();
             RebuildProducerCore.EmitSupportUnitAt(rom, listNoUnit, supPtr, block, firstFieldWidth: 2, name: "SupportUnit");
             Address mainNoUnit = listNoUnit.Single();
-            // entry 0 valid, entry 1 zero+unowned -> DataCount = 1 -> length 24*2 = 48.
+            // entry 0 valid, entry 1 zero+unowned -> DataCount = 1 -> length 24*(1+1) = 48.
             Assert.Equal(block * (1 + 1), mainNoUnit.Length);
         }
 

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -510,6 +510,32 @@ namespace FEBuilderGBA
             progress?.Report("MapTileAnimation2");
             EmitMapTileAnimation2(rom, list);
 
+            // ---- slice 2h: SupportUnit (all versions) + WorldMapPath (FE8-only) ----
+            // SupportUnitForm is called in the WF version==8 AND version==7 branches (block 24); the
+            // SupportUnitFE6Form variant in version==6 (block 32). EmitSupportUnit auto-selects the
+            // per-version block/first-field/name. Its count rule needs the owner-lookahead
+            // (UnitForm.GetUnitIDWhereSupportAddr), reproduced via SupportUnitNavigation, so it is a
+            // dedicated emitter rather than a flat descriptor. WorldMapPathForm is version==8-only and
+            // has per-entry computed-length sub-blocks (CalcPath{,Move}DataLength, pure ROM walks).
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("SupportUnit");
+            EmitSupportUnit(rom, list);
+
+            if (rom.RomInfo.version == 8)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    progress?.Report("MakeAllStructPointersList cancelled");
+                    return new ProducerResult(list, notYet, cancelled: true);
+                }
+                progress?.Report("WorldMapPath");
+                EmitWorldMapPath(rom, list);
+            }
+
             if (rom.RomInfo.version == 7)
             {
                 if (ct.IsCancellationRequested)
@@ -1433,6 +1459,235 @@ namespace FEBuilderGBA
             uint length = block * (dataCount + 1);
             list.Add(new Address(baseAddr, length, U.NOT_FOUND, "Unit",
                 Address.DataTypeEnum.InputFormRef, block, new uint[] { 44 }));
+        }
+
+        // ===================================================================
+        // slice 2h — flat IFR stragglers whose count rule needs a Core helper
+        // (SupportUnit's owner-lookahead; WorldMapPath's per-entry computed-length
+        // sub-blocks). Each gets a dedicated emitter + an explicit-address test
+        // seam that supplies the resolved work items without RomInfo.
+        // ===================================================================
+
+        /// <summary>
+        /// <c>SupportUnitForm.MakeAllDataLength</c> (FE7/FE8, block 24) and
+        /// <c>SupportUnitFE6Form.MakeAllDataLength</c> (FE6, block 32) — slice 2h. Both are a PLAIN flat
+        /// IFR emit (<c>AddAddress(ifr, name, {})</c>, no per-entry sub-walk), but their
+        /// <c>InputFormRef.Init</c> IsDataExists is the "owner-lookahead" terminator that a flat
+        /// <see cref="StructDescriptor"/> rule cannot express: continue while the first field is
+        /// non-zero (<c>u16(addr)!=0</c> for FE7/8, <c>u8(addr)!=0</c> for FE6) OR — even when it is
+        /// zero — any of the entry + next 3 blocks is OWNED, i.e. some unit's <c>+44</c> support
+        /// pointer points at it (<c>UnitForm.GetUnitIDWhereSupportAddr != NOT_FOUND</c>, reproduced by
+        /// <see cref="SupportUnitNavigation.GetUnitIdAtSupportAddr"/>). The owner lookahead is a pure
+        /// ROM walk of the unit table, so this is faithfully headless.
+        /// <para>This emits the SAME single IFR <see cref="Address"/> as
+        /// <c>AddressWinForms.AddAddress(list, ifr, name, {})</c>: base = <c>p32(support_unit_pointer)</c>,
+        /// length = <c>block × (DataCount + 1)</c>, pointer = <c>support_unit_pointer</c> (the RomInfo
+        /// slot), pointerIndexes = <c>{}</c>, type InputFormRef — driven by the SAME
+        /// <see cref="ROM.getBlockDataCount(uint,uint,Func{int,uint,bool})"/> every other form uses, so
+        /// the count is byte-identical to WF's IFR walk.</para>
+        /// </summary>
+        public static void EmitSupportUnit(ROM rom, List<Address> list)
+        {
+            // FE7/FE8: block 24, first-field u16, Info "SupportUnit". FE6: block 32, first-field u8,
+            // Info "SupportUnitFE6". The pointer slot is support_unit_pointer in all versions.
+            bool fe6 = rom.RomInfo.version == 6;
+            EmitSupportUnitAt(rom, list, rom.RomInfo.support_unit_pointer,
+                block: fe6 ? 32u : 24u,
+                firstFieldWidth: fe6 ? 1u : 2u,
+                name: fe6 ? "SupportUnitFE6" : "SupportUnit");
+        }
+
+        /// <summary>SupportUnit walk from an explicit pointer slot / block / first-field width / name
+        /// (test seam — lets a synthetic ROM supply them without populating RomInfo, which has no
+        /// public setters). See <see cref="EmitSupportUnit"/> for the verbatim WF reproduction.</summary>
+        public static void EmitSupportUnitAt(ROM rom, List<Address> list, uint rawPointer,
+            uint block, uint firstFieldWidth, string name)
+        {
+            if (block == 0)
+            {
+                return; // a zero block would make getBlockDataCount spin; not real data.
+            }
+
+            // AddAddress(ifr): addr = ifr.BaseAddress = p32(toOffset(BasePointer)); pointer = BasePointer.
+            // Guard the full pointer slot before p32 (root+3) so a near-EOF slot skips, not throws.
+            uint pointer = U.toOffset(rawPointer);
+            if (!U.isSafetyOffset(pointer + 3, rom))
+            {
+                return;
+            }
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                return; // AddAddress early-returns when !isSafetyOffset(addr).
+            }
+
+            // WF SupportUnit*Form.Init IsDataExists (owner-lookahead), driven by the SAME getBlockDataCount.
+            // getBlockDataCount only fires the callback while addr+block<=Length, so the first-field read
+            // (u8/u16 @ addr) is always in bounds. The owner lookahead reads the unit table via
+            // GetUnitIdAtSupportAddr, which is itself fully bounds-checked.
+            uint dataCount = rom.getBlockDataCount(baseAddr, block, (i, addr) =>
+            {
+                bool firstFieldNonZero = firstFieldWidth == 1
+                    ? rom.u8(addr) != 0
+                    : rom.u16(addr) != 0;
+                if (firstFieldNonZero)
+                {
+                    return true; // 0ではないのでまだデータがある.
+                }
+                // 飛び地になっていることがあるらしい — 4ブロックほど検索してみる (WF: n=0..3, found+=block).
+                uint found = addr;
+                for (int n = 0; n < 4; n++, found += block)
+                {
+                    if (SupportUnitNavigation.GetUnitIdAtSupportAddr(rom, found) != null)
+                    {
+                        return true; // 発見!
+                    }
+                }
+                return false; // 見つからない.
+            });
+
+            // AddAddress(ifr, name, {}): length = block × (DataCount + 1); pointer = the RomInfo slot.
+            uint length = block * (dataCount + 1);
+            list.Add(new Address(baseAddr, length, pointer, name,
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { }));
+        }
+
+        /// <summary>
+        /// <c>WorldMapPathForm.MakeAllDataLength</c> (FE8-only, slice 2h). A flat IFR (base
+        /// <c>worldmap_road_pointer</c>, block 12, IsDataExists = <c>isPointer(u32(addr+0))</c> →
+        /// PointerAt @0, pointerIndexes {0,8}) PLUS a per-entry pair of variable-length sub-blocks
+        /// behind the embedded pointers at +0 and +8, whose lengths come from two pure terminator
+        /// walks (<see cref="CalcPathDataLength"/> / <see cref="CalcPathMoveDataLength"/>). Those
+        /// length walks are pure ROM reads (no PatchUtil/disasm/config), so they are reproduced
+        /// VERBATIM here rather than in a separate Core helper. Reproduced per entry (<c>p = base +
+        /// i*12</c>):
+        /// <list type="bullet">
+        ///   <item><c>a0 = p32(p+0)</c>; if <c>a0 &gt; 0</c>: <c>AddAddress(a0, CalcPathDataLength(a0),
+        ///   p+0, "WorldMapPath:0x&lt;i&gt;", BIN)</c>;</item>
+        ///   <item><c>a8 = p32(p+8)</c>; if <c>a8 &gt; 0</c>: <c>AddAddress(a8, CalcPathMoveDataLength(a8),
+        ///   p+8, "WorldMapPathMove:0x&lt;i&gt;", POINTER)</c>.</item>
+        /// </list>
+        /// The main IFR Address uses pointerIndexes {0,8} (the two embedded pointer FIELDS are
+        /// relocated by the rebuild's pointer-index pass; their DATA is relocated by the two
+        /// sub-Addresses here).
+        /// </summary>
+        public static void EmitWorldMapPath(ROM rom, List<Address> list)
+        {
+            EmitWorldMapPathAt(rom, list, rom.RomInfo.worldmap_road_pointer);
+        }
+
+        /// <summary>WorldMapPath walk from an explicit pointer slot (test seam — lets a synthetic ROM
+        /// supply it without populating RomInfo). See <see cref="EmitWorldMapPath"/> for the verbatim
+        /// WF reproduction.</summary>
+        public static void EmitWorldMapPathAt(ROM rom, List<Address> list, uint rawPointer)
+        {
+            const uint block = 12;
+
+            // Main IFR (AddAddress(ifr, "WorldMapPath", {0,8})): base = p32(toOffset(slot)),
+            // pointer = slot. Guard the full slot before p32 (root+3).
+            uint pointer = U.toOffset(rawPointer);
+            if (!U.isSafetyOffset(pointer + 3, rom))
+            {
+                return;
+            }
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                return;
+            }
+
+            // IsDataExists = isPointer(u32(addr+0)) — PointerAt @0.
+            uint dataCount = rom.getBlockDataCount(baseAddr, block, (i, addr) =>
+                U.isPointer(rom.u32(addr + 0)));
+
+            uint length = block * (dataCount + 1);
+            list.Add(new Address(baseAddr, length, pointer, "WorldMapPath",
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { 0, 8 }));
+
+            // Per-entry sub-blocks. getBlockDataCount guarantees p+block(12)<=Length for i<dataCount,
+            // so p32(p+0) (deepest p+3) and p32(p+8) (deepest p+11) are both in bounds.
+            uint p = baseAddr;
+            for (uint i = 0; i < dataCount; i++, p += block)
+            {
+                uint a0 = rom.p32(p + 0);
+                if (a0 > 0)
+                {
+                    Address.AddAddress(list, a0, CalcPathDataLength(rom, a0), p + 0,
+                        "WorldMapPath:" + U.To0xHexString(i), Address.DataTypeEnum.BIN);
+                }
+
+                uint a8 = rom.p32(p + 8);
+                if (a8 > 0)
+                {
+                    Address.AddAddress(list, a8, CalcPathMoveDataLength(rom, a8), p + 8,
+                        "WorldMapPathMove:" + U.To0xHexString(i), Address.DataTypeEnum.POINTER);
+                }
+            }
+        }
+
+        /// <summary>VERBATIM port of <c>WorldMapPathForm.CalcPathDataLength</c>: walk a path-chip stream
+        /// from <paramref name="addr"/> — each 4-byte header is <c>(x8,y8,count,?)</c> followed by
+        /// <c>count*2</c> chip bytes; stop at the first header whose <c>x8 == 0xFF</c> (consuming that
+        /// header), or when the next 4-byte header would run past a safe offset. Returns the byte length
+        /// consumed (0 on an unsafe start). Pure ROM reads — every dereference is bounds-guarded.</summary>
+        public static uint CalcPathDataLength(ROM rom, uint addr)
+        {
+            if (!U.isSafetyOffset(addr, rom))
+            {
+                return 0;
+            }
+            uint p = addr;
+            while (true)
+            {
+                if (!U.isSafetyOffset(p + 4, rom))
+                {
+                    return p - addr;
+                }
+
+                uint x8 = rom.u8(p + 0);
+                // y8 (p+1) and count (p+2) are read in WF; count drives the advance.
+                uint count = rom.u8(p + 2);
+
+                p += 4;
+                if (x8 == 0xFF)
+                {
+                    return p - addr;
+                }
+                p += count * 2;
+            }
+        }
+
+        /// <summary>VERBATIM port of <c>WorldMapPathForm.CalcPathMoveDataLength</c>: walk a u32 list from
+        /// <paramref name="addr"/>, stopping at (and consuming) the first <c>0xFFFFFFFF</c> terminator,
+        /// or when the next u32 would run past a safe offset. Returns the byte length consumed (0 on an
+        /// unsafe start). Pure ROM reads — every dereference is bounds-guarded.</summary>
+        public static uint CalcPathMoveDataLength(ROM rom, uint addr)
+        {
+            if (!U.isSafetyOffset(addr, rom))
+            {
+                return 0;
+            }
+            uint p = addr;
+            while (true)
+            {
+                // WF guards only `isSafetyOffset(p)` (p < Length) before `u32(p)`, which would THROW
+                // when p is in [Length-3, Length-1] (u32 needs p+4 <= Length). Guard the FULL 4-byte
+                // read (root+3) so a malformed/unterminated stream near EOF returns the length consumed
+                // so far instead of throwing — never changes the result on a well-formed (0xFFFFFFFF-
+                // terminated) stream, where the terminator is always reached before EOF. (WF has a
+                // Debug.Assert(false) on the unsafe path; headless returns p - addr.)
+                if (!U.isSafetyOffset(p + 3, rom))
+                {
+                    return p - addr;
+                }
+                uint a = rom.u32(p);
+
+                p += 4;
+                if (a == 0xFFFFFFFF)
+                {
+                    return p - addr;
+                }
+            }
         }
 
         // ===================================================================
@@ -2933,6 +3188,77 @@ namespace FEBuilderGBA
                         new SubWalk { EmbeddedPointerOffset = 8, Kind = SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77IMG, Name = (r, i) => "ChapterTitleImage_Title" },
                     },
                 });
+
+                // EDStaffRollForm.MakeAllDataLength (FE8, slice 2h) — Info "EDStaffRoll", block 8, base
+                // ed_staffroll_image_pointer, IsDataExists = isPointer(u32(addr+0)) && i < 12. The WF
+                // lambda returns false on a non-pointer OR once i reaches 12, so this is PointerAt @0
+                // with MaxCount 12 (the PointerAt rule checks `i >= MaxCount` before the pointer, so the
+                // combined result is `i < 12 && isPointer(u32+0)` — identical to WF). pointerIndexes
+                // {0,4}. Per entry: LZ77IMG @0, LZ77TSA @4 (both labelled "EDStaffRoll" verbatim — WF
+                // reuses the single `name` string for the main IFR and both columns).
+                l.Add(new StructDescriptor
+                {
+                    Name = "EDStaffRoll",
+                    PointerField = r => r.RomInfo.ed_staffroll_image_pointer,
+                    BlockSize = 8,
+                    Rule = DataCountRule.PointerAt,
+                    RuleOffset = 0,
+                    MaxCount = 12,
+                    PointerIndexes = new uint[] { 0, 4 },
+                    SubWalks = new List<SubWalk>
+                    {
+                        new SubWalk { EmbeddedPointerOffset = 0, Kind = SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77IMG, Name = (r, i) => "EDStaffRoll" },
+                        new SubWalk { EmbeddedPointerOffset = 4, Kind = SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77TSA, Name = (r, i) => "EDStaffRoll" },
+                    },
+                });
+
+                // OPPrologueForm.MakeAllDataLength (FE8, slice 2h) — Info "OPPrologue", block 12, base
+                // op_prologue_image_pointer, IsDataExists = isPointer(u32(addr+0)) (PointerAt @0),
+                // pointerIndexes {0,4}. ALSO a standalone palette pointer: AddPointer(
+                // op_prologue_palette_color_pointer, 2*16=0x20, "OPPrologue Palette", PAL) emitted ONCE
+                // (not per entry) — modelled as an ExtraFixedPointer (DataType override PAL). Per entry:
+                // LZ77IMG @0 ("OPPrologue image"), LZ77TSA @4 ("OPPrologue tsa").
+                l.Add(new StructDescriptor
+                {
+                    Name = "OPPrologue",
+                    PointerField = r => r.RomInfo.op_prologue_image_pointer,
+                    BlockSize = 12,
+                    Rule = DataCountRule.PointerAt,
+                    RuleOffset = 0,
+                    PointerIndexes = new uint[] { 0, 4 },
+                    ExtraFixedPointers = new[]
+                    {
+                        new ExtraFixedPointer { PointerField = r => r.RomInfo.op_prologue_palette_color_pointer, FixedLength = 2 * 16, Name = "OPPrologue Palette", DataType = Address.DataTypeEnum.PAL },
+                    },
+                    SubWalks = new List<SubWalk>
+                    {
+                        new SubWalk { EmbeddedPointerOffset = 0, Kind = SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77IMG, Name = (r, i) => "OPPrologue image" },
+                        new SubWalk { EmbeddedPointerOffset = 4, Kind = SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77TSA, Name = (r, i) => "OPPrologue tsa" },
+                    },
+                });
+
+                if (rom.RomInfo.is_multibyte)
+                {
+                    // OPClassFontForm.MakeAllDataLength (FE8, slice 2h) — called in the WF version==8
+                    // branch ONLY inside `if (is_multibyte)` (the FE8U non-multibyte path uses
+                    // OPClassFontFE8UForm, which is a different — still-deferred — form). Gated
+                    // identically here. Info "OPClassFont", block 4, base op_class_font_pointer,
+                    // IsDataExists = isPointer(u32(addr+0)) (PointerAt @0), pointerIndexes {0}. Per entry:
+                    // ONE LZ77IMG column at 0, labelled "OPClassFont 0x<i>" (U.To0xHexString) verbatim.
+                    l.Add(new StructDescriptor
+                    {
+                        Name = "OPClassFont",
+                        PointerField = r => r.RomInfo.op_class_font_pointer,
+                        BlockSize = 4,
+                        Rule = DataCountRule.PointerAt,
+                        RuleOffset = 0,
+                        PointerIndexes = new uint[] { 0 },
+                        SubWalks = new List<SubWalk>
+                        {
+                            new SubWalk { EmbeddedPointerOffset = 0, Kind = SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77IMG, Name = (r, i) => "OPClassFont " + U.To0xHexString((uint)i) },
+                        },
+                    });
+                }
             }
             else if (rom.RomInfo.version == 7)
             {
@@ -3078,8 +3404,11 @@ namespace FEBuilderGBA
                 // Forms called ONLY inside the WF `else if (version == 6)` branch. UnitFE6Form is ported
                 // in slice 2f via the dedicated EmitUnitFE6 walker (its base is p32(unit_pointer)+
                 // unit_datasize with a NOT_FOUND pointer slot, which the pointer-slot descriptor model
-                // cannot express). WorldMapEventPointerFE6Form (PLIST event-scan), MapSettingFE6Form
-                // (IsMapSettingEnd + CString), SupportUnitFE6Form (GetUnitIDWhereSupportAddr) stay deferred.
+                // cannot express). SupportUnitFE6Form is ported in slice 2h via the version-aware
+                // EmitSupportUnit walker (FE6 block 32, first-field u8, name "SupportUnitFE6"; its
+                // owner-lookahead count rule = SupportUnitNavigation.GetUnitIdAtSupportAddr).
+                // WorldMapEventPointerFE6Form (PLIST event-scan) and MapSettingFE6Form (IsMapSettingEnd +
+                // CString — needs the WF cached text count, not in Core) stay deferred.
                 // ImagePortraitFE6Form STAYS too — its Init has a stateful nullContinuousCount
                 // terminator + GetFEditorLengthHint, not faithfully reproducible by the stateless
                 // descriptor rule model. The clean tables below are ported; ImageChapterTitleFE7Form
@@ -3287,6 +3616,10 @@ namespace FEBuilderGBA
         static readonly string[] NotYetPortedRaw = new[]
             {
                 // event conditions / scripts
+                // (EventCondForm: EventScriptForm.ScanScript event-scan, not in Core.
+                //  EventScript(MakeEventASMMAPList), EventFunctionPointerForm, Command85PointerForm are
+                //  OUT OF SCOPE: emitted by U.AppendAllASMStructPointersList — the ASM/LDR-map path, NOT
+                //  this producer's U.MakeAllStructPointersList data path.)
                 "EventCondForm", "EventScript(MakeEventASMMAPList)", "EventFunctionPointerForm",
                 "Command85PointerForm",
                 // text (Huffman)
@@ -3415,25 +3748,46 @@ namespace FEBuilderGBA
                 //  [FE8, count = ClassDataCount] + OPClassAlphaNameFE6Form [FE6 string-BIN sub-walk],
                 //  WorldMapPointForm [FE8], SupportTalkForm/FE6/FE7, EventBattleTalkFE6Form [FE6 ×2],
                 //  EventHaikuFE6Form [FE6], TacticianAffinityFE7, EventFinalSerifFE7Form.
-                //  STILL deferred (event-scan / LZ77 / recursive / GetUnitIDWhereSupportAddr / dynamic
-                //  base): MonsterWMapProbabilityForm STAYS — although its 5 IFR probability/stage tables
+                //  slice 2h ported the OP/ED LZ77 stragglers + the SupportUnit / WorldMapPath flat-IFR
+                //  forms whose only blocker was a count rule needing a Core helper:
+                //    EDStaffRollForm [FE8] / OPPrologueForm [FE8] / OPClassFontForm [FE8-multibyte] —
+                //      StructDescriptor PointerAt@0 (EDStaffRoll caps at MaxCount 12) + Lz77Pointer
+                //      SubWalks (IMG/TSA) (+ OPPrologue's standalone PAL via ExtraFixedPointer).
+                //    SupportUnitForm [FE7/8] + SupportUnitFE6Form [FE6] — EmitSupportUnit, a flat IFR
+                //      whose owner-lookahead count rule (UnitForm.GetUnitIDWhereSupportAddr) is
+                //      reproduced via SupportUnitNavigation.GetUnitIdAtSupportAddr (pure unit-table walk).
+                //    WorldMapPathForm [FE8] — EmitWorldMapPath, main IFR PointerAt@0/{0,8} + per-entry
+                //      BIN/POINTER sub-blocks whose lengths are the pure CalcPath{,Move}DataLength
+                //      terminator walks (reproduced verbatim, EOF-hardened on the u32 read).
+                //  STILL deferred (event-scan / LZ77+nested-IFR / recursive / dynamic base):
+                //  MonsterWMapProbabilityForm STAYS — although its 5 IFR probability/stage tables
                 //    are flat ROM reads, its MakeAllDataLength ALSO emits EventScriptForm.ScanScript over
                 //    the two skirmish start/end event pointers (no Core ScanScript primitive yet);
                 //    porting only the flat tables would drop those skirmish-event regions = corruption.
                 //  WorldMapEventPointerForm [ScanScript],
-                //  EventBattleTalkForm + EventHaikuForm [FE8, ScanScript per-entry], SupportUnitForm
-                //  [GetUnitIDWhereSupportAddr], WorldMapPathForm [CalcPathDataLength], EDStaffRollForm +
-                //  OPPrologueForm + OPClassFontForm + OPClassDemoForm/FE7Form [LZ77], MapSettingForm
-                //  [IsMapSettingEnd + CString], FE8SpellMenuExtendsForm [FindFE8SpellPatchPointer],
-                //  ImageCGFE7UForm [LZ77].)
+                //  EventBattleTalkForm + EventHaikuForm [FE8, ScanScript per-entry],
+                //  OPClassDemoForm [FE8-multibyte] + OPClassDemoFE7Form [FE7-multibyte] STAY — both run
+                //    a per-entry NESTED IFR sub-table (N1/N2 ReInitPointer'd at an embedded pointer, each
+                //    with its OWN getBlockDataCount-walked variable count: OPClassDemo N1 u8!=0xFF&&i<16
+                //    @+8 / N2 u8!=0 @+24; OPClassDemoFE7 N2 u8!=0 @+28). The SubKind machinery emits ONE
+                //    Address per sub-walk, not a nested count-walked IFR table, so they need a new
+                //    nested-IFR SubKind (plus OPClassDemo's u8(+15)<=4 main rule) — a later slice.
+                //  MapSettingForm [FE8] STAYS — its count rule (IsMapSettingEnd) needs the WF cached
+                //    text count (TextForm.GetDataCount() / g_GetDataCount_Cache, NOT in Core); the
+                //    extracted MapSettingCore.IsMapSettingValid diverges (its `if (textmax>0)` guard
+                //    returns true when textmax==0, where WF returns false), so the per-entry CString
+                //    count is not yet faithfully reproducible — a wrong count = silent corruption.
+                //  FE8SpellMenuExtendsForm [FindFE8SpellPatchPointer], ImageCGFE7UForm [LZ77].)
                 "MonsterWMapProbabilityForm",
                 "EventBattleTalkForm",
-                "WorldMapPathForm", "WorldMapEventPointerForm", "EDStaffRollForm",
-                "OPPrologueForm", "EventHaikuForm",
-                "SupportUnitForm", "MapSettingForm",
-                "OPClassFontForm", "OPClassDemoForm", "FE8SpellMenuExtendsForm",
+                "WorldMapEventPointerForm",
+                "EventHaikuForm",
+                "MapSettingForm",
+                "OPClassDemoForm", "FE8SpellMenuExtendsForm",
                 "OPClassDemoFE7Form", "ImageCGFE7UForm",
-                // patch / procs / ASM (AppendAllASMStructPointersList)
+                // patch / procs / ASM — OUT OF SCOPE for this data-path producer: these are emitted by
+                // U.AppendAllASMStructPointersList (the ASM/LDR-map path), NOT U.MakeAllStructPointersList.
+                // (EventFunctionPointerForm / Command85PointerForm above are likewise ASM-path forms.)
                 "PatchForm(MakePatchStructDataList)", "ProcsScriptForm",
             };
     }


### PR DESCRIPTION
## Summary
**Slice 2h** of #1261 — the **OP/ED LZ77 forms + flat-IFR stragglers**. The OP/ED forms are flat IFR + per-entry `AddLZ77Pointer` (the slice-2e `Lz77Pointer` SubKind, `length = LZ77.getCompressedSize`, already EOF-safe) — the earlier "[LZ77]" deferral was over-conservative. WorldMapPath + SupportUnit reproduce their WF length/count helpers verbatim.

## Ported (5 forms — VERBATIM vs WF `MakeAllDataLength`, version-gated per the WF call site)
- **OPPrologueForm** [FE8] — `StructDescriptor` PointerAt@0 / `{0,4}` + 2 `Lz77Pointer` (IMG@0, TSA@4) + 1 `ExtraFixedPointer` (PAL `op_prologue_palette`).
- **EDStaffRollForm** [FE8] — PointerAt@0 MaxCount=12 / `{0,4}` + 2 `Lz77Pointer` (IMG@0, TSA@4). WF rule `isPointer(u32+0) && i<12` → PointerAt+MaxCount.
- **OPClassFontForm** [FE8-**multibyte** ONLY] — PointerAt@0 / `{0}` + 1 `Lz77Pointer` (IMG@0). Gated on `is_multibyte` exactly as WF (the FE8U non-multibyte path uses `OPClassFontFE8UForm`, still deferred).
- **SupportUnitForm** [FE7/8, block 24] + **SupportUnitFE6Form** [FE6, block 32] — dedicated `EmitSupportUnit`; the owner-lookahead count rule (`UnitForm.GetUnitIDWhereSupportAddr`) reproduced via Core `SupportUnitNavigation.GetUnitIdAtSupportAddr` (pure unit-table walk), driven by the same `getBlockDataCount` as every other form.
- **WorldMapPathForm** [FE8] — dedicated `EmitWorldMapPath`; main IFR PointerAt@0 / `{0,8}` + per-entry BIN/POINTER sub-blocks whose lengths are the pure `CalcPathDataLength` / `CalcPathMoveDataLength` terminator walks, **reproduced verbatim** from WF.

## Faithfulness notes (verified by the lead against WF source)
- `CalcPathDataLength` / `CalcPathMoveDataLength` are line-for-line WF reproductions. `CalcPathMoveDataLength`'s `u32(p)` read is EOF-hardened from WF's `isSafetyOffset(p)` to `isSafetyOffset(p+3)` (the full 4-byte read) — WF would throw past EOF (it has a `Debug.Assert(false)` there); the hardened version returns the consumed length. **Never changes the result on a well-formed 0xFFFFFFFF-terminated stream** (terminator is always reached before EOF). Same EOF discipline as the slice-2d/2f walkers.
- Version gating audited: OPClassFont FE8-multibyte-only; SupportUnit FE7/8 vs SupportUnitFE6 (block 24 vs 32).

## Tests
- RebuildProducer filter: **139 passed / 0 failed** (+19) — planted LZ77 streams (known `getCompressedSize`), version-gated presence, near-EOF `Record.Exception`-null for the hand-written walkers (CalcPath near-EOF; SupportUnit/WorldMapPath unsafe base), coverage delta.
- FEBuilderGBA.Tests (net9.0-windows): no new failures (the `Skill*`/`SkillSystemsAnime*` + StructExport env failures are the known `config/patch2`-absent-in-worktree ones).

Part of #1261.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
