### PR TITLE
feat(core): PatchForm IMAGE dispatch arm (6/8 variants) (#1261 s2pf-4)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchImageTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchImageTests.cs
@@ -1,0 +1,526 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for RebuildProducerCore slice s2pf-4 (#1261) — the TYPE=IMAGE terminal
+// PatchForm producer arm (option-B epic, sub-slice 4 of 11):
+//   RebuildProducerCore.EmitPatchImage          = WF PatchForm.MakePatchStructDataListForIMAGE @:6738
+//   RebuildProducerCore.PatchImageVariantLength = the reusable per-variant length math
+//                                                 (factored so s2pf-5 STRUCT PatchImage_* reuses it).
+//
+// 6 of 8 variants ported (HEADERTSA_POINTER DEFERRED to s2pf-7 — needs
+// CalcByteLengthForHeaderTSAData). Coverage (synthetic in-memory FE8U ROM +
+// synthetic PatchSt — no real GBA ROM file, mirroring RebuildProducerPatchAddrSwitchTests):
+//   1. EmitPatchImage:
+//        - IMAGE_POINTER    -> w*h/2,  IMG     (raw 4bpp)
+//        - ZIMAGE_POINTER   -> LZ77,   LZ77IMG (hand-authored stream, getCompressedSize)
+//        - Z256IMAGE_POINTER-> LZ77,   LZ77IMG
+//        - TSA_POINTER      -> w*h/32, TSA
+//        - ZTSA_POINTER     -> LZ77,   LZ77TSA
+//        - ZHEADERTSA_POINTER -> LZ77, LZ77TSA
+//        - PALETTE_POINTER  -> count*0x20, PAL  (count default 1; explicit count)
+//        - PALETTE_ADDRESS  -> count*0x20, PAL  (direct address, pointer slot NOT_FOUND;
+//                              only when PALETTE_POINTER absent/unsafe)
+//        - WIDTH/HEIGHT default "8"; PALETTE default "1"
+//        - emitted Address addr/length/pointer/type/name byte-faithful to WF
+//        - HEADERTSA_POINTER (the NON-Z variant) is NOT (wrongly) emitted — DEFERRED.
+//        - per-variant safety gates (p==0 for IMAGE/ZIMAGE/Z256IMAGE; unsafe slot; unsafe target)
+//        - all-variants-absent -> nothing (no-op), null-arg guards.
+//   2. PatchImageVariantLength: the raw math (IMAGE=w*h/2, TSA=w*h/32, PALETTE=count*0x20,
+//      LZ77 variants = getCompressedSize), and the unknown-key throw.
+//   3. Integration through the public orchestrator MakePatchStructDataListCore on a staged
+//      config/patch2 tree (proves the IMAGE switch arm is wired).
+//   4. The no-patch-dir invariant is re-asserted in RebuildProducerPatchScaffoldTests; this
+//      file additionally proves the IMAGE arm is a clean no-op when its params are absent.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class RebuildProducerPatchImageTests : IDisposable
+    {
+        readonly ROM _savedRom = CoreState.ROM;
+        readonly string _savedLang = CoreState.Language;
+        readonly string _savedBaseDir = CoreState.BaseDirectory;
+        string? _tempDir;
+
+        public RebuildProducerPatchImageTests()
+        {
+            CoreState.Language = "en";
+        }
+
+        public void Dispose()
+        {
+            CoreState.ROM = _savedRom;
+            CoreState.Language = _savedLang;
+            CoreState.BaseDirectory = _savedBaseDir;
+            try { if (_tempDir != null && Directory.Exists(_tempDir)) Directory.Delete(_tempDir, true); } catch { }
+        }
+
+        // 16 MiB zero-filled FE8U ROM (LoadLow minimum for BE8E01) — same idiom as
+        // RebuildProducerPatchAddrSwitchTests.MakeRom. Also sets CoreState.ROM (the
+        // Address.AddAddress sink uses the single-arg U.isSafetyOffset overload bound to it).
+        static ROM MakeRom()
+        {
+            var rom = new ROM();
+            byte[] data = new byte[0x1000000];
+            bool ok = rom.LoadLow("x.gba", data, "BE8E01");
+            Assert.True(ok, "LoadLow did not recognize BE8E01");
+            CoreState.ROM = rom;
+            return rom;
+        }
+
+        static PatchInstallCore.PatchSt MakePatch(string name, params (string key, string value)[] kv)
+        {
+            var p = new PatchInstallCore.PatchSt
+            {
+                Name = name,
+                PatchFileName = name + ".txt",
+                Param = new Dictionary<string, string>()
+            };
+            foreach (var (key, value) in kv)
+            {
+                p.Param[key] = value;
+            }
+            return p;
+        }
+
+        static Address Single(List<Address> list, string info)
+        {
+            return Assert.Single(list, a => a.Info == info);
+        }
+
+        // Hand-author a VALID all-literal LZ77 stream of `uncompSize` uncompressed bytes at `offset`
+        // (slice-2e idiom from RebuildProducerCoreTests.WriteLz77AllLiteral). Returns the byte length the
+        // stream occupies (== LZ77.getCompressedSize on it): header(4) + ceil(N/8) flags + N literals.
+        static uint WriteLz77AllLiteral(ROM rom, uint offset, int uncompSize)
+        {
+            var bytes = new List<byte>();
+            bytes.Add(0x10);
+            bytes.Add((byte)(uncompSize & 0xFF));
+            bytes.Add((byte)((uncompSize >> 8) & 0xFF));
+            bytes.Add((byte)((uncompSize >> 16) & 0xFF));
+            int written = 0;
+            while (written < uncompSize)
+            {
+                bytes.Add(0x00); // flag: next 8 bytes all literal
+                for (int b = 0; b < 8 && written < uncompSize; b++, written++)
+                {
+                    bytes.Add((byte)(0x40 + (written & 0x3F)));
+                }
+            }
+            for (int i = 0; i < bytes.Count; i++)
+            {
+                rom.write_u8(offset + (uint)i, bytes[i]);
+            }
+            uint clen = LZ77.getCompressedSize(rom.Data, offset);
+            Assert.True(clen > 0, "hand-authored LZ77 stream must be valid (getCompressedSize > 0)");
+            Assert.Equal((uint)bytes.Count, clen);
+            return clen;
+        }
+
+        // ====================================================================
+        // 1. PatchImageVariantLength — the reusable math (WF :6738 lengths)
+        // ====================================================================
+
+        [Fact]
+        public void PatchImageVariantLength_RawImage_IsWidthTimesHeightOver2()
+        {
+            var rom = MakeRom();
+            // 8x8 4bpp = 32 bytes.
+            Assert.Equal(32u, RebuildProducerCore.PatchImageVariantLength(rom, "IMAGE", 0x1000, 8, 8, 1));
+            // 240x160 4bpp = 19200 bytes.
+            Assert.Equal(19200u, RebuildProducerCore.PatchImageVariantLength(rom, "IMAGE", 0x1000, 240, 160, 1));
+        }
+
+        [Fact]
+        public void PatchImageVariantLength_Tsa_IsWidthTimesHeightOver32()
+        {
+            var rom = MakeRom();
+            // 8x8 TSA = 2 bytes (NOT 32 — the /2 vs /32 must not be swapped).
+            Assert.Equal(2u, RebuildProducerCore.PatchImageVariantLength(rom, "TSA", 0x1000, 8, 8, 1));
+            Assert.Equal(1200u, RebuildProducerCore.PatchImageVariantLength(rom, "TSA", 0x1000, 240, 160, 1));
+        }
+
+        [Fact]
+        public void PatchImageVariantLength_Palette_IsCountTimes0x20()
+        {
+            var rom = MakeRom();
+            Assert.Equal(0x20u, RebuildProducerCore.PatchImageVariantLength(rom, "PALETTE", 0x1000, 8, 8, 1));
+            Assert.Equal(0x60u, RebuildProducerCore.PatchImageVariantLength(rom, "PALETTE", 0x1000, 8, 8, 3));
+        }
+
+        [Theory]
+        [InlineData("ZIMAGE")]
+        [InlineData("Z256IMAGE")]
+        [InlineData("ZTSA")]
+        [InlineData("ZHEADERTSA")]
+        public void PatchImageVariantLength_Lz77Variants_UseGetCompressedSize(string key)
+        {
+            var rom = MakeRom();
+            uint at = 0x3000;
+            uint expect = WriteLz77AllLiteral(rom, at, 16);
+            Assert.Equal(expect, RebuildProducerCore.PatchImageVariantLength(rom, key, at, 8, 8, 1));
+        }
+
+        [Fact]
+        public void PatchImageVariantLength_Lz77_MalformedStream_IsZero_NoThrow()
+        {
+            var rom = MakeRom();
+            // 0x10 header claiming a huge decompressed size with no body -> getCompressedSize 0 (EOF-safe).
+            rom.write_u8(0x4000, 0x10);
+            rom.write_u8(0x4001, 0xFF);
+            rom.write_u8(0x4002, 0xFF);
+            rom.write_u8(0x4003, 0xFF);
+            uint len = 0;
+            var ex = Record.Exception(() => len = RebuildProducerCore.PatchImageVariantLength(rom, "ZIMAGE", 0x4000, 8, 8, 1));
+            Assert.Null(ex);
+            Assert.Equal(0u, len);
+        }
+
+        [Fact]
+        public void PatchImageVariantLength_UnknownKey_Throws()
+        {
+            var rom = MakeRom();
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => RebuildProducerCore.PatchImageVariantLength(rom, "NOTAVARIANT", 0x1000, 8, 8, 1));
+        }
+
+        // ====================================================================
+        // 2. EmitPatchImage — the 6 ported variants
+        // ====================================================================
+
+        // Plant a GBA pointer (toPointer) at `slot` -> `target`. Helper for the deref variants.
+        static void PlantPointer(ROM rom, uint slot, uint target)
+        {
+            U.write_u32(rom.Data, slot, U.toPointer(target));
+        }
+
+        [Fact]
+        public void EmitPatchImage_ImagePointer_DefaultSize_EmitsImgWidthHeightOver2()
+        {
+            var rom = MakeRom();
+            const uint slot = 0x1000, target = 0x2000;
+            PlantPointer(rom, slot, target);
+
+            var list = new List<Address>();
+            // No WIDTH/HEIGHT -> default 8x8 -> 8*8/2 = 32 bytes, IMG.
+            RebuildProducerCore.EmitPatchImage(rom, list,
+                MakePatch("Img", ("TYPE", "IMAGE"), ("IMAGE_POINTER", "0x1000")), isPointerOnly: false);
+
+            var a = Single(list, "Img@IMAGE_POINTER");
+            Assert.Equal(target, a.Addr);
+            Assert.Equal(32u, a.Length);
+            Assert.Equal(slot, a.Pointer);
+            Assert.Equal(Address.DataTypeEnum.IMG, a.DataType);
+        }
+
+        [Fact]
+        public void EmitPatchImage_ImagePointer_ExplicitSize_UsesWidthHeight()
+        {
+            var rom = MakeRom();
+            PlantPointer(rom, 0x1000, 0x2000);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchImage(rom, list,
+                MakePatch("Big", ("TYPE", "IMAGE"), ("IMAGE_POINTER", "0x1000"),
+                          ("WIDTH", "16"), ("HEIGHT", "32")), isPointerOnly: false);
+
+            var a = Single(list, "Big@IMAGE_POINTER");
+            Assert.Equal(16u * 32u / 2u, a.Length); // 256
+            Assert.Equal(Address.DataTypeEnum.IMG, a.DataType);
+        }
+
+        [Fact]
+        public void EmitPatchImage_TsaPointer_EmitsTsaWidthHeightOver32()
+        {
+            var rom = MakeRom();
+            PlantPointer(rom, 0x1000, 0x2000);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchImage(rom, list,
+                MakePatch("T", ("TYPE", "IMAGE"), ("TSA_POINTER", "0x1000"),
+                          ("WIDTH", "240"), ("HEIGHT", "160")), isPointerOnly: false);
+
+            var a = Single(list, "T@TSA_POINTER");
+            Assert.Equal(0x2000u, a.Addr);
+            Assert.Equal(240u * 160u / 32u, a.Length); // 1200
+            Assert.Equal(0x1000u, a.Pointer);
+            Assert.Equal(Address.DataTypeEnum.TSA, a.DataType);
+        }
+
+        [Theory]
+        [InlineData("ZIMAGE_POINTER", Address.DataTypeEnum.LZ77IMG)]
+        [InlineData("Z256IMAGE_POINTER", Address.DataTypeEnum.LZ77IMG)]
+        [InlineData("ZTSA_POINTER", Address.DataTypeEnum.LZ77TSA)]
+        [InlineData("ZHEADERTSA_POINTER", Address.DataTypeEnum.LZ77TSA)]
+        public void EmitPatchImage_Lz77Variants_EmitGetCompressedSizeLength(string paramKey, Address.DataTypeEnum expectType)
+        {
+            var rom = MakeRom();
+            const uint slot = 0x1000, target = 0x3000;
+            PlantPointer(rom, slot, target);
+            uint expect = WriteLz77AllLiteral(rom, target, 24);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchImage(rom, list,
+                MakePatch("Z", ("TYPE", "IMAGE"), (paramKey, "0x1000")), isPointerOnly: false);
+
+            var a = Single(list, "Z@" + paramKey);
+            Assert.Equal(target, a.Addr);
+            Assert.Equal(expect, a.Length);
+            Assert.Equal(slot, a.Pointer);
+            Assert.Equal(expectType, a.DataType);
+        }
+
+        [Fact]
+        public void EmitPatchImage_PalettePointer_DefaultCount_Is0x20()
+        {
+            var rom = MakeRom();
+            const uint slot = 0x1000, target = 0x2000;
+            PlantPointer(rom, slot, target);
+
+            var list = new List<Address>();
+            // No PALETTE -> default count 1 -> 0x20 bytes.
+            RebuildProducerCore.EmitPatchImage(rom, list,
+                MakePatch("Pal", ("TYPE", "IMAGE"), ("PALETTE_POINTER", "0x1000")), isPointerOnly: false);
+
+            var a = Single(list, "Pal@PALETTE_POINTER");
+            Assert.Equal(target, a.Addr);
+            Assert.Equal(0x20u, a.Length);
+            Assert.Equal(slot, a.Pointer);
+            Assert.Equal(Address.DataTypeEnum.PAL, a.DataType);
+        }
+
+        [Fact]
+        public void EmitPatchImage_PalettePointer_ExplicitCount_IsCountTimes0x20()
+        {
+            var rom = MakeRom();
+            PlantPointer(rom, 0x1000, 0x2000);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchImage(rom, list,
+                MakePatch("P4", ("TYPE", "IMAGE"), ("PALETTE_POINTER", "0x1000"), ("PALETTE", "4")), isPointerOnly: false);
+
+            var a = Single(list, "P4@PALETTE_POINTER");
+            Assert.Equal(0x80u, a.Length); // 4 * 0x20
+            Assert.Equal(Address.DataTypeEnum.PAL, a.DataType);
+        }
+
+        [Fact]
+        public void EmitPatchImage_PaletteAddress_DirectAddress_PointerIsNotFound()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // No PALETTE_POINTER -> the else-branch reads PALETTE_ADDRESS as a DIRECT address
+            // (no deref). Pointer slot is NOT_FOUND (WF passes U.NOT_FOUND). Count 2 -> 0x40.
+            RebuildProducerCore.EmitPatchImage(rom, list,
+                MakePatch("PA", ("TYPE", "IMAGE"), ("PALETTE_ADDRESS", "0x5000"), ("PALETTE", "2")), isPointerOnly: false);
+
+            var a = Single(list, "PA@PALETTE_ADDRESS");
+            Assert.Equal(0x5000u, a.Addr);
+            Assert.Equal(0x40u, a.Length);
+            Assert.Equal(U.NOT_FOUND, a.Pointer);
+            Assert.Equal(Address.DataTypeEnum.PAL, a.DataType);
+        }
+
+        [Fact]
+        public void EmitPatchImage_PalettePointerPresent_DoesNotUsePaletteAddress()
+        {
+            var rom = MakeRom();
+            PlantPointer(rom, 0x1000, 0x2000);
+            var list = new List<Address>();
+            // Both PALETTE_POINTER (safe) and PALETTE_ADDRESS present -> WF takes the POINTER branch ONLY.
+            RebuildProducerCore.EmitPatchImage(rom, list,
+                MakePatch("Both", ("TYPE", "IMAGE"),
+                          ("PALETTE_POINTER", "0x1000"), ("PALETTE_ADDRESS", "0x5000")), isPointerOnly: false);
+
+            Assert.Single(list, a => a.Info == "Both@PALETTE_POINTER" && a.Addr == 0x2000u);
+            Assert.DoesNotContain(list, a => a.Info == "Both@PALETTE_ADDRESS");
+        }
+
+        // ---- the DEFERRED HEADERTSA_POINTER (NON-Z) must NOT be emitted ------
+
+        [Fact]
+        public void EmitPatchImage_HeaderTsaPointer_IsDeferred_EmitsNothing()
+        {
+            var rom = MakeRom();
+            PlantPointer(rom, 0x1000, 0x2000);
+            var list = new List<Address>();
+            // HEADERTSA_POINTER (non-Z) needs CalcByteLengthForHeaderTSAData (s2pf-7). It is NOT
+            // ported in this slice: the producer must NOT emit a wrong/zero-length entry for it.
+            RebuildProducerCore.EmitPatchImage(rom, list,
+                MakePatch("H", ("TYPE", "IMAGE"), ("HEADERTSA_POINTER", "0x1000")), isPointerOnly: false);
+
+            Assert.Empty(list);
+            Assert.DoesNotContain(list, a => a.Info != null && a.Info.Contains("HEADERTSA_POINTER"));
+        }
+
+        [Fact]
+        public void EmitPatchImage_HeaderTsaDeferred_DoesNotBlockOtherVariants()
+        {
+            var rom = MakeRom();
+            PlantPointer(rom, 0x1000, 0x2000); // IMAGE
+            PlantPointer(rom, 0x1100, 0x2100); // HEADERTSA (deferred)
+            var list = new List<Address>();
+            // The deferred HEADERTSA_POINTER must be a clean skip — the sibling IMAGE_POINTER still emits.
+            RebuildProducerCore.EmitPatchImage(rom, list,
+                MakePatch("M", ("TYPE", "IMAGE"),
+                          ("IMAGE_POINTER", "0x1000"), ("HEADERTSA_POINTER", "0x1100")), isPointerOnly: false);
+
+            Assert.Single(list, a => a.Info == "M@IMAGE_POINTER");
+            Assert.DoesNotContain(list, a => a.Info != null && a.Info.Contains("HEADERTSA_POINTER"));
+        }
+
+        // ---- safety gates --------------------------------------------------
+
+        [Fact]
+        public void EmitPatchImage_ImagePointerZero_Skips()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // IMAGE_POINTER resolves to 0 (WF `p > 0` guard) -> skip. "0" is a literal numeric.
+            RebuildProducerCore.EmitPatchImage(rom, list,
+                MakePatch("Z0", ("TYPE", "IMAGE"), ("IMAGE_POINTER", "0")), isPointerOnly: false);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitPatchImage_UnsafePointerSlot_Skips()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // 0x100 is below the 0x200 safe-offset floor -> the pointer slot itself is unsafe -> skip.
+            RebuildProducerCore.EmitPatchImage(rom, list,
+                MakePatch("U", ("TYPE", "IMAGE"), ("IMAGE_POINTER", "0x100")), isPointerOnly: false);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitPatchImage_UnsafeTarget_Skips()
+        {
+            var rom = MakeRom();
+            // Pointer slot is safe but the dereferenced target is NOT a safe pointer (points below floor).
+            U.write_u32(rom.Data, 0x1000, U.toPointer(0x100));
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchImage(rom, list,
+                MakePatch("Ut", ("TYPE", "IMAGE"), ("IMAGE_POINTER", "0x1000")), isPointerOnly: false);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitPatchImage_NoImageParams_EmitsNothing_NoThrow()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // The IMAGE arm must be a clean no-op when no image params are present (the
+            // no-patch-dir invariant's IMAGE-arm complement).
+            var ex = Record.Exception(() => RebuildProducerCore.EmitPatchImage(rom, list,
+                MakePatch("Empty", ("TYPE", "IMAGE")), isPointerOnly: false));
+            Assert.Null(ex);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitPatchImage_AllSixVariantsTogether_EmitOneEach()
+        {
+            var rom = MakeRom();
+            // IMAGE @0x2000, ZIMAGE @0x3000, Z256IMAGE @0x3100, TSA @0x2100, ZTSA @0x3200, ZHEADERTSA @0x3300
+            PlantPointer(rom, 0x1000, 0x2000);
+            PlantPointer(rom, 0x1010, 0x3000);
+            PlantPointer(rom, 0x1020, 0x3100);
+            PlantPointer(rom, 0x1030, 0x2100);
+            PlantPointer(rom, 0x1040, 0x3200);
+            PlantPointer(rom, 0x1050, 0x3300);
+            PlantPointer(rom, 0x1060, 0x2200); // PALETTE_POINTER
+            uint zimg = WriteLz77AllLiteral(rom, 0x3000, 8);
+            uint z256 = WriteLz77AllLiteral(rom, 0x3100, 8);
+            uint ztsa = WriteLz77AllLiteral(rom, 0x3200, 8);
+            uint zhtsa = WriteLz77AllLiteral(rom, 0x3300, 8);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchImage(rom, list, MakePatch("All",
+                ("TYPE", "IMAGE"),
+                ("IMAGE_POINTER", "0x1000"),
+                ("ZIMAGE_POINTER", "0x1010"),
+                ("Z256IMAGE_POINTER", "0x1020"),
+                ("TSA_POINTER", "0x1030"),
+                ("ZTSA_POINTER", "0x1040"),
+                ("ZHEADERTSA_POINTER", "0x1050"),
+                ("PALETTE_POINTER", "0x1060")), isPointerOnly: false);
+
+            Assert.Equal(7, list.Count);
+            Assert.Single(list, a => a.Info == "All@IMAGE_POINTER" && a.Length == 32u && a.DataType == Address.DataTypeEnum.IMG);
+            Assert.Single(list, a => a.Info == "All@ZIMAGE_POINTER" && a.Length == zimg && a.DataType == Address.DataTypeEnum.LZ77IMG);
+            Assert.Single(list, a => a.Info == "All@Z256IMAGE_POINTER" && a.Length == z256 && a.DataType == Address.DataTypeEnum.LZ77IMG);
+            Assert.Single(list, a => a.Info == "All@TSA_POINTER" && a.Length == 2u && a.DataType == Address.DataTypeEnum.TSA);
+            Assert.Single(list, a => a.Info == "All@ZTSA_POINTER" && a.Length == ztsa && a.DataType == Address.DataTypeEnum.LZ77TSA);
+            Assert.Single(list, a => a.Info == "All@ZHEADERTSA_POINTER" && a.Length == zhtsa && a.DataType == Address.DataTypeEnum.LZ77TSA);
+            Assert.Single(list, a => a.Info == "All@PALETTE_POINTER" && a.Length == 0x20u && a.DataType == Address.DataTypeEnum.PAL);
+        }
+
+        [Fact]
+        public void EmitPatchImage_NullArgs_Throw()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            var patch = MakePatch("p", ("IMAGE_POINTER", "0x1000"));
+            Assert.Throws<ArgumentNullException>(() => RebuildProducerCore.EmitPatchImage(null, list, patch, false));
+            Assert.Throws<ArgumentNullException>(() => RebuildProducerCore.EmitPatchImage(rom, null, patch, false));
+            Assert.Throws<ArgumentNullException>(() => RebuildProducerCore.EmitPatchImage(rom, list, null, false));
+            var noParam = new PatchInstallCore.PatchSt { Name = "p", PatchFileName = "p.txt", Param = null };
+            Assert.Throws<ArgumentNullException>(() => RebuildProducerCore.EmitPatchImage(rom, list, noParam, false));
+        }
+
+        [Fact]
+        public void EmitPatchImage_NullPatchFileName_NormalizesBasedir_NoThrow()
+        {
+            var rom = MakeRom();
+            PlantPointer(rom, 0x1000, 0x2000);
+            var list = new List<Address>();
+            var patch = new PatchInstallCore.PatchSt
+            {
+                Name = "NoFile",
+                PatchFileName = null,
+                Param = new Dictionary<string, string> { ["IMAGE_POINTER"] = "0x1000" }
+            };
+            var ex = Record.Exception(() => RebuildProducerCore.EmitPatchImage(rom, list, patch, false));
+            Assert.Null(ex);
+            Assert.Single(list, a => a.Addr == 0x2000u && a.Info == "NoFile@IMAGE_POINTER");
+        }
+
+        // ====================================================================
+        // 3. Integration through the public orchestrator (IMAGE arm wired)
+        // ====================================================================
+
+        [Fact]
+        public void Orchestrator_ImagePatch_EmitsViaWiredArm()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "RebuildProducerPatchImage_" + Guid.NewGuid().ToString("N"));
+            string patchDir = Path.Combine(_tempDir, "config", "patch2", "FE8U");
+            Directory.CreateDirectory(patchDir);
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_IMAGE.txt"), new[]
+            {
+                "NAME=ImagePatch",
+                "TYPE=IMAGE",
+                "IMAGE_POINTER=0x1000",
+                "WIDTH=8",
+                "HEIGHT=8",
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeRom();
+            CoreState.ROM = fe8;
+            PlantPointer(fe8, 0x1000, 0x2000);
+
+            var list = new List<Address>();
+            RebuildProducerCore.MakePatchStructDataListCore(
+                fe8, list, isPointerOnly: false, isInstallOnly: false, isStructOnly: false);
+
+            // The leaner Core scanner sets only PatchFileName + Param (NOT Name), so Info is "@IMAGE_POINTER".
+            Assert.Contains(list, a => a.Addr == 0x2000u && a.Info.EndsWith("@IMAGE_POINTER")
+                && a.Length == 32u && a.DataType == Address.DataTypeEnum.IMG);
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchImageTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchImageTests.cs
@@ -409,6 +409,43 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Empty(list);
         }
 
