### PR TITLE
feat(core): ROM-rebuild producer — ImageUnitMoveIcon AP-icon form (#1261 slice 2n)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -6163,8 +6163,9 @@ namespace FEBuilderGBA.Core.Tests
 
             // OtherTextForm STAYS — it iterates a config FILE (other_text_*), not a RomInfo table.
             Assert.Contains("OtherTextForm", notYet);
-            // ImageUnitMoveIconFrom STAYS — its AP length needs ImageUtilAP.CalcAPLength (not in Core).
-            Assert.Contains("ImageUnitMoveIconFrom", notYet);
+            // ImageUnitMoveIconFrom is PORTED in slice 2n (ImageUtilAPCore.CalcAPLength is in Core) ->
+            // it must be GONE (see GetNotYetPortedForms_DropsSlice2nMoveIcon_KeepsDeferredSiblings).
+            Assert.DoesNotContain("ImageUnitMoveIconFrom", notYet);
             // MapSettingForm STAYS — its count rule needs the WF cached text count.
             Assert.Contains("MapSettingForm", notYet);
 
@@ -6214,6 +6215,301 @@ namespace FEBuilderGBA.Core.Tests
                 CoreState.ROM = savedRom;
                 CoreState.SystemTextEncoder = savedEnc;
             }
+        }
+
+        // ====================================================================
+        // slice 2n: ImageUnitMoveIconFrom — AP (Animated-Parts) per-entry column
+        // ====================================================================
+
+        /// <summary>Hand-author a VALID, minimal AP (Animated-Parts) stream of a KNOWN length at
+        /// <paramref name="baseOff"/> and return that length. The layout (all offsets relative to base,
+        /// little-endian u16) is traced against ImageUtilAPCore.Parse / WF ImageUtilAP.Parse:
+        /// <list type="bullet">
+        ///   <item>+0  frameDataOffset = 8  (frame-pointer table at base+8)</item>
+        ///   <item>+2  animeTableOffset = 10 (anime-pointer table at base+10)</item>
+        ///   <item>+8  frame-ptr table: ONE u16 = 4 -> frame block at base+8+4 = base+12; minData = 4</item>
+        ///   <item>+10 anime-ptr table: ONE u16 = 10 -> anime block at base+10+10 = base+20</item>
+        ///   <item>+12 frame block: u16 count = 1, then 1 OAM (6 bytes) -> ends at base+20</item>
+        ///   <item>+20 anime block: {wait=5,frame=0}, {wait=0,frame=0} terminator -> ends at base+28</item>
+        /// </list>
+        /// Max extent = 28 (already 4-aligned), so GetLength() = Padding4(28) = 28. The frame-ptr table
+        /// [base+8,base+10) is exactly one u16; the anime-ptr table [base+10, base+8+minData=base+12) is
+        /// exactly one u16.</summary>
+        static uint WriteKnownAP(ROM rom, uint baseOff)
+        {
+            rom.write_u16(baseOff + 0, 8);    // frameDataOffset
+            rom.write_u16(baseOff + 2, 10);   // animeTableOffset
+            rom.write_u16(baseOff + 8, 4);    // frame-ptr table entry -> frame block @ base+12
+            rom.write_u16(baseOff + 10, 10);  // anime-ptr table entry -> anime block @ base+20
+            rom.write_u16(baseOff + 12, 1);   // frame count = 1
+            for (uint k = 14; k < 20; k++) rom.write_u8(baseOff + k, 0x11); // 1 OAM (6 bytes)
+            rom.write_u16(baseOff + 20, 5);   // anime rec1: wait=5
+            rom.write_u16(baseOff + 22, 0);   //            frame=0
+            rom.write_u16(baseOff + 24, 0);   // anime rec2: wait=0 -> terminator
+            rom.write_u16(baseOff + 26, 0);   //            frame=0
+            uint len = ImageUtilAPCore.CalcAPLength(rom.Data, baseOff);
+            Assert.Equal(28u, len); // hand-traced known length (must match the Core/WF parser)
+            return len;
+        }
+
+        [Fact]
+        public void EmitApPointer_EmitsAP_WithCalcAPLength()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint pointer = 0x0240;
+            uint apData = 0x2000;
+            uint expectLen = WriteKnownAP(rom, apData); // 28
+            rom.write_u32(pointer, Ptr(apData));
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitApPointer(rom, list, pointer, "MoveUnitIcon 0x0 AP");
+
+            Address ap = Assert.Single(list);
+            Assert.Equal(Address.DataTypeEnum.AP, ap.DataType);
+            Assert.Equal(apData, ap.Addr);
+            Assert.Equal(expectLen, ap.Length);
+            Assert.Equal(ImageUtilAPCore.CalcAPLength(rom.Data, apData), ap.Length);
+            Assert.Equal(pointer, ap.Pointer);
+            Assert.Equal("MoveUnitIcon 0x0 AP", ap.Info);
+        }
+
+        [Fact]
+        public void EmitApPointer_NullPointerSlot_NoEmit()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint pointer = 0x0240;
+            rom.write_u32(pointer, 0); // NULL target -> isSafetyPointer false -> no emit
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.EmitApPointer(rom, list, pointer, "AP"));
+            Assert.Null(ex);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitApPointer_PointerSlotNearEof_NoThrow_NoEmit()
+        {
+            var rom = CreateTestRom(0x1000);
+            // Pointer slot itself within 4 bytes of EOF -> the pointer+4 EOF guard rejects before the u32.
+            uint pointer = (uint)rom.Data.Length - 2;
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.EmitApPointer(rom, list, pointer, "AP"));
+            Assert.Null(ex);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitApPointer_MalformedAPTarget_EmitsLengthZero_NoThrow()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint pointer = 0x0240;
+            uint apData = 0x2000;
+            // animeTableOffset huge -> frame-end (base+animeTableOffset) past EOF -> Parse returns false
+            // -> CalcAPLength returns 0. The Address is still emitted (the slot is relocated), length 0.
+            rom.write_u16(apData + 0, 4);       // frameDataOffset
+            rom.write_u16(apData + 2, 0xFFFF);  // animeTableOffset -> base+0xFFFF past 0x8000 ROM end
+            rom.write_u32(pointer, Ptr(apData));
+            Assert.Equal(0u, ImageUtilAPCore.CalcAPLength(rom.Data, apData)); // confirm unparseable
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.EmitApPointer(rom, list, pointer, "AP"));
+            Assert.Null(ex);
+            Address ap = Assert.Single(list);
+            Assert.Equal(Address.DataTypeEnum.AP, ap.DataType);
+            Assert.Equal(apData, ap.Addr);
+            Assert.Equal(0u, ap.Length); // malformed -> length 0 (WF parity)
+        }
+
+        [Fact]
+        public void SubWalk_ApPointer_EmitsAP_ThroughWalkAndAdd()
+        {
+            var rom = CreateTestRom(0x8000);
+            // One-entry table at 0x1000, block 8. Entry +0 -> LZ77 image, entry +4 -> AP stream.
+            uint table = 0x1000;
+            uint pointer = 0x0240;
+            uint imageData = 0x2000;
+            uint apData = 0x3000;
+            rom.write_u32(pointer, Ptr(table));
+            rom.write_u32(table + 0, Ptr(imageData)); // embedded image pointer @ +0
+            rom.write_u32(table + 4, Ptr(apData));    // embedded AP pointer @ +4
+            uint imgLen = WriteLz77AllLiteral(rom, imageData, 100);
+            uint apLen = WriteKnownAP(rom, apData); // 28
+
+            var d = new RebuildProducerCore.StructDescriptor
+            {
+                Name = "MoveUnitIcon",
+                PointerField = _ => pointer,
+                BlockSize = 8,
+                Rule = RebuildProducerCore.DataCountRule.FixedCount,
+                RuleFixedCount = 1,
+                PointerIndexes = new uint[] { 0, 4 },
+                SubWalks = new List<RebuildProducerCore.SubWalk>
+                {
+                    new RebuildProducerCore.SubWalk
+                    {
+                        EmbeddedPointerOffset = 0,
+                        Kind = RebuildProducerCore.SubKind.Lz77Pointer,
+                        DataType = Address.DataTypeEnum.LZ77IMG,
+                        Name = (r, i) => "MoveUnitIcon " + U.To0xHexString((uint)i),
+                    },
+                    new RebuildProducerCore.SubWalk
+                    {
+                        EmbeddedPointerOffset = 4,
+                        Kind = RebuildProducerCore.SubKind.ApPointer,
+                        Name = (r, i) => "MoveUnitIcon " + U.To0xHexString((uint)i) + " AP",
+                    },
+                },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.WalkAndAdd(rom, list, d);
+
+            // main IFR (block*(1+1)=16), the LZ77IMG image, and the AP stream.
+            Address img = Assert.Single(list, a => a.DataType == Address.DataTypeEnum.LZ77IMG);
+            Assert.Equal(imageData, img.Addr);
+            Assert.Equal(imgLen, img.Length);
+            Assert.Equal(table + 0, img.Pointer);
+
+            Address ap = Assert.Single(list, a => a.DataType == Address.DataTypeEnum.AP);
+            Assert.Equal(apData, ap.Addr);
+            Assert.Equal(apLen, ap.Length);
+            Assert.Equal(table + 4, ap.Pointer); // embedded AP pointer field
+            // WF per-entry name = U.To0xHexString(i) -> "0x00" for i=0 (2-digit min); + " AP".
+            Assert.Equal("MoveUnitIcon 0x00 AP", ap.Info);
+
+            // Per-entry WF order: LZ77 (image) is emitted BEFORE the AP column.
+            int imgIdx = list.FindIndex(a => a.DataType == Address.DataTypeEnum.LZ77IMG);
+            int apIdx = list.FindIndex(a => a.DataType == Address.DataTypeEnum.AP);
+            Assert.True(imgIdx < apIdx, "WF emits AddLZ77Pointer before AddAPPointer per entry");
+        }
+
+        [Fact]
+        public void MoveUnitIconDescriptor_HasExpectedShape()
+        {
+            // BuildBatchDescriptors reads rom.RomInfo.version (Class FE6-vs-FE78 branch), so it needs a
+            // versioned ROM (CreateTestRom has a NULL RomInfo).
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                var descs = RebuildProducerCore.BuildBatchDescriptors(fe8);
+                var mui = descs.Single(d => d.Name == "MoveUnitIcon");
+
+                Assert.Equal(8u, mui.BlockSize);
+                Assert.Equal(RebuildProducerCore.DataCountRule.MoveIconRule, mui.Rule);
+                Assert.Equal(0u, mui.RuleOffset);
+                Assert.Equal(new uint[] { 0, 4 }, mui.PointerIndexes);
+                Assert.NotNull(mui.SubWalks);
+                Assert.Equal(2, mui.SubWalks.Count);
+                // @0 -> LZ77IMG (the sheet), @4 -> AP (the move-anime stream).
+                var lz = mui.SubWalks.Single(s => s.EmbeddedPointerOffset == 0);
+                Assert.Equal(RebuildProducerCore.SubKind.Lz77Pointer, lz.Kind);
+                Assert.Equal(Address.DataTypeEnum.LZ77IMG, lz.DataType);
+                var ap = mui.SubWalks.Single(s => s.EmbeddedPointerOffset == 4);
+                Assert.Equal(RebuildProducerCore.SubKind.ApPointer, ap.Kind);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+            }
+        }
+
+        [Fact]
+        public void MoveIconRule_ClassCountBounded_AndPointerOrNull()
+        {
+            // The MoveIcon table count is bounded by the class table (ClassDataCount, clamped/decremented),
+            // and per entry (after 0) requires isPointerOrNULL(u32+0). Use a versioned ROM so RomInfo
+            // (class_pointer/class_datasize/unit_move_icon_pointer) is populated.
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+
+                // --- Plant a small class table so ClassDataCount returns a known small number. ---
+                uint cblock = fe8.RomInfo.class_datasize;
+                Assert.True(cblock > 0);
+                uint classPtrLoc = U.toOffset(fe8.RomInfo.class_pointer);
+                uint classTable = 0x300000;
+                fe8.write_u32(classPtrLoc, Ptr(classTable));
+                // entry 0 always; entry1 u8(+4)=1; entry2 u8(+4)=2; entry3 u8(+4)=0 -> stop => count 3.
+                fe8.write_u8(classTable + 1 * cblock + 4, 1);
+                fe8.write_u8(classTable + 2 * cblock + 4, 2);
+                Assert.Equal(3u, RebuildProducerCore.ClassDataCount(fe8));
+                // classCount=3 -> clamp keeps 3 (in [0x7f? no: 3 < 0x7f] => actually <=0 check only).
+                // WF: if(<=0)0x7f; else if(>0xff)0xff. 3 stays 3. classCount-- => 2. So i>=2 stops:
+                // entries i=0 and i=1 only.
+
+                // --- Plant the move-icon table. ---
+                uint muiPtrLoc = U.toOffset(fe8.RomInfo.unit_move_icon_pointer);
+                uint muiTable = 0x310000;
+                fe8.write_u32(muiPtrLoc, Ptr(muiTable));
+                // entry0 (+0 image, +4 AP) — always counted (i==0).
+                uint img0 = 0x320000, ap0 = 0x330000;
+                fe8.write_u32(muiTable + 0 * 8 + 0, Ptr(img0));
+                fe8.write_u32(muiTable + 0 * 8 + 4, Ptr(ap0));
+                WriteLz77AllLiteral(fe8, img0, 40);
+                WriteKnownAP(fe8, ap0);
+                // entry1 (+0 image NULL is allowed by isPointerOrNULL) — counted (i<classCount=2).
+                fe8.write_u32(muiTable + 1 * 8 + 0, 0); // NULL image pointer (isPointerOrNULL true)
+                fe8.write_u32(muiTable + 1 * 8 + 4, 0); // NULL AP -> no AP emit for this entry
+                // entry2 would be i>=2 -> stopped by the class cap regardless of content.
+                fe8.write_u32(muiTable + 2 * 8 + 0, Ptr(0x340000));
+                fe8.write_u32(muiTable + 2 * 8 + 4, Ptr(0x340000));
+
+                var d = RebuildProducerCore.BuildBatchDescriptors(fe8).Single(x => x.Name == "MoveUnitIcon");
+                var list = new List<Address>();
+                RebuildProducerCore.WalkAndAdd(fe8, list, d);
+
+                // Main IFR present with the move-icon base.
+                Address main = Assert.Single(list, a => a.Info == "MoveUnitIcon");
+                Assert.Equal(muiTable, main.Addr);
+                // DataCount = 2 (entries 0,1) -> length = 8*(2+1) = 24.
+                Assert.Equal(8u * (2u + 1u), main.Length);
+
+                // Exactly ONE AP Address (entry0); entry1 AP is NULL (no emit); entry2 is past the cap.
+                Address ap = Assert.Single(list, a => a.DataType == Address.DataTypeEnum.AP);
+                Assert.Equal(ap0, ap.Addr);
+                Assert.Equal(28u, ap.Length);
+                // Exactly ONE LZ77IMG (entry0); entry1 image is NULL.
+                Address img = Assert.Single(list, a => a.DataType == Address.DataTypeEnum.LZ77IMG);
+                Assert.Equal(img0, img.Addr);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+            }
+        }
+
+        // ---- coverage tracker: slice 2n drops ImageUnitMoveIconFrom ----------
+
+        [Fact]
+        public void GetNotYetPortedForms_DropsSlice2nMoveIcon_KeepsDeferredSiblings()
+        {
+            string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
+
+            // slice 2n ports ImageUnitMoveIconFrom (AP per-entry column).
+            Assert.DoesNotContain("ImageUnitMoveIconFrom", notYet);
+
+            // Sibling image forms blocked on an un-ported subsystem STAY:
+            foreach (var kept in new[]
+            {
+                "ImageBattleAnimeForm",      // ImageUtilOAM
+                "ImageMagicFEditorForm",     // ImageUtil*.RecycleOldAnime
+                "ImageItemIconForm",         // out-of-scope icon-SHEET IFR
+                "ImageRomAnimeForm",         // config-file table
+                "ImageTSAAnimeForm", "ImageTSAAnime2Form",
+                "ImagePortraitForm",         // IsHalfBodyFlag runtime header
+            })
+            {
+                Assert.Contains(kept, notYet);
+            }
+
+            // no-duplicates invariant still holds.
+            string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
+            Assert.Equal(raw.Length, raw.Distinct().Count());
         }
     }
 }

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -137,6 +137,14 @@ namespace FEBuilderGBA
             /// +0 name-NULL tie-break, distinct from <see cref="PointerAt"/> which terminates on any
             /// non-pointer).</summary>
             UnitPaletteRule,
