### PR TITLE
feat(core): PatchForm producer scaffold — scanner surface + gate + MakePointerIndexes (#1261 s2pf-1)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchScaffoldTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchScaffoldTests.cs
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for RebuildProducerCore slice s2pf-1 (#1261) — the PatchForm producer
+// SCAFFOLD (option-B epic, sub-slice 1 of 11).
+//
+// This slice ports ONLY the foundation of WinForms
+// PatchForm.MakePatchStructDataList (FEBuilderGBA/PatchForm.cs:7126):
+//   - the public scanner surface (PatchHardCodeScanner.{ScanPatchs, LoadPatch,
+//     isCanonicalSkip, CheckIF, ResolvePatchDirectory}) + PatchInstallCore.PatchSt,
+//   - IsMakePatchStructDataListTarget (WF :6841) — pure gate routing,
+//   - MakePointerIndexes (WF :7174) — pure Param-dict parse + order,
+//   - MakePatchStructDataListCore (WF :7126) — orchestrator SKELETON whose six
+//     TYPE arms are NO-OP STUBS (nothing emitted this slice).
+//
+// Coverage:
+//   1. IsMakePatchStructDataListTarget — full truth table matching WF :6841-6887.
+//   2. MakePointerIndexes — parsed offsets/types + iftType (ASM-only / mix / none)
+//      and the preserved Param iteration ORDER.
+//   3. MakePatchStructDataListCore — empty/no-dir patch set emits nothing & does
+//      not throw; a pre-cancelled token returns the partial list without throwing;
+//      the public scanner surface is reachable from the producer assembly.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class RebuildProducerPatchScaffoldTests : IDisposable
+    {
+        readonly ROM _savedRom = CoreState.ROM;
+        readonly string _savedLang = CoreState.Language;
+        readonly string _savedBaseDir = CoreState.BaseDirectory;
+        readonly string _tempDir;
+
+        public RebuildProducerPatchScaffoldTests()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "RebuildProducerPatchScaffold_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDir);
+            CoreState.Language = "en";
+        }
+
+        public void Dispose()
+        {
+            CoreState.ROM = _savedRom;
+            CoreState.Language = _savedLang;
+            CoreState.BaseDirectory = _savedBaseDir;
+            try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, true); } catch { }
+        }
+
+        static ROM MakeVersionedRom(string versionString, int size = 0x0200_0000)
+        {
+            var rom = new ROM();
+            bool ok = rom.LoadLow("fake.gba", new byte[size], versionString);
+            Assert.True(ok, "LoadLow did not recognize version string: " + versionString);
+            return rom;
+        }
+
+        // Build a PatchInstallCore.PatchSt from raw key/value lines (mirrors a real
+        // LoadPatch result). Param iteration order = insertion order, exactly as
+        // PatchHardCodeScanner.LoadPatch produces it.
+        static PatchInstallCore.PatchSt MakePatch(string name, params (string key, string value)[] kv)
+        {
+            var p = new PatchInstallCore.PatchSt
+            {
+                Name = name,
+                PatchFileName = name + ".txt",
+                Param = new Dictionary<string, string>()
+            };
+            foreach (var (key, value) in kv)
+            {
+                p.Param[key] = value;
+            }
+            return p;
+        }
+
+        // ====================================================================
+        // 1. IsMakePatchStructDataListTarget — truth table (WF :6841-6887)
+        // ====================================================================
+
+        // STRUCT: included unless CheckIF == "E".
+        [Theory]
+        [InlineData("STRUCT", "", false, false, true)]
+        [InlineData("STRUCT", "I", false, false, true)]
+        [InlineData("STRUCT", "E", false, false, false)]   // error -> excluded
+        [InlineData("STRUCT", "E", true, true, false)]     // error wins over flags
+        [InlineData("STRUCT", "", true, true, true)]       // isStructOnly does NOT exclude STRUCT
+        // IMAGE: included unless CheckIF == "E" (and only reached when !isStructOnly).
+        [InlineData("IMAGE", "", false, false, true)]
+        [InlineData("IMAGE", "I", false, false, true)]
+        [InlineData("IMAGE", "E", false, false, false)]
+        [InlineData("IMAGE", "", false, true, false)]      // isStructOnly excludes non-STRUCT BEFORE IMAGE check
+        // non STRUCT/IMAGE, not install-only -> always included (when not struct-only).
+        [InlineData("ADDR", "", false, false, true)]
+        [InlineData("ADDR", "E", false, false, true)]      // checkIF ignored when !isInstallOnly
+        [InlineData("BIN", "I", false, false, true)]
+        [InlineData("EA", "", false, false, true)]
+        [InlineData("SWITCH", "", false, false, true)]
+        // isStructOnly excludes every non-STRUCT type.
+        [InlineData("ADDR", "", false, true, false)]
+        [InlineData("BIN", "I", false, true, false)]
+        [InlineData("EA", "", true, true, false)]
+        // isInstallOnly: excluded on "E"; included on "I"; excluded otherwise (non STRUCT/IMAGE).
+        [InlineData("ADDR", "E", true, false, false)]
+        [InlineData("ADDR", "I", true, false, true)]
+        [InlineData("ADDR", "", true, false, false)]       // not installed -> excluded
+        [InlineData("BIN", "", true, false, false)]
+        public void IsMakePatchStructDataListTarget_Matches_WF(
+            string type, string checkIF, bool isInstallOnly, bool isStructOnly, bool expected)
+        {
+            bool actual = RebuildProducerCore.IsMakePatchStructDataListTarget(type, checkIF, isInstallOnly, isStructOnly);
+            Assert.Equal(expected, actual);
+        }
+
+        // ====================================================================
+        // 2. MakePointerIndexes (WF :7174) — parse + iftType + ORDER
+        // ====================================================================
+
+        [Fact]
+        public void MakePointerIndexes_NoAsm_DataOnly_InputFormRef()
+        {
+            // Two non-ASM pointer fields + a non-P key that must be ignored.
+            var patch = MakePatch("p",
+                ("TYPE", "STRUCT"),
+                ("P0:POINTER", "0x100"),
+                ("BLOCKSIZE", "4"),
+                ("P1:POINTER", "0x200"));
+
+            uint[] idx = RebuildProducerCore.MakePointerIndexes(patch, out string[] types, out Address.DataTypeEnum ift);
+
+            Assert.Equal(new uint[] { 0, 1 }, idx);
+            Assert.Equal(new[] { "POINTER", "POINTER" }, types);
+            Assert.Equal(Address.DataTypeEnum.InputFormRef, ift);
+        }
+
+        [Fact]
+        public void MakePointerIndexes_AsmOnly_InputFormRef_ASM()
+        {
+            var patch = MakePatch("p",
+                ("TYPE", "STRUCT"),
+                ("P0:ASM", "0x100"),
+                ("P2:ASM", "0x200"));
+
+            uint[] idx = RebuildProducerCore.MakePointerIndexes(patch, out string[] types, out Address.DataTypeEnum ift);
+
+            Assert.Equal(new uint[] { 0, 2 }, idx);
+            Assert.Equal(new[] { "ASM", "ASM" }, types);
+            Assert.Equal(Address.DataTypeEnum.InputFormRef_ASM, ift);
+        }
+
+        [Fact]
+        public void MakePointerIndexes_AsmAndData_InputFormRef_MIX()
+        {
+            var patch = MakePatch("p",
+                ("TYPE", "STRUCT"),
+                ("P0:ASM", "0x100"),
+                ("P1:POINTER", "0x200"));
+
+            uint[] idx = RebuildProducerCore.MakePointerIndexes(patch, out string[] types, out Address.DataTypeEnum ift);
+
+            Assert.Equal(new uint[] { 0, 1 }, idx);
+            Assert.Equal(new[] { "ASM", "POINTER" }, types);
+            Assert.Equal(Address.DataTypeEnum.InputFormRef_MIX, ift);
+        }
+
+        [Fact]
+        public void MakePointerIndexes_PreservesParamInsertionOrder()
+        {
+            // Insert pointer fields OUT of numeric order: the result MUST follow Param
+            // insertion (Dictionary) order, NOT sorted-by-index. A later per-entry
+            // sub-walk slice maps pointer slots to struct fields in exactly this order.
+            var patch = MakePatch("p",
+                ("TYPE", "STRUCT"),
+                ("P5:POINTER", "0x500"),
+                ("NAME", "ignored"),
+                ("P2:ASM", "0x200"),
+                ("P9:POINTER", "0x900"),
+                ("P0:POINTER", "0x000"));
+
+            uint[] idx = RebuildProducerCore.MakePointerIndexes(patch, out string[] types, out Address.DataTypeEnum ift);
+
+            Assert.Equal(new uint[] { 5, 2, 9, 0 }, idx);             // insertion order, NOT {0,2,5,9}
+            Assert.Equal(new[] { "POINTER", "ASM", "POINTER", "POINTER" }, types);
+            Assert.Equal(Address.DataTypeEnum.InputFormRef_MIX, ift); // P2:ASM + the data fields
+        }
+
+        [Fact]
+        public void MakePointerIndexes_NoPointerFields_Empty_InputFormRef()
+        {
+            var patch = MakePatch("p", ("TYPE", "BIN"), ("ADDRESS", "0x100"));
+            uint[] idx = RebuildProducerCore.MakePointerIndexes(patch, out string[] types, out Address.DataTypeEnum ift);
+
+            Assert.Empty(idx);
+            Assert.Empty(types);
+            Assert.Equal(Address.DataTypeEnum.InputFormRef, ift);
+        }
+
+        // ====================================================================
+        // 3. MakePatchStructDataListCore (WF :7126) — orchestrator skeleton
+        // ====================================================================
+
+        [Fact]
+        public void MakePatchStructDataListCore_NoPatchDir_EmitsNothing_NoThrow()
+        {
+            // BaseDirectory has no config/patch2/<version> tree -> ScanPatchs returns
+            // empty -> the orchestrator does nothing and the list stays empty.
+            CoreState.BaseDirectory = _tempDir; // empty temp dir, no patch tree
+            var fe8 = MakeVersionedRom("BE8E01");
+            CoreState.ROM = fe8;
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.MakePatchStructDataListCore(
+                    fe8, list, isPointerOnly: false, isInstallOnly: false, isStructOnly: false));
+
+            Assert.Null(ex);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void MakePatchStructDataListCore_Version0Rom_EmitsNothing()
+        {
+            // ROMFE0 ("NAZO") -> version 0 -> SafePatchVersionFolder "" -> WF ScanPatchs
+            // version==0 guard equivalent -> empty list. Use a bare ROM (no recognized
+            // version) which RomInfo defaults to version 0.
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(new byte[0x8000]);
+            CoreState.ROM = rom;
+            CoreState.BaseDirectory = _tempDir;
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.MakePatchStructDataListCore(
+                    rom, list, isPointerOnly: false, isInstallOnly: false, isStructOnly: false));
+
+            Assert.Null(ex);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void MakePatchStructDataListCore_WithPatches_StubsEmitNothing_ReportsProgress()
+        {
+            // A real patch tree with two STRUCT patches that PASS the gate. Every TYPE arm
+            // is a NO-OP STUB this slice, so the list MUST stay empty even though the gate
+            // admits the patches. Progress is reported once per admitted patch.
+            string patchDir = Path.Combine(_tempDir, "config", "patch2", "FE8U");
+            Directory.CreateDirectory(patchDir);
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_A.txt"), new[]
+            {
+                "NAME=PatchA",
+                "TYPE=STRUCT",
+                "P0:POINTER=0x100",
+            });
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_B.txt"), new[]
+            {
+                "NAME=PatchB",
+                "TYPE=STRUCT",
+                "P0:POINTER=0x200",
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeVersionedRom("BE8E01");
+            CoreState.ROM = fe8;
+
+            var reports = new List<string>();
+            var progress = new TestProgress(reports.Add);
+
+            var list = new List<Address>();
+            RebuildProducerCore.MakePatchStructDataListCore(
+                fe8, list, isPointerOnly: false, isInstallOnly: false, isStructOnly: false, progress: progress);
+
+            Assert.Empty(list); // STUBS emit nothing this slice
+            // Both STRUCT patches pass the gate, so the per-patch progress fires twice.
+            // (PatchHardCodeScanner.LoadPatch is the leaner Core scanner — it sets only
+            // PatchFileName + Param, NOT Name, so the WF "Check Patch <name>" message has
+            // an empty name here; the orchestrator null-guards it. The report COUNT is the
+            // meaningful gate/loop signal for the scaffold.)
+            Assert.Equal(2, reports.Count);
+            Assert.All(reports, r => Assert.StartsWith("Check Patch ", r));
+        }
+
+        [Fact]
+        public void MakePatchStructDataListCore_CancelToken_ReturnsPartial_NoThrow()
+        {
+            // A pre-cancelled token: WF early-returns the PARTIAL list on the DoEvents
+            // stop-flag (does NOT throw). With one admitted patch, the Core port returns
+            // after the first iteration's cancel check, list still empty (stubs), no throw.
+            string patchDir = Path.Combine(_tempDir, "config", "patch2", "FE8U");
+            Directory.CreateDirectory(patchDir);
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_A.txt"), new[]
+            {
+                "NAME=PatchA",
+                "TYPE=STRUCT",
+                "P0:POINTER=0x100",
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeVersionedRom("BE8E01");
+            CoreState.ROM = fe8;
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.MakePatchStructDataListCore(
+                    fe8, list, isPointerOnly: false, isInstallOnly: false, isStructOnly: false,
+                    progress: null, ct: cts.Token));
+
+            Assert.Null(ex);       // partial-return, never throws on cancel
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void MakePatchStructDataListCore_NullArgs_Throw()
+        {
+            var fe8 = MakeVersionedRom("BE8E01");
+            CoreState.ROM = fe8;
+            Assert.Throws<ArgumentNullException>(() =>
+                RebuildProducerCore.MakePatchStructDataListCore(null, new List<Address>(), false, false, false));
+            Assert.Throws<ArgumentNullException>(() =>
+                RebuildProducerCore.MakePatchStructDataListCore(fe8, null, false, false, false));
+        }
+
+        // ====================================================================
+        // Public scanner surface is reachable from the producer assembly.
+        // ====================================================================
+
+        [Fact]
+        public void PublicScannerSurface_IsReachable()
+        {
+            // ResolvePatchDirectory + ScanPatchs + LoadPatch + isCanonicalSkip + CheckIF
+            // are all public now (s2pf-1). Exercise them end-to-end on a real patch tree.
+            string patchDir = Path.Combine(_tempDir, "config", "patch2", "FE8U");
+            Directory.CreateDirectory(patchDir);
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_A.txt"), new[]
+            {
+                "NAME=PatchA",
+                "TYPE=STRUCT",
+                "CANONICAL_SKIP=0",
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeVersionedRom("BE8E01");
+            CoreState.ROM = fe8;
+
+            string resolved = PatchHardCodeScanner.ResolvePatchDirectory("FE8U");
+            Assert.Equal(patchDir, resolved);
+
+            List<PatchInstallCore.PatchSt> patchs = PatchHardCodeScanner.ScanPatchs(fe8, resolved, "en");
+            Assert.Single(patchs);
+
+            PatchInstallCore.PatchSt p = patchs[0];
+            Assert.False(PatchHardCodeScanner.isCanonicalSkip(p));
+            // No IF lines -> CheckIF passes ("" — not "E").
+            Assert.NotEqual("E", PatchHardCodeScanner.CheckIF(fe8, p));
+
+            // LoadPatch is public too.
+            PatchInstallCore.PatchSt loaded = PatchHardCodeScanner.LoadPatch(
+                fe8, Path.Combine(patchDir, "PATCH_A.txt"), "en");
+            Assert.NotNull(loaded);
+            Assert.Equal("STRUCT", U.at(loaded.Param, "TYPE"));
+        }
+
+        // Minimal IProgress<string> capture.
+        sealed class TestProgress : IProgress<string>
+        {
+            readonly Action<string> _onReport;
+            public TestProgress(Action<string> onReport) { _onReport = onReport; }
+            public void Report(string value) => _onReport(value);
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchScaffoldTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchScaffoldTests.cs
@@ -258,6 +258,38 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void MakePatchStructDataListCore_Version0Rom_WithPatchTreePresent_DoesNotScanRoot()
+        {
+            // Regression for the version-0 root-scan bug (Copilot PR #1311): a no-version
+            // ROM must NOT fall through ResolvePatchDirectory("") -> the config/patch2 ROOT
+            // and recurse EVERY version's PATCH_*.txt. With a fully populated FE8U tree
+            // present under the base dir, the empty-version guard must short-circuit so
+            // NOTHING is scanned (no progress reports, empty list).
+            string patchDir = Path.Combine(_tempDir, "config", "patch2", "FE8U");
+            Directory.CreateDirectory(patchDir);
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_A.txt"), new[]
+            {
+                "NAME=PatchA",
+                "TYPE=STRUCT",
+                "P0:POINTER=0x100",
+            });
+
+            var rom = new ROM(); // unrecognized -> version 0 -> SafePatchVersionFolder ""
+            rom.SwapNewROMDataDirect(new byte[0x8000]);
+            CoreState.ROM = rom;
+            CoreState.BaseDirectory = _tempDir;
+
+            var reports = new List<string>();
+            var list = new List<Address>();
+            RebuildProducerCore.MakePatchStructDataListCore(
+                rom, list, isPointerOnly: false, isInstallOnly: false, isStructOnly: false,
+                progress: new TestProgress(reports.Add));
+
+            Assert.Empty(list);     // guard short-circuits before any directory walk
+            Assert.Empty(reports);  // NO patch was scanned -> no per-patch progress
+        }
+
+        [Fact]
         public void MakePatchStructDataListCore_WithPatches_StubsEmitNothing_ReportsProgress()
         {
             // A real patch tree with two STRUCT patches that PASS the gate. Every TYPE arm

--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchScaffoldTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchScaffoldTests.cs
@@ -51,7 +51,9 @@ namespace FEBuilderGBA.Core.Tests
             try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, true); } catch { }
         }
 
