### PR TITLE
feat(core): PatchForm producer address resolver + CalcAddrLength (#1261 s2pf-2)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchResolverTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchResolverTests.cs
@@ -3,7 +3,7 @@
 // address resolver + CalcAddrLength HELPERS (option-B epic, sub-slice 2 of 11).
 //
 // This slice ports the producer-side 4-arg address resolver
-//   RebuildProducerCore.ResolvePatchAddress(rom, addrstring, basedir, appnedSize, startOffset)
+//   RebuildProducerCore.ResolvePatchAddress(rom, addrstring, appnedSize, startOffset, basedir)
 // (a thin wrapper over the read-only Core port PatchMacroAddressResolverCore.Resolve,
 //  the faithful port of WF PatchForm.convertBinAddressString @:3000) and
 //   RebuildProducerCore.CalcAddrLength(patch)
@@ -12,9 +12,10 @@
 // Coverage:
 //   1. ResolvePatchAddress — per-macro-form on a synthetic ROM:
 //        plain hex, $0x deref, $GREP (+ align/skip byte-parity), $P32, $TEXTID,
-//        $XGREP, $GREP_ENABLE_POINTER, and the FAITHFUL carve-outs
-//        ($FREEAREA / $EndWeaponDebuffTable3/4/5 -> NOT_FOUND), plus the
-//        appnedSize-is-irrelevant invariant and the startOffset threading.
+//        $XGREP, $GREP_ENABLE_POINTER, the FAITHFUL $FREEAREA -> NOT_FOUND carve-out,
+//        the PRODUCER-FAITHFUL $EndWeaponDebuffTable3/4/5 bounded scans (NOT carved
+//        out — they are real STRUCT DATACOUNT params), plus the appnedSize-is-irrelevant
+//        invariant and the startOffset threading.
 //   2. CalcAddrLength — COMBO/bytes param strings -> expected length, matching WF.
 //
 // All tests use synthetic in-memory ROMs (rom.LoadLow) so they run without any
@@ -69,7 +70,7 @@ namespace FEBuilderGBA.Core.Tests
         {
             var rom = MakeRom();
             // GBA pointer 0x08001234 -> toOffset -> 0x1234. appnedSize=0, startOffset=0x100 (ADDR).
-            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "0x08001234", "", 0, 0x100);
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "0x08001234", 0, 0x100, "");
             Assert.Equal(0x00001234u, result);
         }
 
@@ -83,7 +84,7 @@ namespace FEBuilderGBA.Core.Tests
             const uint target = 0x2000;
             U.write_u32(rom.Data, slot, U.toPointer(target));
 
-            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$0x1000", "", 0, 0x100);
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$0x1000", 0, 0x100, "");
             Assert.Equal(target, result);
         }
 
@@ -98,7 +99,7 @@ namespace FEBuilderGBA.Core.Tests
             rom.Data[0x2002] = 0xCC;
 
             // SWITCH callsite shape: appnedSize=8, startOffset=0.
-            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xAA 0xBB 0xCC", "", 8, 0);
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xAA 0xBB 0xCC", 8, 0, "");
             Assert.Equal(0x2000u, result);
         }
 
@@ -106,7 +107,7 @@ namespace FEBuilderGBA.Core.Tests
         public void ResolvePatchAddress_Grep_PatternNotPresent_ReturnsNotFound()
         {
             var rom = MakeRom();
-            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xDE 0xAD 0xBE 0xEF", "", 8, 0);
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xDE 0xAD 0xBE 0xEF", 8, 0, "");
             Assert.Equal(U.NOT_FOUND, result);
         }
 
@@ -129,7 +130,7 @@ namespace FEBuilderGBA.Core.Tests
 
             // $GREP4ENDA+6 : align=4 (Groups[2]), ENDA (Groups[3]), skip=6 (Groups[4]).
             // startOffset=struct_address style (use 0x100, below the planted pattern).
-            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP4ENDA+6 0x11 0x22 0x33", "", 8, 0x100);
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP4ENDA+6 0x11 0x22 0x33", 8, 0x100, "");
             Assert.Equal(0x4009u, result);
         }
 
@@ -143,11 +144,11 @@ namespace FEBuilderGBA.Core.Tests
             rom.Data[0x5003] = 0x88;
             rom.Data[0x5004] = 0x99;
 
-            uint aligned4 = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP4 0x77 0x88 0x99", "", 8, 0x100);
+            uint aligned4 = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP4 0x77 0x88 0x99", 8, 0x100, "");
             Assert.Equal(U.NOT_FOUND, aligned4);
 
             // The same pattern WITH align=1 finds it at 0x5002.
-            uint aligned1 = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0x77 0x88 0x99", "", 8, 0x100);
+            uint aligned1 = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0x77 0x88 0x99", 8, 0x100, "");
             Assert.Equal(0x5002u, aligned1);
         }
 
@@ -162,7 +163,7 @@ namespace FEBuilderGBA.Core.Tests
             rom.Data[0x6002] = 0xCC;
 
             // Start search just below 0x6000 so the 0xAA at 0x6000 is the first hit.
-            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$XGREP1 0xAA X 0xCC", "", 8, 0x5FFF);
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$XGREP1 0xAA X 0xCC", 8, 0x5FFF, "");
             Assert.Equal(0x6000u, result);
         }
 
@@ -176,7 +177,7 @@ namespace FEBuilderGBA.Core.Tests
             const uint target = 0x2200u;
             U.write_u32(rom.Data, slot, U.toPointer(target));
 
-            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$P32 0x1100", "", 8, 0);
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$P32 0x1100", 8, 0, "");
             Assert.Equal(target, result);
         }
 
@@ -195,7 +196,7 @@ namespace FEBuilderGBA.Core.Tests
             uint textDataOffset = 0x70000u;
             U.write_u32(rom.Data, textBase + 3 * 4, U.toPointer(textDataOffset));
 
-            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$TEXTID 0x3", "", 0, 0x100);
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$TEXTID 0x3", 0, 0x100, "");
             Assert.Equal(textDataOffset, result);
         }
 
@@ -207,7 +208,7 @@ namespace FEBuilderGBA.Core.Tests
             uint textBase = 0x50000u;
             U.write_u32(rom.Data, textPointerSlot, U.toPointer(textBase));
 
-            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$TEXTID_P 0x5", "", 0, 0x100);
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$TEXTID_P 0x5", 0, 0x100, "");
             Assert.Equal(textBase + 5 * 4, result);
         }
 
@@ -221,31 +222,81 @@ namespace FEBuilderGBA.Core.Tests
             U.write_u32(rom.Data, pStart, U.toPointer(0x80000u)); // valid pointer
             // pStart+4 is zero -> not a pointer -> stop.
 
-            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP_ENABLE_POINTER ", "", 0, pStart);
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP_ENABLE_POINTER ", 0, pStart, "");
             Assert.Equal(pStart + 4, result);
         }
 
