### PR TITLE
feat(core): ROM-rebuild producer — FontForm + UnitCustomBattleAnime (#1261 slice 2ab)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -649,9 +649,13 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.DoesNotContain("MonsterWMapProbabilityForm", notYet2b);
                 Assert.DoesNotContain("EventBattleTalkForm", notYet2b);
                 // (MapTileAnimation1Form is now PORTED in slice 2g, the MapTerrain lookup tables in
-                //  slice 2j, and SongTableForm in slice 2r — so the still-deferred misc sibling tracked
-                //  here is UnitCustomBattleAnimeForm [per-unit custom battle-anime recycle, not in Core].)
-                Assert.Contains("UnitCustomBattleAnimeForm", notYet2b);
+                //  slice 2j, SongTableForm in slice 2r, and UnitCustomBattleAnimeForm in slice 2ab — the
+                //  latter is a simple two-level N2/InputFormRef pointer loop, NO anime recycle, so it is
+                //  no longer reported as NotYetPorted.)
+                Assert.DoesNotContain("UnitCustomBattleAnimeForm", notYet2b);
+                // FontForm is also PORTED in slice 2ab (EmitFont — item/text hash-chain + status font +
+                //  the ZH direct-ref codeB walk).
+                Assert.DoesNotContain("FontForm", notYet2b);
 
                 // FAITHFULNESS / COMPLETENESS-SAFETY: ItemForm is NOT emitted (its StatBooster
                 // sub-block size needs un-ported PatchUtil detection) — it must be absent from the

--- a/FEBuilderGBA.Core.Tests/RebuildProducerFontTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerFontTests.cs
@@ -1,0 +1,369 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// Tests for the slice-2ab ROM-rebuild producer FontForm port
+    /// (<see cref="RebuildProducerCore.EmitFont"/> and friends). The producer reproduces
+    /// <c>FontForm.MakeAllDataLength</c> VERBATIM (NOT via the editor enumerators
+    /// FontGlyphRenderCore/FontGlyphZHCore, which diverge): the non-ZH item/text font hash-chain walks
+    /// (JP-SJIS / UTF8 / LAT1), the fixed-size status-font loop, and the ZH direct-reference codeB walk.
+    /// Synthetic NULL-RomInfo ROMs drive the explicit-address seams; a versioned ROM exercises the
+    /// is_multibyte/ZH gate.
+    /// </summary>
+    [Collection("SharedState")]
+    public class RebuildProducerFontTests : IDisposable
+    {
+        readonly ROM _savedRom = CoreState.ROM;
+        readonly ISystemTextEncoder _savedEncoder = CoreState.SystemTextEncoder;
+        readonly TextEncodingEnum _savedEncoding = CoreState.TextEncoding;
+
+        public void Dispose()
+        {
+            CoreState.ROM = _savedRom;
+            CoreState.SystemTextEncoder = _savedEncoder;
+            CoreState.TextEncoding = _savedEncoding;
+        }
+
+        // ---- helpers -------------------------------------------------------
+
+        static ROM CreateTestRom(int size = 0x8000)
+        {
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(new byte[size]);
+            CoreState.ROM = rom;
+            CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+            return rom;
+        }
+
+        static uint Ptr(uint offset) => offset | 0x08000000u;
+
+        static ROM MakeVersionedRom(string versionString, int size = 0x0200_0000)
+        {
+            var rom = new ROM();
+            bool ok = rom.LoadLow("fake.gba", new byte[size], versionString);
+            Assert.True(ok, "LoadLow did not recognize version string: " + versionString);
+            return rom;
+        }
+
+        // A glyph hash-table entry: next u32 + moji2 + width + nazo3 + nazo4 + 64-byte bitmap.
+        static void WriteGlyph(ROM rom, uint addr, uint nextPtr, byte moji2, byte width)
+        {
+            rom.write_u32(addr + 0, nextPtr);
+            rom.write_u8(addr + 4, moji2);
+            rom.write_u8(addr + 5, width);
+            // +6/+7 + the 64-byte bitmap stay zero (irrelevant to the producer's addr/length/pointer/type).
+        }
+
+        // A minimal ISystemTextEncoder whose GetTBLEncodeDicLow() returns a fixed { char -> moji } map
+        // (the ZH producer path consumes only this — Decode/Encode are unused by EmitFontZH).
+        sealed class FakeTblEncoder : ISystemTextEncoder
+        {
+            readonly Dictionary<string, uint> _map;
+            public FakeTblEncoder(Dictionary<string, uint> map) { _map = map; }
+            public string Decode(byte[] str) => "";
+            public string Decode(byte[] str, int start, int len) => "";
+            public byte[] Encode(string str) => Array.Empty<byte>();
+            public Dictionary<string, uint> GetTBLEncodeDicLow() => _map;
+        }
+
+        // ====================================================================
+        // EmitFontInner — LAT1 (English) branch
+        // ====================================================================
+
+        [Fact]
+        public void EmitFontInner_Lat1_EmitsTopPointerEntryAndPerGlyphFontEntries()
+        {
+            var rom = CreateTestRom();
+            uint topaddress = 0x1000;
+            // LAT1: bucket index = moji2; fontlist = topaddress + (moji2<<2). Seed bucket 0x41 ('A').
+            uint moji2 = 0x41;
+            uint fontlist = topaddress + (moji2 << 2);
+            uint glyph = 0x2000;
+            rom.write_u32(fontlist, Ptr(glyph));
+            WriteGlyph(rom, glyph, nextPtr: 0, moji2: (byte)moji2, width: 7); // single-entry chain (next=0)
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitFontInnerAt(rom, list, isItemFont: true, topaddress,
+                PRIORITY_CODE.LAT1, isMultibyte: false);
+
+            // Top POINTER table entry: (topaddress, 4*0xff, NOT_FOUND, "FontItem", POINTER).
+            Address ptrEntry = list.Single(a => a.DataType == Address.DataTypeEnum.POINTER);
+            Assert.Equal(topaddress, ptrEntry.Addr);
+            Assert.Equal(4u * 0xffu, ptrEntry.Length);
+            Assert.Equal(U.NOT_FOUND, ptrEntry.Pointer);
+
+            // One per-glyph FONT entry: (glyph, 8+64, before_pointer=fontlist, FONT).
+            Address fontEntry = list.Single(a => a.DataType == Address.DataTypeEnum.FONT);
+            Assert.Equal(glyph, fontEntry.Addr);
+            Assert.Equal(8u + 64u, fontEntry.Length);
+            Assert.Equal(fontlist, fontEntry.Pointer);
+        }
+
+        [Fact]
+        public void EmitFontInner_Lat1_WalksMultiEntryChain_WithBeforePointerThreading()
+        {
+            var rom = CreateTestRom();
+            uint topaddress = 0x1000;
+            uint moji2 = 0x42;
+            uint fontlist = topaddress + (moji2 << 2);
+            uint g0 = 0x2000, g1 = 0x2100, g2 = 0x2200;
+            rom.write_u32(fontlist, Ptr(g0));
+            WriteGlyph(rom, g0, nextPtr: Ptr(g1), moji2: (byte)moji2, width: 5);
+            WriteGlyph(rom, g1, nextPtr: Ptr(g2), moji2: (byte)moji2, width: 6);
+            WriteGlyph(rom, g2, nextPtr: 0, moji2: (byte)moji2, width: 7);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitFontInnerAt(rom, list, isItemFont: false, topaddress,
+                PRIORITY_CODE.LAT1, isMultibyte: false);
+
+            var fonts = list.Where(a => a.DataType == Address.DataTypeEnum.FONT).OrderBy(a => a.Addr).ToList();
+            Assert.Equal(3, fonts.Count);
+            // before_pointer threads: g0<-fontlist, g1<-g0, g2<-g1 (WF "before_pointer=p" each step).
+            Assert.Equal(fontlist, fonts[0].Pointer);
+            Assert.Equal(g0, fonts[1].Pointer);
+            Assert.Equal(g1, fonts[2].Pointer);
+            Assert.All(fonts, a => Assert.Equal(8u + 64u, a.Length));
+        }
+
+        // ====================================================================
+        // EmitFontInner — JP-SJIS (multibyte) branch
+        // ====================================================================
+
+        [Fact]
+        public void EmitFontInner_JpSjis_TopPointerLengthAndBucketBase()
+        {
+            var rom = CreateTestRom();
+            uint topaddress = 0x1000;
+            // JP: bucket index = moji1 (0x1f..0xff); fontlist = topaddress + (moji1<<2) - 0x100.
+            uint moji1 = 0x82;
+            uint fontlist = topaddress + (moji1 << 2) - 0x100;
+            uint glyph = 0x2000;
+            rom.write_u32(fontlist, Ptr(glyph));
+            WriteGlyph(rom, glyph, nextPtr: 0, moji2: 0xA0, width: 8);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitFontInnerAt(rom, list, isItemFont: true, topaddress,
+                PRIORITY_CODE.SJIS, isMultibyte: true);
+
+            // JP top POINTER length is 4*(0xff-0x1f) (NOT 4*0xff).
+            Address ptrEntry = list.Single(a => a.DataType == Address.DataTypeEnum.POINTER);
+            Assert.Equal(topaddress, ptrEntry.Addr);
+            Assert.Equal(4u * (0xffu - 0x1fu), ptrEntry.Length);
+
+            // The glyph is reached from the - 0x100 bucket base; before_pointer = that fontlist.
+            Address fontEntry = list.Single(a => a.DataType == Address.DataTypeEnum.FONT);
+            Assert.Equal(glyph, fontEntry.Addr);
+            Assert.Equal(8u + 64u, fontEntry.Length);
+            Assert.Equal(fontlist, fontEntry.Pointer);
+        }
+
+        // ====================================================================
+        // EmitFontInner — UTF8 branch
+        // ====================================================================
+
+        [Fact]
+        public void EmitFontInner_Utf8_TopPointerLengthAndBucketBase()
+        {
+            var rom = CreateTestRom();
+            uint topaddress = 0x1000;
+            // UTF8: bucket index = moji1 (0x00..0xff); fontlist = topaddress + (moji1<<2) (NO -0x100).
+            uint moji1 = 0x10;
+            uint fontlist = topaddress + (moji1 << 2);
+            uint glyph = 0x2000;
+            rom.write_u32(fontlist, Ptr(glyph));
+            WriteGlyph(rom, glyph, nextPtr: 0, moji2: 0x20, width: 8);
+            // UTF8 reads u8(p+6)/u8(p+7) for the name; leave them zero (name is informational only).
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitFontInnerAt(rom, list, isItemFont: false, topaddress,
+                PRIORITY_CODE.UTF8, isMultibyte: false);
+
+            Address ptrEntry = list.Single(a => a.DataType == Address.DataTypeEnum.POINTER);
+            Assert.Equal(4u * 0xffu, ptrEntry.Length);
+
+            Address fontEntry = list.Single(a => a.DataType == Address.DataTypeEnum.FONT);
+            Assert.Equal(glyph, fontEntry.Addr);
+            Assert.Equal(fontlist, fontEntry.Pointer); // bucket base = topaddress + (moji1<<2), no -0x100
+        }
+
+        // ====================================================================
+        // EmitFontStatusFont — fixed-size pointer loop
+        // ====================================================================
+
+        [Fact]
+        public void EmitFontStatusFont_EmitsOneFontPerSlot()
+        {
+            var rom = CreateTestRom();
+            uint toppointer = 0x0400;
+            uint table = 0x1000;
+            rom.write_u32(toppointer, Ptr(table));
+            uint f0 = 0x2000, f1 = 0x2100, f2 = 0x2200;
+            rom.write_u32(table + 0, Ptr(f0));
+            rom.write_u32(table + 4, Ptr(f1));
+            rom.write_u32(table + 8, Ptr(f2));
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitFontStatusFont(rom, list, toppointer, count: 3);
+
+            var fonts = list.Where(a => a.DataType == Address.DataTypeEnum.FONT).OrderBy(a => a.Addr).ToList();
+            Assert.Equal(3, fonts.Count);
+            // pointer field = the SLOT address (table + i*4), length 8+64.
+            Assert.Equal(table + 0, fonts[0].Pointer);
+            Assert.Equal(table + 4, fonts[1].Pointer);
+            Assert.Equal(table + 8, fonts[2].Pointer);
+            Assert.All(fonts, a => Assert.Equal(8u + 64u, a.Length));
+        }
+
+        [Fact]
+        public void EmitFontStatusFont_SkipsUnsafeSlotsButContinues()
+        {
+            var rom = CreateTestRom();
+            uint toppointer = 0x0400;
+            uint table = 0x1000;
+            rom.write_u32(toppointer, Ptr(table));
+            rom.write_u32(table + 0, Ptr(0x2000));
+            rom.write_u32(table + 4, 0);           // unsafe (0) -> WF "continue", NOT a stop
+            rom.write_u32(table + 8, Ptr(0x2200));
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitFontStatusFont(rom, list, toppointer, count: 3);
+
+            // The 0-slot is skipped but the loop continues to slot 2 (count-driven, not terminator).
+            var fonts = list.Where(a => a.DataType == Address.DataTypeEnum.FONT).Select(a => a.Addr).ToList();
+            Assert.Equal(2, fonts.Count);
+            Assert.Contains(0x2000u, fonts);
+            Assert.Contains(0x2200u, fonts);
+        }
+
+        [Fact]
+        public void EmitFontStatusFont_UnsafeTopPointer_EmitsNothing()
+        {
+            var rom = CreateTestRom();
+            var list = new List<Address>();
+            // toppointer 0 is an unsafe offset -> immediate return (WF first guard).
+            RebuildProducerCore.EmitFontStatusFont(rom, list, toppointer: 0, count: 10);
+            Assert.Empty(list);
+        }
+
+        // ====================================================================
+        // EmitFontZH — direct-reference codeB walk
+        // ====================================================================
+
+        [Fact]
+        public void EmitFontZHInner_EmitsOneFontCnPerCodeBKey()
+        {
+            var rom = CreateTestRom(0x40000);
+            uint topaddress = 0x1000;
+            // Two codeB keys.
+            var codeBMap = new Dictionary<uint, string> { { 0x00, "A" }, { 0x54, "B" } };
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitFontZHInnerAt(list, isItemFont: true, topaddress, codeBMap);
+
+            var cn = list.Where(a => a.DataType == Address.DataTypeEnum.FONTCN).OrderBy(a => a.Addr).ToList();
+            Assert.Equal(2, cn.Count);
+            Assert.Equal(topaddress + 0x00, cn[0].Addr);
+            Assert.Equal(topaddress + 0x54, cn[1].Addr);
+            // fontSize = 4 + 40 = 44; pointer = NOT_FOUND (direct-ref, no slot).
+            Assert.All(cn, a => Assert.Equal(4u + 40u, a.Length));
+            Assert.All(cn, a => Assert.Equal(U.NOT_FOUND, a.Pointer));
+        }
+
+        // ====================================================================
+        // EmitFont gate: is_multibyte && ZH_TBL -> ZH branch; else inner+status
+        // ====================================================================
+
+        [Fact]
+        public void EmitFont_NonMultibyteFE8U_TakesInnerWalkNotZh()
+        {
+            var rom = MakeVersionedRom("BE8E01"); // FE8U, non-multibyte
+            CoreState.ROM = rom;
+            CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+            CoreState.TextEncoding = TextEncodingEnum.ZH_TBL; // would only matter if is_multibyte
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitFont(rom, list);
+
+            // FE8U is NOT multibyte, so the ZH gate is false even with ZH_TBL -> non-ZH path: there must be
+            // a top POINTER table entry (the inner walk's hash-table pointer) and NO FONTCN entries.
+            Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.POINTER);
+            Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.FONTCN);
+        }
+
+        [Fact]
+        public void EmitFont_MultibyteZhTbl_TakesZhBranch()
+        {
+            // FE8J is multibyte; with TextEncoding=ZH_TBL the ZH branch fires.
+            var rom = MakeVersionedRom("BE8J01");
+            CoreState.ROM = rom;
+            // The producer maps codeA = (moji & 0xff) [low byte], codeB = (moji >> 8) & 0xff [high byte],
+            // then CalcCodeBRaw = ((codeA-0x81)*0x80 + (codeB-0x80)) * 0x54. Pick moji with low byte >= 0x81
+            // and high byte >= 0x80 so the offset stays small and positive -> topaddress + offset lands
+            // in-bounds of the 32 MiB ROM (else AddAddress would skip the unsafe address and emit nothing).
+            var map = new Dictionary<string, uint>
+            {
+                { "你", 0x81A1u }, // codeA=0xA1, codeB=0x81 -> small positive stride
+                { "好", 0x81A2u },
+            };
+            CoreState.SystemTextEncoder = new FakeTblEncoder(map);
+            CoreState.TextEncoding = TextEncodingEnum.ZH_TBL;
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitFont(rom, list);
+
+            // ZH path: FONTCN entries (one per codeB key per item/text font = 2 keys * 2 fonts = 4),
+            // and NO top hash POINTER table entry / FONT entries (those are the non-ZH path only).
+            var cn = list.Where(a => a.DataType == Address.DataTypeEnum.FONTCN).ToList();
+            Assert.NotEmpty(cn);
+            Assert.All(cn, a => Assert.Equal(4u + 40u, a.Length));
+            Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.FONT);
+        }
+
+        // ====================================================================
+        // Robustness: near-EOF / zeroed
+        // ====================================================================
+
+        [Fact]
+        public void EmitFontInner_NearEofChainPointer_DoesNotThrow()
+        {
+            var rom = CreateTestRom(0x2080);
+            uint topaddress = 0x1000;
+            uint moji2 = 0x41;
+            uint fontlist = topaddress + (moji2 << 2);
+            // Point the bucket at a glyph whose 8-byte header does NOT fully fit (Data.Length - 4).
+            uint glyph = (uint)rom.Data.Length - 4;
+            rom.write_u32(fontlist, Ptr(glyph));
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.EmitFontInnerAt(
+                rom, list, isItemFont: true, topaddress, PRIORITY_CODE.LAT1, isMultibyte: false));
+            Assert.Null(ex);
+            // The glyph header doesn't fit -> FontStructFits stops the chain; no FONT entry emitted.
+            Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.FONT);
+        }
+
+        [Fact]
+        public void EmitFont_ZeroedRom_EmitsNoGlyphEntries()
+        {
+            // A versioned ROM with a valid RomInfo but all-zero data: the font pointer resolves to a
+            // RomInfo address, but every bucket is 0 -> no glyphs. (The top POINTER entry only emits when
+            // the resolved font pointer is a safe offset; for an all-zero FE8U it may or may not, but NO
+            // FONT/FONTCN glyph entries can exist over zeroed buckets.)
+            var rom = MakeVersionedRom("BE8E01");
+            CoreState.ROM = rom;
+            CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+            CoreState.TextEncoding = TextEncodingEnum.Auto;
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.EmitFont(rom, list));
+            Assert.Null(ex);
+            Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.FONT);
+            Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.FONTCN);
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/RebuildProducerUnitCustomBattleAnimeTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerUnitCustomBattleAnimeTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// Tests for the slice-2ab ROM-rebuild producer UnitCustomBattleAnimeForm port
+    /// (<see cref="RebuildProducerCore.EmitUnitCustomBattleAnimeAt"/>). FE7-only. A two-level pointer
+    /// table: the N2 main pointer-table IFR (base = the FE7 pointer slot, block 4, rule
+    /// <c>i==0?true:isPointer(u32)</c>, PI {0}), then per N2 entry a ReInitPointer'd inner IFR (block 4,
+    /// rule <c>u32(addr)!=0</c>, PI {}). Synthetic NULL-RomInfo ROMs drive the explicit-address seam.
+    /// </summary>
+    [Collection("SharedState")]
+    public class RebuildProducerUnitCustomBattleAnimeTests : IDisposable
+    {
+        readonly ROM _savedRom = CoreState.ROM;
+        readonly ISystemTextEncoder _savedEncoder = CoreState.SystemTextEncoder;
+
+        public void Dispose()
+        {
+            CoreState.ROM = _savedRom;
+            CoreState.SystemTextEncoder = _savedEncoder;
+        }
+
+        static ROM CreateTestRom(int size = 0x8000)
+        {
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(new byte[size]);
+            CoreState.ROM = rom;
+            CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+            return rom;
+        }
+
+        static uint Ptr(uint offset) => offset | 0x08000000u;
+
+        [Fact]
+        public void EmitUnitCustomBattleAnime_EmitsN2MainIfrAndPerEntryInnerIfr()
+        {
+            var rom = CreateTestRom();
+            uint n2Pointer = 0x0400;     // unit_custom_battle_anime_pointer slot (synthetic)
+            uint n2Table = 0x1000;       // N2 base = p32(n2Pointer)
+            rom.write_u32(n2Pointer, Ptr(n2Table));
+
+            // N2 rule: i==0 ? true : isPointer(u32(addr)). Two entries then a NULL terminator at i=2.
+            uint inner0 = 0x2000, inner1 = 0x2200;
+            rom.write_u32(n2Table + 0, Ptr(inner0)); // i=0 (always counted)
+            rom.write_u32(n2Table + 4, Ptr(inner1)); // i=1 (isPointer -> counted)
+            rom.write_u32(n2Table + 8, 0);           // i=2 (NOT a pointer -> terminates count at 2)
+
+            // Inner IFR (block 4, rule u32(addr)!=0). inner0 has 3 valid records, inner1 has 1.
+            rom.write_u32(inner0 + 0, 0x11111111);
+            rom.write_u32(inner0 + 4, 0x22222222);
+            rom.write_u32(inner0 + 8, 0x33333333);
+            rom.write_u32(inner0 + 12, 0);            // terminator
+            rom.write_u32(inner1 + 0, 0x44444444);
+            rom.write_u32(inner1 + 4, 0);             // terminator
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitUnitCustomBattleAnimeAt(rom, list, n2Pointer);
+
+            // N2 main IFR: addr = n2Table, pointer = n2Pointer slot, block 4, PI {0}, count 2 -> length 4*3.
+            Address main = list.Single(a => a.Addr == n2Table);
+            Assert.Equal(n2Pointer, main.Pointer);
+            Assert.Equal(4u, main.BlockSize);
+            Assert.Equal(new uint[] { 0 }, main.PointerIndexes);
+            Assert.Equal(4u * (2 + 1), main.Length);
+            Assert.Equal(Address.DataTypeEnum.InputFormRef, main.DataType);
+
+            // Inner IFR for entry 0: addr = inner0, pointer = the N2 SLOT (n2Table+0), PI {}, count 3.
+            Address i0 = list.Single(a => a.Addr == inner0);
+            Assert.Equal(n2Table + 0, i0.Pointer);
+            Assert.Equal(4u, i0.BlockSize);
+            Assert.Empty(i0.PointerIndexes);
+            Assert.Equal(4u * (3 + 1), i0.Length);
+
+            // Inner IFR for entry 1: addr = inner1, pointer = the N2 SLOT (n2Table+4), count 1.
+            Address i1 = list.Single(a => a.Addr == inner1);
+            Assert.Equal(n2Table + 4, i1.Pointer);
+            Assert.Equal(4u * (1 + 1), i1.Length);
+        }
+
+        [Fact]
+        public void EmitUnitCustomBattleAnime_UnsafeSlot_EmitsNothing()
+        {
+            var rom = CreateTestRom();
+            var list = new List<Address>();
+            // n2Pointer 0 -> toOffset(0)=0; isSafetyOffset(0+3) false -> immediate return.
+            RebuildProducerCore.EmitUnitCustomBattleAnimeAt(rom, list, 0);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitUnitCustomBattleAnime_ZeroedBase_EmitsNoInnerIfr()
+        {
+            var rom = CreateTestRom();
+            uint n2Pointer = 0x0400;
+            rom.write_u32(n2Pointer, 0); // p32 -> 0 (unsafe base) -> AddAddressInstantIFR emits nothing;
+                                         // getBlockDataCount(0,...) -> 0 -> no inner loop iterations.
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitUnitCustomBattleAnimeAt(rom, list, n2Pointer);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitUnitCustomBattleAnime_NearEof_DoesNotThrow()
+        {
+            // N2 base points near EOF so the per-entry inner pointer slots run past where a 4-byte read
+            // fits. EmitNestedIfrSub guards p+3 and emits nothing there; no throw.
+            var rom = CreateTestRom(0x1010);
+            uint n2Pointer = 0x0400;
+            uint n2Table = (uint)rom.Data.Length - 8; // only 2 four-byte slots before EOF
+            rom.write_u32(n2Pointer, Ptr(n2Table));
+            rom.write_u32(n2Table + 0, Ptr(0x0500)); // i=0 counted
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.EmitUnitCustomBattleAnimeAt(rom, list, n2Pointer));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void EmitUnitCustomBattleAnime_FirstEntryAlwaysCounted_EvenIfNotPointer()
+        {
+            // N2 rule i==0 -> true unconditionally; so a non-pointer first slot still counts (then the
+            // i==1 isPointer check terminates). Proves the i==0 special case is reproduced.
+            var rom = CreateTestRom();
+            uint n2Pointer = 0x0400;
+            uint n2Table = 0x1000;
+            rom.write_u32(n2Pointer, Ptr(n2Table));
+            rom.write_u32(n2Table + 0, 0x00000005); // i=0: NOT a pointer, but counted (i==0 -> true)
+            rom.write_u32(n2Table + 4, 0);           // i=1: not a pointer -> terminates at count 1
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitUnitCustomBattleAnimeAt(rom, list, n2Pointer);
+
+            Address main = list.Single(a => a.Addr == n2Table);
+            Assert.Equal(4u * (1 + 1), main.Length); // count 1
+        }
+    }
+}

--- a/FEBuilderGBA.Core/FontGlyphZHCore.cs
+++ b/FEBuilderGBA.Core/FontGlyphZHCore.cs
@@ -190,6 +190,24 @@ namespace FEBuilderGBA.Core
         }
 
         /// <summary>
