### PR TITLE
feat(core): ROM-rebuild producer — nested-IFR SubKind + OPClassDemo forms (#1261 slice 2i)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -1700,14 +1700,15 @@ namespace FEBuilderGBA.Core.Tests
             {
                 "EventBattleTalkForm", "EventHaikuForm",
                 "WorldMapEventPointerForm",
-                "MapSettingForm", "OPClassDemoForm", "FE8SpellMenuExtendsForm",
+                "MapSettingForm", "FE8SpellMenuExtendsForm",
                 "MonsterWMapProbabilityForm", "SoundRoomForm",
                 // (StatusOptionForm + SoundFootStepsForm ported in slice 2d -> no longer kept here.
                 //  UnitFE6Form + ItemUsagePointerForm + AIPerform*/AIMapSetting/Mant/ArenaEnemyWeapon
                 //  ported in slice 2f -> no longer kept here. MapTileAnimation1Form/MapTileAnimation2Form +
                 //  ItemShopForm + MapChangeForm + MapExitPointForm ported in slice 2g -> no longer kept.
                 //  SupportUnitForm + WorldMapPathForm + EDStaffRollForm + OPPrologueForm + OPClassFontForm
-                //  ported in slice 2h -> no longer kept here.)
+                //  ported in slice 2h -> no longer kept here. OPClassDemoForm + OPClassDemoFE7Form ported
+                //  in slice 2i -> no longer kept here.)
                 "ItemForm", "MapTerrainFloorLookupTableForm",
             })
             {
@@ -4352,11 +4353,393 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("WorldMapPathForm", ported);
 
             // deferred siblings STAY (their blocking subsystem is not in Core):
-            Assert.Contains("OPClassDemoForm", ported);     // nested-IFR N1/N2 sub-table
-            Assert.Contains("OPClassDemoFE7Form", ported);  // nested-IFR N2 sub-table
+            // (NOTE: OPClassDemoForm / OPClassDemoFE7Form were the nested-IFR siblings deferred at
+            //  slice 2h; slice 2i below ports them, so they move to DoesNotContain there.)
             Assert.Contains("MapSettingForm", ported);      // IsMapSettingEnd needs WF text-count cache
             Assert.Contains("WorldMapEventPointerForm", ported); // ScanScript
             Assert.Contains("ImageCGFE7UForm", ported);     // LZ77 CG (FE7U)
+
+            // the no-duplicates invariant still holds after the edits.
+            string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
+            Assert.Equal(raw.Length, raw.Distinct().Count());
+        }
+
+        // ===================================================================
+        // slice 2i — SubKind.NestedIfr + OPClassDemo (FE8-mb) / OPClassDemoFE7
+        // (FE7-mb). Synthetic ROMs prove the main IFR Address AND each nested
+        // IFR Address have the right addr/length/pointer/type/name; the version
+        // gate is proven via multibyte (present) vs non-mb/other (absent); a
+        // near-EOF plant proves no throw.
+        // ===================================================================
+
+        // ---- EmitNestedIfrSub (the reusable nested count-walked IFR) ---------
+
+        [Fact]
+        public void EmitNestedIfrSub_WalksSubTable_EmitsIfrAddress_LengthPlusOne_EmptyPointerIndexes()
+        {
+            // A sub-table at 0x2000, block 2, rule u8(addr)!=0: 3 valid entries then a 0 terminator.
+            var rom = CreateTestRom(0x8000);
+            uint pfield = 0x1000;     // the embedded pointer FIELD
+            uint subBase = 0x2000;    // the nested sub-table base
+            rom.write_u32(pfield, Ptr(subBase));
+            rom.write_u8(subBase + 0, 0x11);
+            rom.write_u8(subBase + 2, 0x22);
+            rom.write_u8(subBase + 4, 0x33);
+            rom.write_u8(subBase + 6, 0x00); // terminator (u8(addr)==0 -> stop) -> count 3
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitNestedIfrSub(rom, list, pfield, 2,
+                (i, addr) => rom.u8(addr) != 0x00, "Nested");
+
+            Address a = Assert.Single(list);
+            Assert.Equal(subBase, a.Addr);
+            Assert.Equal(pfield, a.Pointer);       // pointer = the embedded FIELD
+            Assert.Equal(2u, a.BlockSize);
+            Assert.Equal(2u * (3u + 1u), a.Length); // subBlock * (count + 1) = 8
+            Assert.Equal(Address.DataTypeEnum.InputFormRef, a.DataType);
+            Assert.Empty(a.PointerIndexes);        // WF new uint[] {} -> empty
+        }
+
+        [Fact]
+        public void EmitNestedIfrSub_NullEmbeddedPointer_EmitsNothing()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint pfield = 0x1000;
+            rom.write_u32(pfield, 0); // embedded pointer NULL -> p32 == 0, unsafe -> emit nothing
+            var list = new List<Address>();
+            RebuildProducerCore.EmitNestedIfrSub(rom, list, pfield, 2,
+                (i, addr) => rom.u8(addr) != 0x00, "Nested");
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitNestedIfrSub_ZeroBlock_EmitsNothing_DoesNotHang()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint pfield = 0x1000;
+            rom.write_u32(pfield, Ptr(0x2000));
+            var list = new List<Address>();
+            RebuildProducerCore.EmitNestedIfrSub(rom, list, pfield, 0,
+                (i, addr) => true, "Nested");
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitNestedIfrSub_NearEof_NoThrow()
+        {
+            var rom = CreateTestRom(0x2000);
+            uint pfield = 0x1FFE; // pfield+3 runs past EOF -> guarded, no throw, no emit
+            var list = new List<Address>();
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.EmitNestedIfrSub(rom, list, pfield, 2,
+                    (i, addr) => rom.u8(addr) != 0, "Nested"));
+            Assert.Null(ex);
+            Assert.Empty(list);
+        }
+
+        // ---- EmitOPClassDemoAt (FE8-multibyte): main + N1 + N2 nested IFRs ---
+
+        [Fact]
+        public void EmitOPClassDemoAt_EmitsMainIfr_CString_AndBothNestedIfrs()
+        {
+            var rom = CreateTestRom(0x10000);
+            uint pointer = 0x0400;
+            uint table = 0x1000;
+            uint className = 0x2000;  // CString target (entry +0 pointer)
+            uint n1Base = 0x3000;     // N1 sub-table (entry +8 pointer)
+            uint n2Base = 0x4000;     // N2 sub-table (entry +24 pointer)
+            rom.write_u32(pointer, Ptr(table));
+
+            // entry 0: u8(+0xF) <= 4 -> valid. entry 1: u8(+0xF) = 5 -> terminate -> DataCount 1.
+            rom.write_u8(table + 0 * 28 + 0xF, 0x02);
+            rom.write_u8(table + 1 * 28 + 0xF, 0x05);
+            // embedded pointers for entry 0:
+            rom.write_u32(table + 0, Ptr(className)); // +0 class-name CString
+            rom.write_u32(table + 8, Ptr(n1Base));    // +8 N1 sub-table
+            rom.write_u32(table + 24, Ptr(n2Base));   // +24 N2 sub-table
+            // class-name string
+            rom.write_u8(className + 0, (byte)'A');
+            rom.write_u8(className + 1, (byte)'B');
+            rom.write_u8(className + 2, 0x00); // strlen 2 -> CString length 3
+            // N1 sub-table block 1, rule i>=16?false:u8(addr)!=0xFF: 4 valid then 0xFF terminator.
+            rom.write_u8(n1Base + 0, 0x01);
+            rom.write_u8(n1Base + 1, 0x02);
+            rom.write_u8(n1Base + 2, 0x03);
+            rom.write_u8(n1Base + 3, 0x04);
+            rom.write_u8(n1Base + 4, 0xFF); // terminator -> N1 count 4
+            // N2 sub-table block 2, rule u8(addr)!=0: 2 valid then 0 terminator.
+            rom.write_u8(n2Base + 0, 0x10);
+            rom.write_u8(n2Base + 2, 0x20);
+            rom.write_u8(n2Base + 4, 0x00); // terminator -> N2 count 2
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitOPClassDemoAt(rom, list, pointer);
+
+            // Main IFR: block 28, DataCount 1 -> length 28*(1+1)=56, pointerIndexes {0,8,24}.
+            Address main = list.Single(a => a.DataType == Address.DataTypeEnum.InputFormRef && a.Info == "OPClassDemo");
+            Assert.Equal(table, main.Addr);
+            Assert.Equal(pointer, main.Pointer);
+            Assert.Equal(28u, main.BlockSize);
+            Assert.Equal(56u, main.Length);
+            Assert.Equal(new uint[] { 0, 8, 24 }, main.PointerIndexes);
+
+            // CString at +0: length strlen+1 = 3.
+            Address cstr = list.Single(a => a.DataType == Address.DataTypeEnum.CSTRING && a.Addr == className);
+            Assert.Equal(3u, cstr.Length);
+            Assert.Equal(table + 0, cstr.Pointer);
+
+            // N1 nested IFR @ +8: block 1, count 4 -> length 1*(4+1)=5, pointer = table+8.
+            Address n1 = list.Single(a => a.Info == "OPClassDemo_JPName");
+            Assert.Equal(n1Base, n1.Addr);
+            Assert.Equal(table + 8, n1.Pointer);
+            Assert.Equal(1u, n1.BlockSize);
+            Assert.Equal(5u, n1.Length);
+            Assert.Empty(n1.PointerIndexes);
+            Assert.Equal(Address.DataTypeEnum.InputFormRef, n1.DataType);
+
+            // N2 nested IFR @ +24: block 2, count 2 -> length 2*(2+1)=6, pointer = table+24.
+            Address n2 = list.Single(a => a.Info == "OPClassDemo_Anime");
+            Assert.Equal(n2Base, n2.Addr);
+            Assert.Equal(table + 24, n2.Pointer);
+            Assert.Equal(2u, n2.BlockSize);
+            Assert.Equal(6u, n2.Length);
+            Assert.Empty(n2.PointerIndexes);
+        }
+
+        [Fact]
+        public void EmitOPClassDemoAt_N1CapsAt16_EvenIfNoTerminator()
+        {
+            // N1 rule i>=16 -> false even if u8(addr)!=0xFF, so a sub-table with no 0xFF stops at 16.
+            var rom = CreateTestRom(0x10000);
+            uint pointer = 0x0400;
+            uint table = 0x1000;
+            uint n1Base = 0x3000;
+            uint n2Base = 0x4000;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u8(table + 0xF, 0x00);           // entry 0 valid
+            rom.write_u8(table + 28 + 0xF, 0x05);      // entry 1 terminates main
+            rom.write_u32(table + 8, Ptr(n1Base));
+            rom.write_u32(table + 24, Ptr(n2Base));
+            // N1: 32 non-0xFF bytes (would walk forever w/o the i>=16 cap).
+            for (uint k = 0; k < 32; k++) rom.write_u8(n1Base + k, 0x01);
+            // N2: immediate 0 terminator -> count 0.
+            rom.write_u8(n2Base + 0, 0x00);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitOPClassDemoAt(rom, list, pointer);
+
+            Address n1 = list.Single(a => a.Info == "OPClassDemo_JPName");
+            // count capped at 16 -> length 1*(16+1)=17.
+            Assert.Equal(17u, n1.Length);
+            Address n2 = list.Single(a => a.Info == "OPClassDemo_Anime");
+            // count 0 -> length 2*(0+1)=2.
+            Assert.Equal(2u, n2.Length);
+        }
+
+        [Fact]
+        public void EmitOPClassDemoAt_UnsafeJpNameOrAnime_SkipsBothNestedTables_KeepsCString()
+        {
+            // If either embedded pointer (+8 jpName OR +24 anime) is unsafe, WF `continue`s -> NEITHER
+            // nested table is emitted, but the +0 CString (emitted BEFORE the guards) still is.
+            var rom = CreateTestRom(0x10000);
+            uint pointer = 0x0400;
+            uint table = 0x1000;
+            uint className = 0x2000;
+            uint n1Base = 0x3000;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u8(table + 0xF, 0x00);          // entry 0 valid
+            rom.write_u8(table + 28 + 0xF, 0x05);     // entry 1 terminates
+            rom.write_u32(table + 0, Ptr(className)); // CString OK
+            rom.write_u8(className + 0, (byte)'X'); rom.write_u8(className + 1, 0x00);
+            rom.write_u32(table + 8, Ptr(n1Base));    // jpName SAFE
+            rom.write_u32(table + 24, 0);             // anime NULL -> unsafe -> skip BOTH nested
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitOPClassDemoAt(rom, list, pointer);
+
+            Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.CSTRING && a.Addr == className);
+            Assert.DoesNotContain(list, a => a.Info == "OPClassDemo_JPName"); // skipped (anime unsafe)
+            Assert.DoesNotContain(list, a => a.Info == "OPClassDemo_Anime");
+        }
+
+        [Fact]
+        public void EmitOPClassDemoAt_NearEof_NoThrow()
+        {
+            var rom = CreateTestRom(0x2000);
+            uint pointer = 0x0400;
+            rom.write_u32(pointer, Ptr(0x1FF0)); // base near EOF
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.EmitOPClassDemoAt(rom, list, pointer));
+            Assert.Null(ex);
+        }
+
+        // ---- EmitOPClassDemoFE7At (FE7-multibyte): main + LZ77 + N2 + palette -
+
+        [Fact]
+        public void EmitOPClassDemoFE7At_EmitsMainIfr_CString_Lz77_N2_AndCommonPalette()
+        {
+            // ROM must be large enough to hold the absolute JP_FONT_PALETTE_POINTER (0x0B0038).
+            var rom = CreateTestRom(0xC0000);
+            uint pointer = 0x0400;
+            uint table = 0x1000;
+            uint className = 0x2000;  // CString target (+0)
+            uint jpImg = 0x3000;      // LZ77 target (+8)
+            uint n2Base = 0x5000;     // N2 sub-table (+28)
+            uint paletteData = 0x70000; // common-palette target (past 0x0B0038)
+            rom.write_u32(pointer, Ptr(table));
+
+            // Build ONLY 1 real entry then make the table end via EOF would be huge; instead rely on the
+            // fixed i<=0x41 rule. To keep the per-entry assertions on entry 0, plant entry 0 fully and
+            // leave the rest as zeros (their CString/LZ77/anime are all NULL/unsafe -> emit nothing).
+            rom.write_u32(table + 0, Ptr(className));
+            rom.write_u8(className + 0, (byte)'Z'); rom.write_u8(className + 1, 0x00); // strlen 1 -> len 2
+            uint imgLen = WriteLz77AllLiteral(rom, jpImg, 48);
+            rom.write_u32(table + 8, Ptr(jpImg));
+            rom.write_u32(table + 28, Ptr(n2Base));
+            // N2 block 2, rule u8(addr)!=0: 3 valid then 0 terminator.
+            rom.write_u8(n2Base + 0, 0x10);
+            rom.write_u8(n2Base + 2, 0x20);
+            rom.write_u8(n2Base + 4, 0x30);
+            rom.write_u8(n2Base + 6, 0x00); // -> N2 count 3
+            // common palette: absolute JP_FONT_PALETTE_POINTER = 0x0B0038 holds a pointer to paletteData.
+            rom.write_u32(0x0B0038, Ptr(paletteData));
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitOPClassDemoFE7At(rom, list, pointer);
+
+            // Main IFR: block 32, DataCount = 0x42 (i<=0x41) -> length 32*(0x42+1).
+            Address main = list.Single(a => a.DataType == Address.DataTypeEnum.InputFormRef && a.Info == "OPClassDemo");
+            Assert.Equal(table, main.Addr);
+            Assert.Equal(pointer, main.Pointer);
+            Assert.Equal(32u, main.BlockSize);
+            Assert.Equal(32u * (0x42u + 1u), main.Length);
+            Assert.Equal(new uint[] { 0, 8, 28 }, main.PointerIndexes);
+
+            // entry 0 CString @ +0.
+            Address cstr = list.Single(a => a.DataType == Address.DataTypeEnum.CSTRING && a.Addr == className);
+            Assert.Equal(2u, cstr.Length);
+            Assert.Equal(table + 0, cstr.Pointer);
+
+            // entry 0 LZ77 @ +8: name "OPClassDemo_Anime_<0>_JP_NAME_IMG", real compressed length.
+            Address lz = list.Single(a => a.DataType == Address.DataTypeEnum.LZ77IMG && a.Addr == jpImg);
+            Assert.Equal(imgLen, lz.Length);
+            Assert.Equal(table + 8, lz.Pointer);
+            Assert.Equal("OPClassDemo_Anime_" + U.ToHexString(0u) + "_JP_NAME_IMG", lz.Info);
+
+            // entry 0 N2 nested IFR @ +28: block 2, count 3 -> length 2*(3+1)=8.
+            Address n2 = list.Single(a => a.Info == "OPClassDemo_Anime_" + U.ToHexString(0u) + "_Anime");
+            Assert.Equal(n2Base, n2.Addr);
+            Assert.Equal(table + 28, n2.Pointer);
+            Assert.Equal(2u, n2.BlockSize);
+            Assert.Equal(8u, n2.Length);
+            Assert.Empty(n2.PointerIndexes);
+
+            // trailing common-palette pointer: AddPointer(0x0B0038, 2*16, PAL).
+            Address pal = list.Single(a => a.Info == "OPClassDemo_CommonPalette");
+            Assert.Equal(paletteData, pal.Addr);
+            Assert.Equal(2u * 16u, pal.Length);
+            Assert.Equal(0x0B0038u, pal.Pointer);
+            Assert.Equal(Address.DataTypeEnum.PAL, pal.DataType);
+        }
+
+        [Fact]
+        public void EmitOPClassDemoFE7At_MissingMainTable_StillEmitsCommonPalette()
+        {
+            // WF emits the trailing common-palette AddPointer OUTSIDE the main block (unconditional),
+            // so even a missing main table still emits it.
+            var rom = CreateTestRom(0xC0000); // large enough for the absolute JP_FONT_PALETTE_POINTER
+            uint pointer = 0x0400;
+            rom.write_u32(pointer, 0); // base NULL -> no main IFR
+            uint paletteData = 0x70000;
+            rom.write_u32(0x0B0038, Ptr(paletteData));
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitOPClassDemoFE7At(rom, list, pointer);
+
+            Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.InputFormRef && a.Info == "OPClassDemo");
+            Address pal = list.Single(a => a.Info == "OPClassDemo_CommonPalette");
+            Assert.Equal(paletteData, pal.Addr);
+        }
+
+        [Fact]
+        public void EmitOPClassDemoFE7At_NearEof_NoThrow()
+        {
+            var rom = CreateTestRom(0x2000);
+            uint pointer = 0x0400;
+            rom.write_u32(pointer, Ptr(0x1FF0)); // base near EOF
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.EmitOPClassDemoFE7At(rom, list, pointer));
+            Assert.Null(ex);
+        }
+
+        // ---- version gate: OPClassDemo present on multibyte, absent otherwise ----
+
+        [Fact]
+        public void MakeAllStructPointers_FE8Multibyte_EmitsOPClassDemo()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8j = MakeVersionedRom("BE8J01"); // FE8J: version 8, is_multibyte == true
+                CoreState.ROM = fe8j;
+                Assert.True(fe8j.RomInfo.is_multibyte);
+                var result = RebuildProducerCore.MakeAllStructPointers(fe8j);
+                // On a blank fake ROM the op_class_demo_pointer slot is 0 -> the main IFR is skipped, but
+                // the emitter still RUNS without throwing (proven by FE8 gate firing). Coverage bookkeeping
+                // proves the FORM is no longer deferred (the gate is reached).
+                Assert.DoesNotContain("OPClassDemoForm", result.NotYetPorted);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitOPClassDemo_FE8Multibyte_RunsCleanly_OnEmptyFakeRom()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8j = MakeVersionedRom("BE8J01");
+                CoreState.ROM = fe8j;
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitOPClassDemo(fe8j, list));
+                Assert.Null(ex);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitOPClassDemoFE7_FE7Multibyte_RunsCleanly_OnEmptyFakeRom()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe7j = MakeVersionedRom("AE7J01"); // FE7J: version 7, is_multibyte == true
+                CoreState.ROM = fe7j;
+                Assert.True(fe7j.RomInfo.is_multibyte);
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitOPClassDemoFE7(fe7j, list));
+                Assert.Null(ex);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        // ---- NotYetPorted coverage delta for slice 2i -----------------------
+
+        [Fact]
+        public void GetNotYetPortedForms_DropsSlice2iCoveredForms_KeepsDeferredSiblings()
+        {
+            string[] ported = RebuildProducerCore.GetNotYetPortedForms();
+
+            // slice 2i ported these 2 — no longer in the deferred list:
+            Assert.DoesNotContain("OPClassDemoForm", ported);
+            Assert.DoesNotContain("OPClassDemoFE7Form", ported);
+
+            // deferred siblings STAY (their blocking subsystem is not in Core):
+            Assert.Contains("MapSettingForm", ported);           // IsMapSettingEnd needs WF text-count cache
+            Assert.Contains("WorldMapEventPointerForm", ported); // ScanScript
+            Assert.Contains("MonsterWMapProbabilityForm", ported); // ScanScript skirmish events
+            Assert.Contains("ImageCGFE7UForm", ported);          // LZ77 CG (FE7U)
+            Assert.Contains("FE8SpellMenuExtendsForm", ported);  // FindFE8SpellPatchPointer
 
             // the no-duplicates invariant still holds after the edits.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();

--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -4437,6 +4437,20 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Empty(list);
         }
 
