### PR TITLE
feat(decomp): portrait PACKAGE validator (--validate-asset --kind=portrait-package) (Closes #1350)

### DIFF
--- a/FEBuilderGBA.CLI/Program.cs
+++ b/FEBuilderGBA.CLI/Program.cs
@@ -581,8 +581,11 @@ namespace FEBuilderGBA.CLI
             Console.WriteLine("    --table=<name>         Table name to export to .nmm; pointer/var fields are flagged unsafe via warnings (stderr)");
             Console.WriteLine("    --out=<path>           Optional: write the .nmm to a file (otherwise printed to stdout)");
             Console.WriteLine("  --validate-asset         Structurally validate a decomp IMPORT asset on disk (no ROM; never mutates)");
-            Console.WriteLine("    --kind=<kind>          Asset kind: graphics|palette|portrait|icon|map");
+            Console.WriteLine("    --kind=<kind>          Asset kind: graphics|palette|portrait|icon|map|portrait-package");
             Console.WriteLine("    --in=<srcAsset>        Input asset file (PNG for graphics/portrait/icon, .pal for palette, .mar for map)");
+            Console.WriteLine("    --path=<dir>          For --kind=portrait-package: package DIRECTORY (one 128x112 sheet PNG + optional JASC .pal)");
+            Console.WriteLine("    --allow-main-only     For --kind=portrait-package: accept a 96x80 main-mug-only sheet (warn instead of error)");
+            Console.WriteLine("    --project=<dir>       For --kind=portrait-package: confine --path to the decomp project root (no ROM load)");
             Console.WriteLine("  --import-asset           Re-import a .mar map LAYOUT to a raw uncompressed tilemap blob in the source tree (no ROM; never mutates)");
             Console.WriteLine("    --kind=map             Only map layout is supported (.mar + sidecar .mar.json required)");
             Console.WriteLine("    --in=<x.mar>           Input .mar map layout file");
@@ -627,6 +630,7 @@ namespace FEBuilderGBA.CLI
             Console.WriteLine("  FEBuilderGBA.CLI --manifest-to-nmm --project=decomp/ --table=items --out=items.nmm");
             Console.WriteLine("  FEBuilderGBA.CLI --validate-asset --kind=graphics --in=gfx/tiles.png");
             Console.WriteLine("  FEBuilderGBA.CLI --validate-asset --kind=palette --in=gfx/palette.pal");
+            Console.WriteLine("  FEBuilderGBA.CLI --validate-asset --kind=portrait-package --path portraits/eirika/");
             Console.WriteLine("  FEBuilderGBA.CLI --import-asset --kind=map --in=map/chapter1.mar --out=map/chapter1.tmap_raw.bin");
             Console.WriteLine("  FEBuilderGBA.CLI --roundtrip-asset --kind=map --in=map/chapter1.mar");
             Console.WriteLine("  FEBuilderGBA.CLI --write-source --project=decomp/ --table=items --id=1 --field=might --value=0x0A");
@@ -4697,14 +4701,62 @@ namespace FEBuilderGBA.CLI
         /// --validate-asset: structurally validate a decomp IMPORT asset on disk (#1150).
         /// READ-ONLY; NEVER loads a ROM. Exit 0 when there are no errors (warnings ok),
         /// 2 when there are errors, 1 on a usage / bad-kind fault.
+        ///
+        /// For <c>--kind=portrait-package</c> (#1350) the asset is a DIRECTORY (a multi-file
+        /// portrait package: one composite sheet PNG + an optional JASC sidecar), so it takes
+        /// <c>--path=&lt;dir&gt;</c> instead of <c>--in</c>, an optional presence flag
+        /// <c>--allow-main-only</c>, and an optional <c>--project=&lt;dir&gt;</c> that confines
+        /// <c>--path</c> to the project root (the project must open — else exit 2 — but the
+        /// preview ROM is NEVER loaded). With <c>--project</c> an ABSOLUTE/escaping <c>--path</c>
+        /// is rejected (return 2) — correct containment behaviour.
         /// </summary>
         static int RunValidateAsset(Dictionary<string, string> argsDic)
         {
             if (!argsDic.ContainsKey("--kind") || string.IsNullOrEmpty(argsDic["--kind"]))
-            { Console.Error.WriteLine("Error: --validate-asset requires --kind=<graphics|palette|portrait|icon|map>"); return 1; }
+            { Console.Error.WriteLine("Error: --validate-asset requires --kind=<graphics|palette|portrait|icon|map|portrait-package>"); return 1; }
             AssetKind? kind = DecompAssetValidatorCore.ParseKind(argsDic["--kind"]);
             if (kind == null)
-            { Console.Error.WriteLine($"Error: unknown --kind '{argsDic["--kind"]}'. Use: graphics, palette, portrait, icon, map"); return 1; }
+            { Console.Error.WriteLine($"Error: unknown --kind '{argsDic["--kind"]}'. Use: graphics, palette, portrait, icon, map, portrait-package"); return 1; }
+
+            // --kind=portrait-package is a DIRECTORY validator: --path (not --in), optional
+            // --allow-main-only, optional --project containment. NEVER loads the preview ROM.
+            if (kind.Value == AssetKind.PortraitPackage)
+            {
+                if (!argsDic.ContainsKey("--path") || string.IsNullOrEmpty(argsDic["--path"]))
+                { Console.Error.WriteLine("Error: --validate-asset --kind=portrait-package requires --path=<dir>"); return 1; }
+                string pathArg = argsDic["--path"];
+                bool allowMainOnly = argsDic.ContainsKey("--allow-main-only");
+
+                string dirPath = pathArg;
+                if (argsDic.ContainsKey("--project") && !string.IsNullOrEmpty(argsDic["--project"]))
+                {
+                    // Project-root containment for --path. We resolve the project ROOT only
+                    // (DecompProjectDetector.Detect — no ROM load, no RomLoader.LoadProject) so
+                    // the preview ROM is NEVER loaded; the project must still be a valid decomp
+                    // root (else exit 2 — we never silently drop containment).
+                    RomLoader.InitEnvironment();
+                    string projectDir = argsDic["--project"];
+                    DecompProject project = DecompProjectDetector.Detect(projectDir);
+                    if (project == null)
+                    { Console.Error.WriteLine($"Error: '{projectDir}' is not a decomp project (containment for --path cannot be enforced)"); return 2; }
+
+                    // ResolveSourcePath rejects absolute / ..-escaping paths under the project root.
+                    string absPath = DecompAssetExportCore.ResolveSourcePath(project, pathArg);
+                    if (absPath == null)
+                    { Console.Error.WriteLine("Error: --path rejected (outside project root or invalid)"); return 2; }
+                    dirPath = absPath;
+                }
+
+                AssetValidationResult pkgResult = DecompAssetValidatorCore.ValidateAssetPackage(kind.Value, dirPath, allowMainOnly);
+
+                foreach (AssetIssue e in pkgResult.Errors)
+                    Console.Error.WriteLine($"ERROR [{e.Code}] {e.Message}");
+                foreach (AssetIssue w in pkgResult.Warnings)
+                    Console.WriteLine($"WARN [{w.Code}] {w.Message}");
+
+                Console.WriteLine($"Validation: {pkgResult.Errors.Count} error(s), {pkgResult.Warnings.Count} warning(s) — {(pkgResult.Ok ? "OK" : "FAILED")}");
+                return pkgResult.Ok ? 0 : 2;
+            }
 
             if (!argsDic.ContainsKey("--in") || string.IsNullOrEmpty(argsDic["--in"]))
             { Console.Error.WriteLine("Error: --validate-asset requires --in=<srcAsset>"); return 1; }

--- a/FEBuilderGBA.Core.Tests/DecompPortraitPackageValidatorTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompPortraitPackageValidatorTests.cs
@@ -380,6 +380,67 @@ namespace FEBuilderGBA.Core.Tests
             finally { Cleanup(dir); }
         }
 
+        // The sidecar is matched by the SHEET name (sheet.png -> sheet.pal). A .pal with an
+        // UNRELATED name must NOT be used for the consistency comparison (Copilot PR #1353
+        // review): it would otherwise emit a false PALETTE_COLOR_MISMATCH. The sheet's own
+        // sidecar is absent → MISSING_PALETTE, and the unrelated one is flagged EXTRA_PALETTE.
+        [Fact]
+        public void Package_UnrelatedSidecarName_NotUsed_NoFalseMismatch()
+        {
+            string dir = FreshDir();
+            try
+            {
+                byte[] png = BuildSheetPng(128, 112, 16);
+                File.WriteAllBytes(Path.Combine(dir, "sheet.png"), png);
+
+                // A structurally valid JASC that DIFFERS from the sheet PLTE, but named so it
+                // does NOT match the sheet (other.pal, not sheet.pal).
+                IndexedPngInfo info = IndexedPngReader.Read(png);
+                int count = info.PaletteRgb.Length / 3;
+                var sb = new StringBuilder();
+                sb.Append("JASC-PAL\r\n0100\r\n").Append(count).Append("\r\n");
+                for (int i = 0; i < count; i++)
+                    sb.Append(255).Append(' ').Append(0).Append(' ').Append(0).Append("\r\n"); // all red, definitely != PLTE
+                File.WriteAllText(Path.Combine(dir, "other.pal"), sb.ToString());
+
+                AssetValidationResult r = DecompAssetValidatorCore.ValidateAssetPackage(AssetKind.PortraitPackage, dir);
+                // The unrelated palette was NOT compared → no false mismatch.
+                Assert.DoesNotContain(r.Errors, e => e.Code == "PALETTE_COLOR_MISMATCH");
+                Assert.DoesNotContain(r.Errors, e => e.Code == "PALETTE_COUNT_MISMATCH");
+                // The sheet's own sidecar is missing, and the unrelated one is flagged.
+                Assert.Contains(r.Warnings, w => w.Code == "MISSING_PALETTE");
+                Assert.Contains(r.Warnings, w => w.Code == "EXTRA_PALETTE");
+            }
+            finally { Cleanup(dir); }
+        }
+
+        // A structurally INVALID sidecar (bad RGB triple) must be caught by ValidatePalette
+        // (BAD_PALETTE_*) WITHOUT a misleading PALETTE_COUNT/COLOR_MISMATCH layered on top —
+        // TryParseJascColors now returns false for a malformed/short palette so the
+        // consistency comparison is skipped (Copilot PR #1353 review).
+        [Fact]
+        public void Package_MalformedSidecar_NoConsistencyMismatch_OnlyStructuralError()
+        {
+            string dir = FreshDir();
+            try
+            {
+                byte[] png = BuildSheetPng(128, 112, 16);
+                File.WriteAllBytes(Path.Combine(dir, "sheet.png"), png);
+                // Header declares 16 colors but a triple is malformed (300 is out of 0..255).
+                File.WriteAllText(Path.Combine(dir, "sheet.pal"),
+                    "JASC-PAL\r\n0100\r\n16\r\n0 0 0\r\n300 0 0\r\n");
+
+                AssetValidationResult r = DecompAssetValidatorCore.ValidateAssetPackage(AssetKind.PortraitPackage, dir);
+                Assert.False(r.Ok);
+                // ValidatePalette reports the structural fault.
+                Assert.Contains(r.Errors, e => e.Code == "BAD_PALETTE_COLOR" || e.Code == "BAD_PALETTE_COUNT");
+                // No misleading consistency diagnostics on a structurally invalid palette.
+                Assert.DoesNotContain(r.Errors, e => e.Code == "PALETTE_COUNT_MISMATCH");
+                Assert.DoesNotContain(r.Errors, e => e.Code == "PALETTE_COLOR_MISMATCH");
+            }
+            finally { Cleanup(dir); }
+        }
+
         // ---------------------------------------------------------------- fault safety
 
         [Fact]

--- a/FEBuilderGBA.Core.Tests/DecompPortraitPackageValidatorTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompPortraitPackageValidatorTests.cs
@@ -1,0 +1,456 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// Tests for the decomp-mode PORTRAIT PACKAGE validator (#1350) —
+    /// <see cref="DecompAssetValidatorCore.ValidateAssetPackage"/> + the new
+    /// <see cref="IndexedPngInfo.PaletteRgb"/> field.
+    ///
+    /// READ-ONLY: the package validator never reads CoreState.ROM (it takes a directory
+    /// path only) — proven by a source assertion plus the fact that every test runs without
+    /// a loaded ROM. Pure file I/O over temp dirs; no CoreState mutation, no SharedState.
+    /// </summary>
+    public class DecompPortraitPackageValidatorTests
+    {
+        // ---------------------------------------------------------------- helpers
+
+        /// <summary>A distinct, deterministic GBA palette (BGR555 LE) of <paramref name="colors"/> entries.</summary>
+        static byte[] BuildGbaPalette(int colors)
+        {
+            var pal = new byte[colors * 2];
+            for (int i = 0; i < colors; i++)
+            {
+                // Vary R/G/B across entries so PaletteRgb is non-trivial and a perturbation
+                // of one entry is unambiguously detectable.
+                int r5 = i & 0x1F;
+                int g5 = (i * 2) & 0x1F;
+                int b5 = (i * 3) & 0x1F;
+                ushort c = (ushort)((r5) | (g5 << 5) | (b5 << 10));
+                pal[i * 2 + 0] = (byte)(c & 0xFF);
+                pal[i * 2 + 1] = (byte)(c >> 8);
+            }
+            return pal;
+        }
+
+        /// <summary>Build a 128x112 (or arbitrary w x h) indexed sheet PNG with the given palette.</summary>
+        static byte[] BuildSheetPng(int w, int h, int colors)
+        {
+            var indices = new byte[w * h];
+            for (int i = 0; i < indices.Length; i++) indices[i] = (byte)(i % colors);
+            byte[] png = IndexedPngWriter.Write(indices, w, h, BuildGbaPalette(colors), colors, transparentIndex: 0);
+            Assert.NotNull(png);
+            return png;
+        }
+
+        /// <summary>
+        /// Build a JASC .pal text whose R/G/B triples EXACTLY match the PNG's emitted PLTE.
+        /// We read the PLTE back from the written PNG so the "matching" sidecar is robust to
+        /// the writer's BGR555→RGB conversion (no need to replicate it here).
+        /// </summary>
+        static string BuildMatchingJasc(byte[] pngBytes)
+        {
+            IndexedPngInfo info = IndexedPngReader.Read(pngBytes);
+            Assert.True(info.Ok, info.Error);
+            int count = info.PaletteRgb.Length / 3;
+            var sb = new StringBuilder();
+            sb.Append("JASC-PAL\r\n0100\r\n").Append(count.ToString(CultureInfo.InvariantCulture)).Append("\r\n");
+            for (int i = 0; i < count; i++)
+                sb.Append(info.PaletteRgb[i * 3 + 0]).Append(' ')
+                  .Append(info.PaletteRgb[i * 3 + 1]).Append(' ')
+                  .Append(info.PaletteRgb[i * 3 + 2]).Append("\r\n");
+            return sb.ToString();
+        }
+
+        /// <summary>Create a fresh temp directory and return its path.</summary>
+        static string FreshDir()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "pkg_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+
+        static void Cleanup(string dir)
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+
+        // PNG hand-build helpers (for the non-indexed / garbage cases).
+        static readonly byte[] Sig = { 137, 80, 78, 71, 13, 10, 26, 10 };
+
+        static void WriteU32BE(MemoryStream ms, uint v)
+        {
+            ms.WriteByte((byte)(v >> 24)); ms.WriteByte((byte)(v >> 16));
+            ms.WriteByte((byte)(v >> 8)); ms.WriteByte((byte)v);
+        }
+
+        static void WriteChunk(MemoryStream ms, string type, byte[] data)
+        {
+            WriteU32BE(ms, (uint)data.Length);
+            byte[] t = Encoding.ASCII.GetBytes(type);
+            ms.Write(t, 0, 4);
+            ms.Write(data, 0, data.Length);
+            WriteU32BE(ms, 0); // CRC not validated by the reader
+        }
+
+        static byte[] BuildIhdr(int w, int h, byte colorType)
+        {
+            var d = new byte[13];
+            d[0] = (byte)(w >> 24); d[1] = (byte)(w >> 16); d[2] = (byte)(w >> 8); d[3] = (byte)w;
+            d[4] = (byte)(h >> 24); d[5] = (byte)(h >> 16); d[6] = (byte)(h >> 8); d[7] = (byte)h;
+            d[8] = 8; d[9] = colorType;
+            return d;
+        }
+
+        /// <summary>A color-type-2 (truecolor) PNG with IDAT+IEND — parses but is NON_INDEXED.</summary>
+        static byte[] BuildNonIndexedPng(int w, int h)
+        {
+            using var ms = new MemoryStream();
+            ms.Write(Sig, 0, Sig.Length);
+            WriteChunk(ms, "IHDR", BuildIhdr(w, h, 2)); // colorType 2 = truecolor (no PLTE)
+            WriteChunk(ms, "IDAT", new byte[] { 0x78, 0x01, 0x03, 0x00, 0x00, 0x00, 0x00, 0x01 });
+            WriteChunk(ms, "IEND", Array.Empty<byte>());
+            return ms.ToArray();
+        }
+
+        // ---------------------------------------------------------------- ParseKind
+
+        [Theory]
+        [InlineData("portrait-package")]
+        [InlineData("portraitpackage")]
+        [InlineData("PORTRAIT-PACKAGE")]
+        public void ParseKind_PortraitPackage(string s)
+        {
+            Assert.Equal(AssetKind.PortraitPackage, DecompAssetValidatorCore.ParseKind(s));
+        }
+
+        // ---------------------------------------------------------------- IndexedPngReader.PaletteRgb
+
+        [Fact]
+        public void IndexedPngReader_PaletteRgb_RoundTrips()
+        {
+            int colors = 16;
+            byte[] png = BuildSheetPng(16, 16, colors);
+            IndexedPngInfo info = IndexedPngReader.Read(png);
+            Assert.True(info.Ok, info.Error);
+            Assert.Equal(colors, info.PaletteColorCount);
+            Assert.Equal(colors * 3, info.PaletteRgb.Length);
+
+            // PaletteRgb must equal the GBA→RGB conversion the writer applied (BGR555→8bit).
+            byte[] gba = BuildGbaPalette(colors);
+            for (int i = 0; i < colors; i++)
+            {
+                ushort c = (ushort)(gba[i * 2] | (gba[i * 2 + 1] << 8));
+                byte r = (byte)((c & 0x1F) << 3);
+                byte g = (byte)(((c >> 5) & 0x1F) << 3);
+                byte b = (byte)(((c >> 10) & 0x1F) << 3);
+                Assert.Equal(r, info.PaletteRgb[i * 3 + 0]);
+                Assert.Equal(g, info.PaletteRgb[i * 3 + 1]);
+                Assert.Equal(b, info.PaletteRgb[i * 3 + 2]);
+            }
+        }
+
+        // ---------------------------------------------------------------- happy path
+
+        [Fact]
+        public void Package_Valid128x112_WithMatchingSidecar_Ok()
+        {
+            string dir = FreshDir();
+            try
+            {
+                byte[] png = BuildSheetPng(128, 112, 16);
+                File.WriteAllBytes(Path.Combine(dir, "sheet.png"), png);
+                File.WriteAllText(Path.Combine(dir, "sheet.pal"), BuildMatchingJasc(png));
+
+                AssetValidationResult r = DecompAssetValidatorCore.ValidateAssetPackage(AssetKind.PortraitPackage, dir);
+                Assert.True(r.Ok, string.Join("; ", r.Errors.ConvertAll(e => e.Code + ":" + e.Message)));
+            }
+            finally { Cleanup(dir); }
+        }
+
+        // ---------------------------------------------------------------- sheet presence
+
+        [Fact]
+        public void Package_MissingSheet_Error()
+        {
+            string dir = FreshDir();
+            try
+            {
+                AssetValidationResult r = DecompAssetValidatorCore.ValidateAssetPackage(AssetKind.PortraitPackage, dir);
+                Assert.False(r.Ok);
+                Assert.Contains(r.Errors, e => e.Code == "MISSING_SHEET");
+            }
+            finally { Cleanup(dir); }
+        }
+
+        [Fact]
+        public void Package_TwoPngs_MultipleSheets()
+        {
+            string dir = FreshDir();
+            try
+            {
+                byte[] png = BuildSheetPng(128, 112, 16);
+                File.WriteAllBytes(Path.Combine(dir, "a.png"), png);
+                File.WriteAllBytes(Path.Combine(dir, "b.png"), png);
+
+                AssetValidationResult r = DecompAssetValidatorCore.ValidateAssetPackage(AssetKind.PortraitPackage, dir);
+                Assert.False(r.Ok);
+                Assert.Contains(r.Errors, e => e.Code == "MULTIPLE_SHEETS");
+            }
+            finally { Cleanup(dir); }
+        }
+
+        // ---------------------------------------------------------------- main-only / incomplete
+
+        [Fact]
+        public void Package_MainOnly96x80_NoAllowFlag_IncompleteError()
+        {
+            string dir = FreshDir();
+            try
+            {
+                byte[] png = BuildSheetPng(96, 80, 16);
+                File.WriteAllBytes(Path.Combine(dir, "sheet.png"), png);
+
+                AssetValidationResult r = DecompAssetValidatorCore.ValidateAssetPackage(AssetKind.PortraitPackage, dir, allowMainOnly: false);
+                Assert.False(r.Ok);
+                Assert.Contains(r.Errors, e => e.Code == "INCOMPLETE_PACKAGE");
+            }
+            finally { Cleanup(dir); }
+        }
+
+        [Fact]
+        public void Package_MainOnly96x80_AllowFlag_WarnsButOk()
+        {
+            string dir = FreshDir();
+            try
+            {
+                byte[] png = BuildSheetPng(96, 80, 16);
+                File.WriteAllBytes(Path.Combine(dir, "sheet.png"), png);
+
+                AssetValidationResult r = DecompAssetValidatorCore.ValidateAssetPackage(AssetKind.PortraitPackage, dir, allowMainOnly: true);
+                Assert.DoesNotContain(r.Errors, e => e.Code == "INCOMPLETE_PACKAGE");
+                Assert.Contains(r.Warnings, w => w.Code == "INCOMPLETE_PACKAGE");
+                Assert.True(r.Ok, string.Join("; ", r.Errors.ConvertAll(e => e.Code)));
+            }
+            finally { Cleanup(dir); }
+        }
+
+        // ---------------------------------------------------------------- slot bounds
+
+        [Fact]
+        public void Package_TooNarrow120x112_SheetTooSmall()
+        {
+            // 120x112: the x=96 mini/eye/mouth column (32px wide) needs 128 → exceeds width.
+            string dir = FreshDir();
+            try
+            {
+                byte[] png = BuildSheetPng(120, 112, 16);
+                File.WriteAllBytes(Path.Combine(dir, "sheet.png"), png);
+
+                AssetValidationResult r = DecompAssetValidatorCore.ValidateAssetPackage(AssetKind.PortraitPackage, dir);
+                Assert.False(r.Ok);
+                Assert.Contains(r.Errors, e => e.Code == "SHEET_TOO_SMALL");
+                // Not the canonical 96x80 main-only case either.
+                Assert.DoesNotContain(r.Errors, e => e.Code == "INCOMPLETE_PACKAGE");
+            }
+            finally { Cleanup(dir); }
+        }
+
+        [Fact]
+        public void Package_NonCanonicalButLargeEnough_SheetBadDimsWarn()
+        {
+            // 256x256: non-canonical but every slot (max extent 128x112) fits → WARN only.
+            string dir = FreshDir();
+            try
+            {
+                byte[] png = BuildSheetPng(256, 256, 16);
+                File.WriteAllBytes(Path.Combine(dir, "sheet.png"), png);
+
+                AssetValidationResult r = DecompAssetValidatorCore.ValidateAssetPackage(AssetKind.PortraitPackage, dir);
+                Assert.Contains(r.Warnings, w => w.Code == "SHEET_BAD_DIMS");
+                Assert.DoesNotContain(r.Errors, e => e.Code == "SHEET_TOO_SMALL");
+            }
+            finally { Cleanup(dir); }
+        }
+
+        // ---------------------------------------------------------------- structural / palette
+
+        [Fact]
+        public void Package_NonIndexedSheet_NonIndexed()
+        {
+            string dir = FreshDir();
+            try
+            {
+                File.WriteAllBytes(Path.Combine(dir, "sheet.png"), BuildNonIndexedPng(128, 112));
+
+                AssetValidationResult r = DecompAssetValidatorCore.ValidateAssetPackage(AssetKind.PortraitPackage, dir);
+                Assert.False(r.Ok);
+                Assert.Contains(r.Errors, e => e.Code == "NON_INDEXED" || e.Code == "BAD_PNG");
+            }
+            finally { Cleanup(dir); }
+        }
+
+        [Fact]
+        public void Package_SheetPaletteGt16_PortraitPaletteGt16Warn()
+        {
+            string dir = FreshDir();
+            try
+            {
+                byte[] png = BuildSheetPng(128, 112, 32); // 32-color palette
+                File.WriteAllBytes(Path.Combine(dir, "sheet.png"), png);
+                File.WriteAllText(Path.Combine(dir, "sheet.pal"), BuildMatchingJasc(png));
+
+                AssetValidationResult r = DecompAssetValidatorCore.ValidateAssetPackage(AssetKind.PortraitPackage, dir);
+                Assert.Contains(r.Warnings, w => w.Code == "PORTRAIT_PALETTE_GT16");
+            }
+            finally { Cleanup(dir); }
+        }
+
+        [Fact]
+        public void Package_MissingSidecar_MissingPaletteWarn_StillValidatesSheet()
+        {
+            string dir = FreshDir();
+            try
+            {
+                byte[] png = BuildSheetPng(128, 112, 16);
+                File.WriteAllBytes(Path.Combine(dir, "sheet.png"), png);
+                // no .pal sidecar
+
+                AssetValidationResult r = DecompAssetValidatorCore.ValidateAssetPackage(AssetKind.PortraitPackage, dir);
+                Assert.Contains(r.Warnings, w => w.Code == "MISSING_PALETTE");
+                Assert.True(r.Ok, string.Join("; ", r.Errors.ConvertAll(e => e.Code)));
+            }
+            finally { Cleanup(dir); }
+        }
+
+        [Fact]
+        public void Package_SidecarCountMismatch_PaletteCountMismatch()
+        {
+            string dir = FreshDir();
+            try
+            {
+                byte[] png = BuildSheetPng(128, 112, 16);
+                File.WriteAllBytes(Path.Combine(dir, "sheet.png"), png);
+                // Sidecar has only 8 colors (valid JASC) but the PLTE has 16.
+                File.WriteAllText(Path.Combine(dir, "sheet.pal"),
+                    "JASC-PAL\r\n0100\r\n8\r\n0 0 0\r\n8 8 8\r\n16 16 16\r\n24 24 24\r\n32 32 32\r\n40 40 40\r\n48 48 48\r\n56 56 56\r\n");
+
+                AssetValidationResult r = DecompAssetValidatorCore.ValidateAssetPackage(AssetKind.PortraitPackage, dir);
+                Assert.False(r.Ok);
+                Assert.Contains(r.Errors, e => e.Code == "PALETTE_COUNT_MISMATCH");
+            }
+            finally { Cleanup(dir); }
+        }
+
+        [Fact]
+        public void Package_SidecarColorMismatch_PaletteColorMismatch()
+        {
+            // THE key consistency test: same count, one differing RGB triple.
+            string dir = FreshDir();
+            try
+            {
+                byte[] png = BuildSheetPng(128, 112, 16);
+                File.WriteAllBytes(Path.Combine(dir, "sheet.png"), png);
+
+                // Build a matching sidecar, then perturb entry 5's red channel.
+                IndexedPngInfo info = IndexedPngReader.Read(png);
+                int count = info.PaletteRgb.Length / 3;
+                var sb = new StringBuilder();
+                sb.Append("JASC-PAL\r\n0100\r\n").Append(count).Append("\r\n");
+                for (int i = 0; i < count; i++)
+                {
+                    int rr = info.PaletteRgb[i * 3 + 0];
+                    int gg = info.PaletteRgb[i * 3 + 1];
+                    int bb = info.PaletteRgb[i * 3 + 2];
+                    if (i == 5) rr = (rr == 255) ? 0 : rr + 1; // perturb exactly one channel
+                    sb.Append(rr).Append(' ').Append(gg).Append(' ').Append(bb).Append("\r\n");
+                }
+                File.WriteAllText(Path.Combine(dir, "sheet.pal"), sb.ToString());
+
+                AssetValidationResult r = DecompAssetValidatorCore.ValidateAssetPackage(AssetKind.PortraitPackage, dir);
+                Assert.False(r.Ok);
+                Assert.Contains(r.Errors, e => e.Code == "PALETTE_COLOR_MISMATCH");
+            }
+            finally { Cleanup(dir); }
+        }
+
+        // ---------------------------------------------------------------- fault safety
+
+        [Fact]
+        public void Package_GarbagePng_NoThrow_Error()
+        {
+            string dir = FreshDir();
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "sheet.png"), "this is not a png");
+
+                AssetValidationResult r = DecompAssetValidatorCore.ValidateAssetPackage(AssetKind.PortraitPackage, dir);
+                Assert.False(r.Ok);
+                Assert.NotEmpty(r.Errors);
+            }
+            finally { Cleanup(dir); }
+        }
+
+        [Fact]
+        public void Package_DirNotFound_DirNotFound()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "no_such_" + Guid.NewGuid().ToString("N"));
+            AssetValidationResult r = DecompAssetValidatorCore.ValidateAssetPackage(AssetKind.PortraitPackage, dir);
+            Assert.False(r.Ok);
+            Assert.Contains(r.Errors, e => e.Code == "DIR_NOT_FOUND");
+        }
+
+        [Fact]
+        public void Package_WrongKind_UnknownKind()
+        {
+            string dir = FreshDir();
+            try
+            {
+                AssetValidationResult r = DecompAssetValidatorCore.ValidateAssetPackage(AssetKind.Graphics, dir);
+                Assert.False(r.Ok);
+                Assert.Contains(r.Errors, e => e.Code == "UNKNOWN_KIND");
+            }
+            finally { Cleanup(dir); }
+        }
+
+        // ---------------------------------------------------------------- source assertion
+
+        [SkippableFact]
+        public void PackageValidator_DoesNotReference_CoreStateRom_SourceAssertion()
+        {
+            // The package validation path (in DecompAssetValidatorCore.cs) must contain no
+            // real CODE reference to CoreState.ROM. Strip comment lines so XML docs that
+            // mention CoreState.ROM (to explain it is never read) do not trip the guard.
+            string root = FindRepoRoot();
+            Skip.If(root == null, "repo root not found");
+            string src = Path.Combine(root, "FEBuilderGBA.Core", "DecompAssetValidatorCore.cs");
+            Skip.If(!File.Exists(src), "validator source not found");
+
+            foreach (string line in File.ReadAllLines(src))
+            {
+                string trimmed = line.TrimStart();
+                if (trimmed.StartsWith("//") || trimmed.StartsWith("///") || trimmed.StartsWith("*"))
+                    continue;
+                Assert.DoesNotContain("CoreState.ROM", line);
+            }
+        }
+
+        static string FindRepoRoot()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null)
+            {
+                if (File.Exists(Path.Combine(dir.FullName, "FEBuilderGBA.sln")))
+                    return dir.FullName;
+                dir = dir.Parent;
+            }
+            return null;
+        }
+    }
+}

