### PR TITLE
feat(core): PatchForm $FGREP install-resolution — gate useful on FE8U (#1261 s2pf-18)

### DIFF
--- a/FEBuilderGBA.Core.Tests/RebuildProducerPatchSafeRejectTests.cs
+++ b/FEBuilderGBA.Core.Tests/RebuildProducerPatchSafeRejectTests.cs
@@ -18,11 +18,21 @@
 //
 // SOUNDNESS: the dangerous direction is a false-negative ("safe" when actually
 // unsafe). The naive CheckIF=="I" predicate is UNSOUND (Copilot plan review, issue
-// #1325): it misses PATCHED_IFNOT-installed (e.g. FE8U/MNC2Fix) and $FGREP-signature
-// patches. EaBinInstallStatus fixes both (PATCHED_IFNOT match => Installed;
-// unresolvable signature => Unknown => refuse). These tests pin every branch:
-// PATCHED_IF-installed, PATCHED_IFNOT-installed, resolvable-not-installed,
-// $FGREP-unknown, TYPE/CANONICAL_SKIP/no-dir/version-0 boundaries.
+// #1325): it misses PATCHED_IFNOT-installed (e.g. FE8U/MNC2Fix). EaBinInstallStatus
+// fixes that (PATCHED_IFNOT match => Installed).
+//
+// s2pf-18 (#1261) GATE-USEFULNESS: the install-detection path now reads the $FGREP
+// <file> file-inclusion VERBATIM (port of WF MakeGrepData(value, basedir)), and — for
+// the BYTE-FAITHFUL GREP/FGREP family — treats a NOT_FOUND grep as NOT-MATCHING
+// (NotInstalled), exactly as WF's CheckIF does (the PATCHED_IF unsafe-address
+// `continue`). This narrows the Unknown set so vanilla FE8U's 159 absent-signature
+// $GREP/$FGREP EA/BIN rows resolve to NotInstalled and MakeWithProducer PROCEEDS.
+// FALSE-NEGATIVE still IMPOSSIBLE: Core's grep is byte-identical to WF's, so Core says
+// NotInstalled only where WF does. The un-ported macros ($XGREP/$FREEAREA) STAY
+// Unknown => refuse. These tests pin every branch: PATCHED_IF-installed,
+// PATCHED_IFNOT-installed, resolvable-not-installed, $FGREP file present (match +
+// mismatch) / absent-signature / missing-file, inline-$GREP absent-signature,
+// $XGREP-unknown, TYPE/CANONICAL_SKIP/no-dir/version-0 boundaries.
 
 using System;
 using System.Collections.Generic;
@@ -94,7 +104,8 @@ namespace FEBuilderGBA.Core.Tests
         //      PATCHED_IF:...=0xFF 0xFF   mismatch  -> NotInstalled
         //      PATCHED_IFNOT:...=0xFF 0xFF mismatch -> Installed (the un-patched sig is absent)
         //      PATCHED_IFNOT:...=0x00 0x00 match    -> NotInstalled (un-patched sig present)
-        //      PATCHED_IF:$FGREP <file>=...         -> Unknown (file-inclusion unresolvable)
+        //      PATCHED_IF:$GREP/$FGREP absent-sig   -> NotInstalled (NOT_FOUND = not-matching, mirrors WF; s2pf-18)
+        //      PATCHED_IF:$XGREP/$FREEAREA          -> Unknown (un-ported macro; stays conservative)
         // ====================================================================
 
         [Fact]
@@ -139,13 +150,29 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
-        public void EaBinInstallStatus_UnresolvableFgrepSignature_Unknown()
+        public void EaBinInstallStatus_MissingFgrepFileSignature_NotInstalled_MatchesWf()
         {
-            // The OTHER false-negative (Copilot #1325): an install marker using $FGREP <file> file-inclusion
-            // (162 such PATCHED_IF rows in the FE8U tree). Core's resolver does not port FGREP file-inclusion
-            // -> NOT_FOUND -> never "I". EaBinInstallStatus returns Unknown so the gate refuses conservatively.
+            // s2pf-18 (#1261): a $FGREP <file> install marker whose file is MISSING. The address resolves
+            // there with basedir = Path.GetDirectoryName("p.txt") = "" -> MakeFGrepData returns an empty
+            // pattern -> U.Grep -> NOT_FOUND. WF behaves IDENTICALLY (MakeGrepData(value, basedir) returns
+            // new byte[0] -> U.Grep NOT_FOUND -> CheckIF's unsafe-address `continue` -> the PATCHED_IF does
+            // NOT contribute -> WF IsInstalled is FALSE). Because Core's grep result is byte-identical to
+            // WF's for the GREP/FGREP family, Core faithfully classifies this absent signature as
+            // NotInstalled (NOT Unknown). FALSE-NEGATIVE IMPOSSIBLE: Core agrees with WF exactly here.
             var rom = MakeVersionedRom("BE8E01");
             var patch = MakePatch("p.txt", ("TYPE", "BIN"), ("PATCHED_IF:$FGREP4 nope_missing.bin", "0x00 0xB5"));
+            Assert.Equal(PatchHardCodeScanner.InstallStatusEnum.NotInstalled,
+                PatchHardCodeScanner.EaBinInstallStatus(rom, patch));
+        }
+
+        [Fact]
+        public void EaBinInstallStatus_XgrepSignature_Unknown_StaysSound()
+        {
+            // SOUNDNESS preserved: $XGREP (masked GREP) is NOT byte-faithfully ported, so its NOT_FOUND does
+            // NOT prove the signature absent -> the marker STAYS Unknown -> the gate refuses conservatively.
+            // (This is the residual deferral that keeps the false-negative impossible for un-ported macros.)
+            var rom = MakeVersionedRom("BE8E01");
+            var patch = MakePatch("p.txt", ("TYPE", "BIN"), ("PATCHED_IF:$XGREP4 0x00 X 0xB5", "0x00 0xB5"));
             Assert.Equal(PatchHardCodeScanner.InstallStatusEnum.Unknown,
                 PatchHardCodeScanner.EaBinInstallStatus(rom, patch));
         }
@@ -178,14 +205,133 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void EaBinInstallStatus_InstalledMarkerWins_OverUnknownMarker()
         {
-            // A patch with BOTH an unresolvable marker AND a resolvable matching marker is Installed
-            // (the precise answer), not Unknown — the resolvable match proves presence.
+            // A patch with BOTH an unresolvable $XGREP marker (Unknown alone) AND a resolvable matching
+            // marker is Installed (the precise answer), not Unknown — the resolvable match proves presence.
             var rom = MakeVersionedRom("BE8E01");
             var patch = MakePatch("p.txt", ("TYPE", "EA"),
-                ("PATCHED_IF:$FGREP4 missing.bin", "0x00 0xB5"),   // unresolvable -> would be Unknown alone
+                ("PATCHED_IF:$XGREP4 0x00 X 0xB5", "0x00 0xB5"),   // un-ported macro -> Unknown alone
                 ("PATCHED_IF:0x001000", "0x00 0x00"));             // resolvable + matches -> Installed
             Assert.Equal(PatchHardCodeScanner.InstallStatusEnum.Installed,
                 PatchHardCodeScanner.EaBinInstallStatus(rom, patch));
+        }
+
+        // ====================================================================
+        // 1b. $FGREP <file> install-resolution (s2pf-18 #1261). The install-detection
+        //     path now reads the basedir-relative file's bytes VERBATIM as the GREP
+        //     pattern (port of WF MakeGrepData(value, basedir)), so a $FGREP-based
+        //     PATCHED_IF/PATCHED_IFNOT resolves to a REAL ROM offset and classifies
+        //     Installed/NotInstalled — not Unknown — when the file is present.
+        //     The marker's PatchFileName must point at a real path so basedir =
+        //     Path.GetDirectoryName(PatchFileName) finds the planted .bin.
+        // ====================================================================
+
+        // Build a PatchSt whose PatchFileName lives in _tempDir (so basedir resolves there)
+        // and stage a binary signature file alongside it.
+        PatchInstallCore.PatchSt MakePatchInTempDir(string patchFileName, params (string key, string value)[] kv)
+        {
+            var p = new PatchInstallCore.PatchSt
+            {
+                Name = patchFileName,
+                PatchFileName = Path.Combine(_tempDir, patchFileName),
+                Param = new Dictionary<string, string>(),
+            };
+            foreach (var (key, value) in kv) p.Param[key] = value;
+            return p;
+        }
+
+        [Fact]
+        public void EaBinInstallStatus_FgrepFilePresent_PatchedIfMatch_Installed()
+        {
+            // Plant a unique 4-byte signature at a 4-aligned ROM offset and an identical .bin file
+            // next to the patch. $FGREP4 finds the signature at 0x2000; the PATCHED_IF byte window
+            // (the first two signature bytes) MATCHES the ROM there -> Installed (NOT Unknown).
+            var rom = MakeVersionedRom("BE8E01");
+            rom.Data[0x2000] = 0xAA; rom.Data[0x2001] = 0xBB; rom.Data[0x2002] = 0xCC; rom.Data[0x2003] = 0xDD;
+            File.WriteAllBytes(Path.Combine(_tempDir, "sig.bin"), new byte[] { 0xAA, 0xBB, 0xCC, 0xDD });
+
+            var patch = MakePatchInTempDir("p.txt", ("TYPE", "BIN"),
+                ("PATCHED_IF:$FGREP4 sig.bin", "0xAA 0xBB"));
+            Assert.Equal(PatchHardCodeScanner.InstallStatusEnum.Installed,
+                PatchHardCodeScanner.EaBinInstallStatus(rom, patch));
+        }
+
+        [Fact]
+        public void EaBinInstallStatus_FgrepFilePresent_PatchedIfMismatch_NotInstalled()
+        {
+            // Same planted signature/file, but the PATCHED_IF byte window does NOT match the ROM at the
+            // resolved offset -> NotInstalled (provably absent). This proves the resolution is REAL (a
+            // garbage offset could not deterministically mismatch) and that the gate can now say "safe".
+            var rom = MakeVersionedRom("BE8E01");
+            rom.Data[0x2000] = 0xAA; rom.Data[0x2001] = 0xBB; rom.Data[0x2002] = 0xCC; rom.Data[0x2003] = 0xDD;
+            File.WriteAllBytes(Path.Combine(_tempDir, "sig.bin"), new byte[] { 0xAA, 0xBB, 0xCC, 0xDD });
+
+            var patch = MakePatchInTempDir("p.txt", ("TYPE", "BIN"),
+                ("PATCHED_IF:$FGREP4 sig.bin", "0xFF 0xFF"));   // window mismatches the ROM at 0x2000
+            Assert.Equal(PatchHardCodeScanner.InstallStatusEnum.NotInstalled,
+                PatchHardCodeScanner.EaBinInstallStatus(rom, patch));
+        }
+
+        [Fact]
+        public void EaBinInstallStatus_FgrepFilePresent_PatchedIfNotMismatch_Installed()
+        {
+            // PATCHED_IFNOT is "installed when the un-patched signature is ABSENT". The $FGREP file
+            // resolves to 0x2000; the byte window 0xFF 0xFF mismatches the ROM there -> the un-patched
+            // sig is absent -> Installed. (Mirrors WF's detail-string "PATCHED_IF" rule for IFNOT.)
+            var rom = MakeVersionedRom("BE8E01");
+            rom.Data[0x2000] = 0xAA; rom.Data[0x2001] = 0xBB; rom.Data[0x2002] = 0xCC; rom.Data[0x2003] = 0xDD;
+            File.WriteAllBytes(Path.Combine(_tempDir, "sig.bin"), new byte[] { 0xAA, 0xBB, 0xCC, 0xDD });
+
+            var patch = MakePatchInTempDir("p.txt", ("TYPE", "BIN"),
+                ("PATCHED_IFNOT:$FGREP4 sig.bin", "0xFF 0xFF"));
+            Assert.Equal(PatchHardCodeScanner.InstallStatusEnum.Installed,
+                PatchHardCodeScanner.EaBinInstallStatus(rom, patch));
+        }
+
+        [Fact]
+        public void EaBinInstallStatus_FgrepFilePresentButPatternNotInRom_NotInstalled()
+        {
+            // The $FGREP file IS present, but its signature (the post-install byte pattern) is NOT anywhere
+            // in the (zero-filled) ROM. U.Grep returns NOT_FOUND. WF's CheckIF treats this exactly as
+            // NOT-MATCHING (the PATCHED_IF unsafe-address `continue`), so WF IsInstalled is FALSE. Because
+            // Core's GREP/FGREP resolution is byte-identical to WF, Core classifies it NotInstalled too
+            // (s2pf-18 #1261). This is the case that makes the gate USEFUL on vanilla FE8U (its 125
+            // absent-signature $FGREP rows). FALSE-NEGATIVE IMPOSSIBLE: Core agrees with WF exactly.
+            var rom = MakeVersionedRom("BE8E01"); // all zero — the signature below appears nowhere
+            File.WriteAllBytes(Path.Combine(_tempDir, "sig.bin"), new byte[] { 0xDE, 0xAD, 0xBE, 0xEF });
+
+            var patch = MakePatchInTempDir("p.txt", ("TYPE", "BIN"),
+                ("PATCHED_IF:$FGREP4 sig.bin", "0x00 0x00"));
+            Assert.Equal(PatchHardCodeScanner.InstallStatusEnum.NotInstalled,
+                PatchHardCodeScanner.EaBinInstallStatus(rom, patch));
+        }
+
+        [Fact]
+        public void EaBinInstallStatus_InlineGrepAbsentSignature_NotInstalled_MatchesWf()
+        {
+            // The inline $GREP family (no file) gets the SAME WF-faithful treatment: an absent post-install
+            // signature -> NOT_FOUND -> NotInstalled, NOT Unknown. (34 of FE8U's blocking rows are inline
+            // $GREP, e.g. PATCH_256 colors titlebackground 20180611.) Byte-faithful to WF; sound.
+            var rom = MakeVersionedRom("BE8E01"); // all zero — the 0xDEADBEEF signature appears nowhere
+            var patch = MakePatch("p.txt", ("TYPE", "EA"),
+                ("PATCHED_IF:$GREP4 0xDE 0xAD 0xBE 0xEF", "0x00 0x00"));
+            Assert.Equal(PatchHardCodeScanner.InstallStatusEnum.NotInstalled,
+                PatchHardCodeScanner.EaBinInstallStatus(rom, patch));
+        }
+
+        [Fact]
+        public void EaBinInstallStatus_FgrepFileMissing_NotInstalled_NoThrow()
+        {
+            // The $FGREP file is MISSING. WF MakeGrepData(value, basedir) returns new byte[0] -> U.Grep
+            // returns NOT_FOUND -> CheckIF's PATCHED_IF unsafe-address `continue` -> NOT-MATCHING ->
+            // WF IsInstalled FALSE. Core mirrors this byte-faithfully -> NotInstalled. Headless-safe:
+            // the missing file degrades to the empty pattern, never throws / ShowErrors.
+            var rom = MakeVersionedRom("BE8E01");
+            var patch = MakePatchInTempDir("p.txt", ("TYPE", "BIN"),
+                ("PATCHED_IF:$FGREP4 absent_sig.bin", "0x00 0xB5"));
+            var ex = Record.Exception(() =>
+                Assert.Equal(PatchHardCodeScanner.InstallStatusEnum.NotInstalled,
+                    PatchHardCodeScanner.EaBinInstallStatus(rom, patch)));
+            Assert.Null(ex);  // no throw + NotInstalled
         }
 
         // ====================================================================
@@ -231,14 +377,17 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
-        public void Predicate_UnknownFgrepEa_ReturnsTrue()
+        public void Predicate_UnknownXgrepEa_ReturnsTrue()
         {
-            // Regression for Copilot #1325 false-negative #2: an EA patch whose install marker uses an
-            // unresolvable $FGREP file-inclusion signature is Unknown -> the gate refuses conservatively.
+            // Regression: an EA patch whose ONLY install marker uses an un-ported $XGREP (masked GREP)
+            // signature is Unknown -> the gate refuses conservatively (soundness preserved for the macro
+            // forms Core does NOT byte-faithfully resolve). NOTE: as of s2pf-18 (#1261) a $FGREP signature
+            // is NO LONGER auto-Unknown — it resolves byte-faithfully like WF — so this regression uses
+            // $XGREP, the form that genuinely stays Unknown.
             string patchDir = StageFe8uPatchDir();
-            File.WriteAllLines(Path.Combine(patchDir, "PATCH_FGREP.txt"), new[]
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_XGREP.txt"), new[]
             {
-                "NAME=PatchFgrep", "TYPE=EA", "PATCHED_IF:$FGREP4 nope_missing.bin=0x00 0xB5", "ADDRESS=0x800100",
+                "NAME=PatchXgrep", "TYPE=EA", "PATCHED_IF:$XGREP4 0x00 X 0xB5=0x00 0xB5", "ADDRESS=0x800100",
             });
 
             CoreState.BaseDirectory = _tempDir;
@@ -246,6 +395,29 @@ namespace FEBuilderGBA.Core.Tests
             CoreState.ROM = fe8;
 
             Assert.True(RebuildProducerCore.PatchFormHasUnportableInstalledPatch(fe8));
+        }
+
+        [Fact]
+        public void Predicate_FgrepAbsentSignatureEa_ReturnsFalse_GateUseful()
+        {
+            // s2pf-18 GATE-USEFULNESS (#1261): an EA patch whose ONLY install marker is a $FGREP whose
+            // file IS present but whose post-install signature is NOT in the (vanilla-like) ROM -> NOT_FOUND
+            // -> NotInstalled (byte-faithful to WF's CheckIF `continue`). The predicate returns FALSE (the
+            // rebuild PROCEEDS). This is the synthetic analog of the 125 absent-signature $FGREP rows that
+            // formerly OVER-REFUSED vanilla FE8U.
+            string patchDir = StageFe8uPatchDir();
+            File.WriteAllBytes(Path.Combine(patchDir, "sig.bin"),
+                new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }); // present file, signature absent from the zero ROM
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_FGREP.txt"), new[]
+            {
+                "NAME=PatchFgrep", "TYPE=EA", "PATCHED_IF:$FGREP4 sig.bin=0x00 0xB5", "ADDRESS=0x800100",
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeVersionedRom("BE8E01"); // all zero -> 0xDEADBEEF appears nowhere
+            CoreState.ROM = fe8;
+
+            Assert.False(RebuildProducerCore.PatchFormHasUnportableInstalledPatch(fe8));
         }
 
         [Fact]
@@ -268,6 +440,52 @@ namespace FEBuilderGBA.Core.Tests
             CoreState.ROM = fe8;
 
             Assert.False(RebuildProducerCore.PatchFormHasUnportableInstalledPatch(fe8));
+        }
+
+        [Fact]
+        public void Predicate_FgrepFilePresent_ResolvablyNotInstalled_ReturnsFalse_GateUseful()
+        {
+            // s2pf-18 GATE-USEFULNESS (#1261): an EA/BIN patch whose ONLY install marker is a $FGREP
+            // file-inclusion now RESOLVES (the planted .bin signature lives next to the patch, in the same
+            // dir LoadPatch derives basedir from). The signature IS in the ROM (at 0x2000), but the
+            // PATCHED_IF byte window does NOT match there -> NotInstalled -> the predicate returns FALSE
+            // (the rebuild PROCEEDS). BEFORE this slice the $FGREP marker forced Unknown -> the predicate
+            // returned true and OVER-REFUSED. This is the synthetic analog of the real-FE8U gate-open.
+            string patchDir = StageFe8uPatchDir();
+            File.WriteAllBytes(Path.Combine(patchDir, "sig.bin"), new byte[] { 0xAA, 0xBB, 0xCC, 0xDD });
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_FGREP.txt"), new[]
+            {
+                "NAME=PatchFgrep", "TYPE=EA", "PATCHED_IF:$FGREP4 sig.bin=0xFF 0xFF", "ADDRESS=0x800100",
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeVersionedRom("BE8E01");
+            fe8.Data[0x2000] = 0xAA; fe8.Data[0x2001] = 0xBB; fe8.Data[0x2002] = 0xCC; fe8.Data[0x2003] = 0xDD;
+            CoreState.ROM = fe8;
+
+            Assert.False(RebuildProducerCore.PatchFormHasUnportableInstalledPatch(fe8));
+        }
+
+        [Fact]
+        public void Predicate_FgrepFilePresent_PatchedIfMatch_StillRefuses_Installed()
+        {
+            // SOUNDNESS not weakened: when the $FGREP file resolves AND the PATCHED_IF window MATCHES the
+            // ROM, the patch IS installed -> the predicate STILL returns true (the producer cannot emit an
+            // installed EA/BIN patch's bytes, so the rebuild must refuse). $FGREP resolution narrows the
+            // Unknown set; it never turns an actually-installed patch into a "safe" proceed.
+            string patchDir = StageFe8uPatchDir();
+            File.WriteAllBytes(Path.Combine(patchDir, "sig.bin"), new byte[] { 0xAA, 0xBB, 0xCC, 0xDD });
+            File.WriteAllLines(Path.Combine(patchDir, "PATCH_FGREP.txt"), new[]
+            {
+                "NAME=PatchFgrep", "TYPE=EA", "PATCHED_IF:$FGREP4 sig.bin=0xAA 0xBB", "ADDRESS=0x800100",
+            });
+
+            CoreState.BaseDirectory = _tempDir;
+            var fe8 = MakeVersionedRom("BE8E01");
+            fe8.Data[0x2000] = 0xAA; fe8.Data[0x2001] = 0xBB; fe8.Data[0x2002] = 0xCC; fe8.Data[0x2003] = 0xDD;
+            CoreState.ROM = fe8;
+
+            Assert.True(RebuildProducerCore.PatchFormHasUnportableInstalledPatch(fe8));
         }
 
         [Fact]

--- a/FEBuilderGBA.Core/PatchHardCodeScanner.cs
+++ b/FEBuilderGBA.Core/PatchHardCodeScanner.cs
@@ -392,12 +392,14 @@ namespace FEBuilderGBA
             /// <summary>An install marker matched the ROM — the patch's bytes ARE present.</summary>
             Installed = 1,
             /// <summary>The install status CANNOT be determined: at least one install marker uses a
-            /// signature this Core build cannot resolve to a real ROM offset (e.g. an <c>$XGREP</c> masked
-            /// GREP or another un-ported macro), OR a resolvable marker pointed off the ROM / failed its
-            /// byte read. (As of s2pf-18 #1261 an <c>$FGREP &lt;file&gt;</c> file-inclusion is faithfully
-            /// resolved — it only yields Unknown when its file is MISSING/empty, i.e. the pattern is empty
-            /// and the search returns NOT_FOUND.) Treated as possibly-installed by the safe-reject gate
-            /// (conservative: never claim "safe" when the patch might be present).</summary>
+            /// signature this Core build does NOT resolve byte-faithfully to WinForms (e.g. an
+            /// <c>$XGREP</c> masked GREP, <c>$FREEAREA</c>, or another un-ported macro) and the resolver
+            /// returned an unsafe offset, OR a resolvable marker's comparison window pointed off the ROM /
+            /// failed its byte read. (As of s2pf-18 #1261 the byte-faithful <c>$GREP</c>/<c>$FGREP</c>
+            /// family is NOT a source of Unknown: a NOT_FOUND grep — including a MISSING/empty <c>$FGREP</c>
+            /// file, which yields an empty pattern — is treated as NOT-MATCHING (-&gt; NotInstalled when no
+            /// other marker matches), mirroring WF's CheckIF exactly.) Treated as possibly-installed by the
+            /// safe-reject gate (conservative: never claim "safe" when the patch might be present).</summary>
             Unknown = 2,
         }
 
