### PR TITLE
feat(core): PatchForm TYPE=EA producer arm (trace + PROCS emit) (#1261 s2pf-14)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchEATests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchEATests.cs
@@ -1,0 +1,571 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for RebuildProducerCore slice s2pf-14 (#1261) — the TYPE=EA producer ARM
+// (option-B PatchForm epic, sub-slice 14 of 17):
+//   RebuildProducerCore.TraceEAPatchedMappingForProducer = WF PatchForm.TraceEAPatchedMapping        @:5247
+//   RebuildProducerCore.EmitPatchEA                       = WF PatchForm.MakePatchStructDataListForEA @:6259
+//
+// The trace REUSES the s2pf-13 shared walker EventAssemblerUninstallCore.EmitEaDataList,
+// so the ORG/ASM/MIX/LYN/LYNHOOK/POINTER_ARRAY/BIN/mask/GREP/EraseORG logic stays
+// byte-identical to the verified #1242 uninstall trace. The ONE producer divergence is
+// PROCS: the uninstall path SKIPS PROCS as residue, but the PRODUCER EMITS it via the
+// EmitEaDataList procsHandler hook backed by the verbatim CalcProcsLengthAndCheck
+// (= ProcsScriptForm.CalcLengthAndCheck), skipping ONLY on NOT_FOUND.
+//
+// VERIFICATION of an "installed-EA" scenario without a real installed patch: a synthetic
+// FE8U ROM is loaded, the patch BYTES are PLANTED at known addresses (a valid PROCS table,
+// a POINTER_ARRAY, a unique BIN pattern), and a hand-authored .event + synthetic PatchSt
+// drive the trace/emit. The asserts pin the reconstructed BinMappings + the emitted Address
+// entries (addr/length/pointer/type). Coverage: ORG, BIN(GREP), PROCS emit, PROCS
+// skip-on-NOT_FOUND, GREP-miss -> untraceable, POINTER_ARRAY dispatch, isPointerOnly,
+// ASMMAP=false early-return, SYMBOL= side-channel, and the uninstall NON-regression
+// (null procsHandler still skips PROCS).
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class RebuildProducerPatchEATests : IDisposable
+    {
+        readonly ROM _savedRom = CoreState.ROM;
+        readonly string _savedLang = CoreState.Language;
+        readonly string _savedBaseDir = CoreState.BaseDirectory;
+        readonly List<string> _tempDirs = new List<string>();
+
+        public RebuildProducerPatchEATests()
+        {
+            CoreState.Language = "en";
+        }
+
+        public void Dispose()
+        {
+            CoreState.ROM = _savedRom;
+            CoreState.Language = _savedLang;
+            CoreState.BaseDirectory = _savedBaseDir;
+            foreach (string d in _tempDirs)
+            {
+                try { if (Directory.Exists(d)) Directory.Delete(d, true); } catch { }
+            }
+        }
+
+        // 16 MiB zero-filled FE8U ROM (LoadLow minimum for BE8E01) — RomInfo-bearing so the
+        // walker's compress_image_borderline_address GREP seed + CalcProcsLengthAndCheck work.
+        // Also sets CoreState.ROM: although the emitters thread `rom` explicitly, the
+        // Address.Add* sinks they call use the single-arg U.isSafetyOffset/isSafetyPointer
+        // overloads that read CoreState.ROM (same coupling as RebuildProducerPatchAddrSwitchTests).
+        static ROM MakeRom()
+        {
+            var rom = new ROM();
+            byte[] data = new byte[0x1000000];
+            bool ok = rom.LoadLow("x.gba", data, "BE8E01");
+            Assert.True(ok, "LoadLow did not recognize BE8E01");
+            CoreState.ROM = rom;
+            return rom;
+        }
+
+        // A fresh temp directory tracked for cleanup in Dispose.
+        string NewTempDir()
+        {
+            string d = Path.Combine(Path.GetTempPath(), "ea-s2pf14-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(d);
+            _tempDirs.Add(d);
+            return d;
+        }
+
+        // Build a TYPE=EA PatchSt whose PatchFileName lives in `dir` (so the *.event scan
+        // walks that dir) with the given EA= main-file name + extra params.
+        static PatchInstallCore.PatchSt MakeEaPatch(string dir, string name, string eaFileName,
+            params (string key, string value)[] extra)
+        {
+            var p = new PatchInstallCore.PatchSt
+            {
+                Name = name,
+                PatchFileName = Path.Combine(dir, "PATCH_" + name + ".txt"),
+                Param = new Dictionary<string, string>(),
+            };
+            p.Param["TYPE"] = "EA";
+            p.Param["EA"] = eaFileName;
+            foreach (var (key, value) in extra)
+            {
+                p.Param[key] = value;
+            }
+            return p;
+        }
+
+        // Plant a minimal VALID PROCS table at `offset`: a single all-zero 8-byte
+        // instruction (code=0,sarg=0,parg=0) is the EXIT opcode → CalcProcsLengthAndCheck
+        // returns 8. (The ROM is zero-filled, so this is already true at `offset`; we write
+        // a non-zero guard instruction AFTER it so the length is deterministically > 0 and
+        // not dependent on surrounding zeros being interpreted as more PROCS.) Actually we
+        // keep it simple: an explicit EXIT word. Returns the expected length.
+        static uint PlantProcsExit(ROM rom, uint offset)
+        {
+            // code=0x00 sarg=0x0000 parg=0x00000000 → valid EXIT, length 8.
+            for (int i = 0; i < 8; i++) rom.write_u8(offset + (uint)i, 0x00);
+            return 8;
+        }
+
+        // ====================================================================
+        // EmitPatchEA: ASMMAP=false early-return (WF :6261-6265)
+        // ====================================================================
+
+        [Fact]
+        public void EmitPatchEA_AsmMapFalse_EmitsNothing()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            // A .event that WOULD trace an ORG, but ASMMAP=false opts out entirely.
+            File.WriteAllText(Path.Combine(dir, "main.event"), "ORG 0x800000\r\nBYTE 0xAA\r\n");
+            var patch = MakeEaPatch(dir, "Opt", "main.event", ("ASMMAP", "false"));
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchEA(rom, list, patch, isPointerOnly: false);
+
+            Assert.Empty(list);
+        }
+
+        // ====================================================================
+        // TraceEAPatchedMappingForProducer: ORG + BIN trace (shared walker)
+        // ====================================================================
+
+        [Fact]
+        public void Trace_OrgAndBin_ReconstructsMappings()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+
+            byte[] pattern = { 0xCA, 0xFE, 0xBA, 0xBE, 0xDE, 0xAD, 0xBE, 0xEF };
+            const uint orgAddr = 0x800000;
+            const uint binAddr = 0x801000;
+            for (int i = 0; i < pattern.Length; i++) rom.write_u8(binAddr + (uint)i, pattern[i]);
+
+            File.WriteAllBytes(Path.Combine(dir, "blk.bin"), pattern);
+            File.WriteAllText(Path.Combine(dir, "main.event"),
+                "ORG 0x" + orgAddr.ToString("X") + "\r\n" +
+                "#incbin \"blk.bin\" // HINT=BIN\r\n");
+
+            var patch = MakeEaPatch(dir, "OrgBin", "main.event");
+            var untraceable = new List<string>();
+            var map = RebuildProducerCore.TraceEAPatchedMappingForProducer(rom, patch, untraceable);
+
+            // The BIN GREP-matched the planted pattern; the ORG is provisional and gets
+            // EraseORG'd only if a concrete block lands on its address (it does not here),
+            // so both the ORG and the BIN appear.
+            Assert.Contains(map, m => m.addr == binAddr && m.key == "BIN" && m.type == Address.DataTypeEnum.BIN);
+            Assert.Contains(map, m => m.addr == orgAddr && m.key == "ORG");
+            Assert.Empty(untraceable);
+        }
+
+        [Fact]
+        public void Trace_PicksUpEaMainFileWhenHiddenInTxtPatch()
+        {
+            // The EA= main file is a .txt (not a *.event), so the directory *.event scan
+            // would miss it; WF AddIfNotExist adds it. We give it a .txt extension and assert
+            // it is still traced. (The parser keys off content, not extension.)
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            byte[] pattern = { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88 };
+            const uint binAddr = 0x802000;
+            for (int i = 0; i < pattern.Length; i++) rom.write_u8(binAddr + (uint)i, pattern[i]);
+
+            File.WriteAllBytes(Path.Combine(dir, "blk.bin"), pattern);
+            // Main file is "main.txt" (NOT .event) → only reachable via the EA= AddIfNotExist.
+            File.WriteAllText(Path.Combine(dir, "main.txt"),
+                "ORG 0x800000\r\n#incbin \"blk.bin\" // HINT=BIN\r\n");
+
+            var patch = MakeEaPatch(dir, "TxtMain", "main.txt");
+            var map = RebuildProducerCore.TraceEAPatchedMappingForProducer(rom, patch);
+
+            Assert.Contains(map, m => m.addr == binAddr && m.key == "BIN");
+        }
+
+        // ====================================================================
+        // PROCS EMIT — the producer's STRICTER divergence vs the uninstall path.
+        // ====================================================================
+
+        [Fact]
+        public void Trace_Procs_EmitsBinMapping_WithRealLength()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+
+            // ORG anchor → lastMatchAddr = orgAddr. PROCS ADD advances to advanced; we plant
+            // a valid PROCS EXIT there so CalcProcsLengthAndCheck returns a real length.
+            const uint orgAddr = 0x800000;
+            const uint procsAdd = 0x1000;
+            const uint advanced = orgAddr + procsAdd; // Padding4(0x801000) == 0x801000
+            uint expectedLen = PlantProcsExit(rom, advanced);
+
+            // PROCS with EMPTY BINData (no quoted-string hint) → handler uses addr = advanced.
+            File.WriteAllText(Path.Combine(dir, "main.event"),
+                "ORG 0x" + orgAddr.ToString("X") + "\r\n" +
+                "procs_label: // HINT=PROCS ADD=" + procsAdd.ToString() + "\r\n");
+
+            var patch = MakeEaPatch(dir, "Procs", "main.event");
+            var untraceable = new List<string>();
+            var map = RebuildProducerCore.TraceEAPatchedMappingForProducer(rom, patch, untraceable);
+
+            var procs = map.Find(m => m.type == Address.DataTypeEnum.PROCS);
+            Assert.NotNull(procs); // the PRODUCER emits PROCS (the uninstall path would skip it)
+            Assert.Equal(advanced, procs.addr);
+            Assert.Equal(expectedLen, procs.length);
+            Assert.Equal("PROCS", procs.key);
+            // A successfully-emitted PROCS is NOT residue.
+            Assert.DoesNotContain(untraceable, s => s.Contains("PROCS"));
+        }
+
+        [Fact]
+        public void EmitPatchEA_Procs_EmitsProcsTypedAddress()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            const uint orgAddr = 0x800000;
+            const uint procsAdd = 0x1000;
+            const uint advanced = orgAddr + procsAdd;
+            uint expectedLen = PlantProcsExit(rom, advanced);
+
+            File.WriteAllText(Path.Combine(dir, "main.event"),
+                "ORG 0x" + orgAddr.ToString("X") + "\r\n" +
+                "procs_label: // HINT=PROCS ADD=" + procsAdd.ToString() + "\r\n");
+
+            var patch = MakeEaPatch(dir, "ProcsEmit", "main.event");
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchEA(rom, list, patch, isPointerOnly: false);
+
+            var a = Assert.Single(list, x => x.DataType == Address.DataTypeEnum.PROCS);
+            Assert.Equal(advanced, a.Addr);
+            Assert.Equal(expectedLen, a.Length);
+            Assert.Equal(U.NOT_FOUND, a.Pointer);
+            Assert.Contains("@PROCS", a.Info);
+        }
+
+        [Fact]
+        public void EmitPatchEA_Procs_PointerOnly_LengthZero()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            const uint orgAddr = 0x800000;
+            const uint procsAdd = 0x1000;
+            const uint advanced = orgAddr + procsAdd;
+            PlantProcsExit(rom, advanced);
+
+            File.WriteAllText(Path.Combine(dir, "main.event"),
+                "ORG 0x" + orgAddr.ToString("X") + "\r\n" +
+                "procs_label: // HINT=PROCS ADD=" + procsAdd.ToString() + "\r\n");
+
+            var patch = MakeEaPatch(dir, "ProcsPO", "main.event");
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchEA(rom, list, patch, isPointerOnly: true);
+
+            var a = Assert.Single(list, x => x.DataType == Address.DataTypeEnum.PROCS);
+            Assert.Equal(0u, a.Length); // pointer-only → length 0 (WF :6295)
+        }
+
+        // PROCS whose length cannot be determined (invalid opcode at the resolved address)
+        // must be SKIPPED (verbatim WF `continue` at :5453) and recorded as residue —
+        // NEVER emitted with a guessed length.
+        [Fact]
+        public void Trace_Procs_NotFound_SkipsAndRecordsUntraceable()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            const uint orgAddr = 0x800000;
+            const uint procsAdd = 0x1000;
+            const uint advanced = orgAddr + procsAdd;
+
+            // Plant an INVALID PROCS opcode (code=0x00FF is unhandled → CalcProcsLengthAndCheck
+            // returns NOT_FOUND). Word at +0: FF 00 (u16) = 0x00FF; the rest non-terminating.
+            rom.write_u8(advanced + 0, 0xFF);
+            rom.write_u8(advanced + 1, 0x00);
+
+            File.WriteAllText(Path.Combine(dir, "main.event"),
+                "ORG 0x" + orgAddr.ToString("X") + "\r\n" +
+                "procs_label: // HINT=PROCS ADD=" + procsAdd.ToString() + "\r\n");
+
+            var patch = MakeEaPatch(dir, "ProcsBad", "main.event");
+            var untraceable = new List<string>();
+            var map = RebuildProducerCore.TraceEAPatchedMappingForProducer(rom, patch, untraceable);
+
+            Assert.DoesNotContain(map, m => m.type == Address.DataTypeEnum.PROCS); // skipped
+            Assert.Contains(untraceable, s => s.Contains("PROCS"));                 // recorded (honest)
+        }
+
+        // A PROCS skip must STILL advance the GREP baseline (Append+Padding4), so a block
+        // AFTER it matches at the advanced address — not an earlier decoy. (Same correctness
+        // guard as the uninstall test, here on the producer arm whose handler returns null.)
+        [Fact]
+        public void Trace_ProcsSkip_AdvancesBaseline_NextBlockMatchesAfter()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+
+            byte[] pattern = { 0xDE, 0xAD, 0xC0, 0xDE, 0xFE, 0xED, 0xFA, 0xCE };
+            const uint orgAddr = 0x800000;
+            const uint procsAdd = 0x1000;
+            const uint advanced = orgAddr + procsAdd;     // 0x801000
+            const uint decoyAddr = orgAddr + 0x100;        // 0x800100 — BEFORE advanced
+            const uint realAddr = advanced + 0x1000;       // 0x802000 — AFTER advanced
+
+            // Invalid PROCS at advanced → skip (but baseline still advances).
+            rom.write_u8(advanced + 0, 0xFF);
+            rom.write_u8(advanced + 1, 0x00);
+
+            for (int i = 0; i < pattern.Length; i++)
+            {
+                rom.write_u8(decoyAddr + (uint)i, pattern[i]);
+                rom.write_u8(realAddr + (uint)i, pattern[i]);
+            }
+
+            File.WriteAllBytes(Path.Combine(dir, "blk.bin"), pattern);
+            File.WriteAllText(Path.Combine(dir, "main.event"),
+                "ORG 0x" + orgAddr.ToString("X") + "\r\n" +
+                "procs_label: // HINT=PROCS ADD=" + procsAdd.ToString() + "\r\n" +
+                "#incbin \"blk.bin\" // HINT=BIN\r\n");
+
+            var patch = MakeEaPatch(dir, "ProcsBaseline", "main.event");
+            var map = RebuildProducerCore.TraceEAPatchedMappingForProducer(rom, patch);
+
+            Assert.Contains(map, m => m.addr == realAddr && m.key == "BIN");
+            Assert.DoesNotContain(map, m => m.addr == decoyAddr);
+        }
+
+        // ====================================================================
+        // GREP-miss -> untraceable (honest omission, NEVER silent)
+        // ====================================================================
+
+        [Fact]
+        public void Trace_BinGrepMiss_RecordsUntraceable()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+
+            // A BIN pattern that is NOT present anywhere in the (zero-filled) ROM after the
+            // borderline → GREP miss → recorded as residue, never silently dropped.
+            byte[] pattern = { 0x13, 0x57, 0x9B, 0xDF, 0x24, 0x68, 0xAC, 0xE0 };
+            File.WriteAllBytes(Path.Combine(dir, "blk.bin"), pattern);
+            File.WriteAllText(Path.Combine(dir, "main.event"),
+                "#incbin \"blk.bin\" // HINT=BIN\r\n");
+
+            var patch = MakeEaPatch(dir, "Miss", "main.event");
+            var untraceable = new List<string>();
+            var map = RebuildProducerCore.TraceEAPatchedMappingForProducer(rom, patch, untraceable);
+
+            Assert.DoesNotContain(map, m => m.key == "BIN");
+            Assert.NotEmpty(untraceable);
+            Assert.Contains(untraceable, s => s.Contains("blk.bin") || s.Contains("BIN"));
+        }
+
+        // ====================================================================
+        // POINTER_ARRAY dispatch in EmitPatchEA (WF :6278-6284)
+        // ====================================================================
+
+        [Fact]
+        public void EmitPatchEA_PointerArray_DispatchesToAddPointerArray()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+
+            // ORG anchor → lastMatchAddr = orgAddr. POINTER_ARRAY scans from the advanced
+            // baseline for consecutive valid pointers. Plant exactly two valid pointers, then
+            // a non-pointer word to terminate the run.
+            const uint orgAddr = 0x800000;
+            const uint paAdd = 0x1000;
+            const uint paStart = orgAddr + paAdd;          // 0x801000
+            // Two safe pointers (0x08000200 <= p < 0x08000000+romlen).
+            rom.write_u32(paStart + 0, 0x08800000);
+            rom.write_u32(paStart + 4, 0x08810000);
+            // Terminator: a clearly non-pointer value so the run stops at length 8.
+            rom.write_u32(paStart + 8, 0x00000001);
+
+            File.WriteAllText(Path.Combine(dir, "main.event"),
+                "ORG 0x" + orgAddr.ToString("X") + "\r\n" +
+                "pa_label: // HINT=POINTER_ARRAY ADD=" + paAdd.ToString() + "\r\n");
+
+            var patch = MakeEaPatch(dir, "PArr", "main.event");
+
+            // First confirm the trace produced a POINTER_ARRAY mapping of length 8.
+            var map = RebuildProducerCore.TraceEAPatchedMappingForProducer(rom, patch);
+            var pa = map.Find(m => m.type == Address.DataTypeEnum.POINTER_ARRAY);
+            Assert.NotNull(pa);
+            Assert.Equal(paStart, pa.addr);
+            Assert.Equal(8u, pa.length);
+
+            // EmitPatchEA dispatches POINTER_ARRAY → AddPointerArray, which adds one inner
+            // (MIX) Address per 4-byte slot pointing at the deref'd target.
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchEA(rom, list, patch, isPointerOnly: false);
+
+            // 2 slots → 2 inner MIX entries whose pointer is the slot, target the deref.
+            var inner = list.FindAll(a => a.DataType == Address.DataTypeEnum.MIX
+                && a.Info.Contains("Pointer_Array"));
+            Assert.Equal(2, inner.Count);
+            Assert.Contains(inner, a => a.Pointer == paStart + 0 && a.Addr == U.toOffset(0x08800000));
+            Assert.Contains(inner, a => a.Pointer == paStart + 4 && a.Addr == U.toOffset(0x08810000));
+        }
+
+        // ====================================================================
+        // SYMBOL= side-channel (WF :6266 -> ProcessSymbolByList(list, patch))
+        // ====================================================================
+
+        [Fact]
+        public void EmitPatchEA_SymbolParam_AddsCommentEntries()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            File.WriteAllText(Path.Combine(dir, "main.event"), "ORG 0x800000\r\n");
+            // EA-format symbol: NAME=$<programAddr>. 0x08800001 (thumb) -> offset 0x800000.
+            File.WriteAllText(Path.Combine(dir, "syms.txt"), "MyFunc=$8800001\r\n");
+
+            var patch = MakeEaPatch(dir, "Sym", "main.event", ("SYMBOL", "syms.txt"));
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchEA(rom, list, patch, isPointerOnly: false);
+
+            // The SYMBOL side-channel adds a comment Address for MyFunc at the symbol's offset.
+            Assert.Contains(list, a => a.Info.Contains("MyFunc"));
+        }
+
+        [Fact]
+        public void EmitPatchEA_NoSymbolParam_NoSymbolEntries()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            File.WriteAllText(Path.Combine(dir, "main.event"), "ORG 0x800000\r\n");
+
+            var patch = MakeEaPatch(dir, "NoSym", "main.event");
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchEA(rom, list, patch, isPointerOnly: false);
+
+            // No SYMBOL= → no comment entries from the side-channel (ORG-only trace may still
+            // emit its provisional ORG MIX entry; just assert no symbol leaked in).
+            Assert.DoesNotContain(list, a => a.Info.Contains("MyFunc"));
+        }
+
+        // ====================================================================
+        // Guards
+        // ====================================================================
+
+        [Fact]
+        public void Trace_NullRom_Throws()
+        {
+            var patch = MakeEaPatch(NewTempDir(), "N", "main.event");
+            Assert.Throws<ArgumentNullException>(() =>
+                RebuildProducerCore.TraceEAPatchedMappingForProducer(null, patch));
+        }
+
+        [Fact]
+        public void Trace_MissingEaMainTxt_RecordsUntraceable_NoThrow()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            // EA= names a NON-.event file that does not exist. WF AddIfNotExist adds it to the
+            // file list (because its ext != ".EVENT"); since it is missing, the producer
+            // records the gap instead of throwing (WF's EAUtil ctor would throw on it).
+            var patch = MakeEaPatch(dir, "Gone", "does-not-exist.txt");
+            var untraceable = new List<string>();
+            var map = RebuildProducerCore.TraceEAPatchedMappingForProducer(rom, patch, untraceable);
+
+            Assert.Empty(map);
+            Assert.NotEmpty(untraceable); // the missing main file is a recorded gap, not a crash
+        }
+
+        [Fact]
+        public void Trace_MissingEventFileInDir_NoThrow_EmptyResult()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            // A .event EA= name that does not exist relies on the dir scan finding it (no
+            // AddIfNotExist for .event); the dir is empty, so nothing is traced — and nothing
+            // crashes. WF behaves identically (the file is simply never in the list).
+            var patch = MakeEaPatch(dir, "GoneEvent", "does-not-exist.event");
+            var untraceable = new List<string>();
+            var map = RebuildProducerCore.TraceEAPatchedMappingForProducer(rom, patch, untraceable);
+
+            Assert.Empty(map);
+        }
+
+        // ====================================================================
+        // NON-REGRESSION: the uninstall walker (null procsHandler) still SKIPS PROCS.
+        // This is the contract that keeps EmitEaDataList byte-identical for #1242.
+        // ====================================================================
+
+        [Fact]
+        public void EmitEaDataList_NullProcsHandler_SkipsProcs_AsBeforeS2pf14()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            const uint orgAddr = 0x800000;
+            const uint procsAdd = 0x1000;
+            const uint advanced = orgAddr + procsAdd;
+            PlantProcsExit(rom, advanced); // a VALID PROCS the producer WOULD emit
+
+            File.WriteAllText(Path.Combine(dir, "main.event"),
+                "ORG 0x" + orgAddr.ToString("X") + "\r\n" +
+                "procs_label: // HINT=PROCS ADD=" + procsAdd.ToString() + "\r\n");
+
+            var ea = new EAUtilCore(Path.Combine(dir, "main.event"));
+            var binMappings = new List<EventAssemblerUninstallCore.BinMapping>();
+            var untraceable = new List<string>();
+
+            // Null procsHandler (the uninstall path's default) → PROCS recorded as residue,
+            // NOT emitted — byte-identical to pre-s2pf-14 behaviour even though the PROCS is
+            // perfectly valid and the producer handler WOULD emit it.
+            EventAssemblerUninstallCore.EmitEaDataList(rom, ea, binMappings, untraceable, null);
+
+            Assert.DoesNotContain(binMappings, m => m.type == Address.DataTypeEnum.PROCS);
+            Assert.Contains(untraceable, s => s.Contains("PROCS"));
+        }
+
+        // The PRODUCER handler EMITS the SAME valid PROCS the uninstall path skips — the two
+        // callers of the ONE walker diverge ONLY on PROCS, as designed.
+        [Fact]
+        public void EmitEaDataList_ProducerVsUninstall_DivergeOnlyOnProcs()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            const uint orgAddr = 0x800000;
+            const uint procsAdd = 0x1000;
+            const uint advanced = orgAddr + procsAdd;
+            uint expectedLen = PlantProcsExit(rom, advanced);
+
+            // Also a BIN block after the PROCS so we can assert the NON-PROCS mappings match.
+            byte[] pattern = { 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89 };
+            const uint binAddr = advanced + 0x2000;
+            for (int i = 0; i < pattern.Length; i++) rom.write_u8(binAddr + (uint)i, pattern[i]);
+
+            File.WriteAllBytes(Path.Combine(dir, "blk.bin"), pattern);
+            File.WriteAllText(Path.Combine(dir, "main.event"),
+                "ORG 0x" + orgAddr.ToString("X") + "\r\n" +
+                "procs_label: // HINT=PROCS ADD=" + procsAdd.ToString() + "\r\n" +
+                "#incbin \"blk.bin\" // HINT=BIN\r\n");
+
+            // Producer path (via the public producer trace).
+            var patch = MakeEaPatch(dir, "Diverge", "main.event");
+            var prod = RebuildProducerCore.TraceEAPatchedMappingForProducer(rom, patch);
+
+            // Uninstall path (the shared walker with null handler).
+            var ea = new EAUtilCore(Path.Combine(dir, "main.event"));
+            var uninst = new List<EventAssemblerUninstallCore.BinMapping>();
+            EventAssemblerUninstallCore.EmitEaDataList(rom, ea, uninst, new List<string>(), null);
+
+            // Producer has the PROCS; uninstall does not.
+            Assert.Contains(prod, m => m.type == Address.DataTypeEnum.PROCS && m.addr == advanced && m.length == expectedLen);
+            Assert.DoesNotContain(uninst, m => m.type == Address.DataTypeEnum.PROCS);
+
+            // Every NON-PROCS mapping is identical between the two (same ORG, same BIN).
+            var prodNonProcs = prod.FindAll(m => m.type != Address.DataTypeEnum.PROCS);
+            Assert.Equal(uninst.Count, prodNonProcs.Count);
+            for (int i = 0; i < uninst.Count; i++)
+            {
+                Assert.Equal(uninst[i].addr, prodNonProcs[i].addr);
+                Assert.Equal(uninst[i].length, prodNonProcs[i].length);
+                Assert.Equal(uninst[i].type, prodNonProcs[i].type);
+                Assert.Equal(uninst[i].key, prodNonProcs[i].key);
+            }
+            Assert.Contains(prodNonProcs, m => m.addr == binAddr && m.key == "BIN");
+        }
+    }
+}

