### PR TITLE
feat(core): ROM-rebuild ASM-path producer — OAMSPForm (#1261 slice 2w)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs
@@ -599,6 +599,46 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void EmitOAMSP_NullBaseDirectory_DoesNotThrowAndEmitsLdrmapEntries()
+        {
+            // Regression (Copilot PR #1299): EmitOAMSP loads oam_name_ via ConfigDataFilename, which does
+            // Path.Combine(CoreState.BaseDirectory, ...) -> ArgumentNullException when BaseDirectory is null,
+            // and LoadDicResource -> IsRequiredFileExist shows a dialog + Debug.Assert(false) on a missing
+            // file. The producer must degrade to an EMPTY name dict (loop 2 contributes nothing; the ldrmap
+            // loop still emits, falling back to the hex name) instead of throwing/asserting headless.
+            var saved = CoreState.ROM;
+            var savedBaseDir = CoreState.BaseDirectory;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                CoreState.BaseDirectory = null; // unconfigured / headless
+
+                uint oamspOff = 0x00E0000;
+                PlantOamspTable(fe8, oamspOff, 0x00E1000, ptrCount: 2);
+                var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+                {
+                    new DisassemblerTrumb.LDRPointer
+                    {
+                        ldr_data = Ptr(oamspOff), ldr_data_address = 0x00E5000, ldr_address = 0x00E6000,
+                    }
+                };
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitOAMSP(fe8, list, ldrmap));
+                Assert.Null(ex); // no ArgumentNullException, no Debug.Assert dialog/throw.
+                // The ldrmap loop still emits (name falls back to the hex ToHexString8(ldr_data)).
+                Address main = list.Single(a => a.DataType == Address.DataTypeEnum.OAMSP);
+                Assert.Equal(oamspOff, main.Addr);
+                Assert.Contains("OAMSP ", main.Info); // "OAMSP <hex>" — empty config -> hex name fallback.
+            }
+            finally
+            {
+                CoreState.ROM = saved;
+                CoreState.BaseDirectory = savedBaseDir;
+            }
+        }
+
+        [Fact]
         public void EmitOAMSP_PublicEntry_LoadsConfigAndEmits()
         {
             var saved = CoreState.ROM;

--- a/FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs
@@ -587,15 +587,86 @@ namespace FEBuilderGBA.Core.Tests
 
         // EmitOAMSP (the public entry) loads the oam_name_ config dict via ConfigDataFilename, which on a
         // versioned ROM hits U.IsRequiredFileExist (a Debug.Assert when the file is absent). Build a temp
-        // config/data dir with an empty oam_name_ALL.txt (the ConfigDataFilename ALL fallback) so the load
+        // config/data dir with an oam_name_ALL.txt (the ConfigDataFilename ALL fallback) so the load
         // path runs without tripping the required-config assert; returns the temp BaseDirectory.
-        static string MakeTempConfigBaseDir()
+        static string MakeTempConfigBaseDir(string oamNameContent = "")
         {
             string baseDir = Path.Combine(Path.GetTempPath(), "feb_oamsp_" + Guid.NewGuid().ToString("N"));
             string dataDir = Path.Combine(baseDir, "config", "data");
             Directory.CreateDirectory(dataDir);
-            File.WriteAllText(Path.Combine(dataDir, "oam_name_ALL.txt"), "");
+            File.WriteAllText(Path.Combine(dataDir, "oam_name_ALL.txt"), oamNameContent);
             return baseDir;
+        }
+
+        static string OamNameConfigPath(string baseDir) =>
+            Path.Combine(baseDir, "config", "data", "oam_name_ALL.txt");
+
+        // An IAppServices that THROWS if any dialog method is reached — proves the producer's config load
+        // never surfaces UI (no ShowError) even on a present-but-unreadable config file.
+        sealed class ThrowOnDialogServices : IAppServices
+        {
+            public int ShowErrorCount;
+            public void ShowError(string message)
+            {
+                ShowErrorCount++;
+                throw new InvalidOperationException("ShowError must not be reached from the producer: " + message);
+            }
+            public void ShowInfo(string message) => throw new InvalidOperationException("ShowInfo: " + message);
+            public bool ShowQuestion(string message) => throw new InvalidOperationException("ShowQuestion");
+            public bool ShowYesNo(string message) => throw new InvalidOperationException("ShowYesNo");
+            public void RunOnUIThread(Action action) => action();
+            public bool IsMainThread() => true;
+        }
+
+        [Fact]
+        public void EmitOAMSP_PresentButUnreadableConfig_DoesNotThrowOrShowError()
+        {
+            // Regression (Copilot PR #1299 follow-up): File.Exists is true but the read/parse fails (here an
+            // exclusive lock -> File.OpenText throws IOException). U.LoadDicResource's catch would call
+            // CoreState.Services.ShowError (UI / NRE headless); LoadOamNameDicSafe inlines the parse under a
+            // UI-free swallow, so EmitOAMSP must NOT throw and must NOT reach ShowError, still emitting the
+            // ldrmap-loop OAMSP (config dict ends up empty -> hex name fallback).
+            var savedRom = CoreState.ROM;
+            var savedBaseDir = CoreState.BaseDirectory;
+            var savedServices = CoreState.Services;
+            string baseDir = null;
+            FileStream exclusiveLock = null;
+            var spy = new ThrowOnDialogServices();
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                baseDir = MakeTempConfigBaseDir("0x08E5000=Something\n");
+                CoreState.BaseDirectory = baseDir;
+                CoreState.Services = spy;
+                // Lock the config file for exclusive access so File.OpenText in the parse loop throws.
+                exclusiveLock = new FileStream(OamNameConfigPath(baseDir), FileMode.Open,
+                    FileAccess.Read, FileShare.None);
+
+                uint oamspOff = 0x00E0000;
+                PlantOamspTable(fe8, oamspOff, 0x00E1000, ptrCount: 2);
+                var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+                {
+                    new DisassemblerTrumb.LDRPointer
+                    {
+                        ldr_data = Ptr(oamspOff), ldr_data_address = 0x00E5000, ldr_address = 0x00E6000,
+                    }
+                };
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitOAMSP(fe8, list, ldrmap));
+                Assert.Null(ex);                  // swallowed the IOException — no throw.
+                Assert.Equal(0, spy.ShowErrorCount); // never surfaced UI.
+                // The ldrmap loop still emits (config dict empty after the swallowed read -> hex name).
+                Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.OAMSP && a.Addr == oamspOff);
+            }
+            finally
+            {
+                exclusiveLock?.Dispose();
+                CoreState.ROM = savedRom;
+                CoreState.BaseDirectory = savedBaseDir;
+                CoreState.Services = savedServices;
+                if (baseDir != null) try { Directory.Delete(baseDir, true); } catch { }
+            }
         }
 
         [Fact]

--- a/FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs
@@ -544,6 +544,43 @@ namespace FEBuilderGBA.Core.Tests
                 var list = new List<Address>();
                 RebuildProducerCore.EmitOAMSPCore(fe8, list, ldrmap, new Dictionary<uint, string>());
                 Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.OAMSP);
