### PR TITLE
feat(core): ROM-rebuild producer — Huffman text + FE8 spell-menu forms (#1261 slice 2m)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -5919,44 +5919,51 @@ namespace FEBuilderGBA.Core.Tests
             // No encoder -> the WF isPointerOnly path: per-entry BIN emits with size 0 (the slot is
             // still relocated and the target addr recorded). Avoids the Huffman decode (which needs a
             // valid mask_pointer tree, absent on a bare synthetic ROM).
+            var savedEncoder = CoreState.SystemTextEncoder;
             CoreState.SystemTextEncoder = null;
+            try
+            {
+                uint pointer = 0x0400;
+                uint table = 0x1000;
+                uint textNormal = 0x2000;      // normal-pointer text target
+                rom.write_u32(pointer, Ptr(table));
 
-            uint pointer = 0x0400;
-            uint table = 0x1000;
-            uint textNormal = 0x2000;      // normal-pointer text target
-            rom.write_u32(pointer, Ptr(table));
+                // entry 0: a normal ROM pointer -> isPointer branch.
+                rom.write_u32(table + 0 * 4, Ptr(textNormal));
+                // entry 1: an un-Huffman patch pointer (0x88000000..0x8A000000). 0x88001500 ->
+                // ConvertUnHuffmanPatchToPointer -> 0x08001500 -> toOffset -> 0x1500.
+                rom.write_u32(table + 1 * 4, 0x88001500);
+                // entry 2: NOT a pointer / patch / RAM -> terminates the count (count = 2).
+                rom.write_u32(table + 2 * 4, 0x00000005);
 
-            // entry 0: a normal ROM pointer -> isPointer branch.
-            rom.write_u32(table + 0 * 4, Ptr(textNormal));
-            // entry 1: an un-Huffman patch pointer (0x88000000..0x8A000000). 0x88001500 ->
-            // ConvertUnHuffmanPatchToPointer -> 0x08001500 -> toOffset -> 0x1500.
-            rom.write_u32(table + 1 * 4, 0x88001500);
-            // entry 2: NOT a pointer / patch / RAM -> terminates the count (count = 2).
-            rom.write_u32(table + 2 * 4, 0x00000005);
+                var list = new List<Address>();
+                RebuildProducerCore.EmitTextAt(rom, list, pointer);
 
-            var list = new List<Address>();
-            RebuildProducerCore.EmitTextAt(rom, list, pointer);
+                // Main IFR: TEXTPOINTERS, block 4, count 2 -> length 4*(2+1)=12, pointer = slot, PI {0}.
+                Address main = list.Single(a => a.DataType == Address.DataTypeEnum.TEXTPOINTERS);
+                Assert.Equal(table, main.Addr);
+                Assert.Equal(pointer, main.Pointer);
+                Assert.Equal(4u, main.BlockSize);
+                Assert.Equal(12u, main.Length);
+                Assert.Equal(new uint[] { 0 }, main.PointerIndexes);
+                Assert.Equal("Text", main.Info);
 
-            // Main IFR: TEXTPOINTERS, block 4, count 2 -> length 4*(2+1)=12, pointer = slot, PI {0}.
-            Address main = list.Single(a => a.DataType == Address.DataTypeEnum.TEXTPOINTERS);
-            Assert.Equal(table, main.Addr);
-            Assert.Equal(pointer, main.Pointer);
-            Assert.Equal(4u, main.BlockSize);
-            Assert.Equal(12u, main.Length);
-            Assert.Equal(new uint[] { 0 }, main.PointerIndexes);
-            Assert.Equal("Text", main.Info);
+                // entry 0 BIN: addr = toOffset(Ptr(textNormal)) = textNormal, pointer = slot table+0, size 0.
+                Address e0 = list.Single(a => a.DataType == Address.DataTypeEnum.BIN && a.Pointer == table + 0);
+                Assert.Equal(textNormal, e0.Addr);
+                Assert.Equal(0u, e0.Length);
+                Assert.Equal("Text " + U.ToHexString(0u), e0.Info);
 
-            // entry 0 BIN: addr = toOffset(Ptr(textNormal)) = textNormal, pointer = slot table+0, size 0.
-            Address e0 = list.Single(a => a.DataType == Address.DataTypeEnum.BIN && a.Pointer == table + 0);
-            Assert.Equal(textNormal, e0.Addr);
-            Assert.Equal(0u, e0.Length);
-            Assert.Equal("Text " + U.ToHexString(0u), e0.Info);
-
-            // entry 1 BIN: addr = 0x1500 (un-Huffman decoded), pointer = slot table+4, size 0.
-            Address e1 = list.Single(a => a.DataType == Address.DataTypeEnum.BIN && a.Pointer == table + 4);
-            Assert.Equal(0x1500u, e1.Addr);
-            Assert.Equal(0u, e1.Length);
-            Assert.Equal("Text " + U.ToHexString(1u), e1.Info);
+                // entry 1 BIN: addr = 0x1500 (un-Huffman decoded), pointer = slot table+4, size 0.
+                Address e1 = list.Single(a => a.DataType == Address.DataTypeEnum.BIN && a.Pointer == table + 4);
+                Assert.Equal(0x1500u, e1.Addr);
+                Assert.Equal(0u, e1.Length);
+                Assert.Equal("Text " + U.ToHexString(1u), e1.Info);
+            }
+            finally
+            {
+                CoreState.SystemTextEncoder = savedEncoder;
+            }
         }
 
         [Fact]
@@ -5966,34 +5973,82 @@ namespace FEBuilderGBA.Core.Tests
             // the per-entry loop emits NO AddAddress for it (the target lives in RAM, not ROM). Reproduce
             // exactly: the entry contributes to the main IFR length but produces no BIN.
             var rom = CreateTestRom(0x8000);
+            var savedEncoder = CoreState.SystemTextEncoder;
             CoreState.SystemTextEncoder = null;