--- a/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
+++ b/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
@@ -169,6 +169,36 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
+        /// Result of the producer-only PROCS handler (<see cref="ProcsEmitHandler"/>):
+        /// the reconstructed PROCS <see cref="BinMapping"/> (or <c>null</c> when its length
+        /// could not be determined — i.e. <c>CalcProcsLengthAndCheck == NOT_FOUND</c>, the
+        /// WF skip-on-NOT_FOUND case), plus the advanced <c>lastMatchAddr</c> baseline the
+        /// walker must adopt for the next block. Mirrors the tail of WF
+        /// <c>PatchForm.TraceEAPatchedMapping</c>'s PROCS branch (5437-5471).
+        /// </summary>
+        internal struct ProcsEmitResult
+        {
+            /// <summary>The PROCS mapping, or null to skip (WF <c>continue</c> on NOT_FOUND).</summary>
+            public BinMapping Mapping;
+            /// <summary>The new <c>lastMatchAddr</c> baseline for the next block.</summary>
+            public uint NewLastMatchAddr;
+        }
+
+        /// <summary>
+        /// Producer-only hook that resolves a PROCS block's address+length and builds its
+        /// <see cref="BinMapping"/>. The uninstall path passes <c>null</c> (PROCS length
+        /// detection is WinForms-only there → the block is recorded as untraceable and
+        /// skipped, byte-identical to the original walk). The rebuild-producer EA arm
+        /// (#1261 s2pf-14) passes a handler backed by
+        /// <c>RebuildProducerCore.CalcProcsLengthAndCheck</c> so a real PROCS is EMITTED
+        /// (skipping a live PROCS in the producer would silently corrupt the rebuild free
+        /// list). Receives the ROM, the PROCS <see cref="EAUtilCore.Data"/>, and the
+        /// <c>lastMatchAddr</c> baseline ALREADY advanced by <c>Append</c> + Padding4
+        /// (exactly as WF does at the TOP of its PROCS branch, before the GREP/length).
+        /// </summary>
+        internal delegate ProcsEmitResult ProcsEmitHandler(ROM rom, EAUtilCore.Data data, uint advancedLastMatchAddr);
+
+        /// <summary>
         /// The byte-identical EA DataList walk shared by the uninstall trace
         /// (<see cref="TraceEAFile"/>) and the rebuild-producer EA arm (#1261 s2pf-14).
         /// Walks the parsed <paramref name="ea"/> entries (ORG / ASM / MIX / LYN /
