### PR TITLE
feat(core): ROM-rebuild producer — 4 ScanScript-family forms (#1261 slice 2aa)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -479,10 +479,10 @@ namespace FEBuilderGBA.Core.Tests
             // Their deferred siblings (embedded sub-walk / event-scan / dynamic count / patch
             // pointer set) must STAY tracked — porting only some forms while leaving these
             // un-tracked would dangle their pointers during a rebuild.
-            Assert.Contains("MonsterWMapProbabilityForm", notYet); // EventScriptForm.ScanScript
-            // (CCBranchForm is now PORTED in the #1261 producer sweep via ClassDataCount — it is no
-            //  longer a deferred sibling; EventBattleTalkForm stays deferred for its ScanScript.)
-            Assert.Contains("EventBattleTalkForm", notYet);        // per-entry EventScriptForm.ScanScript
+            // (MonsterWMapProbabilityForm + EventBattleTalkForm are now PORTED in slice 2aa — both
+            //  reuse the slice-2u EmitScanScript block-emitter; CCBranchForm is PORTED via ClassDataCount.)
+            Assert.DoesNotContain("MonsterWMapProbabilityForm", notYet);
+            Assert.DoesNotContain("EventBattleTalkForm", notYet);
             // (MapTileAnimation1Form/MapTileAnimation2Form are now PORTED in slice 2g; the MapTerrain
             //  lookup tables are now PORTED in slice 2j — see
             //  GetNotYetPortedForms_DropsSlice2jCoveredForms_KeepsDeferredSiblings. SongTableForm is now
@@ -641,12 +641,13 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.DoesNotContain("LinkArenaDenyUnitForm", notYet2b);
                 Assert.DoesNotContain("MonsterItemForm", notYet2b);
                 Assert.DoesNotContain("MonsterProbabilityForm", notYet2b);
-                // Deferred sibling forms MUST remain tracked (event-scan / dynamic count / patch).
-                // (CCBranchForm is now PORTED in the #1261 producer sweep — count = ClassDataCount —
-                //  so it is no longer asserted-present here; EventBattleTalkForm stays deferred for its
-                //  per-entry EventScriptForm.ScanScript expansion.)
-                Assert.Contains("MonsterWMapProbabilityForm", notYet2b);
-                Assert.Contains("EventBattleTalkForm", notYet2b);
+                // (CCBranchForm is now PORTED in the #1261 producer sweep — count = ClassDataCount.
+                //  MonsterWMapProbabilityForm + EventBattleTalkForm are now PORTED in slice 2aa — both
+                //  reuse the slice-2u EmitScanScript block-emitter, so the static NotYetPorted no longer
+                //  lists them. NOTE this is the STATIC GetNotYetPortedForms(); the per-run ProducerResult
+                //  would re-report them only when the disassembler is unwired, which this overload bypasses.)
+                Assert.DoesNotContain("MonsterWMapProbabilityForm", notYet2b);
+                Assert.DoesNotContain("EventBattleTalkForm", notYet2b);
                 // (MapTileAnimation1Form is now PORTED in slice 2g, the MapTerrain lookup tables in
                 //  slice 2j, and SongTableForm in slice 2r — so the still-deferred misc sibling tracked
                 //  here is UnitCustomBattleAnimeForm [per-unit custom battle-anime recycle, not in Core].)
@@ -1711,10 +1712,9 @@ namespace FEBuilderGBA.Core.Tests
             // Still deferred (un-ported subsystem) -> must REMAIN:
             foreach (var kept in new[]
             {
-                "EventBattleTalkForm", "EventHaikuForm",
-                "WorldMapEventPointerForm",
-                // (FE8SpellMenuExtendsForm ported in slice 2m -> no longer kept here.)
-                "MonsterWMapProbabilityForm",
+                // (FE8SpellMenuExtendsForm ported in slice 2m -> no longer kept here.
+                //  EventBattleTalkForm/EventHaikuForm/WorldMapEventPointerForm/MonsterWMapProbabilityForm
+                //  ported in slice 2aa -> no longer kept here; asserted GONE below.)
                 // (StatusOptionForm + SoundFootStepsForm ported in slice 2d -> no longer kept here.
                 //  UnitFE6Form + ItemUsagePointerForm + AIPerform*/AIMapSetting/Mant/ArenaEnemyWeapon
                 //  ported in slice 2f -> no longer kept here. MapTileAnimation1Form/MapTileAnimation2Form +
@@ -1734,6 +1734,12 @@ namespace FEBuilderGBA.Core.Tests
             // slice 2s ported AIScriptForm + ImageBattleAnimeForm -> they must now be GONE.
             Assert.DoesNotContain("AIScriptForm", notYet);
             Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
+
+            // slice 2aa ported the four FE8 ScanScript-family forms -> they must now be GONE.
+            Assert.DoesNotContain("MonsterWMapProbabilityForm", notYet);
+            Assert.DoesNotContain("EventBattleTalkForm", notYet);
+            Assert.DoesNotContain("WorldMapEventPointerForm", notYet);
+            Assert.DoesNotContain("EventHaikuForm", notYet);
         }
 
         [Fact]
@@ -1793,7 +1799,7 @@ namespace FEBuilderGBA.Core.Tests
                 string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
                 Assert.DoesNotContain("CCBranchForm", notYet);
                 Assert.DoesNotContain("WorldMapPointForm", notYet);
-                Assert.Contains("EventBattleTalkForm", notYet); // still deferred (ScanScript)
+                Assert.DoesNotContain("EventBattleTalkForm", notYet); // ported in slice 2aa (EmitScanScript)
             }
             finally
             {
@@ -3511,7 +3517,8 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("AIScriptForm", notYet);
             // deferred siblings STAY (their blocking subsystem is not in Core):
             Assert.Contains("UnitActionPointerForm", notYet);     // PatchUtil SearchUnitActionReworkPatch
-            Assert.Contains("MonsterWMapProbabilityForm", notYet);// EventScriptForm.ScanScript skirmish
+            // (MonsterWMapProbabilityForm PORTED in slice 2aa — EmitScanScript skirmish events.)
+            Assert.DoesNotContain("MonsterWMapProbabilityForm", notYet);
             // (the 5 map-PLIST forms that were deferred "for slice size" here are now PORTED in slice 2g
             //  — see GetNotYetPortedForms_DropsSlice2gCoveredForms_KeepsDeferredSiblings.
             //  EventCondForm is PORTED in slice 2u — see
@@ -4393,7 +4400,8 @@ namespace FEBuilderGBA.Core.Tests
             // (NOTE: OPClassDemoForm / OPClassDemoFE7Form were the nested-IFR siblings deferred at
             //  slice 2h; slice 2i below ports them, so they move to DoesNotContain there. MapSettingForm
             //  is ported in slice 2r — its text-count cache is now reproduced by TextDataCount.)
-            Assert.Contains("WorldMapEventPointerForm", notYet); // ScanScript
+            // (WorldMapEventPointerForm PORTED in slice 2aa — EmitWorldMapEventPointer + EmitScanScript.)
+            Assert.DoesNotContain("WorldMapEventPointerForm", notYet);
             // (ImageCGFE7UForm is ported in slice 2k — see GetNotYetPortedForms_DropsSlice2kCoveredForms.)
             Assert.DoesNotContain("ImageCGFE7UForm", notYet);
 
@@ -4787,9 +4795,10 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("OPClassDemoFE7Form", notYet);
 
             // deferred siblings STAY (their blocking subsystem is not in Core):
-            // (MapSettingForm is ported in slice 2r — its text-count cache is now reproduced by TextDataCount.)
-            Assert.Contains("WorldMapEventPointerForm", notYet); // ScanScript
-            Assert.Contains("MonsterWMapProbabilityForm", notYet); // ScanScript skirmish events
+            // (MapSettingForm is ported in slice 2r — its text-count cache is now reproduced by TextDataCount.
+            //  WorldMapEventPointerForm + MonsterWMapProbabilityForm PORTED in slice 2aa — EmitScanScript.)
+            Assert.DoesNotContain("WorldMapEventPointerForm", notYet);
+            Assert.DoesNotContain("MonsterWMapProbabilityForm", notYet);
             // (ImageCGFE7UForm is ported in slice 2k — see GetNotYetPortedForms_DropsSlice2kCoveredForms.)
             Assert.DoesNotContain("ImageCGFE7UForm", notYet);
             // (FE8SpellMenuExtendsForm is ported in slice 2m — see

--- a/FEBuilderGBA.Core.Tests/RebuildProducerEventCondTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerEventCondTests.cs
@@ -532,11 +532,11 @@ namespace FEBuilderGBA.Core.Tests
             string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
             // EventCondForm is now ported (EmitEventCond + EmitScanScript).
             Assert.DoesNotContain("EventCondForm", notYet);
-            // Its ScanScript-dependent siblings stay tracked (scoped out of slice 2u).
-            Assert.Contains("MonsterWMapProbabilityForm", notYet);
-            Assert.Contains("WorldMapEventPointerForm", notYet);
-            Assert.Contains("EventBattleTalkForm", notYet);
-            Assert.Contains("EventHaikuForm", notYet);
+            // Its ScanScript-dependent siblings were ported in slice 2aa (each reuses EmitScanScript).
+            Assert.DoesNotContain("MonsterWMapProbabilityForm", notYet);
+            Assert.DoesNotContain("WorldMapEventPointerForm", notYet);
+            Assert.DoesNotContain("EventBattleTalkForm", notYet);
+            Assert.DoesNotContain("EventHaikuForm", notYet);
         }
 
         [Fact]

--- a/FEBuilderGBA.Core.Tests/RebuildProducerScanScriptFamilyTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerScanScriptFamilyTests.cs
@@ -158,7 +158,7 @@ namespace FEBuilderGBA.Core.Tests
                 Write32(rom, ri.event_ballte_talk_pointer, Ptr(tableBase));
 
                 // Row 0: unit id 0x10, special-event pointer at +12 -> a script.
-                rom.Data[tableBase + 0] = 0x10;
+                rom.write_u8(tableBase + 0, 0x10);
                 uint script = 0x00921000u;
                 Write32(rom, tableBase + 12, Ptr(script));
                 rom.write_u32(script + 0, 0x0000000A); // ENDA
@@ -187,7 +187,7 @@ namespace FEBuilderGBA.Core.Tests
                 var ri = rom.RomInfo;
                 uint tableBase = 0x00920000u;
                 Write32(rom, ri.event_ballte_talk_pointer, Ptr(tableBase));
-                rom.Data[tableBase + 0] = 0x10;
+                rom.write_u8(tableBase + 0, 0x10);
                 Write32(rom, tableBase + 12, 0x00000000u); // NULL event pointer -> not isSafetyPointer
                 rom.write_u16(tableBase + 16, 0xFFFF);     // terminator
 
@@ -213,7 +213,7 @@ namespace FEBuilderGBA.Core.Tests
                 uint tableBase = 0x00930000u;     // block 12, PI {8}
                 Write32(rom, ri.event_haiku_pointer, Ptr(tableBase));
 
-                rom.Data[tableBase + 0] = 0x10;   // unit id
+                rom.write_u8(tableBase + 0, 0x10); // unit id
                 uint script = 0x00931000u;
                 Write32(rom, tableBase + 8, Ptr(script));  // event pointer at +8
                 rom.write_u32(script + 0, 0x0000000A);     // ENDA

--- a/FEBuilderGBA.Core.Tests/RebuildProducerScanScriptFamilyTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerScanScriptFamilyTests.cs
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for RebuildProducerCore slice 2aa — the four FE8 ScanScript-family
+// data-path forms, each a verbatim port of its WinForms MakeAllDataLength:
+//   MonsterWMapProbabilityForm.cs:156  -> EmitMonsterWMapProbability
+//   EventBattleTalkForm.cs:95          -> EmitEventBattleTalk
+//   WorldMapEventPointerForm.cs:247    -> EmitWorldMapEventPointer
+//   EventHaikuForm.cs:99               -> EmitEventHaiku
+//
+// Each reuses the slice-2u EmitScanScript block-emitter for its per-entry /
+// fixed event-script trace. The producer body gates their dispatch on
+// IsEventScriptDisasmReady and re-reports them in NotYetPorted when unwired —
+// these tests wire CoreState.EventScript/CommentCache so the full path runs.
+//
+// Coverage per form: a valid main IFR table emits the right addr/length/pointer/
+// type; the per-entry ScanScript trace emits the referenced-script block; near-
+// EOF doesn't throw; a zeroed ROM emits nothing.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class RebuildProducerScanScriptFamilyTests
+    {
+        const int RomSize = 0x1100000; // 17MB — FE8 LoadLow minimum + scratch.
+
+        static ROM MakeFe8uRom()
+        {
+            var rom = new ROM();
+            rom.LoadLow("synthetic-fe8u.gba", new byte[RomSize], "BE8E01");
+            return rom;
+        }
+
+        static EventScript BuildEventScript(params EventScript.Script[] scripts)
+        {
+            var es = new EventScript();
+            var prop = typeof(EventScript).GetProperty("Scripts");
+            prop!.SetValue(es, scripts);
+            return es;
+        }
+
+        static EventScript.Script TermCommand()
+            => EventScript.ParseScriptLine("0A000000\tENDA [TERM]");
+
+        static void Write32(ROM rom, uint addr, uint value) => rom.write_u32(addr, value);
+        static uint Ptr(uint offset) => offset | 0x08000000u;
+
+        /// <summary>Run with CoreState wired to a fresh FE8U ROM + a single-ENDA
+        /// EventScript (so EmitScanScript's disasm prerequisite is satisfied),
+        /// restoring prior CoreState afterwards. Also clears the InputFormRef-style
+        /// data-count cache is NOT needed (Core producer never uses it).</summary>
+        static void WithEnv(Action<ROM> body)
+        {
+            var rom = MakeFe8uRom();
+            var es = BuildEventScript(TermCommand());
+            var prevRom = CoreState.ROM;
+            var prevEs = CoreState.EventScript;
+            var prevComment = CoreState.CommentCache;
+            try
+            {
+                CoreState.ROM = rom;
+                CoreState.EventScript = es;
+                CoreState.CommentCache = new HeadlessEtcCache();
+                body(rom);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.EventScript = prevEs;
+                CoreState.CommentCache = prevComment;
+            }
+        }
+
+        /// <summary>Plant a one-command ENDA event script behind the pointer slot,
+        /// returning the event addr.</summary>
+        static uint PlantScript(ROM rom, uint pointerSlot, uint eventAddr)
+        {
+            Write32(rom, pointerSlot, Ptr(eventAddr));
+            rom.write_u32(eventAddr + 0, 0x0000000A); // ENDA
+            return eventAddr;
+        }
+
+        // =================================================================
+        // EmitMonsterWMapProbability
+        // =================================================================
+
+        [Fact]
+        public void EmitMonsterWMapProbability_EmitsFiveTablesAndSkirmishScripts()
+        {
+            WithEnv(rom =>
+            {
+                var ri = rom.RomInfo;
+                // Five flat IFR tables. base-point rule i<0x9 (block 1): give it a few
+                // rows then it stops at 0x9 anyway. The other four use rule i<0xB.
+                uint basePoint = 0x00900000u;
+                uint stage1 = 0x00901000u, stage2 = 0x00902000u;
+                uint prob1 = 0x00903000u, prob2 = 0x00904000u;
+                Write32(rom, ri.monster_wmap_base_point_pointer, Ptr(basePoint));
+                Write32(rom, ri.monster_wmap_stage_1_pointer, Ptr(stage1));
+                Write32(rom, ri.monster_wmap_stage_2_pointer, Ptr(stage2));
+                Write32(rom, ri.monster_wmap_probability_1_pointer, Ptr(prob1));
+                Write32(rom, ri.monster_wmap_probability_2_pointer, Ptr(prob2));
+
+                // Two skirmish events.
+                uint startEvt = PlantScript(rom, ri.worldmap_skirmish_startevent_pointer, 0x00910000u);
+                uint endEvt = PlantScript(rom, ri.worldmap_skirmish_endevent_pointer, 0x00911000u);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitMonsterWMapProbability(rom, list);
+
+                // base-point table: block 1, rule i<0x9 => count 9, length = 1*(9+1)=10.
+                Assert.Contains(list, a => a.Addr == basePoint && a.Info == "MonsterWMapProbability"
+                    && a.BlockSize == 1 && a.Length == 10 && a.Pointer == ri.monster_wmap_base_point_pointer);
+                // stage tables: block 1, rule i<0xB => count 11, length = 12.
+                Assert.Contains(list, a => a.Addr == stage1 && a.Info == "MonsterWMapStageEirika"
+                    && a.BlockSize == 1 && a.Length == 12);
+                Assert.Contains(list, a => a.Addr == stage2 && a.Info == "MonsterWMapStageEphraim"
+                    && a.BlockSize == 1 && a.Length == 12);
+                // probability tables: block 9, rule i<0xB => count 11, length = 9*12=108.
+                Assert.Contains(list, a => a.Addr == prob1 && a.Info == "MonsterWMapProbabilityEirika"
+                    && a.BlockSize == 9 && a.Length == 9u * 12u);
+                Assert.Contains(list, a => a.Addr == prob2 && a.Info == "MonsterWMapProbabilityEphraim"
+                    && a.BlockSize == 9 && a.Length == 9u * 12u);
+
+                // Both skirmish scripts traced.
+                Assert.Contains(list, a => a.Addr == startEvt && a.DataType == Address.DataTypeEnum.EVENTSCRIPT);
+                Assert.Contains(list, a => a.Addr == endEvt && a.DataType == Address.DataTypeEnum.EVENTSCRIPT);
+            });
+        }
+
+        [Fact]
+        public void EmitMonsterWMapProbability_ZeroedRom_EmitsNothing()
+        {
+            WithEnv(rom =>
+            {
+                // RomInfo pointer slots all read 0 in a zeroed ROM -> nothing resolves.
+                var list = new List<Address>();
+                RebuildProducerCore.EmitMonsterWMapProbability(rom, list);
+                Assert.Empty(list);
+            });
+        }
+
+        // =================================================================
+        // EmitEventBattleTalk
+        // =================================================================
+
+        [Fact]
+        public void EmitEventBattleTalk_EmitsMainIfrAndPerEntryScript()
+        {
+            WithEnv(rom =>
+            {
+                var ri = rom.RomInfo;
+                uint tableBase = 0x00920000u;     // block 16, PI {12}
+                Write32(rom, ri.event_ballte_talk_pointer, Ptr(tableBase));
+
+                // Row 0: unit id 0x10, special-event pointer at +12 -> a script.
+                rom.Data[tableBase + 0] = 0x10;
+                uint script = 0x00921000u;
+                Write32(rom, tableBase + 12, Ptr(script));
+                rom.write_u32(script + 0, 0x0000000A); // ENDA
+                // Row 1: terminator (u16(addr)==0xFFFF stops the IFR walk).
+                rom.write_u16(tableBase + 16, 0xFFFF);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitEventBattleTalk(rom, list);
+
+                // Main IFR: block 16, count 1 (row 0 only), length = 16*(1+1)=32, PI {12}.
+                var ifr = list.Single(a => a.Addr == tableBase && a.Info == "EventBattleTalkForm");
+                Assert.Equal(16u, ifr.BlockSize);
+                Assert.Equal(16u * 2u, ifr.Length);
+                Assert.Equal(ri.event_ballte_talk_pointer, ifr.Pointer);
+
+                // Per-entry traced script.
+                Assert.Contains(list, a => a.Addr == script && a.DataType == Address.DataTypeEnum.EVENTSCRIPT);
+            });
+        }
+
+        [Fact]
+        public void EmitEventBattleTalk_EntryWithUnsafeEventPointer_SkipsTrace()
+        {
+            WithEnv(rom =>
+            {
+                var ri = rom.RomInfo;
+                uint tableBase = 0x00920000u;
+                Write32(rom, ri.event_ballte_talk_pointer, Ptr(tableBase));
+                rom.Data[tableBase + 0] = 0x10;
+                Write32(rom, tableBase + 12, 0x00000000u); // NULL event pointer -> not isSafetyPointer
+                rom.write_u16(tableBase + 16, 0xFFFF);     // terminator
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitEventBattleTalk(rom, list);
+
+                // Main IFR still emitted; no EVENTSCRIPT block.
+                Assert.Contains(list, a => a.Addr == tableBase && a.Info == "EventBattleTalkForm");
+                Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.EVENTSCRIPT);
+            });
+        }
+
+        // =================================================================
+        // EmitEventHaiku
+        // =================================================================
+
+        [Fact]
+        public void EmitEventHaiku_EmitsMainIfrAndPerEntryScript()
+        {
+            WithEnv(rom =>
+            {
+                var ri = rom.RomInfo;
+                uint tableBase = 0x00930000u;     // block 12, PI {8}
+                Write32(rom, ri.event_haiku_pointer, Ptr(tableBase));
+
+                rom.Data[tableBase + 0] = 0x10;   // unit id
+                uint script = 0x00931000u;
+                Write32(rom, tableBase + 8, Ptr(script));  // event pointer at +8
+                rom.write_u32(script + 0, 0x0000000A);     // ENDA
+                rom.write_u16(tableBase + 12, 0xFFFF);     // terminator
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitEventHaiku(rom, list);
+
+                var ifr = list.Single(a => a.Addr == tableBase && a.Info == "Haiku");
+                Assert.Equal(12u, ifr.BlockSize);
+                Assert.Equal(12u * 2u, ifr.Length);   // count 1 -> 12*(1+1)
+                Assert.Equal(ri.event_haiku_pointer, ifr.Pointer);
+
+                Assert.Contains(list, a => a.Addr == script && a.DataType == Address.DataTypeEnum.EVENTSCRIPT);
+            });
+        }
+
+        // =================================================================
+        // EmitWorldMapEventPointer
+        // =================================================================
+
+        [Fact]
+        public void EmitWorldMapEventPointer_EmitsTwoTablesPerEntryAndThreeFixedEvents()
+        {
+            WithEnv(rom =>
+            {
+                var ri = rom.RomInfo;
+                // "Before" table: block 4, rule i==0?true:isPointer(u32). Row 0 = a pointer
+                // to a script; row 1 = a non-pointer -> walk stops at count 1.
+                uint beforeBase = 0x00940000u;
+                Write32(rom, ri.worldmap_event_on_stageclear_pointer, Ptr(beforeBase));
+                uint beforeScript = 0x00941000u;
+                Write32(rom, beforeBase + 0, Ptr(beforeScript));
+                rom.write_u32(beforeScript + 0, 0x0000000A); // ENDA
+                Write32(rom, beforeBase + 4, 0x00000000u);   // non-pointer -> stop
+
+                // "After" table.
+                uint afterBase = 0x00942000u;
+                Write32(rom, ri.worldmap_event_on_stageselect_pointer, Ptr(afterBase));
+                uint afterScript = 0x00943000u;
+                Write32(rom, afterBase + 0, Ptr(afterScript));
+                rom.write_u32(afterScript + 0, 0x0000000A);
+                Write32(rom, afterBase + 4, 0x00000000u);
+
+                // Three fixed events.
+                uint opScript = PlantScript(rom, ri.oping_event_pointer, 0x00944000u);
+                uint ed1Script = PlantScript(rom, ri.ending1_event_pointer, 0x00945000u);
+                uint ed2Script = PlantScript(rom, ri.ending2_event_pointer, 0x00946000u);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitWorldMapEventPointer(rom, list);
+
+                // Both IFR tables present (block 4, PI {0}, count 1 -> length 8).
+                Assert.Contains(list, a => a.Addr == beforeBase && a.Info == "WorldMapEvent Before"
+                    && a.BlockSize == 4 && a.Length == 8 && a.Pointer == ri.worldmap_event_on_stageclear_pointer);
+                Assert.Contains(list, a => a.Addr == afterBase && a.Info == "WorldMapEvent After"
+                    && a.BlockSize == 4 && a.Length == 8 && a.Pointer == ri.worldmap_event_on_stageselect_pointer);
+
+                // Per-entry traced scripts.
+                Assert.Contains(list, a => a.Addr == beforeScript && a.DataType == Address.DataTypeEnum.EVENTSCRIPT);
+                Assert.Contains(list, a => a.Addr == afterScript && a.DataType == Address.DataTypeEnum.EVENTSCRIPT);
+                // Three fixed events traced.
+                Assert.Contains(list, a => a.Addr == opScript && a.DataType == Address.DataTypeEnum.EVENTSCRIPT);
+                Assert.Contains(list, a => a.Addr == ed1Script && a.DataType == Address.DataTypeEnum.EVENTSCRIPT);
+                Assert.Contains(list, a => a.Addr == ed2Script && a.DataType == Address.DataTypeEnum.EVENTSCRIPT);
+            });
+        }
+
+        [Fact]
+        public void EmitWorldMapEventPointer_ZeroedRom_EmitsNothing()
+        {
+            WithEnv(rom =>
+            {
+                var list = new List<Address>();
+                RebuildProducerCore.EmitWorldMapEventPointer(rom, list);
+                Assert.Empty(list);
+            });
+        }
+
+        // =================================================================
+        // Near-EOF safety (all four)
+        // =================================================================
+
+        [Fact]
+        public void ScanScriptFamily_NearEof_DoesNotThrow()
+        {
+            WithEnv(rom =>
+            {
+                var ri = rom.RomInfo;
+                uint nearEof = (uint)rom.Data.Length - 4;
+                // Point every table/event slot at the very last 4 bytes.
+                foreach (uint slot in new[]
+                {
+                    ri.monster_wmap_base_point_pointer, ri.monster_wmap_stage_1_pointer,
+                    ri.monster_wmap_stage_2_pointer, ri.monster_wmap_probability_1_pointer,
+                    ri.monster_wmap_probability_2_pointer, ri.worldmap_skirmish_startevent_pointer,
+                    ri.worldmap_skirmish_endevent_pointer, ri.event_ballte_talk_pointer,
+                    ri.event_haiku_pointer, ri.worldmap_event_on_stageclear_pointer,
+                    ri.worldmap_event_on_stageselect_pointer, ri.oping_event_pointer,
+                    ri.ending1_event_pointer, ri.ending2_event_pointer,
+                })
+                {
+                    Write32(rom, slot, Ptr(nearEof));
+                }
+
+                var list = new List<Address>();
+                Exception ex = Record.Exception(() =>
+                {
+                    RebuildProducerCore.EmitMonsterWMapProbability(rom, list);
+                    RebuildProducerCore.EmitEventBattleTalk(rom, list);
+                    RebuildProducerCore.EmitWorldMapEventPointer(rom, list);
+                    RebuildProducerCore.EmitEventHaiku(rom, list);
+                });
+                Assert.Null(ex);
+            });
+        }
+
+        // =================================================================
+        // Producer-body gating: disasm unwired -> all four re-reported.
+        // =================================================================
+
+        [Fact]
+        public void MakeAllStructPointers_FE8_DisasmUnwired_ReReportsAllFour()
+        {
+            var rom = MakeFe8uRom();
+            var prevRom = CoreState.ROM;
+            var prevEs = CoreState.EventScript;
+            var prevComment = CoreState.CommentCache;
+            try
+            {
+                CoreState.ROM = rom;
+                CoreState.EventScript = null;   // disasm NOT wired
+                CoreState.CommentCache = null;
+                var result = RebuildProducerCore.MakeAllStructPointers(rom);
+                // The four ScanScript-family forms (and EventCondForm) are re-reported because
+                // their script trace would otherwise be silently dropped.
+                Assert.Contains("MonsterWMapProbabilityForm", result.NotYetPorted);
+                Assert.Contains("EventBattleTalkForm", result.NotYetPorted);
+                Assert.Contains("WorldMapEventPointerForm", result.NotYetPorted);
+                Assert.Contains("EventHaikuForm", result.NotYetPorted);
+                Assert.False(result.IsComplete);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.EventScript = prevEs;
+                CoreState.CommentCache = prevComment;
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -1030,6 +1030,59 @@ namespace FEBuilderGBA
                 }
                 progress?.Report("MapSetting");
                 EmitMapSetting(rom, list);
+
+                // ---- slice 2aa: the four FE8 ScanScript-family data-path forms ----
+                // WF (U.MakeAllStructPointersList, version==8 branch) calls, in this relative
+                // order: MonsterWMapProbabilityForm, EventBattleTalkForm, WorldMapEventPointerForm,
+                // EventHaikuForm. Each references event scripts (EventScriptForm.ScanScript), so
+                // each reuses the slice-2u block-emitter EmitScanScript — whose hard prerequisite
+                // is the event-script disassembler. Mirror the EventCondForm posture EXACTLY: when
+                // the disasm IS wired, emit all four; when it is NOT, skip them AND re-report all
+                // four in NotYetPorted (so the omitted ScanScript blocks are never silent and
+                // IsComplete stays false). The flat IFR tables share the same gate because a
+                // partial emit (tables but no traced scripts) would corrupt a relocation rebuild.
+                if (IsEventScriptDisasmReady(rom))
+                {
+                    if (ct.IsCancellationRequested)
+                    {
+                        progress?.Report("MakeAllStructPointersList cancelled");
+                        return new ProducerResult(list, notYet, cancelled: true);
+                    }
+                    progress?.Report("MonsterWMapProbability");
+                    EmitMonsterWMapProbability(rom, list);
+
+                    if (ct.IsCancellationRequested)
+                    {
+                        progress?.Report("MakeAllStructPointersList cancelled");
+                        return new ProducerResult(list, notYet, cancelled: true);
+                    }
+                    progress?.Report("EventBattleTalk");
+                    EmitEventBattleTalk(rom, list);
+
+                    if (ct.IsCancellationRequested)
+                    {
+                        progress?.Report("MakeAllStructPointersList cancelled");
+                        return new ProducerResult(list, notYet, cancelled: true);
+                    }
+                    progress?.Report("WorldMapEventPointer");
+                    EmitWorldMapEventPointer(rom, list);
+
+                    if (ct.IsCancellationRequested)
+                    {
+                        progress?.Report("MakeAllStructPointersList cancelled");
+                        return new ProducerResult(list, notYet, cancelled: true);
+                    }
+                    progress?.Report("EventHaiku");
+                    EmitEventHaiku(rom, list);
+                }
+                else
+                {
+                    progress?.Report("ScanScript-family FE8 forms (skipped — disassembler not wired)");
+                    notYet = AppendNotYetPorted(notYet, "MonsterWMapProbabilityForm");
+                    notYet = AppendNotYetPorted(notYet, "EventBattleTalkForm");
+                    notYet = AppendNotYetPorted(notYet, "WorldMapEventPointerForm");
+                    notYet = AppendNotYetPorted(notYet, "EventHaikuForm");
+                }
             }
 
             if (rom.RomInfo.version == 7)
@@ -9924,6 +9977,217 @@ namespace FEBuilderGBA
                 (i, addr) => IsTextEntryExists(rom, rom.u32(addr)));
         }
 