@@ -412,15 +414,19 @@ namespace FEBuilderGBA
         /// <c>IF</c>/<c>IFNOT</c>/<c>CONFLICT_IF</c> are prerequisites, not install markers, and never make
         /// WF's <c>IsInstalled</c> true. Per marker:
         /// <list type="bullet">
-        ///   <item>address UNRESOLVABLE (<c>convertBinAddressString</c> -&gt; unsafe/NOT_FOUND, e.g. an
-        ///   <c>$XGREP</c> this Core build does not port, or an <c>$FGREP &lt;file&gt;</c> whose file is
-        ///   MISSING so the search pattern is empty) -&gt; <see cref="InstallStatusEnum.Unknown"/> (the gate
-        ///   refuses conservatively). A <c>$FGREP</c> whose file IS present resolves to a real offset and is
-        ///   classified Installed/NotInstalled like any other marker (s2pf-18 #1261).</item>
+        ///   <item>BYTE-FAITHFUL <c>$GREP</c>/<c>$FGREP</c> family whose grep returns NOT_FOUND (the
+        ///   post-install signature is absent — INCLUDING a MISSING/empty <c>$FGREP</c> file, whose empty
+        ///   pattern grep's to NOT_FOUND) -&gt; NOT-MATCHING (does NOT make the patch Unknown), exactly
+        ///   mirroring WF's CheckIF unsafe-address <c>continue</c> (PatchForm.cs:4416-4433). If no marker
+        ///   matches, the patch is NotInstalled (s2pf-18 #1261 — the gate-usefulness narrowing).</item>
+        ///   <item>address UNRESOLVABLE via a NON-faithful form (<c>convertBinAddressString</c> -&gt;
+        ///   unsafe/NOT_FOUND for an <c>$XGREP</c>/<c>$FREEAREA</c> or another un-ported macro this Core
+        ///   build does not resolve byte-faithfully) -&gt; <see cref="InstallStatusEnum.Unknown"/> (the gate
+        ///   refuses conservatively).</item>
         ///   <item><c>PATCHED_IF</c> whose bytes MATCH the ROM, or <c>PATCHED_IFNOT</c> whose bytes MISMATCH
         ///   -&gt; <see cref="InstallStatusEnum.Installed"/> (mirrors the WF detail-string "PATCHED_IF" rule).</item>
         /// </list>
