### PR TITLE
feat(core): PatchForm STRUCT BATTLEANIMEPOINTER arm — last interim arm (#1261 s2pf-10)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchStructTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchStructTests.cs
@@ -584,42 +584,23 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         // ====================================================================
-        // 4. The FORM-BOUND arms -> INTERIM default-MIX (this slice ONLY)
+        // 4. The FORM-BOUND arms -> ALL PRECISE as of s2pf-10 (NO interim remains)
         // ====================================================================
 
-        // Each interim form-bound type is routed through the same default-MIX placeholder as an
-        // unknown type. THIS IS INTENTIONAL FOR s2pf-5: the precise sub-walked TARGET length is
-        // ported in s2pf-9..10. The test asserts the INTERIM placeholder (length-0 MIX), NOT a
-        // precise WF length — the partial WF-parity test EXCLUDES these types accordingly.
-        // NOTE: EVENT was REMOVED from this interim group in s2pf-6 (it runs the real
-        // EventScriptForm.ScanScript walk — see EmitPatchStruct_EventArm_*),
-        // PatchImage_HEADERTSA in s2pf-7 (it runs EmitHeaderTsaPointer — see
-        // EmitPatchStruct_HeaderTsaField_* below), AP/ROMTCS/PROCS in s2pf-8 (they run
-        // EmitApPointer/EmitRomTcsPointer/EmitProcsPointer — see EmitPatchStruct_ApField_* /
-        // _RomTcsField_* / _ProcsField_* below), and the SIX deterministic STRUCT forms
-        // (VENNOUWEAPONLOCK/AOERANGEPOINTER/SMEPROMOLIST/CLASSLIST/TERRAINBATTLELISTPOINTER/
-        // BATTLEBGLISTPOINTER) in s2pf-9 (they run the precise length-walks — see
-        // EmitPatchStruct_VennouWeaponLockField_* etc. below). Only BATTLEANIMEPOINTER (s2pf-10)
-        // remains interim default-MIX.
-        [Theory]
-        [InlineData("BATTLEANIMEPOINTER")]        // -> s2pf-10 (the LAST interim form-bound arm)
-        public void EmitPatchStruct_FormBoundArm_IsInterimDefaultMix(string fieldType)
-        {
-            var rom = MakeRom();
-            const uint table = 0x2000;
-            PlantPointer(rom, table + 0, 0x9000);
-            var list = new List<Address>();
-            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("FB",
-                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
-                ("DATASIZE", "4"), ("DATACOUNT", "1"),
-                ("P0:" + fieldType, "0")), isPointerOnly: false);
-
-            // INTERIM: emitted as the length-0 MIX placeholder (NOT the precise sub-walked region).
-            var mix = Assert.Single(list, a => a.DataType == Address.DataTypeEnum.MIX);
-            Assert.Equal(0x9000u, mix.Addr);
-            Assert.Equal(0u, mix.Length);
-            Assert.EndsWith("DATA 0", mix.Info);
-        }
+        // Every STRUCT form-bound type now emits its precise WF sub-walked TARGET region — the
+        // INTERIM default-MIX group is EMPTY. The historic interim placeholder test
+        // (EmitPatchStruct_FormBoundArm_IsInterimDefaultMix) was REMOVED in s2pf-10 because its sole
+        // remaining InlineData, BATTLEANIMEPOINTER, is now precise (see
+        // EmitPatchStruct_BattleAnimeField_* below). The migration order was: EVENT (s2pf-6, real
+        // EventScriptForm.ScanScript walk — EmitPatchStruct_EventArm_*), PatchImage_HEADERTSA (s2pf-7,
+        // EmitHeaderTsaPointer — EmitPatchStruct_HeaderTsaField_*), AP/ROMTCS/PROCS (s2pf-8,
+        // EmitApPointer/EmitRomTcsPointer/EmitProcsPointer — EmitPatchStruct_ApField_* / _RomTcsField_* /
+        // _ProcsField_*), the SIX deterministic STRUCT forms (s2pf-9, VENNOUWEAPONLOCK/AOERANGEPOINTER/
+        // SMEPROMOLIST/CLASSLIST/TERRAINBATTLELISTPOINTER/BATTLEBGLISTPOINTER — the precise length-walks
+        // EmitPatchStruct_VennouWeaponLockField_* etc.), and finally BATTLEANIMEPOINTER (s2pf-10, the LAST
+        // — block-4 u32!=0 SETTING IFR). The partial WF-parity comparison now covers ALL form-bound types
+        // (no exclusions); only WF's genuine `default` (unknown pointer -> length-0 MIX, which keeps the
+        // TARGET tracked) remains a length-0 MIX, which IS faithful to WF.
 
         // ====================================================================
         // 4a'. The AP / ROMTCS / PROCS arms (s2pf-8) — the REAL pointer-emitters