-        // ---- FAITHFUL CARVE-OUTS -> NOT_FOUND -------------------------------
+        // ---- FAITHFUL CARVE-OUT -> NOT_FOUND ($FREEAREA only) ---------------
 
         [Fact]
         public void ResolvePatchAddress_FreeArea_ReturnsNotFound()
         {
             var rom = MakeRom();
             // $FREEAREA is the WF run-time allocator (PatchForm.cs:3027 MoveToFreeSapceForm.
-            // SearchFreeSpaceOne) — carved to NOT_FOUND at rebuild time. Test BOTH the
-            // appnedSize==0 and appnedSize!=0 WF callsite shapes: both must be NOT_FOUND.
-            Assert.Equal(U.NOT_FOUND, RebuildProducerCore.ResolvePatchAddress(rom, "$FREEAREA", "", 0, 0x100));
-            Assert.Equal(U.NOT_FOUND, RebuildProducerCore.ResolvePatchAddress(rom, "$FREEAREA", "", 8, 0x100));
+            // SearchFreeSpaceOne) — carved to NOT_FOUND at rebuild time. It never appears as a
+            // producer ADDRESS/POINTER/DATACOUNT param (only BIN/free-area install metadata),
+            // so the carve-out is faithful for the producer. Test BOTH the appnedSize==0 and
+            // appnedSize!=0 WF callsite shapes: both must be NOT_FOUND.
+            Assert.Equal(U.NOT_FOUND, RebuildProducerCore.ResolvePatchAddress(rom, "$FREEAREA", 0, 0x100, ""));
+            Assert.Equal(U.NOT_FOUND, RebuildProducerCore.ResolvePatchAddress(rom, "$FREEAREA", 8, 0x100, ""));
         }
 
-        [Theory]
-        [InlineData("$EndWeaponDebuffTable3 x")]
-        [InlineData("$EndWeaponDebuffTable4 x")]
-        [InlineData("$EndWeaponDebuffTable5 x")]
-        public void ResolvePatchAddress_EndWeaponDebuffTable_ReturnsNotFound(string addrstring)
+        // ---- $EndWeaponDebuffTable3/4/5 — PRODUCER-FAITHFUL bounded scans ----
+        // These ARE real STRUCT DATACOUNT params in FE8U
+        // (config/patch2/FE8U/skill/PATCH_defWeaponDebuffsTable*.txt). WF routes them
+        // through PatchUtil.GetEndWeaponDebuffTable3/4/5 (bounded ROM scans), so the
+        // producer MUST resolve them — NOT_FOUND would silently drop the struct. The
+        // start_offset is the STRUCT struct_address (WF DATACOUNT callsite passes it).
+
+        [Fact]
+        public void ResolvePatchAddress_EndWeaponDebuffTable3_ScansToFirstTerminatorRow()
         {
             var rom = MakeRom();
-            Assert.Equal(U.NOT_FOUND, RebuildProducerCore.ResolvePatchAddress(rom, addrstring, "", 8, 0x100));
+            // struct_address = 0x100000. WF skips the leading 0x00*3 header, then greps for
+            // the FIRST of {000000, FFFF00, FFFFFF} from struct_address+3 within a 3*256 window.
+            const uint structAddr = 0x100000u;
+            // Two non-zero, non-terminator 3-byte rows at +3..+8, then FFFFFF terminator at +9.
+            rom.Data[structAddr + 3] = 0x01; rom.Data[structAddr + 4] = 0x02; rom.Data[structAddr + 5] = 0x03;
+            rom.Data[structAddr + 6] = 0x04; rom.Data[structAddr + 7] = 0x05; rom.Data[structAddr + 8] = 0x06;
+            rom.Data[structAddr + 9] = 0xFF; rom.Data[structAddr + 10] = 0xFF; rom.Data[structAddr + 11] = 0xFF;
+            // (bytes +12.. are zero -> a 000000 row would match at +12, but the FFFFFF row at +9
+            //  is earlier, so the min-found endpoint is structAddr+9.)
+
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$EndWeaponDebuffTable3 0x00", 8, structAddr, "");
+            Assert.Equal(structAddr + 9, result);
+            // The end-delta the STRUCT arm will compute: (end - struct_address) = 9 bytes = 3 rows of DATASIZE=3.
+            Assert.NotEqual(U.NOT_FOUND, result);
+        }
+
+        [Fact]
+        public void ResolvePatchAddress_EndWeaponDebuffTable4_ScansToFirstTerminatorRow()
+        {
+            var rom = MakeRom();
+            // Table4 skips a leading 0x00*4 header (stride 4) before the same terminator grep.
+            const uint structAddr = 0x110000u;
+            // Non-zero rows at +4..+9, then FFFF00 terminator at +10.
+            rom.Data[structAddr + 4] = 0x11; rom.Data[structAddr + 5] = 0x22; rom.Data[structAddr + 6] = 0x33;
+            rom.Data[structAddr + 7] = 0x44; rom.Data[structAddr + 8] = 0x55; rom.Data[structAddr + 9] = 0x66;
+            rom.Data[structAddr + 10] = 0xFF; rom.Data[structAddr + 11] = 0xFF; rom.Data[structAddr + 12] = 0x00;
+
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$EndWeaponDebuffTable4 0x00", 8, structAddr, "");
+            Assert.Equal(structAddr + 10, result);
+        }
+
+        [Fact]
+        public void ResolvePatchAddress_EndWeaponDebuffTable5_WalksUntilHighNibbleSet()
+        {
+            var rom = MakeRom();
+            // Table5: skip leading 0x00*4, then walk u32 rows until byte[+3] high nibble != 0.
+            const uint structAddr = 0x120000u;
+            // Rows from structAddr+4. Each row is 4 bytes; the scan checks rom.u8(addr+3).
+            // Row at +4: [.. .. .. 0x0X] high nibble 0 -> keep going.
+            rom.Data[structAddr + 4 + 3] = 0x05; // high nibble 0 -> continue
+            // Row at +8: [.. .. .. 0x3X]? give it a high nibble != 0 to terminate at +8.
+            rom.Data[structAddr + 8 + 3] = 0x30; // (0x30 & 0xF0) != 0 -> break, return this addr
+
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$EndWeaponDebuffTable5 0x00", 8, structAddr, "");
+            Assert.Equal(structAddr + 8, result);
         }
 
         // ---- appnedSize is IRRELEVANT to the resolved value (invariant) -----
@@ -260,9 +311,9 @@ namespace FEBuilderGBA.Core.Tests
 
             // The only WF branch that read appnedSize ($FREEAREA) is carved out, so every
             // OTHER macro must resolve identically regardless of the appnedSize argument.
-            uint a = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xAA 0xBB 0xCC", "", 0, 0x100);
-            uint b = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xAA 0xBB 0xCC", "", 8, 0x100);
-            uint c = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xAA 0xBB 0xCC", "", 0x1234, 0x100);
+            uint a = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xAA 0xBB 0xCC", 0, 0x100, "");
+            uint b = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xAA 0xBB 0xCC", 8, 0x100, "");
+            uint c = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xAA 0xBB 0xCC", 0x1234, 0x100, "");
             Assert.Equal(0x2000u, a);
             Assert.Equal(a, b);
             Assert.Equal(a, c);
@@ -282,10 +333,10 @@ namespace FEBuilderGBA.Core.Tests
             rom.Data[0x8000] = 0xEE;
             rom.Data[0x8001] = 0xFF;
 
-            uint fromStart = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xEE 0xFF", "", 8, 0x100);
+            uint fromStart = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xEE 0xFF", 8, 0x100, "");
             Assert.Equal(0x3000u, fromStart);
 