+        // ====================================================================
+        // slice 2aa — four FE8 ScanScript-family data-path forms.
+        //
+        // Each of these WF forms (version==8 only) references event scripts and so
+        // reuses the slice-2u block-emitter EmitScanScript (the verbatim port of
+        // EventScriptForm.ScanScript). Like EmitEventCond they have a HARD
+        // prerequisite on the event-script disassembler — the producer body gates
+        // their dispatch on IsEventScriptDisasmReady and re-reports all four in
+        // NotYetPorted when it is unwired (so the omitted script blocks are never
+        // silent). Each emitter ALSO self-checks via EmitScanScript's own throw, so
+        // a direct caller cannot silently drop coverage either.
+        //
+        // The flat IFR main tables are emitted via Address.AddAddressInstantIFR
+        // (the exact Core equivalent of AddressWinForms.AddAddress(list, IFR, name,
+        // pointerIndexes): addr = p32(pointer), length = block*(count+1), guarded).
+        // ====================================================================
+
+        /// <summary>
+        /// VERBATIM port of <c>MonsterWMapProbabilityForm.MakeAllDataLength</c>
+        /// (MonsterWMapProbabilityForm.cs:156). Emits the five flat IFR probability /
+        /// stage tables (base-point + the Eirika/Ephraim stage and probability tables,
+        /// the latter four reached by <c>ReInitPointer</c> in WF) then runs
+        /// <see cref="EmitScanScript"/> over the two world-map skirmish start/end event
+        /// pointers (a single shared tracelist, isWithEventUnit=true, isWorldMapEvent=true).
+        /// </summary>
+        public static void EmitMonsterWMapProbability(ROM rom, List<Address> list)
+        {
+            // Init: base_point table, block 1, IsDataExists i < 0x9, name "MonsterWMapProbability", PI {}.
+            EmitInstantIfrTable(rom, list, rom.RomInfo.monster_wmap_base_point_pointer, 1,
+                (i, addr) => i < 0x9, "MonsterWMapProbability", EmptyPI);
+
+            // N1_Init: block 1, IsDataExists i < 0xB; ReInitPointer to the two stage pointers.
+            EmitInstantIfrTable(rom, list, rom.RomInfo.monster_wmap_stage_1_pointer, 1,
+                (i, addr) => i < 0xB, "MonsterWMapStageEirika", EmptyPI);
+            EmitInstantIfrTable(rom, list, rom.RomInfo.monster_wmap_stage_2_pointer, 1,
+                (i, addr) => i < 0xB, "MonsterWMapStageEphraim", EmptyPI);
+
+            // N2_Init: block 9, IsDataExists i < 0xB; ReInitPointer to the two probability pointers.
+            EmitInstantIfrTable(rom, list, rom.RomInfo.monster_wmap_probability_1_pointer, 9,
+                (i, addr) => i < 0xB, "MonsterWMapProbabilityEirika", EmptyPI);
+            EmitInstantIfrTable(rom, list, rom.RomInfo.monster_wmap_probability_2_pointer, 9,
+                (i, addr) => i < 0xB, "MonsterWMapProbabilityEphraim", EmptyPI);
+
+            // The two skirmish start/end events (WF: one shared tracelist, isWithEventUnit=true,
+            // isWorldMapEvent=true). EmitScanScript guards the slot's full 4-byte read internally.
+            var tracelist = new List<uint>();
+            EmitScanScript(rom, list, rom.RomInfo.worldmap_skirmish_startevent_pointer, true, true,
+                "FreeMapStartEvent", tracelist);
+            EmitScanScript(rom, list, rom.RomInfo.worldmap_skirmish_endevent_pointer, true, true,
+                "FreeMapEndEvent", tracelist);
+        }
+
+        /// <summary>
+        /// VERBATIM port of <c>EventBattleTalkForm.MakeAllDataLength</c>
+        /// (EventBattleTalkForm.cs:95). Emits the main "EventBattleTalkForm" IFR (block 16,
+        /// PI {12}) then, per entry, traces the special-event pointer at <c>addr+12</c> via
+        /// <see cref="EmitScanScript"/> (isWithEventUnit=true, isWorldMapEvent=false) when
+        /// it is a safe pointer.
+        /// </summary>
+        public static void EmitEventBattleTalk(ROM rom, List<Address> list)
+        {
+            const string name = "EventBattleTalkForm";
+            EmitTalkLikeForm(rom, list, rom.RomInfo.event_ballte_talk_pointer, 16, 10,
+                spEventOffset: 12, name, name);
+        }
+
+        /// <summary>
+        /// VERBATIM port of <c>EventHaikuForm.MakeAllDataLength</c> (EventHaikuForm.cs:99).
+        /// Emits the main "Haiku" IFR (block 12, PI {8}) then, per entry, traces the
+        /// special-event pointer at <c>addr+8</c> via <see cref="EmitScanScript"/>
+        /// (isWithEventUnit=true, isWorldMapEvent=false) when it is a safe pointer.
+        /// </summary>
+        public static void EmitEventHaiku(ROM rom, List<Address> list)
+        {
+            EmitTalkLikeForm(rom, list, rom.RomInfo.event_haiku_pointer, 12, 10,
+                spEventOffset: 8, "Haiku", "Haiku");
+        }
+
+        /// <summary>
+        /// Shared body for the two FE8 "talk record" forms (EventBattleTalk / Haiku):
+        /// both Init with a terminator-plus-empty-guard IFR rule (<c>u16(addr)==0xFFFF</c>
+        /// terminator; <c>i &gt; 10 &amp;&amp; IsEmpty(addr, block*10)</c> guard) and per entry
+        /// ScanScript the special-event pointer at <c>addr + spEventOffset</c> (the same
+        /// field that is the IFR pointer column). Reproduces both WF
+        /// <c>MakeAllDataLength</c>s VERBATIM.
+        /// </summary>
+        static void EmitTalkLikeForm(ROM rom, List<Address> list, uint pointerField, uint block,
+            int emptyGuardThreshold, uint spEventOffset, string ifrName, string eventNameBase)
+        {
+            uint pointer = U.toOffset(pointerField);
+            if (!U.isSafetyOffset(pointer + 3, rom)) return;
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom)) return;
+
+            uint dataCount = rom.getBlockDataCount(baseAddr, block,
+                (i, addr) => IsTalkRecordExists(rom, addr, i, block, emptyGuardThreshold));
+
+            // AddressWinForms.AddAddress(list, IFR, name, { spEventOffset }): length = block*(count+1).
+            Address.AddAddressInstantIFR(list, pointer, block, dataCount, ifrName,
+                new uint[] { spEventOffset });
+
+            var tracelist = new List<uint>();
+            uint addr2 = baseAddr;
+            for (uint i = 0; i < dataCount; i++, addr2 += block)
+            {
+                uint slot = addr2 + spEventOffset;
+                // WF: spEventP = ROM.u32(addr + spEventOffset); skip unless isSafetyPointer.
+                if (!U.isSafetyOffset(slot + 3, rom)) continue;
+                uint spEventP = rom.u32(slot);
+                if (!U.isSafetyPointer(spEventP, rom)) continue;
+
+                uint unitid = rom.u8(addr2 + 0);
+                string eventName = eventNameBase + " " + U.ToHexString(unitid);
+                EmitScanScript(rom, list, slot, true, false, eventName, tracelist);
+            }
+        }
+
+        /// <summary>VERBATIM port of the EventBattleTalk/Haiku <c>Init</c> IsDataExists rule
+        /// (both forms share it): <c>u16(addr)==0xFFFF</c> terminator; otherwise
+        /// <c>i &gt; threshold &amp;&amp; IsEmpty(addr, block*threshold)</c> false; else true.
+        /// All reads are EOF-guarded (getBlockDataCount already bounds addr+block&lt;=Length,
+        /// and IsEmpty is internally EOF-safe).</summary>
+        static bool IsTalkRecordExists(ROM rom, uint addr, int i, uint block, int threshold)
+        {
+            if (rom.u16(addr) == 0xFFFF)
+            {
+                return false;
+            }
+            if (i > threshold && rom.IsEmpty(addr, block * (uint)threshold))
+            {//終端符号を無視して 0x00等を利用している人がいるため
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// VERBATIM port of <c>WorldMapEventPointerForm.MakeAllDataLength</c>
+        /// (WorldMapEventPointerForm.cs:247). Emits the two world-map event pointer IFR
+        /// tables ("WorldMapEvent Before" on <c>worldmap_event_on_stageclear_pointer</c> and
+        /// "WorldMapEvent After" on <c>worldmap_event_on_stageselect_pointer</c>, block 4,
+        /// PI {0}), running <see cref="EmitScanScript"/> per table entry, then the three
+        /// fixed opening / Eirika-ending / Ephraim-ending events. One shared tracelist;
+        /// every ScanScript call is isWithEventUnit=true, isWorldMapEvent=true.
+        /// </summary>
+        public static void EmitWorldMapEventPointer(ROM rom, List<Address> list)
+        {
+            var tracelist = new List<uint>();
+
+            EmitWorldMapEventTable(rom, list, rom.RomInfo.worldmap_event_on_stageclear_pointer,
+                "WorldMapEvent Before", tracelist);
+            EmitWorldMapEventTable(rom, list, rom.RomInfo.worldmap_event_on_stageselect_pointer,
+                "WorldMapEvent After", tracelist);
+
+            EmitScanScript(rom, list, rom.RomInfo.oping_event_pointer, true, true,
+                "OpeningEvent", tracelist);
+            EmitScanScript(rom, list, rom.RomInfo.ending1_event_pointer, true, true,
+                "EirikaEnding", tracelist);
+            EmitScanScript(rom, list, rom.RomInfo.ending2_event_pointer, true, true,
+                "EphraimEnding", tracelist);
+        }
+
+        /// <summary>One WorldMapEventPointer IFR table: block 4, IsDataExists
+        /// <c>i==0 ? true : isPointer(u32(addr))</c>, PI {0}; per entry ScanScript the slot
+        /// pointer (isWithEventUnit=true, isWorldMapEvent=true) over the shared tracelist.</summary>
+        static void EmitWorldMapEventTable(ROM rom, List<Address> list, uint pointerField,
+            string name, List<uint> tracelist)
+        {
+            const uint block = 4;
+            uint pointer = U.toOffset(pointerField);
+            if (!U.isSafetyOffset(pointer + 3, rom)) return;
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom)) return;
+
+            uint dataCount = rom.getBlockDataCount(baseAddr, block, (i, addr) =>
+            {
+                if (i == 0) return true;
+                return U.isPointer(rom.u32(addr));
+            });
+
+            // AddressWinForms.AddAddress(list, IFR, name, {0}): length = block*(count+1).
+            Address.AddAddressInstantIFR(list, pointer, block, dataCount, name, new uint[] { 0 });
+
+            uint p = baseAddr;
+            for (uint i = 0; i < dataCount; i++, p += block)
+            {
+                string entryName = name + " " + U.To0xHexString(i);
+                EmitScanScript(rom, list, p, true, true, entryName, tracelist);
+            }
+        }
+
+        /// <summary>Emit one flat IFR table via the Core equivalent of
+        /// <c>AddressWinForms.AddAddress(list, IFR, name, pointerIndexes)</c>: resolve the
+        /// base, count it with <paramref name="isDataExists"/>, and emit the IFR Address
+        /// (length = block*(count+1)). Used by <see cref="EmitMonsterWMapProbability"/> for
+        /// its five flat tables (the Init / ReInitPointer tables — with <c>self==null</c> a
+        /// ReInitPointer count is the SAME 3-arg getBlockDataCount as Init).</summary>
+        static void EmitInstantIfrTable(ROM rom, List<Address> list, uint pointerField, uint block,
+            Func<int, uint, bool> isDataExists, string name, uint[] pointerIndexes)
+        {
+            if (block == 0) return; // a zero block would make getBlockDataCount spin; not real data.
+            uint pointer = U.toOffset(pointerField);
+            if (!U.isSafetyOffset(pointer + 3, rom)) return;
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom)) return;
+
+            uint dataCount = rom.getBlockDataCount(baseAddr, block, isDataExists);
+            Address.AddAddressInstantIFR(list, pointer, block, dataCount, name, pointerIndexes);
+        }
+
+        static readonly uint[] EmptyPI = new uint[] { };
+
         /// <summary>
         /// The <c>MakeAllDataLength</c> statics from <c>U.MakeAllStructPointersList</c> /
         /// <c>U.AppendAllASMStructPointersList</c> that this slice does <b>not</b> yet port.
