### PR TITLE
feat(core): ROM-rebuild producer — config-file-table forms (#1261 slice 2q)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -447,10 +447,9 @@ namespace FEBuilderGBA.Core.Tests
             string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
             Assert.NotEmpty(notYet);
             // The heavy editors that need extraction first must be tracked, not dropped.
-            // (TextForm/TextCharCodeForm are ported in slice 2m — see
-            //  GetNotYetPortedForms_DropsSlice2mCoveredForms_KeepsDeferredSiblings; OtherTextForm STAYS,
-            //  its config-file other_text_* table is not ROM-derived.)
-            Assert.Contains("OtherTextForm", notYet);
+            // (TextForm/TextCharCodeForm are ported in slice 2m; OtherTextForm in slice 2q — see
+            //  GetNotYetPortedForms_DropsSlice2qConfigForms_KeepsDeferredSiblings.)
+            Assert.DoesNotContain("OtherTextForm", notYet);
             Assert.Contains("EventCondForm", notYet);
             Assert.Contains("SongTableForm", notYet);
             // ItemForm stays DEFERRED: its StatBooster sub-block size depends on un-ported PatchUtil
@@ -1146,8 +1145,10 @@ namespace FEBuilderGBA.Core.Tests
             // recursive walkers, so they are now covered — see GetNotYetPortedForms_DropsSlice2dCoveredForms.)
             Assert.Contains("ItemForm", notYet);          // StatBooster size needs PatchUtil detection
             // (ItemWeaponEffectForm was a deferred sibling here; slice 2l ports it via
-            //  EmitItemWeaponEffect — see GetNotYetPortedForms_DropsSlice2lCoveredForms.)
-            Assert.Contains("OtherTextForm", notYet);        // config-file (U.ConfigDataFilename) driven
+            //  EmitItemWeaponEffect — see GetNotYetPortedForms_DropsSlice2lCoveredForms. OtherTextForm
+            //  was the config-file sibling here; slice 2q ports it — see
+            //  GetNotYetPortedForms_DropsSlice2qConfigForms_KeepsDeferredSiblings.)
+            Assert.DoesNotContain("OtherTextForm", notYet);
         }
 
         [Fact]
@@ -3064,12 +3065,14 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("ImageCGForm", notYet);
             Assert.DoesNotContain("ImageSystemIconForm", notYet);
             Assert.DoesNotContain("WorldMapImageForm", notYet);
-            // still deferred (need ImageUtil OAM / config-file / runtime-inspection subsystems):
+            // still deferred (need ImageUtil OAM / runtime-inspection subsystems):
             Assert.Contains("ImageBattleAnimeForm", notYet);
             Assert.Contains("ImagePortraitForm", notYet);
             Assert.Contains("ImageItemIconForm", notYet);
-            Assert.Contains("ImageTSAAnimeForm", notYet);
-            Assert.Contains("ImageTSAAnime2Form", notYet); // config-file "tsaanime2_" TSV, not RomInfo
+            // (ImageTSAAnimeForm / ImageTSAAnime2Form were the config-file TSA-anime siblings here; slice
+            //  2q ports them — see GetNotYetPortedForms_DropsSlice2qConfigForms_KeepsDeferredSiblings.)
+            Assert.DoesNotContain("ImageTSAAnimeForm", notYet);
+            Assert.DoesNotContain("ImageTSAAnime2Form", notYet);
         }
 
         // ===================================================================
@@ -5594,12 +5597,12 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("ImageCGFE7UForm", notYet);
             Assert.DoesNotContain("WorldMapImageForm", notYet);
 
-            // ImageTSAAnime2Form STAYS deferred — its g_TSAAnime table is a config-FILE TSV resource
-            // (U.LoadTSVResource("tsaanime2_")), not a RomInfo table.
-            Assert.Contains("ImageTSAAnime2Form", notYet);
+            // (ImageTSAAnime2Form / ImageTSAAnimeForm were the config-FILE TSA-anime siblings here; slice
+            //  2q ports them — see GetNotYetPortedForms_DropsSlice2qConfigForms_KeepsDeferredSiblings.)
+            Assert.DoesNotContain("ImageTSAAnime2Form", notYet);
+            Assert.DoesNotContain("ImageTSAAnimeForm", notYet);
             // Other header-less image forms blocked on a different subsystem still stay tracked.
             Assert.Contains("ImageBattleAnimeForm", notYet);      // ImageUtilOAM OAM frame walk
-            Assert.Contains("ImageTSAAnimeForm", notYet);         // config-file "tsaanime_" table
             Assert.Contains("ImagePortraitForm", notYet);         // IsHalfBodyFlag runtime header
 
             // the no-duplicates invariant still holds after the edits.
@@ -6161,8 +6164,9 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("TextCharCodeForm", notYet);
             Assert.DoesNotContain("FE8SpellMenuExtendsForm", notYet);
 
-            // OtherTextForm STAYS — it iterates a config FILE (other_text_*), not a RomInfo table.
-            Assert.Contains("OtherTextForm", notYet);
+            // (OtherTextForm was the config-FILE sibling here; slice 2q ports it — see
+            //  GetNotYetPortedForms_DropsSlice2qConfigForms_KeepsDeferredSiblings.)
+            Assert.DoesNotContain("OtherTextForm", notYet);
             // ImageUnitMoveIconFrom is PORTED in slice 2n (ImageUtilAPCore.CalcAPLength is in Core) ->
             // it must be GONE (see GetNotYetPortedForms_DropsSlice2nMoveIcon_KeepsDeferredSiblings).
             Assert.DoesNotContain("ImageUnitMoveIconFrom", notYet);
@@ -6498,13 +6502,17 @@ namespace FEBuilderGBA.Core.Tests
             {
                 "ImageBattleAnimeForm",      // ImageUtilOAM (slice 2p ports the Magic/MapAction siblings)
                 "ImageItemIconForm",         // out-of-scope icon-SHEET IFR
-                "ImageRomAnimeForm",         // config-file table
-                "ImageTSAAnimeForm", "ImageTSAAnime2Form",
                 "ImagePortraitForm",         // IsHalfBodyFlag runtime header
             })
             {
                 Assert.Contains(kept, notYet);
             }
+            // (ImageRomAnimeForm / ImageTSAAnimeForm / ImageTSAAnime2Form were the config-FILE-table
+            //  siblings here; slice 2q ports them — see
+            //  GetNotYetPortedForms_DropsSlice2qConfigForms_KeepsDeferredSiblings.)
+            Assert.DoesNotContain("ImageRomAnimeForm", notYet);
+            Assert.DoesNotContain("ImageTSAAnimeForm", notYet);
+            Assert.DoesNotContain("ImageTSAAnime2Form", notYet);
 
             // no-duplicates invariant still holds.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
@@ -7141,6 +7149,519 @@ namespace FEBuilderGBA.Core.Tests
                 CoreState.ROM = savedRom;
                 CoreState.SystemTextEncoder = savedEnc;
             }
