### PR TITLE
fix(avalonia): write-protect reserved Song ID 0 in Song Table editor (#1423)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/SongTableWriteProtectionTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/SongTableWriteProtectionTests.cs
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for #1423 — the Avalonia Song Table editor must write-protect the
+// reserved Song ID 0 (silence/unset) entry, matching WinForms
+// (SongTableForm.cs:21 UseWriteProtectionID00 = true; InputFormRef
+// CheckWriteProtectionID00 hard-refuses) and the sibling SongTrackView.
+using System;
+using System.IO;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class SongTableWriteProtectionTests
+    {
+        // FE8U sound_table_pointer = 0x28BC (ROMFE8U.cs). We plant a song table
+        // pointer there → base 0x3000, then fill a few 8-byte entries so the
+        // VM's LoadSongList/LoadSong see real data.
+        const uint TableBase = 0x3000;
+
+        // ------------------------------------------------------------------
+        // VM behaviour
+        // ------------------------------------------------------------------
+
+        [Fact]
+        public void WriteSong_OnSongId0_DoesNotMutateRom_AndReturnsFalse()
+        {
+            var rom = MakeRomWithSongTable();
+            var prev = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = rom;
+                var vm = new SongTableViewModel();
+                // Row 0 = the reserved silence entry at the table base.
+                vm.LoadSong(TableBase);
+                Assert.True(vm.IsSongIdZero);
+
+                uint before0 = rom.u32(TableBase + 0);
+                uint before4 = rom.u32(TableBase + 4);
+
+                // Attempt to overwrite the header pointer + PlayerType.
+                vm.SongHeaderPointer = 0x08001234;
+                vm.PlayerType = 0x55;
+                bool wrote = vm.WriteSong();
+
+                Assert.False(wrote);                       // refusal is observable
+                Assert.Equal(before0, rom.u32(TableBase + 0)); // unchanged
+                Assert.Equal(before4, rom.u32(TableBase + 4)); // unchanged
+            }
+            finally { CoreState.ROM = prev; }
+        }
+
+        [Fact]
+        public void WriteSong_OnNonZeroSong_Mutates_AndReturnsTrue()
+        {
+            var rom = MakeRomWithSongTable();
+            var prev = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = rom;
+                var vm = new SongTableViewModel();
+                // Row 1 = entry at base + 8.
+                vm.LoadSong(TableBase + 8);
+                Assert.False(vm.IsSongIdZero);
+                Assert.Equal(1u, vm.SongIndex);
+
+                vm.SongHeaderPointer = 0x08005678;
+                vm.PlayerType = 0x07;
+                bool wrote = vm.WriteSong();
+
+                Assert.True(wrote);
+                Assert.Equal(0x08005678u, rom.u32(TableBase + 8 + 0));
+                Assert.Equal(0x07u, rom.u32(TableBase + 8 + 4));
+            }
+            finally { CoreState.ROM = prev; }
+        }
+
+        // Copilot Finding 1 regression guard: a direct LoadSong(base + 8) that
+        // never went through list selection must still be treated as a non-zero
+        // row (SongIndex derived from the table base, not a stale default of 0).
+        [Fact]
+        public void WriteSong_DirectLoadRow1_WithoutSelection_Mutates()
+        {
+            var rom = MakeRomWithSongTable();
+            var prev = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = rom;
+                var vm = new SongTableViewModel();
+                // Brand-new VM: SongIndex defaults to 0. LoadSong must overwrite
+                // it with the derived index so the guard does not over-block.
+                vm.LoadSong(TableBase + 8);
+
+                Assert.Equal(1u, vm.SongIndex);
+                Assert.False(vm.IsSongIdZero);
+
+                vm.SongHeaderPointer = 0x08009ABC;
+                vm.PlayerType = 0x02;
+                Assert.True(vm.WriteSong());
+                Assert.Equal(0x08009ABCu, rom.u32(TableBase + 8 + 0));
+            }
+            finally { CoreState.ROM = prev; }
+        }
+
+        // WriteSong() must report a refusal (false, no mutation) for an
+        // out-of-range entry too, so Write_Click can roll back instead of falsely
+        // reporting success (Copilot non-blocking follow-up).
+        [Fact]
+        public void WriteSong_OutOfRangeAddress_ReturnsFalse_NoMutation()
+        {
+            var rom = MakeRomWithSongTable();
+            var prev = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = rom;
+                var vm = new SongTableViewModel();
+                // Force an address past the end of the ROM without going through
+                // LoadSong (which would reject it). CurrentAddr is public.
+                vm.CurrentAddr = (uint)rom.Data.Length - 2; // +7 overflows EOF
+                vm.SongIndex = 5;                            // not Song ID 0
+                vm.SongHeaderPointer = 0x08001111;
+                vm.PlayerType = 1;
+
+                Assert.False(vm.WriteSong());
+            }
+            finally { CoreState.ROM = prev; }
+        }
+
+        [Fact]
+        public void IsSongIdZero_TrueForBase_FalseForRow1()
+        {
+            var rom = MakeRomWithSongTable();
+            var prev = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = rom;
+                var vm = new SongTableViewModel();
+
+                vm.LoadSong(TableBase);
+                Assert.True(vm.IsSongIdZero);
+                Assert.Equal(0u, vm.SongIndex);
+
+                vm.LoadSong(TableBase + 8);
+                Assert.False(vm.IsSongIdZero);
+                Assert.Equal(1u, vm.SongIndex);
+
+                vm.LoadSong(TableBase + 16);
+                Assert.False(vm.IsSongIdZero);
+                Assert.Equal(2u, vm.SongIndex);
+            }
+            finally { CoreState.ROM = prev; }
+        }
+
+        // ------------------------------------------------------------------
+        // View source — the Write_Click guard mirrors SongTrackView exactly.
+        // ------------------------------------------------------------------
+
+        [Fact]
+        public void SongTableView_WriteClick_HasWriteProtectionGuard()
+        {
+            string cs = File.ReadAllText(ViewPath("SongTableView.axaml.cs"));
+
+            // Guard present before the undo scope opens.
+            Assert.Contains("Song ID 0 is write-protected (silence song).", cs);
+            Assert.Contains("ShowError", cs);
+
+            // The actual guard returns before Begin() so no undo scope opens for
+            // row 0. Use the full if-statement as the needle (not the first bare
+            // "IsSongIdZero", which now also appears in an OnSongSelected comment)
+            // so this assertion fails if the real guard is removed or moved below
+            // the undo scope.
+            int guardIdx = cs.IndexOf("if (_vm.IsSongIdZero)", StringComparison.Ordinal);
+            int beginIdx = cs.IndexOf("_undoService.Begin(\"Edit Song Table\")", StringComparison.Ordinal);
+            Assert.True(guardIdx >= 0, "Write_Click must contain the 'if (_vm.IsSongIdZero)' guard.");
+            Assert.True(beginIdx >= 0, "Write_Click must open an undo scope.");
+            Assert.True(guardIdx < beginIdx,
+                "The 'if (_vm.IsSongIdZero)' guard must appear before the undo scope opens.");
+        }
+
+        // ------------------------------------------------------------------
+        // Helpers
+        // ------------------------------------------------------------------
+
+        static ROM MakeRomWithSongTable()
+        {
+            var rom = new ROM();
+            rom.LoadLow("synth.gba", new byte[0x1000000], "BE8E01");
+
+            // sound_table_pointer (0x28BC for FE8U) -> table base 0x3000.
+            uint ptr = rom.RomInfo.sound_table_pointer;
+            Assert.Equal(0x28BCu, ptr);
+            WritePtr(rom, ptr, TableBase);
+
+            // Plant 3 song-table entries (8 bytes each). Each entry's u32@+0 must
+            // be a valid pointer (LoadSongList stops at the first non-pointer).
+            for (uint i = 0; i < 3; i++)
+            {
+                uint entry = TableBase + i * 8;
+                WritePtr(rom, entry + 0, 0x4000 + i * 0x100); // header pointer
+                WritePtr(rom, entry + 4, 0);                  // PlayerType
+            }
+            return rom;
+        }
+
+        static void WritePtr(ROM rom, uint at, uint targetOffset)
+        {
+            uint ptr = targetOffset == 0 ? 0 : targetOffset + 0x08000000;
+            rom.Data[at + 0] = (byte)(ptr & 0xFF);
+            rom.Data[at + 1] = (byte)((ptr >> 8) & 0xFF);
+            rom.Data[at + 2] = (byte)((ptr >> 16) & 0xFF);
+            rom.Data[at + 3] = (byte)((ptr >> 24) & 0xFF);
+        }
+
+        static string ViewPath(string fileName)
+            => Path.Combine(FindProjectRoot(), "FEBuilderGBA.Avalonia", "Views", fileName);
+
+        static string FindProjectRoot()
+        {
+            string dir = AppContext.BaseDirectory;
+            for (int i = 0; i < 12; i++)
+            {
+                if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                    return dir;
+                string? parent = Path.GetDirectoryName(dir);
+                if (parent == null || parent == dir) break;
+                dir = parent;
+            }
+            throw new InvalidOperationException("Could not find project root (FEBuilderGBA.sln)");
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/SongTableViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SongTableViewModel.cs
@@ -16,6 +16,20 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public uint SongIndex { get => _songIndex; set => SetField(ref _songIndex, value); }
+
+        /// <summary>
+        /// WF parity: Song ID 0 (the reserved "silence/unset" entry) is
+        /// write-protected. <c>SongTableForm.cs:21</c> sets
+        /// <c>UseWriteProtectionID00 = true</c> and
+        /// <c>InputFormRef.CheckWriteProtectionID00</c> hard-refuses the write
+        /// (default option → <c>ShowStopError</c>). True when the currently
+        /// loaded entry is index 0 (the issue's "tag==0 / CurrentAddr==base"
+        /// criterion). <see cref="SongIndex"/> is derived from the table base
+        /// inside <see cref="LoadSong"/>, so this is reliable even for a headless
+        /// caller that invokes <c>LoadSong(base + 8)</c> without first selecting
+        /// a list row.
+        /// </summary>
+        public bool IsSongIdZero => _songIndex == 0;
         /// <summary>Pointer to the song header (P0).</summary>
         public uint SongHeaderPointer { get => _songHeaderPointer; set => SetField(ref _songHeaderPointer, value); }
         /// <summary>Track count read from the song header (read-only info).</summary>
@@ -63,6 +77,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (addr + 7 >= (uint)rom.Data.Length) return;
 
             CurrentAddr = addr;
+            // Derive the song index from the table base so the write-protection
+            // guard (IsSongIdZero) is reliable even for a direct LoadSong() call
+            // that did not go through list selection. Song table entries are
+            // 8 bytes each; index = (addr - base) / 8.
+            SongIndex = ComputeSongIndex(rom, addr);
 
             uint headerPtr = rom.u32(addr);        // P0 - Song header pointer
             PlayerType = rom.u32(addr + 4);         // D4 - Priority(PlayerType)
@@ -82,14 +101,42 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             CanWrite = true;
         }
 
