### PR TITLE
feat(core): ROM-rebuild ASM-path producer — ProcsScriptForm (#1261 slice 2x)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs
@@ -1047,10 +1047,10 @@ namespace FEBuilderGBA.Core.Tests
                 var res = RebuildProducerCore.AppendAllAsmStructPointers(fe8, list, ldrmap);
                 Assert.False(res.IsComplete);
                 Assert.Contains("PatchForm(MakePatchStructDataList)", res.NotYetPorted);
-                Assert.Contains("ProcsScriptForm", res.NotYetPorted);
                 Assert.Contains("GraphicsToolForm", res.NotYetPorted);
-                // OAMSPForm is PORTED in slice 2w — it is NOT re-reported as deferred.
+                // OAMSPForm is PORTED in slice 2w, ProcsScriptForm in slice 2x — NOT re-reported as deferred.
                 Assert.DoesNotContain("OAMSPForm", res.NotYetPorted);
+                Assert.DoesNotContain("ProcsScriptForm", res.NotYetPorted);
             }
             finally { CoreState.ROM = saved; }
         }
@@ -1096,10 +1096,10 @@ namespace FEBuilderGBA.Core.Tests
         {
             string[] notYet = RebuildProducerCore.GetAsmNotYetPortedForms();
             Assert.Contains("PatchForm(MakePatchStructDataList)", notYet);
-            Assert.Contains("ProcsScriptForm", notYet);
             Assert.Contains("GraphicsToolForm", notYet);
             // The PORTED forms are NOT in the static deferred list.
             Assert.DoesNotContain("OAMSPForm", notYet); // PORTED in slice 2w.
+            Assert.DoesNotContain("ProcsScriptForm", notYet); // PORTED in slice 2x.
             Assert.DoesNotContain("EventScript(MakeEventASMMAPList)", notYet);
             Assert.DoesNotContain("EventFunctionPointerForm", notYet);
             Assert.DoesNotContain("Command85PointerForm", notYet);
@@ -1168,6 +1168,422 @@ namespace FEBuilderGBA.Core.Tests
                 data[i * 4 + 3] = (byte)((words[i] >> 24) & 0xFF);
             }
             return new EventScript.Script { Data = data, Info = new string[] { "test" } };
