### PR TITLE
feat(core): wire PatchForm producer + full Core⊆WF parity; EA/BIN deferred (#1261 s2pf-11)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchScaffoldTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchScaffoldTests.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using Xunit;
 using FEBuilderGBA;
@@ -399,6 +400,192 @@ namespace FEBuilderGBA.Core.Tests
                 RebuildProducerCore.MakePatchStructDataListCore(null, new List<Address>(), false, false, false));
             Assert.Throws<ArgumentNullException>(() =>
                 RebuildProducerCore.MakePatchStructDataListCore(fe8, null, false, false, false));
+        }
+
+        // ====================================================================
+        // s2pf-11 — EA/BIN are HONEST no-op skips (no emission, no throw).
+        // ====================================================================
+
+        [Fact]
+        public void MakePatchStructDataListCore_EaAndBinPatches_AreSkipped_NoEmission_NoThrow()
+        {
+            // The orchestrator dispatches TYPE=EA -> MakePatchStructDataListForEA and TYPE=BIN ->
+            // MakePatchStructDataListForBIN in WF (both drive TracePatchedMapping). That trace subsystem
+            // is NOT yet in Core (the NEXT phase after s2pf-11), so the orchestrator SKIPS those patches:
+            // no Address is emitted (a guessed entry would be corruption) and it does NOT throw (a throw
+            // would abort the whole producer run on FE8U, which carries TYPE=EA/BIN patches). This is the
+            // honest-omission convention covered by the "PatchForm(MakePatchStructDataList)" gate token.
+            string patchDir = Path.Combine(_tempDir, "config", "patch2", "FE8U");
+            Directory.CreateDirectory(patchDir);
+            // Two install-passing EA/BIN patches (no IF lines -> CheckIF "" != "E"; isInstallOnly=true ->
+            // IsMakePatchStructDataListTarget admits a non-STRUCT/IMAGE only on CheckIF "I", so set IF=...
+            // to make CheckIF return "I"). We give each an ADDRESS the EA/BIN trace WOULD use if ported,
+            // proving the SKIP is by TYPE (not by a missing param).
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_EA.txt"), new[]
+            {
+                "NAME=PatchEA",
+                "TYPE=EA",
+                "ADDRESS=0x800100",
+            });
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_BIN.txt"), new[]
+            {
+                "NAME=PatchBIN",
+                "TYPE=BIN",
+                "ADDRESS=0x800200",
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeVersionedRom("BE8E01");
+            CoreState.ROM = fe8;
+
+            var reports = new List<string>();
+            var list = new List<Address>();
+            // Use the SAME flags as the live producer (ToolROMRebuildMake.cs:820): isInstallOnly=true so
+            // the EA/BIN patches reach the dispatch (gated only by CheckIF, which is "" here = NOT "E").
+            var ex = Record.Exception(() =>
+                RebuildProducerCore.MakePatchStructDataListCore(
+                    fe8, list, isPointerOnly: false, isInstallOnly: false, isStructOnly: false,
+                    progress: new TestProgress(reports.Add)));
+
+            Assert.Null(ex);          // EA/BIN never throw out of the producer
+            Assert.Empty(list);       // EA/BIN emit NOTHING (honest skip — no guessed entry)
+        }
+
+        // ====================================================================
+        // s2pf-11 — the orchestrator is WIRED into AppendAllAsmStructPointers as
+        // the first unconditional call; the gate token STAYS (EA/BIN deferred).
+        // ====================================================================
+
+        [Fact]
+        public void AppendAllAsmStructPointers_WiresPatchForm_EmitsAddrEntries_TokenStays()
+        {
+            // After s2pf-11, AppendAllAsmStructPointers calls MakePatchStructDataListCore FIRST
+            // (WF U.cs:2619 order) with the rebuild flags isInstallOnly=true/isPointerOnly=false/
+            // isStructOnly=false (ToolROMRebuildMake.cs:820). With an INSTALLED TYPE=ADDR patch in the
+            // tree, the live producer must now emit the @ADDRESS entry — proving the wiring is real
+            // (not a no-op). The token STAYS: IsComplete is false and PatchForm is still re-reported.
+            string patchDir = Path.Combine(_tempDir, "config", "patch2", "FE8U");
+            Directory.CreateDirectory(patchDir);
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_ADDR.txt"), new[]
+            {
+                "NAME=PatchAddr",
+                "TYPE=ADDR",
+                // The live producer uses isInstallOnly=true, which admits a non-STRUCT ADDR only on
+                // CheckIF=="I". A PATCHED_IF line whose bytes MATCH the ROM returns "I" (installed): the
+                // all-zero synthetic ROM reads 0x00 0x00 at offset 0x1000, so this patch is "installed".
+                "PATCHED_IF:0x001000=0x00 0x00",
+                // A safe ROM offset (>= 0x200; well inside a 0x0100_0000 image) for the ADDR emission.
+                "ADDRESS=0x001000",
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            // AppendAllAsmStructPointers requires rom == CoreState.ROM and a versioned ROM. The default
+            // 16 MiB image is large enough for the ADDR offset; no ldrmap is needed for the PatchForm call.
+            var fe8 = MakeVersionedRom("BE8E01");
+            CoreState.ROM = fe8;
+
+            var list = new List<Address>();
+            // The wiring uses the WF rebuild flags internally; ldrmap=null skips the gated group (fine —
+            // we only assert the PatchForm half ran).
+            var res = RebuildProducerCore.AppendAllAsmStructPointers(fe8, list, ldrmap: null);
+
+            // The wiring is LIVE: the installed ADDR patch's entry was emitted by the first unconditional call.
+            Assert.Contains(list, a => a.Info != null && a.Info.EndsWith("@ADDRESS", StringComparison.Ordinal));
+            // The token STAYS: EA/BIN deferred -> never complete -> PatchForm still re-reported.
+            Assert.False(res.IsComplete);
+            Assert.Contains("PatchForm(MakePatchStructDataList)", res.NotYetPorted);
+        }
+
+        [Fact]
+        public void AppendAllAsmStructPointers_PatchFormCancel_ReturnsCancelled_NoThrow()
+        {
+            // A pre-cancelled token must be observed by the wired PatchForm call (the orchestrator
+            // early-returns the partial list; the wrapper then re-checks ct and reports cancelled).
+            string patchDir = Path.Combine(_tempDir, "config", "patch2", "FE8U");
+            Directory.CreateDirectory(patchDir);
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_ADDR.txt"), new[]
+            {
+                "NAME=PatchAddr",
+                "TYPE=ADDR",
+                "PATCHED_IF:0x001000=0x00 0x00",
+                "ADDRESS=0x001000",
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeVersionedRom("BE8E01");
+            CoreState.ROM = fe8;
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var list = new List<Address>();
+            AsmProducerResultLike res = null;
+            var ex = Record.Exception(() =>
+            {
+                var r = RebuildProducerCore.AppendAllAsmStructPointers(
+                    fe8, list, ldrmap: null, ct: cts.Token);
+                res = new AsmProducerResultLike(r.Cancelled, r.IsComplete);
+            });
+
+            Assert.Null(ex);                 // cancel never throws out of the producer
+            Assert.NotNull(res);
+            Assert.True(res.Cancelled);      // the wired PatchForm cancel propagated to a cancelled result
+        }
+
+        // Tiny value capture so the lambda above can surface the result fields without a closure-captured local.
+        sealed class AsmProducerResultLike
+        {
+            public bool Cancelled { get; }
+            public bool IsComplete { get; }
+            public AsmProducerResultLike(bool cancelled, bool isComplete)
+            {
+                Cancelled = cancelled; IsComplete = isComplete;
+            }
+        }
+
+        [Fact]
+        public void MakeWithProducer_StillRefuses_ListsPatchForm_FromLiveAsmDeferredList()
+        {
+            // The completeness gate (MakeWithProducer) must REFUSE while PatchForm is incomplete. After
+            // s2pf-11 the orchestrator is WIRED but EA/BIN are still deferred, so the LIVE
+            // GetAsmNotYetPortedForms() still contains the token -> the ASM half's IsComplete is false ->
+            // MakeWithProducer throws an InvalidOperationException naming PatchForm and never drives
+            // RebuildMakeCore.Make. This is the load-bearing safety invariant: the still-incomplete
+            // producer can never reach a real defragment. We use the LIVE deferred list (not a synthetic
+            // token) so the test fails the day someone removes the token without porting EA/BIN.
+            var modifiedRom = new ROM();
+            byte[] modified = new byte[0x10000];
+            for (uint i = 0; i < 0x100; i++) modified[i] = (byte)(0x11 + i);
+            modifiedRom.SwapNewROMDataDirect((byte[])modified.Clone());
+            var prevRom = CoreState.ROM;
+            CoreState.ROM = modifiedRom;
+            try
+            {
+                var vanilla = new ROM();
+                vanilla.SwapNewROMDataDirect(new byte[0x1000]);
+
+                // A COMPLETE data result + the LIVE-incomplete asm result (its NotYetPorted is the real
+                // deferred list, which STILL contains the PatchForm token because EA/BIN are deferred).
+                var data = new RebuildProducerCore.ProducerResult(
+                    new List<Address>(), Array.Empty<string>(), cancelled: false);
+                string[] liveAsmNotYet = RebuildProducerCore.GetAsmNotYetPortedForms();
+                Assert.Contains("PatchForm(MakePatchStructDataList)", liveAsmNotYet);
+                var asm = new RebuildProducerCore.AsmProducerResult(liveAsmNotYet, cancelled: false);
+                Assert.False(asm.IsComplete);
+
+                string manifest = Path.Combine(_tempDir, "out.rebuild");
+                var ex = Assert.Throws<InvalidOperationException>(() =>
+                    RebuildProducerCore.MakeWithProducer(
+                        data, asm, modified, vanilla, 0x1000u, manifest));
+
+                Assert.Contains("PatchForm(MakePatchStructDataList)", ex.Message);
+                Assert.Contains("not yet ported", ex.Message);
+                Assert.False(File.Exists(manifest)); // gate refused before Make -> no manifest
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+            }
         }
 
         // ====================================================================

--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchScaffoldTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchScaffoldTests.cs
@@ -417,20 +417,24 @@ namespace FEBuilderGBA.Core.Tests
             // honest-omission convention covered by the "PatchForm(MakePatchStructDataList)" gate token.
             string patchDir = Path.Combine(_tempDir, "config", "patch2", "FE8U");
             Directory.CreateDirectory(patchDir);
-            // Two install-passing EA/BIN patches (no IF lines -> CheckIF "" != "E"; isInstallOnly=true ->
-            // IsMakePatchStructDataListTarget admits a non-STRUCT/IMAGE only on CheckIF "I", so set IF=...
-            // to make CheckIF return "I"). We give each an ADDRESS the EA/BIN trace WOULD use if ported,
-            // proving the SKIP is by TYPE (not by a missing param).
+            // Two INSTALLED EA/BIN patches that reach the EA/BIN dispatch under the LIVE producer flag
+            // (isInstallOnly=true). IsMakePatchStructDataListTarget admits a non-STRUCT/IMAGE only on
+            // CheckIF=="I"; a PATCHED_IF line whose bytes MATCH the ROM returns "I" — the all-zero
+            // synthetic ROM reads 0x00 0x00 at offset 0x1000, so each patch is "installed". We also give
+            // each an ADDRESS the EA/BIN trace WOULD use if ported, proving the SKIP is by TYPE (the patch
+            // is admitted and reaches the EA/BIN arm), not by the install gate or a missing param.
             File.WriteAllLines(Path.Combine(patchDir, "PATCH_EA.txt"), new[]
             {
                 "NAME=PatchEA",
                 "TYPE=EA",
+                "PATCHED_IF:0x001000=0x00 0x00",
                 "ADDRESS=0x800100",
             });
             File.WriteAllLines(Path.Combine(patchDir, "PATCH_BIN.txt"), new[]
             {
                 "NAME=PatchBIN",
                 "TYPE=BIN",
+                "PATCHED_IF:0x001000=0x00 0x00",
                 "ADDRESS=0x800200",
             });
 
@@ -440,15 +444,19 @@ namespace FEBuilderGBA.Core.Tests
 
             var reports = new List<string>();
             var list = new List<Address>();
-            // Use the SAME flags as the live producer (ToolROMRebuildMake.cs:820): isInstallOnly=true so
-            // the EA/BIN patches reach the dispatch (gated only by CheckIF, which is "" here = NOT "E").
+            // The SAME flags as the live producer (ToolROMRebuildMake.cs:820): isInstallOnly=true. Both
+            // patches are installed (CheckIF=="I"), so each is ADMITTED and reaches its EA/BIN dispatch
+            // arm — where it is SKIPPED (no emission, never a throw). Each admitted patch reports progress
+            // once, so the report count proves the patches really reached the dispatch (not gated out).
             var ex = Record.Exception(() =>
                 RebuildProducerCore.MakePatchStructDataListCore(
-                    fe8, list, isPointerOnly: false, isInstallOnly: false, isStructOnly: false,
+                    fe8, list, isPointerOnly: false, isInstallOnly: true, isStructOnly: false,
                     progress: new TestProgress(reports.Add)));
 
-            Assert.Null(ex);          // EA/BIN never throw out of the producer
-            Assert.Empty(list);       // EA/BIN emit NOTHING (honest skip — no guessed entry)
+            Assert.Null(ex);                 // EA/BIN never throw out of the producer
+            Assert.Empty(list);              // EA/BIN emit NOTHING (honest skip — no guessed entry)
+            Assert.Equal(2, reports.Count);  // both EA/BIN patches were ADMITTED and reached the dispatch
+            Assert.All(reports, r => Assert.StartsWith("Check Patch ", r));
         }
 
         // ====================================================================

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -12341,17 +12341,18 @@ namespace FEBuilderGBA
                 // installed-patch tree via ScanPatchs(GetPatchDirectory()) + CheckIFFast + the per-TYPE
                 // MakePatchStructDataListForADDR/EA/BIN/SWITCH/STRUCT/IMAGE helpers. Ported INCREMENTALLY
                 // in the #1261 option-B s2pf-* slices: the orchestrator + ADDR/SWITCH (s2pf-3) + IMAGE
-                // (s2pf-4) + STRUCT skeleton & SAFE arms (s2pf-5) are LIVE in Core, but this token STAYS
-                // until s2pf-11 because (a) EA/BIN are still no-op stubs, AND (b) the STRUCT arm's
-                // FORM-BOUND fields are STILL routed through a DOCUMENTED INTERIM default-MIX (length-0
-                // MIX placeholder) — they are upgraded to precise sub-walked lengths in s2pf-8..10
-                // (AP/ROMTCS/PROCS=8, Vennou/AOE/SMEPromo/SomeClass/TerrainFloor/TerrainBG=9,
-                // BattleAnime=10). EVENT (s2pf-6: the EventScriptForm.ScanScript walk via EmitScanScript,
-                // disasm-gated) and PatchImage_HEADERTSA (s2pf-7: EmitHeaderTsaPointer / CalcHeaderTsaLength)
-                // are now PRECISE. See EmitPatchStruct's block comment for the full audit
-                // table. Until the remaining interim arms land, a wrong/zero patch-pointer length relocates
-                // the wrong bytes = silent corruption — so the gate stays CLOSED (no live rebuild) until
-                // the WHOLE arm is precise.
+                // (s2pf-4/7) + the FULL STRUCT path (skeleton/SAFE arms s2pf-5, EVENT s2pf-6,
+                // HEADERTSA s2pf-7, AP/ROMTCS/PROCS s2pf-8, the six deterministic form-arms s2pf-9,
+                // BATTLEANIMEPOINTER s2pf-10) are all LIVE + PRECISE, AND the orchestrator is now WIRED
+                // into AppendAllAsmStructPointers (s2pf-11). This token NEVERTHELESS STAYS because the
+                // TYPE=EA and TYPE=BIN arms are STILL no-op skips: WF emits Address entries for those via
+                // PatchForm.TracePatchedMapping (the EA/BIN bin-mapping trace subsystem), which is NOT yet
+                // in Core. So Core's PatchForm output is a faithful SUBSET of WF's (Core⊆WF — never a
+                // Core-extra) but NOT a superset (missing every EA/BIN entry). Emitting a wrong/guessed
+                // EA/BIN length would relocate the wrong bytes = silent corruption, so the producer
+                // SKIPS those patches honestly and the gate stays CLOSED (IsComplete false; no live
+                // rebuild) until the EA/BIN subsystem (TracePatchedMapping) lands in Core — the NEXT
+                // phase. See EmitPatchStruct's block comment for the STRUCT-arm audit table.
                 "PatchForm(MakePatchStructDataList)",
                 // ProcsScriptForm.MakeAllDataLength(ldrmap) — PORTED in slice 2x (EmitProcsScript /
                 // EmitProcsScriptCore + ROMInfoLoadResourceKnownArea + Load6cNameDicSafe). Its FindProc walk
@@ -12425,9 +12426,27 @@ namespace FEBuilderGBA
                 return new AsmProducerResult(notYet, cancelled: true);
             }
 
