### PR TITLE
feat(core): ROM-rebuild ASM-path producer — GraphicsToolForm (#1261 slice 2y)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs
@@ -1001,11 +1001,12 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
-        public void EmitGraphicsToolLZ77At_Cancelled_StopsAfterFirstEmit()
+        public void EmitGraphicsToolLZ77At_PreCancelled_EmitsNothing()
         {
+            // The scan checks ct at the TOP of each iteration, so a pre-cancelled token returns before
+            // any emission (responsive cancellation, not "after the first emit").
             var rom = CreateTestRom(0x8000);
             uint borderline = 0x1000;
-            // Two distinct valid images at two scan slots.
             uint imageA = 0x2000, imageB = 0x3000;
             WriteLz77Image(rom, imageA, 32);
             WriteLz77Image(rom, imageB, 32);
@@ -1013,11 +1014,24 @@ namespace FEBuilderGBA.Core.Tests
             rom.write_u32(0x0404, Ptr(imageB));
 
             var cts = new CancellationTokenSource();
-            cts.Cancel(); // pre-cancelled: the loop emits the first match then returns.
+            cts.Cancel(); // pre-cancelled: the loop returns before the first iteration's body.
             var list = new List<Address>();
             RebuildProducerCore.EmitGraphicsToolLZ77At(rom, list,
                 new Dictionary<uint, bool>(), borderline, cts.Token);
-            Assert.True(list.Count(a => a.DataType == Address.DataTypeEnum.LZ77IMG) <= 1);
+            Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.LZ77IMG);
+        }
+
+        [Fact]
+        public void EmitGraphicsToolLZ77At_TinyRom_DoesNotThrow_EmitsNothing()
+        {
+            // A sub-0x104-byte buffer has no scannable slot; the early-size guard prevents the
+            // (uint)(Data.Length-4) underflow that would otherwise blow up the loop bound.
+            var rom = CreateTestRom(0x80);
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.EmitGraphicsToolLZ77At(rom, list,
+                new Dictionary<uint, bool>(), compressBorderline: 0x40));
+            Assert.Null(ex);
+            Assert.Empty(list);
         }
 
         [Fact]
@@ -1040,30 +1054,44 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
-        public void EmitGraphicsToolLZ77_OnFe8_DoesNotThrow_WithPlantedBattleAnimeTable()
+        public void EmitGraphicsToolLZ77_BattleAnimeFrame_IsAddedToIgnoreSet_AndNotEmitted()
         {
-            // Exercise MakeBattleFrameAndOAMDictionary's N_-table walk against a real RomInfo
-            // (image_battle_animelist_pointer) by planting a small valid N_ table.
+            // Observable proof that MakeBattleFrameAndOAMDictionary's N_-table walk populates the ignore
+            // set: plant a valid LZ77 image at an N_ entry's frame pointer (+16). The N_ entry itself sits
+            // in the scan range and its +16 slot is a 0x08-tagged pointer to that image — so WITHOUT the
+            // ignore set the scan WOULD emit it. With the battle-anime builder it is ignored.
             var saved = CoreState.ROM;
             try
             {
                 var fe8 = MakeVersionedRom("BE8E01");
                 CoreState.ROM = fe8;
-                uint listPtr = fe8.RomInfo.image_battle_animelist_pointer; // RomInfo slot
-                uint nTable = 0x00A00000u;
+                uint borderline = fe8.RomInfo.compress_image_borderline_address; // FE8U = 0xDB000
+                uint listPtr = fe8.RomInfo.image_battle_animelist_pointer;        // RomInfo slot
+                uint nTable = 0x00A00000u;        // 4-padded, in-range
+                uint frameImage = 0x00E00000u;    // 4-padded, >= borderline
                 fe8.write_u32(U.toOffset(listPtr), Ptr(nTable));
-                // one entry (block 32): the 3 IsDataExists pointers at +12/+20/+24 + 5 LZ77 ptrs.
-                for (uint off = 0; off < 32; off += 4) fe8.write_u32(nTable + off, Ptr(0x00B00000u + off));
-                // terminator entry: all-zero -> IsDataExists false.
+                // one valid entry (block 32): IsDataExists needs pointers at +12/+20/+24; +16 is the frame.
+                for (uint off = 0; off < 32; off += 4) fe8.write_u32(nTable + off, Ptr(0x00C00000u + off));
+                fe8.write_u32(nTable + 16, Ptr(frameImage)); // frame pointer -> the planted image
+                // terminator entry: all-zero -> IsDataExists false (stops the N_ count at 1).
                 for (uint off = 0; off < 32; off += 4) fe8.write_u32(nTable + 32 + off, 0);
+                WriteLz77Image(fe8, frameImage, 32);
 
-                var ignore = new Dictionary<uint, bool>();
-                var ex = Record.Exception(() =>
-                    RebuildProducerCore.EmitGraphicsToolLZ77(fe8, new List<Address>()));
-                Assert.Null(ex);
-                // Direct builder coverage: the 5 entry pointers land in the ignore set.
-                // (Re-run the builder via the public path already did; assert the table walk reached them.)
-                Assert.True(U.isSafetyOffset(U.toOffset(listPtr) + 3, fe8));
+                Assert.True(frameImage >= borderline, "frameImage must be past the compress borderline");
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitGraphicsToolLZ77(fe8, list);
+                // The frame image was put in the ignore set by the battle-anime builder -> never emitted.
+                Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.LZ77IMG
+                                                 && a.Addr == frameImage);
+
+                // Control: with an EMPTY ignore set the SAME ROM DOES emit frameImage (proving the
+                // suppression above is the ignore set, not some other filter rejecting the candidate).
+                var control = new List<Address>();
+                RebuildProducerCore.EmitGraphicsToolLZ77At(fe8, control,
+                    new Dictionary<uint, bool>(), borderline);
+                Assert.Contains(control, a => a.DataType == Address.DataTypeEnum.LZ77IMG
+                                              && a.Addr == frameImage);
             }
             finally { CoreState.ROM = saved; }
         }