+            try
+            {
+                uint pointer = 0x0400;
+                uint table = 0x1000;
+                rom.write_u32(pointer, Ptr(table));
+                rom.write_u32(table + 0 * 4, 0x03000100);   // is_03RAMPointer -> counted, NOT emitted
+                rom.write_u32(table + 1 * 4, 0x00000005);   // terminates -> count 1
 
-            uint pointer = 0x0400;
-            uint table = 0x1000;
-            rom.write_u32(pointer, Ptr(table));
-            rom.write_u32(table + 0 * 4, 0x03000100);   // is_03RAMPointer -> counted, NOT emitted
-            rom.write_u32(table + 1 * 4, 0x00000005);   // terminates -> count 1
+                var list = new List<Address>();
+                RebuildProducerCore.EmitTextAt(rom, list, pointer);
 
-            var list = new List<Address>();
-            RebuildProducerCore.EmitTextAt(rom, list, pointer);
-
-            Address main = list.Single(a => a.DataType == Address.DataTypeEnum.TEXTPOINTERS);
-            Assert.Equal(4u * (1 + 1), main.Length);    // count 1 -> length 8
-            // No BIN sub-block emitted for the RAM-pointer entry.
-            Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.BIN);
+                Address main = list.Single(a => a.DataType == Address.DataTypeEnum.TEXTPOINTERS);
+                Assert.Equal(4u * (1 + 1), main.Length);    // count 1 -> length 8
+                // No BIN sub-block emitted for the RAM-pointer entry.
+                Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.BIN);
+            }
+            finally
+            {
+                CoreState.SystemTextEncoder = savedEncoder;
+            }
         }
 
         [Fact]
         public void EmitTextAt_NearEof_NoThrow()
         {
             var rom = CreateTestRom(0x1000);
+            var savedEncoder = CoreState.SystemTextEncoder;
             CoreState.SystemTextEncoder = null;
-            // Slot near EOF: the +3 guard before p32 must prevent any out-of-bounds read.
-            uint pointer = (uint)rom.Data.Length - 2;
-            var list = new List<Address>();
-            Assert.Null(Record.Exception(() =>
-                RebuildProducerCore.EmitTextAt(rom, list, pointer)));
-            Assert.Empty(list);
+            try
+            {
+                // Slot near EOF: the +3 guard before p32 must prevent any out-of-bounds read.
+                uint pointer = (uint)rom.Data.Length - 2;
+                var list = new List<Address>();
+                Assert.Null(Record.Exception(() =>
+                    RebuildProducerCore.EmitTextAt(rom, list, pointer)));
+                Assert.Empty(list);
+            }
+            finally
+            {
+                CoreState.SystemTextEncoder = savedEncoder;
+            }
+        }
+
+        [Fact]
+        public void EmitTextAt_EncoderPresent_BrokenMaskTree_DoesNotThrow()
+        {
+            // Regression (PR #1285 review): with an encoder loaded, the per-entry huffman_decode throws
+            // FETextException on a broken mask tree (real RomInfo whose mask_pointer dereferences to an
+            // unsafe tree_base — here the versioned ROM's mask data is all-zero). EmitTextAt must CATCH it
+            // and fall back to size 0 rather than aborting the whole producer run. (A bare CreateTestRom
+            // can't exercise this — its RomInfo is null, so huffman_decode NREs before the mask check; a
+            // real run always has a non-null RomInfo, so FETextException is the realistic failure mode.)
+            var rom = MakeVersionedRom("BE8E01"); // FE8U: non-null RomInfo; mask tree is zero -> unsafe.
+            var savedRom = CoreState.ROM;
+            var savedEncoder = CoreState.SystemTextEncoder;
+            CoreState.ROM = rom;
+            CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+            try
+            {
+                uint pointer = 0x0400, table = 0x1000, textNormal = 0x2000;
+                rom.write_u32(pointer, Ptr(table));
+                rom.write_u32(table + 0 * 4, Ptr(textNormal)); // normal pointer -> isPointer -> huffman_decode throws
+                rom.write_u32(table + 1 * 4, 0x00000005);      // terminate -> count 1
+
+                var list = new List<Address>();
+                Assert.Null(Record.Exception(() => RebuildProducerCore.EmitTextAt(rom, list, pointer)));
+                // The run completes: the main IFR is produced (the per-entry decode was caught -> size 0).
+                Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.TEXTPOINTERS);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEncoder;
+            }
         }
 
         // ---- EmitFE8SpellMenuExtendsAt: main IFR + per-entry NestedIfr -------

--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -447,7 +447,10 @@ namespace FEBuilderGBA.Core.Tests
             string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
             Assert.NotEmpty(notYet);
             // The heavy editors that need extraction first must be tracked, not dropped.
-            Assert.Contains("TextForm", notYet);
+            // (TextForm/TextCharCodeForm are ported in slice 2m — see
+            //  GetNotYetPortedForms_DropsSlice2mCoveredForms_KeepsDeferredSiblings; OtherTextForm STAYS,
+            //  its config-file other_text_* table is not ROM-derived.)
+            Assert.Contains("OtherTextForm", notYet);
             Assert.Contains("EventCondForm", notYet);
             Assert.Contains("SongTableForm", notYet);
             // ItemForm stays DEFERRED: its StatBooster sub-block size depends on un-ported PatchUtil
