### PR TITLE
feat(core): ROM-rebuild producer — SoundRoom + SongTable + MapSetting forms (#1261 slice 2r)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -451,7 +451,10 @@ namespace FEBuilderGBA.Core.Tests
             //  GetNotYetPortedForms_DropsSlice2qConfigForms_KeepsDeferredSiblings.)
             Assert.DoesNotContain("OtherTextForm", notYet);
             Assert.Contains("EventCondForm", notYet);
-            Assert.Contains("SongTableForm", notYet);
+            // (SongTableForm is ported in slice 2r — see
+            //  GetNotYetPortedForms_DropsSlice2rForms_KeepsDeferredSiblings. AIScriptForm stays deferred
+            //  on its per-entry NAME resolver, so it tracks the still-deferred coverage here.)
+            Assert.Contains("AIScriptForm", notYet);
             // ItemForm stays DEFERRED: its StatBooster sub-block size depends on un-ported PatchUtil
             // patch detection. (ClassForm WAS deferred for its MoveCost sub-blocks but is ported in
             // slice 2c — see GetNotYetPortedForms_DropsSlice2cCoveredForms_KeepsDeferredSiblings.)
@@ -480,8 +483,9 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Contains("EventBattleTalkForm", notYet);        // per-entry EventScriptForm.ScanScript
             // (MapTileAnimation1Form/MapTileAnimation2Form are now PORTED in slice 2g; the MapTerrain
             //  lookup tables are now PORTED in slice 2j — see
-            //  GetNotYetPortedForms_DropsSlice2jCoveredForms_KeepsDeferredSiblings.)
-            Assert.Contains("SongTableForm", notYet);              // SongUtil.ParseTrack/RecycleOldInstrument
+            //  GetNotYetPortedForms_DropsSlice2jCoveredForms_KeepsDeferredSiblings. SongTableForm is now
+            //  PORTED in slice 2r — see GetNotYetPortedForms_DropsSlice2rForms_KeepsDeferredSiblings.)
+            Assert.Contains("AIScriptForm", notYet);               // AI name resolver (GetAIName1/2) not in Core
         }
 
         [Fact]
@@ -1707,8 +1711,7 @@ namespace FEBuilderGBA.Core.Tests
                 "EventBattleTalkForm", "EventHaikuForm",
                 "WorldMapEventPointerForm",
                 // (FE8SpellMenuExtendsForm ported in slice 2m -> no longer kept here.)
-                "MapSettingForm",
-                "MonsterWMapProbabilityForm", "SoundRoomForm",
+                "MonsterWMapProbabilityForm",
                 // (StatusOptionForm + SoundFootStepsForm ported in slice 2d -> no longer kept here.
                 //  UnitFE6Form + ItemUsagePointerForm + AIPerform*/AIMapSetting/Mant/ArenaEnemyWeapon
                 //  ported in slice 2f -> no longer kept here. MapTileAnimation1Form/MapTileAnimation2Form +
@@ -1716,8 +1719,9 @@ namespace FEBuilderGBA.Core.Tests
                 //  SupportUnitForm + WorldMapPathForm + EDStaffRollForm + OPPrologueForm + OPClassFontForm
                 //  ported in slice 2h -> no longer kept here. OPClassDemoForm + OPClassDemoFE7Form ported
                 //  in slice 2i -> no longer kept here. MapTerrain{BG,Floor}LookupTableForm + MapPointerForm
-                //  + ExtraUnitForm + ExtraUnitFE8UForm ported in slice 2j -> no longer kept here.)
-                "ItemForm", "SongTableForm",
+                //  + ExtraUnitForm + ExtraUnitFE8UForm ported in slice 2j -> no longer kept here.
+                //  SoundRoomForm + SongTableForm + MapSettingForm ported in slice 2r -> no longer kept here.)
+                "ItemForm", "AIScriptForm", "ImageBattleAnimeForm",
             })
             {
                 Assert.Contains(kept, notYet);
@@ -2307,7 +2311,9 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("MenuDefinitionForm", notYet);
             // sibling forms that genuinely still need un-ported subsystems STAY.
             Assert.Contains("ItemForm", notYet);
-            Assert.Contains("SoundRoomForm", notYet);
+            // (SoundRoomForm ported in slice 2r — see GetNotYetPortedForms_DropsSlice2rForms; AIScriptForm
+            //  stays deferred on its AI name resolver.)
+            Assert.Contains("AIScriptForm", notYet);
             // (ItemWeaponEffectForm ported in slice 2l — see GetNotYetPortedForms_DropsSlice2lCoveredForms.)
         }
 
@@ -3901,7 +3907,8 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("MapTerrainFloorLookupTableForm", notYet);
             Assert.DoesNotContain("MapTerrainBGLookupTableForm", notYet);
             // deferred map siblings STAY (their blocking subsystem is not in Core):
-            Assert.Contains("MapSettingForm", notYet);                 // IsMapSettingEnd + CString
+            // (MapSettingForm is ported in slice 2r — its IsMapSettingEnd text-count cache is now
+            //  reproduced by TextDataCount. ItemForm stays deferred on its StatBooster PatchUtil size.)
             Assert.Contains("ItemForm", notYet);                       // StatBooster size via PatchUtil
 
             // the no-duplicates invariant still holds after the edits.
@@ -4371,8 +4378,8 @@ namespace FEBuilderGBA.Core.Tests
 
             // deferred siblings STAY (their blocking subsystem is not in Core):
             // (NOTE: OPClassDemoForm / OPClassDemoFE7Form were the nested-IFR siblings deferred at
-            //  slice 2h; slice 2i below ports them, so they move to DoesNotContain there.)
-            Assert.Contains("MapSettingForm", notYet);      // IsMapSettingEnd needs WF text-count cache
+            //  slice 2h; slice 2i below ports them, so they move to DoesNotContain there. MapSettingForm
+            //  is ported in slice 2r — its text-count cache is now reproduced by TextDataCount.)
             Assert.Contains("WorldMapEventPointerForm", notYet); // ScanScript
             // (ImageCGFE7UForm is ported in slice 2k — see GetNotYetPortedForms_DropsSlice2kCoveredForms.)
             Assert.DoesNotContain("ImageCGFE7UForm", notYet);
@@ -4767,7 +4774,7 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("OPClassDemoFE7Form", notYet);
 
             // deferred siblings STAY (their blocking subsystem is not in Core):
-            Assert.Contains("MapSettingForm", notYet);           // IsMapSettingEnd needs WF text-count cache
+            // (MapSettingForm is ported in slice 2r — its text-count cache is now reproduced by TextDataCount.)
             Assert.Contains("WorldMapEventPointerForm", notYet); // ScanScript
             Assert.Contains("MonsterWMapProbabilityForm", notYet); // ScanScript skirmish events
             // (ImageCGFE7UForm is ported in slice 2k — see GetNotYetPortedForms_DropsSlice2kCoveredForms.)
@@ -5218,11 +5225,13 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("ExtraUnitFE8UForm", notYet);
 
             // Still deferred (real missing-Core blocker) -> must REMAIN:
-            Assert.Contains("SongTableForm", notYet);                   // SongUtil.ParseTrack/RecycleOldInstrument
+            // (SongTableForm / SoundRoomForm / MapSettingForm are ported in slice 2r — see
+            //  GetNotYetPortedForms_DropsSlice2rForms_KeepsDeferredSiblings. AIScriptForm stays deferred on
+            //  its AI name resolver, ImageBattleAnimeForm on ImageUtilOAM.)
+            Assert.Contains("AIScriptForm", notYet);                    // AI name resolver (GetAIName1/2)
             Assert.Contains("EventUnitForm(RecycleReserveUnits)", notYet); // NewAllocData = editor session state
-            Assert.Contains("SoundRoomForm", notYet);                   // FE7 CString sub-walk + MIX type
+            Assert.Contains("ImageBattleAnimeForm", notYet);            // ImageUtilOAM seat-image walk
             Assert.Contains("ItemForm", notYet);                        // StatBooster size via PatchUtil
-            Assert.Contains("MapSettingForm", notYet);                  // IsMapSettingEnd text-count cache
 
             // the no-duplicates invariant still holds after the edits.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
@@ -6170,8 +6179,11 @@ namespace FEBuilderGBA.Core.Tests
             // ImageUnitMoveIconFrom is PORTED in slice 2n (ImageUtilAPCore.CalcAPLength is in Core) ->
             // it must be GONE (see GetNotYetPortedForms_DropsSlice2nMoveIcon_KeepsDeferredSiblings).
             Assert.DoesNotContain("ImageUnitMoveIconFrom", notYet);
-            // MapSettingForm STAYS — its count rule needs the WF cached text count.
-            Assert.Contains("MapSettingForm", notYet);
+            // (MapSettingForm WAS deferred here on its WF cached-text-count rule, but slice 2r ports it —
+            //  TextDataCount now reproduces TextForm.GetDataCount() byte-faithfully. AIScriptForm stays
+            //  deferred on its AI name resolver.)
+            Assert.DoesNotContain("MapSettingForm", notYet);
+            Assert.Contains("AIScriptForm", notYet);
 
             // the no-duplicates invariant still holds after the edits.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
