### PR TITLE
feat(core): ROM-rebuild producer — RecycleReserveUnits faithful headless no-op, data-path COMPLETE (#1261 slice 2ae)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -5305,8 +5305,10 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.Single(list);
                 Assert.Same(sentinel, list[0]);
 
+                // null! — intentionally pass null to the non-nullable param to validate "does not throw"
+                // for the unused ROM argument (the (x, rom) emitter signature parity); keep it CS8625-free.
                 var ex = Record.Exception(() =>
-                    RebuildProducerCore.EmitEventUnitReserveUnits(null, list));
+                    RebuildProducerCore.EmitEventUnitReserveUnits(null!, list));
                 Assert.Null(ex);
                 Assert.Single(list);
             }

--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -1717,8 +1717,10 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.DoesNotContain(gone, notYet);
             }
 
-            // Still deferred (un-ported subsystem) -> must REMAIN. The only data-path remainder after
-            // slice 2ad is EventUnitForm(RecycleReserveUnits) (editor session state — NewAllocData).
+            // slice 2ae ported EventUnitForm(RecycleReserveUnits) as a faithful headless NO-OP
+            // (NewAllocData is GUI session state, always empty on a loaded ROM) -> it must now be GONE.
+            // This COMPLETES the data-path producer; the only remaining deferred form is PatchForm (the
+            // ASM epic, tracked in AsmNotYetPortedRaw — NOT in this data-path list).
             // (FE8SpellMenuExtendsForm ported in slice 2m. EventBattleTalk/Haiku/WorldMapEventPointer/
             //  MonsterWMapProbability ported in slice 2aa. StatusOption + SoundFootSteps in 2d.
             //  UnitFE6 + ItemUsagePointer + AIPerform*/AIMapSetting/Mant/ArenaEnemyWeapon in 2f.
@@ -1726,14 +1728,8 @@ namespace FEBuilderGBA.Core.Tests
             //  + EDStaffRoll + OPPrologue + OPClassFont in 2h. OPClassDemo + OPClassDemoFE7 in 2i.
             //  MapTerrain{BG,Floor}Lookup + MapPointer + ExtraUnit + ExtraUnitFE8U in 2j. SoundRoom +
             //  SongTable + MapSetting in 2r. AIScript + ImageBattleAnime in 2s.
-            //  ItemForm + UnitActionPointerForm in 2ad -> asserted GONE below.)
-            foreach (var kept in new[]
-            {
-                "EventUnitForm(RecycleReserveUnits)",
-            })
-            {
-                Assert.Contains(kept, notYet);
-            }
+            //  ItemForm + UnitActionPointerForm in 2ad. RecycleReserveUnits in 2ae -> all asserted GONE.)
+            Assert.DoesNotContain("EventUnitForm(RecycleReserveUnits)", notYet);
 
             // slice 2s ported AIScriptForm + ImageBattleAnimeForm -> they must now be GONE.
             Assert.DoesNotContain("AIScriptForm", notYet);
@@ -5242,6 +5238,81 @@ namespace FEBuilderGBA.Core.Tests
             finally { CoreState.ROM = savedRom; }
         }
 
