### PR TITLE
feat(core): ROM-rebuild producer — ItemWeaponEffect PROCS walker (#1261 slice 2l)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -1142,7 +1142,8 @@ namespace FEBuilderGBA.Core.Tests
             // StatusRMenuForm were the recursive-tree siblings here; slice 2d ports them via dedicated
             // recursive walkers, so they are now covered — see GetNotYetPortedForms_DropsSlice2dCoveredForms.)
             Assert.Contains("ItemForm", notYet);          // StatBooster size needs PatchUtil detection
-            Assert.Contains("ItemWeaponEffectForm", notYet); // PROCS length needs ProcsScript disasm
+            // (ItemWeaponEffectForm was a deferred sibling here; slice 2l ports it via
+            //  EmitItemWeaponEffect — see GetNotYetPortedForms_DropsSlice2lCoveredForms.)
             Assert.Contains("OtherTextForm", notYet);        // config-file (U.ConfigDataFilename) driven
         }
 
@@ -2302,7 +2303,7 @@ namespace FEBuilderGBA.Core.Tests
             // sibling forms that genuinely still need un-ported subsystems STAY.
             Assert.Contains("ItemForm", notYet);
             Assert.Contains("SoundRoomForm", notYet);
-            Assert.Contains("ItemWeaponEffectForm", notYet);
+            // (ItemWeaponEffectForm ported in slice 2l — see GetNotYetPortedForms_DropsSlice2lCoveredForms.)
         }
 
         // ---- real ROM: the new tables are found --------------------------
@@ -5663,6 +5664,200 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Single(list);
             // dataCount = 2 -> length = 8 * (2 + 1) = 24.
             Assert.Equal(24u, list[0].Length);