+        // ---- near-EOF pointer-slot guard (#1314 Copilot review) -------------
+        // A pointer slot resolving to within the last 3 bytes of the ROM passes the single-arg
+        // isSafetyOffset(p) but rom.u32(p) reads p..p+3 and would throw. The slot+3 guard skips it
+        // gracefully (WF's verbatim Program.ROM.u32(p) after isSafetyOffset(p) would throw there).
+
+        [Fact]
+        public void EmitPatchImage_PointerSlotNearEof_Skips_NoThrow()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // Slot at Data.Length - 1: isSafetyOffset(p) true, but p+3 is past EOF -> guarded skip.
+            uint nearEof = (uint)rom.Data.Length - 1;
+            var ex = Record.Exception(() => RebuildProducerCore.EmitPatchImage(rom, list,
+                MakePatch("E", ("TYPE", "IMAGE"), ("IMAGE_POINTER", "0x" + nearEof.ToString("X"))),
+                isPointerOnly: false));
+            Assert.Null(ex);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitPatchImage_PalettePointerSlotNearEof_Skips_NoThrow()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // PALETTE_POINTER slot near EOF: isSafetyOffset(pPalette) true, pPalette+3 past EOF.
+            // The guard is INSIDE the WF if-branch (skips the deref) so it does NOT fall to PALETTE_ADDRESS.
+            uint nearEof = (uint)rom.Data.Length - 2;
+            var ex = Record.Exception(() => RebuildProducerCore.EmitPatchImage(rom, list,
+                MakePatch("PE", ("TYPE", "IMAGE"),
+                          ("PALETTE_POINTER", "0x" + nearEof.ToString("X")),
+                          ("PALETTE_ADDRESS", "0x5000")), isPointerOnly: false));
+            Assert.Null(ex);
+            // Near-EOF PALETTE_POINTER is in the WF `if` branch -> the deref is skipped, and (per WF's
+            // branch selection) the else PALETTE_ADDRESS is NOT taken. Nothing emitted.
+            Assert.Empty(list);
+        }
+
         [Fact]
         public void EmitPatchImage_NoImageParams_EmitsNothing_NoThrow()
         {

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -12510,7 +12510,8 @@ namespace FEBuilderGBA
                 }
                 else if (type == "IMAGE")
                 {
-                    // s2pf-8: TYPE=IMAGE handler (WF MakePatchStructDataListForIMAGE @:6738). STUB.
+                    // s2pf-4: TYPE=IMAGE handler (WF MakePatchStructDataListForIMAGE @:6738).
+                    EmitPatchImage(rom, list, patch, isPointerOnly);
                 }
 
                 // WF: if (InputFormRef.DoEvents(null,"Check Patch "+patch.Name)) return;