@@ -1702,7 +1705,8 @@ namespace FEBuilderGBA.Core.Tests
             {
                 "EventBattleTalkForm", "EventHaikuForm",
                 "WorldMapEventPointerForm",
-                "MapSettingForm", "FE8SpellMenuExtendsForm",
+                // (FE8SpellMenuExtendsForm ported in slice 2m -> no longer kept here.)
+                "MapSettingForm",
                 "MonsterWMapProbabilityForm", "SoundRoomForm",
                 // (StatusOptionForm + SoundFootStepsForm ported in slice 2d -> no longer kept here.
                 //  UnitFE6Form + ItemUsagePointerForm + AIPerform*/AIMapSetting/Mant/ArenaEnemyWeapon
@@ -4765,7 +4769,9 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Contains("MonsterWMapProbabilityForm", notYet); // ScanScript skirmish events
             // (ImageCGFE7UForm is ported in slice 2k — see GetNotYetPortedForms_DropsSlice2kCoveredForms.)
             Assert.DoesNotContain("ImageCGFE7UForm", notYet);
-            Assert.Contains("FE8SpellMenuExtendsForm", notYet);  // FindFE8SpellPatchPointer
+            // (FE8SpellMenuExtendsForm is ported in slice 2m — see
+            //  GetNotYetPortedForms_DropsSlice2mCoveredForms_KeepsDeferredSiblings.)
+            Assert.DoesNotContain("FE8SpellMenuExtendsForm", notYet);
 
             // the no-duplicates invariant still holds after the edits.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
@@ -5858,6 +5864,301 @@ namespace FEBuilderGBA.Core.Tests
             // the no-duplicates invariant still holds after the edits.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
             Assert.Equal(raw.Length, raw.Distinct().Count());
+        }
+
+        // ====================================================================
+        // slice 2m: TextForm (EmitText) + TextCharCodeForm (descriptor) +
+        //           FE8SpellMenuExtendsForm (EmitFE8SpellMenuExtends)
+        // ====================================================================
+
+        // ---- TextCharCodeForm: flat U8NotEqual descriptor (mask_pointer) -----
+
+        [Fact]
+        public void TextCharCode_U8NotEqual255_StopsAtTerminator_EmptyPointerIndexes()
+        {
+            var rom = CreateTestRom();
+            // WF TextCharCodeForm.Init: base mask_pointer, block 4, IsDataExists = u8(addr) != 255,
+            // AddAddress(list, IFR, "TextCharCode", new uint[] {}) — empty PI, default InputFormRef type.
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u8(table + 0 * 4, 0x41);  // valid
+            rom.write_u8(table + 1 * 4, 0x42);  // valid
+            rom.write_u8(table + 2 * 4, 0x43);  // valid
+            rom.write_u8(table + 3 * 4, 0xFF);  // 255 terminator -> count 3
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "TextCharCode",
+                PointerField = _ => pointer,
+                BlockSize = 4,
+                Rule = RebuildProducerCore.DataCountRule.U8NotEqual,
+                RuleOffset = 0,
+                RuleStopValue = 255,
+                PointerIndexes = new uint[] { },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            Address a = Assert.Single(list);
+            Assert.Equal(table, a.Addr);
+            Assert.Equal(pointer, a.Pointer);
+            Assert.Equal(4u, a.BlockSize);
+            Assert.Equal(4u * (3 + 1), a.Length);   // block 4, count 3 -> 16
+            Assert.Equal(Address.DataTypeEnum.InputFormRef, a.DataType);
+            Assert.Empty(a.PointerIndexes);
+        }
+
+        // ---- EmitTextAt: main TEXTPOINTERS IFR + per-entry BIN sub-walks ----
+
+        [Fact]
+        public void EmitTextAt_MainIfr_IsTextPointers_Block4_PI0_AndPerEntryBin()
+        {
+            var rom = CreateTestRom(0x8000);
+            // No encoder -> the WF isPointerOnly path: per-entry BIN emits with size 0 (the slot is
+            // still relocated and the target addr recorded). Avoids the Huffman decode (which needs a
+            // valid mask_pointer tree, absent on a bare synthetic ROM).
+            CoreState.SystemTextEncoder = null;
+
+            uint pointer = 0x0400;
+            uint table = 0x1000;
+            uint textNormal = 0x2000;      // normal-pointer text target
+            rom.write_u32(pointer, Ptr(table));
+
+            // entry 0: a normal ROM pointer -> isPointer branch.
+            rom.write_u32(table + 0 * 4, Ptr(textNormal));
+            // entry 1: an un-Huffman patch pointer (0x88000000..0x8A000000). 0x88001500 ->
+            // ConvertUnHuffmanPatchToPointer -> 0x08001500 -> toOffset -> 0x1500.
+            rom.write_u32(table + 1 * 4, 0x88001500);
+            // entry 2: NOT a pointer / patch / RAM -> terminates the count (count = 2).
+            rom.write_u32(table + 2 * 4, 0x00000005);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitTextAt(rom, list, pointer);
+
+            // Main IFR: TEXTPOINTERS, block 4, count 2 -> length 4*(2+1)=12, pointer = slot, PI {0}.
+            Address main = list.Single(a => a.DataType == Address.DataTypeEnum.TEXTPOINTERS);
+            Assert.Equal(table, main.Addr);
+            Assert.Equal(pointer, main.Pointer);
+            Assert.Equal(4u, main.BlockSize);
+            Assert.Equal(12u, main.Length);
+            Assert.Equal(new uint[] { 0 }, main.PointerIndexes);
+            Assert.Equal("Text", main.Info);
+
+            // entry 0 BIN: addr = toOffset(Ptr(textNormal)) = textNormal, pointer = slot table+0, size 0.
+            Address e0 = list.Single(a => a.DataType == Address.DataTypeEnum.BIN && a.Pointer == table + 0);
+            Assert.Equal(textNormal, e0.Addr);
+            Assert.Equal(0u, e0.Length);
+            Assert.Equal("Text " + U.ToHexString(0u), e0.Info);
+
+            // entry 1 BIN: addr = 0x1500 (un-Huffman decoded), pointer = slot table+4, size 0.
+            Address e1 = list.Single(a => a.DataType == Address.DataTypeEnum.BIN && a.Pointer == table + 4);
+            Assert.Equal(0x1500u, e1.Addr);
+            Assert.Equal(0u, e1.Length);
+            Assert.Equal("Text " + U.ToHexString(1u), e1.Info);
+        }
+
+        [Fact]
+        public void EmitTextAt_RamPointerEntry_CountedButNotEmitted()
+        {
+            // WF Init's IsDataExists counts a RAM-pointer slot (Is_RAMPointerArea) toward DataCount, but
+            // the per-entry loop emits NO AddAddress for it (the target lives in RAM, not ROM). Reproduce
+            // exactly: the entry contributes to the main IFR length but produces no BIN.
+            var rom = CreateTestRom(0x8000);
+            CoreState.SystemTextEncoder = null;
+
+            uint pointer = 0x0400;
+            uint table = 0x1000;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u32(table + 0 * 4, 0x03000100);   // is_03RAMPointer -> counted, NOT emitted
+            rom.write_u32(table + 1 * 4, 0x00000005);   // terminates -> count 1
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitTextAt(rom, list, pointer);
+
+            Address main = list.Single(a => a.DataType == Address.DataTypeEnum.TEXTPOINTERS);
+            Assert.Equal(4u * (1 + 1), main.Length);    // count 1 -> length 8
+            // No BIN sub-block emitted for the RAM-pointer entry.
+            Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.BIN);
+        }
+
+        [Fact]
+        public void EmitTextAt_NearEof_NoThrow()
+        {
+            var rom = CreateTestRom(0x1000);
+            CoreState.SystemTextEncoder = null;
+            // Slot near EOF: the +3 guard before p32 must prevent any out-of-bounds read.
+            uint pointer = (uint)rom.Data.Length - 2;
+            var list = new List<Address>();
+            Assert.Null(Record.Exception(() =>
+                RebuildProducerCore.EmitTextAt(rom, list, pointer)));
+            Assert.Empty(list);
+        }
+
+        // ---- EmitFE8SpellMenuExtendsAt: main IFR + per-entry NestedIfr -------
+
+        [Fact]
+        public void EmitFE8SpellMenuExtendsAt_MainIfr_AndPerEntryNestedIfr()
+        {
+            var rom = CreateTestRom(0x10000);
+            uint assignLevelUpP = 0x0400;   // the patch-resolved pointer slot
+            uint table = 0x1000;            // base = p32(assignLevelUpP)
+            uint lv0 = 0x2000;              // entry 0 level-up list (N1 sub-table)
+            uint lv1 = 0x3000;              // entry 1 level-up list
+            rom.write_u32(assignLevelUpP, Ptr(table));
+
+            // The main IFR rule is i < 0xFF (a pure count). To bound the synthetic test, plant level-up
+            // pointers in only the first 2 slots and rely on the getBlockDataCount walk: with rule i<0xFF
+            // it would count to 0xFF, so cap the table region by ROM size — instead verify the per-entry
+            // NestedIfr emission for the two populated slots, and that the main IFR is present.
+            rom.write_u32(table + 0 * 4, Ptr(lv0));   // entry 0 -> N1 @ table+0
+            rom.write_u32(table + 1 * 4, Ptr(lv1));   // entry 1 -> N1 @ table+4
+
+            // N1 sub-table block 2, rule u16 != 0xFFFF && != 0:
+            // lv0: 3 valid u16 then 0x0000 terminator -> count 3 -> length 2*(3+1)=8.
+            rom.write_u16(lv0 + 0, 0x0101);
+            rom.write_u16(lv0 + 2, 0x0202);
+            rom.write_u16(lv0 + 4, 0x0303);
+            rom.write_u16(lv0 + 6, 0x0000);
+            // lv1: 1 valid u16 then 0xFFFF terminator -> count 1 -> length 2*(1+1)=4.
+            rom.write_u16(lv1 + 0, 0x0505);
+            rom.write_u16(lv1 + 2, 0xFFFF);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitFE8SpellMenuExtendsAt(rom, list, assignLevelUpP);
+
+            // Main IFR: base = table, block 4, pointer = slot, PI {}, type InputFormRef.
+            Address main = list.Single(a => a.Info == "SkillAssignmentUnitSkillSystem");
+            Assert.Equal(table, main.Addr);
+            Assert.Equal(assignLevelUpP, main.Pointer);
+            Assert.Equal(4u, main.BlockSize);
+            Assert.Equal(Address.DataTypeEnum.InputFormRef, main.DataType);
+            Assert.Empty(main.PointerIndexes);
+
+            // Per-entry NestedIfr @ table+0 (lv0) and table+4 (lv1).
+            Address n0 = list.Single(a => a.Info == "SkillAssignmentUnitSkillSystem.Levelup0");
+            Assert.Equal(lv0, n0.Addr);
+            Assert.Equal(table + 0, n0.Pointer);
+            Assert.Equal(2u, n0.BlockSize);
+            Assert.Equal(8u, n0.Length);          // count 3 -> 2*(3+1)
+            Assert.Empty(n0.PointerIndexes);
+            Assert.Equal(Address.DataTypeEnum.InputFormRef, n0.DataType);
+
+            Address n1 = list.Single(a => a.Info == "SkillAssignmentUnitSkillSystem.Levelup1");
+            Assert.Equal(lv1, n1.Addr);
+            Assert.Equal(table + 4, n1.Pointer);
+            Assert.Equal(4u, n1.Length);          // count 1 -> 2*(1+1)
+        }
+
+        [Fact]
+        public void EmitFE8SpellMenuExtendsAt_UnsafeLevelupList_ContinuesWithoutNested()
+        {
+            // WF: !isSafetyOffset(levelupList) -> continue (no nested table for that entry, but the loop
+            // keeps going). A NULL level-up pointer must skip ONLY that entry's NestedIfr.
+            var rom = CreateTestRom(0x10000);
+            uint assignLevelUpP = 0x0400;
+            uint table = 0x1000;
+            uint lv1 = 0x3000;
+            rom.write_u32(assignLevelUpP, Ptr(table));
+            rom.write_u32(table + 0 * 4, 0x00000000);  // entry 0 NULL -> continue (no nested)
+            rom.write_u32(table + 1 * 4, Ptr(lv1));    // entry 1 valid
+            rom.write_u16(lv1 + 0, 0x0707);
+            rom.write_u16(lv1 + 2, 0x0000);            // count 1
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitFE8SpellMenuExtendsAt(rom, list, assignLevelUpP);
+
+            Assert.Contains(list, a => a.Info == "SkillAssignmentUnitSkillSystem");
+            Assert.DoesNotContain(list, a => a.Info == "SkillAssignmentUnitSkillSystem.Levelup0");
+            Assert.Contains(list, a => a.Info == "SkillAssignmentUnitSkillSystem.Levelup1");
+        }
+
+        [Fact]
+        public void EmitFE8SpellMenuExtendsAt_NotFoundPointer_EmitsNothing()
+        {
+            var rom = CreateTestRom();
+            var list = new List<Address>();
+            RebuildProducerCore.EmitFE8SpellMenuExtendsAt(rom, list, U.NOT_FOUND);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitFE8SpellMenuExtendsAt_NearEof_NoThrow()
+        {
+            var rom = CreateTestRom(0x1000);
+            uint assignLevelUpP = (uint)rom.Data.Length - 2;   // slot near EOF
+            var list = new List<Address>();
+            Assert.Null(Record.Exception(() =>
+                RebuildProducerCore.EmitFE8SpellMenuExtendsAt(rom, list, assignLevelUpP)));
+            Assert.Empty(list);
+        }
+
+        // ---- coverage tracker: slice 2m drops Text*/FE8SpellMenu, keeps siblings -
+
+        [Fact]
+        public void GetNotYetPortedForms_DropsSlice2mCoveredForms_KeepsDeferredSiblings()
+        {
+            string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
+
+            // slice 2m ports TextForm + TextCharCodeForm + FE8SpellMenuExtendsForm.
+            Assert.DoesNotContain("TextForm", notYet);
+            Assert.DoesNotContain("TextCharCodeForm", notYet);
+            Assert.DoesNotContain("FE8SpellMenuExtendsForm", notYet);
+
+            // OtherTextForm STAYS — it iterates a config FILE (other_text_*), not a RomInfo table.
+            Assert.Contains("OtherTextForm", notYet);
+            // ImageUnitMoveIconFrom STAYS — its AP length needs ImageUtilAP.CalcAPLength (not in Core).
+            Assert.Contains("ImageUnitMoveIconFrom", notYet);
+            // MapSettingForm STAYS — its count rule needs the WF cached text count.
+            Assert.Contains("MapSettingForm", notYet);
+
+            // the no-duplicates invariant still holds after the edits.
+            string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
+            Assert.Equal(raw.Length, raw.Distinct().Count());
+        }
+
+        // ---- real-FE8U: TextForm decodes real Huffman text sizes -------------
+
+        [Fact]
+        public void EmitText_FE8U_DecodesRealHuffmanTextSizes()
+        {
+            string romPath = FindTestRom();
+            if (romPath == null) return; // skip when no ROM available (env-only)
+
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var rom = new ROM();
+                if (!rom.Load(romPath, out string _)) return; // skip
+                CoreState.ROM = rom;
+                if (rom.RomInfo.version != 8) return; // FE8U-specific
+                // huffman_decode needs a SystemTextEncoder (it decodes the string while sizing it).
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitText(rom, list);
+
+                // Main TEXTPOINTERS IFR present at p32(text_pointer), block 4, PI {0}.
+                uint textBase = rom.p32(rom.RomInfo.text_pointer);
+                Address main = list.Single(a => a.DataType == Address.DataTypeEnum.TEXTPOINTERS);
+                Assert.Equal(textBase, main.Addr);
+                Assert.Equal(4u, main.BlockSize);
+                Assert.Equal(new uint[] { 0 }, main.PointerIndexes);
+
+                // With a real encoder the per-entry BIN sub-blocks must carry a NON-zero Huffman length
+                // for at least some entries (proves huffman_decode was actually invoked, not the
+                // pointer-only fallback).
+                int sizedBin = list.Count(a => a.DataType == Address.DataTypeEnum.BIN
+                    && a.Info != null && a.Info.StartsWith("Text ") && a.Length > 0);
+                Assert.True(sizedBin > 0, "expected at least one Huffman-sized Text BIN sub-block");
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
         }
     }
 }

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -647,7 +647,8 @@ namespace FEBuilderGBA
             // IsUnHuffmanPatchPointer || Is_RAMPointerArea) with a text_recover_address ReInit fallback,
             // and each entry's BIN length is a Huffman/UnHuffman decode (FETextDecode.huffman_decode /
             // UnHffmanPatchDecode — both headless Core methods, called directly, internally EOF-hardened).
