### PR TITLE
fix(avalonia): undo-track Event Function Pointer editor write (FE8 + FE7) (#1426)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/EventFunctionPointerUndoTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventFunctionPointerUndoTests.cs
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1426 — Event Function Pointer editor (FE8 + FE7 variants) write must be
+// undo-tracked. Both Avalonia views (EventFunctionPointerView /
+// EventFunctionPointerFE7View) previously called _vm.Write() with NO
+// UndoService scope, so the ROM write recorded into a null ambient undo and was
+// never captured: the global Undo could not revert it and the dirty indicator
+// never flipped. The fix wraps OnWrite in
+//   _undoService.Begin(...); try { ...; _vm.Write(); _undoService.Commit();
+//   _vm.MarkClean(); } catch { _undoService.Rollback(); Log.Error(...); }
+// mirroring the canonical sibling Command85PointerView.
+//
+// These headless tests drive the EXACT View OnWrite sequence with a REAL
+// UndoService against synthetic ROMs and prove:
+//   * Commit() records the write into CoreState.Undo (IsModified == true) and
+//     leaves the VM clean (IsDirty == false), and RunUndo() restores byte
+//     identity.
+//   * Rollback() restores byte identity.
+//   * Both .axaml.cs views actually contain the undo wiring (source guards).
+// Covers BOTH variants: FE8/FE6 (stride 4, one pointer field) and FE7
+// (stride 8, pointer + Unknown4).
+//
+// [Collection("SharedState")] because the tests mutate CoreState.ROM / .Undo.
+
+using System;
+using System.IO;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+[Collection("SharedState")]
+public class EventFunctionPointerUndoTests : IDisposable
+{
+    const uint TableBase = 0x00900000u; // function-pointer table
+    const uint Entry0Ptr = 0x08123456u; // initial pointer at slot 0
+    const uint NewPtr    = 0x08ABCDEFu; // edited pointer
+    const uint NewUnk4   = 0x08FEDCBAu; // edited Unknown4 (FE7 only)
+
+    readonly ROM? _savedRom;
+    readonly Undo? _savedUndo;
+
+    public EventFunctionPointerUndoTests()
+    {
+        _savedRom = CoreState.ROM;
+        _savedUndo = CoreState.Undo;
+    }
+
+    public void Dispose()
+    {
+        CoreState.ROM = _savedRom;
+        CoreState.Undo = _savedUndo;
+    }
+
+    // ================================================================
+    // FE8/FE6 variant (stride 4) — EventFunctionPointerViewModel
+    // ================================================================
+
+    [Fact]
+    public void Write_IsUndoable_FE8()
+    {
+        ROM rom = MakeRom("BE8E01", strideEight: false);
+        CoreState.ROM = rom;
+        CoreState.Undo = new Undo();
+
+        var vm = new EventFunctionPointerViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        uint addr = list[0].addr;
+        vm.LoadEntry(addr);
+        Assert.True(vm.IsLoaded);
+        Assert.Equal(Entry0Ptr, vm.EventCommandFunctionPointer);
+        vm.MarkClean(); // mirror the View's load (selection settles dirty=false)
+
+        byte[] snap = (byte[])rom.Data.Clone();
+        var undoService = new UndoService();
+
+        // EXACT View OnWrite sequence (Begin → set → Write → Commit → MarkClean).
+        undoService.Begin("Edit Event Function Pointer");
+        vm.EventCommandFunctionPointer = NewPtr;
+        vm.Write();
+        undoService.Commit();
+        vm.MarkClean();
+
+        // The write hit the ROM, was captured by the undo buffer, and the VM is
+        // clean again after the save.
+        Assert.Equal(NewPtr, rom.u32(addr));
+        Assert.True(CoreState.Undo.IsModified);
+        Assert.False(vm.IsDirty);
+
+        // Undo reverts byte-identity.
+        CoreState.Undo.RunUndo();
+        Assert.Equal(Entry0Ptr, rom.u32(addr));
+        Assert.Equal(snap, rom.Data);
+    }
+
+    [Fact]
+    public void Rollback_RestoresBytes_FE8()
+    {
+        ROM rom = MakeRom("BE8E01", strideEight: false);
+        CoreState.ROM = rom;
+        CoreState.Undo = new Undo();
+
+        var vm = new EventFunctionPointerViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        uint addr = list[0].addr;
+        vm.LoadEntry(addr);
+        byte[] snap = (byte[])rom.Data.Clone();
+        var undoService = new UndoService();
+
+        undoService.Begin("Edit Event Function Pointer");
+        vm.EventCommandFunctionPointer = NewPtr;
+        vm.Write();
+        Assert.Equal(NewPtr, rom.u32(addr)); // applied inside the scope
+        undoService.Rollback();
+
+        // Rollback discards the in-scope write → byte identity restored.
+        Assert.Equal(Entry0Ptr, rom.u32(addr));
+        Assert.Equal(snap, rom.Data);
+    }
+
+    // ================================================================
+    // FE7 variant (stride 8) — EventFunctionPointerFE7ViewModel
+    // ================================================================
+
+    [Fact]
+    public void Write_IsUndoable_FE7()
+    {
+        ROM rom = MakeRom("AE7E01", strideEight: true);
+        CoreState.ROM = rom;
+        CoreState.Undo = new Undo();
+
+        var vm = new EventFunctionPointerFE7ViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        uint addr = list[0].addr;
+        vm.LoadEntry(addr);
+        Assert.True(vm.IsLoaded);
+        Assert.Equal(Entry0Ptr, vm.EventCommandFunctionPointer);
+        vm.MarkClean();
+
+        byte[] snap = (byte[])rom.Data.Clone();
+        var undoService = new UndoService();
+
+        undoService.Begin("Edit Event Function Pointer");
+        vm.EventCommandFunctionPointer = NewPtr;
+        vm.Unknown4 = NewUnk4;
+        vm.Write();
+        undoService.Commit();
+        vm.MarkClean();
+
+        // Both fields written, captured, and the VM is clean.
+        Assert.Equal(NewPtr, rom.u32(addr + 0));
+        Assert.Equal(NewUnk4, rom.u32(addr + 4));
+        Assert.True(CoreState.Undo.IsModified);
+        Assert.False(vm.IsDirty);
+
+        // Undo reverts both fields → byte identity.
+        CoreState.Undo.RunUndo();
+        Assert.Equal(Entry0Ptr, rom.u32(addr + 0));
+        Assert.Equal(snap, rom.Data);
+    }
+
+    [Fact]
+    public void Rollback_RestoresBytes_FE7()
+    {
+        ROM rom = MakeRom("AE7E01", strideEight: true);
+        CoreState.ROM = rom;
+        CoreState.Undo = new Undo();
+
+        var vm = new EventFunctionPointerFE7ViewModel();
+        var list = vm.LoadList();
+        Assert.NotEmpty(list);
+
+        uint addr = list[0].addr;
+        vm.LoadEntry(addr);
+        byte[] snap = (byte[])rom.Data.Clone();
+        var undoService = new UndoService();
+
+        undoService.Begin("Edit Event Function Pointer");
+        vm.EventCommandFunctionPointer = NewPtr;
+        vm.Unknown4 = NewUnk4;
+        vm.Write();
+        Assert.Equal(NewPtr, rom.u32(addr + 0));
+        Assert.Equal(NewUnk4, rom.u32(addr + 4));
+        undoService.Rollback();
+
+        Assert.Equal(Entry0Ptr, rom.u32(addr + 0));
+        Assert.Equal(snap, rom.Data);
+    }
+
+    // ================================================================
+    // Source-wiring guards — the views actually carry the undo scope.
+    // ================================================================
+
+    [Fact]
+    public void View_FE8_OnWrite_UsesUndoScope()
+        => AssertViewHasUndoWiring("EventFunctionPointerView.axaml.cs");
+
+    [Fact]
+    public void View_FE7_OnWrite_UsesUndoScope()
+        => AssertViewHasUndoWiring("EventFunctionPointerFE7View.axaml.cs");
+
+    static void AssertViewHasUndoWiring(string fileName)
+    {
+        string repoRoot = FindRepoRoot();
+        string path = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views", fileName);
+        Assert.True(File.Exists(path), $"{path} must exist");
+        string src = File.ReadAllText(path);
+
+        Assert.Contains("readonly UndoService _undoService", src);
+        Assert.Contains("_undoService.Begin(", src);
+        Assert.Contains("_undoService.Commit()", src);
+        Assert.Contains("_undoService.Rollback()", src);
+        Assert.Contains("_vm.MarkClean()", src);
+    }
+
+    // ================================================================
+    // Helpers
+    // ================================================================
+
+    /// <summary>
+    /// Synthetic ROM whose <c>event_function_pointer_table_pointer</c> (a fixed
+    /// per-version offset) points at <see cref="TableBase"/>. The table holds N
+    /// function pointers (stride 4 for FE6/8, stride 8 for FE7), terminated by a
+    /// non-pointer (0) so the VM's LoadList stops scanning.
+    /// </summary>
+    static ROM MakeRom(string header, bool strideEight)
+    {
+        var bytes = new byte[0x1100000];
+        var rom = new ROM();
+        rom.LoadLow($"synth-{header}-1426.gba", bytes, header);
+
+        uint stride = strideEight ? 8u : 4u;
+        uint tablePtrLoc = rom.RomInfo.event_function_pointer_table_pointer;
+        Assert.NotEqual(0u, tablePtrLoc);
+
+        // p32(tablePtrLoc) → TableBase (as a GBA pointer).
+        PlantU32(bytes, tablePtrLoc, TableBase | 0x08000000u);
+
+        // Three valid pointer entries, then a 0 terminator.
+        for (uint i = 0; i < 3; i++)
+        {
+            uint slot = TableBase + i * stride;
+            PlantU32(bytes, slot, i == 0 ? Entry0Ptr : (0x08000100u + i * 4u));
+            if (strideEight)
+                PlantU32(bytes, slot + 4, 0x08000000u + i); // Unknown4 (any value)
+        }
+        // Terminator: a non-pointer u32 at the next slot.
+        PlantU32(bytes, TableBase + 3 * stride, 0x00000000u);
+
+        return rom;
+    }
+
+    static void PlantU32(byte[] bytes, uint addr, uint value)
+    {
+        int idx = (int)addr;
+        bytes[idx + 0] = (byte)(value & 0xFF);
+        bytes[idx + 1] = (byte)((value >> 8) & 0xFF);
+        bytes[idx + 2] = (byte)((value >> 16) & 0xFF);
+        bytes[idx + 3] = (byte)((value >> 24) & 0xFF);
+    }
+
+    static string FindRepoRoot()
+    {
+        string dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 12 && dir != null; i++)
+        {
+            if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln"))) return dir;
+            dir = Path.GetDirectoryName(dir)!;
+        }
+        return AppContext.BaseDirectory;
+    }
+}

