### PR TITLE
docs(decomp): reconcile OBJ tileset residual classification after #1371

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,8 +249,10 @@ dotnet run --project FEBuilderGBA.CLI -- --verify-asset --kind=objtiles --rom=ro
 # and the map-change OVERLAY tile-data block is source export/import/round-trip + read-only
 # byte-exact ROM verify (--export-asset/--import-asset/--roundtrip-asset/--verify-asset
 # --kind=mapchange, PR #1357) — neither mutates the preview ROM. The OBJ tileset
-# (LZ77 decompressed-payload) is now source export/import/verify-backed via
-# --kind=objtiles (#1371/PR #1372). ROM-only/manual: the
+# (LZ77 decompressed-payload) is now source export/import/round-trip + read-only
+# decompress-and-byte-compare ROM verify (--export-asset/--import-asset/
+# --roundtrip-asset/--verify-asset --kind=objtiles, #1371/PR #1372) — never
+# mutates the preview ROM. ROM-only/manual: the
 # event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw LZ77 map ASSET
 # binaries (palette, chipset config/TSA, tile animations 1/2) and the
 # 12-byte map-change RECORD chain (structured pointer metadata: terminator/flagID/PLIST)

--- a/README.md
+++ b/README.md
@@ -248,9 +248,11 @@ dotnet run --project FEBuilderGBA.CLI -- --verify-asset --kind=objtiles --rom=ro
 # source import + round-trip verify (--import-asset/--roundtrip-asset --kind=map, PR #1346),
 # and the map-change OVERLAY tile-data block is source export/import/round-trip + read-only
 # byte-exact ROM verify (--export-asset/--import-asset/--roundtrip-asset/--verify-asset
-# --kind=mapchange, PR #1357) — neither mutates the preview ROM. ROM-only/manual: the
+# --kind=mapchange, PR #1357) — neither mutates the preview ROM. The OBJ tileset
+# (LZ77 decompressed-payload) is now source export/import/verify-backed via
+# --kind=objtiles (#1371/PR #1372). ROM-only/manual: the
 # event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw LZ77 map ASSET
-# binaries (OBJ tileset, palette, chipset config/TSA, tile animations 1/2) and the
+# binaries (palette, chipset config/TSA, tile animations 1/2) and the
 # 12-byte map-change RECORD chain (structured pointer metadata: terminator/flagID/PLIST)
 # — migrate these via --export-asset #1133/#1140, and the nested `chapter_settings.json`
 # shape (nested objects / bools /
@@ -474,13 +476,16 @@ sibling.
   AND byte-exact ROM compare, NOT a byte-pinned ROM re-insertion). The **map tile-animation-2 PALETTE**
   block — a raw uncompressed `u16` array of `count` 15-bit GBA colors reached by each anime-2 entry's
   `+0` pointer — joins the same raw-u16 source-backed classes with export/import/round-trip + read-only
