### PR TITLE
fix(ferepo): BattleBG WinForms FE-Repo path rejects non-240x160 instead of silently cropping (Ref #1397)

### DIFF
--- a/FEBuilderGBA.Tests/FERepoRemainingEditorsWiringTests.cs
+++ b/FEBuilderGBA.Tests/FERepoRemainingEditorsWiringTests.cs
@@ -75,10 +75,16 @@ namespace FEBuilderGBA.Tests
             int end = src.IndexOf("private void ImportBitmap", handler, StringComparison.Ordinal);
             string handlerBody = end > handler ? src.Substring(handler, end - handler) : src.Substring(handler);
 
-            // Loads through the shared decolor pipeline with a NON-zero width
-            // (30*8 = 240), so a non-240x160 asset is rejected before cropping.
+            // Loads through the shared decolor pipeline with a width that resolves to 240
+            // (accept "30 * 8", "30*8", or "240"), so a non-240x160 asset is
+            // rejected before cropping. Whitespace-tolerant so reformatting
+            // cannot break the guard.
             Assert.Contains("LoadAndConvertDecolorUILow", handlerBody);
-            Assert.Contains("width = 30 * 8", handlerBody);
+            Assert.Matches(@"width\s*=\s*(?:30\s*\*\s*8|240)", handlerBody);
+            // The width passed to the loader must be the `width` local (240),
+            // never the lenient literal 0 that lets ImportBitmap crop
+            // (whitespace-tolerant inside the call).
+            Assert.Matches(@"LoadAndConvertDecolorUILow\([^,]+,\s*null,\s*width", handlerBody);
             // Must NOT load with the lenient width=0 that allows the crop path.
             Assert.DoesNotMatch(@"LoadAndConvertDecolorUILow\([^,]+,\s*null,\s*0\s*,", handlerBody);
         }

--- a/FEBuilderGBA.Tests/FERepoRemainingEditorsWiringTests.cs
+++ b/FEBuilderGBA.Tests/FERepoRemainingEditorsWiringTests.cs
@@ -54,6 +54,50 @@ namespace FEBuilderGBA.Tests
         }
 
         // -----------------------------------------------------------------
+        // #1397 (Copilot PR #1401 review) — REJECT-not-corrupt for the wired
+        // fixed-dimension editors whose seeded FE-Repo folder is mixed-size.
+        // The FE-Repo path must enforce the editor's exact dimensions so a
+        // wrong-size repository asset is rejected, never silently cropped.
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void WinForms_BattleBG_FERepoPath_EnforcesExactWidth_NotWidthZeroCrop()
+        {
+            // The lenient file-picker path loads width=0 and ImportBitmap crops
+            // anything wider than 240. The FE-Repo path (mixed folder) must
+            // instead pass the EXACT width so ConvertDecolorUI rejects a
+            // 256x160 full-screen asset rather than truncating it.
+            string src = ReadWinFormsSource("ImageBattleBGForm.cs");
+            int handler = src.IndexOf("void FERepoButton_Click", StringComparison.Ordinal);
+            Assert.True(handler >= 0);
+            // Body up to the next method (ImportBitmap) so we only inspect the
+            // FE-Repo handler.
+            int end = src.IndexOf("private void ImportBitmap", handler, StringComparison.Ordinal);
+            string handlerBody = end > handler ? src.Substring(handler, end - handler) : src.Substring(handler);
+
+            // Loads through the shared decolor pipeline with a NON-zero width
+            // (30*8 = 240), so a non-240x160 asset is rejected before cropping.
+            Assert.Contains("LoadAndConvertDecolorUILow", handlerBody);
+            Assert.Contains("width = 30 * 8", handlerBody);
+            // Must NOT load with the lenient width=0 that allows the crop path.
+            Assert.DoesNotMatch(@"LoadAndConvertDecolorUILow\([^,]+,\s*null,\s*0\s*,", handlerBody);
+        }
+
+        [Fact]
+        public void Avalonia_BattleBG_FERepoPath_UsesStrictSize()
+        {
+            // The Avalonia FE-Repo handler funnels through ImportImageFromFile
+            // with strictSize:true, and that body enforces 240x160 strictly.
+            string src = ReadAvaloniaSource("BattleBGViewerView.axaml.cs");
+            int handler = src.IndexOf("void FERepo_Click", StringComparison.Ordinal);
+            Assert.True(handler >= 0);
+            string handlerBody = src.Substring(handler);
+            Assert.Contains("ImportImageFromFile(path, strictSize: true)", handlerBody);
+            // And the shared body forwards strictSize into the dimension check.
+            Assert.Contains("LoadAndQuantizeFromFile(filePath, 240, 160, 16, strictSize: strictSize)", src);
+        }
+
+        // -----------------------------------------------------------------
         // Avalonia wired editors — FERepo_Click routes the picked path through
         // the SAME *FromFile / path-taking import body.
         // -----------------------------------------------------------------