--- a/FEBuilderGBA.Core/DecompAssetValidatorCore.cs
+++ b/FEBuilderGBA.Core/DecompAssetValidatorCore.cs
@@ -282,20 +282,50 @@ namespace FEBuilderGBA
                     $"Sheet palette has {info.PaletteColorCount} colors; a GBA portrait is 4bpp (max {PortraitPaletteMax}). Indices >15 would be clipped on import."));
             }
 
-            // 5) Sidecar palette: optional JASC .pal. When present, validate its structure AND
-            // compare it entry-by-entry against the sheet's embedded PLTE.
+            // 5) Sidecar palette: optional JASC .pal. The sidecar that BELONGS to this sheet
+            // is the one whose name matches the sheet (sheet.png -> sheet.pal); picking the
+            // first sorted *.pal could compare the sheet PLTE against an unrelated palette and
+            // emit false PALETTE_* mismatches (Copilot PR #1353 review). Match by sheet name;
+            // any OTHER *.pal in the dir is reported as an extra sidecar (informational warn).
+            string expectedPal = Path.ChangeExtension(sheetPath, ".pal");
             string[] pals = Directory.GetFiles(dirPath, "*.pal");
             Array.Sort(pals, StringComparer.Ordinal);
-            if (pals.Length == 0)
+            string matchedPal = null;
+            foreach (string p in pals)
             {
+                if (string.Equals(Path.GetFullPath(p), Path.GetFullPath(expectedPal),
+                        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+                {
+                    matchedPal = p;
+                    break;
+                }
+            }
+
+            if (matchedPal == null)
+            {
+                // No sidecar matching the sheet name. The sheet's embedded PLTE was checked by
+                // ValidatePng above (when the PNG was indexed); a JASC sidecar matching the
+                // sheet is still recommended for decomp builds. Keep the wording generic — for
+                // a NON_INDEXED / invalid-PLTE sheet the embedded palette may not have validated.
                 r.Warnings.Add(new AssetIssue("MISSING_PALETTE",
-                    $"No *.pal sidecar found in '{dirPath}'. The sheet's embedded PLTE was validated, but a JASC sidecar is recommended for decomp builds."));
+                    $"No sidecar '{Path.GetFileName(expectedPal)}' found in '{dirPath}'. A JASC sidecar matching the sheet name is recommended for decomp builds."));
+                // Surface any unrelated *.pal so the user knows it was NOT used for comparison.
+                if (pals.Length > 0)
+                {
+                    r.Warnings.Add(new AssetIssue("EXTRA_PALETTE",
+                        $"Found {pals.Length} *.pal file(s) but none match the sheet name '{Path.GetFileNameWithoutExtension(sheetPath)}.pal'; palette consistency was NOT checked."));
+                }
             }
             else
             {
-                string palPath = pals[0];
-                ValidatePalette(palPath, r);
-                ComparePaletteConsistency(palPath, info, r);
+                ValidatePalette(matchedPal, r);
+                ComparePaletteConsistency(matchedPal, info, r);
+                // Note any additional sidecars that are not the sheet's own.
+                if (pals.Length > 1)
+                {
+                    r.Warnings.Add(new AssetIssue("EXTRA_PALETTE",
+                        $"Found {pals.Length} *.pal file(s); only '{Path.GetFileName(matchedPal)}' (matching the sheet) was used for palette consistency."));
+                }
             }
         }
 