-            // WF call 1 (UNCONDITIONAL): PatchForm.MakePatchStructDataList — DEFERRED (already in
-            // AsmNotYetPortedRaw; nothing emitted here).
-            progress?.Report("PatchForm (deferred)");
+            // WF call 1 (UNCONDITIONAL): PatchForm.MakePatchStructDataList (WF U.cs:2619) — now WIRED
+            // LIVE (s2pf-11). The orchestrator emits the ADDR/SWITCH/IMAGE/STRUCT patch entries (all
+            // precise after s2pf-3..10); its EA/BIN TYPE arms are still HONEST no-op skips (the EA/BIN
+            // trace subsystem, WF's TracePatchedMapping, is the NEXT phase). Because EA/BIN are not yet
+            // emitted, Core's PatchForm output is a faithful SUBSET of WF's (Core⊆WF, never a Core-extra)
+            // but NOT a superset — so "PatchForm(MakePatchStructDataList)" STAYS in AsmNotYetPortedRaw
+            // (IsComplete stays false; the MakeWithProducer gate stays CLOSED). WF arg values traced from
+            // ToolROMRebuildMake.cs:820 (isPatchInstallOnly:true, isPatchPointerOnly:false,
+            // isPatchStructOnly:false) -> Core (isPointerOnly:false, isInstallOnly:true, isStructOnly:false).
+            progress?.Report("PatchForm");
+            MakePatchStructDataListCore(rom, list,
+                isPointerOnly: false, isInstallOnly: true, isStructOnly: false,
+                progress: progress, ct: ct);
+            // WF's per-patch DoEvents early-returns the PARTIALLY built list on cancel; the orchestrator
+            // mirrors that (returns leaving `list` intact, never throws). Re-check `ct` here so this
+            // wrapper reports the cancel the same way the rest of AppendAllAsmStructPointers does.
+            if (ct.IsCancellationRequested)
+            {
+                progress?.Report("AppendAllAsmStructPointers cancelled");
+                return new AsmProducerResult(notYet, cancelled: true);
+            }
 
             // WF: `if (ldrmap != null) { ... }`. Of these forms only ProcsScript consumes the ldrmap;
             // the other 6 just need it present (the gate marks "full-ROM disasm available"). We
