### PR TITLE
refactor(core): expose EA trace helpers ROM-explicit for the producer EA arm (#1261 s2pf-13)

### DIFF
--- a/FEBuilderGBA.Core.Tests/EventAssemblerUninstallCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerUninstallCoreTests.cs
@@ -437,6 +437,89 @@ namespace FEBuilderGBA.Core.Tests
             }
         }
 
+        // ---- Exposed EA walker byte-identity (#1261 s2pf-13) ----------------------
+        //
+        // s2pf-13 hoisted the inline DataList walk out of TraceEAFile into the now-exposed
+        // EventAssemblerUninstallCore.EmitEaDataList (internal static, ROM-explicit) so the
+        // rebuild-producer EA arm (s2pf-14) can reuse the SAME verified #1242 walker. This
+        // is a pure refactor — the test locks that the exposed walker, driven directly with
+        // an explicit ROM + freshly-parsed EAUtilCore, produces a BinMapping list BYTE-FOR-
+        // BYTE identical to what TraceEAFile produces internally. If a future edit diverges
+        // the two paths, this fails.
+        [Fact]
+        public void EmitEaDataList_MatchesTraceEAFile_BinMappings_ByteForByte()
+        {
+            var rom = CreateFE8Rom();
+            Assert.NotNull(rom);
+
+            // A multi-block EA exercising ORG (length-unknown 64-byte grab) + a BIN that
+            // GREP-matches a unique pattern we plant in the ROM. Both paths must build the
+            // same mappings from the same ROM bytes.
+            byte[] pattern = { 0xCA, 0xFE, 0xBA, 0xBE, 0xDE, 0xAD, 0xBE, 0xEF };
+            const uint orgAddr = 0x800000;
+            const uint binAddr = 0x801000;
+            for (int i = 0; i < pattern.Length; i++)
+                rom.write_u8(binAddr + (uint)i, pattern[i]);
+
+            string eaDir = Path.Combine(Path.GetTempPath(), "ea-identity-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(eaDir);
+            File.WriteAllBytes(Path.Combine(eaDir, "blk.bin"), pattern);
+            string eaFile = Path.Combine(eaDir, "id.event");
+            File.WriteAllText(eaFile,
+                "ORG 0x" + orgAddr.ToString("X") + "\r\n" +
+                "#incbin \"blk.bin\" // HINT=BIN\r\n");
+            try
+            {
+                // Path A: the uninstall entry (delegates to EmitEaDataList internally).
+                var trace = EventAssemblerUninstallCore.TraceEAFile(eaFile);
+
+                // Path B: drive the exposed walker DIRECTLY, ROM-explicit.
+                var ea = new EAUtilCore(eaFile);
+                var direct = new List<EventAssemblerUninstallCore.BinMapping>();
+                var directUntraceable = new List<string>();
+                EventAssemblerUninstallCore.EmitEaDataList(rom, ea, direct, directUntraceable);
+
+                // Both produced the same number of mappings ...
+                Assert.Equal(trace.Mappings.Count, direct.Count);
+                Assert.True(direct.Count >= 1);
+
+                // ... and each mapping is byte-for-byte identical (addr/length/type/key/bin).
+                for (int i = 0; i < direct.Count; i++)
+                {
+                    var a = trace.Mappings[i];
+                    var b = direct[i];
+                    Assert.Equal(a.addr, b.addr);
+                    Assert.Equal(a.length, b.length);
+                    Assert.Equal(a.type, b.type);
+                    Assert.Equal(a.key, b.key);
+                    Assert.Equal(a.bin, b.bin); // exact byte content
+                }
+
+                // The BIN mapping matched the planted pattern address.
+                Assert.Contains(direct, m => m.addr == binAddr && m.key == "BIN");
+            }
+            finally { try { Directory.Delete(eaDir, true); } catch { } }
+        }
+
+        // The pure mask helpers are exposed (internal static) for the producer EA arm and
+        // must keep producing the SAME masks — they carry no ROM state, so a direct call
+        // is the byte-identity lock. MakeLynMaskPattern masks all-zero 4-byte words;
+        // MakeFullMask is all-true.
+        [Fact]
+        public void ExposedMaskHelpers_ProduceExpectedMasks()
+        {
+            // Two 4-byte words: the first all-zero (lyn relocates → masked), the second not.
+            byte[] lynBin = { 0x00, 0x00, 0x00, 0x00, 0x12, 0x34, 0x56, 0x78 };
+            bool[] lynMask = EventAssemblerUninstallCore.MakeLynMaskPattern(lynBin);
+            Assert.Equal(lynBin.Length, lynMask.Length);
+            Assert.True(lynMask[0] && lynMask[1] && lynMask[2] && lynMask[3]);   // zero word masked
+            Assert.True(!lynMask[4] && !lynMask[5] && !lynMask[6] && !lynMask[7]); // non-zero word kept
+
+            bool[] full = EventAssemblerUninstallCore.MakeFullMask(5);
+            Assert.Equal(5, full.Length);
+            Assert.All(full, m => Assert.True(m));
+        }
+
         // ---- EAUtilCore parser coverage (the extracted parse-only port) ----------
 
         [Fact]

--- a/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
+++ b/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
@@ -163,6 +163,37 @@ namespace FEBuilderGBA
             // Carry over parser-level untraceable blocks (un-hinted inline PNG rasters).
             result.Untraceable.AddRange(ea.UntraceableNotes);
 
+            EmitEaDataList(rom, ea, binMappings, result.Untraceable);
+
+            return result;
+        }
+
+        /// <summary>
+        /// The byte-identical EA DataList walk shared by the uninstall trace
+        /// (<see cref="TraceEAFile"/>) and the rebuild-producer EA arm (#1261 s2pf-14).
+        /// Walks the parsed <paramref name="ea"/> entries (ORG / ASM / MIX / LYN /
+        /// LYNHOOK / POINTER_ARRAY / PROCS / BIN), building the
+        /// <see cref="BinMapping"/>s it can reconstruct into <paramref name="binMappings"/>
+        /// by GREP-matching the expanded bytes against <paramref name="rom"/> from a
+        /// monotonically advancing <c>lastMatchAddr</c> baseline (seeded at
+        /// <c>RomInfo.compress_image_borderline_address</c>), and recording any block it
+        /// could NOT trace (GREP miss, guarded PROCS) into <paramref name="untraceable"/>.
+        ///
+        /// <para>Exposed (internal static, ROM-explicit) for the rebuild-producer EA arm,
+        /// s2pf-14; this is the ONE walker both the uninstall path and the producer arm
+        /// call, so they stay byte-identical. Behaviour is unchanged from the original
+        /// inline <see cref="TraceEAFile"/> walk — the only difference is that the ROM it
+        /// reads is passed explicitly rather than re-read from <see cref="CoreState.ROM"/>
+        /// (the uninstall caller passes <c>CoreState.ROM</c>, so the result is identical).</para>
+        /// </summary>
+        /// <param name="rom">The ROM the expanded blocks are GREP-matched against (the
+        /// current/patched ROM for the uninstall path). Must be non-null with a non-null
+        /// <c>RomInfo</c> — the callers guard this before calling.</param>
+        /// <param name="ea">The parsed EA file whose <see cref="EAUtilCore.DataList"/> is walked.</param>
+        /// <param name="binMappings">Accumulator for the reconstructed ranges (appended to).</param>
+        /// <param name="untraceable">Accumulator for blocks that could not be traced (appended to).</param>
+        internal static void EmitEaDataList(ROM rom, EAUtilCore ea, List<BinMapping> binMappings, List<string> untraceable)
+        {
             uint lastMatchAddr = rom.RomInfo.compress_image_borderline_address;
 
             for (int n = 0; n < ea.DataList.Count; n++)
@@ -210,7 +241,7 @@ namespace FEBuilderGBA
                     uint addr = U.GrepPatternMatch(rom.Data, mod, isSkip, lastMatchAddr, 0, 4);
                     if (addr == U.NOT_FOUND)
                     {//パッチが見つからなかった — 復元できない残骸として記録する.
-                        result.Untraceable.Add(R._("{0} block not found in ROM: {1}",
+                        untraceable.Add(R._("{0} block not found in ROM: {1}",
                             data.DataType.ToString(), BlockName(data.Name)));
                         continue;
                     }
@@ -248,7 +279,7 @@ namespace FEBuilderGBA
                     uint addr = U.GrepPatternMatch(rom.Data, data.BINData, isSkip, lastMatchAddr, 0, 4);
                     if (addr == U.NOT_FOUND)
                     {//LYN ELFが見つからなかった — 復元できない残骸として記録する.
-                        result.Untraceable.Add(R._("LYN block not found in ROM: {0}", BlockName(data.Name)));
+                        untraceable.Add(R._("LYN block not found in ROM: {0}", BlockName(data.Name)));
                         continue;
                     }
                     uint length = (uint)data.BINData.Length;
@@ -347,7 +378,7 @@ namespace FEBuilderGBA
                     // range itself — identical to the WinForms tracer's `continue` when
                     // CalcLengthAndCheck returns NOT_FOUND. Record it as residue so the
                     // caller can warn. (See class doc scope note.)
-                    result.Untraceable.Add(R._("PROCS table (length detection is WinForms-only): {0}",
+                    untraceable.Add(R._("PROCS table (length detection is WinForms-only): {0}",
                         string.IsNullOrEmpty(data.Name) ? R._("(label)") : data.Name));
                     continue;
                 }
@@ -361,7 +392,7 @@ namespace FEBuilderGBA
                     uint addr = U.Grep(rom.Data, data.BINData, lastMatchAddr);
                     if (addr == U.NOT_FOUND)
                     {//BINが見つからなかった — 復元できない残骸として記録する.
-                        result.Untraceable.Add(R._("BIN block not found in ROM: {0}", BlockName(data.Name)));
+                        untraceable.Add(R._("BIN block not found in ROM: {0}", BlockName(data.Name)));
                         continue;
                     }
                     uint length = (uint)data.BINData.Length;
@@ -390,8 +421,6 @@ namespace FEBuilderGBA
                     lastMatchAddr = addr + length;
                 }
             }
-
-            return result;
         }
 
         /// <summary>
@@ -606,10 +635,20 @@ namespace FEBuilderGBA
         }
 
         // ---- Trace helpers (ports of the PatchForm private statics) ---------------
