### PR TITLE
feat(core): ROM-rebuild producer — AIScript + ImageBattleAnime forms (#1261 slice 2s)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -5907,6 +5907,19 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Null(ex);
         }
 
+        [Fact]
+        public void CalcAIScriptLength_NullOrUnsafeStart_ReturnsZero_NoScan()
+        {
+            // Regression (PR #1293 review): a NULL/unsafe entry must return 0 immediately rather than
+            // scanning from offset 0 + computing a huge length. (Same guard added to CalcAIUnitsLength.)
+            var rom = CreateTestRom(0x2000);
+            Assert.Equal(0u, RebuildProducerCore.CalcAIScriptLength(rom, 0));               // NULL entry
+            Assert.Equal(0u, RebuildProducerCore.CalcAIScriptLength(rom, 0x100));           // below 0x200
+            Assert.Equal(0u, RebuildProducerCore.CalcAIScriptLength(rom, (uint)rom.Data.Length)); // >= EOF
+            Assert.Equal(0u, RebuildProducerCore.CalcAIUnitsLength(rom, 0));
+            Assert.Equal(0u, RebuildProducerCore.CalcAIUnitsLength(rom, (uint)rom.Data.Length));
+        }
+
         // ---- CalcAIUnitsLength (verbatim AIUnitsForm.CalcLength u16==0 walk) -
 
         [Fact]

--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -451,10 +451,11 @@ namespace FEBuilderGBA.Core.Tests
             //  GetNotYetPortedForms_DropsSlice2qConfigForms_KeepsDeferredSiblings.)
             Assert.DoesNotContain("OtherTextForm", notYet);
             Assert.Contains("EventCondForm", notYet);
-            // (SongTableForm is ported in slice 2r — see
-            //  GetNotYetPortedForms_DropsSlice2rForms_KeepsDeferredSiblings. AIScriptForm stays deferred
-            //  on its per-entry NAME resolver, so it tracks the still-deferred coverage here.)
-            Assert.Contains("AIScriptForm", notYet);
+            // (SongTableForm is ported in slice 2r; AIScriptForm + ImageBattleAnimeForm in slice 2s —
+            //  see GetNotYetPortedForms_DropsSlice2sForms_KeepsDeferredSiblings. EventCondForm above
+            //  still tracks the deferred coverage here.)
+            Assert.DoesNotContain("AIScriptForm", notYet);
+            Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
             // ItemForm stays DEFERRED: its StatBooster sub-block size depends on un-ported PatchUtil
             // patch detection. (ClassForm WAS deferred for its MoveCost sub-blocks but is ported in
             // slice 2c — see GetNotYetPortedForms_DropsSlice2cCoveredForms_KeepsDeferredSiblings.)
@@ -484,8 +485,9 @@ namespace FEBuilderGBA.Core.Tests
             // (MapTileAnimation1Form/MapTileAnimation2Form are now PORTED in slice 2g; the MapTerrain
             //  lookup tables are now PORTED in slice 2j — see
             //  GetNotYetPortedForms_DropsSlice2jCoveredForms_KeepsDeferredSiblings. SongTableForm is now
-            //  PORTED in slice 2r — see GetNotYetPortedForms_DropsSlice2rForms_KeepsDeferredSiblings.)
-            Assert.Contains("AIScriptForm", notYet);               // AI name resolver (GetAIName1/2) not in Core
+            //  PORTED in slice 2r; AIScriptForm + ImageBattleAnimeForm in slice 2s — see
+            //  GetNotYetPortedForms_DropsSlice2sForms_KeepsDeferredSiblings.)
+            Assert.DoesNotContain("AIScriptForm", notYet);
         }
 
         [Fact]
@@ -1720,12 +1722,17 @@ namespace FEBuilderGBA.Core.Tests
                 //  ported in slice 2h -> no longer kept here. OPClassDemoForm + OPClassDemoFE7Form ported
                 //  in slice 2i -> no longer kept here. MapTerrain{BG,Floor}LookupTableForm + MapPointerForm
                 //  + ExtraUnitForm + ExtraUnitFE8UForm ported in slice 2j -> no longer kept here.
-                //  SoundRoomForm + SongTableForm + MapSettingForm ported in slice 2r -> no longer kept here.)
-                "ItemForm", "AIScriptForm", "ImageBattleAnimeForm",
+                //  SoundRoomForm + SongTableForm + MapSettingForm ported in slice 2r -> no longer kept here.
+                //  AIScriptForm + ImageBattleAnimeForm ported in slice 2s -> no longer kept here.)
+                "ItemForm",
             })
             {
                 Assert.Contains(kept, notYet);
             }
+
+            // slice 2s ported AIScriptForm + ImageBattleAnimeForm -> they must now be GONE.
+            Assert.DoesNotContain("AIScriptForm", notYet);
+            Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
         }
 
         [Fact]
@@ -2312,8 +2319,8 @@ namespace FEBuilderGBA.Core.Tests
             // sibling forms that genuinely still need un-ported subsystems STAY.
             Assert.Contains("ItemForm", notYet);
             // (SoundRoomForm ported in slice 2r — see GetNotYetPortedForms_DropsSlice2rForms; AIScriptForm
-            //  stays deferred on its AI name resolver.)
-            Assert.Contains("AIScriptForm", notYet);
+            //  ported in slice 2s — see GetNotYetPortedForms_DropsSlice2sForms.)
+            Assert.DoesNotContain("AIScriptForm", notYet);
             // (ItemWeaponEffectForm ported in slice 2l — see GetNotYetPortedForms_DropsSlice2lCoveredForms.)
         }
 
@@ -3071,8 +3078,9 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("ImageCGForm", notYet);
             Assert.DoesNotContain("ImageSystemIconForm", notYet);
             Assert.DoesNotContain("WorldMapImageForm", notYet);
-            // still deferred (need ImageUtil OAM / runtime-inspection subsystems):
-            Assert.Contains("ImageBattleAnimeForm", notYet);
+            // (ImageBattleAnimeForm ported in slice 2s — see GetNotYetPortedForms_DropsSlice2sForms.)
+            Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
+            // still deferred (runtime-inspection / out-of-scope subsystems):
             Assert.Contains("ImagePortraitForm", notYet);
             Assert.Contains("ImageItemIconForm", notYet);
             // (ImageTSAAnimeForm / ImageTSAAnime2Form were the config-file TSA-anime siblings here; slice
@@ -3497,8 +3505,9 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("ItemUsagePointerForm", notYet);
             Assert.DoesNotContain("UnitFE6Form", notYet);
 
+            // (AIScriptForm ported in slice 2s — see GetNotYetPortedForms_DropsSlice2sForms.)
+            Assert.DoesNotContain("AIScriptForm", notYet);
             // deferred siblings STAY (their blocking subsystem is not in Core):
-            Assert.Contains("AIScriptForm", notYet);              // AI bytecode CalcLength + nested LZ77
             Assert.Contains("UnitActionPointerForm", notYet);     // PatchUtil SearchUnitActionReworkPatch
             Assert.Contains("MonsterWMapProbabilityForm", notYet);// EventScriptForm.ScanScript skirmish
             // (the 5 map-PLIST forms that were deferred "for slice size" here are now PORTED in slice 2g
@@ -5225,12 +5234,11 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("ExtraUnitFE8UForm", notYet);
 
             // Still deferred (real missing-Core blocker) -> must REMAIN:
-            // (SongTableForm / SoundRoomForm / MapSettingForm are ported in slice 2r — see
-            //  GetNotYetPortedForms_DropsSlice2rForms_KeepsDeferredSiblings. AIScriptForm stays deferred on
-            //  its AI name resolver, ImageBattleAnimeForm on ImageUtilOAM.)
-            Assert.Contains("AIScriptForm", notYet);                    // AI name resolver (GetAIName1/2)
+            // (SongTableForm / SoundRoomForm / MapSettingForm are ported in slice 2r; AIScriptForm +
+            //  ImageBattleAnimeForm in slice 2s — see GetNotYetPortedForms_DropsSlice2sForms.)
+            Assert.DoesNotContain("AIScriptForm", notYet);
+            Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
             Assert.Contains("EventUnitForm(RecycleReserveUnits)", notYet); // NewAllocData = editor session state
-            Assert.Contains("ImageBattleAnimeForm", notYet);            // ImageUtilOAM seat-image walk
             Assert.Contains("ItemForm", notYet);                        // StatBooster size via PatchUtil
 
             // the no-duplicates invariant still holds after the edits.
@@ -5610,8 +5618,9 @@ namespace FEBuilderGBA.Core.Tests
             //  2q ports them — see GetNotYetPortedForms_DropsSlice2qConfigForms_KeepsDeferredSiblings.)
             Assert.DoesNotContain("ImageTSAAnime2Form", notYet);
             Assert.DoesNotContain("ImageTSAAnimeForm", notYet);
+            // (ImageBattleAnimeForm ported in slice 2s — see GetNotYetPortedForms_DropsSlice2sForms.)
+            Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
             // Other header-less image forms blocked on a different subsystem still stay tracked.
-            Assert.Contains("ImageBattleAnimeForm", notYet);      // ImageUtilOAM OAM frame walk
             Assert.Contains("ImagePortraitForm", notYet);         // IsHalfBodyFlag runtime header
 
             // the no-duplicates invariant still holds after the edits.
@@ -5854,6 +5863,452 @@ namespace FEBuilderGBA.Core.Tests
             Assert.True(len != U.NOT_FOUND); // bounded, no throw (exact value not asserted)
         }
 
