### PR TITLE
feat(core): wire PatchForm EA/BIN + open IsComplete gate (#1261 s2pf-17)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerAsmTests.cs
@@ -1322,8 +1322,14 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
-        public void AppendAllAsmStructPointers_IsNeverComplete_DeferredFormsReported()
+        public void AppendAllAsmStructPointers_IncompleteOnlyViaDisasmGate_TokenRemoved()
         {
+            // s2pf-17 (CAPSTONE): the static "PatchForm(MakePatchStructDataList)" token is REMOVED
+            // (the EA/BIN arms are wired LIVE). The ASM-path producer is therefore NO LONGER
+            // statically incomplete — its ONLY residual coverage gate is the RUNTIME
+            // EventScript(MakeEventASMMAPList) disasm check. Here CoreState.EventScript is unwired, so
+            // EventScript is re-reported and IsComplete is false; the reason is the disasm gate, NOT a
+            // static deferred form. The token, ProcsScript, OAMSP, GraphicsTool must all be absent.
             var saved = CoreState.ROM;
             try
             {
@@ -1332,14 +1338,29 @@ namespace FEBuilderGBA.Core.Tests
                 var list = new List<Address>();
                 var ldrmap = RebuildProducerCore.BuildLdrMap(fe8);
                 var res = RebuildProducerCore.AppendAllAsmStructPointers(fe8, list, ldrmap);
+                // Incomplete here ONLY because the event-script disassembler is unwired.
                 Assert.False(res.IsComplete);
-                Assert.Contains("PatchForm(MakePatchStructDataList)", res.NotYetPorted);
+                Assert.Contains("EventScript(MakeEventASMMAPList)", res.NotYetPorted);
+                // The PatchForm token is GONE (EA/BIN wired in s2pf-17).
+                Assert.DoesNotContain("PatchForm(MakePatchStructDataList)", res.NotYetPorted);
                 // OAMSPForm PORTED slice 2w, ProcsScriptForm 2x, GraphicsToolForm 2y — NOT re-reported.
                 Assert.DoesNotContain("GraphicsToolForm", res.NotYetPorted);
                 Assert.DoesNotContain("OAMSPForm", res.NotYetPorted);
                 Assert.DoesNotContain("ProcsScriptForm", res.NotYetPorted);
             }
             finally { CoreState.ROM = saved; }
+        }
+
+        [Fact]
+        public void GetAsmNotYetPortedForms_IsEmpty_AfterTokenRemoved()
+        {
+            // s2pf-17 (CAPSTONE): the STATIC ASM-path deferred list is now EMPTY. Every ASM-path form is
+            // ported; EventScript(MakeEventASMMAPList) is gated only at RUNTIME (re-reported by
+            // AppendAllAsmStructPointers when the disassembler is unwired), never a static entry. So the
+            // static GetAsmNotYetPortedForms() — which AsmProducerResult.IsComplete is keyed on for a
+            // disasm-wired run — must be empty.
+            string[] notYet = RebuildProducerCore.GetAsmNotYetPortedForms();
+            Assert.Empty(notYet);
         }
 
         [Fact]
@@ -1379,10 +1400,12 @@ namespace FEBuilderGBA.Core.Tests
         // ====================================================================
 
         [Fact]
-        public void GetAsmNotYetPortedForms_ListsDeferredForms_NoDuplicates()
+        public void GetAsmNotYetPortedForms_AllFormsPorted_NoDuplicates()
         {
             string[] notYet = RebuildProducerCore.GetAsmNotYetPortedForms();
-            Assert.Contains("PatchForm(MakePatchStructDataList)", notYet);
+            // s2pf-17 (CAPSTONE): the PatchForm token is REMOVED (EA/BIN arms wired LIVE), so the static
+            // ASM-path deferred list is now EMPTY.
+            Assert.DoesNotContain("PatchForm(MakePatchStructDataList)", notYet);
             // The PORTED forms are NOT in the static deferred list.
             Assert.DoesNotContain("GraphicsToolForm", notYet); // PORTED in slice 2y.
             Assert.DoesNotContain("OAMSPForm", notYet); // PORTED in slice 2w.
@@ -1391,6 +1414,7 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("EventFunctionPointerForm", notYet);
             Assert.DoesNotContain("Command85PointerForm", notYet);
             Assert.DoesNotContain("MapMiniMapTerrainImageForm", notYet);
+            Assert.Empty(notYet); // every ASM-path form ported; list empty.
 
             string[] raw = RebuildProducerCore.GetAsmNotYetPortedFormsRaw();
             var dups = raw.GroupBy(x => x).Where(g => g.Count() > 1).Select(g => g.Key).ToArray();

--- a/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerCoreTests.cs
@@ -442,27 +442,30 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
-        public void GetNotYetPortedForms_IsNonEmpty_AndTracksDeferredCoverage()
+        public void GetNotYetPortedForms_IsEmpty_AllDataPathFormsPorted()
         {
+            // s2pf-17 (CAPSTONE): the STATIC data-path NotYetPorted list is now EMPTY. Every form
+            // U.MakeAllStructPointersList emits is ported to the data-path producer; the last entries
+            // (the ASM-path cross-refs PatchForm(MakePatchStructDataList)/ProcsScriptForm/EventScript/
+            // EventFunction/Command85/MapMiniMap) were never emitted by the data-path producer and are
+            // covered by the ASM-path producer, so they are removed here. The ONLY residual coverage gate
+            // is the RUNTIME EventCondForm disasm re-report (not a static entry).
             string[] notYet = RebuildProducerCore.GetNotYetPortedForms();
-            Assert.NotEmpty(notYet);
-            // The heavy editors that need extraction first must be tracked, not dropped.
-            // (TextForm/TextCharCodeForm are ported in slice 2m; OtherTextForm in slice 2q — see
-            //  GetNotYetPortedForms_DropsSlice2qConfigForms_KeepsDeferredSiblings.)
+            Assert.Empty(notYet);
+            // The heavy editors that needed extraction are all ported now (spot-checks, kept as a ledger).
             Assert.DoesNotContain("OtherTextForm", notYet);
-            // EventCondForm is PORTED in slice 2u (EmitEventCond + the Core ScanScript block-emitter) —
-            // see GetNotYetPortedForms_DropsSlice2uForm_KeepsDeferredSiblings.
             Assert.DoesNotContain("EventCondForm", notYet);
-            // (SongTableForm is ported in slice 2r; AIScriptForm + ImageBattleAnimeForm in slice 2s —
-            //  see GetNotYetPortedForms_DropsSlice2sForms_KeepsDeferredSiblings.)
             Assert.DoesNotContain("AIScriptForm", notYet);
             Assert.DoesNotContain("ImageBattleAnimeForm", notYet);
-            // ItemForm is PORTED in slice 2ad (EmitItem + the new Core PatchDetection detectors that
-            // size its StatBooster / effectiveness sub-blocks) — see
-            // GetNotYetPortedForms_DropsSlice2adForms_KeepsDeferredSiblings. (ClassForm WAS deferred for
-            // its MoveCost sub-blocks but is ported in slice 2c.)
             Assert.DoesNotContain("ItemForm", notYet);
             Assert.DoesNotContain("ClassForm", notYet);
+            // The removed ASM-path cross-refs are gone from the data-path list.
+            Assert.DoesNotContain("PatchForm(MakePatchStructDataList)", notYet);
+            Assert.DoesNotContain("ProcsScriptForm", notYet);
+            Assert.DoesNotContain("MapMiniMapTerrainImageForm", notYet);
+            Assert.DoesNotContain("EventScript(MakeEventASMMAPList)", notYet);
+            Assert.DoesNotContain("EventFunctionPointerForm", notYet);
+            Assert.DoesNotContain("Command85PointerForm", notYet);
         }
 
         [Fact]
@@ -508,44 +511,59 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
-        public void MakeAllStructPointers_Cancelled_ReportsIncompleteAndCancelled()
+        public void MakeAllStructPointers_Cancelled_ReportsCancelled_EmptyList()
         {
             var rom = CreateTestRom();
             using var cts = new CancellationTokenSource();
             cts.Cancel();
             RebuildProducerCore.ProducerResult result = RebuildProducerCore.MakeAllStructPointers(rom, null, cts.Token);
-            // Pre-cancel returns before the descriptor walk (no RomInfo needed) and still
-            // surfaces the coverage state.
+            // Pre-cancel returns before the descriptor walk (no RomInfo needed). As of s2pf-17 the STATIC
+            // data-path NotYetPorted list is EMPTY (every form ported), so a pre-cancel result is
+            // "complete-by-static-coverage but CANCELLED" — the CANCEL flag (not IsComplete) is what makes
+            // MakeWithProducer refuse to feed the partial list to Make (it checks Cancelled FIRST).
             Assert.True(result.Cancelled);
-            Assert.False(result.IsComplete);   // NotYetPorted is non-empty regardless of cancel
-            Assert.NotEmpty(result.NotYetPorted);
-            Assert.Empty(result.List);
+            Assert.True(result.IsComplete);     // static NotYetPorted is now empty
+            Assert.Empty(result.NotYetPorted);
+            Assert.Empty(result.List);          // pre-cancel returns before any emission
         }
 
         [Fact]
-        public void MakeAllStructPointers_FE8U_ReportsIncomplete_WhileFormsRemain()
+        public void MakeAllStructPointers_FE8U_DisasmUnwired_IncompleteOnlyViaEventCondGate()
         {
             string romPath = FindTestRom();
             if (romPath == null) return; // skip when no ROM available (env-only)
 
             var savedRom = CoreState.ROM;
+            var savedEs = CoreState.EventScript;
             try
             {
                 var rom = new ROM();
                 if (!rom.Load(romPath, out string _)) return; // skip
                 CoreState.ROM = rom;
+                CoreState.EventScript = null; // disasm unwired -> EventCondForm re-reported at runtime
 
                 RebuildProducerCore.ProducerResult result = RebuildProducerCore.MakeAllStructPointers(rom);
-                // COMPLETENESS-SAFETY: while any form is un-ported the result must report incomplete
-                // so a future wiring slice refuses to feed a partial list to a real defragment.
+                // s2pf-17 (CAPSTONE): the STATIC data-path list is empty, so the ONLY reason this run is
+                // incomplete is the RUNTIME disasm re-report — EventCondForm (always) plus, on FE8, the four
+                // ScanScript-family forms. A disasm-wired run (every real rebuild) would have an empty
+                // NotYetPorted and IsComplete true. Every remaining entry MUST be a disasm-gated form (no
+                // stale static form).
                 Assert.False(result.IsComplete);
                 Assert.NotEmpty(result.NotYetPorted);
+                Assert.Contains("EventCondForm", result.NotYetPorted);
+                string[] disasmGated =
+                {
+                    "EventCondForm", "MonsterWMapProbabilityForm", "EventBattleTalkForm",
+                    "WorldMapEventPointerForm", "EventHaikuForm",
+                };
+                Assert.All(result.NotYetPorted, f => Assert.Contains(f, disasmGated));
                 Assert.False(result.Cancelled);
                 Assert.NotEmpty(result.List);
             }
             finally
             {
                 CoreState.ROM = savedRom;
+                CoreState.EventScript = savedEs;
             }
         }
 
@@ -3061,7 +3079,10 @@ namespace FEBuilderGBA.Core.Tests
                 {
                     RebuildProducerCore.ProducerResult res = RebuildProducerCore.MakeAllStructPointers(fe8);
                     Assert.NotNull(res);
-                    Assert.False(res.IsComplete); // image/anime/etc. forms still deferred
+                    // s2pf-17: the STATIC data-path list is empty; incomplete here ONLY because the
+                    // event-script disassembler is unwired on this synthetic ROM (EventCondForm re-reported).
+                    Assert.False(res.IsComplete);
+                    Assert.Contains("EventCondForm", res.NotYetPorted);
                 });
                 Assert.Null(ex);
             }
@@ -6522,9 +6543,11 @@ namespace FEBuilderGBA.Core.Tests
 
             // (AIScriptForm ported in slice 2s — see GetNotYetPortedForms_DropsSlice2sForms.)
             Assert.DoesNotContain("AIScriptForm", notYet);