+        }
+
+        // ---- slice 2l: EmitItemWeaponEffect + CalcProcsLengthAndCheck --------
+
+        // Plant a minimal valid PROCS stream at `addr`: one 0x0B instruction (parg must be 0) then a
+        // 0x00 EXIT instruction. Length consumed = 16. Returns the planted byte length.
+        static uint PlantProcsStream(ROM rom, uint addr)
+        {
+            // instr 0: code 0x0B, sarg 0, parg 0 (parg-is-null contract).
+            rom.write_u16(addr + 0, 0x000B);
+            rom.write_u16(addr + 2, 0x0000);
+            rom.write_u32(addr + 4, 0x00000000);
+            // instr 1: code 0x00 EXIT (sarg 0, parg 0 -> arg-all-null OK, then EXIT break).
+            rom.write_u16(addr + 8, 0x0000);
+            rom.write_u16(addr + 10, 0x0000);
+            rom.write_u32(addr + 12, 0x00000000);
+            return 16;
+        }
+
+        [Fact]
+        public void EmitItemWeaponEffectAt_EmitsMainIfr_AndPerEntryProcsSubBlocks()
+        {
+            // Two entries, each with a valid +8 PROCS pointer; the 3rd row is a 0xFFFF terminator.
+            var rom = CreateTestRom(0x10000);
+            uint table = 0x1000;
+            uint pointer = 0x0400;
+            uint procs0 = 0x2000;
+            uint procs1 = 0x3000;
+            rom.write_u32(pointer, Ptr(table));
+
+            // entry 0: item id 0x10, mapAnime -> procs0.
+            rom.write_u8(table + 0, 0x10);
+            rom.write_u32(table + 8, Ptr(procs0));
+            // entry 1: item id 0x2A, mapAnime -> procs1.
+            rom.write_u8(table + 16 + 0, 0x2A);
+            rom.write_u32(table + 16 + 8, Ptr(procs1));
+            // entry 2: u16(addr)==0xFFFF -> count terminates at 2.
+            rom.write_u16(table + 32, 0xFFFF);
+
+            uint expect0 = PlantProcsStream(rom, procs0);
+            uint expect1 = PlantProcsStream(rom, procs1);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitItemWeaponEffectAt(rom, list, pointer);
+
+            // main IFR: DataCount 2 -> length 16*(2+1)=48, pointerIndexes {8}.
+            Address main = list.Single(a => a.DataType == Address.DataTypeEnum.InputFormRef && a.Info == "ItemWeaponEffect");
+            Assert.Equal(table, main.Addr);
+            Assert.Equal(pointer, main.Pointer);
+            Assert.Equal(48u, main.Length);
+            Assert.Equal(new uint[] { 8 }, main.PointerIndexes);
+
+            // PROCS sub-block for entry 0.
+            Address p0 = list.Single(a => a.DataType == Address.DataTypeEnum.PROCS && a.Addr == procs0);
+            Assert.Equal(expect0, p0.Length);
+            Assert.Equal(table + 8, p0.Pointer);
+            Assert.Equal("ItemWeaponEffect_PROC_0x10", p0.Info);
+
+            // PROCS sub-block for entry 1.
+            Address p1 = list.Single(a => a.DataType == Address.DataTypeEnum.PROCS && a.Addr == procs1);
+            Assert.Equal(expect1, p1.Length);
+            Assert.Equal(table + 16 + 8, p1.Pointer);
+            Assert.Equal("ItemWeaponEffect_PROC_0x2A", p1.Info);
+        }
+
+        [Fact]
+        public void EmitItemWeaponEffectAt_NullMapAnime_EmitsOnlyMainIfr()
+        {
+            // entry 0 has +8 == 0 (not a safe offset) -> no PROCS sub-block; then terminator.
+            var rom = CreateTestRom(0x10000);
+            uint table = 0x1000;
+            uint pointer = 0x0400;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u8(table + 0, 0x05);
+            rom.write_u32(table + 8, 0); // mapAnime == 0 -> not isSafetyOffset -> skipped
+            rom.write_u16(table + 16, 0xFFFF); // count terminates at 1
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitItemWeaponEffectAt(rom, list, pointer);
+
+            Assert.Single(list, a => a.DataType == Address.DataTypeEnum.InputFormRef);
+            Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.PROCS);
+        }
+
+        [Fact]
+        public void EmitItemWeaponEffectAt_NearEof_NoThrow()
+        {
+            var rom = CreateTestRom(0x2000);
+            uint pointer = 0x0400;
+            rom.write_u32(pointer, Ptr(0x1FF0)); // base near EOF
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.EmitItemWeaponEffectAt(rom, list, pointer));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void EmitItemWeaponEffect_RunsCleanly_OnEmptyFakeRom()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitItemWeaponEffect(fe8, list));
+                Assert.Null(ex);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        // ---- CalcProcsLengthAndCheck (verbatim PROCS terminator walk) --------
+
+        [Fact]
+        public void CalcProcsLengthAndCheck_StopsAtExit00_ReturnsLength()
+        {
+            var rom = CreateTestRom(0x10000);
+            uint addr = 0x1000;
+            uint expect = PlantProcsStream(rom, addr); // 0x0B then 0x00 EXIT -> 16
+            Assert.Equal(expect, RebuildProducerCore.CalcProcsLengthAndCheck(rom, addr));
+        }
+
+        [Fact]
+        public void CalcProcsLengthAndCheck_OddStart_ReturnsNotFound()
+        {
+            var rom = CreateTestRom(0x10000);
+            // An odd start address is rejected up-front (IsValueOdd).
+            Assert.Equal(U.NOT_FOUND, RebuildProducerCore.CalcProcsLengthAndCheck(rom, 0x1001));
+        }
+
+        [Fact]
+        public void CalcProcsLengthAndCheck_UnknownOpcode_ReturnsNotFound()
+        {
+            var rom = CreateTestRom(0x10000);
+            uint addr = 0x1000;
+            // code 0x07FF is not a known opcode (and not 0x800) -> contract violation -> NOT_FOUND.
+            rom.write_u16(addr + 0, 0x07FF);
+            rom.write_u16(addr + 2, 0x0000);
+            rom.write_u32(addr + 4, 0x00000000);
+            Assert.Equal(U.NOT_FOUND, RebuildProducerCore.CalcProcsLengthAndCheck(rom, addr));
+        }
+
+        [Fact]
+        public void CalcProcsLengthAndCheck_BadArgContract_ReturnsNotFound()
+        {
+            var rom = CreateTestRom(0x10000);
+            uint addr = 0x1000;
+            // code 0x0B requires parg == 0; plant a non-zero parg -> contract violation.
+            rom.write_u16(addr + 0, 0x000B);
+            rom.write_u16(addr + 2, 0x0000);
+            rom.write_u32(addr + 4, 0x12345678);
+            Assert.Equal(U.NOT_FOUND, RebuildProducerCore.CalcProcsLengthAndCheck(rom, addr));
+        }
+
+        [Fact]
+        public void CalcProcsLengthAndCheck_UnterminatedNearEof_NoThrow_ReturnsBounded()
+        {
+            // An unterminated valid-opcode stream that runs to EOF: the while (addr+8<=limit) clamp
+            // returns the consumed length instead of throwing on any read.
+            var rom = CreateTestRom(0x2000);
+            uint addr = 0x1FE0; // (0x2000 - 0x1FE0) = 0x20 bytes = 4 PROCS slots
+            for (uint i = 0; i < 4; i++)
+            {
+                rom.write_u16(addr + i * 8 + 0, 0x000B); // valid opcode, parg-is-null
+                rom.write_u16(addr + i * 8 + 2, 0x0000);
+                rom.write_u32(addr + i * 8 + 4, 0x00000000);
+            }
+            uint len = 0;
+            var ex = Record.Exception(() => { len = RebuildProducerCore.CalcProcsLengthAndCheck(rom, addr); });
+            Assert.Null(ex);
+            Assert.True(len != U.NOT_FOUND); // bounded, no throw (exact value not asserted)
+        }
+
+        // ---- NotYetPorted coverage delta for slice 2l -----------------------
+
+        [Fact]
+        public void GetNotYetPortedForms_DropsSlice2lCoveredForms_KeepsDeferredSiblings()
+        {
+            string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
+
+            // slice 2l ports ItemWeaponEffectForm (PROCS sub-block via CalcProcsLengthAndCheck).
+            Assert.DoesNotContain("ItemWeaponEffectForm", notYet);
+
+            // AIScriptForm STAYS — its main-IFR count rule needs the config-file AI name lists
+            // (EventUnitForm.AI1/AI2.Count), not in Core.
+            Assert.Contains("AIScriptForm", notYet);
+            // ProcsScriptForm itself STAYS — it is an ASM-path form (MakePatchStructDataList), out of
+            // scope for this data-path producer; only its CalcLengthAndCheck length helper is reused.
+            Assert.Contains("ProcsScriptForm", notYet);
+            // ItemForm STAYS — StatBooster sub-block size needs un-ported PatchUtil detection.
+            Assert.Contains("ItemForm", notYet);
+
+            // the no-duplicates invariant still holds after the edits.
+            string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
+            Assert.Equal(raw.Length, raw.Distinct().Count());
         }
     }
 }

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -2637,11 +2637,16 @@ namespace FEBuilderGBA
         /// bytecode stream of 8-byte fixed instructions <c>(code:u16, sarg:u16, parg:u32)</c> from
         /// <paramref name="addr"/>, validating each opcode's argument contract and stopping at the EXIT
         /// codes (0x00 / 0x800). Returns the byte length consumed, or <see cref="U.NOT_FOUND"/> when the