-            uint fromMid = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xEE 0xFF", "", 8, 0x4000);
+            uint fromMid = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xEE 0xFF", 8, 0x4000, "");
             Assert.Equal(0x8000u, fromMid);
         }
 
@@ -294,7 +345,7 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void ResolvePatchAddress_NullRom_ReturnsNotFound_NoThrow()
         {
-            uint result = RebuildProducerCore.ResolvePatchAddress(null, "$GREP1 0xAA", "", 0, 0x100);
+            uint result = RebuildProducerCore.ResolvePatchAddress(null, "$GREP1 0xAA", 0, 0x100, "");
             Assert.Equal(U.NOT_FOUND, result);
         }
 
@@ -302,7 +353,7 @@ namespace FEBuilderGBA.Core.Tests
         public void ResolvePatchAddress_EmptyAddrstring_ReturnsNotFound()
         {
             var rom = MakeRom();
-            Assert.Equal(U.NOT_FOUND, RebuildProducerCore.ResolvePatchAddress(rom, "", "", 0, 0x100));
+            Assert.Equal(U.NOT_FOUND, RebuildProducerCore.ResolvePatchAddress(rom, "", 0, 0x100, ""));
         }
 
         // ====================================================================

--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchResolverTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchResolverTests.cs
@@ -1,0 +1,368 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for RebuildProducerCore slice s2pf-2 (#1261) — the PatchForm producer
+// address resolver + CalcAddrLength HELPERS (option-B epic, sub-slice 2 of 11).
+//
+// This slice ports the producer-side 4-arg address resolver
+//   RebuildProducerCore.ResolvePatchAddress(rom, addrstring, basedir, appnedSize, startOffset)
+// (a thin wrapper over the read-only Core port PatchMacroAddressResolverCore.Resolve,
+//  the faithful port of WF PatchForm.convertBinAddressString @:3000) and
+//   RebuildProducerCore.CalcAddrLength(patch)
+// (verbatim port of WF PatchForm.CalcAddrLength @:6197).
+//
+// Coverage:
+//   1. ResolvePatchAddress — per-macro-form on a synthetic ROM:
+//        plain hex, $0x deref, $GREP (+ align/skip byte-parity), $P32, $TEXTID,
+//        $XGREP, $GREP_ENABLE_POINTER, and the FAITHFUL carve-outs
+//        ($FREEAREA / $EndWeaponDebuffTable3/4/5 -> NOT_FOUND), plus the
+//        appnedSize-is-irrelevant invariant and the startOffset threading.
+//   2. CalcAddrLength — COMBO/bytes param strings -> expected length, matching WF.
+//
+// All tests use synthetic in-memory ROMs (rom.LoadLow) so they run without any
+// real GBA ROM file, mirroring PatchMacroAddressResolverCoreTests.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class RebuildProducerPatchResolverTests
+    {
+        // ---- ROM builder (same idiom as PatchMacroAddressResolverCoreTests) ----
+        // 16 MiB zero-filled FE8U ROM (LoadLow minimum for BE8E01).
+        static ROM MakeRom()
+        {
+            var rom = new ROM();
+            byte[] data = new byte[0x1000000];
+            bool ok = rom.LoadLow("x.gba", data, "BE8E01");
+            Assert.True(ok, "LoadLow did not recognize BE8E01");
+            return rom;
+        }
+
+        // Build a PatchSt from raw key/value lines (mirrors a real LoadPatch result).
+        static PatchInstallCore.PatchSt MakePatch(params (string key, string value)[] kv)
+        {
+            var p = new PatchInstallCore.PatchSt
+            {
+                Name = "p",
+                PatchFileName = "p.txt",
+                Param = new Dictionary<string, string>()
+            };
+            foreach (var (key, value) in kv)
+            {
+                p.Param[key] = value;
+            }
+            return p;
+        }
+
+        // ====================================================================
+        // 1. ResolvePatchAddress — per-macro-form
+        // ====================================================================
+
+        // ---- plain hex literal (ADDR callsite uses startOffset=0x100) -------
+
+        [Fact]
+        public void ResolvePatchAddress_PlainHexLiteral_StripsBase()
+        {
+            var rom = MakeRom();
+            // GBA pointer 0x08001234 -> toOffset -> 0x1234. appnedSize=0, startOffset=0x100 (ADDR).
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "0x08001234", "", 0, 0x100);
+            Assert.Equal(0x00001234u, result);
+        }
+
+        // ---- $0x pointer dereference ---------------------------------------
+
+        [Fact]
+        public void ResolvePatchAddress_DollarHexDeref_ReturnsPointedOffset()
+        {
+            var rom = MakeRom();
+            const uint slot = 0x1000;
+            const uint target = 0x2000;
+            U.write_u32(rom.Data, slot, U.toPointer(target));
+
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$0x1000", "", 0, 0x100);
+            Assert.Equal(target, result);
+        }
+
+        // ---- $GREP exact-match (byte tokens use 0xNN) ----------------------
+
+        [Fact]
+        public void ResolvePatchAddress_Grep_FindsExactPattern()
+        {
+            var rom = MakeRom();
+            rom.Data[0x2000] = 0xAA;
+            rom.Data[0x2001] = 0xBB;
+            rom.Data[0x2002] = 0xCC;
+
+            // SWITCH callsite shape: appnedSize=8, startOffset=0.
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xAA 0xBB 0xCC", "", 8, 0);
+            Assert.Equal(0x2000u, result);
+        }
+
+        [Fact]
+        public void ResolvePatchAddress_Grep_PatternNotPresent_ReturnsNotFound()
+        {
+            var rom = MakeRom();
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xDE 0xAD 0xBE 0xEF", "", 8, 0);
+            Assert.Equal(U.NOT_FOUND, result);
+        }
+
+        // ---- $GREP align + skip BYTE-PARITY ---------------------------------
+        // The DATACOUNT end-delta scan uses $GREP<align>ENDA+<skip>. Plant a
+        // pattern at an aligned offset and assert the EXACT endpoint
+        // (= match + pattern length + skip), proving align/skip group parsing
+        // matches WF (a mis-read of Groups[2]/[4] would shift the endpoint and
+        // mis-size the struct).
+
+        [Fact]
+        public void ResolvePatchAddress_GrepAlignSkip_ENDA_ExactEndpoint()
+        {
+            var rom = MakeRom();
+            // Pattern 0x11 0x22 0x33 at 0x4000 (4-aligned). ENDA = address just after
+            // the match; +6 skip => endpoint = 0x4000 + 3 (len) + 6 (skip) = 0x4009.
+            rom.Data[0x4000] = 0x11;
+            rom.Data[0x4001] = 0x22;
+            rom.Data[0x4002] = 0x33;
+
+            // $GREP4ENDA+6 : align=4 (Groups[2]), ENDA (Groups[3]), skip=6 (Groups[4]).
+            // startOffset=struct_address style (use 0x100, below the planted pattern).
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP4ENDA+6 0x11 0x22 0x33", "", 8, 0x100);
+            Assert.Equal(0x4009u, result);
+        }
+
+        [Fact]
+        public void ResolvePatchAddress_GrepAlign_RespectsAlignment()
+        {
+            var rom = MakeRom();
+            // Plant the pattern at a NON-4-aligned offset (0x5002). A 4-aligned GREP
+            // must NOT match it -> NOT_FOUND. This proves Groups[2] (align) is honored.
+            rom.Data[0x5002] = 0x77;
+            rom.Data[0x5003] = 0x88;
+            rom.Data[0x5004] = 0x99;
+
+            uint aligned4 = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP4 0x77 0x88 0x99", "", 8, 0x100);
+            Assert.Equal(U.NOT_FOUND, aligned4);
+
+            // The same pattern WITH align=1 finds it at 0x5002.
+            uint aligned1 = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0x77 0x88 0x99", "", 8, 0x100);
+            Assert.Equal(0x5002u, aligned1);
+        }
+
+        // ---- $XGREP wildcard -----------------------------------------------
+
+        [Fact]
+        public void ResolvePatchAddress_Xgrep_WildcardMatchesAnyByte()
+        {
+            var rom = MakeRom();
+            rom.Data[0x6000] = 0xAA;
+            rom.Data[0x6001] = 0x42; // wildcard slot
+            rom.Data[0x6002] = 0xCC;
+
+            // Start search just below 0x6000 so the 0xAA at 0x6000 is the first hit.
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$XGREP1 0xAA X 0xCC", "", 8, 0x5FFF);
+            Assert.Equal(0x6000u, result);
+        }
+
+        // ---- $P32 -----------------------------------------------------------
+
+        [Fact]
+        public void ResolvePatchAddress_P32_DerefsPointerAtAddress()
+        {
+            var rom = MakeRom();
+            const uint slot = 0x1100u;
+            const uint target = 0x2200u;
+            U.write_u32(rom.Data, slot, U.toPointer(target));
+
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$P32 0x1100", "", 8, 0);
+            Assert.Equal(target, result);
+        }
+
+        // ---- $TEXTID --------------------------------------------------------
+
+        [Fact]
+        public void ResolvePatchAddress_Textid_ReturnsActualTextDataAddress()
+        {
+            var rom = MakeRom();
+            // text_pointer is the base-of-base for $TEXTID; plant the text table base there.
+            uint textPointerSlot = rom.RomInfo.text_pointer;
+            uint textBase = 0x60000u;
+            U.write_u32(rom.Data, textPointerSlot, U.toPointer(textBase));
+
+            // text id 3 -> pointer table entry at textBase + 3*4 -> text data offset
+            uint textDataOffset = 0x70000u;
+            U.write_u32(rom.Data, textBase + 3 * 4, U.toPointer(textDataOffset));
+
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$TEXTID 0x3", "", 0, 0x100);
+            Assert.Equal(textDataOffset, result);
+        }
+
+        [Fact]
+        public void ResolvePatchAddress_TextidP_ReturnsPointerTableEntryAddress()
+        {
+            var rom = MakeRom();
+            uint textPointerSlot = rom.RomInfo.text_pointer;
+            uint textBase = 0x50000u;
+            U.write_u32(rom.Data, textPointerSlot, U.toPointer(textBase));
+
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$TEXTID_P 0x5", "", 0, 0x100);
+            Assert.Equal(textBase + 5 * 4, result);
+        }
+
+        // ---- $GREP_ENABLE_POINTER ------------------------------------------
+
+        [Fact]
+        public void ResolvePatchAddress_GrepEnablePointer_StopsAtFirstNonPointer()
+        {
+            var rom = MakeRom();
+            const uint pStart = 0x1000u;
+            U.write_u32(rom.Data, pStart, U.toPointer(0x80000u)); // valid pointer
+            // pStart+4 is zero -> not a pointer -> stop.
+
+            uint result = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP_ENABLE_POINTER ", "", 0, pStart);
+            Assert.Equal(pStart + 4, result);
+        }
+
+        // ---- FAITHFUL CARVE-OUTS -> NOT_FOUND -------------------------------
+
+        [Fact]
+        public void ResolvePatchAddress_FreeArea_ReturnsNotFound()
+        {
+            var rom = MakeRom();
+            // $FREEAREA is the WF run-time allocator (PatchForm.cs:3027 MoveToFreeSapceForm.
+            // SearchFreeSpaceOne) — carved to NOT_FOUND at rebuild time. Test BOTH the
+            // appnedSize==0 and appnedSize!=0 WF callsite shapes: both must be NOT_FOUND.
+            Assert.Equal(U.NOT_FOUND, RebuildProducerCore.ResolvePatchAddress(rom, "$FREEAREA", "", 0, 0x100));
+            Assert.Equal(U.NOT_FOUND, RebuildProducerCore.ResolvePatchAddress(rom, "$FREEAREA", "", 8, 0x100));
+        }
+
+        [Theory]
+        [InlineData("$EndWeaponDebuffTable3 x")]
+        [InlineData("$EndWeaponDebuffTable4 x")]
+        [InlineData("$EndWeaponDebuffTable5 x")]
+        public void ResolvePatchAddress_EndWeaponDebuffTable_ReturnsNotFound(string addrstring)
+        {
+            var rom = MakeRom();
+            Assert.Equal(U.NOT_FOUND, RebuildProducerCore.ResolvePatchAddress(rom, addrstring, "", 8, 0x100));
+        }
+
+        // ---- appnedSize is IRRELEVANT to the resolved value (invariant) -----
+
+        [Fact]
+        public void ResolvePatchAddress_AppnedSize_DoesNotAffectResult()
+        {
+            var rom = MakeRom();
+            rom.Data[0x2000] = 0xAA;
+            rom.Data[0x2001] = 0xBB;
+            rom.Data[0x2002] = 0xCC;
+
+            // The only WF branch that read appnedSize ($FREEAREA) is carved out, so every
+            // OTHER macro must resolve identically regardless of the appnedSize argument.
+            uint a = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xAA 0xBB 0xCC", "", 0, 0x100);
+            uint b = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xAA 0xBB 0xCC", "", 8, 0x100);
+            uint c = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xAA 0xBB 0xCC", "", 0x1234, 0x100);
+            Assert.Equal(0x2000u, a);
+            Assert.Equal(a, b);
+            Assert.Equal(a, c);
+        }
+
+        // ---- startOffset threading (start_offset narrows the GREP scan) -----
+
+        [Fact]
+        public void ResolvePatchAddress_StartOffset_NarrowsGrepScan()
+        {
+            var rom = MakeRom();
+            // Two copies of the pattern; startOffset above the first hit must skip it
+            // and return the SECOND. This proves startOffset is threaded into the scan
+            // (the WF start_offset arg, e.g. STRUCT DATACOUNT passes struct_address).
+            rom.Data[0x3000] = 0xEE;
+            rom.Data[0x3001] = 0xFF;
+            rom.Data[0x8000] = 0xEE;
+            rom.Data[0x8001] = 0xFF;
+
+            uint fromStart = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xEE 0xFF", "", 8, 0x100);
+            Assert.Equal(0x3000u, fromStart);
+
+            uint fromMid = RebuildProducerCore.ResolvePatchAddress(rom, "$GREP1 0xEE 0xFF", "", 8, 0x4000);
+            Assert.Equal(0x8000u, fromMid);
+        }
+
+        // ---- guards ---------------------------------------------------------
+
+        [Fact]
+        public void ResolvePatchAddress_NullRom_ReturnsNotFound_NoThrow()
+        {
+            uint result = RebuildProducerCore.ResolvePatchAddress(null, "$GREP1 0xAA", "", 0, 0x100);
+            Assert.Equal(U.NOT_FOUND, result);
+        }
+
+        [Fact]
+        public void ResolvePatchAddress_EmptyAddrstring_ReturnsNotFound()
+        {
+            var rom = MakeRom();
+            Assert.Equal(U.NOT_FOUND, RebuildProducerCore.ResolvePatchAddress(rom, "", "", 0, 0x100));
+        }
+
+        // ====================================================================
+        // 2. CalcAddrLength (WF :6197) — COMBO|bytes parse
+        // ====================================================================
+
+        [Fact]
+        public void CalcAddrLength_NoCombo_ReturnsOne()
+        {
+            // No COMBO key -> U.at returns "" -> length 1.
+            var patch = MakePatch(("TYPE", "ADDR"), ("ADDRESS", "0x100"));
+            Assert.Equal(1u, RebuildProducerCore.CalcAddrLength(patch));
+        }
+
+        [Fact]
+        public void CalcAddrLength_EmptyCombo_ReturnsOne()
+        {
+            var patch = MakePatch(("COMBO", ""));
+            Assert.Equal(1u, RebuildProducerCore.CalcAddrLength(patch));
+        }
+
+        [Fact]
+        public void CalcAddrLength_ComboWithoutPipe_ReturnsOne()
+        {
+            // No '|' -> Split yields 1 part (< 2) -> length 1.
+            var patch = MakePatch(("COMBO", "label"));
+            Assert.Equal(1u, RebuildProducerCore.CalcAddrLength(patch));
+        }
+
+        [Fact]
+        public void CalcAddrLength_SingleByteSecondSection_ReturnsOne()
+        {
+            // "name|AA" -> second section "AA" splits to 1 token -> length 1.
+            var patch = MakePatch(("COMBO", "name|AA"));
+            Assert.Equal(1u, RebuildProducerCore.CalcAddrLength(patch));
+        }
+
+        [Fact]
+        public void CalcAddrLength_MultiByteSecondSection_ReturnsTokenCount()
+        {
+            // "name|AA BB CC CD" -> second section has 4 space-separated tokens -> length 4.
+            var patch = MakePatch(("COMBO", "name|AA BB CC CD"));
+            Assert.Equal(4u, RebuildProducerCore.CalcAddrLength(patch));
+        }
+
+        [Fact]
+        public void CalcAddrLength_OnlyFirstSectionUsesSecondPipe_IgnoresThirdSection()
+        {
+            // Only the SECOND '|'-section is counted; a 3rd section is ignored.
+            // "name|AA BB|junk extra here" -> second section "AA BB" -> length 2.
+            var patch = MakePatch(("COMBO", "name|AA BB|junk extra here"));
+            Assert.Equal(2u, RebuildProducerCore.CalcAddrLength(patch));
+        }
+
+        [Fact]
+        public void CalcAddrLength_NullPatchOrParam_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => RebuildProducerCore.CalcAddrLength(null));
+            var noParam = new PatchInstallCore.PatchSt { Name = "p", PatchFileName = "p.txt", Param = null };
+            Assert.Throws<ArgumentNullException>(() => RebuildProducerCore.CalcAddrLength(noParam));
+        }
+    }
+}

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -12564,6 +12564,9 @@ namespace FEBuilderGBA
         //   That is BYTE-FAITHFUL for every macro the producer needs because the
         //   WF appnedSize argument is read in EXACTLY ONE place: the $FREEAREA
         //   branch (PatchForm.cs:3027). See the carve-out note on ResolvePatchAddress.