@@ -185,6 +215,13 @@ namespace FEBuilderGBA
         /// inline <see cref="TraceEAFile"/> walk — the only difference is that the ROM it
         /// reads is passed explicitly rather than re-read from <see cref="CoreState.ROM"/>
         /// (the uninstall caller passes <c>CoreState.ROM</c>, so the result is identical).</para>
+        ///
+        /// <para>The ONLY divergence between the two callers is <paramref name="procsHandler"/>:
+        /// when <c>null</c> (uninstall, the default) a PROCS block is recorded as
+        /// untraceable and skipped (WinForms-only length detection); when supplied
+        /// (producer) the handler reproduces WF's PROCS emit (GREP + CalcProcsLengthAndCheck,
+        /// skip ONLY on NOT_FOUND). Every other branch is identical for both callers, so the
+        /// uninstall behaviour is NOT regressed.</para>
         /// </summary>
         /// <param name="rom">The ROM the expanded blocks are GREP-matched against (the
         /// current/patched ROM for the uninstall path). Must be non-null with a non-null
@@ -192,7 +229,11 @@ namespace FEBuilderGBA
         /// <param name="ea">The parsed EA file whose <see cref="EAUtilCore.DataList"/> is walked.</param>
         /// <param name="binMappings">Accumulator for the reconstructed ranges (appended to).</param>
         /// <param name="untraceable">Accumulator for blocks that could not be traced (appended to).</param>