@@ -7658,6 +7670,361 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Contains("ImageBattleAnimeForm", notYet);
             Assert.Contains("ImagePortraitForm", notYet);
             Assert.Contains("ImageItemIconForm", notYet);
+
+            // no-duplicates invariant still holds.
+            string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
+            Assert.Equal(raw.Length, raw.Distinct().Count());
+        }
+
+        // =====================================================================
+        // slice 2r: SoundRoom + SongTable + MapSetting
+        // =====================================================================
+
+        /// <summary>Run <paramref name="body"/> with a fresh versioned ROM (for RomInfo) set as
+        /// CoreState.ROM + a headless ASCII encoder, restoring both afterwards.</summary>
+        static void WithVersionedRom(string versionString, Action<ROM> body)
+        {
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var rom = MakeVersionedRom(versionString);
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+                body(rom);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
+        }
+
+        // ---- SoundRoom ----
+
+        [Fact]
+        public void EmitSoundRoom_FE8_MainIfrOnly_NoPerEntryNameBin()
+        {
+            // FE8 (version 8): main IFR base p32(sound_room_pointer), block sound_room_datasize, type
+            // InputFormRef_MIX, PI {8,12}, IsDataExists = u32==0xFFFFFFFF stop. NO per-entry sub-walk
+            // (the C-string name BIN is FE7-only).
+            WithVersionedRom("BE8E01", rom =>
+            {
+                uint block = rom.RomInfo.sound_room_datasize; // 16
+                uint slot = rom.RomInfo.sound_room_pointer;   // RomInfo constant
+                uint table = 0x100000;
+                rom.write_u32(slot, Ptr(table));
+                // 2 entries, then a 0xFFFFFFFF terminator at entry 2.
+                rom.write_u32(table + block * 0, Ptr(0x200000)); // song id slot (non-FFFFFFFF)
+                rom.write_u32(table + block * 0 + 12, Ptr(0x210000)); // name ptr (ignored on FE8)
+                rom.write_u32(table + block * 1, Ptr(0x200100));
+                rom.write_u32(table + block * 2, 0xFFFFFFFF); // terminator
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitSoundRoom(rom, list);
+
+                Address mainIfr = list.Single(a => a.Info == "SoundRoom" && a.BlockSize == block);
+                Assert.Equal(table, mainIfr.Addr);
+                Assert.Equal(slot, mainIfr.Pointer);
+                Assert.Equal(block * (2u + 1u), mainIfr.Length); // count 2 -> block*(2+1)
+                Assert.Equal(Address.DataTypeEnum.InputFormRef_MIX, mainIfr.DataType);
+                Assert.Equal(new uint[] { 8, 12 }, mainIfr.PointerIndexes);
+
+                // FE8: no per-entry BIN behind +12.
+                Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.BIN);
+                Assert.Single(list); // just the main IFR
+            });
+        }
+
+        [Fact]
+        public void EmitSoundRoom_FE7_EmitsPerEntryNameBin_StrlenNoPlusOne()
+        {
+            // FE7 (version 7): same main IFR, PLUS a per-entry C-string name BIN (length == strlen, NO +1)
+            // behind the embedded pointer at +12.
+            WithVersionedRom("AE7E01", rom => // FE7U
+            {
+                Assert.Equal(7, rom.RomInfo.version);
+                uint block = rom.RomInfo.sound_room_datasize;
+                uint slot = rom.RomInfo.sound_room_pointer;
+                uint table = 0x100000;
+                uint name0 = 0x300000;
+                uint name1 = 0x300100;
+                rom.write_u32(slot, Ptr(table));
+                rom.write_u32(table + block * 0, Ptr(0x200000));
+                rom.write_u32(table + block * 0 + 12, Ptr(name0));
+                rom.write_u32(table + block * 1, Ptr(0x200100));
+                rom.write_u32(table + block * 1 + 12, Ptr(name1));
+                rom.write_u32(table + block * 2, 0xFFFFFFFF);
+                WriteAsciiZ(rom, name0, "HELLO"); // strlen 5
+                WriteAsciiZ(rom, name1, "AB");    // strlen 2
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitSoundRoom(rom, list);
+
+                Address mainIfr = list.Single(a => a.Info == "SoundRoom" && a.BlockSize == block);
+                Assert.Equal(Address.DataTypeEnum.InputFormRef_MIX, mainIfr.DataType);
+
+                Address b0 = list.Single(a => a.Addr == name0);
+                Assert.Equal(5u, b0.Length); // NO +1
+                Assert.Equal(table + block * 0 + 12, b0.Pointer);
+                Assert.Equal(Address.DataTypeEnum.BIN, b0.DataType);
+                Address b1 = list.Single(a => a.Addr == name1);
+                Assert.Equal(2u, b1.Length);
+                Assert.Equal(table + block * 1 + 12, b1.Pointer);
+            });
+        }
+
+        [Fact]
+        public void EmitSoundRoom_FE7_NoEncoder_SkipsNameBin_NoThrow()
+        {
+            WithVersionedRom("AE7E01", rom =>
+            {
+                uint block = rom.RomInfo.sound_room_datasize;
+                uint slot = rom.RomInfo.sound_room_pointer;
+                uint table = 0x100000;
+                rom.write_u32(slot, Ptr(table));
+                rom.write_u32(table + block * 0, Ptr(0x200000));
+                rom.write_u32(table + block * 0 + 12, Ptr(0x300000));
+                rom.write_u32(table + block * 1, 0xFFFFFFFF);
+                WriteAsciiZ(rom, 0x300000, "X");
+                CoreState.SystemTextEncoder = null; // decode would NRE
+
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitSoundRoom(rom, list));
+                Assert.Null(ex);
+                // Main IFR still emitted; the name BIN skipped gracefully.
+                Assert.Single(list);
+                Assert.Equal("SoundRoom", list[0].Info);
+            });
+        }
+
+        // ---- SongTable ----
+
+        [Fact]
+        public void EmitSongTableAt_MainIfr_AndPerSongHeaderTrack()
+        {
+            // Main IFR block 8, isPointer(u32(addr)) rule, PI {0}. Per entry: SONGTRACK header
+            // (8 + trackcount*4) + per-track SONGSCORE (Padding4(fine-start+1)).
+            var rom = CreateTestRom(0x40000);
+            uint slot = 0x1000;       // SongTable base-pointer SLOT
+            uint songTbl = 0x2000;    // the song-pointer table
+            uint song0Hdr = 0x3000;   // song 0's header (pointed by songTbl[0])
+            uint track0 = 0x3100;     // song 0's track 0 data
+
+            rom.write_u32(slot, Ptr(songTbl));
+            rom.write_u32(songTbl + 8 * 0, Ptr(song0Hdr)); // song 0
+            // songTbl[1] = 0 -> not a pointer -> stop (DataCount 1).
+
+            // song 0 header: [trackcount=1][3 unused][voicegroup ptr][track0 ptr]...
+            rom.write_u8(song0Hdr + 0, 0x01);            // trackcount = 1
+            rom.write_u32(song0Hdr + 4, Ptr(0x3800));    // voicegroup pointer (instpointer = song0Hdr+4)
+            rom.write_u32(song0Hdr + 8, Ptr(track0));    // track 0 pointer (header is 8 bytes + tc*4)
+            // track 0 stream: a couple of wait codes then FINE (0xB1).
+            rom.write_u8(track0 + 0, 0x80); // a WAIT code (in WAIT range)
+            rom.write_u8(track0 + 1, 0xB1); // FINE -> track ends here
+
+            // instrument list (so RecycleOldInstrument has something or gracefully stops)
+            // voicegroup @0x3800: one "without data" square-wave instrument then a terminator type.
+            rom.write_u8(0x3800 + 0, 0x01); // square wave (without data) -> exists
+            rom.write_u8(0x3800 + 12, 0xFF); // unknown type -> stop (DataCount 1)
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitSongTableAt(rom, list, slot);
+
+            // Main song-table IFR.
+            Address mainIfr = list.Single(a => a.Info == "SongTable");
+            Assert.Equal(songTbl, mainIfr.Addr);
+            Assert.Equal(slot, mainIfr.Pointer);
+            Assert.Equal(8u * (1u + 1u), mainIfr.Length); // count 1
+            Assert.Equal(new uint[] { 0 }, mainIfr.PointerIndexes);
+
+            // SONGTRACK header behind the song-0 pointer slot: length 8 + 1*4 = 12.
+            Address hdr = list.Single(a => a.DataType == Address.DataTypeEnum.SONGTRACK);
+            Assert.Equal(song0Hdr, hdr.Addr);
+            Assert.Equal(songTbl + 0, hdr.Pointer);
+            Assert.Equal(8u + 1u * 4u, hdr.Length);
+
+            // SONGSCORE for track 0: start=track0+0, fine=track0+1 -> Padding4(1-0+1)=Padding4(2)=4.
+            Address score = list.Single(a => a.DataType == Address.DataTypeEnum.SONGSCORE);
+            Assert.Equal(track0, score.Addr);
+            Assert.Equal(song0Hdr + 8, score.Pointer); // track 0 pointer slot
+            Assert.Equal(4u, score.Length);
+
+            // Instrument list IFR present (block 12, PI {4,8}). U.ToHexString(0) == "00".
+            Address instIfr = list.Single(a => a.Info == "SongInst00 " && a.BlockSize == 12);
+            Assert.Equal(0x3800u, instIfr.Addr);
+            Assert.Equal(song0Hdr + 4, instIfr.Pointer);
+            Assert.Equal(new uint[] { 4, 8 }, instIfr.PointerIndexes);
+        }
+
+        [Fact]
+        public void EmitRecycleOldInstrument_DirectSoundAndWave_AndDedup()
+        {
+            var rom = CreateTestRom(0x40000);
+            uint slot = 0x1000;     // instrument-list base pointer SLOT
+            uint voca = 0x2000;     // the instrument list
+            uint wave = 0x3000;     // directsound wave data target
+
+            rom.write_u32(slot, Ptr(voca));
+            // entry 0: directsound (type 0x00), data @ +4
+            rom.write_u8(voca + 0, 0x00);
+            rom.write_u32(voca + 4, Ptr(wave));
+            // entry 1: wave (type 0x03), data @ +4 -> fixed 16 block
+            rom.write_u8(voca + 12 + 0, 0x03);
+            rom.write_u32(voca + 12 + 4, Ptr(0x3400));
+            // entry 2: terminator (unknown type)
+            rom.write_u8(voca + 24 + 0, 0xFF);
+
+            // Make wave @0x3000 a valid (non-DPCM) DirectSound: head1!=1 (so not DPCM), and a sane length.
+            rom.write_u8(wave + 0, 0x00);            // not DPCM
+            rom.write_u32(wave + 0xC, 0x00000020);   // sample length field (read by GetDirectSoundWaveDataLength)
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitRecycleOldInstrument(rom, list, "Inst ", slot);
+
+            // Instrument list IFR.
+            Address ifr = list.Single(a => a.Info == "Inst " && a.BlockSize == 12);
+            Assert.Equal(voca, ifr.Addr);
+            Assert.Equal(new uint[] { 4, 8 }, ifr.PointerIndexes);
+
+            // DirectSound block present.
+            Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.SONGINSTDIRECTSOUND
+                && a.Addr == wave && a.Pointer == voca + 4);
+            // Wave block: fixed 16.
+            Address w = list.Single(a => a.DataType == Address.DataTypeEnum.SONGINSTWAVE);
+            Assert.Equal(16u, w.Length);
+            Assert.Equal(voca + 12 + 4, w.Pointer);
+
+            // Dedup: calling again with the same voca pointer adds nothing (already recorded).
+            int before = list.Count;
+            RebuildProducerCore.EmitRecycleOldInstrument(rom, list, "Inst2 ", slot);
+            Assert.Equal(before, list.Count);
+        }
+
+        [Fact]
+        public void GetSoundTablePointer_PrefersRomInfoSlot_WhenItDereferences()
+        {
+            WithVersionedRom("BE8E01", rom =>
+            {
+                uint slot = rom.RomInfo.sound_table_pointer; // 0x28BC for FE8U
+                rom.write_u32(slot, Ptr(0x100000));          // a ROM pointer -> slot is used
+                Assert.Equal(U.toOffset(slot), RebuildProducerCore.GetSoundTablePointer(rom));
+            });
+        }
+
+        [Fact]
+        public void EmitSongTableAt_NearEofPointer_NoThrow()
+        {
+            var rom = CreateTestRom(0x2000);
+            uint slot = (uint)rom.Data.Length - 2; // a 4-byte read at the slot overruns
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.EmitSongTableAt(rom, list, slot));
+            Assert.Null(ex);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitRecycleOldSong_NearEofPointer_NoThrow()
+        {
+            var rom = CreateTestRom(0x2000);
+            uint slot = (uint)rom.Data.Length - 2; // a 4-byte read at the embedded-pointer slot overruns
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.EmitRecycleOldSong(rom, list, "S ", slot));
+            Assert.Null(ex);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitRecycleOldInstrument_NearEofPointer_NoThrow()
+        {
+            var rom = CreateTestRom(0x2000);
+            uint slot = (uint)rom.Data.Length - 2; // a 4-byte read at the embedded-pointer slot overruns
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.EmitRecycleOldInstrument(rom, list, "I ", slot));
+            Assert.Null(ex);
+            Assert.Empty(list);
+        }
+
+        // ---- MapSetting ----
+
+        [Fact]
+        public void EmitMapSetting_FE8_MainIfr_AndPerEntryCString()
+        {
+            // FE8-only. Main IFR base p32(map_setting_pointer), block map_setting_datasize, PI {0}; per
+            // entry a CSTRING (strlen+1) behind the +0 embedded pointer. The IsMapSettingEnd count rule
+            // accepts an entry whose +0 field is a ROM pointer (the common case).
+            WithVersionedRom("BE8E01", rom =>
+            {
+                uint block = rom.RomInfo.map_setting_datasize; // 148
+                uint slot = U.toOffset(rom.RomInfo.map_setting_pointer);
+                uint table = 0x400000;
+                uint name0 = 0x500000;
+                uint name1 = 0x500100;
+                rom.write_u32(slot, Ptr(table));
+                // entry 0/1: +0 is a ROM pointer (-> IsMapSettingEnd returns true) AND the CString name.
+                rom.write_u32(table + block * 0 + 0, Ptr(name0));
+                rom.write_u32(table + block * 1 + 0, Ptr(name1));
+                // entry 2: +0 is 0 (not a pointer) and weather byte 0xFF (>=0xE) -> IsMapSettingEnd false -> stop.
+                rom.write_u8(table + block * 2 + 12, 0xFF);
+                WriteAsciiZ(rom, name0, "MAPNAME"); // strlen 7 -> CSTRING len 8
+                WriteAsciiZ(rom, name1, "X");       // strlen 1 -> CSTRING len 2
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitMapSetting(rom, list);
+
+                Address mainIfr = list.Single(a => a.Info == "MapSetting" && a.BlockSize == block);
+                Assert.Equal(table, mainIfr.Addr);
+                Assert.Equal(slot, mainIfr.Pointer);
+                Assert.Equal(block * (2u + 1u), mainIfr.Length); // count 2
+                Assert.Equal(new uint[] { 0 }, mainIfr.PointerIndexes);
+
+                // Per-entry CSTRING (strlen+1).
+                Address c0 = list.Single(a => a.Addr == name0);
+                Assert.Equal(Address.DataTypeEnum.CSTRING, c0.DataType);
+                Assert.Equal(8u, c0.Length); // 7 + 1
+                Assert.Equal(table + block * 0 + 0, c0.Pointer);
+                Address c1 = list.Single(a => a.Addr == name1);
+                Assert.Equal(2u, c1.Length); // 1 + 1
+            });
+        }
+
+        [Fact]
+        public void IsMapSettingEnd_TextIdOutOfRange_ReturnsFalse()
+        {
+            // When +0 is NOT a ROM pointer, the text-id fields must be < textmax. A map-name id >= textmax
+            // terminates the walk (verbatim WF IsMapSettingEnd).
+            WithVersionedRom("BE8E01", rom =>
+            {
+                uint addr = 0x600000;
+                // +0 not a pointer (0), weather valid (<0xE), a PLIST present so we reach the text checks.
+                rom.write_u8(addr + 12, 0x00);          // weather 0
+                rom.write_u32(addr + 4, Ptr(0x111000)); // plist_direct non-zero / non-FFFFFFFF
+                rom.write_u16(addr + 0x70, 50);         // map1 text id
+
+                Assert.True(RebuildProducerCore.IsMapSettingEnd(rom, addr, textmax: 100)); // 50 < 100 -> in range
+                Assert.False(RebuildProducerCore.IsMapSettingEnd(rom, addr, textmax: 10)); // 50 >= 10 -> stop
+            });
+        }
+
+        // ---- NotYetPorted coverage delta for slice 2r ----
+
+        [Fact]
+        public void GetNotYetPortedForms_DropsSlice2rForms_KeepsDeferredSiblings()
+        {
+            string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
+
+            // slice 2r ports SoundRoom (FE7+FE8), SongTable (all versions), MapSetting (FE8).
+            Assert.DoesNotContain("SoundRoomForm", notYet);
+            Assert.DoesNotContain("SongTableForm", notYet);
+            Assert.DoesNotContain("MapSettingForm", notYet);
+
+            // The siblings flagged by the slice STAY deferred:
+            //  AIScriptForm — its count is now reproducible but the per-entry NAME (GetAIName1/2 ->
+            //    config name list + InputFormRef.GetCommentSA) is not yet in Core.
+            //  ImageBattleAnimeForm — ImageUtilOAM.MakeAllDataLength (the UnCompressFrame seat-image walk)
+            //    + ClassForm.MakeClassList/GetBattleAnimeAddrWhereAddr + the seat-dedup are not in Core.
+            Assert.Contains("AIScriptForm", notYet);
+            Assert.Contains("ImageBattleAnimeForm", notYet);
 
             // no-duplicates invariant still holds.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -680,6 +680,25 @@ namespace FEBuilderGBA
             progress?.Report("Text");
             EmitText(rom, list);
 
+            // ---- slice 2r: SongTableForm (songs + instruments; version-agnostic call site) ----
+            // SongTableForm.MakeAllDataLength is in the WF unconditional section (NOT version-gated). It is
+            // NOT a flat StructDescriptor walk: its base is GetSoundTablePointer (RomInfo slot OR a
+            // signature scan that returns the SLOT, reproduced verbatim), its main IFR is block 8 /
+            // isPointer(u32(addr)) / {0}, and each entry expands the SONG score
+            // (EmitRecycleOldSong = SongUtil.RecycleOldSong: a SONGTRACK header + per-track SONGSCORE blocks
+            // sized from SongMidiCore.ParseTracks' FINE-terminated walk) AND the recursive instrument tree
+            // (EmitRecycleOldInstrument = SongInstrumentForm.RecycleOldInstrument: a block-12 IFR + per-type
+            // DirectSound/Wave/Drum/Multi blocks with a shared visited-list dedup). All pure-ROM walks
+            // (SongDirectSoundWavCore lengths + ParseTracks), NO Drawing / MIDI-import. A dedicated emitter
+            // reproduces it; the dispatch cancel-checks BEFORE calling it (WF DoEvents posture).
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("SongTable");
+            EmitSongTable(rom, list);
+
             // ---- slice 2p: OAM / battle-anime length forms (version-agnostic call site) ----
             // ImageMapActionAnimationForm and the two ImageUtilMagic forms (FEditor / CSA) are all in
             // the WF unconditional section, each internally gated (FindAnimationPointer for MapAction;
@@ -908,6 +927,28 @@ namespace FEBuilderGBA
                 }
                 progress?.Report("ImageTSAAnime");
                 EmitImageTSAAnime(rom, list);