+        }
+
+        // ==== slice 2q: config-FILE-table forms ================================
+        // OtherText / ImageTSAAnime / ImageTSAAnime2 / ImageRomAnime each load a config TSV (resolved by
+        // U.ConfigDataFilename vs CoreState.BaseDirectory). These tests stage a temp config tree with
+        // controlled table addresses, plant the corresponding ROM tables, and assert the emitted
+        // Addresses; plus the empty-config (emit-nothing-no-throw) and near-EOF robustness paths.
+
+        /// <summary>Stage a temp <c>config/data/{type}FE8.txt</c> with the given lines + a real FE8U ROM
+        /// (RomInfo.TitleToFilename == "FE8") assigned to CoreState; runs <paramref name="body"/> with that
+        /// ROM, then restores all mutated CoreState. The temp dir is deleted afterwards.</summary>
+        static void WithConfig(string type, string[] lines, Action<ROM> body)
+        {
+            string savedBase = CoreState.BaseDirectory;
+            string savedLang = CoreState.Language;
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+
+            string tempRoot = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+                "feb_s2q_" + Guid.NewGuid().ToString("N"));
+            string dataDir = System.IO.Path.Combine(tempRoot, "config", "data");
+            System.IO.Directory.CreateDirectory(dataDir);
+            try
+            {
+                if (lines != null)
+                {
+                    // FE8U TitleToFilename == "FE8"; lang "en" -> ConfigDataFilename tries {type}FE8.en.txt
+                    // then {type}FE8.txt. Write the plain .txt so it resolves to our file.
+                    System.IO.File.WriteAllLines(
+                        System.IO.Path.Combine(dataDir, type + "FE8.txt"), lines);
+                }
+
+                CoreState.BaseDirectory = tempRoot;
+                CoreState.Language = "en";
+                var rom = MakeVersionedRom("BE8E01"); // FE8U: version 8, TitleToFilename "FE8"
+                CoreState.ROM = rom; // LoadTSVResource's OtherLangLine reads CoreState.ROM
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+                body(rom);
+            }
+            finally
+            {
+                CoreState.BaseDirectory = savedBase;
+                CoreState.Language = savedLang;
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+                try { System.IO.Directory.Delete(tempRoot, true); } catch { /* best effort */ }
+            }
+        }
+
+        static void WriteAsciiZ(ROM rom, uint addr, string s)
+        {
+            for (int i = 0; i < s.Length; i++)
+            {
+                rom.write_u8(addr + (uint)i, (byte)s[i]);
+            }
+            rom.write_u8(addr + (uint)s.Length, 0x00);
+        }
+
+        // ---- OtherText ----
+
+        [Fact]
+        public void EmitOtherText_PerEntryStringBin_NoPlusOne()
+        {
+            // other_text_ config: each line = ONE hex pointer SLOT. The slot holds a pointer to the
+            // C string; the emitter records a BIN block of length == strlen (NO +1) behind it.
+            uint slot0 = 0x1000;
+            uint slot1 = 0x1100;
+            WithConfig("other_text_", new[] { U.ToHexString(slot0), U.ToHexString(slot1) }, rom =>
+            {
+                uint str0 = 0x2000;
+                uint str1 = 0x2100;
+                rom.write_u32(slot0, Ptr(str0));
+                rom.write_u32(slot1, Ptr(str1));
+                WriteAsciiZ(rom, str0, "HELLO");  // strlen 5
+                WriteAsciiZ(rom, str1, "AB");     // strlen 2
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitOtherText(rom, list);
+
+                Assert.Equal(2, list.Count);
+                Address b0 = list.Single(a => a.Addr == str0);
+                Assert.Equal(5u, b0.Length);            // NO +1
+                Assert.Equal(slot0, b0.Pointer);
+                Assert.Equal(Address.DataTypeEnum.BIN, b0.DataType);
+                Address b1 = list.Single(a => a.Addr == str1);
+                Assert.Equal(2u, b1.Length);
+                Assert.Equal(slot1, b1.Pointer);
+            });
+        }
+
+        [Fact]
+        public void EmitOtherText_NoEncoder_SkipsWithoutThrow()
+        {
+            WithConfig("other_text_", new[] { U.ToHexString(0x1000u) }, rom =>
+            {
+                rom.write_u32(0x1000, Ptr(0x2000));
+                WriteAsciiZ(rom, 0x2000, "X");
+                CoreState.SystemTextEncoder = null; // the critical condition (decode would NRE)
+
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitOtherText(rom, list));
+                Assert.Null(ex);
+                Assert.Empty(list); // skipped, not crashed
+            });
+        }
+
+        [Fact]
+        public void EmitOtherText_MissingConfig_EmitsNothing()
+        {
+            // No config file written (lines == null) -> MakeOtherTextList File.Exists is false -> empty
+            // list -> nothing emitted, no throw (faithful headless behavior).
+            WithConfig("other_text_", null, rom =>
+            {
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitOtherText(rom, list));
+                Assert.Null(ex);
+                Assert.Empty(list);
+            });
+        }
+
+        // ---- ImageTSAAnime ----
+
+        [Fact]
+        public void EmitImageTSAAnime_MainIfr_AndPerEntryLz77PalLz77()
+        {
+            // tsaanime_ config line: <slot>\t<count>\t<name>. The slot holds a pointer to the anime
+            // record table (base); count records of block 12 (LZ77IMG@+0, PAL@+4, LZ77TSA@+8).
+            uint slot = 0x1000;
+            uint baseTbl = 0x2000;
+            // 2 records.
+            WithConfig("tsaanime_",
+                new[] { U.ToHexString(slot) + "\t002\tMyAnime" }, rom =>
+            {
+                rom.write_u32(slot, Ptr(baseTbl));
+                // record 0
+                rom.write_u32(baseTbl + 0 + 0, Ptr(0x3000)); // IMAGE
+                rom.write_u32(baseTbl + 0 + 4, Ptr(0x3100)); // PALETTE
+                rom.write_u32(baseTbl + 0 + 8, Ptr(0x3200)); // TSA
+                // record 1
+                rom.write_u32(baseTbl + 12 + 0, Ptr(0x3300));
+                rom.write_u32(baseTbl + 12 + 4, Ptr(0x3400));
+                rom.write_u32(baseTbl + 12 + 8, Ptr(0x3500));
+                // tiny LZ77 headers so getCompressedSize returns a real (possibly 0) length, no throw
+                rom.write_u32(0x3000, 0x00000010);
+                rom.write_u32(0x3200, 0x00000010);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitImageTSAAnime(rom, list);
+
+                // Main IFR: base baseTbl, block 12, count 2 (atoh("002")==2), length 12*(2+1)=36,
+                // pointer slot, PI {0,4,8}.
+                Address mainIfr = list.Single(a => a.Info == "TSAANIME MyAnime " && a.BlockSize == 12);
+                Assert.Equal(baseTbl, mainIfr.Addr);
+                Assert.Equal(slot, mainIfr.Pointer);
+                Assert.Equal(12u * 3u, mainIfr.Length);
+                Assert.Equal(Address.DataTypeEnum.InputFormRef, mainIfr.DataType);
+                Assert.Equal(new uint[] { 0, 4, 8 }, mainIfr.PointerIndexes);
+
+                // Per-record columns.
+                Assert.Contains(list, a => a.Addr == 0x3100 && a.Length == 0x20 * 8 &&
+                    a.DataType == Address.DataTypeEnum.PAL);
+                Assert.Contains(list, a => a.Addr == 0x3000 &&
+                    a.DataType == Address.DataTypeEnum.LZ77IMG);
+                Assert.Contains(list, a => a.Addr == 0x3200 &&
+                    a.DataType == Address.DataTypeEnum.LZ77TSA);
+                // record 1 PALETTE present too.
+                Assert.Contains(list, a => a.Addr == 0x3400 && a.Length == 0x20 * 8 &&
+                    a.DataType == Address.DataTypeEnum.PAL);
+            });
+        }
+
+        [Fact]
+        public void EmitImageTSAAnime_MissingConfig_EmitsNothing()
+        {
+            // Empty config file (file exists, only a comment) -> empty dict -> nothing emitted, no throw.
+            WithConfig("tsaanime_", new[] { "//empty" }, rom =>
+            {
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitImageTSAAnime(rom, list));
+                Assert.Null(ex);
+                Assert.Empty(list);
+            });
+        }
+
+        [Fact]
+        public void EmitImageTSAAnime_NearEofSlot_NoThrow()
+        {
+            // A config slot WITHIN 4 bytes of EOF: the `pointer + 4 > Data.Length` guard skips that entry
+            // rather than throwing inside p32(pointer). MakeVersionedRom is 32MB, so put the slot 2 bytes
+            // before the end (a GBA offset of Data.Length-2 is a safe offset but its 4-byte read overruns).
+            WithConfig("tsaanime_", null, rom =>
+            {
+                uint nearEof = (uint)rom.Data.Length - 2;
+                // Re-stage the config with the near-EOF slot. (WithConfig wrote no file; write one now.)
+                string dataDir = System.IO.Path.Combine(CoreState.BaseDirectory, "config", "data");
+                System.IO.File.WriteAllLines(
+                    System.IO.Path.Combine(dataDir, "tsaanime_FE8.txt"),
+                    new[] { U.ToHexString(nearEof) + "\t001\tX" });
+
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitImageTSAAnime(rom, list));
+                Assert.Null(ex);
+                Assert.Empty(list); // the near-EOF slot is guarded out
+            });
+        }
+
+        // ---- ImageTSAAnime2 ----
+
+        [Fact]
+        public void EmitImageTSAAnime2_MainAndN1Ifrs_HeaderAndPerRecordTsa()
+        {
+            // tsaanime2_ config line: <slot>\t<name>. The slot holds a pointer to the header (addr);
+            // N1 (block 20) is the 1-entry header IFR; main (block 12) walks records from addr+20.
+            uint slot = 0x1000;
+            uint addr = 0x2000;
+            WithConfig("tsaanime2_", new[] { U.ToHexString(slot) + "\tMyAnime2" }, rom =>
+            {
+                rom.write_u32(slot, Ptr(addr));
+                // HEADER fields: LZ77 image @ addr+16, palette @ addr+4.
+                rom.write_u32(addr + 16, Ptr(0x3000)); // header IMAGE
+                rom.write_u32(addr + 4, Ptr(0x3100));  // header PALETTE
+                rom.write_u32(0x3000, 0x00000010);     // tiny LZ77 header
+
+                // Record table at addr+20: block 12, IsDataExists isPointer(u32(a+8)). 1 record then stop.
+                uint rec0 = addr + 20;
+                rom.write_u32(rec0 + 8, Ptr(0x4000));  // record 0 valid (u32(a+8) is a pointer)
+                // plant a header-TSA stream at the dereferenced target so CalcHeaderTsaLength is non-zero
+                rom.write_u8(0x4000 + 0, 0x01); // x-1
+                rom.write_u8(0x4000 + 1, 0x01); // y-1
+                rom.write_u32((addr + 20) + 12 + 8, 0x12345678); // record 1 +8 not a pointer -> stop
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitImageTSAAnime2(rom, list);
+
+                // Main IFR: base addr+20, block 12, count 1, length 12*(1+1)=24, pointer NOT_FOUND, PI {8}.
+                Address mainIfr = list.Single(a => a.BlockSize == 12 && a.Info == "TSAANIME2 MyAnime2 ");
+                Assert.Equal(addr + 20, mainIfr.Addr);
+                Assert.Equal(U.NOT_FOUND, mainIfr.Pointer);
+                Assert.Equal(12u * 2u, mainIfr.Length);
+                Assert.Equal(new uint[] { 8 }, mainIfr.PointerIndexes);
+
+                // N1 IFR: base addr, block 20, count 1, length 20*(1+1)=40, pointer slot, PI {4,16}.
+                Address n1Ifr = list.Single(a => a.BlockSize == 20 && a.Info == "TSAANIME2 MyAnime2 ");
+                Assert.Equal(addr, n1Ifr.Addr);
+                Assert.Equal(slot, n1Ifr.Pointer);
+                Assert.Equal(20u * 2u, n1Ifr.Length);
+                Assert.Equal(new uint[] { 4, 16 }, n1Ifr.PointerIndexes);
+
+                // WF emits the main IFR BEFORE the N1 IFR — assert that order.
+                Assert.True(list.IndexOf(mainIfr) < list.IndexOf(n1Ifr),
+                    "WF order: main IFR must be emitted before the N1 IFR");
+
+                // HEADER pair (N1.DataCount >= 1): LZ77IMG @ addr+16, PAL 0x20 @ addr+4.
+                Assert.Contains(list, a => a.Addr == 0x3000 && a.DataType == Address.DataTypeEnum.LZ77IMG);
+                Assert.Contains(list, a => a.Addr == 0x3100 && a.Length == 0x20 &&
+                    a.DataType == Address.DataTypeEnum.PAL);
+
+                // Per-record header-TSA @ rec0+8 -> target 0x4000, length = 2 + (2*2*2) = 10.
+                Assert.Contains(list, a => a.Addr == 0x4000 && a.Length == 10u &&
+                    a.DataType == Address.DataTypeEnum.HEADERTSA);
+            });
+        }
+
+        [Fact]
+        public void EmitImageTSAAnime2_MissingConfig_EmitsNothing()
+        {
+            WithConfig("tsaanime2_", new[] { "//empty" }, rom =>
+            {
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitImageTSAAnime2(rom, list));
+                Assert.Null(ex);
+                Assert.Empty(list);
+            });
+        }
+
+        // ---- ImageRomAnime ----
+
+        [Fact]
+        public void EmitImageRomAnime_FramePointerListsAndPalette()
+        {
+            // romanime_ config line: <key>\t<width>\t<option>\t<framePtr>\t<tsaPtr>\t<imgPtr>\t<palPtr>\t<name>
+            uint framePtr = 0x1000;
+            uint tsaPtr = 0x1100;
+            uint imgPtr = 0x1200;
+            uint palPtr = 0x1300;
+            string line = "0000\t30\tNNN\t" + U.ToHexString(framePtr) + "\t" + U.ToHexString(tsaPtr)
+                + "\t" + U.ToHexString(imgPtr) + "\t" + U.ToHexString(palPtr) + "\tMyRom";
+            WithConfig("romanime_", new[] { line }, rom =>
+            {
+                // FRAME table: {id, wait} 4-byte records, terminator id==0xFFFF. 2 frames.
+                uint frameTbl = 0x2000;
+                rom.write_u32(framePtr, Ptr(frameTbl));
+                rom.write_u16(frameTbl + 0, 0x0000); rom.write_u16(frameTbl + 2, 0x0001);
+                rom.write_u16(frameTbl + 4, 0x0001); rom.write_u16(frameTbl + 6, 0x0001);
+                rom.write_u16(frameTbl + 8, 0xFFFF); // terminator -> frameCount 2
+
+                // TSA pointer-list: base -> [ptrA, terminator]
+                uint tsaListBase = 0x2400;
+                rom.write_u32(tsaPtr, Ptr(tsaListBase));
+                rom.write_u32(tsaListBase + 0, Ptr(0x3000)); // TSA target 0
+                rom.write_u32(tsaListBase + 4, 0x00000000);  // not a pointer -> list ends (1 entry)
+                rom.write_u32(0x3000, 0x00000010);           // tiny LZ77 header
+
+                // Image pointer-list
+                uint imgListBase = 0x2500;
+                rom.write_u32(imgPtr, Ptr(imgListBase));
+                rom.write_u32(imgListBase + 0, Ptr(0x3100));
+                rom.write_u32(imgListBase + 4, 0x00000000);
+                rom.write_u32(0x3100, 0x00000010);
+
+                // Palette pointer-list
+                uint palListBase = 0x2600;
+                rom.write_u32(palPtr, Ptr(palListBase));
+                rom.write_u32(palListBase + 0, Ptr(0x3200));
+                rom.write_u32(palListBase + 4, 0x00000000);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitImageRomAnime(rom, list);
+
+                // FRAME Pointer (4-byte POINTER) + FRAME BIN (frameCount*4 == 8).
+                Assert.Contains(list, a => a.Info == "MyRom FRAME Pointer" && a.Length == 4 &&
+                    a.DataType == Address.DataTypeEnum.POINTER);
+                Assert.Contains(list, a => a.Info == "MyRom FRAME" && a.Addr == frameTbl &&
+                    a.Length == 8u && a.DataType == Address.DataTypeEnum.BIN);
+
+                // TSA / Image / Palette pointers + per-list entries.
+                Assert.Contains(list, a => a.Info == "MyRom TSA Pointer" && a.Length == 4);
+                Assert.Contains(list, a => a.Info == "MyRom TSA" && a.Addr == 0x3000 &&
+                    a.DataType == Address.DataTypeEnum.LZ77TSA);
+                Assert.Contains(list, a => a.Info == "MyRom Image" && a.Addr == 0x3100 &&
+                    a.DataType == Address.DataTypeEnum.LZ77IMG);
+                Assert.Contains(list, a => a.Info == "MyRom Palette" && a.Addr == 0x3200 &&
+                    a.Length == 2 * 16 && a.DataType == Address.DataTypeEnum.PAL);
+            });
+        }
+
+        [Fact]
+        public void EmitImageRomAnime_CommonPaletteFallback_EmitsSingleResolvedBase()
+        {
+            // option == "COMMONPALETTE": when the palette pointer-list resolves to ZERO entries, the
+            // fallback adds the single resolved base (toOffset(a)) as the lone palette.
+            uint framePtr = 0x1000;
+            uint tsaPtr = 0x1100;
+            uint imgPtr = 0x1200;
+            uint palPtr = 0x1300;
+            string line = "0000\t30\tCOMMONPALETTE\t" + U.ToHexString(framePtr) + "\t"
+                + U.ToHexString(tsaPtr) + "\t" + U.ToHexString(imgPtr) + "\t" + U.ToHexString(palPtr)
+                + "\tCommonRom";
+            WithConfig("romanime_", new[] { line }, rom =>
+            {
+                uint frameTbl = 0x2000;
+                rom.write_u32(framePtr, Ptr(frameTbl));
+                rom.write_u16(frameTbl + 0, 0xFFFF); // 0 frames (terminator immediately) -> frameCount 0
+
+                rom.write_u32(tsaPtr, Ptr(0x2400));
+                rom.write_u32(0x2400, 0x00000000); // empty list -> fallback adds base 0x2400
+                rom.write_u32(imgPtr, Ptr(0x2500));
+                rom.write_u32(0x2500, 0x00000000);
+                // Palette: base 0x2600 with NO pointer entries -> COMMONPALETTE fallback adds 0x2600.
+                rom.write_u32(palPtr, Ptr(0x2600));
+                rom.write_u32(0x2600, 0x00000000);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitImageRomAnime(rom, list);
+
+                // The COMMONPALETTE fallback: exactly one Palette at the resolved base 0x2600.
+                var pals = list.Where(a => a.Info == "CommonRom Palette").ToList();
+                Assert.Single(pals);
+                Assert.Equal(0x2600u, pals[0].Addr);
+                Assert.Equal(2u * 16u, pals[0].Length);
+            });
+        }
+
+        [Fact]
+        public void EmitImageRomAnime_FixedPaletteCountFallback_WhenFramePointerBelow0x100()
+        {
+            // framePointer < 0x100 (a FIXED per-frame palette COUNT, not a pointer) with an empty
+            // palette list -> the fallback adds one palette per frame at a + i*(2*16).
+            uint tsaPtr = 0x1100;
+            uint imgPtr = 0x1200;
+            uint palPtr = 0x1300;
+            const uint frameCountFixed = 3; // < 0x100
+            string line = "0000\t30\tNNN\t" + U.ToHexString(frameCountFixed) + "\t"
+                + U.ToHexString(tsaPtr) + "\t" + U.ToHexString(imgPtr) + "\t" + U.ToHexString(palPtr)
+                + "\tFixedRom";
+            WithConfig("romanime_", new[] { line }, rom =>
+            {
+                // framePointer == 3 is NOT a safe offset -> checkPonters skips the frame slot, but the
+                // tsa/img/pal slots must still hold safe pointers. frameCount stays NOT_FOUND ->
+                // GetFrameCountLow returns NOT_FOUND for a non-safe framePointer... which would `continue`.
+                // WF: when !isSafetyOffset(framePointer), the FRAME block is skipped AND frameCount stays
+                // NOT_FOUND -> `if (frameCount == NOT_FOUND) continue`. So with framePointer < 0x100 the
+                // WHOLE entry is skipped. Assert that faithfully (no Palette emitted).
+                rom.write_u32(tsaPtr, Ptr(0x2400));
+                rom.write_u32(0x2400, Ptr(0x3000));
+                rom.write_u32(0x3000, 0x00000010);
+                rom.write_u32(imgPtr, Ptr(0x2500));
+                rom.write_u32(0x2500, Ptr(0x3100));
+                rom.write_u32(0x3100, 0x00000010);
+                rom.write_u32(palPtr, Ptr(0x2600));
+                rom.write_u32(0x2600, 0x00000000);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitImageRomAnime(rom, list);
+
+                // framePointer 3 -> isSafetyOffset false -> frameCount NOT_FOUND -> entry skipped entirely.
+                Assert.DoesNotContain(list, a => a.Info != null && a.Info.StartsWith("FixedRom"));
+            });
+        }
+
+        [Fact]
+        public void GetRomAnimePalettePointerListCount_FixedPaletteFallback_OnePerFrame()
+        {
+            // Direct test of the framePointer<0x100 palette fallback (the per-frame palette layout).
+            WithConfig("romanime_", null, rom =>
+            {
+                uint palPtr = 0x1300;
+                uint paletteBase = 0x2600;
+                rom.write_u32(palPtr, Ptr(paletteBase));
+                rom.write_u32(paletteBase, 0x00000000); // empty list -> fallback fires
+
+                List<uint> pals = RebuildProducerCore.GetRomAnimePalettePointerListCount(
+                    rom, palPtr, framePointer: 3, option: "NNN");
+                // 3 entries at base + i*(2*16).
+                Assert.Equal(3, pals.Count);
+                Assert.Equal(paletteBase + 0u * 32u, pals[0]);
+                Assert.Equal(paletteBase + 1u * 32u, pals[1]);
+                Assert.Equal(paletteBase + 2u * 32u, pals[2]);
+            });
+        }
+
+        [Fact]
+        public void GetRomAnimePalettePointerListCount_ElseFallback_SingleBase_WhenFramePointerLarge()
+        {
+            // framePointer >= 0x100 and NOT COMMONPALETTE and empty list -> single resolved base.
+            WithConfig("romanime_", null, rom =>
+            {
+                uint palPtr = 0x1300;
+                uint paletteBase = 0x2600;
+                rom.write_u32(palPtr, Ptr(paletteBase));
+                rom.write_u32(paletteBase, 0x00000000);
+
+                List<uint> pals = RebuildProducerCore.GetRomAnimePalettePointerListCount(
+                    rom, palPtr, framePointer: 0x1000, option: "NNN");
+                Assert.Single(pals);
+                Assert.Equal(paletteBase, pals[0]);
+            });
+        }
+
+        [Fact]
+        public void EmitImageRomAnime_MissingConfig_EmitsNothing()
+        {
+            WithConfig("romanime_", new[] { "//empty" }, rom =>
+            {
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitImageRomAnime(rom, list));
+                Assert.Null(ex);
+                Assert.Empty(list);
+            });
+        }
+
+        [Fact]
+        public void GetRomAnimeFrameCountLow_NearEof_NoThrow()
+        {
+            var rom = CreateTestRom(0x1000);
+            // framePointer slot near EOF -> the +4 guard returns NOT_FOUND, no throw.
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.GetRomAnimeFrameCountLow(rom, (uint)rom.Data.Length - 2));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void CheckRomAnimePonters_ReadsRawU32_NotP32()
+        {
+            // Faithfulness: WF checkPonters reads u32(slot) and isSafetyPointer(...) — it does NOT
+            // p32-normalize before the check. A slot holding a NON-pointer value must fail the gate.
+            var rom = CreateTestRom(0x4000);
+            uint tsaPtr = 0x1100, imgPtr = 0x1200, palPtr = 0x1300;
+            rom.write_u32(tsaPtr, 0x12345678); // NOT a GBA pointer -> isSafetyPointer false -> gate fails
+            rom.write_u32(imgPtr, Ptr(0x2000));
+            rom.write_u32(palPtr, Ptr(0x2100));
+            // framePointer 0 -> isSafetyOffset(0) false -> the frame branch is skipped (WF).
+            bool ok = RebuildProducerCore.CheckRomAnimePonters(rom, 0, tsaPtr, imgPtr, palPtr);
+            Assert.False(ok);
+
+            // Now make the TSA slot a real pointer -> gate passes.
+            rom.write_u32(tsaPtr, Ptr(0x2200));
+            Assert.True(RebuildProducerCore.CheckRomAnimePonters(rom, 0, tsaPtr, imgPtr, palPtr));
+        }
+
+        // ---- NotYetPorted coverage delta for slice 2q ----
+
+        [Fact]
+        public void GetNotYetPortedForms_DropsSlice2qConfigForms_KeepsDeferredSiblings()
+        {
+            string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
+
+            // slice 2q ports the four config-FILE-table forms.
+            Assert.DoesNotContain("OtherTextForm", notYet);
+            Assert.DoesNotContain("ImageTSAAnimeForm", notYet);
+            Assert.DoesNotContain("ImageTSAAnime2Form", notYet);
+            Assert.DoesNotContain("ImageRomAnimeForm", notYet);
+
+            // The remaining image-anime siblings STAY (each blocked on a Core gap):
+            //  ImageBattleAnimeForm (ImageUtilOAM + ClassForm.MakeClassList + seat-dedup),
+            //  ImagePortraitForm (IsHalfBodyFlag runtime header), ImageItemIconForm (out of scope).
+            Assert.Contains("ImageBattleAnimeForm", notYet);
+            Assert.Contains("ImagePortraitForm", notYet);
+            Assert.Contains("ImageItemIconForm", notYet);
+
+            // no-duplicates invariant still holds.
+            string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
+            Assert.Equal(raw.Length, raw.Distinct().Count());
         }
     }
 }

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -532,8 +532,9 @@ namespace FEBuilderGBA
             // version-gated LZ77/PAL/HEADER-TSA sequence) are both called in the WF unconditional section.
             // The FE8/FE7-multibyte ImageCGForm, FE7U ImageCGFE7UForm, and FE8 WorldMapImageForm are
             // version-gated and wired into their respective version branches below. Each gets its own