+        [Fact]
+        public void EmitNestedIfrSub_NullSubRule_Throws()
+        {
+            // Regression (PR #1281 review): a NestedIfr SubWalk misconfigured with a null SubRule must
+            // fail loudly (ArgumentNullException) rather than NRE deep inside getBlockDataCount's
+            // callback — consistent with the producer treating other invalid configs as programming errors.
+            var rom = CreateTestRom(0x8000);
+            uint pfield = 0x1000;
+            rom.write_u32(pfield, Ptr(0x2000));
+            var list = new List<Address>();
+            Assert.Throws<System.ArgumentNullException>(() =>
+                RebuildProducerCore.EmitNestedIfrSub(rom, list, pfield, 2, null!, "Nested"));
+        }
+
         // ---- EmitOPClassDemoAt (FE8-multibyte): main + N1 + N2 nested IFRs ---
 
         [Fact]

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -196,10 +196,10 @@ namespace FEBuilderGBA
             /// <c>new uint[] {}</c>). Unlike every other <see cref="SubKind"/> (which emits a flat block of
             /// a known length), this one runs its OWN inner <c>getBlockDataCount</c>. Used by the
             /// OPClassDemo forms (N1/N2 sub-tables); EOF-safe (the embedded-pointer read and the inner
-            /// walk are both bounds-guarded, never throw). NOT driven by the flat <see cref="SubWalk"/>
-            /// loop in <see cref="EmitSubWalks"/> — the OPClassDemo forms have form-specific per-entry
-            /// guard ordering, so they call <see cref="EmitNestedIfrSub"/> directly from a dedicated
-            /// emitter; this enum value documents/labels the mechanism for future deferred forms.</summary>
+            /// walk are both bounds-guarded, never throw). IS handled by the flat <see cref="SubWalk"/>
+            /// loop in <see cref="EmitSubWalks"/> (available to any future single-nested-sub-table form);
+            /// the OPClassDemo forms, however, have form-specific per-entry guard ordering, so they call
+            /// <see cref="EmitNestedIfrSub"/> directly from a dedicated emitter rather than the flat loop.</summary>
             NestedIfr,
         }
 
