### PR TITLE
feat(core): PatchForm EA/BIN safe-reject gate (sound on modded ROMs) (#1261 s2pf-12)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchSafeRejectTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchSafeRejectTests.cs
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for RebuildProducerCore slice s2pf-12 (#1261) — the PatchForm EA/BIN
+// per-ROM SAFE-REJECT BACKSTOP (option-B epic, sub-slice 12 of 17, the FIRST of
+// the EA/BIN phase).
+//
+// This slice adds:
+//   - PatchHardCodeScanner.EaBinInstallStatus(ROM, PatchSt): a SOUND tri-state
+//     install check (Installed / NotInstalled / Unknown) — a conservative
+//     over-approximation of WF PatchForm.IsInstalled. Refuses on Installed OR
+//     Unknown so it never reports "safe" while a patch could be present.
+//   - RebuildProducerCore.PatchFormHasUnportableInstalledPatch(ROM) -> bool:
+//     true iff the ROM carries an EA/BIN patch the producer can't emit that is
+//     Installed or Unknown.
+//   - MakeWithProducer wiring: REFUSE the rebuild (InvalidOperationException naming
+//     the offending patch) when the predicate is true — IN ADDITION to the existing
+//     IsComplete gate (the token still keeps that gate closed today, so this is
+//     belt-and-suspenders now / load-bearing at the gate-open in s2pf-17).
+//
+// SOUNDNESS: the dangerous direction is a false-negative ("safe" when actually
+// unsafe). The naive CheckIF=="I" predicate is UNSOUND (Copilot plan review, issue
+// #1325): it misses PATCHED_IFNOT-installed (e.g. FE8U/MNC2Fix) and $FGREP-signature
+// patches. EaBinInstallStatus fixes both (PATCHED_IFNOT match => Installed;
+// unresolvable signature => Unknown => refuse). These tests pin every branch:
+// PATCHED_IF-installed, PATCHED_IFNOT-installed, resolvable-not-installed,
+// $FGREP-unknown, TYPE/CANONICAL_SKIP/no-dir/version-0 boundaries.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class RebuildProducerPatchSafeRejectTests : IDisposable
+    {
+        readonly ROM _savedRom = CoreState.ROM;
+        readonly string _savedLang = CoreState.Language;
+        readonly string _savedBaseDir = CoreState.BaseDirectory;
+        readonly string _tempDir;
+
+        public RebuildProducerPatchSafeRejectTests()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "RebuildProducerPatchSafeReject_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDir);
+            CoreState.Language = "en";
+        }
+
+        public void Dispose()
+        {
+            CoreState.ROM = _savedRom;
+            CoreState.Language = _savedLang;
+            CoreState.BaseDirectory = _savedBaseDir;
+            try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, true); } catch { }
+        }
+
+        // 16 MiB = FE8 LoadLow minimum (Rom.cs requires >= 0x0100_0000). Keeping it at the
+        // minimum cuts per-test allocation vs a 32 MiB buffer (same idiom as the scaffold tests).
+        static ROM MakeVersionedRom(string versionString, int size = 0x0100_0000)
+        {
+            var rom = new ROM();
+            bool ok = rom.LoadLow("fake.gba", new byte[size], versionString);
+            Assert.True(ok, "LoadLow did not recognize version string: " + versionString);
+            return rom;
+        }
+
+        // Build a PatchSt directly from key/value lines (mirrors a real LoadPatch result) for the
+        // unit-level EaBinInstallStatus tests that don't need a staged directory.
+        static PatchInstallCore.PatchSt MakePatch(string fileName, params (string key, string value)[] kv)
+        {
+            var p = new PatchInstallCore.PatchSt
+            {
+                Name = fileName,
+                PatchFileName = fileName,
+                Param = new Dictionary<string, string>(),
+            };
+            foreach (var (key, value) in kv) p.Param[key] = value;
+            return p;
+        }
+
+        string StageFe8uPatchDir()
+        {
+            string patchDir = Path.Combine(_tempDir, "config", "patch2", "FE8U");
+            Directory.CreateDirectory(patchDir);
+            return patchDir;
+        }
+
+        // ====================================================================
+        // 1. PatchHardCodeScanner.EaBinInstallStatus — the SOUND tri-state.
+        //    The all-zero synthetic ROM reads 0x00 at every offset, so:
+        //      PATCHED_IF:...=0x00 0x00   matches   -> Installed
+        //      PATCHED_IF:...=0xFF 0xFF   mismatch  -> NotInstalled
+        //      PATCHED_IFNOT:...=0xFF 0xFF mismatch -> Installed (the un-patched sig is absent)
+        //      PATCHED_IFNOT:...=0x00 0x00 match    -> NotInstalled (un-patched sig present)
+        //      PATCHED_IF:$FGREP <file>=...         -> Unknown (file-inclusion unresolvable)
+        // ====================================================================
+
+        [Fact]
+        public void EaBinInstallStatus_PatchedIfMatch_Installed()
+        {
+            var rom = MakeVersionedRom("BE8E01");
+            var patch = MakePatch("p.txt", ("TYPE", "EA"), ("PATCHED_IF:0x001000", "0x00 0x00"));
+            Assert.Equal(PatchHardCodeScanner.InstallStatusEnum.Installed,
+                PatchHardCodeScanner.EaBinInstallStatus(rom, patch));
+        }
+
+        [Fact]
+        public void EaBinInstallStatus_PatchedIfNotMismatch_Installed()
+        {
+            // The KEY false-negative the naive CheckIF=="I" predicate missed (Copilot #1325): a patch
+            // installed via PATCHED_IFNOT only (e.g. FE8U/MNC2Fix). WF IsInstalled deems it installed;
+            // CheckIF returns "E"/"" there. EaBinInstallStatus correctly returns Installed.
+            var rom = MakeVersionedRom("BE8E01");
+            var patch = MakePatch("p.txt", ("TYPE", "EA"), ("PATCHED_IFNOT:0x001000", "0xFF 0xFF"));
+            Assert.Equal(PatchHardCodeScanner.InstallStatusEnum.Installed,
+                PatchHardCodeScanner.EaBinInstallStatus(rom, patch));
+            // Sanity: the OLD predicate basis (CheckIF) does NOT report "I" here — proving the gap is real.
+            Assert.NotEqual("I", PatchHardCodeScanner.CheckIF(rom, patch));
+        }
+
+        [Fact]
+        public void EaBinInstallStatus_PatchedIfMismatch_NotInstalled()
+        {
+            var rom = MakeVersionedRom("BE8E01");
+            var patch = MakePatch("p.txt", ("TYPE", "EA"), ("PATCHED_IF:0x001000", "0xFF 0xFF"));
+            Assert.Equal(PatchHardCodeScanner.InstallStatusEnum.NotInstalled,
+                PatchHardCodeScanner.EaBinInstallStatus(rom, patch));
+        }
+
+        [Fact]
+        public void EaBinInstallStatus_PatchedIfNotMatch_NotInstalled()
+        {
+            var rom = MakeVersionedRom("BE8E01");
+            var patch = MakePatch("p.txt", ("TYPE", "EA"), ("PATCHED_IFNOT:0x001000", "0x00 0x00"));
+            Assert.Equal(PatchHardCodeScanner.InstallStatusEnum.NotInstalled,
+                PatchHardCodeScanner.EaBinInstallStatus(rom, patch));
+        }
+
+        [Fact]
+        public void EaBinInstallStatus_UnresolvableFgrepSignature_Unknown()
+        {
+            // The OTHER false-negative (Copilot #1325): an install marker using $FGREP <file> file-inclusion
+            // (162 such PATCHED_IF rows in the FE8U tree). Core's resolver does not port FGREP file-inclusion
+            // -> NOT_FOUND -> never "I". EaBinInstallStatus returns Unknown so the gate refuses conservatively.
+            var rom = MakeVersionedRom("BE8E01");
+            var patch = MakePatch("p.txt", ("TYPE", "BIN"), ("PATCHED_IF:$FGREP4 nope_missing.bin", "0x00 0xB5"));
+            Assert.Equal(PatchHardCodeScanner.InstallStatusEnum.Unknown,
+                PatchHardCodeScanner.EaBinInstallStatus(rom, patch));
+        }
+
+        [Fact]
+        public void EaBinInstallStatus_NoInstallMarker_NotInstalled()
+        {
+            // An EA/BIN patch with NO PATCHED_IF/PATCHED_IFNOT marker -> NotInstalled (inherits WF's own
+            // blind spot: WF IsInstalled is likewise false for a marker-less patch). Plain IF is a
+            // PREREQUISITE, not an install marker, so it does not count toward install status.
+            var rom = MakeVersionedRom("BE8E01");
+            var patch = MakePatch("p.txt", ("TYPE", "EA"), ("IF:0x001000", "0x00 0x00"), ("ADDRESS", "0x800100"));
+            Assert.Equal(PatchHardCodeScanner.InstallStatusEnum.NotInstalled,
+                PatchHardCodeScanner.EaBinInstallStatus(rom, patch));
+        }
+
+        [Fact]
+        public void EaBinInstallStatus_InstalledMarkerWins_OverUnknownMarker()
+        {
+            // A patch with BOTH an unresolvable marker AND a resolvable matching marker is Installed
+            // (the precise answer), not Unknown — the resolvable match proves presence.
+            var rom = MakeVersionedRom("BE8E01");
+            var patch = MakePatch("p.txt", ("TYPE", "EA"),
+                ("PATCHED_IF:$FGREP4 missing.bin", "0x00 0xB5"),   // unresolvable -> would be Unknown alone
+                ("PATCHED_IF:0x001000", "0x00 0x00"));             // resolvable + matches -> Installed
+            Assert.Equal(PatchHardCodeScanner.InstallStatusEnum.Installed,
+                PatchHardCodeScanner.EaBinInstallStatus(rom, patch));
+        }
+
+        // ====================================================================
+        // 2. PatchFormHasUnportableInstalledPatch — the per-ROM predicate.
+        // ====================================================================
+
+        [Fact]
+        public void Predicate_InstalledEaAndBin_ReturnsTrue()
+        {
+            string patchDir = StageFe8uPatchDir();
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_EA.txt"), new[]
+            {
+                "NAME=PatchEA", "TYPE=EA", "PATCHED_IF:0x001000=0x00 0x00", "ADDRESS=0x800100",
+            });
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_BIN.txt"), new[]
+            {
+                "NAME=PatchBIN", "TYPE=BIN", "PATCHED_IF:0x001000=0x00 0x00", "ADDRESS=0x800200",
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeVersionedRom("BE8E01");
+            CoreState.ROM = fe8;
+
+            Assert.True(RebuildProducerCore.PatchFormHasUnportableInstalledPatch(fe8));
+        }
+
+        [Fact]
+        public void Predicate_PatchedIfNotInstalledEa_ReturnsTrue()
+        {
+            // Regression for Copilot #1325 false-negative #1: a PATCHED_IFNOT-installed EA patch must be
+            // caught (the naive CheckIF=="I" predicate would MISS it).
+            string patchDir = StageFe8uPatchDir();
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_IFNOT.txt"), new[]
+            {
+                "NAME=PatchIfNot", "TYPE=EA", "PATCHED_IFNOT:0x001000=0xFF 0xFF", "ADDRESS=0x800100",
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeVersionedRom("BE8E01");
+            CoreState.ROM = fe8;
+
+            Assert.True(RebuildProducerCore.PatchFormHasUnportableInstalledPatch(fe8));
+        }
+
+        [Fact]
+        public void Predicate_UnknownFgrepEa_ReturnsTrue()
+        {
+            // Regression for Copilot #1325 false-negative #2: an EA patch whose install marker uses an
+            // unresolvable $FGREP file-inclusion signature is Unknown -> the gate refuses conservatively.
+            string patchDir = StageFe8uPatchDir();
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_FGREP.txt"), new[]
+            {
+                "NAME=PatchFgrep", "TYPE=EA", "PATCHED_IF:$FGREP4 nope_missing.bin=0x00 0xB5", "ADDRESS=0x800100",
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeVersionedRom("BE8E01");
+            CoreState.ROM = fe8;
+
+            Assert.True(RebuildProducerCore.PatchFormHasUnportableInstalledPatch(fe8));
+        }
+
+        [Fact]
+        public void Predicate_ResolvablyNotInstalledEaBin_ReturnsFalse()
+        {
+            // EA/BIN patches with a RESOLVABLE PATCHED_IF marker that does NOT match -> NotInstalled ->
+            // the predicate allows (the patch's bytes are provably absent, so a rebuild drops nothing).
+            string patchDir = StageFe8uPatchDir();
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_EA.txt"), new[]
+            {
+                "NAME=PatchEA", "TYPE=EA", "PATCHED_IF:0x001000=0xFF 0xFF", "ADDRESS=0x800100",
+            });
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_BIN.txt"), new[]
+            {
+                "NAME=PatchBIN", "TYPE=BIN", "PATCHED_IF:0x001000=0xFF 0xFF", "ADDRESS=0x800200",
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeVersionedRom("BE8E01");
+            CoreState.ROM = fe8;
+
+            Assert.False(RebuildProducerCore.PatchFormHasUnportableInstalledPatch(fe8));
+        }
+
+        [Fact]
+        public void Predicate_InstalledStruct_ReturnsFalse()
+        {
+            // A TYPE=STRUCT installed patch must NOT trip the predicate — STRUCT is faithfully emitted
+            // (s2pf-5..10), so it is never a reason to refuse. Only EA/BIN are un-ported.
+            string patchDir = StageFe8uPatchDir();
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_STRUCT.txt"), new[]
+            {
+                "NAME=PatchStruct", "TYPE=STRUCT", "PATCHED_IF:0x001000=0x00 0x00", "P0:POINTER=0x100",
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeVersionedRom("BE8E01");
+            CoreState.ROM = fe8;
+
+            Assert.False(RebuildProducerCore.PatchFormHasUnportableInstalledPatch(fe8));
+        }
+
+        [Fact]
+        public void Predicate_CanonicalSkipInstalledEa_ReturnsFalse()
+        {
+            // CANONICAL_SKIP=1 short-circuits the patch (isCanonicalSkip) BEFORE the TYPE/install gate —
+            // exactly as the orchestrator skips it — so even an "installed" EA patch with CANONICAL_SKIP
+            // set is not a reason to refuse.
+            string patchDir = StageFe8uPatchDir();
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_EA_SKIP.txt"), new[]
+            {
+                "NAME=PatchEaSkip", "TYPE=EA", "CANONICAL_SKIP=1", "PATCHED_IF:0x001000=0x00 0x00", "ADDRESS=0x800100",
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeVersionedRom("BE8E01");
+            CoreState.ROM = fe8;
+
+            Assert.False(RebuildProducerCore.PatchFormHasUnportableInstalledPatch(fe8));
+        }
+
+        [Fact]
+        public void Predicate_MixedTree_TrueWhenAnyInstalledEaBin()
+        {
+            // A realistic mix: an installed STRUCT (emittable, ignored), a resolvably-not-installed EA
+            // (ignored), and ONE installed BIN (the offender) -> predicate true.
+            string patchDir = StageFe8uPatchDir();
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_STRUCT.txt"), new[]
+            {
+                "NAME=PatchStruct", "TYPE=STRUCT", "PATCHED_IF:0x001000=0x00 0x00", "P0:POINTER=0x100",
+            });
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_EA_NOTINSTALLED.txt"), new[]
+            {
+                "NAME=PatchEaNot", "TYPE=EA", "PATCHED_IF:0x001000=0xFF 0xFF", "ADDRESS=0x800100",
+            });
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_BIN_INSTALLED.txt"), new[]
+            {
+                "NAME=PatchBinInst", "TYPE=BIN", "PATCHED_IF:0x001000=0x00 0x00", "ADDRESS=0x800200",
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeVersionedRom("BE8E01");
+            CoreState.ROM = fe8;
+
+            Assert.True(RebuildProducerCore.PatchFormHasUnportableInstalledPatch(fe8));
+        }
+
+        [Fact]
+        public void Predicate_NoPatchDir_ReturnsFalse()
+        {
+            // An EMPTY config/patch2/FE8U tree -> ScanPatchs returns empty -> nothing installed -> false.
+            // (The dir EXISTS but is empty so ResolvePatchDirectory pins it instead of falling through to
+            // the build-copied real FE8U tree in bin/, same as the scaffold test.)
+            StageFe8uPatchDir(); // exists, no PATCH_*.txt
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeVersionedRom("BE8E01");
+            CoreState.ROM = fe8;
+
+            Assert.False(RebuildProducerCore.PatchFormHasUnportableInstalledPatch(fe8));
+        }
+
+        [Fact]
+        public void Predicate_Version0Rom_ReturnsFalse()
+        {
+            // An unrecognized ROM -> version 0 -> SafePatchVersionFolder "" -> no patch dir -> false.
+            // Even with a populated FE8U tree present, the version-0 guard short-circuits the scan.
+            string patchDir = StageFe8uPatchDir();
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_EA.txt"), new[]
+            {
+                "NAME=PatchEA", "TYPE=EA", "PATCHED_IF:0x001000=0x00 0x00", "ADDRESS=0x800100",
+            });
+
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(new byte[0x8000]);
+            CoreState.ROM = rom;
+            CoreState.BaseDirectory = _tempDir;
+
+            Assert.False(RebuildProducerCore.PatchFormHasUnportableInstalledPatch(rom));
+        }
+
+        [Fact]
+        public void Predicate_NullRom_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                RebuildProducerCore.PatchFormHasUnportableInstalledPatch(null));
+        }
+
+        // ====================================================================
+        // 3. MakeWithProducer — the per-ROM backstop refuses (naming the patch).
+        // ====================================================================
+
+        [Fact]
+        public void MakeWithProducer_InstalledEaBin_Throws_NamingThePatch()
+        {
+            // The public MakeWithProducer(rom, vanilla, ...) overload must REFUSE before running the
+            // producers when the rom carries an installed EA/BIN patch — and the message must NAME the
+            // offending patch file. This is the per-ROM backstop path (distinct from the IsComplete-gate).
+            string patchDir = StageFe8uPatchDir();
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_BIN.txt"), new[]
+            {
+                "NAME=PatchBIN", "TYPE=BIN", "PATCHED_IF:0x001000=0x00 0x00", "ADDRESS=0x800200",
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeVersionedRom("BE8E01");
+            CoreState.ROM = fe8;
+
+            var vanilla = MakeVersionedRom("BE8E01");
+            string manifest = Path.Combine(_tempDir, "out.rebuild");
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                RebuildProducerCore.MakeWithProducer(
+                    fe8, vanilla, 0x800000u, manifest,
+                    isUseOtherGraphics: false, isUseOAMSP: false));
+
+            Assert.Contains("EA/BIN", ex.Message);
+            Assert.Contains("PATCH_BIN.txt", ex.Message);     // names the offending patch file
+            Assert.False(File.Exists(manifest));              // refused before Make -> no manifest
+        }
+
+        [Fact]
+        public void MakeWithProducer_NoEaBin_StillRefuses_OnIsCompleteGate_NamingPatchForm()
+        {
+            // With NO installed/unknown EA/BIN patch, the per-ROM backstop passes (false) — but the rebuild
+            // is STILL refused by the existing IsComplete gate, because the "PatchForm(MakePatchStructDataList)"
+            // token stays in AsmNotYetPortedRaw (gate-open is s2pf-17). Proves the backstop did NOT open the
+            // gate and the token-based refusal is intact.
+            StageFe8uPatchDir(); // empty -> no installed/unknown EA/BIN -> backstop passes
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeVersionedRom("BE8E01");
+            CoreState.ROM = fe8;
+
+            // Sanity: the per-ROM backstop is NOT the reason for the refusal here.
+            Assert.False(RebuildProducerCore.PatchFormHasUnportableInstalledPatch(fe8));
+
+            var vanilla = MakeVersionedRom("BE8E01");
+            string manifest = Path.Combine(_tempDir, "out.rebuild");
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                RebuildProducerCore.MakeWithProducer(
+                    fe8, vanilla, 0x800000u, manifest,
+                    isUseOtherGraphics: false, isUseOAMSP: false));
+
+            // The IsComplete-gate refusal (not the backstop) — it names the still-deferred PatchForm form.
+            Assert.Contains("PatchForm(MakePatchStructDataList)", ex.Message);
+            Assert.Contains("not yet ported", ex.Message);
+            Assert.False(File.Exists(manifest));
+        }
+
+        [Fact]
+        public void Token_StaysInAsmNotYetPorted()
+        {
+            // Belt-and-suspenders invariant: this slice does NOT open the gate. The
+            // "PatchForm(MakePatchStructDataList)" token MUST still be present so the IsComplete gate stays
+            // closed for the common case (gate-open is s2pf-17).
+            string[] liveAsmNotYet = RebuildProducerCore.GetAsmNotYetPortedForms();
+            Assert.Contains("PatchForm(MakePatchStructDataList)", liveAsmNotYet);
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchSafeRejectTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchSafeRejectTests.cs
@@ -163,6 +163,19 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void EaBinInstallStatus_NullParam_Unknown()
+        {
+            // A null Param cannot be inspected at all -> the only SOUND answer is Unknown (NOT
+            // NotInstalled): uninspectable proves nothing, so the safe-reject gate must not treat it as
+            // safe (Copilot PR #1326 review). LoadPatch never produces a null Param; this guards a direct
+            // caller's contract.
+            var rom = MakeVersionedRom("BE8E01");
+            var patch = new PatchInstallCore.PatchSt { Name = "p.txt", PatchFileName = "p.txt", Param = null };
+            Assert.Equal(PatchHardCodeScanner.InstallStatusEnum.Unknown,
+                PatchHardCodeScanner.EaBinInstallStatus(rom, patch));
+        }
+
+        [Fact]
         public void EaBinInstallStatus_InstalledMarkerWins_OverUnknownMarker()
         {
             // A patch with BOTH an unresolvable marker AND a resolvable matching marker is Installed

--- a/FEBuilderGBA.Core/PatchHardCodeScanner.cs
+++ b/FEBuilderGBA.Core/PatchHardCodeScanner.cs
@@ -381,6 +381,178 @@ namespace FEBuilderGBA
             return "";
         }
 
+        /// <summary>
+        /// Tri-state install status used by the #1261 PatchForm EA/BIN safe-reject gate (s2pf-12).
+        /// </summary>
+        public enum InstallStatusEnum
+        {
+            /// <summary>No install marker matched (and every marker was resolvable) — the patch's bytes
+            /// are NOT in the ROM, so a rebuild can safely omit it.</summary>
+            NotInstalled = 0,
+            /// <summary>An install marker matched the ROM — the patch's bytes ARE present.</summary>
+            Installed = 1,
+            /// <summary>The install status CANNOT be determined: at least one install marker uses a
+            /// signature this Core build cannot resolve (e.g. an <c>$FGREP &lt;file&gt;</c> file-inclusion,
+            /// <c>$XGREP</c>, or another un-ported macro). Treated as possibly-installed by the safe-reject
+            /// gate (conservative: never claim "safe" when the patch might be present).</summary>
+            Unknown = 2,
+        }
+
+        /// <summary>
+        /// Resolve the INSTALL STATUS of <paramref name="patch"/> against <paramref name="rom"/> for the
+        /// #1261 PatchForm EA/BIN safe-reject gate (s2pf-12) — a SOUND over-approximation of the WinForms
+        /// <c>PatchForm.IsInstalled</c> (FEBuilderGBA/PatchForm.cs:199), which deems a patch installed iff
+        /// its detail-mode <c>CheckIF</c> result contains the substring <c>"PATCHED_IF"</c> (i.e. some
+        /// <c>PATCHED_IF</c> match OR some <c>PATCHED_IFNOT</c> match).
+        /// <para>
+        /// Only the install-marker keys (<c>PATCHED_IF</c> / <c>PATCHED_IFNOT</c>) are inspected — plain
+        /// <c>IF</c>/<c>IFNOT</c>/<c>CONFLICT_IF</c> are prerequisites, not install markers, and never make
+        /// WF's <c>IsInstalled</c> true. Per marker:
+        /// <list type="bullet">
+        ///   <item>address UNRESOLVABLE (<c>convertBinAddressString</c> -&gt; unsafe/NOT_FOUND, e.g. an
+        ///   <c>$FGREP &lt;file&gt;</c> file-inclusion or <c>$XGREP</c> this Core build does not port) -&gt;
+        ///   <see cref="InstallStatusEnum.Unknown"/> (the gate refuses conservatively).</item>
+        ///   <item><c>PATCHED_IF</c> whose bytes MATCH the ROM, or <c>PATCHED_IFNOT</c> whose bytes MISMATCH
+        ///   -&gt; <see cref="InstallStatusEnum.Installed"/> (mirrors the WF detail-string "PATCHED_IF" rule).</item>
+        /// </list>
+        /// If every marker is resolvable and none indicates installed -&gt;
+        /// <see cref="InstallStatusEnum.NotInstalled"/>. A patch with NO install markers is
+        /// <see cref="InstallStatusEnum.NotInstalled"/> — inheriting WF's own blind spot (WF's
+        /// <c>IsInstalled</c> is likewise false for a marker-less patch).
+        /// </para>
+        /// <para>
+        /// <b>SOUNDNESS.</b> This is a deliberate OVER-approximation: it returns NotInstalled only when it
+        /// can PROVE (resolvably) the patch is absent. Any doubt (an unresolvable marker) yields Unknown, so
+        /// the safe-reject gate never says "safe" while the patch could be present. The only residual gap is
+        /// the WF-inherited marker-less case, which is documented and identical to WF.
+        /// </para>
+        /// The ROM is passed EXPLICITLY (no CoreState.ROM read), honoring this file's header guarantee.
+        /// </summary>
+        public static InstallStatusEnum EaBinInstallStatus(ROM rom, PatchSt patch)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (patch == null) throw new ArgumentNullException(nameof(patch));
+            if (patch.Param == null) return InstallStatusEnum.NotInstalled;
+
+            bool sawUnknown = false;
+
+            foreach (var pair in patch.Param)
+            {
+                string[] sp = pair.Key.Split(':');
+                string key = sp[0];
+                string addrstring = U.at(sp, 1);
+                string value = pair.Value;
+
+                // Only the two INSTALL markers count toward installed-status (WF IsInstalled looks for
+                // "PATCHED_IF" in the detail string, which only PATCHED_IF / PATCHED_IFNOT produce).
+                bool isPatchedIfNot;
+                if (key == "PATCHED_IF") isPatchedIfNot = false;
+                else if (key == "PATCHED_IFNOT") isPatchedIfNot = true;
+                else continue;
+
+                // SOUNDNESS — detect UNFAITHFULLY-resolvable signatures BEFORE trusting the resolved
+                // address. convertBinAddressString does NOT fail cleanly for the $FGREP <file>
+                // file-inclusion form: MakeGrepData ignores the file and mis-parses the filename token as
+                // a hex byte, so Grep returns a WRONG-but-safe offset (NOT NOT_FOUND). Reading bytes at
+                // that garbage offset could spuriously report Installed or NotInstalled — neither sound.
+                // So any marker whose addrstring is a form this Core build cannot faithfully resolve
+                // ($FGREP / $XGREP / $FREEAREA) is Unknown OUTRIGHT, regardless of what the resolver returns.
+                if (!IsFaithfullyResolvableInstallAddress(addrstring))
+                {
+                    sawUnknown = true;
+                    continue;
+                }
+
+                string basedir = Path.GetDirectoryName(patch.PatchFileName) ?? "";
+                uint address = convertBinAddressString(rom, addrstring, basedir);
+                if (!U.isSafetyOffset(address, rom))
+                {
+                    // Resolver returned NOT_FOUND / an unsafe offset (e.g. an unsupported macro, a $GREP
+                    // whose inline pattern was not found, or a $0x pointer into freespace) — cannot prove
+                    // this marker absent. Remember it and keep scanning: a LATER resolvable marker proving
+                    // Installed still wins (more precise), but if no marker proves Installed we fall back to
+                    // Unknown for the whole patch.
+                    sawUnknown = true;
+                    continue;
+                }
+
+                string[] args = value.Split(' ');
+                if (args.Length <= 1)
+                {
+                    // A malformed marker (no comparison window) cannot be evaluated -> Unknown.
+                    sawUnknown = true;
+                    continue;
+                }
+
+                bool readOk = true;
+                uint[] data = new uint[args.Length];
+                for (int i = 0; i < args.Length; i++)
+                {
+                    uint a = address + (uint)i;
+                    if (!U.isSafetyOffset(a, rom)) { readOk = false; break; }
+                    data[i] = rom.u8(a);
+                }
+                if (!readOk)
+                {
+                    sawUnknown = true;
+                    continue;
+                }
+
+                bool notFound = false;
+                for (int i = 0; i < args.Length; i++)
+                {
+                    if (data[i] != U.atoi0x(args[i]))
+                    {
+                        notFound = true;
+                        break;
+                    }
+                }
+
+                // WF detail-string "PATCHED_IF" => installed:
+                //   PATCHED_IF    installed when bytes MATCH    (notFound == false)
+                //   PATCHED_IFNOT installed when bytes MISMATCH (notFound == true)
+                bool markerSaysInstalled = isPatchedIfNot ? notFound : !notFound;
+                if (markerSaysInstalled)
+                {
+                    return InstallStatusEnum.Installed;
+                }
+            }
+
+            return sawUnknown ? InstallStatusEnum.Unknown : InstallStatusEnum.NotInstalled;
+        }
+
+        /// <summary>
+        /// Can <paramref name="addrstring"/> (an install-marker address) be resolved FAITHFULLY by this
+        /// Core build's <see cref="convertBinAddressString"/>? Returns <c>false</c> for the macro forms the
+        /// resolver does NOT port faithfully and which it cannot reject cleanly:
+        /// <list type="bullet">
+        ///   <item><c>$FGREP...</c> — file-inclusion GREP. <see cref="MakeGrepData"/> ignores the referenced
+        ///   file and mis-parses the filename as a hex byte, so the resolver returns a WRONG-but-safe offset
+        ///   (not NOT_FOUND). Reading bytes there is meaningless, so the marker must be treated as Unknown.</item>
+        ///   <item><c>$XGREP...</c> — masked GREP, not ported (resolver returns NOT_FOUND).</item>
+        ///   <item><c>$FREEAREA</c> — resolver returns 0 under the install path; not a real byte marker.</item>
+        /// </list>
+        /// Every other form (plain numeric, <c>$0x</c> pointer, inline <c>$GREP</c>/<c>$GREP_ENABLE_POINTER</c>,
+        /// <c>$P32</c>) either resolves faithfully or maps to NOT_FOUND, which the caller already treats as
+        /// Unknown via the safety-offset check. This is deliberately conservative — when in doubt, Unknown.
+        /// </summary>
+        static bool IsFaithfullyResolvableInstallAddress(string addrstring)
+        {
+            if (string.IsNullOrEmpty(addrstring)) return false; // empty/null -> resolver NOT_FOUND anyway
+            if (addrstring[0] != '$') return true;              // plain numeric address — always faithful
+
+            string value = addrstring.Substring(1);
+            if (value.Length == 0) return false;
+
+            // $FGREP / $XGREP — the un-ported GREP variants (file-inclusion / masked). Match the same
+            // family prefix convertBinAddressString uses; the F/X flag is the un-ported one.
+            if (value.StartsWith("FGREP", StringComparison.Ordinal)) return false;
+            if (value.StartsWith("XGREP", StringComparison.Ordinal)) return false;
+            if (value.StartsWith("FREEAREA", StringComparison.Ordinal)) return false;
+
+            return true;
+        }
+
         // ---- convertBinAddressString (~:3000) ----------------------------------
         // Ports the address-resolution forms used by CheckIF (appnedSize == 0,
         // start_offset == 0x100). Plain addresses + $pointer + the GREP family +