+
+                // ---- slice 2r: SoundRoomForm (FE8 path) + MapSettingForm (FE8 only) ----
+                // WF calls SoundRoomForm.MakeAllDataLength in BOTH the version==8 and version==7 branches;
+                // its FE8 path has NO per-entry sub-walk (the C-string name BIN is FE7-only). MapSettingForm
+                // is version==8-only; its per-entry CSTRING name + the IsMapSettingEnd count rule (which
+                // needs the cached TextForm.GetDataCount, now reproduced byte-faithfully by TextDataCount)
+                // are both Core-backed. Each gets its own cancel-check (WF DoEvents posture).
+                if (ct.IsCancellationRequested)
+                {
+                    progress?.Report("MakeAllStructPointersList cancelled");
+                    return new ProducerResult(list, notYet, cancelled: true);
+                }
+                progress?.Report("SoundRoom");
+                EmitSoundRoom(rom, list);
+
+                if (ct.IsCancellationRequested)
+                {
+                    progress?.Report("MakeAllStructPointersList cancelled");
+                    return new ProducerResult(list, notYet, cancelled: true);
+                }
+                progress?.Report("MapSetting");
+                EmitMapSetting(rom, list);
             }
 
             if (rom.RomInfo.version == 7)
@@ -919,6 +960,19 @@ namespace FEBuilderGBA
                 }
                 progress?.Report("WorldMapImageFE7");
                 EmitWorldMapImageFE7(rom, list);