-        /// If every marker is resolvable and none indicates installed -&gt;
+        /// If every marker is resolvable (or a faithful-grep not-matching) and none indicates installed -&gt;
         /// <see cref="InstallStatusEnum.NotInstalled"/>. A patch with NO install markers (an empty but
         /// non-null Param) is <see cref="InstallStatusEnum.NotInstalled"/> — inheriting WF's own blind spot
         /// (WF's <c>IsInstalled</c> is likewise false for a marker-less patch). A <c>null</c> Param (which
@@ -429,9 +435,12 @@ namespace FEBuilderGBA
         /// </para>
         /// <para>
         /// <b>SOUNDNESS.</b> This is a deliberate OVER-approximation: it returns NotInstalled only when it
-        /// can PROVE (resolvably) the patch is absent. Any doubt (an unresolvable marker) yields Unknown, so
-        /// the safe-reject gate never says "safe" while the patch could be present. The only residual gap is
-        /// the WF-inherited marker-less case, which is documented and identical to WF.
+        /// can PROVE the patch absent — either by a resolvable byte mismatch, or by a BYTE-FAITHFUL
+        /// <c>$GREP</c>/<c>$FGREP</c> NOT_FOUND (whose result is identical to WF's, so Core says NotInstalled
+        /// only where WF does — a false-negative is IMPOSSIBLE). Any other doubt (an un-ported macro
+        /// resolving unsafe) yields Unknown, so the safe-reject gate never says "safe" while the patch could
+        /// be present. The only residual gap is the WF-inherited marker-less case, documented and identical
+        /// to WF.
         /// </para>
         /// The ROM is passed EXPLICITLY (no CoreState.ROM read), honoring this file's header guarantee.
         /// </summary>