+            /// <summary><c>ImageUnitMoveIconFrom.Init</c> rule: the table is class-count-bounded. The cap
+            /// is <c>classCount = ClassForm.DataCount()</c> clamped to <c>[0x7f, 0xff]</c> (<c>&lt;=0 -&gt;
+            /// 0x7f</c>, <c>&gt;0xff -&gt; 0xff</c>) then decremented; the rule is <c>i &gt;= classCount ?
+            /// false : i == 0 ? true : U.isPointerOrNULL(u32(addr+0))</c> (entry 0 always exists; afterward
+            /// the <c>+0</c> image pointer must be a ROM pointer or NULL). Reproduced VERBATIM; the cap is
+            /// computed via <see cref="ClassDataCount"/> (the Core port of <c>ClassForm.DataCount()</c>).
+            /// <see cref="StructDescriptor.RuleOffset"/> selects the checked field (MoveIcon uses 0).</summary>
+            MoveIconRule,
             /// <summary><c>ImageCGForm.Init</c> rule (the 10-split big-CG table): continue while the entry's
             /// <c>+0</c> field is a ROM pointer AND the FIRST u32 at its target is ALSO a ROM pointer
             /// (<c>p = u32(addr+0); isPointer(p) &amp;&amp; isSafetyPointer(p); p2 = u32(toOffset(p));
