### PR TITLE
feat(core): ROM-rebuild producer — SkillConfig SkillSystems anime ×3 (#1261 slice 2ac)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -7783,6 +7783,83 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void EmitSkillConfigFE8NVer2At_EmissionOrder_N1N2N3_Icon_ThenN4()
+        {
+            // WF SkillConfigFE8NVer2SkillForm.MakeAllDataLength :1100-1128 emits N1, N2, N3, SkillIcon, N4
+            // (the icon is interleaved BETWEEN N3 and the optional N4). Lock the ORDER for entry 0.
+            var rom = CreateTestRom(0x10000);
+            uint skillBaseP = 0x0400, skillTable = 0x1000;
+            uint iconListSize = 20; // block 20 -> N4 emitted.
+            rom.write_u32(skillBaseP, Ptr(skillTable));
+            rom.write_u8(skillTable + 0 * 20, 0x10);
+            rom.write_u8(skillTable + 1 * 20, 0xFF); // 1 entry then terminator.
+            // valid N1..N4 pointers @ +4/+8/+12/+16.
+            uint nbase = 0x2000;
+            for (uint k = 0; k < 4; k++)
+            {
+                uint np = nbase + k * 0x10;
+                rom.write_u32(skillTable + 0 * 20 + 4 + k * 4, Ptr(np));
+                rom.write_u8(np, (byte)(0x05 + k)); rom.write_u8(np + 1, 0x00);
+            }
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitSkillConfigFE8NVer2At(rom, list, skillBaseP, 0, iconListSize);
+
+            // Pull the indices of the entry-0 rows in emission order.
+            int iUnit = list.FindIndex(a => a.Info == "SkillUnit:0x00");
+            int iClass = list.FindIndex(a => a.Info == "SkillClass:0x00");
+            int iItem = list.FindIndex(a => a.Info == "SkillItem:0x00");
+            int iIcon = list.FindIndex(a => a.Info == "SkillIcon:0x00");
+            int iItem2 = list.FindIndex(a => a.Info == "SkillItem2:0x00");
+            Assert.True(iUnit >= 0 && iClass >= 0 && iItem >= 0 && iIcon >= 0 && iItem2 >= 0);
+            // N1 < N2 < N3 < Icon < N4.
+            Assert.True(iUnit < iClass);
+            Assert.True(iClass < iItem);
+            Assert.True(iItem < iIcon);
+            Assert.True(iIcon < iItem2);
+        }
+
+        [Fact]
+        public void EmitSkillConfigFE8NVer3At_EmissionOrder_AllNestedBeforeIcon()
+        {
+            // WF SkillConfigFE8NVer3SkillForm.MakeAllDataLength :1097-1123 emits N1..N5 BEFORE the icon.
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var rom = MakeVersionedRom("BE8J01");
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+
+                uint skillBaseP = 0x0400, skillTable = 0x600;
+                uint iconListSize = 24;
+                rom.write_u32(skillBaseP, Ptr(skillTable));
+                rom.write_u8(skillTable + 0 * 24, 0x10);
+                rom.write_u8(skillTable + 1 * 24, 0xFF);
+                uint nbase = 0x900;
+                for (uint k = 0; k < 5; k++)
+                {
+                    uint np = nbase + k * 0x10;
+                    rom.write_u32(skillTable + 0 * 24 + 4 + k * 4, Ptr(np));
+                    rom.write_u8(np, (byte)(0x05 + k)); rom.write_u8(np + 1, 0x00);
+                }
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitSkillConfigFE8NVer3At(rom, list, skillBaseP, 0, iconListSize);
+
+                int iComplex = list.FindIndex(a => a.Info == "SkillComplex:0x00"); // N5 (last nested).
+                int iIcon = list.FindIndex(a => a.Info == "SkillIcon:0x00");
+                Assert.True(iComplex >= 0 && iIcon >= 0);
+                Assert.True(iComplex < iIcon); // ALL nested before the icon.
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
+        }
+
+        [Fact]
         public void EmitSkillConfigFE8NVer2At_Block24_Pi12NotPi16_ButN4StillEmitted()
         {
             // WF asymmetry: the main pointerIndexes use `ifr.BlockSize == 20` (so block 24 -> {4,8,12}, NOT

--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -7308,10 +7308,10 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         // ---- coverage tracker: slice 2o drops the 3 RecycleOldAnime-free Skill
-        //      forms, keeps the anime-dependent siblings -------------------------
+        //      forms; slice 2ac then drops the 3 anime-dependent siblings -------
 
         [Fact]
-        public void GetNotYetPortedForms_DropsSlice2oSkillForms_KeepsAnimeSiblings()
+        public void GetNotYetPortedForms_DropsSlice2oSkillForms_AndSlice2acAnimeSiblings()
         {
             string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
 
@@ -7320,15 +7320,16 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("SkillAssignmentUnitSkillSystemForm", notYet);
             Assert.DoesNotContain("SkillConfigFE8NSkillForm", notYet);
 
-            // The RecycleOldAnime-dependent Skill siblings STAY (anime length walker not in Core).
-            foreach (var kept in new[]
+            // slice 2ac ports the RecycleOldAnime-dependent Skill siblings (RecycleOldAnime reproduced
+            // VERBATIM as EmitSkillSystemsRecycleOldAnime); all three are now DROPPED from NotYetPorted.
+            foreach (var ported in new[]
             {
                 "SkillConfigSkillSystemForm",
                 "SkillConfigFE8NVer2SkillForm",
                 "SkillConfigFE8NVer3SkillForm",
             })
             {
-                Assert.Contains(kept, notYet);
+                Assert.DoesNotContain(ported, notYet);
             }
 
             // (ImageBattleAnimeForm ported in slice 2s — see GetNotYetPortedForms_DropsSlice2sForms.)
@@ -7354,12 +7355,607 @@ namespace FEBuilderGBA.Core.Tests
             // ImageBattleAnimeForm was the deferred OAM sibling at slice 2p (the test name is historical);
             // it is PORTED in slice 2s — see GetNotYetPortedForms_DropsSlice2sForms.
             Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
-            // The RecycleOldAnime-dependent SkillConfig siblings DO still stay tracked at this point.
-            Assert.Contains("SkillConfigSkillSystemForm", notYet);
+            // The RecycleOldAnime-dependent SkillConfig siblings are PORTED in slice 2ac — see
+            // GetNotYetPortedForms_DropsSlice2oSkillForms_AndSlice2acAnimeSiblings.
+            Assert.DoesNotContain("SkillConfigSkillSystemForm", notYet);
 
             // no-duplicates invariant still holds.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
             Assert.Equal(raw.Length, raw.Distinct().Count());
+        }
+
+        // ====================================================================
+        // slice 2ac — SkillConfig SkillSystems anime forms (RecycleOldAnime
+        // reproduced VERBATIM). The explicit-address *At seams drive the
+        // IFR/recycle shapes over synthetic ROMs; a versioned FE8J ROM
+        // (is_multibyte -> SkipCode returns the anime address DIRECTLY) is used
+        // for the recycle walk so no config/patch2 template file is needed.
+        // ====================================================================
+
+        // Write a minimal valid LZ77 stream (tag 0x10, decompressed size 4, one flag byte = all literal,
+        // 4 literal bytes) at `offset`; getCompressedSize then returns a non-zero length. Returns the next
+        // free offset after the stream.
+        static uint WriteTinyLz77(ROM rom, uint offset)
+        {
+            rom.write_u8(offset + 0, 0x10);   // LZ77 tag
+            rom.write_u8(offset + 1, 0x04);   // decompressed size (3 bytes LE) = 4
+            rom.write_u8(offset + 2, 0x00);
+            rom.write_u8(offset + 3, 0x00);
+            rom.write_u8(offset + 4, 0x00);   // flag byte: all 4 blocks uncompressed (literal)
+            rom.write_u8(offset + 5, 0xAA);
+            rom.write_u8(offset + 6, 0xBB);
+            rom.write_u8(offset + 7, 0xCC);
+            rom.write_u8(offset + 8, 0xDD);
+            return offset + 9;
+        }
+
+        // Lay out ONE FE8J skill anime (is_multibyte -> SkipCode direct) at `animeAddr`:
+        //   config block (5 words) @ animeAddr: frames / tsalist / graphiclist / palettelist / soundid
+        //   frames table @ framesAddr: [u16 id, u16 wait]* terminated by 0xFFFF (the `ids` array)
+        //   per unique id: graphiclist[id] -> a tiny LZ77 OBJ; tsalist[id] -> a tiny LZ77 TSA;
+        //                  palettelist[id] -> a 0x20 raw palette
+        // Returns nothing; the caller plants `animeAddr` into the anime pointer list.
+        static void LayoutSkillAnime(ROM rom, uint animeAddr, uint framesAddr, uint listsAddr,
+            uint imgPoolAddr, ushort[] ids)
+        {
+            // Distinct image/tsa/pal blocks per UNIQUE id, packed into imgPoolAddr.
+            var uniq = ids.Distinct().ToArray();
+            uint graphiclist = listsAddr + 0x00;
+            uint tsalist = listsAddr + 0x80;
+            uint palettelist = listsAddr + 0x100;
+
+            uint pool = imgPoolAddr;
+            foreach (ushort id in uniq)
+            {
+                uint objOff = pool; pool = WriteTinyLz77(rom, pool); pool = (pool + 3) & ~3u;
+                uint tsaOff = pool; pool = WriteTinyLz77(rom, pool); pool = (pool + 3) & ~3u;
+                uint palOff = pool; pool += 0x20; pool = (pool + 3) & ~3u;
+                rom.write_u32(graphiclist + (uint)id * 4, Ptr(objOff));
+                rom.write_u32(tsalist + (uint)id * 4, Ptr(tsaOff));
+                rom.write_u32(palettelist + (uint)id * 4, Ptr(palOff));
+            }
+
+            // config block.
+            rom.write_u32(animeAddr + 0, Ptr(framesAddr));
+            rom.write_u32(animeAddr + 4, Ptr(tsalist));
+            rom.write_u32(animeAddr + 8, Ptr(graphiclist));
+            rom.write_u32(animeAddr + 12, Ptr(palettelist));
+            rom.write_u32(animeAddr + 16, 0x3d1); // sound id (raw)
+
+            // frames table.
+            uint f = framesAddr;
+            foreach (ushort id in ids)
+            {
+                rom.write_u16(f + 0, id);
+                rom.write_u16(f + 2, 0x0001); // wait
+                f += 4;
+            }
+            rom.write_u16(f + 0, 0xFFFF); // terminator
+        }
+
+        [Fact]
+        public void EmitSkillSystemsRecycleOldAnime_FE8J_EmitsPerFrameAndConfigBlocks()
+        {
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var rom = MakeVersionedRom("BE8J01"); // FE8J: is_multibyte -> SkipCode returns addr directly.
+                Assert.True(rom.RomInfo.is_multibyte);
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+
+                uint animeAddr = 0x1000, framesAddr = 0x2000, listsAddr = 0x3000, imgPool = 0x4000;
+                // 2 frames, ids {0, 1} (both unique) then terminator -> count 2.
+                LayoutSkillAnime(rom, animeAddr, framesAddr, listsAddr, imgPool, new ushort[] { 0, 1 });
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitSkillSystemsRecycleOldAnime(rom, list, "SkillAnime:0x0 ", false, animeAddr);
+
+                // Per-frame OBJ/TSA/PAL for each of the 2 frames.
+                Assert.Equal(2, list.Count(a => a.Info == "SkillAnime:0x0 OBJ"));
+                Assert.Equal(2, list.Count(a => a.Info == "SkillAnime:0x0 TSA"));
+                Assert.Equal(2, list.Count(a => a.Info == "SkillAnime:0x0 PAL"));
+                // Type check on the per-frame regions.
+                Assert.All(list.Where(a => a.Info == "SkillAnime:0x0 OBJ"),
+                    a => Assert.Equal(Address.DataTypeEnum.LZ77IMG, a.DataType));
+                Assert.All(list.Where(a => a.Info == "SkillAnime:0x0 TSA"),
+                    a => Assert.Equal(Address.DataTypeEnum.LZ77TSA, a.DataType));
+                Assert.All(list.Where(a => a.Info == "SkillAnime:0x0 PAL"),
+                    a => { Assert.Equal(Address.DataTypeEnum.PAL, a.DataType); Assert.Equal(0x20u, a.Length); });
+
+                // The trailing config + 4 list blocks (count 2).
+                Address ptr = list.Single(a => a.Info == "SkillAnime:0x0 POINTER");
+                Assert.Equal(animeAddr, ptr.Addr);
+                Assert.Equal(Address.DataTypeEnum.POINTER, ptr.DataType);
+                Assert.Equal(U.NOT_FOUND, ptr.Pointer);
+                // config == anime (FE8J), so POINTER length = (config - anime) + 20 = 0 + 20 = 20.
+                Assert.Equal(20u, ptr.Length);
+
+                Address rom_frame = list.Single(a => a.Info == "SkillAnime:0x0 ROMANIMEFRAME");
+                Assert.Equal((2u + 1) * 4, rom_frame.Length);   // (count+1)*4
+                Assert.Equal(Address.DataTypeEnum.ROMANIMEFRAME, rom_frame.DataType);
+
+                Assert.Equal(2u * 4, list.Single(a => a.Info == "SkillAnime:0x0 TSALIST").Length);
+                Assert.Equal(2u * 4, list.Single(a => a.Info == "SkillAnime:0x0 IMAGELIST").Length);
+                // The WF "PALETEELIST" typo is preserved for parity.
+                Assert.Equal(2u * 4, list.Single(a => a.Info == "SkillAnime:0x0 PALETEELIST").Length);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
+        }
+
+        [Fact]
+        public void EmitSkillSystemsRecycleOldAnime_FE8J_SharedFrameId_EmittedOnce_ViaRecyclePoolDedup()
+        {
+            // A frame id referenced TWICE in the frames table resolves to the SAME objPointer/tsaPointer/
+            // palPointer, so the recycle pool collapses them (the WF per-frame Add* with no explicit dedup —
+            // the Address list carries duplicate POINTER slots, but each points at the SAME pool slot). We
+            // assert the per-frame Add* fire per FRAME (count 3 for 3 frames) but the underlying pointers
+            // reference only 2 distinct slots.
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var rom = MakeVersionedRom("BE8J01");
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+
+                uint animeAddr = 0x1000, framesAddr = 0x2000, listsAddr = 0x3000, imgPool = 0x4000;
+                // ids {0, 1, 0}: 3 frames, 2 unique ids. count = 3 (per-frame).
+                LayoutSkillAnime(rom, animeAddr, framesAddr, listsAddr, imgPool, new ushort[] { 0, 1, 0 });
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitSkillSystemsRecycleOldAnime(rom, list, "S ", false, animeAddr);
+
+                // 3 OBJ Address entries (one per FRAME), but only 2 DISTINCT graphiclist slots (id 0 twice).
+                var objs = list.Where(a => a.Info == "S OBJ").ToList();
+                Assert.Equal(3, objs.Count);
+                Assert.Equal(2, objs.Select(a => a.Pointer).Distinct().Count());
+                // count is per-frame (3) -> ROMANIMEFRAME length (3+1)*4.
+                Assert.Equal((3u + 1) * 4, list.Single(a => a.Info == "S ROMANIMEFRAME").Length);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
+        }
+
+        [Fact]
+        public void EmitSkillSystemsRecycleOldAnime_NonMultibyteNoTemplate_EmitsNothing()
+        {
+            // FE8U (is_multibyte == false) with NO config/patch2 template files -> SkipCode returns NOT_FOUND
+            // -> nothing emitted (the WF SkipCode template-miss path). Faithful headless behaviour.
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var rom = MakeVersionedRom("BE8E01"); // FE8U: is_multibyte == false.
+                Assert.False(rom.RomInfo.is_multibyte);
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+
+                uint animeAddr = 0x1000, framesAddr = 0x2000, listsAddr = 0x3000, imgPool = 0x4000;
+                LayoutSkillAnime(rom, animeAddr, framesAddr, listsAddr, imgPool, new ushort[] { 0, 1 });
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitSkillSystemsRecycleOldAnime(rom, list, "X ", false, animeAddr);
+                Assert.Empty(list);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
+        }
+
+        [Fact]
+        public void EmitSkillSystemsRecycleOldAnime_NearEof_NoThrow()
+        {
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var rom = MakeVersionedRom("BE8J01");
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+
+                uint nearEof = (uint)rom.Data.Length - 4; // config block (20 bytes) would overrun.
+                var list = new List<Address>();
+                Assert.Null(Record.Exception(() =>
+                    RebuildProducerCore.EmitSkillSystemsRecycleOldAnime(rom, list, "X ", false, nearEof)));
+                Assert.Empty(list);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
+        }
+
+        // ---- EmitSkillConfigSkillSystemAt (form 1, FE8U) ----
+
+        [Fact]
+        public void EmitSkillConfigSkillSystemAt_EmitsMainIfr_AndSkillAnimeList()
+        {
+            var rom = CreateTestRom(0x10000);
+            uint basetextP = 0x0400, baseanimeP = 0x0500;
+            uint textTable = 0x1000, animeTable = 0x2000;
+            rom.write_u32(basetextP, Ptr(textTable));
+            rom.write_u32(baseanimeP, Ptr(animeTable));
+            // block-2 IFR, rule i < 255 -> count caps at 255 (or EOF). Plant 3 non-zero u16 entries; the
+            // i<255 rule never stops on data, only at EOF — so count = (0x10000 - textTable)/2 capped at 255.
+            // To keep it small, the i<255 rule means it walks until i==255 -> count 255.
+            for (uint k = 0; k < 4; k++) rom.write_u16(textTable + k * 2, (ushort)(0x1000 + k));
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitSkillConfigSkillSystemAt(rom, list, basetextP, baseanimeP);
+
+            Address main = list.Single(a => a.Info == "SkillConfigSkillSystem");
+            Assert.Equal(textTable, main.Addr);
+            Assert.Equal(basetextP, main.Pointer);
+            Assert.Equal(2u, main.BlockSize);
+            Assert.Equal(255u, RomBlockCount(main));     // i<255 -> count 255
+            Assert.Empty(main.PointerIndexes);
+
+            // The "SkillAnime" pointer-list IFR (AddAddressInstantIFR): base = animeTable, block 4,
+            // length = 4 * (255 + 1), pointer = the slot, PI {0}.
+            Address anime = list.Single(a => a.Info == "SkillAnime");
+            Assert.Equal(animeTable, anime.Addr);
+            Assert.Equal(baseanimeP, anime.Pointer);
+            Assert.Equal(4u, anime.BlockSize);
+            Assert.Equal(new uint[] { 0 }, anime.PointerIndexes);
+            Assert.Equal(4u * (255 + 1), anime.Length);
+        }
+
+        // helper: recover the IFR DataCount from an emitted Address (length = block*(count+1)).
+        static uint RomBlockCount(Address a) => (a.Length / a.BlockSize) - 1;
+
+        [Fact]
+        public void EmitSkillConfigSkillSystemAt_PerAnimeRecycleWalk_FE8J()
+        {
+            // Drive form 1's per-anime recycle walk end-to-end on an FE8J ROM (is_multibyte -> SkipCode
+            // direct). The main IFR has a tiny count so the anime loop is bounded; one valid anime entry.
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var rom = MakeVersionedRom("BE8J01");
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+
+                uint basetextP = 0x0400, baseanimeP = 0x0500;
+                uint textTable = 0x600, animeTable = 0x800;
+                rom.write_u32(basetextP, Ptr(textTable));
+                rom.write_u32(baseanimeP, Ptr(animeTable));
+                // text table: block-2, rule i<255 -> count caps at 255. To bound the anime loop to ONE entry
+                // we cannot easily cap i<255; instead point the anime table's entry 0 at a valid anime and
+                // leave the rest NULL (RecycleOldAnime skips NULL via isSafetyOffset continue).
+                uint animeAddr = 0x1000, framesAddr = 0x2000, listsAddr = 0x3000, imgPool = 0x4000;
+                LayoutSkillAnime(rom, animeAddr, framesAddr, listsAddr, imgPool, new ushort[] { 0, 1 });
+                rom.write_u32(animeTable + 0, Ptr(animeAddr)); // entry 0 -> the valid anime.
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitSkillConfigSkillSystemAt(rom, list, basetextP, baseanimeP);
+
+                // The recycle walk for entry 0 fires with the per-skill name "SkillAnime:0x0 ".
+                Assert.Contains(list, a => a.Info == "SkillAnime:0x00 POINTER");
+                Assert.Equal(2, list.Count(a => a.Info == "SkillAnime:0x00 OBJ"));
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
+        }
+
+        [Fact]
+        public void EmitSkillConfigSkillSystemAt_NearEofAnimeSlot_NoThrow()
+        {
+            var rom = CreateTestRom(0x2000);
+            uint basetextP = 0x0400;
+            uint baseanimeP = (uint)rom.Data.Length - 2; // slot near EOF.
+            rom.write_u32(basetextP, Ptr(0x1000));
+            var list = new List<Address>();
+            Assert.Null(Record.Exception(() =>
+                RebuildProducerCore.EmitSkillConfigSkillSystemAt(rom, list, basetextP, baseanimeP)));
+        }
+
+        [Fact]
+        public void EmitSkillConfigSkillSystem_NonSkillSystemRom_EmitsNothing()
+        {
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var fe8 = MakeVersionedRom("BE8E01"); // FE8U, no SkillSystem patch -> SearchSkillSystem != SkillSystem.
+                CoreState.ROM = fe8;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(fe8);
+                var list = new List<Address>();
+                RebuildProducerCore.EmitSkillConfigSkillSystem(fe8, list);
+                Assert.Empty(list);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
+        }
+
+        // ---- EmitSkillConfigFE8NVer2At (form 2, FE8J) ----
+
+        [Fact]
+        public void EmitSkillConfigFE8NVer2At_MainIfr_AnimePointer_NestedAndIcon()
+        {
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var rom = MakeVersionedRom("BE8J01"); // is_multibyte -> SkipCode direct for the recycle walk.
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+
+                uint skillBaseP = 0x0400, animeBaseP = 0x0500;
+                uint skillTable = 0x600, animeTable = 0x800;
+                uint iconListSize = 16; // block 16 -> PI {4,8,12}.
+                rom.write_u32(skillBaseP, Ptr(skillTable));
+                rom.write_u32(animeBaseP, Ptr(animeTable));
+
+                // skill table: 2 entries (u8(addr) != 0xFF) then a 0xFF terminator at entry 2.
+                // entry 0 @ skillTable, entry 1 @ skillTable+16.
+                rom.write_u8(skillTable + 0 * 16, 0x10);   // text id low byte, != 0xFF
+                rom.write_u8(skillTable + 1 * 16, 0x11);
+                rom.write_u8(skillTable + 2 * 16, 0xFF);   // terminator
+                // nested N1/N2/N3 pointers for entry 0 (@ +4/+8/+12) -> tiny u8!=0 lists.
+                uint n1 = 0x900, n2 = 0x910, n3 = 0x920;
+                rom.write_u32(skillTable + 0 * 16 + 4, Ptr(n1));
+                rom.write_u32(skillTable + 0 * 16 + 8, Ptr(n2));
+                rom.write_u32(skillTable + 0 * 16 + 12, Ptr(n3));
+                rom.write_u8(n1, 0x05); rom.write_u8(n1 + 1, 0x00);   // 1 entry then 0
+                rom.write_u8(n2, 0x06); rom.write_u8(n2 + 1, 0x00);
+                rom.write_u8(n3, 0x07); rom.write_u8(n3 + 1, 0x00);
+
+                // anime table entry 0 -> valid anime.
+                uint animeAddr = 0x1000, framesAddr = 0x2000, listsAddr = 0x3000, imgPool = 0x4000;
+                LayoutSkillAnime(rom, animeAddr, framesAddr, listsAddr, imgPool, new ushort[] { 0 });
+                rom.write_u32(animeTable + 0, Ptr(animeAddr));
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitSkillConfigFE8NVer2At(rom, list, skillBaseP, animeBaseP, iconListSize);
+
+                // Main IFR.
+                Address main = list.Single(a => a.Info == "SkillConfigFE8NVer2");
+                Assert.Equal(skillTable, main.Addr);
+                Assert.Equal(skillBaseP, main.Pointer);
+                Assert.Equal(16u, main.BlockSize);
+                Assert.Equal(2u, RomBlockCount(main));         // 2 entries.
+                Assert.Equal(new uint[] { 4, 8, 12 }, main.PointerIndexes);
+
+                // Per-anime POINTER (the AddAddress before the recycle walk).
+                Address animePtr = list.Single(a => a.Info == "SkillAnime:0x00 " && a.DataType == Address.DataTypeEnum.POINTER);
+                Assert.Equal(animeAddr, animePtr.Addr);
+                Assert.Equal(animeTable + 0, animePtr.Pointer);
+                Assert.Equal(4u, animePtr.Length);
+                // recycle walk fired.
+                Assert.Contains(list, a => a.Info == "SkillAnime:0x00 POINTER");
+
+                // Per-entry nested unit/class/item + SkillIcon.
+                Assert.Contains(list, a => a.Info == "SkillUnit:0x00");
+                Assert.Contains(list, a => a.Info == "SkillClass:0x00");
+                Assert.Contains(list, a => a.Info == "SkillItem:0x00");
+                Assert.DoesNotContain(list, a => a.Info == "SkillItem2:0x00"); // block 16 -> no N4.
+                Address icon0 = list.Single(a => a.Info == "SkillIcon:0x00");
+                Assert.Equal(128u, icon0.Length);
+                Assert.Equal(Address.DataTypeEnum.IMG, icon0.DataType);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
+        }
+
+        [Fact]
+        public void EmitSkillConfigFE8NVer2At_Block20_AddsN4_AndPi16()
+        {
+            var rom = CreateTestRom(0x10000);
+            uint skillBaseP = 0x0400;
+            uint skillTable = 0x1000;
+            uint iconListSize = 20; // block 20 -> PI {4,8,12,16}, N4 emitted.
+            rom.write_u32(skillBaseP, Ptr(skillTable));
+            rom.write_u8(skillTable + 0 * 20, 0x10);
+            rom.write_u8(skillTable + 1 * 20, 0xFF); // 1 entry then terminator.
+            uint n4 = 0x2000;
+            rom.write_u32(skillTable + 0 * 20 + 16, Ptr(n4));
+            rom.write_u8(n4, 0x09); rom.write_u8(n4 + 1, 0x00);
+
+            var list = new List<Address>();
+            // animeBase 0 -> no anime walk.
+            RebuildProducerCore.EmitSkillConfigFE8NVer2At(rom, list, skillBaseP, 0, iconListSize);
+
+            Address main = list.Single(a => a.Info == "SkillConfigFE8NVer2");
+            Assert.Equal(new uint[] { 4, 8, 12, 16 }, main.PointerIndexes);
+            Assert.Contains(list, a => a.Info == "SkillItem2:0x00"); // N4 present at block 20.
+        }
+
+        [Fact]
+        public void EmitSkillConfigFE8NVer2At_Block24_Pi12NotPi16_ButN4StillEmitted()
+        {
+            // WF asymmetry: the main pointerIndexes use `ifr.BlockSize == 20` (so block 24 -> {4,8,12}, NOT
+            // {4,8,12,16}), while the optional N4 uses `g_ICON_LIST_SIZE >= 20` (so block 24 DOES emit N4).
+            var rom = CreateTestRom(0x10000);
+            uint skillBaseP = 0x0400;
+            uint skillTable = 0x1000;
+            uint iconListSize = 24;
+            rom.write_u32(skillBaseP, Ptr(skillTable));
+            rom.write_u8(skillTable + 0 * 24, 0x10);
+            rom.write_u8(skillTable + 1 * 24, 0xFF);
+            uint n4 = 0x2000;
+            rom.write_u32(skillTable + 0 * 24 + 16, Ptr(n4));
+            rom.write_u8(n4, 0x09); rom.write_u8(n4 + 1, 0x00);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitSkillConfigFE8NVer2At(rom, list, skillBaseP, 0, iconListSize);
+
+            Address main = list.Single(a => a.Info == "SkillConfigFE8NVer2");
+            Assert.Equal(new uint[] { 4, 8, 12 }, main.PointerIndexes);   // block != 20 -> {4,8,12}.
+            Assert.Contains(list, a => a.Info == "SkillItem2:0x00");      // iconListSize >= 20 -> N4 emitted.
+        }
+
+        [Fact]
+        public void EmitSkillSystemsRecycleOldAnime_IsPointerOnly_ForwardedToObjTsa()
+        {
+            // The producer always passes isPointerOnly=false; prove the method THREADS the flag (true ->
+            // OBJ/TSA LZ77 lengths become 0 via AddLZ77Pointer's isPointerOnly path).
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var rom = MakeVersionedRom("BE8J01");
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+
+                uint animeAddr = 0x1000, framesAddr = 0x2000, listsAddr = 0x3000, imgPool = 0x4000;
+                LayoutSkillAnime(rom, animeAddr, framesAddr, listsAddr, imgPool, new ushort[] { 0 });
+
+                var pf = new List<Address>();
+                RebuildProducerCore.EmitSkillSystemsRecycleOldAnime(rom, pf, "P ", true, animeAddr);
+                Assert.All(pf.Where(a => a.Info == "P OBJ"), a => Assert.Equal(0u, a.Length));
+                Assert.All(pf.Where(a => a.Info == "P TSA"), a => Assert.Equal(0u, a.Length));
+
+                var full = new List<Address>();
+                RebuildProducerCore.EmitSkillSystemsRecycleOldAnime(rom, full, "P ", false, animeAddr);
+                Assert.All(full.Where(a => a.Info == "P OBJ"), a => Assert.True(a.Length > 0));
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
+        }
+
+        [Fact]
+        public void EmitSkillConfigFE8NVer2At_AnimeBaseZero_NoAnimeWalk()
+        {
+            var rom = CreateTestRom(0x10000);
+            uint skillBaseP = 0x0400, skillTable = 0x1000;
+            rom.write_u32(skillBaseP, Ptr(skillTable));
+            rom.write_u8(skillTable + 0 * 16, 0x10);
+            rom.write_u8(skillTable + 1 * 16, 0xFF);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitSkillConfigFE8NVer2At(rom, list, skillBaseP, 0, 16);
+            Assert.DoesNotContain(list, a => a.Info.StartsWith("SkillAnime"));
+            Assert.Contains(list, a => a.Info == "SkillConfigFE8NVer2");
+        }
+
+        [Fact]
+        public void EmitSkillConfigFE8NVer2At_NearEofSkillSlot_NoThrow()
+        {
+            var rom = CreateTestRom(0x2000);
+            uint nearEof = (uint)rom.Data.Length - 2;
+            var list = new List<Address>();
+            Assert.Null(Record.Exception(() =>
+                RebuildProducerCore.EmitSkillConfigFE8NVer2At(rom, list, nearEof, 0, 16)));
+            Assert.Empty(list);
+        }
+
+        // ---- EmitSkillConfigFE8NVer3At (form 3, FE8J) ----
+
+        [Fact]
+        public void EmitSkillConfigFE8NVer3At_MainIfr_Pi5_AnimeViaU32_NestedN5_AndIcon()
+        {
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var rom = MakeVersionedRom("BE8J01");
+                CoreState.ROM = rom;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+
+                uint skillBaseP = 0x0400, animeBaseP = 0x0500;
+                uint skillTable = 0x600, animeTable = 0x800;
+                uint iconListSize = 24; // block 24 holds the +20 N5 pointer.
+                rom.write_u32(skillBaseP, Ptr(skillTable));
+                rom.write_u32(animeBaseP, Ptr(animeTable));
+
+                rom.write_u8(skillTable + 0 * 24, 0x10);
+                rom.write_u8(skillTable + 1 * 24, 0xFF); // 1 entry then terminator.
+                // nested N1..N5 @ +4/+8/+12/+16/+20.
+                uint nbase = 0x900;
+                for (uint k = 0; k < 5; k++)
+                {
+                    uint np = nbase + k * 0x10;
+                    rom.write_u32(skillTable + 0 * 24 + 4 + k * 4, Ptr(np));
+                    rom.write_u8(np, (byte)(0x05 + k)); rom.write_u8(np + 1, 0x00);
+                }
+
+                uint animeAddr = 0x1000, framesAddr = 0x2000, listsAddr = 0x3000, imgPool = 0x4000;
+                LayoutSkillAnime(rom, animeAddr, framesAddr, listsAddr, imgPool, new ushort[] { 0 });
+                rom.write_u32(animeTable + 0, Ptr(animeAddr));
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitSkillConfigFE8NVer3At(rom, list, skillBaseP, animeBaseP, iconListSize);
+
+                Address main = list.Single(a => a.Info == "SkillConfigFE8NVer3");
+                Assert.Equal(new uint[] { 4, 8, 12, 16, 20 }, main.PointerIndexes);
+                Assert.Equal(24u, main.BlockSize);
+
+                // Per-anime POINTER + recycle.
+                Assert.Contains(list, a => a.Info == "SkillAnime:0x00 " && a.DataType == Address.DataTypeEnum.POINTER);
+                Assert.Contains(list, a => a.Info == "SkillAnime:0x00 POINTER");
+
+                // N1..N5.
+                Assert.Contains(list, a => a.Info == "SkillUnit:0x00");
+                Assert.Contains(list, a => a.Info == "SkillClass:0x00");
+                Assert.Contains(list, a => a.Info == "SkillItem:0x00");
+                Assert.Contains(list, a => a.Info == "SkillItem2:0x00");
+                Assert.Contains(list, a => a.Info == "SkillComplex:0x00");
+                Assert.Equal(128u, list.Single(a => a.Info == "SkillIcon:0x00").Length);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
+        }
+
+        [Fact]
+        public void EmitSkillConfigFE8NVer3At_NearEofSkillSlot_NoThrow()
+        {
+            var rom = CreateTestRom(0x2000);
+            uint nearEof = (uint)rom.Data.Length - 2;
+            var list = new List<Address>();
+            Assert.Null(Record.Exception(() =>
+                RebuildProducerCore.EmitSkillConfigFE8NVer3At(rom, list, nearEof, 0, 24)));
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitSkillConfigFE8NVer2_And_Ver3_NonMatchingRom_EmitNothing()
+        {
+            // FE8J with no Ver2/Ver3 patch -> SearchSkillSystem != FE8N_ver2/ver3 -> nothing.
+            var savedRom = CoreState.ROM;
+            var savedEnc = CoreState.SystemTextEncoder;
+            try
+            {
+                var fe8j = MakeVersionedRom("BE8J01");
+                CoreState.ROM = fe8j;
+                CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(fe8j);
+                var list = new List<Address>();
+                RebuildProducerCore.EmitSkillConfigFE8NVer2(fe8j, list);
+                RebuildProducerCore.EmitSkillConfigFE8NVer3(fe8j, list);
+                Assert.Empty(list);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.SystemTextEncoder = savedEnc;
+            }
         }
 
         // --- ImageMapActionAnimation ---------------------------------------

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -861,14 +861,17 @@ namespace FEBuilderGBA
             progress?.Report("SupportUnit");
             EmitSupportUnit(rom, list);
 
-            // ---- slice 2o: SkillSystems skill-config / skill-assignment forms ----
-            // WF (U.MakeAllStructPointersList) runs these in the version-agnostic section, gated on
+            // ---- slice 2o + 2ac: SkillSystems skill-config / skill-assignment forms ----
+            // WF (U.MakeAllStructPointersList :2438-2449) runs these in the version-agnostic section, gated on
             // is_multibyte: `is_multibyte == false` (FE8U) emits the two skill-ASSIGNMENT tables (Class +
-            // Unit); `else` (FE8J) emits SkillConfigFE8N. The RecycleOldAnime-dependent siblings
-            // (SkillConfigSkillSystemForm on FE8U; FE8NVer2/FE8NVer3 on FE8J) STAY deferred (anime length
-            // walker + GUI state not in Core). Each emitter ALSO re-checks SearchSkillSystem (mirroring the
-            // WF MakeAllDataLength early-return), so a non-SkillSystem ROM emits nothing. Gate EXACTLY as
-            // WF: a wrong is_multibyte branch would emit the wrong tables = corruption.
+            // Unit) THEN SkillConfigSkillSystem; `else` (FE8J) emits SkillConfigFE8N THEN
+            // SkillConfigFE8NVer2 THEN SkillConfigFE8NVer3. Slice 2o ported the RecycleOldAnime-FREE subset
+            // (Assignment Class/Unit + SkillConfigFE8N); slice 2ac ports the three RecycleOldAnime-DEPENDENT
+            // siblings (SkillConfigSkillSystem on FE8U; FE8NVer2/FE8NVer3 on FE8J), reproducing the WF
+            // RecycleOldAnime VERBATIM as EmitSkillSystemsRecycleOldAnime. Each emitter ALSO re-checks
+            // SearchSkillSystem (mirroring the WF MakeAllDataLength early-return), so a non-matching ROM emits
+            // nothing. Gate EXACTLY as WF — a wrong is_multibyte branch would emit the wrong tables =
+            // corruption — and preserve the WF call ORDER within each branch.
             if (rom.RomInfo.is_multibyte == false)
             {
                 if (ct.IsCancellationRequested)
@@ -886,6 +889,14 @@ namespace FEBuilderGBA
                 }
                 progress?.Report("SkillAssignmentUnit");
                 EmitSkillAssignmentUnit(rom, list);
+
+                if (ct.IsCancellationRequested)
+                {
+                    progress?.Report("MakeAllStructPointersList cancelled");
+                    return new ProducerResult(list, notYet, cancelled: true);
+                }
+                progress?.Report("SkillConfigSkillSystem");
+                EmitSkillConfigSkillSystem(rom, list);
             }
             else
             {
@@ -896,6 +907,22 @@ namespace FEBuilderGBA
                 }
                 progress?.Report("SkillConfigFE8N");
                 EmitSkillConfigFE8N(rom, list);
+
+                if (ct.IsCancellationRequested)
+                {
+                    progress?.Report("MakeAllStructPointersList cancelled");
+                    return new ProducerResult(list, notYet, cancelled: true);
+                }
+                progress?.Report("SkillConfigFE8NVer2");
+                EmitSkillConfigFE8NVer2(rom, list);
+
+                if (ct.IsCancellationRequested)
+                {
+                    progress?.Report("MakeAllStructPointersList cancelled");
+                    return new ProducerResult(list, notYet, cancelled: true);
+                }
+                progress?.Report("SkillConfigFE8NVer3");
+                EmitSkillConfigFE8NVer3(rom, list);
             }
 
             if (rom.RomInfo.version == 8)
@@ -5916,12 +5943,14 @@ namespace FEBuilderGBA
 
         // ===================================================================
         // slice 2o — SkillSystems skill-config / skill-assignment forms
-        // (the RecycleOldAnime-FREE subset). The other Skill forms
-        // (SkillConfigSkillSystemForm / FE8NVer2 / FE8NVer3) STAY deferred:
-        // they call ImageUtilSkillSystemsAnimeCreator.RecycleOldAnime, an
-        // anime length walker not yet in Core (same blocker as the Group-3
-        // ImageUtilOAM/anime forms), plus the Ver2/Ver3 forms read GUI session
-        // state (g_SkillBaseAddress / g_AnimeBaseAddress / g_ICON_LIST_SIZE).
+        // (the RecycleOldAnime-FREE subset). The RecycleOldAnime-DEPENDENT
+        // siblings (SkillConfigSkillSystemForm / FE8NVer2 / FE8NVer3) are
+        // ported in slice 2ac (below) by reproducing RecycleOldAnime VERBATIM
+        // as EmitSkillSystemsRecycleOldAnime (the import-adapted Core helper
+        // EnumerateOldAnimeRegions diverges on NAMES + an import-only guard).
+        // The Ver2/Ver3 GUI session state (g_SkillBaseAddress /
+        // g_AnimeBaseAddress / g_ICON_LIST_SIZE) is resolved via the new
+        // SkillSystemTextScanner.FindSkillFE8NVer2/Ver3IconPointersFull.
         //
         // All base/count scanners are ALREADY in Core, faithfully:
         //   - SkillSystemTextScanner.SearchSkillSystem  (= WF PatchUtil.SearchSkillSystemLow)
@@ -6069,7 +6098,18 @@ namespace FEBuilderGBA
         public static uint EmitSkillAssignmentMainIfr(ROM rom, List<Address> list, uint assignP,
             string name, Func<int, uint, bool> rule)
         {
-            const uint block = 1;
+            return EmitSkillAssignmentMainIfr(rom, list, assignP, name, rule, 1);
+        }
+
+        /// <summary>Block-overload of <see cref="EmitSkillAssignmentMainIfr(ROM, List{Address}, uint, string,
+        /// Func{int, uint, bool})"/> for callers whose <c>Init</c> uses a non-1 BlockSize (slice 2ac:
+        /// SkillConfigSkillSystem's <c>Init(null, basetextP)</c> is block 2). Same shape: base =
+        /// <c>p32(assignP)</c>, length = <c>block × (DataCount + 1)</c>, pointer = the slot (or
+        /// <see cref="U.NOT_FOUND"/> if unsafe), emit ONLY if the base is safe; pointerIndexes EMPTY (the WF
+        /// <c>new uint[] {}</c>). Returns the resolved <c>DataCount</c>.</summary>
+        public static uint EmitSkillAssignmentMainIfr(ROM rom, List<Address> list, uint assignP,
+            string name, Func<int, uint, bool> rule, uint block)
+        {
             uint slot = U.toOffset(assignP);
             if (!U.isSafetyOffset(slot + 3, rom)) return 0;
             uint baseAddr = rom.p32(slot);
@@ -6223,6 +6263,552 @@ namespace FEBuilderGBA
                         return pp != 0xFFFF && pp != 0;
                     },
                     "SkillConfigFE8N" + U.ToHexString(i));
+            }
+        }
+
+        // ===================================================================
+        // slice 2ac — SkillConfig SkillSystems ANIME forms (the three
+        // RecycleOldAnime-DEPENDENT siblings deferred by slice 2o):
+        //   SkillConfigSkillSystemForm      [FE8U, is_multibyte == false]
+        //   SkillConfigFE8NVer2SkillForm    [FE8J, is_multibyte == true]
+        //   SkillConfigFE8NVer3SkillForm    [FE8J, is_multibyte == true]
+        // Each walks a skill table and, per anime entry, calls the WF
+        // ImageUtilSkillSystemsAnimeCreator.RecycleOldAnime (an uncompressed
+        // anime-frame-stream length walker).
+        //
+        // CENTRAL FAITHFULNESS DECISION (RecycleOldAnime) — REPRODUCED VERBATIM:
+        // The import-adapted Core helper SkillSystemsAnimeImportCore.
+        // EnumerateOldAnimeRegions emits BYTE-IDENTICAL (addr,length,pointer,
+        // DataTypeEnum) tuples vs the WF RecycleOldAnime, BUT diverges on NAMES
+        // (it hardcodes basename "OLDANIME" where WF uses the per-skill
+        // "SkillAnime:0x.. " name, and names the palette list "PALETTELIST"
+        // where WF has the typo "PALETEELIST") AND adds a
+        // `ReferenceEquals(rom, CoreState.ROM)` import-only guard + an
+        // `excludeRegionAddrs` skip mechanism foreign to the producer walk.
+        // Reusing it would change the emitted Address.Info strings the
+        // FEBuilderGBA.Tests WF-parity suite checks. So this slice REPRODUCES
+        // RecycleOldAnime VERBATIM as a producer-local method
+        // (EmitSkillSystemsRecycleOldAnime) taking the per-skill basename —
+        // exactly the slice-2s posture (EmitImageBattleAnimeOAM). It reuses the
+        // PROVEN Core primitive SkillSystemsAnimeExportCore.SkipCode (itself a
+        // faithful WF SkipCode port: FE8J returns the address directly; FE8U
+        // skips the embedded config/patch2/FE8U/skill/*.dmp program template).
+        // ===================================================================
+
+        /// <summary>
+        /// VERBATIM port of <c>ImageUtilSkillSystemsAnimeCreator.RecycleOldAnime</c>
+        /// (<c>FEBuilderGBA/ImageUtilSkillSystemsAnimeCreator.cs:637</c>): for ONE skill anime at
+        /// <paramref name="animeAddress"/>, emit the per-frame OBJ(LZ77)/TSA(LZ77)/PAL(0x20) regions plus —
+        /// only when the frames-table 0xFFFF terminator is reached within the 1 MB limiter — the program+config
+        /// POINTER block and the four config pointer-list blocks (ROMANIMEFRAME / TSALIST / IMAGELIST /
+        /// PALETEELIST). Reproduces the WF emission ORDER, the per-frame Add*(no dedup; the recycle pool
+        /// collapses repeated ids), and the partial-list bail semantics (a mid-walk unsafe pointer returns the
+        /// PARTIAL list; a limiter hit returns WITHOUT the trailing config blocks). The config address is
+        /// resolved via the PROVEN Core primitive <see cref="SkillSystemsAnimeExportCore.SkipCode"/> (FE8J
+        /// direct; FE8U program-template prefix). All emitted NAMES are WF-identical (per-skill
+        /// <paramref name="basename"/> + suffix, including the WF "PALETEELIST" typo) so the WF-parity suite
+        /// matches. The <c>Address.Add*</c> helpers dereference <see cref="CoreState.ROM"/> internally, so the
+        /// producer (which runs with <c>CoreState.ROM == rom</c>) and the test seams (which set
+        /// <c>CoreState.ROM = rom</c>) drive identical data — exactly the slice-2s ImageBattleAnime posture.
+        /// EOF-HARDENING: every computed read's full extent is guarded (<c>animeAddress + 0x14 &gt; Length</c>
+        /// for the 5-word config block; each per-frame pointer SLOT via <c>objPointer/tsaPointer/palPointer +
+        /// 4</c>; each dereferenced offset via <c>isSafetyOffset(... )</c> / <c>palOffset + 0x20</c>) — all
+        /// reproduced from WF. Threads <paramref name="rom"/>; uses no <c>Program.ROM</c>/<c>CoreState.ROM</c>
+        /// for the reads.
+        /// </summary>
+        public static void EmitSkillSystemsRecycleOldAnime(ROM rom, List<Address> list,
+            string basename, bool isPointerOnly, uint animeAddress)
+        {
+            // WF :639-643 — guard the anime address.
+            animeAddress = U.toOffset(animeAddress);
+            if (!U.isSafetyOffset(animeAddress, rom))
+            {
+                return;
+            }
+
+            // WF :648-652 — resolve the config address (FE8J direct, FE8U skips the embedded program
+            // template). NOT_FOUND ⇒ nothing (the SkipCode primitive is the proven WF SkipCode port).
+            uint anime_config_address = SkillSystemsAnimeExportCore.SkipCode(rom, animeAddress, out _);
+            if (anime_config_address == U.NOT_FOUND)
+            {
+                return;
+            }
+            // WF :653-656 — the 5-word config block must be in range.
+            if (anime_config_address + (4 * 5) > rom.Data.Length)
+            {//範囲外
+                return;
+            }
+
+            // WF :663-666 — the four config pointers (frames / tsalist / graphiclist / palettelist); the
+            // 5th word is the raw sound id (not a pointer).
+            uint frames = rom.p32(anime_config_address + (4 * 0));
+            uint tsalist = rom.p32(anime_config_address + (4 * 1));
+            uint graphiclist = rom.p32(anime_config_address + (4 * 2));
+            uint palettelist = rom.p32(anime_config_address + (4 * 3));
+
+            // WF :669-684 — each config pointer must be safe.
+            if (!U.isSafetyOffset(frames, rom))
+            {
+                return;
+            }
+            if (!U.isSafetyOffset(tsalist, rom))
+            {
+                return;
+            }
+            if (!U.isSafetyOffset(graphiclist, rom))
+            {
+                return;
+            }
+            if (!U.isSafetyOffset(palettelist, rom))
+            {
+                return;
+            }
+
+            // WF :686-688 — the frames table is uncompressed, so cap the scan at 1 MB (clamped to the ROM
+            // size) to avoid a runaway on a corrupt table.
+            uint limitter = frames + 1024 * 1024; //1MBサーチしたらもうあきらめる.
+            limitter = (uint)Math.Min(limitter, rom.Data.Length);
+
+            // WF :690-751 — walk the [u16 id, u16 wait]* frames table to the 0xFFFF terminator. count is
+            // PER-FRAME (not per unique id; the recycle pool collapses repeated-id pointers).
+            uint count = 0;
+            uint n;
+            for (n = frames; n < limitter; n += 4)
+            {
+                uint id = rom.u16(n + 0);
+                //uint wait = rom.u16(n + 2);
+                if (id == 0xFFFF)
+                {
+                    break;
+                }
+
+                uint objPointer = graphiclist + (id * 4);
+                uint tsaPointer = tsalist + (id * 4);
+                uint palPointer = palettelist + (id * 4);
+                count++;
+
+                // WF :706-717 — each per-frame pointer SLOT (and its trailing word) must be safe; a mid-walk
+                // bail returns the PARTIAL list.
+                if (!U.isSafetyOffset(objPointer + 4, rom))
+                {
+                    return;
+                }
+                if (!U.isSafetyOffset(tsaPointer + 4, rom))
+                {
+                    return;
+                }
+                if (!U.isSafetyOffset(palPointer + 4, rom))
+                {
+                    return;
+                }
+                uint objOffset = rom.p32(objPointer);
+                uint tsaOffset = rom.p32(tsaPointer);
+                uint palOffset = rom.p32(palPointer);
+                // WF :721-732 — each dereferenced offset must be safe.
+                if (!U.isSafetyOffset(objOffset, rom))
+                {
+                    return;
+                }
+                if (!U.isSafetyOffset(tsaOffset, rom))
+                {
+                    return;
+                }
+                if (!U.isSafetyOffset(palOffset + 0x20, rom))
+                {
+                    return;
+                }
+
+                // WF :733-750 — add the OBJ image (LZ77), TSA (LZ77) and palette (RAW 0x20) for THIS frame.
+                Address.AddLZ77Pointer(list
+                    , objPointer
+                    , basename + "OBJ"
+                    , isPointerOnly
+                    , Address.DataTypeEnum.LZ77IMG);
+
+                Address.AddLZ77Pointer(list
+                    , tsaPointer
+                    , basename + "TSA"
+                    , isPointerOnly
+                    , Address.DataTypeEnum.LZ77TSA);
+
+                Address.AddPointer(list
+                    , palPointer
+                    , 0x20   //16色*2バイト=0x20バイト
+                    , basename + "PAL"
+                    , Address.DataTypeEnum.PAL);
+            }
+            // WF :752-755 — limiter hit (no terminator found) ⇒ return the PARTIAL list, WITHOUT adding the
+            // trailing config/list blocks.
+            if (n >= limitter)
+            {
+                return;
+            }
+
+            // WF :756-783 — the terminator was reached: add the program+config region and the four
+            // pointer-list blocks. Block sizes mirror WF: frames (count+1)*4, each list count*4.
+            Address.AddAddress(list
+                , animeAddress
+                , anime_config_address - animeAddress + (4 * 5)
+                , U.NOT_FOUND
+                , basename + "POINTER"
+                , Address.DataTypeEnum.POINTER);
+
+            Address.AddPointer(list
+                , anime_config_address + (4 * 0)
+                , (count + 1) * 4
+                , basename + "ROMANIMEFRAME"
+                , Address.DataTypeEnum.ROMANIMEFRAME);
+
+            Address.AddPointer(list
+                , anime_config_address + (4 * 1)
+                , (count) * 4
+                , basename + "TSALIST"
+                , Address.DataTypeEnum.POINTER);
+            Address.AddPointer(list
+                , anime_config_address + (4 * 2)
+                , (count) * 4
+                , basename + "IMAGELIST"
+                , Address.DataTypeEnum.POINTER);
+            Address.AddPointer(list
+                , anime_config_address + (4 * 3)
+                , (count) * 4
+                , basename + "PALETEELIST"   // WF typo "PALETEE" preserved for parity.
+                , Address.DataTypeEnum.POINTER);
+        }
+
+        /// <summary>
+        /// <c>SkillConfigSkillSystemForm.MakeAllDataLength</c> (slice 2ac; FE8U ONLY — gated at the WF
+        /// <c>is_multibyte == false</c> call site, AFTER the two skill-ASSIGNMENT tables). The SkillSystems
+        /// skill-config table (a TEXT-pointer-based block-2 IFR) plus a per-skill anime pointer list + the
+        /// verbatim <see cref="EmitSkillSystemsRecycleOldAnime"/> recycle walk. Reproduced VERBATIM
+        /// (<c>FEBuilderGBA/SkillConfigSkillSystemForm.cs:602</c>):
+        /// <list type="bullet">
+        ///   <item>bail unless <see cref="SkillSystemTextScanner.SkillSystemEnum.SkillSystem"/>;</item>
+        ///   <item>resolve <c>baseiconP / basetextP / baseanimeP</c> via
+        ///   <see cref="SkillSystemPatchScanner.FindSkillPointerLocation"/> ("ICON"/"TEXT"/"ANIME", 0); if
+        ///   ANY is <see cref="U.NOT_FOUND"/> return;</item>
+        ///   <item>main IFR (<c>Init(null, basetextP)</c>): base <c>p32(basetextP)</c>, block 2,
+        ///   IsDataExists = <c>i &lt; 255</c>, name "SkillConfigSkillSystem", pointerIndexes EMPTY;</item>
+        ///   <item>a "SkillAnime" pointer-list IFR via <c>AddAddressInstantIFR(baseanimeP, 4, DataCount,
+        ///   "SkillAnime", {0})</c> (fixed count = the MAIN DataCount);</item>
+        ///   <item>per main entry (<c>i &lt; DataCount</c>, <c>anime = p32(baseanimeP) + 4*i</c>): break if
+        ///   <c>!isSafetyOffset(anime)</c>; <c>addr = p32(anime)</c>; continue if
+        ///   <c>!isSafetyOffset(addr)</c>; else <see cref="EmitSkillSystemsRecycleOldAnime"/> with the
+        ///   per-skill name "SkillAnime:0x&lt;i&gt; ".</item>
+        /// </list>
+        /// The 255-cap IFR <c>DataCount</c> (= WF <c>InputFormRef.DataCount</c>) is captured ONCE and used as
+        /// both the <c>AddAddressInstantIFR</c> fixed count and the anime loop bound (the WF closure). NOTE:
+        /// unlike the Ver2/Ver3 forms, this form does NOT emit a per-entry POINTER Address before the recycle
+        /// walk — reproduced exactly.
+        /// </summary>
+        public static void EmitSkillConfigSkillSystem(ROM rom, List<Address> list)
+        {
+            if (SkillSystemTextScanner.SearchSkillSystem(rom)
+                != SkillSystemTextScanner.SkillSystemEnum.SkillSystem)
+            {
+                return;
+            }
+
+            uint baseiconP = SkillSystemPatchScanner.FindSkillPointerLocation(rom, "ICON", 0);
+            uint basetextP = SkillSystemPatchScanner.FindSkillPointerLocation(rom, "TEXT", 0);
+            uint baseanimeP = SkillSystemPatchScanner.FindSkillPointerLocation(rom, "ANIME", 0);
+
+            if (baseiconP == U.NOT_FOUND) return;
+            if (basetextP == U.NOT_FOUND) return;
+            if (baseanimeP == U.NOT_FOUND) return;
+
+            EmitSkillConfigSkillSystemAt(rom, list, basetextP, baseanimeP);
+        }
+
+        /// <summary>SkillConfigSkillSystem walk from explicit TEXT- and ANIME-pointer SLOTs (test seam — lets
+        /// a synthetic ROM supply the slots without the SkillSystem patch grep). See
+        /// <see cref="EmitSkillConfigSkillSystem"/> for the verbatim WF reproduction. The main block-2 IFR
+        /// "SkillConfigSkillSystem" (count rule <c>i &lt; 255</c>), the "SkillAnime" pointer-list IFR
+        /// (<c>AddAddressInstantIFR(baseanimeP, 4, DataCount, {0})</c>), and the per-anime recycle walk.</summary>
+        public static void EmitSkillConfigSkillSystemAt(ROM rom, List<Address> list,
+            uint basetextP, uint baseanimeP)
+        {
+            const uint block = 2;
+
+            // Init(null, basetextP): block 2, IsDataExists = i < 255. Capture DataCount ONCE (the WF
+            // closure: AddAddressInstantIFR fixed count AND the anime loop bound both use it). The main IFR
+            // is emitted via the shared EmitSkillAssignmentMainIfr helper (base = p32(basetextP), pointer =
+            // the slot or NOT_FOUND if unsafe, length = block * (count + 1), emit only if the base is safe)
+            // — it has EXACTLY the AddressWinForms.AddAddress(IFR, name, {}) shape and returns the DataCount.
+            uint mainDataCount = EmitSkillAssignmentMainIfr(rom, list, basetextP,
+                "SkillConfigSkillSystem", (i, addr) => i < 255, block);
+
+            // The "SkillAnime" pointer-list IFR (fixed count = the MAIN DataCount). AddAddressInstantIFR's
+            // own guard is only isSafetyOffset(START) — guard the FULL slot (+3) first so a near-EOF slot
+            // emits nothing instead of throwing (the slice-2o trap).
+            uint animeSlot = U.toOffset(baseanimeP);
+            if (!U.isSafetyOffset(animeSlot + 3, rom)) return;
+            Address.AddAddressInstantIFR(list, baseanimeP, 4, mainDataCount, "SkillAnime", new uint[] { 0 });
+
+            // Per main entry: WF reads anime = p32(baseanimeP) up front, then walks i < mainDataCount,
+            // anime += 4. The loop bound is the MAIN DataCount (not a getBlockDataCount over THIS list), so
+            // anime can advance past where a 4-byte read is in bounds — guard the FULL slot (anime+3) in the
+            // break (WF only checks isSafetyOffset(anime) — the start byte — and would throw on a truncated
+            // synthetic ROM; the +3 extension is behaviour-neutral on a real ROM whose anime list is
+            // allocated to mainDataCount entries).
+            uint anime = rom.p32(animeSlot);
+            for (uint i = 0; i < mainDataCount; i++, anime += 4)
+            {
+                if (!U.isSafetyOffset(anime + 3, rom))
+                {
+                    break;
+                }
+                uint addr = rom.p32(anime);
+                if (!U.isSafetyOffset(addr, rom))
+                {
+                    continue;
+                }
+                string name = "SkillAnime:" + U.To0xHexString(i) + " ";
+                EmitSkillSystemsRecycleOldAnime(rom, list, name, false, addr);
+            }
+        }
+
+        // The 16-colour skill-icon block: (2*8 * 2*8) / 2 = 128 bytes (16 colours -> /2).
+        const uint SkillIconDataCount = (2 * 8 * 2 * 8) / 2;
+
+        /// <summary>
+        /// <c>SkillConfigFE8NVer2SkillForm.MakeAllDataLength</c> (slice 2ac; FE8J ONLY — gated at the WF
+        /// <c>is_multibyte == true</c> / <c>else</c> call site, AFTER SkillConfigFE8N). The Ver2 skill-config
+        /// table (variable BlockSize <c>g_ICON_LIST_SIZE</c>) + a per-anime POINTER + the verbatim
+        /// <see cref="EmitSkillSystemsRecycleOldAnime"/> recycle walk + per-entry N1..N4 nested unit/class/
+        /// item lists + a SkillIcon IMG block. Reproduced VERBATIM
+        /// (<c>FEBuilderGBA/SkillConfigFE8NVer2SkillForm.cs:1023</c>):
+        /// <list type="bullet">
+        ///   <item>bail unless <see cref="SkillSystemTextScanner.SkillSystemEnum.FE8N_ver2"/>;</item>
+        ///   <item>resolve <c>pointer / g_SkillBaseAddress / g_AnimeBaseAddress / g_ICON_LIST_SIZE</c> via the
+        ///   producer-full scanner <see cref="SkillSystemTextScanner.FindSkillFE8NVer2IconPointersFull"/>
+        ///   (the WF <c>FindSkillFE8NVer2IconPointersLow</c> side-effects); if null/zero/unsafe
+        ///   <c>g_SkillBaseAddress</c> return;</item>
+        ///   <item>main IFR (<c>Init(null)</c>, block <c>g_ICON_LIST_SIZE</c>, rule <c>u8(addr) != 0xFF</c>),
+        ///   name "SkillConfigFE8NVer2", PI = {4,8,12,16} when block == 20 else {4,8,12};</item>
+        ///   <item>if <c>g_AnimeBaseAddress != 0</c>: per main entry, <c>anime = p32(g_AnimeBaseAddress)+4*i</c>;
+        ///   break on unsafe <c>anime</c>; <c>addr = p32(anime)</c>; continue on unsafe <c>addr</c>; else
+        ///   <c>AddAddress(addr, 4, anime, name, POINTER)</c> THEN the recycle walk (name
+        ///   "SkillAnime:0x&lt;i&gt; ");</item>
+        ///   <item>per main entry: N1 (unit) @+4, N2 (class) @+8, N3 (item) @+12 [+ N4 (item2) @+16 when
+        ///   block &gt;= 20] block-1 nested IFRs (rule <c>u8(addr) != 0</c>) + a SkillIcon IMG block of 128
+        ///   bytes (<c>icon = p32(g_SkillBaseAddress) + 128*i</c>).</item>
+        /// </list>
+        /// </summary>
+        public static void EmitSkillConfigFE8NVer2(ROM rom, List<Address> list)
+        {
+            if (SkillSystemTextScanner.SearchSkillSystem(rom)
+                != SkillSystemTextScanner.SkillSystemEnum.FE8N_ver2)
+            {
+                return;
+            }
+
+            if (!SkillSystemTextScanner.FindSkillFE8NVer2IconPointersFull(rom,
+                    out _, out uint skillBase, out uint animeBase, out uint iconListSize))
+            {
+                return;
+            }
+            if (skillBase == 0) return;
+            if (!U.isSafetyOffset(skillBase, rom)) return;
+
+            EmitSkillConfigFE8NVer2At(rom, list, skillBase, animeBase, iconListSize);
+        }
+
+        /// <summary>SkillConfigFE8NVer2 walk from explicit skill-base / anime-base / icon-list-size (test seam
+        /// — lets a synthetic ROM supply the scanner side-effects directly). See
+        /// <see cref="EmitSkillConfigFE8NVer2"/> for the verbatim WF reproduction.</summary>
+        public static void EmitSkillConfigFE8NVer2At(ROM rom, List<Address> list,
+            uint skillBaseAddress, uint animeBaseAddress, uint iconListSize)
+        {
+            uint block = iconListSize;
+            if (block == 0) return; // a zero block would make getBlockDataCount spin; not real data.
+
+            // Main IFR: Init(null) — base = p32(g_SkillBaseAddress), block = g_ICON_LIST_SIZE, rule
+            // u8(addr) != 0xFF. Capture DataCount ONCE (the WF closure: anime loop bound AND N-loop bound).
+            uint slot = U.toOffset(skillBaseAddress);
+            if (!U.isSafetyOffset(slot + 3, rom)) return;
+            uint baseAddr = rom.p32(slot);
+            uint dataCount = rom.getBlockDataCount(baseAddr, block,
+                (i, addr) => rom.u8(addr) != 0xFF);
+
+            // WF: PI = {4,8,12,16} when BlockSize == 20 (sizeof 20) else {4,8,12}.
+            uint[] pi = (block == 20) ? new uint[] { 4, 8, 12, 16 } : new uint[] { 4, 8, 12 };
+            if (U.isSafetyOffset(baseAddr, rom))
+            {
+                uint length = block * (dataCount + 1);
+                uint pointer = U.isSafetyOffset(slot, rom) ? slot : U.NOT_FOUND;
+                list.Add(new Address(baseAddr, length, pointer, "SkillConfigFE8NVer2",
+                    Address.DataTypeEnum.InputFormRef, block, pi));
+            }
+
+            // Per-anime POINTER + recycle walk (gated on g_AnimeBaseAddress != 0).
+            if (animeBaseAddress != 0)
+            {
+                uint animeSlot = U.toOffset(animeBaseAddress);
+                if (U.isSafetyOffset(animeSlot + 3, rom))
+                {
+                    uint anime = rom.p32(animeSlot);
+                    for (uint i = 0; i < dataCount; i++, anime += 4)
+                    {
+                        if (!U.isSafetyOffset(anime + 3, rom))
+                        {//WF: if (!isSafetyOffset(anime)) break;
+                            break;
+                        }
+                        uint addr = rom.p32(anime);
+                        if (!U.isSafetyOffset(addr, rom))
+                        {//WF: if (!isSafetyOffset(addr)) continue;
+                            continue;
+                        }
+                        string name = "SkillAnime:" + U.To0xHexString(i) + " ";
+                        // WF emits the per-anime POINTER Address BEFORE the recycle walk.
+                        Address.AddAddress(list, addr, 4, anime, name, Address.DataTypeEnum.POINTER);
+                        EmitSkillSystemsRecycleOldAnime(rom, list, name, false, addr);
+                    }
+                }
+            }
+
+            // Per-entry N1..N4 nested IFRs + SkillIcon IMG. WF walks addr = ifr.BaseAddress (== baseAddr),
+            // icon = p32(g_SkillBaseAddress) (== baseAddr's source), i < dataCount, addr += block,
+            // icon += 128.
+            bool hasN4 = iconListSize >= 20;
+            uint iconWalk = baseAddr; // WF: icon = p32(g_SkillBaseAddress) == baseAddr.
+            uint entryAddr = baseAddr;
+            for (uint i = 0; i < dataCount; i++, entryAddr += block, iconWalk += SkillIconDataCount)
+            {
+                if (!U.isSafetyOffset(entryAddr, rom))
+                {//WF: if (!isSafetyOffset(addr)) break;
+                    break;
+                }
+                EmitSkillUnitClassItemNested(rom, list, entryAddr, i, hasN4 ? 4 : 3, false);
+
+                // SkillIcon IMG (length 128) at icon. WF AddAddress(icon, 128, NOT_FOUND, name, IMG).
+                Address.AddAddress(list, iconWalk, SkillIconDataCount, U.NOT_FOUND,
+                    "SkillIcon:" + U.To0xHexString(i), Address.DataTypeEnum.IMG);
+            }
+        }
+
+        /// <summary>
+        /// <c>SkillConfigFE8NVer3SkillForm.MakeAllDataLength</c> (slice 2ac; FE8J ONLY — gated at the WF
+        /// <c>is_multibyte == true</c> / <c>else</c> call site, AFTER SkillConfigFE8NVer2). The Ver3
+        /// skill-config table + a per-anime POINTER + the verbatim recycle walk + per-entry N1..N5 nested
+        /// lists + a SkillIcon IMG block. Reproduced VERBATIM
+        /// (<c>FEBuilderGBA/SkillConfigFE8NVer3SkillForm.cs:1029</c>). DIFFERENCES vs Ver2:
+        /// <list type="bullet">
+        ///   <item>gate <see cref="SkillSystemTextScanner.SkillSystemEnum.FE8N_ver3"/>; scanner
+        ///   <see cref="SkillSystemTextScanner.FindSkillFE8NVer3IconPointersFull"/> (fixed
+        ///   <c>g_SkillBaseAddress = 0x892A8 + 4</c>);</item>
+        ///   <item>main IFR PI is ALWAYS {4,8,12,16,20}, name "SkillConfigFE8NVer3";</item>
+        ///   <item>the per-anime entry reads <c>anime_pointer_addr = u32(anime)</c>, continues on
+        ///   <c>!isSafetyPointer</c>, then <c>addr = toOffset(anime_pointer_addr)</c> (Ver2 reads
+        ///   <c>p32(anime)</c> directly + an <c>isSafetyOffset</c> guard) — reproduced exactly;</item>
+        ///   <item>five nested IFRs N1..N5 (unit/class/item/item2/complex) @ +4/+8/+12/+16/+20.</item>
+        /// </list>
+        /// </summary>
+        public static void EmitSkillConfigFE8NVer3(ROM rom, List<Address> list)
+        {
+            if (SkillSystemTextScanner.SearchSkillSystem(rom)
+                != SkillSystemTextScanner.SkillSystemEnum.FE8N_ver3)
+            {
+                return;
+            }
+
+            if (!SkillSystemTextScanner.FindSkillFE8NVer3IconPointersFull(rom,
+                    out uint skillBase, out uint animeBase, out uint iconListSize))
+            {
+                return;
+            }
+            if (skillBase == 0) return;
+            if (!U.isSafetyOffset(skillBase, rom)) return;
+
+            EmitSkillConfigFE8NVer3At(rom, list, skillBase, animeBase, iconListSize);
+        }
+
+        /// <summary>SkillConfigFE8NVer3 walk from explicit skill-base / anime-base / icon-list-size (test
+        /// seam). See <see cref="EmitSkillConfigFE8NVer3"/> for the verbatim WF reproduction.</summary>
+        public static void EmitSkillConfigFE8NVer3At(ROM rom, List<Address> list,
+            uint skillBaseAddress, uint animeBaseAddress, uint iconListSize)
+        {
+            uint block = iconListSize;
+            if (block == 0) return;
+
+            uint slot = U.toOffset(skillBaseAddress);
+            if (!U.isSafetyOffset(slot + 3, rom)) return;
+            uint baseAddr = rom.p32(slot);
+            uint dataCount = rom.getBlockDataCount(baseAddr, block,
+                (i, addr) => rom.u8(addr) != 0xFF);
+
+            // WF: PI is ALWAYS {4,8,12,16,20}.
+            if (U.isSafetyOffset(baseAddr, rom))
+            {
+                uint length = block * (dataCount + 1);
+                uint pointer = U.isSafetyOffset(slot, rom) ? slot : U.NOT_FOUND;
+                list.Add(new Address(baseAddr, length, pointer, "SkillConfigFE8NVer3",
+                    Address.DataTypeEnum.InputFormRef, block, new uint[] { 4, 8, 12, 16, 20 }));
+            }
+
+            if (animeBaseAddress != 0)
+            {
+                uint animeSlot = U.toOffset(animeBaseAddress);
+                if (U.isSafetyOffset(animeSlot + 3, rom))
+                {
+                    uint anime = rom.p32(animeSlot);
+                    for (uint i = 0; i < dataCount; i++, anime += 4)
+                    {
+                        if (!U.isSafetyOffset(anime + 3, rom))
+                        {//WF: if (!isSafetyOffset(anime)) break;
+                            break;
+                        }
+                        // WF Ver3: anime_pointer_addr = u32(anime); continue on !isSafetyPointer; then
+                        // addr = toOffset(anime_pointer_addr).
+                        uint anime_pointer_addr = rom.u32(anime);
+                        if (!U.isSafetyPointer(anime_pointer_addr, rom))
+                        {
+                            continue;
+                        }
+                        uint addr = U.toOffset(anime_pointer_addr);
+                        string name = "SkillAnime:" + U.To0xHexString(i) + " ";
+                        Address.AddAddress(list, addr, 4, anime, name, Address.DataTypeEnum.POINTER);
+                        EmitSkillSystemsRecycleOldAnime(rom, list, name, false, addr);
+                    }
+                }
+            }
+
+            uint iconWalk = baseAddr;
+            uint entryAddr = baseAddr;
+            for (uint i = 0; i < dataCount; i++, entryAddr += block, iconWalk += SkillIconDataCount)
+            {
+                if (!U.isSafetyOffset(entryAddr, rom))
+                {
+                    break;
+                }
+                // N1..N5 (unit/class/item/item2/complex) @ +4/+8/+12/+16/+20.
+                EmitSkillUnitClassItemNested(rom, list, entryAddr, i, 5, true);
+
+                Address.AddAddress(list, iconWalk, SkillIconDataCount, U.NOT_FOUND,
+                    "SkillIcon:" + U.To0xHexString(i), Address.DataTypeEnum.IMG);
+            }
+        }
+
+        /// <summary>Shared per-entry nested unit/class/item(/item2/complex) list emitter for the Ver2/Ver3
+        /// skill-config forms. Reproduces the WF <c>N{1..5}_Init</c> block-1 IFRs (each
+        /// <c>ReInitPointer(addr + 4*k)</c>, rule <c>u8(addr) != 0</c>) emitted via
+        /// <see cref="EmitNestedIfrSub"/>. <paramref name="count"/> selects how many slots to emit (Ver2: 3
+        /// or 4; Ver3: 5). Names: "SkillUnit", "SkillClass", "SkillItem", then "SkillItem2" + "SkillComplex"
+        /// (when <paramref name="ver3Naming"/>) or "SkillItem2" (Ver2 N4). The embedded pointers are at
+        /// <c>entryAddr + 4</c>, <c>+8</c>, <c>+12</c>, <c>+16</c>, <c>+20</c>.</summary>
+        static void EmitSkillUnitClassItemNested(ROM rom, List<Address> list, uint entryAddr,
+            uint index, int count, bool ver3Naming)
+        {
+            // Names for slots 1..5 (the WF N1..N5 AddAddress info prefixes).
+            string[] names = ver3Naming
+                ? new[] { "SkillUnit:", "SkillClass:", "SkillItem:", "SkillItem2:", "SkillComplex:" }
+                : new[] { "SkillUnit:", "SkillClass:", "SkillItem:", "SkillItem2:" };
+
+            Func<int, uint, bool> rule = (j, addr) => rom.u8(addr) != 0;
+            for (int k = 0; k < count && k < names.Length; k++)
+            {
+                uint pfield = entryAddr + (uint)(4 * (k + 1)); // +4, +8, +12, +16, +20
+                EmitNestedIfrSub(rom, list, pfield, 1, rule, names[k] + U.To0xHexString(index));
             }
         }
 
