### PR TITLE
fix(core): carry EA trace baseline across .event files (#1261 s2pf-14 follow-up)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchEATests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchEATests.cs
@@ -208,9 +208,14 @@ namespace FEBuilderGBA.Core.Tests
             }
 
             File.WriteAllBytes(Path.Combine(dir, "blk.bin"), pattern);
-            // Two event files. The dir *.event scan returns them sorted; both #incbin blk.bin.
-            // Name them so the ordering is deterministic (a_, b_). Each is a separate file →
-            // each gets its own EmitEaDataList call; the baseline must persist between them.
+            // Two separate event files, both #incbin blk.bin → each gets its own
+            // EmitEaDataList call, so the baseline must persist BETWEEN the calls. The
+            // assertion below is ORDER-INDEPENDENT (U.Directory_GetFiles_Safe does NOT sort —
+            // GetFiles order is unspecified): whichever file is walked first matches the lower
+            // copy and advances the baseline past it, so the other file matches the higher
+            // copy — both copies are claimed regardless of which file comes first. A per-file
+            // baseline reset, by contrast, would re-match the FIRST copy in BOTH files and
+            // drop the second copy, in any order.
             File.WriteAllText(Path.Combine(dir, "a_first.event"), "#incbin \"blk.bin\" // HINT=BIN\r\n");
             File.WriteAllText(Path.Combine(dir, "b_second.event"), "#incbin \"blk.bin\" // HINT=BIN\r\n");
 

--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchEATests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchEATests.cs
@@ -183,6 +183,49 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Contains(map, m => m.addr == binAddr && m.key == "BIN");
         }
 
+        // The GREP baseline (lastMatchAddr) is seeded ONCE and CARRIED ACROSS .event files
+        // (WF PatchForm.TraceEAPatchedMapping seeds it before its foreach, NOT per file). With
+        // TWO files that both #incbin the SAME pattern, the FIRST match claims a copy and
+        // advances the baseline; the SECOND file MUST match the LATER copy, not re-match the
+        // earlier (decoy) one. If the per-file walker reset the baseline to the borderline,
+        // the second file would re-select the FIRST copy → a duplicate/wrong free-list entry.
+        // (Copilot PR #1329 finding.)
+        [Fact]
+        public void Trace_MultipleEventFiles_CarriesBaselineAcrossFiles()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+
+            byte[] pattern = { 0x5A, 0xA5, 0x3C, 0xC3, 0x0F, 0xF0, 0x69, 0x96 };
+            // Two distinct copies of the SAME pattern, both after the borderline. The first
+            // file should match the FIRST copy, the second file the SECOND copy.
+            const uint firstAddr = 0x900000;
+            const uint secondAddr = 0x901000;
+            for (int i = 0; i < pattern.Length; i++)
+            {
+                rom.write_u8(firstAddr + (uint)i, pattern[i]);
+                rom.write_u8(secondAddr + (uint)i, pattern[i]);
+            }
+
+            File.WriteAllBytes(Path.Combine(dir, "blk.bin"), pattern);
+            // Two event files. The dir *.event scan returns them sorted; both #incbin blk.bin.
+            // Name them so the ordering is deterministic (a_, b_). Each is a separate file →
+            // each gets its own EmitEaDataList call; the baseline must persist between them.
+            File.WriteAllText(Path.Combine(dir, "a_first.event"), "#incbin \"blk.bin\" // HINT=BIN\r\n");
+            File.WriteAllText(Path.Combine(dir, "b_second.event"), "#incbin \"blk.bin\" // HINT=BIN\r\n");
+
+            // EA= names one of them with a .EVENT ext (so AddIfNotExist is skipped; the dir
+            // scan supplies both). The patch just needs a valid EA= entry.
+            var patch = MakeEaPatch(dir, "Multi", "a_first.event");
+            var map = RebuildProducerCore.TraceEAPatchedMappingForProducer(rom, patch);
+
+            // Both copies are claimed — the second file matched the LATER address, proving the
+            // baseline carried across files (NOT reset to the borderline, which would have
+            // re-matched firstAddr and dropped secondAddr).
+            Assert.Contains(map, m => m.addr == firstAddr && m.key == "BIN");
+            Assert.Contains(map, m => m.addr == secondAddr && m.key == "BIN");
+        }
+
         // ====================================================================
         // PROCS EMIT — the producer's STRICTER divergence vs the uninstall path.
         // ====================================================================

--- a/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
+++ b/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
@@ -232,10 +232,21 @@ namespace FEBuilderGBA
         /// <param name="procsHandler">Producer-only PROCS emit hook (see
         /// <see cref="ProcsEmitHandler"/>); <c>null</c> for the uninstall path, which skips
         /// PROCS as residue exactly as before.</param>
