### PR TITLE
feat(decomp): map-change overlay source export/import/verify (#1355)

### DIFF
--- a/FEBuilderGBA.CLI/Program.cs
+++ b/FEBuilderGBA.CLI/Program.cs
@@ -369,11 +369,20 @@ namespace FEBuilderGBA.CLI
                 return RunImportAsset(argsDic);
             }
 
-            // --roundtrip-asset --kind=map --in=<x.mar>: validate + prove the .mar BODY
-            // round-trips losslessly (#1148). READ-ONLY, never loads a ROM.
+            // --roundtrip-asset --kind=map|mapchange --in=<x.mar|x.change>: validate + prove the
+            // BODY round-trips (#1148/#1355). READ-ONLY, never loads a ROM.
             if (argsDic.ContainsKey("--roundtrip-asset"))
             {
                 return RunRoundtripAsset(argsDic);
+            }
+
+            // --verify-asset --kind=mapchange --in=<x.change> --addr --width --height (+ ROM via
+            // --project/--rom): byte-exact ROM-backed mismatch proof for a map-change overlay
+            // (#1355). Reads the ROM READ-ONLY; never mutates it. Must precede the bare --project
+            // rom-info fallthrough so --verify-asset --project is not swallowed by RunRomInfo.
+            if (argsDic.ContainsKey("--verify-asset"))
+            {
+                return RunVerifyAsset(argsDic);
             }
 
             // --project=<dir> [--rom-info]: open a decomp project and report its
@@ -542,6 +551,7 @@ namespace FEBuilderGBA.CLI
             Console.WriteLine("    --max-gap=<int>        Optional: small-gap merge distance for range coalescing (default 16)");
             Console.WriteLine("  --list-tables            List all exportable struct table names (no ROM required)");
             Console.WriteLine("  --export-asset           Export a ROM asset to a decomp source-tree path (requires --kind, --out, and --rom or --project)");
+            Console.WriteLine("    --kind=mapchange       Raw uncompressed map-change OVERLAY tile data block (needs --addr=<change_mar hex>, --width, --height); NOT the .mar layout, NOT the record chain (#1355)");
             Console.WriteLine("    --kind=<kind>          Asset kind: graphics|palette|map|text|shop (map data is always LZ77-decompressed; shop = EA .event migration artifact)");
             Console.WriteLine("    --out=<path>           Output path (project-relative when --project; absolute or relative when --rom)");
             Console.WriteLine("    --addr=<hex>           ROM address of the asset (required for graphics, palette, map)");
@@ -587,13 +597,19 @@ namespace FEBuilderGBA.CLI
             Console.WriteLine("    --path=<dir>          For --kind=portrait-package: package DIRECTORY (one 128x112 sheet PNG + optional JASC .pal)");
             Console.WriteLine("    --allow-main-only     For --kind=portrait-package: accept a 96x80 main-mug-only sheet (warn instead of error)");
             Console.WriteLine("    --project=<dir>       For --kind=portrait-package: confine --path to the decomp project root (no ROM load)");
-            Console.WriteLine("  --import-asset           Re-import a .mar map LAYOUT to a raw uncompressed tilemap blob in the source tree (no ROM; never mutates)");
-            Console.WriteLine("    --kind=map             Only map layout is supported (.mar + sidecar .mar.json required)");
-            Console.WriteLine("    --in=<x.mar>           Input .mar map layout file");
-            Console.WriteLine("    --out=<x.bin>          Output raw uncompressed tilemap blob ([w][h] + w*h raw u16 LE); project-relative when --project");
-            Console.WriteLine("  --roundtrip-asset        Validate + prove a .mar map LAYOUT body round-trips losslessly (no ROM; never mutates)");
-            Console.WriteLine("    --kind=map             Only map layout is supported");
-            Console.WriteLine("    --in=<x.mar>           Input .mar map layout file");
+            Console.WriteLine("  --import-asset           Re-import a .mar map LAYOUT (or .change map-change OVERLAY) to a raw uncompressed blob in the source tree (no ROM; never mutates)");
+            Console.WriteLine("    --kind=map|mapchange   map = .mar layout (+ .mar.json); mapchange = raw u16 overlay block (.change + .change.json, identity copy) (#1355)");
+            Console.WriteLine("    --in=<x.mar|x.change>  Input asset file");
+            Console.WriteLine("    --out=<x.bin>          Output raw uncompressed blob; project-relative when --project");
+            Console.WriteLine("  --roundtrip-asset        Validate + prove a map LAYOUT/overlay body round-trips (no ROM; never mutates)");
+            Console.WriteLine("    --kind=map|mapchange   map = lossless u16 .mar layout; mapchange = structure-exact .change overlay (#1355)");
+            Console.WriteLine("    --in=<x.mar|x.change>  Input asset file");
+            Console.WriteLine("  --verify-asset           Byte-exact ROM-backed mismatch proof for a map-change OVERLAY (reads ROM READ-ONLY; never mutates) (#1355)");
+            Console.WriteLine("    --kind=mapchange       Only map-change overlay is supported");
+            Console.WriteLine("    --in=<x.change>        Input .change overlay file (+ required .change.json sidecar)");
+            Console.WriteLine("    --addr=<hex>           change_mar offset of the overlay block in the ROM");
+            Console.WriteLine("    --width=<int> --height=<int>  Overlay dimensions (record +3/+4)");
+            Console.WriteLine("    --rom=<path> | --project=<dir>  ROM source (the preview build for --project)");
             Console.WriteLine("  --export-palette         Export GBA palette to file (requires --rom, --addr, --out)");
             Console.WriteLine("    --addr=<hex>           Palette data address in ROM (e.g., 0x5524)");
             Console.WriteLine("    --colors=<int>         Number of colors to export (default: 16)");
@@ -623,6 +639,7 @@ namespace FEBuilderGBA.CLI
             Console.WriteLine("  FEBuilderGBA.CLI --export-asset --kind=palette --rom=rom.gba --addr=0x5524 --out=gfx/palette.pal");
             Console.WriteLine("  FEBuilderGBA.CLI --export-asset --kind=graphics --project=decomp/ --addr=0x123000 --width=64 --height=64 --palette-addr=0x124000 --out=gfx/tiles.png");
             Console.WriteLine("  FEBuilderGBA.CLI --export-asset --kind=map --rom=rom.gba --addr=0x200000 --out=map/chapter1.mar");
+            Console.WriteLine("  FEBuilderGBA.CLI --export-asset --kind=mapchange --rom=rom.gba --addr=0x300000 --width=15 --height=10 --out=map/chapter1.change");
             Console.WriteLine("  FEBuilderGBA.CLI --export-asset --kind=text --rom=rom.gba --out=text/");
             Console.WriteLine("  FEBuilderGBA.CLI --export-asset --kind=shop --rom=rom.gba --out=shops/");
             Console.WriteLine("  FEBuilderGBA.CLI --decomp-audit --format=md --out=docs/decomp-coverage.md");
@@ -633,7 +650,10 @@ namespace FEBuilderGBA.CLI
             Console.WriteLine("  FEBuilderGBA.CLI --validate-asset --kind=palette --in=gfx/palette.pal");
             Console.WriteLine("  FEBuilderGBA.CLI --validate-asset --kind=portrait-package --path portraits/eirika/");
             Console.WriteLine("  FEBuilderGBA.CLI --import-asset --kind=map --in=map/chapter1.mar --out=map/chapter1.tmap_raw.bin");
+            Console.WriteLine("  FEBuilderGBA.CLI --import-asset --kind=mapchange --in=map/chapter1.change --out=map/chapter1.change_raw.bin");
             Console.WriteLine("  FEBuilderGBA.CLI --roundtrip-asset --kind=map --in=map/chapter1.mar");
+            Console.WriteLine("  FEBuilderGBA.CLI --roundtrip-asset --kind=mapchange --in=map/chapter1.change");
+            Console.WriteLine("  FEBuilderGBA.CLI --verify-asset --kind=mapchange --rom=rom.gba --addr=0x300000 --width=15 --height=10 --in=map/chapter1.change");
             Console.WriteLine("  FEBuilderGBA.CLI --write-source --project=decomp/ --table=items --id=1 --field=might --value=0x0A");
             Console.WriteLine("  FEBuilderGBA.CLI --write-source --project=decomp/ --table=units --id=1 --field=hp --value=18 --field=pow --value=7");
             Console.WriteLine("  FEBuilderGBA.CLI --write-source --project=decomp/ --table=support_units --id=0 --field=b0 --value=6 --field=b1 --value=3   (leading prefix — safe with minimal fields[])");
@@ -4792,17 +4812,17 @@ namespace FEBuilderGBA.CLI
         static int RunImportAsset(Dictionary<string, string> argsDic)
         {
             if (!argsDic.ContainsKey("--kind") || string.IsNullOrEmpty(argsDic["--kind"]))
-            { Console.Error.WriteLine("Error: --import-asset requires --kind=map"); return 1; }
+            { Console.Error.WriteLine("Error: --import-asset requires --kind=map|mapchange"); return 1; }
             AssetKind? kind = DecompAssetValidatorCore.ParseKind(argsDic["--kind"]);
-            if (kind == null || kind.Value != AssetKind.MapLayout)
-            { Console.Error.WriteLine("Error: only --kind=map is supported for --import-asset"); return 1; }
+            if (kind == null || (kind.Value != AssetKind.MapLayout && kind.Value != AssetKind.MapChangeOverlay))
+            { Console.Error.WriteLine("Error: only --kind=map or --kind=mapchange is supported for --import-asset"); return 1; }
 
             if (!argsDic.ContainsKey("--in") || string.IsNullOrEmpty(argsDic["--in"]))
-            { Console.Error.WriteLine("Error: --import-asset requires --in=<x.mar>"); return 1; }
+            { Console.Error.WriteLine("Error: --import-asset requires --in=<x.mar|x.change>"); return 1; }
             string absIn = argsDic["--in"];
 
             if (!argsDic.ContainsKey("--out") || string.IsNullOrEmpty(argsDic["--out"]))
-            { Console.Error.WriteLine("Error: --import-asset requires --out=<x.tmap_raw.bin>"); return 1; }
+            { Console.Error.WriteLine("Error: --import-asset requires --out=<x.bin>"); return 1; }
             string outRel = argsDic["--out"];
 
             RomLoader.InitEnvironment();
@@ -4833,7 +4853,9 @@ namespace FEBuilderGBA.CLI
                 return 2;
             }
 