--- a/FEBuilderGBA.Avalonia/Views/EventFunctionPointerFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventFunctionPointerFE7View.axaml.cs
@@ -9,6 +9,7 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class EventFunctionPointerFE7View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventFunctionPointerFE7ViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         public string ViewTitle => "Event Function Pointer (FE7)";
         public bool IsLoaded => _vm.IsLoaded;
@@ -56,14 +57,20 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void OnWrite(object? sender, RoutedEventArgs e)
         {
+            if (!_vm.IsLoaded) return;
+
+            _undoService.Begin(R._("Edit Event Function Pointer"));
             try
             {
                 _vm.EventCommandFunctionPointer = (uint)(FuncPointerUpDown.Value ?? 0);
                 _vm.Unknown4 = (uint)(Unknown4UpDown.Value ?? 0);
                 _vm.Write();
+                _undoService.Commit();
+                _vm.MarkClean();
             }
             catch (Exception ex)
             {
+                _undoService.Rollback();
                 Log.Error("EventFunctionPointerFE7View.OnWrite failed: {0}", ex.Message);
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/EventFunctionPointerFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventFunctionPointerFE7View.axaml.cs
@@ -71,7 +71,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EventFunctionPointerFE7View.OnWrite failed: {0}", ex.Message);
+                Log.Error("EventFunctionPointerFE7View.OnWrite failed: " + ex.ToString());
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EventFunctionPointerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventFunctionPointerView.axaml.cs
@@ -9,6 +9,7 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class EventFunctionPointerView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventFunctionPointerViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         public string ViewTitle => "Event Function Pointer Editor";
         public bool IsLoaded => _vm.IsLoaded;
@@ -55,13 +56,19 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void OnWrite(object? sender, RoutedEventArgs e)
         {
+            if (!_vm.IsLoaded) return;
+
+            _undoService.Begin(R._("Edit Event Function Pointer"));
             try
             {
                 _vm.EventCommandFunctionPointer = (uint)(FuncPointerUpDown.Value ?? 0);
                 _vm.Write();
+                _undoService.Commit();
+                _vm.MarkClean();
             }
             catch (Exception ex)
             {
+                _undoService.Rollback();
                 Log.Error("EventFunctionPointerView.OnWrite failed: {0}", ex.Message);
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/EventFunctionPointerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventFunctionPointerView.axaml.cs
@@ -69,7 +69,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EventFunctionPointerView.OnWrite failed: {0}", ex.Message);
+                Log.Error("EventFunctionPointerView.OnWrite failed: " + ex.ToString());
             }
         }
 


### PR DESCRIPTION
## Summary
- Both Avalonia Event Function Pointer views (`EventFunctionPointerView` and the FE7 variant `EventFunctionPointerFE7View`) called `_vm.Write()` with **no UndoService scope**. The bare `WriteFields → rom.write_p32/write_u32` recorded into a null ambient undo, so the write was committed but never captured: the global Undo could not revert it and the dirty indicator never flipped.
- Fix (View-layer only, no ViewModel change), mirroring the canonical sibling `Command85PointerView`: add `readonly UndoService _undoService = new();`, guard `if (!_vm.IsLoaded) return;`, and wrap `OnWrite` in `Begin(R._("Edit Event Function Pointer")) → set fields → _vm.Write() → Commit() → _vm.MarkClean()`, with `catch → Rollback() + Log.Error`.
- The write runs synchronously on the UI thread, so `Begin` opens the ambient scope on the same thread that performs the write (no background-thread ambient-undo-NULL trap). `Commit()` fires `NotifyUnsavedChanges()` (global dirty flips); `MarkClean()` resets the per-VM `IsDirty` that the property setters flip before `Write()`.

## Plan Reference
Implements the accepted (Copilot-reviewed) plan: https://github.com/laqieer/FEBuilderGBA/issues/1426#issuecomment-4797513258 — the plan was refined per Copilot's required finding (post-commit `_vm.MarkClean()`).

## Scope
Closes #1426

## Screenshots
Avalonia Event Function Pointer editor (FE8U) — populated list + selected entry (`0x00591B28`, pointer `0x0800D5A1`) + the **Write** button whose handler was fixed:

![Event Function Pointer editor (FE8U)](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1426-eventfuncptr-fe8u.png)

## GUI Test Report

### Environment
- ROM: `roms/FE8U.gba`
- Editor/View: `EventFunctionPointerView` (FE8 primary) + `EventFunctionPointerFE7View` (FE7 variant)
- Capture: headless `--screenshot-all --screenshot-dir` (RenderTargetBitmap), both editors rendered with populated data (0 failed / 325 captured).

### Steps Performed
1. Launched the Avalonia app headless against FE8U and opened both Event Function Pointer editors via the editor registry.
2. `SelectFirstItem()` populated the list and loaded entry 0; the FE8 editor renders the list, Address, Event Command Function Pointer value, and Write button.
3. Drove the exact `OnWrite` sequence (Begin → set → Write → Commit → MarkClean) against synthetic FE8U/FE7U ROMs with a real `UndoService` and asserted undo capture + rollback + clean VM.

### Test Results
| Test | Expected | Actual | Status |
|------|----------|--------|--------|
| FE8 write under undo scope | `CoreState.Undo.IsModified == true`; `RunUndo()` restores byte-identity | matched | PASS |
| FE8 VM dirty after save | `IsDirty == false` after `Commit()`+`MarkClean()` | matched | PASS |
| FE8 rollback | `Rollback()` reverts byte-identity | matched | PASS |
| FE7 write under undo scope (+Unknown4) | both fields captured; `RunUndo()` restores byte-identity | matched | PASS |
| FE7 rollback | `Rollback()` reverts byte-identity | matched | PASS |
| Source wiring (both views) | both `.axaml.cs` carry Begin/Commit/Rollback/MarkClean | matched | PASS |
| Editor renders with data (headless capture) | non-blank editor, populated list + Write button | matched (screenshot) | PASS |

### Verdict
PASS — both variants route the write through the undo path; the editor renders correctly with populated data.

## Test plan
- [x] `Write_IsUndoable_FE8` — real `UndoService` round-trip; Commit records into `CoreState.Undo`, VM clean after save, `RunUndo()` restores byte-identity.
- [x] `Write_IsUndoable_FE7` — same, also exercises `Unknown4` (stride 8).
- [x] `Rollback_RestoresBytes_FE8` / `_FE7` — `Rollback()` reverts byte-identity.
- [x] `View_FE8_OnWrite_UsesUndoScope` / `View_FE7_OnWrite_UsesUndoScope` — source guards assert both views carry the undo wiring.
- [x] Full `FEBuilderGBA.Avalonia.Tests` suite: 8568 passed / 0 failed / 6 skipped (incl. the 6 new tests).
- [x] Full `FEBuilderGBA.Tests` (net9.0-windows): 1925 passed / 0 failed.
- [x] `FEBuilderGBA.Core.Tests`: 5769 passed; the 10 `Skill*` failures are pre-existing env-only (read `config/patch2/FE8U/*.dmp`; that submodule is uninitialized in this worktree) and the diff touches zero Core files — confirmed not a regression.
- [x] Headless GUI capture of both editors with populated FE8U data (325 captured / 0 failed).

## Known limitations
- None. View-layer-only undo wiring; cleanly revertible.

Generated with Claude Code (Opus 4.8, 1M context)