-            // ProcsScriptForm itself STAYS — it is an ASM-path form (MakePatchStructDataList), out of
-            // scope for this data-path producer; only its CalcLengthAndCheck length helper is reused.
-            Assert.Contains("ProcsScriptForm", notYet);
+            // ProcsScriptForm is an ASM-path form (MakePatchStructDataList path), out of scope for this
+            // data-path producer; only its CalcLengthAndCheck length helper is reused HERE. s2pf-17
+            // (CAPSTONE) REMOVED it from the data-path array (it is covered by the ASM-path producer
+            // EmitProcsScript, slice 2x), so it is no longer in this data-path NotYetPorted list.
+            Assert.DoesNotContain("ProcsScriptForm", notYet);
             // (ItemForm ported in slice 2ad — StatBooster size via the new Core PatchDetection detectors.)
             Assert.DoesNotContain("ItemForm", notYet);
 
@@ -9591,9 +9614,11 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("ImagePortraitForm", notYet);
             Assert.DoesNotContain("ImagePortraitFE6Form", notYet);
 
-            // The ASM-path MapMiniMapTerrainImageForm (AppendAllASMStructPointersList, NOT this producer)
-            // STAYS deferred.
-            Assert.Contains("MapMiniMapTerrainImageForm", notYet);
+            // MapMiniMapTerrainImageForm is an ASM-path form (AppendAllASMStructPointersList, NOT this
+            // data-path producer). s2pf-17 (CAPSTONE) REMOVED it from the data-path array — it is covered
+            // by the ASM-path producer (EmitMapMiniMapTerrain, slice 2v), so it is no longer in this
+            // data-path NotYetPorted list.
+            Assert.DoesNotContain("MapMiniMapTerrainImageForm", notYet);
 
             // no-duplicates invariant still holds.
             string[] raw = RebuildProducerCore.GetNotYetPortedFormsRaw();
@@ -9682,10 +9707,13 @@ namespace FEBuilderGBA.Core.Tests
                 ROM vanilla = BuildWireVanilla();
                 var structList = BuildWireStructList();
 
-                // Data path complete, ASM path still defers PatchForm — the real current-master shape.
+                // Data path complete, ASM path SYNTHETICALLY incomplete. As of s2pf-17 the live ASM path
+                // is complete (the PatchForm token is removed), so this uses a generic placeholder form to
+                // drive the incomplete-ASM throw branch — the gate must still refuse ANY non-empty
+                // NotYetPorted, regardless of which form name it carries.
                 var data = new RebuildProducerCore.ProducerResult(structList, new string[0], cancelled: false);
                 var asm = new RebuildProducerCore.AsmProducerResult(
-                    new[] { "PatchForm(MakePatchStructDataList)" }, cancelled: false);
+                    new[] { "SomeDeferredAsmPathForm" }, cancelled: false);
 
                 using (var tmp = new WireTempDir())
                 {
@@ -9695,7 +9723,7 @@ namespace FEBuilderGBA.Core.Tests
                             data, asm, modified, vanilla, WIRE_REBUILD_ADDR, manifestPath));
 
                     // The message NAMES the deferred form so the caller can tell the user exactly what's pending.
-                    Assert.Contains("PatchForm(MakePatchStructDataList)", ex.Message);
+                    Assert.Contains("SomeDeferredAsmPathForm", ex.Message);
                     // GUARD: Make was NOT invoked — no manifest written.
                     Assert.False(System.IO.File.Exists(manifestPath),
                         "incomplete producer must NOT drive Make (no manifest)");
@@ -9793,9 +9821,9 @@ namespace FEBuilderGBA.Core.Tests
                 ROM vanilla = BuildWireVanilla();
                 var structList = BuildWireStructList();
 
-                // SYNTHETIC complete results (empty NotYetPorted) — the live producers cannot
-                // yield these while PatchForm stays deferred, so the seam is the only way to prove
-                // the Make-delegation path actually runs.
+                // Complete results (empty NotYetPorted). As of s2pf-17 the live producers CAN yield these
+                // (every form ported; the data path's only residual gate is the runtime EventCond disasm
+                // check), but the seam keeps the Make-delegation proof independent of a live ROM.
                 var data = new RebuildProducerCore.ProducerResult(structList, new string[0], cancelled: false);
                 var asm = new RebuildProducerCore.AsmProducerResult(new string[0], cancelled: false);
 
@@ -9821,22 +9849,31 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
-        public void MakeWithProducer_PublicEntry_RealProducer_RefusesAndNamesPending_NoManifest()
+        public void MakeWithProducer_PublicEntry_RealProducer_DisasmUnwired_RefusesViaDisasmGate_NotToken()
         {
-            // Public-entry / current-master SMOKE: the real producer path (env-gated on a ROM)
-            // must REFUSE (the gate is closed while forms stay deferred) and name the pending forms,
-            // and must create no output. Skips cleanly when no ROM is present (CI / most worktrees).
+            // s2pf-17 (CAPSTONE) SMOKE on a real ROM: the PatchForm token is REMOVED, so the gate no longer
+            // refuses for that reason. Here CoreState.BaseDirectory is NOT set (the s2pf-12 backstop's patch
+            // scan finds nothing -> backstop passes) and CoreState.EventScript is NOT wired (the event-
+            // script disassembler is unavailable). The producers therefore re-report their disasm-gated
+            // forms at RUNTIME (data: EventCondForm; asm: EventScript(MakeEventASMMAPList)) and the
+            // IsComplete gate STILL refuses — but it names the DISASM forms, NOT the removed PatchForm
+            // token. (The gate-OPEN/PROCEED case is proven by the synthetic
+            // MakeWithProducer_BothComplete_DelegatesToMake_WritesManifest above; the empirical real-FE8U
+            // proceed-vs-over-refuse result is documented in the FEBuilderGBA.Tests WF-parity harness.)
+            // Skips cleanly when no ROM is present (CI / most worktrees).
             string romPath = FindTestRom();
             if (romPath == null) return; // skip when no ROM available (env-only)
 
             var savedRom = CoreState.ROM;
             var savedEnc = CoreState.SystemTextEncoder;
+            var savedEs = CoreState.EventScript;
             try
             {
                 var rom = new ROM();
                 if (!rom.Load(romPath, out string _)) return; // skip
                 CoreState.ROM = rom;
                 CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom);
+                CoreState.EventScript = null; // disasm unwired -> EventCond/EventScript re-reported
 
                 ROM vanilla = BuildWireVanilla();
 
@@ -9848,16 +9885,22 @@ namespace FEBuilderGBA.Core.Tests
                             rom, vanilla, WIRE_REBUILD_ADDR, manifestPath,
                             isUseOtherGraphics: true, isUseOAMSP: false));
 
-                    // The ASM half always keeps PatchForm deferred, so the gate always names it.
-                    Assert.Contains("PatchForm(MakePatchStructDataList)", ex.Message);
+                    // The removed PatchForm token must NOT appear; the refusal is the disasm-gate reason.
+                    Assert.DoesNotContain("PatchForm(MakePatchStructDataList)", ex.Message);
+                    Assert.True(
+                        ex.Message.Contains("EventScript(MakeEventASMMAPList)")
+                        || ex.Message.Contains("EventCondForm")
+                        || ex.Message.Contains("EA/BIN"), // (if BaseDirectory happens to resolve a patch tree)
+                        "expected the disasm-gate (or s2pf-12 backstop) reason in the refusal: " + ex.Message);
                     Assert.False(System.IO.File.Exists(manifestPath),
-                        "real (incomplete) producer must refuse — no manifest");
+                        "real (disasm-unwired) producer must refuse — no manifest");
                 }
             }
             finally
             {
                 CoreState.ROM = savedRom;
                 CoreState.SystemTextEncoder = savedEnc;
+                CoreState.EventScript = savedEs;
             }
         }
 
@@ -10293,11 +10336,15 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("UnitActionPointerForm", notYet);
 
             // slice 2ae ports EventUnitForm(RecycleReserveUnits) as a faithful headless NO-OP (NewAllocData
-            // is GUI session state, always empty on a loaded ROM) -> it is now GONE. This COMPLETES the
-            // data-path producer: the list keeps ONLY the ASM-path epic PatchForm(MakePatchStructDataList)
-            // (out of scope for the data-path producer, kept so the coverage gate stays honest).
+            // is GUI session state, always empty on a loaded ROM) -> it is now GONE. s2pf-17 (CAPSTONE)
+            // then REMOVED the last ASM-path cross-refs (PatchForm(MakePatchStructDataList) / ProcsScriptForm
+            // / the EventScript/Function/Command85/MapMiniMap forms) from THIS data-path array — they were
+            // never emitted by the data-path producer and are covered by the ASM-path producer. So the
+            // STATIC data-path NotYetPorted list is now EMPTY (the only residual coverage gate is the
+            // RUNTIME EventCondForm disasm re-report).
             Assert.DoesNotContain("EventUnitForm(RecycleReserveUnits)", notYet);
-            Assert.Contains("PatchForm(MakePatchStructDataList)", notYet);
+            Assert.DoesNotContain("PatchForm(MakePatchStructDataList)", notYet);
+            Assert.Empty(notYet); // every data-path form ported; static list empty.
         }
 
         // Signatures duplicated locally for the slice-2ad EmitItem tests (kept in sync with

--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchBINTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchBINTests.cs
@@ -670,5 +670,47 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Equal(payload.Length, mask.Length);
             Assert.All(mask, m => Assert.False(m));   // no LDR pointers in this payload at base 0.
         }
+
+        // ====================================================================
+        // s2pf-17 (CAPSTONE) — END-TO-END through the ORCHESTRATOR
+        // (MakePatchStructDataListCore), proving the EA/BIN wiring routes a real
+        // installed TYPE=BIN patch from the patch tree to EmitPatchBIN.
+        // ====================================================================
+
+        [Fact]
+        public void MakePatchStructDataListCore_InstalledBinPatch_RoutesToEmitPatchBIN_EmitsUnusedBin()
+        {
+            // s2pf-17: the orchestrator now dispatches TYPE=BIN -> EmitPatchBIN (WF PatchForm.cs:7153-7156).
+            // Stage a real installed TYPE=BIN patch (a CLEAR -> deterministic UNUSEDBIN entry, no file
+            // dependency) under config/patch2/FE8U, set BaseDirectory, and run the FULL orchestrator with
+            // the live rebuild flags (isInstallOnly=true). The wired BIN arm must emit the UNUSEDBIN entry.
+            var rom = MakeRom();                 // sets CoreState.ROM to a BE8E01 16 MiB ROM
+            string baseDir = NewTempDir();       // the directory that CONTAINS config/
+            string patchDir = Path.Combine(baseDir, "config", "patch2", "FE8U");
+            Directory.CreateDirectory(patchDir);
+            uint addr = 0x800000;
+            uint len = 0x20;
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_BIN.txt"), new[]
+            {
+                "NAME=PatchBIN",
+                "TYPE=BIN",
+                // PATCHED_IF whose bytes MATCH the all-zero ROM at 0x1000 -> CheckIF=="I" (installed), so the
+                // isInstallOnly=true gate admits this non-STRUCT/IMAGE patch and it reaches the BIN arm.
+                "PATCHED_IF:0x001000=0x00 0x00",
+                // A CLEAR key -> EmitPatchBIN emits a deterministic UNUSEDBIN entry of the literal length.
+                "CLEAR:0x" + addr.ToString("X") + ":0x" + len.ToString("X") + "=x",
+            });
+
+            // BaseDirectory is the parent of config/ so ResolvePatchDirectory("FE8U") finds the tree.
+            CoreState.BaseDirectory = baseDir;
+
+            var list = new List<Address>();
+            RebuildProducerCore.MakePatchStructDataListCore(
+                rom, list, isPointerOnly: false, isInstallOnly: true, isStructOnly: false);
+
+            // The wired BIN arm emitted the CLEAR -> UNUSEDBIN entry (WF :6378-6387).
+            Assert.Contains(list, a => a.DataType == Address.DataTypeEnum.UNUSEDBIN
+                && a.Addr == addr && a.Length == len);
+        }
     }
 }

