### PR TITLE
feat(core): PatchForm 6 deterministic STRUCT form-arms (#1261 s2pf-9)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchStructTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchStructTests.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+﻿// SPDX-License-Identifier: GPL-3.0-or-later
 // Tests for RebuildProducerCore slice s2pf-5 (#1261) — the TYPE=STRUCT terminal
 // PatchForm producer arm (option-B epic, sub-slice 5 of 11):
 //   RebuildProducerCore.EmitPatchStruct = WF PatchForm.MakePatchStructDataListForSTRUCT @:6461
@@ -594,17 +594,15 @@ namespace FEBuilderGBA.Core.Tests
         // NOTE: EVENT was REMOVED from this interim group in s2pf-6 (it runs the real
         // EventScriptForm.ScanScript walk — see EmitPatchStruct_EventArm_*),
         // PatchImage_HEADERTSA in s2pf-7 (it runs EmitHeaderTsaPointer — see
-        // EmitPatchStruct_HeaderTsaField_* below), and AP/ROMTCS/PROCS in s2pf-8 (they run
+        // EmitPatchStruct_HeaderTsaField_* below), AP/ROMTCS/PROCS in s2pf-8 (they run
         // EmitApPointer/EmitRomTcsPointer/EmitProcsPointer — see EmitPatchStruct_ApField_* /
-        // _RomTcsField_* / _ProcsField_* below).
+        // _RomTcsField_* / _ProcsField_* below), and the SIX deterministic STRUCT forms
+        // (VENNOUWEAPONLOCK/AOERANGEPOINTER/SMEPROMOLIST/CLASSLIST/TERRAINBATTLELISTPOINTER/
+        // BATTLEBGLISTPOINTER) in s2pf-9 (they run the precise length-walks — see
+        // EmitPatchStruct_VennouWeaponLockField_* etc. below). Only BATTLEANIMEPOINTER (s2pf-10)
+        // remains interim default-MIX.
         [Theory]
-        [InlineData("VENNOUWEAPONLOCK")]          // -> s2pf-9
-        [InlineData("AOERANGEPOINTER")]           // -> s2pf-9
-        [InlineData("SMEPROMOLIST")]              // -> s2pf-9
-        [InlineData("CLASSLIST")]                 // -> s2pf-9
-        [InlineData("TERRAINBATTLELISTPOINTER")]  // -> s2pf-9
-        [InlineData("BATTLEBGLISTPOINTER")]       // -> s2pf-9
-        [InlineData("BATTLEANIMEPOINTER")]        // -> s2pf-10
+        [InlineData("BATTLEANIMEPOINTER")]        // -> s2pf-10 (the LAST interim form-bound arm)
         public void EmitPatchStruct_FormBoundArm_IsInterimDefaultMix(string fieldType)
         {
             var rom = MakeRom();
@@ -778,6 +776,252 @@ namespace FEBuilderGBA.Core.Tests
             var list = new List<Address>();
             Exception ex = Record.Exception(() =>
                 RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("EOF",
+                    ("TYPE", "STRUCT"), ("ADDRESS", "0x" + near.ToString("X")),
+                    ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                    ("P0:" + fieldType, "0")), isPointerOnly: false));
+            Assert.Null(ex);
+        }
+
+        // ====================================================================
+        // 4a2. The SIX deterministic STRUCT form-arms (s2pf-9) — the REAL
+        //      length-walks. WF PatchForm.cs arms 6693/6722/6698/6703/6708/6713 ->
+        //      VennouWeaponLockForm / AOERANGEForm / SMEPromoListForm /
+        //      SomeClassListForm / MapTerrainFloorLookupTableForm /
+        //      MapTerrainBGLookupTableForm .MakeDataLength, reproduced via the Core
+        //      EmitVennouWeaponLockPointer / EmitAoeRangePointer / EmitSmePromoListPointer /
+        //      EmitSomeClassListPointer / EmitMapTerrainLookupPointer. Each derefs the
+        //      slot and emits the precise target length (0x00-terminator BIN / 4+w*h BIN /
+        //      block-2 u16!=0 IFR / block-1 u8!=0 IFR / fixed map_terrain_type_count IFR).
+        // ====================================================================
+
+        [Fact]
+        public void EmitPatchStruct_VennouWeaponLockField_EmitsBinTerminatorLength()
+        {
+            // WF VennouWeaponLockForm.MakeDataLength -> CalcLength: deref u32(p), scan from start+1
+            // to the first 0x00, length = end - start, type BIN. Plant a 5-byte list [01 02 03 04 05]
+            // followed by 0x00 at +5 -> the scan (start at +1) finds 0x00 at +5 -> length = 5.
+            var rom = MakeRom();
+            const uint table = 0x2000, target = 0x8000;
+            PlantPointer(rom, table + 0, target);
+            rom.write_u8(target + 0, 0x01);
+            rom.write_u8(target + 1, 0x02);
+            rom.write_u8(target + 2, 0x03);
+            rom.write_u8(target + 3, 0x04);
+            rom.write_u8(target + 4, 0x05);
+            rom.write_u8(target + 5, 0x00); // terminator
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("VWL",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:VENNOUWEAPONLOCK", "0")), isPointerOnly: false);
+
+            var a = Assert.Single(list, x => x.DataType == Address.DataTypeEnum.BIN);
+            Assert.Equal(target, a.Addr);
+            Assert.Equal(5u, a.Length); // end(0x8005) - start(0x8000)
+            Assert.Equal(table + 0, a.Pointer);
+            Assert.EndsWith("DATA 0", a.Info);
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.MIX);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_VennouWeaponLockField_TerminatorAtStart_IsConsumedAsData_LengthAtLeastOne()
+        {
+            // The WF off-by-one: CalcLength does start=addr; addr++; THEN scans. A 0x00 AT start is
+            // NOT the terminator (the byte at start is consumed as data) -> length >= 1. Plant 0x00 at
+            // +0 and the next 0x00 at +1 -> scan starts at +1, finds 0x00 there -> length = 1.
+            var rom = MakeRom();
+            const uint table = 0x2000, target = 0x8000;
+            PlantPointer(rom, table + 0, target);
+            rom.write_u8(target + 0, 0x00); // terminator AT start — consumed as data
+            rom.write_u8(target + 1, 0x00); // real terminator found by the scan
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("VWL0",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:VENNOUWEAPONLOCK", "0")), isPointerOnly: false);
+
+            var a = Assert.Single(list, x => x.DataType == Address.DataTypeEnum.BIN);
+            Assert.Equal(target, a.Addr);
+            Assert.Equal(1u, a.Length); // NOT 0 — the start byte is data, the +1 byte is the terminator
+        }
+
+        [Fact]
+        public void EmitPatchStruct_AoeRangeField_EmitsBinLengthFourPlusWtimesH()
+        {
+            // WF AOERANGEForm.MakeDataLength: deref p32(p), w=u8(+0), h=u8(+1), length = 4 + w*h, BIN.
+            // w=3, h=5 -> length = 4 + 15 = 19. EXACTLY 4+w*h (not w*h, not (w+1)*(h+1)=24).
+            var rom = MakeRom();
+            const uint table = 0x2000, target = 0x8000;
+            PlantPointer(rom, table + 0, target);
+            rom.write_u8(target + 0, 3); // w
+            rom.write_u8(target + 1, 5); // h
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("AOE",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:AOERANGEPOINTER", "0")), isPointerOnly: false);
+
+            var a = Assert.Single(list, x => x.DataType == Address.DataTypeEnum.BIN);
+            Assert.Equal(target, a.Addr);
+            Assert.Equal(4u + 3u * 5u, a.Length); // 19, EXACTLY 4 + w*h
+            Assert.NotEqual((3u + 1u) * (5u + 1u), a.Length); // NOT (w+1)*(h+1)
+            Assert.NotEqual(3u * 5u, a.Length);               // NOT w*h
+            Assert.Equal(table + 0, a.Pointer);
+            Assert.EndsWith("DATA 0", a.Info);
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.MIX);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_AoeRangeField_ZeroBox_LengthIsFour()
+        {
+            // w=0,h=0 -> length = 4 + 0 = 4 (the 4-byte header only).
+            var rom = MakeRom();
+            const uint table = 0x2000, target = 0x8000;
+            PlantPointer(rom, table + 0, target);
+            rom.write_u8(target + 0, 0);
+            rom.write_u8(target + 1, 0);
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("AOE0",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:AOERANGEPOINTER", "0")), isPointerOnly: false);
+
+            var a = Assert.Single(list, x => x.DataType == Address.DataTypeEnum.BIN);
+            Assert.Equal(4u, a.Length);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_SmePromoListField_EmitsBlock2U16Ifr()
+        {
+            // WF SMEPromoListForm.MakeDataLength: IFR block 2, count = getBlockDataCount(base, 2, u16!=0),
+            // length = 2*(count+1). Plant 3 non-zero u16 entries then a 0x0000 terminator -> count = 3,
+            // length = 2*(3+1) = 8.
+            var rom = MakeRom();
+            const uint table = 0x2000, target = 0x8000;
+            PlantPointer(rom, table + 0, target);
+            rom.write_u16(target + 0, 0x0102);
+            rom.write_u16(target + 2, 0x0304);
+            rom.write_u16(target + 4, 0x0506);
+            rom.write_u16(target + 6, 0x0000); // terminator (u16 == 0)
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("SME",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:SMEPROMOLIST", "0")), isPointerOnly: false);
+
+            var a = Assert.Single(list, x => x.DataType == Address.DataTypeEnum.InputFormRef
+                && x.Pointer == table + 0);
+            Assert.Equal(target, a.Addr);
+            Assert.Equal(2u * (3u + 1u), a.Length); // 8
+            Assert.Equal(2u, a.BlockSize);
+            Assert.EndsWith("DATA 0", a.Info);
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.MIX);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_ClassListField_EmitsBlock1U8Ifr()
+        {
+            // WF SomeClassListForm.MakeDataLength (CLASSLIST): IFR block 1, count =
+            // getBlockDataCount(base, 1, u8!=0), length = 1*(count+1). Plant 4 non-zero u8 then 0x00 ->
+            // count = 4, length = 1*(4+1) = 5.
+            var rom = MakeRom();
+            const uint table = 0x2000, target = 0x8000;
+            PlantPointer(rom, table + 0, target);
+            rom.write_u8(target + 0, 0x11);
+            rom.write_u8(target + 1, 0x22);
+            rom.write_u8(target + 2, 0x33);
+            rom.write_u8(target + 3, 0x44);
+            rom.write_u8(target + 4, 0x00); // terminator (u8 == 0)
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("CLS",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:CLASSLIST", "0")), isPointerOnly: false);
+
+            var a = Assert.Single(list, x => x.DataType == Address.DataTypeEnum.InputFormRef
+                && x.Pointer == table + 0);
+            Assert.Equal(target, a.Addr);
+            Assert.Equal(1u * (4u + 1u), a.Length); // 5
+            Assert.Equal(1u, a.BlockSize);
+            Assert.EndsWith("DATA 0", a.Info);
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.MIX);
+        }
+
+        [Theory]
+        [InlineData("TERRAINBATTLELISTPOINTER")]
+        [InlineData("BATTLEBGLISTPOINTER")]
+        public void EmitPatchStruct_TerrainLookupField_FixedCountIfr_NotTerminatorScan(string fieldType)
+        {
+            // WF MapTerrain{Floor,BG}LookupTableForm.MakeDataLength: IFR block 1, FIXED count =
+            // rom.RomInfo.map_terrain_type_count (NOT a 0x00-terminator scan). Plant the target with
+            // EARLY 0x00 bytes — a terminator scan would stop at count 0, but the FIXED-count walk
+            // ignores the bytes and uses map_terrain_type_count. length = 1*(count+1).
+            var rom = MakeRom();
+            uint count = rom.RomInfo.map_terrain_type_count;
+            Assert.True(count > 0);
+            const uint table = 0x2000, target = 0x8000;
+            PlantPointer(rom, table + 0, target);
+            // Deliberately plant 0x00 at the very start: a terminator scan WOULD yield count 0.
+            rom.write_u8(target + 0, 0x00);
+            rom.write_u8(target + 1, 0x00);
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("TL",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:" + fieldType, "0")), isPointerOnly: false);
+
+            var a = Assert.Single(list, x => x.DataType == Address.DataTypeEnum.InputFormRef
+                && x.Pointer == table + 0);
+            Assert.Equal(target, a.Addr);
+            Assert.Equal(1u * (count + 1u), a.Length); // FIXED-count length, NOT 1 (terminator-scan count 0)
+            Assert.NotEqual(1u, a.Length);
+            Assert.Equal(1u, a.BlockSize);
+            Assert.EndsWith("DATA 0", a.Info);
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.MIX);
+        }
+
+        [Theory]
+        [InlineData("VENNOUWEAPONLOCK")]
+        [InlineData("AOERANGEPOINTER")]
+        [InlineData("SMEPROMOLIST")]
+        [InlineData("CLASSLIST")]
+        [InlineData("TERRAINBATTLELISTPOINTER")]
+        [InlineData("BATTLEBGLISTPOINTER")]
+        public void EmitPatchStruct_S2pf9Field_UnsafeTarget_EmitsNothing(string fieldType)
+        {
+            // The slot derefs below the 0x200 safety floor -> every s2pf-9 arm skips (no emission,
+            // and NOT the interim default-MIX placeholder either).
+            var rom = MakeRom();
+            const uint table = 0x2000;
+            U.write_u32(rom.Data, table + 0, U.toPointer(0x100)); // target below safety floor
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("US9",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:" + fieldType, "0")), isPointerOnly: false);
+
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.BIN);
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.InputFormRef
+                && x.Pointer == table + 0);
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.MIX);
+        }
+
+        [Theory]
+        [InlineData("VENNOUWEAPONLOCK")]
+        [InlineData("AOERANGEPOINTER")]
+        [InlineData("SMEPROMOLIST")]
+        [InlineData("CLASSLIST")]
+        [InlineData("TERRAINBATTLELISTPOINTER")]
+        [InlineData("BATTLEBGLISTPOINTER")]
+        public void EmitPatchStruct_S2pf9Field_SlotNearEof_NoThrow(string fieldType)
+        {
+            // A pointer FIELD sitting in the last 3 bytes -> the slot+3 EOF guard makes a clean skip
+            // (no throw) rather than reading p32/u32 past EOF.
+            var rom = MakeRom();
+            uint near = (uint)rom.Data.Length - 1;
+            var list = new List<Address>();
+            Exception ex = Record.Exception(() =>
+                RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("EOF9",
                     ("TYPE", "STRUCT"), ("ADDRESS", "0x" + near.ToString("X")),
                     ("DATASIZE", "4"), ("DATACOUNT", "1"),
                     ("P0:" + fieldType, "0")), isPointerOnly: false));

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -2539,7 +2539,10 @@ namespace FEBuilderGBA
             // identical. AddAddressInstantIFR then re-derefs pointer (== baseAddr) and emits length
             // blockSize*(count+1) - matching AddressWinForms.AddAddress(IFR, ..., {}).
             uint count = rom.getBlockDataCount(baseAddr, blockSize, isDataExists);
-            Address.AddAddressInstantIFR(list, pointer, blockSize, count, info, new uint[] { });
+            // Reuse the shared empty pointerIndexes array (EmptyPI) rather than allocating a new
+            // uint[] per call — this emitter runs inside the nested per-STRUCT-entry loop, so a
+            // fresh allocation each call is avoidable GC churn (Copilot PR #1320 review).
+            Address.AddAddressInstantIFR(list, pointer, blockSize, count, info, EmptyPI);
         }
 
         // -------------------------------------------------------------------------------------------

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -2319,6 +2319,227 @@ namespace FEBuilderGBA
                 return;
             }
             list.Add(new Address(target, length, pointer, info, Address.DataTypeEnum.PROCS));
+        }
+
+        // ===================================================================================
+        // PatchForm STRUCT producer - option-B epic (#1261, sub-slice s2pf-9 of 11).
+        //
+        // The SIX deterministic embedded-pointer STRUCT field emitters, upgrading the
+        // VENNOUWEAPONLOCK / AOERANGEPOINTER / SMEPROMOLIST / CLASSLIST /
+        // TERRAINBATTLELISTPOINTER / BATTLEBGLISTPOINTER arms of EmitPatchStructEntry from
+        // the interim default-MIX placeholder to precise length-walked targets. Each is a
+        // faithful Core port of the WinForms XxxForm.MakeDataLength(list, pointer, name)
+        // dispatched from PatchForm.cs (arms 6693/6722/6698/6703/6708/6713). Every length is a
+        // DETERMINISTIC pure-ROM read (a 0x00-terminator scan, a 4+w*h box, or a fixed/u8/u16
+        // getBlockDataCount IFR), so a wrong size = a relocation collision = corruption - the
+        // sizes below are reproduced VERBATIM. EOF-HARDENING: every computed read full extent
+        // is guarded (slot+3 before a u32/p32; addr+1 before a u8 pair; the count walks are
+        // bounded by getBlockDataCount own addr+blocksize<=Length stop).
+        // ===================================================================================
+
+        /// <summary>
+        /// Reproduces WinForms <c>VennouWeaponLockForm.MakeDataLength(list, pointer, strname)</c>
+        /// (FEBuilderGBA/VennouWeaponLockForm.cs:290; the STRUCT arm at PatchForm.cs:6693): the
+        /// <paramref name="pointer"/> slot holds a 32-bit ROM pointer to a 0x00-terminated weapon-lock
+        /// BIN list; emit a <see cref="Address.DataTypeEnum.BIN"/> block whose length is the verbatim
+        /// <c>CalcLength</c> terminator scan (VennouWeaponLockForm.cs:88).
+        /// <para><b>Terminator off-by-one reproduced VERBATIM (NOT a bug):</b> WF <c>CalcLength</c> sets
+        /// <c>start = addr</c>, then does <c>addr++</c> BEFORE the scan loop, so the scan begins at
+        /// <c>start+1</c> and the length is <c>end - start</c>. A terminator AT <c>start</c> is therefore
+        /// never matched (the byte at <c>start</c> is consumed as data), yielding length &gt;= 1 - exactly
+        /// WF. EOF-HARDENING: WF reads <c>u32(pointer)</c> after only a single-byte gate; guard the full
+        /// 4-byte slot (slot+3) so a near-EOF pointer is a clean skip, and the scan is bounded by
+        /// <c>rom.Data.Length</c> (WF <c>length</c> local).</para>
+        /// </summary>
+        public static void EmitVennouWeaponLockPointer(ROM rom, List<Address> list, uint pointer, string info)
+        {
+            // WF MakeDataLength: addr = Program.ROM.u32(pointer); if (!isSafetyPointer(addr)) return;
+            pointer = U.toOffset(pointer);
+            if (!U.isSafetyOffset(pointer, rom))
+            {
+                return;
+            }
+            if (pointer + 4 > (uint)rom.Data.Length)
+            {
+                return;
+            }
+            uint addr = rom.u32(pointer);
+            if (!U.isSafetyPointer(addr, rom))
+            {
+                return;
+            }
+            uint length = CalcVennouWeaponLockLength(rom, addr);
+            // WF: AddAddress(list, addr, length, pointer, strname, BIN). addr is toOffset in the
+            // Address ctor; pass it directly (matching the WF arg order addr/length/pointer).
+            Address.AddAddress(list, addr, length, pointer, info, Address.DataTypeEnum.BIN);
+        }
+
+        /// <summary>
+        /// Verbatim Core port of WinForms <c>VennouWeaponLockForm.CalcLength(addr)</c>
+        /// (FEBuilderGBA/VennouWeaponLockForm.cs:88): <c>start = toOffset(addr)</c>, then scan from
+        /// <c>start+1</c> to the first <c>u8 == 0x00</c> (or EOF), returning <c>end - start</c>. The
+        /// <c>addr++</c> BEFORE the loop is reproduced (the byte at <c>start</c> is never the terminator).
+        /// EOF-safe: the scan stops at <c>rom.Data.Length</c> (WF <c>length</c> local), so a missing
+        /// terminator yields the span to EOF rather than throwing.
+        /// </summary>
+        static uint CalcVennouWeaponLockLength(ROM rom, uint addr)
+        {
+            addr = U.toOffset(addr);
+            if (!U.isSafetyOffset(addr, rom))
+            {
+                return 0;
+            }
+            uint start = addr;
+            uint length = (uint)rom.Data.Length;
+            addr++; // WF: skip the leading byte - the byte at start is consumed as data, never the terminator.
+            for (; addr < length; addr += 1)
+            {
+                if (rom.u8(addr) == 0x00)
+                {
+                    break;
+                }
+            }
+            return addr - start;
+        }
+
+        /// <summary>
+        /// Reproduces WinForms <c>AOERANGEForm.MakeDataLength(list, pointer, strname)</c>
+        /// (FEBuilderGBA/AOERANGEForm.cs:25; the STRUCT arm at PatchForm.cs:6722): the
+        /// <paramref name="pointer"/> slot holds a 32-bit ROM pointer to an AOE box-range BIN whose
+        /// first two bytes are <c>w = u8(+0)</c>, <c>h = u8(+1)</c>; emit a
+        /// <see cref="Address.DataTypeEnum.BIN"/> block of length <c>4 + (w*h)</c> (the 4-byte header
+        /// plus the w*h cell grid - EXACTLY <c>4+w*h</c>, NOT <c>w*h</c> or <c>(w+1)*(h+1)</c>). WF
+        /// emits via <c>Address.AddPointer(list, pointer, length, strname, BIN)</c> (the slot is
+        /// re-derefed); reproduced by emitting the dereferenced target directly. EOF-HARDENING: WF
+        /// pre-gates <c>isSafetyOffset(pointer)</c> then <c>isSafetyOffset(addr)</c>; additionally guard
+        /// the full 4-byte slot (slot+3) and the <c>u8(addr+1)</c> read extent so a near-EOF box is a
+        /// clean skip.
+        /// </summary>
+        public static void EmitAoeRangePointer(ROM rom, List<Address> list, uint pointer, string info)
+        {
+            // WF: if (!isSafetyOffset(pointer)) return; addr = Program.ROM.p32(pointer);
+            //     if (!isSafetyOffset(addr)) return;
+            pointer = U.toOffset(pointer);
+            if (!U.isSafetyOffset(pointer, rom))
+            {
+                return;
+            }
+            if (!U.isSafetyOffset(pointer + 3, rom))
+            {
+                return;
+            }
+            uint addr = rom.p32(pointer);
+            if (!U.isSafetyOffset(addr, rom))
+            {
+                return;
+            }
+            // Guard the w/h read extent (u8 at addr+0 and addr+1) before reading.
+            if (!U.isSafetyOffset(addr + 1, rom))
+            {
+                return;
+            }
+            uint w = rom.u8(addr + 0);
+            uint h = rom.u8(addr + 1);
+            uint length = 4 + (w * h); // WF AOERANGEForm.cs:39 - EXACTLY 4 + w*h.
+            // WF: Address.AddPointer(list, pointer, length, strname, BIN) - re-derefs the slot via
+            // Program.ROM. Emit the already-dereferenced target (== p32(pointer)) DIRECTLY so the
+            // emit is rom-explicit (no CoreState.ROM dependency) - identical Address (the ctor
+            // toOffsets addr either way), matching the EmitApPointer/EmitProcsPointer convention.
+            list.Add(new Address(addr, length, pointer, info, Address.DataTypeEnum.BIN));
+        }
+
+        /// <summary>
+        /// Reproduces WinForms <c>SMEPromoListForm.MakeDataLength(list, pointer, strname)</c>
+        /// (FEBuilderGBA/SMEPromoListForm.cs:66; the STRUCT arm at PatchForm.cs:6698): the
+        /// <paramref name="pointer"/> slot holds a 32-bit ROM pointer to an SME branch-promotion list
+        /// (block size 2, terminated by the first <c>u16 == 0x00</c>); emit ONE
+        /// <see cref="Address.DataTypeEnum.InputFormRef"/> Address of length <c>2*(count+1)</c> where
+        /// <c>count = getBlockDataCount(addr, 2, u16!=0)</c> - the verbatim WF Init walk
+        /// (SMEPromoListForm.cs:24-40, blockSize 2, IsDataExists <c>u16(addr) != 0x00</c>).
+        /// </summary>
+        public static void EmitSmePromoListPointer(ROM rom, List<Address> list, uint pointer, string info)
+        {
+            EmitPatchStructBlockListIFR(rom, list, pointer, info, 2,
+                (i, a) => rom.u16(a) != 0x00);
+        }
+
+        /// <summary>
+        /// Reproduces WinForms <c>SomeClassListForm.MakeDataLength(list, pointer, strname)</c>
+        /// (FEBuilderGBA/SomeClassListForm.cs:65; the STRUCT arm at PatchForm.cs:6703, type CLASSLIST):
+        /// the <paramref name="pointer"/> slot holds a 32-bit ROM pointer to a class-id list (block size
+        /// 1, terminated by the first <c>u8 == 0x00</c>); emit ONE
+        /// <see cref="Address.DataTypeEnum.InputFormRef"/> Address of length <c>1*(count+1)</c> where
+        /// <c>count = getBlockDataCount(addr, 1, u8!=0)</c> - the verbatim WF Init walk
+        /// (SomeClassListForm.cs:24-40, blockSize 1, IsDataExists <c>u8(addr) != 0x00</c>).
+        /// </summary>
+        public static void EmitSomeClassListPointer(ROM rom, List<Address> list, uint pointer, string info)
+        {
+            EmitPatchStructBlockListIFR(rom, list, pointer, info, 1,
+                (i, a) => rom.u8(a) != 0x00);
+        }
+
+        /// <summary>
+        /// Reproduces the STRUCT TERRAINBATTLELISTPOINTER / BATTLEBGLISTPOINTER arms
+        /// (PatchForm.cs:6708 / 6713 -> <c>MapTerrain{Floor,BG}LookupTableForm.MakeDataLength(list,
+        /// pointer, strname)</c>, FEBuilderGBA/MapTerrainFloorLookupTableForm.cs:200 /
+        /// MapTerrainBGLookupTableForm.cs:306): the <paramref name="pointer"/> slot holds a 32-bit ROM
+        /// pointer to a per-terrainset lookup table; emit ONE
+        /// <see cref="Address.DataTypeEnum.InputFormRef"/> Address of length <c>1*(count+1)</c>.
+        /// <para><b>FIXED count (NOT a terminator scan):</b> BOTH terrain forms Init walk uses
+        /// IsDataExists <c>i &lt; rom.RomInfo.map_terrain_type_count</c> (block size 1) - there is no
+        /// per-byte non-zero predicate. So <c>count == map_terrain_type_count</c> and the length is
+        /// <c>1*(map_terrain_type_count+1)</c>. A terminator scan would over/under-count = corruption,
+        /// so the FIXED RomInfo count is used VERBATIM (both Floor and BG share the same count field;
+        /// the per-terrainset pointer ENUMERATION used by <c>MakeAllDataLength</c> via
+        /// <see cref="MapTerrainLookupCore"/> is irrelevant to this per-STRUCT-field
+        /// <c>MakeDataLength</c>, which receives a SINGLE pointer).</para>
+        /// </summary>
+        public static void EmitMapTerrainLookupPointer(ROM rom, List<Address> list, uint pointer, string info)
+        {
+            // FixedCount walk: IsDataExists = i < map_terrain_type_count (getBlockDataCount stops at
+            // addr+1 > Length on EOF too, so the count is min(map_terrain_type_count, span-to-EOF)).
+            uint count = rom.RomInfo.map_terrain_type_count;
+            EmitPatchStructBlockListIFR(rom, list, pointer, info, 1,
+                (i, a) => i < count);
+        }
+
+        /// <summary>
+        /// Shared per-STRUCT-field InputFormRef emitter for the SME/CLASS/TERRAIN/BG arms - the verbatim
+        /// effect of WF <c>InputFormRef.ReInitPointer(pointer)</c> +
+        /// <c>AddressWinForms.AddAddress(list, IFR, info, {})</c>: deref <paramref name="pointer"/> to the
+        /// table base, count entries via <c>getBlockDataCount(base, blockSize, isDataExists)</c>, and emit
+        /// ONE <see cref="Address.DataTypeEnum.InputFormRef"/> Address of length
+        /// <c>blockSize*(count+1)</c> (the slot is the Address pointer; empty pointerIndexes; the same
+        /// shape as <see cref="Address.AddAddressInstantIFR"/>). EOF-HARDENING: guard the full 4-byte slot
+        /// (slot+3) BEFORE <see cref="Address.AddAddressInstantIFR"/> (which only gates
+        /// <c>isSafetyOffset(pointer)</c> before its own p32) so a near-EOF pointer is a clean skip; the
+        /// count walk is bounded by getBlockDataCount <c>addr+blockSize&lt;=Length</c> stop.
+        /// </summary>
+        static void EmitPatchStructBlockListIFR(ROM rom, List<Address> list, uint pointer, string info,
+            uint blockSize, Func<int, uint, bool> isDataExists)
+        {
+            // WF ReInitPointer: BasePointer = toOffset(pointer); BaseAddress = p32(pointer). Guard the
+            // full slot before the p32 deref (AddAddressInstantIFR only checks isSafetyOffset(pointer)).
+            pointer = U.toOffset(pointer);
+            if (!U.isSafetyOffset(pointer, rom))
+            {
+                return;
+            }
+            if (!U.isSafetyOffset(pointer + 3, rom))
+            {
+                return;
+            }
+            uint baseAddr = rom.p32(pointer);
+            if (!U.isSafetyOffset(baseAddr, rom))
+            {
+                return; // WF AddAddress early-returns when !isSafetyOffset(BaseAddress).
+            }
+            // WF Init: getBlockDataCount(BaseAddress, IsDataExistsCallback, NextAddrCallback, BlockSize).
+            // None of these four forms overrides NextAddrCallback, so the 3-arg blockSize-strided walk is
+            // identical. AddAddressInstantIFR then re-derefs pointer (== baseAddr) and emits length
+            // blockSize*(count+1) - matching AddressWinForms.AddAddress(IFR, ..., {}).
+            uint count = rom.getBlockDataCount(baseAddr, blockSize, isDataExists);
+            Address.AddAddressInstantIFR(list, pointer, blockSize, count, info, new uint[] { });
         }
 
         // -------------------------------------------------------------------------------------------
@@ -13077,11 +13298,14 @@ namespace FEBuilderGBA
         //       CalcRomTcsLength / CalcProcsLengthAndCheck, all already in Core). PROCS SKIPS on
         //       CalcProcsLengthAndCheck == NOT_FOUND (WF AddProcsAddress: never a guessed length).
         //       No longer interim.
-        //   (C) the REMAINING FORM-BOUND arms (BATTLEANIMEPOINTER/
-        //       VENNOUWEAPONLOCK/SMEPROMOLIST/CLASSLIST/TERRAINBATTLELISTPOINTER/
-        //       BATTLEBGLISTPOINTER/AOERANGEPOINTER) — routed
+        //   (C') the SIX deterministic FORM-BOUND arms (VENNOUWEAPONLOCK/AOERANGEPOINTER/
+        //       SMEPROMOLIST/CLASSLIST/TERRAINBATTLELISTPOINTER/BATTLEBGLISTPOINTER) - ported
+        //       REAL in s2pf-9 (WF 6691-6724): each is a DETERMINISTIC pure-ROM length walk
+        //       (0x00-terminator BIN / 4+w*h BIN / block-2 u16!=0 IFR / block-1 u8!=0 IFR /
+        //       fixed map_terrain_type_count IFR) reproduced VERBATIM. No longer interim.
+        //   (D) the LAST remaining FORM-BOUND arm (BATTLEANIMEPOINTER) - routed
         //       through the SAME `default` -> AddPointer(...,MIX) path as a DOCUMENTED
-        //       INTERIM (each marked `INTERIM default-MIX -> upgraded in s2pf-N`).
+        //       INTERIM (marked `INTERIM default-MIX -> upgraded in s2pf-10`).
         //       This is SAFE because the gate token "PatchForm(MakePatchStructDataList)"
         //       STAYS in AsmNotYetPortedRaw — no live rebuild runs until s2pf-11 — but
         //       it MUST be upgraded before the token is removed, else those embedded
@@ -13091,12 +13315,12 @@ namespace FEBuilderGBA
         //     EVENT                     -> s2pf-6  DONE (EmitScanScript, disasm-gated)
         //     PatchImage_HEADERTSA      -> s2pf-7  DONE (EmitHeaderTsaPointer / CalcHeaderTsaLength)
         //     AP / ROMTCS / PROCS       -> s2pf-8  DONE (EmitApPointer / EmitRomTcsPointer / EmitProcsPointer)
-        //     VENNOUWEAPONLOCK          -> s2pf-9
-        //     AOERANGEPOINTER           -> s2pf-9
-        //     SMEPROMOLIST              -> s2pf-9
-        //     CLASSLIST                 -> s2pf-9
-        //     TERRAINBATTLELISTPOINTER  -> s2pf-9
-        //     BATTLEBGLISTPOINTER       -> s2pf-9
+        //     VENNOUWEAPONLOCK          -> s2pf-9  DONE (EmitVennouWeaponLockPointer / 0x00-terminator BIN)
+        //     AOERANGEPOINTER           -> s2pf-9  DONE (EmitAoeRangePointer / 4+w*h BIN)
+        //     SMEPROMOLIST              -> s2pf-9  DONE (EmitSmePromoListPointer / block-2 u16!=0 IFR)
+        //     CLASSLIST                 -> s2pf-9  DONE (EmitSomeClassListPointer / block-1 u8!=0 IFR)
+        //     TERRAINBATTLELISTPOINTER  -> s2pf-9  DONE (EmitMapTerrainLookupPointer / fixed map_terrain_type_count IFR)
+        //     BATTLEBGLISTPOINTER       -> s2pf-9  DONE (EmitMapTerrainLookupPointer / fixed map_terrain_type_count IFR)
         //     BATTLEANIMEPOINTER        -> s2pf-10
         //
         // FAITHFULNESS NOTE — the WF 6624-6632 COPY-PASTE DEFECT is REPRODUCED
@@ -13523,33 +13747,49 @@ namespace FEBuilderGBA
                 // partial WF-parity test EXCLUDES these types.
 
                 case "VENNOUWEAPONLOCK":
-                    // INTERIM default-MIX -> upgraded in s2pf-9 (VennouWeaponLockForm.MakeDataLength).
-                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    // WF 6691-6695: VennouWeaponLockForm.MakeDataLength(list, p, patchname + " DATA " + n)
+                    // -> EmitVennouWeaponLockPointer (deref u32(p), then a 0x00-terminator BIN scan;
+                    // length = end - start with the WF start+1 off-by-one). EmitVennouWeaponLockPointer
+                    // self-guards the slot + the deref; the slot+3 pre-gate makes a near-EOF p a clean skip.
+                    EmitVennouWeaponLockPointer(rom, list, p, patchname + " DATA " + n);
                     break;
 
                 case "AOERANGEPOINTER":
-                    // INTERIM default-MIX -> upgraded in s2pf-9 (AOERANGEForm.MakeDataLength).
-                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    // WF 6720-6724: AOERANGEForm.MakeDataLength(list, p, patchname + " DATA " + n)
+                    // -> EmitAoeRangePointer (deref p32(p), w=u8(+0)/h=u8(+1), length = EXACTLY 4 + w*h, BIN).
+                    // EmitAoeRangePointer self-guards the slot + addr + the w/h read extent.
+                    EmitAoeRangePointer(rom, list, p, patchname + " DATA " + n);
                     break;
 
                 case "SMEPROMOLIST":
-                    // INTERIM default-MIX -> upgraded in s2pf-9 (SMEPromoListForm.MakeDataLength).
-                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    // WF 6696-6700: SMEPromoListForm.MakeDataLength(list, p, patchname + " DATA " + n)
+                    // -> EmitSmePromoListPointer (IFR, block 2, count = getBlockDataCount(base, 2, u16!=0),
+                    // length = 2*(count+1)). Self-guards the slot + the deref.
+                    EmitSmePromoListPointer(rom, list, p, patchname + " DATA " + n);
                     break;
 
                 case "CLASSLIST":
-                    // INTERIM default-MIX -> upgraded in s2pf-9 (SomeClassListForm.MakeDataLength).
-                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    // WF 6701-6705: SomeClassListForm.MakeDataLength(list, p, patchname + " DATA " + n)
+                    // -> EmitSomeClassListPointer (IFR, block 1, count = getBlockDataCount(base, 1, u8!=0),
+                    // length = 1*(count+1)). Self-guards the slot + the deref.
+                    EmitSomeClassListPointer(rom, list, p, patchname + " DATA " + n);
                     break;
 
                 case "TERRAINBATTLELISTPOINTER":
-                    // INTERIM default-MIX -> upgraded in s2pf-9 (MapTerrainFloorLookupTableForm.MakeDataLength).
-                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    // WF 6706-6710: MapTerrainFloorLookupTableForm.MakeDataLength(list, p, patchname +
+                    // " DATA " + n) -> EmitMapTerrainLookupPointer (IFR, block 1, FIXED count =
+                    // rom.RomInfo.map_terrain_type_count [NOT a terminator scan], length = 1*(count+1)).
+                    // BOTH terrain forms use the same map_terrain_type_count count field. Self-guards
+                    // the slot + the deref.
+                    EmitMapTerrainLookupPointer(rom, list, p, patchname + " DATA " + n);
                     break;
 
                 case "BATTLEBGLISTPOINTER":
-                    // INTERIM default-MIX -> upgraded in s2pf-9 (MapTerrainBGLookupTableForm.MakeDataLength).
-                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    // WF 6711-6715: MapTerrainBGLookupTableForm.MakeDataLength(list, p, patchname +
+                    // " DATA " + n) -> EmitMapTerrainLookupPointer (same FIXED-count IFR as
+                    // TERRAINBATTLELISTPOINTER: block 1, count = rom.RomInfo.map_terrain_type_count,
+                    // length = 1*(count+1) - the WF BG form shares the Floor form Init walk verbatim).
+                    EmitMapTerrainLookupPointer(rom, list, p, patchname + " DATA " + n);
                     break;
 
                 case "BATTLEANIMEPOINTER":

--- a/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
+++ b/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -500,7 +500,7 @@ namespace FEBuilderGBA.Tests.Unit
         }
 
         /// <summary>