@@ -603,8 +633,24 @@ namespace FEBuilderGBA
                         || !TryParseByte(parts[0], out int rr)
                         || !TryParseByte(parts[1], out int gg)
                         || !TryParseByte(parts[2], out int bb))
-                        break; // a malformed triple stops the scan; ValidatePalette already errored
+                    {
+                        // A malformed triple means the JASC file is structurally invalid (and
+                        // ValidatePalette already errored on it). Return FALSE so the caller
+                        // SKIPS the consistency comparison rather than emitting a misleading
+                        // PALETTE_COUNT_MISMATCH/PALETTE_COLOR_MISMATCH on a partial color list
+                        // (Copilot PR #1353 review).
+                        colors = new List<(int, int, int)>();
+                        return false;
+                    }
                     colors.Add((rr, gg, bb));
+                }
+
+                // Fewer triples than the header declared => also structurally invalid (the
+                // declared count was not satisfied). Skip the comparison for the same reason.
+                if (colors.Count < count)
+                {
+                    colors = new List<(int, int, int)>();
+                    return false;
                 }
                 return true;
             }

--- a/FEBuilderGBA.Core/DecompAssetValidatorCore.cs
+++ b/FEBuilderGBA.Core/DecompAssetValidatorCore.cs
@@ -22,6 +22,12 @@ namespace FEBuilderGBA
         Icon,
         /// <summary>.mar tile layout binary (validated against its sidecar JSON).</summary>
         MapLayout,