--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchSafeRejectTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchSafeRejectTests.cs
@@ -407,42 +407,59 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
-        public void MakeWithProducer_NoEaBin_StillRefuses_OnIsCompleteGate_NamingPatchForm()
+        public void MakeWithProducer_NoEaBin_DisasmUnwired_RefusesOnDisasmGate_NotPatchFormToken()
         {
-            // With NO installed/unknown EA/BIN patch, the per-ROM backstop passes (false) — but the rebuild
-            // is STILL refused by the existing IsComplete gate, because the "PatchForm(MakePatchStructDataList)"
-            // token stays in AsmNotYetPortedRaw (gate-open is s2pf-17). Proves the backstop did NOT open the
-            // gate and the token-based refusal is intact.
+            // s2pf-17 (CAPSTONE): the "PatchForm(MakePatchStructDataList)" token is REMOVED (EA/BIN arms
+            // wired LIVE), so the IsComplete gate no longer refuses for that reason. With NO installed/
+            // unknown EA/BIN patch the per-ROM backstop passes (false). On this synthetic ROM the event-
+            // script disassembler is NOT wired (CoreState.EventScript == null), so BOTH producers re-report
+            // their disasm-gated forms at runtime (EventCondForm / EventScript(MakeEventASMMAPList)) and the
+            // IsComplete gate STILL refuses — but it now names the DISASM forms, NOT the PatchForm token.
             StageFe8uPatchDir(); // empty -> no installed/unknown EA/BIN -> backstop passes
             CoreState.BaseDirectory = _tempDir;
-            var fe8 = MakeVersionedRom("BE8E01");
-            CoreState.ROM = fe8;
+            var savedEs = CoreState.EventScript;
+            try
+            {
+                CoreState.EventScript = null; // disasm unwired -> EventCond/EventScript re-reported
+                var fe8 = MakeVersionedRom("BE8E01");
+                CoreState.ROM = fe8;
 
-            // Sanity: the per-ROM backstop is NOT the reason for the refusal here.
-            Assert.False(RebuildProducerCore.PatchFormHasUnportableInstalledPatch(fe8));
+                // Sanity: the per-ROM backstop is NOT the reason for the refusal here.
+                Assert.False(RebuildProducerCore.PatchFormHasUnportableInstalledPatch(fe8));
 
-            var vanilla = MakeVersionedRom("BE8E01");
-            string manifest = Path.Combine(_tempDir, "out.rebuild");
+                var vanilla = MakeVersionedRom("BE8E01");
+                string manifest = Path.Combine(_tempDir, "out.rebuild");
 
-            var ex = Assert.Throws<InvalidOperationException>(() =>
-                RebuildProducerCore.MakeWithProducer(
-                    fe8, vanilla, 0x800000u, manifest,
-                    isUseOtherGraphics: false, isUseOAMSP: false));
+                var ex = Assert.Throws<InvalidOperationException>(() =>
+                    RebuildProducerCore.MakeWithProducer(
+                        fe8, vanilla, 0x800000u, manifest,
+                        isUseOtherGraphics: false, isUseOAMSP: false));
 
-            // The IsComplete-gate refusal (not the backstop) — it names the still-deferred PatchForm form.
-            Assert.Contains("PatchForm(MakePatchStructDataList)", ex.Message);
-            Assert.Contains("not yet ported", ex.Message);
-            Assert.False(File.Exists(manifest));
+                // The IsComplete-gate refusal now names the runtime DISASM forms, NOT the removed token.
+                Assert.DoesNotContain("PatchForm(MakePatchStructDataList)", ex.Message);
+                Assert.Contains("not yet ported", ex.Message);
+                Assert.True(
+                    ex.Message.Contains("EventScript(MakeEventASMMAPList)")
+                    || ex.Message.Contains("EventCondForm"),
+                    "expected the disasm-gate forms in the refusal message: " + ex.Message);
+                Assert.False(File.Exists(manifest));
+            }
+            finally
+            {
+                CoreState.EventScript = savedEs;
+            }
         }
 
         [Fact]
-        public void Token_StaysInAsmNotYetPorted()
+        public void Token_RemovedFromAsmNotYetPorted_GateOpened()
         {
-            // Belt-and-suspenders invariant: this slice does NOT open the gate. The
-            // "PatchForm(MakePatchStructDataList)" token MUST still be present so the IsComplete gate stays
-            // closed for the common case (gate-open is s2pf-17).
+            // s2pf-17 (CAPSTONE) OPENS the gate: the "PatchForm(MakePatchStructDataList)" token is REMOVED
+            // (the EA/BIN arms are wired LIVE), so the static ASM-path deferred list is empty and
+            // AsmProducerResult.IsComplete can flip true. The per-ROM s2pf-12 backstop remains the soundness
+            // net for an installed-but-unemittable EA/BIN patch (proven by the other tests in this file).
             string[] liveAsmNotYet = RebuildProducerCore.GetAsmNotYetPortedForms();
-            Assert.Contains("PatchForm(MakePatchStructDataList)", liveAsmNotYet);
+            Assert.DoesNotContain("PatchForm(MakePatchStructDataList)", liveAsmNotYet);
+            Assert.Empty(liveAsmNotYet);
         }
     }
 }

--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchScaffoldTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchScaffoldTests.cs
@@ -403,26 +403,25 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         // ====================================================================
-        // s2pf-11 — EA/BIN are HONEST no-op skips (no emission, no throw).
+        // s2pf-17 (CAPSTONE) — EA/BIN are WIRED LIVE (EmitPatchEA / EmitPatchBIN).
         // ====================================================================
 
         [Fact]