+        /// The RAW 2-arg codeB stride math — a VERBATIM port of <c>FontZHForm.CalcCodeB(codeA, codeB)</c>
+        /// (no control-code / range guards; just the arithmetic). Used by the ROM-rebuild producer's
+        /// <c>EmitFontZH</c> (which mirrors <c>FontZHForm.MakeCodeBMap</c> -&gt; <c>CalcCodeB(codeA, codeB)</c>
+        /// over the TBL map exactly, including this raw form). Distinct from the guarded single-arg
+        /// <see cref="CalcCodeB(uint)"/>, which the EDITOR uses to reject control codes / out-of-range chars
+        /// (its <c>NOT_FOUND</c> returns would WRONGLY drop entries the producer must emit).
+        /// </summary>
+        public static uint CalcCodeBRaw(uint codeA, uint codeB)
+        {
+            codeA -= 0x81;
+            codeA *= 0x80;
+            codeB -= 0x80;
+            codeB += codeA; // 偏移字数 オフセット語
+            codeB *= 0x54;  // 字体大小 文字サイズ
+            return codeB;
+        }
+
+        /// <summary>
         /// Direct-reference glyph address for <paramref name="moji"/> in the
         /// item/serif ZH font, or <see cref="U.NOT_FOUND"/> when the char can't have
         /// a glyph or the resulting address is out of range.

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -622,6 +622,23 @@ namespace FEBuilderGBA
             progress?.Report("MapChange");
             EmitMapChange(rom, list);
 