+        /// <summary>
+        /// A multi-file PORTRAIT PACKAGE directory (#1350): a single 128x112 composite
+        /// portrait sheet PNG + an optional sidecar JASC .pal. Validated for sheet-slot
+        /// geometry and palette consistency (PLTE-vs-JASC), NOT write-back / frame order.
+        /// </summary>
+        PortraitPackage,
     }
 
     /// <summary>One validation finding (error or warning): a stable CODE + a message.</summary>
@@ -78,6 +84,36 @@ namespace FEBuilderGBA
         /// <summary>Icon dimensions (px).</summary>
         public const int IconSize = 16;
 
+        // ----- Portrait composite SHEET geometry (#1350) -----
+        // Canonical FE7/8 portrait composite sheet is 128x112 indexed. The slot coords
+        // are cited from PortraitImportPreviewCore.cs (:60-92) and
+        // PortraitRendererCore.SplitPortraitSheet (:588-602); they are NOT invented here.
+
+        /// <summary>Full FE7/8 portrait composite sheet width (px).</summary>
+        public const int SheetWidth = 128;
+        /// <summary>Full FE7/8 portrait composite sheet height (px).</summary>
+        public const int SheetHeight = 112;
+
+        /// <summary>Mini/chibi face slot inside the sheet: (96,16) 32x32.</summary>
+        public const int MiniX = 96, MiniY = 16, MiniW = 32, MiniH = 32;
+        /// <summary>Half-closed eyes slot inside the sheet: (96,48) 32x16.</summary>
+        public const int EyeHalfX = 96, EyeHalfY = 48, EyeHalfW = 32, EyeHalfH = 16;
+        /// <summary>Closed eyes slot inside the sheet: (96,64) 32x16.</summary>
+        public const int EyeClosedX = 96, EyeClosedY = 64, EyeClosedW = 32, EyeClosedH = 16;
+
+        /// <summary>
+        /// The 7 mouth slots (each 32x16) inside the sheet:
+        /// (0,80)(32,80)(64,80)(96,80)(0,96)(32,96)(64,96).
+        /// </summary>
+        static readonly (int x, int y, int w, int h)[] MouthSlots =
+        {
+            (0, 80, 32, 16), (32, 80, 32, 16), (64, 80, 32, 16), (96, 80, 32, 16),
+            (0, 96, 32, 16), (32, 96, 32, 16), (64, 96, 32, 16),
+        };
+
+        /// <summary>GBA portrait colour cap — a portrait tile is 4bpp (a single 16-color bank).</summary>
+        public const int PortraitPaletteMax = 16;
+
         /// <summary>
         /// Validate an asset file. On a missing file returns a single
         /// <c>FILE_NOT_FOUND</c> error. Dispatches by <paramref name="kind"/>. NEVER