--- a/FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs
@@ -845,6 +845,265 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         // ====================================================================
+        // EmitGraphicsToolLZ77 / EmitGraphicsToolLZ77At — GraphicsToolForm
+        // .MakeLZ77DataList (slice 2y). The whole-ROM LZ77-image scan.
+        // ====================================================================
+        //
+        // The synthetic-ROM tests drive the scan via the EmitGraphicsToolLZ77At seam (the public
+        // method reads rom.RomInfo, which is NULL on a CreateTestRom). They pass an explicit
+        // ignoreDic + compressBorderline. The RomInfo-driven public EmitGraphicsToolLZ77 and its 3
+        // builders are exercised on a real versioned ROM further below.
+
+        /// <summary>Hand-author a VALID all-literal LZ77 stream (size a multiple of 32 so IsBadImageSize
+        /// passes) at <paramref name="offset"/>; returns its compressed byte length.</summary>
+        static uint WriteLz77Image(ROM rom, uint offset, int uncompSize)
+        {
+            var bytes = new List<byte> { 0x10,
+                (byte)(uncompSize & 0xFF), (byte)((uncompSize >> 8) & 0xFF), (byte)((uncompSize >> 16) & 0xFF) };
+            int written = 0;
+            while (written < uncompSize)
+            {
+                bytes.Add(0x00); // flag: next 8 bytes literal
+                for (int b = 0; b < 8 && written < uncompSize; b++, written++)
+                {
+                    bytes.Add((byte)(0x40 + (written & 0x3F)));
+                }
+            }
+            for (int i = 0; i < bytes.Count; i++) rom.write_u8(offset + (uint)i, bytes[i]);
+            uint clen = LZ77.getCompressedSize(rom.Data, offset);
+            Assert.True(clen > 0, "hand-authored LZ77 stream must be valid");
+            return clen;
+        }
+
+        [Fact]
+        public void EmitGraphicsToolLZ77At_PlantedLz77Image_EmitsLZ77IMG()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint pointerLoc = 0x0400;   // location of the candidate pointer (<= borderline -> trusted)
+            uint imageData = 0x2000;    // pointer target (>= borderline)
+            uint borderline = 0x1000;
+            uint clen = WriteLz77Image(rom, imageData, 32); // 32 = 1 tile, multiple of 32
+            rom.write_u32(pointerLoc, Ptr(imageData));
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitGraphicsToolLZ77At(rom, list,
+                new Dictionary<uint, bool>(), borderline);
+
+            Address img = list.Single(a => a.DataType == Address.DataTypeEnum.LZ77IMG);
+            Assert.Equal(imageData, img.Addr);
+            Assert.Equal(clen, img.Length);
+            Assert.Equal(pointerLoc, img.Pointer);
+        }
+
+        [Fact]
+        public void EmitGraphicsToolLZ77At_AddressInIgnoreDic_IsSkipped()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint pointerLoc = 0x0400;
+            uint imageData = 0x2000;
+            uint borderline = 0x1000;
+            WriteLz77Image(rom, imageData, 32);
+            rom.write_u32(pointerLoc, Ptr(imageData));
+
+            // The same valid image is now in the ignore set (e.g. a battle-anime frame) -> NOT emitted.
+            var ignore = new Dictionary<uint, bool> { [imageData] = true };
+            var list = new List<Address>();
+            RebuildProducerCore.EmitGraphicsToolLZ77At(rom, list, ignore, borderline);
+
+            Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.LZ77IMG);
+        }
+
+        [Fact]
+        public void EmitGraphicsToolLZ77At_AddressAlreadyInList_IsSkipped()
+        {
+            // WF MakeIgnoreDictionnaryFromList: an address already tracked in `list` is never re-emitted.
+            var rom = CreateTestRom(0x8000);
+            uint pointerLoc = 0x0400;
+            uint imageData = 0x2000;
+            uint borderline = 0x1000;
+            WriteLz77Image(rom, imageData, 32);
+            rom.write_u32(pointerLoc, Ptr(imageData));
+
+            var list = new List<Address>();
+            // Pre-seed the list with an Address at imageData (some other form already claimed it).
+            Address.AddAddress(list, imageData, 4, U.NOT_FOUND, "preexisting",
+                Address.DataTypeEnum.BIN);
+            RebuildProducerCore.EmitGraphicsToolLZ77At(rom, list,
+                new Dictionary<uint, bool>(), borderline);
+
+            Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.LZ77IMG);
+        }
+
+        [Fact]
+        public void EmitGraphicsToolLZ77At_BelowBorderlineTarget_IsSkipped()
+        {
+            // The pointer TARGET (the image) must be >= compress_image_borderline_address.
+            var rom = CreateTestRom(0x8000);
+            uint pointerLoc = 0x0400;
+            uint imageData = 0x0800;    // below the borderline -> rejected
+            uint borderline = 0x1000;
+            WriteLz77Image(rom, imageData, 32);
+            rom.write_u32(pointerLoc, Ptr(imageData));
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitGraphicsToolLZ77At(rom, list,
+                new Dictionary<uint, bool>(), borderline);
+
+            Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.LZ77IMG);
+        }
+
+        [Fact]
+        public void EmitGraphicsToolLZ77At_BadImageSize_IsSkipped()
+        {
+            // 40 is NOT a multiple of 32 -> IsBadImageSize -> not emitted.
+            var rom = CreateTestRom(0x8000);
+            uint pointerLoc = 0x0400;
+            uint imageData = 0x2000;
+            uint borderline = 0x1000;
+            WriteLz77Image(rom, imageData, 40);
+            rom.write_u32(pointerLoc, Ptr(imageData));
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitGraphicsToolLZ77At(rom, list,
+                new Dictionary<uint, bool>(), borderline);
+
+            Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.LZ77IMG);
+        }
+
+        [Fact]
+        public void EmitGraphicsToolLZ77At_ZeroedRom_EmitsNothing()
+        {
+            var rom = CreateTestRom(0x8000); // all zero -> Data[addr+3] never 0x08/0x09
+            var list = new List<Address>();
+            RebuildProducerCore.EmitGraphicsToolLZ77At(rom, list,
+                new Dictionary<uint, bool>(), compressBorderline: 0x1000);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitGraphicsToolLZ77At_NearEofCandidate_DoesNotThrow()
+        {
+            // A pointer near EOF whose target is also near EOF must not throw on the bound reads.
+            uint size = 0x4000;
+            var rom = CreateTestRom((int)size);
+            uint imageData = size - 0x40;       // a few bytes from EOF
+            uint borderline = 0x1000;
+            WriteLz77Image(rom, imageData, 32);
+            // Plant a pointer right at the last scannable slot.
+            uint pointerLoc = (size - 4) - 4;   // < length(=size-4), 4-aligned region
+            pointerLoc -= pointerLoc % 4;
+            rom.write_u32(pointerLoc, Ptr(imageData));
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.EmitGraphicsToolLZ77At(rom, list,
+                new Dictionary<uint, bool>(), borderline));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void EmitGraphicsToolLZ77At_Cancelled_StopsAfterFirstEmit()
+        {
+            var rom = CreateTestRom(0x8000);
+            uint borderline = 0x1000;
+            // Two distinct valid images at two scan slots.
+            uint imageA = 0x2000, imageB = 0x3000;
+            WriteLz77Image(rom, imageA, 32);
+            WriteLz77Image(rom, imageB, 32);
+            rom.write_u32(0x0400, Ptr(imageA));
+            rom.write_u32(0x0404, Ptr(imageB));
+
+            var cts = new CancellationTokenSource();
+            cts.Cancel(); // pre-cancelled: the loop emits the first match then returns.
+            var list = new List<Address>();
+            RebuildProducerCore.EmitGraphicsToolLZ77At(rom, list,
+                new Dictionary<uint, bool>(), borderline, cts.Token);
+            Assert.True(list.Count(a => a.DataType == Address.DataTypeEnum.LZ77IMG) <= 1);
+        }
+
+        [Fact]
+        public void EmitGraphicsToolLZ77_RealRom_BuildsIgnoreSetAndScans()
+        {
+            // The RomInfo-driven public method on a real FE8U ROM: the 3 builders populate the ignore set
+            // from RomInfo / the battle-anime N_-table, and the whole-ROM scan runs without throwing.
+            var saved = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                var list = new List<Address>();
+                var ex = Record.Exception(() => RebuildProducerCore.EmitGraphicsToolLZ77(fe8, list));
+                Assert.Null(ex);
+                // A blank-data versioned ROM has no real images, but the scan must complete cleanly.
+                // (Coverage of the ignore-set builders is via the dedicated builder tests below.)
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void EmitGraphicsToolLZ77_OnFe8_DoesNotThrow_WithPlantedBattleAnimeTable()
+        {
+            // Exercise MakeBattleFrameAndOAMDictionary's N_-table walk against a real RomInfo
+            // (image_battle_animelist_pointer) by planting a small valid N_ table.
+            var saved = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                uint listPtr = fe8.RomInfo.image_battle_animelist_pointer; // RomInfo slot
+                uint nTable = 0x00A00000u;
+                fe8.write_u32(U.toOffset(listPtr), Ptr(nTable));
+                // one entry (block 32): the 3 IsDataExists pointers at +12/+20/+24 + 5 LZ77 ptrs.
+                for (uint off = 0; off < 32; off += 4) fe8.write_u32(nTable + off, Ptr(0x00B00000u + off));
+                // terminator entry: all-zero -> IsDataExists false.
+                for (uint off = 0; off < 32; off += 4) fe8.write_u32(nTable + 32 + off, 0);
+
+                var ignore = new Dictionary<uint, bool>();
+                var ex = Record.Exception(() =>
+                    RebuildProducerCore.EmitGraphicsToolLZ77(fe8, new List<Address>()));
+                Assert.Null(ex);
+                // Direct builder coverage: the 5 entry pointers land in the ignore set.
+                // (Re-run the builder via the public path already did; assert the table walk reached them.)
+                Assert.True(U.isSafetyOffset(U.toOffset(listPtr) + 3, fe8));
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void AppendAllAsmStructPointers_UseOtherGraphics_RunsGraphicsToolLZ77()
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                var list = new List<Address>();
+                var ldrmap = RebuildProducerCore.BuildLdrMap(fe8);
+                var ex = Record.Exception(() => RebuildProducerCore.AppendAllAsmStructPointers(
+                    fe8, list, ldrmap, isUseOtherGraphics: true));
+                Assert.Null(ex);
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void AppendAllAsmStructPointers_UseOtherGraphicsFalse_EmitsNoLZ77IMG()
+        {
+            // The gate: with isUseOtherGraphics=false the GraphicsTool scan is intentionally skipped.
+            var saved = CoreState.ROM;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
+                var list = new List<Address>();
+                var ldrmap = RebuildProducerCore.BuildLdrMap(fe8);
+                RebuildProducerCore.AppendAllAsmStructPointers(fe8, list, ldrmap,
+                    isUseOtherGraphics: false);
+                Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.LZ77IMG);
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        // ====================================================================
         // EmitEventFunctionPointer — version split (real ROM)
         // ====================================================================
 
@@ -1047,8 +1306,8 @@ namespace FEBuilderGBA.Core.Tests
                 var res = RebuildProducerCore.AppendAllAsmStructPointers(fe8, list, ldrmap);
                 Assert.False(res.IsComplete);
                 Assert.Contains("PatchForm(MakePatchStructDataList)", res.NotYetPorted);
-                Assert.Contains("GraphicsToolForm", res.NotYetPorted);
-                // OAMSPForm is PORTED in slice 2w, ProcsScriptForm in slice 2x — NOT re-reported as deferred.
+                // OAMSPForm PORTED slice 2w, ProcsScriptForm 2x, GraphicsToolForm 2y — NOT re-reported.
+                Assert.DoesNotContain("GraphicsToolForm", res.NotYetPorted);
                 Assert.DoesNotContain("OAMSPForm", res.NotYetPorted);
                 Assert.DoesNotContain("ProcsScriptForm", res.NotYetPorted);
             }
@@ -1096,8 +1355,8 @@ namespace FEBuilderGBA.Core.Tests
         {
             string[] notYet = RebuildProducerCore.GetAsmNotYetPortedForms();
             Assert.Contains("PatchForm(MakePatchStructDataList)", notYet);
-            Assert.Contains("GraphicsToolForm", notYet);
             // The PORTED forms are NOT in the static deferred list.
+            Assert.DoesNotContain("GraphicsToolForm", notYet); // PORTED in slice 2y.
             Assert.DoesNotContain("OAMSPForm", notYet); // PORTED in slice 2w.
             Assert.DoesNotContain("ProcsScriptForm", notYet); // PORTED in slice 2x.
             Assert.DoesNotContain("EventScript(MakeEventASMMAPList)", notYet);

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -10593,10 +10593,13 @@ namespace FEBuilderGBA
         }
 
         /// <summary>VERBATIM port of <c>SoundFootStepsForm.MakeIgnoreDictionary</c>: add the foot-steps
-        /// data pointer to the ignore set so its LZ77 payload is not mistaken for a free image.</summary>
+        /// data pointer to the ignore set so its LZ77 payload is not mistaken for a free image.
+        /// EOF-HARDENING (beyond WF): the guard checks the slot's FULL u32 extent (+3) before the Core
+        /// <c>p32</c> read, since Core <c>p32</c> THROWS past EOF (WF's <c>isSafetyOffset</c> only checked
+        /// the slot's first byte).</summary>
         static void MakeSoundFootStepsIgnoreDictionary(ROM rom, Dictionary<uint, bool> dic)
         {
-            if (!U.isSafetyOffset(rom.RomInfo.sound_foot_steps_data_pointer, rom))
+            if (!U.isSafetyOffset(rom.RomInfo.sound_foot_steps_data_pointer + 3, rom))
             {
                 return;
             }
@@ -10606,11 +10609,19 @@ namespace FEBuilderGBA
 
         /// <summary>VERBATIM port of <c>WorldMapPointForm.MakeIgnoreDictionary</c>. NOTE the WF guard is on
         /// <c>sound_foot_steps_data_pointer</c> (not worldmap_scroll_somedata_pointer) — reproduced exactly,
-        /// quirk and all — then the worldmap-scroll-somedata pointer is added to the ignore set.</summary>
+        /// quirk and all — then the worldmap-scroll-somedata pointer is added to the ignore set.
+        /// EOF-HARDENING (beyond WF): Core <c>p32</c> THROWS on an out-of-range read, so even though the WF
+        /// guard checks the foot-steps slot, we additionally verify the worldmap-scroll slot's own full u32
+        /// extent before reading it — a trimmed/corrupt ROM with an in-bounds foot-steps slot but an
+        /// out-of-bounds worldmap slot would otherwise crash the producer.</summary>
         static void MakeWorldMapPointIgnoreDictionary(ROM rom, Dictionary<uint, bool> dic)
         {
             if (!U.isSafetyOffset(rom.RomInfo.sound_foot_steps_data_pointer, rom))
             {
+                return;
+            }
+            if (!U.isSafetyOffset(rom.RomInfo.worldmap_scroll_somedata_pointer + 3, rom))
+            {//worldmap slot's u32 would read past EOF — skip (WF would crash on Core p32 here).
                 return;
             }
             uint pointer = rom.p32(rom.RomInfo.worldmap_scroll_somedata_pointer);
@@ -10715,10 +10726,24 @@ namespace FEBuilderGBA
             // WF: MakeIgnoreDictionnaryFromList(ignoreDic, list) — every already-tracked address is ignored.
             MakeIgnoreDictionnaryFromList(ignoreDic, list);
 
+            // EOF guard: the scan reads rom.Data[addr+3] from addr=0x100, so a ROM smaller than 0x104
+            // bytes has no scannable slot. (Also prevents `(uint)Data.Length - 4` underflowing for a
+            // sub-4-byte buffer, which would make the loop bound enormous and the first read throw.)
+            if (rom.Data.Length < 0x104)
+            {
+                return;
+            }
+
             string name = R._("圧縮データ");
             uint length = (uint)rom.Data.Length - 4;
             for (uint addr = 0x100; addr < length; addr += 4)
             {
+                // Per-iteration cancellation (WF DoEvents was per-iteration too): keep the scan responsive
+                // even on a long run where no candidate passes the filters. Returns the partial list.
+                if (ct.IsCancellationRequested)
+                {
+                    return;
+                }
                 uint a = (uint)rom.Data[addr + 3];
                 if (a != 0x08 && a != 0x09)
                 {//ignore non-pointers.

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -10283,12 +10283,12 @@ namespace FEBuilderGBA
         //
         // Coverage honesty: like the data-path GetNotYetPortedForms, the ASM
         // producer never silently omits a form. AsmProducerResult.NotYetPorted
-        // lists the forms still blocked on an un-ported subsystem (the
-        // PatchForm patch-config scanner + GraphicsToolForm LZ77, each its own
-        // follow-up slice; OAMSPForm is PORTED in slice 2w, ProcsScriptForm in
-        // slice 2x — neither needed the WinForms AsmMapFileAsmCache), so
-        // AsmProducerResult.IsComplete stays false until they land — a wiring
-        // slice must not feed an incomplete list to a real defragment.
+        // lists the forms still blocked on an un-ported subsystem (now ONLY the
+        // PatchForm patch-config scanner, its own follow-up slice; OAMSPForm is
+        // PORTED in slice 2w, ProcsScriptForm in slice 2x, GraphicsToolForm LZ77
+        // in slice 2y — none needed the WinForms AsmMapFileAsmCache), so
+        // AsmProducerResult.IsComplete stays false until PatchForm lands — a
+        // wiring slice must not feed an incomplete list to a real defragment.
         // ====================================================================
 
         /// <summary>Result of <see cref="AppendAllAsmStructPointers"/>: the forms NOT yet
@@ -10343,9 +10343,13 @@ namespace FEBuilderGBA
                 // CONSUMES the ldrmap but no longer needs the WinForms AsmMapFileAsmCache: GetKnownArea is
                 // pure RomInfo reflection, IsStopFlagOn() is replaced by the threaded CancellationToken, and
                 // the 6c_name_ config dict loads headless-safe. So it is no longer in this deferred list.
-                // GraphicsToolForm.MakeLZ77DataList (only when isUseOtherGraphics) — the LZ77 graphics-
-                // tool subsystem. Out of scope for this foundation; DEFER.
-                "GraphicsToolForm",
+                // GraphicsToolForm.MakeLZ77DataList (only when isUseOtherGraphics) — PORTED in slice 2y
+                // (EmitGraphicsToolLZ77 + the 3 ignore-dict builders + IsBadImageSize/IsContinuousPointer).
+                // It needs no un-ported subsystem: the battle-anime ignore set reuses the slice-2s N_-table
+                // resolution, the foot-steps / worldmap-scroll ignore pointers are pure RomInfo p32 reads,
+                // and the whole-ROM LZ77 scan uses Core LZ77.getUncompressSize/getCompressedSize. When
+                // isUseOtherGraphics is false the form is intentionally SKIPPED (not unported), so it is
+                // never re-reported here.
                 // OAMSPForm.MakeAllDataLength(ldrmap) (only when isUseOAMSP) — PORTED in slice 2w
                 // (EmitOAMSP/EmitOAMSPCore + the two pure-binary CalcOAMSP* walkers). It does NOT depend
                 // on AsmMapFileAsmCache (unlike ProcsScriptForm), so it is no longer in this deferred
@@ -10380,7 +10384,8 @@ namespace FEBuilderGBA
         /// UnitIncreaseHeight/MapLoadFunction/MapMiniMap group on <c>ldrmap != null</c>. Only
         /// ProcsScript (deferred) actually consumes it; the other forms just need it present.</param>
         /// <param name="isUseOtherGraphics">WF <c>isUseOtherGraphics</c> — gates GraphicsToolForm
-        /// (deferred).</param>
+        /// (PORTED in slice 2y via <see cref="EmitGraphicsToolLZ77"/>; emitted only when this flag is
+        /// true, else intentionally skipped).</param>
         /// <param name="isUseOAMSP">WF <c>isUseOAMSP</c> — gates OAMSPForm (PORTED in slice 2w via
         /// <see cref="EmitOAMSP"/>; emitted only when this flag is true, else intentionally skipped).</param>
         public static AsmProducerResult AppendAllAsmStructPointers(ROM rom, List<Address> list,
@@ -10465,8 +10470,20 @@ namespace FEBuilderGBA
                 EmitMapMiniMapTerrain(rom, list);
             }
 
-            // WF: `if (isUseOtherGraphics)` -> GraphicsToolForm.MakeLZ77DataList — DEFERRED
-            // (stays in AsmNotYetPortedRaw regardless of the flag; nothing emitted here).
+            // WF: `if (isUseOtherGraphics)` -> GraphicsToolForm.MakeLZ77DataList — PORTED (slice 2y).
+            // The LZ77 graphics-tool whole-ROM scan (EmitGraphicsToolLZ77). It runs OUTSIDE the
+            // `ldrmap != null` block — gated solely on the flag (WF U.cs:2648). When the flag is false
+            // the form is intentionally SKIPPED (never re-reported in NotYetPorted, exactly like OAMSP).
+            if (isUseOtherGraphics)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    progress?.Report("AppendAllAsmStructPointers cancelled");
+                    return new AsmProducerResult(notYet, cancelled: true);
+                }
+                progress?.Report("GraphicsToolLZ77");
+                EmitGraphicsToolLZ77(rom, list, ct);
+            }
 
             // WF: `if (isUseOAMSP) { Debug.Assert(ldrmap != null); OAMSPForm.MakeAllDataLength(...); }`
             // PORTED (slice 2w). The form runs OUTSIDE the `ldrmap != null` block — gated solely on the
@@ -10486,6 +10503,273 @@ namespace FEBuilderGBA
             }
 
             return new AsmProducerResult(notYet, cancelled: false);
+        }
+
+        // ====================================================================
+        // slice 2y — GraphicsToolForm.MakeLZ77DataList (the isUseOtherGraphics
+        // whole-ROM LZ77-image scan). VERBATIM port of GraphicsToolForm.cs:1146.
+        //
+        // The method builds an ignore-set of the battle-anime frame/OAM/palette
+        // pointers + the foot-steps + worldmap-scroll pointers + every address
+        // already in `list`, then scans the ROM (0x100..EOF step 4) for LZ77
+        // blocks NOT in the ignore set and emits each as an LZ77IMG Address.
+        //
+        // EOF-HARDENING (Core u32/p32 THROW past EOF; WF's didn't): every
+        // computed read guards its FULL extent before the read — the 5
+        // p32(addr+12..28) in the battle-anime builder guard addr+31, the N_-table
+        // per-entry loop breaks at addr+block>Length, and the scan-loop pointer
+        // read p32(addr) is bounded by `addr < Length-4`. LZ77.getUncompressSize/
+        // getCompressedSize bound-check internally (return 0 past EOF).
+        // ====================================================================
+
+        /// <summary>VERBATIM port of <c>GraphicsToolForm.IsBadImageSize</c>: an LZ77 uncompressed size
+        /// is rejected unless it is a tile-sized multiple (>= 8*8/2, &lt; 8/2*32*8*32, % (8*8/2) == 0).</summary>
+        static bool IsBadImageSize(uint imageDataSize)
+        {
+            return (imageDataSize < (8 * 8 / 2)              // not compressed, or too small
+                || imageDataSize >= (8 / 2 * 32 * 8 * 32)    // too big
+                || imageDataSize % (8 * 8 / 2) != 0          // not divisible by 32 (8*8/2)
+                );
+        }
+
+        /// <summary>VERBATIM port of <c>GraphicsToolForm.IsContinuousPointer</c>: an image pointer in the
+        /// data region is trusted only when an adjacent slot also holds a safe pointer (images carry a
+        /// palette/TSA, so a lone pointer is suspicious). Pointers below the compress borderline (program
+        /// region) are always trusted. <paramref name="addr"/> is the location of the candidate pointer;
+        /// <paramref name="length"/> is the WF scan bound (<c>rom.Data.Length - 4</c>);
+        /// <paramref name="compressBorderline"/> is <c>rom.RomInfo.compress_image_borderline_address</c>
+        /// (passed in so the seam works on a RomInfo-less synthetic ROM).
+        /// EOF-HARDENING: the +checkRange reads guard their full u32 extent before reading.</summary>
+        static bool IsContinuousPointer(ROM rom, uint addr, uint length, uint compressBorderline)
+        {
+            if (addr <= compressBorderline)
+            {//program region — scattered pointers are OK
+                return true;
+            }
+
+            //data region — a real image pointer is part of a contiguous pointer run (palette/TSA siblings).
+            for (int checkRange = 4; checkRange <= 0x8; checkRange += 4)
+            {
+                uint a = (uint)(addr - checkRange);
+                if (!U.isSafetyOffset(a + 3, rom))
+                {//cannot safely read the preceding slot — skip it (WF read past 0; harden here)
+                    continue;
+                }
+                uint p = rom.u32(a);
+                if (U.isSafetyPointer(p, rom))
+                {//safe pointer
+                    return true;
+                }
+            }
+            for (int checkRange = 4; checkRange <= 0xC; checkRange += 4)
+            {
+                uint a = (uint)(addr + checkRange);
+                if (a + 4 >= length)
+                {
+                    break;
+                }
+                if (!U.isSafetyOffset(a + 3, rom))
+                {
+                    break;
+                }
+                uint p = rom.u32(a);
+                if (U.isSafetyPointer(p, rom))
+                {//safe pointer
+                    return true;
+                }
+            }
+            //probably a false match.
+            return false;
+        }
+
+        /// <summary>VERBATIM port of <c>GraphicsToolForm.MakeIgnoreDictionnaryFromList</c>: every address
+        /// already in the struct list is added to the ignore set (it is not a free LZ77 image).</summary>
+        static void MakeIgnoreDictionnaryFromList(Dictionary<uint, bool> dic, List<Address> list)
+        {
+            foreach (Address a in list)
+            {
+                dic[a.Addr] = true;
+            }
+        }
+
+        /// <summary>VERBATIM port of <c>SoundFootStepsForm.MakeIgnoreDictionary</c>: add the foot-steps
+        /// data pointer to the ignore set so its LZ77 payload is not mistaken for a free image.</summary>
+        static void MakeSoundFootStepsIgnoreDictionary(ROM rom, Dictionary<uint, bool> dic)
+        {
+            if (!U.isSafetyOffset(rom.RomInfo.sound_foot_steps_data_pointer, rom))
+            {
+                return;
+            }
+            uint pointer = rom.p32(rom.RomInfo.sound_foot_steps_data_pointer);
+            dic[pointer] = true; //foot-steps data — added to avoid confusion with compressed files
+        }
+
+        /// <summary>VERBATIM port of <c>WorldMapPointForm.MakeIgnoreDictionary</c>. NOTE the WF guard is on
+        /// <c>sound_foot_steps_data_pointer</c> (not worldmap_scroll_somedata_pointer) — reproduced exactly,
+        /// quirk and all — then the worldmap-scroll-somedata pointer is added to the ignore set.</summary>
+        static void MakeWorldMapPointIgnoreDictionary(ROM rom, Dictionary<uint, bool> dic)
+        {
+            if (!U.isSafetyOffset(rom.RomInfo.sound_foot_steps_data_pointer, rom))
+            {
+                return;
+            }
+            uint pointer = rom.p32(rom.RomInfo.worldmap_scroll_somedata_pointer);
+            dic[pointer] = true; //worldmap scroll-related data — added to avoid confusion with compressed files
+        }
+
+        /// <summary>VERBATIM port of <c>ImageBattleAnimeForm.MakeBattleFrameAndOAMDictionary</c>: walks the
+        /// battle-anime <c>N_Init</c> table (base/count/block resolved EXACTLY as in
+        /// <see cref="EmitImageBattleAnime"/> PART B — slice 2s) and adds each entry's 5 LZ77 pointers
+        /// (Section @ +12, frame @ +16, OAM1 @ +20, OAM2 @ +24, Palette @ +28) to the ignore set so the
+        /// whole-ROM scan never re-emits a battle-anime frame/OAM/palette as a free image.
+        /// EOF-HARDENING: each per-entry loop iteration guards addr+31 (the highest read p32(addr+28)
+        /// touches addr+28..+31) before the 5 reads, and breaks when an entry would run past EOF.</summary>
+        static void MakeBattleFrameAndOAMDictionary(ROM rom, Dictionary<uint, bool> dic)
+        {
+            // N_Init base/count/block — resolved identically to EmitImageBattleAnime PART B (slice 2s).
+            const uint nBlock = 32; // N_Init BlockSize.
+            uint nBasePointer = U.toOffset(rom.RomInfo.image_battle_animelist_pointer);
+            if (!U.isSafetyOffset(nBasePointer + 3, rom))
+            {
+                return;
+            }
+            uint nBaseAddr = rom.p32(nBasePointer);
+            if (!U.isSafetyOffset(nBaseAddr, rom))
+            {
+                return;
+            }
+
+            uint feditorHint = GetFEditorLengthHint(rom, nBaseAddr);
+            if (feditorHint >= 0xFF)
+            {//余りにでかいヒントは信じない
+                feditorHint = U.NOT_FOUND;
+            }
+
+            uint nDataCount = rom.getBlockDataCount(nBaseAddr, nBlock, (i, a) =>
+            {//N_Init IsDataExists. getBlockDataCount guards a+32<=Length, so u32(a+12/20/24) is in range.
+                if (U.isPointer(rom.u32(a + 12))
+                    && U.isPointer(rom.u32(a + 20))
+                    && U.isPointer(rom.u32(a + 24)))
+                {
+                    return true;
+                }
+                if (feditorHint != U.NOT_FOUND && i < feditorHint)
+                {//不明なデータではあるがFEditorがあるというので信用する.
+                    return true;
+                }
+                return false;
+            });
+
+            // WF: addr = N_InputFormRef.BaseAddress; for (i < DataCount; addr += BlockSize) { 5× p32 }.
+            uint addr = nBaseAddr;
+            for (uint i = 0; i < nDataCount; i++, addr += nBlock)
+            {
+                if (!U.isSafetyOffset(addr + (nBlock - 1), rom))
+                {//entry would run past EOF — the highest read p32(addr+28) needs addr+31 in range.
+                    break;
+                }
+                dic[rom.p32(addr + 12)] = true; //Section
+                dic[rom.p32(addr + 16)] = true; //frame
+                dic[rom.p32(addr + 20)] = true; //OAM1
+                dic[rom.p32(addr + 24)] = true; //OAM2
+                dic[rom.p32(addr + 28)] = true; //Palette
+            }
+        }
+
+        /// <summary>VERBATIM port of <c>GraphicsToolForm.MakeLZ77DataList</c> (slice 2y). Builds the
+        /// ignore set from the 4 builders above (all RomInfo-driven), then delegates the whole-ROM scan to
+        /// <see cref="EmitGraphicsToolLZ77At"/>. WF <c>InputFormRef.DoEvents</c> is replaced by the
+        /// threaded <paramref name="ct"/>. The only divergence vs WF is the static NAME prefix
+        /// (R._("圧縮データ") + the hex addr — cosmetic / relocation-identical).</summary>
+        public static void EmitGraphicsToolLZ77(ROM rom, List<Address> list, CancellationToken ct = default)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (list == null) throw new ArgumentNullException(nameof(list));
+
+            //誤爆すると面倒なことになるフレームとOAMのデータ群
+            Dictionary<uint, bool> ignoreDic = new Dictionary<uint, bool>();
+            MakeBattleFrameAndOAMDictionary(rom, ignoreDic);
+            MakeSoundFootStepsIgnoreDictionary(rom, ignoreDic);
+            MakeWorldMapPointIgnoreDictionary(rom, ignoreDic);
+            // NOTE: WF adds the existing struct list LAST (MakeIgnoreDictionnaryFromList) so the scan never
+            // re-emits an already-tracked address. EmitGraphicsToolLZ77At does this for us.
+
+            EmitGraphicsToolLZ77At(rom, list, ignoreDic,
+                rom.RomInfo.compress_image_borderline_address, ct);
+        }
+
+        /// <summary>The whole-ROM LZ77 scan half of <see cref="EmitGraphicsToolLZ77"/>, with the
+        /// RomInfo-derived inputs (the pre-built battle-anime/foot-steps/worldmap <paramref name="ignoreDic"/>
+        /// and the <paramref name="compressBorderline"/>) passed in explicitly so a RomInfo-less synthetic
+        /// ROM can exercise the scan/skip/EOF logic directly. Folds in the existing
+        /// <paramref name="list"/> addresses (WF <c>MakeIgnoreDictionnaryFromList</c>), then scans the ROM
+        /// (0x100..<c>Data.Length-4</c>, step 4) for LZ77 blocks not in the ignore set, emitting each as
+        /// an <c>LZ77IMG</c> <see cref="Address"/> (addr/length/pointer/type/order all match WF).</summary>
+        public static void EmitGraphicsToolLZ77At(ROM rom, List<Address> list,
+            Dictionary<uint, bool> ignoreDic, uint compressBorderline, CancellationToken ct = default)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (list == null) throw new ArgumentNullException(nameof(list));
+            if (ignoreDic == null) throw new ArgumentNullException(nameof(ignoreDic));
+
+            // WF: MakeIgnoreDictionnaryFromList(ignoreDic, list) — every already-tracked address is ignored.
+            MakeIgnoreDictionnaryFromList(ignoreDic, list);
+
+            string name = R._("圧縮データ");
+            uint length = (uint)rom.Data.Length - 4;
+            for (uint addr = 0x100; addr < length; addr += 4)
+            {
+                uint a = (uint)rom.Data[addr + 3];
+                if (a != 0x08 && a != 0x09)
+                {//ignore non-pointers.
+                    continue;
+                }
+                a = rom.p32(addr);
+                if (!U.isSafetyOffset(a, rom))
+                {//ignore dangerous pointers
+                    continue;
+                }
+                if (a < compressBorderline)
+                {
+                    continue;
+                }
+                if (!U.isPadding4(a))
+                {//an lz77 image is always 4-byte padded — anything else cannot be one.
+                    continue;
+                }
+
+                if (ignoreDic.ContainsKey(a))
+                {//battle-anime frame/OAM/etc. lz77 data — skip
+                    continue;
+                }
+
+                //is the pointer target compressed?
+                uint imageDataSize = LZ77.getUncompressSize(rom.Data, a);
+                if (IsBadImageSize(imageDataSize))
+                {
+                    continue;
+                }
+
+                //image pointers appear contiguously — check that.
+                if (!IsContinuousPointer(rom, addr, length, compressBorderline))
+                {
+                    continue;
+                }
+
+                uint getcompsize = LZ77.getCompressedSize(rom.Data, a);
+                if (getcompsize == 0)
+                {
+                    continue;
+                }
+
+                //probably an image.
+                Address.AddAddress(list, a, getcompsize, addr, name + U.To0xHexString(a),
+                    Address.DataTypeEnum.LZ77IMG);
+                if (ct.IsCancellationRequested)
+                {
+                    return;
+                }
+            }
         }
 
         // ---- the 6 ldrmap-FREE InputFormRef-table forms (ported) -----------