-        static ROM MakeVersionedRom(string versionString, int size = 0x0200_0000)
+        // 16 MiB is the FE8 LoadLow minimum (Rom.cs requires >= 0x0100_0000); keeping it
+        // at the minimum cuts per-test allocation/GC pressure vs a 32 MiB buffer.
+        static ROM MakeVersionedRom(string versionString, int size = 0x0100_0000)
         {
             var rom = new ROM();
             bool ok = rom.LoadLow("fake.gba", new byte[size], versionString);
@@ -202,6 +204,16 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Equal(new uint[] { 3 }, idx);
             Assert.Equal(new[] { "POINTER" }, types);
             Assert.Equal(Address.DataTypeEnum.InputFormRef, ift);
+        }
+
+        [Fact]
+        public void MakePointerIndexes_NullPatchOrParam_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                RebuildProducerCore.MakePointerIndexes(null, out _, out _));
+            var noParam = new PatchInstallCore.PatchSt { Name = "p", PatchFileName = "p.txt", Param = null };
+            Assert.Throws<ArgumentNullException>(() =>
+                RebuildProducerCore.MakePointerIndexes(noParam, out _, out _));
         }
 
         [Fact]

--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchScaffoldTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchScaffoldTests.cs
@@ -188,6 +188,23 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void MakePointerIndexes_MalformedShortKey_SkippedWithoutThrow()
+        {
+            // A 1-char key (e.g. a malformed "P=..." line) must NOT crash on key[1];
+            // it is skipped. A valid pointer field after it is still collected.
+            var patch = MakePatch("p",
+                ("TYPE", "STRUCT"),
+                ("P", "0x100"),            // malformed: length 1 -> skipped (no IndexOutOfRange)
+                ("P3:POINTER", "0x300"));
+
+            uint[] idx = RebuildProducerCore.MakePointerIndexes(patch, out string[] types, out Address.DataTypeEnum ift);
+
+            Assert.Equal(new uint[] { 3 }, idx);
+            Assert.Equal(new[] { "POINTER" }, types);
+            Assert.Equal(Address.DataTypeEnum.InputFormRef, ift);
+        }
+
+        [Fact]
         public void MakePointerIndexes_NoPointerFields_Empty_InputFormRef()
         {
             var patch = MakePatch("p", ("TYPE", "BIN"), ("ADDRESS", "0x100"));

--- a/FEBuilderGBA.Core/PatchHardCodeScanner.cs
+++ b/FEBuilderGBA.Core/PatchHardCodeScanner.cs
@@ -22,20 +22,16 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+// Unify the scanner's patch record onto the public WinForms-mirror type so the
+// #1261 producer can consume ScanPatchs/LoadPatch results and iterate patch.Param
+// without a private nested type. The scanner only sets PatchFileName + Param and
+// reads only those two fields, so the existing ScanHardCodes behaviour is unchanged.
+using PatchSt = FEBuilderGBA.PatchInstallCore.PatchSt;
 
 namespace FEBuilderGBA
 {
     public static class PatchHardCodeScanner
     {
-        /// <summary>
-        /// A minimal patch record — mirrors the WinForms PatchForm.PatchSt
-        /// fields the hardcode scan actually consumes (PatchFileName + Param).
-        /// </summary>
-        sealed class PatchSt
-        {
-            public string PatchFileName = "";
-            public Dictionary<string, string> Param = new Dictionary<string, string>();
-        }
 
         /// <summary>
         /// Scan all PATCH_*.txt files for the loaded ROM version and populate the
@@ -152,7 +148,10 @@ namespace FEBuilderGBA
         }
 
         // ---- ScanPatchs (~:107) -------------------------------------------------
-        static List<PatchSt> ScanPatchs(ROM rom, string path, string lang)
+        // PUBLIC for the #1261 ROM-rebuild producer (s2pf-1): the producer's
+        // MakePatchStructDataListCore orchestrator calls this with the rom + the
+        // ResolvePatchDirectory(version) path + language. Body unchanged.
+        public static List<PatchSt> ScanPatchs(ROM rom, string path, string lang)
         {
             var patchs = new List<PatchSt>();
             if (string.IsNullOrEmpty(path) || !Directory.Exists(path)) return patchs;
@@ -177,7 +176,8 @@ namespace FEBuilderGBA
         }
 
         // ---- LoadPatch (~:247) --------------------------------------------------
-        static PatchSt LoadPatch(ROM rom, string fullfilename, string lang)
+        // PUBLIC for the #1261 producer (s2pf-1). Body unchanged.
+        public static PatchSt LoadPatch(ROM rom, string fullfilename, string lang)
         {
             string[] lines;
             try
@@ -191,7 +191,9 @@ namespace FEBuilderGBA
 
             bool canSecondLanguageEnglish = U.CanSecondLanguageEnglish(lang);
 
-            var p = new PatchSt { PatchFileName = fullfilename };
+            // PatchInstallCore.PatchSt does not default-init Param (the former private
+            // nested record did), so initialize it explicitly to preserve behaviour.
+            var p = new PatchSt { PatchFileName = fullfilename, Param = new Dictionary<string, string>() };
 
             for (int i = 0; i < lines.Length; i++)
             {
@@ -267,7 +269,8 @@ namespace FEBuilderGBA
         }
 
         // ---- isCanonicalSkip (~:6889) ------------------------------------------
-        static bool isCanonicalSkip(PatchSt patch)
+        // PUBLIC for the #1261 producer (s2pf-1). Body unchanged.
+        public static bool isCanonicalSkip(PatchSt patch)
         {
             string v = U.at(patch.Param, "CANONICAL_SKIP", "0");
             return U.stringbool(v);
@@ -278,7 +281,11 @@ namespace FEBuilderGBA
         // missing), "I" (installed), or "" (passes). MakeHardCodeWarning only
         // skips on "E". The WinForms CacheCheckIF side-table is irrelevant to the
         // gate result, so it is intentionally omitted here.
-        static string CheckIF(ROM rom, PatchSt patch)
+        // PUBLIC for the #1261 producer (s2pf-1): the orchestrator gates patches with
+        // this (the WF MakePatchStructDataList path uses CheckIFFast, whose only
+        // difference is the CacheCheckIF side-table — irrelevant to the gate result,
+        // already documented as intentionally omitted above). Body unchanged.
+        public static string CheckIF(ROM rom, PatchSt patch)
         {
             foreach (var pair in patch.Param)
             {

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -12251,8 +12251,9 @@ namespace FEBuilderGBA
         ///   <item>non-STRUCT while <paramref name="isStructOnly"/>: excluded.</item>
         ///   <item>IMAGE: included unless CheckIF == "E".</item>
         ///   <item>otherwise (non STRUCT/IMAGE) while <paramref name="isInstallOnly"/>:
-        ///   excluded if CheckIF == "E"; if not installed ("I") then excluded unless it is
-        ///   a STRUCT/IMAGE (which by construction it is not at this point, so excluded).</item>
+        ///   excluded if CheckIF == "E"; if NOT installed (CheckIF != "I") then excluded
+        ///   unless it is a STRUCT/IMAGE (which by construction it is not at this point, so
+        ///   excluded). CheckIF "I" = installed (see <see cref="PatchHardCodeScanner.CheckIF"/>).</item>
         ///   <item>else included.</item>
         /// </list>
         /// </summary>
@@ -12338,6 +12339,15 @@ namespace FEBuilderGBA
                 string type = U.at(sp, 1);
                 string value = pair.Value;
 
+                // WF reads key[1] directly (PatchForm.cs:7190). A 1-char key (e.g. a
+                // malformed "P=..." line) would IndexOutOfRange there. Guard the length
+                // and skip — behavior-identical for every valid pointer key (P0..P9, all
+                // length >= 2) and only converts the malformed-key crash into a skip,
+                // honoring the Core "never throws" posture.
+                if (key.Length < 2)
+                {
+                    continue;
+                }
                 if (!U.isnum(key[1]))
                 {
                     continue;
@@ -12422,9 +12432,17 @@ namespace FEBuilderGBA
 
             // WF: ScanPatchs(GetPatchDirectory(), false). GetPatchDirectory() =
             // Program.BaseDirectory/config/patch2/{Program.ROM.RomInfo.VersionToFilename}.
-            // Core threads the rom explicitly: version 0 (no recognized ROM) -> empty patch
-            // dir -> ScanPatchs returns an empty list (matching WF ScanPatchs' version==0 guard).
+            // WF ScanPatchs short-circuits at the TOP: `if (version == 0) return patchs;`.
+            // Reproduce that guard EXPLICITLY here: SafePatchVersionFolder returns "" for
+            // version 0 / no RomInfo, and ResolvePatchDirectory("") would otherwise resolve
+            // to the config/patch2 ROOT and make ScanPatchs recurse EVERY version's
+            // PATCH_*.txt (SearchOption.AllDirectories) — gating in unrelated patches. So a
+            // missing/empty version yields an empty list before any directory walk.
             string version = SafePatchVersionFolder(rom);
+            if (string.IsNullOrEmpty(version))
+            {
+                return;
+            }
             string patchDir = PatchHardCodeScanner.ResolvePatchDirectory(version);
             string lang = CoreState.Language ?? "en";
 

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -12294,6 +12294,10 @@ namespace FEBuilderGBA
                 else if (checkIF != "I")
                 {//インストールされていないので無視したいのだが...
                     //構造体と画像は性質上インストールできない
+                    // NOTE: this STRUCT/IMAGE branch is unreachable (STRUCT and IMAGE already
+                    // return earlier), but it is reproduced VERBATIM from WF PatchForm.cs:6878-6881
+                    // for byte-faithful parity — intentionally NOT pruned so the Core port mirrors
+                    // its WinForms source exactly.
                     if (type == "STRUCT" || type == "IMAGE")
                     {//構造体または画像
                         return true;
@@ -12322,12 +12326,27 @@ namespace FEBuilderGBA
         /// order to map pointer slots to struct fields — a different order corrupts
         /// multi-pointer structs.
         /// </para>
+        /// <para>
+        /// This DELIBERATELY enumerates the shared <c>PatchSt.Param</c>
+        /// <see cref="System.Collections.Generic.Dictionary{TKey,TValue}"/> directly, exactly
+        /// as the WinForms original does — the whole patch pipeline (LoadPatch, CheckIF, the
+        /// per-TYPE emitters) reads the same dict in the same insertion order, so matching WF
+        /// here means matching that enumeration. Substituting an ordered collection would
+        /// DIVERGE from WF and the other Param consumers; the faithful contract is "iterate
+        /// Param as WF iterates it". (.NET preserves Dictionary insertion order absent
+        /// removals, which patch parse never does — both WF and this port depend on that.)
+        /// </para>
         /// </summary>
         public static uint[] MakePointerIndexes(PatchInstallCore.PatchSt patch
             , out string[] out_typeArray
             , out Address.DataTypeEnum out_iftType
             )
         {
+            // Public helper: guard like the other public Core helpers (ArgumentNullException),
+            // rather than NRE inside the foreach, on a null patch / uninitialized Param.
+            if (patch == null) throw new ArgumentNullException(nameof(patch));
+            if (patch.Param == null) throw new ArgumentNullException(nameof(patch) + ".Param");
+
             bool hasASM = false;
             bool hasNoASM = false;
             List<string> typeArray = new List<string>();
@@ -12337,7 +12356,8 @@ namespace FEBuilderGBA
                 string[] sp = pair.Key.Split(':');
                 string key = sp[0];
                 string type = U.at(sp, 1);
-                string value = pair.Value;
+                // (WF also reads pair.Value into an unused local here; the value is not
+                // needed for the index/type parse, so it is not bound in the Core port.)
 
                 // WF reads key[1] directly (PatchForm.cs:7190). A 1-char key (e.g. a
                 // malformed "P=..." line) would IndexOutOfRange there. Guard the length

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -12213,6 +12213,297 @@ namespace FEBuilderGBA
         }
 
         // ====================================================================
+        // PatchForm producer — option-B epic (#1261, sub-slice s2pf-1 of 11).
+        //
+        // SCAFFOLD ONLY. This is the foundation for porting the WinForms
+        // PatchForm.MakePatchStructDataList (FEBuilderGBA/PatchForm.cs:7126) — the
+        // LAST entry in AsmNotYetPortedRaw ("PatchForm(MakePatchStructDataList)").
+        // WF walks the installed-patch tree (config/patch2/{version}/PATCH_*.txt),
+        // gates each patch (CANONICAL_SKIP / CheckIF / IsMakePatchStructDataListTarget),
+        // then dispatches on the patch TYPE to one of six per-TYPE emitters
+        // (ADDR / EA / BIN / SWITCH / STRUCT / IMAGE) that add the patch's known
+        // pointer/struct Addresses to the rebuild manifest.
+        //
+        // THIS SLICE builds the scaffold ONLY — the gate, the pure routing
+        // helpers (IsMakePatchStructDataListTarget, MakePointerIndexes), and the
+        // orchestrator skeleton whose six TYPE arms are documented NO-OP STUBS.
+        // NOTHING is emitted into the manifest yet, and the orchestrator is NOT
+        // wired into AppendAllAsmStructPointers (that wiring is s2pf-11). The gate
+        // token "PatchForm(MakePatchStructDataList)" therefore STAYS in
+        // AsmNotYetPortedRaw and AsmProducerResult.IsComplete stays false — a
+        // rebuild can never consume this half until every TYPE arm lands.
+        //
+        // Public scanner surface this slice exposes (for the later TYPE-arm slices
+        // + the wiring slice): PatchHardCodeScanner.{ScanPatchs, LoadPatch,
+        // isCanonicalSkip, CheckIF, ResolvePatchDirectory} + PatchInstallCore.PatchSt.
+        // (convertBinAddressString stays CheckIF-scoped/private — the producer's own
+        // address resolver is a separate slice s2pf-2.)
+        // ====================================================================
+
+        /// <summary>
+        /// Faithful Core port of WinForms <c>PatchForm.IsMakePatchStructDataListTarget</c>
+        /// (FEBuilderGBA/PatchForm.cs:6841). PURE boolean routing on
+        /// (<paramref name="type"/>, <paramref name="checkIF"/>, <paramref name="isInstallOnly"/>,
+        /// <paramref name="isStructOnly"/>) — no ROM/Form reads. Decides whether a scanned
+        /// patch is a target of the struct-data-list walk:
+        /// <list type="bullet">
+        ///   <item>STRUCT: included unless CheckIF == "E".</item>
+        ///   <item>non-STRUCT while <paramref name="isStructOnly"/>: excluded.</item>
+        ///   <item>IMAGE: included unless CheckIF == "E".</item>
+        ///   <item>otherwise (non STRUCT/IMAGE) while <paramref name="isInstallOnly"/>:
+        ///   excluded if CheckIF == "E"; if not installed ("I") then excluded unless it is
+        ///   a STRUCT/IMAGE (which by construction it is not at this point, so excluded).</item>
+        ///   <item>else included.</item>
+        /// </list>
+        /// </summary>
+        public static bool IsMakePatchStructDataListTarget(string type, string checkIF, bool isInstallOnly, bool isStructOnly)
+        {
+            if (type == "STRUCT")
+            {//構造体
+                if (checkIF == "E")
+                {//エラーがおきているので無視
+                    return false;
+                }
+                return true;
+            }
+            else
+            {//構造体ではない
+                if (isStructOnly)
+                {//構造体以外はダメです
+                    return false;
+                }
+            }
+
+            if (type == "IMAGE")
+            {//画像
+                if (checkIF == "E")
+                {//エラーがおきているので無視
+                    return false;
+                }
+                return true;
+            }
+            //構造体と画像以外
+
+            if (isInstallOnly)
+            {
+                if (checkIF == "E")
+                {//エラーがおきているので無視
+                    return false;
+                }
+                else if (checkIF != "I")
+                {//インストールされていないので無視したいのだが...
+                    //構造体と画像は性質上インストールできない
+                    if (type == "STRUCT" || type == "IMAGE")
+                    {//構造体または画像
+                        return true;
+                    }
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Faithful Core port of WinForms <c>PatchForm.MakePointerIndexes</c>
+        /// (FEBuilderGBA/PatchForm.cs:7174). PURE parse of a patch's <c>Param</c>
+        /// dictionary: collects every <c>P&lt;n&gt;[:type]</c> key into the pointer-index
+        /// array (the parallel <paramref name="out_typeArray"/> records each entry's type),
+        /// and derives the IFR data-type from whether ASM pointers are present
+        /// (ASM-only -> InputFormRef_ASM, ASM+data mix -> InputFormRef_MIX, no-ASM ->
+        /// InputFormRef). No ROM reads.
+        /// <para>
+        /// The <c>patch.Param</c> iteration ORDER is significant and is preserved exactly:
+        /// it is the <see cref="System.Collections.Generic.Dictionary{TKey,TValue}"/>
+        /// insertion order produced by <see cref="PatchHardCodeScanner.LoadPatch"/> (same
+        /// parse loop as WF), so the emitted <c>pointerIndexes</c> visit the patch's pointer
+        /// fields in the same order WF does. A later per-entry sub-walk slice relies on this
+        /// order to map pointer slots to struct fields — a different order corrupts
+        /// multi-pointer structs.
+        /// </para>
+        /// </summary>
+        public static uint[] MakePointerIndexes(PatchInstallCore.PatchSt patch
+            , out string[] out_typeArray
+            , out Address.DataTypeEnum out_iftType
+            )
+        {
+            bool hasASM = false;
+            bool hasNoASM = false;
+            List<string> typeArray = new List<string>();
+            List<uint> pointerIndexes = new List<uint>();
+            foreach (var pair in patch.Param)
+            {
+                string[] sp = pair.Key.Split(':');
+                string key = sp[0];
+                string type = U.at(sp, 1);
+                string value = pair.Value;
+
+                if (!U.isnum(key[1]))
+                {
+                    continue;
+                }
+                int datanum = (int)U.atoi(key.Substring(1));
+
+                if (key[0] == 'P')
+                {
+                    if (type == "ASM")
+                    {
+                        hasASM = true;
+                    }
+                    else
+                    {
+                        hasNoASM = true;
+                    }
+
+                    pointerIndexes.Add((uint)datanum);
+                    typeArray.Add(type);
+                }
+            }
+
+            out_typeArray = typeArray.ToArray();
+
+            if (hasASM)
+            {
+                if (hasNoASM == false)
+                {//ASMだけ
+                    out_iftType = Address.DataTypeEnum.InputFormRef_ASM;
+                }
+                else
+                {//ASMとデータの混在
+                    out_iftType = Address.DataTypeEnum.InputFormRef_MIX;
+                }
+            }
+            else
+            {//ASMを含まない
+                out_iftType = Address.DataTypeEnum.InputFormRef;
+            }
+
+            return pointerIndexes.ToArray();
+        }
+
+        /// <summary>
+        /// SCAFFOLD orchestrator (s2pf-1) for the WinForms
+        /// <c>PatchForm.MakePatchStructDataList</c> (FEBuilderGBA/PatchForm.cs:7126).
+        /// Scans the installed-patch tree for <paramref name="rom"/> and walks each patch
+        /// through the same gate WF uses (<see cref="PatchHardCodeScanner.isCanonicalSkip"/>
+        /// -> <see cref="PatchHardCodeScanner.CheckIF"/> -> <see cref="IsMakePatchStructDataListTarget"/>),
+        /// then dispatches on the patch TYPE.
+        /// <para>
+        /// In THIS slice EVERY per-TYPE arm is a documented NO-OP STUB — nothing is added to
+        /// <paramref name="list"/>. The orchestrator is defined + unit-tested but is NOT wired
+        /// into <see cref="AppendAllAsmStructPointers"/> (wiring = s2pf-11), and
+        /// "PatchForm(MakePatchStructDataList)" stays in <see cref="AsmNotYetPortedRaw"/>.
+        /// </para>
+        /// <para>
+        /// The ROM is passed EXPLICITLY (never CoreState.ROM / Program.ROM): WF reads
+        /// Program.ROM via GetPatchDirectory()/Program.ROM.RomInfo, but the Core port threads
+        /// the rom so headless tests and a future off-thread rebuild use the right instance.
+        /// </para>
+        /// <para>
+        /// Cancellation matches the WF contract: WF's per-patch
+        /// <c>if (InputFormRef.DoEvents(null,msg)) return;</c> early-returns the PARTIALLY
+        /// built list (it does NOT throw). The Core port reports progress and, on a requested
+        /// cancel, returns leaving the partial <paramref name="list"/> intact — it never throws.
+        /// </para>
+        /// </summary>
+        /// <param name="rom">The ROM to scan — passed explicitly (NOT CoreState.ROM).</param>
+        /// <param name="list">The accumulating struct/pointer list (appended to). No-op this slice.</param>
+        /// <param name="isPointerOnly">WF <c>isPointerOnly</c> — forwarded to the (stubbed) TYPE arms.</param>
+        /// <param name="isInstallOnly">WF <c>isInstallOnly</c> — gate input to IsMakePatchStructDataListTarget.</param>
+        /// <param name="isStructOnly">WF <c>isStructOnly</c> — gate input to IsMakePatchStructDataListTarget.</param>
+        /// <param name="progress">Replaces WF's DoEvents message ("Check Patch &lt;name&gt;").</param>
+        /// <param name="ct">Replaces WF's DoEvents stop-flag: on cancel, return the partial list.</param>
+        public static void MakePatchStructDataListCore(ROM rom, List<Address> list,
+            bool isPointerOnly, bool isInstallOnly, bool isStructOnly,
+            IProgress<string> progress = null, CancellationToken ct = default)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (list == null) throw new ArgumentNullException(nameof(list));
+
+            // WF: ScanPatchs(GetPatchDirectory(), false). GetPatchDirectory() =
+            // Program.BaseDirectory/config/patch2/{Program.ROM.RomInfo.VersionToFilename}.
+            // Core threads the rom explicitly: version 0 (no recognized ROM) -> empty patch
+            // dir -> ScanPatchs returns an empty list (matching WF ScanPatchs' version==0 guard).
+            string version = SafePatchVersionFolder(rom);
+            string patchDir = PatchHardCodeScanner.ResolvePatchDirectory(version);
+            string lang = CoreState.Language ?? "en";
+
+            List<PatchInstallCore.PatchSt> patchs = PatchHardCodeScanner.ScanPatchs(rom, patchDir, lang);
+            for (int i = 0; i < patchs.Count; i++)
+            {
+                PatchInstallCore.PatchSt patch = patchs[i];
+
+                if (PatchHardCodeScanner.isCanonicalSkip(patch))
+                {
+                    continue;
+                }
+
+                string type = U.at(patch.Param, "TYPE");
+                // WF uses CheckIFFast; the only difference vs CheckIF is the CacheCheckIF
+                // side-table, which does not change the gate result (documented in
+                // PatchHardCodeScanner). So the Core gate uses CheckIF directly.
+                string checkIF = PatchHardCodeScanner.CheckIF(rom, patch);
+                if (!IsMakePatchStructDataListTarget(type, checkIF, isInstallOnly, isStructOnly))
+                {
+                    continue;
+                }
+
+                if (type == "ADDR")
+                {
+                    // s2pf-3: TYPE=ADDR handler (WF MakePatchStructDataListForADDR @:6213). STUB.
+                }
+                else if (type == "EA")
+                {
+                    // s2pf-4: TYPE=EA handler (WF MakePatchStructDataListForEA @:6259). STUB.
+                }
+                else if (type == "BIN")
+                {
+                    // s2pf-5: TYPE=BIN handler (WF MakePatchStructDataListForBIN @:6317). STUB.
+                }
+                else if (type == "SWITCH")
+                {
+                    // s2pf-6: TYPE=SWITCH handler (WF MakePatchStructDataListForSWITCH @:6425). STUB.
+                }
+                else if (type == "STRUCT")
+                {
+                    // s2pf-7: TYPE=STRUCT handler (WF MakePatchStructDataListForSTRUCT @:6461). STUB.
+                }
+                else if (type == "IMAGE")
+                {
+                    // s2pf-8: TYPE=IMAGE handler (WF MakePatchStructDataListForIMAGE @:6738). STUB.
+                }
+
+                // WF: if (InputFormRef.DoEvents(null,"Check Patch "+patch.Name)) return;
+                // -> report progress, and on a requested cancel RETURN the partial list
+                // (matches WF early-return; does NOT throw). NOTE: the leaner Core scanner
+                // (PatchHardCodeScanner.LoadPatch) sets only PatchFileName + Param, NOT Name,
+                // so patch.Name is null here — this is a COSMETIC progress string only (the
+                // emission arms read patch.Param, never patch.Name), so the null-guard is fine.
+                progress?.Report("Check Patch " + (patch.Name ?? ""));
+                if (ct.IsCancellationRequested) return;
+            }
+        }
+
+        /// <summary>
+        /// Resolve the patch-dir version folder for <paramref name="rom"/> — the Core
+        /// equivalent of the WF <c>GetPatchDirectory()</c> version segment
+        /// (<c>Program.ROM.RomInfo.VersionToFilename</c>), threading the rom explicitly.
+        /// Returns "" for version 0 / no RomInfo, so the resolved patch dir is missing and
+        /// <see cref="PatchHardCodeScanner.ScanPatchs"/> yields an empty list — matching the
+        /// WF <c>ScanPatchs</c> <c>version == 0</c> guard.
+        /// </summary>
+        static string SafePatchVersionFolder(ROM rom)
+        {
+            try
+            {
+                if (rom.RomInfo == null) return "";
+                if (rom.RomInfo.version == 0) return "";
+                return rom.RomInfo.VersionToFilename ?? "";
+            }
+            catch { return ""; }
+        }
+
+        // ====================================================================
         // slice 2z-wire (#1261) — drive RebuildMakeCore.Make from the producers,
         // GATED on IsComplete.
         //


### PR DESCRIPTION
## Summary

First sub-slice (**1/11**) of the **option-B PatchForm epic** for #1261. Builds **only the scaffold** for porting WinForms `PatchForm.MakePatchStructDataList` — the **last** entry in `AsmNotYetPortedRaw` (`"PatchForm(MakePatchStructDataList)"`). **No per-TYPE emission**, and the orchestrator is **not yet wired** into the live producer (wiring = s2pf-11).

**The gate stays closed:** `"PatchForm(MakePatchStructDataList)"` remains in `AsmNotYetPortedRaw`, so `AsmProducerResult.IsComplete` stays `false` and no rebuild can consume this half until every TYPE arm lands.

## Scope (scaffold — 5 pieces)

1. **Public scanner surface** (`PatchHardCodeScanner`): promote `ScanPatchs`, `LoadPatch`, `isCanonicalSkip`, `CheckIF` to `public` (**bodies byte-for-byte unchanged** — only access modifiers). `convertBinAddressString` **stays private/CheckIF-scoped** (the producer's own address resolver is the separate slice s2pf-2). The scanner's private nested `PatchSt` is unified onto the public `PatchInstallCore.PatchSt` so the producer can iterate `patch.Param`.
2. **`PatchInstallCore.PatchSt`** verified public (the WF `PatchForm.PatchSt` mirror).
3. **`IsMakePatchStructDataListTarget`** — faithful port of WF `PatchForm.cs:6841` (pure boolean gate; no ROM/Form reads).
4. **`MakePointerIndexes`** — faithful port of WF `PatchForm.cs:7174` (pure `Param`-dict parse → offset[]/type[]/iftType). The `Param` iteration **ORDER is pinned** to `Dictionary` insertion order — later per-entry sub-walks visit pointer fields in this order.
5. **`MakePatchStructDataListCore`** — orchestrator **skeleton** of WF `PatchForm.cs:7126`: `ScanPatchs(rom, ResolvePatchDirectory(version), lang)` + `isCanonicalSkip` + `CheckIF` + `IsMakePatchStructDataListTarget` gate, then a TYPE switch `{ADDR,EA,BIN,SWITCH,STRUCT,IMAGE}` where **every arm is a documented NO-OP STUB**. ROM is threaded **explicitly** (never `CoreState.ROM`/`Program.ROM`). Cancel **returns the partial list** (matches WF early-return; does not throw).

## Public symbols exposed (API for the next slices)

- `PatchHardCodeScanner.ScanPatchs(ROM, string path, string lang) -> List<PatchInstallCore.PatchSt>`
- `PatchHardCodeScanner.LoadPatch(ROM, string fullfilename, string lang) -> PatchInstallCore.PatchSt`
- `PatchHardCodeScanner.isCanonicalSkip(PatchInstallCore.PatchSt) -> bool`
- `PatchHardCodeScanner.CheckIF(ROM, PatchInstallCore.PatchSt) -> string` ("E" / "I" / "")
- `PatchHardCodeScanner.ResolvePatchDirectory(string version) -> string` (already public)
- `PatchInstallCore.PatchSt` (public; `PatchFileName`, `Name`, `SearchData`, `Date`, `Param`)
- `RebuildProducerCore.IsMakePatchStructDataListTarget(string type, string checkIF, bool isInstallOnly, bool isStructOnly) -> bool`
- `RebuildProducerCore.MakePointerIndexes(PatchInstallCore.PatchSt, out string[] typeArray, out Address.DataTypeEnum iftType) -> uint[]`
- `RebuildProducerCore.MakePatchStructDataListCore(ROM, List<Address>, bool isPointerOnly, bool isInstallOnly, bool isStructOnly, IProgress<string>, CancellationToken)`

## Deferred (with precise blocker)

- **All six TYPE emission arms** (`ADDR`/`EA`/`BIN`/`SWITCH`/`STRUCT`/`IMAGE`) → slices s2pf-3..8 (each ports the WF `MakePatchStructDataListForXxx` helper).
- **Producer-side `convertBinAddressString`** (the wider address-macro resolver) → **s2pf-2** (kept private/CheckIF-scoped here per scope).
- **Wiring `MakePatchStructDataListCore` into `AppendAllAsmStructPointers`** → **s2pf-11**; until then the gate token stays in `AsmNotYetPortedRaw`.
- **`patch.Name` in the progress message** is empty: the leaner `PatchHardCodeScanner.LoadPatch` sets only `PatchFileName` + `Param` (not `Name`). This is a **cosmetic** progress string only (emission arms read `patch.Param`, never `patch.Name`), so the orchestrator null-guards it — no behavior impact.

## WF references

`PatchForm.cs:6841` (gate), `:7174` (MakePointerIndexes), `:7126` (orchestrator).

## Test plan

- [x] `IsMakePatchStructDataListTarget` truth table matching WF 6841-6887 (STRUCT/IMAGE/non-struct, isInstallOnly "E"/"I"/not-installed, isStructOnly excludes non-STRUCT).
- [x] `MakePointerIndexes` — ASM-only → `InputFormRef_ASM`, ASM+data → `InputFormRef_MIX`, no-ASM → `InputFormRef`; non-P keys ignored; empty case; **out-of-order insertion preserves `Param` order** (not sorted-by-index).
- [x] `MakePatchStructDataListCore` — no patch dir → emits nothing, no throw; version-0 ROM → empty; real patch tree → stubs emit nothing, per-patch progress fires; pre-cancelled token → partial return, no throw; null-arg guards.
- [x] Public scanner surface reachable end-to-end (`ResolvePatchDirectory` + `ScanPatchs` + `LoadPatch` + `isCanonicalSkip` + `CheckIF`).
- [x] `dotnet test --filter RebuildProducer` → **479 pass** (447 baseline + 32 new), 0 failed.
- [x] `PatchHardCodeScanner` + `PatchInstallCore` filter → 34 pass, 0 failed (no regression from the `PatchSt` unification).
- [x] `dotnet build FEBuilderGBA.sln` clean (the FEBuilderGBA.Tests WF-parity test still compiles).
- [x] Gate token `"PatchForm(MakePatchStructDataList)"` verified still in `AsmNotYetPortedRaw` (`IsComplete` stays false).

Core-only change (no GUI) — screenshot not applicable; CI/test output is the proof.

Part of #1261.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