@@ -121,8 +157,218 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
-        /// Map a kind string ("graphics"/"palette"/"portrait"/"icon"/"map"|"maplayout",
-        /// case-insensitive) to an <see cref="AssetKind"/>; null when unrecognized.
+        /// Validate a multi-file PORTRAIT PACKAGE directory (#1350). The only supported
+        /// <paramref name="kind"/> is <see cref="AssetKind.PortraitPackage"/>. The directory
+        /// must contain exactly one composite sheet PNG (128x112 full package, or 96x80
+        /// main-mug-only) plus an optional sidecar JASC <c>.pal</c>; this entry point checks
+        /// the sheet's structure (reusing <see cref="ValidatePng"/>), the 128x112 slot
+        /// geometry, the 4bpp palette cap, and PLTE-vs-JASC palette consistency.
+        ///
+        /// When <paramref name="allowMainOnly"/> is true a 96x80 main-only sheet downgrades
+        /// the <c>INCOMPLETE_PACKAGE</c> error to a warning (the package is intentionally
+        /// just the main mug). NEVER reads the ROM, NEVER mutates anything, NEVER throws —
+        /// every fault becomes a <c>VALIDATOR_FAULT</c> error.
+        /// </summary>
+        public static AssetValidationResult ValidateAssetPackage(AssetKind kind, string dirPath, bool allowMainOnly = false)
+        {
+            var r = new AssetValidationResult();
+            try
+            {
+                if (string.IsNullOrEmpty(dirPath) || !Directory.Exists(dirPath))
+                {
+                    r.Errors.Add(new AssetIssue("DIR_NOT_FOUND", $"Directory not found: {dirPath ?? "(null)"}"));
+                    return r;
+                }
+
+                if (kind != AssetKind.PortraitPackage)
+                {
+                    r.Errors.Add(new AssetIssue("UNKNOWN_KIND", $"ValidateAssetPackage only supports portrait-package; got: {kind}"));
+                    return r;
+                }
+
+                ValidatePortraitPackage(dirPath, allowMainOnly, r);
+                return r;
+            }
+            catch (Exception ex)
+            {
+                r.Errors.Add(new AssetIssue("VALIDATOR_FAULT", "Unexpected validator fault: " + ex.Message));
+                return r;
+            }
+        }
+
+        /// <summary>
+        /// Validate a portrait-package directory: enumerate the single sheet PNG, reuse the
+        /// shared <see cref="ValidatePng"/> structural checks (packageMode — no single-mug
+        /// dims advisory), then add package-specific 128x112 slot-geometry / palette-cap /
+        /// sidecar-palette-consistency checks. Appends every finding to <paramref name="r"/>.
+        /// </summary>
+        static void ValidatePortraitPackage(string dirPath, bool allowMainOnly, AssetValidationResult r)
+        {
+            // 1) Find the single sheet PNG. Sort deterministically so a multi-PNG dir picks a
+            // stable "first" sheet for full diagnostics rather than a filesystem-order one.
+            string[] pngs = Directory.GetFiles(dirPath, "*.png");
+            Array.Sort(pngs, StringComparer.Ordinal);
+            if (pngs.Length == 0)
+            {
+                r.Errors.Add(new AssetIssue("MISSING_SHEET",
+                    $"No *.png sheet found in '{dirPath}'. A portrait package needs one composite sheet PNG."));
+                return;
+            }
+            if (pngs.Length > 1)
+            {
+                // Report the ambiguity but still validate the first (sorted) sheet so the user
+                // gets full diagnostics in one run — they then know which extra files to remove.
+                r.Errors.Add(new AssetIssue("MULTIPLE_SHEETS",
+                    $"Found {pngs.Length} *.png files; a portrait package needs exactly one. Validating '{Path.GetFileName(pngs[0])}' (first, sorted)."));
+            }
+            string sheetPath = pngs[0];
+
+            // 2) Reuse the shared PNG structural / index-level checks (colorType 3, tile-align,
+            // palette size, index range, index-0 transparency). packageMode skips the single-mug
+            // PORTRAIT_DIMS advisory because a package sheet is the larger 128x112 composite.
+            ValidatePng(AssetKind.Portrait, sheetPath, r, packageMode: true);
+
+            // Re-read the parsed PNG info for the geometry/palette checks (file already read &
+            // validated above — this is a cheap second parse, never reads the ROM).
+            byte[] bytes;
+            try { bytes = File.ReadAllBytes(sheetPath); }
+            catch (Exception ex)
+            {
+                r.Errors.Add(new AssetIssue("READ_FAILED", "Could not read sheet: " + ex.Message));
+                return;
+            }
+            IndexedPngInfo info = IndexedPngReader.Read(bytes);
+            if (!info.Ok)
+                return; // ValidatePng already reported BAD_PNG; nothing further to geometry-check.
+
+            // 3) Sheet dimensions / slot geometry.
+            int w = info.Width, h = info.Height;
+            if (w == SheetWidth && h == SheetHeight)
+            {
+                // Full package — exactly the canonical composite. OK.
+            }
+            else if (w == PortraitMainWidth && h == PortraitMainHeight)
+            {
+                // Main-mug-only (96x80): an INCOMPLETE package. Error by default; downgrade to
+                // a warning when the caller explicitly allows a main-only package.
+                if (allowMainOnly)
+                {
+                    r.Warnings.Add(new AssetIssue("INCOMPLETE_PACKAGE",
+                        $"Sheet is {w}x{h} (main mug only) — mini/eye/mouth slots are absent. Accepted because --allow-main-only was set."));
+                }
+                else
+                {
+                    r.Errors.Add(new AssetIssue("INCOMPLETE_PACKAGE",
+                        $"Sheet is {w}x{h} (main mug only); the full package sheet is {SheetWidth}x{SheetHeight}. Pass allow-main-only to accept a main-mug-only package."));
+                }
+            }
+            else
+            {
+                // Neither canonical size. Check whether every required slot still fits; if so
+                // it's a non-canonical WARN, otherwise the out-of-bounds slots are errors.
+                int oob = CheckSlotBounds(w, h, r);
+                if (oob == 0)
+                {
+                    r.Warnings.Add(new AssetIssue("SHEET_BAD_DIMS",
+                        $"Sheet is {w}x{h}; expected the full {SheetWidth}x{SheetHeight} package (or {PortraitMainWidth}x{PortraitMainHeight} main-only). All slots fit but the dimensions are non-canonical."));
+                }
+                // else: CheckSlotBounds already emitted SHEET_TOO_SMALL per out-of-bounds slot.
+            }
+
+            // 4) Portrait palette bit-depth: a GBA portrait tile is 4bpp (a single 16-color bank).
+            if (info.PaletteColorCount > PortraitPaletteMax)
+            {
+                r.Warnings.Add(new AssetIssue("PORTRAIT_PALETTE_GT16",
+                    $"Sheet palette has {info.PaletteColorCount} colors; a GBA portrait is 4bpp (max {PortraitPaletteMax}). Indices >15 would be clipped on import."));
+            }
+
+            // 5) Sidecar palette: optional JASC .pal. When present, validate its structure AND
+            // compare it entry-by-entry against the sheet's embedded PLTE.
+            string[] pals = Directory.GetFiles(dirPath, "*.pal");
+            Array.Sort(pals, StringComparer.Ordinal);
+            if (pals.Length == 0)
+            {
+                r.Warnings.Add(new AssetIssue("MISSING_PALETTE",
+                    $"No *.pal sidecar found in '{dirPath}'. The sheet's embedded PLTE was validated, but a JASC sidecar is recommended for decomp builds."));
+            }
+            else
+            {
+                string palPath = pals[0];
+                ValidatePalette(palPath, r);
+                ComparePaletteConsistency(palPath, info, r);
+            }
+        }
+
+        /// <summary>
+        /// Verify every required portrait slot (mini, half/closed eyes, the 7 mouths) lies
+        /// fully within a <paramref name="w"/>x<paramref name="h"/> sheet. Emits a
+        /// <c>SHEET_TOO_SMALL</c> error per out-of-bounds slot (naming the slot + bound) and
+        /// returns the number of out-of-bounds slots (0 = all fit).
+        /// </summary>
+        static int CheckSlotBounds(int w, int h, AssetValidationResult r)
+        {
+            int oob = 0;
+            void Check(string name, int x, int y, int sw, int sh)
+            {
+                if (x + sw > w || y + sh > h)
+                {
+                    oob++;
+                    r.Errors.Add(new AssetIssue("SHEET_TOO_SMALL",
+                        $"Slot '{name}' ({x},{y} {sw}x{sh}) exceeds the {w}x{h} sheet (needs {x + sw}x{y + sh})."));
+                }
+            }
+            Check("mini", MiniX, MiniY, MiniW, MiniH);
+            Check("eyeHalf", EyeHalfX, EyeHalfY, EyeHalfW, EyeHalfH);
+            Check("eyeClosed", EyeClosedX, EyeClosedY, EyeClosedW, EyeClosedH);
+            for (int i = 0; i < MouthSlots.Length; i++)
+            {
+                var (mx, my, mw, mh) = MouthSlots[i];
+                Check($"mouth{i + 1}", mx, my, mw, mh);
+            }
+            return oob;
+        }
+
+        /// <summary>
+        /// Compare a sidecar JASC palette against the sheet PNG's embedded PLTE (#1350). The
+        /// PLTE is stored R,G,B (PNG order) and JASC is also <c>R G B</c>, so they compare
+        /// directly. A differing entry COUNT → <c>PALETTE_COUNT_MISMATCH</c>; same count but
+        /// any differing triple → <c>PALETTE_COLOR_MISMATCH</c> (reporting the first differing
+        /// index + both values). Skipped silently when the PLTE was not recovered or the JASC
+        /// could not be parsed (the structural checks already errored). NEVER throws.
+        /// </summary>
+        static void ComparePaletteConsistency(string palPath, IndexedPngInfo info, AssetValidationResult r)
+        {
+            if (info.PaletteRgb == null || info.PaletteRgb.Length == 0)
+                return; // no PLTE recovered — structural check already errored, skip comparison.
+            if (!TryParseJascColors(palPath, out List<(int r, int g, int b)> jasc))
+                return; // malformed JASC — ValidatePalette already errored.
+
+            int plteCount = info.PaletteRgb.Length / 3;
+            if (jasc.Count != plteCount)
+            {
+                r.Errors.Add(new AssetIssue("PALETTE_COUNT_MISMATCH",
+                    $"Sidecar palette has {jasc.Count} colors but the sheet PLTE has {plteCount}."));
+                return;
+            }
+
+            for (int i = 0; i < plteCount; i++)
+            {
+                int pr = info.PaletteRgb[i * 3 + 0];
+                int pg = info.PaletteRgb[i * 3 + 1];
+                int pb = info.PaletteRgb[i * 3 + 2];
+                if (pr != jasc[i].r || pg != jasc[i].g || pb != jasc[i].b)
+                {
+                    r.Errors.Add(new AssetIssue("PALETTE_COLOR_MISMATCH",
+                        $"Palette entry {i} differs: sidecar ({jasc[i].r} {jasc[i].g} {jasc[i].b}) vs sheet PLTE ({pr} {pg} {pb})."));
+                    return; // report the first offender only.
+                }
+            }
+        }
+
+        /// <summary>
+        /// Map a kind string ("graphics"/"palette"/"portrait"/"icon"/"map"|"maplayout"/
+        /// "portrait-package"|"portraitpackage", case-insensitive) to an
+        /// <see cref="AssetKind"/>; null when unrecognized.
         /// </summary>
         public static AssetKind? ParseKind(string s)
         {
@@ -135,13 +381,21 @@ namespace FEBuilderGBA
                 case "icon": return AssetKind.Icon;
                 case "map":
                 case "maplayout": return AssetKind.MapLayout;
+                case "portrait-package":
+                case "portraitpackage": return AssetKind.PortraitPackage;
                 default: return null;
             }
         }
 
         // -------------------------------------------------------------- PNG kinds
 