+        //   The producer wrapper ResolvePatchAddress keeps WF's argument ORDER
+        //   (addrstring, appnedSize, start_offset, basedir) with rom prepended, so
+        //   s2pf-3..8 transcribe their WF callsites verbatim (no arg-swap risk).
         // ====================================================================
 
         /// <summary>
@@ -12592,27 +12595,136 @@ namespace FEBuilderGBA
         /// callsites also yield an unsafe offset there). For the same reason
         /// <c>appnedSize</c> NEVER changes the resolved value of any OTHER macro, so this
         /// wrapper accepts it for WF-call-signature fidelity (so s2pf-3..8 mirror the WF
-        /// callsites verbatim) but does not need to forward it.
-        /// <c>$EndWeaponDebuffTable3/4/5</c> are likewise carved to NOT_FOUND
-        /// (PatchMacroAddressResolverCore.cs:131): they are PatchUtil/Form-bound
-        /// weapon-debuff macros and never appear in a STRUCT/ADDR/SWITCH/IMAGE
-        /// ADDRESS/POINTER/DATACOUNT param.</para>
+        /// callsites verbatim) but does not need to forward it. <c>$FREEAREA</c> never
+        /// appears as a producer ADDRESS/POINTER/DATACOUNT param (only BIN/free-area install
+        /// metadata), so this carve-out is faithful for the producer.</para>
+        ///
+        /// <para><b>$EndWeaponDebuffTable3/4/5 are NOT carved out for the producer</b> — they
+        /// ARE real STRUCT DATACOUNT params in FE8U
+        /// (config/patch2/FE8U/skill/PATCH_defWeaponDebuffsTable*.txt). WF resolves them via
+        /// <c>PatchUtil.GetEndWeaponDebuffTable3/4/5</c> (PatchForm.cs:3124; PatchUtil.cs:1619)
+        /// — BOUNDED ROM SCANS, not allocator side-effects — so this wrapper dispatches them to
+        /// the Core ports below (threading <paramref name="rom"/> + <paramref name="startOffset"/>=struct_address).
+        /// Returning NOT_FOUND would make the future STRUCT arm SKIP the weapon-debuff struct =
+        /// the silent drop the gate guards against. The dispatch lives HERE (producer) not in the
+        /// shared read-only <see cref="PatchMacroAddressResolverCore.Resolve"/>, which correctly
+        /// keeps the carve-out for its #1027 Text-Editor free-area used-ref scan (a debuff-table
+        /// end address is not a TEXT/SONG id) — preserving BOTH contracts.</para>
+        /// <para>
+        /// PARAMETER ORDER mirrors the WF reference signature
+        /// <c>convertBinAddressString(addrstring, appnedSize, start_offset, basedir)</c> exactly,
+        /// with <paramref name="rom"/> prepended (Core threads the rom explicitly instead of
+        /// reading Program.ROM). Keeping WF's argument order lets s2pf-3..8 transcribe their WF
+        /// callsites verbatim — e.g. WF <c>convertBinAddressString(datacount_str, 8, struct_address,
+        /// basedir)</c> becomes <c>ResolvePatchAddress(rom, datacount_str, 8, struct_address,
+        /// basedir)</c> — with no risk of swapping start_offset/basedir.
+        /// </para>
         /// </summary>
         /// <param name="rom">ROM to resolve against — passed explicitly (NEVER CoreState.ROM / Program.ROM).</param>
