### PR TITLE
feat(core): PatchForm STRUCT skeleton + safe arms (interim form-MIX) (#1261 s2pf-5)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchScaffoldTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchScaffoldTests.cs
@@ -317,9 +317,11 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void MakePatchStructDataListCore_WithPatches_StubsEmitNothing_ReportsProgress()
         {
-            // A real patch tree with two STRUCT patches that PASS the gate. Every TYPE arm
-            // is a NO-OP STUB this slice, so the list MUST stay empty even though the gate
-            // admits the patches. Progress is reported once per admitted patch.
+            // A real patch tree with two STRUCT patches that PASS the gate. As of s2pf-5 the STRUCT
+            // arm is WIRED (no longer a stub), but these patches have NO top-level POINTER/ADDRESS
+            // param (only a P0:POINTER pointer-INDEX field), so EmitPatchStruct early-returns before
+            // emitting a table base — the list still MUST stay empty even though the gate admits the
+            // patches. Progress is reported once per admitted patch.
             string patchDir = Path.Combine(_tempDir, "config", "patch2", "FE8U");
             Directory.CreateDirectory(patchDir);
             File.WriteAllLines(Path.Combine(patchDir, "PATCH_A.txt"), new[]
@@ -346,7 +348,7 @@ namespace FEBuilderGBA.Core.Tests
             RebuildProducerCore.MakePatchStructDataListCore(
                 fe8, list, isPointerOnly: false, isInstallOnly: false, isStructOnly: false, progress: progress);
 
-            Assert.Empty(list); // STUBS emit nothing this slice
+            Assert.Empty(list); // no table base in these patches -> EmitPatchStruct early-returns
             // Both STRUCT patches pass the gate, so the per-patch progress fires twice.
             // (PatchHardCodeScanner.LoadPatch is the leaner Core scanner — it sets only
             // PatchFileName + Param, NOT Name, so the WF "Check Patch <name>" message has

--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchStructTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchStructTests.cs
@@ -1,0 +1,662 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for RebuildProducerCore slice s2pf-5 (#1261) — the TYPE=STRUCT terminal
+// PatchForm producer arm (option-B epic, sub-slice 5 of 11):
+//   RebuildProducerCore.EmitPatchStruct = WF PatchForm.MakePatchStructDataListForSTRUCT @:6461
+//
+// Scope of s2pf-5 (verified here):
+//   (A) the STRUCT SKELETON (WF 6461-6552) — VERBATIM:
+//        - struct_address via POINTER deref OR ADDRESS direct (the WF selection)
+//        - DATASIZE / DATACOUNT (literal + `$`-macro, start_offset = struct_address)
+//        - the DATACOUNT early-return guards (NOT_FOUND, < struct_address, >= 0xffff, "")
+//        - the MAIN InputFormRef Address (datasize*(datacount+1), iftType, blockSize, pointerIndexes)
+//        - the per-entry loop p = struct_address + i*datasize + pointerIndexes[n], IN ORDER.
+//   (B) the SAFE terminal arms (REAL): ASM/ASM_SWITCH/ASM_NOWARNING (AddFunction),
+//        CSTRING (AddCString), PatchImage_IMAGE/_ZIMAGE/_TSA/_ZTSA/_ZHEADERTSA/_PALETTE
+//        (AddAddress sized by PatchImageVariantLength), WF's `default` (AddPointer MIX).
+//   (C) the FORM-BOUND arms -> DOCUMENTED INTERIM default-MIX (length-0 MIX placeholder),
+//        upgraded in s2pf-6..10. Asserted to emit the interim placeholder (NOT a precise length).
+//   + the 6624-6632 copy-paste defect behavior (a PatchImage_ZTSA field takes the LIVE
+//     WF 6595 arm — LZ77IMG " ZTSA " — never the dead block's LZ77TSA " ZHEADERTSA ").
+//   + the no-qualifying-param no-op (preserves the no-patch-dir invariant's STRUCT complement).
+//
+// Coverage idiom: synthetic in-memory FE8U ROM (BE8E01) + synthetic PatchSt — no real
+// GBA ROM file (mirrors RebuildProducerPatchImageTests). CoreState.ROM is set in MakeRom
+// (the ASM/CSTRING/MIX arms' AddFunction/AddCString/AddPointer read CoreState.ROM).
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class RebuildProducerPatchStructTests : IDisposable
+    {
+        readonly ROM _savedRom = CoreState.ROM;
+        readonly string _savedLang = CoreState.Language;
+        readonly string _savedBaseDir = CoreState.BaseDirectory;
+        readonly ISystemTextEncoder _savedEncoder = CoreState.SystemTextEncoder;
+        string? _tempDir;
+
+        public RebuildProducerPatchStructTests()
+        {
+            CoreState.Language = "en";
+        }
+
+        public void Dispose()
+        {
+            CoreState.ROM = _savedRom;
+            CoreState.Language = _savedLang;
+            CoreState.BaseDirectory = _savedBaseDir;
+            CoreState.SystemTextEncoder = _savedEncoder;
+            try { if (_tempDir != null && Directory.Exists(_tempDir)) Directory.Delete(_tempDir, true); } catch { }
+        }
+
+        // 16 MiB zero-filled FE8U ROM (LoadLow minimum for BE8E01). Sets CoreState.ROM (the
+        // AddFunction/AddCString/AddPointer arms + the Address sink read it) and a headless
+        // SystemTextEncoder (Address.AddCString -> rom.getString decodes via CoreState.SystemTextEncoder).
+        static ROM MakeRom()
+        {
+            var rom = new ROM();
+            byte[] data = new byte[0x1000000];
+            bool ok = rom.LoadLow("x.gba", data, "BE8E01");
+            Assert.True(ok, "LoadLow did not recognize BE8E01");
+            CoreState.ROM = rom;
+            CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+            return rom;
+        }
+
+        static PatchInstallCore.PatchSt MakePatch(string name, params (string key, string value)[] kv)
+        {
+            var p = new PatchInstallCore.PatchSt
+            {
+                Name = name,
+                PatchFileName = name + ".txt",
+                Param = new Dictionary<string, string>()
+            };
+            foreach (var (key, value) in kv)
+            {
+                p.Param[key] = value;
+            }
+            return p;
+        }
+
+        // Plant a GBA pointer (toPointer) at `slot` -> `target`.
+        static void PlantPointer(ROM rom, uint slot, uint target)
+        {
+            U.write_u32(rom.Data, slot, U.toPointer(target));
+        }
+
+        static Address Single(List<Address> list, string info)
+        {
+            return Assert.Single(list, a => a.Info == info);
+        }
+
+        static Address Main(List<Address> list)
+        {
+            return Assert.Single(list, a => a.Info != null && a.Info.EndsWith("@STRUCT"));
+        }
+
+        // Hand-author a VALID all-literal LZ77 stream of `uncompSize` uncompressed bytes at `offset`.
+        static uint WriteLz77AllLiteral(ROM rom, uint offset, int uncompSize)
+        {
+            var bytes = new List<byte>();
+            bytes.Add(0x10);
+            bytes.Add((byte)(uncompSize & 0xFF));
+            bytes.Add((byte)((uncompSize >> 8) & 0xFF));
+            bytes.Add((byte)((uncompSize >> 16) & 0xFF));
+            int written = 0;
+            while (written < uncompSize)
+            {
+                bytes.Add(0x00);
+                for (int b = 0; b < 8 && written < uncompSize; b++, written++)
+                {
+                    bytes.Add((byte)(0x40 + (written & 0x3F)));
+                }
+            }
+            for (int i = 0; i < bytes.Count; i++)
+            {
+                rom.write_u8(offset + (uint)i, bytes[i]);
+            }
+            uint clen = LZ77.getCompressedSize(rom.Data, offset);
+            Assert.True(clen > 0);
+            return clen;
+        }
+
+        // ====================================================================
+        // 1. The MAIN struct Address (WF 6536-6543) — POINTER and ADDRESS forms
+        // ====================================================================
+
+        [Fact]
+        public void EmitPatchStruct_PointerForm_DerefsTableBase_EmitsMainInputFormRef()
+        {
+            var rom = MakeRom();
+            const uint slot = 0x1000, table = 0x2000, datasize = 8, datacount = 4;
+            PlantPointer(rom, slot, table);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("S",
+                ("TYPE", "STRUCT"),
+                ("POINTER", "0x1000"),
+                ("DATASIZE", "8"),
+                ("DATACOUNT", "4"),
+                ("P0:POINTER", "0")), isPointerOnly: false);
+
+            var main = Main(list);
+            Assert.Equal(table, main.Addr);
+            // datasize*(datacount+1) = 8*5 = 40.
+            Assert.Equal(datasize * (datacount + 1), main.Length);
+            Assert.Equal(slot, main.Pointer);              // the table's own POINTER slot
+            Assert.Equal(Address.DataTypeEnum.InputFormRef, main.DataType);
+            Assert.Equal(datasize, main.BlockSize);
+            Assert.Equal(new uint[] { 0 }, main.PointerIndexes);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_AddressForm_DirectBase_MainPointerIsNotFound()
+        {
+            var rom = MakeRom();
+            const uint table = 0x3000, datasize = 4, datacount = 2;
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("A",
+                ("TYPE", "STRUCT"),
+                ("ADDRESS", "0x3000"),
+                ("DATASIZE", "4"),
+                ("DATACOUNT", "2"),
+                ("P0:POINTER", "0")), isPointerOnly: false);
+
+            var main = Main(list);
+            Assert.Equal(table, main.Addr);
+            Assert.Equal(datasize * (datacount + 1), main.Length); // 4*3 = 12
+            Assert.Equal(U.NOT_FOUND, main.Pointer);               // ADDRESS form -> no pointer slot
+            Assert.Equal(Address.DataTypeEnum.InputFormRef, main.DataType);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_AsmPointerField_MainIsInputFormRefAsm()
+        {
+            var rom = MakeRom();
+            const uint table = 0x3000;
+            var list = new List<Address>();
+            // P0:ASM only -> iftType InputFormRef_ASM (MakePointerIndexes).
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("Asm",
+                ("TYPE", "STRUCT"),
+                ("ADDRESS", "0x3000"),
+                ("DATASIZE", "8"),
+                ("DATACOUNT", "0"),         // explicit 0 -> MAIN emitted, no entry loop
+                ("P0:ASM", "0")), isPointerOnly: false);
+
+            var main = Main(list);
+            Assert.Equal(table, main.Addr);
+            Assert.Equal(8u * 1u, main.Length);   // datasize*(0+1)
+            Assert.Equal(Address.DataTypeEnum.InputFormRef_ASM, main.DataType);
+        }
+
+        // ====================================================================
+        // 2. DATACOUNT — `$`-macro grep + the early-return guards (WF 6501-6531)
+        // ====================================================================
+
+        [Fact]
+        public void EmitPatchStruct_DataCountMacro_GrepEndAddr_DerivesCount()
+        {
+            var rom = MakeRom();
+            const uint table = 0x4000, datasize = 4;
+            // $EndWeaponDebuffTable5: skip the leading 0x00*4 row, then walk u32 rows until byte[+3]
+            // top nibble != 0. Build: row0 = 00 00 00 00 (skipped), then 3 data rows, then a row with
+            // a high byte[+3]. start = table+4; the walk finds the terminator at table+4 + 3*4 = table+16,
+            // so found = 0x4010, count = ceil((0x4010 - 0x4000)/4) = 4.
+            for (uint i = 0; i < 4; i++) rom.write_u8(table + i, 0x00);          // leading skip row
+            for (uint r = 0; r < 3; r++)
+                for (uint b = 0; b < 4; b++)
+                    rom.write_u8(table + 4 + r * 4 + b, (byte)(b == 3 ? 0x00 : 0x11)); // data rows: byte[+3] low nibble
+            // terminator row at table+16: byte[+3] high nibble set.
+            rom.write_u8(table + 16 + 3, 0x80);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("M",
+                ("TYPE", "STRUCT"),
+                ("ADDRESS", "0x4000"),
+                ("DATASIZE", "4"),
+                ("DATACOUNT", "$EndWeaponDebuffTable5 "),
+                ("P0:POINTER", "0")), isPointerOnly: false);
+
+            var main = Main(list);
+            // found = 0x4010 -> count = 4 -> length = datasize*(4+1) = 20.
+            Assert.Equal(datasize * (4u + 1u), main.Length);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_PointerSlotUnsafe_EmitsNothing()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // POINTER resolves to 0x100 (below the 0x200 safe floor) -> the slot itself is unsafe -> return.
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("U",
+                ("TYPE", "STRUCT"), ("POINTER", "0x100"),
+                ("DATASIZE", "8"), ("DATACOUNT", "4")), isPointerOnly: false);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_PointerTargetUnsafe_EmitsNothing()
+        {
+            var rom = MakeRom();
+            // The slot is safe but the dereferenced table base is below the floor -> return.
+            U.write_u32(rom.Data, 0x1000, U.toPointer(0x100));
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("Ut",
+                ("TYPE", "STRUCT"), ("POINTER", "0x1000"),
+                ("DATASIZE", "8"), ("DATACOUNT", "4")), isPointerOnly: false);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_NoPointerNoAddress_EmitsNothing()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // Neither POINTER nor ADDRESS top-level param -> WF returns before emitting. This is the
+            // STRUCT complement of the no-patch-dir invariant (a STRUCT patch lacking a table base is a no-op).
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("None",
+                ("TYPE", "STRUCT"), ("DATASIZE", "8"), ("DATACOUNT", "4"),
+                ("P0:POINTER", "0")), isPointerOnly: false);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_DataSizeZero_EmitsNothing()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("DZ",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x3000"),
+                ("DATASIZE", "0"), ("DATACOUNT", "4")), isPointerOnly: false);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_DataCountAbsent_EmitsNothing()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // DATACOUNT absent -> datacount 0 AND datacount_str == "" -> WF returns (no MAIN emitted).
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("NoCount",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x3000"),
+                ("DATASIZE", "8"), ("P0:POINTER", "0")), isPointerOnly: false);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_DataCountExplicitZero_EmitsMainOnly_NoEntries()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // Explicit "0" -> datacount 0 but datacount_str != "" -> WF does NOT return; the MAIN
+            // Address is emitted (length datasize*1) and the per-entry loop runs 0 times.
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("Zero",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x3000"),
+                ("DATASIZE", "8"), ("DATACOUNT", "0"),
+                ("P0:POINTER", "0")), isPointerOnly: false);
+            var main = Main(list);
+            Assert.Equal(8u, main.Length);
+            Assert.Single(list); // ONLY the main entry (no per-entry pointers)
+        }
+
+        // ====================================================================
+        // 3. The SAFE terminal arms — per-entry dispatch
+        // ====================================================================
+
+        [Fact]
+        public void EmitPatchStruct_CStringField_EmitsCStringPerEntry()
+        {
+            var rom = MakeRom();
+            const uint table = 0x2000, datasize = 4;
+            // Two entries, each entry's +0 is a CSTRING pointer. Plant a string at 0x5000.
+            uint strAddr = 0x5000;
+            byte[] s = System.Text.Encoding.ASCII.GetBytes("Hi");
+            for (uint i = 0; i < s.Length; i++) rom.write_u8(strAddr + i, s[i]);
+            rom.write_u8(strAddr + (uint)s.Length, 0x00);
+            // entry0 slot = table+0, entry1 slot = table+4 -> both point to the same string.
+            PlantPointer(rom, table + 0, strAddr);
+            PlantPointer(rom, table + 4, strAddr);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("C",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "2"),
+                ("P0:CSTRING", "0")), isPointerOnly: false);
+
+            // MAIN + 2 CSTRING entries (CSTRING Address.Info is the decoded string "Hi").
+            int cstrings = 0;
+            foreach (var a in list)
+            {
+                if (a.DataType == Address.DataTypeEnum.CSTRING)
+                {
+                    cstrings++;
+                    Assert.Equal(strAddr, a.Addr);
+                    Assert.Equal((uint)s.Length + 1, a.Length);
+                }
+            }
+            Assert.Equal(2, cstrings);
+            _ = datasize;
+        }
+
+        [Fact]
+        public void EmitPatchStruct_AsmField_EmitsFunctionPerEntry()
+        {
+            var rom = MakeRom();
+            const uint table = 0x2000;
+            // entry0 P0:ASM -> the ASM function pointer at +0 (a THUMB pointer is odd; AddFunction
+            // strips the low bit via ProgramAddrToPlain).
+            U.write_u32(rom.Data, table + 0, U.toPointer(0x6000) | 1); // ASM pointer (odd)
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("F",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:ASM", "0")), isPointerOnly: false);
+
+            // The ASM field uses AddFunction -> a length-0 entry named "...ASM 0" pointing at the
+            // disassembled target (low bit stripped -> 0x6000).
+            var fn = Assert.Single(list, a => a.Info != null && a.Info.EndsWith("ASM 0"));
+            Assert.Equal(0x6000u, fn.Addr);
+            Assert.Equal(table + 0, fn.Pointer);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_PatchImageFields_EmitSizedAddresses()
+        {
+            var rom = MakeRom();
+            const uint table = 0x2000;
+            // The P-NUMBER is the byte offset within the entry (MakePointerIndexes: datanum =
+            // atoi(key.Substring(1)); the VALUE is ignored). So P0 -> +0, P4 -> +4, P8 -> +8.
+            // entry0: P0 = PatchImage_IMAGE @+0, P4 = PatchImage_TSA @+4, P8 = PatchImage_PALETTE @+8.
+            PlantPointer(rom, table + 0, 0x7000);
+            PlantPointer(rom, table + 4, 0x7100);
+            PlantPointer(rom, table + 8, 0x7200);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("Img",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "12"), ("DATACOUNT", "1"),
+                ("WIDTH", "8"), ("HEIGHT", "8"), ("PALETTE", "2"),
+                ("P0:PatchImage_IMAGE", "0"),
+                ("P4:PatchImage_TSA", "0"),
+                ("P8:PatchImage_PALETTE", "0")), isPointerOnly: false);
+
+            // IMAGE: 8*8/2 = 32, IMG, named "... IMAGE 0" (n is the field ORDINAL, here 0).
+            Assert.Single(list, a => a.Addr == 0x7000u && a.Length == 32u
+                && a.DataType == Address.DataTypeEnum.IMG && a.Info.EndsWith("IMAGE 0"));
+            // TSA: 8*8/32 = 2, TSA, named "... TSA 1".
+            Assert.Single(list, a => a.Addr == 0x7100u && a.Length == 2u
+                && a.DataType == Address.DataTypeEnum.TSA && a.Info.EndsWith("TSA 1"));
+            // PALETTE: count 2 * 0x20 = 0x40, PAL, named "... PALETTE 2".
+            Assert.Single(list, a => a.Addr == 0x7200u && a.Length == 0x40u
+                && a.DataType == Address.DataTypeEnum.PAL && a.Info.EndsWith("PALETTE 2"));
+        }
+
+        [Fact]
+        public void EmitPatchStruct_PatchImageImage_DefaultWidthHeightIsZero_NotEight()
+        {
+            var rom = MakeRom();
+            const uint table = 0x2000;
+            PlantPointer(rom, table + 0, 0x7000);
+            var list = new List<Address>();
+            // NO WIDTH/HEIGHT param -> WF STRUCT arm's atOffset default is "0" (NOT "8"): length 0*0/2 = 0.
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("Z",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:PatchImage_IMAGE", "0")), isPointerOnly: false);
+
+            var img = Assert.Single(list, a => a.DataType == Address.DataTypeEnum.IMG);
+            Assert.Equal(0u, img.Length); // default WIDTH/HEIGHT = 0 (NOT 8 -> would be 32)
+        }
+
+        [Fact]
+        public void EmitPatchStruct_ZtsaField_ReproducesWf6595_NotTheDeadDefect()
+        {
+            // The 6624-6632 copy-paste defect: a PatchImage_ZTSA field must take the LIVE WF 6595 arm
+            // (LZ77IMG named " ZTSA "), NEVER the dead WF 6624 block (LZ77TSA named " ZHEADERTSA ").
+            var rom = MakeRom();
+            const uint table = 0x2000;
+            PlantPointer(rom, table + 0, 0x8000);
+            uint zlen = WriteLz77AllLiteral(rom, 0x8000, 16);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("ZT",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:PatchImage_ZTSA", "0")), isPointerOnly: false);
+
+            // LIVE arm: LZ77IMG, " ZTSA 0". The dead block would have been LZ77TSA, " ZHEADERTSA 0".
+            var a = Assert.Single(list, x => x.Addr == 0x8000u);
+            Assert.Equal(zlen, a.Length);
+            Assert.Equal(Address.DataTypeEnum.LZ77IMG, a.DataType);   // NOT LZ77TSA (the dead defect path)
+            Assert.EndsWith("ZTSA 0", a.Info);                       // NOT "ZHEADERTSA 0"
+        }
+
+        [Fact]
+        public void EmitPatchStruct_ZHeaderTsaField_EmitsLz77ImgNoIndexSuffix()
+        {
+            var rom = MakeRom();
+            const uint table = 0x2000;
+            PlantPointer(rom, table + 0, 0x8000);
+            uint zlen = WriteLz77AllLiteral(rom, 0x8000, 16);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("ZH",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:PatchImage_ZHEADERTSA", "0")), isPointerOnly: false);
+
+            // WF 6614: LZ77IMG, named " ZHEADERTSA " (NO index suffix -> ends with "ZHEADERTSA ").
+            var a = Assert.Single(list, x => x.Addr == 0x8000u);
+            Assert.Equal(zlen, a.Length);
+            Assert.Equal(Address.DataTypeEnum.LZ77IMG, a.DataType);
+            Assert.EndsWith("ZHEADERTSA ", a.Info);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_UnknownType_DefaultMixPlaceholder()
+        {
+            var rom = MakeRom();
+            const uint table = 0x2000;
+            // entry0 +0 -> a pointer to a safe target. An unknown field type hits WF's `default` arm
+            // -> AddPointer(p, 0, .., MIX) -> a length-0 MIX entry.
+            PlantPointer(rom, table + 0, 0x9000);
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("Unk",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:SOMETHINGUNKNOWN", "0")), isPointerOnly: false);
+
+            var mix = Assert.Single(list, a => a.DataType == Address.DataTypeEnum.MIX);
+            Assert.Equal(0x9000u, mix.Addr);
+            Assert.Equal(0u, mix.Length);              // WF default length 0
+            Assert.EndsWith("DATA 0", mix.Info);
+        }
+
+        // ====================================================================
+        // 4. The FORM-BOUND arms -> INTERIM default-MIX (this slice ONLY)
+        // ====================================================================
+
+        // Each interim form-bound type is routed through the same default-MIX placeholder as an
+        // unknown type. THIS IS INTENTIONAL FOR s2pf-5: the precise sub-walked TARGET length is
+        // ported in s2pf-6..10. The test asserts the INTERIM placeholder (length-0 MIX), NOT a
+        // precise WF length — the partial WF-parity test EXCLUDES these types accordingly.
+        [Theory]
+        [InlineData("EVENT")]                     // -> s2pf-6
+        [InlineData("PatchImage_HEADERTSA")]      // -> s2pf-7
+        [InlineData("AP")]                        // -> s2pf-8
+        [InlineData("ROMTCS")]                    // -> s2pf-8
+        [InlineData("PROCS")]                     // -> s2pf-8
+        [InlineData("VENNOUWEAPONLOCK")]          // -> s2pf-9
+        [InlineData("AOERANGEPOINTER")]           // -> s2pf-9
+        [InlineData("SMEPROMOLIST")]              // -> s2pf-9
+        [InlineData("CLASSLIST")]                 // -> s2pf-9
+        [InlineData("TERRAINBATTLELISTPOINTER")]  // -> s2pf-9
+        [InlineData("BATTLEBGLISTPOINTER")]       // -> s2pf-9
+        [InlineData("BATTLEANIMEPOINTER")]        // -> s2pf-10
+        public void EmitPatchStruct_FormBoundArm_IsInterimDefaultMix(string fieldType)
+        {
+            var rom = MakeRom();
+            const uint table = 0x2000;
+            PlantPointer(rom, table + 0, 0x9000);
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("FB",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:" + fieldType, "0")), isPointerOnly: false);
+
+            // INTERIM: emitted as the length-0 MIX placeholder (NOT the precise sub-walked region).
+            var mix = Assert.Single(list, a => a.DataType == Address.DataTypeEnum.MIX);
+            Assert.Equal(0x9000u, mix.Addr);
+            Assert.Equal(0u, mix.Length);
+            Assert.EndsWith("DATA 0", mix.Info);
+        }
+
+        // ====================================================================
+        // 5. Multi-pointer entries + the per-entry ORDER and addressing
+        // ====================================================================
+
+        [Fact]
+        public void EmitPatchStruct_MultiEntryMultiPointer_VisitsEveryFieldAtCorrectAddress()
+        {
+            var rom = MakeRom();
+            const uint table = 0x2000, datasize = 16, datacount = 3;
+            // Each entry has P0:PatchImage_IMAGE @+0 and P8:CSTRING @+8 (the P-NUMBER is the byte
+            // offset). Plant distinct targets so the per-entry addressing
+            // (struct_address + i*datasize + pointerIndexes[n]) is verifiable.
+            uint strAddr = 0xA000;
+            rom.write_u8(strAddr, (byte)'X'); rom.write_u8(strAddr + 1, 0x00);
+            for (uint i = 0; i < datacount; i++)
+            {
+                uint imgSlot = table + i * datasize + 0;
+                uint strSlot = table + i * datasize + 8;
+                PlantPointer(rom, imgSlot, 0xB000 + i * 0x100); // distinct image target per entry
+                PlantPointer(rom, strSlot, strAddr);
+            }
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("Multi",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "16"), ("DATACOUNT", "3"),
+                ("WIDTH", "8"), ("HEIGHT", "8"),
+                ("P0:PatchImage_IMAGE", "0"),
+                ("P8:CSTRING", "0")), isPointerOnly: false);
+
+            // MAIN + 3 IMG + 3 CSTRING = 7.
+            Assert.Equal(7, list.Count);
+            for (uint i = 0; i < datacount; i++)
+            {
+                uint imgTarget = 0xB000 + i * 0x100;
+                Assert.Single(list, a => a.Addr == imgTarget && a.DataType == Address.DataTypeEnum.IMG);
+            }
+            Assert.Equal(3, list.FindAll(a => a.DataType == Address.DataTypeEnum.CSTRING).Count);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_EntryLoopBound_DoesNotVisitSentinelPlusOneRow()
+        {
+            // Copilot plan-review finding #1: the per-entry loop is `i < datacount` (WF 6547) even
+            // though the MAIN block length is datasize*(datacount+1). The sentinel/+1 row must NOT
+            // be visited. Plant a DISTINCT pointer at the sentinel row (i == datacount); it must NOT
+            // be emitted.
+            var rom = MakeRom();
+            const uint table = 0x2000, datasize = 4, datacount = 2;
+            // entries 0,1 -> images; the sentinel row (i==2) at table+2*4 -> a DIFFERENT target.
+            PlantPointer(rom, table + 0 * datasize, 0xB000);
+            PlantPointer(rom, table + 1 * datasize, 0xB100);
+            PlantPointer(rom, table + 2 * datasize, 0xBEEF00 & 0xFFFFFF); // sentinel row target
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("Bound",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "2"),
+                ("WIDTH", "8"), ("HEIGHT", "8"),
+                ("P0:PatchImage_IMAGE", "0")), isPointerOnly: false);
+
+            // Only entries 0 and 1 emit images; the sentinel row is NOT visited.
+            Assert.Single(list, a => a.Addr == 0xB000u && a.DataType == Address.DataTypeEnum.IMG);
+            Assert.Single(list, a => a.Addr == 0xB100u && a.DataType == Address.DataTypeEnum.IMG);
+            Assert.DoesNotContain(list, a => a.Addr == (0xBEEF00u & 0xFFFFFFu));
+            // MAIN + exactly 2 entry images = 3.
+            Assert.Equal(3, list.Count);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_Z256ImageField_IsNotAWfStructArm_FallsToDefaultMix()
+        {
+            // Copilot plan-review finding #3: PatchImage_Z256IMAGE is NOT a WF STRUCT arm (it exists
+            // only in the TYPE=IMAGE handler). WF STRUCT falls through to the `default` -> MIX. The Core
+            // port adds NO real Z256IMAGE STRUCT arm; a Z256IMAGE field must land in default-MIX
+            // (a length-0 MIX placeholder), NOT a sized LZ77 entry.
+            var rom = MakeRom();
+            const uint table = 0x2000;
+            PlantPointer(rom, table + 0, 0x8000);
+            uint unused = WriteLz77AllLiteral(rom, 0x8000, 16); // a real LZ77 stream at the target
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("Z256",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:PatchImage_Z256IMAGE", "0")), isPointerOnly: false);
+
+            var mix = Assert.Single(list, a => a.DataType == Address.DataTypeEnum.MIX);
+            Assert.Equal(0x8000u, mix.Addr);
+            Assert.Equal(0u, mix.Length);   // default-MIX placeholder, NOT the LZ77 length `unused`
+            Assert.NotEqual(unused, mix.Length);
+            Assert.EndsWith("DATA 0", mix.Info);
+            Assert.DoesNotContain(list, a => a.DataType == Address.DataTypeEnum.LZ77IMG
+                || a.DataType == Address.DataTypeEnum.LZ77TSA);
+        }
+
+        // ====================================================================
+        // 6. Null-arg guards + integration through the orchestrator
+        // ====================================================================
+
+        [Fact]
+        public void EmitPatchStruct_NullArgs_Throw()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            var patch = MakePatch("p", ("TYPE", "STRUCT"), ("ADDRESS", "0x3000"), ("DATASIZE", "4"), ("DATACOUNT", "1"));
+            Assert.Throws<ArgumentNullException>(() => RebuildProducerCore.EmitPatchStruct(null, list, patch, false));
+            Assert.Throws<ArgumentNullException>(() => RebuildProducerCore.EmitPatchStruct(rom, null, patch, false));
+            Assert.Throws<ArgumentNullException>(() => RebuildProducerCore.EmitPatchStruct(rom, list, null, false));
+            var noParam = new PatchInstallCore.PatchSt { Name = "p", PatchFileName = "p.txt", Param = null };
+            Assert.Throws<ArgumentNullException>(() => RebuildProducerCore.EmitPatchStruct(rom, list, noParam, false));
+        }
+
+        [Fact]
+        public void Orchestrator_StructPatch_EmitsViaWiredArm()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "RebuildProducerPatchStruct_" + Guid.NewGuid().ToString("N"));
+            string patchDir = Path.Combine(_tempDir, "config", "patch2", "FE8U");
+            Directory.CreateDirectory(patchDir);
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_STRUCT.txt"), new[]
+            {
+                "NAME=StructPatch",
+                "TYPE=STRUCT",
+                "ADDRESS=0x3000",
+                "DATASIZE=8",
+                "DATACOUNT=2",
+                "P0:POINTER=0",
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeRom();
+            CoreState.ROM = fe8;
+
+            var list = new List<Address>();
+            RebuildProducerCore.MakePatchStructDataListCore(
+                fe8, list, isPointerOnly: false, isInstallOnly: false, isStructOnly: false);
+
+            // The wired STRUCT arm emits the MAIN InputFormRef table entry (length 8*(2+1) = 24).
+            Assert.Contains(list, a => a.Addr == 0x3000u && a.Info != null && a.Info.EndsWith("@STRUCT")
+                && a.Length == 24u && a.DataType == Address.DataTypeEnum.InputFormRef);
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchStructTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchStructTests.cs
@@ -367,6 +367,27 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void EmitPatchStruct_AsmFieldSlotNearEof_Skips_NoThrow()
+        {
+            // Copilot PR #1315 review: rom.p32(p) is called for the ASM arm; p32's only guard is
+            // `p >= Data.Length`, so a p in the LAST 3 bytes (in-range but p+4 > Data.Length) would
+            // throw inside u32 -> check_safety(p+4). The full-slot guard must skip it cleanly.
+            var rom = MakeRom();
+            // ADDRESS at the very last 4-aligned-ish offset so that struct_address + pointerIndexes[0]
+            // (P0 -> +0) lands within the last 3 bytes. Use Data.Length - 1 as the table base.
+            uint nearEof = (uint)rom.Data.Length - 1;
+            var list = new List<Address>();
+            var ex = Record.Exception(() => RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("E",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x" + nearEof.ToString("X")),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:ASM", "0")), isPointerOnly: false));
+            Assert.Null(ex);
+            // The near-EOF ASM field is a clean skip; no ASM entry emitted (the MAIN entry's own length
+            // is clamped to 0 by the Address ctor's isSafetyLength guard, but it does not throw).
+            Assert.DoesNotContain(list, a => a.Info != null && a.Info.EndsWith("ASM 0"));
+        }
+
+        [Fact]
         public void EmitPatchStruct_PatchImageFields_EmitSizedAddresses()
         {
             var rom = MakeRom();

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -13270,16 +13270,20 @@ namespace FEBuilderGBA
                 case "ASM_NOWARNING":
                     // WF 6677: deref-safe ASM function pointer -> AddFunction (length 0, disassembled).
                     {
+                        // Guard the FULL 4-byte slot BEFORE rom.p32(p): rom.p32 only checks `p >= Data.Length`,
+                        // then delegates to u32(p) -> check_safety(p+4) which THROWS when p is within the LAST 3
+                        // bytes (in-range but p+4 > Data.Length). WF's verbatim `Program.ROM.p32(p)` would throw
+                        // there too; this slot+3 guard makes a near-EOF slot a clean skip (Core-wide convention;
+                        // Copilot PR #1315 review). AddFunction also re-reads p via CoreState.ROM.u32, so the same
+                        // full-slot guard covers it.
+                        if (!U.isSafetyOffset(p, rom) || !U.isSafetyOffset(p + 3, rom))
+                        {
+                            break;
+                        }
                         uint a = rom.p32(p);
                         if (U.isSafetyOffset(a, rom))
                         {
-                            // WF guards `Program.ROM.p32(p)` safe, then AddFunction(list, p, ..) re-reads
-                            // p via CoreState.ROM.u32 — so the slot must be fully in range. p32 already
-                            // returned a safe `a`, which means p..p+3 were read; guard p+3 to be explicit.
-                            if (U.isSafetyOffset(p + 3, rom))
-                            {
-                                Address.AddFunction(list, p, patchname + " ASM " + n);
-                            }
+                            Address.AddFunction(list, p, patchname + " ASM " + n);
                         }
                     }
                     break;

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -12040,10 +12040,16 @@ namespace FEBuilderGBA
             {
                 // PatchForm.MakePatchStructDataList (the FIRST, unconditional call) — walks the
                 // installed-patch tree via ScanPatchs(GetPatchDirectory()) + CheckIFFast + the per-TYPE
-                // MakePatchStructDataListForADDR/EA/BIN/SWITCH/STRUCT/IMAGE helpers. The whole PatchForm
-                // class is an un-ported WinForms file (patch-config file scanning + DoEvents). A wrong
-                // patch pointer relocates the wrong bytes = silent corruption — DEFER until the patch-
-                // config subsystem reaches Core (its own follow-up slice).
+                // MakePatchStructDataListForADDR/EA/BIN/SWITCH/STRUCT/IMAGE helpers. Ported INCREMENTALLY
+                // in the #1261 option-B s2pf-* slices: the orchestrator + ADDR/SWITCH (s2pf-3) + IMAGE
+                // (s2pf-4) + STRUCT skeleton & SAFE arms (s2pf-5) are LIVE in Core, but this token STAYS
+                // until s2pf-11 because (a) EA/BIN are still no-op stubs, AND (b) the STRUCT arm's
+                // FORM-BOUND fields are routed through a DOCUMENTED INTERIM default-MIX (length-0 MIX
+                // placeholder) — they are upgraded to precise sub-walked lengths in s2pf-6..10 (EVENT=6,
+                // HEADERTSA=7, AP/ROMTCS/PROCS=8, Vennou/AOE/SMEPromo/SomeClass/TerrainFloor/TerrainBG=9,
+                // BattleAnime=10). See EmitPatchStruct's block comment for the full audit table. Until
+                // those land, a wrong/zero patch-pointer length relocates the wrong bytes = silent
+                // corruption — so the gate stays CLOSED (no live rebuild) until the WHOLE arm is precise.
                 "PatchForm(MakePatchStructDataList)",
                 // ProcsScriptForm.MakeAllDataLength(ldrmap) — PORTED in slice 2x (EmitProcsScript /
                 // EmitProcsScriptCore + ROMInfoLoadResourceKnownArea + Load6cNameDicSafe). Its FindProc walk
@@ -12506,7 +12512,13 @@ namespace FEBuilderGBA
                 }
                 else if (type == "STRUCT")
                 {
-                    // s2pf-7: TYPE=STRUCT handler (WF MakePatchStructDataListForSTRUCT @:6461). STUB.
+                    // s2pf-5: TYPE=STRUCT handler (WF MakePatchStructDataListForSTRUCT @:6461).
+                    // Skeleton + SAFE arms (ASM/CSTRING/PatchImage_*/default) ported REAL; the
+                    // FORM-BOUND arms route through a DOCUMENTED INTERIM default-MIX (upgraded
+                    // s2pf-6..10). SAFE: the gate token stays in AsmNotYetPortedRaw (no live
+                    // rebuild) until s2pf-11. See EmitPatchStruct's block comment for the audit
+                    // table of interim types -> upgrade slices.
+                    EmitPatchStruct(rom, list, patch, isPointerOnly);
                 }
                 else if (type == "IMAGE")
                 {
@@ -12950,6 +12962,465 @@ namespace FEBuilderGBA
                     throw new ArgumentOutOfRangeException(nameof(variantKey), variantKey,
                         "Unknown PatchImage variant key.");
             }
+        }
+
+        // ====================================================================
+        // PatchForm producer — option-B epic (#1261, sub-slice s2pf-5 of 11).
+        //
+        // The TYPE=STRUCT terminal arm — the STRUCTURAL HEART of the PatchForm
+        // producer. Faithful Core port of WinForms
+        // PatchForm.MakePatchStructDataListForSTRUCT (FEBuilderGBA/PatchForm.cs:6461).
+        // A TYPE=STRUCT patch describes a fixed-stride table (struct_address,
+        // DATASIZE, DATACOUNT) plus per-entry embedded-pointer fields (P<n>:type).
+        // EmitPatchStruct emits ONE MAIN InputFormRef Address for the table body,
+        // then walks every entry, visiting each pointer field IN ORDER and
+        // dispatching on its type.
+        //
+        // SCOPE OF THIS SLICE (5/11):
+        //   (A) the STRUCT SKELETON (WF 6461-6552) — VERBATIM: struct_address
+        //       resolution (POINTER deref vs ADDRESS direct), DATASIZE/DATACOUNT
+        //       (literal + `$`-macro, start_offset = struct_address), the
+        //       early-returns, the MAIN Address (datasize*(datacount+1), iftType).
+        //   (B) the SAFE terminal arms — ported REAL: ASM/ASM_SWITCH/ASM_NOWARNING
+        //       (AddFunction), CSTRING (AddCString), PatchImage_* (AddAddress sized
+        //       by PatchImageVariantLength), and WF's OWN `default` (AddPointer MIX).
+        //   (C) the FORM-BOUND arms (EVENT/BATTLEANIMEPOINTER/AP/ROMTCS/PROCS/
+        //       VENNOUWEAPONLOCK/SMEPROMOLIST/CLASSLIST/TERRAINBATTLELISTPOINTER/
+        //       BATTLEBGLISTPOINTER/AOERANGEPOINTER + PatchImage_HEADERTSA) — routed
+        //       through the SAME `default` -> AddPointer(...,MIX) path as a DOCUMENTED
+        //       INTERIM (each marked `INTERIM default-MIX -> upgraded in s2pf-N`).
+        //       This is SAFE because the gate token "PatchForm(MakePatchStructDataList)"
+        //       STAYS in AsmNotYetPortedRaw — no live rebuild runs until s2pf-11 — but
+        //       it MUST be upgraded before the token is removed, else those embedded
+        //       pointers' TARGET regions are never relocated (residue corruption).
+        //
+        //   INTERIM default-MIX -> precise-arm UPGRADE MAP (audit table):
+        //     EVENT                     -> s2pf-6
+        //     PatchImage_HEADERTSA      -> s2pf-7  (CalcByteLengthForHeaderTSAData)
+        //     AP / ROMTCS / PROCS       -> s2pf-8
+        //     VENNOUWEAPONLOCK          -> s2pf-9
+        //     AOERANGEPOINTER           -> s2pf-9
+        //     SMEPROMOLIST              -> s2pf-9
+        //     CLASSLIST                 -> s2pf-9
+        //     TERRAINBATTLELISTPOINTER  -> s2pf-9
+        //     BATTLEBGLISTPOINTER       -> s2pf-9
+        //     BATTLEANIMEPOINTER        -> s2pf-10
+        //
+        // FAITHFULNESS NOTE — the WF 6624-6632 COPY-PASTE DEFECT is REPRODUCED
+        // VERBATIM: the SECOND `else if (type == "PatchImage_ZTSA")` (WF 6624) is a
+        // dead/shadowed duplicate of the FIRST PatchImage_ZTSA arm (WF 6595) — the C#
+        // if/else-if chain reaches the FIRST match, so the second branch NEVER fires.
+        // Reproducing WF's literal arm ORDER keeps the dead branch dead exactly as in
+        // WF (a real PatchImage_ZTSA field emits LZ77IMG named " ZTSA ", never the
+        // dead block's LZ77TSA " ZHEADERTSA "). The intended-but-dead ZHEADERTSA arm
+        // (WF 6614) emits LZ77IMG named " ZHEADERTSA " (NO index suffix). See the test
+        // EmitPatchStruct_Ztsa_ReproducesWf6595_NotTheDeadDefect.
+        //
+        // ROM threading: rom is threaded for the p32 derefs/length math; AddFunction/
+        // AddCString/AddPointer read CoreState.ROM internally, so the orchestrator's
+        // caller MUST set CoreState.ROM == rom (same convention as the data-path / ASM
+        // producers — the gate token stays deferred, so no live caller exists yet).
+        // ====================================================================
+
+        /// <summary>
+        /// Faithful Core port of WinForms <c>PatchForm.MakePatchStructDataListForSTRUCT</c>
+        /// (FEBuilderGBA/PatchForm.cs:6461). Resolves the table base (<c>POINTER</c> deref or
+        /// <c>ADDRESS</c> direct), reads <c>DATASIZE</c>/<c>DATACOUNT</c> (literal or
+        /// <c>$</c>-macro, with <c>start_offset = struct_address</c>), emits the MAIN
+        /// InputFormRef <see cref="Address"/> for the whole table body
+        /// (<c>datasize*(datacount+1)</c>, typed by <see cref="MakePointerIndexes"/>), then walks
+        /// every entry and visits each embedded pointer field <c>p = struct_address + i*datasize +
+        /// pointerIndexes[n]</c> IN ORDER, dispatching on the field type via
+        /// <see cref="EmitPatchStructEntry"/>.
+        /// <para>
+        /// <b>This slice (s2pf-5)</b> ports the skeleton + the SAFE terminal arms
+        /// (ASM / CSTRING / PatchImage_* / WF's <c>default</c> MIX). The FORM-BOUND arms route
+        /// through the same MIX <c>default</c> as a DOCUMENTED INTERIM (upgraded s2pf-6..10) —
+        /// SAFE only while the gate token stays deferred. See the block comment above.
+        /// </para>
+        /// </summary>
+        /// <param name="rom">ROM to resolve against — passed explicitly. MUST also be
+        /// <see cref="CoreState.ROM"/> (the ASM/CSTRING/MIX arms' <see cref="Address.AddFunction"/>/
+        /// <see cref="Address.AddCString"/>/<see cref="Address.AddPointer"/> read CoreState.ROM).</param>
+        /// <param name="list">The accumulating struct/pointer list (appended to).</param>
+        /// <param name="patch">The TYPE=STRUCT patch whose POINTER/ADDRESS/DATASIZE/DATACOUNT +
+        /// P&lt;n&gt;:type fields drive emission.</param>
+        /// <param name="isPointerOnly">WF <c>isPointerOnly</c> — forwarded to the AP/ROMTCS/PROCS
+        /// arms (interim this slice).</param>
+        public static void EmitPatchStruct(ROM rom, List<Address> list, PatchInstallCore.PatchSt patch, bool isPointerOnly)
+        {
+            // Public-helper guards (consistent with EmitPatchAddr / EmitPatchImage): throw a clear
+            // ArgumentNullException rather than an unhelpful NRE. The orchestrator always passes a
+            // valid rom/list and a LoadPatch result whose Param is non-null.
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (list == null) throw new ArgumentNullException(nameof(list));
+            if (patch == null) throw new ArgumentNullException(nameof(patch));
+            if (patch.Param == null) throw new ArgumentNullException(nameof(patch) + ".Param");
+
+            // WF: string basedir = Path.GetDirectoryName(patch.PatchFileName);
+            // Normalize null -> "" so the resolver never receives a null basedir (see EmitPatchAddr).
+            string basedir = System.IO.Path.GetDirectoryName(patch.PatchFileName) ?? "";
+
+            // ---- struct_address: POINTER deref vs ADDRESS direct (WF 6464-6493) --
+            uint struct_address;
+            uint struct_pointer = U.NOT_FOUND;
+            string pointer_str = U.at(patch.Param, "POINTER");
+            if (pointer_str != "")
+            {
+                // WF: struct_pointer = convertBinAddressString(pointer_str, 8, 0, basedir);
+                struct_pointer = ResolvePatchAddress(rom, pointer_str, 8, 0, basedir);
+                if (!U.isSafetyOffset(struct_pointer, rom))
+                {
+                    return;
+                }
+                // Guard the FULL 4-byte slot before rom.p32 reads it. WF's verbatim
+                // Program.ROM.p32(struct_pointer) after isSafetyOffset(struct_pointer) returns 0 for
+                // struct_pointer >= Data.Length (p32's own guard), but a struct_pointer in the LAST 3
+                // bytes would read past EOF inside u32. rom.p32 internally only checks `>= Data.Length`,
+                // so harden the slot+3 here (skips a near-EOF slot gracefully; never on valid ROMs).
+                if (!U.isSafetyOffset(struct_pointer + 3, rom))
+                {
+                    return;
+                }
+                struct_address = rom.p32(struct_pointer);
+                if (!U.isSafetyOffset(struct_address, rom))
+                {
+                    return;
+                }
+            }
+            else
+            {
+                string address_str = U.at(patch.Param, "ADDRESS");
+                if (address_str == "")
+                {
+                    return;
+                }
+                // WF: struct_address = convertBinAddressString(address_str, 8, 0, basedir);
+                struct_address = ResolvePatchAddress(rom, address_str, 8, 0, basedir);
+                if (!U.isSafetyOffset(struct_address, rom))
+                {
+                    return;
+                }
+                struct_pointer = U.NOT_FOUND;
+            }
+
+            // ---- DATASIZE (WF 6495-6499) ----------------------------------------
+            uint datasize = U.atoi0x(U.at(patch.Param, "DATASIZE"));
+            if (datasize <= 0)
+            {
+                return;
+            }
+
+            // ---- DATACOUNT: `$`-macro grep vs literal (WF 6501-6531) ------------
+            uint datacount;
+            string datacount_str = U.at(patch.Param, "DATACOUNT");
+            if (datacount_str.Length > 0 && datacount_str[0] == '$')
+            {//grep等 — WF: convertBinAddressString(datacount_str, 8, struct_address, basedir).
+                // NOTE the start_offset is struct_address (NOT 0): the `$`-grep finds the table END
+                // and the count is the byte span / datasize.
+                datacount = ResolvePatchAddress(rom, datacount_str, 8, struct_address, basedir);
+                if (datacount == U.NOT_FOUND)
+                {
+                    return;
+                }
+                if (datacount >= struct_address)
+                {
+                    datacount = (uint)Math.Ceiling((datacount - struct_address) / (double)datasize);
+                }
+                // WF Debug.Assert(false); return; — a span/datasize >= 0xffff is a corrupt/huge count;
+                // never emit it (the assert is a DEBUG-only diagnostic; the return is the real guard).
+                if (datacount >= 0xffff)
+                {
+                    return;
+                }
+            }
+            else
+            {//直値 (literal)
+                datacount = U.atoi0x(datacount_str);
+            }
+            // WF 6525-6531: datacount <= 0 returns ONLY when DATACOUNT was absent ("" yields atoi0x 0);
+            // an explicit "0" falls through (datacount stays 0 -> the per-entry loop simply does not run,
+            // but the MAIN Address is still emitted with length datasize*(0+1)). Reproduced verbatim.
+            if (datacount <= 0)
+            {
+                if (datacount_str == "")
+                {
+                    return;
+                }
+            }
+
+            // ---- pointer-index/type parse + iftType (WF 6532-6534) --------------
+            string[] typeArray;
+            Address.DataTypeEnum iftType;
+            uint[] pointerIndexes = MakePointerIndexes(patch, out typeArray, out iftType);
+
+            // ---- the MAIN struct Address (WF 6536-6543) -------------------------
+            // length = datasize*(datacount+1): WF sizes the body for datacount entries PLUS one
+            // (the +1 covers the terminator/sentinel row the editors append). iftType + blockSize
+            // (=datasize) + pointerIndexes drive the InputFormRef re-walk. The struct_pointer is the
+            // table's own POINTER slot (NOT_FOUND for the ADDRESS form). NOTE: WF uses `new Address(..)`
+            // + list.Add directly here (NOT Address.AddAddress), so the InputFormRef entry is added
+            // even when struct_pointer == NOT_FOUND — reproduced with the same ctor.
+            string patchname = patch.Name + "@STRUCT";
+            list.Add(new Address(struct_address
+                , datasize * (datacount + 1)
+                , struct_pointer
+                , patchname
+                , iftType
+                , datasize
+                , pointerIndexes));
+
+            // ---- per-entry pointer-field walk (WF 6545-6735) --------------------
+            // addr = struct_address + i*datasize; for each pointer index n, p = addr +
+            // pointerIndexes[n], visited IN ORDER. EOF-guard is inside EmitPatchStructEntry.
+            uint addr = struct_address;
+            for (int i = 0; i < datacount; i++, addr += datasize)
+            {
+                for (int n = 0; n < pointerIndexes.Length; n++)
+                {
+                    uint p = addr + pointerIndexes[n];
+                    string type = typeArray[n];
+                    EmitPatchStructEntry(rom, list, patch, basedir, isPointerOnly,
+                        type, p, patchname, n);
+                }
+            }
+        }
+
+        /// <summary>
+        /// One per-entry pointer-field dispatch for <see cref="EmitPatchStruct"/> — the WF
+        /// per-field <c>if/else if</c> chain (FEBuilderGBA/PatchForm.cs:6553-6733), factored into
+        /// a switch so the later slices s2pf-6..10 replace each INTERIM arm body in place.
+        /// <para>
+        /// <b>Dispatch contract for s2pf-6..10:</b> each fully-implemented arm emits a PRECISE
+        /// length; each INTERIM form-bound arm falls into <see cref="EmitPatchStructDefaultMix"/>
+        /// (a length-0 MIX placeholder) and is marked with the slice that upgrades it. To upgrade an
+        /// arm, give its <c>case</c> a real body (sized like the WF helper it ports) and drop it from
+        /// the interim group — the call shape (<paramref name="p"/>, <paramref name="patchname"/>,
+        /// <paramref name="n"/>) is exactly what the WF helpers receive.
+        /// </para>
+        /// </summary>
+        /// <param name="rom">ROM to resolve against — threaded for the p32 derefs / length math.</param>
+        /// <param name="list">The accumulating struct/pointer list (appended to).</param>
+        /// <param name="patch">The owning STRUCT patch (the PatchImage arms read its WIDTH/HEIGHT/PALETTE).</param>
+        /// <param name="basedir">The patch dir (for the WIDTH/HEIGHT/PALETTE <c>$</c>-macros).</param>
+        /// <param name="isPointerOnly">WF <c>isPointerOnly</c> — forwarded to the AP/ROMTCS/PROCS interim arms.</param>
+        /// <param name="type">The pointer field type (<c>typeArray[n]</c>).</param>
+        /// <param name="p">The field address <c>struct_address + i*datasize + pointerIndexes[n]</c>.</param>
+        /// <param name="patchname">The struct's <c>Name@STRUCT</c> info prefix.</param>
+        /// <param name="n">The pointer-index ordinal (for the per-field info suffix).</param>
+        static void EmitPatchStructEntry(ROM rom, List<Address> list, PatchInstallCore.PatchSt patch,
+            string basedir, bool isPointerOnly, string type, uint p, string patchname, int n)
+        {
+            switch (type)
+            {
+                // ---- FULLY IMPLEMENTED — SAFE terminal arms ---------------------
+
+                case "PatchImage_IMAGE":
+                    // WF 6563: raw 4bpp image -> w*h/2, IMG. WIDTH/HEIGHT default "0" (NOT "8" — the
+                    // STRUCT arm's atOffset uses the helper default, unlike the IMAGE TYPE arm).
+                    EmitPatchStructImage(rom, list, patch, basedir, p, "IMAGE",
+                        Address.DataTypeEnum.IMG, patchname + " IMAGE " + n);
+                    break;
+
+                case "PatchImage_ZIMAGE":
+                    // WF 6574: LZ77 image -> getCompressedSize, LZ77IMG. NOTE WF names this " IMAGE "
+                    // (NO index suffix) — reproduced verbatim.
+                    EmitPatchStructImage(rom, list, patch, basedir, p, "ZIMAGE",
+                        Address.DataTypeEnum.LZ77IMG, patchname + " IMAGE ");
+                    break;
+
+                case "PatchImage_TSA":
+                    // WF 6584: raw TSA -> w*h/32, TSA.
+                    EmitPatchStructImage(rom, list, patch, basedir, p, "TSA",
+                        Address.DataTypeEnum.TSA, patchname + " TSA " + n);
+                    break;
+
+                case "PatchImage_ZTSA":
+                    // WF 6595: LZ77 TSA -> getCompressedSize, LZ77IMG named " ZTSA ".
+                    // (This is the LIVE PatchImage_ZTSA arm; the WF 6624 duplicate is DEAD — see below.)
+                    EmitPatchStructImage(rom, list, patch, basedir, p, "ZTSA",
+                        Address.DataTypeEnum.LZ77IMG, patchname + " ZTSA " + n);
+                    break;
+
+                case "PatchImage_ZHEADERTSA":
+                    // WF 6614: LZ77 header-TSA -> getCompressedSize, LZ77IMG named " ZHEADERTSA "
+                    // (NO index suffix). Its length is a plain LZ77 getCompressedSize (no header-TSA
+                    // byte-length calc), so it IS ported here (unlike the non-Z HEADERTSA below).
+                    EmitPatchStructImage(rom, list, patch, basedir, p, "ZHEADERTSA",
+                        Address.DataTypeEnum.LZ77IMG, patchname + " ZHEADERTSA ");
+                    break;
+
+                // FAITHFULNESS — the WF 6624-6632 COPY-PASTE DEFECT: WF has a SECOND
+                // `else if (type == "PatchImage_ZTSA")` block (intended for ZHEADERTSA, emitting
+                // LZ77TSA named " ZHEADERTSA " + n). In WF's if/else-if chain it is UNREACHABLE
+                // (the FIRST PatchImage_ZTSA case at WF 6595 already handles that type). The switch
+                // here has the SAME effect — there is no second "PatchImage_ZTSA" label (a duplicate
+                // case would not even compile), so the dead block is reproduced by its ABSENCE: a
+                // PatchImage_ZTSA field always takes the live arm above, never the dead block's
+                // LZ77TSA path. This matches WF byte-for-byte (the parity harness asserts it).
+
+                case "PatchImage_PALETTE":
+                    // WF 6634: palette -> count*0x20, PAL. PALETTE default "1".
+                    EmitPatchStructImage(rom, list, patch, basedir, p, "PALETTE",
+                        Address.DataTypeEnum.PAL, patchname + " PALETTE " + n);
+                    break;
+
+                case "ASM":
+                case "ASM_SWITCH":
+                case "ASM_NOWARNING":
+                    // WF 6677: deref-safe ASM function pointer -> AddFunction (length 0, disassembled).
+                    {
+                        uint a = rom.p32(p);
+                        if (U.isSafetyOffset(a, rom))
+                        {
+                            // WF guards `Program.ROM.p32(p)` safe, then AddFunction(list, p, ..) re-reads
+                            // p via CoreState.ROM.u32 — so the slot must be fully in range. p32 already
+                            // returned a safe `a`, which means p..p+3 were read; guard p+3 to be explicit.
+                            if (U.isSafetyOffset(p + 3, rom))
+                            {
+                                Address.AddFunction(list, p, patchname + " ASM " + n);
+                            }
+                        }
+                    }
+                    break;
+
+                case "CSTRING":
+                    // WF 6716: AddCString(list, p) — deref the CSTRING pointer at p, add the string body.
+                    // AddCString itself guards the slot + the deref; just guard p+3 for the u32 read.
+                    if (U.isSafetyOffset(p, rom) && U.isSafetyOffset(p + 3, rom))
+                    {
+                        Address.AddCString(list, p);
+                    }
+                    break;
+
+                // ---- INTERIM default-MIX (this slice) — form-bound arms ---------
+                // Each routes through EmitPatchStructDefaultMix (= WF's own `default`,
+                // length-0 MIX). This DIVERGES from WF (WF emits the precise sub-walked
+                // TARGET region); SAFE only while the gate token stays deferred. The
+                // partial WF-parity test EXCLUDES these types.
+
+                case "EVENT":
+                    // INTERIM default-MIX -> upgraded in s2pf-6 (EventScriptForm.ScanScript walk).
+                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    break;
+
+                case "PatchImage_HEADERTSA":
+                    // INTERIM default-MIX -> upgraded in s2pf-7 (CalcByteLengthForHeaderTSAData; the
+                    // WF non-Z HEADERTSA arm at 6605 uses AddHeaderTSAPointer, a WinForms ImageUtil call).
+                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    break;
+
+                case "AP":
+                    // INTERIM default-MIX -> upgraded in s2pf-8 (AddAPPointer).
+                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    break;
+
+                case "ROMTCS":
+                    // INTERIM default-MIX -> upgraded in s2pf-8 (AddROMTCSPointer).
+                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    break;
+
+                case "PROCS":
+                    // INTERIM default-MIX -> upgraded in s2pf-8 (AddProcsPointer).
+                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    break;
+
+                case "VENNOUWEAPONLOCK":
+                    // INTERIM default-MIX -> upgraded in s2pf-9 (VennouWeaponLockForm.MakeDataLength).
+                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    break;
+
+                case "AOERANGEPOINTER":
+                    // INTERIM default-MIX -> upgraded in s2pf-9 (AOERANGEForm.MakeDataLength).
+                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    break;
+
+                case "SMEPROMOLIST":
+                    // INTERIM default-MIX -> upgraded in s2pf-9 (SMEPromoListForm.MakeDataLength).
+                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    break;
+
+                case "CLASSLIST":
+                    // INTERIM default-MIX -> upgraded in s2pf-9 (SomeClassListForm.MakeDataLength).
+                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    break;
+
+                case "TERRAINBATTLELISTPOINTER":
+                    // INTERIM default-MIX -> upgraded in s2pf-9 (MapTerrainFloorLookupTableForm.MakeDataLength).
+                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    break;
+
+                case "BATTLEBGLISTPOINTER":
+                    // INTERIM default-MIX -> upgraded in s2pf-9 (MapTerrainBGLookupTableForm.MakeDataLength).
+                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    break;
+
+                case "BATTLEANIMEPOINTER":
+                    // INTERIM default-MIX -> upgraded in s2pf-10 (ImageBattleAnimeForm.MakeBattleAnimeSettingDataLength).
+                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    break;
+
+                default:
+                    // WF 6725: `default` (不明なポインタ / unknown pointer) -> AddPointer(p, 0, .., MIX).
+                    // This is WF's OWN faithful default — it keeps the embedded pointer's TARGET region
+                    // TRACKED (length 0 = the relocator resolves the real span), NOT a shortcut.
+                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// The PatchImage_* per-entry arm body shared by <see cref="EmitPatchStructEntry"/> (WF
+        /// 6563-6642). Resolves WIDTH/HEIGHT (default "0") and PALETTE (default "1") via
+        /// <see cref="ResolvePatchAddress"/>, dereferences <paramref name="p"/> (<c>rom.p32</c>) and,
+        /// when the target is safe, emits one <see cref="Address"/> sized by
+        /// <see cref="PatchImageVariantLength"/> (<paramref name="variantKey"/>), typed
+        /// <paramref name="type"/>, named <paramref name="info"/>.
+        /// <para>NOTE: WF's STRUCT PatchImage arms call <c>atOffset(Param,"WIDTH")</c> with the helper
+        /// DEFAULT "0" (NOT "8" like the TYPE=IMAGE arm); a missing WIDTH/HEIGHT therefore yields a
+        /// 0-length raw image — faithful to WF. PALETTE defaults "1" (WF 6639).</para>
+        /// </summary>
+        static void EmitPatchStructImage(ROM rom, List<Address> list, PatchInstallCore.PatchSt patch,
+            string basedir, uint p, string variantKey, Address.DataTypeEnum type, string info)
+        {
+            // WF: uint a = Program.ROM.p32(p); if (U.isSafetyOffset(a)) { ... }. rom.p32 is EOF-safe
+            // (returns 0 for p >= Data.Length); guard p+3 so a near-EOF slot does not read past EOF.
+            if (!U.isSafetyOffset(p, rom) || !U.isSafetyOffset(p + 3, rom))
+            {
+                return;
+            }
+            uint a = rom.p32(p);
+            if (!U.isSafetyOffset(a, rom))
+            {
+                return;
+            }
+            // WF STRUCT PatchImage arms: atOffset(Param,"WIDTH") default "0", PALETTE default "1".
+            uint width = ResolvePatchAddress(rom, U.at(patch.Param, "WIDTH", "0"), 0, 0x100, basedir);
+            uint height = ResolvePatchAddress(rom, U.at(patch.Param, "HEIGHT", "0"), 0, 0x100, basedir);
+            uint paletteCount = ResolvePatchAddress(rom, U.at(patch.Param, "PALETTE", "1"), 0, 0x100, basedir);
+            uint len = PatchImageVariantLength(rom, variantKey, a, width, height, paletteCount);
+            Address.AddAddress(list, a, len, p, info, type);
+        }
+
+        /// <summary>
+        /// WF's OWN <c>default</c> arm (FEBuilderGBA/PatchForm.cs:6725): emit a length-0
+        /// <c>InputFormRef_MIX</c> pointer at <paramref name="p"/> named <c>patchname DATA n</c>.
+        /// <see cref="Address.AddPointer"/> derefs <paramref name="p"/> (via <see cref="CoreState.ROM"/>)
+        /// and adds the TARGET as a MIX region whose span the relocator resolves from the length-0
+        /// placeholder — so the embedded pointer's target stays TRACKED. Also the s2pf-5 INTERIM landing
+        /// for every FORM-BOUND arm (each upgraded to a precise length in s2pf-6..10).
+        /// </summary>
+        static void EmitPatchStructDefaultMix(ROM rom, List<Address> list, uint p, string patchname, int n)
+        {
+            // AddPointer reads CoreState.ROM.u32(p) after its own isSafetyOffset(p) guard; that throws
+            // only if p is in the last 3 bytes. Guard p+3 here so a near-EOF slot is a clean skip (WF's
+            // verbatim AddPointer after no extra guard would throw there). `rom` is accepted for a uniform
+            // arm signature + the EOF guard; the deref itself is CoreState.ROM-bound (== rom by contract).
+            if (!U.isSafetyOffset(p, rom) || !U.isSafetyOffset(p + 3, rom))
+            {
+                return;
+            }
+            Address.AddPointer(list, p, 0, patchname + " DATA " + n, Address.DataTypeEnum.MIX);
         }
 
         // ====================================================================

--- a/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
+++ b/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
@@ -502,6 +502,134 @@ namespace FEBuilderGBA.Tests.Unit
             }
         }
 
+        /// <summary>
+        /// PARTIAL WF-parity for #1261 slice s2pf-5 — the PatchForm producer TYPE=STRUCT dispatch arm
+        /// (<see cref="RebuildProducerCore.EmitPatchStruct"/>). Both the WinForms reference
+        /// (<c>PatchForm.MakePatchStructDataList</c> -&gt; <c>MakePatchStructDataListForSTRUCT</c>,
+        /// PatchForm.cs:6461) and the Core orchestrator
+        /// (<see cref="RebuildProducerCore.MakePatchStructDataListCore"/>) run on the SAME real FE8U ROM
+        /// with the SAME rebuild flags. Each side is FILTERED to the FULLY-IMPLEMENTED STRUCT arms only —
+        /// the MAIN struct InputFormRef entry (Info ends <c>@STRUCT</c>) + the per-entry ASM and
+        /// PatchImage_* arms (Info contains <c>@STRUCT </c> then <c>ASM</c>/<c>IMAGE</c>/<c>TSA</c>/
+        /// <c>ZTSA</c>/<c>ZHEADERTSA</c>/<c>PALETTE</c>) — then compared Core ⊆ WF on the load-bearing
+        /// fields (Addr/Length/Pointer/DataType). A Core-extra (Core emits a STRUCT entry WF does not) is a
+        /// faithfulness regression and FAILS.
+        /// <para><b>THE INTERIM FORM-BOUND ARMS ARE EXCLUDED (deferred to s2pf-6..10).</b> The
+        /// EVENT/BATTLEANIMEPOINTER/AP/ROMTCS/PROCS/VENNOUWEAPONLOCK/SMEPROMOLIST/CLASSLIST/
+        /// TERRAINBATTLELISTPOINTER/BATTLEBGLISTPOINTER/AOERANGEPOINTER + PatchImage_HEADERTSA fields are
+        /// routed through Core's INTERIM default-MIX (a length-0 MIX entry named <c>... DATA n</c>) this
+        /// slice — they INTENTIONALLY diverge from WF (WF emits the precise sub-walked TARGET region). So
+        /// every <c>... DATA </c>-suffixed entry (and the HEADERTSA data type) is filtered OUT of BOTH
+        /// sides before the comparison. Those arms gain their own parity teeth in s2pf-6..10, and the FULL
+        /// STRUCT parity (no exclusions) lands at s2pf-11 when the gate token is removed.</para>
+        /// <para><b>CSTRING is NOT in the merged-list parity scope:</b> WF/Core both name a CSTRING entry
+        /// the DECODED STRING (no <c>@STRUCT</c> marker), so it cannot be reliably attributed to a STRUCT
+        /// patch within the merged producer list. The CSTRING arm's byte-faithfulness is carried by the
+        /// synthetic <c>RebuildProducerPatchStructTests.EmitPatchStruct_CStringField_*</c>.</para>
+        /// <para>SKIP-IF-NO-ROM: requires <c>roms/FE8U.gba</c> (gitignored — absent in CI / the worktree,
+        /// present in the user's main checkout). When no ROM is found the test returns early (Pass).</para>
+        /// <para><b>NON-VACUOUS only where <c>config/patch2</c> is CHECKED OUT</b> (same posture as the
+        /// ADDR/SWITCH + IMAGE harnesses): an un-init submodule yields no STRUCT patch files, so both
+        /// filtered lists are empty and Core ⊆ WF holds trivially. The branch-level verification (the
+        /// skeleton arithmetic, the DATACOUNT guards, every safe arm, the 6624-6632 defect, the interim
+        /// default-MIX) is carried by the synthetic Core.Tests (<c>RebuildProducerPatchStructTests</c>).</para>
+        /// </summary>
+        [Fact]
+        public void CorePatchStructArm_IsSubsetOf_WinFormsPatchProducer_ExcludingInterimFormArms()
+        {
+            string? repoRoot = FindRepoRootWithRom();
+            if (repoRoot == null) return; // no checkout with roms/FE8U.gba reachable — early-exit (Pass)
+            string romPath = Path.Combine(repoRoot, "roms", "FE8U.gba");
+            if (!File.Exists(romPath)) return; // no ROM (gitignored, absent in CI) — early-exit (Pass)
+
+            string savedBaseDir = CoreState.BaseDirectory;
+            try
+            {
+                CoreState.BaseDirectory = repoRoot;
+                ForceCommandLineMode();
+                BootstrapWinFormsProgram(repoRoot);
+
+                bool loaded = Program.LoadROM(romPath, "");
+                if (!loaded || Program.ROM == null) return; // ROM did not load — early-exit (Pass)
+                if (Program.ROM.RomInfo.version != 8) return; // calibrated on FE8U — early-exit (Pass)
+
+                PatchForm.ClearCheckIF();
+
+                // ---- WinForms reference: the public patch producer, same flags as the rebuild ----
+                var wfAll = new List<Address>();
+                PatchForm.MakePatchStructDataList(wfAll,
+                    isPointerOnly: IS_PATCH_POINTER_ONLY,
+                    isInstallOnly: IS_PATCH_INSTALL_ONLY,
+                    isStructOnly: IS_PATCH_STRUCT_ONLY);
+
+                // ---- Core: the orchestrator, same flags + the SAME ROM ----
+                var coreAll = new List<Address>();
+                RebuildProducerCore.MakePatchStructDataListCore(Program.ROM, coreAll,
+                    isPointerOnly: IS_PATCH_POINTER_ONLY,
+                    isInstallOnly: IS_PATCH_INSTALL_ONLY,
+                    isStructOnly: IS_PATCH_STRUCT_ONLY);
+
+                // A FULLY-IMPLEMENTED STRUCT-arm entry: the MAIN struct entry (Info ends "@STRUCT") OR a
+                // per-entry ASM / PatchImage_* arm ("@STRUCT " + ASM/IMAGE/TSA/ZTSA/ZHEADERTSA/PALETTE).
+                // EXCLUDES the interim form-bound arms (the "... DATA n" MIX placeholders, which DIVERGE
+                // from WF this slice) and the deferred HEADERTSA data type. CSTRING is out of merged-list
+                // scope (named the decoded string, not "@STRUCT") — see the doc-comment.
+                string[] safeArmTokens = { " ASM ", " IMAGE ", " TSA ", " ZTSA ", " ZHEADERTSA ", " PALETTE " };
+                bool IsImplementedStructEntry(Address a)
+                {
+                    if (a.Info == null) return false;
+                    if (a.DataType == Address.DataTypeEnum.HEADERTSA) return false;   // deferred (s2pf-7)
+                    // The interim form-bound arms emit "<name>@STRUCT DATA n" (Core MIX) — EXCLUDE.
+                    if (a.Info.Contains("@STRUCT DATA ", StringComparison.Ordinal)) return false;
+                    // The MAIN struct InputFormRef entry: Info ends "@STRUCT".
+                    if (a.Info.EndsWith("@STRUCT", StringComparison.Ordinal)) return true;
+                    // A per-entry safe arm: "...@STRUCT <ARM> ..." for one of the implemented arms.
+                    if (a.Info.IndexOf("@STRUCT", StringComparison.Ordinal) < 0) return false;
+                    foreach (string t in safeArmTokens)
+                    {
+                        if (a.Info.Contains("@STRUCT" + t, StringComparison.Ordinal)) return true;
+                    }
+                    return false;
+                }
+
+                var wfStruct = wfAll.Where(IsImplementedStructEntry).ToList();
+                var coreStruct = coreAll.Where(IsImplementedStructEntry).ToList();
+
+                var wfKeys = new HashSet<Key>(wfStruct.Select(Key.Of));
+
+                // Core-extras = Core emits an implemented-STRUCT key WF does not. ALWAYS a faithfulness
+                // regression -> FAIL. WF-extras (WF emits an implemented-STRUCT key Core lacks) are NOT
+                // asserted (subset direction): the interim form-bound arms are already excluded, so a
+                // WF-extra among the implemented arms would signal a gate divergence worth surfacing, not
+                // a silent drop. Core ⊆ WF is the load-bearing guarantee for this skeleton+safe-arms slice.
+                var coreExtras = coreStruct.Where(a => !wfKeys.Contains(Key.Of(a)))
+                                           .Select(Key.Of).Distinct().ToList();
+
+                if (coreExtras.Count > 0)
+                {
+                    const int N = 30;
+                    string dump = string.Join("\n", coreExtras.Take(N).Select(k =>
+                        $"  Addr=0x{k.Addr:X} Len=0x{k.Length:X} Ptr=0x{k.Pointer:X} Type={k.Type}"));
+                    Assert.Fail(
+                        $"Core PatchForm STRUCT arm emitted {coreExtras.Count} (implemented-arm) entr"
+                        + (coreExtras.Count == 1 ? "y" : "ies")
+                        + " NOT present in the WinForms patch producer (faithfulness regression).\n"
+                        + $"WF implemented-STRUCT total={wfStruct.Count}, Core total={coreStruct.Count}.\n"
+                        + $"First {Math.Min(N, coreExtras.Count)} Core-only entries:\n{dump}");
+                }
+
+                // PROVEN: every Core STRUCT entry (of the implemented skeleton + safe arms) is
+                // byte-identical to a WF entry on (Addr/Length/Pointer/DataType) — no faithfulness
+                // regression — with the interim form-bound arms excluded from both sides (or both empty
+                // when config/patch2 is absent). FULL parity (no exclusions) lands at s2pf-11.
+                Assert.Empty(coreExtras);
+            }
+            finally
+            {
+                CoreState.BaseDirectory = savedBaseDir;
+            }
+        }
+
         // ----------------------------------------------------------------
         readonly struct Key : IEquatable<Key>
         {


### PR DESCRIPTION
## Summary

Faithful WinForms→Core port of `PatchForm.MakePatchStructDataListForSTRUCT` (`FEBuilderGBA/PatchForm.cs:6461-6736`) as `RebuildProducerCore.EmitPatchStruct`, wired into the orchestrator's `STRUCT` switch arm. The structural heart of the PatchForm producer. Sub-slice **5/11** of the #1261 option-B PatchForm epic.

Plan: [issue #1261 comment](https://github.com/laqieer/FEBuilderGBA/issues/1261#issuecomment-4761292786) (Copilot-reviewed; all 3 findings verified handled — see below).

## (A) STRUCT skeleton (WF 6461-6552) — VERBATIM
- `struct_address` via `POINTER` deref (`rom.p32`) vs `ADDRESS` direct (WF's exact selection + safety early-returns).
- `DATASIZE` / `DATACOUNT` (literal + `$`-macro, **start_offset = struct_address**), the `NOT_FOUND` / `>= 0xffff` / `""` early-return guards exactly as WF. **No new `< struct_address` early-return** (WF leaves the raw resolved value when `found < struct_address`).
- The MAIN `InputFormRef` `Address(struct_address, datasize*(datacount+1), struct_pointer, …, iftType, datasize, pointerIndexes)` from `MakePointerIndexes`.
- Per-entry loop `p = struct_address + i*datasize + pointerIndexes[n]`, bound `i < datacount` (does NOT visit the `+1` sentinel row), each field dispatched IN ORDER.

## (B) SAFE terminal arms — ported REAL
- `ASM`/`ASM_SWITCH`/`ASM_NOWARNING` → `Address.AddFunction`.
- `CSTRING` → `Address.AddCString`.
- `PatchImage_IMAGE`/`_ZIMAGE`/`_TSA`/`_ZTSA`/`_ZHEADERTSA`/`_PALETTE` → `PatchImageVariantLength` + `Address.AddAddress` (STRUCT `WIDTH`/`HEIGHT` default `"0"` not `"8"`; `PALETTE` `"1"`).
- `default` → `Address.AddPointer(…, MIX)` (WF's OWN faithful default — keeps the region tracked).

### The WF 6624-6632 copy-paste defect — REPRODUCED VERBATIM
The second `else if (type == "PatchImage_ZTSA")` (WF 6624) is dead/shadowed by the first `PatchImage_ZTSA` arm (WF 6595). The C# `if/else-if` chain reaches the first match, so the second branch never fires. The Core `switch` reproduces this by the dead label's ABSENCE: a `PatchImage_ZTSA` field always takes the live arm (`LZ77IMG`, `" ZTSA n"`), never the dead block's `LZ77TSA`, `" ZHEADERTSA "`. Documented in code + pinned by `EmitPatchStruct_ZtsaField_ReproducesWf6595_NotTheDeadDefect`. **Default = reproduce WF; did NOT diverge/fix.**

## (C) Form-bound arms → INTERIM default-MIX (this slice ONLY)
These route through the same length-0 `MIX` `default` path as an EXPLICIT INTERIM (each marked `// INTERIM default-MIX → upgraded in s2pf-N`):

| Type | Upgrade slice |
|---|---|
| `EVENT` | s2pf-6 |
| `PatchImage_HEADERTSA` (non-Z) | s2pf-7 |
| `AP` / `ROMTCS` / `PROCS` | s2pf-8 |
| `VENNOUWEAPONLOCK` / `AOERANGEPOINTER` / `SMEPROMOLIST` / `CLASSLIST` / `TERRAINBATTLELISTPOINTER` / `BATTLEBGLISTPOINTER` | s2pf-9 |
| `BATTLEANIMEPOINTER` | s2pf-10 |

SAFE because the gate token `"PatchForm(MakePatchStructDataList)"` **STAYS** in `AsmNotYetPortedRaw` (no live rebuild runs) until s2pf-11. An auditable note is added next to the gate token + a full audit table in `EmitPatchStruct`'s block comment. **MUST** be upgraded before the token is removed (else those embedded pointers' TARGET regions are never relocated = residue corruption).

## Dispatch structure (for s2pf-6..10)
```
EmitPatchStruct(ROM rom, List<Address> list, PatchInstallCore.PatchSt patch, bool isPointerOnly)
  -> per pointer field: EmitPatchStructEntry(rom, list, patch, basedir, isPointerOnly, type, p, patchname, n)
       switch(type): SAFE arms emit precise lengths; INTERIM arms -> EmitPatchStructDefaultMix (length-0 MIX)
  PatchImage arms share EmitPatchStructImage; interim + default share EmitPatchStructDefaultMix
```
To upgrade an interim arm: give its `case` a real body (sized like the WF helper) + drop it from the interim group — the call shape `(p, patchname, n)` is exactly what the WF helpers receive.

## Copilot plan-review findings — all verified handled
1. **Loop bound `i < datacount`** (not `+1`) — confirmed; pinned by `EmitPatchStruct_EntryLoopBound_DoesNotVisitSentinelPlusOneRow`.
2. **No new `< struct_address` early-return** — confirmed; the code only has `NOT_FOUND` + `>= 0xffff` returns, ceil gated on `>= struct_address`.
3. **`PatchImage_Z256IMAGE` is not a WF STRUCT arm** — confirmed; falls to default-MIX (no non-WF extension); pinned by `EmitPatchStruct_Z256ImageField_IsNotAWfStructArm_FallsToDefaultMix`.

## Scope (Ref)
Part of #1261. Token stays deferred; orchestrator still NOT wired into the live producer (s2pf-11). EA/BIN arms remain no-op stubs (out of scope).

## Test plan
- [x] `RebuildProducerPatchStructTests` (Core.Tests, **34 new**, synthetic FE8U `BE8E01` + synthetic `PatchSt`): POINTER/ADDRESS forms; literal + `$`-macro DATACOUNT; the early-return guards; the MAIN IFR Address (addr/length=`datasize*(count+1)`/pointer/type=iftType/blockSize/pointerIndexes); every safe arm (ASM/CSTRING/PatchImage_*/default) + per-entry ORDER & addressing; the interim default-MIX (length-0 placeholder, asserted interim) for every form-bound type; the 6624-6632 defect; the loop bound; Z256IMAGE→default; the no-table-base no-op; null-arg guards; orchestrator integration.
- [x] `RebuildProducerWFParityTests.CorePatchStructArm_IsSubsetOf_WinFormsPatchProducer_ExcludingInterimFormArms` (FEBuilderGBA.Tests, skip-if-no-ROM): Core ⊆ WF on the MAIN IFR + ASM + PatchImage_* entries, EXCLUDING the interim form-bound types (documented; full parity at s2pf-11). Verified **NON-VACUOUS** on real FE8U + `config/patch2` (385 STRUCT patch files) — 0 Core-extras.
- [x] No-patch-dir invariant (`MakePatchStructDataListCore_NoPatchDir_EmitsNothing_NoThrow`) still passes; the STRUCT arm is a clean no-op when no qualifying table base exists.
- [x] `dotnet test FEBuilderGBA.Core.Tests --filter RebuildProducer` → **598 pass, 0 failed** (564 baseline + 34).
- [x] All 5 `RebuildProducerWFParity` tests pass (non-vacuous with `config/patch2` checked out).
- [x] `dotnet build FEBuilderGBA.sln` clean (0 errors).

## Screenshots
Core-only (no GUI changes) → not applicable. Proof is the test output above (Core.Tests 598/0, parity 5/5 non-vacuous, solution build clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