-        static void ValidatePng(AssetKind kind, string path, AssetValidationResult r)
+        /// <summary>
+        /// Structural + index-level checks shared by all PNG kinds. When
+        /// <paramref name="packageMode"/> is true the <c>PORTRAIT_DIMS</c>/<c>ICON_DIMS</c>
+        /// single-mug advisories are skipped — a portrait PACKAGE sheet is the larger
+        /// 128x112 composite, so the 96x80 single-mug advisory does not apply (#1350).
+        /// </summary>
+        static void ValidatePng(AssetKind kind, string path, AssetValidationResult r, bool packageMode = false)
         {
             byte[] bytes;
             try { bytes = File.ReadAllBytes(path); }
@@ -231,8 +485,9 @@ namespace FEBuilderGBA
                     "PNG uses scanline filters other than None; index-level checks were skipped (structural checks still applied)."));
             }
 
-            // Kind-specific dimension advisories.
-            if (kind == AssetKind.Portrait)
+            // Kind-specific dimension advisories. In packageMode these single-asset advisories
+            // are suppressed — a portrait PACKAGE sheet is the 128x112 composite, not a 96x80 mug.
+            if (!packageMode && kind == AssetKind.Portrait)
             {
                 if (!(info.Width == PortraitMainWidth && info.Height == PortraitMainHeight))
                 {
@@ -240,7 +495,7 @@ namespace FEBuilderGBA
                         $"Portrait is {info.Width}x{info.Height}; the main mug is {PortraitMainWidth}x{PortraitMainHeight}. Confirm this is an intended mouth/chibi strip."));
                 }
             }
-            else if (kind == AssetKind.Icon)
+            else if (!packageMode && kind == AssetKind.Icon)
             {
                 if (!(info.Width == IconSize && info.Height == IconSize))
                 {
@@ -314,6 +569,49 @@ namespace FEBuilderGBA
             {
                 r.Errors.Add(new AssetIssue("BAD_PALETTE_COUNT",
                     $"Header declares {count} colors but only {colorsParsed} 'R G B' lines were found."));
+            }
+        }
+
+        /// <summary>
+        /// Best-effort JASC palette colour parse (#1350): reads up to the declared count of
+        /// <c>R G B</c> triples after the 3-line header. Returns false (and an empty list)
+        /// on a malformed header / count; otherwise true with whatever valid triples were
+        /// found (a bad triple stops the scan but does not fault). Used by the package
+        /// validator for PLTE-vs-JASC consistency — it does NOT replace
+        /// <see cref="ValidatePalette"/>'s structural error reporting. NEVER throws.
+        /// </summary>
+        static bool TryParseJascColors(string path, out List<(int r, int g, int b)> colors)
+        {
+            colors = new List<(int, int, int)>();
+            try
+            {
+                string[] lines = File.ReadAllLines(path);
+                if (lines.Length < 3
+                    || lines[0].Trim() != "JASC-PAL"
+                    || lines[1].Trim() != "0100")
+                    return false;
+                if (!int.TryParse(lines[2].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out int count)
+                    || count < 1 || count > 256)
+                    return false;
+
+                for (int li = 3; li < lines.Length && colors.Count < count; li++)
+                {
+                    string line = lines[li].Trim();
+                    if (line.Length == 0) continue;
+                    string[] parts = line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length < 3
+                        || !TryParseByte(parts[0], out int rr)
+                        || !TryParseByte(parts[1], out int gg)
+                        || !TryParseByte(parts[2], out int bb))
+                        break; // a malformed triple stops the scan; ValidatePalette already errored
+                    colors.Add((rr, gg, bb));
+                }
+                return true;
+            }
+            catch
+            {
+                colors = new List<(int, int, int)>();
+                return false;
             }
         }
 

--- a/FEBuilderGBA.Core/IndexedPngReader.cs
+++ b/FEBuilderGBA.Core/IndexedPngReader.cs
@@ -29,6 +29,13 @@ namespace FEBuilderGBA
         /// <summary>Number of palette entries (PLTE length / 3); 0 when no PLTE.</summary>
         public int PaletteColorCount;
 
+        /// <summary>
+        /// Raw PLTE chunk bytes (R,G,B per entry, 3 bytes each, PNG byte order); empty
+        /// when no PLTE chunk was present. Lets a caller compare the embedded palette
+        /// directly against a sidecar JASC palette (#1350 portrait-package consistency).
+        /// </summary>
+        public byte[] PaletteRgb = Array.Empty<byte>();
+
         /// <summary>True when a tRNS chunk is present.</summary>
         public bool HasTrns;
 
@@ -116,6 +123,11 @@ namespace FEBuilderGBA
 
                         case "PLTE":
                             info.PaletteColorCount = len / 3;
+                            // Also capture the raw PLTE bytes (R,G,B per entry) so callers
+                            // can do a palette-consistency comparison (#1350).
+                            var plte = new byte[len];
+                            Array.Copy(pngBytes, dataPos, plte, 0, len);
+                            info.PaletteRgb = plte;
                             sawPlte = true;
                             break;
 

--- a/FEBuilderGBA.E2ETests/Tests/CliTests.cs
+++ b/FEBuilderGBA.E2ETests/Tests/CliTests.cs
@@ -138,5 +138,179 @@ namespace FEBuilderGBA.E2ETests.Tests
                 try { File.Delete(png); } catch { }
             }
         }
