### PR TITLE
feat(core): PatchForm HEADERTSA (CalcByteLengthForHeaderTSAData + arm) (#1261 s2pf-7)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchImageTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchImageTests.cs
@@ -5,9 +5,9 @@
 //   RebuildProducerCore.PatchImageVariantLength = the reusable per-variant length math
 //                                                 (factored so s2pf-5 STRUCT PatchImage_* reuses it).
 //
-// 6 of 8 variants ported (HEADERTSA_POINTER DEFERRED to s2pf-7 — needs
-// CalcByteLengthForHeaderTSAData). Coverage (synthetic in-memory FE8U ROM +
-// synthetic PatchSt — no real GBA ROM file, mirroring RebuildProducerPatchAddrSwitchTests):
+// ALL 8 variants ported (HEADERTSA_POINTER wired in s2pf-7 via EmitHeaderTsaPointer /
+// CalcHeaderTsaLength = WF CalcByteLengthForHeaderTSAData). Coverage (synthetic in-memory
+// FE8U ROM + synthetic PatchSt — no real GBA ROM file, mirroring RebuildProducerPatchAddrSwitchTests):
 //   1. EmitPatchImage:
 //        - IMAGE_POINTER    -> w*h/2,  IMG     (raw 4bpp)
 //        - ZIMAGE_POINTER   -> LZ77,   LZ77IMG (hand-authored stream, getCompressedSize)
@@ -15,16 +15,16 @@
 //        - TSA_POINTER      -> w*h/32, TSA
 //        - ZTSA_POINTER     -> LZ77,   LZ77TSA
 //        - ZHEADERTSA_POINTER -> LZ77, LZ77TSA
+//        - HEADERTSA_POINTER -> 2+(x+1)*(y+1)*2, HEADERTSA (s2pf-7)
 //        - PALETTE_POINTER  -> count*0x20, PAL  (count default 1; explicit count)
 //        - PALETTE_ADDRESS  -> count*0x20, PAL  (direct address, pointer slot NOT_FOUND;
 //                              only when PALETTE_POINTER absent/unsafe)
 //        - WIDTH/HEIGHT default "8"; PALETTE default "1"
 //        - emitted Address addr/length/pointer/type/name byte-faithful to WF
-//        - HEADERTSA_POINTER (the NON-Z variant) is NOT (wrongly) emitted — DEFERRED.
 //        - per-variant safety gates (p==0 for IMAGE/ZIMAGE/Z256IMAGE; unsafe slot; unsafe target)
 //        - all-variants-absent -> nothing (no-op), null-arg guards.
 //   2. PatchImageVariantLength: the raw math (IMAGE=w*h/2, TSA=w*h/32, PALETTE=count*0x20,
-//      LZ77 variants = getCompressedSize), and the unknown-key throw.
+//      LZ77 variants = getCompressedSize, HEADERTSA=2+(x+1)*(y+1)*2), and the unknown-key throw.
 //   3. Integration through the public orchestrator MakePatchStructDataListCore on a staged
 //      config/patch2 tree (proves the IMAGE switch arm is wired).
 //   4. The no-patch-dir invariant is re-asserted in RebuildProducerPatchScaffoldTests; this
@@ -121,6 +121,16 @@ namespace FEBuilderGBA.Core.Tests
             return clen;
         }
 
+        // Plant a header-TSA master header {x, y} (each stored value = dimension minus one) at `offset`
+        // and return the WF byte length: 2 + (x+1)*(y+1)*2 (the body cells are left zero — the length
+        // depends only on the 2-byte header, matching CalcHeaderTsaLength = WF CalcByteLengthForHeaderTSAData).
+        static uint WriteHeaderTsa(ROM rom, uint offset, byte x, byte y)
+        {
+            rom.write_u8(offset + 0, x);
+            rom.write_u8(offset + 1, y);
+            return 2u + ((uint)x + 1) * ((uint)y + 1) * 2;
+        }
+
         // ====================================================================
         // 1. PatchImageVariantLength — the reusable math (WF :6738 lengths)
         // ====================================================================
@@ -163,6 +173,33 @@ namespace FEBuilderGBA.Core.Tests
             uint at = 0x3000;
             uint expect = WriteLz77AllLiteral(rom, at, 16);
             Assert.Equal(expect, RebuildProducerCore.PatchImageVariantLength(rom, key, at, 8, 8, 1));
+        }
+
+        [Fact]
+        public void PatchImageVariantLength_HeaderTsa_MatchesCalcByteLengthForHeaderTSAData()
+        {
+            var rom = MakeRom();
+            // WF ImageUtil.CalcByteLengthForHeaderTSAData: 2 + (x+1)*(y+1)*2 from the 2-byte master
+            // header. Plant {0x07, 0x03} -> (7+1)*(3+1)=32 cells -> 2 + 32*2 = 66 bytes. The +1 on BOTH
+            // dimensions and the /2-vs-/32 axes must not be swapped (an off-by-one mis-sizes the region).
+            uint at = 0x3000;
+            uint expect = WriteHeaderTsa(rom, at, 0x07, 0x03);
+            Assert.Equal(66u, expect);
+            Assert.Equal(expect, RebuildProducerCore.PatchImageVariantLength(rom, "HEADERTSA", at, 8, 8, 1));
+        }
+
+        [Fact]
+        public void PatchImageVariantLength_HeaderTsa_NearEof_IsZero_NoThrow()
+        {
+            var rom = MakeRom();
+            // pos + 2 >= Length -> WF returns 0 (the 2-byte header itself does not fit). Out-of-bounds
+            // header -> 0 length (the caller's safety gate then skips emission — NOT a 0-length region
+            // that would drop following tiles).
+            uint len = 0;
+            uint nearEof = (uint)rom.Data.Length - 1;
+            var ex = Record.Exception(() => len = RebuildProducerCore.PatchImageVariantLength(rom, "HEADERTSA", nearEof, 8, 8, 1));
+            Assert.Null(ex);
+            Assert.Equal(0u, len);
         }
 
         [Fact]
@@ -340,37 +377,74 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain(list, a => a.Info == "Both@PALETTE_ADDRESS");
         }
 
-        // ---- the DEFERRED HEADERTSA_POINTER (NON-Z) must NOT be emitted ------
+        // ---- the HEADERTSA_POINTER (NON-Z) variant (s2pf-7) -----------------
 
         [Fact]
-        public void EmitPatchImage_HeaderTsaPointer_IsDeferred_EmitsNothing()
+        public void EmitPatchImage_HeaderTsaPointer_EmitsHeaderTsa_WithCalcLength()
         {
             var rom = MakeRom();
-            PlantPointer(rom, 0x1000, 0x2000);
+            const uint slot = 0x1000, target = 0x2000;
+            PlantPointer(rom, slot, target);
+            // WF 6798: AddHeaderTSAPointer(list, p, Name+"@HEADERTSA_POINTER", false) -> length =
+            // CalcByteLengthForHeaderTSAData(target) = 2 + (x+1)*(y+1)*2, typed HEADERTSA.
+            uint expect = WriteHeaderTsa(rom, target, 0x0F, 0x01); // (15+1)*(1+1)=32 -> 2 + 32*2 = 66
+            Assert.Equal(66u, expect);
+
             var list = new List<Address>();
-            // HEADERTSA_POINTER (non-Z) needs CalcByteLengthForHeaderTSAData (s2pf-7). It is NOT
-            // ported in this slice: the producer must NOT emit a wrong/zero-length entry for it.
             RebuildProducerCore.EmitPatchImage(rom, list,
                 MakePatch("H", ("TYPE", "IMAGE"), ("HEADERTSA_POINTER", "0x1000")), isPointerOnly: false);
 
-            Assert.Empty(list);
-            Assert.DoesNotContain(list, a => a.Info != null && a.Info.Contains("HEADERTSA_POINTER"));
+            var a = Single(list, "H@HEADERTSA_POINTER");
+            Assert.Equal(target, a.Addr);
+            Assert.Equal(expect, a.Length);
+            Assert.Equal(slot, a.Pointer);
+            Assert.Equal(Address.DataTypeEnum.HEADERTSA, a.DataType);
         }
 
         [Fact]
