### PR TITLE
feat(core): ROM-rebuild producer — ItemForm + UnitActionPointer (+PatchDetection detectors) (#1261 slice 2ad)

### DIFF
--- a/FEBuilderGBA.Core.Tests/PatchDetectionTests.cs
+++ b/FEBuilderGBA.Core.Tests/PatchDetectionTests.cs
@@ -318,5 +318,260 @@ namespace FEBuilderGBA.Core.Tests
             var rom = MakeAntiHuffmanRom("BE8E01", 0x500000, new byte[] { 0x00, 0xB5, 0xC2, 0x0F });
             Assert.False(PatchDetection.SearchAntiHuffmanPatch(rom));
         }
+
+        // ===============================================================
+        // #1261 slice 2ad — four producer patch detectors.
+        //
+        // - SearchUnitActionReworkPatch: DELEGATE wrap. Each RomInfo subclass
+        //   exposes patch_unitaction_rework_hack(out enable_value) = (addr,
+        //   expected u32). The patch is present when u32(addr)==expected.
+        // - ItemUsingExtendsPatch: FE8U byte table @ 0x28E80.
+        // - SearchClassType: FE8U-only CompareByte(0x2AAEC) vs two patterns.
+        // - SearchGrowsMod: FE8U Vennou byte table @ 0x02BA2A, then FE8U
+        //   whole-ROM grep of the SkillSystems signature.
+        // ===============================================================
+
+        static ROM MakeRom(string signature, byte[] data) // helper for the slice-2ad detectors
+        {
+            var rom = new ROM();
+            bool ok = rom.LoadLow("synthetic-2ad.gba", data, signature);
+            Assert.True(ok, "LoadLow did not recognize version string: " + signature);
+            return rom;
+        }
+
+        // ---- SearchUnitActionReworkPatch (delegate wrap) ----
+
+        [Fact]
+        public void SearchUnitActionReworkPatch_NullRom_ReturnsFalse()
+        {
+            Assert.False(PatchDetection.SearchUnitActionReworkPatch((ROM?)null));
+        }
+
+        [Fact]
+        public void SearchUnitActionReworkPatch_FE8U_PatchAbsent_ReturnsFalse()
+        {
+            // A zeroed FE8U ROM: u32(patch addr) == 0 != enable_value -> false.
+            var rom = MakeRom("BE8E01", new byte[0x1000000]);
+            Assert.False(PatchDetection.SearchUnitActionReworkPatch(rom));
+        }
+
+        [Fact]
+        public void SearchUnitActionReworkPatch_FE8U_PatchPresent_ReturnsTrue()
+        {
+            // Plant the per-version expected u32 at the per-version address from the
+            // RomInfo delegate itself (so this stays faithful even if ROMFE8U's
+            // (addr, value) ever changes). FE8U: addr=0x031F08, value=0x4C03B510.
+            var rom = MakeRom("BE8E01", new byte[0x1000000]);
+            uint expected;
+            uint addr = rom.RomInfo.patch_unitaction_rework_hack(out expected);
+            Assert.NotEqual(0u, addr);
+            // little-endian write of `expected` at `addr`.
+            rom.Data[addr + 0] = (byte)(expected & 0xFF);
+            rom.Data[addr + 1] = (byte)((expected >> 8) & 0xFF);
+            rom.Data[addr + 2] = (byte)((expected >> 16) & 0xFF);
+            rom.Data[addr + 3] = (byte)((expected >> 24) & 0xFF);
+            Assert.True(PatchDetection.SearchUnitActionReworkPatch(rom));
+        }
+
+        [Fact]
+        public void SearchUnitActionReworkPatch_FE8J_PatchPresent_ReturnsTrue()
+        {
+            // FE8J has its own (addr, value) — prove the delegate-wrap is version-correct.
+            var rom = MakeRom("BE8J01", new byte[0x1100000]);
+            uint expected;
+            uint addr = rom.RomInfo.patch_unitaction_rework_hack(out expected);
+            Assert.NotEqual(0u, addr);
+            rom.Data[addr + 0] = (byte)(expected & 0xFF);
+            rom.Data[addr + 1] = (byte)((expected >> 8) & 0xFF);
+            rom.Data[addr + 2] = (byte)((expected >> 16) & 0xFF);
+            rom.Data[addr + 3] = (byte)((expected >> 24) & 0xFF);
+            Assert.True(PatchDetection.SearchUnitActionReworkPatch(rom));
+        }
+
+        // ---- ItemUsingExtendsPatch (FE8U byte table @ 0x28E80) ----
+
+        static readonly byte[] IERSig = new byte[]
+        {
+            0x03, 0x4B, 0x14, 0x22, 0x50, 0x43, 0x40, 0x18,
+            0xC0, 0x18, 0x00, 0x68, 0x70, 0x47, 0x00, 0x00
+        };
+
+        [Fact]
+        public void ItemUsingExtendsPatch_NullRom_ReturnsNO()
+        {
+            Assert.Equal(PatchDetection.ItemUsingExtends_extends.NO,
+                PatchDetection.ItemUsingExtendsPatch((ROM?)null));
+        }
+
+        [Fact]
+        public void ItemUsingExtendsPatch_FE8U_PatchAbsent_ReturnsNO()
+        {
+            var rom = MakeRom("BE8E01", new byte[0x1000000]);
+            Assert.Equal(PatchDetection.ItemUsingExtends_extends.NO,
+                PatchDetection.ItemUsingExtendsPatch(rom));
+        }
+
+        [Fact]
+        public void ItemUsingExtendsPatch_FE8U_PatchPresent_ReturnsIER()
+        {
+            var data = new byte[0x1000000];
+            Array.Copy(IERSig, 0, data, 0x28E80, IERSig.Length);
+            var rom = MakeRom("BE8E01", data);
+            Assert.Equal(PatchDetection.ItemUsingExtends_extends.IER,
+                PatchDetection.ItemUsingExtendsPatch(rom));
+        }
+
+        [Fact]
+        public void ItemUsingExtendsPatch_FE8J_SigAtFE8UOffset_StillNO()
+        {
+            // The table only has an FE8U row — the version filter rejects FE8J even
+            // with the bytes planted at the FE8U offset.
+            var data = new byte[0x1100000];
+            Array.Copy(IERSig, 0, data, 0x28E80, IERSig.Length);
+            var rom = MakeRom("BE8J01", data);
+            Assert.Equal(PatchDetection.ItemUsingExtends_extends.NO,
+                PatchDetection.ItemUsingExtendsPatch(rom));
+        }
+
+        // ---- SearchClassType (FE8U-only CompareByte @ 0x2AAEC) ----
+
+        static readonly byte[] ClassTypePat1 = new byte[] { 0x00, 0x25, 0x00, 0x28, 0x00, 0xD0, 0x05, 0x1C };
+        static readonly byte[] ClassTypePat2 = new byte[] { 0x01, 0x4B, 0xA6, 0xF0, 0xED, 0xFE, 0x01, 0xE0 };
+
+        [Fact]
+        public void SearchClassType_NullRom_ReturnsNO()
+        {
+            Assert.Equal(PatchDetection.class_type_extends.NO,
+                PatchDetection.SearchClassType((ROM?)null));
+        }
+
+        [Fact]
+        public void SearchClassType_FE8U_PatchAbsent_ReturnsNO()
+        {
+            var rom = MakeRom("BE8E01", new byte[0x1000000]);
+            Assert.Equal(PatchDetection.class_type_extends.NO,
+                PatchDetection.SearchClassType(rom));
+        }
+
+        [Fact]
+        public void SearchClassType_FE8U_Pattern1_ReturnsRework()
+        {
+            var data = new byte[0x1000000];
+            Array.Copy(ClassTypePat1, 0, data, 0x2AAEC, ClassTypePat1.Length);
+            var rom = MakeRom("BE8E01", data);
+            Assert.Equal(PatchDetection.class_type_extends.SkillSystems_Rework,
+                PatchDetection.SearchClassType(rom));
+        }
+
+        [Fact]
+        public void SearchClassType_FE8U_Pattern2_ReturnsRework()
+        {
+            var data = new byte[0x1000000];
+            Array.Copy(ClassTypePat2, 0, data, 0x2AAEC, ClassTypePat2.Length);
+            var rom = MakeRom("BE8E01", data);
+            Assert.Equal(PatchDetection.class_type_extends.SkillSystems_Rework,
+                PatchDetection.SearchClassType(rom));
+        }
+
+        [Fact]
+        public void SearchClassType_FE8J_PatternAtFE8UOffset_StillNO()
+        {
+            // FE8J is multibyte -> the version-8 && !is_multibyte gate rejects it
+            // even with the pattern present at 0x2AAEC.
+            var data = new byte[0x1100000];
+            Array.Copy(ClassTypePat1, 0, data, 0x2AAEC, ClassTypePat1.Length);
+            var rom = MakeRom("BE8J01", data);
+            Assert.Equal(PatchDetection.class_type_extends.NO,
+                PatchDetection.SearchClassType(rom));
+        }
+
+        // ---- SearchGrowsMod (FE8U Vennou table + FE8U SkillSystems grep) ----
+
+        static readonly byte[] VennouSig = new byte[]
+        {
+            0x4E, 0x46, 0x45, 0x46, 0x60, 0xB4, 0x8B, 0xB0, 0x07, 0x1C, 0xFF, 0xF7, 0xDE, 0xFF, 0x00, 0x06,
+            0x00, 0x28, 0x00, 0xD1, 0x8E, 0xE0, 0x78, 0x7A, 0x63, 0x28, 0x00, 0xD8, 0x8A, 0xE0, 0x03, 0x1C,
+            0x64, 0x3B, 0x7B, 0x72, 0x38, 0x7A, 0x42, 0x1C, 0x3A, 0x72, 0x38, 0x68, 0x79, 0x68, 0x80, 0x6A,
+            0x89, 0x6A, 0x08, 0x43, 0x80, 0x21, 0x09, 0x03, 0x08, 0x40, 0x00, 0x28, 0x04, 0xD0, 0x10, 0x06,
+            0x00, 0x16, 0x0A, 0x28, 0x0B, 0xD1, 0x03, 0xE0, 0x10, 0x06, 0x00
+        };
+
+        static readonly byte[] SkillSystemsSig = new byte[]
+        {
+            0x17, 0x49, 0x40, 0x18, 0x22, 0x21, 0x41, 0x5C, 0x01, 0x22, 0x11, 0x42, 0x06, 0xD0, 0xC0, 0x68,
+            0x00, 0x28, 0x03, 0xD0, 0x80, 0x57, 0x2D, 0x18, 0x00, 0x2F, 0x02, 0xD0, 0x02, 0x33, 0x08, 0x2B,
+            0xE5, 0xDD, 0x20, 0x1C, 0x10, 0x49, 0x0F, 0x4A
+        };
+
+        [Fact]
+        public void SearchGrowsMod_NullRom_ReturnsNO()
+        {
+            Assert.Equal(PatchDetection.growth_mod_extends.NO,
+                PatchDetection.SearchGrowsMod((ROM?)null));
+        }
+
+        [Fact]
+        public void SearchGrowsMod_FE8U_PatchAbsent_ReturnsNO()
+        {
+            var rom = MakeRom("BE8E01", new byte[0x1000000]);
+            Assert.Equal(PatchDetection.growth_mod_extends.NO,
+                PatchDetection.SearchGrowsMod(rom));
+        }
+
+        [Fact]
+        public void SearchGrowsMod_FE8U_VennouTablePresent_ReturnsVennou()
+        {
+            var data = new byte[0x1000000];
+            Array.Copy(VennouSig, 0, data, 0x02BA2A, VennouSig.Length);
+            var rom = MakeRom("BE8E01", data);
+            Assert.Equal(PatchDetection.growth_mod_extends.Vennou,
+                PatchDetection.SearchGrowsMod(rom));
+        }
+
+        [Fact]
+        public void SearchGrowsMod_FE8U_SkillSystemsGrep_ReturnsSkillSystems()
+        {
+            // Plant the SkillSystems signature AFTER compress_image_borderline_address
+            // (the grep start). With NO Vennou table present, stage 2 finds it.
+            var rom0 = MakeRom("BE8E01", new byte[0x1000000]);
+            uint border = rom0.RomInfo.compress_image_borderline_address;
+            uint plantAt = U.Padding4(border + 0x100); // 4-aligned, inside the scan window
+            var data = new byte[0x1000000];
+            Array.Copy(SkillSystemsSig, 0, data, plantAt, SkillSystemsSig.Length);
+            var rom = MakeRom("BE8E01", data);
+            Assert.Equal(PatchDetection.growth_mod_extends.SkillSystems,
+                PatchDetection.SearchGrowsMod(rom));
+        }
+
+        [Fact]
+        public void SearchGrowsMod_FE8U_VennouWins_WhenBothPresent()
+        {
+            // Stage 1 (Vennou table) is checked first; even if the SkillSystems
+            // signature is also present, Vennou is returned (WF order).
+            var rom0 = MakeRom("BE8E01", new byte[0x1000000]);
+            uint border = rom0.RomInfo.compress_image_borderline_address;
+            uint plantAt = U.Padding4(border + 0x100);
+            var data = new byte[0x1000000];
+            Array.Copy(VennouSig, 0, data, 0x02BA2A, VennouSig.Length);
+            Array.Copy(SkillSystemsSig, 0, data, plantAt, SkillSystemsSig.Length);
+            var rom = MakeRom("BE8E01", data);
+            Assert.Equal(PatchDetection.growth_mod_extends.Vennou,
+                PatchDetection.SearchGrowsMod(rom));
+        }
+
+        [Fact]
+        public void SearchGrowsMod_FE8J_SignaturesPresent_StillNO()
+        {
+            // Both stages are FE8U-gated -> FE8J never matches.
+            var rom0 = MakeRom("BE8J01", new byte[0x1100000]);
+            uint border = rom0.RomInfo.compress_image_borderline_address;
+            uint plantAt = U.Padding4(border + 0x100);
+            var data = new byte[0x1100000];
+            Array.Copy(VennouSig, 0, data, 0x02BA2A, VennouSig.Length);
+            Array.Copy(SkillSystemsSig, 0, data, plantAt, SkillSystemsSig.Length);
+            var rom = MakeRom("BE8J01", data);
+            Assert.Equal(PatchDetection.growth_mod_extends.NO,
+                PatchDetection.SearchGrowsMod(rom));
+        }
     }
 }

