### PR TITLE
feat(core): PatchForm TYPE=BIN producer arm (trace + $FREEAREA) (#1261 s2pf-15)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchBINTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchBINTests.cs
@@ -1,0 +1,607 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for RebuildProducerCore slice s2pf-15 (#1261) — the TYPE=BIN producer ARM
+// (option-B PatchForm epic, sub-slice 15 of 17):
+//   RebuildProducerCore.TraceBINPatchedMappingForProducer = WF PatchForm.TraceBINPatchedMapping        @:4951
+//   RebuildProducerCore.EmitPatchBIN                       = WF PatchForm.MakePatchStructDataListForBIN @:6317
+//   EventAssemblerUninstallCore.ReadMod(string[],string,out,ROM) = WF PatchForm.ReadMod(file)          @:4309
+//
+// The BIN trace is a FROM-SCRATCH port (no Core BIN trace existed). It RE-LOCATES where
+// the already-installed BIN bytes landed in the SAVED ROM (deterministic — never
+// allocates). Three WF arms in WF order: JUMP, BIN-family ($FREEAREA GREP-locate /
+// fixed-addr), SLIDE, CLEAR (UNUSEDBIN).
+//
+// VERIFICATION of an "installed-BIN" scenario without a real installed patch (vanilla
+// FE8U installs 0 BIN patches): a synthetic FE8 ROM is loaded, the patch BYTES are PLANTED
+// at known addresses, and hand-authored .bin files + a synthetic PatchSt drive the
+// trace/emit. The asserts pin the reconstructed BinMappings + the emitted Address entries
+// (addr/length/pointer/type). Coverage per arm: every JUMP length case ($NONE/$NONE+1/
+// $NONE-above-borderline/$B/$BL/generated-aligned/generated-misaligned), $FREEAREA
+// GREP-locate + lastMatchAddr advance + the JUMP-match->ASM cross-arm rule, fixed-addr BIN
+// (BIN/BINP/BINAP/BINF), SLIDE, CLEAR, the EmitPatchBIN per-type dispatch, isPointerOnly,
+// and ASMMAP=false early-return.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public class RebuildProducerPatchBINTests : IDisposable
+    {
+        readonly ROM _savedRom = CoreState.ROM;
+        readonly string _savedLang = CoreState.Language;
+        readonly string _savedBaseDir = CoreState.BaseDirectory;
+        readonly List<string> _tempDirs = new List<string>();
+
+        public RebuildProducerPatchBINTests()
+        {
+            CoreState.Language = "en";
+        }
+
+        public void Dispose()
+        {
+            CoreState.ROM = _savedRom;
+            CoreState.Language = _savedLang;
+            CoreState.BaseDirectory = _savedBaseDir;
+            foreach (string d in _tempDirs)
+            {
+                try { if (Directory.Exists(d)) Directory.Delete(d, true); } catch { }
+            }
+        }
+
+        // 16 MiB zero-filled FE8U ROM (LoadLow minimum for BE8E01) — RomInfo-bearing so the
+        // trace's compress_image_borderline_address seed + $NONE borderline split work. Also
+        // sets CoreState.ROM: although the trace threads `rom` explicitly, EmitPatchBIN's
+        // Address.Add* sinks use the single-arg U.isSafetyOffset/isSafetyPointer overloads
+        // that read CoreState.ROM (same coupling as RebuildProducerPatchEATests).
+        static ROM MakeRom()
+        {
+            var rom = new ROM();
+            byte[] data = new byte[0x1000000];
+            bool ok = rom.LoadLow("x.gba", data, "BE8E01");
+            Assert.True(ok, "LoadLow did not recognize BE8E01");
+            CoreState.ROM = rom;
+            return rom;
+        }
+
+        string NewTempDir()
+        {
+            string d = Path.Combine(Path.GetTempPath(), "bin-s2pf15-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(d);
+            _tempDirs.Add(d);
+            return d;
+        }
+
+        // Build a TYPE=BIN PatchSt whose PatchFileName lives in `dir` (so $FREEAREA/fixed BIN
+        // files resolve against that dir) with the given params (full colon-keys, like a real
+        // PATCH file: "BIN:$FREEAREA", "JUMP:0x...:$NONE", "CLEAR:0x...:0x...").
+        static PatchInstallCore.PatchSt MakeBinPatch(string dir, string name,
+            params (string key, string value)[] kv)
+        {
+            var p = new PatchInstallCore.PatchSt
+            {
+                Name = name,
+                PatchFileName = Path.Combine(dir, "PATCH_" + name + ".txt"),
+                Param = new Dictionary<string, string>(),
+            };
+            p.Param["TYPE"] = "BIN";
+            foreach (var (key, value) in kv)
+            {
+                p.Param[key] = value;
+            }
+            return p;
+        }
+
+        static void Write(ROM rom, uint addr, params byte[] bytes)
+        {
+            for (int i = 0; i < bytes.Length; i++) rom.write_u8(addr + (uint)i, bytes[i]);
+        }
+
+        static EventAssemblerUninstallCore.BinMapping ByKey(
+            List<EventAssemblerUninstallCore.BinMapping> map, string key)
+        {
+            return map.FirstOrDefault(m => m.key == key);
+        }
+
+        // ====================================================================
+        // JUMP arm — every length/type case (WF :4960-5037)
+        // ====================================================================
+
+        [Fact]
+        public void TraceJump_None_AboveBorderline_IsPointerLen4()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            // borderline for FE8 is well below 0x800000, so this addr is "above" => POINTER.
+            uint addr = 0x800000;
+            Write(rom, addr, 0x11, 0x22, 0x33, 0x44, 0x55);
+            var patch = MakeBinPatch(dir, "j",
+                ("JUMP:0x" + addr.ToString("X") + ":$NONE", "lab"));
+
+            var map = RebuildProducerCore.TraceBINPatchedMappingForProducer(rom, patch);
+
+            var b = ByKey(map, "JUMP:0x" + addr.ToString("X") + ":$NONE");
+            Assert.NotNull(b);
+            Assert.Equal(addr, b.addr);
+            Assert.Equal(4u, b.length);
+            Assert.Equal(Address.DataTypeEnum.POINTER, b.type);
+            Assert.Equal("$JUMP:lab", b.filename);
+            Assert.Equal(4, b.mask.Length);
+            Assert.All(b.mask, m => Assert.False(m));     // WF :5030 — all false.
+            Assert.Equal(new byte[] { 0x11, 0x22, 0x33, 0x44 }, b.bin);
+        }
+
+        [Fact]
+        public void TraceJump_NonePlus1_IsPointerAsmLen4()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            uint addr = 0x800000;
+            var patch = MakeBinPatch(dir, "j",
+                ("JUMP:0x" + addr.ToString("X") + ":$NONE:+1", "lab"));
+
+            var map = RebuildProducerCore.TraceBINPatchedMappingForProducer(rom, patch);
+
+            var b = ByKey(map, "JUMP:0x" + addr.ToString("X") + ":$NONE:+1");
+            Assert.NotNull(b);
+            Assert.Equal(4u, b.length);
+            Assert.Equal(Address.DataTypeEnum.POINTER_ASM, b.type);   // WF :4985 — +1 => code.
+        }
+
+        [Fact]
+        public void TraceJump_None_AtOrBelowBorderline_IsPointerAsmLen4()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            // An addr at/below the compress borderline => code => POINTER_ASM (WF :4989).
+            uint border = rom.RomInfo.compress_image_borderline_address;
+            // Pick a safe offset that is <= border (border itself is safe and > 0x200).
+            uint addr = border;
+            var patch = MakeBinPatch(dir, "j",
+                ("JUMP:0x" + addr.ToString("X") + ":$NONE", "lab"));
+
+            var map = RebuildProducerCore.TraceBINPatchedMappingForProducer(rom, patch);
+
+            var b = ByKey(map, "JUMP:0x" + addr.ToString("X") + ":$NONE");
+            Assert.NotNull(b);
+            Assert.Equal(4u, b.length);
+            Assert.Equal(Address.DataTypeEnum.POINTER_ASM, b.type);
+        }
+
+        [Fact]
+        public void TraceJump_B_And_BL_AreBinLen2()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            uint a1 = 0x800000;
+            uint a2 = 0x800010;
+            Write(rom, a1, 0xAA, 0xBB, 0xCC);
+            Write(rom, a2, 0xDD, 0xEE, 0xFF);
+            var patch = MakeBinPatch(dir, "j",
+                ("JUMP:0x" + a1.ToString("X") + ":$B", "lb"),
+                ("JUMP:0x" + a2.ToString("X") + ":$BL", "lbl"));
+
+            var map = RebuildProducerCore.TraceBINPatchedMappingForProducer(rom, patch);
+
+            var b = ByKey(map, "JUMP:0x" + a1.ToString("X") + ":$B");
+            Assert.NotNull(b);
+            Assert.Equal(2u, b.length);
+            Assert.Equal(Address.DataTypeEnum.BIN, b.type);
+            Assert.Equal(new byte[] { 0xAA, 0xBB }, b.bin);
+
+            var bl = ByKey(map, "JUMP:0x" + a2.ToString("X") + ":$BL");
+            Assert.NotNull(bl);
+            Assert.Equal(2u, bl.length);
+            Assert.Equal(Address.DataTypeEnum.BIN, bl.type);
+        }
+
+        [Fact]
+        public void TraceJump_Generated_Aligned_IsJumpToHackLen8()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            uint addr = 0x800000;            // % 4 == 0 => length 8 (WF :5016).
+            var patch = MakeBinPatch(dir, "j",
+                ("JUMP:0x" + addr.ToString("X") + ":$r3", "tgt"));
+
+            var map = RebuildProducerCore.TraceBINPatchedMappingForProducer(rom, patch);
+
+            var b = ByKey(map, "JUMP:0x" + addr.ToString("X") + ":$r3");
+            Assert.NotNull(b);
+            Assert.Equal(8u, b.length);
+            Assert.Equal(Address.DataTypeEnum.JUMPTOHACK, b.type);
+        }
+
+        [Fact]
+        public void TraceJump_Generated_Misaligned_IsJumpToHackLen10()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            uint addr = 0x800002;            // % 4 != 0 => length 10 (NOP align, WF :5012).
+            var patch = MakeBinPatch(dir, "j",
+                ("JUMP:0x" + addr.ToString("X") + ":$r3", "tgt"));
+
+            var map = RebuildProducerCore.TraceBINPatchedMappingForProducer(rom, patch);
+
+            var b = ByKey(map, "JUMP:0x" + addr.ToString("X") + ":$r3");
+            Assert.NotNull(b);
+            Assert.Equal(10u, b.length);
+            Assert.Equal(Address.DataTypeEnum.JUMPTOHACK, b.type);
+        }
+
+        [Fact]
+        public void TraceJump_UnsafeAddress_IsSkipped()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            // 0x100 < 0x200 => isSafetyOffset false => WF :4973 continue.
+            var patch = MakeBinPatch(dir, "j", ("JUMP:0x100:$NONE", "lab"));
+
+            var map = RebuildProducerCore.TraceBINPatchedMappingForProducer(rom, patch);
+
+            Assert.Empty(map);
+        }
+
+        // ====================================================================
+        // BIN-family arm — fixed-addr (WF :5097-5110) + $FREEAREA GREP (WF :5072-5096)
+        // ====================================================================
+
+        [Fact]
+        public void TraceBin_FixedAddr_KeyTypes_AreMapped()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            byte[] payload = { 0x01, 0x02, 0x03, 0x04 };
+            File.WriteAllBytes(Path.Combine(dir, "p.bin"), payload);
+
+            uint aMix = 0x800000;   // BIN  -> MIX
+            uint aPtr = 0x800100;   // BINP -> POINTER
+            uint aAsm = 0x800200;   // BINAP-> POINTER_ASM
+            uint aBin = 0x800300;   // BINF -> BIN
+            var patch = MakeBinPatch(dir, "b",
+                ("BIN:0x" + aMix.ToString("X"), "p.bin"),
+                ("BINP:0x" + aPtr.ToString("X"), "p.bin"),
+                ("BINAP:0x" + aAsm.ToString("X"), "p.bin"),
+                ("BINF:0x" + aBin.ToString("X"), "p.bin"));
+
+            var map = RebuildProducerCore.TraceBINPatchedMappingForProducer(rom, patch);
+
+            var mix = ByKey(map, "BIN:0x" + aMix.ToString("X"));
+            Assert.NotNull(mix);
+            Assert.Equal(aMix, mix.addr);
+            Assert.Equal(4u, mix.length);
+            Assert.Equal(Address.DataTypeEnum.MIX, mix.type);
+            // Fixed-addr: bin == the FILE bytes (WF :5108), not the (zeroed) ROM.
+            Assert.Equal(payload, mix.bin);
+
+            Assert.Equal(Address.DataTypeEnum.POINTER, ByKey(map, "BINP:0x" + aPtr.ToString("X")).type);
+            Assert.Equal(Address.DataTypeEnum.POINTER_ASM, ByKey(map, "BINAP:0x" + aAsm.ToString("X")).type);
+            Assert.Equal(Address.DataTypeEnum.BIN, ByKey(map, "BINF:0x" + aBin.ToString("X")).type);
+        }
+
+        [Fact]
+        public void TraceBin_FreeArea_GrepLocates_AndAdvancesBaseline()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            // A unique pattern PLANTED above the borderline (the GREP search floor).
+            byte[] pat = { 0xCA, 0xFE, 0xBA, 0xBE, 0x12, 0x34, 0x56, 0x78 };
+            uint border = rom.RomInfo.compress_image_borderline_address;
+            uint planted = ((border + 0x10000) + 3) & ~3u;   // 4-aligned, above border.
+            Write(rom, planted, pat);
+            File.WriteAllBytes(Path.Combine(dir, "fa.dmp"), pat);
+
+            var patch = MakeBinPatch(dir, "fa", ("BIN:$FREEAREA", "fa.dmp"));
+
+            var map = RebuildProducerCore.TraceBINPatchedMappingForProducer(rom, patch);
+
+            var b = ByKey(map, "BIN:$FREEAREA");
+            Assert.NotNull(b);
+            Assert.Equal(planted, b.addr);                  // GREP found the planted copy.
+            Assert.Equal((uint)pat.Length, b.length);
+            Assert.Equal(Address.DataTypeEnum.MIX, b.type);  // not JUMP-matched => stays MIX.
+            Assert.Equal(pat, b.bin);                        // read from ROM at the match.
+        }
+
+        [Fact]
+        public void TraceBin_FreeArea_AlsoJumpMatched_BecomesAsm()
+        {
+            // The ContinueBattleBGM real-patch shape: a JUMP and a $FREEAREA BIN that name
+            // the SAME file => the $FREEAREA BIN is typed ASM (WF :5090-5093).
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            byte[] pat = { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0x00, 0x11 };
+            uint border = rom.RomInfo.compress_image_borderline_address;
+            uint planted = ((border + 0x20000) + 3) & ~3u;
+            Write(rom, planted, pat);
+            File.WriteAllBytes(Path.Combine(dir, "code.dmp"), pat);
+
+            uint jumpAddr = 0x800000;
+            Write(rom, jumpAddr, 0x99, 0x88, 0x77, 0x66);
+            var patch = MakeBinPatch(dir, "cbgm",
+                ("BIN:$FREEAREA", "code.dmp"),
+                ("JUMP:0x" + jumpAddr.ToString("X") + ":$r3", "code.dmp"));
+
+            var map = RebuildProducerCore.TraceBINPatchedMappingForProducer(rom, patch);
+
+            var fa = ByKey(map, "BIN:$FREEAREA");
+            Assert.NotNull(fa);
+            Assert.Equal(planted, fa.addr);
+            Assert.Equal(Address.DataTypeEnum.ASM, fa.type);   // JUMP-matched => ASM.
+        }
+
+        [Fact]
+        public void TraceBin_FreeArea_NoMatch_IsSkipped()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            // A pattern that is NOT planted anywhere => GREP miss => WF :5082 continue.
+            byte[] pat = { 0x7F, 0x6E, 0x5D, 0x4C, 0x3B, 0x2A, 0x19, 0x08 };
+            File.WriteAllBytes(Path.Combine(dir, "miss.dmp"), pat);
+            var patch = MakeBinPatch(dir, "m", ("BIN:$FREEAREA", "miss.dmp"));
+
+            var map = RebuildProducerCore.TraceBINPatchedMappingForProducer(rom, patch);
+
+            Assert.Empty(map);
+        }
+
+        // ====================================================================
+        // SLIDE arm (WF :5129-5170) + CLEAR arm (WF :5171-5210)
+        // ====================================================================
+
+        [Fact]
+        public void TraceSlide_LiteralRange_IsMixWithRomBytes()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            uint addr = 0x800000;
+            uint dest = 0x800008;
+            Write(rom, addr, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80);
+            var patch = MakeBinPatch(dir, "s",
+                ("SLIDE:0x" + addr.ToString("X") + ":x", "0x" + dest.ToString("X")));
+
+            var map = RebuildProducerCore.TraceBINPatchedMappingForProducer(rom, patch);
+
+            var b = ByKey(map, "SLIDE:0x" + addr.ToString("X") + ":x");
+            Assert.NotNull(b);
+            Assert.Equal(addr, b.addr);
+            Assert.Equal(dest - addr, b.length);            // WF :5156
+            Assert.Equal(Address.DataTypeEnum.MIX, b.type);
+            Assert.Equal(new byte[] { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80 }, b.bin);
+        }
+
+        [Fact]
+        public void TraceSlide_TooFewFields_IsSkipped()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            // sp.Length < 3 => WF :5141 continue. "SLIDE:0x800000" has only 2 fields.
+            var patch = MakeBinPatch(dir, "s", ("SLIDE:0x800000", "0x800008"));
+
+            var map = RebuildProducerCore.TraceBINPatchedMappingForProducer(rom, patch);
+
+            Assert.Empty(map);
+        }
+
+        [Fact]
+        public void TraceClear_LiteralAddrLength_IsUnusedBin()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            uint addr = 0x800000;
+            uint len = 0x10;
+            Write(rom, addr, 0xAB, 0xCD);
+            var patch = MakeBinPatch(dir, "c",
+                ("CLEAR:0x" + addr.ToString("X") + ":0x" + len.ToString("X"), "x"));
+
+            var map = RebuildProducerCore.TraceBINPatchedMappingForProducer(rom, patch);
+
+            var b = ByKey(map, "CLEAR:0x" + addr.ToString("X") + ":0x" + len.ToString("X"));
+            Assert.NotNull(b);
+            Assert.Equal(addr, b.addr);
+            Assert.Equal(len, b.length);                    // WF :5196 (sp[2]).
+            Assert.Equal(Address.DataTypeEnum.UNUSEDBIN, b.type);
+            Assert.Equal(0xAB, b.bin[0]);
+        }
+
+        // ====================================================================
+        // WF trace ORDER (WF :4960 JUMP, then :5039 BIN, then :5129 SLIDE, then :5171 CLEAR)
+        // ====================================================================
+
+        [Fact]
+        public void Trace_EmitsInWfArmOrder_JumpBinSlideClear()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            byte[] pat = { 0x01, 0x02, 0x03, 0x04 };
+            File.WriteAllBytes(Path.Combine(dir, "p.bin"), pat);
+
+            uint jumpAddr = 0x801000;
+            uint binAddr = 0x802000;
+            uint slideAddr = 0x803000;
+            uint slideDest = 0x803010;
+            uint clearAddr = 0x804000;
+            var patch = MakeBinPatch(dir, "ord",
+                ("CLEAR:0x" + clearAddr.ToString("X") + ":0x8", "x"),
+                ("SLIDE:0x" + slideAddr.ToString("X") + ":y", "0x" + slideDest.ToString("X")),
+                ("BIN:0x" + binAddr.ToString("X"), "p.bin"),
+                ("JUMP:0x" + jumpAddr.ToString("X") + ":$NONE", "lab"));
+
+            var map = RebuildProducerCore.TraceBINPatchedMappingForProducer(rom, patch);
+
+            Assert.Equal(4, map.Count);
+            Assert.StartsWith("JUMP:", map[0].key);
+            Assert.StartsWith("BIN:", map[1].key);
+            Assert.StartsWith("SLIDE:", map[2].key);
+            Assert.StartsWith("CLEAR:", map[3].key);
+        }
+
+        // ====================================================================
+        // EmitPatchBIN per-type dispatch (WF :6317-6422)
+        // ====================================================================
+
+        [Fact]
+        public void EmitPatchBIN_AsmMapFalse_EmitsNothing()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            uint addr = 0x800000;
+            File.WriteAllBytes(Path.Combine(dir, "p.bin"), new byte[] { 1, 2, 3, 4 });
+            var patch = MakeBinPatch(dir, "n",
+                ("ASMMAP", "false"),
+                ("BIN:0x" + addr.ToString("X"), "p.bin"));
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchBIN(rom, list, patch, isPointerOnly: false);
+
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void EmitPatchBIN_PointerType_EmitsPointerPlusExtra()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            // A BINP at a slot whose 4 bytes point to a safe ROM target so AddPointer keeps it.
+            uint slot = 0x800000;
+            uint target = 0x08800100; // GBA pointer to offset 0x800100 (safe).
+            Write(rom, slot, (byte)(target & 0xFF), (byte)((target >> 8) & 0xFF),
+                (byte)((target >> 16) & 0xFF), (byte)((target >> 24) & 0xFF));
+            File.WriteAllBytes(Path.Combine(dir, "p.bin"), new byte[] { 0, 0, 0, 0 });
+            var patch = MakeBinPatch(dir, "p", ("BINP:0x" + slot.ToString("X"), "p.bin"));
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchBIN(rom, list, patch, isPointerOnly: false);
+
+            // WF :6338-6352 — AddPointer (POINTER) + AddAddress (POINTER) at the slot.
+            Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.POINTER && a.Pointer == slot);
+            Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.POINTER && a.Addr == slot && a.Pointer == U.NOT_FOUND);
+        }
+
+        [Fact]
+        public void EmitPatchBIN_BinType_EmitsBinWithLength()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            uint addr = 0x800000;
+            byte[] payload = { 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
+            File.WriteAllBytes(Path.Combine(dir, "p.bin"), payload);
+            var patch = MakeBinPatch(dir, "f", ("BINF:0x" + addr.ToString("X"), "p.bin"));
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchBIN(rom, list, patch, isPointerOnly: false);
+
+            // WF :6368-6377 — AddAddress length m.length typed BIN.
+            Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.BIN
+                && a.Addr == addr && a.Length == (uint)payload.Length);
+        }
+
+        [Fact]
+        public void EmitPatchBIN_JumpToHackType_EmitsBinLengthMinus4()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            uint addr = 0x800000;   // aligned => length 8 => BIN length 8-4 = 4 (WF :6392).
+            var patch = MakeBinPatch(dir, "j",
+                ("JUMP:0x" + addr.ToString("X") + ":$r3", "tgt"));
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchBIN(rom, list, patch, isPointerOnly: false);
+
+            Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.BIN
+                && a.Addr == addr && a.Length == 4u);
+        }
+
+        [Fact]
+        public void EmitPatchBIN_UnusedBinType_EmitsUnusedBin()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            uint addr = 0x800000;
+            uint len = 0x20;
+            var patch = MakeBinPatch(dir, "c",
+                ("CLEAR:0x" + addr.ToString("X") + ":0x" + len.ToString("X"), "x"));
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchBIN(rom, list, patch, isPointerOnly: false);
+
+            // WF :6378-6387 — AddAddress length m.length typed UNUSEDBIN.
+            Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.UNUSEDBIN
+                && a.Addr == addr && a.Length == len);
+        }
+
+        [Fact]
+        public void EmitPatchBIN_PointerOnly_EmitsSingleLengthZero()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            uint addr = 0x800000;
+            byte[] payload = { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66 };
+            File.WriteAllBytes(Path.Combine(dir, "p.bin"), payload);
+            var patch = MakeBinPatch(dir, "f", ("BINF:0x" + addr.ToString("X"), "p.bin"));
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchBIN(rom, list, patch, isPointerOnly: true);
+
+            // WF :6408-6416 — pointer-only collapses to ONE length-0 AddAddress typed m.type.
+            var emitted = list.Where(a => a.Addr == addr).ToList();
+            Assert.Single(emitted);
+            Assert.Equal(0u, emitted[0].Length);
+            Assert.Equal(Address.DataTypeEnum.BIN, emitted[0].DataType);
+        }
+
+        [Fact]
+        public void EmitPatchBIN_DefaultMixType_EmitsLengthZero()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            // A fixed-addr BIN: => MIX => default arm => AddAddress length 0 typed MIX (WF :6398-6406).
+            uint addr = 0x800000;
+            File.WriteAllBytes(Path.Combine(dir, "p.bin"), new byte[] { 1, 2, 3, 4 });
+            var patch = MakeBinPatch(dir, "m", ("BIN:0x" + addr.ToString("X"), "p.bin"));
+
+            var list = new List<Address>();
+            RebuildProducerCore.EmitPatchBIN(rom, list, patch, isPointerOnly: false);
+
+            Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.MIX
+                && a.Addr == addr && a.Length == 0u);
+        }
+
+        // ====================================================================
+        // ReadMod(file) overload — byte-faithful to WF :4309
+        // ====================================================================
+
+        [Fact]
+        public void ReadMod_File_MissingFile_ReturnsEmpty()
+        {
+            var rom = MakeRom();
+            string[] sp = { "BIN", "$FREEAREA" };
+            bool[] mask;
+            byte[] b = EventAssemblerUninstallCore.ReadMod(sp, "no-such-file.bin", out mask, rom);
+            Assert.Empty(b);
+            Assert.Empty(mask);
+        }
+
+        [Fact]
+        public void ReadMod_File_ReadsBytes_AndBuildsMask()
+        {
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            byte[] payload = { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80 };
+            string f = Path.Combine(dir, "m.bin");
+            File.WriteAllBytes(f, payload);
+
+            string[] sp = { "BIN", "$FREEAREA" }; // sp[2] absent => chaddr 0 => no LDR mask.
+            bool[] mask;
+            byte[] b = EventAssemblerUninstallCore.ReadMod(sp, f, out mask, rom);
+
+            Assert.Equal(payload, b);
+            Assert.Equal(payload.Length, mask.Length);
+            Assert.All(mask, m => Assert.False(m));   // no LDR pointers in this payload at base 0.
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchBINTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchBINTests.cs
@@ -335,6 +335,42 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void TraceBin_FreeArea_TwoBlocks_AdvanceBaseline_MatchSecondCopy()
+        {
+            // Rigorous lastMatchAddr-advance coverage (Copilot #1331): TWO $FREEAREA blocks
+            // share the SAME byte pattern, PLANTED at two distinct ROM addresses (the install
+            // order). If the trace did NOT advance lastMatchAddr to addr+length after the first
+            // hit, the SECOND GREP would re-match the FIRST (earliest) copy — corruption. With
+            // the advance, the second entry matches the SECOND copy.
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            byte[] pat = { 0xC0, 0xDE, 0xF0, 0x0D, 0xBA, 0xAD, 0xF0, 0x0D };
+            uint border = rom.RomInfo.compress_image_borderline_address;
+            uint first = ((border + 0x40000) + 3) & ~3u;
+            uint second = first + 0x10000;      // a SECOND, later copy of the same pattern.
+            Write(rom, first, pat);
+            Write(rom, second, pat);
+            File.WriteAllBytes(Path.Combine(dir, "a.dmp"), pat);
+            File.WriteAllBytes(Path.Combine(dir, "b.dmp"), pat);
+
+            // Two distinct dict keys, both with sp[1]=="$FREEAREA" (sp[2] chaddr 0/1 yields no
+            // LDR mask for this pointer-free pattern, so the masks are identical all-false).
+            var patch = MakeBinPatch(dir, "two",
+                ("BIN:$FREEAREA:0", "a.dmp"),
+                ("BIN:$FREEAREA:1", "b.dmp"));
+
+            var map = RebuildProducerCore.TraceBINPatchedMappingForProducer(rom, patch);
+
+            var a = ByKey(map, "BIN:$FREEAREA:0");
+            var b = ByKey(map, "BIN:$FREEAREA:1");
+            Assert.NotNull(a);
+            Assert.NotNull(b);
+            Assert.Equal(first, a.addr);        // first hit at the first planted copy.
+            Assert.Equal(second, b.addr);       // advanced => second hit at the SECOND copy.
+            Assert.NotEqual(a.addr, b.addr);    // would be EQUAL if the baseline did not advance.
+        }
+
+        [Fact]
         public void TraceBin_FreeArea_NoMatch_IsSkipped()
         {
             var rom = MakeRom();
@@ -381,6 +417,37 @@ namespace FEBuilderGBA.Core.Tests
             string dir = NewTempDir();
             // sp.Length < 3 => WF :5141 continue. "SLIDE:0x800000" has only 2 fields.
             var patch = MakeBinPatch(dir, "s", ("SLIDE:0x800000", "0x800008"));
+
+            var map = RebuildProducerCore.TraceBINPatchedMappingForProducer(rom, patch);
+
+            Assert.Empty(map);
+        }
+
+        [Fact]
+        public void TraceSlide_DestBelowOrEqualAddr_IsSkipped_NoUnderflow()
+        {
+            // Producer fault-safety (Copilot #1331): a malformed SLIDE with dest <= addr would
+            // underflow `dest_addr - addr` to a huge uint => OOM on new bool[length]. We skip it.
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            uint addr = 0x800010;
+            uint dest = 0x800000;   // dest < addr => skip (no allocation).
+            var patch = MakeBinPatch(dir, "s",
+                ("SLIDE:0x" + addr.ToString("X") + ":x", "0x" + dest.ToString("X")));
+
+            var map = RebuildProducerCore.TraceBINPatchedMappingForProducer(rom, patch);
+
+            Assert.Empty(map);
+        }
+
+        [Fact]
+        public void TraceClear_MissingLengthField_IsSkipped_NoCrash()
+        {
+            // Producer fault-safety (Copilot #1331): WF guards sp.Length<2 but reads sp[2]
+            // (length). A malformed `CLEAR:0x800000` (no length) would throw. We skip it.
+            var rom = MakeRom();
+            string dir = NewTempDir();
+            var patch = MakeBinPatch(dir, "c", ("CLEAR:0x800000", "x"));
 
             var map = RebuildProducerCore.TraceBINPatchedMappingForProducer(rom, patch);
 

--- a/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
+++ b/FEBuilderGBA.Core/EventAssemblerUninstallCore.cs
@@ -760,6 +760,42 @@ namespace FEBuilderGBA
             return b;
         }
 
+        // Port of PatchForm.ReadMod(string[], string filename, out bool[]) — the
+        // FILE-reading overload (WinForms PatchForm.cs:4309). Reads a BIN file from disk
+        // and builds the GREP mask off the per-key address-move arg (sp[2]) instead of the
+        // instant-EA hardcoded base 0. Exposed for the rebuild-producer BIN arm (#1261
+        // s2pf-15) — byte-identical to WF: missing file -> empty bin + empty mask; else
+        // read all bytes and mask via MakeMaskAddress with chaddr = atoi0x(at(sp,2)).
+        /// <summary>
+        /// Read the installed BIN file from <paramref name="filename"/> and build its GREP
+        /// mask off the per-key address-move arg <c>sp[2]</c> (WinForms
+        /// <c>PatchForm.ReadMod(string[], string, out bool[])</c>, :4309). When the file is
+        /// absent this returns an empty byte[] + empty mask (verbatim WF). ROM-explicit
+        /// (forwards <paramref name="rom"/> to <see cref="MakeMaskAddress"/>). Exposed for
+        /// the rebuild-producer TYPE=BIN arm, s2pf-15.
+        /// </summary>
+        internal static byte[] ReadMod(string[] sp, string filename, out bool[] isSkip, ROM rom)
+        {
+            if (string.IsNullOrEmpty(filename) || !System.IO.File.Exists(filename))
+            {//WF :4311-4315 — missing file: empty bin + empty mask.
+                isSkip = new bool[0];
+                return new byte[0];
+            }
+            // WF :4317 — read the whole installed BIN file. Byte-faithful to WF: WF guards
+            // ONLY File.Exists, then calls File.ReadAllBytes directly (NO try/catch). We do
+            // NOT swallow a read failure into empty output — that would widen WF behaviour
+            // and silently hide a corrupt/locked installed BIN file as a zero-length mapping
+            // (Copilot plan-review #1261 s2pf-15). A genuine read error propagates exactly as
+            // it does in WF.
+            byte[] b = System.IO.File.ReadAllBytes(filename);
+
+            // WF :4320 — chaddr = U.atoi0x(U.at(sp, 2)); the address the block was relocated
+            // to, so MakeMaskAddress can mask the LDR-pointer words that depend on it.
+            uint chaddr = U.atoi0x(U.at(sp, 2));
+            isSkip = MakeMaskAddress(b, chaddr, rom);
+            return b;
+        }
+
         //lynによってインポートされるelfのマスクパターンを作ります。
         // Port of PatchForm.MakeLynMaskPattern.
         /// <summary>

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -13890,6 +13890,19 @@ namespace FEBuilderGBA
                     continue;
                 }
 
