### PR TITLE
fix(avalonia): Demon-King Summon list no longer fabricates 21 rows for count 0/>=100 (#1424)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SummonsDemonKingCountParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SummonsDemonKingCountParityTests.cs
@@ -178,7 +178,11 @@ public class SummonsDemonKingCountParityTests : IDisposable
         }
 
         var rom = new ROM();
-        rom.LoadLow("synth-fe8u-1424.gba", bytes, "BE8E01");
+        // Assert recognition so a future detection-logic change fails here
+        // immediately rather than returning an uninitialized ROM that shifts
+        // failures into the assertions below.
+        bool recognized = rom.LoadLow("synth-fe8u-1424.gba", bytes, "BE8E01");
+        Assert.True(recognized, "Synthetic FE8U ROM must be recognized by LoadLow");
         return rom;
     }
 

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/SummonsDemonKingCountParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/SummonsDemonKingCountParityTests.cs
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1424 — Demon-King Summon list count parity.
+//
+// The Avalonia Demon-King Summon viewer previously forced the count to 20
+// (21 rows) whenever summons_demon_king_count_address held 0 or a value >=100,
+// fabricating adjacent ROM bytes as editable summon rows. The WinForms ground
+// truth (SummonsDemonKingForm.cs:36-42) and the Core canon
+// (StructExportCore.cs:975-978) are:
+//   - count source missing (count_address == 0)  -> 0 rows
+//   - count byte >= 100 (corrupt)                 -> 0 rows
+//   - otherwise loop i <= count                   -> count 0 -> 1 row,
+//                                                    count 11 (vanilla) -> 12 rows
+//
+// These tests assert BOTH live code paths now match that canon:
+//   (a) SummonsDemonKingViewerViewModel.LoadSummonsDemonKingList()
+//   (b) ListParityHelper.BuildReferenceList("SummonsDemonKingViewerView")
+//       -> ListParityHelper.BuildSummonsDemonKingList() (the GapSweep reference
+//          baseline, documented as "matching SummonsDemonKingViewerViewModel").
+// and that the two paths agree row-count-for-row-count (parity assertion).
+//
+// Synthetic FE8U ROM (header "BE8E01"): pointer planted at
+// summons_demon_king_pointer (FE8U 0x7B32C) -> SummonTableBase; count byte at
+// summons_demon_king_count_address (FE8U 0x7B2BC).
+//
+// [Collection("SharedState")] because the tests mutate CoreState.ROM
+// (BuildReferenceList + isSafetyOffset read the ambient CoreState.ROM).
+using System;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests.GapSweep;
+
+[Collection("SharedState")]
+public class SummonsDemonKingCountParityTests : IDisposable
+{
+    // FE8U RomInfo addresses (ROMFE8U.cs:321-322).
+    const uint PointerAddr = 0x7B32Cu;   // summons_demon_king_pointer
+    const uint CountAddr   = 0x7B2BCu;   // summons_demon_king_count_address
+
+    // Summon table base (>= 0x200 so U.isSafetyOffset passes), well clear of the
+    // pointer/count addresses and with room for >>21 20-byte entries.
+    const uint SummonTableBase = 0x00200000u;
+    const uint EntrySize = 20u;
+
+    readonly ROM? _savedRom;
+
+    public SummonsDemonKingCountParityTests()
+    {
+        _savedRom = CoreState.ROM;
+    }
+
+    public void Dispose()
+    {
+        CoreState.ROM = _savedRom;
+    }
+
+    // ------------------------------------------------------------------
+    // Per-case row-count expectations (the canon).
+    // ------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(11, 12)]    // vanilla FE8 -> 12 rows (regression guard, normal path)
+    [InlineData(0, 1)]      // cleared count -> 1 row (was 21)
+    [InlineData(1, 2)]      // boundary -> 2 rows
+    [InlineData(99, 100)]   // largest valid count -> 100 rows
+    [InlineData(100, 0)]    // corrupt (>=100) -> 0 rows (was 21)
+    [InlineData(255, 0)]    // 0xFF corrupt -> 0 rows (was 21)
+    public void RowCount_MatchesCanon_OnBothPaths(int countByte, int expectedRows)
+    {
+        ROM rom = MakeRom((byte)countByte);
+        CoreState.ROM = rom;
+
+        // (a) The live viewer VM.
+        var vm = new SummonsDemonKingViewerViewModel();
+        var vmList = vm.LoadSummonsDemonKingList();
+        Assert.Equal(expectedRows, vmList.Count);
+
+        // (b) The GapSweep reference baseline (routes to BuildSummonsDemonKingList).
+        var refList = ListParityHelper.BuildReferenceList("SummonsDemonKingViewerView");
+        Assert.NotNull(refList);
+        Assert.Equal(expectedRows, refList!.Count);
+
+        // Parity: both code paths agree exactly.
+        Assert.Equal(vmList.Count, refList.Count);
+    }
+
+    // ------------------------------------------------------------------
+    // Cross-validation against the Core canon: both Avalonia paths must match
+    // StructExportCore's registered "summons_demon_king" GetEntryCount(rom) for
+    // every count value. This pins the Avalonia behavior directly to the
+    // single source of truth (StructExportCore.cs:972-979) rather than to a
+    // hand-written expectation table.
+    // ------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(11)]
+    [InlineData(99)]
+    [InlineData(100)]
+    [InlineData(255)]
+    public void BothPaths_MatchStructExportCoreCanon(int countByte)
+    {
+        ROM rom = MakeRom((byte)countByte);
+        CoreState.ROM = rom;
+
+        var table = StructExportCore.GetTable("summons_demon_king");
+        Assert.NotNull(table);
+        int canonRows = (int)table!.GetEntryCount(rom);
+
+        var vm = new SummonsDemonKingViewerViewModel();
+        Assert.Equal(canonRows, vm.LoadSummonsDemonKingList().Count);
+
+        var refList = ListParityHelper.BuildReferenceList("SummonsDemonKingViewerView");
+        Assert.NotNull(refList);
+        Assert.Equal(canonRows, refList!.Count);
+    }
+
+    // ------------------------------------------------------------------
+    // Direct regression: the old behavior fabricated 21 rows for count 0 / 100 /
+    // 255. Assert the new behavior never produces 21 rows for those triggers.
+    // ------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(100)]
+    [InlineData(255)]
+    public void TriggerCounts_NeverProduce21Rows(int countByte)
+    {
+        ROM rom = MakeRom((byte)countByte);
+        CoreState.ROM = rom;
+
+        var vm = new SummonsDemonKingViewerViewModel();
+        int vmCount = vm.LoadSummonsDemonKingList().Count;
+        Assert.NotEqual(21, vmCount);
+
+        var refList = ListParityHelper.BuildReferenceList("SummonsDemonKingViewerView");
+        Assert.NotNull(refList);
+        Assert.NotEqual(21, refList!.Count);
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Build a synthetic FE8U ROM (header "BE8E01") with:
+    ///   - summons_demon_king_pointer (0x7B32C) -> SummonTableBase (GBA pointer)
+    ///   - summons_demon_king_count_address (0x7B2BC) = <paramref name="countByte"/>
+    ///   - SummonTableBase filled with non-zero unit bytes so rows render as
+    ///     populated (proves we count rows, not -EMPTY- placeholders).
+    /// </summary>
+    static ROM MakeRom(byte countByte)
+    {
+        // 16 MB minimum: ROM.LoadLow only assigns the FE8U RomInfo when
+        // data.Length >= 0x1000000 (16 MB). SummonTableBase 0x200000 + 256*20
+        // bytes fits comfortably, and addresses stay < 0x02000000 for
+        // U.isSafetyOffset.
+        var bytes = new byte[0x01000000];
+
+        // Pointer at summons_demon_king_pointer -> SummonTableBase.
+        WriteU32(bytes, (int)PointerAddr, SummonTableBase | 0x08000000u);
+
+        // Count byte.
+        bytes[(int)CountAddr] = countByte;
+
+        // Fill enough summon entries with a non-zero unit id at offset 0 so the
+        // viewer renders populated rows (and so a hypothetical 21-row fabrication
+        // would still find valid-looking data, making the count-cap the only thing
+        // that limits row count).
+        for (uint i = 0; i < 0x120; i++)
+        {
+            int row = (int)(SummonTableBase + i * EntrySize);
+            bytes[row + 0] = 0x01;   // unit id (1-based) -> populated
+            bytes[row + 1] = 0x02;   // class id
+        }
+
+        var rom = new ROM();
+        rom.LoadLow("synth-fe8u-1424.gba", bytes, "BE8E01");
+        return rom;
+    }
+
+    static void WriteU32(byte[] data, int offset, uint value)
+    {
+        data[offset + 0] = (byte)(value & 0xFF);
+        data[offset + 1] = (byte)((value >> 8) & 0xFF);
+        data[offset + 2] = (byte)((value >> 16) & 0xFF);
+        data[offset + 3] = (byte)((value >> 24) & 0xFF);
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/SummonsDemonKingCountScreenshotTest.cs
+++ b/FEBuilderGBA.Avalonia.Tests/SummonsDemonKingCountScreenshotTest.cs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1424 PR proof — render the Avalonia SummonsDemonKingViewerView with a
+// CORRUPTED count byte (0xFF) to a PNG that proves the editor list now shows
+// 0 fabricated rows (WinForms behavior) instead of the old 21 rows.
+//
+// The bug only triggers for an abnormal count byte (vanilla FE8 count == 11 →
+// both editors already agree at 12 rows), so the proof loads a private copy of
+// FE8U, sets summons_demon_king_count_address (0x7B2BC) to 0xFF, and renders.
+//
+// Headless RenderTargetBitmap — works on locked machines and CI. Default output
+// is a per-test temp dir; set FEBUILDERGBA_SCREENSHOT_DIR to regenerate the
+// canonical PR screenshot into the repo's pr-screenshots/.
+using System;
+using System.IO;
+using global::Avalonia;
+using global::Avalonia.Controls;
+using global::Avalonia.Headless.XUnit;
+using global::Avalonia.Media.Imaging;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class SummonsDemonKingCountScreenshotTest : IClassFixture<RomFixture>
+    {
+        // FE8U RomInfo addresses (ROMFE8U.cs:321-322).
+        const uint CountAddr = 0x7B2BCu; // summons_demon_king_count_address
+
+        private readonly RomFixture _fixture;
+        private readonly ITestOutputHelper _output;
+
+        public SummonsDemonKingCountScreenshotTest(RomFixture fixture, ITestOutputHelper output)
+        {
+            _fixture = fixture;
+            _output = output;
+        }
+
+        [AvaloniaFact]
+        public void CorruptCountByte_ListIsEmpty_NotTwentyOne_SavesScreenshot()
+        {
+            if (!_fixture.IsAvailable || _fixture.Version != "FE8U" || _fixture.RomPath == null)
+            {
+                _output.WriteLine($"SKIP: needs FE8U ROM (got {_fixture.Version ?? "none"})");
+                return;
+            }
+
+            ROM? savedRom = CoreState.ROM;
+            try
+            {
+                // Load a private copy of FE8U and corrupt the count byte to 0xFF
+                // (>=100 → corrupt). This is the #1424 trigger.
+                byte[] bytes = File.ReadAllBytes(_fixture.RomPath);
+                bytes[(int)CountAddr] = 0xFF;
+                var rom = new ROM();
+                bool ok = rom.LoadLow("synth-fe8u-1424-corrupt.gba", bytes, "BE8E01");
+                Assert.True(ok, "FE8U copy must load");
+                CoreState.ROM = rom;
+
+                // Data-layer proof of the fix: corrupt count → EMPTY list (0 rows),
+                // matching WinForms (SummonsDemonKingForm.cs: max>=100 → 0 rows),
+                // NOT the old 21 fabricated rows.
+                var vm = new SummonsDemonKingViewerViewModel();
+                var list = vm.LoadSummonsDemonKingList();
+                _output.WriteLine($"Corrupt count byte 0xFF → list rows = {list.Count} (was 21 before #1424)");
+                Assert.Empty(list);
+                Assert.NotEqual(21, list.Count);
+
+                // Render the view as visual proof (empty list).
+                var view = new SummonsDemonKingViewerView { DataContext = vm };
+                try
+                {
+                    const int W = 1000, H = 640;
+                    view.Measure(new Size(W, H));
+                    view.Arrange(new Rect(0, 0, W, H));
+                    using var bitmap = new RenderTargetBitmap(new PixelSize(W, H));
+                    bitmap.Render(view);
+
+                    string outDir = ResolveScreenshotOutputDir();
+                    Directory.CreateDirectory(outDir);
+                    string outPath = Path.Combine(outDir, "pr1424-demonking-count-fe8u.png");
+                    bitmap.Save(outPath);
+                    _output.WriteLine($"Saved screenshot to: {outPath} ({new FileInfo(outPath).Length} bytes)");
+                }
+                catch (Exception ex)
+                {
+                    _output.WriteLine($"Headless render failed (environment, not the #1424 fix): {ex.Message}");
+                }
+            }
+            finally
+            {
+                CoreState.ROM = savedRom;
+            }
+        }
+
+        static string ResolveScreenshotOutputDir()
+        {
+            string? overrideDir = Environment.GetEnvironmentVariable("FEBUILDERGBA_SCREENSHOT_DIR");
+            if (!string.IsNullOrEmpty(overrideDir))
+                return overrideDir;
+            return Path.Combine(Path.GetTempPath(), "FEBuilderGBA-screenshots");
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
@@ -1677,13 +1677,15 @@ namespace FEBuilderGBA.Avalonia.Services
             uint baseAddr = rom.p32(ptr);
             if (!U.isSafetyOffset(baseAddr)) return new List<AddrResult>();
 
-            uint maxCount = 0;
+            // Match the WinForms / Core canon (SummonsDemonKingForm.cs:36-42,
+            // StructExportCore.cs:975-978) and SummonsDemonKingViewerViewModel:
+            // a missing count source or a corrupt count byte (>=100) means an
+            // EMPTY list; count==0 yields exactly 1 row via the i<=maxCount loop
+            // (NOT 21 fabricated rows from the old `maxCount = 20` — issue #1424).
             uint countAddr = rom.RomInfo.summons_demon_king_count_address;
-            if (countAddr > 0 && countAddr < (uint)rom.Data.Length)
-            {
-                maxCount = rom.u8(countAddr);
-            }
-            if (maxCount == 0 || maxCount >= 100) maxCount = 20;
+            if (countAddr == 0 || !U.isSafetyOffset(countAddr)) return new List<AddrResult>();
+            uint maxCount = rom.u8(countAddr);
+            if (maxCount >= 100) return new List<AddrResult>();
 
             const uint blockSize = 20;
             var result = new List<AddrResult>();

--- a/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
@@ -1675,7 +1675,9 @@ namespace FEBuilderGBA.Avalonia.Services
             uint ptr = rom.RomInfo.summons_demon_king_pointer;
             if (ptr == 0) return new List<AddrResult>();
             uint baseAddr = rom.p32(ptr);
-            if (!U.isSafetyOffset(baseAddr)) return new List<AddrResult>();
+            // Bounds-check against THIS rom (the builder's parameter), not ambient
+            // CoreState.ROM, so the guard is consistent if called with a non-ambient ROM.
+            if (!U.isSafetyOffset(baseAddr, rom)) return new List<AddrResult>();
 
             // Match the WinForms / Core canon (SummonsDemonKingForm.cs:36-42,
             // StructExportCore.cs:975-978) and SummonsDemonKingViewerViewModel:
@@ -1683,7 +1685,7 @@ namespace FEBuilderGBA.Avalonia.Services
             // EMPTY list; count==0 yields exactly 1 row via the i<=maxCount loop
             // (NOT 21 fabricated rows from the old `maxCount = 20` — issue #1424).
             uint countAddr = rom.RomInfo.summons_demon_king_count_address;
-            if (countAddr == 0 || !U.isSafetyOffset(countAddr)) return new List<AddrResult>();
+            if (countAddr == 0 || !U.isSafetyOffset(countAddr, rom)) return new List<AddrResult>();
             uint maxCount = rom.u8(countAddr);
             if (maxCount >= 100) return new List<AddrResult>();
 

--- a/FEBuilderGBA.Avalonia/ViewModels/SummonsDemonKingViewerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SummonsDemonKingViewerViewModel.cs
@@ -59,13 +59,15 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             uint baseAddr = rom.p32(ptr);
             if (!U.isSafetyOffset(baseAddr)) return new List<AddrResult>();
 
-            uint maxCount = 0;
+            // Match the WinForms / Core canon (SummonsDemonKingForm.cs:36-42,
+            // StructExportCore.cs:975-978): a missing count source or a corrupt
+            // count byte (>=100) means an EMPTY list. count==0 keeps maxCount==0
+            // so the i<=maxCount loop yields exactly 1 row (NOT 21 fabricated rows
+            // from the old `maxCount = 20` special case — issue #1424).
             uint countAddr = rom.RomInfo.summons_demon_king_count_address;
-            if (countAddr != 0 && U.isSafetyOffset(countAddr))
-            {
-                maxCount = rom.u8(countAddr);
-            }
-            if (maxCount == 0 || maxCount >= 100) maxCount = 20;
+            if (countAddr == 0 || !U.isSafetyOffset(countAddr)) return new List<AddrResult>();
+            uint maxCount = rom.u8(countAddr);
+            if (maxCount >= 100) return new List<AddrResult>();
 
             var result = new List<AddrResult>();
             for (uint i = 0; i <= maxCount; i++)

--- a/FEBuilderGBA.Avalonia/ViewModels/SummonsDemonKingViewerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SummonsDemonKingViewerViewModel.cs
@@ -57,7 +57,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (ptr == 0) return new List<AddrResult>();
 
             uint baseAddr = rom.p32(ptr);
-            if (!U.isSafetyOffset(baseAddr)) return new List<AddrResult>();
+            // Bounds-check against THIS rom (not ambient CoreState.ROM) so the
+            // guard matches the instance we actually read from.
+            if (!U.isSafetyOffset(baseAddr, rom)) return new List<AddrResult>();
 
             // Match the WinForms / Core canon (SummonsDemonKingForm.cs:36-42,
             // StructExportCore.cs:975-978): a missing count source or a corrupt
@@ -65,7 +67,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             // so the i<=maxCount loop yields exactly 1 row (NOT 21 fabricated rows
             // from the old `maxCount = 20` special case — issue #1424).
             uint countAddr = rom.RomInfo.summons_demon_king_count_address;
-            if (countAddr == 0 || !U.isSafetyOffset(countAddr)) return new List<AddrResult>();
+            if (countAddr == 0 || !U.isSafetyOffset(countAddr, rom)) return new List<AddrResult>();
             uint maxCount = rom.u8(countAddr);
             if (maxCount >= 100) return new List<AddrResult>();
 


### PR DESCRIPTION
## Summary
The Avalonia Demon-King Summon viewer forced the entry count to 20 (21 rows) whenever `summons_demon_king_count_address` held `0` or a value `>= 100`, displaying adjacent ROM bytes as editable summon entries. This diverged from the WinForms ground truth and the Core canon.

**Ground truth** (`SummonsDemonKingForm.cs:36-42`, mirrored in `StructExportCore.cs:975-978` and `RebuildProducerCore.cs`):
- count source missing (`count_address == 0`) or corrupt (`>= 100`) → **0 rows**
- otherwise loop `i <= count` → count `0` → **1 row**, vanilla FE8 count `11` → **12 rows**

## Fix
Replaced the buggy `if (maxCount == 0 || maxCount >= 100) maxCount = 20;` in **both** live Avalonia code paths (same defect, same editor):
1. `SummonsDemonKingViewerViewModel.LoadSummonsDemonKingList()` — the editor (cited in the issue).
2. `ListParityHelper.BuildSummonsDemonKingList()` — the GapSweep **reference baseline**, documented as "matching SummonsDemonKingViewerViewModel"; leaving it divergent would keep the wrong 21-row behavior in the parity baseline.

Per the Copilot plan review, `count_address == 0` now returns an empty list **before** reading the byte, matching `StructExportCore.cs:975` exactly.

## Scope
Closes #1424. FE8-only, edge-case (vanilla FE8 count byte is `11` so both editors already agreed at 12 rows; divergence only for a cleared/corrupt count byte). Writes were already bounds-checked and the count byte is never mutated — not corrupting.

## Test plan
- [x] New `FEBuilderGBA.Avalonia.Tests/GapSweep/SummonsDemonKingCountParityTests.cs` cross-validates **both** paths against `StructExportCore.GetEntryCount` canon for counts `0/1/11/99/100/255`; asserts the trigger counts never produce 21 rows; asserts VM↔ListParityHelper parity (15 cases, all pass).
- [x] New `FEBuilderGBA.Avalonia.Tests/SummonsDemonKingCountScreenshotTest.cs` renders the editor on a corrupt-count (0xFF) FE8U ROM and asserts the list is empty (0 rows), generating the PR screenshot.
- [x] `FEBuilderGBA.Avalonia.Tests` — **8566 passed, 0 failed**, 6 skipped (includes the new tests).
- [x] `FEBuilderGBA.Tests` (net9.0-windows) — **1925 passed, 0 failed**.
- [x] `FEBuilderGBA.Core.Tests` — 5765 passed; the 10 failures are the pre-existing `Skill*`/`SkillSystemsAnime*` worktree-env failures (patch2 submodule not checked out), confirmed unrelated to this change.

## GUI Test Report
| Scenario | Editor | Expected | Result |
|---|---|---|---|
| FE8U with count byte corrupted to 0xFF | Demon King Summon Editor | empty entry list (0 rows) | PASS — list empty, no fabricated rows |
| Data layer (corrupt 0xFF) | `LoadSummonsDemonKingList()` | 0 rows (was 21) | PASS |
| Data layer (count 0) | both paths | 1 row | PASS |
| Data layer (vanilla count 11) | both paths | 12 rows | PASS |

Captured via headless launch (`--rom <corrupt FE8U>`) → UIA-invoke the **Demon King** button → WinCapture PrintWindow.

## Screenshot
![Demon King Summon Editor — empty list on corrupt count byte (FE8U)](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1424-demonking-count-fe8u.png)

The entry list (left panel) is empty — 0 rows — instead of the old 21 fabricated rows.

🤖 Generated with Claude Code (Opus 4.8, 1M context)