--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -457,10 +457,11 @@ namespace FEBuilderGBA.Core.Tests
             //  see GetNotYetPortedForms_DropsSlice2sForms_KeepsDeferredSiblings.)
             Assert.DoesNotContain("AIScriptForm", notYet);
             Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
-            // ItemForm stays DEFERRED: its StatBooster sub-block size depends on un-ported PatchUtil
-            // patch detection. (ClassForm WAS deferred for its MoveCost sub-blocks but is ported in
-            // slice 2c — see GetNotYetPortedForms_DropsSlice2cCoveredForms_KeepsDeferredSiblings.)
-            Assert.Contains("ItemForm", notYet);
+            // ItemForm is PORTED in slice 2ad (EmitItem + the new Core PatchDetection detectors that
+            // size its StatBooster / effectiveness sub-blocks) — see
+            // GetNotYetPortedForms_DropsSlice2adForms_KeepsDeferredSiblings. (ClassForm WAS deferred for
+            // its MoveCost sub-blocks but is ported in slice 2c.)
+            Assert.DoesNotContain("ItemForm", notYet);
             Assert.DoesNotContain("ClassForm", notYet);
         }
 
@@ -1155,16 +1156,18 @@ namespace FEBuilderGBA.Core.Tests
             // would dangle their sub-block pointers during a rebuild. (MenuDefinitionForm and
             // StatusRMenuForm were the recursive-tree siblings here; slice 2d ports them via dedicated
             // recursive walkers, so they are now covered — see GetNotYetPortedForms_DropsSlice2dCoveredForms.)
-            Assert.Contains("ItemForm", notYet);          // StatBooster size needs PatchUtil detection
-            // (ItemWeaponEffectForm was a deferred sibling here; slice 2l ports it via
+            // (ItemForm was a deferred sibling here; slice 2ad ports it via EmitItem + the new Core
+            //  PatchDetection detectors — see GetNotYetPortedForms_DropsSlice2adForms_KeepsDeferredSiblings.
+            //  ItemWeaponEffectForm was a deferred sibling here; slice 2l ports it via
             //  EmitItemWeaponEffect — see GetNotYetPortedForms_DropsSlice2lCoveredForms. OtherTextForm
             //  was the config-file sibling here; slice 2q ports it — see
             //  GetNotYetPortedForms_DropsSlice2qConfigForms_KeepsDeferredSiblings.)
+            Assert.DoesNotContain("ItemForm", notYet);
             Assert.DoesNotContain("OtherTextForm", notYet);
         }
 
         [Fact]
-        public void MakeAllStructPointersList_FE8U_FindsClassMoveCostSubBlocks_AndDefersItem()
+        public void MakeAllStructPointersList_FE8U_FindsClassMoveCostSubBlocks_AndItem()
         {
             string romPath = FindTestRom();
             if (romPath == null) return; // skip when no ROM available (env-only)
@@ -1206,13 +1209,14 @@ namespace FEBuilderGBA.Core.Tests
                         && a.Info == "MoveCost ref" && a.DataType == Address.DataTypeEnum.BIN);
                 }
 
-                // ClassForm must no longer be tracked as not-yet-ported; ItemForm STAYS deferred
-                // and its main IFR must be ABSENT from the list (StatBooster size unportable).
+                // ClassForm must no longer be tracked as not-yet-ported. ItemForm is now PORTED in
+                // slice 2ad — its main "Item" IFR must be PRESENT in the list (StatBooster + effectiveness
+                // sizes resolved via the new Core PatchDetection detectors).
                 string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
                 Assert.DoesNotContain("ClassForm", notYet);
-                Assert.Contains("ItemForm", notYet);
+                Assert.DoesNotContain("ItemForm", notYet);
                 uint itemBase = rom.p32(rom.RomInfo.item_pointer);
-                Assert.DoesNotContain(list, a => a.Addr == itemBase && a.Info == "Item");
+                Assert.Contains(list, a => a.Addr == itemBase && a.Info == "Item");
             }
             finally
             {
@@ -1713,23 +1717,19 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.DoesNotContain(gone, notYet);
             }
 