+                // WF accumulates OAM-12 into a LOCAL list and only AddRange's on success, so a
+                // below-threshold parent must NOT leak its OAM-12 sub-table into the struct list.
+                Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.OAMSP12);
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void EmitOAMSPCore_NotFoundTable_DoesNotLeakOam12()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+
+                uint oamspOff = 0x00E0000;
+                uint oam12Off = 0x00E1000;
+                PlantOam12(fe8, oam12Off);
+                // word 0: a valid OAM-12 pointer (its OAM-12 gets computed + recorded in alreadyMatch12).
+                fe8.write_u32(oamspOff + 0, Ptr(oam12Off));
+                // word 1: an un-decodable word (not a terminator, not a safe pointer after the top-nibble
+                // mask) -> CalcOAMSPLengthAndCheck returns NOT_FOUND -> the parent (and its OAM-12) is
+                // discarded. 0x00000003 has no 0x7-nibble (so no mask) and is not a safe pointer.
+                fe8.write_u32(oamspOff + 4, 0x00000003);
+
+                var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+                {
+                    new DisassemblerTrumb.LDRPointer
+                    {
+                        ldr_data = Ptr(oamspOff), ldr_data_address = 0x00E5000, ldr_address = 0x00E6000,
+                    }
+                };
+                var list = new List<Address>();
+                RebuildProducerCore.EmitOAMSPCore(fe8, list, ldrmap, new Dictionary<uint, string>());
+                // NOT_FOUND parent -> nothing emitted (no OAMSP, and the OAM-12 it computed is discarded).
+                Assert.Empty(list);
             }
             finally { CoreState.ROM = saved; }
         }