-            // A dedicated emitter reproduces it (its own cancel-check mirrors the WF DoEvents posture).
+            // A dedicated emitter reproduces it; the dispatch below cancel-checks BEFORE calling it
+            // (mirroring the WF DoEvents posture — EmitText itself takes no token / has no inner check).
             // TextCharCodeForm is a flat U8NotEqual descriptor in BuildBatchDescriptors (version-agnostic).
             if (ct.IsCancellationRequested)
             {
@@ -2944,7 +2945,11 @@ namespace FEBuilderGBA
                     int size = 0;
                     if (hasEncoder)
                     {
-                        textdecoder.UnHffmanPatchDecode(unhuffmanAddr, out size);
+                        // The decoders throw FETextException on a broken mask/tree (malformed ROM). The
+                        // producer must NOT abort the whole run — fall back to size 0 (the slot is still
+                        // relocated + target recorded, matching the no-encoder isPointerOnly path).
+                        try { textdecoder.UnHffmanPatchDecode(unhuffmanAddr, out size); }
+                        catch (FETextDecode.FETextException) { size = 0; }
                     }
                     Address.AddAddress(list, unhuffmanAddr, (uint)size, arlistAddr,
                         "Text " + U.ToHexString(i), Address.DataTypeEnum.BIN);
@@ -2955,7 +2960,8 @@ namespace FEBuilderGBA
                     int size = 0;
                     if (hasEncoder)
                     {
-                        textdecoder.huffman_decode(addr, out size);
+                        try { textdecoder.huffman_decode(addr, out size); }
+                        catch (FETextDecode.FETextException) { size = 0; }
                     }
                     Address.AddAddress(list, addr, (uint)size, arlistAddr,
                         "Text " + U.ToHexString(i), Address.DataTypeEnum.BIN);

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -641,6 +641,22 @@ namespace FEBuilderGBA
             progress?.Report("ItemWeaponEffect");
             EmitItemWeaponEffect(rom, list);
 
+            // ---- slice 2m: TextForm (Huffman text; version-agnostic) ----
+            // TextForm.MakeAllDataLength is in the WF unconditional section (NOT version-gated). It is NOT
+            // a flat StructDescriptor walk: its main IFR has a multi-branch IsDataExists (isPointer ||
+            // IsUnHuffmanPatchPointer || Is_RAMPointerArea) with a text_recover_address ReInit fallback,
+            // and each entry's BIN length is a Huffman/UnHuffman decode (FETextDecode.huffman_decode /
+            // UnHffmanPatchDecode — both headless Core methods, called directly, internally EOF-hardened).
+            // A dedicated emitter reproduces it (its own cancel-check mirrors the WF DoEvents posture).
+            // TextCharCodeForm is a flat U8NotEqual descriptor in BuildBatchDescriptors (version-agnostic).
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("Text");
+            EmitText(rom, list);
+
             // ---- slice 2h: SupportUnit (all versions) + WorldMapPath (FE8-only) ----
             // SupportUnitForm is called in the WF version==8 AND version==7 branches (block 24); the
             // SupportUnitFE6Form variant in version==6 (block 32). EmitSupportUnit auto-selects the
@@ -709,6 +725,21 @@ namespace FEBuilderGBA
                     }
                     progress?.Report("ExtraUnitFE8U");
                     EmitExtraUnitFE8U(rom, list);