@@ -12719,6 +12720,219 @@ namespace FEBuilderGBA
                 {
                     Address.AddAddress(list, a, length, U.NOT_FOUND, patch.Name + "@SWITCH", Address.DataTypeEnum.MIX);
                 }
+            }
+        }
+
+        // ====================================================================
+        // PatchForm producer — option-B epic (#1261, sub-slice s2pf-4 of 11).
+        //
+        // The TYPE=IMAGE terminal arm. Faithful Core port of WinForms
+        // PatchForm.MakePatchStructDataListForIMAGE (FEBuilderGBA/PatchForm.cs:6738).
+        // A TYPE=IMAGE patch lists one or more image-component pointers
+        // (IMAGE_POINTER / ZIMAGE_POINTER / Z256IMAGE_POINTER / TSA_POINTER /
+        // ZTSA_POINTER / [Z]HEADERTSA_POINTER / PALETTE_POINTER|PALETTE_ADDRESS);
+        // each safe one emits a single Address sized by PatchImageVariantLength
+        // and typed per WF (IMG / LZ77IMG / TSA / LZ77TSA / PAL). The WIDTH/HEIGHT
+        // (default "8") feed the raw 4bpp/TSA sizes; PALETTE (default "1") the count.
+        //
+        // DEFERRED (this slice ports 6 of the 8 variants — 6/8):
+        //   - HEADERTSA_POINTER (the NON-Z header-TSA variant, WF :6798): its length
+        //     needs CalcByteLengthForHeaderTSAData (slice s2pf-7), so it is LEFT
+        //     UNHANDLED here (NOT emitted with a wrong/zero length). See the
+        //     `// s2pf-7: HEADERTSA_POINTER` marker below.
+        //
+        // The length math is factored into PatchImageVariantLength so the s2pf-5
+        // STRUCT `PatchImage_*` per-entry arms (WF :6563-6642) reuse the EXACT same
+        // calc. NO Program.ROM / CoreState.ROM read — `rom` is threaded explicitly.
+        // ====================================================================
+
+        /// <summary>
+        /// Faithful Core port of WinForms <c>PatchForm.MakePatchStructDataListForIMAGE</c>
+        /// (FEBuilderGBA/PatchForm.cs:6738). Resolves each image-component pointer param via
+        /// <see cref="ResolvePatchAddress"/> (WF <c>atOffset(.., basedir)</c> =
+        /// <c>convertBinAddressString(v, 0, 0x100, basedir)</c>), dereferences the pointer
+        /// (<c>rom.u32</c>), and — when both the pointer slot and the target are safe — emits one
+        /// <see cref="Address"/> whose length is <see cref="PatchImageVariantLength"/> and whose
+        /// <see cref="Address.DataTypeEnum"/> matches the variant (IMG / LZ77IMG / TSA / LZ77TSA / PAL).
+        /// WIDTH/HEIGHT default "8" (4bpp = w*h/2, TSA = w*h/32); PALETTE count defaults "1" (count*0x20).
+        /// LZ77 lengths come from EOF-safe <see cref="LZ77.getCompressedSize(byte[],uint)"/>.
+        /// <para><b>6 of 8 variants ported.</b> <c>HEADERTSA_POINTER</c> (the non-Z header-TSA, WF :6798)
+        /// is DEFERRED to s2pf-7 (needs <c>CalcByteLengthForHeaderTSAData</c>) and is intentionally NOT
+        /// emitted here. The two header-TSA pointer FIELDS otherwise tracked by WF's
+        /// <c>AddHeaderTSAPointer</c> are out of this slice's scope.</para>
+        /// </summary>
+        /// <param name="rom">ROM to resolve against — passed explicitly (NEVER CoreState.ROM / Program.ROM).</param>
+        /// <param name="list">The accumulating struct/pointer list (appended to).</param>
+        /// <param name="patch">The TYPE=IMAGE patch whose pointer params drive emission.</param>
+        /// <param name="isPointerOnly">WF <c>isPointerOnly</c> — accepted for callsite fidelity. Unlike
+        /// ADDR/SWITCH, the WF IMAGE arm does NOT branch on it (every variant always computes a real
+        /// length), so it is unreferenced here; kept for a uniform TYPE-arm signature.</param>
+        public static void EmitPatchImage(ROM rom, List<Address> list, PatchInstallCore.PatchSt patch, bool isPointerOnly)
+        {
+            // Public-helper guards (consistent with EmitPatchAddr / EmitPatchSwitch): throw a clear
+            // ArgumentNullException rather than an unhelpful NRE. The orchestrator always passes a
+            // valid rom/list and a LoadPatch result whose Param is non-null.
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (list == null) throw new ArgumentNullException(nameof(list));
+            if (patch == null) throw new ArgumentNullException(nameof(patch));
+            if (patch.Param == null) throw new ArgumentNullException(nameof(patch) + ".Param");
+
+            // WF: string basedir = Path.GetDirectoryName(patch.PatchFileName);
+            // Normalize null -> "" (a PatchFileName with no directory part) so the resolver never
+            // receives a null basedir. WF's ResolvePatchAddress/Resolve treats null/"" identically.
+            string basedir = System.IO.Path.GetDirectoryName(patch.PatchFileName) ?? "";
+
+            // WF: uint width = atOffset(patch.Param, "WIDTH", "8");  height likewise.
+            // atOffset(dic, key, def, basedir) = convertBinAddressString(U.at(dic,key,def), 0, 0x100, basedir)
+            //   -> ResolvePatchAddress(rom, U.at(..), 0, 0x100, basedir). A plain "8" parses to 8.
+            uint width = ResolvePatchAddress(rom, U.at(patch.Param, "WIDTH", "8"), 0, 0x100, basedir);
+            uint height = ResolvePatchAddress(rom, U.at(patch.Param, "HEIGHT", "8"), 0, 0x100, basedir);
+            uint paletteCount = ResolvePatchAddress(rom, U.at(patch.Param, "PALETTE", "1"), 0, 0x100, basedir);
+
+            // ---- IMAGE_POINTER (WF :6744) -> w*h/2, IMG -----------------------
+            // WF guards `p > 0 && U.isSafetyOffset(p)` for the IMAGE/ZIMAGE/Z256IMAGE pointer slots
+            // (the TSA/HEADERTSA/PALETTE slots use only `U.isSafetyOffset(p)`); reproduced verbatim.
+            EmitPatchImageVariant(rom, list, patch, basedir, "IMAGE_POINTER", "IMAGE", true,
+                width, height, paletteCount, Address.DataTypeEnum.IMG);
+
+            // ---- ZIMAGE_POINTER (WF :6754) -> LZ77 length, LZ77IMG ------------
+            EmitPatchImageVariant(rom, list, patch, basedir, "ZIMAGE_POINTER", "ZIMAGE", true,
+                width, height, paletteCount, Address.DataTypeEnum.LZ77IMG);
+
+            // ---- Z256IMAGE_POINTER (WF :6765) -> LZ77 length, LZ77IMG ---------
+            EmitPatchImageVariant(rom, list, patch, basedir, "Z256IMAGE_POINTER", "Z256IMAGE", true,
+                width, height, paletteCount, Address.DataTypeEnum.LZ77IMG);
+
+            // ---- TSA_POINTER (WF :6777) -> w*h/32, TSA ------------------------
+            EmitPatchImageVariant(rom, list, patch, basedir, "TSA_POINTER", "TSA", false,
+                width, height, paletteCount, Address.DataTypeEnum.TSA);
+
+            // ---- ZTSA_POINTER (WF :6787) -> LZ77 length, LZ77TSA -------------
+            EmitPatchImageVariant(rom, list, patch, basedir, "ZTSA_POINTER", "ZTSA", false,
+                width, height, paletteCount, Address.DataTypeEnum.LZ77TSA);
+
+            // ---- HEADERTSA_POINTER (WF :6798) -> DEFERRED to s2pf-7 ----------
+            // s2pf-7: HEADERTSA_POINTER. The non-Z header-TSA variant's length needs
+            // CalcByteLengthForHeaderTSAData (WF AddHeaderTSAPointer -> ImageUtil), which is slice
+            // s2pf-7. NOT emitted here (emitting a wrong/zero length would mis-size or orphan the
+            // header-TSA region during a rebuild). Left intentionally unhandled.
+
+            // ---- ZHEADERTSA_POINTER (WF :6807) -> LZ77 length, LZ77TSA ------
+            // NOTE: this is the COMPRESSED header-TSA variant; its length IS a plain LZ77
+            // getCompressedSize (no header-TSA byte-length calc needed), so it IS ported here.
+            EmitPatchImageVariant(rom, list, patch, basedir, "ZHEADERTSA_POINTER", "ZHEADERTSA", false,
+                width, height, paletteCount, Address.DataTypeEnum.LZ77TSA);
+
+            // ---- PALETTE_POINTER (WF :6819) / PALETTE_ADDRESS (WF :6832) -----
+            // WF: if PALETTE_POINTER resolves to a SAFE offset, deref it (pointer form, count*0x20 PAL);
+            // ELSE fall back to PALETTE_ADDRESS as a DIRECT address (no deref, pointer slot NOT_FOUND).
+            // The else-branch fires only when PALETTE_POINTER is absent/unsafe — reproduced verbatim.
+            uint pPalette = ResolvePatchAddress(rom, U.at(patch.Param, "PALETTE_POINTER", "0"), 0, 0x100, basedir);
+            if (U.isSafetyOffset(pPalette, rom))
+            {
+                uint a = rom.u32(pPalette);
+                if (U.isSafetyPointer(a, rom))
+                {
+                    a = U.toOffset(a);
+                    uint len = PatchImageVariantLength(rom, "PALETTE", a, width, height, paletteCount);
+                    Address.AddAddress(list, a, len, pPalette, patch.Name + "@PALETTE_POINTER",
+                        Address.DataTypeEnum.PAL);
+                }
+            }
+            else
+            {
+                uint a = ResolvePatchAddress(rom, U.at(patch.Param, "PALETTE_ADDRESS", "0"), 0, 0x100, basedir);
+                if (U.isSafetyOffset(a, rom))
+                {
+                    uint len = PatchImageVariantLength(rom, "PALETTE", a, width, height, paletteCount);
+                    Address.AddAddress(list, a, len, U.NOT_FOUND, patch.Name + "@PALETTE_ADDRESS",
+                        Address.DataTypeEnum.PAL);
+                }
+            }
+        }
+
+        /// <summary>
+        /// One pointer-deref IMAGE variant (WF :6744-6817 share this shape). Resolves the
+        /// <paramref name="paramKey"/> pointer slot via <see cref="ResolvePatchAddress"/>, applies the
+        /// WF safety gate (<c>requirePositive</c> adds the <c>p &gt; 0</c> check the IMAGE/ZIMAGE/Z256IMAGE
+        /// slots carry but the TSA/ZTSA/ZHEADERTSA slots do not), dereferences (<c>rom.u32</c>), and on a
+        /// safe pointer emits one <see cref="Address"/> sized by <see cref="PatchImageVariantLength"/>
+        /// (variant <paramref name="variantKey"/>) and typed <paramref name="type"/>, named
+        /// <c>Name@paramKey</c> — byte-faithful to the WF <c>Address.AddAddress</c> call.
+        /// </summary>
+        static void EmitPatchImageVariant(ROM rom, List<Address> list, PatchInstallCore.PatchSt patch,
+            string basedir, string paramKey, string variantKey, bool requirePositive,
+            uint width, uint height, uint paletteCount, Address.DataTypeEnum type)
+        {
+            uint p = ResolvePatchAddress(rom, U.at(patch.Param, paramKey, "0"), 0, 0x100, basedir);
+            // WF IMAGE/ZIMAGE/Z256IMAGE: `if (p > 0 && U.isSafetyOffset(p))`.
+            // WF TSA/ZTSA/ZHEADERTSA:    `if (U.isSafetyOffset(p))`.
+            if (requirePositive && p == 0)
+            {
+                return;
+            }
+            if (!U.isSafetyOffset(p, rom))
+            {
+                return;
+            }
+            uint a = rom.u32(p);
+            if (!U.isSafetyPointer(a, rom))
+            {
+                return;
+            }
+            a = U.toOffset(a);
+            uint len = PatchImageVariantLength(rom, variantKey, a, width, height, paletteCount);
+            Address.AddAddress(list, a, len, p, patch.Name + "@" + paramKey, type);
+        }
+
+        /// <summary>
+        /// The reusable IMAGE per-variant length math, factored out of <see cref="EmitPatchImage"/>
+        /// (WF :6738) so the slice s2pf-5 STRUCT <c>PatchImage_*</c> per-entry arms (WF :6563-6642)
+        /// reuse the EXACT same calc. <paramref name="variantKey"/> selects the formula:
+        /// <list type="bullet">
+        ///   <item><c>IMAGE</c> -&gt; <c>width*height/2</c> (4bpp raw image).</item>
+        ///   <item><c>TSA</c> -&gt; <c>width*height/32</c> (raw TSA).</item>
+        ///   <item><c>ZIMAGE</c> / <c>Z256IMAGE</c> / <c>ZTSA</c> / <c>ZHEADERTSA</c> -&gt;
+        ///         <c>LZ77.getCompressedSize(rom.Data, addr)</c> (EOF-safe; 0 on a malformed/near-EOF
+        ///         stream — never throws, never reads past EOF).</item>
+        ///   <item><c>PALETTE</c> -&gt; <c>paletteCount*0x20</c> (count 16-color palettes).</item>
+        /// </list>
+        /// <paramref name="addr"/> is the already-dereferenced, <c>toOffset</c>'d target (only the LZ77
+        /// variants read it). The raw IMG/TSA sizes use only <paramref name="width"/>/<paramref name="height"/>;
+        /// PALETTE uses only <paramref name="paletteCount"/>.
+        /// <para>Must stay byte-faithful to WF: <c>w*h/2</c> (IMG) vs <c>w*h/32</c> (TSA) must not be
+        /// swapped, and the PALETTE default count is 1 (an off-by-one here would corrupt the palette plus
+        /// the following data on a rebuild).</para>
+        /// </summary>
+        /// <param name="rom">ROM whose <c>Data</c> the LZ77 variants scan — passed explicitly.</param>
+        /// <param name="variantKey">One of IMAGE / TSA / ZIMAGE / Z256IMAGE / ZTSA / ZHEADERTSA / PALETTE.</param>
+        /// <param name="addr">The dereferenced target offset (read only by the LZ77 variants).</param>
+        /// <param name="width">Image width in pixels (IMG/TSA only).</param>
+        /// <param name="height">Image height in pixels (IMG/TSA only).</param>
+        /// <param name="paletteCount">16-color palette count (PALETTE only).</param>
+        /// <returns>The variant's byte length (EOF-safe 0 for a malformed LZ77 stream).</returns>
+        public static uint PatchImageVariantLength(ROM rom, string variantKey, uint addr,
+            uint width, uint height, uint paletteCount)
+        {
+            switch (variantKey)
+            {
+                case "IMAGE":
+                    return width * height / 2;          // WF :6751 — 4bpp raw image.
+                case "TSA":
+                    return width * height / 32;         // WF :6784 — raw TSA.
+                case "ZIMAGE":
+                case "Z256IMAGE":
+                case "ZTSA":
+                case "ZHEADERTSA":
+                    // WF :6761/6772/6794/6814 — EOF-safe LZ77 compressed length.
+                    return LZ77.getCompressedSize(rom.Data, addr);
+                case "PALETTE":
+                    return paletteCount * 0x20;          // WF :6826/6835 — count*0x20 PAL bytes.
+                default:
+                    // A new/bad variant key is a programming error — fail loudly rather than emit a
+                    // silent 0-length block (which would orphan the image region on a rebuild).
+                    throw new ArgumentOutOfRangeException(nameof(variantKey), variantKey,
+                        "Unknown PatchImage variant key.");
             }
         }
 

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -12830,6 +12830,17 @@ namespace FEBuilderGBA
             uint pPalette = ResolvePatchAddress(rom, U.at(patch.Param, "PALETTE_POINTER", "0"), 0, 0x100, basedir);
             if (U.isSafetyOffset(pPalette, rom))
             {
+                // Guard the FULL 4-byte slot before rom.u32 (isSafetyOffset(pPalette) leaves pPalette+1..+3
+                // unchecked; rom.u32 throws when pPalette is within the last 3 bytes — WF's verbatim
+                // `Program.ROM.u32(pPalette)` after `isSafetyOffset(pPalette)` would throw there too). NOTE:
+                // the guard is INSIDE the WF `if (isSafetyOffset(pPalette))` BRANCH (skips only the deref) —
+                // NOT folded into the `if` condition, which would mis-route a near-EOF pPalette to the
+                // PALETTE_ADDRESS else-branch and diverge from WF's branch selection. On valid ROMs the
+                // pointer slot is never near EOF; this only hardens synthetic/corrupted ROMs (#1314 review).
+                if (!U.isSafetyOffset(pPalette + 3, rom))
+                {
+                    return;
+                }
                 uint a = rom.u32(pPalette);
                 if (U.isSafetyPointer(a, rom))
                 {
@@ -12871,7 +12882,12 @@ namespace FEBuilderGBA
             {
                 return;
             }
-            if (!U.isSafetyOffset(p, rom))
+            // Guard the FULL 4-byte pointer slot before rom.u32: U.isSafetyOffset(p, rom) alone leaves
+            // p+1..p+3 unchecked, and rom.u32's check_safety THROWS when p is within the last 3 bytes of
+            // the ROM (WF's verbatim `Program.ROM.u32(p)` after `isSafetyOffset(p)` would throw there too).
+            // On valid ROMs the pointer slots are never near EOF, so this only hardens synthetic/corrupted
+            // ROMs to skip gracefully — matching the Core-wide slot+3 convention (Copilot PR #1314 review).
+            if (!U.isSafetyOffset(p, rom) || !U.isSafetyOffset(p + 3, rom))
             {
                 return;
             }

--- a/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
+++ b/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
@@ -377,9 +377,12 @@ namespace FEBuilderGBA.Tests.Unit
         /// reference (<c>PatchForm.MakePatchStructDataList</c> -&gt; <c>MakePatchStructDataListForIMAGE</c>,
         /// PatchForm.cs:6738) and the Core orchestrator (<see cref="RebuildProducerCore.MakePatchStructDataListCore"/>)
         /// run on the SAME real FE8U ROM with the SAME rebuild flags (the <c>ToolROMRebuildMake.Make</c>
-        /// callsite). Each side is FILTERED to the IMAGE arm's six ported variants (Info ends
+        /// callsite). Each side is FILTERED to the IMAGE arm's six ported variants — which surface as
+        /// EIGHT Info suffixes because the PALETTE variant emits under two param keys (<c>@PALETTE_POINTER</c>
+        /// for the deref form and <c>@PALETTE_ADDRESS</c> for the direct-address else-fallback), and ZIMAGE
+        /// covers both <c>@ZIMAGE_POINTER</c> and the <c>@Z256IMAGE_POINTER</c> alias (Info ends
         /// <c>@IMAGE_POINTER</c> / <c>@ZIMAGE_POINTER</c> / <c>@Z256IMAGE_POINTER</c> / <c>@TSA_POINTER</c> /
-        /// <c>@ZTSA_POINTER</c> / <c>@ZHEADERTSA_POINTER</c> / <c>@PALETTE_POINTER</c> / <c>@PALETTE_ADDRESS</c>),
+        /// <c>@ZTSA_POINTER</c> / <c>@ZHEADERTSA_POINTER</c> / <c>@PALETTE_POINTER</c> / <c>@PALETTE_ADDRESS</c>) —
         /// then compared as Core ⊆ WF on the load-bearing fields (Addr/Length/Pointer/DataType) — Info/name
         /// is cosmetic (Core's leaner LoadPatch omits the patch Name, so its Info is just "@VARIANT"; WF
         /// prepends the patch name). A Core-extra (Core emits an IMAGE entry WF does not) is a faithfulness

--- a/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
+++ b/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
@@ -371,6 +371,134 @@ namespace FEBuilderGBA.Tests.Unit
             }
         }
 