@@ -1792,14 +1792,27 @@ namespace FEBuilderGBA
         ///   <see cref="Address.DataTypeEnum.InputFormRef"/>; blockSize <paramref name="subBlock"/>;
         ///   pointerIndexes EMPTY (the WinForms <c>new uint[] {}</c>).</item>
         /// </list>
-        /// EOF-safe: the embedded-pointer read is guarded (<c>pfield+3</c> before <c>p32</c>), an unsafe
-        /// <paramref name="pfield"/> or <c>subBase</c> emits nothing (mirroring <c>AddAddress</c>'s
-        /// <c>!isSafetyOffset(addr)</c> early-return), and <c>getBlockDataCount</c>'s own callback reads
-        /// are <c>addr+subBlock</c>-bounded.
+        /// EOF-safe: emits nothing when <paramref name="subBlock"/> is 0, when the embedded-pointer slot
+        /// is near EOF (<c>!isSafetyOffset(pfield+3)</c>, guarded before <c>p32</c>), or when <c>subBase</c>
+        /// is unsafe (mirroring <c>AddAddress</c>'s <c>!isSafetyOffset(addr)</c> early-return). A
+        /// <paramref name="pfield"/> that is in-bounds for the read but not itself a safe BasePointer does
+        /// NOT suppress emission — it only makes the emitted Address pointer <see cref="U.NOT_FOUND"/>
+        /// (matching <c>AddAddress</c>'s BasePointer fallback). <c>getBlockDataCount</c>'s own callback
+        /// reads are <c>addr+subBlock</c>-bounded. Requires a non-null <paramref name="subRule"/> — a
+        /// misconfigured <see cref="SubKind.NestedIfr"/> with a null rule throws
+        /// <see cref="System.ArgumentNullException"/> (a programming error, not a ROM-data condition).
         /// </summary>
         public static void EmitNestedIfrSub(ROM rom, List<Address> list, uint pfield,
             uint subBlock, Func<int, uint, bool> subRule, string name)
         {
+            if (subRule == null)
+            {
+                // A NestedIfr SubWalk with no SubRule is a descriptor misconfiguration; fail loudly here
+                // rather than NRE deep inside getBlockDataCount's callback invocation (consistent with the
+                // producer treating other invalid SubKind/DataCountRule configs as programming errors).
+                throw new System.ArgumentNullException(nameof(subRule),
+                    "SubKind.NestedIfr requires a non-null SubRule (the nested IsDataExists walk).");
+            }
             if (subBlock == 0)
             {
                 return; // a zero block would make getBlockDataCount spin; not real data.

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -183,6 +183,24 @@ namespace FEBuilderGBA
             /// data type is configurable (PAL / IMG / LZ77PAL), not hard-wired to BIN. Matches the
             /// per-entry <c>AddPointer(p + N, 0x20*K, name, PAL)</c> palette/image columns.</summary>
             FixedPointer,
+            /// <summary>A NESTED count-walked IFR sub-table behind an embedded pointer. Reproduces the
+            /// WinForms <c>N_IFR.ReInitPointer(p + EmbeddedPointerOffset) + AddAddress(N_IFR, name, {})</c>
+            /// idiom: resolves <c>subBase = p32(p + EmbeddedPointerOffset)</c>, walks it with
+            /// <see cref="SubWalk.SubBlockSize"/> and <see cref="SubWalk.SubRule"/> via
+            /// <c>getBlockDataCount</c>, and emits ONE IFR <see cref="Address"/> whose length is
+            /// <c>SubBlockSize × (subCount + 1)</c>, whose pointer is the embedded FIELD (the
+            /// <c>p + EmbeddedPointerOffset</c>, or <see cref="U.NOT_FOUND"/> if that is not a safe
+            /// offset — matching <c>AddressWinForms.AddAddress</c>'s <c>BasePointer</c> fallback), whose
+            /// type is <see cref="Address.DataTypeEnum.InputFormRef"/>, whose blockSize is
+            /// <see cref="SubWalk.SubBlockSize"/>, and whose pointerIndexes are EMPTY (the WinForms
+            /// <c>new uint[] {}</c>). Unlike every other <see cref="SubKind"/> (which emits a flat block of
+            /// a known length), this one runs its OWN inner <c>getBlockDataCount</c>. Used by the
+            /// OPClassDemo forms (N1/N2 sub-tables); EOF-safe (the embedded-pointer read and the inner
+            /// walk are both bounds-guarded, never throw). NOT driven by the flat <see cref="SubWalk"/>
+            /// loop in <see cref="EmitSubWalks"/> — the OPClassDemo forms have form-specific per-entry
+            /// guard ordering, so they call <see cref="EmitNestedIfrSub"/> directly from a dedicated
+            /// emitter; this enum value documents/labels the mechanism for future deferred forms.</summary>
+            NestedIfr,
         }
 
         /// <summary>One per-entry embedded-data sub-walk applied to every entry of a
@@ -214,6 +232,19 @@ namespace FEBuilderGBA
             /// label is taken from the decoded string itself (matching
             /// <see cref="Address.AddCString"/>), so this is only used by the BIN kinds.</summary>
             public Func<ROM, uint, string> Name;
+            /// <summary>For <see cref="SubKind.NestedIfr"/>: the nested sub-table's block size (the
+            /// WinForms <c>N_IFR.Init</c> BlockSize, e.g. OPClassDemo N1 = 1, N2 = 2). Drives both the
+            /// inner <c>getBlockDataCount</c> stride and the emitted length <c>SubBlockSize × (count + 1)</c>.
+            /// Ignored by the non-nested kinds.</summary>
+            public uint SubBlockSize;
+            /// <summary>For <see cref="SubKind.NestedIfr"/>: the nested sub-table's <c>IsDataExists</c>
+            /// callback (the WinForms <c>N_IFR.Init</c> rule lambda), reproduced VERBATIM as a
+            /// <c>(i, addr) =&gt; bool</c> over the SUB-table (e.g. OPClassDemo N1 =
+            /// <c>i &gt;= 16 ? false : u8(addr) != 0xFF</c>, N2 = <c>u8(addr) != 0</c>). The inner
+            /// <c>getBlockDataCount</c> only fires this while <c>addr + SubBlockSize &lt;= Length</c>, so
+            /// a read of width &lt;= <see cref="SubBlockSize"/> at <c>addr</c> is always in bounds.
+            /// Ignored by the non-nested kinds.</summary>
+            public Func<int, uint, bool> SubRule;
         }
 
         /// <summary>A declarative description of one simple "table walk + emit IFR Address" form.</summary>