+
+                    // ---- slice 2m: FE8SpellMenuExtends (FE8U ONLY) ----
+                    // WF calls FE8SpellMenuExtendsForm.MakeAllDataLength inside `version==8 &&
+                    // !is_multibyte` (alongside OPClassDemoFE8U/ExtraUnitFE8U). Its base is resolved by a
+                    // patch-signature scan (FE8SpellMenuPatchScanner — the Core port of WF
+                    // FindFE8SpellPatchPointer; both OldSystem .dmp grep + hard-coded SkillSystems202201
+                    // signature, version/multibyte-gated, NOT_FOUND on a non-patched ROM). Per entry it
+                    // emits a NestedIfr (the slice-2i primitive). Gate EXACTLY as WF.
+                    if (ct.IsCancellationRequested)
+                    {
+                        progress?.Report("MakeAllStructPointersList cancelled");
+                        return new ProducerResult(list, notYet, cancelled: true);
+                    }
+                    progress?.Report("FE8SpellMenuExtends");
+                    EmitFE8SpellMenuExtends(rom, list);
                 }
 
                 // ---- slice 2k: WorldMapImageForm + ImageCGForm (FE8) ----
@@ -2813,6 +2844,242 @@ namespace FEBuilderGBA
         }
 
         // ===================================================================