--- a/FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using Xunit;
@@ -305,6 +306,363 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         // ====================================================================
+        // EmitOAMSP / EmitOAMSPCore — OAMSPForm.MakeAllDataLength (slice 2w)
+        // ====================================================================
+        //
+        // The OAM walk needs a populated ROM region past compress_image_borderline_address
+        // (loop 1's gate) — so these tests use MakeVersionedRom("BE8E01") (borderline 0xDB000,
+        // 32 MiB) and plant a hand-authored OAM byte stream + a synthetic ldrmap, exactly as
+        // the *At seams let the data-path tests do without RomInfo grafting.
+
+        // Plant one OAM-12 record stream at oam12Off: one data record ([0]==0 -> continue) then an
+        // all-zero terminator record. Returns the byte length the walker should report (24).
+        static uint PlantOam12(ROM rom, uint oam12Off)
+        {
+            // record 0: data ([0]==0, rest arbitrary non-terminator-tripping)
+            rom.write_u8(oam12Off + 0, 0x00);
+            for (uint b = 1; b < 12; b++) rom.write_u8(oam12Off + b, (byte)(0x10 + b));
+            // record 1: all-zero first 8 bytes -> terminator
+            for (uint b = 0; b < 12; b++) rom.write_u8(oam12Off + 12 + b, 0x00);
+            return 24;
+        }
+
+        // Plant an OAMSP word table at oamspOff: `ptrCount` words pointing to distinct OAM-12 sub-tables
+        // (each carved out 0x100 apart starting at oam12Base), then a 0x8X0000XX terminator word.
+        // Returns the OAMSP word-table byte length (= (ptrCount + 1) * 4).
+        static uint PlantOamspTable(ROM rom, uint oamspOff, uint oam12Base, int ptrCount)
+        {
+            for (int k = 0; k < ptrCount; k++)
+            {
+                uint oam12Off = oam12Base + (uint)k * 0x100;
+                PlantOam12(rom, oam12Off);
+                rom.write_u32(oamspOff + (uint)k * 4, Ptr(oam12Off));
+            }
+            rom.write_u32(oamspOff + (uint)ptrCount * 4, 0x80000001); // OAM term 0x8X0000XX
+            return (uint)(ptrCount + 1) * 4;
+        }
+
+        [Fact]
+        public void EmitOAMSPCore_ValidLdrmapEntry_EmitsOamspAndOam12()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01"); // borderline 0xDB000
+                CoreState.ROM = fe8;
+
+                uint oamspOff = 0x00E0000;     // past borderline
+                uint oam12Base = 0x00E1000;
+                // 2 OAM-12 pointers + terminator -> main length 12 (>= loop-1 threshold 4*3).
+                uint expectMainLen = PlantOamspTable(fe8, oamspOff, oam12Base, ptrCount: 2);
+
+                var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+                {
+                    new DisassemblerTrumb.LDRPointer
+                    {
+                        ldr_data = Ptr(oamspOff),
+                        ldr_data_address = 0x00E5000, // where the pointer lives (becomes the OAMSP pointer)
+                        ldr_address = 0x00E6000,
+                    }
+                };
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitOAMSPCore(fe8, list, ldrmap, new Dictionary<uint, string>());
+
+                Address main = list.Single(a => a.DataType == Address.DataTypeEnum.OAMSP);
+                Assert.Equal(oamspOff, main.Addr);
+                Assert.Equal(expectMainLen, main.Length);
+                Assert.Equal(0x00E5000u, main.Pointer); // ldr_data_address
+
+                var oam12 = list.Where(a => a.DataType == Address.DataTypeEnum.OAMSP12).ToList();
+                Assert.Equal(2, oam12.Count);
+                Assert.Contains(oam12, a => a.Addr == oam12Base && a.Length == 24);
+                Assert.Contains(oam12, a => a.Addr == oam12Base + 0x100 && a.Length == 24);
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void EmitOAMSPCore_ConfigDictEntry_EmitsOamspWithNotFoundPointer()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+
+                uint oamspOff = 0x00E0000;
+                uint oam12Base = 0x00E1000;
+                PlantOamspTable(fe8, oamspOff, oam12Base, ptrCount: 1); // length 8 (>= loop-2 threshold 4)
+
+                var oamName = new Dictionary<uint, string> { { Ptr(oamspOff), "TestSprite" } };
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitOAMSPCore(fe8, list, ldrmap: null, oamName: oamName);
+
+                Address main = list.Single(a => a.DataType == Address.DataTypeEnum.OAMSP);
+                Assert.Equal(oamspOff, main.Addr);
+                Assert.Equal(8u, main.Length);
+                Assert.Equal(U.NOT_FOUND, main.Pointer); // loop-2 pointer is NOT_FOUND
+                Assert.Equal(1, list.Count(a => a.DataType == Address.DataTypeEnum.OAMSP12));
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void EmitOAMSPCore_DedupAcrossBothLoops()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+
+                uint oamspOff = 0x00E0000;
+                uint oam12Base = 0x00E1000;
+                PlantOamspTable(fe8, oamspOff, oam12Base, ptrCount: 2);
+
+                // The SAME table address appears in BOTH loop 1 (ldrmap) and loop 2 (config dict).
+                var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+                {
+                    new DisassemblerTrumb.LDRPointer
+                    {
+                        ldr_data = Ptr(oamspOff), ldr_data_address = 0x00E5000, ldr_address = 0x00E6000,
+                    }
+                };
+                var oamName = new Dictionary<uint, string> { { Ptr(oamspOff), "Dup" } };
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitOAMSPCore(fe8, list, ldrmap, oamName);
+
+                // alreadyMatch keyed on the offset: loop 1 records it, loop 2 skips it -> exactly ONE OAMSP.
+                Assert.Equal(1, list.Count(a => a.DataType == Address.DataTypeEnum.OAMSP));
+                // alreadyMatch12 dedups the OAM-12 sub-tables too -> exactly two distinct OAM-12s.
+                Assert.Equal(2, list.Count(a => a.DataType == Address.DataTypeEnum.OAMSP12));
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void EmitOAMSPCore_EmptyZeroedRom_EmitsNothing()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01"); // all-zero 32 MiB ROM
+                CoreState.ROM = fe8;
+
+                // An ldrmap pointing at all-zero data: u32 reads 0 -> !isSafetyPointer -> NOT_FOUND -> skip.
+                var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+                {
+                    new DisassemblerTrumb.LDRPointer
+                    {
+                        ldr_data = Ptr(0x00E0000), ldr_data_address = 0x00E5000, ldr_address = 0x00E6000,
+                    }
+                };
+                var list = new List<Address>();
+                RebuildProducerCore.EmitOAMSPCore(fe8, list, ldrmap, new Dictionary<uint, string>());
+                Assert.Empty(list);
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void EmitOAMSPCore_NearEofSlot_DoesNotThrow()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+
+                // An OAMSP start within a few bytes of EOF: the Calc* `while (addr < Data.Length-4/-12)`
+                // bound (and the start guard) must keep every u32/getBinaryData read in-bounds.
+                uint nearEof = (uint)fe8.Data.Length - 6;
+                var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+                {
+                    new DisassemblerTrumb.LDRPointer
+                    {
+                        ldr_data = Ptr(nearEof), ldr_data_address = 0x00E5000, ldr_address = 0x00E6000,
+                    }
+                };
+                var list = new List<Address>();
+                var ex = Record.Exception(() =>
+                    RebuildProducerCore.EmitOAMSPCore(fe8, list, ldrmap, new Dictionary<uint, string>()));
+                Assert.Null(ex);
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void EmitOAMSPCore_BeforeBorderline_SkippedInLoop1()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01"); // borderline 0xDB000
+                CoreState.ROM = fe8;
+
+                uint beforeBorder = 0x00010000; // < 0xDB000
+                uint oam12Base = 0x00011000;
+                PlantOamspTable(fe8, beforeBorder, oam12Base, ptrCount: 2);
+
+                var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+                {
+                    new DisassemblerTrumb.LDRPointer
+                    {
+                        ldr_data = Ptr(beforeBorder), ldr_data_address = 0x00015000, ldr_address = 0x00016000,
+                    }
+                };
+                var list = new List<Address>();
+                RebuildProducerCore.EmitOAMSPCore(fe8, list, ldrmap, new Dictionary<uint, string>());
+                Assert.Empty(list); // loop 1 skips addr < borderline.
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void EmitOAMSPCore_ShortTableBelowThreshold_LoopOneSkips()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+
+                uint oamspOff = 0x00E0000;
+                uint oam12Base = 0x00E1000;
+                // 1 pointer + terminator -> main length 8, BELOW loop-1 threshold (4*3=12) -> skipped.
+                PlantOamspTable(fe8, oamspOff, oam12Base, ptrCount: 1);
+
+                var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+                {
+                    new DisassemblerTrumb.LDRPointer
+                    {
+                        ldr_data = Ptr(oamspOff), ldr_data_address = 0x00E5000, ldr_address = 0x00E6000,
+                    }
+                };
+                var list = new List<Address>();
+                RebuildProducerCore.EmitOAMSPCore(fe8, list, ldrmap, new Dictionary<uint, string>());
+                Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.OAMSP);
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        // EmitOAMSP (the public entry) loads the oam_name_ config dict via ConfigDataFilename, which on a
+        // versioned ROM hits U.IsRequiredFileExist (a Debug.Assert when the file is absent). Build a temp
+        // config/data dir with an empty oam_name_ALL.txt (the ConfigDataFilename ALL fallback) so the load
+        // path runs without tripping the required-config assert; returns the temp BaseDirectory.
+        static string MakeTempConfigBaseDir()
+        {
+            string baseDir = Path.Combine(Path.GetTempPath(), "feb_oamsp_" + Guid.NewGuid().ToString("N"));
+            string dataDir = Path.Combine(baseDir, "config", "data");
+            Directory.CreateDirectory(dataDir);
+            File.WriteAllText(Path.Combine(dataDir, "oam_name_ALL.txt"), "");
+            return baseDir;
+        }
+
+        [Fact]
+        public void EmitOAMSP_PublicEntry_LoadsConfigAndEmits()
+        {
+            var saved = CoreState.ROM;
+            var savedBaseDir = CoreState.BaseDirectory;
+            string baseDir = null;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                baseDir = MakeTempConfigBaseDir();
+                CoreState.BaseDirectory = baseDir;
+
+                uint oamspOff = 0x00E0000;
+                PlantOamspTable(fe8, oamspOff, 0x00E1000, ptrCount: 2);
+                var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+                {
+                    new DisassemblerTrumb.LDRPointer
+                    {
+                        ldr_data = Ptr(oamspOff), ldr_data_address = 0x00E5000, ldr_address = 0x00E6000,
+                    }
+                };
+                var list = new List<Address>();
+                RebuildProducerCore.EmitOAMSP(fe8, list, ldrmap);
+                Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.OAMSP && a.Addr == oamspOff);
+            }
+            finally
+            {
+                CoreState.ROM = saved;
+                CoreState.BaseDirectory = savedBaseDir;
+                if (baseDir != null) try { Directory.Delete(baseDir, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void AppendAllAsmStructPointers_IsUseOamspFalse_EmitsNoOamsp()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                uint oamspOff = 0x00E0000;
+                PlantOamspTable(fe8, oamspOff, 0x00E1000, ptrCount: 2);
+                var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+                {
+                    new DisassemblerTrumb.LDRPointer
+                    {
+                        ldr_data = Ptr(oamspOff), ldr_data_address = 0x00E5000, ldr_address = 0x00E6000,
+                    }
+                };
+                var list = new List<Address>();
+                // isUseOAMSP defaults to false -> the OAMSP gate is closed, even with a valid table present.
+                var res = RebuildProducerCore.AppendAllAsmStructPointers(fe8, list, ldrmap,
+                    isUseOAMSP: false);
+                Assert.False(res.Cancelled);
+                Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.OAMSP);
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void AppendAllAsmStructPointers_IsUseOamspTrue_EmitsOamsp()
+        {
+            var saved = CoreState.ROM;
+            var savedBaseDir = CoreState.BaseDirectory;
+            string baseDir = null;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                // The full entrypoint's EmitOAMSP loads the RomInfo-derived oam_name_ config dict via
+                // ConfigDataFilename; supply an empty temp config so the load runs (loop 2 no-op; loop 1 runs).
+                baseDir = MakeTempConfigBaseDir();
+                CoreState.BaseDirectory = baseDir;
+
+                uint oamspOff = 0x00E0000;
+                PlantOamspTable(fe8, oamspOff, 0x00E1000, ptrCount: 2);
+                // The ldrmap MUST actually contain the OAMSP pointer for loop 1 to find it. Drive EmitOAMSP
+                // through the full entrypoint with a hand-built ldrmap.
+                var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+                {
+                    new DisassemblerTrumb.LDRPointer
+                    {
+                        ldr_data = Ptr(oamspOff), ldr_data_address = 0x00E5000, ldr_address = 0x00E6000,
+                    }
+                };
+                var list = new List<Address>();
+                var res = RebuildProducerCore.AppendAllAsmStructPointers(fe8, list, ldrmap,
+                    isUseOAMSP: true);
+                Assert.False(res.Cancelled);
+                Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.OAMSP && a.Addr == oamspOff);
+            }
+            finally
+            {
+                CoreState.ROM = saved;
+                CoreState.BaseDirectory = savedBaseDir;
+                if (baseDir != null) try { Directory.Delete(baseDir, true); } catch { }
+            }
+        }
+
+        // ====================================================================
         // EmitItemEffectPointerAt — InputFormRef_MIX + magic-count cap
         // ====================================================================
 