-            DecompAssetResult result = DecompAssetExportCore.ImportMap(absIn, absOut);
+            DecompAssetResult result = kind.Value == AssetKind.MapChangeOverlay
+                ? DecompAssetExportCore.ImportMapChange(absIn, absOut)
+                : DecompAssetExportCore.ImportMap(absIn, absOut);
             if (result.Ok)
             {
                 Console.WriteLine(result.Message);
@@ -4855,16 +4877,16 @@ namespace FEBuilderGBA.CLI
         static int RunRoundtripAsset(Dictionary<string, string> argsDic)
         {
             if (!argsDic.ContainsKey("--kind") || string.IsNullOrEmpty(argsDic["--kind"]))
-            { Console.Error.WriteLine("Error: --roundtrip-asset requires --kind=map"); return 1; }
+            { Console.Error.WriteLine("Error: --roundtrip-asset requires --kind=map|mapchange"); return 1; }
             AssetKind? kind = DecompAssetValidatorCore.ParseKind(argsDic["--kind"]);
-            if (kind == null || kind.Value != AssetKind.MapLayout)
-            { Console.Error.WriteLine("Error: only --kind=map is supported for --roundtrip-asset"); return 1; }
+            if (kind == null || (kind.Value != AssetKind.MapLayout && kind.Value != AssetKind.MapChangeOverlay))
+            { Console.Error.WriteLine("Error: only --kind=map or --kind=mapchange is supported for --roundtrip-asset"); return 1; }
 
             if (!argsDic.ContainsKey("--in") || string.IsNullOrEmpty(argsDic["--in"]))
-            { Console.Error.WriteLine("Error: --roundtrip-asset requires --in=<x.mar>"); return 1; }
+            { Console.Error.WriteLine("Error: --roundtrip-asset requires --in=<x.mar|x.change>"); return 1; }
             string inPath = argsDic["--in"];
 
-            AssetValidationResult v = DecompAssetValidatorCore.ValidateAsset(AssetKind.MapLayout, inPath);
+            AssetValidationResult v = DecompAssetValidatorCore.ValidateAsset(kind.Value, inPath);
             if (!v.Ok)
             {
                 foreach (AssetIssue e in v.Errors)
@@ -4875,12 +4897,27 @@ namespace FEBuilderGBA.CLI
             byte[] body;
             try { body = File.ReadAllBytes(inPath); }
             catch (Exception ex)
-            { Console.Error.WriteLine($"Error: could not read .mar: {ex.Message}"); return 2; }
+            { Console.Error.WriteLine($"Error: could not read input: {ex.Message}"); return 2; }
 
-            bool ok = DecompAssetExportCore.RoundTripMarBody(body);
+            bool ok;
+            string okMsg;
+            if (kind.Value == AssetKind.MapChangeOverlay)
+            {
+                // The overlay body has no intrinsic dims — read them from the REQUIRED sidecar.
+                if (!DecompAssetExportCore.TryReadMapChangeDims(inPath + ".json", out int w, out int h))
+                { Console.Error.WriteLine("Error: sidecar .change.json required to read dimensions"); return 2; }
+                ok = DecompAssetExportCore.RoundTripMapChangeBody(body, w, h);
+                okMsg = "Round-trip OK (structure-exact map-change overlay body)";
+            }
+            else
+            {
+                ok = DecompAssetExportCore.RoundTripMarBody(body);
+                okMsg = "Round-trip OK (lossless map layout body)";
+            }
+
             if (ok)
             {
-                Console.WriteLine("Round-trip OK (lossless map layout body)");
+                Console.WriteLine(okMsg);
                 return 0;
             }
 
@@ -4889,15 +4926,101 @@ namespace FEBuilderGBA.CLI
         }
 
         /// <summary>
-        /// --export-asset: export a ROM asset (palette/graphics/map/text) to a decomp source-tree path.
-        /// Supports both --project=&lt;dir&gt; (with path containment) and --rom=&lt;path&gt; (classic, no containment).
-        /// READ-ONLY: never modifies the ROM.
+        /// --verify-asset: byte-exact ROM-backed mismatch proof for a map-change OVERLAY (#1355).
+        /// Compares the raw ROM overlay region at <c>--addr</c> against the <c>.change</c> file body
+        /// byte-for-byte. This path DOES load the ROM (READ-ONLY) — it is the ONLY ROM-backed
+        /// verification path (export/import never touch the ROM). Only <c>--kind=mapchange</c> is
+        /// supported. With <c>--project=&lt;dir&gt;</c> the ROM is the project's preview build; otherwise
+        /// <c>--rom=&lt;path&gt;</c>. Exit 0 byte-identical, 2 mismatch / fault, 1 usage error.
+        /// </summary>
+        static int RunVerifyAsset(Dictionary<string, string> argsDic)
+        {
+            if (!argsDic.ContainsKey("--kind") || string.IsNullOrEmpty(argsDic["--kind"]))
+            { Console.Error.WriteLine("Error: --verify-asset requires --kind=mapchange"); return 1; }
+            AssetKind? kind = DecompAssetValidatorCore.ParseKind(argsDic["--kind"]);
+            if (kind == null || kind.Value != AssetKind.MapChangeOverlay)
+            { Console.Error.WriteLine("Error: only --kind=mapchange is supported for --verify-asset"); return 1; }
+
+            if (!argsDic.ContainsKey("--in") || string.IsNullOrEmpty(argsDic["--in"]))
+            { Console.Error.WriteLine("Error: --verify-asset requires --in=<x.change>"); return 1; }
+            string absIn = argsDic["--in"];
+
+            if (!argsDic.ContainsKey("--addr") || string.IsNullOrEmpty(argsDic["--addr"]))
+            { Console.Error.WriteLine("Error: --verify-asset requires --addr=<hex>"); return 1; }
+            if (!argsDic.ContainsKey("--width") || string.IsNullOrEmpty(argsDic["--width"]))
+            { Console.Error.WriteLine("Error: --verify-asset requires --width=<int>"); return 1; }
+            if (!argsDic.ContainsKey("--height") || string.IsNullOrEmpty(argsDic["--height"]))
+            { Console.Error.WriteLine("Error: --verify-asset requires --height=<int>"); return 1; }
+
+            // ---- ROM source: --project or --rom ----
+            bool isProject = argsDic.ContainsKey("--project") && !string.IsNullOrEmpty(argsDic["--project"]);
+            bool isRom = argsDic.ContainsKey("--rom") && !string.IsNullOrEmpty(argsDic["--rom"]);
+            if (!isProject && !isRom)
+            { Console.Error.WriteLine("Error: --verify-asset requires --rom=<path> or --project=<dir>"); return 1; }
+
+            RomLoader.InitEnvironment();
+
+            if (isProject)
+            {
+                string projectDir = argsDic["--project"];
+                if (!RomLoader.LoadProject(projectDir))
+                    return 1;
+            }
+            else
+            {
+                string romPath = argsDic["--rom"];
+                if (!File.Exists(romPath))
+                { Console.Error.WriteLine($"Error: ROM not found: {romPath}"); return 1; }
+                string forceVersion = argsDic.ContainsKey("--force-version") ? argsDic["--force-version"] : null;
+                if (!RomLoader.LoadRom(romPath, forceVersion))
+                    return 1;
+                RomLoader.InitFull();
+            }
+
+            // ---- Parse hex address + int dims (same convention as RunExportAsset) ----
+            static bool TryParseAddr(string s, out uint result)
+            {
+                result = 0;
+                if (string.IsNullOrEmpty(s)) return false;
+                string clean = s.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? s.Substring(2) : s;
+                if (!uint.TryParse(clean, System.Globalization.NumberStyles.HexNumber, null, out result))
+                    return false;
+                result = U.toOffset(result);
+                return true;
+            }
+
+            if (!TryParseAddr(argsDic["--addr"], out uint addr))
+            { Console.Error.WriteLine($"Error: Invalid address: {argsDic["--addr"]}"); return 1; }
+            if (!int.TryParse(argsDic["--width"], out int width) || width <= 0)
+            { Console.Error.WriteLine($"Error: Invalid --width: {argsDic["--width"]}"); return 1; }
+            if (!int.TryParse(argsDic["--height"], out int height) || height <= 0)
+            { Console.Error.WriteLine($"Error: Invalid --height: {argsDic["--height"]}"); return 1; }
+
+            DecompAssetResult result = DecompAssetExportCore.VerifyMapChangeAgainstRom(CoreState.ROM, addr, width, height, absIn);
+            if (result.Ok)
+            {
+                Console.WriteLine(result.Message);
+                return 0;
+            }
+
+            Console.Error.WriteLine($"Error: {result.Message}");
+            return 2;
+        }
+
+        /// <summary>
+        /// --export-asset: export a ROM asset (palette/graphics/map/mapchange/text/shop) to a decomp
+        /// source-tree path. Supports both --project=&lt;dir&gt; (with path containment) and
+        /// --rom=&lt;path&gt; (classic, no containment). READ-ONLY: never modifies the ROM.
+        ///
+        /// <c>--kind=mapchange</c> (#1355) exports the RAW UNCOMPRESSED map-change OVERLAY tile data
+        /// block (requires <c>--addr</c> = the change_mar offset, <c>--width</c>, <c>--height</c>) — NOT
+        /// the .mar tile layout and NOT the 12-byte change-record chain.
         /// </summary>
         static int RunExportAsset(Dictionary<string, string> argsDic)
         {
             // ---- Required: --kind ----
             if (!argsDic.ContainsKey("--kind") || string.IsNullOrEmpty(argsDic["--kind"]))
-            { Console.Error.WriteLine("Error: --export-asset requires --kind=<graphics|palette|map|text|shop>"); return 1; }
+            { Console.Error.WriteLine("Error: --export-asset requires --kind=<graphics|palette|map|mapchange|text|shop>"); return 1; }
             string kind = argsDic["--kind"].ToLowerInvariant();
 
             // ---- Required: --out ----
@@ -5020,6 +5143,27 @@ namespace FEBuilderGBA.CLI
                     break;
                 }
 
+                case "mapchange":
+                case "mapchange-overlay":
+                {
+                    // Map-change OVERLAY tile data block (#1355): a RAW UNCOMPRESSED u16 LE array.
+                    // --addr is the change_mar offset (record +8 pointer, dereferenced), plus dims.
+                    if (!argsDic.ContainsKey("--addr") || string.IsNullOrEmpty(argsDic["--addr"]))
+                    { Console.Error.WriteLine("Error: --export-asset --kind=mapchange requires --addr=<hex>"); return 1; }
+                    if (!argsDic.ContainsKey("--width") || string.IsNullOrEmpty(argsDic["--width"]))
+                    { Console.Error.WriteLine("Error: --export-asset --kind=mapchange requires --width=<int>"); return 1; }
+                    if (!argsDic.ContainsKey("--height") || string.IsNullOrEmpty(argsDic["--height"]))
+                    { Console.Error.WriteLine("Error: --export-asset --kind=mapchange requires --height=<int>"); return 1; }
+                    if (!TryParseAddr(argsDic["--addr"], out uint addr))
+                    { Console.Error.WriteLine($"Error: Invalid address: {argsDic["--addr"]}"); return 1; }
+                    if (!int.TryParse(argsDic["--width"], out int mcWidth) || mcWidth <= 0)
+                    { Console.Error.WriteLine($"Error: Invalid --width: {argsDic["--width"]}"); return 1; }
+                    if (!int.TryParse(argsDic["--height"], out int mcHeight) || mcHeight <= 0)
+                    { Console.Error.WriteLine($"Error: Invalid --height: {argsDic["--height"]}"); return 1; }
+                    result = DecompAssetExportCore.ExportMapChange(rom, addr, mcWidth, mcHeight, absOut);
+                    break;
+                }
+
                 case "text":
                 {
                     // --out is treated as a directory for text export
@@ -5037,7 +5181,7 @@ namespace FEBuilderGBA.CLI
                 }
 
                 default:
-                    Console.Error.WriteLine($"Error: Unknown --kind '{kind}'. Use: graphics, palette, map, text, shop");
+                    Console.Error.WriteLine($"Error: Unknown --kind '{kind}'. Use: graphics, palette, map, mapchange, text, shop");
                     return 1;
             }
 

--- a/FEBuilderGBA.Core.Tests/DecompAssetExportCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompAssetExportCoreTests.cs
@@ -612,6 +612,487 @@ namespace FEBuilderGBA.Core.Tests
             Assert.False(DecompAssetExportCore.RoundTripMarBody(body));
         }
 