-        /// <param name="addrstring">The patch address string (plain hex or <c>$MACRO</c>).</param>
-        /// <param name="basedir">Patch-file directory, for <c>$FGREP</c> file lookups.</param>
+        /// <param name="addrstring">WF <c>addrstring</c> — the patch address string (plain hex or <c>$MACRO</c>).</param>
         /// <param name="appnedSize">WF <c>appnedSize</c> — accepted for callsite fidelity; only
         /// the carved-out <c>$FREEAREA</c> branch ever read it, so it does not affect the result.</param>
         /// <param name="startOffset">WF <c>start_offset</c> — the GREP scan start
         /// (ADDR=0x100, SWITCH/STRUCT addr/ptr=0, STRUCT DATACOUNT=struct_address).</param>
+        /// <param name="basedir">WF <c>basedir</c> — patch-file directory, for <c>$FGREP</c> file lookups.</param>
         /// <returns>ROM offset, or <see cref="U.NOT_FOUND"/> on any failure / carve-out.</returns>
-        public static uint ResolvePatchAddress(ROM rom, string addrstring, string basedir, uint appnedSize, uint startOffset)
+        public static uint ResolvePatchAddress(ROM rom, string addrstring, uint appnedSize, uint startOffset, string basedir)
         {
             // appnedSize is intentionally unreferenced beyond the contract above: the only
             // WF branch that read it ($FREEAREA) is carved to NOT_FOUND in the Core resolver,
             // so forwarding it would change nothing. Keep the param for WF-callsite fidelity.
             _ = appnedSize;
+
+            // $EndWeaponDebuffTable3/4/5 — PRODUCER-FAITHFUL dispatch (NOT carved out here).
+            // WF convertBinAddressString routes these through PatchUtil.GetEndWeaponDebuffTable3/4/5
+            // (PatchForm.cs:3124-3134), which are BOUNDED ROM SCANS (no allocator side-effect, no
+            // Form/InputFormRef dependency) — see PatchUtil.cs:1619-1677. They ARE used as real
+            // STRUCT DATACOUNT params in FE8U (config/patch2/FE8U/skill/PATCH_defWeaponDebuffsTable*.txt,
+            // .../skill20220120/PATCH_defWeaponDebuffsTable_20220120.txt), so the producer MUST
+            // resolve them — returning NOT_FOUND would make the future STRUCT arm SKIP the
+            // weapon-debuff struct (= the silent drop the gate guards against), diverging from WF.
+            //
+            // These are dispatched in the PRODUCER WRAPPER (threading rom + the WF start_offset),
+            // NOT in the shared read-only PatchMacroAddressResolverCore.Resolve: that resolver is
+            // the #1027 Text-Editor free-area used-ref scanner, where these weapon-debuff
+            // DATACOUNT end-addresses are correctly carved out (a debuff-table end is not a
+            // TEXT/SONG id). Keeping the dispatch here preserves BOTH contracts.
+            if (!string.IsNullOrEmpty(addrstring) && addrstring.Length > 1 && addrstring[0] == '$')
+            {
+                string value = addrstring.Substring(1);
+                if (value.StartsWith("EndWeaponDebuffTable3 ", StringComparison.Ordinal))
+                    return GetEndWeaponDebuffTable3(rom, startOffset);
+                if (value.StartsWith("EndWeaponDebuffTable4 ", StringComparison.Ordinal))
+                    return GetEndWeaponDebuffTable4(rom, startOffset);
+                if (value.StartsWith("EndWeaponDebuffTable5 ", StringComparison.Ordinal))
+                    return GetEndWeaponDebuffTable5(rom, startOffset);
+            }
+
             return PatchMacroAddressResolverCore.Resolve(rom, addrstring, basedir, startOffset);
+        }
+
+        // ---- $EndWeaponDebuffTable3/4/5 bounded-scan ports ------------------
+        // Verbatim Core ports of WF PatchUtil.GetEndWeaponDebuffTable3/4/5
+        // (FEBuilderGBA/PatchUtil.cs:1619-1677), threading `rom` instead of Program.ROM
+        // and never throwing (the start/end clamps + U.Grep bounds keep every read in range).
+        // start_offset is the STRUCT struct_address (WF DATACOUNT callsite passes it).
+
+        // PatchUtil.cs:1619 — skip the leading 0x00*3 row, then return the FIRST of the
+        // three terminator rows (000000 / FFFF00 / FFFFFF) within a 3*256-byte window.
+        static uint GetEndWeaponDebuffTable3(ROM rom, uint start_offset)
+        {
+            if (rom == null || rom.Data == null) return U.NOT_FOUND;
+            uint end = start_offset + (3 * 256);
+            end = Math.Min(end, (uint)rom.Data.Length);
+            start_offset += 3; // 先頭は0x00 0x00 0x00 なので読み飛ばす.
+
+            uint found = end;
+            uint new_found = U.Grep(rom.Data, new byte[] { 0x00, 0x00, 0x00 }, start_offset, end);
+            found = Math.Min(found, new_found);
+            new_found = U.Grep(rom.Data, new byte[] { 0xFF, 0xFF, 0x00 }, start_offset, end);
+            found = Math.Min(found, new_found);
+            new_found = U.Grep(rom.Data, new byte[] { 0xFF, 0xFF, 0xFF }, start_offset, end);
+            found = Math.Min(found, new_found);
+            return found;
+        }
+
+        // PatchUtil.cs:1640 — same as Table3 but the leading skip + window stride is 4.
+        static uint GetEndWeaponDebuffTable4(ROM rom, uint start_offset)
+        {
+            if (rom == null || rom.Data == null) return U.NOT_FOUND;
+            uint end = start_offset + (4 * 256);
+            end = Math.Min(end, (uint)rom.Data.Length);
+            start_offset += 4; // 先頭は0x00 0x00 0x00 0x00 なので読み飛ばす.
+
+            uint found = end;
+            uint new_found = U.Grep(rom.Data, new byte[] { 0x00, 0x00, 0x00 }, start_offset, end);
+            found = Math.Min(found, new_found);
+            new_found = U.Grep(rom.Data, new byte[] { 0xFF, 0xFF, 0x00 }, start_offset, end);
+            found = Math.Min(found, new_found);
+            new_found = U.Grep(rom.Data, new byte[] { 0xFF, 0xFF, 0xFF }, start_offset, end);
+            found = Math.Min(found, new_found);
+            return found;
+        }
+
+        // PatchUtil.cs:1661 — skip the leading 0x00*4 row, then walk u32 rows until the
+        // top nibble of byte[+3] is non-zero; return that row address.
+        static uint GetEndWeaponDebuffTable5(ROM rom, uint start_offset)
+        {
+            if (rom == null || rom.Data == null) return U.NOT_FOUND;
+            start_offset += 4; // 先頭は0x00 0x00 0x00 0x00 なので読み飛ばす.
+            uint end = start_offset + (4 * 256);
+            end = Math.Min(end, (uint)rom.Data.Length);
+
+            uint addr;
+            for (addr = start_offset; addr < end; addr += 4)
+            {
+                uint last = rom.u8(addr + 3);
+                if ((last & 0xf0) != 0)
+                {
+                    break;
+                }
+            }
+            return addr;
         }
 
         /// <summary>

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -12542,6 +12542,112 @@ namespace FEBuilderGBA
         }
 
         // ====================================================================
