### PR TITLE
feat(core): ROM-rebuild producer — EventCond + ScanScript (last data-path form, #1261 slice 2u)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -450,10 +450,11 @@ namespace FEBuilderGBA.Core.Tests
             // (TextForm/TextCharCodeForm are ported in slice 2m; OtherTextForm in slice 2q — see
             //  GetNotYetPortedForms_DropsSlice2qConfigForms_KeepsDeferredSiblings.)
             Assert.DoesNotContain("OtherTextForm", notYet);
-            Assert.Contains("EventCondForm", notYet);
+            // EventCondForm is PORTED in slice 2u (EmitEventCond + the Core ScanScript block-emitter) —
+            // see GetNotYetPortedForms_DropsSlice2uForm_KeepsDeferredSiblings.
+            Assert.DoesNotContain("EventCondForm", notYet);
             // (SongTableForm is ported in slice 2r; AIScriptForm + ImageBattleAnimeForm in slice 2s —
-            //  see GetNotYetPortedForms_DropsSlice2sForms_KeepsDeferredSiblings. EventCondForm above
-            //  still tracks the deferred coverage here.)
+            //  see GetNotYetPortedForms_DropsSlice2sForms_KeepsDeferredSiblings.)
             Assert.DoesNotContain("AIScriptForm", notYet);
             Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
             // ItemForm stays DEFERRED: its StatBooster sub-block size depends on un-ported PatchUtil
@@ -3512,8 +3513,10 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Contains("UnitActionPointerForm", notYet);     // PatchUtil SearchUnitActionReworkPatch
             Assert.Contains("MonsterWMapProbabilityForm", notYet);// EventScriptForm.ScanScript skirmish
             // (the 5 map-PLIST forms that were deferred "for slice size" here are now PORTED in slice 2g
-            //  — see GetNotYetPortedForms_DropsSlice2gCoveredForms_KeepsDeferredSiblings.)
-            Assert.Contains("EventCondForm", notYet);             // EventScriptForm.ScanScript
+            //  — see GetNotYetPortedForms_DropsSlice2gCoveredForms_KeepsDeferredSiblings.
+            //  EventCondForm is PORTED in slice 2u — see
+            //  RebuildProducerEventCondTests.GetNotYetPortedForms_DropsSlice2uForm_KeepsDeferredSiblings.)
+            Assert.DoesNotContain("EventCondForm", notYet);
             // and the no-duplicates invariant still holds after the edits.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
             Assert.Equal(raw.Length, raw.Distinct().Count());

--- a/FEBuilderGBA.Core.Tests/RebuildProducerEventCondTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerEventCondTests.cs
@@ -1,0 +1,550 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for RebuildProducerCore slice 2u — EventCondForm + the Core ScanScript
+// BLOCK-emitter (EmitEventCond / EmitScanScript), a verbatim port of
+// EventScriptForm.ScanScript + EventCondForm.MakeAllDataLength.
+//
+// Two layers (mirroring EventScriptReferenceScannerTests):
+//   1. EmitScanScript synthetic tests — plant a small event script in a scratch
+//      region of a wired FE8U ROM and assert the emitted Address set (the
+//      EVENTSCRIPT block + the per-arg RecycleOldData blocks), the POINTER_EVENT
+//      recursion, the self-cycle alias, and near-EOF safety.
+//   2. EmitEventCond integration test — plant the full map-setting -> event-plist
+//      -> cond-block -> event-script chain (the MapEventUnitCoreNewAllocTests
+//      recipe) and assert the EVENTCOND_*/EVENTTRAP frame + the EventCond Frame
+//      block + a traced event-script block.
+//   3. NotYetPorted coverage — EventCondForm is dropped, ScanScript siblings stay.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class RebuildProducerEventCondTests
+    {
+        const int RomSize = 0x1100000; // 17MB — FE8 LoadLow minimum + scratch.
+        const uint Scratch = 0x00900000u;
+
+        static ROM MakeFe8uRom()
+        {
+            var rom = new ROM();
+            rom.LoadLow("synthetic-fe8u.gba", new byte[RomSize], "BE8E01");
+            return rom;
+        }
+
+        static ROM MakeVersionedRom(string versionString, int size = 0x0200_0000)
+        {
+            var rom = new ROM();
+            bool ok = rom.LoadLow("fake.gba", new byte[size], versionString);
+            Assert.True(ok, "LoadLow did not recognize version string: " + versionString);
+            return rom;
+        }
+
+        static EventScript BuildEventScript(params EventScript.Script[] scripts)
+        {
+            var es = new EventScript();
+            var prop = typeof(EventScript).GetProperty("Scripts");
+            prop!.SetValue(es, scripts);
+            return es;
+        }
+
+        static void Write32(ROM rom, uint addr, uint value) => rom.write_u32(addr, value);
+        static uint Ptr(uint offset) => offset | 0x08000000u;
+
+        /// <summary>Run an action with CoreState wired to a fresh FE8U ROM + the given
+        /// EventScript, restoring prior CoreState afterwards.</summary>
+        static void WithEnv(EventScript es, Action<ROM> body) => WithEnv(MakeFe8uRom(), es, body);
+
+        static void WithEnv(ROM rom, EventScript es, Action<ROM> body)
+        {
+            var prevRom = CoreState.ROM;
+            var prevEs = CoreState.EventScript;
+            var prevComment = CoreState.CommentCache;
+            try
+            {
+                CoreState.ROM = rom;
+                CoreState.EventScript = es;
+                CoreState.CommentCache = new HeadlessEtcCache();
+                body(rom);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.EventScript = prevEs;
+                CoreState.CommentCache = prevComment;
+            }
+        }
+
+        // ---- script-line factories (real FE schema opcodes don't matter for the
+        //      disassembler — only the arg layout the test plants does) ----
+        static EventScript.Script TermCommand()
+            => EventScript.ParseScriptLine("0A000000\tENDA [TERM]");
+        static EventScript.Script CallCommand()  // 4-byte POINTER_EVENT at offset 4
+            => EventScript.ParseScriptLine("03000000XXXXXXXX\tCALL [X:POINTER_EVENT:Target]");
+        static EventScript.Script LoadUnitCommand() // 4-byte POINTER_UNIT at offset 4
+            => EventScript.ParseScriptLine("12000000XXXXXXXX\tLOADUNIT [XXXX:POINTER_UNIT:Units]");
+        static EventScript.Script AiCoordCommand() // 4-byte POINTER_AICOORDINATE at offset 4
+            => EventScript.ParseScriptLine("40000000XXXXXXXX\tAICOORD [XXXX:POINTER_AICOORDINATE:Coord]");
+
+        // =================================================================
+        // EmitScanScript — the block-emitter
+        // =================================================================
+
+        [Fact]
+        public void EmitScanScript_SingleTermEvent_EmitsOneEventScriptBlock()
+        {
+            var es = BuildEventScript(TermCommand());
+            WithEnv(es, rom =>
+            {
+                // Slot at Scratch holds a pointer to the event at Scratch+0x100.
+                uint eventAddr = Scratch + 0x100;
+                Write32(rom, Scratch, Ptr(eventAddr));
+                rom.write_u32(eventAddr + 0, 0x0000000A); // ENDA
+
+                var list = new List<Address>();
+                var trace = new List<uint>();
+                RebuildProducerCore.EmitScanScript(rom, list, Scratch, true, false, "Evt", trace);
+
+                var evt = Assert.Single(list);
+                Assert.Equal(eventAddr, evt.Addr);
+                Assert.Equal(Address.DataTypeEnum.EVENTSCRIPT, evt.DataType);
+                Assert.Equal(Scratch, evt.Pointer);     // the SLOT, not the target
+                Assert.Equal(4u, evt.Length);           // one 4-byte ENDA command
+                Assert.Contains(eventAddr, trace);
+            });
+        }
+
+        [Fact]
+        public void EmitScanScript_PointerEventArg_RecursesAndEmitsNested()
+        {
+            var es = BuildEventScript(CallCommand(), TermCommand());
+            WithEnv(es, rom =>
+            {
+                uint eventAddr = Scratch + 0x100;
+                uint nested = Scratch + 0x200;
+                Write32(rom, Scratch, Ptr(eventAddr));
+
+                // CALL <nested> ; ENDA
+                rom.write_u32(eventAddr + 0, 0x00000003);
+                Write32(rom, eventAddr + 4, Ptr(nested));
+                rom.write_u32(eventAddr + 8, 0x0000000A);
+
+                // nested: ENDA
+                rom.write_u32(nested + 0, 0x0000000A);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitScanScript(rom, list, Scratch, true, false, "Evt", new List<uint>());
+
+                // Two EVENTSCRIPT blocks: the outer (addr=eventAddr) and the nested (addr=nested).
+                Assert.Contains(list, a => a.Addr == eventAddr && a.DataType == Address.DataTypeEnum.EVENTSCRIPT);
+                Assert.Contains(list, a => a.Addr == nested && a.DataType == Address.DataTypeEnum.EVENTSCRIPT);
+                // The nested block's slot pointer is the CALL arg field (eventAddr + 4).
+                var nestedBlock = list.Single(a => a.Addr == nested);
+                Assert.Equal(eventAddr + 4, nestedBlock.Pointer);
+            });
+        }
+
+        [Fact]
+        public void EmitScanScript_SelfCycle_Terminates_AndEmitsAliasPointer()
+        {
+            // A CALL whose POINTER_EVENT arg points back to the event start: the
+            // tracelist guard must stop the recursion and emit a zero-length alias.
+            var es = BuildEventScript(CallCommand(), TermCommand());
+            WithEnv(es, rom =>
+            {
+                uint eventAddr = Scratch + 0x100;
+                Write32(rom, Scratch, Ptr(eventAddr));
+                // CALL <eventAddr> (self) ; ENDA
+                rom.write_u32(eventAddr + 0, 0x00000003);
+                Write32(rom, eventAddr + 4, Ptr(eventAddr));
+                rom.write_u32(eventAddr + 8, 0x0000000A);
+
+                var list = new List<Address>();
+                Exception ex = Record.Exception(() =>
+                    RebuildProducerCore.EmitScanScript(rom, list, Scratch, true, false, "Evt", new List<uint>()));
+                Assert.Null(ex); // no hang / no throw
+
+                // The self-reference emits a zero-length alias EVENTSCRIPT for the CALL arg slot.
+                Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.EVENTSCRIPT
+                                           && a.Pointer == eventAddr + 4 && a.Length == 0);
+            });
+        }
+
+        [Fact]
+        public void EmitScanScript_PointerUnitArg_EmitsRecycleOldUnitsBlock()
+        {
+            var es = BuildEventScript(LoadUnitCommand(), TermCommand());
+            WithEnv(es, rom =>
+            {
+                uint eventAddr = Scratch + 0x100;
+                uint unitList = Scratch + 0x300;
+                Write32(rom, Scratch, Ptr(eventAddr));
+                // LOADUNIT <unitList> ; ENDA
+                rom.write_u32(eventAddr + 0, 0x00000012);
+                Write32(rom, eventAddr + 4, Ptr(unitList));
+                rom.write_u32(eventAddr + 8, 0x0000000A);
+                // unit list: one non-terminator row then a terminator (u8==0).
+                rom.Data[unitList + 0] = 0x10;
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitScanScript(rom, list, Scratch, true, false, "Evt", new List<uint>());
+
+                // The EventUnit IFR block (EmitRecycleOldUnits) is emitted behind the LOADUNIT arg.
+                Assert.Contains(list, a => a.Addr == unitList
+                                           && a.DataType == Address.DataTypeEnum.InputFormRef);
+            });
+        }
+
+        [Fact]
+        public void EmitScanScript_AiCoordinateArg_EmitsFixed4ByteBinBlock()
+        {
+            var es = BuildEventScript(AiCoordCommand(), TermCommand());
+            WithEnv(es, rom =>
+            {
+                uint eventAddr = Scratch + 0x100;
+                uint coord = Scratch + 0x400;
+                Write32(rom, Scratch, Ptr(eventAddr));
+                rom.write_u32(eventAddr + 0, 0x00000040);
+                Write32(rom, eventAddr + 4, Ptr(coord));
+                rom.write_u32(eventAddr + 8, 0x0000000A);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitScanScript(rom, list, Scratch, true, false, "Evt", new List<uint>());
+
+                // AIASMCoordinateForm.RecycleOldData = AddPointer(4, BIN).
+                Assert.Contains(list, a => a.Addr == coord && a.Length == 4
+                                           && a.DataType == Address.DataTypeEnum.BIN);
+            });
+        }
+
+        [Fact]
+        public void EmitScanScript_IsWithEventUnitFalse_DoesNotDispatchSubData()
+        {
+            var es = BuildEventScript(LoadUnitCommand(), TermCommand());
+            WithEnv(es, rom =>
+            {
+                uint eventAddr = Scratch + 0x100;
+                uint unitList = Scratch + 0x300;
+                Write32(rom, Scratch, Ptr(eventAddr));
+                rom.write_u32(eventAddr + 0, 0x00000012);
+                Write32(rom, eventAddr + 4, Ptr(unitList));
+                rom.write_u32(eventAddr + 8, 0x0000000A);
+                rom.Data[unitList + 0] = 0x10;
+
+                var list = new List<Address>();
+                // isWithEventUnit:false — the POINTER_UNIT dispatch is skipped (WF nop branch).
+                RebuildProducerCore.EmitScanScript(rom, list, Scratch, false, false, "Evt", new List<uint>());
+
+                Assert.DoesNotContain(list, a => a.Addr == unitList);
+                Assert.Contains(list, a => a.Addr == eventAddr); // the script block is still emitted
+            });
+        }
+
+        [Fact]
+        public void EmitScanScript_NearEof_DoesNotThrow()
+        {
+            var es = BuildEventScript(TermCommand());
+            WithEnv(es, rom =>
+            {
+                // Slot in the very last 4 bytes; pointer derefs to a near-EOF event.
+                uint slot = (uint)rom.Data.Length - 4;
+                uint eventAddr = (uint)rom.Data.Length - 4;
+                Write32(rom, slot, Ptr(eventAddr));
+
+                var list = new List<Address>();
+                Exception ex = Record.Exception(() =>
+                    RebuildProducerCore.EmitScanScript(rom, list, slot, true, false, "Evt", new List<uint>()));
+                Assert.Null(ex);
+            });
+        }
+
+        // =================================================================
+        // EmitEventCond — the full producer form
+        // =================================================================
+
+        [Fact]
+        public void EmitEventCond_ThrowsWhenDisasmNotWired()
+        {
+            var rom = MakeFe8uRom();
+            var prevRom = CoreState.ROM;
+            var prevEs = CoreState.EventScript;
+            var prevComment = CoreState.CommentCache;
+            try
+            {
+                CoreState.ROM = rom;
+                CoreState.EventScript = null;     // not wired
+                CoreState.CommentCache = null;
+                var list = new List<Address>();
+                Assert.Throws<InvalidOperationException>(() => RebuildProducerCore.EmitEventCond(rom, list));
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.EventScript = prevEs;
+                CoreState.CommentCache = prevComment;
+            }
+        }
+
+        [Fact]
+        public void EmitEventCond_FE8_EmitsCondFrameAndTracedScript()
+        {
+            // Plant a full chain: map setting -> event plist -> cond block -> a TALK
+            // cond record whose event pointer leads to a one-command ENDA script.
+            var es = BuildEventScript(TermCommand());
+            WithEnv(es, rom =>
+            {
+                const uint mapId = 0;
+                uint mapTableBase = 0x00800000u;
+                uint mapSize = rom.RomInfo.map_setting_datasize;
+                Write32(rom, rom.RomInfo.map_setting_pointer, Ptr(mapTableBase));
+                uint mapRecord = mapTableBase + mapId * mapSize;
+                Write32(rom, mapRecord + 0, 0x08123456u); // first dword => valid map row
+                const byte eventPlist = 7;
+                rom.Data[mapRecord + rom.RomInfo.map_setting_event_plist_pos] = eventPlist;
+
+                uint eventTableBase = 0x00810000u;
+                Write32(rom, rom.RomInfo.map_event_pointer, Ptr(eventTableBase));
+                uint condBlock = 0x00820000u;
+                Write32(rom, eventTableBase + eventPlist * 4u, Ptr(condBlock));
+
+                // Cond slots: index 1 is TALK (FE8 layout). Plant one talk record:
+                // type!=0 at +0, event pointer at +4, then a terminator record (all zero).
+                var slots = MapEventUnitCore.GetCondSlots(rom);
+                int talkIdx = slots.FindIndex(s => s.Type == MapEventUnitCore.CondType.Talk);
+                Assert.True(talkIdx >= 0);
+
+                uint talkTable = 0x00830000u;
+                uint talkSize = rom.RomInfo.eventcond_talk_size;
+                uint scriptAddr = 0x00840000u;
+                rom.Data[talkTable + 0] = 0x02;                 // type != 0
+                Write32(rom, talkTable + 4, Ptr(scriptAddr));   // event pointer
+                // terminator record at talkTable + talkSize is left zero (u8==0 stops the walk).
+                Write32(rom, condBlock + (uint)talkIdx * 4u, Ptr(talkTable));
+
+                rom.write_u32(scriptAddr + 0, 0x0000000A);      // ENDA
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitEventCond(rom, list);
+
+                // (1) The TALK cond frame block at the cond slot.
+                Assert.Contains(list, a => a.Addr == talkTable
+                                           && a.DataType == Address.DataTypeEnum.EVENTCOND_TALK);
+                // (2) The traced event-script block.
+                Assert.Contains(list, a => a.Addr == scriptAddr
+                                           && a.DataType == Address.DataTypeEnum.EVENTSCRIPT);
+                // (3) The trailing EventCond Frame block: slots.Count * 4 bytes at the cond block.
+                Assert.Contains(list, a => a.Addr == condBlock
+                                           && a.Length == (uint)slots.Count * 4u
+                                           && a.DataType == Address.DataTypeEnum.POINTER);
+            });
+        }
+
+        [Fact]
+        public void EmitEventCond_FE8_TutorialSlot_EmitsPointerTypeFrame()
+        {
+            var es = BuildEventScript(TermCommand());
+            WithEnv(es, rom =>
+            {
+                const uint mapId = 0;
+                uint mapTableBase = 0x00800000u;
+                uint mapSize = rom.RomInfo.map_setting_datasize;
+                Write32(rom, rom.RomInfo.map_setting_pointer, Ptr(mapTableBase));
+                uint mapRecord = mapTableBase + mapId * mapSize;
+                Write32(rom, mapRecord + 0, 0x08123456u);
+                const byte eventPlist = 7;
+                rom.Data[mapRecord + rom.RomInfo.map_setting_event_plist_pos] = eventPlist;
+
+                uint eventTableBase = 0x00810000u;
+                Write32(rom, rom.RomInfo.map_event_pointer, Ptr(eventTableBase));
+                uint condBlock = 0x00820000u;
+                Write32(rom, eventTableBase + eventPlist * 4u, Ptr(condBlock));
+
+                var slots = MapEventUnitCore.GetCondSlots(rom);
+                int tutorialIdx = slots.FindIndex(s => s.Type == MapEventUnitCore.CondType.Tutorial);
+                Assert.True(tutorialIdx >= 0, "FE8 must have a Tutorial slot");
+
+                uint tutTable = 0x00860000u;
+                // NOTE: the tutorial walk uses BOTH u8(base)==0 as the terminator AND
+                // p32(base+0) as the event pointer (same field). A pointer whose LOW byte
+                // is 0 would falsely terminate the walk — real tutorial pointers never
+                // have a zero low byte, so plant one with a non-zero low byte (+4).
+                uint scriptAddr = 0x00870004u;
+                // Tutorial: 4-byte records, ptr at +0, stop when u8==0.
+                Write32(rom, tutTable + 0, Ptr(scriptAddr));
+                // tutTable + 4 left zero -> terminator.
+                Write32(rom, condBlock + (uint)tutorialIdx * 4u, Ptr(tutTable));
+                rom.write_u32(scriptAddr + 0, 0x0000000A);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitEventCond(rom, list);
+
+                // The tutorial frame is emitted as POINTER (not EVENTCOND_*).
+                Assert.Contains(list, a => a.Addr == tutTable
+                                           && a.DataType == Address.DataTypeEnum.POINTER);
+                Assert.Contains(list, a => a.Addr == scriptAddr
+                                           && a.DataType == Address.DataTypeEnum.EVENTSCRIPT);
+            });
+        }
+
+        [Fact]
+        public void EmitEventCond_FE7_ShortTurnType1_Uses12ByteStride()
+        {
+            // FE7 turn records: a type==1 record advances by 12 (the short-turn event);
+            // a non-1 type advances by eventcond_tern_size. Assert both the script trace
+            // and that the TURN frame length covers BOTH records (= short stride applied).
+            var es = BuildEventScript(TermCommand());
+            var rom = MakeVersionedRom("AE7E01"); // FE7U
+            // FE7U LoadLow recognized? fall back assert inside WithEnv.
+            WithEnv(rom, es, r =>
+            {
+                Assert.Equal(7, r.RomInfo.version);
+                const uint mapId = 0;
+                uint mapTableBase = 0x00800000u;
+                uint mapSize = r.RomInfo.map_setting_datasize;
+                Write32(r, r.RomInfo.map_setting_pointer, Ptr(mapTableBase));
+                uint mapRecord = mapTableBase + mapId * mapSize;
+                Write32(r, mapRecord + 0, 0x08123456u);
+                const byte eventPlist = 7;
+                r.Data[mapRecord + r.RomInfo.map_setting_event_plist_pos] = eventPlist;
+
+                uint eventTableBase = 0x00810000u;
+                Write32(r, r.RomInfo.map_event_pointer, Ptr(eventTableBase));
+                uint condBlock = 0x00820000u;
+                Write32(r, eventTableBase + eventPlist * 4u, Ptr(condBlock));
+
+                var slots = MapEventUnitCore.GetCondSlots(r);
+                int turnIdx = slots.FindIndex(s => s.Type == MapEventUnitCore.CondType.Turn);
+                Assert.True(turnIdx >= 0);
+
+                uint turnTable = 0x00830000u;
+                uint ternSize = r.RomInfo.eventcond_tern_size;
+                uint script1 = 0x00840000u;
+                uint script2 = 0x00850000u;
+
+                // record 0: type==1 (short turn) -> stride 12.
+                r.Data[turnTable + 0] = 0x01;
+                Write32(r, turnTable + 4, Ptr(script1));
+                // record 1 at turnTable + 12: type==2 -> stride ternSize.
+                r.Data[turnTable + 12 + 0] = 0x02;
+                Write32(r, turnTable + 12 + 4, Ptr(script2));
+                // terminator at turnTable + 12 + ternSize: u8==0.
+                Write32(r, condBlock + (uint)turnIdx * 4u, Ptr(turnTable));
+
+                r.write_u32(script1 + 0, 0x0000000A);
+                r.write_u32(script2 + 0, 0x0000000A);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitEventCond(r, list);
+
+                // Both scripts traced (proves the 12-byte short-turn stride advanced to record 1).
+                Assert.Contains(list, a => a.Addr == script1 && a.DataType == Address.DataTypeEnum.EVENTSCRIPT);
+                Assert.Contains(list, a => a.Addr == script2 && a.DataType == Address.DataTypeEnum.EVENTSCRIPT);
+                // TURN frame length = (last base - start) + ternSize = (12 + ternSize - 0) + ternSize.
+                var frame = list.Single(a => a.Addr == turnTable && a.DataType == Address.DataTypeEnum.EVENTCOND_TURN);
+                Assert.Equal(12u + ternSize + ternSize, frame.Length);
+            });
+        }
+
+        [Fact]
+        public void EmitEventCond_FE6_TalkType0x0D_EmitsAsmFunction()
+        {
+            // FE6 talk record type 0x0D -> Address.AddFunction at base_addr + 8.
+            var es = BuildEventScript(TermCommand());
+            var rom = MakeVersionedRom("AFEJ01"); // FE6
+            WithEnv(rom, es, r =>
+            {
+                Assert.Equal(6, r.RomInfo.version);
+                const uint mapId = 0;
+                uint mapTableBase = 0x00800000u;
+                uint mapSize = r.RomInfo.map_setting_datasize;
+                Write32(r, r.RomInfo.map_setting_pointer, Ptr(mapTableBase));
+                uint mapRecord = mapTableBase + mapId * mapSize;
+                Write32(r, mapRecord + 0, 0x08123456u);
+                const byte eventPlist = 7;
+                r.Data[mapRecord + r.RomInfo.map_setting_event_plist_pos] = eventPlist;
+
+                uint eventTableBase = 0x00810000u;
+                Write32(r, r.RomInfo.map_event_pointer, Ptr(eventTableBase));
+                uint condBlock = 0x00820000u;
+                Write32(r, eventTableBase + eventPlist * 4u, Ptr(condBlock));
+
+                var slots = MapEventUnitCore.GetCondSlots(r);
+                int talkIdx = slots.FindIndex(s => s.Type == MapEventUnitCore.CondType.Talk);
+                Assert.True(talkIdx >= 0);
+
+                uint talkTable = 0x00830000u;
+                uint talkSize = r.RomInfo.eventcond_talk_size;
+                uint asmTarget = 0x00880001u; // odd thumb pointer
+                r.Data[talkTable + 0] = 0x0D;                 // FE6 ASM type
+                Write32(r, talkTable + 4, Ptr(0x00890000u));  // event pointer (some script)
+                Write32(r, talkTable + 8, Ptr(asmTarget));    // ASM pointer at +8
+                Write32(r, condBlock + (uint)talkIdx * 4u, Ptr(talkTable));
+                r.write_u32(0x00890000u, 0x0000000A);         // ENDA
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitEventCond(r, list);
+
+                // The ASM function block at +8 is emitted (AddFunction strips the thumb LSB).
+                Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.ASM
+                                           && a.Addr == U.toOffset(asmTarget) - 1);
+            });
+        }
+
+        // =================================================================
+        // GetEventAddrForMap / ResolvePlistToEventAddr out-pointer overloads
+        // =================================================================
+
+        [Fact]
+        public void ResolvePlistToEventAddr_OutPointer_ReturnsSlotAddress()
+        {
+            var rom = MakeFe8uRom();
+            var prevRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = rom;
+                uint tableBase = 0x00810000u;
+                Write32(rom, rom.RomInfo.map_event_pointer, Ptr(tableBase));
+                const uint plist = 7;
+                uint condBlock = 0x00820000u;
+                uint slot = tableBase + plist * 4u;
+                Write32(rom, slot, Ptr(condBlock));
+
+                uint addr = MapEventUnitCore.ResolvePlistToEventAddr(rom, plist, out uint outPointer);
+                Assert.Equal(condBlock, addr);
+                Assert.Equal(slot, outPointer);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+            }
+        }
+
+        // =================================================================
+        // NotYetPorted coverage
+        // =================================================================
+
+        [Fact]
+        public void GetNotYetPortedForms_DropsSlice2uForm_KeepsDeferredSiblings()
+        {
+            string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
+            // EventCondForm is now ported (EmitEventCond + EmitScanScript).
+            Assert.DoesNotContain("EventCondForm", notYet);
+            // Its ScanScript-dependent siblings stay tracked (scoped out of slice 2u).
+            Assert.Contains("MonsterWMapProbabilityForm", notYet);
+            Assert.Contains("WorldMapEventPointerForm", notYet);
+            Assert.Contains("EventBattleTalkForm", notYet);
+            Assert.Contains("EventHaikuForm", notYet);
+        }
+
+        [Fact]
+        public void GetNotYetPortedForms_HasNoDuplicates_AfterSlice2u()
+        {
+            string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
+            var dups = raw.GroupBy(x => x).Where(g => g.Count() > 1).Select(g => g.Key).ToArray();
+            Assert.Empty(dups);
+        }
+    }
+}