+
+                // ---- slice 2r: SoundRoomForm (FE7 path) ----
+                // WF calls SoundRoomForm.MakeAllDataLength in the version==7 branch too; the FE7 path ADDS
+                // the per-entry C-string song-name BIN (length == strlen, NO +1) behind the +12 embedded
+                // pointer (EmitSoundRoom selects it by version). MapSettingForm is NOT in the FE7 branch
+                // (the FE7-multibyte MapSettingFE7Form variant stays deferred — different layout).
+                if (ct.IsCancellationRequested)
+                {
+                    progress?.Report("MakeAllStructPointersList cancelled");
+                    return new ProducerResult(list, notYet, cancelled: true);
+                }
+                progress?.Report("SoundRoom");
+                EmitSoundRoom(rom, list);
 
                 // ---- slice 2q: ImageTSAAnimeForm (FE8 + FE7) ----
                 // WF calls ImageTSAAnimeForm.MakeAllDataLength in the version==7 branch too (NOT FE6).
@@ -7391,6 +7445,526 @@ namespace FEBuilderGBA
             };
         }
 
+        // =====================================================================================
+        // slice 2r: SoundRoom + SongTable + MapSetting (misc tractable forms)
+        // =====================================================================================
+
+        /// <summary>
+        /// <c>SoundRoomForm.MakeAllDataLength</c> (slice 2r). Called in the WF version==8 AND version==7
+        /// branches (NOT FE6). Main IFR: base <c>p32(sound_room_pointer)</c>, block
+        /// <c>sound_room_datasize</c>, IsDataExists = <c>u32(addr)==0xFFFFFFFF</c> stop OR
+        /// <c>i&gt;10 &amp;&amp; IsEmpty(addr, datasize*10)</c> stop (both pure ROM reads), pointerIndexes
+        /// {8,12}, type <see cref="Address.DataTypeEnum.InputFormRef_MIX"/>. On FE7 ONLY (the WF
+        /// <c>version==7</c> guard), each entry additionally tracks its C-string song name: a BIN block
+        /// (length == decoded strlen, NO +1) behind the embedded pointer at +12 — reproduced VERBATIM via
+        /// the existing <see cref="SubKind.BinString"/> sub-walk (WF: <c>getString(p32(addr+12))</c> +
+        /// <c>Address.AddAddress(songname, len, addr+12, BIN)</c>; <see cref="Address.AddAddress"/> already
+        /// filters an unsafe/NULL target, so the BinString <c>isSafetyOffset</c> pre-guard is
+        /// byte-equivalent and harder against a near-EOF read). The name BIN needs a SystemTextEncoder; the
+        /// flat sub-walk loop skips it gracefully (and relocates only the main IFR) when none is loaded.
+        /// </summary>
+        public static void EmitSoundRoom(ROM rom, List<Address> list)
+        {
+            // FE7 adds the per-entry C-string name BIN @ +12; FE8 has no per-entry sub-walk.
+            bool isFE7 = rom.RomInfo.version == 7;
+            var d = new StructDescriptor
+            {
+                Name = "SoundRoom",
+                PointerField = r => r.RomInfo.sound_room_pointer,
+                BlockSize = rom.RomInfo.sound_room_datasize,
+                Rule = DataCountRule.TerminatorWithEmptyGuard,
+                RuleOffset = 0,
+                RuleWidth = 4,
+                RuleStopValue = 0xFFFFFFFF,
+                HasEmptyGuard = true,
+                PointerIndexes = new uint[] { 8, 12 },
+                DataType = Address.DataTypeEnum.InputFormRef_MIX,
+                SubWalks = isFE7
+                    ? new List<SubWalk>
+                      {
+                          new SubWalk { EmbeddedPointerOffset = 12, Kind = SubKind.BinString },
+                      }
+                    : null,
+            };
+            WalkAndAdd(rom, list, d);
+        }
+
+        /// <summary>
+        /// <c>SongTableForm.MakeAllDataLength</c> (slice 2r). Called UNCONDITIONALLY (all versions). The
+        /// song table base is <c>GetSoundTablePointer()</c> (reproduced VERBATIM by
+        /// <see cref="GetSoundTablePointer"/>): the <c>sound_table_pointer</c> RomInfo slot when it
+        /// dereferences to a ROM pointer, else the signature-scanned slot (<see cref="FindSongTablePointer"/>
+        /// — returns the SLOT, not the dereferenced table, so the producer keeps the pointer field to
+        /// relocate), else 0. Main IFR: block 8, IsDataExists = <c>isPointer(u32(addr))</c>
+        /// (<see cref="DataCountRule.PointerAt"/> @0), pointerIndexes {0}. Per entry the song SCORE and the
+        /// instrument tree are tracked by <see cref="EmitRecycleOldSong"/> /
+        /// <see cref="EmitRecycleOldInstrument"/> (the verbatim ports of <c>SongUtil.RecycleOldSong</c> /
+        /// <c>SongInstrumentForm.RecycleOldInstrument</c> — both pure-ROM walks, NO Drawing/MIDI-import).
+        /// </summary>
+        public static void EmitSongTable(ROM rom, List<Address> list)
+        {
+            EmitSongTableAt(rom, list, GetSoundTablePointer(rom));
+        }
+
+        /// <summary>SongTable walk from an explicit base-pointer SLOT (test seam — lets a synthetic ROM
+        /// drive the per-entry recycle without the RomInfo/signature base resolution).</summary>
+        public static void EmitSongTableAt(ROM rom, List<Address> list, uint pointer)
+        {
+            const uint block = 8;
+            pointer = U.toOffset(pointer);
+            // HARDEN: guard the slot's full u32 read (root+3) before p32 — a base-pointer slot within 4
+            // bytes of EOF passes isSafetyOffset but its 4-byte read overruns (ROM.p32 only guards addr,
+            // not addr+3). Valid-ROM-equivalent (the real slot is well inside the ROM).
+            if (!U.isSafetyOffset(pointer + 3, rom))
+            {
+                return;
+            }
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                return;
+            }
+
+            // SongTableForm.Init IsDataExists: U.isPointer(u32(addr)). getBlockDataCount bounds
+            // addr+block(8)<=Length, so u32(addr) (addr+3) is always in-bounds.
+            uint dataCount = rom.getBlockDataCount(baseAddr, block,
+                (i, addr) => U.isPointer(rom.u32(addr)));
+
+            // AddressWinForms.AddAddress(list, IFR, "SongTable", {0}): length = block*(count+1).
+            list.Add(new Address(baseAddr, block * (dataCount + 1), pointer, "SongTable",
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { 0 }));
+
+            // Per entry: MakeAllDataLength_Song_And_Inst — the SONG score + the instrument tree.
+            uint songpointer = baseAddr;
+            for (int i = 0; i < dataCount; i++, songpointer += block)
+            {
+                uint songaddr = rom.p32(songpointer);
+                if (!U.isSafetyOffset(songaddr, rom))
+                {
+                    continue;
+                }
+
+                EmitRecycleOldSong(rom, list, "Song" + U.ToHexString(i) + " ", songpointer);
+
+                // instpointer = songaddr + 4 (the voicegroup pointer slot lives 4 bytes into the header).
+                EmitRecycleOldInstrument(rom, list, "SongInst" + U.ToHexString(i) + " ", songaddr + 4);
+            }
+        }
+
+        /// <summary>VERBATIM port of <c>SongTableForm.GetSoundTablePointer()</c>: the RomInfo
+        /// <c>sound_table_pointer</c> slot when <c>u32(slot)</c> is a ROM pointer, else the
+        /// signature-scanned slot (<see cref="FindSongTablePointer"/>) when it is a safe offset whose
+        /// <c>u32</c> is a ROM pointer, else 0. Returns the pointer SLOT (the dereference is the IFR's job).</summary>
+        public static uint GetSoundTablePointer(ROM rom)
+        {
+            uint p = rom.RomInfo.sound_table_pointer;
+            // Guard the slot's full u32 read (root+3) before reading (WF reads it raw on a valid ROM).
+            if (U.isSafetyOffset(p + 3, rom))
+            {
+                uint a = rom.u32(p);
+                if (U.isPointer(a))
+                {
+                    return p;
+                }
+            }
+            p = FindSongTablePointer(rom);
+            if (U.isSafetyOffset(p, rom) && U.isSafetyOffset(p + 3, rom))
+            {
+                uint a = rom.u32(p);
+                if (U.isPointer(a))
+                {
+                    return p;
+                }
+            }
+            return 0;
+        }
+
+        /// <summary>VERBATIM port of <c>SongUtil.FindSongTablePointer(byte[])</c>: grep the 30-byte
+        /// engine signature, the song-table pointer SLOT lives at <c>found + signatureLen + 10</c>; return
+        /// that slot offset when its <c>u32</c> is a ROM pointer, else <c>U.NOT_FOUND</c>. (Distinct from
+        /// Core <c>SongExchangeCore.FindSongTablePointerByScan</c>, which DEREFERENCES and returns the
+        /// TABLE START — the producer needs the SLOT so the pointer field gets relocated.)</summary>
+        public static uint FindSongTablePointer(ROM rom)
+        {
+            byte[] data = rom.Data;
+            byte[] search = new byte[] {
+                0x00, 0xB5, 0x00, 0x04, 0x07, 0x4A, 0x08, 0x49,
+                0x40, 0x0B, 0x40, 0x18, 0x83, 0x88, 0x59, 0x00,
+                0xC9, 0x18, 0x89, 0x00, 0x89, 0x18, 0x0A, 0x68,
+                0x01, 0x68, 0x10, 0x1C, 0x00, 0xF0
+            };
+            uint foundPoint = U.Grep(data, search);
+            if (foundPoint == U.NOT_FOUND)
+            {
+                return U.NOT_FOUND;
+            }
+            uint songpointer = foundPoint + (uint)search.Length + 10;
+            songpointer = U.toOffset(songpointer);
+            // HARDEN: WF reads u32(songpointer) raw; guard the full read extent (root+3) so a signature
+            // match near EOF cannot read past the array (valid-ROM-equivalent — the slot is well inside).
+            if (!U.isSafetyZArray(songpointer + 3, data))
+            {
+                return U.NOT_FOUND;
+            }
+            uint songlist = U.u32(data, songpointer);
+            if (!U.isPointer(songlist))
+            {
+                return U.NOT_FOUND;
+            }
+            return songpointer;
+        }
+
+        /// <summary>VERBATIM port of <c>SongUtil.RecycleOldSong(ref list, basename, track_basepointer)</c>:
+        /// the song HEADER (length <c>8 + trackcount*4</c>, type SONGTRACK) behind the embedded pointer at
+        /// <paramref name="trackBasePointer"/>, plus one SONGSCORE block per track (length
+        /// <c>Padding4(fineaddr - startaddr + 1)</c>, computed from the parsed track stream). The track
+        /// parse is <see cref="SongMidiCore.ParseTracks"/> (the Core port of <c>SongUtil.ParseTrack</c> —
+        /// the same FINE-terminated bytecode walk; only the per-track START / FINE byte addresses are used,
+        /// which the inserted loop-label codes do NOT shift). Pure ROM; no encoder.</summary>
+        public static void EmitRecycleOldSong(ROM rom, List<Address> list, string basename, uint trackBasePointer)
+        {
+            // HARDEN: guard the embedded-pointer slot's full u32 read (root+3) — WF reads it raw after an
+            // isSafetyOffset(slot) check, which does not cover slot+3. EmitSongTableAt always passes an
+            // in-bounds slot (getBlockDataCount bounds base+i*8+8<=Length), but guard for any caller.
+            if (!U.isSafetyOffset(trackBasePointer + 3, rom))
+            {
+                return;
+            }
+            uint trackBaseAddress = rom.u32(trackBasePointer);
+            if (!U.isPointer(trackBaseAddress))
+            {
+                return;
+            }
+            trackBaseAddress = U.toOffset(trackBaseAddress);
+            if (!U.isSafetyOffset(trackBaseAddress, rom))
+            {
+                return;
+            }
+
+            uint trackcount = rom.u8(trackBaseAddress);
+            Address.AddPointer(list, trackBasePointer, 8 + trackcount * 4,
+                basename + "HEADER", Address.DataTypeEnum.SONGTRACK);
+
+            List<SongMidiCore.Track> tracks = SongMidiCore.ParseTracks(rom, trackBaseAddress, trackcount);
+            for (int i = 0; i < tracks.Count; i++)
+            {
+                int len = tracks[i].codes.Count;
+                if (len <= 0)
+                {
+                    continue;
+                }
+                uint startaddr = tracks[i].codes[0].addr;
+                uint fineaddr = tracks[i].codes[len - 1].addr;
+                Address.AddPointer(list, tracks[i].basepointer,
+                    U.Padding4(fineaddr - startaddr + 1),
+                    basename + "TRACK " + U.To0xHexString(i),
+                    Address.DataTypeEnum.SONGSCORE);
+            }
+        }
+
+        /// <summary>VERBATIM port of <c>SongInstrumentForm.RecycleOldInstrument(ref list, basename,
+        /// voca_basepointer)</c>: the instrument-list IFR (block 12, pointerIndexes {4,8}) behind the
+        /// embedded pointer, plus per-entry DirectSound / Wave / Drum / MultiSample blocks. RECURSIVE
+        /// (drum @0x80 and multisample @0x40 recurse into a nested voice table) with a shared
+        /// visited-list dedup (skip when <c>list</c> already holds an Address at the same target) — both
+        /// reproduced exactly. The DirectSound length comes from
+        /// <see cref="FEBuilderGBA.Core.SongDirectSoundWavCore"/> (the Core ports of
+        /// <c>SongUtil.GetDirectSoundWaveDataLength</c> / <c>IsDirectSoundData</c> /
+        /// <c>IsDirectSoundWaveCompressedDPCM</c>); Wave is a fixed 16, MultiSample's sample table is a
+        /// fixed 128. Pure ROM; no encoder. The IFR count rule is the verbatim
+        /// <see cref="SongInstrumentExists"/>.</summary>
+        public static void EmitRecycleOldInstrument(ROM rom, List<Address> list, string basename, uint vocaBasePointer)
+        {
+            // HARDEN: guard the embedded-pointer slot's full u32 read (root+3) — WF reads it raw after an
+            // isSafetyOffset(slot) check, which does not cover slot+3 (a near-EOF slot would throw in
+            // ROM.u32's bounds check). Valid-ROM-equivalent. The recursive calls (addr+4 with addr+12<=
+            // Length from getBlockDataCount) are already in-bounds; this covers the top-level entry slot.
+            if (!U.isSafetyOffset(vocaBasePointer + 3, rom))
+            {
+                return;
+            }
+            uint vocaBaseAddress = rom.u32(vocaBasePointer);
+            if (!U.isPointer(vocaBaseAddress))
+            {
+                return;
+            }
+            vocaBaseAddress = U.toOffset(vocaBaseAddress);
+            if (!U.isSafetyOffset(vocaBaseAddress, rom))
+            {
+                return;
+            }
+
+            // Already-recorded dedup (the WF `recycle[i].Addr == voca_baseaddress` scan over the global
+            // list — prevents the same shared voice table from being relocated twice / infinite recursion).
+            for (int i = 0; i < list.Count; i++)
+            {
+                if (list[i].Addr == vocaBaseAddress)
+                {
+                    return;
+                }
+            }
+
+            const uint block = 12;
+            // SongInstrumentForm.Init IsDataExists (verbatim) — block 12, cap i>=128.
+            uint dataCount = rom.getBlockDataCount(vocaBaseAddress, block,
+                (i, addr) => SongInstrumentExists(rom, i, addr));
+
+            // AddressWinForms.AddAddress(list, IFR, basename, {4,8}): length = block*(count+1).
+            list.Add(new Address(vocaBaseAddress, block * (dataCount + 1), vocaBasePointer, basename,
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { 4, 8 }));
+
+            uint addr = vocaBaseAddress;
+            for (uint i = 0; i < dataCount; i++, addr += block)
+            {
+                uint type = rom.u8(addr);
+                if (type == 0x00 || type == 0x08 || type == 0x10 || type == 0x18)
+                {//directsound wave
+                    uint songdataAddr = rom.p32(addr + 4);
+                    if (!U.isSafetyOffset(songdataAddr, rom))
+                    {
+                        continue;
+                    }
+                    uint sampleLength = FEBuilderGBA.Core.SongDirectSoundWavCore.GetDirectSoundWaveDataLength(rom, songdataAddr);
+                    if (!U.isSafetyLength(songdataAddr + 12 + 4, sampleLength)
+                        || !FEBuilderGBA.Core.SongDirectSoundWavCore.IsDirectSoundData(rom, songdataAddr))
+                    {//broken — record a length-0 marker (verbatim)
+                        Address.AddPointer(list, addr + 4, 0,
+                            basename + U.To0xHexString((int)i) + "DIRECTSOUND(BROKEN)",
+                            Address.DataTypeEnum.SONGINSTDIRECTSOUND);
+                        continue;
+                    }
+
+                    string name = FEBuilderGBA.Core.SongDirectSoundWavCore.IsDirectSoundWaveCompressedDPCM(rom.Data, songdataAddr)
+                        ? "DIRECTSOUND(DPCM COMPRESSED)"
+                        : "DIRECTSOUND";
+                    Address.AddPointer(list, addr + 4, 12 + 4 + sampleLength,
+                        basename + U.To0xHexString((int)i) + name,
+                        Address.DataTypeEnum.SONGINSTDIRECTSOUND);
+                }
+                else if (type == 0x03 || type == 0x0B)
+                {//wave
+                    uint songdataAddr = rom.p32(addr + 4);
+                    if (!U.isSafetyOffset(songdataAddr, rom))
+                    {
+                        continue;
+                    }
+                    Address.AddPointer(list, addr + 4, 16,
+                        basename + U.To0xHexString((int)i) + "WAVE",
+                        Address.DataTypeEnum.SONGINSTWAVE);
+                }
+                else if (type == 0x80)
+                {//drum (recurse)
+                    uint drumVoices = rom.p32(addr + 4);
+                    if (!U.isSafetyOffset(drumVoices, rom))
+                    {
+                        continue;
+                    }
+                    EmitRecycleOldInstrument(rom, list, basename + U.To0xHexString((int)i) + "DRUM ", addr + 4);
+                }
+                else if (type == 0x40)
+                {//multisample (recurse + a fixed 128-byte sample table)
+                    uint multisampleVoices = rom.p32(addr + 4);
+                    uint sampleLocation = rom.p32(addr + 8);
+                    if (!U.isSafetyOffset(multisampleVoices, rom))
+                    {
+                        continue;
+                    }
+                    if (!U.isSafetyOffset(sampleLocation, rom))
+                    {
+                        continue;
+                    }
+                    EmitRecycleOldInstrument(rom, list, basename + U.To0xHexString((int)i) + "MULTI ", addr + 4);
+                    Address.AddPointer(list, addr + 8, 128,
+                        basename + U.To0xHexString((int)i) + "MULTI2",
+                        Address.DataTypeEnum.BIN);
+                }
+            }
+        }
+
+        /// <summary>VERBATIM port of the <c>SongInstrumentForm.Init</c> IsDataExists predicate: an
+        /// instrument slot "exists" while <c>i &lt; 128</c> AND the type byte at +0 is a known instrument
+        /// type whose data pointer(s) are valid ROM pointers. DirectSound/Wave/Drum (0x00/08/10/18/03/0B/80)
+        /// need <c>u32(addr+4)</c> to be a safe pointer; MultiSample (0x40) needs BOTH <c>u32(addr+4)</c>
+        /// and <c>u32(addr+8)</c>; the "without data" square/noise types (0x01..0x0C subset) always exist;
+        /// any other type terminates. <c>getBlockDataCount</c> guards <c>addr+block(12)&lt;=Length</c>, so
+        /// the <c>+0/+4/+8</c> reads are in-bounds.</summary>
+        public static bool SongInstrumentExists(ROM rom, int i, uint addr)
+        {
+            if (i >= 128)
+            {
+                return false;
+            }
+            uint type = rom.u8(addr + 0);
+            if (type == 0x00 || type == 0x08 || type == 0x10 || type == 0x18 // directsound
+                || type == 0x03 || type == 0x0B // wave
+                || type == 0x80) // drum
+            {
+                uint p = rom.u32(addr + 4);
+                if (!U.isSafetyPointer(p, rom))
+                {
+                    return false;
+                }
+                return true;
+            }
+            if (type == 0x40) // multisamples
+            {
+                uint p = rom.u32(addr + 4);
+                if (!U.isSafetyPointer(p, rom))
+                {
+                    return false;
+                }
+                p = rom.u32(addr + 8);
+                if (!U.isSafetyPointer(p, rom))
+                {
+                    return false;
+                }
+                return true;
+            }
+            if (type == 0x01 || type == 0x02 || type == 0x03 // square wave (without data)
+                || type == 0x04 // noise (without data)
+                || type == 0x09 || type == 0x0A || type == 0x0C) // square wave (without data)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// <c>MapSettingForm.MakeAllDataLength</c> (slice 2r). FE8-only (the WF <c>version==8</c> branch).
+        /// Main IFR: base <c>p32(map_setting_pointer)</c>, block <c>map_setting_datasize</c>, IsDataExists
+        /// = <see cref="IsMapSettingEnd"/> (the verbatim <c>MapSettingForm.IsMapSettingEnd</c>, which needs
+        /// the cached text count <c>TextForm.GetDataCount()</c> — reproduced byte-faithfully by
+        /// <see cref="TextDataCount"/>, the same TextForm IFR count walk WF caches via
+        /// <c>UpdateDataCountCache</c> right before MapSetting runs), pointerIndexes {0}. Per entry: a
+        /// CSTRING block (strlen+1) behind the embedded pointer at +0 (the map-setting name) — reproduced
+        /// via the existing <see cref="SubKind.CString"/> sub-walk. NOTE: <c>MapSettingCore.IsMapSettingValid</c>
+        /// is NOT used (its <c>textmax==0</c> guard diverges from WF); this reproduces
+        /// <c>IsMapSettingEnd</c> directly.
+        /// </summary>
+        public static void EmitMapSetting(ROM rom, List<Address> list)
+        {
+            uint block = rom.RomInfo.map_setting_datasize;
+            if (block == 0)
+            {
+                return; // a zero block would make getBlockDataCount spin; not real data.
+            }
+            uint pointer = U.toOffset(rom.RomInfo.map_setting_pointer);
+            // HARDEN: guard the slot's full u32 read (root+3) before p32 (a near-EOF RomInfo pointer would
+            // throw in ROM.u32). Valid-ROM-equivalent (map_setting_pointer is a constant well inside ROM).
+            if (!U.isSafetyOffset(pointer + 3, rom))
+            {
+                return;
+            }
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                return;
+            }
+
+            // The text-count cap inside IsMapSettingEnd is constant across the whole walk (WF caches it
+            // once); compute it ONCE so the closure does not re-walk the text table per entry.
+            uint textmax = TextDataCount(rom);
+            uint dataCount = rom.getBlockDataCount(baseAddr, block,
+                (i, addr) => IsMapSettingEnd(rom, addr, textmax));
+
+            // AddressWinForms.AddAddress(list, IFR, "MapSetting", {0}): length = block*(count+1).
+            list.Add(new Address(baseAddr, block * (dataCount + 1), pointer, "MapSetting",
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { 0 }));
+
+            // Per entry: Address.AddCString(list, addr + 0) — the map-setting name C-string (strlen+1).
+            // Needs a SystemTextEncoder; skip gracefully (don't NRE) when none is loaded — the main IFR
+            // is still emitted and the slot relocated.
+            if (CoreState.SystemTextEncoder == null)
+            {
+                return;
+            }
+            uint entry = baseAddr;
+            for (uint i = 0; i < dataCount; i++, entry += block)
+            {
+                Address.AddCString(list, entry + 0);
+            }
+        }
+
+        /// <summary>VERBATIM port of <c>MapSettingForm.IsMapSettingEnd(addr)</c> — the per-entry
+        /// "this slot still holds a valid map setting" predicate (WF's name is misleading; it returns TRUE
+        /// while data exists). A <c>u32(addr+0)</c> that is a ROM pointer always exists; otherwise the
+        /// weather / PLIST / four text-id (map name + clear condition) fields must all be in range, where
+        /// the upper bound for the text ids is <paramref name="textmax"/> (= <c>TextForm.GetDataCount()</c>).
+        /// All pure-ROM reads; <c>getBlockDataCount</c> guards <c>addr+block(148)&lt;=Length</c>, so the
+        /// deepest read (<c>u16(addr+0x8A)</c>) is in-bounds.</summary>
+        public static bool IsMapSettingEnd(ROM rom, uint addr, uint textmax)
+        {
+            uint a = rom.u32(addr + 0);
+            if (U.isPointer(a))
+            {
+                return true;
+            }
+
+            // CP-zeroed map guard.
+            uint weather = rom.u8(addr + 12);
+            if (weather >= 0xE)
+            {
+                return false;
+            }
+            uint plistDirect = rom.u32(addr + 4);
+            if (plistDirect == 0 || plistDirect == 0xFFFFFFFF)
+            {
+                plistDirect = rom.u32(addr + 8);
+                if (plistDirect == 0 || plistDirect == 0xFFFFFFFF)
+                {
+                    return false;
+                }
+            }
+            uint map1 = rom.u16(addr + 0x70);
+            if (map1 >= textmax)
+            {
+                return false;
+            }
+            uint map2 = rom.u16(addr + 0x72);
+            if (map2 >= textmax)
+            {
+                return false;
+            }
+            uint clearcond1 = rom.u16(addr + 0x88);
+            if (clearcond1 >= textmax)
+            {
+                return false;
+            }
+            uint clearcond2 = rom.u16(addr + 0x8A);
+            if (clearcond2 >= textmax)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>Byte-faithful reproduction of <c>TextForm.GetDataCount()</c> (the cached text-table
+        /// entry count). WF caches it via <c>TextForm.UpdateDataCountCache</c> inside
+        /// <c>TextForm.MakeAllDataLength</c>, which runs (line 2428) BEFORE <c>MapSettingForm</c> (line
+        /// 2524) — so the cached value equals the TextForm IFR's DataCount computed via the SAME walk
+        /// <see cref="EmitTextAt"/> uses. Returns 0 when the text pointer is unrecoverable (no entries).</summary>
+        public static uint TextDataCount(ROM rom)
+        {
+            const uint block = 4;
+            uint pointer = U.toOffset(rom.RomInfo.text_pointer);
+            if (!U.isSafetyOffset(pointer + 3, rom))
+            {
+                return 0;
+            }
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                // WF TextForm.Init: a broken text pointer ReInits to text_recover_address.
+                baseAddr = U.toOffset(rom.RomInfo.text_recover_address);
+                if (!U.isSafetyOffset(baseAddr, rom))
+                {
+                    return 0;
+                }
+            }
+            return rom.getBlockDataCount(baseAddr, block,
+                (i, addr) => IsTextEntryExists(rom, rom.u32(addr)));
+        }
+
         /// <summary>
         /// The <c>MakeAllDataLength</c> statics from <c>U.MakeAllStructPointersList</c> /
         /// <c>U.AppendAllASMStructPointersList</c> that this slice does <b>not</b> yet port.
@@ -7512,17 +8086,22 @@ namespace FEBuilderGBA
                 "MapMiniMapTerrainImageForm",
                 // songs / sound (recycle, embedded inst)
                 // (SoundRoomCGForm [FE7, clean u32-FFFFFFFF table], SoundRoomFE6Form [FE6, clean],
-                //  and WorldMapBGMForm [FE8, clean] ported in this sweep. SoundFootStepsForm ported in
+                //  and WorldMapBGMForm [FE8, clean] ported in earlier sweeps. SoundFootStepsForm ported in
                 //  slice 2d — Switch2-gated dedicated walker (base/count from sound_foot_steps_switch2_address,
-                //  IsSwitch2Enable gate) + per-entry ASM AddFunction. SoundRoomForm STAYS — its FE7
-                //  path adds a per-entry getString C-string sub-walk + InputFormRef_MIX type.
-                //  SongTableForm STAYS — although its main IFR (sound_table_pointer, block 8, rule
-                //  isPointer(u32(addr)), PI {0}) is trivial, each entry's LENGTH needs SongUtil.RecycleOldSong
-                //  (= SongUtil.ParseTrack, a music-track bytecode/FINE-address walk) + SongInstrumentForm.
-                //  RecycleOldInstrument (an instrument-tree walk) — NEITHER in Core (the Song*Core files are
-                //  MIDI import/export only). Porting just the main IFR would leave the song-score + instrument
-                //  data un-tracked -> dangling pointers on rebuild = corruption.)
-                "SongTableForm", "SoundRoomForm",
+                //  IsSwitch2Enable gate) + per-entry ASM AddFunction.
+                //  SoundRoomForm ported in slice 2r (EmitSoundRoom) — FE8 + FE7 (NOT FE6): main IFR base
+                //  p32(sound_room_pointer), block sound_room_datasize, IsDataExists u32==0xFFFFFFFF /
+                //  i>10 && IsEmpty(addr, datasize*10) (= TerminatorWithEmptyGuard width 4), PI {8,12},
+                //  InputFormRef_MIX. FE7-only per-entry: a string-BIN (length == strlen, NO +1) behind the
+                //  +12 embedded pointer (SubKind.BinString — getString-backed, encoder-skipped gracefully).
+                //  SongTableForm ported in slice 2r (EmitSongTable) — base GetSoundTablePointer (RomInfo slot
+                //  OR a verbatim signature scan returning the SLOT), main IFR block 8 / isPointer(u32(addr))
+                //  / {0}; per entry EmitRecycleOldSong (= SongUtil.RecycleOldSong: SONGTRACK header [8+tc*4]
+                //  + per-track SONGSCORE [Padding4(fine-start+1)] from SongMidiCore.ParseTracks) AND
+                //  EmitRecycleOldInstrument (= SongInstrumentForm.RecycleOldInstrument: a recursive block-12
+                //  IFR with shared visited-list dedup + per-type DirectSound [SongDirectSoundWavCore length] /
+                //  Wave [16] / Drum / Multi [128] blocks). ALL pure-ROM walks — the Song*Core files DO hold
+                //  the parse + DirectSound-length ports the deferral once thought were MIDI-only.)
                 // embedded sub-pointer / event-scan / CString expansion
                 // (ClassForm + StatusParamForm ported in slice 2c — per-entry MoveCost / CString
                 //  sub-walks. ItemForm STAYS: its StatBooster sub-block SIZE depends on un-ported
@@ -7566,14 +8145,17 @@ namespace FEBuilderGBA
                 //  [flat u16!=0 table + per-entry ASM AddFunction @4 via SubKind.AsmFunction] ported in
                 //  slice 2f. AIScriptForm STAYS — its per-entry CalcLength helpers ARE pure ROM walks
                 //  (AIScriptForm.CalcLength = AI 16-byte-opcode terminator walk; AIUnitsForm.CalcLength =
-                //  u16!=0 walk), but its MAIN-IFR COUNT RULE (AIScriptForm.Init IsDataExists) is NOT a pure
-                //  ROM read: in the un-extended-ROM case (the vanilla AI tables) it caps DataCount at the
-                //  config-file AI name lists EventUnitForm.AI1.Count / AI2.Count (loaded from ai1_*/ai2_*
-                //  TSV via PreLoadResourceAI1/2, then padded up to DataCount — circular + editor session
-                //  state), neither of which is in Core. A wrong main count => wrong # of AISCRIPT/AIUnits
-                //  sub-blocks emitted => relocates the wrong bytes on rebuild = corruption. Same shape as
-                //  the MapSettingForm deferral (count rule needs a WF cached resource). Deferred until the
-                //  AI name lists + isExtrendsROMArea reach Core.)
+                //  u16!=0 walk) AND its main-IFR COUNT rule is now reproducible: isExtrendsROMArea is a
+                //  trivial `addr >= toOffset(extends_address)` test, and the un-extended cap = the number of
+                //  data lines in the ai1_/ai2_ config TSV (Program.cs loads PreLoadResourceAI1/2 ONCE at
+                //  ROM-load — NOT editor session state — and DataCount, called inside Init's IsDataExists,
+                //  sees AI{1,2}.Count == the pre-padding config-line-count, so the circularity resolves to
+                //  the TSV line count, loadable headless via the slice-2q ConfigDataFilename/TSV reader).
+                //  The REMAINING blocker is the per-entry NAME (EventUnitForm.GetAIName1/2): faithfully it is
+                //  the loaded config name OR, for padded entries, InputFormRef.GetCommentSA(p32(addr)) — the
+                //  comment-symbol resolver, NOT in Core. The tests assert name verbatim, so a byte-faithful
+                //  port needs the AI name-list loader + GetCommentSA in Core first (the length/count/pointer/
+                //  datatype are all ready). Deferred on the NAME, not the count, until those reach Core.)
                 "AIScriptForm",
                 // skills (version/patch dependent)
                 // (slice 2o ported the RecycleOldAnime-FREE subset, all dependencies already in Core:
@@ -7673,11 +8255,13 @@ namespace FEBuilderGBA
                 //    porting only the flat tables would drop those skirmish-event regions = corruption.
                 //  WorldMapEventPointerForm [ScanScript],
                 //  EventBattleTalkForm + EventHaikuForm [FE8, ScanScript per-entry],
-                //  MapSettingForm [FE8] STAYS — its count rule (IsMapSettingEnd) needs the WF cached
-                //    text count (TextForm.GetDataCount() / g_GetDataCount_Cache, NOT in Core); the
-                //    extracted MapSettingCore.IsMapSettingValid diverges (its `if (textmax>0)` guard
-                //    returns true when textmax==0, where WF returns false), so the per-entry CString
-                //    count is not yet faithfully reproducible — a wrong count = silent corruption.
+                //  MapSettingForm [FE8] ported in slice 2r (EmitMapSetting) — its count rule
+                //    (IsMapSettingEnd, reproduced VERBATIM) needs the WF cached text count
+                //    TextForm.GetDataCount(); that is now byte-faithfully reproduced by TextDataCount (the
+                //    SAME TextForm IFR count walk EmitText uses, which WF caches via UpdateDataCountCache at
+                //    line 2428, BEFORE MapSetting at line 2524). It does NOT use MapSettingCore.IsMapSetting-
+                //    Valid (whose textmax==0 guard diverges from WF). Main IFR block map_setting_datasize,
+                //    PI {0}; per entry a CSTRING (strlen+1) behind the +0 embedded pointer (SubKind.CString).
                 //  (FE8SpellMenuExtendsForm ported in slice 2m — EmitFE8SpellMenuExtends, FE8U-only: the
                 //   base is resolved by the patch-signature scan FE8SpellMenuPatchScanner.FindFE8Spell-
                 //   PatchPointer (the Core port of WF FindFE8SpellPatchPointer — OldSystem .dmp grep +
@@ -7690,7 +8274,6 @@ namespace FEBuilderGBA
                 "EventBattleTalkForm",
                 "WorldMapEventPointerForm",
                 "EventHaikuForm",
-                "MapSettingForm",
                 // patch / procs / ASM — OUT OF SCOPE for this data-path producer: these are emitted by
                 // U.AppendAllASMStructPointersList (the ASM/LDR-map path), NOT U.MakeAllStructPointersList.
                 // (EventFunctionPointerForm / Command85PointerForm above are likewise ASM-path forms.)

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -7836,8 +7836,10 @@ namespace FEBuilderGBA
         /// the cached text count <c>TextForm.GetDataCount()</c> — reproduced byte-faithfully by
         /// <see cref="TextDataCount"/>, the same TextForm IFR count walk WF caches via
         /// <c>UpdateDataCountCache</c> right before MapSetting runs), pointerIndexes {0}. Per entry: a
-        /// CSTRING block (strlen+1) behind the embedded pointer at +0 (the map-setting name) — reproduced
-        /// via the existing <see cref="SubKind.CString"/> sub-walk. NOTE: <c>MapSettingCore.IsMapSettingValid</c>
+        /// CSTRING block (strlen+1) behind the embedded pointer at +0 (the map-setting name) — emitted by
+        /// this dedicated walker's own per-entry loop calling <see cref="Address.AddCString"/> directly
+        /// (same emission as <c>SubKind.CString</c>, but EmitMapSetting is not a descriptor/SubWalk form).
+        /// NOTE: <c>MapSettingCore.IsMapSettingValid</c>
         /// is NOT used (its <c>textmax==0</c> guard diverges from WF); this reproduces
         /// <c>IsMapSettingEnd</c> directly.
         /// </summary>


### PR DESCRIPTION
## Summary
**Slice 2r** of #1261 — more of the tail, now tractable as Core grew. 3 forms ported (all byte-faithful, helpers verbatim vs WF, grep-Core-first confirmed); 2 deferred with refined blockers. Notable: two **divergence-avoidance** calls where an existing Core helper is ADAPTED/divergent, so the WF behavior was reproduced instead.

## Ported (3 forms — VERBATIM vs WF, version-gated [verified vs `U.cs`])
- **SoundRoomForm** [FE8 + FE7, NOT FE6 — `version==8`@2516 + `version==7`@2555] via `EmitSoundRoom` — main IFR `TerminatorWithEmptyGuard(width4, stop 0xFFFFFFFF)`, PI `{8,12}`, `InputFormRef_MIX`; FE7-only per-entry name BIN (`strlen`, no +1) @+12 via the existing `SubKind.BinString` (`getString`, Core).
- **SongTableForm** [all versions — `U.cs:2424`] via `EmitSongTable` — base = verbatim `GetSoundTablePointer` + `FindSongTablePointer` (**reproduced because Core's `SongExchangeCore.FindSongTablePointerByScan` DIVERGES** — it dereferences to the table START rather than returning the SLOT, which the producer needs for the pointer field). Per entry: `EmitRecycleOldSong` (`SongMidiCore.ParseTracks` FINE-walk) + recursive `EmitRecycleOldInstrument` (`SongDirectSoundWavCore` lengths + shared visited-list dedup). All Core-backed / pure-ROM.
- **MapSettingForm** [FE8-only — `version==8`@2524] via `EmitMapSetting` — verbatim `IsMapSettingEnd` + a new `TextDataCount` that reproduces `TextForm.GetDataCount()` **byte-faithfully** (the same TextForm IFR count `EmitText` uses; WF caches it via `UpdateDataCountCache` at line 2428, BEFORE MapSetting at 2524). **Did NOT use `MapSettingCore.IsMapSettingValid`** — its `textmax==0` guard diverges from WF (the slice-2h finding). Per-entry CSTRING @+0.

## Deferred (2, refined blockers)
- **AIScriptForm** — the COUNT is now reproducible (`isExtrendsROMArea` is trivial; the un-extended cap is the `ai1_`/`ai2_` config TSV line count, loaded by `Program.cs` at ROM-load — **NOT editor session state as the old comment claimed**; corrected). The REMAINING blocker is the per-entry NAME (`GetAIName1/2` → config name list + `InputFormRef.GetCommentSA`), not in Core. Length/count/pointer/datatype are ready; deferred on NAME only.
- **ImageBattleAnimeForm** — `ImageUtilOAM.MakeAllDataLength` (UnCompressFrame seat-walk) + `ClassForm.MakeClassList` / `GetBattleAnimeAddrWhereAddr` + seat-dedup, not in Core (its own slice).

## Tests
- RebuildProducer filter: **270 passed / 0 failed** (+14) — per-form addr/length/pointer/DataType/name/order; 3 near-EOF `Record.Exception`-null (caught + fixed a real `IndexOutOfRange` in `EmitSongTableAt`); coverage delta. Removed the 3 forms from `NotYetPortedRaw` + fixed 8 stale deferred-sibling assertions.
- FEBuilderGBA.Tests (net9.0-windows): no new failures (the `Skill*`/`SkillSystemsAnime*` env failures are the known `config/patch2`-absent-in-worktree ones).
- EOF self-audit: every raw `u32`/`p32` on a computed slot guards `root+3` (the WF reads several raw after only `isSafetyOffset(slot)` — valid-ROM-equivalent hardening, documented).

Part of #1261.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