-        /// stream violates the contract (an odd start, an unknown opcode, or a bad arg). Pure ROM reads —
-        /// every dereference is bounds-guarded by the WF <c>while (addr + 8 &lt;= limit)</c> clamp (which
-        /// guarantees <c>addr+7 &lt; Length</c> so the u16/u16/u32 triplet is always in-bounds), plus the
-        /// inner <c>getString</c> (code 0x01) and the GOTO-0 look-ahead recursion (code 0x0C) are both
-        /// themselves EOF-safe. Line-for-line faithful to the WinForms method.</summary>
+        /// stream violates the contract (an odd start, an unknown opcode, or a bad arg). NOTE (verbatim
+        /// WF): after advancing <c>addr += 8</c> the loop breaks on <c>if (addr + 8 &gt; limit) break;</c>
+        /// BEFORE the opcode-specific contract switch, so the final 8-byte slot that sits within
+        /// <c>[limit-8, limit)</c> is counted into the length WITHOUT running its contract/terminator
+        /// check — i.e. the per-opcode validation covers every slot except a trailing one at EOF (WF does
+        /// the same). Pure ROM reads — every dereference is bounds-guarded by the WF
+        /// <c>while (addr + 8 &lt;= limit)</c> clamp (which guarantees <c>addr+7 &lt; Length</c> so the
+        /// u16/u16/u32 triplet is always in-bounds), plus the inner <c>getString</c> (code 0x01) and the
+        /// GOTO-0 look-ahead recursion (code 0x0C) are both themselves EOF-safe. Line-for-line faithful
+        /// to the WinForms method.</summary>
         public static uint CalcProcsLengthAndCheck(ROM rom, uint addr)
         {
             if (U.IsValueOdd(addr))

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -620,6 +620,27 @@ namespace FEBuilderGBA
             progress?.Report("MapPointer");
             EmitMapPointer(rom, list);
 
+            // ---- slice 2l: ItemWeaponEffect (version-agnostic) ----
+            // ItemWeaponEffectForm.MakeAllDataLength is in the WF unconditional section (NOT
+            // version/multibyte-gated). It is NOT a flat StructDescriptor walk: its main IFR (base
+            // p32(item_effect_pointer), block 16, IsDataExists = u16(addr)==0xFFFF stop / i>10 &&
+            // IsEmpty(addr,16*10) stop — both pure ROM reads) is followed by a per-entry PROCS
+            // sub-block behind the embedded pointer at +8, whose length is a PROCS-bytecode
+            // terminator walk (ProcsScriptForm.CalcLengthAndCheck — pure u16/u32/getString reads,
+            // reproduced VERBATIM as CalcProcsLengthAndCheck). A dedicated emitter reproduces it
+            // (its own cancel-check mirrors the WF DoEvents posture). AIScriptForm STAYS deferred —
+            // its main-IFR count rule caps DataCount at the config-file AI name lists
+            // (EventUnitForm.AI1/AI2.Count, NOT in Core), so the entry count is not faithfully
+            // reproducible from ROM bytes (a wrong count = wrong # of AISCRIPT/AIUnits sub-blocks =
+            // corruption); see GetNotYetPortedForms.
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("ItemWeaponEffect");
+            EmitItemWeaponEffect(rom, list);
+
             // ---- slice 2h: SupportUnit (all versions) + WorldMapPath (FE8-only) ----
             // SupportUnitForm is called in the WF version==8 AND version==7 branches (block 24); the
             // SupportUnitFE6Form variant in version==6 (block 32). EmitSupportUnit auto-selects the
@@ -2520,6 +2541,270 @@ namespace FEBuilderGBA
                     return p - addr;
                 }
             }