-        public void EmitPatchImage_HeaderTsaDeferred_DoesNotBlockOtherVariants()
+        public void EmitPatchImage_HeaderTsaPointer_AlongsideOtherVariants()
         {
             var rom = MakeRom();
             PlantPointer(rom, 0x1000, 0x2000); // IMAGE
-            PlantPointer(rom, 0x1100, 0x2100); // HEADERTSA (deferred)
+            PlantPointer(rom, 0x1100, 0x2100); // HEADERTSA
+            uint expect = WriteHeaderTsa(rom, 0x2100, 0x07, 0x03); // 2 + 32*2 = 66
             var list = new List<Address>();
-            // The deferred HEADERTSA_POINTER must be a clean skip — the sibling IMAGE_POINTER still emits.
+            // Both the IMAGE_POINTER and the (now-ported) HEADERTSA_POINTER emit, in order.
             RebuildProducerCore.EmitPatchImage(rom, list,
                 MakePatch("M", ("TYPE", "IMAGE"),
                           ("IMAGE_POINTER", "0x1000"), ("HEADERTSA_POINTER", "0x1100")), isPointerOnly: false);
 
             Assert.Single(list, a => a.Info == "M@IMAGE_POINTER");
-            Assert.DoesNotContain(list, a => a.Info != null && a.Info.Contains("HEADERTSA_POINTER"));
+            var h = Single(list, "M@HEADERTSA_POINTER");
+            Assert.Equal(0x2100u, h.Addr);
+            Assert.Equal(expect, h.Length);
+            Assert.Equal(Address.DataTypeEnum.HEADERTSA, h.DataType);
+        }
+
+        [Fact]
+        public void EmitPatchImage_HeaderTsaPointer_UnsafeTarget_Skips()
+        {
+            var rom = MakeRom();
+            // Pointer slot is safe but the dereferenced target is NOT a safe pointer (points below floor).
+            U.write_u32(rom.Data, 0x1000, U.toPointer(0x100));
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchImage(rom, list,
+                MakePatch("U", ("TYPE", "IMAGE"), ("HEADERTSA_POINTER", "0x1000")), isPointerOnly: false);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitPatchImage_HeaderTsaPointer_SlotNearEof_Skips_NoThrow()
+        {
+            var rom = MakeRom();
+            var list = new List<Address>();
+            // Slot within the last 3 bytes: EmitHeaderTsaPointer's full-extent EOF guard skips cleanly.
+            uint nearEof = (uint)rom.Data.Length - 1;
+            var ex = Record.Exception(() => RebuildProducerCore.EmitPatchImage(rom, list,
+                MakePatch("E", ("TYPE", "IMAGE"), ("HEADERTSA_POINTER", "0x" + nearEof.ToString("X"))),
+                isPointerOnly: false));
+            Assert.Null(ex);
+            Assert.Empty(list);
         }
 
         // ---- safety gates --------------------------------------------------

--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchStructTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchStructTests.cs
@@ -129,6 +129,15 @@ namespace FEBuilderGBA.Core.Tests
             return clen;
         }
 
+        // Plant a header-TSA master header {x, y} at `offset` and return the WF byte length
+        // (2 + (x+1)*(y+1)*2 = CalcHeaderTsaLength = WF ImageUtil.CalcByteLengthForHeaderTSAData).
+        static uint WriteHeaderTsa(ROM rom, uint offset, byte x, byte y)
+        {
+            rom.write_u8(offset + 0, x);
+            rom.write_u8(offset + 1, y);
+            return 2u + ((uint)x + 1) * ((uint)y + 1) * 2;
+        }
+
         // ====================================================================
         // 1. The MAIN struct Address (WF 6536-6543) — POINTER and ADDRESS forms
         // ====================================================================