+        // ====================================================================
+        // slice 2s: AIScriptForm (EmitAIScript) + ImageBattleAnimeForm
+        //           (EmitImageBattleAnime)
+        // ====================================================================
+
+        // ---- CalcAIScriptLength (verbatim AIScriptForm.CalcLength walk) ------
+
+        [Fact]
+        public void CalcAIScriptLength_StopsAtExit03_WhenNextNotLabel()
+        {
+            var rom = CreateTestRom(0x10000);
+            uint addr = 0x1000;
+            // instr 0: code 0x03 (EXIT). instr 1: first byte 0x00 (NOT 0x1B/0x1C) -> stop after reading
+            // instr1's first byte. CalcLength: read code@0 (0x03), addr+=16; addr+16<=limit ok; code==0x03
+            // -> nextcode = u8(addr+0) = 0x00 -> not 1B/1C -> break. length consumed = 16.
+            rom.write_u8(addr + 0, 0x03);
+            rom.write_u8(addr + 16, 0x00);
+            Assert.Equal(16u, RebuildProducerCore.CalcAIScriptLength(rom, addr));
+        }
+
+        [Fact]
+        public void CalcAIScriptLength_ContinuesPastExit_WhenNext1BLabel()
+        {
+            var rom = CreateTestRom(0x10000);
+            uint addr = 0x1000;
+            // instr0: 0x03 EXIT; instr1 first byte 0x1B (label) -> consume instr1 too (addr += 16);
+            // instr2: 0x03 EXIT; instr3 first byte 0x00 -> stop. Total consumed = 16*3 = 48.
+            rom.write_u8(addr + 0, 0x03);
+            rom.write_u8(addr + 16, 0x1B);   // label -> continue
+            rom.write_u8(addr + 32, 0x03);   // EXIT
+            rom.write_u8(addr + 48, 0x00);   // not label -> stop
+            Assert.Equal(48u, RebuildProducerCore.CalcAIScriptLength(rom, addr));
+        }
+
+        [Fact]
+        public void CalcAIScriptLength_NearEof_NoThrow()
+        {
+            var rom = CreateTestRom(0x2000);
+            // start so that addr+16 just fits; the while (addr+16<=limit) clamp bounds every read.
+            uint len = 0;
+            var ex = Record.Exception(() => { len = RebuildProducerCore.CalcAIScriptLength(rom, 0x1FE0); });
+            Assert.Null(ex);
+        }
+
+        // ---- CalcAIUnitsLength (verbatim AIUnitsForm.CalcLength u16==0 walk) -
+
+        [Fact]
+        public void CalcAIUnitsLength_StopsAtU16Zero()
+        {
+            var rom = CreateTestRom(0x10000);
+            uint addr = 0x1000;
+            rom.write_u16(addr + 0, 0x0101);
+            rom.write_u16(addr + 2, 0x0202);
+            rom.write_u16(addr + 4, 0x0000); // terminator
+            Assert.Equal(4u, RebuildProducerCore.CalcAIUnitsLength(rom, addr));
+        }
+
+        [Fact]
+        public void CalcAIUnitsLength_NearEof_NoThrow_ClampedBound()
+        {
+            // An unterminated stream that runs to EOF: the clamped (addr+2<=Length) bound returns the
+            // consumed length without an OOB u16 read.
+            var rom = CreateTestRom(0x2000);
+            uint addr = 0x1FF0;
+            for (uint a = addr; a < 0x2000; a += 2)
+            {
+                rom.write_u16(a, 0x0101); // never zero -> walks to EOF
+            }
+            uint len = 0;
+            var ex = Record.Exception(() => { len = RebuildProducerCore.CalcAIUnitsLength(rom, addr); });
+            Assert.Null(ex);
+            Assert.Equal(0x10u, len); // 0x2000 - 0x1FF0 = 0x10
+        }
+
+        // ---- EmitAIScript: main IFR + per-entry AISCRIPT + AIUNITS sub-blocks
+
+        // Stage ai1_ AND ai2_ config files (the AIScript count cap) + a real FE8U ROM. Runs body with
+        // that ROM; restores all mutated CoreState.
+        static void WithAiConfig(string[] ai1Lines, string[] ai2Lines, Action<ROM> body)
+        {
+            string savedBase = CoreState.BaseDirectory;
+            string savedLang = CoreState.Language;
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+
+            string tempRoot = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+                "feb_s2s_" + Guid.NewGuid().ToString("N"));
+            string dataDir = System.IO.Path.Combine(tempRoot, "config", "data");
+            System.IO.Directory.CreateDirectory(dataDir);
+            try
+            {
+                if (ai1Lines != null)
+                {
+                    System.IO.File.WriteAllLines(System.IO.Path.Combine(dataDir, "ai1_FE8.txt"), ai1Lines);
+                }
+                if (ai2Lines != null)
+                {
+                    System.IO.File.WriteAllLines(System.IO.Path.Combine(dataDir, "ai2_FE8.txt"), ai2Lines);
+                }
+                CoreState.BaseDirectory = tempRoot;
+                CoreState.Language = "en";
+                var rom = MakeVersionedRom("BE8E01"); // FE8U: version 8, TitleToFilename "FE8"
+                CoreState.ROM = rom; // OtherLangLine reads CoreState.ROM
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+                body(rom);
+            }
+            finally
+            {
+                CoreState.BaseDirectory = savedBase;
+                CoreState.Language = savedLang;
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+                try { System.IO.Directory.Delete(tempRoot, true); } catch { /* best effort */ }
+            }
+        }
+
+        [Fact]
+        public void EmitAIScript_MainIfr_PerEntryAiScript_AndAiUnitsSubBlocks()
+        {
+            // 2 config lines -> un-extended cap 2; plant a 2-entry AI1 table below extends_address so the
+            // cap applies (entry 2 is a 3rd valid pointer but i>=AI1.Count(2) stops the count at 2).
+            WithAiConfig(new[] { "00=a", "01=b" }, new[] { "00=c" }, rom =>
+            {
+                uint ai1ptr = rom.RomInfo.ai1_pointer; // FE8U offset, well below extends (0x01000000)
+                uint table = 0x10000;
+                uint aiscript0 = 0x20000;
+                uint aiscript1 = 0x21000;
+                rom.write_u32(ai1ptr, Ptr(table));
+                rom.write_u32(table + 0, Ptr(aiscript0));
+                rom.write_u32(table + 4, Ptr(aiscript1));
+                rom.write_u32(table + 8, Ptr(0x22000)); // 3rd valid ptr -> dropped by the count cap
+
+                // aiscript0: one EXIT instr (0x03) then a 0x00 first byte -> length 16. No +8/+12 ptrs.
+                rom.write_u8(aiscript0 + 0, 0x03);
+                rom.write_u8(aiscript0 + 16, 0x00);
+                // aiscript1: one 0x03 then 0x00 -> length 16, with a +8 AIUNITS data pointer (even).
+                rom.write_u8(aiscript1 + 0, 0x03);
+                rom.write_u8(aiscript1 + 16, 0x00);
+                uint units = 0x23000;
+                rom.write_u32(aiscript1 + 8, Ptr(units)); // even -> AIUNITS BIN
+                rom.write_u16(units + 0, 0x0101);
+                rom.write_u16(units + 2, 0x0000); // u16==0 terminator -> length 2
+
+                // ai2_pointer left as the real FE8U slot pointing at garbage 0 -> p32 unsafe -> emits nothing.
+                rom.write_u32(rom.RomInfo.ai2_pointer, 0);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitAIScript(rom, list);
+
+                // Main AI1 IFR: DataCount 2 -> length 4*(2+1) = 12, pointerIndexes {0}.
+                Address main = list.Single(a => a.DataType == Address.DataTypeEnum.InputFormRef && a.Info == "AI1");
+                Assert.Equal(table, main.Addr);
+                Assert.Equal(ai1ptr, main.Pointer);
+                Assert.Equal(4u, main.BlockSize);
+                Assert.Equal(12u, main.Length);
+                Assert.Equal(new uint[] { 0 }, main.PointerIndexes);
+
+                // Two AISCRIPT blocks (entry 0, entry 1), each length 16; entry 2 dropped by the count cap.
+                var scripts = list.Where(a => a.DataType == Address.DataTypeEnum.AISCRIPT).ToList();
+                Assert.Equal(2, scripts.Count);
+                Address s0 = scripts.Single(a => a.Addr == aiscript0);
+                Assert.Equal(16u, s0.Length);
+                Assert.Equal(table + 0, s0.Pointer);
+                Assert.StartsWith("AI1 ", s0.Info);
+                Address s1 = scripts.Single(a => a.Addr == aiscript1);
+                Assert.Equal(16u, s1.Length);
+                Assert.Equal(table + 4, s1.Pointer);
+
+                // entry 1's +8 even pointer -> an AIUNITS BIN block, length 2 (u16==0 terminator).
+                Address u = list.Single(a => a.DataType == Address.DataTypeEnum.BIN && a.Addr == units);
+                Assert.Equal(2u, u.Length);
+                Assert.Equal(aiscript1 + 8, u.Pointer);
+            });
+        }
+
+        [Fact]
+        public void EmitAIScript_OddPlus8Pointer_EmitsCallAsmFunction()
+        {
+            WithAiConfig(new[] { "00=a" }, new[] { "00=b" }, rom =>
+            {
+                uint ai1ptr = rom.RomInfo.ai1_pointer;
+                uint table = 0x10000;
+                uint aiscript0 = 0x20000;
+                rom.write_u32(ai1ptr, Ptr(table));
+                rom.write_u32(table + 0, Ptr(aiscript0));
+                rom.write_u8(aiscript0 + 0, 0x03);
+                rom.write_u8(aiscript0 + 16, 0x00); // length 16
+                // +8 ODD pointer -> a thumb CallASM function (AddFunction), NOT an AIUNITS BIN.
+                rom.write_u32(aiscript0 + 8, Ptr(0x24001)); // odd
+                rom.write_u32(rom.RomInfo.ai2_pointer, 0);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitAIScript(rom, list);
+
+                // No AIUNITS BIN for the odd +8 (the BIN list only has none from +8); a Function Address
+                // is emitted instead (AddFunction -> the pointer slot is at aiscript0+8).
+                Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.BIN && a.Pointer == aiscript0 + 8);
+                Assert.Contains(list, a => a.Pointer == aiscript0 + 8); // the CallASM function Address
+            });
+        }
+
+        [Fact]
+        public void EmitAIScript_ClonePointerSlots_EmittedWhenPointer()
+        {
+            // MakeAllDataLengthAISomeByte: for slots i=1,2 at ai1_pointer + i*4, if isPointer(u32(slot))
+            // emit a length-0 POINTER "ClonePointer" Address. (Independent of the main IFR walk.)
+            WithAiConfig(new[] { "00=a" }, new[] { "00=b" }, rom =>
+            {
+                uint ai1ptr = rom.RomInfo.ai1_pointer;
+                uint table = 0x10000;
+                rom.write_u32(ai1ptr, Ptr(table)); // slot 0: the table base (not a ClonePointer slot)
+                rom.write_u32(ai1ptr + 4, Ptr(0x30000)); // slot 1 -> ClonePointer1
+                rom.write_u32(ai1ptr + 8, Ptr(0x31000)); // slot 2 -> ClonePointer2
+                rom.write_u32(rom.RomInfo.ai2_pointer, 0);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitAIScript(rom, list);
+
+                Address c1 = list.Single(a => a.Info == "AI1_ClonePointer1");
+                Assert.Equal(0u, c1.Length);
+                Assert.Equal(Address.DataTypeEnum.POINTER, c1.DataType);
+                Address c2 = list.Single(a => a.Info == "AI1_ClonePointer2");
+                Assert.Equal(0u, c2.Length);
+            });
+        }
+
+        [Fact]
+        public void EmitAIScript_MissingConfig_StillEmitsButCapsAtZero()
+        {
+            // No config tree -> CountConfigDataLines returns 0 -> the un-extended cap is 0, so an
+            // un-extended table emits the main IFR (DataCount 0) but no per-entry blocks. No throw.
+            var savedRom = CoreState.ROM;
+            var savedBase = CoreState.BaseDirectory;
+            try
+            {
+                CoreState.BaseDirectory = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+                    "feb_s2s_none_" + Guid.NewGuid().ToString("N"));
+                var rom = MakeVersionedRom("BE8E01");
+                CoreState.ROM = rom;
+                uint ai1ptr = rom.RomInfo.ai1_pointer;
+                uint table = 0x10000;
+                rom.write_u32(ai1ptr, Ptr(table));
+                rom.write_u32(table + 0, Ptr(0x20000)); // valid ptr but i>=cap(0) -> count 0
+                rom.write_u32(rom.RomInfo.ai2_pointer, 0);
+
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitAIScript(rom, list));
+                Assert.Null(ex);
+                Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.AISCRIPT);
+                Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.InputFormRef && a.Info == "AI1");
+            }
+            finally { CoreState.ROM = savedRom; CoreState.BaseDirectory = savedBase; }
+        }
+
+        [Fact]
+        public void EmitAIScript_ExtendedTable_IgnoresConfigCap()
+        {
+            // A table planted in the EXTENDED ROM area (addr >= extends_address) bypasses the config cap:
+            // the count runs until a non-pointer entry, regardless of the config-line count.
+            WithAiConfig(new[] { "00=a" }, new[] { "00=b" }, rom =>
+            {
+                // FE8U extends_address = 0x09000000 -> offset 0x01000000. Plant table above it.
+                uint table = 0x01100000;
+                uint ai1ptr = rom.RomInfo.ai1_pointer;
+                rom.write_u32(ai1ptr, Ptr(table));
+                // 2 valid script pointers then a non-pointer terminator -> count 2 (cap of 1 ignored).
+                rom.write_u32(table + 0, Ptr(0x01200000));
+                rom.write_u32(table + 4, Ptr(0x01210000));
+                rom.write_u32(table + 8, 0x12345678); // not pointer-or-null -> stop
+                // minimal scripts (one EXIT each).
+                rom.write_u8(0x01200000 + 0, 0x03); rom.write_u8(0x01200000 + 16, 0x00);
+                rom.write_u8(0x01210000 + 0, 0x03); rom.write_u8(0x01210000 + 16, 0x00);
+                rom.write_u32(rom.RomInfo.ai2_pointer, 0);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitAIScript(rom, list);
+
+                Address main = list.Single(a => a.DataType == Address.DataTypeEnum.InputFormRef && a.Info == "AI1");
+                Assert.Equal(12u, main.Length); // 4*(2+1) -> DataCount 2 despite cap 1
+            });
+        }
+
+        // ---- EmitImageBattleAnime: per-class IFRs + N_ IFR + per-anime OAM ---
+
+        [Fact]
+        public void EmitImageBattleAnime_NIfr_SectionBin_And4Lz77Pointers()
+        {
+            // A single anime entry with valid +12/+20/+24 pointers (so N_Init counts it). Assert the
+            // "BattleAnime" main IFR + the per-anime section BIN + 4 LZ77 pointers.
+            var savedRom = CoreState.ROM;
+            var savedBase = CoreState.BaseDirectory;
+            try
+            {
+                CoreState.BaseDirectory = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+                    "feb_s2s_iba_" + Guid.NewGuid().ToString("N"));
+                var rom = MakeVersionedRom("BE8E01");
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+
+                uint animePtr = rom.RomInfo.image_battle_animelist_pointer;
+                uint animeTable = 0x100000;
+                rom.write_u32(animePtr, Ptr(animeTable));
+
+                // anime entry 0 (32-byte record). +12 section, +16 frame, +20/+24 OAM, +28 palette.
+                uint section = 0x110000;
+                uint frame = 0x120000;
+                uint oamR = 0x130000;
+                uint oamL = 0x140000;
+                uint pal = 0x150000;
+                rom.write_u32(animeTable + 12, Ptr(section));
+                rom.write_u32(animeTable + 16, Ptr(frame));
+                rom.write_u32(animeTable + 20, Ptr(oamR));
+                rom.write_u32(animeTable + 24, Ptr(oamL));
+                rom.write_u32(animeTable + 28, Ptr(pal));
+                // entry 1 (32 bytes later): +12/+20/+24 NOT all pointers -> N_Init count stops at 1.
+                rom.write_u32(animeTable + 32 + 12, 0);
+
+                // Plant valid all-literal LZ77 streams. The frame decompresses to literals 0x40..0x7F
+                // (never 0x86), so the seat-image sub-walk finds no records (test stays focused on the
+                // section BIN + 4 LZ77 columns). The OAM/palette streams only need a valid
+                // getCompressedSize for their AddLZ77Pointer length.
+                WriteLz77AllLiteral(rom, frame, 32);
+                WriteLz77AllLiteral(rom, oamR, 16);
+                WriteLz77AllLiteral(rom, oamL, 16);
+                WriteLz77AllLiteral(rom, pal, 32);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitImageBattleAnime(rom, list);
+
+                // The N_ "BattleAnime" main IFR: DataCount 1 -> length 32*(1+1)=64, PI {12,16,20,24,28}.
+                Address nMain = list.Single(a => a.DataType == Address.DataTypeEnum.InputFormRef && a.Info == "BattleAnime");
+                Assert.Equal(animeTable, nMain.Addr);
+                Assert.Equal(animePtr, nMain.Pointer);
+                Assert.Equal(32u, nMain.BlockSize);
+                Assert.Equal(64u, nMain.Length);
+                Assert.Equal(new uint[] { 12, 16, 20, 24, 28 }, nMain.PointerIndexes);
+
+                // section BIN: length 0xC*4 = 48, pointer animeTable+12.
+                Address sec = list.Single(a => a.DataType == Address.DataTypeEnum.BIN && a.Addr == section);
+                Assert.Equal(0xC * 4u, sec.Length);
+                Assert.Equal(animeTable + 12, sec.Pointer);
+
+                // 4 LZ77 columns: BATTLEFRAME @ frame, 2x BATTLEOAM @ oamR/oamL, LZ77PAL @ pal.
+                Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.BATTLEFRAME && a.Addr == frame);
+                Assert.Equal(2, list.Count(a => a.DataType == Address.DataTypeEnum.BATTLEOAM));
+                Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.LZ77PAL && a.Addr == pal);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.BaseDirectory = savedBase;
+            }
+        }
+
+        [Fact]
+        public void EmitImageBattleAnime_NearEof_NoThrow()
+        {
+            var savedRom = CoreState.ROM;
+            var savedBase = CoreState.BaseDirectory;
+            try
+            {
+                CoreState.BaseDirectory = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+                    "feb_s2s_ibaeof_" + Guid.NewGuid().ToString("N"));
+                var rom = MakeVersionedRom("BE8E01");
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+                // animelist pointer -> a base near the very end of ROM.
+                rom.write_u32(rom.RomInfo.image_battle_animelist_pointer, Ptr((uint)rom.Data.Length - 16));
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitImageBattleAnime(rom, list));
+                Assert.Null(ex);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.BaseDirectory = savedBase;
+            }
+        }
+
+        [Fact]
+        public void EmitImageBattleAnime_RunsCleanly_OnEmptyFakeRom()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(fe8);
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitImageBattleAnime(fe8, list));
+                Assert.Null(ex);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void GetBattleAnimeAddr_VersionGate_FE6Plus48_FE8Plus52()
+        {
+            // CalcUnCompressFrameLength version-gate proxy: the per-class slot offset differs by version.
+            // (Asserted indirectly through EmitImageBattleAnime's per-class IFR pointer slot.)
+            // FE8: +52.
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                Assert.Equal(8, fe8.RomInfo.version);
+                var fe6 = MakeVersionedRom("AFEJ01");
+                CoreState.ROM = fe6;
+                Assert.Equal(6, fe6.RomInfo.version);
+                // Both run cleanly (the version branch picks +52 / +48 respectively).
+                CoreState.ROM = fe8;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(fe8);
+                var l8 = new List<Address>();
+                Assert.Null(Record.Exception(() => RebuildProducerCore.EmitImageBattleAnime(fe8, l8)));
+                CoreState.ROM = fe6;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(fe6);
+                var l6 = new List<Address>();
+                Assert.Null(Record.Exception(() => RebuildProducerCore.EmitImageBattleAnime(fe6, l6)));
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        // ---- NotYetPorted coverage delta for slice 2s -----------------------
+
+        [Fact]
+        public void GetNotYetPortedForms_DropsSlice2sForms_KeepsDeferredSiblings()
+        {
+            string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
+
+            // slice 2s ports AIScriptForm (AI1/AI2 bytecode tables, static name) and ImageBattleAnimeForm
+            // (battle-anime OAM tables, static name on the per-anime OAM info).
+            Assert.DoesNotContain("AIScriptForm", notYet);
+            Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
+
+            // sibling forms that genuinely still need un-ported subsystems STAY:
+            Assert.Contains("ItemForm", notYet);                  // PatchUtil StatBooster detection
+            Assert.Contains("ImagePortraitForm", notYet);         // IsHalfBodyFlag runtime header
+            Assert.Contains("ImageItemIconForm", notYet);         // out-of-scope icon-SHEET IFR
+            Assert.Contains("UnitActionPointerForm", notYet);     // PatchUtil SearchUnitActionReworkPatch
+
+            // the no-duplicates invariant still holds after the edits.
+            string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
+            Assert.Equal(raw.Length, raw.Distinct().Count());
+        }
+
         // ---- NotYetPorted coverage delta for slice 2l -----------------------
 
         [Fact]
@@ -5864,9 +6319,8 @@ namespace FEBuilderGBA.Core.Tests
             // slice 2l ports ItemWeaponEffectForm (PROCS sub-block via CalcProcsLengthAndCheck).
             Assert.DoesNotContain("ItemWeaponEffectForm", notYet);
 
-            // AIScriptForm STAYS — its main-IFR count rule needs the config-file AI name lists
-            // (EventUnitForm.AI1/AI2.Count), not in Core.
-            Assert.Contains("AIScriptForm", notYet);
+            // (AIScriptForm ported in slice 2s — see GetNotYetPortedForms_DropsSlice2sForms.)
+            Assert.DoesNotContain("AIScriptForm", notYet);
             // ProcsScriptForm itself STAYS — it is an ASM-path form (MakePatchStructDataList), out of
             // scope for this data-path producer; only its CalcLengthAndCheck length helper is reused.
             Assert.Contains("ProcsScriptForm", notYet);
@@ -6180,10 +6634,12 @@ namespace FEBuilderGBA.Core.Tests
             // it must be GONE (see GetNotYetPortedForms_DropsSlice2nMoveIcon_KeepsDeferredSiblings).
             Assert.DoesNotContain("ImageUnitMoveIconFrom", notYet);
             // (MapSettingForm WAS deferred here on its WF cached-text-count rule, but slice 2r ports it —
-            //  TextDataCount now reproduces TextForm.GetDataCount() byte-faithfully. AIScriptForm stays
-            //  deferred on its AI name resolver.)
+            //  TextDataCount now reproduces TextForm.GetDataCount() byte-faithfully. AIScriptForm ported
+            //  in slice 2s — see GetNotYetPortedForms_DropsSlice2sForms.)
             Assert.DoesNotContain("MapSettingForm", notYet);
-            Assert.Contains("AIScriptForm", notYet);
+            Assert.DoesNotContain("AIScriptForm", notYet);
+            // ItemForm STAYS — StatBooster sub-block size needs un-ported PatchUtil detection.
+            Assert.Contains("ItemForm", notYet);
 
             // the no-duplicates invariant still holds after the edits.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
@@ -6512,13 +6968,15 @@ namespace FEBuilderGBA.Core.Tests
             // Sibling image forms blocked on an un-ported subsystem STAY:
             foreach (var kept in new[]
             {
-                "ImageBattleAnimeForm",      // ImageUtilOAM (slice 2p ports the Magic/MapAction siblings)
                 "ImageItemIconForm",         // out-of-scope icon-SHEET IFR
                 "ImagePortraitForm",         // IsHalfBodyFlag runtime header
             })
             {
                 Assert.Contains(kept, notYet);
             }
+            // (ImageBattleAnimeForm was a deferred sibling here; slice 2s ports it — see
+            //  GetNotYetPortedForms_DropsSlice2sForms.)
+            Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
             // (ImageRomAnimeForm / ImageTSAAnimeForm / ImageTSAAnime2Form were the config-FILE-table
             //  siblings here; slice 2q ports them — see
             //  GetNotYetPortedForms_DropsSlice2qConfigForms_KeepsDeferredSiblings.)
@@ -6847,9 +7305,8 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.Contains(kept, notYet);
             }
 