@@ -10242,17 +10506,23 @@ namespace FEBuilderGBA
                 //      PI {0,8,28}; per entry CString@+0, Lz77@+8 (LZ77IMG), anime-guard@+28, then N2
                 //      NestedIfr@+28 (block 2, u8!=0); + a trailing absolute AddPointer(0x0B0038, 0x20,
                 //      PAL) common-palette pointer. (FE8U/FE7U non-multibyte variants STAY deferred.)
+                //  slice 2aa ported the four FE8 ScanScript-family data-path forms (each reuses the
+                //  slice-2u EmitScanScript block-emitter; the producer body gates their dispatch on
+                //  IsEventScriptDisasmReady and re-reports them in NotYetPorted when it is unwired,
+                //  exactly like EventCondForm — so the omitted script blocks are never silent):
+                //    MonsterWMapProbabilityForm [FE8] — EmitMonsterWMapProbability: five flat IFR
+                //      probability/stage tables (base-point block 1 rule i<0x9; the Eirika/Ephraim
+                //      stage block 1 + probability block 9 tables, rule i<0xB, reached by WF's
+                //      ReInitPointer — with self==null a ReInitPointer count is the SAME 3-arg
+                //      getBlockDataCount), then EmitScanScript over the two skirmish start/end events.
+                //    EventBattleTalkForm [FE8] — EmitEventBattleTalk: main IFR block 16 PI {12},
+                //      terminator u16==0xFFFF + i>10 IsEmpty(block*10) guard; per entry ScanScript the
+                //      special-event pointer @ addr+12 when isSafetyPointer.
+                //    EventHaikuForm [FE8] — EmitEventHaiku: same shape, block 12 PI {8}, event @ addr+8.
+                //    WorldMapEventPointerForm [FE8] — EmitWorldMapEventPointer: two event-pointer IFR
+                //      tables (block 4 rule i==0?true:isPointer(u32), PI {0}) each ScanScript per entry,
+                //      then the three fixed opening / Eirika-ending / Ephraim-ending events.
                 //  STILL deferred (event-scan / recursive / dynamic base / LZ77 CG):