@@ -573,13 +582,18 @@ namespace FEBuilderGBA
         /// <see cref="MakeFGrepData"/> reads the basedir-relative file's bytes VERBATIM as the search pattern
         /// (a port of WF <c>MakeGrepData(value, basedir)</c>). It resolves to a real ROM offset, or — on a
         /// missing/unreadable/empty file — to the empty pattern, which <see cref="U.Grep"/> turns into
-        /// NOT_FOUND (the caller's safety-offset check then yields Unknown). Neither path is a wrong-but-safe
-        /// offset, so <c>$FGREP</c> is NO LONGER Unknown-outright — this is what makes the gate USEFUL on
-        /// vanilla FE8U. (Soundness preserved: a false-NEGATIVE is still impossible.)
+        /// NOT_FOUND. Neither path is a wrong-but-safe offset, so <c>$FGREP</c> is NO LONGER Unknown-outright;
+        /// its NOT_FOUND is then handled by the caller as a byte-faithful GREP/FGREP NOT_FOUND — treated as
+        /// NOT-MATCHING (-&gt; NotInstalled when nothing else matches), via
+        /// <see cref="IsFaithfulGrepFamilyInstallAddress"/>, NOT Unknown. This is what makes the gate USEFUL
+        /// on vanilla FE8U. (Soundness preserved: Core's grep is byte-identical to WF's, so a false-NEGATIVE
+        /// is impossible.)
         /// </para>
         /// Every other form (plain numeric, <c>$0x</c> pointer, inline <c>$GREP</c>/<c>$GREP_ENABLE_POINTER</c>,