@@ -947,6 +928,63 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.MIX);
         }
 
+        // ---- s2pf-10: BATTLEANIMEPOINTER — the LAST interim form-bound arm, now precise.
+        //      WF ImageBattleAnimeForm.MakeBattleAnimeSettingDataLength (PatchForm.cs:6558): the per-field
+        //      SETTING walk = Init(null) (block 4, IsDataExists u32(addr+0)!=0) -> ReInitPointer(p) ->
+        //      AddAddress(IFR, name, new uint[]{}) (EMPTY pointerIndexes). length = 4*(count+1). This is
+        //      NOT the slice-2s full-path per-class MakeAllDataLength (EmitImageBattleAnime).
+
+        [Fact]
+        public void EmitPatchStruct_BattleAnimeField_EmitsBlock4U32Ifr_EmptyPI()
+        {
+            // Plant 3 non-zero u32 setting entries then a 0x00000000 terminator -> count = 3,
+            // length = 4*(3+1) = 16, block 4, type InputFormRef, EMPTY pointerIndexes.
+            var rom = MakeRom();
+            const uint table = 0x2000, target = 0x8000;
+            PlantPointer(rom, table + 0, target);
+            rom.write_u32(target + 0, 0x11223344);
+            rom.write_u32(target + 4, 0x55667788);
+            rom.write_u32(target + 8, 0x99AABBCC);
+            rom.write_u32(target + 12, 0x00000000); // terminator (u32 == 0)
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("BA",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:BATTLEANIMEPOINTER", "0")), isPointerOnly: false);
+
+            var a = Assert.Single(list, x => x.DataType == Address.DataTypeEnum.InputFormRef
+                && x.Pointer == table + 0);
+            Assert.Equal(target, a.Addr);
+            Assert.Equal(4u * (3u + 1u), a.Length); // 16
+            Assert.Equal(4u, a.BlockSize);
+            Assert.EndsWith("DATA 0", a.Info);
+            // EMPTY pointerIndexes — the setting block is flat (no embedded sub-pointers to walk).
+            Assert.Empty(a.PointerIndexes);
+            // NOT the interim default-MIX placeholder.
+            Assert.DoesNotContain(list, x => x.DataType == Address.DataTypeEnum.MIX);
+        }
+
+        [Fact]
+        public void EmitPatchStruct_BattleAnimeField_ImmediateTerminator_LengthIsFour()
+        {
+            // u32 == 0 at the very base -> count = 0, length = 4*(0+1) = 4 (the lone terminator slot).
+            var rom = MakeRom();
+            const uint table = 0x2000, target = 0x8000;
+            PlantPointer(rom, table + 0, target);
+            rom.write_u32(target + 0, 0x00000000); // terminator at base
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("BA0",
+                ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
+                ("DATASIZE", "4"), ("DATACOUNT", "1"),
+                ("P0:BATTLEANIMEPOINTER", "0")), isPointerOnly: false);
+
+            var a = Assert.Single(list, x => x.DataType == Address.DataTypeEnum.InputFormRef
+                && x.Pointer == table + 0);
+            Assert.Equal(target, a.Addr);
+            Assert.Equal(4u, a.Length); // 4*(0+1)
+            Assert.Equal(4u, a.BlockSize);
+        }
+
         [Theory]
         [InlineData("TERRAINBATTLELISTPOINTER")]
         [InlineData("BATTLEBGLISTPOINTER")]
@@ -987,15 +1025,16 @@ namespace FEBuilderGBA.Core.Tests
         [InlineData("CLASSLIST")]
         [InlineData("TERRAINBATTLELISTPOINTER")]
         [InlineData("BATTLEBGLISTPOINTER")]