-                //  NOTE: the Core ScanScript BLOCK-emitter (EmitScanScript) now EXISTS (slice 2u). The four
-                //  ScanScript-dependent forms below are no longer blocked on the missing primitive — they
-                //  stay only because slice 2u was scoped to EventCondForm. Each is now a small follow-up
-                //  (resolve its base/entry table, then EmitScanScript over its event pointer(s)).
-                //  MonsterWMapProbabilityForm STAYS — its 5 IFR probability/stage tables are flat ROM reads,
-                //    but its MakeAllDataLength ALSO emits ScanScript over the two skirmish start/end event
-                //    pointers; porting only the flat tables would drop those skirmish-event regions =
-                //    corruption, so it is ported as a unit (with EmitScanScript) in a later slice.
-                //  WorldMapEventPointerForm [ScanScript over the world-map event pointer table],
-                //  EventBattleTalkForm + EventHaikuForm [FE8, ScanScript per-entry],
                 //  MapSettingForm [FE8] ported in slice 2r (EmitMapSetting) — its count rule
                 //    (IsMapSettingEnd, reproduced VERBATIM) needs the WF cached text count
                 //    TextForm.GetDataCount(); that is now byte-faithfully reproduced by TextDataCount (the
@@ -10268,10 +10538,6 @@ namespace FEBuilderGBA
                 //   assignLevelUpAddr (block 2, u16 != 0xFFFF && != 0) via the slice-2i primitive.)
                 //  (ImageCGFE7UForm ported in slice 2k — EmitImageCGFE7U, the FE7U 16-byte big-CG IFR
                 //   with the per-entry flag@+0 16-color-vs-10-split + HEADER-TSA.))
