### PR TITLE
feat(core): PatchForm ADDR + SWITCH dispatch arms (#1261 s2pf-3)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchAddrSwitchTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchAddrSwitchTests.cs
@@ -1,0 +1,415 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for RebuildProducerCore slice s2pf-3 (#1261) — the two TRIVIAL terminal
+// PatchForm producer TYPE arms (option-B epic, sub-slice 3 of 11):
+//   RebuildProducerCore.EmitPatchAddr   = WF PatchForm.MakePatchStructDataListForADDR   @:6213
+//   RebuildProducerCore.EmitPatchSwitch = WF PatchForm.MakePatchStructDataListForSWITCH @:6425
+//
+// Coverage (synthetic in-memory ROM + synthetic PatchSt — no real GBA ROM file,
+// mirroring RebuildProducerPatchResolverTests):
+//   1. EmitPatchAddr:
+//        - literal multi-address ADDRESS -> one Address per token (addr/length/pointer/type/name)
+//        - the BIN(<4) vs MIX(>=4) length classification boundary (length 3,4,5)
+//        - $0x macro single-address path (resolves via ResolvePatchAddress, startOffset=0x100)
+//        - COMBO-driven length (CalcAddrLength)
+//        - per-token isSafetyOffset SKIP (one unsafe addr skipped, the rest emit)
+//        - isPointerOnly -> length 0
+//        - empty ADDRESS -> nothing
+//        - INHERITED s2pf-2 contract: an unsafe $0x deref macro SKIPS (returns, emits nothing)
+//          rather than throwing — pinning the intentional NOT_FOUND-vs-WF-throw divergence.
+//   2. EmitPatchSwitch:
+//        - ONN:/OFF: keys -> one Address per pair (VERBATIM WF prefixes; NOT "ON:")
+//        - length = param VALUE space-token count; BIN/MIX boundary
+//        - non-ONN:/OFF: key ignored; op.Length<2 key skipped; "ON:" (3-char) NOT matched
+//        - $-macro and literal address resolution (both via ResolvePatchAddress unconditionally)
+//        - per-pair isSafetyOffset SKIP; isPointerOnly -> length 0
+//   3. Integration through the public orchestrator MakePatchStructDataListCore on a
+//      staged config/patch2 tree (proves the ADDR/SWITCH switch arms are wired).
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class RebuildProducerPatchAddrSwitchTests : IDisposable
+    {
+        readonly ROM _savedRom = CoreState.ROM;
+        readonly string _savedLang = CoreState.Language;
+        readonly string _savedBaseDir = CoreState.BaseDirectory;
+        string _tempDir;
+
+        public RebuildProducerPatchAddrSwitchTests()
+        {
+            CoreState.Language = "en";
+        }
+
+        public void Dispose()
+        {
+            CoreState.ROM = _savedRom;
+            CoreState.Language = _savedLang;
+            CoreState.BaseDirectory = _savedBaseDir;
+            try { if (_tempDir != null && Directory.Exists(_tempDir)) Directory.Delete(_tempDir, true); } catch { }
+        }
+
+        // 16 MiB zero-filled FE8U ROM (LoadLow minimum for BE8E01) — same idiom as
+        // RebuildProducerPatchResolverTests.MakeRom. Also sets CoreState.ROM: although the
+        // emitters thread `rom` explicitly, the Address.AddAddress sink they call uses the
+        // single-arg U.isSafetyOffset overload, which reads CoreState.ROM (same coupling the
+        // RebuildProducerAsmTests CreateTestRom helper handles). Restored in Dispose.
+        static ROM MakeRom()
+        {
+            var rom = new ROM();
+            byte[] data = new byte[0x1000000];
+            bool ok = rom.LoadLow("x.gba", data, "BE8E01");
+            Assert.True(ok, "LoadLow did not recognize BE8E01");
+            CoreState.ROM = rom;
+            return rom;
+        }
+
+        // Build a PatchSt from raw key/value lines (insertion-ordered Param, exactly like
+        // PatchHardCodeScanner.LoadPatch). Name drives the emitted "@ADDRESS"/"@SWITCH" info.
+        static PatchInstallCore.PatchSt MakePatch(string name, params (string key, string value)[] kv)
+        {
+            var p = new PatchInstallCore.PatchSt
+            {
+                Name = name,
+                PatchFileName = name + ".txt",
+                Param = new Dictionary<string, string>()
+            };
+            foreach (var (key, value) in kv)
+            {
+                p.Param[key] = value;
+            }
+            return p;
+        }
+
+        // Find the single Address whose Info matches (helper for single-entry asserts).
+        static Address Single(List<Address> list, string info)
+        {
+            return Assert.Single(list, a => a.Info == info);
+        }
+
+        // ====================================================================
+        // 1. EmitPatchAddr (WF :6213)
+        // ====================================================================
+
+        [Fact]
+        public void EmitPatchAddr_EmptyAddress_EmitsNothing()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // No ADDRESS key -> U.at returns "" -> return.
+            RebuildProducerCore.EmitPatchAddr(rom, list, MakePatch("p", ("TYPE", "ADDR")), isPointerOnly: false);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitPatchAddr_SingleLiteral_NoCombo_LengthOne_IsBIN()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // No COMBO -> CalcAddrLength = 1 -> length 1 (< 4) -> BIN. ADDRESS 0x1000 is safe.
+            RebuildProducerCore.EmitPatchAddr(rom, list,
+                MakePatch("PatchA", ("TYPE", "ADDR"), ("ADDRESS", "0x1000")), isPointerOnly: false);
+
+            var a = Single(list, "PatchA@ADDRESS");
+            Assert.Equal(0x1000u, a.Addr);
+            Assert.Equal(1u, a.Length);
+            Assert.Equal(U.NOT_FOUND, a.Pointer);
+            Assert.Equal(Address.DataTypeEnum.BIN, a.DataType);
+        }
+
+        [Fact]
+        public void EmitPatchAddr_MultipleLiterals_EmitsOnePerToken()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // Space-split literal -> three addresses, each its own Address entry.
+            RebuildProducerCore.EmitPatchAddr(rom, list,
+                MakePatch("Trio", ("TYPE", "ADDR"), ("ADDRESS", "0x1000 0x2000 0x3000")), isPointerOnly: false);
+
+            Assert.Equal(3, list.Count);
+            Assert.Contains(list, a => a.Addr == 0x1000u && a.Info == "Trio@ADDRESS");
+            Assert.Contains(list, a => a.Addr == 0x2000u && a.Info == "Trio@ADDRESS");
+            Assert.Contains(list, a => a.Addr == 0x3000u && a.Info == "Trio@ADDRESS");
+            Assert.All(list, a => Assert.Equal(Address.DataTypeEnum.BIN, a.DataType)); // length 1 each
+        }
+
+        // ---- BIN(<4) vs MIX(>=4) classification boundary (load-bearing) -----
+        // A COMBO whose 2nd '|'-section has N space tokens => length N. The
+        // length<4 ? BIN : MIX boundary must put length 3 = BIN, 4 = MIX, 5 = MIX
+        // exactly as WF (a >=4 entry mis-typed BIN would drop its pointer sub-scan
+        // during rebuild = corruption).
+
+        [Theory]
+        [InlineData("c|AA BB CC", 3u, Address.DataTypeEnum.BIN)]        // 3 < 4 -> BIN
+        [InlineData("c|AA BB CC DD", 4u, Address.DataTypeEnum.MIX)]     // 4 >= 4 -> MIX
+        [InlineData("c|AA BB CC DD EE", 5u, Address.DataTypeEnum.MIX)]  // 5 >= 4 -> MIX
+        public void EmitPatchAddr_ComboLength_ClassifiesBinMixAtFour(string combo, uint expectLen, Address.DataTypeEnum expectType)
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchAddr(rom, list,
+                MakePatch("Boundary", ("TYPE", "ADDR"), ("ADDRESS", "0x4000"), ("COMBO", combo)), isPointerOnly: false);
+
+            var a = Single(list, "Boundary@ADDRESS");
+            Assert.Equal(0x4000u, a.Addr);
+            Assert.Equal(expectLen, a.Length);
+            Assert.Equal(expectType, a.DataType);
+        }
+
+        [Fact]
+        public void EmitPatchAddr_IsPointerOnly_LengthZero_IsBIN()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // isPointerOnly skips CalcAddrLength -> length stays 0 (< 4) -> BIN, even though
+            // COMBO would otherwise size it to 5.
+            RebuildProducerCore.EmitPatchAddr(rom, list,
+                MakePatch("PtrOnly", ("TYPE", "ADDR"), ("ADDRESS", "0x5000"), ("COMBO", "c|AA BB CC DD EE")), isPointerOnly: true);
+
+            var a = Single(list, "PtrOnly@ADDRESS");
+            Assert.Equal(0u, a.Length);
+            Assert.Equal(Address.DataTypeEnum.BIN, a.DataType);
+        }
+
+        // ---- $0x macro single-address path ----------------------------------
+
+        [Fact]
+        public void EmitPatchAddr_DollarHexMacro_ResolvesAndEmitsSingle()
+        {
+            var rom = MakeRom();
+            const uint slot = 0x1000;
+            const uint target = 0x2000;
+            U.write_u32(rom.Data, slot, U.toPointer(target));
+
+            var list = new List<Address>();
+            // ADDRESS "$0x1000" -> ResolvePatchAddress derefs to target 0x2000 (safe) ->
+            // a single Address at 0x2000. COMBO sizes it to length 2 (< 4) -> BIN.
+            RebuildProducerCore.EmitPatchAddr(rom, list,
+                MakePatch("Macro", ("TYPE", "ADDR"), ("ADDRESS", "$0x1000"), ("COMBO", "c|AA BB")), isPointerOnly: false);
+
+            var a = Single(list, "Macro@ADDRESS");
+            Assert.Equal(target, a.Addr);
+            Assert.Equal(2u, a.Length);
+            Assert.Equal(Address.DataTypeEnum.BIN, a.DataType);
+        }
+
+        // ---- INHERITED s2pf-2 contract: unsafe $0x deref SKIPS (no throw) ----
+        // WF convertBinAddressString would THROW PatchException on an unsafe $0x deref
+        // and (no try/catch up the call chain) abort the whole rebuild. The merged
+        // s2pf-2 resolver maps it to U.NOT_FOUND, which fails the isSafetyOffset guard
+        // -> EmitPatchAddr returns, emitting nothing. This pins that intentional,
+        // inherited divergence so a future change can't silently flip it.
+
+        [Fact]
+        public void EmitPatchAddr_UnsafeDollarHexMacro_Skips_NoThrow()
+        {
+            var rom = MakeRom();
+            const uint slot = 0x1000;
+            // Point the slot at an UNSAFE offset (0x100 < the 0x200 floor) so the resolved
+            // macro address fails isSafetyOffset.
+            U.write_u32(rom.Data, slot, U.toPointer(0x100));
+
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.EmitPatchAddr(rom, list,
+                MakePatch("Unsafe", ("TYPE", "ADDR"), ("ADDRESS", "$0x1000")), isPointerOnly: false));
+
+            Assert.Null(ex);    // INHERITED contract: skip, never throw
+            Assert.Empty(list); // nothing emitted
+        }
+
+        [Fact]
+        public void EmitPatchAddr_UnknownMacro_Skips_NoThrow()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // An unknown $MACRO resolves to NOT_FOUND (resolver fall-through) -> skip, no throw.
+            var ex = Record.Exception(() => RebuildProducerCore.EmitPatchAddr(rom, list,
+                MakePatch("Unk", ("TYPE", "ADDR"), ("ADDRESS", "$NOSUCHMACRO 0x1")), isPointerOnly: false));
+
+            Assert.Null(ex);
+            Assert.Empty(list);
+        }
+
+        // ---- per-token isSafetyOffset SKIP (literal list) -------------------
+
+        [Fact]
+        public void EmitPatchAddr_PerTokenUnsafe_SkipsOnlyThatEntry()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // 0x100 is below the 0x200 safe-offset floor -> unsafe -> that one token is
+            // skipped (continue), but 0x1000 and 0x2000 still emit. Proves the skip is
+            // per-address, not whole-patch.
+            RebuildProducerCore.EmitPatchAddr(rom, list,
+                MakePatch("Mixed", ("TYPE", "ADDR"), ("ADDRESS", "0x1000 0x100 0x2000")), isPointerOnly: false);
+
+            Assert.Equal(2, list.Count);
+            Assert.Contains(list, a => a.Addr == 0x1000u);
+            Assert.Contains(list, a => a.Addr == 0x2000u);
+            Assert.DoesNotContain(list, a => a.Addr == 0x100u);
+        }
+
+        // ====================================================================
+        // 2. EmitPatchSwitch (WF :6425)
+        // ====================================================================
+
+        [Fact]
+        public void EmitPatchSwitch_OnnAndOffKeys_EmitOnePerPair()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // ONN: and OFF: keys both act. Value space-token count = length (here 1 each -> BIN).
+            // A non-ONN:/OFF: key (TYPE) is ignored.
+            RebuildProducerCore.EmitPatchSwitch(rom, list, MakePatch("Sw",
+                ("TYPE", "SWITCH"),
+                ("ONN:0x1000", "AA"),
+                ("OFF:0x2000", "BB")), isPointerOnly: false);
+
+            Assert.Equal(2, list.Count);
+            // both entries share the same Info ("Sw@SWITCH"); assert by addr.
+            Assert.Contains(list, a => a.Addr == 0x1000u && a.Length == 1u && a.DataType == Address.DataTypeEnum.BIN);
+            Assert.Contains(list, a => a.Addr == 0x2000u && a.Length == 1u && a.DataType == Address.DataTypeEnum.BIN);
+            Assert.All(list, a => { Assert.Equal("Sw@SWITCH", a.Info); Assert.Equal(U.NOT_FOUND, a.Pointer); });
+        }
+
+        // ---- BIN/MIX boundary on the VALUE space-token count ----------------
+
+        [Theory]
+        [InlineData("AA BB CC", 3u, Address.DataTypeEnum.BIN)]        // 3 < 4 -> BIN
+        [InlineData("AA BB CC DD", 4u, Address.DataTypeEnum.MIX)]     // 4 >= 4 -> MIX
+        [InlineData("AA BB CC DD EE", 5u, Address.DataTypeEnum.MIX)]  // 5 >= 4 -> MIX
+        public void EmitPatchSwitch_ValueTokenCount_ClassifiesBinMixAtFour(string value, uint expectLen, Address.DataTypeEnum expectType)
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchSwitch(rom, list,
+                MakePatch("B", ("ONN:0x3000", value)), isPointerOnly: false);
+
+            var a = Single(list, "B@SWITCH");
+            Assert.Equal(0x3000u, a.Addr);
+            Assert.Equal(expectLen, a.Length);
+            Assert.Equal(expectType, a.DataType);
+        }
+
+        [Fact]
+        public void EmitPatchSwitch_IsPointerOnly_LengthZero()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchSwitch(rom, list,
+                MakePatch("P", ("ONN:0x3000", "AA BB CC DD EE")), isPointerOnly: true);
+
+            var a = Single(list, "P@SWITCH");
+            Assert.Equal(0u, a.Length);
+            Assert.Equal(Address.DataTypeEnum.BIN, a.DataType);
+        }
+
+        [Fact]
+        public void EmitPatchSwitch_NonOnnOffKeys_Ignored()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // VERBATIM WF: only "ONN:" / "OFF:" prefixes act. "ON:" (3-char), "TYPE",
+            // "NAME" and an arbitrary key must all be ignored.
+            RebuildProducerCore.EmitPatchSwitch(rom, list, MakePatch("X",
+                ("TYPE", "SWITCH"),
+                ("NAME", "X"),
+                ("ON:0x1000", "AA"),     // "ON:" is NOT "ONN:" -> ignored
+                ("RANDOM:0x2000", "BB")  // unrelated prefix -> ignored
+            ), isPointerOnly: false);
+
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitPatchSwitch_KeyWithoutColonSuffix_Skipped()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // "ONN:" with NO address after the colon: Split(':') = {"ONN", ""} -> op.Length==2,
+            // op[1] == "" -> ResolvePatchAddress("") -> NOT_FOUND -> isSafetyOffset false -> skip.
+            // A bare "ONN" key (no colon) would be IndexOf("ONN:")!=0 -> not matched anyway.
+            RebuildProducerCore.EmitPatchSwitch(rom, list,
+                MakePatch("Y", ("ONN:", "AA"), ("ONN", "BB")), isPointerOnly: false);
+
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitPatchSwitch_DollarMacroAddress_Resolves()
+        {
+            var rom = MakeRom();
+            const uint slot = 0x1100u;
+            const uint target = 0x2200u;
+            U.write_u32(rom.Data, slot, U.toPointer(target));
+
+            var list = new List<Address>();
+            // SWITCH resolves op[1] via ResolvePatchAddress unconditionally; a $P32 macro
+            // (SWITCH callsite appnedSize=8, startOffset=0) derefs the pointer at 0x1100.
+            RebuildProducerCore.EmitPatchSwitch(rom, list,
+                MakePatch("M", ("ONN:$P32 0x1100", "AA BB")), isPointerOnly: false);
+
+            var a = Single(list, "M@SWITCH");
+            Assert.Equal(target, a.Addr);
+            Assert.Equal(2u, a.Length);
+        }
+
+        [Fact]
+        public void EmitPatchSwitch_PerPairUnsafe_SkipsOnlyThatPair()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // ONN:0x100 is below the 0x200 floor -> unsafe -> skipped; OFF:0x4000 still emits.
+            RebuildProducerCore.EmitPatchSwitch(rom, list, MakePatch("Z",
+                ("ONN:0x100", "AA"),
+                ("OFF:0x4000", "BB")), isPointerOnly: false);
+
+            var a = Single(list, "Z@SWITCH");
+            Assert.Equal(0x4000u, a.Addr);
+            Assert.DoesNotContain(list, x => x.Addr == 0x100u);
+        }
+
+        // ====================================================================
+        // 3. Integration through the public orchestrator (ADDR/SWITCH arms wired)
+        // ====================================================================
+
+        [Fact]
+        public void Orchestrator_AddrAndSwitchPatches_EmitViaWiredArms()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "RebuildProducerPatchAddrSwitch_" + Guid.NewGuid().ToString("N"));
+            string patchDir = Path.Combine(_tempDir, "config", "patch2", "FE8U");
+            Directory.CreateDirectory(patchDir);
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_ADDR.txt"), new[]
+            {
+                "NAME=AddrPatch",
+                "TYPE=ADDR",
+                "ADDRESS=0x1000",
+                "COMBO=c|AA BB CC DD",   // length 4 -> MIX
+            });
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_SWITCH.txt"), new[]
+            {
+                "NAME=SwitchPatch",
+                "TYPE=SWITCH",
+                "ONN:0x2000=AA BB",      // length 2 -> BIN
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeRom();
+            CoreState.ROM = fe8;
+
+            var list = new List<Address>();
+            RebuildProducerCore.MakePatchStructDataListCore(
+                fe8, list, isPointerOnly: false, isInstallOnly: false, isStructOnly: false);
+
+            // The leaner Core scanner (PatchHardCodeScanner.LoadPatch) sets only PatchFileName
+            // + Param, NOT Name, so the emitted Info is "@ADDRESS"/"@SWITCH" (null Name prefix).
+            Assert.Contains(list, a => a.Addr == 0x1000u && a.Info.EndsWith("@ADDRESS") && a.Length == 4u && a.DataType == Address.DataTypeEnum.MIX);
+            Assert.Contains(list, a => a.Addr == 0x2000u && a.Info.EndsWith("@SWITCH") && a.Length == 2u && a.DataType == Address.DataTypeEnum.BIN);
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchAddrSwitchTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchAddrSwitchTests.cs
@@ -39,7 +39,8 @@ namespace FEBuilderGBA.Core.Tests
         readonly ROM _savedRom = CoreState.ROM;
         readonly string _savedLang = CoreState.Language;
         readonly string _savedBaseDir = CoreState.BaseDirectory;
-        string _tempDir;
+        // Only the orchestrator integration test creates a temp patch tree; nullable by design.
+        string? _tempDir;
 
         public RebuildProducerPatchAddrSwitchTests()
         {
@@ -237,6 +238,39 @@ namespace FEBuilderGBA.Core.Tests
 
         // ---- per-token isSafetyOffset SKIP (literal list) -------------------
 
+        // ---- public-helper null guards (consistent with CalcAddrLength) -----
+
+        [Fact]
+        public void EmitPatchAddr_NullArgs_Throw()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            var patch = MakePatch("p", ("ADDRESS", "0x1000"));
+            Assert.Throws<ArgumentNullException>(() => RebuildProducerCore.EmitPatchAddr(null, list, patch, false));
+            Assert.Throws<ArgumentNullException>(() => RebuildProducerCore.EmitPatchAddr(rom, null, patch, false));
+            Assert.Throws<ArgumentNullException>(() => RebuildProducerCore.EmitPatchAddr(rom, list, null, false));
+            var noParam = new PatchInstallCore.PatchSt { Name = "p", PatchFileName = "p.txt", Param = null };
+            Assert.Throws<ArgumentNullException>(() => RebuildProducerCore.EmitPatchAddr(rom, list, noParam, false));
+        }
+
+        [Fact]
+        public void EmitPatchAddr_NullPatchFileName_NormalizesBasedir_NoThrow()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // PatchFileName null -> Path.GetDirectoryName(null) would throw; the "" normalization
+            // keeps a literal-address ADDR (no $FGREP) emitting normally.
+            var patch = new PatchInstallCore.PatchSt
+            {
+                Name = "NoFile",
+                PatchFileName = null,
+                Param = new Dictionary<string, string> { ["ADDRESS"] = "0x1000" }
+            };
+            var ex = Record.Exception(() => RebuildProducerCore.EmitPatchAddr(rom, list, patch, false));
+            Assert.Null(ex);
+            Assert.Single(list, a => a.Addr == 0x1000u && a.Info == "NoFile@ADDRESS");
+        }
+
         [Fact]
         public void EmitPatchAddr_PerTokenUnsafe_SkipsOnlyThatEntry()
         {
@@ -372,6 +406,19 @@ namespace FEBuilderGBA.Core.Tests
             var a = Single(list, "Z@SWITCH");
             Assert.Equal(0x4000u, a.Addr);
             Assert.DoesNotContain(list, x => x.Addr == 0x100u);
+        }
+
+        [Fact]
+        public void EmitPatchSwitch_NullArgs_Throw()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            var patch = MakePatch("p", ("ONN:0x1000", "AA"));
+            Assert.Throws<ArgumentNullException>(() => RebuildProducerCore.EmitPatchSwitch(null, list, patch, false));
+            Assert.Throws<ArgumentNullException>(() => RebuildProducerCore.EmitPatchSwitch(rom, null, patch, false));
+            Assert.Throws<ArgumentNullException>(() => RebuildProducerCore.EmitPatchSwitch(rom, list, null, false));
+            var noParam = new PatchInstallCore.PatchSt { Name = "p", PatchFileName = "p.txt", Param = null };
+            Assert.Throws<ArgumentNullException>(() => RebuildProducerCore.EmitPatchSwitch(rom, list, noParam, false));
         }
 
         // ====================================================================