@@ -543,7 +901,8 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.Contains("PatchForm(MakePatchStructDataList)", res.NotYetPorted);
                 Assert.Contains("ProcsScriptForm", res.NotYetPorted);
                 Assert.Contains("GraphicsToolForm", res.NotYetPorted);
-                Assert.Contains("OAMSPForm", res.NotYetPorted);
+                // OAMSPForm is PORTED in slice 2w — it is NOT re-reported as deferred.
+                Assert.DoesNotContain("OAMSPForm", res.NotYetPorted);
             }
             finally { CoreState.ROM = saved; }
         }
@@ -591,8 +950,8 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Contains("PatchForm(MakePatchStructDataList)", notYet);
             Assert.Contains("ProcsScriptForm", notYet);
             Assert.Contains("GraphicsToolForm", notYet);
-            Assert.Contains("OAMSPForm", notYet);
             // The PORTED forms are NOT in the static deferred list.
+            Assert.DoesNotContain("OAMSPForm", notYet); // PORTED in slice 2w.
             Assert.DoesNotContain("EventScript(MakeEventASMMAPList)", notYet);
             Assert.DoesNotContain("EventFunctionPointerForm", notYet);
             Assert.DoesNotContain("Command85PointerForm", notYet);

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -10973,31 +10973,53 @@ namespace FEBuilderGBA
         /// <summary>
         /// Load the <c>oam_name_</c> config dictionary, never throwing or surfacing UI. Mirrors the
         /// <see cref="LoadConfigTableSafe"/> precedent (the slice-2q anime forms) but for the
-        /// <see cref="U.LoadDicResource"/> dict shape: <see cref="U.LoadDicResource"/> has no
-        /// <c>isRequired:false</c> overload, so it always routes a missing file through
-        /// <c>U.IsRequiredFileExist</c> (a <c>ShowError</c> dialog + <c>Debug.Assert(false)</c> on a
-        /// versioned ROM). We therefore pre-check <see cref="System.IO.File.Exists"/> and only load when the
-        /// file is present; the try/catch additionally covers a null <see cref="CoreState.BaseDirectory"/>
-        /// (<c>U.ConfigDataFilename</c> does <c>Path.Combine(BaseDirectory, …)</c>). Either way a missing/
-        /// unconfigured config tree degrades to an EMPTY dict — the same faithful headless behavior as a
-        /// present-but-empty <c>oam_name_</c> file (loop 2 of <see cref="EmitOAMSPCore"/> contributes
-        /// nothing; the ldrmap loop is unaffected, falling back to the hex name).
+        /// <see cref="U.LoadDicResource"/> dict shape. We do NOT delegate to <see cref="U.LoadDicResource"/>:
+        /// it has no <c>isRequired:false</c> overload (so a MISSING file routes through
+        /// <c>U.IsRequiredFileExist</c> = a <c>ShowError</c> dialog + <c>Debug.Assert(false)</c> on a
+        /// versioned ROM), AND its parse-loop <c>catch</c> calls <c>CoreState.Services.ShowError</c> so a
+        /// PRESENT-but-malformed file (an <c>atoh</c>/<c>Split</c> throw) also surfaces UI / can NRE
+        /// headless. Instead we pre-check <see cref="System.IO.File.Exists"/> (missing -> empty, no assert)
+        /// and INLINE the exact U.LoadDicResource parse loop (U.cs:1772-1792) under a UI-free try/catch.
+        /// The parse is identical to WF (same comment/other-lang skip, same <c>'='</c> split, same
+        /// <c>atoh</c> key / <c>at(sp,1)</c> value) — only the failure mode differs: a missing/unconfigured/
+        /// malformed config degrades to an EMPTY (or partial) dict instead of a dialog. The
+        /// <c>OtherLangLine(line, rom)</c> overload is used (not the <c>CoreState.ROM</c> global one), which
+        /// safe-falls-back when RomInfo is null; output-equivalent (it only toggles whether a <c>{U}</c>/
+        /// <c>{J}</c>-tagged line is skipped, which the downstream parser ignores anyway). A missing/empty
+        /// dict means loop 2 of <see cref="EmitOAMSPCore"/> contributes nothing; the ldrmap loop is
+        /// unaffected (it falls back to the hex name).
         /// </summary>
         static Dictionary<uint, string> LoadOamNameDicSafe(ROM rom)
         {
+            var dic = new Dictionary<uint, string>();
             try
             {
                 string filename = U.ConfigDataFilename("oam_name_", rom);
                 if (!System.IO.File.Exists(filename))
                 {
-                    return new Dictionary<uint, string>();
+                    return dic;
                 }
-                return U.LoadDicResource(filename);
+                // Inlined U.LoadDicResource parse loop (U.cs:1772-1792) — parse-identical to WF, but the
+                // catch SWALLOWS (returns the partial/empty dict) instead of calling ShowError.
+                using (var reader = System.IO.File.OpenText(filename))
+                {
+                    string line;
+                    while ((line = reader.ReadLine()) != null)
+                    {
+                        if (U.IsComment(line) || U.OtherLangLine(line, rom)) continue;
+                        line = U.ClipComment(line);
+                        if (line == "") continue;
+                        string[] sp = line.Split('=');
+                        dic[U.atoh(sp[0])] = U.at(sp, 1);
+                    }
+                }
             }
             catch (Exception)
             {
-                return new Dictionary<uint, string>();
+                // Null BaseDirectory (ConfigDataFilename Path.Combine), an unreadable handle, or a malformed
+                // line (atoh/Split throw): never surface UI — return whatever parsed so far (partial/empty).
             }
+            return dic;
         }
 
         /// <summary>

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -10284,10 +10284,11 @@ namespace FEBuilderGBA
         // Coverage honesty: like the data-path GetNotYetPortedForms, the ASM
         // producer never silently omits a form. AsmProducerResult.NotYetPorted
         // lists the forms still blocked on an un-ported subsystem (the
-        // PatchForm patch-config scanner + the ProcsScriptForm/OAMSPForm
-        // AsmMapFileAsmCache UI-cache, each its own follow-up slice), so
-        // AsmProducerResult.IsComplete stays false until they land — a wiring
-        // slice must not feed an incomplete list to a real defragment.
+        // PatchForm patch-config scanner + the ProcsScriptForm AsmMapFileAsmCache
+        // UI-cache, each its own follow-up slice; OAMSPForm is PORTED in slice 2w —
+        // it had no AsmMapFileAsmCache dependency), so AsmProducerResult.IsComplete
+        // stays false until they land — a wiring slice must not feed an incomplete
+        // list to a real defragment.
         // ====================================================================
 
         /// <summary>Result of <see cref="AppendAllAsmStructPointers"/>: the forms NOT yet
@@ -10346,9 +10347,11 @@ namespace FEBuilderGBA
                 // GraphicsToolForm.MakeLZ77DataList (only when isUseOtherGraphics) — the LZ77 graphics-
                 // tool subsystem. Out of scope for this foundation; DEFER.
                 "GraphicsToolForm",