+        // PatchForm producer — option-B epic (#1261, sub-slice s2pf-2 of 11).
+        //
+        // The producer-side 4-arg address resolver + CalcAddrLength. These are
+        // the HELPERS the later ADDR/SWITCH/STRUCT/IMAGE TYPE-arm slices
+        // (s2pf-3..s2pf-8) call to turn a patch's ADDRESS/POINTER/DATACOUNT/COMBO
+        // params into ROM offsets and BIN lengths. This slice adds the helpers
+        // ONLY — it emits NO Address and is NOT wired into the live producer, so
+        // "PatchForm(MakePatchStructDataList)" STAYS in AsmNotYetPortedRaw.
+        //
+        // WF SOURCE: the per-TYPE handlers call the 4-arg
+        //   convertBinAddressString(addrstring, appnedSize, start_offset, basedir)
+        //   (FEBuilderGBA/PatchForm.cs:3000). Callsite (appnedSize, start_offset):
+        //     - ADDR    @:6226  -> (0, 0x100)
+        //     - SWITCH  @:6448  -> (8, 0)
+        //     - STRUCT  POINTER @:6469 / ADDRESS @:6487 -> (8, 0)
+        //     - STRUCT  DATACOUNT @:6505 -> (8, struct_address)   (end-delta scan)
+        //   The Core read-only resolver PatchMacroAddressResolverCore.Resolve
+        //   (#1027) is the faithful port of convertBinAddressString's macro family
+        //   but takes only (rom, addrstring, basedir, startOffset) — no appnedSize.
+        //   That is BYTE-FAITHFUL for every macro the producer needs because the
+        //   WF appnedSize argument is read in EXACTLY ONE place: the $FREEAREA
+        //   branch (PatchForm.cs:3027). See the carve-out note on ResolvePatchAddress.
+        // ====================================================================
+
+        /// <summary>
+        /// Producer-scoped 4-arg address resolver — the rebuild-time equivalent of
+        /// WinForms <c>PatchForm.convertBinAddressString(addrstring, appnedSize,
+        /// start_offset, basedir)</c> (FEBuilderGBA/PatchForm.cs:3000). Resolves a
+        /// patch ADDRESS/POINTER/DATACOUNT string (plain hex, <c>$0x</c> deref,
+        /// <c>$GREP</c>/<c>$XGREP</c>/<c>$FGREP</c> + align/skip, <c>$GREP_ENABLE_POINTER</c>,
+        /// <c>$P32</c>[+4], <c>$TEXTID</c>, <c>$TEXTID_P</c>) to a ROM offset by delegating
+        /// to the read-only Core port <see cref="PatchMacroAddressResolverCore.Resolve"/>,
+        /// threading <paramref name="rom"/> and <paramref name="startOffset"/>.
+        /// Returns <see cref="U.NOT_FOUND"/> on any failure (the caller's
+        /// <c>U.isSafetyOffset</c> gate then skips that patch entry — identical to WF).
+        ///
+        /// <para><b>FAITHFUL CARVE-OUT (NOT a shortcut):</b> the WF
+        /// <paramref name="appnedSize"/> argument is consumed in EXACTLY ONE branch of
+        /// convertBinAddressString — <c>$FREEAREA</c> (PatchForm.cs:3027): if
+        /// appnedSize==0 it returns 0 (an unsafe offset that fails isSafetyOffset), else
+        /// it calls <c>MoveToFreeSapceForm.SearchFreeSpaceOne</c> — the WF run-time
+        /// free-space ALLOCATOR. That is non-deterministic at rebuild time, and the
+        /// region it would allocate ALREADY EXISTS in the saved ROM (anchored by normal
+        /// pointers, found by the regular scan) so it is never freed. The Core resolver
+        /// therefore carves <c>$FREEAREA</c> out to <see cref="U.NOT_FOUND"/>
+        /// (PatchMacroAddressResolverCore.cs:72), which propagates here and makes the
+        /// caller skip that entry — IDENTICAL net behavior to WF (whose appnedSize==0
+        /// callsites also yield an unsafe offset there). For the same reason
+        /// <c>appnedSize</c> NEVER changes the resolved value of any OTHER macro, so this
+        /// wrapper accepts it for WF-call-signature fidelity (so s2pf-3..8 mirror the WF
+        /// callsites verbatim) but does not need to forward it.
+        /// <c>$EndWeaponDebuffTable3/4/5</c> are likewise carved to NOT_FOUND
+        /// (PatchMacroAddressResolverCore.cs:131): they are PatchUtil/Form-bound
+        /// weapon-debuff macros and never appear in a STRUCT/ADDR/SWITCH/IMAGE
+        /// ADDRESS/POINTER/DATACOUNT param.</para>
+        /// </summary>
+        /// <param name="rom">ROM to resolve against — passed explicitly (NEVER CoreState.ROM / Program.ROM).</param>
+        /// <param name="addrstring">The patch address string (plain hex or <c>$MACRO</c>).</param>
+        /// <param name="basedir">Patch-file directory, for <c>$FGREP</c> file lookups.</param>
+        /// <param name="appnedSize">WF <c>appnedSize</c> — accepted for callsite fidelity; only
+        /// the carved-out <c>$FREEAREA</c> branch ever read it, so it does not affect the result.</param>
+        /// <param name="startOffset">WF <c>start_offset</c> — the GREP scan start
+        /// (ADDR=0x100, SWITCH/STRUCT addr/ptr=0, STRUCT DATACOUNT=struct_address).</param>
+        /// <returns>ROM offset, or <see cref="U.NOT_FOUND"/> on any failure / carve-out.</returns>
+        public static uint ResolvePatchAddress(ROM rom, string addrstring, string basedir, uint appnedSize, uint startOffset)
+        {
+            // appnedSize is intentionally unreferenced beyond the contract above: the only
+            // WF branch that read it ($FREEAREA) is carved to NOT_FOUND in the Core resolver,
+            // so forwarding it would change nothing. Keep the param for WF-callsite fidelity.
+            _ = appnedSize;
+            return PatchMacroAddressResolverCore.Resolve(rom, addrstring, basedir, startOffset);
+        }
+
+        /// <summary>
+        /// Faithful Core port of WinForms <c>PatchForm.CalcAddrLength</c>
+        /// (FEBuilderGBA/PatchForm.cs:6197). PURE parse of a patch's <c>COMBO</c> param —
+        /// no ROM read. The BIN byte length of an ADDR/SWITCH entry is the number of
+        /// space-separated tokens in the SECOND <c>|</c>-section of COMBO; absent/short
+        /// COMBO yields length 1. Used by the ADDR/SWITCH TYPE arms (s2pf-3/s2pf-6) to
+        /// size each emitted BIN/MIX Address.
+        /// </summary>
+        /// <param name="patch">The patch whose <c>Param["COMBO"]</c> is parsed.</param>
+        /// <returns>The token count of <c>COMBO</c>'s second <c>|</c>-section, else 1.</returns>
+        public static uint CalcAddrLength(PatchInstallCore.PatchSt patch)
+        {
+            // Public helper: guard like the other public Core helpers, rather than NRE on a
+            // null patch / uninitialized Param. WF reads st.Param via U.at, which on a real
+            // LoadPatch result is always non-null.
+            if (patch == null) throw new ArgumentNullException(nameof(patch));
+            if (patch.Param == null) throw new ArgumentNullException(nameof(patch) + ".Param");
+
+            string combo = U.at(patch.Param, "COMBO");
+            if (combo == "")
+            {
+                return 1;
+            }
+            string[] sp = combo.Split('|');
+            if (sp.Length < 2)
+            {
+                return 1;
+            }
+            string[] bytesSP = sp[1].Split(' ');
+            return (uint)bytesSP.Length;
+        }
+
+        // ====================================================================
         // slice 2z-wire (#1261) — drive RebuildMakeCore.Make from the producers,
         // GATED on IsComplete.
         //


