### PR TITLE
feat(core): PatchForm STRUCT AP/ROMTCS/PROCS arms (#1261 s2pf-8)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -5482,6 +5482,94 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Empty(list);
         }
 
+        // ---- slice s2pf-8: EmitApPointer / EmitProcsPointer (the PatchForm STRUCT
+        //      AP/PROCS arms; ROMTCS already covered above). AddressWinForms.AddAPPointer /
+        //      AddProcsPointer -> EmitApPointer / EmitProcsPointer.
+
+        [Fact]
+        public void EmitApPointer_EmitsAP_WithCalcApLength()
+        {
+            // WF AddAPPointer -> AddAPAddress: length = ImageUtilAP.CalcAPLength(addr), typed AP.
+            // CalcAPLength never throws and returns 0 on an unparseable stream; EmitApPointer ALWAYS
+            // emits (unlike PROCS). Cross-check the emitted length against CalcAPLength directly.
+            var rom = CreateTestRom(0x10000);
+            uint apData = 0x2000;
+            uint pointerSlot = 0x1000;
+            rom.write_u32(pointerSlot, Ptr(apData));
+            uint expected = ImageUtilAPCore.CalcAPLength(rom.Data, apData);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitApPointer(rom, list, pointerSlot, "MoveIcon AP");
+
+            Address a = Assert.Single(list);
+            Assert.Equal(apData, a.Addr);
+            Assert.Equal(expected, a.Length);
+            Assert.Equal(pointerSlot, a.Pointer);
+            Assert.Equal(Address.DataTypeEnum.AP, a.DataType);
+        }
+
+        [Fact]
+        public void EmitApPointer_PointerSlotNearEOF_EmitsNothing_NoThrow()
+        {
+            var rom = CreateTestRom(0x8000);
+            var list = new List<Address>();
+            Exception ex = Record.Exception(() =>
+                RebuildProducerCore.EmitApPointer(rom, list, 0x8000 - 1, "X"));
+            Assert.Null(ex);
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitProcsPointer_ValidProcs_EmitsPROCS_WithCalcLength()
+        {
+            // WF AddProcsPointer -> AddProcsAddress: length = ProcsScriptForm.CalcLengthAndCheck(addr)
+            // (= CalcProcsLengthAndCheck), typed PROCS.
+            var rom = CreateTestRom(0x10000);
+            uint procsData = 0x2000;
+            uint pointerSlot = 0x1000;
+            rom.write_u32(pointerSlot, Ptr(procsData));
+            uint expected = PlantProcsStream(rom, procsData); // valid PROCS -> 16
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitProcsPointer(rom, list, pointerSlot, "Map PROCS");
+
+            Address a = Assert.Single(list);
+            Assert.Equal(procsData, a.Addr);
+            Assert.Equal(expected, a.Length);
+            Assert.Equal(pointerSlot, a.Pointer);
+            Assert.Equal(Address.DataTypeEnum.PROCS, a.DataType);
+        }
+
+        [Fact]
+        public void EmitProcsPointer_NotFound_SkipsEntirely_NoEmit()
+        {
+            // WF AddProcsAddress: `if (length == U.NOT_FOUND) return;` — a non-PROCS target is SKIPPED
+            // (NEVER a zero/guessed length). Unknown opcode 0x07FF -> CalcProcsLengthAndCheck NOT_FOUND.
+            var rom = CreateTestRom(0x10000);
+            uint procsData = 0x2000;
+            uint pointerSlot = 0x1000;
+            rom.write_u32(pointerSlot, Ptr(procsData));
+            rom.write_u16(procsData + 0, 0x07FF);
+            rom.write_u16(procsData + 2, 0x0000);
+            rom.write_u32(procsData + 4, 0x00000000);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitProcsPointer(rom, list, pointerSlot, "X");
+
+            Assert.Empty(list); // skipped — no PROCS Address
+        }
+
+        [Fact]
+        public void EmitProcsPointer_PointerSlotNearEOF_EmitsNothing_NoThrow()
+        {
+            var rom = CreateTestRom(0x8000);
+            var list = new List<Address>();
+            Exception ex = Record.Exception(() =>
+                RebuildProducerCore.EmitProcsPointer(rom, list, 0x8000 - 1, "X"));
+            Assert.Null(ex);
+            Assert.Empty(list);
+        }
+
         [Fact]
         public void EmitImageBGAt_NormalEntry_EmitsMainIfrAndPerEntryColumns()
         {

--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchStructTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchStructTests.cs
@@ -138,6 +138,30 @@ namespace FEBuilderGBA.Core.Tests
             return 2u + ((uint)x + 1) * ((uint)y + 1) * 2;
         }
 
+        // Plant the shortest ROMTCS terminator pattern (CalcRomTcsLength needArray[4] = {00 00 FF FF 10 00},
+        // plusOffset 4) at `offset + termAt`; the ROMTCS length is then (termAt + 4). Mirrors the
+        // RebuildProducerCoreTests EmitRomTcsPointer plant.
+        static uint WriteRomTcs(ROM rom, uint offset, uint termAt)
+        {
+            byte[] term = new byte[] { 0x00, 0x00, 0xFF, 0xFF, 0x10, 0x00 };
+            for (int i = 0; i < term.Length; i++) rom.write_u8(offset + termAt + (uint)i, term[i]);
+            return termAt + 4u; // (match + plusOffset) - offset
+        }
+
+        // Plant a minimal VALID PROCS stream at `offset`: one 0x0B instruction (parg-is-null contract)
+        // then a 0x00 EXIT. CalcProcsLengthAndCheck consumes 16 bytes. Mirrors PlantProcsStream in
+        // RebuildProducerCoreTests.
+        static uint WriteProcs(ROM rom, uint offset)
+        {
+            rom.write_u16(offset + 0, 0x000B);
+            rom.write_u16(offset + 2, 0x0000);
+            rom.write_u32(offset + 4, 0x00000000);
+            rom.write_u16(offset + 8, 0x0000);
+            rom.write_u16(offset + 10, 0x0000);
+            rom.write_u32(offset + 12, 0x00000000);
+            return 16u;
+        }
+
         // ====================================================================
         // 1. The MAIN struct Address (WF 6536-6543) — POINTER and ADDRESS forms
         // ====================================================================
@@ -565,16 +589,15 @@ namespace FEBuilderGBA.Core.Tests
 
         // Each interim form-bound type is routed through the same default-MIX placeholder as an
         // unknown type. THIS IS INTENTIONAL FOR s2pf-5: the precise sub-walked TARGET length is
-        // ported in s2pf-8..10. The test asserts the INTERIM placeholder (length-0 MIX), NOT a
+        // ported in s2pf-9..10. The test asserts the INTERIM placeholder (length-0 MIX), NOT a
         // precise WF length — the partial WF-parity test EXCLUDES these types accordingly.
         // NOTE: EVENT was REMOVED from this interim group in s2pf-6 (it runs the real
-        // EventScriptForm.ScanScript walk — see EmitPatchStruct_EventArm_*), and
+        // EventScriptForm.ScanScript walk — see EmitPatchStruct_EventArm_*),
         // PatchImage_HEADERTSA in s2pf-7 (it runs EmitHeaderTsaPointer — see
-        // EmitPatchStruct_HeaderTsaField_* below).
+        // EmitPatchStruct_HeaderTsaField_* below), and AP/ROMTCS/PROCS in s2pf-8 (they run
+        // EmitApPointer/EmitRomTcsPointer/EmitProcsPointer — see EmitPatchStruct_ApField_* /
+        // _RomTcsField_* / _ProcsField_* below).
         [Theory]
-        [InlineData("AP")]                        // -> s2pf-8
-        [InlineData("ROMTCS")]                    // -> s2pf-8
-        [InlineData("PROCS")]                     // -> s2pf-8
         [InlineData("VENNOUWEAPONLOCK")]          // -> s2pf-9
         [InlineData("AOERANGEPOINTER")]           // -> s2pf-9
         [InlineData("SMEPROMOLIST")]              // -> s2pf-9
@@ -598,6 +621,167 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Equal(0x9000u, mix.Addr);
             Assert.Equal(0u, mix.Length);
             Assert.EndsWith("DATA 0", mix.Info);
+        }
+
+        // ====================================================================
+        // 4a'. The AP / ROMTCS / PROCS arms (s2pf-8) — the REAL pointer-emitters
+        //      (WF PatchForm.cs:6644-6675 -> AddressWinForms.AddAPPointer /
+        //      AddROMTCSPointer / AddProcsPointer), reproduced via the Core
+        //      EmitApPointer / EmitRomTcsPointer / EmitProcsPointer. Each derefs
+        //      `a = p32(p)`, pre-gates isSafetyOffset(a), then emits the target
+        //      sized by ImageUtilAPCore.CalcAPLength / CalcRomTcsLength /
+        //      CalcProcsLengthAndCheck. PROCS SKIPS on NOT_FOUND (no emission).
+        // ====================================================================
+
+        [Fact]
+        public void EmitPatchStruct_ApField_EmitsApWithCalcApLength()
+        {
+            // WF 6644-6653: deref p, then AddAPPointer -> EmitApPointer; length =
+            // ImageUtilAPCore.CalcAPLength over the dereferenced target, typed AP, named
+            // "... AP <n>". CalcAPLength NEVER throws and returns 0 on an unparseable stream;
+            // EmitApPointer always emits (unlike PROCS, which skips on NOT_FOUND), so the AP
+            // Address is present whatever the planted bytes parse to. Cross-check its length
+            // against CalcAPLength directly.
+            var rom = MakeRom();
+            const uint table = 0x2000;
+            const uint target = 0x8000;
+            PlantPointer(rom, table + 0, target);
+            uint expect = ImageUtilAPCore.CalcAPLength(rom.Data, target);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("AP",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:AP", "0")), isPointerOnly: false);
+
+            var a = Assert.Single(list, x => x.DataType == Address.DataTypeEnum.AP);
+            Assert.Equal(target, a.Addr);
+            Assert.Equal(expect, a.Length);
+            Assert.Equal(table + 0, a.Pointer);
+            Assert.EndsWith("AP 0", a.Info);
+            // NOT the interim default-MIX placeholder.
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.MIX);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_RomTcsField_EmitsRomTcsWithCalcLength()
+        {
+            // WF 6655-6664: deref p, then AddROMTCSPointer -> EmitRomTcsPointer; length =
+            // CalcRomTcsLength (terminator scan) over the dereferenced target, typed ROMTCS,
+            // named "... ROMTCS <n>".
+            var rom = MakeRom();
+            const uint table = 0x2000;
+            const uint target = 0x8000;
+            PlantPointer(rom, table + 0, target);
+            uint expect = WriteRomTcs(rom, target, 0x10); // terminator @ +0x10 -> length 0x14
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("RT",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:ROMTCS", "0")), isPointerOnly: false);
+
+            var a = Assert.Single(list, x => x.DataType == Address.DataTypeEnum.ROMTCS);
+            Assert.Equal(target, a.Addr);
+            Assert.Equal(expect, a.Length);
+            Assert.Equal(table + 0, a.Pointer);
+            Assert.EndsWith("ROMTCS 0", a.Info);
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.MIX);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_ProcsField_EmitsProcsWithCalcLength()
+        {
+            // WF 6666-6675: deref p, then AddProcsPointer -> EmitProcsPointer; length =
+            // CalcProcsLengthAndCheck over the dereferenced target, typed PROCS, named
+            // "... PROCS <n>".
+            var rom = MakeRom();
+            const uint table = 0x2000;
+            const uint target = 0x8000;
+            PlantPointer(rom, table + 0, target);
+            uint expect = WriteProcs(rom, target); // valid PROCS -> length 16
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("PR",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:PROCS", "0")), isPointerOnly: false);
+
+            var a = Assert.Single(list, x => x.DataType == Address.DataTypeEnum.PROCS);
+            Assert.Equal(target, a.Addr);
+            Assert.Equal(expect, a.Length);
+            Assert.Equal(table + 0, a.Pointer);
+            Assert.EndsWith("PROCS 0", a.Info);
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.MIX);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_ProcsField_NotFoundLength_SkipsEntirely()
+        {
+            // WF AddProcsAddress: `length = CalcLengthAndCheck(addr); if (length == U.NOT_FOUND) return;`
+            // A target that is NOT a valid PROCS (unknown opcode 0x07FF) -> CalcProcsLengthAndCheck
+            // returns NOT_FOUND -> the PROCS arm emits NOTHING (NEVER a zero/guessed length, and NOT
+            // the interim default-MIX placeholder either).
+            var rom = MakeRom();
+            const uint table = 0x2000;
+            const uint target = 0x8000;
+            PlantPointer(rom, table + 0, target);
+            rom.write_u16(target + 0, 0x07FF);   // unknown opcode -> contract violation -> NOT_FOUND
+            rom.write_u16(target + 2, 0x0000);
+            rom.write_u32(target + 4, 0x00000000);
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("PR",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:PROCS", "0")), isPointerOnly: false);
+
+            // The PROCS skip: no PROCS Address AND no MIX placeholder for this field.
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.PROCS);
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.MIX);
+        }
+
+        [Theory]
+        [InlineData("AP")]
+        [InlineData("ROMTCS")]
+        [InlineData("PROCS")]
+        public void EmitPatchStruct_ApRomTcsProcsField_UnsafeTarget_EmitsNothing(string fieldType)
+        {
+            // WF pre-gate `if (isSafetyOffset(a))` (a = p32(p)) fails when the slot derefs below the
+            // 0x200 floor -> the arm is skipped, nothing emitted (NO AP/ROMTCS/PROCS, NO MIX).
+            var rom = MakeRom();
+            const uint table = 0x2000;
+            U.write_u32(rom.Data, table + 0, U.toPointer(0x100)); // target below safety floor
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("US",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:" + fieldType, "0")), isPointerOnly: false);
+
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.AP);
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.ROMTCS);
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.PROCS);
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.MIX);
+        }
+
+        [Theory]
+        [InlineData("AP")]
+        [InlineData("ROMTCS")]
+        [InlineData("PROCS")]
+        public void EmitPatchStruct_ApRomTcsProcsField_SlotNearEof_NoThrow(string fieldType)
+        {
+            // A pointer FIELD sitting in the last 3 bytes -> the slot+3 EOF guard makes a clean skip
+            // (no throw) rather than reading p32 past EOF. Use a STRUCT whose entry-0 +0 slot lands
+            // at Data.Length-1 via a large ADDRESS.
+            var rom = MakeRom();
+            uint near = (uint)rom.Data.Length - 1;
+            var list = new List<Address>();
+            Exception ex = Record.Exception(() =>
+                RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("EOF",
+                    ("TYPE", "STRUCT"), ("ADDRESS", "0x" + near.ToString("X")),
+                    ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                    ("P0:" + fieldType, "0")), isPointerOnly: false));
+            Assert.Null(ex);
         }
 
         // ====================================================================

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -2271,6 +2271,56 @@ namespace FEBuilderGBA
             list.Add(new Address(target, length, pointer, info, Address.DataTypeEnum.AP));
         }
 
