### PR TITLE
feat(decomp): in-place source-backed shop-list writer (--write-shop) (Refs #1347)

### DIFF
--- a/FEBuilderGBA.CLI/Program.cs
+++ b/FEBuilderGBA.CLI/Program.cs
@@ -313,6 +313,15 @@ namespace FEBuilderGBA.CLI
                 return RunWriteSource(argsDic);
             }
 
+            // --write-shop --project=<dir> (--shop-addr=0x.. | --symbol=<name>) --items=<csv>:
+            // in-place source-backed shop-list writer (#1347) — rewrite the owning u16
+            // ITEM_NONE-terminated C list instead of mutating the preview ROM. Must precede
+            // the bare --project rom-info fallthrough or it is swallowed by RunRomInfo.
+            if (argsDic.ContainsKey("--write-shop"))
+            {
+                return RunWriteShop(argsDic);
+            }
+
             // --build-project --project=<dir> [--reload] [--yes] [--timeout=<ms>]:
             // run the decomp project's declared build command + optionally reload
             // the built ROM into CoreState (#1134). Must precede the bare --project
@@ -549,6 +558,11 @@ namespace FEBuilderGBA.CLI
             Console.WriteLine("    --field=<name>         C/JSON field name to change (must be declared on the owner; REPEATABLE — pair each --field with a following --value; other flags may appear between them; a 2nd --field before its --value, or an unpaired --field/--value, is a usage error)");
             Console.WriteLine("    --value=<int>          New value for the preceding --field (0x hex or decimal; signed fields take the two's-complement magnitude; REPEATABLE)");
             Console.WriteLine("    --out-diff=<path>      Optional: write a unified-diff-ish before/after of the changed element");
+            Console.WriteLine("  --write-shop             Rewrite an owning u16 ITEM_NONE-terminated shop LIST in source (requires --project, --items, and one of --shop-addr/--symbol)");
+            Console.WriteLine("    --project=<dir>        Decomp project directory (manifest must declare a u16-list list-owner for the shop's symbol)");
+            Console.WriteLine("    --shop-addr=<hex>      Shop item-list ROM OFFSET; resolved to a list symbol via the project .map/.elf/.sym + manifest list-owner");
+            Console.WriteLine("    --symbol=<name>        OR look up the list-owner directly by name (skips the address resolver)");
+            Console.WriteLine("    --items=<csv>          New list as id:qty pairs (e.g. 0x01:5,0x02:3); id/qty hex-or-dec 0..255, id!=0; empty = emptied shop (just terminator)");
             Console.WriteLine("  --build-project          Run the decomp project's declared build command (requires --project; gated behind --yes)");
             Console.WriteLine("    --project=<dir>        Decomp project directory containing febuilder.project.json with a build section");
             Console.WriteLine("    --yes                  Required to actually execute the build command (explicit opt-in gate)");
@@ -620,6 +634,8 @@ namespace FEBuilderGBA.CLI
             Console.WriteLine("  FEBuilderGBA.CLI --write-source --project=decomp/ --table=support_units --id=0 --field=b0 --value=6 --field=b1 --value=3   (leading prefix — safe with minimal fields[])");
             Console.WriteLine("  FEBuilderGBA.CLI --write-source --project=decomp/ --table=support_attributes --id=1 --field=b1 --value=2   (assumes owner declares b0..b1 or uses .bN= initializers)");
             Console.WriteLine("  FEBuilderGBA.CLI --write-source --project=decomp/ --table=support_talks --id=0 --field=w4 --value=0x0A12   (assumes owner declares the ordered prefix up to w4 or uses .bN= initializers)");
+            Console.WriteLine("  FEBuilderGBA.CLI --write-shop --project=decomp/ --symbol=ItemList_WM_FluornArmory --items=0x01:5,0x02:3");
+            Console.WriteLine("  FEBuilderGBA.CLI --write-shop --project=decomp/ --shop-addr=0xB2A18 --items=0x16:1   (resolves the shop symbol from the project .map/.elf/.sym)");
             Console.WriteLine("  FEBuilderGBA.CLI --build-project --project=decomp/ --reload --yes");
             Console.WriteLine("  FEBuilderGBA.CLI --export-data --rom=rom.gba --table=units --out=units.tsv");
             Console.WriteLine("  FEBuilderGBA.CLI --export-data --rom=rom.gba --table=all --out=data");
@@ -5117,6 +5133,154 @@ namespace FEBuilderGBA.CLI
                     Console.Error.WriteLine($"Error: {res.Message}");
                     return 1;
             }
+        }
+
+        /// <summary>
+        /// CLI entry for the in-place source-backed SHOP-LIST writer (#1347). Opens a decomp
+        /// project, resolves the owning u16-list declaration (by <c>--symbol</c> directly, or
+        /// by resolving <c>--shop-addr</c> to a list symbol via the project's merged
+        /// .map/.elf/.sym + manifest list-owner), then rewrites the owning variable-length
+        /// <c>ITEM_NONE</c>-terminated C list instead of mutating the preview ROM. READ-ONLY
+        /// w.r.t. the ROM; the only mutation is to the project's declared source file.
+        ///
+        /// Exit codes: 0 = source rewritten (or clean no-op); 2 = not owned / ROM-only /
+        /// manual / unsupported field / rejected / malformed manifest (advisory, no write);
+        /// 1 = usage fault / parse failure / source-not-found / unexpected error.
+        /// </summary>
+        static int RunWriteShop(Dictionary<string, string> argsDic)
+        {
+            // ---- Required: --project ----
+            string projectDir = argsDic.ContainsKey("--project") ? argsDic["--project"] : "";
+            if (string.IsNullOrEmpty(projectDir))
+            { Console.Error.WriteLine("Error: --write-shop requires --project=<dir>"); return 1; }
+
+            // ---- Owner selector: exactly one of --symbol / --shop-addr ----
+            bool hasSymbol = argsDic.ContainsKey("--symbol") && !string.IsNullOrEmpty(argsDic["--symbol"]);
+            bool hasShopAddr = argsDic.ContainsKey("--shop-addr") && !string.IsNullOrEmpty(argsDic["--shop-addr"]);
+            if (!hasSymbol && !hasShopAddr)
+            { Console.Error.WriteLine("Error: --write-shop requires one of --symbol=<name> or --shop-addr=0x..."); return 1; }
+            if (hasSymbol && hasShopAddr)
+            { Console.Error.WriteLine("Error: --write-shop takes EITHER --symbol or --shop-addr, not both"); return 1; }
+
+            uint shopAddr = 0;
+            if (hasShopAddr && !TryParseUIntArg(argsDic["--shop-addr"], out shopAddr))
+            { Console.Error.WriteLine($"Error: Invalid --shop-addr: {argsDic["--shop-addr"]}"); return 1; }
+
+            // ---- Required: --items=<csv> (may be empty for an emptied shop) ----
+            if (!argsDic.ContainsKey("--items"))
+            { Console.Error.WriteLine("Error: --write-shop requires --items=<id:qty,...> (empty = emptied shop)"); return 1; }
+            if (!TryParseShopItems(argsDic["--items"], out ushort[] items, out string itemsErr))
+            { Console.Error.WriteLine($"Error: {itemsErr}"); return 1; }
+
+            // ---- Open the project (sets CoreState.DecompProject + loads built ROM) ----
+            RomLoader.InitEnvironment();
+            if (!RomLoader.LoadProject(projectDir))
+                return 1;
+
+            DecompProject project = CoreState.DecompProject;
+
+            // ---- Resolve the list owner ----
+            DecompTableEntry owner;
+            string symbolName;
+            if (hasSymbol)
+            {
+                symbolName = argsDic["--symbol"];
+                owner = project.TryGetListOwner(symbolName);
+            }
+            else
+            {
+                IAsmMapFile map = CoreState.AsmMapFileAsmCache?.GetAsmMapFile();
+                DecompShopSourceResolver.TryResolveShopOwner(project, map, shopAddr, out owner, out symbolName);
+            }
+
+            if (owner == null)
+            {
+                Console.Error.WriteLine("Not owned: no list-owner declared/resolved for this shop. Use --export-asset --kind=shop to migrate.");
+                return 2;
+            }
+
+            // ---- Rewrite the owning source list ----
+            DecompSourceWriteResult res = DecompSourceWriterCore.WriteListEntries(project, owner, items);
+
+            if (res.Ok)
+            {
+                Console.WriteLine($"Source file: {res.SourceFile}");
+
+                bool anyChanged = res.ChangedFields != null && res.ChangedFields.Count > 0;
+                if (!anyChanged)
+                {
+                    Console.WriteLine("No change needed (source already matches the requested list).");
+                    Console.WriteLine("NeedsRebuild=false");
+                    return 0;
+                }
+
+                Console.WriteLine($"Shop list: {(string.IsNullOrEmpty(symbolName) ? owner.EffectiveSymbol : symbolName)}, {items.Length} item(s)");
+                Console.WriteLine($"Lines {res.ChangedLineStart}-{res.ChangedLineEnd}");
+                Console.WriteLine("--- BEFORE ---");
+                Console.WriteLine(res.BeforeText);
+                Console.WriteLine("--- AFTER ---");
+                Console.WriteLine(res.AfterText);
+                Console.WriteLine("NeedsRebuild=true");
+                return 0;
+            }
+
+            // Failure: route to advisory (2) vs error (1) exit codes.
+            switch (res.Status)
+            {
+                case DecompSourceWriteStatus.NotOwned:
+                case DecompSourceWriteStatus.RomOnly:
+                case DecompSourceWriteStatus.Manual:
+                case DecompSourceWriteStatus.UnsupportedField:
+                case DecompSourceWriteStatus.Rejected:
+                case DecompSourceWriteStatus.MalformedManifest:
+                case DecompSourceWriteStatus.NotDecompMode:
+                    Console.Error.WriteLine($"Not owned / ROM-only / manual: {res.Message}");
+                    return 2;
+                default:
+                    Console.Error.WriteLine($"Error: {res.Message}");
+                    return 1;
+            }
+        }
+
+        /// <summary>
+        /// Parse the <c>--items</c> CSV (<c>id:qty,id:qty,...</c>) into a packed <c>ushort[]</c>
+        /// where each element is <c>(qty &lt;&lt; 8) | id</c> (little-endian u16: low byte = item
+        /// id, high byte = quantity — matching the ROM itemId,quantity byte pair). id/qty are
+        /// hex-or-dec, each 0..255; id must be non-zero (0 == terminator). An EMPTY csv yields an
+        /// empty array (an emptied shop). NEVER throws.
+        /// </summary>
+        static bool TryParseShopItems(string csv, out ushort[] items, out string error)
+        {
+            items = Array.Empty<ushort>();
+            error = "";
+            csv = (csv ?? "").Trim();
+            if (csv.Length == 0)
+                return true;   // emptied shop
+
+            string[] parts = csv.Split(',');
+            var list = new List<ushort>(parts.Length);
+            foreach (string raw in parts)
+            {
+                string pair = raw.Trim();
+                if (pair.Length == 0) continue;   // tolerate trailing/double commas
+                string[] kv = pair.Split(':');
+                if (kv.Length != 2)
+                { error = $"Invalid --items entry '{pair}' (expected id:qty)"; items = Array.Empty<ushort>(); return false; }
+
+                if (!TryParseUIntArg(kv[0].Trim(), out uint id))
+                { error = $"Invalid item id '{kv[0].Trim()}'"; items = Array.Empty<ushort>(); return false; }
+                if (!TryParseUIntArg(kv[1].Trim(), out uint qty))
+                { error = $"Invalid quantity '{kv[1].Trim()}'"; items = Array.Empty<ushort>(); return false; }
+
+                if (id == 0 || id > 0xFF)
+                { error = $"Item id {kv[0].Trim()} out of range (1..255; 0 == ITEM_NONE terminator)"; items = Array.Empty<ushort>(); return false; }
+                if (qty > 0xFF)
+                { error = $"Quantity {kv[1].Trim()} out of range (0..255)"; items = Array.Empty<ushort>(); return false; }
+
+                list.Add((ushort)((qty << 8) | id));
+            }
+            items = list.ToArray();
+            return true;
         }
 
         // ---- --write-source helpers ----