-        /// <c>$P32</c>) either resolves faithfully or maps to NOT_FOUND, which the caller already treats as
-        /// Unknown via the safety-offset check. This is deliberately conservative — when in doubt, Unknown.
+        /// <c>$P32</c>) either resolves faithfully or maps to NOT_FOUND. A NOT_FOUND from the byte-faithful
+        /// <c>$GREP</c> family is not-matching (see <see cref="IsFaithfulGrepFamilyInstallAddress"/>); a
+        /// NOT_FOUND from a non-faithful pointer/macro form stays Unknown via the safety-offset check. This
+        /// is deliberately conservative — when in doubt, Unknown.
         /// </summary>
         static bool IsFaithfullyResolvableInstallAddress(string addrstring)
         {
@@ -721,10 +735,12 @@ namespace FEBuilderGBA
             // everything AFTER the first space is the basedir-relative filename, and
             // the file's raw bytes ARE the search pattern. A missing/unreadable file
             // yields an empty pattern (WF returns new byte[0]) -> U.Grep returns
-            // NOT_FOUND, which the install-detection caller treats as "cannot prove
-            // present" (Unknown) — never a wrong-but-safe offset. Headless-safe: a
-            // bad path/IO error degrades to the empty pattern, never throws/ShowError
-            // (the inline-safe-parse discipline this file guarantees; s2pf-18 #1261).
+            // NOT_FOUND. For the byte-faithful GREP/FGREP family, EaBinInstallStatus
+            // treats that NOT_FOUND as NOT-MATCHING (-> NotInstalled when nothing else
+            // matches), exactly as WF's CheckIF does — NOT Unknown (s2pf-18 #1261).
+            // Never a wrong-but-safe offset. Headless-safe: a bad path/IO error degrades
+            // to the empty pattern, never throws/ShowError (the inline-safe-parse
+            // discipline this file guarantees).
             if (isFile)
             {
                 return MakeFGrepData(value, basedir);
@@ -752,9 +768,16 @@ namespace FEBuilderGBA
         // (FEBuilderGBA/PatchForm.cs:3222) — the $FGREP file-inclusion pattern source.
         // WF: firstSpace<0 -> new byte[0]; filename = everything after the first space;
         // fullpath = Path.Combine(basedir, filename); !File.Exists -> new byte[0];
-        // else File.ReadAllBytes(fullpath). Headless-safe: a missing basedir or any IO
-        // failure degrades to the empty pattern (never throws), preserving WF's
-        // missing-file outcome (empty pattern -> U.Grep NOT_FOUND).
+        // else File.ReadAllBytes(fullpath).
+        //
+        // FAITHFULNESS (Copilot PR #1336 review): an EMPTY basedir is NOT short-circuited
+        // here — WF still does Path.Combine("", filename) == filename and would read the
+        // file from the CURRENT directory. We mirror that exactly (the install-detection
+        // caller always passes the patch dir, so empty basedir only arises for a synthetic
+        // PatchFileName with no directory). Only `null` is normalized to "" so Path.Combine
+        // cannot throw. Headless-safe: any IO failure / bad path degrades to the empty
+        // pattern (try/catch), never throws — preserving WF's missing-file outcome (empty
+        // pattern -> U.Grep NOT_FOUND).
         static byte[] MakeFGrepData(string value, string basedir)
         {
             int firstSp = value.IndexOf(' ');
@@ -763,15 +786,12 @@ namespace FEBuilderGBA
                 return new byte[0];
             }
             string filename = value.Substring(firstSp + 1);
-            if (string.IsNullOrEmpty(filename) || string.IsNullOrEmpty(basedir))
-            {
-                // basedir is the patch dir (always set by the install-detection caller);
-                // guard a synthetic empty basedir so Path.Combine cannot throw.
-                return new byte[0];
-            }
+            // WF passes `filename` straight to Path.Combine — even "" (Path.Combine(dir, "")
+            // returns dir, which File.Exists rejects) — so do NOT special-case an empty
+            // filename; only the null guard keeps Path.Combine from throwing.
             try
             {
-                string fullpath = Path.Combine(basedir, filename);
+                string fullpath = Path.Combine(basedir ?? "", filename ?? "");
                 if (!File.Exists(fullpath))
                 {
                     return new byte[0];

--- a/FEBuilderGBA.Core/PatchHardCodeScanner.cs
+++ b/FEBuilderGBA.Core/PatchHardCodeScanner.cs
@@ -392,9 +392,12 @@ namespace FEBuilderGBA
             /// <summary>An install marker matched the ROM — the patch's bytes ARE present.</summary>
             Installed = 1,
             /// <summary>The install status CANNOT be determined: at least one install marker uses a
-            /// signature this Core build cannot resolve (e.g. an <c>$FGREP &lt;file&gt;</c> file-inclusion,
-            /// <c>$XGREP</c>, or another un-ported macro). Treated as possibly-installed by the safe-reject
-            /// gate (conservative: never claim "safe" when the patch might be present).</summary>
+            /// signature this Core build cannot resolve to a real ROM offset (e.g. an <c>$XGREP</c> masked
+            /// GREP or another un-ported macro), OR a resolvable marker pointed off the ROM / failed its
+            /// byte read. (As of s2pf-18 #1261 an <c>$FGREP &lt;file&gt;</c> file-inclusion is faithfully
+            /// resolved — it only yields Unknown when its file is MISSING/empty, i.e. the pattern is empty
+            /// and the search returns NOT_FOUND.) Treated as possibly-installed by the safe-reject gate
+            /// (conservative: never claim "safe" when the patch might be present).</summary>
             Unknown = 2,
         }
 
@@ -410,8 +413,10 @@ namespace FEBuilderGBA
         /// WF's <c>IsInstalled</c> true. Per marker:
         /// <list type="bullet">
         ///   <item>address UNRESOLVABLE (<c>convertBinAddressString</c> -&gt; unsafe/NOT_FOUND, e.g. an
-        ///   <c>$FGREP &lt;file&gt;</c> file-inclusion or <c>$XGREP</c> this Core build does not port) -&gt;
-        ///   <see cref="InstallStatusEnum.Unknown"/> (the gate refuses conservatively).</item>
+        ///   <c>$XGREP</c> this Core build does not port, or an <c>$FGREP &lt;file&gt;</c> whose file is
+        ///   MISSING so the search pattern is empty) -&gt; <see cref="InstallStatusEnum.Unknown"/> (the gate
+        ///   refuses conservatively). A <c>$FGREP</c> whose file IS present resolves to a real offset and is
+        ///   classified Installed/NotInstalled like any other marker (s2pf-18 #1261).</item>
         ///   <item><c>PATCHED_IF</c> whose bytes MATCH the ROM, or <c>PATCHED_IFNOT</c> whose bytes MISMATCH
         ///   -&gt; <see cref="InstallStatusEnum.Installed"/> (mirrors the WF detail-string "PATCHED_IF" rule).</item>
         /// </list>
@@ -458,12 +463,19 @@ namespace FEBuilderGBA
                 else continue;
 
                 // SOUNDNESS — detect UNFAITHFULLY-resolvable signatures BEFORE trusting the resolved
-                // address. convertBinAddressString does NOT fail cleanly for the $FGREP <file>
-                // file-inclusion form: MakeGrepData ignores the file and mis-parses the filename token as
-                // a hex byte, so Grep returns a WRONG-but-safe offset (NOT NOT_FOUND). Reading bytes at
-                // that garbage offset could spuriously report Installed or NotInstalled — neither sound.
-                // So any marker whose addrstring is a form this Core build cannot faithfully resolve
-                // ($FGREP / $XGREP / $FREEAREA) is Unknown OUTRIGHT, regardless of what the resolver returns.
+                // address. Some macro forms convertBinAddressString cannot resolve faithfully AND cannot
+                // reject cleanly (it would return a WRONG-but-safe offset, NOT NOT_FOUND): reading bytes at
+                // that garbage offset could spuriously report Installed or NotInstalled — neither sound. So
+                // any marker whose addrstring is such a form ($XGREP / $FREEAREA) is Unknown OUTRIGHT,
+                // regardless of what the resolver returns.
+                //   $FGREP <file> (file-inclusion GREP) is NO LONGER in that set as of s2pf-18 (#1261):
+                //   convertBinAddressString now reads the referenced file's bytes VERBATIM as the search
+                //   pattern (MakeFGrepData — a faithful port of WF MakeGrepData(value, basedir)). Together
+                //   with inline $GREP it is the FAITHFUL GREP family — byte-identical to WF's resolution —
+                //   so its NOT_FOUND is handled below (not-matching, mirroring WF), NOT Unknown-outright.
+                //   This is what makes the gate USEFUL on vanilla FE8U: all 159 of FE8U's blocking EA/BIN
+                //   markers are absent-signature $GREP/$FGREP rows (125 $FGREP + 34 inline $GREP) that now
+                //   resolve to NotInstalled instead of forcing Unknown.
                 if (!IsFaithfullyResolvableInstallAddress(addrstring))
                 {
                     sawUnknown = true;
@@ -474,11 +486,28 @@ namespace FEBuilderGBA
                 uint address = convertBinAddressString(rom, addrstring, basedir);
                 if (!U.isSafetyOffset(address, rom))
                 {
-                    // Resolver returned NOT_FOUND / an unsafe offset (e.g. an unsupported macro, a $GREP
-                    // whose inline pattern was not found, or a $0x pointer into freespace) — cannot prove
-                    // this marker absent. Remember it and keep scanning: a LATER resolvable marker proving
-                    // Installed still wins (more precise), but if no marker proves Installed we fall back to
-                    // Unknown for the whole patch.
+                    // The resolved address is NOT_FOUND / unsafe. What that MEANS depends on the marker form:
+                    //
+                    //   GREP / FGREP family (faithfully ported — MakeGrepData / MakeFGrepData + U.Grep are
+                    //   VERBATIM ports of WF): a NOT_FOUND here means the post-install byte SIGNATURE is
+                    //   ABSENT from the ROM. WF's CheckIF treats exactly this case as NOT-MATCHING: a
+                    //   PATCHED_IF/PATCHED_IFNOT whose address is unsafe is in the `isnot` branch and hits
+                    //   `continue` (PatchForm.cs:4416-4433), contributing nothing — so WF's IsInstalled is
+                    //   FALSE for a patch whose only markers are absent-signature GREPs. Because Core's grep
+                    //   result is BYTE-IDENTICAL to WF's for this family, Core can faithfully treat it as
+                    //   not-matching too (skip WITHOUT setting sawUnknown). This is the s2pf-18 narrowing
+                    //   (#1261) that makes the gate USEFUL on vanilla FE8U: all 159 of FE8U's blocking EA/BIN
+                    //   markers are absent-signature $GREP/$FGREP rows -> now NotInstalled, matching WF.
+                    //   FALSE-NEGATIVE IMPOSSIBLE: Core NOT_FOUND <=> WF NOT_FOUND for this family, so Core
+                    //   can only say NotInstalled exactly where WF does.
+                    //
+                    //   Any OTHER form (an unsupported macro, $XGREP/$FREEAREA already filtered above, or a
+                    //   $0x/$P32 pointer into freespace) is NOT byte-faithfully resolved by this Core build,
+                    //   so a NOT_FOUND there does NOT prove the signature absent -> stay Unknown.
+                    if (IsFaithfulGrepFamilyInstallAddress(addrstring))
+                    {
+                        continue; // faithful absent-signature GREP/FGREP -> not-matching (mirrors WF)
+                    }
                     sawUnknown = true;
                     continue;
                 }
@@ -530,15 +559,24 @@ namespace FEBuilderGBA
 
         /// <summary>
         /// Can <paramref name="addrstring"/> (an install-marker address) be resolved FAITHFULLY by this
-        /// Core build's <see cref="convertBinAddressString"/>? Returns <c>false</c> for the macro forms the
-        /// resolver does NOT port faithfully and which it cannot reject cleanly:
+        /// Core build's <see cref="convertBinAddressString"/>? Returns <c>false</c> ONLY for the macro forms
+        /// the resolver does NOT port faithfully AND cannot reject cleanly (it would return a WRONG-but-safe
+        /// offset instead of NOT_FOUND), so the caller must treat them as Unknown OUTRIGHT:
         /// <list type="bullet">
-        ///   <item><c>$FGREP...</c> — file-inclusion GREP. <see cref="MakeGrepData"/> ignores the referenced
-        ///   file and mis-parses the filename as a hex byte, so the resolver returns a WRONG-but-safe offset
-        ///   (not NOT_FOUND). Reading bytes there is meaningless, so the marker must be treated as Unknown.</item>
-        ///   <item><c>$XGREP...</c> — masked GREP, not ported (resolver returns NOT_FOUND).</item>
-        ///   <item><c>$FREEAREA</c> — resolver returns 0 under the install path; not a real byte marker.</item>
+        ///   <item><c>$XGREP...</c> — masked/wildcard GREP, not ported (the install-path
+        ///   <see cref="convertBinAddressString"/> returns NOT_FOUND for it; listed here belt-and-suspenders
+        ///   so it is Unknown even if a future resolver change made it return a non-NOT_FOUND offset).</item>
+        ///   <item><c>$FREEAREA</c> — the install path returns 0 (an unsafe offset); not a real byte marker.</item>
         /// </list>
+        /// <para>
+        /// <c>$FGREP &lt;file&gt;</c> (file-inclusion GREP) is FAITHFULLY resolvable as of s2pf-18 (#1261):
+        /// <see cref="MakeFGrepData"/> reads the basedir-relative file's bytes VERBATIM as the search pattern
+        /// (a port of WF <c>MakeGrepData(value, basedir)</c>). It resolves to a real ROM offset, or — on a
+        /// missing/unreadable/empty file — to the empty pattern, which <see cref="U.Grep"/> turns into
+        /// NOT_FOUND (the caller's safety-offset check then yields Unknown). Neither path is a wrong-but-safe
+        /// offset, so <c>$FGREP</c> is NO LONGER Unknown-outright — this is what makes the gate USEFUL on
+        /// vanilla FE8U. (Soundness preserved: a false-NEGATIVE is still impossible.)
+        /// </para>
         /// Every other form (plain numeric, <c>$0x</c> pointer, inline <c>$GREP</c>/<c>$GREP_ENABLE_POINTER</c>,
         /// <c>$P32</c>) either resolves faithfully or maps to NOT_FOUND, which the caller already treats as
         /// Unknown via the safety-offset check. This is deliberately conservative — when in doubt, Unknown.
@@ -551,13 +589,37 @@ namespace FEBuilderGBA
             string value = addrstring.Substring(1);
             if (value.Length == 0) return false;
 
-            // $FGREP / $XGREP — the un-ported GREP variants (file-inclusion / masked). Match the same
-            // family prefix convertBinAddressString uses; the F/X flag is the un-ported one.
-            if (value.StartsWith("FGREP", StringComparison.Ordinal)) return false;
+            // $XGREP — masked GREP, not ported. $FREEAREA — write-time allocator (install path -> 0).
+            // $FGREP is NOT here: MakeFGrepData now reads the file VERBATIM, so it resolves faithfully or
+            // cleanly maps a missing file to NOT_FOUND (the caller's safety check -> Unknown). s2pf-18 #1261.
             if (value.StartsWith("XGREP", StringComparison.Ordinal)) return false;
             if (value.StartsWith("FREEAREA", StringComparison.Ordinal)) return false;
 
             return true;
+        }
+
+        /// <summary>
+        /// Is <paramref name="addrstring"/> a <c>$GREP</c> or <c>$FGREP</c> install-marker address — the
+        /// byte-signature GREP family this Core build resolves BYTE-IDENTICALLY to WinForms
+        /// (<see cref="MakeGrepData"/> / <see cref="MakeFGrepData"/> + <see cref="U.Grep"/>/<see cref="U.GrepEnd"/>
+        /// are all verbatim ports)? For this family ONLY, a NOT_FOUND grep result faithfully means "the
+        /// post-install signature is ABSENT" — exactly the case WF's <c>CheckIF</c> treats as NOT-MATCHING
+        /// (the unsafe-address <c>continue</c> at PatchForm.cs:4416-4433) — so the caller may classify it as
+        /// not-installed for that marker WITHOUT going Unknown. (s2pf-18 #1261, the gate-usefulness narrowing.)
+        /// <para>
+        /// EXCLUDES <c>$XGREP</c> (masked GREP — not ported; its NOT_FOUND is NOT byte-faithful, so a NOT_FOUND
+        /// there must stay Unknown to keep the false-negative impossible). Also excludes every non-GREP form;
+        /// a NOT_FOUND from a pointer/macro form does NOT prove a signature absent.
+        /// </para>
+        /// </summary>
+        static bool IsFaithfulGrepFamilyInstallAddress(string addrstring)
+        {
+            if (string.IsNullOrEmpty(addrstring) || addrstring[0] != '$') return false;
+            string value = addrstring.Substring(1);
+            // $GREP... or $FGREP... (NOT $XGREP — masked GREP is not byte-faithfully ported).
+            if (value.StartsWith("GREP", StringComparison.Ordinal)) return true;   // inline hex GREP
+            if (value.StartsWith("FGREP", StringComparison.Ordinal)) return true;  // file-inclusion GREP
+            return false;
         }
 
         // ---- convertBinAddressString (~:3000) ----------------------------------
@@ -602,7 +664,10 @@ namespace FEBuilderGBA
                 return 0;
             }
 
-            // GREP / FGREP family (XGREP needs a mask builder not ported here).
+            // GREP family. $GREP = inline hex pattern; $FGREP = file-inclusion (the
+            // pattern bytes come from the basedir-relative file — MakeFGrepData, ported
+            // VERBATIM from WF in s2pf-18 #1261). $XGREP (masked) still needs a mask
+            // builder not ported here -> NOT_FOUND.
             var m = RegexCache.Match(value, @"^(F|X)?GREP([0-9]+)(ENDA|END)?\+?([0-9]+)? ");
             if (m.Groups.Count >= 5 && m.Success)
             {
@@ -651,6 +716,21 @@ namespace FEBuilderGBA
 
         static byte[] MakeGrepData(string value, string basedir, bool isFile)
         {
+            // $FGREP <file> — file-inclusion GREP. VERBATIM port of the WinForms
+            // MakeGrepData(value, basedir) overload (FEBuilderGBA/PatchForm.cs:3222):
+            // everything AFTER the first space is the basedir-relative filename, and
+            // the file's raw bytes ARE the search pattern. A missing/unreadable file
+            // yields an empty pattern (WF returns new byte[0]) -> U.Grep returns
+            // NOT_FOUND, which the install-detection caller treats as "cannot prove
+            // present" (Unknown) — never a wrong-but-safe offset. Headless-safe: a
+            // bad path/IO error degrades to the empty pattern, never throws/ShowError
+            // (the inline-safe-parse discipline this file guarantees; s2pf-18 #1261).
+            if (isFile)
+            {
+                return MakeFGrepData(value, basedir);
+            }
+
+            // $GREP <bytes...> — inline hex byte pattern (unchanged).
             string[] sp = value.Split(' ');
             var grepdata = new List<byte>();
             for (int i = 1; i < sp.Length; i++)
@@ -658,16 +738,50 @@ namespace FEBuilderGBA
                 if (sp[i].Length == 0) continue;
                 if (sp[i][0] == '$')
                 {
-                    // Macro tokens inside GREP (e.g. file inclusions) are not
-                    // ported; treat as not-found so the gate excludes safely.
+                    // Macro tokens inside an INLINE GREP (not the $FGREP file form,
+                    // which never reaches here) are not ported; treat as not-found so
+                    // the gate excludes safely.
                     return null;
                 }
                 grepdata.Add((byte)U.atoi0x(sp[i]));
             }
-            // The FGREP file-inclusion form is not ported; only inline byte
-            // patterns are honored. (isFile/basedir reserved for parity.)
-            _ = isFile; _ = basedir;
             return grepdata.ToArray();
+        }
+
+        // VERBATIM port of WinForms PatchForm.MakeGrepData(value, basedir)
+        // (FEBuilderGBA/PatchForm.cs:3222) — the $FGREP file-inclusion pattern source.
+        // WF: firstSpace<0 -> new byte[0]; filename = everything after the first space;
+        // fullpath = Path.Combine(basedir, filename); !File.Exists -> new byte[0];
+        // else File.ReadAllBytes(fullpath). Headless-safe: a missing basedir or any IO
+        // failure degrades to the empty pattern (never throws), preserving WF's
+        // missing-file outcome (empty pattern -> U.Grep NOT_FOUND).
+        static byte[] MakeFGrepData(string value, string basedir)
+        {
+            int firstSp = value.IndexOf(' ');
+            if (firstSp < 0)
+            {
+                return new byte[0];
+            }
+            string filename = value.Substring(firstSp + 1);
+            if (string.IsNullOrEmpty(filename) || string.IsNullOrEmpty(basedir))
+            {
+                // basedir is the patch dir (always set by the install-detection caller);
+                // guard a synthetic empty basedir so Path.Combine cannot throw.
+                return new byte[0];
+            }
+            try
+            {
+                string fullpath = Path.Combine(basedir, filename);
+                if (!File.Exists(fullpath))
+                {
+                    return new byte[0];
+                }
+                return File.ReadAllBytes(fullpath);
+            }
+            catch
+            {
+                return new byte[0];
+            }
         }
 
         static uint ReadPointer(ROM rom, string value, uint plus)


### PR DESCRIPTION
## Summary

Part of #1261 (option-B PatchForm epic), slice **s2pf-18**: make the (already-open, s2pf-17) ROM-rebuild gate **USEFUL** on vanilla FE8U by resolving `$FGREP` file-inclusion install markers — and the byte-faithful `$GREP`/`$FGREP` family generally — deterministically, so `EaBinInstallStatus` is precise instead of conservatively `Unknown`.

Faithful WinForms→Core. Core-only, no GUI.

## Problem

The s2pf-12 EA/BIN safe-reject backstop (`PatchFormHasUnportableInstalledPatch`) refuses a rebuild on any EA/BIN patch whose install status is `Installed` **or** `Unknown`. Its install-detection path classified `$FGREP`/inline-`$GREP` install markers as `Unknown` (the `$FGREP` file was never read; an absent grep signature returned `NOT_FOUND` → `Unknown`). On vanilla FE8U that over-refused — **159** EA/BIN markers (125 `$FGREP` + 34 inline `$GREP`) all became `Unknown`, so `MakeWithProducer` refused even though FE8U installs **0** unportable EA/BIN patches.

## Change

1. **`$FGREP` file-inclusion read** — `PatchHardCodeScanner.MakeFGrepData` ported VERBATIM from WF `PatchForm.MakeGrepData(value, basedir)` (`FEBuilderGBA/PatchForm.cs:3222`): everything after the first space is the basedir-relative filename; the file's raw bytes are the search pattern; missing/unreadable file → empty pattern. Headless-safe (`try/catch` → empty, never throws/`ShowError`). `$FGREP` removed from the `Unknown`-outright set.
2. **Byte-faithful GREP/FGREP `NOT_FOUND` = not-matching** — for the `$GREP`/`$FGREP` family (`MakeGrepData`/`MakeFGrepData` + `U.Grep` are verbatim WF ports), a `NOT_FOUND` grep now means "post-install signature ABSENT" → **not-matching** (NotInstalled), exactly as WF's `CheckIF` does (a `PATCHED_IF`/`PATCHED_IFNOT` with an unsafe address is in the `isnot` branch → `continue`, `PatchForm.cs:4416-4433`, so WF `IsInstalled` is false). New helper `IsFaithfulGrepFamilyInstallAddress` scopes the narrowing to `$GREP`/`$FGREP` only.

## Empirical result (real vanilla FE8U + `config/patch2`)

- Diagnostic: **`TOTAL blocking: Installed=0 Unknown=0`** (was `Unknown=159`).
- `PatchFormHasUnportableInstalledPatch(FE8U) == false`.
- **`MakeWithProducer` now PROCEEDS** — writes the `.rebuild` manifest. The s2pf-17 gate-open test logs: `MakeWithProducer on vanilla FE8U PROCEEDED (manifest written)`.

## Soundness preserved (false-negative still IMPOSSIBLE)

Core's grep is **byte-identical** to WF's for the `$GREP`/`$FGREP` family, so Core can only say `NotInstalled` exactly where WF does — a false-negative ("safe" while a patch is actually installed) remains impossible. The un-ported macros (`$XGREP` masked GREP, `$FREEAREA`) **STAY `Unknown` → still over-refuse** (conservative). Only narrowed `Unknown` by the byte-faithful GREP/FGREP amount.

## Parity unchanged (Core == WF, gap = 0)

This slice changes install-**DETECTION** (the gate), not the emitted producer entries. Confirmed exact: `WF total=591, Core total=591, Core-extras=0, gap=0`.

## Scope (Ref)

Part of #1261. Follow-up (gate-usefulness, separate slice): `$XGREP` masked-GREP install-resolution + `$FREEAREA` are the residual `Unknown` sources for OTHER ROMs (none block vanilla FE8U).

## Test plan

- [x] `EaBinInstallStatus` — `$FGREP` file present, `PATCHED_IF` window MATCHES ROM → **Installed**
- [x] `EaBinInstallStatus` — `$FGREP` file present, `PATCHED_IF` window MISMATCHES → **NotInstalled**
- [x] `EaBinInstallStatus` — `$FGREP` file present, `PATCHED_IFNOT` window mismatches → **Installed**
- [x] `EaBinInstallStatus` — `$FGREP` file present, signature absent from ROM → **NotInstalled** (byte-faithful to WF)
- [x] `EaBinInstallStatus` — inline `$GREP` absent-signature → **NotInstalled**
- [x] `EaBinInstallStatus` — `$FGREP` file MISSING → **NotInstalled**, no throw (headless-safe, mirrors WF empty pattern)
- [x] `EaBinInstallStatus` — `$XGREP` → **Unknown** (soundness preserved for un-ported macros)
- [x] Predicate — `$FGREP` absent-signature EA → **false** (gate proceeds); `$FGREP`-match installed → **true** (still refuses); `$XGREP` → **true**
- [x] Real vanilla FE8U (skip-if-no-ROM) — `PatchFormHasUnportableInstalledPatch == false` AND `MakeWithProducer` **PROCEEDS** (manifest written)
- [x] WF parity (real FE8U) — Core == WF exact, `gap=0`, `Core-extras=0` (unchanged)
- [x] `dotnet build FEBuilderGBA.sln` — clean (0 errors)
- [x] Core.Tests `--filter RebuildProducer` — 736 pass; `--filter PatchHardCode`/`PatchSafeReject`/`PatchMacroAddress` — 94 pass
- [x] Full Core.Tests (CI-like, no ROM) — 5232 pass / 0 fail / 6 skip

> The ROM-triggered data-path producer divergences (`WF-only=68` / `Item-defer`) are **pre-existing env-only** failures — reproduced on the clean baseline with my changes stashed, and skip in CI (`roms/FE8U.gba` is gitignored/absent). Not from this change.

## Proof (CLI / test output — non-GUI Core change)

```
[s2pf-17] MakeWithProducer on vanilla FE8U PROCEEDED (manifest written)
[diag]    TOTAL blocking: Installed=0 Unknown=0
[s2pf-17] PatchForm parity: WF total=591, Core total=591, Core-extras=0, gap=0
Core.Tests RebuildProducerPatchSafeReject: Passed 31, Failed 0
Full Core.Tests (no ROM): Passed 5232, Failed 0, Skipped 6
```

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8[1m]