+
+        // -------------------------------------------------- portrait-package (#1350)
+
+        [Fact]
+        public void ValidateAsset_PortraitPackage_Valid_ExitsZero()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "cli_pkg_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                byte[] png = BuildIndexedPng(128, 112, 16, out byte[] plteRgb);
+                File.WriteAllBytes(Path.Combine(dir, "sheet.png"), png);
+                File.WriteAllText(Path.Combine(dir, "sheet.pal"), BuildJascFromRgb(plteRgb));
+
+                var (code, stdout, stderr) = AppRunner.Run(CliExe, $"--validate-asset --kind=portrait-package --path \"{dir}\"", timeoutMs: 30_000);
+                Assert.True(code == 0, $"exit {code}; stdout={stdout}; stderr={stderr}");
+            }
+            finally
+            {
+                try { Directory.Delete(dir, recursive: true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void ValidateAsset_PortraitPackage_MissingSheet_ExitsTwo()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "cli_pkg_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var (code, stdout, stderr) = AppRunner.Run(CliExe, $"--validate-asset --kind=portrait-package --path \"{dir}\"", timeoutMs: 30_000);
+                Assert.Equal(2, code);
+                Assert.Contains("MISSING_SHEET", stdout + stderr, StringComparison.Ordinal);
+            }
+            finally
+            {
+                try { Directory.Delete(dir, recursive: true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void ValidateAsset_PortraitPackage_MainOnly_AllowFlag_ExitsZero()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "cli_pkg_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                byte[] png = BuildIndexedPng(96, 80, 16, out _);
+                File.WriteAllBytes(Path.Combine(dir, "sheet.png"), png);
+
+                // Without --allow-main-only: incomplete package → exit 2.
+                var (codeNo, _, _) = AppRunner.Run(CliExe, $"--validate-asset --kind=portrait-package --path \"{dir}\"", timeoutMs: 30_000);
+                Assert.Equal(2, codeNo);
+
+                // With --allow-main-only: accepted → exit 0.
+                var (codeYes, stdout, stderr) = AppRunner.Run(CliExe, $"--validate-asset --kind=portrait-package --path \"{dir}\" --allow-main-only", timeoutMs: 30_000);
+                Assert.True(codeYes == 0, $"exit {codeYes}; stdout={stdout}; stderr={stderr}");
+            }
+            finally
+            {
+                try { Directory.Delete(dir, recursive: true); } catch { }
+            }
+        }
+
+        // --- self-contained indexed-PNG builder (E2E project does NOT reference Core) ---
+
+        static readonly byte[] PngSig = { 137, 80, 78, 71, 13, 10, 26, 10 };
+
+        /// <summary>
+        /// Build a valid color-type-3 (indexed) PNG of <paramref name="w"/>x<paramref name="h"/>
+        /// with <paramref name="colors"/> palette entries (proper zlib IDAT + CRC), and return
+        /// the emitted PLTE RGB bytes so a matching JASC sidecar can be built.
+        /// </summary>
+        static byte[] BuildIndexedPng(int w, int h, int colors, out byte[] plteRgb)
+        {
+            plteRgb = new byte[colors * 3];
+            for (int i = 0; i < colors; i++)
+            {
+                // GBA BGR555 → 8-bit RGB (mirror IndexedPngWriter's conversion).
+                int r5 = i & 0x1F, g5 = (i * 2) & 0x1F, b5 = (i * 3) & 0x1F;
+                plteRgb[i * 3 + 0] = (byte)(r5 << 3);
+                plteRgb[i * 3 + 1] = (byte)(g5 << 3);
+                plteRgb[i * 3 + 2] = (byte)(b5 << 3);
+            }
+
+            using var ms = new MemoryStream();
+            ms.Write(PngSig, 0, PngSig.Length);
+
+            byte[] ihdr = new byte[13];
+            WriteU32BE(ihdr, 0, (uint)w); WriteU32BE(ihdr, 4, (uint)h);
+            ihdr[8] = 8; ihdr[9] = 3; // bit depth 8, color type 3
+            WritePngChunk(ms, "IHDR", ihdr);
+            WritePngChunk(ms, "PLTE", plteRgb);
+            WritePngChunk(ms, "tRNS", new byte[] { 0 }); // index 0 transparent
+
+            // Scanlines: filter byte 0 + width index bytes per row.
+            byte[] scan = new byte[h * (1 + w)];
+            for (int y = 0; y < h; y++)
+            {
+                int b = y * (1 + w);
+                scan[b] = 0;
+                for (int x = 0; x < w; x++)
+                    scan[b + 1 + x] = (byte)((y * w + x) % colors);
+            }
+
+            byte[] deflate;
+            using (var dms = new MemoryStream())
+            {
+                using (var ds = new System.IO.Compression.DeflateStream(dms, System.IO.Compression.CompressionLevel.Optimal, leaveOpen: true))
+                    ds.Write(scan, 0, scan.Length);
+                deflate = dms.ToArray();
+            }
+            uint adler = Adler32(scan);
+            byte[] idat = new byte[2 + deflate.Length + 4];
+            idat[0] = 0x78; idat[1] = 0x01;
+            Array.Copy(deflate, 0, idat, 2, deflate.Length);
+            int ao = 2 + deflate.Length;
+            idat[ao] = (byte)(adler >> 24); idat[ao + 1] = (byte)(adler >> 16);
+            idat[ao + 2] = (byte)(adler >> 8); idat[ao + 3] = (byte)adler;
+            WritePngChunk(ms, "IDAT", idat);
+            WritePngChunk(ms, "IEND", Array.Empty<byte>());
+            return ms.ToArray();
+        }
+
+        static string BuildJascFromRgb(byte[] rgb)
+        {
+            int count = rgb.Length / 3;
+            var sb = new System.Text.StringBuilder();
+            sb.Append("JASC-PAL\r\n0100\r\n").Append(count).Append("\r\n");
+            for (int i = 0; i < count; i++)
+                sb.Append(rgb[i * 3 + 0]).Append(' ').Append(rgb[i * 3 + 1]).Append(' ').Append(rgb[i * 3 + 2]).Append("\r\n");
+            return sb.ToString();
+        }
+
+        static void WriteU32BE(byte[] buf, int off, uint v)
+        {
+            buf[off] = (byte)(v >> 24); buf[off + 1] = (byte)(v >> 16);
+            buf[off + 2] = (byte)(v >> 8); buf[off + 3] = (byte)v;
+        }
+
+        static void WritePngChunk(MemoryStream s, string type, byte[] data)
+        {
+            byte[] len = new byte[4]; WriteU32BE(len, 0, (uint)data.Length); s.Write(len, 0, 4);
+            byte[] t = System.Text.Encoding.ASCII.GetBytes(type); s.Write(t, 0, 4);
+            if (data.Length > 0) s.Write(data, 0, data.Length);
+            byte[] crcIn = new byte[4 + data.Length];
+            Array.Copy(t, 0, crcIn, 0, 4); Array.Copy(data, 0, crcIn, 4, data.Length);
+            byte[] crc = new byte[4]; WriteU32BE(crc, 0, Crc32(crcIn)); s.Write(crc, 0, 4);
+        }
+
+        static readonly uint[] CrcTable = BuildCrcTable();
+        static uint[] BuildCrcTable()
+        {
+            var t = new uint[256];
+            for (uint n = 0; n < 256; n++)
+            {
+                uint c = n;
+                for (int k = 0; k < 8; k++) c = (c & 1) != 0 ? (0xEDB88320u ^ (c >> 1)) : (c >> 1);
+                t[n] = c;
+            }
+            return t;
+        }
+        static uint Crc32(byte[] data)
+        {
+            uint crc = 0xFFFFFFFF;
+            foreach (byte b in data) crc = CrcTable[(crc ^ b) & 0xFF] ^ (crc >> 8);
+            return crc ^ 0xFFFFFFFF;
+        }
+        static uint Adler32(byte[] data)
+        {
+            const uint MOD = 65521; uint a = 1, b = 0;
+            foreach (byte x in data) { a = (a + x) % MOD; b = (b + a) % MOD; }
+            return (b << 16) | a;
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -428,9 +428,18 @@ sibling.
   palette size, and in-range pixel indices; a JASC `.pal` for its header/count/color
   triples; a `.mar` against its `.mar.json` sidecar (length == w*h*2 and the `<<3`
   low-3-bits-zero invariant). It exits `0` on no errors (warnings allowed), `2` on errors.
-  Honest residuals: the NMM bridge informs the schema but does not make pointer fields
-  source-writable; the PNG validator is structural + index-level (the full portrait
-  package is a residual); the `.mar` check needs the sidecar for the exact length assertion.
+  `--validate-asset --kind=portrait-package --path=<dir> [--allow-main-only]
+  [--project=<dir>]` is the **multi-file portrait PACKAGE validator** (also ROM-free): it
+  requires exactly one composite sheet PNG in the directory, reuses the single-PNG
+  structural checks, then verifies the 128×112 slot geometry (mini/eye/mouth slots fit;
+  a 96×80 main-mug-only sheet is `INCOMPLETE_PACKAGE` unless `--allow-main-only`), the
+  4bpp (≤16-color) portrait palette cap, and **palette consistency** between the sheet's
+  embedded PLTE and an optional JASC `.pal` sidecar (count + per-entry RGB). `--project`
+  confines `--path` to the decomp project root without loading the preview ROM. Honest
+  residuals: the NMM bridge informs the schema but does not make pointer fields
+  source-writable; the single-PNG validator is structural + index-level; the portrait
+  PACKAGE validator now covers sheet-slot geometry + palette consistency (NOT write-back /
+  semantic frame order); the `.mar` check needs the sidecar for the exact length assertion.
 
 #### Round-trip coverage matrix
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -605,19 +605,25 @@ FEBuilderGBA.CLI --manifest-to-nmm --project=decomp/ --table=items --out=items.n
 
 Structurally validate a decomp IMPORT asset on disk (#1150) **before** wiring it into a build. READ-ONLY; **NEVER loads a ROM**. Indexed PNG → color type 3 / tile alignment / palette size / in-range indices; JASC `.pal` → header/count/color triples; `.mar` → length == w*h*2 and the `<<3` low-3-bits-zero invariant (validated against the `.mar.json` sidecar).
 
+The `portrait-package` kind (#1350) is a **multi-file PACKAGE validator** over a DIRECTORY: it requires exactly one composite sheet PNG, reuses the single-PNG structural checks, then verifies the canonical 128×112 slot geometry (mini/eye/mouth slots fit; a 96×80 main-mug-only sheet is `INCOMPLETE_PACKAGE` unless `--allow-main-only`), the 4bpp (≤16-color) portrait palette cap, and **palette consistency** between the sheet's embedded PLTE and an optional JASC `.pal` sidecar (count + per-entry RGB). It still never loads the ROM.
+
 | Option | Required | Description |
 |---|---|---|
-| `--kind=<kind>` | Required | Asset kind: `graphics`, `palette`, `portrait`, `icon`, `map`. |
-| `--in=<srcAsset>` | Required | Input asset file (PNG / `.pal` / `.mar`). |
+| `--kind=<kind>` | Required | Asset kind: `graphics`, `palette`, `portrait`, `icon`, `map`, `portrait-package`. |
+| `--in=<srcAsset>` | Required (single-file kinds) | Input asset file (PNG / `.pal` / `.mar`). |
+| `--path=<dir>` | Required for `--kind=portrait-package` | Package directory (one 128×112 sheet PNG + optional JASC `.pal`). |
+| `--allow-main-only` | Optional (`portrait-package`) | Accept a 96×80 main-mug-only sheet (warn instead of error). |
+| `--project=<dir>` | Optional (`portrait-package`) | Confine `--path` to the decomp project root (rejects absolute / escaping paths; **never loads the preview ROM**). |
 
 ```
 FEBuilderGBA.CLI --validate-asset --kind=graphics --in=gfx/tiles.png
 FEBuilderGBA.CLI --validate-asset --kind=palette --in=gfx/palette.pal
+FEBuilderGBA.CLI --validate-asset --kind=portrait-package --path portraits/eirika/
 ```
 
 Each finding prints as `ERROR [CODE] msg` (stderr) or `WARN [CODE] msg` (stdout) plus a summary line.
 
-**Exit code:** 0 on no errors (warnings allowed), 2 on errors, 1 on usage / bad-kind.
+**Exit code:** 0 on no errors (warnings allowed), 2 on errors (or a `--project` containment / detection failure for `portrait-package`), 1 on usage / bad-kind.
 
 ---
 
@@ -648,7 +654,7 @@ Each finding prints as `ERROR [CODE] msg` (stderr) or `WARN [CODE] msg` (stdout)
 | `--write-source` | — | — | — | — | `--project`, `--table`, `--id`, `--field`, `--value` | Project |
 | `--write-shop` | — | — | — | — | `--project`, `--items`, one of `--symbol`/`--shop-addr` | Project |
 | `--export-asset` | Optional | — | — | Required | `--kind` (+ `--rom` or `--project`) | Project |
-| `--validate-asset` | — | — | Required | — | `--kind` | No |
+| `--validate-asset` | — | — | Required (single-file kinds) | — | `--kind` (+ `--path` for `portrait-package`; optional `--project`) | No (project root only for `portrait-package` containment) |
 | `--build-project` | — | — | — | — | `--project` (`--yes` to execute) | Project |
 | `--decomp-audit` | — | — | — | Optional | — | No |
 | `--nmm-to-manifest` | — | — | Required | Optional | — | No |

--- a/pr-screenshots/pr1350-portrait-pkg-validator-proof.txt
+++ b/pr-screenshots/pr1350-portrait-pkg-validator-proof.txt
@@ -1,0 +1,13 @@
+=== PR #1350: decomp portrait-package validator — proof ===
+
+## Core unit tests (new file DecompPortraitPackageValidatorTests.cs)
+Passed!  - Failed:     0, Passed:    20, Skipped:     0, Total:    20, Duration: 115 ms - FEBuilderGBA.Core.Tests.dll (net9.0)
+
+## E2E tests (CLI black-box, exe override) — ValidateAsset_PortraitPackage_*
+Passed!  - Failed:     0, Passed:     3, Skipped:     0, Total:     3, Duration: 669 ms - FEBuilderGBA.E2ETests.dll (net9.0)
+
+## CLI live behavior
+$ FEBuilderGBA.CLI --validate-asset --kind=portrait-package --path <empty-dir>
+ERROR [MISSING_SHEET] No *.png sheet found in 'C:/Users/ZHIWEN~1/AppData/Local/Temp/eirika_pkg'. A portrait package needs one composite sheet PNG.
+Validation: 1 error(s), 0 warning(s) - FAILED
+(exit 2)


### PR DESCRIPTION
## Summary
Adds a decomp-mode **portrait PACKAGE validator** — a multi-file unit validator invoked as:
```
FEBuilderGBA.CLI --validate-asset --kind=portrait-package --path path/to/exported/portrait/
```
It builds on the existing #1150/#1160 validation infra (`DecompAssetValidatorCore`, `IndexedPngReader`, `AssetIssue`/`AssetValidationResult`). **READ-ONLY: never mutates the preview ROM, never writes source, never reads a ROM / takes `--rom`.** Closes the "full portrait package is a residual" gap documented in the README.

Plan (Copilot-reviewed + accepted, two rounds): https://github.com/laqieer/FEBuilderGBA/issues/1350#issuecomment-4769902202

## What it validates (honest scope — sheet-slot GEOMETRY, not semantic frame order)
The canonical FE7/8 portrait composite **SHEET is 128×112** indexed. Slot coords are cited directly from `PortraitImportPreviewCore` and `PortraitRendererCore.SplitPortraitSheet` (not invented): base face (0,0) 96×80, mini/chibi (96,16) 32×32, half/closed eyes (96,48)/(96,64) 32×16, mouth 1–7 in the y=80/96 rows.

- **Required files present** — exactly one sheet `*.png` (`MISSING_SHEET` / `MULTIPLE_SHEETS`); optional JASC `.pal` sidecar (`MISSING_PALETTE` warn).
- **Sheet structure** — reuses the existing `ValidatePng` (color-type-3, tile-align, palette size, in-range indices, index-0 transparency); a new `packageMode` flag suppresses the single-mug 96×80 advisory.
- **Slot geometry** — full 128×112 → OK; 96×80 main-only → `INCOMPLETE_PACKAGE` (ERROR by default, WARN with `--allow-main-only`); other sizes → per-slot bounds check (`SHEET_TOO_SMALL`) or `SHEET_BAD_DIMS` warn.
- **Palette bit-depth** — >16 colors → `PORTRAIT_PALETTE_GT16` warn (GBA portrait is 4bpp).
- **Palette consistency (real RGB, not just counts)** — extended `IndexedPngReader` to expose the raw PLTE bytes (`PaletteRgb`); compares them entry-by-entry against the sidecar's parsed JASC `R G B` triples → `PALETTE_COUNT_MISMATCH` / `PALETTE_COLOR_MISMATCH`.
- **Root-confinement** — optional `--project=<dir>` confines `--path` to the decomp project root via `DecompProjectDetector.Detect` + `DecompAssetExportCore.ResolveSourcePath` (NO `RomLoader.LoadProject` → the preview ROM is never loaded); an invalid project / escaping path exits 2 (no silent fallback).

New `AssetIssue` codes: `DIR_NOT_FOUND`, `MISSING_SHEET`, `MULTIPLE_SHEETS`, `INCOMPLETE_PACKAGE`, `SHEET_TOO_SMALL`, `SHEET_BAD_DIMS`, `PORTRAIT_PALETTE_GT16`, `MISSING_PALETTE`, `PALETTE_COUNT_MISMATCH`, `PALETTE_COLOR_MISMATCH`.

## Scope
Closes #1350.

## Non-goals (explicit)
Source-backed portrait write-back/editing; generating portrait art or palette fixes; claiming full per-workflow round-trip; semantic/artistic frame-order judgement. Classic `--validate-asset --in` ROM-mode behavior is unchanged.

## Test plan
- [x] Core unit — `DecompPortraitPackageValidatorTests.cs` (20 tests): valid 128×112 package → OK; missing sheet → `MISSING_SHEET`; >1 PNG → `MULTIPLE_SHEETS`; 96×80 main-only → `INCOMPLETE_PACKAGE` (error default / warn with allow flag); too-small sheet → `SHEET_TOO_SMALL`; non-indexed → `NON_INDEXED`; >16-color palette → `PORTRAIT_PALETTE_GT16`; missing sidecar → `MISSING_PALETTE`; **same-count different-RGB sidecar → `PALETTE_COLOR_MISMATCH`**; different-count → `PALETTE_COUNT_MISMATCH`; malformed input → no throw; `ParseKind("portrait-package"/"portraitpackage")` maps; source-assertion no `CoreState.ROM`; `IndexedPngReader.PaletteRgb` round-trip. **20/20 pass.**
- [x] Filtered Core run (PortraitPackage|DecompAssetValidator|IndexedPng): **70/70 pass.**
- [x] Full Core.Tests: **5337 passed, 10 failed (all `Skill*`, env-only `config/patch2` submodule absent in worktree — not regressions, pass in CI), 6 skipped.**
- [x] E2E — `CliTests.cs`: `ValidateAsset_PortraitPackage_Valid_ExitsZero`, `_MissingSheet_ExitsTwo`, `_MainOnly_AllowFlag` → **3/3 pass** (with CLI exe path).
- [x] `FEBuilderGBA.Tests` (net9.0-windows) builds (0 errors); no cross-project source-text assertion references the validator.
- [x] CLI live behavior verified (MISSING_SHEET → exit 2; help shows new `--path`/`--allow-main-only`/`--project` flags).
- [x] Docs updated: README `--validate-asset` paragraph + `docs/cli-reference.md` (options table, example, exit codes). Byte-locked `<!-- decomp-audit-matrix -->` block untouched.

## Screenshots / proof
Non-GUI PR (Core + CLI + tests only) — CLI/test output proof:
https://raw.githubusercontent.com/laqieer/FEBuilderGBA/feat/decomp-portrait-pkg-validator-1350/pr-screenshots/pr1350-portrait-pkg-validator-proof.txt

```
$ FEBuilderGBA.CLI --validate-asset --kind=portrait-package --path <empty-dir>
ERROR [MISSING_SHEET] No *.png sheet found in '.../eirika_pkg'. A portrait package needs one composite sheet PNG.
Validation: 1 error(s), 0 warning(s) - FAILED   (exit 2)

Core unit: Failed: 0, Passed: 20  (DecompPortraitPackageValidatorTests)
E2E:       Failed: 0, Passed: 3   (ValidateAsset_PortraitPackage_*)
```

---
Generated with Claude Code (model: claude-opus-4-8[1m], harness: ultracode)