--- a/FEBuilderGBA.Core/MapEventUnitCore.cs
+++ b/FEBuilderGBA.Core/MapEventUnitCore.cs
@@ -152,14 +152,18 @@ namespace FEBuilderGBA
             outPointer = U.NOT_FOUND;
             if (rom?.RomInfo == null || plist == 0) return U.NOT_FOUND;
 
-            uint tablePointer = rom.RomInfo.map_event_pointer;
+            uint tablePointer = U.toOffset(rom.RomInfo.map_event_pointer);
             if (tablePointer == 0) return U.NOT_FOUND;
+            // Guard the FULL 4-byte slot (root+3) before each p32: isSafetyOffset(x) alone is a 1-byte
+            // check, so a slot in [Length-3, Length-1] would still throw inside p32->u32->check_safety on a
+            // near-EOF/synthetic ROM. On a valid ROM these are always in-bounds — this only hardens.
+            if (!U.isSafetyOffset(tablePointer + 3, rom)) return U.NOT_FOUND;
 
             uint tableBase = rom.p32(tablePointer);
             if (!U.isSafetyOffset(tableBase, rom)) return U.NOT_FOUND;
 
             uint entryAddr = (uint)(tableBase + plist * 4);
-            if (!U.isSafetyOffset(entryAddr, rom)) return U.NOT_FOUND;
+            if (!U.isSafetyOffset(entryAddr + 3, rom)) return U.NOT_FOUND;
 
             uint eventAddr = rom.p32(entryAddr);
             if (!U.isSafetyOffset(eventAddr, rom)) return U.NOT_FOUND;