+        // ---- EmitEventUnitReserveUnits (slice 2ae): faithful headless NO-OP ----
+        // WF EventUnitForm.RecycleReserveUnits iterates the static NewAllocData list, which is GUI
+        // session state (only CreateNewData via the interactive "NEW" dialog ever Adds to it) and is
+        // ALWAYS empty on a loaded ROM. Core has no NewAllocData mechanism, so the faithful reproduction
+        // appends NOTHING. These tests pin that no-op: a zeroed ROM and a populated synthetic FE8 ROM
+        // (with real EventUnit-looking tables present) must BOTH yield an empty list, and the call must
+        // never append to, reorder, or throw on a pre-populated list.
+
+        [Fact]
+        public void EmitEventUnitReserveUnits_ZeroedRom_EmitsNothing()
+        {
+            var rom = CreateTestRom();
+            var savedRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = rom;
+                var list = new List<Address>();
+                RebuildProducerCore.EmitEventUnitReserveUnits(rom, list);
+                Assert.Empty(list);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitEventUnitReserveUnits_PopulatedSyntheticFE8Rom_EmitsNothing()
+        {
+            // Even with a real-looking EventUnit table planted in the ROM, the producer emits NOTHING
+            // here: WF only recovers reserve regions from the in-memory NewAllocData session list (which
+            // Core never has), NOT from any ROM scan. The ROM-anchored EventUnit data is covered by the
+            // regular RecycleOldUnits scan (EventCond/EventScript), not by this method.
+            var fe8 = MakeVersionedRom("BE8E01");
+            var savedRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = fe8;
+                uint block = fe8.RomInfo.eventunit_data_size;
+                uint scriptPointer = 0x400000;
+                uint unitBase = 0x410000;
+                fe8.write_u32(scriptPointer, Ptr(unitBase));
+                fe8.write_u8(unitBase + 0, 0x10);
+                fe8.write_u8(unitBase + block + 0, 0x11);
+
+                var list = new List<Address>();
+                RebuildProducerCore.EmitEventUnitReserveUnits(fe8, list);
+                Assert.Empty(list);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
+        [Fact]
+        public void EmitEventUnitReserveUnits_DoesNotTouchExistingList_OrThrowOnNullRom()
+        {
+            // Pre-populated list must be left byte-identical (the no-op appends nothing, removes nothing,
+            // reorders nothing); and a null ROM must not throw (the (x, rom) emitter signature parity).
+            var rom = CreateTestRom();
+            var savedRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = rom;
+                var sentinel = new Address(0x1000, 4, U.NOT_FOUND, "sentinel",
+                    Address.DataTypeEnum.BIN);
+                var list = new List<Address> { sentinel };
+
+                RebuildProducerCore.EmitEventUnitReserveUnits(rom, list);
+                Assert.Single(list);
+                Assert.Same(sentinel, list[0]);
+
+                var ex = Record.Exception(() =>
+                    RebuildProducerCore.EmitEventUnitReserveUnits(null, list));
+                Assert.Null(ex);
+                Assert.Single(list);
+            }
+            finally { CoreState.ROM = savedRom; }
+        }
+
         // ---- NotYetPorted coverage delta for slice 2j ----------------------
 
         [Fact]
@@ -5261,7 +5332,9 @@ namespace FEBuilderGBA.Core.Tests
             //  ImageBattleAnimeForm in slice 2s — see GetNotYetPortedForms_DropsSlice2sForms.)
             Assert.DoesNotContain("AIScriptForm", notYet);
             Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
-            Assert.Contains("EventUnitForm(RecycleReserveUnits)", notYet); // NewAllocData = editor session state
+            // (EventUnitForm(RecycleReserveUnits) ported in slice 2ae as a faithful headless NO-OP —
+            //  NewAllocData is GUI session state, always empty on a loaded ROM.)
+            Assert.DoesNotContain("EventUnitForm(RecycleReserveUnits)", notYet);
             // (ItemForm ported in slice 2ad — StatBooster size via the new Core PatchDetection detectors.)
             Assert.DoesNotContain("ItemForm", notYet);
 
@@ -9558,9 +9631,11 @@ namespace FEBuilderGBA.Core.Tests
                 ROM vanilla = BuildWireVanilla();
                 var structList = BuildWireStructList();
 
-                // Data path incomplete (a deferred data-path form), ASM path complete.
+                // Data path incomplete (a synthetic deferred data-path form name — the producer's data
+                // path is in fact complete after slice 2ae, so use a placeholder to drive the incomplete
+                // branch). ASM path complete.
                 var data = new RebuildProducerCore.ProducerResult(
-                    structList, new[] { "EventUnitForm(RecycleReserveUnits)" }, cancelled: false);
+                    structList, new[] { "SomeDeferredDataPathForm" }, cancelled: false);
                 var asm = new RebuildProducerCore.AsmProducerResult(new string[0], cancelled: false);
 
                 using (var tmp = new WireTempDir())
@@ -9569,7 +9644,7 @@ namespace FEBuilderGBA.Core.Tests
                     var ex = Assert.Throws<InvalidOperationException>(() =>
                         RebuildProducerCore.MakeWithProducer(
                             data, asm, modified, vanilla, WIRE_REBUILD_ADDR, manifestPath));