-            // Still deferred (un-ported subsystem) -> must REMAIN:
+            // Still deferred (un-ported subsystem) -> must REMAIN. The only data-path remainder after
+            // slice 2ad is EventUnitForm(RecycleReserveUnits) (editor session state — NewAllocData).
+            // (FE8SpellMenuExtendsForm ported in slice 2m. EventBattleTalk/Haiku/WorldMapEventPointer/
+            //  MonsterWMapProbability ported in slice 2aa. StatusOption + SoundFootSteps in 2d.
+            //  UnitFE6 + ItemUsagePointer + AIPerform*/AIMapSetting/Mant/ArenaEnemyWeapon in 2f.
+            //  MapTileAnimation1/2 + ItemShop + MapChange + MapExitPoint in 2g. SupportUnit + WorldMapPath
+            //  + EDStaffRoll + OPPrologue + OPClassFont in 2h. OPClassDemo + OPClassDemoFE7 in 2i.
+            //  MapTerrain{BG,Floor}Lookup + MapPointer + ExtraUnit + ExtraUnitFE8U in 2j. SoundRoom +
+            //  SongTable + MapSetting in 2r. AIScript + ImageBattleAnime in 2s.
+            //  ItemForm + UnitActionPointerForm in 2ad -> asserted GONE below.)
             foreach (var kept in new[]
             {
-                // (FE8SpellMenuExtendsForm ported in slice 2m -> no longer kept here.
-                //  EventBattleTalkForm/EventHaikuForm/WorldMapEventPointerForm/MonsterWMapProbabilityForm
-                //  ported in slice 2aa -> no longer kept here; asserted GONE below.)
-                // (StatusOptionForm + SoundFootStepsForm ported in slice 2d -> no longer kept here.
-                //  UnitFE6Form + ItemUsagePointerForm + AIPerform*/AIMapSetting/Mant/ArenaEnemyWeapon
-                //  ported in slice 2f -> no longer kept here. MapTileAnimation1Form/MapTileAnimation2Form +
-                //  ItemShopForm + MapChangeForm + MapExitPointForm ported in slice 2g -> no longer kept.
-                //  SupportUnitForm + WorldMapPathForm + EDStaffRollForm + OPPrologueForm + OPClassFontForm
-                //  ported in slice 2h -> no longer kept here. OPClassDemoForm + OPClassDemoFE7Form ported
-                //  in slice 2i -> no longer kept here. MapTerrain{BG,Floor}LookupTableForm + MapPointerForm
-                //  + ExtraUnitForm + ExtraUnitFE8UForm ported in slice 2j -> no longer kept here.
-                //  SoundRoomForm + SongTableForm + MapSettingForm ported in slice 2r -> no longer kept here.
-                //  AIScriptForm + ImageBattleAnimeForm ported in slice 2s -> no longer kept here.)
-                "ItemForm",
+                "EventUnitForm(RecycleReserveUnits)",
             })
             {
                 Assert.Contains(kept, notYet);
@@ -1738,6 +1738,10 @@ namespace FEBuilderGBA.Core.Tests
             // slice 2s ported AIScriptForm + ImageBattleAnimeForm -> they must now be GONE.
             Assert.DoesNotContain("AIScriptForm", notYet);
             Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
+
+            // slice 2ad ported ItemForm + UnitActionPointerForm -> they must now be GONE.
+            Assert.DoesNotContain("ItemForm", notYet);
+            Assert.DoesNotContain("UnitActionPointerForm", notYet);
 
             // slice 2aa ported the four FE8 ScanScript-family forms -> they must now be GONE.
             Assert.DoesNotContain("MonsterWMapProbabilityForm", notYet);
@@ -2327,8 +2331,9 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("SoundFootStepsForm", notYet);
             Assert.DoesNotContain("StatusRMenuForm", notYet);
             Assert.DoesNotContain("MenuDefinitionForm", notYet);
-            // sibling forms that genuinely still need un-ported subsystems STAY.
-            Assert.Contains("ItemForm", notYet);
+            // (ItemForm was a deferred sibling here; slice 2ad ports it via EmitItem + the new Core
+            //  PatchDetection detectors.)
+            Assert.DoesNotContain("ItemForm", notYet);
             // (SoundRoomForm ported in slice 2r — see GetNotYetPortedForms_DropsSlice2rForms; AIScriptForm
             //  ported in slice 2s — see GetNotYetPortedForms_DropsSlice2sForms.)
             Assert.DoesNotContain("AIScriptForm", notYet);
@@ -3519,8 +3524,9 @@ namespace FEBuilderGBA.Core.Tests
 
             // (AIScriptForm ported in slice 2s — see GetNotYetPortedForms_DropsSlice2sForms.)
             Assert.DoesNotContain("AIScriptForm", notYet);
-            // deferred siblings STAY (their blocking subsystem is not in Core):
-            Assert.Contains("UnitActionPointerForm", notYet);     // PatchUtil SearchUnitActionReworkPatch
+            // (UnitActionPointerForm was a deferred sibling here; slice 2ad ports it via
+            //  EmitUnitActionPointer + the new Core PatchDetection.SearchUnitActionReworkPatch detector.)
+            Assert.DoesNotContain("UnitActionPointerForm", notYet);
             // (MonsterWMapProbabilityForm PORTED in slice 2aa — EmitScanScript skirmish events.)
             Assert.DoesNotContain("MonsterWMapProbabilityForm", notYet);
             // (the 5 map-PLIST forms that were deferred "for slice size" here are now PORTED in slice 2g
@@ -3930,10 +3936,10 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("MapPointerForm", notYet);
             Assert.DoesNotContain("MapTerrainFloorLookupTableForm", notYet);
             Assert.DoesNotContain("MapTerrainBGLookupTableForm", notYet);
-            // deferred map siblings STAY (their blocking subsystem is not in Core):
             // (MapSettingForm is ported in slice 2r — its IsMapSettingEnd text-count cache is now
-            //  reproduced by TextDataCount. ItemForm stays deferred on its StatBooster PatchUtil size.)
-            Assert.Contains("ItemForm", notYet);                       // StatBooster size via PatchUtil
+            //  reproduced by TextDataCount. ItemForm is ported in slice 2ad — its StatBooster size now
+            //  comes from the new Core PatchDetection detectors.)
+            Assert.DoesNotContain("ItemForm", notYet);
 
             // the no-duplicates invariant still holds after the edits.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
@@ -5256,7 +5262,8 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("AIScriptForm", notYet);
             Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
             Assert.Contains("EventUnitForm(RecycleReserveUnits)", notYet); // NewAllocData = editor session state
-            Assert.Contains("ItemForm", notYet);                        // StatBooster size via PatchUtil
+            // (ItemForm ported in slice 2ad — StatBooster size via the new Core PatchDetection detectors.)
+            Assert.DoesNotContain("ItemForm", notYet);
 
             // the no-duplicates invariant still holds after the edits.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
@@ -6329,11 +6336,11 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("AIScriptForm", notYet);
             Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
 
-            // sibling forms that genuinely still need un-ported subsystems STAY:
-            Assert.Contains("ItemForm", notYet);                  // PatchUtil StatBooster detection
-            Assert.Contains("UnitActionPointerForm", notYet);     // PatchUtil SearchUnitActionReworkPatch
-            // (ImagePortraitForm + ImageItemIconForm — formerly listed here — ported in slice 2t; see
-            //  GetNotYetPortedForms_DropsSlice2tForms.)
+            // (ItemForm + UnitActionPointerForm — formerly deferred siblings here — ported in slice 2ad
+            //  via EmitItem / EmitUnitActionPointer + the new Core PatchDetection detectors.
+            //  ImagePortraitForm + ImageItemIconForm ported in slice 2t.)
+            Assert.DoesNotContain("ItemForm", notYet);
+            Assert.DoesNotContain("UnitActionPointerForm", notYet);
 
             // the no-duplicates invariant still holds after the edits.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
@@ -6355,8 +6362,8 @@ namespace FEBuilderGBA.Core.Tests
             // ProcsScriptForm itself STAYS — it is an ASM-path form (MakePatchStructDataList), out of
             // scope for this data-path producer; only its CalcLengthAndCheck length helper is reused.
             Assert.Contains("ProcsScriptForm", notYet);
-            // ItemForm STAYS — StatBooster sub-block size needs un-ported PatchUtil detection.
-            Assert.Contains("ItemForm", notYet);
+            // (ItemForm ported in slice 2ad — StatBooster size via the new Core PatchDetection detectors.)
+            Assert.DoesNotContain("ItemForm", notYet);
 
             // the no-duplicates invariant still holds after the edits.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
@@ -6669,8 +6676,8 @@ namespace FEBuilderGBA.Core.Tests
             //  in slice 2s — see GetNotYetPortedForms_DropsSlice2sForms.)
             Assert.DoesNotContain("MapSettingForm", notYet);
             Assert.DoesNotContain("AIScriptForm", notYet);
-            // ItemForm STAYS — StatBooster sub-block size needs un-ported PatchUtil detection.
-            Assert.Contains("ItemForm", notYet);
+            // (ItemForm ported in slice 2ad — StatBooster size via the new Core PatchDetection detectors.)
+            Assert.DoesNotContain("ItemForm", notYet);
 
             // the no-duplicates invariant still holds after the edits.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
@@ -9184,10 +9191,9 @@ namespace FEBuilderGBA.Core.Tests
             //  are now ported in slice 2s — see GetNotYetPortedForms_DropsSlice2sForms.)
             Assert.DoesNotContain("AIScriptForm", notYet);
             Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
-            // Genuinely-still-deferred siblings STAY:
-            Assert.Contains("ItemForm", notYet);          // PatchUtil StatBooster detection
-            // (ImagePortraitForm — formerly listed here — ported in slice 2t; see
-            //  GetNotYetPortedForms_DropsSlice2tForms.)
+            // (ItemForm — formerly a deferred sibling here — ported in slice 2ad via EmitItem + the new
+            //  Core PatchDetection detectors. ImagePortraitForm ported in slice 2t.)
+            Assert.DoesNotContain("ItemForm", notYet);
             Assert.DoesNotContain("ImagePortraitForm", notYet);
 
             // no-duplicates invariant still holds.
@@ -9554,7 +9560,7 @@ namespace FEBuilderGBA.Core.Tests
 
                 // Data path incomplete (a deferred data-path form), ASM path complete.
                 var data = new RebuildProducerCore.ProducerResult(
-                    structList, new[] { "ItemForm" }, cancelled: false);
+                    structList, new[] { "EventUnitForm(RecycleReserveUnits)" }, cancelled: false);
                 var asm = new RebuildProducerCore.AsmProducerResult(new string[0], cancelled: false);
 
                 using (var tmp = new WireTempDir())
@@ -9563,7 +9569,7 @@ namespace FEBuilderGBA.Core.Tests
                     var ex = Assert.Throws<InvalidOperationException>(() =>
                         RebuildProducerCore.MakeWithProducer(
                             data, asm, modified, vanilla, WIRE_REBUILD_ADDR, manifestPath));
-                    Assert.Contains("ItemForm", ex.Message);
+                    Assert.Contains("EventUnitForm(RecycleReserveUnits)", ex.Message);
                     Assert.False(System.IO.File.Exists(manifestPath));
                 }
             }
@@ -9722,5 +9728,429 @@ namespace FEBuilderGBA.Core.Tests
                 CoreState.ROM = savedRom;
             }
         }