+        //
+        // These five are pure (no ROM read) and are exposed internal static for the
+        // rebuild-producer EA arm (#1261 s2pf-14), which calls them — together with
+        // <see cref="EmitEaDataList"/> — to stay byte-identical to this verified #1242
+        // uninstall trace. Visibility is the ONLY change; behaviour is unchanged.
 
         // Port of PatchForm.MakeMaskAddress: mask the LDR-pointer bytes inside a code
         // block so the address-dependent words don't break a GREP pattern match.
-        static bool[] MakeMaskAddress(byte[] original, uint base_address)
+        /// <summary>
+        /// Mask the LDR-pointer bytes inside a code block so the address-dependent words
+        /// don't break a GREP pattern match. Pure (no ROM read). Exposed for the
+        /// rebuild-producer EA arm, s2pf-14; byte-identical to the uninstall walk.
+        /// </summary>
+        internal static bool[] MakeMaskAddress(byte[] original, uint base_address)
         {
             bool[] isSkip = new bool[original.Length];
 
@@ -639,7 +678,12 @@ namespace FEBuilderGBA
         // Port of PatchForm.ReadMod(string[], byte[], out bool[]) — the instant-EA path
         // has no per-key address-move args, so chaddr is 0 and the mask is built off
         // base 0 (matching ReadMod with an empty sp[]).
-        static byte[] ReadMod(byte[] b, out bool[] isSkip)
+        /// <summary>
+        /// Build the GREP mask for an ASM/MIX block off base 0 (instant-EA path has no
+        /// per-key address-move args). Pure (no ROM read). Exposed for the
+        /// rebuild-producer EA arm, s2pf-14; byte-identical to the uninstall walk.
+        /// </summary>
+        internal static byte[] ReadMod(byte[] b, out bool[] isSkip)
         {
             uint chaddr = 0; // U.atoi0x(U.at(sp, 2)) with an empty sp == 0
             isSkip = MakeMaskAddress(b, chaddr);
@@ -648,7 +692,12 @@ namespace FEBuilderGBA
 
         //lynによってインポートされるelfのマスクパターンを作ります。
         // Port of PatchForm.MakeLynMaskPattern.
-        static bool[] MakeLynMaskPattern(byte[] bin)
+        /// <summary>
+        /// Build the GREP mask for a lyn-imported ELF (mask the all-zero 4-byte words
+        /// lyn relocates). Pure (no ROM read). Exposed for the rebuild-producer EA arm,
+        /// s2pf-14; byte-identical to the uninstall walk.
+        /// </summary>
+        internal static bool[] MakeLynMaskPattern(byte[] bin)
         {
             bool[] isSkip = new bool[bin.Length];
             for (int i = 0; i + 3 < bin.Length; i += 4)
@@ -665,7 +714,12 @@ namespace FEBuilderGBA
         }
 
         // Port of PatchForm.MakeFullMask.
-        static bool[] MakeFullMask(uint length)
+        /// <summary>
+        /// Build an all-true mask of <paramref name="length"/> bytes (POINTER_ARRAY,
+        /// where every byte is address-dependent). Pure (no ROM read). Exposed for the
+        /// rebuild-producer EA arm, s2pf-14; byte-identical to the uninstall walk.
+        /// </summary>
+        internal static bool[] MakeFullMask(uint length)
         {
             bool[] r = new bool[length];
             for (int i = 0; i < length; i++)
@@ -677,7 +731,12 @@ namespace FEBuilderGBA
 
         // Port of PatchForm.EraseORG: a later concrete mapping at the same address
         // supersedes a provisional ORG mapping there.
-        static void EraseORG(List<BinMapping> binMappings, BinMapping b)
+        /// <summary>
+        /// Drop a provisional ORG mapping superseded by a later concrete mapping at the
+        /// same address. Pure (no ROM read). Exposed for the rebuild-producer EA arm,
+        /// s2pf-14; byte-identical to the uninstall walk.
+        /// </summary>
+        internal static void EraseORG(List<BinMapping> binMappings, BinMapping b)
         {
             for (int i = 0; i < binMappings.Count; i++)
             {

--- a/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
+++ b/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
@@ -212,10 +212,10 @@ namespace FEBuilderGBA
                         type = Address.DataTypeEnum.MIX,
                     };
 
-                    if (U.isSafetyOffset(addr + 64))
+                    if (U.isSafetyOffset(addr + 64, rom))
                     {//長さが不明なので比較するとき困るので適当に64バイトほど取得します.
                         b.bin = rom.getBinaryData(addr, 64);
-                        b.mask = MakeMaskAddress(b.bin, addr);
+                        b.mask = MakeMaskAddress(b.bin, addr, rom);
                     }
                     else
                     {
@@ -235,7 +235,7 @@ namespace FEBuilderGBA
                     }
                     //展開されるものを生成して、GREP検索する必要があります.
                     bool[] isSkip;
-                    byte[] mod = ReadMod(data.BINData, out isSkip);
+                    byte[] mod = ReadMod(data.BINData, out isSkip, rom);
 
                     //可変なので、maskパターンを作って検索します.
                     uint addr = U.GrepPatternMatch(rom.Data, mod, isSkip, lastMatchAddr, 0, 4);
@@ -318,7 +318,7 @@ namespace FEBuilderGBA
                         bin = rom.getBinaryData(addr, length),
                         type = Address.DataTypeEnum.PATCH_ASM,
                     };
-                    b.mask = MakeMaskAddress(b.bin, addr);
+                    b.mask = MakeMaskAddress(b.bin, addr, rom);
 
                     binMappings.Add(b);
 
@@ -334,7 +334,7 @@ namespace FEBuilderGBA
                     for (; addr + 3 < rom.Data.Length; addr += 4)
                     {
                         uint a = rom.u32(addr);
-                        if (!U.isSafetyPointer(a))
+                        if (!U.isSafetyPointer(a, rom))
                         {
                             break;
                         }
@@ -412,7 +412,7 @@ namespace FEBuilderGBA
                     }
                     else
                     {
-                        b.mask = MakeMaskAddress(b.bin, addr);
+                        b.mask = MakeMaskAddress(b.bin, addr, rom);
                     }
 
                     EraseORG(binMappings, b);
@@ -636,24 +636,30 @@ namespace FEBuilderGBA
 
         // ---- Trace helpers (ports of the PatchForm private statics) ---------------
         //
-        // These five are pure (no ROM read) and are exposed internal static for the
-        // rebuild-producer EA arm (#1261 s2pf-14), which calls them — together with
-        // <see cref="EmitEaDataList"/> — to stay byte-identical to this verified #1242
-        // uninstall trace. Visibility is the ONLY change; behaviour is unchanged.
+        // These are exposed internal static for the rebuild-producer EA arm (#1261
+        // s2pf-14), which calls them — together with <see cref="EmitEaDataList"/> — to
+        // stay byte-identical to this verified #1242 uninstall trace. MakeMaskAddress /
+        // ReadMod take an explicit ROM (matching the ROM-explicit walker — they only used
+        // CoreState.ROM for the isSafetyOffset length bound, threaded through now);
+        // MakeLynMaskPattern / MakeFullMask / EraseORG are pure (no ROM read). Behaviour
+        // is unchanged: the uninstall caller passes CoreState.ROM, and the
+        // U.isSafetyOffset(uint, ROM) overload is the same formula as U.isSafetyOffset(uint).
 
         // Port of PatchForm.MakeMaskAddress: mask the LDR-pointer bytes inside a code
         // block so the address-dependent words don't break a GREP pattern match.
         /// <summary>
         /// Mask the LDR-pointer bytes inside a code block so the address-dependent words
-        /// don't break a GREP pattern match. Pure (no ROM read). Exposed for the
-        /// rebuild-producer EA arm, s2pf-14; byte-identical to the uninstall walk.
+        /// don't break a GREP pattern match. ROM-explicit (only reads
+        /// <paramref name="rom"/> for the <see cref="U.isSafetyOffset(uint, ROM)"/> length
+        /// bound). Exposed for the rebuild-producer EA arm, s2pf-14; byte-identical to the
+        /// uninstall walk (which passes <see cref="CoreState.ROM"/>).
         /// </summary>
-        internal static bool[] MakeMaskAddress(byte[] original, uint base_address)
+        internal static bool[] MakeMaskAddress(byte[] original, uint base_address, ROM rom)
         {
             bool[] isSkip = new bool[original.Length];
 
             base_address = U.toOffset(base_address);
-            if (!U.isSafetyOffset(base_address))
+            if (!U.isSafetyOffset(base_address, rom))
             {
                 return isSkip;
             }
@@ -680,13 +686,14 @@ namespace FEBuilderGBA
         // base 0 (matching ReadMod with an empty sp[]).
         /// <summary>
         /// Build the GREP mask for an ASM/MIX block off base 0 (instant-EA path has no
-        /// per-key address-move args). Pure (no ROM read). Exposed for the
-        /// rebuild-producer EA arm, s2pf-14; byte-identical to the uninstall walk.
+        /// per-key address-move args). ROM-explicit (forwards <paramref name="rom"/> to
+        /// <see cref="MakeMaskAddress"/>). Exposed for the rebuild-producer EA arm,
+        /// s2pf-14; byte-identical to the uninstall walk (which passes <see cref="CoreState.ROM"/>).
         /// </summary>
-        internal static byte[] ReadMod(byte[] b, out bool[] isSkip)
+        internal static byte[] ReadMod(byte[] b, out bool[] isSkip, ROM rom)
         {
             uint chaddr = 0; // U.atoi0x(U.at(sp, 2)) with an empty sp == 0
-            isSkip = MakeMaskAddress(b, chaddr);
+            isSkip = MakeMaskAddress(b, chaddr, rom);
             return b;
         }
 


### PR DESCRIPTION
## Summary
Pure, behavior-preserving refactor (slice **s2pf-13, 13/17** of the #1261 option-B PatchForm epic) that exposes the verified #1242 EA trace machinery in `EventAssemblerUninstallCore` as **ROM-explicit Core statics**, so the next slice — **s2pf-14, the rebuild-producer EA arm** — can REUSE the ONE verified GREP/ORG/mask code instead of re-implementing it. The whole point is to de-risk s2pf-14.

**No behavior change.** No GREP/mask/`EraseORG`/`lastMatchAddr` logic was touched — only visibility + ROM-explicit threading. The #1242 `EventAssemblerUninstallCore` / EA round-trip tests stay green **unchanged**.

## Refactor approach — (b) extract a shared walker
- **Hoisted** the inline DataList walk out of `TraceEAFile` into a new shared, ROM-explicit walker. The ROM it GREP-matches against is now passed in explicitly rather than re-read from `CoreState.ROM`; `TraceEAFile` passes `CoreState.ROM`, so the result is identical. This is the ONE byte-identical walker both the uninstall path and the producer arm (s2pf-14) call.
- **Promoted** the trace helpers `private static` → `internal static`. `MakeMaskAddress` / `ReadMod` also take an explicit `ROM` (they only used `CoreState.ROM` for the `isSafetyOffset` length bound — now threaded through; the `(uint, ROM)` overload is the same formula). `MakeLynMaskPattern` / `MakeFullMask` / `EraseORG` are pure (no ROM read).

## Exposed symbols (the s2pf-14 API)
All on `FEBuilderGBA.EventAssemblerUninstallCore`, visible to Core via `InternalsVisibleTo`:

```csharp
// The byte-identical EA DataList walker (ORG/ASM/MIX/LYN/LYNHOOK/POINTER_ARRAY/PROCS/BIN).
// Seeds lastMatchAddr at rom.RomInfo.compress_image_borderline_address; appends
// reconstructed ranges to binMappings and untraceable notes to untraceable.
internal static void EmitEaDataList(ROM rom, EAUtilCore ea,
    List<BinMapping> binMappings, List<string> untraceable);

// ROM-explicit mask helpers (read rom only for the isSafetyOffset length bound):
internal static bool[] MakeMaskAddress(byte[] original, uint base_address, ROM rom);
internal static byte[] ReadMod(byte[] b, out bool[] isSkip, ROM rom);

// Pure helpers (no ROM read):
internal static bool[] MakeLynMaskPattern(byte[] bin);
internal static bool[] MakeFullMask(uint length);
internal static void   EraseORG(List<BinMapping> binMappings, BinMapping b);
```

`BinMapping` (the public nested type) is unchanged.

## Scope
- Closes #1327. Part of #1261.
- Token STAYS; no producer wiring; no gate change. This is slice 13/17.
- No GUI → Core-only refactor.

## Test plan
- [x] `dotnet test FEBuilderGBA.Core.Tests --filter EventAssemblerUninstall` → **14 pass, 1 skip (ColorzCore not built), 0 fail** — all #1242 EA tests green UNCHANGED.
- [x] New `EmitEaDataList_MatchesTraceEAFile_BinMappings_ByteForByte`: the exposed walker driven directly (ROM-explicit) produces a `BinMapping` list **byte-for-byte identical** to `TraceEAFile`'s internal output. PASS.
- [x] New `ExposedMaskHelpers_ProduceExpectedMasks`: the promoted mask helpers produce the expected masks. PASS.
- [x] `dotnet test FEBuilderGBA.Core.Tests --filter RebuildProducer` → **660 pass, 0 fail** (baseline 651; later merged slices add the rest).
- [x] Full `dotnet test FEBuilderGBA.Core.Tests` → **5155 pass, 6 skip, 0 fail** (Skill* pass — `config/patch2` submodule init'd).
- [x] `dotnet build FEBuilderGBA.sln` → **Build succeeded, 0 errors**.

## Copilot review follow-up
- Threaded the explicit `ROM` through `MakeMaskAddress`/`ReadMod` and the two in-walker safety checks (`U.isSafetyOffset(addr+64, rom)`, `U.isSafetyPointer(a, rom)`) so the ROM-explicit walker no longer reads `CoreState.ROM` implicitly. Kept the `isSafetyOffset` length bound (faithful WinForms `PatchForm.MakeMaskAddress` behavior — the `(uint, ROM)` overload is the identical formula), so behavior stays byte-identical.

## Proof (Core-only refactor — CLI/test output)
```
Passed!  - Failed: 0, Passed: 14, Skipped: 1, Total: 15 - EventAssemblerUninstall filter
Passed!  - Failed: 0, Passed: 660, Skipped: 0, Total: 660 - RebuildProducer filter
Passed!  - Failed: 0, Passed: 5155, Skipped: 6, Total: 5161 - full Core.Tests
Build succeeded. 0 Error(s) - dotnet build FEBuilderGBA.sln
```

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