@@ -10875,17 +11461,20 @@ namespace FEBuilderGBA
                 //    (Ver1)/yugudora/FE8N_ver2 icon tables (Ver3 contributes nothing), pointers from
                 //    SkillSystemTextScanner.FindSkillFE8NVer1/Ver2IconPointers, each a per-pointer block-32
                 //    IFR with the WF DataCount<=0 skip.
-                //  The RecycleOldAnime-DEPENDENT siblings STAY: each calls
-                //  ImageUtilSkillSystemsAnimeCreator.RecycleOldAnime (an anime length walker not yet in
-                //  Core — same blocker class as the Group-3 ImageUtilOAM forms):
-                //    SkillConfigSkillSystemForm [FE8U] — Init(null, basetextP) IFR + a per-anime loop that
-                //      calls RecycleOldAnime on each p32(g_AnimeBaseAddress + 4*i).
-                //    SkillConfigFE8NVer2SkillForm / SkillConfigFE8NVer3SkillForm [FE8J] — RecycleOldAnime
-                //      AND GUI session state (g_SkillBaseAddress / g_AnimeBaseAddress / g_ICON_LIST_SIZE set
-                //      by the Find* scans) + N1..N5 icon sub-tables. Deferred until RecycleOldAnime is in
-                //      Core.)
-                "SkillConfigSkillSystemForm",
-                "SkillConfigFE8NVer2SkillForm", "SkillConfigFE8NVer3SkillForm",
+                //  slice 2ac then ported the three RecycleOldAnime-DEPENDENT siblings by REPRODUCING the WF
+                //  ImageUtilSkillSystemsAnimeCreator.RecycleOldAnime VERBATIM as a producer-local method
+                //  (EmitSkillSystemsRecycleOldAnime — the import-adapted SkillSystemsAnimeImportCore.
+                //  EnumerateOldAnimeRegions emits byte-identical addr/length/pointer/type tuples but diverges
+                //  on NAMES + adds a ReferenceEquals(rom,CoreState.ROM) import guard, so reuse was rejected):
+                //    SkillConfigSkillSystemForm [FE8U] — EmitSkillConfigSkillSystem: Init(null,basetextP)
+                //      block-2 IFR + a "SkillAnime" pointer-list IFR + per-anime RecycleOldAnime.
+                //    SkillConfigFE8NVer2SkillForm / SkillConfigFE8NVer3SkillForm [FE8J] —
+                //      EmitSkillConfigFE8NVer2/Ver3: the GUI session state (g_SkillBaseAddress /
+                //      g_AnimeBaseAddress / g_ICON_LIST_SIZE) is resolved via the new
+                //      SkillSystemTextScanner.FindSkillFE8NVer2/Ver3IconPointersFull (the WF
+                //      FindSkill...IconPointersLow side-effects), plus per-anime POINTER + RecycleOldAnime +
+                //      per-entry N1..N5 unit/class/item nested IFRs + a SkillIcon IMG block. (All three
+                //      removed from this list.)
                 // status / menu definition / misc tables needing extra logic
                 // (StatusUnitsMenuForm + LinkArenaDenyUnitForm ported in slice 2b.
                 //  StatusOptionOrderForm [v7+v8, count-address fixed table] ported in this sweep.

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -6667,10 +6667,14 @@ namespace FEBuilderGBA
                 }
             }
 