+        /// <summary>
+        /// Reproduces WinForms <c>AddressWinForms.AddProcsPointer(list, pointer, info, isPointerOnly)</c>
+        /// (-> <c>AddProcsAddress</c>): the <paramref name="pointer"/> slot holds a 32-bit ROM pointer to a
+        /// PROCS (map-anime) bytecode stream; emit a <see cref="Address.DataTypeEnum.PROCS"/> block whose
+        /// length is <see cref="CalcProcsLengthAndCheck"/> (the verbatim Core port of WF
+        /// <c>ProcsScriptForm.CalcLengthAndCheck</c>) over the dereferenced target. Structurally identical
+        /// to <see cref="EmitApPointer"/>/<see cref="EmitRomTcsPointer"/>, with ONE critical difference
+        /// reproduced verbatim from WF <c>AddProcsAddress</c>: when <see cref="CalcProcsLengthAndCheck"/>
+        /// returns <see cref="U.NOT_FOUND"/> (the stream is not a valid PROCS) the WHOLE entry is SKIPPED —
+        /// no <see cref="Address"/> is emitted (WF: <c>if (length == U.NOT_FOUND) return;</c>). NEVER emit a
+        /// zero/guessed length for a non-PROCS target (a wrong length = relocation collision). The producer
+        /// always scans real lengths (<c>isPointerOnly == false</c>). EOF-HARDENING: guard the full 4-byte
+        /// <c>u32(pointer)</c> read extent before dereferencing (WF reads it after only a single-byte
+        /// <c>isSafetyOffset(pointer)</c> check); <see cref="CalcProcsLengthAndCheck"/> is itself EOF-safe
+        /// (clamped to <c>rom.Data.Length</c>; returns NOT_FOUND, never throws, on a malformed/near-EOF
+        /// stream).
+        /// </summary>
+        public static void EmitProcsPointer(ROM rom, List<Address> list, uint pointer, string info)
+        {
+            pointer = U.toOffset(pointer);
+            if (!U.isSafetyOffset(pointer, rom))
+            {
+                return;
+            }
+            if (pointer + 4 > (uint)rom.Data.Length)
+            {
+                return;
+            }
+            uint addr = rom.u32(pointer);
+            if (!U.isSafetyPointer(addr, rom))
+            {
+                return;
+            }
+            // WF AddProcsPointer(pointer-slot form) -> AddProcsAddress(addr, pointer, ...): addr is
+            // toOffset'd + isSafetyOffset-checked inside, then length = CalcLengthAndCheck(addr).
+            uint target = U.toOffset(addr);
+            if (!U.isSafetyOffset(target, rom))
+            {
+                return;
+            }
+            // WF AddProcsAddress: length = ProcsScriptForm.CalcLengthAndCheck(addr); if (length ==
+            // U.NOT_FOUND) return; — a non-PROCS target is SKIPPED (no emit), NEVER a guessed length.
+            uint length = CalcProcsLengthAndCheck(rom, target);
+            if (length == U.NOT_FOUND)
+            {
+                return;
+            }
+            list.Add(new Address(target, length, pointer, info, Address.DataTypeEnum.PROCS));
+        }
+
         // -------------------------------------------------------------------------------------------
         // slice 2q: config-FILE-table forms (the table base/count come from a config TSV loaded via
         // U.ConfigDataFilename / U.LoadTSVResource, NOT a RomInfo pointer slot, so none fits the flat