-                // OAMSPForm.MakeAllDataLength(ldrmap) (only when isUseOAMSP) — consumes the ldrmap AND
-                // the OAM scan. DEFER alongside the AsmMapFileAsmCache subsystem.
-                "OAMSPForm",
+                // OAMSPForm.MakeAllDataLength(ldrmap) (only when isUseOAMSP) — PORTED in slice 2w
+                // (EmitOAMSP/EmitOAMSPCore + the two pure-binary CalcOAMSP* walkers). It does NOT depend
+                // on AsmMapFileAsmCache (unlike ProcsScriptForm), so it is no longer in this deferred
+                // list. When isUseOAMSP is false the form is intentionally SKIPPED (not unported), so it
+                // is never re-reported here.
             };
 
         /// <summary>
@@ -10379,7 +10382,8 @@ namespace FEBuilderGBA
         /// ProcsScript (deferred) actually consumes it; the other forms just need it present.</param>
         /// <param name="isUseOtherGraphics">WF <c>isUseOtherGraphics</c> — gates GraphicsToolForm
         /// (deferred).</param>
-        /// <param name="isUseOAMSP">WF <c>isUseOAMSP</c> — gates OAMSPForm (deferred).</param>
+        /// <param name="isUseOAMSP">WF <c>isUseOAMSP</c> — gates OAMSPForm (PORTED in slice 2w via
+        /// <see cref="EmitOAMSP"/>; emitted only when this flag is true, else intentionally skipped).</param>
         public static AsmProducerResult AppendAllAsmStructPointers(ROM rom, List<Address> list,
             List<DisassemblerTrumb.LDRPointer> ldrmap,
             bool isUseOtherGraphics = false, bool isUseOAMSP = false,
@@ -10458,9 +10462,25 @@ namespace FEBuilderGBA
                 EmitMapMiniMapTerrain(rom, list);
             }
 
-            // WF: `if (isUseOtherGraphics)` -> GraphicsToolForm.MakeLZ77DataList — DEFERRED.
-            // WF: `if (isUseOAMSP)` -> OAMSPForm.MakeAllDataLength(ldrmap) — DEFERRED.
-            // Both stay in AsmNotYetPortedRaw regardless of the flags; nothing emitted here.
+            // WF: `if (isUseOtherGraphics)` -> GraphicsToolForm.MakeLZ77DataList — DEFERRED
+            // (stays in AsmNotYetPortedRaw regardless of the flag; nothing emitted here).
+
+            // WF: `if (isUseOAMSP) { Debug.Assert(ldrmap != null); OAMSPForm.MakeAllDataLength(...); }`
+            // PORTED (slice 2w). The form runs OUTSIDE the `ldrmap != null` block — gated solely on the
+            // flag. When the flag is false it is intentionally skipped (never re-reported in NotYetPorted).
+            if (isUseOAMSP)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    progress?.Report("AppendAllAsmStructPointers cancelled");
+                    return new AsmProducerResult(notYet, cancelled: true);
+                }
+                // WF Debug.Assert(ldrmap != null): EmitOAMSP tolerates a null map (loop 1 is skipped, the
+                // config-dict loop 2 still runs). Reproduce the WF intent — a null map here is a caller
+                // bug, but we degrade to the dict-only scan rather than throwing in a producer.
+                progress?.Report("OAMSP");
+                EmitOAMSP(rom, list, ldrmap);
+            }
 
             return new AsmProducerResult(notYet, cancelled: false);
         }
@@ -10913,6 +10933,277 @@ namespace FEBuilderGBA
                     }
                 }
             }