+        }
+
+        // ===================================================================
+        // slice 2l — ItemWeaponEffectForm (version-agnostic). A flat IFR (base
+        // p32(item_effect_pointer), block 16, IsDataExists = u16(addr)==0xFFFF
+        // stop / i>10 && IsEmpty(addr,16*10) stop) PLUS, per entry, a PROCS
+        // sub-block behind the embedded pointer at +8 whose length is the
+        // PROCS-bytecode terminator walk ProcsScriptForm.CalcLengthAndCheck
+        // (pure u16/u32/getString reads), reproduced VERBATIM below.
+        // ===================================================================
+
+        /// <summary>
+        /// <c>ItemWeaponEffectForm.MakeAllDataLength</c> (version-agnostic, slice 2l). Reproduces the
+        /// WF main IFR (<c>AddressWinForms.AddAddress(list, ItemWeaponEffectForm.Init, "ItemWeaponEffect",
+        /// {8})</c>) plus the per-entry PROCS sub-block:
+        /// <list type="bullet">
+        ///   <item>base = <c>p32(item_effect_pointer)</c>, block 16, pointerIndexes {8}, type
+        ///   InputFormRef, length = <c>16*(DataCount+1)</c>;</item>
+        ///   <item>count rule (<c>ItemWeaponEffectForm.Init</c> IsDataExists) = stop when
+        ///   <c>u16(addr)==0xFFFF</c>, or when <c>i>10 &amp;&amp; IsEmpty(addr,16*10)</c> — both pure ROM
+        ///   reads (<c>getBlockDataCount</c> guards <c>addr+16&lt;=Length</c>, so the u16 read is always
+        ///   in-bounds; <c>IsEmpty</c> is itself EOF-safe);</item>
+        ///   <item>per entry <c>p = base + i*16</c>: <c>mapAnime = p32(p+8)</c>; if it is a safe offset,
+        ///   <c>AddPointer(p+8, CalcProcsLengthAndCheck(mapAnime), "ItemWeaponEffect_PROC_0x&lt;itemid&gt;",
+        ///   PROCS)</c> (itemid = <c>u8(p+0)</c>; the WF label's localized item NAME is dropped — it does
+        ///   not affect relocation).</item>
+        /// </list>
+        /// The producer always scans real lengths (no isPointerOnly) and is fully bounds-guarded.
+        /// </summary>
+        public static void EmitItemWeaponEffect(ROM rom, List<Address> list)
+        {
+            EmitItemWeaponEffectAt(rom, list, rom.RomInfo.item_effect_pointer);
+        }
+
+        /// <summary>ItemWeaponEffect walk from an explicit pointer slot (test seam — lets a synthetic ROM
+        /// supply it without populating RomInfo). See <see cref="EmitItemWeaponEffect"/> for the verbatim
+        /// WF reproduction.</summary>
+        public static void EmitItemWeaponEffectAt(ROM rom, List<Address> list, uint rawPointer)
+        {
+            const uint block = 16;
+
+            // Main IFR: BasePointer = toOffset(slot), BaseAddress = p32(BasePointer). Guard the full
+            // slot before p32 (root+3). Matches InputFormRef.Init (toOffset then p32, both safety-checked).
+            uint pointer = U.toOffset(rawPointer);
+            if (!U.isSafetyOffset(pointer + 3, rom))
+            {
+                return;
+            }
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                return;
+            }
+
+            // IsDataExists (ItemWeaponEffectForm.Init): stop at u16(addr)==0xFFFF, or i>10 &&
+            // IsEmpty(addr, 16*10). getBlockDataCount guards addr+block(16)<=Length, so u16(addr) is
+            // always in-bounds; IsEmpty is itself EOF-safe (returns false past EOF).
+            uint dataCount = rom.getBlockDataCount(baseAddr, block, (i, addr) =>
+            {
+                if (rom.u16(addr) == 0xFFFF)
+                {
+                    return false;
+                }
+                if (i > 10 && rom.IsEmpty(addr, block * 10))
+                {
+                    return false;
+                }
+                return true;
+            });
+
+            uint length = block * (dataCount + 1);
+            list.Add(new Address(baseAddr, length, pointer, "ItemWeaponEffect",
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { 8 }));
+
+            // Per-entry PROCS sub-blocks. getBlockDataCount guarantees p+block(16)<=Length for
+            // i<dataCount, so p32(p+8) (deepest p+11) and u8(p+0) are both in bounds.
+            uint p = baseAddr;
+            for (uint i = 0; i < dataCount; i++, p += block)
+            {
+                uint mapAnime = rom.p32(p + 8);
+                if (!U.isSafetyOffset(mapAnime, rom))
+                {
+                    continue;
+                }
+                uint itemid = rom.u8(p + 0);
+                string procName = "ItemWeaponEffect_PROC_0x" + itemid.ToString("X");
+
+                Address.AddPointer(list, p + 8, CalcProcsLengthAndCheck(rom, mapAnime),
+                    procName, Address.DataTypeEnum.PROCS);
+            }
+        }
+
+        /// <summary>VERBATIM port of <c>ProcsScriptForm.CalcLengthAndCheck</c>: walk a PROCS (map-anime)
+        /// bytecode stream of 8-byte fixed instructions <c>(code:u16, sarg:u16, parg:u32)</c> from
+        /// <paramref name="addr"/>, validating each opcode's argument contract and stopping at the EXIT
+        /// codes (0x00 / 0x800). Returns the byte length consumed, or <see cref="U.NOT_FOUND"/> when the
+        /// stream violates the contract (an odd start, an unknown opcode, or a bad arg). Pure ROM reads —
+        /// every dereference is bounds-guarded by the WF <c>while (addr + 8 &lt;= limit)</c> clamp (which
+        /// guarantees <c>addr+7 &lt; Length</c> so the u16/u16/u32 triplet is always in-bounds), plus the
+        /// inner <c>getString</c> (code 0x01) and the GOTO-0 look-ahead recursion (code 0x0C) are both
+        /// themselves EOF-safe. Line-for-line faithful to the WinForms method.</summary>
+        public static uint CalcProcsLengthAndCheck(ROM rom, uint addr)
+        {
+            if (U.IsValueOdd(addr))
+            {//奇数から始まるのはどう考えてもおかしい.
+                return U.NOT_FOUND;
+            }
+
+            uint start = addr;
+            uint limit = (uint)rom.Data.Length;
+
+            while (addr + 8 <= limit)
+            {
+                uint code = rom.u16(addr + 0);
+                uint sarg = rom.u16(addr + 2);
+                uint parg = rom.u32(addr + 4);
+
+                addr += 8; //命令は8バイト固定.
+                if (addr + 8 > limit)
+                {
+                    break;
+                }
+                if (code == 0x00)
+                {//arg all null
+                    if (sarg == 0)
+                    {
+                        if (parg != 0)
+                        {//規約違反
+                            return U.NOT_FOUND;
+                        }
+                    }
+                    else if (sarg <= 10)
+                    {//10だったときは、何か値が入ることがあるようだ
+                     //例: 0000 1000 08001800
+                        if (parg == 0)
+                        {//規約違反
+                            return U.NOT_FOUND;
+                        }
+                    }
+                }
+                else if (code == 0x10 || code == 0x11 || code == 0x12 || code == 0x13 || code == 0x15 || code == 0x17 || code == 0x19)
+                {//arg all null
+                    if (sarg != 0 || parg != 0)
+                    {//規約違反
+                        return U.NOT_FOUND;
+                    }
+                }
+                else if (code == 0x01)
+                {//sarg is null, parg is pointer
+                    if (sarg != 0 || !U.isSafetyPointer(parg, rom))
+                    {//規約違反
+                        return U.NOT_FOUND;
+                    }
+                    //文字列参照 ASCIIである必要あり
+                    string name = rom.getString(U.toOffset(parg));
+                    if (!U.isAsciiString(name))
+                    {//規約違反
+                        return U.NOT_FOUND;
+                    }
+                }
+                else if (code == 0x02 || code == 0x03 || code == 0x04 || code == 0x14 || code == 0x16)
+                {//sarg is null, parg is pointer
+                    if (sarg != 0 || !U.isSafetyPointer(parg, rom))
+                    {//規約違反
+                        return U.NOT_FOUND;
+                    }
+                    if (U.IsValueOdd(parg) == false)
+                    {//関数呼び出しなので絶対に奇数でなければならない.
+                        return U.NOT_FOUND;
+                    }
+                }
+                else if (code == 0x05 || code == 0x0D)
+                {//sarg is null, parg is pointer
+                    if (sarg != 0 || !U.isSafetyPointer(parg, rom))
+                    {//規約違反
+                        return U.NOT_FOUND;
+                    }
+                    if (U.IsValueOdd(parg))
+                    {//6C呼び出しなので絶対に偶数でなければならない.
+                        return U.NOT_FOUND;
+                    }
+                }
+                else if (code == 0x06)
+                {//parg is pointer, sargは1になることがあるらしい
+                    if (!U.isPointer(parg))
+                    {//規約違反
+                        return U.NOT_FOUND;
+                    }
+                    if (U.IsValueOdd(parg))
+                    {//6C呼び出しなので絶対に偶数でなければならない.
+                        return U.NOT_FOUND;
+                    }
+                    //Debug.Assert(sarg == 1);
+                    if (sarg >= 2)
+                    {
+                        return U.NOT_FOUND;
+                    }
+                }
+                else if (code == 0x07 || code == 0x08 || code == 0x09 || code == 0x0A)
+                {
+                    if (!U.isPointer(parg))
+                    {//規約違反
+                        return U.NOT_FOUND;
+                    }
+                    if (U.IsValueOdd(parg))
+                    {//6C呼び出しなので絶対に偶数でなければならない.
+                        return U.NOT_FOUND;
+                    }
+                    if (sarg != 0)
+                    {//必ずsarg引数は0
+                        return U.NOT_FOUND;
+                    }
+                }
+                else if (code == 0x0B || code == 0x0E || code == 0x0F)
+                {//parg is null
+                    if (parg != 0)
+                    {//規約違反
+                        return U.NOT_FOUND;
+                    }
+                }
+                else if (code == 0x0C)
+                {//parg is null
+                    if (sarg == 0)
+                    {//GOTO LABEL 0があった
+                        //Goto 0の時だけは、pargにゴミが入るときがある.
+
+                        //先読みをしてみる.
+                        uint sakiyomi = CalcProcsLengthAndCheck(rom, addr + 8);
+                        if (sakiyomi == U.NOT_FOUND)
+                        {//この先が壊れているなら、自分が終端.
+                            if (start == addr)
+                            {//自分が終端なのに、それが最初に出てくるのはおかしいよね.
+                                return U.NOT_FOUND;
+                            }
+                            break;
+                        }
+                    }
+                    else if (parg != 0)
+                    {//規約違反
+                        return U.NOT_FOUND;
+                    }
+                }
+                else if (code == 0x18)
+                {// parg is pointer
+                    if (!U.isSafetyPointer(parg, rom))
+                    {//規約違反
+                        return U.NOT_FOUND;
+                    }
+                }
+                else if (code == 0x800)
+                {//EXIT その3
+                    break;
+                }
+                else
+                {
+                    return U.NOT_FOUND;
+                }
+
+                if (code == 0x00)
+                {//EXIT
+                    break;
+                }
+            }
+            return addr - start;
         }
 
         // ===================================================================