@@ -13020,7 +13070,14 @@ namespace FEBuilderGBA
         //       header-TSA field -> AddHeaderTSAPointer (= EmitHeaderTsaPointer, sized by
         //       CalcHeaderTsaLength = WF ImageUtil.CalcByteLengthForHeaderTSAData), typed
         //       HEADERTSA. No longer interim (was interim default-MIX through s2pf-5/6).
-        //   (C) the REMAINING FORM-BOUND arms (BATTLEANIMEPOINTER/AP/ROMTCS/PROCS/
+        //   (B''') AP / ROMTCS / PROCS — ported REAL in s2pf-8 (WF 6644-6675): each derefs
+        //       `a = p32(p)`, pre-gates `isSafetyOffset(a)`, then calls the AddressWinForms
+        //       pointer-emitter — reproduced VERBATIM as the Core EmitApPointer /
+        //       EmitRomTcsPointer / EmitProcsPointer (lengths via ImageUtilAPCore.CalcAPLength /
+        //       CalcRomTcsLength / CalcProcsLengthAndCheck, all already in Core). PROCS SKIPS on
+        //       CalcProcsLengthAndCheck == NOT_FOUND (WF AddProcsAddress: never a guessed length).
+        //       No longer interim.
+        //   (C) the REMAINING FORM-BOUND arms (BATTLEANIMEPOINTER/
         //       VENNOUWEAPONLOCK/SMEPROMOLIST/CLASSLIST/TERRAINBATTLELISTPOINTER/
         //       BATTLEBGLISTPOINTER/AOERANGEPOINTER) — routed
         //       through the SAME `default` -> AddPointer(...,MIX) path as a DOCUMENTED