-            // The Group-3 OAM form ImageBattleAnimeForm STAYS (slice 2p ports the Magic/MapAction
-            // RecycleOldAnime siblings — see GetNotYetPortedForms_DropsSlice2pAnimeForms_KeepsBattleAnime).
-            Assert.Contains("ImageBattleAnimeForm", notYet);
+            // (ImageBattleAnimeForm ported in slice 2s — see GetNotYetPortedForms_DropsSlice2sForms.)
+            Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
 
             // no-duplicates invariant still holds.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
@@ -6868,8 +7325,11 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("ImageMagicFEditorForm", notYet);
             Assert.DoesNotContain("ImageMagicCSACreatorForm", notYet);
 
-            // ImageBattleAnimeForm STAYS (needs ClassForm.MakeClassList + two IFRs + seat-dedup state).
-            Assert.Contains("ImageBattleAnimeForm", notYet);
+            // ImageBattleAnimeForm was the deferred OAM sibling at slice 2p (the test name is historical);
+            // it is PORTED in slice 2s — see GetNotYetPortedForms_DropsSlice2sForms.
+            Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
+            // The RecycleOldAnime-dependent SkillConfig siblings DO still stay tracked at this point.
+            Assert.Contains("SkillConfigSkillSystemForm", notYet);
 
             // no-duplicates invariant still holds.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