@@ -485,6 +494,52 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void EmitPatchStruct_HeaderTsaField_EmitsHeaderTsaWithCalcLength()
+        {
+            var rom = MakeRom();
+            const uint table = 0x2000;
+            const uint target = 0x8000;
+            PlantPointer(rom, table + 0, target);
+            // WF 6605-6613: non-Z header-TSA -> AddHeaderTSAPointer -> length =
+            // CalcByteLengthForHeaderTSAData(target) = 2 + (x+1)*(y+1)*2, typed HEADERTSA,
+            // named "... HEADERTSA <n>" (n is the field ORDINAL, here 0).
+            uint expect = WriteHeaderTsa(rom, target, 0x07, 0x03); // (7+1)*(3+1)=32 -> 2 + 32*2 = 66
+            Assert.Equal(66u, expect);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("HT",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:PatchImage_HEADERTSA", "0")), isPointerOnly: false);
+
+            var a = Assert.Single(list, x => x.Addr == target);
+            Assert.Equal(expect, a.Length);
+            Assert.Equal(table + 0, a.Pointer);
+            Assert.Equal(Address.DataTypeEnum.HEADERTSA, a.DataType);
+            Assert.EndsWith("HEADERTSA 0", a.Info);
+            // NOT the interim default-MIX placeholder (no length-0 MIX entry).
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.MIX);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_HeaderTsaField_UnsafeTarget_EmitsNoHeaderTsa()
+        {
+            var rom = MakeRom();
+            const uint table = 0x2000;
+            // Slot derefs to an unsafe target (below the 0x200 floor) -> WF's `if (isSafetyOffset(a))`
+            // pre-gate fails -> nothing emitted (NO HEADERTSA, NO MIX placeholder).
+            U.write_u32(rom.Data, table + 0, U.toPointer(0x100));
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("HU",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:PatchImage_HEADERTSA", "0")), isPointerOnly: false);
+
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.HEADERTSA);
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.MIX);
+        }
+
+        [Fact]
         public void EmitPatchStruct_UnknownType_DefaultMixPlaceholder()
         {
             var rom = MakeRom();
@@ -510,12 +565,13 @@ namespace FEBuilderGBA.Core.Tests
 
         // Each interim form-bound type is routed through the same default-MIX placeholder as an
         // unknown type. THIS IS INTENTIONAL FOR s2pf-5: the precise sub-walked TARGET length is
-        // ported in s2pf-6..10. The test asserts the INTERIM placeholder (length-0 MIX), NOT a
+        // ported in s2pf-8..10. The test asserts the INTERIM placeholder (length-0 MIX), NOT a
         // precise WF length — the partial WF-parity test EXCLUDES these types accordingly.
-        // NOTE: EVENT was REMOVED from this interim group in s2pf-6 — it now runs the real
-        // EventScriptForm.ScanScript walk (see the EmitPatchStruct_EventArm_* tests below).
+        // NOTE: EVENT was REMOVED from this interim group in s2pf-6 (it runs the real
+        // EventScriptForm.ScanScript walk — see EmitPatchStruct_EventArm_*), and
+        // PatchImage_HEADERTSA in s2pf-7 (it runs EmitHeaderTsaPointer — see
+        // EmitPatchStruct_HeaderTsaField_* below).
         [Theory]
-        [InlineData("PatchImage_HEADERTSA")]      // -> s2pf-7
         [InlineData("AP")]                        // -> s2pf-8
         [InlineData("ROMTCS")]                    // -> s2pf-8
         [InlineData("PROCS")]                     // -> s2pf-8

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -12045,10 +12045,11 @@ namespace FEBuilderGBA
                 // (s2pf-4) + STRUCT skeleton & SAFE arms (s2pf-5) are LIVE in Core, but this token STAYS
                 // until s2pf-11 because (a) EA/BIN are still no-op stubs, AND (b) the STRUCT arm's
                 // FORM-BOUND fields are STILL routed through a DOCUMENTED INTERIM default-MIX (length-0
-                // MIX placeholder) — they are upgraded to precise sub-walked lengths in s2pf-7..10
-                // (HEADERTSA=7, AP/ROMTCS/PROCS=8, Vennou/AOE/SMEPromo/SomeClass/TerrainFloor/TerrainBG=9,
-                // BattleAnime=10). EVENT is now PRECISE (s2pf-6: the EventScriptForm.ScanScript walk via
-                // EmitScanScript, disasm-gated). See EmitPatchStruct's block comment for the full audit
+                // MIX placeholder) — they are upgraded to precise sub-walked lengths in s2pf-8..10
+                // (AP/ROMTCS/PROCS=8, Vennou/AOE/SMEPromo/SomeClass/TerrainFloor/TerrainBG=9,
+                // BattleAnime=10). EVENT (s2pf-6: the EventScriptForm.ScanScript walk via EmitScanScript,
+                // disasm-gated) and PatchImage_HEADERTSA (s2pf-7: EmitHeaderTsaPointer / CalcHeaderTsaLength)
+                // are now PRECISE. See EmitPatchStruct's block comment for the full audit
                 // table. Until the remaining interim arms land, a wrong/zero patch-pointer length relocates
                 // the wrong bytes = silent corruption — so the gate stays CLOSED (no live rebuild) until
                 // the WHOLE arm is precise.
@@ -12514,10 +12515,11 @@ namespace FEBuilderGBA
                 }
                 else if (type == "STRUCT")
                 {
-                    // s2pf-5/6: TYPE=STRUCT handler (WF MakePatchStructDataListForSTRUCT @:6461).
+                    // s2pf-5/6/7: TYPE=STRUCT handler (WF MakePatchStructDataListForSTRUCT @:6461).
                     // Skeleton + SAFE arms (ASM/CSTRING/PatchImage_*/default) + EVENT (s2pf-6,
-                    // EmitScanScript, disasm-gated) ported REAL; the REMAINING FORM-BOUND arms route
-                    // through a DOCUMENTED INTERIM default-MIX (upgraded s2pf-7..10). SAFE: the gate
+                    // EmitScanScript, disasm-gated) + PatchImage_HEADERTSA (s2pf-7, EmitHeaderTsaPointer)
+                    // ported REAL; the REMAINING FORM-BOUND arms route
+                    // through a DOCUMENTED INTERIM default-MIX (upgraded s2pf-8..10). SAFE: the gate
                     // token stays in AsmNotYetPortedRaw (no live rebuild) until s2pf-11. See
                     // EmitPatchStruct's block comment for the audit table of interim types -> slices.
                     EmitPatchStruct(rom, list, patch, isPointerOnly);
@@ -12746,14 +12748,13 @@ namespace FEBuilderGBA
         // (IMAGE_POINTER / ZIMAGE_POINTER / Z256IMAGE_POINTER / TSA_POINTER /
         // ZTSA_POINTER / [Z]HEADERTSA_POINTER / PALETTE_POINTER|PALETTE_ADDRESS);
         // each safe one emits a single Address sized by PatchImageVariantLength
-        // and typed per WF (IMG / LZ77IMG / TSA / LZ77TSA / PAL). The WIDTH/HEIGHT
-        // (default "8") feed the raw 4bpp/TSA sizes; PALETTE (default "1") the count.
+        // and typed per WF (IMG / LZ77IMG / TSA / LZ77TSA / HEADERTSA / PAL). The
+        // WIDTH/HEIGHT (default "8") feed the raw 4bpp/TSA sizes; PALETTE (default "1") the count.
         //
-        // DEFERRED (this slice ports 6 of the 8 variants — 6/8):
-        //   - HEADERTSA_POINTER (the NON-Z header-TSA variant, WF :6798): its length
-        //     needs CalcByteLengthForHeaderTSAData (slice s2pf-7), so it is LEFT
-        //     UNHANDLED here (NOT emitted with a wrong/zero length). See the
-        //     `// s2pf-7: HEADERTSA_POINTER` marker below.
+        // ALL 8 variants ported (8/8). The last deferred variant —
+        //   - HEADERTSA_POINTER (the NON-Z header-TSA variant, WF :6798) — is now wired
+        //     in slice s2pf-7 via EmitHeaderTsaPointer -> CalcHeaderTsaLength (= WF
+        //     ImageUtil.CalcByteLengthForHeaderTSAData). See the `HEADERTSA_POINTER` arm below.
         //
         // The length math is factored into PatchImageVariantLength so the s2pf-5
         // STRUCT `PatchImage_*` per-entry arms (WF :6563-6642) reuse the EXACT same
@@ -12767,13 +12768,15 @@ namespace FEBuilderGBA
         /// <c>convertBinAddressString(v, 0, 0x100, basedir)</c>), dereferences the pointer
         /// (<c>rom.u32</c>), and — when both the pointer slot and the target are safe — emits one
         /// <see cref="Address"/> whose length is <see cref="PatchImageVariantLength"/> and whose
-        /// <see cref="Address.DataTypeEnum"/> matches the variant (IMG / LZ77IMG / TSA / LZ77TSA / PAL).
+        /// <see cref="Address.DataTypeEnum"/> matches the variant (IMG / LZ77IMG / TSA / LZ77TSA /
+        /// HEADERTSA / PAL).
         /// WIDTH/HEIGHT default "8" (4bpp = w*h/2, TSA = w*h/32); PALETTE count defaults "1" (count*0x20).
         /// LZ77 lengths come from EOF-safe <see cref="LZ77.getCompressedSize(byte[],uint)"/>.
-        /// <para><b>6 of 8 variants ported.</b> <c>HEADERTSA_POINTER</c> (the non-Z header-TSA, WF :6798)
-        /// is DEFERRED to s2pf-7 (needs <c>CalcByteLengthForHeaderTSAData</c>) and is intentionally NOT
-        /// emitted here. The two header-TSA pointer FIELDS otherwise tracked by WF's
-        /// <c>AddHeaderTSAPointer</c> are out of this slice's scope.</para>
+        /// <para><b>All 8 variants ported.</b> <c>HEADERTSA_POINTER</c> (the non-Z header-TSA, WF :6798)
+        /// is wired in slice s2pf-7 via <see cref="EmitHeaderTsaPointer"/> (WF
+        /// <c>AddHeaderTSAPointer</c> -&gt; <see cref="CalcHeaderTsaLength"/> = WF
+        /// <c>ImageUtil.CalcByteLengthForHeaderTSAData</c>); it emits a
+        /// <see cref="Address.DataTypeEnum.HEADERTSA"/> region.</para>
         /// </summary>
         /// <param name="rom">ROM to resolve against — passed explicitly (NEVER CoreState.ROM / Program.ROM).</param>
         /// <param name="list">The accumulating struct/pointer list (appended to).</param>
@@ -12825,11 +12828,21 @@ namespace FEBuilderGBA
             EmitPatchImageVariant(rom, list, patch, basedir, "ZTSA_POINTER", "ZTSA", false,
                 width, height, paletteCount, Address.DataTypeEnum.LZ77TSA);
 
-            // ---- HEADERTSA_POINTER (WF :6798) -> DEFERRED to s2pf-7 ----------
-            // s2pf-7: HEADERTSA_POINTER. The non-Z header-TSA variant's length needs
-            // CalcByteLengthForHeaderTSAData (WF AddHeaderTSAPointer -> ImageUtil), which is slice
-            // s2pf-7. NOT emitted here (emitting a wrong/zero length would mis-size or orphan the
-            // header-TSA region during a rebuild). Left intentionally unhandled.
+            // ---- HEADERTSA_POINTER (WF :6798) -> EmitHeaderTsaPointer (s2pf-7) ----
+            // WF 6798-6806: p = atOffset(.., "HEADERTSA_POINTER", basedir); if (isSafetyOffset(p)) {
+            //   a = u32(p); if (isSafetyPointer(a)) AddHeaderTSAPointer(list, p, Name+"@HEADERTSA_POINTER", false); }.
+            // AddHeaderTSAPointer (= Core EmitHeaderTsaPointer) re-derefs p and re-checks both gates
+            // internally, then sizes the region via CalcHeaderTsaLength (= WF
+            // ImageUtil.CalcByteLengthForHeaderTSAData). So the WF outer u32(p)+isSafetyPointer(a)
+            // pre-check is redundant with EmitHeaderTsaPointer's own gates (emit iff BOTH safe — no
+            // double-emit, no behavioural change). EmitHeaderTsaPointer is EOF-hardened (it guards the
+            // full 4-byte deref extent before u32), so a near-EOF slot is a clean skip rather than the
+            // throw WF's bare u32(p) would hit on a malformed ROM.
+            uint pHeaderTsa = ResolvePatchAddress(rom, U.at(patch.Param, "HEADERTSA_POINTER", "0"), 0, 0x100, basedir);
+            if (U.isSafetyOffset(pHeaderTsa, rom))
+            {
+                EmitHeaderTsaPointer(rom, list, pHeaderTsa, patch.Name + "@HEADERTSA_POINTER");
+            }
 
             // ---- ZHEADERTSA_POINTER (WF :6807) -> LZ77 length, LZ77TSA ------
             // NOTE: this is the COMPRESSED header-TSA variant; its length IS a plain LZ77
@@ -12925,6 +12938,10 @@ namespace FEBuilderGBA
         ///   <item><c>ZIMAGE</c> / <c>Z256IMAGE</c> / <c>ZTSA</c> / <c>ZHEADERTSA</c> -&gt;
         ///         <c>LZ77.getCompressedSize(rom.Data, addr)</c> (EOF-safe; 0 on a malformed/near-EOF
         ///         stream — never throws, never reads past EOF).</item>
+        ///   <item><c>HEADERTSA</c> -&gt; <see cref="CalcHeaderTsaLength"/> (WF
+        ///         <c>ImageUtil.CalcByteLengthForHeaderTSAData</c>: <c>2 + (x+1)*(y+1)*2</c> from the
+        ///         2-byte master header at <paramref name="addr"/>; EOF-safe 0 when the header itself
+        ///         does not fit).</item>
         ///   <item><c>PALETTE</c> -&gt; <c>paletteCount*0x20</c> (count 16-color palettes).</item>
         /// </list>
         /// <paramref name="addr"/> is the already-dereferenced, <c>toOffset</c>'d target (only the LZ77
@@ -12935,7 +12952,7 @@ namespace FEBuilderGBA
         /// the following data on a rebuild).</para>
         /// </summary>
         /// <param name="rom">ROM whose <c>Data</c> the LZ77 variants scan — passed explicitly.</param>
-        /// <param name="variantKey">One of IMAGE / TSA / ZIMAGE / Z256IMAGE / ZTSA / ZHEADERTSA / PALETTE.</param>
+        /// <param name="variantKey">One of IMAGE / TSA / ZIMAGE / Z256IMAGE / ZTSA / ZHEADERTSA / HEADERTSA / PALETTE.</param>
         /// <param name="addr">The dereferenced target offset (read only by the LZ77 variants).</param>
         /// <param name="width">Image width in pixels (IMG/TSA only).</param>
         /// <param name="height">Image height in pixels (IMG/TSA only).</param>
@@ -12956,6 +12973,13 @@ namespace FEBuilderGBA
                 case "ZHEADERTSA":
                     // WF :6761/6772/6794/6814 — EOF-safe LZ77 compressed length.
                     return LZ77.getCompressedSize(rom.Data, addr);
+                case "HEADERTSA":
+                    // WF AddHeaderTSAPointer -> ImageUtil.CalcByteLengthForHeaderTSAData (the non-Z
+                    // header-TSA variant, ported as CalcHeaderTsaLength in slice 2k). The 2-byte master
+                    // header {x, y} (each stored value = dimension minus one) prefixes (x+1)*(y+1) 16-bit
+                    // cells; total = 2 + (x+1)*(y+1)*2 (EOF-safe 0 when the header itself does not fit).
+                    // <paramref name="addr"/> is the already-dereferenced, toOffset'd target.
+                    return CalcHeaderTsaLength(rom, addr);
                 case "PALETTE":
                     return paletteCount * 0x20;          // WF :6826/6835 — count*0x20 PAL bytes.
                 default:
@@ -12992,9 +13016,13 @@ namespace FEBuilderGBA
         //       IsEventScriptDisasmReady (the EventCondForm convention). The per-STRUCT
         //       `tracelist` (WF 6545) is allocated ONCE before the entry loop and shared
         //       across every EVENT arm. No longer interim.
+        //   (B'') PatchImage_HEADERTSA — ported REAL in s2pf-7 (WF 6605-6613): the non-Z
+        //       header-TSA field -> AddHeaderTSAPointer (= EmitHeaderTsaPointer, sized by
+        //       CalcHeaderTsaLength = WF ImageUtil.CalcByteLengthForHeaderTSAData), typed
+        //       HEADERTSA. No longer interim (was interim default-MIX through s2pf-5/6).
         //   (C) the REMAINING FORM-BOUND arms (BATTLEANIMEPOINTER/AP/ROMTCS/PROCS/
         //       VENNOUWEAPONLOCK/SMEPROMOLIST/CLASSLIST/TERRAINBATTLELISTPOINTER/
-        //       BATTLEBGLISTPOINTER/AOERANGEPOINTER + PatchImage_HEADERTSA) — routed
+        //       BATTLEBGLISTPOINTER/AOERANGEPOINTER) — routed
         //       through the SAME `default` -> AddPointer(...,MIX) path as a DOCUMENTED
         //       INTERIM (each marked `INTERIM default-MIX -> upgraded in s2pf-N`).
         //       This is SAFE because the gate token "PatchForm(MakePatchStructDataList)"
@@ -13002,9 +13030,9 @@ namespace FEBuilderGBA
         //       it MUST be upgraded before the token is removed, else those embedded
         //       pointers' TARGET regions are never relocated (residue corruption).
         //
-        //   INTERIM default-MIX -> precise-arm UPGRADE MAP (audit table; EVENT is DONE):
+        //   INTERIM default-MIX -> precise-arm UPGRADE MAP (audit table; EVENT + HEADERTSA DONE):
         //     EVENT                     -> s2pf-6  DONE (EmitScanScript, disasm-gated)
-        //     PatchImage_HEADERTSA      -> s2pf-7  (CalcByteLengthForHeaderTSAData)
+        //     PatchImage_HEADERTSA      -> s2pf-7  DONE (EmitHeaderTsaPointer / CalcHeaderTsaLength)
         //     AP / ROMTCS / PROCS       -> s2pf-8
         //     VENNOUWEAPONLOCK          -> s2pf-9
         //     AOERANGEPOINTER           -> s2pf-9
@@ -13041,11 +13069,12 @@ namespace FEBuilderGBA
         /// pointerIndexes[n]</c> IN ORDER, dispatching on the field type via
         /// <see cref="EmitPatchStructEntry"/>.
         /// <para>
-        /// <b>This slice (s2pf-5/6)</b> ports the skeleton + the SAFE terminal arms
+        /// <b>This slice (s2pf-5/6/7)</b> ports the skeleton + the SAFE terminal arms
         /// (ASM / CSTRING / PatchImage_* / WF's <c>default</c> MIX) + the EVENT arm (s2pf-6: the
-        /// <see cref="EmitScanScript"/> event-script walk, disasm-gated). The REMAINING FORM-BOUND
-        /// arms route through the same MIX <c>default</c> as a DOCUMENTED INTERIM (upgraded s2pf-7..10)
-        /// — SAFE only while the gate token stays deferred. See the block comment above.
+        /// <see cref="EmitScanScript"/> event-script walk, disasm-gated) + PatchImage_HEADERTSA (s2pf-7:
+        /// <see cref="EmitHeaderTsaPointer"/>). The REMAINING FORM-BOUND arms route through the same MIX
+        /// <c>default</c> as a DOCUMENTED INTERIM (upgraded s2pf-8..10) — SAFE only while the gate token
+        /// stays deferred. See the block comment above.
         /// </para>
         /// </summary>
         /// <param name="rom">ROM to resolve against — passed explicitly. MUST also be
@@ -13205,14 +13234,15 @@ namespace FEBuilderGBA
         /// <summary>
         /// One per-entry pointer-field dispatch for <see cref="EmitPatchStruct"/> — the WF
         /// per-field <c>if/else if</c> chain (FEBuilderGBA/PatchForm.cs:6553-6733), factored into
-        /// a switch so the later slices s2pf-7..10 replace each remaining INTERIM arm body in place
-        /// (EVENT was upgraded in s2pf-6).
+        /// a switch so the later slices s2pf-8..10 replace each remaining INTERIM arm body in place
+        /// (EVENT was upgraded in s2pf-6; PatchImage_HEADERTSA in s2pf-7).
         /// <para>
-        /// <b>Dispatch contract for s2pf-7..10:</b> each fully-implemented arm emits a PRECISE
-        /// length (EVENT runs the <see cref="EmitScanScript"/> walk); each remaining INTERIM form-bound
-        /// arm falls into <see cref="EmitPatchStructDefaultMix"/> (a length-0 MIX placeholder) and is
-        /// marked with the slice that upgrades it. To upgrade an arm, give its <c>case</c> a real body
-        /// (sized like the WF helper it ports) and drop it from the interim group — the call shape
+        /// <b>Dispatch contract for s2pf-8..10:</b> each fully-implemented arm emits a PRECISE
+        /// length (EVENT runs the <see cref="EmitScanScript"/> walk; PatchImage_HEADERTSA runs
+        /// <see cref="EmitHeaderTsaPointer"/>); each remaining INTERIM form-bound arm falls into
+        /// <see cref="EmitPatchStructDefaultMix"/> (a length-0 MIX placeholder) and is marked with the
+        /// slice that upgrades it. To upgrade an arm, give its <c>case</c> a real body (sized like the
+        /// WF helper it ports) and drop it from the interim group — the call shape
         /// (<paramref name="p"/>, <paramref name="patchname"/>, <paramref name="n"/>) is exactly what
         /// the WF helpers receive.
         /// </para>
@@ -13345,17 +13375,34 @@ namespace FEBuilderGBA
                     }
                     break;
 