-        internal static void EmitEaDataList(ROM rom, EAUtilCore ea, List<BinMapping> binMappings, List<string> untraceable)
+        /// <param name="procsHandler">Producer-only PROCS emit hook (see
+        /// <see cref="ProcsEmitHandler"/>); <c>null</c> for the uninstall path, which skips
+        /// PROCS as residue exactly as before.</param>
+        internal static void EmitEaDataList(ROM rom, EAUtilCore ea, List<BinMapping> binMappings, List<string> untraceable,
+            ProcsEmitHandler procsHandler = null)
         {
             uint lastMatchAddr = rom.RomInfo.compress_image_borderline_address;
 
@@ -373,13 +414,35 @@ namespace FEBuilderGBA
                     lastMatchAddr += data.Append;
                     lastMatchAddr = U.Padding4(lastMatchAddr);
 
-                    // PROCS length detection (ProcsScriptForm.CalcLengthAndCheck) is
-                    // WinForms-only; without it the length is unknown, so we skip the
-                    // range itself — identical to the WinForms tracer's `continue` when
-                    // CalcLengthAndCheck returns NOT_FOUND. Record it as residue so the
-                    // caller can warn. (See class doc scope note.)
-                    untraceable.Add(R._("PROCS table (length detection is WinForms-only): {0}",
-                        string.IsNullOrEmpty(data.Name) ? R._("(label)") : data.Name));
+                    if (procsHandler == null)
+                    {
+                        // UNINSTALL path (byte-identical to the original walk): PROCS length
+                        // detection (ProcsScriptForm.CalcLengthAndCheck) is WinForms-only;
+                        // without it the length is unknown, so we skip the range itself —
+                        // identical to the WinForms tracer's `continue` when CalcLengthAndCheck
+                        // returns NOT_FOUND. Record it as residue so the caller can warn.
+                        // (See class doc scope note.)
+                        untraceable.Add(R._("PROCS table (length detection is WinForms-only): {0}",
+                            string.IsNullOrEmpty(data.Name) ? R._("(label)") : data.Name));
+                        continue;
+                    }
+
+                    // PRODUCER path (#1261 s2pf-14): the handler reproduces WF's PROCS emit
+                    // (PatchForm.cs:5437-5471) — GREP the BINData from the borderline, then
+                    // CalcProcsLengthAndCheck the resolved address; on NOT_FOUND it returns a
+                    // null Mapping (verbatim WF `continue` at 5453-5455), and we record the
+                    // skip as residue (honest omission — NEVER a guessed length). The walker
+                    // keeps the handler's advanced lastMatchAddr either way.
+                    ProcsEmitResult pr = procsHandler(rom, data, lastMatchAddr);
+                    lastMatchAddr = pr.NewLastMatchAddr;
+                    if (pr.Mapping == null)
+                    {
+                        untraceable.Add(R._("PROCS table (length detection failed): {0}",
+                            string.IsNullOrEmpty(data.Name) ? R._("(label)") : data.Name));
+                        continue;
+                    }
+                    EraseORG(binMappings, pr.Mapping);
+                    binMappings.Add(pr.Mapping);
                     continue;
                 }
                 else

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -13246,6 +13246,349 @@ namespace FEBuilderGBA
         }
 
         // ====================================================================