+        /// <summary>
+        /// PARTIAL WF-parity for #1261 slice s2pf-4 — the PatchForm producer TYPE=IMAGE dispatch arm
+        /// (<see cref="RebuildProducerCore.EmitPatchImage"/>, 6 of 8 variants). Both the WinForms
+        /// reference (<c>PatchForm.MakePatchStructDataList</c> -&gt; <c>MakePatchStructDataListForIMAGE</c>,
+        /// PatchForm.cs:6738) and the Core orchestrator (<see cref="RebuildProducerCore.MakePatchStructDataListCore"/>)
+        /// run on the SAME real FE8U ROM with the SAME rebuild flags (the <c>ToolROMRebuildMake.Make</c>
+        /// callsite). Each side is FILTERED to the IMAGE arm's six ported variants (Info ends
+        /// <c>@IMAGE_POINTER</c> / <c>@ZIMAGE_POINTER</c> / <c>@Z256IMAGE_POINTER</c> / <c>@TSA_POINTER</c> /
+        /// <c>@ZTSA_POINTER</c> / <c>@ZHEADERTSA_POINTER</c> / <c>@PALETTE_POINTER</c> / <c>@PALETTE_ADDRESS</c>),
+        /// then compared as Core ⊆ WF on the load-bearing fields (Addr/Length/Pointer/DataType) — Info/name
+        /// is cosmetic (Core's leaner LoadPatch omits the patch Name, so its Info is just "@VARIANT"; WF
+        /// prepends the patch name). A Core-extra (Core emits an IMAGE entry WF does not) is a faithfulness
+        /// regression and FAILS.
+        /// <para><b>HEADERTSA_POINTER EXCLUDED (deferred to s2pf-7).</b> The NON-Z header-TSA variant
+        /// (<c>@HEADERTSA_POINTER</c>, WF <c>AddHeaderTSAPointer</c> -&gt; <c>DataTypeEnum.HEADERTSA</c>) needs
+        /// <c>CalcByteLengthForHeaderTSAData</c> (slice s2pf-7) and is NOT ported here. WF emits it; Core does
+        /// not — so it is filtered OUT of BOTH sides (by both its name AND the HEADERTSA data type) before the
+        /// comparison. The remaining six variants are asserted Core ⊆ WF. WF-extras among the SIX (an IMAGE
+        /// entry WF emits that Core lacks) are tolerated only if Core's gate legitimately diverges — but the
+        /// gate + resolver are faithful ports, so they are LOGGED (not asserted) exactly as the
+        /// subset-direction harness does, keeping the teeth on the regression direction (Core-extra).</para>
+        /// <para>SKIP-IF-NO-ROM: requires <c>roms/FE8U.gba</c> (gitignored — absent in CI / the worktree,
+        /// present in the user's main checkout). When no ROM is found the test returns early (Pass).</para>
+        /// <para><b>NON-VACUOUS only where <c>config/patch2</c> is CHECKED OUT</b> (same posture as the
+        /// ADDR/SWITCH harness): an un-init submodule yields no IMAGE patch files, so both filtered lists are
+        /// empty and Core ⊆ WF holds trivially. The branch-level verification (all six variants, the /2-vs-/32
+        /// raw sizes, the palette count, the LZ77 lengths, the per-variant safety gates, the HEADERTSA
+        /// deferral) is carried by the synthetic Core.Tests (<c>RebuildProducerPatchImageTests</c>).</para>
+        /// </summary>
+        [Fact]
+        public void CorePatchImageArm_IsSubsetOf_WinFormsPatchProducer_ExcludingHeaderTsa()
+        {
+            string? repoRoot = FindRepoRootWithRom();
+            if (repoRoot == null) return; // no checkout with roms/FE8U.gba reachable — early-exit (Pass)
+            string romPath = Path.Combine(repoRoot, "roms", "FE8U.gba");
+            if (!File.Exists(romPath)) return; // no ROM (gitignored, absent in CI) — early-exit (Pass)
+
+            string savedBaseDir = CoreState.BaseDirectory;
+            try
+            {
+                CoreState.BaseDirectory = repoRoot;
+                ForceCommandLineMode();
+                BootstrapWinFormsProgram(repoRoot);
+
+                bool loaded = Program.LoadROM(romPath, "");
+                if (!loaded || Program.ROM == null) return; // ROM did not load — early-exit (Pass)
+                if (Program.ROM.RomInfo.version != 8) return; // calibrated on FE8U — early-exit (Pass)
+
+                PatchForm.ClearCheckIF();
+
+                // ---- WinForms reference: the public patch producer, same flags as the rebuild ----
+                var wfAll = new List<Address>();
+                PatchForm.MakePatchStructDataList(wfAll,
+                    isPointerOnly: IS_PATCH_POINTER_ONLY,
+                    isInstallOnly: IS_PATCH_INSTALL_ONLY,
+                    isStructOnly: IS_PATCH_STRUCT_ONLY);
+
+                // ---- Core: the orchestrator, same flags + the SAME ROM ----
+                var coreAll = new List<Address>();
+                RebuildProducerCore.MakePatchStructDataListCore(Program.ROM, coreAll,
+                    isPointerOnly: IS_PATCH_POINTER_ONLY,
+                    isInstallOnly: IS_PATCH_INSTALL_ONLY,
+                    isStructOnly: IS_PATCH_STRUCT_ONLY);
+
+                // The six PORTED IMAGE variant param-key suffixes (HEADERTSA_POINTER deliberately ABSENT).
+                string[] portedSuffixes =
+                {
+                    "@IMAGE_POINTER", "@ZIMAGE_POINTER", "@Z256IMAGE_POINTER",
+                    "@TSA_POINTER", "@ZTSA_POINTER", "@ZHEADERTSA_POINTER",
+                    "@PALETTE_POINTER", "@PALETTE_ADDRESS",
+                };
+
+                // An IMAGE arm entry for one of the SIX ported variants. EXCLUDES the deferred
+                // HEADERTSA_POINTER both by name (@HEADERTSA_POINTER) AND by its HEADERTSA data type
+                // (defence in depth: WF's AddHeaderTSAPointer always tags DataTypeEnum.HEADERTSA).
+                bool IsPortedImageEntry(Address a)
+                {
+                    if (a.Info == null) return false;
+                    if (a.DataType == Address.DataTypeEnum.HEADERTSA) return false; // deferred variant
+                    if (a.Info.EndsWith("@HEADERTSA_POINTER", StringComparison.Ordinal)) return false;
+                    foreach (string s in portedSuffixes)
+                    {
+                        if (a.Info.EndsWith(s, StringComparison.Ordinal)) return true;
+                    }
+                    return false;
+                }
+
+                var wfImg = wfAll.Where(IsPortedImageEntry).ToList();
+                var coreImg = coreAll.Where(IsPortedImageEntry).ToList();
+
+                var wfKeys = new HashSet<Key>(wfImg.Select(Key.Of));
+                var coreKeys = new HashSet<Key>(coreImg.Select(Key.Of));
+
+                // Core-extras = Core emits a (ported) IMAGE key WF does not. ALWAYS a faithfulness
+                // regression -> FAIL. WF-extras (WF emits a ported-IMAGE key Core lacks) are logged but
+                // not asserted (subset direction), mirroring the data-path harness — the deferred
+                // HEADERTSA is already excluded, so a WF-extra among the six would signal a gate divergence
+                // worth surfacing, not a silent-drop the way ADDR/SWITCH's exact-equality catches it. Core
+                // ⊆ WF is the load-bearing guarantee for this 6-of-8 slice.
+                var coreExtras = coreImg.Where(a => !wfKeys.Contains(Key.Of(a)))
+                                        .Select(Key.Of).Distinct().ToList();
+                int wfExtraCount = wfKeys.Count(k => !coreKeys.Contains(k));
+
+                if (coreExtras.Count > 0)
+                {
+                    const int N = 30;
+                    string dump = string.Join("\n", coreExtras.Take(N).Select(k =>
+                        $"  Addr=0x{k.Addr:X} Len=0x{k.Length:X} Ptr=0x{k.Pointer:X} Type={k.Type}"));
+                    Assert.Fail(
+                        $"Core PatchForm IMAGE arm emitted {coreExtras.Count} (ported-variant) entr"
+                        + (coreExtras.Count == 1 ? "y" : "ies")
+                        + " NOT present in the WinForms patch producer (faithfulness regression).\n"
+                        + $"WF ported-IMAGE total={wfImg.Count}, Core total={coreImg.Count}, "
+                        + $"WF-only (gate divergence?)={wfExtraCount}.\n"
+                        + $"First {Math.Min(N, coreExtras.Count)} Core-only entries:\n{dump}");
+                }
+
+                // PROVEN: every Core IMAGE entry (of the six ported variants) is byte-identical to a WF
+                // entry on (Addr/Length/Pointer/DataType) — no faithfulness regression — with the deferred
+                // HEADERTSA_POINTER excluded from both sides (or both empty when config/patch2 is absent).
+                Assert.Empty(coreExtras);
+            }
+            finally
+            {
+                CoreState.BaseDirectory = savedBaseDir;
+            }
+        }
+
         // ----------------------------------------------------------------
         readonly struct Key : IEquatable<Key>
         {


### PR DESCRIPTION
## Summary

Sub-slice **4/11** of the option-B `PatchForm(MakePatchStructDataList)` producer epic. Replaces the TYPE=IMAGE terminal no-op stub in the `RebuildProducerCore.MakePatchStructDataListCore` orchestrator's TYPE switch with a faithful WinForms→Core port of `PatchForm.MakePatchStructDataListForIMAGE` (`FEBuilderGBA/PatchForm.cs:6738`):

- **`EmitPatchImage`** — resolves each image-component pointer param via `ResolvePatchAddress` (= WF `atOffset(.., basedir)` = `convertBinAddressString(v, 0, 0x100, basedir)`), dereferences (`rom.u32`), and on a safe pointer/target emits one `Address` sized by the reusable length helper and typed per WF. `rom` is threaded explicitly (never `Program.ROM`/`CoreState.ROM`).

### Variants ported — 6 of 8

| Param | Length | DataType |
|---|---|---|
| `IMAGE_POINTER` | `w*h/2` | `IMG` |
| `ZIMAGE_POINTER` / `Z256IMAGE_POINTER` | `LZ77.getCompressedSize` (EOF-safe) | `LZ77IMG` |
| `TSA_POINTER` | `w*h/32` | `TSA` |
| `ZTSA_POINTER` | `LZ77` length | `LZ77TSA` |
| `ZHEADERTSA_POINTER` | `LZ77` length | `LZ77TSA` |
| `PALETTE_POINTER` / `PALETTE_ADDRESS` | `count*0x20` | `PAL` |

`WIDTH`/`HEIGHT` default `"8"`; `PALETTE` count defaults `"1"`. Emitted via `Address.AddAddress(list, addr, len, ptr, Name + "@" + key, type)` — name/type byte-faithful to WF. The `PALETTE_POINTER` (deref, pointer-slot tracked) vs `PALETTE_ADDRESS` (direct address, pointer slot `NOT_FOUND`) else-fallback is reproduced verbatim (the else fires only when `PALETTE_POINTER` is absent/unsafe).

### Reusable length helper (for s2pf-5)

The per-variant math is factored into the public helper:

```csharp
public static uint PatchImageVariantLength(ROM rom, string variantKey, uint addr,
                                           uint width, uint height, uint paletteCount)
```

so slice **s2pf-5**'s STRUCT `PatchImage_*` per-entry arms (WF `:6563-6642`) reuse the **EXACT** same calc (`IMAGE`=`w*h/2`, `TSA`=`w*h/32`, `ZIMAGE`/`Z256IMAGE`/`ZTSA`/`ZHEADERTSA`=`getCompressedSize`, `PALETTE`=`count*0x20`). The `/2`-vs-`/32` distinction and the palette count default of `1` are load-bearing — a swap or off-by-one corrupts the image/palette + the following data on a rebuild. LZ77 lengths stay EOF-safe (a malformed/near-EOF stream yields `0`, never throws, never reads past EOF).

## Deferred — `HEADERTSA_POINTER` (the NON-Z variant) → s2pf-7

The non-Z header-TSA variant (`HEADERTSA_POINTER`, WF `:6798`) needs `CalcByteLengthForHeaderTSAData` (WF `AddHeaderTSAPointer` → `ImageUtil`), which is slice **s2pf-7**. It is **NOT ported here**: the arm leaves it intentionally **unhandled** (does NOT emit a wrong/zero-length entry that would mis-size or orphan the header-TSA region on a rebuild), with a clear `// s2pf-7: HEADERTSA_POINTER` marker.

**Precise blocker:** `ImageUtil.CalcByteLengthForHeaderTSAData` (called by `FEBuilderGBA/AddressWinForms.cs:32` `AddHeaderTSAPointer`) is not in Core — header-TSA byte-length is the s2pf-7 prerequisite.

> Note: the **compressed** `ZHEADERTSA_POINTER` (WF `:6807`) **IS** ported — its length is a plain LZ77 `getCompressedSize`, no header-TSA byte-length calc needed.

## The WF 6624-6632 copy-paste defect — DECISION

**NOT APPLICABLE to this slice; nothing to reproduce or diverge here.** The brief flags a copy-paste defect at WF `~:6624-6632` — a duplicate `else if (type == "PatchImage_ZTSA")` block (dead code: the first `PatchImage_ZTSA` at `:6595` always wins, so the `ZHEADERTSA` body at `:6624` never executes). That defect lives in the **STRUCT dispatcher** (`MakePatchStructDataListForSTRUCT`, lines `:6563-6642`), which is **slice s2pf-5's** domain. This slice's source — `MakePatchStructDataListForIMAGE` (`:6738`, the standalone IMAGE TYPE arm) — is **clean** and contains no such duplicate. So there is no defect to reproduce in the IMAGE arm. The s2pf-5 STRUCT slice will, per the brief's default, reproduce that defect **verbatim** for byte-faithful FE8U parity (or consciously diverge against the parity harness if it chooses).

## Scope

- **4/11.** The orchestrator is still **NOT wired** into the live producer (that is s2pf-11), so the gate token `"PatchForm(MakePatchStructDataList)"` **STAYS** in `AsmNotYetPortedRaw` (`IsComplete` stays false; the rebuild `Make` gate stays closed). Existing token-pinning tests still pass.
- The **no-patch-dir invariant** is preserved — `MakePatchStructDataListCore` with no patch dir / no qualifying IMAGE patch still emits nothing + does not throw (existing `MakePatchStructDataListCore_NoPatchDir_EmitsNothing_NoThrow` passes; the IMAGE arm is a clean no-op when its params are absent).
- Core-only, no GUI → no screenshot.

Part of #1261.

## Test plan

- [x] `RebuildProducerPatchImageTests` (Core.Tests, **30 cases**): synthetic FE8U ROM + synthetic `PatchSt`; planted hand-authored all-literal LZ77 streams (slice-2e idiom) for the Z variants; planted raw images/palettes; per-variant addr/length/pointer/type/name asserts; the malformed-LZ77 **EOF-safe 0**; the `PatchImageVariantLength` math + **unknown-key throw**; `PALETTE_POINTER`-vs-`PALETTE_ADDRESS` branch + the both-present precedence; **all six variants together**; safety gates (`p==0`, unsafe slot, unsafe target); **`HEADERTSA_POINTER` NOT emitted** (deferral pinned, does not block siblings); null-arg guards; null `PatchFileName` basedir normalization; **orchestrator integration** on a staged `config/patch2` tree (proves the IMAGE switch arm is wired).
- [x] `RebuildProducerWFParityTests.CorePatchImageArm_IsSubsetOf_WinFormsPatchProducer_ExcludingHeaderTsa` (FEBuilderGBA.Tests, net9.0-windows, skip-if-no-ROM): runs WF `PatchForm.MakePatchStructDataList` and Core `MakePatchStructDataListCore` on the real **FE8U** ROM with the rebuild flags, filters both to the **six ported** IMAGE variants, asserts **Core ⊆ WF** on (addr,length,pointer,type). **`HEADERTSA_POINTER` EXCLUDED** from both sides (by name AND `HEADERTSA` data type) as the documented deferral. Non-vacuous only where `config/patch2` is checked out (documented; the 30 synthetic cases carry branch-level verification).
- [x] `dotnet test FEBuilderGBA.Core.Tests --filter RebuildProducer` → **562 pass** (532 baseline + 30), 0 failed — incl. the no-patch-dir invariant.
- [x] `dotnet build FEBuilderGBA.sln` → clean, 0 errors.

## Deferred

- `HEADERTSA_POINTER` (the non-Z header-TSA variant) → **s2pf-7** (blocker: `ImageUtil.CalcByteLengthForHeaderTSAData` not in Core). The other 7 IMAGE pointer params are all ported.
- The STRUCT `PatchImage_*` dispatcher (incl. the WF `:6624-6632` defect) → **s2pf-5**, which reuses `PatchImageVariantLength`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