+        // slice 2m — now-tractable subsystem forms: Huffman text (TextForm) +
+        // the FE8U Gaiden-style spell-menu (FE8SpellMenuExtendsForm). Both are
+        // dedicated emitters: TextForm's main IFR has a custom multi-branch
+        // IsDataExists + a text_recover_address ReInit fallback and a per-entry
+        // Huffman/UnHuffman length sub-walk; FE8SpellMenuExtends resolves its base
+        // via a patch-signature scan (FE8SpellMenuPatchScanner) and emits a
+        // NestedIfr per entry. (TextCharCodeForm is a flat U8NotEqual descriptor
+        // in BuildBatchDescriptors.)
+        // ===================================================================
+
+        /// <summary>
+        /// <c>TextForm.MakeAllDataLength</c> (slice 2m, version-agnostic call site). The Huffman text
+        /// pointer table. Reproduces <c>TextForm.Init</c> + the per-entry length expansion VERBATIM:
+        /// <list type="bullet">
+        ///   <item>Main IFR: base = <c>p32(text_pointer)</c> (or, when that is an unsafe offset,
+        ///   <c>text_recover_address</c> — the WF <c>Init</c> ReInit fallback for a broken text pointer),
+        ///   block 4, pointer = the <c>text_pointer</c> slot, type
+        ///   <see cref="Address.DataTypeEnum.TEXTPOINTERS"/>, pointerIndexes <c>{0}</c>. IsDataExists =
+        ///   <c>isPointer(u32(addr)) || FETextEncode.IsUnHuffmanPatchPointer(u32(addr)) ||
+        ///   TextForm.Is_RAMPointerArea(u32(addr))</c> (reproduced via <see cref="IsTextEntryExists"/>).</item>
+        ///   <item>Per entry <c>i</c> at slot <c>arlistAddr = base + i*4</c>: read
+        ///   <c>paddr = u32(arlistAddr)</c>. If <c>IsUnHuffmanPatchPointer(paddr)</c> -&gt; the BIN block at
+        ///   <c>toOffset(ConvertUnHuffmanPatchToPointer(paddr))</c> with length =
+        ///   <c>FETextDecode.UnHffmanPatchDecode(addr, out size)</c>; else if <c>isPointer(paddr)</c> -&gt;
+        ///   the BIN block at <c>toOffset(paddr)</c> with length =
+        ///   <c>FETextDecode.huffman_decode(addr, out size)</c>. Both via
+        ///   <c>Address.AddAddress(list, addr, size, arlistAddr, "Text " + ToHexString(i), BIN)</c>
+        ///   VERBATIM. (The WF <c>Is_RAMPointerArea</c> branch in IsDataExists has no matching AddAddress
+        ///   in the per-entry loop — a RAM-pointer slot counts toward DataCount but its target lives in RAM,
+        ///   not ROM, so nothing is relocated. Reproduced exactly: counted, not emitted.)</item>
+        /// </list>
+        /// The length helpers (<c>huffman_decode</c> / <c>UnHffmanPatchDecode</c>) are CALLED directly
+        /// (both are headless Core methods, batch 10) — not reproduced. They are both internally
+        /// EOF-hardened (each <c>isSafetyOffset</c>-checks the addr and guards every raw read against
+        /// <c>Data.Length</c>) and return a truncated size near EOF rather than throwing. They DO decode
+        /// the string into text (via <c>SystemTextEncoder</c>) as a side effect of computing the size, so
+        /// when no encoder is loaded the producer falls back to a pointer-only emit (size 0) — exactly the
+        /// WF <c>isPointerOnly</c> branch (which sets <c>size = 0</c> but still emits the AddAddress). A
+        /// pointer-only emit still relocates the text-pointer slot AND records the target addr; the wiring
+        /// slice's <see cref="ProducerResult.IsComplete"/> gate already refuses a partial scan, so a
+        /// no-encoder run is never fed to a real defragment.
+        /// </summary>
+        public static void EmitText(ROM rom, List<Address> list)
+        {
+            EmitTextAt(rom, list, rom.RomInfo.text_pointer);
+        }
+
+        /// <summary>TextForm walk from an explicit <c>text_pointer</c> slot (test seam — lets a synthetic
+        /// ROM supply it without populating RomInfo). See <see cref="EmitText"/> for the verbatim WF
+        /// reproduction.</summary>
+        public static void EmitTextAt(ROM rom, List<Address> list, uint rawPointer)
+        {
+            const uint block = 4;
+
+            // Main IFR: BasePointer = toOffset(slot), BaseAddress = p32(BasePointer). Guard the full
+            // slot before p32 (root+3). Matches InputFormRef.Init (toOffset then p32, both safety-checked).
+            uint pointer = U.toOffset(rawPointer);
+            if (!U.isSafetyOffset(pointer + 3, rom))
+            {
+                return;
+            }
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                // WF TextForm.Init: a broken text pointer ReInits to text_recover_address.
+                baseAddr = U.toOffset(rom.RomInfo.text_recover_address);
+                if (!U.isSafetyOffset(baseAddr, rom))
+                {
+                    return;
+                }
+            }
+
+            // IsDataExists (TextForm.Init): isPointer(u32(addr)) || IsUnHuffmanPatchPointer(u32(addr)) ||
+            // Is_RAMPointerArea(u32(addr)). getBlockDataCount guards addr+block(4)<=Length, so u32(addr)
+            // is always in-bounds.
+            uint dataCount = rom.getBlockDataCount(baseAddr, block,
+                (i, addr) => IsTextEntryExists(rom, rom.u32(addr)));
+
+            // AddressWinForms.AddAddress(list, IFR, "Text", {0}, TEXTPOINTERS): length = block*(count+1).
+            uint length = block * (dataCount + 1);
+            list.Add(new Address(baseAddr, length, pointer, "Text",
+                Address.DataTypeEnum.TEXTPOINTERS, block, new uint[] { 0 }));
+
+            // Per-entry expansion. getBlockDataCount guarantees addr+block(4)<=Length for i<dataCount,
+            // so u32(arlistAddr) (deepest arlistAddr+3) is in bounds. The decoders compute the size only
+            // when an encoder is loaded (they decode the string as a side effect of sizing); without one
+            // the WF isPointerOnly path is taken (size 0). The slot is relocated either way.
+            bool hasEncoder = CoreState.SystemTextEncoder != null;
+            FETextDecode textdecoder = hasEncoder ? new FETextDecode(rom, CoreState.SystemTextEncoder) : null;
+
+            uint arlistAddr = baseAddr;
+            for (uint i = 0; i < dataCount; i++, arlistAddr += block)
+            {
+                uint paddr = rom.u32(arlistAddr);
+                if (FETextEncode.IsUnHuffmanPatchPointer(paddr))
+                {//un-huffman patch?
+                    uint unhuffmanAddr = U.toOffset(FETextEncode.ConvertUnHuffmanPatchToPointer(paddr));
+                    int size = 0;
+                    if (hasEncoder)
+                    {
+                        textdecoder.UnHffmanPatchDecode(unhuffmanAddr, out size);
+                    }
+                    Address.AddAddress(list, unhuffmanAddr, (uint)size, arlistAddr,
+                        "Text " + U.ToHexString(i), Address.DataTypeEnum.BIN);
+                }
+                else if (U.isPointer(paddr))
+                {
+                    uint addr = U.toOffset(paddr);
+                    int size = 0;
+                    if (hasEncoder)
+                    {
+                        textdecoder.huffman_decode(addr, out size);
+                    }
+                    Address.AddAddress(list, addr, (uint)size, arlistAddr,
+                        "Text " + U.ToHexString(i), Address.DataTypeEnum.BIN);
+                }
+                // else (Is_RAMPointerArea-only): counted toward DataCount but target is in RAM — WF emits
+                // no AddAddress for it, so neither do we (nothing to relocate in ROM).
+            }
+        }
+
+        /// <summary>VERBATIM port of the <c>TextForm.Init</c> IsDataExists predicate + the
+        /// <c>TextForm.Is_RAMPointerArea</c> helper it calls: a text-table slot value <paramref name="p"/>
+        /// "exists" when it is a ROM pointer, an un-Huffman patch pointer, OR a RAM-pointer-area value
+        /// (<c>is_03RAMPointer || IsUnHuffmanPatch_IW_RAMPointer || is_02RAMPointer ||
+        /// IsUnHuffmanPatch_EW_RAMPointer</c>). All pure value tests (no ROM read), so EOF-safe.</summary>
+        public static bool IsTextEntryExists(ROM rom, uint p)
+        {
+            if (U.isPointer(p))
+            {
+                return true;
+            }
+            if (FETextEncode.IsUnHuffmanPatchPointer(p))
+            {//海外改造によくある unHuffman patch
+                return true;
+            }
+            // TextForm.Is_RAMPointerArea(p): RAM-resident text data.
+            return U.is_03RAMPointer(p)
+                || FETextEncode.IsUnHuffmanPatch_IW_RAMPointer(p)
+                || U.is_02RAMPointer(p)
+                || FETextEncode.IsUnHuffmanPatch_EW_RAMPointer(p);
+        }
+
+        /// <summary>
+        /// <c>FE8SpellMenuExtendsForm.MakeAllDataLength</c> (slice 2m; FE8U ONLY — gated at the WF
+        /// <c>version == 8 &amp;&amp; !is_multibyte</c> call site, alongside OPClassDemoFE8U/ExtraUnitFE8U).
+        /// The Gaiden-style per-unit spell (level-up) menu. The table base is NOT a RomInfo slot: it is
+        /// resolved by a patch-signature scan, reproduced by
+        /// <see cref="FE8SpellMenuPatchScanner.FindFE8SpellPatchPointer"/> (the Core port of WF
+        /// <c>FindFE8SpellPatchPointer</c> — both the OldSystem <c>SpellsGetter.dmp</c> grep and the
+        /// hard-coded SkillSystems202201 signature; it also reproduces WF's version/multibyte gate and
+        /// returns <see cref="U.NOT_FOUND"/> when neither path matches, so a non-patched ROM emits
+        /// nothing). VERBATIM:
+        /// <list type="bullet">
+        ///   <item><c>assignLevelUpP = FindFE8SpellPatchPointer()</c>; if NOT_FOUND return.</item>
+        ///   <item><c>assignLevelUpAddr = p32(assignLevelUpP)</c>; if NOT_FOUND return.</item>
+        ///   <item>Main IFR: base <c>assignLevelUpP</c>, block 4, IsDataExists = <c>i &lt; 0xFF</c>, name
+        ///   "SkillAssignmentUnitSkillSystem", pointerIndexes EMPTY (WF <c>new uint[] {}</c>).</item>
+        ///   <item>Per main entry <c>i &lt; DataCount</c>, <c>assignLevelUpAddr += 4</c>: if
+        ///   <c>!isSafetyOffset(assignLevelUpAddr)</c> BREAK; <c>levelupList = p32(assignLevelUpAddr)</c>;
+        ///   if <c>!isSafetyOffset(levelupList)</c> CONTINUE; else a nested IFR @ <c>assignLevelUpAddr</c>
+        ///   (the N1 table: block 2, IsDataExists = <c>u16(addr) != 0xFFFF &amp;&amp; u16(addr) != 0</c>),
+        ///   name "SkillAssignmentUnitSkillSystem.Levelup" + i.</item>
+        /// </list>
+        /// The nested IFR is emitted via <see cref="EmitNestedIfrSub"/> (the slice-2i primitive). The WF
+        /// loop's break/continue order is reproduced exactly (note: the break tests
+        /// <c>assignLevelUpAddr</c> AFTER it was advanced, mirroring the WF <c>for</c> increment).
+        /// </summary>
+        public static void EmitFE8SpellMenuExtends(ROM rom, List<Address> list)
+        {
+            uint assignLevelUpP = FE8SpellMenuPatchScanner.FindFE8SpellPatchPointer(rom, CoreState.BaseDirectory);
+            EmitFE8SpellMenuExtendsAt(rom, list, assignLevelUpP);
+        }
+
+        /// <summary>FE8SpellMenuExtends walk from an explicit <c>assignLevelUpP</c> pointer slot (test
+        /// seam — lets a synthetic ROM supply it without the patch-signature scan / RomInfo). See
+        /// <see cref="EmitFE8SpellMenuExtends"/> for the verbatim WF reproduction.</summary>
+        public static void EmitFE8SpellMenuExtendsAt(ROM rom, List<Address> list, uint assignLevelUpP)
+        {
+            const uint block = 4;
+
+            if (assignLevelUpP == U.NOT_FOUND)
+            {
+                return;
+            }
+            // WF reads p32(assignLevelUpP) directly after the NOT_FOUND check. p32 toOffsets + reads; guard
+            // the full slot (root+3) first so a near-EOF pointer emits nothing instead of throwing.
+            uint slot = U.toOffset(assignLevelUpP);
+            if (!U.isSafetyOffset(slot + 3, rom))
+            {
+                return;
+            }
+            uint assignLevelUpAddr = rom.p32(slot);
+            if (assignLevelUpAddr == U.NOT_FOUND)
+            {
+                return;
+            }
+
+            // Main IFR: base = p32(assignLevelUpP) (already in assignLevelUpAddr — but Init's BaseAddress is
+            // ALSO p32(slot); WF AddAddress uses the IFR BaseAddress). IsDataExists = i < 0xFF (a pure
+            // count, no ROM read). pointerIndexes EMPTY. Skip if the resolved base is unsafe.
+            if (!U.isSafetyOffset(assignLevelUpAddr, rom))
+            {
+                return;
+            }
+            uint dataCount = rom.getBlockDataCount(assignLevelUpAddr, block, (i, addr) => i < 0xFF);
+            uint length = block * (dataCount + 1);
+            list.Add(new Address(assignLevelUpAddr, length, slot, "SkillAssignmentUnitSkillSystem",
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { }));
+
+            // Per main entry: advance assignLevelUpAddr by 4 FIRST (WF for-increment), then the break/
+            // continue guards. The nested N1 table (block 2, u16 != 0xFFFF && != 0) is emitted via the
+            // slice-2i NestedIfr primitive (ReInitPointer(assignLevelUpAddr) + AddAddress(N1, ..., {})).
+            for (uint i = 0; i < dataCount; i++, assignLevelUpAddr += block)
+            {
+                if (!U.isSafetyOffset(assignLevelUpAddr, rom))
+                {
+                    break;
+                }
+                uint levelupList = rom.p32(assignLevelUpAddr);
+                if (!U.isSafetyOffset(levelupList, rom))
+                {
+                    continue;
+                }
+                // N1_Init: block 2, IsDataExists = u16(addr) != 0xFFFF && u16(addr) != 0.
+                EmitNestedIfrSub(rom, list, assignLevelUpAddr, 2,
+                    (j, addr) =>
+                    {
+                        uint a = rom.u16(addr);
+                        return a != 0xFFFF && a != 0;
+                    },
+                    "SkillAssignmentUnitSkillSystem.Levelup" + i);
+            }
+        }
+
+        // ===================================================================
         // slice 2i — nested count-walked IFR sub-table (SubKind.NestedIfr) +
         // the OPClassDemo / OPClassDemoFE7 forms (version-gated multibyte).
         // Each form runs, per main-table entry, one or two N_IFR sub-tables