-        /// PARTIAL WF-parity for #1261 slice s2pf-5/6 — the PatchForm producer TYPE=STRUCT dispatch arm
+        /// PARTIAL WF-parity for #1261 slice s2pf-5..9 — the PatchForm producer TYPE=STRUCT dispatch arm
         /// (<see cref="RebuildProducerCore.EmitPatchStruct"/>). Both the WinForms reference
         /// (<c>PatchForm.MakePatchStructDataList</c> -&gt; <c>MakePatchStructDataListForSTRUCT</c>,
         /// PatchForm.cs:6461) and the Core orchestrator
@@ -528,14 +528,22 @@ namespace FEBuilderGBA.Tests.Unit
         /// <c>CalcRomTcsLength</c>/<c>CalcProcsLengthAndCheck</c>); their named info tokens + data types are
         /// compared on BOTH sides. PROCS skips on NOT_FOUND (no entry on either side for a non-PROCS
         /// target — WF AddProcsAddress and Core EmitProcsPointer both return without emitting).</para>
-        /// <para><b>THE REMAINING INTERIM FORM-BOUND ARMS ARE EXCLUDED (deferred to s2pf-9..10).</b> The
-        /// BATTLEANIMEPOINTER/VENNOUWEAPONLOCK/SMEPROMOLIST/CLASSLIST/
-        /// TERRAINBATTLELISTPOINTER/BATTLEBGLISTPOINTER/AOERANGEPOINTER fields are
+        /// <para><b>THE SIX DETERMINISTIC FORM-BOUND ARMS ARE NOW INCLUDED (s2pf-9).</b> The
+        /// VENNOUWEAPONLOCK/AOERANGEPOINTER/SMEPROMOLIST/CLASSLIST/TERRAINBATTLELISTPOINTER/
+        /// BATTLEBGLISTPOINTER fields emit a precise <c>@STRUCT DATA n</c> entry (VENNOU/AOE -&gt; BIN;
+        /// SME/CLASS/Terrain/BG -&gt; InputFormRef) via
+        /// <see cref="RebuildProducerCore.EmitVennouWeaponLockPointer"/>/
+        /// <see cref="RebuildProducerCore.EmitAoeRangePointer"/>/
+        /// <see cref="RebuildProducerCore.EmitSmePromoListPointer"/>/
+        /// <see cref="RebuildProducerCore.EmitSomeClassListPointer"/>/
+        /// <see cref="RebuildProducerCore.EmitMapTerrainLookupPointer"/>; being non-MIX they pass the
+        /// <c>@STRUCT DATA n</c> non-MIX include filter and are compared Core — WF on BOTH sides.</para>
+        /// <para><b>ONLY BATTLEANIMEPOINTER IS STILL EXCLUDED (deferred to s2pf-10).</b> It alone is
         /// routed through Core's INTERIM default-MIX (a length-0 MIX entry named <c>... DATA n</c>) this