-            // Per-entry N1..N4 nested IFRs + SkillIcon IMG. WF walks addr = ifr.BaseAddress (== baseAddr),
-            // icon = p32(g_SkillBaseAddress) (== baseAddr's source), i < dataCount, addr += block,
-            // icon += 128.
+            // Per-entry N1..N3 nested IFRs, THEN SkillIcon IMG, THEN (optionally) N4 — the EXACT WF
+            // SkillConfigFE8NVer2SkillForm.MakeAllDataLength :1100-1128 emission ORDER. WF walks
+            // addr = ifr.BaseAddress (== baseAddr), icon = p32(g_SkillBaseAddress) (== baseAddr), i <
+            // dataCount, addr += block, icon += 128. NOTE: unlike Ver3 (N1..N5 then icon), Ver2 emits the
+            // ICON between N3 and the OPTIONAL N4 (ifr_n4 != null), so the slots are emitted inline here
+            // rather than via the shared EmitSkillUnitClassItemNested (which would place N4 before the icon).
             bool hasN4 = iconListSize >= 20;
+            Func<int, uint, bool> nRule = (j, addr) => rom.u8(addr) != 0;
             uint iconWalk = baseAddr; // WF: icon = p32(g_SkillBaseAddress) == baseAddr.
             uint entryAddr = baseAddr;
             for (uint i = 0; i < dataCount; i++, entryAddr += block, iconWalk += SkillIconDataCount)