--- a/FEBuilderGBA.Core/MapEventUnitCore.cs
+++ b/FEBuilderGBA.Core/MapEventUnitCore.cs
@@ -136,6 +136,20 @@ namespace FEBuilderGBA
         /// </summary>
         public static uint ResolvePlistToEventAddr(ROM rom, uint plist)
         {
+            return ResolvePlistToEventAddr(rom, plist, out _);
+        }
+
+        /// <summary>
+        /// Like <see cref="ResolvePlistToEventAddr(ROM,uint)"/> but ALSO returns
+        /// <paramref name="outPointer"/> — the EVENT-plist table slot
+        /// (<c>tableBase + plist*4</c>) that holds the resolved cond-block address.
+        /// Mirrors WF <c>MapPointerForm.PlistToOffsetAddrFast(EVENT, plist, out pointer)</c>:
+        /// the rebuild producer relocates the cond block through this slot. On any
+        /// failure path <paramref name="outPointer"/> is <see cref="U.NOT_FOUND"/>.
+        /// </summary>
+        public static uint ResolvePlistToEventAddr(ROM rom, uint plist, out uint outPointer)
+        {
+            outPointer = U.NOT_FOUND;
             if (rom?.RomInfo == null || plist == 0) return U.NOT_FOUND;
 
             uint tablePointer = rom.RomInfo.map_event_pointer;
@@ -150,6 +164,7 @@ namespace FEBuilderGBA
             uint eventAddr = rom.p32(entryAddr);
             if (!U.isSafetyOffset(eventAddr, rom)) return U.NOT_FOUND;
 
+            outPointer = entryAddr;
             return eventAddr;
         }
 
@@ -158,6 +173,20 @@ namespace FEBuilderGBA
         /// </summary>
         public static uint GetEventAddrForMap(ROM rom, uint mapId)
         {
+            return GetEventAddrForMap(rom, mapId, out _);
+        }
+
+        /// <summary>
+        /// Like <see cref="GetEventAddrForMap(ROM,uint)"/> but ALSO returns
+        /// <paramref name="mapcondPointer"/> — the EVENT-plist slot that holds the
+        /// cond-block address (WF <c>GetEventAddrWhereMapID(mapid, out pointer)</c>).
+        /// The rebuild producer needs this to emit the <c>EventCond Frame</c> block.
+        /// On any failure path <paramref name="mapcondPointer"/> is
+        /// <see cref="U.NOT_FOUND"/>.
+        /// </summary>
+        public static uint GetEventAddrForMap(ROM rom, uint mapId, out uint mapcondPointer)
+        {
+            mapcondPointer = U.NOT_FOUND;
             if (rom?.RomInfo == null) return U.NOT_FOUND;
 
             // Use the ROM-pinned overload so this delegate never silently reads
@@ -171,7 +200,7 @@ namespace FEBuilderGBA
             uint plist = rom.u8(mapAddr + eventPlistPos);
             if (plist == 0) return U.NOT_FOUND;
 
-            return ResolvePlistToEventAddr(rom, plist);
+            return ResolvePlistToEventAddr(rom, plist, out mapcondPointer);
         }
 
         /// <summary>

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -477,6 +477,32 @@ namespace FEBuilderGBA
                 return new ProducerResult(list, notYet, cancelled: true);
             }
 