-        /// slice — they INTENTIONALLY diverge from WF (WF emits the precise sub-walked TARGET region). So
-        /// every MIX-typed <c>... DATA </c>-suffixed entry is filtered OUT of BOTH sides before the
-        /// comparison. Those arms gain their own parity teeth in s2pf-9..10, and the FULL STRUCT parity
-        /// (no exclusions) lands at s2pf-11 when the gate token is removed.</para>
+        /// slice — it INTENTIONALLY diverges from WF (WF emits the precise sub-walked TARGET region). So the
+        /// MIX-typed <c>@STRUCT DATA n</c> entry is filtered OUT of BOTH sides before the comparison. That
+        /// arm gains its own parity teeth in s2pf-10, and the FULL STRUCT parity (no exclusions) lands at
+        /// s2pf-11 when the gate token is removed.</para>
         /// <para><b>CSTRING is NOT in the merged-list parity scope:</b> WF/Core both name a CSTRING entry
         /// the DECODED STRING (no <c>@STRUCT</c> marker), so it cannot be reliably attributed to a STRUCT
         /// patch within the merged producer list. The CSTRING arm's byte-faithfulness is carried by the
@@ -588,16 +596,21 @@ namespace FEBuilderGBA.Tests.Unit
                 // PALETTE) OR an AP/ROMTCS/PROCS arm (s2pf-8: "@STRUCT AP/ROMTCS/PROCS n", typed
                 // AP/ROMTCS/PROCS) OR an EVENT-walk entry (s2pf-6: the "@STRUCT DATA n" entries the
                 // EventScriptForm.ScanScript walk emits — EVENTSCRIPT script blocks + their