+                case "PatchImage_HEADERTSA":
+                    // WF 6605-6613: non-Z header-TSA -> AddHeaderTSAPointer (= Core EmitHeaderTsaPointer,
+                    // sized by CalcHeaderTsaLength = WF ImageUtil.CalcByteLengthForHeaderTSAData), typed
+                    // HEADERTSA, named "<patchname> HEADERTSA <n>". WF first derefs `a = p32(p)` and pre-gates
+                    // on `isSafetyOffset(a)` BEFORE delegating; reproduced verbatim. EmitHeaderTsaPointer
+                    // re-derefs p (via u32, EOF-hardened) and re-checks both gates internally, so the WF
+                    // pre-check is a redundant guard (emit iff the slot+target are both safe — no double-emit).
+                    {
+                        // WF: uint a = Program.ROM.p32(p); if (U.isSafetyOffset(a)) { ... }. rom.p32 is
+                        // EOF-safe (returns 0 for p >= Data.Length); guard p+3 so a near-EOF slot does not
+                        // read past EOF (matching the Core-wide slot+3 convention; EmitHeaderTsaPointer also
+                        // self-guards the full deref extent). On a clean skip nothing is emitted.
+                        if (U.isSafetyOffset(p, rom) && U.isSafetyOffset(p + 3, rom))
+                        {
+                            uint a = rom.p32(p);
+                            if (U.isSafetyOffset(a, rom))
+                            {
+                                EmitHeaderTsaPointer(rom, list, p, patchname + " HEADERTSA " + n);
+                            }
+                        }
+                    }
+                    break;
+
                 // ---- INTERIM default-MIX (this slice) — form-bound arms ---------
                 // Each routes through EmitPatchStructDefaultMix (= WF's own `default`,
                 // length-0 MIX). This DIVERGES from WF (WF emits the precise sub-walked
                 // TARGET region); SAFE only while the gate token stays deferred. The
                 // partial WF-parity test EXCLUDES these types.