-            // cancel-check, mirroring the WF DoEvents posture. ImageTSAAnime2Form STAYS deferred — its
-            // g_TSAAnime table is a config-FILE TSV (U.LoadTSVResource("tsaanime2_")), not a RomInfo table.
+            // cancel-check, mirroring the WF DoEvents posture. (The config-FILE-table TSA-anime forms —
+            // ImageTSAAnime2Form / ImageTSAAnimeForm, g_TSAAnime from U.LoadTSVResource("tsaanime2_"/
+            // "tsaanime_") — are ported in slice 2q and wired into their version branches below.)
             if (ct.IsCancellationRequested)
             {
                 progress?.Report("MakeAllStructPointersList cancelled");
@@ -716,6 +717,33 @@ namespace FEBuilderGBA
             progress?.Report("ImageMagicCSACreator");
             EmitImageMagicCsaCreator(rom, list);
 
+            // ---- slice 2q: config-FILE-table forms (version-agnostic call site) ----
+            // OtherTextForm and ImageRomAnimeForm are both in the WF unconditional section (NOT
+            // version-gated). Neither is a flat StructDescriptor walk: each loads a config TSV
+            // (other_text_ / romanime_) via U.ConfigDataFilename / U.LoadTSVResource (now in Core,
+            // resolving against CoreState.BaseDirectory) — a config-FILE table, not a RomInfo slot —
+            // and emits per-entry blocks whose lengths are all Core-backed (getString / LZ77
+            // getCompressedSize / pure-ROM frame & pointer-list terminator walks; NO ImageUtilOAM /
+            // Drawing / disasm). A missing config tree -> empty table -> nothing emitted (faithful to
+            // WF's empty-dict headless behavior). Each gets its own cancel-check (WF DoEvents posture).
+            // The version-gated ImageTSAAnimeForm (v8 + v7) / ImageTSAAnime2Form (v8) are wired into
+            // their respective version branches below.
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("OtherText");
+            EmitOtherText(rom, list);
+
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("ImageRomAnime");
+            EmitImageRomAnime(rom, list);
+
             // ---- slice 2h: SupportUnit (all versions) + WorldMapPath (FE8-only) ----
             // SupportUnitForm is called in the WF version==8 AND version==7 branches (block 24); the
             // SupportUnitFE6Form variant in version==6 (block 32). EmitSupportUnit auto-selects the
@@ -858,6 +886,28 @@ namespace FEBuilderGBA
                 }
                 progress?.Report("ImageCG");
                 EmitImageCG(rom, list);