### PR DESCRIPTION
## Summary

Slice **2y** of the #1261 ROM-rebuild producer marathon (porting `U.AppendAllASMStructPointersList` form-by-form into `RebuildProducerCore`).

Ports `GraphicsToolForm.MakeLZ77DataList` — the `isUseOtherGraphics` whole-ROM LZ77-image scan — into the Core ASM-path producer. This is the **second-to-last** ASM-path form: after this slice the ASM producer's `AsmNotYetPortedRaw` has only **one** entry left, `PatchForm(MakePatchStructDataList)`.

## What was ported

Faithful WinForms → Core reproduction of:
- `GraphicsToolForm.MakeLZ77DataList` / `IsBadImageSize` / `IsContinuousPointer` / `MakeIgnoreDictionnaryFromList` (`FEBuilderGBA/GraphicsToolForm.cs:1095-1206`)
- `SoundFootStepsForm.MakeIgnoreDictionary` (`SoundFootStepsForm.cs:138-146`)
- `WorldMapPointForm.MakeIgnoreDictionary` (`WorldMapPointForm.cs:294-302`) — the quirky guard-on-`sound_foot_steps_data_pointer` is reproduced **verbatim**
- `ImageBattleAnimeForm.MakeBattleFrameAndOAMDictionary` (`ImageBattleAnimeForm.cs:886-899`) — the battle-anime `N_`-table base/count/block resolution is **reused** from the slice-2s `EmitImageBattleAnime` PART B, not re-derived