### PR DESCRIPTION
## Summary

Sub-slice **2/11** of the PatchForm producer option-B epic (#1261). Adds the producer-side **4-arg address resolver** + **CalcAddrLength** HELPERS that the later ADDR/SWITCH/STRUCT/IMAGE TYPE-arm slices (s2pf-3..8) will call to turn a patch's `ADDRESS`/`POINTER`/`DATACOUNT`/`COMBO` params into ROM offsets and BIN lengths.

**Helpers ONLY** — this slice emits no `Address` and is NOT wired into the live producer. The gate token `"PatchForm(MakePatchStructDataList)"` **STAYS** in `AsmNotYetPortedRaw` and `AsmProducerResult.IsComplete` stays false.

Plan: https://github.com/laqieer/FEBuilderGBA/issues/1261#issuecomment-4760973207

## What

- **`RebuildProducerCore.ResolvePatchAddress(ROM rom, string addrstring, uint appnedSize, uint startOffset, string basedir) -> uint`** — a thin producer wrapper over the read-only Core port `PatchMacroAddressResolverCore.Resolve` (#1027; faithful port of WF `PatchForm.convertBinAddressString` @`PatchForm.cs:3000`). Parameter order mirrors the WF reference signature `convertBinAddressString(addrstring, appnedSize, start_offset, basedir)` with `rom` prepended, so s2pf-3..8 transcribe their WF callsites verbatim. Handles plain hex, `$0x` deref, `$GREP`/`$XGREP`/`$FGREP` (+align/skip), `$GREP_ENABLE_POINTER`, `$P32`[+4], `$TEXTID`, `$TEXTID_P`, and `$EndWeaponDebuffTable3/4/5`.
- **`RebuildProducerCore.CalcAddrLength(PatchInstallCore.PatchSt patch) -> uint`** — verbatim port of WF `PatchForm.CalcAddrLength` @`PatchForm.cs:6197` (pure `COMBO|bytes` space-split, no ROM read).

## $EndWeaponDebuffTable3/4/5 — producer-faithful bounded scans (Copilot review fix)

These ARE real STRUCT `DATACOUNT` params in FE8U (`config/patch2/FE8U/skill/PATCH_defWeaponDebuffsTable*.txt`, `.../skill20220120/...`). WF resolves them via `PatchUtil.GetEndWeaponDebuffTable3/4/5` (`PatchForm.cs:3124` → `PatchUtil.cs:1619-1677`) — **bounded ROM scans, not allocator side-effects**. They are ported into Core (rom-threaded, never-throw) and dispatched in `ResolvePatchAddress` (threading `rom` + `startOffset`=struct_address) **before** delegating to the shared resolver. They are kept **out of** the shared read-only `PatchMacroAddressResolverCore.Resolve`, which correctly retains the carve-out for its #1027 Text-Editor free-area used-ref scan (a debuff-table end is not a TEXT/SONG id) — both contracts preserved.

## $FREEAREA — faithful carve-out (NOT a shortcut)

`$FREEAREA` resolves to `U.NOT_FOUND`. The WF `appnedSize` arg is consumed in **exactly one** branch of `convertBinAddressString` — `$FREEAREA` (`PatchForm.cs:3027`), the WF run-time allocator `MoveToFreeSapceForm.SearchFreeSpaceOne` — non-deterministic at rebuild time, and the region it would allocate already exists in the saved ROM (anchored by normal pointers, found by the regular scan) so it is never freed. Verified over `config/patch2` that `$FREEAREA` appears only as BIN/free-area install metadata, never a producer `ADDRESS`/`POINTER`/`DATACOUNT` param, so the carve-out is faithful for the producer. The wrapper accepts `appnedSize` for WF-callsite fidelity but does not forward it (it never changes any other macro's resolved value).

## Byte-parity vs WF (verified)

- GREP regex `^(F|X)?GREP([0-9]+)(ENDA|END)?\+?([0-9]+)? ` identical; align=`Groups[2]`, skip=`Groups[4]`. WF reads `U.atoi(Groups[4])` unconditionally; Core reads `IsNullOrEmpty?0:U.atoi(...)`. Since `U.atoi("")==0`, **byte-identical**.
- XGREP wildcard mask (`X`→mask+0xFF, else `atoi0x` byte) matches WF `MakeXGrepData`.
- `$TEXTID` base: Core inlines `rom.p32(text_pointer)` (fallback `text_recover_address`) `+ textid*4` == WF `TextForm.GetTextIDToDataPointer` (`InputFormRef.BaseAddress + BlockSize*textid`, BaseAddress=`p32(text_pointer)` fallback `text_recover_address`, BlockSize=4).
- `$EndWeaponDebuffTable3/4/5` are verbatim ports of `PatchUtil.GetEndWeaponDebuffTable3/4/5`.

## Scope

Ref #1261 (epic). Helpers only; no live-producer wiring (that is s2pf-3..s2pf-11).

## Test plan

- [x] `ResolvePatchAddress` per-macro-form on synthetic ROMs: plain hex literal (base-strip), `$0x` deref, `$GREP` exact-match + not-found
- [x] `$GREP` align + skip **byte-parity**: `$GREP4ENDA+6` planted at a 4-aligned offset → exact endpoint `match + len + skip`; `$GREP4` must NOT match a non-4-aligned pattern (align honored), `$GREP1` does
- [x] `$XGREP` wildcard matches any byte
- [x] `$P32`, `$TEXTID`, `$TEXTID_P`, `$GREP_ENABLE_POINTER`
- [x] `$FREEAREA` (both `appnedSize==0` and `!=0`) → `NOT_FOUND` (faithful producer carve-out)
- [x] `$EndWeaponDebuffTable3/4/5` producer-faithful bounded scans: Table3 terminator-row grep, Table4 stride-4 grep, Table5 high-nibble walk → exact endpoint asserts
- [x] `appnedSize` is irrelevant to the resolved value (invariant across 0 / 8 / 0x1234)
- [x] `startOffset` threading narrows the GREP scan (two planted copies; higher start returns the second)
- [x] Null-rom / empty-addrstring guards → `NOT_FOUND`, no throw
- [x] `CalcAddrLength`: no COMBO / empty / no-pipe / single-byte / multi-byte second section / third-section ignored → matching WF; null patch/Param throws
- [x] Shared resolver carve-out unchanged: `PatchMacro` filter 39 passed (EndWeaponDebuff/FREEAREA still NOT_FOUND there)
- [x] `dotnet test --filter RebuildProducer` → **508 passed (482 baseline + 26 new), 0 failed**
- [x] `dotnet build FEBuilderGBA.sln` → **0 errors** (FEBuilderGBA.Tests WF-parity project compiles)

## Proof (Core-only, no GUI → no screenshot)

```
$ dotnet test FEBuilderGBA.Core.Tests --filter "FullyQualifiedName~RebuildProducer"
Passed!  - Failed: 0, Passed: 508, Skipped: 0, Total: 508

$ dotnet test FEBuilderGBA.Core.Tests --filter "FullyQualifiedName~PatchMacro"
Passed!  - Failed: 0, Passed: 39, Skipped: 0, Total: 39

$ dotnet build FEBuilderGBA.sln
Build succeeded.  0 Error(s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