@@ -12720,17 +12739,23 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
-        /// SCAFFOLD orchestrator (s2pf-1) for the WinForms
+        /// Orchestrator (s2pf-1..11) for the WinForms
         /// <c>PatchForm.MakePatchStructDataList</c> (FEBuilderGBA/PatchForm.cs:7126).
         /// Scans the installed-patch tree for <paramref name="rom"/> and walks each patch
         /// through the same gate WF uses (<see cref="PatchHardCodeScanner.isCanonicalSkip"/>
         /// -> <see cref="PatchHardCodeScanner.CheckIF"/> -> <see cref="IsMakePatchStructDataListTarget"/>),
         /// then dispatches on the patch TYPE.
         /// <para>
-        /// In THIS slice EVERY per-TYPE arm is a documented NO-OP STUB — nothing is added to
-        /// <paramref name="list"/>. The orchestrator is defined + unit-tested but is NOT wired
-        /// into <see cref="AppendAllAsmStructPointers"/> (wiring = s2pf-11), and
-        /// "PatchForm(MakePatchStructDataList)" stays in <see cref="AsmNotYetPortedRaw"/>.
+        /// The ADDR/SWITCH/IMAGE/STRUCT TYPE arms are fully ported + precise (s2pf-3..10) and emit
+        /// into <paramref name="list"/>. The orchestrator is now WIRED into
+        /// <see cref="AppendAllAsmStructPointers"/> as the first unconditional call (s2pf-11). The
+        /// TYPE=EA and TYPE=BIN arms remain HONEST no-op skips — WF emits those via
+        /// <c>TracePatchedMapping</c> (the EA/BIN trace subsystem, the NEXT phase), so Core's output is a
+        /// faithful SUBSET of WF's (Core⊆WF, never a Core-extra) but not a superset. Because EA/BIN are
+        /// not yet emitted, "PatchForm(MakePatchStructDataList)" STAYS in
+        /// <see cref="AsmNotYetPortedRaw"/> (<see cref="AsmProducerResult.IsComplete"/> stays false; the
+        /// <see cref="MakeWithProducer(ROM, ROM, uint, string, bool, bool, IProgress{string}, CancellationToken)"/>
+        /// rebuild gate stays CLOSED).
         /// </para>
         /// <para>
         /// The ROM is passed EXPLICITLY (never CoreState.ROM / Program.ROM): WF reads