-                "MonsterWMapProbabilityForm",
-                "EventBattleTalkForm",
-                "WorldMapEventPointerForm",
-                "EventHaikuForm",
                 // patch / procs / ASM — OUT OF SCOPE for this data-path producer: these are emitted by
                 // U.AppendAllASMStructPointersList (the ASM/LDR-map path), NOT U.MakeAllStructPointersList.
                 // (EventFunctionPointerForm / Command85PointerForm above are likewise ASM-path forms.)


### PR DESCRIPTION
## Summary

Slice 2aa of the #1261 ROM-rebuild producer marathon. Ports **four FE8 data-path forms** whose entries reference event scripts into `RebuildProducerCore.MakeAllStructPointers` — each a VERBATIM port of its WinForms `MakeAllDataLength`, each reusing the slice-2u `EmitScanScript` block-emitter (the verbatim port of `EventScriptForm.ScanScript`) for its per-entry / fixed event-script trace.

Part of #1261.

## Forms ported (FE8 / `version==8` only — gated EXACTLY at the WF `U.MakeAllStructPointersList` call site)

| WF form (file:line) | Core emitter | Shape |
|---|---|---|
| `MonsterWMapProbabilityForm.cs:156` | `EmitMonsterWMapProbability` | five flat IFR tables (base-point block 1 rule `i<0x9`; Eirika/Ephraim stage block 1 + probability block 9, rule `i<0xB`, the latter four reached via WF `ReInitPointer`) + `EmitScanScript` over the two skirmish start/end events |
| `EventBattleTalkForm.cs:95` | `EmitEventBattleTalk` | main IFR block 16 PI `{12}`, terminator `u16==0xFFFF` + `i>10 && IsEmpty(block*10)` guard; per entry `EmitScanScript` the special-event pointer @ `addr+12` when `isSafetyPointer` |
| `WorldMapEventPointerForm.cs:247` | `EmitWorldMapEventPointer` | two event-pointer IFR tables (block 4, rule `i==0?true:isPointer(u32)`, PI `{0}`) each `EmitScanScript` per entry, then the three fixed opening / Eirika-ending / Ephraim-ending events |
| `EventHaikuForm.cs:99` | `EmitEventHaiku` | same shape as EventBattleTalk, block 12 PI `{8}`, event @ `addr+8` |