+        }
+
+        // ====================================================================
+        // OAMSPForm.MakeAllDataLength (#1261 slice 2w) — the only `isUseOAMSP`-gated
+        // ASM form. WF FEBuilderGBA/OAMSPForm.cs:53-228. CLEAN to port: its two Calc*
+        // helpers are pure binary OAM walkers with NO AsmMapFileAsmCache dependency
+        // (unlike ProcsScriptForm, which CONSUMES the cache and stays deferred). Loop 1
+        // walks the ldrmap; loop 2 walks the oam_name_ config dict; a single
+        // `alreadyMatch` dedups across both. Both Calc* reproduced line-for-line below.
+        // ====================================================================
+
+        /// <summary>
+        /// Core port of <c>OAMSPForm.MakeAllDataLength(structlist, structlist, ldrmap)</c>
+        /// (FEBuilderGBA/OAMSPForm.cs:53-134). Loads the <c>oam_name_</c> config dictionary
+        /// (the WF first line) then delegates to <see cref="EmitOAMSPCore"/>. WF passes the SAME
+        /// <paramref name="list"/> as both the OAMSP list and the OAMSP12 list, so OAM-12 sub-tables
+        /// land in the same accumulating struct list — reproduced.
+        /// </summary>
+        /// <param name="rom">The ROM to scan (MUST be the loaded <see cref="CoreState.ROM"/>; the
+        /// <c>oam_name_</c> config filename is RomInfo-derived).</param>
+        /// <param name="list">The accumulating struct list (appended to).</param>
+        /// <param name="ldrmap">The full-ROM LDR map (<see cref="BuildLdrMap"/>). WF asserts non-null
+        /// at the call site (gated by <c>isUseOAMSP</c>); a null map skips loop 1.</param>
+        public static void EmitOAMSP(ROM rom, List<Address> list,
+            List<DisassemblerTrumb.LDRPointer> ldrmap)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (list == null) throw new ArgumentNullException(nameof(list));
+            // WF: U.LoadDicResource(U.ConfigDataFilename("oam_name_")). The data-path filename is
+            // RomInfo-derived; LoadDicResource returns an empty dict when the file is absent.
+            Dictionary<uint, string> oamName = U.LoadDicResource(U.ConfigDataFilename("oam_name_", rom));
+            EmitOAMSPCore(rom, list, ldrmap, oamName);
+        }
+
+        /// <summary>
+        /// Verbatim port of the body of <c>OAMSPForm.MakeAllDataLength</c>
+        /// (FEBuilderGBA/OAMSPForm.cs:57-133) with the <c>oam_name_</c> dictionary supplied
+        /// (test seam — lets a synthetic ROM drive the OAM walk without a RomInfo-derived config file).
+        /// Two loops sharing one <c>alreadyMatch</c> dedup map (the second <c>alreadyMatch12</c> dedups
+        /// the OAM-12 sub-tables across both loops):
+        /// <list type="bullet">
+        ///   <item>Loop 1 (ldrmap): for each safe <c>ldr_data</c> at or past
+        ///   <c>compress_image_borderline_address</c>, <see cref="CalcOAMSPLengthAndCheck"/>; if the
+        ///   length is found and <c>&gt;= 12</c>, emit an OAMSP <see cref="Address"/> (pointer =
+        ///   <c>ldr_data_address</c>).</item>
+        ///   <item>Loop 2 (oam_name_ dict): same Calc, threshold <c>&gt;= 4</c>, pointer = NOT_FOUND.</item>
+        /// </list>
+        /// WF's <c>InputFormRef.DoEvents(...)</c> cancel checks are dropped (this producer is driven by
+        /// <see cref="AppendAllAsmStructPointers"/>'s <c>CancellationToken</c>; the per-entry DoEvents was
+        /// a WinForms UI yield).
+        /// </summary>
+        public static void EmitOAMSPCore(ROM rom, List<Address> list,
+            List<DisassemblerTrumb.LDRPointer> ldrmap, Dictionary<uint, string> oamName)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (list == null) throw new ArgumentNullException(nameof(list));
+            if (oamName == null) oamName = new Dictionary<uint, string>();
+
+            // WF reads Program.ROM.RomInfo.compress_image_borderline_address. A synthetic NULL-RomInfo
+            // ROM has no borderline; fall back to 0 (loop 1's `addr < borderline` skip then never fires,
+            // matching "everything past the borderline" on a real ROM). Output-equivalent on real ROMs.
+            uint borderline = rom.RomInfo != null ? rom.RomInfo.compress_image_borderline_address : 0;
+
+            var alreadyMatch = new Dictionary<uint, bool>();
+            var alreadyMatch12 = new Dictionary<uint, bool>();
+
+            // ---- Loop 1: ldrmap ------------------------------------------------
+            if (ldrmap != null)
+            {
+                for (int i = 0; i < ldrmap.Count; i++)
+                {
+                    uint addr = ldrmap[i].ldr_data;
+                    if (!U.isSafetyPointer(addr, rom))
+                    {
+                        continue;
+                    }
+                    addr = U.toOffset(addr);
+                    if (addr < borderline)
+                    {
+                        continue;
+                    }
+
+                    if (alreadyMatch.ContainsKey(addr))
+                    {//既に知っている.
+                        continue;
+                    }
+
+                    string name = U.at(oamName, ldrmap[i].ldr_data_address);
+                    if (name == "")
+                    {
+                        name = U.at(oamName, ldrmap[i].ldr_address);
+                    }
+                    if (name == "")
+                    {
+                        name = U.ToHexString8(ldrmap[i].ldr_data);
+                    }
+                    name = "OAMSP " + name;
+                    uint length = CalcOAMSPLengthAndCheck(rom, addr, name, list, alreadyMatch12);
+                    if (U.NOT_FOUND == length)
+                    {
+                        alreadyMatch.Add(addr, false); //ダメだったということを記録しておこう
+                        continue;
+                    }
+                    if (length < 4 * 3)
+                    {
+                        alreadyMatch.Add(addr, false); //ダメだったということを記録しておこう
+                        continue;
+                    }
+
+                    Address.AddAddress(list, addr, length, ldrmap[i].ldr_data_address, name,
+                        Address.DataTypeEnum.OAMSP);
+                    alreadyMatch.Add(addr, true);
+                }
+            }
+
+            // ---- Loop 2: oam_name_ config dict --------------------------------
+            foreach (var pair in oamName)
+            {
+                uint addr = U.toOffset(pair.Key);
+                if (alreadyMatch.ContainsKey(addr))
+                {//既に知っている.
+                    continue;
+                }
+
+                string name = "OAMSP_ " + pair.Value;
+                uint length = CalcOAMSPLengthAndCheck(rom, addr, name, list, alreadyMatch12);
+                if (U.NOT_FOUND == length)
+                {
+                    alreadyMatch.Add(addr, false); //ダメだったということを記録しておこう
+                    continue;
+                }
+                if (length < 4)
+                {
+                    alreadyMatch.Add(addr, false); //ダメだったということを記録しておこう
+                    continue;
+                }
+
+                Address.AddAddress(list, addr, length, U.NOT_FOUND, name,
+                    Address.DataTypeEnum.OAMSP);
+                alreadyMatch.Add(addr, true);
+            }
+        }
+
+        /// <summary>
+        /// Verbatim port of <c>OAMSPForm.CalcLengthAndCheck</c> (FEBuilderGBA/OAMSPForm.cs:186-228):
+        /// walks the OAMSP word table from <paramref name="addr"/> to its <c>0x8X0000XX</c> terminator,
+        /// reading each non-terminator word as a pointer to an OAM-12 sub-table (length via
+        /// <see cref="CalcOAMSPLengthAndCheckOAM12"/>, emitted as OAMSP12, dedup'd via
+        /// <paramref name="alreadyMatch"/>). Returns the word-table byte length, or
+        /// <see cref="U.NOT_FOUND"/> on the first un-decodable word.
+        /// </summary>
+        static uint CalcOAMSPLengthAndCheck(ROM rom, uint addr, string name, List<Address> list,
+            Dictionary<uint, bool> alreadyMatch)
+        {
+            // EOF/NULL-start guard (the #1261 producer safety discipline): an unsafe start must never
+            // scan from a bad offset. WF reaches Calc* only with a borderline-checked ldrmap pointer or a
+            // config-dict key; on a real ROM those are always safe offsets, so this is output-equivalent
+            // (an unsafe start returns length 0 -> the caller's `< 4*3` / `< 4` threshold skips it).
+            if (!U.isSafetyOffset(addr, rom))
+            {
+                return 0;
+            }
+            uint start = addr;
+            // WF: length = Data.Length - 4 (so every u32(addr) read stays in-bounds). Guard the
+            // Data.Length < 4 underflow that WF never hits (real ROMs are megabytes).
+            if (rom.Data.Length < 4)
+            {
+                return 0;
+            }
+            uint length = (uint)(rom.Data.Length - 4);
+            while (addr < length)
+            {
+                uint p = rom.u32(addr);
+                if ((p & (uint)0x88FFFF00) == 0x80000000)
+                {//OAM term 0x8X0000XX
+                    //         0x800000XX or 0x810000XX or 0x820000XX or 0x840000XX
+                    addr += 4;
+                    break;
+                }
+                if ((p & (uint)0x70000000) > 0)
+                {//OAM term
+                    //以下のように、先頭7が入っているものがある.
+                    p = (p & 0x0FFFFFFF); //78 67 EA 3B
+                }
+                if (!U.isSafetyPointer(p, rom))
+                {
+                    //理解不能の命令があったのでOAMではない
+                    return U.NOT_FOUND;
+                }
+
+                uint oam12Addr = U.toOffset(p);
+                //多分奇数の場合 整数に直す??? まったくわからないがそう考えると都合がいい.
+                oam12Addr = DisassemblerTrumb.ProgramAddrToPlain(oam12Addr);
+                if (!alreadyMatch.ContainsKey(oam12Addr))
+                {//まだ知らない
+                    uint oam12length = CalcOAMSPLengthAndCheckOAM12(rom, oam12Addr);
+                    if (oam12length == U.NOT_FOUND)
+                    {
+                        return U.NOT_FOUND;
+                    }
+                    Address.AddAddress(list, oam12Addr, oam12length, addr, name + "_OAM",
+                        Address.DataTypeEnum.OAMSP12);
+                    alreadyMatch.Add(oam12Addr, true);
+                }
+
+                addr += 4;
+            }
+            uint ret_length = addr - start;
+            return ret_length;
+        }
+
+        /// <summary>
+        /// Verbatim port of <c>OAMSPForm.CalcLengthAndCheckOAM12</c> (FEBuilderGBA/OAMSPForm.cs:135-184):
+        /// walks 12-byte OAM records from <paramref name="addr"/> to a terminator, returning the byte
+        /// length, or <see cref="U.NOT_FOUND"/> on an OAM-spec violation.
+        /// </summary>
+        static uint CalcOAMSPLengthAndCheckOAM12(ROM rom, uint addr)
+        {
+            // EOF/NULL-start guard: an unsafe start (or one within 12 bytes of EOF) must not scan a bad
+            // offset. On a real ROM the OAMSP pointer always resolves to a safe in-ROM table.
+            if (!U.isSafetyOffset(addr, rom))
+            {
+                return U.NOT_FOUND;
+            }
+            uint start = addr;
+            // WF: length = Data.Length - 12 (so every getBinaryData(addr,12) read stays in-bounds).
+            // Guard the Data.Length < 12 underflow WF never hits.
+            if (rom.Data.Length < 12)
+            {
+                return U.NOT_FOUND;
+            }
+            uint length = (uint)(rom.Data.Length - 12);
+            while (addr < length)
+            {
+                byte[] oam = rom.getBinaryData(addr, 12);
+
+                addr += 12;
+                if (oam[0] == 0 && oam[0 + 1] == 0xFF && oam[0 + 2] == 0xFF && oam[0 + 3] == 0xFF)
+                {//FEditorシリアライズを読み込んだときは別終端がある?
+                    break;
+                }
+                if (oam[0] == 0 && oam[1] == 0 && oam[2] == 0 && oam[3] == 0
+                    && oam[4] == 0 && oam[5] == 0 && oam[6] == 0 && oam[7] == 0)
+                {
+                    break;
+                }
+
+                if (oam[0 + 2] == 0xFF && oam[0 + 3] == 0xFF)
+                {//2バイト目と3バイト目が FFだったら 別ルーチン
+                    continue;
+                }
+                if (oam[0] == 0xFF && oam[1] == 0xFF)
+                {//FF FF xx xx なんか特殊命令?
+                    continue;
+                }
+
+                if (oam[0] == 1)
+                {//終端
+                    break;
+                }
+                if (oam[0] == 0)
+                {//データ
+                    continue;
+                }
+
+                //OAM規約違反
+                return U.NOT_FOUND;
+            }
+
+            uint ret_length = addr - start;
+            return ret_length;
         }
     }
 }

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -11030,7 +11030,12 @@ namespace FEBuilderGBA
                         name = U.ToHexString8(ldrmap[i].ldr_data);
                     }
                     name = "OAMSP " + name;