-                // POINTER_UNIT/AICOORDINATE sub-data IFR/BIN blocks). The STILL-INTERIM form-bound arms
-                // (Vennou/AOE/SMEPromo/SomeClass/Terrain* s2pf-9 / BattleAnime s2pf-10) emit
-                // "@STRUCT DATA n" as a length-0 MIX placeholder — those DIVERGE from WF this slice and are
+                // POINTER_UNIT/AICOORDINATE sub-data IFR/BIN blocks). The s2pf-9 form-bound arms
+                // (Vennou/AOE -> BIN, SMEPromo/SomeClass/Terrain* -> IFR) now emit a PRECISE non-MIX
+                // "@STRUCT DATA n" entry (INCLUDE). The LAST still-interim arm, BattleAnime (s2pf-10), emits
+                // "@STRUCT DATA n" as a length-0 MIX placeholder — it DIVERGES from WF this slice and is
                 // EXCLUDED. Since EmitPatchStructDefaultMix is the ONLY producer of a MIX-typed "@STRUCT
                 // DATA " entry, a simple rule cleanly separates the two: a MIX-typed DATA entry is interim
-                // (EXCLUDE), any other DATA entry came from the now-precise EVENT walk (INCLUDE).
+                // (EXCLUDE), any other DATA entry came from a now-precise arm — the EVENT walk (s2pf-6) or
+                // one of the six s2pf-9 forms (INCLUDE).
                 // PatchImage_HEADERTSA is now precise (s2pf-7), emitting a "@STRUCT HEADERTSA n" / HEADERTSA
                 // entry — INCLUDED via the safeArmTokens. AP/ROMTCS/PROCS are now precise (s2pf-8), emitting
                 // "@STRUCT AP/ROMTCS/PROCS n" — INCLUDED via the safeArmTokens (their named, non-DATA info