--- a/FEBuilderGBA.Core/PatchHardCodeScanner.cs
+++ b/FEBuilderGBA.Core/PatchHardCodeScanner.cs
@@ -416,9 +416,11 @@ namespace FEBuilderGBA
         ///   -&gt; <see cref="InstallStatusEnum.Installed"/> (mirrors the WF detail-string "PATCHED_IF" rule).</item>
         /// </list>
         /// If every marker is resolvable and none indicates installed -&gt;
-        /// <see cref="InstallStatusEnum.NotInstalled"/>. A patch with NO install markers is
-        /// <see cref="InstallStatusEnum.NotInstalled"/> — inheriting WF's own blind spot (WF's
-        /// <c>IsInstalled</c> is likewise false for a marker-less patch).
+        /// <see cref="InstallStatusEnum.NotInstalled"/>. A patch with NO install markers (an empty but
+        /// non-null Param) is <see cref="InstallStatusEnum.NotInstalled"/> — inheriting WF's own blind spot
+        /// (WF's <c>IsInstalled</c> is likewise false for a marker-less patch). A <c>null</c> Param (which
+        /// cannot be inspected at all) is <see cref="InstallStatusEnum.Unknown"/> — uninspectable proves
+        /// nothing, so the conservative answer is "possibly installed".
         /// </para>
         /// <para>
         /// <b>SOUNDNESS.</b> This is a deliberate OVER-approximation: it returns NotInstalled only when it