@@ -12799,13 +12824,26 @@ namespace FEBuilderGBA
                     // s2pf-3: TYPE=ADDR handler (WF MakePatchStructDataListForADDR @:6213).
                     EmitPatchAddr(rom, list, patch, isPointerOnly);
                 }
-                else if (type == "EA")
+                else if (type == "EA" || type == "BIN")
                 {
-                    // s2pf-4: TYPE=EA handler (WF MakePatchStructDataListForEA @:6259). STUB.
-                }
-                else if (type == "BIN")
-                {
-                    // s2pf-5: TYPE=BIN handler (WF MakePatchStructDataListForBIN @:6317). STUB.
+                    // TYPE=EA (WF MakePatchStructDataListForEA @:6259) and TYPE=BIN (WF
+                    // MakePatchStructDataListForBIN @:6317) are GENUINELY DEFERRED — they are the
+                    // remaining phase AFTER this slice (s2pf-11). Both WF arms drive
+                    // PatchForm.TracePatchedMapping(patch) (the EA/BIN bin-mapping trace subsystem) and
+                    // emit one Address per traced BinMapping. That trace subsystem is NOT yet in Core.
+                    //
+                    // HONEST OMISSION (the established EventCond/disasm-gate convention): we SKIP this
+                    // patch's emission entirely — we do NOT emit a wrong/guessed entry (a partial or
+                    // guessed Address would relocate the wrong bytes = silent ROM corruption), and we do
+                    // NOT throw (a throw here would abort the whole producer run on FE8U, which carries
+                    // TYPE=EA/BIN patches such as AI_TalkAI, 16_tracks, 1RNMode, 256colors, ASMC_*). The
+                    // skip is what makes Core a faithful SUBSET of WF (Core⊆WF): every entry Core DOES
+                    // emit is in WF's list, and the EA/BIN entries WF emits are exactly the ones Core
+                    // lacks. The visible re-report of this incompleteness is the gate token
+                    // "PatchForm(MakePatchStructDataList)" in AsmNotYetPortedRaw — it keeps
+                    // AsmProducerResult.IsComplete false so the MakeWithProducer rebuild gate stays
+                    // CLOSED. The token (and gate) are removed only when the EA/BIN trace subsystem
+                    // (TracePatchedMapping) lands in Core — the NEXT phase.
                 }
                 else if (type == "SWITCH")
                 {

--- a/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
+++ b/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
@@ -776,7 +776,6 @@ namespace FEBuilderGBA.Tests.Unit
                 // attribute by the Info markers those arms stamp: WF EA entries end "@EA"/"@PROCS"/
                 // "@Pointer_Array"/"@NEW_TARGET_SELECTION_STRUCT" and BIN entries end "@BIN"/"@UNUSEDBIN"
                 // (PatchForm.cs:6259-6422) — plus the per-mapping SymbolUtil entries those same arms add.
-                var coreInfos = new HashSet<string>(coreAll.Where(a => a.Info != null).Select(a => a.Info));
                 var wfOnly = wfAll.Where(a => !coreKeys.Contains(Key.Of(a))).ToList();
                 int wfOnlyGap = new HashSet<Key>(wfOnly.Select(Key.Of)).Count;
 
@@ -791,18 +790,23 @@ namespace FEBuilderGBA.Tests.Unit
                 // Core.Tests (GetAsmNotYetPortedForms contains the token + IsComplete is false), not by this
                 // ROM's installed set. So the gap is DOCUMENTED, not required to be > 0.
                 //
-                // Whatever the gap is, EVERY WF-only entry must be attributable to an EA/BIN-arm Info
-                // marker — a WF-only entry that is NOT EA/BIN-attributed would mean a PORTED arm silently
-                // dropped an entry (a Core deficit in an already-ported arm), which we DO fail on.
+                // Whatever the gap is, EVERY WF-only entry must be attributable to the EA/BIN arms — a
+                // WF-only entry that is NOT EA/BIN-attributed would mean a PORTED arm silently dropped an
+                // entry (a Core deficit in an already-ported arm), which we DO fail on.
                 bool IsEaBinAttributed(Address a)
                 {
+                    // PRECISE attribution by the markers the EA/BIN arms (PatchForm.cs:6259-6422) stamp:
+                    //   (1) the per-mapping AddAddress entries' Info ends @EA / @BIN / @UNUSEDBIN / @PROCS /
+                    //       @Pointer_Array / @NEW_TARGET_SELECTION_STRUCT;
+                    //   (2) the symbol side-entries SymbolUtil.ProcessSymbolByList + the patch-level
+                    //       ProcessSymbolByList(list, patch) add are Address.AddCommentData -> a length-0
+                    //       DataTypeEnum.Comment entry. BOTH ProcessSymbolByList call-sites are EXCLUSIVELY
+                    //       inside the EA (6266) and BIN (6324) arms — Core's ADDR/SWITCH/IMAGE/STRUCT arms
+                    //       emit NO Comment entries — so a Comment WF-only entry is necessarily an EA/BIN
+                    //       symbol side-entry (this is far more specific than the previous "not in Core's
+                    //       Info set" fallback, which could hide a real deficit in a ported non-EA/BIN arm).
+                    if (a.DataType == Address.DataTypeEnum.Comment) return true;
                     if (a.Info == null) return false;
-                    // The per-mapping SymbolUtil entries an EA/BIN arm adds carry a symbol name, not an
-                    // @EA/@BIN suffix; they are only emitted alongside an EA/BIN mapping, so if Core never
-                    // ran the EA/BIN arm they appear WF-only too. Attribute by the @EA/@BIN family suffixes
-                    // OR by the entry being absent from Core's emitted Info set (i.e. produced only on WF's
-                    // EA/BIN path). The suffix check is the precise signal; the membership check covers the
-                    // symbol side-entries without over-broadening.
                     string info = a.Info;
                     if (info.EndsWith("@EA", StringComparison.Ordinal)) return true;
                     if (info.EndsWith("@BIN", StringComparison.Ordinal)) return true;
@@ -810,9 +814,6 @@ namespace FEBuilderGBA.Tests.Unit
                     if (info.EndsWith("@PROCS", StringComparison.Ordinal)) return true;
                     if (info.EndsWith("@Pointer_Array", StringComparison.Ordinal)) return true;
                     if (info.EndsWith("@NEW_TARGET_SELECTION_STRUCT", StringComparison.Ordinal)) return true;
-                    // A symbol side-entry of an EA/BIN mapping: not in Core's emitted Info set (Core never
-                    // ran the EA/BIN arm) — attributable to the deferred EA/BIN subsystem.
-                    if (!coreInfos.Contains(info)) return true;
                     return false;
                 }
 

--- a/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
+++ b/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
@@ -677,6 +677,213 @@ namespace FEBuilderGBA.Tests.Unit
             }
         }
 