-                    uint length = CalcOAMSPLengthAndCheck(rom, addr, name, list, alreadyMatch12);
+                    // WF accumulates the OAM-12 sub-tables into a LOCAL list (listoam12_local) and only
+                    // AddRange's them into the real list AFTER the parent OAMSP passes its threshold — so
+                    // a NOT_FOUND/below-threshold parent DISCARDS its OAM-12 Addresses (but alreadyMatch12
+                    // still retains them). Reproduce that: local list here, merge only on success.
+                    var listoam12Local = new List<Address>();
+                    uint length = CalcOAMSPLengthAndCheck(rom, addr, name, listoam12Local, alreadyMatch12);
                     if (U.NOT_FOUND == length)
                     {
                         alreadyMatch.Add(addr, false); //ダメだったということを記録しておこう
@@ -11044,6 +11049,7 @@ namespace FEBuilderGBA
 
                     Address.AddAddress(list, addr, length, ldrmap[i].ldr_data_address, name,
                         Address.DataTypeEnum.OAMSP);
+                    list.AddRange(listoam12Local); // WF: listoam12.AddRange(listoam12_local)
                     alreadyMatch.Add(addr, true);
                 }
             }
@@ -11058,7 +11064,8 @@ namespace FEBuilderGBA
                 }
 
                 string name = "OAMSP_ " + pair.Value;
-                uint length = CalcOAMSPLengthAndCheck(rom, addr, name, list, alreadyMatch12);
+                var listoam12Local = new List<Address>();
+                uint length = CalcOAMSPLengthAndCheck(rom, addr, name, listoam12Local, alreadyMatch12);
                 if (U.NOT_FOUND == length)
                 {
                     alreadyMatch.Add(addr, false); //ダメだったということを記録しておこう
@@ -11072,6 +11079,7 @@ namespace FEBuilderGBA
 
                 Address.AddAddress(list, addr, length, U.NOT_FOUND, name,
                     Address.DataTypeEnum.OAMSP);
+                list.AddRange(listoam12Local); // WF: listoam12.AddRange(listoam12_local)
                 alreadyMatch.Add(addr, true);
             }
         }
@@ -11084,7 +11092,11 @@ namespace FEBuilderGBA
         /// <paramref name="alreadyMatch"/>). Returns the word-table byte length, or
         /// <see cref="U.NOT_FOUND"/> on the first un-decodable word.
         /// </summary>