+        }
+
+        // ====================================================================
+        // EmitProcsScript / EmitProcsScriptCore — ProcsScriptForm.MakeAllDataLength (slice 2x)
+        // ====================================================================
+        //
+        // PROCS bytecode = 8-byte fixed records (code:u16, sarg:u16, parg:u32). The terminator-walk
+        // CalcProcsLengthAndCheck validates each record's arg contract and stops at code 0x00 (sarg==0,
+        // parg==0) or 0x800. A synthetic CreateTestRom (NULL RomInfo) gives an EMPTY knownArea so the walk
+        // is exercised in isolation; the reflection/known-area + safe-config tests use a versioned ROM.
+
+        // Plant an 8-byte PROCS record at off. Returns the next record offset (off + 8).
+        static uint PlantProcsRecord(ROM rom, uint off, uint code, uint sarg, uint parg)
+        {
+            rom.write_u16(off + 0, code);
+            rom.write_u16(off + 2, sarg);
+            rom.write_u32(off + 4, parg);
+            return off + 8;
+        }
+
+        // Plant a minimal valid 2-record PROCS at off: record0 = 0x0B (parg-null, non-terminator), record1 =
+        // 0x00 terminator. CalcProcsLengthAndCheck returns 16 (>= the IsTooShort 2-record gate). The trailing
+        // record after the terminator keeps the walk's `addr+8<=limit` clamp from breaking before validating
+        // the terminator. Returns the reported length (16).
+        static uint PlantMinimalProcs(ROM rom, uint off)
+        {
+            PlantProcsRecord(rom, off + 0, 0x0B, 0, 0); // non-terminator, parg must be 0
+            PlantProcsRecord(rom, off + 8, 0x00, 0, 0); // terminator
+            PlantProcsRecord(rom, off + 16, 0x0B, 0, 0); // padding so the clamp doesn't break early
+            return 16;
+        }
+
+        [Fact]
+        public void EmitProcsScriptCore_ValidLdrmapTarget_EmitsProcsAddressLengthName()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint procsOff = 0x1000;
+            uint expectLen = PlantMinimalProcs(rom, procsOff);
+            uint pointerAddr = 0x2000; // where the ldr_data_address pointer lives (becomes Address.Pointer)
+
+            var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+            {
+                new DisassemblerTrumb.LDRPointer
+                {
+                    ldr_data = Ptr(procsOff), ldr_data_address = pointerAddr, ldr_address = 0x2100,
+                }
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitProcsScriptCore(rom, list, ldrmap, new Dictionary<uint, string>());
+
+            Address procs = list.Single(a => a.DataType == Address.DataTypeEnum.PROCS);
+            Assert.Equal(procsOff, procs.Addr);
+            Assert.Equal(expectLen, procs.Length);
+            Assert.Equal(pointerAddr, procs.Pointer);
+            // No config name hint -> the "Procs " prefix fallback (Get6CName2 with both hints empty).
+            Assert.StartsWith("Procs", procs.Info);
+        }
+
+        [Fact]
+        public void EmitProcsScriptCore_TooShort_RejectsSingleRecordProcs()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint procsOff = 0x1000;
+            // A SINGLE-record Procs: record0 = 0x00 terminator immediately -> length 8 (< 16). Non-child
+            // candidates below the IsTooShort 2-record gate are rejected.
+            PlantProcsRecord(rom, procsOff + 0, 0x00, 0, 0);
+            PlantProcsRecord(rom, procsOff + 8, 0x0B, 0, 0); // padding
+
+            var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+            {
+                new DisassemblerTrumb.LDRPointer
+                {
+                    ldr_data = Ptr(procsOff), ldr_data_address = 0x2000, ldr_address = 0x2100,
+                }
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitProcsScriptCore(rom, list, ldrmap, new Dictionary<uint, string>());
+            Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.PROCS);
+        }
+
+        [Fact]
+        public void EmitProcsScriptCore_ChildProcsRecursion_EmitsNestedProcs()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint childOff = 0x1800;  // even offset (a 6C child pointer must be even)
+            PlantMinimalProcs(rom, childOff);
+
+            // Parent: record0 = 0x05 (child-procs opcode; sarg==0, parg = even safe pointer to childOff),
+            // record1 = 0x00 terminator. length 16 -> passes the non-child IsTooShort gate; its 0x05 record
+            // recurses into childOff (emitted as a nested PROCS even though it's only reachable as a child).
+            uint parentOff = 0x1000;
+            PlantProcsRecord(rom, parentOff + 0, 0x05, 0, Ptr(childOff)); // child pointer (even)
+            PlantProcsRecord(rom, parentOff + 8, 0x00, 0, 0);             // terminator
+            PlantProcsRecord(rom, parentOff + 16, 0x0B, 0, 0);            // padding
+
+            var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+            {
+                new DisassemblerTrumb.LDRPointer
+                {
+                    ldr_data = Ptr(parentOff), ldr_data_address = 0x2000, ldr_address = 0x2100,
+                }
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitProcsScriptCore(rom, list, ldrmap, new Dictionary<uint, string>());
+
+            var procs = list.Where(a => a.DataType == Address.DataTypeEnum.PROCS).ToList();
+            Assert.Contains(procs, a => a.Addr == parentOff);
+            Assert.Contains(procs, a => a.Addr == childOff); // child emitted via the recursion
+        }
+
+        [Fact]
+        public void EmitProcsScriptCore_AsmRoutineRecord_EmitsCallAsmFunction()
+        {
+            var rom = CreateTestRom(0x8000);
+            // An ASM-routine function body at funcOff: the record's parg must be a safe ODD thumb pointer
+            // (CalcProcsLengthAndCheck requires hasASMRoutine opcodes 2/3/4/0x14/0x16 to have an ODD parg).
+            uint funcOff = 0x1800;
+            uint thumbPtr = Ptr(funcOff) | 1u; // odd (thumb)
+
+            uint procsOff = 0x1000;
+            PlantProcsRecord(rom, procsOff + 0, 0x02, 0, thumbPtr); // hasASMRoutine, parg odd safe pointer
+            PlantProcsRecord(rom, procsOff + 8, 0x00, 0, 0);        // terminator
+            PlantProcsRecord(rom, procsOff + 16, 0x0B, 0, 0);       // padding
+
+            var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+            {
+                new DisassemblerTrumb.LDRPointer
+                {
+                    ldr_data = Ptr(procsOff), ldr_data_address = 0x2000, ldr_address = 0x2100,
+                }
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitProcsScriptCore(rom, list, ldrmap, new Dictionary<uint, string>());
+
+            // The per-record MakeAllDataLength sub-walk: a hasASMRoutine opcode with parg!=0 emits an
+            // AddFunction (ASM-type Address) at addr+4 pointing at the (plain) thumb routine.
+            Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.ASM && a.Addr == funcOff);
+        }
+
+        [Fact]
+        public void EmitProcsScriptCore_SetNameRecord_EmitsCString()
+        {
+            var rom = CreateTestRom(0x8000);
+            // A 0x01 "set name" record: parg must be a safe pointer to an ASCII string.
+            uint strOff = 0x1800;
+            byte[] ascii = System.Text.Encoding.ASCII.GetBytes("PROCNAME\0");
+            for (uint b = 0; b < ascii.Length; b++) rom.write_u8(strOff + b, ascii[b]);
+
+            uint procsOff = 0x1000;
+            PlantProcsRecord(rom, procsOff + 0, 0x01, 0, Ptr(strOff)); // set-name, parg -> ASCII string
+            PlantProcsRecord(rom, procsOff + 8, 0x00, 0, 0);           // terminator
+            PlantProcsRecord(rom, procsOff + 16, 0x0B, 0, 0);          // padding
+
+            var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+            {
+                new DisassemblerTrumb.LDRPointer
+                {
+                    ldr_data = Ptr(procsOff), ldr_data_address = 0x2000, ldr_address = 0x2100,
+                }
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitProcsScriptCore(rom, list, ldrmap, new Dictionary<uint, string>());
+
+            // The per-record sub-walk: code 0x01 emits an AddCString (CSTRING) at the string address.
+            Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.CSTRING && a.Addr == strOff);
+        }
+
+        [Fact]
+        public void EmitProcsScriptCore_AlreadyMatchDedup_EmitsEachProcsOnce()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint procsOff = 0x1000;
+            PlantMinimalProcs(rom, procsOff);
+
+            // The SAME Procs offset reached by TWO ldrmap entries -> alreadyMatch dedups to one PROCS.
+            var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+            {
+                new DisassemblerTrumb.LDRPointer
+                {
+                    ldr_data = Ptr(procsOff), ldr_data_address = 0x2000, ldr_address = 0x2100,
+                },
+                new DisassemblerTrumb.LDRPointer
+                {
+                    ldr_data = Ptr(procsOff), ldr_data_address = 0x3000, ldr_address = 0x3100,
+                },
+            };
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitProcsScriptCore(rom, list, ldrmap, new Dictionary<uint, string>());
+            Assert.Equal(1, list.Count(a => a.DataType == Address.DataTypeEnum.PROCS));
+        }
+
+        [Fact]
+        public void EmitProcsScriptCore_ConfigDictTarget_EmitsProcsAndDedupsAgainstLdrmap()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint procsOff = 0x1000;
+            PlantMinimalProcs(rom, procsOff);
+
+            // The 6c_name_ config key is an OFFSET to a POINTER SLOT (a location whose u32 derefs to the
+            // Procs pointer) — see config/data/6c_name_FE8.txt (bare-hex offset keys). Plant such a slot,
+            // then key the dict on the slot OFFSET. Loop 2 derefs rom.u32(slot) -> Ptr(procsOff).
+            uint slotOff = 0x2000;
+            rom.write_u32(slotOff, Ptr(procsOff));
+            var procsName = new Dictionary<uint, string> { { slotOff, "MyProc" } };
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitProcsScriptCore(rom, list, ldrmap: null, procsName: procsName);
+
+            Address procs = list.Single(a => a.DataType == Address.DataTypeEnum.PROCS);
+            Assert.Equal(procsOff, procs.Addr);
+            Assert.Equal(slotOff, procs.Pointer);
+            // The per-pointer config name is used (MakeProcNameByAddr maps the deref'd addr -> "MyProc").
+            Assert.Contains("MyProc", procs.Info);
+        }
+
+        [Fact]
+        public void EmitProcsScriptCore_ZeroedRom_EmitsNothing()
+        {
+            var rom = CreateTestRom(0x8000);
+            // An ldrmap pointing at all-zero data: u32 reads 0 -> the first record is a 0x00 terminator
+            // (length 8 < 16) -> rejected; nothing emitted, no throw.
+            var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+            {
+                new DisassemblerTrumb.LDRPointer
+                {
+                    ldr_data = Ptr(0x1000), ldr_data_address = 0x2000, ldr_address = 0x2100,
+                }
+            };
+            var list = new List<Address>();
+            RebuildProducerCore.EmitProcsScriptCore(rom, list, ldrmap, new Dictionary<uint, string>());
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitProcsScriptCore_NearEofSlot_DoesNotThrow()
+        {
+            var rom = CreateTestRom(0x8000);
+            // A Procs start within a few bytes of EOF: the CalcProcsLengthAndCheck `while (addr+8<=limit)`
+            // clamp + the sub-walk `isSafetyOffset(addr+7)` guard must keep every read in-bounds.
+            uint nearEof = (uint)rom.Data.Length - 6;
+            var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+            {
+                new DisassemblerTrumb.LDRPointer
+                {
+                    ldr_data = Ptr(nearEof), ldr_data_address = 0x2000, ldr_address = 0x2100,
+                }
+            };
+            var list = new List<Address>();
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.EmitProcsScriptCore(rom, list, ldrmap, new Dictionary<uint, string>()));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void EmitProcsScriptCore_Cancellation_Throws()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint procsOff = 0x1000;
+            PlantMinimalProcs(rom, procsOff);
+            var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+            {
+                new DisassemblerTrumb.LDRPointer
+                {
+                    ldr_data = Ptr(procsOff), ldr_data_address = 0x2000, ldr_address = 0x2100,
+                }
+            };
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+            // The loops call ct.ThrowIfCancellationRequested() (replacing WF IsStopFlagOn()).
+            Assert.Throws<OperationCanceledException>(() =>
+                RebuildProducerCore.EmitProcsScriptCore(rom, new List<Address>(), ldrmap,
+                    new Dictionary<uint, string>(), cts.Token));
+        }
+
+        [Fact]
+        public void ROMInfoLoadResourceKnownArea_PopulatesFromRomInfo_SkipsProcsNamedProps()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01"); // populated RomInfo (ROMFE8U)
+                CoreState.ROM = fe8;
+
+                var withProcs = new Dictionary<uint, AsmMapSt>();
+                RebuildProducerCore.ROMInfoLoadResourceKnownArea(fe8, withProcs, isWithOutProcs: false);
+
+                var withoutProcs = new Dictionary<uint, AsmMapSt>();
+                RebuildProducerCore.ROMInfoLoadResourceKnownArea(fe8, withoutProcs, isWithOutProcs: true);
+
+                // The reflection found at least some _pointer/_address known-areas.
+                Assert.NotEmpty(withProcs);
+                // isWithOutProcs:true must SKIP every procs-named property -> no entry whose Name contains
+                // "procs" appears in the without-procs map (and it is a subset of the with-procs map).
+                Assert.DoesNotContain(withoutProcs.Values, v => v.Name != null && v.Name.IndexOf("procs") >= 0);
+                Assert.Contains(withProcs.Values, v => v.Name != null && v.Name.IndexOf("procs") >= 0);
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void ROMInfoLoadResourceKnownArea_NullRomInfo_DoesNotThrowAndStaysEmpty()
+        {
+            var rom = CreateTestRom(0x8000); // NULL RomInfo (synthetic)
+            var map = new Dictionary<uint, AsmMapSt>();
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.ROMInfoLoadResourceKnownArea(rom, map, isWithOutProcs: true));
+            Assert.Null(ex);
+            Assert.Empty(map);
+        }
+
+        [Fact]
+        public void EmitProcsScript_NullBaseDirectory_DoesNotThrowOrShowError()
+        {
+            // EmitProcsScript loads 6c_name_ via ConfigDataFilename (Path.Combine(BaseDirectory, ...)) ->
+            // ArgumentNullException when BaseDirectory is null, and U.LoadDicResource -> IsRequiredFileExist
+            // shows a dialog + Debug.Assert on a missing file. Load6cNameDicSafe must degrade to an EMPTY
+            // dict (loop 2 contributes nothing; loop 1 still emits) instead of throwing/asserting headless.
+            var savedRom = CoreState.ROM;
+            var savedBaseDir = CoreState.BaseDirectory;
+            var savedServices = CoreState.Services;
+            var spy = new ThrowOnDialogServices();
+            try
+            {
+                var rom = CreateTestRom(0x8000);
+                CoreState.BaseDirectory = null; // unconfigured / headless
+                CoreState.Services = spy;
+
+                uint procsOff = 0x1000;
+                PlantMinimalProcs(rom, procsOff);
+                var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+                {
+                    new DisassemblerTrumb.LDRPointer
+                    {
+                        ldr_data = Ptr(procsOff), ldr_data_address = 0x2000, ldr_address = 0x2100,
+                    }
+                };
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitProcsScript(rom, list, ldrmap));
+                Assert.Null(ex); // no ArgumentNullException, no Debug.Assert dialog/throw.
+                Assert.Equal(0, spy.ShowErrorCount); // never surfaced UI.
+                // The ldrmap loop still emits (config dict empty -> "Procs " prefix fallback).
+                Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.PROCS && a.Addr == procsOff);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.BaseDirectory = savedBaseDir;
+                CoreState.Services = savedServices;
+            }
+        }
+
+        [Fact]
+        public void EmitProcsScript_PresentButUnreadableConfig_DoesNotThrowOrShowError()
+        {
+            // File.Exists is true but the read fails (exclusive lock). U.LoadDicResource's catch would call
+            // CoreState.Services.ShowError; Load6cNameDicSafe inlines the parse under a UI-free swallow. A
+            // VERSIONED ROM is used so ConfigDataFilename("6c_name_", rom) resolves the planted ...ALL.txt
+            // (a CreateTestRom has a null RomInfo -> ConfigDataFilename would NRE inside the swallow before
+            // ever reaching the locked file, which wouldn't exercise the lock-swallow path).
+            var savedRom = CoreState.ROM;
+            var savedBaseDir = CoreState.BaseDirectory;
+            var savedServices = CoreState.Services;
+            string baseDir = null;
+            FileStream exclusiveLock = null;
+            var spy = new ThrowOnDialogServices();
+            try
+            {
+                var rom = MakeVersionedRom("BE8E01");
+                CoreState.ROM = rom;
+                baseDir = MakeTempConfigBaseDirFor("6c_name_", "0x08001000=Something\n");
+                CoreState.BaseDirectory = baseDir;
+                CoreState.Services = spy;
+                exclusiveLock = new FileStream(
+                    Path.Combine(baseDir, "config", "data", "6c_name_ALL.txt"),
+                    FileMode.Open, FileAccess.Read, FileShare.None);
+
+                uint procsOff = 0x1000;
+                PlantMinimalProcs(rom, procsOff);
+                var ldrmap = new List<DisassemblerTrumb.LDRPointer>
+                {
+                    new DisassemblerTrumb.LDRPointer
+                    {
+                        ldr_data = Ptr(procsOff), ldr_data_address = 0x2000, ldr_address = 0x2100,
+                    }
+                };
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitProcsScript(rom, list, ldrmap));
+                Assert.Null(ex);                  // swallowed the IOException — no throw.
+                Assert.Equal(0, spy.ShowErrorCount); // never surfaced UI.
+                Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.PROCS && a.Addr == procsOff);
+            }
+            finally
+            {
+                exclusiveLock?.Dispose();
+                CoreState.ROM = savedRom;
+                CoreState.BaseDirectory = savedBaseDir;
+                CoreState.Services = savedServices;
+                if (baseDir != null) try { Directory.Delete(baseDir, true); } catch { }
+            }
+        }
+
+        // Build a temp config/data dir with a <type>ALL.txt (the ConfigDataFilename ALL fallback) so the
+        // headless-safe loader's File.Exists pre-check passes; returns the temp BaseDirectory.
+        static string MakeTempConfigBaseDirFor(string type, string content)
+        {
+            string baseDir = Path.Combine(Path.GetTempPath(), "feb_procs_" + Guid.NewGuid().ToString("N"));
+            string dataDir = Path.Combine(baseDir, "config", "data");
+            Directory.CreateDirectory(dataDir);
+            File.WriteAllText(Path.Combine(dataDir, type + "ALL.txt"), content);
+            return baseDir;
         }
     }
 }

