### PR TITLE
feat(core): wire ROM-rebuild producer→RebuildMakeCore.Make (IsComplete-gated) + WF-parity harness (#1261)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -647,10 +647,10 @@ namespace FEBuilderGBA.Core.Tests
                 //  per-entry EventScriptForm.ScanScript expansion.)
                 Assert.Contains("MonsterWMapProbabilityForm", notYet2b);
                 Assert.Contains("EventBattleTalkForm", notYet2b);
-                // (MapTileAnimation1Form is now PORTED in slice 2g and the MapTerrain lookup tables in
-                //  slice 2j — the still-deferred misc sibling SongTableForm [SongUtil.ParseTrack /
-                //  RecycleOldInstrument not in Core] stays tracked here instead.)
-                Assert.Contains("SongTableForm", notYet2b);
+                // (MapTileAnimation1Form is now PORTED in slice 2g, the MapTerrain lookup tables in
+                //  slice 2j, and SongTableForm in slice 2r — so the still-deferred misc sibling tracked
+                //  here is UnitCustomBattleAnimeForm [per-unit custom battle-anime recycle, not in Core].)
+                Assert.Contains("UnitCustomBattleAnimeForm", notYet2b);
 
                 // FAITHFULNESS / COMPLETENESS-SAFETY: ItemForm is NOT emitted (its StatBooster
                 // sub-block size needs un-ported PatchUtil detection) — it must be absent from the
@@ -7783,11 +7783,14 @@ namespace FEBuilderGBA.Core.Tests
                 var list = new List<Address>();
                 RebuildProducerCore.EmitImageTSAAnime(rom, list);
 
-                // Main IFR: base baseTbl, block 12, count 2 (atoh("002")==2), length 12*(2+1)=36,
-                // pointer slot, PI {0,4,8}.
+                // Main IFR: base baseTbl, block 12, count 2 (atoh("002")==2), length 12*(2+1)=36, PI {0,4,8}.
+                // WF parity (#1261 2z-wire): the main IFR Pointer is NOT_FOUND, not the config slot —
+                // WF's ImageTSAAnimeForm.Init constructs the InputFormRef with pointer 0 and ReInit(addr,
+                // count) never sets BasePointer, so AddAddress(IFR) emits Pointer == NOT_FOUND. (Verified
+                // against the WinForms producer by the FEBuilderGBA.Tests WF-parity harness on FE8U.)
                 Address mainIfr = list.Single(a => a.Info == "TSAANIME MyAnime " && a.BlockSize == 12);
                 Assert.Equal(baseTbl, mainIfr.Addr);
-                Assert.Equal(slot, mainIfr.Pointer);
+                Assert.Equal(U.NOT_FOUND, mainIfr.Pointer);
                 Assert.Equal(12u * 3u, mainIfr.Length);
                 Assert.Equal(Address.DataTypeEnum.InputFormRef, mainIfr.DataType);
                 Assert.Equal(new uint[] { 0, 4, 8 }, mainIfr.PointerIndexes);
@@ -8740,6 +8743,298 @@ namespace FEBuilderGBA.Core.Tests
             // no-duplicates invariant still holds.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
             Assert.Equal(raw.Length, raw.Distinct().Count());
+        }
+
+        // ====================================================================
+        // slice 2z-wire (#1261): MakeWithProducer — the IsComplete-gated bridge
+        // from the producers to RebuildMakeCore.Make.
+        //
+        // The internal seam (ProducerResult/AsmProducerResult overload) lets us
+        // exercise the Make-DELEGATION path with a SYNTHETIC complete result —
+        // which the live producers cannot currently yield while PatchForm and the
+        // remaining data-path forms stay deferred — and the THROW path with an
+        // incomplete / cancelled result. The seam still applies the same gate; it
+        // is not a bypass.
+        // ====================================================================
+
+        sealed class WireTempDir : IDisposable
+        {
+            public string Path { get; }
+            public WireTempDir()
+            {
+                Path = System.IO.Path.Combine(
+                    System.IO.Path.GetTempPath(), "feb_make_wire_" + Guid.NewGuid().ToString("N"));
+                System.IO.Directory.CreateDirectory(Path);
+            }
+            public void Dispose() { try { System.IO.Directory.Delete(Path, true); } catch { } }
+        }
+
+        // A minimal modified-ROM + vanilla + struct list that RebuildMakeCore.Make accepts and
+        // emits a non-empty manifest for. Mirrors the RebuildCoreTests round-trip layout: a header,
+        // two pointer fields in the non-rebuild region pointing at two BIN structs in the rebuild
+        // region. CoreState.ROM MUST be the modified ROM (the Address ctor + emitter validate against it).
+        const uint WIRE_REBUILD_ADDR = 0x1000;
+        static byte[] BuildWireModified()
+        {
+            byte[] rom = new byte[0x10000];
+            for (uint i = 0; i < 0x100; i++) rom[i] = (byte)(0x11 + i);
+            // PTR_B @ 0x200 -> struct B @ 0x4000 ; PTR_C @ 0x204 -> struct C @ 0x8000
+            WireU32(rom, 0x200, 0x08000000 + 0x4000);
+            WireU32(rom, 0x204, 0x08000000 + 0x8000);
+            for (uint i = 0; i < 0x20; i++) rom[0x1000 + i] = (byte)(0xA0 + i); // struct A (stays)
+            for (uint i = 0; i < 0x30; i++) rom[0x4000 + i] = (byte)(0xB0 + i); // struct B (relocates)
+            for (uint i = 0; i < 0x40; i++) rom[0x8000 + i] = (byte)(0xC0 + i); // struct C (relocates)
+            return rom;
+        }
+        static void WireU32(byte[] rom, uint off, uint val)
+        {
+            rom[off + 0] = (byte)(val & 0xFF);
+            rom[off + 1] = (byte)((val >> 8) & 0xFF);
+            rom[off + 2] = (byte)((val >> 16) & 0xFF);
+            rom[off + 3] = (byte)((val >> 24) & 0xFF);
+        }
+        static ROM BuildWireVanilla()
+        {
+            byte[] data = new byte[0x1000];
+            for (uint i = 0; i < 0x100; i++) data[i] = (byte)(0x11 + i);
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(data);
+            return rom;
+        }
+        static List<Address> BuildWireStructList()
+        {
+            return new List<Address>
+            {
+                new Address(0x200, 4, U.NOT_FOUND, "PTR_B", Address.DataTypeEnum.POINTER),
+                new Address(0x204, 4, U.NOT_FOUND, "PTR_C", Address.DataTypeEnum.POINTER),
+                new Address(0x1000, 0x20, U.NOT_FOUND, "STRUCT_A", Address.DataTypeEnum.BIN),
+                new Address(0x4000, 0x30, 0x08000000 + 0x200, "STRUCT_B", Address.DataTypeEnum.BIN),
+                new Address(0x8000, 0x40, 0x08000000 + 0x204, "STRUCT_C", Address.DataTypeEnum.BIN),
+            };
+        }
+
+        [Fact]
+        public void MakeWithProducer_IncompleteAsm_Throws_NamesDeferredForm_NoManifest()
+        {
+            var prevRom = CoreState.ROM;
+            try
+            {
+                var modifiedRom = new ROM();
+                byte[] modified = BuildWireModified();
+                modifiedRom.SwapNewROMDataDirect((byte[])modified.Clone());
+                CoreState.ROM = modifiedRom;
+
+                ROM vanilla = BuildWireVanilla();
+                var structList = BuildWireStructList();
+
+                // Data path complete, ASM path still defers PatchForm — the real current-master shape.
+                var data = new RebuildProducerCore.ProducerResult(structList, new string[0], cancelled: false);
+                var asm = new RebuildProducerCore.AsmProducerResult(
+                    new[] { "PatchForm(MakePatchStructDataList)" }, cancelled: false);
+
+                using (var tmp = new WireTempDir())
+                {
+                    string manifestPath = System.IO.Path.Combine(tmp.Path, "wire.rebuild");
+                    var ex = Assert.Throws<InvalidOperationException>(() =>
+                        RebuildProducerCore.MakeWithProducer(
+                            data, asm, modified, vanilla, WIRE_REBUILD_ADDR, structList, manifestPath));
+
+                    // The message NAMES the deferred form so the caller can tell the user exactly what's pending.
+                    Assert.Contains("PatchForm(MakePatchStructDataList)", ex.Message);
+                    // GUARD: Make was NOT invoked — no manifest written.
+                    Assert.False(System.IO.File.Exists(manifestPath),
+                        "incomplete producer must NOT drive Make (no manifest)");
+                }
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+            }
+        }
+
+        [Fact]
+        public void MakeWithProducer_IncompleteData_Throws_NoManifest()
+        {
+            var prevRom = CoreState.ROM;
+            try
+            {
+                var modifiedRom = new ROM();
+                byte[] modified = BuildWireModified();
+                modifiedRom.SwapNewROMDataDirect((byte[])modified.Clone());
+                CoreState.ROM = modifiedRom;
+
+                ROM vanilla = BuildWireVanilla();
+                var structList = BuildWireStructList();
+
+                // Data path incomplete (a deferred data-path form), ASM path complete.
+                var data = new RebuildProducerCore.ProducerResult(
+                    structList, new[] { "ItemForm" }, cancelled: false);
+                var asm = new RebuildProducerCore.AsmProducerResult(new string[0], cancelled: false);
+
+                using (var tmp = new WireTempDir())
+                {
+                    string manifestPath = System.IO.Path.Combine(tmp.Path, "wire.rebuild");
+                    var ex = Assert.Throws<InvalidOperationException>(() =>
+                        RebuildProducerCore.MakeWithProducer(
+                            data, asm, modified, vanilla, WIRE_REBUILD_ADDR, structList, manifestPath));
+                    Assert.Contains("ItemForm", ex.Message);
+                    Assert.False(System.IO.File.Exists(manifestPath));
+                }
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+            }
+        }
+
+        [Fact]
+        public void MakeWithProducer_Cancelled_ThrowsOperationCanceled_NoManifest()
+        {
+            var prevRom = CoreState.ROM;
+            try
+            {
+                var modifiedRom = new ROM();
+                byte[] modified = BuildWireModified();
+                modifiedRom.SwapNewROMDataDirect((byte[])modified.Clone());
+                CoreState.ROM = modifiedRom;
+
+                ROM vanilla = BuildWireVanilla();
+                var structList = BuildWireStructList();
+
+                // Both halves "complete" by coverage, but the data half was CANCELLED mid-run
+                // (partial list) — must never reach Make even though NotYetPorted is empty.
+                var data = new RebuildProducerCore.ProducerResult(structList, new string[0], cancelled: true);
+                var asm = new RebuildProducerCore.AsmProducerResult(new string[0], cancelled: false);
+
+                using (var tmp = new WireTempDir())
+                {
+                    string manifestPath = System.IO.Path.Combine(tmp.Path, "wire.rebuild");
+                    Assert.Throws<OperationCanceledException>(() =>
+                        RebuildProducerCore.MakeWithProducer(
+                            data, asm, modified, vanilla, WIRE_REBUILD_ADDR, structList, manifestPath));
+                    Assert.False(System.IO.File.Exists(manifestPath),
+                        "cancelled producer must NOT drive Make (no manifest)");
+                }
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+            }
+        }
+
+        [Fact]
+        public void MakeWithProducer_BothComplete_DelegatesToMake_WritesManifest()
+        {
+            var prevRom = CoreState.ROM;
+            try
+            {
+                var modifiedRom = new ROM();
+                byte[] modified = BuildWireModified();
+                modifiedRom.SwapNewROMDataDirect((byte[])modified.Clone());
+                CoreState.ROM = modifiedRom;
+
+                ROM vanilla = BuildWireVanilla();
+                var structList = BuildWireStructList();
+
+                // SYNTHETIC complete results (empty NotYetPorted) — the live producers cannot
+                // yield these while PatchForm stays deferred, so the seam is the only way to prove
+                // the Make-delegation path actually runs.
+                var data = new RebuildProducerCore.ProducerResult(structList, new string[0], cancelled: false);
+                var asm = new RebuildProducerCore.AsmProducerResult(new string[0], cancelled: false);
+
+                using (var tmp = new WireTempDir())
+                {
+                    string manifestPath = System.IO.Path.Combine(tmp.Path, "wire.rebuild");
+                    // Must NOT throw — both halves complete ⇒ Make runs.
+                    RebuildProducerCore.MakeWithProducer(
+                        data, asm, modified, vanilla, WIRE_REBUILD_ADDR, structList, manifestPath);
+
+                    // Make ran: the manifest file + its @-token columns exist.
+                    Assert.True(System.IO.File.Exists(manifestPath),
+                        "complete producer must drive Make (manifest written)");
+                    string manifest = System.IO.File.ReadAllText(manifestPath);
+                    Assert.Contains("@_REBUILDADDRESS ", manifest);
+                    Assert.Contains("@BIN ", manifest);   // structs A/B/C emit as fixed BIN
+                }
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+            }
+        }
+
+        [Fact]
+        public void MakeWithProducer_PublicEntry_RealProducer_RefusesAndNamesPending_NoManifest()
+        {
+            // Public-entry / current-master SMOKE: the real producer path (env-gated on a ROM)
+            // must REFUSE (the gate is closed while forms stay deferred) and name the pending forms,
+            // and must create no output. Skips cleanly when no ROM is present (CI / most worktrees).
+            string romPath = FindTestRom();
+            if (romPath == null) return; // skip when no ROM available (env-only)
+
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var rom = new ROM();
+                if (!rom.Load(romPath, out string _)) return; // skip
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+
+                ROM vanilla = BuildWireVanilla();
+
+                using (var tmp = new WireTempDir())
+                {
+                    string manifestPath = System.IO.Path.Combine(tmp.Path, "real.rebuild");
+                    var ex = Assert.Throws<InvalidOperationException>(() =>
+                        RebuildProducerCore.MakeWithProducer(
+                            rom, vanilla, WIRE_REBUILD_ADDR, manifestPath,
+                            isUseOtherGraphics: true, isUseOAMSP: false));
+
+                    // The ASM half always keeps PatchForm deferred, so the gate always names it.
+                    Assert.Contains("PatchForm(MakePatchStructDataList)", ex.Message);
+                    Assert.False(System.IO.File.Exists(manifestPath),
+                        "real (incomplete) producer must refuse — no manifest");
+                }
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
+        }
+
+        [Fact]
+        public void BuildRebuildLdrMap_UsesWFRebuildArgs_BoundedPointerOnly()
+        {
+            // The rebuild-specific LDR map MUST match WF ToolROMRebuildMake.cs:818 — bounded to the
+            // compress borderline + pointer-only — NOT the whole-ROM cache map (BuildLdrMap). Prove the
+            // construction differs from the cache builder so the ASM producers get WF-faithful input.
+            string romPath = FindTestRom();
+            if (romPath == null) return; // skip when no ROM available (env-only)
+
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var rom = new ROM();
+                if (!rom.Load(romPath, out string _)) return; // skip
+                CoreState.ROM = rom;
+
+                var rebuildMap = RebuildProducerCore.BuildRebuildLdrMap(rom);
+                // Byte-exact equality with the WF rebuild args.
+                var expected = DisassemblerTrumb.MakeLDRMap(
+                    rom.Data, 0x100, rom.RomInfo.compress_image_borderline_address, true);
+                Assert.Equal(expected.Count, rebuildMap.Count);
+
+                // The bounded+pointer-only map is a strict subset of the whole-ROM cache map: every
+                // entry is at/below the compress borderline AND points at a real pointer.
+                uint border = rom.RomInfo.compress_image_borderline_address;
+                Assert.All(rebuildMap, e => Assert.True(e.ldr_address < border + 4));
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+            }
         }
     }
 }