@@ -226,6 +234,18 @@ namespace FEBuilderGBA
             /// are unused (the type is fixed HEADERTSA, the length is computed). EOF-safe (the dereference is
             /// full-extent-guarded; the length calc rejects a header that does not fit).</summary>
             HeaderTsaPointer,
+            /// <summary>An embedded AP (Animated-Parts) pointer (the unit move-icon animation stream behind a
+            /// pointer). Emits via <see cref="EmitApPointer"/> VERBATIM (reproduces WF
+            /// <c>AddressWinForms.AddAPPointer</c>: reads <c>u32(p + EmbeddedPointerOffset)</c>,
+            /// <c>isSafetyPointer</c>-checks, then adds a <see cref="Address.DataTypeEnum.AP"/> block whose
+            /// length is <see cref="ImageUtilAPCore.CalcAPLength"/> — the AP frame/anime stream parser —
+            /// over the dereferenced target). Matches the per-entry <c>AddAPPointer(list, p + 4, name + " AP",
+            /// isPointerOnly)</c> in <c>ImageUnitMoveIconFrom</c>. The label is taken from
+            /// <see cref="SubWalk.Name"/>; <see cref="SubWalk.FixedLength"/> / <see cref="SubWalk.DataType"/>
+            /// are unused (the type is fixed AP, the length is computed). EOF-safe (the dereference is
+            /// full-extent-guarded; <see cref="ImageUtilAPCore.CalcAPLength"/> returns 0 on a malformed /
+            /// near-EOF stream, never throws).</summary>
+            ApPointer,
         }
 
         /// <summary>One per-entry embedded-data sub-walk applied to every entry of a