@@ -5270,9 +5555,12 @@ namespace FEBuilderGBA
                 //  and the ItemEffectiveness rework variant on SearchClassType — a wrong size would
                 //  relocate the wrong bytes, so it must wait until those detectors reach Core.)
                 "ItemForm",
-                // The other slice-2c embedded forms also stay — their sub-block LENGTH needs a
-                // subsystem not yet in Core (a wrong length relocates the wrong bytes = corruption):
-                //   ItemWeaponEffectForm— PROCS sub-block length = ProcsScriptForm.CalcLengthAndCheck (disasm).
+                // (ItemWeaponEffectForm ported in slice 2l — EmitItemWeaponEffect: a flat IFR (base
+                //  p32(item_effect_pointer), block 16, IsDataExists u16==0xFFFF / i>10 && IsEmpty(addr,160)
+                //  — both pure ROM reads) + a per-entry PROCS sub-block behind the embedded pointer at +8,
+                //  length = the PROCS-bytecode terminator walk ProcsScriptForm.CalcLengthAndCheck,
+                //  reproduced verbatim as CalcProcsLengthAndCheck — a pure u16/u32/getString walk whose
+                //  only non-ROM dep (getString + isAsciiString for opcode 0x01) is in Core.)
                 // (StatusRMenuForm [recursive 28-byte MIX tree, shared visited-set + 2 ASM AddFunction]
                 //  and MenuDefinitionForm [recursive MenuCommandForm sub-table — InputFormRef_MIX + per-entry
                 //  CString + 6 ASM ptrs — + its own 6 ASM ptrs] ported in slice 2d via dedicated recursive