@@ -534,6 +565,22 @@ namespace FEBuilderGBA
                 }
                 progress?.Report("WorldMapPath");
                 EmitWorldMapPath(rom, list);
+
+                // ---- slice 2i: OPClassDemo (FE8-multibyte ONLY) ----
+                // WF calls OPClassDemoForm.MakeAllDataLength inside `version==8 && is_multibyte` (the
+                // FE8U non-multibyte path uses OPClassDemoFE8UForm, still deferred). Per-entry nested
+                // N1/N2 IFR sub-tables (block 1/2) reached via embedded pointers @ +8/+24 — a dedicated
+                // emitter (EmitOPClassDemo) reproduces the form-specific dual-guard ordering.
+                if (rom.RomInfo.is_multibyte)
+                {
+                    if (ct.IsCancellationRequested)
+                    {
+                        progress?.Report("MakeAllStructPointersList cancelled");
+                        return new ProducerResult(list, notYet, cancelled: true);
+                    }
+                    progress?.Report("OPClassDemo");
+                    EmitOPClassDemo(rom, list);
+                }
             }
 
             if (rom.RomInfo.version == 7)
@@ -545,6 +592,22 @@ namespace FEBuilderGBA
                 }
                 progress?.Report("WorldMapImageFE7");
                 EmitWorldMapImageFE7(rom, list);