@@ -13030,10 +13087,10 @@ namespace FEBuilderGBA
         //       it MUST be upgraded before the token is removed, else those embedded
         //       pointers' TARGET regions are never relocated (residue corruption).
         //
-        //   INTERIM default-MIX -> precise-arm UPGRADE MAP (audit table; EVENT + HEADERTSA DONE):
+        //   INTERIM default-MIX -> precise-arm UPGRADE MAP (audit table; EVENT + HEADERTSA + AP/ROMTCS/PROCS DONE):
         //     EVENT                     -> s2pf-6  DONE (EmitScanScript, disasm-gated)
         //     PatchImage_HEADERTSA      -> s2pf-7  DONE (EmitHeaderTsaPointer / CalcHeaderTsaLength)
-        //     AP / ROMTCS / PROCS       -> s2pf-8
+        //     AP / ROMTCS / PROCS       -> s2pf-8  DONE (EmitApPointer / EmitRomTcsPointer / EmitProcsPointer)
         //     VENNOUWEAPONLOCK          -> s2pf-9
         //     AOERANGEPOINTER           -> s2pf-9
         //     SMEPROMOLIST              -> s2pf-9
@@ -13083,8 +13140,9 @@ namespace FEBuilderGBA
         /// <param name="list">The accumulating struct/pointer list (appended to).</param>
         /// <param name="patch">The TYPE=STRUCT patch whose POINTER/ADDRESS/DATASIZE/DATACOUNT +
         /// P&lt;n&gt;:type fields drive emission.</param>