--- a/FEBuilderGBA/ImageBattleBGForm.cs
+++ b/FEBuilderGBA/ImageBattleBGForm.cs
@@ -142,9 +142,16 @@ namespace FEBuilderGBA
 
         // #1397 — FE-Repo button: import a 240x160 battle background from the
         // FE-Repo "Battle Frames & Backgrounds" folder, routed through the SAME
-        // ImportBitmap body (the existing crop/size handling applies).
+        // ImportBitmap body. The "Battle Frames & Backgrounds" folder is mixed
+        // (240x160 + 256x160 + preview/template strips), so — unlike the lenient
+        // file-picker which loads width=0 and crops anything wider — the FE-Repo
+        // path passes the EXACT 240x160 dimensions to LoadAndConvertDecolorUILow.
+        // ConvertDecolorUI then REJECTS any non-240x160 asset with the existing
+        // size error instead of silently truncating it (Copilot PR #1401 review:
+        // "reject, not corrupt").
         private void FERepoButton_Click(object sender, EventArgs e)
         {
+            int width = 30 * 8;
             int height = 20 * 8;
             int palette_count = 8;
             var folder = FERepoResourceBrowser.GetFERepoFolderForEditor(
@@ -153,7 +160,7 @@ namespace FEBuilderGBA
             {
                 if (browser.ShowDialog(this) != DialogResult.OK || string.IsNullOrEmpty(browser.SelectedFilePath))
                     return;
-                Bitmap bitmap = ImageUtil.LoadAndConvertDecolorUILow(browser.SelectedFilePath, null, 0, height, true, palette_count);
+                Bitmap bitmap = ImageUtil.LoadAndConvertDecolorUILow(browser.SelectedFilePath, null, width, height, true, palette_count);
                 if (bitmap == null) return;
                 ImportBitmap(bitmap);
             }


### PR DESCRIPTION
## Summary

Follow-up to #1397 / #1401, fixing the **blocking correctness finding** the Copilot CLI raised on PR #1401 *after* it was squash-merged (so the fix did not make it into the merge commit `4d6778be7`).

**Bug (in merged master):** the WinForms Battle Background editor's new FE-Repo button (`ImageBattleBGForm.FERepoButton_Click`) loads the chosen file with `width=0`, so a 256×160 full-screen asset from the **mixed-dimension** `BGs, Interface Elements / Battle Frames & Backgrounds` folder (240×160 + 256×160 + preview/template strips) passes validation, and `ImportBitmap` then **silently crops** it to 240 wide. That violates #1397's dimension-matched-folder requirement and the PR's “reject, not corrupt” guarantee.

**Fix:** the FE-Repo path now passes the **exact** 240×160 dimensions to `LoadAndConvertDecolorUILow` (`width = 30*8`), so `ImageUtil.ConvertDecolorUI` **rejects** any non-240×160 asset with the existing size error before it can reach the crop body. The lenient file-picker keeps its `width=0` crop behavior (unchanged WinForms parity).

Verified the other wired editors are already strict and need no change:
- WinForms `ImageCGForm`/`ImageCGFE7UForm` (256×160 with the 240→256 auto-pad), `ImageBGForm` (256×160), `ImageGenericEnemyPortraitForm` (32×32), `ImagePortraitFE6Form` (128×112 / 80×80 — the body itself errors on other sizes).
- Avalonia `BattleBGViewerView` / SkillConfig icon paths already use `strictSize: true`.

## Test plan

- [x] WinForms project builds clean (`0 Error(s)`).
- [x] New regression tests in `FERepoRemainingEditorsWiringTests` (now 35 pass):
  - `WinForms_BattleBG_FERepoPath_EnforcesExactWidth_NotWidthZeroCrop` — the FE-Repo handler loads with a non-zero width (`30*8`) and never `LoadAndConvertDecolorUILow(..., null, 0, ...)`.
  - `Avalonia_BattleBG_FERepoPath_UsesStrictSize` — the Avalonia FE-Repo handler funnels through `ImportImageFromFile(path, strictSize: true)` and the shared body forwards strictSize into the 240×160 check.

## Proof

CLI/test output (non-GUI logic fix; the behavior change is a reject path that cannot be screenshotted without triggering the rejection dialog):

```
dotnet build FEBuilderGBA/FEBuilderGBA.csproj -c Debug   -> Build succeeded. 0 Error(s)
dotnet test FEBuilderGBA.Tests --filter FERepoRemainingEditorsWiringTests
  -> Passed!  Failed: 0, Passed: 35
```

Ref #1397.

---
Generated with Claude Code — model: Opus 4.8 (1M context) `claude-opus-4-8[1m]`