+
+                // ---- slice 2i: OPClassDemoFE7 (FE7-multibyte ONLY) ----
+                // WF calls OPClassDemoFE7Form.MakeAllDataLength inside `version==7 && is_multibyte` (the
+                // FE7U non-multibyte path uses OPClassDemoFE7UForm, still deferred). ONE nested N2 IFR
+                // sub-table @ +28 (block 2), an LZ77 column @ +8, and a trailing absolute common-palette
+                // pointer — a dedicated emitter (EmitOPClassDemoFE7) reproduces the shape verbatim.
+                if (rom.RomInfo.is_multibyte)
+                {
+                    if (ct.IsCancellationRequested)
+                    {
+                        progress?.Report("MakeAllStructPointersList cancelled");
+                        return new ProducerResult(list, notYet, cancelled: true);
+                    }
+                    progress?.Report("OPClassDemoFE7");
+                    EmitOPClassDemoFE7(rom, list);
+                }
             }
             else if (rom.RomInfo.version == 6)
             {
@@ -771,6 +834,18 @@ namespace FEBuilderGBA
                             Address.AddPointer(list, pfield, sw.FixedLength,
                                 sw.Name != null ? sw.Name(rom, i) : d.Name,
                                 sw.DataType);
+                            break;
+
+                        case SubKind.NestedIfr:
+                            // A nested count-walked IFR sub-table behind the embedded pointer
+                            // (N_IFR.ReInitPointer(pfield) + AddAddress(N_IFR, name, {})). EmitNestedIfrSub
+                            // resolves p32(pfield), walks it with SubBlockSize/SubRule, and emits one IFR
+                            // Address (length = SubBlockSize*(count+1), pointer = pfield, pointerIndexes {}).
+                            // EOF-safe; the OPClassDemo forms drive this from a dedicated emitter (their
+                            // per-entry guard ordering differs from this flat loop), but it is available to
+                            // the flat SubWalk loop for any future single-nested-sub-table form.
+                            EmitNestedIfrSub(rom, list, pfield, sw.SubBlockSize, sw.SubRule,
+                                sw.Name != null ? sw.Name(rom, i) : d.Name);
                             break;
 
                         default:
@@ -1688,6 +1763,254 @@ namespace FEBuilderGBA
                     return p - addr;
                 }
             }
