### PR TITLE
docs(decomp): Hyssopi map import to .mar — documented safe failure (#1361)

### DIFF
--- a/docs/DECOMP-FEATURE-INVENTORY.md
+++ b/docs/DECOMP-FEATURE-INVENTORY.md
@@ -116,6 +116,16 @@ matrix so the gaps are visible rather than implied-away:
   macro** — these degrade to the `--export-asset --kind=shop` EA `.event` migration artifact
   (a reviewable migration aid, **not** a byte-pinned ROM round-trip). Symbolic lists are
   item-id-only (non-zero quantity is refused).
+- **Hyssopi map-editor import stays unsupported (investigated, blocked).** Importing
+  map layouts authored in Hyssopi's Fire Emblem Tile Map Editor into source-owned
+  `.mar` layouts was investigated (#1361) and is a **documented safe failure**: Hyssopi
+  exports an opaque tile-**hash** grid, but `.mar` needs each cell's raw GBA `u16`
+  tile index (`< 0x2000`), and the hash → GBA-`u16`-index crosswalk is undocumented and
+  game/tileset-version-dependent. An automatic converter would have to guess that
+  crosswalk, silently producing structurally-valid-but-wrong maps — which the #1361
+  non-goals forbid. The supported interim path remains FEBuilder's own
+  `--export-asset --kind=map` / `.mar` import. See
+  [docs/DECOMP-HYSSOPI-IMPORT-FINDINGS.md](DECOMP-HYSSOPI-IMPORT-FINDINGS.md).
 - **The `.nmm` schema bridge is a schema aid, not a writability path** — generating a
   manifest `tables[]` entry from `.nmm` does not make a table source-writable; pointer /
   var-length / odd-size fields are flagged `unsupported`, never silently treated as writable.
@@ -140,5 +150,6 @@ matrix so the gaps are visible rather than implied-away:
 - [#1350](https://github.com/laqieer/FEBuilderGBA/issues/1350) — portrait PACKAGE validator (PR #1353)
 - [#1355](https://github.com/laqieer/FEBuilderGBA/issues/1355) — map-change overlay source export/import/round-trip/ROM-verify (PR #1357)
 - [#1360](https://github.com/laqieer/FEBuilderGBA/issues/1360) — map tile-animation-2 palette source export/import/round-trip/ROM-verify
+- [#1361](https://github.com/laqieer/FEBuilderGBA/issues/1361) — Hyssopi map import investigation (documented safe failure; see [DECOMP-HYSSOPI-IMPORT-FINDINGS.md](DECOMP-HYSSOPI-IMPORT-FINDINGS.md))
 - [README → Decomp Project Support](../README.md#decomp-project-support-preview)
 - [docs/cli-reference.md](cli-reference.md)

--- a/docs/DECOMP-HYSSOPI-IMPORT-FINDINGS.md
+++ b/docs/DECOMP-HYSSOPI-IMPORT-FINDINGS.md
@@ -1,0 +1,124 @@
+# Decomp maps: Hyssopi map import to source `.mar` — investigation findings
+
+> **Outcome: documented safe failure (no importer this pass).**
+> A safe *automatic* converter from a Hyssopi map export into a FEBuilder/decomp
+> `.mar` map layout **cannot be built today** because the critical tile-hash → GBA
+> Fire Emblem `u16` metatile/config-index crosswalk is undocumented and
+> game-version-dependent. Guessing it would silently produce wrong maps, which
+> [#1361](https://github.com/laqieer/FEBuilderGBA/issues/1361) explicitly forbids.
+> Its acceptance criteria permit exactly this resolution: *"If a safe
+> hash-to-metatile crosswalk cannot be established, the result is a documented safe
+> failure rather than a claimed importer."*
+
+This page records what was verified so a future narrow bridge has a precise starting
+point. Each fact below is labeled **[confirmed]** (read from public Hyssopi source /
+FEBuilder source) or **[inferred]** (deduced from implementation, not a documented
+contract).
+
+## 1. What Hyssopi is
+
+The **Hyssopi Fire Emblem Tile Map Editor** is a browser-based map editor for the
+GBA Fire Emblem games:
+
+- Repository: <https://github.com/Hyssopi/Fire-Emblem-Tile-Map-Editor>
+- Live app: <https://hyssopi.github.io/Fire-Emblem-Tile-Map-Editor/>
+
+The `fireemblem8u` wiki recommends it as an FE-native map editor while noting that
+FEBuilder's own `.mar` already drops into the decomp pipeline (`Porymap-for-FE8.md`,
+`Missing-essentials-and-roadmap.md`).
+
+## 2. Hyssopi's export shape (the candidate input)
+
+- **[confirmed]** Hyssopi exports/imports map files as **JSON** containing a 2D grid
+  of **opaque tile *hashes*** (export action `exportAsTileHashesButtonId` /
+  `exportMapAsTileHashes`; load via `loadMapJson`), organized by game and chapter.
+- **[confirmed]** Each tile hash resolves against Hyssopi's own
+  `tiles/tileReferences.json`, whose entries expose **only** `tileHash`, a `group`
+  label, neighbor lists (north/east/south/west), and `originFilePaths` (image asset
+  paths). There is **no** field that carries a GBA FE metatile / map-config `u16`
+  index, nor a ROM address.
+- **[inferred]** The precise top-level JSON object schema of an exported map
+  (key names, nesting, how width/height/chapter are represented) is **not published
+  as a stable contract** — it is only discoverable by reading the editor's
+  implementation, which can change without notice.
+
+So the Hyssopi export answers *"what does this tile look like / what are its valid
+neighbors"* but **not** *"what GBA map-layout `u16` does this tile correspond to in
+FE6 / FE7 / FE8."*
+
+## 3. The `.mar` target contract (what FEBuilder/decomp needs)
+
+FEBuilder's `.mar` map-layout path is fully documented and confirmed in
+`FEBuilderGBA.Core/DecompAssetExportCore.cs` (`ExportMap` / `ImportMap` /
+`ValidateAsset(MapLayout)`, added in [#1148](https://github.com/laqieer/FEBuilderGBA/issues/1148)
+/ PR [#1346](https://github.com/laqieer/FEBuilderGBA/pull/1346)):
+
+- **[confirmed]** Body: a stream of little-endian `u16` entries, one per map cell.
+  Each `.mar` entry is the raw tilemap `u16` shifted left by 3: `marTile = rawTile << 3`.
+- **[confirmed]** Sidecar `.mar.json`:
+  `{ "width": W, "height": H, "srcAddr": "0x…", "format": "febuilder-mar-u16-shl3" }`.
+- **[confirmed]** Lossless boundary: each **raw** tile index must be `< 0x2000`
+  (bits 13–15 must be clear, else the `<<3` truncates palette/flag bits and the
+  entry is **rejected**). Import reverses the encoding with `rawTile = marU16 >> 3`.
+
+Producing a valid `.mar` therefore requires knowing each cell's **raw GBA `u16`
+tile index** (`< 0x2000`) — exactly the value Hyssopi does **not** carry.
+
+## 4. The blocker
+
+| Need (for a safe converter) | Available from Hyssopi today |
+| --- | --- |
+| Stable, documented map-JSON schema | **No** — implementation-only, may change |
+| Per-cell GBA FE `u16` tile/config index | **No** — only an opaque hash + group/neighbor metadata |
+| Game/tileset (version) context for that index | **No** — FE6/7/8 tilesets differ; not encoded as a crosswalk |
+
+A converter built now would have to **invent or infer** a hash → GBA-`u16`-index
+mapping. Because the same Hyssopi hash means different raw indices across games and
+tilesets, any inferred mapping would be a guess. A wrong guess does not fail loudly —
+it yields a **structurally valid but semantically wrong** `.mar`, i.e. a corrupted
+map that still imports. That is precisely the "silently guess source ownership / tile
+IDs" failure mode the issue's non-goals and acceptance criteria prohibit.
+
+## 5. Prerequisites for a future narrow bridge
+
+A safe, conservative converter becomes possible only once **both** of these exist:
+
+1. **A documented/stable Hyssopi map-JSON schema** (or a frozen, versioned export
+   format) so the grid geometry and tile-hash field can be parsed without guessing.
+2. **A hash → GBA-`u16`-index resolution source**, supplied explicitly rather than
+   inferred. The realistic form is a **user-supplied mapping file** derived from the
+   project's own `tileReferences` / tileset, **plus an explicit target game/version
+   (tileset) selection**. Every resolved raw index must land `< 0x2000` to satisfy
+   the `.mar` lossless boundary.
+
+Any such bridge must **fail closed**: reject (with actionable diagnostics, never a
+silent default) any tile hash it cannot resolve, any tileset/game-context mismatch,
+or any index `≥ 0x2000`. It must be **read-only / never mutate the preview ROM**, and
+write outputs only to user-selected paths under the opened decomp source tree — the
+same guarantees the existing `.mar` import path provides.
+
+## 6. Interim recommendation
+
+Until the prerequisites above are met, the supported authoring path into the decomp
+pipeline is **FEBuilder's own `.mar` flow**, which is already validated and
+round-trip-verified:
+
+- Export a chapter map layout to `.mar` + sidecar via `--export-asset --kind=map`.
+- Re-import / verify via the `.mar` import path (`--import-asset` /
+  `--roundtrip-asset`), backed by `DecompAssetExportCore` and
+  `--validate-asset --kind=map`.
+
+This is the route the wiki (`Porymap-for-FE8.md`) already points decomp users to:
+FEBuilder `.mar` "drops into the decomp pipeline" today, whereas a Hyssopi bridge
+remains blocked on the undocumented crosswalk.
+
+## See also
+
+- [#1361](https://github.com/laqieer/FEBuilderGBA/issues/1361) — this investigation
+- [#1148](https://github.com/laqieer/FEBuilderGBA/issues/1148) /
+  [PR #1346](https://github.com/laqieer/FEBuilderGBA/pull/1346) — source-backed
+  `.mar` map-layout import + round-trip-verify
+- [#1360](https://github.com/laqieer/FEBuilderGBA/issues/1360) /
+  [PR #1365](https://github.com/laqieer/FEBuilderGBA/pull/1365) — remaining LZ77 /
+  pointer-heavy map asset classes (tracked separately; not this layout bridge)
+- [docs/DECOMP-FEATURE-INVENTORY.md](DECOMP-FEATURE-INVENTORY.md) — honest residuals


### PR DESCRIPTION
## Summary

Investigation (#1361): importing map layouts authored in **Hyssopi's Fire Emblem Tile Map Editor** into source-owned FEBuilder/decomp `.mar` map layouts.

**Outcome: documented safe failure (no importer).** Hyssopi exports an **opaque tile-HASH grid**; FEBuilder's `.mar` needs each cell's **raw GBA `u16` tile index** (`< 0x2000`); the **hash → GBA-`u16`-index crosswalk is undocumented and game/tileset-version-dependent**. An automatic converter would have to *guess* that crosswalk, silently producing structurally-valid-but-wrong maps — which #1361's non-goals forbid. The issue's acceptance criteria explicitly permit this resolution: *"If a safe hash-to-metatile crosswalk cannot be established, the result is a documented safe failure rather than a claimed importer."*

This is a docs-only change. No importer is claimed; existing `.mar` support is untouched.

## Plan reference

Plan + Copilot plan-review (GPT-5.5, **no blocking findings**, independently confirmed `tileReferences.json` exposes only `tileHash`/`group`/neighbors/`originFilePaths` — no GBA `u16` field): https://github.com/laqieer/FEBuilderGBA/issues/1361#issuecomment-4778759315

## Scope

Closes #1361

- **Add `docs/DECOMP-HYSSOPI-IMPORT-FINDINGS.md`** — what Hyssopi is + its JSON tile-hash export shape (confirmed-vs-inferred labeled, sources cited), the `.mar` target contract (`febuilder-mar-u16-shl3`, `<<3`/`>>3`, `<0x2000` boundary), the blocker, the prerequisites for a future **fail-closed** narrow bridge (documented schema + user-supplied hash→`u16` mapping + target game/version; indices `< 0x2000`), and the interim recommendation (`--export-asset --kind=map` / `.mar` import). Cross-links #1148/#1346 + #1360/#1365.
- **`docs/DECOMP-FEATURE-INVENTORY.md`** — honest-residuals pointer + See-also link. README `<!-- decomp-audit-matrix -->` block untouched.

## Test plan

- [x] Docs-only: no Core/CLI/GUI source changed (`git show --stat` = only the two `docs/*.md` files) — no new unit/E2E tests required (no behavior change).
- [x] `.mar` contract claims verified against `FEBuilderGBA.Core/DecompAssetExportCore.cs` (`ExportMap`/`ImportMap`/`ValidateAsset`: `rawTile << 3`, sidecar `febuilder-mar-u16-shl3`, `< 0x2000` boundary, `>> 3` inverse).
- [x] Hyssopi export shape verified against the public repo (`exportAsTileHashesButtonId`/`exportMapAsTileHashes`, `tiles/tileReferences.json` exposes only `tileHash`/`group`/neighbors/`originFilePaths`) — corroborated independently by the Copilot plan review.
- [x] Cross-link issue/PR states confirmed (`#1148` CLOSED, `#1346` MERGED, `#1360` CLOSED) and intra-repo doc links resolve to real paths.
- [x] Existing `.mar` support unchanged (no code touched).

## Screenshots

Docs-only (`docs`) PR — screenshots optional per workflow.

---
Generated with Claude Code (claude-opus-4-8[1m], ultracode)