+        // PatchForm producer — option-B epic (#1261, sub-slice s2pf-14 of 17).
+        //
+        // The TYPE=EA producer ARM (NOT yet wired into the orchestrator — that is
+        // s2pf-17; the orchestrator's EA case stays a stub this slice). Faithful Core
+        // port of WinForms:
+        //   - TraceEAPatchedMappingForProducer  <- PatchForm.TraceEAPatchedMapping  (:5247)
+        //   - EmitPatchEA                        <- PatchForm.MakePatchStructDataListForEA (:6259)
+        //
+        // TRACE reuses the s2pf-13 walker EventAssemblerUninstallCore.EmitEaDataList so the
+        // ORG/ASM/MIX/LYN/LYNHOOK/POINTER_ARRAY/BIN/mask/GREP/EraseORG logic stays
+        // byte-identical between the in-place UNINSTALL (#1242) and this PRODUCER arm. The
+        // ONE divergence the producer needs is PROCS: the uninstall path SKIPS PROCS as
+        // residue (its WinForms-only length detector is absent), but the PRODUCER MUST EMIT
+        // PROCS — a missed live PROCS in the rebuild free list = silent corruption. We inject
+        // that via the EmitEaDataList procsHandler hook, backed by the verbatim WF length
+        // detector CalcProcsLengthAndCheck (= ProcsScriptForm.CalcLengthAndCheck, WF :5452),
+        // skipping ONLY on NOT_FOUND (verbatim WF `continue` at :5453).
+        //
+        // The MULTI-EVENT-FILE loop (WF :5253-5264) is reproduced here: every *.event under
+        // the patch dir (recursive) plus the EA= main file (added if a .txt-only patch hid
+        // it). GREP misses on ASM/MIX/LYN/BIN are recorded on `untraceable` by EmitEaDataList
+        // (honest omission, never silent — a range WF would cover that Core drops would be
+        // corruption). NO Program.ROM / CoreState.ROM read — `rom` is threaded explicitly.
+        //
+        // DEFERRED to s2pf-16 (the WF trailers at :5508-5512, driven by extra patch params):
+        //   TraceEditPatch (EDIT_PATCH), AppendMenuPatch (MENU),
+        //   AppendNewTargetSelectionStruct (NEW_TARGET_SELECTION_STRUCT). They emit nothing
+        //   for a bare {TYPE=EA, EA=...} patch, but a real FE8U EA patch can carry those
+        //   params, so they are left as a marked TODO rather than guessed.
+        // ====================================================================
+
+        /// <summary>
+        /// Faithful Core port of WinForms <c>PatchForm.TraceEAPatchedMapping</c>
+        /// (FEBuilderGBA/PatchForm.cs:5247) for the rebuild PRODUCER. Traces where a
+        /// TYPE=EA patch's blocks were mapped into <paramref name="rom"/> and returns the
+        /// reconstructed <see cref="EventAssemblerUninstallCore.BinMapping"/>s.
+        ///
+        /// <para>Walks every <c>*.event</c> file under the patch directory (recursive,
+        /// WF <c>U.Directory_GetFiles_Safe(dir, "*.event", AllDirectories)</c>) plus the
+        /// <c>EA=</c> main file added if a non-<c>.event</c> patch hid it (WF
+        /// <c>U.AddIfNotExist</c>), skipping FBG temp wrappers. Each file is parsed by
+        /// <see cref="EAUtilCore"/> and walked by the shared s2pf-13
+        /// <see cref="EventAssemblerUninstallCore.EmitEaDataList"/> — so the
+        /// ORG/ASM/MIX/LYN/LYNHOOK/POINTER_ARRAY/BIN trace stays byte-identical to the
+        /// verified #1242 uninstall trace.</para>
+        ///
+        /// <para><b>PROCS divergence (the producer-only behaviour):</b> unlike the uninstall
+        /// path, this arm EMITS PROCS. A <see cref="EventAssemblerUninstallCore.ProcsEmitHandler"/>
+        /// is injected that reproduces WF's PROCS branch (:5437-5471): advance the baseline
+        /// by <c>Append</c>+Padding4 (done by the walker), GREP the BINData from the
+        /// borderline, then <see cref="CalcProcsLengthAndCheck"/> the resolved address —
+        /// emitting a <see cref="Address.DataTypeEnum.PROCS"/> mapping, or skipping ONLY on
+        /// NOT_FOUND (verbatim WF <c>continue</c> at :5453; the skip is recorded as
+        /// untraceable, never a guessed length).</para>
+        ///
+        /// <para><b>Honest omission:</b> any block the trace cannot reconstruct (a GREP miss
+        /// on ASM/MIX/LYN/BIN, a NOT_FOUND PROCS, an un-hinted inline PNG raster) is appended
+        /// to <paramref name="untraceable"/> — a range WF would have covered that Core
+        /// silently dropped would be free-list corruption.</para>
+        ///
+        /// <para>The WF trailers <c>TraceEditPatch</c> / <c>AppendMenuPatch</c> /
+        /// <c>AppendNewTargetSelectionStruct</c> (:5508-5512) are DEFERRED to s2pf-16.</para>
+        /// </summary>
+        /// <param name="rom">ROM to trace against — passed explicitly (NEVER CoreState.ROM / Program.ROM).</param>
+        /// <param name="patch">The TYPE=EA patch (its <c>PatchFileName</c> dir is walked; its <c>EA=</c> param adds the main file).</param>
+        /// <param name="untraceable">Accumulator for blocks that could not be traced (GREP miss, NOT_FOUND PROCS). Optional; pass to surface coverage gaps.</param>
+        /// <returns>The reconstructed bin-mappings, in trace order.</returns>
+        public static List<EventAssemblerUninstallCore.BinMapping> TraceEAPatchedMappingForProducer(
+            ROM rom, PatchInstallCore.PatchSt patch, List<string> untraceable = null)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (patch == null) throw new ArgumentNullException(nameof(patch));
+            if (patch.Param == null) throw new ArgumentNullException(nameof(patch) + ".Param");
+            // RomInfo is read by the walker (compress_image_borderline_address GREP seed) and
+            // by the PROCS handler. The orchestrator only reaches the EA arm for an identified
+            // ROM, but guard so a bad direct caller gets a clean ArgumentException, not an NRE.
+            if (rom.RomInfo == null) throw new ArgumentNullException(nameof(rom) + ".RomInfo");
+
+            var binMappings = new List<EventAssemblerUninstallCore.BinMapping>();
+            if (untraceable == null)
+            {
+                untraceable = new List<string>();
+            }
+
+            // WF: string dir = Path.GetDirectoryName(patch.PatchFileName);
+            //     string[] files = U.Directory_GetFiles_Safe(dir, "*.event", AllDirectories);
+            // Normalize a null dir (PatchFileName with no directory part) to "" — Directory
+            // enumeration on "" would throw, so an empty dir yields no .event files (only the
+            // EA= main file, if its combined path exists). This matches WF's effective result
+            // for a patch with no directory context.
+            string dir = System.IO.Path.GetDirectoryName(patch.PatchFileName) ?? "";
+            string[] files;
+            if (dir.Length == 0)
+            {
+                files = new string[0];
+            }
+            else
+            {
+                files = U.Directory_GetFiles_Safe(dir, "*.event", System.IO.SearchOption.AllDirectories);
+            }
+
+            // WF :5256-5264 — the main-process file may be a .txt the *.event scan missed; add
+            // it. WF: string ea = U.at(patch.Param,"EA"); if GetFilenameExt(ea) != ".EVENT" {
+            //   ea = Path.Combine(dir, ea); files = U.AddIfNotExist(files, ea); }
+            {
+                string ea = U.at(patch.Param, "EA");
+                if (U.GetFilenameExt(ea) != ".EVENT")
+                {
+                    ea = System.IO.Path.Combine(dir, ea);
+                    files = U.AddIfNotExist(files, ea);
+                }
+            }
+
+            // The PROCS emit hook (producer-only). Reproduces WF TraceEAPatchedMapping's PROCS
+            // branch tail (:5442-5471): the walker has ALREADY advanced lastMatchAddr by
+            // Append+Padding4 (WF :5439-5440) and passes it in as `advanced`. We GREP the
+            // BINData from the borderline (WF :5443-5450), then CalcProcsLengthAndCheck the
+            // resolved address (WF :5452 = ProcsScriptForm.CalcLengthAndCheck). On NOT_FOUND we
+            // return a null Mapping (verbatim WF `continue` at :5453) and DO NOT advance past
+            // the block. On success we build the PROCS BinMapping and advance
+            // lastMatchAddr = addr + length (WF :5471).
+            EventAssemblerUninstallCore.ProcsEmitHandler procsHandler = (r, data, advanced) =>
+            {
+                uint addr = advanced;
+                if (data.BINData != null && data.BINData.Length > 0)
+                {
+                    uint foundAddr = U.Grep(r.Data, data.BINData,
+                        r.RomInfo.compress_image_borderline_address, 0, 4);
+                    if (foundAddr != U.NOT_FOUND)
+                    {
+                        addr = foundAddr;
+                    }
+                }
+
+                uint length = CalcProcsLengthAndCheck(r, addr);
+                if (length == U.NOT_FOUND)
+                {//WF :5453 — length unknown; skip (do NOT guess). Baseline stays `advanced`.
+                    return new EventAssemblerUninstallCore.ProcsEmitResult
+                    {
+                        Mapping = null,
+                        NewLastMatchAddr = advanced,
+                    };
+                }
+
+                var b = new EventAssemblerUninstallCore.BinMapping
+                {
+                    key = data.DataType.ToString(),
+                    filename = data.Name,
+                    addr = addr,
+                    length = length,
+                    // EOF-guard the binary read (length came from the EOF-clamped
+                    // CalcProcsLengthAndCheck, so addr+length is in-bounds, but guard the
+                    // start defensively — a bad GREP/Append could still land near EOF).
+                    bin = U.isSafetyOffset(addr, r) ? r.getBinaryData(addr, length) : new byte[0],
+                    mask = EventAssemblerUninstallCore.MakeFullMask(length),
+                    type = Address.DataTypeEnum.PROCS,
+                };
+                return new EventAssemblerUninstallCore.ProcsEmitResult
+                {
+                    Mapping = b,
+                    NewLastMatchAddr = addr + length,
+                };
+            };
+
+            foreach (string fullfilename in files)
+            {
+                if (EAUtilCore.IsFBGTemp(fullfilename))
+                {
+                    continue;
+                }
+                if (string.IsNullOrEmpty(fullfilename) || !System.IO.File.Exists(fullfilename))
+                {//WF's EAUtil ctor would throw on a missing file; the producer skips it and
+                 //records the gap rather than aborting the whole rebuild.
+                    untraceable.Add(R._("EA event file not found: {0}", fullfilename ?? ""));
+                    continue;
+                }
+
+                EAUtilCore ea;
+                try
+                {
+                    ea = new EAUtilCore(fullfilename);
+                }
+                catch (Exception ex)
+                {//Honour "never abort the producer": a bad .event becomes a recorded gap.
+                    untraceable.Add(R._("Could not read the event file: {0}", ex.Message));
+                    continue;
+                }
+
+                // Parser-level untraceable blocks (un-hinted inline PNG rasters).
+                untraceable.AddRange(ea.UntraceableNotes);
+
+                // The shared s2pf-13 walker — byte-identical to the uninstall trace for every
+                // block EXCEPT PROCS, which procsHandler now EMITS for the producer.
+                EventAssemblerUninstallCore.EmitEaDataList(rom, ea, binMappings, untraceable, procsHandler);
+            }
+
+            // s2pf-16: WF :5507-5512 trailers (TraceEditPatch / AppendMenuPatch /
+            // AppendNewTargetSelectionStruct) are DEFERRED — they act on extra patch params
+            // (EDIT_PATCH / MENU / NEW_TARGET_SELECTION_STRUCT) and emit nothing for a bare
+            // {TYPE=EA, EA=...} patch. Left as a marked TODO, NOT guessed.
+
+            return binMappings;
+        }
+
+        /// <summary>
+        /// Faithful Core port of WinForms <c>PatchForm.MakePatchStructDataListForEA</c>
+        /// (FEBuilderGBA/PatchForm.cs:6259), the TYPE=EA producer arm. <b>NOT yet wired into
+        /// the orchestrator</b> — the <see cref="MakePatchStructDataListCore"/> EA case stays
+        /// a stub until s2pf-17; this method is the tested API that slice will call.
+        ///
+        /// <para>Early-returns when <c>ASMMAP</c> is false (WF :6261-6265 — the patch opts out
+        /// of the ASM map). Then ports the SYMBOL= side-channel inline (WF
+        /// <c>ProcessSymbolByList(list, patch)</c> at :6266 = read the <c>SYMBOL=</c> param,
+        /// combine with the patch dir, and feed <see cref="SymbolUtil.ProcessSymbolToList"/>),
+        /// traces the patch via <see cref="TraceEAPatchedMappingForProducer"/>, and emits one
+        /// <see cref="Address"/> per <see cref="EventAssemblerUninstallCore.BinMapping"/> by
+        /// its <c>type</c>:</para>
+        /// <list type="bullet">
+        ///   <item><c>POINTER_ARRAY</c> -&gt; <see cref="Address.AddPointerArray"/> (inner MIX), WF :6280.</item>
+        ///   <item><c>NEW_TARGET_SELECTION_STRUCT</c> -&gt; <see cref="Address.AddNewTargetSelectionStruct"/>, WF :6287.</item>
+        ///   <item><c>PROCS</c> -&gt; <see cref="Address.AddAddress"/> typed PROCS (length 0 when <paramref name="isPointerOnly"/>), WF :6293.</item>
+        ///   <item>else -&gt; <see cref="Address.AddAddress"/> typed by the mapping's own type (length 0 when pointer-only), WF :6303.</item>
+        /// </list>
+        /// <para>Each non-empty mapping filename additionally drives
+        /// <see cref="SymbolUtil.ProcessSymbolByList(System.Collections.Generic.List{Address}, string, string, uint)"/>
+        /// (WF :6311-6314, the per-block ELF/sym.txt symbol channel). The per-mapping
+        /// <c>U.isSafetyOffset</c> guard skips only that mapping — verbatim WF :6273.</para>
+        ///
+        /// <para>The trailing WF helpers <c>TraceEditPatch</c> / <c>AppendMenuPatch</c> /
+        /// <c>AppendNewTargetSelectionStruct</c> live inside
+        /// <c>TraceEAPatchedMapping</c> (:5508-5512), DEFERRED to s2pf-16.</para>
+        /// </summary>
+        /// <param name="rom">ROM to trace against — passed explicitly (NEVER CoreState.ROM / Program.ROM).</param>
+        /// <param name="list">The accumulating struct/pointer list (appended to).</param>
+        /// <param name="patch">The TYPE=EA patch whose <c>EA=</c>/<c>SYMBOL=</c>/<c>ASMMAP</c> params drive emission.</param>
+        /// <param name="isPointerOnly">WF <c>isPointerOnly</c> — when true the emitted PROCS/EA lengths are 0 (pointer-only pass).</param>
+        public static void EmitPatchEA(ROM rom, List<Address> list, PatchInstallCore.PatchSt patch, bool isPointerOnly)
+        {
+            // Public-helper guards (consistent with EmitPatchAddr / EmitPatchSwitch): throw a clear
+            // ArgumentNullException rather than an unhelpful NRE. The orchestrator always passes a
+            // valid rom/list and a LoadPatch result whose Param is non-null.
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (list == null) throw new ArgumentNullException(nameof(list));
+            if (patch == null) throw new ArgumentNullException(nameof(patch));
+            if (patch.Param == null) throw new ArgumentNullException(nameof(patch) + ".Param");
+
+            // WF :6261-6265 — ASMMAP=false opts the patch OUT of the ASM map; emit nothing.
+            string use_asmmap = U.at(patch.Param, "ASMMAP", "true");
+            if (U.stringbool(use_asmmap) == false)
+            {
+                return;
+            }
+
+            // WF :6266 — ProcessSymbolByList(list, patch). The WF private static (PatchForm.cs
+            // :9537) needs NO Form state: it reads the SYMBOL= param, combines it with the
+            // patch dir, reads the file, and calls SymbolUtil.ProcessSymbolToList (already in
+            // Core). Ported inline below.
+            ProcessPatchSymbolByList(list, patch);
+
+            // WF :6268 — string basedir = Path.GetDirectoryName(patch.PatchFileName);
+            // Normalize null -> "" so the per-block symbol channel never receives a null dir.
+            string basedir = System.IO.Path.GetDirectoryName(patch.PatchFileName) ?? "";
+
+            // WF :6269 — TracePatchedMapping(patch) dispatches to TraceEAPatchedMapping for
+            // TYPE=EA. We call the producer trace directly (the orchestrator only routes EA
+            // patches here). untraceable gaps are surfaced via the trace; the producer keeps
+            // emitting the ranges it COULD reconstruct (honest subset).
+            List<EventAssemblerUninstallCore.BinMapping> map =
+                TraceEAPatchedMappingForProducer(rom, patch);
+
+            foreach (EventAssemblerUninstallCore.BinMapping m in map)
+            {
+                uint a = m.addr;
+                if (!U.isSafetyOffset(a, rom))
+                {//WF :6273 — skip only this mapping.
+                    continue;
+                }
+
+                if (m.type == Address.DataTypeEnum.POINTER_ARRAY)
+                {//WF :6278-6284
+                    Address.AddPointerArray(list,
+                        a, m.length,
+                        patch.Name + "@" + m.filename + "@Pointer_Array",
+                        Address.DataTypeEnum.MIX);
+                }
+                else if (m.type == Address.DataTypeEnum.NEW_TARGET_SELECTION_STRUCT)
+                {//WF :6285-6290
+                    Address.AddNewTargetSelectionStruct(list,
+                        a, U.NOT_FOUND,
+                        patch.Name + "@" + m.filename + "@NEW_TARGET_SELECTION_STRUCT");
+                }
+                else if (m.type == Address.DataTypeEnum.PROCS)
+                {//WF :6291-6300
+                    Address.AddAddress(list,
+                        a,
+                        isPointerOnly ? 0 : m.length,
+                        U.NOT_FOUND,
+                        patch.Name + "@" + m.filename + "@PROCS",
+                        Address.DataTypeEnum.PROCS);
+                }
+                else
+                {//WF :6301-6309
+                    Address.AddAddress(list,
+                        a,
+                        isPointerOnly ? 0 : m.length,
+                        U.NOT_FOUND,
+                        patch.Name + "@" + m.filename + "@EA",
+                        m.type);
+                }
+
+                if (m.filename != "")
+                {//WF :6311-6314 — per-block ELF/sym.txt symbol channel (already in Core).
+                    SymbolUtil.ProcessSymbolByList(list, basedir, m.filename, m.addr);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Faithful Core port of WinForms <c>PatchForm.ProcessSymbolByList(List&lt;Address&gt;, PatchSt)</c>
+        /// (FEBuilderGBA/PatchForm.cs:9537) — the <c>SYMBOL=</c> side-channel. Reads the
+        /// <c>SYMBOL=</c> param, combines it with the patch directory, and (when the file
+        /// exists) feeds its contents to <see cref="SymbolUtil.ProcessSymbolToList"/> with
+        /// base address 0. Needs NO Form state (only patch params + a file read), so it is
+        /// ported inline. No-op when <c>SYMBOL=</c> is absent or the file is missing.
+        /// </summary>
+        static void ProcessPatchSymbolByList(List<Address> list, PatchInstallCore.PatchSt patch)
+        {
+            string symbol = U.at(patch.Param, "SYMBOL", "");
+            if (symbol == "")
+            {
+                return;
+            }
+            string basedir = System.IO.Path.GetDirectoryName(patch.PatchFileName) ?? "";
+            symbol = System.IO.Path.Combine(basedir, symbol);
+            if (!System.IO.File.Exists(symbol))
+            {
+                return;
+            }
+            string symbolData = System.IO.File.ReadAllText(symbol);
+            SymbolUtil.ProcessSymbolToList(list, patch.Name, symbolData, 0);
+        }
+
+        // ====================================================================
         // PatchForm producer — option-B epic (#1261, sub-slice s2pf-4 of 11).
         //
         // The TYPE=IMAGE terminal arm. Faithful Core port of WinForms

--- a/FEBuilderGBA.Tests/Unit/RebuildProducerEAArmWFParityTests.cs
+++ b/FEBuilderGBA.Tests/Unit/RebuildProducerEAArmWFParityTests.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Tests.Unit
+{
+    /// <summary>
+    /// BYTE-PARITY validation for the #1261 slice s2pf-14 TYPE=EA producer arm
+    /// (<see cref="RebuildProducerCore.EmitPatchEA"/> = WF
+    /// <c>PatchForm.MakePatchStructDataListForEA</c>, PatchForm.cs:6259).
+    ///
+    /// <para><b>Why a SYNTHETIC installed-EA scenario.</b> A freshly-loaded VANILLA FE8U
+    /// has ZERO installed TYPE=EA patches (proven by the sibling
+    /// <c>CorePatchProducer_IsStrictSubsetOf_WinFormsPatchProducer_EaBinGapDocumented</c> —
+    /// its <c>eaBinPatchCount</c> is 0), so the real ROM cannot exercise the EA arm. To get
+    /// an "installed EA patch" deterministically we PLANT the patch bytes into a synthetic
+    /// FE8 ROM at known addresses (a valid PROCS table, a unique BIN pattern, and an ORG
+    /// anchor), author a matching <c>.event</c> + a <c>{TYPE=EA, EA=...}</c> patch, and run
+    /// BOTH producers against that exact ROM:</para>
+    /// <list type="bullet">
+    ///   <item>WF: <c>PatchForm.MakePatchStructDataListForEA(list, isPointerOnly, patch)</c>
+    ///   (private static — reached via reflection; it reads <c>Program.ROM</c>, which we set
+    ///   to the synthetic ROM).</item>
+    ///   <item>Core: <see cref="RebuildProducerCore.EmitPatchEA"/> on the same ROM.</item>
+    /// </list>
+    /// <para>The two emitted lists are then asserted EQUAL on the load-bearing fields
+    /// (Addr/Length/Pointer/DataType) — including the PROCS entry the producer emits (WF via
+    /// <c>ProcsScriptForm.CalcLengthAndCheck</c>, Core via the verbatim
+    /// <c>CalcProcsLengthAndCheck</c>) and the BIN/ORG entries the shared s2pf-13 walker
+    /// reconstructs. Info/name is cosmetic and not compared.</para>
+    ///
+    /// <para>This test lives in <c>FEBuilderGBA.Tests</c> (net9.0-windows) because it calls
+    /// the WinForms <c>PatchForm</c>, which does not exist in the net9.0 Core assembly. It
+    /// SKIPS (early-return = Pass) if the WF reflective hooks are unavailable, so it never
+    /// breaks CI on a layout change. It mutates global <c>Program.ROM</c>/<c>CoreState.ROM</c>,
+    /// so it is in the <c>SharedState</c> collection.</para>
+    /// </summary>
+    [Collection("SharedState")]
+    public class RebuildProducerEAArmWFParityTests
+    {
+        // 16 MiB synthetic FE8 ROM, BE8E01 — RomInfo-bearing so both producers' GREP seed +
+        // PROCS length detector work. Sets Program.ROM (reflection) AND CoreState.ROM.
+        static ROM MakeFe8RomAndInstall()
+        {
+            var data = new byte[0x1000000];
+            byte[] code = System.Text.Encoding.ASCII.GetBytes("BE8E01");
+            Array.Copy(code, 0, data, 0xAC, code.Length);
+
+            var rom = new ROM();
+            bool ok = rom.LoadLow("synthetic-FE8.gba", data, "BE8E01");
+            if (!ok) return null;
+            CoreState.ROM = rom;
+            return SetProgramRom(rom) ? rom : null;
+        }
+
+        // Program.ROM has a private setter — set it via reflection for this headless WF test.
+        static bool SetProgramRom(ROM rom)
+        {
+            try
+            {
+                PropertyInfo p = typeof(Program).GetProperty(
+                    "ROM", BindingFlags.Public | BindingFlags.Static);
+                if (p == null) return false;
+                p.SetValue(null, rom, BindingFlags.NonPublic | BindingFlags.Instance, null, null, null);
+                return ReferenceEquals(Program.ROM, rom);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        // Build a WinForms PatchForm.PatchSt mirroring the Core PatchInstallCore.PatchSt.
+        static PatchForm.PatchSt MakeWfPatch(string dir, string name, string eaFileName,
+            params (string key, string value)[] extra)
+        {
+            var p = new PatchForm.PatchSt
+            {
+                Name = name,
+                PatchFileName = Path.Combine(dir, "PATCH_" + name + ".txt"),
+                Param = new Dictionary<string, string>(),
+            };
+            p.Param["TYPE"] = "EA";
+            p.Param["EA"] = eaFileName;
+            foreach (var (k, v) in extra) p.Param[k] = v;
+            return p;
+        }
+
+        static PatchInstallCore.PatchSt MakeCorePatch(string dir, string name, string eaFileName,
+            params (string key, string value)[] extra)
+        {
+            var p = new PatchInstallCore.PatchSt
+            {
+                Name = name,
+                PatchFileName = Path.Combine(dir, "PATCH_" + name + ".txt"),
+                Param = new Dictionary<string, string>(),
+            };
+            p.Param["TYPE"] = "EA";
+            p.Param["EA"] = eaFileName;
+            foreach (var (k, v) in extra) p.Param[k] = v;
+            return p;
+        }
+
+        // Call the private static WF PatchForm.MakePatchStructDataListForEA via reflection.
+        // Returns null if the method is not found (→ test skips).
+        static List<Address> CallWfMakePatchStructDataListForEA(List<Address> list, bool isPointerOnly, PatchForm.PatchSt patch)
+        {
+            MethodInfo m = typeof(PatchForm).GetMethod(
+                "MakePatchStructDataListForEA",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            if (m == null) return null;
+            m.Invoke(null, new object[] { list, isPointerOnly, patch });
+            return list;
+        }
+
+        readonly struct Key : IEquatable<Key>
+        {
+            public readonly uint Addr;
+            public readonly uint Length;
+            public readonly uint Pointer;
+            public readonly Address.DataTypeEnum Type;
+            Key(uint a, uint l, uint p, Address.DataTypeEnum t) { Addr = a; Length = l; Pointer = p; Type = t; }
+            public static Key Of(Address a) => new Key(a.Addr, a.Length, a.Pointer, a.DataType);
+            public bool Equals(Key o) => Addr == o.Addr && Length == o.Length && Pointer == o.Pointer && Type == o.Type;
+            public override bool Equals(object o) => o is Key k && Equals(k);
+            public override int GetHashCode() => HashCode.Combine(Addr, Length, Pointer, (int)Type);
+        }
+
+        static string Dump(IEnumerable<Key> keys)
+        {
+            return string.Join("\n", keys.Take(30).Select(k =>
+                $"  Addr=0x{k.Addr:X} Len=0x{k.Length:X} Ptr=0x{k.Pointer:X} Type={k.Type}"));
+        }
+
+        [Fact]
+        public void CoreEmitPatchEA_MatchesWinForms_OnInstalledEaRom_OrgBinProcs()
+        {
+            ROM savedCore = CoreState.ROM;
+            ROM savedProg = Program.ROM;
+            string dir = Path.Combine(Path.GetTempPath(), "ea-wfparity-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var rom = MakeFe8RomAndInstall();
+                if (rom == null) return; // WF Program.ROM hook unavailable — SKIP (Pass)
+
+                // ---- PLANT the "installed EA patch" bytes at known addresses ----
+                const uint orgAddr = 0x800000;     // ORG anchor → lastMatchAddr
+                const uint procsAdd = 0x1000;
+                const uint advanced = orgAddr + procsAdd;   // PROCS resolves here (0x801000)
+                // A valid PROCS EXIT (code=0,sarg=0,parg=0) → length 8 on both producers.
+                for (int i = 0; i < 8; i++) rom.write_u8(advanced + (uint)i, 0x00);
+                // A unique BIN pattern after the PROCS region.
+                byte[] pattern = { 0xCA, 0xFE, 0xBA, 0xBE, 0x12, 0x34, 0x56, 0x78 };
+                const uint binAddr = advanced + 0x4000;     // 0x805000
+                for (int i = 0; i < pattern.Length; i++) rom.write_u8(binAddr + (uint)i, pattern[i]);
+
+                File.WriteAllBytes(Path.Combine(dir, "blk.bin"), pattern);
+                File.WriteAllText(Path.Combine(dir, "main.event"),
+                    "ORG 0x" + orgAddr.ToString("X") + "\r\n" +
+                    "procs_label: // HINT=PROCS ADD=" + procsAdd.ToString() + "\r\n" +
+                    "#incbin \"blk.bin\" // HINT=BIN\r\n");
+
+                // ---- WF reference (private static, via reflection; reads Program.ROM) ----
+                var wf = new List<Address>();
+                var wfRet = CallWfMakePatchStructDataListForEA(wf,
+                    false, MakeWfPatch(dir, "EAp", "main.event"));
+                if (wfRet == null) return; // WF method not found — SKIP (Pass)
+
+                // ---- Core: EmitPatchEA on the same ROM ----
+                var core = new List<Address>();
+                RebuildProducerCore.EmitPatchEA(rom, core,
+                    MakeCorePatch(dir, "EAp", "main.event"), isPointerOnly: false);
+
+                Assert.NotEmpty(wf);
+                Assert.NotEmpty(core);
+
+                var wfKeys = new HashSet<Key>(wf.Select(Key.Of));
+                var coreKeys = new HashSet<Key>(core.Select(Key.Of));
+
+                var coreExtras = core.Where(a => !wfKeys.Contains(Key.Of(a))).Select(Key.Of).Distinct().ToList();
+                var wfExtras = wf.Where(a => !coreKeys.Contains(Key.Of(a))).Select(Key.Of).Distinct().ToList();
+
+                if (coreExtras.Count > 0 || wfExtras.Count > 0)
+                {
+                    Assert.Fail(
+                        "Core EmitPatchEA diverges from WF MakePatchStructDataListForEA on an installed-EA ROM.\n"
+                        + $"WF total={wf.Count}, Core total={core.Count}.\n"
+                        + $"Core-only (Core emits, WF does not) [{coreExtras.Count}]:\n{Dump(coreExtras)}\n"
+                        + $"WF-only (Core dropped) [{wfExtras.Count}]:\n{Dump(wfExtras)}");
+                }
+
+                // PROVEN: byte-identical on (Addr/Length/Pointer/DataType).
+                Assert.Empty(coreExtras);
+                Assert.Empty(wfExtras);
+
+                // And the PROCS entry IS present on both (the producer-only emit the uninstall
+                // path skips) — pin it explicitly so a future regression that drops PROCS on
+                // BOTH sides cannot pass the set-equality vacuously.
+                Assert.Contains(core, a => a.DataType == Address.DataTypeEnum.PROCS && a.Addr == advanced && a.Length == 8);
+                Assert.Contains(wf, a => a.DataType == Address.DataTypeEnum.PROCS && a.Addr == advanced && a.Length == 8);
+                // The BIN entry matched the planted pattern on both.
+                Assert.Contains(core, a => a.Addr == binAddr);
+                Assert.Contains(wf, a => a.Addr == binAddr);
+            }
+            finally
+            {
+                CoreState.ROM = savedCore;
+                SetProgramRom(savedProg);
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+
+        // isPointerOnly=true → the PROCS/EA lengths become 0 on BOTH producers; the key sets
+        // must still match exactly.
+        [Fact]
+        public void CoreEmitPatchEA_MatchesWinForms_PointerOnly()
+        {
+            ROM savedCore = CoreState.ROM;
+            ROM savedProg = Program.ROM;
+            string dir = Path.Combine(Path.GetTempPath(), "ea-wfparity-po-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var rom = MakeFe8RomAndInstall();
+                if (rom == null) return;
+
+                const uint orgAddr = 0x800000;
+                const uint procsAdd = 0x1000;
+                const uint advanced = orgAddr + procsAdd;
+                for (int i = 0; i < 8; i++) rom.write_u8(advanced + (uint)i, 0x00);
+
+                File.WriteAllText(Path.Combine(dir, "main.event"),
+                    "ORG 0x" + orgAddr.ToString("X") + "\r\n" +
+                    "procs_label: // HINT=PROCS ADD=" + procsAdd.ToString() + "\r\n");
+
+                var wf = new List<Address>();
+                var wfRet = CallWfMakePatchStructDataListForEA(wf, true, MakeWfPatch(dir, "PO", "main.event"));
+                if (wfRet == null) return;
+
+                var core = new List<Address>();
+                RebuildProducerCore.EmitPatchEA(rom, core, MakeCorePatch(dir, "PO", "main.event"), isPointerOnly: true);
+
+                var wfKeys = new HashSet<Key>(wf.Select(Key.Of));
+                var coreKeys = new HashSet<Key>(core.Select(Key.Of));
+                var coreExtras = core.Where(a => !wfKeys.Contains(Key.Of(a))).Select(Key.Of).Distinct().ToList();
+                var wfExtras = wf.Where(a => !coreKeys.Contains(Key.Of(a))).Select(Key.Of).Distinct().ToList();
+
+                Assert.Empty(coreExtras);
+                Assert.Empty(wfExtras);
+                // PROCS length is 0 in pointer-only mode on both.
+                Assert.Contains(core, a => a.DataType == Address.DataTypeEnum.PROCS && a.Addr == advanced && a.Length == 0);
+                Assert.Contains(wf, a => a.DataType == Address.DataTypeEnum.PROCS && a.Addr == advanced && a.Length == 0);
+            }
+            finally
+            {
+                CoreState.ROM = savedCore;
+                SetProgramRom(savedProg);
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ports the WinForms **TYPE=EA producer arm** to Core for the ROM-rebuild producer (option-B PatchForm epic, **sub-slice 14/17**). Two new public Core methods on `RebuildProducerCore`:

- **`TraceEAPatchedMappingForProducer(rom, patch, untraceable=null)`** — faithful port of WF `PatchForm.TraceEAPatchedMapping` (`PatchForm.cs:5247`). The multi-event-file loop (`*.event` recursive + the `EA=` main file via `AddIfNotExist`) is parsed by `EAUtilCore` and walked by the **s2pf-13 shared `EventAssemblerUninstallCore.EmitEaDataList`**, so ORG/ASM/MIX/LYN/LYNHOOK/POINTER_ARRAY/BIN/mask/GREP/EraseORG stay **byte-identical** to the verified #1242 uninstall trace.
- **`EmitPatchEA(rom, list, patch, isPointerOnly)`** — faithful port of WF `PatchForm.MakePatchStructDataListForEA` (`PatchForm.cs:6259`): `ASMMAP=false` early-return, `SYMBOL=` side-channel (inline port of the Form-private `ProcessSymbolByList` → `SymbolUtil.ProcessSymbolToList`), per-`BinMapping` dispatch (POINTER_ARRAY → `AddPointerArray`, NEW_TARGET_SELECTION_STRUCT → `AddNewTargetSelectionStruct`, PROCS / EA → `AddAddress`) + per-mapping `SymbolUtil.ProcessSymbolByList`.

### s2pf-17 API (for the orchestrator wiring)
```csharp
public static void EmitPatchEA(ROM rom, List<Address> list,
    PatchInstallCore.PatchSt patch, bool isPointerOnly);
```

## STRICTER PROCS emit (the producer divergence)

The **uninstall** path SKIPS PROCS as residue (its WinForms-only length detector is absent), but the **producer MUST EMIT** it — a missed live PROCS in the rebuild free list = silent corruption. Injected via a new `EmitEaDataList` **`procsHandler` hook** (optional param; `null` for the uninstall caller → byte-identical behaviour, **NO regression**) backed by the verbatim `CalcProcsLengthAndCheck` (= `ProcsScriptForm.CalcLengthAndCheck`, WF `:5452`); **skip ONLY on `NOT_FOUND`** (verbatim WF `continue` at `:5453`), recorded as untraceable (honest omission, never a guessed length). GREP misses on ASM/MIX/LYN/BIN are recorded by `EmitEaDataList` → surfaced, never silent-omitted.

## How the installed-EA verification was achieved

A freshly-loaded **vanilla FE8U installs ZERO TYPE=EA patches** (proven by the sibling s2pf-11 parity test's `eaBinPatchCount == 0`), so the real ROM cannot exercise the EA arm. To get an installed-EA scenario deterministically I **PLANT the patch bytes** into a synthetic FE8 ROM at known addresses (a valid PROCS EXIT table, a unique BIN pattern, an ORG anchor), author a matching `.event` + `{TYPE=EA, EA=...}` patch, then run **BOTH** producers on that exact ROM:

- WF `PatchForm.MakePatchStructDataListForEA` (private static, via reflection; reads `Program.ROM` = the synthetic ROM)
- Core `EmitPatchEA` on the same ROM

…and assert **EXACT set-equality** on `(Addr/Length/Pointer/DataType)` — including the PROCS entry (length 8, and 0 in pointer-only mode) and the BIN/ORG entries. **Result: byte-identical.**

## Deferred (s2pf-16, marked in code)

The WF trailers `TraceEditPatch` / `AppendMenuPatch` / `AppendNewTargetSelectionStruct` (`PatchForm.cs:5508-5512`) — they act on extra patch params (`EDIT_PATCH`/`MENU`/`NEW_TARGET_SELECTION_STRUCT`) and emit nothing for a bare `{TYPE=EA, EA=...}` patch.

## Scope

- **14/17.** The gate token `PatchForm(MakePatchStructDataList)` STAYS; the orchestrator's EA case stays a stub (s2pf-17 wires `EmitPatchEA` live).
- Does NOT regress the s2pf-13 `EmitEaDataList` / #1242 uninstall behaviour.

## Test plan

- [x] `RebuildProducerPatchEATests` (Core.Tests, +17): ORG/BIN trace; PROCS emit with real length; PROCS skip-on-`NOT_FOUND` + baseline-advance; GREP-miss → untraceable; POINTER_ARRAY → `AddPointerArray` dispatch; `SYMBOL=` channel; `isPointerOnly` → length 0; `ASMMAP=false` early-return; null/guard cases; **uninstall NON-regression** (null `procsHandler` still skips a valid PROCS; producer-vs-uninstall diverge ONLY on PROCS).
- [x] `RebuildProducerEAArmWFParityTests` (FEBuilderGBA.Tests, net9.0-windows, +2): **byte-parity vs WF** on the synthetic installed-EA ROM (ORG/BIN/PROCS + pointer-only).
- [x] `dotnet test --filter "FullyQualifiedName~RebuildProducer"` → **677 pass** (baseline 660 + 17), 0 failed.
- [x] `dotnet test --filter "FullyQualifiedName~EventAssemblerUninstall"` → 14 pass, 1 skip (stays green — `EmitEaDataList` touched but uninstall behaviour unchanged).
- [x] Full `FEBuilderGBA.Core.Tests` → **5172 pass / 6 skip / 0 fail**.
- [x] `RebuildProducer` WF-parity tests in `FEBuilderGBA.Tests` → 8 pass.
- [x] `dotnet build FEBuilderGBA.sln` → 0 errors.

## Proof (non-GUI — Core/Tests only)

This is a **Core-only** change (no GUI), so no screenshot. The byte-parity test output is the proof: Core `EmitPatchEA` == WF `MakePatchStructDataListForEA` on an installed-EA ROM.

Part of #1261.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]