+        // ============================================================================
+        // Map-change OVERLAY (raw uncompressed u16 LE, #1355)
+        // ============================================================================
+
+        // Build a raw u16 LE overlay body (any value valid — no <<3 shift).
+        static byte[] MakeOverlayBody(int w, int h, Func<int, ushort> valueForIndex)
+        {
+            byte[] body = new byte[w * h * 2];
+            for (int i = 0; i < w * h; i++)
+            {
+                ushort v = valueForIndex(i);
+                body[i * 2 + 0] = (byte)(v & 0xFF);
+                body[i * 2 + 1] = (byte)(v >> 8);
+            }
+            return body;
+        }
+
+        static void WriteChangePlusSidecar(string changePath, int w, int h, byte[] body, string format = "febuilder-mapchange-u16")
+        {
+            File.WriteAllBytes(changePath, body);
+            File.WriteAllText(changePath + ".json",
+                $"{{\n  \"width\": {w},\n  \"height\": {h},\n  \"srcAddr\": \"0x200\",\n  \"format\": \"{format}\"\n}}\n");
+        }
+
+        // ---- RoundTripMapChangeBody (pure) ----
+
+        [Fact]
+        public void RoundTripMapChangeBody_True_ForEvenWxH2Body()
+        {
+            int w = 4, h = 3;
+            byte[] body = MakeOverlayBody(w, h, i => (ushort)(i * 137)); // arbitrary u16, may be >= 0x2000
+            Assert.True(DecompAssetExportCore.RoundTripMapChangeBody(body, w, h));
+        }
+
+        [Fact]
+        public void RoundTripMapChangeBody_False_ForNull()
+        {
+            Assert.False(DecompAssetExportCore.RoundTripMapChangeBody(null, 2, 2));
+        }
+
+        [Fact]
+        public void RoundTripMapChangeBody_False_ForOddLength()
+        {
+            Assert.False(DecompAssetExportCore.RoundTripMapChangeBody(new byte[3], 1, 1));
+        }
+
+        [Fact]
+        public void RoundTripMapChangeBody_False_ForWrongCount()
+        {
+            byte[] body = MakeOverlayBody(2, 2, i => (ushort)i); // 8 bytes
+            Assert.False(DecompAssetExportCore.RoundTripMapChangeBody(body, 3, 3)); // 18 expected
+        }
+
+        [Fact]
+        public void RoundTripMapChangeBody_False_ForDimsBelow1()
+        {
+            byte[] body = MakeOverlayBody(2, 2, i => (ushort)i);
+            Assert.False(DecompAssetExportCore.RoundTripMapChangeBody(body, 0, 2));
+            Assert.False(DecompAssetExportCore.RoundTripMapChangeBody(body, 2, 0));
+        }
+
+        // ---- ImportMapChange ----
+
+        [Fact]
+        public void ImportMapChange_HappyPath_IdentityCopy()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                int w = 3, h = 2; // 6 entries
+                byte[] body = MakeOverlayBody(w, h, i => (ushort)(i == 5 ? 0xFFFF : i + 0x1000));
+                string changePath = Path.Combine(dir, "ch.change");
+                WriteChangePlusSidecar(changePath, w, h, body);
+
+                // Capture CoreState.ROM before/after to prove it is untouched.
+                ROM before = CoreState.ROM;
+
+                string outPath = Path.Combine(dir, "ch.change_raw.bin");
+                var result = DecompAssetExportCore.ImportMapChange(changePath, outPath);
+
+                Assert.True(result.Ok, $"ImportMapChange failed: {result.Message}");
+                Assert.True(File.Exists(outPath));
+                Assert.Same(before, CoreState.ROM); // ROM reference unchanged
+
+                // Output blob == input body byte-for-byte (identity copy, no header, no shift).
+                byte[] actual = File.ReadAllBytes(outPath);
+                Assert.Equal(body, actual);
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void ImportMapChange_RootConfined_OutputLandsWhereTold()
+        {
+            // The Core method writes verbatim to absOutBlobPath; containment is a CLI concern.
+            // Assert the output is exactly the path we passed (under the temp dir).
+            string dir = NewTempDir();
+            try
+            {
+                int w = 2, h = 2;
+                byte[] body = MakeOverlayBody(w, h, i => (ushort)i);
+                string changePath = Path.Combine(dir, "r.change");
+                WriteChangePlusSidecar(changePath, w, h, body);
+
+                string outPath = Path.Combine(dir, "sub", "r.bin");
+                var result = DecompAssetExportCore.ImportMapChange(changePath, outPath);
+
+                Assert.True(result.Ok, result.Message);
+                Assert.Contains(outPath, result.WrittenPaths);
+                Assert.True(File.Exists(outPath));
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void ImportMapChange_MissingSidecar_ReturnsNotData_NoThrow_NoFile()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                int w = 2, h = 2;
+                byte[] body = MakeOverlayBody(w, h, i => (ushort)i);
+                string changePath = Path.Combine(dir, "nosidecar.change");
+                File.WriteAllBytes(changePath, body); // NO sidecar
+
+                string outPath = Path.Combine(dir, "nosidecar.bin");
+                var result = DecompAssetExportCore.ImportMapChange(changePath, outPath);
+
+                Assert.False(result.Ok);
+                Assert.Equal(DecompAssetStatus.NotData, result.Status);
+                Assert.False(File.Exists(outPath));
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void ImportMapChange_NullArgs_ReturnBadArgs()
+        {
+            var r1 = DecompAssetExportCore.ImportMapChange(null, "/tmp/x.bin");
+            Assert.Equal(DecompAssetStatus.BadArgs, r1.Status);
+            var r2 = DecompAssetExportCore.ImportMapChange("/tmp/x.change", null);
+            Assert.Equal(DecompAssetStatus.BadArgs, r2.Status);
+        }
+
+        // ---- ExportMapChange ----
+
+        [Fact]
+        public void ExportMapChange_WritesRawBody_AndSidecar()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                int w = 3, h = 2; // 6 entries → 12 bytes
+                uint addr = 0x200;
+                byte[] romData = new byte[0x400];
+                // Plant overlay u16 LE entries at offset 0x200.
+                ushort[] vals = new ushort[w * h];
+                for (int i = 0; i < vals.Length; i++)
+                {
+                    vals[i] = (ushort)(i * 0x123 + 0x2345); // varied, includes >= 0x2000 (valid for overlay)
+                    romData[addr + i * 2 + 0] = (byte)(vals[i] & 0xFF);
+                    romData[addr + i * 2 + 1] = (byte)(vals[i] >> 8);
+                }
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(romData);
+
+                string changePath = Path.Combine(dir, "c.change");
+                var result = DecompAssetExportCore.ExportMapChange(rom, addr, w, h, changePath);
+
+                Assert.True(result.Ok, $"ExportMapChange failed: {result.Message}");
+                Assert.True(File.Exists(changePath));
+
+                // .change bytes == planted u16 LE.
+                byte[] changeBytes = File.ReadAllBytes(changePath);
+                Assert.Equal(w * h * 2, changeBytes.Length);
+                for (int i = 0; i < vals.Length; i++)
+                {
+                    ushort actual = (ushort)(changeBytes[i * 2] | (changeBytes[i * 2 + 1] << 8));
+                    Assert.Equal(vals[i], actual);
+                }
+
+                // Sidecar has width/height/srcAddr/format.
+                string jsonPath = changePath + ".json";
+                Assert.True(File.Exists(jsonPath));
+                string json = File.ReadAllText(jsonPath);
+                Assert.Contains($"\"width\": {w}", json);
+                Assert.Contains($"\"height\": {h}", json);
+                Assert.Contains($"\"srcAddr\": \"0x{addr:X}\"", json);
+                Assert.Contains("\"format\": \"febuilder-mapchange-u16\"", json);
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void ExportMapChange_OutOfBounds_ReturnsNotData_NoFileWritten()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(new byte[0x210]); // tiny ROM
+                // addr 0x200 + 10*10*2 = 0x200 + 200 = past the 0x210 end.
+                string changePath = Path.Combine(dir, "oob.change");
+                var result = DecompAssetExportCore.ExportMapChange(rom, 0x200, 10, 10, changePath);
+
+                Assert.False(result.Ok);
+                Assert.Equal(DecompAssetStatus.NotData, result.Status);
+                Assert.False(File.Exists(changePath), "no .change must be written on a bounds fault");
+                Assert.False(File.Exists(changePath + ".json"), "no sidecar either");
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void ExportMapChange_BadDims_ReturnsNotData_NoFileWritten()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(new byte[0x400]);
+                string changePath = Path.Combine(dir, "baddims.change");
+                var result = DecompAssetExportCore.ExportMapChange(rom, 0x200, 256, 1, changePath); // width > 255
+
+                Assert.False(result.Ok);
+                Assert.Equal(DecompAssetStatus.NotData, result.Status);
+                Assert.False(File.Exists(changePath));
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void ExportMapChange_NullRom_ReturnsBadArgs()
+        {
+            var result = DecompAssetExportCore.ExportMapChange(null, 0x200, 2, 2, "/tmp/x.change");
+            Assert.False(result.Ok);
+            Assert.Equal(DecompAssetStatus.BadArgs, result.Status);
+        }
+
+        [Fact]
+        public void ExportMapChange_DoesNotMutateRomData()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                int w = 4, h = 4;
+                uint addr = 0x200;
+                byte[] romData = new byte[0x400];
+                for (int i = 0; i < w * h; i++)
+                {
+                    romData[addr + i * 2 + 0] = (byte)(i & 0xFF);
+                    romData[addr + i * 2 + 1] = (byte)(i >> 8);
+                }
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(romData);
+                byte[] before = (byte[])rom.Data.Clone();
+
+                DecompAssetExportCore.ExportMapChange(rom, addr, w, h, Path.Combine(dir, "x.change"));
+
+                Assert.Equal(before, rom.Data);
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        // ---- VerifyMapChangeAgainstRom ----
+
+        [Fact]
+        public void VerifyMapChangeAgainstRom_Match_ReturnsOk()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                int w = 3, h = 2;
+                uint addr = 0x200;
+                byte[] body = MakeOverlayBody(w, h, i => (ushort)(i * 0x1111));
+                byte[] romData = new byte[0x400];
+                Array.Copy(body, 0, romData, addr, body.Length);
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(romData);
+
+                string changePath = Path.Combine(dir, "v.change");
+                WriteChangePlusSidecar(changePath, w, h, body);
+
+                var result = DecompAssetExportCore.VerifyMapChangeAgainstRom(rom, addr, w, h, changePath);
+                Assert.True(result.Ok, $"verify failed: {result.Message}");
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void VerifyMapChangeAgainstRom_SingleByteEdit_ReturnsNotData_WithFirstDiffOffset()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                int w = 3, h = 2;
+                uint addr = 0x200;
+                byte[] body = MakeOverlayBody(w, h, i => (ushort)(i + 1));
+                byte[] romData = new byte[0x400];
+                Array.Copy(body, 0, romData, addr, body.Length);
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(romData);
+
+                // Edit byte offset 4 in the file body (not in the ROM).
+                byte[] edited = (byte[])body.Clone();
+                edited[4] ^= 0xFF;
+                string changePath = Path.Combine(dir, "v.change");
+                WriteChangePlusSidecar(changePath, w, h, edited);
+
+                var result = DecompAssetExportCore.VerifyMapChangeAgainstRom(rom, addr, w, h, changePath);
+                Assert.False(result.Ok);
+                Assert.Equal(DecompAssetStatus.NotData, result.Status);
+                Assert.Contains("byte offset 4", result.Message);
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void VerifyMapChangeAgainstRom_OutOfBoundsAddr_ReturnsNotData_NoThrow()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                int w = 10, h = 10;
+                byte[] body = MakeOverlayBody(w, h, i => (ushort)i);
+                string changePath = Path.Combine(dir, "oob.change");
+                WriteChangePlusSidecar(changePath, w, h, body);
+
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(new byte[0x210]); // too small for 200-byte overlay at 0x200
+                byte[] before = (byte[])rom.Data.Clone();
+
+                var result = DecompAssetExportCore.VerifyMapChangeAgainstRom(rom, 0x200, w, h, changePath);
+                Assert.False(result.Ok);
+                Assert.Equal(DecompAssetStatus.NotData, result.Status);
+                Assert.Equal(before, rom.Data); // ROM unchanged
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        // ---- ValidateMapChange (via DecompAssetValidatorCore) ----
+
+        [Fact]
+        public void ValidateMapChange_CleanOverlay_Ok()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                int w = 4, h = 3;
+                byte[] body = MakeOverlayBody(w, h, i => (ushort)(i * 999)); // values may exceed 0x2000
+                string changePath = Path.Combine(dir, "ok.change");
+                WriteChangePlusSidecar(changePath, w, h, body);
+
+                var v = DecompAssetValidatorCore.ValidateAsset(AssetKind.MapChangeOverlay, changePath);
+                Assert.True(v.Ok, "expected clean overlay to validate: " + DescribeErrors(v));
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void ValidateMapChange_OddLength_BadLength()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                string changePath = Path.Combine(dir, "odd.change");
+                File.WriteAllBytes(changePath, new byte[5]); // odd
+                File.WriteAllText(changePath + ".json",
+                    "{\n  \"width\": 1,\n  \"height\": 1,\n  \"format\": \"febuilder-mapchange-u16\"\n}\n");
+
+                var v = DecompAssetValidatorCore.ValidateAsset(AssetKind.MapChangeOverlay, changePath);
+                Assert.False(v.Ok);
+                Assert.Contains(v.Errors, e => e.Code == "BAD_MAPCHANGE_LENGTH");
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void ValidateMapChange_WrongCountVsSidecar_BadLength()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                // sidecar says 3x3 (18 bytes) but body is 2x2 (8 bytes).
+                byte[] body = new byte[8];
+                string changePath = Path.Combine(dir, "wrongcount.change");
+                File.WriteAllBytes(changePath, body);
+                File.WriteAllText(changePath + ".json",
+                    "{\n  \"width\": 3,\n  \"height\": 3,\n  \"format\": \"febuilder-mapchange-u16\"\n}\n");
+
+                var v = DecompAssetValidatorCore.ValidateAsset(AssetKind.MapChangeOverlay, changePath);
+                Assert.False(v.Ok);
+                Assert.Contains(v.Errors, e => e.Code == "BAD_MAPCHANGE_LENGTH");
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void ValidateMapChange_DimsOver255_BadDims()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                int w = 256, h = 1;
+                byte[] body = new byte[w * h * 2];
+                string changePath = Path.Combine(dir, "bigdims.change");
+                File.WriteAllBytes(changePath, body);
+                File.WriteAllText(changePath + ".json",
+                    $"{{\n  \"width\": {w},\n  \"height\": {h},\n  \"format\": \"febuilder-mapchange-u16\"\n}}\n");
+
+                var v = DecompAssetValidatorCore.ValidateAsset(AssetKind.MapChangeOverlay, changePath);
+                Assert.False(v.Ok);
+                Assert.Contains(v.Errors, e => e.Code == "BAD_MAPCHANGE_DIMS");
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void ValidateMapChange_MissingSidecar_NoSidecarError()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                string changePath = Path.Combine(dir, "nos.change");
+                File.WriteAllBytes(changePath, new byte[8]); // no sidecar
+
+                var v = DecompAssetValidatorCore.ValidateAsset(AssetKind.MapChangeOverlay, changePath);
+                Assert.False(v.Ok);
+                Assert.Contains(v.Errors, e => e.Code == "MAPCHANGE_NO_SIDECAR");
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void ValidateMapChange_WrongFormat_BadFormat()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                int w = 2, h = 2;
+                byte[] body = new byte[w * h * 2];
+                string changePath = Path.Combine(dir, "wrongfmt.change");
+                File.WriteAllBytes(changePath, body);
+                // Wrong format (the .mar format, not the overlay format).
+                File.WriteAllText(changePath + ".json",
+                    $"{{\n  \"width\": {w},\n  \"height\": {h},\n  \"format\": \"febuilder-mar-u16-shl3\"\n}}\n");
+
+                var v = DecompAssetValidatorCore.ValidateAsset(AssetKind.MapChangeOverlay, changePath);
+                Assert.False(v.Ok);
+                Assert.Contains(v.Errors, e => e.Code == "BAD_MAPCHANGE_FORMAT");
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void ValidateMapChange_MissingFormat_BadFormat()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                int w = 2, h = 2;
+                byte[] body = new byte[w * h * 2];
+                string changePath = Path.Combine(dir, "nofmt.change");
+                File.WriteAllBytes(changePath, body);
+                File.WriteAllText(changePath + ".json",
+                    $"{{\n  \"width\": {w},\n  \"height\": {h}\n}}\n"); // no format field
+
+                var v = DecompAssetValidatorCore.ValidateAsset(AssetKind.MapChangeOverlay, changePath);
+                Assert.False(v.Ok);
+                Assert.Contains(v.Errors, e => e.Code == "BAD_MAPCHANGE_FORMAT");
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        static string DescribeErrors(AssetValidationResult v)
+        {
+            var sb = new StringBuilder();
+            foreach (AssetIssue e in v.Errors) sb.Append($"[{e.Code}] {e.Message}; ");
+            return sb.ToString();
+        }
+
         // ---- FormatTexts (internal, testable without ROM) ----
 
         [Fact]

--- a/FEBuilderGBA.Core.Tests/DecompAssetValidatorCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompAssetValidatorCoreTests.cs
@@ -460,6 +460,9 @@ namespace FEBuilderGBA.Core.Tests
         [InlineData("icon", AssetKind.Icon)]
         [InlineData("map", AssetKind.MapLayout)]
         [InlineData("MapLayout", AssetKind.MapLayout)]
+        [InlineData("mapchange", AssetKind.MapChangeOverlay)]
+        [InlineData("mapchange-overlay", AssetKind.MapChangeOverlay)]
+        [InlineData("MapChange", AssetKind.MapChangeOverlay)]
         public void ParseKind_Maps(string s, AssetKind expected)
         {
             Assert.Equal(expected, DecompAssetValidatorCore.ParseKind(s));

--- a/FEBuilderGBA.Core.Tests/DecompRoundTripAuditCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompRoundTripAuditCoreTests.cs
@@ -74,6 +74,35 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void MapChangeOverlay_Row_IsSourceTreeExporter_ImportVerify()
+        {
+            // #1355: the map-change overlay import/verify row is a SourceTreeExporter row.
+            var rows = DecompRoundTripAuditCore.BuildMatrix();
+            var row = rows.SingleOrDefault(r =>
+                r.Table == "map_change_overlay"
+                && r.Action == "Map-change overlay import/verify");
+            Assert.NotNull(row);
+            Assert.Equal(DecompCoverage.SourceTreeExporter, row.Coverage);
+            Assert.Contains("--verify-asset", row.Notes);
+            Assert.Contains("NOT the .mar layout", row.Notes);
+        }
+
+        [Fact]
+        public void MapAssetBinaries_Row_StillManualMigration_NoLongerMentionsOverlay()
+        {
+            // #1355: the map-change OVERLAY tile data block is now source-backed, so the
+            // map_asset_binaries ManualMigration row must no longer claim "overlay".
+            var rows = DecompRoundTripAuditCore.BuildMatrix();
+            var row = rows.SingleOrDefault(r => r.Table == "map_asset_binaries");
+            Assert.NotNull(row);
+            Assert.Equal(DecompCoverage.ManualMigration, row.Coverage);
+            // The row must EXCLUDE the overlay (it is now source-backed export/import/verify),
+            // and must no longer LIST it among the remaining LZ77/pointer binaries.
+            Assert.Contains("NOT the map-change overlay tile data block", row.Notes);
+            Assert.DoesNotContain("tile animations 1/2, map-change overlay", row.Notes);
+        }
+
+        [Fact]
         public void ManualAndRomOnly_Tables_DoNotAppear_AsSourceBackedRowSave_ForSameEditor()
         {
             var rows = DecompRoundTripAuditCore.BuildMatrix();

--- a/FEBuilderGBA.Core/DecompAssetExportCore.cs
+++ b/FEBuilderGBA.Core/DecompAssetExportCore.cs
@@ -525,6 +525,257 @@ namespace FEBuilderGBA
             }
         }
 
+        // ---- Map-change OVERLAY (raw uncompressed u16 LE, #1355) ----
+
+        /// <summary>
+        /// Export a Map-Change OVERLAY tile DATA BLOCK (#1355) — a RAW UNCOMPRESSED <c>u16</c> LE
+        /// array of <c>width*height</c> config-descriptor indices — to a <c>.change</c> file plus a
+        /// sidecar JSON. This is NOT the <c>.mar</c> tile layout (no <c>&lt;&lt;3</c> shift, no LZ77)
+        /// and NOT the 12-byte change-RECORD chain (terminator/flagID/PLIST metadata): it is ONLY the
+        /// overlay data block that the change pointer (record <c>+8</c>) points at.
+        ///
+        /// <para>The body is copied BYTE-FOR-BYTE from the (already-uncompressed) ROM region at
+        /// <paramref name="changeAddr"/>; <c>srcAddr</c> in the sidecar is provenance metadata ONLY
+        /// (no symbol/owner is fabricated). This method is READ-ONLY (never mutates the ROM) and
+        /// NEVER throws.</para>
+        /// </summary>
+        /// <param name="rom">Loaded ROM. Must not be null.</param>
+        /// <param name="changeAddr">ROM byte offset of the raw overlay data block (record <c>+8</c>
+        /// change pointer, dereferenced).</param>
+        /// <param name="width">Overlay width (record <c>+3</c>), 1..255.</param>
+        /// <param name="height">Overlay height (record <c>+4</c>), 1..255.</param>
+        /// <param name="absOutChangePath">Absolute path for the output <c>.change</c> file. A sidecar
+        /// <c>&lt;path&gt;.change.json</c> is written at the same path with <c>.json</c> appended.</param>
+        public static DecompAssetResult ExportMapChange(ROM rom, uint changeAddr, int width, int height, string absOutChangePath)
+        {
+            try
+            {
+                if (rom == null)
+                    return Fail(DecompAssetStatus.BadArgs, "ROM is null");
+                if (string.IsNullOrEmpty(absOutChangePath))
+                    return Fail(DecompAssetStatus.BadArgs, "Output .change path is null or empty");
+                if (rom.Data == null)
+                    return Fail(DecompAssetStatus.NotData, "ROM has no data");
+
+                // Dimensions must fit the u8 record fields (1..255).
+                if (width < 1 || width > 255 || height < 1 || height > 255)
+                    return Fail(DecompAssetStatus.NotData, $"Invalid map-change overlay dimensions {width}x{height} (must be 1..255)");
+
+                long bodyLen = (long)width * height * 2;
+                // Bounds: the start must be a safe offset AND the whole body (last byte inclusive)
+                // must lie inside the ROM. Use a long for the end so a huge w*h cannot wrap a uint.
+                if (!U.isSafetyOffset(changeAddr, rom)
+                    || changeAddr + bodyLen > rom.Data.Length
+                    || changeAddr + bodyLen - 1 >= rom.Data.Length)
+                    return Fail(DecompAssetStatus.NotData,
+                        $"Overlay region [0x{changeAddr:X}, 0x{changeAddr + bodyLen:X}) is outside ROM (size 0x{rom.Data.Length:X})");
+
+                // Copy the raw overlay body byte-for-byte from the (already-uncompressed) ROM.
+                byte[] body = rom.getBinaryData(changeAddr, (int)bodyLen);
+                if (body == null || body.Length != bodyLen)
+                    return Fail(DecompAssetStatus.NotData, $"Could not read {bodyLen}-byte overlay body at 0x{changeAddr:X}");
+
+                EnsureParentDir(absOutChangePath);
+                File.WriteAllBytes(absOutChangePath, body);
+
+                string jsonPath = absOutChangePath + ".json";
+                string json = BuildMapChangeJson(width, height, changeAddr);
+                File.WriteAllText(jsonPath, json, Encoding.UTF8);
+
+                var result = new DecompAssetResult { Status = DecompAssetStatus.Ok, Message = $"Map-change overlay exported ({width}x{height})" };
+                result.WrittenPaths.Add(absOutChangePath);
+                result.WrittenPaths.Add(jsonPath);
+                return result;
+            }
+            catch (Exception ex)
+            {
+                return Fail(DecompAssetStatus.Faulted, ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Re-import a <c>.change</c> map-change OVERLAY (the inverse of <see cref="ExportMapChange"/>)
+        /// into a RAW UNCOMPRESSED overlay blob (#1355). The overlay is an IDENTITY copy — there is NO
+        /// <c>[w][h]</c> header prepend, NO <c>&gt;&gt;3</c> shift, NO LZ77 compression — so the output
+        /// blob is the validated body written VERBATIM.
+        ///
+        /// <para>This method NEVER reads <see cref="CoreState.ROM"/>, NEVER LZ77-compresses, NEVER
+        /// mutates the ROM, and NEVER throws. The REQUIRED sidecar dims (validated against the body
+        /// length) make this a genuine source-backed artifact.</para>
+        /// </summary>
+        /// <param name="absInChangePath">Absolute path to the input <c>.change</c> file. A sidecar
+        /// <c>&lt;path&gt;.change.json</c> (the export-side JSON) is REQUIRED.</param>
+        /// <param name="absOutBlobPath">Absolute path for the output RAW overlay blob (identity copy
+        /// of the validated body).</param>
+        public static DecompAssetResult ImportMapChange(string absInChangePath, string absOutBlobPath)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(absInChangePath))
+                    return Fail(DecompAssetStatus.BadArgs, "Input .change path is null or empty");
+                if (string.IsNullOrEmpty(absOutBlobPath))
+                    return Fail(DecompAssetStatus.BadArgs, "Output blob path is null or empty");
+
+                // Structural validation (required sidecar, format, dims, even length, w*h*2).
+                AssetValidationResult v = DecompAssetValidatorCore.ValidateAsset(AssetKind.MapChangeOverlay, absInChangePath);
+                if (!v.Ok)
+                {
+                    AssetIssue first = v.Errors.Count > 0 ? v.Errors[0] : null;
+                    string detail = first != null ? $"[{first.Code}] {first.Message}" : "unknown error";
+                    return Fail(DecompAssetStatus.NotData, "validation failed: " + detail);
+                }
+
+                byte[] body = File.ReadAllBytes(absInChangePath);
+
+                // The sidecar dims are REQUIRED (the validator already errors when missing, but
+                // re-read here to size-check the body before the identity copy).
+                string sidecar = absInChangePath + ".json";
+                if (!TryReadMapChangeDims(sidecar, out int width, out int height))
+                    return Fail(DecompAssetStatus.NotData, "sidecar .change.json required to read dimensions");
+
+                int expected = width * height * 2;
+                if (body.Length != expected)
+                    return Fail(DecompAssetStatus.NotData,
+                        $"File length {body.Length} != width*height*2 ({width}*{height}*2 = {expected})");
+
+                // The overlay is an identity copy: write the validated body VERBATIM.
+                EnsureParentDir(absOutBlobPath);
+                File.WriteAllBytes(absOutBlobPath, body);
+
+                var result = new DecompAssetResult
+                {
+                    Status = DecompAssetStatus.Ok,
+                    Message = $"Imported {width}x{height} map-change overlay to raw blob ({body.Length} bytes)"
+                };
+                result.WrittenPaths.Add(absOutBlobPath);
+                return result;
+            }
+            catch (Exception ex)
+            {
+                return Fail(DecompAssetStatus.Faulted, ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// PURE structural round-trip proof for a map-change OVERLAY BODY (#1355): true iff
+        /// <paramref name="body"/> is non-null, has even length, the dims are positive, and
+        /// <c>body.Length == width*height*2</c>. Try/catch → false.
+        ///
+        /// <para>This is source-level structure-exact IDENTITY, NOT a byte-pinned ROM round-trip.
+        /// For a byte-exact ROM mismatch proof use <see cref="VerifyMapChangeAgainstRom"/>.</para>
+        /// </summary>
+        public static bool RoundTripMapChangeBody(byte[] body, int width, int height)
+        {
+            try
+            {
+                if (body == null) return false;
+                if (body.Length % 2 != 0) return false;
+                if (width < 1 || height < 1) return false;
+                return body.Length == width * height * 2;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Byte-exact ROM-backed mismatch proof for a map-change OVERLAY (#1355): compare the
+        /// raw ROM overlay region at <paramref name="changeAddr"/> against the <c>.change</c> file
+        /// body byte-for-byte. This is the ONLY ROM-backed verification path (export/import never
+        /// touch the ROM). READ-ONLY (never mutates the ROM), NEVER throws.
+        /// </summary>
+        /// <param name="rom">Loaded ROM. Must not be null.</param>
+        /// <param name="changeAddr">ROM byte offset of the raw overlay data block.</param>
+        /// <param name="width">Overlay width, 1..255.</param>
+        /// <param name="height">Overlay height, 1..255.</param>
+        /// <param name="absInChangePath">Absolute path to the <c>.change</c> file (with required sidecar).</param>
+        public static DecompAssetResult VerifyMapChangeAgainstRom(ROM rom, uint changeAddr, int width, int height, string absInChangePath)
+        {
+            try
+            {
+                if (rom == null)
+                    return Fail(DecompAssetStatus.BadArgs, "ROM is null");
+                if (string.IsNullOrEmpty(absInChangePath))
+                    return Fail(DecompAssetStatus.BadArgs, "Input .change path is null or empty");
+                if (rom.Data == null)
+                    return Fail(DecompAssetStatus.NotData, "ROM has no data");
+
+                // Validate the .change file first (required sidecar, format, dims, length).
+                AssetValidationResult v = DecompAssetValidatorCore.ValidateAsset(AssetKind.MapChangeOverlay, absInChangePath);
+                if (!v.Ok)
+                {
+                    AssetIssue first = v.Errors.Count > 0 ? v.Errors[0] : null;
+                    string detail = first != null ? $"[{first.Code}] {first.Message}" : "unknown error";
+                    return Fail(DecompAssetStatus.NotData, "validation failed: " + detail);
+                }
+
+                if (width < 1 || width > 255 || height < 1 || height > 255)
+                    return Fail(DecompAssetStatus.NotData, $"Invalid map-change overlay dimensions {width}x{height} (must be 1..255)");
+
+                long bodyLen = (long)width * height * 2;
+                if (!U.isSafetyOffset(changeAddr, rom)
+                    || changeAddr + bodyLen > rom.Data.Length
+                    || changeAddr + bodyLen - 1 >= rom.Data.Length)
+                    return Fail(DecompAssetStatus.NotData,
+                        $"Overlay region [0x{changeAddr:X}, 0x{changeAddr + bodyLen:X}) is outside ROM (size 0x{rom.Data.Length:X})");
+
+                byte[] body = File.ReadAllBytes(absInChangePath);
+                if (body.Length != bodyLen)
+                    return Fail(DecompAssetStatus.NotData,
+                        $"File length {body.Length} != width*height*2 ({width}*{height}*2 = {bodyLen})");
+
+                for (int i = 0; i < body.Length; i++)
+                {
+                    byte romByte = rom.Data[changeAddr + i];
+                    byte fileByte = body[i];
+                    if (romByte != fileByte)
+                        return Fail(DecompAssetStatus.NotData,
+                            $"Overlay mismatch at byte offset {i}: ROM=0x{romByte:X2} file=0x{fileByte:X2}");
+                }
+
+                return new DecompAssetResult
+                {
+                    Status = DecompAssetStatus.Ok,
+                    Message = $"Verified {width}x{height} map-change overlay byte-identical to ROM"
+                };
+            }
+            catch (Exception ex)
+            {
+                return Fail(DecompAssetStatus.Faulted, ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Read width/height from a <c>.change.json</c> sidecar (the export-side JSON). NEVER throws;
+        /// returns false on any fault or non-positive dim. Public so the CLI <c>--roundtrip-asset</c>
+        /// path can size the overlay body before calling <see cref="RoundTripMapChangeBody"/>.
+        /// </summary>
+        public static bool TryReadMapChangeDims(string sidecarPath, out int width, out int height)
+        {
+            width = 0; height = 0;
+            try
+            {
+                if (string.IsNullOrEmpty(sidecarPath) || !File.Exists(sidecarPath))
+                    return false;
+                string json = File.ReadAllText(sidecarPath);
+                using System.Text.Json.JsonDocument doc = System.Text.Json.JsonDocument.Parse(json);
+                System.Text.Json.JsonElement root = doc.RootElement;
+                if (root.ValueKind != System.Text.Json.JsonValueKind.Object) return false;
+                if (root.TryGetProperty("width", out System.Text.Json.JsonElement w)
+                    && w.ValueKind == System.Text.Json.JsonValueKind.Number)
+                    width = w.GetInt32();
+                if (root.TryGetProperty("height", out System.Text.Json.JsonElement h)
+                    && h.ValueKind == System.Text.Json.JsonValueKind.Number)
+                    height = h.GetInt32();
+                return width > 0 && height > 0;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
         // ---- ExportText ----
 
         /// <summary>
@@ -831,6 +1082,12 @@ namespace FEBuilderGBA
         {
             // Hand-built to avoid any dependency on System.Text.Json serializer options
             return $"{{\n  \"width\": {w},\n  \"height\": {h},\n  \"srcAddr\": \"0x{addrOffset:X}\",\n  \"format\": \"febuilder-mar-u16-shl3\"\n}}\n";
+        }
+
+        static string BuildMapChangeJson(int w, int h, uint addrOffset)
+        {
+            // Hand-built (same shape as BuildMapJson); srcAddr is provenance metadata ONLY.
+            return $"{{\n  \"width\": {w},\n  \"height\": {h},\n  \"srcAddr\": \"0x{addrOffset:X}\",\n  \"format\": \"febuilder-mapchange-u16\"\n}}\n";
         }
     }
 }

--- a/FEBuilderGBA.Core/DecompAssetValidatorCore.cs
+++ b/FEBuilderGBA.Core/DecompAssetValidatorCore.cs
@@ -810,7 +810,7 @@ namespace FEBuilderGBA
                 || !string.Equals(format, "febuilder-mapchange-u16", StringComparison.Ordinal))
             {
                 r.Errors.Add(new AssetIssue("BAD_MAPCHANGE_FORMAT",
-                    $"Sidecar '{Path.GetFileName(sidecar)}.json' must declare format \"febuilder-mapchange-u16\"; got \"{format ?? "(missing)"}\"."));
+                    $"Sidecar '{Path.GetFileName(sidecar)}' must declare format \"febuilder-mapchange-u16\"; got \"{format ?? "(missing)"}\"."));
                 return;
             }
 

--- a/FEBuilderGBA.Core/DecompAssetValidatorCore.cs
+++ b/FEBuilderGBA.Core/DecompAssetValidatorCore.cs
@@ -23,6 +23,11 @@ namespace FEBuilderGBA
         /// <summary>.mar tile layout binary (validated against its sidecar JSON).</summary>
         MapLayout,
         /// <summary>
+        /// Raw uncompressed u16 LE map-change overlay tile data block (#1355). NOT the .mar
+        /// layout, NOT the change-record chain.
+        /// </summary>
+        MapChangeOverlay,
+        /// <summary>
         /// A multi-file PORTRAIT PACKAGE directory (#1350): a single 128x112 composite
         /// portrait sheet PNG + an optional sidecar JASC .pal. Validated for sheet-slot
         /// geometry and palette consistency (PLTE-vs-JASC), NOT write-back / frame order.
@@ -137,6 +142,9 @@ namespace FEBuilderGBA
                         break;
                     case AssetKind.MapLayout:
                         ValidateMar(path, r);
+                        break;
+                    case AssetKind.MapChangeOverlay:
+                        ValidateMapChange(path, r);
                         break;
                     case AssetKind.Graphics:
                     case AssetKind.Portrait:
@@ -397,8 +405,8 @@ namespace FEBuilderGBA
 
         /// <summary>
         /// Map a kind string ("graphics"/"palette"/"portrait"/"icon"/"map"|"maplayout"/
-        /// "portrait-package"|"portraitpackage", case-insensitive) to an
-        /// <see cref="AssetKind"/>; null when unrecognized.
+        /// "mapchange"|"mapchange-overlay"/"portrait-package"|"portraitpackage",
+        /// case-insensitive) to an <see cref="AssetKind"/>; null when unrecognized.
         /// </summary>
         public static AssetKind? ParseKind(string s)
         {
@@ -411,6 +419,8 @@ namespace FEBuilderGBA
                 case "icon": return AssetKind.Icon;
                 case "map":
                 case "maplayout": return AssetKind.MapLayout;
+                case "mapchange":
+                case "mapchange-overlay": return AssetKind.MapChangeOverlay;
                 case "portrait-package":
                 case "portraitpackage": return AssetKind.PortraitPackage;
                 default: return null;
@@ -752,6 +762,109 @@ namespace FEBuilderGBA
                 if (root.TryGetProperty("height", out JsonElement h) && h.ValueKind == JsonValueKind.Number)
                     height = h.GetInt32();
                 return width > 0 && height > 0;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        // ------------------------------------------------ MapChangeOverlay (raw u16 LE)
+
+        /// <summary>
+        /// Validate a RAW UNCOMPRESSED map-change OVERLAY tile data block (#1355) — a flat
+        /// array of <c>width*height</c> u16 LE config-descriptor indices. Unlike <see cref="ValidateMar"/>
+        /// there is NO <c>&lt;&lt;3</c> low-3-bits invariant (overlay indices are raw u16, any value
+        /// is valid) and almost no intrinsic structure, so the sidecar JSON is REQUIRED (it carries
+        /// the dimensions AND the format declaration). Checks:
+        /// <list type="bullet">
+        ///   <item>sidecar <c>&lt;name&gt;.json</c> present and declares <c>format ==
+        ///   "febuilder-mapchange-u16"</c> — else <c>MAPCHANGE_NO_SIDECAR</c>/<c>BAD_MAPCHANGE_FORMAT</c>;</item>
+        ///   <item>dimensions readable and in u8 range 1..255 — else <c>BAD_MAPCHANGE_DIMS</c>;</item>
+        ///   <item>body length even AND equal to <c>width*height*2</c> — else <c>BAD_MAPCHANGE_LENGTH</c>.</item>
+        /// </list>
+        /// NEVER reads the ROM, NEVER throws.
+        /// </summary>
+        static void ValidateMapChange(string path, AssetValidationResult r)
+        {
+            byte[] body;
+            try { body = File.ReadAllBytes(path); }
+            catch (Exception ex)
+            {
+                r.Errors.Add(new AssetIssue("READ_FAILED", "Could not read file: " + ex.Message));
+                return;
+            }
+
+            // The overlay body has almost no intrinsic invariant, so the sidecar is REQUIRED
+            // (it carries both the dimensions and the format declaration).
+            string sidecar = path + ".json";
+            if (!File.Exists(sidecar))
+            {
+                r.Errors.Add(new AssetIssue("MAPCHANGE_NO_SIDECAR",
+                    $"Sidecar '{Path.GetFileName(sidecar)}' is required for a map-change overlay (it carries width/height and the format declaration)."));
+                return;
+            }
+
+            // The sidecar MUST declare format == "febuilder-mapchange-u16".
+            if (!TryReadSidecarFormat(sidecar, out string format)
+                || !string.Equals(format, "febuilder-mapchange-u16", StringComparison.Ordinal))
+            {
+                r.Errors.Add(new AssetIssue("BAD_MAPCHANGE_FORMAT",
+                    $"Sidecar '{Path.GetFileName(sidecar)}.json' must declare format \"febuilder-mapchange-u16\"; got \"{format ?? "(missing)"}\"."));
+                return;
+            }
+
+            // Dimensions are required and must fit u8 (1..255).
+            if (!TryReadSidecarDims(sidecar, out int width, out int height))
+            {
+                r.Errors.Add(new AssetIssue("BAD_MAPCHANGE_DIMS",
+                    $"Sidecar '{Path.GetFileName(sidecar)}' must declare positive integer width/height."));
+                return;
+            }
+            if (width < 1 || width > 255 || height < 1 || height > 255)
+            {
+                r.Errors.Add(new AssetIssue("BAD_MAPCHANGE_DIMS",
+                    $"Dimensions {width}x{height} are out of the u8 range 1..255."));
+                return;
+            }
+
+            // Length must be even (a sequence of u16 entries).
+            if (body.Length % 2 != 0)
+            {
+                r.Errors.Add(new AssetIssue("BAD_MAPCHANGE_LENGTH",
+                    $"File length {body.Length} is odd; a map-change overlay is a flat array of u16 entries."));
+                return;
+            }
+
+            // Length must equal width*height*2 exactly.
+            int expected = width * height * 2;
+            if (body.Length != expected)
+            {
+                r.Errors.Add(new AssetIssue("BAD_MAPCHANGE_LENGTH",
+                    $"File length {body.Length} != width*height*2 ({width}*{height}*2 = {expected})."));
+            }
+        }
+
+        /// <summary>
+        /// Read the root-object <c>format</c> string property from a sidecar JSON. NEVER throws;
+        /// returns false (and <paramref name="format"/> = null) on any fault or a missing/non-string
+        /// property. Mirrors <see cref="TryReadSidecarDims"/>'s shape.
+        /// </summary>
+        static bool TryReadSidecarFormat(string sidecar, out string format)
+        {
+            format = null;
+            try
+            {
+                string json = File.ReadAllText(sidecar);
+                using JsonDocument doc = JsonDocument.Parse(json);
+                JsonElement root = doc.RootElement;
+                if (root.ValueKind != JsonValueKind.Object) return false;
+                if (root.TryGetProperty("format", out JsonElement f) && f.ValueKind == JsonValueKind.String)
+                {
+                    format = f.GetString();
+                    return format != null;
+                }
+                return false;
             }
             catch
             {

--- a/FEBuilderGBA.Core/DecompRoundTripAuditCore.cs
+++ b/FEBuilderGBA.Core/DecompRoundTripAuditCore.cs
@@ -216,6 +216,8 @@ namespace FEBuilderGBA
                 DecompCoverage.SourceTreeExporter, ".mar tilemap + sidecar .mar.json — export AND re-import/verify (lossless u16 layout body for raw entries < 0x2000, i.e. palette/flag bits 13-15 clear); compressed container re-derived by the build, not byte-pinned"));
             rows.Add(new DecompAuditRow("Map Editor", "map", "Map layout import/verify",
                 DecompCoverage.SourceTreeExporter, "Re-import .mar to raw uncompressed tilemap blob + roundtrip-verify; never mutates the preview ROM"));
+            rows.Add(new DecompAuditRow("Map Editor", "map_change_overlay", "Map-change overlay import/verify",
+                DecompCoverage.SourceTreeExporter, "Raw uncompressed u16 overlay tile data block — export (--export-asset --kind=mapchange) + import (--import-asset) + byte-exact ROM verify (--verify-asset --kind=mapchange) + structural roundtrip; never mutates the preview ROM. Source-level structure-exact identity AND byte-exact ROM compare; NOT the .mar layout and NOT the 12-byte change-record chain"));
             rows.Add(new DecompAuditRow("Text Editor", "text", "Text export",
                 DecompCoverage.SourceTreeExporter, "texts.txt + textdefs.txt (migration format, not lossless macro round-trip)"));
 
@@ -235,7 +237,7 @@ namespace FEBuilderGBA
             rows.Add(new DecompAuditRow("Item Shop Editor", "shops", "Shop list source save",
                 DecompCoverage.SourceBackedWriter, "In-place source-backed rewrite of a u16 ITEM_NONE-terminated list (manifest list-owner: format=u16-list, symbol-resolved) via --write-shop; requires decomp-mode .map/.elf carrying the list symbol AND a manifest list-owner; degrades to --export-asset --kind=shop otherwise (#1347). Supports BOTH a LITERAL raw-hex list AND a SYMBOLIC ITEM_* (item-id-only, quantity 0) list whose macro names resolve from the constants header (owner.constantsHeader / artifacts.itemConstants / include/constants/items.h); a non-zero quantity or an id with no ITEM_* constant is an actionable refusal, not a clobber (#1354)"));
             rows.Add(new DecompAuditRow("Map Editor", "map_asset_binaries", "Raw map asset save (GUI: OBJ/TSA/anim/map-change)",
-                DecompCoverage.ManualMigration, "GUI raw-ROM-save path for the remaining LZ77 map binaries (OBJ tileset, chipset TSA/config, tile animations 1/2, map-change overlay) — NOT the .mar tile layout (which is source-backed import/verify above); migrate these via --export-asset"));
+                DecompCoverage.ManualMigration, "GUI raw-ROM-save path for the remaining LZ77/pointer map binaries (OBJ tileset, chipset TSA/config, tile animations 1/2) AND the 12-byte map-change RECORD chain (terminator/flagID/PLIST metadata) — NOT the map-change overlay tile data block (which is source-backed export/import/verify above) and NOT the .mar tile layout; migrate these via --export-asset"));
             rows.Add(new DecompAuditRow("Event Editor", "chapter_event_pointers", "Event/difficulty pointer fields",
                 DecompCoverage.ManualMigration, "Chapter pointer fields (EventDataPtr, difficulty pointers) are not source-backed"));
 

--- a/FEBuilderGBA.E2ETests/Tests/ExportAssetE2ETests.cs
+++ b/FEBuilderGBA.E2ETests/Tests/ExportAssetE2ETests.cs
@@ -541,5 +541,171 @@ namespace FEBuilderGBA.E2ETests.Tests
                 try { Directory.Delete(projectDir, true); } catch { }
             }
         }
+
+        // ============================================================================
+        // Map-change OVERLAY (raw uncompressed u16 LE, #1355)
+        // ============================================================================
+
+        // Build a synthetic .change overlay body (raw u16 LE, any value) + matching sidecar.
+        static void WriteSyntheticChange(string changePath, int w, int h, string format = "febuilder-mapchange-u16")
+        {
+            byte[] body = new byte[w * h * 2];
+            for (int i = 0; i < w * h; i++)
+            {
+                ushort v = (ushort)(i * 0x101 + 0x2222); // arbitrary u16, includes >= 0x2000
+                body[i * 2 + 0] = (byte)(v & 0xFF);
+                body[i * 2 + 1] = (byte)(v >> 8);
+            }
+            File.WriteAllBytes(changePath, body);
+            File.WriteAllText(changePath + ".json",
+                $"{{\n  \"width\": {w},\n  \"height\": {h},\n  \"srcAddr\": \"0x200\",\n  \"format\": \"{format}\"\n}}\n");
+        }
+
+        [Fact]
+        public void ImportAsset_MapChange_ExitsZero_WritesIdentityBlob()
+        {
+            string dir = NewTempDir("import_change");
+            try
+            {
+                int w = 4, h = 3;
+                string changePath = Path.Combine(dir, "chapter.change");
+                WriteSyntheticChange(changePath, w, h);
+
+                string outBin = Path.Combine(dir, "chapter.change_raw.bin");
+                string args = $"--import-asset --kind=mapchange --in=\"{changePath}\" --out=\"{outBin}\"";
+                var (code, stdout, stderr) = RunWithRetry(args);
+
+                Assert.True(code == 0,
+                    $"--import-asset --kind=mapchange exited with {code}\nStdout: {stdout}\nStderr: {stderr}");
+                Assert.True(File.Exists(outBin), $"Expected raw blob at {outBin}");
+
+                // Identity copy: blob == .change body byte-for-byte.
+                byte[] src = File.ReadAllBytes(changePath);
+                byte[] dst = File.ReadAllBytes(outBin);
+                Assert.Equal(src, dst);
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void RoundtripAsset_MapChange_Clean_ExitsZero()
+        {
+            string dir = NewTempDir("rt_change_ok");
+            try
+            {
+                string changePath = Path.Combine(dir, "chapter.change");
+                WriteSyntheticChange(changePath, 4, 3);
+
+                string args = $"--roundtrip-asset --kind=mapchange --in=\"{changePath}\"";
+                var (code, stdout, stderr) = RunWithRetry(args);
+
+                Assert.True(code == 0,
+                    $"--roundtrip-asset --kind=mapchange exited with {code}\nStdout: {stdout}\nStderr: {stderr}");
+                Assert.Contains("Round-trip OK", stdout);
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void RoundtripAsset_MapChange_TruncatedBody_ExitsTwo()
+        {
+            string dir = NewTempDir("rt_change_bad");
+            try
+            {
+                int w = 4, h = 3;
+                string changePath = Path.Combine(dir, "chapter.change");
+                WriteSyntheticChange(changePath, w, h);
+
+                // Truncate the body by 2 bytes (sidecar still says 4x3) → length mismatch.
+                byte[] body = File.ReadAllBytes(changePath);
+                byte[] truncated = new byte[body.Length - 2];
+                Array.Copy(body, truncated, truncated.Length);
+                File.WriteAllBytes(changePath, truncated);
+
+                string args = $"--roundtrip-asset --kind=mapchange --in=\"{changePath}\"";
+                var (code, _, _) = RunWithRetry(args);
+
+                Assert.Equal(2, code);
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void ImportAsset_MapChange_UnknownKind_ExitsNonZero()
+        {
+            // --import-asset only supports map | mapchange; a bogus kind is exit 1.
+            var (code, _, _) = RunWithRetry("--import-asset --kind=bogus --in=x.change --out=x.bin");
+            Assert.NotEqual(0, code);
+        }
+
+        [Fact]
+        public void RoundtripAsset_MapChange_UnknownKind_ExitsNonZero()
+        {
+            var (code, _, _) = RunWithRetry("--roundtrip-asset --kind=bogus --in=x.change");
+            Assert.NotEqual(0, code);
+        }
+
+        [Fact]
+        public void VerifyAsset_UnknownKind_ExitsOne()
+        {
+            // --verify-asset only supports mapchange; map is rejected as a usage error (exit 1).
+            var (code, _, _) = RunWithRetry("--verify-asset --kind=map --in=x.mar --addr=0x200 --width=2 --height=2 --rom=fake.gba");
+            Assert.Equal(1, code);
+        }
+
+        // ---- ROM-backed export + verify (needs a real ROM; skipped otherwise). ----
+
+        [SkippableFact]
+        public void ExportAsset_MapChange_Rom_ExitsZero_WritesChangeAndSidecar_VerifyMatches()
+        {
+            Skip.If(FirstRom == null, "No ROM available for export-asset mapchange test");
+
+            string dir = NewTempDir("export_change");
+            string outChange = Path.Combine(dir, "chapter.change");
+            try
+            {
+                // A benign in-ROM offset (>= 0x200) and tiny dims so the region is in bounds.
+                // We don't care WHAT bytes are there — only that export reads them and that a
+                // subsequent verify against the SAME address is byte-identical.
+                const string addr = "0x1000";
+                int w = 2, h = 2;
+                string exportArgs =
+                    $"--export-asset --kind=mapchange --rom=\"{FirstRom}\" --addr={addr} --width={w} --height={h} --out=\"{outChange}\"";
+                var (code, stdout, stderr) = RunWithRetry(exportArgs);
+
+                Assert.True(code == 0,
+                    $"--export-asset --kind=mapchange exited with {code}\nStdout: {stdout}\nStderr: {stderr}");
+                Assert.True(File.Exists(outChange), $"Expected .change at {outChange}");
+                Assert.True(File.Exists(outChange + ".json"), "Expected sidecar .change.json");
+                Assert.Equal(w * h * 2, new FileInfo(outChange).Length);
+
+                // Verify the exported overlay against the SAME ROM address → byte-identical (exit 0).
+                string verifyArgs =
+                    $"--verify-asset --kind=mapchange --rom=\"{FirstRom}\" --addr={addr} --width={w} --height={h} --in=\"{outChange}\"";
+                var (vcode, vstdout, vstderr) = RunWithRetry(verifyArgs);
+                Assert.True(vcode == 0,
+                    $"--verify-asset (matching) exited with {vcode}\nStdout: {vstdout}\nStderr: {vstderr}");
+
+                // Edit a byte in the .change file → verify must now MISMATCH (exit 2).
+                byte[] edited = File.ReadAllBytes(outChange);
+                edited[0] ^= 0xFF;
+                File.WriteAllBytes(outChange, edited);
+                var (mcode, _, _) = RunWithRetry(verifyArgs);
+                Assert.Equal(2, mcode);
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ dotnet run --project FEBuilderGBA.CLI -- --import-palette --rom=rom.gba --addr=0
 dotnet run --project FEBuilderGBA.CLI -- --export-asset --kind=palette --rom=rom.gba --addr=0x5524 --colors=16 --out=gfx/palette.pal
 dotnet run --project FEBuilderGBA.CLI -- --export-asset --kind=graphics --project=decomp/ --addr=0x123000 --width=64 --height=64 --palette-addr=0x124000 --out=gfx/tiles.png
 dotnet run --project FEBuilderGBA.CLI -- --export-asset --kind=map --rom=rom.gba --addr=0x200000 --out=map/chapter1.mar
+dotnet run --project FEBuilderGBA.CLI -- --export-asset --kind=mapchange --rom=rom.gba --addr=0x300000 --width=15 --height=10 --out=map/chapter1.change
 dotnet run --project FEBuilderGBA.CLI -- --export-asset --kind=text --rom=rom.gba --out=text/
 dotnet run --project FEBuilderGBA.CLI -- --export-asset --kind=shop --rom=rom.gba --out=shops/
 
@@ -139,6 +140,20 @@ dotnet run --project FEBuilderGBA.CLI -- --export-asset --kind=shop --rom=rom.gb
 # sub-assets remain export-only / manual.
 dotnet run --project FEBuilderGBA.CLI -- --import-asset --kind=map --in=map/chapter1.mar --out=map/chapter1.tmap_raw.bin
 dotnet run --project FEBuilderGBA.CLI -- --roundtrip-asset --kind=map --in=map/chapter1.mar
+
+# Decomp map-change OVERLAY tile data block (#1355): a RAW UNCOMPRESSED u16 LE array of width*height
+# config-descriptor indices (the record +8 change pointer's target) — NOT the .mar tile layout and
+# NOT the 12-byte change-RECORD chain (terminator/flagID/PLIST metadata).
+# --export-asset --kind=mapchange  → read the live ROM overlay block (--addr=change_mar, --width, --height)
+#                                     into a .change file + .change.json sidecar (format "febuilder-mapchange-u16").
+# --import-asset --kind=mapchange  → identity copy of the validated .change body to a raw blob (NO header, NO shift, NO LZ77).
+# --roundtrip-asset --kind=mapchange → structure-exact identity proof (body length == width*height*2).
+# --verify-asset --kind=mapchange  → byte-exact ROM-backed mismatch proof (reads the ROM READ-ONLY; the
+#                                     ONLY ROM-backed verification — export/import never touch the ROM).
+# srcAddr in the sidecar is provenance metadata ONLY (no symbol/owner is fabricated).
+dotnet run --project FEBuilderGBA.CLI -- --import-asset --kind=mapchange --in=map/chapter1.change --out=map/chapter1.change_raw.bin
+dotnet run --project FEBuilderGBA.CLI -- --roundtrip-asset --kind=mapchange --in=map/chapter1.change
+dotnet run --project FEBuilderGBA.CLI -- --verify-asset --kind=mapchange --rom=rom.gba --addr=0x300000 --width=15 --height=10 --in=map/chapter1.change
 
 # Decomp source-backed table writer: rewrite the owning C array element (or JSON
 # element) of a structured table entry instead of mutating the preview ROM (the
@@ -468,11 +483,12 @@ required for variable-length / pointer / raw-binary data), **RomOnlyUnsupported*
 | Icon Editor | icon | Icon export | SourceTreeExporter | Indexed PNG via graphics exporter (16x16 tiles) |
 | Map Editor | map | Map layout export | SourceTreeExporter | .mar tilemap + sidecar .mar.json — export AND re-import/verify (lossless u16 layout body for raw entries < 0x2000, i.e. palette/flag bits 13-15 clear); compressed container re-derived by the build, not byte-pinned |
 | Map Editor | map | Map layout import/verify | SourceTreeExporter | Re-import .mar to raw uncompressed tilemap blob + roundtrip-verify; never mutates the preview ROM |
+| Map Editor | map_change_overlay | Map-change overlay import/verify | SourceTreeExporter | Raw uncompressed u16 overlay tile data block — export (--export-asset --kind=mapchange) + import (--import-asset) + byte-exact ROM verify (--verify-asset --kind=mapchange) + structural roundtrip; never mutates the preview ROM. Source-level structure-exact identity AND byte-exact ROM compare; NOT the .mar layout and NOT the 12-byte change-record chain |
 | Text Editor | text | Text export | SourceTreeExporter | texts.txt + textdefs.txt (migration format, not lossless macro round-trip) |
 | Item Shop Editor | shops | Shop list save | ManualMigration | Decomp-mode GUI save now routes to SOURCE when the shop's ROM address resolves to a manifest u16-list owner (symbol-resolved) AND the source list is literal-only (#1347 Slice 5a); otherwise ROM-only/manual (variable-length ITEM_NONE-terminated lists via scattered hensei/worldmap/event-cond pointers, unresolved/unnamed shops degrade to --export-asset --kind=shop) |
 | Item Shop Editor | shops | Shop list export | SourceTreeExporter | EA .event migration artifact via --export-asset --kind=shop; recreates each u16 ITEM_NONE-terminated list at its source address (migration aid, not source-backed in-place editing, not a byte-pinned round-trip) |
 | Item Shop Editor | shops | Shop list source save | SourceBackedWriter | In-place source-backed rewrite of a u16 ITEM_NONE-terminated list (manifest list-owner: format=u16-list, symbol-resolved) via --write-shop; requires decomp-mode .map/.elf carrying the list symbol AND a manifest list-owner; degrades to --export-asset --kind=shop otherwise (#1347). Supports BOTH a LITERAL raw-hex list AND a SYMBOLIC ITEM_* (item-id-only, quantity 0) list whose macro names resolve from the constants header (owner.constantsHeader / artifacts.itemConstants / include/constants/items.h); a non-zero quantity or an id with no ITEM_* constant is an actionable refusal, not a clobber (#1354) |
-| Map Editor | map_asset_binaries | Raw map asset save (GUI: OBJ/TSA/anim/map-change) | ManualMigration | GUI raw-ROM-save path for the remaining LZ77 map binaries (OBJ tileset, chipset TSA/config, tile animations 1/2, map-change overlay) — NOT the .mar tile layout (which is source-backed import/verify above); migrate these via --export-asset |
+| Map Editor | map_asset_binaries | Raw map asset save (GUI: OBJ/TSA/anim/map-change) | ManualMigration | GUI raw-ROM-save path for the remaining LZ77/pointer map binaries (OBJ tileset, chipset TSA/config, tile animations 1/2) AND the 12-byte map-change RECORD chain (terminator/flagID/PLIST metadata) — NOT the map-change overlay tile data block (which is source-backed export/import/verify above) and NOT the .mar tile layout; migrate these via --export-asset |
 | Event Editor | chapter_event_pointers | Event/difficulty pointer fields | ManualMigration | Chapter pointer fields (EventDataPtr, difficulty pointers) are not source-backed |
 | Battle Animation Editor | battle_anime | Animation view | ImportPreviewOnly | Preview-only in decomp mode; no source write-back (export via --export-battle-anime) |
 | Song Table Editor | song_table | Song view | ImportPreviewOnly | Preview-only; song data edits must be made in source by hand |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -508,25 +508,52 @@ music, portraits, and battle animations.
 
 | Option | Required | Description |
 |---|---|---|
-| `--kind=<kind>` | Yes | Asset kind: `graphics`, `palette`, `map` (always LZ77-decompressed), `text`. |
+| `--kind=<kind>` | Yes | Asset kind: `graphics`, `palette`, `map` (always LZ77-decompressed), `mapchange` (raw u16 map-change overlay), `text`, `shop`. |
 | `--out=<path>` | Yes | Output path (project-relative when `--project`; absolute or relative when `--rom`). |
 | `--rom=<path>` **or** `--project=<dir>` | Yes | Source ROM, or a decomp project whose built ROM is read (one is required). |
-| `--addr=<hex>` | Cond. | ROM address of the asset (required for `graphics`, `palette`, `map`). |
+| `--addr=<hex>` | Cond. | ROM address of the asset (required for `graphics`, `palette`, `map`, `mapchange`). For `mapchange` it is the `change_mar` offset (the record `+8` change pointer, dereferenced). |
 | `--palette-addr=<hex>` | Cond. | ROM address of the palette data (required for `graphics`). |
-| `--width=<int>` | Cond. | Image width in pixels (required for `graphics`). |
-| `--height=<int>` | Cond. | Image height in pixels (required for `graphics`). |
+| `--width=<int>` | Cond. | Image width in pixels (required for `graphics`; overlay width for `mapchange`, record `+3`). |
+| `--height=<int>` | Cond. | Image height in pixels (required for `graphics`; overlay height for `mapchange`, record `+4`). |
 | `--colors=<int>` | No | Palette colors (for `palette` and `graphics`). Default: **16**. |
 | `--bpp=<int>` | No | Bits per pixel for `graphics`: `4` or `8`. Default: **4**. |
 | `--compressed` | No | (graphics only) the source tiles at `--addr` are LZ77-compressed (flag). |
+
+The `mapchange` kind (#1355) exports the **raw uncompressed map-change OVERLAY tile data block** — a flat
+`width*height` array of `u16` LE config-descriptor indices. It is **NOT** the `.mar` tile layout (no `<<3`
+shift, no LZ77) and **NOT** the 12-byte change-RECORD chain (terminator / flagID / PLIST metadata). The body
+is copied byte-for-byte from the (already-uncompressed) ROM; `srcAddr` in the `.change.json` sidecar is
+provenance metadata only. Re-import / round-trip / byte-exact ROM verify are below.
 
 ```
 FEBuilderGBA.CLI --export-asset --kind=palette --rom=rom.gba --addr=0x5524 --out=gfx/palette.pal
 FEBuilderGBA.CLI --export-asset --kind=graphics --project=decomp/ --addr=0x123000 --width=64 --height=64 --palette-addr=0x124000 --out=gfx/tiles.png
 FEBuilderGBA.CLI --export-asset --kind=map --rom=rom.gba --addr=0x200000 --out=map/chapter1.mar
+FEBuilderGBA.CLI --export-asset --kind=mapchange --rom=rom.gba --addr=0x300000 --width=15 --height=10 --out=map/chapter1.change
 FEBuilderGBA.CLI --export-asset --kind=text --rom=rom.gba --out=text/
 ```
 
 **Exit code:** 0 on success, non-zero on usage / export fault.
+
+---
+
+### `--import-asset` / `--roundtrip-asset` / `--verify-asset` (map / mapchange)
+
+Re-import an edited map asset to a raw uncompressed blob, prove a body round-trips, or verify a map-change
+overlay byte-for-byte against the ROM. The `map` (`.mar` layout) variants are documented under `--export-asset`
+above; the `mapchange` (#1355) variants are:
+
+| Command | Reads ROM? | Description |
+|---|---|---|
+| `--import-asset --kind=mapchange --in=<x.change> --out=<x.bin>` | No | Identity copy of the validated `.change` body to a raw blob (NO `[w][h]` header, NO `>>3` shift, NO LZ77). Requires the `.change.json` sidecar. |
+| `--roundtrip-asset --kind=mapchange --in=<x.change>` | No | Structure-exact identity proof (`body.Length == width*height*2`, read from the sidecar). Exit 0 lossless, 2 mismatch. |
+| `--verify-asset --kind=mapchange --in=<x.change> --addr=<hex> --width --height (--rom\|--project)` | **Yes (read-only)** | Byte-exact ROM-backed mismatch proof — the ONLY ROM-backed verification path. Exit 0 byte-identical, 2 mismatch/fault, 1 usage error. |
+
+```
+FEBuilderGBA.CLI --import-asset --kind=mapchange --in=map/chapter1.change --out=map/chapter1.change_raw.bin
+FEBuilderGBA.CLI --roundtrip-asset --kind=mapchange --in=map/chapter1.change
+FEBuilderGBA.CLI --verify-asset --kind=mapchange --rom=rom.gba --addr=0x300000 --width=15 --height=10 --in=map/chapter1.change
+```
 
 ---
 
@@ -618,14 +645,14 @@ FEBuilderGBA.CLI --manifest-to-nmm --project=decomp/ --table=items --out=items.n
 
 ### `--validate-asset`
 
-Structurally validate a decomp IMPORT asset on disk (#1150) **before** wiring it into a build. READ-ONLY; **NEVER loads a ROM**. Indexed PNG → color type 3 / tile alignment / palette size / in-range indices; JASC `.pal` → header/count/color triples; `.mar` → length == w*h*2 and the `<<3` low-3-bits-zero invariant (validated against the `.mar.json` sidecar).
+Structurally validate a decomp IMPORT asset on disk (#1150) **before** wiring it into a build. READ-ONLY; **NEVER loads a ROM**. Indexed PNG → color type 3 / tile alignment / palette size / in-range indices; JASC `.pal` → header/count/color triples; `.mar` → length == w*h*2 and the `<<3` low-3-bits-zero invariant (validated against the `.mar.json` sidecar); `.change` map-change overlay (`--kind=mapchange`, #1355) → REQUIRED `.change.json` sidecar declaring `format "febuilder-mapchange-u16"` + dims 1..255, even length, `length == width*height*2` (NO `<<3` invariant — overlay indices are raw u16).
 
 The `portrait-package` kind (#1350) is a **multi-file PACKAGE validator** over a DIRECTORY: it requires exactly one composite sheet PNG, reuses the single-PNG structural checks, then verifies the canonical 128×112 slot geometry (mini/eye/mouth slots fit; a 96×80 main-mug-only sheet is `INCOMPLETE_PACKAGE` unless `--allow-main-only`), the 4bpp (≤16-color) portrait palette cap, and **palette consistency** between the sheet's embedded PLTE and an optional JASC `.pal` sidecar (count + per-entry RGB). It still never loads the ROM.
 
 | Option | Required | Description |
 |---|---|---|
-| `--kind=<kind>` | Required | Asset kind: `graphics`, `palette`, `portrait`, `icon`, `map`, `portrait-package`. |
-| `--in=<srcAsset>` | Required (single-file kinds) | Input asset file (PNG / `.pal` / `.mar`). |
+| `--kind=<kind>` | Required | Asset kind: `graphics`, `palette`, `portrait`, `icon`, `map`, `mapchange`, `portrait-package`. |
+| `--in=<srcAsset>` | Required (single-file kinds) | Input asset file (PNG / `.pal` / `.mar` / `.change`). |
 | `--path=<dir>` | Required for `--kind=portrait-package` | Package directory (one 128×112 sheet PNG + optional JASC `.pal`). |
 | `--allow-main-only` | Optional (`portrait-package`) | Accept a 96×80 main-mug-only sheet (warn instead of error). |
 | `--project=<dir>` | Optional (`portrait-package`) | Confine `--path` to the decomp project root (rejects absolute / escaping paths; **never loads the preview ROM**). |

--- a/pr-screenshots/pr-mapchange-1355.txt
+++ b/pr-screenshots/pr-mapchange-1355.txt
@@ -1,0 +1,43 @@
+=== #1355 map-change overlay source export/import/verify — CLI proof ===
+ROM: roms/FE8U.gba (real FE8U, read-only). Overlay region: 0x300000, 15x10 (raw u16 LE).
+  (an arbitrary in-bounds region used only to prove export reads the ROM and verify is byte-exact;
+   srcAddr is provenance metadata only — no symbol/owner is fabricated.)
+
+$ --export-asset --kind=mapchange --rom=roms/FE8U.gba --addr=0x300000 --width=15 --height=10 --out=chapter.change
+Wrote: C:\Users\zhiwenzhu\source\repos\laqieer\FEBuilderGBA\.claude\worktrees\agent-ac3b7431f8b96038e\pr-screenshots\_chapter.change
+Wrote: C:\Users\zhiwenzhu\source\repos\laqieer\FEBuilderGBA\.claude\worktrees\agent-ac3b7431f8b96038e\pr-screenshots\_chapter.change.json
+exit=0
+
+--- sidecar chapter.change.json ---
+﻿{
+  "width": 15,
+  "height": 10,
+  "srcAddr": "0x300000",
+  "format": "febuilder-mapchange-u16"
+}
+--- chapter.change size ---
+300
+
+$ --import-asset --kind=mapchange --in=chapter.change --out=chapter.change_raw.bin   (ROM-FREE, identity copy)
+Imported 15x10 map-change overlay to raw blob (300 bytes)
+Wrote: C:\Users\zhiwenzhu\source\repos\laqieer\FEBuilderGBA\.claude\worktrees\agent-ac3b7431f8b96038e\pr-screenshots\_chapter.change_raw.bin
+exit=0
+identity-copy byte-for-byte match: YES
+
+$ --roundtrip-asset --kind=mapchange --in=chapter.change   (ROM-FREE, structure-exact)
+Round-trip OK (structure-exact map-change overlay body)
+exit=0
+
+$ --verify-asset --kind=mapchange --rom=roms/FE8U.gba --addr=0x300000 --width=15 --height=10 --in=chapter.change   (MATCH)
+Verified 15x10 map-change overlay byte-identical to ROM
+exit=0
+
+--- corrupt 1 byte of chapter.change, re-verify against ROM (MISMATCH expected) ---
+$ --verify-asset --kind=mapchange ... --in=chapter.change   (MISMATCH)
+Error: Overlay mismatch at byte offset 0: ROM=0xFE file=0x01
+exit=2
+
+--- validate the corrupted-but-structurally-valid file (still structurally OK; length unchanged) ---
+$ --validate-asset --kind=mapchange --in=chapter.change
+Validation: 0 error(s), 0 warning(s) - OK
+exit=0


### PR DESCRIPTION
## Summary

Adds **source export / import / structure-exact roundtrip / byte-exact ROM verify** for the **Map-Change OVERLAY tile DATA BLOCK** in decomp project mode — the one remaining map-adjacent asset class whose honest verify bar matches the existing `.mar` bar (#1148 / #1346) with **zero compromise**. The overlay block is a **RAW UNCOMPRESSED `u16` LE array** of `width*height` config-descriptor indices: **no LZ77, no embedded GBA pointers, no `<<3` shift** — so the round-trip is pure u16 math, byte-identical, with no encoding artifact.

Plan: https://github.com/laqieer/FEBuilderGBA/issues/1355#issuecomment-4771804466 → revised after Copilot review https://github.com/laqieer/FEBuilderGBA/issues/1355#issuecomment-4771868077 (accepted, no blocking concerns).

Closes #1355.

## What changed

Four CLI verbs over the overlay block (kind = `mapchange` / `mapchange-overlay`):
- `--export-asset --kind=mapchange --rom=<r>|--project=<d> --addr=<change_mar> --width=<w> --height=<h> --out=<x.change>` — reads the live (already-uncompressed) ROM overlay → `.change` body + `.change.json` sidecar (`{width,height,srcAddr,format:"febuilder-mapchange-u16"}`).
- `--import-asset --kind=mapchange --in=<x.change> --out=<blob>` — ROM-FREE identity copy into the source tree (root-confined under `--project`).
- `--roundtrip-asset --kind=mapchange --in=<x.change>` — ROM-FREE PURE structural proof (length/dims invariant).
- `--verify-asset --kind=mapchange --rom=<r>|--project=<d> --addr=<change_mar> --width=<w> --height=<h> --in=<x.change>` — **byte-exact ROM compare** (the mismatch-catching path Copilot required): reads ROM READ-ONLY, exit 0 byte-identical / exit 2 on first-diff offset.

Core: `ExportMapChange` / `ImportMapChange` / `RoundTripMapChangeBody` / `VerifyMapChangeAgainstRom` / `TryReadMapChangeDims` in `DecompAssetExportCore`; `AssetKind.MapChangeOverlay` + `ValidateMapChange` (REQUIRED sidecar, `format` field enforced, dims 1..255, `length==w*h*2`, even length — NO `<<3` invariant) in `DecompAssetValidatorCore`. Audit matrix: a new `map_change_overlay` SourceTreeExporter row; the `map_asset_binaries` ManualMigration row reworded to drop the overlay and explicitly keep the OBJ tileset / chipset TSA-config / tile-anim 1&2 **and the 12-byte change-RECORD chain** guarded.

## Scope guards (honest framing — no over-claim)
- Target is ONLY the overlay tile DATA BLOCK. The 12-byte change-RECORD chain (terminator `0xFF@+0`, flagID@+5, PLIST/flag metadata) is a DIFFERENT artifact — kept OUT OF SCOPE / guarded.
- Verify is **source↔source STRUCTURE-EXACT identity** (`--roundtrip-asset`) **AND a byte-exact ROM compare** (`--verify-asset`) — NOT a byte-pinned ROM *re-insertion*.
- Export READS the live ROM overlay to PRODUCE the source artifact; import/roundtrip NEVER read ROM, NEVER re-compress; verify reads ROM READ-ONLY.
- `srcAddr` is provenance metadata ONLY — no symbol/owner is fabricated.
- The other four LZ77/pointer map classes + the record chain STAY guarded / export-only with clear diagnostics. Classic ROM-mode + existing `.mar` behavior unchanged.

## Test plan
- [x] `RoundTripMapChangeBody` true for even-length `w*h*2` body; false for null / odd / wrong-count / dims<1 (Core unit).
- [x] `ImportMapChange` synthetic `.change`+`.change.json` → output blob == input byte-for-byte; root-confined; `CoreState.ROM` unchanged before/after; never throws on missing sidecar → NotData (Core unit).
- [x] `ExportMapChange` tiny synthetic ROM (overlay planted ≥0x200) → `.change` bytes == planted u16 LE + sidecar dims/srcAddr/format correct; over-bounds length → NotData, NO file written; does-not-mutate-ROM-data (Core unit).
- [x] `VerifyMapChangeAgainstRom` planted ROM + matching `.change` → Ok; single-byte-edited → NotData with first-diff offset; out-of-bounds addr → NotData no-throw; ROM unchanged (Core unit).
- [x] `ValidateMapChange` even/odd length, wrong count vs sidecar, dims>255, missing sidecar, missing/wrong `format` → expected codes (Core unit).
- [x] Audit matrix: new `map_change_overlay` SourceTreeExporter row present; `map_asset_binaries` still ManualMigration and no longer mentions "overlay" (Core unit).
- [x] `DecompAuditDocConsistencyTest` README byte-lock passes after regenerating the matrix block (FEBuilderGBA.Tests).
- [x] E2E `--roundtrip-asset --kind=mapchange` exit 0 lossless / 2 truncated; `--import-asset --kind=mapchange` writes root-confined blob; unknown `--kind` errors; `--export-asset`/`--verify-asset` mapchange ROM-backed cases (ROM-dependent → run in CI where `roms/` is present).

## Local results
- Core.Tests targeted (DecompAsset*/DecompRoundTripAudit*): **131 passed, 0 failed**.
- Core.Tests full: 5408 passed, 10 failed (all `Skill*` — documented env-only `config/patch2` submodule-not-checked-out in worktree, NOT regressions), 6 skipped.
- FEBuilderGBA.Tests `DecompAuditDocConsistencyTest`: **1 passed**.
- E2E `ExportAssetE2ETests` (Release): 19 passed, 8 skipped (ROM-dependent skips run in CI).

## Screenshots / proof
This PR modifies only non-GUI files (Core, CLI, Tests, docs). CLI terminal proof of all four verbs (including byte-exact MISMATCH → exit 2 with first-diff offset) against a real read-only FE8U ROM: [`pr-screenshots/pr-mapchange-1355.txt`](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/pr-mapchange-1355.txt?raw=1) (committed on this branch; will resolve on master after merge).

```
$ --export-asset --kind=mapchange ... exit=0   (300-byte .change + sidecar format=febuilder-mapchange-u16)
$ --import-asset  --kind=mapchange ... exit=0   (identity-copy byte-for-byte match: YES)
$ --roundtrip-asset --kind=mapchange ... exit=0 (structure-exact)
$ --verify-asset  --kind=mapchange ... exit=0   (byte-identical to ROM)
$ --verify-asset (1 byte corrupted) ... exit=2  (Overlay mismatch at byte offset 0: ROM=0xFE file=0x01)
```

---
*Generated with Claude Code (claude-opus-4-8[1m], ultracode)*
