### PR TITLE
feat(core): ROM-rebuild producer — MapTerrain lookup + MapPointer + ExtraUnit forms (#1261 slice 2j)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -2294,15 +2294,15 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void GetNotYetPortedForms_DropsSlice2dCoveredForms()
         {
-            var ported = RebuildProducerCore.GetNotYetPortedForms();
-            Assert.DoesNotContain("StatusOptionForm", ported);
-            Assert.DoesNotContain("SoundFootStepsForm", ported);
-            Assert.DoesNotContain("StatusRMenuForm", ported);
-            Assert.DoesNotContain("MenuDefinitionForm", ported);
+            var notYet = RebuildProducerCore.GetNotYetPortedForms();
+            Assert.DoesNotContain("StatusOptionForm", notYet);
+            Assert.DoesNotContain("SoundFootStepsForm", notYet);
+            Assert.DoesNotContain("StatusRMenuForm", notYet);
+            Assert.DoesNotContain("MenuDefinitionForm", notYet);
             // sibling forms that genuinely still need un-ported subsystems STAY.
-            Assert.Contains("ItemForm", ported);
-            Assert.Contains("SoundRoomForm", ported);
-            Assert.Contains("ItemWeaponEffectForm", ported);
+            Assert.Contains("ItemForm", notYet);
+            Assert.Contains("SoundRoomForm", notYet);
+            Assert.Contains("ItemWeaponEffectForm", notYet);
         }
 
         // ---- real ROM: the new tables are found --------------------------
@@ -3044,24 +3044,24 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void GetNotYetPortedForms_NoLongerListsPortedImageForms_StillListsDeferred()
         {
-            var ported = RebuildProducerCore.GetNotYetPortedForms();
+            var notYet = RebuildProducerCore.GetNotYetPortedForms();
             // ported in slice 2e -> removed from the deferred list:
-            Assert.DoesNotContain("ImageBattleBGForm", ported);
-            Assert.DoesNotContain("ImageBattleTerrainForm", ported);
-            Assert.DoesNotContain("ImageBattleScreenForm", ported);
-            Assert.DoesNotContain("ImageUnitWaitIconFrom", ported);
-            Assert.DoesNotContain("ImageUnitPaletteForm", ported);
-            Assert.DoesNotContain("ImageGenericEnemyPortraitForm", ported);
-            Assert.DoesNotContain("ImageChapterTitleForm", ported);
+            Assert.DoesNotContain("ImageBattleBGForm", notYet);
+            Assert.DoesNotContain("ImageBattleTerrainForm", notYet);
+            Assert.DoesNotContain("ImageBattleScreenForm", notYet);
+            Assert.DoesNotContain("ImageUnitWaitIconFrom", notYet);
+            Assert.DoesNotContain("ImageUnitPaletteForm", notYet);
+            Assert.DoesNotContain("ImageGenericEnemyPortraitForm", notYet);
+            Assert.DoesNotContain("ImageChapterTitleForm", notYet);
             // still deferred (need ImageUtil / config / runtime-inspection subsystems):
-            Assert.Contains("ImageBGForm", ported);
-            Assert.Contains("ImageCGForm", ported);
-            Assert.Contains("ImageSystemIconForm", ported);
-            Assert.Contains("ImageBattleAnimeForm", ported);
-            Assert.Contains("ImagePortraitForm", ported);
-            Assert.Contains("WorldMapImageForm", ported); // the FE8 form stays (AddHeaderTSAPointer)
-            Assert.Contains("ImageItemIconForm", ported);
-            Assert.Contains("ImageTSAAnimeForm", ported);
+            Assert.Contains("ImageBGForm", notYet);
+            Assert.Contains("ImageCGForm", notYet);
+            Assert.Contains("ImageSystemIconForm", notYet);
+            Assert.Contains("ImageBattleAnimeForm", notYet);
+            Assert.Contains("ImagePortraitForm", notYet);
+            Assert.Contains("WorldMapImageForm", notYet); // the FE8 form stays (AddHeaderTSAPointer)
+            Assert.Contains("ImageItemIconForm", notYet);
+            Assert.Contains("ImageTSAAnimeForm", notYet);
         }
 
         // ===================================================================
@@ -3469,24 +3469,24 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void GetNotYetPortedForms_DropsSlice2fCoveredForms_KeepsDeferredSiblings()
         {
-            string[] ported = RebuildProducerCore.GetNotYetPortedForms();
+            string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
 
             // slice 2f ported these 7 — no longer in the deferred list:
-            Assert.DoesNotContain("AIMapSettingForm", ported);
-            Assert.DoesNotContain("AIPerformStaffForm", ported);
-            Assert.DoesNotContain("AIPerformItemForm", ported);
-            Assert.DoesNotContain("MantAnimationForm", ported);
-            Assert.DoesNotContain("ArenaEnemyWeaponForm", ported);
-            Assert.DoesNotContain("ItemUsagePointerForm", ported);
-            Assert.DoesNotContain("UnitFE6Form", ported);
+            Assert.DoesNotContain("AIMapSettingForm", notYet);
+            Assert.DoesNotContain("AIPerformStaffForm", notYet);
+            Assert.DoesNotContain("AIPerformItemForm", notYet);
+            Assert.DoesNotContain("MantAnimationForm", notYet);
+            Assert.DoesNotContain("ArenaEnemyWeaponForm", notYet);
+            Assert.DoesNotContain("ItemUsagePointerForm", notYet);
+            Assert.DoesNotContain("UnitFE6Form", notYet);
 
             // deferred siblings STAY (their blocking subsystem is not in Core):
-            Assert.Contains("AIScriptForm", ported);              // AI bytecode CalcLength + nested LZ77
-            Assert.Contains("UnitActionPointerForm", ported);     // PatchUtil SearchUnitActionReworkPatch
-            Assert.Contains("MonsterWMapProbabilityForm", ported);// EventScriptForm.ScanScript skirmish
+            Assert.Contains("AIScriptForm", notYet);              // AI bytecode CalcLength + nested LZ77
+            Assert.Contains("UnitActionPointerForm", notYet);     // PatchUtil SearchUnitActionReworkPatch
+            Assert.Contains("MonsterWMapProbabilityForm", notYet);// EventScriptForm.ScanScript skirmish
             // (the 5 map-PLIST forms that were deferred "for slice size" here are now PORTED in slice 2g
             //  — see GetNotYetPortedForms_DropsSlice2gCoveredForms_KeepsDeferredSiblings.)
-            Assert.Contains("EventCondForm", ported);             // EventScriptForm.ScanScript
+            Assert.Contains("EventCondForm", notYet);             // EventScriptForm.ScanScript
             // and the no-duplicates invariant still holds after the edits.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
             Assert.Equal(raw.Length, raw.Distinct().Count());
@@ -3873,25 +3873,25 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void GetNotYetPortedForms_DropsSlice2gCoveredForms_KeepsDeferredSiblings()
         {
-            string[] ported = RebuildProducerCore.GetNotYetPortedForms();
+            string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
 
             // slice 2g ported these 5 map-PLIST forms — no longer in the deferred list:
-            Assert.DoesNotContain("ItemShopForm", ported);
-            Assert.DoesNotContain("MapChangeForm", ported);
-            Assert.DoesNotContain("MapExitPointForm", ported);
-            Assert.DoesNotContain("MapTileAnimation1Form", ported);
-            Assert.DoesNotContain("MapTileAnimation2Form", ported);
+            Assert.DoesNotContain("ItemShopForm", notYet);
+            Assert.DoesNotContain("MapChangeForm", notYet);
+            Assert.DoesNotContain("MapExitPointForm", notYet);
+            Assert.DoesNotContain("MapTileAnimation1Form", notYet);
+            Assert.DoesNotContain("MapTileAnimation2Form", notYet);
 
             // (MapPointerForm + MapTerrain{Floor,BG}LookupTableForm were deferred map siblings here, but
             //  are now PORTED in slice 2j — their blocking Core helpers (MapPListResolverCore /
             //  MapTerrainLookupCore + the PatchDetection gates) landed for the Avalonia gap-sweep. See
             //  GetNotYetPortedForms_DropsSlice2jCoveredForms_KeepsDeferredSiblings.)
-            Assert.DoesNotContain("MapPointerForm", ported);
-            Assert.DoesNotContain("MapTerrainFloorLookupTableForm", ported);
-            Assert.DoesNotContain("MapTerrainBGLookupTableForm", ported);
+            Assert.DoesNotContain("MapPointerForm", notYet);
+            Assert.DoesNotContain("MapTerrainFloorLookupTableForm", notYet);
+            Assert.DoesNotContain("MapTerrainBGLookupTableForm", notYet);
             // deferred map siblings STAY (their blocking subsystem is not in Core):
-            Assert.Contains("MapSettingForm", ported);                 // IsMapSettingEnd + CString
-            Assert.Contains("ItemForm", ported);                       // StatBooster size via PatchUtil
+            Assert.Contains("MapSettingForm", notYet);                 // IsMapSettingEnd + CString
+            Assert.Contains("ItemForm", notYet);                       // StatBooster size via PatchUtil
 
             // the no-duplicates invariant still holds after the edits.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
@@ -4349,21 +4349,21 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void GetNotYetPortedForms_DropsSlice2hCoveredForms_KeepsDeferredSiblings()
         {
-            string[] ported = RebuildProducerCore.GetNotYetPortedForms();
+            string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
 
             // slice 2h ported these 5 — no longer in the deferred list:
-            Assert.DoesNotContain("EDStaffRollForm", ported);
-            Assert.DoesNotContain("OPPrologueForm", ported);
-            Assert.DoesNotContain("OPClassFontForm", ported);
-            Assert.DoesNotContain("SupportUnitForm", ported);
-            Assert.DoesNotContain("WorldMapPathForm", ported);
+            Assert.DoesNotContain("EDStaffRollForm", notYet);
+            Assert.DoesNotContain("OPPrologueForm", notYet);
+            Assert.DoesNotContain("OPClassFontForm", notYet);
+            Assert.DoesNotContain("SupportUnitForm", notYet);
+            Assert.DoesNotContain("WorldMapPathForm", notYet);
 
             // deferred siblings STAY (their blocking subsystem is not in Core):
             // (NOTE: OPClassDemoForm / OPClassDemoFE7Form were the nested-IFR siblings deferred at
             //  slice 2h; slice 2i below ports them, so they move to DoesNotContain there.)
-            Assert.Contains("MapSettingForm", ported);      // IsMapSettingEnd needs WF text-count cache
-            Assert.Contains("WorldMapEventPointerForm", ported); // ScanScript
-            Assert.Contains("ImageCGFE7UForm", ported);     // LZ77 CG (FE7U)
+            Assert.Contains("MapSettingForm", notYet);      // IsMapSettingEnd needs WF text-count cache
+            Assert.Contains("WorldMapEventPointerForm", notYet); // ScanScript
+            Assert.Contains("ImageCGFE7UForm", notYet);     // LZ77 CG (FE7U)
 
             // the no-duplicates invariant still holds after the edits.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
@@ -4748,18 +4748,18 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void GetNotYetPortedForms_DropsSlice2iCoveredForms_KeepsDeferredSiblings()
         {
-            string[] ported = RebuildProducerCore.GetNotYetPortedForms();
+            string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
 
             // slice 2i ported these 2 — no longer in the deferred list:
-            Assert.DoesNotContain("OPClassDemoForm", ported);
-            Assert.DoesNotContain("OPClassDemoFE7Form", ported);
+            Assert.DoesNotContain("OPClassDemoForm", notYet);
+            Assert.DoesNotContain("OPClassDemoFE7Form", notYet);
 
             // deferred siblings STAY (their blocking subsystem is not in Core):
-            Assert.Contains("MapSettingForm", ported);           // IsMapSettingEnd needs WF text-count cache
-            Assert.Contains("WorldMapEventPointerForm", ported); // ScanScript
-            Assert.Contains("MonsterWMapProbabilityForm", ported); // ScanScript skirmish events
-            Assert.Contains("ImageCGFE7UForm", ported);          // LZ77 CG (FE7U)
-            Assert.Contains("FE8SpellMenuExtendsForm", ported);  // FindFE8SpellPatchPointer
+            Assert.Contains("MapSettingForm", notYet);           // IsMapSettingEnd needs WF text-count cache
+            Assert.Contains("WorldMapEventPointerForm", notYet); // ScanScript
+            Assert.Contains("MonsterWMapProbabilityForm", notYet); // ScanScript skirmish events
+            Assert.Contains("ImageCGFE7UForm", notYet);          // LZ77 CG (FE7U)
+            Assert.Contains("FE8SpellMenuExtendsForm", notYet);  // FindFE8SpellPatchPointer
 
             // the no-duplicates invariant still holds after the edits.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
@@ -5193,21 +5193,21 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void GetNotYetPortedForms_DropsSlice2jCoveredForms_KeepsDeferredSiblings()
         {
-            string[] ported = RebuildProducerCore.GetNotYetPortedForms();
+            string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
 
             // slice 2j ported these 5 (or 4 forms; ExtraUnit is a FE8J/FE8U split) — no longer deferred:
-            Assert.DoesNotContain("MapTerrainFloorLookupTableForm", ported);
-            Assert.DoesNotContain("MapTerrainBGLookupTableForm", ported);
-            Assert.DoesNotContain("MapPointerForm", ported);
-            Assert.DoesNotContain("ExtraUnitForm", ported);
-            Assert.DoesNotContain("ExtraUnitFE8UForm", ported);
+            Assert.DoesNotContain("MapTerrainFloorLookupTableForm", notYet);
+            Assert.DoesNotContain("MapTerrainBGLookupTableForm", notYet);
+            Assert.DoesNotContain("MapPointerForm", notYet);
+            Assert.DoesNotContain("ExtraUnitForm", notYet);
+            Assert.DoesNotContain("ExtraUnitFE8UForm", notYet);
 
             // Still deferred (real missing-Core blocker) -> must REMAIN:
-            Assert.Contains("SongTableForm", ported);                   // SongUtil.ParseTrack/RecycleOldInstrument
-            Assert.Contains("EventUnitForm(RecycleReserveUnits)", ported); // NewAllocData = editor session state
-            Assert.Contains("SoundRoomForm", ported);                   // FE7 CString sub-walk + MIX type
-            Assert.Contains("ItemForm", ported);                        // StatBooster size via PatchUtil
-            Assert.Contains("MapSettingForm", ported);                  // IsMapSettingEnd text-count cache
+            Assert.Contains("SongTableForm", notYet);                   // SongUtil.ParseTrack/RecycleOldInstrument
+            Assert.Contains("EventUnitForm(RecycleReserveUnits)", notYet); // NewAllocData = editor session state
+            Assert.Contains("SoundRoomForm", notYet);                   // FE7 CString sub-walk + MIX type
+            Assert.Contains("ItemForm", notYet);                        // StatBooster size via PatchUtil
+            Assert.Contains("MapSettingForm", notYet);                  // IsMapSettingEnd text-count cache
 
             // the no-duplicates invariant still holds after the edits.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();

--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -476,10 +476,10 @@ namespace FEBuilderGBA.Core.Tests
             // (CCBranchForm is now PORTED in the #1261 producer sweep via ClassDataCount — it is no
             //  longer a deferred sibling; EventBattleTalkForm stays deferred for its ScanScript.)
             Assert.Contains("EventBattleTalkForm", notYet);        // per-entry EventScriptForm.ScanScript
-            // (MapTileAnimation1Form/MapTileAnimation2Form are now PORTED in slice 2g — see
-            //  GetNotYetPortedForms_DropsSlice2gCoveredForms_KeepsDeferredSiblings.)
-            Assert.Contains("MapTerrainFloorLookupTableForm", notYet); // PatchUtil GetPointers()
-            Assert.Contains("MapTerrainBGLookupTableForm", notYet);    // PatchUtil GetPointers()
+            // (MapTileAnimation1Form/MapTileAnimation2Form are now PORTED in slice 2g; the MapTerrain
+            //  lookup tables are now PORTED in slice 2j — see
+            //  GetNotYetPortedForms_DropsSlice2jCoveredForms_KeepsDeferredSiblings.)
+            Assert.Contains("SongTableForm", notYet);              // SongUtil.ParseTrack/RecycleOldInstrument
         }
 
         [Fact]
@@ -638,9 +638,10 @@ namespace FEBuilderGBA.Core.Tests
                 //  per-entry EventScriptForm.ScanScript expansion.)
                 Assert.Contains("MonsterWMapProbabilityForm", notYet2b);
                 Assert.Contains("EventBattleTalkForm", notYet2b);
-                // (MapTileAnimation1Form is now PORTED in slice 2g — its still-deferred map sibling
-                //  MapTerrainFloorLookupTableForm [PatchUtil GetPointers] stays tracked here instead.)
-                Assert.Contains("MapTerrainFloorLookupTableForm", notYet2b);
+                // (MapTileAnimation1Form is now PORTED in slice 2g and the MapTerrain lookup tables in
+                //  slice 2j — the still-deferred misc sibling SongTableForm [SongUtil.ParseTrack /
+                //  RecycleOldInstrument not in Core] stays tracked here instead.)
+                Assert.Contains("SongTableForm", notYet2b);
 
                 // FAITHFULNESS / COMPLETENESS-SAFETY: ItemForm is NOT emitted (its StatBooster
                 // sub-block size needs un-ported PatchUtil detection) — it must be absent from the
@@ -1708,8 +1709,9 @@ namespace FEBuilderGBA.Core.Tests
                 //  ItemShopForm + MapChangeForm + MapExitPointForm ported in slice 2g -> no longer kept.
                 //  SupportUnitForm + WorldMapPathForm + EDStaffRollForm + OPPrologueForm + OPClassFontForm
                 //  ported in slice 2h -> no longer kept here. OPClassDemoForm + OPClassDemoFE7Form ported
-                //  in slice 2i -> no longer kept here.)
-                "ItemForm", "MapTerrainFloorLookupTableForm",
+                //  in slice 2i -> no longer kept here. MapTerrain{BG,Floor}LookupTableForm + MapPointerForm
+                //  + ExtraUnitForm + ExtraUnitFE8UForm ported in slice 2j -> no longer kept here.)
+                "ItemForm", "SongTableForm",
             })
             {
                 Assert.Contains(kept, notYet);
@@ -3880,10 +3882,14 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("MapTileAnimation1Form", ported);
             Assert.DoesNotContain("MapTileAnimation2Form", ported);
 
+            // (MapPointerForm + MapTerrain{Floor,BG}LookupTableForm were deferred map siblings here, but
+            //  are now PORTED in slice 2j — their blocking Core helpers (MapPListResolverCore /
+            //  MapTerrainLookupCore + the PatchDetection gates) landed for the Avalonia gap-sweep. See
+            //  GetNotYetPortedForms_DropsSlice2jCoveredForms_KeepsDeferredSiblings.)
+            Assert.DoesNotContain("MapPointerForm", ported);
+            Assert.DoesNotContain("MapTerrainFloorLookupTableForm", ported);
+            Assert.DoesNotContain("MapTerrainBGLookupTableForm", ported);
             // deferred map siblings STAY (their blocking subsystem is not in Core):
-            Assert.Contains("MapPointerForm", ported);                 // palette2 via PatchUtil patch detect
-            Assert.Contains("MapTerrainFloorLookupTableForm", ported); // PatchUtil GetPointersExtendsPatch
-            Assert.Contains("MapTerrainBGLookupTableForm", ported);    // PatchUtil GetPointersExtendsPatch
             Assert.Contains("MapSettingForm", ported);                 // IsMapSettingEnd + CString
             Assert.Contains("ItemForm", ported);                       // StatBooster size via PatchUtil
 
@@ -4754,6 +4760,454 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Contains("MonsterWMapProbabilityForm", ported); // ScanScript skirmish events
             Assert.Contains("ImageCGFE7UForm", ported);          // LZ77 CG (FE7U)
             Assert.Contains("FE8SpellMenuExtendsForm", ported);  // FindFE8SpellPatchPointer
+
+            // the no-duplicates invariant still holds after the edits.
+            string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
+            Assert.Equal(raw.Length, raw.Distinct().Count());
+        }
+
+        // ====================================================================
+        // slice 2j — misc self-contained stragglers (MapTerrain lookup tables,
+        // MapPointer, ExtraUnit FE8J/FE8U + the shared RecycleOldUnits walk).
+        // ====================================================================
+
+        // ---- EmitMapTerrainLookupAt (one flat block-1 IFR per non-zero pointer) ----
+
+        [Fact]
+        public void EmitMapTerrainLookupAt_OneIfrPerNonZeroPointer_NameCarriesIndex_FixedCount()
+        {
+            // map_terrain_type_count drives the FixedCount walk (block 1). Two non-zero pointer slots
+            // (index 0 and 2) plus a zero slot (index 1, skipped) -> 2 IFR Addresses, names ...00 / ...02.
+            var fe8 = MakeVersionedRom("BE8E01");
+            var savedRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = fe8;
+                uint count = fe8.RomInfo.map_terrain_type_count; // 65 on FE8U.
+
+                uint slot0 = 0x100000, slot2 = 0x100100;
+                uint table0 = 0x101000, table2 = 0x102000;
+                fe8.write_u32(slot0, Ptr(table0));
+                fe8.write_u32(slot2, Ptr(table2));
+                uint[] pointers = { slot0, 0u, slot2 };
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitMapTerrainLookupAt(fe8, list, pointers, isFloor: false);
+
+                Assert.Equal(2, list.Count);
+                Address a0 = list.Single(a => a.Info == "MapTerrainBGLookupTable" + U.ToHexString(0));
+                Assert.Equal(table0, a0.Addr);
+                Assert.Equal(slot0, a0.Pointer);
+                Assert.Equal(1u, a0.BlockSize);
+                Assert.Equal(1u * (count + 1), a0.Length); // block 1 * (FixedCount + 1)
+                Assert.Equal(Address.DataTypeEnum.InputFormRef, a0.DataType);
+                Assert.Empty(a0.PointerIndexes);
+
+                Address a2 = list.Single(a => a.Info == "MapTerrainBGLookupTable" + U.ToHexString(2));
+                Assert.Equal(table2, a2.Addr);
+                Assert.Equal(slot2, a2.Pointer);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitMapTerrainLookupAt_FloorUsesFloorName_AndSkipsZeroAndUnsafe()
+        {
+            var fe8 = MakeVersionedRom("BE8E01");
+            var savedRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = fe8;
+                uint slot = 0x100000;
+                fe8.write_u32(slot, Ptr(0x101000));
+                // index 0 = a slot whose target is BELOW 0x200 (unsafe) -> skipped; index 1 = valid.
+                uint badSlot = 0x100200;
+                fe8.write_u32(badSlot, Ptr(0x100)); // target < 0x200 -> isSafetyOffset false
+                uint[] pointers = { badSlot, slot };
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitMapTerrainLookupAt(fe8, list, pointers, isFloor: true);
+
+                Address a = Assert.Single(list);
+                Assert.Equal("MapTerrainFloorLookupTable" + U.ToHexString(1), a.Info);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitMapTerrainLookupAt_NullArray_EmitsNothing()
+        {
+            var fe8 = MakeVersionedRom("BE8E01");
+            var savedRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = fe8;
+                var list = new List<Address>();
+                RebuildProducerCore.EmitMapTerrainLookupAt(fe8, list, null, isFloor: false);
+                Assert.Empty(list);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitMapTerrainLookupAt_PointerSlotNearEof_DoesNotThrow()
+        {
+            // A pointer slot at EOF-3 would make p32 read past the end; the slot+3 guard must skip it.
+            var fe8 = MakeVersionedRom("BE8E01");
+            var savedRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = fe8;
+                uint nearEof = (uint)fe8.Data.Length - 2; // slot+3 > Length
+                var list = new List<Address>();
+                var ex = Record.Exception(() =>
+                    RebuildProducerCore.EmitMapTerrainLookupAt(fe8, list, new uint[] { nearEof }, isFloor: false));
+                Assert.Null(ex);
+                Assert.Empty(list);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        // ---- EmitMapPointer (the 6 MAPPOINTERS IFR tables) -----------------
+
+        [Fact]
+        public void EmitMapPointer_EmitsSixMappointersTables_Block4_PI0_VanillaLimit()
+        {
+            // Plant all 6 FE8U map-pointer slots pointing at ONE shared base (vanilla, NOT split) so
+            // IsPlistSplits()==false -> limit = map_map_pointer_list_default_size (0xEC). Each table's
+            // IsDataExists is index-only (i==0||i<limit), so DataCount == limit and length == 4*(limit+1).
+            // No map settings exist -> the per-map sweep adds nothing; only the 6 main tables are emitted.
+            var fe8 = MakeVersionedRom("BE8E01");
+            var savedRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = fe8;
+                uint sharedBase = 0x200000;
+                uint[] slots =
+                {
+                    fe8.RomInfo.map_config_pointer, fe8.RomInfo.map_tileanime1_pointer,
+                    fe8.RomInfo.map_obj_pointer, fe8.RomInfo.map_map_pointer_pointer,
+                    fe8.RomInfo.map_event_pointer, fe8.RomInfo.map_mapchange_pointer,
+                };
+                foreach (uint s in slots) fe8.write_u32(U.toOffset(s), Ptr(sharedBase));
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitMapPointer(fe8, list);
+
+                uint limit = fe8.RomInfo.map_map_pointer_list_default_size; // 0xEC, since not split.
+                uint expectedLen = 4 * (limit + 1);
+                foreach (string name in new[]
+                {
+                    "MAPPOINTERS", "MAPPOINTERS_ANIMATION", "MAPPOINTERS_OBJECT",
+                    "MAPPOINTERS_MAP", "MAPPOINTERS_EVENT", "MAPPOINTERS_CHANGE",
+                })
+                {
+                    Address a = Assert.Single(list, x => x.Info == name);
+                    Assert.Equal(sharedBase, a.Addr);
+                    Assert.Equal(4u, a.BlockSize);
+                    Assert.Equal(expectedLen, a.Length);
+                    Assert.Equal(Address.DataTypeEnum.InputFormRef, a.DataType);
+                    Assert.Equal(new uint[] { 0 }, a.PointerIndexes);
+                }
+                // FE8 (version 8) has NO MAPPOINTERS_WMAP_EVENT (that alias is FE6-only).
+                Assert.DoesNotContain(list, x => x.Info == "MAPPOINTERS_WMAP_EVENT");
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitMapPointer_EmptyVersionedRom_EmitsNothing_DoesNotThrow()
+        {
+            // All map-pointer slots are 0 in an all-zero ROM -> every table base resolves unsafe -> the
+            // emitter adds nothing and never throws (no NRE on RomInfo, no read past EOF).
+            var fe8 = MakeVersionedRom("BE8E01");
+            var savedRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = fe8;
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitMapPointer(fe8, list));
+                Assert.Null(ex);
+                Assert.Empty(list);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        // ---- EmitExtraUnitAt (FE8J: direct base, flag BINs, RecycleOldUnits) ----
+
+        [Fact]
+        public void EmitExtraUnitAt_FE8J_MainIfrNotFoundPointer_PerEntryUnitsAndFlags()
+        {
+            // FE8J: BaseAddress is a DIRECT address (ReInit), BasePointer 0 -> NOT_FOUND. block 4, rule
+            // isSafetyPointer(u32(addr)). 2 valid entries (each points to a script-pointer), then a NULL
+            // 3rd -> DataCount 2. Each entry expands via RecycleOldUnits; the flags are at the absolute
+            // FE8J locations (out of this synthetic data's range -> the flag AddAddress safely no-ops).
+            var fe8 = MakeVersionedRom("BE8J01"); // FE8J = multibyte
+            var savedRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = fe8;
+                uint block = fe8.RomInfo.eventunit_data_size; // 20 on FE8.
+
+                uint baseAddr = 0x300000;
+                // Each ExtraUnit entry's +0 field is the "script pointer" RecycleOldUnits reads. WF:
+                // script_addr = u32(script_pointer) IS the EventUnit IFR base (ReInitPointer -> BaseAddress
+                // = p32(field)). So the entry holds Ptr(unitList) directly; the unit ids live at unitList.
+                uint unitList0 = 0x311000, unitList1 = 0x321000;
+                fe8.write_u32(baseAddr + 0, Ptr(unitList0));
+                fe8.write_u32(baseAddr + 4, Ptr(unitList1));
+                // entry 2 = NULL -> isSafetyPointer(0) false -> terminates (DataCount 2).
+                fe8.write_u8(unitList0 + 0, 0x10); // unit id != 0 -> 1 entry, then 0 terminator at +block.
+                fe8.write_u8(unitList1 + 0, 0x11);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitExtraUnitAt(fe8, list, baseAddr);
+
+                // Main IFR: addr = baseAddr, pointer = NOT_FOUND, block 4, length 4*(2+1)=12, PI {}.
+                Address main = Assert.Single(list, a => a.Info == "ExtraUnit");
+                Assert.Equal(baseAddr, main.Addr);
+                Assert.Equal(U.NOT_FOUND, main.Pointer);
+                Assert.Equal(4u, main.BlockSize);
+                Assert.Equal(12u, main.Length);
+                Assert.Empty(main.PointerIndexes);
+
+                // Two RecycleOldUnits EVENT UNIT IFRs (one per entry), base = u32(entry+0), block 20. Each
+                // has 1 unit + a 0 terminator -> length block*2. pointer = the entry field (baseAddr+i*4).
+                var euList = list.Where(a => a.Info == "ExtraUnit EVENT UNIT").ToList();
+                Assert.Equal(2, euList.Count);
+                Assert.Contains(euList, a => a.Addr == unitList0 && a.BlockSize == block
+                    && a.Length == block * 2 && a.Pointer == baseAddr + 0);
+                Assert.Contains(euList, a => a.Addr == unitList1 && a.BlockSize == block
+                    && a.Pointer == baseAddr + 4);
+                // FE8 (v8) main EVENT UNIT IFR carries pointerIndexes {8}.
+                Assert.All(euList, a => Assert.Equal(new uint[] { 8 }, a.PointerIndexes));
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitExtraUnitAt_FE8J_UnsafeBase_EmitsNothing_AndNearEofDoesNotThrow()
+        {
+            var fe8 = MakeVersionedRom("BE8J01");
+            var savedRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = fe8;
+                var list = new List<Address>();
+                // base below 0x200 -> unsafe -> nothing.
+                RebuildProducerCore.EmitExtraUnitAt(fe8, list, 0x100);
+                Assert.Empty(list);
+
+                // base near EOF with an all-non-null run -> must not throw.
+                uint nearEof = (uint)fe8.Data.Length - 4;
+                var ex = Record.Exception(() => RebuildProducerCore.EmitExtraUnitAt(fe8, list, nearEof));
+                Assert.Null(ex);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        // ---- EmitExtraUnitFE8UAt (FE8U: pointer-slot base, block 8, +4 field) ----
+
+        [Fact]
+        public void EmitExtraUnitFE8UAt_FE8U_MainIfrSafePointer_PerEntryUnitsNoFlag()
+        {
+            // FE8U: BasePointer = the slot (safe), BaseAddress = p32(slot). block 8, rule
+            // isSafetyPointer(u32(addr+4)). 2 entries then a NULL +4 -> DataCount 2. Each expands via
+            // RecycleOldUnits(addr+4). NO flag block (the +0 field is in-table).
+            var fe8 = MakeVersionedRom("BE8E01"); // FE8U = non-multibyte
+            var savedRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = fe8;
+                uint block8 = 8;
+                uint euBlock = fe8.RomInfo.eventunit_data_size; // 20.
+
+                uint slot = 0x300000;
+                uint tableBase = 0x310000;
+                fe8.write_u32(slot, Ptr(tableBase));
+
+                // The +4 field of each 8-byte entry IS the RecycleOldUnits script pointer; u32(+4) is the
+                // EventUnit IFR base directly (ReInitPointer). So +4 holds Ptr(unitList); the +0 field is
+                // the in-table flag (unused by the producer). entry 2 +4 = NULL -> DataCount 2.
+                uint unitList0 = 0x321000, unitList1 = 0x331000;
+                fe8.write_u32(tableBase + 0 + 4, Ptr(unitList0));
+                fe8.write_u32(tableBase + 8 + 4, Ptr(unitList1));
+                fe8.write_u8(unitList0, 0x10);
+                fe8.write_u8(unitList1, 0x11);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitExtraUnitFE8UAt(fe8, list, slot);
+
+                // Main IFR: addr = tableBase, pointer = slot (safe), block 8, length 8*(2+1)=24, PI {}.
+                Address main = Assert.Single(list, a => a.Info == "ExtraUnit");
+                Assert.Equal(tableBase, main.Addr);
+                Assert.Equal(U.toOffset(slot), main.Pointer);
+                Assert.Equal(block8, main.BlockSize);
+                Assert.Equal(24u, main.Length);
+                Assert.Empty(main.PointerIndexes);
+
+                // Two EVENT UNIT IFRs, base = u32(entry+4), pointer = the +4 field, block 20.
+                var euList = list.Where(a => a.Info == "ExtraUnit EVENT UNIT").ToList();
+                Assert.Equal(2, euList.Count);
+                Assert.Contains(euList, a => a.Addr == unitList0 && a.BlockSize == euBlock
+                    && a.Pointer == tableBase + 0 + 4);
+                Assert.Contains(euList, a => a.Addr == unitList1 && a.BlockSize == euBlock
+                    && a.Pointer == tableBase + 8 + 4);
+
+                // No "ExtraUnit Flag" BIN for FE8U.
+                Assert.DoesNotContain(list, a => a.Info == "ExtraUnit Flag");
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitExtraUnitFE8UAt_FE8U_UnsafeSlot_EmitsNothing_AndNearEofDoesNotThrow()
+        {
+            var fe8 = MakeVersionedRom("BE8E01");
+            var savedRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = fe8;
+                var list = new List<Address>();
+                RebuildProducerCore.EmitExtraUnitFE8UAt(fe8, list, 0x100); // slot < 0x200 -> nothing.
+                Assert.Empty(list);
+
+                uint nearEof = (uint)fe8.Data.Length - 2; // slot+3 > Length -> skip.
+                var ex = Record.Exception(() => RebuildProducerCore.EmitExtraUnitFE8UAt(fe8, list, nearEof));
+                Assert.Null(ex);
+                Assert.Empty(list);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        // ---- EmitRecycleOldUnits (the EventUnit IFR + v8 COORD sub-blocks) ----
+
+        [Fact]
+        public void EmitRecycleOldUnits_FE8_EmitsIfrWithPI8_AndCoordBinPerEntryWithAfterCoords()
+        {
+            // v8: main IFR {8} + per entry with u8(addr+7)>0 a count*8 BIN at p32(addr+8).
+            var fe8 = MakeVersionedRom("BE8E01");
+            var savedRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = fe8;
+                uint block = fe8.RomInfo.eventunit_data_size; // 20.
+
+                uint scriptPointer = 0x400000;
+                uint unitBase = 0x410000;
+                fe8.write_u32(scriptPointer, Ptr(unitBase));
+
+                // entry 0: unit id != 0 (counted); u8(+7) = 3 after-coords -> p32(+8) -> 3*8=24 BIN.
+                uint coords0 = 0x420000;
+                fe8.write_u8(unitBase + 0, 0x10);
+                fe8.write_u8(unitBase + 7, 3);
+                fe8.write_u32(unitBase + 8, Ptr(coords0));
+                // entry 1: unit id != 0; u8(+7) = 0 -> NO coord block.
+                fe8.write_u8(unitBase + block + 0, 0x11);
+                fe8.write_u8(unitBase + block + 7, 0);
+                // entry 2: unit id == 0 -> terminator (DataCount 2).
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitRecycleOldUnits(fe8, list, "ExtraUnit", scriptPointer);
+
+                // Main EVENT UNIT IFR: addr = unitBase, pointer = scriptPointer, block 20, length 20*(2+1)=60, {8}.
+                Address main = Assert.Single(list, a => a.Info == "ExtraUnit EVENT UNIT");
+                Assert.Equal(unitBase, main.Addr);
+                Assert.Equal(U.toOffset(scriptPointer), main.Pointer);
+                Assert.Equal(block, main.BlockSize);
+                Assert.Equal(block * 3, main.Length);
+                Assert.Equal(new uint[] { 8 }, main.PointerIndexes);
+
+                // One COORD BIN for entry 0 only (entry 1 had count 0).
+                Address coord = Assert.Single(list, a => a.Info == "ExtraUnit EVENT UNIT COORD 0");
+                Assert.Equal(coords0, coord.Addr);
+                Assert.Equal(24u, coord.Length); // 3 * 8
+                Assert.Equal(unitBase + 8, coord.Pointer);
+                Assert.Equal(Address.DataTypeEnum.BIN, coord.DataType);
+                Assert.DoesNotContain(list, a => a.Info == "ExtraUnit EVENT UNIT COORD 1");
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitRecycleOldUnits_FE7_EmitsSingleIfrWithEmptyPI_NoCoordBlocks()
+        {
+            // v<=7: a single EVENT UNIT IFR with EMPTY pointerIndexes and NO per-entry COORD blocks.
+            var fe7 = MakeVersionedRom("AE7E01"); // FE7U (version 7)
+            var savedRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = fe7;
+                Assert.True(fe7.RomInfo.version <= 7);
+                uint block = fe7.RomInfo.eventunit_data_size; // 16 on FE7.
+
+                uint scriptPointer = 0x400000;
+                uint unitBase = 0x410000;
+                fe7.write_u32(scriptPointer, Ptr(unitBase));
+                fe7.write_u8(unitBase + 0, 0x10);          // entry 0 counted
+                // entry 1 = 0 -> terminator (DataCount 1).
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitRecycleOldUnits(fe7, list, "ExtraUnit", scriptPointer);
+
+                Address main = Assert.Single(list); // ONLY the main IFR (no COORD walk on v<=7).
+                Assert.Equal("ExtraUnit EVENT UNIT", main.Info);
+                Assert.Equal(unitBase, main.Addr);
+                Assert.Equal(block, main.BlockSize);
+                Assert.Equal(block * 2, main.Length); // 1 entry + terminator
+                Assert.Empty(main.PointerIndexes);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitRecycleOldUnits_NullOrUnsafeScriptPointer_EmitsNothing_AndNearEofDoesNotThrow()
+        {
+            var fe8 = MakeVersionedRom("BE8E01");
+            var savedRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = fe8;
+                var list = new List<Address>();
+
+                // script pointer field holds 0 (not a pointer) -> nothing.
+                uint scriptPointer = 0x400000;
+                fe8.write_u32(scriptPointer, 0);
+                RebuildProducerCore.EmitRecycleOldUnits(fe8, list, "ExtraUnit", scriptPointer);
+                Assert.Empty(list);
+
+                // unit base near EOF with an all-non-zero run -> must not throw.
+                uint scriptPointer2 = 0x400100;
+                uint nearEof = (uint)fe8.Data.Length - 4;
+                fe8.write_u32(scriptPointer2, Ptr(nearEof));
+                for (uint i = nearEof; i < (uint)fe8.Data.Length; i++) fe8.write_u8(i, 0x10);
+                var ex = Record.Exception(() =>
+                    RebuildProducerCore.EmitRecycleOldUnits(fe8, list, "ExtraUnit", scriptPointer2));
+                Assert.Null(ex);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        // ---- NotYetPorted coverage delta for slice 2j ----------------------
+
+        [Fact]
+        public void GetNotYetPortedForms_DropsSlice2jCoveredForms_KeepsDeferredSiblings()
+        {
+            string[] ported = RebuildProducerCore.GetNotYetPortedForms();
+
+            // slice 2j ported these 5 (or 4 forms; ExtraUnit is a FE8J/FE8U split) — no longer deferred:
+            Assert.DoesNotContain("MapTerrainFloorLookupTableForm", ported);
+            Assert.DoesNotContain("MapTerrainBGLookupTableForm", ported);
+            Assert.DoesNotContain("MapPointerForm", ported);
+            Assert.DoesNotContain("ExtraUnitForm", ported);
+            Assert.DoesNotContain("ExtraUnitFE8UForm", ported);
+
+            // Still deferred (real missing-Core blocker) -> must REMAIN:
+            Assert.Contains("SongTableForm", ported);                   // SongUtil.ParseTrack/RecycleOldInstrument
+            Assert.Contains("EventUnitForm(RecycleReserveUnits)", ported); // NewAllocData = editor session state
+            Assert.Contains("SoundRoomForm", ported);                   // FE7 CString sub-walk + MIX type
+            Assert.Contains("ItemForm", ported);                        // StatBooster size via PatchUtil
+            Assert.Contains("MapSettingForm", ported);                  // IsMapSettingEnd text-count cache
 
             // the no-duplicates invariant still holds after the edits.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -541,6 +541,37 @@ namespace FEBuilderGBA
             progress?.Report("MapTileAnimation2");
             EmitMapTileAnimation2(rom, list);
 
+            // ---- slice 2j: MapTerrain Floor/BG lookup tables + MapPointer (version-agnostic) ----
+            // All three are called in the WF unconditional section. None is a flat StructDescriptor walk:
+            // the MapTerrain forms loop a per-form pointer array (MapTerrainLookupCore.GetPointers — the
+            // vanilla 21-slot RomInfo list OR the extends-patch table) emitting one flat IFR per non-zero
+            // pointer with the index baked into the name; MapPointer emits 6-7 MAPPOINTERS IFR tables plus a
+            // per-map PLIST sweep (MapPListResolverCore.GetMapPListsWhereAddr). Each gets a dedicated walker
+            // with its own cancel-check, mirroring the WF DoEvents posture. WF order: Floor THEN BG.
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("MapTerrainFloorLookupTable");
+            EmitMapTerrainLookup(rom, list, isFloor: true);
+
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("MapTerrainBGLookupTable");
+            EmitMapTerrainLookup(rom, list, isFloor: false);
+
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("MapPointer");
+            EmitMapPointer(rom, list);
+
             // ---- slice 2h: SupportUnit (all versions) + WorldMapPath (FE8-only) ----
             // SupportUnitForm is called in the WF version==8 AND version==7 branches (block 24); the
             // SupportUnitFE6Form variant in version==6 (block 32). EmitSupportUnit auto-selects the
@@ -580,6 +611,35 @@ namespace FEBuilderGBA
                     }
                     progress?.Report("OPClassDemo");
                     EmitOPClassDemo(rom, list);
+                }
+
+                // ---- slice 2j: ExtraUnit (FE8-only; multibyte/non-multibyte split) ----
+                // WF calls ExtraUnitForm (FE8J) inside `version==8 && is_multibyte` and ExtraUnitFE8UForm
+                // (FE8U) inside `version==8 && !is_multibyte` — a version/multibyte split (the FE8J path is
+                // an if-chain at hardcoded 0x37EE4 / flags @ i*0x14+0x37E10; the FE8U path is a table at
+                // 0x37D88, block 8). Both expand each entry via EventUnitForm.RecycleOldUnits (reproduced
+                // by EmitRecycleOldUnits — the EventUnit IFR + the FE8 per-entry COORD sub-blocks). Gate
+                // EXACTLY as WF: a wrong-shape port on the wrong FE8 variant corrupts (cf. the #1274 FE6
+                // bug). is_multibyte == FE8J, !is_multibyte == FE8U.
+                if (rom.RomInfo.is_multibyte)
+                {
+                    if (ct.IsCancellationRequested)
+                    {
+                        progress?.Report("MakeAllStructPointersList cancelled");
+                        return new ProducerResult(list, notYet, cancelled: true);
+                    }
+                    progress?.Report("ExtraUnit");
+                    EmitExtraUnit(rom, list);
+                }
+                else
+                {
+                    if (ct.IsCancellationRequested)
+                    {
+                        progress?.Report("MakeAllStructPointersList cancelled");
+                        return new ProducerResult(list, notYet, cancelled: true);
+                    }
+                    progress?.Report("ExtraUnitFE8U");
+                    EmitExtraUnitFE8U(rom, list);
                 }
             }
 
@@ -2493,6 +2553,456 @@ namespace FEBuilderGBA
             }
         }
 
+        // ====================================================================
+        // slice 2j — misc self-contained stragglers (MapTerrain lookup tables,
+        // MapPointer, ExtraUnit FE8J/FE8U). Each was DEFERRED on a "helper not in
+        // Core" claim that is now STALE — MapTerrainLookupCore.GetPointers,
+        // MapPListResolverCore.GetMapPListsWhereAddr (+ its PatchDetection gate),
+        // and MapSettingCore.MakeMapIDList were all added for the Avalonia
+        // gap-sweep (#441/#442) and are pure ROM-reads. ExtraUnit's only blocker
+        // (EventUnitForm.RecycleOldUnits) is reproduced verbatim by
+        // EmitRecycleOldUnits below (a pure EventUnit-IFR + FE8 COORD walk).
+        // ====================================================================
+
+        /// <summary>
+        /// <c>MapTerrain{BG,Floor}LookupTableForm.MakeAllDataLength</c> (slice 2j, version-agnostic).
+        /// Both forms share the identical shape — only the pointer SET differs (BG vs Floor) — so one
+        /// emitter covers both via <paramref name="isFloor"/>. WF: <c>pointers = GetPointers()</c> (the
+        /// vanilla 21-slot RomInfo list, or the extends-patch 8-byte-stride table when the ExtendsBattleBG
+        /// patch is installed — reproduced VERBATIM by <see cref="MapTerrainLookupCore.GetPointers"/>),
+        /// then for each non-zero pointer <c>InputFormRef.ReInitPointer(pointers[i])</c> +
+        /// <c>AddAddress(IFR, name + ToHexString(i), {})</c>. The IFR is block 1, IsDataExists
+        /// <c>i &lt; map_terrain_type_count</c> (a FixedCount walk), pointerIndexes EMPTY. The index is
+        /// baked into the per-pointer name (so this is a dedicated emitter, not a flat
+        /// <see cref="StructDescriptor.PointerFields"/> descriptor whose name is shared).
+        /// </summary>
+        public static void EmitMapTerrainLookup(ROM rom, List<Address> list, bool isFloor)
+        {
+            EmitMapTerrainLookupAt(rom, list, MapTerrainLookupCore.GetPointers(rom, isFloor), isFloor);
+        }
+
+        /// <summary>MapTerrain lookup emission from an explicit pointer array (test seam — lets a
+        /// synthetic ROM supply the pointer set directly without populating the 21 RomInfo slots / the
+        /// extends-patch table). See <see cref="EmitMapTerrainLookup"/> for the verbatim WF
+        /// reproduction. <paramref name="pointers"/> is the WF <c>GetPointers()</c> array; each non-zero
+        /// element is a 4-byte pointer SLOT whose <c>p32</c> is the lookup-table base.</summary>
+        public static void EmitMapTerrainLookupAt(ROM rom, List<Address> list, uint[] pointers, bool isFloor)
+        {
+            const uint block = 1; // MapTerrain{BG,Floor}LookupTableForm.Init BlockSize.
+            // WF Init IsDataExists = i < map_terrain_type_count (a FixedCount walk; BOTH the BG and the
+            // Floor form use map_terrain_type_count — there is no separate floor count field).
+            uint count = rom.RomInfo.map_terrain_type_count;
+            string baseName = isFloor ? "MapTerrainFloorLookupTable" : "MapTerrainBGLookupTable";
+
+            if (pointers == null)
+            {
+                return;
+            }
+            for (int i = 0; i < pointers.Length; i++)
+            {
+                uint pointerRaw = pointers[i];
+                if (pointerRaw == 0)
+                {
+                    continue; // WF: pointers[i] == 0 -> continue.
+                }
+                // WF InputFormRef.ReInitPointer(pointers[i]): BasePointer = pointers[i],
+                // BaseAddress = p32(pointers[i]). Guard the full 4-byte slot before p32 (slot+3) so a
+                // near-EOF pointer slot emits nothing instead of throwing.
+                uint pointer = U.toOffset(pointerRaw);
+                if (!U.isSafetyOffset(pointer + 3, rom))
+                {
+                    continue;
+                }
+                uint baseAddr = rom.p32(pointer);
+                if (!U.isSafetyOffset(baseAddr, rom))
+                {
+                    continue; // WF AddAddress early-returns when !isSafetyOffset(BaseAddress).
+                }
+
+                // IsDataExists = i < count (FixedCount); getBlockDataCount stops at addr+1 > Len (EOF) too.
+                uint dataCount = rom.getBlockDataCount(baseAddr, block, (j, addr) => j < count);
+                uint length = block * (dataCount + 1);
+                list.Add(new Address(baseAddr, length, pointer, baseName + U.ToHexString(i),
+                    Address.DataTypeEnum.InputFormRef, block, new uint[] { }));
+            }
+        }
+
+        /// <summary>
+        /// <c>MapPointerForm.MakeAllDataLength</c> (slice 2j, version-agnostic). Emits the 6-7
+        /// MAPPOINTERS PLIST-table IFRs (CONFIG / ANIMATION / OBJECT / MAP / EVENT / CHANGE, plus a FE6
+        /// WMAP_EVENT alias) and then a per-map sweep that resolves each map's PLIST columns
+        /// (<see cref="MapPListResolverCore.GetMapPListsWhereAddr"/>) and adds the pointed-at map-chipset
+        /// LZ77 / MAR / palette / OBJECT blocks. Reproduced VERBATIM:
+        /// <list type="bullet">
+        ///   <item>each PLIST table is a block-4 IFR, IsDataExists <c>i==0 ? true : i &lt; limit</c> where
+        ///   <c>limit = IsPlistSplits() ? 256 : map_map_pointer_list_default_size</c>, pointerIndexes
+        ///   {0}; the base pointers come from <see cref="MapPListResolverCore"/>'s RomInfo slots;</item>
+        ///   <item>the per-map columns index into the CONFIG / MAP / OBJECT tables by PLIST id (the WF
+        ///   <c>configList[plist].addr == configBase + plist*4</c>), each adding an LZ77 (config / MAR /
+        ///   obj-low / obj-high) or fixed-PAL (palette / palette2) block behind the indexed slot.</item>
+        /// </list>
+        /// The deferral claim ("palette2 gated on SearchFlag0x28ToMapSecondPalettePatch — not in Core")
+        /// is STALE: that gate now lives inside <see cref="MapPListResolverCore.GetMapPListsWhereAddr"/>.
+        /// The producer always scans real lengths, so the LZ77 columns pass <c>isPointerOnly: false</c>.
+        /// </summary>
+        public static void EmitMapPointer(ROM rom, List<Address> list)
+        {
+            // IsPlistSplits(): the PLIST tables are split iff CONFIG's base differs from every other
+            // table's base. Pure RomInfo p32 reads (no PatchUtil) — reproduced from MapPointerForm.
+            bool isSplit = IsPlistSplits(rom);
+            // limit = split ? 256 : map_map_pointer_list_default_size (the WF Init local).
+            uint limit = isSplit ? 256u : rom.RomInfo.map_map_pointer_list_default_size;
+
+            // The base POINTER SLOTS (RomInfo fields), reproducing MapPointerForm.GetBasePointer.
+            uint configPtr = rom.RomInfo.map_config_pointer;
+            uint animePtr  = rom.RomInfo.map_tileanime1_pointer;
+            uint objPtr    = rom.RomInfo.map_obj_pointer;
+            uint mapPtr    = rom.RomInfo.map_map_pointer_pointer;
+            uint eventPtr  = rom.RomInfo.map_event_pointer;
+            uint changePtr = rom.RomInfo.map_mapchange_pointer;
+
+            // The 6 (FE6: 7) main MAPPOINTERS IFR tables. WF emits AddAddress(IFR, name, {0}) for each.
+            // configBase/mapBase/objBase are the resolved table bases we also index into per-map below.
+            uint configBase = EmitMapPointerTable(rom, list, configPtr, limit, "MAPPOINTERS");
+            EmitMapPointerTable(rom, list, animePtr, limit, "MAPPOINTERS_ANIMATION"); // ANIMATION2 shares.
+            uint objBase = EmitMapPointerTable(rom, list, objPtr, limit, "MAPPOINTERS_OBJECT"); // PAL shares.
+            uint mapBase = EmitMapPointerTable(rom, list, mapPtr, limit, "MAPPOINTERS_MAP");
+            EmitMapPointerTable(rom, list, eventPtr, limit, "MAPPOINTERS_EVENT");
+            EmitMapPointerTable(rom, list, changePtr, limit, "MAPPOINTERS_CHANGE");
+            if (rom.RomInfo.version == 6)
+            {
+                // WF FE6: a second alias over the CHANGE base ("MAPPOINTERS_WMAP_EVENT").
+                EmitMapPointerTable(rom, list, changePtr, limit, "MAPPOINTERS_WMAP_EVENT");
+            }
+
+            // The per-map column counts: WF indexes configList[plist] (plist < configList.Count). The IFR
+            // DataCount bounds that list, so compute each table's DataCount and require plist < count.
+            uint configCount = MapPointerTableDataCount(rom, configBase, limit);
+            uint objCount     = MapPointerTableDataCount(rom, objBase, limit);
+            uint mapCount     = MapPointerTableDataCount(rom, mapBase, limit);
+
+            // WF: 0x20 * MapStyleEditorForm.MAX_MAP_PALETTE_COUNT. MAX_MAP_PALETTE_COUNT is a WinForms UI
+            // constant (PARTS_MAP_PALETTE_COUNT=5 * 2 = 10), NOT a RomInfo field — reproduce the literal.
+            const uint MAX_MAP_PALETTE_COUNT = 10;
+            const uint palSize = 0x20 * MAX_MAP_PALETTE_COUNT;
+
+            foreach (AddrResult map in MapSettingCore.MakeMapIDList(rom))
+            {
+                MapPListResolverCore.PLists plists =
+                    MapPListResolverCore.GetMapPListsWhereAddr(rom, map.addr);
+                uint mapid = map.tag;
+
+                // config_plist -> LZ77MAPCONFIG behind configList[config_plist].addr (= configBase + plist*4).
+                if (plists.config_plist > 0 && plists.config_plist < configCount)
+                {
+                    uint pointer = configBase + plists.config_plist * 4;
+                    Address.AddLZ77Pointer(list, pointer + 0,
+                        "MAP:" + U.To0xHexString(mapid) + " MAP_CHIPSET" + U.ToHexString(plists.config_plist),
+                        false, Address.DataTypeEnum.LZ77MAPCONFIG);
+                }
+                // mappointer_plist -> LZ77MAPMAR behind mapList[mappointer_plist].addr.
+                if (plists.mappointer_plist > 0 && plists.mappointer_plist < mapCount)
+                {
+                    uint pointer = mapBase + plists.mappointer_plist * 4;
+                    Address.AddLZ77Pointer(list, pointer + 0,
+                        "MAP:" + U.To0xHexString(mapid) + " MAP MAR:" + U.ToHexString(plists.mappointer_plist),
+                        false, Address.DataTypeEnum.LZ77MAPMAR);
+                }
+                // palette_plist -> fixed PAL behind objList[palette_plist].addr (OBJECT and PAL share base).
+                if (plists.palette_plist > 0 && plists.palette_plist < objCount)
+                {
+                    uint pointer = objBase + plists.palette_plist * 4;
+                    Address.AddPointer(list, pointer + 0, palSize,
+                        "MAP:" + U.ToHexString(mapid) + " PALETTE:" + U.ToHexString(plists.palette_plist),
+                        Address.DataTypeEnum.PAL);
+                }
+                // palette2_plist -> fixed PAL (second palette; the value is 0 unless the patch is installed,
+                // gated inside GetMapPListsWhereAddr).
+                if (plists.palette2_plist > 0 && plists.palette2_plist < objCount)
+                {
+                    uint pointer = objBase + plists.palette2_plist * 4;
+                    Address.AddPointer(list, pointer + 0, palSize,
+                        "MAP:" + U.ToHexString(mapid) + " SECOND PALETTE:" + U.ToHexString(plists.palette2_plist),
+                        Address.DataTypeEnum.PAL);
+                }
+                // obj_plist (a packed u16): low and high bytes each -> LZ77IMG behind objList[byte].addr.
+                uint objLow = plists.obj_plist & 0xFF;
+                uint objHigh = (plists.obj_plist >> 8) & 0xFF;
+                if (objLow > 0 && objLow < objCount)
+                {
+                    uint pointer = objBase + objLow * 4;
+                    Address.AddLZ77Pointer(list, pointer + 0,
+                        "MAP:" + U.ToHexString(mapid) + " OBJ:" + U.ToHexString(objLow),
+                        false, Address.DataTypeEnum.LZ77IMG);
+                }
+                if (objHigh > 0 && objHigh < objCount)
+                {
+                    uint pointer = objBase + objHigh * 4;
+                    Address.AddLZ77Pointer(list, pointer + 0,
+                        "MAP:" + U.ToHexString(mapid) + " OBJ:" + U.ToHexString(objHigh),
+                        false, Address.DataTypeEnum.LZ77IMG);
+                }
+            }
+        }
+
+        /// <summary>Emit one MAPPOINTERS PLIST-table IFR (block 4, IsDataExists
+        /// <c>i==0 ? true : i &lt; limit</c>, pointerIndexes {0}) for the RomInfo pointer slot
+        /// <paramref name="rawPointer"/>. Returns the resolved table BASE (<c>p32(slot)</c>) so the
+        /// caller can index per-map columns into it, or <see cref="U.NOT_FOUND"/> when the slot is
+        /// unsafe (the per-map index guards on that). Reproduces the WF
+        /// <c>InputFormRef.ReInitPointer(GetBasePointer(...)) + AddAddress(IFR, name, {0})</c>.</summary>
+        static uint EmitMapPointerTable(ROM rom, List<Address> list, uint rawPointer, uint limit, string name)
+        {
+            uint pointer = U.toOffset(rawPointer);
+            if (!U.isSafetyOffset(pointer + 3, rom))
+            {
+                return U.NOT_FOUND; // p32(slot) would read junk past EOF.
+            }
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                return U.NOT_FOUND; // WF AddAddress early-returns; nothing to index either.
+            }
+            uint dataCount = MapPointerDataCountAt(rom, baseAddr, limit);
+            uint length = 4 * (dataCount + 1);
+            list.Add(new Address(baseAddr, length, pointer, name,
+                Address.DataTypeEnum.InputFormRef, 4, new uint[] { 0 }));
+            return baseAddr;
+        }
+
+        /// <summary>The MapPointer IFR DataCount for a resolved table base, or 0 when the base is
+        /// unsafe/NOT_FOUND. IsDataExists = <c>i==0 ? true : i &lt; limit</c> (the WF Init rule).</summary>
+        static uint MapPointerTableDataCount(ROM rom, uint baseAddr, uint limit)
+        {
+            if (baseAddr == U.NOT_FOUND || !U.isSafetyOffset(baseAddr, rom))
+            {
+                return 0;
+            }
+            return MapPointerDataCountAt(rom, baseAddr, limit);
+        }
+
+        /// <summary>getBlockDataCount over the MapPointer IFR rule (block 4,
+        /// <c>i==0 ? true : i &lt; limit</c>). The callback reads nothing — it is a pure index walk —
+        /// so getBlockDataCount's only extra cutoff is addr+4 &gt; Len (EOF), which is harmless.</summary>
+        static uint MapPointerDataCountAt(ROM rom, uint baseAddr, uint limit)
+        {
+            return rom.getBlockDataCount(baseAddr, 4, (i, addr) => i == 0 || (uint)i < limit);
+        }
+
+        /// <summary>Reproduces <c>MapPointerForm.IsPlistSplits</c>: the PLIST tables are "split" iff the
+        /// CONFIG base differs from every other table's base (a vanilla ROM shares one base across all
+        /// PLIST types). Pure RomInfo <c>p32</c> reads — no PatchUtil dependency.</summary>
+        static bool IsPlistSplits(ROM rom)
+        {
+            uint a = rom.p32(rom.RomInfo.map_config_pointer);
+            if (a == rom.p32(rom.RomInfo.map_tileanime1_pointer)) return false;
+            if (a == rom.p32(rom.RomInfo.map_obj_pointer)) return false;
+            if (a == rom.p32(rom.RomInfo.map_map_pointer_pointer)) return false;
+            if (a == rom.p32(rom.RomInfo.map_mapchange_pointer)) return false;
+            if (a == rom.p32(rom.RomInfo.map_event_pointer)) return false;
+            if (rom.RomInfo.version == 6)
+            {
+                if (a == rom.p32(rom.RomInfo.map_worldmapevent_pointer)) return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// <c>ExtraUnitForm.MakeAllDataLength</c> (slice 2j; FE8J = <c>version==8 &amp;&amp; is_multibyte</c>
+        /// ONLY). The FE8J editor uses an if-chain at a HARDCODED base: <c>ifr.ReInit(0x37EE4)</c> (a
+        /// DIRECT address, NOT a pointer slot — so the IFR BasePointer stays 0 -&gt; NOT_FOUND), block 4,
+        /// IsDataExists <c>isSafetyPointer(u32(addr))</c>. WF: <c>AddAddress(IFR, "ExtraUnit", {})</c>
+        /// then per entry <c>RecycleOldUnits("ExtraUnit", addr + 0)</c> + a 1-byte BIN flag at
+        /// <c>i*0x14 + 0x37E10</c> (pointer NOT_FOUND, name "ExtraUnit Flag"). Reproduced VERBATIM.
+        /// </summary>
+        public static void EmitExtraUnit(ROM rom, List<Address> list)
+        {
+            EmitExtraUnitAt(rom, list, 0x37EE4);
+        }
+
+        /// <summary>ExtraUnit (FE8J) walk from an explicit table base (test seam — lets a synthetic ROM
+        /// supply the base directly without the hardcoded 0x37EE4). <paramref name="baseAddrRaw"/> is the
+        /// WF <c>ReInit</c> DIRECT base address (the unit-pointer entry table). The flag addresses are the
+        /// WF hardcoded <c>i*0x14 + 0x37E10</c> — those are absolute FE8J locations, so the test base is
+        /// only used to vary the entry table.</summary>
+        public static void EmitExtraUnitAt(ROM rom, List<Address> list, uint baseAddrRaw)
+        {
+            const uint block = 4;
+            const uint flagBase = 0x37E10; // WF GetFlagAddr(i) = i*0x14 + 0x37E10.
+            const uint flagStride = 0x14;
+
+            // WF ifr.ReInit(0x37EE4): BaseAddress = 0x37EE4 (DIRECT), BasePointer = 0 -> NOT_FOUND.
+            uint baseAddr = U.toOffset(baseAddrRaw);
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                return; // WF AddAddress early-returns when !isSafetyOffset(BaseAddress).
+            }
+            // IsDataExists = isSafetyPointer(u32(addr)). getBlockDataCount stops at addr+4 > Len too.
+            uint dataCount = rom.getBlockDataCount(baseAddr, block,
+                (i, addr) => U.isSafetyPointer(rom.u32(addr)));
+
+            // Main IFR: pointer = NOT_FOUND (BasePointer 0), pointerIndexes {}.
+            uint length = block * (dataCount + 1);
+            list.Add(new Address(baseAddr, length, U.NOT_FOUND, "ExtraUnit",
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { }));
+
+            for (uint i = 0; i < dataCount; i++)
+            {
+                uint addr = baseAddr + i * block;
+                // Guard the full 4-byte entry before RecycleOldUnits reads u32(addr) (addr+3).
+                if (!U.isSafetyOffset(addr + 3, rom))
+                {
+                    break;
+                }
+                EmitRecycleOldUnits(rom, list, "ExtraUnit", addr + 0);
+
+                // 1-byte BIN flag at the absolute FE8J location i*0x14 + 0x37E10 (pointer NOT_FOUND). WF
+                // calls Address.AddAddress directly (no pre-guard); the Core AddAddress safety-guards the
+                // addr internally and early-returns when out of range (e.g. a smaller synthetic ROM).
+                uint flagAddr = i * flagStride + flagBase;
+                Address.AddAddress(list, flagAddr, 1, U.NOT_FOUND, "ExtraUnit Flag",
+                    Address.DataTypeEnum.BIN);
+            }
+        }
+
+        /// <summary>
+        /// <c>ExtraUnitFE8UForm.MakeAllDataLength</c> (slice 2j; FE8U = <c>version==8 &amp;&amp;
+        /// !is_multibyte</c> ONLY). The FE8U editor is a TABLE at a HARDCODED pointer slot
+        /// <c>0x37D88</c> (constructed as the IFR BasePointer, so BaseAddress = <c>p32(0x37D88)</c>),
+        /// block 8, IsDataExists <c>isSafetyPointer(u32(addr+4))</c>. WF:
+        /// <c>AddAddress(IFR, "ExtraUnit", {})</c> then per entry
+        /// <c>RecycleOldUnits("ExtraUnit", addr + 4)</c> — NO flag block (the flag is the +0 field, an
+        /// in-table u32, not a separate region). Reproduced VERBATIM.
+        /// </summary>
+        public static void EmitExtraUnitFE8U(ROM rom, List<Address> list)
+        {
+            EmitExtraUnitFE8UAt(rom, list, 0x37D88);
+        }
+
+        /// <summary>ExtraUnit (FE8U) walk from an explicit pointer slot (test seam). See
+        /// <see cref="EmitExtraUnitFE8U"/> for the verbatim WF reproduction. <paramref name="rawPointer"/>
+        /// is the 4-byte pointer SLOT (WF BasePointer 0x37D88) whose <c>p32</c> is the table base.</summary>
+        public static void EmitExtraUnitFE8UAt(ROM rom, List<Address> list, uint rawPointer)
+        {
+            const uint block = 8;
+
+            // WF Init(basepointer=0x37D88): BasePointer = slot, BaseAddress = p32(slot). Guard slot+3.
+            uint pointer = U.toOffset(rawPointer);
+            if (!U.isSafetyOffset(pointer + 3, rom))
+            {
+                return;
+            }
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                return; // WF AddAddress early-returns.
+            }
+            // IsDataExists = isSafetyPointer(u32(addr+4)). getBlockDataCount only fires while addr+8<=Len,
+            // so the +4 read is always in bounds.
+            uint dataCount = rom.getBlockDataCount(baseAddr, block,
+                (i, addr) => U.isSafetyPointer(rom.u32(addr + 4)));
+
+            // Main IFR: pointer = BasePointer (0x37D88, safe here), pointerIndexes {}.
+            uint length = block * (dataCount + 1);
+            list.Add(new Address(baseAddr, length, pointer, "ExtraUnit",
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { }));
+
+            for (uint i = 0; i < dataCount; i++)
+            {
+                uint addr = baseAddr + i * block;
+                // Guard the full 8-byte entry before RecycleOldUnits reads u32(addr+4) (addr+7).
+                if (!U.isSafetyOffset(addr + 7, rom))
+                {
+                    break;
+                }
+                EmitRecycleOldUnits(rom, list, "ExtraUnit", addr + 4);
+            }
+        }
+
+        /// <summary>
+        /// Reproduces <c>EventUnitForm.RecycleOldUnits(ref list, basename, script_pointer)</c> +
+        /// <c>RecycleOldUnitsLow</c> (slice 2j). The WF helper recovers the EVENT-UNIT region behind an
+        /// embedded script pointer (the <c>script_pointer</c> field of an ExtraUnit entry): it
+        /// dereferences <c>script_addr = u32(script_pointer)</c> (a pointer; NULL/unsafe -&gt; emit
+        /// nothing), then walks an EventUnit IFR rooted at <paramref name="scriptPointer"/> — block
+        /// <c>eventunit_data_size</c>, IsDataExists <c>u8(addr) != 0</c>. VERBATIM per version:
+        /// <list type="bullet">
+        ///   <item><b>version &lt;= 7</b>: one IFR Address (<c>AddAddress(IFR, basename + " EVENT UNIT",
+        ///   {})</c>) — pointer = the script-pointer field, pointerIndexes EMPTY.</item>
+        ///   <item><b>version 8</b>: one IFR Address with pointerIndexes <c>{8}</c>, PLUS for each entry
+        ///   whose <c>u8(addr+7) &gt; 0</c> a <c>count*8</c>-byte BIN block at <c>p32(addr+8)</c> behind
+        ///   the <c>addr+8</c> field (the FE8 "after-coordinate" placement list), named
+        ///   <c>basename + " EVENT UNIT COORD " + i</c>.</item>
+        /// </list>
+        /// All reads are pure ROM reads (no Form / disasm / session state), so this is faithfully
+        /// headless. EOF-safe: the script-pointer field and every per-entry read are bounds-guarded.
+        /// </summary>
+        public static void EmitRecycleOldUnits(ROM rom, List<Address> list, string basename, uint scriptPointer)
+        {
+            // WF: script_addr = u32(script_pointer); if (!isPointer(script_addr)) return; toOffset;
+            // if (!isSafetyOffset(script_addr)) return. Guard the full 4-byte field (field+3) first.
+            uint field = U.toOffset(scriptPointer);
+            if (!U.isSafetyOffset(field + 3, rom))
+            {
+                return;
+            }
+            uint scriptAddrRaw = rom.u32(field);
+            if (!U.isPointer(scriptAddrRaw))
+            {
+                return;
+            }
+            uint scriptAddr = U.toOffset(scriptAddrRaw);
+            if (!U.isSafetyOffset(scriptAddr, rom))
+            {
+                return;
+            }
+
+            // WF InputFormRef.ReInitPointer(script_pointer): BasePointer = field, BaseAddress = scriptAddr.
+            // EventUnitForm.Init: block = eventunit_data_size, IsDataExists = u8(addr) != 0.
+            uint block = rom.RomInfo.eventunit_data_size;
+            if (block == 0)
+            {
+                return; // a zero block would spin getBlockDataCount; not real data.
+            }
+            uint dataCount = rom.getBlockDataCount(scriptAddr, block, (i, addr) => rom.u8(addr) != 0);
+            uint length = block * (dataCount + 1);
+
+            if (rom.RomInfo.version <= 7)
+            {
+                // v<=7: AddAddress(IFR, basename + " EVENT UNIT", {}) — pointer = field, indexes EMPTY.
+                list.Add(new Address(scriptAddr, length, field, basename + " EVENT UNIT",
+                    Address.DataTypeEnum.InputFormRef, block, new uint[] { }));
+                return;
+            }
+
+            // v8: AddAddress(IFR, basename + " EVENT UNIT", {8}) — pointerIndexes {8} (the +8 after-coord
+            // pointer field in each EventUnit record).
+            list.Add(new Address(scriptAddr, length, field, basename + " EVENT UNIT",
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { 8 }));
+
+            // v8 per-entry: for each entry with u8(addr+7) > 0 add a count*8 BIN at p32(addr+8).
+            for (uint i = 0; i < dataCount; i++)
+            {
+                uint addr = scriptAddr + i * block;
+                // Guard the full record's deepest read (p32(addr+8) -> addr+11) before any read so a
+                // corrupted DataCount near EOF skips instead of throwing.
+                if (addr + 12 > (uint)rom.Data.Length)
+                {
+                    break;
+                }
+                uint count = rom.u8(addr + 7);
+                if (count == 0)
+                {
+                    continue; // WF: count > 0 gate.
+                }
+                uint afterAddress = rom.p32(addr + 8);
+                // WF Address.AddAddress(after_address, count*8, addr+8, name, BIN). The Core AddAddress
+                // early-returns when !isSafetyOffset(after_address), matching WF's downstream behaviour.
+                Address.AddAddress(list, afterAddress, count * 8, addr + 8,
+                    basename + " EVENT UNIT COORD " + i, Address.DataTypeEnum.BIN);
+            }
+        }
+
         /// <summary>Turn a descriptor's <see cref="DataCountRule"/> into the
         /// <c>is_data_exists_callback</c> that <see cref="ROM.getBlockDataCount(uint,uint,Func{int,uint,bool})"/> expects.</summary>
         static Func<int, uint, bool> MakeIsDataExists(ROM rom, StructDescriptor d)
@@ -4001,7 +4511,13 @@ namespace FEBuilderGBA
                 //  and WorldMapBGMForm [FE8, clean] ported in this sweep. SoundFootStepsForm ported in
                 //  slice 2d — Switch2-gated dedicated walker (base/count from sound_foot_steps_switch2_address,
                 //  IsSwitch2Enable gate) + per-entry ASM AddFunction. SoundRoomForm STAYS — its FE7
-                //  path adds a per-entry getString C-string sub-walk + InputFormRef_MIX type.)
+                //  path adds a per-entry getString C-string sub-walk + InputFormRef_MIX type.
+                //  SongTableForm STAYS — although its main IFR (sound_table_pointer, block 8, rule
+                //  isPointer(u32(addr)), PI {0}) is trivial, each entry's LENGTH needs SongUtil.RecycleOldSong
+                //  (= SongUtil.ParseTrack, a music-track bytecode/FINE-address walk) + SongInstrumentForm.
+                //  RecycleOldInstrument (an instrument-tree walk) — NEITHER in Core (the Song*Core files are
+                //  MIDI import/export only). Porting just the main IFR would leave the song-score + instrument
+                //  data un-tracked -> dangling pointers on rebuild = corruption.)
                 "SongTableForm", "SoundRoomForm",
                 // embedded sub-pointer / event-scan / CString expansion
                 // (ClassForm + StatusParamForm ported in slice 2c — per-entry MoveCost / CString
@@ -4031,12 +4547,14 @@ namespace FEBuilderGBA
                 //  EmitMapChange [per map: MapChangeCore.GetMapChangeAddrWhereMapID -> main 12-byte IFR
                 //  {8} + per-entry w*h*2 BIN behind +8] and EmitMapExitPoint [enemy + NPC 4-byte slot
                 //  tables, each with a per-map N-table; NPC main via ButIgnorePointer].
-                //  MapPointerForm STAYS — out of the slice-2g per-map-PLIST scope: its MakeAllDataLength
-                //  emits 6+ MAPPOINTERS IFR tables AND a per-map sweep that reads palette2_plist via
-                //  MapSettingForm.GetMapPListsWhereAddr, gated on PatchUtil.SearchFlag0x28ToMapSecond-
-                //  PalettePatch (PatchUtil patch detection not in Core), so its column set can't be
-                //  reproduced verbatim yet.)
-                "MapPointerForm", "FontForm",
+                //  MapPointerForm ported in slice 2j (EmitMapPointer): the 6-7 MAPPOINTERS PLIST-table
+                //  IFRs (block 4, rule i==0||i<limit, limit = IsPlistSplits()?256:map_map_pointer_list_
+                //  default_size, PI {0}) + a per-map column sweep. Its only blocker was the palette2_plist
+                //  read, gated on PatchUtil.SearchFlag0x28ToMapSecondPalettePatch — that gate now lives in
+                //  Core (PatchDetection.SearchFlag0x28ToMapSecondPalettePatch) inside
+                //  MapPListResolverCore.GetMapPListsWhereAddr, and MapSettingCore.MakeMapIDList +
+                //  RomInfo-only GetBasePointer/IsPlistSplits complete the dependency set.)
+                "FontForm",
                 // AI scripts (disasm)
                 // (AIMapSettingForm [flat u8!=0xFF table], AIPerformStaffForm + AIPerformItemForm
                 //  [flat u16!=0 table + per-entry ASM AddFunction @4 via SubKind.AsmFunction] ported in
@@ -4063,19 +4581,28 @@ namespace FEBuilderGBA
                 //   the version PLIST-limit gate], emit the main 8-byte IFR [isPointer(u32+4)/{4} for anime1,
                 //   isPointer(u32+0)/{0} for anime2], then per-entry IMG [u16(p+2) @ p32(p+4)] / BIN
                 //   [u8(p+5)*2 @ p32(p+0)] columns.)
-                //  MapTerrainFloorLookupTableForm/MapTerrainBGLookupTableForm STAY — their pointer set comes
-                //  from GetPointersExtendsPatch (PatchUtil.SearchExtendsBattleBG + hardcoded FE8 offsets),
-                //  not in Core.)
-                "MapTerrainFloorLookupTableForm",
-                "MapTerrainBGLookupTableForm",
+                //  MapTerrainFloorLookupTableForm/MapTerrainBGLookupTableForm ported in slice 2j
+                //  (EmitMapTerrainLookup): one flat block-1 IFR (rule i<map_terrain_type_count) per
+                //  non-zero pointer, name + ToHexString(i). Their pointer set comes from
+                //  GetPointersExtendsPatch (PatchUtil.SearchExtendsBattleBG + hardcoded FE8 offsets) —
+                //  now in Core as MapTerrainLookupCore.GetPointers + PatchDetection.SearchExtendsBattleBG
+                //  (added for the Avalonia #441/#442 gap-sweep), so the pointer set IS reproducible.)
                 // units / classes per-version with extra reads
                 // (UnitForm [FE8, flat + 24-byte support BinFixed sub-walk @44] and UnitFE7Form
                 //  [FE7, flat, no sub-walk] ported in this sweep; SummonUnitForm + SummonsDemonKingForm
                 //  + EventForceSortieForm [FE8 clean tables] ported too. UnitFE6Form ported in slice 2f
                 //  via the dedicated EmitUnitFE6 walker — base p32(unit_pointer)+unit_datasize, BasePointer
                 //  0 -> NOT_FOUND, i < unit_maxcount, pointerIndexes {44}.)
+                // (ExtraUnitForm [FE8J] + ExtraUnitFE8UForm [FE8U] ported in slice 2j (EmitExtraUnit /
+                //  EmitExtraUnitFE8U — gated EXACTLY as WF: version==8 && is_multibyte = FE8J at hardcoded
+                //  0x37EE4 + flag BINs @ i*0x14+0x37E10; version==8 && !is_multibyte = FE8U table @ 0x37D88
+                //  block 8). Both expand each entry via EventUnitForm.RecycleOldUnits, reproduced verbatim
+                //  by EmitRecycleOldUnits (an EventUnit IFR + the v8 per-entry COORD BIN sub-blocks — pure
+                //  ROM reads, no Form/disasm). EventUnitForm.RecycleReserveUnits STAYS — it iterates the
+                //  static NewAllocData list, which is EDITOR SESSION STATE (newly-allocated unit regions
+                //  recorded during live editing), NOT a ROM-derived table; it is always empty headless, so
+                //  the producer emits nothing for it — kept listed so the coverage gate stays honest.)
                 "UnitCustomBattleAnimeForm",
-                "ExtraUnitForm", "ExtraUnitFE8UForm",
                 "EventUnitForm(RecycleReserveUnits)",
                 // monster / world map / ED / support (FE8/FE7/FE6 variants)
                 // (MonsterItemForm + MonsterProbabilityForm ported in slice 2b.

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -2794,17 +2794,34 @@ namespace FEBuilderGBA
         /// PLIST types). Pure RomInfo <c>p32</c> reads — no PatchUtil dependency.</summary>
         static bool IsPlistSplits(ROM rom)
         {
-            uint a = rom.p32(rom.RomInfo.map_config_pointer);
-            if (a == rom.p32(rom.RomInfo.map_tileanime1_pointer)) return false;
-            if (a == rom.p32(rom.RomInfo.map_obj_pointer)) return false;
-            if (a == rom.p32(rom.RomInfo.map_map_pointer_pointer)) return false;
-            if (a == rom.p32(rom.RomInfo.map_mapchange_pointer)) return false;
-            if (a == rom.p32(rom.RomInfo.map_event_pointer)) return false;
+            // EOF-harden (Copilot #1282): on synthetic/truncated ROMs a RomInfo PLIST slot can sit near
+            // EOF, where ROM.p32 -> u32 -> check_safety throws. On valid ROMs these header slots are
+            // always in-bounds, so guarding slot+3 before each p32 never changes the result; an unsafe
+            // slot is treated as "not equal to config" (the comparison simply does not fire). A missing
+            // config base -> not split (the conservative smaller limit).
+            uint cfg = rom.RomInfo.map_config_pointer;
+            if (!U.isSafetyOffset(cfg + 3, rom)) return false;
+            uint a = rom.p32(cfg);
+            if (PlistBaseEquals(rom, a, rom.RomInfo.map_tileanime1_pointer)) return false;
+            if (PlistBaseEquals(rom, a, rom.RomInfo.map_obj_pointer)) return false;
+            if (PlistBaseEquals(rom, a, rom.RomInfo.map_map_pointer_pointer)) return false;
+            if (PlistBaseEquals(rom, a, rom.RomInfo.map_mapchange_pointer)) return false;
+            if (PlistBaseEquals(rom, a, rom.RomInfo.map_event_pointer)) return false;
             if (rom.RomInfo.version == 6)
             {
-                if (a == rom.p32(rom.RomInfo.map_worldmapevent_pointer)) return false;
+                if (PlistBaseEquals(rom, a, rom.RomInfo.map_worldmapevent_pointer)) return false;
             }
             return true;
+        }
+
+        /// <summary>Guarded <c>a == p32(slot)</c> for <see cref="IsPlistSplits"/>: returns false (treat
+        /// as "not equal", i.e. keep checking) when the 4-byte slot is near EOF, so a synthetic/truncated
+        /// ROM never throws in <c>p32</c>. On valid ROMs the slot is always in-bounds, so the result is
+        /// identical to the verbatim WF comparison.</summary>
+        static bool PlistBaseEquals(ROM rom, uint a, uint slot)
+        {
+            if (!U.isSafetyOffset(slot + 3, rom)) return false;
+            return a == rom.p32(slot);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
**Slice 2j** of #1261 — the **misc self-contained straggler** forms. Notably, **3 of the candidate deferral comments were STALE** — the named "not in Core" helpers had already been ported during the Avalonia #441/#442 gap-sweep, so these forms became tractable.

## Ported (5 forms — dedicated emitters, VERBATIM vs WF `MakeAllDataLength`)
- **MapTerrainBGLookupTableForm** / **MapTerrainFloorLookupTableForm** [version-agnostic] via `EmitMapTerrainLookup`: one flat block-1 IFR (rule `i < map_terrain_type_count`) per non-zero pointer, name + `ToHexString(i)`. Pointer set from the now-in-Core `MapTerrainLookupCore.GetPointers` + `PatchDetection.SearchExtendsBattleBG`.
- **MapPointerForm** [version-agnostic] via `EmitMapPointer`: the 6–7 MAPPOINTERS PLIST IFR tables (block 4, rule `i==0 || i<limit`, PI `{0}`) + per-map column sweep (config/MAR/PAL/PAL2/obj-low/obj-high). The palette2 gate is now in Core (`PatchDetection.SearchFlag0x28ToMapSecondPalettePatch` inside `MapPListResolverCore.GetMapPListsWhereAddr`); `MapSettingCore.MakeMapIDList` + RomInfo-only `GetBasePointer`/`IsPlistSplits` complete the set.
- **ExtraUnitForm** [FE8J: `version==8 && is_multibyte`] / **ExtraUnitFE8UForm** [FE8U: `version==8 && !is_multibyte`] via `EmitExtraUnit`/`EmitExtraUnitFE8U`, gated EXACTLY as the WF call site. Both expand each entry via `EventUnitForm.RecycleOldUnits`, reproduced verbatim by `EmitRecycleOldUnits` (EventUnit IFR block=`eventunit_data_size`, rule `u8!=0`; **`version<=7`** emits one IFR `{}`, **`version 8`** emits `{8}` + a per-entry `count*8` COORD BIN behind `+8`, `count=u8(addr+7)`).

## Deferred (verified real missing-Core blocker — comments sharpened)
- **SongTableForm** — per-entry length needs `SongUtil.ParseTrack` (track bytecode / FINE walk) + `SongInstrumentForm.RecycleOldInstrument`; neither in Core.
- **EventUnitForm(RecycleReserveUnits)** — iterates the static `NewAllocData` list, an editor SESSION state (not a ROM table); always empty headless.

## Faithfulness notes (verified by the lead against WF)
- `EmitRecycleOldUnits` is line-for-line `RecycleOldUnitsLow` (the `version<=7` `{}` / `version 8` `{8}` + `count*8` BIN split confirmed).
- Version gating audited: ExtraUnit FE8J vs FE8U `is_multibyte` split at the WF call site; the terrain/MapPointer forms are version-agnostic.

## Tests
- RebuildProducer filter: **169 passed / 0 failed** (+14) — per-form addr/length/pointer/DataType/name; ExtraUnit FE8J/FE8U version-gate; RecycleOldUnits v≤7 vs v8 split; near-EOF `Record.Exception`-null for the hand-written walkers; coverage delta; updated all stale "still deferred" assertions.
- FEBuilderGBA.Tests (net9.0-windows): no new failures (the `Skill*`/`SkillSystemsAnime*` env failures are the known `config/patch2`-absent-in-worktree ones).
- EOF self-audit confirmed.

Part of #1261.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