@@ -6679,11 +6683,21 @@ namespace FEBuilderGBA
                 {//WF: if (!isSafetyOffset(addr)) break;
                     break;
                 }
-                EmitSkillUnitClassItemNested(rom, list, entryAddr, i, hasN4 ? 4 : 3, false);
+                // N1 (unit) @+4, N2 (class) @+8, N3 (item) @+12 — block-1 nested IFRs (rule u8!=0).
+                EmitNestedIfrSub(rom, list, entryAddr + 4, 1, nRule, "SkillUnit:" + U.To0xHexString(i));
+                EmitNestedIfrSub(rom, list, entryAddr + 8, 1, nRule, "SkillClass:" + U.To0xHexString(i));
+                EmitNestedIfrSub(rom, list, entryAddr + 12, 1, nRule, "SkillItem:" + U.To0xHexString(i));
 
-                // SkillIcon IMG (length 128) at icon. WF AddAddress(icon, 128, NOT_FOUND, name, IMG).
+                // SkillIcon IMG (length 128) at icon — BEFORE N4 (WF order). AddAddress(icon, 128, NOT_FOUND,
+                // name, IMG).
                 Address.AddAddress(list, iconWalk, SkillIconDataCount, U.NOT_FOUND,
                     "SkillIcon:" + U.To0xHexString(i), Address.DataTypeEnum.IMG);