@@ -432,7 +434,12 @@ namespace FEBuilderGBA
         {
             if (rom == null) throw new ArgumentNullException(nameof(rom));
             if (patch == null) throw new ArgumentNullException(nameof(patch));
-            if (patch.Param == null) return InstallStatusEnum.NotInstalled;
+            // A null Param means NO marker can be inspected. The contract is "NotInstalled only when
+            // absence is PROVEN (every resolvable marker evaluated, none matched)". An uninspectable
+            // patch proves nothing, so the only SOUND answer is Unknown — the safe-reject gate must not
+            // treat it as safe (Copilot PR #1326 review). (LoadPatch never produces a null Param, so this
+            // guards only a direct/synthetic caller.)
+            if (patch.Param == null) return InstallStatusEnum.Unknown;
 
             bool sawUnknown = false;
 

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -12898,6 +12898,175 @@ namespace FEBuilderGBA
         }
 
         // ====================================================================
+        // PatchForm producer — option-B epic (#1261, sub-slice s2pf-12 of 17).
+        //
+        // The PER-ROM SAFE-REJECT BACKSTOP — landed FIRST in the EA/BIN phase so
+        // the producer is SOUND on ANY modded ROM before the EA/BIN arms exist.
+        //
+        // WHY (subtle): the MakeWithProducer gate currently refuses ALL rebuilds
+        // because "PatchForm(MakePatchStructDataList)" stays in AsmNotYetPortedRaw
+        // -> AsmProducerResult.IsComplete is false. The eventual gate-open (s2pf-17)
+        // REMOVES that token so the COMMON-case rebuild can run. But the EA/BIN arms
+        // cannot faithfully emit an INSTALLED EA/BIN patch (every EA/BIN arm is an
+        // honest no-op skip today). So we add a per-ROM runtime backstop that
+        // REFUSES a rebuild when the loaded ROM carries an EA/BIN patch the producer
+        // can't emit AND whose bytes are (or might be) present — so that even after
+        // the token is removed, a modded ROM with such a patch STILL refuses (it
+        // never silently relocates the wrong bytes = ROM corruption). Landing this
+        // NOW makes the producer sound on any modded ROM independent of the token.
+        //
+        // SOUNDNESS (and the original "false-negative impossible" claim — RETRACTED).
+        // The first draft of this gate used `CheckIF == "I"` and claimed installed
+        // <=> CheckIF == "I". Copilot's plan review (issue #1325) correctly showed
+        // that is NOT an iff — CheckIF returns "I" ONLY for a PATCHED_IF match, but a
+        // patch can be installed via OTHER markers Core's fast CheckIF does NOT map to
+        // "I", giving real FALSE-NEGATIVES on a MODDED ROM:
+        //   1. PATCHED_IFNOT-installed (e.g. FE8U/MNC2Fix, TYPE=EA, only PATCHED_IFNOT):
+        //      WF IsInstalled treats a matched PATCHED_IFNOT as installed (its detail
+        //      string contains "PATCHED_IF"); the fast CheckIF returns "E"/"" there.
+        //   2. EA/BIN install markers using $FGREP <file> file-inclusion / $XGREP
+        //      signatures (162 such PATCHED_IF rows in the FE8U tree): Core's resolver
+        //      does not port FGREP file-inclusion, so it yields NOT_FOUND and never "I"
+        //      even when the patch IS installed.
+        // The dangerous direction is exactly a false-NEGATIVE (say "safe" when an
+        // installed EA/BIN patch is present), so the gate must NOT use CheckIF=="I".
+        //
+        // The SOUND replacement (PatchHardCodeScanner.EaBinInstallStatus): a tri-state
+        // install check that is a conservative OVER-approximation of WF's IsInstalled
+        // (PatchForm.cs:199, "detail CheckIF contains PATCHED_IF"). It inspects BOTH
+        // install markers (PATCHED_IF match OR PATCHED_IFNOT match => Installed, fixing
+        // #1) and, crucially, returns Unknown for any marker whose signature Core
+        // cannot resolve ($FGREP file-inclusion / $XGREP / unsupported macro, fixing
+        // #2). The gate REFUSES on Installed OR Unknown — so it never says "safe" while
+        // a patch could be present. NotInstalled (every marker resolvable, none
+        // matched) is the only "allow". The sole residual gap is an EA/BIN patch with
+        // NO install marker at all, which WF's OWN IsInstalled likewise reports as
+        // not-installed — an INHERITED WF blind spot, documented, not a new divergence.
+        //
+        // (Contrast the REJECTED PatchFormWouldEmitNothing, which was unsafe because a
+        // FALSE-POSITIVE "would emit nothing" could let an unsafe rebuild PROCEED; this
+        // predicate is the inverse — its conservative error mode is OVER-refusal of a
+        // not-installed-but-unresolvable patch, which is safe.)
+        //
+        // CONSERVATIVE-CURRENT-SCOPE / over-refusal tradeoff. Because the EA/BIN arms
+        // are ENTIRELY un-ported, an Unknown ($FGREP file-inclusion) marker on a ROM
+        // where the patch is actually NOT installed still refuses. That is SOUND but
+        // over-conservative; it means a VANILLA FE8U whose tree carries such markers
+        // can refuse. Narrowing it (so vanilla FE8U passes the gate, which the s2pf-17
+        // gate-open needs to be useful on FE8U) requires porting FGREP file-inclusion
+        // install-resolution — DEFERRED, a precise prerequisite for s2pf-17, NOT this
+        // slice. Soundness (no false-negative) is the priority here and is achieved.
+        // ====================================================================
+
+        /// <summary>
+        /// Per-ROM safe-reject predicate (#1261 s2pf-12): does <paramref name="rom"/> carry an EA/BIN
+        /// patch the PatchForm producer cannot faithfully emit AND whose bytes are (or might be) present?
+        /// Restricted to the un-ported TYPEs (EA/BIN) of the WinForms
+        /// <c>PatchForm.MakePatchStructDataList</c> dispatch (FEBuilderGBA/PatchForm.cs:7126):
+        /// <list type="number">
+        ///   <item>If <see cref="SafePatchVersionFolder"/> is "" (version 0 / no RomInfo / no patch
+        ///   dir) -> false (nothing to scan, matching the WF <c>ScanPatchs version==0</c> guard).</item>
+        ///   <item><see cref="PatchHardCodeScanner.ScanPatchs"/> the version dir; per patch skip
+        ///   <see cref="PatchHardCodeScanner.isCanonicalSkip"/>; read TYPE; skip unless EA or BIN;
+        ///   then <see cref="PatchHardCodeScanner.EaBinInstallStatus"/> -> refuse on
+        ///   <see cref="PatchHardCodeScanner.InstallStatusEnum.Installed"/> OR
+        ///   <see cref="PatchHardCodeScanner.InstallStatusEnum.Unknown"/> (the producer cannot emit the
+        ///   patch's bytes, so a rebuild would drop them = corruption).</item>
+        ///   <item>Every EA/BIN patch resolvably NotInstalled (or none present) -> false.</item>
+        /// </list>
+        /// <para>
+        /// <b>SOUNDNESS.</b> Refusing on Installed OR Unknown means the gate never reports "safe" while an
+        /// EA/BIN patch could be present (the dangerous false-negative). The original CheckIF=="I" draft
+        /// was UNSOUND (Copilot plan review, issue #1325): CheckIF=="I" misses PATCHED_IFNOT-installed and
+        /// $FGREP-file-inclusion-signature patches. See <see cref="PatchHardCodeScanner.EaBinInstallStatus"/>
+        /// and the block comment above for the full argument and the inherited WF blind spot
+        /// (marker-less EA/BIN patches).
+        /// </para>
+        /// <para>
+        /// <b>CONSERVATIVE CURRENT SCOPE.</b> Today the EA/BIN arms are ENTIRELY un-ported, so this flags
+        /// ANY Installed-or-Unknown EA/BIN patch. The Unknown bucket ($FGREP file-inclusion / $XGREP) makes
+        /// it OVER-refuse a not-installed-but-unresolvable patch — sound, but it can refuse a VANILLA FE8U.
+        /// Narrowing that (port FGREP file-inclusion install-resolution) is the precise prerequisite for the
+        /// s2pf-17 gate-open to be useful on FE8U, and is deliberately NOT implemented here.
+        /// </para>
+        /// <para>The ROM is passed EXPLICITLY (never <c>CoreState.ROM</c>), exactly like the
+        /// orchestrator, so headless tests and off-thread rebuilds use the right instance.</para>
+        /// </summary>
+        /// <param name="rom">The ROM to inspect — passed explicitly (NOT CoreState.ROM).</param>
+        /// <returns><c>true</c> iff the ROM has at least one EA/BIN patch the producer can't emit that is
+        /// Installed or whose install status is Unknown.</returns>
+        public static bool PatchFormHasUnportableInstalledPatch(ROM rom)
+        {
+            return FirstUnportableInstalledPatchName(rom) != null;
+        }
+
+        /// <summary>
+        /// The filename of the FIRST EA/BIN patch the PatchForm producer cannot faithfully emit for
+        /// <paramref name="rom"/> that is Installed or has Unknown install status, or <c>null</c> when
+        /// there is none. Drives both <see cref="PatchFormHasUnportableInstalledPatch"/> (the bool
+        /// predicate) and the
+        /// <see cref="MakeWithProducer(ROM, ROM, uint, string, bool, bool, IProgress{string}, CancellationToken)"/>
+        /// refusal message (so the user sees WHICH patch blocked the rebuild). Single scan, single gate —
+        /// the bool predicate is just <c>!= null</c> over this, so they can never disagree.
+        /// </summary>
+        static string FirstUnportableInstalledPatchName(ROM rom)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+
+            // Same version-folder guard the orchestrator uses: version 0 / no RomInfo -> no patch
+            // dir -> nothing installed (matches the WF ScanPatchs version==0 short-circuit).
+            string version = SafePatchVersionFolder(rom);
+            if (string.IsNullOrEmpty(version))
+            {
+                return null;
+            }
+            string patchDir = PatchHardCodeScanner.ResolvePatchDirectory(version);
+            string lang = CoreState.Language ?? "en";
+
+            List<PatchInstallCore.PatchSt> patchs = PatchHardCodeScanner.ScanPatchs(rom, patchDir, lang);
+            for (int i = 0; i < patchs.Count; i++)
+            {
+                PatchInstallCore.PatchSt patch = patchs[i];
+
+                if (PatchHardCodeScanner.isCanonicalSkip(patch))
+                {
+                    continue;
+                }
+
+                string type = U.at(patch.Param, "TYPE");
+                // Only the un-ported EA/BIN TYPEs can carry an unemittable installed patch. STRUCT/
+                // IMAGE/ADDR/SWITCH are all faithfully emitted (s2pf-3..10), so they are never a reason
+                // to refuse. This is the SAME TYPE classification the orchestrator's dispatch uses.
+                if (type != "EA" && type != "BIN")
+                {
+                    continue;
+                }
+
+                // SOUND install check: refuse on Installed (the bytes ARE present) OR Unknown (the install
+                // signature is unresolvable — e.g. $FGREP file-inclusion — so we cannot PROVE absence).
+                // NOT CheckIF=="I", which misses PATCHED_IFNOT-installed and $FGREP-signature patches
+                // (false-negatives — Copilot plan review, issue #1325). Only NotInstalled is allowed.
+                PatchHardCodeScanner.InstallStatusEnum status =
+                    PatchHardCodeScanner.EaBinInstallStatus(rom, patch);
+                if (status == PatchHardCodeScanner.InstallStatusEnum.Installed
+                    || status == PatchHardCodeScanner.InstallStatusEnum.Unknown)
+                {
+                    // LoadPatch sets only PatchFileName (not Name), so use the file's base name for a
+                    // human-readable identity; fall back to the full path / a placeholder if absent.
+                    string file = patch.PatchFileName;
+                    if (string.IsNullOrEmpty(file))
+                    {
+                        return "<unnamed EA/BIN patch>";
+                    }
+                    try { return System.IO.Path.GetFileName(file); }
+                    catch { return file; }
+                }
+            }
+
+            return null;
+        }
+
+        // ====================================================================
         // PatchForm producer — option-B epic (#1261, sub-slice s2pf-3 of 11).
         //
         // The two TRIVIAL terminal TYPE arms: ADDR and SWITCH. Faithful Core