-
-                case "PatchImage_HEADERTSA":
-                    // INTERIM default-MIX -> upgraded in s2pf-7 (CalcByteLengthForHeaderTSAData; the
-                    // WF non-Z HEADERTSA arm at 6605 uses AddHeaderTSAPointer, a WinForms ImageUtil call).
-                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
-                    break;
 
                 case "AP":
                     // INTERIM default-MIX -> upgraded in s2pf-8 (AddAPPointer).
@@ -13455,8 +13502,9 @@ namespace FEBuilderGBA
         /// <see cref="Address.AddPointer"/> derefs <paramref name="p"/> (via <see cref="CoreState.ROM"/>)
         /// and adds the TARGET as a MIX region whose span the relocator resolves from the length-0
         /// placeholder — so the embedded pointer's target stays TRACKED. Also the INTERIM landing for
-        /// the REMAINING FORM-BOUND arms (each upgraded to a precise length in s2pf-7..10; EVENT is
-        /// already precise via <see cref="EmitScanScript"/>).
+        /// the REMAINING FORM-BOUND arms (each upgraded to a precise length in s2pf-8..10; EVENT is
+        /// already precise via <see cref="EmitScanScript"/>, PatchImage_HEADERTSA via
+        /// <see cref="EmitHeaderTsaPointer"/>).
         /// </summary>
         static void EmitPatchStructDefaultMix(ROM rom, List<Address> list, uint p, string patchname, int n)
         {

--- a/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
+++ b/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
@@ -372,39 +372,37 @@ namespace FEBuilderGBA.Tests.Unit
         }
 
         /// <summary>