@@ -4714,6 +4981,24 @@ namespace FEBuilderGBA
                 PointerIndexes = new uint[] { },
             });
 
+            // TextCharCodeForm.MakeAllDataLength (slice 2m) — the Huffman char-code (mask) table.
+            // WF Init: base mask_pointer, block 4, IsDataExists = u8(addr) != 255, then
+            // AddAddress(list, IFR, "TextCharCode", new uint[] {}) — EMPTY pointerIndexes, default
+            // (InputFormRef) DataType. This is a flat single-table walk with no embedded sub-pointer,
+            // so it maps 1:1 onto the DataCountRule.U8NotEqual descriptor (@ offset 0, stop 255).
+            // The per-entry getString/FETextEncode name in WF's display callback is non-load-bearing
+            // for relocation (the producer needs only addr/length/pointer), so it is not reproduced.
+            l.Add(new StructDescriptor
+            {
+                Name = "TextCharCode",
+                PointerField = r => r.RomInfo.mask_pointer,
+                BlockSize = 4,
+                Rule = DataCountRule.U8NotEqual,
+                RuleOffset = 0,
+                RuleStopValue = 255,
+                PointerIndexes = new uint[] { },
+            });
+
             // ---- version==8 (FE8) section ----
             // These forms are called ONLY inside the WinForms `if (version == 8)` branch, in this
             // order. Their data pointers are 0 on FE6/FE7 (EmitOne skips a 0/unsafe pointer), but
@@ -5495,10 +5780,22 @@ namespace FEBuilderGBA
                 "Command85PointerForm",
                 // text (Huffman)
                 // (MapTerrainNameForm ported in slice 2c — per-entry string-BIN sub-walk; TextDicForm