--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -8837,7 +8837,7 @@ namespace FEBuilderGBA.Core.Tests
                     string manifestPath = System.IO.Path.Combine(tmp.Path, "wire.rebuild");
                     var ex = Assert.Throws<InvalidOperationException>(() =>
                         RebuildProducerCore.MakeWithProducer(
-                            data, asm, modified, vanilla, WIRE_REBUILD_ADDR, structList, manifestPath));
+                            data, asm, modified, vanilla, WIRE_REBUILD_ADDR, manifestPath));
 
                     // The message NAMES the deferred form so the caller can tell the user exactly what's pending.
                     Assert.Contains("PatchForm(MakePatchStructDataList)", ex.Message);
@@ -8876,7 +8876,7 @@ namespace FEBuilderGBA.Core.Tests
                     string manifestPath = System.IO.Path.Combine(tmp.Path, "wire.rebuild");
                     var ex = Assert.Throws<InvalidOperationException>(() =>
                         RebuildProducerCore.MakeWithProducer(
-                            data, asm, modified, vanilla, WIRE_REBUILD_ADDR, structList, manifestPath));
+                            data, asm, modified, vanilla, WIRE_REBUILD_ADDR, manifestPath));
                     Assert.Contains("ItemForm", ex.Message);
                     Assert.False(System.IO.File.Exists(manifestPath));
                 }