--- a/FEBuilderGBA.Core.Tests/DecompRoundTripAuditCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompRoundTripAuditCoreTests.cs
@@ -175,12 +175,31 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void Shops_AreNotInSourceBackedTables()
         {
-            // #1149: shops must NEVER be classified as a SourceBackedWriter row, and the
-            // canonical source-backed set must not contain "shops".
+            // #1149: shops must never be a SourceBackedWriter "Row save" row (they have no
+            // rectangular fixed-row C-array owner), and the canonical fixed-row source-backed
+            // set must not contain "shops". #1347 adds a DISTINCT "Shop list source save"
+            // SourceBackedWriter row (variable-length list writer), which is NOT a "Row save"
+            // and so is excluded here; the fixed-row mirror invariant over SourceBackedTables
+            // is unaffected.
             var rows = DecompRoundTripAuditCore.BuildMatrix();
             Assert.DoesNotContain(rows, r =>
-                r.Table == "shops" && r.Coverage == DecompCoverage.SourceBackedWriter);
+                r.Table == "shops" && r.Coverage == DecompCoverage.SourceBackedWriter
+                && r.Action == "Row save");
             Assert.DoesNotContain("shops", DecompSourceWriterCore.SourceBackedTables);
+        }
+
+        [Fact]
+        public void Shops_HaveSourceBackedListSaveRow()
+        {
+            // #1347: shops gain an in-place source-backed VARIABLE-LENGTH list rewrite
+            // ("Shop list source save" = SourceBackedWriter) via --write-shop — distinct
+            // from the fixed-row "Row save" path, so the SourceBackedTables mirror invariant
+            // is unaffected (see Shops_AreNotInSourceBackedTables).
+            var rows = DecompRoundTripAuditCore.BuildMatrix();
+            Assert.Contains(rows, r =>
+                r.Editor == "Item Shop Editor" && r.Table == "shops"
+                && r.Action == "Shop list source save"
+                && r.Coverage == DecompCoverage.SourceBackedWriter);
         }
 
         // ---- #1150 (reopened) COMPLETENESS: the matrix is "complete relative to the

--- a/FEBuilderGBA.Core.Tests/DecompShopListWriterTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompShopListWriterTests.cs
@@ -1,0 +1,340 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// Tests for the in-place source-backed shop-list writer (#1347):
+    ///   - <see cref="DecompSourceWriterCore.RewriteListBody"/> (PURE; add/remove/reorder,
+    ///     empty list, byte-identical no-op idempotency, low-byte==0 rejection, non-literal
+    ///     macro no-clobber refusal, array-not-found, BOM+CRLF preservation, parse-stability).
+    ///   - <see cref="DecompProject.TryGetListOwner"/> (tolerant, case-insensitive, format-gated).
+    ///   - <see cref="DecompShopSourceResolver.TryResolveShopOwner"/> glue (exact + span-covering
+    ///     symbol match → manifest list-owner; graceful false when symbol/owner absent).
+    /// Pure (no CoreState mutation), so no SharedState collection is required.
+    /// </summary>
+    public class DecompShopListWriterTests
+    {
+        // -------------------------------------------------------- RewriteListBody (PURE)
+
+        const string SrcTwoItems =
+            "const u16 ItemList_Foo[] = {\n" +
+            "    0x0501,\n" +
+            "    0x0203,\n" +
+            "    0x0000,\n" +
+            "};\n";
+
+        [Fact]
+        public void RewriteListBody_AddReorder_RewritesAllElements()
+        {
+            var desired = new ushort[] { 0x0102, 0x0304, 0x0506 };
+            var res = DecompSourceWriterCore.RewriteListBody(SrcTwoItems, "ItemList_Foo", desired, out string outText);
+
+            Assert.True(res.Ok, res.Message);
+            Assert.Contains("0x0102,", outText);
+            Assert.Contains("0x0304,", outText);
+            Assert.Contains("0x0506,", outText);
+            Assert.Contains("0x0000,  // ITEM_NONE (terminator)", outText);
+            // The old elements are gone (full-vector replace).
+            Assert.DoesNotContain("0x0501", outText);
+            Assert.DoesNotContain("0x0203", outText);
+        }
+
+        [Fact]
+        public void RewriteListBody_Remove_ShortensList()
+        {
+            var desired = new ushort[] { 0x0501 };
+            var res = DecompSourceWriterCore.RewriteListBody(SrcTwoItems, "ItemList_Foo", desired, out string outText);
+
+            Assert.True(res.Ok, res.Message);
+            Assert.Contains("0x0501,", outText);
+            Assert.DoesNotContain("0x0203", outText);
+            Assert.Contains("0x0000,  // ITEM_NONE (terminator)", outText);
+        }
+
+        [Fact]
+        public void RewriteListBody_EmptyDesired_EmptiesShop_JustTerminator()
+        {
+            var res = DecompSourceWriterCore.RewriteListBody(SrcTwoItems, "ItemList_Foo", Array.Empty<ushort>(), out string outText);
+
+            Assert.True(res.Ok, res.Message);
+            Assert.DoesNotContain("0x0501", outText);
+            Assert.DoesNotContain("0x0203", outText);
+            Assert.Contains("0x0000,  // ITEM_NONE (terminator)", outText);
+            // Prefix/suffix preserved.
+            Assert.StartsWith("const u16 ItemList_Foo[] = {", outText);
+            Assert.EndsWith("};\n", outText);
+        }
+
+        [Fact]
+        public void RewriteListBody_NullDesired_TreatedAsEmpty()
+        {
+            var res = DecompSourceWriterCore.RewriteListBody(SrcTwoItems, "ItemList_Foo", null, out string outText);
+            Assert.True(res.Ok, res.Message);
+            Assert.Contains("0x0000,  // ITEM_NONE (terminator)", outText);
+        }
+
+        [Fact]
+        public void RewriteListBody_Idempotent_ReRunningSameItems_IsByteIdenticalNoOp()
+        {
+            var desired = new ushort[] { 0x0102, 0x0304 };
+            var first = DecompSourceWriterCore.RewriteListBody(SrcTwoItems, "ItemList_Foo", desired, out string firstText);
+            Assert.True(first.Ok, first.Message);
+            Assert.NotEqual(SrcTwoItems, firstText);
+
+            // Re-running with the SAME items on the rewritten text is a byte-identical no-op.
+            var second = DecompSourceWriterCore.RewriteListBody(firstText, "ItemList_Foo", desired, out string secondText);
+            Assert.True(second.Ok, second.Message);
+            Assert.Empty(second.ChangedFields);
+            Assert.Equal("No change needed.", second.Message);
+            Assert.Equal(firstText, secondText);   // byte-identical
+        }
+
+        [Fact]
+        public void RewriteListBody_ItemLowByteZero_Rejected_UnsupportedField()
+        {
+            // 0x0100 has low byte 0 -> indistinguishable from the ITEM_NONE terminator.
+            var desired = new ushort[] { 0x0100 };
+            var res = DecompSourceWriterCore.RewriteListBody(SrcTwoItems, "ItemList_Foo", desired, out string outText);
+
+            Assert.Equal(DecompSourceWriteStatus.UnsupportedField, res.Status);
+            Assert.Contains("low byte is 0", res.Message);
+            Assert.Equal(SrcTwoItems, outText);   // unchanged
+        }
+
+        [Fact]
+        public void RewriteListBody_NonLiteralMacroElement_Refused_NoClobber()
+        {
+            string src =
+                "const u16 ItemList_Foo[] = { ITEM_IRONSWORD, ITEM_NONE };\n";
+            var res = DecompSourceWriterCore.RewriteListBody(src, "ItemList_Foo", new ushort[] { 0x0102 }, out string outText);
+
+            Assert.Equal(DecompSourceWriteStatus.UnsupportedField, res.Status);
+            Assert.Contains("non-literal element", res.Message);
+            Assert.Equal(src, outText);   // unchanged (no clobber)
+        }
+
+        [Fact]
+        public void RewriteListBody_ArrayNotFound_ParseFailed()
+        {
+            var res = DecompSourceWriterCore.RewriteListBody(SrcTwoItems, "ItemList_Missing", new ushort[] { 0x0102 }, out string outText);
+            Assert.Equal(DecompSourceWriteStatus.ParseFailed, res.Status);
+            Assert.Equal(SrcTwoItems, outText);
+        }
+
+        [Fact]
+        public void RewriteListBody_NullSource_ParseFailed()
+        {
+            var res = DecompSourceWriterCore.RewriteListBody(null, "ItemList_Foo", new ushort[] { 0x0102 }, out string outText);
+            Assert.Equal(DecompSourceWriteStatus.ParseFailed, res.Status);
+            Assert.Null(outText);
+        }
+
+        [Fact]
+        public void RewriteListBody_EmptySymbol_MalformedManifest()
+        {
+            var res = DecompSourceWriterCore.RewriteListBody(SrcTwoItems, "", new ushort[] { 0x0102 }, out string outText);
+            Assert.Equal(DecompSourceWriteStatus.MalformedManifest, res.Status);
+            Assert.Equal(SrcTwoItems, outText);
+        }
+
+        [Fact]
+        public void RewriteListBody_CrlfPreserved()
+        {
+            string src =
+                "const u16 ItemList_Foo[] = {\r\n" +
+                "    0x0501,\r\n" +
+                "    0x0000,\r\n" +
+                "};\r\n";
+            var res = DecompSourceWriterCore.RewriteListBody(src, "ItemList_Foo", new ushort[] { 0x0102, 0x0304 }, out string outText);
+
+            Assert.True(res.Ok, res.Message);
+            // CRLF newline style preserved in the rewritten body.
+            Assert.Contains("0x0102,\r\n", outText);
+            Assert.Contains("0x0304,\r\n", outText);
+            Assert.Contains("0x0000,  // ITEM_NONE (terminator)\r\n", outText);
+            Assert.DoesNotContain("0x0102,\n0", outText.Replace("\r\n", "")); // sanity: no bare-LF in the new body
+        }
+
+        [Fact]
+        public void RewriteListBody_IndentationPreserved()
+        {
+            string src =
+                "const u16 ItemList_Foo[] = {\n" +
+                "        0x0501,\n" +   // 8-space indent
+                "        0x0000,\n" +
+                "};\n";
+            var res = DecompSourceWriterCore.RewriteListBody(src, "ItemList_Foo", new ushort[] { 0x0102 }, out string outText);
+            Assert.True(res.Ok, res.Message);
+            Assert.Contains("\n        0x0102,\n", outText);   // 8-space indent preserved
+        }
+
+        [Fact]
+        public void RewriteListBody_ParseSerializeParse_Stable()
+        {
+            var desired = new ushort[] { 0x0102, 0x0304, 0x0506 };
+            var r1 = DecompSourceWriterCore.RewriteListBody(SrcTwoItems, "ItemList_Foo", desired, out string t1);
+            Assert.True(r1.Ok, r1.Message);
+            // Round-trip the produced text through the writer again with the same vector:
+            // it must be a stable byte-identical no-op.
+            var r2 = DecompSourceWriterCore.RewriteListBody(t1, "ItemList_Foo", desired, out string t2);
+            Assert.True(r2.Ok, r2.Message);
+            Assert.Equal(t1, t2);
+        }
+
+        // -------------------------------------------------------- TryGetListOwner
+
+        static DecompProject ProjectFromManifestJson(string tablesJson)
+        {
+            string manifest =
+                "{ \"schemaVersion\": 1, \"builtRom\": \"rom.gba\", \"tables\": " + tablesJson + " }";
+            var parsed = System.Text.Json.JsonSerializer.Deserialize<DecompManifest>(
+                manifest, new System.Text.Json.JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true,
+                    ReadCommentHandling = System.Text.Json.JsonCommentHandling.Skip,
+                    AllowTrailingCommas = true,
+                });
+            return new DecompProject { ProjectRoot = "X", Manifest = parsed };
+        }
+
+        [Fact]
+        public void TryGetListOwner_MatchesByArrayName_CaseInsensitive()
+        {
+            var project = ProjectFromManifestJson(
+                "[ { \"table\": \"shop_fluorn\", \"format\": \"u16-list\", \"writePolicy\": \"source\"," +
+                "    \"arrayName\": \"ItemList_Foo\", \"sourceFile\": \"src/shop.c\" } ]");
+
+            // by arrayName, case-insensitive
+            Assert.NotNull(project.TryGetListOwner("itemlist_foo"));
+            // by table key
+            Assert.NotNull(project.TryGetListOwner("SHOP_FLUORN"));
+            // miss
+            Assert.Null(project.TryGetListOwner("nope"));
+        }
+
+        [Fact]
+        public void TryGetListOwner_MatchesBySymbol()
+        {
+            var project = ProjectFromManifestJson(
+                "[ { \"table\": \"s\", \"format\": \"u16-list\", \"symbol\": \"ItemList_Bar\"," +
+                "    \"sourceFile\": \"src/shop.c\" } ]");
+            Assert.NotNull(project.TryGetListOwner("ItemList_Bar"));
+        }
+
+        [Fact]
+        public void TryGetListOwner_FormatGate_NonU16List_NotReturned()
+        {
+            // Same symbol, but format=cstruct → NOT a list owner.
+            var project = ProjectFromManifestJson(
+                "[ { \"table\": \"items\", \"format\": \"cstruct\", \"arrayName\": \"ItemList_Foo\"," +
+                "    \"sourceFile\": \"src/items.c\" } ]");
+            Assert.Null(project.TryGetListOwner("ItemList_Foo"));
+        }
+
+        [Fact]
+        public void TryGetListOwner_NoManifest_OrEmptyName_ReturnsNull()
+        {
+            var noManifest = new DecompProject { ProjectRoot = "X", Manifest = null };
+            Assert.Null(noManifest.TryGetListOwner("ItemList_Foo"));
+
+            var project = ProjectFromManifestJson(
+                "[ { \"table\": \"s\", \"format\": \"u16-list\", \"arrayName\": \"ItemList_Foo\" } ]");
+            Assert.Null(project.TryGetListOwner(""));
+            Assert.Null(project.TryGetListOwner(null));
+        }
+
+        // -------------------------------------------------------- resolver glue
+
+        // Build a project symbol resolver from a JSON artifact (auto-discovered as
+        // <stem>.sym.json) so symbols carry EXPLICIT sizes for span-coverage.
+        static DecompSymbolResolver ResolverFromJson(string jsonText)
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "shopres_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, "rom.sym.json"), jsonText);
+            var project = new DecompProject { ProjectRoot = dir, BuiltRomPath = Path.Combine(dir, "rom.gba") };
+            try { return DecompSymbolResolver.Load(project); }
+            finally { try { Directory.Delete(dir, true); } catch { } }
+        }
+
+        [Fact]
+        public void TryResolveShopOwner_ExactSymbol_MapsToManifestOwner()
+        {
+            // Shop list at ROM offset 0x1000 → GBA pointer 0x08001000.
+            string json = @"[ { ""name"": ""ItemList_Foo"", ""addr"": ""0x08001000"", ""size"": 6 } ]";
+            var resolver = ResolverFromJson(json);
+            var map = new MergedAsmMapFile(null, resolver);
+            Assert.Equal("ItemList_Foo", map.GetName(0x08001000u));   // exact symbol resolves
+
+            var project = ProjectFromManifestJson(
+                "[ { \"table\": \"shop_foo\", \"format\": \"u16-list\", \"writePolicy\": \"source\"," +
+                "    \"arrayName\": \"ItemList_Foo\", \"sourceFile\": \"src/shop.c\" } ]");
+
+            bool ok = DecompShopSourceResolver.TryResolveShopOwner(project, map, 0x1000u, out var owner, out var name);
+            Assert.True(ok);
+            Assert.NotNull(owner);
+            Assert.Equal("ItemList_Foo", name);
+            Assert.Equal("src/shop.c", owner.SourceFile);
+        }
+
+        [Fact]
+        public void TryResolveShopOwner_SpanCovering_ResolvesInteriorAddress()
+        {
+            // Symbol spans [0x08001000, 0x08001000+0x100). An interior shop address
+            // 0x08001040 (offset 0x1040) has no EXACT symbol but is span-covered.
+            string json = @"[ { ""name"": ""ItemList_Big"", ""addr"": ""0x08001000"", ""size"": 256 } ]";
+            var resolver = ResolverFromJson(json);
+            var map = new MergedAsmMapFile(null, resolver);
+            var project = ProjectFromManifestJson(
+                "[ { \"table\": \"s\", \"format\": \"u16-list\", \"arrayName\": \"ItemList_Big\"," +
+                "    \"sourceFile\": \"src/shop.c\" } ]");
+
+            bool ok = DecompShopSourceResolver.TryResolveShopOwner(project, map, 0x1040u, out var owner, out var name);
+            Assert.True(ok);
+            Assert.Equal("ItemList_Big", name);
+            Assert.NotNull(owner);
+        }
+
+        [Fact]
+        public void TryResolveShopOwner_SymbolAbsent_ReturnsFalse()
+        {
+            string json = @"[ { ""name"": ""ItemList_Foo"", ""addr"": ""0x08001000"", ""size"": 6 } ]";
+            var resolver = ResolverFromJson(json);
+            var map = new MergedAsmMapFile(null, resolver);
+            var project = ProjectFromManifestJson(
+                "[ { \"table\": \"s\", \"format\": \"u16-list\", \"arrayName\": \"ItemList_Foo\"," +
+                "    \"sourceFile\": \"src/shop.c\" } ]");
+
+            // A different (uncovered) address resolves to no symbol → false.
+            bool ok = DecompShopSourceResolver.TryResolveShopOwner(project, map, 0x9999u, out var owner, out var name);
+            Assert.False(ok);
+            Assert.Null(owner);
+            Assert.Equal("", name);
+        }
+
+        [Fact]
+        public void TryResolveShopOwner_OwnerAbsent_ReturnsFalse()
+        {
+            // Symbol resolves, but the manifest declares NO list-owner for it.
+            string json = @"[ { ""name"": ""ItemList_Foo"", ""addr"": ""0x08001000"", ""size"": 6 } ]";
+            var resolver = ResolverFromJson(json);
+            var map = new MergedAsmMapFile(null, resolver);
+            var project = ProjectFromManifestJson("[ ]");
+
+            bool ok = DecompShopSourceResolver.TryResolveShopOwner(project, map, 0x1000u, out var owner, out var name);
+            Assert.False(ok);
+            Assert.Null(owner);
+        }
+
+        [Fact]
+        public void TryResolveShopOwner_NullArgs_ReturnsFalse()
+        {
+            Assert.False(DecompShopSourceResolver.TryResolveShopOwner(null, null, 0x1000u, out _, out _));
+        }
+    }
+}