@@ -1064,6 +1084,18 @@ namespace FEBuilderGBA
                                 sw.Name != null ? sw.Name(rom, i) : d.Name);
                             break;
 
+                        case SubKind.ApPointer:
+                            // ImageUnitMoveIconFrom per-entry AP column:
+                            // AddressWinForms.AddAPPointer(list, p + 4, name + " AP", isPointerOnly).
+                            // Reads u32(pfield), isSafetyPointer-checks, then adds an AP block whose length
+                            // is ImageUtilAPCore.CalcAPLength (the AP frame/anime stream parser) over the
+                            // dereferenced target. No encoder needed (no string decode). EOF-safe (the
+                            // dereference is full-extent-guarded; CalcAPLength returns 0 on a malformed /
+                            // near-EOF stream — never throws).
+                            EmitApPointer(rom, list, pfield,
+                                sw.Name != null ? sw.Name(rom, i) : d.Name);
+                            break;
+
                         default:
                             // A new/bad SubKind is a programming error — fail loudly rather than
                             // silently skip an embedded block (which would dangle on rebuild).
@@ -1717,6 +1749,49 @@ namespace FEBuilderGBA
             }
             uint length = CalcRomTcsLength(rom, target);
             list.Add(new Address(target, length, pointer, info, Address.DataTypeEnum.ROMTCS));