+
+        // ==================================================================
+        // #1261 slice 2ad — EmitItem + EmitUnitActionPointer (data-path forms).
+        //
+        // These use a real FE8U ROM (MakeVersionedRom("BE8E01")) because both
+        // emitters call into RomInfo (item version/datasize, the rework delegate)
+        // and the slice-2ad PatchDetection detectors. The detector signatures live
+        // at LOW fixed addresses (0x02BA2A / 0x2AAEC / 0x28E80); test tables are
+        // planted HIGH (>= 0x100000) so a zeroed-detector ROM gives the vanilla
+        // sizes and planting a detector signature flips exactly one size.
+        // ==================================================================
+
+        // ---- EmitItem ----
+
+        [Fact]
+        public void EmitItem_NullRomInfo_EmitsNothing()
+        {
+            var rom = CreateTestRom(); // synthetic, no RomInfo
+            var list = new List<Address>();
+            RebuildProducerCore.EmitItemAt(rom, list, 0x240, 36);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitItem_ZeroedFe8u_EmitsNothingSafe()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var rom = MakeVersionedRom("BE8E01");
+                CoreState.ROM = rom;
+                var list = new List<Address>();
+                // EmitItem reads RomInfo.item_pointer (FindROMPointer fallback) -> p32 == 0 -> nothing.
+                RebuildProducerCore.EmitItem(rom, list);
+                Assert.Empty(list);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        /// <summary>
+        /// Plant ONE item entry on a FE8U ROM: a pointer slot -> a one-entry item table whose
+        /// entry has a StatBooster pointer at +12 and (optionally) an ItemEffectiveness pointer at
+        /// +16. Returns (slot, table, entry, statboost, effect). The item rule (FE8U: +12 is a
+        /// pointer-or-null) makes exactly one entry valid; entry+block has +12 NOT pointer -> stop.
+        /// </summary>
+        static (uint slot, uint table, uint entry, uint statboost, uint effect) PlantOneItem(
+            ROM rom, byte vennoExtendsFlag, byte passiveBoosterFlag, bool withEffect)
+        {
+            const uint block = 36;
+            uint slot = 0x100000;
+            uint table = 0x101000;
+            uint statboost = 0x102000;
+            uint effect = 0x103000;
+
+            rom.write_u32(slot, Ptr(table));
+
+            // entry 0 at `table`.
+            rom.write_u32(table + 12, Ptr(statboost));         // StatBooster pointer (> 0)
+            rom.write_u8(table + 34, vennoExtendsFlag);        // venno/skill flag
+            rom.write_u8(table + 10, passiveBoosterFlag);      // passive-booster byte
+            if (withEffect)
+            {
+                rom.write_u32(table + 16, Ptr(effect));        // ItemEffectiveness pointer (> 0)
+            }
+
+            // entry 1 (terminator): +12 must NOT be pointer-or-null so the item rule stops at count 1.
+            // 0x00000001 is neither a pointer nor null -> isPointerOrNULL false.
+            rom.write_u32(table + block + 12, 0x00000001);
+
+            return (slot, table, table, statboost, effect);
+        }
+
+        [Fact]
+        public void EmitItem_Vanilla_StatBoosterSize12()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var rom = MakeVersionedRom("BE8E01");
+                CoreState.ROM = rom;
+                var p = PlantOneItem(rom, vennoExtendsFlag: 1, passiveBoosterFlag: 0x80, withEffect: false);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitItemAt(rom, list, p.slot, 36);
+
+                // No GrowsMod/IER/ClassType signatures planted -> vanilla 12-byte StatBooster.
+                Address sb = list.Single(a => a.Addr == p.statboost);
+                Assert.Equal(12u, sb.Length);
+                Assert.Equal(Address.DataTypeEnum.BIN, sb.DataType);
+                Assert.Equal(p.table + 12, sb.Pointer);
+
+                // Main IFR present: base = table, block 36, type InputFormRef, count 1 -> 36*2.
+                Address main = list.Single(a => a.Addr == p.table && a.DataType == Address.DataTypeEnum.InputFormRef);
+                Assert.Equal(36u * 2, main.Length);
+                Assert.Equal(p.slot, main.Pointer);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitItem_Vennou_StatBoosterSize16_WhenFlag1()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var rom = MakeVersionedRom("BE8E01");
+                CoreState.ROM = rom;
+                // Plant the Vennou signature so SearchGrowsMod == Vennou.
+                Array.Copy(VennouSigFor2ad, 0, rom.Data, 0x02BA2A, VennouSigFor2ad.Length);
+                var p = PlantOneItem(rom, vennoExtendsFlag: 1, passiveBoosterFlag: 0x00, withEffect: false);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitItemAt(rom, list, p.slot, 36);
+
+                Address sb = list.Single(a => a.Addr == p.statboost);
+                Assert.Equal(16u, sb.Length); // Vennou + flag==1 -> 16
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitItem_Vennou_StatBoosterSize12_WhenFlagNot1()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var rom = MakeVersionedRom("BE8E01");
+                CoreState.ROM = rom;
+                Array.Copy(VennouSigFor2ad, 0, rom.Data, 0x02BA2A, VennouSigFor2ad.Length);
+                // flag at +34 is 0 -> Vennou branch does NOT fire -> vanilla 12.
+                var p = PlantOneItem(rom, vennoExtendsFlag: 0, passiveBoosterFlag: 0x00, withEffect: false);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitItemAt(rom, list, p.slot, 36);
+
+                Address sb = list.Single(a => a.Addr == p.statboost);
+                Assert.Equal(12u, sb.Length);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitItem_IER_StatBoosterSize20_WhenPassiveBit()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var rom = MakeVersionedRom("BE8E01");
+                CoreState.ROM = rom;
+                Array.Copy(IERSigFor2ad, 0, rom.Data, 0x28E80, IERSigFor2ad.Length);
+                // No GrowsMod signature -> growthmod==NO; IER + passive bit 0x80 -> 20.
+                var p = PlantOneItem(rom, vennoExtendsFlag: 0, passiveBoosterFlag: 0x80, withEffect: false);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitItemAt(rom, list, p.slot, 36);
+
+                Address sb = list.Single(a => a.Addr == p.statboost);
+                Assert.Equal(20u, sb.Length);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitItem_VennouWinsOverIER_WhenBothPresentAndFlags()
+        {
+            // Copilot plan-review point 2: the if/else-if priority means Vennou (flag==1) wins
+            // over IER (passive bit) — both present must yield 16, NOT 20.
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var rom = MakeVersionedRom("BE8E01");
+                CoreState.ROM = rom;
+                Array.Copy(VennouSigFor2ad, 0, rom.Data, 0x02BA2A, VennouSigFor2ad.Length);
+                Array.Copy(IERSigFor2ad, 0, rom.Data, 0x28E80, IERSigFor2ad.Length);
+                var p = PlantOneItem(rom, vennoExtendsFlag: 1, passiveBoosterFlag: 0x80, withEffect: false);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitItemAt(rom, list, p.slot, 36);
+
+                Address sb = list.Single(a => a.Addr == p.statboost);
+                Assert.Equal(16u, sb.Length); // Vennou wins -> 16 (NOT IER's 20)
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitItem_Effectiveness_VanillaLengthIsCountPlusOne()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var rom = MakeVersionedRom("BE8E01");
+                CoreState.ROM = rom;
+                var p = PlantOneItem(rom, vennoExtendsFlag: 0, passiveBoosterFlag: 0, withEffect: true);
+                // Vanilla N_Init: block 1, stop at u8==0. Plant 3 non-zero bytes then a 0.
+                rom.write_u8(p.effect + 0, 0x05);
+                rom.write_u8(p.effect + 1, 0x06);
+                rom.write_u8(p.effect + 2, 0x07);
+                rom.write_u8(p.effect + 3, 0x00); // terminator
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitItemAt(rom, list, p.slot, 36);
+
+                Address eff = list.Single(a => a.Addr == p.effect);
+                // count 3 -> length 3+1 = 4 (block 1).
+                Assert.Equal(4u, eff.Length);
+                Assert.Equal(Address.DataTypeEnum.BIN, eff.DataType);
+                Assert.Equal(p.table + 16, eff.Pointer);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitItem_Effectiveness_ReworkLengthIsCountPlusOneTimes4()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var rom = MakeVersionedRom("BE8E01");
+                CoreState.ROM = rom;
+                // SkillSystems_Rework: plant the ClassType pattern at 0x2AAEC.
+                Array.Copy(ClassTypePat1For2ad, 0, rom.Data, 0x2AAEC, ClassTypePat1For2ad.Length);
+                var p = PlantOneItem(rom, vennoExtendsFlag: 0, passiveBoosterFlag: 0, withEffect: true);
+                // Rework N_Init: block 4, stop when NOT (u8==0 && u32!=0). 2 valid blocks then a stop.
+                rom.write_u32(p.effect + 0, 0x00000200); // u8(low)==0 && u32!=0 -> valid
+                rom.write_u32(p.effect + 4, 0x00000400); // valid
+                rom.write_u32(p.effect + 8, 0x00000001); // u8==1 -> stop (head must be 0)
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitItemAt(rom, list, p.slot, 36);
+
+                Address eff = list.Single(a => a.Addr == p.effect);
+                // count 2 -> length (2+1)*4 = 12 (block 4).
+                Assert.Equal(12u, eff.Length);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitItem_NearEof_NoThrow()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                // A small FE8U ROM is impossible (LoadLow probes high addrs), so use the normal
+                // 32MB ROM but point the slot near EOF: the pointer-slot guard returns safely.
+                var rom = MakeVersionedRom("BE8E01");
+                CoreState.ROM = rom;
+                var list = new List<Address>();
+                uint nearEof = (uint)rom.Data.Length - 2; // slot+3 exceeds EOF -> guarded
+                var ex = Record.Exception(() => RebuildProducerCore.EmitItemAt(rom, list, nearEof, 36));
+                Assert.Null(ex);
+                Assert.Empty(list);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        // ---- EmitUnitActionPointer ----
+
+        [Fact]
+        public void EmitUnitActionPointer_NullRomInfo_EmitsNothing()
+        {
+            var rom = CreateTestRom();
+            var list = new List<Address>();
+            RebuildProducerCore.EmitUnitActionPointerAt(rom, list, 0x240);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitUnitActionPointer_NonRework_EmitsAsmTable()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var rom = MakeVersionedRom("BE8E01");
+                CoreState.ROM = rom;
+                // Non-rework (no rework signature planted): IsDataExists = isSafetyPointer(u32).
+                uint slot = 0x100000;
+                uint table = 0x101000;
+                rom.write_u32(slot, Ptr(table));
+                // 2 valid ASM pointer entries (block 4) then a non-pointer terminator.
+                rom.write_u32(table + 0, Ptr(0x120000));
+                rom.write_u32(table + 4, Ptr(0x120040));
+                rom.write_u32(table + 8, 0x00000001); // not a safe pointer -> stop
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitUnitActionPointerAt(rom, list, slot);
+
+                Address main = list.Single(a => a.Addr == table
+                    && a.DataType == Address.DataTypeEnum.InputFormRef_ASM);
+                Assert.Equal(4u * (2 + 1), main.Length); // count 2 -> 4*(2+1)
+                Assert.Equal(slot, main.Pointer);
+                // One ASM AddFunction per entry (2 entries). AddFunction emits DataTypeEnum.ASM
+                // (the resolved target addr), gated on isSafetyPointer(u32(entry)).
+                int funcs = list.Count(a => a.DataType == Address.DataTypeEnum.ASM);
+                Assert.Equal(2, funcs);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitUnitActionPointer_Rework_TreatsZeroAsValidAndMasksPointer()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var rom = MakeVersionedRom("BE8E01");
+                CoreState.ROM = rom;
+                // Make the rework gate TRUE: plant the per-version expected u32 at the rework addr.
+                uint expected;
+                uint hackAddr = rom.RomInfo.patch_unitaction_rework_hack(out expected);
+                rom.write_u32(hackAddr, expected);
+                Assert.True(PatchDetection.SearchUnitActionReworkPatch(rom));
+
+                uint slot = 0x100000;
+                uint table = 0x101000;
+                rom.write_u32(slot, Ptr(table));
+                // Rework predicate: 0 is a VALID entry; masked pointer (& 0x0FFFFFFF) accepted;
+                // 0xFFFFFFFF terminates.
+                rom.write_u32(table + 0, 0x00000000);   // valid (0)
+                rom.write_u32(table + 4, 0x08120000);    // masked -> 0x00120000 safe offset -> valid
+                rom.write_u32(table + 8, 0xFFFFFFFF);    // NOT_FOUND -> stop
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitUnitActionPointerAt(rom, list, slot);
+
+                Address main = list.Single(a => a.Addr == table
+                    && a.DataType == Address.DataTypeEnum.InputFormRef_ASM);
+                Assert.Equal(4u * (2 + 1), main.Length); // count 2 (the 0 entry counts)
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitUnitActionPointer_ZeroSlot_EmitsNothing()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var rom = MakeVersionedRom("BE8E01");
+                CoreState.ROM = rom;
+                var list = new List<Address>();
+                // A 0 base slot (e.g. SearchActionPointer returned 0 in the rework-no-config path).
+                RebuildProducerCore.EmitUnitActionPointerAt(rom, list, 0);
+                Assert.Empty(list);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void SearchActionPointer_NonRework_ReturnsRomInfoSlot()
+        {
+            var savedRom = CoreState.ROM;
+            try
+            {
+                var rom = MakeVersionedRom("BE8E01");
+                CoreState.ROM = rom;
+                // No rework signature -> non-rework path returns the RomInfo slot verbatim.
+                Assert.Equal(rom.RomInfo.unitaction_function_pointer,
+                    RebuildProducerCore.SearchActionPointer(rom));
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void SearchActionPointer_Rework_NoConfigFile_ReturnsZero()
+        {
+            var savedRom = CoreState.ROM;
+            var savedBase = CoreState.BaseDirectory;
+            try
+            {
+                var rom = MakeVersionedRom("BE8E01");
+                CoreState.ROM = rom;
+                CoreState.BaseDirectory = null; // no config tree -> rework path returns 0 (no throw)
+                uint expected;
+                uint hackAddr = rom.RomInfo.patch_unitaction_rework_hack(out expected);
+                rom.write_u32(hackAddr, expected);
+                Assert.True(PatchDetection.SearchUnitActionReworkPatch(rom));
+
+                Assert.Equal(0u, RebuildProducerCore.SearchActionPointer(rom));
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+                CoreState.BaseDirectory = savedBase;
+            }
+        }
+
+        // ---- NotYetPorted coverage delta for slice 2ad ----
+
+        [Fact]
+        public void GetNotYetPortedForms_DropsSlice2adForms_KeepsDeferredSiblings()
+        {
+            string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
+
+            // slice 2ad ports these two data-path forms -> no longer deferred.
+            Assert.DoesNotContain("ItemForm", notYet);
+            Assert.DoesNotContain("UnitActionPointerForm", notYet);
+
+            // The only data-path remainder (a genuine producer form) is
+            // EventUnitForm(RecycleReserveUnits) — editor session state (NewAllocData). The list also
+            // keeps the ASM-path epic PatchForm(MakePatchStructDataList) and the ASM-only ProcsScriptForm
+            // (whose length helper this data path reuses but whose own table is ASM-path) — both out of
+            // scope for the data-path producer, kept so the coverage gate stays honest.
+            Assert.Contains("EventUnitForm(RecycleReserveUnits)", notYet);
+            Assert.Contains("PatchForm(MakePatchStructDataList)", notYet);
+        }
+
+        // Signatures duplicated locally for the slice-2ad EmitItem tests (kept in sync with
+        // PatchDetection's tables — a divergence would make these tests fail loudly).
+        static readonly byte[] VennouSigFor2ad = new byte[]
+        {
+            0x4E, 0x46, 0x45, 0x46, 0x60, 0xB4, 0x8B, 0xB0, 0x07, 0x1C, 0xFF, 0xF7, 0xDE, 0xFF, 0x00, 0x06,
+            0x00, 0x28, 0x00, 0xD1, 0x8E, 0xE0, 0x78, 0x7A, 0x63, 0x28, 0x00, 0xD8, 0x8A, 0xE0, 0x03, 0x1C,
+            0x64, 0x3B, 0x7B, 0x72, 0x38, 0x7A, 0x42, 0x1C, 0x3A, 0x72, 0x38, 0x68, 0x79, 0x68, 0x80, 0x6A,
+            0x89, 0x6A, 0x08, 0x43, 0x80, 0x21, 0x09, 0x03, 0x08, 0x40, 0x00, 0x28, 0x04, 0xD0, 0x10, 0x06,
+            0x00, 0x16, 0x0A, 0x28, 0x0B, 0xD1, 0x03, 0xE0, 0x10, 0x06, 0x00
+        };
+        static readonly byte[] IERSigFor2ad = new byte[]
+        {
+            0x03, 0x4B, 0x14, 0x22, 0x50, 0x43, 0x40, 0x18,
+            0xC0, 0x18, 0x00, 0x68, 0x70, 0x47, 0x00, 0x00
+        };
+        static readonly byte[] ClassTypePat1For2ad = new byte[] { 0x00, 0x25, 0x00, 0x28, 0x00, 0xD0, 0x05, 0x1C };
     }
 }

--- a/FEBuilderGBA.Core/PatchDetection.cs
+++ b/FEBuilderGBA.Core/PatchDetection.cs
@@ -473,7 +473,7 @@ namespace FEBuilderGBA
         // SkillSystemPatchScanner.IsClassSkillExtends(rom) — see the
         // duplicate-source consolidation done by gap-sweep #415 +
         // gap-sweep #416. Both WinForms (SkillConfigSkillSystemForm.cs)
-        // and Avalonia (SkillAssignmentClassSkillSystemViewModel,
+        // and Avalonia (SkillAssignmentClassCSkillSysViewModel,
         // SkillAssignmentClassSkillSystemViewModel) route through that
         // single helper.
 

--- a/FEBuilderGBA.Core/PatchDetection.cs
+++ b/FEBuilderGBA.Core/PatchDetection.cs
@@ -357,6 +357,9 @@ namespace FEBuilderGBA
             g_Cache_TextEngineRework_enum = TextEngineRework_enum.NoCache;
             g_Cache_ExtendsBattleBG = ExtendsBattleBG_extends.NoCache;
             g_Cache_MapSecondPalette = MapSecondPalette_extends.NoCache;
+            g_Cache_ItemUsingExtends = ItemUsingExtends_extends.NoCache;
+            g_Cache_class_type = class_type_extends.NoCache;
+            g_Cache_growth_mod = growth_mod_extends.NoCache;
         }
 
         // ---- OPClassReel patch detectors (extracted from PatchUtil for gap-sweep #419) ----
@@ -470,8 +473,258 @@ namespace FEBuilderGBA
         // SkillSystemPatchScanner.IsClassSkillExtends(rom) — see the
         // duplicate-source consolidation done by gap-sweep #415 +
         // gap-sweep #416. Both WinForms (SkillConfigSkillSystemForm.cs)
-        // and Avalonia (SkillAssignmentClassCSkillSysViewModel,
+        // and Avalonia (SkillAssignmentClassSkillSystemViewModel,
         // SkillAssignmentClassSkillSystemViewModel) route through that
         // single helper.
+
+        // ---- UnitActionRework patch detector (#1261 slice 2ad) ----
+        // Cross-platform port of WinForms PatchUtil.SearchUnitActionReworkPatch
+        // (PatchUtil.cs:548). Gates UnitActionPointerForm's base resolution
+        // (SearchActionPointer): when the rework patch is installed the unit-action
+        // function-pointer table moves and its entries are masked (& 0x0FFFFFFF).
+        // The producer (RebuildProducerCore.EmitUnitActionPointer) reads this to
+        // pick the base + IsDataExists rule. A wrong answer relocates the wrong
+        // ASM-pointer table — silent ROM corruption.
+        //
+        // This is a thin delegate wrapper (NOT a byte-table): every per-version
+        // RomInfo subclass already carries the (addr, expected_value) pair via the
+        // virtual patch_unitaction_rework_hack(out enable_value) accessor in Core
+        // (ROMFE*.cs), so we reproduce the WF logic verbatim — read u32(address),
+        // compare to enable_value — guarding the full 4-byte read.
+
+        /// <summary>
+        /// True when the "UnitActionRework" patch is installed in <paramref name="rom"/>.
+        /// Verbatim port of WinForms <c>PatchUtil.SearchUnitActionReworkPatch</c>: the
+        /// per-version RomInfo accessor <c>patch_unitaction_rework_hack(out enable_value)</c>
+        /// supplies the (address, expected u32) pair; the patch is present when
+        /// <c>u32(address) == enable_value</c>. Returns false on a null ROM or when the
+        /// accessor reports address 0 (FE versions without the patch concept).
+        /// </summary>
+        public static bool SearchUnitActionReworkPatch(ROM rom)
+        {
+            if (rom?.RomInfo == null) return false;
+            uint check_value;
+            uint address = rom.RomInfo.patch_unitaction_rework_hack(out check_value);
+            if (address == 0)
+            {
+                return false;
+            }
+            // Guard the full 4-byte u32 read (address + 3) on a truncated/synthetic ROM —
+            // WF reads Program.ROM.u32(address) unconditionally; on a valid ROM the patch
+            // slot is never near EOF, so this is output-equivalent.
+            if (!U.isSafetyOffset(address + 3, rom))
+            {
+                return false;
+            }
+            uint a = rom.u32(address);
+            return (a == check_value);
+        }
+
+        /// <summary>Ambient-ROM overload. Reads <see cref="CoreState.ROM"/>.</summary>
+        public static bool SearchUnitActionReworkPatch()
+        {
+            return SearchUnitActionReworkPatch(CoreState.ROM);
+        }
+
+        // ---- ItemUsingExtends (IER) patch detector (#1261 slice 2ad) ----
+        // Cross-platform port of WinForms PatchUtil.ItemUsingExtendsPatch
+        // (PatchUtil.cs:1936). Gates ItemForm's StatBooster sub-block size: when IER
+        // is installed AND the item's passive-booster bit 0x80 is set, the booster
+        // block is 20 bytes (vanilla 12). A fixed-address signature table (FE8U only).
+
+        public enum ItemUsingExtends_extends
+        {
+            NO,
+            IER,
+            NoCache = (int)NO_CACHE
+        }
+
+        static readonly PatchTableSt[] ItemUsingExtendsTable = new PatchTableSt[] {
+            new PatchTableSt{ name="IER", ver = "FE8U", addr = 0x28E80, data = new byte[]{0x03, 0x4B, 0x14, 0x22, 0x50, 0x43, 0x40, 0x18, 0xC0, 0x18, 0x00, 0x68, 0x70, 0x47, 0x00, 0x00}},
+        };
+
+        /// <summary>
+        /// Detect the "ItemUsingExtends" (IER) patch in <paramref name="rom"/>. Verbatim
+        /// port of WinForms <c>PatchUtil.ItemUsingExtendsPatchLow</c> — a single FE8U
+        /// signature at 0x28E80. Returns <see cref="ItemUsingExtends_extends.NO"/> on a
+        /// null ROM or any non-FE8U version (the table only contains FE8U).
+        /// </summary>
+        public static ItemUsingExtends_extends ItemUsingExtendsPatch(ROM rom)
+        {
+            if (SearchPatchBool(rom, ItemUsingExtendsTable))
+            {
+                return ItemUsingExtends_extends.IER;
+            }
+            return ItemUsingExtends_extends.NO;
+        }
+
+        static ItemUsingExtends_extends g_Cache_ItemUsingExtends = ItemUsingExtends_extends.NoCache;
+
+        public static void ClearCacheItemUsingExtends()
+        {
+            g_Cache_ItemUsingExtends = ItemUsingExtends_extends.NoCache;
+        }
+
+        /// <summary>Ambient-ROM overload (cached). Reads <see cref="CoreState.ROM"/>.</summary>
+        public static ItemUsingExtends_extends ItemUsingExtendsPatch()
+        {
+            if (g_Cache_ItemUsingExtends == ItemUsingExtends_extends.NoCache)
+            {
+                g_Cache_ItemUsingExtends = ItemUsingExtendsPatch(CoreState.ROM);
+            }
+            return g_Cache_ItemUsingExtends;
+        }
+
+        // ---- ClassType (SkillSystems effectiveness rework) detector (#1261 slice 2ad) ----
+        // Cross-platform port of WinForms PatchUtil.SearchClassType ->
+        // SearchSkillSystemsEffectivenesReworkLow (PatchUtil.cs:280-306). Gates
+        // ItemForm's ItemEffectiveness sub-block: when the rework is installed the
+        // effectiveness list is a block-4 (class-type) table whose length is
+        // (count+1)*4 instead of the vanilla block-1 (count+1). Uses CompareByte at
+        // a single fixed address (0x2AAEC) against TWO alternative byte patterns,
+        // FE8U-only (version 8 && !is_multibyte) — verbatim.
+
+        public enum class_type_extends
+        {
+            NO,
+            SkillSystems_Rework,
+            NoCache = (int)NO_CACHE
+        }
+
+        /// <summary>
+        /// Detect the "SkillSystems effectiveness rework" (class-type) patch in
+        /// <paramref name="rom"/>. Verbatim port of WinForms
+        /// <c>PatchUtil.SearchSkillSystemsEffectivenesReworkLow</c>: only on FE8U
+        /// (version 8 &amp;&amp; !is_multibyte), <c>CompareByte(0x2AAEC, ..)</c> against
+        /// either of two 8-byte patterns. Returns <see cref="class_type_extends.NO"/> on
+        /// a null ROM or any other version. CompareByte is itself EOF-safe.
+        /// </summary>
+        public static class_type_extends SearchClassType(ROM rom)
+        {
+            if (rom?.RomInfo == null) return class_type_extends.NO;
+            if (rom.RomInfo.version == 8 && rom.RomInfo.is_multibyte == false)
+            {
+                bool r = rom.CompareByte(0x2AAEC,
+                    new byte[] { 0x00, 0x25, 0x00, 0x28, 0x00, 0xD0, 0x05, 0x1C });
+                if (r)
+                {
+                    return class_type_extends.SkillSystems_Rework;
+                }
+                r = rom.CompareByte(0x2AAEC,
+                    new byte[] { 0x01, 0x4B, 0xA6, 0xF0, 0xED, 0xFE, 0x01, 0xE0 });
+                if (r)
+                {
+                    return class_type_extends.SkillSystems_Rework;
+                }
+            }
+            return class_type_extends.NO;
+        }
+
+        static class_type_extends g_Cache_class_type = class_type_extends.NoCache;
+
+        public static void ClearCacheClassType()
+        {
+            g_Cache_class_type = class_type_extends.NoCache;
+        }
+
+        /// <summary>Ambient-ROM overload (cached). Reads <see cref="CoreState.ROM"/>.</summary>
+        public static class_type_extends SearchClassType()
+        {
+            if (g_Cache_class_type == class_type_extends.NoCache)
+            {
+                g_Cache_class_type = SearchClassType(CoreState.ROM);
+            }
+            return g_Cache_class_type;
+        }
+
+        // ---- GrowsMod patch detector (#1261 slice 2ad) ----
+        // Cross-platform port of WinForms PatchUtil.SearchGrowsMod ->
+        // SearchGrowsModLow (PatchUtil.cs:138-169). Gates ItemForm's StatBooster
+        // sub-block size: Vennou -> 16 bytes (when the item's +34 flag == 1),
+        // SkillSystems -> 20 bytes (same flag). Two-stage detection, verbatim:
+        //   1. Vennou: a fixed-address byte table (FE8U @ 0x02BA2A).
+        //   2. SkillSystems: a ROM-WIDE U.Grep of a long signature, scanned from
+        //      compress_image_borderline_address with alignment 4 (reproduces the WF
+        //      GrepPatch(Grep2PatchTableSt[]) helper — same start/blocksize/safety).
+        // FE8U-only on both stages (matching the WF table `ver` fields).
+
+        public enum growth_mod_extends
+        {
+            NO,
+            Vennou,
+            SkillSystems,
+            NoCache = (int)NO_CACHE
+        }
+
+        static readonly PatchTableSt[] GrowsModVennouTable = new PatchTableSt[] {
+            new PatchTableSt{ name="GrowsMod", ver = "FE8U", addr = 0x02BA2A, data = new byte[]{0x4E, 0x46, 0x45, 0x46, 0x60, 0xB4, 0x8B, 0xB0, 0x07, 0x1C, 0xFF, 0xF7, 0xDE, 0xFF, 0x00, 0x06, 0x00, 0x28, 0x00, 0xD1, 0x8E, 0xE0, 0x78, 0x7A, 0x63, 0x28, 0x00, 0xD8, 0x8A, 0xE0, 0x03, 0x1C, 0x64, 0x3B, 0x7B, 0x72, 0x38, 0x7A, 0x42, 0x1C, 0x3A, 0x72, 0x38, 0x68, 0x79, 0x68, 0x80, 0x6A, 0x89, 0x6A, 0x08, 0x43, 0x80, 0x21, 0x09, 0x03, 0x08, 0x40, 0x00, 0x28, 0x04, 0xD0, 0x10, 0x06, 0x00, 0x16, 0x0A, 0x28, 0x0B, 0xD1, 0x03, 0xE0, 0x10, 0x06, 0x00}},
+        };
+
+        // SkillSystems is found by a whole-ROM grep (not a fixed addr) — reproduces the
+        // WF Grep2PatchTableSt path. We keep the version + signature here; the scan is
+        // done in SearchGrowsMod below (it needs rom.Data + the borderline address).
+        static readonly byte[] GrowsModSkillSystemsSignature = new byte[] {
+            0x17, 0x49, 0x40, 0x18, 0x22, 0x21, 0x41, 0x5C, 0x01, 0x22, 0x11, 0x42, 0x06, 0xD0, 0xC0, 0x68,
+            0x00, 0x28, 0x03, 0xD0, 0x80, 0x57, 0x2D, 0x18, 0x00, 0x2F, 0x02, 0xD0, 0x02, 0x33, 0x08, 0x2B,
+            0xE5, 0xDD, 0x20, 0x1C, 0x10, 0x49, 0x0F, 0x4A
+        };
+
+        /// <summary>
+        /// Detect the "GrowsMod" StatBooster-extension patch in <paramref name="rom"/>.
+        /// Verbatim port of WinForms <c>PatchUtil.SearchGrowsModLow</c>:
+        /// <list type="number">
+        ///   <item><b>Vennou</b> — a fixed FE8U byte table at 0x02BA2A.</item>
+        ///   <item><b>SkillSystems</b> — a whole-ROM <see cref="U.Grep"/> of the
+        ///   SkillSystems signature, scanned from
+        ///   <c>compress_image_borderline_address</c> with blocksize 4, accepted only
+        ///   when the hit is a safe offset (reproduces WF <c>GrepPatch</c>). FE8U only.</item>
+        /// </list>
+        /// Returns <see cref="growth_mod_extends.NO"/> on a null ROM or any non-FE8U
+        /// version (both stages are FE8U-gated, matching WF).
+        /// </summary>
+        public static growth_mod_extends SearchGrowsMod(ROM rom)
+        {
+            if (rom?.RomInfo == null) return growth_mod_extends.NO;
+
+            // Stage 1 — Vennou (fixed-address table; SearchPatchBool already version-gates).
+            if (SearchPatchBool(rom, GrowsModVennouTable))
+            {
+                return growth_mod_extends.Vennou;
+            }
+
+            // Stage 2 — SkillSystems (whole-ROM grep, FE8U only). Reproduces WF
+            // GrepPatch(Grep2PatchTableSt[]): U.Grep(rom.Data, signature,
+            // compress_image_borderline_address, 0, 4) and require isSafetyOffset(hit).
+            if (rom.RomInfo.VersionToFilename == "FE8U")
+            {
+                uint addr = U.Grep(rom.Data, GrowsModSkillSystemsSignature,
+                    rom.RomInfo.compress_image_borderline_address, 0, 4);
+                // Use the (addr, rom) safety overload — the no-arg isSafetyOffset(addr) reads
+                // CoreState.ROM, which need not be `rom` when a detector runs outside the producer.
+                if (addr != U.NOT_FOUND && U.isSafetyOffset(addr, rom))
+                {
+                    return growth_mod_extends.SkillSystems;
+                }
+            }
+
+            return growth_mod_extends.NO;
+        }
+
+        static growth_mod_extends g_Cache_growth_mod = growth_mod_extends.NoCache;
+
+        public static void ClearCacheGrowsMod()
+        {
+            g_Cache_growth_mod = growth_mod_extends.NoCache;
+        }
+
+        /// <summary>Ambient-ROM overload (cached). Reads <see cref="CoreState.ROM"/>.</summary>
+        public static growth_mod_extends SearchGrowsMod()
+        {
+            if (g_Cache_growth_mod == growth_mod_extends.NoCache)
+            {
+                g_Cache_growth_mod = SearchGrowsMod(CoreState.ROM);
+            }
+            return g_Cache_growth_mod;
+        }
     }
 }

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -647,6 +647,38 @@ namespace FEBuilderGBA
             progress?.Report("MapExitPoint");
             EmitMapExitPoint(rom, list);
 