@@ -14248,6 +14417,30 @@ namespace FEBuilderGBA
             if (rom == null) throw new ArgumentNullException(nameof(rom));
             if (vanilla == null) throw new ArgumentNullException(nameof(vanilla));
             if (string.IsNullOrEmpty(manifestPath)) throw new ArgumentNullException(nameof(manifestPath));
+
+            // 0) PER-ROM SAFE-REJECT BACKSTOP (#1261 s2pf-12). REFUSE the rebuild when THIS rom carries
+            //    an EA/BIN patch the PatchForm producer can't faithfully emit AND whose bytes are (or
+            //    might be) present — i.e. install status Installed OR Unknown (see
+            //    FirstUnportableInstalledPatchName / PatchHardCodeScanner.EaBinInstallStatus). This is IN
+            //    ADDITION to the IsComplete gate below (and runs FIRST, fail-fast, before the producers).
+            //    Today it is belt-and-suspenders — the "PatchForm(MakePatchStructDataList)" token keeps
+            //    the IsComplete gate CLOSED for every rom — but it becomes the LOAD-BEARING soundness
+            //    invariant the instant the token is removed (s2pf-17): even then, a modded rom with an
+            //    installed-but-unemittable EA/BIN patch must still refuse rather than silently relocate
+            //    the wrong bytes (= ROM corruption). The check is SOUND (no false-negative): it refuses
+            //    whenever install status cannot be PROVEN NotInstalled, so it never reports "safe" while a
+            //    patch could be present. (The naive CheckIF=="I" predicate would be unsound — it misses
+            //    PATCHED_IFNOT-installed and $FGREP-signature patches; Copilot plan review, issue #1325.)
+            string unportablePatch = FirstUnportableInstalledPatchName(rom);
+            if (unportablePatch != null)
+            {
+                throw new InvalidOperationException(
+                    "ROM rebuild unavailable: this ROM has an installed (or possibly-installed) EA/BIN "
+                    + "patch the PatchForm producer cannot faithfully emit yet (" + unportablePatch
+                    + "). Driving RebuildMakeCore.Make would drop that patch's un-enumerated bytes (the "
+                    + "rebuild treats every region NOT in the struct list as free) = silent ROM corruption. "
+                    + "The rebuild stays disabled for this ROM until the EA/BIN producer arms land in Core.");
+            }
 
             // 1) data-path producer.
             ProducerResult data = MakeAllStructPointers(rom, progress, ct);