-                //  ported in this sweep — 3 clean tables (dic_main/chaptor/title). OtherTextForm STAYS:
-                //  it iterates a config file `other_text_*` (U.ConfigDataFilename), not a RomInfo table,
-                //  so it has a headless config-file dependency, not ROM-derived data.)
-                "TextForm", "TextCharCodeForm", "OtherTextForm",
+                //  ported in this sweep — 3 clean tables (dic_main/chaptor/title).
+                //  TextForm + TextCharCodeForm ported in slice 2m:
+                //    TextCharCodeForm — a flat U8NotEqual descriptor (base mask_pointer, block 4, stop
+                //      255, pointerIndexes {}).
+                //    TextForm — a dedicated emitter (EmitText): main IFR (base p32(text_pointer) with the
+                //      text_recover_address ReInit fallback, block 4, multi-branch IsDataExists =
+                //      isPointer || IsUnHuffmanPatchPointer || Is_RAMPointerArea via IsTextEntryExists,
+                //      TEXTPOINTERS, {0}) + a per-entry BIN sub-walk whose length is the Huffman/UnHuffman
+                //      decode (FETextDecode.huffman_decode / UnHffmanPatchDecode — both headless Core
+                //      methods, batch 10, called directly and internally EOF-hardened). The decoders need
+                //      a SystemTextEncoder to size (they decode the string as a side effect); without one
+                //      the producer falls back to the WF isPointerOnly side (size 0) — the slot is still
+                //      relocated and the target addr recorded, and IsComplete already gates a partial scan.
+                //  OtherTextForm STAYS: it iterates a config file `other_text_*` (U.ConfigDataFilename),
+                //  not a RomInfo table, so it has a headless config-file dependency, not ROM-derived data.)
+                "OtherTextForm",
                 // images (LZ77/TSA length calc)
                 // (slice 2e ported the FLAT LZ77-image + palette forms whose every length is
                 //  LZ77.getCompressedSize (EOF-safe) or a CONSTANT palette/image size:
@@ -5688,15 +5985,19 @@ namespace FEBuilderGBA
                 //    extracted MapSettingCore.IsMapSettingValid diverges (its `if (textmax>0)` guard
                 //    returns true when textmax==0, where WF returns false), so the per-entry CString
                 //    count is not yet faithfully reproducible — a wrong count = silent corruption.
-                //  FE8SpellMenuExtendsForm [FindFE8SpellPatchPointer]. (ImageCGFE7UForm ported in slice 2k —
-                //  EmitImageCGFE7U, the FE7U 16-byte big-CG IFR with the per-entry flag@+0 16-color-vs-
-                //  10-split + HEADER-TSA.))
+                //  (FE8SpellMenuExtendsForm ported in slice 2m — EmitFE8SpellMenuExtends, FE8U-only: the
+                //   base is resolved by the patch-signature scan FE8SpellMenuPatchScanner.FindFE8Spell-
+                //   PatchPointer (the Core port of WF FindFE8SpellPatchPointer — OldSystem .dmp grep +
+                //   hard-coded SkillSystems202201 signature, version/multibyte-gated, NOT_FOUND on a
+                //   non-patched ROM), main IFR (block 4, rule i<0xFF, PI {}), per entry a NestedIfr @
+                //   assignLevelUpAddr (block 2, u16 != 0xFFFF && != 0) via the slice-2i primitive.)
+                //  (ImageCGFE7UForm ported in slice 2k — EmitImageCGFE7U, the FE7U 16-byte big-CG IFR
+                //   with the per-entry flag@+0 16-color-vs-10-split + HEADER-TSA.))
                 "MonsterWMapProbabilityForm",
                 "EventBattleTalkForm",
                 "WorldMapEventPointerForm",
                 "EventHaikuForm",
                 "MapSettingForm",
-                "FE8SpellMenuExtendsForm",
                 // patch / procs / ASM — OUT OF SCOPE for this data-path producer: these are emitted by
                 // U.AppendAllASMStructPointersList (the ASM/LDR-map path), NOT U.MakeAllStructPointersList.
                 // (EventFunctionPointerForm / Command85PointerForm above are likewise ASM-path forms.)


### PR DESCRIPTION
## Summary
**Slice 2m** of #1261 — the **Huffman-text + FE8 spell-menu** forms, now tractable because their helpers are already in Core. No reproduced length helper this slice (the text path calls Core decoders directly; the spell-menu reuses the Core scanner).

## Ported (3 forms — VERBATIM vs WF `MakeAllDataLength`, version-gated)
- **TextCharCodeForm** [version-agnostic, WF `U.cs:2434`] — flat `StructDescriptor`: base `mask_pointer`, block 4, `DataCountRule.U8NotEqual @0` stop `255`, PI `{}`, `InputFormRef`. 1:1 with WF `Init`.
- **TextForm** [version-agnostic, WF `U.cs:2428`] via `EmitText`/`EmitTextAt` — main `TEXTPOINTERS` IFR (base `p32(text_pointer)` with the WF `text_recover_address` ReInit fallback, block 4, PI `{0}`); the multi-branch IsDataExists (`isPointer || IsUnHuffmanPatchPointer || Is_RAMPointerArea`) reproduced verbatim as `IsTextEntryExists`. Per-entry BIN sub-walk length = **`FETextDecode.huffman_decode` / `UnHffmanPatchDecode` called DIRECTLY** (already in Core from batch 10, internally EOF-hardened — not reproduced). No encoder → the WF `isPointerOnly` path (size 0, slot still relocated + target recorded); RAM-pointer slots counted-but-not-emitted (target in RAM), matching WF exactly.
- **FE8SpellMenuExtendsForm** [**FE8U-only**: `version==8 && !is_multibyte`, in the `else` branch alongside `ExtraUnitFE8UForm` — verified against WF `U.cs`] via `EmitFE8SpellMenuExtends`. Base from **`FE8SpellMenuPatchScanner.FindFE8SpellPatchPointer`** (the Core port from #1167 — verbatim WF: OldSystem `SpellsGetter.dmp` grep degrading to `NOT_FOUND` if the file is missing + the hard-coded `SkillSystems202201` signature; `NOT_FOUND` on a non-patched ROM). Main IFR (block 4, rule `i<0xFF`, PI `{}`) + per-entry `NestedIfr` @ `assignLevelUpAddr` (block 2, `u16!=0xFFFF && !=0`) via the slice-2i `EmitNestedIfrSub`.

## Deferred (1)
- **ImageUnitMoveIconFrom** — its per-entry AP block length is `ImageUtilAP.CalcAPLength` (= `ImageUtilAP.Parse() + GetLength()`, an AP frame/anime stream parser, ~120 lines; pure-ROM but NOT in Core, and the WF class also pulls in System.Drawing for the unrelated `DrawFrame`). Reproducing it verbatim warrants its own slice. The clamped `ClassDataCount` count rule is reproducible; only the AP length helper blocks it. Kept in `NotYetPortedRaw` with that exact reason.

## Tests
- RebuildProducer filter: **206 passed / 0 failed** (+11) — TextCharCode descriptor; `EmitTextAt` main-IFR + per-entry BIN; RAM-counted-not-emitted; near-EOF; FE8Spell main + NestedIfr; unsafe-levelup-continue; `NOT_FOUND`; near-EOF; a real-FE8U Huffman-sized decode; coverage tracker. Fixed 3 stale "deferred" assertions.
- FEBuilderGBA.Tests (net9.0-windows): no new failures (the `Skill*`/`SkillSystemsAnime*` env failures are the known `config/patch2`-absent-in-worktree ones).
- EOF self-audit confirmed (all 6 new raw `p32`/`u32`/`u16` full-extent guarded; per-entry reads block-bounded by `getBlockDataCount`).

Part of #1261.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