+            // ---- slice 2ad: ItemForm (data path; version-agnostic call site) ----
+            // WF calls ItemForm.MakeAllDataLength at U.cs:2431, right after MapExitPoint (2430). It is NOT
+            // a flat StructDescriptor walk: its main IFR (base p32(item_pointer), block item_datasize,
+            // IsDataExists = ItemRule) is followed by TWO per-entry embedded BIN sub-blocks whose SIZES
+            // depend on PatchUtil patch state — StatBooster (12/16/20 via SearchGrowsMod /
+            // ItemUsingExtendsPatch + per-entry +34/+10 reads) and ItemEffectiveness ((count+1) vanilla
+            // vs (count+1)*4 via SearchClassType). A dedicated emitter reproduces it VERBATIM (the
+            // slice-2ad PatchDetection detectors supply the patch state). Its own cancel-check mirrors the
+            // WF DoEvents posture.
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("Item");
+            EmitItem(rom, list);
+
+            // ---- slice 2ad: UnitActionPointerForm (data path; version-agnostic call site) ----
+            // WF calls UnitActionPointerForm.MakeAllDataLength at U.cs:2435. It is an InputFormRef_ASM
+            // function-pointer table whose base = SearchActionPointer() (resolved via the rework gate
+            // PatchDetection.SearchUnitActionReworkPatch — non-rework: RomInfo unitaction_function_pointer
+            // slot; rework: a U.GrepEnd over the ApplyAction.bin config file). A dedicated emitter
+            // reproduces it VERBATIM via the existing EmitAsmPointerTable helper (its own cancel-check
+            // mirrors the WF DoEvents posture).
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
+            progress?.Report("UnitActionPointer");
+            EmitUnitActionPointer(rom, list);
+
             if (ct.IsCancellationRequested)
             {
                 progress?.Report("MakeAllStructPointersList cancelled");
@@ -3723,6 +3755,270 @@ namespace FEBuilderGBA
                 Address.AddPointer(list, p + 8, CalcProcsLengthAndCheck(rom, mapAnime),
                     procName, Address.DataTypeEnum.PROCS);
             }