### PR DESCRIPTION
Part of #1261 (PatchForm option-B epic). Closes #1325. Sub-slice **12/17** — the FIRST of the EA/BIN phase, landing the per-ROM soundness backstop FIRST so the producer is sound on ANY modded ROM before the EA/BIN arms exist.

## What

- **`RebuildProducerCore.PatchFormHasUnportableInstalledPatch(ROM) -> bool`** (+ private `FirstUnportableInstalledPatchName` driving both the bool and the refusal message). Restricted to the un-ported EA/BIN TYPEs of WF `PatchForm.MakePatchStructDataList`'s `isInstallOnly` gate (`PatchForm.cs:7126`): per non-skip EA/BIN patch, refuse on install status **Installed OR Unknown**.
- **`PatchHardCodeScanner.EaBinInstallStatus(ROM, PatchSt) -> {NotInstalled, Installed, Unknown}`** — a SOUND tri-state over-approximation of WF `IsInstalled` (`PatchForm.cs:199`, "detail `CheckIF` contains `PATCHED_IF`") + `IsFaithfullyResolvableInstallAddress` (flags `$FGREP`/`$XGREP`/`$FREEAREA` as unresolvable → Unknown).
- **Wire the public `MakeWithProducer(ROM, ROM, ...)`** to call the predicate FIRST (fail-fast) and REFUSE `Make` with an `InvalidOperationException` **naming the offending patch** — IN ADDITION to the existing IsComplete gate.
- **Token `"PatchForm(MakePatchStructDataList)"` STAYS** in `AsmNotYetPortedRaw` (gate-open is s2pf-17). No `--force`/bypass. The no-patch-dir / version-0 invariants preserved.