-        /// <param name="isPointerOnly">WF <c>isPointerOnly</c> — forwarded to the AP/ROMTCS/PROCS
-        /// arms (interim this slice).</param>
+        /// <param name="isPointerOnly">WF <c>isPointerOnly</c>. NOTE: the producer always scans REAL
+        /// lengths (the AP/ROMTCS/PROCS emitters use the <c>isPointerOnly == false</c> length path); this
+        /// param is retained for the WF call shape.</param>
         public static void EmitPatchStruct(ROM rom, List<Address> list, PatchInstallCore.PatchSt patch, bool isPointerOnly)
         {
             // Public-helper guards (consistent with EmitPatchAddr / EmitPatchImage): throw a clear
@@ -13234,12 +13292,14 @@ namespace FEBuilderGBA
         /// <summary>
         /// One per-entry pointer-field dispatch for <see cref="EmitPatchStruct"/> — the WF
         /// per-field <c>if/else if</c> chain (FEBuilderGBA/PatchForm.cs:6553-6733), factored into
-        /// a switch so the later slices s2pf-8..10 replace each remaining INTERIM arm body in place
-        /// (EVENT was upgraded in s2pf-6; PatchImage_HEADERTSA in s2pf-7).
+        /// a switch so the later slices s2pf-9..10 replace each remaining INTERIM arm body in place
+        /// (EVENT was upgraded in s2pf-6; PatchImage_HEADERTSA in s2pf-7; AP/ROMTCS/PROCS in s2pf-8).
         /// <para>
-        /// <b>Dispatch contract for s2pf-8..10:</b> each fully-implemented arm emits a PRECISE
+        /// <b>Dispatch contract for s2pf-9..10:</b> each fully-implemented arm emits a PRECISE
         /// length (EVENT runs the <see cref="EmitScanScript"/> walk; PatchImage_HEADERTSA runs
-        /// <see cref="EmitHeaderTsaPointer"/>); each remaining INTERIM form-bound arm falls into
+        /// <see cref="EmitHeaderTsaPointer"/>; AP/ROMTCS/PROCS run
+        /// <see cref="EmitApPointer"/>/<see cref="EmitRomTcsPointer"/>/<see cref="EmitProcsPointer"/>);
+        /// each remaining INTERIM form-bound arm falls into
         /// <see cref="EmitPatchStructDefaultMix"/> (a length-0 MIX placeholder) and is marked with the
         /// slice that upgrades it. To upgrade an arm, give its <c>case</c> a real body (sized like the
         /// WF helper it ports) and drop it from the interim group — the call shape
@@ -13251,7 +13311,8 @@ namespace FEBuilderGBA
         /// <param name="list">The accumulating struct/pointer list (appended to).</param>
         /// <param name="patch">The owning STRUCT patch (the PatchImage arms read its WIDTH/HEIGHT/PALETTE).</param>
         /// <param name="basedir">The patch dir (for the WIDTH/HEIGHT/PALETTE <c>$</c>-macros).</param>
-        /// <param name="isPointerOnly">WF <c>isPointerOnly</c> — forwarded to the AP/ROMTCS/PROCS interim arms.</param>
+        /// <param name="isPointerOnly">WF <c>isPointerOnly</c> — the AP/ROMTCS/PROCS arms always scan REAL
+        /// lengths (s2pf-8), so the param is retained for the WF call shape rather than forwarded.</param>
         /// <param name="type">The pointer field type (<c>typeArray[n]</c>).</param>
         /// <param name="p">The field address <c>struct_address + i*datasize + pointerIndexes[n]</c>.</param>
         /// <param name="patchname">The struct's <c>Name@STRUCT</c> info prefix.</param>
@@ -13398,26 +13459,68 @@ namespace FEBuilderGBA
                     }
                     break;
 