-                    Assert.Contains("EventUnitForm(RecycleReserveUnits)", ex.Message);
+                    Assert.Contains("SomeDeferredDataPathForm", ex.Message);
                     Assert.False(System.IO.File.Exists(manifestPath));
                 }
             }
@@ -10127,12 +10202,11 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("ItemForm", notYet);
             Assert.DoesNotContain("UnitActionPointerForm", notYet);
 
-            // The only data-path remainder (a genuine producer form) is
-            // EventUnitForm(RecycleReserveUnits) — editor session state (NewAllocData). The list also
-            // keeps the ASM-path epic PatchForm(MakePatchStructDataList) and the ASM-only ProcsScriptForm
-            // (whose length helper this data path reuses but whose own table is ASM-path) — both out of
-            // scope for the data-path producer, kept so the coverage gate stays honest.
-            Assert.Contains("EventUnitForm(RecycleReserveUnits)", notYet);
+            // slice 2ae ports EventUnitForm(RecycleReserveUnits) as a faithful headless NO-OP (NewAllocData
+            // is GUI session state, always empty on a loaded ROM) -> it is now GONE. This COMPLETES the
+            // data-path producer: the list keeps ONLY the ASM-path epic PatchForm(MakePatchStructDataList)
+            // (out of scope for the data-path producer, kept so the coverage gate stays honest).
+            Assert.DoesNotContain("EventUnitForm(RecycleReserveUnits)", notYet);
             Assert.Contains("PatchForm(MakePatchStructDataList)", notYet);
         }
 

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -813,6 +813,21 @@ namespace FEBuilderGBA
                 progress?.Report("MakeAllStructPointersList cancelled");
                 return new ProducerResult(list, notYet, cancelled: true);
             }
+            // ---- slice 2ae: EventUnitForm.RecycleReserveUnits (WF U.cs:2485, between
+            // ArenaEnemyWeaponForm and ImageMapActionAnimationForm) — faithful headless NO-OP. WF iterates
+            // EventUnitForm.NewAllocData (GUI session state, always empty on a loaded ROM); the saved
+            // reserve units are recovered by the regular EventUnit scan (RecycleOldUnits via EventCond /
+            // EventScript, already ported). Empirically proven (RebuildProducerWFParityTests) that WF
+            // emits ZERO "NEW EVENT UNIT" entries on the real ROM. Completes the data-path producer
+            // (only PatchForm — the ASM epic — remains). See EmitEventUnitReserveUnits.
+            progress?.Report("EventUnitReserveUnits");
+            EmitEventUnitReserveUnits(rom, list);
+
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("MakeAllStructPointersList cancelled");
+                return new ProducerResult(list, notYet, cancelled: true);
+            }
             progress?.Report("ImageMapActionAnimation");
             EmitImageMapActionAnimation(rom, list);
 