+            // ---- slice 2u: EventCondForm FIRST (matches WF U.MakeAllStructPointersList
+            // order — EventCondForm.MakeAllDataLength(list) at U.cs:2418, the very first
+            // static, BEFORE the first DoEvents checkpoint). It walks every map's event-
+            // condition table and ScanScript-traces every referenced event script + data
+            // block.
+            //
+            // The event-script DISASSEMBLER is a hard prerequisite (CoreState.EventScript
+            // / CommentCache). A REAL rebuild always has them wired (full ROM init); but a
+            // partially-initialised host might not. To honour Copilot plan-review point 1
+            // (the omission must never be SILENT) WITHOUT crashing a valid non-EventCond
+            // producer run, EventCondForm is treated as STILL not-yet-ported when the
+            // disasm is unwired — the EVENTCOND/script blocks are skipped AND
+            // EventCondForm is re-reported in NotYetPorted, so IsComplete stays false and
+            // the coverage signal reflects reality. When the disasm IS wired,
+            // EmitEventCond runs and EventCondForm is fully covered.
+            if (IsEventScriptDisasmReady(rom))
+            {
+                progress?.Report("EventCond");
+                EmitEventCond(rom, list);
+            }
+            else
+            {
+                progress?.Report("EventCond (skipped — disassembler not wired)");
+                notYet = AppendNotYetPorted(notYet, "EventCondForm");
+            }
+
             // The WinForms producer interleaves DoEvents checkpoints between groups of
             // statics. We keep the SAME checkpoint boundaries so a later parity slice can
             // line them up. ct.IsCancellationRequested mirrors a DoEvents cancel.
@@ -6978,6 +7004,838 @@ namespace FEBuilderGBA
             }
         }
 