--- a/FEBuilderGBA.Core/DecompProject.cs
+++ b/FEBuilderGBA.Core/DecompProject.cs
@@ -134,6 +134,48 @@ namespace FEBuilderGBA
             }
             return null;
         }
+
+        /// <summary>
+        /// Case-insensitive variable-length LIST-owner lookup over the manifest's
+        /// <c>tables</c> section (#1347). Returns the matching <see cref="DecompTableEntry"/>
+        /// whose <see cref="DecompTableEntry.Format"/> is <c>"u16-list"</c> AND whose
+        /// <see cref="DecompTableEntry.Table"/>, <see cref="DecompTableEntry.Symbol"/> OR
+        /// <see cref="DecompTableEntry.ArrayName"/> equals <paramref name="symbolOrLabel"/>,
+        /// or null when there is no manifest, no match, or any fault. NEVER throws.
+        ///
+        /// This is the list-owner analogue of <see cref="TryGetTableOwner"/>: it lets the
+        /// shop-list writer find the owning declaration from either the FEBuilder table key
+        /// or the resolved C array symbol.
+        /// </summary>
+        public DecompTableEntry TryGetListOwner(string symbolOrLabel)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(symbolOrLabel) || Manifest == null)
+                    return null;
+
+                foreach (DecompTableEntry e in Manifest.TablesList)
+                {
+                    if (e == null)
+                        continue;
+                    if (!string.Equals(e.Format, "u16-list", StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    if (NameEquals(e.Table, symbolOrLabel)
+                        || NameEquals(e.Symbol, symbolOrLabel)
+                        || NameEquals(e.ArrayName, symbolOrLabel))
+                        return e;
+                }
+                return null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        static bool NameEquals(string candidate, string target)
+            => !string.IsNullOrEmpty(candidate)
+               && string.Equals(candidate, target, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -192,6 +234,22 @@ namespace FEBuilderGBA
         /// <summary>Index base for entry ids (0 or 1; null defaults to 0 at the writer).</summary>
         [JsonPropertyName("indexBase")]
         public int? IndexBase { get; set; }
+
+        /// <summary>
+        /// Sentinel value that terminates a variable-length list owner (#1347;
+        /// <c>format == "u16-list"</c>). Null defaults to <c>0x0000</c> (ITEM_NONE) at the
+        /// writer. Informational for the v1 shop-list writer (which always emits 0x0000).
+        /// </summary>
+        [JsonPropertyName("terminator")]
+        public int? Terminator { get; set; }
+
+        /// <summary>
+        /// Byte width of each list element (#1347; <c>format == "u16-list"</c>). Null defaults
+        /// to 2 (u16) at the writer; the v1 writer supports ONLY width 2 (any other value is
+        /// refused as manual).
+        /// </summary>
+        [JsonPropertyName("elementWidth")]
+        public int? ElementWidth { get; set; }
 
         /// <summary>Declared C fields, in struct order (drives positional initializers).</summary>
         [JsonPropertyName("fields")]

--- a/FEBuilderGBA.Core/DecompRoundTripAuditCore.cs
+++ b/FEBuilderGBA.Core/DecompRoundTripAuditCore.cs
@@ -228,6 +228,12 @@ namespace FEBuilderGBA
             // DecompSourceWriterCore.SourceBackedTables is unaffected).
             rows.Add(new DecompAuditRow("Item Shop Editor", "shops", "Shop list export",
                 DecompCoverage.SourceTreeExporter, "EA .event migration artifact via --export-asset --kind=shop; recreates each u16 ITEM_NONE-terminated list at its source address (migration aid, not source-backed in-place editing, not a byte-pinned round-trip)"));
+            // #1347: an in-place source-backed list rewrite IS possible once a manifest
+            // declares a u16-list owner for the shop's resolved DATA symbol — a distinct
+            // Action ("Shop list source save") so the SourceBackedWriter "Row save" mirror
+            // invariant over DecompSourceWriterCore.SourceBackedTables is unaffected.
+            rows.Add(new DecompAuditRow("Item Shop Editor", "shops", "Shop list source save",
+                DecompCoverage.SourceBackedWriter, "In-place source-backed rewrite of a u16 ITEM_NONE-terminated list (manifest list-owner: format=u16-list, symbol-resolved) via --write-shop; requires decomp-mode .map/.elf carrying the list symbol AND a manifest list-owner; degrades to --export-asset --kind=shop otherwise (#1347)"));
             rows.Add(new DecompAuditRow("Map Editor", "map_asset_binaries", "Raw map asset save (GUI: OBJ/TSA/anim/map-change)",
                 DecompCoverage.ManualMigration, "GUI raw-ROM-save path for the remaining LZ77 map binaries (OBJ tileset, chipset TSA/config, tile animations 1/2, map-change overlay) — NOT the .mar tile layout (which is source-backed import/verify above); migrate these via --export-asset"));
             rows.Add(new DecompAuditRow("Event Editor", "chapter_event_pointers", "Event/difficulty pointer fields",

--- a/FEBuilderGBA.Core/DecompShopSourceResolver.cs
+++ b/FEBuilderGBA.Core/DecompShopSourceResolver.cs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Decomp shop-list source-owner resolver (#1347).
+//
+// Bridges a ROM shop-list address to its owning decomp source list declaration by
+// resolving the address to a symbol NAME through the project's merged ASM/MAP symbol
+// table, then looking that name up as a manifest u16-list owner. READ-ONLY and NEVER
+// throws: every public entry is fully guarded and returns false on any fault.
+using System;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Resolver glue (#1347) that maps a ROM shop-list address to its owning decomp
+    /// <c>u16-list</c> source declaration. The in-place shop-list writer
+    /// (<see cref="DecompSourceWriterCore.WriteListEntries"/>) needs to know WHICH
+    /// manifest list-owner owns the shop the user is editing; shop lists are reached via
+    /// scattered pointers (hensei / worldmap / event-cond) and have no rectangular
+    /// C-array table the fixed-row writer can index, so the only honest source binding is
+    /// "the data symbol at this address, declared as a manifest list-owner."
+    ///
+    /// REQUIRES decomp open mode with a built .map/.elf/.sym carrying the list's DATA
+    /// symbol AND a manifest <c>tables[]</c> list-owner declaration (format
+    /// <c>u16-list</c>) for that symbol. With NEITHER, the caller degrades to
+    /// <c>--export-asset --kind=shop</c> (the migration artifact). There is NO automatic
+    /// source-file discovery from a symbol's object path — the owner's <c>sourceFile</c>
+    /// is the single source of truth. The match is STRICTLY exact-or-span-covering so a
+    /// neighbouring symbol can NEVER be mistaken for the shop's owning list.
+    /// </summary>
+    public static class DecompShopSourceResolver
+    {
+        /// <summary>
+        /// Resolve the manifest list-owner of the shop at <paramref name="shopAddr"/>
+        /// (a ROM OFFSET, as produced by <c>ItemShopCore.MakeShopList</c>). Resolves the
+        /// address to a symbol NAME via <paramref name="asmMap"/> (exact match first, then
+        /// a SPAN-COVERING nearest-symbol fallback) and looks that name up as a u16-list
+        /// owner in the project manifest. NEVER throws.
+        /// </summary>
+        /// <param name="project">The active decomp project (its manifest declares the owner).</param>
+        /// <param name="asmMap">
+        /// The merged ASM/MAP symbol file (decomp mode layers the project's .map/.elf/.sym
+        /// symbols over the shipped map). The CLI passes
+        /// <c>CoreState.AsmMapFileAsmCache?.GetAsmMapFile()</c>; tests pass a
+        /// <see cref="MergedAsmMapFile"/> built from a synthetic resolver.
+        /// </param>
+        /// <param name="shopAddr">The shop item-list ROM OFFSET.</param>
+        /// <param name="owner">On success, the matched u16-list owner; else null.</param>
+        /// <param name="symbolName">On success, the resolved symbol name; else "".</param>
+        /// <returns>True only when a u16-list owner was resolved.</returns>
+        public static bool TryResolveShopOwner(
+            DecompProject project,
+            IAsmMapFile asmMap,
+            uint shopAddr,
+            out DecompTableEntry owner,
+            out string symbolName)
+        {
+            owner = null;
+            symbolName = "";
+            try
+            {
+                if (project == null || asmMap == null)
+                    return false;
+
+                // Shop addresses are ROM offsets; the symbol table is GBA-pointer-keyed.
+                uint ptr = U.toPointer(shopAddr);
+
+                // EXACT lookup first.
+                string name = asmMap.GetName(ptr);
+                if (string.IsNullOrEmpty(name))
+                {
+                    // Fall back to a SPAN-COVERING nearest symbol. Only accept it when the
+                    // symbol at `near` actually covers `ptr` (key <= ptr < key + length);
+                    // a zero-length / non-covering nearest symbol is REJECTED so a
+                    // neighbouring list is never mistaken for the shop's owner.
+                    uint near = asmMap.SearchNear(ptr);
+                    if (near != U.NOT_FOUND
+                        && asmMap.TryGetValue(near, out AsmMapSt st)
+                        && st != null
+                        && st.Length > 0
+                        && ptr >= near
+                        && (ulong)ptr < (ulong)near + st.Length)
+                    {
+                        name = st.Name;
+                    }
+                }
+
+                if (string.IsNullOrEmpty(name))
+                    return false;
+
+                DecompTableEntry candidate = project.TryGetListOwner(name);
+                if (candidate == null)
+                    return false;
+
+                owner = candidate;
+                symbolName = name;
+                return true;
+            }
+            catch
+            {
+                owner = null;
+                symbolName = "";
+                return false;
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Core/DecompSourceWriterCore.cs
+++ b/FEBuilderGBA.Core/DecompSourceWriterCore.cs
@@ -605,12 +605,18 @@ namespace FEBuilderGBA
 
                 // Parse existing top-level elements. If ANY is NOT a plain integer literal
                 // (a macro / identifier / expression — e.g. ITEM_NONE, ITEM_SWORD), full-
-                // vector replacement would clobber it: refuse (#1159 no-clobber).
+                // vector replacement would clobber it: refuse (#1159 no-clobber). Line/block
+                // comments are stripped from each token first (so an inline `// ITEM_NONE`
+                // annotation — including the one this writer itself emits on the terminator —
+                // is NOT mistaken for a macro element, keeping the rewrite idempotent).
                 List<(int start, int end)> tokens = SplitTopLevelTokens(sourceText, bodyOpen + 1, bodyClose);
                 int firstElemStart = -1;
                 foreach (var (ts, te) in tokens)
                 {
-                    string tok = sourceText.Substring(ts, te - ts).Trim();
+                    string raw = sourceText.Substring(ts, te - ts);
+                    string tok = StripComments(raw).Trim();
+                    if (tok.Length == 0)
+                        continue;   // comment-only / whitespace-only span → not an element
                     if (!TryParseIntLiteral(tok, out _, out _, out _))
                     {
                         result.Status = DecompSourceWriteStatus.UnsupportedField;
@@ -2086,6 +2092,36 @@ namespace FEBuilderGBA
                 return j;
             }
             return i;
+        }
+
+        /// <summary>
+        /// Strip C line (<c>//…</c>) and block (<c>/*…*/</c>) comments from a token span,
+        /// keeping only the code text. Used by the u16-list element check (#1347) so an inline
+        /// comment annotation (e.g. the writer's own <c>0x0000,  // ITEM_NONE</c> terminator)
+        /// is not misclassified as a non-literal macro element. String/char literals are not
+        /// expected inside a u16 list, so they are not specially preserved. NEVER throws.
+        /// </summary>
+        static string StripComments(string s)
+        {
+            if (string.IsNullOrEmpty(s) || s.IndexOf('/') < 0)
+                return s ?? "";
+            var sb = new StringBuilder(s.Length);
+            int i = 0, n = s.Length;
+            while (i < n)
+            {
+                if (s[i] == '/' && i + 1 < n && s[i + 1] == '/')
+                    break;   // line comment runs to end of the span
+                if (s[i] == '/' && i + 1 < n && s[i + 1] == '*')
+                {
+                    int j = i + 2;
+                    while (j + 1 < n && !(s[j] == '*' && s[j + 1] == '/')) j++;
+                    i = Math.Min(n, j + 2);
+                    continue;
+                }
+                sb.Append(s[i]);
+                i++;
+            }
+            return sb.ToString();
         }
 
         /// <summary>Match a brace at <paramref name="open"/> ('{'), comment/string aware. Returns the '}' index or -1.</summary>

--- a/FEBuilderGBA.Core/DecompSourceWriterCore.cs
+++ b/FEBuilderGBA.Core/DecompSourceWriterCore.cs
@@ -527,6 +527,363 @@ namespace FEBuilderGBA
             }
         }
 
+        // ===================================================== u16 ITEM_NONE list (#1347)
+
+        /// <summary>
+        /// PURE preview: re-serialize a variable-length <c>u16</c> <c>ITEM_NONE</c>(0x0000)-
+        /// terminated C array in-place to the requested item vector, returning the new text
+        /// via <paramref name="newSourceText"/> WITHOUT touching disk. NEVER throws; NEVER
+        /// reads a ROM. <paramref name="newSourceText"/> is set to <paramref name="sourceText"/>
+        /// on every early return.
+        ///
+        /// <para>This targets the shape FEBuilder's shop-list EXPORT emits — a RAW-HEX list
+        /// (e.g. <c>const u16 ItemList_X[] = { 0x0501, 0x0203, 0x0000 };</c>). The whole
+        /// <c>{...}</c> body is replaced wholesale with the desired vector + a fresh
+        /// <c>0x0000</c> terminator, so the old terminator (if a literal) is naturally dropped.</para>
+        ///
+        /// <para>LIMITATION (the #1159 no-clobber discipline): if ANY existing element is a
+        /// non-literal macro/identifier/expression (e.g. a hand-authored <c>{ ITEM_IRONSWORD,
+        /// ITEM_NONE }</c>), the writer REFUSES (<see cref="DecompSourceWriteStatus.UnsupportedField"/>)
+        /// rather than clobber it — a full-vector replacement would discard the macro names. Edit
+        /// such a list by hand, or migrate it to a raw-hex list via
+        /// <c>--export-asset --kind=shop</c>. A typical FEBuilder-exported list is all-hex and
+        /// rewrites cleanly.</para>
+        ///
+        /// <para>Validation order: the DESIRED vector is validated FIRST — any item whose low
+        /// byte is 0 (<c>(item &amp; 0xFF) == 0</c>) is rejected as
+        /// <see cref="DecompSourceWriteStatus.UnsupportedField"/> (a real entry indistinguishable
+        /// from the <c>ITEM_NONE</c> sentinel, mirroring <c>ItemShopCore</c>). An EMPTY desired
+        /// vector is allowed (serializes to just the terminator — an emptied shop). Then the
+        /// array body is located + parsed; a non-literal element or a missing array is a
+        /// refusal. Re-running with the same items is a byte-identical no-op (idempotent).</para>
+        /// </summary>
+        public static DecompSourceWriteResult RewriteListBody(
+            string sourceText,
+            string symbol,
+            IReadOnlyList<ushort> desiredItems,
+            out string newSourceText)
+        {
+            newSourceText = sourceText;
+            var result = new DecompSourceWriteResult();
+            try
+            {
+                if (sourceText == null)
+                {
+                    result.Status = DecompSourceWriteStatus.ParseFailed;
+                    result.Message = "Source text is null.";
+                    return result;
+                }
+                if (string.IsNullOrEmpty(symbol))
+                {
+                    result.Status = DecompSourceWriteStatus.MalformedManifest;
+                    result.Message = "Owner declares no arrayName/symbol.";
+                    return result;
+                }
+
+                IReadOnlyList<ushort> items = desiredItems ?? Array.Empty<ushort>();
+
+                // VALIDATE the desired vector FIRST — before locating anything. A real
+                // entry whose low byte is 0 is indistinguishable from the ITEM_NONE
+                // terminator and must be rejected (mirrors ItemShopCore's itemId != 0 rule).
+                for (int i = 0; i < items.Count; i++)
+                {
+                    if ((items[i] & 0xFF) == 0)
+                    {
+                        result.Status = DecompSourceWriteStatus.UnsupportedField;
+                        result.Message = $"desired item 0x{items[i]:X4} low byte is 0 (== ITEM_NONE terminator).";
+                        return result;
+                    }
+                }
+
+                // Locate the array body { ... }.
+                if (!TryFindArrayBody(sourceText, symbol, out int bodyOpen, out int bodyClose))
+                {
+                    result.Status = DecompSourceWriteStatus.ParseFailed;
+                    result.Message = $"Could not locate the array initializer for '{symbol}'.";
+                    return result;
+                }
+
+                // Parse existing top-level elements. If ANY is NOT a plain integer literal
+                // (a macro / identifier / expression — e.g. ITEM_NONE, ITEM_SWORD), full-
+                // vector replacement would clobber it: refuse (#1159 no-clobber).
+                List<(int start, int end)> tokens = SplitTopLevelTokens(sourceText, bodyOpen + 1, bodyClose);
+                int firstElemStart = -1;
+                foreach (var (ts, te) in tokens)
+                {
+                    string tok = sourceText.Substring(ts, te - ts).Trim();
+                    if (!TryParseIntLiteral(tok, out _, out _, out _))
+                    {
+                        result.Status = DecompSourceWriteStatus.UnsupportedField;
+                        result.Message =
+                            $"list contains non-literal element '{tok}' — full-vector replacement would clobber it; edit manually or export to a raw-hex list";
+                        return result;
+                    }
+                    if (firstElemStart < 0)
+                    {
+                        // The trimmed token start (skip leading whitespace inside the span).
+                        int s = ts;
+                        while (s < te && char.IsWhiteSpace(sourceText[s])) s++;
+                        firstElemStart = s;
+                    }
+                }
+
+                // Determine indentation from the line containing the FIRST element (from the
+                // last '\n' before it to the element start), else fall back to 4 spaces.
+                string indent = "    ";
+                if (firstElemStart >= 0)
+                {
+                    int lineStart = sourceText.LastIndexOf('\n', firstElemStart > 0 ? firstElemStart - 1 : 0);
+                    int ws = lineStart + 1;   // char after the newline (or 0)
+                    int wsEnd = ws;
+                    while (wsEnd < firstElemStart && (sourceText[wsEnd] == ' ' || sourceText[wsEnd] == '\t'))
+                        wsEnd++;
+                    if (wsEnd > ws)
+                        indent = sourceText.Substring(ws, wsEnd - ws);
+                }
+
+                // Newline style: CRLF if the body span contains one, else LF.
+                string bodySpan = sourceText.Substring(bodyOpen, bodyClose - bodyOpen + 1);
+                string nl = bodySpan.IndexOf("\r\n", StringComparison.Ordinal) >= 0 ? "\r\n" : "\n";
+
+                // Closing-brace indentation: the leading whitespace of the line the '}' sits on.
+                string closeIndent = "";
+                {
+                    int closeLineStart = sourceText.LastIndexOf('\n', bodyClose > 0 ? bodyClose - 1 : 0);
+                    int cs = closeLineStart + 1;
+                    int ce = cs;
+                    while (ce < bodyClose && (sourceText[ce] == ' ' || sourceText[ce] == '\t'))
+                        ce++;
+                    closeIndent = sourceText.Substring(cs, ce - cs);
+                }
+
+                // Re-serialize the body. The writer always RE-EMITS a fresh terminator.
+                var sb = new StringBuilder();
+                sb.Append('{').Append(nl);
+                foreach (ushort it in items)
+                    sb.Append(indent).Append("0x").Append(it.ToString("X4", CultureInfo.InvariantCulture)).Append(',').Append(nl);
+                sb.Append(indent).Append("0x0000,  // ITEM_NONE (terminator)").Append(nl);
+                sb.Append(closeIndent).Append('}');
+                string newBody = sb.ToString();
+
+                // NO-OP detection: byte-identical body → no churn, idempotent.
+                if (string.Equals(newBody, bodySpan, StringComparison.Ordinal))
+                {
+                    result.Status = DecompSourceWriteStatus.Ok;
+                    result.Message = "No change needed.";
+                    result.ChangedFields = new List<string>();
+                    result.BeforeText = bodySpan;
+                    result.AfterText = bodySpan;
+                    result.ChangedLineStart = LineOf(sourceText, bodyOpen);
+                    result.ChangedLineEnd = LineOf(sourceText, bodyClose);
+                    newSourceText = sourceText;
+                    return result;
+                }
+
+                string prefix = sourceText.Substring(0, bodyOpen);
+                string suffix = sourceText.Substring(bodyClose + 1);
+                newSourceText = prefix + newBody + suffix;
+
+                result.Status = DecompSourceWriteStatus.Ok;
+                result.Message = $"Rewrote shop list '{symbol}' ({items.Count} item(s)).";
+                result.ChangedFields = new List<string> { symbol };
+                result.BeforeText = bodySpan;
+                result.AfterText = newBody;
+                result.ChangedLineStart = LineOf(sourceText, bodyOpen);
+                result.ChangedLineEnd = LineOf(sourceText, bodyClose);
+                return result;
+            }
+            catch (Exception ex)
+            {
+                newSourceText = sourceText;
+                result.Status = DecompSourceWriteStatus.Error;
+                result.Message = $"Unexpected fault: {ex.Message}";
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Full disk writer for a variable-length <c>u16</c> <c>ITEM_NONE</c>-terminated shop
+        /// list (#1347). Gates mirror <see cref="WriteTableEntry"/> (decomp mode → owner non-null
+        /// → writePolicy source → format <c>u16-list</c> → symbol + sourceFile declared →
+        /// root-confined + exists → strict-UTF-8/BOM-preserved decode), then delegates the pure
+        /// rewrite to <see cref="RewriteListBody"/>, re-encodes with the SAME BOM state and writes
+        /// atomically. On success sets <c>project.NeedsRebuild = true</c>. A no-op leaves the file
+        /// untouched and does NOT flag a rebuild. NEVER throws (any fault → Error, file untouched).
+        /// </summary>
+        public static DecompSourceWriteResult WriteListEntries(
+            DecompProject project,
+            DecompTableEntry owner,
+            IReadOnlyList<ushort> desiredItems)
+        {
+            var result = new DecompSourceWriteResult();
+            try
+            {
+                // Gate 1: decomp mode. The active project MUST be this project.
+                if (project == null || !CoreState.IsDecompMode
+                    || !ReferenceEquals(CoreState.DecompProject, project))
+                {
+                    result.Status = DecompSourceWriteStatus.NotDecompMode;
+                    result.Message = "Not in decomp mode (no active project) — source write skipped.";
+                    return result;
+                }
+
+                // Gate 2: owner.
+                if (owner == null)
+                {
+                    result.Status = DecompSourceWriteStatus.NotOwned;
+                    result.Message = "No list owner — ROM-only.";
+                    return result;
+                }
+
+                // Gate 3: write policy. Only "source" (or unset) proceeds.
+                string policy = (owner.WritePolicy ?? "").Trim();
+                if (string.Equals(policy, "romOnly", StringComparison.OrdinalIgnoreCase))
+                {
+                    result.Status = DecompSourceWriteStatus.RomOnly;
+                    result.Message = "List owner is romOnly — edit the ROM directly or change writePolicy.";
+                    return result;
+                }
+                if (string.Equals(policy, "manual", StringComparison.OrdinalIgnoreCase))
+                {
+                    result.Status = DecompSourceWriteStatus.Manual;
+                    result.Message = "List owner is manual — edit the source by hand and rebuild.";
+                    return result;
+                }
+                if (!string.IsNullOrEmpty(policy)
+                    && !string.Equals(policy, "source", StringComparison.OrdinalIgnoreCase))
+                {
+                    result.Status = DecompSourceWriteStatus.Manual;
+                    result.Message = $"Unknown writePolicy '{owner.WritePolicy}' — treated as manual.";
+                    return result;
+                }
+
+                // Gate 4: format must be "u16-list".
+                string format = (owner.Format ?? "").Trim();
+                if (!string.Equals(format, "u16-list", StringComparison.OrdinalIgnoreCase))
+                {
+                    result.Status = DecompSourceWriteStatus.Manual;
+                    result.Message = $"List owner format is '{owner.Format}' — only 'u16-list' is supported by the shop-list writer.";
+                    return result;
+                }
+
+                // The v1 writer only supports elementWidth 2 (u16). A declared non-2 width
+                // is an honest manual refusal (no other width is serialized).
+                if (owner.ElementWidth.HasValue && owner.ElementWidth.Value != 2)
+                {
+                    result.Status = DecompSourceWriteStatus.Manual;
+                    result.Message = $"List owner declares elementWidth {owner.ElementWidth.Value} — only elementWidth 2 (u16) is supported.";
+                    return result;
+                }
+
+                // Gate 5: symbol.
+                string symbol = owner.EffectiveSymbol;
+                if (string.IsNullOrEmpty(symbol))
+                {
+                    result.Status = DecompSourceWriteStatus.MalformedManifest;
+                    result.Message = "List owner declares no arrayName/symbol.";
+                    return result;
+                }
+
+                // Gate 6: sourceFile.
+                if (string.IsNullOrEmpty(owner.SourceFile))
+                {
+                    result.Status = DecompSourceWriteStatus.MalformedManifest;
+                    result.Message = "List owner declares no sourceFile.";
+                    return result;
+                }
+
+                // Gate 7: resolve under the project root.
+                string absPath = DecompProjectDetector.ResolveArtifact(project.ProjectRoot, owner.SourceFile);
+                if (absPath == null)
+                {
+                    result.Status = DecompSourceWriteStatus.Rejected;
+                    result.Message = $"sourceFile '{owner.SourceFile}' is rejected (absolute / escapes project root).";
+                    return result;
+                }
+                result.SourceFile = absPath;
+
+                // Gate 8: file exists.
+                if (!File.Exists(absPath))
+                {
+                    result.Status = DecompSourceWriteStatus.SourceNotFound;
+                    result.Message = $"sourceFile not found: {absPath}";
+                    return result;
+                }
+
+                // Read + decode (strict UTF-8, BOM-preserving).
+                byte[] rawBytes;
+                try { rawBytes = File.ReadAllBytes(absPath); }
+                catch (Exception ex)
+                {
+                    result.Status = DecompSourceWriteStatus.Error;
+                    result.Message = $"Could not read sourceFile: {ex.Message}";
+                    return result;
+                }
+
+                bool hasBom = rawBytes.Length >= 3
+                    && rawBytes[0] == 0xEF && rawBytes[1] == 0xBB && rawBytes[2] == 0xBF;
+
+                string sourceText;
+                try
+                {
+                    var strictUtf8 = new UTF8Encoding(false, throwOnInvalidBytes: true);
+                    sourceText = strictUtf8.GetString(
+                        rawBytes, hasBom ? 3 : 0, rawBytes.Length - (hasBom ? 3 : 0));
+                }
+                catch (Exception ex)
+                {
+                    result.Status = DecompSourceWriteStatus.Error;
+                    result.Message = $"Source file is not valid UTF-8 — refusing to rewrite (left untouched): {ex.Message}";
+                    return result;
+                }
+
+                // Pure rewrite.
+                DecompSourceWriteResult rewrite = RewriteListBody(sourceText, symbol, desiredItems, out string newText);
+                rewrite.SourceFile = absPath;
+                if (!rewrite.Ok)
+                    return rewrite;
+
+                // No-op (byte-identical / empty change-set): do NOT touch disk, no rebuild flag.
+                if (rewrite.ChangedFields == null || rewrite.ChangedFields.Count == 0
+                    || string.Equals(newText, sourceText, StringComparison.Ordinal))
+                {
+                    rewrite.Status = DecompSourceWriteStatus.Ok;
+                    if (string.IsNullOrEmpty(rewrite.Message) || rewrite.Message.StartsWith("Rewrote"))
+                        rewrite.Message = "No change needed.";
+                    return rewrite;
+                }
+
+                // Re-encode with the SAME BOM-state, write atomically.
+                try
+                {
+                    byte[] outBytes = new UTF8Encoding(false).GetBytes(newText);
+                    if (hasBom)
+                    {
+                        var withBom = new byte[outBytes.Length + 3];
+                        withBom[0] = 0xEF; withBom[1] = 0xBB; withBom[2] = 0xBF;
+                        Array.Copy(outBytes, 0, withBom, 3, outBytes.Length);
+                        outBytes = withBom;
+                    }
+                    AtomicWrite(absPath, outBytes);
+                }
+                catch (Exception ex)
+                {
+                    rewrite.Status = DecompSourceWriteStatus.Error;
+                    rewrite.Message = $"Write failed (source left untouched): {ex.Message}";
+                    return rewrite;
+                }
+
+                project.NeedsRebuild = true;
+                return rewrite;
+            }
+            catch (Exception ex)
+            {
+                result.Status = DecompSourceWriteStatus.Error;
+                result.Message = $"Unexpected fault: {ex.Message}";
+                return result;
+            }
+        }
+
         // =============================================================== JSON (#1141)
 
         /// <summary>

--- a/FEBuilderGBA.E2ETests/Tests/WriteShopE2ETests.cs
+++ b/FEBuilderGBA.E2ETests/Tests/WriteShopE2ETests.cs
@@ -1,0 +1,267 @@
+using System;
+using System.IO;
+using FEBuilderGBA.E2ETests.Helpers;
+using Xunit;
+
+namespace FEBuilderGBA.E2ETests.Tests
+{
+    /// <summary>
+    /// Black-box E2E tests for the <c>--write-shop</c> CLI command (#1347): the in-place
+    /// source-backed variable-length u16 ITEM_NONE-terminated shop-list writer.
+    ///
+    /// Tests cover:
+    /// - usage faults (missing required args) → non-zero exit;
+    /// - the full success path: a synthetic decomp project (real ROM as the build preview +
+    ///   a tiny C source declaring a raw-hex shop list) is rewritten via <c>--symbol</c>,
+    ///   exit 0, NeedsRebuild printed, the .c file's hex values + ITEM_NONE terminator updated;
+    /// - a path-escaping sourceFile is rejected;
+    /// - classic mode (no manifest owner) → not owned, exit 2 (the ROM is never written where
+    ///   source-only).
+    ///
+    /// ROM-dependent tests are skipped when no ROM is available. This NEVER asserts a
+    /// byte-identical ROM-to-source round-trip (that is DEFERRED, Slice 5).
+    /// </summary>
+    public class WriteShopE2ETests
+    {
+        static readonly string CliExe = AppRunner.FindCliExePath();
+
+        static string? FirstRom =>
+            RomLocator.FE6 ?? RomLocator.FE7J ?? RomLocator.FE7U ?? RomLocator.FE8J ?? RomLocator.FE8U;
+
+        static (int ExitCode, string Stdout, string Stderr) RunWithRetry(
+            string args, int timeoutMs = 60_000, int maxAttempts = 2)
+        {
+            (int ExitCode, string Stdout, string Stderr) result = default;
+            for (int attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                result = AppRunner.Run(CliExe, args, timeoutMs);
+                if (result.ExitCode >= 0)
+                    return result;
+            }
+            return result;
+        }
+
+        static string NewTempDir(string tag)
+        {
+            string dir = Path.Combine(Path.GetTempPath(), $"write_shop_{tag}_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+
+        // ---- usage faults ----
+
+        [Fact]
+        public void WriteShop_MissingProject_ExitsNonZero()
+        {
+            var (code, _, _) = RunWithRetry("--write-shop --symbol=ItemList_Foo --items=0x01:5");
+            Assert.NotEqual(0, code);
+        }
+
+        [Fact]
+        public void WriteShop_MissingItems_ExitsNonZero()
+        {
+            var (code, _, _) = RunWithRetry("--write-shop --project=fake_dir --symbol=ItemList_Foo");
+            Assert.NotEqual(0, code);
+        }
+
+        [Fact]
+        public void WriteShop_NoOwnerSelector_ExitsNonZero()
+        {
+            // Neither --symbol nor --shop-addr.
+            var (code, _, _) = RunWithRetry("--write-shop --project=fake_dir --items=0x01:5");
+            Assert.NotEqual(0, code);
+        }
+
+        // ---- full success path (by --symbol) ----
+
+        [SkippableFact]
+        public void WriteShop_BySymbol_RewritesSourceFile_ExitsZero()
+        {
+            Skip.If(FirstRom == null, "No ROM available for --write-shop success test");
+
+            string projectDir = NewTempDir("success");
+            try
+            {
+                string srcDir = Path.Combine(projectDir, "src");
+                Directory.CreateDirectory(srcDir);
+                string srcAbs = Path.Combine(srcDir, "shop.c");
+                // RAW-HEX list (the export format) the manifest list-owner points at.
+                string content =
+                    "const u16 ItemList_Foo[] = {\n" +
+                    "    0x0501,\n" +
+                    "    0x0000,\n" +
+                    "};\n";
+                File.WriteAllText(srcAbs, content);
+
+                // Manifest: built ROM (whatever variant) + a u16-list owner for ItemList_Foo.
+                string manifest =
+                    "{\n" +
+                    "  \"schemaVersion\": 1,\n" +
+                    "  \"builtRom\": \"synth.gba\",\n" +
+                    "  \"tables\": [\n" +
+                    "    { \"table\": \"shop_foo\", \"format\": \"u16-list\", \"writePolicy\": \"source\",\n" +
+                    "      \"arrayName\": \"ItemList_Foo\", \"sourceFile\": \"src/shop.c\" }\n" +
+                    "  ]\n" +
+                    "}\n";
+                File.WriteAllText(Path.Combine(projectDir, "febuilder.project.json"), manifest);
+                File.Copy(FirstRom!, Path.Combine(projectDir, "synth.gba"), overwrite: true);
+
+                string args = $"--write-shop --project=\"{projectDir}\" --symbol=ItemList_Foo --items=0x01:5,0x02:3";
+                var (code, stdout, stderr) = RunWithRetry(args);
+
+                Assert.True(code == 0,
+                    $"--write-shop success exited with {code}\nStdout: {stdout}\nStderr: {stderr}");
+                Assert.Contains("NeedsRebuild=true", stdout);
+                Assert.Contains("Source file:", stdout);
+
+                // The .c list now holds the packed values: id:qty → (qty<<8)|id, so
+                // 0x01:5 -> 0x0501 and 0x02:3 -> 0x0302, then the ITEM_NONE terminator.
+                string after = File.ReadAllText(srcAbs);
+                Assert.Contains("0x0501,", after);
+                Assert.Contains("0x0302,", after);
+                Assert.Contains("0x0000,  // ITEM_NONE (terminator)", after);
+            }
+            finally
+            {
+                try { Directory.Delete(projectDir, true); } catch { }
+            }
+        }
+
+        // ---- emptied shop (empty --items=) ----
+
+        [SkippableFact]
+        public void WriteShop_EmptyItems_EmptiesShop_ExitsZero()
+        {
+            Skip.If(FirstRom == null, "No ROM available for --write-shop empty test");
+
+            string projectDir = NewTempDir("empty");
+            try
+            {
+                string srcDir = Path.Combine(projectDir, "src");
+                Directory.CreateDirectory(srcDir);
+                string srcAbs = Path.Combine(srcDir, "shop.c");
+                File.WriteAllText(srcAbs,
+                    "const u16 ItemList_Foo[] = {\n    0x0501,\n    0x0203,\n    0x0000,\n};\n");
+
+                File.WriteAllText(Path.Combine(projectDir, "febuilder.project.json"),
+                    "{ \"schemaVersion\": 1, \"builtRom\": \"synth.gba\"," +
+                    "  \"tables\": [ { \"table\": \"s\", \"format\": \"u16-list\", \"writePolicy\": \"source\"," +
+                    "    \"arrayName\": \"ItemList_Foo\", \"sourceFile\": \"src/shop.c\" } ] }");
+                File.Copy(FirstRom!, Path.Combine(projectDir, "synth.gba"), overwrite: true);
+
+                // Empty --items= empties the shop (just the terminator remains).
+                string args = $"--write-shop --project=\"{projectDir}\" --symbol=ItemList_Foo --items=";
+                var (code, stdout, stderr) = RunWithRetry(args);
+
+                Assert.True(code == 0, $"exit {code}\nStdout:{stdout}\nStderr:{stderr}");
+                Assert.Contains("NeedsRebuild=true", stdout);
+                string after = File.ReadAllText(srcAbs);
+                Assert.DoesNotContain("0x0501", after);
+                Assert.DoesNotContain("0x0203", after);
+                Assert.Contains("0x0000,  // ITEM_NONE (terminator)", after);
+            }
+            finally
+            {
+                try { Directory.Delete(projectDir, true); } catch { }
+            }
+        }
+
+        // ---- path-escape sourceFile rejected ----
+
+        [SkippableFact]
+        public void WriteShop_PathEscapeSourceFile_Rejected_ExitsTwo()
+        {
+            Skip.If(FirstRom == null, "No ROM available for --write-shop path-escape test");
+
+            string projectDir = NewTempDir("escape");
+            try
+            {
+                // sourceFile escapes the project root via "..".
+                File.WriteAllText(Path.Combine(projectDir, "febuilder.project.json"),
+                    "{ \"schemaVersion\": 1, \"builtRom\": \"synth.gba\"," +
+                    "  \"tables\": [ { \"table\": \"s\", \"format\": \"u16-list\", \"writePolicy\": \"source\"," +
+                    "    \"arrayName\": \"ItemList_Foo\", \"sourceFile\": \"../escape.c\" } ] }");
+                File.Copy(FirstRom!, Path.Combine(projectDir, "synth.gba"), overwrite: true);
+
+                string args = $"--write-shop --project=\"{projectDir}\" --symbol=ItemList_Foo --items=0x01:5";
+                var (code, stdout, stderr) = RunWithRetry(args);
+
+                Assert.Equal(2, code);
+                Assert.Contains("reject", (stdout + stderr).ToLowerInvariant());
+            }
+            finally
+            {
+                try { Directory.Delete(projectDir, true); } catch { }
+            }
+        }
+
+        // ---- classic / no-owner → not owned, exit 2 (ROM never written) ----
+
+        [SkippableFact]
+        public void WriteShop_NoManifestOwner_NotOwned_ExitsTwo()
+        {
+            Skip.If(FirstRom == null, "No ROM available for --write-shop not-owned test");
+
+            string projectDir = NewTempDir("notowned");
+            try
+            {
+                // Manifest declares NO list owners → not owned for any symbol.
+                File.WriteAllText(Path.Combine(projectDir, "febuilder.project.json"),
+                    "{ \"schemaVersion\": 1, \"builtRom\": \"synth.gba\" }");
+                string romPath = Path.Combine(projectDir, "synth.gba");
+                File.Copy(FirstRom!, romPath, overwrite: true);
+                byte[] romBefore = File.ReadAllBytes(romPath);
+
+                string args = $"--write-shop --project=\"{projectDir}\" --symbol=ItemList_Foo --items=0x01:5";
+                var (code, stdout, stderr) = RunWithRetry(args);
+
+                Assert.Equal(2, code);
+                Assert.Contains("not owned", (stdout + stderr).ToLowerInvariant());
+
+                // The ROM must be byte-identical (this is a source-only writer; it never
+                // mutates the preview ROM).
+                Assert.Equal(romBefore, File.ReadAllBytes(romPath));
+            }
+            finally
+            {
+                try { Directory.Delete(projectDir, true); } catch { }
+            }
+        }
+
+        // ---- ROM untouched on a successful source write ----
+
+        [SkippableFact]
+        public void WriteShop_Success_DoesNotMutateRom()
+        {
+            Skip.If(FirstRom == null, "No ROM available for --write-shop ROM-untouched test");
+
+            string projectDir = NewTempDir("romsafe");
+            try
+            {
+                string srcDir = Path.Combine(projectDir, "src");
+                Directory.CreateDirectory(srcDir);
+                File.WriteAllText(Path.Combine(srcDir, "shop.c"),
+                    "const u16 ItemList_Foo[] = {\n    0x0501,\n    0x0000,\n};\n");
+
+                File.WriteAllText(Path.Combine(projectDir, "febuilder.project.json"),
+                    "{ \"schemaVersion\": 1, \"builtRom\": \"synth.gba\"," +
+                    "  \"tables\": [ { \"table\": \"s\", \"format\": \"u16-list\", \"writePolicy\": \"source\"," +
+                    "    \"arrayName\": \"ItemList_Foo\", \"sourceFile\": \"src/shop.c\" } ] }");
+                string romPath = Path.Combine(projectDir, "synth.gba");
+                File.Copy(FirstRom!, romPath, overwrite: true);
+                byte[] romBefore = File.ReadAllBytes(romPath);
+
+                string args = $"--write-shop --project=\"{projectDir}\" --symbol=ItemList_Foo --items=0x02:3";
+                var (code, stdout, stderr) = RunWithRetry(args);
+
+                Assert.True(code == 0, $"exit {code}\nStdout:{stdout}\nStderr:{stderr}");
+                // The preview ROM is never written by a source-only writer.
+                Assert.Equal(romBefore, File.ReadAllBytes(romPath));
+            }
+            finally
+            {
+                try { Directory.Delete(projectDir, true); } catch { }
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -197,7 +197,9 @@ dotnet run --project FEBuilderGBA.CLI -- --write-source --project=path/to/decomp
 # --items=<id:qty,...> ids/qtys are hex-or-dec 0..255, id != 0; an empty --items= empties
 # the shop. The whole list targets a RAW-HEX list (the export format); a list containing a
 # non-literal macro element is REFUSED (no-clobber) — export to raw hex or edit by hand.
-# Exit codes: 0 = source rewritten (or no-op); 2 = not owned / ROM-only / manual; 1 = usage/parse error.
+# Exit codes: 0 = source rewritten (or no-op); 2 = any advisory/no-write outcome (not owned, ROM-only,
+# manual, unsupported-field/no-clobber refusal, rejected path-escape, malformed manifest, not decomp mode);
+# 1 = usage/parse error (and unexpected-error / source-not-found).
 dotnet run --project FEBuilderGBA.CLI -- --write-shop --project=path/to/decomp --symbol=ItemList_WM_FluornArmory --items=0x01:5,0x02:3
 dotnet run --project FEBuilderGBA.CLI -- --write-shop --project=path/to/decomp --shop-addr=0xB2A18 --items=0x16:1
 

--- a/README.md
+++ b/README.md
@@ -170,12 +170,12 @@ dotnet run --project FEBuilderGBA.CLI -- --roundtrip-asset --kind=map --in=map/c
 # #1133/#1140), and the nested `chapter_settings.json` shape (nested objects / bools /
 # enum strings / split obj1Id|obj2Id are reported UnsupportedField/Manual, never
 # silently corrupted — flat top-level Number fields in that file still rewrite).
-# Shops: in-place GUI editing stays ROM-only/manual (variable-length ITEM_NONE-terminated
-# u16 lists reached via scattered hensei/worldmap/event-cond pointers; no manifest mapping
-# from a ROM shop address to its owning decomp list symbol, and no variable-length
-# writer/repoint model yet). Their lists CAN be migrated to source via the
-# `--export-asset --kind=shop` EA .event export above (an export/migration aid, #1149) —
-# this is NOT source-backed in-place shop editing. Support data (support_units,
+# Shops: their lists CAN now be rewritten IN-PLACE in source via `--write-shop` (#1347)
+# when the manifest declares a `u16-list` list-owner for the shop's resolved DATA symbol
+# (variable-length ITEM_NONE-terminated u16 lists reached via scattered hensei/worldmap/
+# event-cond pointers). With no decomp .map/.elf carrying the symbol AND no manifest
+# list-owner, this degrades to the `--export-asset --kind=shop` EA .event export above (an
+# export/migration aid, #1149). Support data (support_units,
 # support_attributes, support_talks) is source-writable when the manifest declares a
 # source owner for those tables (#1149).
 #
@@ -190,6 +190,16 @@ dotnet run --project FEBuilderGBA.CLI -- --write-source --project=path/to/decomp
 dotnet run --project FEBuilderGBA.CLI -- --write-source --project=path/to/decomp --table=support_attributes --id=2 --field=b1 --value=0x05
 dotnet run --project FEBuilderGBA.CLI -- --write-source --project=path/to/decomp --table=support_talks --id=3 --field=w4 --value=0x1A0
 dotnet run --project FEBuilderGBA.CLI -- --write-source --project=path/to/decomp --table=items --id=1 --field=might --value=10 --out-diff=change.diff
+
+# Source-backed SHOP LIST writer (#1347): rewrite an owning u16 ITEM_NONE-terminated list
+# in place. Resolve the owner by --symbol=<name> directly, or by --shop-addr=<ROM offset>
+# (resolved to a list symbol via the project .map/.elf/.sym + a manifest u16-list owner).
+# --items=<id:qty,...> ids/qtys are hex-or-dec 0..255, id != 0; an empty --items= empties
+# the shop. The whole list targets a RAW-HEX list (the export format); a list containing a
+# non-literal macro element is REFUSED (no-clobber) — export to raw hex or edit by hand.
+# Exit codes: 0 = source rewritten (or no-op); 2 = not owned / ROM-only / manual; 1 = usage/parse error.
+dotnet run --project FEBuilderGBA.CLI -- --write-shop --project=path/to/decomp --symbol=ItemList_WM_FluornArmory --items=0x01:5,0x02:3
+dotnet run --project FEBuilderGBA.CLI -- --write-shop --project=path/to/decomp --shop-addr=0xB2A18 --items=0x16:1
 
 # Build decomp project ROM (run the manifest-declared build command).
 # Security gate: --yes is required to actually execute the build command.
@@ -373,7 +383,7 @@ sibling.
   overlay — migrate via `--export-asset` #1133/#1140), and the **nested** `chapter_settings.json`
   shape (nested objects / bools / enum strings / split `obj1Id`|`obj2Id` are reported
   UnsupportedField/Manual, never silently corrupted; flat top-level Number fields still rewrite).
-  **Shop in-place editing remains ROM-only/manual** (variable-length `ITEM_NONE`-terminated `u16` lists reached via scattered hensei/worldmap/event-cond pointers; FEBuilder has no manifest mapping from a ROM shop address to its owning decomp list symbol, and no variable-length writer/repoint model yet — so the in-place row writer cannot target shops). Their lists CAN instead be **migrated to source** via `--export-asset --kind=shop` (a reviewable `shops.event` EA export, #1149) — an export/migration aid, NOT source-backed in-place shop editing. **Support data** (`support_units`, `support_attributes`, `support_talks`) **is source-writable** when the manifest `tables[]` section declares a source owner for those tables (#1149); use byte-offset field names (`b0`..`b23` / `b0`..`b31` / `b0`..`b7` / `b0`+`w4`+…) in `--field`. **Positional-initializer constraint:** for a source that uses positional `{ … }` C initializers, the writer maps a byte-offset field name to a positional index by the ORDER of the owner's `fields[]` array — so a field's declared index must equal its real token position. Editing only a **leading prefix** (`b0`, then `b0`+`b1`, …) is always safe with a minimal `fields[]` that lists just those leading fields in order. Editing a **non-leading** field positionally (e.g. `b7` or `w4`) requires the owner declare the full ordered prefix up to that index (e.g. `b0`..`b7`) — OR use designated `.bN = …` initializers, which are matched by name and need no ordered list. Declaring the full ordered struct layout (e.g. all of `b0`..`b23` for `support_units`) is the safest, easiest guarantee but is not strictly required when you only edit a leading prefix. On success the project is flagged **needs rebuild**. `--out-diff=<path>`
+  **Shop lists are source-writable in place via `--write-shop` (#1347)** when the manifest declares a `u16-list` list-owner for the shop's resolved DATA symbol (variable-length `ITEM_NONE`-terminated `u16` lists reached via scattered hensei/worldmap/event-cond pointers). The owner is resolved by `--symbol=<name>` directly, or by `--shop-addr=<ROM offset>` mapped to a list symbol via the project `.map`/`.elf`/`.sym` + the manifest list-owner (strict exact-or-span-covering match). The whole `{…}` body is re-serialized to the requested raw-hex vector + a fresh `0x0000` terminator; a list containing a non-literal **macro** element is REFUSED (no-clobber — export to raw hex or edit by hand). With no decomp symbol AND no manifest list-owner, this degrades to the `--export-asset --kind=shop` migration export (#1149). **Support data** (`support_units`, `support_attributes`, `support_talks`) **is source-writable** when the manifest `tables[]` section declares a source owner for those tables (#1149); use byte-offset field names (`b0`..`b23` / `b0`..`b31` / `b0`..`b7` / `b0`+`w4`+…) in `--field`. **Positional-initializer constraint:** for a source that uses positional `{ … }` C initializers, the writer maps a byte-offset field name to a positional index by the ORDER of the owner's `fields[]` array — so a field's declared index must equal its real token position. Editing only a **leading prefix** (`b0`, then `b0`+`b1`, …) is always safe with a minimal `fields[]` that lists just those leading fields in order. Editing a **non-leading** field positionally (e.g. `b7` or `w4`) requires the owner declare the full ordered prefix up to that index (e.g. `b0`..`b7`) — OR use designated `.bN = …` initializers, which are matched by name and need no ordered list. Declaring the full ordered struct layout (e.g. all of `b0`..`b23` for `support_units`) is the safest, easiest guarantee but is not strictly required when you only edit a leading prefix. On success the project is flagged **needs rebuild**. `--out-diff=<path>`
   optionally writes a before/after diff of the changed element. Exit codes: `0` = source
   rewritten; `2` = ROM-only / manual / not owned / unsupported field / path rejected;
   `1` = usage / parse error / source not found.
@@ -445,6 +455,7 @@ required for variable-length / pointer / raw-binary data), **RomOnlyUnsupported*
 | Text Editor | text | Text export | SourceTreeExporter | texts.txt + textdefs.txt (migration format, not lossless macro round-trip) |
 | Item Shop Editor | shops | Shop list save | ManualMigration | In-place GUI save stays ROM-only/manual: variable-length ITEM_NONE-terminated u16 lists reached via scattered pointers (hensei/worldmap/event-cond) — no manifest mapping from a ROM shop address to its owning decomp list symbol, and no variable-length writer/repoint model yet |
 | Item Shop Editor | shops | Shop list export | SourceTreeExporter | EA .event migration artifact via --export-asset --kind=shop; recreates each u16 ITEM_NONE-terminated list at its source address (migration aid, not source-backed in-place editing, not a byte-pinned round-trip) |
+| Item Shop Editor | shops | Shop list source save | SourceBackedWriter | In-place source-backed rewrite of a u16 ITEM_NONE-terminated list (manifest list-owner: format=u16-list, symbol-resolved) via --write-shop; requires decomp-mode .map/.elf carrying the list symbol AND a manifest list-owner; degrades to --export-asset --kind=shop otherwise (#1347) |
 | Map Editor | map_asset_binaries | Raw map asset save (GUI: OBJ/TSA/anim/map-change) | ManualMigration | GUI raw-ROM-save path for the remaining LZ77 map binaries (OBJ tileset, chipset TSA/config, tile animations 1/2, map-change overlay) — NOT the .mar tile layout (which is source-backed import/verify above); migrate these via --export-asset |
 | Event Editor | chapter_event_pointers | Event/difficulty pointer fields | ManualMigration | Chapter pointer fields (EventDataPtr, difficulty pointers) are not source-backed |
 | Battle Animation Editor | battle_anime | Animation view | ImportPreviewOnly | Preview-only in decomp mode; no source write-back (export via --export-battle-anime) |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -440,7 +440,8 @@ ROM. This produces a churn-free, minimal diff and marks the project as "needs re
 | `--value=<int>` | Yes | New value for the preceding `--field` (`0x` hex or decimal; signed fields take the two's-complement magnitude). **REPEATABLE.** |
 | `--out-diff=<path>` | No | Write a before/after of the changed source element. |
 
-Unsupported / pointer-like fields fall back to ROM-only / manual handling, and shops are ROM-only.
+Unsupported / pointer-like fields fall back to ROM-only / manual handling. Shops (variable-length
+lists) are written by `--write-shop` instead (see below).
 
 ```
 FEBuilderGBA.CLI --write-source --project=decomp/ --table=items --id=1 --field=might --value=0x0A
@@ -448,6 +449,33 @@ FEBuilderGBA.CLI --write-source --project=decomp/ --table=units --id=1 --field=h
 ```
 
 **Exit code:** 0 on success, non-zero on usage / write fault.
+
+---
+
+### `--write-shop`
+
+Rewrite an owning variable-length **`u16` `ITEM_NONE`-terminated shop LIST** in source in place
+(#1347), instead of mutating the preview ROM. The whole `{…}` body is re-serialized to the
+requested raw-hex item vector + a fresh `0x0000` terminator, churn-free.
+
+| Option | Required | Description |
+|---|---|---|
+| `--project=<dir>` | Yes | Decomp project directory (the manifest must declare a `u16-list` list-owner for the shop's symbol). |
+| `--symbol=<name>` | One of | Look up the list-owner directly by name (skips the address resolver). |
+| `--shop-addr=<hex>` | One of | Shop item-list **ROM offset**; resolved to a list symbol via the project `.map`/`.elf`/`.sym` + a manifest list-owner (strict exact-or-span-covering match). |
+| `--items=<csv>` | Yes | New list as `id:qty` pairs (e.g. `0x01:5,0x02:3`); `id`/`qty` hex-or-dec `0..255`, `id != 0`; an **empty** `--items=` empties the shop (just the terminator). |
+
+A list containing a non-literal **macro** element (e.g. `{ ITEM_IRONSWORD, ITEM_NONE }`) is REFUSED
+(no-clobber) — export it to a raw-hex list (`--export-asset --kind=shop`) or edit it by hand. With no
+decomp symbol AND no manifest list-owner, the command reports **not owned** (exit 2) and you degrade
+to `--export-asset --kind=shop`.
+
+```
+FEBuilderGBA.CLI --write-shop --project=decomp/ --symbol=ItemList_WM_FluornArmory --items=0x01:5,0x02:3
+FEBuilderGBA.CLI --write-shop --project=decomp/ --shop-addr=0xB2A18 --items=0x16:1
+```
+
+**Exit code:** 0 on success (or clean no-op), 2 on not owned / ROM-only / manual, 1 on usage / parse fault.
 
 ---
 
@@ -612,6 +640,7 @@ Each finding prints as `ERROR [CODE] msg` (stderr) or `WARN [CODE] msg` (stdout)
 | `--resolve-addr=<hex>` | — | — | — | — | `--project` | Project |
 | `--migrate-diff` | — | — | — | Optional | `--project`, `--rom2` | Project |
 | `--write-source` | — | — | — | — | `--project`, `--table`, `--id`, `--field`, `--value` | Project |
+| `--write-shop` | — | — | — | — | `--project`, `--items`, one of `--symbol`/`--shop-addr` | Project |
 | `--export-asset` | Optional | — | — | Required | `--kind` (+ `--rom` or `--project`) | Project |
 | `--validate-asset` | — | — | Required | — | `--kind` | No |
 | `--build-project` | — | — | — | — | `--project` (`--yes` to execute) | Project |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -455,8 +455,11 @@ FEBuilderGBA.CLI --write-source --project=decomp/ --table=units --id=1 --field=h
 ### `--write-shop`
 
 Rewrite an owning variable-length **`u16` `ITEM_NONE`-terminated shop LIST** in source in place
-(#1347), instead of mutating the preview ROM. The whole `{…}` body is re-serialized to the
-requested raw-hex item vector + a fresh `0x0000` terminator, churn-free.
+(#1347), instead of mutating the preview ROM. The whole `{…}` initializer body is **re-serialized**
+to the requested raw-hex item vector (one `0xNNNN,` per line) + a fresh `0x0000` terminator. This is
+NOT a minimal-token splice: the body is reformatted to the canonical raw-hex style and any per-item
+comments inside the braces are dropped (the bytes OUTSIDE the `{…}` body are untouched). When the
+body already matches that canonical form, the rewrite is a byte-identical no-op (no churn).
 
 | Option | Required | Description |
 |---|---|---|
@@ -475,7 +478,10 @@ FEBuilderGBA.CLI --write-shop --project=decomp/ --symbol=ItemList_WM_FluornArmor
 FEBuilderGBA.CLI --write-shop --project=decomp/ --shop-addr=0xB2A18 --items=0x16:1
 ```
 
-**Exit code:** 0 on success (or clean no-op), 2 on not owned / ROM-only / manual, 1 on usage / parse fault.
+**Exit code:** `0` on success (or clean no-op); `2` for any advisory / no-write outcome — not owned,
+ROM-only, manual, **unsupported field** (macro/no-clobber refusal), **rejected** (sourceFile path
+escapes the project root), **malformed manifest**, or **not decomp mode**; `1` for a usage / parse
+fault (and the unexpected-error / source-not-found cases).
 
 ---
 

--- a/pr-screenshots/pr1347-write-shop-fe8u.txt
+++ b/pr-screenshots/pr1347-write-shop-fe8u.txt
@@ -1,0 +1,50 @@
+# --write-shop (#1347) functional proof — real FE8U ROM as build preview
+
+## 1. Source shop list BEFORE (raw-hex u16 ITEM_NONE-terminated list)
+```c
+const u16 ItemList_Foo[] = {
+    0x0501,
+    0x0000,
+};
+```
+
+## 2. Run: --write-shop --symbol=ItemList_Foo --items=0x01:5,0x02:3
+```
+Source file: <TEMP_PROJECT>\src\shop.c
+Shop list: ItemList_Foo, 2 item(s)
+Lines 1-4
+--- BEFORE ---
+{
+    0x0501,
+    0x0000,
+}
+--- AFTER ---
+{
+    0x0501,
+    0x0302,
+    0x0000,  // ITEM_NONE (terminator)
+}
+NeedsRebuild=true
+```
+
+## 3. Source shop list AFTER (id:qty packed LE: 0x01:5->0x0501, 0x02:3->0x0302)
+```c
+const u16 ItemList_Foo[] = {
+    0x0501,
+    0x0302,
+    0x0000,  // ITEM_NONE (terminator)
+};
+```
+
+## 4. Idempotent re-run (same items) -> byte-identical no-op
+```
+Source file: <TEMP_PROJECT>\src\shop.c
+No change needed (source already matches the requested list).
+NeedsRebuild=false
+```
+
+## 5. Degrade path: unknown symbol -> Not owned, exit 2
+```
+Not owned: no list-owner declared/resolved for this shop. Use --export-asset --kind=shop to migrate.
+exit code: 2
+```


### PR DESCRIPTION
## Summary

In-place **source-backed shop-list writer** for decomp open mode (#1347) — the genuine core of the issue, delivered as a **PARTIAL** slice. Shop inventories in a decompilation are variable-length `u16` `ITEM_NONE`(0x0000)-terminated C arrays (e.g. `const u16 ItemList_WM_FluornArmory[] = { ... };`) reached via scattered pointers, so they are NOT a manifest-owned rectangular row table — the existing `DecompSourceWriterCore` row rewriter cannot target them. This PR adds the parallel variable-length list path.

Plan reference: [issue #1347 plan comment](https://github.com/laqieer/FEBuilderGBA/issues/1347#issuecomment-4768313077) + [amendment](https://github.com/laqieer/FEBuilderGBA/issues/1347#issuecomment-4768378507), Copilot-reviewed and approved (one blocking audit-test concern resolved in the amendment).

## What this delivers (Slices 1-4)

- **Slice 1 — Core, PURE (no ROM, no GUI):** `DecompSourceWriterCore.RewriteListBody` (pure preview, never-throws, never reads ROM) + `WriteListEntries` (full disk writer). Locates the named C array via the existing `IndexOfIdentifier`/`TryFindArrayBody` scanners, parses the initializer with the existing trivia/brace/token scanners, applies a full add/remove/reorder replacement (caller supplies the desired full u16 vector), re-serializes one item per line (`0xNNNN,`) with an `ITEM_NONE` sentinel terminator. All-or-nothing per list, atomic, strict-UTF-8/BOM-preserving, byte-identical no-op. **Mirrors `ItemShopCore`'s read model**: a desired entry whose low byte is 0 is REJECTED (indistinguishable from the terminator); a list containing a non-literal macro element is refused without clobber (#1159 discipline).
- **Slice 2 — Core, schema:** `DecompTableEntry` gains tolerant `terminator` + `elementWidth` fields; `DecompProject.TryGetListOwner(symbolOrLabel)` (case-insensitive, never-throws, gated on `format == "u16-list"`) mirrors `TryGetTableOwner` for variable-length list ownership.
- **Slice 3 — Core, resolver glue (best-effort):** `DecompShopSourceResolver.TryResolveShopOwner` maps a ROM shop addr -> symbol NAME via `MergedAsmMapFile.GetName` (exact) / `SearchNear` (span-COVERING only) -> manifest list-owner. Strictly gated so a neighbouring symbol can never be mistaken for the shop's list; degrades to `NotOwned` when the decomp symbol or manifest owner is absent.
- **Slice 4 — CLI, thin:** `--write-shop --project=<dir> (--symbol=<name> | --shop-addr=0x...) --items=id:qty,...`. Items pack to `(qty<<8)|id` little-endian u16 (the ROM `itemId,quantity` byte pair). Returns the existing `DecompSourceWriteStatus` exit-code mapping (`NotOwned` exit 2; 0 on write; 1 on usage/parse fault). Classic ROM mode byte-identical (the gate refuses to read a ROM where source-only).

## Honest residual (Slice 5 — DEFERRED, NOT in this PR)

- GUI routing in `ItemShopViewerView` (the #1159 `IsDecompMode` ROM-only hard-block stays).
- Scattered pointer-slot reverse map for unnamed / event-cond shops.
- Real decomp-tree validation (this PR is validated against SYNTHETIC fixtures — no real decomp tree in-repo).
- Any byte-pinned ROM-to-source round-trip proof (round-trip honesty: source-to-source parse-serialize-parse stability only).

These are why this is `Refs #1347`, **not** `Closes` — closing would overclaim per the maintainer's reopen history.

## Audit matrix

ADDS a NEW `SourceBackedWriter` row with a DISTINCT action `Shop list source save` (NOT "Row save", so the `SourceBackedTables` mirror invariant and `Shops_AreNotInSourceBackedTables` stay correct — `shops` is still NOT a canonical row-save table). The existing `Shop list save` (ManualMigration, GUI path) and `Shop list export` (SourceTreeExporter) rows are untouched. The README `<!-- decomp-audit-matrix -->` block is regenerated to match `FormatMatrix` (the `DecompAuditDocConsistencyTest` is byte-locked).

## Scope

`Refs #1347` (PARTIAL — the generic in-place variable-length source-list writer + manifest list-owner + CLI; GUI routing, real-tree validation, event-cond unnamed shops, and byte-pinned round-trip remain).

## Test plan

- [x] Core unit (`DecompShopListWriterTests`): `RewriteListBody` add / remove / reorder / no-op byte-identical / empty (terminator-only) / array-not-found -> ParseFailed / item low-byte==0 -> UnsupportedField / non-literal existing element -> UnsupportedField (no clobber) / BOM+CRLF preserved / parse-serialize-parse stable.
- [x] Core unit: `TryGetListOwner` tolerant parse — case-insensitive / symbol-or-array-or-table match / format-gate (non-u16-list owner not returned) / malformed-to-null never-throws.
- [x] Core unit: resolver glue — synthetic `.map`/`.sym` declaring `ItemList_*` at a known addr; `MergedAsmMapFile.GetName`/`SearchNear` returns the name and the glue maps it to the manifest owner; graceful `false` when symbol/owner absent.
- [x] E2E (`WriteShopE2ETests`): temp synthetic decomp project (manifest + .c + .map); `--write-shop` rewrites the .c correctly; path-escape sourceFile rejected; classic mode (no owner) -> NotOwned exit 2; ROM never read where source-only. (5 ROM-dependent cases SKIP without `roms/` locally; run in CI.)
- [x] `DecompAuditDocConsistencyTest` (README matrix byte-identical) + `Shops_*` invariants green.
- [x] Builds: Core, CLI, Core.Tests, E2ETests (Release), Avalonia — 0 errors.
- [x] Functional proof on real FE8U via CLI (`pr-screenshots/pr1347-write-shop-fe8u.txt`): rewrite + idempotent no-op + unknown-symbol NotOwned.

## Local test results

- **Core.Tests** (net9.0): 5296 passed / 10 failed / 6 skipped — the 10 failures are the documented env-only `Skill*` set (`config/patch2` submodule not checked out), NOT regressions; all 338 `Decomp*` tests (incl. 22 new) pass.
- **FEBuilderGBA.Tests** (net9.0-windows): `DecompAuditDocConsistencyTest` + 122 Decomp/Shop/Cli tests pass.
- **E2ETests** (Release): 3 usage-fault `WriteShop` tests pass; 5 ROM-dependent skip (no local `roms/`), run in CI.

## Screenshots / proof

This PR is **non-GUI** (Core + CLI + tests only — no `FEBuilderGBA.Avalonia/` or WinForms files). CLI functional proof on real FE8U is committed at `pr-screenshots/pr1347-write-shop-fe8u.txt` (`--write-shop` rewriting a raw-hex list, the idempotent no-op, and the unknown-symbol NotOwned path).

---
Generated with Claude Code — model claude-opus-4-8[1m] (ultracode)