@@ -8911,7 +8911,7 @@ namespace FEBuilderGBA.Core.Tests
                     string manifestPath = System.IO.Path.Combine(tmp.Path, "wire.rebuild");
                     Assert.Throws<OperationCanceledException>(() =>
                         RebuildProducerCore.MakeWithProducer(
-                            data, asm, modified, vanilla, WIRE_REBUILD_ADDR, structList, manifestPath));
+                            data, asm, modified, vanilla, WIRE_REBUILD_ADDR, manifestPath));
                     Assert.False(System.IO.File.Exists(manifestPath),
                         "cancelled producer must NOT drive Make (no manifest)");
                 }
@@ -8947,7 +8947,7 @@ namespace FEBuilderGBA.Core.Tests
                     string manifestPath = System.IO.Path.Combine(tmp.Path, "wire.rebuild");
                     // Must NOT throw — both halves complete ⇒ Make runs.
                     RebuildProducerCore.MakeWithProducer(
-                        data, asm, modified, vanilla, WIRE_REBUILD_ADDR, structList, manifestPath);
+                        data, asm, modified, vanilla, WIRE_REBUILD_ADDR, manifestPath);
 
                     // Make ran: the manifest file + its @-token columns exist.
                     Assert.True(System.IO.File.Exists(manifestPath),

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -10610,9 +10610,11 @@ namespace FEBuilderGBA
             AsmProducerResult asm = AppendAllAsmStructPointers(
                 rom, data.List, ldrmap, isUseOtherGraphics, isUseOAMSP, progress, ct);
 
-            // 3) + 4) gate (cancel + IsComplete) then delegate.
+            // 3) + 4) gate (cancel + IsComplete) then delegate. The internal seam emits data.List
+            //    itself — the ASM producer above appended into that same list, so the gated result
+            //    and the relocated list are guaranteed identical.
             MakeWithProducer(
-                data, asm, rom.Data, vanilla, rebuildAddress, data.List, manifestPath,
+                data, asm, rom.Data, vanilla, rebuildAddress, manifestPath,
                 romVersion: rom.RomInfo.version,
                 nameResolver: null,
                 eventScriptWithPatch: CoreState.EventScript,
@@ -10630,12 +10632,14 @@ namespace FEBuilderGBA
         /// <c>NotYetPorted</c>) — which the live producers cannot currently produce while PatchForm and
         /// the remaining data-path forms stay deferred — and the throw path with an incomplete result.
         /// </summary>
-        /// <param name="data">The data-path result (gated on <see cref="ProducerResult.IsComplete"/>).</param>
+        /// <param name="data">The data-path result; the gate is applied to it AND <see cref="ProducerResult.List"/>
+        /// is the EXACT list emitted to <see cref="RebuildMakeCore.Make"/> — there is no separate list
+        /// parameter, so the gated result and the relocated list can never diverge (Copilot PR #1302 review).
+        /// The ASM-path producer must have appended into this same <c>data.List</c>.</param>
         /// <param name="asm">The ASM-path result (gated on <see cref="AsmProducerResult.IsComplete"/>).</param>
         /// <param name="modified">The modified ROM bytes to defragment (was <c>rom.Data</c>).</param>
         /// <param name="vanilla">The unmodified base ROM.</param>
         /// <param name="rebuildAddress">Offset at/after which data is rebuilt.</param>
-        /// <param name="structList">The combined struct list to emit (normally <c>data.List</c>).</param>
         /// <param name="manifestPath">Output <c>.rebuild</c> path.</param>
         /// <param name="romVersion">FE game version forwarded to Make.</param>
         /// <param name="nameResolver">Optional symbol-name resolver forwarded to Make.</param>
@@ -10647,7 +10651,7 @@ namespace FEBuilderGBA
         /// <param name="ct">Cancellation token.</param>
         internal static void MakeWithProducer(
             ProducerResult data, AsmProducerResult asm,
-            byte[] modified, ROM vanilla, uint rebuildAddress, List<Address> structList, string manifestPath,
+            byte[] modified, ROM vanilla, uint rebuildAddress, string manifestPath,
             int romVersion = 8,
             Func<uint, string> nameResolver = null,
             EventScript eventScriptWithPatch = null,
@@ -10661,7 +10665,7 @@ namespace FEBuilderGBA
             if (asm == null) throw new ArgumentNullException(nameof(asm));
             if (modified == null) throw new ArgumentNullException(nameof(modified));
             if (vanilla == null) throw new ArgumentNullException(nameof(vanilla));
-            if (structList == null) throw new ArgumentNullException(nameof(structList));
+            if (data.List == null) throw new ArgumentException("data.List must not be null.", nameof(data));
             if (string.IsNullOrEmpty(manifestPath)) throw new ArgumentNullException(nameof(manifestPath));
 
             // CANCEL: a cancelled producer returned a PARTIAL list — never feed it to Make.
@@ -10693,9 +10697,10 @@ namespace FEBuilderGBA
                     + "as free) = silent ROM corruption. The rebuild stays disabled until coverage is complete.");
             }
 
-            // COMPLETE: safe to defragment.
+            // COMPLETE: safe to defragment. Emit data.List itself (the exact list the gate guarded) —
+            // never a caller-supplied alias that could have diverged from the gated result.
             RebuildMakeCore.Make(
-                modified, vanilla, rebuildAddress, structList, manifestPath,
+                modified, vanilla, rebuildAddress, data.List, manifestPath,
                 nameResolver: nameResolver,
                 romVersion: romVersion,
                 eventScriptWithPatch: eventScriptWithPatch,

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -2243,9 +2243,16 @@ namespace FEBuilderGBA
                 string basename = "TSAANIME " + U.at(pair.Value, 1) + " ";
 
                 // Main IFR: ReInit(addr, count) -> BaseAddress addr, DataCount count; AddAddress(IFR, ...)
-                // length = block * (count + 1), pointer = BasePointer (= pointer here, safe).
+                // length = block * (count + 1). WF parity (#1261 2z-wire): ImageTSAAnimeForm.Init's
+                // InputFormRef is constructed with pointer arg 0, and ReInit(addr, count) updates ONLY
+                // BaseAddress/DataCount — it never sets BasePointer. So WF's AddAddress(IFR) reads
+                // BasePointer == 0, fails isSafetyOffset, and emits Pointer == NOT_FOUND (verified against
+                // the WinForms producer on FE8U). Emitting the config-table slot pointer here instead
+                // would make the rebuild back-patch a slot WF leaves alone = divergence. Match WF exactly.
+                // (NOTE: EmitImageTSAAnime2's main IFR already uses NOT_FOUND for the same reason; its N1
+                // IFR keeps the slot pointer because WF reaches it via ReInitPointer, which DOES set it.)
                 uint length = block * (count + 1);
-                list.Add(new Address(addr, length, pointer, basename,
+                list.Add(new Address(addr, length, U.NOT_FOUND, basename,
                     Address.DataTypeEnum.InputFormRef, block, new uint[] { 0, 4, 8 }));
 
                 for (uint i = 0; i < count; i++, addr += block)
@@ -10503,6 +10510,199 @@ namespace FEBuilderGBA
             }
 
             return new AsmProducerResult(notYet, cancelled: false);
+        }
+
+        // ====================================================================
+        // slice 2z-wire (#1261) — drive RebuildMakeCore.Make from the producers,
+        // GATED on IsComplete.
+        //
+        // CORRUPTION MODEL (why the gate is mandatory): RebuildMakeCore.Make
+        // emits a .rebuild manifest from ONLY the caller-supplied structList.
+        // The rebuild treats every ROM region NOT named in that list as free
+        // and droppable (AsmMapFile.MakeFreeDataList uses the COMPLEMENT of the
+        // listed structs; Make carries only the listed structs into the rebuilt
+        // ROM). So a Make driven by an INCOMPLETE producer silently drops or
+        // mis-types the bytes the producer failed to enumerate = silent ROM
+        // corruption. Therefore MakeWithProducer REFUSES to call Make unless
+        // BOTH the data-path and ASM-path producers report IsComplete (empty
+        // NotYetPorted) — there is intentionally NO --force / bypass: an
+        // incomplete producer must never reach Make.
+        //
+        // Current state: the data-path NotYetPorted (GetNotYetPortedForms) is
+        // non-empty and the ASM-path keeps PatchForm(MakePatchStructDataList)
+        // in AsmNotYetPortedRaw, so the gate is CURRENTLY ALWAYS CLOSED — that
+        // is correct, honest and safe until those subsystems land in Core.
+        // ====================================================================
+
+        /// <summary>
+        /// Build the LDR pointer map exactly as the WinForms ROM-rebuild does
+        /// (<c>ToolROMRebuildMake.Make</c>, <c>ToolROMRebuildMake.cs:818</c>):
+        /// <c>DisassemblerTrumb.MakeLDRMap(Program.ROM.Data, 0x100,
+        /// Program.ROM.RomInfo.compress_image_borderline_address, true)</c> — i.e.
+        /// bounded to the compress-image borderline AND <c>isPointerOnly:true</c>.
+        /// <para>
+        /// This is DISTINCT from <see cref="BuildLdrMap"/>, which reproduces the
+        /// WinForms whole-ROM <i>cache</i> map (<c>AsmMapFileAsmCache.GetLDRMapCache</c>
+        /// = <c>MakeLDRMap(.., 0x100)</c>, unbounded + non-pointer-only). The ASM-path
+        /// producers (<see cref="AppendAllAsmStructPointers"/> → <c>EmitProcsScript</c>/
+        /// <c>EmitOAMSP</c>) iterate the supplied map and emit one <see cref="Address"/>
+        /// per LDR entry, so feeding the broader cache map would emit extra/different
+        /// addresses than WinForms. For a WF-parity-faithful, corruption-safe rebuild the
+        /// ASM half MUST receive THIS rebuild-specific map.
+        /// </para>
+        /// </summary>
+        public static List<DisassemblerTrumb.LDRPointer> BuildRebuildLdrMap(ROM rom)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            return DisassemblerTrumb.MakeLDRMap(
+                rom.Data, 0x100, rom.RomInfo.compress_image_borderline_address, true);
+        }
+
+        /// <summary>
+        /// Run BOTH producers (data-path <see cref="MakeAllStructPointers"/> + ASM-path
+        /// <see cref="AppendAllAsmStructPointers"/>) and, only if BOTH report
+        /// <see cref="ProducerResult.IsComplete"/>/<see cref="AsmProducerResult.IsComplete"/>,
+        /// drive <see cref="RebuildMakeCore.Make"/> to emit the <c>.rebuild</c> manifest.
+        /// Mirrors the WinForms arg-assembly in <c>ToolROMRebuildMake.Make</c>
+        /// (<c>ToolROMRebuildMake.cs</c> L775-827): ldrmap via <see cref="BuildRebuildLdrMap"/>,
+        /// the data list from the data-path producer, the ASM list appended into the SAME list,
+        /// then <see cref="RebuildMakeCore.Make"/>.
+        /// <para>
+        /// <b>COMPLETENESS GATE (corruption-safety).</b> If either producer's
+        /// <c>NotYetPorted</c> is non-empty this throws <see cref="InvalidOperationException"/>
+        /// naming the still-deferred forms and does NOT call Make. Rationale: Make relocates only
+        /// the listed structs and treats every unlisted region as free (free-list = COMPLEMENT of
+        /// the list), so an incomplete list = silently dropped/mis-typed bytes = ROM corruption.
+        /// There is deliberately no bypass. Because PatchForm (and the remaining data-path forms)
+        /// stay deferred, this gate is CURRENTLY ALWAYS CLOSED — the safe, honest default.
+        /// </para>
+        /// <para>
+        /// <b>FORWARD-LOOKING.</b> <see cref="RebuildMakeCore.Make"/> still omits several WinForms
+        /// post-producer phases (<c>AppendLDR</c>, the hardcoded-pointer search, <c>OptimizeList</c>,
+        /// <c>ProcssPointer</c>) — it takes the supplied list as authoritative. That is harmless while
+        /// this gate is closed, but before any future patch OPENS the gate on real ROMs those phases
+        /// need their own completeness proof/gate. Porting them is a separate item, not this wiring slice.
+        /// </para>
+        /// </summary>
+        /// <param name="rom">The loaded ROM to rebuild — MUST be <see cref="CoreState.ROM"/> (the
+        /// producers' <see cref="Address"/> validation is CoreState-bound).</param>
+        /// <param name="vanilla">The unmodified base ROM (<see cref="RebuildMakeCore.Make"/>'s diff base).</param>
+        /// <param name="rebuildAddress">Offset at/after which data is rebuilt.</param>
+        /// <param name="manifestPath">Output <c>.rebuild</c> path (sidecar folders created beside it).</param>
+        /// <param name="isUseOtherGraphics">WF <c>isUseOtherGraphics</c> (gates GraphicsToolForm in the ASM half).</param>
+        /// <param name="isUseOAMSP">WF <c>isUseOAMSP</c> (gates OAMSPForm in the ASM half).</param>
+        /// <param name="progress">Optional progress reporter (forwarded to both producers and Make).</param>
+        /// <param name="ct">Cancellation token (a cancelled producer throws <see cref="OperationCanceledException"/>).</param>
+        public static void MakeWithProducer(ROM rom, ROM vanilla, uint rebuildAddress, string manifestPath,
+            bool isUseOtherGraphics, bool isUseOAMSP,
+            IProgress<string> progress = null, CancellationToken ct = default)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (vanilla == null) throw new ArgumentNullException(nameof(vanilla));
+            if (string.IsNullOrEmpty(manifestPath)) throw new ArgumentNullException(nameof(manifestPath));
+
+            // 1) data-path producer.
+            ProducerResult data = MakeAllStructPointers(rom, progress, ct);
+
+            // 2) ASM-path producer, appended into the SAME list (WF builds one combined list).
+            //    Use the rebuild-specific LDR map (bounded + pointer-only), NOT the whole-ROM cache map.
+            List<DisassemblerTrumb.LDRPointer> ldrmap = BuildRebuildLdrMap(rom);
+            AsmProducerResult asm = AppendAllAsmStructPointers(
+                rom, data.List, ldrmap, isUseOtherGraphics, isUseOAMSP, progress, ct);
+
+            // 3) + 4) gate (cancel + IsComplete) then delegate.
+            MakeWithProducer(
+                data, asm, rom.Data, vanilla, rebuildAddress, data.List, manifestPath,
+                romVersion: rom.RomInfo.version,
+                nameResolver: null,
+                eventScriptWithPatch: CoreState.EventScript,
+                eventScriptWithoutPatch: null,
+                aiScript: CoreState.AIScript,
+                procsScript: CoreState.ProcsScript,
+                ct: ct,
+                progress: progress);
+        }
+
+        /// <summary>
+        /// Internal seam (NOT a bypass — it applies the SAME cancel + IsComplete gate): delegates to
+        /// <see cref="RebuildMakeCore.Make"/> from already-built producer results. Exists so a test can
+        /// exercise the Make-delegation path with a synthetic COMPLETE result (empty
+        /// <c>NotYetPorted</c>) — which the live producers cannot currently produce while PatchForm and
+        /// the remaining data-path forms stay deferred — and the throw path with an incomplete result.
+        /// </summary>
+        /// <param name="data">The data-path result (gated on <see cref="ProducerResult.IsComplete"/>).</param>
+        /// <param name="asm">The ASM-path result (gated on <see cref="AsmProducerResult.IsComplete"/>).</param>
+        /// <param name="modified">The modified ROM bytes to defragment (was <c>rom.Data</c>).</param>
+        /// <param name="vanilla">The unmodified base ROM.</param>
+        /// <param name="rebuildAddress">Offset at/after which data is rebuilt.</param>
+        /// <param name="structList">The combined struct list to emit (normally <c>data.List</c>).</param>
+        /// <param name="manifestPath">Output <c>.rebuild</c> path.</param>
+        /// <param name="romVersion">FE game version forwarded to Make.</param>
+        /// <param name="nameResolver">Optional symbol-name resolver forwarded to Make.</param>
+        /// <param name="eventScriptWithPatch">Optional EVENTSCRIPT (with patch) dict; null -&gt; Make's WildCard.</param>
+        /// <param name="eventScriptWithoutPatch">Optional EVENTSCRIPT (without patch) dict; null -&gt; WildCard.</param>
+        /// <param name="aiScript">Optional AISCRIPT dict; null -&gt; WildCard.</param>
+        /// <param name="procsScript">Optional PROCS dict; null -&gt; WildCard.</param>
+        /// <param name="progress">Optional progress reporter.</param>
+        /// <param name="ct">Cancellation token.</param>
+        internal static void MakeWithProducer(
+            ProducerResult data, AsmProducerResult asm,
+            byte[] modified, ROM vanilla, uint rebuildAddress, List<Address> structList, string manifestPath,
+            int romVersion = 8,
+            Func<uint, string> nameResolver = null,
+            EventScript eventScriptWithPatch = null,
+            EventScript eventScriptWithoutPatch = null,
+            EventScript aiScript = null,
+            EventScript procsScript = null,
+            IProgress<string> progress = null,
+            CancellationToken ct = default)
+        {
+            if (data == null) throw new ArgumentNullException(nameof(data));
+            if (asm == null) throw new ArgumentNullException(nameof(asm));
+            if (modified == null) throw new ArgumentNullException(nameof(modified));
+            if (vanilla == null) throw new ArgumentNullException(nameof(vanilla));
+            if (structList == null) throw new ArgumentNullException(nameof(structList));
+            if (string.IsNullOrEmpty(manifestPath)) throw new ArgumentNullException(nameof(manifestPath));
+
+            // CANCEL: a cancelled producer returned a PARTIAL list — never feed it to Make.
+            if (data.Cancelled || asm.Cancelled)
+            {
+                throw new OperationCanceledException(
+                    "ROM rebuild cancelled before the struct producer completed.", ct);
+            }
+
+            // GATE: refuse to Make while EITHER half is incomplete (corruption model above).
+            if (!data.IsComplete || !asm.IsComplete)
+            {
+                var pending = new List<string>();
+                if (data.NotYetPorted != null) pending.AddRange(data.NotYetPorted);
+                if (asm.NotYetPorted != null) pending.AddRange(asm.NotYetPorted);
+                // de-dup (the two halves cross-list some ASM forms) and keep a stable order.
+                var combined = new List<string>();
+                var seen = new HashSet<string>();
+                foreach (string f in pending)
+                {
+                    if (f != null && seen.Add(f)) combined.Add(f);
+                }
+                throw new InvalidOperationException(
+                    "ROM rebuild unavailable: " + combined.Count
+                    + (combined.Count == 1 ? " form not" : " forms not")
+                    + " yet ported to Core: " + string.Join(", ", combined)
+                    + ". Driving RebuildMakeCore.Make from an incomplete producer would drop the "
+                    + "un-enumerated regions (the rebuild treats every region NOT in the struct list "
+                    + "as free) = silent ROM corruption. The rebuild stays disabled until coverage is complete.");
+            }
+
+            // COMPLETE: safe to defragment.
+            RebuildMakeCore.Make(
+                modified, vanilla, rebuildAddress, structList, manifestPath,
+                nameResolver: nameResolver,
+                romVersion: romVersion,
+                eventScriptWithPatch: eventScriptWithPatch,
+                eventScriptWithoutPatch: eventScriptWithoutPatch,
+                aiScript: aiScript,
+                procsScript: procsScript,
+                progress: progress);
         }
 
         // ====================================================================