+            // ---- slice 2ab: FontForm (item / text / status font; version-agnostic call site) ----
+            // WF calls FontForm.MakeAllDataLength at U.cs:2427, IMMEDIATELY AFTER MapChange (2426) and
+            // before Text (2428). Wired here, directly after EmitMapChange, to preserve that WF emission
+            // ORDER (Copilot plan-review point 1). It is NOT a flat StructDescriptor walk: the non-ZH path
+            // emits a top hash POINTER table entry then chain-walks each bucket's next-pointer list (per-
+            // glyph FONT entries with before_pointer as the pointer field); the ZH path (is_multibyte &&
+            // textencoding==ZH_TBL) emits one FONTCN entry per codeB TBL key. Reproduced VERBATIM as a
+            // dedicated emitter (the editor enumerators FontGlyphRenderCore/FontGlyphZHCore DIVERGE — see
+            // EmitFont). Its own cancel-check mirrors the WF DoEvents posture.
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("Font");
+            EmitFont(rom, list);
+
             if (ct.IsCancellationRequested)
             {
                 progress?.Report("MakeAllStructPointersList cancelled");
@@ -1094,6 +1111,20 @@ namespace FEBuilderGBA
                 }
                 progress?.Report("WorldMapImageFE7");
                 EmitWorldMapImageFE7(rom, list);