+        }
+
+        /// <summary>
+        /// <c>ItemForm.MakeAllDataLength</c> (data path, #1261 slice 2ad — WF <c>ItemForm.cs:328</c>).
+        /// Main IFR (base <c>p32(item_pointer)</c>, block <c>item_datasize</c>, IsDataExists = the
+        /// existing <see cref="DataCountRule.ItemRule"/> = <c>ItemForm.Init</c>'s callback verbatim,
+        /// pointerIndexes <c>{12,16}</c>), then per entry TWO embedded BIN sub-blocks whose SIZES depend
+        /// on PatchUtil patch state (reproduced VERBATIM):
+        /// <list type="bullet">
+        ///   <item><b>StatBooster</b> behind <c>p32(addr+12)</c> (only when &gt; 0): 12 bytes (vanilla),
+        ///   16 when <see cref="PatchDetection.SearchGrowsMod"/>==Vennou &amp;&amp; <c>u8(addr+34)==1</c>,
+        ///   20 when GrowsMod==SkillSystems &amp;&amp; <c>u8(addr+34)==1</c>, 20 when
+        ///   <see cref="PatchDetection.ItemUsingExtendsPatch"/>==IER &amp;&amp; <c>(u8(addr+10)&amp;0x80)==0x80</c>.</item>
+        ///   <item><b>ItemEffectiveness</b> behind <c>p32(addr+16)</c> (only when &gt; 0): length =
+        ///   <c>(MakeCriticalClassList(eff).Count + 1)</c> vanilla (block 1, stop at <c>u8==0</c>), OR
+        ///   <c>(MakeCriticalClassList(eff).Count + 1) * 4</c> when
+        ///   <see cref="PatchDetection.SearchClassType"/>==SkillSystems_Rework (block 4, stop at
+        ///   <c>!(u8==0 &amp;&amp; u32!=0)</c>). Both counts are reproduced via <c>getBlockDataCount</c>
+        ///   (EOF-bounded; equals the WF <c>N_InputFormRef.ReInit(eff).MakeList().Count</c> away from EOF).</item>
+        /// </list>
+        /// A wrong StatBooster / effectiveness size relocates the wrong bytes — the FE8U WF-parity harness
+        /// catches it as a Core-extra. All reads bounds-guarded.
+        /// </summary>
+        public static void EmitItem(ROM rom, List<Address> list)
+        {
+            EmitItemAt(rom, list, rom.RomInfo.item_pointer, rom.RomInfo.item_datasize);
+        }
+
+        /// <summary>Item walk from an explicit pointer slot + block size (test seam — lets a synthetic ROM
+        /// supply them without populating RomInfo). See <see cref="EmitItem"/> for the verbatim WF
+        /// reproduction.</summary>
+        public static void EmitItemAt(ROM rom, List<Address> list, uint rawPointer, uint block)
+        {
+            if (rom?.RomInfo == null) return;
+            if (block == 0) return; // getBlockDataCount would never advance — a descriptor bug, not data.
+
+            // WF InputFormRef.Init: BasePointer = toOffset(item_pointer); BaseAddress = p32(BasePointer).
+            // Guard the full slot (pointer+3) before p32 on a truncated/synthetic ROM.
+            uint pointer = U.toOffset(rawPointer);
+            if (!U.isSafetyOffset(pointer + 3, rom))
+            {
+                return;
+            }
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                return;
+            }
+
+            // ItemForm.Init IsDataExists == the existing ItemRule (reproduced once in MakeIsDataExists):
+            // i<=0xff; FE8U checks only isPointerOrNULL(u32(addr+12)); else both +12 and +16.
+            Func<int, uint, bool> itemRule = (i, addr) =>
+            {
+                if (i > 0xff) return false;
+                if (rom.RomInfo.version == 8 && rom.RomInfo.is_multibyte == false)
+                {
+                    return U.isPointerOrNULL(rom.u32(addr + 12));
+                }
+                return U.isPointerOrNULL(rom.u32(addr + 12))
+                    && U.isPointerOrNULL(rom.u32(addr + 16));
+            };
+            uint dataCount = rom.getBlockDataCount(baseAddr, block, itemRule);
+
+            // Main IFR Address (AddressWinForms.AddAddress(list, ifr, "Item", {12,16})).
+            uint length = block * (dataCount + 1);
+            uint mainPointer = U.isSafetyOffset(pointer, rom) ? pointer : U.NOT_FOUND;
+            list.Add(new Address(baseAddr, length, mainPointer, "Item",
+                Address.DataTypeEnum.InputFormRef, block, new uint[] { 12, 16 }));
+
+            // The per-entry SIZE selectors — read once outside the loop (WF reads them once before the
+            // for loop). These wrap the slice-2ad PatchDetection detectors (rom overloads, pure).
+            PatchDetection.class_type_extends effectivenesRework = PatchDetection.SearchClassType(rom);
+            PatchDetection.growth_mod_extends growthmod = PatchDetection.SearchGrowsMod(rom);
+            PatchDetection.ItemUsingExtends_extends itemUsingExtends = PatchDetection.ItemUsingExtendsPatch(rom);
+
+            // Per-entry sub-blocks. getBlockDataCount guarantees addr+block<=Length for i<dataCount, so
+            // (for the common item_datasize >= 36) the +34/+16 reads below are in-bounds; we still guard
+            // each computed read defensively (a tiny synthetic block, or a near-EOF base).
+            uint addrEntry = baseAddr;
+            for (uint i = 0; i < dataCount; i++, addrEntry += block)
+            {
+                // ---- StatBooster (behind p32(addr+12)) ----
+                if (U.isSafetyOffset(addrEntry + 15, rom)) // p32(addr+12) reads addr+12..addr+15
+                {
+                    uint itemStatBonuses = rom.p32(addrEntry + 12);
+                    if (itemStatBonuses > 0)
+                    {
+                        // u8(addr+34) / u8(addr+10) — guard the wider one (addr+34).
+                        uint vennoExtends = U.isSafetyOffset(addrEntry + 34, rom) ? rom.u8(addrEntry + 34) : 0;
+                        uint passivebooster = U.isSafetyOffset(addrEntry + 10, rom) ? rom.u8(addrEntry + 10) : 0;
+                        uint statBonusesSize = 12; // vanilla is 12 bytes.
+                        if (growthmod == PatchDetection.growth_mod_extends.Vennou && vennoExtends == 1)
+                        {
+                            statBonusesSize = 16; // vennou extension is 16 bytes.
+                        }
+                        else if (growthmod == PatchDetection.growth_mod_extends.SkillSystems && vennoExtends == 1)
+                        {
+                            statBonusesSize = 20; // SkillSystems is 20 bytes.
+                        }
+                        else if (itemUsingExtends == PatchDetection.ItemUsingExtends_extends.IER
+                            && ((passivebooster & 0x80) == 0x80))
+                        {
+                            statBonusesSize = 20; // IER is 20 bytes.
+                        }
+
+                        Address.AddAddress(list, itemStatBonuses, statBonusesSize, addrEntry + 12,
+                            "StatBooster " + U.To0xHexString(i), Address.DataTypeEnum.BIN);
+                    }
+                }
+
+                // ---- ItemEffectiveness (behind p32(addr+16)) ----
+                if (U.isSafetyOffset(addrEntry + 19, rom)) // p32(addr+16) reads addr+16..addr+19
+                {
+                    uint itemEffectiveness = rom.p32(addrEntry + 16);
+                    if (itemEffectiveness > 0)
+                    {
+                        uint effOffset = U.toOffset(itemEffectiveness);
+                        if (effectivenesRework == PatchDetection.class_type_extends.SkillSystems_Rework)
+                        {
+                            // ItemEffectivenessSkillSystemsReworkForm.N_Init: block 4, stop when NOT
+                            // (u8(addr)==0 && u32(addr)!=0). length = (count + 1) * 4.
+                            uint cnt = U.isSafetyOffset(effOffset, rom)
+                                ? rom.getBlockDataCount(effOffset, 4, (j, a) =>
+                                    {
+                                        if (rom.u8(a) != 0) return false; // head must be 0
+                                        return rom.u32(a) != 0;
+                                    })
+                                : 0;
+                            Address.AddAddress(list, itemEffectiveness, (cnt + 1) * 4, addrEntry + 16,
+                                "ItemEffectiveness " + U.To0xHexString(i), Address.DataTypeEnum.BIN);
+                        }
+                        else
+                        {
+                            // ItemEffectivenessForm.N_Init: block 1, stop when u8(addr)==0. length = count+1.
+                            uint cnt = U.isSafetyOffset(effOffset, rom)
+                                ? rom.getBlockDataCount(effOffset, 1, (j, a) => rom.u8(a) != 0)
+                                : 0;
+                            Address.AddAddress(list, itemEffectiveness, cnt + 1, addrEntry + 16,
+                                "ItemEffectiveness " + U.To0xHexString(i), Address.DataTypeEnum.BIN);
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// <c>UnitActionPointerForm.MakeAllDataLength</c> (data path, #1261 slice 2ad — WF
+        /// <c>UnitActionPointerForm.cs:88</c>). An <see cref="Address.DataTypeEnum.InputFormRef_ASM"/>
+        /// function-pointer table whose base is <c>SearchActionPointer()</c> (a pointer SLOT, resolved
+        /// via the rework gate <see cref="PatchDetection.SearchUnitActionReworkPatch"/>) and whose block
+        /// is 4. Reproduced VERBATIM via the existing <see cref="EmitAsmPointerTableFrom"/> helper (same
+        /// AddAddress + AddFunctions idiom the other ASM-pointer-table forms use):
+        /// <list type="bullet">
+        ///   <item>base resolution = <see cref="SearchActionPointer"/> (non-rework: RomInfo
+        ///   <c>unitaction_function_pointer</c> SLOT; rework: a <c>U.GrepEnd</c> over the
+        ///   <c>UnitActionRework/.../ApplyAction.bin</c> config file — null-BaseDirectory / missing-file safe);</item>
+        ///   <item>BasePointer = <c>toOffset(slot)</c>, BaseAddress = <c>p32(slot)</c> (the <c>ReInitPointer</c>
+        ///   semantics — identical to <see cref="EmitAsmPointerTable"/>'s pointer-slot resolution);</item>
+        ///   <item>IsDataExists gated on the rework flag VERBATIM: non-rework = <c>isSafetyPointer(u32)</c>;
+        ///   rework = keep <c>0</c> (NULL slot), reject <c>NOT_FOUND</c>, accept
+        ///   <c>isSafetyPointer(u32 &amp; 0x0FFFFFFF)</c>;</item>
+        ///   <item>main IFR length = <c>4*(count+1)</c>, plus one ASM AddFunction per entry.</item>
+        /// </list>
+        /// </summary>
+        public static void EmitUnitActionPointer(ROM rom, List<Address> list)
+        {
+            EmitUnitActionPointerAt(rom, list, SearchActionPointer(rom));
+        }
+
+        /// <summary>UnitActionPointer walk from an explicit base pointer SLOT (test seam — lets a synthetic
+        /// ROM supply the resolved <c>SearchActionPointer()</c> result, including the rework-config path,
+        /// without staging the config tree). See <see cref="EmitUnitActionPointer"/> for the verbatim WF
+        /// reproduction.</summary>
+        public static void EmitUnitActionPointerAt(ROM rom, List<Address> list, uint rawPointerSlot)
+        {
+            if (rom?.RomInfo == null) return;
+
+            bool isRework = PatchDetection.SearchUnitActionReworkPatch(rom);
+
+            // UnitActionPointerForm.Init IsDataExists (block 4), gated on isRework — verbatim.
+            Func<int, uint, bool> isDataExists = (i, addr) =>
+            {
+                uint a = rom.u32(addr);
+                if (isRework == false)
+                {//not reworked
+                    if (U.isSafetyPointer(a, rom))
+                    {
+                        return true;
+                    }
+                }
+                else
+                {//reworked
+                    if (a == U.NOT_FOUND)
+                    {
+                        return false;
+                    }
+                    if (a == 0)
+                    {
+                        return true;
+                    }
+                    if (U.isSafetyPointer(a & 0x0FFFFFFF, rom))
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            };
+
+            // WF: ReInitPointer(SearchActionPointer()) -> BasePointer = toOffset(slot),
+            // BaseAddress = p32(slot). EmitAsmPointerTable performs exactly that resolution from the SLOT
+            // (basePointerField), so feed it the slot and reuse the verbatim AddAddress + AddFunctions shape.
+            EmitAsmPointerTable(rom, list, rawPointerSlot, 4, isDataExists,
+                "UnitActionFunctionPointer", Address.DataTypeEnum.InputFormRef_ASM);
+        }
+
+        /// <summary>
+        /// VERBATIM port of <c>UnitActionPointerForm.SearchActionPointer</c>. Returns the unit-action
+        /// function-pointer table SLOT. Non-rework: the RomInfo <c>unitaction_function_pointer</c> slot.
+        /// Rework (<see cref="PatchDetection.SearchUnitActionReworkPatch"/>): a <c>U.GrepEnd</c> of the
+        /// <c>config/patch2/&lt;ver&gt;/UnitActionRework/UnitActionRework/asm/ApplyAction.bin</c> stream
+        /// from <c>unitaction_function_pointer - 0x100</c> (blocksize 4) — returns 0 if BaseDirectory is
+        /// null / the config file is absent / the signature is not found (the WF behavior: a 0 base emits
+        /// nothing). Headless-config safe.
+        /// </summary>
+        public static uint SearchActionPointer(ROM rom)
+        {
+            if (rom?.RomInfo == null) return 0;
+
+            if (!PatchDetection.SearchUnitActionReworkPatch(rom))
+            {//not reworked
+                return rom.RomInfo.unitaction_function_pointer;
+            }
+
+            // Rework path: read the ApplyAction.bin signature and GrepEnd for the patched table slot.
+            string baseDir = CoreState.BaseDirectory;
+            if (string.IsNullOrEmpty(baseDir))
+            {
+                return 0; // null BaseDirectory -> WF's File.Exists false path -> 0.
+            }
+            string filename = System.IO.Path.Combine(baseDir, "config", "patch2",
+                rom.RomInfo.VersionToFilename, "UnitActionRework", "UnitActionRework", "asm", "ApplyAction.bin");
+            if (!System.IO.File.Exists(filename))
+            {
+                return 0;
+            }
+
+            uint hintAddr = rom.RomInfo.unitaction_function_pointer - 0x100;
+
+            byte[] bin;
+            try
+            {
+                bin = System.IO.File.ReadAllBytes(filename);
+            }
+            catch
+            {
+                return 0; // unreadable handle -> treat as absent (no throw in the producer).
+            }
+            uint addrApplyAction = U.GrepEnd(rom.Data, bin, hintAddr, 0, 4);
+            if (addrApplyAction == U.NOT_FOUND)
+            {
+                return 0;
+            }
+
+            return addrApplyAction;
         }
 
         /// <summary>VERBATIM port of <c>ProcsScriptForm.CalcLengthAndCheck</c>: walk a PROCS (map-anime)
@@ -11398,11 +11694,11 @@ namespace FEBuilderGBA
                 //  the parse + DirectSound-length ports the deferral once thought were MIDI-only.)
                 // embedded sub-pointer / event-scan / CString expansion
                 // (ClassForm + StatusParamForm ported in slice 2c — per-entry MoveCost / CString
-                //  sub-walks. ItemForm STAYS: its StatBooster sub-block SIZE depends on un-ported
-                //  PatchUtil patch detection (SearchGrowsMod / ItemUsingExtendsPatch -> 12/16/20)
-                //  and the ItemEffectiveness rework variant on SearchClassType — a wrong size would
-                //  relocate the wrong bytes, so it must wait until those detectors reach Core.)
-                "ItemForm",
+                //  sub-walks. ItemForm PORTED in slice 2ad — EmitItem: main IFR (ItemRule) + per-entry
+                //  StatBooster BIN whose size (12/16/20) comes from the new Core PatchDetection detectors
+                //  SearchGrowsMod / ItemUsingExtendsPatch + per-entry +34/+10 reads, and ItemEffectiveness
+                //  BIN whose length is (count+1) vanilla vs (count+1)*4 on SearchClassType. The 4 detectors
+                //  now live in PatchDetection.cs.)
                 // (ItemWeaponEffectForm ported in slice 2l — EmitItemWeaponEffect: a flat IFR (base
                 //  p32(item_effect_pointer), block 16, IsDataExists u16==0xFFFF / i>10 && IsEmpty(addr,160)
                 //  — both pure ROM reads) + a per-entry PROCS sub-block behind the embedded pointer at +8,
@@ -11416,12 +11712,14 @@ namespace FEBuilderGBA
                 // (ItemShopForm ported in slice 2g — EmitItemShop walks ItemShopCore.MakeShopList [hensei +
                 //  FE8 worldmap + per-map event-cond OBJECT-slot shops] and emits one BIN Address per shop,
                 //  length = (count of non-zero 2-byte item entries + 1) * 2.)
-                // UnitActionPointerForm STAYS — its base = SearchActionPointer(), gated on
-                //   PatchUtil.SearchUnitActionReworkPatch() (PatchUtil patch detection not in Core).
+                // UnitActionPointerForm PORTED in slice 2ad — EmitUnitActionPointer: an InputFormRef_ASM
+                //   table whose base = SearchActionPointer() (gated on the new Core
+                //   PatchDetection.SearchUnitActionReworkPatch — a thin wrap of the RomInfo
+                //   patch_unitaction_rework_hack delegate; rework path = U.GrepEnd over ApplyAction.bin),
+                //   reproduced via the existing EmitAsmPointerTable helper.
                 // (ItemUsagePointerForm ported in slice 2f — dedicated EmitItemUsagePointer walker over
                 //  the 10 Switch2-gated usage tables, base/count from each xxx_array_switch2_address via
                 //  the Core ItemUsagePointerCore.IsSwitch2Enable + per-entry ASM AddFunction @0.)
-                "UnitActionPointerForm",
                 // (MapChangeForm + MapExitPointForm ported in slice 2g via dedicated per-map walkers:
                 //  EmitMapChange [per map: MapChangeCore.GetMapChangeAddrWhereMapID -> main 12-byte IFR
                 //  {8} + per-entry w*h*2 BIN behind +8] and EmitMapExitPoint [enemy + NPC 4-byte slot

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -3806,13 +3806,19 @@ namespace FEBuilderGBA
 
             // ItemForm.Init IsDataExists == the existing ItemRule (reproduced once in MakeIsDataExists):
             // i<=0xff; FE8U checks only isPointerOrNULL(u32(addr+12)); else both +12 and +16.
+            // getBlockDataCount only guarantees addr+block<=Length; for the vanilla item_datasize (>=20)
+            // the +12/+16 reads are always in-bounds, but a too-small synthetic block could let u32 read
+            // past EOF. Guard the FULL 4-byte read extent first (Copilot PR #1309 review) — a slot whose
+            // u32 window would exceed EOF is "no data" (false), identical to WF on valid item blocks.
             Func<int, uint, bool> itemRule = (i, addr) =>
             {
                 if (i > 0xff) return false;
+                if (!U.isSafetyOffset(addr + 15, rom)) return false; // u32(addr+12) -> addr+12..addr+15
                 if (rom.RomInfo.version == 8 && rom.RomInfo.is_multibyte == false)
                 {
                     return U.isPointerOrNULL(rom.u32(addr + 12));
                 }
+                if (!U.isSafetyOffset(addr + 19, rom)) return false; // u32(addr+16) -> addr+16..addr+19
                 return U.isPointerOrNULL(rom.u32(addr + 12))
                     && U.isPointerOrNULL(rom.u32(addr + 16));
             };
@@ -4001,7 +4007,12 @@ namespace FEBuilderGBA
                 return 0;
             }
 
-            uint hintAddr = rom.RomInfo.unitaction_function_pointer - 0x100;
+            // WF: hintAddr = unitaction_function_pointer - 0x100. Clamp the subtraction so a slot < 0x100
+            // does not underflow to a huge uint (Copilot PR #1309 review). Harmless today (U.Grep returns
+            // NOT_FOUND when start > end) but the clamp keeps the start address well-defined; on every real
+            // FE* ROM the slot is >> 0x100, so this is output-equivalent to WF.
+            uint uafp = rom.RomInfo.unitaction_function_pointer;
+            uint hintAddr = uafp >= 0x100 ? uafp - 0x100 : 0;
 
             byte[] bin;
             try


### PR DESCRIPTION
## Summary
Part of the #1261 ROM-rebuild producer marathon (porting WF `U.MakeAllStructPointersList` form-by-form into cross-platform `RebuildProducerCore`). This slice ports the TWO remaining data-path forms that each gate a struct size / base resolution on a `PatchUtil` detector not yet in Core. After this slice the only data-path remainder is `EventUnitForm(RecycleReserveUnits)` (editor session state); the only ASM remainder is `PatchForm` (epic).

Plan reviewed by Copilot CLI on issue #1308 (both findings addressed — see acceptance below).

## What changed

### 4 PatchDetection detectors (`FEBuilderGBA.Core/PatchDetection.cs`)
| Detector | WF source | Approach |
|---|---|---|
| `SearchUnitActionReworkPatch(rom)` → bool | `PatchUtil.cs:548` | **Delegate-wrap** of the existing Core RomInfo `patch_unitaction_rework_hack(out enable_value)` — `u32(addr)==enable_value`, 4-byte read guarded |
| `SearchGrowsMod(rom)` → {NO, Vennou, SkillSystems} | `PatchUtil.cs:138` | **Byte-table** (Vennou FE8U @ `0x02BA2A`) + **whole-ROM `U.Grep`** of the SkillSystems signature from `compress_image_borderline_address` (reproduces `GrepPatch`) |
| `SearchClassType(rom)` → {NO, SkillSystems_Rework} | `PatchUtil.cs:280` | **Byte-table** — `CompareByte(0x2AAEC)` vs two 8-byte patterns, FE8U-only (version 8 && !is_multibyte) |
| `ItemUsingExtendsPatch(rom)` → {NO, IER} | `PatchUtil.cs:1936` | **Byte-table** — FE8U @ `0x28E80` |

All pure (no UI/globals), `(rom)` + cached ambient overloads, EOF-safe, version-gated exactly at the WF call site, wired into `ClearAllCaches`.

### 2 producer forms (`RebuildProducerCore`)
- **`EmitItem` / `EmitItemAt`** — WF `ItemForm.cs:328` `MakeAllDataLength`. Main IFR (item_pointer / item_datasize / `ItemRule`, PI `{12,16}`); per-entry **StatBooster** BIN size 12/16/20 selected by `SearchGrowsMod` / `ItemUsingExtendsPatch` + per-entry `+34`/`+10` reads (the `if/else-if` priority means Vennou wins over IER); per-entry **ItemEffectiveness** BIN length `(count+1)` vanilla [block 1, `u8!=0`] vs `(count+1)*4` [block 4, `u8==0 && u32!=0`] on `SearchClassType`. Reproduced VERBATIM.
- **`EmitUnitActionPointer` / `EmitUnitActionPointerAt`** (+ `SearchActionPointer`) — WF `UnitActionPointerForm.cs:88` `MakeAllDataLength`. `InputFormRef_ASM` table whose base = `SearchActionPointer()` (non-rework: RomInfo `unitaction_function_pointer` slot; rework: `U.GrepEnd` over `ApplyAction.bin`, null-BaseDirectory/missing-file safe), gated on `SearchUnitActionReworkPatch`; IsDataExists gated on the rework flag verbatim (NOT_FOUND terminates, `0` valid, masked `&0x0FFFFFFF` accepted). Reproduced via the existing `EmitAsmPointerTable` helper.

Both wired into `MakeAllStructPointers` in WF call order and removed from `NotYetPortedRaw`.

## Copilot plan-review acceptance
1. **UnitActionPointer rework predicate** — reproduced verbatim (test `EmitUnitActionPointer_Rework_TreatsZeroAsValidAndMasksPointer`).
2. **StatBooster `if/else if` priority (Vennou wins over IER)** — added the requested overlap test `EmitItem_VennouWinsOverIER_WhenBothPresentAndFlags` asserting **16** (not 20).

## Scope
- Closes #1308
- Part of #1261

## Test plan
- [x] `dotnet build FEBuilderGBA.sln` — 0 errors (WF-parity test in FEBuilderGBA.Tests still compiles)
- [x] PatchDetection tests — 76 pass (per-detector present/absent/wrong-version with planted-signature synthetic ROMs; delegate-derived expected-value plant; Vennou-wins-when-both)
- [x] RebuildProducer tests — 444 pass (EmitItem size matrix incl. Vennou-over-IER → 16, effectiveness vanilla vs rework lengths, near-EOF no-throw, zeroed-ROM safe; EmitUnitActionPointer non-rework / rework-zero-valid-masked / zero-slot; SearchActionPointer non-rework-slot + rework-no-config→0; slice-2ad deferral flips)
- [x] **FE8U WF-parity harness** (`RebuildProducerWFParityTests`, Core ⊆ WF on addr/length/pointer/type) — **PASSES** against the real FE8U ROM, proving the StatBooster/effectiveness sizes and UnitActionPointer base are byte-faithful
- [x] Full Core.Tests run — 4927 pass; the 10 `Skill*`/`SkillSystemsAnime*` failures are the known `config/patch2`-submodule-not-checked-out env failures (identical on origin/master, pass in CI)

## Proof (Core-only — no GUI)
This is a Core-library change (no GUI), so per the workflow non-GUI PRs use test output as proof. The WF-parity harness passing is the load-bearing faithfulness proof:
```
Passed!  - Failed: 0, Passed: 1, Skipped: 0, Total: 1 — RebuildProducerWFParityTests
Passed!  - Failed: 0, Passed: 76 — PatchDetectionTests
Passed!  - Failed: 0, Passed: 444 — RebuildProducer (filter)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]