## Soundness — the CheckIF false-negative analysis (the crux of this slice)

The original draft used `CheckIF == "I"` and claimed installed ⇔ `CheckIF == "I"`, i.e. "false-negative impossible." **That claim is RETRACTED.** Copilot's plan review (issue #1325) correctly showed `CheckIF == "I"` is NOT iff "installed" — there are real **false-negatives** (the only dangerous direction) on a modded ROM:

1. **`PATCHED_IFNOT`-installed** (e.g. `config/patch2/FE8U/MNC2Fix/Patch_MNC2Fix.txt`, `TYPE=EA`, only `PATCHED_IFNOT`): WF `IsInstalled` deems a matched `PATCHED_IFNOT` installed (its detail string contains `"PATCHED_IF"`); Core's fast `CheckIF` returns `"E"`/`""` there, never `"I"`.
2. **`$FGREP <file>` file-inclusion install markers** (162 such `PATCHED_IF` rows in the FE8U tree): Core's resolver does not port FGREP file-inclusion — it mis-resolves to a garbage-but-safe offset (NOT a clean `NOT_FOUND`), so it never returns `"I"` even when the patch IS installed.

A patch with **no** install marker at all is reported NotInstalled — but that is WF's OWN behavior too (`IsInstalled` is likewise false for a marker-less patch), so it is an **inherited WF blind spot**, documented, not a new divergence.