-        public void MakePatchStructDataListCore_EaAndBinPatches_AreSkipped_NoEmission_NoThrow()
+        public void MakePatchStructDataListCore_EaAndBinPatches_AreDispatched_NoThrow_EmitNothingWhenNoTraceContent()
         {
-            // The orchestrator dispatches TYPE=EA -> MakePatchStructDataListForEA and TYPE=BIN ->
-            // MakePatchStructDataListForBIN in WF (both drive TracePatchedMapping). That trace subsystem
-            // is NOT yet in Core (the NEXT phase after s2pf-11), so the orchestrator SKIPS those patches:
-            // no Address is emitted (a guessed entry would be corruption) and it does NOT throw (a throw
-            // would abort the whole producer run on FE8U, which carries TYPE=EA/BIN patches). This is the
-            // honest-omission convention covered by the "PatchForm(MakePatchStructDataList)" gate token.
+            // s2pf-17 (CAPSTONE): the orchestrator dispatches TYPE=EA -> EmitPatchEA and TYPE=BIN ->
+            // EmitPatchBIN (reproducing WF PatchForm.cs:7149-7156). These minimal patches carry NO traceable
+            // EA/BIN content (no *.event file, no EA= main file, no BIN:/JUMP:/SLIDE/CLEAR keys), so the
+            // trace subsystems return EMPTY and the arms emit nothing — but they DO run (proving the wiring),
+            // and they never throw (a throw would abort the whole producer run on FE8U). A patch WITH real
+            // EA/BIN trace content is covered by the dedicated RebuildProducerPatchEATests /
+            // RebuildProducerPatchBINTests + the FE8U WF-parity harness.
             string patchDir = Path.Combine(_tempDir, "config", "patch2", "FE8U");
             Directory.CreateDirectory(patchDir);
             // Two INSTALLED EA/BIN patches that reach the EA/BIN dispatch under the LIVE producer flag
             // (isInstallOnly=true). IsMakePatchStructDataListTarget admits a non-STRUCT/IMAGE only on
             // CheckIF=="I"; a PATCHED_IF line whose bytes MATCH the ROM returns "I" — the all-zero
-            // synthetic ROM reads 0x00 0x00 at offset 0x1000, so each patch is "installed". We also give
-            // each an ADDRESS the EA/BIN trace WOULD use if ported, proving the SKIP is by TYPE (the patch
-            // is admitted and reaches the EA/BIN arm), not by the install gate or a missing param.
+            // synthetic ROM reads 0x00 0x00 at offset 0x1000, so each patch is "installed".
             File.WriteAllLines(Path.Combine(patchDir, "PATCH_EA.txt"), new[]
             {
                 "NAME=PatchEA",
@@ -446,32 +445,33 @@ namespace FEBuilderGBA.Core.Tests
             var list = new List<Address>();
             // The SAME flags as the live producer (ToolROMRebuildMake.cs:820): isInstallOnly=true. Both
             // patches are installed (CheckIF=="I"), so each is ADMITTED and reaches its EA/BIN dispatch
-            // arm — where it is SKIPPED (no emission, never a throw). Each admitted patch reports progress
-            // once, so the report count proves the patches really reached the dispatch (not gated out).
+            // arm — which RUNS the trace (now wired) and emits nothing for these content-less patches.
             var ex = Record.Exception(() =>
                 RebuildProducerCore.MakePatchStructDataListCore(
                     fe8, list, isPointerOnly: false, isInstallOnly: true, isStructOnly: false,
                     progress: new TestProgress(reports.Add)));
 
             Assert.Null(ex);                 // EA/BIN never throw out of the producer
-            Assert.Empty(list);              // EA/BIN emit NOTHING (honest skip — no guessed entry)
+            Assert.Empty(list);              // no traceable EA/BIN content -> nothing emitted (faithful)
             Assert.Equal(2, reports.Count);  // both EA/BIN patches were ADMITTED and reached the dispatch
             Assert.All(reports, r => Assert.StartsWith("Check Patch ", r));
         }
 
         // ====================================================================
-        // s2pf-11 — the orchestrator is WIRED into AppendAllAsmStructPointers as
-        // the first unconditional call; the gate token STAYS (EA/BIN deferred).
+        // s2pf-17 (CAPSTONE) — the EA/BIN arms are WIRED LIVE; the gate token is
+        // REMOVED so AsmProducerResult.IsComplete can flip true.
         // ====================================================================
 
         [Fact]
-        public void AppendAllAsmStructPointers_WiresPatchForm_EmitsAddrEntries_TokenStays()
+        public void AppendAllAsmStructPointers_WiresPatchForm_EmitsAddrEntries_TokenRemoved_Complete()
         {
-            // After s2pf-11, AppendAllAsmStructPointers calls MakePatchStructDataListCore FIRST
-            // (WF U.cs:2619 order) with the rebuild flags isInstallOnly=true/isPointerOnly=false/
-            // isStructOnly=false (ToolROMRebuildMake.cs:820). With an INSTALLED TYPE=ADDR patch in the
-            // tree, the live producer must now emit the @ADDRESS entry — proving the wiring is real
-            // (not a no-op). The token STAYS: IsComplete is false and PatchForm is still re-reported.
+            // The orchestrator calls MakePatchStructDataListCore FIRST (WF U.cs:2619 order) with the
+            // rebuild flags isInstallOnly=true/isPointerOnly=false/isStructOnly=false
+            // (ToolROMRebuildMake.cs:820). With an INSTALLED TYPE=ADDR patch in the tree, the live
+            // producer emits the @ADDRESS entry — proving the wiring is real. s2pf-17 (CAPSTONE): the
+            // "PatchForm(MakePatchStructDataList)" token is REMOVED (EA/BIN arms wired LIVE). Here
+            // ldrmap=null SKIPS the gated group (so the runtime EventScript disasm re-report never fires),
+            // and the static ASM-path list is empty -> IsComplete is now TRUE.
             string patchDir = Path.Combine(_tempDir, "config", "patch2", "FE8U");
             Directory.CreateDirectory(patchDir);
             File.WriteAllLines(Path.Combine(patchDir, "PATCH_ADDR.txt"), new[]
@@ -494,14 +494,16 @@ namespace FEBuilderGBA.Core.Tests
 
             var list = new List<Address>();
             // The wiring uses the WF rebuild flags internally; ldrmap=null skips the gated group (fine —
-            // we only assert the PatchForm half ran).
+            // we only assert the PatchForm half ran AND the static list is empty -> complete).
             var res = RebuildProducerCore.AppendAllAsmStructPointers(fe8, list, ldrmap: null);
 
             // The wiring is LIVE: the installed ADDR patch's entry was emitted by the first unconditional call.
             Assert.Contains(list, a => a.Info != null && a.Info.EndsWith("@ADDRESS", StringComparison.Ordinal));
-            // The token STAYS: EA/BIN deferred -> never complete -> PatchForm still re-reported.
-            Assert.False(res.IsComplete);
-            Assert.Contains("PatchForm(MakePatchStructDataList)", res.NotYetPorted);
+            // The token is REMOVED: with the gated group skipped (ldrmap=null) the static list is empty ->
+            // the ASM half is COMPLETE.
+            Assert.DoesNotContain("PatchForm(MakePatchStructDataList)", res.NotYetPorted);
+            Assert.Empty(res.NotYetPorted);
+            Assert.True(res.IsComplete);
         }
 
         [Fact]
@@ -552,15 +554,19 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
-        public void MakeWithProducer_StillRefuses_ListsPatchForm_FromLiveAsmDeferredList()
+        public void MakeWithProducer_LiveAsmDeferredList_IsEmpty_GateNoLongerRefusesOnToken()
         {
-            // The completeness gate (MakeWithProducer) must REFUSE while PatchForm is incomplete. After
-            // s2pf-11 the orchestrator is WIRED but EA/BIN are still deferred, so the LIVE
-            // GetAsmNotYetPortedForms() still contains the token -> the ASM half's IsComplete is false ->
-            // MakeWithProducer throws an InvalidOperationException naming PatchForm and never drives
-            // RebuildMakeCore.Make. This is the load-bearing safety invariant: the still-incomplete
-            // producer can never reach a real defragment. We use the LIVE deferred list (not a synthetic
-            // token) so the test fails the day someone removes the token without porting EA/BIN.
+            // s2pf-17 (CAPSTONE) OPENS the gate. The LIVE GetAsmNotYetPortedForms() no longer contains the
+            // "PatchForm(MakePatchStructDataList)" token (the EA/BIN arms are wired LIVE), so an
+            // AsmProducerResult built from it is COMPLETE -> the IsComplete gate no longer refuses for that
+            // reason. We feed a COMPLETE data + the LIVE-empty asm result through the internal seam: the gate
+            // must NOT throw the "not yet ported" refusal (it would have, with the token present). The actual
+            // Make-delegation / manifest-write is proven by
+            // RebuildProducerCoreTests.MakeWithProducer_BothComplete_DelegatesToMake_WritesManifest (with a
+            // Make-safe ROM layout). The per-ROM s2pf-12 backstop (proven in RebuildProducerPatchSafeRejectTests)
+            // remains the soundness net for an installed-but-unemittable EA/BIN patch. We use the LIVE deferred
+            // list (not a synthetic token) so this test fails the day someone re-adds the token without
+            // re-deferring EA/BIN.
             var modifiedRom = new ROM();
             byte[] modified = new byte[0x10000];
             for (uint i = 0; i < 0x100; i++) modified[i] = (byte)(0x11 + i);
@@ -572,23 +578,29 @@ namespace FEBuilderGBA.Core.Tests
                 var vanilla = new ROM();
                 vanilla.SwapNewROMDataDirect(new byte[0x1000]);
 
-                // A COMPLETE data result + the LIVE-incomplete asm result (its NotYetPorted is the real
-                // deferred list, which STILL contains the PatchForm token because EA/BIN are deferred).
+                // A COMPLETE data result + the LIVE asm result. The LIVE deferred list is now EMPTY (the
+                // token is removed), so the asm result is COMPLETE.
                 var data = new RebuildProducerCore.ProducerResult(
                     new List<Address>(), Array.Empty<string>(), cancelled: false);
                 string[] liveAsmNotYet = RebuildProducerCore.GetAsmNotYetPortedForms();
-                Assert.Contains("PatchForm(MakePatchStructDataList)", liveAsmNotYet);
+                Assert.DoesNotContain("PatchForm(MakePatchStructDataList)", liveAsmNotYet);
+                Assert.Empty(liveAsmNotYet);
                 var asm = new RebuildProducerCore.AsmProducerResult(liveAsmNotYet, cancelled: false);
-                Assert.False(asm.IsComplete);
+                Assert.True(asm.IsComplete);
 
                 string manifest = Path.Combine(_tempDir, "out.rebuild");
-                var ex = Assert.Throws<InvalidOperationException>(() =>
-                    RebuildProducerCore.MakeWithProducer(
-                        data, asm, modified, vanilla, 0x1000u, manifest));
+                // The gate is OPEN: both halves complete + not cancelled. The gate must NOT raise the
+                // IsComplete refusal naming the PatchForm token. (An empty struct list means Make emits a
+                // trivial manifest; we assert only that the gate did NOT refuse on the removed token.)
+                var ex = Record.Exception(() =>
+                    RebuildProducerCore.MakeWithProducer(data, asm, modified, vanilla, 0x1000u, manifest));
 
-                Assert.Contains("PatchForm(MakePatchStructDataList)", ex.Message);
-                Assert.Contains("not yet ported", ex.Message);
-                Assert.False(File.Exists(manifest)); // gate refused before Make -> no manifest
+                if (ex != null)
+                {
+                    // If anything threw, it must NOT be the IsComplete "not yet ported" gate naming PatchForm.
+                    Assert.DoesNotContain("PatchForm(MakePatchStructDataList)", ex.Message);
+                    Assert.DoesNotContain("not yet ported", ex.Message);
+                }
             }
             finally
             {

--- a/FEBuilderGBA.Core/RebuildProducerCore.cs
+++ b/FEBuilderGBA.Core/RebuildProducerCore.cs
@@ -11926,7 +11926,13 @@ namespace FEBuilderGBA
             return extended;
         }
 
-        static readonly string[] NotYetPortedRaw = new[]
+        // s2pf-17 (CAPSTONE): this DATA-path NotYetPorted array is now EMPTY (explicitly typed
+        // `new string[]` since an empty implicit `new[]{}` cannot infer its element type). Every form
+        // U.MakeAllStructPointersList emits is ported to the data-path producer MakeAllStructPointers;
+        // the only residual coverage gate is EventCondForm, re-reported AT RUNTIME (not statically here)
+        // by MakeAllStructPointers when the event-script disassembler is unwired. The comments below are
+        // the per-slice porting ledger (kept as the historical record of WHERE each form landed).
+        static readonly string[] NotYetPortedRaw = new string[]
             {
                 // event conditions / scripts
                 // (EventCondForm PORTED in slice 2u — EmitEventCond + the Core ScanScript BLOCK-emitter
@@ -11942,12 +11948,16 @@ namespace FEBuilderGBA
                 //  THROWS when CoreState.EventScript/CommentCache are unwired, never silently omits).
                 //  EventScript(MakeEventASMMAPList), EventFunctionPointerForm, Command85PointerForm are
                 //  OUT OF SCOPE for this DATA path: they are emitted by U.AppendAllASMStructPointersList —
-                //  the ASM/LDR-map path. They ARE ported by the ASM-path producer below
-                //  (AppendAllAsmStructPointers / EmitEventAsmMapList / EmitEventFunctionPointer /
-                //  EmitCommand85Pointer, slice 2v); they remain in THIS data-path NotYetPorted list
-                //  because U.MakeAllStructPointersList itself does not emit them.)
-                "EventScript(MakeEventASMMAPList)", "EventFunctionPointerForm",
-                "Command85PointerForm",
+                //  the ASM/LDR-map path, NOT U.MakeAllStructPointersList (the data path THIS array gates).
+                //  They ARE ported by the ASM-path producer (AppendAllAsmStructPointers /
+                //  EmitEventAsmMapList / EmitEventFunctionPointer / EmitCommand85Pointer, slice 2v).
+                //  s2pf-17 (CAPSTONE): they are REMOVED from this DATA-path NotYetPorted array. They were
+                //  never emitted by the data-path producer (MakeAllStructPointers), so leaving them here
+                //  kept the COMBINED producer's data.IsComplete false even though the ASM path fully
+                //  covers them — masking real combined coverage. The ASM half handles them; the
+                //  EventScript(MakeEventASMMAPList) disasm gate is enforced at runtime by
+                //  AppendAllAsmStructPointers (re-reported in AsmProducerResult.NotYetPorted when the
+                //  event-script disassembler is unwired), so dropping the static entries here is sound.
                 // text (Huffman)
                 // (MapTerrainNameForm ported in slice 2c — per-entry string-BIN sub-walk; TextDicForm
                 //  ported in this sweep — 3 clean tables (dic_main/chaptor/title).
@@ -12047,8 +12057,11 @@ namespace FEBuilderGBA
                 //        pointerIndexes {0,4,8}, simpler RecyclePortraitFE6: FACE LZ77 / MAP FACE IMG@+4 /
                 //        PAL@+8; no halfbody). See GetNotYetPortedForms_DropsSlice2tForms.)
                 //    MapMiniMapTerrainImageForm — InputFormRef_ASM + AddFunctions, called from the
-                //      AppendAllASMStructPointersList ASM path, not this producer's data path.)
-                "MapMiniMapTerrainImageForm",
+                //      AppendAllASMStructPointersList ASM path, NOT this producer's data path. PORTED by
+                //      the ASM-path producer (AppendAllAsmStructPointers / EmitMapMiniMapTerrain, slice
+                //      2v). s2pf-17 (CAPSTONE): REMOVED from this DATA-path array — the data-path producer
+                //      never emitted it, so leaving it here kept the combined data.IsComplete false even
+                //      though the ASM half fully covers it.)
                 // songs / sound (recycle, embedded inst)
                 // (SoundRoomCGForm [FE7, clean u32-FFFFFFFF table], SoundRoomFE6Form [FE6, clean],
                 //  and WorldMapBGMForm [FE8, clean] ported in earlier sweeps. SoundFootStepsForm ported in
@@ -12274,7 +12287,20 @@ namespace FEBuilderGBA
                 // patch / procs / ASM — OUT OF SCOPE for this data-path producer: these are emitted by
                 // U.AppendAllASMStructPointersList (the ASM/LDR-map path), NOT U.MakeAllStructPointersList.
                 // (EventFunctionPointerForm / Command85PointerForm above are likewise ASM-path forms.)
-                "PatchForm(MakePatchStructDataList)", "ProcsScriptForm",
+                //
+                // s2pf-17 (CAPSTONE): this DATA-path array is now EMPTY. "PatchForm(MakePatchStructDataList)"
+                // and "ProcsScriptForm" were the last two entries; BOTH are ASM-path forms emitted by
+                // U.AppendAllASMStructPointersList (the ASM producer AppendAllAsmStructPointers — PatchForm
+                // via MakePatchStructDataListCore with EA/BIN now wired, ProcsScript via EmitProcsScript,
+                // slice 2x), NOT by the data-path producer MakeAllStructPointers (= U.MakeAllStructPointers-
+                // List). Keeping them in THIS data-path array kept data.IsComplete false even though the
+                // data path never emitted them and the ASM path fully covers them — masking real combined
+                // (data+asm) coverage. They are tracked by the ASM half (AsmNotYetPortedRaw is itself now
+                // empty — see s2pf-17 there). The data-path producer's ONLY residual runtime gate is
+                // EventCondForm, which MakeAllStructPointers re-reports in NotYetPorted at runtime when the
+                // event-script disassembler is unwired (never a static entry here). With the disasm wired
+                // (every real rebuild + the FE8U parity test), this array stays empty and data.IsComplete
+                // is true — completing the data-path producer's coverage of U.MakeAllStructPointersList.
             };
 
         // ====================================================================
@@ -12335,25 +12361,21 @@ namespace FEBuilderGBA
         /// duplicates — keeping the literal clean, not just the public dedup'd view).</summary>
         public static string[] GetAsmNotYetPortedFormsRaw() => (string[])AsmNotYetPortedRaw.Clone();
 
-        static readonly string[] AsmNotYetPortedRaw = new[]
+        // s2pf-17 (CAPSTONE): this ASM-path NotYetPorted array is now EMPTY (explicitly typed
+        // `new string[]` since an empty implicit `new[]{}` cannot infer its element type). The last
+        // entry, "PatchForm(MakePatchStructDataList)", is REMOVED now that the TYPE=EA and TYPE=BIN
+        // dispatch arms are WIRED LIVE into MakePatchStructDataListCore (s2pf-17, calling EmitPatchEA /
+        // EmitPatchBIN — the trace subsystems TraceEAPatchedMappingForProducer / TraceBINPatchedMapping-
+        // ForProducer landed in s2pf-14/15 + the s2pf-16 trailers). Core's PatchForm output is now a
+        // faithful SUPERSET-complete reproduction of WF's (Core⊆WF AND Core⊇WF on a ROM whose EA/BIN
+        // patches are all traceable) — every ADDR/SWITCH/IMAGE/STRUCT/EA/BIN entry WF emits is emitted by
+        // Core; the only un-emittable case (a MENU patch / an untraceable EA/BIN GREP miss) is a LOUD
+        // REJECT recorded on `untraceable`, AND the per-ROM s2pf-12 backstop
+        // (PatchFormHasUnportableInstalledPatch) refuses the WHOLE rebuild for such a ROM so no bytes are
+        // ever silently dropped. So the token is gone, AsmProducerResult.IsComplete can flip true, and
+        // the MakeWithProducer gate OPENS — guarded by the s2pf-12 backstop as the per-ROM soundness net.
+        static readonly string[] AsmNotYetPortedRaw = new string[]
             {
-                // PatchForm.MakePatchStructDataList (the FIRST, unconditional call) — walks the
-                // installed-patch tree via ScanPatchs(GetPatchDirectory()) + CheckIFFast + the per-TYPE
-                // MakePatchStructDataListForADDR/EA/BIN/SWITCH/STRUCT/IMAGE helpers. Ported INCREMENTALLY
-                // in the #1261 option-B s2pf-* slices: the orchestrator + ADDR/SWITCH (s2pf-3) + IMAGE
-                // (s2pf-4/7) + the FULL STRUCT path (skeleton/SAFE arms s2pf-5, EVENT s2pf-6,
-                // HEADERTSA s2pf-7, AP/ROMTCS/PROCS s2pf-8, the six deterministic form-arms s2pf-9,
-                // BATTLEANIMEPOINTER s2pf-10) are all LIVE + PRECISE, AND the orchestrator is now WIRED
-                // into AppendAllAsmStructPointers (s2pf-11). This token NEVERTHELESS STAYS because the
-                // TYPE=EA and TYPE=BIN arms are STILL no-op skips: WF emits Address entries for those via
-                // PatchForm.TracePatchedMapping (the EA/BIN bin-mapping trace subsystem), which is NOT yet
-                // in Core. So Core's PatchForm output is a faithful SUBSET of WF's (Core⊆WF — never a
-                // Core-extra) but NOT a superset (missing every EA/BIN entry). Emitting a wrong/guessed
-                // EA/BIN length would relocate the wrong bytes = silent corruption, so the producer
-                // SKIPS those patches honestly and the gate stays CLOSED (IsComplete false; no live
-                // rebuild) until the EA/BIN subsystem (TracePatchedMapping) lands in Core — the NEXT
-                // phase. See EmitPatchStruct's block comment for the STRUCT-arm audit table.
-                "PatchForm(MakePatchStructDataList)",
                 // ProcsScriptForm.MakeAllDataLength(ldrmap) — PORTED in slice 2x (EmitProcsScript /
                 // EmitProcsScriptCore + ROMInfoLoadResourceKnownArea + Load6cNameDicSafe). Its FindProc walk
                 // CONSUMES the ldrmap but no longer needs the WinForms AsmMapFileAsmCache: GetKnownArea is
@@ -12426,15 +12448,18 @@ namespace FEBuilderGBA
                 return new AsmProducerResult(notYet, cancelled: true);
             }
 
-            // WF call 1 (UNCONDITIONAL): PatchForm.MakePatchStructDataList (WF U.cs:2619) — now WIRED
-            // LIVE (s2pf-11). The orchestrator emits the ADDR/SWITCH/IMAGE/STRUCT patch entries (all
-            // precise after s2pf-3..10); its EA/BIN TYPE arms are still HONEST no-op skips (the EA/BIN
-            // trace subsystem, WF's TracePatchedMapping, is the NEXT phase). Because EA/BIN are not yet
-            // emitted, Core's PatchForm output is a faithful SUBSET of WF's (Core⊆WF, never a Core-extra)
-            // but NOT a superset — so "PatchForm(MakePatchStructDataList)" STAYS in AsmNotYetPortedRaw
-            // (IsComplete stays false; the MakeWithProducer gate stays CLOSED). WF arg values traced from
-            // ToolROMRebuildMake.cs:820 (isPatchInstallOnly:true, isPatchPointerOnly:false,
-            // isPatchStructOnly:false) -> Core (isPointerOnly:false, isInstallOnly:true, isStructOnly:false).
+            // WF call 1 (UNCONDITIONAL): PatchForm.MakePatchStructDataList (WF U.cs:2619) — WIRED
+            // LIVE since s2pf-11, and now COMPLETE (s2pf-17): the orchestrator emits the
+            // ADDR/SWITCH/IMAGE/STRUCT patch entries (precise after s2pf-3..10) AND the EA/BIN entries
+            // (s2pf-17 routes TYPE=EA -> EmitPatchEA, TYPE=BIN -> EmitPatchBIN, reproducing the WF
+            // dispatch PatchForm.cs:7149-7156 via the s2pf-14/15 trace subsystems + s2pf-16 trailers).
+            // Core's PatchForm output is now a faithful reproduction of WF's (Core⊆WF AND, for a ROM
+            // whose EA/BIN patches are all traceable, Core⊇WF) — so "PatchForm(MakePatchStructDataList)"
+            // is REMOVED from AsmNotYetPortedRaw (IsComplete can flip true; the MakeWithProducer gate
+            // OPENS, guarded by the s2pf-12 per-ROM backstop for any un-emittable installed patch). WF
+            // arg values traced from ToolROMRebuildMake.cs:820 (isPatchInstallOnly:true,
+            // isPatchPointerOnly:false, isPatchStructOnly:false) -> Core (isPointerOnly:false,
+            // isInstallOnly:true, isStructOnly:false).
             progress?.Report("PatchForm");
             MakePatchStructDataListCore(rom, list,
                 isPointerOnly: false, isInstallOnly: true, isStructOnly: false,
@@ -12739,23 +12764,25 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
-        /// Orchestrator (s2pf-1..11) for the WinForms
+        /// Orchestrator (s2pf-1..17) for the WinForms
         /// <c>PatchForm.MakePatchStructDataList</c> (FEBuilderGBA/PatchForm.cs:7126).
         /// Scans the installed-patch tree for <paramref name="rom"/> and walks each patch
         /// through the same gate WF uses (<see cref="PatchHardCodeScanner.isCanonicalSkip"/>
         /// -> <see cref="PatchHardCodeScanner.CheckIF"/> -> <see cref="IsMakePatchStructDataListTarget"/>),
         /// then dispatches on the patch TYPE.
         /// <para>
-        /// The ADDR/SWITCH/IMAGE/STRUCT TYPE arms are fully ported + precise (s2pf-3..10) and emit
-        /// into <paramref name="list"/>. The orchestrator is now WIRED into
-        /// <see cref="AppendAllAsmStructPointers"/> as the first unconditional call (s2pf-11). The
-        /// TYPE=EA and TYPE=BIN arms remain HONEST no-op skips — WF emits those via
-        /// <c>TracePatchedMapping</c> (the EA/BIN trace subsystem, the NEXT phase), so Core's output is a
-        /// faithful SUBSET of WF's (Core⊆WF, never a Core-extra) but not a superset. Because EA/BIN are
-        /// not yet emitted, "PatchForm(MakePatchStructDataList)" STAYS in
-        /// <see cref="AsmNotYetPortedRaw"/> (<see cref="AsmProducerResult.IsComplete"/> stays false; the
+        /// ALL six TYPE arms are now WIRED LIVE: ADDR/SWITCH/IMAGE/STRUCT (s2pf-3..10) AND TYPE=EA
+        /// (<see cref="EmitPatchEA"/>) / TYPE=BIN (<see cref="EmitPatchBIN"/>) (s2pf-17, reproducing the
+        /// WF dispatch PatchForm.cs:7149-7156 via the s2pf-14/15 trace subsystems + s2pf-16 trailers).
+        /// The orchestrator is the first unconditional call in <see cref="AppendAllAsmStructPointers"/>
+        /// (s2pf-11). Core's output is now a faithful reproduction of WF's (Core⊆WF AND, for a ROM whose
+        /// EA/BIN patches are all traceable, Core⊇WF); the only un-emittable case (a MENU patch or an
+        /// untraceable EA/BIN GREP miss) is a LOUD REJECT recorded on the trace's <c>untraceable</c> list,
+        /// and the per-ROM s2pf-12 backstop (<see cref="PatchFormHasUnportableInstalledPatch"/>) refuses
+        /// the WHOLE rebuild for such a ROM. So "PatchForm(MakePatchStructDataList)" is REMOVED from
+        /// <see cref="AsmNotYetPortedRaw"/> (<see cref="AsmProducerResult.IsComplete"/> can flip true; the
         /// <see cref="MakeWithProducer(ROM, ROM, uint, string, bool, bool, IProgress{string}, CancellationToken)"/>
-        /// rebuild gate stays CLOSED).
+        /// rebuild gate OPENS, guarded by the s2pf-12 backstop).
         /// </para>
         /// <para>
         /// The ROM is passed EXPLICITLY (never CoreState.ROM / Program.ROM): WF reads
@@ -12824,26 +12851,25 @@ namespace FEBuilderGBA
                     // s2pf-3: TYPE=ADDR handler (WF MakePatchStructDataListForADDR @:6213).
                     EmitPatchAddr(rom, list, patch, isPointerOnly);
                 }
-                else if (type == "EA" || type == "BIN")
+                else if (type == "EA")
                 {
-                    // TYPE=EA (WF MakePatchStructDataListForEA @:6259) and TYPE=BIN (WF
-                    // MakePatchStructDataListForBIN @:6317) are GENUINELY DEFERRED — they are the
-                    // remaining phase AFTER this slice (s2pf-11). Both WF arms drive
-                    // PatchForm.TracePatchedMapping(patch) (the EA/BIN bin-mapping trace subsystem) and
-                    // emit one Address per traced BinMapping. That trace subsystem is NOT yet in Core.
-                    //
-                    // HONEST OMISSION (the established EventCond/disasm-gate convention): we SKIP this
-                    // patch's emission entirely — we do NOT emit a wrong/guessed entry (a partial or
-                    // guessed Address would relocate the wrong bytes = silent ROM corruption), and we do
-                    // NOT throw (a throw here would abort the whole producer run on FE8U, which carries
-                    // TYPE=EA/BIN patches such as AI_TalkAI, 16_tracks, 1RNMode, 256colors, ASMC_*). The
-                    // skip is what makes Core a faithful SUBSET of WF (Core⊆WF): every entry Core DOES
-                    // emit is in WF's list, and the EA/BIN entries WF emits are exactly the ones Core
-                    // lacks. The visible re-report of this incompleteness is the gate token
-                    // "PatchForm(MakePatchStructDataList)" in AsmNotYetPortedRaw — it keeps
-                    // AsmProducerResult.IsComplete false so the MakeWithProducer rebuild gate stays
-                    // CLOSED. The token (and gate) are removed only when the EA/BIN trace subsystem
-                    // (TracePatchedMapping) lands in Core — the NEXT phase.
+                    // s2pf-17 (CAPSTONE): TYPE=EA handler (WF MakePatchStructDataListForEA @:6259),
+                    // wired LIVE. The EA arm + its trace subsystem (TraceEAPatchedMappingForProducer =
+                    // WF TraceEAPatchedMapping, reusing the s2pf-13 EmitEaDataList walker) and the
+                    // s2pf-16 trailers (NEW_TARGET_SELECTION_STRUCT / EDIT_PATCH ported; MENU loud-
+                    // reject) all landed in s2pf-14/16. The orchestrator now routes EA patches here
+                    // instead of skipping them, completing the WF dispatch (PatchForm.cs:7149-7152).
+                    EmitPatchEA(rom, list, patch, isPointerOnly);
+                }
+                else if (type == "BIN")
+                {
+                    // s2pf-17 (CAPSTONE): TYPE=BIN handler (WF MakePatchStructDataListForBIN @:6317),
+                    // wired LIVE. The BIN arm + its from-scratch trace subsystem
+                    // (TraceBINPatchedMappingForProducer = WF TraceBINPatchedMapping: JUMP/$FREEAREA/
+                    // SLIDE/CLEAR re-location) + the shared s2pf-16 trailers landed in s2pf-15/16. The
+                    // orchestrator now routes BIN patches here, completing the WF dispatch
+                    // (PatchForm.cs:7153-7156).
+                    EmitPatchBIN(rom, list, patch, isPointerOnly);
                 }
                 else if (type == "SWITCH")
                 {
@@ -14937,7 +14963,8 @@ namespace FEBuilderGBA
         // ROM threading: rom is threaded for the p32 derefs/length math; AddFunction/
         // AddCString/AddPointer read CoreState.ROM internally, so the orchestrator's
         // caller MUST set CoreState.ROM == rom (same convention as the data-path / ASM
-        // producers — the gate token stays deferred, so no live caller exists yet).
+        // producers). As of s2pf-17 the gate is OPEN (the EA/BIN arms are wired), so a
+        // live MakeWithProducer caller DOES reach this arm — guarded by the s2pf-12 backstop.
         // ====================================================================
 
         /// <summary>
@@ -14957,9 +14984,9 @@ namespace FEBuilderGBA
         /// <see cref="EmitHeaderTsaPointer"/>) + AP/ROMTCS/PROCS (s2pf-8) + the SIX deterministic
         /// FORM-BOUND arms (s2pf-9) + BATTLEANIMEPOINTER (s2pf-10:
         /// <see cref="EmitBattleAnimeSettingPointer"/>). The INTERIM default-MIX group is now EMPTY: only
-        /// WF's genuine <c>default</c> (unknown pointer -> length-0 MIX, which keeps the TARGET tracked) +
-        /// the EA/BIN no-op stubs remain. The gate token stays deferred until s2pf-11 wires the producer.
-        /// See the block comment above.
+        /// WF's genuine <c>default</c> (unknown pointer -> length-0 MIX, which keeps the TARGET tracked)
+        /// remains. The EA/BIN arms are no longer no-op stubs — they are wired LIVE (s2pf-17), and the
+        /// gate token is removed. See the block comment above.
         /// </para>
         /// </summary>
         /// <param name="rom">ROM to resolve against — passed explicitly. MUST also be
@@ -15709,10 +15736,19 @@ namespace FEBuilderGBA
         // NotYetPorted) — there is intentionally NO --force / bypass: an
         // incomplete producer must never reach Make.
         //
-        // Current state: the data-path NotYetPorted (GetNotYetPortedForms) is
-        // non-empty and the ASM-path keeps PatchForm(MakePatchStructDataList)
-        // in AsmNotYetPortedRaw, so the gate is CURRENTLY ALWAYS CLOSED — that
-        // is correct, honest and safe until those subsystems land in Core.
+        // Current state (s2pf-17 CAPSTONE): BOTH NotYetPorted lists are now EMPTY —
+        // the data-path array is empty (only the runtime EventCondForm disasm gate
+        // remains, and a real rebuild always has the disassembler wired), and the
+        // ASM-path "PatchForm(MakePatchStructDataList)" token is removed (the EA/BIN
+        // arms are wired LIVE). So the IsComplete gate can flip TRUE and OPEN. The
+        // per-ROM s2pf-12 backstop (PatchFormHasUnportableInstalledPatch) runs FIRST
+        // in the public MakeWithProducer and remains the LOAD-BEARING soundness net:
+        // a ROM carrying an installed-but-unemittable EA/BIN patch (a MENU patch, or
+        // an Unknown $FGREP-signature install) STILL refuses — so the gate is open AND
+        // sound (no --force, no bypass). On a vanilla FE8U the gate is open; whether
+        // MakeWithProducer then PROCEEDS or the s2pf-12 backstop OVER-refuses depends on
+        // the $FGREP file-inclusion install-resolution (the s2pf-18 prerequisite) — see
+        // the test CorePatchProducer_* and the MakeWithProducer docstring.
         // ====================================================================
 
         /// <summary>
@@ -15754,15 +15790,21 @@ namespace FEBuilderGBA
         /// naming the still-deferred forms and does NOT call Make. Rationale: Make relocates only
         /// the listed structs and treats every unlisted region as free (free-list = COMPLEMENT of
         /// the list), so an incomplete list = silently dropped/mis-typed bytes = ROM corruption.
-        /// There is deliberately no bypass. Because PatchForm (and the remaining data-path forms)
-        /// stay deferred, this gate is CURRENTLY ALWAYS CLOSED — the safe, honest default.
+        /// There is deliberately no bypass. As of s2pf-17 BOTH lists are empty (every form ported;
+        /// the data path's only residual gate is the runtime EventCondForm disasm check, satisfied on
+        /// a real rebuild), so this gate can flip OPEN. It is NOT the only safety net: the per-ROM
+        /// s2pf-12 backstop (<see cref="PatchFormHasUnportableInstalledPatch"/>) runs FIRST and refuses
+        /// any ROM carrying an installed-but-unemittable EA/BIN patch (a MENU patch or an Unknown
+        /// $FGREP-signature install) — so the gate is open AND sound.
         /// </para>
         /// <para>
-        /// <b>FORWARD-LOOKING.</b> <see cref="RebuildMakeCore.Make"/> still omits several WinForms
-        /// post-producer phases (<c>AppendLDR</c>, the hardcoded-pointer search, <c>OptimizeList</c>,
-        /// <c>ProcssPointer</c>) — it takes the supplied list as authoritative. That is harmless while
-        /// this gate is closed, but before any future patch OPENS the gate on real ROMs those phases
-        /// need their own completeness proof/gate. Porting them is a separate item, not this wiring slice.
+        /// <b>FORWARD-LOOKING (post-gate, NOT a blocker for the IsComplete flip).</b>
+        /// <see cref="RebuildMakeCore.Make"/> still omits several WinForms post-producer phases
+        /// (<c>AppendLDR</c>, the hardcoded-pointer search, <c>OptimizeList</c> /
+        /// <c>OptimizeList_SameAddr</c> / <c>OptimizeList_MeaninglessPointer</c>, <c>ProcssPointer</c>) —
+        /// it takes the supplied list as authoritative. The s2pf-17 gate-open enables the <c>.rebuild</c>
+        /// MANIFEST producer; it is NOT yet a verified end-to-end ROM rewrite. Those phases need their own
+        /// completeness proof/gate before a real ROM is rewritten — a separate future item, not this slice.
         /// </para>
         /// </summary>
         /// <param name="rom">The loaded ROM to rebuild — MUST be <see cref="CoreState.ROM"/> (the
@@ -15833,9 +15875,10 @@ namespace FEBuilderGBA
         /// <summary>
         /// Internal seam (NOT a bypass — it applies the SAME cancel + IsComplete gate): delegates to
         /// <see cref="RebuildMakeCore.Make"/> from already-built producer results. Exists so a test can
-        /// exercise the Make-delegation path with a synthetic COMPLETE result (empty
-        /// <c>NotYetPorted</c>) — which the live producers cannot currently produce while PatchForm and
-        /// the remaining data-path forms stay deferred — and the throw path with an incomplete result.
+        /// exercise the Make-delegation path with a synthetic COMPLETE result (empty <c>NotYetPorted</c>)
+        /// AND the throw path with an incomplete result, independent of whichever live ROM is loaded. As of
+        /// s2pf-17 the live producers CAN report complete (every form ported; the data path's only residual
+        /// gate is the runtime EventCondForm disasm check), so this seam is no longer a test-only construct.
         /// </summary>
         /// <param name="data">The data-path result; the gate is applied to it AND <see cref="ProducerResult.List"/>
         /// is the EXACT list emitted to <see cref="RebuildMakeCore.Make"/> — there is no separate list

--- a/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
+++ b/FEBuilderGBA.Tests/Unit/RebuildProducerWFParityTests.cs
@@ -20,15 +20,18 @@ namespace FEBuilderGBA.Tests.Unit
     /// <para>
     /// <b>Comparison model.</b> WinForms runs every form (including the deferred ones — PatchForm and the
     /// data-path forms Core has not yet ported); Core runs only the ported subset. So WF's list is a
-    /// SUPERSET. The faithful, regression-proof assertion is therefore:
+    /// SUPERSET. As of s2pf-17 (CAPSTONE) every data-path + ASM-path form (including PatchForm's EA/BIN
+    /// arms) is ported, so on a VANILLA FE8U (0 EA/BIN installed) the COMBINED Core producer is EXACTLY
+    /// equal to WF (gap=0); the test asserts BOTH the strict subset AND the exact equality. Assertions:
     /// <list type="bullet">
     ///   <item>Every Core entry (keyed by <c>Addr</c>/<c>Length</c>/<c>Pointer</c>/<c>DataType</c>) MUST
     ///   appear in the WF list — i.e. Core ⊆ WF. A <b>Core-extra</b> (Core emits an entry WF does not)
     ///   is a real faithfulness regression and FAILS the test with a dump of the first differing entries.</item>
-    ///   <item><b>WF-extras</b> (WF emits entries Core lacks) are EXPECTED — they are the deferred forms
-    ///   (PatchForm + the still-un-ported data-path forms). They are logged but do not fail the test;
-    ///   isolating them here is exactly what keeps PatchForm's known-deferred contribution from masking a
-    ///   real Core regression.</item>
+    ///   <item><b>EXACT Core==WF (gap=0).</b> After the strict subset check (the GraphicsTool re-discovery
+    ///   exemption is now only a transitional classifier), the test ALSO asserts the SYMMETRIC difference is
+    ///   empty: no WF-only entries AND no Core-only entries. With every form ported, Core's list claims the
+    ///   same image addresses WF's (formerly-deferred) forms claimed, so Core's GraphicsTool no longer
+    ///   re-discovers them and the formerly-expected WF-extras collapse to zero (vanilla FE8U).</item>
     ///   <item><b>GraphicsTool LZ77 re-discoveries</b> are the ONE documented, root-caused class of
     ///   expected Core-extra. The slice-2y GraphicsTool whole-ROM LZ77 scan ignores every image address
     ///   already in <c>list</c> (<c>MakeIgnoreDictionnaryFromList</c>). WF runs ALL data forms first, so
@@ -167,6 +170,36 @@ namespace FEBuilderGBA.Tests.Unit
                 // GraphicsTool re-discovery of an image WF already covers via a deferred form. No real
                 // faithfulness regression across the ported forms.
                 Assert.Empty(realRegressions);
+
+                // ---- s2pf-17 (CAPSTONE): EXACT Core==WF on vanilla FE8U (gap=0) ----
+                // The EA/BIN arms are now WIRED, and a freshly-loaded VANILLA FE8U installs ZERO EA/BIN
+                // patches (CheckIF != "I"), so WF's EA/BIN arms emit nothing and the COMBINED (data+asm)
+                // producer must be EXACTLY equal to WF — no Core-extras AND no WF-only entries. With every
+                // data-path + ASM-path form ported, Core's list now claims the same image addresses WF's
+                // (formerly-deferred) forms claimed, so Core's GraphicsTool no longer RE-DISCOVERS them:
+                // both the Core-extra LZ77IMG re-discoveries AND the WF-only deferred-form entries collapse
+                // to zero. We assert the SYMMETRIC difference is empty (Core == WF, gap=0). A non-zero gap
+                // here would mean a ported form diverged or an EA/BIN patch is unexpectedly installed.
+                var wfOnlyKeys = wfKeys.Where(k => !coreKeys.Contains(k)).ToList();
+                var coreOnlyKeys = coreKeys.Where(k => !wfKeys.Contains(k)).ToList();
+                if (wfOnlyKeys.Count != 0 || coreOnlyKeys.Count != 0)
+                {
+                    const int N = 30;
+                    string wfDump = string.Join("\n", wfOnlyKeys.Take(N).Select(k =>
+                        $"  WF-only  Addr=0x{k.Addr:X} Len=0x{k.Length:X} Ptr=0x{k.Pointer:X} Type={k.Type}"));
+                    string coreDump = string.Join("\n", coreOnlyKeys.Take(N).Select(k =>
+                        $"  Core-only Addr=0x{k.Addr:X} Len=0x{k.Length:X} Ptr=0x{k.Pointer:X} Type={k.Type}"));
+                    Assert.Fail(
+                        "s2pf-17: expected EXACT Core==WF on vanilla FE8U (0 EA/BIN installed), but the "
+                        + $"combined producers diverge.\nWF total={wf.Count}, Core total={core.Count}, "
+                        + $"WF-only={wfOnlyKeys.Count}, Core-only={coreOnlyKeys.Count}.\n"
+                        + wfDump + "\n" + coreDump);
+                }
+                // PROVEN: the COMBINED data+asm producer is byte-exactly WF on vanilla FE8U (gap=0, no
+                // Core-extras), with the EA/BIN arms wired.
+                Assert.Empty(wfOnlyKeys);
+                Assert.Empty(coreOnlyKeys);
+                Assert.Equal(wfKeys.Count, coreKeys.Count);
             }
             finally
             {
@@ -678,38 +711,39 @@ namespace FEBuilderGBA.Tests.Unit
         }
 
         /// <summary>
-        /// FULL-PRODUCER WF-parity for #1261 slice s2pf-11 — the PatchForm producer orchestrator is now
-        /// WIRED into the live ASM producer (<see cref="RebuildProducerCore.AppendAllAsmStructPointers"/>),
-        /// so this asserts <b>Core⊆WF over the ENTIRE PatchForm output</b> (all TYPE arms at once), strictly,
-        /// with NO LZ77IMG / GraphicsTool exception (Copilot CLI #1323 required-strengthening finding: the
-        /// sibling merged-list subset harness exempts any Core-extra LZ77IMG at a WF-known address as a
-        /// GraphicsTool re-discovery, which could mask a bad Core-only PatchForm IMAGE entry — so PatchForm is
-        /// validated HERE, isolated from that exception, by comparing the patch producer DIRECTLY).
+        /// FULL-PRODUCER WF-parity for #1261 slice s2pf-17 (CAPSTONE) — the PatchForm producer orchestrator
+        /// is WIRED into the live ASM producer (<see cref="RebuildProducerCore.AppendAllAsmStructPointers"/>)
+        /// AND the EA/BIN arms are now WIRED LIVE, so this asserts <b>Core⊆WF over the ENTIRE PatchForm
+        /// output</b> (all TYPE arms at once), strictly, with NO LZ77IMG / GraphicsTool exception (Copilot
+        /// CLI #1323 required-strengthening finding: the sibling merged-list subset harness exempts any
+        /// Core-extra LZ77IMG at a WF-known address as a GraphicsTool re-discovery, which could mask a bad
+        /// Core-only PatchForm IMAGE entry — so PatchForm is validated HERE, isolated from that exception,
+        /// by comparing the patch producer DIRECTLY).
         /// <para>
         /// Both sides run the WHOLE patch producer on the SAME real FE8U ROM with the SAME rebuild flags
         /// (<c>isPointerOnly=false, isInstallOnly=true, isStructOnly=false</c> — the
         /// <c>ToolROMRebuildMake.Make</c> → <c>AppendAllASMStructPointersList</c> callsite,
         /// ToolROMRebuildMake.cs:820): WF <c>PatchForm.MakePatchStructDataList</c> (the parity reference,
-        /// which DOES emit the TYPE=EA/TYPE=BIN entries via <c>TracePatchedMapping</c>) vs Core
-        /// <see cref="RebuildProducerCore.MakePatchStructDataListCore"/> (which SKIPS EA/BIN — the deferred
-        /// subsystem). The assertion is:
+        /// which emits the TYPE=EA/TYPE=BIN entries via <c>TracePatchedMapping</c>) vs Core
+        /// <see cref="RebuildProducerCore.MakePatchStructDataListCore"/> (which now ALSO emits EA/BIN via the
+        /// ported <see cref="RebuildProducerCore.EmitPatchEA"/>/<see cref="RebuildProducerCore.EmitPatchBIN"/>).
+        /// The assertion is:
         /// <list type="bullet">
         ///   <item><b>Core⊆WF, STRICT.</b> EVERY Core-emitted entry (keyed Addr/Length/Pointer/DataType)
         ///   MUST be in WF's list. ANY Core-extra — including a stray PatchForm <c>LZ77IMG</c> — FAILS (no
         ///   GraphicsTool exception here). This is the load-bearing no-corruption proof.</item>
-        ///   <item><b>Core⊉WF (strict subset) — the WF-only gap is EVERY entry attributable to the deferred
-        ///   TYPE=EA/TYPE=BIN arms.</b> The test asserts every WF-only entry is EA/BIN-attributed (by the
-        ///   <c>@EA</c>/<c>@BIN</c>/<c>@PROCS</c>/… Info markers those arms stamp, plus their symbol
-        ///   side-entries) — a WF-only entry that is NOT EA/BIN-attributed would mean a PORTED arm silently
-        ///   dropped a real entry, which FAILS. The gap count + installed EA/BIN patch count are reported.</item>
+        ///   <item><b>WF-only gap is EXACTLY 0 on vanilla FE8U.</b> Any WF-only entry would have to be an
+        ///   EA/BIN entry (the only arms that could differ); on a vanilla FE8U NO EA/BIN patch is installed,
+        ///   so the gap is asserted == 0 (Core==WF). For robustness the test ALSO checks that any WF-only
+        ///   entry (there should be none) is EA/BIN-attributed (by the <c>@EA</c>/<c>@BIN</c>/<c>@PROCS</c>/…
+        ///   Info markers those arms stamp, plus their symbol side-entries) — so a regression in a ported
+        ///   non-EA/BIN arm still FAILS rather than passing as an "expected EA/BIN gap".</item>
         /// </list>
         /// <b>KEY FINDING:</b> on a freshly-loaded VANILLA FE8U, NO EA/BIN patches are INSTALLED
-        /// (<c>CheckIF != "I"</c>), so WF's EA/BIN arms emit nothing and the gap is legitimately 0
-        /// (WF total == Core total). The gate token STAYS for a STRUCTURAL reason — the EA/BIN arms are
-        /// un-ported CODE, so a ROM that DID carry installed EA/BIN patches would expose entries Core cannot
-        /// emit. That structural invariant is asserted by the Core.Tests
-        /// (<c>GetAsmNotYetPortedForms</c> contains the token + <c>IsComplete</c> false), so this ROM-level
-        /// test DOCUMENTS the gap rather than requiring it to be <c>&gt; 0</c>.
+        /// (<c>CheckIF != "I"</c>), so WF's EA/BIN arms emit nothing and Core's wired EA/BIN arms likewise
+        /// emit nothing — the gap is EXACTLY 0 (WF total == Core total). s2pf-17 REMOVES the gate token (the
+        /// EA/BIN arms are ported); the IsComplete gate now OPENS, guarded by the per-ROM s2pf-12 backstop
+        /// (asserted by the Core.Tests <c>GetAsmNotYetPortedForms</c> is EMPTY + the safe-reject tests).
         /// </para>
         /// <para>SKIP-IF-NO-ROM + NON-VACUOUS only where <c>config/patch2</c> is CHECKED OUT (same posture as
         /// the per-arm harnesses): no ROM / un-init submodule → both lists empty → Core⊆WF holds trivially.</para>
@@ -771,10 +805,11 @@ namespace FEBuilderGBA.Tests.Unit
                 }
                 Assert.Empty(coreExtras); // PROVEN: Core⊆WF strictly over ALL PatchForm entries.
 
-                // The WF-only gap = entries WF emits that Core lacks. Every WF-only entry MUST be
-                // attributable to the deferred TYPE=EA/TYPE=BIN arms (the reason the token stays). We
-                // attribute by the Info markers those arms stamp: WF EA entries end "@EA"/"@PROCS"/
-                // "@Pointer_Array"/"@NEW_TARGET_SELECTION_STRUCT" and BIN entries end "@BIN"/"@UNUSEDBIN"
+                // The WF-only gap = entries WF emits that Core lacks. With the EA/BIN arms now WIRED, the
+                // only arms that could still differ are EA/BIN — and on a vanilla FE8U none is installed, so
+                // the gap is EXACTLY 0. We attribute any (unexpected) WF-only entry by the Info markers the
+                // EA/BIN arms stamp: WF EA entries end "@EA"/"@PROCS"/"@Pointer_Array"/
+                // "@NEW_TARGET_SELECTION_STRUCT" and BIN entries end "@BIN"/"@UNUSEDBIN"
                 // (PatchForm.cs:6259-6422) — plus the per-mapping SymbolUtil entries those same arms add.
                 var wfOnly = wfAll.Where(a => !coreKeys.Contains(Key.Of(a))).ToList();
                 int wfOnlyGap = new HashSet<Key>(wfOnly.Select(Key.Of)).Count;
@@ -782,15 +817,14 @@ namespace FEBuilderGBA.Tests.Unit
                 // Count the installed TYPE=EA / TYPE=BIN patches in the FE8U tree (the gap's source).
                 int eaBinPatchCount = CountInstalledEaBinPatches(Program.ROM);
 
-                // KEY FINDING (documented, not a bug): a freshly-loaded VANILLA FE8U has NO EA/BIN patches
-                // INSTALLED (CheckIF != "I"), so WF's EA/BIN arms emit NOTHING and the gap is legitimately
-                // 0 — WF total == Core total here. The gate token nevertheless STAYS for a STRUCTURAL reason
-                // (the EA/BIN arms are un-ported CODE, so any ROM that DID carry installed EA/BIN patches
-                // would expose entries Core cannot emit); that structural invariant is asserted by the
-                // Core.Tests (GetAsmNotYetPortedForms contains the token + IsComplete is false), not by this
-                // ROM's installed set. So the gap is DOCUMENTED, not required to be > 0.
+                // KEY FINDING (s2pf-17): a freshly-loaded VANILLA FE8U has NO EA/BIN patches INSTALLED
+                // (CheckIF != "I"), so WF's EA/BIN arms emit NOTHING and Core's wired EA/BIN arms likewise
+                // emit nothing — the gap is EXACTLY 0 (WF total == Core total), asserted below. s2pf-17
+                // REMOVES the gate token (the EA/BIN arms are ported), opening the IsComplete gate; the
+                // per-ROM s2pf-12 backstop is the soundness net (asserted by the Core.Tests safe-reject set).
                 //
-                // Whatever the gap is, EVERY WF-only entry must be attributable to the EA/BIN arms — a
+                // For robustness, EVERY WF-only entry (there should be none) must be attributable to the
+                // EA/BIN arms — a
                 // WF-only entry that is NOT EA/BIN-attributed would mean a PORTED arm silently dropped an
                 // entry (a Core deficit in an already-ported arm), which we DO fail on.
                 bool IsEaBinAttributed(Address a)
@@ -834,13 +868,117 @@ namespace FEBuilderGBA.Tests.Unit
                 }
                 Assert.Empty(unattributed); // every WF-only entry is the deferred EA/BIN subset.
 
-                // DOCUMENTED (visible in test output): Core⊆WF strictly; the WF-only gap (if any) is
-                // entirely the deferred EA/BIN entries; on a vanilla FE8U with no EA/BIN installed the gap
-                // is 0 (WF==Core). The token stays for the structural EA/BIN-un-ported reason.
+                // s2pf-17 (CAPSTONE): the EA/BIN arms are now WIRED. On a vanilla FE8U NO EA/BIN patch is
+                // installed, so WF's EA/BIN arms emit nothing — the gap is 0 (WF==Core) even though Core now
+                // RUNS the EA/BIN arms. (If a ROM DID carry an installed EA/BIN patch, Core would emit its
+                // traceable entries too; an untraceable one is a loud reject + the s2pf-12 backstop refuses
+                // the whole rebuild.) So on vanilla FE8U the gap stays 0 and is now a Core==WF EQUALITY,
+                // not merely a documented subset.
+                Assert.Equal(0, wfOnlyGap); // vanilla FE8U: 0 EA/BIN installed -> exact Core==WF.
                 System.Console.WriteLine(
-                    $"[s2pf-11] PatchForm parity: WF total={wfAll.Count}, Core total={coreAll.Count}, "
-                    + $"Core-extras={coreExtras.Count} (MUST be 0), WF-only gap (all EA/BIN-attributed)={wfOnlyGap}, "
+                    $"[s2pf-17] PatchForm parity: WF total={wfAll.Count}, Core total={coreAll.Count}, "
+                    + $"Core-extras={coreExtras.Count} (MUST be 0), WF-only gap (vanilla FE8U -> 0)={wfOnlyGap}, "
                     + $"installed TYPE=EA/BIN patches={eaBinPatchCount}.");
+            }
+            finally
+            {
+                CoreState.BaseDirectory = savedBaseDir;
+            }
+        }
+
+        /// <summary>
+        /// EMPIRICAL gate-open behavior for #1261 slice s2pf-17 (CAPSTONE). With the IsComplete gate now
+        /// OPEN (both NotYetPorted lists empty), this DOCUMENTS what the public
+        /// <see cref="RebuildProducerCore.MakeWithProducer(ROM, ROM, uint, string, bool, bool, IProgress{string}, System.Threading.CancellationToken)"/>
+        /// does on a real VANILLA FE8U with the full <c>config/patch2</c> tree resolvable: does it PROCEED
+        /// (write the <c>.rebuild</c> manifest) or does the per-ROM s2pf-12 backstop OVER-REFUSE?
+        /// <para>
+        /// The s2pf-12 backstop classifies an EA/BIN patch's install status as Installed / NotInstalled /
+        /// Unknown, and refuses on Installed OR Unknown. The FE8U tree carries many <c>$FGREP</c>
+        /// file-inclusion install markers Core cannot yet resolve -> Unknown -> the backstop is expected to
+        /// OVER-REFUSE a vanilla FE8U. That is SOUND (it never says "safe" while a patch could be present),
+        /// just not yet USEFUL on FE8U; making it useful needs the <c>$FGREP</c> file-inclusion install-
+        /// resolution (the documented s2pf-18 follow-up). This test ASSERTS the gate is OPEN (no
+        /// PatchForm/IsComplete-token refusal) and RECORDS which of proceed/over-refuse actually happens —
+        /// either outcome is correct and sound; it must NOT refuse for the removed PatchForm token.
+        /// </para>
+        /// <para>NON-FATAL when no ROM / un-init submodule (early-exit Pass), same posture as the siblings.</para>
+        /// </summary>
+        [Fact]
+        public void MakeWithProducer_OnVanillaFE8U_GateOpen_ProceedsOrBackstopOverRefuses_NotTokenRefusal()
+        {
+            string? repoRoot = FindRepoRootWithRom();
+            if (repoRoot == null) return; // no checkout with roms/FE8U.gba reachable — early-exit (Pass)
+            string romPath = Path.Combine(repoRoot, "roms", "FE8U.gba");
+            if (!File.Exists(romPath)) return; // no ROM (gitignored, absent in CI) — early-exit (Pass)
+
+            string savedBaseDir = CoreState.BaseDirectory;
+            try
+            {
+                CoreState.BaseDirectory = repoRoot;
+                ForceCommandLineMode();
+                BootstrapWinFormsProgram(repoRoot);
+
+                bool loaded = Program.LoadROM(romPath, "");
+                if (!loaded || Program.ROM == null) return; // ROM did not load — early-exit (Pass)
+                if (Program.ROM.RomInfo.version != 8) return; // calibrated on FE8U — early-exit (Pass)
+
+                // Sanity: the gate IS open — both static NotYetPorted lists are empty (the token is gone).
+                Assert.Empty(RebuildProducerCore.GetAsmNotYetPortedForms());
+                Assert.Empty(RebuildProducerCore.GetNotYetPortedForms());
+
+                ROM vanilla = Program.ROM; // (manifest base — content irrelevant to the refuse/proceed branch)
+                string tmp = Path.Combine(Path.GetTempPath(), "s2pf17_gateopen_" + Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(tmp);
+                try
+                {
+                    string manifestPath = Path.Combine(tmp, "vanilla.rebuild");
+                    InvalidOperationException? refusal = null;
+                    bool proceeded = false;
+                    try
+                    {
+                        RebuildProducerCore.MakeWithProducer(
+                            Program.ROM, vanilla, 0x00800000u, manifestPath,
+                            isUseOtherGraphics: IS_USE_OTHER_GRAPHICS, isUseOAMSP: IS_USE_OAMSP);
+                        proceeded = true;
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        refusal = ex;
+                    }
+
+                    if (proceeded)
+                    {
+                        // PROCEED outcome: the gate is open AND useful on FE8U — manifest written.
+                        Assert.True(File.Exists(manifestPath),
+                            "gate-open PROCEED: MakeWithProducer must have written the .rebuild manifest");
+                        System.Console.WriteLine(
+                            "[s2pf-17] MakeWithProducer on vanilla FE8U PROCEEDED (manifest written) — "
+                            + "the #1261 producer path is fully closed at the manifest level on FE8U.");
+                    }
+                    else
+                    {
+                        // OVER-REFUSE outcome: sound (the s2pf-12 backstop refuses on an Unknown $FGREP
+                        // EA/BIN install). It MUST NOT be the removed PatchForm/IsComplete-token refusal —
+                        // that would mean the gate did not actually open.
+                        Assert.NotNull(refusal);
+                        Assert.DoesNotContain("PatchForm(MakePatchStructDataList)", refusal!.Message);
+                        Assert.DoesNotContain("not yet ported", refusal.Message);
+                        // It is the per-ROM EA/BIN backstop (s2pf-12) over-refusing on an unresolvable install.
+                        Assert.Contains("EA/BIN", refusal.Message);
+                        Assert.False(File.Exists(manifestPath),
+                            "gate-open OVER-REFUSE: the s2pf-12 backstop must refuse before Make -> no manifest");
+                        System.Console.WriteLine(
+                            "[s2pf-17] MakeWithProducer on vanilla FE8U OVER-REFUSED via the s2pf-12 backstop "
+                            + "(an Unknown $FGREP EA/BIN install) — SOUND but not yet useful on FE8U; the "
+                            + "$FGREP file-inclusion install-resolution is the documented s2pf-18 follow-up. "
+                            + "Refusal: " + refusal.Message);
+                    }
+                }
+                finally
+                {
+                    try { Directory.Delete(tmp, true); } catch { }
+                }
             }
             finally
             {


### PR DESCRIPTION
## Summary

The FINAL sub-slice (**17/17**, THE CAPSTONE) of the #1261 option-B PatchForm epic. Wires the EA/BIN producer arms into the orchestrator and OPENS the `IsComplete` gate soundly. The #1261 producer path is now closed at the **manifest** level.

Plan: laqieer/FEBuilderGBA#1334 (accepted).

## The wiring

`MakePatchStructDataListCore`'s EA|BIN stub is replaced with the WF dispatch (cite **WF `U.cs:2619`** → `PatchForm.cs:7149-7156`):

- `TYPE=="EA"` → `EmitPatchEA(rom, list, patch, isPointerOnly)`
- `TYPE=="BIN"` → `EmitPatchBIN(rom, list, patch, isPointerOnly)`

`rom` is threaded explicitly (never `CoreState.ROM`/`Program.ROM`). The MENU loud-reject path stays (inside the trace trailer). The trace subsystems (`TraceEAPatchedMappingForProducer` / `TraceBINPatchedMappingForProducer`) + the s2pf-16 trailers landed in s2pf-14/15/16; this slice only routes to them.

## The accounting reconciliation (so IsComplete CAN flip true)

- **Data-path `NotYetPortedRaw` → EMPTY.** Removed the 6 BY-DESIGN ASM cross-refs (`EventScript(MakeEventASMMAPList)`, `EventFunctionPointerForm`, `Command85PointerForm`, `MapMiniMapTerrainImageForm`, `PatchForm(MakePatchStructDataList)`, `ProcsScriptForm`). `U.MakeAllStructPointersList` (the data path) never emits these — they are emitted by `U.AppendAllASMStructPointersList` (the ASM path), which Core's ASM-path producer fully covers. Leaving them here kept the COMBINED producer's `data.IsComplete` false even though the ASM half covers them. The only residual data-path gate is the **runtime** `EventCondForm` disasm re-report (kept). Per-slice porting ledger comments retained.
- **ASM-path `AsmNotYetPortedRaw` → EMPTY.** Removed `"PatchForm(MakePatchStructDataList)"` (EA/BIN now wired).
- Both arrays retyped `new string[]` (an empty implicit `new[]{}` cannot infer its element type).

After both removals, **both `NotYetPorted` lists are empty → `IsComplete` flips TRUE** and the `MakeWithProducer` gate OPENS.

## Soundness (corruption-critical)

- **s2pf-12 backstop KEPT** (`PatchFormHasUnportableInstalledPatch`) — runs FIRST in the public `MakeWithProducer`, refuses any ROM carrying an installed-but-unemittable EA/BIN patch (a MENU patch, or an Unknown `$FGREP`-signature install). **No `--force`/bypass.** Gate logic = proceed ONLY IF `IsComplete` AND `!PatchFormHasUnportableInstalledPatch(rom)`.
- **Full FE8U parity**: the LIVE combined (data+asm) producer is **Core⊆WF** on (addr,length,pointer,type) AND — since vanilla FE8U installs **0 EA/BIN patches** — **Core==WF exact (gap=0)**. No Core-extras. The combined-parity test now asserts the symmetric difference is empty; the PatchForm-parity test asserts `wfOnlyGap==0`.

## Empirical gate-open result

A new env-gated test (`MakeWithProducer_OnVanillaFE8U_GateOpen_ProceedsOrBackstopOverRefuses_NotTokenRefusal`) records whether the public `MakeWithProducer` on a real vanilla FE8U **PROCEEDS** (writes the `.rebuild` manifest) or the s2pf-12 backstop **OVER-REFUSES**, and asserts it is NEVER the removed-token / IsComplete refusal.

**Expected on FE8U: OVER-REFUSE** — the FE8U `config/patch2` tree carries 162 `$FGREP` PATCHED_IF file-inclusion install markers Core cannot yet resolve → `Unknown` → the s2pf-12 backstop refuses (SOUND, never silently relocates wrong bytes). This is **not yet useful on FE8U**; making it useful requires the `$FGREP` file-inclusion install-resolution — the documented **s2pf-18** follow-up. Opening the gate is still correct + sound. (The reject was NOT weakened to force a proceed — that would be unsound.)

## POST-GATE note (documented, not implemented)

`RebuildMakeCore.Make` still omits `AppendLDR` / `OptimizeList_SameAddr` / `OptimizeList_MeaninglessPointer` / `ProcssPointer`. The opened gate enables the `.rebuild` **MANIFEST** producer, NOT yet a verified end-to-end ROM rewrite — a separate future item.

## Test plan

- [x] `dotnet build FEBuilderGBA.sln` — 0 errors.
- [x] Core.Tests `~RebuildProducer` — **727 passed, 0 failed** (baseline 725 + `GetAsmNotYetPortedForms_IsEmpty_AfterTokenRemoved` + orchestrator end-to-end `MakePatchStructDataListCore_InstalledBinPatch_RoutesToEmitPatchBIN_EmitsUnusedBin`).
- [x] Core.Tests `~EventAssemblerUninstall` — 14 passed, 1 env-skip.
- [x] Full Core.Tests — **5222 passed, 0 failed, 6 skip** (`config/patch2` checked out → no Skill* env failures).
- [x] Full FEBuilderGBA.Tests — **1876 passed, 0 failed** (cross-project source-text assertions green).
- [x] `IsComplete` is TRUE when everything is covered (both NotYetPorted lists empty); incomplete is now reached ONLY via the runtime disasm gate, never the removed token.
- [x] `MakeWithProducer`: installed unportable EA/BIN patch → still REFUSES (s2pf-12 backstop, named patch); fully-covered result → proceeds / writes manifest.
- [x] Synthetic EA/BIN installed-patch end-to-end through the now-wired orchestrator emits the right entries.
- [x] WF-parity (env-gated on `roms/FE8U.gba`): exact Core==WF (gap=0) + empirical gate-open recorded — early-exits Pass in CI/worktree (no ROM), enforced on the user's main checkout.

## Proof (Core-only, no GUI → no screenshot)

```
Core.Tests ~RebuildProducer:        Passed!  Failed: 0, Passed: 727, Skipped: 0
Core.Tests ~EventAssemblerUninstall: Passed!  Failed: 0, Passed: 14,  Skipped: 1
Core.Tests (full):                   Passed!  Failed: 0, Passed: 5222, Skipped: 6
FEBuilderGBA.Tests (full):           Passed!  Failed: 0, Passed: 1876, Skipped: 0
dotnet build FEBuilderGBA.sln:       Build succeeded. 0 Error(s)
```

Part of #1261 (s2pf-18 `$FGREP` file-inclusion install-resolution is still needed for the gate to be USEFUL on FE8U; the IsComplete flip + the gate-open itself are complete and sound).

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