--- a/FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs
@@ -1485,6 +1485,46 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void ROMInfoLoadResourceKnownArea_PointerSlotNearEof_DoesNotThrow()
+        {
+            // Regression (Copilot PR #1300): the once-dereferenced rom.u32(addr) on a reflected _pointer
+            // property is EOF-guarded only by isSafetyOffset(addr), which proves the START is in-bounds but
+            // NOT the full 4-byte extent — Core's u32 THROWS when addr+4 > Length. Truncate a versioned ROM
+            // so its SMALLEST in-range RomInfo _pointer offset sits within 3 bytes of EOF: the unguarded read
+            // would throw; the explicit isSafetyOffset(addr+3) guard must skip it instead.
+            var saved = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+
+                // Find the smallest in-range _pointer offset via the same reflection the method uses.
+                uint smallest = uint.MaxValue;
+                foreach (var prop in fe8.RomInfo.GetType().GetProperties())
+                {
+                    if (prop.PropertyType != typeof(uint)) continue;
+                    if (prop.Name.IndexOf("_pointer") < 0) continue;
+                    uint off = U.toOffset((uint)prop.GetValue(fe8.RomInfo, null));
+                    if (off >= 0x200 && off < (uint)fe8.Data.Length && off < smallest) smallest = off;
+                }
+                Assert.NotEqual(uint.MaxValue, smallest); // a versioned ROM has at least one _pointer.
+
+                // Truncate so [smallest, smallest+? ) straddles EOF: Length = smallest + 2 makes addr in-range
+                // (addr < Length) but addr+4 (= smallest+4) > Length -> the unguarded u32 would throw.
+                var truncated = new byte[smallest + 2];
+                fe8.SwapNewROMDataDirect(truncated);
+                CoreState.ROM = fe8;
+                Assert.True(U.isSafetyOffset(smallest, fe8));          // start in-bounds
+                Assert.False(U.isSafetyOffset(smallest + 3, fe8));     // full extent NOT in-bounds
+
+                var map = new Dictionary<uint, AsmMapSt>();
+                var ex = Record.Exception(() =>
+                    RebuildProducerCore.ROMInfoLoadResourceKnownArea(fe8, map, isWithOutProcs: true));
+                Assert.Null(ex); // the addr+3 guard skipped the near-EOF deref instead of throwing.
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
         public void EmitProcsScript_NullBaseDirectory_DoesNotThrowOrShowError()
         {
             // EmitProcsScript loads 6c_name_ via ConfigDataFilename (Path.Combine(BaseDirectory, ...)) ->

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -11332,9 +11332,13 @@ namespace FEBuilderGBA
         /// <c>_pointer</c>, the once-dereferenced <c>_address</c>) as a known-area <see cref="AsmMapSt"/>.
         /// Used by the PROCS walk as the "this is a different data table, do not mis-scan it as Procs"
         /// filter. Pure reflection + Core-available guards (<c>U.toOffset</c>/<c>isSafetyOffset</c>/
-        /// <c>toPointer</c>/<c>isPointer</c> + <c>rom.u32</c>); the once-dereferenced read is EOF-guarded by
-        /// <c>isSafetyOffset(addr)</c> (addr is already an in-ROM offset, so addr+3 is in-bounds — the WF
-        /// code reads <c>rom.u32(addr)</c> the same way under the same guard).
+        /// <c>toPointer</c>/<c>isPointer</c> + <c>rom.u32</c>). The once-dereferenced <c>rom.u32(addr)</c>
+        /// read is EOF-guarded by an EXPLICIT <c>isSafetyOffset(addr + 3, rom)</c> check (the start guard
+        /// <c>isSafetyOffset(addr)</c> only proves <c>addr</c> is in-bounds, NOT the full 4-byte extent —
+        /// Core's <c>u32</c> throws when <c>addr+4 &gt; Length</c>). On any real ROM a RomInfo
+        /// <c>_pointer</c> never sits in the last 3 bytes, so the extra guard is output-equivalent to WF
+        /// (which reads <c>Program.ROM.u32(addr)</c> under the same start guard); a slot that close to EOF
+        /// simply skips recording its dereferenced <c>_address</c> instead of throwing.
         /// </summary>
         public static void ROMInfoLoadResourceKnownArea(ROM rom, Dictionary<uint, AsmMapSt> asmMap, bool isWithOutProcs)
         {
@@ -11380,12 +11384,18 @@ namespace FEBuilderGBA
                         p.Name = info.Name;
                         asmMap[pointer] = p;
 
-                        uint pointer2 = rom.u32(addr);
-                        if (U.isPointer(pointer2))
+                        // EOF-guard the FULL 4-byte extent before the deref: isSafetyOffset(addr) above only
+                        // proves addr is in-bounds, and Core's rom.u32 throws when addr+4 > Length. A slot
+                        // within 3 bytes of EOF skips its dereferenced _address (never happens on a real ROM).
+                        if (U.isSafetyOffset(addr + 3, rom))
                         {
-                            p = new AsmMapSt();
-                            p.Name = info.Name.Replace("_pointer", "_address");
-                            asmMap[pointer2] = p;
+                            uint pointer2 = rom.u32(addr);
+                            if (U.isPointer(pointer2))
+                            {
+                                p = new AsmMapSt();
+                                p.Name = info.Name.Replace("_pointer", "_address");
+                                asmMap[pointer2] = p;
+                            }
                         }
                     }
                 }
@@ -11583,8 +11593,10 @@ namespace FEBuilderGBA
                 {
                     continue;
                 }
-                // Guard the full u32 extent (pointer+3) before the deref (the #1261 producer discipline;
-                // isSafetyOffset(pointer) above already implies pointer+3 < Length, but be explicit).
+                // EOF-guard the FULL u32 extent (pointer+3) before the deref (the #1261 producer discipline).
+                // The start guard isSafetyOffset(pointer) above only proves `pointer` is in-bounds, NOT that
+                // pointer+3 is — Core's rom.u32 throws when pointer+4 > Length, so this explicit extent guard
+                // is required (a config slot within 3 bytes of EOF is skipped instead of throwing).
                 if (!U.isSafetyOffset(pointer + 3, rom))
                 {
                     continue;

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -10284,11 +10284,11 @@ namespace FEBuilderGBA
         // Coverage honesty: like the data-path GetNotYetPortedForms, the ASM
         // producer never silently omits a form. AsmProducerResult.NotYetPorted
         // lists the forms still blocked on an un-ported subsystem (the
-        // PatchForm patch-config scanner + the ProcsScriptForm AsmMapFileAsmCache
-        // UI-cache, each its own follow-up slice; OAMSPForm is PORTED in slice 2w —
-        // it had no AsmMapFileAsmCache dependency), so AsmProducerResult.IsComplete
-        // stays false until they land — a wiring slice must not feed an incomplete
-        // list to a real defragment.
+        // PatchForm patch-config scanner + GraphicsToolForm LZ77, each its own
+        // follow-up slice; OAMSPForm is PORTED in slice 2w, ProcsScriptForm in
+        // slice 2x — neither needed the WinForms AsmMapFileAsmCache), so
+        // AsmProducerResult.IsComplete stays false until they land — a wiring
+        // slice must not feed an incomplete list to a real defragment.
         // ====================================================================
 
         /// <summary>Result of <see cref="AppendAllAsmStructPointers"/>: the forms NOT yet
@@ -10338,12 +10338,11 @@ namespace FEBuilderGBA
                 // patch pointer relocates the wrong bytes = silent corruption — DEFER until the patch-
                 // config subsystem reaches Core (its own follow-up slice).
                 "PatchForm(MakePatchStructDataList)",
-                // ProcsScriptForm.MakeAllDataLength(ldrmap) — the only form (besides the optional OAMSP)
-                // that CONSUMES the ldrmap. Its FindProc walk depends on Program.AsmMapFileAsmCache
-                // (IsStopFlagOn() / GetKnownArea() — a WinForms UI cache) + the 6c_name_ config dic. The
-                // ldrmap itself is Core-buildable (DisassemblerTrumb.MakeLDRMap), but the AsmMapFileAsmCache
-                // dependency is not — DEFER until that cache reaches Core (its own follow-up slice).
-                "ProcsScriptForm",
+                // ProcsScriptForm.MakeAllDataLength(ldrmap) — PORTED in slice 2x (EmitProcsScript /
+                // EmitProcsScriptCore + ROMInfoLoadResourceKnownArea + Load6cNameDicSafe). Its FindProc walk
+                // CONSUMES the ldrmap but no longer needs the WinForms AsmMapFileAsmCache: GetKnownArea is
+                // pure RomInfo reflection, IsStopFlagOn() is replaced by the threaded CancellationToken, and
+                // the 6c_name_ config dict loads headless-safe. So it is no longer in this deferred list.
                 // GraphicsToolForm.MakeLZ77DataList (only when isUseOtherGraphics) — the LZ77 graphics-
                 // tool subsystem. Out of scope for this foundation; DEFER.
                 "GraphicsToolForm",
@@ -10415,8 +10414,12 @@ namespace FEBuilderGBA
             // reproduce the gate faithfully: with no ldrmap, none of this group runs.
             if (ldrmap != null)
             {
-                // ProcsScriptForm.MakeAllDataLength(ldrmap) — DEFERRED (AsmMapFileAsmCache). Nothing here.
-                progress?.Report("ProcsScriptForm (deferred)");
+                // ProcsScriptForm.MakeAllDataLength(ldrmap) — PORTED (slice 2x). The FIRST form inside the
+                // `if (ldrmap != null)` block (WF U.cs:2624). Its FindProc walk no longer needs the WinForms
+                // AsmMapFileAsmCache: GetKnownArea is a pure RomInfo reflection (ROMInfoLoadResourceKnownArea),
+                // IsStopFlagOn() is replaced by `ct`, and the 6c_name_ config dict is loaded headless-safe.
+                progress?.Report("ProcsScriptForm");
+                EmitProcsScript(rom, list, ldrmap, ct);
 
                 if (ct.IsCancellationRequested)
                 {
@@ -11271,6 +11274,469 @@ namespace FEBuilderGBA
 
             uint ret_length = addr - start;
             return ret_length;
+        }
+
+        // ====================================================================
+        // slice 2x — ProcsScriptForm.MakeAllDataLength(structlist, ldrmap)
+        // (FEBuilderGBA/ProcsScriptForm.cs:265-294 + the nested FindProc class
+        // L122-253). The PROCS (map-anime "6C") bytecode tables, discovered by
+        // walking the LDR map and the 6c_name_ config dict, validated by the
+        // already-ported VERBATIM CalcProcsLengthAndCheck terminator walk, then
+        // recursed into child Procs / ASM routines.
+        //
+        // WinForms→Core substitutions (each faithful, no relocation drift):
+        //   - Program.AsmMapFileAsmCache.GetKnownArea() => a pure RomInfo
+        //     reflection (ROMInfoLoadResourceKnownArea, the verbatim port of
+        //     AsmMapFile.ROMInfoLoadResource, isWithOutProcs:true);
+        //   - Program.AsmMapFileAsmCache.IsStopFlagOn() => the threaded
+        //     CancellationToken (ct.ThrowIfCancellationRequested, matching the
+        //     rest of AppendAllAsmStructPointers);
+        //   - U.LoadDicResource(ConfigDataFilename("6c_name_")) => the
+        //     headless-safe Load6cNameDicSafe (the slice-2w LoadOamNameDicSafe
+        //     idiom: File.Exists pre-check + inlined parse loop under a
+        //     UI-free swallow, never ShowError / NRE on a null BaseDirectory);
+        //   - every Program.ROM => the threaded `rom`, every read EOF-guarded.
+        //
+        // NAME fidelity: Get6CName2 / MakeProcNameByAddr / GetProcsName are
+        // reproduced. The ONE unavoidable simplification (cosmetic, relocation-
+        // identical — same precedent as EmitItemWeaponEffect/EmitAIScript) is
+        // Get6CNameAddr's WinForms TextForm.Direct(stringPointer) tail: that
+        // helper dereferences an in-bytecode ASCII pointer through a WinForms
+        // text decoder NOT in Core (FETextDecode.Direct takes a TEXT-ID, wrong
+        // semantics), and its result feeds only the Address.Info string (never
+        // addr/length/pointer/DataType/emission-order). When both config name
+        // hints are empty the producer keeps the "Procs " prefix without the
+        // dereferenced tail.
+        // ====================================================================
+
+        /// <summary>WF <c>ProcsScriptForm.hasASMRoutine</c> (ProcsScriptForm.cs:106): opcodes whose
+        /// <c>parg</c> is an ASM-routine pointer (2/3/4/0x14/0x16/0x18). Verbatim.</summary>
+        static bool HasProcsASMRoutine(uint code)
+        {
+            return (code == 0x2 || code == 0x3 || code == 0x4 || code == 0x14 || code == 0x16 || code == 0x18);
+        }
+
+        /// <summary>WF <c>ProcsScriptForm.hasChildProcs</c> (ProcsScriptForm.cs:110): opcodes whose
+        /// <c>parg</c> nests a child PROCS table (5..0xA, or 0xD). Verbatim.</summary>
+        static bool HasProcsChildProcs(uint code)
+        {
+            return (code >= 0x5 && code <= 0xA) || code == 0xD;
+        }
+
+        /// <summary>
+        /// VERBATIM port of <c>AsmMapFile.ROMInfoLoadResource</c> (FEBuilderGBA/AsmMapFile.cs:197-257),
+        /// parameterized by <paramref name="rom"/> (replacing every <c>Program.ROM</c>). Reflects over the
+        /// <c>uint</c> properties of <paramref name="rom"/>'s <c>RomInfo</c> whose name contains
+        /// <c>_pointer</c> / <c>_address</c> (skipping <c>"procs"</c>-named ones when
+        /// <paramref name="isWithOutProcs"/>), recording each resolvable address (and, for a
+        /// <c>_pointer</c>, the once-dereferenced <c>_address</c>) as a known-area <see cref="AsmMapSt"/>.
+        /// Used by the PROCS walk as the "this is a different data table, do not mis-scan it as Procs"
+        /// filter. Pure reflection + Core-available guards (<c>U.toOffset</c>/<c>isSafetyOffset</c>/
+        /// <c>toPointer</c>/<c>isPointer</c> + <c>rom.u32</c>); the once-dereferenced read is EOF-guarded by
+        /// <c>isSafetyOffset(addr)</c> (addr is already an in-ROM offset, so addr+3 is in-bounds — the WF
+        /// code reads <c>rom.u32(addr)</c> the same way under the same guard).
+        /// </summary>
+        public static void ROMInfoLoadResourceKnownArea(ROM rom, Dictionary<uint, AsmMapSt> asmMap, bool isWithOutProcs)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (asmMap == null) throw new ArgumentNullException(nameof(asmMap));
+            if (rom.RomInfo == null)
+            {
+                // A synthetic NULL-RomInfo ROM has no known-area table; WF always runs on a versioned ROM.
+                return;
+            }
+
+            //せっかくなので、ROMで判明しているデータも追加する.
+            System.Reflection.MemberInfo[] members = rom.RomInfo.GetType().GetMembers();
+            foreach (System.Reflection.MemberInfo info in members)
+            {
+                if (info.MemberType != System.Reflection.MemberTypes.Property)
+                {
+                    continue;
+                }
+                System.Reflection.PropertyInfo field = (System.Reflection.PropertyInfo)info;
+                if (field.PropertyType != typeof(uint))
+                {
+                    continue;
+                }
+
+                if (isWithOutProcs)
+                {
+                    if (info.Name.IndexOf("procs") >= 0)
+                    {
+                        continue;
+                    }
+                }
+
+                if (info.Name.IndexOf("_pointer") >= 0)
+                {
+                    uint addr = (uint)field.GetValue(rom.RomInfo, null);
+                    addr = U.toOffset(addr);
+                    if (addr > 0 && U.isSafetyOffset(addr, rom))
+                    {
+                        uint pointer = U.toPointer(addr);
+
+                        AsmMapSt p = new AsmMapSt();
+                        p.Name = info.Name;
+                        asmMap[pointer] = p;
+
+                        uint pointer2 = rom.u32(addr);
+                        if (U.isPointer(pointer2))
+                        {
+                            p = new AsmMapSt();
+                            p.Name = info.Name.Replace("_pointer", "_address");
+                            asmMap[pointer2] = p;
+                        }
+                    }
+                }
+
+                if (info.Name.IndexOf("_address") >= 0)
+                {
+                    uint addr = (uint)field.GetValue(rom.RomInfo, null);
+                    addr = U.toOffset(addr);
+                    if (addr > 0 && U.isSafetyOffset(addr, rom))
+                    {
+                        uint pointer = U.toPointer(addr);
+                        AsmMapSt p = new AsmMapSt();
+                        p.Name = info.Name;
+                        asmMap[pointer] = p;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Load the <c>6c_name_</c> config dictionary (WF <c>FindProc</c> ctor's first line,
+        /// ProcsScriptForm.cs:131), never throwing or surfacing UI. Identical idiom to the slice-2w
+        /// <see cref="LoadOamNameDicSafe"/>: a <see cref="System.IO.File.Exists"/> pre-check (missing ->
+        /// empty, no <c>IsRequiredFileExist</c> ShowError + Debug.Assert) plus the inlined
+        /// <see cref="U.LoadDicResource"/> parse loop (U.cs:1772-1792) under a UI-free try/catch (a present-
+        /// but-malformed file degrades to a partial dict instead of <c>CoreState.Services.ShowError</c>).
+        /// Uses the <c>OtherLangLine(line, rom)</c> overload (not the <c>CoreState.ROM</c> global), which
+        /// only toggles whether a <c>{U}</c>/<c>{J}</c>-tagged line is skipped (output-equivalent). A
+        /// missing/empty dict means loop 2 of <see cref="EmitProcsScriptCore"/> contributes nothing; the
+        /// ldrmap loop is unaffected.
+        /// </summary>
+        static Dictionary<uint, string> Load6cNameDicSafe(ROM rom)
+        {
+            var dic = new Dictionary<uint, string>();
+            try
+            {
+                string filename = U.ConfigDataFilename("6c_name_", rom);
+                if (!System.IO.File.Exists(filename))
+                {
+                    return dic;
+                }
+                using (var reader = System.IO.File.OpenText(filename))
+                {
+                    string line;
+                    while ((line = reader.ReadLine()) != null)
+                    {
+                        if (U.IsComment(line) || U.OtherLangLine(line, rom)) continue;
+                        line = U.ClipComment(line);
+                        if (line == "") continue;
+                        string[] sp = line.Split('=');
+                        dic[U.atoh(sp[0])] = U.at(sp, 1);
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // Null BaseDirectory, an unreadable handle, or a malformed line: never surface UI —
+                // return whatever parsed so far (partial/empty).
+            }
+            return dic;
+        }
+
+        /// <summary>WF <c>ProcsScriptForm.Get6CNameAddr</c> (ProcsScriptForm.cs:62-84) is NOT reproduced:
+        /// it dereferences an in-bytecode ASCII string pointer through the WinForms <c>TextForm.Direct</c>
+        /// (no Core equivalent — <c>FETextDecode.Direct</c> takes a text-ID, wrong semantics) to build a
+        /// COSMETIC name tail. Per the EmitItemWeaponEffect/EmitAIScript precedent, the Address <c>Info</c>
+        /// is cosmetic (never affects addr/length/pointer/DataType/order), so the producer keeps the
+        /// <c>"Procs "</c> prefix without the dereferenced tail. This helper reproduces only the
+        /// HINT-selection logic of <c>Get6CName2</c> (ProcsScriptForm.cs:87-104): use the per-pointer config
+        /// name, else the per-addr config name, else the bare prefix.</summary>
+        static string Get6CName2(string hint, string hint2)
+        {
+            string name = "Procs ";
+            if (hint.Length > 0)
+            {
+                name += hint;
+            }
+            else if (hint2.Length > 0)
+            {
+                name += hint2;
+            }
+            // else: WF appends Get6CNameAddr (TextForm.Direct tail) — cosmetic only, dropped (see summary).
+            return name;
+        }
+
+        /// <summary>WF <c>ProcsScriptForm.GetProcsName</c> (ProcsScriptForm.cs:256-263): a bare
+        /// <c>"Procs "</c> info gets the address appended for the per-record CallASM label.</summary>
+        static string GetProcsName(Address a)
+        {
+            if (a.Info == "Procs ")
+            {
+                return a.Info + U.ToHexString(a.Addr);
+            }
+            return a.Info;
+        }
+
+        /// <summary>
+        /// Core port of <c>ProcsScriptForm.MakeAllDataLength(structlist, ldrmap)</c>
+        /// (FEBuilderGBA/ProcsScriptForm.cs:265-294). Loads the <c>6c_name_</c> config dictionary
+        /// (the WF <c>FindProc</c> ctor's first line) headless-safe, then delegates to
+        /// <see cref="EmitProcsScriptCore"/>.
+        /// </summary>
+        /// <param name="rom">The ROM to scan (MUST be the loaded <see cref="CoreState.ROM"/>; the
+        /// <c>6c_name_</c> config filename is RomInfo-derived).</param>
+        /// <param name="list">The accumulating struct list (appended to).</param>
+        /// <param name="ldrmap">The full-ROM LDR map (<see cref="BuildLdrMap"/>). WF gates this whole form
+        /// on a non-null map; a null map skips loop 1 (loop 2 / the config-dict scan still runs).</param>
+        /// <param name="ct">Cancellation (replaces WF <c>AsmMapFileAsmCache.IsStopFlagOn()</c>).</param>
+        public static void EmitProcsScript(ROM rom, List<Address> list,
+            List<DisassemblerTrumb.LDRPointer> ldrmap, CancellationToken ct = default)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (list == null) throw new ArgumentNullException(nameof(list));
+            Dictionary<uint, string> procsName = Load6cNameDicSafe(rom);
+            EmitProcsScriptCore(rom, list, ldrmap, procsName, ct);
+        }
+
+        /// <summary>
+        /// Verbatim port of <c>ProcsScriptForm.MakeAllDataLength</c> + its nested <c>FindProc</c> class
+        /// (FEBuilderGBA/ProcsScriptForm.cs:122-294) with the <c>6c_name_</c> dictionary supplied (test seam
+        /// — lets a synthetic ROM drive the Procs walk without a RomInfo-derived config file). WF builds the
+        /// discovered Procs into a LOCAL list (so the per-record CallASM/CString sub-walk iterates exactly
+        /// the discovered Procs, not whatever else was already in <paramref name="list"/>), then AddRange's
+        /// it into the real list and finally walks each discovered Procs for embedded ASM-routine / set-name
+        /// pointers — reproduced.
+        /// <list type="bullet">
+        ///   <item><c>FindProc</c>: <c>knownArea</c> = <see cref="ROMInfoLoadResourceKnownArea"/>
+        ///   (isWithOutProcs:true); <c>ProcsNameByAddr</c> = <see cref="MakeProcNameByAddr"/>; loop 1 over
+        ///   <paramref name="ldrmap"/> (<c>ldr_data</c>/<c>ldr_data_address</c>), loop 2 over the config dict
+        ///   (deref <c>rom.u32(pointer)</c>); both skip <c>knownArea</c>/<c>alreadyMatch</c>; each calls
+        ///   <see cref="FindProcOne"/>.</item>
+        ///   <item><c>FindProcOne</c>: <see cref="CalcProcsLengthAndCheck"/> + the <c>IsTooShort</c> (&gt;=16)
+        ///   gate for non-child entries + <c>Address.AddAddress(..., PROCS)</c> + record <c>alreadyMatch</c> +
+        ///   recurse into child Procs (<see cref="HasProcsChildProcs"/> -> <c>p32(addr+4)</c>).</item>
+        ///   <item>per-record sub-walk: <see cref="HasProcsASMRoutine"/> -> <c>AddFunction(addr+4, ...)</c>
+        ///   when <c>p32(addr+4)!=0</c>; code <c>0x01</c> -> <c>AddCString(addr+4)</c>.</item>
+        /// </list>
+        /// Every computed read is EOF-guarded: the per-8-byte loops bound on <c>end = addr + length</c> where
+        /// <c>length</c> came from the EOF-clamped <see cref="CalcProcsLengthAndCheck"/>, so each
+        /// <c>p32(addr+4)</c>/<c>u8(addr)</c> within <c>[addr, end)</c> is in-bounds; the
+        /// <c>U.isSafetyOffset(addr+7, rom)</c> belt-and-braces guard before the +4 p32 reads keeps a
+        /// boundary record (where <c>end</c> sits within 8 bytes of EOF) safe. The recursion is dedup'd via
+        /// <c>alreadyMatch</c> (no infinite loop on a self-referential child pointer).
+        /// </summary>
+        public static void EmitProcsScriptCore(ROM rom, List<Address> list,
+            List<DisassemblerTrumb.LDRPointer> ldrmap, Dictionary<uint, string> procsName,
+            CancellationToken ct = default)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (list == null) throw new ArgumentNullException(nameof(list));
+            if (procsName == null) procsName = new Dictionary<uint, string>();
+
+            var procs = new List<Address>();
+            var alreadyMatch = new Dictionary<uint, bool>();
+
+            // FindProc ctor (ProcsScriptForm.cs:129-180): the addr->name map + the known-area filter.
+            Dictionary<uint, string> procsNameByAddr = MakeProcNameByAddr(rom, procsName);
+            var knownArea = new Dictionary<uint, AsmMapSt>();
+            ROMInfoLoadResourceKnownArea(rom, knownArea, isWithOutProcs: true);
+
+            // ---- Loop 1: ldrmap (FindProc ctor L137-156) -----------------------
+            if (ldrmap != null)
+            {
+                for (int i = 0; i < ldrmap.Count; i++)
+                {
+                    ct.ThrowIfCancellationRequested(); // WF: if (IsStopFlagOn()) return;
+
+                    uint addr = ldrmap[i].ldr_data;
+                    if (!U.isSafetyPointer(addr, rom))
+                    {
+                        continue;
+                    }
+                    if (knownArea.ContainsKey(addr))
+                    {//既知のエリア 別のデータのテーブルを誤参照
+                        continue;
+                    }
+                    addr = U.toOffset(addr);
+                    if (alreadyMatch.ContainsKey(addr))
+                    {//既に知っている.
+                        continue;
+                    }
+                    FindProcOne(rom, procs, alreadyMatch, procsName, procsNameByAddr,
+                        ldrmap[i].ldr_data_address, addr, child6C: false);
+                }
+            }
+
+            // ---- Loop 2: 6c_name_ config dict (FindProc ctor L157-178) ---------
+            foreach (var pair in procsName)
+            {
+                ct.ThrowIfCancellationRequested(); // WF: if (IsStopFlagOn()) return;
+
+                uint pointer = pair.Key;
+                pointer = U.toOffset(pointer);
+                if (!U.isSafetyOffset(pointer, rom))
+                {
+                    continue;
+                }
+                // Guard the full u32 extent (pointer+3) before the deref (the #1261 producer discipline;
+                // isSafetyOffset(pointer) above already implies pointer+3 < Length, but be explicit).
+                if (!U.isSafetyOffset(pointer + 3, rom))
+                {
+                    continue;
+                }
+                uint addr = rom.u32(pointer);
+                if (knownArea.ContainsKey(addr))
+                {//既知のエリア 別のデータのテーブルを誤参照
+                    continue;
+                }
+                addr = U.toOffset(addr);
+                if (alreadyMatch.ContainsKey(addr))
+                {//既に知っている.
+                    continue;
+                }
+                FindProcOne(rom, procs, alreadyMatch, procsName, procsNameByAddr,
+                    pointer, addr, child6C: false);
+            }
+
+            // MakeAllDataLength L267-293: append the discovered Procs, then walk each for attached data.
+            list.AddRange(procs); //発見したProcsを追加.
+
+            foreach (Address a in procs)
+            {
+                uint addr = a.Addr;
+                uint end = addr + a.Length;
+                for (; addr < end; addr += 8)
+                {
+                    // EOF-guard the full +4 p32 extent (addr+7) before the read. `end` came from the
+                    // EOF-clamped CalcProcsLengthAndCheck so every in-range record is in-bounds, but a
+                    // boundary record (end within 8 bytes of EOF) is made explicit-safe here.
+                    if (!U.isSafetyOffset(addr + 7, rom))
+                    {
+                        break;
+                    }
+                    uint code = rom.u8(addr);
+
+                    if (HasProcsASMRoutine(code))
+                    {//呼び出しているASM関数
+                        uint arg = rom.p32(addr + 4);
+                        if (arg != 0)
+                        {
+                            Address.AddFunction(list, addr + 4, GetProcsName(a) + " CallASM");
+                        }
+                    }
+                    else if (code == 0x01)
+                    {//Set name
+                        Address.AddCString(list, addr + 4);
+                    }
+                }
+            }
+        }
+
+        /// <summary>VERBATIM port of <c>FindProc.MakeProcNameByAddr</c> (ProcsScriptForm.cs:182-200):
+        /// builds an addr->name map by dereferencing each safe config pointer
+        /// (<c>p = rom.u32(key); ret[toOffset(p)] = value</c>). The <c>key+3</c> / <c>p</c> reads are
+        /// EOF-guarded (isSafetyOffset on the key, isSafetyPointer on the dereferenced value).</summary>
+        static Dictionary<uint, string> MakeProcNameByAddr(ROM rom, Dictionary<uint, string> procsName)
+        {
+            var ret = new Dictionary<uint, string>();
+            foreach (var pair in procsName)
+            {
+                if (!U.isSafetyOffset(pair.Key, rom))
+                {
+                    continue;
+                }
+                if (!U.isSafetyOffset(pair.Key + 3, rom))
+                {
+                    continue;
+                }
+                uint p = rom.u32(pair.Key);
+                if (!U.isSafetyPointer(p, rom))
+                {
+                    continue;
+                }
+                p = U.toOffset(p);
+                ret[p] = pair.Value;
+            }
+            return ret;
+        }
+
+        /// <summary>WF <c>FindProc.IsTooShort</c> (ProcsScriptForm.cs:202-210): a non-child Procs must be at
+        /// least 2 records (16 bytes) long. NOTE the WF method name is inverted — it returns <c>true</c>
+        /// when the length is ACCEPTABLE (&gt;= 16); reproduced verbatim.</summary>
+        static bool IsTooShort(uint length)
+        {
+            if (length >= 8 * 2)
+            {
+                return true;
+            }
+            //短すぎる
+            return false;
+        }
+
+        /// <summary>
+        /// VERBATIM port of <c>FindProc.FindProcOne</c> (ProcsScriptForm.cs:212-253): validate a candidate
+        /// PROCS at <paramref name="addr"/> via <see cref="CalcProcsLengthAndCheck"/>; on success (and, for a
+        /// non-child entry, the <see cref="IsTooShort"/> &gt;=16 gate) emit a PROCS <see cref="Address"/>,
+        /// record <paramref name="alreadyMatch"/>, then recurse into each child-Procs opcode's pointer. A
+        /// rejected candidate records <c>alreadyMatch[addr]=false</c> (so it is not retried). The recursion
+        /// is bounded by <paramref name="alreadyMatch"/> (a child already matched <c>true</c> is skipped).
+        /// </summary>
+        static void FindProcOne(ROM rom, List<Address> list, Dictionary<uint, bool> alreadyMatch,
+            Dictionary<uint, string> procsName, Dictionary<uint, string> procsNameByAddr,
+            uint pointer, uint addr, bool child6C)
+        {
+            uint length = CalcProcsLengthAndCheck(rom, addr);
+            if (U.NOT_FOUND == length)
+            {
+                alreadyMatch[addr] = false; //ダメだったということを記録しておこう
+                return;
+            }
+
+            if (child6C == false)
+            {
+                if (IsTooShort(length) == false)
+                {
+                    alreadyMatch[addr] = false; //ダメだったということを記録しておこう
+                    return;
+                }
+            }
+
+            string name = Get6CName2(U.at(procsName, pointer), U.at(procsNameByAddr, addr));
+            Address.AddAddress(list, addr, length, pointer, name, Address.DataTypeEnum.PROCS);
+            alreadyMatch[addr] = true;
+
+            uint end = addr + length;
+            for (; addr < end; addr += 8)
+            {
+                // EOF-guard the full +4 p32 extent (addr+7) before the read. `end` came from the EOF-clamped
+                // CalcProcsLengthAndCheck so every in-range record is in-bounds; a boundary record (end within
+                // 8 bytes of EOF) is made explicit-safe here (WF reads p32(addr+4) unconditionally).
+                if (!U.isSafetyOffset(addr + 7, rom))
+                {
+                    break;
+                }
+                uint code = rom.u8(addr);
+                if (HasProcsChildProcs(code))
+                {
+                    uint arg = rom.p32(addr + 4);
+
+                    bool result;
+                    if (alreadyMatch.TryGetValue(arg, out result))
+                    {//既に知っている.
+                        if (result)
+                        {
+                            continue;
+                        }
+                    }
+                    FindProcOne(rom, list, alreadyMatch, procsName, procsNameByAddr,
+                        addr + 4, arg, child6C: true);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
Faithful WinForms→Core port of `ProcsScriptForm.MakeAllDataLength(structlist, ldrmap)` (`FEBuilderGBA/ProcsScriptForm.cs:265-294`) + its nested `FindProc` class (L122-253) into `FEBuilderGBA.Core/RebuildProducerCore.cs`, wired into the existing ASM-path producer `AppendAllAsmStructPointers` as the FIRST form inside the `if (ldrmap != null)` block (WF call site `U.cs:2624`). **Part of #1261** (the ROM-rebuild producer marathon — slice 2x).

The PROCS (map-anime "6C") bytecode tables are discovered by walking the LDR map and the `6c_name_` config dict, validated by the already-ported VERBATIM `CalcProcsLengthAndCheck` terminator walk, then recursed into child Procs / ASM routines. The per-record `MakeAllDataLength` sub-walk emits a CallASM `AddFunction` (`hasASMRoutine` opcodes) and an `AddCString` (code `0x01` set-name).

## WinForms→Core substitutions (each faithful, no relocation drift)
- `Program.AsmMapFileAsmCache.GetKnownArea()` → `ROMInfoLoadResourceKnownArea`, the VERBATIM port of `AsmMapFile.ROMInfoLoadResource` (`AsmMapFile.cs:197-257`), `isWithOutProcs:true` — pure `RomInfo` reflection over `uint` `_pointer`/`_address` props (skipping `"procs"`-named), no WinForms UI cache.
- `Program.AsmMapFileAsmCache.IsStopFlagOn()` → the threaded `CancellationToken` (`ct.ThrowIfCancellationRequested`), matching the rest of the ASM producer.
- `U.LoadDicResource(ConfigDataFilename("6c_name_"))` → the headless-safe `Load6cNameDicSafe` (the slice-2w `LoadOamNameDicSafe` idiom: `File.Exists` pre-check + inlined parse loop under a UI-free swallow — never `ShowError` / NRE on a null `BaseDirectory` or a present-but-malformed/locked config).
- every `Program.ROM` → the threaded `rom`; every computed read EOF-guarded (`isSafetyOffset(addr+7, rom)` before the `+4` p32 in both the `FindProcOne` recursion and the `MakeAllDataLength` sub-walk; the length engine `CalcProcsLengthAndCheck` is already EOF-clamped).

## NAME fidelity
`Get6CName2` / `MakeProcNameByAddr` / `GetProcsName` reproduced. The ONE unavoidable simplification (cosmetic, relocation-identical — same precedent as `EmitItemWeaponEffect`/`EmitAIScript`) is `Get6CNameAddr`'s WinForms `TextForm.Direct(stringPointer)` name tail: that helper dereferences an in-bytecode ASCII pointer through a WinForms text decoder NOT in Core (`FETextDecode.Direct` takes a TEXT-ID — wrong semantics), and its result feeds only the cosmetic `Address.Info` string (never addr/length/pointer/DataType/emission-order). When both config name hints are empty the producer keeps the `"Procs "` prefix without the dereferenced tail.

`ProcsScriptForm` removed from `AsmNotYetPortedRaw` (now ported); the deferred-coverage comments updated.

## Scope
Ref #1261. Core-only (no GUI), like the prior 22 producer slices.

## Test plan
- [x] valid PROCS at an ldrmap target emits the right PROCS addr/length/name (`EmitProcsScriptCore_ValidLdrmapTarget_EmitsProcsAddressLengthName`)
- [x] `IsTooShort` (<16, i.e. <2 records) reject path (`EmitProcsScriptCore_TooShort_RejectsSingleRecordProcs`)
- [x] child-procs recursion emits a nested PROCS (`EmitProcsScriptCore_ChildProcsRecursion_EmitsNestedProcs`)
- [x] ASM-routine record emits a CallASM `AddFunction` (`EmitProcsScriptCore_AsmRoutineRecord_EmitsCallAsmFunction`)
- [x] set-name record (code 0x01) emits an `AddCString` (`EmitProcsScriptCore_SetNameRecord_EmitsCString`)
- [x] config-dict target emits a PROCS + `MakeProcNameByAddr` name application (`EmitProcsScriptCore_ConfigDictTarget_EmitsProcsAndDedupsAgainstLdrmap`)
- [x] `alreadyMatch` dedup — same Procs via two ldrmap entries emits once (`EmitProcsScriptCore_AlreadyMatchDedup_EmitsEachProcsOnce`)
- [x] zeroed ROM emits nothing (`EmitProcsScriptCore_ZeroedRom_EmitsNothing`)
- [x] near-EOF slot does not throw (`EmitProcsScriptCore_NearEofSlot_DoesNotThrow`)
- [x] cancellation throws (`EmitProcsScriptCore_Cancellation_Throws`)
- [x] `ROMInfoLoadResourceKnownArea` reflection populates from a versioned RomInfo + skips "procs"-named props (`ROMInfoLoadResourceKnownArea_PopulatesFromRomInfo_SkipsProcsNamedProps`)
- [x] `ROMInfoLoadResourceKnownArea` null-RomInfo no-throw (`ROMInfoLoadResourceKnownArea_NullRomInfo_DoesNotThrowAndStaysEmpty`)
- [x] null `BaseDirectory` 6c_name_ safe-load does not throw or ShowError (`EmitProcsScript_NullBaseDirectory_DoesNotThrowOrShowError`)
- [x] present-but-unreadable (locked) 6c_name_ config does not throw or ShowError (`EmitProcsScript_PresentButUnreadableConfig_DoesNotThrowOrShowError`)
- [x] the two ASM-coverage tests move `ProcsScriptForm` `Contains`→`DoesNotContain` (`AppendAllAsmStructPointers_IsNeverComplete_DeferredFormsReported`, `GetAsmNotYetPortedForms_ListsDeferredForms_NoDuplicates`)

## Gates (proof — Core-only PR, CLI/test output is the accepted proof)
- `dotnet test FEBuilderGBA.Core.Tests --filter ~RebuildProducer` → **362 passed / 0 failed** (baseline 348; +14 net new).
- `dotnet build FEBuilderGBA.Core/FEBuilderGBA.Core.csproj` → **0 Errors**; `dotnet build FEBuilderGBA.sln` → **0 Errors**.
- Full `Core.Tests`: **4826 passed, 10 failed, 6 skipped** — all 10 failures are `Skill*`/`SkillSystemsAnime*` from the un-checked-out `config/patch2` submodule (known-env, identical on `origin/master`); **0 non-Skill failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