--- a/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
+++ b/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
@@ -51,7 +51,12 @@ namespace FEBuilderGBA.Tests.Unit
     /// <para>SKIP-IF-NO-ROM: requires <c>roms/FE8U.gba</c> (gitignored — absent in CI / most worktrees,
     /// present in the user's main checkout). When no ROM is found the test returns early (skips) and
     /// never fails CI.</para>
+    /// <para>In the <c>SharedState</c> xUnit collection: it mutates global WinForms/Core state
+    /// (<c>CoreState.BaseDirectory</c>, <c>Program.BaseDirectory</c>/<c>Config</c>/<c>ROM</c> via
+    /// <c>LoadROM</c>), so it must not run in parallel with other state-mutating tests (Copilot PR #1302
+    /// review).</para>
     /// </summary>
+    [Collection("SharedState")]
     public class RebuildProducerWFParityTests
     {
         // WF rebuild flags — match the ToolROMRebuildMake.Make defaults (ToolROMRebuildMake.cs:820-826).

--- a/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
+++ b/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Tests.Unit
+{
+    /// <summary>
+    /// WF-parity validation harness for the cross-platform ROM-rebuild PRODUCER (#1261 slice 2z-wire).
+    /// <para>
+    /// Proves the Core producer (<see cref="RebuildProducerCore.MakeAllStructPointers"/> +
+    /// <see cref="RebuildProducerCore.AppendAllAsmStructPointers"/>) is byte-faithful to the WinForms
+    /// producer (<c>U.MakeAllStructPointersList</c> + <c>U.AppendAllASMStructPointersList</c>) for every
+    /// form Core has ported. This test MUST live in <c>FEBuilderGBA.Tests</c> (net9.0-windows) because it
+    /// calls the WinForms <c>U</c> producer, which does not exist in the net9.0 Core assembly.
+    /// </para>
+    /// <para>
+    /// <b>Comparison model.</b> WinForms runs every form (including the deferred ones — PatchForm and the
+    /// data-path forms Core has not yet ported); Core runs only the ported subset. So WF's list is a
+    /// SUPERSET. The faithful, regression-proof assertion is therefore:
+    /// <list type="bullet">
+    ///   <item>Every Core entry (keyed by <c>Addr</c>/<c>Length</c>/<c>Pointer</c>/<c>DataType</c>) MUST
+    ///   appear in the WF list — i.e. Core ⊆ WF. A <b>Core-extra</b> (Core emits an entry WF does not)
+    ///   is a real faithfulness regression and FAILS the test with a dump of the first differing entries.</item>
+    ///   <item><b>WF-extras</b> (WF emits entries Core lacks) are EXPECTED — they are the deferred forms
+    ///   (PatchForm + the still-un-ported data-path forms). They are logged but do not fail the test;
+    ///   isolating them here is exactly what keeps PatchForm's known-deferred contribution from masking a
+    ///   real Core regression.</item>
+    ///   <item><b>GraphicsTool LZ77 re-discoveries</b> are the ONE documented, root-caused class of
+    ///   expected Core-extra. The slice-2y GraphicsTool whole-ROM LZ77 scan ignores every image address
+    ///   already in <c>list</c> (<c>MakeIgnoreDictionnaryFromList</c>). WF runs ALL data forms first, so
+    ///   its list claims those images and WF's GraphicsTool ignores them; Core DEFERS some of those forms,
+    ///   so their image addresses are not in Core's list and Core's GraphicsTool legitimately re-discovers
+    ///   them as <c>LZ77IMG</c>. Such a Core-extra is always a <c>LZ77IMG</c> whose data address WF ALSO
+    ///   covers (it is in WF's list via the deferred form). They are bounded and vanish as the deferred
+    ///   forms are ported. The test still FAILS on any Core-extra that is NOT this exact shape (a non-
+    ///   LZ77IMG extra, or a LZ77IMG at an address WF does not know at all = a real regression).</item>
+    /// </list>
+    /// The <c>Info</c>/name field is INFORMATIONAL only (a documented cosmetic divergence — Core and WF
+    /// name some entries differently); name mismatches are never asserted.
+    /// </para>
+    /// <para>
+    /// <b>LDR map.</b> Both sides build the ASM-path LDR map with the SAME WF rebuild args
+    /// (<c>MakeLDRMap(.., 0x100, compress_image_borderline_address, true)</c> — bounded + pointer-only,
+    /// per <c>ToolROMRebuildMake.cs:818</c>), so the ASM producers receive identical input. Core uses
+    /// <see cref="RebuildProducerCore.BuildRebuildLdrMap"/>, which reproduces exactly that.
+    /// </para>
+    /// <para>SKIP-IF-NO-ROM: requires <c>roms/FE8U.gba</c> (gitignored — absent in CI / most worktrees,
+    /// present in the user's main checkout). When no ROM is found the test returns early (skips) and
+    /// never fails CI.</para>
+    /// </summary>
+    public class RebuildProducerWFParityTests
+    {
+        // WF rebuild flags — match the ToolROMRebuildMake.Make defaults (ToolROMRebuildMake.cs:820-826).
+        const bool IS_PATCH_INSTALL_ONLY = true;
+        const bool IS_PATCH_POINTER_ONLY = false;
+        const bool IS_PATCH_STRUCT_ONLY = false;
+        const bool IS_USE_OTHER_GRAPHICS = true;
+        const bool IS_USE_OAMSP = false;
+
+        [Fact]
+        public void CoreProducer_IsSubsetOf_WinFormsProducer_ForAllPortedForms()
+        {
+            string? repoRoot = FindRepoRoot();
+            if (repoRoot == null) return; // cannot locate the solution — skip
+            string romPath = Path.Combine(repoRoot, "roms", "FE8U.gba");
+            if (!File.Exists(romPath)) return; // SKIP-IF-NO-ROM (gitignored, absent in CI)
+
+            // CoreState.BaseDirectory lets the config/patch trees + producer config files resolve.
+            string savedBaseDir = CoreState.BaseDirectory;
+            try
+            {
+                CoreState.BaseDirectory = repoRoot;
+                // Skip the WinForms background AsmMap cache rebuild (test-only): the producer only needs
+                // the synchronous base symbol table. Program.IsCommandLine has a private setter.
+                ForceCommandLineMode();
+
+                // Replicate the WinForms Main() pre-init that LoadROM/InitSystem assumes (Program.cs
+                // L60-68): Program.BaseDirectory + a non-null Program.Config. Without them
+                // OptionForm.lang_low() NREs on Program.Config inside InitSystem. The WF app normally
+                // does this in Main; a headless test must do it before the first LoadROM.
+                BootstrapWinFormsProgram(repoRoot);
+
+                // Full WinForms ROM load — populates Program.ROM, every InputFormRef registry, the
+                // PatchForm CheckIF scan, and all PreLoadResource config the WF producer reads.
+                bool loaded = Program.LoadROM(romPath, "");
+                if (!loaded || Program.ROM == null) return; // skip if the ROM did not load
+                if (Program.ROM.RomInfo.version != 8) return; // this harness is calibrated on FE8U
+
+                // ---- WinForms producer (the parity reference) ----
+                List<Address> wf = U.MakeAllStructPointersList(false);
+                List<DisassemblerTrumb.LDRPointer> ldrmap = DisassemblerTrumb.MakeLDRMap(
+                    Program.ROM.Data, 0x100, Program.ROM.RomInfo.compress_image_borderline_address, true);
+                U.AppendAllASMStructPointersList(wf, ldrmap,
+                    isPatchInstallOnly: IS_PATCH_INSTALL_ONLY,
+                    isPatchPointerOnly: IS_PATCH_POINTER_ONLY,
+                    isPatchStructOnly: IS_PATCH_STRUCT_ONLY,
+                    isUseOtherGraphics: IS_USE_OTHER_GRAPHICS,
+                    isUseOAMSP: IS_USE_OAMSP);
+
+                // ---- Core producer (same flags, same rebuild LDR map) ----
+                RebuildProducerCore.ProducerResult coreData =
+                    RebuildProducerCore.MakeAllStructPointers(Program.ROM);
+                List<DisassemblerTrumb.LDRPointer> coreLdr =
+                    RebuildProducerCore.BuildRebuildLdrMap(Program.ROM);
+                RebuildProducerCore.AppendAllAsmStructPointers(
+                    Program.ROM, coreData.List, coreLdr,
+                    isUseOtherGraphics: IS_USE_OTHER_GRAPHICS, isUseOAMSP: IS_USE_OAMSP);
+                List<Address> core = coreData.List;
+
+                Assert.NotEmpty(wf);
+                Assert.NotEmpty(core);
+
+                // Key on the load-bearing fields (Addr, Length, Pointer, DataType). Name/Info is cosmetic.
+                var wfKeys = new HashSet<Key>(wf.Select(Key.Of));
+                var coreKeys = new HashSet<Key>(core.Select(Key.Of));
+                var wfAddrs = new HashSet<uint>(wf.Select(a => a.Addr));
+
+                // Core entries WF does NOT emit on all 4 fields (Addr/Length/Pointer/DataType).
+                var coreExtras = core.Where(a => !wfKeys.Contains(Key.Of(a))).ToList();
+                // WF-extras = the deferred forms WF still emits (PatchForm + un-ported data-path forms).
+                int wfExtraCount = wfKeys.Count(k => !coreKeys.Contains(k));
+
+                // ---- isolate the ONE documented, root-caused class of expected divergence ----
+                // GraphicsTool LZ77 whole-ROM scan (slice 2y) ignores every image-data address already in
+                // `list` (MakeIgnoreDictionnaryFromList adds a.Addr for each entry). WF runs ALL data forms
+                // first, so its list already claims the images those forms own and WF's GraphicsTool ignores
+                // them. Core DEFERS some of those forms, so their image addresses are NOT in Core's list and
+                // Core's GraphicsTool legitimately RE-DISCOVERS them as LZ77IMG. These are EXPECTED: each
+                // such Core-extra is a LZ77IMG whose data address WF ALSO covers (it is in WF's list, just
+                // via the deferred form's entry, not a GraphicsTool one). When those forms are ported, the
+                // extras vanish. They are bounded and never mask a real regression because we still FAIL on
+                // any Core-extra that is NOT this exact shape.
+                var expectedGfxReDiscovery = coreExtras
+                    .Where(a => a.DataType == Address.DataTypeEnum.LZ77IMG && wfAddrs.Contains(a.Addr))
+                    .ToList();
+                // A REAL regression = a Core-extra that is NOT an expected GraphicsTool re-discovery:
+                // either a non-LZ77IMG entry, or a LZ77IMG at an address WF does not know at all.
+                var realRegressions = coreExtras
+                    .Where(a => !(a.DataType == Address.DataTypeEnum.LZ77IMG && wfAddrs.Contains(a.Addr)))
+                    .Select(Key.Of).Distinct().ToList();
+
+                if (realRegressions.Count > 0)
+                {
+                    const int N = 30;
+                    string dump = string.Join("\n", realRegressions.Take(N).Select(k =>
+                        $"  Addr=0x{k.Addr:X} Len=0x{k.Length:X} Ptr=0x{k.Pointer:X} Type={k.Type}"
+                        + $" wfHasAddr={wfAddrs.Contains(k.Addr)}"));
+                    Assert.Fail(
+                        $"Core producer emitted {realRegressions.Count} entr{(realRegressions.Count == 1 ? "y" : "ies")} "
+                        + "NOT present in the WinForms producer and NOT an expected GraphicsTool re-discovery "
+                        + "(faithfulness regression).\n"
+                        + $"WF total={wf.Count}, Core total={core.Count}, WF-only (deferred forms)={wfExtraCount}, "
+                        + $"expected GraphicsTool re-discoveries={expectedGfxReDiscovery.Count}.\n"
+                        + $"First {Math.Min(N, realRegressions.Count)} unexpected Core-only entries:\n{dump}");
+                }
+
+                // PROVEN: every Core entry is either byte-identical to a WF entry OR a documented, bounded
+                // GraphicsTool re-discovery of an image WF already covers via a deferred form. No real
+                // faithfulness regression across the ported forms.
+                Assert.Empty(realRegressions);
+            }
+            finally
+            {
+                CoreState.BaseDirectory = savedBaseDir;
+            }
+        }
+
+        // ----------------------------------------------------------------
+        readonly struct Key : IEquatable<Key>
+        {
+            public readonly uint Addr;
+            public readonly uint Length;
+            public readonly uint Pointer;
+            public readonly Address.DataTypeEnum Type;
+            Key(uint addr, uint length, uint pointer, Address.DataTypeEnum type)
+            {
+                Addr = addr; Length = length; Pointer = pointer; Type = type;
+            }
+            public static Key Of(Address a) => new Key(a.Addr, a.Length, a.Pointer, a.DataType);
+            public bool Equals(Key o) => Addr == o.Addr && Length == o.Length
+                                          && Pointer == o.Pointer && Type == o.Type;
+            public override bool Equals(object? o) => o is Key k && Equals(k);
+            public override int GetHashCode() => HashCode.Combine(Addr, Length, Pointer, (int)Type);
+        }
+
+        // Program.IsCommandLine has a private setter; force it on for headless test init.
+        static void ForceCommandLineMode()
+        {
+            try
+            {
+                PropertyInfo? p = typeof(Program).GetProperty(
+                    "IsCommandLine", BindingFlags.Public | BindingFlags.Static);
+                p?.SetValue(null, true, BindingFlags.NonPublic | BindingFlags.Instance, null, null, null);
+            }
+            catch
+            {
+                // Non-fatal: without it InitSystem just runs the synchronous ClearCache instead.
+            }
+        }
+
+        /// <summary>
+        /// Replicate the minimal WinForms <c>Program.Main</c> pre-init that <c>Program.LoadROM</c> →
+        /// <c>InitSystem</c> assumes (Program.cs L60-68): <c>Program.BaseDirectory</c> pointed at the repo
+        /// root (so config/translate trees resolve) and a non-null <c>Program.Config</c> (so
+        /// <c>OptionForm.lang_low()</c> does not NRE). Both have private/internal setters, so this uses
+        /// reflection — strictly test-only setup. <c>Config.at("func_lang","auto")</c> falls back to "auto"
+        /// when <c>config.xml</c> is absent, so an empty Config instance is sufficient.
+        /// </summary>
+        static void BootstrapWinFormsProgram(string repoRoot)
+        {
+            Type prog = typeof(Program);
+
+            // Program.BaseDirectory = repoRoot (private static setter).
+            PropertyInfo? baseDirProp = prog.GetProperty(
+                "BaseDirectory", BindingFlags.Public | BindingFlags.Static);
+            baseDirProp?.SetValue(null, repoRoot);
+
+            // Program.Config = new ConfigWinForms(); Config.Load(repoRoot/config/config.xml).
+            // ConfigWinForms is internal to the FEBuilderGBA assembly — construct it via reflection.
+            PropertyInfo? configProp = prog.GetProperty(
+                "Config", BindingFlags.Public | BindingFlags.Static);
+            if (configProp != null && configProp.GetValue(null) == null)
+            {
+                Type? configType = prog.Assembly.GetType("FEBuilderGBA.ConfigWinForms");
+                if (configType != null)
+                {
+                    object? cfg = Activator.CreateInstance(configType, nonPublic: true);
+                    if (cfg != null)
+                    {
+                        MethodInfo? load = configType.GetMethod("Load", new[] { typeof(string) });
+                        load?.Invoke(cfg, new object[] { Path.Combine(repoRoot, "config", "config.xml") });
+                        configProp.SetValue(null, cfg);
+                        CoreState.Config = (Config)cfg;
+                    }
+                }
+            }
+        }
+
+        static string? FindRepoRoot()
+        {
+            string? dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            for (int i = 0; i < 12 && dir != null; i++)
+            {
+                if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln"))) return dir;
+                dir = Path.GetDirectoryName(dir);
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Wires the cross-platform ROM-rebuild **PRODUCER** to the already-ported `RebuildMakeCore.Make`, **GATED on `IsComplete`**, plus a WinForms-parity validation harness (#1261 slice 2z-wire — producer→Make wiring item (b)).

Plan + accepted Copilot review: issue #1261 ([plan](https://github.com/laqieer/FEBuilderGBA/issues/1261#issuecomment-4758529568), [review](https://github.com/laqieer/FEBuilderGBA/issues/1261#issuecomment-4758559477)).

## The corruption model that motivates the gate

`RebuildMakeCore.Make` emits a `.rebuild` manifest from **only** the caller-supplied `structList`. The rebuild treats every ROM region **NOT** in that list as free/droppable (`AsmMapFile.MakeFreeDataList` = the **COMPLEMENT** of the listed structs; `Make` carries only the listed structs into the rebuilt ROM). So a `Make` driven by an **incomplete** producer silently drops or mis-types the bytes the producer failed to enumerate = **silent ROM corruption**.

Therefore `MakeWithProducer` **REFUSES** to call `Make` unless BOTH the data-path and ASM-path producers report `IsComplete` (empty `NotYetPorted`). There is intentionally **no `--force`/bypass** (unproven safety, out of scope). Because `PatchForm(MakePatchStructDataList)` (and the remaining data-path forms) stay deferred, **the gate is currently always closed — the safe, honest default** until those subsystems land in Core.

## TASK A — `RebuildProducerCore.MakeWithProducer`

- Public entry runs BOTH producers (data-path `MakeAllStructPointers` + ASM-path `AppendAllAsmStructPointers`, appended into one list) and only delegates to `RebuildMakeCore.Make` when BOTH are complete. Mirrors the WF arg-assembly in `ToolROMRebuildMake.cs` L775-827 (romVersion from `rom.RomInfo`, script dicts from `CoreState`, null optional args fall back to Make's `WildCard`).
- **`BuildRebuildLdrMap`** reproduces the WF *rebuild* LDR map exactly — `MakeLDRMap(.., 0x100, compress_image_borderline_address, true)` (bounded + pointer-only) — **not** the whole-ROM *cache* map (`BuildLdrMap`). The ASM producers (`EmitProcsScript`/`EmitOAMSP`) iterate the supplied map and emit one `Address` per LDR entry, so the broader cache map would diverge from WF (resolved a [Copilot plan-review blocking finding](https://github.com/laqieer/FEBuilderGBA/issues/1261#issuecomment-4758559477)).
- Gate: incomplete ⇒ `InvalidOperationException` **naming the deferred forms**; cancelled ⇒ `OperationCanceledException`; both no manifest.
- Internal seam overload (`ProducerResult`/`AsmProducerResult`) applies the **same** gate and delegates — lets a test exercise the Make path with a synthetic COMPLETE result (the live producers cannot yield one while PatchForm stays deferred). It is the seam, **not a bypass**.

## TASK B — Core unit tests (`FEBuilderGBA.Core.Tests`)

- incomplete ASM (PatchForm) ⇒ throws, **names PatchForm**, no manifest
- incomplete data (ItemForm) ⇒ throws, no manifest
- cancelled ⇒ `OperationCanceledException`, no manifest
- both complete ⇒ delegates to `Make`, writes manifest (`@_REBUILDADDRESS`/`@BIN`)
- public-entry smoke (env-gated) ⇒ real producer refuses, names PatchForm
- `BuildRebuildLdrMap` (env-gated) ⇒ WF rebuild args, bounded + pointer-only

## TASK C — WF-parity harness (`FEBuilderGBA.Tests`, net9.0-windows)

Proves the Core producer is **byte-faithful** to the WF producer (`U.MakeAllStructPointersList` + `U.AppendAllASMStructPointersList`) for every ported form. Lives in `FEBuilderGBA.Tests` because it calls the WinForms `U` producer (absent in net9.0). Skip-if-no-ROM (`roms/FE8U.gba` — gitignored, absent in CI). Bootstraps the WF `Program` headless, runs both producers with the SAME flags + SAME rebuild LDR map, asserts **Core ⊆ WF** on `(Addr,Length,Pointer,DataType)` (Info is cosmetic).

**Validated on real FE8U: WF=33344, Core=32250 entries.** The ONLY Core-extras are 88 documented, bounded **GraphicsTool LZ77 re-discoveries**: the slice-2y GraphicsTool whole-ROM scan ignores image addresses already in `list`; WF's list claims them via data forms Core **DEFERS**, so Core's GraphicsTool legitimately re-discovers them (each is a `LZ77IMG` WF also covers; they vanish as the forms are ported). The test **FAILS on any other Core-extra**, so it never masks a real regression.

## Faithfulness fix surfaced by the harness (slice 2q)

`EmitImageTSAAnime` emitted the config-table slot as the main-IFR `Pointer`, but WF's `ImageTSAAnimeForm.Init` builds the `InputFormRef` with pointer `0` and `ReInit(addr,count)` never sets `BasePointer`, so WF emits `Pointer=NOT_FOUND`. A wrong pointer would back-patch a slot WF leaves alone = divergence. Now matches WF exactly (`EmitImageTSAAnime2` was already correct). Also fixed a pre-existing stale env-gated assertion (`SongTableForm` was ported in 2r → now asserts the still-deferred `UnitCustomBattleAnimeForm`).

## Test plan

- [x] `dotnet build FEBuilderGBA.sln` clean (0 errors)
- [x] Core.Tests full suite: **4856 passed / 0 failed / 6 skipped**
- [x] `dotnet test FEBuilderGBA.Core.Tests --filter ~RebuildProducer`: **382 passed / 0 failed**
- [x] WF-parity harness passes against real FE8U (Core ⊆ WF, only the 88 documented GraphicsTool re-discoveries)
- [x] WF-parity harness SKIPS cleanly with no ROM (8 ms — CI-safe)
- [x] Gate refuses (lists `PatchForm(MakePatchStructDataList)`) when run against the current producer

## Scope

Core-only logic + tests, **no GUI** (CLI/Avalonia rebuild GUI is a separate later item) → no screenshot. PatchForm stays deferred, so the gate is intentionally closed until that subsystem lands.

Part of #1261.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