+
+                // N4 (item2) @+16 — only when ifr_n4 != null (g_ICON_LIST_SIZE >= 20), emitted AFTER the icon.
+                if (hasN4)
+                {
+                    EmitNestedIfrSub(rom, list, entryAddr + 16, 1, nRule, "SkillItem2:" + U.To0xHexString(i));
+                }
             }
         }
 
@@ -6781,31 +6795,26 @@ namespace FEBuilderGBA
                 {
                     break;
                 }
-                // N1..N5 (unit/class/item/item2/complex) @ +4/+8/+12/+16/+20.
-                EmitSkillUnitClassItemNested(rom, list, entryAddr, i, 5, true);
+                // N1..N5 (unit/class/item/item2/complex) @ +4/+8/+12/+16/+20, THEN the SkillIcon — the EXACT
+                // WF SkillConfigFE8NVer3SkillForm.MakeAllDataLength :1097-1123 ORDER (Ver3 emits ALL five
+                // nested IFRs BEFORE the icon, unlike Ver2 which interleaves the icon between N3 and N4).
+                EmitSkillVer3UnitClassItemNested(rom, list, entryAddr, i);
 
                 Address.AddAddress(list, iconWalk, SkillIconDataCount, U.NOT_FOUND,
                     "SkillIcon:" + U.To0xHexString(i), Address.DataTypeEnum.IMG);
             }
         }
 