**The sound fix** (`EaBinInstallStatus`): refuse on **Installed OR Unknown**, so the gate never reports "safe" while a patch could be present. It catches `PATCHED_IFNOT`-installed (fix #1) and returns Unknown for unresolvable signatures (fix #2). The only error mode is OVER-refusal (Unknown on a not-installed-but-unresolvable patch) — which is SAFE. Contrast the REJECTED `PatchFormWouldEmitNothing`, whose false-POSITIVE could let an unsafe rebuild PROCEED.

**Conclusion: the gate is SOUND** (no false-negative) for the current scope.

## Tradeoff (documented, deferred)

The Unknown bucket (`$FGREP` file-inclusion) makes the gate **over-refuse** a not-installed-but-unresolvable patch — sound, but it can refuse a VANILLA FE8U. Narrowing it (so vanilla FE8U passes, which s2pf-17's gate-open needs to be useful on FE8U) requires **porting FGREP file-inclusion install-resolution** — DEFERRED. Precise blocker: `PatchHardCodeScanner.MakeGrepData`/`convertBinAddressString` do not read the referenced `$FGREP <file>` content. This is a precise prerequisite for s2pf-17, NOT this slice. **Soundness is the priority here and is achieved.**

## Why land first (12/17, token stays)

Even after the token is removed at s2pf-17, a modded ROM with an installed/unknown EA/BIN patch the producer can't emit STILL refuses rather than silently relocate the wrong bytes (= ROM corruption). The token stays so the IsComplete gate keeps the common-case rebuild closed today; this backstop becomes load-bearing the instant the token is removed.

## Test plan

All automated in `FEBuilderGBA.Core.Tests/RebuildProducerPatchSafeRejectTests.cs` (20 new tests):

- [x] `EaBinInstallStatus`: `PATCHED_IF` match → Installed; `PATCHED_IFNOT` mismatch → Installed (the false-negative #1 regression, + sanity that `CheckIF != "I"`); `PATCHED_IF` mismatch → NotInstalled; `PATCHED_IFNOT` match → NotInstalled; `$FGREP` → Unknown (false-negative #2 regression); marker-less → NotInstalled; installed-marker wins over unknown-marker.
- [x] Predicate: installed EA+BIN → true; `PATCHED_IFNOT`-installed → true; `$FGREP`-unknown → true; resolvably-not-installed EA/BIN → false; installed STRUCT → false (not EA/BIN); CANONICAL_SKIP installed EA → false; mixed tree → true; no-patch-dir → false; version-0 → false; null ROM → throws.
- [x] `MakeWithProducer`: ROM with installed EA/BIN → throws naming the patch (`PATCH_BIN.txt`), no manifest; no-EA/BIN → still throws on the IsComplete gate naming `PatchForm(MakePatchStructDataList)`; token stays in `AsmNotYetPortedRaw`.
- [x] `dotnet test FEBuilderGBA.Core.Tests` → **5152 passed / 0 failed / 6 skipped** (real-ROM skips).
- [x] `dotnet build FEBuilderGBA.sln` → 0 errors.
- [x] FEBuilderGBA.Tests RebuildProducer/PatchForm parity → 6 passed.

## Screenshots

Core-only change (no GUI). Per the workflow, non-GUI PRs use test output as proof:

```
Passed!  - Failed:     0, Passed:    20, Skipped:     0  (RebuildProducerPatchSafeRejectTests)
Passed!  - Failed:     0, Passed:  5152, Skipped:     6  (FEBuilderGBA.Core.Tests, full)
Build succeeded.  0 Error(s)  (FEBuilderGBA.sln)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]