+        }
+
+        /// <summary>
+        /// Reproduces WinForms <c>AddressWinForms.AddAPPointer(list, pointer, info, isPointerOnly)</c>: the
+        /// <paramref name="pointer"/> slot holds a 32-bit ROM pointer to an AP (Animated-Parts, unit
+        /// move-icon animation) stream; emit a <see cref="Address.DataTypeEnum.AP"/> block whose length is
+        /// <see cref="ImageUtilAPCore.CalcAPLength"/> (the AP frame/anime stream parser) over the
+        /// dereferenced target. Structurally identical to <see cref="EmitRomTcsPointer"/> — the WF
+        /// <c>AddAPPointer</c>/<c>AddAPAddress</c> pair differs from <c>AddROMTCSPointer</c>/
+        /// <c>AddROMTCSAddress</c> only in <c>CalcAPLength</c> vs <c>CalcROMTCSLength</c> and the
+        /// <c>AP</c> vs <c>ROMTCS</c> data type. The producer always scans real lengths (isPointerOnly
+        /// false). <see cref="ImageUtilAPCore.CalcAPLength"/> is the verbatim Core port of WF
+        /// <c>ImageUtilAP.CalcAPLength</c> (= <c>Parse</c> + <c>GetLength</c>), already covered by the Core
+        /// AP-length tests. EOF-HARDENING: guard the full 4-byte <c>u32(pointer)</c> read extent before
+        /// dereferencing (WF reads it after only a single-byte <c>isSafetyOffset(pointer)</c> check);
+        /// <see cref="ImageUtilAPCore.CalcAPLength"/> itself returns 0 on any malformed / near-EOF stream
+        /// (never throws).
+        /// </summary>
+        public static void EmitApPointer(ROM rom, List<Address> list, uint pointer, string info)
+        {
+            pointer = U.toOffset(pointer);
+            if (!U.isSafetyOffset(pointer, rom))
+            {
+                return;
+            }
+            if (pointer + 4 > (uint)rom.Data.Length)
+            {
+                return;
+            }
+            uint addr = rom.u32(pointer);
+            if (!U.isSafetyPointer(addr, rom))
+            {
+                return;
+            }
+            // WF AddAPPointer(pointer-slot form) -> AddAPAddress(addr, pointer, ...): addr is toOffset'd +
+            // isSafetyOffset-checked inside, then length = CalcAPLength(addr).
+            uint target = U.toOffset(addr);
+            if (!U.isSafetyOffset(target, rom))
+            {
+                return;
+            }
+            uint length = ImageUtilAPCore.CalcAPLength(rom.Data, target);
+            list.Add(new Address(target, length, pointer, info, Address.DataTypeEnum.AP));
         }
 
         // -------------------------------------------------------------------------------------------