+
+                // ---- slice 2ab: UnitCustomBattleAnimeForm (FE7-only) ----
+                // WF calls UnitCustomBattleAnimeForm.MakeAllDataLength ONLY in the version==7 branch
+                // (U.cs:2549). A two-level pointer table: the N2 main IFR (base
+                // unit_custom_battle_anime_pointer, block 4, rule i==0?true:isPointer(u32), PI {0}), then
+                // per N2 entry a ReInitPointer'd inner IFR (block 4, rule u32(addr)!=0, PI {}) via the
+                // slice-2i EmitNestedIfrSub primitive. Its own cancel-check mirrors the WF DoEvents posture.
+                if (ct.IsCancellationRequested)
+                {
+                    progress?.Report("MakeAllStructPointersList cancelled");
+                    return new ProducerResult(list, notYet, cancelled: true);
+                }
+                progress?.Report("UnitCustomBattleAnime");
+                EmitUnitCustomBattleAnime(rom, list);
 
                 // ---- slice 2t: ImagePortraitForm (FE7 path) ----
                 // WF calls ImagePortraitForm.MakeAllDataLength in the version==7 branch too (same emitter as
@@ -4965,6 +4996,331 @@ namespace FEBuilderGBA
                 || FETextEncode.IsUnHuffmanPatch_EW_RAMPointer(p);
         }
 