-        /// PARTIAL WF-parity for #1261 slice s2pf-4 — the PatchForm producer TYPE=IMAGE dispatch arm
-        /// (<see cref="RebuildProducerCore.EmitPatchImage"/>, 6 of 8 variants). Both the WinForms
+        /// PARTIAL WF-parity for #1261 slice s2pf-4/7 — the PatchForm producer TYPE=IMAGE dispatch arm
+        /// (<see cref="RebuildProducerCore.EmitPatchImage"/>, ALL 8 variants). Both the WinForms
         /// reference (<c>PatchForm.MakePatchStructDataList</c> -&gt; <c>MakePatchStructDataListForIMAGE</c>,
         /// PatchForm.cs:6738) and the Core orchestrator (<see cref="RebuildProducerCore.MakePatchStructDataListCore"/>)
         /// run on the SAME real FE8U ROM with the SAME rebuild flags (the <c>ToolROMRebuildMake.Make</c>
-        /// callsite). Each side is FILTERED to the IMAGE arm's six ported variants — which surface as
-        /// EIGHT Info suffixes because the PALETTE variant emits under two param keys (<c>@PALETTE_POINTER</c>
+        /// callsite). Each side is FILTERED to the IMAGE arm's ported variants — which surface as
+        /// NINE Info suffixes because the PALETTE variant emits under two param keys (<c>@PALETTE_POINTER</c>
         /// for the deref form and <c>@PALETTE_ADDRESS</c> for the direct-address else-fallback), and ZIMAGE
         /// covers both <c>@ZIMAGE_POINTER</c> and the <c>@Z256IMAGE_POINTER</c> alias (Info ends
         /// <c>@IMAGE_POINTER</c> / <c>@ZIMAGE_POINTER</c> / <c>@Z256IMAGE_POINTER</c> / <c>@TSA_POINTER</c> /
-        /// <c>@ZTSA_POINTER</c> / <c>@ZHEADERTSA_POINTER</c> / <c>@PALETTE_POINTER</c> / <c>@PALETTE_ADDRESS</c>) —
-        /// then compared as Core ⊆ WF on the load-bearing fields (Addr/Length/Pointer/DataType) — Info/name
-        /// is cosmetic (Core's leaner LoadPatch omits the patch Name, so its Info is just "@VARIANT"; WF
-        /// prepends the patch name). A Core-extra (Core emits an IMAGE entry WF does not) is a faithfulness
-        /// regression and FAILS.
-        /// <para><b>HEADERTSA_POINTER EXCLUDED (deferred to s2pf-7).</b> The NON-Z header-TSA variant
-        /// (<c>@HEADERTSA_POINTER</c>, WF <c>AddHeaderTSAPointer</c> -&gt; <c>DataTypeEnum.HEADERTSA</c>) needs
-        /// <c>CalcByteLengthForHeaderTSAData</c> (slice s2pf-7) and is NOT ported here. WF emits it; Core does
-        /// not — so it is filtered OUT of BOTH sides (by both its name AND the HEADERTSA data type) before the
-        /// comparison. The remaining six variants are asserted Core ⊆ WF. WF-extras among the SIX (an IMAGE
-        /// entry WF emits that Core lacks) are tolerated only if Core's gate legitimately diverges — but the
-        /// gate + resolver are faithful ports, so they are LOGGED (not asserted) exactly as the
-        /// subset-direction harness does, keeping the teeth on the regression direction (Core-extra).</para>
+        /// <c>@ZTSA_POINTER</c> / <c>@ZHEADERTSA_POINTER</c> / <c>@HEADERTSA_POINTER</c> / <c>@PALETTE_POINTER</c> /
+        /// <c>@PALETTE_ADDRESS</c>) — then compared as Core ⊆ WF on the load-bearing fields
+        /// (Addr/Length/Pointer/DataType) — Info/name is cosmetic (Core's leaner LoadPatch omits the patch
+        /// Name, so its Info is just "@VARIANT"; WF prepends the patch name). A Core-extra (Core emits an
+        /// IMAGE entry WF does not) is a faithfulness regression and FAILS.
+        /// <para><b>HEADERTSA_POINTER NOW INCLUDED (s2pf-7).</b> The NON-Z header-TSA variant
+        /// (<c>@HEADERTSA_POINTER</c>, WF <c>AddHeaderTSAPointer</c> -&gt; <c>DataTypeEnum.HEADERTSA</c>) is
+        /// wired via <c>EmitHeaderTsaPointer</c> / <c>CalcHeaderTsaLength</c> (= WF
+        /// <c>ImageUtil.CalcByteLengthForHeaderTSAData</c>); it is compared on BOTH sides like the other
+        /// variants. WF-extras (an IMAGE entry WF emits that Core lacks) are LOGGED (not asserted) exactly as
+        /// the subset-direction harness does, keeping the teeth on the regression direction (Core-extra).</para>
         /// <para>SKIP-IF-NO-ROM: requires <c>roms/FE8U.gba</c> (gitignored — absent in CI / the worktree,
         /// present in the user's main checkout). When no ROM is found the test returns early (Pass).</para>
         /// <para><b>NON-VACUOUS only where <c>config/patch2</c> is CHECKED OUT</b> (same posture as the
         /// ADDR/SWITCH harness): an un-init submodule yields no IMAGE patch files, so both filtered lists are
-        /// empty and Core ⊆ WF holds trivially. The branch-level verification (all six variants, the /2-vs-/32
-        /// raw sizes, the palette count, the LZ77 lengths, the per-variant safety gates, the HEADERTSA
-        /// deferral) is carried by the synthetic Core.Tests (<c>RebuildProducerPatchImageTests</c>).</para>
+        /// empty and Core ⊆ WF holds trivially. The branch-level verification (all eight variants, the
+        /// /2-vs-/32 raw sizes, the palette count, the LZ77 lengths, the header-TSA byte length, the
+        /// per-variant safety gates) is carried by the synthetic Core.Tests (<c>RebuildProducerPatchImageTests</c>).</para>
         /// </summary>
         [Fact]
-        public void CorePatchImageArm_IsSubsetOf_WinFormsPatchProducer_ExcludingHeaderTsa()
+        public void CorePatchImageArm_IsSubsetOf_WinFormsPatchProducer_AllVariants()
         {
             string? repoRoot = FindRepoRootWithRom();
             if (repoRoot == null) return; // no checkout with roms/FE8U.gba reachable — early-exit (Pass)
@@ -438,22 +436,21 @@ namespace FEBuilderGBA.Tests.Unit
                     isInstallOnly: IS_PATCH_INSTALL_ONLY,
                     isStructOnly: IS_PATCH_STRUCT_ONLY);
 
-                // The six PORTED IMAGE variant param-key suffixes (HEADERTSA_POINTER deliberately ABSENT).
+                // ALL eight ported IMAGE variant param-key suffixes (HEADERTSA_POINTER now INCLUDED — s2pf-7).
                 string[] portedSuffixes =
                 {
                     "@IMAGE_POINTER", "@ZIMAGE_POINTER", "@Z256IMAGE_POINTER",
                     "@TSA_POINTER", "@ZTSA_POINTER", "@ZHEADERTSA_POINTER",
+                    "@HEADERTSA_POINTER",
                     "@PALETTE_POINTER", "@PALETTE_ADDRESS",
                 };
 