+                // Producer fault-safety (Copilot #1331 review): WF computes the unsigned
+                // `dest_addr - addr` with NO ordering guard (WF :5156). A valid SLIDE always
+                // has dest_addr > addr (the moved region is [addr, dest_addr)), but a
+                // malformed/typoed key with dest_addr <= addr would underflow to a huge
+                // uint32 here and then allocate `new bool[length]` / read getBinaryData with
+                // an unbounded size (OOM). Skip such an entry — this changes NOTHING for any
+                // real patch (dest_addr > addr) and keeps the producer from aborting the whole
+                // rebuild on bad input, consistent with the honest-omission convention.
+                if (dest_addr <= addr)
+                {
+                    continue;
+                }
+
                 uint length = dest_addr - addr;       // WF :5156
                 byte[] bin = U.isSafetyOffset(addr, rom) ? rom.getBinaryData(addr, length) : new byte[0];
                 bool[] mask = new bool[length];
@@ -13918,8 +13931,15 @@ namespace FEBuilderGBA
                 {//WF :5179
                     continue;
                 }
-                if (sp.Length < 2)
-                {//WF :5183
+                // WF :5183 guards `sp.Length < 2` but then unconditionally reads sp[2] for the
+                // length (WF :5196) — a latent IndexOutOfRangeException on a malformed key like
+                // `CLEAR:0x800000` (no length field). A real CLEAR key is always
+                // `CLEAR:<addr>:<length>` (3 fields), so this never triggers in practice; the
+                // producer tightens the guard to `< 3` (Copilot #1331 review) so bad input is
+                // skipped, NOT crashed — faithful to WF for every valid key, fault-safe for the
+                // rest. (s2pf-16 may surface such a malformed entry as untraceable.)
+                if (sp.Length < 3)
+                {
                     continue;
                 }
 

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -13589,6 +13589,514 @@ namespace FEBuilderGBA
         }
 
         // ====================================================================