--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchScaffoldTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchScaffoldTests.cs
@@ -234,9 +234,22 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void MakePatchStructDataListCore_NoPatchDir_EmitsNothing_NoThrow()
         {
-            // BaseDirectory has no config/patch2/<version> tree -> ScanPatchs returns
+            // An EMPTY config/patch2/<version> tree under BaseDirectory -> ScanPatchs returns
             // empty -> the orchestrator does nothing and the list stays empty.
-            CoreState.BaseDirectory = _tempDir; // empty temp dir, no patch tree
+            //
+            // The version dir is created EMPTY (not just absent) so PatchHardCodeScanner.
+            // ResolvePatchDirectory returns THIS path (the first existing root) instead of
+            // falling through to AppContext.BaseDirectory — the test-output bin/, which in CI
+            // carries the build-copied REAL config/patch2/FE8U tree. Before the s2pf-3 ADDR/
+            // SWITCH arms emitted, that fallback was harmless (every TYPE arm was a no-op stub
+            // regardless of what got scanned); now a fallback to the real FE8U tree would emit
+            // genuine @ADDRESS/@SWITCH entries and the empty-list assertion would (correctly)
+            // fail. Pinning an empty version dir keeps the test's "no patches -> nothing"
+            // intent robust in CI (where the submodule is checked out) and locally (where it
+            // is not).
+            string emptyPatchDir = Path.Combine(_tempDir, "config", "patch2", "FE8U");
+            Directory.CreateDirectory(emptyPatchDir); // exists but contains no PATCH_*.txt
+            CoreState.BaseDirectory = _tempDir;
             var fe8 = MakeVersionedRom("BE8E01");
             CoreState.ROM = fe8;
 

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -12599,13 +12599,26 @@ namespace FEBuilderGBA
         /// <param name="isPointerOnly">WF <c>isPointerOnly</c> — when true the BIN length is 0.</param>
         public static void EmitPatchAddr(ROM rom, List<Address> list, PatchInstallCore.PatchSt patch, bool isPointerOnly)
         {
+            // Public-helper guards (consistent with CalcAddrLength / MakePointerIndexes): throw
+            // a clear ArgumentNullException rather than an unhelpful NRE on bad input. The
+            // orchestrator always passes a valid rom/list and a LoadPatch result whose Param is
+            // non-null, so these never fire on the real producer path.
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (list == null) throw new ArgumentNullException(nameof(list));
+            if (patch == null) throw new ArgumentNullException(nameof(patch));
+            if (patch.Param == null) throw new ArgumentNullException(nameof(patch) + ".Param");
+
             string address_string = U.at(patch.Param, "ADDRESS");
             if (address_string.Length <= 0)
             {
                 return;
             }
 
-            string basedir = System.IO.Path.GetDirectoryName(patch.PatchFileName);
+            // Path.GetDirectoryName can return null (e.g. a PatchFileName with no directory part);
+            // normalize to "" so the resolver never receives a null basedir (avoids $FGREP
+            // exception-driven control flow). WF's basedir can be null, but ResolvePatchAddress ->
+            // Resolve treats null/"" identically, so "" is byte-faithful.
+            string basedir = System.IO.Path.GetDirectoryName(patch.PatchFileName) ?? "";
             string[] address_sp;
             uint addr;
             if (address_string[0] == '$')
@@ -12663,7 +12676,18 @@ namespace FEBuilderGBA
         /// <param name="isPointerOnly">WF <c>isPointerOnly</c> — when true the BIN length is 0.</param>
         public static void EmitPatchSwitch(ROM rom, List<Address> list, PatchInstallCore.PatchSt patch, bool isPointerOnly)
         {
-            string basedir = System.IO.Path.GetDirectoryName(patch.PatchFileName);
+            // Public-helper guards (consistent with CalcAddrLength / MakePointerIndexes): throw a
+            // clear ArgumentNullException rather than an unhelpful NRE on bad input. The
+            // orchestrator always passes a valid rom/list and a LoadPatch result whose Param is
+            // non-null, so these never fire on the real producer path.
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (list == null) throw new ArgumentNullException(nameof(list));
+            if (patch == null) throw new ArgumentNullException(nameof(patch));
+            if (patch.Param == null) throw new ArgumentNullException(nameof(patch) + ".Param");
+
+            // Normalize basedir to "" (Path.GetDirectoryName can return null) — byte-faithful for
+            // the resolver, which treats null/"" identically. See EmitPatchAddr note.
+            string basedir = System.IO.Path.GetDirectoryName(patch.PatchFileName) ?? "";
             foreach (var pair in patch.Param)
             {
                 if (pair.Key.IndexOf("ONN:") != 0)

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -12488,7 +12488,8 @@ namespace FEBuilderGBA
 
                 if (type == "ADDR")
                 {
-                    // s2pf-3: TYPE=ADDR handler (WF MakePatchStructDataListForADDR @:6213). STUB.
+                    // s2pf-3: TYPE=ADDR handler (WF MakePatchStructDataListForADDR @:6213).
+                    EmitPatchAddr(rom, list, patch, isPointerOnly);
                 }
                 else if (type == "EA")
                 {
@@ -12500,7 +12501,8 @@ namespace FEBuilderGBA
                 }
                 else if (type == "SWITCH")
                 {
-                    // s2pf-6: TYPE=SWITCH handler (WF MakePatchStructDataListForSWITCH @:6425). STUB.
+                    // s2pf-3: TYPE=SWITCH handler (WF MakePatchStructDataListForSWITCH @:6425).
+                    EmitPatchSwitch(rom, list, patch, isPointerOnly);
                 }
                 else if (type == "STRUCT")
                 {
@@ -12539,6 +12541,161 @@ namespace FEBuilderGBA
                 return rom.RomInfo.VersionToFilename ?? "";
             }
             catch { return ""; }
+        }
+
+        // ====================================================================
+        // PatchForm producer — option-B epic (#1261, sub-slice s2pf-3 of 11).
+        //
+        // The two TRIVIAL terminal TYPE arms: ADDR and SWITCH. Faithful Core
+        // ports of WinForms PatchForm.MakePatchStructDataListForADDR
+        // (FEBuilderGBA/PatchForm.cs:6213) and MakePatchStructDataListForSWITCH
+        // (FEBuilderGBA/PatchForm.cs:6425). Both turn a patch's ADDRESS / ON:OFF:
+        // params into BIN/MIX Address entries, sized by the s2pf-2 helpers
+        // (CalcAddrLength for ADDR, the SWITCH value's space-token count for
+        // SWITCH) and resolved by the s2pf-2 ResolvePatchAddress wrapper.
+        //
+        // INHERITED FAILURE-CONTRACT DIVERGENCE (from s2pf-2, NOT new here):
+        //   WF convertBinAddressString THROWS PatchException for an unsafe $0x
+        //   deref / unknown macro. The WF MakePatchStructDataList outer loop
+        //   (PatchForm.cs:7126), U.AppendAllASMStructPointersList (U.cs:2619),
+        //   ToolROMRebuildMake.Make and the ToolROMRebuildForm.Make button +
+        //   ComandLineRebuild callers have NO try/catch, so that throw would
+        //   propagate to the top-level handler and ABORT the whole rebuild.
+        //   The merged s2pf-2 resolver (PatchMacroAddressResolverCore.Resolve,
+        //   try/catch -> U.NOT_FOUND; ResolvePatchAddress is built on it) maps
+        //   every unsafe/unknown macro to U.NOT_FOUND instead, which fails the
+        //   isSafetyOffset guard below and SKIPS that one entry. The net
+        //   difference (skip-entry vs abort-rebuild) manifests ONLY on a
+        //   malformed/anomalous ADDRESS/SWITCH param — a patch-data defect — and
+        //   in that pathological case skip-entry is strictly safer than aborting
+        //   the defrag. Full byte-for-byte parity over real config/patch2 data is
+        //   covered by s2pf-11. This is an intentional inherited contract, NOT a
+        //   verbatim throw (pinned by RebuildProducerPatchAddr's unsafe-$0x test).
+        //
+        // These arms emit into the orchestrator's list but are NOT wired into the
+        // live producer (s2pf-11), so "PatchForm(MakePatchStructDataList)" STAYS
+        // in AsmNotYetPortedRaw.
+        // ====================================================================
+
+        /// <summary>
+        /// Faithful Core port of WinForms <c>PatchForm.MakePatchStructDataListForADDR</c>
+        /// (FEBuilderGBA/PatchForm.cs:6213). Reads the patch <c>ADDRESS</c> param: a
+        /// <c>$</c>-prefixed macro is resolved once (WF <c>convertBinAddressString(addr,
+        /// 0, 0x100, basedir)</c> -> <see cref="ResolvePatchAddress"/> with
+        /// <c>appnedSize=0, startOffset=0x100</c>) and, if safe, treated as a single
+        /// address; otherwise the literal string is space-split into one-or-more hex
+        /// addresses. The BIN byte length is <see cref="CalcAddrLength"/> (0 when
+        /// <paramref name="isPointerOnly"/>). Each safe address emits one
+        /// <see cref="Address"/> named <c>Name@ADDRESS</c>, typed
+        /// <see cref="Address.DataTypeEnum.BIN"/> when <c>length &lt; 4</c> else
+        /// <see cref="Address.DataTypeEnum.MIX"/> (mis-classifying a &gt;=4 entry as BIN
+        /// would drop its pointer sub-scan during rebuild = corruption). The per-address
+        /// <see cref="U.isSafetyOffset(uint, ROM)"/> guard skips only that entry, never
+        /// the whole patch — verbatim WF.
+        /// </summary>
+        /// <param name="rom">ROM to resolve against — passed explicitly (NEVER CoreState.ROM / Program.ROM).</param>
+        /// <param name="list">The accumulating struct/pointer list (appended to).</param>
+        /// <param name="patch">The TYPE=ADDR patch whose <c>ADDRESS</c>/<c>COMBO</c> params drive emission.</param>
+        /// <param name="isPointerOnly">WF <c>isPointerOnly</c> — when true the BIN length is 0.</param>
+        public static void EmitPatchAddr(ROM rom, List<Address> list, PatchInstallCore.PatchSt patch, bool isPointerOnly)
+        {
+            string address_string = U.at(patch.Param, "ADDRESS");
+            if (address_string.Length <= 0)
+            {
+                return;
+            }
+
+            string basedir = System.IO.Path.GetDirectoryName(patch.PatchFileName);
+            string[] address_sp;
+            uint addr;
+            if (address_string[0] == '$')
+            {//マクロ展開. (WF: convertBinAddressString(address_string, 0, 0x100, basedir) //check only.)
+                addr = ResolvePatchAddress(rom, address_string, 0, 0x100, basedir);
+                if (!U.isSafetyOffset(addr, rom))
+                {
+                    return;
+                }
+                address_sp = new string[] { U.To0xHexString(addr) };
+            }
+            else
+            {//直値か、直値が複数.
+                address_sp = address_string.Split(' ');
+            }
+
+            uint length = 0;
+            if (isPointerOnly == false)
+            {
+                length = CalcAddrLength(patch);
+            }
+
+            for (int n = 0; n < address_sp.Length; n++)
+            {
+                uint a = U.toOffset(U.atoi0x(address_sp[n]));
+                if (!U.isSafetyOffset(a, rom)) continue;
+
+                if (length < 4)
+                {
+                    Address.AddAddress(list, a, length, U.NOT_FOUND, patch.Name + "@ADDRESS", Address.DataTypeEnum.BIN);
+                }
+                else
+                {
+                    Address.AddAddress(list, a, length, U.NOT_FOUND, patch.Name + "@ADDRESS", Address.DataTypeEnum.MIX);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Faithful Core port of WinForms <c>PatchForm.MakePatchStructDataListForSWITCH</c>
+        /// (FEBuilderGBA/PatchForm.cs:6425). Iterates <c>patch.Param</c>, acting only on keys
+        /// prefixed <c>ONN:</c> or <c>OFF:</c> (VERBATIM WF prefixes — WF uses <c>"ONN:"</c>,
+        /// not <c>"ON:"</c>). The address is the <c>:</c>-split key's second token, resolved
+        /// by <see cref="ResolvePatchAddress"/> with <c>appnedSize=8, startOffset=0</c> (WF
+        /// <c>convertBinAddressString(op[1], 8, 0, basedir)</c>, called UNCONDITIONALLY — the
+        /// <c>$</c>-vs-literal branch lives inside the resolver). The BIN byte length is the
+        /// space-token count of the param VALUE (0 when <paramref name="isPointerOnly"/>).
+        /// Each safe address emits one <see cref="Address"/> named <c>Name@SWITCH</c>, typed
+        /// BIN when <c>length &lt; 4</c> else MIX. The per-pair
+        /// <see cref="U.isSafetyOffset(uint, ROM)"/> guard skips only that pair — verbatim WF.
+        /// </summary>
+        /// <param name="rom">ROM to resolve against — passed explicitly (NEVER CoreState.ROM / Program.ROM).</param>
+        /// <param name="list">The accumulating struct/pointer list (appended to).</param>
+        /// <param name="patch">The TYPE=SWITCH patch whose <c>ONN:</c>/<c>OFF:</c> params drive emission.</param>
+        /// <param name="isPointerOnly">WF <c>isPointerOnly</c> — when true the BIN length is 0.</param>
+        public static void EmitPatchSwitch(ROM rom, List<Address> list, PatchInstallCore.PatchSt patch, bool isPointerOnly)
+        {
+            string basedir = System.IO.Path.GetDirectoryName(patch.PatchFileName);
+            foreach (var pair in patch.Param)
+            {
+                if (pair.Key.IndexOf("ONN:") != 0)
+                {
+                    if (pair.Key.IndexOf("OFF:") != 0)
+                    {
+                        continue;
+                    }
+                }
+                string[] op = pair.Key.Split(':');
+                if (op.Length < 2)
+                {
+                    continue;
+                }
+                uint length = 0;
+                if (isPointerOnly == false)
+                {
+                    length = (uint)pair.Value.Split(' ').Length;
+                }
+
+                uint a = ResolvePatchAddress(rom, op[1], 8, 0, basedir);
+                if (!U.isSafetyOffset(a, rom)) continue;
+
+                if (length < 4)
+                {
+                    Address.AddAddress(list, a, length, U.NOT_FOUND, patch.Name + "@SWITCH", Address.DataTypeEnum.BIN);
+                }
+                else
+                {
+                    Address.AddAddress(list, a, length, U.NOT_FOUND, patch.Name + "@SWITCH", Address.DataTypeEnum.MIX);
+                }
+            }
         }
 
         // ====================================================================

--- a/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
+++ b/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
@@ -260,8 +260,12 @@ namespace FEBuilderGBA.Tests.Unit
         /// (Core's leaner LoadPatch omits Name, so its Info is just "@ADDRESS"; WF prepends the patch
         /// name). A Core-extra (Core emits an @ADDRESS/@SWITCH entry WF does not) is a faithfulness
         /// regression and FAILS. WF-extras are expected only if Core's gate diverges — but the gate is a
-        /// faithful port, so for ADDR/SWITCH the two sets must match exactly; this test asserts the
-        /// STRICT Core ⊆ WF direction (the regression-proof one) and logs any WF-only count.
+        /// faithful port, so for ADDR/SWITCH the two key sets must match EXACTLY when the patch tree
+        /// is present. This test asserts FULL set equality — both Core-extras (Core emits an entry WF
+        /// does not = faithfulness regression) AND WF-extras (WF emits an entry Core does not = Core
+        /// silently dropped a real patch entry) FAIL. The latter direction closes the gap a Core ⊆ WF
+        /// only check would leave (it passes vacuously even if Core drops every entry — Copilot CLI
+        /// PR #1313 review).
         /// <para>SKIP-IF-NO-ROM: requires <c>roms/FE8U.gba</c> (gitignored — absent in CI / the worktree,
         /// present in the user's main checkout). When no ROM is found the test returns early (Pass).</para>
         /// <para><b>NON-VACUOUS only where <c>config/patch2</c> is CHECKED OUT.</b> Both producers walk the
@@ -276,7 +280,7 @@ namespace FEBuilderGBA.Tests.Unit
         /// full-producer parity (once the orchestrator is wired) covers the end-to-end path.</para>
         /// </summary>
         [Fact]
-        public void CorePatchAddrSwitchArms_AreSubsetOf_WinFormsPatchProducer()
+        public void CorePatchAddrSwitchArms_MatchExactly_WinFormsPatchProducer()
         {
             string? repoRoot = FindRepoRootWithRom();
             if (repoRoot == null) return; // no checkout with roms/FE8U.gba reachable — early-exit (Pass)
@@ -321,25 +325,45 @@ namespace FEBuilderGBA.Tests.Unit
                 var coreArm = coreAll.Where(IsArmEntry).ToList();
 
                 var wfKeys = new HashSet<Key>(wfArm.Select(Key.Of));
+                var coreKeys = new HashSet<Key>(coreArm.Select(Key.Of));
+
+                // Core-extras = Core emits an @ADDRESS/@SWITCH key WF does not. ALWAYS a regression
+                // (faithfulness). WF-extras = WF emits a key Core does not = Core SILENTLY DROPPED a
+                // real patch entry — for these two arms (same faithful gate + same resolver) the key
+                // sets MUST match exactly when the patch tree is present, so a WF-extra is ALSO a
+                // regression (the gap Copilot CLI flagged: a Core⊆WF-only check passes vacuously even
+                // when Core drops every entry). Assert FULL set equality. When config/patch2 is absent
+                // (this worktree / un-init submodule) BOTH sets are empty and equality holds trivially.
                 var coreExtras = coreArm.Where(a => !wfKeys.Contains(Key.Of(a)))
                                         .Select(Key.Of).Distinct().ToList();
+                var wfExtras = wfArm.Where(a => !coreKeys.Contains(Key.Of(a)))
+                                    .Select(Key.Of).Distinct().ToList();
 
-                if (coreExtras.Count > 0)
+                static string Dump(System.Collections.Generic.IEnumerable<Key> keys)
                 {
                     const int N = 30;
-                    string dump = string.Join("\n", coreExtras.Take(N).Select(k =>
-                        $"  Addr=0x{k.Addr:X} Len=0x{k.Length:X} Ptr=0x{k.Pointer:X} Type={k.Type}"));
-                    Assert.Fail(
-                        $"Core PatchForm ADDR/SWITCH arms emitted {coreExtras.Count} entr"
-                        + (coreExtras.Count == 1 ? "y" : "ies")
-                        + " NOT present in the WinForms patch producer (faithfulness regression).\n"
-                        + $"WF @ADDRESS/@SWITCH total={wfArm.Count}, Core total={coreArm.Count}.\n"
-                        + $"First {Math.Min(N, coreExtras.Count)} Core-only entries:\n{dump}");
+                    var l = keys.ToList();
+                    return string.Join("\n", l.Take(N).Select(k =>
+                        $"  Addr=0x{k.Addr:X} Len=0x{k.Length:X} Ptr=0x{k.Pointer:X} Type={k.Type}"))
+                        + (l.Count > N ? $"\n  ... (+{l.Count - N} more)" : "");
                 }
 
-                // PROVEN: every Core @ADDRESS/@SWITCH entry is byte-identical (Addr/Length/Pointer/
-                // DataType) to a WinForms one — Core ⊆ WF for the two ported arms on the real ROM.
+                if (coreExtras.Count > 0 || wfExtras.Count > 0)
+                {
+                    Assert.Fail(
+                        "Core PatchForm ADDR/SWITCH arms diverge from the WinForms patch producer "
+                        + "(faithfulness regression).\n"
+                        + $"WF @ADDRESS/@SWITCH total={wfArm.Count}, Core total={coreArm.Count}.\n"
+                        + $"Core-only entries (Core emits, WF does not) [{coreExtras.Count}]:\n{Dump(coreExtras)}\n"
+                        + $"WF-only entries (Core SILENTLY DROPPED) [{wfExtras.Count}]:\n{Dump(wfExtras)}");
+                }
+
+                // PROVEN: the Core and WinForms @ADDRESS/@SWITCH key sets are EQUAL on
+                // (Addr/Length/Pointer/DataType) — no Core-extra (faithfulness) and no dropped
+                // Core entry — for the two ported arms on the real ROM (or both empty when the
+                // submodule is absent).
                 Assert.Empty(coreExtras);
+                Assert.Empty(wfExtras);
             }
             finally
             {

--- a/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
+++ b/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
@@ -246,6 +246,107 @@ namespace FEBuilderGBA.Tests.Unit
             }
         }
 
+        /// <summary>
+        /// PARTIAL WF-parity for #1261 slice s2pf-3 — the PatchForm producer ADDR + SWITCH
+        /// dispatch arms (<see cref="RebuildProducerCore.EmitPatchAddr"/> /
+        /// <see cref="RebuildProducerCore.EmitPatchSwitch"/>). Both the WinForms reference
+        /// (<c>PatchForm.MakePatchStructDataList</c>, PatchForm.cs:7126) and the Core orchestrator
+        /// (<see cref="RebuildProducerCore.MakePatchStructDataListCore"/>) are run on the SAME real
+        /// FE8U ROM with the SAME rebuild flags (isPointerOnly=false, isInstallOnly=true,
+        /// isStructOnly=false — the <c>ToolROMRebuildMake.Make</c> -&gt; <c>AppendAllASMStructPointersList</c>
+        /// callsite, ToolROMRebuildMake.cs:820). Each side is FILTERED to entries whose <c>Info</c> ends
+        /// <c>@ADDRESS</c> / <c>@SWITCH</c> (the names the two arms emit), then compared as
+        /// Core ⊆ WF on the load-bearing fields (Addr/Length/Pointer/DataType) — Info/name is cosmetic
+        /// (Core's leaner LoadPatch omits Name, so its Info is just "@ADDRESS"; WF prepends the patch
+        /// name). A Core-extra (Core emits an @ADDRESS/@SWITCH entry WF does not) is a faithfulness
+        /// regression and FAILS. WF-extras are expected only if Core's gate diverges — but the gate is a
+        /// faithful port, so for ADDR/SWITCH the two sets must match exactly; this test asserts the
+        /// STRICT Core ⊆ WF direction (the regression-proof one) and logs any WF-only count.
+        /// <para>SKIP-IF-NO-ROM: requires <c>roms/FE8U.gba</c> (gitignored — absent in CI / the worktree,
+        /// present in the user's main checkout). When no ROM is found the test returns early (Pass).</para>
+        /// <para><b>NON-VACUOUS only where <c>config/patch2</c> is CHECKED OUT.</b> Both producers walk the
+        /// <c>config/patch2/&lt;version&gt;</c> submodule tree; where that submodule is un-initialized (the
+        /// known-env state of this worktree and the local main checkout — <c>git submodule status</c> shows a
+        /// leading <c>-</c>), there are no ADDR/SWITCH patch files, so BOTH filtered lists are empty and the
+        /// Core ⊆ WF assertion holds vacuously (still a valid, passing real-ROM run that proves no Core-extra,
+        /// just with nothing to compare). The branch-level verification — every ADDR/SWITCH code path, the
+        /// BIN/MIX length boundary, the per-address isSafetyOffset skip, the inherited unsafe-$0x divergence —
+        /// is carried by the synthetic Core.Tests (<c>RebuildProducerPatchAddrSwitchTests</c>, 21 cases). This
+        /// harness gains teeth automatically wherever <c>config/patch2</c> is populated, and s2pf-11's
+        /// full-producer parity (once the orchestrator is wired) covers the end-to-end path.</para>
+        /// </summary>
+        [Fact]
+        public void CorePatchAddrSwitchArms_AreSubsetOf_WinFormsPatchProducer()
+        {
+            string? repoRoot = FindRepoRootWithRom();
+            if (repoRoot == null) return; // no checkout with roms/FE8U.gba reachable — early-exit (Pass)
+            string romPath = Path.Combine(repoRoot, "roms", "FE8U.gba");
+            if (!File.Exists(romPath)) return; // no ROM (gitignored, absent in CI) — early-exit (Pass)
+
+            string savedBaseDir = CoreState.BaseDirectory;
+            try
+            {
+                CoreState.BaseDirectory = repoRoot;
+                ForceCommandLineMode();
+                BootstrapWinFormsProgram(repoRoot);
+
+                bool loaded = Program.LoadROM(romPath, "");
+                if (!loaded || Program.ROM == null) return; // ROM did not load — early-exit (Pass)
+                if (Program.ROM.RomInfo.version != 8) return; // calibrated on FE8U — early-exit (Pass)
+
+                // Re-scan CheckIF exactly as ToolROMRebuildMake.Make does (PatchForm.ClearCheckIF
+                // before the producer) so the WF and Core gates see the same installed state.
+                PatchForm.ClearCheckIF();
+
+                // ---- WinForms reference: the public patch producer, same flags as the rebuild ----
+                var wfAll = new List<Address>();
+                PatchForm.MakePatchStructDataList(wfAll,
+                    isPointerOnly: IS_PATCH_POINTER_ONLY,
+                    isInstallOnly: IS_PATCH_INSTALL_ONLY,
+                    isStructOnly: IS_PATCH_STRUCT_ONLY);
+
+                // ---- Core: the orchestrator, same flags + the SAME ROM ----
+                var coreAll = new List<Address>();
+                RebuildProducerCore.MakePatchStructDataListCore(Program.ROM, coreAll,
+                    isPointerOnly: IS_PATCH_POINTER_ONLY,
+                    isInstallOnly: IS_PATCH_INSTALL_ONLY,
+                    isStructOnly: IS_PATCH_STRUCT_ONLY);
+
+                // Filter BOTH to the two arms' entries (Info ends @ADDRESS / @SWITCH).
+                static bool IsArmEntry(Address a) =>
+                    a.Info != null && (a.Info.EndsWith("@ADDRESS", StringComparison.Ordinal)
+                                       || a.Info.EndsWith("@SWITCH", StringComparison.Ordinal));
+
+                var wfArm = wfAll.Where(IsArmEntry).ToList();
+                var coreArm = coreAll.Where(IsArmEntry).ToList();
+
+                var wfKeys = new HashSet<Key>(wfArm.Select(Key.Of));
+                var coreExtras = coreArm.Where(a => !wfKeys.Contains(Key.Of(a)))
+                                        .Select(Key.Of).Distinct().ToList();
+
+                if (coreExtras.Count > 0)
+                {
+                    const int N = 30;
+                    string dump = string.Join("\n", coreExtras.Take(N).Select(k =>
+                        $"  Addr=0x{k.Addr:X} Len=0x{k.Length:X} Ptr=0x{k.Pointer:X} Type={k.Type}"));
+                    Assert.Fail(
+                        $"Core PatchForm ADDR/SWITCH arms emitted {coreExtras.Count} entr"
+                        + (coreExtras.Count == 1 ? "y" : "ies")
+                        + " NOT present in the WinForms patch producer (faithfulness regression).\n"
+                        + $"WF @ADDRESS/@SWITCH total={wfArm.Count}, Core total={coreArm.Count}.\n"
+                        + $"First {Math.Min(N, coreExtras.Count)} Core-only entries:\n{dump}");
+                }
+
+                // PROVEN: every Core @ADDRESS/@SWITCH entry is byte-identical (Addr/Length/Pointer/
+                // DataType) to a WinForms one — Core ⊆ WF for the two ported arms on the real ROM.
+                Assert.Empty(coreExtras);
+            }
+            finally
+            {
+                CoreState.BaseDirectory = savedBaseDir;
+            }
+        }
+
         // ----------------------------------------------------------------
         readonly struct Key : IEquatable<Key>
         {


### PR DESCRIPTION
## Summary

Sub-slice **3/11** of the option-B `PatchForm(MakePatchStructDataList)` producer epic. Replaces the two TRIVIAL terminal no-op stubs in the `RebuildProducerCore.MakePatchStructDataListCore` orchestrator's TYPE switch with faithful WinForms→Core ports:

- **`EmitPatchAddr`** = WF `PatchForm.MakePatchStructDataListForADDR` (`FEBuilderGBA/PatchForm.cs:6213`)
- **`EmitPatchSwitch`** = WF `PatchForm.MakePatchStructDataListForSWITCH` (`FEBuilderGBA/PatchForm.cs:6425`)

Both turn a patch's `ADDRESS` / `ONN:`/`OFF:` params into BIN/MIX `Address` entries, sized by the s2pf-2 helpers (`CalcAddrLength` for ADDR; the param value's space-token count for SWITCH) and resolved by the s2pf-2 `ResolvePatchAddress` wrapper. `rom` is threaded explicitly (never `CoreState.ROM`/`Program.ROM`).

### Faithfulness (verbatim WF)
- The `length < 4 ? BIN : MIX` classification is load-bearing — mis-typing a `>=4` entry as BIN would drop its pointer sub-scan during rebuild (corruption). Boundary pinned at 3/4/5.
- VERBATIM `"ONN:"`/`"OFF:"` SWITCH prefixes (WF uses `ONN:`, **not** `ON:`); the `op.Length<2` skip; the `@ADDRESS`/`@SWITCH` names; the literal `Split(' ')` tokenization; the per-address `isSafetyOffset(a, rom)` continue-guard (skips only that entry, never the whole patch).
- SWITCH calls `ResolvePatchAddress(op[1], 8, 0)` **unconditionally** — the `$`-vs-literal branch lives inside the resolver (the faithful port of the whole `convertBinAddressString`).

### Inherited s2pf-2 failure-contract divergence (documented + tested, NOT new)
WF `convertBinAddressString` throws `PatchException` on an unsafe `$0x` deref / unknown macro, and the WF call chain (`MakePatchStructDataList@:7126`, `U.AppendAllASMStructPointersList@:2619`, `ToolROMRebuildMake.Make`, the form button + `ComandLineRebuild`) has **no** try/catch — so that throw aborts the whole rebuild. The merged s2pf-2 resolver maps it to `U.NOT_FOUND`, which fails `isSafetyOffset` and **skips only that entry**. The net difference manifests only on a malformed/anomalous param (a patch-data defect), where skip-entry is strictly safer than aborting the defrag. Documented in the arm code and pinned by a unit test. Raised by Copilot CLI on the plan; traced + resolved (see issue #1261 thread).

## Scope
- **3/11.** The orchestrator is still **NOT wired** into the live producer (that is s2pf-11), so the gate token `"PatchForm(MakePatchStructDataList)"` **STAYS** in `AsmNotYetPortedRaw` (`IsComplete` stays false; the rebuild Make gate stays closed). Existing token-pinning tests (`Assert.Contains("PatchForm(MakePatchStructDataList)", ...)`) still pass.
- Core-only, no GUI → no screenshot.

Part of #1261.

## Test plan
- [x] `RebuildProducerPatchAddrSwitchTests` (Core.Tests, **21 cases**): synthetic ROM + `PatchSt` — literal/multi/`$0x`-macro ADDR; `ONN:`/`OFF:` SWITCH; the **BIN/MIX length boundary** (3→BIN, 4→MIX, 5→MIX) for both arms; per-address `isSafetyOffset` skip (only that entry); `isPointerOnly`→length 0; empty ADDRESS→nothing; non-`ONN:`/`OFF:` + `op.Length<2` skips; the **inherited unsafe-`$0x` SKIP-no-throw** + unknown-macro skip; and an **orchestrator integration test** on a staged `config/patch2` tree (proves the switch arms are wired).
- [x] `RebuildProducerWFParityTests.CorePatchAddrSwitchArms_AreSubsetOf_WinFormsPatchProducer` (FEBuilderGBA.Tests, net9.0-windows, skip-if-no-ROM): runs WF `PatchForm.MakePatchStructDataList` and Core `MakePatchStructDataListCore` on the real **FE8U** ROM with the rebuild flags, filters both to `@ADDRESS`/`@SWITCH`, asserts **Core ⊆ WF** on (addr,length,pointer,type). Non-vacuous only where `config/patch2` is checked out (documented); the 21 synthetic cases carry branch-level verification.
- [x] `dotnet test FEBuilderGBA.Core.Tests --filter RebuildProducer` → **529 pass** (508 baseline + 21), 0 failed.
- [x] Full `Core.Tests` → 5012 pass / 10 known-env `Skill*` failures (un-checked-out `config/patch2` submodule — pass in CI).
- [x] `FEBuilderGBA.Tests` (net9.0-windows) → **1868 pass**, 0 failed.
- [x] `dotnet build FEBuilderGBA.sln` → clean, 0 errors.

## Deferred
Nothing for this slice. ADDR + SWITCH are the two trivial terminal arms; EA / BIN / STRUCT / IMAGE remain stubs for s2pf-4..8, and wiring into the live producer is s2pf-11.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