-        /// <summary>Shared per-entry nested unit/class/item(/item2/complex) list emitter for the Ver2/Ver3
-        /// skill-config forms. Reproduces the WF <c>N{1..5}_Init</c> block-1 IFRs (each
-        /// <c>ReInitPointer(addr + 4*k)</c>, rule <c>u8(addr) != 0</c>) emitted via
-        /// <see cref="EmitNestedIfrSub"/>. <paramref name="count"/> selects how many slots to emit (Ver2: 3
-        /// or 4; Ver3: 5). Names: "SkillUnit", "SkillClass", "SkillItem", then "SkillItem2" + "SkillComplex"
-        /// (when <paramref name="ver3Naming"/>) or "SkillItem2" (Ver2 N4). The embedded pointers are at
-        /// <c>entryAddr + 4</c>, <c>+8</c>, <c>+12</c>, <c>+16</c>, <c>+20</c>.</summary>
-        static void EmitSkillUnitClassItemNested(ROM rom, List<Address> list, uint entryAddr,
-            uint index, int count, bool ver3Naming)
+        /// <summary>Ver3 per-entry nested unit/class/item/item2/complex list emitter. Reproduces the WF
+        /// <c>N{1..5}_Init</c> block-1 IFRs (each <c>ReInitPointer(addr + 4*k)</c>, rule <c>u8(addr) != 0</c>)
+        /// emitted via <see cref="EmitNestedIfrSub"/> in order N1..N5 at <c>entryAddr + 4/8/12/16/20</c>.
+        /// (Ver2 does NOT use this — its icon is interleaved between N3 and the optional N4, so its slots are
+        /// emitted inline in <see cref="EmitSkillConfigFE8NVer2At"/>.)</summary>
+        static void EmitSkillVer3UnitClassItemNested(ROM rom, List<Address> list, uint entryAddr, uint index)
         {
-            // Names for slots 1..5 (the WF N1..N5 AddAddress info prefixes).
-            string[] names = ver3Naming
-                ? new[] { "SkillUnit:", "SkillClass:", "SkillItem:", "SkillItem2:", "SkillComplex:" }
-                : new[] { "SkillUnit:", "SkillClass:", "SkillItem:", "SkillItem2:" };
-
+            string[] names = { "SkillUnit:", "SkillClass:", "SkillItem:", "SkillItem2:", "SkillComplex:" };
             Func<int, uint, bool> rule = (j, addr) => rom.u8(addr) != 0;
-            for (int k = 0; k < count && k < names.Length; k++)
+            for (int k = 0; k < names.Length; k++)
             {
                 uint pfield = entryAddr + (uint)(4 * (k + 1)); // +4, +8, +12, +16, +20
                 EmitNestedIfrSub(rom, list, pfield, 1, rule, names[k] + U.To0xHexString(index));

--- a/FEBuilderGBA.Core/SkillSystemTextScanner.cs
+++ b/FEBuilderGBA.Core/SkillSystemTextScanner.cs
@@ -300,6 +300,145 @@ namespace FEBuilderGBA
             return pointer.ToArray();
         }
 
+        /// <summary>
+        /// The FULL side-effect resolution of WF <c>SkillConfigFE8NVer2SkillForm.
+        /// FindSkillFE8NVer2IconPointersLow</c> — the existing
+        /// <see cref="FindSkillFE8NVer2IconPointers(ROM, out uint)"/> only returns the pointer slots +
+        /// <c>g_SkillBaseAddress</c> (slot[4]); the ROM-rebuild producer ALSO needs the
+        /// <c>g_AnimeBaseAddress</c> and <c>g_ICON_LIST_SIZE</c> the WF form computes as side effects (the
+        /// main IFR BlockSize, the {4,8,12} vs {4,8,12,16} pointerIndexes, and the anime pointer-list base).
+        /// Reproduced VERBATIM (incl. the <c>u16(0x70B96) == 0</c> gate, the 2019-Nov variable-length-struct
+        /// branch [slot 8 = anime, iconListSize from slot 11], and the 2018-original branch [slot 3 nazo
+        /// pointer appended, then slot 5 = anime]). EOF-HARDENED (each read guarded). Returns false (all outs
+        /// zero) when the pointer chain is absent or too short — exactly the WF <c>return null</c>.
+        /// </summary>
+        public static bool FindSkillFE8NVer2IconPointersFull(ROM rom,
+            out uint[] pointers, out uint skillBaseAddress, out uint animeBaseAddress, out uint iconListSize)
+        {
+            pointers = null;
+            skillBaseAddress = 0;
+            animeBaseAddress = 0;
+            iconListSize = 16; // WF g_ICON_LIST_SIZE default.
+
+            if (rom?.Data == null) return false;
+            if (!U.isSafetyOffset(0x89268 + 4 + 3, rom)) return false;
+            uint iconExPointer = rom.u32(0x89268 + 4);
+            if (!U.isSafetyPointer(iconExPointer, rom)) return false;
+
+            byte[] need = new byte[] { 0x50, 0x93, 0x08, 0x08, 0x48, 0x93, 0x08, 0x08 };
+            uint iconPointers = U.Grep(rom.Data, need, 0xE00000, 0, 4);
+            if (iconPointers == U.NOT_FOUND) return false;
+            if (iconPointers < (uint)(4 * 5)) return false;
+            iconPointers = iconPointers - (4 * 5);
+
+            var pointer = new List<uint>();
+            for (uint p = iconPointers; ; p += 4)
+            {
+                if (!U.isSafetyOffset(p + 3, rom)) break;
+                uint pp = rom.u32(p);
+                if (!U.isSafetyPointer(pp, rom)) break;
+                pp = U.toOffset(pp);
+                if (pp < 0xE00000) continue; // distinguish from API pointers
+                pointer.Add(p);
+            }
+            if (pointer.Count <= 4) return false;
+            skillBaseAddress = pointer[4];
+
+            // WF: if (Program.ROM.u16(0x70B96) == 0x00) { ... resolve ICON_LIST_SIZE + anime ... }
+            if (U.isSafetyOffset(0x70B96 + 1, rom) && rom.u16(0x70B96) == 0x00)
+            {
+                // ICON_LIST_SIZE candidate at slot 11.
+                uint p11 = iconPointers + (4 * 11);
+                if (U.isSafetyOffset(p11 + 3, rom))
+                {
+                    uint candidate = rom.u32(p11);
+                    if (candidate >= 16 && candidate <= 40 && (candidate % 4 == 0))
+                    {//2019 11月後半 開発版 — 構造体が可変長になった
+                        iconListSize = candidate;
+                        // slot 8 is the anime pointer.
+                        uint p8 = iconPointers + (4 * 8);
+                        if (U.isSafetyOffset(p8 + 3, rom))
+                        {
+                            uint anime_pointer = rom.u32(p8);
+                            if (U.isSafetyPointer(anime_pointer, rom))
+                            {
+                                animeBaseAddress = rom.p32(U.toOffset(p8));
+                            }
+                        }
+                    }
+                    else
+                    {//2018年版を元にしたFEBuilderGBAオリジナル拡張版 anime pointer
+                        uint p3 = iconPointers + (4 * 3);
+                        if (U.isSafetyOffset(p3 + 3, rom))
+                        {
+                            uint nazo_pointer = rom.u32(p3);
+                            if (U.isSafetyPointer(nazo_pointer, rom))
+                            {//バージョンによって、ポインタ数が違うので、参考値程度に・・・
+                                pointer.Add(U.toOffset(nazo_pointer));
+                            }
+                        }
+                        if (pointer.Count > 5)
+                        {//この場合、5番目のポインタがアニメになります。
+                            uint slot5 = pointer[5];
+                            if (U.isSafetyOffset(slot5 + 3, rom))
+                            {
+                                animeBaseAddress = rom.p32(slot5);
+                            }
+                        }
+                    }
+                }
+            }
+            pointers = pointer.ToArray();
+            return true;
+        }
+
+        /// <summary>
+        /// The FULL side-effect resolution of WF <c>SkillConfigFE8NVer3SkillForm.
+        /// FindSkillFE8NVer3IconPointersLow</c> — the existing <see cref="IsFE8NVer3"/> is detection-only.
+        /// The ROM-rebuild producer needs <c>g_SkillBaseAddress</c> (the fixed slot <c>0x892A8 + 4</c>),
+        /// <c>g_ICON_LIST_SIZE</c> (<c>u32(0x892A8 + 8)</c>), and <c>g_AnimeBaseAddress</c>
+        /// (<c>toOffset(u32(0x892A8 + 20))</c>). Reproduced VERBATIM (incl. the iconExPointer + skl-table
+        /// safety gates and the <c>iconListSize &lt;= 0 || &gt; 100</c> reject). EOF-HARDENED. Returns false
+        /// (all outs zero) on any failed gate — exactly the WF <c>return null</c>.
+        /// </summary>
+        public static bool FindSkillFE8NVer3IconPointersFull(ROM rom,
+            out uint skillBaseAddress, out uint animeBaseAddress, out uint iconListSize)
+        {
+            skillBaseAddress = 0;
+            animeBaseAddress = 0;
+            iconListSize = 0;
+
+            if (rom?.Data == null) return false;
+            if (!U.isSafetyOffset(0x89268 + 4 + 3, rom)) return false;
+            uint iconExPointer = rom.u32(0x89268 + 4);
+            if (!U.isSafetyPointer(iconExPointer, rom)) return false;
+
+            if (!U.isSafetyOffset(0x892A8 + 4 + 3, rom)) return false;
+            uint skl_table = rom.u32(0x892A8 + 4);
+            if (!U.isSafetyPointer(skl_table, rom)) return false;
+            skillBaseAddress = 0x892A8 + 4;
+
+            if (!U.isSafetyOffset(0x892A8 + 8 + 3, rom)) return false;
+            iconListSize = rom.u32(0x892A8 + 8);
+            if (iconListSize <= 0 || iconListSize > 100)
+            {
+                iconListSize = 0;
+                skillBaseAddress = 0;
+                return false;
+            }
+
+            // skl_anime_table at 0x892A8 + 20 (== 0x892BC).
+            if (U.isSafetyOffset(0x892A8 + 20 + 3, rom))
+            {
+                uint skl_anime_table = rom.u32(0x892A8 + 20);
+                if (U.isSafetyPointer(skl_anime_table, rom))
+                {
+                    animeBaseAddress = U.toOffset(skl_anime_table);
+                }
+            }
+            return true;
+        }
+
         // ---- WF SkillConfigFE8NVer3SkillForm.FindSkillFE8NVer3IconPointersLow ----
         // Detection-only (Ver3 contributes no skill text to the export filter).
         static bool IsFE8NVer3(ROM rom)


### PR DESCRIPTION
## Summary

Part of #1261 (ROM-rebuild producer marathon). Ports the THREE remaining
RecycleOldAnime-dependent SkillConfig SkillSystems forms' `MakeAllDataLength` into the
data-path producer (`RebuildProducerCore`), removing all three from `NotYetPortedRaw`.
Slice 2o ported the RecycleOldAnime-FREE subset; this completes the SkillSystems family.

Closes #1306.

### Forms ported (WF file:line of `MakeAllDataLength`)
| # | Form | Version | WF source |
|---|------|---------|-----------|
| 1 | `SkillConfigSkillSystemForm` | FE8U | `FEBuilderGBA/SkillConfigSkillSystemForm.cs:602` |
| 2 | `SkillConfigFE8NVer2SkillForm` | FE8J | `FEBuilderGBA/SkillConfigFE8NVer2SkillForm.cs:1023` |
| 3 | `SkillConfigFE8NVer3SkillForm` | FE8J | `FEBuilderGBA/SkillConfigFE8NVer3SkillForm.cs:1029` |

Wired at the EXACT WF call order (`U.MakeAllStructPointersList`, `U.cs:2438-2449`):
- `is_multibyte == false` (FE8U): … `EmitSkillAssignmentUnit` → **`EmitSkillConfigSkillSystem`**
- `else` (FE8J): … `EmitSkillConfigFE8N` → **`EmitSkillConfigFE8NVer2`** → **`EmitSkillConfigFE8NVer3`**

Each emitter self-gates on `SearchSkillSystem` exactly like the WF form, so a non-matching ROM emits nothing.

## The verbatim-vs-reuse decision (RecycleOldAnime) — REPRODUCED VERBATIM (all 3 forms)

The import-adapted Core helper `SkillSystemsAnimeImportCore.EnumerateOldAnimeRegions`
emits **byte-identical** `(addr,length,pointer,DataTypeEnum)` tuples vs WF
`ImageUtilSkillSystemsAnimeCreator.RecycleOldAnime` (`ImageUtilSkillSystemsAnimeCreator.cs:637`),
**but diverges on NAMES** — it hardcodes basename `"OLDANIME"` (WF uses the per-skill
`"SkillAnime:0x.. "` name) and renames the palette list `"PALETTELIST"` (WF has the typo
`"PALETEELIST"`) — and adds an import-only `ReferenceEquals(rom,CoreState.ROM)` guard +
an `excludeRegionAddrs` skip mechanism + a hardcoded `isPointerOnly=false`. Reusing it
would change the `Address.Info` strings the `FEBuilderGBA.Tests` WF-parity suite checks.

So this slice **reproduces `RecycleOldAnime` VERBATIM** as a producer-local method
(`EmitSkillSystemsRecycleOldAnime`) taking the per-skill `basename` + threading
`isPointerOnly` — exactly the slice-2s posture (`EmitImageBattleAnimeOAM`). It reuses the
**proven Core primitive** `SkillSystemsAnimeExportCore.SkipCode` (a faithful WF `SkipCode`
port: FE8J returns the address directly; FE8U skips the `config/patch2/FE8U/skill/*.dmp`
program template). For Forms 2/3 the WF `FindSkillFE8NVer2/Ver3IconPointersLow`
side-effects (`g_AnimeBaseAddress` / `g_ICON_LIST_SIZE` — NOT exposed by the existing
Core scanner) are reproduced verbatim as new `SkillSystemTextScanner.
FindSkillFE8NVer2/Ver3IconPointersFull` methods.

The stale "deferred — RecycleOldAnime not in Core" comments (slice-2o block, `NotYetPortedRaw`, the `MakeAllStructPointers` doc block) were updated.

## Discipline
Every computed read's full extent is EOF-guarded (`slot+3` before `p32`; the
`AddAddressInstantIFR` slot guarded `+3` before the call; per-entry loop bounds = the
MAIN DataCount, `break` on `addr+3`). All reads thread the explicit `rom` via `(x, rom)`
overloads. `is_multibyte` gated exactly at the WF call site. No `InputFormRef.DoEvents` —
`CancellationToken` checks instead.