-        public void EmitPatchStruct_S2pf9Field_UnsafeTarget_EmitsNothing(string fieldType)
+        [InlineData("BATTLEANIMEPOINTER")] // s2pf-10
+        public void EmitPatchStruct_FormBoundField_UnsafeTarget_EmitsNothing(string fieldType)
         {
-            // The slot derefs below the 0x200 safety floor -> every s2pf-9 arm skips (no emission,
-            // and NOT the interim default-MIX placeholder either).
+            // The slot derefs below the 0x200 safety floor -> every precise form-bound arm skips
+            // (no emission, and NOT a default-MIX placeholder either).
             var rom = MakeRom();
             const uint table = 0x2000;
             U.write_u32(rom.Data, table + 0, U.toPointer(0x100)); // target below safety floor
             var list = new List<Address>();
-            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("US9",
+            RebuildProducerCore.EmitPatchStruct(rom, list, MakePatch("USB",
                 ("TYPE", "STRUCT"), ("ADDRESS", "0x2000"),
                 ("DATASIZE", "4"), ("DATACOUNT", "1"),
                 ("P0:" + fieldType, "0")), isPointerOnly: false);
@@ -1013,7 +1052,8 @@ namespace FEBuilderGBA.Core.Tests
         [InlineData("CLASSLIST")]
         [InlineData("TERRAINBATTLELISTPOINTER")]
         [InlineData("BATTLEBGLISTPOINTER")]
-        public void EmitPatchStruct_S2pf9Field_SlotNearEof_NoThrow(string fieldType)
+        [InlineData("BATTLEANIMEPOINTER")] // s2pf-10
+        public void EmitPatchStruct_FormBoundField_SlotNearEof_NoThrow(string fieldType)
         {
             // A pointer FIELD sitting in the last 3 bytes -> the slot+3 EOF guard makes a clean skip
             // (no throw) rather than reading p32/u32 past EOF.

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -2504,8 +2504,33 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
-        /// Shared per-STRUCT-field InputFormRef emitter for the SME/CLASS/TERRAIN/BG arms - the verbatim
-        /// effect of WF <c>InputFormRef.ReInitPointer(pointer)</c> +
+        /// Reproduces WinForms <c>ImageBattleAnimeForm.MakeBattleAnimeSettingDataLength(list, pointer,
+        /// selfname)</c> (FEBuilderGBA/ImageBattleAnimeForm.cs:876; the STRUCT arm at PatchForm.cs:6558,
+        /// type BATTLEANIMEPOINTER): the <paramref name="pointer"/> slot holds a 32-bit ROM pointer to a
+        /// battle-anime SETTING block (block size 4, terminated by the first <c>u32 == 0</c>); emit ONE
+        /// <see cref="Address.DataTypeEnum.InputFormRef"/> Address of length <c>4*(count+1)</c> where
+        /// <c>count = getBlockDataCount(addr, 4, u32!=0)</c>.
+        /// <para><b>This is the per-STRUCT-field <c>MakeDataLength</c> SETTING walk, NOT the full-path
+        /// per-class/N_-table <c>MakeAllDataLength</c></b> (that walk - the slice-2s
+        /// <c>EmitImageBattleAnime</c> / <c>ImageBattleAnime*ImportCore</c> port - enumerates EVERY class's
+        /// animation list and is irrelevant here, where the arm receives a SINGLE setting pointer). WF's
+        /// <c>MakeBattleAnimeSettingDataLength</c> is exactly <c>Init(null)</c> (block 4, IsDataExists
+        /// <c>u32(addr+0) != 0</c>; ImageBattleAnimeForm.cs:74-82) -> <c>ReInitPointer(pointer)</c> ->
+        /// <c>AddressWinForms.AddAddress(list, IFR, selfname, new uint[]{})</c> (EMPTY pointerIndexes - the
+        /// setting block is flat, no embedded sub-pointers to walk). That is the IDENTICAL ReInitPointer +
+        /// empty-PI shape as the s2pf-9 SME/CLASS/TERRAIN/BG arms, so this reuses the shared
+        /// <see cref="EmitPatchStructBlockListIFR"/> helper with blockSize 4 and predicate <c>u32 != 0</c>
+        /// (same EOF-hardening: the full-slot slot+3 guard before the p32 deref).</para>
+        /// </summary>
+        public static void EmitBattleAnimeSettingPointer(ROM rom, List<Address> list, uint pointer, string info)
+        {
+            EmitPatchStructBlockListIFR(rom, list, pointer, info, 4,
+                (i, a) => rom.u32(a) != 0);
+        }
+
+        /// <summary>
+        /// Shared per-STRUCT-field InputFormRef emitter for the SME/CLASS/TERRAIN/BG/BATTLEANIME arms - the
+        /// verbatim effect of WF <c>InputFormRef.ReInitPointer(pointer)</c> +
         /// <c>AddressWinForms.AddAddress(list, IFR, info, {})</c>: deref <paramref name="pointer"/> to the
         /// table base, count entries via <c>getBlockDataCount(base, blockSize, isDataExists)</c>, and emit
         /// ONE <see cref="Address.DataTypeEnum.InputFormRef"/> Address of length
@@ -13306,15 +13331,17 @@ namespace FEBuilderGBA
         //       REAL in s2pf-9 (WF 6691-6724): each is a DETERMINISTIC pure-ROM length walk
         //       (0x00-terminator BIN / 4+w*h BIN / block-2 u16!=0 IFR / block-1 u8!=0 IFR /
         //       fixed map_terrain_type_count IFR) reproduced VERBATIM. No longer interim.
-        //   (D) the LAST remaining FORM-BOUND arm (BATTLEANIMEPOINTER) - routed
-        //       through the SAME `default` -> AddPointer(...,MIX) path as a DOCUMENTED
-        //       INTERIM (marked `INTERIM default-MIX -> upgraded in s2pf-10`).
-        //       This is SAFE because the gate token "PatchForm(MakePatchStructDataList)"
-        //       STAYS in AsmNotYetPortedRaw — no live rebuild runs until s2pf-11 — but
-        //       it MUST be upgraded before the token is removed, else those embedded
-        //       pointers' TARGET regions are never relocated (residue corruption).
+        //   (D) BATTLEANIMEPOINTER — ported REAL in s2pf-10 (WF 6558-6561): the per-STRUCT-field
+        //       SETTING walk ImageBattleAnimeForm.MakeBattleAnimeSettingDataLength (Init block 4,
+        //       IsDataExists u32(addr+0)!=0; ReInitPointer; AddAddress empty-PI) reproduced VERBATIM as
+        //       EmitBattleAnimeSettingPointer (the shared EmitPatchStructBlockListIFR with blockSize 4 +
+        //       predicate u32!=0, length 4*(count+1), EMPTY pointerIndexes). This is the per-field
+        //       MakeDataLength SETTING block — NOT the full-path per-class MakeAllDataLength (slice-2s
+        //       EmitImageBattleAnime). With this the INTERIM default-MIX group is EMPTY: EVERY STRUCT
+        //       form-bound arm is now precise; only WF's genuine `default` (unknown pointer -> length-0
+        //       MIX, which keeps the TARGET tracked — NOT a shortcut) + the EA/BIN no-op stubs remain.
         //
-        //   INTERIM default-MIX -> precise-arm UPGRADE MAP (audit table; EVENT + HEADERTSA + AP/ROMTCS/PROCS DONE):
+        //   INTERIM default-MIX -> precise-arm UPGRADE MAP (audit table — ALL DONE, the interim group is now EMPTY):
         //     EVENT                     -> s2pf-6  DONE (EmitScanScript, disasm-gated)
         //     PatchImage_HEADERTSA      -> s2pf-7  DONE (EmitHeaderTsaPointer / CalcHeaderTsaLength)
         //     AP / ROMTCS / PROCS       -> s2pf-8  DONE (EmitApPointer / EmitRomTcsPointer / EmitProcsPointer)
@@ -13324,7 +13351,7 @@ namespace FEBuilderGBA
         //     CLASSLIST                 -> s2pf-9  DONE (EmitSomeClassListPointer / block-1 u8!=0 IFR)
         //     TERRAINBATTLELISTPOINTER  -> s2pf-9  DONE (EmitMapTerrainLookupPointer / fixed map_terrain_type_count IFR)
         //     BATTLEBGLISTPOINTER       -> s2pf-9  DONE (EmitMapTerrainLookupPointer / fixed map_terrain_type_count IFR)
-        //     BATTLEANIMEPOINTER        -> s2pf-10
+        //     BATTLEANIMEPOINTER        -> s2pf-10 DONE (EmitBattleAnimeSettingPointer / block-4 u32!=0 IFR — the LAST)
         //
         // FAITHFULNESS NOTE — the WF 6624-6632 COPY-PASTE DEFECT is REPRODUCED
         // VERBATIM: the SECOND `else if (type == "PatchImage_ZTSA")` (WF 6624) is a
@@ -13353,12 +13380,15 @@ namespace FEBuilderGBA
         /// pointerIndexes[n]</c> IN ORDER, dispatching on the field type via
         /// <see cref="EmitPatchStructEntry"/>.
         /// <para>
-        /// <b>This slice (s2pf-5/6/7)</b> ports the skeleton + the SAFE terminal arms
-        /// (ASM / CSTRING / PatchImage_* / WF's <c>default</c> MIX) + the EVENT arm (s2pf-6: the
+        /// <b>As of s2pf-10 EVERY arm is precise</b> — the skeleton + the SAFE terminal arms
+        /// (ASM / CSTRING / PatchImage_* / WF's genuine <c>default</c> MIX) + the EVENT arm (s2pf-6: the
         /// <see cref="EmitScanScript"/> event-script walk, disasm-gated) + PatchImage_HEADERTSA (s2pf-7:
-        /// <see cref="EmitHeaderTsaPointer"/>). The REMAINING FORM-BOUND arms route through the same MIX
-        /// <c>default</c> as a DOCUMENTED INTERIM (upgraded s2pf-8..10) — SAFE only while the gate token
-        /// stays deferred. See the block comment above.
+        /// <see cref="EmitHeaderTsaPointer"/>) + AP/ROMTCS/PROCS (s2pf-8) + the SIX deterministic
+        /// FORM-BOUND arms (s2pf-9) + BATTLEANIMEPOINTER (s2pf-10:
+        /// <see cref="EmitBattleAnimeSettingPointer"/>). The INTERIM default-MIX group is now EMPTY: only
+        /// WF's genuine <c>default</c> (unknown pointer -> length-0 MIX, which keeps the TARGET tracked) +
+        /// the EA/BIN no-op stubs remain. The gate token stays deferred until s2pf-11 wires the producer.
+        /// See the block comment above.
         /// </para>
         /// </summary>
         /// <param name="rom">ROM to resolve against — passed explicitly. MUST also be
@@ -13743,11 +13773,14 @@ namespace FEBuilderGBA
                     }
                     break;
 
-                // ---- INTERIM default-MIX (this slice) — form-bound arms ---------
-                // Each routes through EmitPatchStructDefaultMix (= WF's own `default`,
-                // length-0 MIX). This DIVERGES from WF (WF emits the precise sub-walked
-                // TARGET region); SAFE only while the gate token stays deferred. The
-                // partial WF-parity test EXCLUDES these types.
+                // ---- PRECISE FORM-BOUND arms (s2pf-9..10 — ALL ported) ----------
+                // Every STRUCT form-bound type below now emits its precise WF sub-walked
+                // TARGET region (NO interim default-MIX remains: VENNOUWEAPONLOCK/
+                // AOERANGEPOINTER/SMEPROMOLIST/CLASSLIST/TERRAINBATTLELISTPOINTER/
+                // BATTLEBGLISTPOINTER in s2pf-9, BATTLEANIMEPOINTER in s2pf-10 — the LAST).
+                // The partial WF-parity test now compares ALL of these (no exclusions). Only
+                // WF's genuine `default` (unknown pointer -> length-0 MIX) + the EA/BIN no-op
+                // stubs remain non-precise, which IS faithful to WF.
 
                 case "VENNOUWEAPONLOCK":
                     // WF 6691-6695: VennouWeaponLockForm.MakeDataLength(list, p, patchname + " DATA " + n)
@@ -13796,8 +13829,14 @@ namespace FEBuilderGBA
                     break;
 
                 case "BATTLEANIMEPOINTER":
-                    // INTERIM default-MIX -> upgraded in s2pf-10 (ImageBattleAnimeForm.MakeBattleAnimeSettingDataLength).
-                    EmitPatchStructDefaultMix(rom, list, p, patchname, n);
+                    // WF 6558-6561: ImageBattleAnimeForm.MakeBattleAnimeSettingDataLength(list, p,
+                    // patchname + " DATA " + n) -> EmitBattleAnimeSettingPointer (IFR, block 4, count =
+                    // getBlockDataCount(base, 4, u32!=0), length = 4*(count+1); EMPTY pointerIndexes - the
+                    // setting block is flat). This is the per-STRUCT-field SETTING walk (WF
+                    // MakeBattleAnimeSettingDataLength = Init+ReInitPointer+empty-PI AddAddress), NOT the
+                    // full-path per-class MakeAllDataLength (slice-2s EmitImageBattleAnime). Self-guards the
+                    // slot + the deref (slot+3 before p32). s2pf-10: the LAST interim form-bound arm.
+                    EmitBattleAnimeSettingPointer(rom, list, p, patchname + " DATA " + n);
                     break;
 
                 default:

--- a/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
+++ b/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
@@ -500,7 +500,7 @@ namespace FEBuilderGBA.Tests.Unit
         }
 
         /// <summary>
-        /// PARTIAL WF-parity for #1261 slice s2pf-5..9 — the PatchForm producer TYPE=STRUCT dispatch arm
+        /// PARTIAL WF-parity for #1261 slice s2pf-5..10 — the PatchForm producer TYPE=STRUCT dispatch arm
         /// (<see cref="RebuildProducerCore.EmitPatchStruct"/>). Both the WinForms reference
         /// (<c>PatchForm.MakePatchStructDataList</c> -&gt; <c>MakePatchStructDataListForSTRUCT</c>,
         /// PatchForm.cs:6461) and the Core orchestrator
@@ -538,12 +538,17 @@ namespace FEBuilderGBA.Tests.Unit
         /// <see cref="RebuildProducerCore.EmitSomeClassListPointer"/>/
         /// <see cref="RebuildProducerCore.EmitMapTerrainLookupPointer"/>; being non-MIX they pass the
         /// <c>@STRUCT DATA n</c> non-MIX include filter and are compared Core — WF on BOTH sides.</para>
-        /// <para><b>ONLY BATTLEANIMEPOINTER IS STILL EXCLUDED (deferred to s2pf-10).</b> It alone is
-        /// routed through Core's INTERIM default-MIX (a length-0 MIX entry named <c>... DATA n</c>) this
-        /// slice — it INTENTIONALLY diverges from WF (WF emits the precise sub-walked TARGET region). So the
-        /// MIX-typed <c>@STRUCT DATA n</c> entry is filtered OUT of BOTH sides before the comparison. That
-        /// arm gains its own parity teeth in s2pf-10, and the FULL STRUCT parity (no exclusions) lands at
-        /// s2pf-11 when the gate token is removed.</para>
+        /// <para><b>BATTLEANIMEPOINTER IS NOW INCLUDED (s2pf-10) — NO FORM-BOUND ARM IS EXCLUDED.</b> It
+        /// emits a precise <c>@STRUCT DATA n</c> InputFormRef (block 4, length <c>4*(count+1)</c>) via
+        /// <see cref="RebuildProducerCore.EmitBattleAnimeSettingPointer"/> (the per-field SETTING walk =
+        /// WF <c>ImageBattleAnimeForm.MakeBattleAnimeSettingDataLength</c>), so being non-MIX it passes the
+        /// <c>@STRUCT DATA n</c> non-MIX include filter and is compared Core — WF on BOTH sides. This makes
+        /// the comparison the <b>FULL set of STRUCT field-type arms</b> (no per-arm exclusions remain). The
+        /// ONLY entries still filtered out are WF's genuine <c>default</c> (unknown-pointer) length-0 MIX
+        /// <c>@STRUCT DATA n</c> entries — which WF emits too, so the MIX-DATA filter is SYMMETRIC (Core and
+        /// WF both drop them) and faithful (a non-ported field type is not a slice-10 arm). The
+        /// orchestrator-LEVEL full parity (the merged producer list, gate token removed) lands at
+        /// s2pf-11.</para>
         /// <para><b>CSTRING is NOT in the merged-list parity scope:</b> WF/Core both name a CSTRING entry
         /// the DECODED STRING (no <c>@STRUCT</c> marker), so it cannot be reliably attributed to a STRUCT
         /// patch within the merged producer list. The CSTRING arm's byte-faithfulness is carried by the
@@ -553,11 +558,12 @@ namespace FEBuilderGBA.Tests.Unit
         /// <para><b>NON-VACUOUS only where <c>config/patch2</c> is CHECKED OUT</b> (same posture as the
         /// ADDR/SWITCH + IMAGE harnesses): an un-init submodule yields no STRUCT patch files, so both
         /// filtered lists are empty and Core ⊆ WF holds trivially. The branch-level verification (the
-        /// skeleton arithmetic, the DATACOUNT guards, every safe arm, the 6624-6632 defect, the interim
-        /// default-MIX) is carried by the synthetic Core.Tests (<c>RebuildProducerPatchStructTests</c>).</para>
+        /// skeleton arithmetic, the DATACOUNT guards, every safe arm, the 6624-6632 defect, the precise
+        /// BATTLEANIMEPOINTER SETTING walk) is carried by the synthetic Core.Tests
+        /// (<c>RebuildProducerPatchStructTests</c>).</para>
         /// </summary>
         [Fact]
-        public void CorePatchStructArm_IsSubsetOf_WinFormsPatchProducer_ExcludingInterimFormArms()
+        public void CorePatchStructArm_IsSubsetOf_WinFormsPatchProducer_AllFormArmsIncluded()
         {
             string? repoRoot = FindRepoRootWithRom();
             if (repoRoot == null) return; // no checkout with roms/FE8U.gba reachable — early-exit (Pass)
@@ -597,26 +603,27 @@ namespace FEBuilderGBA.Tests.Unit
                 // AP/ROMTCS/PROCS) OR an EVENT-walk entry (s2pf-6: the "@STRUCT DATA n" entries the
                 // EventScriptForm.ScanScript walk emits — EVENTSCRIPT script blocks + their
                 // POINTER_UNIT/AICOORDINATE sub-data IFR/BIN blocks). The s2pf-9 form-bound arms
-                // (Vennou/AOE -> BIN, SMEPromo/SomeClass/Terrain* -> IFR) now emit a PRECISE non-MIX
-                // "@STRUCT DATA n" entry (INCLUDE). The LAST still-interim arm, BattleAnime (s2pf-10), emits
-                // "@STRUCT DATA n" as a length-0 MIX placeholder — it DIVERGES from WF this slice and is
-                // EXCLUDED. Since EmitPatchStructDefaultMix is the ONLY producer of a MIX-typed "@STRUCT
-                // DATA " entry, a simple rule cleanly separates the two: a MIX-typed DATA entry is interim
-                // (EXCLUDE), any other DATA entry came from a now-precise arm — the EVENT walk (s2pf-6) or
-                // one of the six s2pf-9 forms (INCLUDE).
+                // (Vennou/AOE -> BIN, SMEPromo/SomeClass/Terrain* -> IFR) and BATTLEANIMEPOINTER (s2pf-10:
+                // block-4 u32!=0 SETTING IFR) now ALL emit a PRECISE non-MIX "@STRUCT DATA n" entry
+                // (INCLUDE). The ONLY MIX-typed "@STRUCT DATA " entries left are WF's genuine `default`
+                // (unknown-pointer) emissions — Core reproduces that verbatim (EmitPatchStructDefaultMix),
+                // so a MIX-typed DATA entry is the WF default on BOTH sides (EXCLUDE, symmetric); any other
+                // DATA entry came from a now-precise arm — the EVENT walk (s2pf-6), the six s2pf-9 forms, or
+                // BATTLEANIMEPOINTER (s2pf-10) (INCLUDE).
                 // PatchImage_HEADERTSA is now precise (s2pf-7), emitting a "@STRUCT HEADERTSA n" / HEADERTSA
                 // entry — INCLUDED via the safeArmTokens. AP/ROMTCS/PROCS are now precise (s2pf-8), emitting
                 // "@STRUCT AP/ROMTCS/PROCS n" — INCLUDED via the safeArmTokens (their named, non-DATA info
-                // tokens). The six s2pf-9 forms (Vennou/AOE/SME/Class/Terrain/BG) emit "@STRUCT DATA n" with
-                // a non-MIX type, so they are INCLUDED by the non-MIX DATA rule above (NOT the safeArmTokens
-                // list, which keys on named non-DATA tokens). CSTRING is out of merged-list scope (named the
-                // decoded string) — see doc-comment.
+                // tokens). The six s2pf-9 forms (Vennou/AOE/SME/Class/Terrain/BG) + BATTLEANIMEPOINTER
+                // (s2pf-10) emit "@STRUCT DATA n" with a non-MIX type, so they are INCLUDED by the non-MIX
+                // DATA rule above (NOT the safeArmTokens list, which keys on named non-DATA tokens). CSTRING
+                // is out of merged-list scope (named the decoded string) — see doc-comment.
                 string[] safeArmTokens = { " ASM ", " IMAGE ", " TSA ", " ZTSA ", " ZHEADERTSA ", " HEADERTSA ", " PALETTE ", " AP ", " ROMTCS ", " PROCS " };
                 bool IsImplementedStructEntry(Address a)
                 {
                     if (a.Info == null) return false;
-                    // A per-entry "... DATA n" entry: the STILL-INTERIM arms emit it as a length-0 MIX
-                    // placeholder (EXCLUDE); the EVENT walk (s2pf-6) emits EVENTSCRIPT/IFR/BIN (INCLUDE).
+                    // A per-entry "... DATA n" entry: WF's genuine `default` (unknown pointer) emits it as a
+                    // length-0 MIX (EXCLUDE, symmetric on both sides); every precise arm — the EVENT walk
+                    // (s2pf-6), the six s2pf-9 forms, BATTLEANIMEPOINTER (s2pf-10) — emits non-MIX (INCLUDE).
                     if (a.Info.Contains("@STRUCT DATA ", StringComparison.Ordinal))
                     {
                         return a.DataType != Address.DataTypeEnum.MIX;
@@ -639,9 +646,9 @@ namespace FEBuilderGBA.Tests.Unit
 
                 // Core-extras = Core emits an implemented-STRUCT key WF does not. ALWAYS a faithfulness
                 // regression -> FAIL. WF-extras (WF emits an implemented-STRUCT key Core lacks) are NOT
-                // asserted (subset direction): the interim form-bound arms are already excluded, so a
+                // asserted (subset direction): only WF's symmetric `default` MIX is excluded, so a
                 // WF-extra among the implemented arms would signal a gate divergence worth surfacing, not
-                // a silent drop. Core ⊆ WF is the load-bearing guarantee for this skeleton+safe-arms slice.
+                // a silent drop. Core ⊆ WF is the load-bearing guarantee for this full-form-arm slice.
                 var coreExtras = coreStruct.Where(a => !wfKeys.Contains(Key.Of(a)))
                                            .Select(Key.Of).Distinct().ToList();
 
@@ -658,10 +665,10 @@ namespace FEBuilderGBA.Tests.Unit
                         + $"First {Math.Min(N, coreExtras.Count)} Core-only entries:\n{dump}");
                 }
 
-                // PROVEN: every Core STRUCT entry (of the implemented skeleton + safe arms) is
+                // PROVEN: every Core STRUCT entry (of the implemented skeleton + ALL form-bound arms) is
                 // byte-identical to a WF entry on (Addr/Length/Pointer/DataType) — no faithfulness
-                // regression — with the interim form-bound arms excluded from both sides (or both empty
-                // when config/patch2 is absent). FULL parity (no exclusions) lands at s2pf-11.
+                // regression — with only WF's symmetric `default` MIX excluded from both sides (or both
+                // empty when config/patch2 is absent). The orchestrator-LEVEL full parity lands at s2pf-11.
                 Assert.Empty(coreExtras);
             }
             finally


### PR DESCRIPTION
## Summary

Faithful WinForms→Core port of the **last interim STRUCT field arm** in the PatchForm producer (`#1261` option-B epic, sub-slice **10/11**). Upgrades the `BATTLEANIMEPOINTER` arm of `RebuildProducerCore.EmitPatchStructEntry` from the interim default-MIX placeholder to the precise WF length-walk.

After this slice, **every STRUCT field-type arm is precise — the interim default-MIX list is now EMPTY.** Only WF's genuine `default` (unknown pointer → length-0 MIX, which keeps the TARGET tracked — faithful to WF) + the EA/BIN no-op stubs remain.

## What changed

- **New `EmitBattleAnimeSettingPointer`** — reuses the existing s2pf-9 shared helper `EmitPatchStructBlockListIFR(rom, list, pointer, info, blockSize: 4, (i,a) => rom.u32(a) != 0)`. Length = `4*(count+1)`, type `InputFormRef`, **EMPTY** pointerIndexes; the slot+3 EOF guard before the p32 deref is already inside the shared helper.
- `case "BATTLEANIMEPOINTER"` now dispatches the real emitter (was `EmitPatchStructDefaultMix`).
- Audit-table block comment updated: `BATTLEANIMEPOINTER → s2pf-10 DONE`; the interim-MIX group is now **EMPTY**.

## Faithfulness — verbatim vs the full-path walk

This ports the **per-STRUCT-field `MakeDataLength` SETTING walk**:
- `PatchForm.cs:6558-6561` → `ImageBattleAnimeForm.MakeBattleAnimeSettingDataLength(list, p, name)`
- `ImageBattleAnimeForm.cs:876-883` → `Init(null)` (block **4**, IsDataExists `u32(addr+0) != 0`) → `ReInitPointer(pointer)` → `AddAddress(IFR, name, new uint[]{})` (EMPTY pointerIndexes — the setting block is flat).

It is **NOT** the slice-2s full-path per-class/N_-table `MakeAllDataLength` (`EmitImageBattleAnime` / `ImageBattleAnime*ImportCore`), which enumerates every class's animation list and is irrelevant for a single setting pointer. (Same trap the s2pf-9 agent avoided for the analogous MapTerrainLookup full-path walk.) Reused the s2pf-9 shared helper rather than re-writing the walk — block-4, `u32 != 0`, `4*(count+1)`, EMPTY PI are all identical to the SME/CLASS/TERRAIN/BG arms' ReInitPointer + empty-PI shape.

## Invariants

- Gate token `"PatchForm(MakePatchStructDataList)"` **STAYS** in `AsmNotYetPortedRaw` (s2pf-11 removes it).
- Orchestrator still **NOT** wired into the live producer (s2pf-11).
- `MakePatchStructDataListCore_NoPatchDir_EmitsNothing_NoThrow` invariant preserved.

## Test plan

- [x] `dotnet build FEBuilderGBA.sln` — clean (warnings only, all pre-existing)
- [x] Core.Tests `--filter RebuildProducer` — **635 passed, 0 failed** (baseline 632 + net +3)
- [x] New Core.Tests: `EmitPatchStruct_BattleAnimeField_EmitsBlock4U32Ifr_EmptyPI` (length `4*(count+1)`=16, block 4, EMPTY PI, no MIX), `EmitPatchStruct_BattleAnimeField_ImmediateTerminator_LengthIsFour` (count 0 → len 4)
- [x] BATTLEANIMEPOINTER added to `EmitPatchStruct_FormBoundField_UnsafeTarget_EmitsNothing` + `_SlotNearEof_NoThrow` Theories; the now-empty interim Theory removed
- [x] no-patch-dir invariant `MakePatchStructDataListCore_NoPatchDir_EmitsNothing_NoThrow` — passes
- [x] WF-parity `RebuildProducerWFParityTests` (5 tests) — pass (skip-if-no-ROM early-exit in CI/worktree); STRUCT parity now compares ALL form-bound arms (no per-arm exclusions; only WF's symmetric `default` MIX filtered). Renamed `..._ExcludingInterimFormArms` → `..._AllFormArmsIncluded`.
- [x] Full Core.Tests suite — only the 10 known-env `SkillSystemsAnimeImportCoreTests` failures (un-checked-out `config/patch2` submodule: "Cannot read FE8U skill-anime program temp"); none touch RebuildProducer.

## Proof (non-GUI, Core-only)

```
Passed!  - Failed: 0, Passed: 635, Skipped: 0, Total: 635 — FEBuilderGBA.Core.Tests (--filter RebuildProducer)
Passed!  - Failed: 0, Passed:   1                          — MakePatchStructDataListCore_NoPatchDir_EmitsNothing_NoThrow
Passed!  - Failed: 0, Passed:   5                          — RebuildProducerWFParityTests (FEBuilderGBA.Tests)
```

![s2pf-10 test proof](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1321-s2pf10-tests.png)

Core-only change, no GUI surface — no screenshot (per scope).

## Scope

Part of #1261. Sub-slice **10/11**: the LAST interim STRUCT arm. s2pf-11 wires the orchestrator into the live producer and removes the gate token.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]