-                // An IMAGE arm entry for one of the SIX ported variants. EXCLUDES the deferred
-                // HEADERTSA_POINTER both by name (@HEADERTSA_POINTER) AND by its HEADERTSA data type
-                // (defence in depth: WF's AddHeaderTSAPointer always tags DataTypeEnum.HEADERTSA).
+                // An IMAGE arm entry for one of the ported variants (all eight). HEADERTSA_POINTER is now
+                // wired (s2pf-7), so it is INCLUDED (its @HEADERTSA_POINTER suffix is in portedSuffixes and
+                // its DataTypeEnum.HEADERTSA is no longer filtered out).
                 bool IsPortedImageEntry(Address a)
                 {
                     if (a.Info == null) return false;
-                    if (a.DataType == Address.DataTypeEnum.HEADERTSA) return false; // deferred variant
-                    if (a.Info.EndsWith("@HEADERTSA_POINTER", StringComparison.Ordinal)) return false;
                     foreach (string s in portedSuffixes)
                     {
                         if (a.Info.EndsWith(s, StringComparison.Ordinal)) return true;
@@ -469,10 +466,10 @@ namespace FEBuilderGBA.Tests.Unit
 
                 // Core-extras = Core emits a (ported) IMAGE key WF does not. ALWAYS a faithfulness
                 // regression -> FAIL. WF-extras (WF emits a ported-IMAGE key Core lacks) are logged but
-                // not asserted (subset direction), mirroring the data-path harness — the deferred
-                // HEADERTSA is already excluded, so a WF-extra among the six would signal a gate divergence
-                // worth surfacing, not a silent-drop the way ADDR/SWITCH's exact-equality catches it. Core
-                // ⊆ WF is the load-bearing guarantee for this 6-of-8 slice.
+                // not asserted (subset direction), mirroring the data-path harness — all eight variants
+                // are now ported, so a WF-extra would signal a gate divergence worth surfacing, not a
+                // silent-drop the way ADDR/SWITCH's exact-equality catches it. Core ⊆ WF is the
+                // load-bearing guarantee for this (now 8-of-8) slice.
                 var coreExtras = coreImg.Where(a => !wfKeys.Contains(Key.Of(a)))
                                         .Select(Key.Of).Distinct().ToList();
                 int wfExtraCount = wfKeys.Count(k => !coreKeys.Contains(k));
@@ -491,9 +488,9 @@ namespace FEBuilderGBA.Tests.Unit
                         + $"First {Math.Min(N, coreExtras.Count)} Core-only entries:\n{dump}");
                 }
 
-                // PROVEN: every Core IMAGE entry (of the six ported variants) is byte-identical to a WF
-                // entry on (Addr/Length/Pointer/DataType) — no faithfulness regression — with the deferred
-                // HEADERTSA_POINTER excluded from both sides (or both empty when config/patch2 is absent).
+                // PROVEN: every Core IMAGE entry (of all eight ported variants, including HEADERTSA_POINTER)
+                // is byte-identical to a WF entry on (Addr/Length/Pointer/DataType) — no faithfulness
+                // regression (or both empty when config/patch2 is absent).
                 Assert.Empty(coreExtras);
             }
             finally
@@ -515,18 +512,22 @@ namespace FEBuilderGBA.Tests.Unit
         /// <c>EventScriptForm.ScanScript</c> walk's <c>@STRUCT DATA n</c> EVENTSCRIPT/IFR/BIN entries) —
         /// then compared Core ⊆ WF on the load-bearing fields (Addr/Length/Pointer/DataType). A Core-extra
         /// (Core emits a STRUCT entry WF does not) is a faithfulness regression and FAILS.
-        /// <para><b>EVENT is NOW INCLUDED (s2pf-6).</b> Its <c>@STRUCT DATA n</c> entries are emitted by the
+        /// <para><b>EVENT is INCLUDED (s2pf-6).</b> Its <c>@STRUCT DATA n</c> entries are emitted by the
         /// real ScanScript walk (<see cref="RebuildProducerCore.EmitScanScript"/>), disasm-gated; they are
         /// non-MIX (EVENTSCRIPT for the script blocks, IFR/BIN for POINTER_UNIT/AICOORDINATE sub-data), so
         /// the filter includes any non-MIX <c>@STRUCT DATA n</c> entry.</para>
-        /// <para><b>THE REMAINING INTERIM FORM-BOUND ARMS ARE EXCLUDED (deferred to s2pf-7..10).</b> The
+        /// <para><b>PatchImage_HEADERTSA is NOW INCLUDED (s2pf-7).</b> The non-Z header-TSA field
+        /// (<c>@STRUCT HEADERTSA n</c>, WF <c>AddHeaderTSAPointer</c> -&gt; <c>DataTypeEnum.HEADERTSA</c>) is
+        /// wired via <see cref="RebuildProducerCore.EmitHeaderTsaPointer"/>; its <c>@STRUCT HEADERTSA </c>
+        /// info token + HEADERTSA data type are compared on BOTH sides.</para>
+        /// <para><b>THE REMAINING INTERIM FORM-BOUND ARMS ARE EXCLUDED (deferred to s2pf-8..10).</b> The
         /// BATTLEANIMEPOINTER/AP/ROMTCS/PROCS/VENNOUWEAPONLOCK/SMEPROMOLIST/CLASSLIST/
-        /// TERRAINBATTLELISTPOINTER/BATTLEBGLISTPOINTER/AOERANGEPOINTER + PatchImage_HEADERTSA fields are
+        /// TERRAINBATTLELISTPOINTER/BATTLEBGLISTPOINTER/AOERANGEPOINTER fields are
         /// routed through Core's INTERIM default-MIX (a length-0 MIX entry named <c>... DATA n</c>) this
         /// slice — they INTENTIONALLY diverge from WF (WF emits the precise sub-walked TARGET region). So
-        /// every MIX-typed <c>... DATA </c>-suffixed entry (and the HEADERTSA data type) is filtered OUT of
-        /// BOTH sides before the comparison. Those arms gain their own parity teeth in s2pf-7..10, and the
-        /// FULL STRUCT parity (no exclusions) lands at s2pf-11 when the gate token is removed.</para>
+        /// every MIX-typed <c>... DATA </c>-suffixed entry is filtered OUT of BOTH sides before the
+        /// comparison. Those arms gain their own parity teeth in s2pf-8..10, and the FULL STRUCT parity
+        /// (no exclusions) lands at s2pf-11 when the gate token is removed.</para>
         /// <para><b>CSTRING is NOT in the merged-list parity scope:</b> WF/Core both name a CSTRING entry
         /// the DECODED STRING (no <c>@STRUCT</c> marker), so it cannot be reliably attributed to a STRUCT
         /// patch within the merged producer list. The CSTRING arm's byte-faithfulness is carried by the
@@ -575,21 +576,22 @@ namespace FEBuilderGBA.Tests.Unit
                     isStructOnly: IS_PATCH_STRUCT_ONLY);
 
                 // A FULLY-IMPLEMENTED STRUCT-arm entry: the MAIN struct entry (Info ends "@STRUCT") OR a