-        public void WriteSong()
+        /// <summary>
+        /// Maps a song-table entry address to its index. Entries are 8 bytes
+        /// each starting at the table base (<c>rom.p32(sound_table_pointer)</c>).
+        /// Returns <see cref="uint.MaxValue"/> if the base cannot be resolved or
+        /// the address is below it (which never matches index 0, so the guard
+        /// fails open to "not protected" only for genuinely unknown addresses).
+        /// </summary>
+        static uint ComputeSongIndex(ROM rom, uint addr)
+        {
+            if (rom?.RomInfo == null) return uint.MaxValue;
+            uint ptr = rom.RomInfo.sound_table_pointer;
+            // Guard the full 4-byte read: ROM.p32 only checks ptr >= Data.Length,
+            // so a ptr within the last 3 bytes of the buffer can throw.
+            if (ptr == 0 || ptr + 3 >= (uint)rom.Data.Length) return uint.MaxValue;
+            uint baseAddr = rom.p32(ptr);
+            if (!U.isSafetyOffset(baseAddr) || addr < baseAddr) return uint.MaxValue;
+            return (addr - baseAddr) / 8;
+        }
+
+        /// <summary>
+        /// Writes the song-table entry. Returns <c>false</c> WITHOUT mutating the
+        /// ROM when the entry is the reserved Song ID 0 (silence) — WF parity,
+        /// defense-in-depth behind the view's Write_Click guard so no caller can
+        /// bypass the protection — or when the address is out of range.
+        /// </summary>
+        public bool WriteSong()
         {
             ROM rom = CoreState.ROM;
-            if (rom == null || CurrentAddr == 0) return;
-            if (CurrentAddr + 7 >= (uint)rom.Data.Length) return;
+            if (rom == null || CurrentAddr == 0) return false;
+            if (CurrentAddr + 7 >= (uint)rom.Data.Length) return false;
+            // WF parity: never overwrite the reserved Song ID 0 (silence) entry.
+            if (IsSongIdZero) return false;
 
             rom.write_u32(CurrentAddr + 0, SongHeaderPointer);
             rom.write_u32(CurrentAddr + 4, PlayerType);
+            return true;
         }
 
         public int GetListCount() => LoadSongList().Count;