+        // ====================================================================
+        // slice 2u — EventCondForm + the Core ScanScript event-script BLOCK-emitter.
+        //
+        // EventCondForm.MakeAllDataLength (EventCondForm.cs:2450) walks every map's
+        // event-condition table and, per cond slot, emits the EVENTCOND_*/EVENTTRAP
+        // frame Address PLUS — for the slots that hold event-script pointers — runs
+        // EventScriptForm.ScanScript (EventScriptForm.cs:379), the recursive
+        // event-script tracer that emits one Address per referenced data region
+        // (the event-script bytes themselves + the per-arg RecycleOldData blocks:
+        // units, FE7 battle/move/talk data, AI coords/range/calltalk, menus, ASM).
+        //
+        // ScanScript is reproduced VERBATIM as EmitScanScript (the recursive Scan
+        // closure). It is DISTINCT from EventScriptReferenceScanner.ScanScriptForArg
+        // (which collects id VALUES for the references UI) — this one emits Address
+        // BLOCKS for relocation.
+        //
+        // PREREQUISITES (Copilot plan-review point 1 — the omission must be LOUD, not
+        // silent): the event-script DISASSEMBLY path (EventScript.DisAseemble /
+        // IsExitCode / the per-command CommentCache lookup) is bound to the static
+        // CoreState.ROM / CoreState.EventScript / CoreState.CommentCache. Because the
+        // producer already REQUIRES rom == CoreState.ROM (asserted in
+        // MakeAllStructPointers), a real rebuild always has the active ROM wired. But
+        // EventScript / CommentCache could still be unset (e.g. a partially-initialised
+        // headless host). If they are, EmitEventCond would silently emit NO script
+        // blocks — a silent relocation gap once EventCondForm is dropped from
+        // NotYetPorted. So EmitEventCond THROWS InvalidOperationException when the
+        // disasm prerequisites are missing (the caller wires them or keeps the producer
+        // un-wired) rather than producing a partial, falsely-"complete" list.
+        // ====================================================================
+
+        /// <summary>
+        /// Returns true when the event-script disassembly path is wired for
+        /// <paramref name="rom"/>: <paramref name="rom"/> IS the active
+        /// <see cref="CoreState.ROM"/>, an <see cref="EventScript"/> is set, AND a
+        /// comment cache is set (the disasm path dereferences it). Same gate as
+        /// <see cref="EventScriptReferenceScanner.FindAllArgReferences"/>, but the
+        /// producer treats a false result as a HARD ERROR (see
+        /// <see cref="EmitEventCond"/>), never as "emit nothing".
+        /// </summary>
+        static bool IsEventScriptDisasmReady(ROM rom)
+        {
+            if (CoreState.EventScript == null) return false;
+            if (CoreState.ROM == null || !ReferenceEquals(CoreState.ROM, rom)) return false;
+            if (CoreState.CommentCache == null) return false;
+            return true;
+        }
+
+        /// <summary>
+        /// Core port of <c>EventCondForm.MakeAllDataLength</c> (EventCondForm.cs:2450).
+        /// Walks every map (<c>mapid 0..MapSettingCore.GetMapCount()</c>); per map
+        /// resolves the cond-block address + its EVENT-plist slot pointer
+        /// (split-aware, via <see cref="MapChangeCore.PlistToOffsetAddr"/> = WF
+        /// <c>GetEventAddrWhereMapID(out pointer)</c>); per cond slot (laid out by
+        /// <see cref="MapEventUnitCore.GetCondSlots"/> = WF <c>MapCond</c>) emits the
+        /// EVENTCOND_*/EVENTTRAP frame Address at <c>base_pointer = mapcond_addr+4*i</c>,
+        /// runs <see cref="EmitScanScript"/> per referenced event, emits the per-version
+        /// ASM <see cref="Address.DataTypeEnum.ASM"/> blocks, the FE8 random-chest IFR,
+        /// the unit-placement recycle, and the trailing <c>EventCond Frame</c> block.
+        ///
+        /// <para>The <c>tracelist</c> is allocated ONCE for the whole walk (matching WF
+        /// <c>EventCondForm.MakeAllDataLength</c>'s single <c>tracelist</c>), so a script
+        /// reached from two maps/conds is emitted once (the second reference becomes a
+        /// zero-length alias <see cref="Address.DataTypeEnum.EVENTSCRIPT"/> pointer).</para>
+        ///
+        /// <para>THROWS <see cref="InvalidOperationException"/> when the event-script
+        /// disasm path is not wired (<see cref="IsEventScriptDisasmReady"/>) — the
+        /// omission of every traced script block would otherwise be silent.</para>
+        /// </summary>
+        public static void EmitEventCond(ROM rom, List<Address> list)
+        {
+            if (rom?.RomInfo == null) return;
+
+            if (!IsEventScriptDisasmReady(rom))
+            {
+                throw new InvalidOperationException(
+                    "RebuildProducerCore.EmitEventCond requires the event-script disassembler to be "
+                    + "wired (CoreState.ROM == rom, CoreState.EventScript != null, CoreState.CommentCache "
+                    + "!= null). Without it every ScanScript-traced data block would be silently dropped "
+                    + "from the rebuild relocation list (corruption). Wire the disassembler before running "
+                    + "the producer, or keep EventCondForm in NotYetPorted.");
+            }
+
+            var tracelist = new List<uint>();
+            int mapmax = MapSettingCore.GetMapCount();
+            var slots = MapEventUnitCore.GetCondSlots(rom);
+            if (slots.Count == 0) return;
+
+            uint ternSize = rom.RomInfo.eventcond_tern_size;
+            uint talkSize = rom.RomInfo.eventcond_talk_size;
+
+            for (uint mapid = 0; mapid < mapmax; mapid++)
+            {
+                // mapcond_pointer = the EVENT-plist slot holding the cond block; mapcond_addr = the block.
+                uint mapcondPointer;
+                uint mapcondAddr = ResolveEventCondAddr(rom, mapid, out mapcondPointer);
+                if (!U.isSafetyOffset(mapcondAddr, rom))
+                {
+                    continue;
+                }
+                string mapidString = U.To0xHexString(mapid);
+
+                for (int i = 0; i < slots.Count; i++)
+                {
+                    MapEventUnitCore.CondType condtype = slots[i].Type;
+                    uint basePointer = (uint)(mapcondAddr + (4 * i));
+                    // WF reads base_addr = p32(base_pointer); guard the full 4-byte slot first.
+                    if (!U.isSafetyOffset(basePointer + 3, rom))
+                    {
+                        continue;
+                    }
+                    uint baseAddr = rom.p32(basePointer);
+                    if (!U.isSafetyOffset(baseAddr, rom))
+                    {
+                        continue;
+                    }
+
+                    uint startaddr = baseAddr;
+                    switch (condtype)
+                    {
+                        case MapEventUnitCore.CondType.Turn:
+                        {
+                            while (true)
+                            {
+                                if (!U.isSafetyOffset(baseAddr + ternSize, rom)) break;
+                                uint type = rom.u8(baseAddr);
+                                if (type == 0) break;
+
+                                if (rom.RomInfo.version == 6 && type == 0x0D)
+                                {
+                                    EmitEventCondAsm(rom, list, baseAddr + 8,
+                                        "EventCond map:" + mapidString + " talk: ASM");
+                                }
+
+                                uint eventAddr = rom.p32(baseAddr + 4);
+                                if (U.isSafetyOffset(eventAddr, rom))
+                                {
+                                    EmitScanScript(rom, list, baseAddr + 4, true, false,
+                                        "EventScript map:" + mapidString + " turn:" + U.To0xHexString(eventAddr),
+                                        tracelist);
+                                }
+
+                                if (rom.RomInfo.version == 7 && type == 1)
+                                {
+                                    baseAddr += 12; // FE7 12-byte short-turn event
+                                }
+                                else
+                                {
+                                    baseAddr += ternSize;
+                                }
+                            }
+                            Address.AddAddress(list, startaddr, baseAddr - startaddr + ternSize, basePointer,
+                                "EventCond map:" + mapidString + " turn:" + U.ToHexString(startaddr),
+                                Address.DataTypeEnum.EVENTCOND_TURN);
+                            break;
+                        }
+                        case MapEventUnitCore.CondType.Talk:
+                        {
+                            for (; true; baseAddr += talkSize)
+                            {
+                                if (!U.isSafetyOffset(baseAddr + talkSize, rom)) break;
+                                uint type = rom.u8(baseAddr + 0);
+                                if (type == 0) break;
+
+                                if (rom.RomInfo.version == 6)
+                                {
+                                    if (type == 0x0D)
+                                    {
+                                        EmitEventCondAsm(rom, list, baseAddr + 8,
+                                            "EventCond map:" + mapidString + " talk: ASM");
+                                    }
+                                }
+                                else
+                                {
+                                    if (type == 0x04)
+                                    {
+                                        EmitEventCondAsm(rom, list, baseAddr + 12,
+                                            "EventCond map:" + mapidString + " talk: ASM");
+                                    }
+                                }
+
+                                uint eventAddr = rom.p32(baseAddr + 4);
+                                if (!U.isSafetyOffset(eventAddr, rom)) continue;
+
+                                EmitScanScript(rom, list, baseAddr + 4, true, false,
+                                    "EventScript map:" + mapidString + " talk:" + U.To0xHexString(eventAddr),
+                                    tracelist);
+                            }
+                            Address.AddAddress(list, startaddr, baseAddr - startaddr + talkSize, basePointer,
+                                "EventCond map:" + mapidString + " talk:" + U.ToHexString(startaddr),
+                                Address.DataTypeEnum.EVENTCOND_TALK);
+                            break;
+                        }
+                        case MapEventUnitCore.CondType.Object:
+                        {
+                            for (; true; baseAddr += 12)
+                            {
+                                if (!U.isSafetyOffset(baseAddr + 12, rom)) break;
+                                uint type = rom.u8(baseAddr);
+                                if (type == 0) break;
+
+                                uint eventAddr = rom.p32(baseAddr + 4);
+                                if (!U.isSafetyOffset(eventAddr, rom)) continue;
+
+                                uint objectType = rom.u8(baseAddr + 10);
+                                if (IsShopObjectType(rom, objectType))
+                                {
+                                    // shop — recovered as separate data, nothing here.
+                                }
+                                else if (IsChestObjectType(rom, objectType))
+                                {
+                                    if (rom.RomInfo.version == 8 && type == 0x5)
+                                    {
+                                        EmitItemRandomChest(rom, list, baseAddr + 4, mapidString);
+                                    }
+                                }
+                                else
+                                {
+                                    EmitScanScript(rom, list, baseAddr + 4, true, false,
+                                        "EventScript map:" + mapidString + " obj:" + U.To0xHexString(eventAddr),
+                                        tracelist);
+                                }
+                            }
+                            Address.AddAddress(list, startaddr, baseAddr - startaddr + 12, basePointer,
+                                "EventCond Object map:" + mapidString + " obj:" + U.To0xHexString(startaddr),
+                                Address.DataTypeEnum.EVENTCOND_OBJECT);
+                            break;
+                        }
+                        case MapEventUnitCore.CondType.Always:
+                        {
+                            for (; true; baseAddr += 12)
+                            {
+                                if (!U.isSafetyOffset(baseAddr + 12, rom)) break;
+                                uint type = rom.u32(baseAddr);
+                                if (type == 0) break;
+
+                                if (rom.RomInfo.version == 6)
+                                {
+                                    if (type == 0x0D)
+                                    {
+                                        EmitEventCondAsm(rom, list, baseAddr + 8,
+                                            "EventCond map:" + mapidString + " always: ASM");
+                                    }
+                                }
+                                else
+                                {
+                                    if (type == 0x0E)
+                                    {
+                                        EmitEventCondAsm(rom, list, baseAddr + 12,
+                                            "EventCond map:" + mapidString + " always: ASM");
+                                    }
+                                }
+
+                                uint eventAddr = rom.p32(baseAddr + 4);
+                                if (!U.isSafetyOffset(eventAddr, rom)) continue;
+
+                                EmitScanScript(rom, list, baseAddr + 4, true, false,
+                                    "EventScript map:" + mapidString + " always:" + U.To0xHexString(eventAddr),
+                                    tracelist);
+                            }
+                            Address.AddAddress(list, startaddr, baseAddr - startaddr + 12, basePointer,
+                                "EventCond map:" + mapidString + " always:" + U.ToHexString(startaddr),
+                                Address.DataTypeEnum.EVENTCOND_ALWAYS);
+                            break;
+                        }
+                        case MapEventUnitCore.CondType.Trap:
+                        {
+                            for (; true; baseAddr += 6)
+                            {
+                                if (!U.isSafetyOffset(baseAddr + 6, rom)) break;
+                                if (rom.u8(baseAddr) == 0) break;
+                                // nop — TRAP records hold no event-script / sub-pointers.
+                            }
+                            Address.AddAddress(list, startaddr, baseAddr - startaddr + 6, basePointer,
+                                "EventScript map:" + mapidString + " trap:" + U.To0xHexString(startaddr),
+                                Address.DataTypeEnum.EVENTTRAP);
+                            break;
+                        }
+                        case MapEventUnitCore.CondType.Tutorial:
+                        {
+                            for (; true; baseAddr += 4)
+                            {
+                                if (!U.isSafetyOffset(baseAddr + 4, rom)) break;
+                                if (rom.u8(baseAddr) == 0) break;
+
+                                uint eventAddr = rom.p32(baseAddr + 0);
+                                if (!U.isSafetyOffset(eventAddr, rom)) continue;
+
+                                EmitScanScript(rom, list, baseAddr + 0, true, false,
+                                    "EventScript map:" + mapidString + " tutorial:" + U.To0xHexString(eventAddr),
+                                    tracelist);
+                            }
+                            Address.AddAddress(list, startaddr, baseAddr - startaddr + 4, basePointer,
+                                "EventScript map:" + mapidString + " tutorial:" + U.To0xHexString(startaddr),
+                                Address.DataTypeEnum.POINTER);
+                            break;
+                        }
+                        case MapEventUnitCore.CondType.PlayerUnit:
+                        case MapEventUnitCore.CondType.EnemyUnit:
+                        case MapEventUnitCore.CondType.FreemapPlayerUnit:
+                        case MapEventUnitCore.CondType.FreemapEnemyUnit:
+                        {
+                            // Unit placement — WF EventUnitForm.RecycleOldUnits(ref list, name, base_pointer).
+                            EmitRecycleOldUnits(rom, list,
+                                "EventCond map:" + mapidString + " units:" + U.To0xHexString(startaddr),
+                                basePointer);
+                            break;
+                        }
+                        case MapEventUnitCore.CondType.StartEvent:
+                        case MapEventUnitCore.CondType.EndEvent:
+                        {
+                            // 18,19 chapter start/end event — the cond-slot itself is the script pointer.
+                            EmitScanScript(rom, list, basePointer, true, false,
+                                "EventScript map:" + mapidString + " chaptor:" + U.To0xHexString(startaddr),
+                                tracelist);
+                            break;
+                        }
+                        default:
+                            // Unknown cond type — WF has no branch; nothing emitted.
+                            break;
+                    }
+                }
+
+                Address.AddAddress(list, mapcondAddr, (uint)slots.Count * 4, mapcondPointer,
+                    "EventCond Frame map:" + mapidString, Address.DataTypeEnum.POINTER);
+            }
+        }
+
+        /// <summary>
+        /// Resolve a map's event-condition block address + the EVENT-plist slot that
+        /// holds it (= WF <c>MapSettingForm.GetEventAddrWhereMapID(mapid, out pointer)</c>).
+        /// Reads the map's event plist index (<c>u8(mapAddr + map_setting_event_plist_pos)</c>)
+        /// then resolves it SPLIT-AWARE through
+        /// <see cref="MapChangeCore.PlistToOffsetAddr"/> (= WF
+        /// <c>PlistToOffsetAddrFast(EVENT, plist, out pointer)</c>, which applies the
+        /// per-version PLIST limit). Returns <see cref="U.NOT_FOUND"/> + an
+        /// <see cref="U.NOT_FOUND"/> pointer on any failure.
+        /// </summary>
+        static uint ResolveEventCondAddr(ROM rom, uint mapId, out uint mapcondPointer)
+        {
+            mapcondPointer = U.NOT_FOUND;
+            if (rom?.RomInfo == null) return U.NOT_FOUND;
+
+            uint mapAddr = MapSettingCore.GetMapAddr(rom, mapId);
+            if (mapAddr == U.NOT_FOUND) return U.NOT_FOUND;
+
+            uint eventPlistPos = rom.RomInfo.map_setting_event_plist_pos;
+            if (eventPlistPos == 0) return U.NOT_FOUND;
+            if (!U.isSafetyOffset(mapAddr + eventPlistPos, rom)) return U.NOT_FOUND;
+
+            uint plist = rom.u8(mapAddr + eventPlistPos);
+            if (plist == 0) return U.NOT_FOUND;
+
+            // Split-aware EVENT-plist resolution (Copilot plan-review point 2).
+            return MapChangeCore.PlistToOffsetAddr(rom, MapChangeCore.PlistType.EVENT, plist, out mapcondPointer);
+        }
+
+        /// <summary>
+        /// One EventCond ASM block: WF <c>Address.AddFunction(list, addr, name)</c>.
+        /// EOF-hardened (Copilot plan-review point 4): <see cref="Address.AddFunction"/>
+        /// reads <c>u32(addr)</c> after only a start-offset check, so the full 4-byte
+        /// field is guarded here first.
+        /// </summary>
+        static void EmitEventCondAsm(ROM rom, List<Address> list, uint addr, string name)
+        {
+            if (!U.isSafetyOffset(U.toOffset(addr) + 3, rom)) return;
+            Address.AddFunction(list, addr, name);
+        }
+
+        /// <summary>
+        /// VERBATIM port of <c>EventScriptForm.ScanScript</c> (EventScriptForm.cs:379)
+        /// + its inner <c>ScanScriptHelper.Scan</c>. Disassembles the event script
+        /// behind the pointer slot <paramref name="scriptPointer"/> and emits one
+        /// <see cref="Address.DataTypeEnum.EVENTSCRIPT"/> block for it, recursing through
+        /// <see cref="EventScript.ScriptHas.POINTER_UNIT_OR_EVENT"/> /
+        /// <see cref="EventScript.ScriptHas.POINTER_OTHER"/> args. With
+        /// <paramref name="isWithEventUnit"/> it ALSO dispatches each pointer-arg type to
+        /// the per-form <c>RecycleOldData</c> reproduction (units / FE7 battle/move/talk /
+        /// AI coord/range/calltalk / units-short-text / menu-extends / ASM).
+        ///
+        /// <para>The shared <paramref name="tracelist"/> stores TARGET offsets (the
+        /// dereferenced event_addr); a revisited target emits a zero-length alias
+        /// EVENTSCRIPT pointer for the SLOT (matching WF, Copilot plan-review point 3).</para>
+        ///
+        /// <para>EOF/termination guards (Copilot plan-review point 4): a hard
+        /// <see cref="ScanMaxSteps"/> step cap and a <c>Script.Size &gt; 0</c> advance
+        /// guard supplement the WF 10-UNKNOWN cutoff so a non-advancing / malformed
+        /// decode can never spin.</para>
+        /// </summary>
+        public static void EmitScanScript(ROM rom, List<Address> list, uint scriptPointer,
+            bool isWithEventUnit, bool isWorldMapEvent, string basename, List<uint> tracelist)
+        {
+            var es = CoreState.EventScript;
+            if (es == null) return; // disasm not wired — caller (EmitEventCond) already hard-errors.
+            ScanScriptRecurse(rom, es, list, scriptPointer, isWithEventUnit, isWorldMapEvent, basename, tracelist, 0);
+        }
+
+        // WF cutoff: 10 consecutive UNKNOWN commands abort a single walk.
+        const int ScanUnknownCutoff = 10;
+        // Defensive recursion + step caps (no WF equivalent — WF relies on the tracelist
+        // cycle-guard + exit/unknown cutoffs; we add hard caps so a pathological ROM can
+        // never hang or stack-overflow). The tracelist already bounds distinct targets.
+        const int ScanMaxSteps = 1 << 20;
+        const int ScanMaxDepth = 4096;
+
+        static void ScanScriptRecurse(ROM rom, EventScript es, List<Address> list, uint eventPointer,
+            bool isWithEventUnit, bool isWorldMapEvent, string basename, List<uint> tracelist, int depth)
+        {
+            if (depth > ScanMaxDepth) return;
+
+            // WF: event_addr = Program.ROM.u32(event_pointer); guard the full 4-byte slot.
+            uint eptr = U.toOffset(eventPointer);
+            if (!U.isSafetyOffset(eptr + 3, rom)) return;
+            uint eventAddrRaw = rom.u32(eptr);
+            if (!U.isPointer(eventAddrRaw)) return;
+            uint eventAddr = U.toOffset(eventAddrRaw);
+            if (!U.isSafetyOffset(eventAddr, rom)) return;
+
+            if (tracelist.IndexOf(eventAddr) >= 0)
+            {//既知 — emit the zero-length alias pointer for the SLOT.
+                Address.AddPointer(list, eventPointer, 0, basename, Address.DataTypeEnum.EVENTSCRIPT);
+                return;
+            }
+            tracelist.Add(eventAddr);
+
+            uint addr = eventAddr;
+            uint lastBranchAddr = 0;
+            int unknownCount = 0;
+            for (int step = 0; step < ScanMaxSteps; step++)
+            {
+                // Guard the 4-byte minimum a decode reads (Copilot plan-review point 4).
+                if (U.toOffset(addr) + 4 > (uint)rom.Data.Length)
+                {
+                    Address.AddPointer(list, eventPointer, 0, basename, Address.DataTypeEnum.EVENTSCRIPT);
+                    return;
+                }
+
+                EventScript.OneCode code = es.DisAseemble(rom.Data, addr);
+                if (code?.Script == null)
+                {
+                    Address.AddPointer(list, eventPointer, 0, basename, Address.DataTypeEnum.EVENTSCRIPT);
+                    return;
+                }
+
+                if (EventScript.IsExitCode(code, addr, lastBranchAddr))
+                {//終端命令
+                    uint len = (uint)(addr - eventAddr + code.Script.Size);
+                    Address.AddPointer(list, eventPointer, len, basename, Address.DataTypeEnum.EVENTSCRIPT);
+                    return;
+                }
+                else if (code.Script.Has == EventScript.ScriptHas.UNKNOWN)
+                {
+                    unknownCount++;
+                    if (unknownCount > ScanUnknownCutoff)
+                    {//不明命令が連続したら打ち切る
+                        Address.AddPointer(list, eventPointer, 0, basename, Address.DataTypeEnum.EVENTSCRIPT);
+                        return;
+                    }
+                }
+                else
+                {
+                    unknownCount = 0;
+
+                    if (code.Script.Has == EventScript.ScriptHas.POINTER_UNIT_OR_EVENT
+                        || code.Script.Has == EventScript.ScriptHas.POINTER_OTHER)
+                    {
+                        ScanScriptDispatchArgs(rom, es, list, code, addr, isWithEventUnit, basename, tracelist, depth);
+                    }
+                    else if (code.Script.Has == EventScript.ScriptHas.LABEL_CONDITIONAL)
+                    {
+                        lastBranchAddr = 0;
+                    }
+                    else if (code.Script.Has == EventScript.ScriptHas.IF_CONDITIONAL)
+                    {
+                        lastBranchAddr = addr;
+                    }
+                }
+
+                int size = code.Script.Size;
+                if (size <= 0)
+                {// guard against a non-advancing decode (no WF equiv; cannot happen on valid data).
+                    Address.AddPointer(list, eventPointer, 0, basename, Address.DataTypeEnum.EVENTSCRIPT);
+                    return;
+                }
+                addr += (uint)size;
+            }
+        }
+
+        /// <summary>
+        /// The per-arg dispatch loop of WF <c>ScanScriptHelper.Scan</c> — for each arg
+        /// of <paramref name="code"/> recurse through POINTER_EVENT (cycle-guarded by the
+        /// shared <paramref name="tracelist"/>) or, when <paramref name="isWithEventUnit"/>,
+        /// dispatch to the per-pointer-type RecycleOldData reproduction.
+        /// </summary>
+        static void ScanScriptDispatchArgs(ROM rom, EventScript es, List<Address> list,
+            EventScript.OneCode code, uint addr, bool isWithEventUnit, string basename,
+            List<uint> tracelist, int depth)
+        {
+            if (code.Script.Args == null) return;
+            for (int i = 0; i < code.Script.Args.Length; i++)
+            {
+                EventScript.ArgType argType = code.Script.Args[i].Type;
+                if (argType == EventScript.ArgType.POINTER_EVENT)
+                {
+                    // WF passes the POINTER SLOT (GetArgPointer = base+position), NOT the
+                    // dereferenced target. The tracelist add here guards the SLOT v; Scan
+                    // re-checks the dereferenced target's tracelist membership.
+                    uint v = EventScript.GetArgPointer(code, i, addr);
+                    if (U.isSafetyOffset(v, rom) && tracelist.IndexOf(v) < 0)
+                    {
+                        tracelist.Add(v);
+                        ScanScriptRecurse(rom, es, list, v, isWithEventUnit, false, basename, tracelist, depth + 1);
+                    }
+                }
+                else if (!isWithEventUnit)
+                {//nop
+                }
+                else if (argType == EventScript.ArgType.POINTER_UNIT)
+                {//ユニット配置の回収
+                    uint v = EventScript.GetArgPointer(code, i, addr);
+                    if (v == EventUnitInvalidatePointer)
+                    {//ユニット指定がない状態
+                    }
+                    else if (U.isSafetyOffset(v, rom) && tracelist.IndexOf(v) < 0)
+                    {
+                        tracelist.Add(v);
+                        EmitRecycleOldUnits(rom, list, basename, v);
+                    }
+                }
+                else if (argType == EventScript.ArgType.POINTER_EVENTBATTLEDATA)
+                {//FE7戦闘バトルポインタの回収
+                    uint v = EventScript.GetArgPointer(code, i, addr);
+                    if (U.isSafetyOffset(v, rom) && tracelist.IndexOf(v) < 0)
+                    {
+                        tracelist.Add(v);
+                        EmitEventBattleDataFE7(rom, list, v);
+                    }
+                }
+                else if (argType == EventScript.ArgType.POINTER_EVENTMOVEDATA)
+                {//FE7イベントの移動配置座標の回収
+                    uint v = EventScript.GetArgPointer(code, i, addr);
+                    if (U.isSafetyOffset(v, rom) && tracelist.IndexOf(v) < 0)
+                    {
+                        tracelist.Add(v);
+                        EmitEventMoveDataFE7(rom, list, v);
+                    }
+                }
+                else if (argType == EventScript.ArgType.POINTER_TALKGROUP)
+                {//FE7会話グループポインタの回収
+                    uint v = EventScript.GetArgPointer(code, i, addr);
+                    if (U.isSafetyOffset(v, rom) && tracelist.IndexOf(v) < 0)
+                    {
+                        tracelist.Add(v);
+                        EmitEventTalkGroupFE7(rom, list, v);
+                    }
+                }
+                else if (argType == EventScript.ArgType.POINTER_MENUEXTENDS)
+                {//メニューオプション
+                    uint v = EventScript.GetArgPointer(code, i, addr);
+                    if (U.isSafetyOffset(v, rom) && tracelist.IndexOf(v) < 0)
+                    {
+                        tracelist.Add(v);
+                        EmitMenuExtendSplitMenu(rom, list, v);
+                    }
+                }
+                else if (argType == EventScript.ArgType.POINTER_UNITSSHORTTEXT)
+                {//unitに関連付けられたshort型データ
+                    uint v = EventScript.GetArgPointer(code, i, addr);
+                    if (U.isSafetyOffset(v, rom) && tracelist.IndexOf(v) < 0)
+                    {
+                        tracelist.Add(v);
+                        // UnitsShortTextForm.RecycleOldData: AddPointer(2*DATAMAX, BIN), DATAMAX=0x46.
+                        EmitFixedBinPointer(rom, list, v, 2 * 0x46, "UnitsShortText");
+                    }
+                }
+                else if (argType == EventScript.ArgType.POINTER_AICOORDINATE)
+                {//AI座標
+                    uint v = EventScript.GetArgPointer(code, i, addr);
+                    if (U.isSafetyOffset(v, rom) && tracelist.IndexOf(v) < 0)
+                    {
+                        tracelist.Add(v);
+                        EmitFixedBinPointer(rom, list, v, 4, "AI Coordinate");
+                    }
+                }
+                else if (argType == EventScript.ArgType.POINTER_AIRANGE)
+                {//AI範囲
+                    uint v = EventScript.GetArgPointer(code, i, addr);
+                    if (U.isSafetyOffset(v, rom) && tracelist.IndexOf(v) < 0)
+                    {
+                        tracelist.Add(v);
+                        EmitFixedBinPointer(rom, list, v, 4, "AI Range");
+                    }
+                }
+                else if (argType == EventScript.ArgType.POINTER_AICALLTALK)
+                {//敵AIから話しかける
+                    uint v = EventScript.GetArgPointer(code, i, addr);
+                    if (U.isSafetyOffset(v, rom) && tracelist.IndexOf(v) < 0)
+                    {
+                        tracelist.Add(v);
+                        EmitFixedBinPointer(rom, list, v, 4, "AI CallTalk");
+                    }
+                }
+                else if (argType == EventScript.ArgType.POINTER_ASM)
+                {//ASM
+                    uint v = EventScript.GetArgPointer(code, i, addr);
+                    if (U.isSafetyOffset(v, rom) && tracelist.IndexOf(v) < 0)
+                    {
+                        tracelist.Add(v);
+                        EmitEventCondAsm(rom, list, v, "");
+                    }
+                }
+            }
+        }
+
+        // EventUnitForm.INVALIDATE_UNIT_POINTER (a "no unit specified" sentinel).
+        const uint EventUnitInvalidatePointer = 0xFFFFFF;
+
+        /// <summary>
+        /// <c>UnitsShortTextForm</c> / <c>AIASMCoordinateForm</c> / <c>AIASMRangeForm</c> /
+        /// <c>AIASMCALLTALKForm</c> <c>RecycleOldData</c> = a single
+        /// <c>Address.AddPointer(script_pointer, length, name, BIN)</c>. EOF-hardened:
+        /// <see cref="Address.AddPointer"/> reads <c>u32(pointer)</c> after only a
+        /// start-offset check, so the full 4-byte slot is guarded here first.
+        /// </summary>
+        static void EmitFixedBinPointer(ROM rom, List<Address> list, uint scriptPointer, uint length, string name)
+        {
+            if (!U.isSafetyOffset(U.toOffset(scriptPointer) + 3, rom)) return;
+            Address.AddPointer(list, scriptPointer, length, name, Address.DataTypeEnum.BIN);
+        }
+
+        /// <summary>
+        /// <c>EventBattleDataFE7Form.RecycleOldData</c>: <c>ReInitPointer(script_pointer)</c>
+        /// → an IFR Address {pointer = script_pointer, indexes {}}, block 4, count predicate
+        /// <c>(u32(addr) &amp; 0x800000) != 0x800000</c>. Length = block*(count+1).
+        /// </summary>
+        static void EmitEventBattleDataFE7(ROM rom, List<Address> list, uint scriptPointer)
+        {
+            uint field = U.toOffset(scriptPointer);
+            if (!U.isSafetyOffset(field + 3, rom)) return;
+            uint scriptAddrRaw = rom.u32(field);
+            if (!U.isPointer(scriptAddrRaw)) return;
+            uint scriptAddr = U.toOffset(scriptAddrRaw);
+            if (!U.isSafetyOffset(scriptAddr, rom)) return;
+
+            const uint block = 4;
+            uint count = rom.getBlockDataCount(scriptAddr, block,
+                (i, a) => (rom.u32(a) & 0x800000) != 0x800000);
+            uint length = block * (count + 1);
+            list.Add(new Address(scriptAddr, length, field, "",
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { }));
+        }
+
+        /// <summary>
+        /// <c>EventMoveDataFE7Form.RecycleOldData</c>: <c>ReInit(script_addr)</c>
+        /// → an IFR Address with pointer = NOT_FOUND (ReInit, NOT ReInitPointer — the
+        /// fresh IFR's BasePointer is 0, which fails isSafetyOffset → NOT_FOUND), block 1,
+        /// a VARIABLE-STRIDE reader (<c>IsAppnedData(u8) ? addr+2 : addr+1</c>;
+        /// IsAppnedData = type∈{9,0xC}) and count predicate
+        /// <c>IsEnableData(u8)</c> (type ≤ 3 || 0xA || 9 || 0xC). Length = block*(count+1)
+        /// = count+1 (VERBATIM WF — the IFR length formula is BlockSize-based even with a
+        /// variable stride). name "FE7MoveData".
+        /// </summary>
+        static void EmitEventMoveDataFE7(ROM rom, List<Address> list, uint scriptPointer)
+        {
+            uint field = U.toOffset(scriptPointer);
+            if (!U.isSafetyOffset(field + 3, rom)) return;
+            uint scriptAddrRaw = rom.u32(field);
+            if (!U.isPointer(scriptAddrRaw)) return;
+            uint scriptAddr = U.toOffset(scriptAddrRaw);
+            if (!U.isSafetyOffset(scriptAddr, rom)) return;
+
+            const uint block = 1;
+            uint count = rom.getBlockDataCount(scriptAddr,
+                (i, a) =>
+                {
+                    uint type = rom.u8(a);
+                    return type <= 3 || type == 0xA || type == 9 || type == 0xC; // IsEnableData
+                },
+                (a) =>
+                {
+                    uint type = rom.u8(a);
+                    if (type == 9 || type == 0xC) return a + 2; // IsAppnedData
+                    return a + 1;
+                },
+                block);
+            uint length = block * (count + 1);
+            // ReInit(addr): BasePointer unset (0) → pointer = NOT_FOUND (a direct addr block).
+            list.Add(new Address(scriptAddr, length, U.NOT_FOUND, "FE7MoveData",
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { }));
+        }
+
+        /// <summary>
+        /// <c>EventTalkGroupFE7Form.RecycleOldData</c>: <c>ReInitPointer(script_pointer)</c>
+        /// → an IFR Address {pointer = script_pointer, indexes {}}, block 4, count predicate
+        /// <c>i &lt;= 0xD</c> (a FIXED 0xE-entry table). Length = block*(count+1).
+        /// </summary>
+        static void EmitEventTalkGroupFE7(ROM rom, List<Address> list, uint scriptPointer)
+        {
+            uint field = U.toOffset(scriptPointer);
+            if (!U.isSafetyOffset(field + 3, rom)) return;
+            uint scriptAddrRaw = rom.u32(field);
+            if (!U.isPointer(scriptAddrRaw)) return;
+            uint scriptAddr = U.toOffset(scriptAddrRaw);
+            if (!U.isSafetyOffset(scriptAddr, rom)) return;
+
+            const uint block = 4;
+            uint count = rom.getBlockDataCount(scriptAddr, block, (i, a) => i <= 0xD);
+            uint length = block * (count + 1);
+            list.Add(new Address(scriptAddr, length, field, "",
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { }));
+        }
+
+        /// <summary>
+        /// <c>MenuExtendSplitMenuForm.RecycleOldData</c>: if the terminator at
+        /// <c>addr + 36 + 36*9</c> is 0xFFFFFFFF → <c>AddPointer(36+36*9+4, SplitMenu9)</c>;
+        /// elif at <c>addr + 36 + 36*5</c> → <c>AddPointer(36+36*5+4, SplitMenu5)</c>; else
+        /// fall through to <c>MenuDefinitionForm.MakeAllDataLength(isDirectAddress:true)</c>
+        /// (= <see cref="EmitMenuDefinitionDirect"/>, a count-1 direct-address menu walk).
+        /// </summary>
+        static void EmitMenuExtendSplitMenu(ROM rom, List<Address> list, uint scriptPointer)
+        {
+            uint field = U.toOffset(scriptPointer);
+            if (!U.isSafetyOffset(field + 3, rom)) return;
+            uint addr = rom.p32(field);
+            // WF reads from the DEREFERENCED data addr; addr may be junk — every read guarded.
+
+            const uint menu = 36;
+            uint term9Off = menu + (menu * 9);
+            if (U.isSafetyOffset(addr + term9Off + 3, rom))
+            {
+                uint term = rom.u32(addr + term9Off);
+                if (term == 0xFFFFFFFF)
+                {
+                    Address.AddPointer(list, scriptPointer, term9Off + 4, "SplitMenu9",
+                        Address.DataTypeEnum.SplitMenu9);
+                    return;
+                }
+            }
+            uint term5Off = menu + (menu * 5);
+            if (U.isSafetyOffset(addr + term5Off + 3, rom))
+            {
+                uint term = rom.u32(addr + term5Off);
+                if (term == 0xFFFFFFFF)
+                {
+                    Address.AddPointer(list, scriptPointer, term5Off + 4, "SplitMenu5",
+                        Address.DataTypeEnum.SplitMenu5);
+                    return;
+                }
+            }
+            // General fall-through (WF MenuDefinitionForm.MakeAllDataLength(isDirectAddress:true)).
+            EmitMenuDefinitionDirect(rom, list, scriptPointer);
+        }
+
+        /// <summary>
+        /// <c>MenuDefinitionForm.MakeAllDataLength(list, pointer, isDirectAddress:true)</c>:
+        /// <c>ReInitPointer(pointer, 1)</c> — base = p32(pointer), DataCount FIXED at 1
+        /// (NOT a getBlockDataCount walk). Emits the main MenuDefinition IFR (length =
+        /// block*DataCount, NO +1; type InputFormRef_1; indexes {8,12,16,20,24,28,32}) +
+        /// the single entry's MenuCommand sub-table (<see cref="EmitMenuCommandSubTable"/>)
+        /// and 6 ASM blocks. Reuses the slice-2d MenuDefinition machinery.
+        /// </summary>
+        static void EmitMenuDefinitionDirect(ROM rom, List<Address> list, uint pointer)
+        {
+            pointer = U.toOffset(pointer);
+            if (!U.isSafetyOffset(pointer + 3, rom)) return;
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom)) return;
+
+            const uint block = 36;
+            const uint dataCount = 1; // ReInitPointer(pointer, 1) — fixed count.
+
+            // AddAddressButDoNotLengthPuls1: length = block * DataCount (NO +1), InputFormRef_1.
+            uint length = block * dataCount;
+            list.Add(new Address(baseAddr, length, pointer, "MenuDefinition",
+                Address.DataTypeEnum.InputFormRef_1, block,
+                new uint[] { 8, 12, 16, 20, 24, 28, 32 }));
+
+            for (uint i = 0; i < dataCount; i++)
+            {
+                uint p = baseAddr + i * block;
+                string name = "MenuDef" + i + "_";
+
+                if (!U.isSafetyOffset(8 + p + 3, rom)) continue;
+                uint paddr = rom.p32(8 + p);
+                if (!U.isSafetyOffset(paddr, rom)) continue;
+                EmitMenuCommandSubTable(rom, list, 8 + p, name);
+
+                EmitMenuDefAsm(rom, list, p, 12, name + "_HandleBPress");
+                EmitMenuDefAsm(rom, list, p, 16, name + "_HandleRPress");
+                EmitMenuDefAsm(rom, list, p, 20, name + "_Construction");
+                EmitMenuDefAsm(rom, list, p, 24, name + "_Destruction");
+                EmitMenuDefAsm(rom, list, p, 28, name + "_UnkP28");
+                EmitMenuDefAsm(rom, list, p, 32, name + "_Unk32");
+            }
+        }
+
+        /// <summary>
+        /// <c>ItemRandomChestForm.MakeAllDataLength(list, pointer, appendName)</c> (FE8
+        /// chest objects): <c>ReInitPointer(pointer)</c> → an IFR Address, block 2, count
+        /// predicate <c>u8(addr) != 0</c>, indexes {}, name "RandomChest mapid:&lt;append&gt;".
+        /// Length = block*(count+1).
+        /// </summary>
+        static void EmitItemRandomChest(ROM rom, List<Address> list, uint pointer, string appendName)
+        {
+            uint field = U.toOffset(pointer);
+            if (!U.isSafetyOffset(field + 3, rom)) return;
+            uint addrRaw = rom.u32(field);
+            if (!U.isPointer(addrRaw)) return;
+            uint addr = U.toOffset(addrRaw);
+            if (!U.isSafetyOffset(addr, rom)) return;
+
+            const uint block = 2;
+            uint count = rom.getBlockDataCount(addr, block, (i, a) => rom.u8(a) != 0x00);
+            uint length = block * (count + 1);
+            list.Add(new Address(addr, length, field, "RandomChest mapid:" + appendName,
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { }));
+        }
+
+        // WF EventCondForm.IsChestObjectType: FE8 chest=0x14, FE6/7 chest=0x12.
+        static bool IsChestObjectType(ROM rom, uint objectType)
+        {
+            if (rom.RomInfo.version == 8) return objectType == 0x14;
+            return objectType == 0x12;
+        }
+
+        // WF EventCondForm.IsShopObjectType: FE8 shop=0x16-0x18, FE6/7 shop=0x13-0x15.
+        static bool IsShopObjectType(ROM rom, uint objectType)
+        {
+            if (rom.RomInfo.version == 8)
+                return objectType == 0x16 || objectType == 0x17 || objectType == 0x18;
+            return objectType == 0x13 || objectType == 0x14 || objectType == 0x15;
+        }
+
         /// <summary>Turn a descriptor's <see cref="DataCountRule"/> into the
         /// <c>is_data_exists_callback</c> that <see cref="ROM.getBlockDataCount(uint,uint,Func{int,uint,bool})"/> expects.</summary>
         static Func<int, uint, bool> MakeIsDataExists(ROM rom, StructDescriptor d)