@@ -7664,10 +8124,10 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("ImageTSAAnime2Form", notYet);
             Assert.DoesNotContain("ImageRomAnimeForm", notYet);
 
+            // (ImageBattleAnimeForm ported in slice 2s — see GetNotYetPortedForms_DropsSlice2sForms.)
+            Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
             // The remaining image-anime siblings STAY (each blocked on a Core gap):
-            //  ImageBattleAnimeForm (ImageUtilOAM + ClassForm.MakeClassList + seat-dedup),
             //  ImagePortraitForm (IsHalfBodyFlag runtime header), ImageItemIconForm (out of scope).
-            Assert.Contains("ImageBattleAnimeForm", notYet);
             Assert.Contains("ImagePortraitForm", notYet);
             Assert.Contains("ImageItemIconForm", notYet);
 
@@ -8018,13 +8478,13 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("SongTableForm", notYet);
             Assert.DoesNotContain("MapSettingForm", notYet);
 
-            // The siblings flagged by the slice STAY deferred:
-            //  AIScriptForm — its count is now reproducible but the per-entry NAME (GetAIName1/2 ->
-            //    config name list + InputFormRef.GetCommentSA) is not yet in Core.
-            //  ImageBattleAnimeForm — ImageUtilOAM.MakeAllDataLength (the UnCompressFrame seat-image walk)
-            //    + ClassForm.MakeClassList/GetBattleAnimeAddrWhereAddr + the seat-dedup are not in Core.
-            Assert.Contains("AIScriptForm", notYet);
-            Assert.Contains("ImageBattleAnimeForm", notYet);
+            // (AIScriptForm + ImageBattleAnimeForm were the deferred siblings flagged at slice 2r; both
+            //  are now ported in slice 2s — see GetNotYetPortedForms_DropsSlice2sForms.)
+            Assert.DoesNotContain("AIScriptForm", notYet);
+            Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
+            // Genuinely-still-deferred siblings STAY:
+            Assert.Contains("ItemForm", notYet);          // PatchUtil StatBooster detection
+            Assert.Contains("ImagePortraitForm", notYet); // IsHalfBodyFlag runtime header
 
             // no-duplicates invariant still holds.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -650,11 +650,7 @@ namespace FEBuilderGBA
             // sub-block behind the embedded pointer at +8, whose length is a PROCS-bytecode
             // terminator walk (ProcsScriptForm.CalcLengthAndCheck — pure u16/u32/getString reads,
             // reproduced VERBATIM as CalcProcsLengthAndCheck). A dedicated emitter reproduces it
-            // (its own cancel-check mirrors the WF DoEvents posture). AIScriptForm STAYS deferred —
-            // its main-IFR count rule caps DataCount at the config-file AI name lists
-            // (EventUnitForm.AI1/AI2.Count, NOT in Core), so the entry count is not faithfully
-            // reproducible from ROM bytes (a wrong count = wrong # of AISCRIPT/AIUnits sub-blocks =
-            // corruption); see GetNotYetPortedForms.
+            // (its own cancel-check mirrors the WF DoEvents posture).
             if (ct.IsCancellationRequested)
             {
                 progress?.Report("MakeAllStructPointersList cancelled");
@@ -662,6 +658,24 @@ namespace FEBuilderGBA
             }
             progress?.Report("ItemWeaponEffect");
             EmitItemWeaponEffect(rom, list);
+
+            // ---- slice 2s: AIScript (AI1 / AI2 bytecode tables; version-agnostic) ----
+            // AIScriptForm.MakeAllDataLength is in the WF unconditional section (NOT version-gated). Its
+            // per-entry length walks (CalcAIScriptLength / CalcAIUnitsLength) are pure-ROM terminator
+            // scans, and its main-IFR DataCount caps an un-extended table at the ai{1,2}_ config-line
+            // count (CountConfigDataLines — the same IsComment/OtherLangLine filter PreLoadResourceAI{1,2}
+            // uses, degrading to 0 when the config tree is absent). The ONLY divergence is the per-entry
+            // NAME (WF's GetAIName1/2 -> a config name list OR InputFormRef.GetCommentSA, neither in Core):
+            // the producer uses a STATIC name, which is relocation-identical (the established
+            // ItemWeaponEffect precedent). A dedicated emitter reproduces it (cancel-check mirrors the WF
+            // DoEvents posture).
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("AIScript");
+            EmitAIScript(rom, list);
 
             // ---- slice 2m: TextForm (Huffman text; version-agnostic) ----
             // TextForm.MakeAllDataLength is in the WF unconditional section (NOT version-gated). It is NOT
@@ -707,11 +721,9 @@ namespace FEBuilderGBA
             // expands every table entry via a verbatim ImageUtil*.RecycleOldAnime length walk (a pure-ROM
             // anime-stream terminator scan; the OAM column length is the verbatim CalcMagicOamLength port
             // of WF ImageUtilMagicFEditor.calcOAMLength). Each gets a dedicated emitter with its own
-            // cancel-check, mirroring the WF DoEvents posture. ImageBattleAnimeForm (ImageUtilOAM
-            // MakeAllDataLength — the UnCompressFrame-embedded seat-image walk) and the
-            // RecycleOldAnime-dependent SkillConfig siblings STAY deferred (see GetNotYetPortedForms):
-            // ImageBattleAnime additionally needs ClassForm.MakeClassList + the per-class two-IFR /
-            // seat-dedup machinery, a larger surface left for a later slice.
+            // cancel-check, mirroring the WF DoEvents posture. The RecycleOldAnime-dependent SkillConfig
+            // siblings STAY deferred (see GetNotYetPortedForms). ImageBattleAnimeForm is PORTED in slice 2s
+            // (EmitImageBattleAnime — wired just below).
             if (ct.IsCancellationRequested)
             {
                 progress?.Report("MakeAllStructPointersList cancelled");
@@ -719,6 +731,25 @@ namespace FEBuilderGBA
             }
             progress?.Report("ImageMapActionAnimation");
             EmitImageMapActionAnimation(rom, list);
+
+            // ---- slice 2s: ImageBattleAnime (battle-anime OAM tables; version-agnostic) ----
+            // ImageBattleAnimeForm.MakeAllDataLength is in the WF unconditional section (NOT version-gated;
+            // the per-class GetBattleAnimeAddrWhereAddr is version-gated internally — +48 FE6 / +52 FE7+FE8).
+            // Three parts: the per-class "BattleAnimeSeting" IFRs (ClassForm.MakeClassList reproduced via
+            // MakeClassListAddrs), the N_ "BattleAnime" animelist IFR (FEditorHint via CoreState.Config), and
+            // the per-anime OAM walk (EmitImageBattleAnimeOAM = ImageUtilOAM.MakeAllDataLength — section BIN +
+            // 4 LZ77 pointers + the UnCompressFrame-embedded seat-image sub-walk, dedup'd across entries via a
+            // shared seatNumberList). All deps are Core (UnCompressFrame = FETextEncode/LZ77/getBinaryData +
+            // CalcUnCompressFrameLength; AddLZ77Pointer/Address). The ONLY divergence is the per-anime OAM
+            // `info` (WF decodes the anime name via getString — relocation-irrelevant; the producer uses a
+            // static name). A dedicated emitter reproduces it (cancel-check mirrors the WF DoEvents posture).
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("ImageBattleAnime");
+            EmitImageBattleAnime(rom, list);
 
             if (ct.IsCancellationRequested)
             {
@@ -3679,6 +3710,675 @@ namespace FEBuilderGBA
                 }
             }
             return addr - start;