--- a/FEBuilderGBA.Avalonia/Views/SongTableView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongTableView.axaml.cs
@@ -48,6 +48,9 @@ namespace FEBuilderGBA.Avalonia.Views
             _vm.IsLoading = true;
             try
             {
+                // LoadSong derives SongIndex from the table base, so the
+                // write-protection guard (IsSongIdZero) recognises Song ID 0
+                // regardless of how the entry was selected.
                 _vm.LoadSong(addr);
                 UpdateUI();
             }
@@ -80,16 +83,35 @@ namespace FEBuilderGBA.Avalonia.Views
         void Write_Click(object? sender, RoutedEventArgs e)
         {
             if (!_vm.CanWrite) return;
+            // WF parity: SongID 0 is write-protected (UseWriteProtectionID00).
+            // Mirrors SongTrackView — the reserved silence entry must not be
+            // overwritten (breaks "no music" semantics).
+            if (_vm.IsSongIdZero)
+            {
+                CoreState.Services.ShowError("Song ID 0 is write-protected (silence song).");
+                return;
+            }
 
             _undoService.Begin("Edit Song Table");
             try
             {
                 _vm.SongHeaderPointer = ParseHexText(HeaderBox.Text);
                 _vm.PlayerType = (uint)(PlayerTypeBox.Value ?? 0);
-                _vm.WriteSong();
-                _undoService.Commit();
-                _vm.MarkClean();
-                CoreState.Services.ShowInfo("Song table data written.");
+                // Only commit + report success when a write actually occurred.
+                // WriteSong() returns false (no ROM mutation) for a protected /
+                // out-of-range entry — roll back and surface an error instead of
+                // falsely reporting success.
+                if (_vm.WriteSong())
+                {
+                    _undoService.Commit();
+                    _vm.MarkClean();
+                    CoreState.Services.ShowInfo("Song table data written.");
+                }
+                else
+                {
+                    _undoService.Rollback();
+                    CoreState.Services.ShowError("Song table data was not written.");
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- The Avalonia **Song Table editor** wrote the selected row's header pointer + PlayerType with **no guard for Song ID 0** (the reserved "silence/unset" entry), unlike WinForms and the sibling Avalonia Song Track editor.
- WinForms ground truth: `SongTableForm.cs:21` sets `UseWriteProtectionID00 = true`; `InputFormRef.CheckWriteProtectionID00` hard-refuses the index-0 write (default option → `ShowStopError`). The sibling `SongTrackView.axaml.cs:222-227` already blocks `SelectedSongIndex == 0` — the Song Table view was the inconsistent one.
- `SongTableView.Write_Click` now rejects Song ID 0 with the **same message the sibling uses** — `"Song ID 0 is write-protected (silence song)."` — **before** opening the undo scope, and consumes the `WriteSong()` bool so a refusal rolls back and shows an error instead of falsely reporting success.
- `SongTableViewModel.LoadSong` derives `SongIndex` from the table base (`ComputeSongIndex`, which guards the full 4-byte `sound_table_pointer` read and validates the resolved base), so the `IsSongIdZero` guard is reliable even for a direct `LoadSong(base + 8)` that never went through list selection.
- `WriteSong()` returns `bool` so the refusal is observable to callers/tests; it returns `false` without mutating the ROM for Song ID 0 or out-of-range addresses.

## Plan Reference
Implements the accepted plan from [issue #1423 comment](https://github.com/laqieer/FEBuilderGBA/issues/1423#issuecomment-4797076366) (revised to address both Copilot CLI plan-review findings, then the three PR-review findings).

## Scope
Closes #1423

## Screenshots
Avalonia Song Table Editor with row 0 ("00 NULL" — the reserved Song ID 0 silence entry) selected; this is the entry the fix write-protects. Clicking **Write** on this row now shows the write-protection error and performs no ROM mutation.

![Song Table editor — Song ID 0 selected](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1423-songtable-fe8u.png)

## GUI Test Report

### Environment
- ROM: `roms/FE8U.gba`
- Editor/View: `SongTableView` (Avalonia Song Table editor)

### Steps Performed
1. Launched the Avalonia app headlessly (`--screenshot-all`) against FE8U and captured the Song Table editor with the first row (Song ID 0 / "00 NULL") selected.
2. Verified via automated tests that loading row 0 and clicking Write performs **no** ROM mutation and returns `false`.
3. Verified loading row 1 (and a direct `LoadSong(base + 8)` without list selection) still mutates and returns `true`.

### Test Results
| Test | Expected | Actual | Status |
|------|----------|--------|--------|
| Write on Song ID 0 (row 0) | No ROM mutation, refusal observable | `u32@+0/+4` unchanged, `WriteSong()` returns false | PASS |
| Write on row 1 | ROM mutated, returns true | bytes updated, returns true | PASS |
| Direct `LoadSong(base+8)` w/o selection | Treated as row 1, mutates | `SongIndex==1`, mutates | PASS |
| Out-of-range address | Refused, no mutation | `WriteSong()` returns false | PASS |
| `IsSongIdZero` per row | true@base, false@row1/row2 | matches | PASS |
| `Write_Click` guard placement | guard + message before undo scope | confirmed in source | PASS |

### Verdict
PASS — Song Table editor now write-protects the reserved Song ID 0 entry, matching WinForms and the sibling Song Track editor.

## Test plan
- [x] `WriteSong_OnSongId0_DoesNotMutateRom_AndReturnsFalse` — row 0 write refused, ROM unchanged, returns false
- [x] `WriteSong_OnNonZeroSong_Mutates_AndReturnsTrue` — row 1 write succeeds, bytes updated, returns true
- [x] `WriteSong_DirectLoadRow1_WithoutSelection_Mutates` — Copilot Finding 1 regression guard (no over-blocking)
- [x] `WriteSong_OutOfRangeAddress_ReturnsFalse_NoMutation` — out-of-range refusal observable (PR-review follow-up)
- [x] `IsSongIdZero_TrueForBase_FalseForRow1` — guard recognises index 0 only
- [x] `SongTableView_WriteClick_HasWriteProtectionGuard` — keys on the full `if (_vm.IsSongIdZero)` guard, asserts it precedes the undo scope
- [x] Full Avalonia.Tests suite — 8548 passed, 0 failed, 6 skipped
- [x] Full FEBuilderGBA.Tests suite — 1925 passed, 0 failed
- [x] Full Core.Tests suite — 5756 passed; the 10 `SkillSystemsAnimeImportCore*` failures are the known patch2-submodule-not-checked-out worktree-env issue (unrelated to this Avalonia-only change), not regressions

## Known limitations
- Does NOT implement the WinForms `write_00` tri-state option (NoWarning/Warning/Stop). The sibling `SongTrackView` uses the simple hard-refuse and the issue makes the option "optional"; matching the sibling keeps Avalonia internally consistent.

Generated with Claude Code (Opus 4.8, 1M context)