@@ -9060,14 +9918,36 @@ namespace FEBuilderGBA
         /// duplicates — keeping the literal clean, not just the public dedup'd view).</summary>
         public static string[] GetNotYetPortedFormsRaw() => (string[])NotYetPortedRaw.Clone();
 
+        /// <summary>Append <paramref name="name"/> to a NotYetPorted snapshot if absent (used by
+        /// <see cref="MakeAllStructPointers"/> to re-report EventCondForm when the event-script
+        /// disassembler is not wired, so the skipped coverage is never silent).</summary>
+        static string[] AppendNotYetPorted(string[] current, string name)
+        {
+            if (System.Array.IndexOf(current, name) >= 0) return current;
+            var extended = new string[current.Length + 1];
+            System.Array.Copy(current, extended, current.Length);
+            extended[current.Length] = name;
+            return extended;
+        }
+
         static readonly string[] NotYetPortedRaw = new[]
             {
                 // event conditions / scripts
-                // (EventCondForm: EventScriptForm.ScanScript event-scan, not in Core.
+                // (EventCondForm PORTED in slice 2u — EmitEventCond + the Core ScanScript BLOCK-emitter
+                //  EmitScanScript (the verbatim port of EventScriptForm.ScanScript: a recursive,
+                //  tracelist-cycle-guarded event-script trace that emits one EVENTSCRIPT Address per
+                //  referenced script + dispatches each pointer-arg to its RecycleOldData reproduction —
+                //  EmitRecycleOldUnits [POINTER_UNIT], EmitEventBattleData/MoveData/TalkGroupFE7 [3 FE7
+                //  IFRs], EmitFixedBinPointer [AI coord/range/calltalk + units-short-text BINs],
+                //  EmitMenuExtendSplitMenu [SplitMenu5/9 const OR EmitMenuDefinitionDirect count=1],
+                //  EmitEventCondAsm [POINTER_ASM]). EmitEventCond loops maps × GetCondSlots, emits the
+                //  EVENTCOND_*/EVENTTRAP frame + per-version ASM AddFunction + FE8 EmitItemRandomChest +
+                //  the trailing EventCond Frame. The disasm path is a HARD prerequisite (EmitEventCond
+                //  THROWS when CoreState.EventScript/CommentCache are unwired, never silently omits).
                 //  EventScript(MakeEventASMMAPList), EventFunctionPointerForm, Command85PointerForm are
                 //  OUT OF SCOPE: emitted by U.AppendAllASMStructPointersList — the ASM/LDR-map path, NOT
                 //  this producer's U.MakeAllStructPointersList data path.)
-                "EventCondForm", "EventScript(MakeEventASMMAPList)", "EventFunctionPointerForm",
+                "EventScript(MakeEventASMMAPList)", "EventFunctionPointerForm",
                 "Command85PointerForm",
                 // text (Huffman)
                 // (MapTerrainNameForm ported in slice 2c — per-entry string-BIN sub-walk; TextDicForm
@@ -9332,11 +10212,15 @@ namespace FEBuilderGBA
                 //      NestedIfr@+28 (block 2, u8!=0); + a trailing absolute AddPointer(0x0B0038, 0x20,
                 //      PAL) common-palette pointer. (FE8U/FE7U non-multibyte variants STAY deferred.)
                 //  STILL deferred (event-scan / recursive / dynamic base / LZ77 CG):
-                //  MonsterWMapProbabilityForm STAYS — although its 5 IFR probability/stage tables
-                //    are flat ROM reads, its MakeAllDataLength ALSO emits EventScriptForm.ScanScript over
-                //    the two skirmish start/end event pointers (no Core ScanScript primitive yet);
-                //    porting only the flat tables would drop those skirmish-event regions = corruption.
-                //  WorldMapEventPointerForm [ScanScript],
+                //  NOTE: the Core ScanScript BLOCK-emitter (EmitScanScript) now EXISTS (slice 2u). The four
+                //  ScanScript-dependent forms below are no longer blocked on the missing primitive — they
+                //  stay only because slice 2u was scoped to EventCondForm. Each is now a small follow-up
+                //  (resolve its base/entry table, then EmitScanScript over its event pointer(s)).
+                //  MonsterWMapProbabilityForm STAYS — its 5 IFR probability/stage tables are flat ROM reads,
+                //    but its MakeAllDataLength ALSO emits ScanScript over the two skirmish start/end event
+                //    pointers; porting only the flat tables would drop those skirmish-event regions =
+                //    corruption, so it is ported as a unit (with EmitScanScript) in a later slice.
+                //  WorldMapEventPointerForm [ScanScript over the world-map event pointer table],
                 //  EventBattleTalkForm + EventHaikuForm [FE8, ScanScript per-entry],
                 //  MapSettingForm [FE8] ported in slice 2r (EmitMapSetting) — its count rule
                 //    (IsMapSettingEnd, reproduced VERBATIM) needs the WF cached text count

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -7395,8 +7395,17 @@ namespace FEBuilderGBA
         public static void EmitScanScript(ROM rom, List<Address> list, uint scriptPointer,
             bool isWithEventUnit, bool isWorldMapEvent, string basename, List<uint> tracelist)
         {
+            // A relocation primitive must NOT silently no-op when its prerequisite is unwired (Copilot
+            // #1296) — that would drop script/data blocks unnoticed. EmitScanScript disassembles via
+            // CoreState.EventScript, so that is its hard prerequisite; throw if absent rather than return.
+            // (The producer's EventCond dispatch gates on the fuller IsEventScriptDisasmReady before reaching
+            // here; a direct caller from another slice must wire CoreState.EventScript.)
             var es = CoreState.EventScript;
-            if (es == null) return; // disasm not wired — caller (EmitEventCond) already hard-errors.
+            if (es == null)
+            {
+                throw new System.InvalidOperationException(
+                    "EmitScanScript requires the event-script disassembler (CoreState.EventScript) to be wired.");
+            }
             ScanScriptRecurse(rom, es, list, scriptPointer, isWithEventUnit, isWorldMapEvent, basename, tracelist, 0);
         }
 
@@ -7411,7 +7420,14 @@ namespace FEBuilderGBA
         static void ScanScriptRecurse(ROM rom, EventScript es, List<Address> list, uint eventPointer,
             bool isWithEventUnit, bool isWorldMapEvent, string basename, List<uint> tracelist, int depth)
         {
-            if (depth > ScanMaxDepth) return;
+            if (depth > ScanMaxDepth)
+            {
+                // Defensive depth cap hit (no WF equiv). Still emit the 0-length alias for the slot, like
+                // every other abort path, so the manifest stays self-consistent — the slot is recorded for
+                // relocation rather than silently dropped, and the tracelist can't mask it as "covered".
+                Address.AddPointer(list, eventPointer, 0, basename, Address.DataTypeEnum.EVENTSCRIPT);
+                return;
+            }
 
             // WF: event_addr = Program.ROM.u32(event_pointer); guard the full 4-byte slot.
             uint eptr = U.toOffset(eventPointer);
@@ -7489,6 +7505,11 @@ namespace FEBuilderGBA
                 }
                 addr += (uint)size;
             }