## Implementation

`FEBuilderGBA.Core/RebuildProducerCore.cs`:
- `EmitGraphicsToolLZ77` — RomInfo-driven public entry: builds the ignore set from the 4 builders, then delegates to the scan seam.
- `EmitGraphicsToolLZ77At` — the whole-ROM scan (`0x100..Data.Length-4`, step 4), with the RomInfo-derived ignore set + `compress_image_borderline_address` passed in explicitly so a RomInfo-less synthetic ROM drives it directly.
- Wired into `AppendAllAsmStructPointers` gated on `isUseOtherGraphics` (WF `U.cs:2648-2652`) — **outside** the `ldrmap != null` block, like OAMSP. When the flag is false the form is intentionally skipped (never re-reported as deferred).
- Removed `"GraphicsToolForm"` from `AsmNotYetPortedRaw`.

## Corruption safety

Core `u32`/`p32` **throw** past EOF (WF's did not), so every computed read guards its full extent first: the 5 `p32(addr+12..28)` in the battle-anime builder guard `addr+31` and break when an entry runs past EOF; the scan-loop pointer read is bounded by `addr < Data.Length-4`; `LZ77.getUncompressSize`/`getCompressedSize` bound-check internally. `addr`/`length`/`pointer`/`LZ77IMG` type / emission-order / skip-conditions all match WF; the only divergence is the static name prefix (cosmetic / relocation-identical).

## Scope

**Part of #1261.** This leaves only `PatchForm(MakePatchStructDataList)` deferred in the ASM-path producer.

## Test plan

All automated in `FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs` (+12 tests, producer count **363 → 375**, all green):

- [x] Planted hand-authored LZ77 image emits an `LZ77IMG` Address with the right addr / length / pointer
- [x] An address in the ignore dict is skipped
- [x] An address already in the struct `list` is skipped (`MakeIgnoreDictionnaryFromList`)
- [x] A pointer target below the compress borderline is skipped
- [x] A non-multiple-of-32 uncompressed size (`IsBadImageSize`) is skipped
- [x] A zeroed ROM emits nothing
- [x] A near-EOF candidate does not throw
- [x] Cancellation stops after the first emit
- [x] The 3 RomInfo/battle-anime ignore-set builders run on a real `BE8E01` ROM without throwing (+ planted N_-table walk)
- [x] `isUseOtherGraphics=true` runs the scan via `AppendAllAsmStructPointers`
- [x] `isUseOtherGraphics=false` emits no `LZ77IMG` (the gate)
- [x] Deferred-form coverage honesty: `GraphicsToolForm` no longer in `NotYetPorted`; only `PatchForm` remains
- [x] `dotnet build FEBuilderGBA.sln` clean (0 errors)

The 10 `SkillSystemsAnime*` / `SkillConfig*` Core.Tests failures are the known-env `config/patch2` unchecked-out submodule (pass in CI), pre-existing on `origin/master` — not a regression.

Core-only (no GUI) — no screenshot, like the prior 23 producer slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