@@ -5280,7 +5568,6 @@ namespace FEBuilderGBA
                 // (ItemShopForm ported in slice 2g — EmitItemShop walks ItemShopCore.MakeShopList [hensei +
                 //  FE8 worldmap + per-map event-cond OBJECT-slot shops] and emits one BIN Address per shop,
                 //  length = (count of non-zero 2-byte item entries + 1) * 2.)
-                "ItemWeaponEffectForm",
                 // UnitActionPointerForm STAYS — its base = SearchActionPointer(), gated on
                 //   PatchUtil.SearchUnitActionReworkPatch() (PatchUtil patch detection not in Core).
                 // (ItemUsagePointerForm ported in slice 2f — dedicated EmitItemUsagePointer walker over
@@ -5302,9 +5589,16 @@ namespace FEBuilderGBA
                 // AI scripts (disasm)
                 // (AIMapSettingForm [flat u8!=0xFF table], AIPerformStaffForm + AIPerformItemForm
                 //  [flat u16!=0 table + per-entry ASM AddFunction @4 via SubKind.AsmFunction] ported in
-                //  slice 2f. AIScriptForm STAYS — its per-entry length is AIScriptForm.CalcLength (AI
-                //  16-byte-opcode bytecode walk) + AIUnitsForm.CalcLength + nested LZ77 sub-pointers, none
-                //  of which is in Core.)
+                //  slice 2f. AIScriptForm STAYS — its per-entry CalcLength helpers ARE pure ROM walks
+                //  (AIScriptForm.CalcLength = AI 16-byte-opcode terminator walk; AIUnitsForm.CalcLength =
+                //  u16!=0 walk), but its MAIN-IFR COUNT RULE (AIScriptForm.Init IsDataExists) is NOT a pure
+                //  ROM read: in the un-extended-ROM case (the vanilla AI tables) it caps DataCount at the
+                //  config-file AI name lists EventUnitForm.AI1.Count / AI2.Count (loaded from ai1_*/ai2_*
+                //  TSV via PreLoadResourceAI1/2, then padded up to DataCount — circular + editor session
+                //  state), neither of which is in Core. A wrong main count => wrong # of AISCRIPT/AIUnits
+                //  sub-blocks emitted => relocates the wrong bytes on rebuild = corruption. Same shape as
+                //  the MapSettingForm deferral (count rule needs a WF cached resource). Deferred until the
+                //  AI name lists + isExtrendsROMArea reach Core.)
                 "AIScriptForm",
                 // skills (version/patch dependent)
                 "SkillAssignmentClassSkillSystemForm", "SkillAssignmentUnitSkillSystemForm",