+        }
+
+        // ===================================================================
+        // slice 2i — nested count-walked IFR sub-table (SubKind.NestedIfr) +
+        // the OPClassDemo / OPClassDemoFE7 forms (version-gated multibyte).
+        // Each form runs, per main-table entry, one or two N_IFR sub-tables
+        // reached via an embedded pointer, each with its OWN getBlockDataCount-
+        // walked variable count — a shape no flat block-length SubKind expresses.
+        // The per-entry guard ordering is form-specific (FE8 guards BOTH embedded
+        // pointers before emitting EITHER nested table), so each form gets a
+        // dedicated emitter rather than the flat EmitSubWalks loop.
+        // ===================================================================
+
+        /// <summary>
+        /// Emit ONE nested count-walked IFR <see cref="Address"/> for the embedded pointer at
+        /// <paramref name="pfield"/>. Reproduces the WinForms
+        /// <c>N_IFR.ReInitPointer(pfield); AddressWinForms.AddAddress(list, N_IFR, name, new uint[] {})</c>
+        /// VERBATIM:
+        /// <list type="bullet">
+        ///   <item><c>subBase = p32(pfield)</c> — the nested table's base
+        ///   (<c>ReInitPointer</c> -&gt; <c>ReInit(p32(pfield))</c>);</item>
+        ///   <item><c>subCount = getBlockDataCount(subBase, subBlock, subRule)</c> — the inner walk
+        ///   (<c>ReInit</c>'s <c>getBlockDataCount</c>);</item>
+        ///   <item>length = <c>subBlock × (subCount + 1)</c>; pointer = <paramref name="pfield"/>
+        ///   (the embedded FIELD = <c>N_IFR.BasePointer</c>), or <see cref="U.NOT_FOUND"/> if that is
+        ///   not a safe offset (matching <c>AddAddress</c>'s <c>BasePointer</c> fallback); type
+        ///   <see cref="Address.DataTypeEnum.InputFormRef"/>; blockSize <paramref name="subBlock"/>;
+        ///   pointerIndexes EMPTY (the WinForms <c>new uint[] {}</c>).</item>
+        /// </list>
+        /// EOF-safe: the embedded-pointer read is guarded (<c>pfield+3</c> before <c>p32</c>), an unsafe
+        /// <paramref name="pfield"/> or <c>subBase</c> emits nothing (mirroring <c>AddAddress</c>'s
+        /// <c>!isSafetyOffset(addr)</c> early-return), and <c>getBlockDataCount</c>'s own callback reads
+        /// are <c>addr+subBlock</c>-bounded.
+        /// </summary>
+        public static void EmitNestedIfrSub(ROM rom, List<Address> list, uint pfield,
+            uint subBlock, Func<int, uint, bool> subRule, string name)
+        {
+            if (subBlock == 0)
+            {
+                return; // a zero block would make getBlockDataCount spin; not real data.
+            }
+            // ReInitPointer reads p32(pfield); guard the FULL 4-byte field (root+3) before the read so a
+            // near-EOF embedded pointer emits nothing instead of throwing.
+            uint field = U.toOffset(pfield);
+            if (!U.isSafetyOffset(field + 3, rom))
+            {
+                return;
+            }
+            uint subBase = rom.p32(field);
+            if (!U.isSafetyOffset(subBase, rom))
+            {
+                return; // AddAddress early-returns when !isSafetyOffset(addr).
+            }
+
+            uint subCount = rom.getBlockDataCount(subBase, subBlock, subRule);
+            uint length = subBlock * (subCount + 1);
+
+            // AddAddress's BasePointer fallback: pointer = BasePointer if a safe offset else NOT_FOUND.
+            uint pointer = U.isSafetyOffset(field, rom) ? field : U.NOT_FOUND;
+            list.Add(new Address(subBase, length, pointer, name,
+                Address.DataTypeEnum.InputFormRef, subBlock, new uint[] { }));
+        }
+
+        /// <summary>
+        /// <c>OPClassDemoForm.MakeAllDataLength</c> (slice 2i; FE8-multibyte ONLY — gated at the
+        /// <c>version == 8 &amp;&amp; is_multibyte</c> call site, like OPClassFont; the FE8U non-multibyte
+        /// path is <c>OPClassDemoFE8UForm</c>, still deferred). Main IFR: base
+        /// <c>op_class_demo_pointer</c>, block 28, IsDataExists = <c>u8(addr+0xF) &lt;= 4</c>,
+        /// emitted via <c>AddAddress(list, IFR, "OPClassDemo", {0, 8, 24})</c>. Per main-table entry
+        /// (<c>addr = base + i*28</c>, <c>i &lt; DataCount</c>), VERBATIM:
+        /// <list type="bullet">
+        ///   <item><c>AddCString(list, addr + 0)</c> — the entry's class-name pointer at +0;</item>
+        ///   <item>guard <c>jpName = p32(addr + 8)</c>; if <c>!isSafetyOffset(jpName)</c> -&gt; continue
+        ///   (skips BOTH nested tables);</item>
+        ///   <item>guard <c>anime = p32(addr + 24)</c>; if <c>!isSafetyOffset(anime)</c> -&gt; continue
+        ///   (the WF order: jpName guard FIRST, anime guard SECOND, then BOTH nested tables);</item>
+        ///   <item>N1 nested IFR @ <c>addr + 8</c>: block 1, rule <c>i &gt;= 16 ? false : u8(addr) != 0xFF</c>,
+        ///   name "OPClassDemo_JPName";</item>
+        ///   <item>N2 nested IFR @ <c>addr + 24</c>: block 2, rule <c>u8(addr) != 0</c>,
+        ///   name "OPClassDemo_Anime".</item>
+        /// </list>
+        /// The main IFR's pointerIndexes {0, 8, 24} relocate the three embedded pointer FIELDS; the two
+        /// nested-IFR sub-Addresses (and the CString) relocate the pointed-at DATA.
+        /// </summary>
+        public static void EmitOPClassDemo(ROM rom, List<Address> list)
+        {
+            EmitOPClassDemoAt(rom, list, rom.RomInfo.op_class_demo_pointer);
+        }
+
+        /// <summary>OPClassDemo (FE8-multibyte) walk from an explicit pointer slot (test seam — lets a
+        /// synthetic ROM supply it without populating RomInfo). See <see cref="EmitOPClassDemo"/> for the
+        /// verbatim WF reproduction.</summary>
+        public static void EmitOPClassDemoAt(ROM rom, List<Address> list, uint rawPointer)
+        {
+            const uint block = 28;
+
+            // Main IFR (AddAddress(ifr, "OPClassDemo", {0,8,24})): base = p32(toOffset(slot)),
+            // pointer = slot. Guard the full slot before p32 (root+3).
+            uint pointer = U.toOffset(rawPointer);
+            if (!U.isSafetyOffset(pointer + 3, rom))
+            {
+                return;
+            }
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                return;
+            }
+
+            // IsDataExists = u8(addr+0xF) <= 4. getBlockDataCount only fires while addr+28<=Length, so
+            // the +0xF read is always in bounds.
+            uint dataCount = rom.getBlockDataCount(baseAddr, block, (i, addr) =>
+                rom.u8(addr + 0xF) <= 4);
+
+            uint length = block * (dataCount + 1);
+            list.Add(new Address(baseAddr, length, pointer, "OPClassDemo",
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { 0, 8, 24 }));
+
+            // Per-entry expansion. getBlockDataCount guarantees addr+block(28)<=Length for i<dataCount,
+            // so p32(addr+8) (deepest addr+11) and p32(addr+24) (deepest addr+27) are both in bounds.
+            uint p = baseAddr;
+            for (uint i = 0; i < dataCount; i++, p += block)
+            {
+                // Address.AddCString(list, 0 + addr): the class-name CString pointer at entry offset +0.
+                Address.AddCString(list, p + 0);
+
+                // WF guards BOTH embedded pointers (jpName @ +8, anime @ +24) before emitting EITHER
+                // nested table; a NULL/unsafe either one skips both N1 and N2 for this entry.
+                uint jpName = rom.p32(p + 8);
+                if (!U.isSafetyOffset(jpName, rom))
+                {
+                    continue;
+                }
+                uint anime = rom.p32(p + 24);
+                if (!U.isSafetyOffset(anime, rom))
+                {
+                    continue;
+                }
+
+                // N1_InputFormRef.ReInitPointer(addr + 8); AddAddress(N1, "OPClassDemo_JPName", {}).
+                // N1_Init: block 1, IsDataExists = i >= 16 ? false : u8(addr) != 0xFF.
+                EmitNestedIfrSub(rom, list, p + 8, 1,
+                    (j, addr) => j >= 16 ? false : rom.u8(addr) != 0xFF,
+                    "OPClassDemo_JPName");
+
+                // N2_InputFormRef.ReInitPointer(addr + 24); AddAddress(N2, "OPClassDemo_Anime", {}).
+                // N2_Init: block 2, IsDataExists = u8(addr) != 0x00.
+                EmitNestedIfrSub(rom, list, p + 24, 2,
+                    (j, addr) => rom.u8(addr) != 0x00,
+                    "OPClassDemo_Anime");
+            }
+        }
+
+        /// <summary>
+        /// <c>OPClassDemoFE7Form.MakeAllDataLength</c> (slice 2i; FE7-multibyte ONLY — gated at the
+        /// <c>version == 7 &amp;&amp; is_multibyte</c> call site; the FE7U non-multibyte path is
+        /// <c>OPClassDemoFE7UForm</c>, still deferred). Differs from the FE8 form: ONE nested table (N2),
+        /// an LZ77 column at +8 (not a nested table), a FIXED main count (<c>i &lt;= 0x41</c>), and a
+        /// trailing standalone common-palette pointer. Main IFR: base <c>op_class_demo_pointer</c>,
+        /// block 32, IsDataExists = <c>i &lt;= 0x41</c>, emitted via
+        /// <c>AddAddress(list, IFR, "OPClassDemo", {0, 8, 28})</c>. Per main-table entry
+        /// (<c>addr = base + i*32</c>, <c>i &lt; DataCount</c>), VERBATIM:
+        /// <list type="bullet">
+        ///   <item><c>AddCString(list, addr + 0)</c> — class-name pointer at +0;</item>
+        ///   <item><c>AddLZ77Pointer(list, addr + 8, "OPClassDemo_Anime_&lt;i&gt;_JP_NAME_IMG", false,
+        ///   LZ77IMG)</c> — the JP-name image (producer always scans real lengths, isPointerOnly=false);</item>
+        ///   <item>guard <c>anime = p32(addr + 28)</c>; if <c>!isSafetyOffset(anime)</c> -&gt; continue;</item>
+        ///   <item>N2 nested IFR @ <c>addr + 28</c>: block 2, rule <c>u8(addr) != 0</c>,
+        ///   name "OPClassDemo_Anime_&lt;i&gt;_Anime".</item>
+        /// </list>
+        /// AFTER the loop (once): <c>AddPointer(list, 0x0B0038, 2*16, "OPClassDemo_CommonPalette", PAL)</c>
+        /// — the absolute <c>JP_FONT_PALETTE_POINTER</c> common-palette pointer (a fixed ROM location, NOT
+        /// a RomInfo field; its DATA is a 32-byte palette). The main IFR's pointerIndexes {0, 8, 28}
+        /// relocate the three embedded pointer FIELDS.
+        /// </summary>
+        public static void EmitOPClassDemoFE7(ROM rom, List<Address> list)
+        {
+            EmitOPClassDemoFE7At(rom, list, rom.RomInfo.op_class_demo_pointer);
+        }
+
+        /// <summary>OPClassDemo (FE7-multibyte) walk from an explicit pointer slot (test seam). See
+        /// <see cref="EmitOPClassDemoFE7"/> for the verbatim WF reproduction.</summary>
+        public static void EmitOPClassDemoFE7At(ROM rom, List<Address> list, uint rawPointer)
+        {
+            const uint block = 32;
+            // WF OPClassDemoFE7Form: const uint JP_FONT_PALETTE_POINTER = 0x0B0038.
+            const uint JP_FONT_PALETTE_POINTER = 0x0B0038;
+
+            // Main IFR (AddAddress(ifr, "OPClassDemo", {0,8,28})): base = p32(toOffset(slot)),
+            // pointer = slot. Guard the full slot before p32 (root+3).
+            uint pointer = U.toOffset(rawPointer);
+            if (!U.isSafetyOffset(pointer + 3, rom))
+            {
+                // Even on a missing main table, WF still emits the trailing common-palette pointer
+                // (it is outside the `{ ... }` block but unconditional). Reproduce that.
+                Address.AddPointer(list, JP_FONT_PALETTE_POINTER, 2 * 16,
+                    "OPClassDemo_CommonPalette", Address.DataTypeEnum.PAL);
+                return;
+            }
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                Address.AddPointer(list, JP_FONT_PALETTE_POINTER, 2 * 16,
+                    "OPClassDemo_CommonPalette", Address.DataTypeEnum.PAL);
+                return;
+            }
+
+            // IsDataExists = i <= 0x41 (a pure fixed count; addr is ignored). DataCount caps at 0x42
+            // entries (i = 0..0x41) or sooner if addr+32 runs past EOF (getBlockDataCount's own guard).
+            uint dataCount = rom.getBlockDataCount(baseAddr, block, (i, addr) => i <= 0x41);
+
+            uint length = block * (dataCount + 1);
+            list.Add(new Address(baseAddr, length, pointer, "OPClassDemo",
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { 0, 8, 28 }));
+
+            // Per-entry expansion. getBlockDataCount guarantees addr+block(32)<=Length for i<dataCount,
+            // so p32(addr+28) (deepest addr+31) is in bounds. AddCString/AddLZ77Pointer self-guard.
+            uint p = baseAddr;
+            for (uint i = 0; i < dataCount; i++, p += block)
+            {
+                string name = "OPClassDemo_Anime_" + U.ToHexString(i);
+
+                // Address.AddCString(list, 0 + addr): class-name CString pointer at +0.
+                Address.AddCString(list, p + 0);
+
+                // Address.AddLZ77Pointer(list, addr + 8, name + "_JP_NAME_IMG", isPointerOnly, LZ77IMG).
+                // The producer always scans real lengths (isPointerOnly: false). Self-guards + EOF-safe.
+                Address.AddLZ77Pointer(list, p + 8, name + "_JP_NAME_IMG", false,
+                    Address.DataTypeEnum.LZ77IMG);
+
+                // WF guards anime @ +28 before emitting the N2 nested table.
+                uint anime = rom.p32(p + 28);
+                if (!U.isSafetyOffset(anime, rom))
+                {
+                    continue;
+                }
+
+                // N2_InputFormRef.ReInitPointer(addr + 28); AddAddress(N2, name + "_Anime", {}).
+                // N2_Init: block 2, IsDataExists = u8(addr) != 0x00.
+                EmitNestedIfrSub(rom, list, p + 28, 2,
+                    (j, addr) => rom.u8(addr) != 0x00,
+                    name + "_Anime");
+            }
+
+            // After the loop, unconditional (outside the `{ ... }` block in WF):
+            // Address.AddPointer(list, JP_FONT_PALETTE_POINTER, 2*16, "OPClassDemo_CommonPalette", PAL).
+            Address.AddPointer(list, JP_FONT_PALETTE_POINTER, 2 * 16,
+                "OPClassDemo_CommonPalette", Address.DataTypeEnum.PAL);
         }
 
         // ===================================================================