@@ -8321,6 +8336,56 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
+        /// <c>EventUnitForm.RecycleReserveUnits(ref list)</c> (WF <c>EventUnitForm.cs:1746-1755</c>;
+        /// called from the producer in <c>U.MakeAllStructPointersList</c> at <c>U.cs:2485</c>, between
+        /// <c>ArenaEnemyWeaponForm.MakeAllDataLength</c> and
+        /// <c>ImageMapActionAnimationForm.MakeAllDataLength</c>). Reproduced VERBATIM as an explicit,
+        /// documented <b>NO-OP</b> — the faithful headless reproduction, following the
+        /// <see cref="EmitMapLoadFunction"/> precedent (a WF producer call that contributes ZERO Address
+        /// records is reproduced as a no-op rather than "fixed", so the Core rebuild manifest matches the
+        /// app's byte-for-byte).
+        /// <para>
+        /// <b>Why a no-op is faithful (empirically proven, slice 2ae).</b> WF
+        /// <c>RecycleReserveUnits</c> iterates the static field <c>EventUnitForm.NewAllocData</c>
+        /// (<c>EventUnitForm.cs:1660</c>, declared as an EMPTY <c>new List&lt;AddrResult&gt;()</c>) and
+        /// emits one <c>RecycleOldUnitsLow(ref list, "NEW", ..)</c> region per entry. <c>NewAllocData</c>
+        /// is <b>EDITOR SESSION STATE</b>: its ONLY producer is <c>CreateNewData</c>
+        /// (<c>EventUnitForm.cs:1665-1698</c>, line 1689 <c>NewAllocData.Add(..)</c>), which is gated on
+        /// the interactive <c>EventUnitNewAllocForm.ShowDialog()</c> returning <c>DialogResult.OK</c>
+        /// (line 1674) — reachable only from the GUI "NEW" button (<c>NewButton_Click</c>, line 1661).
+        /// The other references only DRAIN it: <c>AppendNoWriteNewData</c> removes saved entries
+        /// (1700-1724), <c>ClearNewData</c> resets it (1725-1728), <c>ReallocUnrelatedData</c> only
+        /// relocates an existing entry's address on an expand event (1029-1038). On any freshly
+        /// loaded/saved ROM <c>NewAllocData</c> is therefore EMPTY → WF emits ZERO entries here. The
+        /// newly-allocated unit regions a prior live session created were SAVED into the ROM and anchored
+        /// by normal pointers; on reload they are recovered by the regular EventUnit scan
+        /// (<c>EventUnitForm.RecycleOldUnits</c>, called from the per-map event-condition scan
+        /// <c>EventCondForm.cs:2748</c> and the event-script scan <c>EventScriptForm.cs:498</c>) — both
+        /// already in the Core producer. Core has NO <c>NewAllocData</c> mechanism at all (it never opens
+        /// the NEW dialog), so emitting anything here would FABRICATE entries WF never emits — corrupting
+        /// the rebuild (the recycle free-list is the complement of the producer list). Hence: no-op.
+        /// </para>
+        /// <para>EMPIRICAL PROOF: the FEBuilderGBA.Tests WF-parity harness
+        /// (<c>RebuildProducerWFParityTests.WinFormsProducer_EmitsNoReserveUnitEntries_OnLoadedRom</c>)
+        /// runs the real WF <c>U.MakeAllStructPointersList</c> on <c>roms/FE8U.gba</c> and asserts ZERO
+        /// entries whose <c>Info</c> starts with <c>"NEW EVENT UNIT"</c> (the exact name
+        /// <c>RecycleOldUnitsLow("NEW", ..)</c> would produce) — confirming WF itself emits nothing here
+        /// on a loaded ROM, so the Core no-op omits nothing real.</para>
+        /// </summary>
+        /// <param name="rom">unused — present for the <c>(x, rom)</c> producer-emitter signature parity.</param>
+        /// <param name="list">unused — VERBATIM no-op: nothing is appended.</param>
+        public static void EmitEventUnitReserveUnits(ROM rom, List<Address> list)
+        {
+            // VERBATIM no-op. See the method doc-comment for the empirical proof: WF
+            // RecycleReserveUnits iterates EventUnitForm.NewAllocData (GUI-session-only; always empty on a
+            // loaded ROM) and so emits ZERO Address records headless. Emitting ANYTHING here would
+            // fabricate entries the WF producer never emits and corrupt the rebuild free-list. Core has no
+            // NewAllocData mechanism, so the faithful reproduction is to append nothing.
+            _ = rom;
+            _ = list;
+        }
+
+        /// <summary>
         /// Reproduces <c>EventUnitForm.RecycleOldUnits(ref list, basename, script_pointer)</c> +
         /// <c>RecycleOldUnitsLow</c> (slice 2j). The WF helper recovers the EVENT-UNIT region behind an
         /// embedded script pointer (the <c>script_pointer</c> field of an ExtraUnit entry): it
@@ -11825,10 +11890,17 @@ namespace FEBuilderGBA
                 //  0x37EE4 + flag BINs @ i*0x14+0x37E10; version==8 && !is_multibyte = FE8U table @ 0x37D88
                 //  block 8). Both expand each entry via EventUnitForm.RecycleOldUnits, reproduced verbatim
                 //  by EmitRecycleOldUnits (an EventUnit IFR + the v8 per-entry COORD BIN sub-blocks — pure