+                // ---- FULLY IMPLEMENTED — embedded-pointer length-walks (s2pf-8) -
+
+                case "AP":
+                    // WF 6644-6653: deref `a = p32(p)`, pre-gate `isSafetyOffset(a)`, then
+                    // AddressWinForms.AddAPPointer(list, p, name, isPointerOnly) -> EmitApPointer (the
+                    // verbatim Core port: deref p, length = ImageUtilAPCore.CalcAPLength over the target).
+                    // EmitApPointer re-derefs p and re-checks both gates internally, so the WF pre-gate is a
+                    // redundant guard (emit iff slot+target are both safe — no double-emit). The slot+3 EOF
+                    // guard makes a near-EOF p a clean skip (Core-wide convention).
+                    {
+                        if (U.isSafetyOffset(p, rom) && U.isSafetyOffset(p + 3, rom))
+                        {
+                            uint a = rom.p32(p);
+                            if (U.isSafetyOffset(a, rom))
+                            {
+                                EmitApPointer(rom, list, p, patchname + " AP " + n);
+                            }
+                        }
+                    }
+                    break;
+
+                case "ROMTCS":
+                    // WF 6655-6664: deref `a = p32(p)`, pre-gate `isSafetyOffset(a)`, then
+                    // AddressWinForms.AddROMTCSPointer(list, p, name, isPointerOnly) -> EmitRomTcsPointer
+                    // (the verbatim Core port: deref p, length = CalcRomTcsLength over the target).
+                    // EmitRomTcsPointer re-derefs + re-gates internally (redundant pre-gate, no double-emit).
+                    {
+                        if (U.isSafetyOffset(p, rom) && U.isSafetyOffset(p + 3, rom))
+                        {
+                            uint a = rom.p32(p);
+                            if (U.isSafetyOffset(a, rom))
+                            {
+                                EmitRomTcsPointer(rom, list, p, patchname + " ROMTCS " + n);
+                            }
+                        }
+                    }
+                    break;
+
+                case "PROCS":
+                    // WF 6666-6675: deref `a = p32(p)`, pre-gate `isSafetyOffset(a)`, then
+                    // AddressWinForms.AddProcsPointer(list, p, name, isPointerOnly) -> EmitProcsPointer
+                    // (the verbatim Core port: deref p, length = CalcProcsLengthAndCheck over the target).
+                    // PROCS SKIPS on NOT_FOUND — EmitProcsPointer reproduces WF AddProcsAddress's
+                    // `if (length == U.NOT_FOUND) return;` (NEVER a zero/guessed length for a non-PROCS
+                    // target). EmitProcsPointer re-derefs + re-gates internally (redundant pre-gate).
+                    {
+                        if (U.isSafetyOffset(p, rom) && U.isSafetyOffset(p + 3, rom))
+                        {
+                            uint a = rom.p32(p);
+                            if (U.isSafetyOffset(a, rom))
+                            {
+                                EmitProcsPointer(rom, list, p, patchname + " PROCS " + n);
+                            }
+                        }
+                    }
+                    break;
+
                 // ---- INTERIM default-MIX (this slice) — form-bound arms ---------
                 // Each routes through EmitPatchStructDefaultMix (= WF's own `default`,
                 // length-0 MIX). This DIVERGES from WF (WF emits the precise sub-walked
                 // TARGET region); SAFE only while the gate token stays deferred. The
                 // partial WF-parity test EXCLUDES these types.
-
-                case "AP":
-                    // INTERIM default-MIX -> upgraded in s2pf-8 (AddAPPointer).
-                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
-                    break;
-
-                case "ROMTCS":
-                    // INTERIM default-MIX -> upgraded in s2pf-8 (AddROMTCSPointer).
-                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
-                    break;
-
-                case "PROCS":
-                    // INTERIM default-MIX -> upgraded in s2pf-8 (AddProcsPointer).
-                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
-                    break;
 
                 case "VENNOUWEAPONLOCK":
                     // INTERIM default-MIX -> upgraded in s2pf-9 (VennouWeaponLockForm.MakeDataLength).

--- a/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
+++ b/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
@@ -520,13 +520,21 @@ namespace FEBuilderGBA.Tests.Unit
         /// (<c>@STRUCT HEADERTSA n</c>, WF <c>AddHeaderTSAPointer</c> -&gt; <c>DataTypeEnum.HEADERTSA</c>) is
         /// wired via <see cref="RebuildProducerCore.EmitHeaderTsaPointer"/>; its <c>@STRUCT HEADERTSA </c>
         /// info token + HEADERTSA data type are compared on BOTH sides.</para>