-        internal static void EmitEaDataList(ROM rom, EAUtilCore ea, List<BinMapping> binMappings, List<string> untraceable,
-            ProcsEmitHandler procsHandler = null)
+        /// <param name="initialLastMatchAddr">The starting GREP/POINTER_ARRAY/PROCS baseline.
+        /// <c>null</c> (the uninstall caller's default) seeds it from
+        /// <c>rom.RomInfo.compress_image_borderline_address</c> — byte-identical to the
+        /// original single-file walk. The PRODUCER's multi-event-file loop passes the value
+        /// RETURNED by the previous file's call, so the baseline is CARRIED ACROSS files
+        /// exactly as WF <c>PatchForm.TraceEAPatchedMapping</c> does (it seeds
+        /// <c>lastMatchAddr</c> ONCE at :5266, BEFORE the <c>foreach (files)</c> loop at
+        /// :5268). Without this, file 2+ would re-seed at the borderline and a duplicate
+        /// pattern earlier in free space could be mis-selected (Copilot PR #1329 finding).</param>
+        /// <returns>The advanced <c>lastMatchAddr</c> after walking this file — the producer
+        /// threads it into the next file's call to preserve the cross-file baseline.</returns>
+        internal static uint EmitEaDataList(ROM rom, EAUtilCore ea, List<BinMapping> binMappings, List<string> untraceable,
+            ProcsEmitHandler procsHandler = null, uint? initialLastMatchAddr = null)
         {
-            uint lastMatchAddr = rom.RomInfo.compress_image_borderline_address;
+            uint lastMatchAddr = initialLastMatchAddr ?? rom.RomInfo.compress_image_borderline_address;
 
             for (int n = 0; n < ea.DataList.Count; n++)
             {
@@ -484,6 +495,11 @@ namespace FEBuilderGBA
                     lastMatchAddr = addr + length;
                 }
             }
+
+            // Return the advanced baseline so the producer's multi-event-file loop can carry
+            // it into the next file (WF seeds lastMatchAddr ONCE before its foreach). The
+            // uninstall caller walks a single file and ignores this.
+            return lastMatchAddr;
         }
 
         /// <summary>

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -13410,6 +13410,12 @@ namespace FEBuilderGBA
                 };
             };
 
+            // WF :5266 — seed lastMatchAddr ONCE at the borderline, BEFORE the file loop
+            // (:5268), so the GREP/POINTER_ARRAY/PROCS baseline is CARRIED ACROSS every
+            // .event file. Re-seeding per file (the bug Copilot PR #1329 flagged) would let
+            // a duplicate pattern earlier in free space be mis-selected for file 2+.
+            uint lastMatchAddr = rom.RomInfo.compress_image_borderline_address;
+
             foreach (string fullfilename in files)
             {
                 if (EAUtilCore.IsFBGTemp(fullfilename))
@@ -13438,8 +13444,11 @@ namespace FEBuilderGBA
                 untraceable.AddRange(ea.UntraceableNotes);
 
                 // The shared s2pf-13 walker — byte-identical to the uninstall trace for every
-                // block EXCEPT PROCS, which procsHandler now EMITS for the producer.
-                EventAssemblerUninstallCore.EmitEaDataList(rom, ea, binMappings, untraceable, procsHandler);
+                // block EXCEPT PROCS, which procsHandler now EMITS for the producer. Thread
+                // lastMatchAddr IN (the baseline reached by prior files) and OUT (its advanced
+                // value) so it persists across files exactly as WF's single seed does.
+                lastMatchAddr = EventAssemblerUninstallCore.EmitEaDataList(
+                    rom, ea, binMappings, untraceable, procsHandler, lastMatchAddr);
             }
 
             // s2pf-16: WF :5507-5512 trailers (TraceEditPatch / AppendMenuPatch /


### PR DESCRIPTION
## Summary

Follow-up to the s2pf-14 TYPE=EA producer arm (#1329, already merged) addressing a **blocking Copilot CLI review finding** that arrived after auto-merge had already squashed #1329 — so the fix lands here.

**The bug.** WF `PatchForm.TraceEAPatchedMapping` seeds `lastMatchAddr` ONCE at the borderline (`PatchForm.cs:5266`) **before** its `foreach (files)` loop (`:5268`), so the GREP / POINTER_ARRAY / PROCS baseline persists across **every** `.event` file. The s2pf-14 port called the shared `EmitEaDataList` per-file, and `EmitEaDataList` re-seeded `lastMatchAddr` from the borderline on **every** call — so file 2+ restarted at the borderline. A duplicate BIN/ASM/MIX/LYN pattern earlier in free space could then be mis-selected for a later file, producing a wrong rebuild free-list entry and breaking the claimed WF parity.

**The fix.** `EmitEaDataList` now accepts an optional `initialLastMatchAddr` (`null` = seed from the borderline, **byte-identical** to the single-file uninstall caller) and **RETURNS** the advanced baseline. `TraceEAPatchedMappingForProducer` seeds it ONCE before the file loop and threads the returned value into each subsequent `EmitEaDataList` call — reproducing WF's single seed exactly. The uninstall caller (single file) passes `null` and ignores the return → **NO behaviour change** (the #1242 uninstall trace stays byte-identical).

## Test plan

- [x] `Trace_MultipleEventFiles_CarriesBaselineAcrossFiles` (Core.Tests, +1): two `.event` files both `#incbin` the SAME pattern planted at two addresses; BOTH copies must be claimed (the second file matches the LATER copy) — which only holds if the baseline carried across files (a per-file reset would re-match the first copy and drop the second).
- [x] `RebuildProducerPatchEATests` + `EventAssemblerUninstall*` → 32 pass, 1 skip (uninstall NON-regression preserved).
- [x] `dotnet test --filter "FullyQualifiedName~RebuildProducer"` → 678 pass.
- [x] `dotnet build FEBuilderGBA.sln` → 0 errors.

## Proof (non-GUI — Core/Tests only)

Core-only change, no GUI → no screenshot. The new multi-file test is the proof: both planted copies are claimed, proving the cross-file baseline.

Part of #1261.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]