-                //  ROM reads, no Form/disasm). EventUnitForm.RecycleReserveUnits STAYS — it iterates the
-                //  static NewAllocData list, which is EDITOR SESSION STATE (newly-allocated unit regions
-                //  recorded during live editing), NOT a ROM-derived table; it is always empty headless, so
-                //  the producer emits nothing for it — kept listed so the coverage gate stays honest.)
+                //  ROM reads, no Form/disasm). EventUnitForm.RecycleReserveUnits PORTED in slice 2ae as a
+                //  faithful headless NO-OP (EmitEventUnitReserveUnits, MapLoadFunction precedent): it
+                //  iterates the static NewAllocData list, which is EDITOR SESSION STATE (newly-allocated
+                //  unit regions recorded during live editing via the GUI "NEW" button — CreateNewData,
+                //  gated on EventUnitNewAllocForm.ShowDialog), NOT a ROM-derived table; it is ALWAYS empty
+                //  on a loaded ROM, so WF emits ZERO entries here (empirically proven on roms/FE8U.gba by
+                //  RebuildProducerWFParityTests.WinFormsProducer_EmitsNoReserveUnitEntries_OnLoadedRom).
+                //  Saved reserve units are recovered by the regular EventUnit scan (RecycleOldUnits via
+                //  EventCond/EventScript, already ported). Core has no NewAllocData mechanism, so the
+                //  no-op omits nothing real. THIS COMPLETES THE DATA-PATH PRODUCER — only PatchForm (the
+                //  ASM epic, in AsmNotYetPortedRaw) remains.)
                 // (UnitCustomBattleAnimeForm [FE7-only] ported in slice 2ab — EmitUnitCustomBattleAnime: the
                 //  N2 main pointer-table IFR (base unit_custom_battle_anime_pointer, block 4, rule
                 //  i==0?true:isPointer(u32), PI {0}) via AddAddressInstantIFR, then per N2 entry a
@@ -11836,7 +11908,9 @@ namespace FEBuilderGBA
                 //  EmitNestedIfrSub primitive. NO anime-recycle, NO patch detection, NO sub-length — the
                 //  inner IFR's default +blocksize NextAddrCallback makes its getBlockDataCount identical to
                 //  EmitNestedIfrSub's 3-arg walk.)
-                "EventUnitForm(RecycleReserveUnits)",
+                // (EventUnitForm(RecycleReserveUnits) PORTED in slice 2ae as a faithful headless NO-OP —
+                //  EmitEventUnitReserveUnits, removed from this list; see the ExtraUnit comment above. This
+                //  COMPLETES the data-path producer; only PatchForm (the ASM epic) remains.)
                 // monster / world map / ED / support (FE8/FE7/FE6 variants)
                 // (MonsterItemForm + MonsterProbabilityForm ported in slice 2b.
                 //  This sweep ported the CLEAN per-version tables: EDForm [FE8 ×4], EDFE7Form [FE7 ×5],

--- a/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
+++ b/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
@@ -190,17 +190,21 @@ namespace FEBuilderGBA.Tests.Unit
         /// per-entry <c>"NEW EVENT UNIT COORD &lt;i&gt;"</c>). So filtering the WF producer list by
         /// <c>Info.StartsWith("NEW EVENT UNIT")</c> and asserting count==0 directly proves the no-op safe.
         /// </para>