### PR DESCRIPTION
## Summary
**Slice 2l** of #1261 — the **PROCS bytecode-walker** form. `ItemWeaponEffectForm` ported; `AIScriptForm` deferred for a precise correctness reason.

## Ported
- **ItemWeaponEffectForm** [version-agnostic — WF `U.cs:2474`, no version/`is_multibyte` gate, no FE6/FE7 variant] via `EmitItemWeaponEffect`/`EmitItemWeaponEffectAt`. Main IFR: base `p32(item_effect_pointer)`, block 16, PI `{8}`, length `16*(DataCount+1)`; count rule reproduces `ItemWeaponEffectForm.Init` IsDataExists (`u16==0xFFFF` stop / `i>10 && IsEmpty(addr,160)` stop — both pure ROM, EOF-safe). Per entry: a PROCS sub-block at `p32(p+8)`, length = `CalcProcsLengthAndCheck`. Name uses the static `"ItemWeaponEffect_PROC_0x<itemid>"` (`itemid=u8(p+0)`, pure ROM; dropped the localized `GetItemName` — relocation-identical).
- **Reproduced helper `CalcProcsLengthAndCheck`** = VERBATIM line-for-line port of `ProcsScriptForm.CalcLengthAndCheck` (8-byte-opcode PROCS walk). *(Lead-verified: a normalized diff of the full method vs WF is identical bar whitespace — including the `0x00`/`0x800` EXIT terminators, the `0x0C` GOTO-LABEL-0 look-ahead recursion `CalcProcsLengthAndCheck(rom, addr+8)`, opcode arg contracts, and the `return addr - start`.)* Only deltas: `Program.ROM`→`rom`, `isSafetyPointer(parg)`→`isSafetyPointer(parg, rom)`. `getString`+`isAsciiString` (opcode `0x01`) are in Core; `CreateTestRom` wires `HeadlessSystemTextEncoder`.