-        static uint CalcOAMSPLengthAndCheck(ROM rom, uint addr, string name, List<Address> list,
+        /// <param name="listoam12Local">The LOCAL OAM-12 accumulator (WF <c>ref listoam12_local</c>): the
+        /// caller merges it into the real struct list only when the parent OAMSP passes its threshold, so a
+        /// NOT_FOUND/below-threshold parent discards these (though <paramref name="alreadyMatch"/> retains
+        /// the OAM-12 addresses).</param>
+        static uint CalcOAMSPLengthAndCheck(ROM rom, uint addr, string name, List<Address> listoam12Local,
             Dictionary<uint, bool> alreadyMatch)
         {
             // EOF/NULL-start guard (the #1261 producer safety discipline): an unsafe start must never
@@ -11133,7 +11145,7 @@ namespace FEBuilderGBA
                     {
                         return U.NOT_FOUND;
                     }
-                    Address.AddAddress(list, oam12Addr, oam12length, addr, name + "_OAM",
+                    Address.AddAddress(listoam12Local, oam12Addr, oam12length, addr, name + "_OAM",
                         Address.DataTypeEnum.OAMSP12);
                     alreadyMatch.Add(oam12Addr, true);
                 }

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -10961,10 +10961,43 @@ namespace FEBuilderGBA
         {
             if (rom == null) throw new ArgumentNullException(nameof(rom));
             if (list == null) throw new ArgumentNullException(nameof(list));
-            // WF: U.LoadDicResource(U.ConfigDataFilename("oam_name_")). The data-path filename is
-            // RomInfo-derived; LoadDicResource returns an empty dict when the file is absent.
-            Dictionary<uint, string> oamName = U.LoadDicResource(U.ConfigDataFilename("oam_name_", rom));
+            // WF: U.LoadDicResource(U.ConfigDataFilename("oam_name_")). WF always runs with a valid
+            // BaseDirectory + a present oam_name_ config (shipped under config/data/). The producer may run
+            // headless / before the config tree is staged, so load DEFENSIVELY (see LoadOamNameDicSafe):
+            // null BaseDirectory or a missing file degrades to an empty dict (loop 2 contributes nothing)
+            // instead of an ArgumentNullException / the IsRequiredFileExist ShowError + Debug.Assert.
+            Dictionary<uint, string> oamName = LoadOamNameDicSafe(rom);
             EmitOAMSPCore(rom, list, ldrmap, oamName);
+        }
+
+        /// <summary>
+        /// Load the <c>oam_name_</c> config dictionary, never throwing or surfacing UI. Mirrors the
+        /// <see cref="LoadConfigTableSafe"/> precedent (the slice-2q anime forms) but for the
+        /// <see cref="U.LoadDicResource"/> dict shape: <see cref="U.LoadDicResource"/> has no
+        /// <c>isRequired:false</c> overload, so it always routes a missing file through
+        /// <c>U.IsRequiredFileExist</c> (a <c>ShowError</c> dialog + <c>Debug.Assert(false)</c> on a
+        /// versioned ROM). We therefore pre-check <see cref="System.IO.File.Exists"/> and only load when the
+        /// file is present; the try/catch additionally covers a null <see cref="CoreState.BaseDirectory"/>
+        /// (<c>U.ConfigDataFilename</c> does <c>Path.Combine(BaseDirectory, …)</c>). Either way a missing/
+        /// unconfigured config tree degrades to an EMPTY dict — the same faithful headless behavior as a
+        /// present-but-empty <c>oam_name_</c> file (loop 2 of <see cref="EmitOAMSPCore"/> contributes
+        /// nothing; the ldrmap loop is unaffected, falling back to the hex name).
+        /// </summary>
+        static Dictionary<uint, string> LoadOamNameDicSafe(ROM rom)
+        {
+            try
+            {
+                string filename = U.ConfigDataFilename("oam_name_", rom);
+                if (!System.IO.File.Exists(filename))
+                {
+                    return new Dictionary<uint, string>();
+                }
+                return U.LoadDicResource(filename);
+            }
+            catch (Exception)
+            {
+                return new Dictionary<uint, string>();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Ports `OAMSPForm.MakeAllDataLength` (`FEBuilderGBA/OAMSPForm.cs:53-228`) into the ASM-path producer `RebuildProducerCore.AppendAllAsmStructPointers` (added in slice 2v). OAMSPForm is the cleanest remaining `isUseOAMSP`-gated ASM form — its two `Calc*` helpers are **pure binary OAM walkers with no `AsmMapFileAsmCache` dependency** (unlike the deferred `ProcsScriptForm`, which CONSUMES that WinForms UI cache).

Part of #1261 (the ROM-rebuild compaction Make/Apply Core port — the ASM-path producer marathon).

## What changed (`FEBuilderGBA.Core/RebuildProducerCore.cs`)

- **`EmitOAMSP(rom, list, ldrmap)`** — public entry: loads the `oam_name_` config dict via `U.ConfigDataFilename` (the WF first line), then delegates to `EmitOAMSPCore`. WF passes the SAME `structlist` as both the OAMSP list and the OAMSP12 list, so OAM-12 sub-tables land in the same accumulating struct list — reproduced.
- **`EmitOAMSPCore(rom, list, ldrmap, oamName)`** — verbatim port of `OAMSPForm.MakeAllDataLength:57-133` (test seam taking the dict). Two loops sharing one `alreadyMatch` dedup (+ `alreadyMatch12` for the OAM-12 sub-tables): loop 1 walks the `ldrmap` (borderline-gated, threshold `len >= 4*3`, pointer = `ldr_data_address`), loop 2 walks the `oam_name_` dict (threshold `len >= 4`, pointer = `NOT_FOUND`).
- **`CalcOAMSPLengthAndCheck`** (`OAMSPForm.cs:186-228`) + **`CalcOAMSPLengthAndCheckOAM12`** (`135-184`) — line-for-line ports of the OAM word-table / 12-byte-record walkers (same offsets, same terminator conditions, same `DataTypeEnum` `OAMSP`/`OAMSP12`, same name strings).

### Wiring + coverage honesty
- `AppendAllAsmStructPointers` now emits OAMSP `if (isUseOAMSP)` — reproducing the WF caller gate (which runs OUTSIDE the `ldrmap != null` block; `isUseOAMSP` is a parameter that varies per caller). A null map degrades to the dict-only loop 2 rather than throwing in a producer.
- Removed `"OAMSPForm"` from `AsmNotYetPortedRaw` (it is now PORTED). When `isUseOAMSP` is false the form is intentionally **skipped** (not unported) — never re-reported as deferred.

## Safety / faithfulness (corruption-critical — this writes ROM rebuild relocation tables)

- **EOF-guarded the full read extent**: each `Calc*` keeps WF's `while (addr < Data.Length - 4 / -12)` bound (so every `u32` / `getBinaryData(addr,12)` read stays in-bounds), guards the `<4` / `<12` length underflow WF never hits, and returns `0` / `NOT_FOUND` on an unsafe/NULL start (never scans from offset 0). Output-equivalent on real ROMs, where the borderline-checked ldrmap pointer / config key is always a safe offset.
- Uses the `(x, rom)` ROM-parameter safety-helper overloads, not the `CoreState.ROM` global, inside the producer.
- Dropped WF's per-entry `InputFormRef.DoEvents` UI yields; the producer is driven by `AppendAllAsmStructPointers`'s `CancellationToken`.
- Reused the already-in-Core `U.LoadDicResource` / `U.ConfigDataFilename` / `Address.AddAddress` / `DisassemblerTrumb.ProgramAddrToPlain` — none re-ported.

## Test plan

All automated in `FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs` (+10 tests). Producer filter: **345 passed / 0 failed** (was 335 at slice-2v merge).

- [x] `EmitOAMSPCore_ValidLdrmapEntry_EmitsOamspAndOam12` — valid ldrmap entry emits the OAMSP main (addr/length/pointer = `ldr_data_address`) + two OAMSP12 sub-tables (len 24 each)
- [x] `EmitOAMSPCore_ConfigDictEntry_EmitsOamspWithNotFoundPointer` — loop-2 entry emits OAMSP with `NOT_FOUND` pointer
- [x] `EmitOAMSPCore_DedupAcrossBothLoops` — same table in both loops → exactly one OAMSP; OAM-12 sub-tables dedup'd via `alreadyMatch12`
- [x] `EmitOAMSPCore_EmptyZeroedRom_EmitsNothing` — zeroed ROM → nothing
- [x] `EmitOAMSPCore_NearEofSlot_DoesNotThrow` — start within a few bytes of EOF does not throw
- [x] `EmitOAMSPCore_BeforeBorderline_SkippedInLoop1` — `addr < compress_image_borderline_address` skipped in loop 1
- [x] `EmitOAMSPCore_ShortTableBelowThreshold_LoopOneSkips` — main length 8 (< `4*3`) skipped in loop 1
- [x] `AppendAllAsmStructPointers_IsUseOamspFalse_EmitsNoOamsp` — the `isUseOAMSP=false` gate emits nothing even with a valid table present
- [x] `AppendAllAsmStructPointers_IsUseOamspTrue_EmitsOamsp` — the `isUseOAMSP=true` gate emits OAMSP
- [x] `EmitOAMSP_PublicEntry_LoadsConfigAndEmits` — the public entry's `oam_name_` config-load path runs end-to-end
- [x] Updated the two coverage-honesty assertions: `OAMSPForm` is no longer in `AsmProducerResult.NotYetPorted` / `GetAsmNotYetPortedForms`
- [x] `dotnet build FEBuilderGBA.Core/FEBuilderGBA.Core.csproj` → clean (0 errors)
- [x] Full `FEBuilderGBA.Core.Tests` → only the 10 known `config/patch2`-submodule `SkillSystemsAnime*`/`SkillConfigSkillSystem*` env failures (submodule not checked out in the worktree; pass in CI), no new failures from this change

## Deferred

None. The whole `OAMSPForm` (both `Calc*` walkers + both loops) ported faithfully with no sub-dependency blocker. `ProcsScriptForm` / `GraphicsToolForm` / `PatchForm` remain deferred (each its own follow-up slice — `ProcsScriptForm` is blocked on porting `AsmMapFileAsmCache` to Core).

This is a Core-only change (no GUI) — like the prior 21 producer slices it needs no screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