-        /// <para>SKIP-IF-NO-ROM: requires <c>roms/FE8U.gba</c> (gitignored — absent in CI / the worktree;
-        /// present in the user's main checkout, found by walking up to a root that has BOTH the solution
-        /// AND the ROM).</para>
+        /// <para>NO-ROM EARLY-EXIT (reported as Pass): requires <c>roms/FE8U.gba</c> (gitignored — absent
+        /// in CI / the worktree; present in the user's main checkout, found by walking up to a root that
+        /// has BOTH the solution AND the ROM). This project has no SkippableFact package, so — exactly like
+        /// the sibling <see cref="CoreProducer_IsSubsetOf_WinFormsProducer_ForAllPortedForms"/> harness —
+        /// the no-ROM guards <c>return;</c> early and xUnit reports the test as Pass (a silent early-exit,
+        /// NOT a true "skipped" outcome). The empirical proof is therefore only ENFORCED where the ROM is
+        /// present (the user's main checkout, run locally before this slice merged).</para>
         /// </summary>
         [Fact]
         public void WinFormsProducer_EmitsNoReserveUnitEntries_OnLoadedRom()
         {
             string? repoRoot = FindRepoRootWithRom();
-            if (repoRoot == null) return; // no checkout with roms/FE8U.gba reachable — skip
+            if (repoRoot == null) return; // no checkout with roms/FE8U.gba reachable — early-exit (Pass)
             string romPath = Path.Combine(repoRoot, "roms", "FE8U.gba");
-            if (!File.Exists(romPath)) return; // SKIP-IF-NO-ROM (gitignored, absent in CI)
+            if (!File.Exists(romPath)) return; // no ROM (gitignored, absent in CI) — early-exit (Pass)
 
             string savedBaseDir = CoreState.BaseDirectory;
             try
@@ -210,8 +214,8 @@ namespace FEBuilderGBA.Tests.Unit
                 BootstrapWinFormsProgram(repoRoot);
 
                 bool loaded = Program.LoadROM(romPath, "");
-                if (!loaded || Program.ROM == null) return; // skip if the ROM did not load
-                if (Program.ROM.RomInfo.version != 8) return; // calibrated on FE8U
+                if (!loaded || Program.ROM == null) return; // ROM did not load — early-exit (Pass)
+                if (Program.ROM.RomInfo.version != 8) return; // calibrated on FE8U — early-exit (Pass)
 
                 // The full WF data-path producer (the parity reference). It DOES call
                 // EventUnitForm.RecycleReserveUnits(ref list) at U.cs:2485.

--- a/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
+++ b/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
@@ -174,6 +174,74 @@ namespace FEBuilderGBA.Tests.Unit
             }
         }
 