+
+                // ---- slice 2q: ImageTSAAnime2Form (FE8 ONLY) + ImageTSAAnimeForm (FE8 + FE7) ----
+                // WF calls ImageTSAAnime2Form.MakeAllDataLength ONLY in the version==8 branch (its
+                // g_TSAAnime / tsaanime2_ config exists only for FE8); ImageTSAAnimeForm.MakeAllDataLength
+                // is called in BOTH the version==8 AND version==7 branches (NOT version==6). Both load a
+                // config TSV (tsaanime2_ / tsaanime_) and emit an IFR + LZ77/PAL/HEADER-TSA columns —
+                // all Core-backed lengths. EmitImageTSAAnime is wired into the version==7 branch below too.
+                if (ct.IsCancellationRequested)
+                {
+                    progress?.Report("MakeAllStructPointersList cancelled");
+                    return new ProducerResult(list, notYet, cancelled: true);
+                }
+                progress?.Report("ImageTSAAnime2");
+                EmitImageTSAAnime2(rom, list);
+
+                if (ct.IsCancellationRequested)
+                {
+                    progress?.Report("MakeAllStructPointersList cancelled");
+                    return new ProducerResult(list, notYet, cancelled: true);
+                }
+                progress?.Report("ImageTSAAnime");
+                EmitImageTSAAnime(rom, list);
             }
 
             if (rom.RomInfo.version == 7)
@@ -869,6 +919,17 @@ namespace FEBuilderGBA
                 }
                 progress?.Report("WorldMapImageFE7");
                 EmitWorldMapImageFE7(rom, list);
+
+                // ---- slice 2q: ImageTSAAnimeForm (FE8 + FE7) ----
+                // WF calls ImageTSAAnimeForm.MakeAllDataLength in the version==7 branch too (NOT FE6).
+                // Same emitter as the version==8 path (tsaanime_ config + IFR + LZ77/PAL/LZ77TSA columns).
+                if (ct.IsCancellationRequested)
+                {
+                    progress?.Report("MakeAllStructPointersList cancelled");
+                    return new ProducerResult(list, notYet, cancelled: true);
+                }
+                progress?.Report("ImageTSAAnime");
+                EmitImageTSAAnime(rom, list);
 
                 // ---- slice 2i: OPClassDemoFE7 (FE7-multibyte ONLY) ----
                 // WF calls OPClassDemoFE7Form.MakeAllDataLength inside `version==7 && is_multibyte` (the