-                // tokens). CSTRING is out of merged-list scope (named the decoded string) — see doc-comment.
+                // tokens). The six s2pf-9 forms (Vennou/AOE/SME/Class/Terrain/BG) emit "@STRUCT DATA n" with
+                // a non-MIX type, so they are INCLUDED by the non-MIX DATA rule above (NOT the safeArmTokens
+                // list, which keys on named non-DATA tokens). CSTRING is out of merged-list scope (named the
+                // decoded string) — see doc-comment.
                 string[] safeArmTokens = { " ASM ", " IMAGE ", " TSA ", " ZTSA ", " ZHEADERTSA ", " HEADERTSA ", " PALETTE ", " AP ", " ROMTCS ", " PROCS " };
                 bool IsImplementedStructEntry(Address a)
                 {


### PR DESCRIPTION
## Summary

#1261 option-B PatchForm producer epic, sub-slice **9/11**. Faithful WinForms→Core port of the **six deterministic embedded-pointer STRUCT field arms** in `EmitPatchStructEntry` (`RebuildProducerCore`), upgrading them from the interim `EmitPatchStructDefaultMix` placeholder to precise length-walked targets. Each is a verbatim reproduction of the WF `XxxForm.MakeDataLength` dispatched from `PatchForm.cs`.

### The 6 forms (WF `PatchForm.cs` arm → form helper)
| Type | WF arm | Length rule | DataType |
|------|--------|-------------|----------|
| **VENNOUWEAPONLOCK** | 6693 → `VennouWeaponLockForm.MakeDataLength` | `0x00`-terminator scan (`start+1` off-by-one), `end - start` | BIN |
| **AOERANGEPOINTER** | 6722 → `AOERANGEForm.MakeDataLength` | EXACTLY `4 + (w*h)` (`w@+0`, `h@+1`) | BIN |
| **SMEPROMOLIST** | 6698 → `SMEPromoListForm.MakeDataLength` | block-2 IFR, `2*(count+1)`, count=`getBlockDataCount(addr,2,u16!=0)` | InputFormRef |
| **CLASSLIST** | 6703 → `SomeClassListForm.MakeDataLength` | block-1 IFR, `1*(count+1)`, count=`getBlockDataCount(addr,1,u8!=0)` | InputFormRef |
| **TERRAINBATTLELISTPOINTER** | 6708 → `MapTerrainFloorLookupTableForm.MakeDataLength` | block-1 IFR, **FIXED** `1*(map_terrain_type_count+1)` | InputFormRef |
| **BATTLEBGLISTPOINTER** | 6713 → `MapTerrainBGLookupTableForm.MakeDataLength` | same FIXED-count IFR as above | InputFormRef |

**Terrain forms use the FIXED `rom.RomInfo.map_terrain_type_count`, NOT a terminator scan** — a scan would over/under-count and corrupt relocation. Both Floor and BG share the one count field.

### Reused Core helpers vs new
- **Reused (no re-port):** `rom.getBlockDataCount`, `Address.AddAddressInstantIFR` / `Address.AddAddress`, `U.isSafetyOffset`/`isSafetyPointer`/`toOffset`, `rom.p32`/`u32`/`u8`/`u16`, `rom.RomInfo.map_terrain_type_count`.
- **New emitters:** `EmitVennouWeaponLockPointer` (+`CalcVennouWeaponLockLength`), `EmitAoeRangePointer`, `EmitSmePromoListPointer`, `EmitSomeClassListPointer`, `EmitMapTerrainLookupPointer`, and the shared `EmitPatchStructBlockListIFR`.
- `MapTerrainLookupCore.GetPointers*` is the `MakeAllDataLength` per-terrainset enumeration, **not** this per-STRUCT-field `MakeDataLength` (single pointer) — intentionally not reused (import-adapted-helper trap avoided).

### Invariants preserved
- Gate token `"PatchForm(MakePatchStructDataList)"` **STAYS** in `AsmNotYetPortedRaw` (orchestrator not wired live until s2pf-11).
- `MakePatchStructDataListCore_NoPatchDir_EmitsNothing_NoThrow` still passes.
- EOF-guarded every computed read (`slot+3` before u32/p32, `addr+1` before the u8 pair; count walks bounded by `getBlockDataCount`).
- **9/11** — only **BATTLEANIMEPOINTER** remains interim default-MIX (→ s2pf-10).

## Scope
Closes #1319. Part of #1261.

## Test plan
- [x] +14 RebuildProducer Core.Tests cases (618 → **632**, 0 failed), incl. the no-patch-dir invariant: Vennou terminator off-by-one + terminator-at-start (length≥1), AOE `4+w*h` + zero-box, SME block-2 u16 + Class block-1 u8 boundaries, Terrain/BG fixed-count (planted early `0x00` proves it is **not** a terminator scan), unsafe-target no-emit, near-EOF no-throw.
- [x] WF-parity STRUCT test (real FE8U, `FEBuilderGBA.Tests`) extended to INCLUDE all 6 forms (non-MIX `@STRUCT DATA n` passes the include filter); only BATTLEANIMEPOINTER stays excluded — runs non-vacuously against the main checkout's `roms/FE8U.gba` (Core ⊆ WF held).
- [x] `dotnet build FEBuilderGBA.sln` clean (0 errors).
- [x] The ~10 `Skill*` Core.Tests failures are the known un-checked-out `config/patch2` submodule env issue (pass in CI), not a regression.

Core-only change — no GUI, no screenshot required.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