## Deferred (correctness-driven, NOT size)
- **AIScriptForm** — its two `CalcLength` helpers (AI 16-byte-opcode walk + `AIUnitsForm.CalcLength`) ARE pure ROM, but its **main-IFR count rule** (`AIScriptForm.Init` IsDataExists) caps the un-extended `DataCount` at `EventUnitForm.AI1.Count`/`AI2.Count` — which are **config-FILE TSV lists** (`ai1_*`/`ai2_*` via `PreLoadResourceAI1/2`, padded to DataCount → circular/session-state), not in Core. A wrong count = wrong number of AISCRIPT/AIUnits sub-blocks emitted = corruption. Same blocker class as `MapSettingForm`. `NotYetPortedRaw` comment updated.

## Tests
- RebuildProducer filter: **196 passed / 0 failed** (+10) — `EmitItemWeaponEffectAt` main+PROCS; null-mapAnime skip; near-EOF no-throw; empty-FE8-ROM clean; `CalcProcsLengthAndCheck` planted-length, odd-start/unknown-opcode/bad-arg → `NOT_FOUND`, unterminated-near-EOF no-throw. Fixed 2 stale slice-2c/2d sibling assertions listing ItemWeaponEffectForm as deferred.
- FEBuilderGBA.Tests (net9.0-windows): no new failures (the `Skill*`/`SkillSystemsAnime*` env failures are the known `config/patch2`-absent-in-worktree ones).
- EOF self-audit confirmed (`pointer+3` before `p32`; the PROCS `u16/u16/u32` triplet bounded by `while addr+8<=limit`; count-rule reads block-bounded by `getBlockDataCount`).

Part of #1261.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