All four reuse `EmitScanScript(rom, list, scriptPointer, isWithEventUnit, isWorldMapEvent, name, tracelist)` — matching each WF `ScanScript` call's exact arg pattern (the two WorldMap/MonsterWMap families pass `isWorldMapEvent=true`; all pass `isWithEventUnit=true`). Each form's shared `tracelist` matches its WF scope exactly.

## Faithfulness & safety

- Flat IFR tables emitted via `Address.AddAddressInstantIFR` (the exact Core equivalent of `AddressWinForms.AddAddress(list, IFR, name, pointerIndexes)`: `addr = p32(pointer)`, `length = block*(count+1)`, guarded).
- Every computed read is EOF-guarded (`slot+3` before `u32`; `getBlockDataCount` bounds the IFR walk; `IsEmpty` is internally EOF-safe; per-entry loops bound by the IFR `DataCount`).
- All reads use the threaded `rom` — never `Program.ROM`/`CoreState.ROM`.
- **Disasm gating (honest, never silent):** like `EmitEventCond`, these have a HARD prerequisite on the event-script disassembler. The producer body gates their dispatch on `IsEventScriptDisasmReady` and **re-reports all four in `NotYetPorted`** when it is unwired, so the traced script blocks are never silently dropped and `IsComplete` stays false. `EmitScanScript` also self-throws if called directly with the disassembler unwired.
- Shrinks the data-path `NotYetPorted` tail by removing all four forms from `NotYetPortedRaw`.

No form deferred — all four ported.

## Test plan

- [x] `dotnet test FEBuilderGBA.Core.Tests --filter "FullyQualifiedName~RebuildProducer"` → **391 passed, 0 failed** (baseline 382 + 9 new).
- [x] New `RebuildProducerScanScriptFamilyTests`: per-form valid-emit (right addr/length/pointer/type), per-entry ScanScript trace emits the referenced-script block, zeroed-ROM emits nothing, near-EOF doesn't throw, and the producer-body disasm-unwired path re-reports all four.
- [x] Updated stale `NotYetPorted` assertions in `RebuildProducerCoreTests` / `RebuildProducerEventCondTests` (the four forms are now asserted GONE).
- [x] `dotnet build FEBuilderGBA.sln` clean (0 errors) — the WF-parity test in FEBuilderGBA.Tests still compiles.
- [x] Full `FEBuilderGBA.Core.Tests` run: only the 10 known `Skill*`/`SkillSystemsAnime*` failures from the un-checked-out `config/patch2` submodule (pre-existing, env-only, identical on origin/master); **zero non-Skill failures**.

## Scope

Core-only (no GUI) → no screenshot required.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]