+
+            // Defensive step cap exhausted (no WF equiv — a valid script always reaches an exit/unknown
+            // cutoff first). Emit the 0-length alias for the slot, consistent with the UNKNOWN/EOF abort
+            // paths, so the (already tracelist-marked) script is still recorded and not silently dropped.
+            Address.AddPointer(list, eventPointer, 0, basename, Address.DataTypeEnum.EVENTSCRIPT);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
**Slice 2u** of #1261 — the **last data-path form**: `EventCondForm`, which needed `EventScriptForm.ScanScript` (the recursive event-script data tracer). **Ported, not deferred.** After this, every remaining `NotYetPortedRaw` entry is the out-of-scope ASM-path (`AppendAllASMStructPointersList`, a separate producer).

## Grep-Core result
Substantial EventScript infra existed (`EventScriptReferenceScanner`, `EventCondCore`, `MapEventUnitCore`), but `ScanScript` as a **block-emitter** did not — the existing `ScanScriptForArg`/`ScanScriptForTextIds` only collect ID *values*. So `ScanScript` was reproduced fresh as a block-emitter.

## Ported
- **`EmitScanScript`** = VERBATIM port of `EventScriptForm.ScanScript` (recursive, `tracelist` cycle-guarded; emits one `EVENTSCRIPT` Address per script + the zero-length alias on revisit; `IsExitCode` / 10-UNKNOWN cutoff / IF-LABEL `lastBranchAddr` all reproduced). All **9 `RecycleOldData` dispatches**: `RecycleOldUnits` [reused the existing `EmitRecycleOldUnits`], 3 FE7 IFRs (`EmitEventBattleData`/`MoveData`/`TalkGroupFE7` — incl. `EventMoveDataFE7`'s variable-stride reader + `ReInit`→pointer NOT_FOUND), AI/UnitsShortText BINs, MenuExtendSplit (`SplitMenu5/9` const OR `EmitMenuDefinitionDirect` count=1), POINTER_ASM.
- **`EmitEventCond`** = VERBATIM port of `EventCondForm.MakeAllDataLength` (maps × `GetCondSlots`; EVENTCOND_*/EVENTTRAP frames; FE6-0x0D / FE7-8-0x04/0x0E ASM; FE8 `EmitItemRandomChest`; EventCond Frame). Wired FIRST in `MakeAllStructPointers` (WF order `U.cs:2418`).
- New: `MapEventUnitCore.GetEventAddrForMap`/`ResolvePlistToEventAddr(out pointer)`; cond addr resolved split-aware via `MapChangeCore.PlistToOffsetAddr(EVENT)`.

## Safety — honest omission (never silent corruption)
The event-script **disassembler** (`CoreState.EventScript`/CommentCache) is a hard prerequisite. A REAL rebuild always has it wired (full ROM init). When it's NOT wired (a partially-initialised host / test), `IsEventScriptDisasmReady(rom)` is false → EventCond is **skipped AND `EventCondForm` is re-reported in NotYetPorted**, so `IsComplete` stays false and the coverage signal reflects reality (the omission is VISIBLE, never a silent under-relocation). When wired, `EmitEventCond` runs and `EventCondForm` is fully covered.

## Cross-check
`GetCondSlots` types/order/count match the `eventcond_FE{6,7,8}.txt` config files EXACTLY (7/16/20 slots), so the frame block length (`slots.Count*4`) is byte-faithful. Static names are the only divergence (the `ItemWeaponEffect` precedent).

## Tests
- RebuildProducer filter: **310 passed / 0 failed** (+15, in a new `RebuildProducerEventCondTests.cs`) — `EmitScanScript` single/recursion/**self-cycle**/dispatch/near-EOF-no-throw; `EmitEventCond` FE8 frame+traced-script + tutorial POINTER + FE7 short-turn 12-byte stride + FE6 0x0D ASM + **throw-when-unwired**; out-pointer overload; NotYetPorted coverage. Updated 2 stale assertions.
- FEBuilderGBA.Tests (net9.0-windows): 1865/1865.
- EOF self-audit: every raw read full-extent-guarded.

## Status + bonus
**This is the last data-path form** — `NotYetPortedRaw` now holds only the 4 ASM-path forms (`Command85PointerForm`/`EventFunctionPointerForm`/`EventScript(MakeEventASMMAPList)`/`MapMiniMapTerrainImageForm`, a separate producer). BONUS: the `ScanScript` block-emitter now unblocks the 4 sibling forms that cited "no Core ScanScript primitive" (`MonsterWMapProbability`/`WorldMapEventPointer`/`EventBattleTalk`/`EventHaiku`) — each a small follow-up; their deferral comments are sharpened to say so.

Part of #1261.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