+        /// <summary>
+        /// EMPIRICAL PROOF for #1261 slice 2ae: the WinForms producer
+        /// (<c>U.MakeAllStructPointersList</c>) emits ZERO <c>EventUnitForm.RecycleReserveUnits</c>
+        /// entries on a freshly-loaded ROM — confirming the Core
+        /// <see cref="RebuildProducerCore.EmitEventUnitReserveUnits"/> no-op omits nothing real.
+        /// <para>
+        /// <c>RecycleReserveUnits</c> (EventUnitForm.cs:1746) iterates the static
+        /// <c>EventUnitForm.NewAllocData</c> list (EventUnitForm.cs:1660, declared EMPTY); its ONLY
+        /// producer is the interactive "NEW" button (<c>CreateNewData</c> → <c>NewAllocData.Add</c>,
+        /// EventUnitForm.cs:1689, gated on <c>EventUnitNewAllocForm.ShowDialog()==OK</c>). On a loaded ROM
+        /// with no live NEW clicks, <c>NewAllocData</c> is empty, so <c>RecycleReserveUnits</c> emits
+        /// nothing. Each entry it WOULD emit goes through <c>RecycleOldUnitsLow(ref list, "NEW", ..)</c>
+        /// (EventUnitForm.cs:1776), whose <c>Info</c> is <c>"NEW" + " EVENT UNIT"</c> (and, on FE8,
+        /// per-entry <c>"NEW EVENT UNIT COORD &lt;i&gt;"</c>). So filtering the WF producer list by
+        /// <c>Info.StartsWith("NEW EVENT UNIT")</c> and asserting count==0 directly proves the no-op safe.
+        /// </para>
+        /// <para>SKIP-IF-NO-ROM: requires <c>roms/FE8U.gba</c> (gitignored — absent in CI / the worktree;
+        /// present in the user's main checkout, found by walking up to a root that has BOTH the solution
+        /// AND the ROM).</para>
+        /// </summary>
+        [Fact]
+        public void WinFormsProducer_EmitsNoReserveUnitEntries_OnLoadedRom()
+        {
+            string? repoRoot = FindRepoRootWithRom();
+            if (repoRoot == null) return; // no checkout with roms/FE8U.gba reachable — skip
+            string romPath = Path.Combine(repoRoot, "roms", "FE8U.gba");
+            if (!File.Exists(romPath)) return; // SKIP-IF-NO-ROM (gitignored, absent in CI)
+
+            string savedBaseDir = CoreState.BaseDirectory;
+            try
+            {
+                CoreState.BaseDirectory = repoRoot;
+                ForceCommandLineMode();
+                BootstrapWinFormsProgram(repoRoot);
+
+                bool loaded = Program.LoadROM(romPath, "");
+                if (!loaded || Program.ROM == null) return; // skip if the ROM did not load
+                if (Program.ROM.RomInfo.version != 8) return; // calibrated on FE8U
+
+                // The full WF data-path producer (the parity reference). It DOES call
+                // EventUnitForm.RecycleReserveUnits(ref list) at U.cs:2485.
+                List<Address> wf = U.MakeAllStructPointersList(false);
+                Assert.NotEmpty(wf);
+
+                // RecycleReserveUnits → RecycleOldUnitsLow(ref list, "NEW", ..) names every entry
+                // "NEW EVENT UNIT" (+ FE8 "NEW EVENT UNIT COORD <i>"). On a loaded ROM NewAllocData is
+                // empty, so there must be ZERO such entries. A non-zero count would mean WF CAN emit
+                // reserve-unit entries from a loaded ROM — which would make the Core no-op UNSAFE.
+                var reserveEntries = wf
+                    .Where(a => a.Info != null && a.Info.StartsWith("NEW EVENT UNIT", StringComparison.Ordinal))
+                    .ToList();
+
+                Assert.True(reserveEntries.Count == 0,
+                    $"EMPIRICAL PROOF FAILED: the WinForms producer emitted {reserveEntries.Count} "
+                    + "RecycleReserveUnits entr"
+                    + (reserveEntries.Count == 1 ? "y" : "ies")
+                    + " (Info starts with \"NEW EVENT UNIT\") on a freshly-loaded ROM. This means "
+                    + "EventUnitForm.NewAllocData was NOT empty on load, so the Core "
+                    + "EmitEventUnitReserveUnits no-op is NOT a faithful reproduction. First few: "
+                    + string.Join("; ", reserveEntries.Take(5).Select(a =>
+                        $"[{a.Info}] Addr=0x{a.Addr:X} Len=0x{a.Length:X}")));
+            }
+            finally
+            {
+                CoreState.BaseDirectory = savedBaseDir;
+            }
+        }
+
         // ----------------------------------------------------------------
         readonly struct Key : IEquatable<Key>
         {
@@ -251,6 +319,29 @@ namespace FEBuilderGBA.Tests.Unit
             for (int i = 0; i < 12 && dir != null; i++)
             {
                 if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln"))) return dir;
+                dir = Path.GetDirectoryName(dir);
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Like <see cref="FindRepoRoot"/> but walks up to a root that has BOTH the solution AND
+        /// <c>roms/FE8U.gba</c>. The worktree root has the solution but NOT the gitignored ROM, so a
+        /// plain <c>FindRepoRoot</c> would resolve to the worktree and skip; the ROM lives in the user's
+        /// main checkout, which is an ancestor of the worktree (<c>&lt;main&gt;/.claude/worktrees/X</c>).
+        /// Walking up to the first ancestor that has both lets the slice-2ae empirical proof actually run
+        /// locally while still cleanly skipping in CI (where no ancestor has the ROM).
+        /// </summary>
+        static string? FindRepoRootWithRom()
+        {
+            string? dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            for (int i = 0; i < 16 && dir != null; i++)
+            {
+                if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln"))
+                    && File.Exists(Path.Combine(dir, "roms", "FE8U.gba")))
+                {
+                    return dir;
+                }
                 dir = Path.GetDirectoryName(dir);
             }
             return null;


### PR DESCRIPTION
## Summary

Resolves the LAST real data-path producer form in the #1261 marathon — `EventUnitForm(RecycleReserveUnits)` — as an explicit, documented **faithful headless NO-OP**, after empirically proving it is safe. **This COMPLETES the data-path producer**; only `PatchForm` (the ASM epic, tracked in `AsmNotYetPortedRaw`) remains.

Part of #1261.

## The hypothesis — and the empirical proof (HARD GATE, done before porting)

WF `U.MakeAllStructPointersList` (`U.cs:2485`, between `ArenaEnemyWeaponForm` and `ImageMapActionAnimationForm`) calls `EventUnitForm.RecycleReserveUnits(ref list)` (`EventUnitForm.cs:1746-1755`), which iterates the static `EventUnitForm.NewAllocData` list (`EventUnitForm.cs:1660`, declared **empty**).

**Source-reading proof.** `NewAllocData`'s ONLY producer is `CreateNewData` (`EventUnitForm.cs:1689` `NewAllocData.Add`), gated on the interactive `EventUnitNewAllocForm.ShowDialog() == DialogResult.OK` (line 1674), reachable only via the GUI "NEW" button (`NewButton_Click`, line 1661). Every other reference only **drains** it: `AppendNoWriteNewData` removes saved entries (1700-1724), `ClearNewData` resets it (1725-1728), `ReallocUnrelatedData` only relocates an existing entry's address on an expand event (1029-1038). So on any freshly loaded/saved ROM, `NewAllocData` is **empty** → WF emits **zero** entries here.

**Empirical proof.** The FEBuilderGBA.Tests WF-parity harness now runs the real WF `U.MakeAllStructPointersList` on `roms/FE8U.gba` and asserts **zero** entries whose `Info` starts with `"NEW EVENT UNIT"` (the exact name `RecycleOldUnitsLow("NEW", ..)` would produce). **PASSED** — WF itself emits nothing here on a loaded ROM, so the Core no-op omits nothing real.

```
Passed  RebuildProducerWFParityTests.WinFormsProducer_EmitsNoReserveUnitEntries_OnLoadedRom [2 s]
Passed  RebuildProducerWFParityTests.CoreProducer_IsSubsetOf_WinFormsProducer_ForAllPortedForms [1 s]
```

Saved reserve units a prior live session allocated are written into the ROM and anchored by normal pointers; on reload they are recovered by the regular EventUnit scan (`EventUnitForm.RecycleOldUnits`, called from `EventCondForm.cs:2748` and `EventScriptForm.cs:498` — both already in the Core producer). Core has **no** `NewAllocData` mechanism, so the faithful reproduction is a no-op (the `EmitMapLoadFunction` verbatim-no-op precedent). Emitting anything here would fabricate entries WF never emits and corrupt the rebuild (the recycle free-list is the complement of the producer list).

## Changes

- **`RebuildProducerCore`**: add `EmitEventUnitReserveUnits` — explicit, documented no-op; wired into the producer at the WF-faithful order position (between `ArenaEnemyWeapon` and `ImageMapActionAnimation`), with a matching cancel-check. Remove `"EventUnitForm(RecycleReserveUnits)"` from `NotYetPortedRaw`; update the ExtraUnit coverage comment.
- **Core.Tests**: 3 new no-op tests (zeroed ROM, populated synthetic FE8 ROM, list-untouched + null-ROM-no-throw); flip the 3 `NotYetPorted`-delta assertions (slice 2j / 2ad / sweep) from `Contains` → `DoesNotContain`; replace the now-stale synthetic deferred-form fixture string.
- **FEBuilderGBA.Tests**: the WF-parity empirical-proof test, skip-if-no-ROM, walking up to a checkout that has both the solution AND `roms/FE8U.gba`.

## Test plan

- [x] `dotnet build FEBuilderGBA.sln` — clean (0 errors)
- [x] `dotnet test FEBuilderGBA.Core.Tests --filter ~RebuildProducer` — **447 passed, 0 failed** (baseline 444 + 3 new no-op tests)
- [x] WF-parity empirical proof `WinFormsProducer_EmitsNoReserveUnitEntries_OnLoadedRom` — **PASSED** on the real FE8U ROM (WF emits 0 `"NEW EVENT UNIT"` entries)
- [x] WF-parity subset `CoreProducer_IsSubsetOf_WinFormsProducer_ForAllPortedForms` — **PASSED** (the new no-op introduced no Core-extra; Core ⊆ WF still holds)
- [x] Full Core.Tests suite — only the ~10 known-env `Skill*` failures (un-checked-out `config/patch2` submodule, identical on `origin/master`; verified `git submodule status config/patch2` shows the leading `-`)

Core-only, no GUI change → no screenshot (per workflow, non-GUI Core PRs use CLI/test output as proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
