### PR TITLE
docs(decomp): reconcile README chapter/map paragraph with source .mar + map-change-overlay state (#1358)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,11 @@ dotnet run --project FEBuilderGBA.CLI -- --verify-asset --kind=mapchange --rom=r
 # and the map-change OVERLAY tile-data block is source export/import/round-trip + read-only
 # byte-exact ROM verify (--export-asset/--import-asset/--roundtrip-asset/--verify-asset
 # --kind=mapchange, PR #1357) — neither mutates the preview ROM. ROM-only/manual: the
-# event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw pointer-heavy map
-# ASSET binaries (OBJ tileset, palette, chipset config/TSA, tile animations 1/2, and the
-# 12-byte map-change RECORD chain — these are LZ77/pointer binaries, migrate via --export-asset
-# #1133/#1140), and the nested `chapter_settings.json` shape (nested objects / bools /
+# event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw LZ77 map ASSET
+# binaries (OBJ tileset, palette, chipset config/TSA, tile animations 1/2) and the
+# 12-byte map-change RECORD chain (structured pointer metadata: terminator/flagID/PLIST)
+# — migrate these via --export-asset #1133/#1140, and the nested `chapter_settings.json`
+# shape (nested objects / bools /
 # enum strings / split obj1Id|obj2Id are reported UnsupportedField/Manual, never
 # silently corrupted — flat top-level Number fields in that file still rewrite).
 # Shops: their lists CAN now be rewritten IN-PLACE in source via `--write-shop` (#1347)
@@ -406,9 +407,10 @@ sibling.
   export/import/round-trip + read-only byte-exact ROM verify (`--export-asset`/`--import-asset`/
   `--roundtrip-asset`/`--verify-asset --kind=mapchange`, #1355/PR #1357 — source-level structure-exact
   AND byte-exact ROM compare, NOT a byte-pinned ROM re-insertion). ROM-only/manual remain the
-  event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw pointer-heavy map ASSET binaries
-  (OBJ tileset, palette, chipset config/TSA, tile animations 1/2, and the 12-byte map-change RECORD
-  chain — migrate via `--export-asset` #1133/#1140), and the **nested** `chapter_settings.json`
+  event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw LZ77 map ASSET binaries
+  (OBJ tileset, palette, chipset config/TSA, tile animations 1/2) and the 12-byte map-change RECORD
+  chain (structured pointer metadata — terminator/flagID/PLIST — not the overlay tile-data block;
+  migrate these via `--export-asset` #1133/#1140), and the **nested** `chapter_settings.json`
   shape (nested objects / bools / enum strings / split `obj1Id`|`obj2Id` are reported
   UnsupportedField/Manual, never silently corrupted; flat top-level Number fields still rewrite).
   **Shop lists are source-writable in place via `--write-shop` (#1347)** when the manifest declares a `u16-list` list-owner for the shop's resolved DATA symbol (variable-length `ITEM_NONE`-terminated `u16` lists reached via scattered hensei/worldmap/event-cond pointers). The owner is resolved by `--symbol=<name>` directly, or by `--shop-addr=<ROM offset>` mapped to a list symbol via the project `.map`/`.elf`/`.sym` + the manifest list-owner (strict exact-or-span-covering match). The whole `{…}` body is re-serialized to the requested vector + a fresh terminator. **Symbolic `ITEM_*` lists (#1354):** when the existing source list uses `ITEM_*` macro names (the canonical FE8U `worldmap_shop_data.c` item-id-only form, e.g. `{ ITEM_SWORD_IRON, ITEM_NONE, }`), the writer re-serializes it SYMBOLICALLY — resolving id↔macro from the constants header (an **enum** or `#define` table, typically `include/constants/items.h`). Discovery precedence: the owner's `constantsHeader` (project-relative), then the manifest top-level `artifacts.itemConstants`, then the conventional default `include/constants/items.h`; an EXPLICIT path that is absolute / escapes the root / missing / unparseable refuses (it does NOT fall back to the default — wrong-universe danger). Symbolic lists are **item-id-only**: each entry's quantity must be `0` (a non-zero quantity is an actionable refusal — keep quantity 0 or migrate to a raw-hex list), and an id with no `ITEM_*` constant is refused. A plain-hex list still re-serializes to a raw-hex vector + a `0x0000` terminator; a list containing an UNKNOWN or AMBIGUOUS macro element is REFUSED (no-clobber — export to raw hex or edit by hand). With no decomp symbol AND no manifest list-owner, this degrades to the `--export-asset --kind=shop` migration export (#1149). **Support data** (`support_units`, `support_attributes`, `support_talks`) **is source-writable** when the manifest `tables[]` section declares a source owner for those tables (#1149); use byte-offset field names (`b0`..`b23` / `b0`..`b31` / `b0`..`b7` / `b0`+`w4`+…) in `--field`. **Positional-initializer constraint:** for a source that uses positional `{ … }` C initializers, the writer maps a byte-offset field name to a positional index by the ORDER of the owner's `fields[]` array — so a field's declared index must equal its real token position. Editing only a **leading prefix** (`b0`, then `b0`+`b1`, …) is always safe with a minimal `fields[]` that lists just those leading fields in order. Editing a **non-leading** field positionally (e.g. `b7` or `w4`) requires the owner declare the full ordered prefix up to that index (e.g. `b0`..`b7`) — OR use designated `.bN = …` initializers, which are matched by name and need no ordered list. Declaring the full ordered struct layout (e.g. all of `b0`..`b23` for `support_units`) is the safest, easiest guarantee but is not strictly required when you only edit a leading prefix. On success the project is flagged **needs rebuild**. `--out-diff=<path>`

--- a/README.md
+++ b/README.md
@@ -136,8 +136,9 @@ dotnet run --project FEBuilderGBA.CLI -- --export-asset --kind=shop --rom=rom.gb
 # --export-asset --kind=map REJECTS a tilemap with any raw u16 entry >= 0x2000 (the <<3 .mar encoding
 # would truncate its top 3 bits — the palette/flag bits) rather than emit a silently-lossy .mar, so every exported .mar is
 # guaranteed to round-trip. The compressed ROM bytes are NOT byte-pinned (FEBuilder's LZ77 packer is
-# non-canonical, so the decomp build re-compresses from source). OBJ/TSA/tile-animations/map-change
-# sub-assets remain export-only / manual.
+# non-canonical, so the decomp build re-compresses from source). OBJ/TSA/tile-animations and the
+# 12-byte map-change RECORD chain remain export-only / manual; the map-change OVERLAY tile-data
+# block, by contrast, is now source export/import/round-trip + ROM-verify (see --kind=mapchange below).
 dotnet run --project FEBuilderGBA.CLI -- --import-asset --kind=map --in=map/chapter1.mar --out=map/chapter1.tmap_raw.bin
 dotnet run --project FEBuilderGBA.CLI -- --roundtrip-asset --kind=map --in=map/chapter1.mar
 
@@ -178,10 +179,14 @@ dotnet run --project FEBuilderGBA.CLI -- --verify-asset --kind=mapchange --rom=r
 # Chapter / map scope (#1148): chapter SETTINGS (map_settings) are source-backed —
 # the scalar struct fields (weather, fog, PLIST index bytes, BGM ids, difficulty
 # bytes, chapter number, clear-condition text ids, escape markers, etc.) rewrite the
-# owning C array element (or a flat-numeric JSON element). ROM-only/manual: the
-# event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw map ASSET
-# bytes (.mar tile layout, OBJ tileset, palette, chipset config/TSA, tile animations,
-# the map-change overlay — these are LZ77 binaries, migrate via --export-asset
+# owning C array element (or a flat-numeric JSON element). The .mar map LAYOUT is now
+# source import + round-trip verify (--import-asset/--roundtrip-asset --kind=map, PR #1346),
+# and the map-change OVERLAY tile-data block is source export/import/round-trip + read-only
+# byte-exact ROM verify (--export-asset/--import-asset/--roundtrip-asset/--verify-asset
+# --kind=mapchange, PR #1357) — neither mutates the preview ROM. ROM-only/manual: the
+# event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw pointer-heavy map
+# ASSET binaries (OBJ tileset, palette, chipset config/TSA, tile animations 1/2, and the
+# 12-byte map-change RECORD chain — these are LZ77/pointer binaries, migrate via --export-asset
 # #1133/#1140), and the nested `chapter_settings.json` shape (nested objects / bools /
 # enum strings / split obj1Id|obj2Id are reported UnsupportedField/Manual, never
 # silently corrupted — flat top-level Number fields in that file still rewrite).
@@ -394,10 +399,16 @@ sibling.
   are **REPEATABLE**: each `--field` must be paired with a FOLLOWING `--value` (other flags may
   appear between them; a second `--field` before its `--value`, or an unpaired `--field`/`--value`,
   is a usage error) so multiple fields of one entry update in a single atomic source write.
-  **Chapter / map (#1148):** `map_settings` scalar fields are source-backed; ROM-only/manual are
-  the event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw map ASSET binaries
-  (`.mar` tile layout, OBJ tileset, palette, chipset config/TSA, tile animations, the map-change
-  overlay — migrate via `--export-asset` #1133/#1140), and the **nested** `chapter_settings.json`
+  **Chapter / map (#1148):** `map_settings` scalar fields are source-backed. The **`.mar` map
+  LAYOUT** is now source import + round-trip verify (`--import-asset`/`--roundtrip-asset --kind=map`,
+  #1148/PR #1346 — lossless u16 layout body for raw entries < 0x2000; the compressed container is
+  re-derived by the build, not byte-pinned), and the **map-change OVERLAY** tile-data block is source
+  export/import/round-trip + read-only byte-exact ROM verify (`--export-asset`/`--import-asset`/
+  `--roundtrip-asset`/`--verify-asset --kind=mapchange`, #1355/PR #1357 — source-level structure-exact
+  AND byte-exact ROM compare, NOT a byte-pinned ROM re-insertion). ROM-only/manual remain the
+  event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw pointer-heavy map ASSET binaries
+  (OBJ tileset, palette, chipset config/TSA, tile animations 1/2, and the 12-byte map-change RECORD
+  chain — migrate via `--export-asset` #1133/#1140), and the **nested** `chapter_settings.json`
   shape (nested objects / bools / enum strings / split `obj1Id`|`obj2Id` are reported
   UnsupportedField/Manual, never silently corrupted; flat top-level Number fields still rewrite).
   **Shop lists are source-writable in place via `--write-shop` (#1347)** when the manifest declares a `u16-list` list-owner for the shop's resolved DATA symbol (variable-length `ITEM_NONE`-terminated `u16` lists reached via scattered hensei/worldmap/event-cond pointers). The owner is resolved by `--symbol=<name>` directly, or by `--shop-addr=<ROM offset>` mapped to a list symbol via the project `.map`/`.elf`/`.sym` + the manifest list-owner (strict exact-or-span-covering match). The whole `{…}` body is re-serialized to the requested vector + a fresh terminator. **Symbolic `ITEM_*` lists (#1354):** when the existing source list uses `ITEM_*` macro names (the canonical FE8U `worldmap_shop_data.c` item-id-only form, e.g. `{ ITEM_SWORD_IRON, ITEM_NONE, }`), the writer re-serializes it SYMBOLICALLY — resolving id↔macro from the constants header (an **enum** or `#define` table, typically `include/constants/items.h`). Discovery precedence: the owner's `constantsHeader` (project-relative), then the manifest top-level `artifacts.itemConstants`, then the conventional default `include/constants/items.h`; an EXPLICIT path that is absolute / escapes the root / missing / unparseable refuses (it does NOT fall back to the default — wrong-universe danger). Symbolic lists are **item-id-only**: each entry's quantity must be `0` (a non-zero quantity is an actionable refusal — keep quantity 0 or migrate to a raw-hex list), and an id with no `ITEM_*` constant is refused. A plain-hex list still re-serializes to a raw-hex vector + a `0x0000` terminator; a list containing an UNKNOWN or AMBIGUOUS macro element is REFUSED (no-clobber — export to raw hex or edit by hand). With no decomp symbol AND no manifest list-owner, this degrades to the `--export-asset --kind=shop` migration export (#1149). **Support data** (`support_units`, `support_attributes`, `support_talks`) **is source-writable** when the manifest `tables[]` section declares a source owner for those tables (#1149); use byte-offset field names (`b0`..`b23` / `b0`..`b31` / `b0`..`b7` / `b0`+`w4`+…) in `--field`. **Positional-initializer constraint:** for a source that uses positional `{ … }` C initializers, the writer maps a byte-offset field name to a positional index by the ORDER of the owner's `fields[]` array — so a field's declared index must equal its real token position. Editing only a **leading prefix** (`b0`, then `b0`+`b1`, …) is always safe with a minimal `fields[]` that lists just those leading fields in order. Editing a **non-leading** field positionally (e.g. `b7` or `w4`) requires the owner declare the full ordered prefix up to that index (e.g. `b0`..`b7`) — OR use designated `.bN = …` initializers, which are matched by name and need no ordered list. Declaring the full ordered struct layout (e.g. all of `b0`..`b23` for `support_units`) is the safest, easiest guarantee but is not strictly required when you only edit a leading prefix. On success the project is flagged **needs rebuild**. `--out-diff=<path>`

--- a/pr-screenshots/pr1358b-readme-mapchange-reconcile.diff
+++ b/pr-screenshots/pr1358b-readme-mapchange-reconcile.diff
@@ -1,0 +1,56 @@
+diff --git a/README.md b/README.md
+index 83f575bf5..bafcb7d93 100644
+--- a/README.md
++++ b/README.md
+@@ -136,8 +136,9 @@ dotnet run --project FEBuilderGBA.CLI -- --export-asset --kind=shop --rom=rom.gb
+ # --export-asset --kind=map REJECTS a tilemap with any raw u16 entry >= 0x2000 (the <<3 .mar encoding
+ # would truncate its top 3 bits — the palette/flag bits) rather than emit a silently-lossy .mar, so every exported .mar is
+ # guaranteed to round-trip. The compressed ROM bytes are NOT byte-pinned (FEBuilder's LZ77 packer is
+-# non-canonical, so the decomp build re-compresses from source). OBJ/TSA/tile-animations/map-change
+-# sub-assets remain export-only / manual.
++# non-canonical, so the decomp build re-compresses from source). OBJ/TSA/tile-animations and the
++# 12-byte map-change RECORD chain remain export-only / manual; the map-change OVERLAY tile-data
++# block, by contrast, is now source export/import/round-trip + ROM-verify (see --kind=mapchange below).
+ dotnet run --project FEBuilderGBA.CLI -- --import-asset --kind=map --in=map/chapter1.mar --out=map/chapter1.tmap_raw.bin
+ dotnet run --project FEBuilderGBA.CLI -- --roundtrip-asset --kind=map --in=map/chapter1.mar
+ 
+@@ -178,10 +179,14 @@ dotnet run --project FEBuilderGBA.CLI -- --verify-asset --kind=mapchange --rom=r
+ # Chapter / map scope (#1148): chapter SETTINGS (map_settings) are source-backed —
+ # the scalar struct fields (weather, fog, PLIST index bytes, BGM ids, difficulty
+ # bytes, chapter number, clear-condition text ids, escape markers, etc.) rewrite the
+-# owning C array element (or a flat-numeric JSON element). ROM-only/manual: the
+-# event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw map ASSET
+-# bytes (.mar tile layout, OBJ tileset, palette, chipset config/TSA, tile animations,
+-# the map-change overlay — these are LZ77 binaries, migrate via --export-asset
++# owning C array element (or a flat-numeric JSON element). The .mar map LAYOUT is now
++# source import + round-trip verify (--import-asset/--roundtrip-asset --kind=map, PR #1346),
++# and the map-change OVERLAY tile-data block is source export/import/round-trip + read-only
++# byte-exact ROM verify (--export-asset/--import-asset/--roundtrip-asset/--verify-asset
++# --kind=mapchange, PR #1357) — neither mutates the preview ROM. ROM-only/manual: the
++# event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw pointer-heavy map
++# ASSET binaries (OBJ tileset, palette, chipset config/TSA, tile animations 1/2, and the
++# 12-byte map-change RECORD chain — these are LZ77/pointer binaries, migrate via --export-asset
+ # #1133/#1140), and the nested `chapter_settings.json` shape (nested objects / bools /
+ # enum strings / split obj1Id|obj2Id are reported UnsupportedField/Manual, never
+ # silently corrupted — flat top-level Number fields in that file still rewrite).
+@@ -394,10 +399,16 @@ sibling.
+   are **REPEATABLE**: each `--field` must be paired with a FOLLOWING `--value` (other flags may
+   appear between them; a second `--field` before its `--value`, or an unpaired `--field`/`--value`,
+   is a usage error) so multiple fields of one entry update in a single atomic source write.
+-  **Chapter / map (#1148):** `map_settings` scalar fields are source-backed; ROM-only/manual are
+-  the event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw map ASSET binaries
+-  (`.mar` tile layout, OBJ tileset, palette, chipset config/TSA, tile animations, the map-change
+-  overlay — migrate via `--export-asset` #1133/#1140), and the **nested** `chapter_settings.json`
++  **Chapter / map (#1148):** `map_settings` scalar fields are source-backed. The **`.mar` map
++  LAYOUT** is now source import + round-trip verify (`--import-asset`/`--roundtrip-asset --kind=map`,
++  #1148/PR #1346 — lossless u16 layout body for raw entries < 0x2000; the compressed container is
++  re-derived by the build, not byte-pinned), and the **map-change OVERLAY** tile-data block is source
++  export/import/round-trip + read-only byte-exact ROM verify (`--export-asset`/`--import-asset`/
++  `--roundtrip-asset`/`--verify-asset --kind=mapchange`, #1355/PR #1357 — source-level structure-exact
++  AND byte-exact ROM compare, NOT a byte-pinned ROM re-insertion). ROM-only/manual remain the
++  event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw pointer-heavy map ASSET binaries
++  (OBJ tileset, palette, chipset config/TSA, tile animations 1/2, and the 12-byte map-change RECORD
++  chain — migrate via `--export-asset` #1133/#1140), and the **nested** `chapter_settings.json`
+   shape (nested objects / bools / enum strings / split `obj1Id`|`obj2Id` are reported
+   UnsupportedField/Manual, never silently corrupted; flat top-level Number fields still rewrite).
+   **Shop lists are source-writable in place via `--write-shop` (#1347)** when the manifest declares a `u16-list` list-owner for the shop's resolved DATA symbol (variable-length `ITEM_NONE`-terminated `u16` lists reached via scattered hensei/worldmap/event-cond pointers). The owner is resolved by `--symbol=<name>` directly, or by `--shop-addr=<ROM offset>` mapped to a list symbol via the project `.map`/`.elf`/`.sym` + the manifest list-owner (strict exact-or-span-covering match). The whole `{…}` body is re-serialized to the requested vector + a fresh terminator. **Symbolic `ITEM_*` lists (#1354):** when the existing source list uses `ITEM_*` macro names (the canonical FE8U `worldmap_shop_data.c` item-id-only form, e.g. `{ ITEM_SWORD_IRON, ITEM_NONE, }`), the writer re-serializes it SYMBOLICALLY — resolving id↔macro from the constants header (an **enum** or `#define` table, typically `include/constants/items.h`). Discovery precedence: the owner's `constantsHeader` (project-relative), then the manifest top-level `artifacts.itemConstants`, then the conventional default `include/constants/items.h`; an EXPLICIT path that is absolute / escapes the root / missing / unparseable refuses (it does NOT fall back to the default — wrong-universe danger). Symbolic lists are **item-id-only**: each entry's quantity must be `0` (a non-zero quantity is an actionable refusal — keep quantity 0 or migrate to a raw-hex list), and an id with no `ITEM_*` constant is refused. A plain-hex list still re-serializes to a raw-hex vector + a `0x0000` terminator; a list containing an UNKNOWN or AMBIGUOUS macro element is REFUSED (no-clobber — export to raw hex or edit by hand). With no decomp symbol AND no manifest list-owner, this degrades to the `--export-asset --kind=shop` migration export (#1149). **Support data** (`support_units`, `support_attributes`, `support_talks`) **is source-writable** when the manifest `tables[]` section declares a source owner for those tables (#1149); use byte-offset field names (`b0`..`b23` / `b0`..`b31` / `b0`..`b7` / `b0`+`w4`+…) in `--field`. **Positional-initializer constraint:** for a source that uses positional `{ … }` C initializers, the writer maps a byte-offset field name to a positional index by the ORDER of the owner's `fields[]` array — so a field's declared index must equal its real token position. Editing only a **leading prefix** (`b0`, then `b0`+`b1`, …) is always safe with a minimal `fields[]` that lists just those leading fields in order. Editing a **non-leading** field positionally (e.g. `b7` or `w4`) requires the owner declare the full ordered prefix up to that index (e.g. `b0`..`b7`) — OR use designated `.bN = …` initializers, which are matched by name and need no ordered list. Declaring the full ordered struct layout (e.g. all of `b0`..`b23` for `support_units`) is the safest, easiest guarantee but is not strictly required when you only edit a leading prefix. On success the project is flagged **needs rebuild**. `--out-diff=<path>`

--- a/pr-screenshots/pr1358b-readme-mapchange-reconcile.diff
+++ b/pr-screenshots/pr1358b-readme-mapchange-reconcile.diff
@@ -1,56 +1,34 @@
 diff --git a/README.md b/README.md
-index 83f575bf5..bafcb7d93 100644
+index bafcb7d93..20d605ab3 100644
 --- a/README.md
 +++ b/README.md
-@@ -136,8 +136,9 @@ dotnet run --project FEBuilderGBA.CLI -- --export-asset --kind=shop --rom=rom.gb
- # --export-asset --kind=map REJECTS a tilemap with any raw u16 entry >= 0x2000 (the <<3 .mar encoding
- # would truncate its top 3 bits — the palette/flag bits) rather than emit a silently-lossy .mar, so every exported .mar is
- # guaranteed to round-trip. The compressed ROM bytes are NOT byte-pinned (FEBuilder's LZ77 packer is
--# non-canonical, so the decomp build re-compresses from source). OBJ/TSA/tile-animations/map-change
--# sub-assets remain export-only / manual.
-+# non-canonical, so the decomp build re-compresses from source). OBJ/TSA/tile-animations and the
-+# 12-byte map-change RECORD chain remain export-only / manual; the map-change OVERLAY tile-data
-+# block, by contrast, is now source export/import/round-trip + ROM-verify (see --kind=mapchange below).
- dotnet run --project FEBuilderGBA.CLI -- --import-asset --kind=map --in=map/chapter1.mar --out=map/chapter1.tmap_raw.bin
- dotnet run --project FEBuilderGBA.CLI -- --roundtrip-asset --kind=map --in=map/chapter1.mar
- 
-@@ -178,10 +179,14 @@ dotnet run --project FEBuilderGBA.CLI -- --verify-asset --kind=mapchange --rom=r
- # Chapter / map scope (#1148): chapter SETTINGS (map_settings) are source-backed —
- # the scalar struct fields (weather, fog, PLIST index bytes, BGM ids, difficulty
- # bytes, chapter number, clear-condition text ids, escape markers, etc.) rewrite the
--# owning C array element (or a flat-numeric JSON element). ROM-only/manual: the
--# event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw map ASSET
--# bytes (.mar tile layout, OBJ tileset, palette, chipset config/TSA, tile animations,
--# the map-change overlay — these are LZ77 binaries, migrate via --export-asset
-+# owning C array element (or a flat-numeric JSON element). The .mar map LAYOUT is now
-+# source import + round-trip verify (--import-asset/--roundtrip-asset --kind=map, PR #1346),
-+# and the map-change OVERLAY tile-data block is source export/import/round-trip + read-only
-+# byte-exact ROM verify (--export-asset/--import-asset/--roundtrip-asset/--verify-asset
-+# --kind=mapchange, PR #1357) — neither mutates the preview ROM. ROM-only/manual: the
-+# event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw pointer-heavy map
-+# ASSET binaries (OBJ tileset, palette, chipset config/TSA, tile animations 1/2, and the
-+# 12-byte map-change RECORD chain — these are LZ77/pointer binaries, migrate via --export-asset
- # #1133/#1140), and the nested `chapter_settings.json` shape (nested objects / bools /
+@@ -184,10 +184,11 @@ dotnet run --project FEBuilderGBA.CLI -- --verify-asset --kind=mapchange --rom=r
+ # and the map-change OVERLAY tile-data block is source export/import/round-trip + read-only
+ # byte-exact ROM verify (--export-asset/--import-asset/--roundtrip-asset/--verify-asset
+ # --kind=mapchange, PR #1357) — neither mutates the preview ROM. ROM-only/manual: the
+-# event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw pointer-heavy map
+-# ASSET binaries (OBJ tileset, palette, chipset config/TSA, tile animations 1/2, and the
+-# 12-byte map-change RECORD chain — these are LZ77/pointer binaries, migrate via --export-asset
+-# #1133/#1140), and the nested `chapter_settings.json` shape (nested objects / bools /
++# event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw LZ77 map ASSET
++# binaries (OBJ tileset, palette, chipset config/TSA, tile animations 1/2) and the
++# 12-byte map-change RECORD chain (structured pointer metadata: terminator/flagID/PLIST)
++# — migrate these via --export-asset #1133/#1140, and the nested `chapter_settings.json`
++# shape (nested objects / bools /
  # enum strings / split obj1Id|obj2Id are reported UnsupportedField/Manual, never
  # silently corrupted — flat top-level Number fields in that file still rewrite).
-@@ -394,10 +399,16 @@ sibling.
-   are **REPEATABLE**: each `--field` must be paired with a FOLLOWING `--value` (other flags may
-   appear between them; a second `--field` before its `--value`, or an unpaired `--field`/`--value`,
-   is a usage error) so multiple fields of one entry update in a single atomic source write.
--  **Chapter / map (#1148):** `map_settings` scalar fields are source-backed; ROM-only/manual are
--  the event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw map ASSET binaries
--  (`.mar` tile layout, OBJ tileset, palette, chipset config/TSA, tile animations, the map-change
--  overlay — migrate via `--export-asset` #1133/#1140), and the **nested** `chapter_settings.json`
-+  **Chapter / map (#1148):** `map_settings` scalar fields are source-backed. The **`.mar` map
-+  LAYOUT** is now source import + round-trip verify (`--import-asset`/`--roundtrip-asset --kind=map`,
-+  #1148/PR #1346 — lossless u16 layout body for raw entries < 0x2000; the compressed container is
-+  re-derived by the build, not byte-pinned), and the **map-change OVERLAY** tile-data block is source
-+  export/import/round-trip + read-only byte-exact ROM verify (`--export-asset`/`--import-asset`/
-+  `--roundtrip-asset`/`--verify-asset --kind=mapchange`, #1355/PR #1357 — source-level structure-exact
-+  AND byte-exact ROM compare, NOT a byte-pinned ROM re-insertion). ROM-only/manual remain the
-+  event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw pointer-heavy map ASSET binaries
-+  (OBJ tileset, palette, chipset config/TSA, tile animations 1/2, and the 12-byte map-change RECORD
-+  chain — migrate via `--export-asset` #1133/#1140), and the **nested** `chapter_settings.json`
+ # Shops: their lists CAN now be rewritten IN-PLACE in source via `--write-shop` (#1347)
+@@ -406,9 +407,10 @@ sibling.
+   export/import/round-trip + read-only byte-exact ROM verify (`--export-asset`/`--import-asset`/
+   `--roundtrip-asset`/`--verify-asset --kind=mapchange`, #1355/PR #1357 — source-level structure-exact
+   AND byte-exact ROM compare, NOT a byte-pinned ROM re-insertion). ROM-only/manual remain the
+-  event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw pointer-heavy map ASSET binaries
+-  (OBJ tileset, palette, chipset config/TSA, tile animations 1/2, and the 12-byte map-change RECORD
+-  chain — migrate via `--export-asset` #1133/#1140), and the **nested** `chapter_settings.json`
++  event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw LZ77 map ASSET binaries
++  (OBJ tileset, palette, chipset config/TSA, tile animations 1/2) and the 12-byte map-change RECORD
++  chain (structured pointer metadata — terminator/flagID/PLIST — not the overlay tile-data block;
++  migrate these via `--export-asset` #1133/#1140), and the **nested** `chapter_settings.json`
    shape (nested objects / bools / enum strings / split `obj1Id`|`obj2Id` are reported
    UnsupportedField/Manual, never silently corrupted; flat top-level Number fields still rewrite).
    **Shop lists are source-writable in place via `--write-shop` (#1347)** when the manifest declares a `u16-list` list-owner for the shop's resolved DATA symbol (variable-length `ITEM_NONE`-terminated `u16` lists reached via scattered hensei/worldmap/event-cond pointers). The owner is resolved by `--symbol=<name>` directly, or by `--shop-addr=<ROM offset>` mapped to a list symbol via the project `.map`/`.elf`/`.sym` + the manifest list-owner (strict exact-or-span-covering match). The whole `{…}` body is re-serialized to the requested vector + a fresh terminator. **Symbolic `ITEM_*` lists (#1354):** when the existing source list uses `ITEM_*` macro names (the canonical FE8U `worldmap_shop_data.c` item-id-only form, e.g. `{ ITEM_SWORD_IRON, ITEM_NONE, }`), the writer re-serializes it SYMBOLICALLY — resolving id↔macro from the constants header (an **enum** or `#define` table, typically `include/constants/items.h`). Discovery precedence: the owner's `constantsHeader` (project-relative), then the manifest top-level `artifacts.itemConstants`, then the conventional default `include/constants/items.h`; an EXPLICIT path that is absolute / escapes the root / missing / unparseable refuses (it does NOT fall back to the default — wrong-universe danger). Symbolic lists are **item-id-only**: each entry's quantity must be `0` (a non-zero quantity is an actionable refusal — keep quantity 0 or migrate to a raw-hex list), and an id with no `ITEM_*` constant is refused. A plain-hex list still re-serializes to a raw-hex vector + a `0x0000` terminator; a list containing an UNKNOWN or AMBIGUOUS macro element is REFUSED (no-clobber — export to raw hex or edit by hand). With no decomp symbol AND no manifest list-owner, this degrades to the `--export-asset --kind=shop` migration export (#1149). **Support data** (`support_units`, `support_attributes`, `support_talks`) **is source-writable** when the manifest `tables[]` section declares a source owner for those tables (#1149); use byte-offset field names (`b0`..`b23` / `b0`..`b31` / `b0`..`b7` / `b0`+`w4`+…) in `--field`. **Positional-initializer constraint:** for a source that uses positional `{ … }` C initializers, the writer maps a byte-offset field name to a positional index by the ORDER of the owner's `fields[]` array — so a field's declared index must equal its real token position. Editing only a **leading prefix** (`b0`, then `b0`+`b1`, …) is always safe with a minimal `fields[]` that lists just those leading fields in order. Editing a **non-leading** field positionally (e.g. `b7` or `w4`) requires the owner declare the full ordered prefix up to that index (e.g. `b0`..`b7`) — OR use designated `.bN = …` initializers, which are matched by name and need no ordered list. Declaring the full ordered struct layout (e.g. all of `b0`..`b23` for `support_units`) is the safest, easiest guarantee but is not strictly required when you only edit a leading prefix. On success the project is flagged **needs rebuild**. `--out-diff=<path>`


### PR DESCRIPTION
## Summary

The **reopened #1358** flagged one remaining consistency residual (maintainer's words): *"a README chapter/map decomp-support paragraph still appears to describe `.mar` and map-change overlay support as manual/export-only, which conflicts with the updated inventory/CLI/audit state after #1346 and #1357."*

This tightly-scoped, docs-only reconciliation updates the three drifted README prose/comment spots to the current merged state. No code behavior changes.

## What changed

| Spot | Before (stale) | After (reconciled) |
|------|----------------|--------------------|
| Prose paragraph (`**Chapter / map (#1148):**`) | `.mar` tile layout AND map-change overlay listed in the "raw map ASSET binaries — migrate via `--export-asset`" (manual/export-only) bucket | `.mar` map LAYOUT = source import + round-trip verify (`--import-asset`/`--roundtrip-asset --kind=map`, #1148/PR #1346); map-change OVERLAY = source export/import/round-trip + read-only byte-exact ROM verify (`--kind=mapchange`, #1355/PR #1357) |
| CLI `--write-source` comment ("Chapter / map scope") | same stale manual/export-only claim | same reconciliation |
| CLI `--export-asset --kind=map` comment | "OBJ/TSA/tile-animations/**map-change** sub-assets remain export-only / manual" | OBJ/TSA/tile-animations + the **12-byte map-change RECORD chain** stay export-only; the **OVERLAY** block is now source export/import/round-trip + ROM-verify |

The genuinely-manual classes stay accurate: **OBJ tileset, palette, chipset config/TSA, tile animations 1/2, and the 12-byte map-change RECORD chain** remain guarded / export-only.

## Not over-claimed
- The `.mar` compressed container is re-derived by the build, **NOT byte-pinned**.
- The overlay verify is **source-level structure-exact + read-only byte-exact ROM compare**, **NOT a byte-pinned ROM re-insertion**.

## Consistency
Reconciled README now matches `docs/DECOMP-FEATURE-INVENTORY.md` (refreshed in #1359), the `<!-- decomp-audit-matrix -->` block (**untouched** — byte-locked by `DecompAuditDocConsistencyTest`, which stays green), and `docs/cli-reference.md`.

## Scope
`Closes #1358`

## Test plan
- [x] `DecompAuditDocConsistencyTest` passes (audit-matrix block untouched; verified lines 482–511 outside all edited regions) — `Passed! Failed: 0, Passed: 1`
- [x] Grepped every remaining `.mar` / `overlay` / `mapchange` mention in README — all now consistent with the CLI blocks and the audit matrix; no stale "manual/export-only" claim remains
- [x] Cross-checked the reconciled prose against `docs/DECOMP-FEATURE-INVENTORY.md` rows (lines 78, 86, 101–106) — matching wording

## Proof
Docs-only diff snippet committed at [`pr-screenshots/pr1358b-readme-mapchange-reconcile.diff`](https://github.com/laqieer/FEBuilderGBA/blob/master/pr-screenshots/pr1358b-readme-mapchange-reconcile.diff?raw=1).

---
Generated with Claude Code (claude-opus-4-8[1m], ultracode)