@@ -3759,19 +4082,24 @@ namespace FEBuilderGBA
                 //    WorldMapPathForm [FE8] — EmitWorldMapPath, main IFR PointerAt@0/{0,8} + per-entry
                 //      BIN/POINTER sub-blocks whose lengths are the pure CalcPath{,Move}DataLength
                 //      terminator walks (reproduced verbatim, EOF-hardened on the u32 read).
-                //  STILL deferred (event-scan / LZ77+nested-IFR / recursive / dynamic base):
+                //  slice 2i ported the two OPClassDemo forms via the new SubKind.NestedIfr mechanism
+                //  (EmitNestedIfrSub: an embedded pointer whose target is ITSELF a getBlockDataCount-
+                //  walked variable-count IFR sub-table, length = subBlock*(subCount+1), pointer = field,
+                //  pointerIndexes {}):
+                //    OPClassDemoForm [FE8-multibyte] — EmitOPClassDemo: main block 28, rule u8(+0xF)<=4,
+                //      PI {0,8,24}; per entry CString@+0, dual-guard (jpName@+8 AND anime@+24), then N1
+                //      NestedIfr@+8 (block 1, i>=16?false:u8!=0xFF) + N2 NestedIfr@+24 (block 2, u8!=0).
+                //    OPClassDemoFE7Form [FE7-multibyte] — EmitOPClassDemoFE7: main block 32, rule i<=0x41,
+                //      PI {0,8,28}; per entry CString@+0, Lz77@+8 (LZ77IMG), anime-guard@+28, then N2
+                //      NestedIfr@+28 (block 2, u8!=0); + a trailing absolute AddPointer(0x0B0038, 0x20,
+                //      PAL) common-palette pointer. (FE8U/FE7U non-multibyte variants STAY deferred.)
+                //  STILL deferred (event-scan / recursive / dynamic base / LZ77 CG):
                 //  MonsterWMapProbabilityForm STAYS — although its 5 IFR probability/stage tables
                 //    are flat ROM reads, its MakeAllDataLength ALSO emits EventScriptForm.ScanScript over
                 //    the two skirmish start/end event pointers (no Core ScanScript primitive yet);
                 //    porting only the flat tables would drop those skirmish-event regions = corruption.
                 //  WorldMapEventPointerForm [ScanScript],
                 //  EventBattleTalkForm + EventHaikuForm [FE8, ScanScript per-entry],