-                // per-entry ASM / PatchImage_* arm ("@STRUCT " + ASM/IMAGE/TSA/ZTSA/ZHEADERTSA/PALETTE) OR
-                // an EVENT-walk entry (s2pf-6: the "@STRUCT DATA n" entries the EventScriptForm.ScanScript
-                // walk emits — EVENTSCRIPT script blocks + their POINTER_UNIT/AICOORDINATE sub-data IFR/BIN
-                // blocks). The STILL-INTERIM form-bound arms (HEADERTSA s2pf-7 / AP/ROMTCS/PROCS s2pf-8 /
-                // Vennou/AOE/SMEPromo/SomeClass/Terrain* s2pf-9 / BattleAnime s2pf-10) emit "@STRUCT DATA n"
-                // as a length-0 MIX placeholder — those DIVERGE from WF this slice and are EXCLUDED. Since
-                // EmitPatchStructDefaultMix is the ONLY producer of a MIX-typed "@STRUCT DATA " entry, a
-                // simple rule cleanly separates the two: a MIX-typed DATA entry is interim (EXCLUDE), any
-                // other DATA entry came from the now-precise EVENT walk (INCLUDE). HEADERTSA data type stays
-                // deferred. CSTRING is out of merged-list scope (named the decoded string) — see doc-comment.
-                string[] safeArmTokens = { " ASM ", " IMAGE ", " TSA ", " ZTSA ", " ZHEADERTSA ", " PALETTE " };
+                // per-entry ASM / PatchImage_* arm ("@STRUCT " + ASM/IMAGE/TSA/ZTSA/ZHEADERTSA/HEADERTSA/
+                // PALETTE) OR an EVENT-walk entry (s2pf-6: the "@STRUCT DATA n" entries the
+                // EventScriptForm.ScanScript walk emits — EVENTSCRIPT script blocks + their
+                // POINTER_UNIT/AICOORDINATE sub-data IFR/BIN blocks). The STILL-INTERIM form-bound arms
+                // (AP/ROMTCS/PROCS s2pf-8 / Vennou/AOE/SMEPromo/SomeClass/Terrain* s2pf-9 / BattleAnime
+                // s2pf-10) emit "@STRUCT DATA n" as a length-0 MIX placeholder — those DIVERGE from WF this
+                // slice and are EXCLUDED. Since EmitPatchStructDefaultMix is the ONLY producer of a MIX-typed
+                // "@STRUCT DATA " entry, a simple rule cleanly separates the two: a MIX-typed DATA entry is
+                // interim (EXCLUDE), any other DATA entry came from the now-precise EVENT walk (INCLUDE).
+                // PatchImage_HEADERTSA is now precise (s2pf-7), emitting a "@STRUCT HEADERTSA n" / HEADERTSA
+                // entry — INCLUDED via the safeArmTokens. CSTRING is out of merged-list scope (named the
+                // decoded string) — see doc-comment.
+                string[] safeArmTokens = { " ASM ", " IMAGE ", " TSA ", " ZTSA ", " ZHEADERTSA ", " HEADERTSA ", " PALETTE " };
                 bool IsImplementedStructEntry(Address a)
                 {
                     if (a.Info == null) return false;
-                    if (a.DataType == Address.DataTypeEnum.HEADERTSA) return false;   // deferred (s2pf-7)
                     // A per-entry "... DATA n" entry: the STILL-INTERIM arms emit it as a length-0 MIX
                     // placeholder (EXCLUDE); the EVENT walk (s2pf-6) emits EVENTSCRIPT/IFR/BIN (INCLUDE).
                     if (a.Info.Contains("@STRUCT DATA ", StringComparison.Ordinal))


### PR DESCRIPTION
## Summary
#1261 option-B PatchForm producer epic, sub-slice **7/11**. Faithful WinForms→Core port of the non-Z header-TSA image variant + STRUCT arm.

- **`PatchImageVariantLength`** — add the `"HEADERTSA"` case → `CalcHeaderTsaLength` (the byte-exact port of WF `ImageUtil.CalcByteLengthForHeaderTSAData`, `ImageUtil.cs:4597`: `2 + (x+1)*(y+1)*2` from the 2-byte master header `{x,y}`, EOF-safe `0` when `pos+2 >= len`). The length helper `CalcHeaderTsaLength` **and** `EmitHeaderTsaPointer` were already ported in slice 2k, so this slice **reuses** them (no re-port needed) — verified by grepping Core first.
- **`EmitPatchImage`** — wire the last deferred IMAGE variant `HEADERTSA_POINTER` (WF `PatchForm.cs:6798`) via `EmitHeaderTsaPointer` (= WF `AddHeaderTSAPointer`). **IMAGE arm now 8/8.** WF's outer `u32(p)+isSafetyPointer(a)` pre-check is redundant with `EmitHeaderTsaPointer`'s own internal gates (emit iff both safe; EOF-hardened deref).
- **`EmitPatchStructEntry`** — upgrade the `PatchImage_HEADERTSA` STRUCT arm (WF `PatchForm.cs:6605`) from interim default-MIX to the real `EmitHeaderTsaPointer` walk (reproduce WF's `a = p32(p); if (isSafetyOffset(a))` pre-gate; typed `HEADERTSA`, named `... HEADERTSA n`).
- Update all audit tables / block comments: `PatchImage_HEADERTSA` moves interim → **DONE**.

### Where `CalcByteLengthForHeaderTSAData` lives
Already in Core as `RebuildProducerCore.CalcHeaderTsaLength(ROM, uint)` (slice 2k). This slice did not need to (re-)port it — it adds the `"HEADERTSA"` dispatch in `PatchImageVariantLength` and the two arm call-sites.

### Remaining interim STRUCT arms (after this slice)
- AP / ROMTCS / PROCS → s2pf-8
- VENNOUWEAPONLOCK / AOERANGEPOINTER / SMEPROMOLIST / CLASSLIST / TERRAINBATTLELISTPOINTER / BATTLEBGLISTPOINTER (6 forms) → s2pf-9
- BATTLEANIMEPOINTER → s2pf-10

### Invariants
- Gate token `"PatchForm(MakePatchStructDataList)"` **STAYS** in `AsmNotYetPortedRaw` (orchestrator not wired into the live producer until s2pf-11).
- `MakePatchStructDataListCore_NoPatchDir_EmitsNothing_NoThrow` preserved.

## Scope
Part of #1261.

## Test plan
- [x] `dotnet build FEBuilderGBA.sln` — clean (0 errors).
- [x] Core.Tests `--filter ~RebuildProducer` — **606 passed** (baseline 601 + 5 net new), incl. the no-patch-dir invariant.
- [x] `PatchImageVariantLength("HEADERTSA")` math (`2+(x+1)*(y+1)*2`) + near-EOF `→0` guard.
- [x] IMAGE `HEADERTSA_POINTER`: emits HEADERTSA with `CalcHeaderTsaLength`; alongside other variants; unsafe-target skip; near-EOF slot skip (no throw).
- [x] STRUCT `PatchImage_HEADERTSA`: emits HEADERTSA (not interim MIX); unsafe-target emits nothing.
- [x] WF-parity (real FE8U + `config/patch2`) — HEADERTSA now **included** in both the IMAGE (8/8) and STRUCT parity filters; ran **non-vacuously**: Core ⊆ WF byte-identical on Addr/Length/Pointer/DataType. **2/2 pass.**
- [x] The ~10 `Skill*` Core.Tests failures were the un-checked-out `config/patch2` submodule (env); pass (75/75) once initialized — not a regression.

## Test output (proof)
```
Core.Tests --filter ~RebuildProducer:
  Passed!  - Failed: 0, Passed: 606, Skipped: 0, Total: 606

WF-parity (real FE8U.gba + config/patch2 checked out), non-vacuous:
  CorePatchImageArm_IsSubsetOf_WinFormsPatchProducer_AllVariants
  CorePatchStructArm_IsSubsetOf_WinFormsPatchProducer_ExcludingInterimFormArms
  Passed!  - Failed: 0, Passed: 2, Skipped: 0, Total: 2
```

(Core-only change, no GUI → no screenshot.)

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