+        // ===================================================================
+        // slice 2ab: FontForm (item / text / status font; version-agnostic
+        // call site at U.cs:2427, BETWEEN MapChange and Text). Reproduced
+        // VERBATIM from FontForm.MakeAllDataLength (FontForm.cs:803) — NOT via
+        // the editor enumerators FontGlyphRenderCore.EnumerateGlyphs /
+        // FontGlyphZHCore.EnumerateGlyphsZH, which DIVERGE from the producer
+        // walk (the editor helpers omit the top POINTER table entry, drop the
+        // per-glyph before_pointer field, and add a stricter p+72 EOF guard
+        // where the producer only checks isSafetyOffset(p) — same corruption-
+        // risk class as the MagicEffect*ImportCore.RecycleOld* EOF mismatch).
+        // The FontGlyphRenderCore / FontGlyphZHCore / PatchDetection.Search-
+        // PriorityCode helpers cited in the (now removed) stale deferral comment
+        // ARE used for the pure pieces (GetFontPointer, GetFontPointerZH,
+        // CalcCodeB, SearchPriorityCode), but the EMISSION walk is local.
+        // ===================================================================
+
+        /// <summary>
+        /// <c>FontForm.MakeAllDataLength</c> (slice 2ab; version-agnostic call site). Gated EXACTLY at the
+        /// WF entry: <c>is_multibyte &amp;&amp; CoreState.TextEncoding == ZH_TBL</c> dispatches the ZH
+        /// direct-reference codeB walk (<see cref="EmitFontZH"/>); otherwise the item font, the text font
+        /// (both <see cref="EmitFontInner"/>) and the status font (<see cref="EmitFontStatusFont"/>).
+        /// </summary>
+        public static void EmitFont(ROM rom, List<Address> list)
+        {
+            // WF: if (is_multibyte) { if (textencoding() == ZH_TBL) { FontZHForm.MakeAllDataLength; return; } }
+            if (rom.RomInfo.is_multibyte && CoreState.TextEncoding == TextEncodingEnum.ZH_TBL)
+            {
+                EmitFontZH(rom, list);
+                return;
+            }
+
+            // アイテム / セリフ.
+            EmitFontInner(rom, list, isItemFont: true);
+            EmitFontInner(rom, list, isItemFont: false);
+
+            // ステータスフォント.
+            EmitFontStatusFont(rom, list,
+                rom.RomInfo.status_font_pointer, rom.RomInfo.status_font_count);
+        }
+
+        /// <summary>
+        /// Verbatim port of <c>FontForm.MakeAllDataLengthInner</c> (the non-ZH item/text font). Emits the
+        /// top hash POINTER table entry, then walks each hash bucket's next-pointer chain emitting one
+        /// <c>8+64</c>-byte <see cref="Address.DataTypeEnum.FONT"/> entry per glyph (pointer field =
+        /// <c>before_pointer</c>, exactly as WF). Three branches:
+        /// <list type="bullet">
+        ///   <item>JP (<c>is_multibyte</c>): POINTER length <c>4*(0xff-0x1f)</c>; buckets <c>moji1</c>
+        ///   0x1f..0xff at <c>topaddress + (moji1&lt;&lt;2) - 0x100</c>; name <c>FontChar(moji2,moji1)</c>.</item>
+        ///   <item>UTF8 (priority code): POINTER length <c>4*0xff</c>; buckets <c>moji1</c> 0x00..0xff at
+        ///   <c>topaddress + (moji1&lt;&lt;2)</c>; name <c>FontCharUTF8</c> (reads <c>u8(p+6)/u8(p+7)</c>).</item>
+        ///   <item>LAT1 (else): POINTER length <c>4*0xff</c>; buckets <c>moji2</c> 0x00..0xff at
+        ///   <c>topaddress + (moji2&lt;&lt;2)</c>; name <c>FontChar(0,moji2)</c>.</item>
+        /// </list>
+        /// EOF-hardening: WF reads <c>u8(p+4)</c>/<c>u8(p+6)</c>/<c>u8(p+7)</c>/<c>u32(p)</c> after only
+        /// <c>isSafetyOffset(p)</c> (the START byte). The chain walk here additionally requires the full
+        /// 8-byte struct header to fit (<c>isSafetyOffset(p+7)</c>) before any read — behaviour-neutral on a
+        /// real ROM (every glyph struct is 72 bytes, always allocated) and EOF-robust on a truncated /
+        /// synthetic one (the never-throws contract). A cap (<c>MAX_FONT_CHAIN</c>) guards a corrupt cyclic
+        /// chain (matching the editor helper's MAX_CHAIN).
+        /// </summary>
+        public static void EmitFontInner(ROM rom, List<Address> list, bool isItemFont)
+        {
+            uint topaddress = FontCore.GetFontPointer(isItemFont, rom);
+            // PriorityCodeUtil.SearchPriorityCode is the Core port of WF PatchUtil.SearchPriorityCode (byte-
+            // faithful — same is_multibyte/DrawFont gate); it returns the bare FEBuilderGBA.PRIORITY_CODE the
+            // FontGlyphRenderCore font code uses (PatchDetection.PRIORITY_CODE is the duplicate enum in the
+            // other namespace).
+            PRIORITY_CODE priorityCode = PriorityCodeUtil.SearchPriorityCode(rom);
+            EmitFontInnerAt(rom, list, isItemFont, topaddress, priorityCode, rom.RomInfo.is_multibyte);
+        }
+
+        /// <summary>FontForm inner walk from an EXPLICIT top hash-table address + priority code +
+        /// multibyte flag (test seam — lets a synthetic NULL-RomInfo ROM supply the hash-table base and
+        /// branch selection without populating RomInfo / a draw-font patch). See
+        /// <see cref="EmitFontInner"/> for the verbatim WF reproduction.</summary>
+        public static void EmitFontInnerAt(ROM rom, List<Address> list, bool isItemFont,
+            uint topaddress, PRIORITY_CODE priorityCode, bool isMultibyte)
+        {
+            string name = isItemFont ? "FontItem" : "FontText";
+
+            if (isMultibyte)
+            {//日本語版
+                Address.AddAddress(list, topaddress, 4 * (0xffu - 0x1fu), U.NOT_FOUND,
+                    name, Address.DataTypeEnum.POINTER);
+
+                for (uint moji1 = 0x1f; moji1 <= 0xff; moji1++)
+                {
+                    uint fontlist = topaddress + (moji1 << 2) - 0x100;
+                    if (!U.isSafetyOffset(fontlist, rom)) continue;
+                    uint p = rom.p32(fontlist);
+                    if (!U.isSafetyOffset(p, rom)) continue;
+                    uint before_pointer = fontlist;
+
+                    int guard = 0;
+                    while (p > 0 && guard++ < MAX_FONT_CHAIN)
+                    {
+                        if (!FontStructFits(rom, p)) break; // EOF-extend (WF: only isSafetyOffset(p))
+                        uint moji2 = rom.u8(p + 4);
+                        Address.AddAddress(list, p, 8 + 64, before_pointer,
+                            name + FontChar(rom, moji2, moji1, priorityCode),
+                            Address.DataTypeEnum.FONT);
+
+                        uint next = rom.u32(p);
+                        if (next == 0) break;                       // リスト終端.
+                        if (!U.isSafetyPointer(next, rom)) break;   // リストが壊れている.
+                        before_pointer = p;
+                        p = U.toOffset(next);
+                    }
+                }
+            }
+            else if (priorityCode == PRIORITY_CODE.UTF8)
+            {//UTF-8
+                Address.AddAddress(list, topaddress, 4 * 0xffu, U.NOT_FOUND,
+                    name, Address.DataTypeEnum.POINTER);
+
+                for (uint moji1 = 0x0; moji1 <= 0xff; moji1++)
+                {
+                    uint fontlist = topaddress + (moji1 << 2);
+                    if (!U.isSafetyOffset(fontlist, rom)) continue;
+                    uint p = rom.p32(fontlist);
+                    if (!U.isSafetyOffset(p, rom)) continue;
+                    uint before_pointer = fontlist;
+
+                    int guard = 0;
+                    while (p > 0 && guard++ < MAX_FONT_CHAIN)
+                    {
+                        if (!FontStructFits(rom, p)) break;
+                        uint moji2 = rom.u8(p + 4);
+                        uint moji3 = rom.u8(p + 6);
+                        uint moji4 = rom.u8(p + 7);
+                        Address.AddAddress(list, p, 8 + 64, before_pointer,
+                            name + FontCharUTF8(moji1, moji2, moji3, moji4),
+                            Address.DataTypeEnum.FONT);
+
+                        uint next = rom.u32(p);
+                        if (next == 0) break;
+                        if (!U.isSafetyPointer(next, rom)) break;
+                        before_pointer = p;
+                        p = U.toOffset(next);
+                    }
+                }
+            }
+            else
+            {//英語版
+                Address.AddAddress(list, topaddress, 4 * 0xffu, U.NOT_FOUND,
+                    name, Address.DataTypeEnum.POINTER);
+
+                for (uint moji2 = 0x0; moji2 <= 0xff; moji2++)
+                {
+                    uint fontlist = topaddress + (moji2 << 2);
+                    if (!U.isSafetyOffset(fontlist, rom)) continue;
+                    uint p = rom.p32(fontlist);
+                    if (!U.isSafetyOffset(p, rom)) continue;
+                    uint before_pointer = fontlist;
+
+                    int guard = 0;
+                    while (p > 0 && guard++ < MAX_FONT_CHAIN)
+                    {
+                        if (!FontStructFits(rom, p)) break;
+                        Address.AddAddress(list, p, 8 + 64, before_pointer,
+                            name + FontChar(rom, 0, moji2, priorityCode),
+                            Address.DataTypeEnum.FONT);
+
+                        uint next = rom.u32(p);
+                        if (next == 0) break;
+                        if (!U.isSafetyPointer(next, rom)) break;
+                        before_pointer = p;
+                        p = U.toOffset(next);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Verbatim port of <c>FontForm.MakeAllDataLengthStatusFont</c>. A fixed-size status-font pointer
+        /// loop: <c>topaddress = p32(toppointer)</c> (both <paramref name="toppointer"/> and the resolved
+        /// base guarded), then <c>i &lt; count</c>, <c>addr += 4</c>: emit the <c>8+64</c>-byte
+        /// <see cref="Address.DataTypeEnum.FONT"/> glyph at <c>p32(addr)</c> (pointer field = the slot
+        /// <c>addr</c>), skipping any slot whose resolved font is an unsafe offset. The slot is guarded
+        /// (<c>addr+3</c>) before the <c>p32</c> read.
+        /// </summary>
+        public static void EmitFontStatusFont(ROM rom, List<Address> list, uint toppointer, uint count)
+        {
+            if (!U.isSafetyOffset(toppointer, rom)) return;
+            uint topaddress = rom.p32(toppointer);
+            if (!U.isSafetyOffset(topaddress, rom)) return;
+
+            const string name = "StatusFont";
+            uint addr = topaddress;
+            for (uint i = 0; i < count; i++, addr += 4)
+            {
+                // WF reads p32(addr) after only the loop bound; guard the full slot (addr+3) so a near-EOF
+                // count emits nothing instead of throwing (behaviour-neutral on a real ROM allocated to
+                // `count` slots).
+                if (!U.isSafetyOffset(addr + 3, rom)) break;
+                uint font = rom.p32(addr);
+                if (!U.isSafetyOffset(font, rom)) continue;
+
+                Address.AddAddress(list, font, 8 + 64, addr, name, Address.DataTypeEnum.FONT);
+            }
+        }
+
+        /// <summary>
+        /// Verbatim port of <c>FontZHForm.MakeAllDataLength</c> (the Chinese direct-reference codeB font).
+        /// Builds the <c>{ codeB -&gt; char }</c> map from the AMBIENT
+        /// <see cref="CoreState.SystemTextEncoder"/> (mirroring WF <c>Program.SystemTextEncoder</c> — in the
+        /// ZH producer branch the loaded encoder IS the ZH_TBL one; this is NOT the editor helper's fresh
+        /// <c>new SystemTextEncoder(ZH_TBL)</c>), then emits one <c>44</c>-byte
+        /// <see cref="Address.DataTypeEnum.FONTCN"/> entry per key at <c>GetFontPointerZH(version,isItemFont)
+        /// + codeB</c> for both the item and text fonts. Emission is UNCONDITIONAL per key (no struct-fits
+        /// guard — WF emits every key; <see cref="Address.AddAddress(List{Address},uint,uint,uint,string,
+        /// Address.DataTypeEnum)"/> already guards the start offset). The codeB stride math is
+        /// <see cref="FontGlyphZHCore.CalcCodeBRaw"/> (the verbatim <c>FontZHForm.CalcCodeB</c>).
+        /// </summary>
+        public static void EmitFontZH(ROM rom, List<Address> list)
+        {
+            var codeBMap = MakeFontZHCodeBMap();
+            EmitFontZHInner(rom, list, isItemFont: true, codeBMap);
+            EmitFontZHInner(rom, list, isItemFont: false, codeBMap);
+        }
+
+        // FontZHForm.MakeCodeBMap(isKanjiOnly:false). { codeB -> char }. The WF producer path passes
+        // isKanjiOnly=false (the bigendian<=0x8397 skip never applies). Last-char-for-a-colliding-codeB
+        // wins (Dictionary indexer assignment), exactly as WF.
+        static Dictionary<uint, string> MakeFontZHCodeBMap()
+        {
+            var codeBMap = new Dictionary<uint, string>();
+            ISystemTextEncoder encoder = CoreState.SystemTextEncoder;
+            if (encoder == null) return codeBMap;
+            Dictionary<string, uint> encodeMap = encoder.GetTBLEncodeDicLow();
+            if (encodeMap == null) return codeBMap;
+
+            foreach (var p in encodeMap)
+            {
+                uint codeA = p.Value & 0xff;
+                uint codeB = (p.Value >> 8) & 0xff;
+                uint codeBB = FEBuilderGBA.Core.FontGlyphZHCore.CalcCodeBRaw(codeA, codeB);
+                codeBMap[codeBB] = p.Key;
+            }
+            return codeBMap;
+        }
+
+        // FontZHForm.MakeAllDataLengthInner. fontSize == 4 (header) + 40 (2bpp bitmap) == 44.
+        static void EmitFontZHInner(ROM rom, List<Address> list, bool isItemFont,
+            Dictionary<uint, string> codeBMap)
+        {
+            uint topaddress = FEBuilderGBA.Core.FontGlyphZHCore.GetFontPointerZH(rom.RomInfo.version, isItemFont);
+            EmitFontZHInnerAt(list, isItemFont, topaddress, codeBMap);
+        }
+
+        /// <summary>ZH font inner walk from an EXPLICIT table head (test seam — supply the ZH font head
+        /// without a real FE6/7/8 RomInfo version). One <c>44</c>-byte
+        /// <see cref="Address.DataTypeEnum.FONTCN"/> entry per codeB key. See <see cref="EmitFontZH"/>.</summary>
+        public static void EmitFontZHInnerAt(List<Address> list, bool isItemFont,
+            uint topaddress, Dictionary<uint, string> codeBMap)
+        {
+            string name = isItemFont ? "FontItem" : "FontText";
+            const uint fontSize = 4 + 40;
+
+            foreach (var p in codeBMap)
+            {
+                uint addr = topaddress + p.Key;
+                Address.AddAddress(list, addr, fontSize, U.NOT_FOUND,
+                    name + p.Value, Address.DataTypeEnum.FONTCN);
+            }
+        }
+
+        // Hard cap on a single font hash-bucket chain length (a corrupt cyclic next-pointer chain would
+        // otherwise spin). No real font bucket approaches this; matches FontGlyphRenderCore.MAX_CHAIN.
+        const int MAX_FONT_CHAIN = 0x10000;
+
+        // True when the full 8-byte font struct header at p (next u32 + moji2/width/moji3/moji4) is
+        // in-bounds, so the subsequent u8(p+4..p+7)/u32(p) reads can't throw on EOF. isSafetyOffset(p)
+        // alone only checks the FIRST byte. (The producer relocates 72 bytes, but WF only ever READS the
+        // first 8 in the walk, so guarding +7 is sufficient and exactly bounds every read it performs.)
+        static bool FontStructFits(ROM rom, uint p)
+        {
+            return U.isSafetyOffset(p, rom)
+                && (ulong)p + 8 <= (ulong)rom.Data.Length;
+        }
+
+        // Verbatim port of FontForm.FontChar — decode (moji1,moji2) to a display string. NAME-ONLY
+        // (informational; the WF-parity harness does not assert names). The WF @-fallback uses
+        // U.ToCharOneHex (one hex char); Core uses the 2-hex form (X2), matching FontGlyphRenderCore.Hex2 —
+        // a cosmetic divergence, relocation-identical.
+        static string FontChar(ROM rom, uint moji1, uint moji2, PRIORITY_CODE priorityCode)
+        {
+            ISystemTextEncoder encoder = CoreState.SystemTextEncoder;
+            if (encoder != null && priorityCode == PRIORITY_CODE.SJIS)
+            {
+                if (U.isSJIS1stCode((byte)moji1) && U.isSJIS2ndCode((byte)moji2))
+                {
+                    byte[] str = { (byte)moji1, (byte)moji2, 0 };
+                    return encoder.Decode(str, 0, 2);
+                }
+                if (moji1 > 0 && moji2 == 0x40)
+                {
+                    byte[] str = { (byte)moji1, 0 };
+                    return encoder.Decode(str, 0, 1);
+                }
+            }
+
+            if (moji1 == 0 && encoder != null)
+            {
+                byte[] str = { (byte)moji2, 0 };
+                return encoder.Decode(str, 0, 1);
+            }
+
+            return "@" + ((byte)moji2).ToString("X2") + ((byte)moji1).ToString("X2");
+        }
+
+        // Verbatim port of FontForm.FontCharUTF8 (UTF-32 decode of the 4 packed bytes). NAME-ONLY.
+        static string FontCharUTF8(uint moji1, uint moji2, uint moji3, uint moji4)
+        {
+            byte[] str = { (byte)moji1, (byte)moji2, (byte)moji3, (byte)moji4, 0 };
+            try
+            {
+                return System.Text.Encoding.GetEncoding("UTF-32").GetString(str, 0, 4);
+            }
+            catch
+            {
+                return "@" + ((byte)moji1).ToString("X2");
+            }
+        }
+
         // =====================================================================================
         // slice 2p: OAM / battle-anime length forms (version-agnostic call sites)
         // =====================================================================================
@@ -5941,6 +6297,87 @@ namespace FEBuilderGBA
             uint pointer = U.isSafetyOffset(field, rom) ? field : U.NOT_FOUND;
             list.Add(new Address(subBase, length, pointer, name,
                 Address.DataTypeEnum.InputFormRef, subBlock, new uint[] { }));
+        }
+
+        // ===================================================================
+        // slice 2ab: UnitCustomBattleAnimeForm (FE7-only; WF call site in the
+        // version==7 branch at U.cs:2549). A two-level N2/InputFormRef pointer
+        // loop reproduced VERBATIM from UnitCustomBattleAnimeForm.MakeAllData-
+        // Length (UnitCustomBattleAnimeForm.cs:142): the N2 main pointer table
+        // IFR, then per N2 entry a ReInitPointer'd inner IFR. NO anime-recycle,
+        // NO patch detection, NO sub-length. The inner ReInitPointer + AddAddress
+        // (IFR, {}) is exactly the slice-2i EmitNestedIfrSub primitive (the inner
+        // IFR's NextAddrCallback defaults to +blocksize, so its 4-arg getBlock-
+        // DataCount == the 3-arg one EmitNestedIfrSub uses).
+        // ===================================================================
+
+        /// <summary>
+        /// <c>UnitCustomBattleAnimeForm.MakeAllDataLength</c> (slice 2ab; FE7-only). Resolves the N2 base
+        /// from <c>unit_custom_battle_anime_pointer</c> and delegates to
+        /// <see cref="EmitUnitCustomBattleAnimeAt"/>.
+        /// </summary>
+        public static void EmitUnitCustomBattleAnime(ROM rom, List<Address> list)
+        {
+            EmitUnitCustomBattleAnimeAt(rom, list, rom.RomInfo.unit_custom_battle_anime_pointer);
+        }
+
+        /// <summary>
+        /// UnitCustomBattleAnime walk from an EXPLICIT N2 pointer-table slot (test seam — lets a synthetic
+        /// ROM supply it without populating RomInfo). Reproduces <c>MakeAllDataLength</c> VERBATIM:
+        /// <list type="bullet">
+        ///   <item><b>N2 main IFR</b> (<c>N2_Init</c>): BasePointer = <paramref name="n2Pointer"/>,
+        ///   BaseAddress = <c>p32(slot)</c>, block 4, IsDataExists = <c>i == 0 ? true : isPointer(u32(addr))</c>.
+        ///   Emitted via <see cref="Address.AddAddressInstantIFR"/> as
+        ///   <c>AddressWinForms.AddAddress(list, N2_IFR, "UnitCustomBattle", {0})</c> — addr = BaseAddress,
+        ///   length = <c>4 * (DataCount + 1)</c>, pointer = the slot, pointerIndexes <c>{0}</c>.</item>
+        ///   <item><b>per N2 entry</b> (<c>p = N2.BaseAddress</c>, <c>i &lt; N2.DataCount</c>, <c>p += 4</c>):
+        ///   <c>InputFormRef.ReInitPointer(p)</c> (inner base = <c>p32(p)</c>, block 4, IsDataExists =
+        ///   <c>u32(addr) != 0</c>) + <c>AddAddress(list, InputFormRef, "UnitCustomBattle" + To0xHexString(i),
+        ///   {})</c> — reproduced by <see cref="EmitNestedIfrSub"/> (pointer field = <c>p</c> = the inner
+        ///   IFR's BasePointer; pointerIndexes EMPTY).</item>
+        /// </list>
+        /// The N2 main DataCount is computed via the SAME <c>getBlockDataCount(N2.BaseAddress, 4, N2rule)</c>
+        /// WF's <c>N2_Init</c> runs (BaseAddress-derived). The slot is guarded (<c>+3</c>) before the
+        /// <c>p32</c> read; the per-entry <c>p</c> can run to where a 4-byte read is near-EOF (WF's loop
+        /// bound is the N2 DataCount, not a re-walk of THIS pointer list), but
+        /// <see cref="EmitNestedIfrSub"/> already guards <c>p+3</c> and emits nothing there — behaviour-
+        /// neutral on a real ROM allocated to <c>DataCount</c> entries, EOF-robust on a synthetic one.
+        /// </summary>
+        public static void EmitUnitCustomBattleAnimeAt(ROM rom, List<Address> list, uint n2Pointer)
+        {
+            const uint block = 4;
+
+            // N2_Init: BasePointer = toOffset(slot); BaseAddress = p32(BasePointer). Guard the full slot
+            // before p32 (root+3), matching InputFormRef.Init (toOffset then p32, both safety-checked).
+            uint slot = U.toOffset(n2Pointer);
+            if (!U.isSafetyOffset(slot + 3, rom))
+            {
+                return;
+            }
+            uint baseAddr = rom.p32(slot);
+
+            // N2 IsDataExists: i == 0 ? true : isPointer(u32(addr)). getBlockDataCount guards
+            // addr+block(4) <= Length, so u32(addr) is always in bounds. A baseAddr of 0/NOT_FOUND yields
+            // count 0 (getBlockDataCount short-circuits), exactly as InputFormRef.Init over an unsafe base.
+            Func<int, uint, bool> n2Rule = (i, addr) =>
+                i == 0 ? true : U.isPointer(rom.u32(addr));
+            uint n2Count = rom.getBlockDataCount(baseAddr, block, n2Rule);
+
+            // AddAddressInstantIFR == AddressWinForms.AddAddress(list, N2_IFR, "UnitCustomBattle", {0}):
+            // addr = p32(slot), length = block*(count+1), pointer = slot (if safe), PI {0}. It internally
+            // guards the resolved base (no emit when unsafe), matching AddAddress's isSafetyOffset(addr).
+            Address.AddAddressInstantIFR(list, n2Pointer, block, n2Count, "UnitCustomBattle", new uint[] { 0 });
+
+            // Per N2 entry: p = N2.BaseAddress; p += BlockSize. WF loops i < N2.DataCount and calls
+            // InputFormRef.ReInitPointer(p) + AddAddress(InputFormRef, name, {}) == EmitNestedIfrSub with
+            // pfield = p. Inner IFR: block 4, IsDataExists = u32(addr) != 0 (the "00まで検索" terminator).
+            uint p = baseAddr;
+            for (uint i = 0; i < n2Count; i++, p += block)
+            {
+                EmitNestedIfrSub(rom, list, p, block,
+                    (j, addr) => rom.u32(addr) != 0,
+                    "UnitCustomBattle" + U.To0xHexString(i));
+            }
         }
 
         /// <summary>
@@ -10400,7 +10837,16 @@ namespace FEBuilderGBA
                 //  Core (PatchDetection.SearchFlag0x28ToMapSecondPalettePatch) inside
                 //  MapPListResolverCore.GetMapPListsWhereAddr, and MapSettingCore.MakeMapIDList +
                 //  RomInfo-only GetBasePointer/IsPlistSplits complete the dependency set.)
-                "FontForm",
+                // (FontForm ported in slice 2ab — EmitFont: gated EXACTLY at the WF entry
+                //  (is_multibyte && CoreState.TextEncoding==ZH_TBL -> the ZH direct-ref codeB walk
+                //  EmitFontZH; else the item/text hash-chain walks EmitFontInner + the fixed-size status
+                //  font loop EmitFontStatusFont). Reproduced VERBATIM as producer-local methods, NOT via the
+                //  editor enumerators FontGlyphRenderCore.EnumerateGlyphs/FontGlyphZHCore.EnumerateGlyphsZH —
+                //  those DIVERGE (the editor helpers omit the top POINTER table entry, drop the per-glyph
+                //  before_pointer field, and add a stricter p+72 EOF guard where WF only checks
+                //  isSafetyOffset(p); EnumerateGlyphsZH also adds a struct-fits guard WF lacks + builds its
+                //  own fresh encoder). The pure helpers ARE reused: FontCore.GetFontPointer,
+                //  FontGlyphZHCore.GetFontPointerZH/CalcCodeBRaw, PatchDetection.SearchPriorityCode.)
                 // AI scripts (disasm)
                 // (AIMapSettingForm [flat u8!=0xFF table], AIPerformStaffForm + AIPerformItemForm
                 //  [flat u16!=0 table + per-entry ASM AddFunction @4 via SubKind.AsmFunction] ported in
@@ -10475,7 +10921,13 @@ namespace FEBuilderGBA
                 //  static NewAllocData list, which is EDITOR SESSION STATE (newly-allocated unit regions
                 //  recorded during live editing), NOT a ROM-derived table; it is always empty headless, so
                 //  the producer emits nothing for it — kept listed so the coverage gate stays honest.)
-                "UnitCustomBattleAnimeForm",
+                // (UnitCustomBattleAnimeForm [FE7-only] ported in slice 2ab — EmitUnitCustomBattleAnime: the
+                //  N2 main pointer-table IFR (base unit_custom_battle_anime_pointer, block 4, rule
+                //  i==0?true:isPointer(u32), PI {0}) via AddAddressInstantIFR, then per N2 entry a
+                //  ReInitPointer'd inner IFR (block 4, rule u32(addr)!=0, PI {}) via the slice-2i
+                //  EmitNestedIfrSub primitive. NO anime-recycle, NO patch detection, NO sub-length — the
+                //  inner IFR's default +blocksize NextAddrCallback makes its getBlockDataCount identical to
+                //  EmitNestedIfrSub's 3-arg walk.)
                 "EventUnitForm(RecycleReserveUnits)",
                 // monster / world map / ED / support (FE8/FE7/FE6 variants)
                 // (MonsterItemForm + MonsterProbabilityForm ported in slice 2b.

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -5279,8 +5279,9 @@ namespace FEBuilderGBA
 
         // Verbatim port of FontForm.FontChar — decode (moji1,moji2) to a display string. NAME-ONLY
         // (informational; the WF-parity harness does not assert names). The WF @-fallback uses
-        // U.ToCharOneHex (one hex char); Core uses the 2-hex form (X2), matching FontGlyphRenderCore.Hex2 —
-        // a cosmetic divergence, relocation-identical.
+        // U.ToCharOneHex, which is ToString("X02") = TWO hex digits; Core's ToString("X2") produces the
+        // SAME two-digit output for a byte (X2 already pads a single-digit byte to 2), so the @-fallback is
+        // byte-identical to WF (matching FontGlyphRenderCore.Hex2).
         static string FontChar(ROM rom, uint moji1, uint moji2, PRIORITY_CODE priorityCode)
         {
             ISystemTextEncoder encoder = CoreState.SystemTextEncoder;


### PR DESCRIPTION
## Summary
Port two tractable data-path forms into the cross-platform ROM-rebuild producer (`RebuildProducerCore.MakeAllStructPointers`), faithful WinForms→Core ports. Part of the #1261 producer marathon. Both forms were in `NotYetPortedRaw` with STALE deferral comments — the Core helpers they need now exist.

Plan reviewed by Copilot CLI on #1304 (both findings addressed — see below).

## Forms ported
- **FontForm** (WF `FontForm.cs:803` `MakeAllDataLength`; `U.cs:2427`, between MapChange and Text). `EmitFont` gates EXACTLY at the WF entry: `is_multibyte && CoreState.TextEncoding==ZH_TBL` → the ZH direct-reference codeB walk (`EmitFontZH`); else the item/text font hash-chain walks (`EmitFontInner`) + the fixed-size status-font loop (`EmitFontStatusFont`). Wired immediately after `EmitMapChange` to preserve WF emission order.
- **UnitCustomBattleAnimeForm** (WF `UnitCustomBattleAnimeForm.cs:142` `MakeAllDataLength`; FE7-only, `U.cs:2549`). `EmitUnitCustomBattleAnime`: the N2 main pointer-table IFR via `AddAddressInstantIFR`, then per N2 entry a `ReInitPointer`'d inner IFR via the slice-2i `EmitNestedIfrSub` primitive. NO anime-recycle, NO patch detection, NO sub-length.

## Faithfulness (corruption-critical)
Reproduced BOTH font walks **VERBATIM as producer-local methods**, NOT via the editor enumerators `FontGlyphRenderCore.EnumerateGlyphs` / `FontGlyphZHCore.EnumerateGlyphsZH` — those DIVERGE from the producer (they omit the top POINTER table entry, drop the per-glyph `before_pointer` field, and add a stricter `p+72` EOF guard where WF only checks `isSafetyOffset(p)`; the ZH enumerator also adds a struct-fits guard WF lacks + builds its own fresh encoder). Same corruption-risk class as the `MagicEffect*ImportCore.RecycleOld*` EOF mismatch. The PURE helpers ARE reused (`FontCore.GetFontPointer`, `FontGlyphZHCore.GetFontPointerZH` + the new `CalcCodeBRaw`, `PriorityCodeUtil.SearchPriorityCode`).

## Copilot plan-review findings (both addressed in code)
1. **Wiring order** — `EmitFont` is wired immediately after `EmitMapChange` (matching WF MapChange→Font→Text), not "just before the current EmitText".
2. **Test gap (JP-SJIS + UTF8 branches)** — added synthetic tests for the JP-SJIS multibyte hash-chain (top POINTER length `4*(0xff-0x1f)`, `-0x100` bucket base) and the UTF8 hash-chain (`4*0xff`, no `-0x100`), in addition to LAT1 and ZH.

## Test plan
- [x] `EmitFontInner` LAT1: top POINTER entry (`4*0xff`) + per-glyph FONT entry (`8+64`, pointer = `before_pointer`)
- [x] `EmitFontInner` LAT1 multi-entry chain: `before_pointer` threading (fontlist → g0 → g1)
- [x] `EmitFontInner` JP-SJIS: top POINTER length `4*(0xff-0x1f)`, `-0x100` bucket base
- [x] `EmitFontInner` UTF8: top POINTER length `4*0xff`, bucket base with no `-0x100`
- [x] `EmitFontStatusFont`: one FONT per slot (pointer = slot), unsafe-slot continue, unsafe-toppointer emits nothing
- [x] `EmitFontZHInner`: one FONTCN per codeB key (length `44`, pointer NOT_FOUND)
- [x] `EmitFont` gate: FE8U non-multibyte takes inner walk even with `ZH_TBL`; FE8J multibyte+`ZH_TBL` takes ZH branch
- [x] FontForm near-EOF chain pointer → no throw; zeroed ROM → no glyph entries
- [x] `EmitUnitCustomBattleAnime`: N2 main IFR + per-entry inner IFR (pointer = N2 slot, PI `{}`)
- [x] `EmitUnitCustomBattleAnime`: `i==0` always counted, unsafe slot, zeroed base, near-EOF no-throw
- [x] `dotnet test --filter RebuildProducer`: **408 pass** (391 baseline + 17 new), 0 failed
- [x] `dotnet build FEBuilderGBA.sln` clean (WF-parity test in FEBuilderGBA.Tests still compiles)

## Proof (Core-only, no GUI → CLI/test output)
```
Passed!  - Failed:     0, Passed:   408, Skipped:     0, Total:   408 - FEBuilderGBA.Core.Tests.dll (net9.0)
```
Build succeeded. 0 Error(s).

The 10 `Skill*`/`SkillSystemsAnime*` Core.Tests failures are the KNOWN un-checked-out `config/patch2` submodule env failures (identical on origin/master; the submodule shows `-` in `git submodule status`).

Closes #1304. Part of #1261.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