-                //  OPClassDemoForm [FE8-multibyte] + OPClassDemoFE7Form [FE7-multibyte] STAY — both run
-                //    a per-entry NESTED IFR sub-table (N1/N2 ReInitPointer'd at an embedded pointer, each
-                //    with its OWN getBlockDataCount-walked variable count: OPClassDemo N1 u8!=0xFF&&i<16
-                //    @+8 / N2 u8!=0 @+24; OPClassDemoFE7 N2 u8!=0 @+28). The SubKind machinery emits ONE
-                //    Address per sub-walk, not a nested count-walked IFR table, so they need a new
-                //    nested-IFR SubKind (plus OPClassDemo's u8(+15)<=4 main rule) — a later slice.
                 //  MapSettingForm [FE8] STAYS — its count rule (IsMapSettingEnd) needs the WF cached
                 //    text count (TextForm.GetDataCount() / g_GetDataCount_Cache, NOT in Core); the
                 //    extracted MapSettingCore.IsMapSettingValid diverges (its `if (textmax>0)` guard
@@ -3783,8 +4111,8 @@ namespace FEBuilderGBA
                 "WorldMapEventPointerForm",
                 "EventHaikuForm",
                 "MapSettingForm",
-                "OPClassDemoForm", "FE8SpellMenuExtendsForm",
-                "OPClassDemoFE7Form", "ImageCGFE7UForm",
+                "FE8SpellMenuExtendsForm",
+                "ImageCGFE7UForm",
                 // patch / procs / ASM — OUT OF SCOPE for this data-path producer: these are emitted by
                 // U.AppendAllASMStructPointersList (the ASM/LDR-map path), NOT U.MakeAllStructPointersList.
                 // (EventFunctionPointerForm / Command85PointerForm above are likewise ASM-path forms.)


### PR DESCRIPTION
## Summary
**Slice 2i** of #1261 — adds a reusable **`SubKind.NestedIfr`** (an embedded pointer whose target is itself a `getBlockDataCount`-walked variable-count IFR sub-table) and uses it to port the **OPClassDemo** forms.

## New machinery — `SubKind.NestedIfr` + `EmitNestedIfrSub`
At an embedded pointer offset: guard `pfield+3`, `subBase = p32(pfield)`, walk `subRule` via `getBlockDataCount`, emit `Address(subBase, subBlock*(count+1), pfield-if-safe-else-NOT_FOUND, name, InputFormRef, subBlock, {})` — mirroring WF's `N_IFR.ReInitPointer(pfield) + AddAddress(N_IFR, name, {})`. Wired into the flat `EmitSubWalks` switch for future single-nested forms; existing SubKinds unchanged. The OPClassDemo forms themselves use **dedicated emitters** (their per-entry guard ordering is form-specific).

## Ported (2 forms — VERBATIM vs WF `MakeAllDataLength`, version-gated)
- **OPClassDemoForm** [`version==8 && is_multibyte`] — main IFR `op_class_demo_pointer`, block 28, rule `u8(addr+0xF)<=4`, pointerIndexes `{0,8,24}`. Per entry: `AddCString@0`; WF dual-guard (`p32(+8)` jpName AND `p32(+24)` anime both `isSafetyOffset` before EITHER nested); **N1** `NestedIfr@+8` (block 1, rule `i>=16?false:u8!=0xFF`); **N2** `NestedIfr@+24` (block 2, rule `u8!=0`).
- **OPClassDemoFE7Form** [`version==7 && is_multibyte`] — DIFFERS from FE8: block 32, main rule `i<=0x41` (FixedCount), pointerIndexes `{0,8,28}`. Per entry: `AddCString@0`; `AddLZ77Pointer@+8` (LZ77IMG — NOT nested); anime-guard `p32(+28)`; ONE **N2** `NestedIfr@+28` (block 2, `u8!=0`). **After the loop, UNCONDITIONAL** `AddPointer(JP_FONT_PALETTE_POINTER, 2*16, PAL)` — verified verbatim: WF emits it *outside* the IFR `{}` block, so it lands even when the main table is missing.

Version gating matches the WF `MakeAllStructPointersList` call site (`if(version==8){... if(is_multibyte) ...}` / `version==7` likewise) — same `is_multibyte` branches as OPClassFont/ChapterTitleFE7. No FE6 variant. FE8U/FE7U non-multibyte (`OPClassDemoFE8UForm`/`FE7UForm`) stay deferred.

## Tests
- RebuildProducer filter: **154 passed / 0 failed** (+15) — `EmitNestedIfrSub` (len+1/empty-PI, null-ptr, zero-block-no-hang, near-EOF); `EmitOPClassDemo` (main+CString+N1+N2 exact, N1 caps-at-16, unsafe-anime skips BOTH nested but keeps CString, near-EOF); `EmitOPClassDemoFE7` (main+CString+LZ77+N2+palette, missing-table-still-emits-palette, near-EOF); version gates FE8mb(BE8J01)/FE7mb(AE7J01). Updated 3 pre-existing "still deferred" coverage assertions.
- FEBuilderGBA.Tests (net9.0-windows): no new failures (the `Skill*`/`SkillSystemsAnime*` env failures are the known `config/patch2`-absent-in-worktree ones).
- EOF self-audit confirmed: `pfield+3`/`pointer+3` guards before every new `p32`; per-entry reads block-bounded by `getBlockDataCount`.

Part of #1261.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