@@ -4483,6 +4558,23 @@ namespace FEBuilderGBA
                         }
                         return true; // any other value -> valid
                     };
+                case DataCountRule.MoveIconRule:
+                {
+                    // ImageUnitMoveIconFrom.Init verbatim. The class-count cap is computed ONCE (WF
+                    // reads ClassForm.DataCount() once in Init), then clamped to [0x7f,0xff] and
+                    // decremented. The per-entry rule: i>=cap -> stop; i==0 -> always; else the +0
+                    // (RuleOffset) image pointer must be a ROM pointer OR NULL.
+                    uint classCount = ClassDataCount(rom);
+                    if (classCount <= 0) classCount = 0x7f;
+                    else if (classCount > 0xFF) classCount = 0xFF;
+                    classCount--;
+                    return (i, addr) =>
+                    {
+                        if (i >= classCount) return false;
+                        if (i == 0) return true;
+                        return U.isPointerOrNULL(rom.u32(addr + d.RuleOffset));
+                    };
+                }
                 case DataCountRule.NestedPointerAt:
                     return (i, addr) =>
                     {
@@ -4762,9 +4854,11 @@ namespace FEBuilderGBA
             // (DataCount+1)) PLUS a per-entry loop of AddLZ77Pointer / AddPointer columns. The
             // per-entry columns are the SubWalks (Lz77Pointer / FixedPointer). EVERY length is either
             // LZ77.getCompressedSize (EOF-safe, 0 on malformed) or a CONSTANT palette/image size — no
-            // ImageUtil/TSA-header/frame-walk dependency. The forms that DO need such a subsystem
-            // (AddHeaderTSAPointer, ImageUtil*.RecycleOldAnime, config-file g_TSAAnime/g_ROMAnime,
-            // ImageUtilOAM, IsHalfBodyFlag, AddAPPointer) stay in GetNotYetPortedForms.
+            // ImageUtil/TSA-header/frame-walk dependency. (slice 2k added the AddHeaderTSAPointer header-TSA
+            // forms; slice 2n adds ImageUnitMoveIconFrom — its per-entry AP column uses SubKind.ApPointer /
+            // EmitApPointer, whose length is the verbatim Core ImageUtilAPCore.CalcAPLength frame/anime walk.)
+            // The forms that DO still need an un-ported subsystem (ImageUtil*.RecycleOldAnime, config-file
+            // g_TSAAnime/g_ROMAnime, ImageUtilOAM, IsHalfBodyFlag) stay in GetNotYetPortedForms.
 
             // ImageBattleBGForm.MakeAllDataLength — Info "BattleBG", block 12, base battle_bg_pointer,
             // IsDataExists = isPointer(u32+0) && isPointer(u32+4) (TwoU32PointerAt04), pointerIndexes
@@ -4816,6 +4910,29 @@ namespace FEBuilderGBA
                 SubWalks = new List<SubWalk>
                 {
                     new SubWalk { EmbeddedPointerOffset = 4, Kind = SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77IMG, Name = (r, i) => "WaitUnitIcon " + U.To0xHexString((uint)i) },
+                },
+            });
+
+            // ImageUnitMoveIconFrom.MakeAllDataLength (slice 2n) — Info "MoveUnitIcon", block 8, base
+            // unit_move_icon_pointer, IsDataExists = MoveIconRule (class-count-bounded; i==0 always; else
+            // isPointerOrNULL(u32+0)), pointerIndexes {0,4}. Per entry: LZ77IMG @0 (the move-icon sheet)
+            // + AP @4 (the move-anime stream). The per-entry WF label is name = "MoveUnitIcon " +
+            // To0xHexString(i); the LZ77 column uses that name verbatim and the AP column uses name + " AP".
+            // The AP block's length is ImageUtilAPCore.CalcAPLength (the verbatim Core port of WF
+            // ImageUtilAP.CalcAPLength = Parse + GetLength) over the dereferenced +4 target — see
+            // SubKind.ApPointer / EmitApPointer.
+            l.Add(new StructDescriptor
+            {
+                Name = "MoveUnitIcon",
+                PointerField = r => r.RomInfo.unit_move_icon_pointer,
+                BlockSize = 8,
+                Rule = DataCountRule.MoveIconRule,
+                RuleOffset = 0,
+                PointerIndexes = new uint[] { 0, 4 },
+                SubWalks = new List<SubWalk>
+                {
+                    new SubWalk { EmbeddedPointerOffset = 0, Kind = SubKind.Lz77Pointer, DataType = Address.DataTypeEnum.LZ77IMG, Name = (r, i) => "MoveUnitIcon " + U.To0xHexString((uint)i) },
+                    new SubWalk { EmbeddedPointerOffset = 4, Kind = SubKind.ApPointer, Name = (r, i) => "MoveUnitIcon " + U.To0xHexString((uint)i) + " AP" },
                 },
             });
 