-  byte-exact ROM verify (`--kind=mapanime2pal`, #1360); the OBJ/chipset tilesets and anime-1 graphics
-  stay manual. ROM-only/manual remain the
+  byte-exact ROM verify (`--kind=mapanime2pal`, #1360); the **OBJ tileset** (LZ77 decompressed-payload)
+  joins the same raw source-backed classes with export/import/round-trip + read-only decompress-and-byte-compare
+  ROM verify (`--kind=objtiles`, #1371/PR #1372 — decompressed-payload equivalence, NOT compressed-stream
+  byte identity; `--addr` is the DEREFERENCED OBJ LZ77 stream address); the chipset tilesets and
+  anime-1 graphics stay manual. ROM-only/manual remain the
   event/difficulty POINTER fields (D0/EventDataPtr, D96–D108), the raw LZ77 map ASSET binaries
-  (OBJ tileset, palette, chipset config/TSA, tile-animation-1 graphics, the anime-2 ENTRY/PLIST table +
+  (palette, chipset config/TSA, tile-animation-1 graphics, the anime-2 ENTRY/PLIST table +
   non-palette anime-2 record/provenance chain) and the 12-byte map-change RECORD
   chain (structured pointer metadata — terminator/flagID/PLIST — not the overlay tile-data block nor the
-  anime-2 palette block; migrate these via `--export-asset` #1133/#1140), and the **nested** `chapter_settings.json`
+  anime-2 palette block nor the OBJ tileset; migrate these via `--export-asset` #1133/#1140), and the **nested** `chapter_settings.json`
   shape (nested objects / bools / enum strings / split `obj1Id`|`obj2Id` are reported
   UnsupportedField/Manual, never silently corrupted; flat top-level Number fields still rewrite).
   **Shop lists are source-writable in place via `--write-shop` (#1347)** when the manifest declares a `u16-list` list-owner for the shop's resolved DATA symbol (variable-length `ITEM_NONE`-terminated `u16` lists reached via scattered hensei/worldmap/event-cond pointers). The owner is resolved by `--symbol=<name>` directly, or by `--shop-addr=<ROM offset>` mapped to a list symbol via the project `.map`/`.elf`/`.sym` + the manifest list-owner (strict exact-or-span-covering match). The whole `{…}` body is re-serialized to the requested vector + a fresh terminator. **Symbolic `ITEM_*` lists (#1354):** when the existing source list uses `ITEM_*` macro names (the canonical FE8U `worldmap_shop_data.c` item-id-only form, e.g. `{ ITEM_SWORD_IRON, ITEM_NONE, }`), the writer re-serializes it SYMBOLICALLY — resolving id↔macro from the constants header (an **enum** or `#define` table, typically `include/constants/items.h`). Discovery precedence: the owner's `constantsHeader` (project-relative), then the manifest top-level `artifacts.itemConstants`, then the conventional default `include/constants/items.h`; an EXPLICIT path that is absolute / escapes the root / missing / unparseable refuses (it does NOT fall back to the default — wrong-universe danger). Symbolic lists are **item-id-only**: each entry's quantity must be `0` (a non-zero quantity is an actionable refusal — keep quantity 0 or migrate to a raw-hex list), and an id with no `ITEM_*` constant is refused. A plain-hex list still re-serializes to a raw-hex vector + a `0x0000` terminator; a list containing an UNKNOWN or AMBIGUOUS macro element is REFUSED (no-clobber — export to raw hex or edit by hand). With no decomp symbol AND no manifest list-owner, this degrades to the `--export-asset --kind=shop` migration export (#1149). **Support data** (`support_units`, `support_attributes`, `support_talks`) **is source-writable** when the manifest `tables[]` section declares a source owner for those tables (#1149); use byte-offset field names (`b0`..`b23` / `b0`..`b31` / `b0`..`b7` / `b0`+`w4`+…) in `--field`. **Positional-initializer constraint:** for a source that uses positional `{ … }` C initializers, the writer maps a byte-offset field name to a positional index by the ORDER of the owner's `fields[]` array — so a field's declared index must equal its real token position. Editing only a **leading prefix** (`b0`, then `b0`+`b1`, …) is always safe with a minimal `fields[]` that lists just those leading fields in order. Editing a **non-leading** field positionally (e.g. `b7` or `w4`) requires the owner declare the full ordered prefix up to that index (e.g. `b0`..`b7`) — OR use designated `.bN = …` initializers, which are matched by name and need no ordered list. Declaring the full ordered struct layout (e.g. all of `b0`..`b23` for `support_units`) is the safest, easiest guarantee but is not strictly required when you only edit a leading prefix. On success the project is flagged **needs rebuild**. `--out-diff=<path>`

--- a/docs/DECOMP-FEATURE-INVENTORY.md
+++ b/docs/DECOMP-FEATURE-INVENTORY.md
@@ -85,7 +85,7 @@ Each row lists the capability, the tracking issue, and the PR(s)/commit(s) that 
 | **Portrait PACKAGE validator** (`--validate-asset --kind=portrait-package --path=<dir>`; multi-file package — required composite sheet, indexed PNG structural checks, 128×112 slot geometry, 4bpp palette cap, sheet↔`.pal` palette consistency; READ-ONLY, never reads a ROM; `--project` root-confined) | #1350 | PR #1353 (`1659f356b`) |
 | **Map-change overlay source export/import/round-trip/ROM-verify** (`--export-asset` / `--import-asset` / `--roundtrip-asset` / `--verify-asset --kind=mapchange`; the raw uncompressed `u16` overlay tile-data block — source-level structure-exact identity + read-only byte-exact ROM compare; not the `.mar` layout, not the 12-byte change-record chain) | #1355 | PR #1357 (`92962bbde`) |
 | **Map tile-animation-2 palette source export/import/round-trip/ROM-verify** (`--export-asset` / `--import-asset` / `--roundtrip-asset` / `--verify-asset --kind=mapanime2pal`; the raw uncompressed `u16` palette block of `count` 15-bit GBA colors reached by each anime-2 entry's `+0` pointer — structural twin of `mapchange` with a single `count` descriptor; source-level structure-exact identity + read-only byte-exact ROM compare; not the anime-2 entry/PLIST table, not LZ77) | #1360 | PR #1365 (`b8a0b5700`) |
-| **OBJ tileset LZ77 decompressed-payload source export/import/round-trip/ROM-verify** (`--export-asset` / `--import-asset` / `--roundtrip-asset` / `--verify-asset --kind=objtiles`; the DECOMPRESSED 4bpp payload of the OBJ LZ77 tile block — decompressed-payload equivalence, NOT compressed-stream byte identity (FEBuilder's LZ77 packer is non-canonical so the build re-compresses); `--addr` is the dereferenced OBJ LZ77 stream address; FE7 obj2 split out of scope; not chipset TSA/config, not tile animations 1/2) | #1371 | (this PR) |
+| **OBJ tileset LZ77 decompressed-payload source export/import/round-trip/ROM-verify** (`--export-asset` / `--import-asset` / `--roundtrip-asset` / `--verify-asset --kind=objtiles`; the DECOMPRESSED 4bpp payload of the OBJ LZ77 tile block — decompressed-payload equivalence, NOT compressed-stream byte identity (FEBuilder's LZ77 packer is non-canonical so the build re-compresses); `--addr` is the dereferenced OBJ LZ77 stream address; FE7 obj2 split out of scope; not chipset TSA/config, not tile animations 1/2) | #1371 | PR #1372 (`026f5ddd2`) |
 | **Voicegroup source-macro-asm export** (`--export-voicegroup`; a FEBuilder M4A instrument set → reviewable `sound/voicegroups/voicegroupNNN.s` using `asm/macros/music_voice.inc`. Supported voice types emit the exact macros (`voice_directsound`/`_no_resample`/`_alt`, `voice_square_1`/`_2`, `voice_programmable_wave`, `voice_noise`, `voice_keysplit`/`_all`); keysplit/drum sub-voicegroups + DirectSound sample pointers emit valid raw `0x08XXXXXX` macro args + an unresolved-pointer diagnostic (no guessed symbol, sub-table NOT inlined); `0x18`/unknown → commented placeholder + diagnostic, never a wrong macro. READ-ONLY, never mutates the ROM, project-root-confined; EXPORT/source-helper only, not a byte-pinned round-trip or M4A re-assembler) | #1362 | PR #1368 (`670516783`) |
 
 CLI usage for every flag above is documented in
@@ -102,14 +102,16 @@ matrix so the gaps are visible rather than implied-away:
   source (or are ROM-only). No format has byte-pinned ROM re-insertion of an edited asset —
   source-backed writers rewrite the *source* and flag the project **needs rebuild**.
 - **Raw pointer-heavy map binaries stay manual / export-only** — the LZ77 map-asset binaries
-  (OBJ tileset, chipset TSA/config, **tile-animation-1 graphics**, the **tile-animation-2
+  (chipset TSA/config, **tile-animation-1 graphics**, the **tile-animation-2
   ENTRY/PLIST table** + the non-palette anime-2 record/provenance chain) and the **12-byte
   map-change RECORD chain** (terminator / flag-ID / PLIST metadata) have no in-place source
   writer; they stay guarded in decomp mode and migrate via `--export-asset` where an exporter
   exists. *(The map-change **overlay tile-data block** is now source export/import/verify-backed
-  (#1355), and the dereferenced **tile-animation-2 PALETTE body** is now source
-  export/import/verify-backed (#1360) — see the feature-inventory rows above — but the anime-2
-  entry/PLIST table that points at the palette, and the 12-byte change-record chain, are not.)*
+  (#1355), the dereferenced **tile-animation-2 PALETTE body** is now source
+  export/import/verify-backed (#1360), and the **OBJ tileset** (LZ77 decompressed-payload) is
+  now source export/import/verify-backed (#1371) — see the feature-inventory rows above — but
+  the anime-2 entry/PLIST table that points at the palette, and the 12-byte change-record chain,
+  are not.)*
 - **Shop residuals after `--write-shop` (#1351/#1356):** shop **lists** are now source-backed
   in place (literal-numeric and symbolic `ITEM_*`), so they are **no longer** an unconditional
   manual residual. The remaining residual is the **unresolvable** case: a shop reached via a
@@ -152,7 +154,7 @@ matrix so the gaps are visible rather than implied-away:
 - [#1350](https://github.com/laqieer/FEBuilderGBA/issues/1350) — portrait PACKAGE validator (PR #1353)
 - [#1355](https://github.com/laqieer/FEBuilderGBA/issues/1355) — map-change overlay source export/import/round-trip/ROM-verify (PR #1357)
 - [#1360](https://github.com/laqieer/FEBuilderGBA/issues/1360) — map tile-animation-2 palette source export/import/round-trip/ROM-verify
-- [#1371](https://github.com/laqieer/FEBuilderGBA/issues/1371) — OBJ tileset LZ77 decompressed-payload source export/import/round-trip/ROM-verify (this PR)
+- [#1371](https://github.com/laqieer/FEBuilderGBA/issues/1371) — OBJ tileset LZ77 decompressed-payload source export/import/round-trip/ROM-verify (PR #1372, `026f5ddd2`)
 - [#1361](https://github.com/laqieer/FEBuilderGBA/issues/1361) — Hyssopi map import investigation (documented safe failure; see [DECOMP-HYSSOPI-IMPORT-FINDINGS.md](DECOMP-HYSSOPI-IMPORT-FINDINGS.md))
 - [README → Decomp Project Support](../README.md#decomp-project-support-preview)
 - [docs/cli-reference.md](cli-reference.md)


### PR DESCRIPTION
Closes #1373

## Summary

After PR #1372 (`026f5ddd2`) landed OBJ tileset LZ77 decompressed-payload source export/import/round-trip/ROM-verify (#1371), four doc locations still classified the OBJ tileset as "manual / export-only":

- **README.md Decomp Project Support prose**: sentence "the OBJ/chipset tilesets and anime-1 graphics stay manual" + ROM-only/manual asset list including "OBJ tileset"
- **README.md CLI comment block** (`--write-source` chapter/map section): "(OBJ tileset, palette, chipset config/TSA, tile animations 1/2)"
- **docs/DECOMP-FEATURE-INVENTORY.md capability row**: `Landed via` column still said `(this PR)`
- **docs/DECOMP-FEATURE-INVENTORY.md "See also" entry**: also said `(this PR)`
- **docs/DECOMP-FEATURE-INVENTORY.md honest residuals**: OBJ tileset still listed in the manual/export-only set without the parenthetical carve-out already present for mapchange (#1355) and mapanime2pal (#1360)

## Changes

**`README.md`** (Decomp Project Support prose, ~lines 479–488):
- Added explicit paragraph introducing `--kind=objtiles` (#1371/PR #1372) as source-backed, alongside mapchange and mapanime2pal.
- Changed "the OBJ/chipset tilesets and anime-1 graphics stay manual" → "the chipset tilesets and anime-1 graphics stay manual".
- Removed `OBJ tileset` from the ROM-only/manual asset list; updated the chain note to "not the overlay tile-data block nor the anime-2 palette block nor the OBJ tileset".

**`README.md`** (CLI comment block, ~lines 251–257):
- Removed `OBJ tileset` from the "(OBJ tileset, palette, chipset config/TSA, tile animations 1/2)" list.
- Added: "The OBJ tileset (LZ77 decompressed-payload) is now source export/import/verify-backed via --kind=objtiles (#1371/PR #1372)."

**`docs/DECOMP-FEATURE-INVENTORY.md`**:
- Capability row `Landed via`: `(this PR)` → `PR #1372 (026f5ddd2)`.
- Honest residuals bullet: removed OBJ tileset from the manual/export-only list; added parenthetical note matching the mapchange/mapanime2pal pattern: "*(The OBJ tileset (LZ77 decompressed-payload) is now source export/import/verify-backed (#1371) — see the feature-inventory rows above …)*"
- "See also" entry for #1371: `(this PR)` → `PR #1372, 026f5ddd2`.

## What was NOT changed

- The `<!-- decomp-audit-matrix:start/end -->` generated block in README.md — already correct (map_obj_tileset = SourceTreeExporter; map_asset_binaries already carved out OBJ tileset).
- `docs/cli-reference.md` — already has full `--kind=objtiles` documentation.
- No code behavior changes.

## Test plan

- [x] `dotnet test FEBuilderGBA.Tests/FEBuilderGBA.Tests.csproj --filter DecompAuditDocConsistencyTest` — **Passed: 1** (the generated audit matrix block is untouched; byte-identity preserved)
- [x] Grepped all `.md` files for `OBJ tileset`, `OBJ/chipset`, `this PR` — no stale claims remain outside the audit matrix (which is correctly generated)
- [x] Remaining manual areas (chipset TSA/config, tile-animation-1 graphics, anime-2 ENTRY/PLIST, 12-byte change-record chain) are explicitly listed as residual in both README and DECOMP-FEATURE-INVENTORY.md
- [x] Docs-only PR — no GUI changes, screenshots exempt per DEVELOPMENT-WORKFLOW.md

Generated with Claude Code (claude-opus-4-6)

> Claude Code Opus 4.8 (1M context) / claude-opus-4-8[1m]