## Test plan
- [x] `EmitSkillSystemsRecycleOldAnime` (FE8J): per-frame OBJ/TSA/PAL + the trailing config + 4 list blocks (right addr/length/pointer/type; WF `PALETEELIST` typo preserved)
- [x] recycle-pool dedup: a frame id referenced by 2 frames emits per-frame but references only the distinct underlying slots
- [x] `isPointerOnly` forwarding (true → OBJ/TSA length 0; false → length > 0)
- [x] FE8U-no-template → SkipCode NOT_FOUND → nothing emitted (faithful headless)
- [x] near-EOF anime/skill slots → no throw, nothing emitted
- [x] Form 1 `EmitSkillConfigSkillSystemAt`: main block-2 IFR (count rule `i<255`), `SkillAnime` pointer-list IFR (`AddAddressInstantIFR`, PI {0}), per-anime recycle walk (FE8J)
- [x] Form 2 `EmitSkillConfigFE8NVer2At`: main IFR + per-anime POINTER + recycle + N1..N3 nested + SkillIcon IMG; block-20 → PI {4,8,12,16} + N4; block-24 → PI {4,8,12} but N4 still emitted (the WF `BlockSize==20` vs `ICON_LIST_SIZE>=20` asymmetry); animeBase 0 → no anime walk
- [x] Form 3 `EmitSkillConfigFE8NVer3At`: main IFR PI {4,8,12,16,20} + u32-anime path + N1..N5 nested + SkillIcon IMG
- [x] version/multibyte gate: non-matching ROM emits nothing
- [x] `GetNotYetPortedForms` drops all 3 forms; no-duplicates invariant holds
- [x] `dotnet test --filter RebuildProducer` → **425 passed (408 baseline + 17 new), 0 failed**
- [x] `dotnet build FEBuilderGBA.sln` → Build succeeded, 0 errors (WF-parity test compiles)

### Test output
```
Passed!  - Failed:     0, Passed:   425, Skipped:     0, Total:   425 - FEBuilderGBA.Core.Tests.dll (RebuildProducer filter)
Build succeeded.  0 Error(s)  (FEBuilderGBA.sln)
```

> The ~10 `SkillSystemsAnime*`/`Skill*` **FE8U-template** Core.Tests failures are the KNOWN
> `config/patch2`-submodule env condition (identical on `origin/master`; pass in CI). They are a
> DIFFERENT suite from the new RebuildProducer SkillConfig tests, which use the FE8J path (no template needed).

Core-only, no GUI → no screenshot (test output is the proof).

Part of #1261

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