+        }
+
+        // ===================================================================
+        // slice 2s — AIScriptForm (AI1 / AI2 bytecode tables; version-agnostic
+        // call site). A dedicated emitter (EmitAIScript) reproduces
+        // AIScriptForm.MakeAllDataLength VERBATIM:
+        //   - the main IFR per AI table (block 4, IsDataExists reproduced
+        //     inline from AIScriptForm.Init, pointerIndexes {0}),
+        //   - the per-table "ClonePointer" slots (AISomeByte, length 0),
+        //   - the per-entry AISCRIPT block (length = CalcAIScriptLength, the
+        //     verbatim AIScriptForm.CalcLength 16-byte-opcode terminator walk),
+        //   - and per 16-byte AISCRIPT slot the embedded +8/+12 pointers: a
+        //     thumb function (AddFunction) for an odd +8, else an AIUNITS BIN
+        //     block (length = CalcAIUnitsLength, the verbatim AIUnitsForm.CalcLength
+        //     u16==0 terminator walk).
+        // STATIC NAME divergence (the ONLY divergence, relocation-identical — see
+        // EmitItemWeaponEffect): WF labels each entry with the per-entry AI name
+        // (EventUnitForm.GetAIName1/2 -> a config name list OR
+        // InputFormRef.GetCommentSA, neither in Core). The Address `name` is
+        // COSMETIC (does not affect addr/length/pointer/DataType/order, i.e. the
+        // relocation manifest is byte-identical), so the producer uses a STATIC
+        // name "AI<n> 0x<i>" — dropping ONLY the GetAIName1/2 part. The
+        // length/count/pointer/DataType are reproduced byte-faithfully.
+        //
+        // COUNT rule: the main IFR DataCount (AIScriptForm.Init's IsDataExists)
+        // caps an un-extended AI table at EventUnitForm.AI{1,2}.Count — which, at
+        // the moment IsDataExists reads it, equals the number of DATA LINES in the
+        // ai1_/ai2_ config TSV (PreLoadResourceAI{1,2} loads those lines BEFORE
+        // padding the list up to DataCount, so the un-extended cap resolves to the
+        // config-line count). The producer recomputes that count headlessly from
+        // the ai1_/ai2_ config files (CountConfigDataLines, the same
+        // IsComment/OtherLangLine filter PreLoadResourceAI{1,2} uses), gracefully
+        // degrading to 0 when the config tree is absent.
+        // ===================================================================
+
+        /// <summary>VERBATIM port of <c>AIScriptForm.CalcLength</c>: walk the AI bytecode of
+        /// 16-byte fixed instructions from <paramref name="addr"/>, stopping at the EXIT opcode
+        /// (<c>u8(addr+0)==0x03</c>) UNLESS the next instruction's first byte is a 0x1B/0x1C label
+        /// (then it continues past one more instruction). Returns the consumed byte length. Pure ROM
+        /// reads; the WF <c>while (addr + 16 &lt;= limit)</c> clamp guarantees <c>u8(addr+0)</c> is
+        /// in-bounds. EOF-equivalent to WF (a near-EOF stream simply stops at the clamp).</summary>
+        public static uint CalcAIScriptLength(ROM rom, uint addr)
+        {
+            uint start = addr;
+            uint limit = (uint)rom.Data.Length;
+
+            while (addr + 16 <= limit)
+            {
+                uint code = rom.u8(addr + 0);
+                addr += 16; //命令は16バイト固定.
+                if (addr + 16 > limit)
+                {
+                    break;
+                }
+                if (code == 0x03)
+                {//EXIT
+                    //1命令先読みして1Bラベルがあるかどうかを見るあるならまだ続く
+                    uint nextcode = rom.u8(addr + 0);
+                    if (!(nextcode == 0x1B || nextcode == 0x1C))
+                    {//1B or 1Cではないので終わり.
+                        break;
+                    }
+                    addr += 16;
+                }
+            }
+            return addr - start;
+        }
+
+        /// <summary>VERBATIM port of <c>AIUnitsForm.CalcLength</c>: from <c>toOffset(addr)</c>, walk
+        /// 2 bytes at a time until <c>u16==0x00</c>; returns the consumed byte length. Pure ROM reads.
+        /// EOF-HARDENING: WF's loop bound is <c>addr &lt; Data.Length</c>, so the final iteration could
+        /// read <c>u16(Length-1)</c> (1 byte OOB) on a non-terminated stream; the producer clamps the
+        /// bound to <c>addr + 2 &lt;= Length</c> (valid-ROM-equivalent: a real AIUNITS stream is
+        /// 0-terminated well before EOF, so the clamp only differs on a malformed unterminated tail).</summary>
+        public static uint CalcAIUnitsLength(ROM rom, uint addr)
+        {
+            addr = U.toOffset(addr);
+            uint start = addr;
+            uint length = (uint)rom.Data.Length;
+            for (; addr + 2 <= length; addr += 2)
+            {
+                if (rom.u16(addr) == 0x00)
+                {
+                    break;
+                }
+            }
+            return addr - start;
+        }
+
+        /// <summary>
+        /// Count the DATA lines of an <c>ai1_</c>/<c>ai2_</c> config TSV (the per-entry AI name list),
+        /// reproducing the line filter <c>EventUnitForm.PreLoadResourceAI{1,2}</c> uses
+        /// (<c>!(U.IsComment(line) || U.OtherLangLine(line))</c>) — every other line increments the count
+        /// (the WF <c>sp.Length &lt;= 0</c> guard is never true). This is the un-extended-table cap the
+        /// AIScript main-IFR <c>IsDataExists</c> compares <c>i</c> against (<c>AI{1,2}.Count</c>). Never
+        /// throws: a missing/unconfigured config tree (null BaseDirectory, missing file) yields 0 — the
+        /// same faithful headless behavior as an empty config (WF's <c>IsRequiredFileExist</c> false path
+        /// leaves <c>AI{1,2}</c> empty before padding).
+        /// </summary>
+        static int CountConfigDataLines(string type, ROM rom)
+        {
+            try
+            {
+                string fullfilename = U.ConfigDataFilename(type, rom);
+                if (!System.IO.File.Exists(fullfilename))
+                {
+                    return 0;
+                }
+                int count = 0;
+                using (System.IO.StreamReader reader = System.IO.File.OpenText(fullfilename))
+                {
+                    string line;
+                    while ((line = reader.ReadLine()) != null)
+                    {
+                        // Verbatim PreLoadResourceAI{1,2} filter: skip comment / other-lang lines,
+                        // count everything else (sp.Length <= 0 is never true after Split('\t')).
+                        if (U.IsComment(line) || U.OtherLangLine(line))
+                        {
+                            continue;
+                        }
+                        count++;
+                    }
+                }
+                return count;
+            }
+            catch (Exception)
+            {
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// <c>AIScriptForm.MakeAllDataLength</c> (slice 2s, version-agnostic call site). For each of the
+        /// two AI tables (<c>ai1_pointer</c>, <c>ai2_pointer</c>): skip if the slot is 0, else emit
+        /// <see cref="EmitAIScriptSub"/> (the main IFR + per-entry AISCRIPT / AIUNITS sub-blocks) and
+        /// <see cref="EmitAIScriptSomeByte"/> (the two ClonePointer slots). Reproduced VERBATIM; only the
+        /// entry NAME is static (relocation-identical — see the slice-2s header above).
+        /// </summary>
+        public static void EmitAIScript(ROM rom, List<Address> list)
+        {
+            // WF: addlist = { ai1_pointer, ai2_pointer }.
+            uint[] addlist = new uint[] { rom.RomInfo.ai1_pointer, rom.RomInfo.ai2_pointer };
+            // The IsDataExists count cap reads AI{1,2}.Count == the ai{1,2}_ config-line count.
+            int ai1Count = CountConfigDataLines("ai1_", rom);
+            int ai2Count = CountConfigDataLines("ai2_", rom);
+
+            for (int aiType = 0; aiType < addlist.Length; aiType++)
+            {
+                uint aiAddr = addlist[aiType];
+                if (aiAddr == 0)
+                {//WF: if (aiAddr == 0) continue;
+                    continue;
+                }
+                EmitAIScriptSub(rom, list, aiAddr, aiType, aiType == 0 ? ai1Count : ai2Count, ai1Count, ai2Count);
+                EmitAIScriptSomeByte(rom, list, aiAddr, aiType);
+            }
+        }
+
+        /// <summary>VERBATIM port of <c>AIScriptForm.MakeAllDataLengthAISomeByte</c>: for slots
+        /// <c>i=1,2</c> at <c>aiAddr + i*4</c>, if <c>isPointer(u32(slot))</c> emit a length-0 POINTER
+        /// "ClonePointer" Address (<c>AddPointer(slot, 0, ...)</c>). EOF-HARDENING: WF reads
+        /// <c>u32(aiAddr+i*4)</c> unguarded; the producer guards the 4-byte extent first.</summary>
+        public static void EmitAIScriptSomeByte(ROM rom, List<Address> list, uint aiAddr, int aiType)
+        {
+            for (uint i = 1; i < 3; i++)
+            {
+                uint addr = aiAddr + (i * 4);
+                // EOF-harden: u32(addr) reads addr..addr+3.
+                if (addr + 4 > (uint)rom.Data.Length)
+                {
+                    continue;
+                }
+                uint p = rom.u32(addr);
+                if (!U.isPointer(p))
+                {
+                    continue;
+                }
+                Address.AddPointer(list, addr, 0, "AI" + (aiType + 1) + "_ClonePointer" + i,
+                    Address.DataTypeEnum.POINTER);
+            }
+        }
+
+        /// <summary>VERBATIM port of <c>AIScriptForm.MakeAllDataLengthSub</c>: the main IFR
+        /// (<c>AddressWinForms.AddAddress(IFR, "AI<n>", {0})</c>) followed by the per-entry AISCRIPT
+        /// block + its embedded +8/+12 AIUNITS / CallASM pointers. The IFR DataCount reproduces
+        /// <c>AIScriptForm.Init</c>'s <c>IsDataExists</c> inline. Only the per-entry NAME is static
+        /// ("AI&lt;n&gt; 0x&lt;i&gt;") — see the slice-2s header (relocation-identical).</summary>
+        static void EmitAIScriptSub(ROM rom, List<Address> list, uint aiAddr, int aiType,
+            int thisCount, int ai1Count, int ai2Count)
+        {
+            // WF: InputFormRef.ReInitPointer(aiAddr) -> BasePointer = toOffset(aiAddr),
+            // BaseAddress = p32(BasePointer). Reproduce that, then the AddressWinForms.AddAddress(IFR)
+            // emission (addr = BaseAddress, length = block*(DataCount+1), pointer = BasePointer or
+            // NOT_FOUND, type InputFormRef, block 4, pointerIndexes {0}).
+            const uint block = 4;
+            uint basePointer = U.toOffset(aiAddr);
+            // InputFormRef.Init guards BasePointer; an unsafe slot -> BaseAddress 0, emit nothing.
+            if (!U.isSafetyOffset(basePointer + 3, rom))
+            {
+                return;
+            }
+            uint baseAddr = rom.p32(basePointer);
+            // WF Init: if !isSafetyOffset(BaseAddress) -> BaseAddress = 0, BasePointer = 0 (DataCount 0,
+            // AddAddress returns without emitting). Mirror by bailing out here.
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                return;
+            }
+
+            uint p32ai1 = ResolveAiTableBase(rom, rom.RomInfo.ai1_pointer);
+            uint p32ai2 = ResolveAiTableBase(rom, rom.RomInfo.ai2_pointer);
+            uint extendsBase = U.toOffset(rom.RomInfo.extends_address);
+
+            // DataCount: getBlockDataCount(BaseAddress, 4, IsDataExists). IsDataExists reproduces
+            // AIScriptForm.Init verbatim (with the AI{1,2}.Count cap == config-line count).
+            uint dataCount = rom.getBlockDataCount(baseAddr, block, (i, addr) =>
+            {
+                uint a = rom.u32(addr); // getBlockDataCount guarantees addr+4<=Length.
+                if (!U.isPointerOrNULL(a))
+                {
+                    return false;
+                }
+                // U.isExtrendsROMArea(addr) == addr >= toOffset(extends_address).
+                if (addr >= extendsBase)
+                {//拡張済みなのでサイズは終端まで
+                }
+                else
+                {//未拡張
+                    uint comparebase = addr - (uint)(block * i);
+                    if (comparebase == p32ai1)
+                    {
+                        if (i >= ai1Count)
+                        {
+                            return false;
+                        }
+                    }
+                    else if (comparebase == p32ai2)
+                    {
+                        if (i >= ai2Count)
+                        {
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            });
+
+            // Main IFR Address (AddressWinForms.AddAddress(list, IFR, "AI<n>", {0})).
+            uint mainLength = block * (dataCount + 1);
+            uint mainPointer = U.isSafetyOffset(basePointer, rom) ? basePointer : U.NOT_FOUND;
+            list.Add(new Address(baseAddr, mainLength, mainPointer, "AI" + (aiType + 1),
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { 0 }));
+
+            uint p = baseAddr;
+            for (uint i = 0; i < dataCount; i++, p += block)
+            {
+                if (!U.isSafetyOffset(p, rom))
+                {
+                    continue;
+                }
+
+                // STATIC NAME (the only divergence): WF appends GetAIName1/2(i) here.
+                string name = "AI" + (aiType + 1) + " " + U.To0xHexString(i);
+
+                uint aiscript = rom.p32(p);
+                uint length = CalcAIScriptLength(rom, aiscript);
+
+                Address.AddAddress(list, aiscript, length, p, name, Address.DataTypeEnum.AISCRIPT);
+
+                uint end = aiscript + length;
+                for (uint k = aiscript; k < end; k += 16)
+                {
+                    // EOF-harden: u32(k+8)/u32(k+12) read up to k+15. CalcAIScriptLength bounds each
+                    // 16-byte block within [aiscript, aiscript+length) by addr+16<=Length, so k+15 <
+                    // k+16 <= Length already holds for k < end; guard anyway for robustness.
+                    if (k + 16 > (uint)rom.Data.Length)
+                    {
+                        break;
+                    }
+                    uint pp;
+                    pp = rom.u32(k + 8);
+                    if (U.isPointer(pp))
+                    {
+                        if ((pp % 2) == 1)
+                        {//thumbプログラムコード
+                            Address.AddFunction(list, k + 8, name + " CallASM");
+                        }
+                        else
+                        {//データ
+                            Address.AddAddress(list, pp, CalcAIUnitsLength(rom, pp), k + 8, name,
+                                Address.DataTypeEnum.BIN);
+                        }
+                    }
+                    pp = rom.u32(k + 12);
+                    if (U.isPointer(pp))
+                    {
+                        Address.AddAddress(list, pp, CalcAIUnitsLength(rom, pp), k + 12, name,
+                            Address.DataTypeEnum.BIN);
+                    }
+                }
+            }
+        }
+
+        /// <summary>Resolve an AI table base the way <c>AIScriptForm.Init</c>'s IsDataExists does
+        /// (<c>Program.ROM.p32(ai{1,2}_pointer)</c>) for the per-entry <c>baseaddr ==</c> comparison.
+        /// Returns <see cref="U.NOT_FOUND"/> when the slot is an unsafe offset (so the comparison can
+        /// never match — the same effect as WF reading a garbage slot, since a real table base is a safe
+        /// offset).</summary>
+        static uint ResolveAiTableBase(ROM rom, uint slot)
+        {
+            uint s = U.toOffset(slot);
+            if (!U.isSafetyOffset(s + 3, rom))
+            {
+                return U.NOT_FOUND;
+            }
+            return rom.p32(s);
+        }
+
+        // ===================================================================
+        // slice 2s — ImageBattleAnimeForm (battle-animation OAM tables;
+        // version-agnostic call site). A dedicated emitter (EmitImageBattleAnime)
+        // reproduces ImageBattleAnimeForm.MakeAllDataLength VERBATIM:
+        //   PART A (per-class BattleAnimeSeting IFR): for each class
+        //     (ClassForm.MakeClassList -> the class-table addrs), resolve
+        //     GetBattleAnimeAddrWhereAddr (version-gated +48 FE6 / +52 FE7+FE8),
+        //     and if the anime-setting addr is safe emit the "BattleAnimeSeting"
+        //     main IFR (block 4, IsDataExists = u32(addr)!=0, pointerIndexes {}).
+        //   PART B (the N_ animelist IFR): the "BattleAnime" main IFR (base
+        //     image_battle_animelist_pointer, block 32, IsDataExists =
+        //     (isPointer(u32+12)&&isPointer(u32+20)&&isPointer(u32+24)) ||
+        //     (FEditorHint!=NOT_FOUND && i<FEditorHint), pointerIndexes
+        //     {12,16,20,24,28}). FEditorHint = GetFEditorLengthHint (config-gated;
+        //     reproduced via CoreState.Config "func_lookup_feditor", default off).
+        //   PART C (per-anime OAM walk): per anime entry, ImageUtilOAM.MakeAllDataLength
+        //     (EmitImageBattleAnimeOAM) — a fixed section BIN + 4 LZ77 pointers
+        //     (frame / 2x OAM / palette) + the UnCompressFrame-embedded seat-image
+        //     sub-walk (dedup'd across entries via a shared seatNumberList).
+        // STATIC NAME divergence (the ONLY divergence, relocation-identical — see
+        // EmitItemWeaponEffect): WF's per-anime ImageUtilOAM name reads
+        // ROM.getString(base,12) (the anime name, needs a SystemTextEncoder); the
+        // producer drops ONLY that decoded name (the `info` string is COSMETIC —
+        // does not affect addr/length/pointer/DataType/order). All lengths/counts/
+        // pointers/DataTypes are reproduced byte-faithfully.
+        // ===================================================================
+
+        /// <summary>The list of class-table entry addresses = <c>ClassForm.MakeClassList()</c>
+        /// (<c>Init(null).MakeList()</c>). Reproduces <c>ClassForm.Init</c> VERBATIM (base
+        /// <c>class_pointer</c>, block <c>class_datasize</c>, count = the <c>i==0||(i&lt;=0xff &amp;&amp;
+        /// u8(addr+4)!=0)</c> rule — the same as <see cref="ClassDataCount"/>) and yields one addr per
+        /// entry (<c>baseAddr + i*block</c>). The name (slot 2 of the WF IFR) is irrelevant —
+        /// <c>MakeAllDataLength</c> only consumes the addrs. Returns an empty list on an unsafe/zero
+        /// pointer (faithful headless behavior).</summary>
+        static List<uint> MakeClassListAddrs(ROM rom)
+        {
+            var result = new List<uint>();
+            uint pointer = U.toOffset(rom.RomInfo.class_pointer);
+            if (!U.isSafetyOffset(pointer, rom)) return result;
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom)) return result;
+            uint block = rom.RomInfo.class_datasize;
+            if (block == 0) return result;
+            uint count = rom.getBlockDataCount(baseAddr, block, (i, addr) =>
+            {
+                if (i == 0) return true;
+                if (i > 0xff) return false;
+                return rom.u8(addr + 4) != 0;
+            });
+            uint p = baseAddr;
+            for (uint i = 0; i < count; i++, p += block)
+            {
+                result.Add(p);
+            }
+            return result;
+        }
+
+        /// <summary>VERBATIM port of <c>ClassForm.GetBattleAnimeAddrWhereAddr</c>: from a class addr,
+        /// the anime-setting pointer slot is at <c>+48</c> (FE6) / <c>+52</c> (FE7+FE8); returns
+        /// <c>p32(slot)</c> as the anime-setting addr and reports the slot via <paramref name="outPointer"/>.
+        /// EOF-HARDENING: WF reads <c>p32(addr+48/52)</c> after only <c>isSafetyOffset(addr)</c>; the
+        /// producer guards the full slot extent (slot+3) so a near-EOF class addr yields NOT_FOUND.</summary>
+        static uint GetBattleAnimeAddrWhereAddr(ROM rom, uint classAddr, out uint outPointer)
+        {
+            if (!U.isSafetyOffset(classAddr, rom))
+            {
+                outPointer = U.NOT_FOUND;
+                return U.NOT_FOUND;
+            }
+            uint slot = (rom.RomInfo.version == 6) ? classAddr + 48 : classAddr + 52;
+            outPointer = slot;
+            if (slot + 4 > (uint)rom.Data.Length)
+            {
+                return U.NOT_FOUND;
+            }
+            return rom.p32(slot);
+        }
+
+        /// <summary>VERBATIM port of <c>InputFormRef.GetFEditorLengthHint</c>: the FEditor-Adv list-length
+        /// hint stored 4 bytes BEFORE <paramref name="dataOffset"/>. Gated on the config option
+        /// <c>func_lookup_feditor</c> (default "0" = None -> always NOT_FOUND; the same default the WF
+        /// OptionForm reads); when enabled, returns <c>u32(dataOffset-4)</c> if it is in <c>[100, 1024)</c>,
+        /// else NOT_FOUND. Pure ROM read + a CoreState.Config lookup (the config is set in the real app /
+        /// CLI; a null Config degrades to the default-off path).</summary>
+        static uint GetFEditorLengthHint(ROM rom, uint dataOffset)
+        {
+            // OptionForm.lookup_feditor() == (lookup_feditor_enum)atoi(Config.at("func_lookup_feditor","0"));
+            // Lookup == 1. Default "0" (None) -> do NOT use the hint.
+            string cfg = CoreState.Config?.at("func_lookup_feditor", "0") ?? "0";
+            if (U.atoi(cfg) != 1)
+            {
+                return U.NOT_FOUND;
+            }
+            if (!U.isSafetyOffset(dataOffset - 4, rom))
+            {
+                return U.NOT_FOUND;
+            }
+            uint value = rom.u32(dataOffset - 4);
+            if (value >= 1024)
+            {//大きすぎる
+                return U.NOT_FOUND;
+            }
+            if (value < 100)
+            {//小さすぎる、別の値では？
+                return U.NOT_FOUND;
+            }
+            return value;
+        }
+
+        /// <summary>
+        /// <c>ImageBattleAnimeForm.MakeAllDataLength</c> (slice 2s, version-agnostic call site). See the
+        /// slice-2s header for the three-part structure. Reproduced VERBATIM; the ONLY divergence is the
+        /// per-anime OAM `info` string (WF decodes the anime name, the producer uses a static name —
+        /// relocation-identical).
+        /// </summary>
+        public static void EmitImageBattleAnime(ROM rom, List<Address> list)
+        {
+            const uint classBlock = 4; // ImageBattleAnimeForm.Init BlockSize (per-class BattleAnimeSeting).
+
+            // ---- PART A: per-class "BattleAnimeSeting" IFRs ----
+            List<uint> classList = MakeClassListAddrs(rom);
+            for (uint cid = 0; cid < classList.Count; cid++)
+            {
+                uint pointer;
+                uint classAddr = classList[(int)cid];
+                uint addr = GetBattleAnimeAddrWhereAddr(rom, classAddr, out pointer);
+                if (!U.isSafetyOffset(addr, rom))
+                {//WF: if (!isSafetyOffset(addr)) continue;
+                    continue;
+                }
+
+                // WF: InputFormRef.ReInitPointer(pointer) -> BasePointer = toOffset(pointer),
+                // BaseAddress = p32(BasePointer), DataCount from Init's IsDataExists (u32(addr)!=0).
+                uint basePointer = U.toOffset(pointer);
+                if (!U.isSafetyOffset(basePointer + 3, rom))
+                {
+                    continue;
+                }
+                uint baseAddr = rom.p32(basePointer);
+                if (!U.isSafetyOffset(baseAddr, rom))
+                {//Init: unsafe BaseAddress -> 0/0 -> AddAddress emits nothing.
+                    continue;
+                }
+                uint dataCount = rom.getBlockDataCount(baseAddr, classBlock, (i, a) =>
+                {//ImageBattleAnimeForm.Init IsDataExists: u32(a+0) != 0. getBlockDataCount guards a+4<=Length.
+                    return rom.u32(a + 0) != 0;
+                });
+
+                string selfname = "BattleAnimeSeting:" + U.To0xHexString(cid);
+                uint length = classBlock * (dataCount + 1);
+                uint mainPointer = U.isSafetyOffset(basePointer, rom) ? basePointer : U.NOT_FOUND;
+                // WF AddAddress(IFR, name, new uint[] { }) -> pointerIndexes empty.
+                list.Add(new Address(baseAddr, length, mainPointer, selfname,
+                    Address.DataTypeEnum.InputFormRef, classBlock, new uint[] { }));
+            }
+
+            // ---- PART B: the N_ "BattleAnime" animelist IFR ----
+            const uint nBlock = 32; // N_Init BlockSize.
+            uint nBasePointer = U.toOffset(rom.RomInfo.image_battle_animelist_pointer);
+            if (!U.isSafetyOffset(nBasePointer + 3, rom))
+            {
+                return;
+            }
+            uint nBaseAddr = rom.p32(nBasePointer);
+            if (!U.isSafetyOffset(nBaseAddr, rom))
+            {
+                return;
+            }
+
+            // N_Init: FEditorHint = GetFEditorLengthHint(p32(image_battle_animelist_pointer)); if it is
+            // >= 0xFF (too big) it is discarded.
+            uint feditorHint = GetFEditorLengthHint(rom, nBaseAddr);
+            if (feditorHint >= 0xFF)
+            {//余りにでかいヒントは信じない
+                feditorHint = U.NOT_FOUND;
+            }
+
+            uint nDataCount = rom.getBlockDataCount(nBaseAddr, nBlock, (i, a) =>
+            {//N_Init IsDataExists. getBlockDataCount guards a+32<=Length, so u32(a+12/20/24) is in range.
+                if (U.isPointer(rom.u32(a + 12))
+                    && U.isPointer(rom.u32(a + 20))
+                    && U.isPointer(rom.u32(a + 24)))
+                {
+                    return true;
+                }
+                if (feditorHint != U.NOT_FOUND && i < feditorHint)
+                {//不明なデータではあるがFEditorがあるというので信用する.
+                    return true;
+                }
+                return false;
+            });
+
+            uint nLength = nBlock * (nDataCount + 1);
+            uint nMainPointer = U.isSafetyOffset(nBasePointer, rom) ? nBasePointer : U.NOT_FOUND;
+            list.Add(new Address(nBaseAddr, nLength, nMainPointer, "BattleAnime",
+                Address.DataTypeEnum.InputFormRef, nBlock, new uint[] { 12, 16, 20, 24, 28 }));
+
+            // ---- PART C: per-anime OAM walk (ImageUtilOAM.MakeAllDataLength) ----
+            // 戦闘アニメーションはlz77圧縮の中にポインタがある特殊形式です — the seatNumberList dedups
+            // shared seat images ACROSS anime entries (a seat image referenced by 2 animes is emitted once).
+            var seatNumberList = new List<uint>(256);
+            uint walkAddr = nBaseAddr;
+            for (int i = 0; i < nDataCount; i++, walkAddr += nBlock)
+            {
+                if (!U.isSafetyOffset(12 + walkAddr + 4, rom))
+                {//WF: if (!isSafetyOffset(12 + addr + 4)) break;
+                    break;
+                }
+                uint section = rom.p32(12 + walkAddr);
+                if (!U.isSafetyOffset(section, rom))
+                {//WF: if (!isSafetyOffset(section)) break;
+                    break;
+                }
+                string selfname = "BattleAnime:" + U.To0xHexString((uint)(i + 1));
+                EmitImageBattleAnimeOAM(rom, list, selfname, walkAddr, seatNumberList);
+            }
+        }
+
+        /// <summary>VERBATIM port of <c>ImageUtilOAM.MakeAllDataLength</c> (the producer always scans real
+        /// lengths, isPointerOnly==false). For one anime at <paramref name="battleanimeBaseaddress"/>:
+        /// a fixed <c>0xC*4</c>-byte section BIN @ +12, four LZ77 pointers (frame @ +16, 2× OAM @ +20/+24,
+        /// palette @ +28), then the UnCompressFrame-decompressed frame stream's embedded seat-image
+        /// pointers (each a 0x86-tagged 4-byte field at +4 of a 12-byte record) emitted as
+        /// BATTLEFRAMEIMG LZ77 addresses, dedup'd via the shared <paramref name="seatNumberList"/>.
+        /// STATIC NAME (the only divergence): WF prefixes the info with ROM.getString(base,12) — the
+        /// producer drops that decoded anime name (cosmetic / relocation-identical).
+        /// EOF-HARDENING: the <c>isSafetyZArray(base+32-1)</c> guard (WF) covers the +12..+31 header reads;
+        /// the frame-stream loop is bounded by the decompressed-array length + an explicit i+8 ZArray check.</summary>
+        public static void EmitImageBattleAnimeOAM(ROM rom, List<Address> list, string info,
+            uint battleanimeBaseaddress, List<uint> seatNumberList)
+        {
+            // WF: if (!isSafetyZArray(base + 32 - 1)) return; — guards the +12..+31 p32 reads.
+            if (!U.isSafetyZArray(battleanimeBaseaddress + 32 - 1, rom.Data))
+            {
+                return;
+            }
+
+            // WF prefixes info with " " + getString(base,12) (the anime name) before the per-column
+            // " section"/" frame"/... suffixes. STATIC-NAME divergence: drop the decoded name entirely
+            // (cosmetic / relocation-identical) and append the suffixes directly to the passed-in name.
+            uint sectionData = rom.p32(battleanimeBaseaddress + 12); //セクションデータ 固定長
+            uint frameData_offset = rom.p32(battleanimeBaseaddress + 16);
+            // (rightToLeftOAM / leftToRightOAM / palettes offsets at +20/+24/+28 are read by the
+            //  AddLZ77Pointer calls below; WF reads them into locals only for the magic-motion path.)
+
+            // 解凍する. 固定長のsectionData以外はLZ77で圧縮されている.
+            byte[] frameData_UZ = UnCompressBattleFrame(rom, frameData_offset);
+
+            Address.AddAddress(list, sectionData, 0xC * 4, battleanimeBaseaddress + 12,
+                info + " section", Address.DataTypeEnum.BIN);
+            Address.AddLZ77Pointer(list, battleanimeBaseaddress + 16, info + " frame", false,
+                Address.DataTypeEnum.BATTLEFRAME);
+            Address.AddLZ77Pointer(list, battleanimeBaseaddress + 20, info + " rightToLeftOAM", false,
+                Address.DataTypeEnum.BATTLEOAM);
+            Address.AddLZ77Pointer(list, battleanimeBaseaddress + 24, info + " leftToRightOAM", false,
+                Address.DataTypeEnum.BATTLEOAM);
+            Address.AddLZ77Pointer(list, battleanimeBaseaddress + 28, info + " palettes", false,
+                Address.DataTypeEnum.LZ77PAL);
+
+            int number = 0;
+            for (int i = 0; i < frameData_UZ.Length; i += 4)
+            {
+                if (!U.isSafetyZArray((uint)(i + 8), frameData_UZ))
+                {
+                    break;
+                }
+                if (frameData_UZ[i + 3] != 0x86)
+                {
+                    continue;
+                }
+                //シート画像をリサイクルリストに突っ込む.
+                uint imageOffset = U.u32(frameData_UZ, (uint)(i + 4));
+                if (U.isPointer(imageOffset))
+                {
+                    imageOffset = U.toOffset(imageOffset);
+                    if (seatNumberList.IndexOf(imageOffset) < 0)
+                    {
+                        //lz77された中にあるのでポインタは存在しない.
+                        Address.AddLZ77Address(list, imageOffset, U.NOT_FOUND,
+                            info + " seat" + number, false, Address.DataTypeEnum.BATTLEFRAMEIMG);
+                        number++;
+                        seatNumberList.Add(imageOffset);
+                    }
+                }
+                i = i + 4 + 4; // 4+4+ 4 = 12
+            }
+        }
+
+        /// <summary>VERBATIM port of <c>ImageUtilOAM.UnCompressFrame</c>: decompress a battle-anime frame
+        /// stream. If the frame pointer is an UnHuffman-patch pointer, read the raw (uncompressed) frame
+        /// bytes (length = <see cref="CalcUnCompressFrameLength"/>); else LZ77-decompress. Returns an empty
+        /// array on an out-of-range / undecompressable pointer (LZ77.decompress and getBinaryData are
+        /// EOF-safe). All deps are Core (FETextEncode / LZ77 / getBinaryData).</summary>
+        static byte[] UnCompressBattleFrame(ROM rom, uint frameAddr)
+        {
+            //FEの戦闘アニメフレームはlz77で圧縮されています。
+            //無圧縮フレームというデータ構造もある.
+            if (FETextEncode.IsUnHuffmanPatchPointer(frameAddr))
+            {
+                frameAddr = FETextEncode.ConvertUnHuffmanPatchToPointer(frameAddr);
+                frameAddr = U.toOffset(frameAddr);
+                uint length = CalcUnCompressFrameLength(rom, frameAddr);
+                return rom.getBinaryData(frameAddr, length);
+            }
+            else
+            {
+                frameAddr = U.toOffset(frameAddr);
+                return LZ77.decompress(rom.Data, frameAddr);
+            }
+        }
+
+        /// <summary>VERBATIM port of <c>ImageUtilOAM.CalcUnCompressFrameLength</c>: walk an uncompressed
+        /// frame stream of 4-byte records from <paramref name="frameDataOffset"/>, counting 0x80-terminated
+        /// frames (up to 0xC), skipping 0x86 image records (+8) and 0x85 / unknown records (+0). A 1MB
+        /// limiter caps a runaway. EOF-HARDENING: WF's <c>frameData[i+3]</c> read is bounded only by
+        /// <c>i &lt; limitter = min(start+1MB, Length)</c>, so on a non-terminated tail it could read up to
+        /// <c>Length+2</c> (OOB); the producer clamps the loop bound to <c>i + 4 &lt;= limitter</c>
+        /// (valid-ROM-equivalent: a real frame stream is 0x80-terminated well within the ROM, so the clamp
+        /// only differs on a malformed unterminated tail).</summary>
+        public static uint CalcUnCompressFrameLength(ROM rom, uint frameDataOffset)
+        {
+            //圧縮されていないデータなので、事故防止のため リミッターをかける.
+            uint limitter = frameDataOffset + 1024 * 1024; //1MBサーチしたらもうあきらめる.
+            limitter = (uint)Math.Min(limitter, rom.Data.Length);
+            byte[] frameData = rom.Data;
+            uint i;
+            uint frameCount = 0;
+            for (i = frameDataOffset; i + 4 <= limitter; i += 4)
+            {
+                if (frameData[i + 3] == 0x80)
+                {//終端データ
+                    frameCount++;
+                    i += 4;
+                    if (frameCount > 0xC)
+                    {//アニメはフレーム0xCまである
+                        break;
+                    }
+                    continue;
+                }
+                else if (frameData[i + 3] != 0x86)
+                {
+                    if (frameData[i + 3] == 0x85)
+                    {
+                        continue;
+                    }
+                    //不明な命令.
+                    continue;
+                }
+                i += 8;
+            }
+            return i - frameDataOffset;
         }
 
         // ===================================================================
@@ -8061,10 +8761,15 @@ namespace FEBuilderGBA
                 //      Magic_Append_SpellTable block, and per spell (p32==dim/no_dim) EmitMagicRecycleOldAnime
                 //      (the verbatim WF RecycleOldAnime: FEditorAdv 28-byte / CSA 32-byte+TSA records; the OAM
                 //      column length is the verbatim CalcMagicOamLength port of WF calcOAMLength).
-                //  ImageBattleAnimeForm STAYS — ImageUtilOAM.MakeAllDataLength (the UnCompressFrame-embedded
-                //  seat-image walk IS Core-reproducible, but the form additionally needs ClassForm.MakeClassList
-                //  + ClassForm.GetBattleAnimeAddrWhereAddr + two IFRs (Init per-class + N_Init) + a seat-image
-                //  dedup list threaded across entries — a larger surface left for a later slice.)
+                //  ImageBattleAnimeForm PORTED in slice 2s (EmitImageBattleAnime) — all its deps reached Core:
+                //  the per-class "BattleAnimeSeting" IFRs (ClassForm.MakeClassList = MakeClassListAddrs +
+                //  GetBattleAnimeAddrWhereAddr version-gated +48/+52), the N_ "BattleAnime" animelist IFR
+                //  (FEditorHint via CoreState.Config), and the per-anime OAM walk (EmitImageBattleAnimeOAM =
+                //  ImageUtilOAM.MakeAllDataLength — section BIN + 4 LZ77 pointers + the UnCompressFrame-embedded
+                //  seat-image sub-walk, dedup'd across entries via a shared seatNumberList; UnCompressFrame =
+                //  FETextEncode/LZ77/getBinaryData + CalcUnCompressFrameLength, all Core). Only the per-anime
+                //  OAM `info` name is static (WF's getString-decoded anime name is cosmetic / relocation-
+                //  identical — the ItemWeaponEffect precedent). See GetNotYetPortedForms_DropsSlice2sForms.)
                 //  (slice 2n ported ImageUnitMoveIconFrom — its per-entry AP column uses SubKind.ApPointer /
                 //   EmitApPointer, length = ImageUtilAPCore.CalcAPLength [the verbatim Core port of WF
                 //   ImageUtilAP.CalcAPLength = Parse + GetLength, already a tested Core helper]. The count
@@ -8082,7 +8787,6 @@ namespace FEBuilderGBA
                 //      image / palette to relocate) whose count rule reads a hardcoded FE7U magic addr.
                 //    MapMiniMapTerrainImageForm — InputFormRef_ASM + AddFunctions, called from the
                 //      AppendAllASMStructPointersList ASM path, not this producer's data path.)
-                "ImageBattleAnimeForm",
                 "ImageItemIconForm",
                 "ImagePortraitForm",
                 "MapMiniMapTerrainImageForm",
@@ -8145,20 +8849,17 @@ namespace FEBuilderGBA
                 // AI scripts (disasm)
                 // (AIMapSettingForm [flat u8!=0xFF table], AIPerformStaffForm + AIPerformItemForm
                 //  [flat u16!=0 table + per-entry ASM AddFunction @4 via SubKind.AsmFunction] ported in
-                //  slice 2f. AIScriptForm STAYS — its per-entry CalcLength helpers ARE pure ROM walks
-                //  (AIScriptForm.CalcLength = AI 16-byte-opcode terminator walk; AIUnitsForm.CalcLength =
-                //  u16!=0 walk) AND its main-IFR COUNT rule is now reproducible: isExtrendsROMArea is a
-                //  trivial `addr >= toOffset(extends_address)` test, and the un-extended cap = the number of
-                //  data lines in the ai1_/ai2_ config TSV (Program.cs loads PreLoadResourceAI1/2 ONCE at
-                //  ROM-load — NOT editor session state — and DataCount, called inside Init's IsDataExists,
-                //  sees AI{1,2}.Count == the pre-padding config-line-count, so the circularity resolves to
-                //  the TSV line count, loadable headless via the slice-2q ConfigDataFilename/TSV reader).
-                //  The REMAINING blocker is the per-entry NAME (EventUnitForm.GetAIName1/2): faithfully it is
-                //  the loaded config name OR, for padded entries, InputFormRef.GetCommentSA(p32(addr)) — the
-                //  comment-symbol resolver, NOT in Core. The tests assert name verbatim, so a byte-faithful
-                //  port needs the AI name-list loader + GetCommentSA in Core first (the length/count/pointer/
-                //  datatype are all ready). Deferred on the NAME, not the count, until those reach Core.)
-                "AIScriptForm",
+                //  slice 2f. AIScriptForm PORTED in slice 2s (EmitAIScript) — per AI table (ai1_/ai2_):
+                //  the main IFR (block 4, IsDataExists = isPointerOrNULL(u32) with the un-extended cap =
+                //  CountConfigDataLines("ai{1,2}_") [isExtrendsROMArea = addr >= toOffset(extends_address)],
+                //  PI {0}) + the two ClonePointer slots (AISomeByte, length-0 POINTER) + per entry an
+                //  AISCRIPT block (length = CalcAIScriptLength = the verbatim AIScriptForm.CalcLength
+                //  16-byte-opcode terminator walk) and per 16-byte slot the embedded +8/+12 pointers
+                //  (odd +8 -> AddFunction CallASM; else an AIUNITS BIN block of length CalcAIUnitsLength =
+                //  the verbatim AIUnitsForm.CalcLength u16==0 walk). Only the per-entry NAME is STATIC
+                //  ("AI<n> 0x<i>") — WF appends GetAIName1/2 (a config name list OR InputFormRef.GetCommentSA,
+                //  neither in Core), which is COSMETIC / relocation-identical (the ItemWeaponEffect
+                //  static-name precedent). See GetNotYetPortedForms_DropsSlice2sForms.)
                 // skills (version/patch dependent)
                 // (slice 2o ported the RecycleOldAnime-FREE subset, all dependencies already in Core:
                 //  SkillAssignmentClassSkillSystemForm + SkillAssignmentUnitSkillSystemForm [FE8U,

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -3753,6 +3753,16 @@ namespace FEBuilderGBA
         /// in-bounds. EOF-equivalent to WF (a near-EOF stream simply stops at the clamp).</summary>
         public static uint CalcAIScriptLength(ROM rom, uint addr)
         {
+            // A NULL/unsafe entry (a 0 table slot, or a pointer outside the ROM) must NOT trigger a full
+            // scan from offset 0 + a huge computed length. WF passes p32(slot) straight into CalcLength; on
+            // a valid ROM every AI entry is a real pointer so this never fires, but guarding the start makes
+            // a malformed/NULL entry return 0 -> the AISCRIPT AddAddress is skipped (addr unsafe) AND the
+            // downstream AIUNITS loop (end == start) doesn't run. Output-equivalent to WF on valid ROMs;
+            // far cheaper + no spurious offset-0 emissions on malformed ones.
+            if (!U.isSafetyOffset(addr, rom))
+            {
+                return 0;
+            }
             uint start = addr;
             uint limit = (uint)rom.Data.Length;
 
@@ -3787,6 +3797,13 @@ namespace FEBuilderGBA
         public static uint CalcAIUnitsLength(ROM rom, uint addr)
         {
             addr = U.toOffset(addr);
+            // Same start guard as CalcAIScriptLength: the caller isPointer-checks pp, but isPointer does not
+            // bound it to Data.Length, so guard an out-of-range start to avoid a scan past EOF (return 0 ->
+            // the AIUNITS AddAddress is skipped). Valid-ROM-equivalent.
+            if (!U.isSafetyOffset(addr, rom))
+            {
+                return 0;
+            }
             uint start = addr;
             uint length = (uint)rom.Data.Length;
             for (; addr + 2 <= length; addr += 2)
@@ -3825,8 +3842,11 @@ namespace FEBuilderGBA
                     while ((line = reader.ReadLine()) != null)
                     {
                         // Verbatim PreLoadResourceAI{1,2} filter: skip comment / other-lang lines,
-                        // count everything else (sp.Length <= 0 is never true after Split('\t')).
-                        if (U.IsComment(line) || U.OtherLangLine(line))
+                        // count everything else (sp.Length <= 0 is never true after Split('\t')). Use the
+                        // (line, rom) OtherLangLine overload so the is_multibyte language filter consults the
+                        // passed rom, not CoreState.ROM (the producer's rom==CoreState.ROM invariant makes
+                        // these identical, but the explicit rom keeps the count correct if they ever differ).
+                        if (U.IsComment(line) || U.OtherLangLine(line, rom))
                         {
                             continue;
                         }


### PR DESCRIPTION
## Summary
**Slice 2s** of #1261 — the two remaining "big" data-path forms. **Both ported** (neither needed a new Core helper; all deps already in Core, reproduced inline). The only divergence in either is a **static Address name** (relocation-identical — the established `EmitItemWeaponEffect` precedent; addr/length/pointer/DataType/order are byte-faithful).

## Ported (2 forms — VERBATIM addr/length/pointer/DataType/order, version-gated)
- **AIScriptForm** [version-agnostic — `U.cs:2468`] via `EmitAIScript` — main IFR per AI table (block 4, PI `{0}`) + 2 ClonePointer slots (`AISomeByte`) + per-entry AISCRIPT block + embedded +8/+12 pointers (odd → `AddFunction` CallASM, even → AIUNITS BIN). Length helpers reproduced **line-for-line**: `CalcAIScriptLength` (= `AIScriptForm.CalcLength`, 16-byte-opcode 0x03/label walk) + `CalcAIUnitsLength` (= `AIUnitsForm.CalcLength`, `u16==0` walk). **Count:** the un-extended cap is the `ai1_`/`ai2_` config-LINE count — reproduced via `CountConfigDataLines` using `PreLoadResourceAI`'s exact `!(IsComment||OtherLangLine)` filter, **NOT `LoadTSVResource`** (which dedups by hex key → wrong count); graceful-empty when the config tree is absent. `isExtrendsROMArea` inlined as `addr >= toOffset(extends_address)`. Static name (drops `GetAIName1/2`).
- **ImageBattleAnimeForm** [version-agnostic call @2420, internal FE6/FE7+8 branch] via `EmitImageBattleAnime` — 3 parts: per-class "BattleAnimeSeting" IFRs (`MakeClassListAddrs` = `ClassForm.Init` walk + `GetBattleAnimeAddrWhereAddr` **version-gated +48 FE6 / +52 FE7+8** — *lead-verified vs WF `ClassForm`*), N_ "BattleAnime" IFR (FEditorHint via `CoreState.Config` "func_lookup_feditor"), per-anime `EmitImageBattleAnimeOAM` = `ImageUtilOAM.MakeAllDataLength` **verbatim** (section BIN + 4 LZ77 ptrs + `UnCompressFrame`-embedded seat-image walk, dedup'd via a `seatNumberList` threaded across entries). `UnCompressFrame` = `FETextEncode`/`LZ77`/`getBinaryData` + `CalcUnCompressFrameLength` (reproduced verbatim). Static name (drops the getString anime name).

## Discipline
- **Static NAME is the ONLY divergence** in both (relocation-identical, documented in code).
- **EOF self-audit:** every computed-addr raw read guards its full extent (`slot+3` before `p32`; `getBlockDataCount` bounds the IsDataExists reads; `isSafetyZArray(base+31)` before the OAM header); `CalcAIUnitsLength` + `CalcUnCompressFrameLength` loop bounds hardened (`addr+2`/`i+4 <= limit`) vs WF's under-guard — documented valid-ROM-equivalent.

## Tests
- RebuildProducer filter: **285 passed / 0 failed** (+21) — length-walk units, synthetic-ROM emitter tests, config-cap / extended-table / version-gate / near-EOF / empty-ROM robustness. Removed both forms from `NotYetPortedRaw` + updated ~16 stale coverage assertions (grepped ALL test/Core/CLI/docs files — no stale "deferred" claims remain).
- FEBuilderGBA.Tests (net9.0-windows): 1865/1865 (incl. the cross-project source-text + AvaloniaFieldCompleteness gates).
- (Full Core.Tests: only the known env-only `Skill*`/`SkillSystemsAnime*` failures — `config/patch2` submodule absent in the worktree.)

Part of #1261. **Both remaining large data-path forms are now ported** — the data-path tail is down to the form-coupled ScanScript events, the PatchUtil-detector forms, and a small misc set.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