-        /// <para><b>THE REMAINING INTERIM FORM-BOUND ARMS ARE EXCLUDED (deferred to s2pf-8..10).</b> The
-        /// BATTLEANIMEPOINTER/AP/ROMTCS/PROCS/VENNOUWEAPONLOCK/SMEPROMOLIST/CLASSLIST/
+        /// <para><b>AP / ROMTCS / PROCS are NOW INCLUDED (s2pf-8).</b> Each embedded-pointer field
+        /// (<c>@STRUCT AP/ROMTCS/PROCS n</c>, WF <c>AddAPPointer</c>/<c>AddROMTCSPointer</c>/
+        /// <c>AddProcsPointer</c> -&gt; <c>DataTypeEnum.AP</c>/<c>ROMTCS</c>/<c>PROCS</c>) is wired via
+        /// <see cref="RebuildProducerCore.EmitApPointer"/>/<see cref="RebuildProducerCore.EmitRomTcsPointer"/>/
+        /// <see cref="RebuildProducerCore.EmitProcsPointer"/> (lengths via <c>ImageUtilAPCore.CalcAPLength</c>/
+        /// <c>CalcRomTcsLength</c>/<c>CalcProcsLengthAndCheck</c>); their named info tokens + data types are
+        /// compared on BOTH sides. PROCS skips on NOT_FOUND (no entry on either side for a non-PROCS
+        /// target — WF AddProcsAddress and Core EmitProcsPointer both return without emitting).</para>
+        /// <para><b>THE REMAINING INTERIM FORM-BOUND ARMS ARE EXCLUDED (deferred to s2pf-9..10).</b> The
+        /// BATTLEANIMEPOINTER/VENNOUWEAPONLOCK/SMEPROMOLIST/CLASSLIST/
         /// TERRAINBATTLELISTPOINTER/BATTLEBGLISTPOINTER/AOERANGEPOINTER fields are
         /// routed through Core's INTERIM default-MIX (a length-0 MIX entry named <c>... DATA n</c>) this
         /// slice — they INTENTIONALLY diverge from WF (WF emits the precise sub-walked TARGET region). So
         /// every MIX-typed <c>... DATA </c>-suffixed entry is filtered OUT of BOTH sides before the
-        /// comparison. Those arms gain their own parity teeth in s2pf-8..10, and the FULL STRUCT parity
+        /// comparison. Those arms gain their own parity teeth in s2pf-9..10, and the FULL STRUCT parity
         /// (no exclusions) lands at s2pf-11 when the gate token is removed.</para>
         /// <para><b>CSTRING is NOT in the merged-list parity scope:</b> WF/Core both name a CSTRING entry
         /// the DECODED STRING (no <c>@STRUCT</c> marker), so it cannot be reliably attributed to a STRUCT
@@ -577,18 +585,20 @@ namespace FEBuilderGBA.Tests.Unit
 
                 // A FULLY-IMPLEMENTED STRUCT-arm entry: the MAIN struct entry (Info ends "@STRUCT") OR a
                 // per-entry ASM / PatchImage_* arm ("@STRUCT " + ASM/IMAGE/TSA/ZTSA/ZHEADERTSA/HEADERTSA/
-                // PALETTE) OR an EVENT-walk entry (s2pf-6: the "@STRUCT DATA n" entries the
+                // PALETTE) OR an AP/ROMTCS/PROCS arm (s2pf-8: "@STRUCT AP/ROMTCS/PROCS n", typed
+                // AP/ROMTCS/PROCS) OR an EVENT-walk entry (s2pf-6: the "@STRUCT DATA n" entries the
                 // EventScriptForm.ScanScript walk emits — EVENTSCRIPT script blocks + their
                 // POINTER_UNIT/AICOORDINATE sub-data IFR/BIN blocks). The STILL-INTERIM form-bound arms
-                // (AP/ROMTCS/PROCS s2pf-8 / Vennou/AOE/SMEPromo/SomeClass/Terrain* s2pf-9 / BattleAnime
-                // s2pf-10) emit "@STRUCT DATA n" as a length-0 MIX placeholder — those DIVERGE from WF this
-                // slice and are EXCLUDED. Since EmitPatchStructDefaultMix is the ONLY producer of a MIX-typed
-                // "@STRUCT DATA " entry, a simple rule cleanly separates the two: a MIX-typed DATA entry is
-                // interim (EXCLUDE), any other DATA entry came from the now-precise EVENT walk (INCLUDE).
+                // (Vennou/AOE/SMEPromo/SomeClass/Terrain* s2pf-9 / BattleAnime s2pf-10) emit
+                // "@STRUCT DATA n" as a length-0 MIX placeholder — those DIVERGE from WF this slice and are
+                // EXCLUDED. Since EmitPatchStructDefaultMix is the ONLY producer of a MIX-typed "@STRUCT
+                // DATA " entry, a simple rule cleanly separates the two: a MIX-typed DATA entry is interim
+                // (EXCLUDE), any other DATA entry came from the now-precise EVENT walk (INCLUDE).
                 // PatchImage_HEADERTSA is now precise (s2pf-7), emitting a "@STRUCT HEADERTSA n" / HEADERTSA