+        // PatchForm producer — option-B epic (#1261, sub-slice s2pf-15 of 17).
+        //
+        // The TYPE=BIN producer ARM (NOT yet wired into the orchestrator — the
+        // MakePatchStructDataListCore EA|BIN case stays a stub until s2pf-17; this is the
+        // tested API that slice will call). Faithful Core port of WinForms:
+        //   - TraceBINPatchedMappingForProducer  <- PatchForm.TraceBINPatchedMapping        (:4951)
+        //   - EmitPatchBIN                        <- PatchForm.MakePatchStructDataListForBIN (:6317)
+        //
+        // The BIN trace is a FROM-SCRATCH port (no Core BIN trace existed — the s2pf-13/14
+        // EA walker is EA-specific). It RE-LOCATES where the already-installed BIN bytes
+        // landed in the SAVED ROM (deterministic — never allocates), so the rebuild free
+        // list can keep those ranges live. Three WF arms, in WF order:
+        //   1. JUMP (:4960-5037): per-case lengths VERBATIM — a wrong JUMP length relocates
+        //      the wrong bytes = corruption. $NONE=4 (POINTER_ASM if "+1" or addr<=borderline,
+        //      else POINTER); $B/$BL=2 (BIN); generated-jump = 10 when addr%4!=0 (4-byte NOP
+        //      align) else 8 (JUMPTOHACK). addr via PatchMacroAddressResolverCore.Resolve.
+        //   2. BIN-family (:5039-5127): $FREEAREA -> ReadMod(file) mask + GrepPatternMatch from
+        //      lastMatchAddr (sequential re-locate; advance lastMatchAddr=addr+length; if the
+        //      same file also matched a JUMP, type becomes ASM). Else fixed-addr via the
+        //      resolver, bin=mod, mask=isSkip. BINP->POINTER, BINAP->POINTER_ASM, BINF->BIN,
+        //      BIN->MIX.
+        //   3. SLIDE (:5129-5170) + CLEAR/UNUSEDBIN (:5171-5210): literal addr/length reads.
+        //
+        // NO Program.ROM / CoreState.ROM read in the trace — `rom` is threaded explicitly.
+        // (EmitPatchBIN's Address.Add* sinks DO read CoreState.ROM for the
+        // isSafetyOffset/isSafetyPointer length bound — the SAME coupling as the s2pf-14 EA
+        // arm; the orchestrator/tests set CoreState.ROM to the same ROM.)
+        //
+        // ADDRESS-RESOLVER faithfulness ($FREEAREA / file-relative branch — prereq port 2):
+        //   * In the BIN-family loop $FREEAREA is intercepted INLINE (GrepPatternMatch) BEFORE
+        //     the resolver call (WF :5072), so the resolver's $FREEAREA branch is never on the
+        //     BIN-family path.
+        //   * The JUMP-loop + fixed-addr resolver calls use WF appendSize=0 (WF :4972,:5100).
+        //     With appendSize=0, WF convertBinAddressString returns 0 for $FREEAREA (WF
+        //     :3027-3030) — and isSafetyOffset(0) is false, so WF SKIPS it. Core
+        //     PatchMacroAddressResolverCore.Resolve returns NOT_FOUND for $FREEAREA, which ALSO
+        //     fails isSafetyOffset/addr!=NOT_FOUND -> SKIP. The two are behaviourally identical
+        //     for the BIN trace. File-relative resolution (plain hex / $GREP / $P32 / $TEXTID)
+        //     is already faithfully covered by Resolve. No new resolver state is needed.
+        //
+        // DEFERRED to s2pf-16 (the WF trailers at :5213-5218, driven by extra patch params):
+        //   TraceEditPatch (EDIT_PATCH), AppendMenuPatch (MENU),
+        //   AppendNewTargetSelectionStruct (NEW_TARGET_SELECTION_STRUCT). They emit nothing for
+        //   a bare {TYPE=BIN, BIN/JUMP/SLIDE/CLEAR=...} patch, but a real patch can carry those
+        //   params, so they are left as a marked TODO rather than guessed.
+        // ====================================================================
+
+        /// <summary>
+        /// Faithful Core port of WinForms <c>PatchForm.TraceBINPatchedMapping</c>
+        /// (FEBuilderGBA/PatchForm.cs:4951) for the rebuild PRODUCER. Re-locates where a
+        /// TYPE=BIN patch's already-installed bytes landed in <paramref name="rom"/> and
+        /// returns the reconstructed <see cref="EventAssemblerUninstallCore.BinMapping"/>s,
+        /// in WF order: all <c>JUMP:</c> keys, then all <c>BIN/BINP/BINAP/BINF</c> keys,
+        /// then <c>SLIDE</c>, then <c>CLEAR</c>.
+        ///
+        /// <para><b>JUMP</b> (WF :4960-5037): each <c>JUMP:&lt;addr&gt;[:$NONE|$B|$BL][:+1]</c>
+        /// resolves its address via <see cref="PatchMacroAddressResolverCore.Resolve"/>
+        /// (WF appendSize 0, startOffset 0x100) and gets a VERBATIM length/type: <c>$NONE</c>
+        /// = 4 bytes typed <c>POINTER_ASM</c> when the trailing arg is <c>+1</c> or the addr
+        /// is at/below the compress borderline (code), else <c>POINTER</c>; <c>$B</c>/<c>$BL</c>
+        /// = 2 bytes typed <c>BIN</c>; any other third arg = a generated jump (<c>JUMPTOHACK</c>)
+        /// of 10 bytes when <c>addr%4!=0</c> (a NOP is inserted for 4-byte alignment) else 8.
+        /// The matched <c>JUMP:</c> value (the target file) is recorded so a later
+        /// <c>$FREEAREA</c> BIN of the same file is typed <c>ASM</c> (WF :5090-5093).</para>
+        ///
+        /// <para><b>BIN-family</b> (WF :5039-5127): <c>$FREEAREA</c> blocks are re-located by
+        /// reading the installed BIN file (<see cref="EventAssemblerUninstallCore.ReadMod(string[], string, out bool[], ROM)"/>),
+        /// building the LDR-pointer mask, and <see cref="U.GrepPatternMatch"/>-ing it from
+        /// <c>lastMatchAddr</c> (seeded at the compress borderline, advanced to <c>addr+length</c>
+        /// after each hit so free-area blocks are matched in install order — a wrong baseline
+        /// re-matches an EARLIER ROM address = corruption). A miss <c>continue</c>s (WF :5082).
+        /// Fixed-addr blocks resolve via the resolver and carry the file's own bytes + mask.</para>
+        ///
+        /// <para><b>SLIDE</b> (WF :5129-5170) and <b>CLEAR</b> (WF :5171-5210, typed
+        /// <c>UNUSEDBIN</c>) are literal <c>addr</c>/<c>length</c> ROM reads (every computed
+        /// read is EOF-guarded via <see cref="U.isSafetyOffset(uint, ROM)"/>).</para>
+        ///
+        /// <para>The WF trailers <c>TraceEditPatch</c> / <c>AppendMenuPatch</c> /
+        /// <c>AppendNewTargetSelectionStruct</c> (:5213-5218) are DEFERRED to s2pf-16.</para>
+        /// </summary>
+        /// <param name="rom">ROM to trace against — passed explicitly (NEVER CoreState.ROM / Program.ROM).</param>
+        /// <param name="patch">The TYPE=BIN patch (its <c>PatchFileName</c> dir resolves <c>$FREEAREA</c>/fixed BIN files).</param>
+        /// <returns>The reconstructed bin-mappings, in WF trace order.</returns>
+        public static List<EventAssemblerUninstallCore.BinMapping> TraceBINPatchedMappingForProducer(
+            ROM rom, PatchInstallCore.PatchSt patch)
+        {
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (patch == null) throw new ArgumentNullException(nameof(patch));
+            if (patch.Param == null) throw new ArgumentNullException(nameof(patch) + ".Param");
+            // RomInfo.compress_image_borderline_address seeds lastMatchAddr (WF :4957) and
+            // gates the $NONE POINTER_ASM/POINTER split (WF :4989). Guard so a bad direct
+            // caller gets a clean ArgumentException, not an NRE.
+            if (rom.RomInfo == null) throw new ArgumentNullException(nameof(rom) + ".RomInfo");
+
+            var binMappings = new List<EventAssemblerUninstallCore.BinMapping>();
+            // WF :4957 — free-area blocks are GREP-matched sequentially from the compress
+            // borderline; advanced to addr+length after each $FREEAREA hit.
+            uint lastMatchAddr = rom.RomInfo.compress_image_borderline_address;
+
+            // WF :4959 — file (JUMP value) -> matched, so a later $FREEAREA BIN of the same
+            // file is typed ASM (WF :5090).
+            var jumpMatch = new Dictionary<string, bool>();
+
+            // WF :4971 / :5075 / :5099 — Path.GetDirectoryName(patch.PatchFileName).
+            // Normalize null -> "" so Path.Combine never receives a null base.
+            string basedir = System.IO.Path.GetDirectoryName(patch.PatchFileName) ?? "";
+
+            // ---- ARM 1: JUMP (WF :4960-5037) ----
+            foreach (var pair in patch.Param)
+            {
+                string[] sp = pair.Key.Split(':');
+                string key = sp[0];
+                string value = pair.Value;
+
+                if (key != "JUMP")
+                {//WF :4966
+                    continue;
+                }
+
+                // WF :4972 — convertBinAddressString(sp[1], appendSize:0, start_offset:0x100, basedir).
+                uint addr = PatchMacroAddressResolverCore.Resolve(rom, U.at(sp, 1), basedir, 0x100);
+                if (!U.isSafetyOffset(addr, rom))
+                {//WF :4973-4976
+                    continue;
+                }
+
+                uint length;
+                Address.DataTypeEnum datatype;
+                string sp2 = U.at(sp, 2);
+                if (sp2 == "$NONE")
+                {//WF :4981 — not a jump instruction, just a 4-byte pointer slot.
+                    length = 4;
+                    string sp3 = U.at(sp, 3);
+                    if (sp3 == "+1")
+                    {//WF :4985 — +1 => definitely code.
+                        datatype = Address.DataTypeEnum.POINTER_ASM;
+                    }
+                    else if (addr <= rom.RomInfo.compress_image_borderline_address)
+                    {//WF :4989 — below the borderline => code.
+                        datatype = Address.DataTypeEnum.POINTER_ASM;
+                    }
+                    else
+                    {//WF :4994
+                        datatype = Address.DataTypeEnum.POINTER;
+                    }
+                }
+                else if (sp2 == "$B")
+                {//WF :4998 — B jump, 2 bytes.
+                    length = 2;
+                    datatype = Address.DataTypeEnum.BIN;
+                }
+                else if (sp2 == "$BL")
+                {//WF :5003 — BL jump, 2 bytes.
+                    length = 2;
+                    datatype = Address.DataTypeEnum.BIN;
+                }
+                else
+                {//WF :5009 — a generated jump code.
+                    if (addr % 4 != 0)
+                    {//WF :5010 — 4-byte alignment not met: a NOP is added.
+                        length = 10;
+                    }
+                    else
+                    {//WF :5016
+                        length = 8;
+                    }
+                    datatype = Address.DataTypeEnum.JUMPTOHACK;
+                }
+
+                if (addr != U.NOT_FOUND)
+                {//WF :5021 — (isSafetyOffset already ensured addr != NOT_FOUND; kept verbatim).
+                    var b = new EventAssemblerUninstallCore.BinMapping
+                    {
+                        key = pair.Key,
+                        filename = "$JUMP:" + pair.Value,
+                        addr = addr,
+                        length = length,
+                        type = datatype,
+                        // EOF-guard the binary read (addr passed isSafetyOffset; clamp the
+                        // tail defensively in case addr+length nears EOF).
+                        bin = U.isSafetyOffset(addr, rom) ? rom.getBinaryData(addr, length) : new byte[0],
+                        mask = new bool[length], // WF :5030 — all false.
+                    };
+                    binMappings.Add(b);
+                    jumpMatch[pair.Value] = true; // WF :5034
+                }
+            }
+
+            // ---- ARM 2: BIN-family (WF :5039-5127) ----
+            foreach (var pair in patch.Param)
+            {
+                string[] sp = pair.Key.Split(':');
+                string key = sp[0];
+                string value = pair.Value;
+                byte[] bin;
+                bool[] mask;
+
+                if (!(key == "BIN" || key == "BINP" || key == "BINAP" || key == "BINF"))
+                {//WF :5047
+                    continue;
+                }
+                if (sp.Length < 2)
+                {//WF :5051
+                    continue;
+                }
+
+                uint addr;
+                uint length;
+                Address.DataTypeEnum datatype = Address.DataTypeEnum.MIX;
+                if (key == "BINP")
+                {//WF :5059
+                    datatype = Address.DataTypeEnum.POINTER;
+                }
+                else if (key == "BINAP")
+                {//WF :5063
+                    datatype = Address.DataTypeEnum.POINTER_ASM;
+                }
+                else if (key == "BINF")
+                {//WF :5067
+                    datatype = Address.DataTypeEnum.BIN;
+                }
+
+                if (sp[1] == "$FREEAREA")
+                {//WF :5072 — free-area install: re-build + GREP-locate the installed bytes.
+                    string filename = System.IO.Path.Combine(basedir, value);
+                    bool[] isSkip;
+                    byte[] mod = EventAssemblerUninstallCore.ReadMod(sp, filename, out isSkip, rom);
+
+                    // WF :5081 — pointers vary, so mask them and pattern-match from lastMatchAddr.
+                    addr = U.GrepPatternMatch(rom.Data, mod, isSkip, lastMatchAddr, 0, 4);
+                    if (addr == U.NOT_FOUND)
+                    {//WF :5082-5085
+                        continue;
+                    }
+                    length = (uint)mod.Length;
+                    // WF :5087 — read the installed bytes from the ROM at the matched addr.
+                    bin = U.isSafetyOffset(addr, rom) ? rom.getBinaryData(addr, length) : new byte[0];
+                    mask = isSkip;
+
+                    if (jumpMatch.ContainsKey(value))
+                    {//WF :5090 — the same file also matched a JUMP => it's ASM code.
+                        datatype = Address.DataTypeEnum.ASM;
+                    }
+                    // WF :5095 — free-area blocks are placed sequentially; advance the baseline.
+                    lastMatchAddr = addr + length;
+                }
+                else
+                {//WF :5097 — the position is fixed/known.
+                    addr = PatchMacroAddressResolverCore.Resolve(rom, U.at(sp, 1), basedir, 0x100);
+
+                    string filename = System.IO.Path.Combine(basedir, value);
+                    bool[] isSkip;
+                    byte[] mod = EventAssemblerUninstallCore.ReadMod(sp, filename, out isSkip, rom);
+                    length = (uint)mod.Length;
+
+                    bin = mod;   // WF :5108
+                    mask = isSkip;
+                }
+
+                if (addr != U.NOT_FOUND)
+                {//WF :5113
+                    var b = new EventAssemblerUninstallCore.BinMapping
+                    {
+                        key = pair.Key,
+                        filename = pair.Value,
+                        addr = addr,
+                        length = length,
+                        type = datatype,
+                        bin = bin,
+                        mask = mask,
+                    };
+                    binMappings.Add(b);
+                }
+            }
+
+            // ---- ARM 3a: SLIDE (WF :5129-5170) ----
+            foreach (var pair in patch.Param)
+            {
+                string[] sp = pair.Key.Split(':');
+                string key = sp[0];
+                string value = pair.Value;
+
+                if (key != "SLIDE")
+                {//WF :5137
+                    continue;
+                }
+                if (sp.Length < 3)
+                {//WF :5141
+                    continue;
+                }
+
+                Address.DataTypeEnum datatype = Address.DataTypeEnum.MIX;
+
+                uint addr = U.atoi0x(sp[1]);          // WF :5148
+                uint dest_addr = U.atoi0x(value);     // WF :5149
+                if (!U.isSafetyOffset(addr, rom)
+                    || !U.isSafetyOffset(dest_addr, rom))
+                {//WF :5150-5154
+                    continue;
+                }
+
+                uint length = dest_addr - addr;       // WF :5156
+                byte[] bin = U.isSafetyOffset(addr, rom) ? rom.getBinaryData(addr, length) : new byte[0];
+                bool[] mask = new bool[length];
+
+                var b = new EventAssemblerUninstallCore.BinMapping
+                {
+                    key = pair.Key,
+                    filename = pair.Value,
+                    addr = addr,
+                    length = length,
+                    type = datatype,
+                    bin = bin,
+                    mask = mask,
+                };
+                binMappings.Add(b);
+            }
+
+            // ---- ARM 3b: CLEAR / UNUSEDBIN (WF :5171-5210) ----
+            foreach (var pair in patch.Param)
+            {
+                string[] sp = pair.Key.Split(':');
+                string key = sp[0];
+                string value = pair.Value;
+
+                if (key != "CLEAR")
+                {//WF :5179
+                    continue;
+                }
+                if (sp.Length < 2)
+                {//WF :5183
+                    continue;
+                }
+
+                Address.DataTypeEnum datatype = Address.DataTypeEnum.UNUSEDBIN;
+
+                uint addr = U.atoi0x(sp[1]);          // WF :5190
+                if (!U.isSafetyOffset(addr, rom))
+                {//WF :5191-5194
+                    continue;
+                }
+
+                uint length = U.atoi0x(sp[2]);        // WF :5196
+                byte[] bin = U.isSafetyOffset(addr, rom) ? rom.getBinaryData(addr, length) : new byte[0];
+                bool[] mask = new bool[length];
+
+                var b = new EventAssemblerUninstallCore.BinMapping
+                {
+                    key = pair.Key,
+                    filename = pair.Value,
+                    addr = addr,
+                    length = length,
+                    type = datatype,
+                    bin = bin,
+                    mask = mask,
+                };
+                binMappings.Add(b);
+            }
+
+            // s2pf-16: WF :5213-5218 trailers (TraceEditPatch / AppendMenuPatch /
+            // AppendNewTargetSelectionStruct) are DEFERRED — they act on extra patch params
+            // (EDIT_PATCH / MENU / NEW_TARGET_SELECTION_STRUCT) and emit nothing for a bare
+            // {TYPE=BIN, BIN/JUMP/SLIDE/CLEAR=...} patch. Left as a marked TODO, NOT guessed.
+
+            return binMappings;
+        }
+
+        /// <summary>
+        /// Faithful Core port of WinForms <c>PatchForm.MakePatchStructDataListForBIN</c>
+        /// (FEBuilderGBA/PatchForm.cs:6317), the TYPE=BIN producer arm. <b>NOT yet wired into
+        /// the orchestrator</b> — the <see cref="MakePatchStructDataListCore"/> EA|BIN case
+        /// stays a stub until s2pf-17; this is the tested API that slice will call.
+        ///
+        /// <para>Early-returns when <c>ASMMAP</c> is false (WF :6319-6323 — the patch opts out
+        /// of the ASM map). Ports the <c>SYMBOL=</c> side-channel inline via
+        /// <see cref="ProcessPatchSymbolByList"/> (WF :6324), traces the patch via
+        /// <see cref="TraceBINPatchedMappingForProducer"/> (WF :6327), and emits one
+        /// <see cref="Address"/> per <see cref="EventAssemblerUninstallCore.BinMapping"/> by
+        /// its <c>type</c> (verbatim WF :6328-6422):</para>
+        /// <list type="bullet">
+        ///   <item><c>POINTER</c> -&gt; <see cref="Address.AddPointer"/> (POINTER) + an extra
+        ///   <see cref="Address.AddAddress"/> POINTER at the same slot, WF :6338-6352.</item>
+        ///   <item><c>POINTER_ASM</c> -&gt; <see cref="Address.AddPointerASM"/> (PATCH_ASM) + an
+        ///   extra <see cref="Address.AddAddress"/> POINTER_ASM at the same slot, WF :6353-6367.</item>
+        ///   <item><c>BIN</c> -&gt; <see cref="Address.AddAddress"/> length <c>m.length</c> typed BIN, WF :6368-6377.</item>
+        ///   <item><c>UNUSEDBIN</c> -&gt; <see cref="Address.AddAddress"/> length <c>m.length</c> typed UNUSEDBIN, WF :6378-6387.</item>
+        ///   <item><c>JUMPTOHACK</c> -&gt; <see cref="Address.AddAddress"/> length <c>m.length−4</c> typed BIN, WF :6388-6397.</item>
+        ///   <item>else -&gt; <see cref="Address.AddAddress"/> length 0 typed by the mapping's own type, WF :6398-6406.</item>
+        /// </list>
+        /// <para>When <paramref name="isPointerOnly"/> the whole per-type branch collapses to a
+        /// single length-0 <see cref="Address.AddAddress"/> typed by the mapping's type (WF
+        /// :6408-6416). Each non-empty mapping filename additionally drives
+        /// <see cref="SymbolUtil.ProcessSymbolByList(System.Collections.Generic.List{Address}, string, string, uint)"/>
+        /// (WF :6418-6421). The per-mapping <c>U.isSafetyOffset</c> guard skips only that
+        /// mapping — verbatim WF :6330.</para>
+        ///
+        /// <para>The trailing WF helpers <c>TraceEditPatch</c> / <c>AppendMenuPatch</c> /
+        /// <c>AppendNewTargetSelectionStruct</c> live inside <c>TraceBINPatchedMapping</c>
+        /// (:5213-5218), DEFERRED to s2pf-16.</para>
+        /// </summary>
+        /// <param name="rom">ROM to trace against — passed explicitly (NEVER CoreState.ROM / Program.ROM).</param>
+        /// <param name="list">The accumulating struct/pointer list (appended to).</param>
+        /// <param name="patch">The TYPE=BIN patch whose <c>BIN/JUMP/SLIDE/CLEAR</c>/<c>SYMBOL=</c>/<c>ASMMAP</c> params drive emission.</param>
+        /// <param name="isPointerOnly">WF <c>isPointerOnly</c> — when true every mapping emits a single length-0 Address.</param>
+        public static void EmitPatchBIN(ROM rom, List<Address> list, PatchInstallCore.PatchSt patch, bool isPointerOnly)
+        {
+            // Public-helper guards (consistent with EmitPatchEA / EmitPatchAddr): throw a clear
+            // ArgumentNullException rather than an unhelpful NRE.
+            if (rom == null) throw new ArgumentNullException(nameof(rom));
+            if (list == null) throw new ArgumentNullException(nameof(list));
+            if (patch == null) throw new ArgumentNullException(nameof(patch));
+            if (patch.Param == null) throw new ArgumentNullException(nameof(patch) + ".Param");
+
+            // WF :6319-6323 — ASMMAP=false opts the patch OUT of the ASM map; emit nothing.
+            string use_asmmap = U.at(patch.Param, "ASMMAP", "true");
+            if (U.stringbool(use_asmmap) == false)
+            {
+                return;
+            }
+
+            // WF :6324 — ProcessSymbolByList(list, patch): the SYMBOL= side-channel.
+            ProcessPatchSymbolByList(list, patch);
+
+            // WF :6326 — string basedir = Path.GetDirectoryName(patch.PatchFileName).
+            string basedir = System.IO.Path.GetDirectoryName(patch.PatchFileName) ?? "";
+
+            // WF :6327 — TracePatchedMapping(patch) dispatches to TraceBINPatchedMapping for
+            // TYPE=BIN. We call the producer trace directly (the orchestrator only routes BIN
+            // patches here).
+            List<EventAssemblerUninstallCore.BinMapping> map =
+                TraceBINPatchedMappingForProducer(rom, patch);
+
+            foreach (EventAssemblerUninstallCore.BinMapping m in map)
+            {
+                if (!U.isSafetyOffset(m.addr, rom))
+                {//WF :6330 — skip only this mapping.
+                    continue;
+                }
+
+                if (isPointerOnly == false)
+                {//WF :6335
+                    if (m.type == Address.DataTypeEnum.POINTER)
+                    {//WF :6338-6352
+                        Address.AddPointer(list,
+                            m.addr, 0,
+                            patch.Name + "@" + m.filename + "@BIN",
+                            Address.DataTypeEnum.POINTER);
+                        Address.AddAddress(list,
+                            m.addr, 0, U.NOT_FOUND,
+                            "Pointer_" + patch.Name + "@" + m.filename + "@BIN",
+                            Address.DataTypeEnum.POINTER);
+                    }
+                    else if (m.type == Address.DataTypeEnum.POINTER_ASM)
+                    {//WF :6353-6367
+                        Address.AddPointerASM(list,
+                            m.addr, 0,
+                            "ASM" + patch.Name + "@" + m.filename + "@BIN",
+                            Address.DataTypeEnum.PATCH_ASM);
+                        Address.AddAddress(list,
+                            m.addr, 0, U.NOT_FOUND,
+                            "Pointer_" + patch.Name + "@" + m.filename + "@BIN",
+                            Address.DataTypeEnum.POINTER_ASM);
+                    }
+                    else if (m.type == Address.DataTypeEnum.BIN)
+                    {//WF :6368-6377
+                        Address.AddAddress(list,
+                            m.addr, m.length, U.NOT_FOUND,
+                            "Fixed " + patch.Name + "@" + m.filename + "@BIN",
+                            Address.DataTypeEnum.BIN);
+                    }
+                    else if (m.type == Address.DataTypeEnum.UNUSEDBIN)
+                    {//WF :6378-6387
+                        Address.AddAddress(list,
+                            m.addr, m.length, U.NOT_FOUND,
+                            "Fixed " + patch.Name + "@" + m.filename + "@UNUSEDBIN",
+                            Address.DataTypeEnum.UNUSEDBIN);
+                    }
+                    else if (m.type == Address.DataTypeEnum.JUMPTOHACK)
+                    {//WF :6388-6397 — the trailing 4 bytes are the jump target slot, not code.
+                        Address.AddAddress(list,
+                            m.addr, m.length - 4, U.NOT_FOUND,
+                            "Jump " + patch.Name + "@" + m.filename + "@BIN",
+                            Address.DataTypeEnum.BIN);
+                    }
+                    else
+                    {//WF :6398-6406
+                        Address.AddAddress(list,
+                            m.addr, 0, U.NOT_FOUND,
+                            patch.Name + "@" + m.filename + "@BIN",
+                            m.type);
+                    }
+                }
+                else
+                {//WF :6408-6416 — pointer-only: a single length-0 Address typed by m.type.
+                    Address.AddAddress(list,
+                        m.addr, 0, U.NOT_FOUND,
+                        patch.Name + "@" + m.filename + "@BIN",
+                        m.type);
+                }
+
+                if (m.filename != "")
+                {//WF :6418-6421 — per-block ELF/sym.txt symbol channel (already in Core).
+                    SymbolUtil.ProcessSymbolByList(list, basedir, m.filename, m.addr);
+                }
+            }
+        }
+
+        // ====================================================================
         // PatchForm producer — option-B epic (#1261, sub-slice s2pf-4 of 11).
         //
         // The TYPE=IMAGE terminal arm. Faithful Core port of WinForms