@@ -5827,7 +5944,10 @@ namespace FEBuilderGBA
                 //    ImageMagicFEditorForm/ImageMagicCSACreatorForm/ImageMapActionAnimationForm —
                 //      ImageUtil*.RecycleOldAnime (ImageUtil anime length helpers).
                 //    ImageBattleAnimeForm — ImageUtilOAM.MakeAllDataLength (LZ77-embedded OAM pointers).
-                //    ImageUnitMoveIconFrom — AddAPPointer (ImageUtilAP.CalcAPLength).
+                //  (slice 2n ported ImageUnitMoveIconFrom — its per-entry AP column uses SubKind.ApPointer /
+                //   EmitApPointer, length = ImageUtilAPCore.CalcAPLength [the verbatim Core port of WF
+                //   ImageUtilAP.CalcAPLength = Parse + GetLength, already a tested Core helper]. The count
+                //   rule is MoveIconRule [class-count-bounded]. So it is no longer deferred.)
                 //    ImageRomAnimeForm/ImageTSAAnimeForm — config-file tables (U.ConfigDataFilename
                 //      "romanime_"/"tsaanime_") + dynamic pointer-list frame walks, not RomInfo slots.
                 //    ImagePortraitForm — IsHalfBodyFlag runtime header inspection (+ ImagePortraitFE6Form
@@ -5838,7 +5958,7 @@ namespace FEBuilderGBA
                 //      AppendAllASMStructPointersList ASM path, not this producer's data path.)
                 "ImageBattleAnimeForm",
                 "ImageMagicFEditorForm", "ImageMagicCSACreatorForm",
-                "ImageItemIconForm", "ImageUnitMoveIconFrom",
+                "ImageItemIconForm",
                 "ImageRomAnimeForm",
                 "ImageMapActionAnimationForm", "ImageTSAAnimeForm",
                 "ImageTSAAnime2Form", "ImagePortraitForm",

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -138,8 +138,9 @@ namespace FEBuilderGBA
             /// non-pointer).</summary>
             UnitPaletteRule,
             /// <summary><c>ImageUnitMoveIconFrom.Init</c> rule: the table is class-count-bounded. The cap