-                // entry — INCLUDED via the safeArmTokens. CSTRING is out of merged-list scope (named the
-                // decoded string) — see doc-comment.
-                string[] safeArmTokens = { " ASM ", " IMAGE ", " TSA ", " ZTSA ", " ZHEADERTSA ", " HEADERTSA ", " PALETTE " };
+                // entry — INCLUDED via the safeArmTokens. AP/ROMTCS/PROCS are now precise (s2pf-8), emitting
+                // "@STRUCT AP/ROMTCS/PROCS n" — INCLUDED via the safeArmTokens (their named, non-DATA info
+                // tokens). CSTRING is out of merged-list scope (named the decoded string) — see doc-comment.
+                string[] safeArmTokens = { " ASM ", " IMAGE ", " TSA ", " ZTSA ", " ZHEADERTSA ", " HEADERTSA ", " PALETTE ", " AP ", " ROMTCS ", " PROCS " };
                 bool IsImplementedStructEntry(Address a)
                 {
                     if (a.Info == null) return false;


### PR DESCRIPTION
## Summary
#1261 option-B PatchForm producer epic, sub-slice **8/11**. Faithful WinForms→Core port of the three embedded-pointer STRUCT field arms (`AP` / `ROMTCS` / `PROCS`), upgrading them from the interim default-MIX placeholder to precise length-walked targets.

- **`EmitPatchStructEntry`** — upgrade the `AP` / `ROMTCS` / `PROCS` STRUCT arms (WF `PatchForm.cs:6644` / `6655` / `6666` → `AddressWinForms.AddAPPointer` / `AddROMTCSPointer` / `AddProcsPointer`) from interim default-MIX to the real pointer-emitters. Each reproduces WF **verbatim**: deref `a = p32(p)`, pre-gate `isSafetyOffset(a)`, then emit the dereferenced target sized by the length helper.
- **AP / ROMTCS reuse the already-in-Core** `EmitApPointer` / `EmitRomTcsPointer` (lengths via `ImageUtilAPCore.CalcAPLength` / `CalcRomTcsLength`) — verified byte-parity against WF `AddAPAddress` / `AddROMTCSAddress`, **no re-port**.
- **PROCS needed a new `EmitProcsPointer`** (mirrors the AP/ROMTCS emitter shape) using the already-in-Core `CalcProcsLengthAndCheck`. It reproduces WF `AddProcsAddress`'s critical difference: **PROCS SKIPS on `CalcProcsLengthAndCheck == NOT_FOUND`** — never a zero/guessed length for a non-PROCS target (a wrong length = relocation collision = corruption). `EmitApPointer` always emits (length 0 on an unparseable AP stream), matching WF `AddAPAddress`.
- **EOF-hardening**: guard the `p32(p)` deref (slot+3 extent) before reading; the emitters re-deref + re-gate internally (the WF outer pre-gate is redundant, no double-emit).
- Update all audit tables / block comments: `AP` / `ROMTCS` / `PROCS` move interim → **DONE**.

### Where the length helpers live (reused, not re-ported)
| arm | helper | location |
|---|---|---|
| AP | `ImageUtilAPCore.CalcAPLength` | `ImageUtilAPCore.cs:352` |
| ROMTCS | `RebuildProducerCore.CalcRomTcsLength` | `RebuildProducerCore.cs:2158` |
| PROCS | `RebuildProducerCore.CalcProcsLengthAndCheck` | `RebuildProducerCore.cs:4064` (slice 2x) |

`EmitApPointer` / `EmitRomTcsPointer` already existed in Core (prior slices) and were reused verbatim. Only `EmitProcsPointer` is new.

### Remaining interim STRUCT arms (after this slice)
- VENNOUWEAPONLOCK / AOERANGEPOINTER / SMEPROMOLIST / CLASSLIST / TERRAINBATTLELISTPOINTER / BATTLEBGLISTPOINTER (**6 forms**) → s2pf-9
- BATTLEANIMEPOINTER → s2pf-10

### Invariants
- Gate token `"PatchForm(MakePatchStructDataList)"` **STAYS** in `AsmNotYetPortedRaw` (orchestrator not wired into the live producer until s2pf-11).
- `MakePatchStructDataListCore_NoPatchDir_EmitsNothing_NoThrow` preserved.

## Test plan
- [x] **Core unit (synthetic)** — `RebuildProducerPatchStructTests`: AP-typed STRUCT field → planted target, length cross-checked vs `CalcAPLength`, typed AP, named `… AP n`; ROMTCS field → planted terminator, length via `CalcRomTcsLength`, typed ROMTCS; PROCS field (valid) → planted stream, length 16, typed PROCS; **PROCS NOT_FOUND → skip** (no PROCS Address, no MIX); AP/ROMTCS/PROCS unsafe-target → emits nothing; near-EOF slot → no-throw.
- [x] **Core unit (emitter direct)** — `RebuildProducerCoreTests`: `EmitApPointer` (length == `CalcAPLength`, always emits) + near-EOF no-throw; `EmitProcsPointer` valid (length 16) + **NOT_FOUND → empty** + near-EOF no-throw.
- [x] **Partial WF-parity** (`FEBuilderGBA.Tests`, skip-if-no-ROM, real FE8U + config/patch2): `CorePatchStructArm_IsSubsetOf_WinFormsPatchProducer_*` now INCLUDES AP/ROMTCS/PROCS (added `" AP "/" ROMTCS "/" PROCS "` safe-arm tokens). Remaining excluded: the 6 forms + BattleAnime. (Early-exits Pass in the worktree / CI without `roms/FE8U.gba`; non-vacuous where config/patch2 is checked out.)
- [x] `dotnet test FEBuilderGBA.Core.Tests --filter "FullyQualifiedName~RebuildProducer"` → **618 pass** (baseline 606 + 12), 0 failed, incl. `NoPatchDir`.
- [x] `dotnet build FEBuilderGBA.sln` clean (0 errors).
- [x] The 10 `Skill*` Core.Tests failures are the known un-checked-out `config/patch2` submodule (env-only — pass in CI).

## Proof (Core-only, no GUI)
```
Passed!  - Failed: 0, Passed: 618, Skipped: 0, Total: 618 — FEBuilderGBA.Core.Tests.dll (RebuildProducer filter)
Build succeeded. 0 Error(s) — FEBuilderGBA.sln
```

Part of #1261.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]