--- a/FEBuilderGBA.Tests/Unit/RebuildProducerBINArmWFParityTests.cs
+++ b/FEBuilderGBA.Tests/Unit/RebuildProducerBINArmWFParityTests.cs
@@ -1,0 +1,291 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Tests.Unit
+{
+    /// <summary>
+    /// BYTE-PARITY validation for the #1261 slice s2pf-15 TYPE=BIN producer arm
+    /// (<see cref="RebuildProducerCore.EmitPatchBIN"/> = WF
+    /// <c>PatchForm.MakePatchStructDataListForBIN</c>, PatchForm.cs:6317).
+    ///
+    /// <para><b>Why a SYNTHETIC installed-BIN scenario.</b> A freshly-loaded VANILLA FE8U
+    /// has ZERO installed TYPE=BIN patches (the sibling EA-arm parity test documents the
+    /// same for EA; both EA and BIN install counts are 0 on vanilla), so the real ROM cannot
+    /// exercise the BIN arm. To get an "installed BIN patch" deterministically we PLANT the
+    /// patch bytes into a synthetic FE8 ROM at known addresses (a JUMP target, a fixed-addr
+    /// BIN block, a $FREEAREA pattern above the compress borderline, and a CLEAR region),
+    /// author the matching <c>.bin</c>/<c>.dmp</c> files + a <c>{TYPE=BIN, ...}</c> patch,
+    /// and run BOTH producers against that exact ROM:</para>
+    /// <list type="bullet">
+    ///   <item>WF: <c>PatchForm.MakePatchStructDataListForBIN(list, isPointerOnly, patch)</c>
+    ///   (private static — reached via reflection; it reads <c>Program.ROM</c>, which we set
+    ///   to the synthetic ROM).</item>
+    ///   <item>Core: <see cref="RebuildProducerCore.EmitPatchBIN"/> on the same ROM.</item>
+    /// </list>
+    /// <para>The two emitted lists are asserted EQUAL on the load-bearing fields
+    /// (Addr/Length/Pointer/DataType) — including the JUMPTOHACK (length−4), the fixed-addr
+    /// BIN, the GREP-located $FREEAREA, and the UNUSEDBIN/CLEAR entries. Info/name is cosmetic
+    /// and not compared.</para>
+    ///
+    /// <para>This test lives in <c>FEBuilderGBA.Tests</c> (net9.0-windows) because it calls
+    /// the WinForms <c>PatchForm</c>, which does not exist in the net9.0 Core assembly. It
+    /// SKIPS (early-return = Pass) if the WF reflective hooks are unavailable, so it never
+    /// breaks CI on a layout change. It mutates global <c>Program.ROM</c>/<c>CoreState.ROM</c>,
+    /// so it is in the <c>SharedState</c> collection.</para>
+    /// </summary>
+    [Collection("SharedState")]
+    public class RebuildProducerBINArmWFParityTests
+    {
+        // 16 MiB synthetic FE8 ROM, BE8E01 — RomInfo-bearing so both producers' compress
+        // borderline seed + $NONE split work. Sets Program.ROM (reflection) AND CoreState.ROM.
+        static ROM MakeFe8RomAndInstall()
+        {
+            var data = new byte[0x1000000];
+            byte[] code = System.Text.Encoding.ASCII.GetBytes("BE8E01");
+            Array.Copy(code, 0, data, 0xAC, code.Length);
+
+            var rom = new ROM();
+            bool ok = rom.LoadLow("synthetic-FE8.gba", data, "BE8E01");
+            if (!ok) return null;
+            CoreState.ROM = rom;
+            return SetProgramRom(rom) ? rom : null;
+        }
+
+        // Program.ROM has a private setter — set it via reflection for this headless WF test.
+        static bool SetProgramRom(ROM rom)
+        {
+            try
+            {
+                PropertyInfo p = typeof(Program).GetProperty(
+                    "ROM", BindingFlags.Public | BindingFlags.Static);
+                if (p == null) return false;
+                p.SetValue(null, rom, BindingFlags.NonPublic | BindingFlags.Instance, null, null, null);
+                return ReferenceEquals(Program.ROM, rom);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        static PatchForm.PatchSt MakeWfPatch(string dir, string name,
+            params (string key, string value)[] kv)
+        {
+            var p = new PatchForm.PatchSt
+            {
+                Name = name,
+                PatchFileName = Path.Combine(dir, "PATCH_" + name + ".txt"),
+                Param = new Dictionary<string, string>(),
+            };
+            p.Param["TYPE"] = "BIN";
+            foreach (var (k, v) in kv) p.Param[k] = v;
+            return p;
+        }
+
+        static PatchInstallCore.PatchSt MakeCorePatch(string dir, string name,
+            params (string key, string value)[] kv)
+        {
+            var p = new PatchInstallCore.PatchSt
+            {
+                Name = name,
+                PatchFileName = Path.Combine(dir, "PATCH_" + name + ".txt"),
+                Param = new Dictionary<string, string>(),
+            };
+            p.Param["TYPE"] = "BIN";
+            foreach (var (k, v) in kv) p.Param[k] = v;
+            return p;
+        }
+
+        // Call the private static WF PatchForm.MakePatchStructDataListForBIN via reflection.
+        // Returns null if the method is not found (→ test skips).
+        static List<Address> CallWfMakePatchStructDataListForBIN(List<Address> list, bool isPointerOnly, PatchForm.PatchSt patch)
+        {
+            MethodInfo m = typeof(PatchForm).GetMethod(
+                "MakePatchStructDataListForBIN",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            if (m == null) return null;
+            m.Invoke(null, new object[] { list, isPointerOnly, patch });
+            return list;
+        }
+
+        static void Write(ROM rom, uint addr, params byte[] bytes)
+        {
+            for (int i = 0; i < bytes.Length; i++) rom.write_u8(addr + (uint)i, bytes[i]);
+        }
+
+        readonly struct Key : IEquatable<Key>
+        {
+            public readonly uint Addr;
+            public readonly uint Length;
+            public readonly uint Pointer;
+            public readonly Address.DataTypeEnum Type;
+            Key(uint a, uint l, uint p, Address.DataTypeEnum t) { Addr = a; Length = l; Pointer = p; Type = t; }
+            public static Key Of(Address a) => new Key(a.Addr, a.Length, a.Pointer, a.DataType);
+            public bool Equals(Key o) => Addr == o.Addr && Length == o.Length && Pointer == o.Pointer && Type == o.Type;
+            public override bool Equals(object o) => o is Key k && Equals(k);
+            public override int GetHashCode() => HashCode.Combine(Addr, Length, Pointer, (int)Type);
+        }
+
+        static string Dump(IEnumerable<Key> keys)
+        {
+            return string.Join("\n", keys.Take(30).Select(k =>
+                $"  Addr=0x{k.Addr:X} Len=0x{k.Length:X} Ptr=0x{k.Pointer:X} Type={k.Type}"));
+        }
+
+        [Fact]
+        public void CoreEmitPatchBIN_MatchesWinForms_OnInstalledBinRom_JumpBinFreeAreaClear()
+        {
+            ROM savedCore = CoreState.ROM;
+            ROM savedProg = Program.ROM;
+            string dir = Path.Combine(Path.GetTempPath(), "bin-wfparity-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var rom = MakeFe8RomAndInstall();
+                if (rom == null) return; // WF Program.ROM hook unavailable — SKIP (Pass)
+
+                uint border = rom.RomInfo.compress_image_borderline_address;
+
+                // ---- PLANT the "installed BIN patch" bytes at known addresses ----
+                // JUMP generated (aligned) — JUMPTOHACK, length 8 -> emitted BIN length 4.
+                uint jumpAddr = 0x801000;
+                Write(rom, jumpAddr, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80);
+
+                // Fixed-addr BIN (BINF) — typed BIN, emitted with its file length.
+                byte[] binPayload = { 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
+                uint binAddr = 0x802000;
+                Write(rom, binAddr, binPayload);
+                File.WriteAllBytes(Path.Combine(dir, "blk.bin"), binPayload);
+
+                // $FREEAREA — a unique pattern PLANTED above the borderline; GREP re-locates it.
+                byte[] faPayload = { 0xCA, 0xFE, 0xBA, 0xBE, 0x12, 0x34, 0x56, 0x78 };
+                uint faAddr = ((border + 0x30000) + 3) & ~3u;
+                Write(rom, faAddr, faPayload);
+                File.WriteAllBytes(Path.Combine(dir, "fa.dmp"), faPayload);
+
+                // CLEAR — a literal addr/length unused region -> UNUSEDBIN.
+                uint clearAddr = 0x804000;
+                uint clearLen = 0x20;
+
+                var kv = new (string, string)[]
+                {
+                    ("JUMP:0x" + jumpAddr.ToString("X") + ":$r3", "tgt"),
+                    ("BINF:0x" + binAddr.ToString("X"), "blk.bin"),
+                    ("BIN:$FREEAREA", "fa.dmp"),
+                    ("CLEAR:0x" + clearAddr.ToString("X") + ":0x" + clearLen.ToString("X"), "x"),
+                };
+
+                // ---- WF reference (private static, via reflection; reads Program.ROM) ----
+                var wf = new List<Address>();
+                var wfRet = CallWfMakePatchStructDataListForBIN(wf, false, MakeWfPatch(dir, "BINp", kv));
+                if (wfRet == null) return; // WF method not found — SKIP (Pass)
+
+                // ---- Core: EmitPatchBIN on the same ROM ----
+                var core = new List<Address>();
+                RebuildProducerCore.EmitPatchBIN(rom, core, MakeCorePatch(dir, "BINp", kv), isPointerOnly: false);
+
+                Assert.NotEmpty(wf);
+                Assert.NotEmpty(core);
+
+                var wfKeys = new HashSet<Key>(wf.Select(Key.Of));
+                var coreKeys = new HashSet<Key>(core.Select(Key.Of));
+
+                var coreExtras = core.Where(a => !wfKeys.Contains(Key.Of(a))).Select(Key.Of).Distinct().ToList();
+                var wfExtras = wf.Where(a => !coreKeys.Contains(Key.Of(a))).Select(Key.Of).Distinct().ToList();
+
+                if (coreExtras.Count > 0 || wfExtras.Count > 0)
+                {
+                    Assert.Fail(
+                        "Core EmitPatchBIN diverges from WF MakePatchStructDataListForBIN on an installed-BIN ROM.\n"
+                        + $"WF total={wf.Count}, Core total={core.Count}.\n"
+                        + $"Core-only (Core emits, WF does not) [{coreExtras.Count}]:\n{Dump(coreExtras)}\n"
+                        + $"WF-only (Core dropped) [{wfExtras.Count}]:\n{Dump(wfExtras)}");
+                }
+
+                // PROVEN: byte-identical on (Addr/Length/Pointer/DataType).
+                Assert.Empty(coreExtras);
+                Assert.Empty(wfExtras);
+
+                // Pin the load-bearing entries explicitly so a future regression that drops the
+                // same entry on BOTH sides cannot pass the set-equality vacuously.
+                // JUMPTOHACK -> BIN length 8-4 = 4 (WF :6392).
+                Assert.Contains(core, a => a.DataType == Address.DataTypeEnum.BIN && a.Addr == jumpAddr && a.Length == 4);
+                Assert.Contains(wf, a => a.DataType == Address.DataTypeEnum.BIN && a.Addr == jumpAddr && a.Length == 4);
+                // Fixed-addr BINF -> BIN length = file length.
+                Assert.Contains(core, a => a.DataType == Address.DataTypeEnum.BIN && a.Addr == binAddr && a.Length == (uint)binPayload.Length);
+                Assert.Contains(wf, a => a.DataType == Address.DataTypeEnum.BIN && a.Addr == binAddr && a.Length == (uint)binPayload.Length);
+                // $FREEAREA GREP-located (default MIX -> default arm length 0).
+                Assert.Contains(core, a => a.Addr == faAddr);
+                Assert.Contains(wf, a => a.Addr == faAddr);
+                // CLEAR -> UNUSEDBIN length.
+                Assert.Contains(core, a => a.DataType == Address.DataTypeEnum.UNUSEDBIN && a.Addr == clearAddr && a.Length == clearLen);
+                Assert.Contains(wf, a => a.DataType == Address.DataTypeEnum.UNUSEDBIN && a.Addr == clearAddr && a.Length == clearLen);
+            }
+            finally
+            {
+                CoreState.ROM = savedCore;
+                SetProgramRom(savedProg);
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+
+        // isPointerOnly=true → every mapping collapses to a single length-0 Address on BOTH
+        // producers; the key sets must still match exactly.
+        [Fact]
+        public void CoreEmitPatchBIN_MatchesWinForms_PointerOnly()
+        {
+            ROM savedCore = CoreState.ROM;
+            ROM savedProg = Program.ROM;
+            string dir = Path.Combine(Path.GetTempPath(), "bin-wfparity-po-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var rom = MakeFe8RomAndInstall();
+                if (rom == null) return;
+
+                uint binAddr = 0x802000;
+                byte[] binPayload = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
+                Write(rom, binAddr, binPayload);
+                File.WriteAllBytes(Path.Combine(dir, "blk.bin"), binPayload);
+
+                uint clearAddr = 0x804000;
+                uint clearLen = 0x20;
+
+                var kv = new (string, string)[]
+                {
+                    ("BINF:0x" + binAddr.ToString("X"), "blk.bin"),
+                    ("CLEAR:0x" + clearAddr.ToString("X") + ":0x" + clearLen.ToString("X"), "x"),
+                };
+
+                var wf = new List<Address>();
+                var wfRet = CallWfMakePatchStructDataListForBIN(wf, true, MakeWfPatch(dir, "PO", kv));
+                if (wfRet == null) return;
+
+                var core = new List<Address>();
+                RebuildProducerCore.EmitPatchBIN(rom, core, MakeCorePatch(dir, "PO", kv), isPointerOnly: true);
+
+                var wfKeys = new HashSet<Key>(wf.Select(Key.Of));
+                var coreKeys = new HashSet<Key>(core.Select(Key.Of));
+                var coreExtras = core.Where(a => !wfKeys.Contains(Key.Of(a))).Select(Key.Of).Distinct().ToList();
+                var wfExtras = wf.Where(a => !coreKeys.Contains(Key.Of(a))).Select(Key.Of).Distinct().ToList();
+
+                Assert.Empty(coreExtras);
+                Assert.Empty(wfExtras);
+                // In pointer-only mode the BINF entry is length 0 on both.
+                Assert.Contains(core, a => a.Addr == binAddr && a.Length == 0);
+                Assert.Contains(wf, a => a.Addr == binAddr && a.Length == 0);
+            }
+            finally
+            {
+                CoreState.ROM = savedCore;
+                SetProgramRom(savedProg);
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
From-scratch faithful WinForms→Core port of the **TYPE=BIN producer arm** of the option-B PatchForm Make/Apply epic — sub-slice **15/17**. Reproduces the DETERMINISTIC BIN bin-mapping trace + the BIN emit, mirroring the s2pf-14 EA arm. **Core-only, NOT wired** into the orchestrator (the EA|BIN case stays a stub until s2pf-17); the gate token `PatchForm(MakePatchStructDataList)` STAYS, keeping the live rebuild gate CLOSED.

Part of #1261. Plan: [issue comment](https://github.com/laqieer/FEBuilderGBA/issues/1261#issuecomment-4762616961) (Copilot-reviewed, accepted).

## New Core API (s2pf-17 will call these)
- **`TraceBINPatchedMappingForProducer(ROM, PatchInstallCore.PatchSt) → List<EventAssemblerUninstallCore.BinMapping>`** = WF `PatchForm.TraceBINPatchedMapping` (`PatchForm.cs:4951`), **MINUS** the MENU/EDIT_PATCH/NEW_TARGET_SELECTION trailers (`:5213-5218`, deferred to s2pf-16). Three arms, VERBATIM WF order + lengths:
  - **JUMP** (`:4960-5037`): `$NONE`=4 (`POINTER_ASM` if `+1` or addr≤borderline, else `POINTER`); `$B`/`$BL`=2 (`BIN`); generated jump = 10 when `addr%4!=0` (NOP align) else 8 (`JUMPTOHACK`). addr via `PatchMacroAddressResolverCore.Resolve`. *(Every JUMP length case unit-tested — a wrong length relocates wrong bytes = corruption.)*
  - **BIN-family** (`:5039-5127`): `$FREEAREA` → `ReadMod(file)` mask + `U.GrepPatternMatch` from `lastMatchAddr` (sequential re-locate; advance `lastMatchAddr=addr+length`; same-file JUMP match ⇒ type `ASM`); else fixed-addr via resolver. `BINP→POINTER`, `BINAP→POINTER_ASM`, `BINF→BIN`, `BIN→MIX`.
  - **SLIDE** (`:5129-5170`) + **CLEAR/UNUSEDBIN** (`:5171-5210`): literal addr/length reads (EOF-guarded).
- **`EmitPatchBIN(ROM rom, List<Address> list, PatchInstallCore.PatchSt patch, bool isPointerOnly)`** = WF `PatchForm.MakePatchStructDataListForBIN` (`PatchForm.cs:6317`): `ASMMAP=false` early-return; `SYMBOL=` side-channel; per-`m.type` dispatch (POINTER→AddPointer+extra; POINTER_ASM→AddPointerASM+extra; BIN→len `m.length`; UNUSEDBIN; JUMPTOHACK→len `m.length−4` BIN; default→len 0); pointer-only collapses to one length-0 AddAddress; per-mapping `SymbolUtil.ProcessSymbolByList`. **MENU/trailers SKIPPED** (s2pf-16 marker).

## Prereq ports inside this slice
1. **File-reading `ReadMod(string[] sp, string filename, out bool[], ROM)`** on `EventAssemblerUninstallCore` = WF `PatchForm.ReadMod` (`:4309`). `chaddr=U.atoi0x(U.at(sp,2))`, mask via the s2pf-13 `MakeMaskAddress`. **Byte-faithful**: missing file → empty bin+mask; a genuine read error **propagates** (NOT swallowed — per the Copilot plan-review fidelity guard, swallowing would hide a corrupt installed BIN as a zero-length mapping).
2. **`$FREEAREA`/file-relative resolver branch** — VERIFIED already faithful (no new state). `$FREEAREA` is intercepted INLINE (GrepPatternMatch) before the resolver; the JUMP/fixed-addr resolver calls use WF `appendSize=0` where WF returns 0 for `$FREEAREA` (`isSafetyOffset(0)` false → skip) ≡ Core `Resolve` returning NOT_FOUND → skip. Documented inline.

## Verification approach — how the installed-BIN scenario was achieved
Vanilla FE8U installs **0** TYPE=BIN patches, so the real ROM cannot exercise the arm. A **synthetic 16 MiB BE8E01 ROM** is loaded and the installed BIN bytes are **PLANTED** at known addresses (a JUMP target, a fixed-addr BIN block, a unique `$FREEAREA` pattern above the compress borderline, and a CLEAR region), with hand-authored `.bin`/`.dmp` files + a `{TYPE=BIN, ...}` `PatchSt`. **Byte-parity vs WF** (`FEBuilderGBA.Tests`, net9.0-windows): WF `MakePatchStructDataListForBIN` (private static via reflection, `Program.ROM` set to the synthetic ROM) is run vs Core `EmitPatchBIN` on the **same** installed-BIN ROM, and the two `List<Address>` are asserted **EQUAL** on `(Addr, Length, Pointer, DataType)` — JUMPTOHACK (len−4), fixed-addr BIN, GREP-located `$FREEAREA`, CLEAR/UNUSEDBIN — plus the pointer-only path. **Result: byte-identical (PASS).**

## Test plan
- [x] Core.Tests: every JUMP length case ($NONE / $NONE+1 / $NONE-at-borderline / $B / $BL / generated-aligned-8 / generated-misaligned-10 / unsafe-skip) — `RebuildProducerPatchBINTests`
- [x] Core.Tests: `$FREEAREA` GREP-locate + `lastMatchAddr` advance (single + a **two-block decoy** case that fails if the 2nd GREP restarts from the original baseline) + JUMP-match→ASM cross-arm rule + GREP-miss skip
- [x] Core.Tests: fixed-addr BIN/BINP/BINAP/BINF type mapping; SLIDE (literal range + too-few-fields skip + **dest≤addr underflow skip**); CLEAR→UNUSEDBIN (+ **missing-length-field skip, no crash**); WF arm ORDER
- [x] Core.Tests: `EmitPatchBIN` per-type dispatch (POINTER+extra, BIN-len, JUMPTOHACK len−4, UNUSEDBIN, default-MIX len 0, pointer-only single-len-0, ASMMAP=false early-return)
- [x] Core.Tests: `ReadMod(file)` overload (missing→empty; reads bytes + builds mask)
- [x] **Byte-parity vs WF** on installed-BIN ROM (`RebuildProducerBINArmWFParityTests`, net9.0-windows; skip-if-WF-hook-unavailable) — JumpBinFreeAreaClear + PointerOnly, both PASS
- [x] `dotnet test FEBuilderGBA.Core.Tests --filter RebuildProducer` → **718 passed, 0 failed** (27 new BIN tests incl. the 2 Copilot-review hardening regressions)
- [x] `EventAssemblerUninstall` filter → **14 passed, 1 skipped, 0 failed** (no s2pf-13/14 regression)
- [x] Full Core.Tests → **5196 passed, 6 skipped, 0 failed**
- [x] `dotnet build FEBuilderGBA.sln` → **0 errors**

## Scope / deferrals
- 15/17. Gate token **stays**; **not wired** into the orchestrator (s2pf-17).
- Deferred to **s2pf-16** (precise blocker): WF trailers `TraceEditPatch` / `AppendMenuPatch` / `AppendNewTargetSelectionStruct` (`:5213-5218`) — driven by `EDIT_PATCH`/`MENU`/`NEW_TARGET_SELECTION_STRUCT` extra params; emit nothing for a bare `{TYPE=BIN, ...}` patch. Left as a marked TODO, not guessed.

Core-only, no GUI change → no screenshot (non-GUI; CLI/test output is the proof).

Ref #1261

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]