-            /// is <c>classCount = ClassForm.DataCount()</c> clamped to <c>[0x7f, 0xff]</c> (<c>&lt;=0 -&gt;
-            /// 0x7f</c>, <c>&gt;0xff -&gt; 0xff</c>) then decremented; the rule is <c>i &gt;= classCount ?
+            /// is <c>classCount = ClassForm.DataCount()</c> with ONLY the extremes coerced
+            /// (<c>&lt;=0 -&gt; 0x7f</c>, <c>&gt;0xff -&gt; 0xff</c>; values 1..0xff are left UNCHANGED — this is
+            /// NOT a clamp to <c>[0x7f, 0xff]</c>), then decremented; the rule is <c>i &gt;= classCount ?
             /// false : i == 0 ? true : U.isPointerOrNULL(u32(addr+0))</c> (entry 0 always exists; afterward
             /// the <c>+0</c> image pointer must be a ROM pointer or NULL). Reproduced VERBATIM; the cap is
             /// computed via <see cref="ClassDataCount"/> (the Core port of <c>ClassForm.DataCount()</c>).
@@ -4561,7 +4562,8 @@ namespace FEBuilderGBA
                 case DataCountRule.MoveIconRule:
                 {
                     // ImageUnitMoveIconFrom.Init verbatim. The class-count cap is computed ONCE (WF
-                    // reads ClassForm.DataCount() once in Init), then clamped to [0x7f,0xff] and
+                    // reads ClassForm.DataCount() once in Init); ONLY the extremes are coerced (<=0 ->
+                    // 0x7f, >0xFF -> 0xFF; values 1..0xFF stay AS-IS — not a clamp to [0x7f,0xff]), then
                     // decremented. The per-entry rule: i>=cap -> stop; i==0 -> always; else the +0
                     // (RuleOffset) image pointer must be a ROM pointer OR NULL.
                     uint classCount = ClassDataCount(rom);


### PR DESCRIPTION
## Summary
**Slice 2n** of #1261 — the **AP-icon** form (`ImageUnitMoveIconFrom`). The AP-length helper turned out to already be in Core, so this slice just wires it in (no reproduced length helper — like slice 2m's FE8 spell-menu).

## Ported
- **ImageUnitMoveIconFrom** [version-agnostic — WF `U.cs:2454`] — main IFR base `unit_move_icon_pointer`, block 8, pointerIndexes `{0,4}`; per entry a **LZ77IMG** move-icon sheet at +0 (existing `Lz77Pointer` SubKind) + an **AP** (Animated-Parts) move-anime stream at +4. These were previously left dangling during a rebuild; now relocated.
- **New `DataCountRule.MoveIconRule`** — the WF count rule verbatim: cap = `ClassDataCount` clamped to `[0x7f, 0xff]` then decremented; `i >= cap` → stop; `i == 0` → always; else `isPointerOrNULL(u32(addr+0))`.
- **New `SubKind.ApPointer` + `EmitApPointer`** — reproduces WF `AddAPPointer`/`AddAPAddress`, modeled exactly on the slice-2k `EmitRomTcsPointer` (`toOffset` → `isSafetyOffset` → **`pointer+4` EOF-guard before the `u32` deref** → `isSafetyPointer` → an `AP` block whose length is the AP stream length).
- **AP length REUSES the pre-existing Core helper `ImageUtilAPCore.CalcAPLength`** (= `Parse` + `GetLength`, the System.Drawing-free port; also used by `UnitMoveIconImportCore`, so already covered) rather than copy-pasting a second parser — confirmed by the lead that the helper exists in Core. (This mirrors the slice-2k posture: `CalcRomTcsLength` was reproduced only because no Core helper existed; here one does.)

## Discipline
- **Verbatim** main IFR (base/block/PI `{0,4}`) + `MoveIconRule` (count) + per-entry LZ77IMG@0 / AP@4 — checked against WF `MakeAllDataLength` + `Init`.
- **Version audit:** version-agnostic (WF unconditional section), no FE6/FE7 variant.
- **EOF self-audit:** `pointer+4` guard before `EmitApPointer`'s `u32`; per-entry reads block-bounded by `getBlockDataCount`; `CalcAPLength` is the already-EOF-hardened Core helper.

## Tests
- RebuildProducer filter: **215 passed / 0 failed** (+8) — main IFR + per-entry LZ77IMG/AP; `MoveIconRule` count cap; `EmitApPointer` near-EOF `Record.Exception`-null; planted AP-stream length via the Core helper; coverage drop. Removed the stale "ImageUnitMoveIconFrom deferred" assertions.
- FEBuilderGBA.Tests (net9.0-windows): no new failures (the `Skill*`/`SkillSystemsAnime*` env failures are the known `config/patch2`-absent-in-worktree ones).

Part of #1261.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