+        /// <summary>
+        /// FULL-PRODUCER WF-parity for #1261 slice s2pf-11 — the PatchForm producer orchestrator is now
+        /// WIRED into the live ASM producer (<see cref="RebuildProducerCore.AppendAllAsmStructPointers"/>),
+        /// so this asserts <b>Core⊆WF over the ENTIRE PatchForm output</b> (all TYPE arms at once), strictly,
+        /// with NO LZ77IMG / GraphicsTool exception (Copilot CLI #1323 required-strengthening finding: the
+        /// sibling merged-list subset harness exempts any Core-extra LZ77IMG at a WF-known address as a
+        /// GraphicsTool re-discovery, which could mask a bad Core-only PatchForm IMAGE entry — so PatchForm is
+        /// validated HERE, isolated from that exception, by comparing the patch producer DIRECTLY).
+        /// <para>
+        /// Both sides run the WHOLE patch producer on the SAME real FE8U ROM with the SAME rebuild flags
+        /// (<c>isPointerOnly=false, isInstallOnly=true, isStructOnly=false</c> — the
+        /// <c>ToolROMRebuildMake.Make</c> → <c>AppendAllASMStructPointersList</c> callsite,
+        /// ToolROMRebuildMake.cs:820): WF <c>PatchForm.MakePatchStructDataList</c> (the parity reference,
+        /// which DOES emit the TYPE=EA/TYPE=BIN entries via <c>TracePatchedMapping</c>) vs Core
+        /// <see cref="RebuildProducerCore.MakePatchStructDataListCore"/> (which SKIPS EA/BIN — the deferred
+        /// subsystem). The assertion is:
+        /// <list type="bullet">
+        ///   <item><b>Core⊆WF, STRICT.</b> EVERY Core-emitted entry (keyed Addr/Length/Pointer/DataType)
+        ///   MUST be in WF's list. ANY Core-extra — including a stray PatchForm <c>LZ77IMG</c> — FAILS (no
+        ///   GraphicsTool exception here). This is the load-bearing no-corruption proof.</item>
+        ///   <item><b>Core⊉WF (strict subset) — the WF-only gap is EVERY entry attributable to the deferred
+        ///   TYPE=EA/TYPE=BIN arms.</b> The test asserts every WF-only entry is EA/BIN-attributed (by the
+        ///   <c>@EA</c>/<c>@BIN</c>/<c>@PROCS</c>/… Info markers those arms stamp, plus their symbol
+        ///   side-entries) — a WF-only entry that is NOT EA/BIN-attributed would mean a PORTED arm silently
+        ///   dropped a real entry, which FAILS. The gap count + installed EA/BIN patch count are reported.</item>
+        /// </list>
+        /// <b>KEY FINDING:</b> on a freshly-loaded VANILLA FE8U, NO EA/BIN patches are INSTALLED
+        /// (<c>CheckIF != "I"</c>), so WF's EA/BIN arms emit nothing and the gap is legitimately 0
+        /// (WF total == Core total). The gate token STAYS for a STRUCTURAL reason — the EA/BIN arms are
+        /// un-ported CODE, so a ROM that DID carry installed EA/BIN patches would expose entries Core cannot
+        /// emit. That structural invariant is asserted by the Core.Tests
+        /// (<c>GetAsmNotYetPortedForms</c> contains the token + <c>IsComplete</c> false), so this ROM-level
+        /// test DOCUMENTS the gap rather than requiring it to be <c>&gt; 0</c>.
+        /// </para>
+        /// <para>SKIP-IF-NO-ROM + NON-VACUOUS only where <c>config/patch2</c> is CHECKED OUT (same posture as
+        /// the per-arm harnesses): no ROM / un-init submodule → both lists empty → Core⊆WF holds trivially.</para>
+        /// </summary>
+        [Fact]
+        public void CorePatchProducer_IsStrictSubsetOf_WinFormsPatchProducer_EaBinGapDocumented()
+        {
+            string? repoRoot = FindRepoRootWithRom();
+            if (repoRoot == null) return; // no checkout with roms/FE8U.gba reachable — early-exit (Pass)
+            string romPath = Path.Combine(repoRoot, "roms", "FE8U.gba");
+            if (!File.Exists(romPath)) return; // no ROM (gitignored, absent in CI) — early-exit (Pass)
+
+            string savedBaseDir = CoreState.BaseDirectory;
+            try
+            {
+                CoreState.BaseDirectory = repoRoot;
+                ForceCommandLineMode();
+                BootstrapWinFormsProgram(repoRoot);
+
+                bool loaded = Program.LoadROM(romPath, "");
+                if (!loaded || Program.ROM == null) return; // ROM did not load — early-exit (Pass)
+                if (Program.ROM.RomInfo.version != 8) return; // calibrated on FE8U — early-exit (Pass)
+
+                PatchForm.ClearCheckIF();
+
+                // ---- WinForms reference: the WHOLE patch producer (emits EA/BIN via TracePatchedMapping) ----
+                var wfAll = new List<Address>();
+                PatchForm.MakePatchStructDataList(wfAll,
+                    isPointerOnly: IS_PATCH_POINTER_ONLY,
+                    isInstallOnly: IS_PATCH_INSTALL_ONLY,
+                    isStructOnly: IS_PATCH_STRUCT_ONLY);
+
+                // ---- Core: the WHOLE orchestrator, same flags + same ROM (skips EA/BIN) ----
+                var coreAll = new List<Address>();
+                RebuildProducerCore.MakePatchStructDataListCore(Program.ROM, coreAll,
+                    isPointerOnly: IS_PATCH_POINTER_ONLY,
+                    isInstallOnly: IS_PATCH_INSTALL_ONLY,
+                    isStructOnly: IS_PATCH_STRUCT_ONLY);
+
+                var wfKeys = new HashSet<Key>(wfAll.Select(Key.Of));
+                var coreKeys = new HashSet<Key>(coreAll.Select(Key.Of));
+
+                // STRICT Core⊆WF over the ENTIRE patch output — NO LZ77IMG/GraphicsTool exception. A Core
+                // entry not in WF (any DataType, any address) is a faithfulness regression and FAILS.
+                var coreExtras = coreAll.Where(a => !wfKeys.Contains(Key.Of(a)))
+                                        .Select(Key.Of).Distinct().ToList();
+                if (coreExtras.Count > 0)
+                {
+                    const int N = 30;
+                    string dump = string.Join("\n", coreExtras.Take(N).Select(k =>
+                        $"  Addr=0x{k.Addr:X} Len=0x{k.Length:X} Ptr=0x{k.Pointer:X} Type={k.Type}"));
+                    Assert.Fail(
+                        $"Core PatchForm producer emitted {coreExtras.Count} entr"
+                        + (coreExtras.Count == 1 ? "y" : "ies")
+                        + " NOT present in the WinForms patch producer (faithfulness regression — STRICT, "
+                        + "no GraphicsTool exception).\n"
+                        + $"WF patch total={wfAll.Count}, Core total={coreAll.Count}.\n"
+                        + $"First {Math.Min(N, coreExtras.Count)} Core-only entries:\n{dump}");
+                }
+                Assert.Empty(coreExtras); // PROVEN: Core⊆WF strictly over ALL PatchForm entries.
+
+                // The WF-only gap = entries WF emits that Core lacks. Every WF-only entry MUST be
+                // attributable to the deferred TYPE=EA/TYPE=BIN arms (the reason the token stays). We
+                // attribute by the Info markers those arms stamp: WF EA entries end "@EA"/"@PROCS"/
+                // "@Pointer_Array"/"@NEW_TARGET_SELECTION_STRUCT" and BIN entries end "@BIN"/"@UNUSEDBIN"
+                // (PatchForm.cs:6259-6422) — plus the per-mapping SymbolUtil entries those same arms add.
+                var coreInfos = new HashSet<string>(coreAll.Where(a => a.Info != null).Select(a => a.Info));
+                var wfOnly = wfAll.Where(a => !coreKeys.Contains(Key.Of(a))).ToList();
+                int wfOnlyGap = new HashSet<Key>(wfOnly.Select(Key.Of)).Count;
+
+                // Count the installed TYPE=EA / TYPE=BIN patches in the FE8U tree (the gap's source).
+                int eaBinPatchCount = CountInstalledEaBinPatches(Program.ROM);
+
+                // KEY FINDING (documented, not a bug): a freshly-loaded VANILLA FE8U has NO EA/BIN patches
+                // INSTALLED (CheckIF != "I"), so WF's EA/BIN arms emit NOTHING and the gap is legitimately
+                // 0 — WF total == Core total here. The gate token nevertheless STAYS for a STRUCTURAL reason
+                // (the EA/BIN arms are un-ported CODE, so any ROM that DID carry installed EA/BIN patches
+                // would expose entries Core cannot emit); that structural invariant is asserted by the
+                // Core.Tests (GetAsmNotYetPortedForms contains the token + IsComplete is false), not by this
+                // ROM's installed set. So the gap is DOCUMENTED, not required to be > 0.
+                //
+                // Whatever the gap is, EVERY WF-only entry must be attributable to an EA/BIN-arm Info
+                // marker — a WF-only entry that is NOT EA/BIN-attributed would mean a PORTED arm silently
+                // dropped an entry (a Core deficit in an already-ported arm), which we DO fail on.
+                bool IsEaBinAttributed(Address a)
+                {
+                    if (a.Info == null) return false;
+                    // The per-mapping SymbolUtil entries an EA/BIN arm adds carry a symbol name, not an
+                    // @EA/@BIN suffix; they are only emitted alongside an EA/BIN mapping, so if Core never
+                    // ran the EA/BIN arm they appear WF-only too. Attribute by the @EA/@BIN family suffixes
+                    // OR by the entry being absent from Core's emitted Info set (i.e. produced only on WF's
+                    // EA/BIN path). The suffix check is the precise signal; the membership check covers the
+                    // symbol side-entries without over-broadening.
+                    string info = a.Info;
+                    if (info.EndsWith("@EA", StringComparison.Ordinal)) return true;
+                    if (info.EndsWith("@BIN", StringComparison.Ordinal)) return true;
+                    if (info.EndsWith("@UNUSEDBIN", StringComparison.Ordinal)) return true;
+                    if (info.EndsWith("@PROCS", StringComparison.Ordinal)) return true;
+                    if (info.EndsWith("@Pointer_Array", StringComparison.Ordinal)) return true;
+                    if (info.EndsWith("@NEW_TARGET_SELECTION_STRUCT", StringComparison.Ordinal)) return true;
+                    // A symbol side-entry of an EA/BIN mapping: not in Core's emitted Info set (Core never
+                    // ran the EA/BIN arm) — attributable to the deferred EA/BIN subsystem.
+                    if (!coreInfos.Contains(info)) return true;
+                    return false;
+                }
+
+                var unattributed = wfOnly.Where(a => !IsEaBinAttributed(a)).Select(Key.Of).Distinct().ToList();
+                if (unattributed.Count > 0)
+                {
+                    const int N = 30;
+                    string dump = string.Join("\n", unattributed.Take(N).Select(k =>
+                        $"  Addr=0x{k.Addr:X} Len=0x{k.Length:X} Ptr=0x{k.Pointer:X} Type={k.Type}"));
+                    Assert.Fail(
+                        $"Found {unattributed.Count} WF-only PatchForm entr"
+                        + (unattributed.Count == 1 ? "y" : "ies")
+                        + " NOT attributable to the deferred EA/BIN arms — a PORTED arm silently dropped a "
+                        + "real entry (Core deficit).\n"
+                        + $"WF total={wfAll.Count}, Core total={coreAll.Count}, WF-only gap={wfOnlyGap}, "
+                        + $"installed EA/BIN patches={eaBinPatchCount}.\n"
+                        + $"First {Math.Min(N, unattributed.Count)} unattributed WF-only entries:\n{dump}");
+                }
+                Assert.Empty(unattributed); // every WF-only entry is the deferred EA/BIN subset.
+
+                // DOCUMENTED (visible in test output): Core⊆WF strictly; the WF-only gap (if any) is
+                // entirely the deferred EA/BIN entries; on a vanilla FE8U with no EA/BIN installed the gap
+                // is 0 (WF==Core). The token stays for the structural EA/BIN-un-ported reason.
+                System.Console.WriteLine(
+                    $"[s2pf-11] PatchForm parity: WF total={wfAll.Count}, Core total={coreAll.Count}, "
+                    + $"Core-extras={coreExtras.Count} (MUST be 0), WF-only gap (all EA/BIN-attributed)={wfOnlyGap}, "
+                    + $"installed TYPE=EA/BIN patches={eaBinPatchCount}.");
+            }
+            finally
+            {
+                CoreState.BaseDirectory = savedBaseDir;
+            }
+        }
+
+        /// <summary>
+        /// Count the installed TYPE=EA / TYPE=BIN patches for the loaded ROM — the entry source for the
+        /// deferred EA/BIN gap. Walks the same <c>config/patch2/&lt;version&gt;</c> tree the producer scans
+        /// (via the Core scanner so it stays headless) and counts patches whose TYPE is EA/BIN and that pass
+        /// the install gate the producer applies (CheckIF != "E"; for non-STRUCT/IMAGE under isInstallOnly
+        /// the producer further requires CheckIF == "I"). Returns 0 when the submodule is un-init.
+        /// </summary>
+        static int CountInstalledEaBinPatches(ROM rom)
+        {
+            try
+            {
+                string version = rom.RomInfo?.VersionToFilename ?? "";
+                if (string.IsNullOrEmpty(version)) return 0;
+                string patchDir = PatchHardCodeScanner.ResolvePatchDirectory(version);
+                List<PatchInstallCore.PatchSt> patchs = PatchHardCodeScanner.ScanPatchs(rom, patchDir, "en");
+                int n = 0;
+                foreach (PatchInstallCore.PatchSt p in patchs)
+                {
+                    if (PatchHardCodeScanner.isCanonicalSkip(p)) continue;
+                    string type = U.at(p.Param, "TYPE");
+                    if (type != "EA" && type != "BIN") continue;
+                    string checkIF = PatchHardCodeScanner.CheckIF(rom, p);
+                    // Mirror IsMakePatchStructDataListTarget for non-STRUCT/IMAGE under isInstallOnly=true.
+                    if (RebuildProducerCore.IsMakePatchStructDataListTarget(
+                            type, checkIF, isInstallOnly: IS_PATCH_INSTALL_ONLY, isStructOnly: IS_PATCH_STRUCT_ONLY))
+                    {
+                        n++;
+                    }
+                }
+                return n;
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
         // ----------------------------------------------------------------
         readonly struct Key : IEquatable<Key>
         {


### PR DESCRIPTION
## Summary

Sub-slice **11/11** of the #1261 option-B PatchForm STRUCT path: WIRE the now-complete `MakePatchStructDataListCore` orchestrator into the LIVE ASM producer, validate **Core⊆WF** on the full FE8U patch set, and **KEEP the gate token** — EA/BIN are genuinely deferred to the next phase.

Closes the wiring step; Part of #1261. Plan: #1323.

### The wiring
- `MakePatchStructDataListCore` is now called as the FIRST unconditional statement in `AppendAllAsmStructPointers`, matching WF `U.cs:2619` ordering. Arg values traced from `ToolROMRebuildMake.cs:820` (`isPatchInstallOnly:true, isPatchPointerOnly:false, isPatchStructOnly:false`) → Core `(isPointerOnly:false, isInstallOnly:true, isStructOnly:false)`.
- `rom`/`progress`/`ct` threaded. The orchestrator early-returns the partial list on cancel (never throws); the wrapper re-checks `ct` and returns `cancelled:true`. The no-patch-dir / version-0 invariant is preserved by the existing `SafePatchVersionFolder` guard.

### Core⊆WF proof (the load-bearing safety guarantee)
New `CorePatchProducer_IsStrictSubsetOf_WinFormsPatchProducer_EaBinGapDocumented` (FEBuilderGBA.Tests, skip-if-no-ROM + real FE8U + `config/patch2`) runs the WHOLE `PatchForm.MakePatchStructDataList` (WF) vs `MakePatchStructDataListCore` (Core) and asserts **STRICT Core⊆WF over the ENTIRE PatchForm output** — NO `LZ77IMG`/GraphicsTool exception (per the Copilot CLI #1323 required-strengthening finding, so a stray Core-only PatchForm image entry can't be masked). It also asserts every WF-only entry is **EA/BIN-attributed** (a non-EA/BIN WF-only entry would mean a ported arm silently dropped data → FAIL) and documents the gap.

**Empirical result on real FE8U:**
```
[s2pf-11] PatchForm parity: WF total=591, Core total=591, Core-extras=0 (MUST be 0),
          WF-only gap (all EA/BIN-attributed)=0, installed TYPE=EA/BIN patches=0.
```

### Why the token STAYS (EA/BIN deferred)
- The TYPE=EA arm (WF `MakePatchStructDataListForEA` @:6259) and TYPE=BIN arm (@:6317) both drive `PatchForm.TracePatchedMapping` — the EA/BIN bin-mapping **trace subsystem**, which is NOT yet in Core. The orchestrator SKIPS those patches (no emission — a guessed entry would relocate the wrong bytes = corruption; never throws — a throw would abort the producer on FE8U).
- So Core's PatchForm output is a faithful **SUBSET** of WF's (Core⊆WF, never a Core-extra) but **NOT a superset**. `"PatchForm(MakePatchStructDataList)"` therefore STAYS in `AsmNotYetPortedRaw` → `IsComplete` stays **false** → the `MakeWithProducer` rebuild gate stays **CLOSED**. Full closure (token removal + gate-open) is the EA/BIN subsystem — the NEXT phase.
- **KEY FINDING:** on a freshly-loaded **vanilla** FE8U, no EA/BIN patches are *installed* (`CheckIF != "I"`), so WF's EA/BIN arms emit nothing either → the gap is legitimately 0 (WF==Core). The token stays for a **structural** reason (the EA/BIN arms are un-ported code; a ROM that DID carry installed EA/BIN patches would expose entries Core cannot emit). That structural invariant is asserted by the Core.Tests (`GetAsmNotYetPortedForms` contains the token + `IsComplete` false).

## Test plan
- [x] `dotnet build FEBuilderGBA.sln -c Debug` → **0 errors**.
- [x] Core.Tests `RebuildProducer*` → **639 passed, 0 failed** (632 baseline + 7 new).
- [x] FE8U WF-parity (`RebuildProducerWFParityTests`, real ROM + checked-out `config/patch2`) → all 6 pass, incl. new strict-subset test (Core⊆WF, 591==591, 0 Core-extras).
- [x] New: synthetic EA-type + BIN-type patches are SKIPPED (no emission, no throw).
- [x] New: `AppendAllAsmStructPointers` wires PatchForm (emits `@ADDRESS`, `IsComplete` false, lists the PatchForm token); cancel propagates `cancelled:true`.
- [x] New: `MakeWithProducer` (incomplete asm) still REFUSES — throws `InvalidOperationException` naming `PatchForm(MakePatchStructDataList)`, writes no manifest.

## Screenshots
N/A — Core-only change (no GUI). Proof is the parity console output + test results above.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