@@ -1891,6 +1952,550 @@ namespace FEBuilderGBA
             }
             uint length = ImageUtilAPCore.CalcAPLength(rom.Data, target);
             list.Add(new Address(target, length, pointer, info, Address.DataTypeEnum.AP));
+        }
+
+        // -------------------------------------------------------------------------------------------
+        // slice 2q: config-FILE-table forms (the table base/count come from a config TSV loaded via
+        // U.ConfigDataFilename / U.LoadTSVResource, NOT a RomInfo pointer slot, so none fits the flat
+        // StructDescriptor model — each gets a dedicated emitter). All four are pure-ROM + config: every
+        // per-entry length is LZ77.getCompressedSize, a constant palette size, CalcHeaderTsaLength
+        // (slice 2k), ROM.getString, or a pure-ROM frame/pointer-list terminator walk — NO ImageUtilOAM,
+        // System.Drawing, or disasm. The config files (other_text_/tsaanime_/tsaanime2_/romanime_) ship
+        // under config/data/; ConfigDataFilename resolves them against CoreState.BaseDirectory. In a
+        // headless scan with the config tree absent the load returns an EMPTY dict/list (no throw — WF's
+        // LoadTSVResource / MakeOtherTextMap exact behavior), so the emitter contributes nothing, which
+        // is faithful (the same as a vanilla ROM with no entries).
+
+        /// <summary>
+        /// Load a config TSV table (<see cref="U.LoadTSVResource"/>) for a slice-2q anime form, never
+        /// throwing. WF's <c>PreLoadResource</c> always runs with a valid <see cref="CoreState.BaseDirectory"/>
+        /// (set during app/CLI init), but the producer may be invoked by a test / tool before the config
+        /// tree is staged: <see cref="U.ConfigDataFilename"/> does <c>Path.Combine(CoreState.BaseDirectory,
+        /// …)</c>, which throws <see cref="ArgumentNullException"/> when BaseDirectory is null. Wrap BOTH the
+        /// path build and the load in a try/catch so a missing/unconfigured config tree degrades to an EMPTY
+        /// table (emit nothing) — the same faithful headless behavior as a present-but-empty config file
+        /// (WF's <see cref="U.LoadTSVResource"/> returns an empty dict for a missing file).
+        /// </summary>
+        static Dictionary<uint, string[]> LoadConfigTableSafe(string type, ROM rom)
+        {
+            try
+            {
+                return U.LoadTSVResource(U.ConfigDataFilename(type, rom));
+            }
+            catch (Exception)
+            {
+                return new Dictionary<uint, string[]>();
+            }
+        }
+
+        /// <summary>
+        /// <c>OtherTextForm.MakeAllDataLength</c> (slice 2q, version-agnostic call site). WF iterates the
+        /// per-entry list from <c>MakeOtherTextMap()</c> (the <c>other_text_</c> config file, ONE hex
+        /// pointer per line, comment/other-lang filtered, <c>isSafetyOffset</c> gated — reproduced by
+        /// <see cref="TextSourceListCore.MakeOtherTextList"/>), and for each entry <c>p = textlist[i].addr</c>
+        /// reads <c>nameAddr = p32(p + 0)</c>; if <c>isSafetyOffset(nameAddr)</c> it decodes the C string
+        /// (<c>getString(nameAddr, out length)</c>) and emits a BIN block of that exact decoded length
+        /// (<c>AddAddress(nameAddr, length, p + 0, name, BIN)</c> — the byte length of the string WITHOUT a
+        /// trailing-NUL +1, like the MapTerrainName/Text BinString sub-walks). VERBATIM.
+        /// <para>The decode needs a <see cref="CoreState.SystemTextEncoder"/> (set in the real app + CLI
+        /// <c>InitFull</c>). With none loaded the producer SKIPS the per-entry block rather than NRE — the
+        /// embedded string is then un-tracked, but a partial scan is already <c>IsComplete == false</c>
+        /// (mirrors the <see cref="EmitSubWalks"/> encoder-null guard).</para>
+        /// <para>EOF-HARDENING: WF reads <c>p32(p)</c> after only the <c>isSafetyOffset(p)</c> the entry
+        /// list already guarantees; the producer guards the full 4-byte read extent before dereferencing.</para>
+        /// </summary>
+        public static void EmitOtherText(ROM rom, List<Address> list)
+        {
+            // BOTH the entry-list builder (TextSourceListCore.MakeOtherTextList decodes each entry's name
+            // via ROM.getString) AND the per-entry block decode need a CoreState.SystemTextEncoder (set in
+            // the real app + CLI InitFull). Check it FIRST and skip the whole form (don't NRE) when none is
+            // loaded — WF's MakeOtherTextMap would equally need one; mirrors the EmitSubWalks guard.
+            if (CoreState.SystemTextEncoder == null)
+            {
+                return;
+            }
+
+            // MakeOtherTextList reproduces MakeOtherTextMap (the entry's .addr is the config-file offset
+            // p; its .name is irrelevant here — MakeAllDataLength re-decodes the name from nameAddr).
+            // Missing config tree -> empty list -> nothing emitted (faithful headless behavior).
+            List<AddrResult> textlist = TextSourceListCore.MakeOtherTextList(rom);
+
+            for (int i = 0; i < textlist.Count; i++)
+            {
+                uint p = textlist[i].addr;
+                // EOF-harden: p32(p) reads p..p+3. The entry list already isSafetyOffset(p)-gated p, but
+                // guard the full extent so a near-EOF p skips rather than throws.
+                if (p + 4 > (uint)rom.Data.Length)
+                {
+                    continue;
+                }
+                uint nameAddr = rom.p32(0 + p);
+                if (U.isSafetyOffset(nameAddr, rom))
+                {
+                    int length;
+                    string name = rom.getString(nameAddr, out length);
+                    Address.AddAddress(list, nameAddr, (uint)length, p + 0, name,
+                        Address.DataTypeEnum.BIN);
+                }
+            }
+        }
+
+        /// <summary>
+        /// <c>ImageTSAAnimeForm.MakeAllDataLength</c> (slice 2q; WF calls it in the <c>version==8</c> AND
+        /// <c>version==7</c> branches — NOT FE6). WF loads <c>g_TSAAnime = LoadTSVResource(ConfigDataFilename(
+        /// "tsaanime_"))</c> (key = a 4-byte pointer SLOT, value = [count, name, …]). For each entry: the
+        /// slot is <c>pointer = toOffset(key)</c>; <c>addr = p32(pointer)</c> is the anime-record table base;
+        /// <c>count = atoh(value[0])</c> is its FIXED entry count. The main IFR is <c>ReInit(addr, count)</c>
+        /// (block <c>4*3 = 12</c>, pointerIndexes {0,4,8}). Per entry <c>i &lt; count</c> (addr += 12): an
+        /// LZ77 image @ +0, a fixed <c>0x20*8</c>-byte palette @ +4, and an LZ77 TSA @ +8. Reproduced VERBATIM.
+        /// <para>EOF-HARDENING: WF reads <c>p32(pointer)</c> after only <c>isSafetyOffset(pointer)</c>; the
+        /// producer guards the full 4-byte extent. The per-column <c>Address.Add*</c> helpers re-check pointer
+        /// safety and compute the real length (<c>getCompressedSize</c> — 0/never-throws on a malformed stream).</para>
+        /// </summary>
+        public static void EmitImageTSAAnime(ROM rom, List<Address> list)
+        {
+            // WF PreLoadResource(): g_TSAAnime = LoadTSVResource(ConfigDataFilename("tsaanime_")). Load it
+            // fresh here (the producer has no live form to hold the static). Missing config -> empty dict.
+            const uint block = 4 * 3; // ImageTSAAnimeForm.Init BlockSize.
+            var g_TSAAnime = LoadConfigTableSafe("tsaanime_", rom);
+            foreach (var pair in g_TSAAnime)
+            {
+                uint pointer = pair.Key;
+                pointer = U.toOffset(pointer);
+                if (!U.isSafetyOffset(pointer, rom))
+                {
+                    continue;
+                }
+                // EOF-harden: p32(pointer) reads pointer..pointer+3.
+                if (pointer + 4 > (uint)rom.Data.Length)
+                {
+                    continue;
+                }
+                uint addr = rom.p32(pointer);
+                if (!U.isSafetyOffset(addr, rom))
+                {
+                    continue;
+                }
+                uint count = U.atoh(U.at(pair.Value, 0));
+                string basename = "TSAANIME " + U.at(pair.Value, 1) + " ";
+
+                // Main IFR: ReInit(addr, count) -> BaseAddress addr, DataCount count; AddAddress(IFR, ...)
+                // length = block * (count + 1), pointer = BasePointer (= pointer here, safe).
+                uint length = block * (count + 1);
+                list.Add(new Address(addr, length, pointer, basename,
+                    Address.DataTypeEnum.InputFormRef, block, new uint[] { 0, 4, 8 }));
+
+                for (uint i = 0; i < count; i++, addr += block)
+                {
+                    string name = basename + "" + U.To0xHexString(i);
+
+                    Address.AddLZ77Pointer(list, addr + 0, name + " IMAGE", false,
+                        Address.DataTypeEnum.LZ77IMG);
+                    Address.AddPointer(list, addr + 4, 0x20 * 8, name + " PALETTE",
+                        Address.DataTypeEnum.PAL);
+                    Address.AddLZ77Pointer(list, addr + 8, name + " TSA", false,
+                        Address.DataTypeEnum.LZ77TSA);
+                }
+            }
+        }
+
+        /// <summary>
+        /// <c>ImageTSAAnime2Form.MakeAllDataLength</c> (slice 2q; WF calls it in the <c>version==8</c> branch
+        /// ONLY). WF loads <c>g_TSAAnime = LoadTSVResource(ConfigDataFilename("tsaanime2_"))</c> (key = a
+        /// 4-byte pointer SLOT, value = [name, …]). The main IFR is block 12 with IsDataExists =
+        /// <c>isPointer(u32(addr+8))</c>; the N1 IFR is block 20 with IsDataExists = <c>i &lt; 1</c>. Per entry:
+        /// <c>pointer = toOffset(key)</c>; <c>addr = p32(pointer)</c>. N1 <c>ReInitPointer(pointer, 1)</c> makes
+        /// N1.BasePointer = pointer, N1.BaseAddress = addr, N1.DataCount = 1; main <c>ReInit(addr + 20)</c>
+        /// walks the TSA records starting 20 bytes past the header (VARIABLE count via getBlockDataCount).
+        /// WF emits: the main IFR (pointerIndexes {8}), the N1 IFR (pointerIndexes {4,16}); if N1.DataCount
+        /// &gt;= 1 a HEADER pair (LZ77 image @ addr+16, fixed 0x20-byte palette @ addr+4); then it skips the
+        /// 20-byte header (<c>addr += 20</c>) and per record <c>i &lt; main.DataCount</c> (addr += 12) emits a
+        /// header-TSA pointer @ addr+8. Reproduced VERBATIM.
+        /// <para>EOF-HARDENING: the <c>p32(pointer)</c> slot read and the <c>u32(a+8)</c> IsDataExists read
+        /// guard their full extents (getBlockDataCount already bounds addr+block &lt;= Length; the explicit
+        /// guard covers the +8 sub-read and the near-EOF slot). <see cref="EmitHeaderTsaPointer"/> is EOF-safe.</para>
+        /// </summary>
+        public static void EmitImageTSAAnime2(ROM rom, List<Address> list)
+        {
+            const uint block = 12;   // ImageTSAAnime2Form.Init BlockSize.
+            const uint n1Block = 20; // ImageTSAAnime2Form.N1_Init BlockSize.
+            // WF ImageTSAAnime2Form.PreLoadResource(): g_TSAAnime = LoadTSVResource("tsaanime2_").
+            var g_TSAAnime = LoadConfigTableSafe("tsaanime2_", rom);
+            foreach (var pair in g_TSAAnime)
+            {
+                uint pointer = pair.Key;
+                pointer = U.toOffset(pointer);
+                if (!U.isSafetyOffset(pointer, rom))
+                {
+                    continue;
+                }
+                // EOF-harden: p32(pointer) reads pointer..pointer+3.
+                if (pointer + 4 > (uint)rom.Data.Length)
+                {
+                    continue;
+                }
+                uint addr = rom.p32(pointer);
+                if (!U.isSafetyOffset(addr, rom))
+                {
+                    continue;
+                }
+                string basename = "TSAANIME2 " + U.at(pair.Value, 0) + " ";
+
+                // WF: N1_InputFormRef.ReInitPointer(pointer, 1) -> N1.BasePointer = pointer, N1.BaseAddress
+                // = p32(pointer) = addr, N1.DataCount = 1. InputFormRef.ReInit(addr + 20) -> main.BaseAddress
+                // = toOffset(addr + 20), main.DataCount = getBlockDataCount(IsDataExists = isPointer(u32(a+8))),
+                // main.BasePointer is the form default (unset/0).
+                uint mainAddr = U.toOffset(addr + 20);
+                uint mainCount;
+                if (U.isSafetyOffset(mainAddr, rom))
+                {
+                    mainCount = rom.getBlockDataCount(mainAddr, block, (i, a) =>
+                    {
+                        // WF Init IsDataExists: isPointer(u32(a + 8)). getBlockDataCount already bounds
+                        // a + block(12) <= Length, so a + 8 .. a + 11 is in range; guard anyway.
+                        if (a + 12 > (uint)rom.Data.Length)
+                        {
+                            return false;
+                        }
+                        return U.isPointer(rom.u32(a + 8));
+                    });
+                }
+                else
+                {
+                    mainCount = 0;
+                }
+
+                // WF order: AddAddress(main IFR, {8}) FIRST, then AddAddress(N1 IFR, {4,16}).
+                // WF main AddAddress: returns WITHOUT emitting when !isSafetyOffset(main.BaseAddress).
+                if (U.isSafetyOffset(mainAddr, rom))
+                {
+                    uint mainLength = block * (mainCount + 1);
+                    // WF main IFR BasePointer is unset (0) -> AddAddress sets pointer = NOT_FOUND.
+                    list.Add(new Address(mainAddr, mainLength, U.NOT_FOUND, basename,
+                        Address.DataTypeEnum.InputFormRef, block, new uint[] { 8 }));
+                }
+
+                // N1 IFR: ReInitPointer(pointer, 1) -> BasePointer pointer, BaseAddress addr, DataCount 1.
+                // (addr is already isSafetyOffset-checked above, so WF's N1 AddAddress always emits.)
+                uint n1Length = n1Block * (1 + 1);
+                list.Add(new Address(addr, n1Length, pointer, basename,
+                    Address.DataTypeEnum.InputFormRef, n1Block, new uint[] { 4, 16 }));
+
+                if (1 >= 1) // WF: if (N1_InputFormRef.DataCount >= 1) — DataCount is fixed 1 here.
+                {
+                    string name = basename + " HEADER";
+
+                    Address.AddLZ77Pointer(list, addr + 16, name + " IMAGE", false,
+                        Address.DataTypeEnum.LZ77IMG);
+                    Address.AddPointer(list, addr + 4, 0x20, name + " PALETTE",
+                        Address.DataTypeEnum.PAL);
+                }
+
+                uint recAddr = addr + 20; // WF: addr += 20 (SkipHeader).
+                for (uint i = 0; i < mainCount; i++, recAddr += block)
+                {
+                    string name = basename + "" + U.To0xHexString(i);
+
+                    EmitHeaderTsaPointer(rom, list, recAddr + 8, name + " TSA");
+                }
+            }
+        }
+
+        /// <summary>
+        /// <c>ImageRomAnimeForm.MakeAllDataLength</c> (slice 2q, version-agnostic call site). WF loads
+        /// <c>g_ROMAnime = LoadTSVResource(ConfigDataFilename("romanime_"))</c> (value = [imageWidth, option,
+        /// framePointer, tsaPointer, imagePointer, palettePointer, name, …]). Per entry it gates on
+        /// <see cref="CheckRomAnimePonters"/> (pure-ROM), then emits: a 4-byte FRAME pointer + (frameCount*4)
+        /// BIN frame table (frameCount from <see cref="GetRomAnimeFrameCountLow"/>, an <c>u16==0xFFFF</c>
+        /// terminator walk; if NOT_FOUND the whole entry is skipped); a 4-byte TSA pointer + one LZ77 TSA per
+        /// <see cref="GetRomAnimePointerListCount"/> entry; a 4-byte Image pointer + one LZ77 image per list
+        /// entry; a 4-byte Palette pointer + one fixed <c>2*16</c>-byte PAL per
+        /// <see cref="GetRomAnimePalettePointerListCount"/> entry. The per-frame pointer slot is verified
+        /// (<c>p32(baseAddr + i*4) == a</c>) before being used as the relocation pointer (else NOT_FOUND).
+        /// All helpers are reproduced VERBATIM (pure-ROM, EOF-hardened).
+        /// </summary>
+        public static void EmitImageRomAnime(ROM rom, List<Address> list)
+        {
+            // WF ImageRomAnimeForm.PreLoadResource(): g_ROMAnime = LoadTSVResource("romanime_").
+            var g_ROMAnime = LoadConfigTableSafe("romanime_", rom);
+            foreach (var pair in g_ROMAnime)
+            {
+                string[] sp = pair.Value;
+                string option = U.at(sp, 1);
+                uint framePointer = U.atoh(U.at(sp, 2));
+                uint tsaPointer = U.atoh(U.at(sp, 3));
+                uint imagePointer = U.atoh(U.at(sp, 4));
+                uint palettePointer = U.atoh(U.at(sp, 5));
+                string name = U.at(sp, 6);
+
+                if (!CheckRomAnimePonters(rom, framePointer, tsaPointer, imagePointer, palettePointer))
+                {
+                    continue;
+                }
+
+                uint frameCount = U.NOT_FOUND;
+                if (U.isSafetyOffset(framePointer, rom))
+                {
+                    Address.AddAddress(list, framePointer, 4, U.NOT_FOUND,
+                        name + " FRAME Pointer", Address.DataTypeEnum.POINTER);
+                    // WF: the !isPointerOnly branch always runs for a producer scan.
+                    frameCount = GetRomAnimeFrameCountLow(rom, framePointer);
+                    if (frameCount != U.NOT_FOUND)
+                    {
+                        // EOF-harden the p32(framePointer) slot read (isSafetyOffset(framePointer) above
+                        // guards the offset but not the full 4-byte extent on a near-EOF slot).
+                        if (framePointer + 4 <= (uint)rom.Data.Length)
+                        {
+                            uint p = rom.p32(framePointer);
+                            Address.AddAddress(list, p, frameCount * 4, framePointer,
+                                name + " FRAME", Address.DataTypeEnum.BIN);
+                        }
+                    }
+                }
+
+                if (frameCount == U.NOT_FOUND)
+                {
+                    continue;
+                }
+
+                Address.AddAddress(list, tsaPointer, 4, U.NOT_FOUND,
+                    name + " TSA Pointer", Address.DataTypeEnum.POINTER);
+                EmitRomAnimePointerList(rom, list, tsaPointer,
+                    GetRomAnimePointerListCount(rom, tsaPointer),
+                    name + " TSA", Address.DataTypeEnum.LZ77TSA, isPalette: false);
+
+                Address.AddAddress(list, imagePointer, 4, U.NOT_FOUND,
+                    name + " Image Pointer", Address.DataTypeEnum.POINTER);
+                EmitRomAnimePointerList(rom, list, imagePointer,
+                    GetRomAnimePointerListCount(rom, imagePointer),
+                    name + " Image", Address.DataTypeEnum.LZ77IMG, isPalette: false);
+
+                Address.AddAddress(list, palettePointer, 4, U.NOT_FOUND,
+                    name + " Palette Pointer", Address.DataTypeEnum.POINTER);
+                EmitRomAnimePointerList(rom, list, palettePointer,
+                    GetRomAnimePalettePointerListCount(rom, palettePointer, framePointer, option),
+                    name + " Palette", Address.DataTypeEnum.PAL, isPalette: true);
+            }
+        }
+
+        /// <summary>Shared per-pointer-list emission for <see cref="EmitImageRomAnime"/>: walk the resolved
+        /// target list, and for each entry verify the per-entry pointer slot (<c>p32(baseAddr + i*4) == a</c>;
+        /// else relocation pointer = NOT_FOUND) and emit an Address. LZ77 entries use
+        /// <c>LZ77.getCompressedSize</c>; the palette list uses a fixed <c>2*16</c> length. VERBATIM
+        /// reproduction of the three WF column loops (which differ only in length + data type).</summary>
+        static void EmitRomAnimePointerList(ROM rom, List<Address> list, uint listPointer,
+            List<uint> targets, string name, Address.DataTypeEnum type, bool isPalette)
+        {
+            // WF: baseAddr = p32(listPointer). EOF-harden the slot read.
+            uint baseAddr = 0;
+            if (U.isSafetyOffset(listPointer, rom) && listPointer + 4 <= (uint)rom.Data.Length)
+            {
+                baseAddr = rom.p32(listPointer);
+            }
+            for (int i = 0; i < targets.Count; i++)
+            {
+                uint p = baseAddr + ((uint)i * 4);
+                uint a = targets[i];
+                // WF: if (p32(p) != a) p = NOT_FOUND; — the per-entry pointer slot must actually point at
+                // this target to be used as the relocation pointer. EOF-harden the p32(p) read.
+                if (p + 4 > (uint)rom.Data.Length || rom.p32(p) != a)
+                {
+                    p = U.NOT_FOUND;
+                }
+                uint length = isPalette
+                    ? (uint)(2 * 16)
+                    : LZ77.getCompressedSize(rom.Data, U.toOffset(a));
+                Address.AddAddress(list, a, length, p, name, type);
+            }
+        }
+
+        /// <summary>VERBATIM port of WF <c>ImageRomAnimeForm.checkPonters</c>: a pure-ROM gate — if a frame
+        /// pointer slot is present it must hold a safe pointer, and the TSA/image/palette pointer slots must
+        /// each be a safe offset holding a safe pointer. Returns false (skip the entry) otherwise.
+        /// EOF-hardened on every <c>u32</c> slot read.</summary>
+        public static bool CheckRomAnimePonters(ROM rom, uint framePointer, uint tsaPointer,
+            uint imagePointer, uint palettePointer)
+        {
+            if (U.isSafetyOffset(framePointer, rom))
+            {
+                if (framePointer + 4 > (uint)rom.Data.Length)
+                {
+                    return false;
+                }
+                uint frameAddress = rom.u32(framePointer);
+                if (!U.isSafetyPointer(frameAddress, rom))
+                {
+                    return false;
+                }
+            }
+
+            if (!U.isSafetyOffset(tsaPointer, rom) || tsaPointer + 4 > (uint)rom.Data.Length)
+            {
+                return false;
+            }
+            uint tsaAddress = rom.u32(tsaPointer);
+            if (!U.isSafetyPointer(tsaAddress, rom))
+            {
+                return false;
+            }
+
+            if (!U.isSafetyOffset(imagePointer, rom) || imagePointer + 4 > (uint)rom.Data.Length)
+            {
+                return false;
+            }
+            uint imageAddress = rom.u32(imagePointer);
+            if (!U.isSafetyPointer(imageAddress, rom))
+            {
+                return false;
+            }
+
+            if (!U.isSafetyOffset(palettePointer, rom) || palettePointer + 4 > (uint)rom.Data.Length)
+            {
+                return false;
+            }
+            uint paletteAddress = rom.u32(palettePointer);
+            if (!U.isSafetyPointer(paletteAddress, rom))
+            {
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>VERBATIM port of WF <c>ImageRomAnimeForm.GetFrameCountLow</c>: the frame table behind
+        /// <paramref name="framePointer"/> is an uncompressed stream of 4-byte {id, wait} records; the count
+        /// is the number of records before an <c>id == 0xFFFF</c> terminator. A 1 MB limiter (clamped to
+        /// <c>Data.Length</c>) prevents a runaway scan. Returns NOT_FOUND when the pointer / its target is
+        /// not a safe offset. EOF-hardened on every <c>u16</c> read.</summary>
+        public static uint GetRomAnimeFrameCountLow(ROM rom, uint framePointer)
+        {
+            if (!U.isSafetyOffset(framePointer, rom))
+            {
+                return U.NOT_FOUND;
+            }
+            if (framePointer + 4 > (uint)rom.Data.Length)
+            {
+                return U.NOT_FOUND;
+            }
+            uint addr = rom.p32(framePointer);
+            if (!U.isSafetyOffset(addr, rom))
+            {
+                return U.NOT_FOUND;
+            }
+
+            // WF limitter = addr + 1MB, clamped to Data.Length.
+            uint limitter = addr + 1024 * 1024;
+            uint dataLen = (uint)rom.Data.Length;
+            if (limitter > dataLen)
+            {
+                limitter = dataLen;
+            }
+
+            uint i;
+            for (i = 0; addr < limitter; i++, addr += 4)
+            {
+                // WF reads u16(addr) and u16(addr+2); guard the 4-byte record extent.
+                if (addr + 4 > dataLen)
+                {
+                    break;
+                }
+                uint id = rom.u16(addr);
+                if (id == 0xFFFF)
+                {
+                    break;
+                }
+            }
+            return i;
+        }
+
+        /// <summary>VERBATIM port of WF <c>ImageRomAnimeForm.GetPointerListCount</c>: the list behind
+        /// <paramref name="p"/> is a NULL/non-pointer-terminated array of 4-byte ROM pointers; walk
+        /// <c>a = p32(p)</c> forward (step 4) collecting <c>toOffset</c> targets while the slot is a safe
+        /// pointer. If the list resolves to ZERO entries WF still adds a single <c>toOffset(a)</c> fallback
+        /// (the resolved base IS the lone target). EOF-hardened on every <c>u32</c> read.</summary>
+        public static List<uint> GetRomAnimePointerListCount(ROM rom, uint p)
+        {
+            var ret = new List<uint>();
+
+            if (!U.isSafetyOffset(p, rom) || p + 4 > (uint)rom.Data.Length)
+            {
+                return ret;
+            }
+            uint a = rom.p32(p);
+            if (!U.isSafetyOffset(a, rom))
+            {
+                return ret;
+            }
+
+            uint length = (uint)rom.Data.Length - 4;
+            for (; a < length; a += 4)
+            {
+                // WF reads u32(a); a < Data.Length-4 keeps a..a+3 in range.
+                uint p2 = rom.u32(a);
+                if (!U.isSafetyPointer(p2, rom))
+                {
+                    break;
+                }
+                ret.Add(U.toOffset(p2));
+            }
+
+            if (ret.Count <= 0)
+            {
+                ret.Add(U.toOffset(a));
+            }
+            return ret;
+        }
+
+        /// <summary>VERBATIM port of WF <c>ImageRomAnimeForm.GetPalettePointerListCount</c>: like
+        /// <see cref="GetRomAnimePointerListCount"/>, but when the list resolves to ZERO entries the
+        /// fallback depends on <paramref name="option"/>/<paramref name="framePointer"/>: "COMMONPALETTE"
+        /// (or <paramref name="framePointer"/> &gt;= 0x100) adds the single resolved base; a
+        /// <paramref name="framePointer"/> &lt; 0x100 (a FIXED per-frame palette count, not a pointer) adds
+        /// one entry per frame at <c>a + i*(2*16)</c>. EOF-hardened on the <c>u32</c> read.</summary>
+        public static List<uint> GetRomAnimePalettePointerListCount(ROM rom, uint p, uint framePointer,
+            string option)
+        {
+            var ret = new List<uint>();
+
+            if (!U.isSafetyOffset(p, rom) || p + 4 > (uint)rom.Data.Length)
+            {
+                return ret;
+            }
+            uint a = rom.p32(p);
+            if (!U.isSafetyOffset(a, rom))
+            {
+                return ret;
+            }
+
+            uint length = (uint)rom.Data.Length - 4;
+            for (; a < length; a += 4)
+            {
+                uint p2 = rom.u32(a);
+                if (!U.isSafetyPointer(p2, rom))
+                {
+                    break;
+                }
+                ret.Add(U.toOffset(p2));
+            }
+
+            if (ret.Count <= 0)
+            {
+                if (option == "COMMONPALETTE")
+                {
+                    ret.Add(U.toOffset(a));
+                }
+                else if (framePointer < 0x100)
+                {
+                    for (uint i = 0; i < framePointer; i++)
+                    {
+                        ret.Add(U.toOffset(a + (i * (2 * 16))));
+                    }
+                }
+                else
+                {
+                    ret.Add(U.toOffset(a));
+                }
+            }
+            return ret;
         }
 
         // -------------------------------------------------------------------------------------------
@@ -6828,9 +7433,12 @@ namespace FEBuilderGBA
                 //      a SystemTextEncoder to size (they decode the string as a side effect); without one
                 //      the producer falls back to the WF isPointerOnly side (size 0) — the slot is still
                 //      relocated and the target addr recorded, and IsComplete already gates a partial scan.
-                //  OtherTextForm STAYS: it iterates a config file `other_text_*` (U.ConfigDataFilename),
-                //  not a RomInfo table, so it has a headless config-file dependency, not ROM-derived data.)
-                "OtherTextForm",
+                //  OtherTextForm ported in slice 2q (EmitOtherText): its entry list comes from a config
+                //  file (other_text_, one hex pointer per line) via TextSourceListCore.MakeOtherTextList
+                //  (= WF MakeOtherTextMap), and per entry it emits a string-BIN block (length == decoded
+                //  strlen, NO +1) behind the embedded pointer at +0. U.ConfigDataFilename / the line
+                //  reader are in Core (resolving against CoreState.BaseDirectory); a missing config tree
+                //  -> empty list -> nothing emitted (faithful headless behavior).)
                 // images (LZ77/TSA length calc)
                 // (slice 2e ported the FLAT LZ77-image + palette forms whose every length is
                 //  LZ77.getCompressedSize (EOF-safe) or a CONSTANT palette/image size:
@@ -6850,9 +7458,15 @@ namespace FEBuilderGBA
                 //      LZ77 + WorldmapCountyBorder IFR with per-entry ROMTCS + WorldMapIconData IFR].
                 //  The rest STAY, each blocked on a subsystem not yet in Core (a wrong length relocates
                 //  the wrong bytes = silent corruption):
-                //    ImageTSAAnime2Form — its g_TSAAnime table is a config-FILE TSV resource
-                //      (U.LoadTSVResource(U.ConfigDataFilename("tsaanime2_"))) + IFR ReInit/ReInitPointer
-                //      machinery, NOT a RomInfo table (same class of blocker as ImageTSAAnimeForm).
+                //  (slice 2q ported the config-FILE-table TSA-anime forms — once U.ConfigDataFilename /
+                //   U.LoadTSVResource reached Core (resolving config/data/ vs CoreState.BaseDirectory) the
+                //   config-LOAD stopped being a blocker; every per-entry LENGTH is Core-backed (LZ77
+                //   getCompressedSize / const PAL / CalcHeaderTsaLength). EmitImageTSAAnime [v8 + v7] —
+                //   per tsaanime_ entry: ReInit(addr, count=atoh(v[0])) main IFR block 12 PI {0,4,8} +
+                //   per i: LZ77IMG@+0 / PAL 0x20*8@+4 / LZ77TSA@+8. EmitImageTSAAnime2 [v8 ONLY] —
+                //   per tsaanime2_ entry: main block 12 ReInit(addr+20) isPointer(u32(a+8)) PI {8},
+                //   N1 block 20 ReInitPointer(ptr,1) PI {4,16}, HEADER LZ77IMG@addr+16 + PAL 0x20@addr+4,
+                //   then per record HeaderTsa@+8.)
                 //  (slice 2p ported the RecycleOldAnime forms whose length walk is PURE ROM (no Drawing, no
                 //   config) and whose gate/count deps are already in Core:
                 //    ImageMapActionAnimationForm — EmitImageMapActionAnimation: FindMapActionAnimationPointer
@@ -6875,8 +7489,13 @@ namespace FEBuilderGBA
                 //   EmitApPointer, length = ImageUtilAPCore.CalcAPLength [the verbatim Core port of WF
                 //   ImageUtilAP.CalcAPLength = Parse + GetLength, already a tested Core helper]. The count
                 //   rule is MoveIconRule [class-count-bounded]. So it is no longer deferred.)
-                //    ImageRomAnimeForm/ImageTSAAnimeForm — config-file tables (U.ConfigDataFilename
-                //      "romanime_"/"tsaanime_") + dynamic pointer-list frame walks, not RomInfo slots.
+                //  (slice 2q ported ImageRomAnimeForm [all versions] — EmitImageRomAnime: per romanime_
+                //   config entry, CheckRomAnimePonters gate (pure-ROM), then FRAME ptr + BIN
+                //   (frameCount*4, frameCount = GetRomAnimeFrameCountLow u16==0xFFFF terminator walk),
+                //   TSA/Image ptr + per GetRomAnimePointerListCount entry LZ77 (getCompressedSize,
+                //   pointer-verified), Palette ptr + per GetRomAnimePalettePointerListCount entry PAL
+                //   (2*16, with the COMMONPALETTE / framePointer<0x100 / else fallbacks). All pure-ROM
+                //   walks, no Drawing/disasm. ImageTSAAnimeForm ported alongside it — see above.)
                 //    ImagePortraitForm — IsHalfBodyFlag runtime header inspection (+ ImagePortraitFE6Form
                 //      has a stateful nullContinuousCount terminator + GetFEditorLengthHint).
                 //    ImageItemIconForm — out of slice scope: a flat 128-byte icon-SHEET IFR (no LZ77
@@ -6885,9 +7504,7 @@ namespace FEBuilderGBA
                 //      AppendAllASMStructPointersList ASM path, not this producer's data path.)
                 "ImageBattleAnimeForm",
                 "ImageItemIconForm",
-                "ImageRomAnimeForm",
-                "ImageTSAAnimeForm",
-                "ImageTSAAnime2Form", "ImagePortraitForm",
+                "ImagePortraitForm",
                 "MapMiniMapTerrainImageForm",
                 // songs / sound (recycle, embedded inst)
                 // (SoundRoomCGForm [FE7, clean u32-FFFFFFFF table], SoundRoomFE6Form [FE6, clean],


### PR DESCRIPTION
## Summary
**Slice 2q** of #1261 — the **config-file-table** forms. The config-LOAD stopped being a blocker once `U.ConfigDataFilename`/`U.LoadTSVResource` reached Core, so **all 4 forms ported** (every one fully Core-backed — no ImageUtilOAM / System.Drawing / disasm).

## Ported (4 forms — VERBATIM vs WF `MakeAllDataLength`, version-gated [verified vs `U.cs`])
- **OtherTextForm** [version-agnostic] via `EmitOtherText` — entry list via `TextSourceListCore.MakeOtherTextList` (= WF `MakeOtherTextMap`, the `other_text_` config, 1 hex ptr/line); per entry a string-BIN @+0 (length = `strlen`, **no +1**). The encoder-null guard runs FIRST (the list builder itself decodes names → would NRE otherwise).
- **ImageTSAAnimeForm** [`version==8` + `version==7`, NOT v6] via `EmitImageTSAAnime` — `tsaanime_`; main IFR `ReInit(addr, count=atoh(v[0]))` block 12 PI `{0,4,8}` + per record LZ77IMG@+0 / PAL `0x20*8`@+4 / LZ77TSA@+8.
- **ImageTSAAnime2Form** [`version==8` only] via `EmitImageTSAAnime2` — `tsaanime2_`; main block 12 `ReInit(addr+20)` `isPointer(u32(a+8))` PI `{8}` (BasePointer unset → ptr NOT_FOUND), N1 block 20 `ReInitPointer(ptr,1)` PI `{4,16}`; HEADER LZ77IMG@addr+16 + PAL `0x20`@addr+4; per record `HeaderTsaPointer`@+8 (slice-2k primitive). WF order = main IFR THEN N1 (preserved).
- **ImageRomAnimeForm** [version-agnostic] via `EmitImageRomAnime` — `romanime_`; `CheckRomAnimePonters` gate (**raw `u32` + `isSafetyPointer`, NOT `p32`** — verbatim), FRAME ptr+BIN (`frameCount*4` via `GetRomAnimeFrameCountLow` `u16==0xFFFF` walk; entry skipped if NOT_FOUND), TSA/Image ptr+per-list LZ77, Palette ptr+per-list PAL `2*16` (all 3 WF fallbacks — COMMONPALETTE / per-frame `framePointer<0x100` / else — reproduced).

## Robustness (both masked by always-set WF state)
- `U.ConfigDataFilename` does `Path.Combine(CoreState.BaseDirectory, …)` → `ArgumentNullException` when `BaseDirectory` is null (the existing `MakeAllStructPointers` tests don't set it). Added a `LoadConfigTableSafe` try/catch → empty table, doesn't crash the walk (missing/empty config → emits nothing, which is the faithful headless behavior).
- Moved the OtherText encoder-null guard BEFORE the list builder (`MakeOtherTextList` decodes names via `getString`).

## Tests
- RebuildProducer filter: **258 passed / 0 failed** (+14) — per-form shape; the 3 palette fallbacks; raw-`u32` checkPonters gate; near-EOF `Record.Exception`-null; missing/empty-config emit-nothing (via a `WithConfig` temp-config-tree helper); coverage delta. Removed the 4 from `NotYetPortedRaw` + updated 9 stale coverage assertions (slices 2c/2k/2m/2n + 2 base tests).
- FEBuilderGBA.Tests (net9.0-windows): no new failures (the `Skill*`/`SkillSystemsAnime*` env failures are the known `config/patch2`-absent-in-worktree ones).
- EOF self-audit confirmed.

## Still deferred (unchanged)
`ImageBattleAnimeForm` (`ImageUtilOAM` + `ClassForm.MakeClassList` + seat-dedup), `ImagePortraitForm` (`IsHalfBodyFlag`), `ImageItemIconForm` (out of scope).

Part of #1261.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
